### PR TITLE
Charts: Add interactive legend support to Pie and Semi-Circle charts

### DIFF
--- a/projects/js-packages/charts/changelog/add-charts-pie-chart-interactive-legend
+++ b/projects/js-packages/charts/changelog/add-charts-pie-chart-interactive-legend
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Charts: adds interactive legend to pie charts

--- a/projects/js-packages/charts/src/components/pie-chart/pie-chart.tsx
+++ b/projects/js-packages/charts/src/components/pie-chart/pie-chart.tsx
@@ -284,7 +284,7 @@ const PieChartInternal = ( {
 	const centerY = adjustedHeight / 2;
 
 	// Calculate the angle between each (use original data length for consistent spacing)
-	const padAngle = gapScale * ( ( 2 * Math.PI ) / visibleData.length );
+	const padAngle = gapScale * ( ( 2 * Math.PI ) / data.length );
 
 	const outerRadius = radius - padding;
 	const innerRadius = thickness === 0 ? 0 : outerRadius * ( 1 - thickness );

--- a/projects/js-packages/charts/src/components/pie-chart/pie-chart.tsx
+++ b/projects/js-packages/charts/src/components/pie-chart/pie-chart.tsx
@@ -183,7 +183,7 @@ const PieChartInternal = ( {
 	const { getElementStyles, isSeriesVisible } = useGlobalChartsContext();
 
 	// Filter and recalculate data for interactive legends
-	const { visibleData, allSegmentsHidden } = useInteractiveLegendData( {
+	const { visibleData, allSegmentsHidden, legendData } = useInteractiveLegendData( {
 		data,
 		chartId,
 		legendInteractive,
@@ -196,28 +196,7 @@ const PieChartInternal = ( {
 		[ legendValueDisplay ]
 	);
 
-	// Create legend items using the reusable hook
-	// Always use original data for legend - the Legend component handles visibility styling
-	// For interactive legends, we need to show recalculated percentages for visible items only
-	const legendData = useMemo( () => {
-		if ( ! legendInteractive || ! chartId ) {
-			return data;
-		}
-
-		// Map original data to show recalculated percentages for visible items
-		return data.map( segment => {
-			const isVisible = isSeriesVisible( chartId, segment.label );
-			if ( ! isVisible ) {
-				// Return original data for hidden items
-				return segment;
-			}
-
-			// For visible items, find the recalculated percentage from visibleData
-			const recalculated = visibleData.find( d => d.label === segment.label );
-			return recalculated || segment;
-		} );
-	}, [ data, visibleData, legendInteractive, chartId, isSeriesVisible ] );
-
+	// Create legend items using legendData (has recalculated percentages for visible items)
 	const legendItems = useChartLegendItems( legendData, legendOptions );
 
 	const { isValid, message } = validateData( data );

--- a/projects/js-packages/charts/src/components/pie-chart/pie-chart.tsx
+++ b/projects/js-packages/charts/src/components/pie-chart/pie-chart.tsx
@@ -2,6 +2,7 @@ import { localPoint } from '@visx/event';
 import { Group } from '@visx/group';
 import { Pie } from '@visx/shape';
 import { useTooltip, useTooltipInPortal } from '@visx/tooltip';
+import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
 import { useCallback, useContext, useMemo } from 'react';
 import { useElementHeight } from '../../hooks';
@@ -69,6 +70,13 @@ export interface PieChartProps extends BaseChartProps< DataPointPercentage[] > {
 	 * - 'none': Shows no values, only labels
 	 */
 	legendValueDisplay?: LegendValueDisplay;
+
+	/**
+	 * Enable interactive legend items that can toggle segment visibility.
+	 * Requires chartId and GlobalChartsProvider.
+	 * When segments are hidden, percentages are recalculated so visible segments total 100%.
+	 */
+	legendInteractive?: boolean;
 
 	/**
 	 * Use the children prop to render additional elements on the chart.
@@ -147,6 +155,7 @@ const PieChartInternal = ( {
 	cornerScale = 0,
 	showLabels = true,
 	legendValueDisplay = 'percentage',
+	legendInteractive = false,
 	children = null,
 	tooltipOffsetX = 0,
 	tooltipOffsetY = -15,
@@ -171,6 +180,36 @@ const PieChartInternal = ( {
 		hideTooltip();
 	}, [ withTooltips, hideTooltip ] );
 
+	const { getElementStyles, isSeriesVisible } = useGlobalChartsContext();
+
+	// Filter and recalculate data for interactive legends
+	const visibleData = useMemo( () => {
+		if ( ! chartId || ! legendInteractive ) {
+			return data;
+		}
+
+		// Filter to only visible segments
+		const filtered = data.filter( segment => isSeriesVisible( chartId, segment.label ) );
+
+		// If no segments are visible, return empty array
+		if ( filtered.length === 0 ) {
+			return [];
+		}
+
+		// Recalculate percentages so they total 100%
+		const totalValue = filtered.reduce( ( sum, segment ) => sum + segment.value, 0 );
+
+		return filtered.map( segment => ( {
+			...segment,
+			percentage: totalValue > 0 ? ( segment.value / totalValue ) * 100 : 0,
+		} ) );
+	}, [ data, chartId, isSeriesVisible, legendInteractive ] );
+
+	// Check if all segments are hidden
+	const allSegmentsHidden = useMemo( () => {
+		return legendInteractive && visibleData.length === 0;
+	}, [ legendInteractive, visibleData ] );
+
 	// Memoize legend options to prevent unnecessary re-calculations
 	const legendOptions = useMemo(
 		() => ( { showValues: true, legendValueDisplay } ),
@@ -178,7 +217,28 @@ const PieChartInternal = ( {
 	);
 
 	// Create legend items using the reusable hook
-	const legendItems = useChartLegendItems( data, legendOptions );
+	// Always use original data for legend - the Legend component handles visibility styling
+	// For interactive legends, we need to show recalculated percentages for visible items only
+	const legendData = useMemo( () => {
+		if ( ! legendInteractive || ! chartId ) {
+			return data;
+		}
+
+		// Map original data to show recalculated percentages for visible items
+		return data.map( segment => {
+			const isVisible = isSeriesVisible( chartId, segment.label );
+			if ( ! isVisible ) {
+				// Return original data for hidden items
+				return segment;
+			}
+
+			// For visible items, find the recalculated percentage from visibleData
+			const recalculated = visibleData.find( d => d.label === segment.label );
+			return recalculated || segment;
+		} );
+	}, [ data, visibleData, legendInteractive, chartId, isSeriesVisible ] );
+
+	const legendItems = useChartLegendItems( legendData, legendOptions );
 
 	const { isValid, message } = validateData( data );
 
@@ -204,8 +264,6 @@ const PieChartInternal = ( {
 		metadata: chartMetadata,
 	} );
 
-	const { getElementStyles } = useGlobalChartsContext();
-
 	if ( ! isValid ) {
 		return (
 			<div className={ clsx( 'pie-chart', styles[ 'pie-chart' ], className ) }>
@@ -225,8 +283,8 @@ const PieChartInternal = ( {
 	const centerX = width / 2;
 	const centerY = adjustedHeight / 2;
 
-	// Calculate the angle between each
-	const padAngle = gapScale * ( ( 2 * Math.PI ) / data.length );
+	// Calculate the angle between each (use original data length for consistent spacing)
+	const padAngle = gapScale * ( ( 2 * Math.PI ) / visibleData.length );
 
 	const outerRadius = radius - padding;
 	const innerRadius = thickness === 0 ? 0 : outerRadius * ( 1 - thickness );
@@ -235,10 +293,14 @@ const PieChartInternal = ( {
 	const cornerRadius = cornerScale ? Math.min( cornerScale * outerRadius, maxCornerRadius ) : 0;
 
 	// Map the data to include index for color assignment
-	const dataWithIndex = data.map( ( d, index ) => ( {
-		...d,
-		index,
-	} ) );
+	// When interactive, we need to find the original index to maintain consistent colors
+	const dataWithIndex = visibleData.map( d => {
+		const originalIndex = data.findIndex( item => item.label === d.label );
+		return {
+			...d,
+			index: originalIndex >= 0 ? originalIndex : 0,
+		};
+	} );
 
 	const accessors = {
 		value: ( d: DataPointPercentage ) => d.value,
@@ -270,91 +332,106 @@ const PieChartInternal = ( {
 					height={ adjustedHeight }
 				>
 					<Group top={ centerY } left={ centerX }>
-						<Pie< DataPointPercentage & { index: number } >
-							data={ dataWithIndex }
-							pieValue={ accessors.value }
-							outerRadius={ outerRadius }
-							innerRadius={ innerRadius }
-							padAngle={ padAngle }
-							cornerRadius={ cornerRadius }
-						>
-							{ pie => {
-								return pie.arcs.map( ( arc, index ) => {
-									const [ centroidX, centroidY ] = pie.path.centroid( arc );
-									const hasSpaceForLabel = arc.endAngle - arc.startAngle >= 0.25;
-									const handleMouseMove = ( event: MouseEvent< SVGElement > ) => {
-										if ( ! withTooltips ) {
-											return;
+						{ allSegmentsHidden ? (
+							<text
+								textAnchor="middle"
+								dy=".33em"
+								fill={ providerTheme.gridColor || '#ccc' }
+								fontSize="14"
+								fontFamily="-apple-system,BlinkMacSystemFont,Roboto,Helvetica Neue,sans-serif"
+							>
+								{ __(
+									'All segments are hidden. Click legend items to show data.',
+									'jetpack-charts'
+								) }
+							</text>
+						) : (
+							<Pie< DataPointPercentage & { index: number } >
+								data={ dataWithIndex }
+								pieValue={ accessors.value }
+								outerRadius={ outerRadius }
+								innerRadius={ innerRadius }
+								padAngle={ padAngle }
+								cornerRadius={ cornerRadius }
+							>
+								{ pie => {
+									return pie.arcs.map( ( arc, index ) => {
+										const [ centroidX, centroidY ] = pie.path.centroid( arc );
+										const hasSpaceForLabel = arc.endAngle - arc.startAngle >= 0.25;
+										const handleMouseMove = ( event: MouseEvent< SVGElement > ) => {
+											if ( ! withTooltips ) {
+												return;
+											}
+
+											// Get coordinates relative to the current target element
+											const coords = localPoint( event );
+											if ( coords ) {
+												// Account for legend offset when legend is on top
+												const legendOffset =
+													showLegend && legendPosition === 'top' ? legendHeight : 0;
+												showTooltip( {
+													tooltipData: arc.data,
+													tooltipLeft: coords.x + tooltipOffsetX,
+													tooltipTop: coords.y + legendOffset + tooltipOffsetY,
+												} );
+											}
+										};
+
+										const pathProps: SVGProps< SVGPathElement > & { 'data-testid'?: string } = {
+											d: pie.path( arc ) || '',
+											fill: accessors.fill( arc.data ),
+											'data-testid': 'pie-segment',
+										};
+
+										const groupProps: SVGProps< SVGGElement > = {};
+										if ( withTooltips ) {
+											groupProps.onMouseMove = handleMouseMove;
+											groupProps.onMouseLeave = onMouseLeave;
 										}
 
-										// Get coordinates relative to the current target element
-										const coords = localPoint( event );
-										if ( coords ) {
-											// Account for legend offset when legend is on top
-											const legendOffset =
-												showLegend && legendPosition === 'top' ? legendHeight : 0;
-											showTooltip( {
-												tooltipData: arc.data,
-												tooltipLeft: coords.x + tooltipOffsetX,
-												tooltipTop: coords.y + legendOffset + tooltipOffsetY,
-											} );
-										}
-									};
+										// Estimate text width more accurately for background sizing
+										const fontSize = 12;
+										const estimatedTextWidth = getStringWidth( arc.data.label, { fontSize } );
+										const labelPadding = 6;
+										const backgroundWidth = estimatedTextWidth + labelPadding * 2;
+										const backgroundHeight = fontSize + labelPadding * 2;
 
-									const pathProps: SVGProps< SVGPathElement > & { 'data-testid'?: string } = {
-										d: pie.path( arc ) || '',
-										fill: accessors.fill( arc.data ),
-										'data-testid': 'pie-segment',
-									};
-
-									const groupProps: SVGProps< SVGGElement > = {};
-									if ( withTooltips ) {
-										groupProps.onMouseMove = handleMouseMove;
-										groupProps.onMouseLeave = onMouseLeave;
-									}
-
-									// Estimate text width more accurately for background sizing
-									const fontSize = 12;
-									const estimatedTextWidth = getStringWidth( arc.data.label, { fontSize } );
-									const labelPadding = 6;
-									const backgroundWidth = estimatedTextWidth + labelPadding * 2;
-									const backgroundHeight = fontSize + labelPadding * 2;
-
-									return (
-										<g key={ `arc-${ index }` } { ...groupProps }>
-											<path { ...pathProps } />
-											{ showLabels && hasSpaceForLabel && (
-												<g>
-													{ providerTheme.labelBackgroundColor && (
-														<rect
-															x={ centroidX - backgroundWidth / 2 }
-															y={ centroidY - backgroundHeight / 2 }
-															width={ backgroundWidth }
-															height={ backgroundHeight }
-															fill={ providerTheme.labelBackgroundColor }
-															rx={ 4 }
-															ry={ 4 }
+										return (
+											<g key={ `arc-${ index }` } { ...groupProps }>
+												<path { ...pathProps } />
+												{ showLabels && hasSpaceForLabel && (
+													<g>
+														{ providerTheme.labelBackgroundColor && (
+															<rect
+																x={ centroidX - backgroundWidth / 2 }
+																y={ centroidY - backgroundHeight / 2 }
+																width={ backgroundWidth }
+																height={ backgroundHeight }
+																fill={ providerTheme.labelBackgroundColor }
+																rx={ 4 }
+																ry={ 4 }
+																pointerEvents="none"
+															/>
+														) }
+														<text
+															x={ centroidX }
+															y={ centroidY }
+															dy=".33em"
+															fill={ providerTheme.labelTextColor || '#333' }
+															fontSize={ fontSize }
+															textAnchor="middle"
 															pointerEvents="none"
-														/>
-													) }
-													<text
-														x={ centroidX }
-														y={ centroidY }
-														dy=".33em"
-														fill={ providerTheme.labelTextColor || '#333' }
-														fontSize={ fontSize }
-														textAnchor="middle"
-														pointerEvents="none"
-													>
-														{ arc.data.label }
-													</text>
-												</g>
-											) }
-										</g>
-									);
-								} );
-							} }
-						</Pie>
+														>
+															{ arc.data.label }
+														</text>
+													</g>
+												) }
+											</g>
+										);
+									} );
+								} }
+							</Pie>
+						) }
 
 						{ /* Render SVG children (like Group, Text) inside the SVG */ }
 						{ svgChildren }
@@ -373,6 +450,7 @@ const PieChartInternal = ( {
 						shape={ legendShape }
 						ref={ legendRef }
 						chartId={ chartId }
+						interactive={ legendInteractive }
 					/>
 				) }
 

--- a/projects/js-packages/charts/src/components/pie-chart/pie-chart.tsx
+++ b/projects/js-packages/charts/src/components/pie-chart/pie-chart.tsx
@@ -434,7 +434,7 @@ const PieChartInternal = ( {
 						) }
 
 						{ /* Render SVG children (like Group, Text) inside the SVG */ }
-						{ svgChildren }
+						{ ! allSegmentsHidden && svgChildren }
 					</Group>
 				</svg>
 

--- a/projects/js-packages/charts/src/components/pie-chart/pie-chart.tsx
+++ b/projects/js-packages/charts/src/components/pie-chart/pie-chart.tsx
@@ -5,7 +5,7 @@ import { useTooltip, useTooltipInPortal } from '@visx/tooltip';
 import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
 import { useCallback, useContext, useMemo } from 'react';
-import { useElementHeight } from '../../hooks';
+import { useElementHeight, useInteractiveLegendData } from '../../hooks';
 import {
 	GlobalChartsProvider,
 	useChartId,
@@ -183,32 +183,12 @@ const PieChartInternal = ( {
 	const { getElementStyles, isSeriesVisible } = useGlobalChartsContext();
 
 	// Filter and recalculate data for interactive legends
-	const visibleData = useMemo( () => {
-		if ( ! chartId || ! legendInteractive ) {
-			return data;
-		}
-
-		// Filter to only visible segments
-		const filtered = data.filter( segment => isSeriesVisible( chartId, segment.label ) );
-
-		// If no segments are visible, return empty array
-		if ( filtered.length === 0 ) {
-			return [];
-		}
-
-		// Recalculate percentages so they total 100%
-		const totalValue = filtered.reduce( ( sum, segment ) => sum + segment.value, 0 );
-
-		return filtered.map( segment => ( {
-			...segment,
-			percentage: totalValue > 0 ? ( segment.value / totalValue ) * 100 : 0,
-		} ) );
-	}, [ data, chartId, isSeriesVisible, legendInteractive ] );
-
-	// Check if all segments are hidden
-	const allSegmentsHidden = useMemo( () => {
-		return legendInteractive && visibleData.length === 0;
-	}, [ legendInteractive, visibleData ] );
+	const { visibleData, allSegmentsHidden } = useInteractiveLegendData( {
+		data,
+		chartId,
+		legendInteractive,
+		isSeriesVisible,
+	} );
 
 	// Memoize legend options to prevent unnecessary re-calculations
 	const legendOptions = useMemo(

--- a/projects/js-packages/charts/src/components/pie-chart/stories/donut.stories.tsx
+++ b/projects/js-packages/charts/src/components/pie-chart/stories/donut.stories.tsx
@@ -5,6 +5,7 @@ import {
 } from '@wordpress/components';
 import { Fragment } from 'react';
 import { BaseLegendItem } from '../../../components/legend/types';
+import { GlobalChartsProvider } from '../../../providers';
 import {
 	chartDecorator,
 	sharedChartArgTypes,
@@ -279,6 +280,54 @@ export const WithCompositionLegend: Story = {
 			description: {
 				story:
 					'Demonstrates the donut chart composition API, allowing flexible combination of chart elements and legends.',
+			},
+		},
+	},
+};
+
+export const InteractiveLegend: Story = {
+	render: args => (
+		<GlobalChartsProvider>
+			<div style={ { padding: '20px' } }>
+				<h3>Interactive Donut Chart</h3>
+				<p style={ { marginBottom: '20px', color: '#666' } }>
+					Click legend items to show/hide segments. The total value updates dynamically.
+				</p>
+				<PieChartUnresponsive
+					chartId="interactive-donut-chart"
+					size={ args.size || 400 }
+					data={ args.data }
+					thickness={ 0.5 }
+					showLegend={ true }
+					legendInteractive={ true }
+					legendPosition={ args.legendPosition || 'bottom' }
+					legendOrientation={ args.legendOrientation || 'horizontal' }
+					legendAlignment={ args.legendAlignment || 'center' }
+					legendValueDisplay={ args.legendValueDisplay }
+				>
+					<Group>
+						<Text textAnchor="middle" verticalAnchor="middle" fontSize={ 16 } y={ -8 }>
+							User Stats
+						</Text>
+						<Text textAnchor="middle" verticalAnchor="middle" fontSize={ 14 } y={ 12 } fill="#666">
+							100K Total
+						</Text>
+					</Group>
+				</PieChartUnresponsive>
+			</div>
+		</GlobalChartsProvider>
+	),
+	args: {
+		data,
+		size: 400,
+		thickness: 0.5,
+		containerHeight: '600px',
+	},
+	parameters: {
+		docs: {
+			description: {
+				story:
+					'Interactive donut chart with clickable legend. Segments can be hidden/shown, and percentages recalculate automatically. Requires chartId and GlobalChartsProvider.',
 			},
 		},
 	},

--- a/projects/js-packages/charts/src/components/pie-chart/stories/donut.stories.tsx
+++ b/projects/js-packages/charts/src/components/pie-chart/stories/donut.stories.tsx
@@ -275,6 +275,11 @@ export const WithCompositionLegend: Story = {
 		thickness: 0.5,
 		containerHeight: '500px',
 	},
+	argTypes: {
+		legendInteractive: {
+			table: { disable: true },
+		},
+	},
 	parameters: {
 		docs: {
 			description: {

--- a/projects/js-packages/charts/src/components/pie-chart/stories/index.api.mdx
+++ b/projects/js-packages/charts/src/components/pie-chart/stories/index.api.mdx
@@ -20,7 +20,7 @@ Main component for rendering pie and donut charts.
 | `cornerScale` | `number` | `0` | Scale of corner rounding for segments (0-1) |
 | `withTooltips` | `boolean` | `false` | Enable interactive tooltips on hover |
 | `showLegend` | `boolean` | `false` | Display chart legend |
-| `legendInteractive` | `boolean` | `false` | Enable clickable legend items to show/hide segments. Requires `chartId` and `GlobalChartsProvider`. When segments are hidden, percentages recalculate so visible segments total 100% |
+| `legendInteractive` | `boolean` | `false` | Enable clickable legend items to show/hide segments. Requires `chartId` and `GlobalChartsProvider`. When segments are hidden, percentages recalculate so visible segments total 100%. **Note:** Only works with props-based legends (`showLegend={true}`), not with composition API (`<PieChart.Legend />`) |
 | `legendOrientation` | `'horizontal' \| 'vertical'` | `'horizontal'` | Legend layout direction |
 | `legendAlignment` | `'start' \| 'center' \| 'end'` | `'center'` | Legend alignment within its position |
 | `legendPosition` | `'top' \| 'bottom'` | `'bottom'` | Legend position (where the legend appears) |

--- a/projects/js-packages/charts/src/components/pie-chart/stories/index.api.mdx
+++ b/projects/js-packages/charts/src/components/pie-chart/stories/index.api.mdx
@@ -20,6 +20,7 @@ Main component for rendering pie and donut charts.
 | `cornerScale` | `number` | `0` | Scale of corner rounding for segments (0-1) |
 | `withTooltips` | `boolean` | `false` | Enable interactive tooltips on hover |
 | `showLegend` | `boolean` | `false` | Display chart legend |
+| `legendInteractive` | `boolean` | `false` | Enable clickable legend items to show/hide segments. Requires `chartId` and `GlobalChartsProvider`. When segments are hidden, percentages recalculate so visible segments total 100% |
 | `legendOrientation` | `'horizontal' \| 'vertical'` | `'horizontal'` | Legend layout direction |
 | `legendAlignment` | `'start' \| 'center' \| 'end'` | `'center'` | Legend alignment within its position |
 | `legendPosition` | `'top' \| 'bottom'` | `'bottom'` | Legend position (where the legend appears) |

--- a/projects/js-packages/charts/src/components/pie-chart/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/components/pie-chart/stories/index.stories.tsx
@@ -195,6 +195,11 @@ export const WithCompositionLegend: Story = {
 		data,
 		containerHeight: '500px',
 	},
+	argTypes: {
+		legendInteractive: {
+			table: { disable: true },
+		},
+	},
 	parameters: {
 		docs: {
 			description: {
@@ -372,6 +377,11 @@ export const CompositionAPI: Story = {
 	},
 	args: {
 		data,
+	},
+	argTypes: {
+		legendInteractive: {
+			table: { disable: true },
+		},
 	},
 	parameters: {
 		docs: {

--- a/projects/js-packages/charts/src/components/pie-chart/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/components/pie-chart/stories/index.stories.tsx
@@ -205,6 +205,44 @@ export const WithCompositionLegend: Story = {
 	},
 };
 
+export const InteractiveLegend: Story = {
+	render: args => (
+		<GlobalChartsProvider>
+			<div style={ { padding: '20px' } }>
+				<h3>Interactive Legend</h3>
+				<p style={ { marginBottom: '20px', color: '#666' } }>
+					Click legend items to show/hide segments. Percentages recalculate automatically for
+					visible segments.
+				</p>
+				<PieChartUnresponsive
+					chartId="interactive-pie-chart"
+					size={ args.size || 400 }
+					data={ args.data }
+					showLegend={ true }
+					legendInteractive={ true }
+					legendPosition={ args.legendPosition || 'bottom' }
+					legendOrientation={ args.legendOrientation || 'horizontal' }
+					legendAlignment={ args.legendAlignment || 'center' }
+					legendValueDisplay={ args.legendValueDisplay }
+				/>
+			</div>
+		</GlobalChartsProvider>
+	),
+	args: {
+		data,
+		size: 400,
+		containerHeight: '600px',
+	},
+	parameters: {
+		docs: {
+			description: {
+				story:
+					'Interactive legends allow users to toggle segment visibility by clicking legend items. When segments are hidden, the visible segments are recalculated to total 100%. Requires chartId and GlobalChartsProvider.',
+			},
+		},
+	},
+};
+
 export const CustomLegendPositioning: Story = {
 	args: {
 		data: [

--- a/projects/js-packages/charts/src/components/pie-chart/test/pie-chart.test.tsx
+++ b/projects/js-packages/charts/src/components/pie-chart/test/pie-chart.test.tsx
@@ -334,4 +334,178 @@ describe( 'PieChart', () => {
 			expect( screen.getByRole( 'tooltip' ) ).toHaveTextContent( 'Test: 42' );
 		} );
 	} );
+
+	describe( 'Interactive Legend', () => {
+		test( 'filters segments when interactive legend is enabled and segment is toggled', async () => {
+			const user = userEvent.setup();
+			const testData = [
+				{ label: 'Segment A', value: 50, percentage: 50 },
+				{ label: 'Segment B', value: 50, percentage: 50 },
+			];
+
+			renderWithTheme( {
+				data: testData,
+				showLegend: true,
+				legendInteractive: true,
+				chartId: 'test-interactive-pie-chart',
+			} );
+
+			// Initially both segments should be visible
+			let segments = screen.getAllByTestId( 'pie-segment' );
+			expect( segments ).toHaveLength( 2 );
+
+			// Click first legend item to hide segment A
+			const legendItem = screen.getByRole( 'button', { name: /Segment A/i } );
+			await user.click( legendItem );
+
+			// Only one segment should remain
+			await waitFor( () => {
+				segments = screen.getAllByTestId( 'pie-segment' );
+				expect( segments ).toHaveLength( 1 );
+			} );
+
+			// Legend item should be marked as hidden
+			expect( legendItem ).toHaveAttribute( 'aria-pressed', 'false' );
+		} );
+
+		test( 'shows empty state when all segments are hidden', async () => {
+			const user = userEvent.setup();
+			const testData = [
+				{ label: 'Segment A', value: 50, percentage: 50 },
+				{ label: 'Segment B', value: 50, percentage: 50 },
+			];
+
+			renderWithTheme( {
+				data: testData,
+				showLegend: true,
+				legendInteractive: true,
+				chartId: 'test-all-hidden-pie-chart',
+			} );
+
+			// Initially should have 2 segments
+			expect( screen.getAllByTestId( 'pie-segment' ) ).toHaveLength( 2 );
+
+			// Hide both segments by clicking legend items
+			const legendItems = screen.getAllByRole( 'button' );
+			await user.click( legendItems[ 0 ] );
+
+			// Wait for first segment to be hidden
+			await waitFor( () => {
+				expect( screen.getAllByTestId( 'pie-segment' ) ).toHaveLength( 1 );
+			} );
+
+			await user.click( legendItems[ 1 ] );
+
+			// Wait for all segments to be hidden
+			await waitFor( () => {
+				expect( screen.queryAllByTestId( 'pie-segment' ) ).toHaveLength( 0 );
+			} );
+
+			// Empty state should appear
+			expect( screen.getByText( /all segments are hidden/i ) ).toBeInTheDocument();
+
+			// Legend items should still be present (just marked inactive)
+			expect( screen.getAllByRole( 'button' ) ).toHaveLength( 2 );
+		} );
+
+		test( 'does not filter segments when legendInteractive is false', () => {
+			const testData = [
+				{ label: 'Segment A', value: 50, percentage: 50 },
+				{ label: 'Segment B', value: 50, percentage: 50 },
+			];
+
+			renderWithTheme( {
+				data: testData,
+				showLegend: true,
+				legendInteractive: false,
+				chartId: 'test-non-interactive-pie-chart',
+			} );
+
+			// Legend items should not be buttons
+			const buttons = screen.queryAllByRole( 'button' );
+			expect( buttons ).toHaveLength( 0 );
+
+			// All segments should be visible
+			const segments = screen.getAllByTestId( 'pie-segment' );
+			expect( segments ).toHaveLength( 2 );
+		} );
+
+		test( 'maintains consistent colors when segments are hidden', async () => {
+			const user = userEvent.setup();
+			const testData = [
+				{ label: 'Segment A', value: 30, percentage: 30 },
+				{ label: 'Segment B', value: 40, percentage: 40 },
+				{ label: 'Segment C', value: 30, percentage: 30 },
+			];
+
+			renderWithTheme( {
+				data: testData,
+				showLegend: true,
+				legendInteractive: true,
+				chartId: 'test-color-consistency-pie-chart',
+			} );
+
+			// Get initial segment colors
+			const initialSegments = screen.getAllByTestId( 'pie-segment' );
+			const segmentBColor = initialSegments[ 1 ].getAttribute( 'fill' );
+
+			// Hide Segment A
+			const legendItemA = screen.getByRole( 'button', { name: /Segment A/i } );
+			await user.click( legendItemA );
+
+			// Segment B should maintain its color (now it's the first visible segment)
+			await waitFor( () => {
+				expect( screen.getAllByTestId( 'pie-segment' ) ).toHaveLength( 2 );
+			} );
+
+			const remainingSegments = screen.getAllByTestId( 'pie-segment' );
+			expect( remainingSegments[ 0 ] ).toHaveAttribute( 'fill', segmentBColor );
+		} );
+
+		test( 'recalculates legend percentages when segments are hidden', async () => {
+			const user = userEvent.setup();
+			const testData = [
+				{ label: 'Segment A', value: 25, percentage: 25 },
+				{ label: 'Segment B', value: 50, percentage: 50 },
+				{ label: 'Segment C', value: 25, percentage: 25 },
+			];
+
+			renderWithTheme( {
+				data: testData,
+				showLegend: true,
+				legendInteractive: true,
+				legendValueDisplay: 'percentage',
+				chartId: 'test-percentage-recalc-pie-chart',
+			} );
+
+			// Initially, legend should show original percentages
+			const legendItems = screen.getAllByTestId( 'legend-item' );
+			expect( legendItems ).toHaveLength( 3 );
+			expect( screen.getAllByText( '25%' ) ).toHaveLength( 2 ); // A and C both 25%
+			expect( screen.getByText( '50%' ) ).toBeInTheDocument();
+
+			// Hide Segment A (25%)
+			const legendItemA = screen.getByRole( 'button', { name: /Segment A/i } );
+			await user.click( legendItemA );
+
+			// Now B and C should recalculate: B = 50/75 = 66.67%, C = 25/75 = 33.33%
+			await waitFor( () => {
+				expect( screen.getByText( /66\.6/ ) ).toBeInTheDocument();
+			} );
+
+			// All 3 legend items should remain (hidden items stay in legend)
+			const remainingItems = screen.getAllByTestId( 'legend-item' );
+			expect( remainingItems ).toHaveLength( 3 );
+
+			// Segment A should still show original 25% (hidden items don't recalculate)
+			expect( legendItemA ).toHaveAttribute( 'aria-pressed', 'false' );
+			expect( screen.getAllByText( '25%' ) ).toHaveLength( 1 ); // Only A shows 25%
+
+			// Segment B should now show ~67% (50 out of remaining 75)
+			expect( screen.getByText( /66\.6/ ) ).toBeInTheDocument();
+
+			// Segment C should now show ~33% (25 out of remaining 75)
+			expect( screen.getByText( /33\.3/ ) ).toBeInTheDocument();
+		} );
+	} );
 } );

--- a/projects/js-packages/charts/src/components/pie-semi-circle-chart/pie-semi-circle-chart.tsx
+++ b/projects/js-packages/charts/src/components/pie-semi-circle-chart/pie-semi-circle-chart.tsx
@@ -195,7 +195,7 @@ const PieSemiCircleChartInternal: FC< PieSemiCircleChartProps > = ( {
 	const { getElementStyles, isSeriesVisible } = useGlobalChartsContext();
 
 	// Filter and recalculate data for interactive legends
-	const { visibleData, allSegmentsHidden } = useInteractiveLegendData( {
+	const { visibleData, allSegmentsHidden, legendData } = useInteractiveLegendData( {
 		data,
 		chartId,
 		legendInteractive,
@@ -222,28 +222,7 @@ const PieSemiCircleChartInternal: FC< PieSemiCircleChartProps > = ( {
 		[ legendValueDisplay ]
 	);
 
-	// Create legend items using the reusable hook
-	// Always use original data for legend - the Legend component handles visibility styling
-	// For interactive legends, we need to show recalculated percentages for visible items only
-	const legendData = useMemo( () => {
-		if ( ! legendInteractive || ! chartId ) {
-			return data;
-		}
-
-		// Map original data to show recalculated percentages for visible items
-		return data.map( segment => {
-			const isVisible = isSeriesVisible( chartId, segment.label );
-			if ( ! isVisible ) {
-				// Return original data for hidden items
-				return segment;
-			}
-
-			// For visible items, find the recalculated percentage from visibleData
-			const recalculated = visibleData.find( d => d.label === segment.label );
-			return recalculated || segment;
-		} );
-	}, [ data, visibleData, legendInteractive, chartId, isSeriesVisible ] );
-
+	// Create legend items using legendData (has recalculated percentages for visible items)
 	const legendItems = useChartLegendItems( legendData, legendOptions );
 
 	// Process children to extract compound components

--- a/projects/js-packages/charts/src/components/pie-semi-circle-chart/pie-semi-circle-chart.tsx
+++ b/projects/js-packages/charts/src/components/pie-semi-circle-chart/pie-semi-circle-chart.tsx
@@ -3,6 +3,7 @@ import { Group } from '@visx/group';
 import { Pie } from '@visx/shape';
 import { Text } from '@visx/text';
 import { useTooltip, useTooltipInPortal } from '@visx/tooltip';
+import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
 import { useCallback, useContext, useMemo } from 'react';
 import { useElementHeight } from '../../hooks';
@@ -71,6 +72,13 @@ export interface PieSemiCircleChartProps extends BaseChartProps< DataPointPercen
 	legendValueDisplay?: LegendValueDisplay;
 
 	/**
+	 * Enable interactive legend items that can toggle segment visibility.
+	 * Requires chartId and GlobalChartsProvider.
+	 * When segments are hidden, percentages are recalculated so visible segments total 100%.
+	 */
+	legendInteractive?: boolean;
+
+	/**
 	 * Horizontal offset for tooltip positioning in pixels (default: 0)
 	 */
 	tooltipOffsetX?: number;
@@ -133,6 +141,7 @@ const PieSemiCircleChartInternal: FC< PieSemiCircleChartProps > = ( {
 	legendItemClassName,
 	legendShape = 'circle',
 	legendValueDisplay = 'percentage',
+	legendInteractive = false,
 	label,
 	note,
 	className,
@@ -183,7 +192,35 @@ const PieSemiCircleChartInternal: FC< PieSemiCircleChartProps > = ( {
 	// Validate data first to get validation result
 	const { isValid, message } = validateData( data );
 
-	const { getElementStyles } = useGlobalChartsContext();
+	const { getElementStyles, isSeriesVisible } = useGlobalChartsContext();
+
+	// Filter and recalculate data for interactive legends
+	const visibleData = useMemo( () => {
+		if ( ! chartId || ! legendInteractive ) {
+			return data;
+		}
+
+		// Filter to only visible segments
+		const filtered = data.filter( segment => isSeriesVisible( chartId, segment.label ) );
+
+		// If no segments are visible, return empty array
+		if ( filtered.length === 0 ) {
+			return [];
+		}
+
+		// Recalculate percentages so they total 100%
+		const totalValue = filtered.reduce( ( sum, segment ) => sum + segment.value, 0 );
+
+		return filtered.map( segment => ( {
+			...segment,
+			percentage: totalValue > 0 ? ( segment.value / totalValue ) * 100 : 0,
+		} ) );
+	}, [ data, chartId, isSeriesVisible, legendInteractive ] );
+
+	// Check if all segments are hidden
+	const allSegmentsHidden = useMemo( () => {
+		return legendInteractive && visibleData.length === 0;
+	}, [ legendInteractive, visibleData ] );
 
 	// Define accessors with useMemo to avoid changing dependencies
 	const accessors = useMemo(
@@ -206,7 +243,28 @@ const PieSemiCircleChartInternal: FC< PieSemiCircleChartProps > = ( {
 	);
 
 	// Create legend items using the reusable hook
-	const legendItems = useChartLegendItems( data, legendOptions );
+	// Always use original data for legend - the Legend component handles visibility styling
+	// For interactive legends, we need to show recalculated percentages for visible items only
+	const legendData = useMemo( () => {
+		if ( ! legendInteractive || ! chartId ) {
+			return data;
+		}
+
+		// Map original data to show recalculated percentages for visible items
+		return data.map( segment => {
+			const isVisible = isSeriesVisible( chartId, segment.label );
+			if ( ! isVisible ) {
+				// Return original data for hidden items
+				return segment;
+			}
+
+			// For visible items, find the recalculated percentage from visibleData
+			const recalculated = visibleData.find( d => d.label === segment.label );
+			return recalculated || segment;
+		} );
+	}, [ data, visibleData, legendInteractive, chartId, isSeriesVisible ] );
+
+	const legendItems = useChartLegendItems( legendData, legendOptions );
 
 	// Process children to extract compound components
 	const { svgChildren, htmlChildren, otherChildren } = useChartChildren(
@@ -253,10 +311,14 @@ const PieSemiCircleChartInternal: FC< PieSemiCircleChartProps > = ( {
 	const innerRadius = radius * ( 1 - thickness );
 
 	// Map data with index for color assignment
-	const dataWithIndex = data.map( ( d, index ) => ( {
-		...d,
-		index,
-	} ) );
+	// When interactive, we need to find the original index to maintain consistent colors
+	const dataWithIndex = visibleData.map( d => {
+		const originalIndex = data.findIndex( item => item.label === d.label );
+		return {
+			...d,
+			index: originalIndex >= 0 ? originalIndex : 0,
+		};
+	} );
 
 	// Configure pie angles based on clockwise direction
 	const startAngle = clockwise ? -Math.PI / 2 : Math.PI / 2;
@@ -287,57 +349,74 @@ const PieSemiCircleChartInternal: FC< PieSemiCircleChartProps > = ( {
 				>
 					{ /* Main chart group centered horizontally and positioned at bottom */ }
 					<Group top={ chartHeight } left={ width / 2 }>
-						{ /* Pie chart */ }
-						<Pie< DataPointPercentage & { index: number } >
-							data={ dataWithIndex }
-							pieValue={ accessors.value }
-							outerRadius={ radius }
-							innerRadius={ innerRadius }
-							cornerRadius={ 3 }
-							padAngle={ PAD_ANGLE }
-							startAngle={ startAngle }
-							endAngle={ endAngle }
-							pieSort={ accessors.sort }
-						>
-							{ pie => {
-								return pie.arcs.map( arc => (
-									<g
-										key={ arc.data.label }
-										onMouseMove={ withTooltips ? handleArcMouseMove( arc ) : undefined }
-										onMouseLeave={ withTooltips ? handleMouseLeave : undefined }
+						{ allSegmentsHidden ? (
+							<text
+								textAnchor="middle"
+								y={ -radius / 2 }
+								fill="#ccc"
+								fontSize="14"
+								fontFamily="-apple-system,BlinkMacSystemFont,Roboto,Helvetica Neue,sans-serif"
+							>
+								{ __(
+									'All segments are hidden. Click legend items to show data.',
+									'jetpack-charts'
+								) }
+							</text>
+						) : (
+							<>
+								{ /* Pie chart */ }
+								<Pie< DataPointPercentage & { index: number } >
+									data={ dataWithIndex }
+									pieValue={ accessors.value }
+									outerRadius={ radius }
+									innerRadius={ innerRadius }
+									cornerRadius={ 3 }
+									padAngle={ PAD_ANGLE }
+									startAngle={ startAngle }
+									endAngle={ endAngle }
+									pieSort={ accessors.sort }
+								>
+									{ pie => {
+										return pie.arcs.map( arc => (
+											<g
+												key={ arc.data.label }
+												onMouseMove={ withTooltips ? handleArcMouseMove( arc ) : undefined }
+												onMouseLeave={ withTooltips ? handleMouseLeave : undefined }
+											>
+												<path
+													d={ pie.path( arc ) || '' }
+													fill={ accessors.fill( arc.data ) }
+													data-testid="pie-segment"
+												/>
+											</g>
+										) );
+									} }
+								</Pie>
+
+								{ /* Label and note text */ }
+								<Group>
+									<Text
+										textAnchor="middle"
+										verticalAnchor="start"
+										y={ -40 } // Position above the chart with space for note
+										className={ styles.label }
 									>
-										<path
-											d={ pie.path( arc ) || '' }
-											fill={ accessors.fill( arc.data ) }
-											data-testid="pie-segment"
-										/>
-									</g>
-								) );
-							} }
-						</Pie>
+										{ label }
+									</Text>
+									<Text
+										textAnchor="middle"
+										verticalAnchor="start"
+										y={ -20 } // Position between label and chart
+										className={ styles.note }
+									>
+										{ note }
+									</Text>
+								</Group>
 
-						{ /* Label and note text */ }
-						<Group>
-							<Text
-								textAnchor="middle"
-								verticalAnchor="start"
-								y={ -40 } // Position above the chart with space for note
-								className={ styles.label }
-							>
-								{ label }
-							</Text>
-							<Text
-								textAnchor="middle"
-								verticalAnchor="start"
-								y={ -20 } // Position between label and chart
-								className={ styles.note }
-							>
-								{ note }
-							</Text>
-						</Group>
-
-						{ /* Render SVG children from composition API */ }
-						{ svgChildren }
+								{ /* Render SVG children from composition API */ }
+								{ svgChildren }
+							</>
+						) }
 					</Group>
 				</svg>
 
@@ -360,6 +439,7 @@ const PieSemiCircleChartInternal: FC< PieSemiCircleChartProps > = ( {
 						shape={ legendShape }
 						ref={ legendRef }
 						chartId={ chartId }
+						interactive={ legendInteractive }
 					/>
 				) }
 

--- a/projects/js-packages/charts/src/components/pie-semi-circle-chart/pie-semi-circle-chart.tsx
+++ b/projects/js-packages/charts/src/components/pie-semi-circle-chart/pie-semi-circle-chart.tsx
@@ -414,7 +414,7 @@ const PieSemiCircleChartInternal: FC< PieSemiCircleChartProps > = ( {
 								</Group>
 
 								{ /* Render SVG children from composition API */ }
-								{ svgChildren }
+								{ ! allSegmentsHidden && svgChildren }
 							</>
 						) }
 					</Group>

--- a/projects/js-packages/charts/src/components/pie-semi-circle-chart/pie-semi-circle-chart.tsx
+++ b/projects/js-packages/charts/src/components/pie-semi-circle-chart/pie-semi-circle-chart.tsx
@@ -6,7 +6,7 @@ import { useTooltip, useTooltipInPortal } from '@visx/tooltip';
 import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
 import { useCallback, useContext, useMemo } from 'react';
-import { useElementHeight } from '../../hooks';
+import { useElementHeight, useInteractiveLegendData } from '../../hooks';
 import {
 	GlobalChartsProvider,
 	useChartId,
@@ -195,32 +195,12 @@ const PieSemiCircleChartInternal: FC< PieSemiCircleChartProps > = ( {
 	const { getElementStyles, isSeriesVisible } = useGlobalChartsContext();
 
 	// Filter and recalculate data for interactive legends
-	const visibleData = useMemo( () => {
-		if ( ! chartId || ! legendInteractive ) {
-			return data;
-		}
-
-		// Filter to only visible segments
-		const filtered = data.filter( segment => isSeriesVisible( chartId, segment.label ) );
-
-		// If no segments are visible, return empty array
-		if ( filtered.length === 0 ) {
-			return [];
-		}
-
-		// Recalculate percentages so they total 100%
-		const totalValue = filtered.reduce( ( sum, segment ) => sum + segment.value, 0 );
-
-		return filtered.map( segment => ( {
-			...segment,
-			percentage: totalValue > 0 ? ( segment.value / totalValue ) * 100 : 0,
-		} ) );
-	}, [ data, chartId, isSeriesVisible, legendInteractive ] );
-
-	// Check if all segments are hidden
-	const allSegmentsHidden = useMemo( () => {
-		return legendInteractive && visibleData.length === 0;
-	}, [ legendInteractive, visibleData ] );
+	const { visibleData, allSegmentsHidden } = useInteractiveLegendData( {
+		data,
+		chartId,
+		legendInteractive,
+		isSeriesVisible,
+	} );
 
 	// Define accessors with useMemo to avoid changing dependencies
 	const accessors = useMemo(

--- a/projects/js-packages/charts/src/components/pie-semi-circle-chart/stories/index.api.mdx
+++ b/projects/js-packages/charts/src/components/pie-semi-circle-chart/stories/index.api.mdx
@@ -20,6 +20,7 @@ Main component for rendering semi-circular pie charts.
 | `note` | `string` | - | Additional text displayed below the label |
 | `withTooltips` | `boolean` | `false` | Enable interactive tooltips on hover |
 | `showLegend` | `boolean` | `false` | Display legend below the chart |
+| `legendInteractive` | `boolean` | `false` | Enable clickable legend items to show/hide segments. Requires `chartId` and `GlobalChartsProvider`. When segments are hidden, percentages recalculate so visible segments total 100% |
 | `legendOrientation` | `'horizontal' \| 'vertical'` | `'horizontal'` | Legend layout direction |
 | `legendAlignment` | `'start' \| 'center' \| 'end'` | `'center'` | Legend alignment within its position |
 | `legendPosition` | `'top' \| 'bottom'` | `'bottom'` | Legend position (where the legend appears) |

--- a/projects/js-packages/charts/src/components/pie-semi-circle-chart/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/components/pie-semi-circle-chart/stories/index.stories.tsx
@@ -128,6 +128,11 @@ export const WithCompositionLegend: Story = {
 	args: {
 		data,
 	},
+	argTypes: {
+		legendInteractive: {
+			table: { disable: true },
+		},
+	},
 	parameters: {
 		docs: {
 			description: {
@@ -411,6 +416,11 @@ export const CompositionAPI: Story = {
 	),
 	args: {
 		data,
+	},
+	argTypes: {
+		legendInteractive: {
+			table: { disable: true },
+		},
 	},
 	parameters: {
 		layout: 'fullscreen',

--- a/projects/js-packages/charts/src/components/pie-semi-circle-chart/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/components/pie-semi-circle-chart/stories/index.stories.tsx
@@ -1,5 +1,6 @@
 import { Group } from '@visx/group';
 import { Text } from '@visx/text';
+import { GlobalChartsProvider } from '../../../providers';
 import {
 	chartDecorator,
 	sharedChartArgTypes,
@@ -8,7 +9,7 @@ import {
 	partialOsUsageData as data,
 	themeArgTypes,
 } from '../../../stories';
-import { PieSemiCircleChart } from '../index';
+import { PieSemiCircleChart, PieSemiCircleChartUnresponsive } from '../index';
 import type { Meta, StoryObj } from '@storybook/react';
 
 type StoryArgs = ChartStoryArgs< React.ComponentProps< typeof PieSemiCircleChart > >;
@@ -132,6 +133,44 @@ export const WithCompositionLegend: Story = {
 			description: {
 				story:
 					'Demonstrates the semi-circle chart composition API, allowing flexible component composition with explicit legend placement.',
+			},
+		},
+	},
+};
+
+export const InteractiveLegend: Story = {
+	render: args => (
+		<GlobalChartsProvider>
+			<div style={ { padding: '20px' } }>
+				<h3>Interactive Semi-Circle Chart</h3>
+				<p style={ { marginBottom: '20px', color: '#666' } }>
+					Click legend items to show/hide segments. Percentages adjust automatically.
+				</p>
+				<PieSemiCircleChartUnresponsive
+					chartId="interactive-semi-circle-chart"
+					width={ args.width || 400 }
+					data={ args.data }
+					label="Performance Metrics"
+					note="Click legend to filter"
+					showLegend={ true }
+					legendInteractive={ true }
+					legendPosition={ args.legendPosition || 'bottom' }
+					legendOrientation={ args.legendOrientation || 'horizontal' }
+					legendAlignment={ args.legendAlignment || 'center' }
+				/>
+			</div>
+		</GlobalChartsProvider>
+	),
+	args: {
+		data,
+		width: 400,
+		containerHeight: '500px',
+	},
+	parameters: {
+		docs: {
+			description: {
+				story:
+					'Interactive semi-circle chart with clickable legend items. Hidden segments are excluded and percentages recalculate. Requires chartId and GlobalChartsProvider.',
 			},
 		},
 	},

--- a/projects/js-packages/charts/src/components/pie-semi-circle-chart/test/pie-semi-circle-chart.test.tsx
+++ b/projects/js-packages/charts/src/components/pie-semi-circle-chart/test/pie-semi-circle-chart.test.tsx
@@ -178,4 +178,88 @@ describe( 'PieSemiCircleChart', () => {
 			).toBeInTheDocument();
 		} );
 	} );
+
+	describe( 'Interactive Legend', () => {
+		test( 'filters segments when interactive legend is enabled and segment is toggled', async () => {
+			const user = userEvent.setup();
+			const testData = [
+				{ label: 'Segment A', value: 50, percentage: 50 },
+				{ label: 'Segment B', value: 50, percentage: 50 },
+			];
+
+			renderPieChart( {
+				data: testData,
+				showLegend: true,
+				legendInteractive: true,
+				chartId: 'test-interactive-semi-circle-chart',
+			} );
+
+			// Initially both segments should be visible
+			let segments = screen.getAllByTestId( 'pie-segment' );
+			expect( segments ).toHaveLength( 2 );
+
+			// Click first legend item to hide segment A
+			const legendItem = screen.getByRole( 'button', { name: /Segment A/i } );
+			await user.click( legendItem );
+
+			// Only one segment should remain
+			await waitFor( () => {
+				segments = screen.getAllByTestId( 'pie-segment' );
+				expect( segments ).toHaveLength( 1 );
+			} );
+
+			// Legend item should be marked as hidden
+			expect( legendItem ).toHaveAttribute( 'aria-pressed', 'false' );
+		} );
+
+		test( 'shows empty state when all segments are hidden', async () => {
+			const user = userEvent.setup();
+			const testData = [
+				{ label: 'Segment A', value: 50, percentage: 50 },
+				{ label: 'Segment B', value: 50, percentage: 50 },
+			];
+
+			renderPieChart( {
+				data: testData,
+				showLegend: true,
+				legendInteractive: true,
+				chartId: 'test-all-hidden-semi-circle-chart',
+			} );
+
+			// Hide both segments
+			const legendItems = screen.getAllByRole( 'button' );
+			await user.click( legendItems[ 0 ] );
+			await user.click( legendItems[ 1 ] );
+
+			// Should show empty state message
+			await waitFor( () => {
+				expect( screen.getByText( /all segments are hidden/i ) ).toBeInTheDocument();
+			} );
+
+			// Should not render any segments
+			expect( screen.queryAllByTestId( 'pie-segment' ) ).toHaveLength( 0 );
+		} );
+
+		test( 'does not filter segments when legendInteractive is false', () => {
+			const testData = [
+				{ label: 'Segment A', value: 50, percentage: 50 },
+				{ label: 'Segment B', value: 50, percentage: 50 },
+			];
+
+			renderPieChart( {
+				data: testData,
+				showLegend: true,
+				legendInteractive: false,
+				chartId: 'test-non-interactive-semi-circle-chart',
+			} );
+
+			// Legend items should not be buttons
+			const buttons = screen.queryAllByRole( 'button' );
+			expect( buttons ).toHaveLength( 0 );
+
+			// All segments should be visible
+			const segments = screen.getAllByTestId( 'pie-segment' );
+			expect( segments ).toHaveLength( 2 );
+		} );
+	} );
 } );

--- a/projects/js-packages/charts/src/hooks/index.ts
+++ b/projects/js-packages/charts/src/hooks/index.ts
@@ -6,3 +6,4 @@ export { useChartMargin } from './use-chart-margin';
 export { useElementHeight } from './use-element-height';
 export { useTextTruncation } from './use-text-truncation';
 export { useZeroValueDisplay } from './use-zero-value-display';
+export { useInteractiveLegendData } from './use-interactive-legend-data';

--- a/projects/js-packages/charts/src/hooks/use-interactive-legend-data.ts
+++ b/projects/js-packages/charts/src/hooks/use-interactive-legend-data.ts
@@ -1,0 +1,107 @@
+import { useMemo } from 'react';
+
+/**
+ * Data point interface for charts with interactive legends.
+ * Requires label for series identification, value for calculations, and percentage for display.
+ */
+interface DataPointWithPercentage {
+	label: string;
+	value: number;
+	percentage: number;
+}
+
+/**
+ * Parameters for the useInteractiveLegendData hook.
+ */
+interface UseInteractiveLegendDataParams< T extends DataPointWithPercentage > {
+	/** The chart data to filter based on legend visibility */
+	data: T[];
+	/** Unique chart identifier, required for interactive legends */
+	chartId: string | undefined;
+	/** Whether interactive legend filtering is enabled */
+	legendInteractive: boolean;
+	/** Function to check if a series is visible in the legend */
+	isSeriesVisible: ( chartId: string, label: string ) => boolean;
+}
+
+/**
+ * Return value from the useInteractiveLegendData hook.
+ */
+interface UseInteractiveLegendDataResult< T extends DataPointWithPercentage > {
+	/** Filtered data array containing only visible segments with recalculated percentages */
+	visibleData: T[];
+	/** Boolean indicating if all segments are hidden */
+	allSegmentsHidden: boolean;
+}
+
+/**
+ * Custom hook to filter and recalculate chart data for interactive legends.
+ *
+ * When interactive legends are enabled, this hook:
+ * 1. Filters data to show only visible series based on legend selection
+ * 2. Recalculates percentages so visible segments total 100%
+ * 3. Tracks whether all segments are hidden to show empty state
+ *
+ * This is particularly useful for pie charts, donut charts, and semi-circle charts
+ * where segment visibility and percentages need to be dynamically adjusted.
+ *
+ * @example
+ * ```tsx
+ * const { visibleData, allSegmentsHidden } = useInteractiveLegendData({
+ *   data: chartData,
+ *   chartId: 'my-pie-chart',
+ *   legendInteractive: true,
+ *   isSeriesVisible: (id, label) => context.isSeriesVisible(id, label),
+ * });
+ *
+ * if (allSegmentsHidden) {
+ *   return <EmptyState />;
+ * }
+ *
+ * return <PieChart data={visibleData} />;
+ * ```
+ *
+ * @param params                   - Configuration object for the hook
+ * @param params.data              - The chart data to filter
+ * @param params.chartId           - Unique identifier for the chart (required for interactive mode)
+ * @param params.legendInteractive - Whether to enable interactive filtering
+ * @param params.isSeriesVisible   - Function to check series visibility
+ * @return Object containing visibleData and allSegmentsHidden flag
+ */
+export const useInteractiveLegendData = < T extends DataPointWithPercentage >( {
+	data,
+	chartId,
+	legendInteractive,
+	isSeriesVisible,
+}: UseInteractiveLegendDataParams< T > ): UseInteractiveLegendDataResult< T > => {
+	// Filter and recalculate data for interactive legends
+	const visibleData = useMemo( () => {
+		// If interactive mode is disabled or no chartId, return all data unchanged
+		if ( ! chartId || ! legendInteractive ) {
+			return data;
+		}
+
+		// Filter to only visible segments based on legend state
+		const filtered = data.filter( segment => isSeriesVisible( chartId, segment.label ) );
+
+		// If no segments are visible, return empty array
+		if ( filtered.length === 0 ) {
+			return [];
+		}
+
+		// Recalculate percentages so visible segments total 100%
+		const totalValue = filtered.reduce( ( sum, segment ) => sum + segment.value, 0 );
+
+		return filtered.map( segment => ( {
+			...segment,
+			percentage: totalValue > 0 ? ( segment.value / totalValue ) * 100 : 0,
+		} ) );
+	}, [ data, chartId, isSeriesVisible, legendInteractive ] );
+
+	// Check if all segments are hidden (only relevant in interactive mode)
+	const allSegmentsHidden = useMemo( () => {
+		return legendInteractive && visibleData.length === 0;
+	}, [ legendInteractive, visibleData ] );
+
+	return { visibleData, allSegmentsHidden };
+};

--- a/projects/js-packages/charts/src/hooks/use-interactive-legend-data.ts
+++ b/projects/js-packages/charts/src/hooks/use-interactive-legend-data.ts
@@ -32,6 +32,12 @@ interface UseInteractiveLegendDataResult< T extends DataPointWithPercentage > {
 	visibleData: T[];
 	/** Boolean indicating if all segments are hidden */
 	allSegmentsHidden: boolean;
+	/**
+	 * Legend data with recalculated percentages for visible items.
+	 * Uses original data for hidden items, but shows recalculated percentages for visible ones.
+	 * This ensures the legend displays accurate percentages while maintaining all entries.
+	 */
+	legendData: T[];
 }
 
 /**
@@ -47,17 +53,21 @@ interface UseInteractiveLegendDataResult< T extends DataPointWithPercentage > {
  *
  * @example
  * ```tsx
- * const { visibleData, allSegmentsHidden } = useInteractiveLegendData({
+ * const { visibleData, allSegmentsHidden, legendData } = useInteractiveLegendData({
  *   data: chartData,
  *   chartId: 'my-pie-chart',
  *   legendInteractive: true,
  *   isSeriesVisible: (id, label) => context.isSeriesVisible(id, label),
  * });
  *
+ * // Use legendData for creating legend items (shows recalculated percentages)
+ * const legendItems = useChartLegendItems(legendData, legendOptions);
+ *
  * if (allSegmentsHidden) {
  *   return <EmptyState />;
  * }
  *
+ * // Use visibleData for rendering the chart (only visible segments)
  * return <PieChart data={visibleData} />;
  * ```
  *
@@ -66,7 +76,7 @@ interface UseInteractiveLegendDataResult< T extends DataPointWithPercentage > {
  * @param params.chartId           - Unique identifier for the chart (required for interactive mode)
  * @param params.legendInteractive - Whether to enable interactive filtering
  * @param params.isSeriesVisible   - Function to check series visibility
- * @return Object containing visibleData and allSegmentsHidden flag
+ * @return Object containing visibleData, allSegmentsHidden flag, and legendData with recalculated percentages
  */
 export const useInteractiveLegendData = < T extends DataPointWithPercentage >( {
 	data,
@@ -103,5 +113,26 @@ export const useInteractiveLegendData = < T extends DataPointWithPercentage >( {
 		return legendInteractive && visibleData.length === 0;
 	}, [ legendInteractive, visibleData ] );
 
-	return { visibleData, allSegmentsHidden };
+	// Prepare legend data with recalculated percentages for visible items
+	// This maintains all legend entries but shows updated percentages for visible segments
+	const legendData = useMemo( () => {
+		if ( ! legendInteractive || ! chartId ) {
+			return data;
+		}
+
+		// Map original data to show recalculated percentages for visible items
+		return data.map( segment => {
+			const isVisible = isSeriesVisible( chartId, segment.label );
+			if ( ! isVisible ) {
+				// Return original data for hidden items
+				return segment;
+			}
+
+			// For visible items, find the recalculated percentage from visibleData
+			const recalculated = visibleData.find( d => d.label === segment.label );
+			return recalculated || segment;
+		} );
+	}, [ data, visibleData, legendInteractive, chartId, isSeriesVisible ] );
+
+	return { visibleData, allSegmentsHidden, legendData };
 };

--- a/projects/js-packages/charts/src/types.ts
+++ b/projects/js-packages/charts/src/types.ts
@@ -365,7 +365,9 @@ export type BaseChartProps< T = DataPoint | DataPointDate | LeaderboardEntry > =
 	legendItemClassName?: string;
 	/**
 	 * Enable interactive legend items that can toggle series visibility.
-	 * Currently only supported for LineChart. Requires chartId and GlobalChartsProvider.
+	 * Supported for LineChart, PieChart, and PieSemiCircleChart.
+	 * Requires chartId and GlobalChartsProvider.
+	 * For pie charts, percentages are recalculated so visible segments total 100%.
 	 */
 	legendInteractive?: boolean;
 	/**


### PR DESCRIPTION
## Proposed changes:
* Add `legendInteractive` prop to PieChart component to enable clickable legend items
* Add `legendInteractive` prop to PieSemiCircleChart component 
* Implement segment visibility toggling when legend items are clicked
* Add percentage recalculation logic so visible segments always total 100%
* Maintain consistent segment colors when toggling visibility using original indices
* Display empty state message when all segments are hidden
* Update type definitions and JSDoc documentation for pie chart support
* Pass `interactive` prop to Legend component when `legendInteractive` is enabled
* Create smart legend data mapping that shows recalculated percentages for visible segments only
* Keep all legend items visible (styled as inactive) rather than removing hidden items

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?

No, it does not.

## Testing instructions:

### PieChart:
* Go to Storybook -> Charts -> Types -> Pie Chart -> Interactive Legend story
* Click on legend items to toggle segment visibility
* Verify segments show/hide smoothly
* Check that visible segment percentages recalculate to total 100%
* Example: Hide a 25% segment, remaining segments should show 66.67% and 33.33%
* Verify hidden legend items remain visible but styled as inactive (grayed out)
* Hide all segments and verify empty state message appears
* Click hidden items again to show segments
* Verify segment colors remain consistent when toggling

### DonutChart:
* Go to Storybook -> Charts -> Types -> Pie Chart -> Donut Interactive Legend story
* Test same functionality as above with donut variant
* Verify the donut hole remains visible in empty state

### PieSemiCircleChart:
* Go to Storybook -> Charts -> Types -> Pie Semi Circle Chart -> Interactive Legend story
* Test same interactive legend functionality
* Verify semi-circle layout is maintained when segments are hidden
* Check percentage recalculation works correctly

### All Charts:
* Verify clicking legend items requires `legendInteractive` prop to be true
* Verify `chartId` and `GlobalChartsProvider` are required for functionality
* Check that aria-pressed attribute updates correctly (true/false)
* Test keyboard accessibility (Enter and Space keys should toggle)
* Verify no TypeScript errors
* Confirm no visual regressions in tooltips, labels, or other features
* Run tests: `npm test -- src/components/pie-chart/test`
* Run tests: `npm test -- src/components/pie-semi-circle-chart/test`