### PR TITLE
Revert "Instant Search: address browser privacy settings stripping the $query= value."

### DIFF
--- a/projects/packages/search/changelog/revert-45533-fix-privacy-settings-breaking-jetpack-search
+++ b/projects/packages/search/changelog/revert-45533-fix-privacy-settings-breaking-jetpack-search
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Instant Search: Revert Safari privacy settings fix due to E2E failure.

--- a/projects/packages/search/src/instant-search/components/dom-event-handler.jsx
+++ b/projects/packages/search/src/instant-search/components/dom-event-handler.jsx
@@ -122,13 +122,9 @@ export default class DomEventHandler extends Component {
 	};
 
 	handleInput = debounce( event => {
-		// Safari's Advanced Tracking and Fingerprinting Protection blocks reading event.target.value,
-		// so we read directly from the input element itself.
-		const inputValue = event.currentTarget.value;
-
 		// Reference: https://rawgit.com/w3c/input-events/v1/index.html#interface-InputEvent-Attributes
 		// NOTE: inputType is not compatible with IE11, so we use optional chaining here. https://caniuse.com/mdn-api_inputevent_inputtype
-		if ( event.inputType?.includes( 'format' ) || inputValue === '' ) {
+		if ( event.inputType?.includes( 'format' ) || event.target.value === '' ) {
 			return;
 		}
 
@@ -144,7 +140,7 @@ export default class DomEventHandler extends Component {
 			return;
 		}
 
-		this.props.setSearchQuery( inputValue );
+		this.props.setSearchQuery( event.target.value );
 
 		if ( [ 'immediate', 'results' ].includes( this.props.overlayOptions.overlayTrigger ) ) {
 			this.props.showResults();
@@ -154,9 +150,7 @@ export default class DomEventHandler extends Component {
 	handleKeyup = event => {
 		// If user presses enter, propagate the query value and immediately show the results.
 		if ( event.key === 'Enter' ) {
-			// Safari's Advanced Tracking and Fingerprinting Protection blocks reading event.target.value,
-			// so we read directly from the input element itself.
-			this.props.setSearchQuery( event.currentTarget.value );
+			this.props.setSearchQuery( event.target.value );
 			this.props.showResults();
 		}
 	};

--- a/projects/packages/search/src/instant-search/components/search-box.jsx
+++ b/projects/packages/search/src/instant-search/components/search-box.jsx
@@ -41,11 +41,7 @@ const SearchBox = props => {
 						inputMode="search"
 						// IE11 will immediately fire an onChange event when the placeholder contains a unicode character.
 						// Ensure that the search application is visible before invoking the onChange callback to guard against this.
-						// Safari's Advanced Tracking and Fingerprinting Protection blocks reading event.currentTarget.value,
-						// so we read directly from the ref instead.
-						onChange={
-							props.isVisible ? () => props.onChange( inputRef.current?.value ?? '' ) : null
-						}
+						onChange={ props.isVisible ? props.onChange : null }
 						ref={ inputRef }
 						placeholder={ __( 'Search…', 'jetpack-search-pkg' ) }
 						type="search"

--- a/projects/packages/search/src/instant-search/components/search-form.jsx
+++ b/projects/packages/search/src/instant-search/components/search-form.jsx
@@ -6,7 +6,7 @@ const noop = event => event.preventDefault();
 
 class SearchForm extends Component {
 	onClear = () => this.props.onChangeSearch( '' );
-	onChangeSearch = value => this.props.onChangeSearch( value );
+	onChangeSearch = event => this.props.onChangeSearch( event.currentTarget.value );
 
 	render() {
 		return (

--- a/projects/plugins/search/changelog/fix-privacy-settings-breaking-jetpack-search
+++ b/projects/plugins/search/changelog/fix-privacy-settings-breaking-jetpack-search
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Instant Search: address browser privacy settings from stripping out the search query value.


### PR DESCRIPTION
Reverts Automattic/jetpack#45533

These changes work, but they're breaking one E2E test. Will need to address the test and then try again. I'm unsure when that will happen so reverting in the meantime.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Ensure Jetpack Search still works, noting that Safari's privacy settings will once again break the `$query` value.