### PR TITLE
Jetpack Sync Tests: Update test_get_post_types_method

### DIFF
--- a/projects/plugins/jetpack/changelog/update-unit-tests-test_get_post_types_method
+++ b/projects/plugins/jetpack/changelog/update-unit-tests-test_get_post_types_method
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Update Sync related unit test
+
+

--- a/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Functions_Test.php
+++ b/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Functions_Test.php
@@ -787,33 +787,16 @@ class Jetpack_Sync_Functions_Test extends Jetpack_Sync_TestBase {
 		}
 
 		global $wp_post_types;
-		$synced = Functions::get_post_types();
+
+		$synced_post_types  = Functions::get_post_types();
+		$keys_we_care_about = array_keys( Defaults::$default_post_type_attributes );
+
 		foreach ( $wp_post_types as $post_type => $post_type_object ) {
-			$post_type_object->rest_controller_class = false;
-			$post_type_object->rest_controller       = null;
-			if ( isset( $post_type_object->revisions_rest_controller_class ) ) {
-				$post_type_object->revisions_rest_controller_class = false;
-			}
-			if ( isset( $post_type_object->revisions_rest_controller ) ) {
-				$post_type_object->revisions_rest_controller = null;
-			}
-			if ( isset( $post_type_object->autosave_rest_controller_class ) ) {
-				$post_type_object->autosave_rest_controller_class = false;
-			}
-			if ( isset( $post_type_object->autosave_rest_controller ) ) {
-				$post_type_object->autosave_rest_controller = null;
-			}
-			if ( isset( $post_type_object->late_route_registration ) ) {
-				$post_type_object->late_route_registration = false;
-			}
-			if ( ! isset( $post_type_object->supports ) ) {
-				$post_type_object->supports = array();
-			}
-			$synced_post_type = Functions::expand_synced_post_type( $synced[ $post_type ], $post_type );
-			if ( isset( $synced_post_type->labels->template_name ) ) {
-				$post_type_object->labels->template_name = $synced_post_type->labels->template_name;
-			}
-			$this->assertEqualsObject( $post_type_object, $synced_post_type, 'POST TYPE :' . $post_type . ' not equal' );
+			$post_type_arr    = array_filter( (array) $post_type_object, fn ( $item ) => null !== $item ); // remove 'null' elements.
+			$synced_post_type = (array) $synced_post_types[ $post_type ];
+			ksort( $post_type_arr );
+			ksort( $synced_post_type );
+			$this->assertArrayIsIdenticalToArrayOnlyConsideringListOfKeys( $post_type_arr, $synced_post_type, $keys_we_care_about );
 		}
 	}
 

--- a/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Functions_Test.php
+++ b/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Functions_Test.php
@@ -792,7 +792,13 @@ class Jetpack_Sync_Functions_Test extends Jetpack_Sync_TestBase {
 		$keys_we_care_about = array_keys( Defaults::$default_post_type_attributes );
 
 		foreach ( $wp_post_types as $post_type => $post_type_object ) {
-			$post_type_arr    = array_filter( (array) $post_type_object, fn ( $item ) => null !== $item ); // remove 'null' elements.
+			// remove 'null' elements.
+			$post_type_arr    = array_filter(
+				(array) $post_type_object,
+				function ( $item ) {
+					return null !== $item;
+				}
+			);
 			$synced_post_type = (array) $synced_post_types[ $post_type ];
 			ksort( $post_type_arr );
 			ksort( $synced_post_type );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to https://github.com/Automattic/jetpack/pull/45573

A more graceful approach for testing `Functions::get_post_types`

With the existing approach we would fetch the post types after Sync sanitizes them via `get_post_types`. Post-sanitization various post type properties we don't care about were missing.
It looks like **only** for testing purposes, we were adding all those properties back via `expand_synced_post_type` - we no longer seem to use this method outside of tests.
Finally, we were comparing to the actual post type object - which as core adds/removes properties (see for example [this commit](https://github.com/WordPress/WordPress/commit/82c917225c#diff-92fb957641ab31dd02d924a3fd05c5409a453ed484c879b11b67e4d969bf77d1)) might contain extra properties we don't actually care about, resulting in failing unit test.

This PR refactors the whole logic for testing, focusing only on the properties Sync cares about (see `Defaults::$default_post_type_attributes` )

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* `test_get_post_types_method`: Refactor unit test and stop using `expand_synced_post_type`. Make sure we only compare the post type properties we care about.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1761061184549869-slack-C034JEXD1RD

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Code review