### PR TITLE
Private site: Auto-redirect to login

### DIFF
--- a/projects/plugins/wpcomsh/changelog/dotcom-14922-user-sees-a-private-site-even-after-they-are-logged-in
+++ b/projects/plugins/wpcomsh/changelog/dotcom-14922-user-sees-a-private-site-even-after-they-are-logged-in
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Private site: Auto-redirect to login

--- a/projects/plugins/wpcomsh/private-site/private-site.php
+++ b/projects/plugins/wpcomsh/private-site/private-site.php
@@ -705,8 +705,11 @@ function access_denied_template_path() {
 
 	if ( site_is_coming_soon() ) {
 		return __DIR__ . '/access-denied-coming-soon-template.php';
-	} else {
+	} elseif ( is_user_logged_in() ) {
 		return __DIR__ . '/access-denied-private-site-template.php';
+	} else {
+		wp_safe_redirect( wp_login_url( set_url_scheme( original_request_url() ) ) );
+		exit( 0 );
 	}
 }
 

--- a/projects/plugins/wpcomsh/private-site/private-site.php
+++ b/projects/plugins/wpcomsh/private-site/private-site.php
@@ -117,9 +117,6 @@ function init() {
 	// Robots requests are allowed via parse_request / maybe_print_robots_txt
 	add_filter( 'robots_txt', '\Private_Site\private_robots_txt' );
 
-	// Add info to login form.
-	add_filter( 'login_message', '\Private_Site\add_login_message' );
-
 	// @TODO pre_trackback_post maybe..?
 
 	// @TODO add "lock" toolbar item when private
@@ -706,13 +703,21 @@ function access_denied_template_path() {
 		return __DIR__ . '/access-denied-preview-login-template.php';
 	}
 
-	if ( site_is_coming_soon() ) {
-		return __DIR__ . '/access-denied-coming-soon-template.php';
-	} elseif ( is_user_logged_in() ) {
-		return __DIR__ . '/access-denied-private-site-template.php';
-	} else {
+	$calypso_domains = array(
+		'https://wordpress.com/',
+		'https://horizon.wordpress.com/',
+		'https://wpcalypso.wordpress.com/',
+		'http://calypso.localhost:3000/',
+		'http://127.0.0.1:41050/', // Desktop App.
+	);
+	if ( in_array( wp_get_referer(), $calypso_domains, true ) ) {
+		// Redirect to the login page, so the SSO module can try to automatically log the user in.
 		wp_safe_redirect( wp_login_url( set_url_scheme( original_request_url() ) ) );
 		exit( 0 );
+	} elseif ( site_is_coming_soon() ) {
+		return __DIR__ . '/access-denied-coming-soon-template.php';
+	} else {
+		return __DIR__ . '/access-denied-private-site-template.php';
 	}
 }
 
@@ -933,27 +938,4 @@ function should_override_editor_with_classic_editor() {
 	}
 
 	return true;
-}
-
-/**
- * Display a message in the login form.
- *
- * @param string $message Login message text.
- *
- * @return string The update login message text.
- */
-function add_login_message( $message ) {
-	error_log('add_login_message');
-	if ( ! empty( $_GET['redirect_to'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		// If we have something to redirect to.
-		$url = esc_url_raw( wp_unslash( $_GET['redirect_to'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		error_log($url);
-		error_log(admin_url());
-
-		// Display message only if we're redirecting to the frontend.
-		if ( strpos( $url, admin_url() ) === false ) {
-			$message .= sprintf( '<p class="message">%s</p>', __( 'You need to be logged in as a user who has permission to view this site.', 'wpcomsh' ) );
-		}
-	}
-	return $message;
 }

--- a/projects/plugins/wpcomsh/private-site/private-site.php
+++ b/projects/plugins/wpcomsh/private-site/private-site.php
@@ -703,15 +703,19 @@ function access_denied_template_path() {
 		return __DIR__ . '/access-denied-preview-login-template.php';
 	}
 
-	$calypso_domains = array(
+	/*
+	 * Logged-out users coming from Calypso are likely authenticated in wordpress.com, so if we redirect them
+	 * straight away to the login page, the SSO module will try to automatically log them in into the site.
+	 */
+	$calypso_domains          = array(
 		'https://wordpress.com/',
 		'https://horizon.wordpress.com/',
 		'https://wpcalypso.wordpress.com/',
 		'http://calypso.localhost:3000/',
 		'http://127.0.0.1:41050/', // Desktop App.
 	);
-	if ( in_array( wp_get_referer(), $calypso_domains, true ) ) {
-		// Redirect to the login page, so the SSO module can try to automatically log the user in.
+	$should_redirect_to_login = ( ! is_user_logged_in() ) && class_exists( 'Jetpack' ) && Jetpack::is_module_active( 'sso' ) && in_array( wp_get_referer(), $calypso_domains, true );
+	if ( $should_redirect_to_login ) {
 		wp_safe_redirect( wp_login_url( set_url_scheme( original_request_url() ) ) );
 		exit( 0 );
 	} elseif ( site_is_coming_soon() ) {

--- a/projects/plugins/wpcomsh/private-site/private-site.php
+++ b/projects/plugins/wpcomsh/private-site/private-site.php
@@ -943,9 +943,12 @@ function should_override_editor_with_classic_editor() {
  * @return string The update login message text.
  */
 function add_login_message( $message ) {
+	error_log('add_login_message');
 	if ( ! empty( $_GET['redirect_to'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		// If we have something to redirect to.
 		$url = esc_url_raw( wp_unslash( $_GET['redirect_to'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		error_log($url);
+		error_log(admin_url());
 
 		// Display message only if we're redirecting to the frontend.
 		if ( strpos( $url, admin_url() ) === false ) {

--- a/projects/plugins/wpcomsh/private-site/private-site.php
+++ b/projects/plugins/wpcomsh/private-site/private-site.php
@@ -117,6 +117,9 @@ function init() {
 	// Robots requests are allowed via parse_request / maybe_print_robots_txt
 	add_filter( 'robots_txt', '\Private_Site\private_robots_txt' );
 
+	// Add info to login form.
+	add_filter( 'login_message', '\Private_Site\add_login_message' );
+
 	// @TODO pre_trackback_post maybe..?
 
 	// @TODO add "lock" toolbar item when private
@@ -930,4 +933,16 @@ function should_override_editor_with_classic_editor() {
 	}
 
 	return true;
+}
+
+/**
+ * Display a message in the login form.
+ *
+ * @param string $message Login message text.
+ *
+ * @return string The update login message text.
+ */
+function add_login_message( $message ) {
+	$message .= sprintf( '<p class="message">%s</p>', __( 'You need to be logged in as a user who has permission to view this site.', 'wpcomsh' ) );
+	return $message;
 }

--- a/projects/plugins/wpcomsh/private-site/private-site.php
+++ b/projects/plugins/wpcomsh/private-site/private-site.php
@@ -943,6 +943,14 @@ function should_override_editor_with_classic_editor() {
  * @return string The update login message text.
  */
 function add_login_message( $message ) {
-	$message .= sprintf( '<p class="message">%s</p>', __( 'You need to be logged in as a user who has permission to view this site.', 'wpcomsh' ) );
+	if ( ! empty( $_GET['redirect_to'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		// If we have something to redirect to.
+		$url = esc_url_raw( wp_unslash( $_GET['redirect_to'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+
+		// Display message only if we're redirecting to the frontend.
+		if ( strpos( $url, admin_url() ) === false ) {
+			$message .= sprintf( '<p class="message">%s</p>', __( 'You need to be logged in as a user who has permission to view this site.', 'wpcomsh' ) );
+		}
+	}
 	return $message;
 }


### PR DESCRIPTION
Fixes DOTCOM-14922

## Proposed changes:

Instead of showing a custom login form to logged-out users trying to visit an Atomic private site, we now automatically redirect to the wp-login flow, so the automated login performed by Jetpack SSO (see https://github.com/Automattic/jetpack/pull/39139) take places.

**Before**

https://github.com/user-attachments/assets/e1b9ed14-d596-4e7d-a27c-5c025683e360

**After**


https://github.com/user-attachments/assets/67b87255-8360-4c51-bb11-02d0373f25f6



### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
N/A

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
- Apply these changes to a WoA dev blog
- Go to Settings > Reading and change the site visibility to "Private"
- Go to `wordpress.com/people/new/:site`
- Invite a user that already has a WP.com account as viewer
- Accept the invitation with that another user
- You'll see a notice saying "You're now a Subscriber of <SITE_TITLE>"
- Click on the site title link.
- Make sure you're automatically logged in and you can see the site.

