### PR TITLE
Forms: update visual representation of "image select field" responses at inbox

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25281,7 +25281,7 @@ snapshots:
       '@babel/core': 7.28.4
       find-cache-dir: 3.3.2
       schema-utils: 4.3.3
-      webpack: 5.101.3(webpack-cli@6.0.1)
+      webpack: 5.101.3(esbuild@0.25.9)(webpack-cli@6.0.1)
 
   babel-loader@9.2.1(@babel/core@7.28.4)(webpack@5.101.3):
     dependencies:
@@ -26086,7 +26086,7 @@ snapshots:
       postcss-value-parser: 4.2.0
       semver: 7.7.1
     optionalDependencies:
-      webpack: 5.101.3(webpack-cli@6.0.1)
+      webpack: 5.101.3(esbuild@0.25.9)(webpack-cli@6.0.1)
 
   css-minimizer-webpack-plugin@7.0.2(webpack@5.101.3):
     dependencies:
@@ -29951,7 +29951,7 @@ snapshots:
     dependencies:
       schema-utils: 4.3.3
       tapable: 2.3.0
-      webpack: 5.101.3(webpack-cli@6.0.1)
+      webpack: 5.101.3(esbuild@0.25.9)(webpack-cli@6.0.1)
 
   minimalistic-assert@1.0.1: {}
 
@@ -30610,7 +30610,7 @@ snapshots:
       postcss: 8.5.6
       semver: 7.7.1
     optionalDependencies:
-      webpack: 5.101.3(webpack-cli@6.0.1)
+      webpack: 5.101.3(esbuild@0.25.9)(webpack-cli@6.0.1)
     transitivePeerDependencies:
       - typescript
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2584,6 +2584,9 @@ importers:
       lodash:
         specifier: 4.17.21
         version: 4.17.21
+      photon:
+        specifier: 4.1.1
+        version: 4.1.1
       react-redux:
         specifier: 7.2.8
         version: 7.2.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -25278,7 +25281,7 @@ snapshots:
       '@babel/core': 7.28.4
       find-cache-dir: 3.3.2
       schema-utils: 4.3.3
-      webpack: 5.101.3(esbuild@0.25.9)(webpack-cli@6.0.1)
+      webpack: 5.101.3(webpack-cli@6.0.1)
 
   babel-loader@9.2.1(@babel/core@7.28.4)(webpack@5.101.3):
     dependencies:
@@ -26083,7 +26086,7 @@ snapshots:
       postcss-value-parser: 4.2.0
       semver: 7.7.1
     optionalDependencies:
-      webpack: 5.101.3(esbuild@0.25.9)(webpack-cli@6.0.1)
+      webpack: 5.101.3(webpack-cli@6.0.1)
 
   css-minimizer-webpack-plugin@7.0.2(webpack@5.101.3):
     dependencies:
@@ -29948,7 +29951,7 @@ snapshots:
     dependencies:
       schema-utils: 4.3.3
       tapable: 2.3.0
-      webpack: 5.101.3(esbuild@0.25.9)(webpack-cli@6.0.1)
+      webpack: 5.101.3(webpack-cli@6.0.1)
 
   minimalistic-assert@1.0.1: {}
 
@@ -30607,7 +30610,7 @@ snapshots:
       postcss: 8.5.6
       semver: 7.7.1
     optionalDependencies:
-      webpack: 5.101.3(esbuild@0.25.9)(webpack-cli@6.0.1)
+      webpack: 5.101.3(webpack-cli@6.0.1)
     transitivePeerDependencies:
       - typescript
 

--- a/projects/packages/forms/changelog/update-forms-image-select-img-perf
+++ b/projects/packages/forms/changelog/update-forms-image-select-img-perf
@@ -1,4 +1,4 @@
 Significance: minor
 Type: changed
 
-Forms: for image option field responses, use smaller images
+Forms: update visual representation of "image select field" responses at inbox

--- a/projects/packages/forms/changelog/update-forms-image-select-img-perf
+++ b/projects/packages/forms/changelog/update-forms-image-select-img-perf
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Forms: for image option field responses, use smaller images

--- a/projects/packages/forms/package.json
+++ b/projects/packages/forms/package.json
@@ -70,6 +70,7 @@
 		"js-sha256": "0.11.1",
 		"libphonenumber-js": "1.12.23",
 		"lodash": "4.17.21",
+		"photon": "4.1.1",
 		"react-redux": "7.2.8",
 		"react-router": "7.6.2",
 		"react-transition-group": "^4.4.5",

--- a/projects/packages/forms/src/dashboard/components/response-view/body.tsx
+++ b/projects/packages/forms/src/dashboard/components/response-view/body.tsx
@@ -21,6 +21,7 @@ import { decodeEntities } from '@wordpress/html-entities';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { download } from '@wordpress/icons';
 import clsx from 'clsx';
+import photon from 'photon';
 /**
  * Internal dependencies
  */
@@ -265,9 +266,9 @@ const ResponseViewBody = ( {
 							</div>
 							<div className="image-select-field-images">
 								{ value.choices.map( choice => {
-									const imageSrc =
-										choice.image?.src ||
-										'data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=';
+									const imageSrc = choice.image?.src
+										? photon( choice.image.src, { width: 120, height: 120 } )
+										: 'data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=';
 
 									return (
 										<figure
@@ -281,6 +282,7 @@ const ResponseViewBody = ( {
 													'is-empty': ! choice.image?.src,
 												} ) }
 												src={ imageSrc }
+												loading="lazy"
 												alt={ choice.selected }
 											/>
 										</figure>

--- a/projects/packages/forms/src/dashboard/components/response-view/body.tsx
+++ b/projects/packages/forms/src/dashboard/components/response-view/body.tsx
@@ -19,7 +19,7 @@ import { dateI18n, getSettings as getDateSettings } from '@wordpress/date';
 import { useCallback, useEffect, useRef, useState } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
 import { __, _n, sprintf } from '@wordpress/i18n';
-import { download } from '@wordpress/icons';
+import { download, image } from '@wordpress/icons';
 import clsx from 'clsx';
 import photon from 'photon';
 /**
@@ -250,46 +250,46 @@ const ResponseViewBody = ( {
 				<div className="image-select-field">
 					{ ( value.choices?.length ?? 0 ) === 0 && '-' }
 					{ ( value.choices?.length ?? 0 ) > 0 && (
-						<>
-							<div className="image-select-field-choices">
-								{ value.choices
-									.map( choice => {
-										let transformedValue = choice.selected;
-
-										if ( choice.label != null && choice.label !== '' ) {
-											transformedValue += ' - ' + choice.label;
+						<VStack spacing="1">
+							{ value.choices.map( choice => {
+								const label = choice.label
+									? `${ choice.selected }: ${ choice.label }`
+									: choice.selected;
+								const hasImage = choice.image?.src;
+								return (
+									<Button
+										__next40pxDefaultSize
+										key={ choice.selected }
+										variant="tertiary"
+										onClick={
+											hasImage
+												? handleFilePreview( {
+														file_id: choice.image.id,
+														name: label,
+														url: choice.image.src,
+												  } )
+												: undefined
 										}
-
-										return transformedValue;
-									} )
-									.join( ', ' ) }
-							</div>
-							<div className="image-select-field-images">
-								{ value.choices.map( choice => {
-									const imageSrc = choice.image?.src
-										? photon( choice.image.src, { width: 120, height: 120 } )
-										: 'data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=';
-
-									return (
-										<figure
-											key={ choice.selected }
-											className={ clsx( 'image-select-field-image', {
-												'is-empty': ! choice.image?.src,
-											} ) }
-										>
-											<img
-												className={ clsx( 'image-select-field-image', {
-													'is-empty': ! choice.image?.src,
-												} ) }
-												src={ imageSrc }
-												loading="lazy"
-												alt={ choice.selected }
-											/>
-										</figure>
-									);
-								} ) }
-							</div>
-						</>
+										className="image-select-field-button"
+										icon={
+											hasImage ? (
+												<img
+													alt={ choice.selected }
+													className="image-select-field-image"
+													loading="lazy"
+													src={ photon( choice.image.src, { width: 120, height: 120 } ) }
+												/>
+											) : (
+												image
+											)
+										}
+										iconSize={ hasImage ? 60 : 24 }
+									>
+										{ label }
+									</Button>
+								);
+							} ) }
+						</VStack>
 					) }
 				</div>
 			);

--- a/projects/packages/forms/src/dashboard/components/response-view/body.tsx
+++ b/projects/packages/forms/src/dashboard/components/response-view/body.tsx
@@ -283,7 +283,7 @@ const ResponseViewBody = ( {
 												image
 											)
 										}
-										iconSize={ hasImage ? 60 : 24 }
+										iconSize={ 60 }
 									>
 										{ label }
 									</Button>

--- a/projects/packages/forms/src/dashboard/inbox/style.scss
+++ b/projects/packages/forms/src/dashboard/inbox/style.scss
@@ -274,36 +274,9 @@
 
 .jp-forms__inbox-response-data-value .image-select-field {
 
-	.image-select-field-images {
-		display: flex;
-		flex-wrap: wrap;
-		gap: 16px;
-	}
-
-	.image-select-field-image {
-		margin: 0;
-		width: 60px;
-		height: 60px;
-
-		&.is-empty {
-			position: relative;
-
-			&::before {
-
-				@extend %empty-image-option-background;
-			}
-
-			&::after {
-
-				@extend %empty-image-option-icon;
-				background-color: #000;
-			}
-		}
-
-		img {
-			aspect-ratio: 1/1;
-			object-fit: cover;
-		}
+	.image-select-field-button {
+		gap: variables.$grid-unit-10;
+		height: auto;
 	}
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Follow-up to https://github.com/Automattic/jetpack/pull/45576
Part of FORMS-60

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Use Photon to load only a small image
* Add `lazy` to prevent loading images early when they're outside the viewport, especially on mobile
* Wrap images & responses next to each other, each on its own row, wrapped in a button
* Open a modal to preview a larger photo when clicked
* Simplify CSS to have fewer styles, use more components. 
* Especially an empty image is now a simpler implementation as more of an edge case; previously it was nicer, but I'm not sure it's worth the code.


### Before

<img width="252" height="150" alt="Screenshot 2025-10-22 at 13 53 35" src="https://github.com/user-attachments/assets/c8adb18e-a331-42ba-93bd-b2e638bdb039" />
<img width="288" height="151" alt="Screenshot 2025-10-22 at 13 53 33" src="https://github.com/user-attachments/assets/6b293b9f-2276-4f3e-8871-56049972bd91" />
<img width="227" height="145" alt="Screenshot 2025-10-22 at 13 53 42" src="https://github.com/user-attachments/assets/145b2aa5-4d5c-4c30-89d0-9a149c3e0aaf" />

### After


https://github.com/user-attachments/assets/53470e84-cd82-4399-9b3b-6e45b894bab8



Multiple answers:
<img width="380" height="218" alt="Screenshot 2025-10-22 at 13 45 06" src="https://github.com/user-attachments/assets/a473e5e6-bf5d-4250-b5d1-b459b6313c97" />

Empty label answers:
<img width="325" height="154" alt="Screenshot 2025-10-22 at 13 45 12" src="https://github.com/user-attachments/assets/7713a827-b23a-4d57-ba24-e3bf2ac7eec3" />

Empty image answer:
<img width="392" height="209" alt="Screenshot 2025-10-22 at 13 45 01" src="https://github.com/user-attachments/assets/8f9d3f0d-8558-4f01-b9ca-915c6331f323" />

Modal for preview:
<img width="1116" height="631" alt="Screenshot 2025-10-22 at 13 45 31" src="https://github.com/user-attachments/assets/8442d8e4-2a17-4903-b164-863298f43d6d" />



### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Add image option field with option label, empty label, and empty image (but with label)
* Submit responses
