### PR TITLE
Forms: store user agent on form submission

### DIFF
--- a/projects/packages/forms/changelog/add-forms-submission-user-agent
+++ b/projects/packages/forms/changelog/add-forms-submission-user-agent
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Forms: store the user agent used on form submissions.

--- a/projects/packages/forms/src/contact-form/class-feedback.php
+++ b/projects/packages/forms/src/contact-form/class-feedback.php
@@ -71,6 +71,15 @@ class Feedback {
 	protected $ip_address = null;
 
 	/**
+	 * The user agent of the user who submitted the feedback.
+	 *
+	 * This is only available on form submissions, and might not be available when retrieving existing feedback posts.
+	 *
+	 * @var string|null
+	 */
+	protected $user_agent = null;
+
+	/**
 	 * The subject of the feedback entry.
 	 *
 	 * @var string
@@ -215,6 +224,7 @@ class Feedback {
 		);
 
 		$this->ip_address = $parsed_content['ip'] ?? $this->get_first_field_of_type( 'ip' );
+		$this->user_agent = $parsed_content['user_agent'] ?? null;
 		$this->subject    = $parsed_content['subject'] ?? $this->get_first_field_of_type( 'subject' );
 
 		$this->notification_recipients = $parsed_content['notification_recipients'] ?? array();
@@ -270,6 +280,7 @@ class Feedback {
 		// If post_data is provided, use it to populate fields.
 		$this->fields          = $this->get_computed_fields( $post_data, $form );
 		$this->ip_address      = Contact_Form_Plugin::get_ip_address();
+		$this->user_agent      = isset( $_SERVER['HTTP_USER_AGENT'] ) ? filter_var( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ) ) : null;
 		$this->subject         = $this->get_computed_subject( $post_data, $form );
 		$this->author_data     = Feedback_Author::from_submission( $post_data, $form );
 		$this->comment_content = $this->get_computed_comment_content( $post_data, $form );
@@ -744,6 +755,15 @@ class Feedback {
 	}
 
 	/**
+	 * Get the user agent of the submitted feedback request.
+	 *
+	 * @return string|null
+	 */
+	public function get_user_agent() {
+		return $this->user_agent;
+	}
+
+	/**
 	 * Get the email subject.
 	 *
 	 * @return string
@@ -995,6 +1015,7 @@ class Feedback {
 			array(
 				'subject'                 => $this->subject,
 				'ip'                      => $this->ip_address,
+				'user_agent'              => $this->user_agent,
 				'notification_recipients' => $this->notification_recipients,
 			),
 			$this->source->serialize()

--- a/projects/packages/forms/tests/php/contact-form/Feedback_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Feedback_Test.php
@@ -266,6 +266,49 @@ class Feedback_Test extends BaseTestCase {
 	}
 
 	/**
+	 * Test the user agent is included in the serialized response.
+	 * It should be available when the response is created during the form submission.
+	 */
+	public function test_user_agent_included_in_serialized_response() {
+
+		$form_id = Utility::get_form_id();
+		// Create a form submission
+		$_post_data = Utility::get_post_request(
+			array(
+				'name'    => 'John Doe',
+				'email'   => 'john@example.com',
+				'message' => 'Test message',
+			),
+			'g' . $form_id
+		);
+
+		$form = new Contact_Form(
+			array(
+				'title'       => 'Test Form',
+				'description' => 'This is a test form.',
+			),
+			"[contact-field label='Name' type='name' required='1'/][contact-field label='Email' type='email' required='1'/][contact-field label='Message' type='textarea' required='1'/]"
+		);
+
+		// Set a test user agent
+		$_SERVER['HTTP_USER_AGENT'] = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36';
+
+		// Create a contact form
+		$response         = Feedback::from_submission( $_post_data, $form );
+		$feedback_post_id = $response->save();
+		$saved_response   = Feedback::get( $feedback_post_id );
+
+		// The user agent should be present.
+		$this->assertNotEmpty( $response->get_user_agent(), 'User agent should not be empty' );
+		$this->assertNotEmpty( $saved_response->get_user_agent(), 'User agent should not be empty' );
+		$this->assertEquals( $response->get_user_agent(), $saved_response->get_user_agent(), 'User agent should match' );
+		$this->assertEquals( $_SERVER['HTTP_USER_AGENT'], $saved_response->get_user_agent(), 'User agent should match server value' );
+
+		// Clean up
+		unset( $_SERVER['HTTP_USER_AGENT'] );
+	}
+
+	/**
 	 * Test the subject line is computed for legacy correctly.
 	 */
 	public function test_computed_subject_legacy() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Part of FORMS-319

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Added user_agent property to Feedback class
* Capture user agent during submission (defaults to null if not available)
* Load user agent from stored data
* Store user agent in database: user agent is now persisted alongside IP address and other submission metadata
* Added tests 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this branch to your local environment and submit a form response.
* Check that the user agent was stored in the post content by running this command on your terminal:
```bash
jetpack docker wp db query 'select post_content from wp_posts where post_type = "feedback" order by ID asc\G;'
```
* You should get something like:
```
post_content: {"subject":"[Local test site] Test","ip":"172.21.0.1","user_agent":"Mozilla\/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/141.0.0.0 Safari\/537.36","notification_recipients":["1"],"entry_title":"Test","entry_page":1,"source_id":97,"source_type":"single","request_url":"http:\/\/localhost\/2025\/10\/15\/test"....
```

