### PR TITLE
MU WPCOM: Add a new wpcom_theme_switch Tracks event to theme screens

### DIFF
--- a/.phan/config.base.php
+++ b/.phan/config.base.php
@@ -114,6 +114,7 @@ function make_phan_config( $dir, $options = array() ) {
 					$extra_stubs[] = "$root/projects/plugins/wpcomsh/lib/require-lib.php";
 					$extra_stubs[] = "$root/projects/plugins/wpcomsh/wpcom-features/class-wpcom-features.php";
 					$extra_stubs[] = "$root/projects/plugins/wpcomsh/wpcom-features/functions-wpcom-features.php";
+					$extra_stubs[] = "$root/projects/plugins/wpcomsh/wpcom-themes/themes.php";
 				}
 				break;
 			default:

--- a/.phan/config.base.php
+++ b/.phan/config.base.php
@@ -115,6 +115,7 @@ function make_phan_config( $dir, $options = array() ) {
 					$extra_stubs[] = "$root/projects/plugins/wpcomsh/wpcom-features/class-wpcom-features.php";
 					$extra_stubs[] = "$root/projects/plugins/wpcomsh/wpcom-features/functions-wpcom-features.php";
 					$extra_stubs[] = "$root/projects/plugins/wpcomsh/wpcom-themes/themes.php";
+					$extra_stubs[] = "$root/projects/plugins/wpcomsh/wpcom-themes/includes/class-wpcom-themes-service.php";
 				}
 				break;
 			default:

--- a/projects/packages/jetpack-mu-wpcom/changelog/dotthem-107-themes-add-all-the-tracks-events-to-wp-admin
+++ b/projects/packages/jetpack-mu-wpcom/changelog/dotthem-107-themes-add-all-the-tracks-events-to-wp-admin
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add Tracks events to theme screens

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -340,6 +340,7 @@ class Jetpack_Mu_Wpcom {
 		require_once __DIR__ . '/features/wpcom-profile-settings/profile-settings-link-to-wpcom.php';
 		require_once __DIR__ . '/features/wpcom-profile-settings/profile-settings-notices.php';
 		require_once __DIR__ . '/features/wpcom-sidebar-notice/wpcom-sidebar-notice.php';
+		require_once __DIR__ . '/features/wpcom-themes/wpcom-theme-tracking.php';
 		require_once __DIR__ . '/features/wpcom-themes/wpcom-themes.php';
 		require_once __DIR__ . '/features/wpcom-user-edit/wpcom-user-edit.php';
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-themes/wpcom-theme-tracking.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-themes/wpcom-theme-tracking.php
@@ -25,7 +25,7 @@ function wpcom_themes_tracks_get_theme_props( $theme, $prefix = '' ) {
 	$theme_data           = $wpcom_themes_service->get_theme( $theme->stylesheet );
 
 	if ( $prefix !== '' ) {
-		$prefix = $prefix . '_';
+		$prefix .= '_';
 	}
 
 	$props = array();

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-themes/wpcom-theme-tracking.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-themes/wpcom-theme-tracking.php
@@ -34,11 +34,13 @@ function wpcom_themes_tracks_get_theme_props( $theme, $prefix = '' ) {
 		$props[ $prefix . 'theme_stylesheet' ]     = $theme->get_stylesheet();
 		$props[ $prefix . 'theme_tier' ]           = 'community';
 		$props[ $prefix . 'theme_is_block_theme' ] = $theme->is_block_theme();
+		$props[ $prefix . 'theme_is_retired' ]     = false;
 	} else {
 		$props[ $prefix . 'theme' ]                = $theme_data->name;
 		$props[ $prefix . 'theme_stylesheet' ]     = $theme_data->slug;
 		$props[ $prefix . 'theme_tier' ]           = $theme_data->theme_tier;
 		$props[ $prefix . 'theme_is_block_theme' ] = $theme_data->block_theme;
+		$props[ $prefix . 'theme_is_retired' ]     = $theme_data->is_retired;
 	}
 
 	return $props;

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-themes/wpcom-theme-tracking.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-themes/wpcom-theme-tracking.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * WordPress.com Theme Tracking
+ *
+ * Add Tracks events to the wp-admin theme screens.
+ *
+ * @package automattic/jetpack-mu-wpcom
+ */
+
+use Automattic\Jetpack\Jetpack_Mu_Wpcom\Common;
+
+/**
+ * Record a theme switch.
+ *
+ * @todo There is already a theme switch event for Simple sites. It should be removed in favor of this one.
+ *
+ * @param string   $new_theme_name New theme name.
+ * @param WP_Theme $new_theme      New theme object.
+ * @param WP_Theme $old_theme      Old theme object.
+ */
+function wpcom_themes_tracks_switch_theme( $new_theme_name, $new_theme, $old_theme ) {
+	if ( ! function_exists( 'wpcomsh_get_wpcom_themes_service_instance' ) ) {
+		return;
+	}
+
+	$wpcom_themes_service = wpcomsh_get_wpcom_themes_service_instance();
+
+	$old = $wpcom_themes_service->get_theme( $old_theme->stylesheet );
+	$new = $wpcom_themes_service->get_theme( $new_theme->stylesheet );
+
+	$event_props = array(
+		'blog_id'                  => get_wpcom_blog_id(),
+		'new_theme'                => $new->name,
+		'new_theme_stylesheet'     => $new->slug,
+		'new_theme_tier'           => $new->theme_tier,
+		'new_theme_is_block_theme' => $new->block_theme,
+		'old_theme'                => $old->name,
+		'old_theme_stylesheet'     => $old->slug,
+		'old_theme_tier'           => $old->theme_tier,
+		'old_theme_is_block_theme' => $old->block_theme,
+	);
+
+	Common\wpcom_record_tracks_event( 'wpcom_theme_switch', $event_props );
+}
+add_action( 'switch_theme', 'wpcom_themes_tracks_switch_theme', 12, 3 );

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-themes/wpcom-theme-tracking.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-themes/wpcom-theme-tracking.php
@@ -10,6 +10,41 @@
 use Automattic\Jetpack\Jetpack_Mu_Wpcom\Common;
 
 /**
+ * Get theme properties for Tracks event.
+ *
+ * @param WP_Theme $theme  Theme object.
+ * @param string   $prefix Prefix for the property keys.
+ * @return array Associative array of theme properties.
+ */
+function wpcom_themes_tracks_get_theme_props( $theme, $prefix = '' ) {
+	if ( ! function_exists( 'wpcomsh_get_wpcom_themes_service_instance' ) ) {
+		return array();
+	}
+
+	$wpcom_themes_service = wpcomsh_get_wpcom_themes_service_instance();
+	$theme_data           = $wpcom_themes_service->get_theme( $theme->stylesheet );
+
+	if ( $prefix !== '' ) {
+		$prefix = $prefix . '_';
+	}
+
+	$props = array();
+	if ( $theme_data === null ) {
+		$props[ $prefix . 'theme' ]                = $theme->get( 'Name' );
+		$props[ $prefix . 'theme_stylesheet' ]     = $theme->get_stylesheet();
+		$props[ $prefix . 'theme_tier' ]           = 'community';
+		$props[ $prefix . 'theme_is_block_theme' ] = $theme->is_block_theme();
+	} else {
+		$props[ $prefix . 'theme' ]                = $theme_data->name;
+		$props[ $prefix . 'theme_stylesheet' ]     = $theme_data->slug;
+		$props[ $prefix . 'theme_tier' ]           = $theme_data->theme_tier;
+		$props[ $prefix . 'theme_is_block_theme' ] = $theme_data->block_theme;
+	}
+
+	return $props;
+}
+
+/**
  * Record a theme switch.
  *
  * @todo There is already a theme switch event for Simple sites. It should be removed in favor of this one.
@@ -23,21 +58,13 @@ function wpcom_themes_tracks_switch_theme( $new_theme_name, $new_theme, $old_the
 		return;
 	}
 
-	$wpcom_themes_service = wpcomsh_get_wpcom_themes_service_instance();
+	$old_theme_props = wpcom_themes_tracks_get_theme_props( $old_theme, 'old' );
+	$new_theme_props = wpcom_themes_tracks_get_theme_props( $new_theme, 'new' );
 
-	$old = $wpcom_themes_service->get_theme( $old_theme->stylesheet );
-	$new = $wpcom_themes_service->get_theme( $new_theme->stylesheet );
-
-	$event_props = array(
-		'blog_id'                  => get_wpcom_blog_id(),
-		'new_theme'                => $new->name,
-		'new_theme_stylesheet'     => $new->slug,
-		'new_theme_tier'           => $new->theme_tier,
-		'new_theme_is_block_theme' => $new->block_theme,
-		'old_theme'                => $old->name,
-		'old_theme_stylesheet'     => $old->slug,
-		'old_theme_tier'           => $old->theme_tier,
-		'old_theme_is_block_theme' => $old->block_theme,
+	$event_props = array_merge(
+		array( 'blog_id' => get_wpcom_blog_id() ),
+		$old_theme_props,
+		$new_theme_props
 	);
 
 	Common\wpcom_record_tracks_event( 'wpcom_theme_switch', $event_props );

--- a/projects/plugins/wpcomsh/changelog/dotthem-107-themes-add-all-the-tracks-events-to-wp-admin
+++ b/projects/plugins/wpcomsh/changelog/dotthem-107-themes-add-all-the-tracks-events-to-wp-admin
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add Tracks events to theme screens

--- a/projects/plugins/wpcomsh/wpcom-themes/includes/class-wpcom-themes-mapper.php
+++ b/projects/plugins/wpcomsh/wpcom-themes/includes/class-wpcom-themes-mapper.php
@@ -72,6 +72,7 @@ class WPCom_Themes_Mapper {
 		$theme->is_wpcom_theme       = true;
 		$theme->tags                 = $this->build_theme_tags( $wpcom_theme );
 		$theme->theme_tier           = $wpcom_theme->theme_tier->slug ?? null;
+		$theme->is_retired           = $wpcom_theme->retired ?? false;
 
 		return $theme;
 	}

--- a/projects/plugins/wpcomsh/wpcom-themes/includes/class-wpcom-themes-mapper.php
+++ b/projects/plugins/wpcomsh/wpcom-themes/includes/class-wpcom-themes-mapper.php
@@ -71,6 +71,7 @@ class WPCom_Themes_Mapper {
 		$theme->creation_time        = $wpcom_theme->date_added;
 		$theme->is_wpcom_theme       = true;
 		$theme->tags                 = $this->build_theme_tags( $wpcom_theme );
+		$theme->theme_tier           = $wpcom_theme->theme_tier->slug ?? null;
 
 		return $theme;
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Part of DOTTHEM-107

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add a new `wpcom_theme_switch` Tracks event to theme screens on Dotcom (both Simple and Atomic).

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

We are adding event tracking to several themes screens actions, such as switch, upload, search, etc. These events are only recorded on Dotcom sites (Simple and Atomic).

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* These changes should work for both Simple and Atomic but events are ignored when sandboxed so... sync the changes to an Atomic environment.
* Navigate to Themes screen
  * `/wp-admin/themes.php`
  * `/wp-admin/theme-install.php` (only on Atomic)
  * `/themes/SITE`
* Switch theme.
* Wait 5-10 minutes for the event to show up in the Tracks Live View.
* Open Tracks Live View, filtered by event name and your username (`/tracks/live/?eventname=wpcom_theme_switch&user=USERNAME`.
* You should see your `wpcom_theme_switch` events showing up. Open one of them and check its `eventprops`.

<img width="300" alt="Screenshot 2025-10-22 at 17 17 33" src="https://github.com/user-attachments/assets/d8ff38e6-92a0-4ecf-8562-ed7b17232604" />