### PR TITLE
Instant Search: Fix Safari Privacy Settings from breaking Search

### DIFF
--- a/projects/packages/search/changelog/fix-jps-safari-privacy
+++ b/projects/packages/search/changelog/fix-jps-safari-privacy
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Instant Search: Fix issue where Safari's 'Use advanced tracking and fingerprinting protection' setting breaks Search.

--- a/projects/packages/search/src/instant-search/components/search-box.jsx
+++ b/projects/packages/search/src/instant-search/components/search-box.jsx
@@ -1,6 +1,6 @@
 import { __ } from '@wordpress/i18n';
 import * as React from 'react';
-import { Fragment, useState, useEffect, useRef } from 'react';
+import { Fragment, useState, useEffect, useRef, forwardRef } from 'react';
 import { OVERLAY_SEARCH_BOX_INPUT_CLASS_NAME } from '../lib/constants';
 import Gridicon from './gridicon';
 import './search-box.scss';
@@ -14,17 +14,18 @@ const restoreFocus = () => initiallyFocusedElement && initiallyFocusedElement.fo
 
 let searchBoxCounter = 0;
 
-const SearchBox = props => {
+const SearchBox = forwardRef( ( props, ref ) => {
 	const [ inputId ] = useState( () => `jetpack-instant-search__box-input-${ ++searchBoxCounter }` );
-	const inputRef = useRef( null );
+	const localInputRef = useRef( null );
+	const inputRef = ref || localInputRef;
 
 	useEffect( () => {
-		if ( props.isVisible ) {
+		if ( props.isVisible && inputRef.current ) {
 			stealFocusWithInput( inputRef.current )();
 		} else if ( props.shouldRestoreFocus ) {
 			restoreFocus();
 		}
-	}, [ props.isVisible, props.shouldRestoreFocus ] );
+	}, [ props.isVisible, props.shouldRestoreFocus, inputRef ] );
 
 	return (
 		<Fragment>
@@ -64,6 +65,6 @@ const SearchBox = props => {
 			</div>
 		</Fragment>
 	);
-};
+} );
 
 export default SearchBox;

--- a/projects/packages/search/src/instant-search/components/search-form.jsx
+++ b/projects/packages/search/src/instant-search/components/search-form.jsx
@@ -1,18 +1,40 @@
 import * as React from 'react';
-import { Component } from 'react';
+import { Component, createRef } from 'react';
 import SearchBox from './search-box';
 
 const noop = event => event.preventDefault();
 
 class SearchForm extends Component {
+	constructor( props ) {
+		super( props );
+		this.searchInputRef = createRef();
+	}
+
 	onClear = () => this.props.onChangeSearch( '' );
-	onChangeSearch = event => this.props.onChangeSearch( event.currentTarget.value );
+	onChangeSearch = event => {
+		// Safari's "Use advanced tracking and fingerprinting protection" privacy setting
+		// can block access to event.currentTarget.value, returning empty/undefined.
+		// In such cases, fall back to reading the value directly from the input element via ref.
+		let value;
+		try {
+			value = event.currentTarget.value;
+			// Check if the value is actually accessible (Safari may return empty string when blocked)
+			if ( value === undefined || value === null ) {
+				throw new Error( 'Event value blocked by browser privacy settings' );
+			}
+		} catch {
+			// Fallback to ref when event.currentTarget.value is blocked
+			value = this.searchInputRef.current?.value ?? '';
+		}
+		this.props.onChangeSearch( value );
+	};
 
 	render() {
 		return (
 			<form autoComplete="off" onSubmit={ noop } role="search" className={ this.props.className }>
 				<div className="jetpack-instant-search__search-form">
 					<SearchBox
+						ref={ this.searchInputRef }
 						isVisible={ this.props.isVisible }
 						onChange={ this.onChangeSearch }
 						onClear={ this.onClear }

--- a/projects/plugins/jetpack/changelog/fix-jps-safari-privacy
+++ b/projects/plugins/jetpack/changelog/fix-jps-safari-privacy
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Instant Search: Fix issue where Safari's 'Use advanced tracking and fingerprinting protection' setting breaks Search.

--- a/projects/plugins/search/changelog/fix-jps-safari-privacy
+++ b/projects/plugins/search/changelog/fix-jps-safari-privacy
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Instant Search: Fix issue where Safari's 'Use advanced tracking and fingerprinting protection' setting breaks Search.


### PR DESCRIPTION
Fixes # [SEARCH-104](https://linear.app/a8c/issue/SEARCH-104/jetpack-search-broken-for-safari-on-wpcom-jetpack-tumblr-and-pocket#comment-1ad2539a)

Safari's enhanced privacy protection blocks access to `event.currentTarget.value` in certain contexts, returning `undefined` or empty strings. This causes the search functionality to break:

1. User types a search query
2. The `onChange` handler attempts to read `event.currentTarget.value`
3. Safari blocks the read operation, returning empty/undefined
4. An API request is made with an empty query (`query=`)
5. Default results are displayed instead of the actual search results

## Proposed changes:

Implemented a fallback mechanism that preserves normal behavior while gracefully handling Safari's privacy restrictions:

- **`search-box.jsx`**: Wrapped component with `forwardRef` to expose the input element ref to parent components
- **`search-form.jsx`**: Modified `onChangeSearch` handler to implement a two-tier approach:
  1. **Primary**: Attempt to read `event.currentTarget.value` (normal behavior for all browsers)
  2. **Fallback**: If blocked (undefined/null), read directly from the input element via ref (`this.searchInputRef.current?.value`)

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

No

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

- Checkout this branch on your WPcom sandbox with `bin/jetpack-downloader test jetpack fix/jps-safari-privacy`
- Sandbox wpcom
- Open wordpress.com/support in Safari
- Enable the **Settings** --> **Advanced** --> "Use advanced tracking and fingerpriting protection" setting for all browsing sessions
- Follow these steps on sandboxing with Safari PCYsg-e-p2
- Ensure that search works as expected, and continues to work in other browsers