### PR TITLE
Forms: add 'create new form' CTA to inbox empty state

### DIFF
--- a/projects/packages/forms/changelog/update-forms-empty-state-cta
+++ b/projects/packages/forms/changelog/update-forms-empty-state-cta
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Forms: add 'create new form' CTA to inbox empty state

--- a/projects/packages/forms/src/dashboard/inbox/empty-responses.tsx
+++ b/projects/packages/forms/src/dashboard/inbox/empty-responses.tsx
@@ -4,8 +4,9 @@ import {
 } from '@wordpress/components';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import useConfigValue from '../../hooks/use-config-value';
+import CreateFormButton from '../components/create-form-button';
 
-const EmptyWrapper = ( { heading = '', body = '' } ) => (
+const EmptyWrapper = ( { heading = '', body = '', actions = null } ) => (
 	<VStack alignment="center" spacing="2">
 		{ heading && (
 			<Text as="h3" weight="500" size="15">
@@ -13,6 +14,7 @@ const EmptyWrapper = ( { heading = '', body = '' } ) => (
 			</Text>
 		) }
 		{ body && <Text variant="muted">{ body }</Text> }
+		{ actions && <span style={ { marginBlockStart: '16px' } }>{ actions }</span> }
 	</VStack>
 );
 
@@ -66,6 +68,7 @@ const EmptyResponses = ( { status, isSearch, readStatusFilter }: EmptyResponsesP
 				'Share your form to start collecting responses. New items will appear here.',
 				'jetpack-forms'
 			) }
+			actions={ <CreateFormButton label={ __( 'Create a new form', 'jetpack-forms' ) } /> }
 		/>
 	);
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->


Add CTA "create new form" to Inbox empty state.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

Before

<img width="794" height="331" alt="Screenshot 2025-10-22 at 18 36 34" src="https://github.com/user-attachments/assets/cbe0bb17-b57c-4ab9-b751-f5745d783bfa" />


After

<img width="843" height="301" alt="Screenshot 2025-10-22 at 18 36 12" src="https://github.com/user-attachments/assets/778dae0b-b658-49ca-b587-c95431e0caae" />


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Have empty forms inbox
* See empty state
* Try CTA; opens new tab with forms block on page

