### PR TITLE
Forms: Add country code to responses

### DIFF
--- a/projects/packages/forms/changelog/add-country-location-to-responses
+++ b/projects/packages/forms/changelog/add-country-location-to-responses
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Forms: start storing the country code with the form responses based on the IP address.

--- a/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
@@ -539,6 +539,16 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 			'readonly'    => true,
 		);
 
+		$schema['properties']['country_code'] = array(
+			'description' => __( 'The country code derived from the IP address.', 'jetpack-forms' ),
+			'type'        => 'string',
+			'context'     => array( 'view', 'edit', 'embed' ),
+			'arg_options' => array(
+				'sanitize_callback' => 'sanitize_text_field',
+			),
+			'readonly'    => true,
+		);
+
 		$schema['properties']['entry_title'] = array(
 			'description' => __( 'The title of the page or post where the form was submitted.', 'jetpack-forms' ),
 			'type'        => 'string',
@@ -785,6 +795,9 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 		}
 		if ( rest_is_field_included( 'ip', $fields ) ) {
 			$data['ip'] = $feedback_response->get_ip_address();
+		}
+		if ( rest_is_field_included( 'country_code', $fields ) ) {
+			$data['country_code'] = $feedback_response->get_country_code();
 		}
 		if ( rest_is_field_included( 'entry_title', $fields ) ) {
 			$data['entry_title'] = $feedback_response->get_entry_title();

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -2428,7 +2428,7 @@ class Contact_Form_Plugin {
 			);
 
 			$post_export_data[] = array(
-				'name'  => __( 'Country Code', 'jetpack-forms' ),
+				'name'  => __( 'Country code', 'jetpack-forms' ),
 				'value' => $feedback->get_country_code(),
 			);
 
@@ -2677,7 +2677,7 @@ class Contact_Form_Plugin {
 
 			$results[ __( 'Consent', 'jetpack-forms' ) ][]      = $feedback->has_consent() ? __( 'Yes', 'jetpack-forms' ) : __( 'No', 'jetpack-forms' );
 			$results[ __( 'IP Address', 'jetpack-forms' ) ][]   = $feedback->get_ip_address();
-			$results[ __( 'Country Code', 'jetpack-forms' ) ][] = $feedback->get_country_code();
+			$results[ __( 'Country code', 'jetpack-forms' ) ][] = $feedback->get_country_code();
 
 		}
 		return $results;
@@ -2717,7 +2717,7 @@ class Contact_Form_Plugin {
 			'-3_response_date' => __( 'Response Date', 'jetpack-forms' ),
 			'90_consent'       => _x( 'Consent', 'noun', 'jetpack-forms' ),
 			'93_ip_address'    => __( 'IP Address', 'jetpack-forms' ),
-			'94_country_code'  => __( 'Country Code', 'jetpack-forms' ),
+			'94_country_code'  => __( 'Country code', 'jetpack-forms' ),
 		);
 	}
 

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -2427,6 +2427,11 @@ class Contact_Form_Plugin {
 				'value' => $feedback->get_ip_address(),
 			);
 
+			$post_export_data[] = array(
+				'name'  => __( 'Country Code', 'jetpack-forms' ),
+				'value' => $feedback->get_country_code(),
+			);
+
 			$export_data[] = array(
 				'group_id'    => 'feedback',
 				'group_label' => __( 'Feedback', 'jetpack-forms' ),
@@ -2670,8 +2675,9 @@ class Contact_Form_Plugin {
 				$results[ $single_field_name ][] = $feedback->get_field_value_by_label( $single_field_name, 'csv' );
 			}
 
-			$results[ __( 'Consent', 'jetpack-forms' ) ][]    = $feedback->has_consent() ? __( 'Yes', 'jetpack-forms' ) : __( 'No', 'jetpack-forms' );
-			$results[ __( 'IP Address', 'jetpack-forms' ) ][] = $feedback->get_ip_address();
+			$results[ __( 'Consent', 'jetpack-forms' ) ][]      = $feedback->has_consent() ? __( 'Yes', 'jetpack-forms' ) : __( 'No', 'jetpack-forms' );
+			$results[ __( 'IP Address', 'jetpack-forms' ) ][]   = $feedback->get_ip_address();
+			$results[ __( 'Country Code', 'jetpack-forms' ) ][] = $feedback->get_country_code();
 
 		}
 		return $results;
@@ -2711,6 +2717,7 @@ class Contact_Form_Plugin {
 			'-3_response_date' => __( 'Response Date', 'jetpack-forms' ),
 			'90_consent'       => _x( 'Consent', 'noun', 'jetpack-forms' ),
 			'93_ip_address'    => __( 'IP Address', 'jetpack-forms' ),
+			'94_country_code'  => __( 'Country Code', 'jetpack-forms' ),
 		);
 	}
 

--- a/projects/packages/forms/src/contact-form/class-feedback.php
+++ b/projects/packages/forms/src/contact-form/class-feedback.php
@@ -7,7 +7,7 @@
 
 namespace Automattic\Jetpack\Forms\ContactForm;
 
-use Automattic\Jetpack\Constants;
+use Automattic\Jetpack\Connection\Client;
 use WP_Post;
 /**
  * Handles the response for a contact form submission.
@@ -861,18 +861,12 @@ class Feedback {
 	private static function geolocate_via_api( $ip_address ) {
 		$country_code = \get_transient( 'geoip_' . $ip_address );
 		if ( false === $country_code ) {
-
-			$version = Constants::get_constant( 'JETPACK__VERSION' );
-			if ( empty( $version ) ) {
-				$version = '0.1';
-			}
-
-			$response = \wp_safe_remote_get(
-				sprintf( 'https://public-api.wordpress.com/geo/?ip=%s', $ip_address ),
-				array(
-					'timeout'    => 2,
-					'user-agent' => 'jetpack/' . $version,
-				)
+			$response = Client::wpcom_json_api_request_as_blog(
+				'/ip-to-geo/' . $ip_address,
+				'2',
+				array( 'method' => 'GET' ),
+				null,
+				'wpcom'
 			);
 
 			if ( ! is_wp_error( $response ) && ! empty( $response['body'] ) ) {

--- a/projects/packages/forms/src/contact-form/class-feedback.php
+++ b/projects/packages/forms/src/contact-form/class-feedback.php
@@ -849,7 +849,7 @@ class Feedback {
 			return strtoupper( $country );
 		}
 
-		return empty( $country ) ? null : strtoupper( $country );
+		return null;
 	}
 
 	/**
@@ -871,7 +871,7 @@ class Feedback {
 
 			if ( ! is_wp_error( $response ) && ! empty( $response['body'] ) ) {
 				$data         = json_decode( $response['body'] );
-				$country_code = isset( $data->country_short ) ? $data->country_short : '';
+				$country_code = $data->country_short ?? '';
 				$country_code = \sanitize_text_field( $country_code );
 				// Share the transient with woocommerce to avoid multiple lookups.
 				\set_transient( 'geoip_' . $ip_address, $country_code, DAY_IN_SECONDS );

--- a/projects/packages/forms/src/contact-form/class-feedback.php
+++ b/projects/packages/forms/src/contact-form/class-feedback.php
@@ -852,13 +852,7 @@ class Feedback {
 	}
 
 	/**
-	 * Use APIs to Geolocate the user.
-	 *
-	 * Geolocation APIs can be added through the use of the woocommerce_geolocation_geoip_apis filter.
-	 * Provide a name=>value pair for service-slug=>endpoint.
-	 *
-	 * If APIs are defined, one will be chosen at random to fulfil the request. After completing, the result
-	 * will be cached in a transient.
+	 * Use APIs to Geolocate the IP address.
 	 *
 	 * @param  string $ip_address IP address.
 	 * @return string

--- a/projects/packages/forms/src/contact-form/class-feedback.php
+++ b/projects/packages/forms/src/contact-form/class-feedback.php
@@ -797,11 +797,12 @@ class Feedback {
 		if ( ! $ip_address ) {
 			return null;
 		}
-		// this filter allows site owners to disable IP address storage
-		// this filter is documented in src/contact-form/class-contact-form-plugin.php
+		// This filter allows site owners to disable IP address storage entirely as well as GeoIP lookups.
+		// This filter is documented in src/contact-form/class-contact-form-plugin.php
 		if ( apply_filters( 'jetpack_contact_form_forget_ip_address', false ) ) {
 			return null;
 		}
+
 		/**
 		 * Filter to get country code from IP address.
 		 *
@@ -812,7 +813,7 @@ class Feedback {
 		 * @param string      $context The context for the geolocation request.
 		 */
 		$country = apply_filters( 'jetpack_get_country_from_ip', null, $ip_address, 'form-response' );
-		if ( ! empty( $country ) ) {
+		if ( is_string( $country ) ) {
 			return strtoupper( $country );
 		}
 
@@ -848,7 +849,7 @@ class Feedback {
 			return strtoupper( $country );
 		}
 
-		return strtoupper( $country );
+		return empty( $country ) ? null : strtoupper( $country );
 	}
 
 	/**
@@ -877,7 +878,7 @@ class Feedback {
 			if ( ! is_wp_error( $response ) && ! empty( $response['body'] ) ) {
 				$data         = json_decode( $response['body'] );
 				$country_code = isset( $data->country_short ) ? $data->country_short : '';
-				$country_code = \sanitize_text_field( strtoupper( $country_code ) );
+				$country_code = \sanitize_text_field( $country_code );
 				// Share the transient with woocommerce to avoid multiple lookups.
 				\set_transient( 'geoip_' . $ip_address, $country_code, DAY_IN_SECONDS );
 			}

--- a/projects/packages/forms/src/contact-form/class-feedback.php
+++ b/projects/packages/forms/src/contact-form/class-feedback.php
@@ -7,6 +7,7 @@
 
 namespace Automattic\Jetpack\Forms\ContactForm;
 
+use Automattic\Jetpack\Constants;
 use WP_Post;
 /**
  * Handles the response for a contact form submission.
@@ -78,6 +79,15 @@ class Feedback {
 	 * @var string|null
 	 */
 	protected $user_agent = null;
+
+	/**
+	 * The country code derived from the IP address.
+	 *
+	 * This is derived from the IP address and stored for easier display.
+	 *
+	 * @var string|null
+	 */
+	protected $country_code = null;
 
 	/**
 	 * The subject of the feedback entry.
@@ -223,9 +233,10 @@ class Feedback {
 			$parsed_content['request_url'] ?? ''
 		);
 
-		$this->ip_address = $parsed_content['ip'] ?? $this->get_first_field_of_type( 'ip' );
-		$this->user_agent = $parsed_content['user_agent'] ?? null;
-		$this->subject    = $parsed_content['subject'] ?? $this->get_first_field_of_type( 'subject' );
+		$this->ip_address   = $parsed_content['ip'] ?? $this->get_first_field_of_type( 'ip' );
+		$this->country_code = $parsed_content['country_code'] ?? null;
+		$this->user_agent   = $parsed_content['user_agent'] ?? null;
+		$this->subject      = $parsed_content['subject'] ?? $this->get_first_field_of_type( 'subject' );
 
 		$this->notification_recipients = $parsed_content['notification_recipients'] ?? array();
 
@@ -280,6 +291,7 @@ class Feedback {
 		// If post_data is provided, use it to populate fields.
 		$this->fields          = $this->get_computed_fields( $post_data, $form );
 		$this->ip_address      = Contact_Form_Plugin::get_ip_address();
+		$this->country_code    = $this->get_country_code_from_ip( $this->ip_address );
 		$this->user_agent      = isset( $_SERVER['HTTP_USER_AGENT'] ) ? filter_var( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ) ) : null;
 		$this->subject         = $this->get_computed_subject( $post_data, $form );
 		$this->author_data     = Feedback_Author::from_submission( $post_data, $form );
@@ -764,6 +776,122 @@ class Feedback {
 	}
 
 	/**
+	 * Get the country code derived from the IP address.
+	 *
+	 * @return string|null
+	 */
+	public function get_country_code() {
+		return $this->country_code;
+	}
+
+	/**
+	 * Get country code from IP address.
+	 *
+	 * This method uses a filter to allow custom implementations of GeoIP lookup.
+	 * The filter should return a country code (e.g., 'US', 'GB', 'DE') or null.
+	 *
+	 * @param string|null $ip_address The IP address.
+	 * @return string|null The country code or null if unavailable.
+	 */
+	private function get_country_code_from_ip( $ip_address ) {
+		if ( ! $ip_address ) {
+			return null;
+		}
+		// this filter allows site owners to disable IP address storage
+		// this filter is documented in src/contact-form/class-contact-form-plugin.php
+		if ( apply_filters( 'jetpack_contact_form_forget_ip_address', false ) ) {
+			return null;
+		}
+		/**
+		 * Filter to get country code from IP address.
+		 *
+		 * @since $$NEXT_VERSION$$
+		 *
+		 * @param string|null $country The country code (e.g., 'US', 'GB', 'DE') or null.
+		 * @param string      $ip_address The IP address to look up.
+		 * @param string      $context The context for the geolocation request.
+		 */
+		$country = apply_filters( 'jetpack_get_country_from_ip', null, $ip_address, 'form-response' );
+		if ( ! empty( $country ) ) {
+			return strtoupper( $country );
+		}
+
+		$headers = array(
+			'MM_COUNTRY_CODE',
+			'GEOIP_COUNTRY_CODE',
+			'HTTP_CF_IPCOUNTRY',
+			'HTTP_X_COUNTRY_CODE',
+			'HTTP_X_APPENGINE_COUNTRY',
+			'HTTP_X_FORWARDED_FOR_COUNTRY',
+			'HTTP_CLOUDFRONT_VIEWER_COUNTRY',
+		);
+
+		// Check for headers from the server.
+		foreach ( $headers as $header ) {
+			if ( isset( $_SERVER[ $header ] ) ) {
+				$country = sanitize_text_field( wp_unslash( $_SERVER[ $header ] ) );
+				if ( ! empty( $country ) ) {
+					return strtoupper( $country );
+				}
+			}
+		}
+
+		if ( function_exists( 'geoip_country_code_by_name' ) ) {
+			$country = geoip_country_code_by_name( $ip_address );
+			if ( ! empty( $country ) ) {
+				return strtoupper( $country );
+			}
+		}
+
+		$country = self::geolocate_via_api( $ip_address );
+		if ( ! empty( $country ) ) {
+			return strtoupper( $country );
+		}
+
+		return strtoupper( $country );
+	}
+
+	/**
+	 * Use APIs to Geolocate the user.
+	 *
+	 * Geolocation APIs can be added through the use of the woocommerce_geolocation_geoip_apis filter.
+	 * Provide a name=>value pair for service-slug=>endpoint.
+	 *
+	 * If APIs are defined, one will be chosen at random to fulfil the request. After completing, the result
+	 * will be cached in a transient.
+	 *
+	 * @param  string $ip_address IP address.
+	 * @return string
+	 */
+	private static function geolocate_via_api( $ip_address ) {
+		$country_code = \get_transient( 'geoip_' . $ip_address );
+		if ( false === $country_code ) {
+
+			$version = Constants::get_constant( 'JETPACK__VERSION' );
+			if ( empty( $version ) ) {
+				$version = '0.1';
+			}
+
+			$response = \wp_safe_remote_get(
+				sprintf( 'https://public-api.wordpress.com/geo/?ip=%s', $ip_address ),
+				array(
+					'timeout'    => 2,
+					'user-agent' => 'jetpack/' . $version,
+				)
+			);
+
+			if ( ! is_wp_error( $response ) && ! empty( $response['body'] ) ) {
+				$data         = json_decode( $response['body'] );
+				$country_code = isset( $data->country_short ) ? $data->country_short : '';
+				$country_code = \sanitize_text_field( strtoupper( $country_code ) );
+				// Share the transient with woocommerce to avoid multiple lookups.
+				\set_transient( 'geoip_' . $ip_address, $country_code, DAY_IN_SECONDS );
+			}
+		}
+		return $country_code;
+	}
+
+	/**
 	 * Get the email subject.
 	 *
 	 * @return string
@@ -1015,6 +1143,7 @@ class Feedback {
 			array(
 				'subject'                 => $this->subject,
 				'ip'                      => $this->ip_address,
+				'country_code'            => $this->country_code,
 				'user_agent'              => $this->user_agent,
 				'notification_recipients' => $this->notification_recipients,
 			),
@@ -1026,9 +1155,10 @@ class Feedback {
 			$fields_to_serialize['fields'][] = $field->serialize();
 		}
 
-		// Check if the IP should be included.
+		// Check if the IP and country_code should be included.
 		if ( apply_filters( 'jetpack_contact_form_forget_ip_address', false, $this->ip_address ) ) {
-			$fields_to_serialize['ip'] = null;
+			$fields_to_serialize['ip']           = null;
+			$fields_to_serialize['country_code'] = null;
 		}
 
 		return addslashes( wp_json_encode( $fields_to_serialize ) );

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
@@ -659,19 +659,21 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 		$default_consent = 'No';
 		$ip              = 'https://127.0.0.1';
 
+		$country_code = null; // No country code for legacy feedback
+
 		$this->assertEquals(
 			array(
 
-				'ID'         => array( $post_id_1, $post_id_2 ),
-				'Date'       => array( $post_1->post_date, $post_2->post_date ),
-				'Title'      => array( $current_post->post_title, $current_post->post_title ),
-				'field_A'    => array( 'value1', 'value1' ),
-				'field_B'    => array( 'value2', '' ),
-				'field_C'    => array( '', 'value2' ),
-				'Source'     => array( '/?p=' . $current_post->ID, '/?p=' . $current_post->ID ),
-				'Consent'    => array( $default_consent, $default_consent ),
-				'IP Address' => array( $ip, $ip ),
-
+				'ID'           => array( $post_id_1, $post_id_2 ),
+				'Date'         => array( $post_1->post_date, $post_2->post_date ),
+				'Title'        => array( $current_post->post_title, $current_post->post_title ),
+				'field_A'      => array( 'value1', 'value1' ),
+				'field_B'      => array( 'value2', '' ),
+				'field_C'      => array( '', 'value2' ),
+				'Source'       => array( '/?p=' . $current_post->ID, '/?p=' . $current_post->ID ),
+				'Consent'      => array( $default_consent, $default_consent ),
+				'IP Address'   => array( $ip, $ip ),
+				'Country Code' => array( $country_code, $country_code ),
 			),
 			$plugin->get_export_feedback_data( $post_ids )
 		);
@@ -834,6 +836,10 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 					'name'  => 'IP Address',
 					'value' => 'https://127.0.0.1',
 				), // same as the default value in the create_legacy_feedback
+				array(
+					'name'  => 'Country Code',
+					'value' => null,
+				), // no country code for legacy feedback
 			),
 		);
 

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
@@ -673,7 +673,7 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 				'Source'       => array( '/?p=' . $current_post->ID, '/?p=' . $current_post->ID ),
 				'Consent'      => array( $default_consent, $default_consent ),
 				'IP Address'   => array( $ip, $ip ),
-				'Country Code' => array( $country_code, $country_code ),
+				'Country code' => array( $country_code, $country_code ),
 			),
 			$plugin->get_export_feedback_data( $post_ids )
 		);
@@ -837,7 +837,7 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 					'value' => 'https://127.0.0.1',
 				), // same as the default value in the create_legacy_feedback
 				array(
-					'name'  => 'Country Code',
+					'name'  => 'Country code',
 					'value' => null,
 				), // no country code for legacy feedback
 			),

--- a/projects/packages/forms/tests/php/contact-form/Feedback_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Feedback_Test.php
@@ -309,6 +309,58 @@ class Feedback_Test extends BaseTestCase {
 	}
 
 	/**
+	 * Test that country code is included in serialized response and persists after save/load.
+	 */
+	public function test_country_code_included_in_serialized_response() {
+
+		$form_id = Utility::get_form_id();
+		// Create a form submission
+		$_post_data = Utility::get_post_request(
+			array(
+				'name'    => 'Jane Doe',
+				'email'   => 'jane@example.com',
+				'message' => 'Test message from Canada',
+			),
+			'g' . $form_id
+		);
+
+		$form = new Contact_Form(
+			array(
+				'title'       => 'Test Form',
+				'description' => 'This is a test form.',
+			),
+			"[contact-field label='Name' type='name' required='1'/][contact-field label='Email' type='email' required='1'/][contact-field label='Message' type='textarea' required='1'/]"
+		);
+
+		// Set up filter to return a test country code
+		$test_country_code = 'CA';
+		$filter_callback   = function () use ( $test_country_code ) {
+			return $test_country_code;
+		};
+		add_filter( 'jetpack_get_country_from_ip', $filter_callback, 10 );
+
+		// Create a contact form response
+		$response         = Feedback::from_submission( $_post_data, $form );
+		$feedback_post_id = $response->save();
+		$saved_response   = Feedback::get( $feedback_post_id );
+
+		// The country code should be present and match the test value.
+		$this->assertNotEmpty( $response->get_country_code(), 'Country code should not be empty' );
+		$this->assertNotEmpty( $saved_response->get_country_code(), 'Country code should not be empty after save/load' );
+		$this->assertEquals( $response->get_country_code(), $saved_response->get_country_code(), 'Country code should match after save/load' );
+		$this->assertEquals( $test_country_code, $saved_response->get_country_code(), 'Country code should match the filter value' );
+
+		add_filter( 'jetpack_contact_form_forget_ip_address', '__return_true' );
+		$new_post_id = $response->save();
+		remove_filter( 'jetpack_contact_form_forget_ip_address', '__return_true' );
+
+		$saved_response = Feedback::get( $new_post_id );
+		$this->assertEmpty( $saved_response->get_country_code(), 'Country code should be empty when IP is forgotten' );
+		// Clean up
+		remove_filter( 'jetpack_get_country_from_ip', $filter_callback, 10 );
+	}
+
+	/**
 	 * Test the subject line is computed for legacy correctly.
 	 */
 	public function test_computed_subject_legacy() {

--- a/projects/plugins/jetpack/changelog/add-country-location-to-responses
+++ b/projects/plugins/jetpack/changelog/add-country-location-to-responses
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Forms: Start storing the country_code based on the IP with the form responses.


### PR DESCRIPTION
This PR starts storing the country code in form responses based on the IP address. 

This is done so we give more context to the IP address that is associated with the form responses already. 

Relies on 194495-ghe-Automattic/wpcom


## Proposed changes:
* Updates the feedback endpoint to show the new country_code. 
* Adds a new get_country_code_from_ip method. 
   That tried hard not to have to call the new endpoint on .com. 
* Makes sure that we also export the country code. 
* We don't backfill form responses that currently exist. This is something that we might do in the future iterations. 

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion


## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
Rsync the change to .com simple site. 
Notice that once you fill the form that the endpoint returns the country_code in the api. 
you need to sandbox public-api.wordpress.com

For Jetpack sites apply.
Apply the PR in 194495-ghe-Automattic/wpcom to your sandbox and get your test site to talk to .com. (unless this is done already)
Submit the form. 
Notice that the reponse endpoint contains the country_code. 

