### PR TITLE
Forms: fix textarea submission on enter

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-textarea-double-enter
+++ b/projects/packages/forms/changelog/fix-forms-textarea-double-enter
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: fix textarea submission on enter.

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -1204,7 +1204,6 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 						data-wp-on--blur='actions.onFieldBlur'
 						data-wp-class--has-value='state.hasFieldValue'
 						data-wp-bind--aria-invalid='state.fieldHasErrors'
-						data-wp-on--keydown='actions.onKeyDownTextarea'
 						aria-errormessage='" . esc_attr( $id ) . "-textarea-error-message'
 						"
 						. $class

--- a/projects/packages/forms/src/modules/form/view.js
+++ b/projects/packages/forms/src/modules/form/view.js
@@ -12,7 +12,7 @@ import {
  * Internal dependencies
  */
 import { validateField, isEmptyValue } from '../../contact-form/js/validate-helper';
-import { focusNextInput, dispatchSubmitEvent, submitForm } from './shared';
+import { focusNextInput, submitForm } from './shared';
 
 const withSyncEvent =
 	originalWithSyncEvent ||
@@ -496,19 +496,6 @@ const { state, actions } = store( NAMESPACE, {
 
 				context.isSubmitting = false;
 			}
-		} ),
-
-		onKeyDownTextarea: withSyncEvent( event => {
-			if ( ! ( event.key === 'Enter' && event.shiftKey ) ) {
-				return;
-			}
-			// Prevent the default behavior of adding a new line.
-			event.preventDefault();
-			event.stopPropagation();
-
-			const context = getContext();
-
-			dispatchSubmitEvent( context.formHash );
 		} ),
 
 		scrollIntoView: withSyncEvent( event => {

--- a/projects/plugins/jetpack/changelog/fix-forms-textarea-double-enter
+++ b/projects/plugins/jetpack/changelog/fix-forms-textarea-double-enter
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Forms: fix textarea submission on enter.


### PR DESCRIPTION
Fixes [FORMS-312](https://linear.app/a8c/issue/FORMS-312/prevent-unintended-form-submission-on-mobile-when-pressing-enter-twice)

## Proposed changes:

Customer reported that hitting enter twice when in a textarea field is causing a form submission. It should allow users to enter a newline. This PR removes a keydown handler we attached to textarea fields that was causing the submission. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
See linear issue and slack here: p1759928357932629-slack-C052XEUUBL4

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

You may want to confirm the bug by creating a form with a text area, opening it on mobile, selecting the text area, and hitting enter twice. You should see the form submit. 

Then load this PR, reload the form on mobile, and confirm double enter just adds a new line. 