### PR TITLE
Help Center: Pass `is_test_mode` flag along

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/help-center-pass-testing-flag
+++ b/projects/packages/jetpack-mu-wpcom/changelog/help-center-pass-testing-flag
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Help Center: pass the is_test_mode along to WPCOM

--- a/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-wp-rest-help-center-support-interactions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-wp-rest-help-center-support-interactions.php
@@ -187,6 +187,10 @@ class WP_REST_Help_Center_Support_Interactions extends \WP_REST_Controller {
 			$data['event_metadata'] = $request['event_metadata'];
 		}
 
+		if ( isset( $request['is_test_mode'] ) ) {
+			$data['is_test_mode'] = $request['is_test_mode'];
+		}
+
 		$body = Client::wpcom_json_api_request_as_user(
 			'/support-interactions',
 			'2',
@@ -225,6 +229,10 @@ class WP_REST_Help_Center_Support_Interactions extends \WP_REST_Controller {
 
 		if ( isset( $request['event_metadata'] ) ) {
 			$data['event_metadata'] = $request['event_metadata'];
+		}
+
+		if ( isset( $request['is_test_mode'] ) ) {
+			$data['is_test_mode'] = $request['is_test_mode'];
 		}
 
 		$body = Client::wpcom_json_api_request_as_user(


### PR DESCRIPTION
Fixes DOTCOM-15020

## Proposed changes:
This passes along the staging flag for Help Center requests. 


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
1. Apply on an Atomic site. 
2. Open the Help Center on that atomic site while proxied.
3. Open DevTools > Network and filter by `support-interactions`.
4. Start a new Odie conversation.
5. The newly created interaction should have `environment: staging`. 

