### PR TITLE
MU WPCOM: Fix new wpcom_theme_switch event not working on Simple

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/dotthem-107-simple-support
+++ b/projects/packages/jetpack-mu-wpcom/changelog/dotthem-107-simple-support
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed wpcom_theme_switch tracking not working on Simple sites.

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-themes/wpcom-theme-tracking.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-themes/wpcom-theme-tracking.php
@@ -17,30 +17,35 @@ use Automattic\Jetpack\Jetpack_Mu_Wpcom\Common;
  * @return array Associative array of theme properties.
  */
 function wpcom_themes_tracks_get_theme_props( $theme, $prefix = '' ) {
-	if ( ! function_exists( 'wpcomsh_get_wpcom_themes_service_instance' ) ) {
-		return array();
-	}
-
-	$wpcom_themes_service = wpcomsh_get_wpcom_themes_service_instance();
-	$theme_data           = $wpcom_themes_service->get_theme( $theme->stylesheet );
-
 	if ( $prefix !== '' ) {
 		$prefix .= '_';
 	}
 
-	$props = array();
-	if ( $theme_data === null ) {
-		$props[ $prefix . 'theme' ]                = $theme->get( 'Name' );
-		$props[ $prefix . 'theme_stylesheet' ]     = $theme->get_stylesheet();
-		$props[ $prefix . 'theme_tier' ]           = 'community';
-		$props[ $prefix . 'theme_is_block_theme' ] = $theme->is_block_theme();
-		$props[ $prefix . 'theme_is_retired' ]     = false;
-	} else {
-		$props[ $prefix . 'theme' ]                = $theme_data->name;
-		$props[ $prefix . 'theme_stylesheet' ]     = $theme_data->slug;
-		$props[ $prefix . 'theme_tier' ]           = $theme_data->theme_tier;
-		$props[ $prefix . 'theme_is_block_theme' ] = $theme_data->block_theme;
-		$props[ $prefix . 'theme_is_retired' ]     = $theme_data->is_retired;
+	$props = array(
+		$prefix . 'theme'                => $theme->get( 'Name' ),
+		$prefix . 'theme_stylesheet'     => $theme->get_stylesheet(),
+		$prefix . 'theme_tier'           => null,
+		$prefix . 'theme_is_block_theme' => $theme->is_block_theme(),
+		$prefix . 'theme_is_retired'     => false,
+	);
+
+	// Simple sites
+	if ( defined( 'IS_WPCOM' ) && IS_WPCOM && class_exists( 'WPCom_Themes' ) ) {
+		$props[ $prefix . 'theme_tier' ]       = WPCom_Themes::get_theme_tier( $theme->get_stylesheet() );
+		$props[ $prefix . 'theme_is_retired' ] = WPCom_Themes::is_retired( $theme->get_stylesheet() );
+	}
+
+	// Atomic sites
+	$props[ $prefix . 'theme_tier' ] = 'community';
+
+	if ( function_exists( 'wpcomsh_get_wpcom_themes_service_instance' ) ) {
+		$wpcom_themes_service = wpcomsh_get_wpcom_themes_service_instance();
+		$theme_data           = $wpcom_themes_service->get_theme( $theme->get_stylesheet() );
+
+		if ( $theme_data !== null ) {
+			$props[ $prefix . 'theme_tier' ]       = $theme_data->theme_tier;
+			$props[ $prefix . 'theme_is_retired' ] = $theme_data->is_retired;
+		}
 	}
 
 	return $props;
@@ -56,10 +61,6 @@ function wpcom_themes_tracks_get_theme_props( $theme, $prefix = '' ) {
  * @param WP_Theme $old_theme      Old theme object.
  */
 function wpcom_themes_tracks_switch_theme( $new_theme_name, $new_theme, $old_theme ) {
-	if ( ! function_exists( 'wpcomsh_get_wpcom_themes_service_instance' ) ) {
-		return;
-	}
-
 	$old_theme_props = wpcom_themes_tracks_get_theme_props( $old_theme, 'old' );
 	$new_theme_props = wpcom_themes_tracks_get_theme_props( $new_theme, 'new' );
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-themes/wpcom-theme-tracking.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-themes/wpcom-theme-tracking.php
@@ -31,7 +31,9 @@ function wpcom_themes_tracks_get_theme_props( $theme, $prefix = '' ) {
 
 	// Simple sites
 	if ( defined( 'IS_WPCOM' ) && IS_WPCOM && class_exists( 'WPCom_Themes' ) ) {
-		$props[ $prefix . 'theme_tier' ]       = WPCom_Themes::get_theme_tier( $theme->get_stylesheet() );
+		// @phan-suppress-next-line PhanUndeclaredClassMethod
+		$props[ $prefix . 'theme_tier' ] = WPCom_Themes::get_theme_tier( $theme->get_stylesheet() );
+		// @phan-suppress-next-line PhanUndeclaredClassMethod
 		$props[ $prefix . 'theme_is_retired' ] = WPCom_Themes::is_retired( $theme->get_stylesheet() );
 	}
 
@@ -43,8 +45,8 @@ function wpcom_themes_tracks_get_theme_props( $theme, $prefix = '' ) {
 		$theme_data           = $wpcom_themes_service->get_theme( $theme->get_stylesheet() );
 
 		if ( $theme_data !== null ) {
-			$props[ $prefix . 'theme_tier' ]       = $theme_data->theme_tier;
-			$props[ $prefix . 'theme_is_retired' ] = $theme_data->is_retired;
+			$props[ $prefix . 'theme_tier' ]       = $theme_data->theme_tier ?? null;
+			$props[ $prefix . 'theme_is_retired' ] = $theme_data->is_retired ?? false;
 		}
 	}
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-themes/wpcom-theme-tracking.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-themes/wpcom-theme-tracking.php
@@ -35,6 +35,8 @@ function wpcom_themes_tracks_get_theme_props( $theme, $prefix = '' ) {
 		$props[ $prefix . 'theme_tier' ] = WPCom_Themes::get_theme_tier( $theme->get_stylesheet() );
 		// @phan-suppress-next-line PhanUndeclaredClassMethod
 		$props[ $prefix . 'theme_is_retired' ] = WPCom_Themes::is_retired( $theme->get_stylesheet() );
+
+		return $props;
 	}
 
 	// Atomic sites


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Part of DOTTHEM-107
Follow up to https://github.com/Automattic/jetpack/pull/45587

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* The new `wpcom_theme_switch` tracking was relying on WPCOMSH, therefore not working on Simple. This ensure it runs on Simple as well, accessing theme data right away.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

**Check for regressions on Atomic following the same steps as the previous PR:**

* Sync these changes to an Atomic environment.
* Navigate to Themes screen.
  * `/wp-admin/themes.php`
  * `/wp-admin/theme-install.php` (only on Atomic)
  * `/themes/SITE`
* Switch theme.
* Wait 5-10 minutes for the event to show up in the Tracks Live View.
* Open Tracks Live View, filtered by event name and your username (`/tracks/live/?eventname=wpcom_theme_switch&user=USERNAME`.
* You should see your `wpcom_theme_switch` events showing up. Open one of them and check its `eventprops`.

<img width="300" alt="Screenshot 2025-10-22 at 17 17 33" src="https://github.com/user-attachments/assets/d8ff38e6-92a0-4ecf-8562-ed7b17232604" />

**Test on Simple:**

* Since events are not tracked while sandboxed, add this somewhere in the `wpcom_themes_tracks_switch_theme` function:
  * `var_dump( $event_props ); die();`
* Sync these changes to the Sandbox.
* Navigate to Themes screen (`/wp-admin/themes.php`).
* Switch theme.
* The screen should have died dumping all the event props. Ensure they are as expected.

