### PR TITLE
Forms: hide trash as primary action on mobile

### DIFF
--- a/projects/packages/forms/changelog/update-forms-hide-trash-action-mobile
+++ b/projects/packages/forms/changelog/update-forms-hide-trash-action-mobile
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Forms: hide trash as primary action on mobile

--- a/projects/packages/forms/src/dashboard/inbox/dataviews/index.js
+++ b/projects/packages/forms/src/dashboard/inbox/dataviews/index.js
@@ -330,7 +330,6 @@ export default function InboxView() {
 			markAsUnreadAction,
 			markAsSpamAction,
 			markAsNotSpamAction,
-			moveToTrashAction,
 			editFormAction,
 			restoreAction,
 			deleteAction,
@@ -346,8 +345,13 @@ export default function InboxView() {
 					const [ item ] = items;
 					return <ResponseMobileView response={ item } closeModal={ closeModal } />;
 				},
-				hideModalHeader: true,
-			} );
+				{
+					...moveToTrashAction,
+					// Hide as primary action on mobile
+					// Can be removed after https://github.com/WordPress/gutenberg/pull/72597
+					isPrimary: false,
+				}
+			);
 		} else {
 			_actions.unshift( {
 				...viewAction,
@@ -361,7 +365,8 @@ export default function InboxView() {
 					const selectionWithoutSelectedId = selection.filter( id => id !== selectedId );
 					onChangeSelection( [ ...selectionWithoutSelectedId, selectedId ] );
 				},
-			} );
+				moveToTrashAction
+			);
 		}
 		return _actions;
 	}, [ isMobile, onChangeSelection, selection ] );

--- a/projects/packages/forms/src/dashboard/inbox/dataviews/index.js
+++ b/projects/packages/forms/src/dashboard/inbox/dataviews/index.js
@@ -335,15 +335,17 @@ export default function InboxView() {
 			deleteAction,
 		];
 		if ( isMobile ) {
-			_actions.unshift( {
-				...viewAction,
-				RenderModal: ( { items, closeModal } ) => {
-					jetpackAnalytics.tracks.recordEvent( 'jetpack_forms_inbox_action_click', {
-						action: 'view-response',
-						multiple: items.length > 1,
-					} );
-					const [ item ] = items;
-					return <ResponseMobileView response={ item } closeModal={ closeModal } />;
+			_actions.unshift(
+				{
+					...viewAction,
+					RenderModal: ( { items, closeModal } ) => {
+						jetpackAnalytics.tracks.recordEvent( 'jetpack_forms_inbox_action_click', {
+							action: 'view-response',
+							multiple: items.length > 1,
+						} );
+						const [ item ] = items;
+						return <ResponseMobileView response={ item } closeModal={ closeModal } />;
+					},
 				},
 				{
 					...moveToTrashAction,
@@ -353,17 +355,19 @@ export default function InboxView() {
 				}
 			);
 		} else {
-			_actions.unshift( {
-				...viewAction,
-				callback( items ) {
-					jetpackAnalytics.tracks.recordEvent( 'jetpack_forms_inbox_action_click', {
-						action: 'view-response',
-						multiple: items.length > 1,
-					} );
-					const [ item ] = items;
-					const selectedId = item.id.toString();
-					const selectionWithoutSelectedId = selection.filter( id => id !== selectedId );
-					onChangeSelection( [ ...selectionWithoutSelectedId, selectedId ] );
+			_actions.unshift(
+				{
+					...viewAction,
+					callback( items ) {
+						jetpackAnalytics.tracks.recordEvent( 'jetpack_forms_inbox_action_click', {
+							action: 'view-response',
+							multiple: items.length > 1,
+						} );
+						const [ item ] = items;
+						const selectedId = item.id.toString();
+						const selectionWithoutSelectedId = selection.filter( id => id !== selectedId );
+						onChangeSelection( [ ...selectionWithoutSelectedId, selectedId ] );
+					},
 				},
 				moveToTrashAction
 			);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Follow-up to https://github.com/Automattic/jetpack/pull/45597#issuecomment-3436067232

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* While waiting for next release of dataviews with https://github.com/WordPress/gutenberg/pull/72597, we can hide the "trash" action already to give the list more space; in next version of dataviews it'll get hidden so we can revert this change.
* We need to keep the "view" action there as it's the only quick way currently to open responses on mobile, but we'll change that.


### Before

<img width="453" height="711" alt="image" src="https://github.com/user-attachments/assets/c39a921a-5246-48d3-ade9-5845d80b6c93" />


### After

<img width="453" height="696" alt="Screenshot 2025-10-23 at 16 09 11" src="https://github.com/user-attachments/assets/b6d7b42e-148e-41ea-a5d1-e05e59ca7acf" />

Desktop stays as-is:

<img width="850" height="310" alt="image" src="https://github.com/user-attachments/assets/5948799e-aa6e-40ce-b1db-8d3f3c87d875" />


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Trash action in rows gone on mobile, but available on multi-actions and dropdown
* Trash action visible on desktop

