### PR TITLE
Forms: add tracks events to inbox actions

### DIFF
--- a/projects/packages/forms/changelog/update-forms-add-tracks-to-actions
+++ b/projects/packages/forms/changelog/update-forms-add-tracks-to-actions
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Forms: record tracks events for inbox actions

--- a/projects/packages/forms/src/dashboard/inbox/dataviews/actions.js
+++ b/projects/packages/forms/src/dashboard/inbox/dataviews/actions.js
@@ -57,7 +57,7 @@ export const editFormAction = {
 	async callback( items ) {
 		jetpackAnalytics.tracks.recordEvent( 'jetpack_forms_inbox_action_click', {
 			action: 'edit-form',
-			multiple: items.length > 1,
+			multiple: false,
 		} );
 		const [ item ] = items;
 		if ( item?.edit_form_url ) {

--- a/projects/packages/forms/src/dashboard/inbox/dataviews/actions.js
+++ b/projects/packages/forms/src/dashboard/inbox/dataviews/actions.js
@@ -1,3 +1,4 @@
+import jetpackAnalytics from '@automattic/jetpack-analytics';
 import apiFetch from '@wordpress/api-fetch';
 import { Icon } from '@wordpress/components';
 import { store as coreStore } from '@wordpress/core-data';
@@ -54,6 +55,10 @@ export const editFormAction = {
 	isEligible: item => !! item?.edit_form_url,
 	supportsBulk: false,
 	async callback( items ) {
+		jetpackAnalytics.tracks.recordEvent( 'jetpack_forms_inbox_action_click', {
+			action: 'edit-form',
+			multiple: items.length > 1,
+		} );
 		const [ item ] = items;
 		if ( item?.edit_form_url ) {
 			const url = new URL( item.edit_form_url, window.location.origin );
@@ -86,6 +91,10 @@ export const markAsSpamAction = {
 	supportsBulk: true,
 	icon: <Icon icon={ spam } />,
 	async callback( items, { registry } ) {
+		jetpackAnalytics.tracks.recordEvent( 'jetpack_forms_inbox_action_click', {
+			action: 'mark-as-spam',
+			multiple: items.length > 1,
+		} );
 		const { createSuccessNotice, createErrorNotice } = registry.dispatch( noticesStore );
 		const { saveEntityRecord } = registry.dispatch( coreStore );
 		const { updateCountsOptimistically } = registry.dispatch( dashboardStore );
@@ -151,6 +160,10 @@ export const markAsNotSpamAction = {
 	supportsBulk: true,
 	icon: <Icon icon={ notSpam } />,
 	async callback( items, { registry } ) {
+		jetpackAnalytics.tracks.recordEvent( 'jetpack_forms_inbox_action_click', {
+			action: 'mark-as-not-spam',
+			multiple: items.length > 1,
+		} );
 		const { createSuccessNotice, createErrorNotice } = registry.dispatch( noticesStore );
 		const { saveEntityRecord } = registry.dispatch( coreStore );
 		const { updateCountsOptimistically } = registry.dispatch( dashboardStore );
@@ -218,6 +231,10 @@ export const restoreAction = {
 	supportsBulk: true,
 	icon: <Icon icon={ backup } />,
 	async callback( items, { registry } ) {
+		jetpackAnalytics.tracks.recordEvent( 'jetpack_forms_inbox_action_click', {
+			action: 'restore',
+			multiple: items.length > 1,
+		} );
 		const { saveEntityRecord } = registry.dispatch( coreStore );
 		const { createSuccessNotice, createErrorNotice } = registry.dispatch( noticesStore );
 		const { updateCountsOptimistically } = registry.dispatch( dashboardStore );
@@ -277,6 +294,10 @@ export const moveToTrashAction = {
 	supportsBulk: true,
 	icon: <Icon icon={ trash } />,
 	async callback( items, { registry } ) {
+		jetpackAnalytics.tracks.recordEvent( 'jetpack_forms_inbox_action_click', {
+			action: 'move-to-trash',
+			multiple: items.length > 1,
+		} );
 		const { deleteEntityRecord } = registry.dispatch( coreStore );
 		const { createSuccessNotice, createErrorNotice } = registry.dispatch( noticesStore );
 		const { updateCountsOptimistically } = registry.dispatch( dashboardStore );
@@ -335,6 +356,10 @@ export const deleteAction = {
 	supportsBulk: true,
 	icon: <Icon icon={ trash } />,
 	async callback( items, { registry } ) {
+		jetpackAnalytics.tracks.recordEvent( 'jetpack_forms_inbox_action_click', {
+			action: 'delete',
+			multiple: items.length > 1,
+		} );
 		const { deleteEntityRecord } = registry.dispatch( coreStore );
 		const { invalidateFilters, updateCountsOptimistically } = registry.dispatch( dashboardStore );
 		const { getCurrentQuery } = registry.select( dashboardStore );
@@ -388,6 +413,10 @@ export const markAsReadAction = {
 	supportsBulk: true,
 	icon: <Icon icon={ seen } />,
 	async callback( items, { registry } ) {
+		jetpackAnalytics.tracks.recordEvent( 'jetpack_forms_inbox_action_click', {
+			action: 'mark-as-read',
+			multiple: items.length > 1,
+		} );
 		// const { receiveEntityRecords, editEntityRecord } = registry.dispatch( coreStore );
 		const { editEntityRecord } = registry.dispatch( coreStore );
 		const { getEntityRecord } = registry.select( coreStore );
@@ -491,6 +520,10 @@ export const markAsUnreadAction = {
 	supportsBulk: true,
 	icon: <Icon icon={ unseen } />,
 	async callback( items, { registry } ) {
+		jetpackAnalytics.tracks.recordEvent( 'jetpack_forms_inbox_action_click', {
+			action: 'mark-as-unread',
+			multiple: items.length > 1,
+		} );
 		const { editEntityRecord } = registry.dispatch( coreStore );
 		const { getEntityRecord } = registry.select( coreStore );
 		const { createSuccessNotice, createErrorNotice } = registry.dispatch( noticesStore );

--- a/projects/packages/forms/src/dashboard/inbox/dataviews/index.js
+++ b/projects/packages/forms/src/dashboard/inbox/dataviews/index.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import jetpackAnalytics from '@automattic/jetpack-analytics';
 import {
 	ExternalLink,
 	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
@@ -338,6 +339,10 @@ export default function InboxView() {
 			_actions.unshift( {
 				...viewAction,
 				RenderModal: ( { items, closeModal } ) => {
+					jetpackAnalytics.tracks.recordEvent( 'jetpack_forms_inbox_action_click', {
+						action: 'view-response',
+						multiple: items.length > 1,
+					} );
 					const [ item ] = items;
 					return <ResponseMobileView response={ item } closeModal={ closeModal } />;
 				},
@@ -347,6 +352,10 @@ export default function InboxView() {
 			_actions.unshift( {
 				...viewAction,
 				callback( items ) {
+					jetpackAnalytics.tracks.recordEvent( 'jetpack_forms_inbox_action_click', {
+						action: 'view-response',
+						multiple: items.length > 1,
+					} );
 					const [ item ] = items;
 					const selectedId = item.id.toString();
 					const selectionWithoutSelectedId = selection.filter( id => id !== selectedId );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Part of FORMS-330

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds Tracks event to each action in Forms inbox.

It's the same event but with different "action" prop, and "multiple: true/false" depending on if your action handled one or multiple items.

<img width="229" height="319" alt="image" src="https://github.com/user-attachments/assets/c5f0adea-0e95-4d7e-bf58-828f55109ea5" />


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

