### PR TITLE
Stats: Remove "Jetpack > Stats" menu

### DIFF
--- a/projects/packages/stats-admin/changelog/dotcom-14370-remove-the-jetpack-stats-callout-after-a-month
+++ b/projects/packages/stats-admin/changelog/dotcom-14370-remove-the-jetpack-stats-callout-after-a-month
@@ -1,0 +1,4 @@
+Significance: minor
+Type: removed
+
+Stats: Remove "Jetpack > Stats" menu

--- a/projects/packages/stats-admin/src/class-dashboard.php
+++ b/projects/packages/stats-admin/src/class-dashboard.php
@@ -7,7 +7,6 @@
 
 namespace Automattic\Jetpack\Stats_Admin;
 
-use Automattic\Jetpack\Admin_UI\Admin_Menu;
 use Automattic\Jetpack\Stats\Options as Stats_Options;
 
 /**
@@ -48,7 +47,6 @@ class Dashboard {
 	public function init_hooks() {
 		self::$initialized = true;
 		// Jetpack uses 998 and 'Admin_Menu' uses 1000.
-		add_action( 'admin_menu', array( $this, 'add_wp_admin_submenu' ), $this->menu_priority );
 		add_action( 'admin_menu', array( $this, 'add_wp_admin_menu' ), $this->menu_priority );
 	}
 
@@ -80,39 +78,6 @@ class Dashboard {
 		if ( $page_suffix ) {
 			add_action( 'load-' . $page_suffix, array( $this, 'admin_init' ) );
 		}
-	}
-
-	/**
-	 * The page to be added to submenu
-	 */
-	public function add_wp_admin_submenu() {
-		$page_suffix = Admin_Menu::add_menu(
-			__( 'Stats', 'jetpack-stats-admin' ),
-			_x( 'Stats', 'product name shown in menu', 'jetpack-stats-admin' ),
-			'view_stats',
-			'callout-stats',
-			array( $this, 'render_callout' )
-		);
-
-		if ( $page_suffix ) {
-			add_action( 'load-' . $page_suffix, array( $this, 'admin_init' ) );
-		}
-	}
-
-	/**
-	 * Add the render callout function. We need to pass the location.hash to the stats moved page.
-	 *
-	 * This code is temporary and will be removed after a month.
-	 *
-	 * @return void
-	 */
-	public function render_callout() {
-		?>
-		<script>
-			location.hash = '#!/stats/moved?page=callout-stats';
-		</script>
-		<?php
-		$this->render();
 	}
 
 	/**

--- a/projects/plugins/jetpack/changelog/dotcom-14370-remove-the-jetpack-stats-callout-after-a-month
+++ b/projects/plugins/jetpack/changelog/dotcom-14370-remove-the-jetpack-stats-callout-after-a-month
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+

--- a/projects/plugins/jetpack/tests/php/general/Jetpack_Admin_Menu_Test.php
+++ b/projects/plugins/jetpack/tests/php/general/Jetpack_Admin_Menu_Test.php
@@ -72,24 +72,16 @@ class Jetpack_Admin_Menu_Test extends WP_UnitTestCase {
 
 		$submenu_names = array_column( $submenu['jetpack'], 3 );
 		// Capture the positions of these submenu items.
-		$stats_submenu_position      = array_search( 'Stats', $submenu_names, true );
 		$videopress_submenu_position = array_search( 'Jetpack VideoPress', $submenu_names, true );
 		$backup_submenu_position     = array_search( 'Jetpack VaultPress Backup', $submenu_names, true );
 		$search_submenu_position     = array_search( 'Jetpack Search', $submenu_names, true );
 		$settings_submenu_position   = array_search( 'Settings', $submenu_names, true );
-
-		// Some sites - multisites / WoA for example - may not have all of the menu items.
-		if ( in_array( 'My Jetpack', $submenu_names, true ) ) {
-			$my_jetpack_submenu_position = array_search( 'My Jetpack', $submenu_names, true );
-			$this->assertLessThan( $stats_submenu_position, $my_jetpack_submenu_position, 'My Jetpack should be above Stats in the submenu order.' );
-		}
 
 		if ( in_array( 'Activity Log', $submenu_names, true ) ) {
 			$activity_log_submenu_position = array_search( 'Activity Log', $submenu_names, true );
 			$this->assertLessThan( $search_submenu_position, $activity_log_submenu_position, 'Activity Log should be above Search in the submenu order.' );
 			$this->assertLessThan( $activity_log_submenu_position, $backup_submenu_position, 'Jetpack VaultPress Backup should be above Activity Log in the submenu order.' );
 		}
-		$this->assertLessThan( $videopress_submenu_position, $stats_submenu_position, 'Stats should be above VideoPress in the submenu order.' );
 		$this->assertLessThan( $backup_submenu_position, $videopress_submenu_position, 'Jetpack VideoPress should be above Jetpack VaultPress Backup in the submenu order.' );
 		$this->assertLessThan( $search_submenu_position, $backup_submenu_position, 'Jetpack VaultPress Backup should be above Search in the submenu order.' );
 		$this->assertLessThan( $settings_submenu_position, $search_submenu_position, 'Search should be above Settings in the submenu order.' );


### PR DESCRIPTION
Part of DOTCOM-14370

## Proposed changes:

Removes the deprecated "Jetpack > Stats" menu since the new top-level Stats menu has been live one month.

Before | After
--- | ---
<img width="332" height="103" alt="Screenshot 2025-10-23 at 16 00 38" src="https://github.com/user-attachments/assets/c3a34b21-506a-4eb2-9a46-c927ce08a0a9" /> | <img width="334" height="99" alt="Screenshot 2025-10-23 at 16 01 39" src="https://github.com/user-attachments/assets/ae6fddee-9f79-49fa-bb5e-c0506b62040c" />


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
N/A

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
- Apply these changes to your site
- Make sure the "Jetpack > Stats" menu is not available
- Make sure the Stats top-level menu is still available

