### PR TITLE
Forms: add dashboard header Jetpack logo

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-dashboard-header-logo
+++ b/projects/packages/forms/changelog/fix-forms-dashboard-header-logo
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Forms: use jetpack logo on dashboard header

--- a/projects/packages/forms/src/dashboard/components/layout/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/layout/index.tsx
@@ -19,7 +19,7 @@ import ExportResponsesButton from '../../inbox/export-responses';
 import { store as dashboardStore } from '../../store';
 import ActionsDropdownMenu from '../actions-dropdown-menu';
 import CreateFormButton from '../create-form-button';
-
+import JetpackFormsLogo from '../logo';
 import './style.scss';
 // eslint-disable-next-line import/no-unresolved -- aliased to the package's built asset in webpack config.
 import '@wordpress/admin-ui/build-style/style.css';
@@ -115,11 +115,7 @@ const Layout = () => {
 	);
 
 	return (
-		<Page
-			className="jp-forms__layout"
-			title={ __( 'Forms', 'jetpack-forms' ) }
-			actions={ headerActions }
-		>
+		<Page className="jp-forms__layout" title={ <JetpackFormsLogo /> } actions={ headerActions }>
 			<NavigableRegion
 				className="admin-ui-page__content"
 				ariaLabel={ __( 'Forms dashboard content', 'jetpack-forms' ) }

--- a/projects/packages/forms/src/dashboard/components/layout/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/layout/index.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import jetpackAnalytics from '@automattic/jetpack-analytics';
-import { useBreakpointMatch } from '@automattic/jetpack-components';
+import { useBreakpointMatch, JetpackLogo } from '@automattic/jetpack-components';
 import { NavigableRegion, Page } from '@wordpress/admin-ui';
 import { TabPanel } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
@@ -19,7 +19,7 @@ import ExportResponsesButton from '../../inbox/export-responses';
 import { store as dashboardStore } from '../../store';
 import ActionsDropdownMenu from '../actions-dropdown-menu';
 import CreateFormButton from '../create-form-button';
-import JetpackFormsLogo from '../logo';
+
 import './style.scss';
 // eslint-disable-next-line import/no-unresolved -- aliased to the package's built asset in webpack config.
 import '@wordpress/admin-ui/build-style/style.css';
@@ -115,7 +115,15 @@ const Layout = () => {
 	);
 
 	return (
-		<Page className="jp-forms__layout" title={ <JetpackFormsLogo /> } actions={ headerActions }>
+		<Page
+			className="jp-forms__layout"
+			title={
+				<div className="jp-forms__layout-header-title">
+					<JetpackLogo showText={ false } width={ 24 } /> Forms
+				</div>
+			}
+			actions={ headerActions }
+		>
 			<NavigableRegion
 				className="admin-ui-page__content"
 				ariaLabel={ __( 'Forms dashboard content', 'jetpack-forms' ) }

--- a/projects/packages/forms/src/dashboard/components/layout/style.scss
+++ b/projects/packages/forms/src/dashboard/components/layout/style.scss
@@ -28,6 +28,12 @@ body.jetpack_page_jetpack-forms-admin {
 		gap: 8px;
 	}
 
+	.jp-forms__layout-header-title {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+	}
+
 	.jp-forms__logo {
 		margin: 0 0 4px;
 		width: 200px;

--- a/projects/packages/forms/src/dashboard/components/layout/style.scss
+++ b/projects/packages/forms/src/dashboard/components/layout/style.scss
@@ -29,11 +29,12 @@ body.jetpack_page_jetpack-forms-admin {
 	}
 
 	.jp-forms__logo {
-		margin: 20px 48px;
+		margin: 0 0 4px;
 		width: 200px;
+		vertical-align: middle;
 
 		@media (max-width: 660px) {
-			margin: 20px 24px;
+			margin: 0;
 		}
 	}
 }


### PR DESCRIPTION
Resolves FORMS-348

## Proposed changes:
This PR reinstates the Jetpack Logo at the dashboard header using the JP Logo component:

<img width="902" height="442" alt="image" src="https://github.com/user-attachments/assets/e5609322-424e-487b-af93-587e9544e689" />


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1760695290228499-slack-C052XEUUBL4

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Visit the Forms dashboard, see that the header holds the Jetpack logo
