### PR TITLE
Forms: Use Page and NavigableRegion from @wordpress/admin-ui

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2503,6 +2503,9 @@ importers:
       '@gravatar-com/hovercards':
         specifier: 0.15.0
         version: 0.15.0
+      '@wordpress/admin-ui':
+        specifier: 1.1.0
+        version: 1.1.0(@types/react@18.3.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/base-styles':
         specifier: 6.7.0
         version: 6.7.0
@@ -9578,6 +9581,10 @@ packages:
 
   '@wordpress/a11y@4.33.0':
     resolution: {integrity: sha512-LUFmuDkwKS15XkV8ziR2isSMvgLZjyRg0EQD4lfCywS9ycQzuzGFHDzUxpg0ECjYQfRrGDzMcPQe5ts8HuklOA==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+
+  '@wordpress/admin-ui@1.1.0':
+    resolution: {integrity: sha512-YhzlNXI8DT8u8N2idtE5mWwmnVvJAKZqw4QaGFT/TO5LLrPFEmfYFqhFMTwnYUFfocgjW2qP0FI1OtDw6KFjjQ==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
   '@wordpress/annotations@3.31.0':
@@ -22247,6 +22254,19 @@ snapshots:
     dependencies:
       '@wordpress/dom-ready': 4.33.0
       '@wordpress/i18n': 6.6.0
+
+  '@wordpress/admin-ui@1.1.0(@types/react@18.3.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@wordpress/base-styles': 6.9.0
+      '@wordpress/components': 30.6.0(@types/react@18.3.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/element': 6.33.0
+      clsx: 2.1.1
+    transitivePeerDependencies:
+      - '@emotion/is-prop-valid'
+      - '@types/react'
+      - react
+      - react-dom
+      - supports-color
 
   '@wordpress/annotations@3.31.0(react@18.3.1)':
     dependencies:

--- a/projects/packages/forms/changelog/add-forms-admin-ui-page-component
+++ b/projects/packages/forms/changelog/add-forms-admin-ui-page-component
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Forms: integrate @wordpress/admin-ui Page component into dashboard layout

--- a/projects/packages/forms/package.json
+++ b/projects/packages/forms/package.json
@@ -43,6 +43,7 @@
 		"@automattic/request-external-access": "1.0.1",
 		"@automattic/ui": "1.0.2",
 		"@gravatar-com/hovercards": "0.15.0",
+		"@wordpress/admin-ui": "1.1.0",
 		"@wordpress/base-styles": "6.7.0",
 		"@wordpress/block-editor": "15.4.0",
 		"@wordpress/blocks": "15.4.0",

--- a/projects/packages/forms/src/dashboard/components/layout/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/layout/index.tsx
@@ -3,11 +3,8 @@
  */
 import jetpackAnalytics from '@automattic/jetpack-analytics';
 import { useBreakpointMatch } from '@automattic/jetpack-components';
-import {
-	TabPanel,
-	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
-	__experimentalHeading as Heading,
-} from '@wordpress/components';
+import { NavigableRegion, Page } from '@wordpress/admin-ui';
+import { TabPanel } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { useCallback, useEffect, useMemo } from '@wordpress/element';
 import { __, _x } from '@wordpress/i18n';
@@ -24,7 +21,8 @@ import ActionsDropdownMenu from '../actions-dropdown-menu';
 import CreateFormButton from '../create-form-button';
 
 import './style.scss';
-
+// eslint-disable-next-line import/no-unresolved -- aliased to the package's built asset in webpack config.
+import '@wordpress/admin-ui/build-style/style.css';
 const Layout = () => {
 	const location = useLocation();
 	const navigate = useNavigate();
@@ -104,42 +102,46 @@ const Layout = () => {
 		[ navigate, location.search, isSm, getCurrentTab, hasFeedback ]
 	);
 
-	return (
-		<div className="jp-forms__layout">
-			<div className="jp-forms__layout-header">
-				<Heading level={ 1 } size="15px" lineHeight="32px">
-					Forms
-					{ /** "Forms" is a product name, do not translate. */ }
-				</Heading>
-				{ isSm ? (
-					<>
-						{ isResponsesTab && isResponsesTrashView && <EmptyTrashButton /> }
-						{ isResponsesTab && isResponsesSpamView && <EmptySpamButton /> }
-						<ActionsDropdownMenu exportData={ { show: isResponsesTab } } />
-					</>
-				) : (
-					<div className="jp-forms__layout-header-actions">
-						{ isResponsesTab && <ExportResponsesButton /> }
-						{ isResponsesTab && isResponsesTrashView && <EmptyTrashButton /> }
-						{ isResponsesTab && isResponsesSpamView && <EmptySpamButton /> }
-						{ ! isResponsesTrashView && ! isResponsesSpamView && (
-							<CreateFormButton label={ __( 'Create form', 'jetpack-forms' ) } />
-						) }
-					</div>
-				) }
-			</div>
-			{ ! isLoadingConfig && (
-				<TabPanel
-					className="jp-forms__dashboard-tabs"
-					tabs={ tabs }
-					initialTabName={ getCurrentTab() }
-					onSelect={ handleTabSelect }
-					key={ getCurrentTab() }
-				>
-					{ () => <Outlet /> }
-				</TabPanel>
+	const headerActions = isSm ? (
+		<>
+			{ isResponsesTab && isResponsesTrashView && <EmptyTrashButton /> }
+			{ isResponsesTab && isResponsesSpamView && <EmptySpamButton /> }
+			<ActionsDropdownMenu exportData={ { show: isResponsesTab } } />
+		</>
+	) : (
+		<div className="jp-forms__layout-header-actions">
+			{ isResponsesTab && <ExportResponsesButton /> }
+			{ isResponsesTab && isResponsesTrashView && <EmptyTrashButton /> }
+			{ isResponsesTab && isResponsesSpamView && <EmptySpamButton /> }
+			{ ! isResponsesTrashView && ! isResponsesSpamView && (
+				<CreateFormButton label={ __( 'Create form', 'jetpack-forms' ) } />
 			) }
 		</div>
+	);
+
+	return (
+		<Page
+			className="jp-forms__layout"
+			title={ __( 'Forms', 'jetpack-forms' ) }
+			actions={ headerActions }
+		>
+			<NavigableRegion
+				className="admin-ui-page__content"
+				ariaLabel={ __( 'Forms dashboard content', 'jetpack-forms' ) }
+			>
+				{ ! isLoadingConfig && (
+					<TabPanel
+						className="jp-forms__dashboard-tabs"
+						tabs={ tabs }
+						initialTabName={ getCurrentTab() }
+						onSelect={ handleTabSelect }
+						key={ getCurrentTab() }
+					>
+						{ () => <Outlet /> }
+					</TabPanel>
+				) }
+			</NavigableRegion>
+		</Page>
 	);
 };
 

--- a/projects/packages/forms/src/dashboard/components/layout/style.scss
+++ b/projects/packages/forms/src/dashboard/components/layout/style.scss
@@ -23,12 +23,8 @@ body.jetpack_page_jetpack-forms-admin {
 	width: 100%;
 	min-height: calc(100vh - var(--wp-admin--admin-bar--height));
 
-	.jp-forms__logo-wrapper,
-	.jp-forms__layout-header {
-		flex: 0 1 auto; /* Flex, but don't grow */
-	}
-
 	.jp-forms__logo-wrapper {
+		flex: 0 1 auto; /* Flex, but don't grow */
 
 		@include mobile {
 			width: 180px;
@@ -53,11 +49,7 @@ body.jetpack_page_jetpack-forms-admin {
 #jp-forms-dashboard .jp-forms__layout {
 	background: var(--wpds-color-bg-surface-neutral-strong, #f9f9f6);
 
-	.jp-forms__layout-header {
-		display: flex;
-		align-items: center;
-		justify-content: space-between;
-
+	.admin-ui-page__header {
 		box-sizing: border-box;
 		margin: 0;
 		padding: 16px 48px 0;
@@ -115,5 +107,5 @@ body.jetpack_page_jetpack-forms-admin {
 			background: var(--jp-white);
 		}
 	}
-}
 
+}

--- a/projects/packages/forms/src/dashboard/components/layout/style.scss
+++ b/projects/packages/forms/src/dashboard/components/layout/style.scss
@@ -23,14 +23,6 @@ body.jetpack_page_jetpack-forms-admin {
 	width: 100%;
 	min-height: calc(100vh - var(--wp-admin--admin-bar--height));
 
-	.jp-forms__logo-wrapper {
-		flex: 0 1 auto; /* Flex, but don't grow */
-
-		@include mobile {
-			width: 180px;
-		}
-	}
-
 	.jp-forms__layout-header-actions {
 		display: flex;
 		gap: 8px;

--- a/projects/packages/forms/tools/webpack.config.dashboard.js
+++ b/projects/packages/forms/tools/webpack.config.dashboard.js
@@ -42,6 +42,15 @@ module.exports = {
 		alias: {
 			...jetpackWebpackConfig.resolve.alias,
 			fs: false,
+			'@wordpress/admin-ui/build-style/style.css': path.join(
+				__dirname,
+				'..',
+				'node_modules',
+				'@wordpress',
+				'admin-ui',
+				'build-style',
+				'style.css'
+			),
 		},
 	},
 	externals: {
@@ -97,7 +106,17 @@ module.exports = {
 			jetpackWebpackConfig.FileRule(),
 		],
 	},
-	plugins: [ ...jetpackWebpackConfig.StandardPlugins() ],
+	plugins: [
+		...jetpackWebpackConfig.StandardPlugins( {
+			DependencyExtractionPlugin: {
+				requestMap: {
+					// Bundle the package with our assets until WP core exposes wp-admin-ui.
+					'@wordpress/admin-ui': { external: false },
+					'@wordpress/admin-ui/build-style/style.css': { external: false },
+				},
+			},
+		} ),
+	],
 	watchOptions: {
 		...jetpackWebpackConfig.watchOptions,
 	},


### PR DESCRIPTION
Part of FORMS-329

## Proposed changes:
* Switch the Forms dashboard layout to `@wordpress/admin-ui`’s `Page`/`NavigableRegion`.
* Bundle the admin-ui assets locally (JS and CSS) so the dashboard renders reliably without depending on a core-provided script handle (not available in WP).

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
* Go to `wp-admin/admin.php?page=jetpack-forms-admin`.
* Confirm the dashboard loads and the header actions/tabs behave as before.
