### PR TITLE
Forms: fix dashboard selection bug

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-dashboard-selection-bug
+++ b/projects/packages/forms/changelog/fix-forms-dashboard-selection-bug
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: fix a response selection type error in filter bug

--- a/projects/packages/forms/changelog/fix-forms-dashboard-selection-bug
+++ b/projects/packages/forms/changelog/fix-forms-dashboard-selection-bug
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Forms: fix a response selection type error in filter bug
+Forms: fix response selection filtering bug caused by type mismatch

--- a/projects/packages/forms/src/dashboard/components/response-view/single.tsx
+++ b/projects/packages/forms/src/dashboard/components/response-view/single.tsx
@@ -58,7 +58,7 @@ const SingleResponseView = ( {
 				setSidePanelItem( actionedItem );
 			} else if ( actionedItem?.id && selection ) {
 				// Remove only the actioned item from selection, keep the rest
-				const actionedItemId = String(actionedItem.id);
+				const actionedItemId = String( actionedItem.id );
 				const newSelection = selection.filter( id => id !== actionedItemId );
 				onChangeSelection?.( newSelection );
 			}

--- a/projects/packages/forms/src/dashboard/components/response-view/single.tsx
+++ b/projects/packages/forms/src/dashboard/components/response-view/single.tsx
@@ -58,7 +58,7 @@ const SingleResponseView = ( {
 				setSidePanelItem( actionedItem );
 			} else if ( actionedItem?.id && selection ) {
 				// Remove only the actioned item from selection, keep the rest
-				const actionedItemId = actionedItem.id.toString();
+				const actionedItemId = String(actionedItem.id);
 				const newSelection = selection.filter( id => id !== actionedItemId );
 				onChangeSelection?.( newSelection );
 			}

--- a/projects/packages/forms/src/dashboard/components/response-view/single.tsx
+++ b/projects/packages/forms/src/dashboard/components/response-view/single.tsx
@@ -52,15 +52,15 @@ const SingleResponseView = ( {
 
 	const handleActionComplete = useCallback(
 		actionedItem => {
-			// Remove only the actioned item from selection, keep the rest
-			if ( actionedItem?.id && selection ) {
-				const newSelection = selection.filter( id => id !== actionedItem.id );
-				onChangeSelection?.( newSelection );
-			}
 			// if the action is on current response and hasn't changed status,
 			// don't close the modal but update the side panel item
 			if ( actionedItem?.id === sidePanelItem.id && actionedItem.status === sidePanelItem.status ) {
 				setSidePanelItem( actionedItem );
+			} else if ( actionedItem?.id && selection ) {
+				// Remove only the actioned item from selection, keep the rest
+				const actionedItemId = actionedItem.id.toString();
+				const newSelection = selection.filter( id => id !== actionedItemId );
+				onChangeSelection?.( newSelection );
 			}
 		},
 		[ onChangeSelection, selection, sidePanelItem, setSidePanelItem ]


### PR DESCRIPTION
This PR fixes a bug that happens when you select a responses. Click the "mark as unread" and switch the selection. 

The issue is that the we were comparing integers to strings so we ended up in a state where the values didn't match. This PR fixes it. 

Fixes FORMS-NEW

## Proposed changes:
* Make sure that we are comparing the same types. 

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1761163986120539-slack-C052XEUUBL4

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
* Go to the forms responses dashboard. Using a jurassic.tube site will make it more easier to replicate the issue. 
* Replicae the issue on trunk. So you can see that this PR fixes it. 
* Select a reponse. Notice mark the response and before there response comes back select the different response. 
* Notice that the selection reverts to the previous one. 

Now switch to this branch. 
And notice that things work as expected again. The selection doesn't change to the previous one. 