### PR TITLE
Forms: Remove About tab and related logic

### DIFF
--- a/projects/packages/forms/changelog/update-remove-about-page
+++ b/projects/packages/forms/changelog/update-remove-about-page
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Forms: Remove About page from dashboard

--- a/projects/packages/forms/src/dashboard/components/layout/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/layout/index.tsx
@@ -10,7 +10,7 @@ import {
 } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { useCallback, useEffect, useMemo } from '@wordpress/element';
-import { __, _x } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { Outlet, useLocation, useNavigate } from 'react-router';
 /**
  * Internal dependencies
@@ -31,7 +31,6 @@ const Layout = () => {
 	const [ isSm ] = useBreakpointMatch( 'sm' );
 
 	const enableIntegrationsTab = useConfigValue( 'isIntegrationsEnabled' );
-	const hasFeedback = useConfigValue( 'hasFeedback' );
 	const isLoadingConfig = enableIntegrationsTab === undefined;
 
 	const { currentStatus } = useSelect(
@@ -59,10 +58,6 @@ const Layout = () => {
 			...( enableIntegrationsTab
 				? [ { name: 'integrations', title: __( 'Integrations', 'jetpack-forms' ) } ]
 				: [] ),
-			{
-				name: 'about',
-				title: _x( 'About', 'About Forms', 'jetpack-forms' ),
-			},
 		],
 		[ enableIntegrationsTab ]
 	);
@@ -75,15 +70,15 @@ const Layout = () => {
 			return path;
 		}
 
-		return hasFeedback ? 'responses' : 'about';
-	}, [ location.pathname, tabs, hasFeedback ] );
+		return 'responses';
+	}, [ location.pathname, tabs ] );
 
 	const isResponsesTab = getCurrentTab() === 'responses';
 
 	const handleTabSelect = useCallback(
 		( tabName: string ) => {
 			if ( ! tabName ) {
-				tabName = hasFeedback ? 'responses' : 'about';
+				tabName = 'responses';
 			}
 
 			const currentTab = getCurrentTab();
@@ -101,7 +96,7 @@ const Layout = () => {
 				search: tabName === 'responses' ? location.search : '',
 			} );
 		},
-		[ navigate, location.search, isSm, getCurrentTab, hasFeedback ]
+		[ navigate, location.search, isSm, getCurrentTab ]
 	);
 
 	return (

--- a/projects/packages/forms/src/dashboard/inbox/index.js
+++ b/projects/packages/forms/src/dashboard/inbox/index.js
@@ -1,27 +1,2 @@
-import { useEffect } from '@wordpress/element';
-import { useNavigate } from 'react-router';
-import useConfigValue from '../../hooks/use-config-value';
-import InboxView from './dataviews';
 import './style.scss';
-
-const Inbox = () => {
-	const navigate = useNavigate();
-
-	const hasFeedback = useConfigValue( 'hasFeedback' );
-
-	// If a user has no responses yet, redirect them to the landing page.
-	useEffect( () => {
-		if ( hasFeedback !== false ) {
-			return;
-		}
-		navigate( '/about' );
-	}, [ navigate, hasFeedback ] );
-
-	if ( hasFeedback === undefined ) {
-		return null; // or a loading spinner, if you prefer
-	}
-
-	return <InboxView />;
-};
-
-export default Inbox;
+export { default } from './dataviews';

--- a/projects/packages/forms/src/dashboard/index.tsx
+++ b/projects/packages/forms/src/dashboard/index.tsx
@@ -8,7 +8,6 @@ import { RouterProvider } from 'react-router/dom';
 /**
  * Internal dependencies
  */
-import About from './about';
 import Layout from './components/layout';
 import Inbox from './inbox';
 import Integrations from './integrations';
@@ -49,10 +48,6 @@ function initFormsDashboard() {
 				{
 					path: 'integrations',
 					element: <Integrations />,
-				},
-				{
-					path: 'about',
-					element: <About />,
 				},
 			],
 		},


### PR DESCRIPTION
Part of FORMS-329

## Proposed changes:
* Remove the About tab/page/route.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
* Go to `wp-admin/admin.php?page=jetpack-forms-admin`.
* Verify the dashboard loads with only the Responses and Integrations tabs and that tab switching works.
