### PR TITLE
Forms: Fix notices placement in the dashboard

### DIFF
--- a/projects/packages/forms/changelog/fix-form-notices-placement
+++ b/projects/packages/forms/changelog/fix-form-notices-placement
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Forms: fix where notices show up so thay don't overlap the bottom action bar
+Forms: fix where notices show up so they don't overlap the bottom action bar

--- a/projects/packages/forms/changelog/fix-form-notices-placement
+++ b/projects/packages/forms/changelog/fix-form-notices-placement
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: fix where notices show up so thay don't overlap the bottom action bar

--- a/projects/packages/forms/src/dashboard/style.scss
+++ b/projects/packages/forms/src/dashboard/style.scss
@@ -38,7 +38,7 @@ body.jetpack_page_jetpack-forms-admin {
 .forms-dashboard-notices {
 	position: sticky;
 	right: 0;
-	bottom: 24px;
+	bottom: 44px;
 	padding-left: 24px;
 	padding-right: 24px;
 }

--- a/projects/plugins/jetpack/changelog/fix-form-notices-placement
+++ b/projects/plugins/jetpack/changelog/fix-form-notices-placement
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Forms: fix where notices show up so thay don't overlap the bottom action bar 

--- a/projects/plugins/jetpack/changelog/fix-form-notices-placement
+++ b/projects/plugins/jetpack/changelog/fix-form-notices-placement
@@ -1,4 +1,4 @@
 Significance: patch
 Type: bugfix
 
-Forms: fix where notices show up so thay don't overlap the bottom action bar 
+Forms: fix where notices show up so they don't overlap the bottom action bar 


### PR DESCRIPTION
Before:
<img width="612" height="339" alt="Screenshot 2025-10-23 at 3 43 14 PM" src="https://github.com/user-attachments/assets/e88e74e0-592c-42b1-946f-a2536f28b2fe" />

<img width="454" height="271" alt="Screenshot 2025-10-23 at 3 43 08 PM" src="https://github.com/user-attachments/assets/0d1f7ef5-b7ac-4341-b246-2c9796a67f81" />


After:
<img width="579" height="258" alt="Screenshot 2025-10-23 at 3 42 09 PM" src="https://github.com/user-attachments/assets/3ae74d90-c429-4ed8-88e1-09543807f893" />


<img width="464" height="231" alt="Screenshot 2025-10-23 at 3 41 57 PM" src="https://github.com/user-attachments/assets/de74190f-b148-4cde-99cd-5188d0346e1a" />

Fixes [FORMS-338](https://linear.app/a8c/issue/FORMS-338/improve-notice-placement-in-the-dashboard)

## Proposed changes:
* Move the notice bar higher up. 

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
None

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:
* Go to the dashboard. 
* Notice that the notice doesn't cover the actions. 



