### PR TITLE
fix: Editor assets endpoint mocks current screen

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-block-editor-assets.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-block-editor-assets.php
@@ -198,6 +198,31 @@ class WPCOM_REST_API_V2_Endpoint_Block_Editor_Assets extends WP_REST_Controller 
 			$wp_styles->registered[ $handle ] = $style;
 		}
 
+		// Ensure screen class and functions are available
+		if ( ! class_exists( 'WP_Screen' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/class-wp-screen.php';
+		}
+		if ( ! function_exists( 'get_current_screen' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/screen.php';
+		}
+
+		// Set up a block editor screen context to prevent errors when
+		// plugins/themes call get_current_screen() during asset enqueueing
+		$post_type = get_query_var( 'post_type', 'post' );
+		if ( is_array( $post_type ) ) {
+			$post_type = reset( $post_type );
+		}
+
+		// Create a post editor screen context
+		set_current_screen( 'post' );
+
+		// Update the screen to indicate it's using the block editor
+		$current_screen = get_current_screen();
+		if ( $current_screen ) {
+			$current_screen->is_block_editor( true );
+			$current_screen->post_type = $post_type;
+		}
+
 		// Trigger an action frequently used by plugins to enqueue assets.
 		do_action( 'wp_loaded' );
 

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-block-editor-assets.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-block-editor-assets.php
@@ -316,7 +316,7 @@ class WPCOM_REST_API_V2_Endpoint_Block_Editor_Assets extends WP_REST_Controller 
 		// Determine the post type for the screen context
 		$post_type = get_query_var( 'post_type', 'post' );
 		if ( is_array( $post_type ) ) {
-			$post_type = reset( $post_type );
+			$post_type = $post_type[0];
 		}
 
 		// Create a post editor screen context

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-block-editor-assets.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-block-editor-assets.php
@@ -198,30 +198,9 @@ class WPCOM_REST_API_V2_Endpoint_Block_Editor_Assets extends WP_REST_Controller 
 			$wp_styles->registered[ $handle ] = $style;
 		}
 
-		// Ensure screen class and functions are available
-		if ( ! class_exists( 'WP_Screen' ) ) {
-			require_once ABSPATH . 'wp-admin/includes/class-wp-screen.php';
-		}
-		if ( ! function_exists( 'get_current_screen' ) ) {
-			require_once ABSPATH . 'wp-admin/includes/screen.php';
-		}
-
 		// Set up a block editor screen context to prevent errors when
 		// plugins/themes call get_current_screen() during asset enqueueing
-		$post_type = get_query_var( 'post_type', 'post' );
-		if ( is_array( $post_type ) ) {
-			$post_type = reset( $post_type );
-		}
-
-		// Create a post editor screen context
-		set_current_screen( 'post' );
-
-		// Update the screen to indicate it's using the block editor
-		$current_screen = get_current_screen();
-		if ( $current_screen ) {
-			$current_screen->is_block_editor( true );
-			$current_screen->post_type = $post_type;
-		}
+		$this->setup_block_editor_screen();
 
 		// Trigger an action frequently used by plugins to enqueue assets.
 		do_action( 'wp_loaded' );
@@ -316,6 +295,39 @@ class WPCOM_REST_API_V2_Endpoint_Block_Editor_Assets extends WP_REST_Controller 
 				'styles'              => $styles,
 			)
 		);
+	}
+
+	/**
+	 * Sets up a mock block editor screen context for the REST API request.
+	 *
+	 * This ensures get_current_screen() is available and returns a proper
+	 * block editor screen object, preventing fatal errors when plugins/themes
+	 * call get_current_screen() during the enqueue_block_editor_assets action.
+	 */
+	private function setup_block_editor_screen() {
+		// Ensure screen class and functions are available
+		if ( ! class_exists( 'WP_Screen' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/class-wp-screen.php';
+		}
+		if ( ! function_exists( 'get_current_screen' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/screen.php';
+		}
+
+		// Determine the post type for the screen context
+		$post_type = get_query_var( 'post_type', 'post' );
+		if ( is_array( $post_type ) ) {
+			$post_type = reset( $post_type );
+		}
+
+		// Create a post editor screen context
+		set_current_screen( 'post' );
+
+		// Update the screen to indicate it's using the block editor
+		$current_screen = get_current_screen();
+		if ( $current_screen ) {
+			$current_screen->is_block_editor( true );
+			$current_screen->post_type = $post_type;
+		}
 	}
 
 	/**

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-block-editor-assets.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-block-editor-assets.php
@@ -319,6 +319,11 @@ class WPCOM_REST_API_V2_Endpoint_Block_Editor_Assets extends WP_REST_Controller 
 			$post_type = $post_type[0];
 		}
 
+		// Validate that the post type is registered
+		if ( ! post_type_exists( $post_type ) ) {
+			$post_type = 'post';
+		}
+
 		// Create a post editor screen context
 		set_current_screen( 'post' );
 

--- a/projects/plugins/jetpack/changelog/fix-editor-assets-endpoint-mocks-current-screen
+++ b/projects/plugins/jetpack/changelog/fix-editor-assets-endpoint-mocks-current-screen
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Editor assets endpoint: mock current screen to avoid fatal errors from plugins/themes.

--- a/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_Block_Editor_Assets_Test.php
+++ b/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_Block_Editor_Assets_Test.php
@@ -633,4 +633,164 @@ class WPCOM_REST_API_V2_Endpoint_Block_Editor_Assets_Test extends Jetpack_REST_T
 		$this->assertFalse( has_filter( 'script_loader_src', array( $this->instance, 'make_url_absolute' ) ), 'Script filter should be removed after processing' );
 		$this->assertFalse( has_filter( 'style_loader_src', array( $this->instance, 'make_url_absolute' ) ), 'Style filter should be removed after processing' );
 	}
+
+	/**
+	 * Test that the screen is properly configured as a block editor.
+	 */
+	public function test_screen_is_configured_as_block_editor() {
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'editor' ) ) );
+
+		$screen_captured = null;
+
+		add_action(
+			'enqueue_block_editor_assets',
+			function () use ( &$screen_captured ) {
+				$screen_captured = get_current_screen();
+			},
+			1
+		);
+
+		$request = new WP_REST_Request( Requests::GET, '/wpcom/v2/editor-assets' );
+		$this->server->dispatch( $request );
+
+		$this->assertNotNull( $screen_captured );
+		$this->assertTrue( $screen_captured->is_block_editor(), 'Screen should be marked as block editor' );
+		$this->assertSame( 'post', $screen_captured->base, 'Screen base should be "post"' );
+	}
+
+	/**
+	 * Test that the correct post type is set on the screen.
+	 */
+	public function test_screen_post_type_is_set_correctly() {
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'editor' ) ) );
+
+		$screen_captured = null;
+
+		add_action(
+			'enqueue_block_editor_assets',
+			function () use ( &$screen_captured ) {
+				$screen_captured = get_current_screen();
+			},
+			1
+		);
+
+		// Test with default post type
+		$request = new WP_REST_Request( Requests::GET, '/wpcom/v2/editor-assets' );
+		$this->server->dispatch( $request );
+
+		$this->assertSame( 'post', $screen_captured->post_type, 'Default post type should be "post"' );
+	}
+
+	/**
+	 * Test that custom post type is properly handled.
+	 */
+	public function test_screen_handles_custom_post_type() {
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'editor' ) ) );
+
+		// Register a custom post type
+		register_post_type( 'custom_test_type', array( 'show_in_rest' => true ) );
+
+		$screen_captured = null;
+
+		add_action(
+			'enqueue_block_editor_assets',
+			function () use ( &$screen_captured ) {
+				$screen_captured = get_current_screen();
+			},
+			1
+		);
+
+		// Set the post_type query var
+		set_query_var( 'post_type', 'custom_test_type' );
+
+		$request = new WP_REST_Request( Requests::GET, '/wpcom/v2/editor-assets' );
+		$this->server->dispatch( $request );
+
+		$this->assertSame( 'custom_test_type', $screen_captured->post_type, 'Custom post type should be set on screen' );
+
+		// Cleanup
+		unregister_post_type( 'custom_test_type' );
+		set_query_var( 'post_type', null );
+	}
+
+	/**
+	 * Test that array post type uses the first value.
+	 */
+	public function test_screen_handles_array_post_type() {
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'editor' ) ) );
+
+		$screen_captured = null;
+
+		add_action(
+			'enqueue_block_editor_assets',
+			function () use ( &$screen_captured ) {
+				$screen_captured = get_current_screen();
+			},
+			1
+		);
+
+		// Set the post_type query var as an array (edge case)
+		set_query_var( 'post_type', array( 'page', 'post' ) );
+
+		$request = new WP_REST_Request( Requests::GET, '/wpcom/v2/editor-assets' );
+		$this->server->dispatch( $request );
+
+		$this->assertSame( 'page', $screen_captured->post_type, 'First post type from array should be used' );
+
+		// Cleanup
+		set_query_var( 'post_type', null );
+	}
+
+	/**
+	 * Test that plugins calling get_current_screen() don't cause fatal errors.
+	 */
+	public function test_no_fatal_error_when_plugin_calls_get_current_screen() {
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'editor' ) ) );
+
+		$callback_executed = false;
+
+		// Simulate a plugin/theme that calls get_current_screen() during enqueue
+		add_action(
+			'enqueue_block_editor_assets',
+			function () use ( &$callback_executed ) {
+				// This is what plugins do that was causing fatal errors
+				$screen = get_current_screen();
+
+				// If we get here without fatal error, test passes
+				$callback_executed = true;
+
+				// Verify we can actually use the screen object
+				$this->assertNotNull( $screen );
+				$this->assertIsString( $screen->base );
+			}
+		);
+
+		$request  = new WP_REST_Request( Requests::GET, '/wpcom/v2/editor-assets' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertTrue( $callback_executed, 'Plugin callback should execute without fatal error' );
+		$this->assertInstanceOf( WP_REST_Response::class, $response, 'Request should complete successfully' );
+	}
+
+	/**
+	 * Test that WP_Screen class is loaded during request processing.
+	 */
+	public function test_wp_screen_class_is_loaded() {
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'editor' ) ) );
+
+		$class_exists_captured = false;
+
+		add_action(
+			'enqueue_block_editor_assets',
+			function () use ( &$class_exists_captured ) {
+				$class_exists_captured = class_exists( 'WP_Screen' );
+			},
+			1
+		);
+
+		$request = new WP_REST_Request( Requests::GET, '/wpcom/v2/editor-assets' );
+		$this->server->dispatch( $request );
+
+		$this->assertTrue( $class_exists_captured, 'WP_Screen class should be loaded during request' );
+	}
 }

--- a/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_Block_Editor_Assets_Test.php
+++ b/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_Block_Editor_Assets_Test.php
@@ -773,26 +773,4 @@ class WPCOM_REST_API_V2_Endpoint_Block_Editor_Assets_Test extends Jetpack_REST_T
 		$this->assertTrue( $callback_executed, 'Plugin callback should execute without fatal error' );
 		$this->assertInstanceOf( WP_REST_Response::class, $response, 'Request should complete successfully' );
 	}
-
-	/**
-	 * Test that WP_Screen class is loaded during request processing.
-	 */
-	public function test_wp_screen_class_is_loaded() {
-		wp_set_current_user( self::factory()->user->create( array( 'role' => 'editor' ) ) );
-
-		$class_exists_captured = false;
-
-		add_action(
-			'enqueue_block_editor_assets',
-			function () use ( &$class_exists_captured ) {
-				$class_exists_captured = class_exists( 'WP_Screen' );
-			},
-			1
-		);
-
-		$request = new WP_REST_Request( Requests::GET, '/wpcom/v2/editor-assets' );
-		$this->server->dispatch( $request );
-
-		$this->assertTrue( $class_exists_captured, 'WP_Screen class should be loaded during request' );
-	}
 }

--- a/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_Block_Editor_Assets_Test.php
+++ b/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_Block_Editor_Assets_Test.php
@@ -737,6 +737,7 @@ class WPCOM_REST_API_V2_Endpoint_Block_Editor_Assets_Test extends Jetpack_REST_T
 		$request = new WP_REST_Request( Requests::GET, '/wpcom/v2/editor-assets' );
 		$this->server->dispatch( $request );
 
+		$this->assertNotNull( $screen_captured, 'Screen should be captured' );
 		$this->assertSame( 'page', $screen_captured->post_type, 'First post type from array should be used' );
 
 		// Cleanup

--- a/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_Block_Editor_Assets_Test.php
+++ b/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_Block_Editor_Assets_Test.php
@@ -642,16 +642,16 @@ class WPCOM_REST_API_V2_Endpoint_Block_Editor_Assets_Test extends Jetpack_REST_T
 
 		$screen_captured = null;
 
-		add_action(
-			'enqueue_block_editor_assets',
-			function () use ( &$screen_captured ) {
-				$screen_captured = get_current_screen();
-			},
-			1
-		);
+		$action = function () use ( &$screen_captured ) {
+			$screen_captured = get_current_screen();
+		};
+
+		add_action( 'enqueue_block_editor_assets', $action, 1 );
 
 		$request = new WP_REST_Request( Requests::GET, '/wpcom/v2/editor-assets' );
 		$this->server->dispatch( $request );
+
+		remove_action( 'enqueue_block_editor_assets', $action, 1 );
 
 		$this->assertNotNull( $screen_captured, 'Screen should be captured' );
 		$this->assertTrue( $screen_captured->is_block_editor(), 'Screen should be marked as block editor' );
@@ -666,17 +666,17 @@ class WPCOM_REST_API_V2_Endpoint_Block_Editor_Assets_Test extends Jetpack_REST_T
 
 		$screen_captured = null;
 
-		add_action(
-			'enqueue_block_editor_assets',
-			function () use ( &$screen_captured ) {
-				$screen_captured = get_current_screen();
-			},
-			1
-		);
+		$action = function () use ( &$screen_captured ) {
+			$screen_captured = get_current_screen();
+		};
+
+		add_action( 'enqueue_block_editor_assets', $action, 1 );
 
 		// Test with default post type
 		$request = new WP_REST_Request( Requests::GET, '/wpcom/v2/editor-assets' );
 		$this->server->dispatch( $request );
+
+		remove_action( 'enqueue_block_editor_assets', $action, 1 );
 
 		$this->assertNotNull( $screen_captured, 'Screen should be captured' );
 		$this->assertSame( 'post', $screen_captured->post_type, 'Default post type should be "post"' );
@@ -695,19 +695,19 @@ class WPCOM_REST_API_V2_Endpoint_Block_Editor_Assets_Test extends Jetpack_REST_T
 
 		$screen_captured = null;
 
-		add_action(
-			'enqueue_block_editor_assets',
-			function () use ( &$screen_captured ) {
-				$screen_captured = get_current_screen();
-			},
-			1
-		);
+		$action = function () use ( &$screen_captured ) {
+			$screen_captured = get_current_screen();
+		};
+
+		add_action( 'enqueue_block_editor_assets', $action, 1 );
 
 		// Set the post_type query var
 		set_query_var( 'post_type', 'custom_test_type' );
 
 		$request = new WP_REST_Request( Requests::GET, '/wpcom/v2/editor-assets' );
 		$this->server->dispatch( $request );
+
+		remove_action( 'enqueue_block_editor_assets', $action, 1 );
 
 		$this->assertNotNull( $screen_captured, 'Screen should be captured' );
 		$this->assertSame( 'custom_test_type', $screen_captured->post_type, 'Custom post type should be set on screen' );
@@ -727,19 +727,19 @@ class WPCOM_REST_API_V2_Endpoint_Block_Editor_Assets_Test extends Jetpack_REST_T
 
 		$screen_captured = null;
 
-		add_action(
-			'enqueue_block_editor_assets',
-			function () use ( &$screen_captured ) {
-				$screen_captured = get_current_screen();
-			},
-			1
-		);
+		$action = function () use ( &$screen_captured ) {
+			$screen_captured = get_current_screen();
+		};
+
+		add_action( 'enqueue_block_editor_assets', $action, 1 );
 
 		// Set the post_type query var as an array (edge case)
 		set_query_var( 'post_type', array( 'page', 'post' ) );
 
 		$request = new WP_REST_Request( Requests::GET, '/wpcom/v2/editor-assets' );
 		$this->server->dispatch( $request );
+
+		remove_action( 'enqueue_block_editor_assets', $action, 1 );
 
 		$this->assertNotNull( $screen_captured, 'Screen should be captured' );
 		$this->assertSame( 'page', $screen_captured->post_type, 'First post type from array should be used' );
@@ -791,23 +791,24 @@ class WPCOM_REST_API_V2_Endpoint_Block_Editor_Assets_Test extends Jetpack_REST_T
 		$callback_executed = false;
 
 		// Simulate a plugin/theme that calls get_current_screen() during enqueue
-		add_action(
-			'enqueue_block_editor_assets',
-			function () use ( &$callback_executed ) {
-				// This is what plugins do that was causing fatal errors
-				$screen = get_current_screen();
+		$action = function () use ( &$callback_executed ) {
+			// This is what plugins do that was causing fatal errors
+			$screen = get_current_screen();
 
-				// If we get here without fatal error, test passes
-				$callback_executed = true;
+			// If we get here without fatal error, test passes
+			$callback_executed = true;
 
-				// Verify we can actually use the screen object
-				$this->assertNotNull( $screen );
-				$this->assertIsString( $screen->base );
-			}
-		);
+			// Verify we can actually use the screen object
+			$this->assertNotNull( $screen );
+			$this->assertIsString( $screen->base );
+		};
+
+		add_action( 'enqueue_block_editor_assets', $action );
 
 		$request  = new WP_REST_Request( Requests::GET, '/wpcom/v2/editor-assets' );
 		$response = $this->server->dispatch( $request );
+
+		remove_action( 'enqueue_block_editor_assets', $action );
 
 		$this->assertTrue( $callback_executed, 'Plugin callback should execute without fatal error' );
 		$this->assertInstanceOf( WP_REST_Response::class, $response, 'Request should complete successfully' );

--- a/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_Block_Editor_Assets_Test.php
+++ b/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_Block_Editor_Assets_Test.php
@@ -751,6 +751,38 @@ class WPCOM_REST_API_V2_Endpoint_Block_Editor_Assets_Test extends Jetpack_REST_T
 	}
 
 	/**
+	 * Test that invalid post type falls back to default 'post'.
+	 */
+	public function test_screen_handles_invalid_post_type() {
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'editor' ) ) );
+
+		$screen_captured = null;
+
+		$action = function () use ( &$screen_captured ) {
+			$screen_captured = get_current_screen();
+		};
+
+		add_action( 'enqueue_block_editor_assets', $action, 1 );
+
+		// Set an invalid post type that doesn't exist
+		set_query_var( 'post_type', 'nonexistent_post_type' );
+
+		$request = new WP_REST_Request( Requests::GET, '/wpcom/v2/editor-assets' );
+		$this->server->dispatch( $request );
+
+		remove_action( 'enqueue_block_editor_assets', $action, 1 );
+
+		$this->assertNotNull( $screen_captured, 'Screen should be captured' );
+		// Should fall back to 'post' when invalid post type provided
+		$this->assertSame( 'post', $screen_captured->post_type, 'Should fall back to "post" for invalid post type' );
+		$this->assertSame( 'post', $screen_captured->base, 'Screen base should be "post"' );
+		$this->assertSame( 'post', $screen_captured->id, 'Screen ID should be "post"' );
+
+		// Cleanup
+		set_query_var( 'post_type', null );
+	}
+
+	/**
 	 * Test that plugins calling get_current_screen() don't cause fatal errors.
 	 */
 	public function test_no_fatal_error_when_plugin_calls_get_current_screen() {

--- a/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_Block_Editor_Assets_Test.php
+++ b/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_Block_Editor_Assets_Test.php
@@ -680,6 +680,8 @@ class WPCOM_REST_API_V2_Endpoint_Block_Editor_Assets_Test extends Jetpack_REST_T
 
 		$this->assertNotNull( $screen_captured, 'Screen should be captured' );
 		$this->assertSame( 'post', $screen_captured->post_type, 'Default post type should be "post"' );
+		$this->assertSame( 'post', $screen_captured->base, 'Screen base is always "post" for edit screens' );
+		$this->assertSame( 'post', $screen_captured->id, 'Screen ID is always "post" for edit screens' );
 	}
 
 	/**
@@ -709,6 +711,8 @@ class WPCOM_REST_API_V2_Endpoint_Block_Editor_Assets_Test extends Jetpack_REST_T
 
 		$this->assertNotNull( $screen_captured, 'Screen should be captured' );
 		$this->assertSame( 'custom_test_type', $screen_captured->post_type, 'Custom post type should be set on screen' );
+		$this->assertSame( 'post', $screen_captured->base, 'Screen base is always "post" for edit screens' );
+		$this->assertSame( 'post', $screen_captured->id, 'Screen ID is always "post" for edit screens' );
 
 		// Cleanup
 		unregister_post_type( 'custom_test_type' );
@@ -739,6 +743,8 @@ class WPCOM_REST_API_V2_Endpoint_Block_Editor_Assets_Test extends Jetpack_REST_T
 
 		$this->assertNotNull( $screen_captured, 'Screen should be captured' );
 		$this->assertSame( 'page', $screen_captured->post_type, 'First post type from array should be used' );
+		$this->assertSame( 'post', $screen_captured->base, 'Screen base is always "post" for edit screens' );
+		$this->assertSame( 'post', $screen_captured->id, 'Screen ID is always "post" for edit screens' );
 
 		// Cleanup
 		set_query_var( 'post_type', null );

--- a/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_Block_Editor_Assets_Test.php
+++ b/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_Block_Editor_Assets_Test.php
@@ -653,7 +653,7 @@ class WPCOM_REST_API_V2_Endpoint_Block_Editor_Assets_Test extends Jetpack_REST_T
 		$request = new WP_REST_Request( Requests::GET, '/wpcom/v2/editor-assets' );
 		$this->server->dispatch( $request );
 
-		$this->assertNotNull( $screen_captured );
+		$this->assertNotNull( $screen_captured, 'Screen should be captured' );
 		$this->assertTrue( $screen_captured->is_block_editor(), 'Screen should be marked as block editor' );
 		$this->assertSame( 'post', $screen_captured->base, 'Screen base should be "post"' );
 	}
@@ -678,6 +678,7 @@ class WPCOM_REST_API_V2_Endpoint_Block_Editor_Assets_Test extends Jetpack_REST_T
 		$request = new WP_REST_Request( Requests::GET, '/wpcom/v2/editor-assets' );
 		$this->server->dispatch( $request );
 
+		$this->assertNotNull( $screen_captured, 'Screen should be captured' );
 		$this->assertSame( 'post', $screen_captured->post_type, 'Default post type should be "post"' );
 	}
 
@@ -706,6 +707,7 @@ class WPCOM_REST_API_V2_Endpoint_Block_Editor_Assets_Test extends Jetpack_REST_T
 		$request = new WP_REST_Request( Requests::GET, '/wpcom/v2/editor-assets' );
 		$this->server->dispatch( $request );
 
+		$this->assertNotNull( $screen_captured, 'Screen should be captured' );
 		$this->assertSame( 'custom_test_type', $screen_captured->post_type, 'Custom post type should be set on screen' );
 
 		// Cleanup


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fix CMM-755.

Plugins and themes often invoke `get_current_screen()` while enqueueing
block editor assets. The `get_current_screen()` function is not defined
by default for the REST API context, it is created for WP Admin pages.
To avoid fatal errors while collection editor assets, we mock the
current screen as the block editor.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Create a mocked current screen in the context of the editor assets endpoint
context.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

### 1. Editor assets endpoint returns a 200 response
1. Apply the changes to your [testing environment](https://github.com/Automattic/jetpack/pull/45617#issuecomment-3442606964).
1. Activate the Astra theme on your site.
1. Make a request to the `/wpcom/v2/sites/<site_id>/editor-assets` endpoint for the site—via [API Console](https://developer.wordpress.com/docs/api/console/), curl, etc.
1. **Verify** a 200 response is returned.

### 2. Smoke test WP Admin and web editor
1. Apply the changes to your [testing environment](https://github.com/Automattic/jetpack/pull/45617#issuecomment-3442606964).
1. **Verify** the WP Admin and web block editor function as expected. 