### PR TITLE
Forms: Fix dashborad selection untill change

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-dashborad-presever-selection-untill-change
+++ b/projects/packages/forms/changelog/fix-forms-dashborad-presever-selection-untill-change
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: Simplfy the selection so that it changes everytime to only the valid set of items

--- a/projects/packages/forms/changelog/fix-forms-dashborad-presever-selection-untill-change
+++ b/projects/packages/forms/changelog/fix-forms-dashborad-presever-selection-untill-change
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Forms: Simplfy the selection so that it changes everytime to only the valid set of items
+Forms: Simplify the selection so that it changes every time to only the valid set of items

--- a/projects/packages/forms/src/dashboard/inbox/dataviews/actions.js
+++ b/projects/packages/forms/src/dashboard/inbox/dataviews/actions.js
@@ -397,6 +397,27 @@ export const deleteAction = {
 							items.length
 					  );
 			createSuccessNotice( successMessage, { type: 'snackbar', id: 'move-to-trash-action' } );
+
+			// Update the URL to remove references to deleted items.
+			// Parse the hash to extract just the query params (e.g., #/responses?r=1,2,3)
+			const hash = window.location.hash;
+			const hashQueryIndex = hash.indexOf( '?' );
+			const hashBase = hashQueryIndex > 0 ? hash.substring( 0, hashQueryIndex ) : hash;
+			const hashQuery = hashQueryIndex > 0 ? hash.substring( hashQueryIndex + 1 ) : '';
+
+			const hashParams = new URLSearchParams( hashQuery );
+			const currentSelection = hashParams.get( 'r' )?.split( ',' ) || [];
+			const deletedIds = items.map( ( { id } ) => id.toString() );
+			const newSelection = currentSelection.filter( id => ! deletedIds.includes( id ) );
+
+			if ( newSelection.length ) {
+				hashParams.set( 'r', newSelection.join( ',' ) );
+			} else {
+				hashParams.delete( 'r' );
+			}
+
+			const hashString = hashParams.toString();
+			window.location.hash = hashString ? `${ hashBase }?${ hashString }` : hashBase;
 			return;
 		}
 		// There is at least one failure.

--- a/projects/packages/forms/src/dashboard/inbox/dataviews/index.js
+++ b/projects/packages/forms/src/dashboard/inbox/dataviews/index.js
@@ -149,7 +149,6 @@ export default function InboxView() {
 		setSelectedResponses( validSelectedIds );
 	}, [ records, selection, setSelectedResponses ] );
 
-	const [ sidePanelItem, setSidePanelItem ] = useState();
 	const onChangeSelection = useCallback(
 		items => {
 			// Set the side panel item only when we are not on mobile.
@@ -161,18 +160,8 @@ export default function InboxView() {
 			}
 			setSearchParams( previousSearchParams => {
 				const _searchParams = new URLSearchParams( previousSearchParams );
-				const currentURLSelection = _searchParams.get( 'r' )?.split( ',' ) || [];
-
-				// Filter out IDs from the current URL selection that are either already selected in the current view
-				// or already present in the current records, to avoid duplication when merging selections across pages.
-				const currentSelection = currentURLSelection.filter(
-					id => ! ( items.includes( id ) || records?.some( record => getItemId( record ) === id ) )
-				);
-
-				// merge items with the current URL
-				const mergedItems = [ ...new Set( [ ...currentSelection, ...items ] ) ];
-				if ( mergedItems.length ) {
-					_searchParams.set( 'r', mergedItems.join( ',' ) );
+				if ( items.length ) {
+					_searchParams.set( 'r', items.join( ',' ) );
 				} else {
 					_searchParams.delete( 'r' );
 				}
@@ -181,6 +170,8 @@ export default function InboxView() {
 		},
 		[ records, setSearchParams, isMobile ]
 	);
+
+	const [ sidePanelItem, setSidePanelItem ] = useState();
 	// Because selection is in sync with the URL and data takes some time to load,
 	// We need to carefully (avoid infinite loops by always updating the state)
 	// set the sidePanelItem when we have data and selection.

--- a/projects/plugins/jetpack/changelog/fix-forms-dashborad-presever-selection-untill-change
+++ b/projects/plugins/jetpack/changelog/fix-forms-dashborad-presever-selection-untill-change
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Forms: Simplfy the selection on the responses dashboard so that it changes everytime to only the valid set of items

--- a/projects/plugins/jetpack/changelog/fix-forms-dashborad-presever-selection-untill-change
+++ b/projects/plugins/jetpack/changelog/fix-forms-dashborad-presever-selection-untill-change
@@ -1,4 +1,4 @@
 Significance: patch
 Type: bugfix
 
-Forms: Simplfy the selection on the responses dashboard so that it changes everytime to only the valid set of items
+Forms: Simplify the selection on the responses dashboard so that it changes every time to only the valid set of items


### PR DESCRIPTION
Fixes FORMS-NEW

This PR remove does 2 things. 
1. It removes response ID that are permanently deleted from the URL string right away. 
2. It update the responses in the URL String to show only the ones that are currently selected once you select them. 

## Proposed changes:
* Improves the persistence of the URL string storage to be more accurate. 

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion


## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Visit the Forms Dashboard ( responses) view. 
Select all response on the first page. 
Navigate to the second page. 
Navigate back. Notice that the selection is still selected.
Navigate to the second page again. 
Select something on the second page. Notice that the URL change with the items only found on the second page. 
Navigate back to the first page. The items are not selected any more. 

Select items on the trash page. And permanently delete them. Notice that they are not in the URL any more. 
