### PR TITLE
Forms: Remove edit form from responses actions

### DIFF
--- a/projects/packages/forms/changelog/remove-edit-form-from-responses
+++ b/projects/packages/forms/changelog/remove-edit-form-from-responses
@@ -1,0 +1,4 @@
+Significance: patch
+Type: removed
+
+Forms: remove the edit form link from the responses dashboard

--- a/projects/packages/forms/src/dashboard/inbox/stage/actions.tsx
+++ b/projects/packages/forms/src/dashboard/inbox/stage/actions.tsx
@@ -284,29 +284,6 @@ export const viewAction: Action = {
 	modalHeader: __( 'Response', 'jetpack-forms' ),
 };
 
-export const editFormAction: Action = {
-	id: 'edit-form',
-	isPrimary: false,
-	icon: <Icon icon={ backup } />,
-	label: __( 'Edit form', 'jetpack-forms' ),
-	isEligible: item => !! item?.edit_form_url,
-	supportsBulk: false,
-	async callback( items ) {
-		jetpackAnalytics.tracks.recordEvent( 'jetpack_forms_inbox_action_click', {
-			action: 'edit-form',
-			multiple: false,
-		} );
-
-		const [ item ] = items;
-
-		if ( item?.edit_form_url ) {
-			const url = new URL( item.edit_form_url, window.location.origin );
-			// redirect to the form edit page
-			window.location.href = url.toString();
-		}
-	},
-};
-
 export const markAsSpamAction: Action = {
 	id: 'mark-as-spam',
 	isPrimary: true,

--- a/projects/packages/forms/src/dashboard/inbox/stage/index.js
+++ b/projects/packages/forms/src/dashboard/inbox/stage/index.js
@@ -41,7 +41,6 @@ import {
 	restoreAction,
 	markAsReadAction,
 	markAsUnreadAction,
-	editFormAction,
 } from './actions.tsx';
 import { useView, defaultLayouts } from './views.js';
 
@@ -433,7 +432,7 @@ export default function InboxView() {
 		const viewResponseAction = isMobileViewport ? mobileViewAction : desktopViewAction;
 
 		const primaryActions = [ viewResponseAction ];
-		const secondaryActions = [ markAsUnreadAction, editFormAction ];
+		const secondaryActions = [ markAsUnreadAction ];
 
 		switch ( statusFilter ) {
 			case 'trash':


### PR DESCRIPTION
Before:
<img width="288" height="319" alt="Screenshot 2025-10-24 at 6 09 23 AM" src="https://github.com/user-attachments/assets/403c3dc4-9886-4418-8357-39026136d21a" />


After:
<img width="268" height="240" alt="Screenshot 2025-10-24 at 6 09 08 AM" src="https://github.com/user-attachments/assets/8be22098-2535-425a-8de8-502cda8d2fdb" />


Fixes [FORMS-339](https://linear.app/a8c/issue/FORMS-339/remove-edit-form-link-from-responses-actions) 

## Proposed changes:
* Removes the Edit Form link since it isn't a core feedback action. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
See p1761164853968619-slack-C052XEUUBL4

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Visit the From responses dashboard. You shouldn't see the Edit Form link any more. 