### PR TITLE
Prevent PHP fatal on malformed style source with style_loader_src hook

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-jetpack-fatal_on_style_loader_src_hook
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-fatal_on_style_loader_src_hook
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Prevent PHP error when handling malformed style source.

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -5122,7 +5122,7 @@ endif;
 	 * @return mixed
 	 */
 	public static function set_suffix_on_min( $src, $handle ) {
-		if ( ! str_contains( $src, '.min.css' ) ) {
+		if ( ! is_string( $src ) || ! str_contains( $src, '.min.css' ) ) {
 			return $src;
 		}
 


### PR DESCRIPTION
Closes MONOREP-162

 <!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This adds a check to ensure the param passed is a string, and if not it returns early.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

There were some instances of this:
```
PHP Fatal error: Uncaught TypeError: str_contains(): Argument #1 ($haystack) must be of type string, array given in /wordpress/plugins/jetpack/15.2-a.5/class.jetpack.php:5124 Stack trace: #0 /wordpress/plugins/jetpack/15.2-a.5/class.jetpack.php(5124): str_contains(Array, '.min.css') #1 /wordpress/core/6.8.3/wp-includes/class-wp-hook.php(324): Jetpack::set_suffix_on_min(Array, 'vc_animate-css') #2 /wordpress/core/6.8.3/wp-includes/plugin.php(205): WP_Hook->apply_filters(Array, Array) #3 /wordpress/plugins/page-optimize/0.5.7/concat-css.php(53): apply_filters('style_loader_sr...', Array, 'vc_animate-css') #4 /wordpress/core/6.8.3/wp-includes/functions.wp-styles.php(68): Page_Optimize_CSS_Concat->do_items(Array) #5 /wordpress/core/6.8.3/wp-includes/class-wp-hook.php(324): wp_print_styles(false) #6 /wordpress/core/6.8.3/wp-includes/class-wp-hook.php(348): WP_Hook->apply_filters(NULL, Array) #7 /wordpress/core/6.8.3/wp-includes/plugin.php(517): WP_Hook->do_action(Array) #8 /wordpress/core/6.8.3/wp-includes/general-template.php(3192): do_action('wp_head') #9 /srv/htdocs/wp-content/themes/hazel/header.php(13): wp_head() #10 /wordpress/core/6.8.3/wp-includes/template.php(810): require_once('/srv/htdocs/wp-...') #11 /wordpress/core/6.8.3/wp-includes/template.php(745): load_template('/srv/htdocs/wp-...', true, Array) #12 /wordpress/core/6.8.3/wp-includes/general-template.php(48): locate_template(Array, true, true, Array) #13 /srv/htdocs/wp-content/themes/hazel/template-home.php(6): get_header() #14 /wordpress/core/6.8.3/wp-includes/template-loader.php(106): include('/srv/htdocs/wp-...') #15 /wordpress/core/6.8.3/wp-blog-header.php(19): require_once('/wordpress/core...') #16 /wordpress/core/6.8.3/index.php(17): require('/wordpress/core...') #17 {main} thrown in /wordpress/plugins/jetpack/15.2-a.5/class.jetpack.php on line 5124
```

All the sites with the error mention `vc_animate-css` (WP Bakery/Visual Composer?) as the handle, and pass an array as the source despite the hook expecting a string:
https://developer.wordpress.org/reference/hooks/style_loader_src/

However, none of them seem to be running said code anymore, so it's a bit difficult to reproduce. That said, it should be safe enough to return early.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

