### PR TITLE
Post Images: Ensure type is WP_Post before treating it as a post

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-jetpack-warnings_on_nonpost
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-warnings_on_nonpost
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Post Images: Ensure type is WP_Post before treating it as a post.

--- a/projects/plugins/jetpack/class.jetpack-post-images.php
+++ b/projects/plugins/jetpack/class.jetpack-post-images.php
@@ -31,8 +31,7 @@ class Jetpack_PostImages {
 		$images = array();
 
 		$post = get_post( $post_id );
-
-		if ( ! $post ) {
+		if ( ! $post instanceof WP_Post ) {
 			return $images;
 		}
 
@@ -150,8 +149,7 @@ class Jetpack_PostImages {
 		$images = array();
 
 		$post = get_post( $post_id );
-
-		if ( ! $post ) {
+		if ( ! $post instanceof WP_Post ) {
 			return $images;
 		}
 
@@ -246,6 +244,9 @@ class Jetpack_PostImages {
 		$images = array();
 
 		$post = get_post( $post_id );
+		if ( ! $post instanceof WP_Post ) {
+			return $images;
+		}
 
 		if ( ! empty( $post->post_password ) ) {
 			return $images;
@@ -319,6 +320,9 @@ class Jetpack_PostImages {
 		$images = array();
 
 		$post = get_post( $post_id );
+		if ( ! $post instanceof WP_Post ) {
+			return $images;
+		}
 
 		if ( ! empty( $post->post_password ) ) {
 			return $images;
@@ -724,12 +728,12 @@ class Jetpack_PostImages {
 	 * @return array containing details of the image, or empty array if none.
 	 */
 	public static function from_gravatar( $post_id, $size = 96, $default = false ) {
-		$post      = get_post( $post_id );
-		$permalink = get_permalink( $post_id );
-
+		$post = get_post( $post_id );
 		if ( ! $post instanceof WP_Post ) {
 			return array();
 		}
+
+		$permalink = get_permalink( $post_id );
 
 		if ( function_exists( 'wpcom_get_avatar_url' ) ) {
 			$url = wpcom_get_avatar_url( $post->post_author, $size, $default, true );
@@ -1009,8 +1013,7 @@ class Jetpack_PostImages {
 	public static function get_post_html( $html_or_id ) {
 		if ( is_numeric( $html_or_id ) ) {
 			$post = get_post( $html_or_id );
-
-			if ( empty( $post ) || ! empty( $post->post_password ) ) {
+			if ( ! $post instanceof WP_Post || ! empty( $post->post_password ) ) {
 				return '';
 			}
 


### PR DESCRIPTION
Closes MONOREP-163

 <!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This verifies the result of `get_post()` is a `WP_Post` prior to treating it as such.

Reported here: p1761317184019159-slack-CDLH4C1UZ

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*