### PR TITLE
 Forms: Add error codes to submission errors

### DIFF
--- a/projects/packages/forms/changelog/update-forms-error-codes
+++ b/projects/packages/forms/changelog/update-forms-error-codes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Forms: Add error codes to submission errors

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -1521,7 +1521,7 @@ class Contact_Form_Plugin {
 		// phpcs:enable
 
 		if ( ! is_string( $id ) || ! is_string( $hash ) ) {
-			return new Form_Submission_Error( 'invalid_form_id_or_hash', __( 'Invalid form ID or hash.', 'jetpack-forms' ), Form_Submission_Error::TYPE_SYSTEM );
+			return Form_Submission_Error::system_error( 'invalid_form_id_or_hash', __( 'Invalid form ID or hash.', 'jetpack-forms' ) );
 		}
 
 		if ( is_user_logged_in() ) {
@@ -1536,7 +1536,7 @@ class Contact_Form_Plugin {
 			$form = Contact_Form::get_instance_from_jwt( sanitize_text_field( wp_unslash( $_POST['jetpack_contact_form_jwt'] ) ) );
 			if ( ! $form ) { // fail early if the JWT is invalid.
 				// If the JWT is invalid, we can't process the form.
-				return new Form_Submission_Error( 'invalid_jwt', __( 'Invalid JWT token.', 'jetpack-forms' ), Form_Submission_Error::TYPE_SYSTEM );
+				return Form_Submission_Error::system_error( 'invalid_jwt', __( 'Invalid JWT token.', 'jetpack-forms' ) );
 			}
 
 			$form->validate();
@@ -1648,12 +1648,12 @@ class Contact_Form_Plugin {
 
 			if ( ! is_post_publicly_viewable( $id ) && ! current_user_can( 'read_post', $id ) ) {
 				// The user can't see the post.
-				return new Form_Submission_Error( 'post_not_viewable', __( 'You do not have permission to view this form.', 'jetpack-forms' ), Form_Submission_Error::TYPE_SYSTEM );
+				return Form_Submission_Error::system_error( 'post_not_viewable', __( 'You do not have permission to view this form.', 'jetpack-forms' ) );
 			}
 
 			if ( post_password_required( $id ) ) {
 				// The post is password-protected and the password is not provided.
-				return new Form_Submission_Error( 'post_password_required', __( 'This form requires a password.', 'jetpack-forms' ), Form_Submission_Error::TYPE_SYSTEM );
+				return Form_Submission_Error::system_error( 'post_password_required', __( 'This form requires a password.', 'jetpack-forms' ) );
 			}
 
 			$post = get_post( $id );
@@ -1705,7 +1705,7 @@ class Contact_Form_Plugin {
 		}
 
 		if ( ! $form ) {
-			return new Form_Submission_Error( 'form_not_found', __( 'Form not found.', 'jetpack-forms' ), Form_Submission_Error::TYPE_SYSTEM );
+			return Form_Submission_Error::system_error( 'form_not_found', __( 'Form not found.', 'jetpack-forms' ) );
 		}
 
 		if ( $form->has_errors() ) {
@@ -1728,7 +1728,7 @@ class Contact_Form_Plugin {
 	public function ajax_request() {
 		$submission_result = self::process_form_submission();
 		$accepts_json      = isset( $_SERVER['HTTP_ACCEPT'] ) && false !== strpos( strtolower( sanitize_text_field( wp_unslash( $_SERVER['HTTP_ACCEPT'] ) ) ), 'application/json' );
-		$is_system_error   = $submission_result instanceof Form_Submission_Error && $submission_result->is_system_error();
+		$is_system_error   = Form_Submission_Error::is_system_error( $submission_result );
 
 		if ( ! $submission_result || $is_system_error ) {
 			$error_code = $is_system_error ? $submission_result->get_error_code() : 'unknown';

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -23,6 +23,9 @@ use WP_Block_Patterns_Registry;
 use WP_Block_Type_Registry;
 use WP_Error;
 
+// Load the Form_Submission_Error class.
+require_once __DIR__ . '/class-form-submission-error.php';
+
 /**
  * Sets up various actions, filters, post types, post statuses, shortcodes.
  */
@@ -1518,7 +1521,7 @@ class Contact_Form_Plugin {
 		// phpcs:enable
 
 		if ( ! is_string( $id ) || ! is_string( $hash ) ) {
-			return false;
+			return new Form_Submission_Error( 'invalid_form_id_or_hash', __( 'Invalid form ID or hash.', 'jetpack-forms' ), Form_Submission_Error::TYPE_SYSTEM );
 		}
 
 		if ( is_user_logged_in() ) {
@@ -1533,7 +1536,7 @@ class Contact_Form_Plugin {
 			$form = Contact_Form::get_instance_from_jwt( sanitize_text_field( wp_unslash( $_POST['jetpack_contact_form_jwt'] ) ) );
 			if ( ! $form ) { // fail early if the JWT is invalid.
 				// If the JWT is invalid, we can't process the form.
-				return false;
+				return new Form_Submission_Error( 'invalid_jwt', __( 'Invalid JWT token.', 'jetpack-forms' ), Form_Submission_Error::TYPE_SYSTEM );
 			}
 
 			$form->validate();
@@ -1645,12 +1648,12 @@ class Contact_Form_Plugin {
 
 			if ( ! is_post_publicly_viewable( $id ) && ! current_user_can( 'read_post', $id ) ) {
 				// The user can't see the post.
-				return false;
+				return new Form_Submission_Error( 'post_not_viewable', __( 'You do not have permission to view this form.', 'jetpack-forms' ), Form_Submission_Error::TYPE_SYSTEM );
 			}
 
 			if ( post_password_required( $id ) ) {
 				// The post is password-protected and the password is not provided.
-				return false;
+				return new Form_Submission_Error( 'post_password_required', __( 'This form requires a password.', 'jetpack-forms' ), Form_Submission_Error::TYPE_SYSTEM );
 			}
 
 			$post = get_post( $id );
@@ -1702,11 +1705,11 @@ class Contact_Form_Plugin {
 		}
 
 		if ( ! $form ) {
-			return false;
+			return new Form_Submission_Error( 'form_not_found', __( 'Form not found.', 'jetpack-forms' ), Form_Submission_Error::TYPE_SYSTEM );
 		}
 
 		if ( $form->has_errors() ) {
-			return false;
+			return $form->errors;
 		}
 
 		if ( ! empty( $form->attributes['salesforceData'] ) || ! empty( $form->attributes['postToUrl'] ) ) {
@@ -1725,19 +1728,25 @@ class Contact_Form_Plugin {
 	public function ajax_request() {
 		$submission_result = self::process_form_submission();
 		$accepts_json      = isset( $_SERVER['HTTP_ACCEPT'] ) && false !== strpos( strtolower( sanitize_text_field( wp_unslash( $_SERVER['HTTP_ACCEPT'] ) ) ), 'application/json' );
+		$is_system_error   = $submission_result instanceof Form_Submission_Error && $submission_result->is_system_error();
 
-		if ( ! $submission_result ) {
+		if ( ! $submission_result || $is_system_error ) {
+			$error_code = $is_system_error ? $submission_result->get_error_code() : 'unknown';
+
 			/**
 			 * Action when we want to log a jetpack_forms event.
 			 *
 			 * @since 6.3.0
 			 *
 			 * @param string $log_message The log message.
+			 * @param string $error_code The error code (optional).
 			 */
-			do_action( 'jetpack_forms_log', 'submission_failed' );
+			do_action( 'jetpack_forms_log', 'submission_failed', $error_code );
+
 			$accepts_json && wp_send_json_error(
 				array(
 					'error' => __( 'An error occurred. Please try again later.', 'jetpack-forms' ),
+					'code'  => $error_code,
 				),
 				500
 			);
@@ -1747,10 +1756,11 @@ class Contact_Form_Plugin {
 			echo '<div class="form-error"><ul class="form-errors"><li class="form-error-message">';
 			esc_html_e( 'An error occurred. Please try again later.', 'jetpack-forms' );
 			echo '</li></ul></div>';
-			die();
 
+			die();
 		} elseif ( is_wp_error( $submission_result ) ) {
 			do_action( 'jetpack_forms_log', $submission_result->get_error_message() );
+
 			$accepts_json && wp_send_json_error(
 				array(
 					'error' => $submission_result->get_error_message(),
@@ -1763,6 +1773,7 @@ class Contact_Form_Plugin {
 			echo '<div class="form-error"><ul class="form-errors"><li class="form-error-message">';
 			echo esc_html( $submission_result->get_error_message() );
 			echo '</li></ul></div>';
+
 			die();
 		}
 

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -1801,18 +1801,18 @@ class Contact_Form extends Contact_Form_Shortcode {
 			// Make sure we're processing the form we think we're processing... probably a redundant check.
 			if ( $widget ) {
 				if ( isset( $_POST['contact-form-id'] ) && 'widget-' . $widget !== $_POST['contact-form-id'] ) { // phpcs:Ignore WordPress.Security.NonceVerification.Missing -- check done by caller process_form_submission()
-					return new Form_Submission_Error( 'form_id_mismatch', __( 'Form ID mismatch.', 'jetpack-forms' ), Form_Submission_Error::TYPE_SYSTEM );
+					return Form_Submission_Error::system_error( 'form_id_mismatch_widget', __( 'Form ID mismatch.', 'jetpack-forms' ) );
 				}
 			} elseif ( $block_template ) {
 				if ( isset( $_POST['contact-form-id'] ) && 'block-template-' . $block_template !== $_POST['contact-form-id'] ) { // phpcs:Ignore WordPress.Security.NonceVerification.Missing -- check done by caller process_form_submission()
-					return new Form_Submission_Error( 'form_id_mismatch', __( 'Form ID mismatch.', 'jetpack-forms' ), Form_Submission_Error::TYPE_SYSTEM );
+					return Form_Submission_Error::system_error( 'form_id_mismatch_block_template', __( 'Form ID mismatch.', 'jetpack-forms' ) );
 				}
 			} elseif ( $block_template_part ) {
 				if ( isset( $_POST['contact-form-id'] ) && 'block-template-part-' . $block_template_part !== $_POST['contact-form-id'] ) { // phpcs:Ignore WordPress.Security.NonceVerification.Missing -- check done by caller process_form_submission()
-					return new Form_Submission_Error( 'form_id_mismatch', __( 'Form ID mismatch.', 'jetpack-forms' ), Form_Submission_Error::TYPE_SYSTEM );
+						return Form_Submission_Error::system_error( 'form_id_mismatch_block_template_part', __( 'Form ID mismatch.', 'jetpack-forms' ) );
 				}
 			} elseif ( isset( $_POST['contact-form-id'] ) && ( empty( $this->current_post ) || self::get_post_property( $this->current_post, 'ID' ) !== (int) sanitize_text_field( wp_unslash( $_POST['contact-form-id'] ) ) ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing -- check done by caller process_form_submission()
-				return new Form_Submission_Error( 'form_id_mismatch', __( 'Form ID mismatch.', 'jetpack-forms' ), Form_Submission_Error::TYPE_SYSTEM );
+				return Form_Submission_Error::system_error( 'form_id_mismatch_post', __( 'Form ID mismatch.', 'jetpack-forms' ) );
 			}
 		}
 
@@ -2835,7 +2835,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 	public function add_error( $error_code, $error_message ) {
 		$id = $this->get_attribute( 'id' );
 		if ( ! isset( self::$static_errors[ $id ] ) ) {
-			self::$static_errors[ $id ] = new Form_Submission_Error( $error_code, $error_message, Form_Submission_Error::TYPE_VALIDATION );
+			self::$static_errors[ $id ] = Form_Submission_Error::validation_error( $error_code, $error_message );
 		} else {
 			// If we already have errors, add this error to the existing Form_Submission_Error
 			self::$static_errors[ $id ]->add( $error_code, $error_message );

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -17,6 +17,9 @@ use WP_Block;
 use WP_Error;
 use WP_Post;
 
+// Load the Form_Submission_Error class.
+require_once __DIR__ . '/class-form-submission-error.php';
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit( 0 );
 }
@@ -1798,18 +1801,18 @@ class Contact_Form extends Contact_Form_Shortcode {
 			// Make sure we're processing the form we think we're processing... probably a redundant check.
 			if ( $widget ) {
 				if ( isset( $_POST['contact-form-id'] ) && 'widget-' . $widget !== $_POST['contact-form-id'] ) { // phpcs:Ignore WordPress.Security.NonceVerification.Missing -- check done by caller process_form_submission()
-					return false;
+					return new Form_Submission_Error( 'form_id_mismatch', __( 'Form ID mismatch.', 'jetpack-forms' ), Form_Submission_Error::TYPE_SYSTEM );
 				}
 			} elseif ( $block_template ) {
 				if ( isset( $_POST['contact-form-id'] ) && 'block-template-' . $block_template !== $_POST['contact-form-id'] ) { // phpcs:Ignore WordPress.Security.NonceVerification.Missing -- check done by caller process_form_submission()
-					return false;
+					return new Form_Submission_Error( 'form_id_mismatch', __( 'Form ID mismatch.', 'jetpack-forms' ), Form_Submission_Error::TYPE_SYSTEM );
 				}
 			} elseif ( $block_template_part ) {
 				if ( isset( $_POST['contact-form-id'] ) && 'block-template-part-' . $block_template_part !== $_POST['contact-form-id'] ) { // phpcs:Ignore WordPress.Security.NonceVerification.Missing -- check done by caller process_form_submission()
-					return false;
+					return new Form_Submission_Error( 'form_id_mismatch', __( 'Form ID mismatch.', 'jetpack-forms' ), Form_Submission_Error::TYPE_SYSTEM );
 				}
 			} elseif ( isset( $_POST['contact-form-id'] ) && ( empty( $this->current_post ) || self::get_post_property( $this->current_post, 'ID' ) !== (int) sanitize_text_field( wp_unslash( $_POST['contact-form-id'] ) ) ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing -- check done by caller process_form_submission()
-				return false;
+				return new Form_Submission_Error( 'form_id_mismatch', __( 'Form ID mismatch.', 'jetpack-forms' ), Form_Submission_Error::TYPE_SYSTEM );
 			}
 		}
 

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -2835,9 +2835,11 @@ class Contact_Form extends Contact_Form_Shortcode {
 	public function add_error( $error_code, $error_message ) {
 		$id = $this->get_attribute( 'id' );
 		if ( ! isset( self::$static_errors[ $id ] ) ) {
-			self::$static_errors[ $id ] = new \WP_Error();
+			self::$static_errors[ $id ] = new Form_Submission_Error( $error_code, $error_message, Form_Submission_Error::TYPE_VALIDATION );
+		} else {
+			// If we already have errors, add this error to the existing Form_Submission_Error
+			self::$static_errors[ $id ]->add( $error_code, $error_message );
 		}
-		self::$static_errors[ $id ]->add( $error_code, $error_message );
 		$this->errors = self::$static_errors[ $id ];
 	}
 	/**

--- a/projects/packages/forms/src/contact-form/class-form-submission-error.php
+++ b/projects/packages/forms/src/contact-form/class-form-submission-error.php
@@ -58,7 +58,7 @@ class Form_Submission_Error extends WP_Error {
 	 *
 	 * @return bool True if validation error, false otherwise.
 	 */
-	public function is_validation_error() {
+	public function is_validation_type() {
 		return self::TYPE_VALIDATION === $this->error_type;
 	}
 
@@ -67,7 +67,49 @@ class Form_Submission_Error extends WP_Error {
 	 *
 	 * @return bool True if system error, false otherwise.
 	 */
-	public function is_system_error() {
+	public function is_system_type() {
 		return self::TYPE_SYSTEM === $this->error_type;
+	}
+
+	/**
+	 * Check if the given error is a Form Submission Error with system error type.
+	 *
+	 * @param mixed $error The error to check.
+	 * @return bool True if the error is a Form_Submission_Error with system type, false otherwise.
+	 */
+	public static function is_system_error( $error ) {
+		return $error instanceof self && $error->is_system_type();
+	}
+
+	/**
+	 * Check if the given error is a Form Submission Error with validation error type.
+	 *
+	 * @param mixed $error The error to check.
+	 * @return bool True if the error is a Form_Submission_Error with validation type, false otherwise.
+	 */
+	public static function is_validation_error( $error ) {
+		return $error instanceof self && $error->is_validation_type();
+	}
+
+	/**
+	 * Create a validation Form Submission Error.
+	 *
+	 * @param string $code    Error code.
+	 * @param string $message Error message.
+	 * @return Form_Submission_Error The validation error instance.
+	 */
+	public static function validation_error( $code, $message ) {
+		return new self( $code, $message, self::TYPE_VALIDATION );
+	}
+
+	/**
+	 * Create a system Form Submission Error.
+	 *
+	 * @param string $code    Error code.
+	 * @param string $message Error message.
+	 * @return Form_Submission_Error The system error instance.
+	 */
+	public static function system_error( $code, $message ) {
+		return new self( $code, $message, self::TYPE_SYSTEM );
 	}
 }

--- a/projects/packages/forms/src/contact-form/class-form-submission-error.php
+++ b/projects/packages/forms/src/contact-form/class-form-submission-error.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * Form_Submission_Error class.
+ *
+ * @package automattic/jetpack-forms
+ */
+
+namespace Automattic\Jetpack\Forms\ContactForm;
+
+use WP_Error;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
+/**
+ * Custom error class for form submission errors.
+ * Extends WP_Error to add error type classification.
+ */
+class Form_Submission_Error extends WP_Error {
+
+	/**
+	 * Error type constants.
+	 */
+	const TYPE_VALIDATION = 'validation';
+	const TYPE_SYSTEM     = 'system';
+
+	/**
+	 * The error type (validation or system).
+	 *
+	 * @var string
+	 */
+	public $error_type;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param string $code    Error code.
+	 * @param string $message Error message.
+	 * @param string $type    Error type (validation or system).
+	 */
+	public function __construct( $code, $message, $type = self::TYPE_SYSTEM ) {
+		parent::__construct( $code, $message );
+		$this->error_type = $type;
+	}
+
+	/**
+	 * Get the error type.
+	 *
+	 * @return string The error type.
+	 */
+	public function get_error_type() {
+		return $this->error_type;
+	}
+
+	/**
+	 * Check if this is a validation error.
+	 *
+	 * @return bool True if validation error, false otherwise.
+	 */
+	public function is_validation_error() {
+		return self::TYPE_VALIDATION === $this->error_type;
+	}
+
+	/**
+	 * Check if this is a system error.
+	 *
+	 * @return bool True if system error, false otherwise.
+	 */
+	public function is_system_error() {
+		return self::TYPE_SYSTEM === $this->error_type;
+	}
+}

--- a/projects/packages/forms/src/modules/form/shared.ts
+++ b/projects/packages/forms/src/modules/form/shared.ts
@@ -66,7 +66,7 @@ export const submitForm = async ( formHash: string ) => {
 		const result = await response.json();
 
 		if ( ! response.ok ) {
-			debug( 'Form submission failed', response );
+			debug( `Form submission failed: ${ result?.data?.code }`, response );
 			// If we have a specific error from the server, use it; otherwise fall back to network error
 			return result && result.data && result.data.error
 				? { success: false, error: result.data.error }

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
@@ -13,6 +13,9 @@ use WorDBless\BaseTestCase;
 use WP_Block;
 use WP_Error;
 
+// Load the Form_Submission_Error class for testing.
+require_once __DIR__ . '/../../../src/contact-form/class-form-submission-error.php';
+
 /**
  * Test class for Contact_Form_Plugin
  *
@@ -583,7 +586,9 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 		$plugin = Contact_Form_Plugin::init();
 		$result = $plugin->process_form_submission();
 
-		$this->assertFalse( $result, 'Expected a WP_Error when processing the form submission.' );
+		$this->assertInstanceOf( Form_Submission_Error::class, $result, 'Expected a Form_Submission_Error when processing the form submission with invalid JWT.' );
+		$this->assertEquals( 'invalid_jwt', $result->get_error_code(), 'Expected the error code to be "invalid_jwt".' );
+		$this->assertTrue( $result->is_system_error(), 'Expected this to be a system error.' );
 
 		$this->teardown_post_for_test( $previous_post );
 	}

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
@@ -576,7 +576,7 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 		$result = $plugin->process_form_submission();
 		$this->assertInstanceOf( Form_Submission_Error::class, $result, 'Expected a Form_Submission_Error when processing the form submission.' );
 		$this->assertEquals( 'Name field is required.', $result->get_error_message(), 'Expected the error message to be "Name field is required.".' );
-		$this->assertTrue( $result->is_validation_error(), 'Expected this to be a validation error.' );
+		$this->assertTrue( $result->is_validation_type(), 'Expected this to be a validation error.' );
 
 		$this->teardown_post_for_test( $previous_post );
 	}
@@ -589,7 +589,7 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 
 		$this->assertInstanceOf( Form_Submission_Error::class, $result, 'Expected a Form_Submission_Error when processing the form submission with invalid JWT.' );
 		$this->assertEquals( 'invalid_jwt', $result->get_error_code(), 'Expected the error code to be "invalid_jwt".' );
-		$this->assertTrue( $result->is_system_error(), 'Expected this to be a system error.' );
+		$this->assertTrue( $result->is_system_type(), 'Expected this to be a system error.' );
 
 		$this->teardown_post_for_test( $previous_post );
 	}

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
@@ -574,8 +574,9 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 
 		$plugin = Contact_Form_Plugin::init();
 		$result = $plugin->process_form_submission();
-		$this->assertInstanceOf( WP_Error::class, $result, 'Expected a WP_Error when processing the form submission.' );
-		$this->assertEquals( 'Name field is required.', $result->get_error_message(), 'Expected the error code to be "check_spam".' );
+		$this->assertInstanceOf( Form_Submission_Error::class, $result, 'Expected a Form_Submission_Error when processing the form submission.' );
+		$this->assertEquals( 'Name field is required.', $result->get_error_message(), 'Expected the error message to be "Name field is required.".' );
+		$this->assertTrue( $result->is_validation_error(), 'Expected this to be a validation error.' );
 
 		$this->teardown_post_for_test( $previous_post );
 	}

--- a/projects/packages/forms/tests/php/contact-form/Form_Submission_Error_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Form_Submission_Error_Test.php
@@ -1,0 +1,216 @@
+<?php
+/**
+ * Test Form_Submission_Error class.
+ *
+ * @package automattic/jetpack-forms
+ */
+
+namespace Automattic\Jetpack\Forms\ContactForm;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Test Form_Submission_Error class.
+ */
+class Form_Submission_Error_Test extends TestCase {
+
+	/**
+	 * Test constructor with default system error type.
+	 */
+	public function test_constructor_default_system_error() {
+		$error = new Form_Submission_Error( 'test_code', 'Test message' );
+
+		$this->assertEquals( 'test_code', $error->get_error_code() );
+		$this->assertEquals( 'Test message', $error->get_error_message() );
+		$this->assertEquals( Form_Submission_Error::TYPE_SYSTEM, $error->get_error_type() );
+		$this->assertTrue( $error->is_system_type() );
+		$this->assertFalse( $error->is_validation_type() );
+	}
+
+	/**
+	 * Test constructor with explicit validation error type.
+	 */
+	public function test_constructor_validation_error() {
+		$error = new Form_Submission_Error( 'validation_code', 'Validation message', Form_Submission_Error::TYPE_VALIDATION );
+
+		$this->assertEquals( 'validation_code', $error->get_error_code() );
+		$this->assertEquals( 'Validation message', $error->get_error_message() );
+		$this->assertEquals( Form_Submission_Error::TYPE_VALIDATION, $error->get_error_type() );
+		$this->assertFalse( $error->is_system_type() );
+		$this->assertTrue( $error->is_validation_type() );
+	}
+
+	/**
+	 * Test constructor with explicit system error type.
+	 */
+	public function test_constructor_system_error() {
+		$error = new Form_Submission_Error( 'system_code', 'System message', Form_Submission_Error::TYPE_SYSTEM );
+
+		$this->assertEquals( 'system_code', $error->get_error_code() );
+		$this->assertEquals( 'System message', $error->get_error_message() );
+		$this->assertEquals( Form_Submission_Error::TYPE_SYSTEM, $error->get_error_type() );
+		$this->assertTrue( $error->is_system_type() );
+		$this->assertFalse( $error->is_validation_type() );
+	}
+
+	/**
+	 * Test get_error_type method.
+	 */
+	public function test_get_error_type() {
+		$system_error     = new Form_Submission_Error( 'code', 'message', Form_Submission_Error::TYPE_SYSTEM );
+		$validation_error = new Form_Submission_Error( 'code', 'message', Form_Submission_Error::TYPE_VALIDATION );
+
+		$this->assertEquals( Form_Submission_Error::TYPE_SYSTEM, $system_error->get_error_type() );
+		$this->assertEquals( Form_Submission_Error::TYPE_VALIDATION, $validation_error->get_error_type() );
+	}
+
+	/**
+	 * Test is_validation_type method.
+	 */
+	public function test_is_validation_type() {
+		$validation_error = new Form_Submission_Error( 'code', 'message', Form_Submission_Error::TYPE_VALIDATION );
+		$system_error     = new Form_Submission_Error( 'code', 'message', Form_Submission_Error::TYPE_SYSTEM );
+
+		$this->assertTrue( $validation_error->is_validation_type() );
+		$this->assertFalse( $system_error->is_validation_type() );
+	}
+
+	/**
+	 * Test is_system_type method.
+	 */
+	public function test_is_system_type() {
+		$system_error     = new Form_Submission_Error( 'code', 'message', Form_Submission_Error::TYPE_SYSTEM );
+		$validation_error = new Form_Submission_Error( 'code', 'message', Form_Submission_Error::TYPE_VALIDATION );
+
+		$this->assertTrue( $system_error->is_system_type() );
+		$this->assertFalse( $validation_error->is_system_type() );
+	}
+
+	/**
+	 * Test static is_system_error method with system error.
+	 */
+	public function test_static_is_system_error_with_system_error() {
+		$system_error = new Form_Submission_Error( 'code', 'message', Form_Submission_Error::TYPE_SYSTEM );
+
+		$this->assertTrue( Form_Submission_Error::is_system_error( $system_error ) );
+	}
+
+	/**
+	 * Test static is_system_error method with validation error.
+	 */
+	public function test_static_is_system_error_with_validation_error() {
+		$validation_error = new Form_Submission_Error( 'code', 'message', Form_Submission_Error::TYPE_VALIDATION );
+
+		$this->assertFalse( Form_Submission_Error::is_system_error( $validation_error ) );
+	}
+
+	/**
+	 * Test static is_system_error method with non-Form_Submission_Error.
+	 */
+	public function test_static_is_system_error_with_non_form_submission_error() {
+		$wp_error = new \WP_Error( 'code', 'message' );
+		$string   = 'not an error';
+		$null     = null;
+
+		$this->assertFalse( Form_Submission_Error::is_system_error( $wp_error ) );
+		$this->assertFalse( Form_Submission_Error::is_system_error( $string ) );
+		$this->assertFalse( Form_Submission_Error::is_system_error( $null ) );
+	}
+
+	/**
+	 * Test static is_validation_error method with validation error.
+	 */
+	public function test_static_is_validation_error_with_validation_error() {
+		$validation_error = new Form_Submission_Error( 'code', 'message', Form_Submission_Error::TYPE_VALIDATION );
+
+		$this->assertTrue( Form_Submission_Error::is_validation_error( $validation_error ) );
+	}
+
+	/**
+	 * Test static is_validation_error method with system error.
+	 */
+	public function test_static_is_validation_error_with_system_error() {
+		$system_error = new Form_Submission_Error( 'code', 'message', Form_Submission_Error::TYPE_SYSTEM );
+
+		$this->assertFalse( Form_Submission_Error::is_validation_error( $system_error ) );
+	}
+
+	/**
+	 * Test static is_validation_error method with non-Form_Submission_Error.
+	 */
+	public function test_static_is_validation_error_with_non_form_submission_error() {
+		$wp_error = new \WP_Error( 'code', 'message' );
+		$string   = 'not an error';
+		$null     = null;
+
+		$this->assertFalse( Form_Submission_Error::is_validation_error( $wp_error ) );
+		$this->assertFalse( Form_Submission_Error::is_validation_error( $string ) );
+		$this->assertFalse( Form_Submission_Error::is_validation_error( $null ) );
+	}
+
+	/**
+	 * Test validation_error factory method.
+	 */
+	public function test_validation_error_factory() {
+		$error = Form_Submission_Error::validation_error( 'validation_code', 'Validation message' );
+
+		$this->assertInstanceOf( Form_Submission_Error::class, $error );
+		$this->assertEquals( 'validation_code', $error->get_error_code() );
+		$this->assertEquals( 'Validation message', $error->get_error_message() );
+		$this->assertEquals( Form_Submission_Error::TYPE_VALIDATION, $error->get_error_type() );
+		$this->assertTrue( $error->is_validation_type() );
+		$this->assertFalse( $error->is_system_type() );
+	}
+
+	/**
+	 * Test system_error factory method.
+	 */
+	public function test_system_error_factory() {
+		$error = Form_Submission_Error::system_error( 'system_code', 'System message' );
+
+		$this->assertInstanceOf( Form_Submission_Error::class, $error );
+		$this->assertEquals( 'system_code', $error->get_error_code() );
+		$this->assertEquals( 'System message', $error->get_error_message() );
+		$this->assertEquals( Form_Submission_Error::TYPE_SYSTEM, $error->get_error_type() );
+		$this->assertTrue( $error->is_system_type() );
+		$this->assertFalse( $error->is_validation_type() );
+	}
+
+	/**
+	 * Test that Form_Submission_Error extends WP_Error.
+	 */
+	public function test_extends_wp_error() {
+		$error = new Form_Submission_Error( 'code', 'message' );
+
+		$this->assertInstanceOf( \WP_Error::class, $error );
+	}
+
+	/**
+	 * Test that Form_Submission_Error can use WP_Error methods.
+	 */
+	public function test_wp_error_methods() {
+		$error = new Form_Submission_Error( 'code', 'message' );
+
+		// Test adding additional errors
+		$error->add( 'additional_code', 'Additional message' );
+
+		$this->assertTrue( $error->has_errors() );
+		$this->assertEquals( 'code', $error->get_error_code() );
+		$this->assertEquals( 'message', $error->get_error_message() );
+		$this->assertEquals( 'Additional message', $error->get_error_message( 'additional_code' ) );
+	}
+
+	/**
+	 * Test multiple errors with same Form_Submission_Error instance.
+	 */
+	public function test_multiple_errors_same_instance() {
+		$error = Form_Submission_Error::validation_error( 'first_code', 'First message' );
+		$error->add( 'second_code', 'Second message' );
+
+		$this->assertTrue( $error->is_validation_type() );
+		$this->assertEquals( 'first_code', $error->get_error_code() );
+		$this->assertEquals( 'First message', $error->get_error_message() );
+		$this->assertEquals( 'Second message', $error->get_error_message( 'second_code' ) );
+		$this->assertCount( 2, $error->get_error_codes() );
+	}
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Resolves FORMS-340
Related to FORMS-341

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Adds error codes for submission errors that are not validation errors.
These error codes are then logged in the backend, sent as part of the response payload and printed with `debug` so we can quickly check what is going on.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Test with 194668-ghe-Automattic/wpcom
* Force an error (easiest way is to edit the `process_form_submission` function to force an error return)
* Check that there is a debug message with the error code
* Check the network request, the error code should be present in the response body
* Check logstash for your blog id
