### PR TITLE
Charts: Extract common legend container logic into shared helper

### DIFF
--- a/projects/js-packages/charts/changelog/charts-41-legends-extract-common-container-logic-into-a-shared-helper
+++ b/projects/js-packages/charts/changelog/charts-41-legends-extract-common-container-logic-into-a-shared-helper
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Charts: legends - extract common container logic to shared helper

--- a/projects/js-packages/charts/src/components/bar-chart/bar-chart.module.scss
+++ b/projects/js-packages/charts/src/components/bar-chart/bar-chart.module.scss
@@ -1,12 +1,10 @@
 .bar-chart {
-	display: flex;
-	flex-direction: column;
 
 	svg {
 		overflow: visible;
 	}
 
-	&-legend {
+	&__legend {
 		margin-top: 1rem;
 	}
 }

--- a/projects/js-packages/charts/src/components/bar-chart/bar-chart.tsx
+++ b/projects/js-packages/charts/src/components/bar-chart/bar-chart.tsx
@@ -9,6 +9,7 @@ import {
 	useZeroValueDisplay,
 	useChartMargin,
 	useElementHeight,
+	useLegendLayout,
 } from '../../hooks';
 import {
 	GlobalChartsProvider,
@@ -18,6 +19,7 @@ import {
 	useGlobalChartsTheme,
 	GlobalChartsContext,
 } from '../../providers';
+import containerStyles from '../../styles/chart-container.module.scss';
 import { attachSubComponents } from '../../utils';
 import { Legend, useChartLegendItems } from '../legend';
 import { SingleChartContext } from '../private/single-chart-context';
@@ -276,6 +278,15 @@ const BarChartInternal: FC< BarChartProps > = ( {
 		return generatedStyles;
 	}, [ selectedIndex, data, chartId ] );
 
+	// Use the legend layout hook for consistent calculations
+	const { adjustedChartHeight, adjustedMargin, containerClassName } = useLegendLayout( {
+		height,
+		showLegend,
+		legendPosition,
+		legendHeight,
+		defaultMargin: { ...defaultMargin, ...margin },
+	} );
+
 	// Validate data first
 	const error = validateData( dataSorted );
 	const isDataValid = ! error;
@@ -310,19 +321,23 @@ const BarChartInternal: FC< BarChartProps > = ( {
 			value={ {
 				chartId,
 				chartWidth: width,
-				chartHeight: height - ( showLegend ? legendHeight : 0 ),
+				chartHeight: adjustedChartHeight,
 			} }
 		>
 			<div
-				className={ clsx( 'bar-chart', styles[ 'bar-chart' ], className ) }
+				className={ clsx(
+					'bar-chart',
+					styles[ 'bar-chart' ],
+					containerStyles[ 'chart-container' ],
+					containerStyles[ containerClassName ],
+					className
+				) }
 				data-testid="bar-chart"
 				role="grid"
 				aria-label={ __( 'Bar chart', 'jetpack-charts' ) }
 				style={ {
 					width,
 					height,
-					display: 'flex',
-					flexDirection: showLegend && legendPosition === 'top' ? 'column-reverse' : 'column',
 				} }
 				tabIndex={ 0 }
 				onKeyDown={ onChartKeyDown }
@@ -334,14 +349,8 @@ const BarChartInternal: FC< BarChartProps > = ( {
 				<XYChart
 					theme={ theme }
 					width={ width }
-					height={ height - ( showLegend ? legendHeight : 0 ) }
-					margin={ {
-						...defaultMargin,
-						...margin,
-						...( showLegend && legendPosition === 'top'
-							? { top: ( defaultMargin.top || 0 ) + legendHeight }
-							: {} ),
-					} }
+					height={ adjustedChartHeight }
+					margin={ adjustedMargin }
 					xScale={ chartOptions.xScale }
 					yScale={ chartOptions.yScale }
 					horizontal={ horizontal }
@@ -376,7 +385,7 @@ const BarChartInternal: FC< BarChartProps > = ( {
 					{ allSeriesHidden ? (
 						<text
 							x={ width / 2 }
-							y={ ( height - ( showLegend ? legendHeight : 0 ) ) / 2 }
+							y={ adjustedChartHeight / 2 }
 							textAnchor="middle"
 							fill={ providerTheme.gridStyles?.stroke || '#ccc' }
 							fontSize="14"

--- a/projects/js-packages/charts/src/components/leaderboard-chart/leaderboard-chart.tsx
+++ b/projects/js-packages/charts/src/components/leaderboard-chart/leaderboard-chart.tsx
@@ -16,6 +16,7 @@ import {
 	useGlobalChartsContext,
 	useGlobalChartsTheme,
 } from '../../providers';
+import containerStyles from '../../styles/chart-container.module.scss';
 import { formatMetricValue, attachSubComponents } from '../../utils';
 import { Legend } from '../legend';
 import { useChartChildren } from '../private/chart-composition';
@@ -234,11 +235,19 @@ const LeaderboardChartInternal: FC< LeaderboardChartProps > = ( {
 			} }
 		>
 			<div
-				className={ clsx( styles.leaderboardChart, loading && styles.loading, className ) }
+				className={ clsx(
+					styles.leaderboardChart,
+					containerStyles[ 'chart-container' ],
+					containerStyles[
+						showLegend && legendPosition === 'top'
+							? 'chart-container--legend-top'
+							: 'chart-container--legend-bottom'
+					],
+					loading && styles.loading,
+					className
+				) }
 				style={ {
 					...style,
-					display: 'flex',
-					flexDirection: showLegend && legendPosition === 'top' ? 'column-reverse' : 'column',
 					gap: showLegend ? '16px' : '0',
 				} }
 			>

--- a/projects/js-packages/charts/src/components/line-chart/line-chart.tsx
+++ b/projects/js-packages/charts/src/components/line-chart/line-chart.tsx
@@ -12,6 +12,7 @@ import {
 	useChartDataTransform,
 	useChartMargin,
 	useElementHeight,
+	useLegendLayout,
 } from '../../hooks';
 import {
 	GlobalChartsProvider,
@@ -21,6 +22,7 @@ import {
 	useGlobalChartsContext,
 	useGlobalChartsTheme,
 } from '../../providers';
+import containerStyles from '../../styles/chart-container.module.scss';
 import { attachSubComponents } from '../../utils';
 import { Legend, useChartLegendItems } from '../legend';
 import { DefaultGlyph } from '../private/default-glyph';
@@ -379,6 +381,15 @@ const LineChartInternal = forwardRef< SingleChartRef, LineChartProps >(
 
 		const defaultMargin = useChartMargin( height, chartOptions, dataSorted, theme );
 
+		// Use the legend layout hook for consistent calculations
+		const { adjustedChartHeight, adjustedMargin, containerClassName } = useLegendLayout( {
+			height,
+			showLegend,
+			legendPosition,
+			legendHeight,
+			defaultMargin: { ...defaultMargin, ...margin },
+		} );
+
 		const error = validateData( dataSorted );
 		const isDataValid = ! error;
 
@@ -433,17 +444,21 @@ const LineChartInternal = forwardRef< SingleChartRef, LineChartProps >(
 					chartId,
 					chartRef: internalChartRef,
 					chartWidth: width,
-					chartHeight: height - ( showLegend ? legendHeight : 0 ),
+					chartHeight: adjustedChartHeight,
 				} }
 			>
 				<div
-					className={ clsx( 'line-chart', styles[ 'line-chart' ], className ) }
+					className={ clsx(
+						'line-chart',
+						styles[ 'line-chart' ],
+						containerStyles[ 'chart-container' ],
+						containerStyles[ containerClassName ],
+						className
+					) }
 					data-testid="line-chart"
 					style={ {
 						width,
 						height,
-						display: 'flex',
-						flexDirection: showLegend && legendPosition === 'top' ? 'column-reverse' : 'column',
 						position: 'relative',
 					} }
 				>
@@ -459,14 +474,8 @@ const LineChartInternal = forwardRef< SingleChartRef, LineChartProps >(
 						<XYChart
 							theme={ theme }
 							width={ width }
-							height={ height - ( showLegend ? legendHeight : 0 ) }
-							margin={ {
-								...defaultMargin,
-								...margin,
-								...( showLegend && legendPosition === 'top'
-									? { top: ( defaultMargin.top || 0 ) + legendHeight }
-									: {} ),
-							} }
+							height={ adjustedChartHeight }
+							margin={ adjustedMargin }
 							// xScale and yScale could be set in Axis as well, but they are `scale` props there.
 							xScale={ chartOptions.xScale }
 							yScale={ chartOptions.yScale }
@@ -483,7 +492,7 @@ const LineChartInternal = forwardRef< SingleChartRef, LineChartProps >(
 							{ allSeriesHidden ? (
 								<text
 									x={ width / 2 }
-									y={ ( height - ( showLegend ? legendHeight : 0 ) ) / 2 }
+									y={ adjustedChartHeight / 2 }
 									textAnchor="middle"
 									fill={ providerTheme.gridStyles?.stroke || '#ccc' }
 									fontSize="14"

--- a/projects/js-packages/charts/src/components/pie-chart/pie-chart.tsx
+++ b/projects/js-packages/charts/src/components/pie-chart/pie-chart.tsx
@@ -5,7 +5,7 @@ import { useTooltip, useTooltipInPortal } from '@visx/tooltip';
 import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
 import { useCallback, useContext, useMemo } from 'react';
-import { useElementHeight, useInteractiveLegendData } from '../../hooks';
+import { useElementHeight, useInteractiveLegendData, useLegendLayout } from '../../hooks';
 import {
 	GlobalChartsProvider,
 	useChartId,
@@ -14,6 +14,7 @@ import {
 	useGlobalChartsTheme,
 	GlobalChartsContext,
 } from '../../providers';
+import containerStyles from '../../styles/chart-container.module.scss';
 import { attachSubComponents } from '../../utils';
 import { getStringWidth } from '../../visx/text';
 import { Legend, useChartLegendItems } from '../legend';
@@ -223,6 +224,19 @@ const PieChartInternal = ( {
 		metadata: chartMetadata,
 	} );
 
+	const width = size;
+	const height = size;
+
+	// Use the legend layout hook for consistent calculations
+	const { adjustedChartHeight, containerClassName } = useLegendLayout( {
+		height,
+		showLegend,
+		legendPosition,
+		legendHeight,
+	} );
+
+	const adjustedHeight = adjustedChartHeight;
+
 	if ( ! isValid ) {
 		return (
 			<div className={ clsx( 'pie-chart', styles[ 'pie-chart' ], className ) }>
@@ -230,10 +244,6 @@ const PieChartInternal = ( {
 			</div>
 		);
 	}
-
-	const width = size;
-	const height = size;
-	const adjustedHeight = showLegend && legendPosition === 'top' ? height - legendHeight : height;
 
 	// Calculate radius based on width/height
 	const radius = Math.min( width, adjustedHeight ) / 2;
@@ -278,11 +288,13 @@ const PieChartInternal = ( {
 		>
 			<div
 				ref={ containerRef }
-				className={ clsx( 'pie-chart', styles[ 'pie-chart' ], className ) }
-				style={ {
-					display: 'flex',
-					flexDirection: showLegend && legendPosition === 'top' ? 'column-reverse' : 'column',
-				} }
+				className={ clsx(
+					'pie-chart',
+					styles[ 'pie-chart' ],
+					containerStyles[ 'chart-container' ],
+					containerStyles[ containerClassName ],
+					className
+				) }
 			>
 				<svg
 					viewBox={ `0 0 ${ width } ${ adjustedHeight }` }

--- a/projects/js-packages/charts/src/components/pie-chart/pie-chart.tsx
+++ b/projects/js-packages/charts/src/components/pie-chart/pie-chart.tsx
@@ -235,8 +235,6 @@ const PieChartInternal = ( {
 		legendHeight,
 	} );
 
-	const adjustedHeight = adjustedChartHeight;
-
 	if ( ! isValid ) {
 		return (
 			<div className={ clsx( 'pie-chart', styles[ 'pie-chart' ], className ) }>
@@ -246,11 +244,11 @@ const PieChartInternal = ( {
 	}
 
 	// Calculate radius based on width/height
-	const radius = Math.min( width, adjustedHeight ) / 2;
+	const radius = Math.min( width, adjustedChartHeight ) / 2;
 
 	// Center the chart in the available space
 	const centerX = width / 2;
-	const centerY = adjustedHeight / 2;
+	const centerY = adjustedChartHeight / 2;
 
 	// Calculate the angle between each (use original data length for consistent spacing)
 	const padAngle = gapScale * ( ( 2 * Math.PI ) / data.length );
@@ -283,7 +281,7 @@ const PieChartInternal = ( {
 			value={ {
 				chartId,
 				chartWidth: width,
-				chartHeight: adjustedHeight,
+				chartHeight: adjustedChartHeight,
 			} }
 		>
 			<div
@@ -297,10 +295,10 @@ const PieChartInternal = ( {
 				) }
 			>
 				<svg
-					viewBox={ `0 0 ${ width } ${ adjustedHeight }` }
+					viewBox={ `0 0 ${ width } ${ adjustedChartHeight }` }
 					preserveAspectRatio="xMidYMid meet"
 					width={ width }
-					height={ adjustedHeight }
+					height={ adjustedChartHeight }
 				>
 					<Group top={ centerY } left={ centerX }>
 						{ allSegmentsHidden ? (

--- a/projects/js-packages/charts/src/components/pie-semi-circle-chart/pie-semi-circle-chart.tsx
+++ b/projects/js-packages/charts/src/components/pie-semi-circle-chart/pie-semi-circle-chart.tsx
@@ -262,8 +262,6 @@ const PieSemiCircleChartInternal: FC< PieSemiCircleChartProps > = ( {
 		legendHeight,
 	} );
 
-	const chartHeight = adjustedChartHeight;
-
 	if ( ! isValid ) {
 		return (
 			<div className={ styles[ 'pie-semi-circle-chart' ] }>
@@ -275,7 +273,7 @@ const PieSemiCircleChartInternal: FC< PieSemiCircleChartProps > = ( {
 			</div>
 		);
 	}
-	const radius = Math.min( width / 2, chartHeight );
+	const radius = Math.min( width / 2, adjustedChartHeight );
 	const innerRadius = radius * ( 1 - thickness );
 
 	// Map data with index for color assignment
@@ -314,11 +312,11 @@ const PieSemiCircleChartInternal: FC< PieSemiCircleChartProps > = ( {
 				<svg
 					width={ width }
 					height={ radius }
-					viewBox={ `0 0 ${ width } ${ chartHeight }` }
+					viewBox={ `0 0 ${ width } ${ adjustedChartHeight }` }
 					data-testid="pie-chart-svg"
 				>
 					{ /* Main chart group centered horizontally and positioned at bottom */ }
-					<Group top={ chartHeight } left={ width / 2 }>
+					<Group top={ adjustedChartHeight } left={ width / 2 }>
 						{ allSegmentsHidden ? (
 							<text
 								textAnchor="middle"

--- a/projects/js-packages/charts/src/components/pie-semi-circle-chart/pie-semi-circle-chart.tsx
+++ b/projects/js-packages/charts/src/components/pie-semi-circle-chart/pie-semi-circle-chart.tsx
@@ -6,7 +6,7 @@ import { useTooltip, useTooltipInPortal } from '@visx/tooltip';
 import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
 import { useCallback, useContext, useMemo } from 'react';
-import { useElementHeight, useInteractiveLegendData } from '../../hooks';
+import { useElementHeight, useInteractiveLegendData, useLegendLayout } from '../../hooks';
 import {
 	GlobalChartsProvider,
 	useChartId,
@@ -14,6 +14,7 @@ import {
 	useGlobalChartsContext,
 	GlobalChartsContext,
 } from '../../providers';
+import containerStyles from '../../styles/chart-container.module.scss';
 import { attachSubComponents } from '../../utils';
 import { Legend, useChartLegendItems } from '../legend';
 import { ChartSVG, ChartHTML, useChartChildren } from '../private/chart-composition';
@@ -249,6 +250,20 @@ const PieSemiCircleChartInternal: FC< PieSemiCircleChartProps > = ( {
 		metadata: chartMetadata,
 	} );
 
+	// Calculate chart dimensions
+	// TODO: we might want to accept height as a prop in the future, because the height of container might not always be enough.
+	const height = width / 2;
+
+	// Use the legend layout hook for consistent calculations
+	const { adjustedChartHeight, containerClassName } = useLegendLayout( {
+		height,
+		showLegend,
+		legendPosition,
+		legendHeight,
+	} );
+
+	const chartHeight = adjustedChartHeight;
+
 	if ( ! isValid ) {
 		return (
 			<div className={ styles[ 'pie-semi-circle-chart' ] }>
@@ -260,12 +275,6 @@ const PieSemiCircleChartInternal: FC< PieSemiCircleChartProps > = ( {
 			</div>
 		);
 	}
-
-	// Calculate chart dimensions
-	// TODO: we might want to accept height as a prop in the future, because the height of container might not always be enough.
-	const height = width / 2;
-	// The chart only takes the height minus the legend height.
-	const chartHeight = height - ( showLegend && legendPosition === 'top' ? legendHeight : 0 );
 	const radius = Math.min( width / 2, chartHeight );
 	const innerRadius = radius * ( 1 - thickness );
 
@@ -293,12 +302,14 @@ const PieSemiCircleChartInternal: FC< PieSemiCircleChartProps > = ( {
 		>
 			<div
 				ref={ containerRef }
-				className={ clsx( 'pie-semi-circle-chart', styles[ 'pie-semi-circle-chart' ], className ) }
+				className={ clsx(
+					'pie-semi-circle-chart',
+					styles[ 'pie-semi-circle-chart' ],
+					containerStyles[ 'chart-container' ],
+					containerStyles[ containerClassName ],
+					className
+				) }
 				data-testid="pie-chart-container"
-				style={ {
-					display: 'flex',
-					flexDirection: showLegend && legendPosition === 'top' ? 'column-reverse' : 'column',
-				} }
 			>
 				<svg
 					width={ width }

--- a/projects/js-packages/charts/src/hooks/index.ts
+++ b/projects/js-packages/charts/src/hooks/index.ts
@@ -7,3 +7,4 @@ export { useElementHeight } from './use-element-height';
 export { useTextTruncation } from './use-text-truncation';
 export { useZeroValueDisplay } from './use-zero-value-display';
 export { useInteractiveLegendData } from './use-interactive-legend-data';
+export { useLegendLayout } from './use-legend-layout';

--- a/projects/js-packages/charts/src/hooks/use-legend-layout.ts
+++ b/projects/js-packages/charts/src/hooks/use-legend-layout.ts
@@ -64,5 +64,15 @@ export const useLegendLayout = ( {
 			adjustedMargin,
 			containerClassName,
 		};
-	}, [ height, showLegend, legendPosition, legendHeight, defaultMargin ] );
+		// eslint-disable-next-line react-hooks/exhaustive-deps -- Using individual margin properties to avoid object reference changes
+	}, [
+		height,
+		showLegend,
+		legendPosition,
+		legendHeight,
+		defaultMargin.top,
+		defaultMargin.right,
+		defaultMargin.bottom,
+		defaultMargin.left,
+	] );
 };

--- a/projects/js-packages/charts/src/hooks/use-legend-layout.ts
+++ b/projects/js-packages/charts/src/hooks/use-legend-layout.ts
@@ -17,10 +17,10 @@ interface UseLegendLayoutParams {
 interface UseLegendLayoutReturn {
 	adjustedChartHeight: number;
 	adjustedMargin: {
-		top?: number;
-		right?: number;
-		bottom?: number;
-		left?: number;
+		top: number;
+		right: number;
+		bottom: number;
+		left: number;
 	};
 	containerClassName: string;
 }
@@ -44,14 +44,14 @@ export const useLegendLayout = ( {
 		const adjustedChartHeight =
 			showLegend && legendPosition === 'top' ? height - legendHeight : height;
 
-		// Calculate adjusted margin for top legend position
-		const adjustedMargin =
-			showLegend && legendPosition === 'top'
-				? {
-						...defaultMargin,
-						top: ( defaultMargin.top || 0 ) + legendHeight,
-				  }
-				: defaultMargin;
+		// Calculate adjusted margin for top legend position, ensuring all properties are defined
+		const adjustedMargin = {
+			top:
+				( defaultMargin.top || 0 ) + ( showLegend && legendPosition === 'top' ? legendHeight : 0 ),
+			right: defaultMargin.right || 0,
+			bottom: defaultMargin.bottom || 0,
+			left: defaultMargin.left || 0,
+		};
 
 		// Determine container class name
 		const containerClassName =
@@ -64,7 +64,6 @@ export const useLegendLayout = ( {
 			adjustedMargin,
 			containerClassName,
 		};
-		// eslint-disable-next-line react-hooks/exhaustive-deps -- Using individual margin properties to avoid object reference changes
 	}, [
 		height,
 		showLegend,

--- a/projects/js-packages/charts/src/hooks/use-legend-layout.ts
+++ b/projects/js-packages/charts/src/hooks/use-legend-layout.ts
@@ -2,29 +2,10 @@ import { useMemo } from 'react';
 import type { LegendPosition } from '../types';
 
 interface UseLegendLayoutParams {
-	/**
-	 * Total height of the chart container
-	 */
 	height: number;
-
-	/**
-	 * Whether the legend is shown
-	 */
 	showLegend: boolean;
-
-	/**
-	 * Position of the legend
-	 */
 	legendPosition: LegendPosition;
-
-	/**
-	 * Measured height of the legend element
-	 */
 	legendHeight: number;
-
-	/**
-	 * Default margin for the chart
-	 */
 	defaultMargin?: {
 		top?: number;
 		right?: number;
@@ -34,42 +15,22 @@ interface UseLegendLayoutParams {
 }
 
 interface UseLegendLayoutReturn {
-	/**
-	 * Adjusted height for the chart area (excluding legend)
-	 */
 	adjustedChartHeight: number;
-
-	/**
-	 * Adjusted margin object for the chart
-	 */
 	adjustedMargin: {
 		top?: number;
 		right?: number;
 		bottom?: number;
 		left?: number;
 	};
-
-	/**
-	 * CSS class name for the chart container based on legend position
-	 */
 	containerClassName: string;
 }
 
 /**
- * Hook to calculate layout adjustments for charts with legends.
- * Abstracts the logic for adjusting chart height and margins based on legend position.
+ * Calculates layout adjustments for charts with legends.
+ * Handles chart height reduction and margin adjustments when legend is positioned at top.
  *
- * @param {UseLegendLayoutParams} params                      - Layout parameters
- * @param {number}                params.height               - Total height of the chart container
- * @param {boolean}               params.showLegend           - Whether the legend is shown
- * @param {LegendPosition}        params.legendPosition       - Position of the legend
- * @param {number}                params.legendHeight         - Measured height of the legend element
- * @param {object}                params.defaultMargin        - Default margin for the chart
- * @param {number}                params.defaultMargin.top    - Top margin
- * @param {number}                params.defaultMargin.right  - Right margin
- * @param {number}                params.defaultMargin.bottom - Bottom margin
- * @param {number}                params.defaultMargin.left   - Left margin
- * @return {UseLegendLayoutReturn} Layout adjustments for the chart
+ * @param {UseLegendLayoutParams} params - Layout parameters including height, legend position, and margins
+ * @return {UseLegendLayoutReturn} Adjusted height, margins, and CSS class name for container
  */
 export const useLegendLayout = ( {
 	height,

--- a/projects/js-packages/charts/src/hooks/use-legend-layout.ts
+++ b/projects/js-packages/charts/src/hooks/use-legend-layout.ts
@@ -1,0 +1,107 @@
+import { useMemo } from 'react';
+import type { LegendPosition } from '../types';
+
+interface UseLegendLayoutParams {
+	/**
+	 * Total height of the chart container
+	 */
+	height: number;
+
+	/**
+	 * Whether the legend is shown
+	 */
+	showLegend: boolean;
+
+	/**
+	 * Position of the legend
+	 */
+	legendPosition: LegendPosition;
+
+	/**
+	 * Measured height of the legend element
+	 */
+	legendHeight: number;
+
+	/**
+	 * Default margin for the chart
+	 */
+	defaultMargin?: {
+		top?: number;
+		right?: number;
+		bottom?: number;
+		left?: number;
+	};
+}
+
+interface UseLegendLayoutReturn {
+	/**
+	 * Adjusted height for the chart area (excluding legend)
+	 */
+	adjustedChartHeight: number;
+
+	/**
+	 * Adjusted margin object for the chart
+	 */
+	adjustedMargin: {
+		top?: number;
+		right?: number;
+		bottom?: number;
+		left?: number;
+	};
+
+	/**
+	 * CSS class name for the chart container based on legend position
+	 */
+	containerClassName: string;
+}
+
+/**
+ * Hook to calculate layout adjustments for charts with legends.
+ * Abstracts the logic for adjusting chart height and margins based on legend position.
+ *
+ * @param {UseLegendLayoutParams} params                      - Layout parameters
+ * @param {number}                params.height               - Total height of the chart container
+ * @param {boolean}               params.showLegend           - Whether the legend is shown
+ * @param {LegendPosition}        params.legendPosition       - Position of the legend
+ * @param {number}                params.legendHeight         - Measured height of the legend element
+ * @param {object}                params.defaultMargin        - Default margin for the chart
+ * @param {number}                params.defaultMargin.top    - Top margin
+ * @param {number}                params.defaultMargin.right  - Right margin
+ * @param {number}                params.defaultMargin.bottom - Bottom margin
+ * @param {number}                params.defaultMargin.left   - Left margin
+ * @return {UseLegendLayoutReturn} Layout adjustments for the chart
+ */
+export const useLegendLayout = ( {
+	height,
+	showLegend,
+	legendPosition,
+	legendHeight,
+	defaultMargin = {},
+}: UseLegendLayoutParams ): UseLegendLayoutReturn => {
+	return useMemo( () => {
+		// Calculate adjusted chart height
+		const adjustedChartHeight =
+			showLegend && legendPosition === 'top' ? height - legendHeight : height;
+
+		// Calculate adjusted margin for top legend position
+		const adjustedMargin =
+			showLegend && legendPosition === 'top'
+				? {
+						...defaultMargin,
+						top: ( defaultMargin.top || 0 ) + legendHeight,
+				  }
+				: defaultMargin;
+
+		// Determine container class name
+		const containerClassName =
+			showLegend && legendPosition === 'top'
+				? 'chart-container--legend-top'
+				: 'chart-container--legend-bottom';
+
+		return {
+			adjustedChartHeight,
+			adjustedMargin,
+			containerClassName,
+		};
+	}, [ height, showLegend, legendPosition, legendHeight, defaultMargin ] );
+};

--- a/projects/js-packages/charts/src/styles/chart-container.module.scss
+++ b/projects/js-packages/charts/src/styles/chart-container.module.scss
@@ -1,0 +1,16 @@
+/**
+ * Shared chart container styles for legend positioning
+ * Using BEM naming convention
+ */
+
+.chart-container {
+	display: flex;
+
+	&--legend-top {
+		flex-direction: column-reverse;
+	}
+
+	&--legend-bottom {
+		flex-direction: column;
+	}
+}

--- a/projects/js-packages/charts/src/types.ts
+++ b/projects/js-packages/charts/src/types.ts
@@ -15,6 +15,8 @@ export type Optional< T, K extends keyof T > = Pick< Partial< T >, K > & Omit< T
 
 export type OrientationType = ValueOf< typeof Orientation >;
 
+export type LegendPosition = 'top' | 'bottom';
+
 export type AnnotationStyles = {
 	circleSubject?: Omit< CircleSubjectProps, 'x' | 'y' > & { fill?: string };
 	lineSubject?: Omit< LineSubjectProps, 'x' | 'y' >;
@@ -342,7 +344,7 @@ export type BaseChartProps< T = DataPoint | DataPointDate | LeaderboardEntry > =
 	 * Legend position (where the legend appears)
 	 * TODO: Add 'left' | 'right' positioning support in future implementation
 	 */
-	legendPosition?: 'top' | 'bottom';
+	legendPosition?: LegendPosition;
 	/**
 	 * Legend alignment within its position
 	 */


### PR DESCRIPTION
## Proposed changes:

* Add shared CSS module (`chart-container.module.scss`) for chart container flex layout using BEM convention
* Create `useLegendLayout` hook to centralize chart height and margin adjustment calculations for legend positioning
* Refactor BarChart to use shared legend layout utilities, removing duplicated inline styles
* Refactor LineChart to use shared legend layout utilities, removing duplicated inline styles
* Refactor PieChart to use shared legend layout utilities, removing duplicated inline styles
* Refactor PieSemiCircleChart to use shared legend layout utilities, removing duplicated inline styles
* Refactor LeaderboardChart to use shared container layout CSS classes
* Export `useLegendLayout` from hooks index

This refactoring eliminates ~20 lines of duplicated legend positioning logic across 5 chart components, improving maintainability and ensuring consistent behavior.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?

No, it does not.

## Testing instructions:

### Automated Tests
* Run `pnpm test` - all 530 tests should pass
* Run `pnpm lint` - no linting errors should be present

### Manual Testing - Legend Positioning
For each chart type (BarChart, LineChart, PieChart, PieSemiCircleChart, LeaderboardChart):

1. **Test Bottom Legend (default)**:
   - Set `showLegend={true}` and `legendPosition="bottom"`
   - Verify legend appears below the chart
   - Verify chart height is correctly adjusted
   - Verify no layout issues or overlap

2. **Test Top Legend**:
   - Set `showLegend={true}` and `legendPosition="top"`
   - Verify legend appears above the chart (using `column-reverse` flex direction)
   - Verify chart height is reduced by legend height
   - Verify chart margin top is increased by legend height
   - Verify no layout issues or overlap

3. **Test No Legend**:
   - Set `showLegend={false}`
   - Verify chart uses full height
   - Verify no margin adjustments applied

### Visual Regression Testing
* Compare chart rendering before/after changes in Storybook
* Verify tooltips, interactive legends, and keyboard navigation still work
* Check that all chart variants (horizontal bars, with patterns, etc.) render correctly
* Ensure no visual differences in chart appearance or legend styling