### PR TITLE
Update user agent info capabilities

### DIFF
--- a/projects/packages/device-detection/changelog/update-user-agent-info-capabilities
+++ b/projects/packages/device-detection/changelog/update-user-agent-info-capabilities
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Improved user agent string parsing functionality and added browser detection for six more browsers (Samsung Internet, UC, Yandex, Vivaldi, MIUI, Amazon Silk)

--- a/projects/packages/device-detection/src/class-user-agent-info.php
+++ b/projects/packages/device-detection/src/class-user-agent-info.php
@@ -242,7 +242,7 @@ class User_Agent_Info {
 	 */
 	public function get_platform() {
 		if ( isset( $this->platform ) ) {
-				return $this->platform;
+			return $this->platform;
 		}
 
 		if ( empty( $this->useragent ) ) {
@@ -484,13 +484,14 @@ class User_Agent_Info {
 	 * @return bool
 	 */
 	public function is_tablet() {
+		$ua = $this->useragent;
 		return ( 0 // Never true, but makes it easier to manage our list of tablet conditions.
-				|| self::is_ipad()
-				|| self::is_android_tablet()
-				|| self::is_blackberry_tablet()
-				|| self::is_kindle_fire()
-				|| self::is_MaemoTablet()
-				|| self::is_TouchPad()
+				|| self::is_ipad( $ua )
+				|| self::is_android_tablet( $ua )
+				|| self::is_blackberry_tablet( $ua )
+				|| self::is_kindle_fire( $ua )
+				|| self::is_MaemoTablet( $ua )
+				|| self::is_TouchPad( $ua )
 		);
 	}
 

--- a/projects/packages/device-detection/src/class-user-agent-info.php
+++ b/projects/packages/device-detection/src/class-user-agent-info.php
@@ -152,7 +152,7 @@ class User_Agent_Info {
 		if ( $ua ) {
 			$this->useragent = $ua;
 		} elseif ( ! empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
-			$this->useragent = strtolower( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This class is all about validating.
+			$this->useragent = wp_unslash( $_SERVER['HTTP_USER_AGENT'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This class is all about validating.
 		}
 	}
 
@@ -249,17 +249,18 @@ class User_Agent_Info {
 			return false;
 		}
 
-		if ( strpos( $this->useragent, 'windows phone' ) !== false ) {
-				$this->platform = self::PLATFORM_WINDOWS;
-		} elseif ( strpos( $this->useragent, 'windows ce' ) !== false ) {
+		$ua = strtolower( $this->useragent );
+		if ( strpos( $ua, 'windows phone' ) !== false ) {
 			$this->platform = self::PLATFORM_WINDOWS;
-		} elseif ( strpos( $this->useragent, 'ipad' ) !== false ) {
+		} elseif ( strpos( $ua, 'windows ce' ) !== false ) {
+			$this->platform = self::PLATFORM_WINDOWS;
+		} elseif ( strpos( $ua, 'ipad' ) !== false ) {
 			$this->platform = self::PLATFORM_IPAD;
-		} elseif ( strpos( $this->useragent, 'ipod' ) !== false ) {
+		} elseif ( strpos( $ua, 'ipod' ) !== false ) {
 			$this->platform = self::PLATFORM_IPOD;
-		} elseif ( strpos( $this->useragent, 'iphone' ) !== false ) {
+		} elseif ( strpos( $ua, 'iphone' ) !== false ) {
 			$this->platform = self::PLATFORM_IPHONE;
-		} elseif ( strpos( $this->useragent, 'android' ) !== false ) {
+		} elseif ( strpos( $ua, 'android' ) !== false ) {
 			if ( static::is_android_tablet() ) {
 				$this->platform = self::PLATFORM_ANDROID_TABLET;
 			} else {
@@ -269,7 +270,7 @@ class User_Agent_Info {
 			$this->platform = self::PLATFORM_ANDROID_TABLET;
 		} elseif ( static::is_blackberry_10() ) {
 			$this->platform = self::PLATFORM_BLACKBERRY_10;
-		} elseif ( strpos( $this->useragent, 'blackberry' ) !== false ) {
+		} elseif ( strpos( $ua, 'blackberry' ) !== false ) {
 			$this->platform = self::PLATFORM_BLACKBERRY;
 		} elseif ( static::is_blackberry_tablet() ) {
 			$this->platform = self::PLATFORM_BLACKBERRY;
@@ -300,13 +301,13 @@ class User_Agent_Info {
 		}
 		$platform = self::OTHER;
 
-		if ( static::is_linux_desktop() ) {
+		if ( static::is_linux_desktop( $ua ) ) {
 			$platform = self::PLATFORM_DESKTOP_LINUX;
-		} elseif ( static::is_mac_desktop() ) {
+		} elseif ( static::is_mac_desktop( $ua ) ) {
 			$platform = self::PLATFORM_DESKTOP_MAC;
-		} elseif ( static::is_windows_desktop() ) {
+		} elseif ( static::is_windows_desktop( $ua ) ) {
 			$platform = self::PLATFORM_DESKTOP_WINDOWS;
-		} elseif ( static::is_chrome_desktop() ) {
+		} elseif ( static::is_chrome_desktop( $ua ) ) {
 			$platform = self::PLATFORM_DESKTOP_CHROME;
 		}
 		return $platform;
@@ -323,17 +324,17 @@ class User_Agent_Info {
 			return self::OTHER;
 		}
 
-		if ( static::is_opera_mini() || static::is_opera_mobile() || static::is_opera_desktop() || static::is_opera_mini_dumb() ) {
+		if ( static::is_opera_mini( $ua ) || static::is_opera_mobile( $ua ) || static::is_opera_desktop( $ua ) || static::is_opera_mini_dumb( $ua ) ) {
 			return self::BROWSER_OPERA;
-		} elseif ( static::is_edge_browser() ) {
+		} elseif ( static::is_edge_browser( $ua ) ) {
 			return self::BROWSER_EDGE;
-		} elseif ( static::is_chrome_desktop() || self::is_chrome_for_iOS() ) {
+		} elseif ( static::is_chrome_desktop( $ua ) || self::is_chrome_for_iOS( $ua ) ) {
 			return self::BROWSER_CHROME;
-		} elseif ( static::is_safari_browser() ) {
+		} elseif ( static::is_safari_browser( $ua ) ) {
 			return self::BROWSER_SAFARI;
-		} elseif ( static::is_firefox_mobile() || static::is_firefox_desktop() ) {
+		} elseif ( static::is_firefox_mobile( $ua ) || static::is_firefox_desktop( $ua ) ) {
 			return self::BROWSER_FIREFOX;
-		} elseif ( static::is_ie_browser() ) {
+		} elseif ( static::is_ie_browser( $ua ) ) {
 			return self::BROWSER_IE;
 		}
 		return self::OTHER;

--- a/projects/packages/device-detection/src/class-user-agent-info.php
+++ b/projects/packages/device-detection/src/class-user-agent-info.php
@@ -540,6 +540,23 @@ class User_Agent_Info {
 	}
 
 	/**
+	 * Retrieves the user agent from the server if not provided.
+	 *
+	 * @param string|null $user_agent Optional. User agent string to check. If not provided, uses $_SERVER['HTTP_USER_AGENT'].
+	 * @return string|false The user agent string or false if not available.
+	 */
+	private static function maybe_get_user_agent_from_server( $user_agent = null ) {
+		if ( null !== $user_agent ) {
+			return $user_agent;
+		}
+
+		if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
+			return false;
+		}
+		return wp_unslash( $_SERVER['HTTP_USER_AGENT'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
+	}
+
+	/**
 	 *  Detects if the current UA is iPhone Mobile Safari or another iPhone or iPod Touch Browser.
 	 *
 	 *  They type can check for any iPhone, an iPhone using Safari, or an iPhone using something other than Safari.
@@ -552,13 +569,8 @@ class User_Agent_Info {
 	 * @param string|null $user_agent Optional. User agent string to check. If not provided, uses $_SERVER['HTTP_USER_AGENT'].
 	 */
 	public static function is_iphone_or_ipod( $type = 'iphone-any', $user_agent = null ) {
-		if ( null === $user_agent ) {
-			if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
-				return false;
-			}
-			$user_agent = wp_unslash( $_SERVER['HTTP_USER_AGENT'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
-		}
 
+		$user_agent = self::maybe_get_user_agent_from_server( $user_agent );
 		if ( empty( $user_agent ) ) {
 			return false;
 		}
@@ -585,13 +597,7 @@ class User_Agent_Info {
 	 * @param string|null $user_agent Optional. User agent string to check. If not provided, uses $_SERVER['HTTP_USER_AGENT'].
 	 */
 	public static function is_chrome_for_iOS( $user_agent = null ) {
-		if ( null === $user_agent ) {
-			if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
-				return false;
-			}
-			$user_agent = wp_unslash( $_SERVER['HTTP_USER_AGENT'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
-		}
-
+		$user_agent = self::maybe_get_user_agent_from_server( $user_agent );
 		if ( empty( $user_agent ) ) {
 			return false;
 		}
@@ -618,13 +624,7 @@ class User_Agent_Info {
 	 * @param string|null $user_agent Optional. User agent string to check. If not provided, uses $_SERVER['HTTP_USER_AGENT'].
 	 */
 	public static function is_twitter_for_iphone( $user_agent = null ) {
-		if ( null === $user_agent ) {
-			if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
-				return false;
-			}
-			$user_agent = wp_unslash( $_SERVER['HTTP_USER_AGENT'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
-		}
-
+		$user_agent = self::maybe_get_user_agent_from_server( $user_agent );
 		if ( empty( $user_agent ) ) {
 			return false;
 		}
@@ -651,13 +651,7 @@ class User_Agent_Info {
 	 * @param string|null $user_agent Optional. User agent string to check. If not provided, uses $_SERVER['HTTP_USER_AGENT'].
 	 */
 	public static function is_twitter_for_ipad( $user_agent = null ) {
-		if ( null === $user_agent ) {
-			if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
-				return false;
-			}
-			$user_agent = wp_unslash( $_SERVER['HTTP_USER_AGENT'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
-		}
-
+		$user_agent = self::maybe_get_user_agent_from_server( $user_agent );
 		if ( empty( $user_agent ) ) {
 			return false;
 		}
@@ -682,13 +676,7 @@ class User_Agent_Info {
 	 * @param string|null $user_agent Optional. User agent string to check. If not provided, uses $_SERVER['HTTP_USER_AGENT'].
 	 */
 	public static function is_facebook_for_iphone( $user_agent = null ) {
-		if ( null === $user_agent ) {
-			if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
-				return false;
-			}
-			$user_agent = wp_unslash( $_SERVER['HTTP_USER_AGENT'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
-		}
-
+		$user_agent = self::maybe_get_user_agent_from_server( $user_agent );
 		if ( empty( $user_agent ) ) {
 			return false;
 		}
@@ -719,13 +707,7 @@ class User_Agent_Info {
 	 * @param string|null $user_agent Optional. User agent string to check. If not provided, uses $_SERVER['HTTP_USER_AGENT'].
 	 */
 	public static function is_facebook_for_ipad( $user_agent = null ) {
-		if ( null === $user_agent ) {
-			if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
-				return false;
-			}
-			$user_agent = wp_unslash( $_SERVER['HTTP_USER_AGENT'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
-		}
-
+		$user_agent = self::maybe_get_user_agent_from_server( $user_agent );
 		if ( empty( $user_agent ) ) {
 			return false;
 		}
@@ -749,13 +731,7 @@ class User_Agent_Info {
 	 * @param string|null $user_agent Optional. User agent string to check. If not provided, uses $_SERVER['HTTP_USER_AGENT'].
 	 */
 	public static function is_wordpress_for_ios( $user_agent = null ) {
-		if ( null === $user_agent ) {
-			if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
-				return false;
-			}
-			$user_agent = wp_unslash( $_SERVER['HTTP_USER_AGENT'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
-		}
-
+		$user_agent = self::maybe_get_user_agent_from_server( $user_agent );
 		if ( empty( $user_agent ) ) {
 			return false;
 		}
@@ -780,13 +756,7 @@ class User_Agent_Info {
 	 * @param string|null $user_agent Optional. User agent string to check. If not provided, uses $_SERVER['HTTP_USER_AGENT'].
 	 */
 	public static function is_ipad( $type = 'ipad-any', $user_agent = null ) {
-		if ( null === $user_agent ) {
-			if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
-				return false;
-			}
-			$user_agent = wp_unslash( $_SERVER['HTTP_USER_AGENT'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
-		}
-
+		$user_agent = self::maybe_get_user_agent_from_server( $user_agent );
 		if ( empty( $user_agent ) ) {
 			return false;
 		}
@@ -815,13 +785,7 @@ class User_Agent_Info {
 	 * @param string|null $user_agent Optional. User agent string to check. If not provided, uses $_SERVER['HTTP_USER_AGENT'].
 	 */
 	public static function is_firefox_mobile( $user_agent = null ) {
-		if ( null === $user_agent ) {
-			if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
-				return false;
-			}
-			$user_agent = wp_unslash( $_SERVER['HTTP_USER_AGENT'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
-		}
-
+		$user_agent = self::maybe_get_user_agent_from_server( $user_agent );
 		if ( empty( $user_agent ) ) {
 			return false;
 		}
@@ -845,13 +809,7 @@ class User_Agent_Info {
 	 * @param string|null $user_agent Optional. User agent string to check. If not provided, uses $_SERVER['HTTP_USER_AGENT'].
 	 */
 	public static function is_firefox_desktop( $user_agent = null ) {
-		if ( null === $user_agent ) {
-			if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
-				return false;
-			}
-			$user_agent = wp_unslash( $_SERVER['HTTP_USER_AGENT'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
-		}
-
+		$user_agent = self::maybe_get_user_agent_from_server( $user_agent );
 		if ( empty( $user_agent ) ) {
 			return false;
 		}
@@ -873,13 +831,7 @@ class User_Agent_Info {
 	 * @param string|null $user_agent Optional. User agent string to check. If not provided, uses $_SERVER['HTTP_USER_AGENT'].
 	 */
 	public static function is_firefox_os( $user_agent = null ) {
-		if ( null === $user_agent ) {
-			if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
-				return false;
-			}
-			$user_agent = wp_unslash( $_SERVER['HTTP_USER_AGENT'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
-		}
-
+		$user_agent = self::maybe_get_user_agent_from_server( $user_agent );
 		if ( empty( $user_agent ) ) {
 			return false;
 		}
@@ -899,13 +851,7 @@ class User_Agent_Info {
 	 * @param string|null $user_agent Optional. User agent string to check. If not provided, uses $_SERVER['HTTP_USER_AGENT'].
 	 */
 	public static function is_safari_browser( $user_agent = null ) {
-		if ( null === $user_agent ) {
-			if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
-				return false;
-			}
-			$user_agent = wp_unslash( $_SERVER['HTTP_USER_AGENT'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
-		}
-
+		$user_agent = self::maybe_get_user_agent_from_server( $user_agent );
 		if ( empty( $user_agent ) ) {
 			return false;
 		}
@@ -922,13 +868,7 @@ class User_Agent_Info {
 	 * @param string|null $user_agent Optional. User agent string to check. If not provided, uses $_SERVER['HTTP_USER_AGENT'].
 	 */
 	public static function is_edge_browser( $user_agent = null ) {
-		if ( null === $user_agent ) {
-			if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
-				return false;
-			}
-			$user_agent = wp_unslash( $_SERVER['HTTP_USER_AGENT'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
-		}
-
+		$user_agent = self::maybe_get_user_agent_from_server( $user_agent );
 		if ( empty( $user_agent ) ) {
 			return false;
 		}
@@ -948,13 +888,7 @@ class User_Agent_Info {
 	 * @param string|null $user_agent Optional. User agent string to check. If not provided, uses $_SERVER['HTTP_USER_AGENT'].
 	 */
 	public static function is_ie_browser( $user_agent = null ) {
-		if ( null === $user_agent ) {
-			if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
-				return false;
-			}
-			$user_agent = wp_unslash( $_SERVER['HTTP_USER_AGENT'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
-		}
-
+		$user_agent = self::maybe_get_user_agent_from_server( $user_agent );
 		if ( empty( $user_agent ) ) {
 			return false;
 		}
@@ -976,13 +910,7 @@ class User_Agent_Info {
 	 * @param string|null $user_agent Optional. User agent string to check. If not provided, uses $_SERVER['HTTP_USER_AGENT'].
 	 */
 	public static function is_opera_desktop( $user_agent = null ) {
-		if ( null === $user_agent ) {
-			if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
-				return false;
-			}
-			$user_agent = wp_unslash( $_SERVER['HTTP_USER_AGENT'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
-		}
-
+		$user_agent = self::maybe_get_user_agent_from_server( $user_agent );
 		if ( empty( $user_agent ) ) {
 			return false;
 		}
@@ -1009,13 +937,7 @@ class User_Agent_Info {
 	 * @param string|null $user_agent Optional. User agent string to check. If not provided, uses $_SERVER['HTTP_USER_AGENT'].
 	 */
 	public static function is_opera_mobile( $user_agent = null ) {
-		if ( null === $user_agent ) {
-			if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
-				return false;
-			}
-			$user_agent = wp_unslash( $_SERVER['HTTP_USER_AGENT'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
-		}
-
+		$user_agent = self::maybe_get_user_agent_from_server( $user_agent );
 		if ( empty( $user_agent ) ) {
 			return false;
 		}
@@ -1045,13 +967,7 @@ class User_Agent_Info {
 	 * @param string|null $user_agent Optional. User agent string to check. If not provided, uses $_SERVER['HTTP_USER_AGENT'].
 	 */
 	public static function is_opera_mini( $user_agent = null ) {
-		if ( null === $user_agent ) {
-			if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
-				return false;
-			}
-			$user_agent = wp_unslash( $_SERVER['HTTP_USER_AGENT'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
-		}
-
+		$user_agent = self::maybe_get_user_agent_from_server( $user_agent );
 		if ( empty( $user_agent ) ) {
 			return false;
 		}
@@ -1072,13 +988,7 @@ class User_Agent_Info {
 	 * @param string|null $user_agent Optional. User agent string to check. If not provided, uses $_SERVER['HTTP_USER_AGENT'].
 	 */
 	public static function is_opera_mini_dumb( $user_agent = null ) {
-		if ( null === $user_agent ) {
-			if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
-				return false;
-			}
-			$user_agent = wp_unslash( $_SERVER['HTTP_USER_AGENT'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
-		}
-
+		$user_agent = self::maybe_get_user_agent_from_server( $user_agent );
 		if ( empty( $user_agent ) ) {
 			return false;
 		}
@@ -1107,13 +1017,7 @@ class User_Agent_Info {
 	 * @return bool
 	 */
 	public static function is_samsung_browser( $user_agent = null ) {
-		if ( null === $user_agent ) {
-			if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
-				return false;
-			}
-			$user_agent = wp_unslash( $_SERVER['HTTP_USER_AGENT'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
-		}
-
+		$user_agent = self::maybe_get_user_agent_from_server( $user_agent );
 		if ( empty( $user_agent ) ) {
 			return false;
 		}
@@ -1131,13 +1035,7 @@ class User_Agent_Info {
 	 * @return bool
 	 */
 	public static function is_uc_browser( $user_agent = null ) {
-		if ( null === $user_agent ) {
-			if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
-				return false;
-			}
-			$user_agent = wp_unslash( $_SERVER['HTTP_USER_AGENT'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
-		}
-
+		$user_agent = self::maybe_get_user_agent_from_server( $user_agent );
 		if ( empty( $user_agent ) ) {
 			return false;
 		}
@@ -1155,13 +1053,7 @@ class User_Agent_Info {
 	 * @return bool
 	 */
 	public static function is_yandex_browser( $user_agent = null ) {
-		if ( null === $user_agent ) {
-			if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
-				return false;
-			}
-			$user_agent = wp_unslash( $_SERVER['HTTP_USER_AGENT'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
-		}
-
+		$user_agent = self::maybe_get_user_agent_from_server( $user_agent );
 		if ( empty( $user_agent ) ) {
 			return false;
 		}
@@ -1179,13 +1071,7 @@ class User_Agent_Info {
 	 * @return bool
 	 */
 	public static function is_vivaldi_browser( $user_agent = null ) {
-		if ( null === $user_agent ) {
-			if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
-				return false;
-			}
-			$user_agent = wp_unslash( $_SERVER['HTTP_USER_AGENT'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
-		}
-
+		$user_agent = self::maybe_get_user_agent_from_server( $user_agent );
 		if ( empty( $user_agent ) ) {
 			return false;
 		}
@@ -1203,13 +1089,7 @@ class User_Agent_Info {
 	 * @return bool
 	 */
 	public static function is_miui_browser( $user_agent = null ) {
-		if ( null === $user_agent ) {
-			if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
-				return false;
-			}
-			$user_agent = wp_unslash( $_SERVER['HTTP_USER_AGENT'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
-		}
-
+		$user_agent = self::maybe_get_user_agent_from_server( $user_agent );
 		if ( empty( $user_agent ) ) {
 			return false;
 		}
@@ -1227,13 +1107,7 @@ class User_Agent_Info {
 	 * @return bool
 	 */
 	public static function is_silk_browser( $user_agent = null ) {
-		if ( null === $user_agent ) {
-			if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
-				return false;
-			}
-			$user_agent = wp_unslash( $_SERVER['HTTP_USER_AGENT'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
-		}
-
+		$user_agent = self::maybe_get_user_agent_from_server( $user_agent );
 		if ( empty( $user_agent ) ) {
 			return false;
 		}
@@ -1248,13 +1122,7 @@ class User_Agent_Info {
 	 * @param string|null $user_agent Optional. User agent string to check. If not provided, uses $_SERVER['HTTP_USER_AGENT'].
 	 */
 	public static function is_WindowsPhone7( $user_agent = null ) {
-		if ( null === $user_agent ) {
-			if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
-				return false;
-			}
-			$user_agent = wp_unslash( $_SERVER['HTTP_USER_AGENT'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
-		}
-
+		$user_agent = self::maybe_get_user_agent_from_server( $user_agent );
 		if ( empty( $user_agent ) ) {
 			return false;
 		}
@@ -1277,13 +1145,7 @@ class User_Agent_Info {
 	 * @param string|null $user_agent Optional. User agent string to check. If not provided, uses $_SERVER['HTTP_USER_AGENT'].
 	 */
 	public static function is_windows_phone_8( $user_agent = null ) {
-		if ( null === $user_agent ) {
-			if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
-				return false;
-			}
-			$user_agent = wp_unslash( $_SERVER['HTTP_USER_AGENT'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
-		}
-
+		$user_agent = self::maybe_get_user_agent_from_server( $user_agent );
 		if ( empty( $user_agent ) ) {
 			return false;
 		}
@@ -1305,13 +1167,7 @@ class User_Agent_Info {
 	 * @param string|null $user_agent Optional. User agent string to check. If not provided, uses $_SERVER['HTTP_USER_AGENT'].
 	 */
 	public static function is_PalmWebOS( $user_agent = null ) {
-		if ( null === $user_agent ) {
-			if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
-				return false;
-			}
-			$user_agent = wp_unslash( $_SERVER['HTTP_USER_AGENT'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
-		}
-
+		$user_agent = self::maybe_get_user_agent_from_server( $user_agent );
 		if ( empty( $user_agent ) ) {
 			return false;
 		}
@@ -1336,13 +1192,7 @@ class User_Agent_Info {
 	 * @param string|null $user_agent Optional. User agent string to check. If not provided, uses $_SERVER['HTTP_USER_AGENT'].
 	 */
 	public static function is_TouchPad( $user_agent = null ) {
-		if ( null === $user_agent ) {
-			if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
-				return false;
-			}
-			$user_agent = wp_unslash( $_SERVER['HTTP_USER_AGENT'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
-		}
-
+		$user_agent = self::maybe_get_user_agent_from_server( $user_agent );
 		if ( empty( $user_agent ) ) {
 			return false;
 		}
@@ -1371,13 +1221,7 @@ class User_Agent_Info {
 	 * @param string|null $user_agent Optional. User agent string to check. If not provided, uses $_SERVER['HTTP_USER_AGENT'].
 	 */
 	public static function is_S60_OSSBrowser( $user_agent = null ) {
-		if ( null === $user_agent ) {
-			if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
-				return false;
-			}
-			$user_agent = wp_unslash( $_SERVER['HTTP_USER_AGENT'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
-		}
-
+		$user_agent = self::maybe_get_user_agent_from_server( $user_agent );
 		if ( empty( $user_agent ) ) {
 			return false;
 		}
@@ -1410,13 +1254,7 @@ class User_Agent_Info {
 	 * @param string|null $user_agent Optional. User agent string to check. If not provided, uses $_SERVER['HTTP_USER_AGENT'].
 	 */
 	public static function is_symbian_platform( $user_agent = null ) {
-		if ( null === $user_agent ) {
-			if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
-				return false;
-			}
-			$user_agent = wp_unslash( $_SERVER['HTTP_USER_AGENT'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
-		}
-
+		$user_agent = self::maybe_get_user_agent_from_server( $user_agent );
 		if ( empty( $user_agent ) ) {
 			return false;
 		}
@@ -1452,13 +1290,7 @@ class User_Agent_Info {
 	 * @param string|null $user_agent Optional. User agent string to check. If not provided, uses $_SERVER['HTTP_USER_AGENT'].
 	 */
 	public static function is_symbian_s40_platform( $user_agent = null ) {
-		if ( null === $user_agent ) {
-			if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
-				return false;
-			}
-			$user_agent = wp_unslash( $_SERVER['HTTP_USER_AGENT'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
-		}
-
+		$user_agent = self::maybe_get_user_agent_from_server( $user_agent );
 		if ( empty( $user_agent ) ) {
 			return false;
 		}
@@ -1482,13 +1314,7 @@ class User_Agent_Info {
 	 * @return bool
 	 */
 	public static function is_J2ME_platform( $user_agent = null ) {
-		if ( null === $user_agent ) {
-			if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
-				return false;
-			}
-			$user_agent = wp_unslash( $_SERVER['HTTP_USER_AGENT'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
-		}
-
+		$user_agent = self::maybe_get_user_agent_from_server( $user_agent );
 		if ( empty( $user_agent ) ) {
 			return false;
 		}
@@ -1509,13 +1335,7 @@ class User_Agent_Info {
 	 * @param string|null $user_agent Optional. User agent string to check. If not provided, uses $_SERVER['HTTP_USER_AGENT'].
 	 */
 	public static function is_MaemoTablet( $user_agent = null ) {
-		if ( null === $user_agent ) {
-			if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
-				return false;
-			}
-			$user_agent = wp_unslash( $_SERVER['HTTP_USER_AGENT'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
-		}
-
+		$user_agent = self::maybe_get_user_agent_from_server( $user_agent );
 		if ( empty( $user_agent ) ) {
 			return false;
 		}
@@ -1545,13 +1365,7 @@ class User_Agent_Info {
 	 * @param string|null $user_agent Optional. User agent string to check. If not provided, uses $_SERVER['HTTP_USER_AGENT'].
 	 */
 	public static function is_MeeGo( $user_agent = null ) {
-		if ( null === $user_agent ) {
-			if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
-				return false;
-			}
-			$user_agent = wp_unslash( $_SERVER['HTTP_USER_AGENT'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
-		}
-
+		$user_agent = self::maybe_get_user_agent_from_server( $user_agent );
 		if ( empty( $user_agent ) ) {
 			return false;
 		}
@@ -1573,13 +1387,7 @@ class User_Agent_Info {
 	 * @param string|null $user_agent Optional. User agent string to check. If not provided, uses $_SERVER['HTTP_USER_AGENT'].
 	 */
 	public static function is_webkit( $user_agent = null ) {
-		if ( null === $user_agent ) {
-			if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
-				return false;
-			}
-			$user_agent = wp_unslash( $_SERVER['HTTP_USER_AGENT'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
-		}
-
+		$user_agent = self::maybe_get_user_agent_from_server( $user_agent );
 		if ( empty( $user_agent ) ) {
 			return false;
 		}
@@ -1603,13 +1411,7 @@ class User_Agent_Info {
 	 * @return boolean true if the browser is Android otherwise false
 	 */
 	public static function is_android( $user_agent = null ) {
-		if ( null === $user_agent ) {
-			if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
-				return false;
-			}
-			$user_agent = wp_unslash( $_SERVER['HTTP_USER_AGENT'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
-		}
-
+		$user_agent = self::maybe_get_user_agent_from_server( $user_agent );
 		if ( empty( $user_agent ) ) {
 			return false;
 		}
@@ -1636,13 +1438,7 @@ class User_Agent_Info {
 	 * @return boolean true if the browser is Android and not 'mobile' otherwise false
 	 */
 	public static function is_android_tablet( $user_agent = null ) {
-		if ( null === $user_agent ) {
-			if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
-				return false;
-			}
-			$user_agent = wp_unslash( $_SERVER['HTTP_USER_AGENT'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
-		}
-
+		$user_agent = self::maybe_get_user_agent_from_server( $user_agent );
 		if ( empty( $user_agent ) ) {
 			return false;
 		}
@@ -1675,13 +1471,7 @@ class User_Agent_Info {
 	 * @return boolean true if the browser is Kindle Fire Native browser otherwise false
 	 */
 	public static function is_kindle_fire( $user_agent = null ) {
-		if ( null === $user_agent ) {
-			if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
-				return false;
-			}
-			$user_agent = wp_unslash( $_SERVER['HTTP_USER_AGENT'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
-		}
-
+		$user_agent = self::maybe_get_user_agent_from_server( $user_agent );
 		if ( empty( $user_agent ) ) {
 			return false;
 		}
@@ -1706,13 +1496,7 @@ class User_Agent_Info {
 	 * @return boolean true if the browser is Kindle monochrome Native browser otherwise false
 	 */
 	public static function is_kindle_touch( $user_agent = null ) {
-		if ( null === $user_agent ) {
-			if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
-				return false;
-			}
-			$user_agent = wp_unslash( $_SERVER['HTTP_USER_AGENT'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
-		}
-
+		$user_agent = self::maybe_get_user_agent_from_server( $user_agent );
 		if ( empty( $user_agent ) ) {
 			return false;
 		}
@@ -1732,13 +1516,7 @@ class User_Agent_Info {
 	 * @param string|null $user_agent Optional. User agent string to check. If not provided, uses $_SERVER['HTTP_USER_AGENT'].
 	 */
 	public static function is_windows8_auth( $user_agent = null ) {
-		if ( null === $user_agent ) {
-			if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
-				return false;
-			}
-			$user_agent = wp_unslash( $_SERVER['HTTP_USER_AGENT'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
-		}
-
+		$user_agent = self::maybe_get_user_agent_from_server( $user_agent );
 		if ( empty( $user_agent ) ) {
 			return false;
 		}
@@ -1758,13 +1536,7 @@ class User_Agent_Info {
 	 * @param string|null $user_agent Optional. User agent string to check. If not provided, uses $_SERVER['HTTP_USER_AGENT'].
 	 */
 	public static function is_wordpress_for_win8( $user_agent = null ) {
-		if ( null === $user_agent ) {
-			if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
-				return false;
-			}
-			$user_agent = wp_unslash( $_SERVER['HTTP_USER_AGENT'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
-		}
-
+		$user_agent = self::maybe_get_user_agent_from_server( $user_agent );
 		if ( empty( $user_agent ) ) {
 			return false;
 		}
@@ -1784,13 +1556,7 @@ class User_Agent_Info {
 	 * @param string|null $user_agent Optional. User agent string to check. If not provided, uses $_SERVER['HTTP_USER_AGENT'].
 	 */
 	public static function is_wordpress_desktop_app( $user_agent = null ) {
-		if ( null === $user_agent ) {
-			if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
-				return false;
-			}
-			$user_agent = wp_unslash( $_SERVER['HTTP_USER_AGENT'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
-		}
-
+		$user_agent = self::maybe_get_user_agent_from_server( $user_agent );
 		if ( empty( $user_agent ) ) {
 			return false;
 		}
@@ -1812,13 +1578,7 @@ class User_Agent_Info {
 	 * @param string|null $user_agent Optional. User agent string to check. If not provided, uses $_SERVER['HTTP_USER_AGENT'].
 	 */
 	public static function is_blackberry_tablet( $user_agent = null ) {
-		if ( null === $user_agent ) {
-			if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
-				return false;
-			}
-			$user_agent = wp_unslash( $_SERVER['HTTP_USER_AGENT'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
-		}
-
+		$user_agent = self::maybe_get_user_agent_from_server( $user_agent );
 		if ( empty( $user_agent ) ) {
 			return false;
 		}
@@ -1841,13 +1601,7 @@ class User_Agent_Info {
 	 * @param string|null $user_agent Optional. User agent string to check. If not provided, uses $_SERVER['HTTP_USER_AGENT'].
 	 */
 	public static function is_blackbeberry( $user_agent = null ) {
-		if ( null === $user_agent ) {
-			if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
-				return false;
-			}
-			$user_agent = wp_unslash( $_SERVER['HTTP_USER_AGENT'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
-		}
-
+		$user_agent = self::maybe_get_user_agent_from_server( $user_agent );
 		if ( empty( $user_agent ) ) {
 			return false;
 		}
@@ -1872,13 +1626,7 @@ class User_Agent_Info {
 	 * @param string|null $user_agent Optional. User agent string to check. If not provided, uses $_SERVER['HTTP_USER_AGENT'].
 	 */
 	public static function is_blackberry_10( $user_agent = null ) {
-		if ( null === $user_agent ) {
-			if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
-				return false;
-			}
-			$user_agent = wp_unslash( $_SERVER['HTTP_USER_AGENT'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
-		}
-
+		$user_agent = self::maybe_get_user_agent_from_server( $user_agent );
 		if ( empty( $user_agent ) ) {
 			return false;
 		}
@@ -1895,13 +1643,7 @@ class User_Agent_Info {
 	 * @return bool
 	 */
 	public static function is_linux_desktop( $user_agent = null ) {
-		if ( null === $user_agent ) {
-			if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
-				return false;
-			}
-			$user_agent = wp_unslash( $_SERVER['HTTP_USER_AGENT'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
-		}
-
+		$user_agent = self::maybe_get_user_agent_from_server( $user_agent );
 		if ( empty( $user_agent ) ) {
 			return false;
 		}
@@ -1920,13 +1662,7 @@ class User_Agent_Info {
 	 * @return bool
 	 */
 	public static function is_mac_desktop( $user_agent = null ) {
-		if ( null === $user_agent ) {
-			if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
-				return false;
-			}
-			$user_agent = wp_unslash( $_SERVER['HTTP_USER_AGENT'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
-		}
-
+		$user_agent = self::maybe_get_user_agent_from_server( $user_agent );
 		if ( empty( $user_agent ) ) {
 			return false;
 		}
@@ -1945,13 +1681,7 @@ class User_Agent_Info {
 	 * @return bool
 	 */
 	public static function is_windows_desktop( $user_agent = null ) {
-		if ( null === $user_agent ) {
-			if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
-				return false;
-			}
-			$user_agent = wp_unslash( $_SERVER['HTTP_USER_AGENT'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
-		}
-
+		$user_agent = self::maybe_get_user_agent_from_server( $user_agent );
 		if ( empty( $user_agent ) ) {
 			return false;
 		}
@@ -1970,13 +1700,7 @@ class User_Agent_Info {
 	 * @return bool
 	 */
 	public static function is_chrome_desktop( $user_agent = null ) {
-		if ( null === $user_agent ) {
-			if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
-				return false;
-			}
-			$user_agent = wp_unslash( $_SERVER['HTTP_USER_AGENT'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
-		}
-
+		$user_agent = self::maybe_get_user_agent_from_server( $user_agent );
 		if ( empty( $user_agent ) ) {
 			return false;
 		}
@@ -2006,13 +1730,7 @@ class User_Agent_Info {
 	 * If version is not found, get_blackbeberry_OS_version will return boolean false.
 	 */
 	public static function get_blackbeberry_OS_version( $user_agent = null ) {
-		if ( null === $user_agent ) {
-			if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
-				return false;
-			}
-			$user_agent = wp_unslash( $_SERVER['HTTP_USER_AGENT'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
-		}
-
+		$user_agent = self::maybe_get_user_agent_from_server( $user_agent );
 		if ( empty( $user_agent ) ) {
 			return false;
 		}
@@ -2099,13 +1817,7 @@ class User_Agent_Info {
 	 * If browser's version is not found, detect_blackbeberry_browser_version will return boolean false.
 	 */
 	public static function detect_blackberry_browser_version( $user_agent = null ) {
-		if ( null === $user_agent ) {
-			if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
-				return false;
-			}
-			$user_agent = wp_unslash( $_SERVER['HTTP_USER_AGENT'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
-		}
-
+		$user_agent = self::maybe_get_user_agent_from_server( $user_agent );
 		if ( empty( $user_agent ) ) {
 			return false;
 		}
@@ -2161,13 +1873,7 @@ class User_Agent_Info {
 	 * @return bool
 	 */
 	public static function is_mobile_app( $user_agent = null ) {
-		if ( null === $user_agent ) {
-			if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
-				return false;
-			}
-			$user_agent = wp_unslash( $_SERVER['HTTP_USER_AGENT'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
-		}
-
+		$user_agent = self::maybe_get_user_agent_from_server( $user_agent );
 		if ( empty( $user_agent ) ) {
 			return false;
 		}
@@ -2202,13 +1908,7 @@ class User_Agent_Info {
 	 * @param string|null $user_agent Optional. User agent string to check. If not provided, uses $_SERVER['HTTP_USER_AGENT'].
 	 */
 	public static function is_Nintendo_3DS( $user_agent = null ) {
-		if ( null === $user_agent ) {
-			if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
-				return false;
-			}
-			$user_agent = wp_unslash( $_SERVER['HTTP_USER_AGENT'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
-		}
-
+		$user_agent = self::maybe_get_user_agent_from_server( $user_agent );
 		if ( empty( $user_agent ) ) {
 			return false;
 		}

--- a/projects/packages/device-detection/src/class-user-agent-info.php
+++ b/projects/packages/device-detection/src/class-user-agent-info.php
@@ -87,6 +87,12 @@ class User_Agent_Info {
 	const BROWSER_EDGE             = 'edge';
 	const BROWSER_OPERA            = 'opera';
 	const BROWSER_IE               = 'ie';
+	const BROWSER_SAMSUNG          = 'samsung';
+	const BROWSER_UC               = 'uc';
+	const BROWSER_YANDEX           = 'yandex';
+	const BROWSER_VIVALDI          = 'vivaldi';
+	const BROWSER_MIUI             = 'miui';
+	const BROWSER_SILK             = 'silk';
 	const OTHER                    = 'other';
 
 	/**
@@ -324,7 +330,23 @@ class User_Agent_Info {
 			return self::OTHER;
 		}
 
-		if ( static::is_opera_mini( $ua ) || static::is_opera_mobile( $ua ) || static::is_opera_desktop( $ua ) || static::is_opera_mini_dumb( $ua ) ) {
+		// Check for browsers based on Chromium BEFORE checking for Chrome itself,
+		// as they all include "Chrome" in their user agent string.
+		// Order matters - most specific checks first!
+
+		if ( static::is_samsung_browser( $ua ) ) {
+			return self::BROWSER_SAMSUNG;
+		} elseif ( static::is_yandex_browser( $ua ) ) {
+			return self::BROWSER_YANDEX;
+		} elseif ( static::is_vivaldi_browser( $ua ) ) {
+			return self::BROWSER_VIVALDI;
+		} elseif ( static::is_uc_browser( $ua ) ) {
+			return self::BROWSER_UC;
+		} elseif ( static::is_miui_browser( $ua ) ) {
+			return self::BROWSER_MIUI;
+		} elseif ( static::is_silk_browser( $ua ) ) {
+			return self::BROWSER_SILK;
+		} elseif ( static::is_opera_mini( $ua ) || static::is_opera_mobile( $ua ) || static::is_opera_desktop( $ua ) || static::is_opera_mini_dumb( $ua ) ) {
 			return self::BROWSER_OPERA;
 		} elseif ( static::is_edge_browser( $ua ) ) {
 			return self::BROWSER_EDGE;
@@ -911,7 +933,10 @@ class User_Agent_Info {
 			return false;
 		}
 
-		if ( false === strpos( wp_unslash( $user_agent ), 'Edge' ) ) { // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
+		$ua = wp_unslash( $user_agent ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
+
+		// Check for both legacy Edge ("Edge/") and modern Chromium-based Edge ("Edg/")
+		if ( false === strpos( $ua, 'Edge' ) && false === strpos( $ua, 'Edg/' ) ) {
 			return false;
 		}
 		return true;
@@ -1070,6 +1095,150 @@ class User_Agent_Info {
 		} else {
 			return false;
 		}
+	}
+
+	/**
+	 * Detects if the current browser is Samsung Internet for Android.
+	 *
+	 * Samsung Internet is the default browser on Samsung devices.
+	 * User agent contains: SamsungBrowser
+	 *
+	 * @param string|null $user_agent Optional user agent string.
+	 * @return bool
+	 */
+	public static function is_samsung_browser( $user_agent = null ) {
+		if ( null === $user_agent ) {
+			if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
+				return false;
+			}
+			$user_agent = wp_unslash( $_SERVER['HTTP_USER_AGENT'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
+		}
+
+		if ( empty( $user_agent ) ) {
+			return false;
+		}
+
+		return false !== stripos( $user_agent, 'SamsungBrowser' );
+	}
+
+	/**
+	 * Detects if the current browser is UC Browser.
+	 *
+	 * UC Browser is popular in Asia and emerging markets.
+	 * User agent contains: UCBrowser or UCWEB
+	 *
+	 * @param string|null $user_agent Optional user agent string.
+	 * @return bool
+	 */
+	public static function is_uc_browser( $user_agent = null ) {
+		if ( null === $user_agent ) {
+			if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
+				return false;
+			}
+			$user_agent = wp_unslash( $_SERVER['HTTP_USER_AGENT'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
+		}
+
+		if ( empty( $user_agent ) ) {
+			return false;
+		}
+
+		return false !== stripos( $user_agent, 'UCBrowser' ) || false !== stripos( $user_agent, 'UCWEB' );
+	}
+
+	/**
+	 * Detects if the current browser is Yandex Browser.
+	 *
+	 * Yandex Browser is popular in Russia and CIS countries.
+	 * User agent contains: YaBrowser
+	 *
+	 * @param string|null $user_agent Optional user agent string.
+	 * @return bool
+	 */
+	public static function is_yandex_browser( $user_agent = null ) {
+		if ( null === $user_agent ) {
+			if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
+				return false;
+			}
+			$user_agent = wp_unslash( $_SERVER['HTTP_USER_AGENT'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
+		}
+
+		if ( empty( $user_agent ) ) {
+			return false;
+		}
+
+		return false !== stripos( $user_agent, 'YaBrowser' );
+	}
+
+	/**
+	 * Detects if the current browser is Vivaldi.
+	 *
+	 * Vivaldi is a feature-rich browser for power users.
+	 * User agent contains: Vivaldi
+	 *
+	 * @param string|null $user_agent Optional user agent string.
+	 * @return bool
+	 */
+	public static function is_vivaldi_browser( $user_agent = null ) {
+		if ( null === $user_agent ) {
+			if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
+				return false;
+			}
+			$user_agent = wp_unslash( $_SERVER['HTTP_USER_AGENT'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
+		}
+
+		if ( empty( $user_agent ) ) {
+			return false;
+		}
+
+		return false !== stripos( $user_agent, 'Vivaldi' );
+	}
+
+	/**
+	 * Detects if the current browser is MIUI Browser.
+	 *
+	 * MIUI Browser is the default browser on Xiaomi devices.
+	 * User agent contains: MiuiBrowser or XiaoMi
+	 *
+	 * @param string|null $user_agent Optional user agent string.
+	 * @return bool
+	 */
+	public static function is_miui_browser( $user_agent = null ) {
+		if ( null === $user_agent ) {
+			if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
+				return false;
+			}
+			$user_agent = wp_unslash( $_SERVER['HTTP_USER_AGENT'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
+		}
+
+		if ( empty( $user_agent ) ) {
+			return false;
+		}
+
+		return false !== stripos( $user_agent, 'MiuiBrowser' ) || false !== stripos( $user_agent, 'XiaoMi' );
+	}
+
+	/**
+	 * Detects if the current browser is Amazon Silk.
+	 *
+	 * Amazon Silk is the browser on Kindle Fire and Echo devices.
+	 * User agent contains: Silk or Silk-Accelerated
+	 *
+	 * @param string|null $user_agent Optional user agent string.
+	 * @return bool
+	 */
+	public static function is_silk_browser( $user_agent = null ) {
+		if ( null === $user_agent ) {
+			if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
+				return false;
+			}
+			$user_agent = wp_unslash( $_SERVER['HTTP_USER_AGENT'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
+		}
+
+		if ( empty( $user_agent ) ) {
+			return false;
+		}
+
+		return false !== stripos( $user_agent, 'Silk' );
 	}
 
 	/**

--- a/projects/packages/device-detection/src/class-user-agent-info.php
+++ b/projects/packages/device-detection/src/class-user-agent-info.php
@@ -524,14 +524,22 @@ class User_Agent_Info {
 	 *  you should put the check condition before the check for 'iphone-any' or 'iphone-not-safari'.
 	 *  Otherwise those browsers will be 'catched' by the iphone string.
 	 *
-	 * @param string $type Type of iPhone detection.
+	 * @param string      $type       Type of iPhone detection.
+	 * @param string|null $user_agent Optional. User agent string to check. If not provided, uses $_SERVER['HTTP_USER_AGENT'].
 	 */
-	public static function is_iphone_or_ipod( $type = 'iphone-any' ) {
-		if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
+	public static function is_iphone_or_ipod( $type = 'iphone-any', $user_agent = null ) {
+		if ( null === $user_agent ) {
+			if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
+				return false;
+			}
+			$user_agent = wp_unslash( $_SERVER['HTTP_USER_AGENT'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
+		}
+
+		if ( empty( $user_agent ) ) {
 			return false;
 		}
 
-		$ua        = strtolower( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
+		$ua        = strtolower( wp_unslash( $user_agent ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
 		$is_iphone = ( strpos( $ua, 'iphone' ) !== false ) || ( strpos( $ua, 'ipod' ) !== false );
 		$is_safari = ( false !== strpos( $ua, 'safari' ) );
 
@@ -549,17 +557,26 @@ class User_Agent_Info {
 	 *
 	 *  The User-Agent string in Chrome for iOS is the same as the Mobile Safari User-Agent, with CriOS/<ChromeRevision> instead of Version/<VersionNum>.
 	 *  - Mozilla/5.0 (iPhone; U; CPU iPhone OS 5_1_1 like Mac OS X; en) AppleWebKit/534.46.0 (KHTML, like Gecko) CriOS/19.0.1084.60 Mobile/9B206 Safari/7534.48.3
+	 *
+	 * @param string|null $user_agent Optional. User agent string to check. If not provided, uses $_SERVER['HTTP_USER_AGENT'].
 	 */
-	public static function is_chrome_for_iOS() {
-		if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
+	public static function is_chrome_for_iOS( $user_agent = null ) {
+		if ( null === $user_agent ) {
+			if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
+				return false;
+			}
+			$user_agent = wp_unslash( $_SERVER['HTTP_USER_AGENT'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
+		}
+
+		if ( empty( $user_agent ) ) {
 			return false;
 		}
 
-		if ( self::is_iphone_or_ipod( 'iphone-safari' ) === false ) {
+		if ( self::is_iphone_or_ipod( 'iphone-safari', $user_agent ) === false ) {
 			return false;
 		}
 
-		$ua = strtolower( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
+		$ua = strtolower( wp_unslash( $user_agent ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
 
 		if ( strpos( $ua, 'crios/' ) !== false ) {
 			return true;
@@ -573,13 +590,22 @@ class User_Agent_Info {
 	 *
 	 * Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_3_5 like Mac OS X; nb-no) AppleWebKit/533.17.9 (KHTML, like Gecko) Mobile/8L1 Twitter for iPhone
 	 * Mozilla/5.0 (iPhone; CPU iPhone OS 5_1_1 like Mac OS X) AppleWebKit/534.46 (KHTML, like Gecko) Mobile/9B206 Twitter for iPhone
+	 *
+	 * @param string|null $user_agent Optional. User agent string to check. If not provided, uses $_SERVER['HTTP_USER_AGENT'].
 	 */
-	public static function is_twitter_for_iphone() {
-		if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
+	public static function is_twitter_for_iphone( $user_agent = null ) {
+		if ( null === $user_agent ) {
+			if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
+				return false;
+			}
+			$user_agent = wp_unslash( $_SERVER['HTTP_USER_AGENT'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
+		}
+
+		if ( empty( $user_agent ) ) {
 			return false;
 		}
 
-		$ua = strtolower( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
+		$ua = strtolower( wp_unslash( $user_agent ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
 
 		if ( strpos( $ua, 'ipad' ) !== false ) {
 			return false;
@@ -597,13 +623,22 @@ class User_Agent_Info {
 	 *
 	 * Old version 4.X - Mozilla/5.0 (iPad; U; CPU OS 4_3_5 like Mac OS X; en-us) AppleWebKit/533.17.9 (KHTML, like Gecko) Mobile/8L1 Twitter for iPad
 	 * Ver 5.0 or Higher - Mozilla/5.0 (iPad; CPU OS 5_1_1 like Mac OS X) AppleWebKit/534.46 (KHTML, like Gecko) Mobile/9B206 Twitter for iPhone
+	 *
+	 * @param string|null $user_agent Optional. User agent string to check. If not provided, uses $_SERVER['HTTP_USER_AGENT'].
 	 */
-	public static function is_twitter_for_ipad() {
-		if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
+	public static function is_twitter_for_ipad( $user_agent = null ) {
+		if ( null === $user_agent ) {
+			if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
+				return false;
+			}
+			$user_agent = wp_unslash( $_SERVER['HTTP_USER_AGENT'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
+		}
+
+		if ( empty( $user_agent ) ) {
 			return false;
 		}
 
-		$ua = strtolower( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
+		$ua = strtolower( wp_unslash( $user_agent ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
 
 		if ( strpos( $ua, 'twitter for ipad' ) !== false ) {
 			return true;
@@ -619,13 +654,22 @@ class User_Agent_Info {
 	 * - Facebook 4020.0 (iPhone; iPhone OS 5.0.1; fr_FR)
 	 * - Mozilla/5.0 (iPhone; U; CPU iPhone OS 5_0 like Mac OS X; en_US) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/4.0.2;FBBV/4020.0;FBDV/iPhone3,1;FBMD/iPhone;FBSN/iPhone OS;FBSV/5.0;FBSS/2; FBCR/O2;FBID/phone;FBLC/en_US;FBSF/2.0]
 	 * - Mozilla/5.0 (iPhone; CPU iPhone OS 5_1_1 like Mac OS X) AppleWebKit/534.46 (KHTML, like Gecko) Mobile/9B206 [FBAN/FBIOS;FBAV/5.0;FBBV/47423;FBDV/iPhone3,1;FBMD/iPhone;FBSN/iPhone OS;FBSV/5.1.1;FBSS/2; FBCR/3ITA;FBID/phone;FBLC/en_US]
+	 *
+	 * @param string|null $user_agent Optional. User agent string to check. If not provided, uses $_SERVER['HTTP_USER_AGENT'].
 	 */
-	public static function is_facebook_for_iphone() {
-		if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
+	public static function is_facebook_for_iphone( $user_agent = null ) {
+		if ( null === $user_agent ) {
+			if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
+				return false;
+			}
+			$user_agent = wp_unslash( $_SERVER['HTTP_USER_AGENT'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
+		}
+
+		if ( empty( $user_agent ) ) {
 			return false;
 		}
 
-		$ua = strtolower( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
+		$ua = strtolower( wp_unslash( $user_agent ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
 
 		if ( false === strpos( $ua, 'iphone' ) ) {
 			return false;
@@ -647,13 +691,22 @@ class User_Agent_Info {
 	 * - Facebook 4020.0 (iPad; iPhone OS 5.0.1; en_US)
 	 * - Mozilla/5.0 (iPad; U; CPU iPhone OS 5_0 like Mac OS X; en_US) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/4.0.2;FBBV/4020.0;FBDV/iPad2,1;FBMD/iPad;FBSN/iPhone OS;FBSV/5.0;FBSS/1; FBCR/;FBID/tablet;FBLC/en_US;FBSF/1.0]
 	 * - Mozilla/5.0 (iPad; CPU OS 6_0 like Mac OS X) AppleWebKit/536.26 (KHTML, like Gecko) Mobile/10A403 [FBAN/FBIOS;FBAV/5.0;FBBV/47423;FBDV/iPad2,1;FBMD/iPad;FBSN/iPhone OS;FBSV/6.0;FBSS/1; FBCR/;FBID/tablet;FBLC/en_US]
+	 *
+	 * @param string|null $user_agent Optional. User agent string to check. If not provided, uses $_SERVER['HTTP_USER_AGENT'].
 	 */
-	public static function is_facebook_for_ipad() {
-		if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
+	public static function is_facebook_for_ipad( $user_agent = null ) {
+		if ( null === $user_agent ) {
+			if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
+				return false;
+			}
+			$user_agent = wp_unslash( $_SERVER['HTTP_USER_AGENT'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
+		}
+
+		if ( empty( $user_agent ) ) {
 			return false;
 		}
 
-		$ua = strtolower( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
+		$ua = strtolower( wp_unslash( $user_agent ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
 
 		if ( false === strpos( $ua, 'ipad' ) ) {
 			return false;
@@ -668,13 +721,22 @@ class User_Agent_Info {
 
 	/**
 	 *  Detects if the current UA is WordPress for iOS
+	 *
+	 * @param string|null $user_agent Optional. User agent string to check. If not provided, uses $_SERVER['HTTP_USER_AGENT'].
 	 */
-	public static function is_wordpress_for_ios() {
-		if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
+	public static function is_wordpress_for_ios( $user_agent = null ) {
+		if ( null === $user_agent ) {
+			if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
+				return false;
+			}
+			$user_agent = wp_unslash( $_SERVER['HTTP_USER_AGENT'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
+		}
+
+		if ( empty( $user_agent ) ) {
 			return false;
 		}
 
-		$ua = strtolower( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
+		$ua = strtolower( wp_unslash( $user_agent ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
 		if ( false !== strpos( $ua, 'wp-iphone' ) ) {
 			return true;
 		} else {
@@ -690,15 +752,22 @@ class User_Agent_Info {
 	 * you should put the check condition before the check for 'iphone-any' or 'iphone-not-safari'.
 	 * Otherwise those browsers will be 'catched' by the ipad string.
 	 *
-	 * @param string $type iPad type.
+	 * @param string      $type       iPad type.
+	 * @param string|null $user_agent Optional. User agent string to check. If not provided, uses $_SERVER['HTTP_USER_AGENT'].
 	 */
-	public static function is_ipad( $type = 'ipad-any' ) {
+	public static function is_ipad( $type = 'ipad-any', $user_agent = null ) {
+		if ( null === $user_agent ) {
+			if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
+				return false;
+			}
+			$user_agent = wp_unslash( $_SERVER['HTTP_USER_AGENT'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
+		}
 
-		if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
+		if ( empty( $user_agent ) ) {
 			return false;
 		}
 
-		$ua = strtolower( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
+		$ua = strtolower( wp_unslash( $user_agent ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
 
 		$is_ipad   = ( false !== strpos( $ua, 'ipad' ) );
 		$is_safari = ( false !== strpos( $ua, 'safari' ) );
@@ -718,14 +787,22 @@ class User_Agent_Info {
 	 * See http://www.useragentstring.com/pages/Fennec/
 	 * Mozilla/5.0 (Windows NT 6.1; WOW64; rv:2.1.1) Gecko/20110415 Firefox/4.0.2pre Fennec/4.0.1
 	 * Mozilla/5.0 (X11; U; Linux i686; en-US; rv:1.9.1b2pre) Gecko/20081015 Fennec/1.0a1
+	 *
+	 * @param string|null $user_agent Optional. User agent string to check. If not provided, uses $_SERVER['HTTP_USER_AGENT'].
 	 */
-	public static function is_firefox_mobile() {
+	public static function is_firefox_mobile( $user_agent = null ) {
+		if ( null === $user_agent ) {
+			if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
+				return false;
+			}
+			$user_agent = wp_unslash( $_SERVER['HTTP_USER_AGENT'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
+		}
 
-		if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
+		if ( empty( $user_agent ) ) {
 			return false;
 		}
 
-		$ua = strtolower( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
+		$ua = strtolower( wp_unslash( $user_agent ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
 
 		if ( strpos( $ua, 'fennec' ) !== false ) {
 			return true;
@@ -740,14 +817,22 @@ class User_Agent_Info {
 	 * See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/User-Agent/Firefox
 	 * Mozilla/5.0 (platform; rv:geckoversion) Gecko/geckotrail Firefox/firefoxversion
 	 * The platform section will include 'Mobile' for phones and 'Tablet' for tablets.
+	 *
+	 * @param string|null $user_agent Optional. User agent string to check. If not provided, uses $_SERVER['HTTP_USER_AGENT'].
 	 */
-	public static function is_firefox_desktop() {
+	public static function is_firefox_desktop( $user_agent = null ) {
+		if ( null === $user_agent ) {
+			if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
+				return false;
+			}
+			$user_agent = wp_unslash( $_SERVER['HTTP_USER_AGENT'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
+		}
 
-		if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
+		if ( empty( $user_agent ) ) {
 			return false;
 		}
 
-		$ua = strtolower( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
+		$ua = strtolower( wp_unslash( $user_agent ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
 
 		if ( false !== strpos( $ua, 'firefox' ) && false === strpos( $ua, 'mobile' ) && false === strpos( $ua, 'tablet' ) ) {
 			return true;
@@ -760,14 +845,22 @@ class User_Agent_Info {
 	 * Detects if the current browser is FirefoxOS Native browser
 	 *
 	 * Mozilla/5.0 (Mobile; rv:14.0) Gecko/14.0 Firefox/14.0
+	 *
+	 * @param string|null $user_agent Optional. User agent string to check. If not provided, uses $_SERVER['HTTP_USER_AGENT'].
 	 */
-	public static function is_firefox_os() {
+	public static function is_firefox_os( $user_agent = null ) {
+		if ( null === $user_agent ) {
+			if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
+				return false;
+			}
+			$user_agent = wp_unslash( $_SERVER['HTTP_USER_AGENT'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
+		}
 
-		if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
+		if ( empty( $user_agent ) ) {
 			return false;
 		}
 
-		$ua = strtolower( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
+		$ua = strtolower( wp_unslash( $user_agent ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
 
 		if ( strpos( $ua, 'mozilla' ) !== false && strpos( $ua, 'mobile' ) !== false && strpos( $ua, 'gecko' ) !== false && strpos( $ua, 'firefox' ) !== false ) {
 			return true;
@@ -778,12 +871,22 @@ class User_Agent_Info {
 
 	/**
 	 * Detect Safari browser
+	 *
+	 * @param string|null $user_agent Optional. User agent string to check. If not provided, uses $_SERVER['HTTP_USER_AGENT'].
 	 */
-	public static function is_safari_browser() {
-		if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
+	public static function is_safari_browser( $user_agent = null ) {
+		if ( null === $user_agent ) {
+			if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
+				return false;
+			}
+			$user_agent = wp_unslash( $_SERVER['HTTP_USER_AGENT'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
+		}
+
+		if ( empty( $user_agent ) ) {
 			return false;
 		}
-		if ( false === strpos( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ), 'Safari' ) ) { // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
+
+		if ( false === strpos( wp_unslash( $user_agent ), 'Safari' ) ) { // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
 			return false;
 		}
 		return true;
@@ -791,25 +894,45 @@ class User_Agent_Info {
 
 	/**
 	 * Detect Edge browser
+	 *
+	 * @param string|null $user_agent Optional. User agent string to check. If not provided, uses $_SERVER['HTTP_USER_AGENT'].
 	 */
-	public static function is_edge_browser() {
-		if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
+	public static function is_edge_browser( $user_agent = null ) {
+		if ( null === $user_agent ) {
+			if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
+				return false;
+			}
+			$user_agent = wp_unslash( $_SERVER['HTTP_USER_AGENT'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
+		}
+
+		if ( empty( $user_agent ) ) {
 			return false;
 		}
-		if ( false === strpos( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ), 'Edge' ) ) { // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
+
+		if ( false === strpos( wp_unslash( $user_agent ), 'Edge' ) ) { // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
 			return false;
 		}
 		return true;
 	}
 
 	/**
-	 * Detect Edge browser
+	 * Detect IE browser
+	 *
+	 * @param string|null $user_agent Optional. User agent string to check. If not provided, uses $_SERVER['HTTP_USER_AGENT'].
 	 */
-	public static function is_ie_browser() {
-		if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
+	public static function is_ie_browser( $user_agent = null ) {
+		if ( null === $user_agent ) {
+			if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
+				return false;
+			}
+			$user_agent = wp_unslash( $_SERVER['HTTP_USER_AGENT'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
+		}
+
+		if ( empty( $user_agent ) ) {
 			return false;
 		}
-		$ua = wp_unslash( $_SERVER['HTTP_USER_AGENT'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
+
+		$ua = wp_unslash( $user_agent ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
 		if ( false === ( strpos( $ua, 'MSIE' ) || strpos( $ua, 'Trident/7' ) ) ) {
 			return false;
 		}
@@ -822,13 +945,22 @@ class User_Agent_Info {
 	 * Mozilla/5.0 (Macintosh; Intel Mac OS X 11_2_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/88.0.4324.182 Safari/537.36 OPR/74.0.3911.203
 	 *
 	 * Looking for "OPR/" specifically.
+	 *
+	 * @param string|null $user_agent Optional. User agent string to check. If not provided, uses $_SERVER['HTTP_USER_AGENT'].
 	 */
-	public static function is_opera_desktop() {
-		if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
+	public static function is_opera_desktop( $user_agent = null ) {
+		if ( null === $user_agent ) {
+			if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
+				return false;
+			}
+			$user_agent = wp_unslash( $_SERVER['HTTP_USER_AGENT'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
+		}
+
+		if ( empty( $user_agent ) ) {
 			return false;
 		}
 
-		if ( false === strpos( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ), 'OPR/' ) ) { // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
+		if ( false === strpos( wp_unslash( $user_agent ), 'OPR/' ) ) { // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
 			return false;
 		}
 
@@ -846,13 +978,22 @@ class User_Agent_Info {
 	 *
 	 * Opera/9.80 (Windows NT 6.1; Opera Mobi/14316; U; en) Presto/2.7.81 Version/11.00"
 	 * Opera/9.50 (Nintendo DSi; Opera/507; U; en-US)
+	 *
+	 * @param string|null $user_agent Optional. User agent string to check. If not provided, uses $_SERVER['HTTP_USER_AGENT'].
 	 */
-	public static function is_opera_mobile() {
-		if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
+	public static function is_opera_mobile( $user_agent = null ) {
+		if ( null === $user_agent ) {
+			if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
+				return false;
+			}
+			$user_agent = wp_unslash( $_SERVER['HTTP_USER_AGENT'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
+		}
+
+		if ( empty( $user_agent ) ) {
 			return false;
 		}
 
-		$ua = strtolower( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
+		$ua = strtolower( wp_unslash( $user_agent ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
 
 		if ( strpos( $ua, 'opera' ) !== false && strpos( $ua, 'mobi' ) !== false ) {
 			return true;
@@ -873,13 +1014,22 @@ class User_Agent_Info {
 	 * Opera/9.80 (J2ME/iPhone;Opera Mini/5.0.019802/886; U; ja) Presto/2.4.15
 	 * Opera/9.80 (Series 60; Opera Mini/5.1.22783/23.334; U; en) Presto/2.5.25 Version/10.54
 	 * Opera/9.80 (BlackBerry; Opera Mini/5.1.22303/22.387; U; en) Presto/2.5.25 Version/10.54
+	 *
+	 * @param string|null $user_agent Optional. User agent string to check. If not provided, uses $_SERVER['HTTP_USER_AGENT'].
 	 */
-	public static function is_opera_mini() {
-		if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
+	public static function is_opera_mini( $user_agent = null ) {
+		if ( null === $user_agent ) {
+			if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
+				return false;
+			}
+			$user_agent = wp_unslash( $_SERVER['HTTP_USER_AGENT'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
+		}
+
+		if ( empty( $user_agent ) ) {
 			return false;
 		}
 
-		$ua = strtolower( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
+		$ua = strtolower( wp_unslash( $user_agent ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
 
 		if ( strpos( $ua, 'opera' ) !== false && strpos( $ua, 'mini' ) !== false ) {
 			return true;
@@ -891,14 +1041,24 @@ class User_Agent_Info {
 	/**
 	 * Detects if the current browser is Opera Mini, but not on a smart device OS(Android, iOS, etc)
 	 * Used to send users on dumb devices to m.wor
+	 *
+	 * @param string|null $user_agent Optional. User agent string to check. If not provided, uses $_SERVER['HTTP_USER_AGENT'].
 	 */
-	public static function is_opera_mini_dumb() {
-		if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
+	public static function is_opera_mini_dumb( $user_agent = null ) {
+		if ( null === $user_agent ) {
+			if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
+				return false;
+			}
+			$user_agent = wp_unslash( $_SERVER['HTTP_USER_AGENT'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
+		}
+
+		if ( empty( $user_agent ) ) {
 			return false;
 		}
-		$ua = strtolower( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
 
-		if ( self::is_opera_mini() ) {
+		$ua = strtolower( wp_unslash( $user_agent ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
+
+		if ( self::is_opera_mini( $user_agent ) ) {
 			if ( strpos( $ua, 'android' ) !== false || strpos( $ua, 'iphone' ) !== false || strpos( $ua, 'ipod' ) !== false
 			|| strpos( $ua, 'ipad' ) !== false || strpos( $ua, 'blackberry' ) !== false ) {
 				return false;
@@ -913,17 +1073,26 @@ class User_Agent_Info {
 	/**
 	 * Detects if the current browser is a Windows Phone 7 device.
 	 * ex: Mozilla/4.0 (compatible; MSIE 7.0; Windows Phone OS 7.0; Trident/3.1; IEMobile/7.0; LG; GW910)
+	 *
+	 * @param string|null $user_agent Optional. User agent string to check. If not provided, uses $_SERVER['HTTP_USER_AGENT'].
 	 */
-	public static function is_WindowsPhone7() {
-		if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
+	public static function is_WindowsPhone7( $user_agent = null ) {
+		if ( null === $user_agent ) {
+			if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
+				return false;
+			}
+			$user_agent = wp_unslash( $_SERVER['HTTP_USER_AGENT'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
+		}
+
+		if ( empty( $user_agent ) ) {
 			return false;
 		}
 
-		$ua = strtolower( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
+		$ua = strtolower( wp_unslash( $user_agent ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
 
 		if ( false === strpos( $ua, 'windows phone os 7' ) ) {
 			return false;
-		} elseif ( self::is_opera_mini() || self::is_opera_mobile() || self::is_firefox_mobile() ) {
+		} elseif ( self::is_opera_mini( $user_agent ) || self::is_opera_mobile( $user_agent ) || self::is_firefox_mobile( $user_agent ) ) {
 			return false;
 		} else {
 			return true;
@@ -933,13 +1102,22 @@ class User_Agent_Info {
 	/**
 	 * Detects if the current browser is a Windows Phone 8 device.
 	 * ex: Mozilla/5.0 (compatible; MSIE 10.0; Windows Phone 8.0; Trident/6.0; ARM; Touch; IEMobile/10.0; <Manufacturer>; <Device> [;<Operator>])
+	 *
+	 * @param string|null $user_agent Optional. User agent string to check. If not provided, uses $_SERVER['HTTP_USER_AGENT'].
 	 */
-	public static function is_windows_phone_8() {
-		if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
+	public static function is_windows_phone_8( $user_agent = null ) {
+		if ( null === $user_agent ) {
+			if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
+				return false;
+			}
+			$user_agent = wp_unslash( $_SERVER['HTTP_USER_AGENT'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
+		}
+
+		if ( empty( $user_agent ) ) {
 			return false;
 		}
 
-		$ua = strtolower( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
+		$ua = strtolower( wp_unslash( $user_agent ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
 		if ( strpos( $ua, 'windows phone 8' ) === false ) {
 			return false;
 		} else {
@@ -952,17 +1130,26 @@ class User_Agent_Info {
 	 *
 	 * Ex1: Mozilla/5.0 (webOS/1.4.0; U; en-US) AppleWebKit/532.2 (KHTML, like Gecko) Version/1.0 Safari/532.2 Pre/1.1
 	 * Ex2: Mozilla/5.0 (webOS/1.4.0; U; en-US) AppleWebKit/532.2 (KHTML, like Gecko) Version/1.0 Safari/532.2 Pixi/1.1
+	 *
+	 * @param string|null $user_agent Optional. User agent string to check. If not provided, uses $_SERVER['HTTP_USER_AGENT'].
 	 */
-	public static function is_PalmWebOS() {
-		if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
+	public static function is_PalmWebOS( $user_agent = null ) {
+		if ( null === $user_agent ) {
+			if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
+				return false;
+			}
+			$user_agent = wp_unslash( $_SERVER['HTTP_USER_AGENT'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
+		}
+
+		if ( empty( $user_agent ) ) {
 			return false;
 		}
 
-		$ua = strtolower( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
+		$ua = strtolower( wp_unslash( $user_agent ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
 
 		if ( false === strpos( $ua, 'webos' ) ) {
 			return false;
-		} elseif ( self::is_opera_mini() || self::is_opera_mobile() || self::is_firefox_mobile() ) {
+		} elseif ( self::is_opera_mini( $user_agent ) || self::is_opera_mobile( $user_agent ) || self::is_firefox_mobile( $user_agent ) ) {
 			return false;
 		} else {
 			return true;
@@ -974,15 +1161,24 @@ class User_Agent_Info {
 	 *
 	 * TouchPad Emulator: Mozilla/5.0 (hp-desktop; Linux; hpwOS/2.0; U; it-IT) AppleWebKit/534.6 (KHTML, like Gecko) wOSBrowser/233.70 Safari/534.6 Desktop/1.0
 	 * TouchPad: Mozilla/5.0 (hp-tablet; Linux; hpwOS/3.0.0; U; en-US) AppleWebKit/534.6 (KHTML, like Gecko) wOSBrowser/233.70 Safari/534.6 TouchPad/1.0
+	 *
+	 * @param string|null $user_agent Optional. User agent string to check. If not provided, uses $_SERVER['HTTP_USER_AGENT'].
 	 */
-	public static function is_TouchPad() {
-		if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
+	public static function is_TouchPad( $user_agent = null ) {
+		if ( null === $user_agent ) {
+			if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
+				return false;
+			}
+			$user_agent = wp_unslash( $_SERVER['HTTP_USER_AGENT'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
+		}
+
+		if ( empty( $user_agent ) ) {
 			return false;
 		}
 
-		$http_user_agent = strtolower( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
+		$http_user_agent = strtolower( wp_unslash( $user_agent ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
 		if ( false !== strpos( $http_user_agent, 'hp-tablet' ) || false !== strpos( $http_user_agent, 'hpwos' ) || false !== strpos( $http_user_agent, 'touchpad' ) ) {
-			if ( self::is_opera_mini() || self::is_opera_mobile() || self::is_firefox_mobile() ) {
+			if ( self::is_opera_mini( $user_agent ) || self::is_opera_mobile( $user_agent ) || self::is_firefox_mobile( $user_agent ) ) {
 				return false;
 			} else {
 				return true;
@@ -1000,15 +1196,23 @@ class User_Agent_Info {
 	 * 7.0 Browser (Nokia 5800 XpressMusic (v21.0.025)) : Mozilla/5.0 (SymbianOS/9.4; U; Series60/5.0 Nokia5800d-1/21.0.025; Profile/MIDP-2.1 Configuration/CLDC-1.1 ) AppleWebKit/413 (KHTML, like Gecko) Safari/413
 	 *
 	 * Browser 7.1 (Nokia N97 (v12.0.024)) : Mozilla/5.0 (SymbianOS/9.4; Series60/5.0 NokiaN97-1/12.0.024; Profile/MIDP-2.1 Configuration/CLDC-1.1; en-us) AppleWebKit/525 (KHTML, like Gecko) BrowserNG/7.1.12344
+	 *
+	 * @param string|null $user_agent Optional. User agent string to check. If not provided, uses $_SERVER['HTTP_USER_AGENT'].
 	 */
-	public static function is_S60_OSSBrowser() {
+	public static function is_S60_OSSBrowser( $user_agent = null ) {
+		if ( null === $user_agent ) {
+			if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
+				return false;
+			}
+			$user_agent = wp_unslash( $_SERVER['HTTP_USER_AGENT'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
+		}
 
-		if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
+		if ( empty( $user_agent ) ) {
 			return false;
 		}
 
-		$agent = strtolower( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
-		if ( self::is_opera_mini() || self::is_opera_mobile() || self::is_firefox_mobile() ) {
+		$agent = strtolower( wp_unslash( $user_agent ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
+		if ( self::is_opera_mini( $user_agent ) || self::is_opera_mobile( $user_agent ) || self::is_firefox_mobile( $user_agent ) ) {
 			return false;
 		}
 
@@ -1031,14 +1235,22 @@ class User_Agent_Info {
 
 	/**
 	 * Detects if the device platform is the Symbian Series 60.
+	 *
+	 * @param string|null $user_agent Optional. User agent string to check. If not provided, uses $_SERVER['HTTP_USER_AGENT'].
 	 */
-	public static function is_symbian_platform() {
+	public static function is_symbian_platform( $user_agent = null ) {
+		if ( null === $user_agent ) {
+			if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
+				return false;
+			}
+			$user_agent = wp_unslash( $_SERVER['HTTP_USER_AGENT'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
+		}
 
-		if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
+		if ( empty( $user_agent ) ) {
 			return false;
 		}
 
-		$agent = strtolower( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
+		$agent = strtolower( wp_unslash( $user_agent ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
 
 		$pos_webkit = strpos( $agent, 'webkit' );
 		if ( false !== $pos_webkit ) {
@@ -1065,14 +1277,22 @@ class User_Agent_Info {
 	 * Detects if the device platform is the Symbian Series 40.
 	 * Nokia Browser for Series 40 is a proxy based browser, previously known as Ovi Browser.
 	 * This browser will report 'NokiaBrowser' in the header, however some older version will also report 'OviBrowser'.
+	 *
+	 * @param string|null $user_agent Optional. User agent string to check. If not provided, uses $_SERVER['HTTP_USER_AGENT'].
 	 */
-	public static function is_symbian_s40_platform() {
+	public static function is_symbian_s40_platform( $user_agent = null ) {
+		if ( null === $user_agent ) {
+			if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
+				return false;
+			}
+			$user_agent = wp_unslash( $_SERVER['HTTP_USER_AGENT'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
+		}
 
-		if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
+		if ( empty( $user_agent ) ) {
 			return false;
 		}
 
-		$agent = strtolower( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
+		$agent = strtolower( wp_unslash( $user_agent ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
 
 		if ( strpos( $agent, 'series40' ) !== false ) {
 			if ( strpos( $agent, 'nokia' ) !== false || strpos( $agent, 'ovibrowser' ) !== false || strpos( $agent, 'nokiabrowser' ) !== false ) {
@@ -1086,15 +1306,23 @@ class User_Agent_Info {
 	/**
 	 * Returns if the device belongs to J2ME capable family.
 	 *
+	 * @param string|null $user_agent Optional. User agent string to check. If not provided, uses $_SERVER['HTTP_USER_AGENT'].
+	 *
 	 * @return bool
 	 */
-	public static function is_J2ME_platform() {
+	public static function is_J2ME_platform( $user_agent = null ) {
+		if ( null === $user_agent ) {
+			if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
+				return false;
+			}
+			$user_agent = wp_unslash( $_SERVER['HTTP_USER_AGENT'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
+		}
 
-		if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
+		if ( empty( $user_agent ) ) {
 			return false;
 		}
 
-		$agent = strtolower( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
+		$agent = strtolower( wp_unslash( $user_agent ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
 
 		if ( strpos( $agent, 'j2me/midp' ) !== false ) {
 			return true;
@@ -1106,14 +1334,22 @@ class User_Agent_Info {
 
 	/**
 	 * Detects if the current UA is on one of the Maemo-based Nokia Internet Tablets.
+	 *
+	 * @param string|null $user_agent Optional. User agent string to check. If not provided, uses $_SERVER['HTTP_USER_AGENT'].
 	 */
-	public static function is_MaemoTablet() {
+	public static function is_MaemoTablet( $user_agent = null ) {
+		if ( null === $user_agent ) {
+			if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
+				return false;
+			}
+			$user_agent = wp_unslash( $_SERVER['HTTP_USER_AGENT'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
+		}
 
-		if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
+		if ( empty( $user_agent ) ) {
 			return false;
 		}
 
-		$agent = strtolower( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
+		$agent = strtolower( wp_unslash( $user_agent ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
 
 		$pos_maemo = strpos( $agent, 'maemo' );
 		if ( false === $pos_maemo ) {
@@ -1122,7 +1358,7 @@ class User_Agent_Info {
 
 		// Must be Linux + Tablet, or else it could be something else.
 		if ( strpos( $agent, 'tablet' ) !== false && strpos( $agent, 'linux' ) !== false ) {
-			if ( self::is_opera_mini() || self::is_opera_mobile() || self::is_firefox_mobile() ) {
+			if ( self::is_opera_mini( $user_agent ) || self::is_opera_mobile( $user_agent ) || self::is_firefox_mobile( $user_agent ) ) {
 				return false;
 			} else {
 				return true;
@@ -1134,18 +1370,26 @@ class User_Agent_Info {
 
 	/**
 	 * Detects if the current UA is a MeeGo device (Nokia Smartphone).
+	 *
+	 * @param string|null $user_agent Optional. User agent string to check. If not provided, uses $_SERVER['HTTP_USER_AGENT'].
 	 */
-	public static function is_MeeGo() {
+	public static function is_MeeGo( $user_agent = null ) {
+		if ( null === $user_agent ) {
+			if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
+				return false;
+			}
+			$user_agent = wp_unslash( $_SERVER['HTTP_USER_AGENT'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
+		}
 
-		if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
+		if ( empty( $user_agent ) ) {
 			return false;
 		}
 
-		$ua = strtolower( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
+		$ua = strtolower( wp_unslash( $user_agent ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
 
 		if ( false === strpos( $ua, 'meego' ) ) {
 			return false;
-		} elseif ( self::is_opera_mini() || self::is_opera_mobile() || self::is_firefox_mobile() ) {
+		} elseif ( self::is_opera_mini( $user_agent ) || self::is_opera_mobile( $user_agent ) || self::is_firefox_mobile( $user_agent ) ) {
 			return false;
 		} else {
 			return true;
@@ -1154,14 +1398,22 @@ class User_Agent_Info {
 
 	/**
 	 * The is_webkit() method can be used to check the User Agent for an webkit generic browser.
+	 *
+	 * @param string|null $user_agent Optional. User agent string to check. If not provided, uses $_SERVER['HTTP_USER_AGENT'].
 	 */
-	public static function is_webkit() {
+	public static function is_webkit( $user_agent = null ) {
+		if ( null === $user_agent ) {
+			if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
+				return false;
+			}
+			$user_agent = wp_unslash( $_SERVER['HTTP_USER_AGENT'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
+		}
 
-		if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
+		if ( empty( $user_agent ) ) {
 			return false;
 		}
 
-		$agent = strtolower( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
+		$agent = strtolower( wp_unslash( $user_agent ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
 
 		$pos_webkit = strpos( $agent, 'webkit' );
 
@@ -1175,17 +1427,26 @@ class User_Agent_Info {
 	/**
 	 * Detects if the current browser is the Native Android browser.
 	 *
+	 * @param string|null $user_agent Optional. User agent string to check. If not provided, uses $_SERVER['HTTP_USER_AGENT'].
+	 *
 	 * @return boolean true if the browser is Android otherwise false
 	 */
-	public static function is_android() {
-		if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
+	public static function is_android( $user_agent = null ) {
+		if ( null === $user_agent ) {
+			if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
+				return false;
+			}
+			$user_agent = wp_unslash( $_SERVER['HTTP_USER_AGENT'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
+		}
+
+		if ( empty( $user_agent ) ) {
 			return false;
 		}
 
-		$agent       = strtolower( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
+		$agent       = strtolower( wp_unslash( $user_agent ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
 		$pos_android = strpos( $agent, 'android' );
 		if ( false !== $pos_android ) {
-			if ( self::is_opera_mini() || self::is_opera_mobile() || self::is_firefox_mobile() ) {
+			if ( self::is_opera_mini( $user_agent ) || self::is_opera_mobile( $user_agent ) || self::is_firefox_mobile( $user_agent ) ) {
 				return false;
 			} else {
 				return true;
@@ -1199,21 +1460,30 @@ class User_Agent_Info {
 	 * Detects if the current browser is the Native Android Tablet browser.
 	 * Assumes 'Android' should be in the user agent, but not 'mobile'
 	 *
+	 * @param string|null $user_agent Optional. User agent string to check. If not provided, uses $_SERVER['HTTP_USER_AGENT'].
+	 *
 	 * @return boolean true if the browser is Android and not 'mobile' otherwise false
 	 */
-	public static function is_android_tablet() {
-		if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
+	public static function is_android_tablet( $user_agent = null ) {
+		if ( null === $user_agent ) {
+			if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
+				return false;
+			}
+			$user_agent = wp_unslash( $_SERVER['HTTP_USER_AGENT'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
+		}
+
+		if ( empty( $user_agent ) ) {
 			return false;
 		}
 
-		$agent = strtolower( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
+		$agent = strtolower( wp_unslash( $user_agent ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
 
 		$pos_android      = strpos( $agent, 'android' );
 		$pos_mobile       = strpos( $agent, 'mobile' );
 		$post_android_app = strpos( $agent, 'wp-android' );
 
 		if ( false !== $pos_android && false === $pos_mobile && false === $post_android_app ) {
-			if ( self::is_opera_mini() || self::is_opera_mobile() || self::is_firefox_mobile() ) {
+			if ( self::is_opera_mini( $user_agent ) || self::is_opera_mobile( $user_agent ) || self::is_firefox_mobile( $user_agent ) ) {
 				return false;
 			} else {
 				return true;
@@ -1229,14 +1499,23 @@ class User_Agent_Info {
 	 * Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_3; en-us; Silk/1.1.0-84) AppleWebKit/533.16 (KHTML, like Gecko) Version/5.0 Safari/533.16 Silk-Accelerated=true
 	 * Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_3; en-us; Silk/1.1.0-84) AppleWebKit/533.16 (KHTML, like Gecko) Version/5.0 Safari/533.16 Silk-Accelerated=false
 	 *
+	 * @param string|null $user_agent Optional. User agent string to check. If not provided, uses $_SERVER['HTTP_USER_AGENT'].
+	 *
 	 * @return boolean true if the browser is Kindle Fire Native browser otherwise false
 	 */
-	public static function is_kindle_fire() {
-		if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
+	public static function is_kindle_fire( $user_agent = null ) {
+		if ( null === $user_agent ) {
+			if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
+				return false;
+			}
+			$user_agent = wp_unslash( $_SERVER['HTTP_USER_AGENT'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
+		}
+
+		if ( empty( $user_agent ) ) {
 			return false;
 		}
 
-		$agent        = strtolower( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
+		$agent        = strtolower( wp_unslash( $user_agent ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
 		$pos_silk     = strpos( $agent, 'silk/' );
 		$pos_silk_acc = strpos( $agent, 'silk-accelerated=' );
 		if ( false !== $pos_silk && false !== $pos_silk_acc ) {
@@ -1251,15 +1530,25 @@ class User_Agent_Info {
 	 *
 	 * Mozilla/5.0 (X11; U; Linux armv7l like Android; en-us) AppleWebKit/531.2+ (KHTML, like Gecko) Version/5.0 Safari/533.2+ Kindle/3.0+
 	 *
+	 * @param string|null $user_agent Optional. User agent string to check. If not provided, uses $_SERVER['HTTP_USER_AGENT'].
+	 *
 	 * @return boolean true if the browser is Kindle monochrome Native browser otherwise false
 	 */
-	public static function is_kindle_touch() {
-		if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
+	public static function is_kindle_touch( $user_agent = null ) {
+		if ( null === $user_agent ) {
+			if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
+				return false;
+			}
+			$user_agent = wp_unslash( $_SERVER['HTTP_USER_AGENT'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
+		}
+
+		if ( empty( $user_agent ) ) {
 			return false;
 		}
-		$agent            = strtolower( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
+
+		$agent            = strtolower( wp_unslash( $user_agent ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
 		$pos_kindle_touch = strpos( $agent, 'kindle/3.0+' );
-		if ( false !== $pos_kindle_touch && false === self::is_kindle_fire() ) {
+		if ( false !== $pos_kindle_touch && false === self::is_kindle_fire( $user_agent ) ) {
 			return true;
 		} else {
 			return false;
@@ -1268,13 +1557,22 @@ class User_Agent_Info {
 
 	/**
 	 * Detect if user agent is the WordPress.com Windows 8 app (used ONLY on the custom oauth stylesheet)
+	 *
+	 * @param string|null $user_agent Optional. User agent string to check. If not provided, uses $_SERVER['HTTP_USER_AGENT'].
 	 */
-	public static function is_windows8_auth() {
-		if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
+	public static function is_windows8_auth( $user_agent = null ) {
+		if ( null === $user_agent ) {
+			if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
+				return false;
+			}
+			$user_agent = wp_unslash( $_SERVER['HTTP_USER_AGENT'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
+		}
+
+		if ( empty( $user_agent ) ) {
 			return false;
 		}
 
-		$agent = strtolower( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
+		$agent = strtolower( wp_unslash( $user_agent ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
 		$pos   = strpos( $agent, 'msauthhost' );
 		if ( false !== $pos ) {
 			return true;
@@ -1285,13 +1583,22 @@ class User_Agent_Info {
 
 	/**
 	 * Detect if user agent is the WordPress.com Windows 8 app.
+	 *
+	 * @param string|null $user_agent Optional. User agent string to check. If not provided, uses $_SERVER['HTTP_USER_AGENT'].
 	 */
-	public static function is_wordpress_for_win8() {
-		if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
+	public static function is_wordpress_for_win8( $user_agent = null ) {
+		if ( null === $user_agent ) {
+			if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
+				return false;
+			}
+			$user_agent = wp_unslash( $_SERVER['HTTP_USER_AGENT'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
+		}
+
+		if ( empty( $user_agent ) ) {
 			return false;
 		}
 
-		$agent = strtolower( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
+		$agent = strtolower( wp_unslash( $user_agent ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
 		$pos   = strpos( $agent, 'wp-windows8' );
 		if ( false !== $pos ) {
 			return true;
@@ -1302,13 +1609,22 @@ class User_Agent_Info {
 
 	/**
 	 * Detect if user agent is the WordPress.com Desktop app.
+	 *
+	 * @param string|null $user_agent Optional. User agent string to check. If not provided, uses $_SERVER['HTTP_USER_AGENT'].
 	 */
-	public static function is_wordpress_desktop_app() {
-		if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
+	public static function is_wordpress_desktop_app( $user_agent = null ) {
+		if ( null === $user_agent ) {
+			if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
+				return false;
+			}
+			$user_agent = wp_unslash( $_SERVER['HTTP_USER_AGENT'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
+		}
+
+		if ( empty( $user_agent ) ) {
 			return false;
 		}
 
-		$agent = strtolower( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
+		$agent = strtolower( wp_unslash( $user_agent ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
 		$pos   = strpos( $agent, 'WordPressDesktop' );
 		if ( false !== $pos ) {
 			return true;
@@ -1321,14 +1637,22 @@ class User_Agent_Info {
 	 * The is_blackberry_tablet() method can be used to check the User Agent for a RIM blackberry tablet.
 	 * The user agent of the BlackBerry® Tablet OS follows a format similar to the following:
 	 * Mozilla/5.0 (PlayBook; U; RIM Tablet OS 1.0.0; en-US) AppleWebKit/534.8+ (KHTML, like Gecko) Version/0.0.1 Safari/534.8+
+	 *
+	 * @param string|null $user_agent Optional. User agent string to check. If not provided, uses $_SERVER['HTTP_USER_AGENT'].
 	 */
-	public static function is_blackberry_tablet() {
+	public static function is_blackberry_tablet( $user_agent = null ) {
+		if ( null === $user_agent ) {
+			if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
+				return false;
+			}
+			$user_agent = wp_unslash( $_SERVER['HTTP_USER_AGENT'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
+		}
 
-		if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
+		if ( empty( $user_agent ) ) {
 			return false;
 		}
 
-		$agent          = strtolower( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
+		$agent          = strtolower( wp_unslash( $user_agent ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
 		$pos_playbook   = stripos( $agent, 'PlayBook' );
 		$pos_rim_tablet = stripos( $agent, 'RIM Tablet' );
 
@@ -1342,17 +1666,26 @@ class User_Agent_Info {
 	/**
 	 * The is_blackbeberry() method can be used to check the User Agent for a blackberry device.
 	 * Note that opera mini on BB matches this rule.
+	 *
+	 * @param string|null $user_agent Optional. User agent string to check. If not provided, uses $_SERVER['HTTP_USER_AGENT'].
 	 */
-	public static function is_blackbeberry() {
-		if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
+	public static function is_blackbeberry( $user_agent = null ) {
+		if ( null === $user_agent ) {
+			if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
+				return false;
+			}
+			$user_agent = wp_unslash( $_SERVER['HTTP_USER_AGENT'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
+		}
+
+		if ( empty( $user_agent ) ) {
 			return false;
 		}
 
-		$agent = strtolower( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
+		$agent = strtolower( wp_unslash( $user_agent ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
 
 		$pos_blackberry = strpos( $agent, 'blackberry' );
 		if ( false !== $pos_blackberry ) {
-			if ( self::is_opera_mini() || self::is_opera_mobile() || self::is_firefox_mobile() ) {
+			if ( self::is_opera_mini( $user_agent ) || self::is_opera_mobile( $user_agent ) || self::is_firefox_mobile( $user_agent ) ) {
 				return false;
 			} else {
 				return true;
@@ -1364,25 +1697,45 @@ class User_Agent_Info {
 
 	/**
 	 * The is_blackberry_10() method can be used to check the User Agent for a BlackBerry 10 device.
+	 *
+	 * @param string|null $user_agent Optional. User agent string to check. If not provided, uses $_SERVER['HTTP_USER_AGENT'].
 	 */
-	public static function is_blackberry_10() {
-		if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
+	public static function is_blackberry_10( $user_agent = null ) {
+		if ( null === $user_agent ) {
+			if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
+				return false;
+			}
+			$user_agent = wp_unslash( $_SERVER['HTTP_USER_AGENT'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
+		}
+
+		if ( empty( $user_agent ) ) {
 			return false;
 		}
-		$agent = strtolower( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
+
+		$agent = strtolower( wp_unslash( $user_agent ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
 		return ( strpos( $agent, 'bb10' ) !== false ) && ( strpos( $agent, 'mobile' ) !== false );
 	}
 
 	/**
 	 * Determines whether a desktop platform is Linux OS
 	 *
+	 * @param string|null $user_agent Optional. User agent string to check. If not provided, uses $_SERVER['HTTP_USER_AGENT'].
+	 *
 	 * @return bool
 	 */
-	public static function is_linux_desktop() {
-		if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
+	public static function is_linux_desktop( $user_agent = null ) {
+		if ( null === $user_agent ) {
+			if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
+				return false;
+			}
+			$user_agent = wp_unslash( $_SERVER['HTTP_USER_AGENT'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
+		}
+
+		if ( empty( $user_agent ) ) {
 			return false;
 		}
-		if ( ! preg_match( '/linux/i', wp_unslash( $_SERVER['HTTP_USER_AGENT'] ) ) ) { // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
+
+		if ( ! preg_match( '/linux/i', wp_unslash( $user_agent ) ) ) { // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
 			return false;
 		}
 		return true;
@@ -1391,13 +1744,23 @@ class User_Agent_Info {
 	/**
 	 * Determines whether a desktop platform is Mac OS
 	 *
+	 * @param string|null $user_agent Optional. User agent string to check. If not provided, uses $_SERVER['HTTP_USER_AGENT'].
+	 *
 	 * @return bool
 	 */
-	public static function is_mac_desktop() {
-		if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
+	public static function is_mac_desktop( $user_agent = null ) {
+		if ( null === $user_agent ) {
+			if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
+				return false;
+			}
+			$user_agent = wp_unslash( $_SERVER['HTTP_USER_AGENT'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
+		}
+
+		if ( empty( $user_agent ) ) {
 			return false;
 		}
-		if ( ! preg_match( '/macintosh|mac os x/i', wp_unslash( $_SERVER['HTTP_USER_AGENT'] ) ) ) { // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
+
+		if ( ! preg_match( '/macintosh|mac os x/i', wp_unslash( $user_agent ) ) ) { // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
 			return false;
 		}
 		return true;
@@ -1406,13 +1769,23 @@ class User_Agent_Info {
 	/**
 	 * Determines whether a desktop platform is Windows OS
 	 *
+	 * @param string|null $user_agent Optional. User agent string to check. If not provided, uses $_SERVER['HTTP_USER_AGENT'].
+	 *
 	 * @return bool
 	 */
-	public static function is_windows_desktop() {
-		if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
+	public static function is_windows_desktop( $user_agent = null ) {
+		if ( null === $user_agent ) {
+			if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
+				return false;
+			}
+			$user_agent = wp_unslash( $_SERVER['HTTP_USER_AGENT'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
+		}
+
+		if ( empty( $user_agent ) ) {
 			return false;
 		}
-		if ( ! preg_match( '/windows|win32/i', wp_unslash( $_SERVER['HTTP_USER_AGENT'] ) ) ) { // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
+
+		if ( ! preg_match( '/windows|win32/i', wp_unslash( $user_agent ) ) ) { // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
 			return false;
 		}
 		return true;
@@ -1421,13 +1794,23 @@ class User_Agent_Info {
 	/**
 	 * Determines whether a desktop platform is Chrome OS
 	 *
+	 * @param string|null $user_agent Optional. User agent string to check. If not provided, uses $_SERVER['HTTP_USER_AGENT'].
+	 *
 	 * @return bool
 	 */
-	public static function is_chrome_desktop() {
-		if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
+	public static function is_chrome_desktop( $user_agent = null ) {
+		if ( null === $user_agent ) {
+			if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
+				return false;
+			}
+			$user_agent = wp_unslash( $_SERVER['HTTP_USER_AGENT'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
+		}
+
+		if ( empty( $user_agent ) ) {
 			return false;
 		}
-		if ( ! preg_match( '/chrome/i', wp_unslash( $_SERVER['HTTP_USER_AGENT'] ) ) ) { // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
+
+		if ( ! preg_match( '/chrome/i', wp_unslash( $user_agent ) ) ) { // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
 			return false;
 		}
 		return true;
@@ -1446,20 +1829,28 @@ class User_Agent_Info {
 	 * - blackberry-4.6
 	 * - blackberry-4.5
 	 *
+	 * @param string|null $user_agent Optional. User agent string to check. If not provided, uses $_SERVER['HTTP_USER_AGENT'].
+	 *
 	 * @return string Version of the BB OS.
 	 * If version is not found, get_blackbeberry_OS_version will return boolean false.
 	 */
-	public static function get_blackbeberry_OS_version() {
+	public static function get_blackbeberry_OS_version( $user_agent = null ) {
+		if ( null === $user_agent ) {
+			if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
+				return false;
+			}
+			$user_agent = wp_unslash( $_SERVER['HTTP_USER_AGENT'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
+		}
 
-		if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
+		if ( empty( $user_agent ) ) {
 			return false;
 		}
 
-		if ( self::is_blackberry_10() ) {
+		if ( self::is_blackberry_10( $user_agent ) ) {
 			return 'blackberry-10';
 		}
 
-		$agent = strtolower( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
+		$agent = strtolower( wp_unslash( $user_agent ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
 
 		$pos_blackberry = stripos( $agent, 'blackberry' );
 		if ( false === $pos_blackberry ) {
@@ -1531,18 +1922,26 @@ class User_Agent_Info {
 	 * - blackberry-4.7
 	 * - blackberry-4.6
 	 *
+	 * @param string|null $user_agent Optional. User agent string to check. If not provided, uses $_SERVER['HTTP_USER_AGENT'].
+	 *
 	 * @return string Type of the BB browser.
 	 * If browser's version is not found, detect_blackbeberry_browser_version will return boolean false.
 	 */
-	public static function detect_blackberry_browser_version() {
+	public static function detect_blackberry_browser_version( $user_agent = null ) {
+		if ( null === $user_agent ) {
+			if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
+				return false;
+			}
+			$user_agent = wp_unslash( $_SERVER['HTTP_USER_AGENT'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
+		}
 
-		if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
+		if ( empty( $user_agent ) ) {
 			return false;
 		}
 
-		$agent = strtolower( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
+		$agent = strtolower( wp_unslash( $user_agent ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
 
-		if ( self::is_blackberry_10() ) {
+		if ( self::is_blackberry_10( $user_agent ) ) {
 			return 'blackberry-10';
 		}
 
@@ -1586,15 +1985,23 @@ class User_Agent_Info {
 	/**
 	 * Checks if a visitor is coming from one of the WordPress mobile apps.
 	 *
+	 * @param string|null $user_agent Optional. User agent string to check. If not provided, uses $_SERVER['HTTP_USER_AGENT'].
+	 *
 	 * @return bool
 	 */
-	public static function is_mobile_app() {
+	public static function is_mobile_app( $user_agent = null ) {
+		if ( null === $user_agent ) {
+			if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
+				return false;
+			}
+			$user_agent = wp_unslash( $_SERVER['HTTP_USER_AGENT'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
+		}
 
-		if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
+		if ( empty( $user_agent ) ) {
 			return false;
 		}
 
-		$agent = strtolower( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
+		$agent = strtolower( wp_unslash( $user_agent ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
 
 		if ( isset( $_SERVER['X_USER_AGENT'] ) && preg_match( '|wp-webos|', $_SERVER['X_USER_AGENT'] ) ) { // phpcs:ignore WordPress.Security.ValidatedSanitizedInput -- This is validating.
 			return true; // Wp4webos 1.1 or higher.
@@ -1620,13 +2027,22 @@ class User_Agent_Info {
 	 *
 	 * Example: Mozilla/5.0 (Nintendo 3DS; U; ; en) Version/1.7498.US
 	 * can differ in language, version and region
+	 *
+	 * @param string|null $user_agent Optional. User agent string to check. If not provided, uses $_SERVER['HTTP_USER_AGENT'].
 	 */
-	public static function is_Nintendo_3DS() {
-		if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
+	public static function is_Nintendo_3DS( $user_agent = null ) {
+		if ( null === $user_agent ) {
+			if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
+				return false;
+			}
+			$user_agent = wp_unslash( $_SERVER['HTTP_USER_AGENT'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
+		}
+
+		if ( empty( $user_agent ) ) {
 			return false;
 		}
 
-		$ua = strtolower( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
+		$ua = strtolower( wp_unslash( $user_agent ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
 		if ( strpos( $ua, 'nintendo 3ds' ) !== false ) {
 			return true;
 		}
@@ -1636,20 +2052,32 @@ class User_Agent_Info {
 	/**
 	 * Was the current request made by a known bot?
 	 *
+	 * @param string|null $user_agent Optional. User agent string to check. If not provided, uses $_SERVER['HTTP_USER_AGENT'].
+	 *
 	 * @return boolean
 	 */
-	public static function is_bot() {
+	public static function is_bot( $user_agent = null ) {
 		static $is_bot = null;
 
-		if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
+		if ( null === $user_agent ) {
+			if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
+				return false;
+			}
+			$user_agent = wp_unslash( $_SERVER['HTTP_USER_AGENT'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
+
+			// Use cached result only when using the default $_SERVER['HTTP_USER_AGENT'].
+			if ( $is_bot === null ) {
+				$is_bot = self::is_bot_user_agent( $user_agent );
+			}
+			return $is_bot;
+		}
+
+		if ( empty( $user_agent ) ) {
 			return false;
 		}
 
-		if ( $is_bot === null ) {
-			$is_bot = self::is_bot_user_agent( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
-		}
-
-		return $is_bot;
+		// Don't use cache when a custom user agent is provided.
+		return self::is_bot_user_agent( $user_agent );
 	}
 
 	/**

--- a/projects/packages/device-detection/tests/php/Device_Detection_Test.php
+++ b/projects/packages/device-detection/tests/php/Device_Detection_Test.php
@@ -187,6 +187,83 @@ class Device_Detection_Test extends TestCase {
 				false,
 				'other',
 			),
+
+			// Samsung Internet 19.0 on Android.
+			array(
+				'Mozilla/5.0 (Linux; Android 13; SM-S918B) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/19.0 Chrome/102.0.5005.125 Mobile Safari/537.36',
+				array(
+					'is_phone',
+					'is_smartphone',
+					'is_handheld',
+				),
+				'android',
+				'samsung',
+			),
+
+			// UC Browser 13.4 on Android.
+			array(
+				'Mozilla/5.0 (Linux; U; Android 13; en-US; SM-A525F Build/TP1A.220624.014) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/78.0.3904.108 UCBrowser/13.4.0.1306 Mobile Safari/537.36',
+				array(
+					'is_phone',
+					'is_smartphone',
+					'is_handheld',
+				),
+				'android',
+				'uc',
+			),
+
+			// Yandex Browser 23.1 on Windows.
+			array(
+				'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 YaBrowser/23.1.1.138 Yowser/2.5 Safari/537.36',
+				array(
+					'is_desktop',
+				),
+				false,
+				'yandex',
+			),
+
+			// Vivaldi 5.3 on Windows.
+			array(
+				'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/108.0.0.0 Safari/537.36 Vivaldi/5.3.2679.68',
+				array(
+					'is_desktop',
+				),
+				false,
+				'vivaldi',
+			),
+
+			// MIUI Browser 12.10 on Android.
+			array(
+				'Mozilla/5.0 (Linux; U; Android 11; zh-CN; Redmi K30 Pro Build/RKQ1.200826.002) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/89.0.4389.116 MiuiBrowser/12.10.0-gn Quark/4.7.5.176 Mobile Safari/537.36',
+				array(
+					'is_phone',
+					'is_smartphone',
+					'is_handheld',
+				),
+				'android',
+				'miui',
+			),
+
+			// Amazon Silk 96.3 on Kindle Fire.
+			array(
+				'Mozilla/5.0 (Linux; Android 9; KFMAWI Build/PS7327.3183N) AppleWebKit/537.36 (KHTML, like Gecko) Silk/96.3.7 like Chrome/96.0.4664.45 Safari/537.36',
+				array(
+					'is_tablet',
+					'is_handheld',
+				),
+				false,
+				'silk',
+			),
+
+			// Modern Edge (Chromium-based) on Windows.
+			array(
+				'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36 Edg/120.0.2210.91',
+				array(
+					'is_desktop',
+				),
+				false,
+				'edge',
+			),
 		);
 	}
 

--- a/projects/packages/device-detection/tests/php/User_Agent_Info_Test.php
+++ b/projects/packages/device-detection/tests/php/User_Agent_Info_Test.php
@@ -1,0 +1,309 @@
+<?php
+/**
+ * Tests for the User_Agent_Info class.
+ *
+ * @package automattic/jetpack-device-detection
+ */
+
+use Automattic\Jetpack\Device_Detection\User_Agent_Info;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for the User_Agent_Info class static methods.
+ *
+ * Tests both explicit user agent parameter passing and fallback to $_SERVER['HTTP_USER_AGENT'].
+ */
+class User_Agent_Info_Test extends TestCase {
+
+	/**
+	 * Test browser detection methods with both explicit UA and $_SERVER fallback.
+	 *
+	 * @param string $ua User agent string.
+	 * @param string $method Method name to test.
+	 * @param bool   $expected_result Expected result.
+	 * @param bool   $use_server Whether to test $_SERVER fallback.
+	 * @return void
+	 *
+	 * @dataProvider browser_detection_provider
+	 */
+	#[DataProvider( 'browser_detection_provider' )]
+	public function test_browser_detection( string $ua, string $method, bool $expected_result, bool $use_server ) {
+		if ( $use_server ) {
+			$_SERVER['HTTP_USER_AGENT'] = $ua;
+			$actual_result              = call_user_func( array( User_Agent_Info::class, $method ) );
+		} else {
+			$actual_result = call_user_func( array( User_Agent_Info::class, $method ), $ua );
+		}
+
+		$this->assertEquals( $expected_result, $actual_result );
+	}
+
+	/**
+	 * Test platform detection methods with both explicit UA and $_SERVER fallback.
+	 *
+	 * @param string      $ua User agent string.
+	 * @param string      $method Method name to test.
+	 * @param bool        $expected_result Expected result.
+	 * @param bool        $use_server Whether to test $_SERVER fallback.
+	 * @param string|null $type Optional type parameter for methods like is_iphone_or_ipod and is_ipad.
+	 * @return void
+	 *
+	 * @dataProvider platform_detection_provider
+	 */
+	#[DataProvider( 'platform_detection_provider' )]
+	public function test_platform_detection( string $ua, string $method, bool $expected_result, bool $use_server, ?string $type = null ) {
+		if ( $use_server ) {
+			$_SERVER['HTTP_USER_AGENT'] = $ua;
+			if ( $type !== null ) {
+				$actual_result = call_user_func( array( User_Agent_Info::class, $method ), $type );
+			} else {
+				$actual_result = call_user_func( array( User_Agent_Info::class, $method ) );
+			}
+		} elseif ( $type !== null ) {
+				$actual_result = call_user_func( array( User_Agent_Info::class, $method ), $type, $ua );
+		} else {
+			$actual_result = call_user_func( array( User_Agent_Info::class, $method ), $ua );
+		}
+
+		$this->assertEquals( $expected_result, $actual_result );
+	}
+
+	/**
+	 * Data provider for browser detection tests.
+	 *
+	 * Returns test cases for each browser detection method, testing both with explicit UA parameter
+	 * and with $_SERVER['HTTP_USER_AGENT'] fallback.
+	 *
+	 * @return array
+	 */
+	public static function browser_detection_provider() {
+		$test_cases = array();
+
+		// Samsung Internet tests
+		$samsung_ua = 'Mozilla/5.0 (Linux; Android 13; SM-S918B) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/19.0 Chrome/102.0.5005.125 Mobile Safari/537.36';
+		$test_cases = array_merge(
+			$test_cases,
+			array(
+				// Test with explicit UA parameter
+				array( $samsung_ua, 'is_samsung_browser', true, false ),
+				// Test with $_SERVER fallback
+				array( $samsung_ua, 'is_samsung_browser', true, true ),
+			)
+		);
+
+		// UC Browser tests
+		$uc_ua      = 'Mozilla/5.0 (Linux; U; Android 13; en-US; SM-A525F) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/78.0.3904.108 UCBrowser/13.4.0.1306 Mobile Safari/537.36';
+		$test_cases = array_merge(
+			$test_cases,
+			array(
+				array( $uc_ua, 'is_uc_browser', true, false ),
+				array( $uc_ua, 'is_uc_browser', true, true ),
+			)
+		);
+
+		// Yandex Browser tests
+		$yandex_ua  = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 YaBrowser/23.1.1.138 Safari/537.36';
+		$test_cases = array_merge(
+			$test_cases,
+			array(
+				array( $yandex_ua, 'is_yandex_browser', true, false ),
+				array( $yandex_ua, 'is_yandex_browser', true, true ),
+			)
+		);
+
+		// Vivaldi tests
+		$vivaldi_ua = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/108.0.0.0 Safari/537.36 Vivaldi/5.3.2679.68';
+		$test_cases = array_merge(
+			$test_cases,
+			array(
+				array( $vivaldi_ua, 'is_vivaldi_browser', true, false ),
+				array( $vivaldi_ua, 'is_vivaldi_browser', true, true ),
+			)
+		);
+
+		// MIUI Browser tests
+		$miui_ua    = 'Mozilla/5.0 (Linux; U; Android 11; zh-CN; Redmi K30 Pro) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/89.0.4389.116 MiuiBrowser/12.10.0-gn Mobile Safari/537.36';
+		$test_cases = array_merge(
+			$test_cases,
+			array(
+				array( $miui_ua, 'is_miui_browser', true, false ),
+				array( $miui_ua, 'is_miui_browser', true, true ),
+			)
+		);
+
+		// Amazon Silk tests
+		$silk_ua    = 'Mozilla/5.0 (Linux; Android 9; KFMAWI) AppleWebKit/537.36 (KHTML, like Gecko) Silk/96.3.7 like Chrome/96.0.4664.45 Safari/537.36';
+		$test_cases = array_merge(
+			$test_cases,
+			array(
+				array( $silk_ua, 'is_silk_browser', true, false ),
+				array( $silk_ua, 'is_silk_browser', true, true ),
+			)
+		);
+
+		// Chrome tests
+		$chrome_ua  = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.6099.109 Safari/537.36';
+		$test_cases = array_merge(
+			$test_cases,
+			array(
+				array( $chrome_ua, 'is_chrome_desktop', true, false ),
+				array( $chrome_ua, 'is_chrome_desktop', true, true ),
+			)
+		);
+
+		// Firefox tests
+		$firefox_ua = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:121.0) Gecko/20100101 Firefox/121.0';
+		$test_cases = array_merge(
+			$test_cases,
+			array(
+				array( $firefox_ua, 'is_firefox_desktop', true, false ),
+				array( $firefox_ua, 'is_firefox_desktop', true, true ),
+			)
+		);
+
+		// Safari tests
+		$safari_ua  = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.2 Safari/605.1.15';
+		$test_cases = array_merge(
+			$test_cases,
+			array(
+				array( $safari_ua, 'is_safari_browser', true, false ),
+				array( $safari_ua, 'is_safari_browser', true, true ),
+			)
+		);
+
+		// Edge tests (modern Chromium-based)
+		$edge_ua    = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36 Edg/120.0.2210.91';
+		$test_cases = array_merge(
+			$test_cases,
+			array(
+				array( $edge_ua, 'is_edge_browser', true, false ),
+				array( $edge_ua, 'is_edge_browser', true, true ),
+			)
+		);
+
+		// Opera tests
+		$opera_ua   = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36 OPR/105.0.0.0';
+		$test_cases = array_merge(
+			$test_cases,
+			array(
+				array( $opera_ua, 'is_opera_desktop', true, false ),
+				array( $opera_ua, 'is_opera_desktop', true, true ),
+			)
+		);
+
+		// IE tests
+		$ie_ua      = 'Mozilla/5.0 (Windows NT 10.0; WOW64; Trident/7.0; rv:11.0) like Gecko';
+		$test_cases = array_merge(
+			$test_cases,
+			array(
+				array( $ie_ua, 'is_ie_browser', true, false ),
+				array( $ie_ua, 'is_ie_browser', true, true ),
+			)
+		);
+
+		// Negative tests - Chrome UA should not be detected as Samsung
+		$test_cases = array_merge(
+			$test_cases,
+			array(
+				array( $chrome_ua, 'is_samsung_browser', false, false ),
+				array( $chrome_ua, 'is_samsung_browser', false, true ),
+			)
+		);
+
+		return $test_cases;
+	}
+
+	/**
+	 * Data provider for platform detection tests.
+	 *
+	 * Returns test cases for each platform detection method, testing both with explicit UA parameter
+	 * and with $_SERVER['HTTP_USER_AGENT'] fallback.
+	 *
+	 * @return array
+	 */
+	public static function platform_detection_provider() {
+		$test_cases = array();
+
+		// iPhone tests (uses is_iphone_or_ipod method)
+		$iphone_ua  = 'Mozilla/5.0 (iPhone; CPU iPhone OS 11_4_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/11.0 Mobile/15E148 Safari/604.1';
+		$test_cases = array_merge(
+			$test_cases,
+			array(
+				array( $iphone_ua, 'is_iphone_or_ipod', true, false, 'iphone-any' ),
+				array( $iphone_ua, 'is_iphone_or_ipod', true, true, 'iphone-any' ),
+			)
+		);
+
+		// iPad tests (requires specific user agent with Safari/Version)
+		$ipad_ua    = 'Mozilla/5.0 (iPad; CPU OS 11_4_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/11.0 Mobile/15G77 Safari/604.1';
+		$test_cases = array_merge(
+			$test_cases,
+			array(
+				array( $ipad_ua, 'is_ipad', true, false, 'ipad-any' ),
+				array( $ipad_ua, 'is_ipad', true, true, 'ipad-any' ),
+			)
+		);
+
+		// Android tests
+		$android_ua = 'Mozilla/5.0 (Linux; Android 13; SM-S918B) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Mobile Safari/537.36';
+		$test_cases = array_merge(
+			$test_cases,
+			array(
+				array( $android_ua, 'is_android', true, false, null ),
+				array( $android_ua, 'is_android', true, true, null ),
+			)
+		);
+
+		// BlackBerry tests (uses is_blackbeberry with typo in method name)
+		$bb_ua      = 'Mozilla/5.0 (BlackBerry; U; BlackBerry 9900; en) AppleWebKit/534.11+ (KHTML, like Gecko) Version/7.1.0.346 Mobile Safari/534.11+';
+		$test_cases = array_merge(
+			$test_cases,
+			array(
+				array( $bb_ua, 'is_blackbeberry', true, false, null ),
+				array( $bb_ua, 'is_blackbeberry', true, true, null ),
+			)
+		);
+
+		// Windows Phone 8 tests
+		$wp8_ua     = 'Mozilla/5.0 (compatible; MSIE 10.0; Windows Phone 8.0; Trident/6.0; IEMobile/10.0; ARM; Touch; NOKIA; Lumia 920)';
+		$test_cases = array_merge(
+			$test_cases,
+			array(
+				array( $wp8_ua, 'is_windows_phone_8', true, false, null ),
+				array( $wp8_ua, 'is_windows_phone_8', true, true, null ),
+			)
+		);
+
+		// Kindle Fire tests (needs specific Kindle Fire user agent)
+		$kindle_ua  = 'Mozilla/5.0 (Linux; U; en-us; KFAPWI Build/JDQ39) AppleWebKit/535.19 (KHTML, like Gecko) Silk/3.13 Safari/535.19 Silk-Accelerated=true';
+		$test_cases = array_merge(
+			$test_cases,
+			array(
+				array( $kindle_ua, 'is_kindle_fire', true, false, null ),
+				array( $kindle_ua, 'is_kindle_fire', true, true, null ),
+			)
+		);
+
+		// Android tablet tests
+		$tablet_ua  = 'Mozilla/5.0 (Linux; Android 9; SAMSUNG SM-T820) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/9.2 Chrome/67.0.3396.87 Safari/537.36';
+		$test_cases = array_merge(
+			$test_cases,
+			array(
+				array( $tablet_ua, 'is_android_tablet', true, false, null ),
+				array( $tablet_ua, 'is_android_tablet', true, true, null ),
+			)
+		);
+
+		// Negative tests - iPhone UA should not be detected as Android
+		$test_cases = array_merge(
+			$test_cases,
+			array(
+				array( $iphone_ua, 'is_android', false, false, null ),
+				array( $iphone_ua, 'is_android', false, true, null ),
+			)
+		);
+
+		return $test_cases;
+	}
+}


### PR DESCRIPTION
Part of FORMS-319

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

We want to use the `User_Agent_Info` class to parse the user-agent strings we store with each form submission and display information such as the browser, version, and platform.  The `User_Agent_Info` class appears to have been initially conceived to parse the user-agent value from the PHP server variable `$_SERVER['HTTP_USER_AGENT']` sent by the browser. Even though its constructor can receive a user agent string, all of its static methods ignored it and defaulted to use the PHP global server variable value instead. In this PR, I've modified the class to honor the user-agent string passed to the constructor in a backward-compatible way. In this PR, I have only modified `get_browser`, `get_platform` and `get_desktop_platform` in order to keep it short and more contained. 

I've also added detection to six popular browsers  that were previously classified as "other":
* Samsung Internet (default on Samsung devices)
* UC Browser (popular in Asia)
* Yandex Browser (popular in Russia)
* Vivaldi (power users)
* MIUI Browser (Xiaomi devices)
* Amazon Silk (Kindle/Fire devices)
    
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Pass useragent to static methods: pass down the user agent in the methods get_browser, get_platform and
    get_desktop_platform.
* Use useragent in is_tablet method.
* Added detection to 6 additional browsers: Samsung Internet, UC, Yandex, Vivaldi, MIUI, Amazon Silk.
* Updated the detection order to check for Chromium-based browsers BEFORE checking for Chrome itself. This is critical because Samsung, Yandex, Vivaldi, UC, MIUI, and Silk all include "Chrome" in their user agent strings.
*  Updated is_edge_browser() to detect both: 
    * Legacy Edge: "Edge/".
    *  Modern Chromium-based Edge: "Edg/".
* Update tests for the new browsers detected.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Run the unit tests with `jetpack test -v php packages/device-detection`

