### PR TITLE
Forms: default to post author when recipients list is empty

### DIFF
--- a/projects/packages/forms/changelog/update-forms-notification-blank-recipients-behavior
+++ b/projects/packages/forms/changelog/update-forms-notification-blank-recipients-behavior
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Forms: default to notify the post author when the notification recipients list is empty.

--- a/projects/packages/forms/src/blocks/contact-form/components/notifications-settings.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/notifications-settings.js
@@ -115,6 +115,17 @@ const NotificationsSettings = ( {
 								value={ selectedUserNames }
 								suggestions={ allUserNames }
 								onChange={ selectedNames => {
+									// If field is empty, default to post author
+									if ( selectedNames.length === 0 ) {
+										const authorIdStr = postAuthorId?.toString();
+										if ( authorIdStr && eligibleUsers.some( user => user.id === postAuthorId ) ) {
+											const defaultRecipients = [ authorIdStr ];
+											setLocalNotificationRecipients( defaultRecipients );
+											setAttributes( { notificationRecipients: defaultRecipients } );
+											return;
+										}
+									}
+
 									// Convert user names back to IDs
 									const newRecipients = selectedNames
 										.map( name => {

--- a/projects/packages/forms/tests/js/contact-form/components/notifications-settings.test.js
+++ b/projects/packages/forms/tests/js/contact-form/components/notifications-settings.test.js
@@ -24,6 +24,10 @@ const createTokenFieldHandler = ( onChange, value ) => {
 	};
 };
 
+const createClearHandler = onChange => {
+	return () => onChange( [] );
+};
+
 // Mock WordPress components
 jest.mock( '@wordpress/components', () => {
 	/**
@@ -70,6 +74,9 @@ jest.mock( '@wordpress/components', () => {
 					data-suggestions={ JSON.stringify( suggestions ) }
 					onChange={ createTokenFieldHandler( onChange, value ) }
 				/>
+				<button data-testid="clear-all-button" onClick={ createClearHandler( onChange ) }>
+					Clear All
+				</button>
 			</div>
 		);
 	}
@@ -317,5 +324,29 @@ describe( 'NotificationsSettings', () => {
 		// Should display user names, not IDs
 		expect( input.value ).toContain( 'Admin User' );
 		expect( input.value ).toContain( 'Editor User' );
+	} );
+
+	it( 'defaults to post author when all recipients are removed', async () => {
+		// Start with Editor User as recipient
+		render(
+			<NotificationsSettings
+				setAttributes={ setAttributesMock }
+				notificationRecipients={ [ '2' ] }
+				{ ...defaultProps }
+			/>
+		);
+
+		// User selector should be visible with Editor User selected
+		const input = screen.getByRole( 'textbox' );
+		expect( input.value ).toContain( 'Editor User' );
+
+		// Clear all recipients by clicking the clear button
+		const clearButton = screen.getByTestId( 'clear-all-button' );
+		await userEvent.click( clearButton );
+
+		// Should auto-select the post author (user ID 1) when field is cleared
+		expect( setAttributesMock ).toHaveBeenCalledWith( {
+			notificationRecipients: [ '1' ],
+		} );
 	} );
 } );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

To make this feature consistent with the email notifications, whenever the recipients list is empty, we'll automatically add the post author to the list.

Fixes FORMS-NEW

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Automatically add the post author to the notification recipients list is empty

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Enable the feature flag `jetpack_forms_enable_notifications`. 
* Create a form and enable the toggle `Enable notifications for responses` in the forms block sidebar `Form notifications` panel setting.
* Confirm that it's not possible to delete the post author from the recipients list unless you add another user.
* Add other users to the list to delete the post author, and then delete the post author from the list. Confirm that the post author is added back to the list.

