### PR TITLE
Backport jetpack 15.2-a.7 Changes

### DIFF
--- a/projects/js-packages/charts/CHANGELOG.md
+++ b/projects/js-packages/charts/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.45.0] - 2025-10-27
+### Added
+- Add interactive legend support to BarChart. [#45561]
+- Add interactive legend to pie charts. [#45580]
+
 ## [0.44.0] - 2025-10-21
 ### Changed
 - Improve legends toggling. [#45545]
@@ -523,6 +528,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed lints following ESLint rule changes for TS [#40584]
 - Fixing a bug in Chart storybook data. [#40640]
 
+[0.45.0]: https://github.com/Automattic/charts/compare/v0.44.0...v0.45.0
 [0.44.0]: https://github.com/Automattic/charts/compare/v0.43.0...v0.44.0
 [0.43.0]: https://github.com/Automattic/charts/compare/v0.42.0...v0.43.0
 [0.42.0]: https://github.com/Automattic/charts/compare/v0.41.1...v0.42.0

--- a/projects/js-packages/charts/changelog/add-charts-bar-chart-interactive-legend
+++ b/projects/js-packages/charts/changelog/add-charts-bar-chart-interactive-legend
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Charts: Add interactive legend support to BarChart

--- a/projects/js-packages/charts/changelog/add-charts-pie-chart-interactive-legend
+++ b/projects/js-packages/charts/changelog/add-charts-pie-chart-interactive-legend
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Charts: adds interactive legend to pie charts

--- a/projects/js-packages/charts/package.json
+++ b/projects/js-packages/charts/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/charts",
-	"version": "0.44.0",
+	"version": "0.45.0",
 	"description": "Display charts within Automattic products.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/charts/#readme",
 	"bugs": {

--- a/projects/js-packages/publicize-components/CHANGELOG.md
+++ b/projects/js-packages/publicize-components/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.6] - 2025-10-27
+### Changed
+- Update package dependencies. [#45551]
+
 ## [1.4.5] - 2025-10-20
 ### Changed
 - Update dependencies. [#45488]
@@ -1389,6 +1393,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Updated package dependencies. [#24470]
 
+[1.4.6]: https://github.com/Automattic/jetpack-publicize-components/compare/v1.4.5...v1.4.6
 [1.4.5]: https://github.com/Automattic/jetpack-publicize-components/compare/v1.4.4...v1.4.5
 [1.4.4]: https://github.com/Automattic/jetpack-publicize-components/compare/v1.4.3...v1.4.4
 [1.4.3]: https://github.com/Automattic/jetpack-publicize-components/compare/v1.4.2...v1.4.3

--- a/projects/js-packages/publicize-components/package.json
+++ b/projects/js-packages/publicize-components/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-publicize-components",
-	"version": "1.4.5",
+	"version": "1.4.6",
 	"private": true,
 	"description": "A library of JS components required by the Publicize editor plugin",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/publicize-components/#readme",

--- a/projects/packages/connection/CHANGELOG.md
+++ b/projects/packages/connection/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.19.1] - 2025-10-27
+### Changed
+- Internal updates.
+
 ## [6.19.0] - 2025-10-20
 ### Added
 - Add Newspack and VIP check to `should_allow_error_filtering`. [#45481]
@@ -1619,6 +1623,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Separate the connection library into its own package.
 
+[6.19.1]: https://github.com/Automattic/jetpack-connection/compare/v6.19.0...v6.19.1
 [6.19.0]: https://github.com/Automattic/jetpack-connection/compare/v6.18.14...v6.19.0
 [6.18.14]: https://github.com/Automattic/jetpack-connection/compare/v6.18.13...v6.18.14
 [6.18.13]: https://github.com/Automattic/jetpack-connection/compare/v6.18.12...v6.18.13

--- a/projects/packages/connection/changelog/fix-phan-PhanAccessMethodInternal
+++ b/projects/packages/connection/changelog/fix-phan-PhanAccessMethodInternal
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Resolve all PhanAccessMethodInternal instances (all of which are suppression comments).
-
-

--- a/projects/packages/connection/src/class-package-version.php
+++ b/projects/packages/connection/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Connection;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '6.19.0';
+	const PACKAGE_VERSION = '6.19.1';
 
 	const PACKAGE_SLUG = 'connection';
 

--- a/projects/packages/device-detection/CHANGELOG.md
+++ b/projects/packages/device-detection/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.1.1] - 2025-10-27
+### Changed
+- Add missing bot agents to bot detection. [#45552]
+
 ## [3.1.0] - 2025-10-10
 ### Added
 - Filter data for SEO bot. [#45431]
@@ -252,6 +256,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Moving jetpack_is_mobile into a package
 
+[3.1.1]: https://github.com/Automattic/jetpack-device-detection/compare/v3.1.0...v3.1.1
 [3.1.0]: https://github.com/Automattic/jetpack-device-detection/compare/v3.0.9...v3.1.0
 [3.0.9]: https://github.com/Automattic/jetpack-device-detection/compare/v3.0.8...v3.0.9
 [3.0.8]: https://github.com/Automattic/jetpack-device-detection/compare/v3.0.7...v3.0.8

--- a/projects/packages/device-detection/changelog/update-bot-agents
+++ b/projects/packages/device-detection/changelog/update-bot-agents
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Add missing bot agents to bot detection

--- a/projects/packages/external-media/CHANGELOG.md
+++ b/projects/packages/external-media/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.8] - 2025-10-27
+### Removed
+- GutenbergKit: Disable problematic media providers. [#45461]
+
 ## [0.5.7] - 2025-10-20
 ### Changed
 - External media: Prevent site editor performance issues by bringing back previous script enqueue approach. [#45546]
@@ -203,6 +207,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix the button size in the editor for Gutenberg 18 or below. [#41619]
 - Media Library: Fix the Import Media button color in some color schemes. [#41664]
 
+[0.5.8]: https://github.com/Automattic/jetpack-external-media/compare/v0.5.7...v0.5.8
 [0.5.7]: https://github.com/Automattic/jetpack-external-media/compare/v0.5.6...v0.5.7
 [0.5.6]: https://github.com/Automattic/jetpack-external-media/compare/v0.5.5...v0.5.6
 [0.5.5]: https://github.com/Automattic/jetpack-external-media/compare/v0.5.4...v0.5.5

--- a/projects/packages/external-media/changelog/task-disable-problematic-media-providers-for-gutenberg-kit
+++ b/projects/packages/external-media/changelog/task-disable-problematic-media-providers-for-gutenberg-kit
@@ -1,4 +1,0 @@
-Significance: patch
-Type: removed
-
-GutenbergKit: disable problematic media providers.

--- a/projects/packages/external-media/package.json
+++ b/projects/packages/external-media/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-external-media",
-	"version": "0.5.7",
+	"version": "0.5.8",
 	"private": true,
 	"description": "The external media feature allows users to select and import photos from external media",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/external-media/#readme",

--- a/projects/packages/external-media/src/class-external-media.php
+++ b/projects/packages/external-media/src/class-external-media.php
@@ -18,7 +18,7 @@ use Jetpack_Options;
  * Class External_Media
  */
 class External_Media {
-	const PACKAGE_VERSION = '0.5.7';
+	const PACKAGE_VERSION = '0.5.8';
 	const BASE_DIR        = __DIR__ . '/';
 	const BASE_FILE       = __FILE__;
 

--- a/projects/packages/forms/CHANGELOG.md
+++ b/projects/packages/forms/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.13.0] - 2025-10-27
+### Changed
+- Add 'create new form' CTA to inbox empty state. [#45589]
+- Add shared ConsentToggle component. [#45556]
+- Align layout grid/components with DataViews table grid. [#45559]
+- Improve the performance of loading the form responsesn dashboard by breaking it up into two stages. [#45565]
+- Integrate `@wordpress/admin-ui` Page component into dashboard layout. [#45610]
+- Record tracks events for inbox actions. [#45606]
+- Remove About page from dashboard. [#45615]
+- Store the user agent used on form submissions. [#45586]
+- Update visual representation of "image select field" responses at inbox. [#45585]
+- Update package dependencies. [#45551] [#45592] [#45598]
+
+### Removed
+- Remove custom green buttons [#45613]
+- Remove hovercards from inbox list [#45572]
+
+### Fixed
+- Fix textarea submission on enter. [#45602]
+- Reduce re-renders in the dashboard. [#45567]
+- Update feedback form screenshot. [#45578]
+- UX and accessibility fixes for image select field. [#45560]
+
 ## [6.12.0] - 2025-10-21
 ### Added
 - Show gravatar on dataviews list. [#45555]
@@ -1730,6 +1753,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a new jetpack/forms package [#28409]
 - Added a public load_contact_form method for initializing the contact form module. [#28416]
 
+[6.13.0]: https://github.com/automattic/jetpack-forms/compare/v6.12.0...v6.13.0
 [6.12.0]: https://github.com/automattic/jetpack-forms/compare/v6.11.0...v6.12.0
 [6.11.0]: https://github.com/automattic/jetpack-forms/compare/v6.10.0...v6.11.0
 [6.10.0]: https://github.com/automattic/jetpack-forms/compare/v6.9.0...v6.10.0

--- a/projects/packages/forms/CHANGELOG.md
+++ b/projects/packages/forms/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add 'create new form' CTA to inbox empty state. [#45589]
 - Add shared ConsentToggle component. [#45556]
 - Align layout grid/components with DataViews table grid. [#45559]
-- Improve the performance of loading the form responsesn dashboard by breaking it up into two stages. [#45565]
+- Improve the performance of loading the form responses dashboard. [#45565]
 - Integrate `@wordpress/admin-ui` Page component into dashboard layout. [#45610]
 - Record tracks events for inbox actions. [#45606]
 - Remove About page from dashboard. [#45615]
@@ -19,14 +19,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update package dependencies. [#45551] [#45592] [#45598]
 
 ### Removed
-- Remove custom green buttons [#45613]
-- Remove hovercards from inbox list [#45572]
+- Remove custom green buttons. [#45613]
+- Remove hovercards from inbox list. [#45572]
 
 ### Fixed
 - Fix textarea submission on enter. [#45602]
-- Reduce re-renders in the dashboard. [#45567]
+- Reduce rerenders in the dashboard. [#45567]
 - Update feedback form screenshot. [#45578]
-- UX and accessibility fixes for image select field. [#45560]
+- Adjust UX and accessibility for image select field. [#45560]
 
 ## [6.12.0] - 2025-10-21
 ### Added

--- a/projects/packages/forms/changelog/add-forms-admin-ui-page-component
+++ b/projects/packages/forms/changelog/add-forms-admin-ui-page-component
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Forms: integrate @wordpress/admin-ui Page component into dashboard layout

--- a/projects/packages/forms/changelog/add-forms-submission-user-agent
+++ b/projects/packages/forms/changelog/add-forms-submission-user-agent
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Forms: store the user agent used on form submissions.

--- a/projects/packages/forms/changelog/fix-forms-dashboard-inbox-alignments
+++ b/projects/packages/forms/changelog/fix-forms-dashboard-inbox-alignments
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Forms: align layout grid/components with DataViews table grid

--- a/projects/packages/forms/changelog/fix-forms-resolve_stylelint_issue
+++ b/projects/packages/forms/changelog/fix-forms-resolve_stylelint_issue
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Remove redundant style definition that Stylelint is complaining about.
-
-

--- a/projects/packages/forms/changelog/fix-forms-textarea-double-enter
+++ b/projects/packages/forms/changelog/fix-forms-textarea-double-enter
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Forms: fix textarea submission on enter.

--- a/projects/packages/forms/changelog/fix-forms-useState-errors
+++ b/projects/packages/forms/changelog/fix-forms-useState-errors
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Forms: reduce re-renders in the dashboard 

--- a/projects/packages/forms/changelog/fix-integration-endpoint-performance
+++ b/projects/packages/forms/changelog/fix-integration-endpoint-performance
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Forms: Improve the performance of loading the form responsesn dashboard by breaking it up into two stages

--- a/projects/packages/forms/changelog/remove-forms-dashbobard-green-buttons
+++ b/projects/packages/forms/changelog/remove-forms-dashbobard-green-buttons
@@ -1,4 +1,0 @@
-Significance: minor
-Type: removed
-
-Forms: remove custom green buttons

--- a/projects/packages/forms/changelog/remove-forms-inbox-hovercards
+++ b/projects/packages/forms/changelog/remove-forms-inbox-hovercards
@@ -1,4 +1,0 @@
-Significance: patch
-Type: removed
-
-Forms: remove hovercards from inbox list

--- a/projects/packages/forms/changelog/renovate-semver-7.x
+++ b/projects/packages/forms/changelog/renovate-semver-7.x
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/packages/forms/changelog/update-forms-add-tracks-to-actions
+++ b/projects/packages/forms/changelog/update-forms-add-tracks-to-actions
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Forms: record tracks events for inbox actions

--- a/projects/packages/forms/changelog/update-forms-consent-component
+++ b/projects/packages/forms/changelog/update-forms-consent-component
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Forms: add shared ConsentToggle component.

--- a/projects/packages/forms/changelog/update-forms-empty-state-cta
+++ b/projects/packages/forms/changelog/update-forms-empty-state-cta
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Forms: add 'create new form' CTA to inbox empty state

--- a/projects/packages/forms/changelog/update-forms-image-select-dashboard-image-size
+++ b/projects/packages/forms/changelog/update-forms-image-select-dashboard-image-size
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Just a small and specific CSS change
-
-

--- a/projects/packages/forms/changelog/update-forms-image-select-further-feedback
+++ b/projects/packages/forms/changelog/update-forms-image-select-further-feedback
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Forms: UX and accessibility fixes for image select field

--- a/projects/packages/forms/changelog/update-forms-image-select-img-perf
+++ b/projects/packages/forms/changelog/update-forms-image-select-img-perf
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Forms: update visual representation of "image select field" responses at inbox

--- a/projects/packages/forms/changelog/update-forms-screenshot-feedback-form
+++ b/projects/packages/forms/changelog/update-forms-screenshot-feedback-form
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Forms: Update feedback form screenshot

--- a/projects/packages/forms/changelog/update-remove-about-page
+++ b/projects/packages/forms/changelog/update-remove-about-page
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Forms: Remove About page from dashboard

--- a/projects/packages/forms/composer.json
+++ b/projects/packages/forms/composer.json
@@ -71,7 +71,7 @@
 			"link-template": "https://github.com/automattic/jetpack-forms/compare/v${old}...v${new}"
 		},
 		"branch-alias": {
-			"dev-trunk": "6.12.x-dev"
+			"dev-trunk": "6.13.x-dev"
 		},
 		"textdomain": "jetpack-forms",
 		"version-constants": {

--- a/projects/packages/forms/package.json
+++ b/projects/packages/forms/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-forms",
-	"version": "6.12.0",
+	"version": "6.13.0",
 	"private": true,
 	"description": "Jetpack Forms",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/forms/#readme",

--- a/projects/packages/forms/src/class-jetpack-forms.php
+++ b/projects/packages/forms/src/class-jetpack-forms.php
@@ -14,7 +14,7 @@ use Automattic\Jetpack\Forms\Dashboard\Dashboard;
  */
 class Jetpack_Forms {
 
-	const PACKAGE_VERSION = '6.12.0';
+	const PACKAGE_VERSION = '6.13.0';
 
 	/**
 	 * Load the contact form module.

--- a/projects/packages/import/CHANGELOG.md
+++ b/projects/packages/import/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.12] - 2025-10-27
+### Changed
+- Internal updates.
+
 ## [0.9.11] - 2025-08-18
 ### Changed
 - Internal updates.
@@ -170,6 +174,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fixed various imported resources hierarchies [#29012]
 
+[0.9.12]: https://github.com/Automattic/jetpack-import/compare/v0.9.11...v0.9.12
 [0.9.11]: https://github.com/Automattic/jetpack-import/compare/v0.9.10...v0.9.11
 [0.9.10]: https://github.com/Automattic/jetpack-import/compare/v0.9.9...v0.9.10
 [0.9.9]: https://github.com/Automattic/jetpack-import/compare/v0.9.8...v0.9.9

--- a/projects/packages/import/changelog/fix-phan-PhanAccessMethodInternal
+++ b/projects/packages/import/changelog/fix-phan-PhanAccessMethodInternal
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Resolve all PhanAccessMethodInternal instances (all of which are suppression comments).
-
-

--- a/projects/packages/import/package.json
+++ b/projects/packages/import/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-import",
-	"version": "0.9.11",
+	"version": "0.9.12",
 	"private": true,
 	"description": "Set of REST API routes used in WPCOM Unified Importer.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/import/#readme",

--- a/projects/packages/import/src/class-main.php
+++ b/projects/packages/import/src/class-main.php
@@ -20,7 +20,7 @@ class Main {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '0.9.11';
+	const PACKAGE_VERSION = '0.9.12';
 
 	/**
 	 * A list of all the routes.

--- a/projects/packages/my-jetpack/CHANGELOG.md
+++ b/projects/packages/my-jetpack/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.27.9] - 2025-10-27
+### Changed
+- Update package dependencies. [#45551]
+
 ## [5.27.8] - 2025-10-21
 ### Changed
 - Update dependencies. [#45493]
@@ -2388,6 +2392,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Created package
 
+[5.27.9]: https://github.com/Automattic/jetpack-my-jetpack/compare/5.27.8...5.27.9
 [5.27.8]: https://github.com/Automattic/jetpack-my-jetpack/compare/5.27.7...5.27.8
 [5.27.7]: https://github.com/Automattic/jetpack-my-jetpack/compare/5.27.6...5.27.7
 [5.27.6]: https://github.com/Automattic/jetpack-my-jetpack/compare/5.27.5...5.27.6

--- a/projects/packages/my-jetpack/changelog/renovate-@wordpressdataviews
+++ b/projects/packages/my-jetpack/changelog/renovate-@wordpressdataviews
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-my-jetpack",
-	"version": "5.27.8",
+	"version": "5.27.9",
 	"private": true,
 	"description": "WP Admin page with information and configuration shared among all Jetpack stand-alone plugins",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/my-jetpack/#readme",

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -39,7 +39,7 @@ class Initializer {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '5.27.8';
+	const PACKAGE_VERSION = '5.27.9';
 
 	/**
 	 * HTML container ID for the IDC screen on My Jetpack page.

--- a/projects/packages/publicize/CHANGELOG.md
+++ b/projects/packages/publicize/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.66.19] - 2025-10-27
+### Changed
+- Update dependencies. [#44736]
+
 ## [0.66.18] - 2025-10-20
 ### Fixed
 - Sharing: Prevent PHP fatals when passed malformed data. [#45418]
@@ -1130,6 +1134,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies.
 - Update package.json metadata.
 
+[0.66.19]: https://github.com/Automattic/jetpack-publicize/compare/v0.66.18...v0.66.19
 [0.66.18]: https://github.com/Automattic/jetpack-publicize/compare/v0.66.17...v0.66.18
 [0.66.17]: https://github.com/Automattic/jetpack-publicize/compare/v0.66.16...v0.66.17
 [0.66.16]: https://github.com/Automattic/jetpack-publicize/compare/v0.66.15...v0.66.16

--- a/projects/packages/publicize/package.json
+++ b/projects/packages/publicize/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-publicize",
-	"version": "0.66.18",
+	"version": "0.66.19",
 	"private": true,
 	"description": "Publicize makes it easy to share your site’s posts on several social media networks automatically when you publish a new post.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/publicize/#readme",

--- a/projects/packages/search/CHANGELOG.md
+++ b/projects/packages/search/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.53.0] - 2025-10-27
+### Added
+- Instant Search: Add global WooCommerce Product Attributes as filter options. [#45416]
+
+### Changed
+- Instant Search: Fix issue where Safari's 'Use advanced tracking and fingerprinting protection' setting breaks Search. [#45588]
+- Instant Search: Revert Safari privacy settings fix due to E2E failure. [#45582]
+
 ## [0.52.24] - 2025-10-21
 ### Fixed
 - Instant Search: Handle browser privacy settings stripping out the search query value. [#45533]
@@ -1356,6 +1364,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies.
 - Update PHPUnit configs to include just what needs coverage rather than include everything then try to exclude stuff that doesn't.
 
+[0.53.0]: https://github.com/Automattic/jetpack-search/compare/v0.52.24...v0.53.0
 [0.52.24]: https://github.com/Automattic/jetpack-search/compare/v0.52.23...v0.52.24
 [0.52.23]: https://github.com/Automattic/jetpack-search/compare/v0.52.22...v0.52.23
 [0.52.22]: https://github.com/Automattic/jetpack-search/compare/v0.52.21...v0.52.22

--- a/projects/packages/search/CHANGELOG.md
+++ b/projects/packages/search/CHANGELOG.md
@@ -10,8 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Instant Search: Add global WooCommerce Product Attributes as filter options. [#45416]
 
 ### Changed
-- Instant Search: Fix issue where Safari's 'Use advanced tracking and fingerprinting protection' setting breaks Search. [#45588]
-- Instant Search: Revert Safari privacy settings fix due to E2E failure. [#45582]
+- Instant Search: Fix issue where Safari's 'Use advanced tracking and fingerprinting protection' setting breaks Search. [#45582] [#45588]
 
 ## [0.52.24] - 2025-10-21
 ### Fixed

--- a/projects/packages/search/changelog/add-instant-search-wc-attributes
+++ b/projects/packages/search/changelog/add-instant-search-wc-attributes
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Instant Search: Add global WooCommerce Product Attributes as filter options.

--- a/projects/packages/search/changelog/fix-jps-safari-privacy
+++ b/projects/packages/search/changelog/fix-jps-safari-privacy
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Instant Search: Fix issue where Safari's 'Use advanced tracking and fingerprinting protection' setting breaks Search.

--- a/projects/packages/search/changelog/revert-45533-fix-privacy-settings-breaking-jetpack-search
+++ b/projects/packages/search/changelog/revert-45533-fix-privacy-settings-breaking-jetpack-search
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Instant Search: Revert Safari privacy settings fix due to E2E failure.

--- a/projects/packages/search/composer.json
+++ b/projects/packages/search/composer.json
@@ -72,7 +72,7 @@
 			"link-template": "https://github.com/Automattic/jetpack-search/compare/v${old}...v${new}"
 		},
 		"branch-alias": {
-			"dev-trunk": "0.52.x-dev"
+			"dev-trunk": "0.53.x-dev"
 		},
 		"version-constants": {
 			"::VERSION": "src/class-package.php"

--- a/projects/packages/search/src/class-package.php
+++ b/projects/packages/search/src/class-package.php
@@ -15,7 +15,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Search package general information
  */
 class Package {
-	const VERSION = '0.52.24';
+	const VERSION = '0.53.0';
 	const SLUG    = 'search';
 
 	/**

--- a/projects/packages/stats-admin/CHANGELOG.md
+++ b/projects/packages/stats-admin/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.30.0 - 2025-10-27
+### Removed
+- Remove "Jetpack > Stats" menu. [#45607]
+
 ## 0.29.1 - 2025-09-29
 ### Fixed
 - Fix dashboard.wordpress.com breaking non-odyssey stats on older versions of Jetpack. [#45283]

--- a/projects/packages/stats-admin/changelog/dotcom-14370-remove-the-jetpack-stats-callout-after-a-month
+++ b/projects/packages/stats-admin/changelog/dotcom-14370-remove-the-jetpack-stats-callout-after-a-month
@@ -1,4 +1,0 @@
-Significance: minor
-Type: removed
-
-Stats: Remove "Jetpack > Stats" menu

--- a/projects/packages/stats-admin/composer.json
+++ b/projects/packages/stats-admin/composer.json
@@ -55,7 +55,7 @@
 		"autotagger": true,
 		"mirror-repo": "Automattic/jetpack-stats-admin",
 		"branch-alias": {
-			"dev-trunk": "0.29.x-dev"
+			"dev-trunk": "0.30.x-dev"
 		},
 		"textdomain": "jetpack-stats-admin",
 		"version-constants": {

--- a/projects/packages/stats-admin/package.json
+++ b/projects/packages/stats-admin/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-stats-admin",
-	"version": "0.29.1",
+	"version": "0.30.0",
 	"private": true,
 	"description": "Stats Dashboard",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/stats-admin/#readme",

--- a/projects/packages/stats-admin/src/class-main.php
+++ b/projects/packages/stats-admin/src/class-main.php
@@ -22,7 +22,7 @@ class Main {
 	/**
 	 * Stats version.
 	 */
-	const VERSION = '0.29.1';
+	const VERSION = '0.30.0';
 
 	/**
 	 * Singleton Main instance.

--- a/projects/packages/subscribers-dashboard/CHANGELOG.md
+++ b/projects/packages/subscribers-dashboard/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.4.4 - 2025-10-27
+### Changed
+- Update package dependencies. [#45551]
+
 ## 0.4.3 - 2025-10-10
 ### Changed
 - Update package dependencies. [#45428]

--- a/projects/packages/subscribers-dashboard/changelog/renovate-@wordpressdataviews
+++ b/projects/packages/subscribers-dashboard/changelog/renovate-@wordpressdataviews
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/packages/subscribers-dashboard/package.json
+++ b/projects/packages/subscribers-dashboard/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-subscribers-dashboard",
-	"version": "0.4.3",
+	"version": "0.4.4",
 	"private": true,
 	"description": "WP Admin page to manage subscribers",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/subscribers-dashboard/#readme",

--- a/projects/packages/subscribers-dashboard/src/class-dashboard.php
+++ b/projects/packages/subscribers-dashboard/src/class-dashboard.php
@@ -17,7 +17,7 @@ use Automattic\Jetpack\Status\Host;
  * @package jetpack-subscribers
  */
 class Dashboard {
-	const VERSION = '0.4.3';
+	const VERSION = '0.4.4';
 	/**
 	 * Whether the class has been initialized
 	 *

--- a/projects/packages/sync/CHANGELOG.md
+++ b/projects/packages/sync/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.22.2] - 2025-10-27
+### Changed
+- Internal updates.
+
 ## [4.22.1] - 2025-10-10
 ### Changed
 - Handle lazy-loading of `WP_User` object properties. [#45450]
@@ -1563,6 +1567,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Packages: Move sync to a classmapped package
 
+[4.22.2]: https://github.com/Automattic/jetpack-sync/compare/v4.22.1...v4.22.2
 [4.22.1]: https://github.com/Automattic/jetpack-sync/compare/v4.22.0...v4.22.1
 [4.22.0]: https://github.com/Automattic/jetpack-sync/compare/v4.21.3...v4.22.0
 [4.21.3]: https://github.com/Automattic/jetpack-sync/compare/v4.21.2...v4.21.3

--- a/projects/packages/sync/changelog/fix-phan-PhanAccessMethodInternal
+++ b/projects/packages/sync/changelog/fix-phan-PhanAccessMethodInternal
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Resolve all PhanAccessMethodInternal instances (all of which are suppression comments).
-
-

--- a/projects/packages/sync/src/class-package-version.php
+++ b/projects/packages/sync/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Sync;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '4.22.1';
+	const PACKAGE_VERSION = '4.22.2';
 
 	const PACKAGE_SLUG = 'sync';
 

--- a/projects/packages/videopress/CHANGELOG.md
+++ b/projects/packages/videopress/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.32.11] - 2025-10-27
+### Changed
+- Internal updates.
+
 ## [0.32.10] - 2025-10-20
 ### Changed
 - Update dependencies. [#45488]
@@ -1760,6 +1764,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Created empty package [#24952]
 
+[0.32.11]: https://github.com/Automattic/jetpack-videopress/compare/v0.32.10...v0.32.11
 [0.32.10]: https://github.com/Automattic/jetpack-videopress/compare/v0.32.9...v0.32.10
 [0.32.9]: https://github.com/Automattic/jetpack-videopress/compare/v0.32.8...v0.32.9
 [0.32.8]: https://github.com/Automattic/jetpack-videopress/compare/v0.32.7...v0.32.8

--- a/projects/packages/videopress/changelog/fix-phan-PhanAccessMethodInternal
+++ b/projects/packages/videopress/changelog/fix-phan-PhanAccessMethodInternal
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Resolve all PhanAccessMethodInternal instances (all of which are suppression comments).
-
-

--- a/projects/packages/videopress/package.json
+++ b/projects/packages/videopress/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-videopress",
-	"version": "0.32.10",
+	"version": "0.32.11",
 	"private": true,
 	"description": "VideoPress package",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/videopress/#readme",

--- a/projects/packages/videopress/src/class-package-version.php
+++ b/projects/packages/videopress/src/class-package-version.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\VideoPress;
  * The Package_Version class.
  */
 class Package_Version {
-	const PACKAGE_VERSION = '0.32.10';
+	const PACKAGE_VERSION = '0.32.11';
 
 	const PACKAGE_SLUG = 'videopress';
 

--- a/projects/packages/woocommerce-analytics/CHANGELOG.md
+++ b/projects/packages/woocommerce-analytics/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.1] - 2025-10-27
+### Changed
+- Enhance JSON encoding by adding `JSON_HEX_TAG` and `JSON_UNESCAPED_SLASHES` options. [#45393]
+- Ensure anonymous ID is set. [#45547]
+
+### Fixed
+- Fix call to undefined method `WC_Tracks::get_server_details()`. [#45394]
+- Use existing bot detection from Device Detection package to skip event recording in analytics tracking. [#45552]
+
 ## [0.10.0] - 2025-10-02
 ### Added
 - Implement WP Consent API Integration [#45323]
@@ -184,6 +193,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix namespace issue with WooCommerce class reference. [#35857]
 - General: bail early when WooCommerce is not active. [#36278]
 
+[0.10.1]: https://github.com/Automattic/woocommerce-analytics/compare/v0.10.0...v0.10.1
 [0.10.0]: https://github.com/Automattic/woocommerce-analytics/compare/v0.9.2...v0.10.0
 [0.9.2]: https://github.com/Automattic/woocommerce-analytics/compare/v0.9.1...v0.9.2
 [0.9.1]: https://github.com/Automattic/woocommerce-analytics/compare/v0.9.0...v0.9.1

--- a/projects/packages/woocommerce-analytics/changelog/fix-wc-analytics-undefined-methods
+++ b/projects/packages/woocommerce-analytics/changelog/fix-wc-analytics-undefined-methods
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Fix call to undefined method WC_Tracks::get_server_details()

--- a/projects/packages/woocommerce-analytics/changelog/update-ensure-anonymous-id-set
+++ b/projects/packages/woocommerce-analytics/changelog/update-ensure-anonymous-id-set
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Ensure anonymous ID is set

--- a/projects/packages/woocommerce-analytics/changelog/update-save-wp-json-encode
+++ b/projects/packages/woocommerce-analytics/changelog/update-save-wp-json-encode
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Enhance JSON encoding by adding JSON_HEX_TAG and JSON_UNESCAPED_SLASHES options

--- a/projects/packages/woocommerce-analytics/changelog/update-stop-record-events-bot
+++ b/projects/packages/woocommerce-analytics/changelog/update-stop-record-events-bot
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Use existing bot detection from Device Detection package to skip event recording in analytics tracking

--- a/projects/packages/woocommerce-analytics/package.json
+++ b/projects/packages/woocommerce-analytics/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/woocommerce-analytics",
-	"version": "0.10.0",
+	"version": "0.10.1",
 	"private": true,
 	"description": "WooCommerce Analytics package to track frontend events",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/woocommerce-analytics/#readme",

--- a/projects/packages/woocommerce-analytics/src/class-woocommerce-analytics.php
+++ b/projects/packages/woocommerce-analytics/src/class-woocommerce-analytics.php
@@ -21,7 +21,7 @@ class Woocommerce_Analytics {
 	/**
 	 * Package version.
 	 */
-	const PACKAGE_VERSION = '0.10.0';
+	const PACKAGE_VERSION = '0.10.1';
 
 	/**
 	 * Proxy speed module version.

--- a/projects/plugins/jetpack/CHANGELOG.md
+++ b/projects/plugins/jetpack/CHANGELOG.md
@@ -5,12 +5,12 @@
 ## 15.2-a.7 - 2025-10-27
 ### Enhancements
 - Forms: Add shared ConsentToggle component. [#45556]
-- Forms: Improve the performance of loading the form responsesn dashboard by breaking it up into two stages. [#45565]
+- Forms: Improve the performance of loading the form responses. [#45565]
 - Instant Search: Add global WooCommerce Product Attributes as filter options. [#45416]
 - Instant Search: Fix issue where Safari's 'Use advanced tracking and fingerprinting protection' setting breaks Search. [#45588]
 
 ### Improved compatibility
-- Tested up to WordPress 6.9 [#45571]
+- Tested up to WordPress 6.9. [#45571]
 
 ### Bug fixes
 - Forms: Fix textarea submission on enter. [#45602]

--- a/projects/plugins/jetpack/CHANGELOG.md
+++ b/projects/plugins/jetpack/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 ### This is a list detailing changes for all Jetpack releases.
 
+## 15.2-a.7 - 2025-10-27
+### Enhancements
+- Forms: Add shared ConsentToggle component. [#45556]
+- Forms: Improve the performance of loading the form responsesn dashboard by breaking it up into two stages. [#45565]
+- Instant Search: Add global WooCommerce Product Attributes as filter options. [#45416]
+- Instant Search: Fix issue where Safari's 'Use advanced tracking and fingerprinting protection' setting breaks Search. [#45588]
+
+### Improved compatibility
+- Tested up to WordPress 6.9 [#45571]
+
+### Bug fixes
+- Forms: Fix textarea submission on enter. [#45602]
+
+### Other changes <!-- Non-user-facing changes go here. This section will not be copied to readme.txt. -->
+- Post Images: Ensure type is WP_Post before treating it as a post. [#45623]
+
 ## 15.2-a.5 - 2025-10-21
 ### Enhancements
 - Forms: merged email and push notification settings panels. [#45548]

--- a/projects/plugins/jetpack/changelog/add-instant-search-wc-attributes
+++ b/projects/plugins/jetpack/changelog/add-instant-search-wc-attributes
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-Instant Search: Add global WooCommerce Product Attributes as filter options.

--- a/projects/plugins/jetpack/changelog/disable-tests-sync_issues_with_wp_trunk
+++ b/projects/plugins/jetpack/changelog/disable-tests-sync_issues_with_wp_trunk
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Fix Sync test that broke on WP 6.9 beta.
-
-

--- a/projects/plugins/jetpack/changelog/dotcom-14370-remove-the-jetpack-stats-callout-after-a-month
+++ b/projects/plugins/jetpack/changelog/dotcom-14370-remove-the-jetpack-stats-callout-after-a-month
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-

--- a/projects/plugins/jetpack/changelog/fix-forms-textarea-double-enter
+++ b/projects/plugins/jetpack/changelog/fix-forms-textarea-double-enter
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-Forms: fix textarea submission on enter.

--- a/projects/plugins/jetpack/changelog/fix-integration-endpoint-performance
+++ b/projects/plugins/jetpack/changelog/fix-integration-endpoint-performance
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-Forms: Improve the performance of loading the form responsesn dashboard by breaking it up into two stages. 

--- a/projects/plugins/jetpack/changelog/fix-jetpack-warnings_on_nonpost
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-warnings_on_nonpost
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Post Images: Ensure type is WP_Post before treating it as a post.

--- a/projects/plugins/jetpack/changelog/fix-jps-safari-privacy
+++ b/projects/plugins/jetpack/changelog/fix-jps-safari-privacy
@@ -1,4 +1,0 @@
-Significance: patch
-Type: enhancement
-
-Instant Search: Fix issue where Safari's 'Use advanced tracking and fingerprinting protection' setting breaks Search.

--- a/projects/plugins/jetpack/changelog/fix-phan-PhanAccessMethodInternal
+++ b/projects/plugins/jetpack/changelog/fix-phan-PhanAccessMethodInternal
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Resolve all PhanAccessMethodInternal instances (all of which are suppression comments).
-
-

--- a/projects/plugins/jetpack/changelog/update-comments
+++ b/projects/plugins/jetpack/changelog/update-comments
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updating a comment to check build process.
-
-

--- a/projects/plugins/jetpack/changelog/update-forms-consent-component
+++ b/projects/plugins/jetpack/changelog/update-forms-consent-component
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-Forms: add shared ConsentToggle component.

--- a/projects/plugins/jetpack/changelog/update-jetpack-tested-to-ver-wp
+++ b/projects/plugins/jetpack/changelog/update-jetpack-tested-to-ver-wp
@@ -1,4 +1,0 @@
-Significance: patch
-Type: compat
-
-Tested up to WordPress 6.9

--- a/projects/plugins/jetpack/changelog/update-stop-record-events-bot
+++ b/projects/plugins/jetpack/changelog/update-stop-record-events-bot
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Update composer.lock
-
-

--- a/projects/plugins/jetpack/changelog/update-unit-tests-test_get_post_types_method
+++ b/projects/plugins/jetpack/changelog/update-unit-tests-test_get_post_types_method
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Update Sync related unit test
-
-

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -111,7 +111,7 @@
 		"platform": {
 			"ext-intl": "0.0.0"
 		},
-		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ15_2_a_5",
+		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ15_2_a_7",
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -1490,7 +1490,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/forms",
-                "reference": "e7cb1f32b7ba9bf64e566c669597f8fed4fc013b"
+                "reference": "21e32e4949421c9c2f8e42131b071f7427ea1f99"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1523,7 +1523,7 @@
                     "link-template": "https://github.com/automattic/jetpack-forms/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "6.12.x-dev"
+                    "dev-trunk": "6.13.x-dev"
                 },
                 "textdomain": "jetpack-forms",
                 "version-constants": {
@@ -2830,7 +2830,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/search",
-                "reference": "2a95b63ad7c0d51c615ac631a309920cdf0fff3f"
+                "reference": "0e7c20324ff820efb82d3462205b958965e7260b"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -2860,7 +2860,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-search/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "0.52.x-dev"
+                    "dev-trunk": "0.53.x-dev"
                 },
                 "version-constants": {
                     "::VERSION": "src/class-package.php"
@@ -2980,7 +2980,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/stats-admin",
-                "reference": "5001fa55b765879df69e7cd989cbf2ac0835a0a0"
+                "reference": "f60f396b95fede69b361f9f9c80f01a6d4f39c3b"
             },
             "require": {
                 "automattic/jetpack-blaze": "@dev",
@@ -3006,7 +3006,7 @@
                 "autotagger": true,
                 "mirror-repo": "Automattic/jetpack-stats-admin",
                 "branch-alias": {
-                    "dev-trunk": "0.29.x-dev"
+                    "dev-trunk": "0.30.x-dev"
                 },
                 "textdomain": "jetpack-stats-admin",
                 "version-constants": {

--- a/projects/plugins/jetpack/jetpack.php
+++ b/projects/plugins/jetpack/jetpack.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://jetpack.com
  * Description: Security, performance, and marketing tools made by WordPress experts. Jetpack keeps your site protected so you can focus on more important things.
  * Author: Automattic
- * Version: 15.2-a.5
+ * Version: 15.2-a.7
  * Author URI: https://jetpack.com
  * License: GPL2+
  * Text Domain: jetpack
@@ -38,7 +38,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 if ( ! defined( 'JETPACK__VERSION' ) ) {
 	// This breaks the project version checks when a one-liner.
-	define( 'JETPACK__VERSION', '15.2-a.5' );
+	define( 'JETPACK__VERSION', '15.2-a.7' );
 }
 defined( 'JETPACK__MINIMUM_WP_VERSION' ) || define( 'JETPACK__MINIMUM_WP_VERSION', '6.7' );
 defined( 'JETPACK__MINIMUM_PHP_VERSION' ) || define( 'JETPACK__MINIMUM_PHP_VERSION', '7.2' );

--- a/projects/plugins/jetpack/readme.txt
+++ b/projects/plugins/jetpack/readme.txt
@@ -326,15 +326,18 @@ Jetpack Backup can do a full website migration to a new host, migrate theme file
 
 
 == Changelog ==
-### 15.2-a.5 - 2025-10-21
+### 15.2-a.7 - 2025-10-27
 #### Enhancements
-- Forms: merged email and push notification settings panels.
+- Forms: Add shared ConsentToggle component.
+- Forms: Improve the performance of loading the form responsesn dashboard by breaking it up into two stages.
+- Instant Search: Add global WooCommerce Product Attributes as filter options.
+- Instant Search: Fix issue where Safari's 'Use advanced tracking and fingerprinting protection' setting breaks Search.
+
+#### Improved compatibility
+- Tested up to WordPress 6.9
 
 #### Bug fixes
-- Forms: Fix a bug where ther responsive modal is not able to be closed.
-- Forms: Reset the selection on tab switch in dashboard.
-- Forms: Stop preloading the integrations endpoint.
-- Instant Search: Handle browser privacy settings stripping out the search query value.
+- Forms: Fix textarea submission on enter.
 
 --------
 

--- a/projects/plugins/mu-wpcom-plugin/changelog/prerelease#3
+++ b/projects/plugins/mu-wpcom-plugin/changelog/prerelease#3
@@ -1,4 +1,5 @@
 Significance: patch
 Type: changed
+Comment: Update composer.lock.
 
-Update package dependencies.
+

--- a/projects/plugins/mu-wpcom-plugin/composer.lock
+++ b/projects/plugins/mu-wpcom-plugin/composer.lock
@@ -1471,7 +1471,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/stats-admin",
-                "reference": "5001fa55b765879df69e7cd989cbf2ac0835a0a0"
+                "reference": "f60f396b95fede69b361f9f9c80f01a6d4f39c3b"
             },
             "require": {
                 "automattic/jetpack-blaze": "@dev",
@@ -1497,7 +1497,7 @@
                 "autotagger": true,
                 "mirror-repo": "Automattic/jetpack-stats-admin",
                 "branch-alias": {
-                    "dev-trunk": "0.29.x-dev"
+                    "dev-trunk": "0.30.x-dev"
                 },
                 "textdomain": "jetpack-stats-admin",
                 "version-constants": {

--- a/projects/plugins/search/changelog/prerelease#5
+++ b/projects/plugins/search/changelog/prerelease#5
@@ -1,4 +1,5 @@
 Significance: patch
 Type: changed
+Comment: Update composer.lock.
 
-Update package dependencies.
+

--- a/projects/plugins/search/composer.lock
+++ b/projects/plugins/search/composer.lock
@@ -1560,7 +1560,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/search",
-                "reference": "2a95b63ad7c0d51c615ac631a309920cdf0fff3f"
+                "reference": "0e7c20324ff820efb82d3462205b958965e7260b"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -1590,7 +1590,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-search/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "0.52.x-dev"
+                    "dev-trunk": "0.53.x-dev"
                 },
                 "version-constants": {
                     "::VERSION": "src/class-package.php"

--- a/projects/plugins/wpcomsh/changelog/prerelease#3
+++ b/projects/plugins/wpcomsh/changelog/prerelease#3
@@ -1,4 +1,5 @@
 Significance: patch
 Type: changed
+Comment: Update composer.lock.
 
-Update package dependencies.
+

--- a/projects/plugins/wpcomsh/composer.lock
+++ b/projects/plugins/wpcomsh/composer.lock
@@ -1746,7 +1746,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/stats-admin",
-                "reference": "5001fa55b765879df69e7cd989cbf2ac0835a0a0"
+                "reference": "f60f396b95fede69b361f9f9c80f01a6d4f39c3b"
             },
             "require": {
                 "automattic/jetpack-blaze": "@dev",
@@ -1772,7 +1772,7 @@
                 "autotagger": true,
                 "mirror-repo": "Automattic/jetpack-stats-admin",
                 "branch-alias": {
-                    "dev-trunk": "0.29.x-dev"
+                    "dev-trunk": "0.30.x-dev"
                 },
                 "textdomain": "jetpack-stats-admin",
                 "version-constants": {


### PR DESCRIPTION
Closes MONOREP-168

 <!--- This template is used for backporting changes made during a plugin release back to trunk. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Backports changes for jetpack 15.2-a.7

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/a
## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Proofread changes.