### PR TITLE
Forms: Adds country flags to dashboard based on IP.

### DIFF
--- a/projects/packages/forms/changelog/add-forms-add-flags-to-dashboard
+++ b/projects/packages/forms/changelog/add-forms-add-flags-to-dashboard
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Forms: Add flag next to the IP address 

--- a/projects/packages/forms/src/dashboard/components/response-view/body.tsx
+++ b/projects/packages/forms/src/dashboard/components/response-view/body.tsx
@@ -478,6 +478,11 @@ const ResponseViewBody = ( {
 							<th>{ __( 'IP address:', 'jetpack-forms' ) }&nbsp;</th>
 							<td>
 								<Tooltip text={ __( 'Lookup IP address', 'jetpack-forms' ) }>
+									{ response.country_code && (
+										<span className="jp-forms__inbox-response-meta-country-flag response-country-flag">
+											{ getCountryFlagEmoji( response.country_code ) }
+										</span>
+									) }
 									<ExternalLink href={ getRedirectUrl( 'ip-lookup', { path: response.ip } ) }>
 										{ response.ip }
 									</ExternalLink>

--- a/projects/packages/forms/src/dashboard/components/response-view/body.tsx
+++ b/projects/packages/forms/src/dashboard/components/response-view/body.tsx
@@ -31,7 +31,12 @@ import CopyClipboardButton from '../../components/copy-clipboard-button';
 import Gravatar from '../../components/gravatar';
 import useInboxData from '../../hooks/use-inbox-data';
 import { useMarkAsSpam } from '../../hooks/use-mark-as-spam';
-import { getPath, updateMenuCounter, updateMenuCounterOptimistically } from '../../inbox/utils';
+import {
+	getPath,
+	updateMenuCounter,
+	updateMenuCounterOptimistically,
+	getCountryFlagEmoji,
+} from '../../inbox/utils';
 import { store as dashboardStore } from '../../store';
 import type { FormResponse } from '../../../types';
 

--- a/projects/packages/forms/src/dashboard/inbox/dataviews/index.js
+++ b/projects/packages/forms/src/dashboard/inbox/dataviews/index.js
@@ -23,7 +23,7 @@ import InboxStatusToggle from '../../components/inbox-status-toggle';
 import { ResponseMobileView, SingleResponseView } from '../../components/response-view';
 import useInboxData from '../../hooks/use-inbox-data';
 import EmptyResponses from '../empty-responses';
-import { getPath, getItemId } from '../utils.js';
+import { getPath, getItemId, getCountryFlagEmoji } from '../utils.js';
 import {
 	viewAction,
 	markAsSpamAction,
@@ -310,7 +310,21 @@ export default function InboxView() {
 				filterBy: { operators: [ 'is' ] },
 				enableSorting: false,
 			},
-			{ id: 'ip', label: __( 'IP Address', 'jetpack-forms' ), enableSorting: false },
+			{
+				id: 'ip',
+				label: __( 'IP Address', 'jetpack-forms' ),
+				enableSorting: false,
+				render: ( { item } ) => {
+					return (
+						<>
+							<span className="response-country-flag">
+								{ getCountryFlagEmoji( item.country_code ) }
+							</span>
+							{ item.ip || '' }
+						</>
+					);
+				},
+			},
 		],
 		[ filterOptions, dateSettings.formats.date ]
 	);

--- a/projects/packages/forms/src/dashboard/inbox/dataviews/index.js
+++ b/projects/packages/forms/src/dashboard/inbox/dataviews/index.js
@@ -13,6 +13,7 @@ import { dateI18n, getSettings as getDateSettings } from '@wordpress/date';
 import { useCallback, useMemo, useState } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
 import { __ } from '@wordpress/i18n';
+import { Icon, globe } from '@wordpress/icons';
 import { useEffect } from 'react';
 import { useSearchParams } from 'react-router';
 /**
@@ -318,7 +319,8 @@ export default function InboxView() {
 					return (
 						<>
 							<span className="response-country-flag">
-								{ getCountryFlagEmoji( item.country_code ) }
+								{ ! item.country_code && <Icon icon={ globe } size={ 20 } /> }
+								{ item.country_code && getCountryFlagEmoji( item.country_code ) }
 							</span>
 							{ item.ip || '' }
 						</>

--- a/projects/packages/forms/src/dashboard/inbox/style.scss
+++ b/projects/packages/forms/src/dashboard/inbox/style.scss
@@ -171,6 +171,13 @@
 	align-items: center;
 }
 
+.response-country-flag {
+	font-size: 16px;
+	display: inline;
+	padding-right: 4px;
+	vertical-align: top;
+}
+
 .jp-forms__inbox-response-data-value .file-field {
 	margin-top: 4px;
 

--- a/projects/packages/forms/src/dashboard/inbox/style.scss
+++ b/projects/packages/forms/src/dashboard/inbox/style.scss
@@ -178,6 +178,11 @@
 	vertical-align: top;
 }
 
+.response-country-flag svg {
+	fill: currentColor;
+	vertical-align: text-top;
+}
+
 .jp-forms__inbox-response-data-value .file-field {
 	margin-top: 4px;
 

--- a/projects/packages/forms/src/dashboard/inbox/style.scss
+++ b/projects/packages/forms/src/dashboard/inbox/style.scss
@@ -175,7 +175,7 @@
 	font-size: 16px;
 	display: inline;
 	padding-right: 4px;
-	vertical-align: top;
+	vertical-align: middle;
 }
 
 .response-country-flag svg {

--- a/projects/packages/forms/src/dashboard/inbox/utils.js
+++ b/projects/packages/forms/src/dashboard/inbox/utils.js
@@ -82,7 +82,7 @@ export const getItemId = item => item?.id?.toString() ?? '';
  */
 export const getCountryFlagEmoji = countryCode => {
 	if ( ! countryCode ) {
-		return '🏳️'; // white flag. Since there is no unknown flag.
+		return '';
 	}
 	const upperCountryCode = countryCode.toUpperCase();
 	const offset = 127397;

--- a/projects/packages/forms/src/dashboard/inbox/utils.js
+++ b/projects/packages/forms/src/dashboard/inbox/utils.js
@@ -73,3 +73,21 @@ export const updateMenuCounterOptimistically = count => {
  * @return {string} The ID of the item.
  */
 export const getItemId = item => item?.id?.toString() ?? '';
+
+/**
+ * Get the country flag emoji from a country code.
+ *
+ * @param {string|null} countryCode - Two-letter ISO 3166-1 alpha-2 country code (e.g., "US") or null if unknown.
+ * @return {string} The country flag emoji.
+ */
+export const getCountryFlagEmoji = countryCode => {
+	if ( ! countryCode ) {
+		return '🏳️'; // white flag. Since there is no unknown flag.
+	}
+	const upperCountryCode = countryCode.toUpperCase();
+	const offset = 127397;
+	return String.fromCodePoint(
+		upperCountryCode.charCodeAt( 0 ) + offset,
+		upperCountryCode.charCodeAt( 1 ) + offset
+	);
+};

--- a/projects/packages/forms/src/types/index.ts
+++ b/projects/packages/forms/src/types/index.ts
@@ -100,6 +100,8 @@ export interface FormResponse {
 	author_avatar: string;
 	/** The IP address of the response author. */
 	ip: string;
+	/** The country code of the response author. */
+	country_code: string;
 	/** The title of the form that the response was submitted to. */
 	entry_title: string;
 	/** The permalink of the form that the response was submitted to. */

--- a/projects/plugins/jetpack/changelog/add-forms-add-flags-to-dashboard
+++ b/projects/plugins/jetpack/changelog/add-forms-add-flags-to-dashboard
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Forms: add flag next to the IP Address


### PR DESCRIPTION
Fixes [FORMS-342](https://linear.app/a8c/issue/FORMS-342/add-country-flags-to-dashboard-based-on-ip-address) 
Part of FORMS-316

Adds (with flag)
<img width="698" height="240" alt="Screenshot 2025-10-29 at 11 01 13 AM" src="https://github.com/user-attachments/assets/2f511fed-323c-4444-9b01-ed2ff4c31188" />


when there is no flag
<img width="927" height="304" alt="Screenshot 2025-10-28 at 2 23 28 PM" src="https://github.com/user-attachments/assets/0ff286d3-6d59-4b6f-bc4f-b1810bdd714d" />



## Proposed changes:
* Add the emoji flag based on the country_code that we have for a given response. 

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1761592460796429-slack-C052XEUUBL4

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Apply this PR. 
Create a form. 
Fill out the form. 
Notice when you visit the dashboard that the emoi flag show up as you would expect next the the IP address.


Further enhancements 
In future PRs. 
* We could add a country name as a tooltip. 
* Mark Private IP as private. Using the Utils:ip_is_private( $ip ). 
 