### PR TITLE
Forms: invalidate counts on spam link

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-invalidate-counts-on-spam-request
+++ b/projects/packages/forms/changelog/fix-forms-invalidate-counts-on-spam-request
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: update counts after landing on a mark as spam link

--- a/projects/packages/forms/src/dashboard/hooks/use-mark-as-spam.ts
+++ b/projects/packages/forms/src/dashboard/hooks/use-mark-as-spam.ts
@@ -4,6 +4,7 @@
 import { store as coreStore } from '@wordpress/core-data';
 import { useDispatch } from '@wordpress/data';
 import { useCallback, useEffect, useState } from '@wordpress/element';
+import { store as dashboardStore } from '../store';
 /**
  * Types
  */
@@ -12,6 +13,7 @@ import type { FormResponse } from '../../types';
 export const useMarkAsSpam = ( response: FormResponse ) => {
 	const [ isConfirmDialogOpen, setIsConfirmDialogOpen ] = useState( false );
 	const { saveEntityRecord } = useDispatch( coreStore );
+	const { invalidateCounts } = useDispatch( dashboardStore );
 
 	const onConfirmMarkAsSpam = useCallback( async () => {
 		setIsConfirmDialogOpen( false );
@@ -21,8 +23,10 @@ export const useMarkAsSpam = ( response: FormResponse ) => {
 			status: 'spam',
 		} );
 
+		await invalidateCounts();
+
 		window.location.hash = window.location.hash.replace( 'status=inbox', 'status=spam' );
-	}, [ response, saveEntityRecord ] );
+	}, [ response, saveEntityRecord, invalidateCounts ] );
 
 	const onCancelMarkAsSpam = useCallback( () => {
 		setIsConfirmDialogOpen( false );


### PR DESCRIPTION


## Proposed changes:
This PR addresses a glitch where responses marked as spam from a link (email) would not update the inbox counts afterwards.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
None

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
To see the glitch:

- go to forms dashboard, select a response
- mind the counts on the inbox tabs, specially the Spam one
- the URL will look like `#/responses?r=1669` where `r` is the ID of the response. Add `&mark_as_spam` to it, hit Enter and reload the page
- a confirm dialog will show, accept it to mark the selected response as Spam, see that the counts on the tabs hasn't changed

Apply the patch and repeat the process. This time, as soon as you confirm sending the response to spam, the counts should update