### PR TITLE
Forms: Add emoji flag to email responses

### DIFF
--- a/projects/packages/forms/changelog/add-emoji-flag-to-email-responses
+++ b/projects/packages/forms/changelog/add-emoji-flag-to-email-responses
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Forms: add emoji flag to the response email next to the IP Address

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -2077,11 +2077,11 @@ class Contact_Form extends Contact_Form_Shortcode {
 		);
 		$footer_ip = null;
 		if ( $comment_author_ip ) {
-			$comment_author_ip = $comment_author_ip . ' ' . $response->get_country_flag();
-			$footer_ip         = sprintf(
+			$comment_author_ip_with_flag = $comment_author_ip . ( $response->get_country_flag() ? ' ' . $response->get_country_flag() : '' );
+			$footer_ip                   = sprintf(
 				/* translators: Placeholder is the IP address of the person who submitted a form. */
 				esc_html__( 'IP Address: %1$s', 'jetpack-forms' ),
-				$comment_author_ip
+				$comment_author_ip_with_flag
 			) . '<br />';
 		}
 

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -2077,11 +2077,11 @@ class Contact_Form extends Contact_Form_Shortcode {
 		);
 		$footer_ip = null;
 		if ( $comment_author_ip ) {
-			$footer_ip = sprintf(
-				/* translators: %1$s placeholder is the IP address, %2$s is the country flag of the person who submitted a form. */
-				esc_html__( 'IP Address: %1$s %2$s', 'jetpack-forms' ),
-				$comment_author_ip,
-				$response->get_country_flag()
+			$comment_author_ip = $comment_author_ip . ' ' . $response->get_country_flag();
+			$footer_ip         = sprintf(
+				/* translators: Placeholder is the IP address of the person who submitted a form. */
+				esc_html__( 'IP Address: %1$s', 'jetpack-forms' ),
+				$comment_author_ip
 			) . '<br />';
 		}
 

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -2078,9 +2078,10 @@ class Contact_Form extends Contact_Form_Shortcode {
 		$footer_ip = null;
 		if ( $comment_author_ip ) {
 			$footer_ip = sprintf(
-			/* translators: Placeholder is the IP address of the person who submitted a form. */
-				esc_html__( 'IP Address: %1$s', 'jetpack-forms' ),
-				$comment_author_ip
+				/* translators: %1$s placeholder is the IP address, %2$s is the country flag of the person who submitted a form. */
+				esc_html__( 'IP Address: %1$s %2$s', 'jetpack-forms' ),
+				$comment_author_ip,
+				$response->get_country_flag()
 			) . '<br />';
 		}
 

--- a/projects/packages/forms/src/contact-form/class-feedback.php
+++ b/projects/packages/forms/src/contact-form/class-feedback.php
@@ -785,6 +785,50 @@ class Feedback {
 	}
 
 	/**
+	 * Get the emoji flag for the country.
+	 *
+	 * @return string The emoji flag for the country code, or empty string if unavailable.
+	 */
+	public function get_country_flag() {
+		return self::country_code_to_emoji_flag( $this->country_code );
+	}
+
+	/**
+	 * Convert a country code to an emoji flag.
+	 *
+	 * Country codes should already be uppercase as they're stored that way by get_country_code_from_ip().
+	 *
+	 * @param string $country_code - the two-letter country code (e.g., 'US', 'GB', 'DE').
+	 *
+	 * @return string The emoji flag for the country code, or empty string if invalid.
+	 */
+	private static function country_code_to_emoji_flag( $country_code ) {
+		if ( empty( $country_code ) || strlen( $country_code ) !== 2 ) {
+			return '';
+		}
+
+		// Convert each letter to a regional indicator symbol
+		// Regional indicator symbols start at Unicode code point 127462 (🇦)
+		// and correspond to A-Z (ASCII 65-90)
+		$flag = '';
+		for ( $i = 0; $i < 2; $i++ ) {
+			$char = $country_code[ $i ];
+
+			// Check if the character is a valid uppercase letter (A-Z)
+			if ( ord( $char ) < 65 || ord( $char ) > 90 ) {
+				return '';
+			}
+
+			$code_point = 127462 + ( ord( $char ) - 65 );
+
+			// Convert code point to UTF-8 encoded character
+			$flag .= mb_chr( $code_point, 'UTF-8' );
+		}
+
+		return $flag;
+	}
+
+	/**
 	 * Get country code from IP address.
 	 *
 	 * This method uses a filter to allow custom implementations of GeoIP lookup.

--- a/projects/packages/forms/tests/php/contact-form/Feedback_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Feedback_Test.php
@@ -2972,4 +2972,62 @@ class Feedback_Test extends BaseTestCase {
 		wp_delete_user( $author_id );
 		wp_delete_user( $subscriber_id );
 	}
+
+	/**
+	 * Test that country flags are returned correctly.
+	 */
+	public function test_get_country_flag() {
+		$form_id = Utility::get_form_id();
+
+		$_post_data = Utility::get_post_request(
+			array(
+				'name'    => 'John Doe',
+				'email'   => 'john@example.com',
+				'message' => 'Test message',
+			),
+			'g' . $form_id
+		);
+
+		$form = new Contact_Form(
+			array(
+				'title'       => 'Test Form',
+				'description' => 'This is a test form.',
+			),
+			"[contact-field label='Name' type='name' required='1'/][contact-field label='Email' type='email' required='1'/][contact-field label='Message' type='textarea' required='1'/]"
+		);
+
+		// Test valid country codes
+		$test_cases = array(
+			'US' => '🇺🇸',
+			'GB' => '🇬🇧',
+			'DE' => '🇩🇪',
+			'CA' => '🇨🇦',
+			'JP' => '🇯🇵',
+			'us' => '🇺🇸', // Test lowercase (should be converted to uppercase internally)
+		);
+
+		foreach ( $test_cases as $country_code => $expected_flag ) {
+			$filter_callback = function () use ( $country_code ) {
+				return $country_code;
+			};
+			add_filter( 'jetpack_get_country_from_ip', $filter_callback, 10 );
+
+			$response = Feedback::from_submission( $_post_data, $form );
+
+			$this->assertEquals( $expected_flag, $response->get_country_flag(), "Country code {$country_code} should convert to flag emoji {$expected_flag}" );
+
+			remove_filter( 'jetpack_get_country_from_ip', $filter_callback, 10 );
+		}
+
+		// Test when no country code is available
+		$filter_callback = function () {
+			return null;
+		};
+		add_filter( 'jetpack_get_country_from_ip', $filter_callback, 10 );
+
+		$response = Feedback::from_submission( $_post_data, $form );
+		$this->assertSame( '', $response->get_country_flag(), 'Should return empty string when no country code is available' );
+
+		remove_filter( 'jetpack_get_country_from_ip', $filter_callback, 10 );
+	}
 }

--- a/projects/plugins/jetpack/changelog/add-emoji-flag-to-email-responses
+++ b/projects/plugins/jetpack/changelog/add-emoji-flag-to-email-responses
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Forms: Add emoji flag to the response email next to the IP address.


### PR DESCRIPTION
Part of FORMS-316


This PR adds the emoji flag next the IP Address. 

<img width="197" height="32" alt="Screenshot 2025-10-27 at 3 04 05 PM" src="https://github.com/user-attachments/assets/d6251fac-7517-403a-aecb-cf808aa7b22e" />

## Proposed changes:
* Adds a new method to the `get_country_flag()` class to the Feedback class. 
* Apply the new method to the email copy next to the IP.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
N/A

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
* Apply this class. 
* Fill out the form from a non Private IP Address. (try testing it via a jurassic ninja site ) 
* Check the email that you recieved. Notice the emoji flag. 

Do the tests pass? 

