### PR TITLE
 Forms: Add details for JWT decoding errors

### DIFF
--- a/projects/packages/forms/changelog/update-forms-error-details
+++ b/projects/packages/forms/changelog/update-forms-error-details
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Forms: Add details for JWT decoding errors

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -1533,10 +1533,16 @@ class Contact_Form_Plugin {
 		$is_block_template_part = str_starts_with( $id, 'block-template-part-' );
 
 		if ( isset( $_POST['jetpack_contact_form_jwt'] ) ) {
-			$form = Contact_Form::get_instance_from_jwt( sanitize_text_field( wp_unslash( $_POST['jetpack_contact_form_jwt'] ) ) );
-			if ( ! $form ) { // fail early if the JWT is invalid.
-				// If the JWT is invalid, we can't process the form.
-				return Form_Submission_Error::system_error( 'invalid_jwt', __( 'Invalid JWT token.', 'jetpack-forms' ) );
+			$jwt = sanitize_text_field( wp_unslash( $_POST['jetpack_contact_form_jwt'] ) );
+
+			try {
+				$form = Contact_Form::get_instance_from_jwt( $jwt );
+			} catch ( \Exception $e ) {
+				// Fail early if the JWT is invalid with detailed error information.
+				return Form_Submission_Error::system_error(
+					'invalid_jwt',
+					$e->getMessage()
+				);
 			}
 
 			$form->validate();
@@ -1731,7 +1737,8 @@ class Contact_Form_Plugin {
 		$is_system_error   = Form_Submission_Error::is_system_error( $submission_result );
 
 		if ( ! $submission_result || $is_system_error ) {
-			$error_code = $is_system_error ? $submission_result->get_error_code() : 'unknown';
+			$error_code    = $is_system_error ? $submission_result->get_error_code() : 'unknown';
+			$error_details = $is_system_error ? $submission_result->get_error_message() : null;
 
 			/**
 			 * Action when we want to log a jetpack_forms event.
@@ -1740,13 +1747,15 @@ class Contact_Form_Plugin {
 			 *
 			 * @param string $log_message The log message.
 			 * @param string $error_code The error code (optional).
+			 * @param string $error_details The error details (optional).
 			 */
-			do_action( 'jetpack_forms_log', 'submission_failed', $error_code );
+			do_action( 'jetpack_forms_log', 'submission_failed', $error_code, $error_details );
 
 			$accepts_json && wp_send_json_error(
 				array(
-					'error' => __( 'An error occurred. Please try again later.', 'jetpack-forms' ),
-					'code'  => $error_code,
+					'error'   => __( 'An error occurred. Please try again later.', 'jetpack-forms' ),
+					'code'    => $error_code,
+					'details' => $error_details,
 				),
 				500
 			);

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -1536,7 +1536,7 @@ class Contact_Form_Plugin {
 			$jwt = sanitize_text_field( wp_unslash( $_POST['jetpack_contact_form_jwt'] ) );
 
 			try {
-				$form = Contact_Form::get_instance_from_jwt( $jwt );
+				$form = Contact_Form::get_instance_from_jwt( $jwt, true );
 			} catch ( \Exception $e ) {
 				// Fail early if the JWT is invalid with detailed error information.
 				return Form_Submission_Error::system_error(

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -1753,9 +1753,8 @@ class Contact_Form_Plugin {
 
 			$accepts_json && wp_send_json_error(
 				array(
-					'error'   => __( 'An error occurred. Please try again later.', 'jetpack-forms' ),
-					'code'    => $error_code,
-					'details' => $error_details,
+					'error' => __( 'An error occurred. Please try again later.', 'jetpack-forms' ),
+					'code'  => $error_code,
 				),
 				500
 			);

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -254,26 +254,31 @@ class Contact_Form extends Contact_Form_Shortcode {
 	 * Get the instance of the contact form from a JWT token.
 	 *
 	 * @param string $jwt_token The JWT token.
+	 * @param bool   $throw_exception Whether to throw an exception if the JWT token is invalid or cannot be decoded.
 	 *
-	 * @return Contact_Form The contact form instance.
-	 * @throws \Exception If the JWT token is invalid or cannot be decoded.
+	 * @return Contact_Form|null The contact form instance, or null if decoding fails and $throw_exception is false.
+	 * @throws \Exception If the JWT token is invalid or cannot be decoded and $throw_exception is true.
 	 */
-	public static function get_instance_from_jwt( $jwt_token ) {
+	public static function get_instance_from_jwt( $jwt_token, $throw_exception = false ) {
 		$secret = self::get_secret();
 
 		try {
 			$data = JWT::decode( $jwt_token, $secret, array( 'HS256' ), true );
 		} catch ( \Exception $e ) {
 			// Re-throw with more context about the failure.
-			throw new \Exception(
-				sprintf(
-					/* translators: %s is the original exception message */
-					__( 'Failed to decode JWT token: %s', 'jetpack-forms' ),
-					$e->getMessage()
-				),
-				0,
-				$e
-			);
+			if ( $throw_exception ) {
+				throw new \Exception(
+					sprintf(
+						/* translators: %s is the original exception message */
+						__( 'Failed to decode JWT token: %s', 'jetpack-forms' ),
+						$e->getMessage()
+					),
+					0,
+					$e
+				);
+			}
+
+			return null;
 		}
 
 		$source = $data['source'] ?? array();

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -255,24 +255,34 @@ class Contact_Form extends Contact_Form_Shortcode {
 	 *
 	 * @param string $jwt_token The JWT token.
 	 *
-	 * @return Contact_Form|null The contact form instance or null if not found.
+	 * @return Contact_Form The contact form instance.
+	 * @throws \Exception If the JWT token is invalid or cannot be decoded.
 	 */
 	public static function get_instance_from_jwt( $jwt_token ) {
 		$secret = self::get_secret();
-		if ( empty( $secret ) ) {
-			return null;
-		}
 
 		try {
 			$data = JWT::decode( $jwt_token, $secret, array( 'HS256' ), true );
 		} catch ( \Exception $e ) {
-			return null;
+			// Re-throw with more context about the failure.
+			throw new \Exception(
+				sprintf(
+					/* translators: %s is the original exception message */
+					__( 'Failed to decode JWT token: %s', 'jetpack-forms' ),
+					$e->getMessage()
+				),
+				0,
+				$e
+			);
 		}
+
 		$source = $data['source'] ?? array();
+
 		if ( empty( $source ) ) {
 			// phpcs:ignore WordPress.Security.NonceVerification.Missing -- check done by caller process_form_submission()
 			$source_post_id = ! empty( $_POST['contact-form-id'] ) && is_numeric( $_POST['contact-form-id'] ) ? absint( wp_unslash( $_POST['contact-form-id'] ) ) : 0;
 			$post           = get_post( $source_post_id );
+
 			if ( $post !== null && $source_post_id > 0 ) {
 				// create a fallback source
 				$source = array(
@@ -289,6 +299,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 		$form->source           = Feedback_Source::from_serialized( $source );
 		$form->hash             = $data['hash'];
 		$form->has_verified_jwt = true;
+
 		return $form;
 	}
 
@@ -370,12 +381,13 @@ class Contact_Form extends Contact_Form_Shortcode {
 	/**
 	 * Helper function to get the secret from the Tokens class.
 	 *
-	 * @return string|null The secret from the Tokens class or null if not available.
+	 * @return string The secret from the Tokens class, or a default secret if not available.
 	 */
 	private static function get_secret() {
 		$token          = ( new Tokens() )->get_access_token();
 		$default_secret = hash_hmac( 'md5', get_option( 'admin_email' ), JETPACK__VERSION );
-		if ( ! isset( $token->secret ) ) {
+
+		if ( empty( $token->secret ) ) {
 			return $default_secret;
 		}
 

--- a/projects/packages/forms/src/modules/form/shared.ts
+++ b/projects/packages/forms/src/modules/form/shared.ts
@@ -66,7 +66,12 @@ export const submitForm = async ( formHash: string ) => {
 		const result = await response.json();
 
 		if ( ! response.ok ) {
-			debug( `Form submission failed: ${ result?.data?.code }`, response );
+			debug(
+				`Form submission failed: ${ result?.data?.code } ${
+					result?.data?.details ? `- ${ result?.data?.details }` : ''
+				}`,
+				response
+			);
 			// If we have a specific error from the server, use it; otherwise fall back to network error
 			return result && result.data && result.data.error
 				? { success: false, error: result.data.error }

--- a/projects/packages/forms/src/modules/form/shared.ts
+++ b/projects/packages/forms/src/modules/form/shared.ts
@@ -66,12 +66,7 @@ export const submitForm = async ( formHash: string ) => {
 		const result = await response.json();
 
 		if ( ! response.ok ) {
-			debug(
-				`Form submission failed: ${ result?.data?.code } ${
-					result?.data?.details ? `- ${ result?.data?.details }` : ''
-				}`,
-				response
-			);
+			debug( `Form submission failed: ${ result?.data?.code }`, response );
 			// If we have a specific error from the server, use it; otherwise fall back to network error
 			return result && result.data && result.data.error
 				? { success: false, error: result.data.error }

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
@@ -2722,8 +2722,8 @@ EOT;
 		Constants::clear_single_constant( 'JETPACK_BLOG_TOKEN' );
 	}
 
-	public function test_get_instance_from_jwt_returns_null_when_no_secret() {
-		// Ensure JETPACK_BLOG_TOKEN is not defined
+	public function test_get_instance_from_jwt_uses_default_secret_when_no_token_secret() {
+		// Ensure JETPACK_BLOG_TOKEN is not defined, so default secret is used
 		Constants::clear_single_constant( 'JETPACK_BLOG_TOKEN' );
 
 		$form = new Contact_Form(
@@ -2810,11 +2810,13 @@ EOT;
 		$this->assertEquals( $form->get_source(), $form_copy->get_source(), 'Form sources should match' );
 	}
 
-	public function test_get_instance_from_jwt_returns_null_for_invalid_jwt() {
+	public function test_get_instance_from_jwt_throws_exception_for_invalid_jwt() {
 		Constants::set_constant( 'JETPACK_BLOG_TOKEN', 'test.token' );
 
-		$form_copy = Contact_Form::get_instance_from_jwt( 'invalid_jwt_token' );
-		$this->assertNull( $form_copy, 'Should return null for invalid JWT token' );
+		$this->expectException( \Exception::class );
+		$this->expectExceptionMessage( 'Failed to decode JWT token' );
+
+		Contact_Form::get_instance_from_jwt( 'invalid_jwt_token' );
 
 		Constants::clear_single_constant( 'JETPACK_BLOG_TOKEN' );
 	}

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
@@ -2816,10 +2816,20 @@ EOT;
 		$this->expectException( \Exception::class );
 		$this->expectExceptionMessage( 'Failed to decode JWT token' );
 
-		Contact_Form::get_instance_from_jwt( 'invalid_jwt_token' );
+		Contact_Form::get_instance_from_jwt( 'invalid_jwt_token', true );
 
 		Constants::clear_single_constant( 'JETPACK_BLOG_TOKEN' );
 	}
+
+	public function test_get_instance_from_jwt_returns_null_for_invalid_jwt() {
+		Constants::set_constant( 'JETPACK_BLOG_TOKEN', 'test.token' );
+
+		$form = Contact_Form::get_instance_from_jwt( 'invalid_jwt_token', false );
+		$this->assertNull( $form, 'Form should be null if decoding fails and $throw_exception is false' );
+
+		Constants::clear_single_constant( 'JETPACK_BLOG_TOKEN' );
+	}
+
 	/**
 	 * Test compute_id method with basic attributes
 	 */


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Follow-up to https://github.com/Automattic/jetpack/pull/45628

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds more details for the error

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Test with 194737-ghe-Automattic/wpcom
* Follow the instructions there