### PR TITLE
CI: Add phpcs ignore comments due to temporary failing CI test

### DIFF
--- a/projects/plugins/wpcomsh/changelog/update-php-compatibility-temp-fix
+++ b/projects/plugins/wpcomsh/changelog/update-php-compatibility-temp-fix
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Added phpcs ignore comments due to temporary failing CI test
+
+

--- a/projects/plugins/wpcomsh/storage/storage.php
+++ b/projects/plugins/wpcomsh/storage/storage.php
@@ -104,7 +104,7 @@ function wpcomsh_allow_file_uploads_with_invalid_mime_types( $file_data, $file, 
 
 	$finfo     = finfo_open( FILEINFO_MIME_TYPE );
 	$real_mime = finfo_file( $finfo, $file );
-	finfo_close( $finfo );
+	finfo_close( $finfo ); // phpcs:ignore PHPCompatibility.FunctionUse.RemovedFunctions.finfo_closeDeprecated
 
 	if ( empty( $real_mime ) ) {
 		return $file_data;

--- a/tools/get-wp-version.php
+++ b/tools/get-wp-version.php
@@ -13,7 +13,7 @@ curl_setopt( $ch, CURLOPT_RETURNTRANSFER, true );
 
 // Get the response and close the channel.
 $response = curl_exec( $ch );
-curl_close( $ch );
+curl_close( $ch ); // phpcs:ignore PHPCompatibility.FunctionUse.RemovedFunctions.curl_closeDeprecated
 
 $versions = json_decode( $response );
 $versions = $versions->offers;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Workaround for an issue with CI tests failing temporarily due to upstream changes

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds phpcs ignore comments for functions deprecated in PHP 8.5

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

p1761606377081319/1761603200.791369-slack-C052XEUUBL4

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Do all tests pass?