### PR TITLE
 Forms: Improve empty state centering and fix scrolling issues

### DIFF
--- a/projects/packages/forms/changelog/forms-empty-state-centering
+++ b/projects/packages/forms/changelog/forms-empty-state-centering
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Improve empty state centering and fix scrolling by consolidating layout min-height rules and improving flexbox handling.

--- a/projects/packages/forms/src/dashboard/components/layout/style.scss
+++ b/projects/packages/forms/src/dashboard/components/layout/style.scss
@@ -18,10 +18,11 @@ body.jetpack_page_jetpack-forms-admin {
 	box-sizing: border-box;
 	display: flex;
 	flex-direction: column;
+	flex: 1 1 auto;
 	margin: 0;
 	padding: 0;
 	width: 100%;
-	min-height: calc(100vh - var(--wp-admin--admin-bar--height));
+	min-height: calc(100vh - var(--wp-admin--admin-bar--height, 0px));
 
 	.jp-forms__layout-header-actions {
 		display: flex;
@@ -40,6 +41,14 @@ body.jetpack_page_jetpack-forms-admin {
 
 #jp-forms-dashboard .jp-forms__layout {
 	background: var(--wpds-color-bg-surface-neutral-strong, #f9f9f6);
+	min-height: calc(100vh - var(--wp-admin--admin-bar--height, 0px));
+
+	.admin-ui-page__content {
+		display: flex;
+		flex: 1 1 auto;
+		flex-direction: column;
+		min-height: 0;
+	}
 
 	.admin-ui-page__header {
 		box-sizing: border-box;
@@ -56,6 +65,7 @@ body.jetpack_page_jetpack-forms-admin {
 		display: flex;
 		flex-direction: column;
 		flex: 1;
+		min-height: 0;
 
 		> .components-tab-panel__tabs {
 			margin: 0;
@@ -96,6 +106,7 @@ body.jetpack_page_jetpack-forms-admin {
 		.components-tab-panel__tab-content {
 			display: flex;
 			flex: 1;
+			min-height: 0;
 			background: var(--jp-white);
 		}
 	}

--- a/projects/packages/forms/src/dashboard/components/layout/style.scss
+++ b/projects/packages/forms/src/dashboard/components/layout/style.scss
@@ -41,7 +41,6 @@ body.jetpack_page_jetpack-forms-admin {
 
 #jp-forms-dashboard .jp-forms__layout {
 	background: var(--wpds-color-bg-surface-neutral-strong, #f9f9f6);
-	min-height: calc(100vh - var(--wp-admin--admin-bar--height, 0px));
 
 	.admin-ui-page__content {
 		display: flex;
@@ -65,7 +64,6 @@ body.jetpack_page_jetpack-forms-admin {
 		display: flex;
 		flex-direction: column;
 		flex: 1;
-		min-height: 0;
 
 		> .components-tab-panel__tabs {
 			margin: 0;
@@ -106,7 +104,6 @@ body.jetpack_page_jetpack-forms-admin {
 		.components-tab-panel__tab-content {
 			display: flex;
 			flex: 1;
-			min-height: 0;
 			background: var(--jp-white);
 		}
 	}


### PR DESCRIPTION
Fixes #

## Proposed changes:

This PR improves the Forms dashboard layout to ensure the empty state is properly centered and scrolling works correctly.

<img width="1468" height="783" alt="Screenshot 2025-10-27 at 10 50 21 PM" src="https://github.com/user-attachments/assets/17089507-3501-4bd0-ba7d-9dc69e644a21" />


### Other information:

- [x] Have you written new tests for your changes, if applicable? _(N/A - CSS-only changes)_
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?

No, this PR only contains CSS layout improvements.

## Testing instructions:

### Prerequisites
* Install and activate Jetpack
* Ensure Jetpack Forms is enabled
* Have a site with **no form responses** in the inbox (or create a fresh test site)

### Testing Steps

1. Go to **Jetpack → Forms** in wp-admin
2. Click on the **"Responses"** tab
3. Verify the empty state displays correctly:
   - The message "You're set up. No responses yet." should be vertically centered in the available space
   - The container should expand from the header to the bottom of the viewport
   - No awkward scrolling should occur

