### PR TITLE
WooCommerce Analytics: Set dynamic WebPack public path for split assets

### DIFF
--- a/projects/packages/woocommerce-analytics/changelog/fix-wca-concatenated-js-error
+++ b/projects/packages/woocommerce-analytics/changelog/fix-wca-concatenated-js-error
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Set dynamic WebPack public path for split assets

--- a/projects/packages/woocommerce-analytics/src/class-universal.php
+++ b/projects/packages/woocommerce-analytics/src/class-universal.php
@@ -84,7 +84,7 @@ class Universal {
 				const wcAnalytics = window.wcAnalytics;
 
 				// Set the assets URL for webpack to find the split assets.
-				wcAnalytics.assets_url = '<?php echo esc_url( plugins_url( '/build/', __DIR__ . '/class-woocommerce-analytics.php' ) ); ?>';
+				wcAnalytics.assets_url = '<?php echo esc_url( plugins_url( '../build/', __DIR__ . '/class-woocommerce-analytics.php' ) ); ?>';
 
 				// Set common properties for all events.
 				wcAnalytics.commonProps = <?php echo wp_json_encode( $common_properties, JSON_HEX_TAG | JSON_UNESCAPED_SLASHES ); ?>;

--- a/projects/packages/woocommerce-analytics/src/class-universal.php
+++ b/projects/packages/woocommerce-analytics/src/class-universal.php
@@ -83,6 +83,9 @@ class Universal {
 				window.wcAnalytics = window.wcAnalytics || {};
 				const wcAnalytics = window.wcAnalytics;
 
+				// Set the assets URL for webpack to find the split assets.
+				wcAnalytics.assets_url = '<?php echo esc_url( plugins_url( '/build/', __DIR__ . '/class-woocommerce-analytics.php' ) ); ?>';
+
 				// Set common properties for all events.
 				wcAnalytics.commonProps = <?php echo wp_json_encode( $common_properties, JSON_HEX_TAG | JSON_UNESCAPED_SLASHES ); ?>;
 

--- a/projects/packages/woocommerce-analytics/src/client/index.ts
+++ b/projects/packages/woocommerce-analytics/src/client/index.ts
@@ -3,6 +3,7 @@
 /**
  * Internal dependencies
  */
+import './public-path';
 import { consentManager } from './consent';
 
 jQuery( () => {

--- a/projects/packages/woocommerce-analytics/src/client/public-path.ts
+++ b/projects/packages/woocommerce-analytics/src/client/public-path.ts
@@ -1,0 +1,13 @@
+/* exported __webpack_public_path__ */
+/* global __webpack_public_path__ */
+
+/**
+ * Dynamically set WebPack's publicPath so that split assets can be found.
+ * Unfortunately we can't set `publicPath: 'auto'` because WordPress.com Simple's JS concatenation breaks it (and other plugins that do JS concatenation probably would too).
+ * @see https://webpack.js.org/guides/public-path/#on-the-fly
+ */
+if ( typeof window === 'object' && window.wcAnalytics?.assets_url ) {
+	// @ts-expect-error: __webpack_public_path__ is set globally by webpack, ignore TS2304
+	// eslint-disable-next-line no-global-assign
+	__webpack_public_path__ = window.wcAnalytics.assets_url;
+}

--- a/projects/packages/woocommerce-analytics/src/client/types/global.d.ts
+++ b/projects/packages/woocommerce-analytics/src/client/types/global.d.ts
@@ -10,6 +10,7 @@ declare global {
 			features: Record< string, boolean >;
 			pages: Record< string, boolean >;
 			breadcrumbs?: string[];
+			assets_url: string;
 		};
 		_wca?: {
 			push: ( props: Record< string, unknown > ) => void;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes p1761575260746959/1761559588.913789-slack-C03CU7X3U

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

In certain cases, the JS files are concatenated into a single file. In this case, the split JS files are not loaded properly because the relative path is incorrect and causes an error like the following:

```
Uncaught exception happened on the page: /
Loading chunk 956 failed.
(error: https://example.com/_static/956.js?minify=false&ver=f60e4b77da2ce00a2e0f)
```

This PR fixes the issue by setting the webpack public path dynamically based on the plugin path like other existing packages do.

https://github.com/Automattic/jetpack/blob/720a6037297153576139990bc76b624275c5b6a9/projects/plugins/jetpack/extensions/shared/public-path.js#L1-L12

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to your site frontend 
* Check that `wcAnalytics.assets_url` is correctly set to the woocommerce-analytics asset path (`YOUR_SITE/wp-content/plugins/jetpack-dev/jetpack_vendor/automattic/woocommerce-analytics/src/build/'`
* Confirm that WooCommerce Analytics assets are loaded correctly without any errors

<img width="1266" height="412" alt="Screenshot 2025-10-30 at 16 51 50" src="https://github.com/user-attachments/assets/d06c43d4-6694-4ce8-a173-5353cc7879bd" />
