### PR TITLE
Boost: Add compatibility for WooCommerce Analytics JS

### DIFF
--- a/projects/plugins/boost/changelog/fix-concat-js-compatibility-woocommerce-analytics
+++ b/projects/plugins/boost/changelog/fix-concat-js-compatibility-woocommerce-analytics
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Concatenate JS: Fix incompatibility with WooCommerce Analytics.

--- a/projects/plugins/boost/compatibility/js-concatenate.php
+++ b/projects/plugins/boost/compatibility/js-concatenate.php
@@ -16,6 +16,8 @@ function maybe_do_not_concat( $do_concat, $handle ) {
 		'DEPAY_WC_WIDGETS',
 		// Plugin: `woocommerce-bookings`
 		'wc-bookings-booking-form',
+		// WooCommerce Analytics
+		'woocommerce-analytics-client',
 	);
 
 	if ( in_array( $handle, $excluded_handles, true ) ) {


### PR DESCRIPTION
Fixes HOG-391

I suspect the `woocommerce-analytics-client` tries to load files from the directory it's in. When concatenating, it tries to load `956.js` and `613.js` from the folder where the concatenated file is stored (`/wp-content/boost-cache/static/`), but since those files only exist in the build folder (`wp-content/plugins/jetpack/jetpack_vendor/automattic/woocommerce-analytics/build`), there's a JS error.

## Proposed changes:

* Add `woocommerce-analytics-client` to php excludes for Concatenate JS.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

HOG-391

## Does this pull request change what data or activity we track or use?

no

## Testing instructions:

### Test that it breaks

- Setup Jetpack (finish the entire setup);
- Setup Jetpack Boost 4.5.0 (select free);
- Setup WooCommerce (finish the entire setup and launch the store);
- Enable `Concatenate JS`;
- Check the console and there should be an error in the console:

```
Uncaught (in promise) ChunkLoadError: Loading chunk 956 failed.
```

### Test that it works

- Only change the version of Boost to this PR;
- Open the page again and there should be no error in the console.