### PR TITLE
Fix/forms phone controls error

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-phone-controls-error
+++ b/projects/packages/forms/changelog/fix-forms-phone-controls-error
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: fix an error on phone field controls due to lack of key prop

--- a/projects/packages/forms/src/blocks/field-telephone/edit.js
+++ b/projects/packages/forms/src/blocks/field-telephone/edit.js
@@ -147,7 +147,6 @@ export default function PhoneFieldEdit( props ) {
 						element: (
 							<div key="phoneFieldControls">
 								<ToggleControl
-									key="showCountrySelectorControl"
 									label={ __( 'Show country selector', 'jetpack-forms' ) }
 									checked={ showCountrySelector || false }
 									onChange={ onChangeShowCountrySelector }
@@ -155,7 +154,6 @@ export default function PhoneFieldEdit( props ) {
 								/>
 								{ showCountrySelector && (
 									<TextControl
-										key="countrySearchPlaceholderControl"
 										label={ __( 'Search placeholder', 'jetpack-forms' ) }
 										value={ searchPlaceholder }
 										placeholder={ __( 'Search countries…', 'jetpack-forms' ) }

--- a/projects/packages/forms/src/blocks/field-telephone/edit.js
+++ b/projects/packages/forms/src/blocks/field-telephone/edit.js
@@ -145,8 +145,9 @@ export default function PhoneFieldEdit( props ) {
 					{
 						index: 1,
 						element: (
-							<>
+							<div key="phoneFieldControls">
 								<ToggleControl
+									key="showCountrySelectorControl"
 									label={ __( 'Show country selector', 'jetpack-forms' ) }
 									checked={ showCountrySelector || false }
 									onChange={ onChangeShowCountrySelector }
@@ -154,6 +155,7 @@ export default function PhoneFieldEdit( props ) {
 								/>
 								{ showCountrySelector && (
 									<TextControl
+										key="countrySearchPlaceholderControl"
 										label={ __( 'Search placeholder', 'jetpack-forms' ) }
 										value={ searchPlaceholder }
 										placeholder={ __( 'Search countries…', 'jetpack-forms' ) }
@@ -162,7 +164,7 @@ export default function PhoneFieldEdit( props ) {
 										__next40pxDefaultSize={ true }
 									/>
 								) }
-							</>
+							</div>
 						),
 					},
 				] }


### PR DESCRIPTION


## Proposed changes:
This PR fixes an error shown on console due to iterable block controls not carrying a `key` prop.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
https://github.com/Automattic/jetpack/pull/45272#discussion_r2469325619

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Insert a phone input field, see that there are no errors on the console. Verify the block controls work as usual.