### PR TITLE
Forms: release time field

### DIFF
--- a/projects/packages/forms/changelog/update-forms-release-time-field
+++ b/projects/packages/forms/changelog/update-forms-release-time-field
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Forms: add time field

--- a/projects/packages/forms/src/blocks/contact-form/child-blocks.js
+++ b/projects/packages/forms/src/blocks/contact-form/child-blocks.js
@@ -1,7 +1,4 @@
-import {
-	hasFeatureFlag,
-	getJetpackBlocksVariation,
-} from '@automattic/jetpack-shared-extension-utils';
+import { hasFeatureFlag } from '@automattic/jetpack-shared-extension-utils';
 import DeprecatedOptionCheckbox from '../deprecated/field-option-checkbox';
 import DeprecatedOptionRadio from '../deprecated/field-option-radio';
 import JetpackDropzone from '../dropzone';
@@ -60,6 +57,7 @@ export const childBlocks = [
 	JetpackUrlField,
 	JetpackTelephoneField,
 	JetpackTextareaField,
+	JetpackTimeField,
 	JetpackFieldFile,
 	JetpackRatingField,
 	JetpackRatingInput,
@@ -68,7 +66,6 @@ export const childBlocks = [
 	JetpackImageSelectField,
 	JetpackImageOptionsFieldset,
 	JetpackImageOptionInput,
-	...( getJetpackBlocksVariation() === 'beta' ? [ JetpackTimeField ] : [] ),
 
 	// The following are required for these blocks to be parsed correctly in block
 	// deprecations. They have been flagged with `supports.inserter: false` to

--- a/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
+++ b/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
@@ -473,15 +473,13 @@ class Contact_Form_Block {
 			)
 		);
 
-		if ( Blocks::get_variation() === 'beta' ) {
-			Blocks::jetpack_register_block(
-				'jetpack/field-time',
-				array(
-					'render_callback'  => array( Contact_Form_Plugin::class, 'gutenblock_render_field_time' ),
-					'provides_context' => array( 'jetpack/field-required' => 'required' ),
-				)
-			);
-		}
+		Blocks::jetpack_register_block(
+			'jetpack/field-time',
+			array(
+				'render_callback'  => array( Contact_Form_Plugin::class, 'gutenblock_render_field_time' ),
+				'provides_context' => array( 'jetpack/field-required' => 'required' ),
+			)
+		);
 
 		// Paid file field block
 		add_action(

--- a/projects/plugins/jetpack/changelog/update-forms-release-time-field
+++ b/projects/plugins/jetpack/changelog/update-forms-release-time-field
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Forms: add time field


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Releases the basic browser native based time field

<img width="271" height="132" alt="Screenshot 2025-10-30 at 18 01 25" src="https://github.com/user-attachments/assets/ac477fe8-a125-4e8e-b104-80dc98b4ebcc" />


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Add time field
* It works :-)

