### PR TITLE
Forms: disable Jetpack CRM integration by default

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-crm-enabled-by-default
+++ b/projects/packages/forms/changelog/fix-forms-crm-enabled-by-default
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Forms: disable Jetpack CRM integration by default.

--- a/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
@@ -57,7 +57,7 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 				'title'                   => __( 'Jetpack CRM', 'jetpack-forms' ),
 				'subtitle'                => __( 'Store contact form submissions in your CRM', 'jetpack-forms' ),
 				// Overriding this may automatically enable/disable the integration when editing a form.
-				'enabled_by_default'      => true,
+				'enabled_by_default'      => false,
 			),
 			'salesforce'   => array(
 				'type'                    => 'service',

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -196,7 +196,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 			'customThankyouMessage'  => '', // The message to show when customThankyou is set to 'message'.
 			'customThankyouRedirect' => '', // The URL to redirect to when confirmationType is set to 'redirect'.
 			'confirmationType'       => null, // The type of confirmation to show after submitting a form. 'text' for a text message, 'redirect' for a redirect link.
-			'jetpackCRM'             => true, // Whether Jetpack CRM should store the form submission.
+			'jetpackCRM'             => null, // Whether Jetpack CRM should store the form submission.
 			'mailpoet'               => null,
 			'hostingerReach'         => null,
 			'className'              => null,

--- a/projects/plugins/jetpack/changelog/fix-forms-crm-enabled-by-default
+++ b/projects/plugins/jetpack/changelog/fix-forms-crm-enabled-by-default
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Forms: disable Jetpack CRM integration by default.


### PR DESCRIPTION
## Proposed changes:

Right now, if Jetpack CRM is installed and active, it will be enabled by default for new forms. It's been like that since we started working Forms. This PR turns that off. 

<img width="667" height="522" alt="disable-crm-default" src="https://github.com/user-attachments/assets/d2ff9fbc-597e-4fa3-9219-a8458c521184" />

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
On Slack: p1761688939357909/1761682106.173649-slack-C052XEUUBL4

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

With Jetpack CRM installed and active, add a form to a post. Open the integrations modal and confirm that Jetpack CRM integration is not enabled by default (ie, the header toggle on the CRM card should be off).