### PR TITLE
Forms: avoid api call if integrations are disabled

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-disable-integrations-api-call
+++ b/projects/packages/forms/changelog/fix-forms-disable-integrations-api-call
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: avoid integrations api call if disabled.

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integration-controls.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integration-controls.js
@@ -5,6 +5,7 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { plugins } from '@wordpress/icons';
+import useConfigValue from '../../../hooks/use-config-value';
 import { INTEGRATIONS_STORE } from '../../../store/integrations';
 import IntegrationsModal from './jetpack-integrations-modal';
 import ActiveIntegrations from './jetpack-integrations-modal/active-integrations';
@@ -19,11 +20,20 @@ import ActiveIntegrations from './jetpack-integrations-modal/active-integrations
  */
 export default function IntegrationControls( { attributes, setAttributes } ) {
 	const [ isModalOpen, setIsModalOpen ] = useState( false );
-	const integrations = useSelect( select => {
-		const store = select( INTEGRATIONS_STORE );
-		return store.getIntegrations() || [];
-	}, [] );
-	const isLoading = useSelect( select => select( INTEGRATIONS_STORE ).isIntegrationsLoading(), [] );
+	const isIntegrationsEnabled = useConfigValue( 'isIntegrationsEnabled' );
+	const { integrations, isLoading } = useSelect(
+		select => {
+			if ( isIntegrationsEnabled === false ) {
+				return { integrations: [], isLoading: false };
+			}
+			const store = select( INTEGRATIONS_STORE );
+			return {
+				integrations: store.getIntegrations() || [],
+				isLoading: store.isIntegrationsLoading(),
+			};
+		},
+		[ isIntegrationsEnabled ]
+	);
 	const { refreshIntegrations } = useDispatch( INTEGRATIONS_STORE );
 	const { tracks } = useAnalytics();
 

--- a/projects/packages/forms/src/blocks/contact-form/shared/hooks/use-form-block-defaults.js
+++ b/projects/packages/forms/src/blocks/contact-form/shared/hooks/use-form-block-defaults.js
@@ -1,5 +1,6 @@
 import { useSelect } from '@wordpress/data';
 import { useEffect } from '@wordpress/element';
+import useConfigValue from '../../../../hooks/use-config-value';
 import { INTEGRATIONS_STORE } from '../../../../store/integrations';
 
 /**
@@ -13,11 +14,20 @@ import { INTEGRATIONS_STORE } from '../../../../store/integrations';
  * @param {Function} params.setAttributes - Setter for block attributes
  */
 export default function useFormBlockDefaults( { attributes, setAttributes } ) {
-	const integrations = useSelect( select => {
-		const store = select( INTEGRATIONS_STORE );
-		return store.getIntegrations() || [];
-	}, [] );
-	const isLoading = useSelect( select => select( INTEGRATIONS_STORE ).isIntegrationsLoading(), [] );
+	const isIntegrationsEnabled = useConfigValue( 'isIntegrationsEnabled' );
+	const { integrations, isLoading } = useSelect(
+		select => {
+			if ( isIntegrationsEnabled === false ) {
+				return { integrations: [], isLoading: false };
+			}
+			const store = select( INTEGRATIONS_STORE );
+			return {
+				integrations: store.getIntegrations() || [],
+				isLoading: store.isIntegrationsLoading(),
+			};
+		},
+		[ isIntegrationsEnabled ]
+	);
 
 	useEffect( () => {
 		if ( isLoading || ! Array.isArray( integrations ) ) {

--- a/projects/packages/forms/src/dashboard/class-dashboard.php
+++ b/projects/packages/forms/src/dashboard/class-dashboard.php
@@ -11,6 +11,7 @@ use Automattic\Jetpack\Admin_UI\Admin_Menu;
 use Automattic\Jetpack\Assets;
 use Automattic\Jetpack\Connection\Initial_State as Connection_Initial_State;
 use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin;
+use Automattic\Jetpack\Forms\Jetpack_Forms;
 use Automattic\Jetpack\Tracking;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -103,14 +104,16 @@ class Dashboard {
 		$preload_paths                 = array(
 			'/wp/v2/types?context=view',
 			'/wp/v2/feedback/config',
-			'/wp/v2/feedback/integrations-metadata',
 			'/wp/v2/feedback/counts',
 			$filters_path,
 			$filters_locale_path,
 			$initial_responses_path,
 			$initial_responses_locale_path,
 		);
-		$preload_data_raw              = array_reduce( $preload_paths, 'rest_preload_api_request', array() );
+		if ( Jetpack_Forms::is_integrations_enabled() ) {
+			$preload_paths[] = '/wp/v2/feedback/integrations-metadata';
+		}
+		$preload_data_raw = array_reduce( $preload_paths, 'rest_preload_api_request', array() );
 
 		// Normalize keys to match what apiFetch will request (without domain).
 		$preload_data = array();

--- a/projects/packages/forms/src/dashboard/components/layout/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/layout/index.tsx
@@ -30,7 +30,6 @@ const Layout = () => {
 
 	const enableIntegrationsTab = useConfigValue( 'isIntegrationsEnabled' );
 	const isLoadingConfig = enableIntegrationsTab === undefined;
-
 	const { currentStatus } = useSelect(
 		select => ( {
 			currentStatus: select( dashboardStore ).getCurrentStatus(),

--- a/projects/packages/forms/src/dashboard/integrations/index.tsx
+++ b/projects/packages/forms/src/dashboard/integrations/index.tsx
@@ -8,6 +8,7 @@ import { useState, useCallback } from 'react';
 /**
  * Internal dependencies
  */
+import useConfigValue from '../../hooks/use-config-value';
 import { INTEGRATIONS_STORE } from '../../store/integrations';
 import AkismetDashboardCard from './akismet-card';
 import GoogleSheetsDashboardCard from './google-sheets-card';
@@ -25,12 +26,19 @@ import type { Integration } from '../../types';
 const EMPTY_ARRAY: Integration[] = [];
 
 const Integrations = () => {
-	const { integrations } = useSelect( ( select: SelectIntegrations ) => {
-		const store = select( INTEGRATIONS_STORE );
-		return {
-			integrations: store.getIntegrations() ?? EMPTY_ARRAY,
-		};
-	}, [] ) as { integrations: Integration[] };
+	const isIntegrationsEnabled = useConfigValue( 'isIntegrationsEnabled' );
+	const { integrations } = useSelect(
+		( select: SelectIntegrations ) => {
+			if ( isIntegrationsEnabled === false ) {
+				return { integrations: EMPTY_ARRAY };
+			}
+			const store = select( INTEGRATIONS_STORE );
+			return {
+				integrations: store.getIntegrations() ?? EMPTY_ARRAY,
+			};
+		},
+		[ isIntegrationsEnabled ]
+	) as { integrations: Integration[] };
 	const { refreshIntegrations } = useDispatch( INTEGRATIONS_STORE ) as IntegrationsDispatch;
 	const [ expandedCards, setExpandedCards ] = useState( {
 		akismet: false,

--- a/projects/packages/forms/src/store/integrations/resolvers.ts
+++ b/projects/packages/forms/src/store/integrations/resolvers.ts
@@ -1,10 +1,11 @@
 import apiFetch from '@wordpress/api-fetch';
 import { addQueryArgs } from '@wordpress/url';
+import { CONFIG_STORE } from '../config';
 import { UNKNOWN_ERROR_MESSAGE } from '../constants';
 import { INVALIDATE_INTEGRATIONS } from './action-types';
 import { receiveIntegrations, setIntegrationsError, setIntegrationsLoading } from './actions';
 import type { IntegrationsAction } from './types';
-import type { Integration, IntegrationMetadata } from '../../types';
+import type { FormsConfigData, Integration, IntegrationMetadata } from '../../types';
 
 let hasLoadedMeta = false;
 
@@ -71,9 +72,24 @@ const fetchFullIntegrations =
  */
 export const getIntegrations =
 	() =>
-	async ( { dispatch }: { dispatch: ( action: IntegrationsAction ) => void } ) => {
+	async ( {
+		dispatch,
+		resolveSelect,
+	}: {
+		dispatch: ( action: IntegrationsAction ) => void;
+		resolveSelect: ( store: typeof CONFIG_STORE ) => {
+			getConfig: () => Promise< Partial< FormsConfigData > | null >;
+		};
+	} ) => {
 		dispatch( setIntegrationsLoading( true ) );
 		try {
+			// Check config flag first; if disabled, avoid all API calls
+			const config = await resolveSelect( CONFIG_STORE ).getConfig();
+			if ( config?.isIntegrationsEnabled === false ) {
+				dispatch( receiveIntegrations( [] ) );
+				return;
+			}
+
 			if ( ! hasLoadedMeta ) {
 				await fetchIntegrationsMetadata()( { dispatch } );
 				hasLoadedMeta = true;

--- a/projects/packages/forms/src/store/integrations/resolvers.ts
+++ b/projects/packages/forms/src/store/integrations/resolvers.ts
@@ -1,11 +1,10 @@
 import apiFetch from '@wordpress/api-fetch';
 import { addQueryArgs } from '@wordpress/url';
-import { CONFIG_STORE } from '../config';
 import { UNKNOWN_ERROR_MESSAGE } from '../constants';
 import { INVALIDATE_INTEGRATIONS } from './action-types';
 import { receiveIntegrations, setIntegrationsError, setIntegrationsLoading } from './actions';
 import type { IntegrationsAction } from './types';
-import type { FormsConfigData, Integration, IntegrationMetadata } from '../../types';
+import type { Integration, IntegrationMetadata } from '../../types';
 
 let hasLoadedMeta = false;
 
@@ -72,24 +71,9 @@ const fetchFullIntegrations =
  */
 export const getIntegrations =
 	() =>
-	async ( {
-		dispatch,
-		resolveSelect,
-	}: {
-		dispatch: ( action: IntegrationsAction ) => void;
-		resolveSelect: ( store: typeof CONFIG_STORE ) => {
-			getConfig: () => Promise< Partial< FormsConfigData > | null >;
-		};
-	} ) => {
+	async ( { dispatch }: { dispatch: ( action: IntegrationsAction ) => void } ) => {
 		dispatch( setIntegrationsLoading( true ) );
 		try {
-			// Check config flag first; if disabled, avoid all API calls
-			const config = await resolveSelect( CONFIG_STORE ).getConfig();
-			if ( config?.isIntegrationsEnabled === false ) {
-				dispatch( receiveIntegrations( [] ) );
-				return;
-			}
-
 			if ( ! hasLoadedMeta ) {
 				await fetchIntegrationsMetadata()( { dispatch } );
 				hasLoadedMeta = true;


### PR DESCRIPTION
## Proposed changes:

We noticed that the forms plugin is making integrations-related API calls even if the integrations feature flag is set to off. This PR checks the feature flag before preloading or fetching the integrations endpoint. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
Slack: 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No: 

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

First test for no regressions by making sure the integrations dashboard and modal loads like normal. 

Then set turn off integrations with the filter below. Open your dev tools > network tab. Reload both the integrations dashboard and block editor and confirm no integration api calls. 

