### PR TITLE
Forms: keep frontend CRM integration true by default

### DIFF
--- a/projects/packages/forms/changelog/update-forms-crm-frontend-default
+++ b/projects/packages/forms/changelog/update-forms-crm-frontend-default
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Forms: revert CRM frontend default to true.

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -196,7 +196,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 			'customThankyouMessage'  => '', // The message to show when customThankyou is set to 'message'.
 			'customThankyouRedirect' => '', // The URL to redirect to when confirmationType is set to 'redirect'.
 			'confirmationType'       => null, // The type of confirmation to show after submitting a form. 'text' for a text message, 'redirect' for a redirect link.
-			'jetpackCRM'             => null, // Whether Jetpack CRM should store the form submission.
+			'jetpackCRM'             => true, // Whether Jetpack CRM should store the form submission.
 			'mailpoet'               => null,
 			'hostingerReach'         => null,
 			'className'              => null,


### PR DESCRIPTION
## Proposed changes:

We just pushed a change to [disable Jetpack CRM](https://github.com/Automattic/jetpack/pull/45667) by default on forms. As part of that, we updated a frontend default. But in testing, we realized that for older forms that didn't explicitly set Jetpack CRM and were relying the default, changing that frontend default value will actually change how existing forms behave. In short, for older forms using defaults, they're dependent on the default set in class-contact-form.php. So we need to leave that be. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Ensure that older forms without an eplicity value set for jetapckCRM continue to send contacts to the CRM. 