### PR TITLE
Forms: Update dataview actions

### DIFF
--- a/projects/packages/forms/changelog/update-forms-dashboard-dataview-actions
+++ b/projects/packages/forms/changelog/update-forms-dashboard-dataview-actions
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Forms: Update dataview actions

--- a/projects/packages/forms/src/dashboard/components/response-actions/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/response-actions/index.tsx
@@ -20,9 +20,10 @@ import {
  * Types
  */
 import type { FormResponse } from '../../../types';
+import type { Registry } from '../../inbox/dataviews/types';
 
 type ResponseNavigationProps = {
-	onActionComplete?: ( FormResponse ) => void;
+	onActionComplete?: ( response: FormResponse ) => void;
 	response: FormResponse;
 };
 
@@ -37,7 +38,7 @@ const ResponseActions = ( {
 	const [ isDeleting, setIsDeleting ] = useState( false );
 	const [ isTogglingReadStatus, setIsTogglingReadStatus ] = useState( false );
 
-	const registry = useRegistry();
+	const registry = useRegistry() as unknown as Registry;
 
 	const handleMarkAsSpam = useCallback( async () => {
 		onActionComplete?.( response );

--- a/projects/packages/forms/src/dashboard/inbox/dataviews/actions.js
+++ b/projects/packages/forms/src/dashboard/inbox/dataviews/actions.js
@@ -81,9 +81,32 @@ const invalidateCacheAndNavigate = (
 	}
 };
 
+// TODO: We should probably have better error messages in case of failure.
+const getGenericErrorMessage = numberOfErrors => {
+	return numberOfErrors.length === 1
+		? __( 'An error occurred.', 'jetpack-forms' )
+		: sprintf(
+				/* translators: %d: the number of responses. */
+				_n(
+					'An error occurred for %d response.',
+					'An error occurred for %d responses.',
+					numberOfErrors,
+					'jetpack-forms'
+				),
+				numberOfErrors
+		  );
+};
+
 export const BULK_ACTIONS = {
 	markAsSpam: 'mark_as_spam',
 	markAsNotSpam: 'mark_as_not_spam',
+};
+
+export const viewAction = {
+	id: 'view-response',
+	isPrimary: true,
+	label: __( 'View', 'jetpack-forms' ),
+	modalHeader: __( 'Response', 'jetpack-forms' ),
 };
 
 export const editFormAction = {
@@ -107,25 +130,10 @@ export const editFormAction = {
 	},
 };
 
-// TODO: We should probably have better error messages in case of failure.
-const getGenericErrorMessage = numberOfErrors => {
-	return numberOfErrors.length === 1
-		? __( 'An error occurred.', 'jetpack-forms' )
-		: sprintf(
-				/* translators: %d: the number of responses. */
-				_n(
-					'An error occurred for %d response.',
-					'An error occurred for %d responses.',
-					numberOfErrors,
-					'jetpack-forms'
-				),
-				numberOfErrors
-		  );
-};
-
 export const markAsSpamAction = {
 	id: 'mark-as-spam',
-	label: __( 'Mark as spam', 'jetpack-forms' ),
+	isPrimary: true,
+	label: __( 'Spam', 'jetpack-forms' ),
 	isEligible: item => item.status !== 'spam',
 	supportsBulk: true,
 	async callback( items, { registry } ) {

--- a/projects/packages/forms/src/dashboard/inbox/dataviews/actions.js
+++ b/projects/packages/forms/src/dashboard/inbox/dataviews/actions.js
@@ -3,12 +3,15 @@
  */
 import jetpackAnalytics from '@automattic/jetpack-analytics';
 import apiFetch from '@wordpress/api-fetch';
+import { Icon } from '@wordpress/components';
 import { store as coreStore } from '@wordpress/core-data';
 import { __, _n, sprintf } from '@wordpress/i18n';
+import { seen, unseen, trash, backup, commentContent } from '@wordpress/icons';
 import { store as noticesStore } from '@wordpress/notices';
 /**
  * Internal dependencies
  */
+import { notSpam, spam } from '../../icons';
 import { store as dashboardStore } from '../../store';
 import { updateMenuCounter, updateMenuCounterOptimistically } from '../utils';
 import { defaultView } from './views';
@@ -105,12 +108,15 @@ export const BULK_ACTIONS = {
 export const viewAction = {
 	id: 'view-response',
 	isPrimary: true,
+	icon: <Icon icon={ commentContent } />,
 	label: __( 'View', 'jetpack-forms' ),
 	modalHeader: __( 'Response', 'jetpack-forms' ),
 };
 
 export const editFormAction = {
 	id: 'edit-form',
+	isPrimary: false,
+	icon: <Icon icon={ backup } />,
 	label: __( 'Edit form', 'jetpack-forms' ),
 	isEligible: item => !! item?.edit_form_url,
 	supportsBulk: false,
@@ -133,6 +139,7 @@ export const editFormAction = {
 export const markAsSpamAction = {
 	id: 'mark-as-spam',
 	isPrimary: true,
+	icon: <Icon icon={ spam } />,
 	label: __( 'Spam', 'jetpack-forms' ),
 	isEligible: item => item.status !== 'spam',
 	supportsBulk: true,
@@ -215,10 +222,11 @@ export const markAsSpamAction = {
 
 export const markAsNotSpamAction = {
 	id: 'mark-as-not-spam',
+	isPrimary: true,
+	icon: <Icon icon={ notSpam } />,
 	label: __( 'Not spam', 'jetpack-forms' ),
 	isEligible: item => item.status === 'spam',
 	supportsBulk: true,
-	isPrimary: true,
 	async callback( items, { registry } ) {
 		jetpackAnalytics.tracks.recordEvent( 'jetpack_forms_inbox_action_click', {
 			action: 'mark-as-not-spam',
@@ -296,10 +304,11 @@ export const markAsNotSpamAction = {
 
 export const restoreAction = {
 	id: 'restore',
+	isPrimary: true,
+	icon: <Icon icon={ backup } />,
 	label: __( 'Restore', 'jetpack-forms' ),
 	isEligible: item => item.status === 'trash',
 	supportsBulk: true,
-	isPrimary: true,
 	async callback( items, { registry } ) {
 		jetpackAnalytics.tracks.recordEvent( 'jetpack_forms_inbox_action_click', {
 			action: 'restore',
@@ -370,9 +379,10 @@ export const restoreAction = {
 
 export const moveToTrashAction = {
 	id: 'move-to-trash',
+	isPrimary: true,
+	icon: <Icon icon={ trash } />,
 	label: __( 'Trash', 'jetpack-forms' ),
 	isEligible: item => item.status !== 'trash',
-	isPrimary: true,
 	supportsBulk: true,
 	async callback( items, { registry } ) {
 		jetpackAnalytics.tracks.recordEvent( 'jetpack_forms_inbox_action_click', {
@@ -447,10 +457,11 @@ export const moveToTrashAction = {
 
 export const deleteAction = {
 	id: 'delete',
+	isPrimary: true,
+	icon: <Icon icon={ trash } />,
 	label: __( 'Delete', 'jetpack-forms' ),
 	isEligible: item => item.status === 'trash',
 	supportsBulk: true,
-	isPrimary: true,
 	async callback( items, { registry } ) {
 		jetpackAnalytics.tracks.recordEvent( 'jetpack_forms_inbox_action_click', {
 			action: 'delete',
@@ -526,6 +537,8 @@ export const deleteAction = {
 
 export const markAsReadAction = {
 	id: 'mark-as-read',
+	isPrimary: false,
+	icon: <Icon icon={ seen } />,
 	label: __( 'Mark as read', 'jetpack-forms' ),
 	isEligible: item => item.is_unread,
 	supportsBulk: true,
@@ -638,6 +651,8 @@ export const markAsReadAction = {
 
 export const markAsUnreadAction = {
 	id: 'mark-as-unread',
+	isPrimary: false,
+	icon: <Icon icon={ unseen } />,
 	label: __( 'Mark as unread', 'jetpack-forms' ),
 	isEligible: item => ! item.is_unread,
 	supportsBulk: true,

--- a/projects/packages/forms/src/dashboard/inbox/dataviews/actions.js
+++ b/projects/packages/forms/src/dashboard/inbox/dataviews/actions.js
@@ -1,11 +1,14 @@
+/**
+ * External dependencies
+ */
 import jetpackAnalytics from '@automattic/jetpack-analytics';
 import apiFetch from '@wordpress/api-fetch';
-import { Icon } from '@wordpress/components';
 import { store as coreStore } from '@wordpress/core-data';
 import { __, _n, sprintf } from '@wordpress/i18n';
-import { seen, unseen, trash, backup, commentContent } from '@wordpress/icons';
 import { store as noticesStore } from '@wordpress/notices';
-import { notSpam, spam } from '../../icons';
+/**
+ * Internal dependencies
+ */
 import { store as dashboardStore } from '../../store';
 import { updateMenuCounter, updateMenuCounterOptimistically } from '../utils';
 import { defaultView } from './views';
@@ -83,18 +86,9 @@ export const BULK_ACTIONS = {
 	markAsNotSpam: 'mark_as_not_spam',
 };
 
-export const viewAction = {
-	id: 'view-response',
-	icon: <Icon icon={ commentContent } />,
-	isPrimary: true,
-	label: __( 'View response', 'jetpack-forms' ),
-	modalHeader: __( 'Response', 'jetpack-forms' ),
-};
-
 export const editFormAction = {
 	id: 'edit-form',
 	label: __( 'Edit form', 'jetpack-forms' ),
-	icon: <Icon icon={ backup } />,
 	isEligible: item => !! item?.edit_form_url,
 	supportsBulk: false,
 	async callback( items ) {
@@ -132,7 +126,6 @@ export const markAsSpamAction = {
 	label: __( 'Mark as spam', 'jetpack-forms' ),
 	isEligible: item => item.status !== 'spam',
 	supportsBulk: true,
-	icon: <Icon icon={ spam } />,
 	async callback( items, { registry } ) {
 		jetpackAnalytics.tracks.recordEvent( 'jetpack_forms_inbox_action_click', {
 			action: 'mark-as-spam',
@@ -211,7 +204,7 @@ export const markAsNotSpamAction = {
 	label: __( 'Not spam', 'jetpack-forms' ),
 	isEligible: item => item.status === 'spam',
 	supportsBulk: true,
-	icon: <Icon icon={ notSpam } />,
+	isPrimary: true,
 	async callback( items, { registry } ) {
 		jetpackAnalytics.tracks.recordEvent( 'jetpack_forms_inbox_action_click', {
 			action: 'mark-as-not-spam',
@@ -288,7 +281,7 @@ export const restoreAction = {
 	label: __( 'Restore', 'jetpack-forms' ),
 	isEligible: item => item.status === 'trash',
 	supportsBulk: true,
-	icon: <Icon icon={ backup } />,
+	isPrimary: true,
 	async callback( items, { registry } ) {
 		jetpackAnalytics.tracks.recordEvent( 'jetpack_forms_inbox_action_click', {
 			action: 'restore',
@@ -354,11 +347,10 @@ export const restoreAction = {
 
 export const moveToTrashAction = {
 	id: 'move-to-trash',
-	label: __( 'Move to trash', 'jetpack-forms' ),
+	label: __( 'Trash', 'jetpack-forms' ),
 	isEligible: item => item.status !== 'trash',
 	isPrimary: true,
 	supportsBulk: true,
-	icon: <Icon icon={ trash } />,
 	async callback( items, { registry } ) {
 		jetpackAnalytics.tracks.recordEvent( 'jetpack_forms_inbox_action_click', {
 			action: 'move-to-trash',
@@ -429,10 +421,10 @@ export const moveToTrashAction = {
 
 export const deleteAction = {
 	id: 'delete',
-	label: __( 'Delete permanently', 'jetpack-forms' ),
+	label: __( 'Delete', 'jetpack-forms' ),
 	isEligible: item => item.status === 'trash',
 	supportsBulk: true,
-	icon: <Icon icon={ trash } />,
+	isPrimary: true,
 	async callback( items, { registry } ) {
 		jetpackAnalytics.tracks.recordEvent( 'jetpack_forms_inbox_action_click', {
 			action: 'delete',
@@ -511,13 +503,11 @@ export const markAsReadAction = {
 	label: __( 'Mark as read', 'jetpack-forms' ),
 	isEligible: item => item.is_unread,
 	supportsBulk: true,
-	icon: <Icon icon={ seen } />,
 	async callback( items, { registry } ) {
 		jetpackAnalytics.tracks.recordEvent( 'jetpack_forms_inbox_action_click', {
 			action: 'mark-as-read',
 			multiple: items.length > 1,
 		} );
-		// const { receiveEntityRecords, editEntityRecord } = registry.dispatch( coreStore );
 		const { editEntityRecord } = registry.dispatch( coreStore );
 		const { getEntityRecord } = registry.select( coreStore );
 		const { createSuccessNotice, createErrorNotice } = registry.dispatch( noticesStore );
@@ -618,7 +608,6 @@ export const markAsUnreadAction = {
 	label: __( 'Mark as unread', 'jetpack-forms' ),
 	isEligible: item => ! item.is_unread,
 	supportsBulk: true,
-	icon: <Icon icon={ unseen } />,
 	async callback( items, { registry } ) {
 		jetpackAnalytics.tracks.recordEvent( 'jetpack_forms_inbox_action_click', {
 			action: 'mark-as-unread',

--- a/projects/packages/forms/src/dashboard/inbox/dataviews/actions.js
+++ b/projects/packages/forms/src/dashboard/inbox/dataviews/actions.js
@@ -96,7 +96,9 @@ export const editFormAction = {
 			action: 'edit-form',
 			multiple: false,
 		} );
+
 		const [ item ] = items;
+
 		if ( item?.edit_form_url ) {
 			const url = new URL( item.edit_form_url, window.location.origin );
 			// redirect to the form edit page
@@ -131,6 +133,7 @@ export const markAsSpamAction = {
 			action: 'mark-as-spam',
 			multiple: items.length > 1,
 		} );
+
 		const { createSuccessNotice, createErrorNotice } = registry.dispatch( noticesStore );
 		const { saveEntityRecord } = registry.dispatch( coreStore );
 		const { updateCountsOptimistically } = registry.dispatch( dashboardStore );
@@ -145,6 +148,7 @@ export const markAsSpamAction = {
 		const promises = await Promise.allSettled(
 			items.map( ( { id } ) => saveEntityRecord( 'postType', 'feedback', { id, status: 'spam' } ) )
 		);
+
 		const itemsUpdated = promises.filter( ( { status } ) => status === 'fulfilled' );
 
 		// If there is at least one successful update, invalidate the cache and navigate if needed
@@ -171,6 +175,7 @@ export const markAsSpamAction = {
 							),
 							items.length
 					  );
+
 			createSuccessNotice( successMessage, {
 				type: 'snackbar',
 				id: 'mark-as-spam-action',
@@ -189,6 +194,7 @@ export const markAsSpamAction = {
 			const errorMessage = getGenericErrorMessage( numberOfErrors );
 			createErrorNotice( errorMessage, { type: 'snackbar' } );
 		}
+
 		// Make the REST request which performs the `contact_form_akismet` `ham` action.
 		if ( itemsUpdated.length ) {
 			registry.dispatch( dashboardStore ).doBulkAction(
@@ -210,6 +216,7 @@ export const markAsNotSpamAction = {
 			action: 'mark-as-not-spam',
 			multiple: items.length > 1,
 		} );
+
 		const { createSuccessNotice, createErrorNotice } = registry.dispatch( noticesStore );
 		const { saveEntityRecord } = registry.dispatch( coreStore );
 		const { updateCountsOptimistically } = registry.dispatch( dashboardStore );
@@ -226,6 +233,7 @@ export const markAsNotSpamAction = {
 				saveEntityRecord( 'postType', 'feedback', { id, status: 'publish' } )
 			)
 		);
+
 		const itemsUpdated = promises.filter( ( { status } ) => status === 'fulfilled' );
 
 		// If there is at least one successful update, invalidate the cache and navigate if needed
@@ -248,6 +256,7 @@ export const markAsNotSpamAction = {
 							),
 							items.length
 					  );
+
 			createSuccessNotice( successMessage, {
 				type: 'snackbar',
 				id: 'mark-as-not-spam-action',
@@ -264,6 +273,7 @@ export const markAsNotSpamAction = {
 			// There is at least one failure.
 			const numberOfErrors = promises.filter( ( { status } ) => status === 'rejected' ).length;
 			const errorMessage = getGenericErrorMessage( numberOfErrors );
+
 			createErrorNotice( errorMessage, { type: 'snackbar' } );
 		}
 		// Make the REST request which performs the `contact_form_akismet` `ham` action.
@@ -287,6 +297,7 @@ export const restoreAction = {
 			action: 'restore',
 			multiple: items.length > 1,
 		} );
+
 		const { saveEntityRecord } = registry.dispatch( coreStore );
 		const { createSuccessNotice, createErrorNotice } = registry.dispatch( noticesStore );
 		const { updateCountsOptimistically } = registry.dispatch( dashboardStore );
@@ -303,6 +314,7 @@ export const restoreAction = {
 				saveEntityRecord( 'postType', 'feedback', { id, status: 'publish' } )
 			)
 		);
+
 		const itemsUpdated = promises.filter( ( { status } ) => status === 'fulfilled' );
 
 		// If there is at least one successful update, invalidate the cache and navigate if needed
@@ -324,6 +336,7 @@ export const restoreAction = {
 							),
 							items.length
 					  );
+
 			createSuccessNotice( successMessage, {
 				type: 'snackbar',
 				id: 'restore-action',
@@ -336,8 +349,10 @@ export const restoreAction = {
 					},
 				],
 			} );
+
 			return;
 		}
+
 		// There is at least one failure.
 		const numberOfErrors = promises.filter( ( { status } ) => status === 'rejected' ).length;
 		const errorMessage = getGenericErrorMessage( numberOfErrors );
@@ -356,6 +371,7 @@ export const moveToTrashAction = {
 			action: 'move-to-trash',
 			multiple: items.length > 1,
 		} );
+
 		const { deleteEntityRecord } = registry.dispatch( coreStore );
 		const { createSuccessNotice, createErrorNotice } = registry.dispatch( noticesStore );
 		const { updateCountsOptimistically } = registry.dispatch( dashboardStore );
@@ -398,6 +414,7 @@ export const moveToTrashAction = {
 							),
 							items.length
 					  );
+
 			createSuccessNotice( successMessage, {
 				type: 'snackbar',
 				id: 'move-to-trash-action',
@@ -410,6 +427,7 @@ export const moveToTrashAction = {
 					},
 				],
 			} );
+
 			return;
 		}
 		// There is at least one failure.
@@ -508,6 +526,7 @@ export const markAsReadAction = {
 			action: 'mark-as-read',
 			multiple: items.length > 1,
 		} );
+
 		const { editEntityRecord } = registry.dispatch( coreStore );
 		const { getEntityRecord } = registry.select( coreStore );
 		const { createSuccessNotice, createErrorNotice } = registry.dispatch( noticesStore );
@@ -552,6 +571,7 @@ export const markAsReadAction = {
 								updateMenuCounterOptimistically( 1 );
 							}
 						}
+
 						throw new Error( 'Failed to mark as read' );
 					} );
 			} )
@@ -561,9 +581,11 @@ export const markAsReadAction = {
 		if ( promises.some( ( { status } ) => status === 'fulfilled' ) ) {
 			invalidateCounts();
 			// Mark successfully updated records as invalid instead of removing from view
+
 			const updatedIds = items
 				.filter( ( _, index ) => promises[ index ]?.status === 'fulfilled' )
 				.map( item => item.id );
+
 			markRecordsAsInvalid( updatedIds );
 		}
 
@@ -582,6 +604,7 @@ export const markAsReadAction = {
 							),
 							items.length
 					  );
+
 			createSuccessNotice( successMessage, {
 				type: 'snackbar',
 				id: 'mark-as-read-action',
@@ -594,8 +617,10 @@ export const markAsReadAction = {
 					},
 				],
 			} );
+
 			return;
 		}
+
 		// There is at least one failure.
 		const numberOfErrors = promises.filter( ( { status } ) => status === 'rejected' ).length;
 		const errorMessage = getGenericErrorMessage( numberOfErrors );
@@ -613,6 +638,7 @@ export const markAsUnreadAction = {
 			action: 'mark-as-unread',
 			multiple: items.length > 1,
 		} );
+
 		const { editEntityRecord } = registry.dispatch( coreStore );
 		const { getEntityRecord } = registry.select( coreStore );
 		const { createSuccessNotice, createErrorNotice } = registry.dispatch( noticesStore );
@@ -657,10 +683,12 @@ export const markAsUnreadAction = {
 								updateMenuCounterOptimistically( -1 );
 							}
 						}
+
 						throw new Error( 'Failed to mark as unread' );
 					} );
 			} )
 		);
+
 		if ( promises.every( ( { status } ) => status === 'fulfilled' ) ) {
 			// Invalidate counts cache to ensure counts are refetched and stay accurate
 			invalidateCounts();
@@ -681,6 +709,7 @@ export const markAsUnreadAction = {
 							),
 							items.length
 					  );
+
 			createSuccessNotice( successMessage, {
 				type: 'snackbar',
 				id: 'mark-as-unread-action',
@@ -693,8 +722,10 @@ export const markAsUnreadAction = {
 					},
 				],
 			} );
+
 			return;
 		}
+
 		// There is at least one failure.
 		const numberOfErrors = promises.filter( ( { status } ) => status === 'rejected' ).length;
 		const errorMessage = getGenericErrorMessage( numberOfErrors );

--- a/projects/packages/forms/src/dashboard/inbox/dataviews/actions.tsx
+++ b/projects/packages/forms/src/dashboard/inbox/dataviews/actions.tsx
@@ -15,6 +15,10 @@ import { notSpam, spam } from '../../icons';
 import { store as dashboardStore } from '../../store';
 import { updateMenuCounter, updateMenuCounterOptimistically } from '../utils';
 import { defaultView } from './views';
+/**
+ * Types
+ */
+import type { Action, QueryParams } from './types';
 
 /**
  * Helper function to extract count-relevant query params from the current query.
@@ -22,8 +26,9 @@ import { defaultView } from './views';
  * @param {object} currentQuery - The current query from the store.
  * @return {object} Query params relevant for count caching.
  */
-const getCountQueryParams = currentQuery => {
-	const queryParams = {};
+const getCountQueryParams = ( currentQuery: QueryParams ): QueryParams => {
+	const queryParams: QueryParams = {};
+
 	if ( currentQuery?.search ) {
 		queryParams.search = currentQuery.search;
 	}
@@ -39,6 +44,7 @@ const getCountQueryParams = currentQuery => {
 	if ( currentQuery?.is_unread !== undefined ) {
 		queryParams.is_unread = currentQuery.is_unread;
 	}
+
 	return queryParams;
 };
 
@@ -85,8 +91,8 @@ const invalidateCacheAndNavigate = (
 };
 
 // TODO: We should probably have better error messages in case of failure.
-const getGenericErrorMessage = numberOfErrors => {
-	return numberOfErrors.length === 1
+const getGenericErrorMessage = ( numberOfErrors: number ): string => {
+	return numberOfErrors === 1
 		? __( 'An error occurred.', 'jetpack-forms' )
 		: sprintf(
 				/* translators: %d: the number of responses. */
@@ -105,7 +111,7 @@ export const BULK_ACTIONS = {
 	markAsNotSpam: 'mark_as_not_spam',
 };
 
-export const viewAction = {
+export const viewAction: Action = {
 	id: 'view-response',
 	isPrimary: true,
 	icon: <Icon icon={ commentContent } />,
@@ -113,7 +119,7 @@ export const viewAction = {
 	modalHeader: __( 'Response', 'jetpack-forms' ),
 };
 
-export const editFormAction = {
+export const editFormAction: Action = {
 	id: 'edit-form',
 	isPrimary: false,
 	icon: <Icon icon={ backup } />,
@@ -136,7 +142,7 @@ export const editFormAction = {
 	},
 };
 
-export const markAsSpamAction = {
+export const markAsSpamAction: Action = {
 	id: 'mark-as-spam',
 	isPrimary: true,
 	icon: <Icon icon={ spam } />,
@@ -160,11 +166,13 @@ export const markAsSpamAction = {
 			updateCountsOptimistically( item.status, 'spam', 1, queryParams );
 		} );
 
-		const promises = await Promise.allSettled(
+		const promises = ( await Promise.allSettled(
 			items.map( ( { id } ) => saveEntityRecord( 'postType', 'feedback', { id, status: 'spam' } ) )
-		);
+		) ) as PromiseSettledResult< { id: string } >[];
 
-		const itemsUpdated = promises.filter( ( { status } ) => status === 'fulfilled' );
+		const itemsUpdated = promises.filter(
+			( { status } ) => status === 'fulfilled'
+		) as PromiseFulfilledResult< { id: string } >[];
 
 		// If there is at least one successful update, invalidate the cache and navigate if needed
 		if ( itemsUpdated.length ) {
@@ -207,6 +215,7 @@ export const markAsSpamAction = {
 			// There is at least one failure.
 			const numberOfErrors = promises.filter( ( { status } ) => status === 'rejected' ).length;
 			const errorMessage = getGenericErrorMessage( numberOfErrors );
+
 			createErrorNotice( errorMessage, { type: 'snackbar' } );
 		}
 
@@ -220,7 +229,7 @@ export const markAsSpamAction = {
 	},
 };
 
-export const markAsNotSpamAction = {
+export const markAsNotSpamAction: Action = {
 	id: 'mark-as-not-spam',
 	isPrimary: true,
 	icon: <Icon icon={ notSpam } />,
@@ -244,13 +253,15 @@ export const markAsNotSpamAction = {
 			updateCountsOptimistically( 'spam', 'publish', 1, queryParams );
 		} );
 
-		const promises = await Promise.allSettled(
+		const promises = ( await Promise.allSettled(
 			items.map( ( { id } ) =>
 				saveEntityRecord( 'postType', 'feedback', { id, status: 'publish' } )
 			)
-		);
+		) ) as PromiseSettledResult< { id: string } >[];
 
-		const itemsUpdated = promises.filter( ( { status } ) => status === 'fulfilled' );
+		const itemsUpdated = promises.filter(
+			( { status } ) => status === 'fulfilled'
+		) as PromiseFulfilledResult< { id: string } >[];
 
 		// If there is at least one successful update, invalidate the cache and navigate if needed
 		if ( itemsUpdated.length ) {
@@ -302,7 +313,7 @@ export const markAsNotSpamAction = {
 	},
 };
 
-export const restoreAction = {
+export const restoreAction: Action = {
 	id: 'restore',
 	isPrimary: true,
 	icon: <Icon icon={ backup } />,
@@ -373,11 +384,12 @@ export const restoreAction = {
 		// There is at least one failure.
 		const numberOfErrors = promises.filter( ( { status } ) => status === 'rejected' ).length;
 		const errorMessage = getGenericErrorMessage( numberOfErrors );
+
 		createErrorNotice( errorMessage, { type: 'snackbar' } );
 	},
 };
 
-export const moveToTrashAction = {
+export const moveToTrashAction: Action = {
 	id: 'move-to-trash',
 	isPrimary: true,
 	icon: <Icon icon={ trash } />,
@@ -448,14 +460,16 @@ export const moveToTrashAction = {
 
 			return;
 		}
+
 		// There is at least one failure.
 		const numberOfErrors = promises.filter( ( { status } ) => status === 'rejected' ).length;
 		const errorMessage = getGenericErrorMessage( numberOfErrors );
+
 		createErrorNotice( errorMessage, { type: 'snackbar' } );
 	},
 };
 
-export const deleteAction = {
+export const deleteAction: Action = {
 	id: 'delete',
 	isPrimary: true,
 	icon: <Icon icon={ trash } />,
@@ -467,6 +481,7 @@ export const deleteAction = {
 			action: 'delete',
 			multiple: items.length > 1,
 		} );
+
 		const { deleteEntityRecord } = registry.dispatch( coreStore );
 		const { invalidateFilters, updateCountsOptimistically } = registry.dispatch( dashboardStore );
 		const { getCurrentQuery } = registry.select( dashboardStore );
@@ -483,12 +498,15 @@ export const deleteAction = {
 				deleteEntityRecord( 'postType', 'feedback', id, { force: true }, { throwOnError: true } )
 			)
 		);
+
 		const itemsUpdated = promises.filter( ( { status } ) => status === 'fulfilled' );
+
 		// If there is at least one successful update, invalidate the cache for filters.
 		if ( itemsUpdated.length ) {
 			invalidateFilters();
 			invalidateCacheAndNavigate( registry, getCurrentQuery(), queryParams, 'trash' );
 		}
+
 		if ( itemsUpdated.length === items.length ) {
 			// Every request was successful.
 			const successMessage =
@@ -504,6 +522,7 @@ export const deleteAction = {
 							),
 							items.length
 					  );
+
 			createSuccessNotice( successMessage, { type: 'snackbar', id: 'move-to-trash-action' } );
 
 			// Update the URL to remove references to deleted items.
@@ -526,16 +545,18 @@ export const deleteAction = {
 
 			const hashString = hashParams.toString();
 			window.location.hash = hashString ? `${ hashBase }?${ hashString }` : hashBase;
+
 			return;
 		}
 		// There is at least one failure.
 		const numberOfErrors = promises.filter( ( { status } ) => status === 'rejected' ).length;
 		const errorMessage = getGenericErrorMessage( numberOfErrors );
+
 		createErrorNotice( errorMessage, { type: 'snackbar' } );
 	},
 };
 
-export const markAsReadAction = {
+export const markAsReadAction: Action = {
 	id: 'mark-as-read',
 	isPrimary: false,
 	icon: <Icon icon={ seen } />,
@@ -645,11 +666,12 @@ export const markAsReadAction = {
 		// There is at least one failure.
 		const numberOfErrors = promises.filter( ( { status } ) => status === 'rejected' ).length;
 		const errorMessage = getGenericErrorMessage( numberOfErrors );
+
 		createErrorNotice( errorMessage, { type: 'snackbar' } );
 	},
 };
 
-export const markAsUnreadAction = {
+export const markAsUnreadAction: Action = {
 	id: 'mark-as-unread',
 	isPrimary: false,
 	icon: <Icon icon={ unseen } />,
@@ -752,6 +774,7 @@ export const markAsUnreadAction = {
 		// There is at least one failure.
 		const numberOfErrors = promises.filter( ( { status } ) => status === 'rejected' ).length;
 		const errorMessage = getGenericErrorMessage( numberOfErrors );
+
 		createErrorNotice( errorMessage, { type: 'snackbar' } );
 	},
 };

--- a/projects/packages/forms/src/dashboard/inbox/dataviews/actions.tsx
+++ b/projects/packages/forms/src/dashboard/inbox/dataviews/actions.tsx
@@ -18,7 +18,7 @@ import { defaultView } from './views';
 /**
  * Types
  */
-import type { Action, QueryParams } from './types';
+import type { Action, QueryParams, Registry } from './types';
 
 /**
  * Helper function to extract count-relevant query params from the current query.
@@ -57,11 +57,11 @@ const getCountQueryParams = ( currentQuery: QueryParams ): QueryParams => {
  * @param {string} statusBeingRemovedFrom - The status items are being removed from ('trash', 'spam', or 'inbox').
  */
 const invalidateCacheAndNavigate = (
-	registry,
-	currentQuery,
-	queryParams,
-	statusBeingRemovedFrom
-) => {
+	registry: Registry,
+	currentQuery: QueryParams,
+	queryParams: QueryParams,
+	statusBeingRemovedFrom: string
+): void => {
 	// Invalidate counts to ensure accurate totals
 	registry.dispatch( dashboardStore ).invalidateCounts();
 

--- a/projects/packages/forms/src/dashboard/inbox/dataviews/index.js
+++ b/projects/packages/forms/src/dashboard/inbox/dataviews/index.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import jetpackAnalytics from '@automattic/jetpack-analytics';
 import {
 	ExternalLink,
 	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
@@ -20,11 +21,12 @@ import { useSearchParams } from 'react-router';
  */
 import Gravatar from '../../components/gravatar';
 import InboxStatusToggle from '../../components/inbox-status-toggle';
-import { SingleResponseView } from '../../components/response-view';
+import { ResponseMobileView, SingleResponseView } from '../../components/response-view';
 import useInboxData from '../../hooks/use-inbox-data';
 import EmptyResponses from '../empty-responses';
 import { getPath, getItemId, getCountryFlagEmoji } from '../utils.js';
 import {
+	viewAction,
 	markAsSpamAction,
 	markAsNotSpamAction,
 	moveToTrashAction,
@@ -330,21 +332,57 @@ export default function InboxView() {
 	);
 
 	const actions = useMemo( () => {
+		const mobileViewAction = {
+			...viewAction,
+			RenderModal: ( { items, closeModal } ) => {
+				jetpackAnalytics.tracks.recordEvent( 'jetpack_forms_inbox_action_click', {
+					action: 'view-response',
+					multiple: items.length > 1,
+				} );
+
+				const [ item ] = items;
+
+				return <ResponseMobileView response={ item } closeModal={ closeModal } />;
+			},
+			hideModalHeader: true,
+		};
+
+		const desktopViewAction = {
+			...viewAction,
+			callback( items ) {
+				jetpackAnalytics.tracks.recordEvent( 'jetpack_forms_inbox_action_click', {
+					action: 'view-response',
+					multiple: items.length > 1,
+				} );
+
+				const [ item ] = items;
+				const selectedId = item.id.toString();
+				const selectionWithoutSelectedId = selection.filter( id => id !== selectedId );
+
+				onChangeSelection( [ ...selectionWithoutSelectedId, selectedId ] );
+			},
+		};
+
+		const viewResponseAction = isMobile ? mobileViewAction : desktopViewAction;
+
+		const primaryActions = [ viewResponseAction ];
+		const secondaryActions = [ markAsUnreadAction, editFormAction ];
+
 		switch ( statusFilter ) {
 			case 'trash':
-				return [ restoreAction, deleteAction, markAsSpamAction ];
+				return [ ...primaryActions, restoreAction, deleteAction, ...secondaryActions ];
 			case 'spam':
-				return [ markAsNotSpamAction, moveToTrashAction ];
+				return [ ...primaryActions, markAsNotSpamAction, moveToTrashAction, ...secondaryActions ];
 			default:
 				return [
+					...primaryActions,
 					markAsReadAction,
-					markAsUnreadAction,
 					markAsSpamAction,
 					moveToTrashAction,
-					editFormAction,
+					...secondaryActions,
 				];
 		}
-	}, [ statusFilter ] );
+	}, [ isMobile, onChangeSelection, selection, statusFilter ] );
 
 	const resetPage = useCallback( () => {
 		view.page = 1;

--- a/projects/packages/forms/src/dashboard/inbox/dataviews/index.js
+++ b/projects/packages/forms/src/dashboard/inbox/dataviews/index.js
@@ -6,14 +6,16 @@ import {
 	ExternalLink,
 	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
 	__experimentalHStack as HStack,
+	Modal,
 } from '@wordpress/components';
-import { useResizeObserver } from '@wordpress/compose';
+import { useResizeObserver, useViewportMatch } from '@wordpress/compose';
 import { DataViews } from '@wordpress/dataviews/wp';
 import { dateI18n, getSettings as getDateSettings } from '@wordpress/date';
 import { useCallback, useMemo, useState } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
 import { __ } from '@wordpress/i18n';
 import { Icon, globe } from '@wordpress/icons';
+import clsx from 'clsx';
 import { useEffect } from 'react';
 import { useSearchParams } from 'react-router';
 /**
@@ -89,6 +91,30 @@ export default function InboxView() {
 	);
 	const isMobile = containerWidth <= MOBILE_BREAKPOINT;
 	const selectedResponses = searchParams.get( 'r' );
+	const isMobileViewport = useViewportMatch( 'medium', '<' );
+	const [ isResponseModalOpen, setIsResponseModalOpen ] = useState( false );
+	const [ responseModal, setResponseModal ] = useState( null );
+
+	const closeResponseModal = useCallback( () => {
+		setIsResponseModalOpen( false );
+		setResponseModal( null );
+	}, [ setIsResponseModalOpen, setResponseModal ] );
+
+	const openResponseModal = useCallback(
+		item => {
+			const content = <ResponseMobileView response={ item } closeModal={ closeResponseModal } />;
+
+			setResponseModal( content );
+			setIsResponseModalOpen( true );
+		},
+		[ setIsResponseModalOpen, closeResponseModal, setResponseModal ]
+	);
+
+	useEffect( () => {
+		if ( ! isMobileViewport ) {
+			closeResponseModal();
+		}
+	}, [ isMobileViewport, closeResponseModal ] );
 
 	useEffect( () => {
 		return setupSidebarWidthObserver();
@@ -228,8 +254,22 @@ export default function InboxView() {
 						item.author_name || item.author_email || item.author_url || item.ip
 					);
 					const defaultImage = item.author_name || item.author_email ? 'initials' : 'mp';
+
+					const handleClick = isMobileViewport ? () => openResponseModal( item ) : undefined;
+
 					return (
-						<div className="jp-forms__inbox__author-field">
+						<div
+							className={ clsx(
+								'jp-forms__inbox__author-field',
+								isMobileViewport && 'jp-forms__inbox__author-field--mobile'
+							) }
+							{ ...( isMobileViewport && {
+								onClick: handleClick,
+								onKeyDown: () => {},
+								role: 'button',
+								tabIndex: 0,
+							} ) }
+						>
 							{ item.is_unread && (
 								<span
 									className="jp-forms__inbox__unread-indicator"
@@ -328,7 +368,13 @@ export default function InboxView() {
 				},
 			},
 		],
-		[ filterOptions, dateSettings.formats.date ]
+		[
+			filterOptions?.date,
+			filterOptions?.source,
+			isMobileViewport,
+			openResponseModal,
+			dateSettings.formats.date,
+		]
 	);
 
 	const actions = useMemo( () => {
@@ -421,6 +467,15 @@ export default function InboxView() {
 						/>
 					}
 				/>
+				{ isResponseModalOpen && (
+					<Modal
+						title={ __( 'Response', 'jetpack-forms' ) }
+						__experimentalHideHeader={ true }
+						onRequestClose={ closeResponseModal }
+					>
+						{ responseModal }
+					</Modal>
+				) }
 			</div>
 			<SingleResponseView
 				sidePanelItem={ selection.length && sidePanelItem }

--- a/projects/packages/forms/src/dashboard/inbox/dataviews/index.js
+++ b/projects/packages/forms/src/dashboard/inbox/dataviews/index.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import jetpackAnalytics from '@automattic/jetpack-analytics';
 import {
 	ExternalLink,
 	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
@@ -21,12 +20,11 @@ import { useSearchParams } from 'react-router';
  */
 import Gravatar from '../../components/gravatar';
 import InboxStatusToggle from '../../components/inbox-status-toggle';
-import { ResponseMobileView, SingleResponseView } from '../../components/response-view';
+import { SingleResponseView } from '../../components/response-view';
 import useInboxData from '../../hooks/use-inbox-data';
 import EmptyResponses from '../empty-responses';
 import { getPath, getItemId, getCountryFlagEmoji } from '../utils.js';
 import {
-	viewAction,
 	markAsSpamAction,
 	markAsNotSpamAction,
 	moveToTrashAction,
@@ -332,46 +330,21 @@ export default function InboxView() {
 	);
 
 	const actions = useMemo( () => {
-		const _actions = [
-			markAsReadAction,
-			markAsUnreadAction,
-			markAsSpamAction,
-			markAsNotSpamAction,
-			moveToTrashAction,
-			editFormAction,
-			restoreAction,
-			deleteAction,
-		];
-		if ( isMobile ) {
-			_actions.unshift( {
-				...viewAction,
-				RenderModal: ( { items, closeModal } ) => {
-					jetpackAnalytics.tracks.recordEvent( 'jetpack_forms_inbox_action_click', {
-						action: 'view-response',
-						multiple: items.length > 1,
-					} );
-					const [ item ] = items;
-					return <ResponseMobileView response={ item } closeModal={ closeModal } />;
-				},
-				hideModalHeader: true,
-			} );
-		} else {
-			_actions.unshift( {
-				...viewAction,
-				callback( items ) {
-					jetpackAnalytics.tracks.recordEvent( 'jetpack_forms_inbox_action_click', {
-						action: 'view-response',
-						multiple: items.length > 1,
-					} );
-					const [ item ] = items;
-					const selectedId = item.id.toString();
-					const selectionWithoutSelectedId = selection.filter( id => id !== selectedId );
-					onChangeSelection( [ ...selectionWithoutSelectedId, selectedId ] );
-				},
-			} );
+		switch ( statusFilter ) {
+			case 'trash':
+				return [ restoreAction, deleteAction, markAsSpamAction ];
+			case 'spam':
+				return [ markAsNotSpamAction, moveToTrashAction ];
+			default:
+				return [
+					markAsReadAction,
+					markAsUnreadAction,
+					markAsSpamAction,
+					moveToTrashAction,
+					editFormAction,
+				];
 		}
-		return _actions;
-	}, [ isMobile, onChangeSelection, selection ] );
+	}, [ statusFilter ] );
 
 	const resetPage = useCallback( () => {
 		view.page = 1;

--- a/projects/packages/forms/src/dashboard/inbox/dataviews/types.tsx
+++ b/projects/packages/forms/src/dashboard/inbox/dataviews/types.tsx
@@ -1,3 +1,4 @@
+import type { FormResponse } from '../../../types';
 import type { StoreDescriptor } from '@wordpress/data';
 
 /**
@@ -14,7 +15,7 @@ export type QueryParams = {
 /**
  * Store actions
  */
-type Registry = {
+export type Registry = {
 	dispatch: ( store: StoreDescriptor ) => {
 		// Notices store actions
 		createSuccessNotice: (
@@ -35,14 +36,14 @@ type Registry = {
 		deleteEntityRecord: (
 			kind: string,
 			name: string,
-			recordId: string,
+			recordId: number,
 			query: Record< string, unknown >,
 			options?: { throwOnError?: boolean }
 		) => Promise< void >;
 		editEntityRecord: (
 			kind: string,
 			name: string,
-			recordId: string,
+			recordId: number,
 			edits: Record< string, unknown >
 		) => Promise< void >;
 
@@ -56,7 +57,7 @@ type Registry = {
 		doBulkAction: ( ids: string[], action: string ) => void;
 		invalidateFilters: () => void;
 		invalidateCounts: () => void;
-		markRecordsAsInvalid: ( ids: string[] ) => void;
+		markRecordsAsInvalid: ( ids: number[] ) => void;
 	};
 	select: ( store: StoreDescriptor ) => {
 		// Dashboard store select actions
@@ -66,16 +67,9 @@ type Registry = {
 		getEntityRecord: (
 			kind: string,
 			name: string,
-			recordId: string
+			recordId: number
 		) => Record< string, unknown > | undefined;
 	};
-};
-
-type Item = {
-	id: string;
-	status: string;
-	edit_form_url: string;
-	is_unread: boolean;
 };
 
 export type Action = {
@@ -84,7 +78,7 @@ export type Action = {
 	icon: React.ReactNode;
 	label: string;
 	modalHeader?: string;
-	isEligible?: ( item: Item ) => boolean;
+	isEligible?: ( item: FormResponse ) => boolean;
 	supportsBulk?: boolean;
-	callback?: ( items: Item[], { registry }: { registry: Registry } ) => Promise< void >;
+	callback?: ( items: FormResponse[], { registry }: { registry: Registry } ) => Promise< void >;
 };

--- a/projects/packages/forms/src/dashboard/inbox/dataviews/types.tsx
+++ b/projects/packages/forms/src/dashboard/inbox/dataviews/types.tsx
@@ -10,6 +10,8 @@ export type QueryParams = {
 	before?: string;
 	after?: string;
 	is_unread?: boolean;
+	per_page?: number;
+	page?: number;
 };
 
 /**
@@ -58,10 +60,14 @@ export type Registry = {
 		invalidateFilters: () => void;
 		invalidateCounts: () => void;
 		markRecordsAsInvalid: ( ids: number[] ) => void;
+		setCurrentQuery: ( queryParams: QueryParams ) => void;
 	};
 	select: ( store: StoreDescriptor ) => {
 		// Dashboard store select actions
 		getCurrentQuery: () => QueryParams;
+		getTrashCount: ( queryParams: QueryParams ) => number;
+		getSpamCount: ( queryParams: QueryParams ) => number;
+		getInboxCount: ( queryParams: QueryParams ) => number;
 
 		// Core store select actions
 		getEntityRecord: (

--- a/projects/packages/forms/src/dashboard/inbox/dataviews/types.tsx
+++ b/projects/packages/forms/src/dashboard/inbox/dataviews/types.tsx
@@ -1,0 +1,90 @@
+import type { StoreDescriptor } from '@wordpress/data';
+
+/**
+ * Query parameters for the dashboard.
+ */
+export type QueryParams = {
+	search?: string;
+	parent?: string;
+	before?: string;
+	after?: string;
+	is_unread?: boolean;
+};
+
+/**
+ * Store actions
+ */
+type Registry = {
+	dispatch: ( store: StoreDescriptor ) => {
+		// Notices store actions
+		createSuccessNotice: (
+			message: string,
+			options: { type?: string; id?: string; actions?: { label: string; onClick: () => void }[] }
+		) => void;
+		createErrorNotice: (
+			message: string,
+			options: { type?: string; id?: string; actions?: { label: string; onClick: () => void }[] }
+		) => void;
+
+		// Core store actions
+		saveEntityRecord: (
+			kind: string,
+			name: string,
+			record: Record< string, unknown >
+		) => Promise< void >;
+		deleteEntityRecord: (
+			kind: string,
+			name: string,
+			recordId: string,
+			query: Record< string, unknown >,
+			options?: { throwOnError?: boolean }
+		) => Promise< void >;
+		editEntityRecord: (
+			kind: string,
+			name: string,
+			recordId: string,
+			edits: Record< string, unknown >
+		) => Promise< void >;
+
+		// Dashboard store actions
+		updateCountsOptimistically: (
+			status: string,
+			newStatus: string,
+			count: number,
+			queryParams: QueryParams
+		) => void;
+		doBulkAction: ( ids: string[], action: string ) => void;
+		invalidateFilters: () => void;
+		invalidateCounts: () => void;
+		markRecordsAsInvalid: ( ids: string[] ) => void;
+	};
+	select: ( store: StoreDescriptor ) => {
+		// Dashboard store select actions
+		getCurrentQuery: () => QueryParams;
+
+		// Core store select actions
+		getEntityRecord: (
+			kind: string,
+			name: string,
+			recordId: string
+		) => Record< string, unknown > | undefined;
+	};
+};
+
+type Item = {
+	id: string;
+	status: string;
+	edit_form_url: string;
+	is_unread: boolean;
+};
+
+export type Action = {
+	id: string;
+	isPrimary: boolean;
+	icon: React.ReactNode;
+	label: string;
+	modalHeader?: string;
+	isEligible?: ( item: Item ) => boolean;
+	supportsBulk?: boolean;
+	callback?: ( items: Item[], { registry }: { registry: Registry } ) => Promise< void >;
+};

--- a/projects/packages/forms/src/dashboard/inbox/style.scss
+++ b/projects/packages/forms/src/dashboard/inbox/style.scss
@@ -350,6 +350,10 @@
 		display: flex;
 		align-items: center;
 		gap: 12px;
+
+		&--mobile {
+			text-decoration: underline;
+		}
 	}
 
 	.jp-forms__inbox__unread-indicator {

--- a/projects/packages/forms/src/types/index.ts
+++ b/projects/packages/forms/src/types/index.ts
@@ -114,6 +114,8 @@ export interface FormResponse {
 	is_unread: boolean;
 	/** The fields of the response. */
 	fields: Record< string, unknown >;
+	/** The URL to edit the form that the response was submitted to. */
+	edit_form_url: string;
 }
 
 /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Part of FORMS-330
Depends on https://github.com/Automattic/jetpack/pull/45735

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Updates the dataview dependency
* Uses text instead of icons for primary actions (required the dependency update)
* Contextualize actions depending on the status

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the dashboard
* Check that primary actions now use text instead of icons
* Check that the inbox, spam and trash views show contextualized actions based on the design exploration

<img width="367" height="425" alt="2025-10-31_14-23" src="https://github.com/user-attachments/assets/b6e3b675-879e-46b4-95f1-2ee50a5c2108" />

<img width="384" height="426" alt="2025-10-31_14-23_1" src="https://github.com/user-attachments/assets/b394f743-c953-40b0-93ba-08fcde045a97" />

<img width="348" height="432" alt="2025-10-31_14-24" src="https://github.com/user-attachments/assets/c894feec-d583-4077-b4f8-a89d498c565b" />

<img width="452" height="368" alt="Screenshot from 2025-10-31 21-56-23" src="https://github.com/user-attachments/assets/f154187a-8ae5-486b-a856-3d040d5c90ac" />
