### PR TITLE
Jetpack Sync: Enable WPCOM REST API feature by default

### DIFF
--- a/projects/packages/sync/.phan/baseline.php
+++ b/projects/packages/sync/.phan/baseline.php
@@ -17,9 +17,9 @@ return [
     // PhanTypeMismatchArgumentProbablyReal : 10+ occurrences
     // PhanPluginSimplifyExpressionBool : 9 occurrences
     // PhanPluginDuplicateSwitchCaseLooseEquality : 6 occurrences
-    // PhanNonClassMethodCall : 5 occurrences
-    // PhanPossiblyUndeclaredVariable : 5 occurrences
+    // PhanPossiblyUndeclaredVariable : 4 occurrences
     // PhanTypeExpectedObjectPropAccess : 4 occurrences
+    // PhanNonClassMethodCall : 3 occurrences
     // PhanTypeArraySuspiciousNullable : 3 occurrences
     // PhanImpossibleCondition : 2 occurrences
     // PhanTypeArraySuspicious : 2 occurrences
@@ -50,7 +50,7 @@ return [
         'src/class-rest-sender.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchArgumentProbablyReal'],
         'src/class-sender.php' => ['PhanNonClassMethodCall', 'PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchProperty', 'PhanTypeMismatchReturnProbablyReal'],
         'src/class-server.php' => ['PhanTypeMismatchDeclaredParam', 'PhanTypeMismatchReturnProbablyReal'],
-        'src/class-settings.php' => ['PhanNonClassMethodCall', 'PhanPossiblyUndeclaredVariable', 'PhanTypeMismatchArgumentProbablyReal'],
+        'src/class-settings.php' => ['PhanPossiblyUndeclaredVariable', 'PhanTypeMismatchArgumentProbablyReal'],
         'src/class-utils.php' => ['PhanTypeExpectedObjectPropAccess'],
         'src/modules/class-callables.php' => ['PhanParamSignatureMismatch', 'PhanTypeArraySuspicious', 'PhanTypeMismatchArgument'],
         'src/modules/class-comments.php' => ['PhanTypeMismatchReturn', 'PhanTypeMismatchReturnProbablyReal'],

--- a/projects/packages/sync/changelog/update-sync-wpcom_rest_api_enabled
+++ b/projects/packages/sync/changelog/update-sync-wpcom_rest_api_enabled
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Jetpack Sync: Enable WPCOM REST API feature by default

--- a/projects/packages/sync/src/class-defaults.php
+++ b/projects/packages/sync/src/class-defaults.php
@@ -1374,5 +1374,5 @@ class Defaults {
 	 *
 	 * @var int Bool-ish. Default 0.
 	 */
-	public static $default_wpcom_rest_api_enabled = 0;
+	public static $default_wpcom_rest_api_enabled = 1;
 }

--- a/projects/packages/sync/src/class-defaults.php
+++ b/projects/packages/sync/src/class-defaults.php
@@ -1372,7 +1372,7 @@ class Defaults {
 	/**
 	 * Default for enabling wpcom rest api for Sync.
 	 *
-	 * @var int Bool-ish. Default 0.
+	 * @var int Bool-ish. Default 1.
 	 */
 	public static $default_wpcom_rest_api_enabled = 1;
 }

--- a/projects/packages/sync/src/class-settings.php
+++ b/projects/packages/sync/src/class-settings.php
@@ -304,26 +304,6 @@ class Settings {
 					update_option( self::SETTINGS_OPTION_PREFIX . $setting, 0, true );
 				}
 			}
-
-			// Do not enable wpcom rest api if we cannot send a test request.
-
-			if ( 'wpcom_rest_api_enabled' === $setting && $updated && (bool) $value ) {
-				$sender = Sender::get_instance();
-				$data   = array(
-					'timestamp' => microtime( true ),
-				);
-				$items  = $sender->send_action( 'jetpack_sync_wpcom_rest_api_enable_test', $data );
-				// If we can't send a test request, disable the setting and send action tolog the error.
-				if ( is_wp_error( $items ) ) {
-					update_option( self::SETTINGS_OPTION_PREFIX . $setting, 0, true );
-					$data = array(
-						'timestamp'     => microtime( true ),
-						'response_code' => $items->get_error_code(),
-						'response_body' => $items->get_error_message() ?? '',
-					);
-					$sender->send_action( 'jetpack_sync_wpcom_rest_api_enable_error', $data );
-				}
-			}
 		}
 	}
 

--- a/projects/packages/sync/tests/php/Actions_Test.php
+++ b/projects/packages/sync/tests/php/Actions_Test.php
@@ -22,6 +22,8 @@ class Actions_Test extends BaseTestCase {
 		Constants::set_constant( 'JETPACK_DISABLE_RAW_OPTIONS', true );
 		// Required for XML-RPC requests to work.
 		Constants::set_constant( 'JETPACK__API_BASE', 'https://public-api.wordpress.com' );
+		// Required for REST API requests to work.
+		Constants::set_constant( 'JETPACK__WPCOM_JSON_API_BASE', 'https://public-api.wordpress.com' );
 		// Mock Site level connection.
 		\Jetpack_Options::update_option( 'blog_token', 'blog_token.secret' );
 		\Jetpack_Options::update_option( 'id', 1 );
@@ -67,7 +69,7 @@ class Actions_Test extends BaseTestCase {
 		Settings::update_settings( array( 'dedicated_sync_enabled' => 1 ) );
 
 		add_filter( 'pre_http_request', array( $this, 'pre_http_request_set_dedicated_sync_header_off' ), 10, 3 );
-		Actions::send_data( array(), 'dummy', microtime(), 'sync', 0, 0 );
+		Actions::send_data( array( 1 ), 'dummy', microtime(), 'sync', 0, 0 );
 		remove_filter( 'pre_http_request', array( $this, 'pre_http_request_set_dedicated_sync_header_off' ) );
 
 		$this->assertFalse( Settings::is_dedicated_sync_enabled() );
@@ -78,7 +80,7 @@ class Actions_Test extends BaseTestCase {
 	 */
 	public function test_send_data_without_jetpack_dedicated_sync_enabled_response_header_off() {
 		add_filter( 'pre_http_request', array( $this, 'pre_http_request_set_dedicated_sync_header_off' ), 10, 3 );
-		Actions::send_data( array(), 'dummy', microtime(), 'sync', 0, 0 );
+		Actions::send_data( array( 1 ), 'dummy', microtime(), 'sync', 0, 0 );
 		remove_filter( 'pre_http_request', array( $this, 'pre_http_request_set_dedicated_sync_header_off' ) );
 
 		$this->assertFalse( Settings::is_dedicated_sync_enabled() );
@@ -91,7 +93,7 @@ class Actions_Test extends BaseTestCase {
 		set_transient( Dedicated_Sender::DEDICATED_SYNC_CHECK_TRANSIENT, Dedicated_Sender::DEDICATED_SYNC_VALIDATION_STRING, 100 );
 
 		add_filter( 'pre_http_request', array( $this, 'pre_http_request_set_dedicated_sync_header_on' ), 10, 3 );
-		Actions::send_data( array(), 'dummy', microtime(), 'sync', 0, 0 );
+		Actions::send_data( array( 1 ), 'dummy', microtime(), 'sync', 0, 0 );
 		remove_filter( 'pre_http_request', array( $this, 'pre_http_request_set_dedicated_sync_header_on' ) );
 
 		delete_transient( Dedicated_Sender::DEDICATED_SYNC_CHECK_TRANSIENT );
@@ -108,7 +110,7 @@ class Actions_Test extends BaseTestCase {
 		Settings::update_settings( array( 'dedicated_sync_enabled' => 1 ) );
 
 		add_filter( 'pre_http_request', array( $this, 'pre_http_request_set_dedicated_sync_header_on' ), 10, 3 );
-		Actions::send_data( array(), 'dummy', microtime(), 'sync', 0, 0 );
+		Actions::send_data( array( 1 ), 'dummy', microtime(), 'sync', 0, 0 );
 		remove_filter( 'pre_http_request', array( $this, 'pre_http_request_set_dedicated_sync_header_on' ) );
 
 		delete_transient( Dedicated_Sender::DEDICATED_SYNC_CHECK_TRANSIENT );

--- a/projects/plugins/jetpack/changelog/update-sync-wpcom_rest_api_enabled
+++ b/projects/plugins/jetpack/changelog/update-sync-wpcom_rest_api_enabled
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Update Sync related unit test
+
+

--- a/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Settings_Test.php
+++ b/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Settings_Test.php
@@ -180,6 +180,7 @@ class Jetpack_Sync_Settings_Test extends Jetpack_Sync_TestBase {
 	}
 
 	public function test_enabling_wpcom_rest_api_enabled_gets_disabled_when_send_data_fails() {
+		Settings::update_settings( array( 'wpcom_rest_api_enabled' => 0 ) );
 		add_filter( 'jetpack_sync_send_data', array( $this, 'serverReceiveWithError' ) );
 		Settings::update_settings( array( 'wpcom_rest_api_enabled' => 1 ) );
 		remove_filter( 'jetpack_sync_send_data', array( $this, 'serverReceiveWithError' ) );

--- a/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Settings_Test.php
+++ b/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Settings_Test.php
@@ -179,14 +179,6 @@ class Jetpack_Sync_Settings_Test extends Jetpack_Sync_TestBase {
 		);
 	}
 
-	public function test_enabling_wpcom_rest_api_enabled_gets_disabled_when_send_data_fails() {
-		Settings::update_settings( array( 'wpcom_rest_api_enabled' => 0 ) );
-		add_filter( 'jetpack_sync_send_data', array( $this, 'serverReceiveWithError' ) );
-		Settings::update_settings( array( 'wpcom_rest_api_enabled' => 1 ) );
-		remove_filter( 'jetpack_sync_send_data', array( $this, 'serverReceiveWithError' ) );
-		$this->assertFalse( Settings::is_wpcom_rest_api_enabled() );
-	}
-
 	/**
 	 * Intercept send_data to return WP_Error.
 	 */


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Closes SYNC-150

The `wpcom_rest_api_enabled` Sync Setting is a feature flag we introduced when we switched the Sync endpoint on WPCOM to REST from XML-RPC.
By default, new JP sites would use the old XML-RPC endpoint for sending their Sync queue.
WPCOM would then trigger an async job to enable using the REST API, which also involved the remote site making a test request to send its queue and only enable it if the later succeeded.
Atm the feature is mature enough to use the REST API by default without making test requests anymore. Plus, the only reason for these requests to fail were concurrency issues usually occurring because the initial Full Sync is also in progress at the time WPCOM receives the test request.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* `Automattic\Jetpack\Sync\Defaults::$default_wpcom_rest_api_enabled`: Switch to `1` to enable by default.
* `Automattic\Jetpack\Sync\Settings::update_settings`: Remove test request logic when enabling the WPCOM REST API feature

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* On a new JN site with Jetpack enabled confirm all Incremental/Full Sync actions are sent to WPCOM's REST endpoint vs XML-RPC via monitoring 13eef2acf610ec6b6ee4e06652777c14-logstash
* No fatals/warnings on both ends