### PR TITLE
Boost: Backport 4.5.1 release changes

### DIFF
--- a/projects/plugins/boost/CHANGELOG.md
+++ b/projects/plugins/boost/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [4.5.1-beta] - 2025-10-28
+## [4.5.1] - 2025-10-29
 ### Added
 - Tested up to WordPress 6.9 [#45571]
 
@@ -843,7 +843,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - First public alpha release
 
-[4.5.1-beta]: https://github.com/Automattic/jetpack-boost-production/compare/4.5.0...4.5.1-beta
+[4.5.1]: https://github.com/Automattic/jetpack-boost-production/compare/4.5.0...4.5.1
 [4.5.0]: https://github.com/Automattic/jetpack-boost-production/compare/4.4.0...4.5.0
 [4.4.0]: https://github.com/Automattic/jetpack-boost-production/compare/4.3.1...4.4.0
 [4.3.1]: https://github.com/Automattic/jetpack-boost-production/compare/4.3.0...4.3.1

--- a/projects/plugins/boost/changelog/update-boost-backport-4.5.1
+++ b/projects/plugins/boost/changelog/update-boost-backport-4.5.1
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Backport changes from 4.5.1 release.
+
+

--- a/projects/plugins/boost/composer.json
+++ b/projects/plugins/boost/composer.json
@@ -3,7 +3,7 @@
 	"description": "Boost your WordPress site's performance, from the creators of Jetpack",
 	"type": "library",
 	"license": "GPL-2.0-or-later",
-	"version": "4.5.1-beta",
+	"version": "4.5.1",
 	"authors": [
 		{
 			"name": "Automattic, Inc.",
@@ -77,7 +77,7 @@
 		"platform": {
 			"ext-intl": "0.0.0"
 		},
-		"autoloader-suffix": "b1e77e6231d50e7663f84529b6a3dfda_jetpack_boostⓥ4_5_1_beta",
+		"autoloader-suffix": "b1e77e6231d50e7663f84529b6a3dfda_jetpack_boostⓥ4_5_1",
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true

--- a/projects/plugins/boost/composer.lock
+++ b/projects/plugins/boost/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "59856658e0c40d72da023f0f96c749bc",
+    "content-hash": "7c4157435b1fbccbf2da9af45ef6caf5",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",

--- a/projects/plugins/boost/jetpack-boost.php
+++ b/projects/plugins/boost/jetpack-boost.php
@@ -9,7 +9,7 @@
  * Plugin Name:       Jetpack Boost
  * Plugin URI:        https://jetpack.com/boost
  * Description:       Boost your WordPress site's performance, from the creators of Jetpack
- * Version: 4.5.1-beta
+ * Version: 4.5.1
  * Author:            Automattic - Jetpack Site Speed team
  * Author URI:        https://jetpack.com/boost/
  * License:           GPL-2.0+
@@ -29,7 +29,7 @@ if ( ! defined( 'WPINC' ) ) {
 	die( 0 );
 }
 
-define( 'JETPACK_BOOST_VERSION', '4.5.1-beta' );
+define( 'JETPACK_BOOST_VERSION', '4.5.1' );
 define( 'JETPACK_BOOST_SLUG', 'jetpack-boost' );
 
 if ( ! defined( 'JETPACK_BOOST_CLIENT_NAME' ) ) {

--- a/projects/plugins/boost/readme.txt
+++ b/projects/plugins/boost/readme.txt
@@ -183,7 +183,7 @@ If you run into compatibility issues, please do let us know. You can drop us a l
 2. Jetpack Boost Speed Improvement
 
 == Changelog ==
-### 4.5.1-beta - 2025-10-28
+### 4.5.1 - 2025-10-29
 #### Added
 - Tested up to WordPress 6.9
 

--- a/projects/plugins/boost/readme.txt
+++ b/projects/plugins/boost/readme.txt
@@ -5,7 +5,7 @@ Tags: performance, speed, web vitals, critical css, cache
 Requires at least: 6.7
 Tested up to: 6.9
 Requires PHP: 7.2
-Stable tag: 4.5.0
+Stable tag: 4.5.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 


### PR DESCRIPTION
Fixes HOG-374

## Proposed changes:

* Backport changes from the beta release;
* Update stable tag to 4.5.1.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

HOG-374

## Does this pull request change what data or activity we track or use?

no

## Testing instructions:

- Make sure all GitHub checks pass;
- Proof read changes and make sure they make sense.