### PR TITLE
Forms: Add browser info to form responses detail view

### DIFF
--- a/projects/packages/device-detection/changelog/add-form-submission-browser-info
+++ b/projects/packages/device-detection/changelog/add-form-submission-browser-info
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Device detection: added a method that returns the browser display name.

--- a/projects/packages/device-detection/src/class-user-agent-info.php
+++ b/projects/packages/device-detection/src/class-user-agent-info.php
@@ -385,7 +385,7 @@ class User_Agent_Info {
 	 */
 	public function get_browser_display_name() {
 		$browser = $this->get_browser();
-		return isset( self::BROWSER_DISPLAY_NAME_MAP[ $browser ] ) ? self::BROWSER_DISPLAY_NAME_MAP[ $browser ] : $browser;
+		return self::BROWSER_DISPLAY_NAME_MAP[ $browser ] ?? $browser;
 	}
 
 	/**

--- a/projects/packages/device-detection/src/class-user-agent-info.php
+++ b/projects/packages/device-detection/src/class-user-agent-info.php
@@ -108,6 +108,7 @@ class User_Agent_Info {
 		self::BROWSER_VIVALDI => 'Vivaldi',
 		self::BROWSER_MIUI    => 'MIUI Browser',
 		self::BROWSER_SILK    => 'Amazon Silk',
+		self::OTHER           => 'Other',
 	);
 
 	/**

--- a/projects/packages/device-detection/src/class-user-agent-info.php
+++ b/projects/packages/device-detection/src/class-user-agent-info.php
@@ -95,6 +95,21 @@ class User_Agent_Info {
 	const BROWSER_SILK             = 'silk';
 	const OTHER                    = 'other';
 
+	const BROWSER_DISPLAY_NAME_MAP = array(
+		self::BROWSER_CHROME  => 'Chrome',
+		self::BROWSER_FIREFOX => 'Firefox',
+		self::BROWSER_SAFARI  => 'Safari',
+		self::BROWSER_EDGE    => 'Edge',
+		self::BROWSER_OPERA   => 'Opera',
+		self::BROWSER_IE      => 'Internet Explorer',
+		self::BROWSER_SAMSUNG => 'Samsung Browser',
+		self::BROWSER_UC      => 'UC Browser',
+		self::BROWSER_YANDEX  => 'Yandex Browser',
+		self::BROWSER_VIVALDI => 'Vivaldi',
+		self::BROWSER_MIUI    => 'MIUI Browser',
+		self::BROWSER_SILK    => 'Amazon Silk',
+	);
+
 	/**
 	 * A list of dumb-phone user agent parts.
 	 *
@@ -360,6 +375,16 @@ class User_Agent_Info {
 			return self::BROWSER_IE;
 		}
 		return self::OTHER;
+	}
+
+	/**
+	 * Get the display name of the browser.
+	 *
+	 * @return string
+	 */
+	public function get_browser_display_name() {
+		$browser = $this->get_browser();
+		return isset( self::BROWSER_DISPLAY_NAME_MAP[ $browser ] ) ? self::BROWSER_DISPLAY_NAME_MAP[ $browser ] : $browser;
 	}
 
 	/**

--- a/projects/packages/device-detection/tests/php/User_Agent_Info_Test.php
+++ b/projects/packages/device-detection/tests/php/User_Agent_Info_Test.php
@@ -306,4 +306,130 @@ class User_Agent_Info_Test extends TestCase {
 
 		return $test_cases;
 	}
+
+	/**
+	 * Test get_browser_display_name() returns human-readable browser names.
+	 *
+	 * @param string $ua User agent string.
+	 * @param string $expected_name Expected browser display name.
+	 * @return void
+	 *
+	 * @dataProvider browser_display_name_provider
+	 */
+	#[DataProvider( 'browser_display_name_provider' )]
+	public function test_get_browser_display_name( string $ua, string $expected_name ) {
+		$ua_info = new User_Agent_Info( $ua );
+		$this->assertEquals( $expected_name, $ua_info->get_browser_display_name() );
+	}
+
+	/**
+	 * Data provider for browser display name tests.
+	 *
+	 * @return array
+	 */
+	public static function browser_display_name_provider() {
+		return array(
+			// Chrome Desktop
+			array(
+				'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.114 Safari/537.36',
+				'Chrome',
+			),
+			// Firefox Desktop
+			array(
+				'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:89.0) Gecko/20100101 Firefox/89.0',
+				'Firefox',
+			),
+			// Safari Desktop
+			array(
+				'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.1.1 Safari/605.1.15',
+				'Safari',
+			),
+			// Edge
+			array(
+				'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36 Edg/91.0.864.59',
+				'Edge',
+			),
+			// Opera
+			array(
+				'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36 OPR/77.0.4054.277',
+				'Opera',
+			),
+			// Internet Explorer
+			array(
+				'Mozilla/5.0 (Windows NT 10.0; WOW64; Trident/7.0; rv:11.0) like Gecko',
+				'Internet Explorer',
+			),
+			// Samsung Browser
+			array(
+				'Mozilla/5.0 (Linux; Android 13; SM-S918B) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/19.0 Chrome/102.0.5005.125 Mobile Safari/537.36',
+				'Samsung Browser',
+			),
+			// UC Browser
+			array(
+				'Mozilla/5.0 (Linux; U; Android 13; en-US; SM-A525F) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/78.0.3904.108 UCBrowser/13.4.0.1306 Mobile Safari/537.36',
+				'UC Browser',
+			),
+			// Yandex Browser
+			array(
+				'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.4430.93 YaBrowser/21.5.0.582 Yowser/2.5 Safari/537.36',
+				'Yandex Browser',
+			),
+			// Vivaldi
+			array(
+				'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.114 Safari/537.36 Vivaldi/4.0.2312.38',
+				'Vivaldi',
+			),
+			// MIUI Browser
+			array(
+				'Mozilla/5.0 (Linux; U; Android 11; zh-cn; Mi 10 Build/RKQ1.200826.002) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/89.0.4389.116 Mobile Safari/537.36 XiaoMi/MiuiBrowser/13.10.0-gn',
+				'MIUI Browser',
+			),
+			// Amazon Silk
+			array(
+				'Mozilla/5.0 (Linux; Android 9; KFMAWI) AppleWebKit/537.36 (KHTML, like Gecko) Silk/89.3.12 like Chrome/89.0.4389.116 Safari/537.36',
+				'Amazon Silk',
+			),
+			// Unknown/Other browser (should return the constant value)
+			array(
+				'CustomBrowser/1.0',
+				'other',
+			),
+		);
+	}
+
+	/**
+	 * Test that get_browser_display_name() returns the constant value for unknown browsers.
+	 *
+	 * @return void
+	 */
+	public function test_get_browser_display_name_returns_constant_for_unknown() {
+		$ua_info      = new User_Agent_Info( 'UnknownBrowser/1.0' );
+		$browser      = $ua_info->get_browser();
+		$display_name = $ua_info->get_browser_display_name();
+
+		// Should return the constant value (likely 'other') for unknown browsers
+		$this->assertEquals( $browser, $display_name );
+	}
+
+	/**
+	 * Test that get_browser_display_name() handles empty user agent.
+	 *
+	 * @return void
+	 */
+	public function test_get_browser_display_name_handles_empty_ua() {
+		// Unset the server variable to ensure we're testing with truly empty UA
+		$original_ua = $_SERVER['HTTP_USER_AGENT'] ?? null;
+		unset( $_SERVER['HTTP_USER_AGENT'] );
+
+		$ua_info      = new User_Agent_Info( '' );
+		$display_name = $ua_info->get_browser_display_name();
+
+		// Should return 'other' for empty UA
+		$this->assertEquals( 'other', $display_name );
+
+		// Restore original UA
+		if ( $original_ua !== null ) {
+			$_SERVER['HTTP_USER_AGENT'] = $original_ua;
+		}
+	}
 }

--- a/projects/packages/device-detection/tests/php/User_Agent_Info_Test.php
+++ b/projects/packages/device-detection/tests/php/User_Agent_Info_Test.php
@@ -389,16 +389,16 @@ class User_Agent_Info_Test extends TestCase {
 				'Mozilla/5.0 (Linux; Android 9; KFMAWI) AppleWebKit/537.36 (KHTML, like Gecko) Silk/89.3.12 like Chrome/89.0.4389.116 Safari/537.36',
 				'Amazon Silk',
 			),
-			// Unknown/Other browser (should return the constant value)
+			// Unknown/Other browser (should return the display name from the map)
 			array(
 				'CustomBrowser/1.0',
-				'other',
+				'Other',
 			),
 		);
 	}
 
 	/**
-	 * Test that get_browser_display_name() returns the constant value for unknown browsers.
+	 * Test that get_browser_display_name() returns the display name for unknown browsers.
 	 *
 	 * @return void
 	 */
@@ -407,8 +407,10 @@ class User_Agent_Info_Test extends TestCase {
 		$browser      = $ua_info->get_browser();
 		$display_name = $ua_info->get_browser_display_name();
 
-		// Should return the constant value (likely 'other') for unknown browsers
-		$this->assertEquals( $browser, $display_name );
+		// Browser should be 'other' constant
+		$this->assertEquals( 'other', $browser );
+		// Display name should be 'Other' (capitalized)
+		$this->assertEquals( 'Other', $display_name );
 	}
 
 	/**
@@ -424,8 +426,8 @@ class User_Agent_Info_Test extends TestCase {
 		$ua_info      = new User_Agent_Info( '' );
 		$display_name = $ua_info->get_browser_display_name();
 
-		// Should return 'other' for empty UA
-		$this->assertEquals( 'other', $display_name );
+		// Should return 'Other' (capitalized) for empty UA
+		$this->assertEquals( 'Other', $display_name );
 
 		// Restore original UA
 		if ( $original_ua !== null ) {

--- a/projects/packages/forms/.phan/baseline.php
+++ b/projects/packages/forms/.phan/baseline.php
@@ -9,7 +9,7 @@
  */
 return [
     // # Issue statistics:
-    // PhanTypeMismatchArgument : 45+ occurrences
+    // PhanTypeMismatchArgument : 50+ occurrences
     // PhanPluginDuplicateConditionalNullCoalescing : 30+ occurrences
     // PhanDeprecatedFunction : 8 occurrences
     // PhanTypeMismatchReturnProbablyReal : 8 occurrences

--- a/projects/packages/forms/changelog/add-form-submission-browser-info
+++ b/projects/packages/forms/changelog/add-form-submission-browser-info
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Device detection: added a method that returns the browser display name.

--- a/projects/packages/forms/composer.json
+++ b/projects/packages/forms/composer.json
@@ -8,6 +8,7 @@
 		"automattic/jetpack-blocks": "@dev",
 		"automattic/jetpack-assets": "@dev",
 		"automattic/jetpack-connection": "@dev",
+		"automattic/jetpack-device-detection": "@dev",
 		"automattic/jetpack-external-connections": "@dev",
 		"automattic/jetpack-jwt": "@dev",
 		"automattic/jetpack-logo": "@dev",

--- a/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
@@ -549,6 +549,16 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 			'readonly'    => true,
 		);
 
+		$schema['properties']['browser'] = array(
+			'description' => __( 'The browser and platform used to submit the form.', 'jetpack-forms' ),
+			'type'        => 'string',
+			'context'     => array( 'view', 'edit', 'embed' ),
+			'arg_options' => array(
+				'sanitize_callback' => 'sanitize_text_field',
+			),
+			'readonly'    => true,
+		);
+
 		$schema['properties']['entry_title'] = array(
 			'description' => __( 'The title of the page or post where the form was submitted.', 'jetpack-forms' ),
 			'type'        => 'string',
@@ -798,6 +808,9 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 		}
 		if ( rest_is_field_included( 'country_code', $fields ) ) {
 			$data['country_code'] = $feedback_response->get_country_code();
+		}
+		if ( rest_is_field_included( 'browser', $fields ) ) {
+			$data['browser'] = $feedback_response->get_browser();
 		}
 		if ( rest_is_field_included( 'entry_title', $fields ) ) {
 			$data['entry_title'] = $feedback_response->get_entry_title();

--- a/projects/packages/forms/src/contact-form/class-feedback.php
+++ b/projects/packages/forms/src/contact-form/class-feedback.php
@@ -943,6 +943,10 @@ class Feedback {
 		// Get browser name.
 		$browser_name = $ua_info->get_browser_display_name();
 
+		if ( $browser_name === User_Agent_Info::OTHER ) {
+			return __( 'Unknown browser', 'jetpack-forms' );
+		}
+
 		// Determine platform type (Mobile, Tablet, or Desktop).
 		$platform_type = 'Desktop';
 		if ( $ua_info->is_tablet() ) {

--- a/projects/packages/forms/src/contact-form/class-feedback.php
+++ b/projects/packages/forms/src/contact-form/class-feedback.php
@@ -8,6 +8,7 @@
 namespace Automattic\Jetpack\Forms\ContactForm;
 
 use Automattic\Jetpack\Connection\Client;
+use Automattic\Jetpack\Device_Detection\User_Agent_Info;
 use WP_Post;
 /**
  * Handles the response for a contact form submission.
@@ -922,6 +923,36 @@ class Feedback {
 			}
 		}
 		return $country_code;
+	}
+
+	/**
+	 * Get the browser information from the user agent.
+	 *
+	 * Returns a formatted string like "Chrome (Desktop)" or "Safari (Mobile)".
+	 *
+	 * @return string|null Browser information or null if user agent is not available.
+	 */
+	public function get_browser() {
+		if ( empty( $this->user_agent ) ) {
+			return null;
+		}
+
+		// Use Jetpack Device Detection to parse the user agent.
+		$ua_info = new User_Agent_Info( $this->user_agent );
+
+		// Get browser name.
+		$browser_name = $ua_info->get_browser_display_name();
+
+		// Determine platform type (Mobile, Tablet, or Desktop).
+		$platform_type = 'Desktop';
+		if ( $ua_info->is_tablet() ) {
+			$platform_type = 'Tablet';
+		} elseif ( $ua_info->get_platform() ) {
+			// If there's a mobile platform detected (not false), it's mobile.
+			$platform_type = 'Mobile';
+		}
+
+		return sprintf( '%s (%s)', $browser_name, $platform_type );
 	}
 
 	/**

--- a/projects/packages/forms/src/dashboard/components/response-view/body.tsx
+++ b/projects/packages/forms/src/dashboard/components/response-view/body.tsx
@@ -492,6 +492,14 @@ const ResponseViewBody = ( {
 							</tr>
 						</tbody>
 					</table>
+					{ response.browser && (
+						<div className="jp-forms__inbox-response-meta-label">
+							<span className="jp-forms__inbox-response-meta-key	">
+								{ __( 'Browser:', 'jetpack-forms' ) }&nbsp;
+							</span>
+							<span className="jp-forms__inbox-response-meta-value">{ response.browser }</span>
+						</div>
+					) }
 				</div>
 
 				<div className="jp-forms__inbox-response-data">

--- a/projects/packages/forms/src/dashboard/components/response-view/body.tsx
+++ b/projects/packages/forms/src/dashboard/components/response-view/body.tsx
@@ -490,16 +490,14 @@ const ResponseViewBody = ( {
 									</Tooltip>
 								</td>
 							</tr>
+							{ response.browser && (
+								<tr>
+									<th>{ __( 'Browser:', 'jetpack-forms' ) }&nbsp;</th>
+									<td>{ response.browser }</td>
+								</tr>
+							) }
 						</tbody>
 					</table>
-					{ response.browser && (
-						<div className="jp-forms__inbox-response-meta-label">
-							<span className="jp-forms__inbox-response-meta-key	">
-								{ __( 'Browser:', 'jetpack-forms' ) }&nbsp;
-							</span>
-							<span className="jp-forms__inbox-response-meta-value">{ response.browser }</span>
-						</div>
-					) }
 				</div>
 
 				<div className="jp-forms__inbox-response-data">

--- a/projects/packages/forms/src/types/index.ts
+++ b/projects/packages/forms/src/types/index.ts
@@ -102,6 +102,8 @@ export interface FormResponse {
 	ip: string;
 	/** The country code of the response author. */
 	country_code: string;
+	/** The browser and platform used to submit the form. */
+	browser?: string;
 	/** The title of the form that the response was submitted to. */
 	entry_title: string;
 	/** The permalink of the form that the response was submitted to. */

--- a/projects/packages/forms/tests/php/contact-form/Feedback_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Feedback_Test.php
@@ -361,6 +361,58 @@ class Feedback_Test extends BaseTestCase {
 	}
 
 	/**
+	 * Test the browser information is parsed correctly from user agent.
+	 */
+	public function test_browser_parsing_from_user_agent() {
+
+		$form_id = Utility::get_form_id();
+		// Create a form submission
+		$_post_data = Utility::get_post_request(
+			array(
+				'name'    => 'John Doe',
+				'email'   => 'john@example.com',
+				'message' => 'Test message',
+			),
+			'g' . $form_id
+		);
+
+		$form = new Contact_Form(
+			array(
+				'title'       => 'Test Form',
+				'description' => 'This is a test form.',
+			),
+			"[contact-field label='Name' type='name' required='1'/][contact-field label='Email' type='email' required='1'/][contact-field label='Message' type='textarea' required='1'/]"
+		);
+
+		// Test Chrome Desktop
+		$_SERVER['HTTP_USER_AGENT'] = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.114 Safari/537.36';
+		$response                   = Feedback::from_submission( $_post_data, $form );
+		$browser                    = $response->get_browser();
+		$this->assertStringContainsString( 'Chrome', $browser, 'Browser should be Chrome' );
+		$this->assertStringContainsString( 'Desktop', $browser, 'Platform should be Desktop' );
+
+		// Test Safari Mobile (iPhone)
+		$_SERVER['HTTP_USER_AGENT'] = 'Mozilla/5.0 (iPhone; CPU iPhone OS 14_6 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.0 Mobile/15E148 Safari/604.1';
+		$response                   = Feedback::from_submission( $_post_data, $form );
+		$browser                    = $response->get_browser();
+		$this->assertStringContainsString( 'Safari', $browser, 'Browser should be Safari' );
+		$this->assertStringContainsString( 'Mobile', $browser, 'Platform should be Mobile' );
+
+		// Test Firefox Desktop
+		$_SERVER['HTTP_USER_AGENT'] = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:89.0) Gecko/20100101 Firefox/89.0';
+		$response                   = Feedback::from_submission( $_post_data, $form );
+		$browser                    = $response->get_browser();
+		$this->assertStringContainsString( 'Firefox', $browser, 'Browser should be Firefox' );
+		$this->assertStringContainsString( 'Desktop', $browser, 'Platform should be Desktop' );
+
+		// Test no user agent
+		unset( $_SERVER['HTTP_USER_AGENT'] );
+		$response = Feedback::from_submission( $_post_data, $form );
+		$browser  = $response->get_browser();
+		$this->assertNull( $browser, 'Browser should be null when no user agent' );
+	}
+
+	/**
 	 * Test the subject line is computed for legacy correctly.
 	 */
 	public function test_computed_subject_legacy() {

--- a/projects/plugins/jetpack/changelog/add-form-submission-browser-info
+++ b/projects/plugins/jetpack/changelog/add-form-submission-browser-info
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Forms: add browser info to form responses detail view.

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -1490,13 +1490,14 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/forms",
-                "reference": "21e32e4949421c9c2f8e42131b071f7427ea1f99"
+                "reference": "c45031d4923f1603f53416562ecc426d6082c447"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
                 "automattic/jetpack-assets": "@dev",
                 "automattic/jetpack-blocks": "@dev",
                 "automattic/jetpack-connection": "@dev",
+                "automattic/jetpack-device-detection": "@dev",
                 "automattic/jetpack-external-connections": "@dev",
                 "automattic/jetpack-jwt": "@dev",
                 "automattic/jetpack-logo": "@dev",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Resolves FORMS-352
Part of FORMS-319

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Added browser info to the contact form endpoint
* Display browser name and platform in the response detail view of the forms responses dashboard

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
Before:
<img width="2146" height="497" alt="Screenshot 2025-10-29 at 13 52 19" src="https://github.com/user-attachments/assets/4e131eeb-52c7-4e79-9c16-dc165356d8e8" />

After:
<img width="2134" height="550" alt="Screenshot 2025-10-29 at 13 51 53" src="https://github.com/user-attachments/assets/e41e70df-a891-4c24-b3ad-2441a38b6120" />

* Create a form and submit responses from different browsers and platforms (mobile, desktop, tablet)
* Check that the form response detail view shows the browser you used on submit. 

