### PR TITLE
Update/wpcloud sso sync settings

### DIFF
--- a/projects/plugins/wpcloud-sso/changelog/update-wpcloud-sso-sync-settings
+++ b/projects/plugins/wpcloud-sso/changelog/update-wpcloud-sso-sync-settings
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Update Sync settings to include users and dataset required by A4A.

--- a/projects/plugins/wpcloud-sso/src/class-jetpack-wpcloud-sso.php
+++ b/projects/plugins/wpcloud-sso/src/class-jetpack-wpcloud-sso.php
@@ -41,11 +41,15 @@ class Jetpack_WPCloud_SSO {
 						'url_info' => JETPACK_WPCLOUD_SSO_URI,
 					)
 				);
-				// Sync package.
-				$config->ensure( 'sync', Data_Settings::MUST_SYNC_DATA_SETTINGS );
 
-				// Identity crisis package.
-				$config->ensure( 'identity_crisis' );
+				// Sync package.
+				$must_sync_data = Data_Settings::MUST_SYNC_DATA_SETTINGS;
+				// Add additional modules.
+				$must_sync_data['jetpack_sync_modules'][] = 'Automattic\\Jetpack\\Sync\\Modules\\Plugins';
+				$must_sync_data['jetpack_sync_modules'][] = 'Automattic\\Jetpack\\Sync\\Modules\\Users';
+				$must_sync_data['jetpack_sync_modules'][] = 'Automattic\\Jetpack\\Sync\\Modules\\Meta';
+				$must_sync_data['jetpack_sync_modules'][] = 'Automattic\\Jetpack\\Sync\\Modules\\Stats';
+				$config->ensure( 'sync', $must_sync_data );
 
 				// Read persisistent data and establish connection.
 				if ( class_exists( 'Atomic_Persistent_Data' ) ) {


### PR DESCRIPTION
WPCloud_SSO was initially setup with Default sync settings. This allows for Jetpack SSO to work but it does not allow for user information to be synced to WP.com Cache Site which powers the sites dashboard. 

This PR updates the sync settings to align with A4A which also uses the sites dashboard and should ensure consistent data across functionality.

##Testing instructions:
Testing requires spinning up a WP Cloud Site, WPcom Cache Site, persisting tokens and then applying the WP Cloud SSO plugin to the site and confirming that user data is synced to the cache site. 

## Does this pull request change what data or activity we track or use?
Changes the configuration of Sync to include users, plugins, meta