### PR TITLE
Forms: handle width of single input forms smoother

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-field-errors-style
+++ b/projects/packages/forms/changelog/fix-forms-field-errors-style
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Forms: add "auto" width for fields and detect when a form has a single input in it to show prettier validation errors 

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -106,6 +106,10 @@
 				max-width: 75%;
 			}
 
+			&.jetpack-field__width-auto {
+				flex: 1 1 auto;
+			}
+
 			@media (max-width: #{ (gb.$break-mobile) }) {
 
 				&[class*="jetpack-field__width-"] {

--- a/projects/packages/forms/src/blocks/shared/components/jetpack-field-width.js
+++ b/projects/packages/forms/src/blocks/shared/components/jetpack-field-width.js
@@ -5,7 +5,7 @@ import {
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
-const PERCENTAGE_WIDTHS = [ 25, 33, 50, 75, 100 ];
+const PERCENTAGE_WIDTHS = [ 25, 33, 50, 75, 100, 'auto' ];
 
 export default function JetpackFieldWidth( { setAttributes, width } ) {
 	return (
@@ -29,7 +29,7 @@ export default function JetpackFieldWidth( { setAttributes, width } ) {
 					return (
 						<ToggleGroupControlOption
 							key={ widthValue }
-							label={ `${ widthValue }%` }
+							label={ widthValue === 'auto' ? __( 'Auto', 'jetpack-forms' ) : `${ widthValue }%` }
 							value={ widthValue }
 						/>
 					);

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -694,7 +694,14 @@ class Contact_Form extends Contact_Form_Shortcode {
 			$version
 		);
 
-		$container_classes        = array( 'wp-block-jetpack-contact-form-container' );
+		$is_single_input_form = count( $form->fields ) === 1;
+
+		$container_classes = array( 'wp-block-jetpack-contact-form-container' );
+
+		if ( $is_single_input_form ) {
+			$container_classes[] = 'is-single-input-form';
+		}
+
 		$container_classes[]      = self::get_block_alignment_class( $attributes );
 		$container_classes_string = implode( ' ', $container_classes );
 
@@ -865,7 +872,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 
 			if ( $is_multistep ) {
 				$r = preg_replace( '/<div class="wp-block-jetpack-form-step-navigation__wrapper/', self::render_error_wrapper() . ' <div class="wp-block-jetpack-form-step-navigation__wrapper', $r, 1 );
-			} elseif ( $has_submit_button_block ) {
+			} elseif ( $has_submit_button_block && ! $is_single_input_form ) {
 				// Place the error wrapper before the FIRST button block only to avoid duplicates (e.g., navigation buttons in multistep forms).
 				// Replace only the first occurrence.
 				$r = preg_replace( '/<div class="wp-block-jetpack-button/', self::render_error_wrapper() . ' <div class="wp-block-jetpack-button', $r, 1 );

--- a/projects/packages/forms/src/contact-form/css/grunion.scss
+++ b/projects/packages/forms/src/contact-form/css/grunion.scss
@@ -434,6 +434,10 @@ that needs to mimic the input element styles */
 	max-width: 75%;
 }
 
+.wp-block-jetpack-contact-form .grunion-field-width-auto-wrap {
+	flex: 1 1 auto;
+}
+
 @media only screen and ( max-width: 480px ) {
 
 	.wp-block-jetpack-contact-form .grunion-field-wrap {

--- a/projects/packages/forms/src/contact-form/css/grunion.scss
+++ b/projects/packages/forms/src/contact-form/css/grunion.scss
@@ -1217,12 +1217,18 @@ on production builds, the attributes are being reordered, causing side-effects
 }
 
 .contact-form__input-error.has-errors {
+
 	margin: 0.25rem 0;
 	display: flex;
 	opacity: 1;
 	max-height: unset;
 	transform: translateY(0);
 	transition: opacity 200ms cubic-bezier(0.34, 0.8, 0.34, 1), transform 200ms cubic-bezier(0.34, 0.8, 0.34, 1);
+
+	.is-single-input-form & {
+		position: absolute;
+	}
+
 }
 
 .contact-form [aria-invalid="true"]:not(fieldset),


### PR DESCRIPTION
Part of FORMS-220

## Proposed changes:
This PR adds a new "auto" width setting for the fields and handles the error wrapper when a single input is detected.

<img width="813" height="268" alt="image" src="https://github.com/user-attachments/assets/efc98fe7-a0d6-46c8-99da-ae42e8397009" />

With error:
<img width="804" height="209" alt="image" src="https://github.com/user-attachments/assets/594833c8-1490-4e6a-b58f-aa8f43ea8065" />


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1761753661489339-slack-C052XEUUBL4

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Add a single input on a post, it will spawn a form. Change the field's width so both the field and the submit button are on a single line. See that you can manually accommodate the submit button by using one of the `%` widths on the field, but once you change the button's label, that might come up short (or long). Use the new "auto" width on the field. See that now the field and the submit button fill (between the 2) 100% width of the post.

Try to submit empty, an error below the field should show.

Submit with a valid value, see that even if the submit button changes width (due to spinner being shown) the field reacts to it and the form continues to be in a single line.

cc @ilonagl 