### PR TITLE
Forms: fix iterable key error

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-field-rating-controls-key-error
+++ b/projects/packages/forms/changelog/fix-forms-field-rating-controls-key-error
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: fix a consoler error triggered by iterable without key prop

--- a/projects/packages/forms/src/blocks/field-rating/edit.js
+++ b/projects/packages/forms/src/blocks/field-rating/edit.js
@@ -87,7 +87,7 @@ export default function RatingFieldEdit( props ) {
 					{
 						index: 1,
 						element: (
-							<>
+							<div key="ratingFieldControls">
 								<NumberControl
 									__next40pxDefaultSize
 									__unstableInputWidth="50%"
@@ -107,7 +107,7 @@ export default function RatingFieldEdit( props ) {
 									value={ defaultValue }
 									onChange={ onChangeDefault }
 								/>
-							</>
+							</div>
 						),
 					},
 				] }


### PR DESCRIPTION


## Proposed changes:
This PR fixes an error thrown on console for an iterable control without a `key` prop.

<img width="462" height="234" alt="image" src="https://github.com/user-attachments/assets/8467ed58-1148-4beb-8676-4210f731d3cc" />


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
None

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Without this change, whenever a Rating field is present/inserted on the editor, an error could be seen on the console.

After the change, the console should not show the error anymore.