### PR TITLE
Forms: fix response view table markup

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-response-view-table-markup
+++ b/projects/packages/forms/changelog/fix-forms-response-view-table-markup
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: fix react error due to nesting tr as direct descendant of table, needs tbody

--- a/projects/packages/forms/src/dashboard/components/response-view/body.tsx
+++ b/projects/packages/forms/src/dashboard/components/response-view/body.tsx
@@ -455,40 +455,42 @@ const ResponseViewBody = ( {
 
 				<div className="jp-forms__inbox-response-meta">
 					<table>
-						<tr>
-							<th>{ __( 'Date:', 'jetpack-forms' ) }</th>
-							<td>
-								{ sprintf(
-									/* Translators: %1$s is the date, %2$s is the time. */
-									__( '%1$s at %2$s', 'jetpack-forms' ),
-									dateI18n( getDateSettings().formats.date, response.date ),
-									dateI18n( getDateSettings().formats.time, response.date )
-								) }
-							</td>
-						</tr>
-						<tr>
-							<th>{ __( 'Source:', 'jetpack-forms' ) }</th>
-							<td>
-								<ExternalLink href={ response.entry_permalink }>
-									{ decodeEntities( response.entry_title ) || getPath( response ) }
-								</ExternalLink>
-							</td>
-						</tr>
-						<tr>
-							<th>{ __( 'IP address:', 'jetpack-forms' ) }&nbsp;</th>
-							<td>
-								<Tooltip text={ __( 'Lookup IP address', 'jetpack-forms' ) }>
-									{ response.country_code && (
-										<span className="jp-forms__inbox-response-meta-country-flag response-country-flag">
-											{ getCountryFlagEmoji( response.country_code ) }
-										</span>
+						<tbody>
+							<tr>
+								<th>{ __( 'Date:', 'jetpack-forms' ) }</th>
+								<td>
+									{ sprintf(
+										/* Translators: %1$s is the date, %2$s is the time. */
+										__( '%1$s at %2$s', 'jetpack-forms' ),
+										dateI18n( getDateSettings().formats.date, response.date ),
+										dateI18n( getDateSettings().formats.time, response.date )
 									) }
-									<ExternalLink href={ getRedirectUrl( 'ip-lookup', { path: response.ip } ) }>
-										{ response.ip }
+								</td>
+							</tr>
+							<tr>
+								<th>{ __( 'Source:', 'jetpack-forms' ) }</th>
+								<td>
+									<ExternalLink href={ response.entry_permalink }>
+										{ decodeEntities( response.entry_title ) || getPath( response ) }
 									</ExternalLink>
-								</Tooltip>
-							</td>
-						</tr>
+								</td>
+							</tr>
+							<tr>
+								<th>{ __( 'IP address:', 'jetpack-forms' ) }&nbsp;</th>
+								<td>
+									<Tooltip text={ __( 'Lookup IP address', 'jetpack-forms' ) }>
+										{ response.country_code && (
+											<span className="jp-forms__inbox-response-meta-country-flag response-country-flag">
+												{ getCountryFlagEmoji( response.country_code ) }
+											</span>
+										) }
+										<ExternalLink href={ getRedirectUrl( 'ip-lookup', { path: response.ip } ) }>
+											{ response.ip }
+										</ExternalLink>
+									</Tooltip>
+								</td>
+							</tr>
+						</tbody>
 					</table>
 				</div>
 


### PR DESCRIPTION

Fixes [FORMS-353](https://linear.app/a8c/issue/FORMS-353/table-markup-causes-nesting-error-in-response-view)

## Proposed changes:
This PR wraps the table's `tr` with a `tbody` so react doesn't surface a "nesting" error.
<img width="466" height="331" alt="image" src="https://github.com/user-attachments/assets/39a2f8b9-e4dc-4018-95fd-828feb5fe76c" />


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
None

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Visit forms dashboard and select a response. Prior to this change the error shown on description could be seen. Wrapping the `tr`s with a `tbody` fixes the issue.