### PR TITLE
Forms: explore using native dataviews media display

### DIFF
--- a/projects/packages/forms/changelog/add-forms-native-dataviews-media-display
+++ b/projects/packages/forms/changelog/add-forms-native-dataviews-media-display
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Forms: use DataViews mediaField to display responders avatars

--- a/projects/packages/forms/src/dashboard/components/gravatar/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/gravatar/index.tsx
@@ -5,6 +5,7 @@ import { Hovercards } from '@gravatar-com/hovercards';
 import '@gravatar-com/hovercards/dist/style.css';
 import { useEffect, useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import clsx from 'clsx';
 import { sha256 } from 'js-sha256';
 import './style.scss';
 
@@ -23,6 +24,7 @@ type GravatarProps = {
 	email: string;
 	size?: number;
 	useHovercard?: boolean;
+	isRounded?: boolean;
 };
 
 /**
@@ -40,6 +42,7 @@ export default function Gravatar( {
 	email,
 	size = 48,
 	useHovercard = true,
+	isRounded = true,
 }: GravatarProps ): JSX.Element | null {
 	const profileImageRef = useRef( null );
 	const hovercardRef = useRef( null );
@@ -80,10 +83,14 @@ export default function Gravatar( {
 
 	const hashedEmail = sha256( email );
 
+	const classes = clsx( 'jp-forms__gravatar', {
+		'is-rounded': isRounded,
+	} );
+
 	return (
 		<img
 			alt={ displayName || '' }
-			className="jp-forms__gravatar"
+			className={ classes }
 			ref={ profileImageRef }
 			src={ `https://0.gravatar.com/avatar/${ hashedEmail }?d=${ defaultImage }&name=${ displayName }` }
 			width={ size }

--- a/projects/packages/forms/src/dashboard/components/gravatar/style.scss
+++ b/projects/packages/forms/src/dashboard/components/gravatar/style.scss
@@ -1,6 +1,9 @@
 .jp-forms__gravatar {
 	background-color: var(--jp-gray-5);
-	border-radius: 50%;
 	flex-shrink: 0; // Prevent shrinking when Gravatar is inside flex containers
 	overflow: hidden;
+
+	&.is-rounded {
+		border-radius: 50%;
+	}
 }

--- a/projects/packages/forms/src/dashboard/inbox/dataviews/index.js
+++ b/projects/packages/forms/src/dashboard/inbox/dataviews/index.js
@@ -244,6 +244,25 @@ export default function InboxView() {
 	const fields = useMemo(
 		() => [
 			{
+				id: 'avatar',
+				label: __( 'Avatar', 'jetpack-forms' ),
+				render: ( { item } ) => {
+					return (
+						<img
+							src={ item.author_avatar }
+							alt={ item.author_name }
+							width={ 24 }
+							height={ 24 }
+							style={ { borderRadius: '50%' } }
+						/>
+					);
+				},
+				enableSorting: false,
+				enableHiding: true,
+				globalSearch: false,
+				type: 'media',
+			},
+			{
 				id: 'from',
 				label: __( 'From', 'jetpack-forms' ),
 				render: ( { item } ) => {

--- a/projects/packages/forms/src/dashboard/inbox/dataviews/index.js
+++ b/projects/packages/forms/src/dashboard/inbox/dataviews/index.js
@@ -248,13 +248,7 @@ export default function InboxView() {
 				label: __( 'Avatar', 'jetpack-forms' ),
 				render: ( { item } ) => {
 					return (
-						<img
-							src={ item.author_avatar }
-							alt={ item.author_name }
-							width={ 24 }
-							height={ 24 }
-							style={ { borderRadius: '50%' } }
-						/>
+						<img src={ item.author_avatar } alt={ item.author_name } width={ 24 } height={ 24 } />
 					);
 				},
 				enableSorting: false,

--- a/projects/packages/forms/src/dashboard/inbox/dataviews/index.js
+++ b/projects/packages/forms/src/dashboard/inbox/dataviews/index.js
@@ -247,8 +247,23 @@ export default function InboxView() {
 				id: 'avatar',
 				label: __( 'Avatar', 'jetpack-forms' ),
 				render: ( { item } ) => {
+					const authorInfo = decodeEntities(
+						item.author_name || item.author_email || item.author_url || item.ip
+					);
+					const defaultImage = item.author_name || item.author_email ? 'initials' : 'mp';
+
 					return (
-						<img src={ item.author_avatar } alt={ item.author_name } width={ 24 } height={ 24 } />
+						<>
+							<Gravatar
+								email={ item.author_email || item.ip } // With IP we still return placeholder image
+								defaultImage={ defaultImage }
+								displayName={ authorInfo }
+								key={ item.id }
+								size={ 32 }
+								useHovercard={ false }
+								isRounded={ false }
+							/>
+						</>
 					);
 				},
 				enableSorting: false,
@@ -263,7 +278,6 @@ export default function InboxView() {
 					const authorInfo = decodeEntities(
 						item.author_name || item.author_email || item.author_url || item.ip
 					);
-					const defaultImage = item.author_name || item.author_email ? 'initials' : 'mp';
 					const secondaryInfo =
 						item.author_email && authorInfo !== decodeEntities( item.author_email ) ? (
 							<span className="jp-forms__inbox__author-field__email">
@@ -294,14 +308,6 @@ export default function InboxView() {
 									●
 								</span>
 							) }
-							<Gravatar
-								email={ item.author_email || item.ip } // With IP we still return placeholder image
-								defaultImage={ defaultImage }
-								displayName={ authorInfo }
-								key={ item.id }
-								size={ 32 }
-								useHovercard={ false }
-							/>
 							<div className="jp-forms__inbox__author-info-container">
 								<span className="jp-forms__inbox__author-info">
 									{ wrapperUnread( item.is_unread, authorInfo ) }

--- a/projects/packages/forms/src/dashboard/inbox/dataviews/views.js
+++ b/projects/packages/forms/src/dashboard/inbox/dataviews/views.js
@@ -13,7 +13,9 @@ export const defaultView = {
 	filters: [],
 	page: 1,
 	perPage: 20,
-	fields: [ 'from', 'date', 'source', 'ip' ],
+	fields: [ 'date', 'source', 'ip' ],
+	titleField: 'from',
+	mediaField: 'avatar',
 };
 
 export const defaultLayouts = {

--- a/projects/packages/forms/src/dashboard/inbox/style.scss
+++ b/projects/packages/forms/src/dashboard/inbox/style.scss
@@ -303,6 +303,12 @@
 		@media (min-width: 782px) {
 			border-right: 1px solid var(--jp-gray-5);
 		}
+
+		// Override DataViews default max-width for media in primary column
+		// to better fit smaller avatars (24x24 instead of larger preview images)
+		.dataviews-column-primary__media {
+			max-width: 32px;
+		}
 	}
 
 	.dataviews-footer {

--- a/projects/packages/forms/src/dashboard/inbox/style.scss
+++ b/projects/packages/forms/src/dashboard/inbox/style.scss
@@ -357,7 +357,8 @@
 		color: #d63638;
 		font-size: 8px;
 		position: absolute;
-		left: -12px;
+		left: -10px;
+		top: 5px;
 		cursor: pointer;
 	}
 }


### PR DESCRIPTION
Part of FORMS-334
Resolves FORMS-397

## Proposed changes:
This PR is an exploration to set up DataViews and make use of the mediaField prop to show avatars.

It does carry some minimal style override, which we're trying not to, but it was the only way to have play nice with the list.

<img width="902" height="352" alt="image" src="https://github.com/user-attachments/assets/45f4f096-3979-48fb-9b3c-bb0c43b70fbf" />

<img width="375" height="560" alt="image" src="https://github.com/user-attachments/assets/3f745d6a-f44c-4cf1-ac13-a17e1b987547" />

<img width="905" height="342" alt="image" src="https://github.com/user-attachments/assets/b5aef2e2-744a-42c7-9494-0301531a89d0" />


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1761739561258309-slack-C052XEUUBL4

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Visit the Forms dashboard. See the new avatars implementation. Use the view cog to hide/show the avatar.