### PR TITLE
Enable WordPress-controlled CSS loading for Instant Search

### DIFF
--- a/projects/packages/search/changelog/add-wordpress-css-control-for-instant-search
+++ b/projects/packages/search/changelog/add-wordpress-css-control-for-instant-search
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Changed css to be loaded by WordPress

--- a/projects/packages/search/src/instant-search/class-instant-search.php
+++ b/projects/packages/search/src/instant-search/class-instant-search.php
@@ -112,9 +112,12 @@ class Instant_Search extends Classic_Search {
 			'build/instant-search/jp-search.js',
 			$package_base_path . '/src', // A full path to a file or a directory inside a plugin.
 			array(
-				'dependencies' => array( 'wp-i18n' ),
-				'in_footer'    => true,
-				'textdomain'   => 'jetpack-search-pkg',
+				'dependencies'     => array( 'wp-i18n' ),
+				'in_footer'        => true,
+				'textdomain'       => 'jetpack-search-pkg',
+				// CSS is extracted by webpack but not auto-injected, allowing WordPress to control loading
+				'css_path'         => 'build/instant-search/jp-search.chunk-main-payload.css',
+				'css_dependencies' => array(),
 			)
 		);
 		Assets::enqueue_script( 'jetpack-instant-search' );

--- a/projects/packages/search/tools/webpack.instant.config.js
+++ b/projects/packages/search/tools/webpack.instant.config.js
@@ -64,6 +64,17 @@ module.exports = {
 				requestToExternal,
 				requestToHandle: defaultRequestToHandle,
 			},
+			// Configure MiniCssExtractPlugin for WordPress Interactivity API compatibility
+			// Use static filenames so WordPress can enqueue the same URL
+			MiniCssExtractPlugin: {
+				filename: '[name].css',
+				chunkFilename: '[name].css', // No contenthash - WordPress handles versioning
+				// Disable runtime CSS loading - WordPress will enqueue it
+				runtime: false,
+			},
+			// Disable MiniCssWithRtlPlugin since we're not using webpack CSS runtime
+			// WordPress will handle RTL CSS loading
+			MiniCssWithRtlPlugin: false,
 		} ),
 		// Replace 'debug' module with a dummy implementation in production
 		...( jetpackWebpackConfig.isDevelopment


### PR DESCRIPTION
## Proposed changes:
<!-- Explain what functional changes your PR includes -->

This PR modifies the Instant Search build configuration to make it compatible with the WordPress Interactivity API by allowing WordPress to control CSS loading instead of webpack's automatic injection.

**Changes:**
* Configure MiniCssExtractPlugin to use static filenames without contenthash
* Disable webpack CSS runtime loading (`runtime: false`)
* Disable MiniCssWithRtlPlugin (WordPress Assets class handles RTL detection)
* Add `css_path` parameter to `Assets::register_script()` to enqueue CSS via  WordPress

**Why these changes?**

The WordPress Interactivity API requires CSS to be properly enqueued in the  `<head>` before JavaScript hydration occurs. Previously, webpack was dynamically   injecting CSS when the async chunk loaded, which:

2. Created timing issues with Interactivity API hydration
3. Wasn't following WordPress plugin best practices for asset loading

Now CSS is:
* Extracted by webpack to a static filename (`jp-search.chunk-main-payload.css`)
* Enqueued by WordPress with proper versioning (`?ver=<ver>`)
* Loaded in `<head>` before any JavaScript executes
* No longer auto-injected by webpack

### Other information:

- [x] Have you written new tests for your changes, if applicable? - *No new   tests needed; existing functionality maintained with different loading   mechanism*
- [ ] Have you checked the E2E test CI results, and verified that your changes  do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so,  you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with  Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed  upon -->
p1753090979383509-slack-C02ME06LF

## Does this pull request change what data or activity we track or use?
No, this PR only changes how CSS assets are loaded. No tracking or data collection changes.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be  presented? -->
<!-- Please include detailed testing steps, explaining how to test your change.  -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR  as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is  visual. -->

### Prerequisites
* Jetpack local dev env
* Instant Search enabled

### Testing Steps

1. **Build the assets:**
```bash
cd projects/packages/search
pnpm run build-instant
```

2. Verify CSS files are generated without contenthash:
```bash
ls -la build/instant-search/*.css
```

2. You should see:
  - `jp-search.chunk-main-payload.css`
  - `jp-search.chunk-main-payload.rtl.css`
(No version hash in the filename itself)

3. Check that webpack doesn't include CSS loading runtime:
`grep -c "miniCssF" build/instant-search/jp-search.js`

3. Should return 0 (no CSS loading code)

5. Test in WordPress:
  - Activate Jetpack Search with Instant Search enabled
  - Load a page with the search overlay
  - Open browser DevTools

6. Verify CSS loading:
  - Network tab: Look for `jp-search.chunk-main-payload.css`
  - Should be loaded from WordPress (check URL includes ?ver=<xxx>)
  - Should only load once (no duplicate requests)

7. Verify in page source:
  - View page source (Cmd/Ctrl + U)
  - Search for `jp-search.chunk-main-payload.css`
  - Should appear in <head> as a <link> tag enqueued by WordPress
  - Should NOT be added dynamically by JavaScript

8. Test build artifacts:
  - Check that no CSS loading errors appear in console
  - Verify dynamic chunk (`jp-search.chunk-main-payload.js`) loads successfully
  - Confirm search functionality works identically to before