### PR TITLE
WooCommerce Analytics: Enable ClickHouse tracking by default to send all front-end data to both ClickHouse and Nosara

### DIFF
--- a/projects/packages/woocommerce-analytics/changelog/wooa7s-612-send-all-front-end-data-to-both-clickhouse-and-nosara
+++ b/projects/packages/woocommerce-analytics/changelog/wooa7s-612-send-all-front-end-data-to-both-clickhouse-and-nosara
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Enable ClickHouse by default

--- a/projects/packages/woocommerce-analytics/src/class-features.php
+++ b/projects/packages/woocommerce-analytics/src/class-features.php
@@ -43,6 +43,6 @@ class Features {
 		 *
 		 * @param bool $enabled Whether ClickHouse event tracking is enabled.
 		 */
-		return apply_filters( 'woocommerce_analytics_clickhouse_enabled', false );
+		return apply_filters( 'woocommerce_analytics_clickhouse_enabled', true );
 	}
 }


### PR DESCRIPTION
Fixes WOOA7S-612

pfKYZu-2ZQ-p2#comment-3109

## Proposed changes:

* Enable ClickHouse tracking by default in WooCommerce Analytics to send all front-end data to both ClickHouse and Nosara simultaneously

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
No, this PR does not change what data is tracked. It only changes where the existing front-end analytics data is sent - now going to both ClickHouse and Nosara instead of just Nosara.

## Testing instructions:

* Install WooCommerce on a test site with Jetpack connected
* Deactivate WooCommerce Analytics plugin if it’s active
* Open developer tools > network tab
* Go to site’s front-end
* Verify that events are being sent to both ClickHouse and Nosara/Tracks (both `t.gif` and `w.gif` requests should be present with `ch` parameter in the URL)


🤖 Generated with [Claude Code](https://claude.com/claude-code)