### PR TITLE
Jetpack Sync: Only enqueue a single HPOS order save event per request

### DIFF
--- a/projects/packages/sync/changelog/update-sync-hpos-orders
+++ b/projects/packages/sync/changelog/update-sync-hpos-orders
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Jetpack Sync: Only enqueue a single HPOS order save event per request

--- a/projects/packages/sync/src/modules/class-woocommerce-hpos-orders.php
+++ b/projects/packages/sync/src/modules/class-woocommerce-hpos-orders.php
@@ -119,7 +119,7 @@ class WooCommerce_HPOS_Orders extends Module {
 	public function init_listeners( $callable ) {
 		foreach ( self::get_order_types_to_sync() as $type ) {
 			add_action( "woocommerce_after_{$type}_object_save", $callable );
-			add_filter( "jetpack_sync_before_enqueue_woocommerce_after_{$type}_object_save", array( $this, 'expand_order_object' ) );
+			add_filter( "jetpack_sync_before_enqueue_woocommerce_after_{$type}_object_save", array( $this, 'on_before_enqueue_order_save' ) );
 		}
 		add_action( 'woocommerce_delete_order', $callable );
 		add_action( 'woocommerce_delete_subscription', $callable );
@@ -148,6 +148,10 @@ class WooCommerce_HPOS_Orders extends Module {
 	 * @access public
 	 */
 	public function init_before_send() {
+		// Incremental Sync
+		foreach ( self::get_order_types_to_sync() as $type ) {
+			add_filter( "jetpack_sync_before_send_woocommerce_after_{$type}_object_save", array( $this, 'expand_order_object' ) );
+		}
 		// Full sync.
 		add_filter( 'jetpack_sync_before_send_jetpack_full_sync_woocommerce_hpos_orders', array( $this, 'build_full_sync_action_array' ) );
 	}
@@ -263,15 +267,32 @@ class WooCommerce_HPOS_Orders extends Module {
 	}
 
 	/**
+	 * Retrieve filtered order data before sending.
+	 *
+	 * @access public
+	 *
+	 * @param \WC_Abstract_Order $order_object The order object.
+	 *
+	 * @return array
+	 */
+	public function expand_order_object( $order_object ) {
+
+		return $this->filter_order_data( $order_object );
+	}
+
+	/**
 	 * Retrieve order data by its ID.
 	 *
 	 * @access public
 	 *
 	 * @param array $args Order ID.
 	 *
-	 * @return array
+	 * @return \WC_Abstract_Order|false
 	 */
-	public function expand_order_object( $args ) {
+	public function on_before_enqueue_order_save( $args ) {
+		// Prevent multiple triggers on a single request.
+		static $processed = array();
+
 		if ( ! is_array( $args ) || ! isset( $args[0] ) ) {
 			return false;
 		}
@@ -285,7 +306,13 @@ class WooCommerce_HPOS_Orders extends Module {
 			return false;
 		}
 
-		return $this->filter_order_data( $order_object );
+		if ( isset( $processed[ $order_object->id ] ) ) {
+			return false;
+		}
+
+		$processed[ $order_object->id ] = true;
+
+		return $order_object;
 	}
 
 	/**

--- a/projects/packages/sync/src/modules/class-woocommerce-hpos-orders.php
+++ b/projects/packages/sync/src/modules/class-woocommerce-hpos-orders.php
@@ -271,11 +271,20 @@ class WooCommerce_HPOS_Orders extends Module {
 	 *
 	 * @access public
 	 *
-	 * @param \WC_Abstract_Order $order_object The order object.
+	 * @param array $args An array with order data.
 	 *
-	 * @return array
+	 * @return array|false
 	 */
-	public function expand_order_object( $order_object ) {
+	public function expand_order_object( $args ) {
+		if ( empty( $args['id'] ) ) {
+			return false;
+		}
+
+		$order_object = wc_get_order( $args['id'] );
+
+		if ( ! $order_object instanceof \WC_Abstract_Order ) {
+			return false;
+		}
 
 		return $this->filter_order_data( $order_object );
 	}
@@ -312,7 +321,7 @@ class WooCommerce_HPOS_Orders extends Module {
 
 		$processed[ $order_object->id ] = true;
 
-		return $order_object;
+		return array( 'id' => $order_object->id );
 	}
 
 	/**

--- a/projects/packages/sync/src/modules/class-woocommerce-hpos-orders.php
+++ b/projects/packages/sync/src/modules/class-woocommerce-hpos-orders.php
@@ -296,7 +296,7 @@ class WooCommerce_HPOS_Orders extends Module {
 	 *
 	 * @param array $args Order ID.
 	 *
-	 * @return \WC_Abstract_Order|false
+	 * @return array|false
 	 */
 	public function on_before_enqueue_order_save( $args ) {
 		// Prevent multiple triggers on a single request.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Closes SYNC-143
Fixes https://github.com/Automattic/jetpack/issues/39068

Prevent `woocommerce_after_{$type}_object_save` from running multiple times in a single request and ensure we send the most "fresh" version of the corresponding order that fired the hook by expanding it before sending (vs before enqueuing).

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* `Automattic\Jetpack\Sync\Modules\WooCommerce_HPOS_Orders`: Introduce `on_before_enqueue_order_save` to run before we add a `woocommerce_after_{$type}_object_save` action in Sync's queue.
* `Automattic\Jetpack\Sync\Modules\WooCommerce_HPOS_Orders`: Update `expand_order_object` method and run it before we send a `woocommerce_after_{$type}_object_save` action to WPCOM

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
See SYNC-143

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Pre-requisites: A JP connected site with Jetpack, WooCommerce and WooCommerce Subscriptions plugins active.

* Creating and updating orders should work exactly as before. Try the following scenarios and ensure the changes are persisted by checking the corresponding Cache site tables on WPCOM - checkout these test instructions for details: D154441-code:
- Create a new order
- Update various core order fields and meta we care about: Order dates, order status, price, address and billing info etc
- Refund an order
- Create a new subscription
- Update a subscription
- Updating the order status
- Introducing a custom order status and updating an order with it. You can use the Code Snippets plugin to add:
```
function register_shipment_arrival_order_status() {
   register_post_status( 'wc-arrival-shipment', array(
       'label'                     => 'Shipment Arrival',
       'public'                    => true,
       'show_in_admin_status_list' => true,
       'show_in_admin_all_list'    => true,
       'exclude_from_search'       => true,
       'label_count'               => _n_noop( 'Shipment Arrival <span class="count">(%s)</span>', 'Shipment Arrival <span class="count">(%s)</span>' )
   ) );
}
add_action( 'init', 'register_shipment_arrival_order_status' );

function add_awaiting_shipment_to_order_statuses( $order_statuses ) {
   $order_statuses['wc-arrival-shipment'] = 'Shipment Arrival';
   return $order_statuses;
}
add_filter( 'wc_order_statuses', 'add_awaiting_shipment_to_order_statuses' );
```
- Confirm it fixes https://github.com/Automattic/jetpack/issues/39068

Finally lets test an edge case where we already have `woocommerce_after_order_object_save` in the queue:
- Switch to trunk
- Sabotage the sending of any Sync actions by returning an error in `do_sync_and_set_delays`, eg add  `return new WP_Error( 'dummy' );` [here](https://github.com/Automattic/jetpack/blob/c171fd42e40edf4045721ea69cd6969b6042c22b/projects/packages/sync/src/class-sender.php#L449)
- Create a new order and update it
- Now switch to the current branch and remove the error to enable sending again
- Confirm the changes are persisted by checking the corresponding Cache site tables on WPCOM
- Confirm no fatals/warnings on both ends (WPCOM and local site)