### PR TITLE
Forms: support autocomplete attribute

### DIFF
--- a/projects/packages/forms/changelog/update-forms-autocomplete-attr
+++ b/projects/packages/forms/changelog/update-forms-autocomplete-attr
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Forms: support 'autocomplete' attributes

--- a/projects/packages/forms/src/blocks/field-date/index.js
+++ b/projects/packages/forms/src/blocks/field-date/index.js
@@ -37,6 +37,19 @@ const settings = {
 	},
 	deprecated,
 	save,
+	variations: [
+		{
+			name: 'field-birthdate',
+			title: __( 'Birthdate', 'jetpack-forms' ),
+			description: __( 'Capture age with a date picker.', 'jetpack-forms' ),
+			attributes: {
+				// https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/autocomplete#bday
+				autocomplete: 'bday',
+			},
+			isActive: ( blockAttributes, variationAttributes ) =>
+				blockAttributes.autocomplete === variationAttributes.autocomplete,
+		},
+	],
 	example: {
 		innerBlocks: [
 			{

--- a/projects/packages/forms/src/blocks/field-number/edit.js
+++ b/projects/packages/forms/src/blocks/field-number/edit.js
@@ -10,6 +10,7 @@ export default function NumberFieldEdit( props ) {
 			clientId={ props.clientId }
 			type="number"
 			label={ __( 'Number', 'jetpack-forms' ) }
+			autocomplete={ props.attributes.autocomplete }
 			required={ props.attributes.required }
 			requiredText={ props.attributes.requiredText }
 			requiredIndicator={ props.attributes.requiredIndicator }

--- a/projects/packages/forms/src/blocks/field-telephone/edit.js
+++ b/projects/packages/forms/src/blocks/field-telephone/edit.js
@@ -32,6 +32,7 @@ const isBoolean = value => {
 export default function PhoneFieldEdit( props ) {
 	const { setAttributes, attributes, clientId, isSelected } = props;
 	const {
+		autocomplete,
 		showCountrySelector,
 		width,
 		id,
@@ -141,6 +142,7 @@ export default function PhoneFieldEdit( props ) {
 			</BlockControls>
 
 			<JetpackFieldControls
+				autocomplete={ autocomplete }
 				clientId={ clientId }
 				id={ id }
 				required={ required }

--- a/projects/packages/forms/src/blocks/field-text/edit.js
+++ b/projects/packages/forms/src/blocks/field-text/edit.js
@@ -10,6 +10,7 @@ export default function TextFieldEdit( props ) {
 			clientId={ props.clientId }
 			type="text"
 			label={ __( 'Text', 'jetpack-forms' ) }
+			autocomplete={ props.attributes.autocomplete }
 			required={ props.attributes.required }
 			requiredText={ props.attributes.requiredText }
 			requiredIndicator={ props.attributes.requiredIndicator }

--- a/projects/packages/forms/src/blocks/field-textarea/edit.js
+++ b/projects/packages/forms/src/blocks/field-textarea/edit.js
@@ -11,7 +11,7 @@ import { ALLOWED_INNER_BLOCKS } from '../shared/util/constants.js';
 
 export default function TextareaFieldEdit( props ) {
 	const { attributes, clientId, isSelected, setAttributes } = props;
-	const { id, required, width, requiredIndicator } = attributes;
+	const { id, required, width, requiredIndicator, autocomplete } = attributes;
 
 	useFormWrapper( props );
 	const { blockStyle } = useJetpackFieldStyles( attributes );
@@ -49,6 +49,7 @@ export default function TextareaFieldEdit( props ) {
 		<>
 			<div { ...innerBlocksProps } />
 			<JetpackFieldControls
+				autocomplete={ autocomplete }
 				id={ id }
 				required={ required }
 				setAttributes={ setAttributes }

--- a/projects/packages/forms/src/blocks/field-time/edit.js
+++ b/projects/packages/forms/src/blocks/field-time/edit.js
@@ -10,6 +10,7 @@ export default function NumberFieldEdit( props ) {
 			clientId={ props.clientId }
 			type="time"
 			label={ __( 'Time', 'jetpack-forms' ) }
+			autocomplete={ props.attributes.autocomplete }
 			required={ props.attributes.required }
 			requiredText={ props.attributes.requiredText }
 			requiredIndicator={ props.attributes.requiredIndicator }

--- a/projects/packages/forms/src/blocks/field-url/edit.js
+++ b/projects/packages/forms/src/blocks/field-url/edit.js
@@ -10,6 +10,7 @@ export default function UrlFieldEdit( props ) {
 			clientId={ props.clientId }
 			type="url"
 			label={ __( 'Website', 'jetpack-forms' ) }
+			autocomplete={ props.attributes.autocomplete }
 			required={ props.attributes.required }
 			requiredText={ props.attributes.requiredText }
 			requiredIndicator={ props.attributes.requiredIndicator }

--- a/projects/packages/forms/src/blocks/shared/components/jetpack-field-controls.js
+++ b/projects/packages/forms/src/blocks/shared/components/jetpack-field-controls.js
@@ -3,7 +3,13 @@ import {
 	InspectorControls,
 	BlockControls,
 } from '@wordpress/block-editor';
-import { PanelBody, TextControl, ToggleControl } from '@wordpress/components';
+import {
+	ExternalLink,
+	PanelBody,
+	SelectControl,
+	TextControl,
+	ToggleControl,
+} from '@wordpress/components';
 import { isValidElement, useState } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import JetpackFieldWidth from './jetpack-field-width.js';
@@ -25,6 +31,7 @@ const reservedAttributes = [
 
 const JetpackFieldControls = ( {
 	attributes,
+	autocomplete,
 	id,
 	required,
 	setAttributes,
@@ -141,6 +148,113 @@ const JetpackFieldControls = ( {
 					help={ errorState.error ? errorState.message : helpMessage }
 					__nextHasNoMarginBottom={ true }
 					__next40pxDefaultSize={ true }
+				/>
+				<SelectControl
+					label={ __( 'Autocomplete', 'jetpack-forms' ) }
+					value={ autocomplete || '' }
+					onChange={ value => setAttributes( { autocomplete: value } ) }
+					help={
+						<>
+							{ __( 'Guidance to the browser for autocompleting the form.', 'jetpack-forms' ) }
+							<br />
+							<ExternalLink href="https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/autocomplete">
+								{ __( 'Read more', 'jetpack-forms' ) }
+							</ExternalLink>
+						</>
+					}
+					// See https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/autocomplete
+					options={ [
+						{
+							label: __( 'Default', 'jetpack-forms' ),
+							value: '',
+						},
+						{
+							label: __( 'Off', 'jetpack-forms' ),
+							value: 'off',
+						},
+						{
+							label: __( 'Telephone', 'jetpack-forms' ),
+							value: 'tel',
+						},
+						{
+							label: __( 'Full name', 'jetpack-forms' ),
+							value: 'name',
+						},
+						{
+							label: __( 'First name', 'jetpack-forms' ),
+							value: 'given-name',
+						},
+						{
+							label: __( 'Middle name', 'jetpack-forms' ),
+							value: 'additional-name',
+						},
+						{
+							label: __( 'The last name', 'jetpack-forms' ),
+							value: 'family-name',
+						},
+						{
+							label: __( 'The honorific prefix ("Mrs.", etc)', 'jetpack-forms' ),
+							value: 'honorific-prefix',
+						},
+						{
+							label: __( 'The honorific suffix ("Jr." etc)', 'jetpack-forms' ),
+							value: 'honorific-suffix',
+						},
+						{
+							label: __( 'A nickname', 'jetpack-forms' ),
+							value: 'nickname',
+						},
+						{
+							label: __( 'A username', 'jetpack-forms' ),
+							value: 'username',
+						},
+						{
+							label: __( 'A job title', 'jetpack-forms' ),
+							value: 'organization-title',
+						},
+						{
+							label: __( 'A company or organization name', 'jetpack-forms' ),
+							value: 'organization',
+						},
+						{
+							label: __( 'A street address', 'jetpack-forms' ),
+							value: 'street-address',
+						},
+						{
+							label: __( 'A country code', 'jetpack-forms' ),
+							value: 'country',
+						},
+						{
+							label: __( 'A country name', 'jetpack-forms' ),
+							value: 'country-name',
+						},
+						{
+							label: __( 'A postal code or ZIP code', 'jetpack-forms' ),
+							value: 'postal-code',
+						},
+						{
+							label: __( 'Currency', 'jetpack-forms' ),
+							value: 'transaction-currency',
+						},
+						{
+							label: __( 'A preferred language', 'jetpack-forms' ),
+							value: 'language',
+						},
+						{
+							label: __( 'A birth date', 'jetpack-forms' ),
+							value: 'bday',
+						},
+						{
+							label: __( 'A gender identity (e.g. "Female")', 'jetpack-forms' ),
+							value: 'sex',
+						},
+						{
+							label: __( 'A URL', 'jetpack-forms' ),
+							value: 'url',
+						},
+					] }
+					__next40pxDefaultSize
+					__nextHasNoMarginBottom
 				/>
 			</InspectorAdvancedControls>
 		</>

--- a/projects/packages/forms/src/blocks/shared/components/jetpack-field.js
+++ b/projects/packages/forms/src/blocks/shared/components/jetpack-field.js
@@ -12,6 +12,7 @@ import JetpackFieldControls from './jetpack-field-controls.js';
 const JetpackField = props => {
 	const {
 		attributes,
+		autocomplete,
 		clientId,
 		id,
 		isSelected,
@@ -57,6 +58,7 @@ const JetpackField = props => {
 		<>
 			<div { ...innerBlocksProps } />
 			<JetpackFieldControls
+				autocomplete={ autocomplete }
 				id={ id }
 				required={ required }
 				width={ width }

--- a/projects/packages/forms/src/blocks/shared/settings/index.js
+++ b/projects/packages/forms/src/blocks/shared/settings/index.js
@@ -4,6 +4,7 @@ export default {
 	apiVersion: 3,
 	attributes: {
 		id: { type: 'string' },
+		autocomplete: { type: 'string', default: '' },
 		required: {
 			type: 'boolean',
 			default: false,

--- a/projects/plugins/jetpack/changelog/update-forms-autocomplete-attr
+++ b/projects/plugins/jetpack/changelog/update-forms-autocomplete-attr
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Forms: support 'autocomplete' browser guidance attributes.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

WIP

Autocompletion in browsers picks on English language pretty well — none of these inputs had `autocomplete` guidance but it still works:

<img width="709" height="365" alt="image" src="https://github.com/user-attachments/assets/2fa65251-ff37-4b0b-9350-5d182152f2ab" />


Once you translate them though, it stops working:

<img width="704" height="370" alt="Screenshot 2025-10-30 at 18 44 57" src="https://github.com/user-attachments/assets/4eaf45bc-4f44-48fc-b06d-618d2f6ce5e8" />

Until you add `autocomplete` guidance, then it works again:

<img width="721" height="373" alt="Screenshot 2025-10-30 at 18 44 49" src="https://github.com/user-attachments/assets/78463b33-4f70-4c05-873b-d512ea18fa2f" />


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Supports `autocomplete` attribute ([doc](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/autocomplete)) in each field
* Adds "birthday" variation of date picker, essentially just setting autocomplete correctly. We can use 
* 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

