### PR TITLE
Help Center: Create wp-admin help center menu panel

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/DOTCOM-15054-show-the-help-menu-in-wp-admin-and-the-editor
+++ b/projects/packages/jetpack-mu-wpcom/changelog/DOTCOM-15054-show-the-help-menu-in-wp-admin-and-the-editor
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Help Center: Add menu panel for experiment in wp-admin and editor

--- a/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-help-center-menu-panel.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-help-center-menu-panel.php
@@ -1,0 +1,131 @@
+<?php
+/**
+ * Help Center Menu Panel
+ *
+ * @package automattic/jetpack-mu-wpcom
+ */
+
+namespace A8C\FSE;
+
+/**
+ * Class Help_Center_Menu_Panel
+ *
+ * Handles the help center menu panel functionality in the admin bar.
+ *
+ * @since $$next-version$$
+ */
+class Help_Center_Menu_Panel {
+
+	/**
+	 * Check if the help center menu panel should be displayed.
+	 *
+	 * @return bool True if the menu panel should be displayed.
+	 */
+	public static function should_display_menu_panel() {
+		// Only add the help center menu panel if the flags parameter is present
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended
+		return isset( $_GET['flags'] ) && strpos( sanitize_text_field( wp_unslash( $_GET['flags'] ) ), 'help-center-menu-panel' ) !== false;
+		// phpcs:enable WordPress.Security.NonceVerification.Recommended
+	}
+
+	/**
+	 * Add the help center menu panel to the admin bar.
+	 *
+	 * @param \WP_Admin_Bar $wp_admin_bar The WP_Admin_Bar instance.
+	 */
+	public static function add_menu_panel( $wp_admin_bar ) {
+		if ( ! self::should_display_menu_panel() ) {
+			return;
+		}
+
+		// Add chat support group
+		$wp_admin_bar->add_group(
+			array(
+				'parent' => 'help-center',
+				'id'     => 'help-center-menu-panel-chat',
+				'meta'   => array(
+					'class' => 'ab-sub-secondary',
+				),
+			)
+		);
+
+		// Add chat support menu item
+		$wp_admin_bar->add_node(
+			array(
+				'parent' => 'help-center-menu-panel-chat',
+				'id'     => 'help-center-chat-support',
+				'title'  => __( 'Chat support', 'jetpack-mu-wpcom' ),
+			)
+		);
+
+		// Add chat history menu item
+		$wp_admin_bar->add_node(
+			array(
+				'parent' => 'help-center-menu-panel-chat',
+				'id'     => 'help-center-chat-history',
+				'title'  => __( 'Chat history', 'jetpack-mu-wpcom' ),
+			)
+		);
+
+		// Add links group
+		$wp_admin_bar->add_group(
+			array(
+				'parent' => 'help-center',
+				'id'     => 'help-center-menu-panel-links',
+				'meta'   => array(
+					'class' => 'ab-sub-secondary',
+				),
+			)
+		);
+
+		// Add support guides menu item
+		$wp_admin_bar->add_node(
+			array(
+				'parent' => 'help-center-menu-panel-links',
+				'id'     => 'help-center-support-guides',
+				'title'  => __( 'Support guides', 'jetpack-mu-wpcom' ),
+			)
+		);
+
+		// Add courses menu item
+		$wp_admin_bar->add_node(
+			array(
+				'parent' => 'help-center-menu-panel-links',
+				'id'     => 'help-center-courses',
+				'title'  => __( 'Courses', 'jetpack-mu-wpcom' ),
+				'href'   => 'https://wordpress.com/support/courses/',
+				'meta'   => array(
+					'target' => '_blank',
+				),
+			)
+		);
+
+		// Add product updates menu item
+		$wp_admin_bar->add_node(
+			array(
+				'parent' => 'help-center-menu-panel-links',
+				'id'     => 'help-center-product-updates',
+				'title'  => __( 'Product updates', 'jetpack-mu-wpcom' ),
+				'href'   => 'https://wordpress.com/blog/category/product-features/',
+				'meta'   => array(
+					'target' => '_blank',
+				),
+			)
+		);
+	}
+
+	/**
+	 * Initialize the help center menu panel.
+	 *
+	 * @param string $variant The variant of the help center being loaded.
+	 */
+	public static function init( $variant ) {
+		if ( $variant === 'wp-admin' || $variant === 'wp-admin-disconnected' ) {
+			add_action(
+				'admin_bar_menu',
+				array( __CLASS__, 'add_menu_panel' ),
+				12
+			);
+		}
+	}
+}

--- a/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-help-center.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-help-center.php
@@ -204,6 +204,10 @@ class Help_Center {
 				// Add the help center icon to the admin bar after the reader icon.
 				12
 			);
+
+			// Initialize the help center menu panel
+			require_once __DIR__ . '/class-help-center-menu-panel.php';
+			Help_Center_Menu_Panel::init( $variant );
 		}
 
 		if ( $variant !== 'wp-admin-disconnected' && $variant !== 'gutenberg-disconnected' ) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://linear.app/a8c/issue/dotcom-15054/show-the-help-menu-in-wp-admin-and-the-editor

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

We need to run [this](https://linear.app/a8c/project/help-menu-in-wordpresscom-experiment-76975bd2e7e7/overview) experiment for the Help Center: showing a help menu panel instead of directly the Help Center

<img width="613" height="377" alt="image" src="https://github.com/user-attachments/assets/4cd48761-873d-40cf-b57d-ddc0e7521d8f" />


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Check sun/moon
* `jetpack rsync mu-wpcom-plugin [your-sandbox]:~/public_html/wp-content/mu-plugins/jetpack-mu-wpcom-plugin/[sun or moon]
* Follow the WP-ADMIN instructions [here](https://github.com/Automattic/wp-calypso/pull/106831)

