### PR TITLE
Shortcodes: fix JS error in presentation shortcode

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-presentation-shortcode
+++ b/projects/plugins/jetpack/changelog/fix-presentation-shortcode
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Shortcodes: fix JS error in presentation shortcode.

--- a/projects/plugins/jetpack/modules/shortcodes/js/main.js
+++ b/projects/plugins/jetpack/modules/shortcodes/js/main.js
@@ -251,8 +251,8 @@
 	} );
 
 	$( document ).ready( function () {
-		$( '.presentation-wrapper' ).each( function () {
-			new Presentation( this );
-		} );
+		[ ...document.getElementsByClassName( 'presentation-wrapper' ) ].forEach(
+			el => new Presentation( el )
+		);
 	} );
 } )( jQuery );

--- a/projects/plugins/jetpack/modules/shortcodes/js/main.js
+++ b/projects/plugins/jetpack/modules/shortcodes/js/main.js
@@ -251,7 +251,7 @@
 	} );
 
 	$( document ).ready( function () {
-		$( '.presentation-wrapper' ).forEach( function () {
+		$( '.presentation-wrapper' ).each( function () {
 			new Presentation( this );
 		} );
 	} );

--- a/projects/plugins/jetpack/modules/shortcodes/js/main.js
+++ b/projects/plugins/jetpack/modules/shortcodes/js/main.js
@@ -250,7 +250,7 @@
 		},
 	} );
 
-	$( document ).ready( function () {
+	addEventListener( 'DOMContentLoaded', () => {
 		[ ...document.getElementsByClassName( 'presentation-wrapper' ) ].forEach(
 			el => new Presentation( el )
 		);

--- a/projects/plugins/jetpack/modules/shortcodes/js/main.js
+++ b/projects/plugins/jetpack/modules/shortcodes/js/main.js
@@ -251,8 +251,8 @@
 	} );
 
 	addEventListener( 'DOMContentLoaded', () => {
-		[ ...document.getElementsByClassName( 'presentation-wrapper' ) ].forEach(
-			el => new Presentation( el )
-		);
+		document.querySelectorAll( '.presentation-wrapper' ).forEach( el => {
+			new Presentation( el );
+		} );
 	} );
 } )( jQuery );


### PR DESCRIPTION
## Proposed changes:
Presentation shortcode was broken by [this change](https://github.com/Automattic/jetpack/pull/40503/files#diff-ba0eb0c965a6f9e7aed3767d672388ae12ae02ba5077acaf95d7924a8156ea5aL254), now it fails to render and triggers a JS error.
This PR fixes the JS error, making it work again.
We also rewrite this part in VanillaJS while we're at it.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
https://linear.app/a8c/issue/VULCAN-23

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
1. Connection Jetpack.
2. Go to Post Edit, and use "Shortcode" block to create a presentation:
```
[presentation bgimg="https://jetpack.com/wp-content/uploads/2025/01/jetpack1392x886.jpg"]
[slide]Hello World[/slide]
[slide]Hello Again[/slide]
[/presentation]
```
3. Make sure the presentation renders fine and all the buttons work.