### PR TITLE
Boost: Prevent the same LCP job from being added multiple times

### DIFF
--- a/projects/plugins/boost/app/modules/optimizations/lcp/class-lcp-analyzer.php
+++ b/projects/plugins/boost/app/modules/optimizations/lcp/class-lcp-analyzer.php
@@ -97,7 +97,7 @@ class LCP_Analyzer {
 	private function analyze_pages( $pages ) {
 		$payload = array(
 			'pages'     => $pages,
-			'requestId' => md5( wp_json_encode( $pages ) . time() ),
+			'requestId' => md5( wp_json_encode( $pages ) ),
 		);
 		return Boost_API::post( 'lcp', $payload );
 	}

--- a/projects/plugins/boost/changelog/update-boost-lcp-prevent-same-payload-belonging-to-multiple-jobs
+++ b/projects/plugins/boost/changelog/update-boost-lcp-prevent-same-payload-belonging-to-multiple-jobs
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+LCP: Prevent requesting analysis for the same pages multiple times.

--- a/projects/plugins/boost/changelog/update-boost-lcp-prevent-same-payload-belonging-to-multiple-jobs
+++ b/projects/plugins/boost/changelog/update-boost-lcp-prevent-same-payload-belonging-to-multiple-jobs
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-LCP: Prevent requesting analysis for the same pages multiple times.
+LCP Optimization: Prevent requesting analysis for the same pages multiple times.


### PR DESCRIPTION
Fixes HOG-396

We do this for Cloud CSS as well, but I didn't want to touch it as we have job deferring and the payload is merged.

## Proposed changes:

* Simplify the job ID to prevent the same job from being enqueued multiple times.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

HOG-396

## Does this pull request change what data or activity we track or use?

no

## Testing instructions:

- This is easiest tested with local boost cloud;
- Setup Boost and enable LCP;
- Keep an eye on the logs - there should be entries about the job being enqueued and processed;
- Stop the worker for the LCP service (`boost-hydra-lcp`). This will prevent the jobs from being processed and you'll be able to observe the queue easily;
- Toggle the LCP analysis multiple times and pay attention to the request ID;
- If you're using trunk/production Boost, you should see a different request ID every time you toggle the feature;
- If you're using this branch, you should see the same request ID when you toggle the feature. That's assuming you didn't update the cornerstone pages list.