### PR TITLE
Forms: add hide label toggle

### DIFF
--- a/projects/packages/forms/changelog/add-forms-hide-label-toggle
+++ b/projects/packages/forms/changelog/add-forms-hide-label-toggle
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Forms: add option to hide label(s)

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -841,6 +841,10 @@
 				// See the selector in class-contact-form-block.php for
 				// 'jetpack/input' registration.
 				color: unset !important;
+
+				&:has(.screen-reader-text) {
+					display: none;
+				}
 			}
 
 			.notched-label__label {
@@ -972,7 +976,7 @@
 				outline: none;
 			}
 
-			.jetpack-field__input,
+			.jetpack-field__input:not(~ .screen-reader-text),
 			.jetpack-field__textarea,
 			.jetpack-field-dropdown__toggle {
 				padding-top: max(var(--jetpack--contact-form--input-padding-top, 0), 1.4em);

--- a/projects/packages/forms/src/blocks/field-telephone/edit.js
+++ b/projects/packages/forms/src/blocks/field-telephone/edit.js
@@ -154,7 +154,7 @@ export default function PhoneFieldEdit( props ) {
 				width={ width }
 				extraFieldSettings={ [
 					{
-						index: 1,
+						index: 3,
 						element: (
 							<div key="phoneFieldControls">
 								<ToggleControl

--- a/projects/packages/forms/src/blocks/field-telephone/edit.js
+++ b/projects/packages/forms/src/blocks/field-telephone/edit.js
@@ -13,6 +13,7 @@ import JetpackFieldControls from '../shared/components/jetpack-field-controls';
 import useFieldSelected from '../shared/hooks/use-field-selected';
 import useFormWrapper from '../shared/hooks/use-form-wrapper';
 import useJetpackFieldStyles from '../shared/hooks/use-jetpack-field-styles';
+import useSyncHideLabel from '../shared/hooks/use-sync-hide-label';
 import useSyncRequiredIndicator from '../shared/hooks/use-sync-required-indicator';
 import { countries } from './country-list';
 import { getTranslatedCountryName } from './country-names-translated';
@@ -35,6 +36,7 @@ export default function PhoneFieldEdit( props ) {
 		searchPlaceholder,
 		default: defaultCountry,
 		requiredIndicator,
+		hideLabel,
 	} = attributes;
 	const [ countryList, setCountryList ] = useState( EMPTY_ARRAY );
 
@@ -87,6 +89,7 @@ export default function PhoneFieldEdit( props ) {
 					required,
 					requiredText,
 					requiredIndicator,
+					hideLabel,
 				},
 			],
 			[ 'jetpack/phone-input', {} ],
@@ -96,6 +99,14 @@ export default function PhoneFieldEdit( props ) {
 	} );
 
 	useSyncRequiredIndicator( {
+		clientId,
+		blockName: 'jetpack/field-sync',
+		isSynced: attributes?.shareFieldAttributes,
+		attributes,
+		setAttributes,
+	} );
+
+	useSyncHideLabel( {
 		clientId,
 		blockName: 'jetpack/field-sync',
 		isSynced: attributes?.shareFieldAttributes,

--- a/projects/packages/forms/src/blocks/field-textarea/edit.js
+++ b/projects/packages/forms/src/blocks/field-textarea/edit.js
@@ -6,12 +6,13 @@ import JetpackFieldControls from '../shared/components/jetpack-field-controls';
 import useFieldSelected from '../shared/hooks/use-field-selected';
 import useFormWrapper from '../shared/hooks/use-form-wrapper';
 import useJetpackFieldStyles from '../shared/hooks/use-jetpack-field-styles';
+import useSyncHideLabel from '../shared/hooks/use-sync-hide-label';
 import useSyncRequiredIndicator from '../shared/hooks/use-sync-required-indicator';
 import { ALLOWED_INNER_BLOCKS } from '../shared/util/constants';
 
 export default function TextareaFieldEdit( props ) {
 	const { attributes, clientId, isSelected, setAttributes } = props;
-	const { id, required, width, requiredIndicator } = attributes;
+	const { id, required, width, requiredIndicator, hideLabel } = attributes;
 
 	useFormWrapper( props );
 	const { blockStyle } = useJetpackFieldStyles( attributes );
@@ -26,10 +27,13 @@ export default function TextareaFieldEdit( props ) {
 
 	const template = useMemo( () => {
 		return [
-			[ 'jetpack/label', { label: __( 'Message', 'jetpack-forms' ), requiredIndicator } ],
+			[
+				'jetpack/label',
+				{ label: __( 'Message', 'jetpack-forms' ), requiredIndicator, hideLabel },
+			],
 			[ 'jetpack/input', { type: 'textarea' } ],
 		];
-	}, [ requiredIndicator ] );
+	}, [ requiredIndicator, hideLabel ] );
 
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {
 		allowedBlocks: ALLOWED_INNER_BLOCKS,
@@ -38,6 +42,14 @@ export default function TextareaFieldEdit( props ) {
 	} );
 
 	useSyncRequiredIndicator( {
+		clientId,
+		blockName: 'jetpack/field-sync',
+		isSynced: attributes?.shareFieldAttributes,
+		attributes,
+		setAttributes,
+	} );
+
+	useSyncHideLabel( {
 		clientId,
 		blockName: 'jetpack/field-sync',
 		isSynced: attributes?.shareFieldAttributes,

--- a/projects/packages/forms/src/blocks/input-phone/editor.scss
+++ b/projects/packages/forms/src/blocks/input-phone/editor.scss
@@ -103,7 +103,7 @@
 .is-style-animated .jetpack-contact-form .jetpack-field.jetpack-field-phone,
 .is-style-animated .jetpack-contact-form .jetpack-field.jetpack-field-telephone {
 
-	.jetpack-field__input {
+	.jetpack-field__input:not(~ .screen-reader-text) {
 		padding-top: max(var(--jetpack--contact-form--input-padding-top, 0), 1.4em);
 	}
 
@@ -126,6 +126,13 @@
 
 .is-style-outlined .jetpack-contact-form .jetpack-field.jetpack-field-phone,
 .is-style-outlined .jetpack-contact-form .jetpack-field.jetpack-field-telephone {
+
+	// .notched-label .screen-reader-text:has(~ .jetpack-field__input) {
+	// 	padding-top: var(--jetpack--contact-form--input-padding, 16px);
+	// }
+	.notched-label:has(.screen-reader-text) ~ .jetpack-field__input {
+		padding-top: var(--jetpack--contact-form--input-padding-top, 16px);
+	}
 
 	.jetpack-field__input {
 

--- a/projects/packages/forms/src/blocks/label/edit.js
+++ b/projects/packages/forms/src/blocks/label/edit.js
@@ -93,7 +93,7 @@ const LabelEdit = ( { clientId, attributes, name, setAttributes, context } ) => 
 	} = context;
 	useSyncedAttributes( name, isSynced, SYNCED_ATTRIBUTE_KEYS, attributes, setAttributes );
 
-	const { label, placeholder, requiredText, requiredIndicator } = attributes;
+	const { label, placeholder, requiredText, requiredIndicator, hideLabel } = attributes;
 	const placeholderValue = placeholder !== '' ? placeholder : __( 'Add label…', 'jetpack-forms' );
 	const suffix = dateFormat
 		? `(${ DATE_FORMATS.find( f => f.value === dateFormat )?.label })`
@@ -103,6 +103,7 @@ const LabelEdit = ( { clientId, attributes, name, setAttributes, context } ) => 
 		'notched-label__label': formStyle === FORM_STYLE.OUTLINED,
 		'animated-label__label': formStyle === FORM_STYLE.ANIMATED,
 		'below-label__label': formStyle === FORM_STYLE.BELOW,
+		'screen-reader-text': hideLabel,
 	} );
 
 	const inputBlock = useSiblingBlock( clientId );

--- a/projects/packages/forms/src/blocks/label/edit.js
+++ b/projects/packages/forms/src/blocks/label/edit.js
@@ -14,6 +14,7 @@ const SYNCED_ATTRIBUTE_KEYS = [
 	'fontSize',
 	'style',
 	'requiredIndicator',
+	'hideLabel',
 ];
 
 const getLabelOrFallback = ( label, placeholder ) => {

--- a/projects/packages/forms/src/blocks/label/index.js
+++ b/projects/packages/forms/src/blocks/label/index.js
@@ -70,6 +70,10 @@ const settings = {
 			type: 'boolean',
 			default: true,
 		},
+		hideLabel: {
+			type: 'boolean',
+			default: false,
+		},
 	},
 	usesContext: [
 		'jetpack/form-class-name',

--- a/projects/packages/forms/src/blocks/shared/components/jetpack-field-controls.js
+++ b/projects/packages/forms/src/blocks/shared/components/jetpack-field-controls.js
@@ -80,6 +80,7 @@ const JetpackFieldControls = ( {
 				key="requiredIndicator"
 				label={ __( 'Show required text', 'jetpack-forms' ) }
 				checked={ !! attributes.requiredIndicator }
+				disabled={ attributes.hideLabel }
 				onChange={ value => setAttributes( { requiredIndicator: value } ) }
 				help={ __(
 					'Toggle whether to display the required indicator text for this field.',
@@ -88,6 +89,17 @@ const JetpackFieldControls = ( {
 				__nextHasNoMarginBottom={ true }
 			/>
 		),
+		<ToggleControl
+			key="hideLabelControl"
+			label={ __( 'Hide label', 'jetpack-forms' ) }
+			checked={ attributes.hideLabel }
+			onChange={ value => setAttributes( { hideLabel: value } ) }
+			help={ __(
+				'When label is hidden, the placeholder text will be used for accessibility',
+				'jetpack-forms'
+			) }
+			__nextHasNoMarginBottom={ true }
+		/>,
 		<JetpackFieldWidth key="width" setAttributes={ setAttributes } width={ width } />,
 		<ToggleControl
 			key="shareFieldAttributes"

--- a/projects/packages/forms/src/blocks/shared/components/jetpack-field.js
+++ b/projects/packages/forms/src/blocks/shared/components/jetpack-field.js
@@ -5,6 +5,7 @@ import { addFilter } from '@wordpress/hooks';
 import clsx from 'clsx';
 import useFieldSelected from '../hooks/use-field-selected';
 import useJetpackFieldStyles from '../hooks/use-jetpack-field-styles';
+import useSyncHideLabel from '../hooks/use-sync-hide-label';
 import useSyncRequiredIndicator from '../hooks/use-sync-required-indicator';
 import { ALLOWED_INNER_BLOCKS } from '../util/constants';
 import JetpackFieldControls from './jetpack-field-controls';
@@ -33,14 +34,24 @@ const JetpackField = props => {
 		style: blockStyle,
 	} );
 
+	const hideLabel = attributes?.hideLabel;
+
 	const template = useMemo( () => {
 		return [
-			[ 'jetpack/label', { label, required, requiredText, requiredIndicator } ],
+			[ 'jetpack/label', { label, required, requiredText, requiredIndicator, hideLabel } ],
 			[ 'jetpack/input', { type } ],
 		];
-	}, [ label, required, requiredText, requiredIndicator, type ] );
+	}, [ label, required, requiredText, requiredIndicator, hideLabel, type ] );
 
 	useSyncRequiredIndicator( {
+		clientId,
+		blockName: 'jetpack/field-sync',
+		isSynced: attributes?.shareFieldAttributes,
+		attributes,
+		setAttributes,
+	} );
+
+	useSyncHideLabel( {
 		clientId,
 		blockName: 'jetpack/field-sync',
 		isSynced: attributes?.shareFieldAttributes,

--- a/projects/packages/forms/src/blocks/shared/hooks/use-sync-hide-label.js
+++ b/projects/packages/forms/src/blocks/shared/hooks/use-sync-hide-label.js
@@ -1,0 +1,50 @@
+import { store as blockEditorStore } from '@wordpress/block-editor';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { useEffect } from '@wordpress/element';
+import { useSyncedAttributes } from './use-synced-attributes';
+
+/**
+ * Syncs `hideLabel` vertically between parent field and nested label,
+ * and also horizontally across form fields if isSynced is true.
+ *
+ * @param {object}   opts               - Options.
+ * @param {string}   opts.clientId      - Parent field block client ID.
+ * @param {string}   opts.blockName     - Sync group key (e.g., 'jetpack/field-sync' or per-type name).
+ * @param {boolean}  opts.isSynced      - Whether field attributes are shared (`shareFieldAttributes`).
+ * @param {object}   opts.attributes    - Field attributes object.
+ * @param {Function} opts.setAttributes - Field setAttributes function.
+ * @return {void}
+ */
+export const useSyncHideLabel = ( {
+	clientId,
+	blockName,
+	isSynced,
+	attributes,
+	setAttributes,
+} ) => {
+	// Syncs horizontally across form fields if isSynced is true.
+	useSyncedAttributes( blockName, isSynced, [ 'hideLabel' ], attributes, setAttributes );
+
+	// Syncs vertically between label and parent.
+	const labelClientId = useSelect(
+		select => {
+			const { getBlock } = select( blockEditorStore );
+			const parentBlock = getBlock( clientId );
+			if ( ! parentBlock ) {
+				return undefined;
+			}
+			const labelBlock = parentBlock.innerBlocks.find( block => block.name === 'jetpack/label' );
+			return labelBlock?.clientId;
+		},
+		[ clientId ]
+	);
+
+	const { updateBlockAttributes } = useDispatch( blockEditorStore );
+
+	useEffect( () => {
+		if ( labelClientId ) {
+			updateBlockAttributes( labelClientId, { hideLabel: attributes?.hideLabel } );
+		}
+	}, [ labelClientId, attributes?.hideLabel, updateBlockAttributes ] );
+};
+export default useSyncHideLabel;

--- a/projects/packages/forms/src/blocks/shared/settings/index.js
+++ b/projects/packages/forms/src/blocks/shared/settings/index.js
@@ -12,6 +12,10 @@ export default {
 			type: 'boolean',
 			default: true,
 		},
+		hideLabel: {
+			type: 'boolean',
+			default: false,
+		},
 		width: {
 			type: 'number',
 			default: 100,

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -172,6 +172,8 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 				'issupersized'             => null,
 				'randomizeoptions'         => null,
 				'showotheroption'          => null,
+				// label setting/attribute
+				'hidelabel'                => null,
 			),
 			$attributes,
 			'contact-field'
@@ -774,6 +776,9 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 	 * @return string HTML
 	 */
 	public function render_label( $type, $id, $label, $required, $required_field_text, $extra_attrs = array(), $always_render = false, $required_indicator = true ) {
+		if ( $this->get_attribute( 'hidelabel' ) ) {
+			return '';
+		}
 		$form_style = $this->get_form_style();
 
 		if ( ! empty( $form_style ) && $form_style !== 'default' ) {
@@ -894,6 +899,11 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 		// this is a hack for Firefox to prevent users from falsely entering a something other than a number into a number field.
 		if ( $type === 'number' ) {
 			$extra_attrs_string .= " data-wp-on--keypress='actions.handleNumberKeyPress' ";
+		}
+
+		if ( $this->get_attribute( 'hidelabel' ) ) {
+			$aria_label          = ! empty( $placeholder ) ? $placeholder : Contact_Form_Plugin::strip_tags( $this->get_attribute( 'label' ) );
+			$extra_attrs_string .= " aria-label='" . esc_attr( $aria_label ) . "' ";
 		}
 
 		return "<input


### PR DESCRIPTION
Fixes [FORMS-360](https://linear.app/a8c/issue/FORMS-360/add-toggle-to-hide-field-labels-in-forms)

## Proposed changes:
This PR is an exploration to add a toggle for hiding field labels. It also adds a fallback aria-label defaulting to field's placeholder or default field label for accessibility.

<img width="1008" height="379" alt="image" src="https://github.com/user-attachments/assets/2f537a68-b345-4e27-a4f5-2100659118ac" />

<img width="972" height="333" alt="image" src="https://github.com/user-attachments/assets/afffb18a-c27f-408a-8472-92ec63cf083d" />


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1761820914350279-slack-C052XEUUBL4

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Insert a form/field. Select any field and look into sidebar settings. There should be a new toggle "Hide label". Toggling it on/off should reflect on the field's label being shown/rendered or not. 

See that "Show required text" becomes disabled when "Hide label" is on (as it doesn't make sense since the required text is part of the label).

Check you can hide all labels or individual field depending on "Sync fields style" toggle.

See frontend reflects the setting.