### PR TITLE
Forms: Add ip address as a default column in the responses dashboard

### DIFF
--- a/projects/packages/forms/changelog/add-forms-ip-address-default-dashboard
+++ b/projects/packages/forms/changelog/add-forms-ip-address-default-dashboard
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Forms: add the IP address as a default field in the forms dashboard

--- a/projects/packages/forms/src/dashboard/inbox/dataviews/views.js
+++ b/projects/packages/forms/src/dashboard/inbox/dataviews/views.js
@@ -13,7 +13,7 @@ const defaultView = {
 	filters: [],
 	page: 1,
 	perPage: 20,
-	fields: [ 'from', 'date', 'source' ],
+	fields: [ 'from', 'date', 'source', 'ip' ],
 };
 
 export const defaultLayouts = {

--- a/projects/plugins/jetpack/changelog/add-forms-ip-address-default-dashboard
+++ b/projects/plugins/jetpack/changelog/add-forms-ip-address-default-dashboard
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Forms: Add the IP address as the default field in the responses dashboard


### PR DESCRIPTION
This PR adds the IP address by default to the responses dashboard. 

<img width="934" height="516" alt="Screenshot 2025-10-30 at 10 07 42 AM" src="https://github.com/user-attachments/assets/5bd105cc-6e68-40f7-932d-cf874cffcef7" />

Fixes FORMS-358

## Proposed changes:
* Add IP to the default View fields. 

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1761834342312659/1761831632.464479-slack-C052XEUUBL4

## Does this pull request change what data or activity we track or use?
NO

## Testing instructions:
Go the the form responses dashboard. Do you see the IP in the fields by default?

cc: @ilonagl 