### PR TITLE
Forms: fix tooltip in response IP link

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-ip-link-tooltip
+++ b/projects/packages/forms/changelog/fix-forms-ip-link-tooltip
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: fix tooltip in response IP link

--- a/projects/packages/forms/src/dashboard/components/response-view/body.tsx
+++ b/projects/packages/forms/src/dashboard/components/response-view/body.tsx
@@ -478,12 +478,12 @@ const ResponseViewBody = ( {
 							<tr>
 								<th>{ __( 'IP address:', 'jetpack-forms' ) }&nbsp;</th>
 								<td>
+									{ response.country_code && (
+										<span className="jp-forms__inbox-response-meta-country-flag response-country-flag">
+											{ getCountryFlagEmoji( response.country_code ) }
+										</span>
+									) }
 									<Tooltip text={ __( 'Lookup IP address', 'jetpack-forms' ) }>
-										{ response.country_code && (
-											<span className="jp-forms__inbox-response-meta-country-flag response-country-flag">
-												{ getCountryFlagEmoji( response.country_code ) }
-											</span>
-										) }
 										<ExternalLink href={ getRedirectUrl( 'ip-lookup', { path: response.ip } ) }>
 											{ response.ip }
 										</ExternalLink>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes error:

<img width="756" height="290" alt="Screenshot 2025-10-30 at 19 13 57" src="https://github.com/user-attachments/assets/95f133d3-5661-4095-851f-73db40a48094" />

After the fix, the tooltip in response IP works again:

<img width="268" height="75" alt="Screenshot 2025-10-30 at 19 16 10" src="https://github.com/user-attachments/assets/8020088e-4929-41b4-9db2-1975106c9ab9" />


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

