### PR TITLE
API: Prevent errors on Plugins page

### DIFF
--- a/projects/plugins/jetpack/_inc/client/portals/plugin-deactivation.jsx
+++ b/projects/plugins/jetpack/_inc/client/portals/plugin-deactivation.jsx
@@ -39,9 +39,11 @@ const PluginDeactivation = props => {
 	const [ modalOpen, setModalOpen ] = useState( false );
 
 	useEffect( () => {
+		restApi.setApiRoot( apiRoot );
+		restApi.setApiNonce( apiNonce );
 		fetchSiteBenefits();
 		fetchUserConnectionData();
-	}, [ fetchSiteBenefits, fetchUserConnectionData ] );
+	}, [ apiRoot, apiNonce, fetchSiteBenefits, fetchUserConnectionData ] );
 
 	// Modify the deactivation link.
 	const deactivationLink = document.querySelector( '#deactivate-jetpack, #deactivate-jetpack-dev' ); // ID set by WP on the deactivation link.
@@ -49,11 +51,6 @@ const PluginDeactivation = props => {
 	if ( deactivationLink !== null ) {
 		deactivationLink.setAttribute( 'title', __( 'Deactivate Jetpack', 'jetpack' ) );
 	}
-
-	useEffect( () => {
-		restApi.setApiRoot( apiRoot );
-		restApi.setApiNonce( apiNonce );
-	}, [ apiRoot, apiNonce ] );
 
 	const toggleVisibility = useCallback( () => {
 		setModalOpen( ! modalOpen );

--- a/projects/plugins/jetpack/changelog/fix-jetpack-undefined_api_root
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-undefined_api_root
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+API: Ensure API root is set prior to usage.


### PR DESCRIPTION
Closes MONOREP-171

 <!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

When visiting the Plugins page (`/wp-admin/plugins.php`) on a Jetpack-connected site, one would get the following errors:
```
GET https://{some_site}/wp-admin/undefinedjetpack/v4/site/benefits?_cacheBuster=1761851261024 404 (Not Found)
GET https://{some_site}/wp-admin/undefinedjetpack/v4/connection/data?_cacheBuster=1761851261024 404 (Not Found)
```

As best I can tell, there's a race condition that results in `apiRoot` not being set early enough. The solution I went with was to combine the two `useEffects()` into one, forcing `apiRoot` to be set prior to the call.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. On a Jetpack-connected site, go to the Plugins page: `/wp-admin/plugins.php`
2. View the Network tab or Console.

On `trunk` or older, you'll see two 404s with `undefinedjetpack` in the URL.

On the `fix/jetpack/undefined_api_root` branch the URLs are properly populated as `wp-json/jetpack`, and they load successfully.