### PR TITLE
Forms: add  browser info to responses exports

### DIFF
--- a/projects/packages/forms/changelog/add-form-submission-browser-info-exports
+++ b/projects/packages/forms/changelog/add-form-submission-browser-info-exports
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Forms: add browser info to form responses exports.

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -2697,6 +2697,7 @@ class Contact_Form_Plugin {
 			$results[ __( 'Consent', 'jetpack-forms' ) ][]      = $feedback->has_consent() ? __( 'Yes', 'jetpack-forms' ) : __( 'No', 'jetpack-forms' );
 			$results[ __( 'IP Address', 'jetpack-forms' ) ][]   = $feedback->get_ip_address();
 			$results[ __( 'Country code', 'jetpack-forms' ) ][] = $feedback->get_country_code();
+			$results[ __( 'Browser', 'jetpack-forms' ) ][]      = $feedback->get_browser();
 
 		}
 		return $results;
@@ -2737,6 +2738,7 @@ class Contact_Form_Plugin {
 			'90_consent'       => _x( 'Consent', 'noun', 'jetpack-forms' ),
 			'93_ip_address'    => __( 'IP Address', 'jetpack-forms' ),
 			'94_country_code'  => __( 'Country code', 'jetpack-forms' ),
+			'95_browser'       => __( 'Browser', 'jetpack-forms' ),
 		);
 	}
 

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
@@ -680,6 +680,7 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 				'Consent'      => array( $default_consent, $default_consent ),
 				'IP Address'   => array( $ip, $ip ),
 				'Country code' => array( $country_code, $country_code ),
+				'Browser'      => array( null, null ), // No browser for legacy feedback
 			),
 			$plugin->get_export_feedback_data( $post_ids )
 		);
@@ -770,6 +771,7 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 		$this->assertTrue( isset( $result['Source'] ) );
 		$this->assertTrue( isset( $result['Consent'] ) );
 		$this->assertTrue( isset( $result['IP Address'] ) );
+		$this->assertTrue( isset( $result['Browser'] ) );
 
 		$equals = array(
 			'Name'    => array( 'Test "Quotes" User' ),

--- a/projects/plugins/jetpack/changelog/add-form-submission-browser-info-exports
+++ b/projects/plugins/jetpack/changelog/add-form-submission-browser-info-exports
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Forms: add browser info to form responses exports.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes FORMS-355

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add browser info to CSV exports

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the forms responses page and click on the export button.
* Check that the browser column is present in the generated CSV

