### PR TITLE
Forms: add browser info to the form response email notification

### DIFF
--- a/projects/packages/forms/changelog/add-form-submission-browser-info-email
+++ b/projects/packages/forms/changelog/add-form-submission-browser-info-email
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Forms: add browser info to the form response email notification.

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -2101,6 +2101,14 @@ class Contact_Form extends Contact_Form_Shortcode {
 				$comment_author_ip_with_flag
 			) . '<br />';
 		}
+		$footer_browser = null;
+		if ( $response->get_browser() ) {
+			$footer_browser = sprintf(
+				/* translators: Placeholder is the browser and platform used to submit a form. */
+				esc_html__( 'Browser: %1$s', 'jetpack-forms' ),
+				$response->get_browser()
+			) . '<br />';
+		}
 
 		$footer_url = sprintf(
 			/* translators: Placeholder is the URL of the page where a form was submitted. */
@@ -2142,6 +2150,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 						'<span style="font-size: 12px">',
 						$footer_time . '<br />',
 						$footer_ip ? $footer_ip . '<br />' : null,
+						$footer_browser ? $footer_browser . '<br />' : null,
 						$footer_url . '<br /><br />',
 						$footer_mark_as_spam_url ? $footer_mark_as_spam_url . '<br />' : null,
 						$sent_by_text,

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -2099,7 +2099,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 				/* translators: Placeholder is the IP address of the person who submitted a form. */
 				esc_html__( 'IP Address: %1$s', 'jetpack-forms' ),
 				$comment_author_ip_with_flag
-			) . '<br />';
+			);
 		}
 		$footer_browser = null;
 		if ( $response->get_browser() ) {

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
@@ -492,6 +492,26 @@ class Contact_Form_Test extends BaseTestCase {
 	}
 
 	/**
+	 * Tests that the browser information is included in the email message.
+	 */
+	public function test_process_submission_includes_browser_in_email() {
+		$_SERVER['HTTP_USER_AGENT'] = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.114 Safari/537.36';
+		$form                       = new Contact_Form( array() );
+		$result                     = $form->process_submission();
+
+		// Processing should be successful and produce the success message.
+		$this->assertTrue( is_string( $result ) );
+
+		$feedback_id = end( Posts::init()->posts )->ID;
+		$submission  = get_post( $feedback_id );
+
+		// Browser information should be included in the email.
+		$email = get_post_meta( $submission->ID, '_feedback_email', true );
+		$this->assertStringContainsString( 'Browser:', $email['message'] );
+		$this->assertStringContainsString( 'Chrome', $email['message'] );
+	}
+
+	/**
 	 * Tests that the submission as a whole will produce something in the
 	 * database when some labels are provided.
 	 *

--- a/projects/plugins/jetpack/changelog/add-form-submission-browser-info-email
+++ b/projects/plugins/jetpack/changelog/add-form-submission-browser-info-email
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Forms: add browser info to the form response email notification.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes FORMS-356

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add browser info to the email footer if available.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
Before:
<img width="742" height="598" alt="Screenshot 2025-10-31 at 12 46 31" src="https://github.com/user-attachments/assets/5743c14d-4882-4d47-93c5-ac229773db73" />

After:
<img width="680" height="603" alt="Screenshot 2025-10-31 at 13 06 53" src="https://github.com/user-attachments/assets/a0057d43-7144-4872-bb4d-de141477659a" />

<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Submit a form response to a form with email notifications enabled.
* Check that the email footer contains the browser field.

