### PR TITLE
Forms: Fix default email to in the editor. 

### DIFF
--- a/projects/packages/forms/changelog/fix-form-email-default-set
+++ b/projects/packages/forms/changelog/fix-form-email-default-set
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: Fix a bug with the default email in the editor

--- a/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
+++ b/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
@@ -782,7 +782,7 @@ class Contact_Form_Block {
 
 		$data = array(
 			'defaults' => array(
-				'to'                   => Contact_Form::get_default_to( $post ? Contact_Form::get_post_property( $post, 'post_author' ) : null ),
+				'to'                   => Contact_Form::get_default_to_for_editor( $post ),
 				'subject'              => Contact_Form::get_default_subject( array() ),
 				'formsResponsesUrl'    => $form_responses_url,
 				'akismetActiveWithKey' => $akismet_active_with_key,

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -482,7 +482,35 @@ class Contact_Form extends Contact_Form_Shortcode {
 			return $default_to;
 		}
 
-		$post_author = get_userdata( $post_author_id );
+		$post = get_post( $source->get_id() );
+		if ( ! $post ) {
+			return $default_to;
+		}
+
+		return self::get_default_to_for_editor( $post );
+	}
+
+	/**
+	 * Get the default recipient email address for the contact form based on post data.
+	 *
+	 * This is used when we load the post or page in the editor, and we don't have the post author ID directly.
+	 *
+	 * @param mixed|null $post Optional post data (object or array).
+	 *
+	 * @return string The default recipient email address.
+	 */
+	public static function get_default_to_for_editor( $post = null ) {
+		$default_to = get_option( 'admin_email' );
+
+		if ( empty( $post ) ) {
+			return $default_to;
+		}
+
+		$post_author_id = self::get_post_property( $post, 'post_author' );
+		$post_id        = self::get_post_property( $post, 'ID' );
+		$post_author    = get_user( $post_author_id );
+
+		// Check that the user has edit permissions for this blog and has an email address
 		if ( empty( $post_author ) || empty( $post_author->user_email ) ) {
 			return $default_to;
 		}
@@ -493,7 +521,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 		}
 
 		// Check that the author can still edit the post or page.
-		if ( user_can( $post_author_id, 'edit_post', $source->get_id() ) ) {
+		if ( user_can( $post_author_id, 'edit_post', $post_id ) ) {
 			return $post_author->user_email;
 		}
 

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
@@ -2505,9 +2505,9 @@ EOT;
 	}
 
 	/**
-	 * Tests get_default_to method with valid post author
+	 * Tests get_default_to_for_editor method with valid post author
 	 */
-	public function test_get_default_to_with_valid_post_author_but_no_source() {
+	public function test_get_default_to_for_editor_with_valid_post_author() {
 		$email     = 'author@example.com';
 		$author_id = wp_insert_user(
 			array(
@@ -2532,6 +2532,14 @@ EOT;
 
 		wp_delete_user( $author_id );
 		wp_delete_post( $post_id, true );
+	}
+
+	/**
+	 * Tests get_default_to_for_editor method with null
+	 */
+	public function test_get_default_to_for_editor_with_null() {
+		$result = Contact_Form::get_default_to_for_editor( null );
+		$this->assertEquals( get_option( 'admin_email' ), $result );
 	}
 
 	/**

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
@@ -2505,6 +2505,36 @@ EOT;
 	}
 
 	/**
+	 * Tests get_default_to method with valid post author
+	 */
+	public function test_get_default_to_with_valid_post_author_but_no_source() {
+		$email     = 'author@example.com';
+		$author_id = wp_insert_user(
+			array(
+				'user_email' => $email,
+				'user_login' => 'test_author',
+				'user_pass'  => 'password123',
+				'role'       => 'editor',
+			)
+		);
+		$post_id   = wp_insert_post(
+			array(
+				'post_title'   => 'Test Post',
+				'post_content' => 'This is a test post.',
+				'post_status'  => 'publish',
+				'post_author'  => $author_id,
+			)
+		);
+
+		$post   = get_post( $post_id );
+		$result = Contact_Form::get_default_to_for_editor( $post );
+		$this->assertEquals( $email, $result );
+
+		wp_delete_user( $author_id );
+		wp_delete_post( $post_id, true );
+	}
+
+	/**
 	 * Tests get_default_to method with valid post author.
 	 */
 	public function test_get_default_to_with_valid_post_author() {


### PR DESCRIPTION
This PR addresses a big that was recently introduced in the https://github.com/Automattic/jetpack/pull/45515 

Fixes FORMS-359 

This PR fixes an issue where the block wasn't storing the "default" email address if it matched the one that was provided by the settings. 

The bug is that the "default" email address was no longer the author's but the admin email. 
So the user wasn't able to set the email to the admin since the "default" was wrongly return by the get_default_to function to be the admin. So when the email went out the email was being send to the author instead of the admin which is what they would expect to happen. 

This PR fixes this by return the email address in the right context of the author of the page or post. 

## Proposed changes:
* Add a new method that is specific for the editor context. So that we set the email address when we 

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
See p1761840767527009-slack-C052XEUUBL4 

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
* Go to the editor. 
* Insert the form block. 
* Notice that the email is set by default to be the admin. 
* Now change the editor of the post or page. Save and refresh the page. 
* Notice now that the email is being set to the editor of the page and that you can set it to the admin or whever email you want. 
Save and refresh the page. 