### PR TITLE
Help Center: Dont download external assets on boot

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-help-center-perf-in-atomic
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-help-center-perf-in-atomic
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Help Center: do not download external assets on boot

--- a/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-help-center.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-help-center.php
@@ -190,7 +190,14 @@ class Help_Center {
 					$wp_admin_bar->add_menu(
 						array(
 							'id'     => 'help-center',
-							'title'  => '<span title="' . __( 'Help', 'jetpack-mu-wpcom' ) . '">' . self::download_asset( 'widgets.wp.com/help-center/help-icon.svg', false ) . '</span>',
+							'title'  => '<span title="' . __( 'Help Center', 'jetpack-mu-wpcom' ) . '"><svg id="help-center-icon" class="ab-icon" width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+												<path fill="currentColor" fill-rule="evenodd" clip-rule="evenodd" d="M12 2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm-1 16v-2h2v2h-2zm2-3v-1.141A3.991 3.991 0 0016 10a4 4 0 00-8 0h2c0-1.103.897-2 2-2s2 .897 2 2-.897 2-2 2a1 1 0 00-1 1v2h2z" />
+											</svg>
+											<svg id="help-center-icon-with-notification" class="ab-icon"  width="24" height="24" viewBox="0 0 25 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+												<path d="M12 2C6.477 2 2 6.477 2 12C2 17.523 6.477 22 12 22C17.523 22 22 17.523 22 12C22 6.477 17.523 2 12 2ZM13 18H11V16H13V18ZM13 13.859V15H11V13C11 12.448 11.448 12 12 12C13.103 12 14 11.103 14 10C14 8.897 13.103 8 12 8C10.897 8 10 8.897 10 10H8C8 7.791 9.791 6 12 6C14.209 6 16 7.791 16 10C16 11.862 14.722 13.413 13 13.859Z" fill="currentColor"/>
+												<circle cx="20" cy="3.5" r="4.3" fill="#e65054" stroke="#1d2327" stroke-width="2"/>
+											</svg>
+										</span>',
 							'parent' => 'top-secondary',
 							'href'   => $this->get_help_center_url(),
 							'meta'   => array(
@@ -492,25 +499,17 @@ class Help_Center {
 	 * Get the asset via file-system on wpcom and via network on Atomic sites.
 	 *
 	 * @param string $filepath The URL to download the asset file from.
-	 * @param bool   $parse_json Whether to parse the JSON file or not.
 	 */
-	private static function download_asset( $filepath, $parse_json = true ) {
+	private static function get_assets_json( $filepath ) {
 		$accessible_directly = file_exists( ABSPATH . '/' . $filepath );
 		if ( $accessible_directly ) {
-			if ( $parse_json ) {
-				return json_decode( file_get_contents( ABSPATH . $filepath ), true );
-			}
-			return file_get_contents( ABSPATH . $filepath );
-		} else {
-			$request = wp_remote_get( 'https://' . $filepath );
-			if ( is_wp_error( $request ) ) {
-				return null;
-			} elseif ( $parse_json ) {
-				return json_decode( wp_remote_retrieve_body( $request ), true );
-			} else {
-				return wp_remote_retrieve_body( $request );
-			}
+			return json_decode( file_get_contents( ABSPATH . $filepath ), true );
 		}
+		$request = wp_remote_get( 'https://' . $filepath );
+		if ( is_wp_error( $request ) ) {
+			return null;
+		}
+		return json_decode( wp_remote_retrieve_body( $request ), true );
 	}
 
 	/**
@@ -546,9 +545,15 @@ class Help_Center {
 			$variant = 'wp-admin' . ( $this->is_jetpack_disconnected() ? '-disconnected' : '' );
 		}
 
-		$asset_file = self::download_asset( 'widgets.wp.com/help-center/help-center-' . $variant . '.asset.json' );
+		$cache_key  = 'help-center-asset-' . $variant . '.asset.json';
+		$asset_file = get_transient( $cache_key );
+
 		if ( ! $asset_file ) {
-			return;
+			$asset_file = self::get_assets_json( 'widgets.wp.com/help-center/help-center-' . $variant . '.asset.json' );
+			if ( ! $asset_file ) {
+				return;
+			}
+			set_transient( $cache_key, $asset_file, HOUR_IN_SECONDS );
 		}
 
 		// When the request is proxied, use a random cache buster as the version for easier debugging.


### PR DESCRIPTION
## Proposed changes:
- Inline the Help Center SVG instead of issuing a remote request to get it.
- Transient cache asset.json requests.

They were terrible for performance.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
1. cd into `/projects/packages/jetpack-mu-wpcom`.
2. Assuming your Atomic site host is `wpcom-atomic`, run `jetpack rsync mu-wpcom-plugin wpcom-atomic:htdocs/wp-content/plugins/jetpack-mu-wpcom-plugin-dev.
3. Visit wp-admin.
4. The Help Center icons should work.