### PR TITLE
Flex sites: Add is_wpcom_flex site flag in the API response for deleted sites

### DIFF
--- a/projects/plugins/jetpack/changelog/add-wpcom-flex-deleted-sites
+++ b/projects/plugins/jetpack/changelog/add-wpcom-flex-deleted-sites
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Flex sites: return the is_wpcom_flex flag from the sites API for deleted sites

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
@@ -134,6 +134,7 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 		'is_wpcom_atomic',
 		'is_wpcom_staging_site',
 		'is_deleted',
+		'is_wpcom_flex',
 		'is_a4a_client',
 		'is_a4a_dev_site',
 	);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Part of ARC-1033

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add the is_wpcom_flex field to the list of no_member sites fields, so that it could be used for deleted sites

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Delete any site and examine the /sites or /me/sites API response for that site to confirm that is_wpcom_flex flag is appearing there.

