### PR TITLE
Carousel: Prevent duplicate tracking requests

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-carousel-duplicate-tracking-on-close
+++ b/projects/plugins/jetpack/changelog/fix-carousel-duplicate-tracking-on-close
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Fix duplicate tracking event for carousel

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
@@ -830,6 +830,11 @@
 				pageview( attachmentId );
 			}
 
+			// Update lastKnownLocationHash before setting window.location.hash to prevent
+			// the hashchange event handler from re-triggering selectSlideAtIndex.
+			// If we use a combined assignment (window.location.hash = lastKnownLocationHash = value),
+			// the hashchange event can fire before lastKnownLocationHash is updated, causing
+			// duplicate tracking calls.
 			lastKnownLocationHash = '#jp-carousel-' + attachmentId;
 			window.location.hash = lastKnownLocationHash;
 		}

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
@@ -815,7 +815,7 @@
 			}
 
 			// Record pageview in WP Stats, for each new image loaded full-screen.
-			if ( jetpackCarouselStrings.stats ) {
+			if ( jetpackCarouselStrings.stats && carousel.isOpen ) {
 				new Image().src =
 					document.location.protocol +
 					'//pixel.wp.com/g.gif?' +
@@ -826,7 +826,9 @@
 					Math.random();
 			}
 
-			pageview( attachmentId );
+			if ( carousel.isOpen ) {
+				pageview( attachmentId );
+			}
 
 			window.location.hash = lastKnownLocationHash = '#jp-carousel-' + attachmentId;
 		}
@@ -845,8 +847,8 @@
 
 			domUtil.emitEvent( carousel.overlay, 'jp_carousel.beforeClose' );
 			restoreScroll();
-			swiper.destroy();
 			carousel.isOpen = false;
+			swiper.destroy();
 			// Clear slide data for DOM garbage collection.
 			carousel.slides = [];
 			carousel.currentSlide = undefined;

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
@@ -830,7 +830,8 @@
 				pageview( attachmentId );
 			}
 
-			window.location.hash = lastKnownLocationHash = '#jp-carousel-' + attachmentId;
+			lastKnownLocationHash = '#jp-carousel-' + attachmentId;
+			window.location.hash = lastKnownLocationHash;
 		}
 
 		function restoreScroll() {

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
@@ -1609,6 +1609,9 @@
 			} );
 
 			swiper.on( 'slideChange', function ( swiper ) {
+				if ( ! carousel.isOpen ) {
+					return;
+				}
 				selectSlideAtIndex( swiper.realIndex );
 				carousel.overlay.classList.remove( 'jp-carousel-hide-controls' );
 			} );

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
@@ -831,10 +831,11 @@
 			}
 
 			// Update lastKnownLocationHash before setting window.location.hash to prevent
-			// the hashchange event handler from re-triggering selectSlideAtIndex.
-			// If we use a combined assignment (window.location.hash = lastKnownLocationHash = value),
-			// the hashchange event can fire before lastKnownLocationHash is updated, causing
-			// duplicate tracking calls.
+			// a race condition. Setting window.location.hash triggers the hashchange event
+			// synchronously, which can execute before lastKnownLocationHash is fully updated
+			// in a chained assignment like: window.location.hash = lastKnownLocationHash = value.
+			// This causes the hashchange handler to see mismatched values and re-trigger
+			// selectSlideAtIndex, resulting in duplicate tracking calls.
 			lastKnownLocationHash = '#jp-carousel-' + attachmentId;
 			window.location.hash = lastKnownLocationHash;
 		}


### PR DESCRIPTION
Closes STATS-176

## Proposed changes:
* Fixed an issue where closing the Jetpack Carousel would trigger a duplicate pixel.wp.com tracking request
* This occurred because `swiper.destroy()` fired a `slideChange` event before `carousel.isOpen` was set to false
* Set `carousel.isOpen = false` before calling `swiper.destroy()` in the `closeCarousel()` function
* Added `carousel.isOpen` checks to prevent tracking when carousel is closed in `selectSlideAtIndex()`

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
n/a

## Does this pull request change what data or activity we track or use?
Yes - This PR reduces tracking data by preventing duplicate pixel requests when the carousel is closed. No new data is tracked; we're only fixing over-reporting.

## Testing instructions:

* Set up a site with Jetpack Carousel enabled
* Create a post/page with a gallery containing at least 2 images
* Open browser DevTools Network tab and filter by "pixel.wp.com"
* Click on an image to open the carousel
* You should see a pixel.wp.com request with the attachment post ID (e.g., `post=1234`)
* Navigate to the second image in the carousel
* You should see another pixel.wp.com request with a different post ID
* Click the X button (or press ESC) to close the carousel
* **Expected:** No additional pixel.wp.com request should fire
* **Before this fix:** An extra duplicate pixel request would fire with the last viewed attachment ID