### PR TITLE
WooCommerce Analytics: Send all front-end data to both ClickHouse and Nosara

### DIFF
--- a/projects/packages/woocommerce-analytics/changelog/fix-clickhouse-events
+++ b/projects/packages/woocommerce-analytics/changelog/fix-clickhouse-events
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Send all events to clickhouse

--- a/projects/packages/woocommerce-analytics/src/class-features.php
+++ b/projects/packages/woocommerce-analytics/src/class-features.php
@@ -43,6 +43,6 @@ class Features {
 		 *
 		 * @param bool $enabled Whether ClickHouse event tracking is enabled.
 		 */
-		return apply_filters( 'woocommerce_analytics_clickhouse_enabled', true );
+		return apply_filters( 'woocommerce_analytics_clickhouse_enabled', false );
 	}
 }

--- a/projects/packages/woocommerce-analytics/src/class-wc-analytics-tracking.php
+++ b/projects/packages/woocommerce-analytics/src/class-wc-analytics-tracking.php
@@ -34,26 +34,6 @@ class WC_Analytics_Tracking extends WC_Tracks {
 	const DAILY_SALT_OPTION = 'woocommerce_analytics_daily_salt';
 
 	/**
-	 * Allowed ClickHouse events.
-	 *
-	 * @var array
-	 */
-	const ALLOWED_CH_EVENTS = array(
-		'woocommerceanalytics_session_started',
-		'woocommerceanalytics_session_engagement',
-		'woocommerceanalytics_product_view',
-		'woocommerceanalytics_cart_view',
-		'woocommerceanalytics_add_to_cart',
-		'woocommerceanalytics_remove_from_cart',
-		'woocommerceanalytics_checkout_view',
-		'woocommerceanalytics_product_checkout',
-		'woocommerceanalytics_product_purchase',
-		'woocommerceanalytics_order_confirmation_view',
-		'woocommerceanalytics_search',
-		'woocommerceanalytics_page_view',
-	);
-
-	/**
 	 * Event queue.
 	 *
 	 * @var array
@@ -105,7 +85,7 @@ class WC_Analytics_Tracking extends WC_Tracks {
 
 		// Record ClickHouse event, if applicable.
 		$ch_error = null;
-		if ( self::should_send_to_clickhouse( $prefixed_event_name ) ) {
+		if ( Features::is_clickhouse_enabled() ) {
 			$properties['ch'] = 1;
 			$ch_result        = self::record_ch_event( $properties );
 			if ( is_wp_error( $ch_result ) ) {
@@ -380,17 +360,6 @@ class WC_Analytics_Tracking extends WC_Tracks {
 			);
 		}
 		return self::$cached_visitor_id;
-	}
-
-	/**
-	 * Check if the event should be sent to ClickHouse
-	 *
-	 * @param string $event The event name.
-	 * @return bool True if it should be sent to ClickHouse
-	 */
-	private static function should_send_to_clickhouse( $event ) {
-		return Features::is_clickhouse_enabled() &&
-			in_array( $event, self::ALLOWED_CH_EVENTS, true );
 	}
 
 	/**

--- a/projects/packages/woocommerce-analytics/src/client/analytics.ts
+++ b/projects/packages/woocommerce-analytics/src/client/analytics.ts
@@ -7,7 +7,7 @@ import debugFactory from 'debug';
  */
 import { ApiClient } from './api-client';
 import { consentManager } from './consent';
-import { EVENT_NAME_REGEX, EVENT_PREFIX, CLICK_HOUSE_EVENTS } from './constants';
+import { EVENT_NAME_REGEX, EVENT_PREFIX } from './constants';
 import SessionManager from './session-manager';
 import { getCookie, generateRandomToken } from './utils';
 import type { AnalyticsConfig } from './types/shared';
@@ -159,7 +159,7 @@ export class Analytics {
 			return;
 		}
 
-		if ( this.features.ch && CLICK_HOUSE_EVENTS.includes( event ) ) {
+		if ( this.features.ch ) {
 			eventProperties.ch = 1;
 		} else {
 			delete eventProperties.ch;

--- a/projects/packages/woocommerce-analytics/src/client/constants.ts
+++ b/projects/packages/woocommerce-analytics/src/client/constants.ts
@@ -7,18 +7,3 @@ export const API_NAMESPACE = 'woocommerce-analytics/v1';
 export const API_ENDPOINT = 'track';
 export const BATCH_SIZE = 10;
 export const DEBOUNCE_DELAY = 1000; // 1 second
-
-export const CLICK_HOUSE_EVENTS = [
-	'session_started',
-	'session_engagement',
-	'product_view',
-	'cart_view',
-	'add_to_cart',
-	'remove_from_cart',
-	'checkout_view',
-	'product_checkout',
-	'product_purchase',
-	'order_confirmation_view',
-	'search',
-	'page_view',
-];


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Follow-up to https://github.com/Automattic/jetpack/pull/45696

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

* Revert the changes in https://github.com/Automattic/jetpack/pull/45696
* What we acutally need is just to send all front-end data to both ClickHouse and Nosara

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

pfKYZu-2ZQ-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

n/a

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Install WooCommerce on a test site with Jetpack connected
* Enable clickhouse feature flag
* Open developer tools > network tab
* Go to site's account page
* Log in to the site
* Confirm that `woocommerceanalytics_my_account_page_view` is recorded in ClickHouse
