### PR TITLE
 WooCommerce_HPOS_Orders: Fix 'Order properties should not be accessed directly.' notice

### DIFF
--- a/projects/packages/sync/changelog/fix-sync-hpos-access-notice
+++ b/projects/packages/sync/changelog/fix-sync-hpos-access-notice
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: WooCommerce_HPOS_Orders: Fix 'Order properties should not be accessed directly.' notice
+
+

--- a/projects/packages/sync/src/modules/class-woocommerce-hpos-orders.php
+++ b/projects/packages/sync/src/modules/class-woocommerce-hpos-orders.php
@@ -315,13 +315,19 @@ class WooCommerce_HPOS_Orders extends Module {
 			return false;
 		}
 
-		if ( isset( $processed[ $order_object->id ] ) ) {
+		$order_id = $order_object->get_id();
+
+		if ( empty( $order_id ) ) {
 			return false;
 		}
 
-		$processed[ $order_object->id ] = true;
+		if ( isset( $processed[ $order_id ] ) ) {
+			return false;
+		}
 
-		return array( 'id' => $order_object->id );
+		$processed[ $order_id ] = true;
+
+		return array( 'id' => $order_id );
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes `Order properties should not be accessed directly.` notice, coming from `on_before_enqueue_order_save`

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* `WooCommerce_HPOS_Orders`: Ensure we fetch the order id via `get_id()` vs the actual id property

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Code review should suffice here
* For manual testing see https://github.com/Automattic/jetpack/pull/45697

