### PR TITLE
Forms: move storage setting lower in sidebar

### DIFF
--- a/projects/packages/forms/changelog/update-forms-response-storage-down
+++ b/projects/packages/forms/changelog/update-forms-response-storage-down
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Forms: move storage setting lower in sidebar

--- a/projects/packages/forms/src/blocks/contact-form/edit.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/edit.tsx
@@ -804,16 +804,6 @@ function JetpackContactFormEdit( {
 				</BlockControls>
 				<InspectorControls>
 					<PanelBody
-						title={ __( 'Responses storage', 'jetpack-forms' ) }
-						className="jetpack-contact-form__panel jetpack-contact-form__responses-storage-panel"
-						initialOpen={ false }
-					>
-						<JetpackManageResponsesSettings
-							attributes={ attributes }
-							setAttributes={ setAttributes }
-						/>
-					</PanelBody>
-					<PanelBody
 						title={ __( 'Action after submit', 'jetpack-forms' ) }
 						initialOpen={ false }
 						className="jetpack-contact-form__panel"
@@ -908,6 +898,16 @@ function JetpackContactFormEdit( {
 							<IntegrationControls attributes={ attributes } setAttributes={ setAttributes } />
 						</Suspense>
 					) }
+					<PanelBody
+						title={ __( 'Responses storage', 'jetpack-forms' ) }
+						className="jetpack-contact-form__panel jetpack-contact-form__responses-storage-panel"
+						initialOpen={ false }
+					>
+						<JetpackManageResponsesSettings
+							attributes={ attributes }
+							setAttributes={ setAttributes }
+						/>
+					</PanelBody>
 				</InspectorControls>
 				<InspectorAdvancedControls>
 					<TextControl


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* It's not as important setting as other ones in the sidebar, so let's move it down.

Before

<img width="286" height="670" alt="Screenshot 2025-10-31 at 13 23 36" src="https://github.com/user-attachments/assets/02775035-6dde-4830-9d63-54c7f01b17bd" />


After

<img width="279" height="452" alt="Screenshot 2025-10-31 at 13 24 58" src="https://github.com/user-attachments/assets/da862fdd-a392-459c-925f-7545c3b308af" />


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

