### PR TITLE
Prevent PHP fatals when directly accessing files, round 10

### DIFF
--- a/projects/packages/publicize/changelog/fix-jetpack-direct_access_fatals_part_10
+++ b/projects/packages/publicize/changelog/fix-jetpack-direct_access_fatals_part_10
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Prevent PHP errors by limiting direct access to files.
+
+

--- a/projects/packages/publicize/src/social-image-generator/class-rest-settings-controller.php
+++ b/projects/packages/publicize/src/social-image-generator/class-rest-settings-controller.php
@@ -18,6 +18,10 @@ use WP_REST_Request;
 use WP_REST_Response;
 use WP_REST_Server;
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 /**
  * Defines our endpoints.
  */

--- a/projects/packages/sync/changelog/fix-jetpack-direct_access_fatals_part_10
+++ b/projects/packages/sync/changelog/fix-jetpack-direct_access_fatals_part_10
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Prevent PHP errors by limiting direct access to files.
+
+

--- a/projects/packages/sync/src/replicastore/class-table-checksum-users.php
+++ b/projects/packages/sync/src/replicastore/class-table-checksum-users.php
@@ -9,6 +9,10 @@ namespace Automattic\Jetpack\Sync\Replicastore;
 
 use Exception;
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 /**
  * Class to handle Table Checksums for the Users table.
  */

--- a/projects/packages/videopress/changelog/fix-jetpack-direct_access_fatals_part_10
+++ b/projects/packages/videopress/changelog/fix-jetpack-direct_access_fatals_part_10
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Prevent PHP errors by limiting direct access to files.
+
+

--- a/projects/packages/videopress/src/videopress-divi/class-videopress-divi-extension.php
+++ b/projects/packages/videopress/src/videopress-divi/class-videopress-divi-extension.php
@@ -7,6 +7,10 @@
 
 use Automattic\Jetpack\Assets;
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 /**
  * Divi extension.
  **/

--- a/projects/packages/videopress/src/videopress-divi/class-videopress-divi-module.php
+++ b/projects/packages/videopress/src/videopress-divi/class-videopress-divi-module.php
@@ -7,6 +7,10 @@
 
 use Automattic\Jetpack\VideoPress\Jwt_Token_Bridge;
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 /**
  * VideoPress Divi module
  **/

--- a/projects/plugins/jetpack/changelog/fix-jetpack-direct_access_fatals_part_10
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-direct_access_fatals_part_10
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Prevent PHP errors by limiting direct access to files.
+
+

--- a/projects/plugins/jetpack/extensions/extended-blocks/core-audio/core-audio.php
+++ b/projects/plugins/jetpack/extensions/extended-blocks/core-audio/core-audio.php
@@ -5,6 +5,10 @@
  * @package automattic/jetpack
  **/
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 // Populate the available extensions with core/audio.
 add_filter(
 	'jetpack_set_available_extensions',


### PR DESCRIPTION
Closes MONOREP-173

 <!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

As a follow-up to #44574, this gates against direct access to some more files as found in the logs.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

