### PR TITLE
wpcomsh: Prevent PHP fatals when footer is nested in an output buffer

### DIFF
--- a/projects/plugins/wpcomsh/changelog/fix-wpcomsh-fix_footer_fatals
+++ b/projects/plugins/wpcomsh/changelog/fix-wpcomsh-fix_footer_fatals
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Footer: Avoid PHP errors when nested in output buffering.

--- a/projects/plugins/wpcomsh/footer-credit/footer-credit-optimizations.php
+++ b/projects/plugins/wpcomsh/footer-credit/footer-credit-optimizations.php
@@ -17,7 +17,7 @@ function wpcom_better_footer_links_buffer( $page ) {
 	}
 
 	// Would like to only see footer content before wp_footer output.
-	$output = preg_split( '/wpcom_wp_footer/i', $page, 2 );
+	$output = explode( 'wpcom_wp_footer', $page, 2 );
 
 	// Run "better link" filters.
 	$footer = wpcom_better_footer_links( $output[0] );
@@ -25,7 +25,7 @@ function wpcom_better_footer_links_buffer( $page ) {
 	$remaining_content = $output[1] ?? '';
 
 	// Piece back together again.
-	$page = implode( array( $footer, 'wpcom_wp_footer' . $remaining_content ) );
+	$page = $footer . 'wpcom_wp_footer' . $remaining_content;
 
 	// If nothing to join, return empty string.
 	if ( 'wpcom_wp_footer' === $page ) {
@@ -33,7 +33,7 @@ function wpcom_better_footer_links_buffer( $page ) {
 	}
 
 	// Replace any dangling references of glue code.
-	$page = preg_replace( '/wpcom_wp_footer/i', '', $page );
+	$page = str_replace( 'wpcom_wp_footer', '', $page );
 
 	return $page;
 }


### PR DESCRIPTION
Closes MONOREP-174

 <!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This addresses the following fatals:
```
PHP Fatal error: preg_split(): Cannot use output buffering in output buffering display handlers in /wordpress/plugins/wpcomsh/8.1.0-alpha+rolling.1761763643.g48b79fe/footer-credit/footer-credit-optimizations.php on line 20
PHP Fatal error: wpcom_better_footer_links_buffer(): Cannot use output buffering in output buffering display handlers in /wordpress/plugins/wpcomsh/8.1.0-alpha+rolling.1761916560.gcfb3b38/footer-credit/footer-credit-optimizations.php on line 28
PHP Fatal error: preg_replace(): Cannot use output buffering in output buffering display handlers in /wordpress/plugins/wpcomsh/8.1.0-alpha+rolling.1761763643.g48b79fe/footer-credit/footer-credit-optimizations.php on line 36
```

I wasn't able to reproduce this, but it should be a safe change, and is more efficient, too (no regex stuff):

* `preg_split()` → `explode()`: both limit to two, but now it's not case-insensitive (nor does it need to be from what I can see)
* `implode( array() )` → string concatenation: I'm not sure why it was anything but this originally
* `preg_replace()` → `str_replace()`: now it's not case-insensitive (nor does it need to be from what I can see)

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

