### PR TITLE
Phan: Handle PhanPluginDuplicateIfCondition violations

### DIFF
--- a/projects/plugins/crm/.phan/baseline.php
+++ b/projects/plugins/crm/.phan/baseline.php
@@ -96,7 +96,6 @@ return [
     // PhanNoopVariable : 1 occurrence
     // PhanPluginDuplicateArrayKey : 1 occurrence
     // PhanPluginDuplicateCatchStatementBody : 1 occurrence
-    // PhanPluginDuplicateIfCondition : 1 occurrence
     // PhanPluginUseReturnValueInternalKnown : 1 occurrence
     // PhanRedefineFunctionInternal : 1 occurrence
     // PhanSuspiciousWeakTypeComparisonInLoop : 1 occurrence
@@ -186,7 +185,7 @@ return [
         'includes/ZeroBSCRM.DataIOValidation.php' => ['PhanTypeMismatchArgument'],
         'includes/ZeroBSCRM.Database.php' => ['PhanRedundantCondition', 'PhanSuspiciousValueComparison'],
         'includes/ZeroBSCRM.Delete.php' => ['PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentInternal'],
-        'includes/ZeroBSCRM.Edit.php' => ['PhanPluginDuplicateIfCondition', 'PhanTypeArraySuspiciousNullable', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentInternal'],
+        'includes/ZeroBSCRM.Edit.php' => ['PhanTypeArraySuspiciousNullable', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentInternal'],
         'includes/ZeroBSCRM.Encryption.php' => ['PhanUndeclaredConstant'],
         'includes/ZeroBSCRM.ExternalSources.php' => ['PhanPluginMixedKeyNoKey', 'PhanPluginUnreachableCode'],
         'includes/ZeroBSCRM.FileUploads.php' => ['PhanTypeComparisonFromArray', 'PhanTypeMismatchDimFetch'],

--- a/projects/plugins/crm/changelog/fix-phan-PhanPluginDuplicateIfCondition
+++ b/projects/plugins/crm/changelog/fix-phan-PhanPluginDuplicateIfCondition
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Invoices: Ensure object owner is properly set.

--- a/projects/plugins/crm/includes/ZeroBSCRM.Edit.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.Edit.php
@@ -153,45 +153,43 @@ class zeroBSCRM_Edit{
     // check ownership, access etc. 
     public function preChecks(){
 
-        global $zbs;
+		global $zbs;
 
-          $is_malformed_obj = false;
+		$is_malformed_obj = false;
 
-          if (is_array($this->obj) && isset($this->obj['owner'])){
-				$obj_owner = (int) $this->obj['owner'];
+		if ( is_array( $this->obj ) && isset( $this->obj['owner'] ) ) {
+			$obj_owner = (int) $this->obj['owner'];
 
 				// Transactions can have a contact or company assigned, and quotes just a contact. This covers checking owners for both.
 			if ( isset( $this->obj['contact'][0]['owner'] ) ) {
 					$obj_owner = (int) $this->obj['contact'][0]['owner'];
 
 			} elseif ( isset( $this->obj['company'][0]['owner'] ) ) {
-					$obj_owner = (int) $this->obj['company'][0]['owner'];
-				// phpcs:disable Generic.WhiteSpace.ScopeIndent.IncorrectExact,Generic.WhiteSpace.ScopeIndent.Incorrect -- this sniff is incorrectly reporting spacing issues.
-				}
+				$obj_owner = (int) $this->obj['company'][0]['owner'];
+			}
 
-				// This covers checking owners for assigned contacts or companies in invoices.
-				if ( $this->objTypeID === ZBS_TYPE_INVOICE ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
-					$data = zeroBSCRM_invoicing_getInvoiceData( $this->objID ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
-					if ( ! empty( $data['invoiceObj']['contact'] ) ) {
-						$obj_owner = (int) $data['invoiceObj']['contact'][0]['owner'];
-					} elseif ( ! empty( $data['invoiceObj']['company'] ) ) {
-						$obj_owner = (int) $data['invoiceObj']['company'][0]['owner'];
-					}
+			// This covers checking owners for assigned contacts or companies in invoices.
+			if ( $this->objTypeID === ZBS_TYPE_INVOICE ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+				$data = zeroBSCRM_invoicing_getInvoiceData( $this->objID ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+				if ( ! empty( $data['invoiceObj']['contact'] ) ) {
+					$obj_owner = (int) $data['invoiceObj']['contact'][0]['owner'];
+				} elseif ( ! empty( $data['invoiceObj']['company'] ) ) {
+					$obj_owner = (int) $data['invoiceObj']['company'][0]['owner'];
 				}
-          } else {
-			// phpcs:enable Generic.WhiteSpace.ScopeIndent.IncorrectExact,Generic.WhiteSpace.ScopeIndent.Incorrect
-            // if $this->obj is not an array, somehow it's not been loaded properly (probably perms)
-            // get owner info anyway
-            $is_malformed_obj = true;
-				$obj_owner    = $zbs->DAL->getObjectOwner( // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
-					array(
-						'objID'     => $this->objID, // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
-						'objTypeID' => $this->objTypeID, // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
-					)
-				);
-          }
-          // get current user
-			$current_user_id = get_current_user_id();
+			}
+		} else {
+			// if $this->obj is not an array, somehow it's not been loaded properly (probably perms)
+			// get owner info anyway
+			$is_malformed_obj = true;
+			$obj_owner        = $zbs->DAL->getObjectOwner( // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+				array(
+					'objID'     => $this->objID, // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+					'objTypeID' => $this->objTypeID, // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+				)
+			);
+		}
+		// get current user
+		$current_user_id = get_current_user_id();
 
 		if ( $obj_owner > 0 && $obj_owner != $current_user_id || $obj_owner == -1 ) { // phpcs:ignore Universal.Operators.StrictComparisons.LooseNotEqual,Universal.Operators.StrictComparisons.LooseEqual -- see below.
 				// not current user

--- a/projects/plugins/crm/includes/ZeroBSCRM.Edit.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.Edit.php
@@ -174,7 +174,7 @@ class zeroBSCRM_Edit{
 					$data = zeroBSCRM_invoicing_getInvoiceData( $this->objID ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 					if ( ! empty( $data['invoiceObj']['contact'] ) ) {
 						$obj_owner = (int) $data['invoiceObj']['contact'][0]['owner'];
-					} elseif ( ! empty( $data['invoiceObj']['contact'] ) ) {
+					} elseif ( ! empty( $data['invoiceObj']['company'] ) ) {
 						$obj_owner = (int) $data['invoiceObj']['company'][0]['owner'];
 					}
 				}

--- a/projects/plugins/super-cache/.phan/baseline.php
+++ b/projects/plugins/super-cache/.phan/baseline.php
@@ -40,7 +40,6 @@ return [
     // PhanTypeMismatchReturn : 2 occurrences
     // PhanTypeSuspiciousStringExpression : 2 occurrences
     // PhanCommentParamWithoutRealParam : 1 occurrence
-    // PhanPluginDuplicateIfCondition : 1 occurrence
     // PhanTypeConversionFromArray : 1 occurrence
     // PhanTypeInvalidLeftOperandOfBitwiseOp : 1 occurrence
     // PhanTypeInvalidRightOperandOfAdd : 1 occurrence
@@ -72,7 +71,7 @@ return [
         'tests/e2e/tools/mu-test-helpers.php' => ['PhanTypeMismatchArgument'],
         'wp-cache-base.php' => ['PhanTypeMismatchArgumentNullableInternal'],
         'wp-cache-phase1.php' => ['PhanTypeNonVarPassByRef'],
-        'wp-cache-phase2.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanPluginDuplicateIfCondition', 'PhanPluginSimplifyExpressionBool', 'PhanPluginUnreachableCode', 'PhanPossiblyUndeclaredVariable', 'PhanSuspiciousValueComparison', 'PhanTypeArraySuspiciousNullable', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentInternalProbablyReal', 'PhanTypeMismatchArgumentNullable', 'PhanTypeMismatchArgumentNullableInternal', 'PhanTypeNonVarPassByRef', 'PhanTypePossiblyInvalidDimOffset', 'PhanTypeSuspiciousNonTraversableForeach', 'PhanTypeSuspiciousStringExpression', 'PhanUndeclaredVariableDim'],
+        'wp-cache-phase2.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanPluginSimplifyExpressionBool', 'PhanPluginUnreachableCode', 'PhanPossiblyUndeclaredVariable', 'PhanSuspiciousValueComparison', 'PhanTypeArraySuspiciousNullable', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentInternalProbablyReal', 'PhanTypeMismatchArgumentNullable', 'PhanTypeMismatchArgumentNullableInternal', 'PhanTypeNonVarPassByRef', 'PhanTypePossiblyInvalidDimOffset', 'PhanTypeSuspiciousNonTraversableForeach', 'PhanTypeSuspiciousStringExpression', 'PhanUndeclaredVariableDim'],
         'wp-cache.php' => ['PhanPluginDuplicateAdjacentStatement', 'PhanPluginDuplicateExpressionAssignmentOperation', 'PhanPluginNeverReturnFunction', 'PhanPluginSimplifyExpressionBool', 'PhanPossiblyUndeclaredVariable', 'PhanSuspiciousValueComparison', 'PhanTypeArraySuspiciousNullable', 'PhanTypeInvalidDimOffset', 'PhanTypeInvalidLeftOperandOfBitwiseOp', 'PhanTypeInvalidLeftOperandOfNumericOp', 'PhanTypeInvalidRightOperandOfAdd', 'PhanTypeInvalidRightOperandOfBitwiseOp', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentInternal', 'PhanTypeMismatchArgumentInternalProbablyReal', 'PhanTypeMismatchArgumentInternalReal', 'PhanTypeMismatchArgumentNullable', 'PhanTypeMismatchArgumentNullableInternal', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeNonVarPassByRef', 'PhanTypePossiblyInvalidDimOffset', 'PhanTypeSuspiciousNonTraversableForeach', 'PhanUndeclaredFunction', 'PhanUndeclaredVariable', 'PhanUndeclaredVariableDim'],
     ],
     // 'directory_suppressions' => ['src/directory_name' => ['PhanIssueName1', 'PhanIssueName2']] can be manually added if needed.

--- a/projects/plugins/super-cache/changelog/fix-phan-PhanPluginDuplicateIfCondition
+++ b/projects/plugins/super-cache/changelog/fix-phan-PhanPluginDuplicateIfCondition
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Remove redundant code.

--- a/projects/plugins/super-cache/wp-cache-phase2.php
+++ b/projects/plugins/super-cache/wp-cache-phase2.php
@@ -2153,9 +2153,6 @@ function wp_cache_ob_callback( $buffer ) {
 	} elseif ( wpsc_is_caching_user_disabled() ) {
 		wp_cache_debug( 'wp_cache_ob_callback: Caching disabled for known user. User logged in or cookie found.' );
 		$cache_this_page = false;
-	} elseif ( wp_cache_user_agent_is_rejected() ) {
-		wp_cache_debug( 'wp_cache_ob_callback: Caching disabled because user agent was rejected.' );
-		$cache_this_page = false;
 	}
 
 	if ( isset( $wpsc_save_headers ) && $wpsc_save_headers ) {


### PR DESCRIPTION
Closes MONOREP-175

 <!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This fixes the two violations found:
* CRM: in #36239 some logic was expanded, and there was a typo introduced that I corrected (`contact` → `company`)
* Super Cache: the same `elseif` condition was listed twice, so I removed the second instance that was unreachable

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

CI should be happy.
