### PR TITLE
Forms: fix fields count call

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-fields-count-call
+++ b/projects/packages/forms/changelog/fix-forms-fields-count-call
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: make sure fields is array before attempting a count

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -735,7 +735,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 			$version
 		);
 
-		$is_single_input_form = count( $form->fields ) === 1;
+		$is_single_input_form = is_array( $form->fields ) && count( $form->fields ) === 1;
 
 		$container_classes = array( 'wp-block-jetpack-contact-form-container' );
 

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
@@ -3827,13 +3827,6 @@ EOT;
 	 * when $form->fields is null or not countable.
 	 */
 	public function test_parse_handles_null_fields_without_fatal_error() {
-		global $post;
-
-		// Create a post for testing
-		if ( ! $post ) {
-			$post = self::factory()->post->create_and_get();
-		}
-
 		// Test 1: Create a form and set fields to null to simulate the error condition
 		$form = new Contact_Form(
 			array( 'to' => 'test@example.com' ),
@@ -3841,6 +3834,7 @@ EOT;
 		);
 
 		// Manually set fields to null to simulate the error condition
+		// @phan-suppress-next-line PhanTypeMismatchPropertyProbablyReal -- purely for testing purposes
 		$form->fields = null;
 
 		// Now test that parse() doesn't throw a fatal error when accessing $form->fields
@@ -3854,10 +3848,11 @@ EOT;
 		$this->assertIsString( $result, 'Parse should return a string even when fields is null' );
 
 		// Test 2: Test with fields set to false
-		$form2         = new Contact_Form(
+		$form2 = new Contact_Form(
 			array( 'to' => 'test@example.com' ),
 			''
 		);
+		// @phan-suppress-next-line PhanTypeMismatchPropertyProbablyReal -- purely for testing purposes
 		$form2->fields = false;
 
 		$result2 = Contact_Form::parse(

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
@@ -3820,4 +3820,88 @@ EOT;
 
 		remove_filter( 'grunion_should_send_email', '__return_true' );
 	}
+
+	/**
+	 * Test that parse method handles null or non-array fields gracefully without fatal error.
+	 * This tests the safety check added at line 738 to prevent PHP fatal errors
+	 * when $form->fields is null or not countable.
+	 */
+	public function test_parse_handles_null_fields_without_fatal_error() {
+		global $post;
+
+		// Create a post for testing
+		if ( ! $post ) {
+			$post = self::factory()->post->create_and_get();
+		}
+
+		// Test 1: Create a form and set fields to null to simulate the error condition
+		$form = new Contact_Form(
+			array( 'to' => 'test@example.com' ),
+			'' // Empty content
+		);
+
+		// Manually set fields to null to simulate the error condition
+		$form->fields = null;
+
+		// Now test that parse() doesn't throw a fatal error when accessing $form->fields
+		$result = Contact_Form::parse(
+			array( 'to' => 'test@example.com' ),
+			'',
+			array()
+		);
+
+		// Should return a valid string without throwing a fatal error
+		$this->assertIsString( $result, 'Parse should return a string even when fields is null' );
+
+		// Test 2: Test with fields set to false
+		$form2         = new Contact_Form(
+			array( 'to' => 'test@example.com' ),
+			''
+		);
+		$form2->fields = false;
+
+		$result2 = Contact_Form::parse(
+			array( 'to' => 'test@example.com' ),
+			'',
+			array()
+		);
+
+		$this->assertIsString( $result2, 'Parse should return a string even when fields is false' );
+
+		// Test 3: Test with empty array (should identify as not single input form)
+		$form3         = new Contact_Form(
+			array( 'to' => 'test@example.com' ),
+			''
+		);
+		$form3->fields = array();
+
+		$result3 = Contact_Form::parse(
+			array( 'to' => 'test@example.com' ),
+			'',
+			array()
+		);
+
+		$this->assertIsString( $result3, 'Parse should return a string with empty fields array' );
+		$this->assertStringNotContainsString( 'is-single-input-form', $result3, 'Should not have single-input-form class with empty fields' );
+
+		// Test 4: Test with single field (should identify as single input form)
+		$result4 = Contact_Form::parse(
+			array( 'to' => 'test@example.com' ),
+			"[contact-field label='Name' type='name' required='1'/]",
+			array()
+		);
+
+		$this->assertIsString( $result4, 'Parse should return a string with single field' );
+		$this->assertStringContainsString( 'is-single-input-form', $result4, 'Should have single-input-form class with one field' );
+
+		// Test 5: Test with multiple fields (should not be single input form)
+		$result5 = Contact_Form::parse(
+			array( 'to' => 'test@example.com' ),
+			"[contact-field label='Name' type='name' required='1'/][contact-field label='Email' type='email' required='1'/]",
+			array()
+		);
+
+		$this->assertIsString( $result5, 'Parse should return a string with multiple fields' );
+		$this->assertStringNotContainsString( 'is-single-input-form', $result5, 'Should not have single-input-form class with multiple fields' );
+	}
 }


### PR DESCRIPTION
Fixes FORMS-NEW

## Proposed changes:
This PR addresses a fatal due to calling `count` on `null` values (though `fields` should never be `null`)

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1762011118869409-slack-C06QF6JJDTM

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Run the tests with `jetpack test php packages/forms`.

The error should stop showing in production.