### PR TITLE
Forms: Fix last page remove items from view bug

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-second-page
+++ b/projects/packages/forms/changelog/fix-forms-second-page
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: fix last page invalidation error when items are removed

--- a/projects/packages/forms/src/dashboard/inbox/dataviews/actions.js
+++ b/projects/packages/forms/src/dashboard/inbox/dataviews/actions.js
@@ -50,11 +50,6 @@ const invalidateCacheAndNavigate = (
 	queryParams,
 	statusBeingRemovedFrom
 ) => {
-	// Invalidate entity records cache for current view
-	registry
-		.dispatch( coreStore )
-		.invalidateResolution( 'getEntityRecords', [ 'postType', 'feedback', currentQuery ] );
-
 	// Invalidate counts to ensure accurate totals
 	registry.dispatch( dashboardStore ).invalidateCounts();
 
@@ -161,7 +156,11 @@ export const markAsSpamAction = {
 
 		// If there is at least one successful update, invalidate the cache and navigate if needed
 		if ( itemsUpdated.length ) {
-			invalidateCacheAndNavigate( registry, getCurrentQuery(), queryParams, items[ 0 ]?.status );
+			let status = 'inbox';
+			if ( items[ 0 ]?.status === 'trash' ) {
+				status = 'trash';
+			}
+			invalidateCacheAndNavigate( registry, getCurrentQuery(), queryParams, status );
 		}
 
 		if ( itemsUpdated.length === items.length ) {
@@ -386,7 +385,11 @@ export const moveToTrashAction = {
 
 		// If there is at least one successful update, invalidate the cache and navigate if needed
 		if ( itemsUpdated.length ) {
-			invalidateCacheAndNavigate( registry, getCurrentQuery(), queryParams, items[ 0 ]?.status );
+			let status = 'inbox';
+			if ( items[ 0 ]?.status === 'trash' ) {
+				status = 'trash';
+			}
+			invalidateCacheAndNavigate( registry, getCurrentQuery(), queryParams, status );
 		}
 
 		if ( promises.every( ( { status } ) => status === 'fulfilled' ) ) {

--- a/projects/packages/forms/src/dashboard/inbox/dataviews/actions.js
+++ b/projects/packages/forms/src/dashboard/inbox/dataviews/actions.js
@@ -35,6 +35,53 @@ const getCountQueryParams = currentQuery => {
 	return queryParams;
 };
 
+/**
+ * Helper function to invalidate cache and navigate to correct page after removing items.
+ *
+ * @param {object} registry               - WordPress data registry.
+ * @param {object} currentQuery           - The current query.
+ * @param {object} queryParams            - Query parameters for count caching.
+ * @param {string} statusBeingRemovedFrom - The status items are being removed from ('trash', 'spam', or 'inbox').
+ */
+const invalidateCacheAndNavigate = (
+	registry,
+	currentQuery,
+	queryParams,
+	statusBeingRemovedFrom
+) => {
+	// Invalidate entity records cache for current view
+	registry
+		.dispatch( coreStore )
+		.invalidateResolution( 'getEntityRecords', [ 'postType', 'feedback', currentQuery ] );
+
+	// Invalidate counts to ensure accurate totals
+	registry.dispatch( dashboardStore ).invalidateCounts();
+
+	// Navigate to correct page if current page will be invalid
+	const { getTrashCount, getSpamCount, getInboxCount } = registry.select( dashboardStore );
+	const { setCurrentQuery } = registry.dispatch( dashboardStore );
+
+	// Get the appropriate count based on which status we're removing from
+	const countGetters = {
+		trash: getTrashCount,
+		spam: getSpamCount,
+		inbox: getInboxCount,
+	};
+	const remainingCount = countGetters[ statusBeingRemovedFrom ]( queryParams );
+
+	const perPage = currentQuery?.per_page || 20;
+	const newTotalPages = Math.max( 1, Math.ceil( remainingCount / perPage ) );
+	const currentPage = currentQuery?.page || 1;
+
+	if ( currentPage > newTotalPages ) {
+		// Navigate to the last valid page
+		setCurrentQuery( {
+			...currentQuery,
+			page: newTotalPages,
+		} );
+	}
+};
+
 export const BULK_ACTIONS = {
 	markAsSpam: 'mark_as_spam',
 	markAsNotSpam: 'mark_as_not_spam',
@@ -110,6 +157,12 @@ export const markAsSpamAction = {
 			items.map( ( { id } ) => saveEntityRecord( 'postType', 'feedback', { id, status: 'spam' } ) )
 		);
 		const itemsUpdated = promises.filter( ( { status } ) => status === 'fulfilled' );
+
+		// If there is at least one successful update, invalidate the cache and navigate if needed
+		if ( itemsUpdated.length ) {
+			invalidateCacheAndNavigate( registry, getCurrentQuery(), queryParams, 'inbox' );
+		}
+
 		if ( itemsUpdated.length === items.length ) {
 			// Every request was successful.
 			const successMessage =
@@ -181,6 +234,12 @@ export const markAsNotSpamAction = {
 			)
 		);
 		const itemsUpdated = promises.filter( ( { status } ) => status === 'fulfilled' );
+
+		// If there is at least one successful update, invalidate the cache and navigate if needed
+		if ( itemsUpdated.length ) {
+			invalidateCacheAndNavigate( registry, getCurrentQuery(), queryParams, 'spam' );
+		}
+
 		if ( itemsUpdated.length === items.length ) {
 			// Every request was successful.
 			const successMessage =
@@ -251,6 +310,13 @@ export const restoreAction = {
 				saveEntityRecord( 'postType', 'feedback', { id, status: 'publish' } )
 			)
 		);
+		const itemsUpdated = promises.filter( ( { status } ) => status === 'fulfilled' );
+
+		// If there is at least one successful update, invalidate the cache and navigate if needed
+		if ( itemsUpdated.length ) {
+			invalidateCacheAndNavigate( registry, getCurrentQuery(), queryParams, 'trash' );
+		}
+
 		if ( promises.every( ( { status } ) => status === 'fulfilled' ) ) {
 			const successMessage =
 				items.length === 1
@@ -314,6 +380,14 @@ export const moveToTrashAction = {
 				deleteEntityRecord( 'postType', 'feedback', id, {}, { throwOnError: true } )
 			)
 		);
+
+		const itemsUpdated = promises.filter( ( { status } ) => status === 'fulfilled' );
+
+		// If there is at least one successful update, invalidate the cache and navigate if needed
+		if ( itemsUpdated.length ) {
+			invalidateCacheAndNavigate( registry, getCurrentQuery(), queryParams, 'inbox' );
+		}
+
 		if ( promises.every( ( { status } ) => status === 'fulfilled' ) ) {
 			const successMessage =
 				items.length === 1
@@ -380,6 +454,7 @@ export const deleteAction = {
 		// If there is at least one successful update, invalidate the cache for filters.
 		if ( itemsUpdated.length ) {
 			invalidateFilters();
+			invalidateCacheAndNavigate( registry, getCurrentQuery(), queryParams, 'trash' );
 		}
 		if ( itemsUpdated.length === items.length ) {
 			// Every request was successful.

--- a/projects/packages/forms/src/dashboard/inbox/dataviews/actions.js
+++ b/projects/packages/forms/src/dashboard/inbox/dataviews/actions.js
@@ -161,7 +161,7 @@ export const markAsSpamAction = {
 
 		// If there is at least one successful update, invalidate the cache and navigate if needed
 		if ( itemsUpdated.length ) {
-			invalidateCacheAndNavigate( registry, getCurrentQuery(), queryParams, 'inbox' );
+			invalidateCacheAndNavigate( registry, getCurrentQuery(), queryParams, items[ 0 ]?.status );
 		}
 
 		if ( itemsUpdated.length === items.length ) {
@@ -386,7 +386,7 @@ export const moveToTrashAction = {
 
 		// If there is at least one successful update, invalidate the cache and navigate if needed
 		if ( itemsUpdated.length ) {
-			invalidateCacheAndNavigate( registry, getCurrentQuery(), queryParams, 'inbox' );
+			invalidateCacheAndNavigate( registry, getCurrentQuery(), queryParams, items[ 0 ]?.status );
 		}
 
 		if ( promises.every( ( { status } ) => status === 'fulfilled' ) ) {

--- a/projects/packages/forms/src/dashboard/inbox/dataviews/actions.js
+++ b/projects/packages/forms/src/dashboard/inbox/dataviews/actions.js
@@ -8,6 +8,7 @@ import { store as noticesStore } from '@wordpress/notices';
 import { notSpam, spam } from '../../icons';
 import { store as dashboardStore } from '../../store';
 import { updateMenuCounter, updateMenuCounterOptimistically } from '../utils';
+import { defaultView } from './views';
 
 /**
  * Helper function to extract count-relevant query params from the current query.
@@ -69,9 +70,9 @@ const invalidateCacheAndNavigate = (
 	};
 	const remainingCount = countGetters[ statusBeingRemovedFrom ]( queryParams );
 
-	const perPage = currentQuery?.per_page || 20;
+	const perPage = currentQuery?.per_page || defaultView.perPage;
 	const newTotalPages = Math.max( 1, Math.ceil( remainingCount / perPage ) );
-	const currentPage = currentQuery?.page || 1;
+	const currentPage = currentQuery?.page || defaultView.page;
 
 	if ( currentPage > newTotalPages ) {
 		// Navigate to the last valid page

--- a/projects/packages/forms/src/dashboard/inbox/dataviews/views.js
+++ b/projects/packages/forms/src/dashboard/inbox/dataviews/views.js
@@ -7,7 +7,7 @@ import { useSearchParams } from 'react-router';
 
 const LAYOUT_TABLE = 'table';
 
-const defaultView = {
+export const defaultView = {
 	type: LAYOUT_TABLE,
 	search: '',
 	filters: [],


### PR DESCRIPTION
Currently when you remove items from the last page, the request for content on the page returns a 400 error which results the state of the page freezing. 

This is fixed by making sure that we invalidate and navigate away from the last page if we notice that there is nothing on the last page. 

Before:

https://github.com/user-attachments/assets/539be11b-528a-47c7-9e82-0854835976bd

After:

https://github.com/user-attachments/assets/d1ef1848-f7c3-48c7-9202-60c3839bda3f

Fixes FORMS-361

## Proposed changes:

* Implement a invalidateCacheAndNavigate function that we can call on all the bulk actions that. 

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
See FORMS-361

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
* On trunk (to replicate the bug) 
* Create multiple pages of trashed items. 
* On the last page mark all the items as spam. 
* Notice that you end up on the last page with everything freeszing. 

Now switch to this branch and follow the same steps as above. 
Notice that you end up on the correct page as expected. 

