### PR TITLE
Forms: fix fields width auto attribute

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-fields-width-auto-attribute
+++ b/projects/packages/forms/changelog/fix-forms-fields-width-auto-attribute
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Forms: change field's attribute width to enum to support both integers and string

--- a/projects/packages/forms/src/blocks/shared/settings/index.js
+++ b/projects/packages/forms/src/blocks/shared/settings/index.js
@@ -13,7 +13,7 @@ export default {
 			default: true,
 		},
 		width: {
-			type: 'number',
+			enum: [ 25, 33, 50, 75, 100, 'auto' ],
 			default: 100,
 		},
 		shareFieldAttributes: {

--- a/projects/packages/forms/src/contact-form/css/grunion.scss
+++ b/projects/packages/forms/src/contact-form/css/grunion.scss
@@ -412,6 +412,8 @@ that needs to mimic the input element styles */
 	box-sizing: border-box;
 	position: relative;
 	flex: 1 1 100%;
+	display: flex;
+	flex-direction: column;
 }
 
 .wp-block-jetpack-contact-form .grunion-field-width-25-wrap {


### PR DESCRIPTION


Fixes [FORMS-370](https://linear.app/a8c/issue/FORMS-370/field-width-auto-setting-not-retained-after-editor-reload)

## Proposed changes:
This PR addresses an issue with new setting "auto" for field widths where the "auto" setting would be lost after a reload on the editor. This is due the `width` attribute being `type: number`. Changing the attribute definition to `enum` fixes the problem.

It also addresses field wrappers not being `display: flex`, making them not render the same way as in the editor.

Editor:
<img width="739" height="398" alt="image" src="https://github.com/user-attachments/assets/1d614e9d-eeb9-4461-afec-0de2195478f0" />

Frontend:
<img width="690" height="353" alt="image" src="https://github.com/user-attachments/assets/f6b7ec8a-4539-4fda-8b5c-1727bf48a4e5" />


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
None

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Insert a form with at least 2 fields. Make the first 2 width "auto". See that the editor and frontend show those side by side attempting to split the space evenly.
<img width="719" height="305" alt="image" src="https://github.com/user-attachments/assets/1df89294-efa5-45d9-a50f-d692bf26ed93" />
