### PR TITLE
Forms: update animated & outlined styles

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-animated-outlined-styles
+++ b/projects/packages/forms/changelog/fix-forms-animated-outlined-styles
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: animated and outlined styles need maintenance

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -976,7 +976,6 @@
 				outline: none;
 			}
 
-			.jetpack-field__input,
 			.jetpack-field__textarea,
 			.jetpack-field-dropdown__toggle {
 				padding-top: max(var(--jetpack--contact-form--input-padding-top, 0), 1.4em);

--- a/projects/packages/forms/src/blocks/contact-form/util/form-styles.js
+++ b/projects/packages/forms/src/blocks/contact-form/util/form-styles.js
@@ -129,6 +129,7 @@ window.jetpackForms.generateStyleVariables = function ( formNode ) {
 		fontFamily,
 		lineHeight,
 		height: inputHeight,
+		backdropFilter: inputBackdropFilter,
 	} = window.getComputedStyle( inputNode );
 
 	styleProbe.remove();
@@ -166,5 +167,6 @@ window.jetpackForms.generateStyleVariables = function ( formNode ) {
 		'--jetpack--contact-form--button-outline--border-radius': buttonOutlineBorderRadius,
 		'--jetpack--contact-form--button-outline--text-color': buttonOutlineTextColor,
 		'--jetpack--contact-form--button-outline--line-height': buttonOutlineLineHeight,
+		'--jetpack--contact-form--input-backdrop-filter': inputBackdropFilter,
 	};
 };

--- a/projects/packages/forms/src/blocks/input-phone/editor.scss
+++ b/projects/packages/forms/src/blocks/input-phone/editor.scss
@@ -103,10 +103,6 @@
 .is-style-animated .jetpack-contact-form .jetpack-field.jetpack-field-phone,
 .is-style-animated .jetpack-contact-form .jetpack-field.jetpack-field-telephone {
 
-	.jetpack-field__input {
-		padding-top: max(var(--jetpack--contact-form--input-padding-top, 0), 1.4em);
-	}
-
 	&:not(.has-placeholder):not(.is-selected),
 	&:not(.has-placeholder):not(.has-child-selected) {
 

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -553,7 +553,7 @@ class Contact_Form_Plugin {
 					}
 
 					$input_attrs           = self::get_block_support_classes_and_styles( $block_name, $inner_block['attrs'] );
-					$atts['inputclasses']  = 'wp-block-jetpack-input jetpack-field__input-element';
+					$atts['inputclasses']  = 'wp-block-jetpack-input';
 					$atts['inputclasses'] .= isset( $input_attrs['class'] ) ? ' ' . $input_attrs['class'] : '';
 					$atts['inputstyles']   = $input_attrs['style'] ?? null;
 

--- a/projects/packages/forms/src/contact-form/css/combobox.scss
+++ b/projects/packages/forms/src/contact-form/css/combobox.scss
@@ -24,6 +24,7 @@
 		padding-inline: 0;
 		gap: 0.4em;
 		color: inherit;
+		height: unset;
 
 		&:focus {
 			outline: 0;

--- a/projects/packages/forms/src/contact-form/css/grunion.scss
+++ b/projects/packages/forms/src/contact-form/css/grunion.scss
@@ -854,7 +854,7 @@ on production builds, the attributes are being reordered, causing side-effects
 	outline: none;
 }
 
-.contact-form .is-style-animated .grunion-field-wrap:not(.no-label) > input,
+.contact-form .is-style-animated .grunion-field-wrap:not(.no-label) > input:not([type="checkbox"]):not([type="radio"]):not([type="range"]),
 .contact-form .is-style-animated .grunion-field-wrap:not(.no-label) > textarea,
 .contact-form .is-style-animated .grunion-field-wrap:not(.no-label) select:not(.jetpack-field__input-element) {
 	padding-top: 1.4em;

--- a/projects/packages/forms/src/contact-form/css/phone-field.scss
+++ b/projects/packages/forms/src/contact-form/css/phone-field.scss
@@ -18,6 +18,7 @@
 		padding: var(--jetpack--contact-form--input-padding);
 		line-height: var(--jetpack--contact-form--line-height);
 		align-items: center;
+		backdrop-filter: var(--jetpack--contact-form--input-backdrop-filter, none);
 
 		&:has(.jetpack-field__input-element:focus) {
 			outline-width: 2px;
@@ -49,13 +50,14 @@
 			flex: 1;
 			outline: none;
 			color: inherit;
-			background: inherit;
+			background: none;
 			width: inherit;
 			box-sizing: border-box;
 			resize: none;
 			padding: 0;
 			min-width: unset;
 			min-height: unset;
+			backdrop-filter: none;
 
 			&:not(.jetpack-field__input-prefix .jetpack-field__input-element) {
 				letter-spacing: inherit;

--- a/projects/packages/forms/src/contact-form/css/phone-field.scss
+++ b/projects/packages/forms/src/contact-form/css/phone-field.scss
@@ -121,6 +121,7 @@
 
 		.jetpack-field__input-phone-wrapper {
 			z-index: unset;
+			border-color: transparent !important;
 
 			&:has(.jetpack-field__input-element:focus) {
 				outline: unset;

--- a/projects/packages/forms/src/contact-form/css/phone-field.scss
+++ b/projects/packages/forms/src/contact-form/css/phone-field.scss
@@ -75,9 +75,10 @@
 	.is-style-animated & {
 
 		.jetpack-field__input-phone-wrapper {
-			padding-top: max(var(--jetpack--contact-form--input-padding-top, 0), 1.4em);
-			padding-left: var(--jetpack--contact-form--animated-left-offset);
-			padding-right: var(--jetpack--contact-form--animated-right-offset);
+
+			&:not(.no-label) {
+				padding-top: max(var(--jetpack--contact-form--input-padding-top, 0), 1.4em);
+			}
 
 			&:has(.jetpack-field__input-element:focus) {
 				outline: unset;
@@ -104,6 +105,10 @@
 
 				.grunion-label-text {
 					font-size: 0.75em;
+				}
+
+				.grunion-label-required {
+					font-size: 0.6375em;
 				}
 			}
 		}


### PR DESCRIPTION


## Proposed changes:
This PR updates some values and adds a new variable to keep mimicking theme's defaults on Jetpack Forms fields.
It addresses an issue with wrong padding.
It addresses a css class wrongly applied to a wrapper

Before:
<img width="665" height="339" alt="image" src="https://github.com/user-attachments/assets/fb487ef2-aab4-41a8-9385-f7e9126f3406" />


After:
<img width="650" height="318" alt="image" src="https://github.com/user-attachments/assets/9b71a979-7fd8-4752-929a-4610f2c85247" />


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
None

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Insert a form and switch it to Animated and Outlined styles. Glitches were most noticeable on Phone input field, but overall the styles are no more consistent between editor and frontend.