### PR TITLE
Forms: add integrations to dashboard mobile menu

### DIFF
--- a/projects/packages/forms/changelog/add-form-integrations-mobile-menu
+++ b/projects/packages/forms/changelog/add-form-integrations-mobile-menu
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Forms: add integrations to dashboard mobile menu.

--- a/projects/packages/forms/src/dashboard/components/actions-dropdown-menu/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/actions-dropdown-menu/index.tsx
@@ -5,7 +5,8 @@ import jetpackAnalytics from '@automattic/jetpack-analytics';
 import { DropdownMenu } from '@wordpress/components';
 import { useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { menu, plus, download } from '@wordpress/icons';
+import { menu, plus, download, plugins } from '@wordpress/icons';
+import { useNavigate } from 'react-router';
 /**
  * Internal dependencies
  */
@@ -21,6 +22,7 @@ const ActionsDropdownMenu = ( { exportData }: ActionsDropdownMenuProps ) => {
 	const { openNewForm } = useCreateForm();
 	const { showExportModal, openModal, closeModal, onExport, autoConnectGdrive, exportLabel } =
 		useExportResponses();
+	const navigate = useNavigate();
 
 	const analyticsEvent = useCallback( () => {
 		jetpackAnalytics.tracks.recordEvent( 'jetpack_wpa_forms_landing_page_cta_click', {
@@ -34,7 +36,19 @@ const ActionsDropdownMenu = ( { exportData }: ActionsDropdownMenuProps ) => {
 		} );
 	}, [ openNewForm, analyticsEvent ] );
 
+	const onIntegrationsClick = useCallback( () => {
+		jetpackAnalytics.tracks.recordEvent( 'jetpack_forms_integrations_button_click', {
+			origin: 'dashboard',
+		} );
+		navigate( '/integrations' );
+	}, [ navigate ] );
+
 	const controls = [
+		{
+			icon: plugins,
+			onClick: onIntegrationsClick,
+			title: __( 'Integrations', 'jetpack-forms' ),
+		},
 		...( exportData.show
 			? [
 					{

--- a/projects/packages/forms/src/dashboard/components/layout/style.scss
+++ b/projects/packages/forms/src/dashboard/components/layout/style.scss
@@ -78,4 +78,17 @@ body.jetpack_page_jetpack-forms-admin {
 	}
 
 
+	.admin-ui-page__header {
+		box-sizing: border-box;
+		margin: 0;
+		padding: 16px 48px 4px;
+		width: 100%;
+		background: transparent;
+
+		@media (max-width: 782px) {
+			padding: 8px 24px 0;
+		}
+	}
+
+
 }

--- a/projects/packages/forms/src/dashboard/components/layout/style.scss
+++ b/projects/packages/forms/src/dashboard/components/layout/style.scss
@@ -78,17 +78,4 @@ body.jetpack_page_jetpack-forms-admin {
 	}
 
 
-	.admin-ui-page__header {
-		box-sizing: border-box;
-		margin: 0;
-		padding: 16px 48px 4px;
-		width: 100%;
-		background: transparent;
-
-		@media (max-width: 782px) {
-			padding: 8px 24px 0;
-		}
-	}
-
-
 }

--- a/projects/plugins/jetpack/changelog/add-form-integrations-mobile-menu
+++ b/projects/plugins/jetpack/changelog/add-form-integrations-mobile-menu
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+orms: add integrations to dashboard mobile menu.


### PR DESCRIPTION
## Proposed changes:

We recently removed the Integrations  tab and added an Integrations button in the header. On mobile the header buttons do not appear, so you can't access integrations. This adds integrations to the mobile menu. The link will open the new modal. 

<img width="496" height="594" alt="integrations-mobile-menu-2" src="https://github.com/user-attachments/assets/5daa7d98-bca4-4daf-8c70-3cacc5818175" />

<img width="496" height="753" alt="integrations-mobile-2" src="https://github.com/user-attachments/assets/1280d4e6-14e8-4c12-b50d-c4200dde49b9" />


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Go to Jetpack > Forms, either on mobile device, or you can also resize browser to mobile. Confirm that Integrations appears on mobile menu in upper right, and that modal opens and closes as expected

