### PR TITLE
Forms: make width auto adjust to content

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-width-auto-adjust-to-content
+++ b/projects/packages/forms/changelog/fix-forms-width-auto-adjust-to-content
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Forms: use flex-basis 0 for auto width as it will deal better adjusting to content and not extra space

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -107,7 +107,7 @@
 			}
 
 			&.jetpack-field__width-auto {
-				flex: 1 1 auto;
+				flex: 1 1 0;
 			}
 
 			@media (max-width: #{ (gb.$break-mobile) }) {

--- a/projects/packages/forms/src/contact-form/css/grunion.scss
+++ b/projects/packages/forms/src/contact-form/css/grunion.scss
@@ -1220,12 +1220,14 @@ on production builds, the attributes are being reordered, causing side-effects
 	overflow: hidden;
 	transform: translateY(-0.33em);
 	transition: max-height 200ms cubic-bezier(0.34, 0.8, 0.34, 1), opacity 200ms cubic-bezier(0.34, 0.8, 0.34, 1), transform 100ms cubic-bezier(0.34, 0.8, 0.34, 1);
+	display: flex;
+	flex-wrap: nowrap;
+	flex-direction: row;
 }
 
 .contact-form__input-error.has-errors {
 
 	margin: 0.25rem 0;
-	display: flex;
 	opacity: 1;
 	max-height: unset;
 	transform: translateY(0);

--- a/projects/packages/forms/src/contact-form/css/grunion.scss
+++ b/projects/packages/forms/src/contact-form/css/grunion.scss
@@ -437,7 +437,7 @@ that needs to mimic the input element styles */
 }
 
 .wp-block-jetpack-contact-form .grunion-field-width-auto-wrap {
-	flex: 1 1 auto;
+	flex: 1 1 0;
 }
 
 @media only screen and ( max-width: 480px ) {


### PR DESCRIPTION

## Proposed changes:
This PR changes how the CSS classes for auto width deal with extra content using `0` instead of `auto` for flex-basis. Using auto (which tries to distributes extra space) would fail when errors are shown, making it snap back at 100% width.


Before:
<img width="695" height="324" alt="image" src="https://github.com/user-attachments/assets/01c16d2a-bae9-4d75-911e-b89725e6c0f1" />


After:
<img width="697" height="298" alt="image" src="https://github.com/user-attachments/assets/29b90333-147a-4705-8912-fb78c029e85c" />


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
None

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Insert a form and use width `auto` for 2 fields so that they sit next to each other. Visit on the frontend and test that it looks like in the editor. Make sure to trigger some error to verify the issue was fixed.
