### PR TITLE
Forms: fix error overlap on single input forms

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-error-overlap-on-single-input-forms
+++ b/projects/packages/forms/changelog/fix-forms-error-overlap-on-single-input-forms
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: fix error overlapping on single input forms after using position: absolute and turning the main container to display: flex

--- a/projects/packages/forms/src/contact-form/css/grunion.scss
+++ b/projects/packages/forms/src/contact-form/css/grunion.scss
@@ -378,6 +378,13 @@ that needs to mimic the input element styles */
 	padding-left: 0;
 }
 
+.wp-block-jetpack-contact-form-container.is-single-input-form {
+
+	&:has(.contact-form__input-error.has-errors) {
+		margin-bottom: calc(var(--wp--style--block-gap, 1.5rem) * 2);
+	}
+}
+
 .wp-block-jetpack-contact-form .wp-block-jetpack-button {
 	min-height: var(--jetpack--contact-form--input-height, auto);
 	align-self: flex-end;

--- a/projects/packages/forms/src/contact-form/css/grunion.scss
+++ b/projects/packages/forms/src/contact-form/css/grunion.scss
@@ -419,8 +419,11 @@ that needs to mimic the input element styles */
 	box-sizing: border-box;
 	position: relative;
 	flex: 1 1 100%;
-	display: flex;
-	flex-direction: column;
+
+	:where(:not(.is-single-input-form) > .grunion-field-wrap) {
+		display: flex;
+		flex-direction: column;
+	}
 }
 
 .wp-block-jetpack-contact-form .grunion-field-width-25-wrap {


### PR DESCRIPTION
Fixes [FORMS-371](https://linear.app/a8c/issue/FORMS-371/error-message-overlaps-on-single-input-forms)

## Proposed changes:
This PR addresses a wee regression on field errors after implementation of width auto feature (https://github.com/Automattic/jetpack/pull/45741). The wrapper needs to remain `display: block` for the error to show properly.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
https://github.com/Automattic/jetpack/pull/45747#discussion_r2487105198

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Create a single input form (a form with just one input on it, the typical subscribe lean form). Try submitting without any content (or trigger an error due to field validation). See that the error shows below the input and doesn't overlap.

Before:
<img width="675" height="127" alt="image" src="https://github.com/user-attachments/assets/e0ac4cce-3030-4289-8b1d-7f66a21668b4" />


After:
<img width="677" height="131" alt="image" src="https://github.com/user-attachments/assets/b9533ea1-adeb-40da-b948-0ac40678acab" />
