### PR TITLE
Replace icons removed from `@wordpress/icons`

### DIFF
--- a/projects/js-packages/ai-client/changelog/update-replace-removed-wordpress-icons
+++ b/projects/js-packages/ai-client/changelog/update-replace-removed-wordpress-icons
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Replace icons removed from @wordpress/icons with alternatives.

--- a/projects/js-packages/ai-client/src/logo-generator/components/upgrade-nudge.tsx
+++ b/projects/js-packages/ai-client/src/logo-generator/components/upgrade-nudge.tsx
@@ -5,7 +5,7 @@ import { useAnalytics } from '@automattic/jetpack-shared-extension-utils';
 import { Button } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { Icon, warning } from '@wordpress/icons';
+import { Icon, cautionFilled as warning } from '@wordpress/icons';
 /**
  * Internal dependencies
  */

--- a/projects/js-packages/components/changelog/update-replace-removed-wordpress-icons
+++ b/projects/js-packages/components/changelog/update-replace-removed-wordpress-icons
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Replace icons removed from @wordpress/icons with alternatives.

--- a/projects/js-packages/components/components/alert/index.tsx
+++ b/projects/js-packages/components/components/alert/index.tsx
@@ -1,4 +1,4 @@
-import { Icon, warning, info, check } from '@wordpress/icons';
+import { Icon, cautionFilled as warning, info, check } from '@wordpress/icons';
 import clsx from 'clsx';
 import styles from './style.module.scss';
 import type { ReactNode, Component, ReactElement, FC } from 'react';

--- a/projects/js-packages/components/components/notice/index.tsx
+++ b/projects/js-packages/components/components/notice/index.tsx
@@ -1,4 +1,4 @@
-import { Icon, warning, info, check, close } from '@wordpress/icons';
+import { Icon, cautionFilled as warning, info, check, close } from '@wordpress/icons';
 import clsx from 'clsx';
 import styles from './style.module.scss';
 import type { Component, FC, ReactElement, ReactNode } from 'react';

--- a/projects/js-packages/licensing/changelog/update-replace-removed-wordpress-icons
+++ b/projects/js-packages/licensing/changelog/update-replace-removed-wordpress-icons
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Replace icons removed from @wordpress/icons with alternatives.

--- a/projects/js-packages/licensing/components/activation-screen-error/index.tsx
+++ b/projects/js-packages/licensing/components/activation-screen-error/index.tsx
@@ -1,5 +1,5 @@
 import jetpackAnalytics from '@automattic/jetpack-analytics';
-import { Icon, warning, check } from '@wordpress/icons';
+import { Icon, cautionFilled as warning, check } from '@wordpress/icons';
 import { useEffect } from 'react';
 import { LICENSE_ERRORS } from './constants';
 import { useGetErrorContent } from './use-get-error-content';

--- a/projects/js-packages/scan/changelog/update-replace-removed-wordpress-icons
+++ b/projects/js-packages/scan/changelog/update-replace-removed-wordpress-icons
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Replace icons removed from @wordpress/icons with alternatives.

--- a/projects/js-packages/scan/src/components/threat-modal/threat-notice.tsx
+++ b/projects/js-packages/scan/src/components/threat-modal/threat-notice.tsx
@@ -1,7 +1,7 @@
 import { Text, Button } from '@automattic/jetpack-components';
 import { Notice, Spinner } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { Icon, warning } from '@wordpress/icons';
+import { Icon, cautionFilled as warning } from '@wordpress/icons';
 import { useContext } from 'react';
 import { ThreatModalContext } from './index.tsx';
 import styles from './styles.module.scss';

--- a/projects/packages/videopress/changelog/update-replace-removed-wordpress-icons
+++ b/projects/packages/videopress/changelog/update-replace-removed-wordpress-icons
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Replace icons removed from @wordpress/icons with alternatives.

--- a/projects/packages/videopress/src/client/admin/components/global-notice/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/global-notice/index.tsx
@@ -1,7 +1,7 @@
 import { useConnection } from '@automattic/jetpack-connection';
 import { Notice } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { Icon, warning, info, check } from '@wordpress/icons';
+import { Icon, cautionFilled as warning, info, check } from '@wordpress/icons';
 import clsx from 'clsx';
 import styles from './styles.module.scss';
 import type { ReactElement, ReactNode } from 'react';

--- a/projects/packages/videopress/src/client/admin/components/video-list/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/video-list/index.tsx
@@ -4,7 +4,7 @@
 import { Text, useBreakpointMatch } from '@automattic/jetpack-components';
 import { Tooltip } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { Icon, info, warning } from '@wordpress/icons';
+import { Icon, info, cautionFilled as warning } from '@wordpress/icons';
 import clsx from 'clsx';
 import { useState } from 'react';
 /**

--- a/projects/packages/videopress/src/client/admin/components/video-thumbnail/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/video-thumbnail/index.tsx
@@ -12,7 +12,15 @@ import {
 import { Dropdown } from '@wordpress/components';
 import { gmdateI18n } from '@wordpress/date';
 import { __, sprintf } from '@wordpress/i18n';
-import { Icon, edit, cloud, image, media, video, warning } from '@wordpress/icons';
+import {
+	Icon,
+	pencil as edit,
+	cloud,
+	image,
+	media,
+	video,
+	cautionFilled as warning,
+} from '@wordpress/icons';
 import clsx from 'clsx';
 import { forwardRef } from 'react';
 /**

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/banner/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/banner/index.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { Spinner } from '@wordpress/components';
-import { Icon, warning } from '@wordpress/icons';
+import { Icon, cautionFilled as warning } from '@wordpress/icons';
 /**
  * Types
  */

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/video-not-owned-warning/index.native.js
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/video-not-owned-warning/index.native.js
@@ -3,7 +3,7 @@
  */
 import { usePreferredColorSchemeStyle } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
-import { Icon, warning } from '@wordpress/icons';
+import { Icon, cautionFilled as warning } from '@wordpress/icons';
 /**
  * External dependencies
  */

--- a/projects/plugins/jetpack/changelog/update-replace-removed-wordpress-icons
+++ b/projects/plugins/jetpack/changelog/update-replace-removed-wordpress-icons
@@ -1,0 +1,4 @@
+Significance: patch
+Type: compat
+
+Replace icons removed from @wordpress/icons with alternatives.

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/message/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/message/index.tsx
@@ -3,7 +3,7 @@
  */
 import {
 	Icon,
-	warning,
+	cautionFilled as warning,
 	info,
 	cancelCircleFilled as error,
 	check as success,

--- a/projects/plugins/jetpack/extensions/blocks/google-docs-embed/embed.js
+++ b/projects/plugins/jetpack/extensions/blocks/google-docs-embed/embed.js
@@ -5,7 +5,7 @@ import { ToolbarGroup, ToolbarButton, withNotices } from '@wordpress/components'
 import { compose } from '@wordpress/compose';
 import { useEffect, useRef, useState } from '@wordpress/element';
 import { __, _x, sprintf } from '@wordpress/i18n';
-import { edit } from '@wordpress/icons';
+import { pencil as edit } from '@wordpress/icons';
 import EmbedPlaceHolder from './embed-placeholder';
 import Preview from './preview';
 

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/email-preview.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/email-preview.js
@@ -19,7 +19,15 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
 import { useState, useCallback, useEffect, createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { desktop, mobile, tablet, check, people, currencyDollar, warning } from '@wordpress/icons';
+import {
+	desktop,
+	mobile,
+	tablet,
+	check,
+	people,
+	currencyDollar,
+	cautionFilled as warning,
+} from '@wordpress/icons';
 import './email-preview.scss';
 import { accessOptions } from '../../shared/memberships/constants';
 import { useAccessLevel } from '../../shared/memberships/edit';

--- a/projects/plugins/jetpack/extensions/shared/components/product-management-controls/invalid-product-warning.js
+++ b/projects/plugins/jetpack/extensions/shared/components/product-management-controls/invalid-product-warning.js
@@ -1,5 +1,5 @@
 import { Warning } from '@wordpress/block-editor';
-import { Icon, warning } from '@wordpress/icons';
+import { Icon, cautionFilled as warning } from '@wordpress/icons';
 import { useProductManagementContext } from './context';
 import { getMessageByProductType } from './utils';
 

--- a/projects/plugins/jetpack/extensions/shared/components/product-management-controls/toolbar-control.js
+++ b/projects/plugins/jetpack/extensions/shared/components/product-management-controls/toolbar-control.js
@@ -3,7 +3,7 @@ import { BlockControls } from '@wordpress/block-editor';
 import { ExternalLink, MenuGroup, MenuItem, ToolbarDropdownMenu } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { __, sprintf } from '@wordpress/i18n';
-import { check, update, warning } from '@wordpress/icons';
+import { check, update, cautionFilled as warning } from '@wordpress/icons';
 import { store as membershipProductsStore } from '../../../store/membership-products';
 import { CUSTOMIZER_EDITOR, getEditorType } from '../../get-editor-type';
 import { useProductManagementContext } from './context';

--- a/projects/plugins/protect/changelog/update-replace-removed-wordpress-icons
+++ b/projects/plugins/protect/changelog/update-replace-removed-wordpress-icons
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Replace icons removed from @wordpress/icons with alternatives.

--- a/projects/plugins/protect/src/js/components/error-admin-section-hero/index.tsx
+++ b/projects/plugins/protect/src/js/components/error-admin-section-hero/index.tsx
@@ -1,6 +1,6 @@
 import { Text } from '@automattic/jetpack-components';
 import { __ } from '@wordpress/i18n';
-import { Icon, warning } from '@wordpress/icons';
+import { Icon, cautionFilled as warning } from '@wordpress/icons';
 import AdminSectionHero from '../admin-section-hero';
 import ScanNavigation from '../scan-navigation';
 import styles from './styles.module.scss';

--- a/projects/plugins/protect/src/js/components/notice/index.jsx
+++ b/projects/plugins/protect/src/js/components/notice/index.jsx
@@ -1,5 +1,5 @@
 import { __ } from '@wordpress/i18n';
-import { check, close, info, warning, Icon } from '@wordpress/icons';
+import { check, close, info, cautionFilled as warning, Icon } from '@wordpress/icons';
 import { useCallback, useEffect } from 'react';
 import useNotices from '../../hooks/use-notices';
 import styles from './styles.module.scss';

--- a/projects/plugins/protect/src/js/components/threats-list/navigation.jsx
+++ b/projects/plugins/protect/src/js/components/threats-list/navigation.jsx
@@ -3,7 +3,7 @@ import { __ } from '@wordpress/i18n';
 import {
 	wordpress as coreIcon,
 	plugins as pluginsIcon,
-	warning as warningIcon,
+	cautionFilled as warningIcon,
 	color as themesIcon,
 	code as filesIcon,
 	grid as databaseIcon,


### PR DESCRIPTION
`edit` and `warning` icons have been [removed ](https://github.com/WordPress/gutenberg/blob/02748a7d56c4a8b30266c0d471b7973838d33fc4/packages/icons/CHANGELOG.md#1100-2025-10-17) from `@wordpress/icons` and replacements mentioned there. Those replacements have been there for a [long time](https://github.com/WordPress/gutenberg/pull/67895) now. Thus, in preparation for the package update, I have extracted these changes out of #45651.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Replace `edit` and `warning` with `pencil` and `cautionFilled` icons respectively

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Just do a sanity check of some UIs where those icons are used.
    - For example, add `define( 'JETPACK_BLOCKS_VARIATION', 'beta' );` to `wp-config.php`
    - Insert the "Google Docs (Beta)" block
    - Check the icon for the edit URL UI
    <img width="340" height="311" alt="Screenshot 2025-11-04 at 5 22 43 PM" src="https://github.com/user-attachments/assets/c683b87b-2045-4a37-9143-66486d7aadc6" />



