### PR TITLE
Build: Prepend priority repos to mirrors.txt

### DIFF
--- a/tools/cli/commands/build.js
+++ b/tools/cli/commands/build.js
@@ -196,7 +196,7 @@ export async function handler( argv ) {
 		.then( async () => {
 			if ( argv.forMirrors && ctx.mirrorRepos.length > 0 ) {
 				const mirrorsFile = `${ argv.forMirrors }/mirrors.txt`;
-				await fs.writeFile( mirrorsFile, ctx.mirrorRepos.join( '\n' ), {
+				await fs.writeFile( mirrorsFile, ctx.mirrorRepos.join( '\n' ) + '\n', {
 					encoding: 'utf8',
 				} );
 			}

--- a/tools/cli/commands/build.js
+++ b/tools/cli/commands/build.js
@@ -540,6 +540,28 @@ async function writeFileAtomic( file, data, options = {} ) {
 }
 
 /**
+ * Prepend data to a file.
+ *
+ * Reads the existing file content and prepends the new data.
+ * Intended to be similar to fs.appendFile. Too bad this isn't a native function.
+ *
+ * If the file doesn't exist, it will be created.
+ *
+ * @param {string} path    - Path to file.
+ * @param {string} data    - Contents to prepend.
+ * @param {object} options - Options.
+ */
+async function prependFile( path, data, options = {} ) {
+	const existingData = await fs.readFile( path, options ).catch( e => {
+		if ( e.code === 'ENOENT' ) {
+			return '';
+		}
+		throw e;
+	} );
+	await writeFileAtomic( path, data + existingData, options );
+}
+
+/**
  * Copy a file atomically.
  *
  * Copies to a temporary file then renames, on the assumption that the latter is an atomic operation.
@@ -1065,7 +1087,14 @@ async function buildProject( t ) {
 		runversion: projectRunVersionNumber,
 	};
 	await t.ctx.mirrorMutex( async () => {
-		// prettier-ignore
-		await fs.appendFile( `${ t.argv.forMirrors }/mirrors.txt`, `${ gitSlug }\n`, { encoding: 'utf8' } );
+		// Priority repos are pushed to the mirror repos first so we can deploy them sooner.
+		const priorityRepos = [ 'Automattic/jetpack-production', 'Automattic/jetpack-mu-wpcom-plugin' ];
+		const mirrorsFile = `${ t.argv.forMirrors }/mirrors.txt`;
+
+		if ( priorityRepos.includes( gitSlug ) ) {
+			await prependFile( mirrorsFile, `${ gitSlug }\n`, { encoding: 'utf8' } );
+		} else {
+			await fs.appendFile( mirrorsFile, `${ gitSlug }\n`, { encoding: 'utf8' } );
+		}
 	} );
 }

--- a/tools/cli/commands/build.js
+++ b/tools/cli/commands/build.js
@@ -189,9 +189,18 @@ export async function handler( argv ) {
 		promises: {},
 		mirrorMutex: pLimit( 1 ),
 		versions: {},
+		mirrorRepos: [],
 	};
 	await listr
 		.run( ctx )
+		.then( async () => {
+			if ( argv.forMirrors && ctx.mirrorRepos.length > 0 ) {
+				const mirrorsFile = `${ argv.forMirrors }/mirrors.txt`;
+				await fs.writeFile( mirrorsFile, ctx.mirrorRepos.join( '\n' ), {
+					encoding: 'utf8',
+				} );
+			}
+		} )
 		.finally( () => {
 			if ( missing.size ) {
 				console.error( '' );
@@ -537,28 +546,6 @@ async function writeFileAtomic( file, data, options = {} ) {
 		await fs.rm( tmpfile ).catch( () => null );
 		throw e;
 	}
-}
-
-/**
- * Prepend data to a file.
- *
- * Reads the existing file content and prepends the new data.
- * Intended to be similar to fs.appendFile. Too bad this isn't a native function.
- *
- * If the file doesn't exist, it will be created.
- *
- * @param {string} path    - Path to file.
- * @param {string} data    - Contents to prepend.
- * @param {object} options - Options.
- */
-async function prependFile( path, data, options = {} ) {
-	const existingData = await fs.readFile( path, options ).catch( e => {
-		if ( e.code === 'ENOENT' ) {
-			return '';
-		}
-		throw e;
-	} );
-	await writeFileAtomic( path, data + existingData, options );
 }
 
 /**
@@ -1089,12 +1076,11 @@ async function buildProject( t ) {
 	await t.ctx.mirrorMutex( async () => {
 		// Priority repos are pushed to the mirror repos first so we can deploy them sooner.
 		const priorityRepos = [ 'Automattic/jetpack-production', 'Automattic/jetpack-mu-wpcom-plugin' ];
-		const mirrorsFile = `${ t.argv.forMirrors }/mirrors.txt`;
 
 		if ( priorityRepos.includes( gitSlug ) ) {
-			await prependFile( mirrorsFile, `${ gitSlug }\n`, { encoding: 'utf8' } );
+			t.ctx.mirrorRepos.unshift( gitSlug );
 		} else {
-			await fs.appendFile( mirrorsFile, `${ gitSlug }\n`, { encoding: 'utf8' } );
+			t.ctx.mirrorRepos.push( gitSlug );
 		}
 	} );
 }

--- a/tools/cli/commands/build.js
+++ b/tools/cli/commands/build.js
@@ -24,6 +24,11 @@ import { chalkJetpackGreen } from '../helpers/styling.js';
 export const command = 'build [project...]';
 export const describe = 'Builds one or more monorepo projects';
 
+const priorityRepos = new Set( [
+	'Automattic/jetpack-production',
+	'Automattic/jetpack-mu-wpcom-plugin',
+] );
+
 /**
  * Options definition for the build subcommand.
  *
@@ -1074,9 +1079,7 @@ async function buildProject( t ) {
 	};
 
 	// Priority repos are pushed to the mirror repos first so we can deploy them sooner.
-	const priorityRepos = [ 'Automattic/jetpack-production', 'Automattic/jetpack-mu-wpcom-plugin' ];
-
-	if ( priorityRepos.includes( gitSlug ) ) {
+	if ( priorityRepos.has( gitSlug ) ) {
 		t.ctx.mirrorRepos.unshift( gitSlug );
 	} else {
 		t.ctx.mirrorRepos.push( gitSlug );

--- a/tools/cli/commands/build.js
+++ b/tools/cli/commands/build.js
@@ -24,6 +24,7 @@ import { chalkJetpackGreen } from '../helpers/styling.js';
 export const command = 'build [project...]';
 export const describe = 'Builds one or more monorepo projects';
 
+// Priority repos are pushed to the mirror repos first so we can deploy them sooner.
 const priorityRepos = new Set( [
 	'Automattic/jetpack-production',
 	'Automattic/jetpack-mu-wpcom-plugin',

--- a/tools/cli/commands/build.js
+++ b/tools/cli/commands/build.js
@@ -187,7 +187,6 @@ export async function handler( argv ) {
 		limit: pLimit( argv.concurrency ),
 		dependencies,
 		promises: {},
-		mirrorMutex: pLimit( 1 ),
 		versions: {},
 		mirrorRepos: [],
 	};
@@ -1073,14 +1072,13 @@ async function buildProject( t ) {
 		version: projectVersionNumber,
 		runversion: projectRunVersionNumber,
 	};
-	await t.ctx.mirrorMutex( async () => {
-		// Priority repos are pushed to the mirror repos first so we can deploy them sooner.
-		const priorityRepos = [ 'Automattic/jetpack-production', 'Automattic/jetpack-mu-wpcom-plugin' ];
 
-		if ( priorityRepos.includes( gitSlug ) ) {
-			t.ctx.mirrorRepos.unshift( gitSlug );
-		} else {
-			t.ctx.mirrorRepos.push( gitSlug );
-		}
-	} );
+	// Priority repos are pushed to the mirror repos first so we can deploy them sooner.
+	const priorityRepos = [ 'Automattic/jetpack-production', 'Automattic/jetpack-mu-wpcom-plugin' ];
+
+	if ( priorityRepos.includes( gitSlug ) ) {
+		t.ctx.mirrorRepos.unshift( gitSlug );
+	} else {
+		t.ctx.mirrorRepos.push( gitSlug );
+	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This prepends the following repos to `mirrors.txt`:
* `Automattic/jetpack-production`
* `Automattic/jetpack-mu-wpcom-plugin`

This will reduce the wait to deploy to Simple by 60-90 seconds, as they'll be pushed first rather than last.

More discussion here: p1762272271170879-slack-C05Q5HSS013

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

I'm not sure the best way to test, as this fails locally: `jetpack build plugins/jetpack --for-mirrors=asdf`

Temporarily adding `packages/phpunit-select-config` to `priorityRepos` and then running this results in the expected order:

`jetpack build packages/ip --for-mirrors=asdf`