### PR TITLE
Forms: fix phone field controls overlap

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-phone-field-controls-overlap
+++ b/projects/packages/forms/changelog/fix-forms-phone-field-controls-overlap
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: fix phone field extra controls option to append to shared field controls

--- a/projects/packages/forms/src/blocks/field-telephone/edit.js
+++ b/projects/packages/forms/src/blocks/field-telephone/edit.js
@@ -151,14 +151,7 @@ export default function PhoneFieldEdit( props ) {
 					{
 						index: 2,
 						element: (
-							<BaseControl
-								help={ __(
-									'Search and select a default country for the phone number field.',
-									'jetpack-forms'
-								) }
-								__nextHasNoMarginBottom={ true }
-								key="phoneFieldControls"
-							>
+							<BaseControl __nextHasNoMarginBottom={ true } key="phoneFieldControls">
 								<ToggleControl
 									label={ __( 'Show country selector', 'jetpack-forms' ) }
 									checked={ showCountrySelector || false }
@@ -173,6 +166,10 @@ export default function PhoneFieldEdit( props ) {
 										onChange={ newValue => setAttributes( { searchPlaceholder: newValue } ) }
 										__nextHasNoMarginBottom={ true }
 										__next40pxDefaultSize={ true }
+										help={ __(
+											'Search and select a default country for the phone number field.',
+											'jetpack-forms'
+										) }
 									/>
 								) }
 							</BaseControl>

--- a/projects/packages/forms/src/blocks/field-telephone/edit.js
+++ b/projects/packages/forms/src/blocks/field-telephone/edit.js
@@ -160,14 +160,14 @@ export default function PhoneFieldEdit( props ) {
 								/>
 								{ showCountrySelector && (
 									<TextControl
-										label={ __( 'Default country', 'jetpack-forms' ) }
+										label={ __( 'Search placeholder', 'jetpack-forms' ) }
 										value={ searchPlaceholder }
 										placeholder={ __( 'Search countries…', 'jetpack-forms' ) }
 										onChange={ newValue => setAttributes( { searchPlaceholder: newValue } ) }
 										__nextHasNoMarginBottom={ true }
 										__next40pxDefaultSize={ true }
 										help={ __(
-											'Search and select a default country for the phone number field.',
+											'Set placeholder text shown in the country selector search.',
 											'jetpack-forms'
 										) }
 									/>

--- a/projects/packages/forms/src/blocks/field-telephone/edit.js
+++ b/projects/packages/forms/src/blocks/field-telephone/edit.js
@@ -4,7 +4,13 @@ import {
 	BlockContextProvider,
 	BlockControls,
 } from '@wordpress/block-editor';
-import { TextControl, ToggleControl, ToolbarButton, ToolbarGroup } from '@wordpress/components';
+import {
+	BaseControl,
+	TextControl,
+	ToggleControl,
+	ToolbarButton,
+	ToolbarGroup,
+} from '@wordpress/components';
 import { useCallback, useEffect, useMemo, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { globe } from '@wordpress/icons';
@@ -143,9 +149,16 @@ export default function PhoneFieldEdit( props ) {
 				width={ width }
 				extraFieldSettings={ [
 					{
-						index: 1,
+						index: 2,
 						element: (
-							<div key="phoneFieldControls">
+							<BaseControl
+								help={ __(
+									'Search and select a default country for the phone number field.',
+									'jetpack-forms'
+								) }
+								__nextHasNoMarginBottom={ true }
+								key="phoneFieldControls"
+							>
 								<ToggleControl
 									label={ __( 'Show country selector', 'jetpack-forms' ) }
 									checked={ showCountrySelector || false }
@@ -154,7 +167,7 @@ export default function PhoneFieldEdit( props ) {
 								/>
 								{ showCountrySelector && (
 									<TextControl
-										label={ __( 'Search placeholder', 'jetpack-forms' ) }
+										label={ __( 'Default country', 'jetpack-forms' ) }
 										value={ searchPlaceholder }
 										placeholder={ __( 'Search countries…', 'jetpack-forms' ) }
 										onChange={ newValue => setAttributes( { searchPlaceholder: newValue } ) }
@@ -162,7 +175,7 @@ export default function PhoneFieldEdit( props ) {
 										__next40pxDefaultSize={ true }
 									/>
 								) }
-							</div>
+							</BaseControl>
 						),
 					},
 				] }


### PR DESCRIPTION
Fixes [FORMS-372](https://linear.app/a8c/issue/FORMS-372/phone-field-controls-overlap-in-forms)

## Proposed changes:
This PR changes how the extra control for phone field is placed among the shared field controls. It also adds a small copy for the control hint.

| Before | After |
|--------|--------|
| <img width="305" height="532" alt="image" src="https://github.com/user-attachments/assets/9dc613d0-fc3d-44ba-b341-9e4b49603a61" /> | <img width="306" height="575" alt="image" src="https://github.com/user-attachments/assets/f06784dd-7b63-4a2e-9857-879f9a0d0f50" /> |






### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
None

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Insert a form and some fields, including a Phone field. Check the controls on each of the fields so to verify nothing else has been affected. Check the Phone field controls and verify the country selector section renders as expected.