### PR TITLE
Build: Packages before Plugins

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -110,7 +110,20 @@ jobs:
             mkdir "$BUILD_BASE"
             touch "$BUILD_BASE/mirrors.txt"
           else
-            pnpm jetpack build -v --no-pnpm-install --for-mirrors="$BUILD_BASE" "${PROJECTS[@]}"
+
+            # Sort projects so plugins come last (allowing parallel builds but ensuring plugins build after all packages are built)
+            NON_PLUGIN_PROJECTS=()
+            PLUGIN_PROJECTS=()
+            for project in "${PROJECTS[@]}"; do
+              if [[ "$project" != plugins/* ]]; then
+                NON_PLUGIN_PROJECTS+=("$project")
+              else
+                PLUGIN_PROJECTS+=("$project")
+              fi
+            done
+            SORTED_PROJECTS=("${NON_PLUGIN_PROJECTS[@]}" "${PLUGIN_PROJECTS[@]}")
+
+            pnpm jetpack build -v --no-pnpm-install --for-mirrors="$BUILD_BASE" "${SORTED_PROJECTS[@]}"
           fi
 
       - name: Filter mirror list for release branch


### PR DESCRIPTION
Closes MONOREP-178

 <!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This ensures all packages are built before plugins, hopefully ensuring maximum parallelization.

Let's see if it makes a difference.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

