### PR TITLE
PHP 8.5 prep: Wrap deprecated functions

### DIFF
--- a/projects/plugins/crm/changelog/fix-php8.5-wrap_deprecated_functions
+++ b/projects/plugins/crm/changelog/fix-php8.5-wrap_deprecated_functions
@@ -1,0 +1,5 @@
+Significance: patch
+Type: removed
+Comment: Remove obsolete comment.
+
+

--- a/projects/plugins/crm/includes/ZeroBSCRM.AJAX.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.AJAX.php
@@ -5362,18 +5362,6 @@ function zeroBSCRM_AJAX_sendStatement() {
 		wp_send_json( $r );
 }
 
-/*
-replaced with zeroBSCRM_retrieve
-function zbs_get_content($URL){
-		//need to wrap this in if function exists...
-		$ch = curl_init();
-		curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
-		curl_setopt($ch, CURLOPT_URL, $URL);
-		$data = curl_exec($ch);
-		curl_close($ch);
-		return $data;
-} */
-
 add_action( 'wp_ajax_zbs_invoice_mark_paid', 'zbs_invoice_mark_paid' );
 function zbs_invoice_mark_paid() {
 

--- a/projects/plugins/wpcomsh/changelog/fix-php8.5-wrap_deprecated_functions
+++ b/projects/plugins/wpcomsh/changelog/fix-php8.5-wrap_deprecated_functions
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Wrap deprecated no-op function in PHP version checks.

--- a/projects/plugins/wpcomsh/storage/storage.php
+++ b/projects/plugins/wpcomsh/storage/storage.php
@@ -104,7 +104,7 @@ function wpcomsh_allow_file_uploads_with_invalid_mime_types( $file_data, $file, 
 
 	$finfo     = finfo_open( FILEINFO_MIME_TYPE );
 	$real_mime = finfo_file( $finfo, $file );
-	// todo: remove when we are PHP 8.1+, as curl_close() is noop in 8.1+ and deprecated in PHP 8.5+
+	// todo: remove when we are PHP 8.1+, as finfo_close() is noop in 8.1+ and deprecated in PHP 8.5+
 	if ( PHP_VERSION_ID < 80100 ) {
 		finfo_close( $finfo ); // phpcs:ignore PHPCompatibility.FunctionUse.RemovedFunctions.finfo_closeDeprecated
 	}

--- a/projects/plugins/wpcomsh/storage/storage.php
+++ b/projects/plugins/wpcomsh/storage/storage.php
@@ -104,7 +104,10 @@ function wpcomsh_allow_file_uploads_with_invalid_mime_types( $file_data, $file, 
 
 	$finfo     = finfo_open( FILEINFO_MIME_TYPE );
 	$real_mime = finfo_file( $finfo, $file );
-	finfo_close( $finfo ); // phpcs:ignore PHPCompatibility.FunctionUse.RemovedFunctions.finfo_closeDeprecated
+	// todo: remove when we are PHP 8.1+, as curl_close() is noop in 8.1+ and deprecated in PHP 8.5+
+	if ( PHP_VERSION_ID < 80100 ) {
+		finfo_close( $finfo ); // phpcs:ignore PHPCompatibility.FunctionUse.RemovedFunctions.finfo_closeDeprecated
+	}
 
 	if ( empty( $real_mime ) ) {
 		return $file_data;

--- a/tools/get-wp-version.php
+++ b/tools/get-wp-version.php
@@ -13,7 +13,10 @@ curl_setopt( $ch, CURLOPT_RETURNTRANSFER, true );
 
 // Get the response and close the channel.
 $response = curl_exec( $ch );
-curl_close( $ch ); // phpcs:ignore PHPCompatibility.FunctionUse.RemovedFunctions.curl_closeDeprecated
+// todo: remove when we are PHP 8.0+, as curl_close() is noop in 8.0+ and deprecated in PHP 8.5+
+if ( PHP_VERSION_ID < 80000 ) {
+	curl_close( $ch ); // phpcs:ignore PHPCompatibility.FunctionUse.RemovedFunctions.curl_closeDeprecated
+}
 
 $versions = json_decode( $response );
 $versions = $versions->offers;


### PR DESCRIPTION
Closes MONOREP-179

 <!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Several functions were deprecated in PHP 8.5 since they became no-ops in 8.0/8.1:

https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_no-op_functions_from_the_resource_to_object_conversion

There were three instances of the functions:

* CRM: a commented-out function that called `curl_close()`. I removed this.
* `wpcomsh`: a call to `finfo_close()`. I wrapped this in a PHP version check.
* tools: a call to `curl_close()`. I wrapped this in a PHP version check.

The calls were previously PHPCS-ignored in #45647.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Any obvious mistakes?