### PR TITLE
PHP 8.5: Wrap deprecated setAccessible method in PHP version check

### DIFF
--- a/projects/packages/account-protection/changelog/fix-php8.5-wrap_deprecated_setAccessible_method
+++ b/projects/packages/account-protection/changelog/fix-php8.5-wrap_deprecated_setAccessible_method
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Tests: Ensure PHP 8.5 compatibility.

--- a/projects/packages/account-protection/tests/php/Account_Protection_Test.php
+++ b/projects/packages/account-protection/tests/php/Account_Protection_Test.php
@@ -39,7 +39,10 @@ class Account_Protection_Test extends BaseTestCase {
 	public function test_init_registers_hooks_but_not_runtime_hooks_if_module_disabled(): void {
 		$reflection = new \ReflectionClass( Account_Protection::class );
 		$property   = $reflection->getProperty( 'hooks_registered' );
-		$property->setAccessible( true );
+		// @todo Remove this call once we no longer need to support PHP <8.1.
+		if ( PHP_VERSION_ID < 80100 ) {
+			$property->setAccessible( true );
+		}
 		$property->setValue( null, false );
 
 		$sut = $this->createPartialMock( Account_Protection::class, array( 'is_enabled', 'register_hooks', 'register_runtime_hooks' ) );

--- a/projects/packages/assets/changelog/fix-php8.5-wrap_deprecated_setAccessible_method
+++ b/projects/packages/assets/changelog/fix-php8.5-wrap_deprecated_setAccessible_method
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Tests: Ensure PHP 8.5 compatibility.

--- a/projects/packages/assets/tests/php/ScriptDataTest.php
+++ b/projects/packages/assets/tests/php/ScriptDataTest.php
@@ -76,7 +76,10 @@ class ScriptDataTest extends TestCase {
 		Monkey\tearDown();
 		// Reset the static property for isolation between tests.
 		$ref = new \ReflectionProperty( Script_Data::class, 'did_render_script_data' );
-		$ref->setAccessible( true );
+		// @todo Remove this call once we no longer need to support PHP <8.1.
+		if ( PHP_VERSION_ID < 80100 ) {
+			$ref->setAccessible( true );
+		}
 		$ref->setValue( null, false );
 		parent::tearDown();
 	}
@@ -112,7 +115,10 @@ class ScriptDataTest extends TestCase {
 
 	public function test_render_script_data_for_unauthenticated_rest_request() {
 		$ref = new \ReflectionProperty( Script_Data::class, 'did_render_script_data' );
-		$ref->setAccessible( true );
+		// @todo Remove this call once we no longer need to support PHP <8.1.
+		if ( PHP_VERSION_ID < 80100 ) {
+			$ref->setAccessible( true );
+		}
 		$ref->setValue( null, false );
 
 		Functions\when( 'is_admin' )->justReturn( false );
@@ -145,7 +151,10 @@ class ScriptDataTest extends TestCase {
 
 	public function test_render_script_data_for_authenticated_rest_request_with_block_editor_assets() {
 		$ref = new \ReflectionProperty( Script_Data::class, 'did_render_script_data' );
-		$ref->setAccessible( true );
+		// @todo Remove this call once we no longer need to support PHP <8.1.
+		if ( PHP_VERSION_ID < 80100 ) {
+			$ref->setAccessible( true );
+		}
 		$ref->setValue( null, false );
 
 		Functions\when( 'is_admin' )->justReturn( false );
@@ -178,7 +187,10 @@ class ScriptDataTest extends TestCase {
 
 	public function test_render_script_data_with_no_data() {
 		$ref = new \ReflectionProperty( Script_Data::class, 'did_render_script_data' );
-		$ref->setAccessible( true );
+		// @todo Remove this call once we no longer need to support PHP <8.1.
+		if ( PHP_VERSION_ID < 80100 ) {
+			$ref->setAccessible( true );
+		}
 		$ref->setValue( null, false );
 
 		Functions\when( 'is_admin' )->justReturn( false );

--- a/projects/packages/connection/changelog/fix-php8.5-wrap_deprecated_setAccessible_method
+++ b/projects/packages/connection/changelog/fix-php8.5-wrap_deprecated_setAccessible_method
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Tests: Ensure PHP 8.5 compatibility.

--- a/projects/packages/connection/tests/php/Connection_Notice_Test.php
+++ b/projects/packages/connection/tests/php/Connection_Notice_Test.php
@@ -37,7 +37,10 @@ class Connection_Notice_Test extends TestCase {
 		$manager    = new Manager();
 		$reflection = new \ReflectionClass( $manager );
 		$method     = $reflection->getMethod( 'add_connection_status_invalidation_hooks' );
-		$method->setAccessible( true );
+		// @todo Remove this call once we no longer need to support PHP <8.1.
+		if ( PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
 		$method->invoke( $manager );
 	}
 

--- a/projects/packages/connection/tests/php/Error_Handler_Test.php
+++ b/projects/packages/connection/tests/php/Error_Handler_Test.php
@@ -36,7 +36,10 @@ class Error_Handler_Test extends BaseTestCase {
 		// Clear any cached data between tests
 		$reflection = new \ReflectionClass( $this->error_handler );
 		$property   = $reflection->getProperty( 'cached_displayable_errors' );
-		$property->setAccessible( true );
+		// @todo Remove this call once we no longer need to support PHP <8.1.
+		if ( PHP_VERSION_ID < 80100 ) {
+			$property->setAccessible( true );
+		}
 		$property->setValue( $this->error_handler, null );
 
 		// Clear any test data
@@ -728,7 +731,10 @@ class Error_Handler_Test extends BaseTestCase {
 	public function test_should_allow_error_filtering() {
 		$reflection = new \ReflectionClass( $this->error_handler );
 		$method     = $reflection->getMethod( 'should_allow_error_filtering' );
-		$method->setAccessible( true );
+		// @todo Remove this call once we no longer need to support PHP <8.1.
+		if ( PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
 
 		// This test will depend on the actual Host class implementation
 		// We'll just verify the method exists and returns a boolean
@@ -1293,7 +1299,10 @@ class Error_Handler_Test extends BaseTestCase {
 		// Use reflection to access protected method
 		$reflection = new \ReflectionClass( $this->error_handler );
 		$method     = $reflection->getMethod( 'has_external_filters' );
-		$method->setAccessible( true );
+		// @todo Remove this call once we no longer need to support PHP <8.1.
+		if ( PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
 
 		// Test without filters
 		$result = $method->invoke( $this->error_handler );
@@ -1319,7 +1328,10 @@ class Error_Handler_Test extends BaseTestCase {
 		// Use reflection to access protected method
 		$reflection = new \ReflectionClass( $this->error_handler );
 		$method     = $reflection->getMethod( 'invalidate_displayable_errors_cache' );
-		$method->setAccessible( true );
+		// @todo Remove this call once we no longer need to support PHP <8.1.
+		if ( PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
 
 		// Test that the method doesn't throw any errors
 		$method->invoke( $this->error_handler );

--- a/projects/packages/connection/tests/php/External_Storage_Test.php
+++ b/projects/packages/connection/tests/php/External_Storage_Test.php
@@ -53,7 +53,10 @@ class External_Storage_Test extends TestCase {
 		// Reset the provider using reflection
 		$reflection = new \ReflectionClass( External_Storage::class );
 		$property   = $reflection->getProperty( 'provider' );
-		$property->setAccessible( true );
+		// @todo Remove this call once we no longer need to support PHP <8.1.
+		if ( PHP_VERSION_ID < 80100 ) {
+			$property->setAccessible( true );
+		}
 		$property->setValue( null, null );
 	}
 
@@ -67,7 +70,10 @@ class External_Storage_Test extends TestCase {
 		// Test that we can register a provider and it behaves as expected
 		$reflection        = new \ReflectionClass( External_Storage::class );
 		$provider_property = $reflection->getProperty( 'provider' );
-		$provider_property->setAccessible( true );
+		// @todo Remove this call once we no longer need to support PHP <8.1.
+		if ( PHP_VERSION_ID < 80100 ) {
+			$provider_property->setAccessible( true );
+		}
 		$provider = $provider_property->getValue();
 
 		// Verify provider is registered and behaves correctly
@@ -168,7 +174,10 @@ class External_Storage_Test extends TestCase {
 		// Use reflection to access the private should_log_event method
 		$reflection = new \ReflectionClass( External_Storage::class );
 		$method     = $reflection->getMethod( 'should_log_event' );
-		$method->setAccessible( true );
+		// @todo Remove this call once we no longer need to support PHP <8.1.
+		if ( PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
 
 		// First call should return true (no rate limiting yet)
 		$result1 = $method->invoke( null, 'test_key' );
@@ -197,7 +206,10 @@ class External_Storage_Test extends TestCase {
 		// Use reflection to access the private should_report_empty_state method
 		$reflection = new \ReflectionClass( External_Storage::class );
 		$method     = $reflection->getMethod( 'should_report_empty_state' );
-		$method->setAccessible( true );
+		// @todo Remove this call once we no longer need to support PHP <8.1.
+		if ( PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
 
 		// First call should return false (sets delay, doesn't report yet)
 		$result1 = $method->invoke( null, 'test_key' );

--- a/projects/packages/connection/tests/php/Jetpack_XMLRPC_Server_Test.php
+++ b/projects/packages/connection/tests/php/Jetpack_XMLRPC_Server_Test.php
@@ -32,7 +32,10 @@ class Jetpack_XMLRPC_Server_Test extends BaseTestCase {
 		$manager    = new Manager();
 		$reflection = new \ReflectionClass( $manager );
 		$method     = $reflection->getMethod( 'add_connection_status_invalidation_hooks' );
-		$method->setAccessible( true );
+		// @todo Remove this call once we no longer need to support PHP <8.1.
+		if ( PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
 		$method->invoke( $manager );
 	}
 

--- a/projects/packages/connection/tests/php/ManagerIntegrationTest.php
+++ b/projects/packages/connection/tests/php/ManagerIntegrationTest.php
@@ -38,7 +38,10 @@ class ManagerIntegrationTest extends \WorDBless\BaseTestCase {
 		$manager    = new Manager();
 		$reflection = new \ReflectionClass( $manager );
 		$method     = $reflection->getMethod( 'add_connection_status_invalidation_hooks' );
-		$method->setAccessible( true );
+		// @todo Remove this call once we no longer need to support PHP <8.1.
+		if ( PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
 		$method->invoke( $manager );
 	}
 

--- a/projects/packages/connection/tests/php/ManagerTest.php
+++ b/projects/packages/connection/tests/php/ManagerTest.php
@@ -59,7 +59,10 @@ class ManagerTest extends TestCase {
 		$manager    = new Manager();
 		$reflection = new \ReflectionClass( $manager );
 		$method     = $reflection->getMethod( 'add_connection_status_invalidation_hooks' );
-		$method->setAccessible( true );
+		// @todo Remove this call once we no longer need to support PHP <8.1.
+		if ( PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
 		$method->invoke( $manager );
 	}
 

--- a/projects/packages/connection/tests/php/Partner_Coupon_Test.php
+++ b/projects/packages/connection/tests/php/Partner_Coupon_Test.php
@@ -208,7 +208,10 @@ class Partner_Coupon_Test extends TestCase {
 		$instance = Partner_Coupon::get_instance();
 		$class    = new \ReflectionClass( $instance );
 		$method   = $class->getMethod( 'maybe_purge_coupon_by_added_date' );
-		$method->setAccessible( true );
+		// @todo Remove this call once we no longer need to support PHP <8.1.
+		if ( PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
 		$method->invoke( $instance );
 
 		// Confirm assertion.
@@ -276,7 +279,10 @@ class Partner_Coupon_Test extends TestCase {
 		$instance = new Partner_Coupon( $callback );
 		$class    = new \ReflectionClass( $instance );
 		$method   = $class->getMethod( 'maybe_purge_coupon_by_availability_check' );
-		$method->setAccessible( true );
+		// @todo Remove this call once we no longer need to support PHP <8.1.
+		if ( PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
 		$status = $method->invoke( $instance );
 
 		$this->assertSame( $status, $expectation );

--- a/projects/packages/connection/tests/php/Plugin_Storage_Test.php
+++ b/projects/packages/connection/tests/php/Plugin_Storage_Test.php
@@ -56,11 +56,17 @@ class Plugin_Storage_Test extends TestCase {
 			$reflection_class->setStaticPropertyValue( 'plugins', array() );
 		} catch ( \ReflectionException $e ) { // PHP 7 compat
 			$configured = $reflection_class->getProperty( 'configured' );
-			$configured->setAccessible( true );
+			// @todo Remove this call once we no longer need to support PHP <8.1.
+			if ( PHP_VERSION_ID < 80100 ) {
+				$configured->setAccessible( true );
+			}
 			$configured->setValue( false );
 
 			$plugins = $reflection_class->getProperty( 'plugins' );
-			$plugins->setAccessible( true );
+			// @todo Remove this call once we no longer need to support PHP <8.1.
+			if ( PHP_VERSION_ID < 80100 ) {
+				$plugins->setAccessible( true );
+			}
 			$plugins->setValue( array() );
 		}
 		$this->reset_connection_status();

--- a/projects/packages/connection/tests/php/Plugin_Test.php
+++ b/projects/packages/connection/tests/php/Plugin_Test.php
@@ -48,7 +48,10 @@ class Plugin_Test extends TestCase {
 
 		$reflection       = new \ReflectionClass( Plugin_Storage::class );
 		$plugins_property = $reflection->getProperty( 'plugins' );
-		$plugins_property->setAccessible( true );
+		// @todo Remove this call once we no longer need to support PHP <8.1.
+		if ( PHP_VERSION_ID < 80100 ) {
+			$plugins_property->setAccessible( true );
+		}
 		$plugins_property->setValue( null, array() );
 	}
 
@@ -117,7 +120,10 @@ class Plugin_Test extends TestCase {
 		// De-configuring the `Plugin_Storage` to trigger the error.
 		$reflection          = new \ReflectionClass( Plugin_Storage::class );
 		$configured_property = $reflection->getProperty( 'configured' );
-		$configured_property->setAccessible( true );
+		// @todo Remove this call once we no longer need to support PHP <8.1.
+		if ( PHP_VERSION_ID < 80100 ) {
+			$configured_property->setAccessible( true );
+		}
 		$configured_property->setValue( null, false );
 
 		set_error_handler(

--- a/projects/packages/connection/tests/php/REST_Authentication_Test.php
+++ b/projects/packages/connection/tests/php/REST_Authentication_Test.php
@@ -39,7 +39,10 @@ class REST_Authentication_Test extends TestCase {
 	private static function clear_auth_singleton() {
 		$reflection_class  = new \ReflectionClass( Rest_Authentication::class );
 		$instance_property = $reflection_class->getProperty( 'instance' );
-		$instance_property->setAccessible( true );
+		// @todo Remove this call once we no longer need to support PHP <8.1.
+		if ( PHP_VERSION_ID < 80100 ) {
+			$instance_property->setAccessible( true );
+		}
 		$instance_property->setValue( null, null );
 	}
 
@@ -57,7 +60,10 @@ class REST_Authentication_Test extends TestCase {
 
 		$reflection_class = new \ReflectionClass( get_class( $this->rest_authentication ) );
 		$manager_property = $reflection_class->getProperty( 'connection_manager' );
-		$manager_property->setAccessible( true );
+		// @todo Remove this call once we no longer need to support PHP <8.1.
+		if ( PHP_VERSION_ID < 80100 ) {
+			$manager_property->setAccessible( true );
+		}
 		$manager_property->setValue( $this->rest_authentication, $this->manager );
 	}
 

--- a/projects/packages/connection/tests/php/SecretsTest.php
+++ b/projects/packages/connection/tests/php/SecretsTest.php
@@ -19,7 +19,10 @@ class SecretsTest extends TestCase {
 	 */
 	public function call_private_secret_callable_method() {
 		$method = new \ReflectionMethod( 'Automattic\Jetpack\Connection\Secrets', 'secret_callable_method' );
-		$method->setAccessible( true );
+		// @todo Remove this call once we no longer need to support PHP <8.1.
+		if ( PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
 		return $method->invoke( new Secrets() );
 	}
 

--- a/projects/packages/connection/tests/php/identity-crisis/Identity_Crisis_Test.php
+++ b/projects/packages/connection/tests/php/identity-crisis/Identity_Crisis_Test.php
@@ -46,10 +46,6 @@ class Identity_Crisis_Test extends BaseTestCase {
 			$instance->setAccessible( true );
 		}
 		$instance->setValue( null, null );
-		// @todo Remove this call once we no longer need to support PHP <8.1.
-		if ( PHP_VERSION_ID < 80100 ) {
-			$instance->setAccessible( false );
-		}
 		$this->reset_connection_status();
 	}
 

--- a/projects/packages/connection/tests/php/identity-crisis/Identity_Crisis_Test.php
+++ b/projects/packages/connection/tests/php/identity-crisis/Identity_Crisis_Test.php
@@ -41,9 +41,15 @@ class Identity_Crisis_Test extends BaseTestCase {
 		$reflection = new \ReflectionClass( $idc );
 		$instance   = $reflection->getProperty( 'instance' );
 
-		$instance->setAccessible( true );
+		// @todo Remove this call once we no longer need to support PHP <8.1.
+		if ( PHP_VERSION_ID < 80100 ) {
+			$instance->setAccessible( true );
+		}
 		$instance->setValue( null, null );
-		$instance->setAccessible( false );
+		// @todo Remove this call once we no longer need to support PHP <8.1.
+		if ( PHP_VERSION_ID < 80100 ) {
+			$instance->setAccessible( false );
+		}
 		$this->reset_connection_status();
 	}
 

--- a/projects/packages/connection/tests/php/identity-crisis/UI_Test.php
+++ b/projects/packages/connection/tests/php/identity-crisis/UI_Test.php
@@ -53,10 +53,6 @@ class UI_Test extends TestCase {
 			$property->setAccessible( true );
 		}
 		$property->setValue( null, null );
-		// @todo Remove this call once we no longer need to support PHP <8.1.
-		if ( PHP_VERSION_ID < 80100 ) {
-			$property->setAccessible( false );
-		}
 	}
 
 	/**

--- a/projects/packages/connection/tests/php/identity-crisis/UI_Test.php
+++ b/projects/packages/connection/tests/php/identity-crisis/UI_Test.php
@@ -48,9 +48,15 @@ class UI_Test extends TestCase {
 	private function reset_static_consumers() {
 		$reflection = new ReflectionClass( UI::class );
 		$property   = $reflection->getProperty( 'consumers' );
-		$property->setAccessible( true );
+		// @todo Remove this call once we no longer need to support PHP <8.1.
+		if ( PHP_VERSION_ID < 80100 ) {
+			$property->setAccessible( true );
+		}
 		$property->setValue( null, null );
-		$property->setAccessible( false );
+		// @todo Remove this call once we no longer need to support PHP <8.1.
+		if ( PHP_VERSION_ID < 80100 ) {
+			$property->setAccessible( false );
+		}
 	}
 
 	/**

--- a/projects/packages/image-cdn/changelog/fix-php8.5-wrap_deprecated_setAccessible_method
+++ b/projects/packages/image-cdn/changelog/fix-php8.5-wrap_deprecated_setAccessible_method
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Tests: Ensure PHP 8.5 compatibility.

--- a/projects/packages/image-cdn/tests/php/Breakdance_Compat_Test.php
+++ b/projects/packages/image-cdn/tests/php/Breakdance_Compat_Test.php
@@ -62,11 +62,17 @@ class Breakdance_Compat_Test extends BaseTestCase {
 		// Reset the Image CDN instance to ensure it's disabled
 		$reflection        = new \ReflectionClass( Image_CDN::class );
 		$instance_property = $reflection->getProperty( 'instance' );
-		$instance_property->setAccessible( true );
+		// @todo Remove this call once we no longer need to support PHP <8.1.
+		if ( PHP_VERSION_ID < 80100 ) {
+			$instance_property->setAccessible( true );
+		}
 		$instance_property->setValue( null, null );
 
 		$enabled_property = $reflection->getProperty( 'is_enabled' );
-		$enabled_property->setAccessible( true );
+		// @todo Remove this call once we no longer need to support PHP <8.1.
+		if ( PHP_VERSION_ID < 80100 ) {
+			$enabled_property->setAccessible( true );
+		}
 		$enabled_property->setValue( null, false );
 
 		$sample_content = '<p>Test content with <img src="http://example.com/image.jpg" alt="test"> image</p>';

--- a/projects/packages/image-cdn/tests/php/Image_CDN_Test.php
+++ b/projects/packages/image-cdn/tests/php/Image_CDN_Test.php
@@ -100,14 +100,20 @@ class Image_CDN_Test extends Image_CDN_Attachment_TestCase {
 		// static variable.
 		// l337 h4X0Ring required:
 		$instance = new ReflectionProperty( Image_CDN::class, 'instance' );
-		$instance->setAccessible( true );
+		// @todo Remove this call once we no longer need to support PHP <8.1.
+		if ( PHP_VERSION_ID < 80100 ) {
+			$instance->setAccessible( true );
+		}
 		$instance->setValue( null, null );
 
 		/**
 		 * Reset the `image_sizes` property, as it persists between class instantiations, since it's static.
 		 */
 		$instance = new ReflectionProperty( Image_CDN::class, 'image_sizes' );
-		$instance->setAccessible( true );
+		// @todo Remove this call once we no longer need to support PHP <8.1.
+		if ( PHP_VERSION_ID < 80100 ) {
+			$instance->setAccessible( true );
+		}
 		$instance->setValue( null, null );
 
 		self::delete_author();
@@ -1592,7 +1598,10 @@ class Image_CDN_Test extends Image_CDN_Attachment_TestCase {
 	public function test_image_cdn_validate_image_url_file_types( $url, $expected ) {
 		$testable                    = new ReflectionClass( Image_CDN::class );
 		$testable_validate_image_url = $testable->getMethod( 'validate_image_url' );
-		$testable_validate_image_url->setAccessible( true );
+		// @todo Remove this call once we no longer need to support PHP <8.1.
+		if ( PHP_VERSION_ID < 80100 ) {
+			$testable_validate_image_url->setAccessible( true );
+		}
 		$this->assertEquals( $expected, $testable_validate_image_url->invoke( null, $url ) );
 	}
 

--- a/projects/packages/search/changelog/fix-php8.5-wrap_deprecated_setAccessible_method
+++ b/projects/packages/search/changelog/fix-php8.5-wrap_deprecated_setAccessible_method
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Tests: Ensure PHP 8.5 compatibility.

--- a/projects/packages/search/tests/php/Instant_Search_Add_Search_Block_Test.php
+++ b/projects/packages/search/tests/php/Instant_Search_Add_Search_Block_Test.php
@@ -228,7 +228,10 @@ EOT;
 	 */
 	public function test_wp_pattern_block_replace() {
 		$method = new ReflectionMethod( 'Automattic\Jetpack\Search\Instant_Search', 'replace_block_patterns' );
-		$method->setAccessible( true );
+		// @todo Remove this call once we no longer need to support PHP <8.1.
+		if ( PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
 		Instant_Search::initialize( 1 );
 		WP_Block_Patterns_Registry::get_instance()->register(
 			'jetpack-search/footer',

--- a/projects/packages/stats-admin/changelog/fix-php8.5-wrap_deprecated_setAccessible_method
+++ b/projects/packages/stats-admin/changelog/fix-php8.5-wrap_deprecated_setAccessible_method
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Tests: Ensure PHP 8.5 compatibility.

--- a/projects/packages/stats-admin/tests/php/Dashboard_Test.php
+++ b/projects/packages/stats-admin/tests/php/Dashboard_Test.php
@@ -17,7 +17,10 @@ class Dashboard_Test extends Stats_TestCase {
 		Dashboard::init();
 
 		$rp = new ReflectionProperty( Dashboard::class, 'initialized' );
-		$rp->setAccessible( true );
+		// @todo Remove this call once we no longer need to support PHP <8.1.
+		if ( PHP_VERSION_ID < 80100 ) {
+			$rp->setAccessible( true );
+		}
 		$this->assertTrue( $rp->getValue() );
 	}
 

--- a/projects/packages/stats-admin/tests/php/Odyssey_Assets_Test.php
+++ b/projects/packages/stats-admin/tests/php/Odyssey_Assets_Test.php
@@ -108,7 +108,10 @@ class Odyssey_Assets_Test extends Stats_TestCase {
 	protected function get_cdn_asset_cache_buster_callable() {
 		$odyssey_assets             = new Odyssey_Assets();
 		$get_cdn_asset_cache_buster = new \ReflectionMethod( $odyssey_assets, 'get_cdn_asset_cache_buster' );
-		$get_cdn_asset_cache_buster->setAccessible( true );
+		// @todo Remove this call once we no longer need to support PHP <8.1.
+		if ( PHP_VERSION_ID < 80100 ) {
+			$get_cdn_asset_cache_buster->setAccessible( true );
+		}
 
 		return $get_cdn_asset_cache_buster->invoke( $odyssey_assets );
 	}

--- a/projects/packages/stats-admin/tests/php/REST_Controller_Test.php
+++ b/projects/packages/stats-admin/tests/php/REST_Controller_Test.php
@@ -212,7 +212,10 @@ class REST_Controller_Test extends Stats_TestCase {
 	 */
 	public function test_filter_and_build_query_string() {
 		$filter_and_build_query_string = new \ReflectionMethod( $this->rest_controller, 'filter_and_build_query_string' );
-		$filter_and_build_query_string->setAccessible( true );
+		// @todo Remove this call once we no longer need to support PHP <8.1.
+		if ( PHP_VERSION_ID < 80100 ) {
+			$filter_and_build_query_string->setAccessible( true );
+		}
 
 		$this->assertEquals(
 			'c=d&e=f',
@@ -253,7 +256,10 @@ class REST_Controller_Test extends Stats_TestCase {
 	 */
 	public function test_get_wp_error() {
 		$get_wp_error = new \ReflectionMethod( WPCOM_Client::class, 'get_wp_error' );
-		$get_wp_error->setAccessible( true );
+		// @todo Remove this call once we no longer need to support PHP <8.1.
+		if ( PHP_VERSION_ID < 80100 ) {
+			$get_wp_error->setAccessible( true );
+		}
 
 		$error = $get_wp_error->invoke(
 			$this->rest_controller,

--- a/projects/packages/stats/changelog/fix-php8.5-wrap_deprecated_setAccessible_method
+++ b/projects/packages/stats/changelog/fix-php8.5-wrap_deprecated_setAccessible_method
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Tests: Ensure PHP 8.5 compatibility.

--- a/projects/packages/stats/tests/php/Main_Test.php
+++ b/projects/packages/stats/tests/php/Main_Test.php
@@ -52,12 +52,18 @@ class Main_Test extends StatsBaseTestCase {
 
 		$reflected_class    = new \ReflectionClass( 'Automattic\Jetpack\Stats\Main' );
 		$reflected_property = $reflected_class->getProperty( 'instance' );
-		$reflected_property->setAccessible( true );
+		// @todo Remove this call once we no longer need to support PHP <8.1.
+		if ( PHP_VERSION_ID < 80100 ) {
+			$reflected_property->setAccessible( true );
+		}
 		$reflected_property = $reflected_property->setValue( null, null );
 
 		$reflected_class    = new \ReflectionClass( 'Automattic\Jetpack\Stats\XMLRPC_Provider' );
 		$reflected_property = $reflected_class->getProperty( 'instance' );
-		$reflected_property->setAccessible( true );
+		// @todo Remove this call once we no longer need to support PHP <8.1.
+		if ( PHP_VERSION_ID < 80100 ) {
+			$reflected_property->setAccessible( true );
+		}
 		$reflected_property = $reflected_property->setValue( null, null );
 	}
 

--- a/projects/packages/stats/tests/php/Options_Test.php
+++ b/projects/packages/stats/tests/php/Options_Test.php
@@ -23,7 +23,10 @@ class Options_Test extends StatsBaseTestCase {
 	public function tear_down() {
 		$reflected_class    = new \ReflectionClass( 'Automattic\Jetpack\Stats\Options' );
 		$reflected_property = $reflected_class->getProperty( 'options' );
-		$reflected_property->setAccessible( true );
+		// @todo Remove this call once we no longer need to support PHP <8.1.
+		if ( PHP_VERSION_ID < 80100 ) {
+			$reflected_property->setAccessible( true );
+		}
 		$reflected_property = $reflected_property->setValue( null, array() );
 
 		parent::tear_down();

--- a/projects/packages/stats/tests/php/Tracking_Pixel_Test.php
+++ b/projects/packages/stats/tests/php/Tracking_Pixel_Test.php
@@ -291,7 +291,10 @@ class Tracking_Pixel_Test extends StatsBaseTestCase {
 		add_filter( 'jetpack_is_amp_request', '__return_true' );
 
 		$method = new \ReflectionMethod( Tracking_Pixel::class, 'get_amp_footer' );
-		$method->setAccessible( true );
+		// @todo Remove this call once we no longer need to support PHP <8.1.
+		if ( PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
 
 		$amp_footer_data = $method->invoke( new Tracking_Pixel(), $data );
 
@@ -325,7 +328,10 @@ class Tracking_Pixel_Test extends StatsBaseTestCase {
 		);
 
 		$method = new \ReflectionMethod( Tracking_Pixel::class, 'build_stats_details' );
-		$method->setAccessible( true );
+		// @todo Remove this call once we no longer need to support PHP <8.1.
+		if ( PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
 		$pixel_details = $method->invoke( new Tracking_Pixel(), $data );
 
 		$expected_pixel_details = '_stq = window._stq || [];

--- a/projects/packages/stats/tests/php/WPCOM_Stats_Test.php
+++ b/projects/packages/stats/tests/php/WPCOM_Stats_Test.php
@@ -541,7 +541,10 @@ class WPCOM_Stats_Test extends StatsBaseTestCase {
 	public function test_get_total_post_views_with_valid_post_ids_on_simple_sites() {
 		$reflection = new \ReflectionClass( $this->wpcom_stats );
 		$property   = $reflection->getProperty( 'is_wpcom_simple' );
-		$property->setAccessible( true );
+		// @todo Remove this call once we no longer need to support PHP <8.1.
+		if ( PHP_VERSION_ID < 80100 ) {
+			$property->setAccessible( true );
+		}
 		$property->setValue( $this->wpcom_stats, true );
 
 		// Prepare mock data for the stats

--- a/projects/packages/stats/tests/php/XMLRPC_Provider_Test.php
+++ b/projects/packages/stats/tests/php/XMLRPC_Provider_Test.php
@@ -41,7 +41,10 @@ class XMLRPC_Provider_Test extends StatsBaseTestCase {
 
 		$reflected_class    = new \ReflectionClass( 'Automattic\Jetpack\Stats\XMLRPC_Provider' );
 		$reflected_property = $reflected_class->getProperty( 'instance' );
-		$reflected_property->setAccessible( true );
+		// @todo Remove this call once we no longer need to support PHP <8.1.
+		if ( PHP_VERSION_ID < 80100 ) {
+			$reflected_property->setAccessible( true );
+		}
 		$reflected_property = $reflected_property->setValue( null, null );
 	}
 

--- a/projects/packages/sync/changelog/fix-php8.5-wrap_deprecated_setAccessible_method
+++ b/projects/packages/sync/changelog/fix-php8.5-wrap_deprecated_setAccessible_method
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Tests: Ensure PHP 8.5 compatibility.

--- a/projects/packages/sync/tests/php/Modules_Test.php
+++ b/projects/packages/sync/tests/php/Modules_Test.php
@@ -21,7 +21,10 @@ class Modules_Test extends BaseTestCase {
 			$reflection_class->setStaticPropertyValue( 'initialized_modules', null );
 		} catch ( \ReflectionException $e ) { // PHP 7 compat
 			$configured = $reflection_class->getProperty( 'initialized_modules' );
-			$configured->setAccessible( true );
+			// @todo Remove this call once we no longer need to support PHP <8.1.
+			if ( PHP_VERSION_ID < 80100 ) {
+				$configured->setAccessible( true );
+			}
 			$configured->setValue( null );
 		}
 	}

--- a/projects/plugins/boost/changelog/fix-php8.5-wrap_deprecated_setAccessible_method
+++ b/projects/plugins/boost/changelog/fix-php8.5-wrap_deprecated_setAccessible_method
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Tests: Ensure PHP 8.5 compatibility.

--- a/projects/plugins/boost/tests/php/Super_Cache_Compatibility_Checker_Test.php
+++ b/projects/plugins/boost/tests/php/Super_Cache_Compatibility_Checker_Test.php
@@ -86,7 +86,10 @@ class Super_Cache_Compatibility_Checker_Test extends Base_TestCase {
 	private function invoke_private_method( $method_name ) {
 		$class  = new ReflectionClass( Super_Cache_Config_Compatibility::class );
 		$method = $class->getMethod( $method_name );
-		$method->setAccessible( true );
+		// @todo Remove this call once we no longer need to support PHP <8.1.
+		if ( PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
 		return $method->invoke( null );
 	}
 }

--- a/projects/plugins/boost/tests/php/admin/Config_Test.php
+++ b/projects/plugins/boost/tests/php/admin/Config_Test.php
@@ -254,7 +254,10 @@ class Config_Test extends TestCase {
 
 		$reflection = new \ReflectionClass( Config::class );
 		$method     = $reflection->getMethod( 'get_custom_post_types' );
-		$method->setAccessible( true );
+		// @todo Remove this call once we no longer need to support PHP <8.1.
+		if ( PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
 
 		$result = $method->invokeArgs( new Config(), array() );
 

--- a/projects/plugins/jetpack/changelog/fix-php8.5-wrap_deprecated_setAccessible_method
+++ b/projects/plugins/jetpack/changelog/fix-php8.5-wrap_deprecated_setAccessible_method
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Tests: Ensure PHP 8.5 compatibility.

--- a/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_Admin_Menu_Test.php
+++ b/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_Admin_Menu_Test.php
@@ -149,7 +149,10 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu_Test extends Jetpack_REST_TestCase {
 		$class = new ReflectionClass( 'WPCOM_REST_API_V2_Endpoint_Admin_Menu' );
 
 		$prepare_menu_item = $class->getMethod( 'prepare_menu_item' );
-		$prepare_menu_item->setAccessible( true );
+		// @todo Remove this call once we no longer need to support PHP <8.1.
+		if ( PHP_VERSION_ID < 80100 ) {
+			$prepare_menu_item->setAccessible( true );
+		}
 
 		$this->assertEquals(
 			$expected,
@@ -246,7 +249,10 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu_Test extends Jetpack_REST_TestCase {
 		$class = new ReflectionClass( 'WPCOM_REST_API_V2_Endpoint_Admin_Menu' );
 
 		$prepare_submenu_item = $class->getMethod( 'prepare_submenu_item' );
-		$prepare_submenu_item->setAccessible( true );
+		// @todo Remove this call once we no longer need to support PHP <8.1.
+		if ( PHP_VERSION_ID < 80100 ) {
+			$prepare_submenu_item->setAccessible( true );
+		}
 
 		$this->assertSame(
 			$expected,
@@ -350,7 +356,10 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu_Test extends Jetpack_REST_TestCase {
 		$class = new ReflectionClass( 'WPCOM_REST_API_V2_Endpoint_Admin_Menu' );
 
 		$prepare_menu_item = $class->getMethod( 'prepare_menu_item' );
-		$prepare_menu_item->setAccessible( true );
+		// @todo Remove this call once we no longer need to support PHP <8.1.
+		if ( PHP_VERSION_ID < 80100 ) {
+			$prepare_menu_item->setAccessible( true );
+		}
 
 		$expected = array(
 			'icon'  => 'dashicons-admin-generic',
@@ -380,7 +389,10 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu_Test extends Jetpack_REST_TestCase {
 		$class = new ReflectionClass( 'WPCOM_REST_API_V2_Endpoint_Admin_Menu' );
 
 		$prepare_menu_item_icon = $class->getMethod( 'prepare_menu_item_icon' );
-		$prepare_menu_item_icon->setAccessible( true );
+		// @todo Remove this call once we no longer need to support PHP <8.1.
+		if ( PHP_VERSION_ID < 80100 ) {
+			$prepare_menu_item_icon->setAccessible( true );
+		}
 
 		$this->assertEquals(
 			$expected,
@@ -448,7 +460,10 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu_Test extends Jetpack_REST_TestCase {
 		$class = new ReflectionClass( 'WPCOM_REST_API_V2_Endpoint_Admin_Menu' );
 
 		$prepare_menu_item_url = $class->getMethod( 'prepare_menu_item_url' );
-		$prepare_menu_item_url->setAccessible( true );
+		// @todo Remove this call once we no longer need to support PHP <8.1.
+		if ( PHP_VERSION_ID < 80100 ) {
+			$prepare_menu_item_url->setAccessible( true );
+		}
 
 		if ( empty( $parent_slug ) ) {
 			add_menu_page( 'Title', 'Title', 'read', $url, $callback );
@@ -588,7 +603,10 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu_Test extends Jetpack_REST_TestCase {
 		$class = new ReflectionClass( 'WPCOM_REST_API_V2_Endpoint_Admin_Menu' );
 
 		$prepare_menu_item_url = $class->getMethod( 'parse_menu_item' );
-		$prepare_menu_item_url->setAccessible( true );
+		// @todo Remove this call once we no longer need to support PHP <8.1.
+		if ( PHP_VERSION_ID < 80100 ) {
+			$prepare_menu_item_url->setAccessible( true );
+		}
 
 		$this->assertSame(
 			$expected,

--- a/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_Memberships_Test.php
+++ b/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_Memberships_Test.php
@@ -987,7 +987,10 @@ class WPCOM_REST_API_V2_Endpoint_Memberships_Test extends Jetpack_REST_TestCase 
 
 		$reflection = new ReflectionClass( $endpoint );
 		$method     = $reflection->getMethod( 'validate_tier_field' );
-		$method->setAccessible( true );
+		// @todo Remove this call once we no longer need to support PHP <8.1.
+		if ( PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
 
 		$result = $method->invoke( $endpoint, $request, null, 'tier', '1 month' );
 		$this->assertNull( $result );
@@ -1002,7 +1005,10 @@ class WPCOM_REST_API_V2_Endpoint_Memberships_Test extends Jetpack_REST_TestCase 
 
 		$reflection = new ReflectionClass( $endpoint );
 		$method     = $reflection->getMethod( 'validate_tier_field' );
-		$method->setAccessible( true );
+		// @todo Remove this call once we no longer need to support PHP <8.1.
+		if ( PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
 
 		$result = $method->invoke( $endpoint, $request, 123, 'donation', '1 month' );
 		$this->assertNull( $result );
@@ -1017,7 +1023,10 @@ class WPCOM_REST_API_V2_Endpoint_Memberships_Test extends Jetpack_REST_TestCase 
 
 		$reflection = new ReflectionClass( $endpoint );
 		$method     = $reflection->getMethod( 'validate_tier_field' );
-		$method->setAccessible( true );
+		// @todo Remove this call once we no longer need to support PHP <8.1.
+		if ( PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
 
 		$result = $method->invoke( $endpoint, $request, 123, 'tier', '1 month' );
 		$this->assertInstanceOf( WP_Error::class, $result );
@@ -1033,7 +1042,10 @@ class WPCOM_REST_API_V2_Endpoint_Memberships_Test extends Jetpack_REST_TestCase 
 
 		$reflection = new ReflectionClass( $endpoint );
 		$method     = $reflection->getMethod( 'validate_yearly_tier' );
-		$method->setAccessible( true );
+		// @todo Remove this call once we no longer need to support PHP <8.1.
+		if ( PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
 
 		$result = $method->invoke( $endpoint, $request, -1 );
 		$this->assertInstanceOf( WP_Error::class, $result );
@@ -1049,7 +1061,10 @@ class WPCOM_REST_API_V2_Endpoint_Memberships_Test extends Jetpack_REST_TestCase 
 
 		$reflection = new ReflectionClass( $endpoint );
 		$method     = $reflection->getMethod( 'validate_yearly_tier' );
-		$method->setAccessible( true );
+		// @todo Remove this call once we no longer need to support PHP <8.1.
+		if ( PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
 
 		$result = $method->invoke( $endpoint, $request, 'invalid' );
 		$this->assertInstanceOf( WP_Error::class, $result );

--- a/projects/plugins/jetpack/tests/php/json-api/Jetpack_Json_Api_Plugins_Endpoints_Test.php
+++ b/projects/plugins/jetpack/tests/php/json-api/Jetpack_Json_Api_Plugins_Endpoints_Test.php
@@ -71,10 +71,16 @@ class Jetpack_Json_Api_Plugins_Endpoints_Test extends WP_UnitTestCase {
 		 */
 		$class                = new ReflectionClass( 'Jetpack_JSON_API_Plugins_Modify_Endpoint' );
 		$update_plugin_method = $class->getMethod( 'update' );
-		$update_plugin_method->setAccessible( true );
+		// @todo Remove this call once we no longer need to support PHP <8.1.
+		if ( PHP_VERSION_ID < 80100 ) {
+			$update_plugin_method->setAccessible( true );
+		}
 
 		$plugin_property = $class->getProperty( 'plugins' );
-		$plugin_property->setAccessible( true );
+		// @todo Remove this call once we no longer need to support PHP <8.1.
+		if ( PHP_VERSION_ID < 80100 ) {
+			$plugin_property->setAccessible( true );
+		}
 		$plugin_property->setValue( $endpoint, array( 'the/the.php' ) );
 
 		$the_plugin_file = 'the/the.php';
@@ -143,10 +149,16 @@ class Jetpack_Json_Api_Plugins_Endpoints_Test extends WP_UnitTestCase {
 		 */
 		$class                = new ReflectionClass( 'Jetpack_JSON_API_Plugins_Modify_Endpoint' );
 		$update_plugin_method = $class->getMethod( 'update' );
-		$update_plugin_method->setAccessible( true );
+		// @todo Remove this call once we no longer need to support PHP <8.1.
+		if ( PHP_VERSION_ID < 80100 ) {
+			$update_plugin_method->setAccessible( true );
+		}
 
 		$plugin_property = $class->getProperty( 'plugins' );
-		$plugin_property->setAccessible( true );
+		// @todo Remove this call once we no longer need to support PHP <8.1.
+		if ( PHP_VERSION_ID < 80100 ) {
+			$plugin_property->setAccessible( true );
+		}
 		$plugin_property->setValue( $endpoint, array( 'the/the.php' ) );
 
 		$the_plugin_file = 'the/the.php';
@@ -225,10 +237,16 @@ class Jetpack_Json_Api_Plugins_Endpoints_Test extends WP_UnitTestCase {
 		 */
 		$class                = new ReflectionClass( 'Jetpack_JSON_API_Plugins_Modify_Endpoint' );
 		$update_plugin_method = $class->getMethod( 'update' );
-		$update_plugin_method->setAccessible( true );
+		// @todo Remove this call once we no longer need to support PHP <8.1.
+		if ( PHP_VERSION_ID < 80100 ) {
+			$update_plugin_method->setAccessible( true );
+		}
 
 		$plugin_property = $class->getProperty( 'plugins' );
-		$plugin_property->setAccessible( true );
+		// @todo Remove this call once we no longer need to support PHP <8.1.
+		if ( PHP_VERSION_ID < 80100 ) {
+			$plugin_property->setAccessible( true );
+		}
 		$plugin_property->setValue( $endpoint, array( 'the/the.php' ) );
 
 		$the_plugin_file = 'the/the.php';
@@ -318,16 +336,25 @@ class Jetpack_Json_Api_Plugins_Endpoints_Test extends WP_UnitTestCase {
 		$class = new ReflectionClass( 'Jetpack_JSON_API_Plugins_Install_Endpoint' );
 
 		$plugins_property = $class->getProperty( 'plugins' );
-		$plugins_property->setAccessible( true );
+		// @todo Remove this call once we no longer need to support PHP <8.1.
+		if ( PHP_VERSION_ID < 80100 ) {
+			$plugins_property->setAccessible( true );
+		}
 		$plugins_property->setValue( $endpoint, array( $the_plugin_slug ) );
 
 		$validate_plugins_method = $class->getMethod( 'validate_plugins' );
-		$validate_plugins_method->setAccessible( true );
+		// @todo Remove this call once we no longer need to support PHP <8.1.
+		if ( PHP_VERSION_ID < 80100 ) {
+			$validate_plugins_method->setAccessible( true );
+		}
 		$result = $validate_plugins_method->invoke( $endpoint );
 		$this->assertTrue( $result );
 
 		$install_plugin_method = $class->getMethod( 'install' );
-		$install_plugin_method->setAccessible( true );
+		// @todo Remove this call once we no longer need to support PHP <8.1.
+		if ( PHP_VERSION_ID < 80100 ) {
+			$install_plugin_method->setAccessible( true );
+		}
 
 		$result = $install_plugin_method->invoke( $endpoint );
 

--- a/projects/plugins/jetpack/tests/php/json-api/Json_Api_Update_Post_Endpoints_Test.php
+++ b/projects/plugins/jetpack/tests/php/json-api/Json_Api_Update_Post_Endpoints_Test.php
@@ -161,7 +161,10 @@ class Json_Api_Update_Post_Endpoints_Test extends WP_UnitTestCase {
 	public function invoke_method( &$object, $method_name, array $parameters = array() ) {
 		$reflection = new \ReflectionClass( get_class( $object ) );
 		$method     = $reflection->getMethod( $method_name );
-		$method->setAccessible( true );
+		// @todo Remove this call once we no longer need to support PHP <8.1.
+		if ( PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
 
 		return $method->invokeArgs( $object, $parameters );
 	}

--- a/projects/plugins/jetpack/tests/php/modules/subscriptions/Jetpack_Subscriptions_Test.php
+++ b/projects/plugins/jetpack/tests/php/modules/subscriptions/Jetpack_Subscriptions_Test.php
@@ -329,7 +329,10 @@ class Jetpack_Subscriptions_Test extends WP_UnitTestCase {
 			}
 			$online_subscription_service = new WPCOM_Online_Subscription_Service();
 			$ref_method                  = new ReflectionMethod( $online_subscription_service, 'user_can_view_content' );
-			$ref_method->setAccessible( true );
+			// @todo Remove this call once we no longer need to support PHP <8.1.
+			if ( PHP_VERSION_ID < 80100 ) {
+				$ref_method->setAccessible( true );
+			}
 			$result = $ref_method->invoke( $online_subscription_service, array( $this->plan_id ), $post_access_level, $logged && $is_blog_subscriber, get_the_ID() );
 		}
 

--- a/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Checksum_Test.php
+++ b/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Checksum_Test.php
@@ -121,7 +121,10 @@ class Jetpack_Sync_Checksum_Test extends WP_UnitTestCase {
 		$reflection = new ReflectionClass( 'Automattic\Jetpack\Sync\Modules' );
 
 		$prop = $reflection->getProperty( 'initialized_modules' );
-		$prop->setAccessible( true );
+		// @todo Remove this call once we no longer need to support PHP <8.1.
+		if ( PHP_VERSION_ID < 80100 ) {
+			$prop->setAccessible( true );
+		}
 		$prop->setValue( null, null );
 
 		$this->sync_enabled_modules = $enabled_modules;

--- a/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Post_Test.php
+++ b/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Post_Test.php
@@ -1441,7 +1441,10 @@ That was a cool video.';
 		$test_instance = new Modules\Posts();
 		$test_ref      = new ReflectionObject( $test_instance );
 		$property_ref  = $test_ref->getProperty( 'action_handler' );
-		$property_ref->setAccessible( true );
+		// @todo Remove this call once we no longer need to support PHP <8.1.
+		if ( PHP_VERSION_ID < 80100 ) {
+			$property_ref->setAccessible( true );
+		}
 		$property_ref->setValue( $test_instance, function () {} );
 
 		$test_instance->daily_akismet_meta_cleanup_before( $ids );
@@ -1466,7 +1469,10 @@ That was a cool video.';
 		$test_instance = new Modules\Posts();
 		$test_ref      = new ReflectionObject( $test_instance );
 		$property_ref  = $test_ref->getProperty( 'action_handler' );
-		$property_ref->setAccessible( true );
+		// @todo Remove this call once we no longer need to support PHP <8.1.
+		if ( PHP_VERSION_ID < 80100 ) {
+			$property_ref->setAccessible( true );
+		}
 		$property_ref->setValue( $test_instance, function () {} );
 
 		$test_instance->daily_akismet_meta_cleanup_before( $ids );
@@ -1491,7 +1497,10 @@ That was a cool video.';
 		$test_instance = new Modules\Posts();
 		$test_ref      = new ReflectionObject( $test_instance );
 		$property_ref  = $test_ref->getProperty( 'action_handler' );
-		$property_ref->setAccessible( true );
+		// @todo Remove this call once we no longer need to support PHP <8.1.
+		if ( PHP_VERSION_ID < 80100 ) {
+			$property_ref->setAccessible( true );
+		}
 		$property_ref->setValue( $test_instance, function () {} );
 
 		$test_instance->daily_akismet_meta_cleanup_before( $ids );

--- a/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Queue_Dedicated_Table_Test.php
+++ b/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Queue_Dedicated_Table_Test.php
@@ -108,7 +108,10 @@ class Jetpack_Sync_Queue_Dedicated_Table_Test extends Jetpack_Sync_Queue_TestBas
 		 */
 		$reflection_class    = new ReflectionClass( Queue_Storage_Table::class );
 		$create_table_method = $reflection_class->getMethod( 'create_table' );
-		$create_table_method->setAccessible( true );
+		// @todo Remove this call once we no longer need to support PHP <8.1.
+		if ( PHP_VERSION_ID < 80100 ) {
+			$create_table_method->setAccessible( true );
+		}
 
 		// Reset the table
 		$table_storage = new Queue_Storage_Table( $test_queue_id );

--- a/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Themes_Test.php
+++ b/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Themes_Test.php
@@ -24,7 +24,10 @@ class Dummy_Sync_Test_WP_Upgrader {
 		$instance = $reflection->newInstanceWithoutConstructor();
 
 		$prop = $reflection->getProperty( 'stylesheet' );
-		$prop->setAccessible( true );
+		// @todo Remove this call once we no longer need to support PHP <8.1.
+		if ( PHP_VERSION_ID < 80100 ) {
+			$prop->setAccessible( true );
+		}
 		$prop->setValue( $instance, 'foobar-theme' );
 		return $instance;
 	}

--- a/projects/plugins/jetpack/tests/php/sync/Z_IJetpack_Sync_Replicastore_Test.php
+++ b/projects/plugins/jetpack/tests/php/sync/Z_IJetpack_Sync_Replicastore_Test.php
@@ -50,7 +50,10 @@ class Z_IJetpack_Sync_Replicastore_Test extends TestCase {
 
 		// this is a hack so that our setUp method can access the $store instance and call reset()
 		$prop = new ReflectionProperty( 'PHPUnit_Framework_TestCase', 'data' );
-		$prop->setAccessible( true );
+		// @todo Remove this call once we no longer need to support PHP <8.1.
+		if ( PHP_VERSION_ID < 80100 ) {
+			$prop->setAccessible( true );
+		}
 		$test_data = $prop->getValue( $this );
 
 		if ( isset( $test_data[0] ) && $test_data[0] ) {

--- a/projects/plugins/wpcomsh/changelog/fix-php8.5-wrap_deprecated_setAccessible_method
+++ b/projects/plugins/wpcomsh/changelog/fix-php8.5-wrap_deprecated_setAccessible_method
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Tests: Ensure PHP 8.5 compatibility.

--- a/projects/plugins/wpcomsh/tests/ProtectedOwnerErrorHandlerTest.php
+++ b/projects/plugins/wpcomsh/tests/ProtectedOwnerErrorHandlerTest.php
@@ -54,7 +54,10 @@ class ProtectedOwnerErrorHandlerTest extends WP_UnitTestCase {
 		// Use reflection to access private method
 		$reflection = new ReflectionClass( $this->handler );
 		$method     = $reflection->getMethod( 'build_error_data' );
-		$method->setAccessible( true );
+		// @todo Remove this call once we no longer need to support PHP <8.1.
+		if ( PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
 
 		$result = $method->invoke( $this->handler, $raw_error );
 
@@ -223,7 +226,10 @@ class ProtectedOwnerErrorHandlerTest extends WP_UnitTestCase {
 		// Use reflection to access private method
 		$reflection = new ReflectionClass( $this->handler );
 		$method     = $reflection->getMethod( 'get_prepopulation_email' );
-		$method->setAccessible( true );
+		// @todo Remove this call once we no longer need to support PHP <8.1.
+		if ( PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
 
 		$result = $method->invoke( $this->handler );
 
@@ -245,7 +251,10 @@ class ProtectedOwnerErrorHandlerTest extends WP_UnitTestCase {
 		// Use reflection to access private method
 		$reflection = new ReflectionClass( $this->handler );
 		$method     = $reflection->getMethod( 'get_prepopulation_email' );
-		$method->setAccessible( true );
+		// @todo Remove this call once we no longer need to support PHP <8.1.
+		if ( PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
 
 		$result = $method->invoke( $this->handler );
 
@@ -268,7 +277,10 @@ class ProtectedOwnerErrorHandlerTest extends WP_UnitTestCase {
 		// Use reflection to access private method
 		$reflection = new ReflectionClass( $this->handler );
 		$method     = $reflection->getMethod( 'get_prepopulation_email' );
-		$method->setAccessible( true );
+		// @todo Remove this call once we no longer need to support PHP <8.1.
+		if ( PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
 
 		$result = $method->invoke( $this->handler );
 
@@ -296,7 +308,10 @@ class ProtectedOwnerErrorHandlerTest extends WP_UnitTestCase {
 		// Use reflection to access private method
 		$reflection = new ReflectionClass( $this->handler );
 		$method     = $reflection->getMethod( 'get_prepopulation_email' );
-		$method->setAccessible( true );
+		// @todo Remove this call once we no longer need to support PHP <8.1.
+		if ( PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
 
 		$result = $method->invoke( $this->handler );
 
@@ -311,7 +326,10 @@ class ProtectedOwnerErrorHandlerTest extends WP_UnitTestCase {
 		// Use reflection to access private method
 		$reflection = new ReflectionClass( $this->handler );
 		$method     = $reflection->getMethod( 'get_prepopulation_email' );
-		$method->setAccessible( true );
+		// @todo Remove this call once we no longer need to support PHP <8.1.
+		if ( PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
 
 		$result = $method->invoke( $this->handler );
 
@@ -341,7 +359,10 @@ class ProtectedOwnerErrorHandlerTest extends WP_UnitTestCase {
 		// Use reflection to access private method
 		$reflection = new ReflectionClass( $this->handler );
 		$method     = $reflection->getMethod( 'get_prepopulation_email' );
-		$method->setAccessible( true );
+		// @todo Remove this call once we no longer need to support PHP <8.1.
+		if ( PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
 
 		$result = $method->invoke( $this->handler );
 


### PR DESCRIPTION
Closes MONOREP-181

 <!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

The `Reflection*::setAccessible()` functions are no-op as of PHP 8.1 and have been deprecated in PHP 8.5.

This PR wraps those calls in a PHP version check.

More info: https://wiki.php.net/rfc/deprecations_php_8_5#extreflection_deprecations

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

CI should still be happy and the only changes should be a version check wrapper.
