### PR TITLE
PHP 8.5: Enable CI tests

### DIFF
--- a/.github/files/generate-ci-matrix.php
+++ b/.github/files/generate-ci-matrix.php
@@ -80,6 +80,15 @@ foreach ( array( 'previous', 'trunk' ) as $wp ) {
 	);
 }
 
+// todo: move to the main matrix once WP latest is compatible with PHP 8.5.
+$matrix[] = array(
+	'name'    => 'PHP tests: PHP 8.5 WP trunk',
+	'script'  => 'test-php',
+	'php'     => '8.5',
+	'wp'      => 'trunk',
+	'timeout' => 20,
+);
+
 // Add WooCommerce tests.
 $matrix[] = array(
 	'name'             => 'PHP tests: PHP 7.4 WP latest with WooCommerce',

--- a/.github/files/generate-ci-matrix.php
+++ b/.github/files/generate-ci-matrix.php
@@ -87,6 +87,7 @@ $matrix[] = array(
 	'php'     => '8.5',
 	'wp'      => 'trunk',
 	'timeout' => 20,
+	'force-package-tests' => true,
 );
 
 // Add WooCommerce tests.

--- a/.github/files/generate-ci-matrix.php
+++ b/.github/files/generate-ci-matrix.php
@@ -82,11 +82,11 @@ foreach ( array( 'previous', 'trunk' ) as $wp ) {
 
 // todo: move to the main matrix once WP latest is compatible with PHP 8.5.
 $matrix[] = array(
-	'name'    => 'PHP tests: PHP 8.5 WP trunk',
-	'script'  => 'test-php',
-	'php'     => '8.5',
-	'wp'      => 'trunk',
-	'timeout' => 20,
+	'name'                => 'PHP tests: PHP 8.5 WP trunk',
+	'script'              => 'test-php',
+	'php'                 => '8.5',
+	'wp'                  => 'trunk',
+	'timeout'             => 20,
 	'force-package-tests' => true,
 );
 

--- a/.github/versions.sh
+++ b/.github/versions.sh
@@ -6,4 +6,4 @@ PNPM_VERSION=10.4.0
 
 # Other useful version numbers.
 MIN_PHP_VERSION=7.2
-MAX_PHP_VERSION=8.4
+MAX_PHP_VERSION=8.5

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -196,7 +196,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: [ '7.2', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4' ]
+        php-versions: [ '7.2', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5' ]
         experimental: [ false ]
 
     steps:

--- a/docs/monorepo.md
+++ b/docs/monorepo.md
@@ -41,7 +41,7 @@ All GitHub Actions configuration for the monorepo, including CI, lives in `.gith
 
 ## Compatibility
 
-All projects should be compatible with PHP versions WordPress supports. That's currently PHP 7.2 to 8.4.
+All projects should be compatible with PHP versions WordPress supports. That's currently PHP 7.2 to 8.5.
 
 ## First Time
 
@@ -259,7 +259,7 @@ If a project contains PHP tests (typically PHPUnit), it must define `.scripts.te
 
 A MySQL database is available if needed; credentials may be found in `~/.my.cnf`. Note that the host must be specified as `127.0.0.1`, as when passed `localhost` PHP will try to connect via a Unix domain socket which is not available in the Actions environment.
 
-Tests are run with a variety of supported PHP versions from 7.2 to 8.4. If you have tests that only need to be run once, run them when `PHP_VERSION` matches that in `.github/versions.sh`.
+Tests are run with a variety of supported PHP versions from 7.2 to 8.5. If you have tests that only need to be run once, run them when `PHP_VERSION` matches that in `.github/versions.sh`.
 
 #### PHP tests for non-plugins
 
@@ -267,7 +267,7 @@ For all project types other than WordPress plugins, the necessary version of PHP
 
 We currently make use of the following packages in testing; it's encouraged to use these rather than introducing other tools that serve the same purpose.
 
-* [yoast/phpunit-polyfills](https://packagist.org/packages/yoast/phpunit-polyfills) supplies polyfills for compatibility with PHPUnit 8.5 to 9.6, to support PHP 7.2 to 8.4.
+* [yoast/phpunit-polyfills](https://packagist.org/packages/yoast/phpunit-polyfills) supplies polyfills for compatibility with PHPUnit 8.5 to 12.4, to support PHP 7.2 to 8.5.
 * [automattic/phpunit-select-config](https://packagist.org/packages/automattic/phpunit-select-config) allows for selecting a configuration file based on the version of PHPUnit in use, since configs are often not compatible across major versions since PHPUnit 9.
 * PHPUnit's built-in mocking is used for class mocks.
 * [brain/monkey](https://packagist.org/packages/brain/monkey) is used for mocking functions, and can also provide some functions for minimal WordPress compatibility.

--- a/projects/packages/assets/changelog/fix-php8.5-package_tests
+++ b/projects/packages/assets/changelog/fix-php8.5-package_tests
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Tests: Improve compatibility with PHP 8.5.

--- a/projects/packages/assets/tests/php/bootstrap.php
+++ b/projects/packages/assets/tests/php/bootstrap.php
@@ -9,3 +9,17 @@
  * Load the composer packages.
  */
 require_once __DIR__ . '/../../vendor/autoload.php';
+
+// Suppress PHP 8.5 deprecation warnings from wikimedia/testing-access-wrapper.
+// See here: https://phabricator.wikimedia.org/T406744
+// @todo: Remove this when a new version is released with the fix.
+if ( PHP_VERSION_ID >= 80500 ) {
+	set_error_handler(
+		function ( $errno, $errstr, $errfile = '' ) {
+			return E_DEPRECATED === $errno
+				&& str_contains( $errstr, 'setAccessible() is deprecated' )
+				&& str_ends_with( $errfile, 'vendor/wikimedia/testing-access-wrapper/src/TestingAccessWrapper.php' );
+		},
+		E_ALL
+	);
+}

--- a/projects/packages/autoloader/changelog/fix-php8.5-package_tests
+++ b/projects/packages/autoloader/changelog/fix-php8.5-package_tests
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Tests: Improve compatibility with PHP 8.5.

--- a/projects/packages/autoloader/tests/php/lib/class-test-plugin-factory.php
+++ b/projects/packages/autoloader/tests/php/lib/class-test-plugin-factory.php
@@ -361,12 +361,20 @@ class Test_Plugin_Factory {
 		// the developer has installed is compatible. To address these differences we will download a
 		// composer package that is compatible based on ranges of autoloader versions.
 		$composer_versions = array(
+			// Version 2.8.12 is compatible with PHP 8.5.
+			'2.8.12'  => array(
+				'min'     => '2.6.0',
+				'url'     => 'https://getcomposer.org/download/2.8.12/composer.phar',
+				'sha256'  => 'f446ea719708bb85fcbf4ef18def5d0515f1f9b4d703f6d820c9c1656e10a2f2',
+				'min_php' => 70205,
+			),
 			// Version 2.4.0 renamed a class, we want to test with that.
 			'2.4.4'   => array(
 				'min'     => '2.6.0',
 				'url'     => 'https://getcomposer.org/download/2.4.4/composer.phar',
 				'sha256'  => 'c252c2a2219956f88089ffc242b42c8cb9300a368fd3890d63940e4fc9652345',
 				'min_php' => 70205,
+				'max_php' => 80499,
 			),
 			// Version 2.1.6 of Composer is the first to support PHP 8.1.
 			'2.1.6'   => array(

--- a/projects/packages/changelogger/changelog/fix-php8.5-package_tests
+++ b/projects/packages/changelogger/changelog/fix-php8.5-package_tests
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Tests: Improve compatibility with PHP 8.5.

--- a/projects/packages/changelogger/tests/php/bootstrap.php
+++ b/projects/packages/changelogger/tests/php/bootstrap.php
@@ -7,3 +7,17 @@
 
 // Include the Composer autoloader.
 require_once __DIR__ . '/../../vendor/autoload.php';
+
+// Suppress PHP 8.5 deprecation warnings from wikimedia/testing-access-wrapper.
+// See here: https://phabricator.wikimedia.org/T406744
+// @todo: Remove this when a new version is released with the fix.
+if ( PHP_VERSION_ID >= 80500 ) {
+	set_error_handler(
+		function ( $errno, $errstr, $errfile = '' ) {
+			return E_DEPRECATED === $errno
+				&& str_contains( $errstr, 'setAccessible() is deprecated' ) // phpcs:ignore PHPCompatibility.FunctionUse.NewFunctions.str_containsFound -- this is a PHP 7.4+ function in a PHP 8.5+ block
+				&& str_ends_with( $errfile, 'vendor/wikimedia/testing-access-wrapper/src/TestingAccessWrapper.php' ); // phpcs:ignore PHPCompatibility.FunctionUse.NewFunctions.str_ends_withFound -- this is a PHP 7.4+ function in a PHP 8.5+ block
+		},
+		E_ALL
+	);
+}

--- a/projects/packages/codesniffer/changelog/fix-php8.5-package_tests
+++ b/projects/packages/codesniffer/changelog/fix-php8.5-package_tests
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Tests: Improve compatibility with PHP 8.5.

--- a/projects/packages/codesniffer/src/Utils/NamespaceInfo.php
+++ b/projects/packages/codesniffer/src/Utils/NamespaceInfo.php
@@ -176,7 +176,7 @@ class NamespaceInfo {
 			$unprefixed = null;
 		}
 		// Skip if the shortened version is an alias though.
-		if ( isset( $aliases[ $unprefixed ] ) ) {
+		if ( $unprefixed !== null && isset( $aliases[ $unprefixed ] ) ) {
 			$unprefixed = null;
 		}
 		$unprefixedCt = $unprefixed === null ? INF : substr_count( $unprefixed, '\\' );

--- a/projects/packages/connection/changelog/fix-php8.5-package_tests
+++ b/projects/packages/connection/changelog/fix-php8.5-package_tests
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Tests: Improve compatibility with PHP 8.5.

--- a/projects/packages/connection/src/class-manager.php
+++ b/projects/packages/connection/src/class-manager.php
@@ -1747,16 +1747,16 @@ class Manager {
 	 * @return array $amended arguments.
 	 */
 	public static function apply_activation_source_to_args( $args ) {
-		list( $activation_source_name, $activation_source_keyword ) = get_option( 'jetpack_activation_source' );
+		$activation_source = get_option( 'jetpack_activation_source' );
 
-		if ( $activation_source_name ) {
+		if ( ! empty( $activation_source[0] ) ) {
 			// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.urlencode_urlencode
-			$args['_as'] = urlencode( $activation_source_name );
+			$args['_as'] = urlencode( $activation_source[0] );
 		}
 
-		if ( $activation_source_keyword ) {
+		if ( ! empty( $activation_source[1] ) ) {
 			// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.urlencode_urlencode
-			$args['_ak'] = urlencode( $activation_source_keyword );
+			$args['_ak'] = urlencode( $activation_source[1] );
 		}
 
 		return $args;

--- a/projects/packages/patchwork-redefine-exit/changelog/add-php8.5-enable_ci_tests
+++ b/projects/packages/patchwork-redefine-exit/changelog/add-php8.5-enable_ci_tests
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Improve PHP 8.5 compatibility.

--- a/projects/packages/patchwork-redefine-exit/tests/php/fixtures/die.php
+++ b/projects/packages/patchwork-redefine-exit/tests/php/fixtures/die.php
@@ -4,6 +4,5 @@ if ( isset( $arg ) ) {
 	// phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
 	die( $arg );
 } else {
-	// @phan-suppress-current-line UnusedPluginSuppression @phan-suppress-next-line PhanParamTooFewInternal -- Phan bug with PHP 8.4: https://github.com/phan/phan/issues/4888
 	die();
 }

--- a/projects/packages/patchwork-redefine-exit/tests/php/fixtures/exit.php
+++ b/projects/packages/patchwork-redefine-exit/tests/php/fixtures/exit.php
@@ -4,6 +4,5 @@ if ( isset( $arg ) ) {
 	// phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
 	exit( $arg );
 } else {
-	// @phan-suppress-current-line UnusedPluginSuppression @phan-suppress-next-line PhanParamTooFewInternal -- Phan bug with PHP 8.4: https://github.com/phan/phan/issues/4888
 	exit();
 }

--- a/projects/packages/scheduled-updates/.phan/baseline.php
+++ b/projects/packages/scheduled-updates/.phan/baseline.php
@@ -10,12 +10,10 @@
 return [
     // # Issue statistics:
     // PhanTypeArraySuspiciousNullable : 2 occurrences
-    // PhanCompatibleAccessMethodOnTraitDefinition : 1 occurrence
 
     // Currently, file_suppressions and directory_suppressions are the only supported suppressions
     'file_suppressions' => [
         'src/pluggable.php' => ['PhanTypeArraySuspiciousNullable'],
-        'tests/php/Scheduled_Updates_Test.php' => ['PhanCompatibleAccessMethodOnTraitDefinition'],
     ],
     // 'directory_suppressions' => ['src/directory_name' => ['PhanIssueName1', 'PhanIssueName2']] can be manually added if needed.
     // (directory_suppressions will currently be ignored by subsequent calls to --save-baseline, but may be preserved in future Phan releases)

--- a/projects/packages/scheduled-updates/changelog/fix-php8.5-package_tests
+++ b/projects/packages/scheduled-updates/changelog/fix-php8.5-package_tests
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Tests: Improve compatibility with PHP 8.5.

--- a/projects/packages/scheduled-updates/composer.json
+++ b/projects/packages/scheduled-updates/composer.json
@@ -15,7 +15,6 @@
 		"yoast/phpunit-polyfills": "^4.0.0",
 		"automattic/jetpack-changelogger": "@dev",
 		"automattic/jetpack-test-environment": "@dev",
-		"php-mock/php-mock-phpunit": "^2.10",
 		"automattic/phpunit-select-config": "@dev"
 	},
 	"suggest": {

--- a/projects/packages/scheduled-updates/tests/php/Scheduled_Updates_Health_Paths_Test.php
+++ b/projects/packages/scheduled-updates/tests/php/Scheduled_Updates_Health_Paths_Test.php
@@ -20,13 +20,6 @@ use PHPUnit\Framework\Attributes\CoversClass;
 class Scheduled_Updates_Health_Paths_Test extends \WorDBless\BaseTestCase {
 
 	/**
-	 * Used to mock global functions inside a namespace.
-	 *
-	 * @see https://github.com/php-mock/php-mock-phpunit
-	 */
-	use \phpmock\phpunit\PHPMock;
-
-	/**
 	 * Admin user ID.
 	 *
 	 * @var int

--- a/projects/packages/scheduled-updates/tests/php/Scheduled_Updates_Logs_Test.php
+++ b/projects/packages/scheduled-updates/tests/php/Scheduled_Updates_Logs_Test.php
@@ -18,29 +18,11 @@ use PHPUnit\Framework\Attributes\CoversClass;
 class Scheduled_Updates_Logs_Test extends \WorDBless\BaseTestCase {
 
 	/**
-	 * Used to mock global functions inside a namespace.
-	 *
-	 * @see https://github.com/php-mock/php-mock-phpunit
-	 */
-	use \phpmock\phpunit\PHPMock;
-
-	/**
 	 * Admin user ID.
 	 *
 	 * @var int
 	 */
 	public $admin_id;
-
-	/**
-	 * Set up before class.
-	 *
-	 * @see Restrictions here: https://github.com/php-mock/php-mock-phpunit?tab=readme-ov-file#restrictions
-	 */
-	public static function set_up_before_class() {
-		parent::set_up_before_class();
-
-		static::defineFunctionMock( 'Automattic\Jetpack', 'realpath' );
-	}
 
 	/**
 	 * Set up.

--- a/projects/packages/scheduled-updates/tests/php/Scheduled_Updates_Test.php
+++ b/projects/packages/scheduled-updates/tests/php/Scheduled_Updates_Test.php
@@ -8,7 +8,6 @@
 namespace Automattic\Jetpack;
 
 use PHPUnit\Framework\Attributes\CoversClass;
-use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Test class for Scheduled_Updates.
@@ -19,13 +18,6 @@ use PHPUnit\Framework\Attributes\Group;
 #[CoversClass( Scheduled_Updates::class )]
 #[CoversClass( \WPCOM_REST_API_V2_Endpoint_Update_Schedules::class )]
 class Scheduled_Updates_Test extends \WorDBless\BaseTestCase {
-
-	/**
-	 * Used to mock global functions inside a namespace.
-	 *
-	 * @see https://github.com/php-mock/php-mock-phpunit
-	 */
-	use \phpmock\phpunit\PHPMock;
 
 	/**
 	 * Admin user ID.
@@ -40,16 +32,6 @@ class Scheduled_Updates_Test extends \WorDBless\BaseTestCase {
 	 * @var \WP_Filesystem_Direct
 	 */
 	public $wp_filesystem;
-
-	/**
-	 * Set up before class.
-	 *
-	 * @see Restrictions here: https://github.com/php-mock/php-mock-phpunit?tab=readme-ov-file#restrictions
-	 */
-	public static function set_up_before_class() {
-		parent::set_up_before_class();
-		\phpmock\phpunit\PHPMock::defineFunctionMock( 'Automattic\Jetpack', 'realpath' );
-	}
 
 	/**
 	 * Set up.
@@ -93,6 +75,8 @@ class Scheduled_Updates_Test extends \WorDBless\BaseTestCase {
 		delete_option( 'jetpack_scheduled_update_statuses' );
 		delete_option( 'auto_update_plugins' );
 
+		unset( $GLOBALS['mock_realpath'] );
+
 		parent::tear_down_wordbless();
 	}
 
@@ -127,16 +111,12 @@ class Scheduled_Updates_Test extends \WorDBless\BaseTestCase {
 
 	/**
 	 * Simulate managed plugins linked from a root /wordpress directory.
-	 *
-	 * @group failing
 	 */
-	#[Group( 'failing' )]
 	public function test_managed_plugins() {
 		symlink( WP_PLUGIN_DIR . '/wordpress/managed-plugin', WP_PLUGIN_DIR . '/managed-plugin' );
 
-		// Tweak realpath so that it returns `/wordpress/...`.
-		$realpath = $this->getFunctionMock( __NAMESPACE__, 'realpath' );
-		$realpath->expects( $this->once() )->willReturn( '/wordpress/plugins/managed-plugin' );
+		// Mock realpath to return a path starting with /wordpress/.
+		$GLOBALS['mock_realpath'][ WP_PLUGIN_DIR . '/managed-plugin' ] = '/wordpress/plugins/managed-plugin';
 
 		$request       = new \WP_REST_Request( 'GET', '/wp/v2/plugins' );
 		$result        = rest_do_request( $request );
@@ -690,13 +670,8 @@ class Scheduled_Updates_Test extends \WorDBless\BaseTestCase {
 		$plugins = array( 'managed-plugin/managed-plugin.php', 'installed-plugin/installed-plugin.php' );
 		symlink( WP_PLUGIN_DIR . '/wordpress/managed-plugin', WP_PLUGIN_DIR . '/managed-plugin' );
 
-		// Tweak realpath so that it returns `/wordpress/...` for the managed plugin.
-		$realpath = $this->getFunctionMock( __NAMESPACE__, 'realpath' );
-		$realpath->expects( $this->once() )->willReturnCallback(
-			function ( $path ) {
-				return str_replace( WP_PLUGIN_DIR, '/wordpress/plugins', $path );
-			}
-		);
+		// Mock realpath to return a path starting with /wordpress/ for the managed plugin.
+		$GLOBALS['mock_realpath'][ WP_PLUGIN_DIR . '/managed-plugin' ] = '/wordpress/plugins/managed-plugin';
 
 		$request = new \WP_REST_Request( 'POST', '/wpcom/v2/update-schedules' );
 		$request->set_body_params(

--- a/projects/packages/scheduled-updates/tests/php/WPCOM_REST_API_V2_Endpoint_Update_Schedules_Active_Test.php
+++ b/projects/packages/scheduled-updates/tests/php/WPCOM_REST_API_V2_Endpoint_Update_Schedules_Active_Test.php
@@ -19,13 +19,6 @@ use PHPUnit\Framework\Attributes\CoversClass;
 class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Active_Test extends \WorDBless\BaseTestCase {
 
 	/**
-	 * Used to mock global functions inside a namespace.
-	 *
-	 * @see https://github.com/php-mock/php-mock-phpunit
-	 */
-	use \phpmock\phpunit\PHPMock;
-
-	/**
 	 * Admin user ID.
 	 *
 	 * @var int

--- a/projects/packages/scheduled-updates/tests/php/bootstrap.php
+++ b/projects/packages/scheduled-updates/tests/php/bootstrap.php
@@ -12,6 +12,11 @@ if ( ! file_exists( WP_PLUGIN_DIR ) ) {
 }
 
 /**
+ * Include mock functions before autoloader so they're available when classes are loaded.
+ */
+require_once __DIR__ . '/mock-functions.php';
+
+/**
  * Include the composer autoloader and dependencies.
  */
 require_once __DIR__ . '/../../vendor/autoload.php';

--- a/projects/packages/scheduled-updates/tests/php/mock-functions.php
+++ b/projects/packages/scheduled-updates/tests/php/mock-functions.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Mock functions for testing
+ *
+ * @package automattic/scheduled-updates
+ */
+
+namespace Automattic\Jetpack;
+
+/**
+ * Mock realpath in the current namespace
+ *
+ * If $GLOBALS['mock_realpath'][ $path ] is set, it will be used as the return value.
+ * Otherwise, it falls back to the native realpath function.
+ *
+ * @param string $path The path to resolve.
+ * @return string|false The resolved path or false on failure.
+ */
+function realpath( $path ) {
+	if ( isset( $GLOBALS['mock_realpath'][ $path ] ) ) {
+		return $GLOBALS['mock_realpath'][ $path ];
+	}
+	return \realpath( $path );
+}

--- a/projects/plugins/jetpack/changelog/add-php8.5-enable_ci_tests
+++ b/projects/plugins/jetpack/changelog/add-php8.5-enable_ci_tests
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Improve PHP 8.5 compatibility.

--- a/projects/plugins/jetpack/sal/class.json-api-links.php
+++ b/projects/plugins/jetpack/sal/class.json-api-links.php
@@ -329,7 +329,7 @@ class WPCOM_JSON_API_Links {
 		}
 
 		$endpoint_path_versions = $this->get_endpoint_path_versions();
-		$last_path_segment      = $this->get_last_segment_of_relative_path( $path ) ?? '';
+		$last_path_segment      = $this->get_last_segment_of_relative_path( $path );
 		$max_version_found      = null;
 
 		foreach ( $endpoint_path_versions as $endpoint_last_path_segment => $endpoints ) {
@@ -418,7 +418,7 @@ class WPCOM_JSON_API_Links {
 			list( $path, $min_version, $max_version ) = unserialize( $key );         // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_unserialize -- Legacy, see serialization at class.json-api.php.
 
 			// Grab the last component of the relative path to use as the top-level key.
-			$last_path_segment = $this->get_last_segment_of_relative_path( $path );
+			$last_path_segment = $this->get_last_segment_of_relative_path( $path ) ?? '';
 
 			$endpoint_path_versions[ $last_path_segment ][] = array(
 				'path'            => $path,

--- a/projects/plugins/jetpack/sal/class.json-api-links.php
+++ b/projects/plugins/jetpack/sal/class.json-api-links.php
@@ -293,10 +293,11 @@ class WPCOM_JSON_API_Links {
 	public function get_closest_version_of_endpoint( $template_path, $path, $request_method = 'GET' ) {
 		$closest_endpoint_cache_by_version = & $this->closest_endpoint_cache_by_version;
 
-		$closest_endpoint_cache = & $closest_endpoint_cache_by_version[ $this->api->version ];
+		$api_version            = $this->api->version ?? '';
+		$closest_endpoint_cache = & $closest_endpoint_cache_by_version[ $api_version ];
 		if ( ! $closest_endpoint_cache ) {
-			$closest_endpoint_cache_by_version[ $this->api->version ] = array();
-			$closest_endpoint_cache                                   = & $closest_endpoint_cache_by_version[ $this->api->version ];
+			$closest_endpoint_cache_by_version[ $api_version ] = array();
+			$closest_endpoint_cache                            = & $closest_endpoint_cache_by_version[ $api_version ];
 		}
 
 		if ( ! isset( $closest_endpoint_cache[ $template_path ] ) ) {
@@ -316,10 +317,10 @@ class WPCOM_JSON_API_Links {
 		$matches_by_version = & $this->matches_by_version;
 
 		// try to match out of saved matches.
-		if ( ! isset( $matches_by_version[ $this->api->version ] ) ) {
-			$matches_by_version[ $this->api->version ] = array();
+		if ( ! isset( $matches_by_version[ $api_version ] ) ) {
+			$matches_by_version[ $api_version ] = array();
 		}
-		foreach ( $matches_by_version[ $this->api->version ] as $match ) {
+		foreach ( $matches_by_version[ $api_version ] as $match ) {
 			$regex = $match->regex;
 			if ( preg_match( "#^$regex\$#", $path ) ) {
 				$closest_endpoint_cache[ $template_path ][ $request_method ] = $match->version;
@@ -328,7 +329,7 @@ class WPCOM_JSON_API_Links {
 		}
 
 		$endpoint_path_versions = $this->get_endpoint_path_versions();
-		$last_path_segment      = $this->get_last_segment_of_relative_path( $path );
+		$last_path_segment      = $this->get_last_segment_of_relative_path( $path ) ?? '';
 		$max_version_found      = null;
 
 		foreach ( $endpoint_path_versions as $endpoint_last_path_segment => $endpoints ) {
@@ -382,7 +383,7 @@ class WPCOM_JSON_API_Links {
 		// If the endpoint version is less than the requested endpoint version, return the max version found.
 		if ( ! empty( $max_version_found ) ) {
 			array_push(
-				$matches_by_version[ $this->api->version ],
+				$matches_by_version[ $api_version ],
 				(object) $max_version_found
 			);
 			$closest_endpoint_cache[ $template_path ][ $request_method ] = $max_version_found['version'];

--- a/projects/plugins/jetpack/tests/php/bootstrap.php
+++ b/projects/plugins/jetpack/tests/php/bootstrap.php
@@ -218,6 +218,20 @@ if ( false !== getenv( 'WP_TESTS_CONFIG_FILE_PATH' ) ) {
 // Load trait for WP_UnitTestCase PHPUnit 10 compat.
 require_once __DIR__ . '/WP_UnitTestCase_Fix.php';
 
+// Suppress PHP 8.5 deprecation warnings from WordPress core.
+// See here: https://core.trac.wordpress.org/ticket/63061
+// @todo: Remove this when resolved in WP core.
+if ( PHP_VERSION_ID >= 80500 ) {
+	set_error_handler(
+		function ( $errno, $errstr, $errfile = '' ) {
+			return E_DEPRECATED === $errno
+				&& $errstr === 'Using null as an array offset is deprecated, use an empty string instead'
+				&& str_ends_with( $errfile, 'wp-includes/theme.php' );
+		},
+		E_ALL
+	);
+}
+
 require $test_root . '/includes/bootstrap.php';
 
 // Load the shortcodes module to test properly.

--- a/projects/plugins/mu-wpcom-plugin/changelog/fix-php8.5-package_tests
+++ b/projects/plugins/mu-wpcom-plugin/changelog/fix-php8.5-package_tests
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update package dependencies.

--- a/projects/plugins/mu-wpcom-plugin/composer.lock
+++ b/projects/plugins/mu-wpcom-plugin/composer.lock
@@ -1757,7 +1757,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/scheduled-updates",
-                "reference": "23e79cec756fee0825405c764a6fa7415f1360a3"
+                "reference": "3f52602bf5f9547ed9d5081beac4660a8887dcfb"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1771,7 +1771,6 @@
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "php-mock/php-mock-phpunit": "^2.10",
                 "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {

--- a/projects/plugins/wpcomsh/changelog/fix-php8.5-package_tests
+++ b/projects/plugins/wpcomsh/changelog/fix-php8.5-package_tests
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update package dependencies.

--- a/projects/plugins/wpcomsh/composer.lock
+++ b/projects/plugins/wpcomsh/composer.lock
@@ -2032,7 +2032,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/scheduled-updates",
-                "reference": "23e79cec756fee0825405c764a6fa7415f1360a3"
+                "reference": "3f52602bf5f9547ed9d5081beac4660a8887dcfb"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -2046,7 +2046,6 @@
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "php-mock/php-mock-phpunit": "^2.10",
                 "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {


### PR DESCRIPTION
Closes MONOREP-182

 <!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This enables PHP 8.5 CI tests after a few tweaks for compatibility. In particular, changes are as follows:

* Enabled PHP 8.5 + WP `trunk`. Once WP 6.9 is out we can switch to WP latest, but right now that just triggers tons of core deprecations.
* Removed some unneeded Phan suppressions.
* Updated docs.
* Handle null offset deprecations by updating relevant monorepo code and disabling core deprecations.

Related PRs:
* #45766
* #45767
* #45769

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Does CI show PHP 8.5 and is it happy?