### PR TITLE
Jetpack Sync: Do not sync shop_order_placehold post-type

### DIFF
--- a/projects/packages/sync/changelog/add-sync-defaults-blacklist-shop_order_placehold
+++ b/projects/packages/sync/changelog/add-sync-defaults-blacklist-shop_order_placehold
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Sync: Ignore the shop_order_placehold post-type from Woo.

--- a/projects/packages/sync/src/class-defaults.php
+++ b/projects/packages/sync/src/class-defaults.php
@@ -468,7 +468,7 @@ class Defaults {
 		'iw_omnibus_price_log', // Omnibus Plugin - Log price changes.
 		'od_url_metrics', // Optimization Detective - Log URL metrics.
 		'ap_outbox', // ActivityPub Outbox; only used for broadcasting ActivityPub activity to followers.
-		'shop_order_placehold', // WooCommerce placeholder - Used to maintain compatibility and references when switching between WP Posts-based order storage and the newer HPOS tables
+		'shop_order_placehold', // WooCommerce placeholder - Used to maintain compatibility and references when switching between WP Posts-based order storage and the newer HPOS tables.
 	);
 
 	/**

--- a/projects/packages/sync/src/class-defaults.php
+++ b/projects/packages/sync/src/class-defaults.php
@@ -468,6 +468,7 @@ class Defaults {
 		'iw_omnibus_price_log', // Omnibus Plugin - Log price changes.
 		'od_url_metrics', // Optimization Detective - Log URL metrics.
 		'ap_outbox', // ActivityPub Outbox; only used for broadcasting ActivityPub activity to followers.
+		'shop_order_placehold', // WooCommerce placeholder - Used to maintain compatibility and references when switching between WP Posts-based order storage and the newer HPOS tables
 	);
 
 	/**


### PR DESCRIPTION
Part of SYNC-144

## Proposed changes:

* This PR adds `shop_order_placehold` to the Jetpack sync post-type blacklist, as it does not need to be synced. See pf5801-1PW-p2

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

pf5801-1PW-p2

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

* Code-review.
* On a site with WooCommerce installed and active, on (Jetpack) trunk you can visit the Pc9OEs-v-p2 and you will not see `shop_order_placehold` in the 'Post type blacklist' (under 'Sync settings')
* With this PR applied via the Jetpack Beta tester plugin, you will see that post type listed in the above section.

To confirm the post type isn't synced:
* Add a new order draft, but don't click on 'create'. Add an item.
* In your sandbox, in `wpsh`, check to see that the post with `shop_order_placehold` has been added with  `gpr select * from wp_YOURBLOGID_posts where post_type="shop_order_placehold"`
* Apply this PR, and follow the same steps. There should not be a entry in the cache site.