### PR TITLE
Forms: add dashboard page subtitle

### DIFF
--- a/projects/packages/forms/changelog/add-forms-dashboard-page-subtitle
+++ b/projects/packages/forms/changelog/add-forms-dashboard-page-subtitle
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Forms: add subtitle to dashboard page

--- a/projects/packages/forms/src/dashboard/components/layout/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/layout/index.tsx
@@ -76,6 +76,7 @@ const Layout = () => {
 					<JetpackLogo showText={ false } width={ 24 } /> Forms
 				</div>
 			}
+			subTitle={ __( 'Manage your forms and responses', 'jetpack-forms' ) }
 			actions={ headerActions }
 		>
 			<NavigableRegion

--- a/projects/packages/forms/src/dashboard/components/layout/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/layout/index.tsx
@@ -76,7 +76,7 @@ const Layout = () => {
 					<JetpackLogo showText={ false } width={ 24 } /> Forms
 				</div>
 			}
-			subTitle={ __( 'Manage your forms and responses', 'jetpack-forms' ) }
+			subTitle={ __( 'View and manage all your form submissions in one place.', 'jetpack-forms' ) }
 			actions={ headerActions }
 		>
 			<NavigableRegion


### PR DESCRIPTION
Fixes [FORMS-377](https://linear.app/a8c/issue/FORMS-377/add-subtitle-to-dashboard-page)

## Proposed changes:
This PR adds a page subtitle to the dashboard page after some layout changes.

<img width="879" height="223" alt="image" src="https://github.com/user-attachments/assets/b708ba41-b154-4502-80d9-3e59a8c7b6e2" />


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1762356082928229/1762189872.152339-slack-C052XEUUBL4

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Visit the forms dashboard page, see that it looks like in the screenshot. Buttons and menus should continue to work as usual