### PR TITLE
PHP 8.5: Fix package tests

### DIFF
--- a/projects/packages/assets/changelog/fix-php8.5-package_tests
+++ b/projects/packages/assets/changelog/fix-php8.5-package_tests
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Tests: Improve compatibility with PHP 8.5.

--- a/projects/packages/assets/tests/php/bootstrap.php
+++ b/projects/packages/assets/tests/php/bootstrap.php
@@ -9,3 +9,17 @@
  * Load the composer packages.
  */
 require_once __DIR__ . '/../../vendor/autoload.php';
+
+// Suppress PHP 8.5 deprecation warnings from wikimedia/testing-access-wrapper.
+// See here: https://phabricator.wikimedia.org/T406744
+// @todo: Remove this when a new version is released with the fix.
+if ( PHP_VERSION_ID >= 80500 ) {
+	set_error_handler(
+		function ( $errno, $errstr, $errfile = '' ) {
+			return E_DEPRECATED === $errno
+				&& str_contains( $errstr, 'setAccessible() is deprecated' )
+				&& str_ends_with( $errfile, 'vendor/wikimedia/testing-access-wrapper/src/TestingAccessWrapper.php' );
+		},
+		E_ALL
+	);
+}

--- a/projects/packages/autoloader/changelog/fix-php8.5-package_tests
+++ b/projects/packages/autoloader/changelog/fix-php8.5-package_tests
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Tests: Improve compatibility with PHP 8.5.

--- a/projects/packages/autoloader/tests/php/lib/class-test-plugin-factory.php
+++ b/projects/packages/autoloader/tests/php/lib/class-test-plugin-factory.php
@@ -361,12 +361,20 @@ class Test_Plugin_Factory {
 		// the developer has installed is compatible. To address these differences we will download a
 		// composer package that is compatible based on ranges of autoloader versions.
 		$composer_versions = array(
+			// Version 2.8.12 is compatible with PHP 8.5.
+			'2.8.12'  => array(
+				'min'     => '2.6.0',
+				'url'     => 'https://getcomposer.org/download/2.8.12/composer.phar',
+				'sha256'  => 'f446ea719708bb85fcbf4ef18def5d0515f1f9b4d703f6d820c9c1656e10a2f2',
+				'min_php' => 70205,
+			),
 			// Version 2.4.0 renamed a class, we want to test with that.
 			'2.4.4'   => array(
 				'min'     => '2.6.0',
 				'url'     => 'https://getcomposer.org/download/2.4.4/composer.phar',
 				'sha256'  => 'c252c2a2219956f88089ffc242b42c8cb9300a368fd3890d63940e4fc9652345',
 				'min_php' => 70205,
+				'max_php' => 80499,
 			),
 			// Version 2.1.6 of Composer is the first to support PHP 8.1.
 			'2.1.6'   => array(

--- a/projects/packages/changelogger/changelog/fix-php8.5-package_tests
+++ b/projects/packages/changelogger/changelog/fix-php8.5-package_tests
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Tests: Improve compatibility with PHP 8.5.

--- a/projects/packages/changelogger/tests/php/bootstrap.php
+++ b/projects/packages/changelogger/tests/php/bootstrap.php
@@ -15,8 +15,8 @@ if ( PHP_VERSION_ID >= 80500 ) {
 	set_error_handler(
 		function ( $errno, $errstr, $errfile = '' ) {
 			return E_DEPRECATED === $errno
-				&& str_contains( $errstr, 'setAccessible() is deprecated' )
-				&& str_ends_with( $errfile, 'vendor/wikimedia/testing-access-wrapper/src/TestingAccessWrapper.php' );
+				&& str_contains( $errstr, 'setAccessible() is deprecated' ) // phpcs:ignore PHPCompatibility.FunctionUse.NewFunctions.str_containsFound -- this is a PHP 7.4+ function in a PHP 8.5+ block
+				&& str_ends_with( $errfile, 'vendor/wikimedia/testing-access-wrapper/src/TestingAccessWrapper.php' ); // phpcs:ignore PHPCompatibility.FunctionUse.NewFunctions.str_ends_withFound -- this is a PHP 7.4+ function in a PHP 8.5+ block
 		},
 		E_ALL
 	);

--- a/projects/packages/changelogger/tests/php/bootstrap.php
+++ b/projects/packages/changelogger/tests/php/bootstrap.php
@@ -7,3 +7,17 @@
 
 // Include the Composer autoloader.
 require_once __DIR__ . '/../../vendor/autoload.php';
+
+// Suppress PHP 8.5 deprecation warnings from wikimedia/testing-access-wrapper.
+// See here: https://phabricator.wikimedia.org/T406744
+// @todo: Remove this when a new version is released with the fix.
+if ( PHP_VERSION_ID >= 80500 ) {
+	set_error_handler(
+		function ( $errno, $errstr, $errfile = '' ) {
+			return E_DEPRECATED === $errno
+				&& str_contains( $errstr, 'setAccessible() is deprecated' )
+				&& str_ends_with( $errfile, 'vendor/wikimedia/testing-access-wrapper/src/TestingAccessWrapper.php' );
+		},
+		E_ALL
+	);
+}

--- a/projects/packages/codesniffer/changelog/fix-php8.5-package_tests
+++ b/projects/packages/codesniffer/changelog/fix-php8.5-package_tests
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Tests: Improve compatibility with PHP 8.5.

--- a/projects/packages/codesniffer/src/Utils/NamespaceInfo.php
+++ b/projects/packages/codesniffer/src/Utils/NamespaceInfo.php
@@ -176,7 +176,7 @@ class NamespaceInfo {
 			$unprefixed = null;
 		}
 		// Skip if the shortened version is an alias though.
-		if ( isset( $aliases[ $unprefixed ?? '' ] ) ) {
+		if ( $unprefixed !== null && isset( $aliases[ $unprefixed ] ) ) {
 			$unprefixed = null;
 		}
 		$unprefixedCt = $unprefixed === null ? INF : substr_count( $unprefixed, '\\' );

--- a/projects/packages/codesniffer/src/Utils/NamespaceInfo.php
+++ b/projects/packages/codesniffer/src/Utils/NamespaceInfo.php
@@ -176,7 +176,7 @@ class NamespaceInfo {
 			$unprefixed = null;
 		}
 		// Skip if the shortened version is an alias though.
-		if ( isset( $aliases[ $unprefixed ] ) ) {
+		if ( isset( $aliases[ $unprefixed ?? '' ] ) ) {
 			$unprefixed = null;
 		}
 		$unprefixedCt = $unprefixed === null ? INF : substr_count( $unprefixed, '\\' );

--- a/projects/packages/connection/changelog/fix-php8.5-package_tests
+++ b/projects/packages/connection/changelog/fix-php8.5-package_tests
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Tests: Improve compatibility with PHP 8.5.

--- a/projects/packages/connection/src/class-manager.php
+++ b/projects/packages/connection/src/class-manager.php
@@ -1747,16 +1747,16 @@ class Manager {
 	 * @return array $amended arguments.
 	 */
 	public static function apply_activation_source_to_args( $args ) {
-		list( $activation_source_name, $activation_source_keyword ) = get_option( 'jetpack_activation_source' );
+		$activation_source = get_option( 'jetpack_activation_source' );
 
-		if ( $activation_source_name ) {
+		if ( ! empty( $activation_source[0] ) ) {
 			// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.urlencode_urlencode
-			$args['_as'] = urlencode( $activation_source_name );
+			$args['_as'] = urlencode( $activation_source[0] );
 		}
 
-		if ( $activation_source_keyword ) {
+		if ( ! empty( $activation_source[1] ) ) {
 			// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.urlencode_urlencode
-			$args['_ak'] = urlencode( $activation_source_keyword );
+			$args['_ak'] = urlencode( $activation_source[1] );
 		}
 
 		return $args;

--- a/projects/packages/scheduled-updates/.phan/baseline.php
+++ b/projects/packages/scheduled-updates/.phan/baseline.php
@@ -10,12 +10,10 @@
 return [
     // # Issue statistics:
     // PhanTypeArraySuspiciousNullable : 2 occurrences
-    // PhanCompatibleAccessMethodOnTraitDefinition : 1 occurrence
 
     // Currently, file_suppressions and directory_suppressions are the only supported suppressions
     'file_suppressions' => [
         'src/pluggable.php' => ['PhanTypeArraySuspiciousNullable'],
-        'tests/php/Scheduled_Updates_Test.php' => ['PhanCompatibleAccessMethodOnTraitDefinition'],
     ],
     // 'directory_suppressions' => ['src/directory_name' => ['PhanIssueName1', 'PhanIssueName2']] can be manually added if needed.
     // (directory_suppressions will currently be ignored by subsequent calls to --save-baseline, but may be preserved in future Phan releases)

--- a/projects/packages/scheduled-updates/changelog/fix-php8.5-package_tests
+++ b/projects/packages/scheduled-updates/changelog/fix-php8.5-package_tests
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Tests: Improve compatibility with PHP 8.5.

--- a/projects/packages/scheduled-updates/composer.json
+++ b/projects/packages/scheduled-updates/composer.json
@@ -15,7 +15,6 @@
 		"yoast/phpunit-polyfills": "^4.0.0",
 		"automattic/jetpack-changelogger": "@dev",
 		"automattic/jetpack-test-environment": "@dev",
-		"php-mock/php-mock-phpunit": "^2.10",
 		"automattic/phpunit-select-config": "@dev"
 	},
 	"suggest": {

--- a/projects/packages/scheduled-updates/tests/php/Scheduled_Updates_Health_Paths_Test.php
+++ b/projects/packages/scheduled-updates/tests/php/Scheduled_Updates_Health_Paths_Test.php
@@ -20,13 +20,6 @@ use PHPUnit\Framework\Attributes\CoversClass;
 class Scheduled_Updates_Health_Paths_Test extends \WorDBless\BaseTestCase {
 
 	/**
-	 * Used to mock global functions inside a namespace.
-	 *
-	 * @see https://github.com/php-mock/php-mock-phpunit
-	 */
-	use \phpmock\phpunit\PHPMock;
-
-	/**
 	 * Admin user ID.
 	 *
 	 * @var int

--- a/projects/packages/scheduled-updates/tests/php/Scheduled_Updates_Logs_Test.php
+++ b/projects/packages/scheduled-updates/tests/php/Scheduled_Updates_Logs_Test.php
@@ -18,29 +18,11 @@ use PHPUnit\Framework\Attributes\CoversClass;
 class Scheduled_Updates_Logs_Test extends \WorDBless\BaseTestCase {
 
 	/**
-	 * Used to mock global functions inside a namespace.
-	 *
-	 * @see https://github.com/php-mock/php-mock-phpunit
-	 */
-	use \phpmock\phpunit\PHPMock;
-
-	/**
 	 * Admin user ID.
 	 *
 	 * @var int
 	 */
 	public $admin_id;
-
-	/**
-	 * Set up before class.
-	 *
-	 * @see Restrictions here: https://github.com/php-mock/php-mock-phpunit?tab=readme-ov-file#restrictions
-	 */
-	public static function set_up_before_class() {
-		parent::set_up_before_class();
-
-		static::defineFunctionMock( 'Automattic\Jetpack', 'realpath' );
-	}
 
 	/**
 	 * Set up.

--- a/projects/packages/scheduled-updates/tests/php/Scheduled_Updates_Test.php
+++ b/projects/packages/scheduled-updates/tests/php/Scheduled_Updates_Test.php
@@ -8,7 +8,6 @@
 namespace Automattic\Jetpack;
 
 use PHPUnit\Framework\Attributes\CoversClass;
-use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Test class for Scheduled_Updates.
@@ -93,6 +92,8 @@ class Scheduled_Updates_Test extends \WorDBless\BaseTestCase {
 		delete_option( 'jetpack_scheduled_update_statuses' );
 		delete_option( 'auto_update_plugins' );
 
+		unset( $GLOBALS['mock_realpath'] );
+
 		parent::tear_down_wordbless();
 	}
 
@@ -127,16 +128,12 @@ class Scheduled_Updates_Test extends \WorDBless\BaseTestCase {
 
 	/**
 	 * Simulate managed plugins linked from a root /wordpress directory.
-	 *
-	 * @group failing
 	 */
-	#[Group( 'failing' )]
 	public function test_managed_plugins() {
 		symlink( WP_PLUGIN_DIR . '/wordpress/managed-plugin', WP_PLUGIN_DIR . '/managed-plugin' );
 
-		// Tweak realpath so that it returns `/wordpress/...`.
-		$realpath = $this->getFunctionMock( __NAMESPACE__, 'realpath' );
-		$realpath->expects( $this->once() )->willReturn( '/wordpress/plugins/managed-plugin' );
+		// Mock realpath to return a path starting with /wordpress/.
+		$GLOBALS['mock_realpath'][ WP_PLUGIN_DIR . '/managed-plugin' ] = '/wordpress/plugins/managed-plugin';
 
 		$request       = new \WP_REST_Request( 'GET', '/wp/v2/plugins' );
 		$result        = rest_do_request( $request );
@@ -690,13 +687,8 @@ class Scheduled_Updates_Test extends \WorDBless\BaseTestCase {
 		$plugins = array( 'managed-plugin/managed-plugin.php', 'installed-plugin/installed-plugin.php' );
 		symlink( WP_PLUGIN_DIR . '/wordpress/managed-plugin', WP_PLUGIN_DIR . '/managed-plugin' );
 
-		// Tweak realpath so that it returns `/wordpress/...` for the managed plugin.
-		$realpath = $this->getFunctionMock( __NAMESPACE__, 'realpath' );
-		$realpath->expects( $this->once() )->willReturnCallback(
-			function ( $path ) {
-				return str_replace( WP_PLUGIN_DIR, '/wordpress/plugins', $path );
-			}
-		);
+		// Mock realpath to return a path starting with /wordpress/ for the managed plugin.
+		$GLOBALS['mock_realpath'][ WP_PLUGIN_DIR . '/managed-plugin' ] = '/wordpress/plugins/managed-plugin';
 
 		$request = new \WP_REST_Request( 'POST', '/wpcom/v2/update-schedules' );
 		$request->set_body_params(

--- a/projects/packages/scheduled-updates/tests/php/Scheduled_Updates_Test.php
+++ b/projects/packages/scheduled-updates/tests/php/Scheduled_Updates_Test.php
@@ -20,13 +20,6 @@ use PHPUnit\Framework\Attributes\CoversClass;
 class Scheduled_Updates_Test extends \WorDBless\BaseTestCase {
 
 	/**
-	 * Used to mock global functions inside a namespace.
-	 *
-	 * @see https://github.com/php-mock/php-mock-phpunit
-	 */
-	use \phpmock\phpunit\PHPMock;
-
-	/**
 	 * Admin user ID.
 	 *
 	 * @var int
@@ -39,16 +32,6 @@ class Scheduled_Updates_Test extends \WorDBless\BaseTestCase {
 	 * @var \WP_Filesystem_Direct
 	 */
 	public $wp_filesystem;
-
-	/**
-	 * Set up before class.
-	 *
-	 * @see Restrictions here: https://github.com/php-mock/php-mock-phpunit?tab=readme-ov-file#restrictions
-	 */
-	public static function set_up_before_class() {
-		parent::set_up_before_class();
-		\phpmock\phpunit\PHPMock::defineFunctionMock( 'Automattic\Jetpack', 'realpath' );
-	}
 
 	/**
 	 * Set up.

--- a/projects/packages/scheduled-updates/tests/php/WPCOM_REST_API_V2_Endpoint_Update_Schedules_Active_Test.php
+++ b/projects/packages/scheduled-updates/tests/php/WPCOM_REST_API_V2_Endpoint_Update_Schedules_Active_Test.php
@@ -19,13 +19,6 @@ use PHPUnit\Framework\Attributes\CoversClass;
 class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Active_Test extends \WorDBless\BaseTestCase {
 
 	/**
-	 * Used to mock global functions inside a namespace.
-	 *
-	 * @see https://github.com/php-mock/php-mock-phpunit
-	 */
-	use \phpmock\phpunit\PHPMock;
-
-	/**
 	 * Admin user ID.
 	 *
 	 * @var int

--- a/projects/packages/scheduled-updates/tests/php/bootstrap.php
+++ b/projects/packages/scheduled-updates/tests/php/bootstrap.php
@@ -12,6 +12,11 @@ if ( ! file_exists( WP_PLUGIN_DIR ) ) {
 }
 
 /**
+ * Include mock functions before autoloader so they're available when classes are loaded.
+ */
+require_once __DIR__ . '/mock-functions.php';
+
+/**
  * Include the composer autoloader and dependencies.
  */
 require_once __DIR__ . '/../../vendor/autoload.php';

--- a/projects/packages/scheduled-updates/tests/php/mock-functions.php
+++ b/projects/packages/scheduled-updates/tests/php/mock-functions.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Mock functions for testing
+ *
+ * @package automattic/scheduled-updates
+ */
+
+namespace Automattic\Jetpack;
+
+/**
+ * Mock realpath in the current namespace
+ *
+ * If $GLOBALS['mock_realpath'] is set, it will be used as the return value.
+ * Otherwise, it falls back to the native realpath function.
+ *
+ * @param string $path The path to resolve.
+ * @return string|false The resolved path or false on failure.
+ */
+function realpath( $path ) {
+	if ( isset( $GLOBALS['mock_realpath'][ $path ] ) ) {
+		return $GLOBALS['mock_realpath'][ $path ];
+	}
+	return \realpath( $path );
+}

--- a/projects/packages/scheduled-updates/tests/php/mock-functions.php
+++ b/projects/packages/scheduled-updates/tests/php/mock-functions.php
@@ -10,7 +10,7 @@ namespace Automattic\Jetpack;
 /**
  * Mock realpath in the current namespace
  *
- * If $GLOBALS['mock_realpath'] is set, it will be used as the return value.
+ * If $GLOBALS['mock_realpath'][ $path ] is set, it will be used as the return value.
  * Otherwise, it falls back to the native realpath function.
  *
  * @param string $path The path to resolve.

--- a/projects/plugins/mu-wpcom-plugin/changelog/fix-php8.5-package_tests
+++ b/projects/plugins/mu-wpcom-plugin/changelog/fix-php8.5-package_tests
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update package dependencies.

--- a/projects/plugins/mu-wpcom-plugin/composer.lock
+++ b/projects/plugins/mu-wpcom-plugin/composer.lock
@@ -1757,7 +1757,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/scheduled-updates",
-                "reference": "23e79cec756fee0825405c764a6fa7415f1360a3"
+                "reference": "3f52602bf5f9547ed9d5081beac4660a8887dcfb"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1771,7 +1771,6 @@
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "php-mock/php-mock-phpunit": "^2.10",
                 "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {

--- a/projects/plugins/wpcomsh/changelog/fix-php8.5-package_tests
+++ b/projects/plugins/wpcomsh/changelog/fix-php8.5-package_tests
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update package dependencies.

--- a/projects/plugins/wpcomsh/composer.lock
+++ b/projects/plugins/wpcomsh/composer.lock
@@ -2032,7 +2032,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/scheduled-updates",
-                "reference": "23e79cec756fee0825405c764a6fa7415f1360a3"
+                "reference": "3f52602bf5f9547ed9d5081beac4660a8887dcfb"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -2046,7 +2046,6 @@
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "php-mock/php-mock-phpunit": "^2.10",
                 "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR fixes package tests that broke on PHP 8.5:

* `packages/connection`: ensure option value is an array before using it
* `packages/codesniffer`: use empty string array offset instead of `null`
* `packages/assets` and `packages/changelogger`: suppress deprecations as we await a [`wikimedia/testing-access-wrapper`](https://phabricator.wikimedia.org/T406744) release
* `packages/autoloader`: use newer `composer` version for tests
* `packages/scheduled-updates`: replace external mock dependency with a simple local mock

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Is CI happy?