### PR TITLE
Forms: fix integrations modal flash

### DIFF
--- a/projects/packages/forms/changelog/fix-integrations-modal-flash
+++ b/projects/packages/forms/changelog/fix-integrations-modal-flash
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: fix integrations modal flash.

--- a/projects/packages/forms/src/dashboard/integrations/index.tsx
+++ b/projects/packages/forms/src/dashboard/integrations/index.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { useSelect, useDispatch } from '@wordpress/data';
-import { useCallback } from '@wordpress/element';
+import { useCallback, useEffect, useState } from '@wordpress/element';
 import { useNavigate } from 'react-router';
 /**
  * Internal dependencies
@@ -19,6 +19,7 @@ const EMPTY_ARRAY: Integration[] = [];
 
 const Integrations = () => {
 	const navigate = useNavigate();
+	const [ isOpen, setIsOpen ] = useState( false );
 	const { integrations } = useSelect( ( select: SelectIntegrations ) => {
 		const store = select( INTEGRATIONS_STORE );
 		return {
@@ -27,13 +28,18 @@ const Integrations = () => {
 	}, [] ) as { integrations: Integration[] };
 	const { refreshIntegrations } = useDispatch( INTEGRATIONS_STORE ) as IntegrationsDispatch;
 
+	useEffect( () => {
+		setIsOpen( true );
+	}, [] );
+
 	const handleClose = useCallback( () => {
+		setIsOpen( false );
 		navigate( '/responses' );
 	}, [ navigate ] );
 
 	return (
 		<IntegrationsModal
-			isOpen={ true }
+			isOpen={ isOpen }
 			onClose={ handleClose }
 			attributes={ undefined }
 			setAttributes={ undefined }

--- a/projects/plugins/jetpack/changelog/fix-integrations-modal-flash
+++ b/projects/plugins/jetpack/changelog/fix-integrations-modal-flash
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Forms: fix integrations modal flash. 


### PR DESCRIPTION
## Proposed changes:

On the forms dashboard, we recently removed the Integration tab and added an [Integrations button](https://github.com/Automattic/jetpack/pull/45662) that opens a modal. I noticed there's a flash when closing the modal. See video below. I think this is related to making the modal dependent on react routing. This PR fixes it by making the modal open/close state dependent on component state, while also keeping the /integration route so we can link to the modal. 

**The flash:**
https://github.com/user-attachments/assets/59a2943f-eb6b-4636-8d00-f25dca3cb780


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None. 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Go to Jetpack > Forms. Click the integrations button in the header to open the modal. Then close the modal and confirm it is smooth with no secondary flash. Try it a few times to confirm, as the original flash often varied in severity. 

