### PR TITLE
Gdoc blocks: Fix slides and spreadsheet embeds

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-google-docs-block-embeds
+++ b/projects/plugins/jetpack/changelog/fix-google-docs-block-embeds
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+GDoc embeds: ensure that slides/sheets render on the front-end

--- a/projects/plugins/jetpack/extensions/blocks/google-docs-embed/google-docs-embed.php
+++ b/projects/plugins/jetpack/extensions/blocks/google-docs-embed/google-docs-embed.php
@@ -39,7 +39,6 @@ add_action( 'init', __NAMESPACE__ . '\register_blocks' );
  * @return string
  */
 function render_callback( $attributes ) {
-
 	Jetpack_Gutenberg::load_assets_as_required( __DIR__ );
 	wp_localize_script(
 		'jetpack-block-' . sanitize_title_with_dashes( Blocks::get_block_feature( __DIR__ ) ),
@@ -52,7 +51,7 @@ function render_callback( $attributes ) {
 	$url          = empty( $attributes['url'] ) ? '' : map_gsuite_url( $attributes['url'] );
 	$aspect_ratio = empty( $attributes['aspectRatio'] ) ? '' : $attributes['aspectRatio'];
 
-	switch ( $attributes['variation'] ?? 'google-docs' ) {
+	switch ( str_replace( 'jetpack/', '', $attributes['variation'] ?? 'google-docs' ) ) {
 		case 'google-docs':
 		default:
 			$pattern = '/^http[s]?:\/\/((?:www\.)?docs\.google\.com(?:.*)?(?:document)\/[a-z0-9\/\?=_\-\.\,&%$#\@\!\+]*)\/preview/i';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes EDI-19

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

The embeds for slides and spreadsheets didn't show anything on the front-end. This happens because the [PHP render code](https://github.com/Automattic/jetpack/blob/920bbbd772c047f3ba8ac4169ea231f33f5072fe/projects/plugins/jetpack/extensions/blocks/google-docs-embed/google-docs-embed.php#L55) is looking for a variation attribute with a value of  google-slides or google-sheets to validate the given URL. The [JS code](https://github.com/Automattic/jetpack/blob/920bbbd772c047f3ba8ac4169ea231f33f5072fe/projects/plugins/jetpack/extensions/blocks/google-docs-embed/variations.js#L22) supplies a variation attribute with a value of jetpack/google-slides or jetpack/google-sheets but also has some [fallback code](https://github.com/Automattic/jetpack/blob/920bbbd772c047f3ba8ac4169ea231f33f5072fe/projects/plugins/jetpack/extensions/blocks/google-docs-embed/edit.js#L82) that sets the value without the jetpack/ prefix.


In my testing I always get the prefixed version, however assuming this used to work, then customers might have prefixed or unprefixed attribute names saved. This change fixes the problem by being more flexible over variation naming - accepting prefixed and unprefixed variation names when selecting a validation regex.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Create a new post / page
2. Add a google slides block to it
3. Paste in the share URL of a google slides doc
4. Save the post / page
5. View the front-end, the doc should render.

Repeat with a google spreadsheet and a google docs doc for good measure.

If you're testing this on a self-hosted jetpack / jurassic ninja site, then you'll need to enable Jetpack blocks in the Jetpack → Settings menu, then add this snippet to make the blocks available `add_filter( 'jetpack_blocks_variation', function () { return 'beta'; } );`



