### PR TITLE
Forms: disable export button if no form entries

### DIFF
--- a/projects/packages/forms/changelog/update-forms-disable-export-button
+++ b/projects/packages/forms/changelog/update-forms-disable-export-button
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Forms: disable export button if no form entries.

--- a/projects/packages/forms/src/dashboard/components/actions-dropdown-menu/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/actions-dropdown-menu/index.tsx
@@ -12,6 +12,7 @@ import { useNavigate } from 'react-router';
  */
 import useCreateForm from '../../hooks/use-create-form';
 import useExportResponses from '../../hooks/use-export-responses';
+import useInboxData from '../../hooks/use-inbox-data';
 import ExportResponsesModal from '../export-responses-modal';
 
 type ActionsDropdownMenuProps = {
@@ -23,6 +24,8 @@ const ActionsDropdownMenu = ( { exportData }: ActionsDropdownMenuProps ) => {
 	const { showExportModal, openModal, closeModal, onExport, autoConnectGdrive, exportLabel } =
 		useExportResponses();
 	const navigate = useNavigate();
+	const { totalItems, isLoadingData } = useInboxData();
+	const hasItems = ! isLoadingData && totalItems > 0;
 
 	const analyticsEvent = useCallback( () => {
 		jetpackAnalytics.tracks.recordEvent( 'jetpack_wpa_forms_landing_page_cta_click', {
@@ -45,11 +48,16 @@ const ActionsDropdownMenu = ( { exportData }: ActionsDropdownMenuProps ) => {
 
 	const controls = [
 		{
+			icon: plus,
+			onClick: onCreateFormClick,
+			title: __( 'Create form', 'jetpack-forms' ),
+		},
+		{
 			icon: plugins,
 			onClick: onIntegrationsClick,
 			title: __( 'Integrations', 'jetpack-forms' ),
 		},
-		...( exportData.show
+		...( exportData.show && hasItems
 			? [
 					{
 						icon: download,
@@ -58,11 +66,6 @@ const ActionsDropdownMenu = ( { exportData }: ActionsDropdownMenuProps ) => {
 					},
 			  ]
 			: [] ),
-		{
-			icon: plus,
-			onClick: onCreateFormClick,
-			title: __( 'Create form', 'jetpack-forms' ),
-		},
 	];
 
 	return (

--- a/projects/packages/forms/src/dashboard/inbox/export-responses/index.tsx
+++ b/projects/packages/forms/src/dashboard/inbox/export-responses/index.tsx
@@ -32,7 +32,7 @@ const ExportResponsesButton = () => {
 
 	return (
 		<>
-			<Button 
+			<Button
 				size="compact"
 				variant="primary"
 				icon={ download }

--- a/projects/packages/forms/src/dashboard/inbox/export-responses/index.tsx
+++ b/projects/packages/forms/src/dashboard/inbox/export-responses/index.tsx
@@ -2,12 +2,14 @@
  * External dependencies
  */
 import { Button } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
 import { download } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
 import ExportResponsesModal from '../../components/export-responses-modal';
 import useExportResponses from '../../hooks/use-export-responses';
+import useInboxData from '../../hooks/use-inbox-data';
 
 import './style.scss';
 
@@ -21,6 +23,8 @@ const ExportResponsesButton = () => {
 		autoConnectGdrive,
 		exportLabel,
 	} = useExportResponses();
+	const { totalItems, isLoadingData } = useInboxData();
+	const isEmpty = isLoadingData || totalItems === 0;
 
 	if ( ! userCanExport ) {
 		return null;
@@ -28,7 +32,16 @@ const ExportResponsesButton = () => {
 
 	return (
 		<>
-			<Button size="compact" variant="primary" icon={ download } onClick={ openModal }>
+			<Button 
+				size="compact"
+				variant="primary"
+				icon={ download }
+				onClick={ openModal }
+				accessibleWhenDisabled
+				disabled={ isEmpty }
+				label={ isEmpty ? __( 'Nothing to export.', 'jetpack-forms' ) : '' }
+				showTooltip={ isEmpty }
+			>
 				{ exportLabel }
 			</Button>
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes [FORMS-386](https://linear.app/a8c/issue/FORMS-346/forms-disable-export-when-theres-nothing-to-export)

## Proposed changes:

Disables the Export button on the form dashboard if the current screen (inbox/spam/trash) has no form entries (nothing to export). 

**Example**
<img width="1361" height="497" alt="disable-export" src="https://github.com/user-attachments/assets/5ecdfb46-612f-4b08-862c-0347673bd26a" />

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
See linear issue. 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to Jetpack > Forms
* With Spam or Trash or Inbox empty, go to that screen and confirm button is disabled
* Confirm button is still enabled and works like normal if there are form entries on the current screen