### PR TITLE
Forms: Fix mobile response view modal spacing

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-response-modal-header
+++ b/projects/packages/forms/changelog/fix-forms-response-modal-header
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: Fix mobile response view modal spacing

--- a/projects/packages/forms/src/dashboard/inbox/style.scss
+++ b/projects/packages/forms/src/dashboard/inbox/style.scss
@@ -466,6 +466,10 @@
 		font-size: 1.2rem;
 		font-weight: 600;
 	}
+
+	.jp-forms__inbox__response-mobile__header-actions {
+		width: auto;
+	}
 }
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Follow-up to #45748

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Fixes a UX issue with the response modal header on mobile, recently introduced. See screenshots

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* On mobile viewport, go to the Forms dashboard
* View one response
* Check that the modal header title does not overlap with the icon

| Before | After |
| - | - |
| <img width="425" height="236" alt="2025-11-05_17-55" src="https://github.com/user-attachments/assets/73cc77a3-e434-45d1-b59e-ce50ffcf98ee" /> | <img width="469" height="367" alt="2025-11-05_17-54" src="https://github.com/user-attachments/assets/878b6d9b-3804-42da-90bf-5e23a42b5597" /> |


