### PR TITLE
ci: Retry WP.org downloads in test-plugin-update

### DIFF
--- a/.github/files/test-plugin-update/prepare-zips.sh
+++ b/.github/files/test-plugin-update/prepare-zips.sh
@@ -52,13 +52,13 @@ fi
 echo "::endgroup::"
 
 echo "::group::Fetching $PLUGIN_SLUG-stable.zip..."
-JSON="$(curl "https://api.wordpress.org/plugins/info/1.0/$PLUGIN_SLUG.json")"
+JSON="$(curl -L --fail --retry 2 --retry-delay $(( 30 + RANDOM % 8 )) "https://api.wordpress.org/plugins/info/1.0/$PLUGIN_SLUG.json")"
 if jq -e --arg slug "$PLUGIN_SLUG" '.slug == $slug' <<<"$JSON" &>/dev/null; then
 	URL="$(jq -r '.download_link // ""' <<<"$JSON")"
 	if [[ -z "$URL" ]]; then
 		echo "Plugin has no stable release."
 	else
-		curl -L --fail --url "$URL" --output "zips/$PLUGIN_SLUG-stable.zip" 2>&1
+		curl -L --fail --retry 2 --retry-delay $(( 30 + RANDOM % 8 )) --url "$URL" --output "zips/$PLUGIN_SLUG-stable.zip" 2>&1
 	fi
 elif jq -e '.error == "Plugin not found."' <<<"$JSON" &>/dev/null; then
 	echo "Plugin is not published."


### PR DESCRIPTION
Closes MONOREP-184

 <!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
WordPress.org's plugin downloader seems to occasionally not respond to connections, whether as a form of rate limiting or something else I don't know.

Anyway, before failing the CI run, let's retry on transient-seeming failures. The setting is to retry twice, with a delay of 30–37 seconds between each try, to allow the network to calm or the rate limiting to cool off.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1762375950250449/1762375886.463929-slack-C034JEXD1RD

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* 🤷