### PR TITLE
ci: Fix test-plugin-update wporg API call

### DIFF
--- a/.github/files/test-plugin-update/prepare-zips.sh
+++ b/.github/files/test-plugin-update/prepare-zips.sh
@@ -52,7 +52,8 @@ fi
 echo "::endgroup::"
 
 echo "::group::Fetching $PLUGIN_SLUG-stable.zip..."
-JSON="$(curl -L --fail --retry 2 --retry-delay $(( 30 + RANDOM % 8 )) "https://api.wordpress.org/plugins/info/1.0/$PLUGIN_SLUG.json")"
+# Note: Don't use --fail here, the API returns a 404 with a valid resonse if the plugin doesn't exist. Sigh.
+JSON="$(curl -L --retry 2 --retry-delay $(( 30 + RANDOM % 8 )) "https://api.wordpress.org/plugins/info/1.0/$PLUGIN_SLUG.json")"
 if jq -e --arg slug "$PLUGIN_SLUG" '.slug == $slug' <<<"$JSON" &>/dev/null; then
 	URL="$(jq -r '.download_link // ""' <<<"$JSON")"
 	if [[ -z "$URL" ]]; then


### PR DESCRIPTION
Closes MONOREP-185

 <!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
The API returns a valid response with a 404 status when the plugin doesn't exist. `--fail` makes curl fail that, which we don't want.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1762378689917389-slack-C034JEXD1RD

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Merge and see if it works