### PR TITLE
Forms: Update error message for jwt_invalid token errors

### DIFF
--- a/projects/packages/forms/changelog/update-forms-error-message
+++ b/projects/packages/forms/changelog/update-forms-error-message
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Forms: Improve the jwt_invalid error message that we show to the user. 
+Forms: Improve the invalid_jwt error message that we show to the user. 

--- a/projects/packages/forms/changelog/update-forms-error-message
+++ b/projects/packages/forms/changelog/update-forms-error-message
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: Improve the jwt_invalid error message that we show to the user. 

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -1754,9 +1754,14 @@ class Contact_Form_Plugin {
 			 */
 			do_action( 'jetpack_forms_log', 'submission_failed', $error_code, $error_details );
 
+			// Use a specific error message for invalid JWT tokens
+			$error_message = ( 'invalid_jwt' === $error_code )
+				? __( 'Oh no, this form is no longer valid. Reload the page and try again — data entered may be lost.', 'jetpack-forms' )
+				: __( 'An error occurred. Please try again later.', 'jetpack-forms' );
+
 			$accepts_json && wp_send_json_error(
 				array(
-					'error' => __( 'An error occurred. Please try again later.', 'jetpack-forms' ),
+					'error' => $error_message,
 					'code'  => $error_code,
 				),
 				500
@@ -1765,7 +1770,7 @@ class Contact_Form_Plugin {
 			// Non-JSON request, output the error message directly.
 			header( 'HTTP/1.1 500 Server Error', true, 500 );
 			echo '<div class="form-error"><ul class="form-errors"><li class="form-error-message">';
-			esc_html_e( 'An error occurred. Please try again later.', 'jetpack-forms' );
+			echo esc_html( $error_message );
 			echo '</li></ul></div>';
 
 			die();

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -1756,7 +1756,7 @@ class Contact_Form_Plugin {
 
 			// Use a specific error message for invalid JWT tokens
 			$error_message = ( 'invalid_jwt' === $error_code )
-				? __( 'Oh no, this form is no longer valid. Reload the page and try again — data entered may be lost.', 'jetpack-forms' )
+				? __( 'An error occurred. Reload the page and try again — data entered may be lost.', 'jetpack-forms' )
 				: __( 'An error occurred. Please try again later.', 'jetpack-forms' );
 
 			$accepts_json && wp_send_json_error(

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -1756,7 +1756,7 @@ class Contact_Form_Plugin {
 
 			// Use a specific error message for invalid JWT tokens
 			$error_message = ( 'invalid_jwt' === $error_code )
-				? __( 'An error occurred. Reload the page and try again — data entered may be lost.', 'jetpack-forms' )
+				? __( 'An error occurred. Please reload the page and try again — data entered may be lost.', 'jetpack-forms' )
 				: __( 'An error occurred. Please try again later.', 'jetpack-forms' );
 
 			$accepts_json && wp_send_json_error(

--- a/projects/packages/forms/src/contact-form/css/grunion.scss
+++ b/projects/packages/forms/src/contact-form/css/grunion.scss
@@ -1198,6 +1198,7 @@ on production builds, the attributes are being reordered, causing side-effects
 	min-width: 100%;
 	box-sizing: inherit;
 	margin-block-end: 0.5em;
+	text-wrap: pretty;
 }
 
 .contact-form__error ul {


### PR DESCRIPTION
This Pr improved the error message that we show to users when they encounter the 'jwt_invalid' error. 

Before:
<img width="801" height="306" alt="Screenshot 2025-11-05 at 3 32 28 PM" src="https://github.com/user-attachments/assets/09d25012-f188-4cd4-8cd3-7673c44b3df5" />


After:

<img width="854" height="359" alt="Screenshot 2025-11-05 at 4 04 44 PM" src="https://github.com/user-attachments/assets/8c2f8961-4e93-4508-8e53-c42f4ffd291a" />


## Proposed changes:
* Update the copy of the jwt_invalid token error. 

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:
Load this PR. 

On a form edit the JWT token so that it is invalid. 
Submit the form. 

Notice the new copy of the error message. 
