### PR TITLE
Forms: Update dashboard styling for consistency

### DIFF
--- a/projects/packages/forms/changelog/update-forms-styling-consistency
+++ b/projects/packages/forms/changelog/update-forms-styling-consistency
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated dashboard styling for visual consistency - improved header, buttons, tabs, and color variables

--- a/projects/packages/forms/src/dashboard/components/create-form-button/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/create-form-button/index.tsx
@@ -48,7 +48,7 @@ export default function CreateFormButton( {
 
 	return (
 		<Button
-			__next40pxDefaultSize
+			size="compact"
 			variant={ variant }
 			onClick={ onButtonClickHandler }
 			icon={ plus }

--- a/projects/packages/forms/src/dashboard/components/empty-spam-button/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/empty-spam-button/index.tsx
@@ -122,7 +122,7 @@ const EmptySpamButton = ( {
 	return (
 		<>
 			<Button
-				__next40pxDefaultSize
+				size="compact"
 				accessibleWhenDisabled
 				disabled={ isEmpty || isEmptying }
 				icon={ trash }

--- a/projects/packages/forms/src/dashboard/components/empty-trash-button/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/empty-trash-button/index.tsx
@@ -122,7 +122,7 @@ const EmptyTrashButton = ( {
 	return (
 		<>
 			<Button
-				__next40pxDefaultSize
+				size="compact"
 				accessibleWhenDisabled
 				disabled={ isEmpty || isEmptying }
 				icon={ trash }

--- a/projects/packages/forms/src/dashboard/components/inbox-status-toggle/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/inbox-status-toggle/index.tsx
@@ -4,6 +4,7 @@
 import jetpackAnalytics from '@automattic/jetpack-analytics';
 import { useBreakpointMatch } from '@automattic/jetpack-components';
 import { formatNumberCompact } from '@automattic/number-formatters';
+import { Badge } from '@automattic/ui';
 import { __, _x } from '@wordpress/i18n';
 import { useCallback } from 'react';
 import { useSearchParams } from 'react-router';
@@ -22,10 +23,10 @@ import * as Tabs from '../tabs';
  */
 function getTabLabel( label: string, count: number ): JSX.Element {
 	return (
-		<>
+		<span style={ { display: 'flex', gap: '4px', alignItems: 'center' } }>
 			{ label }
-			<span className="jp-forms__inbox-status-count">{ formatNumberCompact( count || 0 ) }</span>
-		</>
+			<Badge variant="muted">{ formatNumberCompact( count || 0 ) }</Badge>
+		</span>
 	);
 }
 

--- a/projects/packages/forms/src/dashboard/components/integrations-button/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/integrations-button/index.tsx
@@ -23,7 +23,7 @@ export default function IntegrationsButton(): JSX.Element {
 	}, [ navigate ] );
 
 	return (
-		<Button __next40pxDefaultSize variant="secondary" onClick={ onButtonClickHandler }>
+		<Button size="compact" variant="secondary" onClick={ onButtonClickHandler }>
 			{ __( 'Integrations', 'jetpack-forms' ) }
 		</Button>
 	);

--- a/projects/packages/forms/src/dashboard/components/layout/header.tsx
+++ b/projects/packages/forms/src/dashboard/components/layout/header.tsx
@@ -1,0 +1,50 @@
+/**
+ * WordPress dependencies
+ */
+
+import {
+	__experimentalHeading as Heading, // eslint-disable-line @wordpress/no-unsafe-wp-apis
+	__experimentalHStack as HStack, // eslint-disable-line @wordpress/no-unsafe-wp-apis
+	__experimentalVStack as VStack, // eslint-disable-line @wordpress/no-unsafe-wp-apis
+} from '@wordpress/components';
+
+/**
+ * Custom header component for Forms dashboard with consistent styling.
+ *
+ * @param {object}          props          - Component props.
+ * @param {React.ReactNode} props.title    - The header title content.
+ * @param {React.ReactNode} props.subTitle - The header subtitle/description.
+ * @param {React.ReactNode} props.actions  - Action buttons to display in the header.
+ * @return {JSX.Element} The header component.
+ */
+export default function Header( {
+	title,
+	subTitle,
+	actions,
+}: {
+	title?: React.ReactNode;
+	subTitle: React.ReactNode;
+	actions?: React.ReactNode;
+} ) {
+	return (
+		<VStack className="admin-ui-page__header" as="header" spacing={ 0 }>
+			<HStack className="admin-ui-page__header-title" justify="space-between" spacing={ 2 }>
+				<HStack spacing={ 2 }>
+					{ title && (
+						<Heading level={ 1 } size="15px" lineHeight="32px" truncate>
+							{ title }
+						</Heading>
+					) }
+				</HStack>
+				<HStack
+					style={ { width: 'auto', flexShrink: 0 } }
+					spacing={ 2 }
+					className="admin-ui-page__header-actions"
+				>
+					{ actions }
+				</HStack>
+			</HStack>
+			{ subTitle && <p className="admin-ui-page__header-subtitle">{ subTitle }</p> }
+		</VStack>
+	);
+}

--- a/projects/packages/forms/src/dashboard/components/layout/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/layout/index.tsx
@@ -20,6 +20,7 @@ import { store as dashboardStore } from '../../store';
 import ActionsDropdownMenu from '../actions-dropdown-menu';
 import CreateFormButton from '../create-form-button';
 import IntegrationsButton from '../integrations-button';
+import Header from './header';
 
 import './style.scss';
 // eslint-disable-next-line import/no-unresolved -- aliased to the package's built asset in webpack config.
@@ -69,16 +70,19 @@ const Layout = () => {
 	);
 
 	return (
-		<Page
-			className="jp-forms__layout"
-			title={
-				<div className="jp-forms__layout-header-title">
-					<JetpackLogo showText={ false } width={ 24 } /> Forms
-				</div>
-			}
-			subTitle={ __( 'View and manage all your form submissions in one place.', 'jetpack-forms' ) }
-			actions={ headerActions }
-		>
+		<Page className="jp-forms__layout">
+			<Header
+				title={
+					<div className="jp-forms__layout-header-title">
+						<JetpackLogo showText={ false } width={ 24 } /> Forms
+					</div>
+				}
+				subTitle={ __(
+					'View and manage all your form submissions in one place.',
+					'jetpack-forms'
+				) }
+				actions={ headerActions }
+			/>
 			<NavigableRegion
 				className="admin-ui-page__content"
 				ariaLabel={ __( 'Forms dashboard content', 'jetpack-forms' ) }

--- a/projects/packages/forms/src/dashboard/components/layout/style.scss
+++ b/projects/packages/forms/src/dashboard/components/layout/style.scss
@@ -23,6 +23,8 @@ body.jetpack_page_jetpack-forms-admin {
 	padding: 0;
 	width: 100%;
 	min-height: calc(100vh - var(--wp-admin--admin-bar--height, 0px));
+	background: var(--wpds-color-bg-surface-neutral-strong, #fff);
+	color: var(--wpds-color-fg-content-neutral, #1e1e1e);
 
 	.jp-forms__layout-header-title {
 		display: flex;
@@ -42,14 +44,13 @@ body.jetpack_page_jetpack-forms-admin {
 }
 
 #jp-forms-dashboard .jp-forms__layout {
-	background: #fff;
 
 	.admin-ui-page__content {
 		display: flex;
 		flex: 1 1 auto;
 		flex-direction: column;
 		min-height: 0;
-		background: var(--jp-white);
+		background: var(--wpds-color-bg-surface-neutral-strong, #fff);
 
 		// Ensure Outlet renders as flex child that expands
 		> * {
@@ -68,13 +69,20 @@ body.jetpack_page_jetpack-forms-admin {
 	.admin-ui-page__header {
 		box-sizing: border-box;
 		margin: 0;
-		padding: 16px 48px 4px;
+		padding: 8px 20px;
 		width: 100%;
-		background: transparent;
+		background: var(--wpds-color-bg-surface-neutral-strong, #fff);
+		border-bottom: none;
 
 		@media (max-width: 782px) {
-			padding: 8px 24px 0;
+			padding: 12px 24px;
 		}
+	}
+
+	.admin-ui-page__header-subtitle {
+		color: var(--wpds-color-fg-content-neutral-weak, #757575);
+		margin: 0;
+		padding-block-end: 8px;
 	}
 
 

--- a/projects/packages/forms/src/dashboard/inbox/export-responses/index.tsx
+++ b/projects/packages/forms/src/dashboard/inbox/export-responses/index.tsx
@@ -28,7 +28,7 @@ const ExportResponsesButton = () => {
 
 	return (
 		<>
-			<Button __next40pxDefaultSize variant="primary" icon={ download } onClick={ openModal }>
+			<Button size="compact" variant="primary" icon={ download } onClick={ openModal }>
 				{ exportLabel }
 			</Button>
 

--- a/projects/packages/forms/src/dashboard/inbox/style.scss
+++ b/projects/packages/forms/src/dashboard/inbox/style.scss
@@ -97,17 +97,18 @@
 }
 
 .jp-forms__inbox__view-actions {
-	border-bottom: 1px solid var(--jp-forms-border-color);
-	padding-inline: 48px; // Match .admin-ui-page__header padding
+	border-bottom: 1px solid var(--wpds-color-stroke-surface-neutral-weak, #dcdcde);
+	padding: 0 20px; // Match .admin-ui-page__header padding
 	overflow-x: auto;
 	width: 100%;
 	box-sizing: border-box;
 	display: flex;
 	container-type: inline-size;
 	flex-shrink: 0;
+	background: var(--wpds-color-bg-surface-neutral-strong, #fff);
 
 	@media (max-width: 782px) {
-		padding-inline: 24px; // Match mobile padding
+		padding: 0 24px; // Match mobile padding
 	}
 
 	// On small stacks, switch to column stacking
@@ -141,13 +142,6 @@
 
 		&:hover:not([data-active="true"]) {
 			color: var(--wpds-color-fg-interactive-neutral-active);
-		}
-
-		.jp-forms__inbox-status-count {
-			padding: 2px 6px;
-			margin-left: 4px;
-			background-color: var(--jp-gray-5);
-			border-radius: 2px;
 		}
 	}
 }


### PR DESCRIPTION
This PR updates the Jetpack Forms dashboard styling to improve visual consistency across the interface.

#### Before

<img width="1352" height="825" alt="Screenshot 2025-11-05 at 11 43 56 PM" src="https://github.com/user-attachments/assets/25f69fa7-e4c0-4895-b387-710d5206765d" />

#### After

<img width="1352" height="826" alt="Screenshot 2025-11-05 at 11 42 47 PM" src="https://github.com/user-attachments/assets/24c83113-b93b-4be1-8861-6cc7114466ab" />


  **Header & Typography:**
  - Created custom Header component with standardized title sizing (15px)
  - Reduced header padding from 16px to 8px vertical
  - Added proper subtitle spacing (8px bottom padding, removed margin)
  - Fixed vertical gaps by setting VStack spacing to 0

  **Buttons:**
  - Changed all CTA buttons from `__next40pxDefaultSize` to `size="compact"` for consistency
  - Updated: CreateFormButton, IntegrationsButton, ExportResponsesButton, EmptyTrashButton, EmptySpamButton

  **Tabs:**
  - Adjusted tabs padding to match header (20px horizontal)
  - Replaced custom count span with Badge component from `@automattic/ui`
  - Added flex layout with 4px gap for proper label-badge spacing

  **Colors:**
  - Applied variables consistently throughout

  ### Other information:

  - [x] Have you written new tests for your changes, if applicable?
  - [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
  - [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

  ## Jetpack product discussion

  N/A - This is a styling-only change that improves visual consistency without functional changes.

  ## Does this pull request change what data or activity we track or use?

  No.

  ## Testing instructions:

  * Go to Jetpack Forms dashboard in wp-admin
  * Verify the header has more compact padding (should feel less spacious)
  * Check that all action buttons (Create form, Integrations, Export, Empty trash/spam) have consistent compact sizing
  * Navigate between Inbox/Spam/Trash tabs and verify the count badges display correctly with proper spacing between label and number
  * Check both desktop and mobile viewports to ensure responsive styling works correctly