### PR TITLE
Forms: Fix mobile dashboard horizontal scroll 

### DIFF
--- a/projects/packages/forms/changelog/fix-mobile-form-dashboard-sticky
+++ b/projects/packages/forms/changelog/fix-mobile-form-dashboard-sticky
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: fix horizontal scroll on mobile

--- a/projects/packages/forms/src/dashboard/inbox/style.scss
+++ b/projects/packages/forms/src/dashboard/inbox/style.scss
@@ -105,6 +105,8 @@
 	display: flex;
 	container-type: inline-size;
 	flex-shrink: 0;
+	position: sticky;
+	left: 0;
 
 	@media (max-width: 782px) {
 		padding-inline: 24px; // Match mobile padding
@@ -361,6 +363,7 @@
 	.dataviews-wrapper {
 		background: var(--jp-white);
 		flex-grow: 1;
+		overscroll-behavior: none;
 
 		@media (min-width: 782px) {
 			border-right: 1px solid var(--jp-gray-5);


### PR DESCRIPTION
Before:
<img width="411" height="809" alt="Screenshot 2025-11-05 at 10 22 45 PM" src="https://github.com/user-attachments/assets/d7897fb7-1038-4e53-90e9-a188d91e2136" />

After: 
<img width="466" height="825" alt="Screenshot 2025-11-05 at 10 22 26 PM" src="https://github.com/user-attachments/assets/3ea76da4-cfb5-438a-9a4a-44d578b08bfe" />

Notice on mobile how the seach bar and the tabs scroll with the table content. 

Fixes [FORMS-378](https://linear.app/a8c/issue/FORMS-378/mobile-dashboard-tabs-and-search-bar-scroll-with-table-content)

This PR fixes this. 

## Proposed changes:
* Make the tabs stick as well as the other table contols. 

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
Non
## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
On mobile notice how on the dashboard the tabs and the filter don't scroll any more. when you scroll in the responses table. 

