### PR TITLE
Stats: Display post views after quick edit

### DIFF
--- a/projects/packages/stats-admin/changelog/edi-65-star-column-incorrectly-shows-last-modified-date-after-quick
+++ b/projects/packages/stats-admin/changelog/edi-65-star-column-incorrectly-shows-last-modified-date-after-quick
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Stats: Display post views after quick edit

--- a/projects/packages/stats-admin/src/class-admin-post-list-column.php
+++ b/projects/packages/stats-admin/src/class-admin-post-list-column.php
@@ -221,11 +221,13 @@ class Admin_Post_List_Column {
 	public function get_post_page_views_for_current_list(): array {
 		global $wp_query;
 
-		if ( ! $wp_query->posts ) {
+		if ( $wp_query->posts ) {
+			$post_ids = wp_list_pluck( $wp_query->posts, 'ID' );
+		} elseif ( wp_doing_ajax() && ! empty( $_POST['action'] ) && 'inline-save' === $_POST['action'] && ! empty( $_POST['post_ID'] ) && check_ajax_referer( 'inlineeditnonce', '_inline_edit' ) ) {
+			$post_ids = array( sanitize_text_field( wp_unslash( $_POST['post_ID'] ) ) );
+		} else {
 			return array();
 		}
-
-		$post_ids = wp_list_pluck( $wp_query->posts, 'ID' );
 
 		$wpcom_stats = $this->get_stats();
 		$post_views  = $wpcom_stats->get_total_post_views(


### PR DESCRIPTION
Part of EDI-65

## Proposed changes:

Fixes a regression introduced by https://github.com/Automattic/jetpack/pull/42218 which caused the post views to be missing after quick editing a post:

Before | After
--- | ---
<img width="719" height="81" alt="Screenshot 2025-11-06 at 12 37 49" src="https://github.com/user-attachments/assets/fa166104-7310-4dbb-9365-580e27f60580" /> | <img width="728" height="99" alt="Screenshot 2025-11-06 at 12 36 17" src="https://github.com/user-attachments/assets/21d66c9d-8607-49b3-a5b9-2ba7b7d4762c" />


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
N/A

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
- Apply these changes to your site
- If you're testing on a WP.com simple site, also apply 195448-ghe-Automattic/wpcom
- Go to `/wp-admin/edit.php`
- Click Quick Edit under any published post with a views counter
- Make some changes and save them
- Make sure the views counter is still visible