### PR TITLE
My Jetpack: Fix Protect card showing as active when modules are disabled

### DIFF
--- a/projects/packages/my-jetpack/changelog/fix-myjp-273-protect-module-check
+++ b/projects/packages/my-jetpack/changelog/fix-myjp-273-protect-module-check
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix Protect card showing as active when Jetpack modules are disabled.

--- a/projects/packages/my-jetpack/src/products/class-protect.php
+++ b/projects/packages/my-jetpack/src/products/class-protect.php
@@ -39,6 +39,13 @@ class Protect extends Hybrid_Product {
 	public static $slug = 'protect';
 
 	/**
+	 * The Jetpack module name
+	 *
+	 * @var string
+	 */
+	public static $module_name = 'protect';
+
+	/**
 	 * The filename (id) of the plugin associated with this product.
 	 *
 	 * @var string


### PR DESCRIPTION
Fixes MYJP-273

## Proposed changes:

Fixes a bug where the Protect card in My Jetpack would show as active even when all Jetpack modules were disabled, causing customer confusion.

**Root cause:** The `Protect` class was missing the `$module_name` property, which caused the module status check to be skipped. When `is_module_active()` is called without a `$module_name` defined, it returns `true` by default.

**Solution:** Added `public static $module_name = 'protect';` to the Protect class, following the same pattern as other Hybrid products (Search, Social, VideoPress).

### Other information:

- [x] Have you written new tests for your changes, if applicable? (N/A - simple property addition)
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
https://linear.app/a8c/issue/MYJP-273/despite-modules-being-disabled-protect-card-shows-in-my-jetpack

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
1. Install Jetpack on a test site
2. Go to Jetpack > Settings
3. Disable all modules (including Protect)
4. Go to My Jetpack
5. Verify that the Protect card no longer shows as active
6. Re-enable the Protect module
7. Verify that the Protect card now shows as active again

<img width="692" height="592" alt="CleanShot 2025-11-06 at 15 04 05@2x" src="https://github.com/user-attachments/assets/7404ae74-44e9-41e3-b60f-73d318c1d2f6" />
