### PR TITLE
Forms: fix single input general error

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-single-input-general-error
+++ b/projects/packages/forms/changelog/fix-forms-single-input-general-error
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: single input forms don't show general errors, move general form error into field error when necessary

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -806,6 +806,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 			'submissionSuccess'       => $submission_success,
 			'submissionError'         => null,
 			'elementId'               => $element_id,
+			'isSingleInputForm'       => $is_single_input_form,
 		);
 
 		if ( $is_multistep ) {

--- a/projects/packages/forms/src/modules/form/view.js
+++ b/projects/packages/forms/src/modules/form/view.js
@@ -183,6 +183,11 @@ const { state, actions } = store( NAMESPACE, {
 				return false;
 			}
 
+			// For single input forms, show submission errors in the field error div
+			if ( context.isSingleInputForm && context.submissionError ) {
+				return true;
+			}
+
 			return ( context.showErrors || field.showFieldError ) && field.error && field.error !== 'yes';
 		},
 
@@ -232,6 +237,11 @@ const { state, actions } = store( NAMESPACE, {
 			const context = getContext();
 			const fieldId = context.fieldId;
 			const field = context.fields[ fieldId ] || {};
+
+			// For single input forms, show submission errors in the field error div
+			if ( context.isSingleInputForm && context.submissionError ) {
+				return context.submissionError;
+			}
 
 			if ( ! ( context.showErrors || field.showFieldError ) || ! field.error ) {
 				return '';


### PR DESCRIPTION

Fixes [FORMS-380](https://linear.app/a8c/issue/FORMS-380/single-input-forms-do-not-display-general-errors)

## Proposed changes:
This PR addresses an issue where single input forms wouldn't show general form errors

Before:

https://github.com/user-attachments/assets/c2fe423d-4c7c-4526-ba81-c22f1801b93a

After:

https://github.com/user-attachments/assets/c0f3de57-373d-4f28-be2b-79b573af787d



### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
None

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

Test with both a single input form and a regular form.

- field validation errors should have not changed
- use devtools network tab to set as offline (or disconnect from the internet, could be healthy sometimes) and try to submit
  - single input forms should show the error below the field
  - regular forms should have not changed
- browse the markup and change the JWT value, errors should show the same as with disconnection