### PR TITLE
WooCommerce Analytics: Fix proxy speed module installation with proper error/path handling

### DIFF
--- a/projects/packages/woocommerce-analytics/changelog/fix-woocomerce-analytics-proxy-speed-copy
+++ b/projects/packages/woocommerce-analytics/changelog/fix-woocomerce-analytics-proxy-speed-copy
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix proxy speed module installation using WP_Filesystem API with proper error

--- a/projects/packages/woocommerce-analytics/changelog/fix-woocomerce-analytics-proxy-speed-copy
+++ b/projects/packages/woocommerce-analytics/changelog/fix-woocomerce-analytics-proxy-speed-copy
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Fix proxy speed module installation using WP_Filesystem API with proper error
+Fix proxy speed module installation using WP_Filesystem API with proper error handling

--- a/projects/packages/woocommerce-analytics/src/class-woocommerce-analytics.php
+++ b/projects/packages/woocommerce-analytics/src/class-woocommerce-analytics.php
@@ -210,7 +210,7 @@ class Woocommerce_Analytics {
 		$mu_plugin_dest_file = trailingslashit( WPMU_PLUGIN_DIR ) . 'woocommerce-analytics-proxy-speed-module.php';
 
 		// Verify source file exists before attempting to copy.
-		if ( ! $wp_filesystem->exists( $mu_plugin_src_file ) ) {
+		if ( ! file_exists( $mu_plugin_src_file ) ) {
 			if ( function_exists( 'wc_get_logger' ) ) {
 				wc_get_logger()->error( 'WooCommerce Analytics proxy speed module source file not found.', array( 'source' => 'woocommerce-analytics' ) );
 			}

--- a/projects/packages/woocommerce-analytics/src/class-woocommerce-analytics.php
+++ b/projects/packages/woocommerce-analytics/src/class-woocommerce-analytics.php
@@ -221,7 +221,7 @@ class Woocommerce_Analytics {
 
 		if ( ! $results ) {
 			if ( function_exists( 'wc_get_logger' ) ) {
-				wc_get_logger()->error( 'Failed to copy the WooCommerce Analytics proxy speed module files.', array( 'source' => 'woocommerce-analytics' ) );
+				wc_get_logger()->error( 'Failed to copy the WooCommerce Analytics proxy speed module file.', array( 'source' => 'woocommerce-analytics' ) );
 			}
 			return;
 		}

--- a/projects/packages/woocommerce-analytics/src/class-woocommerce-analytics.php
+++ b/projects/packages/woocommerce-analytics/src/class-woocommerce-analytics.php
@@ -181,6 +181,8 @@ class Woocommerce_Analytics {
 		// Initialize the WP filesystem.
 		WP_Filesystem();
 
+		global $wp_filesystem;
+
 		// Create the mu-plugin directory if it doesn't exist.
 		if ( ! is_dir( WPMU_PLUGIN_DIR ) ) {
 			wp_mkdir_p( WPMU_PLUGIN_DIR );
@@ -191,21 +193,40 @@ class Woocommerce_Analytics {
 			return;
 		}
 
+		// Check if the mu-plugin directory is writable.
+		if ( ! $wp_filesystem->is_writable( WPMU_PLUGIN_DIR ) ) {
+			if ( function_exists( 'wc_get_logger' ) ) {
+				wc_get_logger()->debug( 'WooCommerce Analytics proxy speed module not installed: mu-plugins directory is not writable.', array( 'source' => 'woocommerce-analytics' ) );
+			}
+			return;
+		}
+
 		if ( get_option( 'woocommerce_analytics_proxy_speed_module_version' ) === self::PROXY_SPEED_MODULE_VERSION ) {
 			// No need to copy the files again.
 			return;
 		}
 
-		update_option( 'woocommerce_analytics_proxy_speed_module_version', self::PROXY_SPEED_MODULE_VERSION );
 		$mu_plugin_src_file  = __DIR__ . '/mu-plugin/woocommerce-analytics-proxy-speed-module.php';
-		$mu_plugin_dest_file = WPMU_PLUGIN_DIR . '/woocommerce-analytics-proxy-speed-module.php';
-		$results             = copy( $mu_plugin_src_file, $mu_plugin_dest_file );
+		$mu_plugin_dest_file = trailingslashit( WPMU_PLUGIN_DIR ) . 'woocommerce-analytics-proxy-speed-module.php';
+
+		// Verify source file exists before attempting to copy.
+		if ( ! $wp_filesystem->exists( $mu_plugin_src_file ) ) {
+			if ( function_exists( 'wc_get_logger' ) ) {
+				wc_get_logger()->error( 'WooCommerce Analytics proxy speed module source file not found.', array( 'source' => 'woocommerce-analytics' ) );
+			}
+			return;
+		}
+
+		$results = $wp_filesystem->copy( $mu_plugin_src_file, $mu_plugin_dest_file, true );
 
 		if ( ! $results ) {
 			if ( function_exists( 'wc_get_logger' ) ) {
 				wc_get_logger()->error( 'Failed to copy the WooCommerce Analytics proxy speed module files.', array( 'source' => 'woocommerce-analytics' ) );
 			}
+			return;
 		}
+
+		update_option( 'woocommerce_analytics_proxy_speed_module_version', self::PROXY_SPEED_MODULE_VERSION );
 	}
 
 	/**
@@ -215,7 +236,7 @@ class Woocommerce_Analytics {
 		/**
 		 * Clean up MU plugin.
 		 */
-		$file_path = WPMU_PLUGIN_DIR . '/woocommerce-analytics-proxy-speed-module.php';
+		$file_path = trailingslashit( WPMU_PLUGIN_DIR ) . 'woocommerce-analytics-proxy-speed-module.php';
 
 		if ( file_exists( $file_path ) ) {
 			wp_delete_file( $file_path );

--- a/projects/packages/woocommerce-analytics/src/class-woocommerce-analytics.php
+++ b/projects/packages/woocommerce-analytics/src/class-woocommerce-analytics.php
@@ -174,12 +174,9 @@ class Woocommerce_Analytics {
 	 * Maybe add proxy speed module.
 	 */
 	public static function maybe_add_proxy_speed_module() {
-		if ( ! function_exists( 'WP_Filesystem' ) ) {
-			require_once ABSPATH . 'wp-admin/includes/file.php';
+		if ( ! self::init_filesystem() ) {
+			return;
 		}
-
-		// Initialize the WP filesystem.
-		WP_Filesystem();
 
 		global $wp_filesystem;
 
@@ -217,9 +214,15 @@ class Woocommerce_Analytics {
 			return;
 		}
 
-		$results = copy( $mu_plugin_src_file, $mu_plugin_dest_file );
+		$content = $wp_filesystem->get_contents( $mu_plugin_src_file );
+		if ( false === $content ) {
+			if ( function_exists( 'wc_get_logger' ) ) {
+				wc_get_logger()->error( 'Failed to read the WooCommerce Analytics proxy speed module source file.', array( 'source' => 'woocommerce-analytics' ) );
+			}
+			return;
+		}
 
-		if ( ! $results ) {
+		if ( ! $wp_filesystem->put_contents( $mu_plugin_dest_file, $content ) ) {
 			if ( function_exists( 'wc_get_logger' ) ) {
 				wc_get_logger()->error( 'Failed to copy the WooCommerce Analytics proxy speed module file.', array( 'source' => 'woocommerce-analytics' ) );
 			}
@@ -233,15 +236,39 @@ class Woocommerce_Analytics {
 	 * Maybe removes the proxy speed module. This should be invoked when the plugin is deactivated.
 	 */
 	public static function maybe_remove_proxy_speed_module() {
+		if ( ! self::init_filesystem() ) {
+			return;
+		}
+
+		global $wp_filesystem;
+
 		/**
 		 * Clean up MU plugin.
 		 */
 		$file_path = trailingslashit( WPMU_PLUGIN_DIR ) . 'woocommerce-analytics-proxy-speed-module.php';
 
-		if ( file_exists( $file_path ) ) {
-			wp_delete_file( $file_path );
+		if ( $wp_filesystem->exists( $file_path ) && $wp_filesystem->is_writable( $file_path ) ) {
+			$wp_filesystem->delete( $file_path );
 		}
 
 		delete_option( 'woocommerce_analytics_proxy_speed_module_version' );
+	}
+
+	/**
+	 * Initialize the WP filesystem.
+	 *
+	 * @return bool True if filesystem is initialized, false otherwise.
+	 */
+	private static function init_filesystem() {
+		if ( ! function_exists( 'WP_Filesystem' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/file.php';
+		}
+
+		// Initialize the WP filesystem.
+		ob_start();
+		$initialized = WP_Filesystem();
+		ob_end_clean();
+
+		return $initialized;
 	}
 }

--- a/projects/packages/woocommerce-analytics/src/class-woocommerce-analytics.php
+++ b/projects/packages/woocommerce-analytics/src/class-woocommerce-analytics.php
@@ -217,7 +217,7 @@ class Woocommerce_Analytics {
 			return;
 		}
 
-		$results = $wp_filesystem->copy( $mu_plugin_src_file, $mu_plugin_dest_file, true );
+		$results = copy( $mu_plugin_src_file, $mu_plugin_dest_file );
 
 		if ( ! $results ) {
 			if ( function_exists( 'wc_get_logger' ) ) {


### PR DESCRIPTION
Fixes p1762444618534419-slack-CK365S85V

## Proposed changes:

This PR fixes issues with the proxy speed module installation introduced in #45243:

* Add writability checks for the mu-plugins directory before attempting to copy
* Verify source file existence before copying
* Use `trailingslashit()` for proper path handling across different environments
* Only update version option after successful copy

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you will see a generated comment below with a script to run)?

## Jetpack product discussion

n/a

## Does this pull request change what data or activity we track or use?

n/a

## Testing instructions:

Follow the same testing instructions as #45243 (steps 1~6) to verify the proxy speed module is still correctly installed/removed when Jetpack is activated/deactivated.

**Additional edge case testing:**

1. Test with read-only mu-plugins directory:
   - Make the `wp-content/mu-plugins` directory read-only: `chmod 555 wp-content/mu-plugins`
   - Activate Jetpack
   - Verify the proxy speed module is not added to mu-plugins
   - Check the `wp-content/debug.log` and verify no errors are logged related to woocommerce-analytics package
   - Restore permissions: `chmod 755 wp-content/mu-plugins`

2. Verify file operations work correctly on different server configurations with various filesystem permissions