### PR TITLE
Forms: Add email as secondary information on dashboard

### DIFF
--- a/projects/packages/forms/changelog/update-forms-dashboard-display-email
+++ b/projects/packages/forms/changelog/update-forms-dashboard-display-email
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Forms: Add email as secondary information on dashboard

--- a/projects/packages/forms/src/dashboard/inbox/dataviews/index.js
+++ b/projects/packages/forms/src/dashboard/inbox/dataviews/index.js
@@ -254,6 +254,12 @@ export default function InboxView() {
 						item.author_name || item.author_email || item.author_url || item.ip
 					);
 					const defaultImage = item.author_name || item.author_email ? 'initials' : 'mp';
+					const secondaryInfo =
+						authorInfo === decodeEntities( item.author_name ) && item.author_email ? (
+							<span className="jp-forms__inbox__author-field__email">
+								{ decodeEntities( item.author_email ) }
+							</span>
+						) : null;
 
 					const handleClick = isMobileViewport ? () => openResponseModal( item ) : undefined;
 
@@ -286,7 +292,12 @@ export default function InboxView() {
 								size={ 32 }
 								useHovercard={ false }
 							/>
-							{ wrapperUnread( item.is_unread, authorInfo ) }
+							<div className="jp-forms__inbox__author-info-container">
+								<span className="jp-forms__inbox__author-info">
+									{ wrapperUnread( item.is_unread, authorInfo ) }
+								</span>
+								{ secondaryInfo }
+							</div>
 						</div>
 					);
 				},

--- a/projects/packages/forms/src/dashboard/inbox/style.scss
+++ b/projects/packages/forms/src/dashboard/inbox/style.scss
@@ -385,10 +385,28 @@
 		display: flex;
 		align-items: center;
 		gap: 12px;
+		overflow: hidden;
 
 		&--mobile {
 			text-decoration: underline;
 		}
+	}
+
+	.jp-forms__inbox__author-info-container {
+		overflow: hidden;
+		display: flex;
+		flex-direction: column;
+	}
+
+	.jp-forms__inbox__author-info,
+	.jp-forms__inbox__author-field__email {
+		text-overflow: ellipsis;
+		overflow: hidden;
+	}
+
+	.jp-forms__inbox__author-field__email {
+		font-size: 11px;
+		filter: opacity(0.8);
 	}
 
 	.jp-forms__inbox__unread-indicator {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Closes FORMS-364

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* What the title says. See screenshots below.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the Forms dashboard
* Check that entries with name and email now shows the email below the name in the list
* Check that entries without name do not show the email.

| Before | After |
| - | - |
| <img width="1097" height="282" alt="Screenshot from 2025-11-06 18-50-54" src="https://github.com/user-attachments/assets/089b9562-3449-4bf6-b7e0-648ab8736292" /> | <img width="1097" height="282" alt="Screenshot from 2025-11-06 18-50-13" src="https://github.com/user-attachments/assets/0db22c67-fad1-4c3f-b18b-a063716c5136" /> |
| <img width="381" height="349" alt="Screenshot from 2025-11-06 18-51-16" src="https://github.com/user-attachments/assets/ae10f622-19d0-425f-8f5b-183fea09c561" /> | <img width="381" height="300" alt="Screenshot from 2025-11-06 18-49-41" src="https://github.com/user-attachments/assets/1625a93a-ff4b-4afb-adcd-f0f16cb24055" /> |


