### PR TITLE
CI: Update timeouts and comments

### DIFF
--- a/.github/files/generate-ci-matrix.php
+++ b/.github/files/generate-ci-matrix.php
@@ -65,7 +65,7 @@ foreach ( array( '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4' ) as $ph
 		'script'  => 'test-php',
 		'php'     => $php,
 		'wp'      => 'latest',
-		'timeout' => 20, // 2024-11-12: Successful runs seem to take up to ~7 minutes.
+		'timeout' => 20, // 2025-11-06: Successful runs seem to take ~7 minutes.
 	);
 }
 
@@ -76,7 +76,7 @@ foreach ( array( 'previous', 'trunk' ) as $wp ) {
 		'script'  => 'test-php',
 		'php'     => $phpver,
 		'wp'      => $wp,
-		'timeout' => 15, // 2024-11-12: Successful runs seem to take ~7 minutes with PHP 8.2.
+		'timeout' => 15, // 2025-11-06: Successful runs seem to take ~7 minutes.
 	);
 }
 
@@ -86,7 +86,7 @@ $matrix[] = array(
 	'script'              => 'test-php',
 	'php'                 => '8.5',
 	'wp'                  => 'trunk',
-	'timeout'             => 20,
+	'timeout'             => 15, // 2025-11-06: Successful runs seem to take ~8 minutes.
 	'force-package-tests' => true,
 );
 
@@ -96,7 +96,7 @@ $matrix[] = array(
 	'script'           => 'test-php',
 	'php'              => '7.4',
 	'wp'               => 'latest',
-	'timeout'          => 20,
+	'timeout'          => 15, // 2025-11-06: Successful runs seem to take ~3 minutes.
 	'with-woocommerce' => true,
 );
 
@@ -106,7 +106,7 @@ $matrix[] = array(
 	'script'       => 'test-php',
 	'php'          => '8.1',
 	'wp'           => 'latest',
-	'timeout'      => 20,
+	'timeout'      => 15, // 2025-11-06: Successful runs seem to take ~7 minutes.
 	'with-wpcomsh' => true,
 );
 
@@ -114,7 +114,7 @@ $matrix[] = array(
 $matrix[] = array(
 	'name'    => 'JS tests',
 	'script'  => 'test-js',
-	'timeout' => 15, // 2024-11-12: Successful runs seem to take ~5 minutes.
+	'timeout' => 15, // 2025-11-06: Successful runs seem to take ~5 minutes.
 );
 
 // Add Coverage tests.
@@ -122,7 +122,7 @@ $matrix[] = array(
 	'name'    => 'Code coverage',
 	'script'  => 'test-coverage',
 	'wp'      => 'latest',
-	'timeout' => 40, // 2024-11-12: Successful runs seem to take ~14 minutes.
+	'timeout' => 40, // 2025-11-06: Successful runs seem to take ~15 minutes.
 );
 
 // END matrix definitions.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
   build:
     name: Build all projects
     runs-on: ubuntu-latest
-    timeout-minutes: 30  # 2023-05-25: Build times have crept up to ~15–25+ minutes as we've added more projects, bump to 30.
+    timeout-minutes: 30  # 2025-11-06: Build times have crept up to ~15–20 minutes as we've added more projects, bump to 30.
     env:
       # Hard-code a specific directory to avoid paths in vendor/composer/installed.json changing every build.
       BUILD_BASE: /tmp/jetpack-build
@@ -175,7 +175,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     if: needs.build.outputs.any_plugins == 'true'
-    timeout-minutes: 10  # 2021-06-24: Successful runs should take just a few seconds now. But sometimes the upload is slow.
+    timeout-minutes: 10  # 2025-11-06: Successful runs should take about 30 seconds. But sometimes the upload is slow.
     steps:
       - uses: actions/checkout@v5
         with:
@@ -270,16 +270,16 @@ jobs:
       - uses: actions/checkout@v5
         with:
           path: monorepo
-        timeout-minutes: 1  # 2021-01-18: Successful runs seem to take a few seconds
+        timeout-minutes: 1  # 2025-11-06: Successful runs seem to take a few seconds
 
       - name: Download build artifact
         uses: actions/download-artifact@v5
         with:
           name: jetpack-build
-        timeout-minutes: 2  # 2022-03-15: Successful runs normally take a few seconds, but on occasion they've been taking 60+ recently.
+        timeout-minutes: 2  # 2025-11-06: Successful runs normally take a few seconds
       - name: Extract build archive
         run: tar --xz -xvvf build.tar.xz build
-        timeout-minutes: 1  # 2021-01-18: Successful runs seem to take a few seconds
+        timeout-minutes: 1  # 2025-11-06: Successful runs seem to take a few seconds
 
       - name: Wait for prior instances of the workflow to finish
         uses: ./monorepo/.github/actions/turnstile
@@ -292,4 +292,4 @@ jobs:
           upstream-ref-since: '2024-04-10' # No point in checking 12 years of earlier commits from before we started adding "Upstream-Ref".
           username: matticbot
           working-directory: ${{ github.workspace }}/build
-        timeout-minutes: 10  # 2024-04-11: Successful runs seem to take about a minute.
+        timeout-minutes: 10  # 2025-11-06: Successful runs seem to take a minute or two.

--- a/.github/workflows/gardening.yml
+++ b/.github/workflows/gardening.yml
@@ -20,7 +20,7 @@ jobs:
     name: "Manage labels and assignees"
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request_target' || github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
-    timeout-minutes: 10  # 2021-03-12: Successful runs seem to take a few seconds, but can sometimes take a lot longer since we wait for previous runs to complete.
+    timeout-minutes: 10  # 2025-11-06: Successful runs seem to take a minute or two, primarily since we wait for previous runs to complete.
     steps:
       - name: Checkout
         uses: actions/checkout@v5

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -20,7 +20,7 @@ jobs:
   changed_files:
     name: detect changed files
     runs-on: ubuntu-latest
-    timeout-minutes: 1  # 2021-01-18: Successful runs seem to take a few seconds
+    timeout-minutes: 1  # 2025-11-06: Successful runs seem to take a few seconds
     outputs:
       # Whether any PHP files have changed.
       php: ${{ steps.filter.outputs.php }}
@@ -191,7 +191,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: changed_files
     continue-on-error: ${{ matrix.experimental }}
-    timeout-minutes: 3  # 2021-01-18: Successful runs seem to take ~1 minute
+    timeout-minutes: 3  # 2025-11-06: Successful runs seem to take ~1 minute
 
     strategy:
       fail-fast: false
@@ -229,7 +229,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: changed_files
     if: needs.changed_files.outputs.php == 'true' || needs.changed_files.outputs.misc_php == 'true'
-    timeout-minutes: 5  # 2021-01-18: Successful runs seem to take ~1 minute. Leaving some extra for future expansion.
+    timeout-minutes: 5  # 2025-11-06: Successful runs seem to take ~2 minutes. Leaving some extra for future expansion.
 
     steps:
       - uses: actions/checkout@v5
@@ -255,7 +255,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: changed_files
     if: needs.changed_files.outputs.php == 'true' || needs.changed_files.outputs.misc_php == 'true'
-    timeout-minutes: 5  # 2021-01-18: Successful runs seem to take ~1 minute. Leaving some extra for future expansion.
+    timeout-minutes: 5  # 2025-11-06: Successful runs seem to take ~1 minute. Leaving some extra for future expansion.
 
     steps:
       - uses: actions/checkout@v5
@@ -285,7 +285,7 @@ jobs:
     needs: changed_files
     if: needs.changed_files.outputs.php_excluded_files != '[]'
     continue-on-error: true
-    timeout-minutes: 5  # 2021-01-18: Successful runs seem to take ~1 minute. Leaving some extra for future expansion.
+    timeout-minutes: 5  # 2025-11-06: Successful runs seem to take 30 seconds. Leaving some extra for future expansion.
 
     steps:
       # We don't need full git history, but phpcs-changed does need everything up to the merge-base.
@@ -321,7 +321,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: changed_files
     if: needs.changed_files.outputs.js == 'true' || needs.changed_files.outputs.misc_js == 'true'
-    timeout-minutes: 10  # 2021-03-05: Runs now take ~5 minutes due to now installing all php/js deps to ensure valid linting.
+    timeout-minutes: 10  # 2025-11-06: Runs now take ~5 minutes due to now installing all php/js deps to ensure valid linting.
 
     steps:
       - uses: actions/checkout@v5
@@ -344,7 +344,7 @@ jobs:
     needs: changed_files
     if: needs.changed_files.outputs.js_excluded_files != '[]'
     continue-on-error: true
-    timeout-minutes: 10  # 2021-03-05: Taking ~4:30 now due to now installing all php/js deps to ensure valid linting.
+    timeout-minutes: 10  # 2025-11-06: Takes about a minute, but rarely runs.
 
     steps:
       # We don't need full git history, but eslint-changed does need everything up to the merge-base.
@@ -372,7 +372,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: changed_files
     if: needs.changed_files.outputs.css == 'true' || needs.changed_files.outputs.misc_css == 'true'
-    timeout-minutes: 5  # 2025-04-03: Takes about a minute, so give a little wiggle room.
+    timeout-minutes: 5  # 2025-11-06: Takes a bit more than a minute, so give a little wiggle room.
 
     steps:
       - uses: actions/checkout@v5
@@ -392,7 +392,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: changed_files
     if: needs.changed_files.outputs.ghactionsfiles == 'true' || needs.changed_files.outputs.misc == 'true'
-    timeout-minutes: 5  # 2021-03-24: Pnpm stuff takes about a minute.
+    timeout-minutes: 5  # 2025-11-06: Takes less than a minute.
     steps:
       - uses: actions/checkout@v5
 
@@ -410,7 +410,7 @@ jobs:
   copied_files:
     name: Copied files are in sync
     runs-on: ubuntu-latest
-    timeout-minutes: 1  # 2021-01-18: Successful runs seem to take a few seconds.
+    timeout-minutes: 1  # 2025-11-06: Successful runs seem to take a few seconds.
 
     steps:
       - uses: actions/checkout@v5
@@ -423,7 +423,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: changed_files
     if: needs.changed_files.outputs.excludelist == 'true'
-    timeout-minutes: 10  # 2022-05-11: The check itself takes 4 minutes.
+    timeout-minutes: 10  # 2025-11-06: The check itself takes 2 minutes.
     steps:
       - uses: actions/checkout@v5
 
@@ -444,7 +444,7 @@ jobs:
   changelogger_used:
     name: Changelogger use
     runs-on: ubuntu-latest
-    timeout-minutes: 5  # 2021-03-24: Takes about a minute.
+    timeout-minutes: 5  # 2025-11-06: Takes a few seconds.
     steps:
       # We don't need full git history, but tools/check-changelogger-use.php does need everything up to the merge-base.
       - uses: actions/checkout@v5
@@ -469,7 +469,7 @@ jobs:
   changelogger_valid:
     name: Changelogger validity
     runs-on: ubuntu-latest
-    timeout-minutes: 5  # 2021-03-24: Takes about a minute
+    timeout-minutes: 5  # 2025-11-06: Takes less than a minute.
     steps:
       - uses: actions/checkout@v5
 
@@ -489,7 +489,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: changed_files
     if: needs.changed_files.outputs.lockfiles == 'true' || needs.changed_files.outputs.misc == 'true'
-    timeout-minutes: 7  # 2021-03-17: Successful runs seem to take 3+ minutes, thanks to pnpm building stuff.
+    timeout-minutes: 7  # 2025-11-06: Successful runs seem to take about 2 minutes.
     steps:
       - uses: actions/checkout@v5
 
@@ -505,7 +505,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: changed_files
     if: needs.changed_files.outputs.lockfiles == 'true' || needs.changed_files.outputs.misc == 'true'
-    timeout-minutes: 5  # 2022-03-25: The pnpm install will probably take a minute or so.
+    timeout-minutes: 7  # 2025-11-06: Takes a minute or two.
     steps:
       - uses: actions/checkout@v5
       - name: Setup tools
@@ -519,7 +519,7 @@ jobs:
   project_structure:
     name: Project structure
     runs-on: ubuntu-latest
-    timeout-minutes: 5  # 2021-03-24: Pnpm stuff takes about a minute.
+    timeout-minutes: 5  # 2025-11-06: Takes a minute or two.
     steps:
       - uses: actions/checkout@v5
 
@@ -535,7 +535,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: changed_files
     if: needs.changed_files.outputs.phanstubs == 'true' && github.event.pull_request.user.login != 'matticbot'
-    timeout-minutes: 5  # 2025-07-28: Probably takes about a minute.
+    timeout-minutes: 5  # 2025-11-06: Probably takes about a minute, but shouldn't run often.
     steps:
       - uses: actions/checkout@v5
       - uses: ./.github/actions/deepen-to-merge-base

--- a/.github/workflows/phpcompatibility-dev.yml
+++ b/.github/workflows/phpcompatibility-dev.yml
@@ -17,7 +17,7 @@ jobs:
   changed_files:
     name: detect changed files
     runs-on: ubuntu-latest
-    timeout-minutes: 1  # 2021-01-18: Successful runs seem to take a few seconds.
+    timeout-minutes: 1  # 2025-11-06: Successful runs seem to take a few seconds.
     outputs:
       php: ${{ steps.filter.outputs.php }}
       misc: ${{ steps.filter.outputs.misc }}
@@ -49,7 +49,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: changed_files
     if: needs.changed_files.outputs.php == 'true' || needs.changed_files.outputs.misc == 'true'
-    timeout-minutes: 5  # 2021-01-18: Successful runs seem to take ~1 minute.
+    timeout-minutes: 7  # 2025-11-06: Successful runs seem to take ~2 minutes.
 
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/post-build.yml
+++ b/.github/workflows/post-build.yml
@@ -302,7 +302,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [ setup, find_artifact, prepare_upgrade_test ]
     if: needs.find_artifact.outputs.any_plugins == 'true'
-    timeout-minutes: 15  # 2022-08-26: Successful runs seem to take about 6 minutes, but give some extra time for the downloads.
+    timeout-minutes: 15  # 2025-11-06: Successful runs seem to take about 3 minutes, but give some extra time for the downloads.
     strategy:
       fail-fast: false
       matrix:

--- a/docs/monorepo.md
+++ b/docs/monorepo.md
@@ -233,8 +233,8 @@ This assumes you have PHP installed via Homebrew, e.g. you've done `brew install
    ast
 
    ast support => enabled
-   extension version => 1.1.1
-   AST version => Current version is 90. All versions (including experimental): {50, 60, 70, 80, 85, 90, 100}
+   extension version => 1.1.3
+   AST version => Current version is 120. All versions (including experimental): {50, 60, 70, 80, 85, 90, 100, 110, 120}
    ```
 2. You may need to `brew install pkg-config zlib` to install some necessary dependencies.
 3. Update the list of available extensions: `pecl channel-update pecl.php.net`


### PR DESCRIPTION
Closes MONOREP-189

 <!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

While working on PHP 8.4 updates, I noticed a lot of the comments regarding CI job run times were outdated. This PR updates them and adjusts a few timeouts accordingly.

Edit: 19c5dc8 was pushed to the wrong branch, but is harmless.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*