### PR TITLE
cli: Add `jetpack dependencies depths`

### DIFF
--- a/tools/cli/commands/dependencies.js
+++ b/tools/cli/commands/dependencies.js
@@ -1,7 +1,12 @@
 import { spawn } from 'child_process';
 import { chalkStderr } from 'chalk';
 import ignore from 'ignore';
-import { getDependencies, filterDeps, getBuildOrder } from '../helpers/dependencyAnalysis.js';
+import {
+	getDependencies,
+	filterDeps,
+	getBuildOrder,
+	getDependencyDepths,
+} from '../helpers/dependencyAnalysis.js';
 
 // Files that mean --git-changed should report all projects as changed.
 const infrastructureFileSets = {};
@@ -68,9 +73,9 @@ export function builder( yargs ) {
 	return yargs
 		.positional( 'subcommand', {
 			describe:
-				'Whether to print `json` dependency data, a `list` of projects, or print a `build-order`.',
+				'Whether to print `json` dependency data, a `list` of projects, print a `build-order`, or calculate `depths`.',
 			type: 'string',
-			choices: [ 'json', 'list', 'build-order' ],
+			choices: [ 'json', 'list', 'build-order', 'depths' ],
 		} )
 		.positional( 'projects', {
 			describe: 'Only include dependencies relevant to these projects.',
@@ -93,6 +98,10 @@ export function builder( yargs ) {
 			type: 'string',
 			choices: [ 'build', 'test', 'e2e' ],
 		} )
+		.option( 'targets', {
+			describe: 'Targets for `depth`, comma-separated.',
+			type: 'string',
+		} )
 		.option( 'ignore-root', {
 			describe: 'Ignore the monorepo root.',
 			type: 'boolean',
@@ -102,7 +111,7 @@ export function builder( yargs ) {
 			type: 'boolean',
 		} )
 		.option( 'pretty', {
-			describe: 'Pretty-print JSON or build-order output.',
+			describe: 'Pretty-print JSON, build-order, or depths output.',
 			type: 'boolean',
 		} );
 }
@@ -220,6 +229,37 @@ export async function handler( argv ) {
 		const order = getBuildOrder( deps );
 		for ( const group of order ) {
 			console.log( Array.from( group ).join( argv.pretty ? '\n' : ' ' ) );
+		}
+	} else if ( argv.subcommand === 'depths' ) {
+		const depths = getDependencyDepths(
+			deps,
+			String( argv.targets ?? '' )
+				.split( ',' )
+				.map( v => v.trim() )
+		);
+		if ( argv.pretty ) {
+			const tiers = new Map();
+			for ( const [ p, d ] of depths.entries() ) {
+				if ( ! tiers.has( d ) ) {
+					tiers.set( d, [] );
+				}
+				tiers.get( d ).push( p );
+			}
+			const keys = tiers
+				.keys()
+				.toArray()
+				.sort( ( a, b ) => Math.sign( b - a ) || 0 );
+			for ( const d of keys ) {
+				console.log( d, tiers.get( d ).sort().join( ' ' ) );
+			}
+		} else {
+			const entries = depths
+				.entries()
+				.toArray()
+				.sort( ( [ p1, d1 ], [ p2, d2 ] ) => Math.sign( d2 - d1 ) || p1.localeCompare( p2 ) );
+			for ( const [ p, d ] of entries ) {
+				console.log( p, d );
+			}
 		}
 	}
 }

--- a/tools/cli/helpers/dependencyAnalysis.js
+++ b/tools/cli/helpers/dependencyAnalysis.js
@@ -191,6 +191,7 @@ export function getBuildOrder( deps ) {
  * Get the max "depth" of all projects from a set of targets.
  *
  * If there are cycles, the "depth" for affected projects will be `deps.size + 1`.
+ * Any projects not reachable from any target will have a depth of Infinity.
  *
  * @param {Map}      deps    - Project dependency map.
  * @param {Iterable} targets - Targets.
@@ -204,22 +205,22 @@ export function getDependencyDepths( deps, targets ) {
 	}
 
 	const maxDepth = deps.size + 1;
-	const stack = [];
-	for ( const p of targets.values() ) {
+	const queue = [];
+	for ( const p of targets ) {
 		if ( deps.has( p ) ) {
 			depths.set( p, 0 );
-			stack.push( p );
+			queue.push( p );
 		}
 	}
 
-	while ( stack.length > 0 ) {
-		const p = stack.shift();
+	while ( queue.length > 0 ) {
+		const p = queue.shift();
 		const depth = Math.min( depths.get( p ) + 1, maxDepth );
 		for ( const p2 of deps.get( p ) ) {
 			const d2 = depths.get( p2 );
 			if ( d2 < depth || d2 === Infinity ) {
 				depths.set( p2, depth );
-				stack.push( p2 );
+				queue.push( p2 );
 			}
 		}
 	}

--- a/tools/cli/helpers/dependencyAnalysis.js
+++ b/tools/cli/helpers/dependencyAnalysis.js
@@ -186,3 +186,43 @@ export function getBuildOrder( deps ) {
 
 	return ret;
 }
+
+/**
+ * Get the max "depth" of all projects from a set of targets.
+ *
+ * If there are cycles, the "depth" for affected projects will be `deps.size + 1`.
+ *
+ * @param {Map}      deps    - Project dependency map.
+ * @param {Iterable} targets - Targets.
+ * @return {Map<string,number>} - Map of projects to depths.
+ */
+export function getDependencyDepths( deps, targets ) {
+	const depths = new Map();
+
+	for ( const p of deps.keys() ) {
+		depths.set( p, Infinity );
+	}
+
+	const maxDepth = deps.size + 1;
+	const stack = [];
+	for ( const p of targets.values() ) {
+		if ( deps.has( p ) ) {
+			depths.set( p, 0 );
+			stack.push( p );
+		}
+	}
+
+	while ( stack.length > 0 ) {
+		const p = stack.shift();
+		const depth = Math.min( depths.get( p ) + 1, maxDepth );
+		for ( const p2 of deps.get( p ) ) {
+			const d2 = depths.get( p2 );
+			if ( d2 < depth || d2 === Infinity ) {
+				depths.set( p2, depth );
+				stack.push( p2 );
+			}
+		}
+	}
+
+	return depths;
+}


### PR DESCRIPTION
Closes MONOREP-190

 <!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
It may be useful in build ordering to priotitize packages that are "farther away" from some of our heavier plugins. This adds a function to calculate that, and a command line interface to output it.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1762462365822739/1762271818.004839-slack-C05Q5HSS013

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Run something like `jetpack dependencies depths --targets=plugins/jetpack,plugins/mu-wpcom-plugin`.