### PR TITLE
Forms: Fix multiple selection view

### DIFF
--- a/projects/packages/forms/changelog/fix-form-multiple-selection-view
+++ b/projects/packages/forms/changelog/fix-form-multiple-selection-view
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: dashboard fix visible sidebar when multiple items are selected 

--- a/projects/packages/forms/src/dashboard/inbox/dataviews/index.js
+++ b/projects/packages/forms/src/dashboard/inbox/dataviews/index.js
@@ -178,13 +178,8 @@ export default function InboxView() {
 
 	const onChangeSelection = useCallback(
 		items => {
-			// Set the side panel item only when we are not on mobile.
-			if ( ! isMobile ) {
-				setSidePanelItem(
-					!! items?.length &&
-						records?.find( record => getItemId( record ) === items[ items.length - 1 ] )
-				);
-			}
+			// Update URL params with selected items
+			// The useEffect above will handle updating the sidebar
 			setSearchParams( previousSearchParams => {
 				const _searchParams = new URLSearchParams( previousSearchParams );
 				if ( items.length ) {
@@ -195,44 +190,45 @@ export default function InboxView() {
 				return _searchParams;
 			} );
 		},
-		[ records, setSearchParams, isMobile ]
+		[ setSearchParams ]
 	);
 
 	const [ sidePanelItem, setSidePanelItem ] = useState();
-	// Because selection is in sync with the URL and data takes some time to load,
-	// We need to carefully (avoid infinite loops by always updating the state)
-	// set the sidePanelItem when we have data and selection.
-	// We don't need to do this in `mobile`,  because we don't render the side panel.
-	if ( ! isMobile && !! records && !! selection.length ) {
-		// Find the last (most recently selected) valid selection instead of the first
-		const lastValidSelection = selection
-			.slice()
-			.reverse()
-			.find( id => records.some( record => getItemId( record ) === id ) );
-		const recordToShow = records?.find( record => getItemId( record ) === lastValidSelection );
-		if ( ! sidePanelItem && recordToShow ) {
-			setSidePanelItem( recordToShow );
-		} else if ( !! sidePanelItem && ! recordToShow ) {
-			// This case handles the case where we were having a side panel item
-			// visible but the data have changed and the item is not there anymore.
-			setSidePanelItem();
-		} else if (
-			!! sidePanelItem &&
-			!! recordToShow &&
-			getItemId( sidePanelItem ) === getItemId( recordToShow ) &&
+
+	// Manage sidebar visibility based on selection
+	// Only show sidebar when exactly one item is selected on desktop
+	useEffect( () => {
+		if ( isMobile ) {
+			// Don't manage sidebar on mobile
+			return;
+		}
+
+		if ( ! records || selection.length !== 1 ) {
+			// Clear sidebar if no records, no selection, or multiple selections
+			setSidePanelItem( null );
+			return;
+		}
+
+		// Single item selected - find it in records
+		const selectedId = selection[ 0 ];
+		const recordToShow = records.find( record => getItemId( record ) === selectedId );
+
+		if ( ! recordToShow ) {
+			// Selected item not in current records - clear sidebar
+			setSidePanelItem( null );
+			return;
+		}
+
+		// Update sidebar if item changed or needs refresh
+		if (
+			! sidePanelItem ||
+			getItemId( sidePanelItem ) !== getItemId( recordToShow ) ||
 			sidePanelItem !== recordToShow
 		) {
-			// Update side panel item if the data has been refreshed for the SAME item (e.g., after an action)
-			// This ensures the side panel shows the latest version of the same entity
-			setSidePanelItem( recordToShow );
-		} else if (
-			!! recordToShow &&
-			( ! sidePanelItem || getItemId( sidePanelItem ) !== getItemId( recordToShow ) )
-		) {
-			// Set side panel item when selecting a different item
 			setSidePanelItem( recordToShow );
 		}
-	}
+	}, [ isMobile, records, selection, sidePanelItem ] );
+
 	const paginationInfo = useMemo(
 		() => ( { totalItems, totalPages } ),
 		[ totalItems, totalPages ]
@@ -244,6 +240,7 @@ export default function InboxView() {
 		}
 		return itemValue;
 	};
+
 	const fields = useMemo(
 		() => [
 			{
@@ -403,9 +400,9 @@ export default function InboxView() {
 
 				const [ item ] = items;
 				const selectedId = item.id.toString();
-				const selectionWithoutSelectedId = selection.filter( id => id !== selectedId );
 
-				onChangeSelection( [ ...selectionWithoutSelectedId, selectedId ] );
+				// Select only this item to show it in the sidebar
+				onChangeSelection( [ selectedId ] );
 			},
 		};
 
@@ -428,7 +425,7 @@ export default function InboxView() {
 					...secondaryActions,
 				];
 		}
-	}, [ isMobile, onChangeSelection, selection, statusFilter ] );
+	}, [ isMobile, onChangeSelection, statusFilter ] );
 
 	const resetPage = useCallback( () => {
 		view.page = 1;
@@ -496,7 +493,7 @@ export default function InboxView() {
 				) }
 			</div>
 			<SingleResponseView
-				sidePanelItem={ selection.length && sidePanelItem }
+				sidePanelItem={ selection.length === 1 && sidePanelItem }
 				setSidePanelItem={ setSidePanelItem }
 				isLoadingData={ isLoadingData }
 				isMobile={ isMobile }


### PR DESCRIPTION
Currently when you have multiple responses selected the sidebar is still open. 

We should not show the sidebar if this is the case. 

Fixes FORMS-363

Before: 
<img width="1200" height="643" alt="Screenshot 2025-11-06 at 2 12 34 PM" src="https://github.com/user-attachments/assets/b96f6db2-ed9b-45a9-920f-e19f794d8b55" />


After:
<img width="805" height="523" alt="Screenshot 2025-11-06 at 2 12 02 PM" src="https://github.com/user-attachments/assets/f29eebd9-a9a7-4266-b4ef-50b81470175f" />



## Proposed changes:
* Only show the sidebar if one of the items is selected. 


### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
See FORMS-363 

## Does this pull request change what data or activity we track or use?
NO

## Testing instructions:
Go to the forms responses dashboard. 

## On desktop. 
Does the view still works as expected? 
When you select one response you should see it in the sidebar. 

When you selected all the items you should not see the sidebar. 
If you have non selected the sidebar should be gone. 

## On Mobile

You should be able to select the items that you want selected without opening the sidebar. 
You should be able to view any item that you want to see and keep the selection. 

