### PR TITLE
Forms: Fix mobile scroll on desktop

### DIFF
--- a/projects/packages/forms/changelog/fix-mobile-scroll-desktop
+++ b/projects/packages/forms/changelog/fix-mobile-scroll-desktop
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Forms: revert recently added css overscroll-behavior 
+Forms: revert recently added css overscroll-behavior

--- a/projects/packages/forms/changelog/fix-mobile-scroll-desktop
+++ b/projects/packages/forms/changelog/fix-mobile-scroll-desktop
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: revert recently added css overscroll-behavior 

--- a/projects/packages/forms/src/dashboard/inbox/style.scss
+++ b/projects/packages/forms/src/dashboard/inbox/style.scss
@@ -357,7 +357,6 @@
 	.dataviews-wrapper {
 		background: var(--jp-white);
 		flex-grow: 1;
-		overscroll-behavior: none;
 
 		@media (min-width: 782px) {
 			border-right: 1px solid var(--jp-gray-5);


### PR DESCRIPTION
In https://github.com/Automattic/jetpack/pull/45788 we fixed an issue where the navigation was also scrolling. 

But this also introduced a change where the table view stopped scrolling on desktop responsive view. 

This PR fixes the issue for me. 

## Proposed changes:
* Remove the overscroll-behavior: none; on the main datatable view. 

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
no

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Go to the dashboard. 
On desktop Firefox in developer tools switch to responsive view. 
Notice that you are able to scroll again as expected. 
