### PR TITLE
Forms: Fix export responses with empty labels

### DIFF
--- a/projects/packages/forms/changelog/fix-export-form-entries-with-empty-labels
+++ b/projects/packages/forms/changelog/fix-export-form-entries-with-empty-labels
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: fix a bug where we were not showing duplicate form field values

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -2650,36 +2650,48 @@ class Contact_Form_Plugin {
 	 * @return array
 	 */
 	public function get_export_feedback_data( $feedback_ids ) {
-		$feedback_data = array();
-		$field_names   = array();
+		$feedback_data   = array();
+		$all_field_names = array();
 
+		// Collect all feedback responses and their compiled fields
 		foreach ( $feedback_ids as $feedback_id ) {
 			$response = Feedback::get( $feedback_id );
 			if ( ! $response instanceof Feedback ) {
 				continue; // Skip if the feedback is not an instance of Feedback.
 			}
-			$feedback_data[ $feedback_id ] = $response;
-			$field_names                   = array_merge( $field_names, $response->get_compiled_fields( 'csv', 'label' ) );
+
+			// Get fields with automatic duplicate handling (label-value shape includes counts)
+			$compiled_fields = $response->get_compiled_fields( 'csv', 'label-value' );
+
+			$feedback_data[ $feedback_id ] = array(
+				'response' => $response,
+				'fields'   => $compiled_fields,
+			);
+
+			// Collect all unique field names across all responses
+			$all_field_names = array_merge( $all_field_names, array_keys( $compiled_fields ) );
 		}
 
-		/**
-		 * Make sure the field names are unique, because we don't want duplicate data.
-		 */
-		$field_names = array_unique( $field_names );
-		return $this->format_feedback_data_for_csv( $feedback_data, $field_names );
+		// Get unique field names (this preserves the incremented labels like "Name (2)")
+		$all_field_names = array_unique( $all_field_names );
+
+		return $this->format_feedback_data_for_csv( $feedback_data, $all_field_names );
 	}
 
 	/**
 	 * Returns an array of feedback data for CSV export.
 	 *
-	 * @param array $feedback_data Array of feedback data to fetch the results for.
+	 * @param array $feedback_data Array of feedback data with 'response' and 'fields' keys.
 	 * @param array $field_names   Array of field names to include in the results.
 	 *
 	 * @return array
 	 */
 	private function format_feedback_data_for_csv( $feedback_data, $field_names ) {
 		$results = array();
-		foreach ( $feedback_data as $feedback_id => $feedback ) {
+		foreach ( $feedback_data as $feedback_id => $data ) {
+
+			$feedback        = $data['response'];
+			$compiled_fields = $data['fields'];
 
 			if ( ! $feedback instanceof Feedback ) {
 				continue; // Skip if the feedback is not an instance of Feedback.
@@ -2699,7 +2711,8 @@ class Contact_Form_Plugin {
 				if ( ! isset( $results[ $single_field_name ] ) ) {
 					$results[ $single_field_name ] = array();
 				}
-				$results[ $single_field_name ][] = $feedback->get_field_value_by_label( $single_field_name, 'csv' );
+				// Use the compiled fields directly (which already have incremented labels)
+				$results[ $single_field_name ][] = isset( $compiled_fields[ $single_field_name ] ) ? $compiled_fields[ $single_field_name ] : '';
 			}
 
 			$results[ __( 'Consent', 'jetpack-forms' ) ][]      = $feedback->has_consent() ? __( 'Yes', 'jetpack-forms' ) : __( 'No', 'jetpack-forms' );
@@ -3019,7 +3032,7 @@ class Contact_Form_Plugin {
 	public function esc_csv( $field ) {
 		$active_content_triggers = array( '=', '+', '-', '@' );
 
-		if ( in_array( mb_substr( $field, 0, 1 ), $active_content_triggers, true ) ) {
+		if ( $field && in_array( mb_substr( $field, 0, 1 ), $active_content_triggers, true ) ) {
 			$field = "'" . $field;
 		}
 

--- a/projects/packages/forms/src/contact-form/class-feedback-field.php
+++ b/projects/packages/forms/src/contact-form/class-feedback-field.php
@@ -98,7 +98,7 @@ class Feedback_Field {
 
 		$postfix = $count > 1 ? " ({$count})" : '';
 
-		if ( 'api' === $context ) {
+		if ( in_array( $context, array( 'api', 'csv' ), true ) ) {
 			if ( empty( $this->label ) ) {
 				return __( 'Field', 'jetpack-forms' ) . $postfix;
 			}

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
@@ -878,4 +878,120 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 		Contact_Form_Plugin::recalculate_unread_count();
 		$this->assertSame( 0, Contact_Form_Plugin::get_unread_count() );
 	}
+
+	/**
+	 * Test get_export_feedback_data with duplicate field labels and empty labels.
+	 * Ensures that duplicate labels are incremented (e.g., "Name", "Name (2)", "Name (3)")
+	 * and empty labels are replaced with "Field", "Field (2)", etc.
+	 */
+	public function test_get_export_feedback_data_duplicate_and_empty_labels() {
+		global $post;
+		$current_post = Utility::create_post_context();
+
+		// Create feedback with duplicate field labels manually
+		$feedback_time_1  = current_time( 'mysql' );
+		$feedback_title_1 = 'Test User 1 - ' . $feedback_time_1;
+		$feedback_id_1    = md5( $feedback_title_1 );
+
+		// Create fields with duplicates and empty labels
+		$fields_1 = array(
+			( new Feedback_Field( '1_question', 'Question', 'Answer 1', 'text', array(), 'question' ) )->serialize(),
+			( new Feedback_Field( '2_email', 'Email', 'user1@example.com', 'email', array(), 'email' ) )->serialize(),
+			( new Feedback_Field( '3_question', 'Question', 'Answer 2', 'text', array(), 'question' ) )->serialize(), // Duplicate label
+			( new Feedback_Field( '4_empty', '', 'Hidden value 1', 'text', array(), 'empty' ) )->serialize(), // Empty label
+			( new Feedback_Field( '5_question', 'Question', 'Answer 3', 'text', array(), 'question' ) )->serialize(), // Another duplicate
+			( new Feedback_Field( '6_empty', '', 'Hidden value 2', 'text', array(), 'empty' ) )->serialize(), // Another empty label
+		);
+
+		$content_1 = array(
+			'subject'     => 'Test Subject',
+			'ip'          => 'https://127.0.0.1',
+			'entry_title' => 'Cool Post Title',
+			'entry_page'  => 1,
+			'fields'      => $fields_1,
+		);
+
+		$post_id_1 = wp_insert_post(
+			array(
+				'post_type'      => 'feedback',
+				'post_status'    => 'publish',
+				'post_title'     => addslashes( wp_kses( $feedback_title_1, array() ) ),
+				'post_date'      => $feedback_time_1,
+				'post_name'      => $feedback_id_1,
+				'post_content'   => wp_json_encode( $content_1 ),
+				'post_mime_type' => 'v2',
+				'post_parent'    => $post ? $post->ID : 0,
+			)
+		);
+
+		// Create another feedback with different duplicate pattern
+		$feedback_time_2  = current_time( 'mysql' );
+		$feedback_title_2 = 'Test User 2 - ' . $feedback_time_2;
+		$feedback_id_2    = md5( $feedback_title_2 );
+
+		$fields_2 = array(
+			( new Feedback_Field( '1_name', 'Name', 'John Doe', 'text', array(), 'name' ) )->serialize(),
+			( new Feedback_Field( '2_question', 'Question', 'What is this?', 'text', array(), 'question' ) )->serialize(),
+			( new Feedback_Field( '3_empty', '', 'Some data', 'text', array(), 'empty' ) )->serialize(), // Empty label
+		);
+
+		$content_2 = array(
+			'subject'     => 'Test Subject 2',
+			'ip'          => 'https://127.0.0.2',
+			'entry_title' => 'Cool Post Title',
+			'entry_page'  => 1,
+			'fields'      => $fields_2,
+		);
+
+		$post_id_2 = wp_insert_post(
+			array(
+				'post_type'      => 'feedback',
+				'post_status'    => 'publish',
+				'post_title'     => addslashes( wp_kses( $feedback_title_2, array() ) ),
+				'post_date'      => $feedback_time_2,
+				'post_name'      => $feedback_id_2,
+				'post_content'   => wp_json_encode( $content_2 ),
+				'post_mime_type' => 'v2',
+				'post_parent'    => $post ? $post->ID : 0,
+			)
+		);
+
+		$plugin = Contact_Form_Plugin::init();
+		$result = $plugin->get_export_feedback_data( array( $post_id_1, $post_id_2 ) );
+
+		// Verify that the result contains the expected fields with incremented labels
+		$this->assertIsArray( $result );
+
+		// Check that duplicate "Question" labels are incremented
+		$this->assertTrue( isset( $result['Question'] ), 'First Question field should exist' );
+		$this->assertTrue( isset( $result['Question (2)'] ), 'Second Question field should be incremented' );
+		$this->assertTrue( isset( $result['Question (3)'] ), 'Third Question field should be incremented' );
+
+		// Check that empty labels are replaced with "Field" and incremented
+		$this->assertTrue( isset( $result['Field'] ), 'First empty field should be "Field"' );
+		$this->assertTrue( isset( $result['Field (2)'] ), 'Second empty field should be "Field (2)"' );
+
+		// Check regular fields
+		$this->assertTrue( isset( $result['Email'] ), 'Email field should exist' );
+		$this->assertTrue( isset( $result['Name'] ), 'Name field should exist' );
+
+		// Verify the data integrity - all fields should have 2 entries (one per feedback)
+		$this->assertCount( 2, $result['Question'], 'Question should have 2 entries' );
+		$this->assertCount( 2, $result['Question (2)'], 'Question (2) should have 2 entries' );
+		$this->assertCount( 2, $result['Question (3)'], 'Question (3) should have 2 entries' );
+
+		// Verify the actual values for the first feedback
+		$this->assertEquals( 'Answer 1', $result['Question'][0], 'First Question should have correct value' );
+		$this->assertEquals( 'Answer 2', $result['Question (2)'][0], 'Second Question should have correct value' );
+		$this->assertEquals( 'Answer 3', $result['Question (3)'][0], 'Third Question should have correct value' );
+		$this->assertEquals( 'Hidden value 1', $result['Field'][0], 'First Field should have correct value' );
+		$this->assertEquals( 'Hidden value 2', $result['Field (2)'][0], 'Second Field should have correct value' );
+
+		// Verify the second feedback has empty values for fields it doesn't have
+		$this->assertEquals( 'What is this?', $result['Question'][1], 'Second feedback Question should have value' );
+		$this->assertSame( '', $result['Question (2)'][1], 'Second feedback should have empty Question (2)' );
+		$this->assertSame( '', $result['Question (3)'][1], 'Second feedback should have empty Question (3)' );
+
+		Utility::destroy_post_context( $current_post );
+	}
 }

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
@@ -750,6 +750,44 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 	}
 
 	/**
+	 * Test get_export_feedback_data with duplicate field labels (legacy format).
+	 * Ensures that when the same label appears multiple times in a form response,
+	 * the duplicates are incremented with "(2)", "(3)", etc.
+	 */
+	public function test_get_export_feedback_data_same_fields() {
+		$current_post = Utility::create_post_context();
+
+		// Create two feedback entries with duplicate "Name" fields
+		$post_id_1 = Utility::create_legacy_feedback(
+			array(
+				'1_Name' => 'User 1',
+				'2_Name' => 'First message',
+			)
+		);
+
+		$post_id_2 = Utility::create_legacy_feedback(
+			array(
+				'1_Name' => 'User 2',
+				'2_Name' => '123-456-7890',
+			)
+		);
+		$plugin    = Contact_Form_Plugin::init();
+		$result    = $plugin->get_export_feedback_data( array( $post_id_1, $post_id_2 ) );
+
+		// Verify that the result contains the expected fields with incremented labels
+		$this->assertIsArray( $result );
+		$this->assertTrue( isset( $result['Name'] ), 'First Name field should exist' );
+		$this->assertCount( 2, $result['Name'] );
+		$this->assertEquals( array( 'User 1', 'User 2' ), $result['Name'] );
+
+		$this->assertTrue( isset( $result['Name (2)'] ), 'Second Name field should be incremented to "Name (2)"' );
+		$this->assertCount( 2, $result['Name (2)'] );
+		$this->assertEquals( array( 'First message', '123-456-7890' ), $result['Name (2)'] );
+
+		Utility::destroy_post_context( $current_post );
+	}
+
+	/**
 	 * Test get_export_feedback_data returns correct structure
 	 */
 	public function test_get_export_feedback_data_structure() {

--- a/projects/plugins/jetpack/changelog/fix-export-form-entries-with-empty-labels
+++ b/projects/plugins/jetpack/changelog/fix-export-form-entries-with-empty-labels
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Forms: fix a bug where we were not showing duplcuate form field values on export

--- a/projects/plugins/jetpack/changelog/fix-export-form-entries-with-empty-labels
+++ b/projects/plugins/jetpack/changelog/fix-export-form-entries-with-empty-labels
@@ -1,4 +1,4 @@
 Significance: patch
 Type: bugfix
 
-Forms: fix a bug where we were not showing duplcuate form field values on export
+Forms: fix a bug where we were not showing duplicate form field values on export


### PR DESCRIPTION
This PR fixes an issue with empty or duplicate form fields. 

Fixes FORMS-381

## Proposed changes:
* Update the function that generates the export data to be what we expect it to be. 

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
See FORMS-381


## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Create a form with empty form labels. Make sure that you have a few responses to this form.

Export the responses. 

Make sure that you can see the form responses as expected. 

All the data is there. 

