### PR TITLE
Forms: Add keyboard navigation forms dashboard

### DIFF
--- a/projects/packages/forms/changelog/add-keyboard-navigation-forms-dashboard
+++ b/projects/packages/forms/changelog/add-keyboard-navigation-forms-dashboard
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Form: add up and down and esc keyboard navigation to view responses quickly

--- a/projects/packages/forms/src/dashboard/components/response-view/mobile.tsx
+++ b/projects/packages/forms/src/dashboard/components/response-view/mobile.tsx
@@ -32,11 +32,13 @@ const ResponseMobileView = ( { response, closeModal } ) => {
 			) as unknown as FormResponse,
 		[ currentResponseId ]
 	);
+
 	// Use the navigation hook
 	const navigation = useResponseNavigation( {
-		onChangeSelection: null,
+		onChangeSelection: setCurrentResponseId,
 		record: responseRecord,
-		setRecord: record => setCurrentResponseId( record.id ),
+		setRecord: () => {}, // No-op for this mobile view - state is managed by onChangeSelection
+		isMobile: true,
 	} );
 
 	const { hasNext, hasPrevious, handleNext, handlePrevious } = navigation;

--- a/projects/packages/forms/src/dashboard/components/response-view/single.tsx
+++ b/projects/packages/forms/src/dashboard/components/response-view/single.tsx
@@ -70,6 +70,8 @@ const SingleResponseView = ( {
 	const navigation = useResponseNavigation( {
 		onChangeSelection,
 		record: sidePanelItem,
+		setRecord: setSidePanelItem,
+		isMobile,
 	} );
 
 	// Add keyboard navigation using refs to avoid re-registering listeners

--- a/projects/packages/forms/src/dashboard/components/response-view/single.tsx
+++ b/projects/packages/forms/src/dashboard/components/response-view/single.tsx
@@ -3,7 +3,7 @@ import {
 	__experimentalHStack as HStack,
 	Modal,
 } from '@wordpress/components';
-import { useCallback, useState } from '@wordpress/element';
+import { useCallback, useEffect, useRef, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import useResponseNavigation from '../../hooks/use-response-navigation';
 import ResponseActions from '../response-actions';
@@ -70,8 +70,47 @@ const SingleResponseView = ( {
 	const navigation = useResponseNavigation( {
 		onChangeSelection,
 		record: sidePanelItem,
-		setRecord: setSidePanelItem,
 	} );
+
+	// Add keyboard navigation using refs to avoid re-registering listeners
+	const handleNextRef = useRef( navigation.handleNext );
+	const handlePreviousRef = useRef( navigation.handlePrevious );
+	const hasNextRef = useRef( navigation.hasNext );
+	const hasPreviousRef = useRef( navigation.hasPrevious );
+	const onRequestCloseRef = useRef( onRequestClose );
+
+	// Update refs when values change
+	useEffect( () => {
+		handleNextRef.current = navigation.handleNext;
+		handlePreviousRef.current = navigation.handlePrevious;
+		hasNextRef.current = navigation.hasNext;
+		hasPreviousRef.current = navigation.hasPrevious;
+		onRequestCloseRef.current = onRequestClose;
+	} );
+
+	// Register keyboard event listener only once
+	useEffect( () => {
+		const handleKeyDown = event => {
+			// Prevent default behavior for arrow keys to avoid scrolling
+			if ( event.key === 'ArrowUp' || event.key === 'ArrowDown' ) {
+				event.preventDefault();
+			}
+
+			if ( event.key === 'ArrowUp' && hasPreviousRef.current ) {
+				handlePreviousRef.current();
+			} else if ( event.key === 'ArrowDown' && hasNextRef.current ) {
+				handleNextRef.current();
+			} else if ( event.key === 'Escape' ) {
+				onRequestCloseRef.current();
+			}
+		};
+
+		window.addEventListener( 'keydown', handleKeyDown );
+
+		return () => {
+			window.removeEventListener( 'keydown', handleKeyDown );
+		};
+	}, [] ); // Empty dependencies - listener registered only once
 
 	if ( ! sidePanelItem ) {
 		return null;

--- a/projects/packages/forms/src/dashboard/hooks/use-response-navigation.ts
+++ b/projects/packages/forms/src/dashboard/hooks/use-response-navigation.ts
@@ -6,9 +6,16 @@ import useInboxData from './use-inbox-data';
 interface UseResponseNavigationProps {
 	onChangeSelection: ( responses: string[] ) => void | null;
 	record: FormResponse;
+	setRecord: ( response: FormResponse ) => void;
+	isMobile?: boolean;
 }
 
-const useResponseNavigation = ( { onChangeSelection, record }: UseResponseNavigationProps ) => {
+const useResponseNavigation = ( {
+	onChangeSelection,
+	record,
+	setRecord,
+	isMobile = false,
+}: UseResponseNavigationProps ) => {
 	const { records } = useInboxData();
 	const currentIndex = useMemo(
 		() =>
@@ -28,21 +35,29 @@ const useResponseNavigation = ( { onChangeSelection, record }: UseResponseNaviga
 		if ( hasNext && records && currentIndex >= 0 ) {
 			const nextItem = records[ currentIndex + 1 ];
 			if ( nextItem ) {
-				// Only update selection - let parent's useEffect handle sidePanelItem
+				// Only call setRecord on mobile (where parent's useEffect doesn't run)
+				// On desktop, parent's useEffect handles it via onChangeSelection
+				if ( isMobile ) {
+					setRecord( nextItem );
+				}
 				onChangeSelection?.( [ getItemId( nextItem ) ] );
 			}
 		}
-	}, [ hasNext, records, currentIndex, onChangeSelection ] );
+	}, [ hasNext, records, currentIndex, isMobile, setRecord, onChangeSelection ] );
 
 	const handlePrevious = useCallback( () => {
 		if ( hasPrevious && records && currentIndex >= 0 ) {
 			const prevItem = records[ currentIndex - 1 ];
 			if ( prevItem ) {
-				// Only update selection - let parent's useEffect handle sidePanelItem
+				// Only call setRecord on mobile (where parent's useEffect doesn't run)
+				// On desktop, parent's useEffect handles it via onChangeSelection
+				if ( isMobile ) {
+					setRecord( prevItem );
+				}
 				onChangeSelection?.( [ getItemId( prevItem ) ] );
 			}
 		}
-	}, [ hasPrevious, records, currentIndex, onChangeSelection ] );
+	}, [ hasPrevious, records, currentIndex, isMobile, setRecord, onChangeSelection ] );
 
 	return {
 		currentIndex,

--- a/projects/packages/forms/src/dashboard/hooks/use-response-navigation.ts
+++ b/projects/packages/forms/src/dashboard/hooks/use-response-navigation.ts
@@ -6,14 +6,9 @@ import useInboxData from './use-inbox-data';
 interface UseResponseNavigationProps {
 	onChangeSelection: ( responses: string[] ) => void | null;
 	record: FormResponse;
-	setRecord: ( response: FormResponse ) => void;
 }
 
-const useResponseNavigation = ( {
-	onChangeSelection,
-	record,
-	setRecord,
-}: UseResponseNavigationProps ) => {
+const useResponseNavigation = ( { onChangeSelection, record }: UseResponseNavigationProps ) => {
 	const { records } = useInboxData();
 	const currentIndex = useMemo(
 		() =>
@@ -33,21 +28,21 @@ const useResponseNavigation = ( {
 		if ( hasNext && records && currentIndex >= 0 ) {
 			const nextItem = records[ currentIndex + 1 ];
 			if ( nextItem ) {
-				setRecord( nextItem );
+				// Only update selection - let parent's useEffect handle sidePanelItem
 				onChangeSelection?.( [ getItemId( nextItem ) ] );
 			}
 		}
-	}, [ hasNext, records, currentIndex, setRecord, onChangeSelection ] );
+	}, [ hasNext, records, currentIndex, onChangeSelection ] );
 
 	const handlePrevious = useCallback( () => {
 		if ( hasPrevious && records && currentIndex >= 0 ) {
 			const prevItem = records[ currentIndex - 1 ];
 			if ( prevItem ) {
-				setRecord( prevItem );
+				// Only update selection - let parent's useEffect handle sidePanelItem
 				onChangeSelection?.( [ getItemId( prevItem ) ] );
 			}
 		}
-	}, [ hasPrevious, records, currentIndex, setRecord, onChangeSelection ] );
+	}, [ hasPrevious, records, currentIndex, onChangeSelection ] );
 
 	return {
 		currentIndex,

--- a/projects/packages/forms/tests/js/dashboard/hooks/use-response-navigation.test.jsx
+++ b/projects/packages/forms/tests/js/dashboard/hooks/use-response-navigation.test.jsx
@@ -17,7 +17,6 @@ const mockedUseInboxData = useInboxData;
 const mockedGetItemId = getItemId;
 
 describe( 'useResponseNavigation', () => {
-	const mockSetRecord = jest.fn();
 	const mockOnChangeSelection = jest.fn();
 
 	// Mock response data
@@ -102,7 +101,6 @@ describe( 'useResponseNavigation', () => {
 				useResponseNavigation( {
 					onChangeSelection: mockOnChangeSelection,
 					record: mockRecords[ 0 ],
-					setRecord: mockSetRecord,
 				} )
 			);
 
@@ -116,7 +114,6 @@ describe( 'useResponseNavigation', () => {
 				useResponseNavigation( {
 					onChangeSelection: mockOnChangeSelection,
 					record: mockRecords[ 1 ],
-					setRecord: mockSetRecord,
 				} )
 			);
 
@@ -130,7 +127,6 @@ describe( 'useResponseNavigation', () => {
 				useResponseNavigation( {
 					onChangeSelection: mockOnChangeSelection,
 					record: mockRecords[ 2 ],
-					setRecord: mockSetRecord,
 				} )
 			);
 
@@ -149,7 +145,6 @@ describe( 'useResponseNavigation', () => {
 				useResponseNavigation( {
 					onChangeSelection: mockOnChangeSelection,
 					record: unknownRecord,
-					setRecord: mockSetRecord,
 				} )
 			);
 
@@ -180,7 +175,6 @@ describe( 'useResponseNavigation', () => {
 				useResponseNavigation( {
 					onChangeSelection: mockOnChangeSelection,
 					record: mockRecords[ 0 ],
-					setRecord: mockSetRecord,
 				} )
 			);
 
@@ -211,7 +205,6 @@ describe( 'useResponseNavigation', () => {
 				useResponseNavigation( {
 					onChangeSelection: mockOnChangeSelection,
 					record: mockRecords[ 0 ],
-					setRecord: mockSetRecord,
 				} )
 			);
 
@@ -227,13 +220,11 @@ describe( 'useResponseNavigation', () => {
 				useResponseNavigation( {
 					onChangeSelection: mockOnChangeSelection,
 					record: mockRecords[ 0 ],
-					setRecord: mockSetRecord,
 				} )
 			);
 
 			result.current.handleNext();
 
-			expect( mockSetRecord ).toHaveBeenCalledWith( mockRecords[ 1 ] );
 			expect( mockOnChangeSelection ).toHaveBeenCalledWith( [ '2' ] );
 		} );
 
@@ -242,13 +233,11 @@ describe( 'useResponseNavigation', () => {
 				useResponseNavigation( {
 					onChangeSelection: mockOnChangeSelection,
 					record: mockRecords[ 1 ],
-					setRecord: mockSetRecord,
 				} )
 			);
 
 			result.current.handlePrevious();
 
-			expect( mockSetRecord ).toHaveBeenCalledWith( mockRecords[ 0 ] );
 			expect( mockOnChangeSelection ).toHaveBeenCalledWith( [ '1' ] );
 		} );
 
@@ -257,13 +246,11 @@ describe( 'useResponseNavigation', () => {
 				useResponseNavigation( {
 					onChangeSelection: mockOnChangeSelection,
 					record: mockRecords[ 2 ],
-					setRecord: mockSetRecord,
 				} )
 			);
 
 			result.current.handleNext();
 
-			expect( mockSetRecord ).not.toHaveBeenCalled();
 			expect( mockOnChangeSelection ).not.toHaveBeenCalled();
 		} );
 
@@ -272,13 +259,11 @@ describe( 'useResponseNavigation', () => {
 				useResponseNavigation( {
 					onChangeSelection: mockOnChangeSelection,
 					record: mockRecords[ 0 ],
-					setRecord: mockSetRecord,
 				} )
 			);
 
 			result.current.handlePrevious();
 
-			expect( mockSetRecord ).not.toHaveBeenCalled();
 			expect( mockOnChangeSelection ).not.toHaveBeenCalled();
 		} );
 
@@ -292,14 +277,12 @@ describe( 'useResponseNavigation', () => {
 				useResponseNavigation( {
 					onChangeSelection: mockOnChangeSelection,
 					record: unknownRecord,
-					setRecord: mockSetRecord,
 				} )
 			);
 
 			result.current.handleNext();
 			result.current.handlePrevious();
 
-			expect( mockSetRecord ).not.toHaveBeenCalled();
 			expect( mockOnChangeSelection ).not.toHaveBeenCalled();
 		} );
 
@@ -308,13 +291,11 @@ describe( 'useResponseNavigation', () => {
 				useResponseNavigation( {
 					onChangeSelection: null,
 					record: mockRecords[ 0 ],
-					setRecord: mockSetRecord,
 				} )
 			);
 
 			// Should not throw when onChangeSelection is null
 			expect( () => result.current.handleNext() ).not.toThrow();
-			expect( mockSetRecord ).toHaveBeenCalledWith( mockRecords[ 1 ] );
 		} );
 
 		it( 'should handle undefined onChangeSelection callback', () => {
@@ -322,13 +303,11 @@ describe( 'useResponseNavigation', () => {
 				useResponseNavigation( {
 					onChangeSelection: undefined,
 					record: mockRecords[ 0 ],
-					setRecord: mockSetRecord,
 				} )
 			);
 
 			// Should not throw when onChangeSelection is undefined
 			expect( () => result.current.handleNext() ).not.toThrow();
-			expect( mockSetRecord ).toHaveBeenCalledWith( mockRecords[ 1 ] );
 		} );
 	} );
 
@@ -355,7 +334,6 @@ describe( 'useResponseNavigation', () => {
 				useResponseNavigation( {
 					onChangeSelection: mockOnChangeSelection,
 					record: mockRecords[ 0 ],
-					setRecord: mockSetRecord,
 				} )
 			);
 
@@ -366,7 +344,7 @@ describe( 'useResponseNavigation', () => {
 			// Navigation should not work with null records
 			result.current.handleNext();
 			result.current.handlePrevious();
-			expect( mockSetRecord ).not.toHaveBeenCalled();
+			expect( mockOnChangeSelection ).not.toHaveBeenCalled();
 		} );
 
 		it( 'should handle record being null', () => {
@@ -374,7 +352,6 @@ describe( 'useResponseNavigation', () => {
 				useResponseNavigation( {
 					onChangeSelection: mockOnChangeSelection,
 					record: null,
-					setRecord: mockSetRecord,
 				} )
 			);
 
@@ -389,7 +366,6 @@ describe( 'useResponseNavigation', () => {
 					useResponseNavigation( {
 						onChangeSelection: mockOnChangeSelection,
 						record,
-						setRecord: mockSetRecord,
 					} ),
 				{
 					initialProps: { record: mockRecords[ 0 ] },
@@ -413,7 +389,6 @@ describe( 'useResponseNavigation', () => {
 				useResponseNavigation( {
 					onChangeSelection: mockOnChangeSelection,
 					record: mockRecords[ 1 ],
-					setRecord: mockSetRecord,
 				} )
 			);
 
@@ -452,7 +427,6 @@ describe( 'useResponseNavigation', () => {
 				useResponseNavigation( {
 					onChangeSelection: mockOnChangeSelection,
 					record: mockRecords[ 1 ],
-					setRecord: mockSetRecord,
 				} )
 			);
 

--- a/projects/packages/forms/tests/js/dashboard/hooks/use-response-navigation.test.jsx
+++ b/projects/packages/forms/tests/js/dashboard/hooks/use-response-navigation.test.jsx
@@ -228,6 +228,7 @@ describe( 'useResponseNavigation', () => {
 					onChangeSelection: mockOnChangeSelection,
 					record: mockRecords[ 0 ],
 					setRecord: mockSetRecord,
+					isMobile: true,
 				} )
 			);
 
@@ -243,6 +244,7 @@ describe( 'useResponseNavigation', () => {
 					onChangeSelection: mockOnChangeSelection,
 					record: mockRecords[ 1 ],
 					setRecord: mockSetRecord,
+					isMobile: true,
 				} )
 			);
 
@@ -309,6 +311,7 @@ describe( 'useResponseNavigation', () => {
 					onChangeSelection: null,
 					record: mockRecords[ 0 ],
 					setRecord: mockSetRecord,
+					isMobile: true,
 				} )
 			);
 
@@ -323,6 +326,7 @@ describe( 'useResponseNavigation', () => {
 					onChangeSelection: undefined,
 					record: mockRecords[ 0 ],
 					setRecord: mockSetRecord,
+					isMobile: true,
 				} )
 			);
 

--- a/projects/packages/forms/tests/js/dashboard/hooks/use-response-navigation.test.jsx
+++ b/projects/packages/forms/tests/js/dashboard/hooks/use-response-navigation.test.jsx
@@ -17,6 +17,7 @@ const mockedUseInboxData = useInboxData;
 const mockedGetItemId = getItemId;
 
 describe( 'useResponseNavigation', () => {
+	const mockSetRecord = jest.fn();
 	const mockOnChangeSelection = jest.fn();
 
 	// Mock response data
@@ -101,6 +102,7 @@ describe( 'useResponseNavigation', () => {
 				useResponseNavigation( {
 					onChangeSelection: mockOnChangeSelection,
 					record: mockRecords[ 0 ],
+					setRecord: mockSetRecord,
 				} )
 			);
 
@@ -114,6 +116,7 @@ describe( 'useResponseNavigation', () => {
 				useResponseNavigation( {
 					onChangeSelection: mockOnChangeSelection,
 					record: mockRecords[ 1 ],
+					setRecord: mockSetRecord,
 				} )
 			);
 
@@ -127,6 +130,7 @@ describe( 'useResponseNavigation', () => {
 				useResponseNavigation( {
 					onChangeSelection: mockOnChangeSelection,
 					record: mockRecords[ 2 ],
+					setRecord: mockSetRecord,
 				} )
 			);
 
@@ -145,6 +149,7 @@ describe( 'useResponseNavigation', () => {
 				useResponseNavigation( {
 					onChangeSelection: mockOnChangeSelection,
 					record: unknownRecord,
+					setRecord: mockSetRecord,
 				} )
 			);
 
@@ -175,6 +180,7 @@ describe( 'useResponseNavigation', () => {
 				useResponseNavigation( {
 					onChangeSelection: mockOnChangeSelection,
 					record: mockRecords[ 0 ],
+					setRecord: mockSetRecord,
 				} )
 			);
 
@@ -205,6 +211,7 @@ describe( 'useResponseNavigation', () => {
 				useResponseNavigation( {
 					onChangeSelection: mockOnChangeSelection,
 					record: mockRecords[ 0 ],
+					setRecord: mockSetRecord,
 				} )
 			);
 
@@ -220,11 +227,13 @@ describe( 'useResponseNavigation', () => {
 				useResponseNavigation( {
 					onChangeSelection: mockOnChangeSelection,
 					record: mockRecords[ 0 ],
+					setRecord: mockSetRecord,
 				} )
 			);
 
 			result.current.handleNext();
 
+			expect( mockSetRecord ).toHaveBeenCalledWith( mockRecords[ 1 ] );
 			expect( mockOnChangeSelection ).toHaveBeenCalledWith( [ '2' ] );
 		} );
 
@@ -233,11 +242,13 @@ describe( 'useResponseNavigation', () => {
 				useResponseNavigation( {
 					onChangeSelection: mockOnChangeSelection,
 					record: mockRecords[ 1 ],
+					setRecord: mockSetRecord,
 				} )
 			);
 
 			result.current.handlePrevious();
 
+			expect( mockSetRecord ).toHaveBeenCalledWith( mockRecords[ 0 ] );
 			expect( mockOnChangeSelection ).toHaveBeenCalledWith( [ '1' ] );
 		} );
 
@@ -246,11 +257,13 @@ describe( 'useResponseNavigation', () => {
 				useResponseNavigation( {
 					onChangeSelection: mockOnChangeSelection,
 					record: mockRecords[ 2 ],
+					setRecord: mockSetRecord,
 				} )
 			);
 
 			result.current.handleNext();
 
+			expect( mockSetRecord ).not.toHaveBeenCalled();
 			expect( mockOnChangeSelection ).not.toHaveBeenCalled();
 		} );
 
@@ -259,11 +272,13 @@ describe( 'useResponseNavigation', () => {
 				useResponseNavigation( {
 					onChangeSelection: mockOnChangeSelection,
 					record: mockRecords[ 0 ],
+					setRecord: mockSetRecord,
 				} )
 			);
 
 			result.current.handlePrevious();
 
+			expect( mockSetRecord ).not.toHaveBeenCalled();
 			expect( mockOnChangeSelection ).not.toHaveBeenCalled();
 		} );
 
@@ -277,12 +292,14 @@ describe( 'useResponseNavigation', () => {
 				useResponseNavigation( {
 					onChangeSelection: mockOnChangeSelection,
 					record: unknownRecord,
+					setRecord: mockSetRecord,
 				} )
 			);
 
 			result.current.handleNext();
 			result.current.handlePrevious();
 
+			expect( mockSetRecord ).not.toHaveBeenCalled();
 			expect( mockOnChangeSelection ).not.toHaveBeenCalled();
 		} );
 
@@ -291,11 +308,13 @@ describe( 'useResponseNavigation', () => {
 				useResponseNavigation( {
 					onChangeSelection: null,
 					record: mockRecords[ 0 ],
+					setRecord: mockSetRecord,
 				} )
 			);
 
 			// Should not throw when onChangeSelection is null
 			expect( () => result.current.handleNext() ).not.toThrow();
+			expect( mockSetRecord ).toHaveBeenCalledWith( mockRecords[ 1 ] );
 		} );
 
 		it( 'should handle undefined onChangeSelection callback', () => {
@@ -303,11 +322,13 @@ describe( 'useResponseNavigation', () => {
 				useResponseNavigation( {
 					onChangeSelection: undefined,
 					record: mockRecords[ 0 ],
+					setRecord: mockSetRecord,
 				} )
 			);
 
 			// Should not throw when onChangeSelection is undefined
 			expect( () => result.current.handleNext() ).not.toThrow();
+			expect( mockSetRecord ).toHaveBeenCalledWith( mockRecords[ 1 ] );
 		} );
 	} );
 
@@ -334,6 +355,7 @@ describe( 'useResponseNavigation', () => {
 				useResponseNavigation( {
 					onChangeSelection: mockOnChangeSelection,
 					record: mockRecords[ 0 ],
+					setRecord: mockSetRecord,
 				} )
 			);
 
@@ -344,6 +366,7 @@ describe( 'useResponseNavigation', () => {
 			// Navigation should not work with null records
 			result.current.handleNext();
 			result.current.handlePrevious();
+			expect( mockSetRecord ).not.toHaveBeenCalled();
 			expect( mockOnChangeSelection ).not.toHaveBeenCalled();
 		} );
 
@@ -352,6 +375,7 @@ describe( 'useResponseNavigation', () => {
 				useResponseNavigation( {
 					onChangeSelection: mockOnChangeSelection,
 					record: null,
+					setRecord: mockSetRecord,
 				} )
 			);
 
@@ -366,6 +390,7 @@ describe( 'useResponseNavigation', () => {
 					useResponseNavigation( {
 						onChangeSelection: mockOnChangeSelection,
 						record,
+						setRecord: mockSetRecord,
 					} ),
 				{
 					initialProps: { record: mockRecords[ 0 ] },
@@ -389,6 +414,7 @@ describe( 'useResponseNavigation', () => {
 				useResponseNavigation( {
 					onChangeSelection: mockOnChangeSelection,
 					record: mockRecords[ 1 ],
+					setRecord: mockSetRecord,
 				} )
 			);
 
@@ -427,6 +453,7 @@ describe( 'useResponseNavigation', () => {
 				useResponseNavigation( {
 					onChangeSelection: mockOnChangeSelection,
 					record: mockRecords[ 1 ],
+					setRecord: mockSetRecord,
 				} )
 			);
 

--- a/projects/plugins/jetpack/changelog/add-keyboard-navigation-forms-dashboard
+++ b/projects/plugins/jetpack/changelog/add-keyboard-navigation-forms-dashboard
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Forms: add up, down and esc keyboard navigation to view through reponses really quickly


### PR DESCRIPTION
This Pr add Up and Down and ESC key to go though the form respones really quickly. 

FORM-NEW 

## Proposed changes:
* Add keyboard navigation when you have the Form response open so that you can view form responses really quickly. 

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
No

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Go to the Form Responses Dashboard. 
Open up a Response. 
Push the up, down or esc key. Do they work as you would expect? 
