### PR TITLE
Forms: Update to use up and down icons

### DIFF
--- a/projects/packages/forms/changelog/update-use-up-and-down-icons
+++ b/projects/packages/forms/changelog/update-use-up-and-down-icons
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Forms: update arrows to be up and down vs left and right.

--- a/projects/packages/forms/src/dashboard/components/response-navigation/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/response-navigation/index.tsx
@@ -3,7 +3,7 @@
  */
 import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { close, chevronLeft, chevronRight } from '@wordpress/icons';
+import { close, chevronUp, chevronDown } from '@wordpress/icons';
 
 type ResponseNavigationProps = {
 	hasNext: boolean;
@@ -26,7 +26,7 @@ const ResponseNavigation = ( {
 				<Button
 					accessibleWhenDisabled={ true }
 					disabled={ ! hasPrevious }
-					icon={ chevronLeft }
+					icon={ chevronUp }
 					label={ __( 'Previous', 'jetpack-forms' ) }
 					onClick={ onPrevious }
 					showTooltip={ true }
@@ -38,7 +38,7 @@ const ResponseNavigation = ( {
 				<Button
 					accessibleWhenDisabled={ true }
 					disabled={ ! hasNext }
-					icon={ chevronRight }
+					icon={ chevronDown }
 					label={ __( 'Next', 'jetpack-forms' ) }
 					onClick={ onNext }
 					showTooltip={ true }


### PR DESCRIPTION
Before:
<img width="431" height="64" alt="Screenshot 2025-11-06 at 9 59 13 PM" src="https://github.com/user-attachments/assets/f83ec1d9-c42d-4939-9a6d-0a402507e727" />

After:
<img width="511" height="71" alt="Screenshot 2025-11-06 at 9 55 43 PM" src="https://github.com/user-attachments/assets/0e1b07a9-ccb0-483e-b144-abc5bc66e656" />

## Proposed changes:
* Update the icons

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
No

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Visit the responses dashboard. 
View a response. Notice that the icons are now up and down vs left or right.  
