### PR TITLE
Jetpack Sync: Update Dedicated Sync locking logic for spawning requests

### DIFF
--- a/projects/packages/sync/.phan/baseline.php
+++ b/projects/packages/sync/.phan/baseline.php
@@ -28,7 +28,6 @@ return [
     // PhanTypePossiblyInvalidDimOffset : 2 occurrences
     // PhanParamTooManyCallable : 1 occurrence
     // PhanPluginUseReturnValueInternalKnown : 1 occurrence
-    // PhanTypeInvalidLeftOperandOfNumericOp : 1 occurrence
     // PhanTypeMismatchArgumentNullableInternal : 1 occurrence
     // PhanTypeMismatchDeclaredParam : 1 occurrence
     // PhanTypeMismatchDefault : 1 occurrence
@@ -39,7 +38,6 @@ return [
     'file_suppressions' => [
         'src/class-actions.php' => ['PhanPluginSimplifyExpressionBool'],
         'src/class-data-settings.php' => ['PhanPluginDuplicateConditionalNullCoalescing'],
-        'src/class-dedicated-sender.php' => ['PhanTypeInvalidLeftOperandOfNumericOp'],
         'src/class-functions.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchReturnProbablyReal', 'PhanTypePossiblyInvalidDimOffset'],
         'src/class-listener.php' => ['PhanNonClassMethodCall', 'PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeArraySuspicious', 'PhanTypeExpectedObjectPropAccess', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchReturn', 'PhanTypeMismatchReturnProbablyReal'],
         'src/class-lock.php' => ['PhanTypeMismatchReturn'],

--- a/projects/packages/sync/changelog/update-dedicated-sync-lock
+++ b/projects/packages/sync/changelog/update-dedicated-sync-lock
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Jetpack Sync: Update Dedicated Sync locking logic for spawning requests 

--- a/projects/packages/sync/src/class-actions.php
+++ b/projects/packages/sync/src/class-actions.php
@@ -364,6 +364,10 @@ class Actions {
 
 		$queue      = self::$sender->get_sync_queue();
 		$full_queue = self::$sender->get_full_sync_queue();
+		// We are sending the expiry vs the actual dedicated lock value to ensure backwards compatibility
+		// with previous versions where the lock value was a timestamp.
+		$dedicated_sync_lock_option_name  = Dedicated_Sender::DEDICATED_SYNC_REQUEST_LOCK_OPTION_NAME;
+		$dedicated_sync_lock_expires_name = $dedicated_sync_lock_option_name . '_expires';
 
 		$debug['debug_details']['sync_locks'] = array(
 			'retry_time_sync'                       => get_option( self::RETRY_AFTER_PREFIX . 'sync' ),
@@ -372,7 +376,7 @@ class Actions {
 			'next_sync_time_full_sync'              => self::$sender->get_next_sync_time( 'full_sync' ),
 			'queue_locked_sync'                     => $queue->is_locked(),
 			'queue_locked_full_sync'                => $full_queue->is_locked(),
-			'dedicated_sync_request_lock'           => \Jetpack_Options::get_raw_option( Dedicated_Sender::DEDICATED_SYNC_REQUEST_LOCK_OPTION_NAME, null ),
+			'dedicated_sync_request_lock'           => \Jetpack_Options::get_raw_option( $dedicated_sync_lock_expires_name, null ),
 			'dedicated_sync_temporary_disable_flag' => get_transient( Dedicated_Sender::DEDICATED_SYNC_TEMPORARY_DISABLE_FLAG ),
 		);
 

--- a/projects/packages/sync/src/class-actions.php
+++ b/projects/packages/sync/src/class-actions.php
@@ -174,9 +174,8 @@ class Actions {
 			self::should_initialize_sender()
 		) ) {
 			self::initialize_sender();
-			if ( ! Constants::is_true( 'DOING_CRON' ) ) {
-				add_action( 'shutdown', array( self::$sender, 'do_sync' ), 9998 );
-			}
+			add_action( 'shutdown', array( self::$sender, 'do_sync' ), 9998 );
+
 			if ( self::should_initialize_sender( true ) ) {
 				add_action( 'shutdown', array( self::$sender, 'do_full_sync' ), 9999 );
 			}
@@ -804,7 +803,15 @@ class Actions {
 				break;
 			}
 
-			$result = 'full_sync' === $type ? self::$sender->do_full_sync() : self::$sender->do_sync_and_set_delays( self::$sender->get_sync_queue() );
+			/**
+			 * Only try to sync once if Dedicated Sync is enabled. Dedicated Sync has its own requeueing mechanism
+			 * that will re-run it if there are items in the queue at the end.
+			 */
+			if ( 'sync' === $type && $executions >= 1 && Settings::is_dedicated_sync_enabled() ) {
+				break;
+			}
+
+			$result = 'full_sync' === $type ? self::$sender->do_full_sync() : self::$sender->do_sync();
 
 			// # of send actions performed.
 			++$executions;

--- a/projects/packages/sync/src/class-actions.php
+++ b/projects/packages/sync/src/class-actions.php
@@ -732,6 +732,7 @@ class Actions {
 				if ( $delay > 15 ) {
 					break;
 				} elseif ( $delay > 0 ) {
+					Dedicated_Sender::try_lock_spawn_request();
 					sleep( (int) $delay );
 				}
 			}

--- a/projects/packages/sync/src/class-actions.php
+++ b/projects/packages/sync/src/class-actions.php
@@ -1134,7 +1134,11 @@ class Actions {
 		delete_option( self::RETRY_AFTER_PREFIX . 'sync' );
 		delete_option( self::RETRY_AFTER_PREFIX . 'full_sync' );
 		// Dedicated sync locks.
-		\Jetpack_Options::delete_raw_option( Dedicated_Sender::DEDICATED_SYNC_REQUEST_LOCK_OPTION_NAME );
+		$dedicated_sync_lock_option         = Dedicated_Sender::DEDICATED_SYNC_REQUEST_LOCK_OPTION_NAME;
+		$dedicated_sync_lock_expires_option = $dedicated_sync_lock_option . '_expires';
+		\Jetpack_Options::delete_raw_option( $dedicated_sync_lock_option );
+		\Jetpack_Options::delete_raw_option( $dedicated_sync_lock_expires_option );
+
 		delete_transient( Dedicated_Sender::DEDICATED_SYNC_TEMPORARY_DISABLE_FLAG );
 		// Lock for disabling Sync sending temporarily.
 		delete_transient( Sender::TEMP_SYNC_DISABLE_TRANSIENT_NAME );

--- a/projects/packages/sync/src/class-actions.php
+++ b/projects/packages/sync/src/class-actions.php
@@ -736,15 +736,7 @@ class Actions {
 				break;
 			}
 
-			/**
-			 * Only try to sync once if Dedicated Sync is enabled. Dedicated Sync has its own requeueing mechanism
-			 * that will re-run it if there are items in the queue at the end.
-			 */
-			if ( 'sync' === $type && $executions >= 1 && Settings::is_dedicated_sync_enabled() ) {
-				break;
-			}
-
-			$result = 'full_sync' === $type ? self::$sender->do_full_sync() : self::$sender->do_sync();
+			$result = 'full_sync' === $type ? self::$sender->do_full_sync() : self::$sender->do_sync_and_set_delays( self::$sender->get_sync_queue() );
 
 			// # of send actions performed.
 			++$executions;

--- a/projects/packages/sync/src/class-actions.php
+++ b/projects/packages/sync/src/class-actions.php
@@ -690,7 +690,45 @@ class Actions {
 	 * @static
 	 */
 	public static function do_cron_sync() {
-		self::do_cron_sync_by_type( 'sync' );
+		if ( ! self::sync_allowed() ) {
+			return;
+		}
+
+		self::initialize_sender();
+
+		$time_limit = Settings::get_setting( 'cron_sync_time_limit' );
+		$start_time = time();
+		$executions = 0;
+
+		$lock_id = Dedicated_Sender::try_lock_spawn_request();
+
+		do {
+			$next_sync_time = self::$sender->get_next_sync_time( 'sync' );
+
+			if ( $next_sync_time ) {
+				$delay = $next_sync_time - time() + 1;
+				if ( $delay > 15 ) {
+					break;
+				} elseif ( $delay > 0 ) {
+					sleep( (int) $delay );
+				}
+			}
+
+			$result = self::$sender->do_sync_and_set_delays( self::$sender->get_sync_queue() );
+
+			if ( is_wp_error( $result ) && in_array( $result->get_error_code(), array( 'unclosed_buffer', 'sync_throttled' ), true ) ) {
+				$result = true; // Give it some time.
+			}
+			// # of send actions performed.
+			++$executions;
+
+		} while ( $result && ! is_wp_error( $result ) && ( $start_time + $time_limit ) > time() );
+
+		if ( $lock_id ) {
+			Dedicated_Sender::try_release_lock_spawn_request( $lock_id );
+		}
+
+		return $executions;
 	}
 
 	/**
@@ -700,7 +738,31 @@ class Actions {
 	 * @static
 	 */
 	public static function do_cron_full_sync() {
-		self::do_cron_sync_by_type( 'full_sync' );
+		if ( ! self::sync_allowed() ) {
+			return;
+		}
+
+		self::initialize_sender();
+
+		$executions = 0;
+
+		$next_sync_time = self::$sender->get_next_sync_time( 'full_sync' );
+
+		if ( $next_sync_time ) {
+			$delay = $next_sync_time - time() + 1;
+			if ( $delay > 15 ) {
+				return;
+			} elseif ( $delay > 0 ) {
+				sleep( (int) $delay );
+			}
+		}
+
+		// Explicitly only allow 1 do_full_sync call until issue with Immediate Full Sync is resolved.
+		// For more context see p1HpG7-9pe-p2.
+		self::$sender->do_full_sync();
+		++$executions;
+
+		return $executions;
 	}
 
 	/**
@@ -732,7 +794,6 @@ class Actions {
 				if ( $delay > 15 ) {
 					break;
 				} elseif ( $delay > 0 ) {
-					Dedicated_Sender::try_lock_spawn_request();
 					sleep( (int) $delay );
 				}
 			}

--- a/projects/packages/sync/src/class-actions.php
+++ b/projects/packages/sync/src/class-actions.php
@@ -174,7 +174,9 @@ class Actions {
 			self::should_initialize_sender()
 		) ) {
 			self::initialize_sender();
-			add_action( 'shutdown', array( self::$sender, 'do_sync' ), 9998 );
+			if ( ! Constants::is_true( 'DOING_CRON' ) ) {
+				add_action( 'shutdown', array( self::$sender, 'do_sync' ), 9998 );
+			}
 			if ( self::should_initialize_sender( true ) ) {
 				add_action( 'shutdown', array( self::$sender, 'do_full_sync' ), 9999 );
 			}

--- a/projects/packages/sync/src/class-dedicated-sender.php
+++ b/projects/packages/sync/src/class-dedicated-sender.php
@@ -133,7 +133,7 @@ class Dedicated_Sender {
 			return new WP_Error( 'empty_queue_' . $queue->id );
 		}
 
-		if ( get_transient( self::TEMP_SYNC_DISABLE_TRANSIENT_NAME ) ) {
+		if ( get_transient( Sender::TEMP_SYNC_DISABLE_TRANSIENT_NAME ) ) {
 			return new WP_Error( 'sender_temporarily_disabled_while_pulling' );
 		}
 

--- a/projects/packages/sync/src/class-dedicated-sender.php
+++ b/projects/packages/sync/src/class-dedicated-sender.php
@@ -201,36 +201,50 @@ class Dedicated_Sender {
 	 * To avoid spawning multiple requests at the same time, we need to have a quick lock that will
 	 * allow only a single request to continue if we try to spawn multiple at the same time.
 	 *
-	 * @return false|mixed|string
+	 * @return string|false
 	 */
 	public static function try_lock_spawn_request() {
-		$current_microtime = (string) microtime( true );
+		$option_name  = self::DEDICATED_SYNC_REQUEST_LOCK_OPTION_NAME;
+		$expires_name = $option_name . '_expires';
+		$ttl          = self::DEDICATED_SYNC_REQUEST_LOCK_TIMEOUT;
+		$lock_id      = wp_generate_uuid4();
+		$now          = microtime( true );
 
+		// Fast path: external object cache is atomic.
 		if ( wp_using_ext_object_cache() ) {
-			if ( true !== wp_cache_add( self::DEDICATED_SYNC_REQUEST_LOCK_OPTION_NAME, $current_microtime, 'jetpack', self::DEDICATED_SYNC_REQUEST_LOCK_TIMEOUT ) ) {
-				// Cache lock has been claimed already.
-				return false;
+			if ( wp_cache_add( $option_name, $lock_id, 'jetpack', $ttl ) ) {
+				return $lock_id;
 			}
-
-			return $current_microtime;
+			return false; // Worker already active
 		}
 
-		$current_lock_value = \Jetpack_Options::get_raw_option( self::DEDICATED_SYNC_REQUEST_LOCK_OPTION_NAME, null );
+		global $wpdb;
 
-		if ( ! empty( $current_lock_value ) ) {
-			// Check if time has passed to overwrite the lock.
-			if ( is_numeric( $current_lock_value ) && ( ( $current_microtime - $current_lock_value ) < self::DEDICATED_SYNC_REQUEST_LOCK_TIMEOUT ) ) {
-				// Still in previous lock, quit
-				return false;
-			}
-
-			// If the value is not numeric (float/current time), we want to just overwrite it and continue.
+		// 1) Check & clear expired lock (best effort; failure here is harmless)
+		$expiry = \Jetpack_Options::get_raw_option( $expires_name, 0 );
+		if ( $expiry && $expiry < $now ) {
+			\Jetpack_Options::delete_raw_option( $option_name );
+			\Jetpack_Options::delete_raw_option( $expires_name );
 		}
 
-		// Update. We don't want it to autoload, as we want to fetch it right before the checks.
-		\Jetpack_Options::update_raw_option( self::DEDICATED_SYNC_REQUEST_LOCK_OPTION_NAME, $current_microtime, false );
+		// 2) Atomic acquisition: INSERT IGNORE (succeeds only if the lock doesn't exist)
+		$inserted = $wpdb->query( // phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching --- Ensure atomicity.
+			$wpdb->prepare(
+				"INSERT IGNORE INTO $wpdb->options ( option_name, option_value, autoload )
+	             VALUES ( %s, %s, 'no' )",
+				$option_name,
+				maybe_serialize( $lock_id )
+			)
+		);
 
-		return $current_microtime;
+		if ( $inserted ) {
+			// 3) We own the lock — store expiry separately
+			\Jetpack_Options::update_raw_option( $expires_name, $now + $ttl, false );
+			return $lock_id; // Success
+		}
+
+		// Lock already present → normal state → do not spawn
+		return false;
 	}
 
 	/**
@@ -247,12 +261,13 @@ class Dedicated_Sender {
 		}
 
 		// If it's still not a valid lock_id, throw an error and let the lock process figure it out.
-		if ( empty( $lock_id ) || ! is_numeric( $lock_id ) ) {
+		if ( empty( $lock_id ) ) {
 			return new WP_Error( 'dedicated_request_lock_invalid', 'Invalid lock_id supplied for unlock' );
 		}
 
 		if ( wp_using_ext_object_cache() ) {
-			if ( (string) $lock_id === wp_cache_get( self::DEDICATED_SYNC_REQUEST_LOCK_OPTION_NAME, 'jetpack', true ) ) {
+			$cached = wp_cache_get( self::DEDICATED_SYNC_REQUEST_LOCK_OPTION_NAME, 'jetpack', true );
+			if ( (string) $lock_id === $cached ) {
 				wp_cache_delete( self::DEDICATED_SYNC_REQUEST_LOCK_OPTION_NAME, 'jetpack' );
 
 				return true;
@@ -263,6 +278,7 @@ class Dedicated_Sender {
 
 		// If this is the flow that has the lock, let's release it so we can spawn other requests afterwards
 		$current_lock_value = \Jetpack_Options::get_raw_option( self::DEDICATED_SYNC_REQUEST_LOCK_OPTION_NAME, null );
+
 		if ( (string) $lock_id === $current_lock_value ) {
 			\Jetpack_Options::delete_raw_option( self::DEDICATED_SYNC_REQUEST_LOCK_OPTION_NAME );
 			return true;
@@ -278,7 +294,7 @@ class Dedicated_Sender {
 	 */
 	public static function get_request_lock_id_from_request() {
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		if ( ! isset( $_GET[ self::DEDICATED_SYNC_REQUEST_LOCK_QUERY_PARAM_NAME ] ) || ! is_numeric( $_GET[ self::DEDICATED_SYNC_REQUEST_LOCK_QUERY_PARAM_NAME ] ) ) {
+		if ( ! isset( $_GET[ self::DEDICATED_SYNC_REQUEST_LOCK_QUERY_PARAM_NAME ] ) ) {
 			return null;
 		}
 

--- a/projects/packages/sync/src/class-dedicated-sender.php
+++ b/projects/packages/sync/src/class-dedicated-sender.php
@@ -222,7 +222,7 @@ class Dedicated_Sender {
 
 		// 1) Check & clear expired lock (best effort; failure here is harmless)
 		$expiry = \Jetpack_Options::get_raw_option( $expires_name, 0 );
-		if ( $expiry && $expiry < $now ) {
+		if ( $expiry && (float) $expiry < $now ) {
 			\Jetpack_Options::delete_raw_option( $option_name );
 			\Jetpack_Options::delete_raw_option( $expires_name );
 		}
@@ -292,7 +292,7 @@ class Dedicated_Sender {
 	 *
 	 * @return array|string|string[]|null
 	 */
-	public static function get_request_lock_id_from_request() {
+	private static function get_request_lock_id_from_request() {
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		if ( ! isset( $_GET[ self::DEDICATED_SYNC_REQUEST_LOCK_QUERY_PARAM_NAME ] ) ) {
 			return null;

--- a/projects/packages/sync/src/class-dedicated-sender.php
+++ b/projects/packages/sync/src/class-dedicated-sender.php
@@ -297,7 +297,7 @@ class Dedicated_Sender {
 	 *
 	 * @return array|string|string[]|null
 	 */
-	private static function get_request_lock_id_from_request() {
+	public static function get_request_lock_id_from_request() {
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		if ( ! isset( $_GET[ self::DEDICATED_SYNC_REQUEST_LOCK_QUERY_PARAM_NAME ] ) ) {
 			return null;

--- a/projects/packages/sync/src/class-dedicated-sender.php
+++ b/projects/packages/sync/src/class-dedicated-sender.php
@@ -43,7 +43,7 @@ class Dedicated_Sender {
 	 *
 	 * 5 seconds as default value seems sane, but we might want to adjust that in the future.
 	 */
-	const DEDICATED_SYNC_REQUEST_LOCK_TIMEOUT = 5;
+	const DEDICATED_SYNC_REQUEST_LOCK_TIMEOUT = 60;
 
 	/**
 	 * The query parameter name to use when passing the current lock id.
@@ -211,12 +211,14 @@ class Dedicated_Sender {
 				// Cache lock has been claimed already.
 				return false;
 			}
+
+			return $current_microtime;
 		}
 
 		$current_lock_value = \Jetpack_Options::get_raw_option( self::DEDICATED_SYNC_REQUEST_LOCK_OPTION_NAME, null );
 
 		if ( ! empty( $current_lock_value ) ) {
-			// Check if time has passed to overwrite the lock - min 5s?
+			// Check if time has passed to overwrite the lock.
 			if ( is_numeric( $current_lock_value ) && ( ( $current_microtime - $current_lock_value ) < self::DEDICATED_SYNC_REQUEST_LOCK_TIMEOUT ) ) {
 				// Still in previous lock, quit
 				return false;
@@ -227,16 +229,8 @@ class Dedicated_Sender {
 
 		// Update. We don't want it to autoload, as we want to fetch it right before the checks.
 		\Jetpack_Options::update_raw_option( self::DEDICATED_SYNC_REQUEST_LOCK_OPTION_NAME, $current_microtime, false );
-		// Give some time for the update to happen
-		usleep( wp_rand( 1000, 3000 ) );
 
-		$updated_value = \Jetpack_Options::get_raw_option( self::DEDICATED_SYNC_REQUEST_LOCK_OPTION_NAME, null );
-
-		if ( $updated_value === $current_microtime ) {
-			return $current_microtime;
-		}
-
-		return false;
+		return $current_microtime;
 	}
 
 	/**
@@ -260,7 +254,11 @@ class Dedicated_Sender {
 		if ( wp_using_ext_object_cache() ) {
 			if ( (string) $lock_id === wp_cache_get( self::DEDICATED_SYNC_REQUEST_LOCK_OPTION_NAME, 'jetpack', true ) ) {
 				wp_cache_delete( self::DEDICATED_SYNC_REQUEST_LOCK_OPTION_NAME, 'jetpack' );
+
+				return true;
 			}
+
+			return false;
 		}
 
 		// If this is the flow that has the lock, let's release it so we can spawn other requests afterwards

--- a/projects/packages/sync/src/class-dedicated-sender.php
+++ b/projects/packages/sync/src/class-dedicated-sender.php
@@ -221,8 +221,9 @@ class Dedicated_Sender {
 		global $wpdb;
 
 		// 1) Check & clear expired lock (best effort; failure here is harmless)
-		$expiry = \Jetpack_Options::get_raw_option( $expires_name, 0 );
-		if ( $expiry && (float) $expiry < $now ) {
+		$expiry = (float) \Jetpack_Options::get_raw_option( $expires_name, 0 );
+		if ( ! $expiry || $expiry < $now ) {
+			// Either missing (edge case) or expired → clean up
 			\Jetpack_Options::delete_raw_option( $option_name );
 			\Jetpack_Options::delete_raw_option( $expires_name );
 		}

--- a/projects/packages/sync/src/class-dedicated-sender.php
+++ b/projects/packages/sync/src/class-dedicated-sender.php
@@ -412,6 +412,13 @@ class Dedicated_Sender {
 			}
 		}
 
+		$current_setting = Settings::is_dedicated_sync_enabled();
+
+		// No need to update if current setting matches header value.
+		if ( $current_setting === (bool) $dedicated_sync_enabled ) {
+			return $current_setting;
+		}
+
 		Settings::update_settings(
 			array(
 				'dedicated_sync_enabled' => $dedicated_sync_enabled,

--- a/projects/packages/sync/src/class-dedicated-sender.php
+++ b/projects/packages/sync/src/class-dedicated-sender.php
@@ -133,6 +133,10 @@ class Dedicated_Sender {
 			return new WP_Error( 'empty_queue_' . $queue->id );
 		}
 
+		if ( get_transient( self::TEMP_SYNC_DISABLE_TRANSIENT_NAME ) ) {
+			return new WP_Error( 'sender_temporarily_disabled_while_pulling' );
+		}
+
 		// Return early if we've gotten a retry-after header response that is not expired.
 		$retry_time = get_option( Actions::RETRY_AFTER_PREFIX . $queue->id );
 		if ( $retry_time && $retry_time >= microtime( true ) ) {

--- a/projects/packages/sync/src/class-defaults.php
+++ b/projects/packages/sync/src/class-defaults.php
@@ -1120,7 +1120,7 @@ class Defaults {
 	 *
 	 * @var int Number of seconds.
 	 */
-	public static $default_sync_wait_threshold = 15;
+	public static $default_sync_wait_threshold = 10;
 
 	/**
 	 * Default wait between attempting to continue a full sync via requests.

--- a/projects/packages/sync/src/class-defaults.php
+++ b/projects/packages/sync/src/class-defaults.php
@@ -1120,7 +1120,7 @@ class Defaults {
 	 *
 	 * @var int Number of seconds.
 	 */
-	public static $default_sync_wait_threshold = 10;
+	public static $default_sync_wait_threshold = 15;
 
 	/**
 	 * Default wait between attempting to continue a full sync via requests.

--- a/projects/packages/sync/src/class-sender.php
+++ b/projects/packages/sync/src/class-sender.php
@@ -497,7 +497,7 @@ class Sender {
 			if ( 'wpcom_error' === $sync_result->get_error_code() ) {
 				$this->set_next_sync_time( time() + self::WPCOM_ERROR_SYNC_DELAY, $queue->id );
 			}
-		} elseif ( $exceeded_sync_wait_threshold ) {
+		} elseif ( $exceeded_sync_wait_threshold && ! Settings::is_doing_cron() ) {
 			// If we actually sent data and it took a while, wait before sending again.
 			$this->set_next_sync_time( time() + $this->get_sync_wait_time(), $queue->id );
 		}

--- a/projects/packages/sync/src/class-sender.php
+++ b/projects/packages/sync/src/class-sender.php
@@ -418,11 +418,11 @@ class Sender {
 			session_write_close();
 		}
 
-		// Output not used right now. Try to release dedicated sync lock
-		Dedicated_Sender::try_release_lock_spawn_request();
-
 		// Actually try to send Sync events.
 		$result = $this->do_sync_and_set_delays( $this->sync_queue );
+
+		// Output not used right now. Try to release dedicated sync lock
+		Dedicated_Sender::try_release_lock_spawn_request();
 
 		// If no errors occurred, re-spawn a dedicated Sync request.
 		if ( true === $result ) {

--- a/projects/packages/sync/tests/php/Actions_Test.php
+++ b/projects/packages/sync/tests/php/Actions_Test.php
@@ -130,6 +130,7 @@ class Actions_Test extends BaseTestCase {
 		update_option( Actions::RETRY_AFTER_PREFIX . 'full_sync', 'dummy' );
 		// Dedicated sync lock.
 		\Jetpack_Options::update_raw_option( Dedicated_Sender::DEDICATED_SYNC_REQUEST_LOCK_OPTION_NAME, 'dummy' );
+		\Jetpack_Options::update_raw_option( Dedicated_Sender::DEDICATED_SYNC_REQUEST_LOCK_OPTION_NAME . '_expires', 'dummy' );
 		// Queue locks.
 		$sync_queue = new Queue( 'sync' );
 		$this->assertTrue( $sync_queue->lock() );
@@ -145,6 +146,8 @@ class Actions_Test extends BaseTestCase {
 		$this->assertFalse( get_option( Sender::NEXT_SYNC_TIME_OPTION_NAME . '_full-sync-enqueue' ) );
 		$this->assertFalse( get_option( Actions::RETRY_AFTER_PREFIX . 'sync' ) );
 		$this->assertFalse( get_option( Actions::RETRY_AFTER_PREFIX . 'full_sync' ) );
+		$this->assertFalse( get_option( Dedicated_Sender::DEDICATED_SYNC_REQUEST_LOCK_OPTION_NAME ) );
+		$this->assertFalse( get_option( Dedicated_Sender::DEDICATED_SYNC_REQUEST_LOCK_OPTION_NAME . '_expires' ) );
 		$this->assertFalse( $sync_queue->is_locked() );
 		$this->assertFalse( $full_sync_queue->is_locked() );
 		$this->assertFalse( get_transient( Sender::TEMP_SYNC_DISABLE_TRANSIENT_NAME ) );

--- a/projects/packages/sync/tests/php/Dedicated_Sender_Test.php
+++ b/projects/packages/sync/tests/php/Dedicated_Sender_Test.php
@@ -318,6 +318,50 @@ class Dedicated_Sender_Test extends BaseTestCase {
 	}
 
 	/**
+	 * Tests Dedicated_Sender::test_try_lock_spawn_request without existing locks.
+	 *
+	 * @see Jetpack_Sync_Sender_Test for full coverage - Direct DB query in test_try_lock_spawn_request doesn't play well with WordDBLess
+	 */
+	public function test_try_lock_spawn_request_without_existing_locks() {
+		$result = Dedicated_Sender::try_lock_spawn_request();
+
+		$this->assertNotFalse( $result );
+
+		$lock_option_name  = Dedicated_Sender::DEDICATED_SYNC_REQUEST_LOCK_OPTION_NAME;
+		$lock_expires_name = $lock_option_name . '_expires';
+
+		$lock_expires_value = \Jetpack_Options::get_raw_option( $lock_expires_name );
+
+		$this->assertEqualsWithDelta( microtime( true ) + Dedicated_Sender::DEDICATED_SYNC_REQUEST_LOCK_TIMEOUT, $lock_expires_value, 0.01 );
+	}
+
+	/**
+	 * Tests Dedicated_Sender::test_try_release_lock_spawn_request.
+	 */
+	public function test_try_release_lock_spawn_request() {
+		$lock_option_name = Dedicated_Sender::DEDICATED_SYNC_REQUEST_LOCK_OPTION_NAME;
+		\Jetpack_Options::update_raw_option( $lock_option_name, 'dummy' );
+
+		$result = Dedicated_Sender::try_release_lock_spawn_request( 'dummy' );
+
+		$this->assertTrue( $result );
+		$this->assertEmpty( \Jetpack_Options::get_raw_option( $lock_option_name ) );
+	}
+
+	/**
+	 * Tests Dedicated_Sender::test_try_release_lock_spawn_request with invalid lock.
+	 */
+	public function test_try_release_lock_spawn_request_invalid_lock() {
+		$lock_option_name = Dedicated_Sender::DEDICATED_SYNC_REQUEST_LOCK_OPTION_NAME;
+		\Jetpack_Options::update_raw_option( $lock_option_name, 'dummy' );
+
+		$result = Dedicated_Sender::try_release_lock_spawn_request( 'invalid_lock' );
+
+		$this->assertFalse( $result );
+		$this->assertSame( 'dummy', \Jetpack_Options::get_raw_option( $lock_option_name ) );
+	}
+
+	/**
 	 * Intercept HTTP request to run Sync and mock the response.
 	 * Should be hooked on the `pre_http_request` filter.
 	 *

--- a/projects/packages/sync/tests/php/Dedicated_Sender_Test.php
+++ b/projects/packages/sync/tests/php/Dedicated_Sender_Test.php
@@ -179,6 +179,24 @@ class Dedicated_Sender_Test extends BaseTestCase {
 	}
 
 	/**
+	 * Tests Dedicated_Sender::maybe_change_dedicated_sync_status_from_wpcom_header.
+	 */
+	public function test_maybe_change_dedicated_sync_status_from_wpcom_header() {
+		$result = Dedicated_Sender::maybe_change_dedicated_sync_status_from_wpcom_header( 'on' );
+
+		$this->assertTrue( $result );
+
+		$dedicated_sync_status = Settings::get_setting( 'dedicated_sync_enabled' );
+		$this->assertTrue( (bool) $dedicated_sync_status );
+
+		$result = Dedicated_Sender::maybe_change_dedicated_sync_status_from_wpcom_header( 'off' );
+		$this->assertFalse( $result );
+
+		$dedicated_sync_status = Settings::get_setting( 'dedicated_sync_enabled' );
+		$this->assertFalse( (bool) $dedicated_sync_status );
+	}
+
+	/**
 	 * Tests Dedicated_Sender::maybe_enable_dedicated_sync when Sync has not been sending for a while.
 	 */
 	public function test_enable_dedicated_sync_when_temporary_disabled() {

--- a/projects/plugins/jetpack/changelog/update-dedicated-sync-lock
+++ b/projects/plugins/jetpack/changelog/update-dedicated-sync-lock
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Update Sync related unit tests
+
+

--- a/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Sender_Test.php
+++ b/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Sender_Test.php
@@ -678,7 +678,7 @@ class Jetpack_Sync_Sender_Test extends Jetpack_Sync_TestBase {
 		$this->assertSame( 'dummy', \Jetpack_Options::get_raw_option( $lock_option_name ) );
 
 		$lock_expires_value = (float) \Jetpack_Options::get_raw_option( $lock_expires_name );
-		$this->assertSame( round( $expires_at, 4 ), $lock_expires_value );
+		$this->assertEqualsWithDelta( round( $expires_at, 4 ), $lock_expires_value, 0.001 );
 	}
 
 	/**

--- a/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Sender_Test.php
+++ b/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Sender_Test.php
@@ -699,16 +699,17 @@ class Jetpack_Sync_Sender_Test extends Jetpack_Sync_TestBase {
 
 		$this->assertTrue( $this->dedicated_sync_request_spawned );
 		$this->assertNotSame( 'dummy', \Jetpack_Options::get_raw_option( $lock_option_name ) );
-		$this->assertNotFalse( \Jetpack_Options::get_raw_option( $lock_option_name ) );
+		$this->assertNotEmpty( \Jetpack_Options::get_raw_option( $lock_option_name ) );
 
 		$lock_expires_value = (float) \Jetpack_Options::get_raw_option( $lock_expires_name );
 		$this->assertEqualsWithDelta( microtime( true ) + Dedicated_Sender::DEDICATED_SYNC_REQUEST_LOCK_TIMEOUT, $lock_expires_value, 0.01 );
 	}
 
 	/**
-	 * Test do_sync will NOT spawn a dedicated Sync request with dedicated sync lock set but no expiry at all.
+	 * Test do_sync will spawn a dedicated Sync request with dedicated sync lock set but no expiry at all.
+	 * Edge case for preventing permanent starvation.
 	 */
-	public function test_do_sync_will_not_spawn_with_dedicated_sync_lock_set_without_expiry() {
+	public function test_do_sync_will_spawn_with_dedicated_sync_lock_set_without_expiry() {
 		Settings::update_settings( array( 'dedicated_sync_enabled' => 1 ) );
 		$lock_option_name = Dedicated_Sender::DEDICATED_SYNC_REQUEST_LOCK_OPTION_NAME;
 		\Jetpack_Options::update_raw_option( $lock_option_name, 'dummy' );
@@ -719,11 +720,12 @@ class Jetpack_Sync_Sender_Test extends Jetpack_Sync_TestBase {
 		$this->sender->do_sync();
 		remove_filter( 'pre_http_request', array( $this, 'pre_http_sync_request_spawned' ) );
 
-		$this->assertFalse( $this->dedicated_sync_request_spawned );
-		$this->assertSame( 'dummy', \Jetpack_Options::get_raw_option( $lock_option_name ) );
+		$this->assertTrue( $this->dedicated_sync_request_spawned );
+		$this->assertNotSame( 'dummy', \Jetpack_Options::get_raw_option( $lock_option_name ) );
+		$this->assertNotEmpty( \Jetpack_Options::get_raw_option( $lock_option_name ) );
 
-		$lock_expires_value = \Jetpack_Options::get_raw_option( $lock_expires_name, 0 );
-		$this->assertSame( 0, $lock_expires_value );
+		$lock_expires_value = (float) \Jetpack_Options::get_raw_option( $lock_expires_name );
+		$this->assertEqualsWithDelta( microtime( true ) + Dedicated_Sender::DEDICATED_SYNC_REQUEST_LOCK_TIMEOUT, $lock_expires_value, 0.01 );
 	}
 
 	/**

--- a/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Sender_Test.php
+++ b/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Sender_Test.php
@@ -649,6 +649,81 @@ class Jetpack_Sync_Sender_Test extends Jetpack_Sync_TestBase {
 		remove_filter( 'pre_http_request', array( $this, 'pre_http_sync_request_spawned' ) );
 
 		$this->assertTrue( $this->dedicated_sync_request_spawned );
+
+		$lock_option_name = Dedicated_Sender::DEDICATED_SYNC_REQUEST_LOCK_OPTION_NAME;
+		$this->assertNotFalse( \Jetpack_Options::get_raw_option( $lock_option_name ) );
+
+		$lock_expires_name  = $lock_option_name . '_expires';
+		$lock_expires_value = \Jetpack_Options::get_raw_option( $lock_expires_name );
+		$this->assertEqualsWithDelta( microtime( true ) + Dedicated_Sender::DEDICATED_SYNC_REQUEST_LOCK_TIMEOUT, $lock_expires_value, 0.01 );
+	}
+
+	/**
+	 * Test do_sync will NOT spawn a dedicated Sync request with dedicated sync lock.
+	 */
+	public function test_do_sync_will_not_spawn_with_dedicated_sync_lock_set() {
+		Settings::update_settings( array( 'dedicated_sync_enabled' => 1 ) );
+		$lock_option_name = Dedicated_Sender::DEDICATED_SYNC_REQUEST_LOCK_OPTION_NAME;
+		\Jetpack_Options::update_raw_option( $lock_option_name, 'dummy' );
+		$lock_expires_name = $lock_option_name . '_expires';
+		$expires_at        = microtime( true ) + 10;
+		\Jetpack_Options::update_raw_option( $lock_expires_name, $expires_at );
+		self::factory()->post->create();
+
+		add_filter( 'pre_http_request', array( $this, 'pre_http_sync_request_spawned' ), 10, 3 );
+		$this->sender->do_sync();
+		remove_filter( 'pre_http_request', array( $this, 'pre_http_sync_request_spawned' ) );
+
+		$this->assertFalse( $this->dedicated_sync_request_spawned );
+		$this->assertSame( 'dummy', \Jetpack_Options::get_raw_option( $lock_option_name ) );
+
+		$lock_expires_value = (float) \Jetpack_Options::get_raw_option( $lock_expires_name );
+		$this->assertSame( round( $expires_at, 4 ), $lock_expires_value );
+	}
+
+	/**
+	 * Test do_sync will spawn a dedicated Sync request with dedicated sync lock set but expired.
+	 */
+	public function test_do_sync_will_spawn_with_dedicated_sync_lock_expired() {
+		Settings::update_settings( array( 'dedicated_sync_enabled' => 1 ) );
+		$lock_option_name = Dedicated_Sender::DEDICATED_SYNC_REQUEST_LOCK_OPTION_NAME;
+		\Jetpack_Options::update_raw_option( $lock_option_name, 'dummy' );
+		$lock_expires_name = $lock_option_name . '_expires';
+		$expires_at        = microtime( true ) - Dedicated_Sender::DEDICATED_SYNC_REQUEST_LOCK_TIMEOUT;
+		\Jetpack_Options::update_raw_option( $lock_expires_name, $expires_at );
+		self::factory()->post->create();
+
+		add_filter( 'pre_http_request', array( $this, 'pre_http_sync_request_spawned' ), 10, 3 );
+		$this->sender->do_sync();
+		remove_filter( 'pre_http_request', array( $this, 'pre_http_sync_request_spawned' ) );
+
+		$this->assertTrue( $this->dedicated_sync_request_spawned );
+		$this->assertNotSame( 'dummy', \Jetpack_Options::get_raw_option( $lock_option_name ) );
+		$this->assertNotFalse( \Jetpack_Options::get_raw_option( $lock_option_name ) );
+
+		$lock_expires_value = (float) \Jetpack_Options::get_raw_option( $lock_expires_name );
+		$this->assertEqualsWithDelta( microtime( true ) + Dedicated_Sender::DEDICATED_SYNC_REQUEST_LOCK_TIMEOUT, $lock_expires_value, 0.01 );
+	}
+
+	/**
+	 * Test do_sync will NOT spawn a dedicated Sync request with dedicated sync lock set but no expiry at all.
+	 */
+	public function test_do_sync_will_not_spawn_with_dedicated_sync_lock_set_without_expiry() {
+		Settings::update_settings( array( 'dedicated_sync_enabled' => 1 ) );
+		$lock_option_name = Dedicated_Sender::DEDICATED_SYNC_REQUEST_LOCK_OPTION_NAME;
+		\Jetpack_Options::update_raw_option( $lock_option_name, 'dummy' );
+		$lock_expires_name = $lock_option_name . '_expires';
+		self::factory()->post->create();
+
+		add_filter( 'pre_http_request', array( $this, 'pre_http_sync_request_spawned' ), 10, 3 );
+		$this->sender->do_sync();
+		remove_filter( 'pre_http_request', array( $this, 'pre_http_sync_request_spawned' ) );
+
+		$this->assertFalse( $this->dedicated_sync_request_spawned );
+		$this->assertSame( 'dummy', \Jetpack_Options::get_raw_option( $lock_option_name ) );
+
+		$lock_expires_value = \Jetpack_Options::get_raw_option( $lock_expires_name, 0 );
+		$this->assertSame( 0, $lock_expires_value );
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Closes SYNC-160

### Incremental Sync flows

Incremental Sync is the process of sending actions that we are interested in tracking from the remote sites to WPCOM.
All those actions are stored in Sync's queue and sent to WPCOM via the following flows:
- **Old "default" Sync flow:** During the shutdown of POST requests / wp-admin requests or requests initiated by an administrator we check if Sync's queue has actions and is not locked and send those actions to WPCOM.
- **Dedicated Sync flow**: During the shutdown of **any** request, we check if Sync's queue has actions and is not locked and spawn a **non-blocking** dedicated Sync request to `jetpack/v4/jetpack/sync/spawn-sync`. The actual sending of actions to WPCOM happens as part of the dedicated Sync request.
- **Sync's `jetpack_sync_cron` cron job**: Every five minutes, `jetpack_sync_cron` runs in order to check Sync's queue and if it has actions send them to WPCOM
- **Sync Pulls**: This is initiated from WordPress.com under certain conditions, eg when Sync's queue grows too much. Instead of the site sending it's queue to WPCOM, WPCOM is pulling the queue by making requests to `jetpack/v4/sync/checkout` 

### How and why the current PR affects Incremental Sync

**Dedicated Sync flow**

Independently of the existing Sync locks, we had introduced a special lock only for Dedicated Sync flow to ensure we don't spawn multiple requests at the same time. The lock would either self-expire or get deleted during a dedicated sync request BUT before the actual sending of Sync actions to WPCOM would occur. This is not ideal, since during the actual sending of Sync actions to WPCOM we'd get multiple simultaneous spawn requests that would fail to send anything because of the rest Sync locks. This can be easily confirmed for WoA sites, since we do have both logs on the actual Sync requests to WPCOM and the requests to `jetpack/v4/jetpack/sync/spawn-sync` endpoint (see test instructions).
- This PR sets the dedicated lock to a higher expiry, 1 minute, and clears it AFTER syncing instead.
- It also optimizes the process of acquiring the lock to return early when external object caching is enabled. 
- We stop using `microtime(true)` as the lock key. This could lead to issues when concurrency is high. The lock key really needs to be unique so we are using a uuid instead.
- We updated the whole flow for acquiring the dedicated sync lock for sites that are not using external object caching by introducing a new option for expiring the lock and ensuring the lock update is ATOMIC.
- We ensure to check a special transient which gets set during a Sync Pull, to decide if we can spawn a dedicated Sync request

**Sync via Cron**
The idea here is to rely on Sync's `jetpack_sync_cron` cron job as much as possible to empty Sync's queue. This will greatly benefit sites with large Sync queues. Up to now, we used to spawn dedicated Sync requests during Sync's cron jobs but there's actually no valid reason to do so. We can simply send our requests to WPCOM without spawning any Sync requests. Therefore in this PR:
- We stop triggering dedicated sync requests during `jetpack_sync_cron`
- We stop taking `default_sync_wait_threshold` lock into account when syncing via cron jobs. This only makes sense for Dedicated and Normal Sync flows anyways to ensure we minimize Sync's impact on actual user requests.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
**Dedicated Sync flow**
- `Dedicated_Sender::DEDICATED_SYNC_REQUEST_LOCK_TIMEOUT`: Update from 5 to 60 seconds
- `Sender::do_dedicated_sync_and_exit`: Move `Dedicated_Sender::try_release_lock_spawn_request();` after `do_sync_and_set_delays`
- `Dedicated_Sender::try_lock_spawn_request`: Early return when `wp_using_ext_object_cache` is `true` no matter if we acquired the lock or not.
- `Dedicated_Sender::try_lock_spawn_request`: Use `wp_generate_uuid4()` vs `microtime(true)` as the dedicated sync lock value.
-  `Dedicated_Sender::try_lock_spawn_request`: Introduce an additional option for storing the lock expiry and refactor the lock check to ensure atomicity by taking advantage of `INSERT IGNORE`
- `Dedicated_Sender::spawn_sync`: Add a missing check for one of Sync's locks `Sender::TEMP_SYNC_DISABLE_TRANSIENT_NAME`. This is the transient we set when a Sync Pull is in progress to temporarily stop sending while WPCOM is pulling to reduce stress.
- `Dedicated_Sender:: maybe_change_dedicated_sync_status_from_wpcom_header`: A small optimization so we only attempt to update the `dedicated_sync_enabled` Sync setting only when it doesn't match the corresponding header we received from WordPress.com

**Sync via Cron**
- `Actions:: do_cron_sync_by_type` : Stop using this method for both `jetpack_sync_cron` and `jetpack_full_sync_cron`. The shared code between those two jobs is minimal so we might as well keep their logic separate.
- `Actions::do_cron_sync`: Stop spawning dedicated sync requests during cron
- `Actions::do_cron_sync`: Be more flexible when certain errors occur while we try to send Sync data to WordPress.com. If we got an error code that indicates the queue is locked atm ('unclosed_buffer', 'sync_throttled') lets wait a bit and retry.
- `Actions::do_cron_sync`: Lock dedicated sync while `jetpack_sync_cron` is running. As mentioned above, our goal here it to take advantage of the cron job to empty Sync's queue as much as possible. We don't want dedicated sync requests happening during that time.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
See SYNC-160

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
Pre-requisites: A WoA dev blog with WooCommerce and Smooth Generator plugins active. Also WP Crontrol plugin for testing Sync cron jobs easily. 

We will be looking at the **Sync Single Site Dashboard** in Grafana (see linked issue) and comparing:
- Sync Requests to WPCOM
- Dedicated Sync requests
- Overall lag
- Overall queue size

We should be also looking at the **Atomic Single Site Dashboard** in Grafana to monitor load (CPU, MySQL) and potential Fatals on logs.

- Let's stress a Woo site by creating 100+ orders via the Smooth Generator plugin on trunk and current branch
- Performance monitoring / comparison via "Jetpack Sync: Single site dashboard" in Grafana
- Spawned requests monitoring via "Jetpack Sync: Single site dashboard" in Grafana -- Ideally the number of requests we spawn should match (or be lower than) the number of Sync requests to WPCOM 
- Normal Sync flow should be unaffected - Disable Dedicated Sync and trigger Sync activity to confirm
- Sync via cron: Should no longer spawn dedicated sync requests  - Trigger the `jetpack_sync_cron` job via the WP Crontrol plugin and confirm Sync actions are sent without spawning dedicated Sync requests.
- Sync via Pull: Trigger a Pull via the JP Debugger and confirm we're not spawning dedicated Sync requests while pulling