### PR TITLE
eslint: Enable `package-json/require-license` for published JS packages

### DIFF
--- a/projects/js-packages/jetpack-cli/changelog/fix-enable-eslint-package-json-require-license-for-published-packages
+++ b/projects/js-packages/jetpack-cli/changelog/fix-enable-eslint-package-json-require-license-for-published-packages
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Specify license in package.json.
+
+

--- a/projects/js-packages/jetpack-cli/package.json
+++ b/projects/js-packages/jetpack-cli/package.json
@@ -11,6 +11,7 @@
 		"url": "https://github.com/Automattic/jetpack.git",
 		"directory": "projects/js-packages/jetpack-cli"
 	},
+	"license": "GPL-2.0-or-later",
 	"type": "module",
 	"bin": {
 		"jp": "bin/jp.js"

--- a/tools/js-tools/eslintrc/base.mjs
+++ b/tools/js-tools/eslintrc/base.mjs
@@ -477,9 +477,6 @@ export function makeBaseConfig( configurl, opts = {} ) {
 
 				// Maybe someday, but not yet.
 				'package-json/require-type': 'off',
-
-				// Not needed for every package.json.
-				'package-json/require-license': 'off',
 			},
 		},
 		{
@@ -497,6 +494,7 @@ export function makeBaseConfig( configurl, opts = {} ) {
 			rules: {
 				'package-json/require-description': 'off',
 				'package-json/require-version': 'off',
+				'package-json/require-license': 'off',
 			},
 		},
 


### PR DESCRIPTION
Closes MONOREP-192

 <!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
If a JS package is being published, we should specify the license using the standard package.json field.

If it's not being published, there's no compelling reason to, so no point in enabling it globally.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
Followup to #45658.

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Try removing a `license` field from various package.json files, then run eslint on them.
