### PR TITLE
tools: Add warning to changelog ignore variable

### DIFF
--- a/tools/check-changelogger-use.php
+++ b/tools/check-changelogger-use.php
@@ -172,9 +172,13 @@ if ( ! $p ) {
 }
 fclose( $pipes[0] );
 
+// WARNING: Be very careful adding files to this list!
+// Much of our tooling relies on the existence of the changelog entry to identify that there's a change to the project.
+// Adding a file to this list may result in the project not getting released if there are no other changes, or other oddities.
+$files_to_ignore = array( 'projects/plugins/jetpack/to-test.md' );
+
 $ok_projects      = array();
 $touched_projects = array();
-$files_to_ignore  = array( 'projects/plugins/jetpack/to-test.md' );
 // phpcs:ignore Generic.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition
 while ( ( $line = fgets( $pipes[1] ) ) ) {
 	$line                  = trim( $line );


### PR DESCRIPTION
Closes MONOREP-194

 <!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
I'm half tempted to revert it as an attractive nuisance, but instead let's add a clear warning about the potential consequences of adding a file to the list.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Proofread the comment.
