### PR TITLE
Jetpack Sync: Prevent syncing unchanged orders on save or update within a short window

### DIFF
--- a/projects/packages/sync/changelog/update-sync-hpos-orders-save-no-changes
+++ b/projects/packages/sync/changelog/update-sync-hpos-orders-save-no-changes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Jetpack Sync: Prevent syncing unchanged orders on save within a short window.

--- a/projects/packages/sync/src/modules/class-woocommerce-hpos-orders.php
+++ b/projects/packages/sync/src/modules/class-woocommerce-hpos-orders.php
@@ -29,6 +29,11 @@ class WooCommerce_HPOS_Orders extends Module {
 	const HPOS_CACHE_KEY = 'jetpack_sync_hpos_cache_key_';
 
 	/**
+	 * Cache expiration time for storing order checksums.
+	 */
+	const CACHE_EXPIRATION = 5 * MINUTE_IN_SECONDS;
+
+	/**
 	 * Order table name. There are four order tables (order, addresses, operational_data and meta), but for sync purposes we only care about the main table since it has the order ID.
 	 *
 	 * @access private
@@ -340,7 +345,11 @@ class WooCommerce_HPOS_Orders extends Module {
 		$checksum  = md5( wp_json_encode( $filtered ) );
 		$cache_key = self::HPOS_CACHE_KEY . $order_id;
 
-		$previous = get_transient( $cache_key );
+		$group = 'jetpack_sync_hpos';
+
+		$previous = wp_using_ext_object_cache()
+		? wp_cache_get( $cache_key, $group )
+		: get_transient( $cache_key );
 
 		// If no substantive changes, skip enqueue.
 		if ( is_string( $previous ) && hash_equals( $previous, $checksum ) ) {
@@ -348,7 +357,11 @@ class WooCommerce_HPOS_Orders extends Module {
 		}
 
 		// Remember current signature briefly to avoid "Update" or "Recalculate" clicks syncing again with no changes.
-		set_transient( $cache_key, $checksum, 5 * MINUTE_IN_SECONDS );
+		if ( wp_using_ext_object_cache() ) {
+			wp_cache_set( $cache_key, $checksum, $group, self::CACHE_EXPIRATION );
+		} else {
+			set_transient( $cache_key, $checksum, self::CACHE_EXPIRATION );
+		}
 
 		$processed[ $order_id ] = true;
 

--- a/projects/packages/sync/src/modules/class-woocommerce-hpos-orders.php
+++ b/projects/packages/sync/src/modules/class-woocommerce-hpos-orders.php
@@ -333,8 +333,7 @@ class WooCommerce_HPOS_Orders extends Module {
 		$filtered = $this->filter_order_data( $order_object );
 
 		unset(
-			$filtered['date_modified'],
-			$filtered['date_updated_gmt']
+			$filtered['date_modified']
 		);
 
 		// md5 of the date-stripped order payload to detect no-change saves (ignores timestamp-only changes)

--- a/projects/packages/sync/src/modules/class-woocommerce-hpos-orders.php
+++ b/projects/packages/sync/src/modules/class-woocommerce-hpos-orders.php
@@ -24,6 +24,11 @@ class WooCommerce_HPOS_Orders extends Module {
 	const WOOCOMMERCE_SUBSCRIPTIONS_PATH = 'woocommerce-subscriptions/woocommerce-subscriptions.php';
 
 	/**
+	 * Cache key prefix for storing order checksums to avoid resyncing unchanged orders.
+	 */
+	const HPOS_CACHE_KEY = 'jetpack_sync_hpos_cache_key_';
+
+	/**
 	 * Order table name. There are four order tables (order, addresses, operational_data and meta), but for sync purposes we only care about the main table since it has the order ID.
 	 *
 	 * @access private
@@ -324,6 +329,27 @@ class WooCommerce_HPOS_Orders extends Module {
 		if ( isset( $processed[ $order_id ] ) ) {
 			return false;
 		}
+
+		$filtered = $this->filter_order_data( $order_object );
+
+		unset(
+			$filtered['date_modified'],
+			$filtered['date_updated_gmt']
+		);
+
+		// md5 of the date-stripped order payload to detect no-change saves (ignores timestamp-only changes)
+		$checksum  = md5( wp_json_encode( $filtered ) );
+		$cache_key = self::HPOS_CACHE_KEY . $order_id;
+
+		$previous = get_transient( $cache_key );
+
+		// If no substantive changes, skip enqueue.
+		if ( (string) $previous === (string) $checksum ) {
+			return false;
+		}
+
+		// Remember current signature briefly to avoid "Update" or "Recalculate" clicks syncing again with no changes.
+		set_transient( $cache_key, (string) $checksum, 5 * MINUTE_IN_SECONDS );
 
 		$processed[ $order_id ] = true;
 

--- a/projects/packages/sync/src/modules/class-woocommerce-hpos-orders.php
+++ b/projects/packages/sync/src/modules/class-woocommerce-hpos-orders.php
@@ -29,7 +29,7 @@ class WooCommerce_HPOS_Orders extends Module {
 	const HPOS_CACHE_KEY = 'jetpack_sync_hpos_cache_key_';
 
 	/**
-	 * Cache expiration time for storing order checksums.
+	 * Cache expiration for storing order content signatures.
 	 */
 	const CACHE_EXPIRATION = 5 * MINUTE_IN_SECONDS;
 
@@ -342,25 +342,25 @@ class WooCommerce_HPOS_Orders extends Module {
 		);
 
 		// md5 of the date-stripped order payload to detect no-change saves (ignores timestamp-only changes)
-		$checksum  = md5( wp_json_encode( $filtered ) );
-		$cache_key = self::HPOS_CACHE_KEY . $order_id;
+		$current_signature = md5( wp_json_encode( $filtered ) );
+		$cache_key         = self::HPOS_CACHE_KEY . $order_id;
 
 		$group = 'jetpack_sync_hpos';
 
-		$previous = wp_using_ext_object_cache()
+		$previous_signature = wp_using_ext_object_cache()
 		? wp_cache_get( $cache_key, $group )
 		: get_transient( $cache_key );
 
 		// If no substantive changes, skip enqueue.
-		if ( is_string( $previous ) && hash_equals( $previous, $checksum ) ) {
+		if ( is_string( $previous_signature ) && hash_equals( $previous_signature, $current_signature ) ) {
 			return false;
 		}
 
 		// Remember current signature briefly to avoid "Update" or "Recalculate" clicks syncing again with no changes.
 		if ( wp_using_ext_object_cache() ) {
-			wp_cache_set( $cache_key, $checksum, $group, self::CACHE_EXPIRATION );
+			wp_cache_set( $cache_key, $current_signature, $group, self::CACHE_EXPIRATION );
 		} else {
-			set_transient( $cache_key, $checksum, self::CACHE_EXPIRATION );
+			set_transient( $cache_key, $current_signature, self::CACHE_EXPIRATION );
 		}
 
 		$processed[ $order_id ] = true;

--- a/projects/packages/sync/src/modules/class-woocommerce-hpos-orders.php
+++ b/projects/packages/sync/src/modules/class-woocommerce-hpos-orders.php
@@ -344,12 +344,12 @@ class WooCommerce_HPOS_Orders extends Module {
 		$previous = get_transient( $cache_key );
 
 		// If no substantive changes, skip enqueue.
-		if ( (string) $previous === (string) $checksum ) {
+		if ( is_string( $previous ) && hash_equals( $previous, $checksum ) ) {
 			return false;
 		}
 
 		// Remember current signature briefly to avoid "Update" or "Recalculate" clicks syncing again with no changes.
-		set_transient( $cache_key, (string) $checksum, 5 * MINUTE_IN_SECONDS );
+		set_transient( $cache_key, $checksum, 5 * MINUTE_IN_SECONDS );
 
 		$processed[ $order_id ] = true;
 


### PR DESCRIPTION
Closes SYNC-164

## Proposed changes:

* This PR prevents `woocommerce_update_order_item` and `woocommerce_after_order_object_save` action items being synced if there are no changes within a specific time window (due to a transient or persistent object cache if present), if the order is saved more than once in that time period.
* This can happen if clicking the 'Recalculate' button in an order after making some changes such as a refund, then pressing 'Update' on the order as well.
* The changes include adding a 5 minute window (currently) for a transient / cache. We also exclude changes to only the date modified or changed of the order if no other changes.
* Even though the changes are applied to `on_before_enqueue_order_save`, which is hooked into the `jetpack_sync_before_enqueue_woocommerce_after_{$type}_object_save` filter, in this save flow both the per‑item updates and the order save occur in the same request. With our before‑enqueue guard, that request ends up with nothing meaningful to send, so those per‑item `woocommerce_update_order_item` events are not synced in this path. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

SYNC-164

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

To replicate the issue:

* On a local development site or a JN test site with Jetpack and WooCommerce installed (and set to use HPOS ( `/wp-admin/admin.php?page=wc-settings&tab=advanced`):
* Create a new order and add several order items.
* Make sure you are watching logs for your site - visit 571a247b6623a0aa62165b5e4e2c7b10-logstash but replace the filter URL with your test site URL
* Apply a refund to each of the order items and click 'save'.
* View the actions via logstash
* View the order ad order items on the cache site. Using `wpsh` when sandboxed: `gpr select * from wp_YOURBLOGID_wc_orders` and `gpr select * from wp_YOURBLOGID_woocommerce_order_itemmeta`
* Then, click on 'Update' (or 'Recalculate').
* You should see a `woocommerce_after_order_object_save` action synced, as well as one `woocommerce_update_order_item` for each order item.
* Check the order via `wpsh`,  nothing should have changed.

To test the changes:
* Apply this PR using the Jetpack beta tester plugin.
* Follow the same steps as above.
* After clicking 'Update' or 'Recalculate' after a refund of order items, there should be no new actions synced if within 5 minutes of the refund.
* Checking via the order via `wpsh`, nothing should have changed.
* If you take another action in that same 5 minute window, eg updating an order item total, then clicking save or update should correctly sync the corresponding action.