### PR TITLE
Forms: fix Gravatar consistency in the sidebar

### DIFF
--- a/projects/packages/forms/changelog/forms-fix-gravatar-consistency
+++ b/projects/packages/forms/changelog/forms-fix-gravatar-consistency
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: Add gravatar everywhere to improve consistancy

--- a/projects/packages/forms/changelog/forms-fix-gravatar-consistency
+++ b/projects/packages/forms/changelog/forms-fix-gravatar-consistency
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Forms: Add gravatar everywhere to improve consistancy
+Forms: Add gravatar everywhere to improve consistency

--- a/projects/packages/forms/src/dashboard/components/response-view/body.tsx
+++ b/projects/packages/forms/src/dashboard/components/response-view/body.tsx
@@ -428,19 +428,21 @@ const ResponseViewBody = ( {
 	}
 
 	const displayName = getDisplayName( response );
+	// Match the data view gravatar logic: use email or IP, and set defaultImage conditionally
+	const gravatarEmail = response.author_email || response.ip;
+	const defaultImage = response.author_name || response.author_email ? 'initials' : 'mp';
 
 	return (
 		<>
 			<div ref={ ref } className="jp-forms__inbox-response">
 				<div className="jp-forms__inbox-response-header">
 					<HStack alignment="topLeft" spacing="3">
-						{ response.author_email && (
-							<Gravatar
-								email={ response.author_email }
-								displayName={ displayName }
-								key={ response.author_email }
-							/>
-						) }
+						<Gravatar
+							email={ gravatarEmail }
+							defaultImage={ defaultImage }
+							displayName={ displayName }
+							key={ gravatarEmail }
+						/>
 						<VStack spacing="0" className="jp-forms__inbox-response-header-title">
 							<h3 className="jp-forms__inbox-response-name">{ displayName }</h3>
 							{ response.author_email && displayName !== response.author_email && (


### PR DESCRIPTION
Part of FORMS-395

Follow-up to https://github.com/Automattic/jetpack/pull/45726

This PR also add the Gravatar to the sidebar header

Before:
<img width="319" height="199" alt="Screenshot 2025-11-07 at 8 58 23 AM" src="https://github.com/user-attachments/assets/804fe12b-8b1d-4baf-8bdf-1cea71c7d1b2" />

After:
<img width="391" height="215" alt="Screenshot 2025-11-07 at 8 58 07 AM" src="https://github.com/user-attachments/assets/468ba872-34cb-45fd-8b92-5af4a8da745c" />


## Proposed changes:
* Implement the same default Gravatar when no email is available


### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
none

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:
Visit the dashboard. Open up a resoonse that doesn't have an email or name. 
Do you see the Gravatar? 