### PR TITLE
Fix/forms dataviews paddings

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-dataviews-paddings
+++ b/projects/packages/forms/changelog/fix-forms-dataviews-paddings
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Forms: adjust dataviews paddings for consistent spacing with the header

--- a/projects/packages/forms/src/dashboard/components/layout/style.scss
+++ b/projects/packages/forms/src/dashboard/components/layout/style.scss
@@ -73,10 +73,6 @@ body.jetpack_page_jetpack-forms-admin {
 		width: 100%;
 		background: var(--wpds-color-bg-surface-neutral-strong, #fff);
 		border-bottom: none;
-
-		@media (max-width: 782px) {
-			padding: 12px 24px;
-		}
 	}
 
 	.admin-ui-page__header-subtitle {

--- a/projects/packages/forms/src/dashboard/components/layout/style.scss
+++ b/projects/packages/forms/src/dashboard/components/layout/style.scss
@@ -86,5 +86,14 @@ body.jetpack_page_jetpack-forms-admin {
 		line-height: 20px;
 	}
 
+	// these overrides mimic the ones in new admin packages
+	.dataviews-wrapper .dataviews-view-table tr td:first-child,
+	.dataviews-wrapper .dataviews-view-table tr th:first-child {
+		padding-inline-start: 20px;
+	}
 
+	.dataviews-wrapper .dataviews-view-table tr td:last-child,
+	.dataviews-wrapper .dataviews-view-table tr th:last-child {
+		padding-inline-end: 20px;
+	}
 }

--- a/projects/packages/forms/src/dashboard/inbox/style.scss
+++ b/projects/packages/forms/src/dashboard/inbox/style.scss
@@ -363,6 +363,9 @@
 		position: fixed;
 		bottom: 0;
 
+		// Match .admin-ui-page__header padding
+		padding-inline: 20px;
+
 		// Compensation for the width of the sidebar
 		// Set left position when auto-fold is not on the body element.
 		// Adapted from https://github.com/WordPress/gutenberg/blob/4ea86f891145daa12c8b59b18f02fb9fc4d83c5a/packages/base-styles/_mixins.scss#L183-L218

--- a/projects/packages/forms/src/dashboard/inbox/style.scss
+++ b/projects/packages/forms/src/dashboard/inbox/style.scss
@@ -109,10 +109,6 @@
 	left: 0;
 	background: var(--wpds-color-bg-surface-neutral-strong, #fff);
 
-	@media (max-width: 782px) {
-		padding: 0 24px; // Match mobile padding
-	}
-
 	// On small stacks, switch to column stacking
 	flex-direction: row;
 

--- a/projects/packages/forms/src/dashboard/inbox/style.scss
+++ b/projects/packages/forms/src/dashboard/inbox/style.scss
@@ -145,12 +145,8 @@
 }
 
 .jp-forms__inbox__filters-container:not(:empty) {
-	padding-inline: 48px; // Match header padding
+	padding-inline: 20px; // Match header padding
 	padding-block: 12px;
-
-	@media (max-width: 782px) {
-		padding-inline: 24px;
-	}
 }
 
 .jp-forms__inbox-response-name {


### PR DESCRIPTION
Fixes FORMS-379

## Proposed changes:
This PR adjusts dataviews paddings for consistent spacing aligned with the header

<img width="856" height="416" alt="image" src="https://github.com/user-attachments/assets/9a0754ef-0c5b-42a0-97ff-5caacbbabf38" />


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1762529706170569-slack-C052XEUUBL4

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Load Forms dashboard, see the paddings now match the page header paddings. Check all forms admin pages to see no glitches are introduced.