### PR TITLE
Make sure the domain stays aligned in any screen resolution

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/dsgcom-309-misaligned-domain-in-wp-admin-suggestions-widget
+++ b/projects/packages/jetpack-mu-wpcom/changelog/dsgcom-309-misaligned-domain-in-wp-admin-suggestions-widget
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Suggestion widget: make sure the domain stays aligned in any screen resolution

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard-widgets/wpcom-general-tasks-widget/tasks/home-task-domain-upsell/index.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard-widgets/wpcom-general-tasks-widget/tasks/home-task-domain-upsell/index.js
@@ -51,23 +51,22 @@ export default ( { siteDomain, sitePlan } ) => {
 					}
 				) }
 			</p>
-			<p style={ { position: 'relative' } }>
-				{ /* To do: convert to SVG.  */ }
-				<span
-					style={ {
-						position: 'absolute',
-						transform: 'translate(130px, 14px)',
-						fontSize: '16px',
-					} }
+			<div style={ { position: 'relative', margin: '1em 0' } }>
+				<svg
+					viewBox="0 0 40 17"
+					id="map"
+					style={ { height: '43%', left: '24%', position: 'absolute', top: '17%', width: '70%' } }
 				>
-					{ domain }
-				</span>
+					<text x="-95" y="15" textAnchor="start" direction="ltr">
+						asdf572.com.br
+					</text>
+				</svg>
 				<img
 					src="https://wordpress.com/calypso/images/illustration--feature-domain-upsell-3eff1284ca73c71a3c77.svg"
 					alt={ domain }
 					style={ { width: '100%' } }
 				/>
-			</p>
+			</div>
 			<div>
 				<a href={ getLink } className="button button-primary">
 					{ __( 'Get this domain', 'jetpack-mu-wpcom' ) }

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard-widgets/wpcom-general-tasks-widget/tasks/home-task-domain-upsell/index.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard-widgets/wpcom-general-tasks-widget/tasks/home-task-domain-upsell/index.js
@@ -1,6 +1,6 @@
 import apiFetch from '@wordpress/api-fetch';
 import { useState, useEffect, createInterpolateElement } from '@wordpress/element';
-import { __, sprintf } from '@wordpress/i18n';
+import { __, isRTL, sprintf } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
 
 export default ( { siteDomain, sitePlan } ) => {
@@ -51,14 +51,26 @@ export default ( { siteDomain, sitePlan } ) => {
 					}
 				) }
 			</p>
-			<div style={ { position: 'relative', margin: '1em 0' } }>
+			<div
+				style={ {
+					position: 'relative',
+					margin: '1em 0',
+					transform: isRTL() ? 'scale(-1, 1)' : 'none',
+				} }
+			>
 				<svg
 					viewBox="0 0 40 17"
 					id="map"
 					style={ { height: '43%', left: '24%', position: 'absolute', top: '17%', width: '70%' } }
 				>
-					<text x="-95" y="15" textAnchor="start" direction="ltr">
-						asdf572.com.br
+					<text
+						x={ isRTL() ? '95' : '-95' }
+						y="15"
+						textAnchor={ isRTL() ? 'end' : 'start' }
+						direction="ltr"
+						style={ { transform: isRTL() ? 'scale(-1, 1)' : 'none' } }
+					>
+						{ domain }
 					</text>
 				</svg>
 				<img


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes [DSGCOM-309](https://linear.app/a8c/issue/DSGCOM-309/misaligned-domain-in-wp-admin-suggestions-widget)

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* We're fixing the domain on any screen resolution


https://github.com/user-attachments/assets/db6a86bc-a8dc-44de-953c-8bb238c0019e



### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this to your sandbox [following these instructions](https://github.com/Automattic/jetpack/pull/45826#issuecomment-3503873080)
* On a Simple site with a free plan, make sure the Domain upsell work well in any device resolution including mobile

