### PR TITLE
Code block: Remove experimental notice

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/code-block-remove-warning-notice
+++ b/projects/packages/jetpack-mu-wpcom/changelog/code-block-remove-warning-notice
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Code block: Remove experimental warning.

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/block-definition/block-definition.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/block-definition/block-definition.tsx
@@ -6,7 +6,6 @@ import * as wpBlockEditor from '@wordpress/block-editor';
 import * as wpBlocks from '@wordpress/blocks';
 import {
 	CustomSelectControl,
-	Notice,
 	PanelBody,
 	SelectControl,
 	TextControl,
@@ -223,10 +222,6 @@ const blockEdit = withColors(
 			<React.Suspense fallback={ <Loading { ...props } /> }>
 				<Chrome { ...props }>
 					<EditCodeMirror { ...props } />
-					<Notice status="warning" isDismissible={ false }>
-						<b>Caution!</b> This block is experimental and <em>will</em> change. Existing content
-						may break.
-					</Notice>
 				</Chrome>
 			</React.Suspense>
 		</>
@@ -407,10 +402,6 @@ function Loading( props: EditBlockProps ): React.JSX.Element {
 	return (
 		<Chrome isLoading { ...props }>
 			<CodeWrapper { ...props }>{ code }</CodeWrapper>
-			<Notice status="warning" isDismissible={ false }>
-				<b>Caution!</b> This block is experimental and <em>will</em> change. Existing content may
-				break.
-			</Notice>
 		</Chrome>
 	);
 }

--- a/projects/plugins/mu-wpcom-plugin/changelog/code-block-remove-warning-notice
+++ b/projects/plugins/mu-wpcom-plugin/changelog/code-block-remove-warning-notice
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Code block: Remove experimental warning

--- a/projects/plugins/wpcomsh/changelog/code-block-remove-warning-notice
+++ b/projects/plugins/wpcomsh/changelog/code-block-remove-warning-notice
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Code block: Remove experimental warning


### PR DESCRIPTION
## Proposed changes:

Remove a notice the block editor. The block is not yet public.

Note that the block is still "experimental" in its description. That remains unchanged here and will be removed completely in #45389.


### Before
<img width="1114" height="584" alt="Screenshot 2025-11-07 at 19 07 38" src="https://github.com/user-attachments/assets/f8906e4e-0562-45e3-8cc5-f3d313398927" />


### After
<img width="1114" height="584" alt="Screenshot 2025-11-07 at 18 59 31" src="https://github.com/user-attachments/assets/4ba3b05f-d178-43c1-ae57-3cbdd30df7a7" />


### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?



## Does this pull request change what data or activity we track or use?
No