### PR TITLE
Code block: Prevent line highlight when unselected

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/code-block-fix-selected-line-unselected-block
+++ b/projects/packages/jetpack-mu-wpcom/changelog/code-block-fix-selected-line-unselected-block
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Code block: Remove active line highlight when block is unselected.

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/editor.css
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/editor.css
@@ -59,6 +59,11 @@
 	.cm-gutterElement {
 		backdrop-filter: blur(1em);
 	}
+
+	/* Disable active line highlight on inactive blocks. */
+	&:not(.is-selected) .cm-activeLine {
+		background-color: transparent !important;
+	}
 }
 
 .a8c\/code__header {

--- a/projects/plugins/mu-wpcom-plugin/changelog/code-block-fix-selected-line-unselected-block
+++ b/projects/plugins/mu-wpcom-plugin/changelog/code-block-fix-selected-line-unselected-block
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Code block: Remove active line highlight when block is unselected.

--- a/projects/plugins/wpcomsh/changelog/code-block-fix-selected-line-unselected-block
+++ b/projects/plugins/wpcomsh/changelog/code-block-fix-selected-line-unselected-block
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Code block: Remove active line highlight when block is unselected.


### PR DESCRIPTION
## Proposed changes:

Remove active line highlight when the block is not selected.

### Before

https://github.com/user-attachments/assets/e08ffd5a-c170-4e4f-b8dd-47cb72000ebc


### After

https://github.com/user-attachments/assets/1981ceaa-2fa3-4347-a170-d2946c37e899


### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?


## Does this pull request change what data or activity we track or use?
no

## Testing instructions:
See screenshots.

