### PR TITLE
ci: Retry WP core downloads in test-plugin-update

### DIFF
--- a/.github/files/test-plugin-update/setup.sh
+++ b/.github/files/test-plugin-update/setup.sh
@@ -2,7 +2,7 @@
 
 set -eo pipefail
 
-echo "::group::Setup database"
+echo "::group::Set up database"
 cat <<EOF > ~/.my.cnf
 [client]
 host=${MYSQL_HOST%:*}
@@ -16,7 +16,7 @@ mysql -e "drop database if exists wordpress;"
 mysql -e "create database wordpress;"
 echo "::endgroup::"
 
-echo "::group::Setup WordPress"
+echo "::group::Set up WordPress"
 mkdir -p /var/log/php/ /var/scripts/
 cd /var/www/html
 sed -i 's/apachectl -D FOREGROUND/apachectl start/' /usr/local/bin/run

--- a/tools/docker/bin/run.sh
+++ b/tools/docker/bin/run.sh
@@ -13,7 +13,11 @@ user="${APACHE_RUN_USER:-www-data}"
 group="${APACHE_RUN_GROUP:-www-data}"
 
 # Download WordPress
-[ -f /var/www/html/xmlrpc.php ] || wp core download
+# Sometimes it fails, and a retry would be nice:
+#   https://github.com/wp-cli/core-command/pull/258
+#   https://github.com/wp-cli/wp-cli/pull/6140
+# For now this should work well enough
+[ -f /var/www/html/xmlrpc.php ] || wp core download || wp core download
 
 # Configure WordPress
 if [ ! -f /var/www/html/wp-config.php ]; then

--- a/tools/docker/bin/run.sh
+++ b/tools/docker/bin/run.sh
@@ -17,7 +17,7 @@ group="${APACHE_RUN_GROUP:-www-data}"
 #   https://github.com/wp-cli/core-command/pull/258
 #   https://github.com/wp-cli/wp-cli/pull/6140
 # For now this should work well enough
-[ -f /var/www/html/xmlrpc.php ] || wp core download || wp core download
+[ -f /var/www/html/xmlrpc.php ] || wp core download || sleep $(( 30 + RANDOM % 8 )) && wp core download
 
 # Configure WordPress
 if [ ! -f /var/www/html/wp-config.php ]; then


### PR DESCRIPTION
Closes MONOREP-197

 <!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Similar to #45779, sometimes WP core downloads fail as well, e.g.:
https://github.com/Automattic/jetpack/actions/runs/19178820882/job/54830260653

For now let's just do a single retry after a variable sleep. A more robust solution might be coming in WP-CLI:

* wp-cli/wp-cli#6140
* wp-cli/core-command#258

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

The general effect can be tested like so:
`wp core download asdf.asdf || sleep $(( 0 + RANDOM % 8 )) && wp core download fdsa.fdsa`