### PR TITLE
Tooling: Remove changelog exclusion for to-test.md

### DIFF
--- a/tools/check-changelogger-use.php
+++ b/tools/check-changelogger-use.php
@@ -174,7 +174,6 @@ fclose( $pipes[0] );
 
 $ok_projects      = array();
 $touched_projects = array();
-$files_to_ignore  = array( 'projects/plugins/jetpack/to-test.md' );
 // phpcs:ignore Generic.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition
 while ( ( $line = fgets( $pipes[1] ) ) ) {
 	$line                  = trim( $line );
@@ -191,9 +190,9 @@ while ( ( $line = fgets( $pipes[1] ) ) ) {
 	}
 	if ( $parts[3] === $changelogger_projects[ $slug ]['changelog'] ) {
 		if ( $status === 'A' ) {
-			debug( 'Changes add changelog file %s, but this does not count as having a change file.', $file );
+			debug( 'PR adds changelog file %s, but this does not count as having a change file.', $file );
 		} else {
-			debug( 'Changes touch changelog file %s, so marking %s as having a change file.', $file, $slug );
+			debug( 'PR touches changelog file %s, so marking %s as having a change file.', $file, $slug );
 			$ok_projects[ $slug ] = true;
 			continue;
 		}
@@ -202,17 +201,13 @@ while ( ( $line = fgets( $pipes[1] ) ) ) {
 		if ( '.' === $parts[4][0] ) {
 			debug( 'Ignoring changes dir dotfile %s.', $file );
 		} else {
-			debug( 'Changes touch file %s, so marking %s as having a change file.', $file, $slug );
+			debug( 'PR touches file %s, so marking %s as having a change file.', $file, $slug );
 			$ok_projects[ $slug ] = true;
 		}
 		continue;
 	}
-	if ( in_array( $file, $files_to_ignore, true ) ) {
-		debug( 'Ignoring file %s, as it is explicitly set to be ignored.', $file );
-		continue;
-	}
 
-	debug( 'PR touches file %s, marking %s as touched.', $file, $slug );
+	debug( 'PR touches file %s, so marking %s as touched.', $file, $slug );
 	if ( ! isset( $touched_projects[ $slug ] ) ) {
 		$touched_projects[ $slug ][] = $file;
 	}
@@ -231,7 +226,7 @@ if ( ! $needed_projects ) {
 }
 
 // Look for unmerged change entry files.
-debug( 'Checking for unmerged change entry files.' );
+debug( 'Checking for unmerged change entry files...' );
 $pipes = null;
 $p     = proc_open(
 	'git -c core.quotepath=off status --no-renames --porcelain',
@@ -254,14 +249,14 @@ while ( ( $line = fgets( $pipes[1] ) ) ) {
 	}
 	$slug = "{$parts[1]}/{$parts[2]}";
 	if ( ! isset( $changelogger_projects[ $slug ] ) ) {
-		debug( 'Ignoring file %s, project %s does not use changelogger.', $file, $slug );
+		debug( 'Ignoring file %s, as project %s does not use changelogger.', $file, $slug );
 		continue;
 	}
 	if ( $parts[3] === $changelogger_projects[ $slug ]['changes-dir'] && '.' !== $parts[4][0] ) {
 		if ( empty( $needed_projects[ $slug ] ) ) {
-			debug( 'Ignoring unmerged change entry file %s, project %s is already ok.', $file, $slug );
+			debug( 'Ignoring unmerged change entry file %s, as project %s is already ok.', $file, $slug );
 		} else {
-			debug( 'Unmerged changes touch change entry file %s, marking %s as having an unmerged change file.', $file, $slug );
+			debug( 'Unmerged changes touch change entry file %s, so marking %s as having an unmerged change file.', $file, $slug );
 			$unmerged_projects[ $slug ][] = $file;
 		}
 		continue;


### PR DESCRIPTION
Closes MONOREP-199

 <!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

In #44637 I added the ability to exclude specific files from the changelog requirements. This bypassed the push requirements, but CI still failed, and in the end it's probably best just to leave it how it was.

This PR removes those changes, but tweaks some of the messaging for clarity (I hope).

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Try committing a change to `projects/plugins/jetpack/to-test.md` and it should require a changelog entry on this branch.
