### PR TITLE
Forms: add background shade for unread rows

### DIFF
--- a/projects/packages/forms/changelog/add-forms-dashboard-unread-background
+++ b/projects/packages/forms/changelog/add-forms-dashboard-unread-background
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Forms: remove unread indicator, use CSS selector to show rows with a different background

--- a/projects/packages/forms/src/dashboard/components/layout/style.scss
+++ b/projects/packages/forms/src/dashboard/components/layout/style.scss
@@ -92,4 +92,19 @@ body.jetpack_page_jetpack-forms-admin {
 	.dataviews-wrapper .dataviews-view-table tr th:last-child {
 		padding-inline-end: 20px;
 	}
+
+	// these override to have rows marked as unread
+	.dataviews-wrapper .dataviews-view-table tr:has(.is-unread) {
+		font-weight: 600;
+		color: var(--jp-gray-50, #646970);
+
+		&:not(.is-selected) {
+			background-color: var(--jp-gray-5, #f0f0f0);
+
+			.dataviews-view-table__actions-column {
+				background-color: var(--jp-gray-5, #f0f0f0);
+			}
+		}
+
+	}
 }

--- a/projects/packages/forms/src/dashboard/inbox/dataviews/index.js
+++ b/projects/packages/forms/src/dashboard/inbox/dataviews/index.js
@@ -234,13 +234,6 @@ export default function InboxView() {
 		[ totalItems, totalPages ]
 	);
 
-	const wrapperUnread = ( isUnread, itemValue ) => {
-		if ( isUnread ) {
-			return <span className="jp-forms__inbox__unread">{ itemValue }</span>;
-		}
-		return itemValue;
-	};
-
 	const fields = useMemo(
 		() => [
 			{
@@ -274,14 +267,6 @@ export default function InboxView() {
 								tabIndex: 0,
 							} ) }
 						>
-							{ item.is_unread && (
-								<span
-									className="jp-forms__inbox__unread-indicator"
-									aria-label={ __( '(Unread form response)', 'jetpack-forms' ) }
-								>
-									●
-								</span>
-							) }
 							<Gravatar
 								email={ item.author_email || item.ip } // With IP we still return placeholder image
 								defaultImage={ defaultImage }
@@ -291,9 +276,7 @@ export default function InboxView() {
 								useHovercard={ false }
 							/>
 							<div className="jp-forms__inbox__author-info-container">
-								<span className="jp-forms__inbox__author-info">
-									{ wrapperUnread( item.is_unread, authorInfo ) }
-								</span>
+								<span className="jp-forms__inbox__author-info">{ authorInfo }</span>
 								{ secondaryInfo }
 							</div>
 						</div>
@@ -311,7 +294,7 @@ export default function InboxView() {
 				id: 'date',
 				label: __( 'Date', 'jetpack-forms' ),
 				render: ( { item } ) => {
-					return wrapperUnread( item.is_unread, dateI18n( dateSettings.formats.date, item.date ) );
+					return dateI18n( dateSettings.formats.date, item.date );
 				},
 				elements: ( filterOptions?.date || [] ).map( _filter => {
 					const date = new Date();
@@ -336,10 +319,7 @@ export default function InboxView() {
 				render: ( { item } ) => {
 					return (
 						<ExternalLink href={ item.entry_permalink }>
-							{ wrapperUnread(
-								item.is_unread,
-								decodeEntities( item.entry_title ) || getPath( item )
-							) }
+							{ decodeEntities( item.entry_title ) || getPath( item ) }
 						</ExternalLink>
 					);
 				},

--- a/projects/packages/forms/src/dashboard/inbox/dataviews/index.js
+++ b/projects/packages/forms/src/dashboard/inbox/dataviews/index.js
@@ -264,7 +264,8 @@ export default function InboxView() {
 						<div
 							className={ clsx(
 								'jp-forms__inbox__author-field',
-								isMobileViewport && 'jp-forms__inbox__author-field--mobile'
+								isMobileViewport && 'jp-forms__inbox__author-field--mobile',
+								{ 'is-unread': item.is_unread }
 							) }
 							{ ...( isMobileViewport && {
 								onClick: handleClick,

--- a/projects/packages/forms/src/dashboard/inbox/style.scss
+++ b/projects/packages/forms/src/dashboard/inbox/style.scss
@@ -402,14 +402,6 @@
 		font-size: 11px;
 		filter: opacity(0.8);
 	}
-
-	.jp-forms__inbox__unread-indicator {
-		color: #d63638;
-		font-size: 8px;
-		position: absolute;
-		left: -12px;
-		cursor: pointer;
-	}
 }
 
 /*
@@ -583,8 +575,3 @@ body.jetpack_page_jetpack-forms-admin {
 	gap: 16px;
 	align-items: center;
 }
-
-.jp-forms__inbox__unread {
-	font-weight: 600;
-}
-


### PR DESCRIPTION
## Proposed changes:
This PR explores an alternative to the unread indicator by querying inside the row and using a different background color.
It removes the wrapperUnread component and the unread indicator used before.

Background is now using `--jp-grey-5` but it's up for review on the right shade to use.
Text is set a bit darker using `--jp-grey-50`. Same as above.

<img width="1363" height="639" alt="image" src="https://github.com/user-attachments/assets/56c7f806-677f-464f-8ded-2257e0fb8015" />

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1762540000396489/1762529706.170569-slack-C052XEUUBL4

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Visit the dashboard and mark some entries as unread if necessary.