### PR TITLE
Fix/add base path for default category link

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-add-base-path-for-default-category-link
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-add-base-path-for-default-category-link
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+fixed the set default behavior for newly added categories

--- a/projects/packages/jetpack-mu-wpcom/src/features/post-categories/quick-actions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/post-categories/quick-actions.php
@@ -25,8 +25,9 @@ function wpcom_add_set_default_category_quick_action( $actions, $category ) {
 
 	$action = 'set-default';
 
-	$link = add_query_arg( array( $action => $category->term_id ) );
-	$link = wp_nonce_url( $link, $action . '_' . $category->term_id );
+	$base_url = admin_url( 'edit-tags.php?taxonomy=category' );
+	$link     = add_query_arg( array( $action => $category->term_id ), $base_url );
+	$link     = wp_nonce_url( $link, $action . '_' . $category->term_id );
 
 	$actions[ $action ] = sprintf(
 		'<a href="%1$s" aria-label="%2$s">%3$s</a>',


### PR DESCRIPTION
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* This PR fixes a bug where adding a new category and then immedaitely clicking on "set default" redirects to a blank screen

Current state:

https://github.com/user-attachments/assets/a1559eba-b5a7-4fbd-89f6-2ccd8d676f06

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Follow instructions here to test on your sandbox: PCYsg-Osp-p2
* On a sandboxed simple site, go to Categories > Add New
* Fill in the new category form and click "Add Category"
* Without reloading, click the "set as default" quicklink in the category list
* Confirm that the new category is set as the default w/ a success message
<img width="718" height="105" alt="Screenshot 2025-11-08 at 4 06 34 PM" src="https://github.com/user-attachments/assets/039d2ce0-fbcf-44b1-9497-9878d65c6c5e" />