### PR TITLE
External Media: add to replace flow

### DIFF
--- a/projects/packages/external-media/changelog/add-external-media-replace-flow
+++ b/projects/packages/external-media/changelog/add-external-media-replace-flow
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Support external media in replace flow, too

--- a/projects/packages/external-media/src/features/editor/index.js
+++ b/projects/packages/external-media/src/features/editor/index.js
@@ -1,10 +1,15 @@
 import { isUserConnected } from '@automattic/jetpack-shared-extension-utils';
 import { useBlockEditContext } from '@wordpress/block-editor';
+import { useState } from '@wordpress/element';
 import { addFilter } from '@wordpress/hooks';
 import {
 	addPexelsToMediaInserter,
 	addGooglePhotosToMediaInserter,
+	ALLOWED_BLOCKS,
+	externalMediaSources,
+	getExternalLibrary,
 	MediaButton,
+	MediaSources,
 	mediaSources,
 } from '../../shared';
 import './editor.scss';
@@ -35,19 +40,9 @@ if ( isUserConnected() && 'function' === typeof useBlockEditContext ) {
 		( props.modalClass && props.modalClass.indexOf( 'featured-image' ) > -1 );
 
 	const isAllowedBlock = ( name, render ) => {
-		const allowedBlocks = [
-			'core/cover',
-			'core/image',
-			'core/gallery',
-			'core/media-text',
-			'jetpack/image-compare',
-			'jetpack/slideshow',
-			'jetpack/story',
-			'jetpack/tiled-gallery',
-			'videopress/video',
-		];
-
-		return allowedBlocks.indexOf( name ) > -1 && render.toString().indexOf( 'coblocks' ) === -1;
+		const isInAllowedList = ALLOWED_BLOCKS.indexOf( name ) > -1;
+		const isNotCoBlocks = render ? render.toString().indexOf( 'coblocks' ) === -1 : true;
+		return isInAllowedList && isNotCoBlocks;
 	};
 
 	// Register the new 'browse media' button.
@@ -80,5 +75,48 @@ if ( isUserConnected() && 'function' === typeof useBlockEditContext ) {
 		'blocks.registerBlockType',
 		'external-media/individual-blocks',
 		insertExternalMediaBlocks
+	);
+
+	// Add external media sources to MediaReplaceFlow dropdown.
+	addFilter(
+		'editor.MediaReplaceFlow',
+		'external-media/add-external-sources',
+		OriginalComponent => {
+			return props => {
+				const { name } = useBlockEditContext();
+				const [ selectedSource, setSelectedSource ] = useState( null );
+
+				// Only add external media sources for allowed blocks
+				if ( ! isAllowedBlock( name ) ) {
+					return <OriginalComponent { ...props } />;
+				}
+
+				const ExternalLibrary = selectedSource ? getExternalLibrary( selectedSource ) : null;
+				const externalSource = selectedSource
+					? externalMediaSources.find( s => s.id === selectedSource )
+					: null;
+
+				return (
+					<>
+						<OriginalComponent { ...props }>
+							{ ( { onClose } ) => (
+								<MediaSources onClick={ onClose } setSource={ setSelectedSource } />
+							) }
+						</OriginalComponent>
+
+						{ ExternalLibrary && (
+							<ExternalLibrary
+								onSelect={ props.onSelect }
+								onClose={ () => setSelectedSource( null ) }
+								allowedTypes={ props.allowedTypes }
+								multiple={ false }
+								mode="replace"
+								externalSource={ externalSource }
+							/>
+						) }
+					</>
+				);
+			};
+		}
 	);
 }

--- a/projects/packages/external-media/src/features/editor/index.js
+++ b/projects/packages/external-media/src/features/editor/index.js
@@ -109,8 +109,9 @@ if ( isUserConnected() && 'function' === typeof useBlockEditContext ) {
 								onSelect={ props.onSelect }
 								onClose={ () => setSelectedSource( null ) }
 								allowedTypes={ props.allowedTypes }
-								multiple={ false }
-								mode="replace"
+								multiple={ props.multiple }
+								addToGallery={ props.addToGallery }
+								value={ props.mediaIds }
 								externalSource={ externalSource }
 							/>
 						) }

--- a/projects/packages/external-media/src/shared/constants.js
+++ b/projects/packages/external-media/src/shared/constants.js
@@ -176,6 +176,18 @@ export const GOOGLE_PHOTOS_DATE_PRESETS = [
 
 export const CURRENT_YEAR = new Date().getFullYear();
 
+export const ALLOWED_BLOCKS = [
+	'core/cover',
+	'core/image',
+	'core/gallery',
+	'core/media-text',
+	'jetpack/image-compare',
+	'jetpack/slideshow',
+	'jetpack/story',
+	'jetpack/tiled-gallery',
+	'videopress/video',
+];
+
 export const MONTH_SELECT_OPTIONS = [
 	{ label: __( 'Any Month', 'jetpack-external-media' ), value: -1 },
 	...Array.from( Array( 12 ), ( _, value ) => ( {

--- a/projects/packages/external-media/src/shared/index.js
+++ b/projects/packages/external-media/src/shared/index.js
@@ -1,6 +1,7 @@
 export * from './constants';
 export { default as MediaBrowser } from './media-browser';
 export { default as MediaButton } from './media-button';
+export { default as MediaSources } from './media-button/media-sources';
 export * from './media-service';
 export * from './media-service/types';
 export * from './sources';

--- a/projects/packages/external-media/src/shared/sources/with-media.js
+++ b/projects/packages/external-media/src/shared/sources/with-media.js
@@ -157,15 +157,16 @@ export default function withMedia( mediaSource = MediaSource.Unknown, mediaOptio
 			};
 
 			selectMediaForMode = result => {
-				const { value, addToGallery, multiple, mode } = this.props;
-				const isReplaceMode = mode === 'replace';
-				const media = multiple ? result : result[ 0 ];
+				const { addToGallery, multiple, existingMedia } = this.props;
 
-				// In replace mode, always select single item. Otherwise use the existing logic.
-				if ( isReplaceMode ) {
-					return result[ 0 ];
+				if ( multiple ) {
+					// For galleries, merge existing images with new selections
+					if ( addToGallery && existingMedia && existingMedia.length > 0 ) {
+						return existingMedia.concat( result );
+					}
+					return result;
 				}
-				return addToGallery ? value.concat( result ) : media;
+				return result[ 0 ];
 			};
 
 			getMediaRequest = url => {
@@ -472,15 +473,32 @@ export default function withMedia( mediaSource = MediaSource.Unknown, mediaOptio
 			}
 		}
 
-		return withSelect( select => {
+		return withSelect( ( select, ownProps ) => {
 			const currentPost = select( 'core/editor' ).getCurrentPost();
 			// Templates and template parts' numerical ID is stored in `wp_id`.
 			const currentPostId =
 				typeof currentPost?.id === 'number' ? currentPost.id : currentPost?.wp_id;
 
+			// we only get the ids in the value prop, so we need to fetch the media objects
+			let existingMedia = [];
+			if ( ownProps.addToGallery && ownProps.value && ownProps.value.length > 0 ) {
+				const coreSelect = select( 'core' );
+				existingMedia = ownProps.value
+					.map( id => coreSelect?.getMedia?.( id ) )
+					.filter( Boolean )
+					.map( media => ( {
+						id: media.id,
+						url: media.source_url,
+						alt: media.alt_text || '',
+						caption: media.caption?.raw || '',
+						type: 'image',
+					} ) );
+			}
+
 			return {
 				postId: currentPostId ?? 0,
 				pickerSession: getGooglePhotosPickerSession(),
+				existingMedia,
 			};
 		} )( withNotices( WithMediaComponent ) );
 	} );

--- a/projects/packages/external-media/src/shared/sources/with-media.js
+++ b/projects/packages/external-media/src/shared/sources/with-media.js
@@ -156,6 +156,18 @@ export default function withMedia( mediaSource = MediaSource.Unknown, mediaOptio
 				this.setState( { isLoading: false, isCopying: false } );
 			};
 
+			selectMediaForMode = result => {
+				const { value, addToGallery, multiple, mode } = this.props;
+				const isReplaceMode = mode === 'replace';
+				const media = multiple ? result : result[ 0 ];
+
+				// In replace mode, always select single item. Otherwise use the existing logic.
+				if ( isReplaceMode ) {
+					return result[ 0 ];
+				}
+				return addToGallery ? value.concat( result ) : media;
+			};
+
 			getMediaRequest = url => {
 				const { nextHandle, media } = this.state;
 
@@ -239,9 +251,6 @@ export default function withMedia( mediaSource = MediaSource.Unknown, mediaOptio
 							} ) );
 						}
 
-						const { value, addToGallery, multiple } = this.props;
-						const media = multiple ? result : result[ 0 ];
-
 						const itemWithErrors = result.find( item => item.errors );
 						if ( itemWithErrors ) {
 							const { errors } = itemWithErrors;
@@ -254,8 +263,7 @@ export default function withMedia( mediaSource = MediaSource.Unknown, mediaOptio
 						}
 
 						this.props.onClose();
-						// Select the image(s). This will close the modal
-						this.props.onSelect( addToGallery ? value.concat( result ) : media );
+						this.props.onSelect( this.selectMediaForMode( result ) );
 					} )
 					.catch( this.handleApiError );
 			};
@@ -338,11 +346,8 @@ export default function withMedia( mediaSource = MediaSource.Unknown, mediaOptio
 					result = [ this.mapImageToResult( items ) ];
 				}
 
-				const { value, multiple, addToGallery } = this.props;
-				const media = multiple ? result : result[ 0 ];
-
 				this.props.onClose();
-				this.props.onSelect( addToGallery ? value.concat( result ) : media );
+				this.props.onSelect( this.selectMediaForMode( result ) );
 				// end insert media
 			};
 

--- a/projects/plugins/jetpack/changelog/add-external-media-replace-flow
+++ b/projects/plugins/jetpack/changelog/add-external-media-replace-flow
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+External media: add replace flow support


### PR DESCRIPTION
Enable external media sources (Pexels, Google Photos, Openverse) in the MediaReplaceFlow dropdown menu. Users can now replace existing images directly from external sources without needing to delete and insert again.

## Implementation notes

* We're hooking to `editor.MediaReplaceFlow` and adding extra children, unlike replacing the button in the case of insertion.
* Avoided some duplication, the modal pattern (`ExternalLibrary`) was left in to be the same in both places, didn't find an obvious way to deduplicate.
* Didn't find an obvious way to add tests, may work on adding some later before merging.

## Testing instructions

* Connect Jetpack.
* Add a supported image-y block with some images that supports replacing an image.
* Click Replace.
* You should see external sources like Generate with AI, Google Photos, and Pexels.
* Replacing with an image from these sources should work.

## Does this pull request change what data or activity we track or use?

No.

Fixes EDI-80