### PR TITLE
Remove/jetpack ai reading score hint

### DIFF
--- a/projects/plugins/jetpack/changelog/remove-jetpack-ai-reading-score-hint
+++ b/projects/plugins/jetpack/changelog/remove-jetpack-ai-reading-score-hint
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Jetpack AI: remove tooltip for reading grade score

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/controls.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/controls.tsx
@@ -4,7 +4,6 @@ import {
 	PanelRow,
 	CheckboxControl,
 	ToggleControl,
-	Tooltip,
 	Card,
 	CardBody,
 	CardFooter,
@@ -12,7 +11,6 @@ import {
 import { compose, useDebounce } from '@wordpress/compose';
 import { useDispatch, useSelect, withSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
-import { Icon, help } from '@wordpress/icons';
 import { useState, useEffect, useCallback } from 'react';
 import features from './features';
 import calculateFleschKincaid from './utils/flesch-kincaid-utils';
@@ -136,14 +134,9 @@ const Controls = ( { blocks, disabledFeatures } ) => {
 									{ __( 'Write to see your grade level.', 'jetpack' ) }
 								</p>
 							) : (
-								<>
-									<div className="jetpack-ai-proofread__grade-label">
-										{ gradeLevel } { __( 'Reading grade score', 'jetpack' ) }
-									</div>
-									<Tooltip text={ __( 'To make it easy to read, aim for level 8–12', 'jetpack' ) }>
-										<Icon icon={ help } size={ 20 } />
-									</Tooltip>
-								</>
+								<div className="jetpack-ai-proofread__grade-label">
+									{ gradeLevel } { __( 'Reading grade score', 'jetpack' ) }
+								</div>
 							) }
 						</CardFooter>
 					</Card>


### PR DESCRIPTION
Fixes JPAI-59

## Proposed changes:
Remove tooltip for Reading grade score:

<img width="312" height="390" alt="image" src="https://github.com/user-attachments/assets/80150af4-2e51-4459-88df-b775b34d335a" />



After:
<img width="281" height="302" alt="image" src="https://github.com/user-attachments/assets/2e624bc8-42c1-4e4d-ae03-720d64300c91" />


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1762766101915939/1759427866.437279-slack-C054LN8RNVA

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Add some content to a post and use the Jetpack sidebar to enable Writing Assistance's "Show issues & suggestions". At the bottom of the option toggles there should be a "Reading grade score" and it should have a tooltip at the end.