### PR TITLE
A4A: Update wpcomsh for parity. Added A4A Jetpack Stats products

### DIFF
--- a/projects/plugins/wpcomsh/changelog/update-wpcomsh-wpcom-feature-parity-a4a-jetpack-stats
+++ b/projects/plugins/wpcomsh/changelog/update-wpcomsh-wpcom-feature-parity-a4a-jetpack-stats
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+WPCOM: Sync changes from class-wpcom-feature.php

--- a/projects/plugins/wpcomsh/wpcom-features/class-wpcom-features.php
+++ b/projects/plugins/wpcomsh/wpcom-features/class-wpcom-features.php
@@ -1318,6 +1318,9 @@ class WPCOM_Features {
 			self::JETPACK_COMPLETE_PLANS,
 			self::JETPACK_BUSINESS_PLANS,
 			self::JETPACK_GROWTH_PLANS,
+			// A4A Jetpack Stats plans
+			self::A4A_JETPACK_STATS_MONTHLY,
+			self::A4A_JETPACK_STATS_YEARLY,
 		),
 		self::STUDIO_SYNC                       => array(
 			self::WPCOM_BUSINESS_AND_HIGHER_PLANS,
@@ -1338,6 +1341,9 @@ class WPCOM_Features {
 				self::WPCOM_MIGRATION_TRIAL_PLANS,
 				self::WPCOM_HOSTING_TRIAL_PLANS,
 			),
+			// A4A Jetpack Stats plans
+			self::A4A_JETPACK_STATS_MONTHLY,
+			self::A4A_JETPACK_STATS_YEARLY,
 		),
 
 		self::SUBSCRIPTION_GIFTING              => array(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

## Proposed changes:

- Sync recent changes to class-wpcom-features.php on WPCOM, adding A4A Jetpack Stats products.
  - Changes from: 195585-ghe-Automattic/wpcom

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:

- Check the changes; they should match the WPCOM change.