### PR TITLE
Forms: fix dashboard primary buttons

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-dashboard-primary-buttons
+++ b/projects/packages/forms/changelog/fix-forms-dashboard-primary-buttons
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Forms: let there be only 1 primary header CTA and make it to the right

--- a/projects/packages/forms/src/dashboard/components/layout/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/layout/index.tsx
@@ -57,15 +57,15 @@ const Layout = () => {
 		</>
 	) : (
 		<>
-			{ isResponsesTrashView && <EmptyTrashButton /> }
-			{ isResponsesSpamView && <EmptySpamButton /> }
 			{ ! isResponsesTrashView && ! isResponsesSpamView && (
 				<>
 					{ enableIntegrationsTab && <IntegrationsButton /> }
 					<CreateFormButton label={ __( 'Create form', 'jetpack-forms' ) } />
 				</>
 			) }
-			<ExportResponsesButton />
+			<ExportResponsesButton isPrimary={ ! isResponsesTrashView && ! isResponsesSpamView } />
+			{ isResponsesTrashView && <EmptyTrashButton /> }
+			{ isResponsesSpamView && <EmptySpamButton /> }
 		</>
 	);
 

--- a/projects/packages/forms/src/dashboard/inbox/export-responses/index.tsx
+++ b/projects/packages/forms/src/dashboard/inbox/export-responses/index.tsx
@@ -13,7 +13,7 @@ import useInboxData from '../../hooks/use-inbox-data';
 
 import './style.scss';
 
-const ExportResponsesButton = () => {
+const ExportResponsesButton = ( { isPrimary = false }: { isPrimary?: boolean } ) => {
 	const {
 		showExportModal,
 		openModal,
@@ -34,7 +34,7 @@ const ExportResponsesButton = () => {
 		<>
 			<Button
 				size="compact"
-				variant="primary"
+				variant={ isPrimary ? 'primary' : 'secondary' }
 				icon={ download }
 				onClick={ openModal }
 				accessibleWhenDisabled


### PR DESCRIPTION
Fixes FORMS-387

## Proposed changes:
Have a single primary CTA on dashboard screens and make it the last in row. 

| Before | After |
|--------|--------|
| <img width="302" height="69" alt="image" src="https://github.com/user-attachments/assets/257f8b6c-e270-4862-9e77-6af172e7a300" /> | <img width="320" height="77" alt="image" src="https://github.com/user-attachments/assets/01f11a4b-cc47-4e88-a4a6-782cb8dd5b09" /> |
| <img width="304" height="60" alt="image" src="https://github.com/user-attachments/assets/a7a670f1-77e6-430a-a833-5cb768f65117" /> | <img width="317" height="71" alt="image" src="https://github.com/user-attachments/assets/392ec5c2-5237-482f-b730-23f7b865338f" /> |
| <img width="311" height="66" alt="image" src="https://github.com/user-attachments/assets/9a607de9-02d5-4f9d-8699-856bc29ef975" /> | <img width="314" height="77" alt="image" src="https://github.com/user-attachments/assets/d4c49cab-2206-47d2-b48d-9c473a7098b4" /> | 









### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1762781493442119-slack-C052XEUUBL4

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Visit the Forms dashboard, navigate the different status views and verify the changes.