### PR TITLE
jetpack: Use locking in CI coverage test

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-jetpack-coverage-theme-test-collision
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-coverage-theme-test-collision
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: CI: Use locking to avoid multiple instances of Jetpack_Sync_Themes_Test from interfering with each other.
+
+

--- a/projects/plugins/jetpack/tests/action-test-coverage.sh
+++ b/projects/plugins/jetpack/tests/action-test-coverage.sh
@@ -2,6 +2,8 @@
 
 set -eo pipefail
 
+export PHPUNIT_JETPACK_TESTSUITE_IS_PARALLEL=true
+
 # To run the PHP tests in parallel, we need to create custom configs for each.
 for test in lfs multi; do
 	P="${WP_TESTS_CONFIG_FILE_PATH%.php}.$test.php"

--- a/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Themes_Test.php
+++ b/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Themes_Test.php
@@ -52,10 +52,30 @@ class Jetpack_Sync_Themes_Test extends Jetpack_Sync_TestBase {
 	);
 
 	/**
+	 * Lock file.
+	 *
+	 * @var resource|null
+	 */
+	protected static $lockfile = null;
+
+	/**
 	 * Move Dummy Themes to proper location for testing.
+	 *
+	 * @throws RuntimeException If locking is needed and fails.
 	 */
 	public static function set_up_before_class() {
 		parent::set_up_before_class();
+
+		// For CI coverage tests, use a lock file to avoid multiple copies of this test from interfering with each other.
+		if ( getenv( 'PHPUNIT_JETPACK_TESTSUITE_IS_PARALLEL' ) === 'true' ) {
+			static::$lockfile = fopen( WP_CONTENT_DIR . '/themes/.jplock', 'c+' );
+			if ( ! static::$lockfile ) {
+				throw new RuntimeException( 'Failed to open lockfile ' . WP_CONTENT_DIR . '/themes/.jplock' );
+			}
+			if ( ! flock( static::$lockfile, LOCK_EX ) ) {
+				throw new RuntimeException( 'Failed to lock lockfile ' . WP_CONTENT_DIR . '/themes/.jplock' );
+			}
+		}
 
 		// Copy themes from tests/php/files/ to wp-content/themes.
 		foreach ( static::$themes as $theme ) {
@@ -85,6 +105,10 @@ class Jetpack_Sync_Themes_Test extends Jetpack_Sync_TestBase {
 			}
 
 			rmdir( $dest_dir );
+		}
+
+		if ( static::$lockfile ) {
+			fclose( static::$lockfile );
 		}
 	}
 


### PR DESCRIPTION
Closes MONOREP-201

 <!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Jetpack_Sync_Themes_Test creates some files on class setup and deletes them on teardown. When the CI coverage test tries to run multiple copies in parallen (for normal and multisite), these can wind up interfering with each other.

Avoid this by locking a file when running the CI coverage test.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* You could try doing something similar to what `tests/action-test-coverage.sh` does, but with `--filter=Jetpack_Sync_Themes_Test` to only run the one test.
