### PR TITLE
Forms: fix export modal styling on mobile

### DIFF
--- a/projects/packages/forms/changelog/update-forms-export-modal-mobile
+++ b/projects/packages/forms/changelog/update-forms-export-modal-mobile
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Form: fix export modal styling.

--- a/projects/packages/forms/src/dashboard/inbox/export-responses/style.scss
+++ b/projects/packages/forms/src/dashboard/inbox/export-responses/style.scss
@@ -1,3 +1,5 @@
+@use "@wordpress/base-styles/breakpoints";
+
 .jp-forms__export-modal-card {
 	border-radius: var(--jp-border-radius, 4px);
 	box-shadow: 0 0 0 1px var(--jp-gray-10, #c3c4c7) inset;
@@ -26,14 +28,16 @@
 }
 
 .jp-forms__export-modal-card-body {
-	gap: 32px;
-	align-items: center;
-	justify-content: space-between;
+	gap: 20px;
+	align-items: flex-start;
+	flex-direction: column;
 
-	@media (max-width: 782px) {
-		flex-direction: column;
-		align-items: flex-start;
-		gap: 20px;
+
+	@media (min-width: #{ (breakpoints.$break-medium + 1) }) {
+		gap: 32px;
+		align-items: center;
+		justify-content: space-between;
+		flex-direction: row;
 	}
 }
 
@@ -45,10 +49,10 @@
 	line-height: 24px;
 	letter-spacing: -0.02em;
 	color: #000;
-	max-width: 60%;
+	max-width: 100%;
 
-	@media (max-width: 782px) {
-		max-width: 100%;
+	@media (min-width: #{ (breakpoints.$break-medium + 1) }) {
+		max-width: 60%;
 	}
 }
 
@@ -57,10 +61,10 @@
 }
 
 .jp-forms__export-modal-card-body-cta {
-	align-self: flex-end;
+	align-self: flex-start;
 
-	@media (max-width: 782px) {
-		align-self: flex-start;
+	@media (min-width: #{ (breakpoints.$break-medium + 1) }) {
+		align-self: flex-end;
 	}
 
 	a.export-gdrive {

--- a/projects/packages/forms/src/dashboard/inbox/export-responses/style.scss
+++ b/projects/packages/forms/src/dashboard/inbox/export-responses/style.scss
@@ -29,6 +29,12 @@
 	gap: 32px;
 	align-items: center;
 	justify-content: space-between;
+
+	@media (max-width: 782px) {
+		flex-direction: column;
+		align-items: flex-start;
+		gap: 20px;
+	}
 }
 
 .jp-forms__export-modal-card-body-description {
@@ -40,6 +46,10 @@
 	letter-spacing: -0.02em;
 	color: #000;
 	max-width: 60%;
+
+	@media (max-width: 782px) {
+		max-width: 100%;
+	}
 }
 
 .jp-forms__export-modal-card-body-description a {
@@ -48,6 +58,10 @@
 
 .jp-forms__export-modal-card-body-cta {
 	align-self: flex-end;
+
+	@media (max-width: 782px) {
+		align-self: flex-start;
+	}
 
 	a.export-gdrive {
 		display: flex;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes [FORMS-388](https://linear.app/a8c/issue/FORMS-388/forms-fix-mobile-export-modal)

## Proposed changes:

Fixes spacing and alignment style issues in the export modal on mobile. 

<img width="958" height="601" alt="export-modal-before-after" src="https://github.com/user-attachments/assets/be58bb1a-3b6f-4b4e-959e-e2c537315a64" />

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Test on mobile device or resize browser
* You can see the issue better of Google is disconnected
* Go to Jetpack > Forms > Export (button in upper right corner) to open the modal
* Confirm button now wraps under text, text is full width, and everything is aligned left - like after screenshot
* Test a few different screen widths

