### PR TITLE
Forms: fix staged changes sync

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-staged-changes-sync
+++ b/projects/packages/forms/changelog/fix-forms-staged-changes-sync
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: toggling read/unread currently leaves dirty records, fix depends on core store unstable mechanics

--- a/projects/packages/forms/src/dashboard/components/response-view/body.tsx
+++ b/projects/packages/forms/src/dashboard/components/response-view/body.tsx
@@ -211,7 +211,7 @@ const ResponseViewBody = ( {
 	const [ isImageLoading, setIsImageLoading ] = useState( true );
 	const [ hasMarkedSelfAsRead, setHasMarkedSelfAsRead ] = useState( 0 );
 
-	const { editEntityRecord } = useDispatch( 'core' );
+	const { editEntityRecord, saveEditedEntityRecord } = useDispatch( 'core' );
 
 	const emptyTrashDays = useConfigValue( 'emptyTrashDays' ) ?? 0;
 
@@ -376,10 +376,13 @@ const ResponseViewBody = ( {
 		}
 
 		// Then update on server
-		apiFetch( {
-			path: `/wp/v2/feedback/${ response.id }/read`,
-			method: 'POST',
-			data: { is_unread: false },
+		saveEditedEntityRecord( 'postType', 'feedback', response.id, {
+			__unstableFetch: () =>
+				apiFetch( {
+					path: `/wp/v2/feedback/${ response.id }/read`,
+					method: 'POST',
+					data: { is_unread: false },
+				} ),
 		} )
 			.then( ( { count }: { count: number } ) => {
 				// Update menu counter with accurate count from server
@@ -407,6 +410,7 @@ const ResponseViewBody = ( {
 		invalidateCounts,
 		markRecordsAsInvalid,
 		currentQuery,
+		saveEditedEntityRecord,
 	] );
 
 	const handelImageLoaded = useCallback( () => {

--- a/projects/packages/forms/src/dashboard/inbox/dataviews/actions.tsx
+++ b/projects/packages/forms/src/dashboard/inbox/dataviews/actions.tsx
@@ -569,7 +569,7 @@ export const markAsReadAction: Action = {
 			multiple: items.length > 1,
 		} );
 
-		const { editEntityRecord } = registry.dispatch( coreStore );
+		const { editEntityRecord, saveEditedEntityRecord } = registry.dispatch( coreStore );
 		const { getEntityRecord } = registry.select( coreStore );
 		const { createSuccessNotice, createErrorNotice } = registry.dispatch( noticesStore );
 		const { invalidateCounts, markRecordsAsInvalid } = registry.dispatch( dashboardStore );
@@ -592,12 +592,15 @@ export const markAsReadAction: Action = {
 				}
 
 				// Update on server
-				return apiFetch( {
-					path: `/wp/v2/feedback/${ id }/read`,
-					method: 'POST',
-					data: { is_unread: false },
+				return saveEditedEntityRecord( 'postType', 'feedback', id, {
+					__unstableFetch: () =>
+						apiFetch( {
+							path: `/wp/v2/feedback/${ id }/read`,
+							method: 'POST',
+							data: { is_unread: false },
+						} ),
 				} )
-					.then( ( { count } ) => {
+					.then( ( { count }: { count: number } ) => {
 						// Update menu counter with accurate count from server.
 						updateMenuCounter( count );
 					} )

--- a/projects/packages/forms/src/dashboard/inbox/dataviews/types.tsx
+++ b/projects/packages/forms/src/dashboard/inbox/dataviews/types.tsx
@@ -35,6 +35,12 @@ export type Registry = {
 			name: string,
 			record: Record< string, unknown >
 		) => Promise< void >;
+		saveEditedEntityRecord: (
+			kind: string,
+			name: string,
+			recordId: number,
+			options?: { __unstableFetch?: () => Promise< void > }
+		) => Promise< { id: string; count: number } >;
 		deleteEntityRecord: (
 			kind: string,
 			name: string,


### PR DESCRIPTION
## Proposed changes:
This PR is a WIP while looking for better options. It calls saveEditedEntityRecord (after the record has been edited) with `__unstableFetch` option to use the custom API endpoint for read/unread status toggle.

This way, the edit done when toggling read/unread status is immediately "committed" to store and fetches from the API.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1762795602061299/1762781493.442119-slack-C052XEUUBL4

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Test on all envs by confirming toggling read/unread continues to work. See that no staged changes are out of sync on the store.