### PR TITLE
Forms: change integrations modal width

### DIFF
--- a/projects/packages/forms/changelog/udpate-forms-consistent-modal-sizes
+++ b/projects/packages/forms/changelog/udpate-forms-consistent-modal-sizes
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Forms: change integrations modal width.

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/index.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/index.tsx
@@ -42,7 +42,7 @@ const IntegrationsModal = ( {
 		<Modal
 			title={ __( 'Manage integrations', 'jetpack-forms' ) }
 			onRequestClose={ onClose }
-			style={ { width: '700px' } }
+			size="large"
 			className="jetpack-forms-integrations-modal"
 		>
 			<VStack spacing="4">

--- a/projects/plugins/jetpack/changelog/udpate-forms-consistent-modal-sizes
+++ b/projects/plugins/jetpack/changelog/udpate-forms-consistent-modal-sizes
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Forms: change integrations modal width.


### PR DESCRIPTION
## Proposed changes:

This PR increases the width of the integrations modal. We had been setting a custom width on the modal. We now use the default 'large' size. One goal was to be consistent in modals widths and match the Export responses modal (see comment [here](https://github.com/Automattic/jetpack/pull/45852#issuecomment-3513192780) and [here](https://github.com/Automattic/jetpack/pull/45852#issuecomment-3513277586)). 

**Dashboard: before**
<img width="1498" height="723" alt="integrations-modal-dashboard-before" src="https://github.com/user-attachments/assets/f6d61414-ca86-4a1b-b4e0-284fba9e4126" />

**Dashboard: after**
<img width="1503" height="719" alt="dashboard-integrations-modal-after" src="https://github.com/user-attachments/assets/566fba75-1892-483b-9c3f-5554d59767e7" />"

**Editor: before**
<img width="1505" height="752" alt="integrations-modal-editor-before" src="https://github.com/user-attachments/assets/53ab5aef-c403-4c7b-ab4e-e943ed96df17" />

**Editor: after**
<img width="1504" height="729" alt="block-integrations-modal-after" src="https://github.com/user-attachments/assets/6572be0d-699e-45e8-a7f5-faf05329810d" />

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
See PR comment links above. 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No. 

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to Jetpack > Forms > Integrations, and confirm the modal opens, has the new width, and otherwise works as expected. Try changing browser widths as well. 

* Add a form to a post, open the integrations modal, and confirm the modal opens, has the new width, and otherwise works as expected. Try changing browser widths as well. 

