### PR TITLE
Forms: Fix hidden unread dot

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-dashboard-unread
+++ b/projects/packages/forms/changelog/fix-forms-dashboard-unread
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: Fix hidden unread dot

--- a/projects/packages/forms/src/dashboard/inbox/style.scss
+++ b/projects/packages/forms/src/dashboard/inbox/style.scss
@@ -329,7 +329,7 @@
 		display: flex;
 		align-items: center;
 		gap: 12px;
-		overflow: hidden;
+		max-width: 100%;
 
 		&--mobile {
 			text-decoration: underline;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Follow-up to #45802

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Fixes an issue introduced in the PR above, which made the unread dot disappear

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the Forms dashboard
* Mark a response as unread
* Check that the unread dot is there

| Before | After |
| - | - |
| <img width="698" height="191" alt="Screenshot from 2025-11-10 16-56-32" src="https://github.com/user-attachments/assets/3450907b-0c46-440f-90ee-a158612c2466" /> | <img width="698" height="191" alt="Screenshot from 2025-11-10 16-56-11" src="https://github.com/user-attachments/assets/572c6cc9-cf97-4457-883e-0ad5487cc522" /> |

