### PR TITLE
wpcomsh: Prevent PHP warnings when doing Jetpack SSO bypass checks

### DIFF
--- a/projects/plugins/wpcomsh/changelog/fix-wpcomsh-jetpack_sso_bypass_warnings
+++ b/projects/plugins/wpcomsh/changelog/fix-wpcomsh-jetpack_sso_bypass_warnings
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Prevent PHP errors when doing SSO bypass checks.

--- a/projects/plugins/wpcomsh/wpcomsh.php
+++ b/projects/plugins/wpcomsh/wpcomsh.php
@@ -241,9 +241,11 @@ function wpcomsh_bypass_jetpack_sso_login() {
 
 	if ( class_exists( '\Automattic\Jetpack\Connection\Manager' ) ) {
 		$connection_manager = new \Automattic\Jetpack\Connection\Manager( 'jetpack' );
-		$users              = get_users( array( 'fields' => array( 'ID' ) ) );
-		foreach ( $users as $user_id ) {
-			if ( ! $connection_manager->is_user_connected( $user_id ) ) {
+
+		// Fetching an extra field to overcome the caching bug: https://core.trac.wordpress.org/ticket/62003
+		$users = get_users( array( 'fields' => array( 'ID', 'user_login' ) ) );
+		foreach ( $users as $user ) {
+			if ( ! $connection_manager->is_user_connected( $user->ID ) ) {
 				return false;
 			}
 		}

--- a/projects/plugins/wpcomsh/wpcomsh.php
+++ b/projects/plugins/wpcomsh/wpcomsh.php
@@ -242,8 +242,8 @@ function wpcomsh_bypass_jetpack_sso_login() {
 	if ( class_exists( '\Automattic\Jetpack\Connection\Manager' ) ) {
 		$connection_manager = new \Automattic\Jetpack\Connection\Manager( 'jetpack' );
 		$users              = get_users( array( 'fields' => array( 'ID' ) ) );
-		foreach ( $users as $user ) {
-			if ( ! $connection_manager->is_user_connected( $user->ID ) ) {
+		foreach ( $users as $user_id ) {
+			if ( ! $connection_manager->is_user_connected( $user_id ) ) {
 				return false;
 			}
 		}


### PR DESCRIPTION
Closes MONOREP-204

 <!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

When checking if Jetpack SSO should be bypassed, we're trying to iterate through `WP_User` objects, but the array is actually user IDs.

I'm not sure the larger implications of this being broken and this PR fixing it.

Here's the warning we're preventing:
```
PHP Warning: Attempt to read property "ID" on string in /wordpress/plugins/wpcomsh/8.1.0-alpha+rolling.1762350417.gbcf04df/wpcomsh.php on line 246
```

Caused by this WP bug: https://core.trac.wordpress.org/ticket/62003

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1762806759887379-slack-C05PV073SG3

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
Reproducing the error is a bit tricky, so we'll just make sure the SSO flow works fine.
1. Create a WoA Dev Blog, checkout the branch for `wpcomsh` plugin.
2. Use your non-a8c Google account to create new Google Docs document.
3. Click on the menu "Extensions -> Add-ons -> Get add-ons", find "WordPress.com for Google Docs" and install it to your Google account.
4. Click on the menu "Extensions -> WordPress.com for Google Docs -> Open". You should see the "WordPress" sidebar.
5. Click "Add WordPress Site", the new browser tab should open. Choose your WoA site and click "Approve".
6. Wait a bit, the authorization window should automatically close.
7. Refresh the document and open the "WPCOM for Google Docs" panel again, confirm you WoA site is now added.