### PR TITLE
wpcomsh: Fix PHP warnings on private site feature

### DIFF
--- a/projects/plugins/wpcomsh/changelog/fix-wpcomsh-private_site_warnings
+++ b/projects/plugins/wpcomsh/changelog/fix-wpcomsh-private_site_warnings
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Private sites: Prevent PHP errors.

--- a/projects/plugins/wpcomsh/private-site/private-site.php
+++ b/projects/plugins/wpcomsh/private-site/private-site.php
@@ -170,7 +170,7 @@ function fetch_option_from_wpcom( $option ) {
 	}
 	$options = $jetpack->get_cloud_site_options( array( $option ) );
 
-	return $options[ $option ];
+	return $options[ $option ] ?? false;
 }
 
 /**

--- a/projects/plugins/wpcomsh/private-site/private-site.php
+++ b/projects/plugins/wpcomsh/private-site/private-site.php
@@ -394,7 +394,9 @@ function get_read_access_cookies( $args ) {
 function is_jetpack_admin_ajax_request() {
 	// phpcs:disable WordPress.Security
 	return (
+		isset( $_SERVER['REQUEST_URI'] ) &&
 		substr( $_SERVER['REQUEST_URI'], 0, 24 ) === '/wp-admin/admin-ajax.php' &&
+		isset( $_SERVER['HTTP_AUTHORIZATION'] ) &&
 		substr( $_SERVER['HTTP_AUTHORIZATION'], 0, 9 ) === 'X_JETPACK' &&
 		array_key_exists( 'action', $_POST ) &&
 		substr( $_POST['action'], 0, 8 ) === 'jetpack_'

--- a/projects/plugins/wpcomsh/private-site/private-site.php
+++ b/projects/plugins/wpcomsh/private-site/private-site.php
@@ -321,6 +321,10 @@ function register_additional_jetpack_xmlrpc_methods( $methods ) {
  * @return array|false
  */
 function get_closest_thumbnail_size_url( $args ) {
+	if ( ! isset( $args['url'] ) || ! isset( $args['width'] ) || ! isset( $args['height'] ) ) {
+		return false;
+	}
+
 	$id = attachment_url_to_postid( $args['url'] );
 	if ( ! $id ) {
 		return false;


### PR DESCRIPTION
Closes MONOREP-205

 <!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This resolves three sets of PHP warnings causing 1M+ log entries in WP Cloud/month.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
```
PHP Warning: Undefined array key "HTTP_AUTHORIZATION" in /wordpress/plugins/wpcomsh/8.1.0-alpha+rolling.1762350417.gbcf04df/private-site/private-site.php on line 398
```

For the above, we verify this key and its `REQUEST_URI` counterpart are set prior to trying to access it.

```
PHP Warning: Undefined array key "url" in /wordpress/plugins/wpcomsh/8.1.0-alpha+rolling.1762799052.g6dc2f33/private-site/private-site.php on line 324
PHP Warning: Undefined array key "width" in /wordpress/plugins/wpcomsh/8.1.0-alpha+rolling.1762799052.g6dc2f33/private-site/private-site.php on line 329
PHP Warning: Undefined array key "height" in /wordpress/plugins/wpcomsh/8.1.0-alpha+rolling.1762799052.g6dc2f33/private-site/private-site.php on line 329
```

For the above, we verify these keys are set prior to trying to access it. Returning `false` is a preexisting return value.

```
PHP Warning: Undefined array key "launch-status" in /wordpress/plugins/wpcomsh/8.1.0-alpha+rolling.1762799052.g6dc2f33/private-site/private-site.php on line 173
PHP Warning: Undefined array key "wpcom_coming_soon" in /wordpress/plugins/wpcomsh/8.1.0-alpha+rolling.1762799052.g6dc2f33/private-site/private-site.php on line 173
```

For these, we fall back to `false` if the key doesn't exist, which is a preexisting return value.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

