### PR TITLE
Forms: add optimistic move for entities

### DIFF
--- a/projects/packages/forms/changelog/add-forms-optimistic-move-entities
+++ b/projects/packages/forms/changelog/add-forms-optimistic-move-entities
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Forms: optimistically move items from/to inbox/trash

--- a/projects/packages/forms/src/dashboard/components/layout/style.scss
+++ b/projects/packages/forms/src/dashboard/components/layout/style.scss
@@ -92,4 +92,24 @@ body.jetpack_page_jetpack-forms-admin {
 	.dataviews-wrapper .dataviews-view-table tr th:last-child {
 		padding-inline-end: 20px;
 	}
+
+	// these override to have rows marked as unread
+	.dataviews-wrapper .dataviews-view-table tr:has(.is-triggering-remove) {
+		// add an animation to collapse the row
+		animation: collapse 0.3s ease-in-out;
+		animation-fill-mode: forwards;
+
+		@keyframes collapse {
+
+			from {
+				opacity: 1;
+				height: 100%;
+			}
+
+			to {
+				opacity: 0;
+				height: 0;
+			}
+		}
+	}
 }

--- a/projects/packages/forms/src/dashboard/inbox/dataviews/actions.tsx
+++ b/projects/packages/forms/src/dashboard/inbox/dataviews/actions.tsx
@@ -326,14 +326,18 @@ export const restoreAction: Action = {
 			multiple: items.length > 1,
 		} );
 
-		const { saveEntityRecord } = registry.dispatch( coreStore );
+		const { saveEntityRecord, editEntityRecord, receiveEntityRecords } =
+			registry.dispatch( coreStore );
 		const { createSuccessNotice, createErrorNotice } = registry.dispatch( noticesStore );
 		const { updateCountsOptimistically } = registry.dispatch( dashboardStore );
 		const { getCurrentQuery } = registry.select( dashboardStore );
 
 		const queryParams = getCountQueryParams( getCurrentQuery() );
 
-		items.forEach( () => {
+		items.forEach( item => {
+			editEntityRecord( 'postType', 'feedback', item.id, {
+				is_triggering_remove: true,
+			} );
 			updateCountsOptimistically( 'trash', 'publish', 1, queryParams );
 		} );
 
@@ -378,6 +382,14 @@ export const restoreAction: Action = {
 				],
 			} );
 
+			const restoreItems = items.map( item => {
+				return {
+					...item,
+					is_triggering_remove: false,
+				};
+			} );
+			receiveEntityRecords( 'postType', 'feedback', restoreItems, queryParams, true );
+
 			return;
 		}
 
@@ -402,7 +414,8 @@ export const moveToTrashAction: Action = {
 			multiple: items.length > 1,
 		} );
 
-		const { deleteEntityRecord } = registry.dispatch( coreStore );
+		const { deleteEntityRecord, editEntityRecord, receiveEntityRecords } =
+			registry.dispatch( coreStore );
 		const { createSuccessNotice, createErrorNotice } = registry.dispatch( noticesStore );
 		const { updateCountsOptimistically } = registry.dispatch( dashboardStore );
 		const { getCurrentQuery } = registry.select( dashboardStore );
@@ -410,6 +423,9 @@ export const moveToTrashAction: Action = {
 		const queryParams = getCountQueryParams( getCurrentQuery() );
 
 		items.forEach( item => {
+			editEntityRecord( 'postType', 'feedback', item.id, {
+				is_triggering_remove: true,
+			} );
 			updateCountsOptimistically( item.status, 'trash', 1, queryParams );
 		} );
 
@@ -457,6 +473,14 @@ export const moveToTrashAction: Action = {
 					},
 				],
 			} );
+
+			const restoreItems = items.map( item => {
+				return {
+					...item,
+					is_triggering_remove: false,
+				};
+			} );
+			receiveEntityRecords( 'postType', 'feedback', restoreItems, queryParams, true );
 
 			return;
 		}

--- a/projects/packages/forms/src/dashboard/inbox/dataviews/index.js
+++ b/projects/packages/forms/src/dashboard/inbox/dataviews/index.js
@@ -264,7 +264,8 @@ export default function InboxView() {
 						<div
 							className={ clsx(
 								'jp-forms__inbox__author-field',
-								isMobileViewport && 'jp-forms__inbox__author-field--mobile'
+								isMobileViewport && 'jp-forms__inbox__author-field--mobile',
+								item.is_triggering_remove === true && 'is-triggering-remove'
 							) }
 							{ ...( isMobileViewport && {
 								onClick: handleClick,

--- a/projects/packages/forms/src/dashboard/inbox/dataviews/types.tsx
+++ b/projects/packages/forms/src/dashboard/inbox/dataviews/types.tsx
@@ -48,6 +48,13 @@ export type Registry = {
 			recordId: number,
 			edits: Record< string, unknown >
 		) => Promise< void >;
+		receiveEntityRecords: (
+			kind: string,
+			name: string,
+			records: FormResponse[],
+			query?: QueryParams,
+			invalidateCache?: boolean
+		) => Promise< void >;
 
 		// Dashboard store actions
 		updateCountsOptimistically: (


### PR DESCRIPTION
WIP

Fixes #

## Proposed changes:
Use an entity prop to flag rows being actioned. TBD

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1762781493442119-slack-C052XEUUBL4

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
TBD