### PR TITLE
Forms: Fix default background color

### DIFF
--- a/projects/packages/forms/changelog/fix-default-background-color
+++ b/projects/packages/forms/changelog/fix-default-background-color
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: set the correct default background color for inputs. 

--- a/projects/packages/forms/src/blocks/contact-form/util/form-styles.js
+++ b/projects/packages/forms/src/blocks/contact-form/util/form-styles.js
@@ -92,7 +92,10 @@ window.jetpackForms.generateStyleVariables = function ( formNode ) {
 
 	const backgroundColor = window.jetpackForms.getBackgroundColor( bodyNode );
 	const inputBackgroundFallback = window.jetpackForms.getBackgroundColor( inputNode );
-	const inputBackground = window.getComputedStyle( inputNode ).backgroundColor;
+
+	const inputElementBackground = window.getComputedStyle( inputNode ).backgroundColor;
+	const inputBackground =
+		inputElementBackground === 'rgba(0, 0, 0, 0)' ? '#FFF' : inputElementBackground;
 	const bodyTextColor = window.getComputedStyle( formRootNode ).color;
 	const invertedBodyTextColor = window.jetpackForms.getInverseReadableColor( bodyTextColor );
 	const {

--- a/projects/packages/forms/src/contact-form/css/file-field.scss
+++ b/projects/packages/forms/src/contact-form/css/file-field.scss
@@ -10,6 +10,7 @@
 	margin-bottom: 8px;
 	background-color: var(--jetpack--contact-form--input-background);
 	border-radius: var(--jetpack--contact-form--border-radius, 0);
+	color: var(--jetpack--contact-form--text-color, currentColor);
 }
 
 .wp-block-jetpack-dropzone.is-content-justification-right {

--- a/projects/packages/forms/src/contact-form/css/grunion.scss
+++ b/projects/packages/forms/src/contact-form/css/grunion.scss
@@ -1100,6 +1100,10 @@ on production builds, the attributes are being reordered, causing side-effects
 	left: 0;
 }
 
+.contact-form .grunion-field-wrap:not(.is-style-plain) input.radio:checked::after {
+	display: none; /* Prevent themes style from being added to the radio button as well */
+}
+
 .contact-form .grunion-field-wrap.grunion-field-checkbox-multiple-wrap.is-style-button-wrap .contact-form-field,
 .contact-form .grunion-field-wrap.grunion-field-radio-wrap.is-style-button-wrap .contact-form-field {
 	display: inline-flex;

--- a/projects/packages/forms/src/contact-form/css/grunion.scss
+++ b/projects/packages/forms/src/contact-form/css/grunion.scss
@@ -1068,6 +1068,12 @@ on production builds, the attributes are being reordered, causing side-effects
 	left: 0;
 }
 
+.contact-form .is-style-list input.consent::after,
+.contact-form .is-style-list input.checkbox::after,
+.contact-form .grunion-field-wrap:not(.is-style-plain) input.checkbox-multiple::after {
+	display: none;
+}
+
 .contact-form .is-style-list input.consent:checked::before,
 .contact-form .is-style-list input.checkbox:checked::before,
 .contact-form .grunion-field-wrap:not(.is-style-plain) input.checkbox-multiple:checked::before {

--- a/projects/packages/forms/src/contact-form/css/grunion.scss
+++ b/projects/packages/forms/src/contact-form/css/grunion.scss
@@ -1042,7 +1042,7 @@ on production builds, the attributes are being reordered, causing side-effects
 .contact-form .is-style-list input.consent:checked,
 .contact-form .is-style-list input.checkbox:checked,
 .contact-form .grunion-field-wrap:not(.is-style-plain) input.checkbox-multiple:checked {
-	background-color: currentColor;
+	background-color: var(--jetpack--contact-form--text-color);
 
 }
 

--- a/projects/plugins/jetpack/changelog/fix-default-background-color
+++ b/projects/plugins/jetpack/changelog/fix-default-background-color
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Forms: set the correct default backfround color for inputs


### PR DESCRIPTION
Related to FORMS-299

This PR fixes the default input colour to be White. Which is the expected colour for inputs when no input is set. 

This happends on the Ravington as well as the default Twenty-Twenty One theme. 

Fixes THEME-85

Before Revington theme.

<img width="1016" height="848" alt="Screenshot 2025-11-10 at 3 35 12 PM" src="https://github.com/user-attachments/assets/e3456092-3467-4328-9471-2f7efc7f4919" />

After:

<img width="972" height="771" alt="Screenshot 2025-11-10 at 3 34 54 PM" src="https://github.com/user-attachments/assets/c0c9b1b1-24d1-47b1-92e2-49836c28a9c8" />



This also 

## Proposed changes:
* This PR fixes a number of issues.
1. default backgournd colour should be white. 
2. Checkboxes should work as well. 
3. Prevent double adding checkboxes and radio buttons. (by removing the after psudeo elements) This applies to the twenty-twenty-one theme. 
4. Use the same colour on dropzone as the text. So that the dropzone get the expected text colour. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
* Create a page with all the form fields. 
* Switch to the Ravinngto theme Notice that it looks as expected. 
* Switch to the Twenty Twenty One the Notice that the page looks like you would expect. 
* Switch to many other themes notice that things still work as expected. 

