### PR TITLE
Use batch requests when possible

### DIFF
--- a/projects/packages/woocommerce-analytics/changelog/update-batch-requests-when-possible
+++ b/projects/packages/woocommerce-analytics/changelog/update-batch-requests-when-possible
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Implement batched pixel requests for improved performance when sending tracking events

--- a/projects/packages/woocommerce-analytics/src/class-wc-analytics-tracking.php
+++ b/projects/packages/woocommerce-analytics/src/class-wc-analytics-tracking.php
@@ -268,10 +268,8 @@ class WC_Analytics_Tracking extends WC_Tracks {
 			} elseif ( class_exists( 'Requests' ) ) {
 				\Requests::request_multiple( $requests, $options ); // phpcs:ignore PHPCompatibility.FunctionUse.RemovedFunctions.requestsDeprecated
 			}
-		} catch ( \Exception $e ) {
+		} catch ( \Exception $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
 			// Silently fail - tracking pixels should not break the site.
-			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
-			error_log( 'WooCommerce Analytics: Batch pixel request failed - ' . $e->getMessage() );
 		}
 	}
 

--- a/projects/packages/woocommerce-analytics/src/class-wc-analytics-tracking.php
+++ b/projects/packages/woocommerce-analytics/src/class-wc-analytics-tracking.php
@@ -177,7 +177,7 @@ class WC_Analytics_Tracking extends WC_Tracks {
 	 * @return bool|WP_Error True for success or WP_Error if the event pixel could not be fired.
 	 */
 	private static function record_event_pixel( $event ) {
-		$pixel = $event->build_pixel_url( $event );
+		$pixel = $event->build_pixel_url();
 
 		if ( ! $pixel ) {
 			return new WP_Error( 'invalid_pixel', 'cannot generate tracks pixel for given input', 400 );

--- a/projects/packages/woocommerce-analytics/src/class-wc-analytics-tracking.php
+++ b/projects/packages/woocommerce-analytics/src/class-wc-analytics-tracking.php
@@ -192,7 +192,9 @@ class WC_Analytics_Tracking extends WC_Tracks {
 			self::queue_pixel_for_batch( $pixel );
 		} else {
 			// Send immediately as batching is not supported.
-			return WC_Tracks_Client::record_event( $event ); // phpcs:ignore WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid -- @phan-suppress-current-line PhanTypeMismatchArgumentProbablyReal
+			// phpcs:ignore WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid
+			// @phan-suppress-next-line PhanTypeMismatchArgument
+			return WC_Tracks_Client::record_event( $event );
 		}
 
 		return true;

--- a/projects/packages/woocommerce-analytics/src/class-wc-analytics-tracking.php
+++ b/projects/packages/woocommerce-analytics/src/class-wc-analytics-tracking.php
@@ -210,7 +210,7 @@ class WC_Analytics_Tracking extends WC_Tracks {
 
 		// Register shutdown hook once.
 		if ( ! self::$shutdown_hook_registered ) {
-			add_action( 'shutdown', array( __CLASS__, 'send_batched_pixels' ), 1 );
+			add_action( 'shutdown', array( __CLASS__, 'send_batched_pixels' ), 20 );
 			self::$shutdown_hook_registered = true;
 		}
 	}

--- a/projects/packages/woocommerce-analytics/src/class-wc-analytics-tracking.php
+++ b/projects/packages/woocommerce-analytics/src/class-wc-analytics-tracking.php
@@ -41,6 +41,20 @@ class WC_Analytics_Tracking extends WC_Tracks {
 	protected static $event_queue = array();
 
 	/**
+	 * Batch pixel queue for batched requests.
+	 *
+	 * @var array
+	 */
+	private static $pixel_batch_queue = array();
+
+	/**
+	 * Whether the shutdown hook has been registered.
+	 *
+	 * @var bool
+	 */
+	private static $shutdown_hook_registered = false;
+
+	/**
 	 * Cached user IP address for the current request.
 	 *
 	 * @var string|null
@@ -138,7 +152,7 @@ class WC_Analytics_Tracking extends WC_Tracks {
 			return $event_obj->error;
 		}
 
-		return WC_Tracks_Client::record_event( $event_obj ); // phpcs:ignore WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid @phan-suppress-current-line PhanTypeMismatchArgumentProbablyReal
+		return self::record_event_pixel( $event_obj );
 	}
 
 	/**
@@ -152,7 +166,131 @@ class WC_Analytics_Tracking extends WC_Tracks {
 		if ( is_wp_error( $event_obj->error ) ) {
 			return $event_obj->error;
 		}
-		return WC_Tracks_Client::record_event( $event_obj ); // phpcs:ignore WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid @phan-suppress-current-line PhanTypeMismatchArgumentProbablyReal
+
+		return self::record_event_pixel( $event_obj );
+	}
+
+	/**
+	 * Record an event pixel using batching.
+	 *
+	 * @param WC_Tracks_Event|WC_Analytics_Ch_Event $event The event object.
+	 * @return bool|WP_Error True for success or WP_Error if the event pixel could not be fired.
+	 */
+	private static function record_event_pixel( $event ) {
+		$pixel = $event->build_pixel_url( $event );
+
+		if ( ! $pixel ) {
+			return new WP_Error( 'invalid_pixel', 'cannot generate tracks pixel for given input', 400 );
+		}
+
+		// Queue the pixel and send on shutdown.
+		self::queue_pixel_for_batch( $pixel );
+		return true;
+	}
+
+	/**
+	 * Queue a pixel URL for batch sending.
+	 *
+	 * @param string $pixel The pixel URL to queue.
+	 */
+	private static function queue_pixel_for_batch( $pixel ) {
+		self::$pixel_batch_queue[] = $pixel;
+
+		// Register shutdown hook once.
+		if ( ! self::$shutdown_hook_registered ) {
+			add_action( 'shutdown', array( __CLASS__, 'send_batched_pixels' ), 1 );
+			self::$shutdown_hook_registered = true;
+		}
+	}
+
+	/**
+	 * Send all queued pixels using batched non-blocking requests.
+	 * This runs on the shutdown hook to batch all requests together.
+	 *
+	 * Uses Requests library's request_multiple() when available for true parallel
+	 * batching via curl_multi, otherwise falls back to sequential non-blocking requests.
+	 */
+	public static function send_batched_pixels() {
+		if ( empty( self::$pixel_batch_queue ) ) {
+			return;
+		}
+
+		// Add request timestamp and nocache to all pixels.
+		$pixels_to_send = array();
+		foreach ( self::$pixel_batch_queue as $pixel ) {
+			$pixels_to_send[] = WC_Tracks_Client::add_request_timestamp_and_nocache( $pixel );
+		}
+
+		// Try to use Requests library for true parallel batching.
+		$can_batch = ( class_exists( 'WpOrg\Requests\Requests' ) && method_exists( 'WpOrg\Requests\Requests', 'request_multiple' ) )
+			|| ( class_exists( 'Requests' ) && method_exists( 'Requests', 'request_multiple' ) );
+
+		if ( $can_batch ) {
+			self::send_with_requests_multiple( $pixels_to_send );
+		} else {
+			// Fallback: send individual non-blocking requests.
+			self::send_with_individual_requests( $pixels_to_send );
+		}
+
+		// Clear the queue.
+		self::$pixel_batch_queue = array();
+	}
+
+	/**
+	 * Send pixels using Requests::request_multiple() for parallel non-blocking execution.
+	 * Uses blocking => false for true non-blocking behavior via curl_multi.
+	 *
+	 * @param array $pixels Array of pixel URLs to send.
+	 */
+	private static function send_with_requests_multiple( $pixels ) {
+		$requests = array();
+		$options  = array(
+			'blocking' => false, // Non-blocking mode - returns immediately.
+			'timeout'  => 1,
+		);
+
+		foreach ( $pixels as $pixel ) {
+			$requests[] = array(
+				'url'     => $pixel,
+				'headers' => array(),
+				'data'    => array(),
+				'type'    => 'GET',
+			);
+		}
+
+		try {
+			// Try modern namespaced version first.
+			if ( class_exists( 'WpOrg\Requests\Requests' ) ) {
+				\WpOrg\Requests\Requests::request_multiple( $requests, $options );
+			} elseif ( class_exists( 'Requests' ) ) {
+				\Requests::request_multiple( $requests, $options ); // phpcs:ignore PHPCompatibility.FunctionUse.RemovedFunctions.requestsDeprecated
+			}
+		} catch ( \Exception $e ) {
+			// Silently fail - tracking pixels should not break the site.
+			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+			error_log( 'WooCommerce Analytics: Batch pixel request failed - ' . $e->getMessage() );
+		}
+	}
+
+	/**
+	 * Send pixels using individual non-blocking wp_remote_get() calls.
+	 * This is the fallback when Requests::request_multiple() is not available.
+	 *
+	 * @param array $pixels Array of pixel URLs to send.
+	 */
+	private static function send_with_individual_requests( $pixels ) {
+		foreach ( $pixels as $pixel ) {
+			wp_remote_get(
+				$pixel,
+				array(
+					'blocking'    => false,
+					'timeout'     => 1,
+					'redirection' => 2,
+					'httpversion' => '1.1',
+					'sslverify'   => true,
+				)
+			);
+		}
 	}
 
 	/**

--- a/projects/packages/woocommerce-analytics/src/class-wc-analytics-tracking.php
+++ b/projects/packages/woocommerce-analytics/src/class-wc-analytics-tracking.php
@@ -268,8 +268,9 @@ class WC_Analytics_Tracking extends WC_Tracks {
 			} elseif ( class_exists( 'Requests' ) ) {
 				\Requests::request_multiple( $requests, $options ); // phpcs:ignore PHPCompatibility.FunctionUse.RemovedFunctions.requestsDeprecated
 			}
-		} catch ( \Exception $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
-			// Silently fail - tracking pixels should not break the site.
+		} catch ( \Exception $e ) {
+			// Log error but don't break the site - tracking pixels should fail gracefully.
+			wc_get_logger()->error( 'WooCommerce Analytics: Batch pixel request failed - ' . $e->getMessage(), array( 'source' => 'woocommerce-analytics' ) );
 		}
 	}
 

--- a/projects/packages/woocommerce-analytics/src/class-wc-analytics-tracking.php
+++ b/projects/packages/woocommerce-analytics/src/class-wc-analytics-tracking.php
@@ -274,27 +274,6 @@ class WC_Analytics_Tracking extends WC_Tracks {
 	}
 
 	/**
-	 * Send pixels using individual non-blocking wp_remote_get() calls.
-	 * This is the fallback when Requests::request_multiple() is not available.
-	 *
-	 * @param array $pixels Array of pixel URLs to send.
-	 */
-	private static function send_with_individual_requests( $pixels ) {
-		foreach ( $pixels as $pixel ) {
-			wp_remote_get(
-				$pixel,
-				array(
-					'blocking'    => false,
-					'timeout'     => 1,
-					'redirection' => 2,
-					'httpversion' => '1.1',
-					'sslverify'   => true,
-				)
-			);
-		}
-	}
-
-	/**
 	 * Get all properties for the event including filtered and identity properties.
 	 *
 	 * @param string $event_name Event name.

--- a/projects/packages/woocommerce-analytics/src/class-wc-analytics-tracking.php
+++ b/projects/packages/woocommerce-analytics/src/class-wc-analytics-tracking.php
@@ -192,7 +192,17 @@ class WC_Analytics_Tracking extends WC_Tracks {
 			self::queue_pixel_for_batch( $pixel );
 		} else {
 			// Send immediately as batching is not supported.
-			return WC_Tracks_Client::record_event( $event ); // phpcs:ignore WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid
+			$pixel_with_timestamp = WC_Tracks_Client::add_request_timestamp_and_nocache( $pixel );
+			wp_remote_get(
+				$pixel_with_timestamp,
+				array(
+					'blocking'    => true,
+					'timeout'     => 1,
+					'redirection' => 2,
+					'httpversion' => '1.1',
+					'sslverify'   => true,
+				)
+			);
 		}
 
 		return true;

--- a/projects/packages/woocommerce-analytics/src/class-wc-analytics-tracking.php
+++ b/projects/packages/woocommerce-analytics/src/class-wc-analytics-tracking.php
@@ -183,8 +183,18 @@ class WC_Analytics_Tracking extends WC_Tracks {
 			return new WP_Error( 'invalid_pixel', 'cannot generate tracks pixel for given input', 400 );
 		}
 
-		// Queue the pixel and send on shutdown.
-		self::queue_pixel_for_batch( $pixel );
+		// Check if batching is supported.
+		$can_batch = ( class_exists( 'WpOrg\Requests\Requests' ) && method_exists( 'WpOrg\Requests\Requests', 'request_multiple' ) )
+			|| ( class_exists( 'Requests' ) && method_exists( 'Requests', 'request_multiple' ) );
+
+		if ( $can_batch ) {
+			// Queue the pixel and send on shutdown.
+			self::queue_pixel_for_batch( $pixel );
+		} else {
+			// Send immediately as batching is not supported.
+			return WC_Tracks_Client::record_event( $event ); // phpcs:ignore WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid
+		}
+
 		return true;
 	}
 
@@ -207,8 +217,7 @@ class WC_Analytics_Tracking extends WC_Tracks {
 	 * Send all queued pixels using batched non-blocking requests.
 	 * This runs on the shutdown hook to batch all requests together.
 	 *
-	 * Uses Requests library's request_multiple() when available for true parallel
-	 * batching via curl_multi, otherwise falls back to sequential non-blocking requests.
+	 * Uses Requests library's request_multiple() for true parallel batching via curl_multi.
 	 */
 	public static function send_batched_pixels() {
 		if ( empty( self::$pixel_batch_queue ) ) {
@@ -221,16 +230,8 @@ class WC_Analytics_Tracking extends WC_Tracks {
 			$pixels_to_send[] = WC_Tracks_Client::add_request_timestamp_and_nocache( $pixel );
 		}
 
-		// Try to use Requests library for true parallel batching.
-		$can_batch = ( class_exists( 'WpOrg\Requests\Requests' ) && method_exists( 'WpOrg\Requests\Requests', 'request_multiple' ) )
-			|| ( class_exists( 'Requests' ) && method_exists( 'Requests', 'request_multiple' ) );
-
-		if ( $can_batch ) {
-			self::send_with_requests_multiple( $pixels_to_send );
-		} else {
-			// Fallback: send individual non-blocking requests.
-			self::send_with_individual_requests( $pixels_to_send );
-		}
+		// Send with Requests library for true parallel batching.
+		self::send_with_requests_multiple( $pixels_to_send );
 
 		// Clear the queue.
 		self::$pixel_batch_queue = array();

--- a/projects/packages/woocommerce-analytics/src/class-wc-analytics-tracking.php
+++ b/projects/packages/woocommerce-analytics/src/class-wc-analytics-tracking.php
@@ -192,7 +192,7 @@ class WC_Analytics_Tracking extends WC_Tracks {
 			self::queue_pixel_for_batch( $pixel );
 		} else {
 			// Send immediately as batching is not supported.
-			return WC_Tracks_Client::record_event( $event ); // phpcs:ignore WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid @phan-suppress-current-line PhanTypeMismatchArgumentProbablyReal
+			return WC_Tracks_Client::record_event( $event ); // phpcs:ignore WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid -- @phan-suppress-current-line PhanTypeMismatchArgumentProbablyReal
 		}
 
 		return true;

--- a/projects/packages/woocommerce-analytics/src/class-wc-analytics-tracking.php
+++ b/projects/packages/woocommerce-analytics/src/class-wc-analytics-tracking.php
@@ -192,17 +192,7 @@ class WC_Analytics_Tracking extends WC_Tracks {
 			self::queue_pixel_for_batch( $pixel );
 		} else {
 			// Send immediately as batching is not supported.
-			$pixel_with_timestamp = WC_Tracks_Client::add_request_timestamp_and_nocache( $pixel );
-			wp_remote_get(
-				$pixel_with_timestamp,
-				array(
-					'blocking'    => true,
-					'timeout'     => 1,
-					'redirection' => 2,
-					'httpversion' => '1.1',
-					'sslverify'   => true,
-				)
-			);
+			return WC_Tracks_Client::record_event( $event ); // phpcs:ignore WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid @phan-suppress-current-line PhanTypeMismatchArgumentProbablyReal
 		}
 
 		return true;


### PR DESCRIPTION
## Proposed changes:

This PR implements request batching for analytics tracking pixels to improve performance by sending multiple tracking events together rather than individually.

### Changes:
* Queue tracking pixels during request execution instead of sending immediately
* Send all queued pixels together on the shutdown hook using WordPress Requests library
* Use `Requests::request_multiple()` with `blocking => false` for parallel non-blocking execution when available
* Fallback to sequential non-blocking `wp_remote_get()` calls when batch API is unavailable
* Maintains full backward compatibility with existing `WC_Tracks_Client` implementation

### Benefits:
* **Performance improvement**: Parallel execution reduces total request time (e.g., 10 pixels execute in ~100ms vs ~1000ms sequential)
* **Non-blocking**: Uses `blocking => false` to ensure zero impact on page load time
* **Efficient batching**: Reduces overhead by grouping related tracking requests
* **WordPress-native**: Uses WordPress Requests library instead of direct curl usage
* **Graceful degradation**: Automatically falls back when batching is unavailable

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- p2 discussion link if applicable -->

## Does this pull request change what data or activity we track or use?

No, this PR does not change what data is tracked. It only changes *how* tracking pixels are sent (batched vs individual requests). The same events with the same data are still being tracked.

## Testing instructions:

### Prerequisites:
* Set up a WooCommerce site with Jetpack and WooCommerce Analytics enabled
* Ensure analytics consent is granted (required for events to fire)

### Test 1: Verify events still fire correctly
1. Navigate to a WooCommerce store page that triggers multiple analytics events (e.g., product page, cart page)
2. Open browser developer tools → Network tab
3. Filter for requests to `/wp-json/woocommerce-analytics/v1/track`
4. The response time should be ~1/2 than it used to be for two+ events
5. Check that events appear in ClickHouse

Note: on my local, this reduced response time from 500ms+ to ~250ms for two events.

