### PR TITLE
Fix `WordPress.WP.GetMetaSingle.Missing` sniff

### DIFF
--- a/projects/packages/publicize/changelog/fix-wordpress-wp-getmetasingle
+++ b/projects/packages/publicize/changelog/fix-wordpress-wp-getmetasingle
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Fix `WordPress.WP.GetMetaSingle.Missing` sniff, being added in WPCS 3.2.
+
+

--- a/projects/packages/publicize/src/class-publicize-base.php
+++ b/projects/packages/publicize/src/class-publicize-base.php
@@ -910,7 +910,7 @@ abstract class Publicize_Base {
 							get_post_meta( $post->ID, $this->POST_SKIP_PUBLICIZE . $connection_id, true )
 							||
 							// Old flags.
-							get_post_meta( $post->ID, $this->POST_SKIP . $service_name )
+							get_post_meta( $post->ID, $this->POST_SKIP . $service_name, false )
 						)
 					)
 					||

--- a/projects/packages/publicize/src/class-publicize.php
+++ b/projects/packages/publicize/src/class-publicize.php
@@ -699,7 +699,7 @@ class Publicize extends Publicize_Base {
 		}
 		// Only do this when a post transitions to being published.
 		// phpcs:disable WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
-		if ( get_post_meta( $post->ID, $this->PENDING ) && $this->post_type_is_publicizeable( $post->post_type ) ) {
+		if ( get_post_meta( $post->ID, $this->PENDING, false ) && $this->post_type_is_publicizeable( $post->post_type ) ) {
 			delete_post_meta( $post->ID, $this->PENDING );
 			update_post_meta( $post->ID, $this->POST_DONE . 'all', true );
 		}

--- a/projects/packages/publicize/src/class-share-status.php
+++ b/projects/packages/publicize/src/class-share-status.php
@@ -35,7 +35,7 @@ class Share_Status {
 		// If the data is in an associative array format, we fetch it without true to get all the shares.
 		// This is needed to support the old WPCOM format.
 		if ( isset( $shares ) && is_array( $shares ) && ! array_is_list( $shares ) ) {
-			$shares = get_post_meta( $post_id, self::SHARES_META_KEY );
+			$shares = get_post_meta( $post_id, self::SHARES_META_KEY, false );
 		}
 
 		// Better safe than sorry.

--- a/projects/packages/publicize/tests/php/Share_Status_Test.php
+++ b/projects/packages/publicize/tests/php/Share_Status_Test.php
@@ -218,7 +218,8 @@ class Share_Status_Test extends TestCase {
 		$this->assertEquals(
 			get_post_meta(
 				static::$post_id,
-				Share_Status::SHARES_META_KEY
+				Share_Status::SHARES_META_KEY,
+				false
 			),
 			array(
 				$shares[0],

--- a/projects/packages/stats/changelog/fix-wordpress-wp-getmetasingle
+++ b/projects/packages/stats/changelog/fix-wordpress-wp-getmetasingle
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Fix `WordPress.WP.GetMetaSingle.Missing` sniff, being added in WPCS 3.2.
+
+

--- a/projects/packages/stats/src/class-wpcom-stats.php
+++ b/projects/packages/stats/src/class-wpcom-stats.php
@@ -498,7 +498,7 @@ class WPCOM_Stats {
 	protected function fetch_post_stats( $args, $post_id ) {
 		$endpoint    = $this->build_endpoint();
 		$meta_name   = '_' . self::STATS_CACHE_TRANSIENT_PREFIX;
-		$stats_cache = get_post_meta( $post_id, $meta_name );
+		$stats_cache = get_post_meta( $post_id, $meta_name, false );
 
 		if ( $stats_cache ) {
 			$data = reset( $stats_cache );

--- a/projects/packages/videopress/changelog/fix-wordpress-wp-getmetasingle
+++ b/projects/packages/videopress/changelog/fix-wordpress-wp-getmetasingle
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Fix `WordPress.WP.GetMetaSingle.Missing` sniff, being added in WPCS 3.2.
+
+

--- a/projects/packages/videopress/src/class-attachment-handler.php
+++ b/projects/packages/videopress/src/class-attachment-handler.php
@@ -194,7 +194,7 @@ class Attachment_Handler {
 	 */
 	public static function prepare_attachment_for_js( $post ) {
 		if ( 'video' === $post['type'] ) {
-			$guid = get_post_meta( $post['id'], 'videopress_guid' );
+			$guid = get_post_meta( $post['id'], 'videopress_guid', true );
 			if ( $guid ) {
 				$post['videopress_guid'] = $guid;
 			}

--- a/projects/plugins/jetpack/_inc/lib/class.media.php
+++ b/projects/plugins/jetpack/_inc/lib/class.media.php
@@ -245,7 +245,7 @@ class Jetpack_Media {
 	 * @return array `revision_history` array
 	 */
 	public static function get_revision_history( $media_id ) {
-		return array_reverse( get_post_meta( $media_id, self::WP_REVISION_HISTORY ) );
+		return array_reverse( get_post_meta( $media_id, self::WP_REVISION_HISTORY, false ) );
 	}
 
 	/**

--- a/projects/plugins/jetpack/changelog/fix-wordpress-wp-getmetasingle
+++ b/projects/plugins/jetpack/changelog/fix-wordpress-wp-getmetasingle
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Fix `WordPress.WP.GetMetaSingle.Missing` sniff, being added in WPCS 3.2.
+
+

--- a/projects/plugins/jetpack/class.jetpack-post-images.php
+++ b/projects/plugins/jetpack/class.jetpack-post-images.php
@@ -371,7 +371,7 @@ class Jetpack_PostImages {
 			// Let's try to use the postmeta if we can, since it seems to be
 			// more reliable
 			if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
-				$featured_image = get_post_meta( $post->ID, '_jetpack_featured_image' );
+				$featured_image = get_post_meta( $post->ID, '_jetpack_featured_image', false );
 				if ( $featured_image ) {
 					$url = $featured_image[0];
 				} else {

--- a/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Meta_Test.php
+++ b/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Meta_Test.php
@@ -88,7 +88,7 @@ class Jetpack_Sync_Meta_Test extends Jetpack_Sync_TestBase {
 		$this->sender->do_sync();
 
 		$meta_key_array = $this->server_replica_storage->get_metadata( 'post', $this->post_id, $this->whitelisted_post_meta );
-		$this->assertEquals( get_post_meta( $this->post_id, $this->whitelisted_post_meta ), $meta_key_array );
+		$this->assertEquals( get_post_meta( $this->post_id, $this->whitelisted_post_meta, false ), $meta_key_array );
 	}
 
 	/**
@@ -101,7 +101,7 @@ class Jetpack_Sync_Meta_Test extends Jetpack_Sync_TestBase {
 		$this->sender->do_sync();
 
 		$meta_key_array = $this->server_replica_storage->get_metadata( 'post', $this->post_id, $this->whitelisted_post_meta );
-		$this->assertEquals( get_post_meta( $this->post_id, $this->whitelisted_post_meta ), $meta_key_array );
+		$this->assertEquals( get_post_meta( $this->post_id, $this->whitelisted_post_meta, false ), $meta_key_array );
 	}
 
 	/**
@@ -117,7 +117,7 @@ class Jetpack_Sync_Meta_Test extends Jetpack_Sync_TestBase {
 		$meta_key_array = $this->server_replica_storage->get_metadata( 'post', $this->post_id, $this->whitelisted_post_meta );
 
 		$this->assertEquals( get_post_meta( $this->post_id, $this->whitelisted_post_meta, true ), $meta_key_value );
-		$this->assertEquals( get_post_meta( $this->post_id, $this->whitelisted_post_meta ), $meta_key_array );
+		$this->assertEquals( get_post_meta( $this->post_id, $this->whitelisted_post_meta, false ), $meta_key_array );
 	}
 
 	/**
@@ -133,7 +133,7 @@ class Jetpack_Sync_Meta_Test extends Jetpack_Sync_TestBase {
 		$meta_key_value = $this->server_replica_storage->get_metadata( 'post', $this->post_id, $this->whitelisted_post_meta, true );
 		$meta_key_array = $this->server_replica_storage->get_metadata( 'post', $this->post_id, $this->whitelisted_post_meta );
 		$this->assertEquals( get_post_meta( $this->post_id, $this->whitelisted_post_meta, true ), $meta_key_value );
-		$this->assertEquals( get_post_meta( $this->post_id, $this->whitelisted_post_meta ), $meta_key_array );
+		$this->assertEquals( get_post_meta( $this->post_id, $this->whitelisted_post_meta, false ), $meta_key_array );
 	}
 
 	/**


### PR DESCRIPTION
Closes MONOREP-210

 <!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Being added in WPCS 3.2.

Most of the time I set it false to preserve the current behavior. One case seemed pretty obviously intending to fetch a single item though, and is used as such in other calls.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Changes look right?
