### PR TITLE
Update `Jetpack_Notifications::print_js()` to be CSP-compatible

### DIFF
--- a/projects/plugins/jetpack/changelog/improve-csp-compatibility
+++ b/projects/plugins/jetpack/changelog/improve-csp-compatibility
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Update Jetpack notifications script tag to use wp_print_inline_script_tag. This allows for injection of a nonce attribute and CSP compatibility.

--- a/projects/plugins/jetpack/modules/notes.php
+++ b/projects/plugins/jetpack/modules/notes.php
@@ -237,7 +237,7 @@ var wpNotesIsJetpackClient = true;
 var wpNotesIsJetpackClientV2 = true;
 JS;
 		if ( $link_accounts_url ) {
-			$script_contents .= "\nvar wpNotesLinkAccountsURL = " . wp_json_encode( $link_accounts_url, JSON_HEX_TAG | JSON_UNESCAPED_SLASHES );
+			$script_contents .= "\nvar wpNotesLinkAccountsURL = " . wp_json_encode( $link_accounts_url, JSON_HEX_TAG | JSON_UNESCAPED_SLASHES ) . ';';
 		}
 		wp_print_inline_script_tag(
 			$script_contents,

--- a/projects/plugins/jetpack/modules/notes.php
+++ b/projects/plugins/jetpack/modules/notes.php
@@ -232,7 +232,7 @@ class Jetpack_Notifications {
 	 */
 	public function print_js() {
 		$link_accounts_url = is_user_logged_in() && ! ( new Connection_Manager( 'jetpack' ) )->is_user_connected() ? Jetpack::admin_url() : false;
-		$script_contents   = <<<JS
+		$script_contents   = <<<'JS'
 var wpNotesIsJetpackClient = true;
 var wpNotesIsJetpackClientV2 = true;
 JS;

--- a/projects/plugins/jetpack/modules/notes.php
+++ b/projects/plugins/jetpack/modules/notes.php
@@ -232,17 +232,22 @@ class Jetpack_Notifications {
 	 */
 	public function print_js() {
 		$link_accounts_url = is_user_logged_in() && ! ( new Connection_Manager( 'jetpack' ) )->is_user_connected() ? Jetpack::admin_url() : false;
+		ob_start();
 		?>
-<script data-ampdevmode type="text/javascript">
-/* <![CDATA[ */
-	var wpNotesIsJetpackClient = true;
-	var wpNotesIsJetpackClientV2 = true;
+		<script>
+		var wpNotesIsJetpackClient = true;
+		var wpNotesIsJetpackClientV2 = true;
 		<?php if ( $link_accounts_url ) : ?>
-	var wpNotesLinkAccountsURL = '<?php echo esc_url( $link_accounts_url ); ?>';
-<?php endif; ?>
-/* ]]> */
-</script>
+			var wpNotesLinkAccountsURL = <?php echo wp_json_encode( $link_accounts_url, JSON_HEX_TAG | JSON_UNESCAPED_SLASHES ); ?>;
+		<?php endif; ?>
+		</script>
 		<?php
+		wp_print_inline_script_tag(
+			str_replace( array( '<script>', '</script>' ), '', ob_get_clean() ),
+			array(
+				'data-ampdevmode' => true,
+			)
+		);
 	}
 
 	/**

--- a/projects/plugins/jetpack/modules/notes.php
+++ b/projects/plugins/jetpack/modules/notes.php
@@ -232,18 +232,15 @@ class Jetpack_Notifications {
 	 */
 	public function print_js() {
 		$link_accounts_url = is_user_logged_in() && ! ( new Connection_Manager( 'jetpack' ) )->is_user_connected() ? Jetpack::admin_url() : false;
-		ob_start();
-		?>
-		<script>
-		var wpNotesIsJetpackClient = true;
-		var wpNotesIsJetpackClientV2 = true;
-		<?php if ( $link_accounts_url ) : ?>
-			var wpNotesLinkAccountsURL = <?php echo wp_json_encode( $link_accounts_url, JSON_HEX_TAG | JSON_UNESCAPED_SLASHES ); ?>;
-		<?php endif; ?>
-		</script>
-		<?php
+		$script_contents   = <<<JS
+var wpNotesIsJetpackClient = true;
+var wpNotesIsJetpackClientV2 = true;
+JS;
+		if ( $link_accounts_url ) {
+			$script_contents .= "\nvar wpNotesLinkAccountsURL = " . wp_json_encode( $link_accounts_url, JSON_HEX_TAG | JSON_UNESCAPED_SLASHES );
+		}
 		wp_print_inline_script_tag(
-			str_replace( array( '<script>', '</script>' ), '', ob_get_clean() ),
+			$script_contents,
 			array(
 				'data-ampdevmode' => true,
 			)


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:

To be compatible with CSP, the `nonce` attribute needs to be able to be inserted into `SCRIPT` tags generated by WordPress. This is made possible when using `wp_print_script_tag()` and `wp_print_inline_script_tag()`.

This has been slowly rolling out to WordPress core. For context, see these Trac tickets:

* [#58664: Eliminate manual construction of script tags in WP_Scripts and of inline scripts on frontend/login screen](https://core.trac.wordpress.org/ticket/58664)
* [#39941: Allow using Content-Security-Policy without unsafe-inline
](https://core.trac.wordpress.org/ticket/39941)
* [#63806: Bundled themes: Scripts are printed directly without using wp_print_script_tag()/wp_print_inline_script_tag()](https://core.trac.wordpress.org/ticket/63806)
* [#59446: Use script helper functions in admin to enable Content-Security-Policy opt-in
](https://core.trac.wordpress.org/ticket/59446)

This also improves the exporting of data from PHP to JS per https://sirre.al/2025/08/06/safe-json-in-script-tags-how-not-to-break-a-site/

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Install the [Strict CSP](https://wordpress.org/plugins/strict-csp/) plugin.
2. Ensure the admin bar Notes 🔔  dropdown works on the frontend.

