### PR TITLE
Tooling: Bypass Packagist cache when polling for published packages

### DIFF
--- a/tools/js-tools/await-packagist-updates.mjs
+++ b/tools/js-tools/await-packagist-updates.mjs
@@ -76,7 +76,9 @@ function pollPackagist( name, versionRange ) {
 	return {
 		title: `${ name } ${ versionRange }`,
 		task: async ( ctx, task ) => {
+			let i = 0;
 			while ( ! aborter.aborted ) {
+				i++;
 				try {
 					const cleanup = [];
 					// http2 isn't a promise-based API, so wrap in a promise ourselves and await it.
@@ -117,7 +119,16 @@ function pollPackagist( name, versionRange ) {
 						} );
 
 						// Make the actual request.
-						const req = http2Client.request( reqHeaders, { signal: aborter.signal } );
+						// Note that Packagist's cache seems to be broken in some way, so we add a random param to the URL for now.
+						// See also: https://github.com/composer/packagist/issues/1606
+						const req = http2Client.request(
+							{
+								...reqHeaders,
+								[ http2.constants
+									.HTTP2_HEADER_PATH ]: `/p2/${ name }.json?cache_is_broken_see_packagist_GH_issue_1606=${ i }`,
+							},
+							{ signal: aborter.signal }
+						);
 						cleanup.push( () => {
 							// Make sure the request actually gets closed whenever the promise settles.
 							// We don't want hung connections waiting on us to read more data or something.
@@ -155,10 +166,12 @@ function pollPackagist( name, versionRange ) {
 								);
 							}
 
-							// Use the Last-Modified in an If-Modified-Since for future requests to save traffic.
-							if ( resHeaders[ 'last-modified' ] ) {
-								reqHeaders[ 'if-modified-since' ] = resHeaders[ 'last-modified' ];
-							}
+							// Ideally we'd use the Last-Modified in an If-Modified-Since for future requests to save traffic,
+							// but we've disabled it for now since Packagist's cache seems to be broken in some way.
+							// See also: https://github.com/composer/packagist/issues/1606
+							// if ( resHeaders[ 'last-modified' ] ) {
+							// 	reqHeaders[ 'if-modified-since' ] = resHeaders[ 'last-modified' ];
+							// }
 
 							// Any non-200 2xx is weird.
 							if ( status !== 200 ) {

--- a/tools/js-tools/await-packagist-updates.mjs
+++ b/tools/js-tools/await-packagist-updates.mjs
@@ -120,12 +120,12 @@ function pollPackagist( name, versionRange ) {
 
 						// Make the actual request.
 						// Note that Packagist's cache seems to be broken in some way, so we add a random param to the URL for now.
-						// See also: https://github.com/composer/packagist/issues/1606
+						// See also: https://github.com/composer/packagist/issues/1612
 						const req = http2Client.request(
 							{
 								...reqHeaders,
 								[ http2.constants
-									.HTTP2_HEADER_PATH ]: `/p2/${ name }.json?cache_is_broken_see_packagist_GH_issue_1606=${ i }`,
+									.HTTP2_HEADER_PATH ]: `/p2/${ name }.json?cache_is_broken_see_packagist_GH_issue_1612=${ i }`,
 							},
 							{ signal: aborter.signal }
 						);
@@ -168,7 +168,7 @@ function pollPackagist( name, versionRange ) {
 
 							// Ideally we'd use the Last-Modified in an If-Modified-Since for future requests to save traffic,
 							// but we've disabled it for now since Packagist's cache seems to be broken in some way.
-							// See also: https://github.com/composer/packagist/issues/1606
+							// See also: https://github.com/composer/packagist/issues/1612
 							// if ( resHeaders[ 'last-modified' ] ) {
 							// 	reqHeaders[ 'if-modified-since' ] = resHeaders[ 'last-modified' ];
 							// }


### PR DESCRIPTION
Closes MONOREP-213

 <!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

When we're polling Packagist to see if packages were published yet, it seems at times there is a caching issue (see composer/packagist#1606).

Adding a param to the URL (`cache_is_broken_see_packagist_GH_issue_1606`) with an incrementing value seems to bypass the cache, allowing us to see the real version available.

Presumably since we don't hit the canonical URL until after we confirm the package is published, this will in later steps allow composer to retrieve from the canonical URL and get the real version as well.

Unfortunately since we can't trust the Packagist cache, we also disabled the `If-Modified-Since` logic for now.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Something like this should still work:
`tools/js-tools/await-packagist-updates.mjs automattic/jetpack-autoloader=v5.0.12`

And this should poll indefinitely:
`tools/js-tools/await-packagist-updates.mjs automattic/jetpack-autoloader=v9.99.999`