### PR TITLE
Docker: Add troubleshooting section for Jurassic Tube cURL error

### DIFF
--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -82,9 +82,11 @@ For more in depth Docker instructions, follow the [Docker environment for Jetpac
 
 In order to test features that require a WordPress.com connection and other network related Jetpack features, you'll need a test site that can create local HTTP tunnels. If you're an Automattician, we recommend using Jurassic Tube.
 
-Note: This is for Automattician use only. For other methods, check out [ngrok](../tools/docker/README.md#using-ngrok-with-jetpack) or [another similar service](https://alternativeto.net/software/ngrok/).
-
 To set up Jurassic Tube and establish a tunnel to your local machine, use the following instructions: PCYsg-GJ2-p2
+
+For detailed information about using Jurassic Tube with Docker, including recommended proxy configurations, see the [Jurassic Tube Tunneling Service](../tools/docker/README.md#jurassic-tube-tunneling-service) section in the Docker documentation.
+
+**Note:** This is for Automattician use only. For other methods, check out [ngrok](../tools/docker/README.md#using-ngrok-with-jetpack) or [another similar service](https://alternativeto.net/software/ngrok/).
 
 ## Development Workflow
 

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -80,13 +80,13 @@ For more in depth Docker instructions, follow the [Docker environment for Jetpac
 
 ## Setting up Jurassic Tube
 
+**Note:** This is for Automattician use only. For other methods, check out [ngrok](../tools/docker/README.md#using-ngrok-with-jetpack) or [another similar service](https://alternativeto.net/software/ngrok/).
+
 In order to test features that require a WordPress.com connection and other network related Jetpack features, you'll need a test site that can create local HTTP tunnels. If you're an Automattician, we recommend using Jurassic Tube.
 
 To set up Jurassic Tube and establish a tunnel to your local machine, use the following instructions: PCYsg-GJ2-p2
 
 For detailed information about using Jurassic Tube with Docker, including recommended proxy configurations, see the [Jurassic Tube Tunneling Service](../tools/docker/README.md#jurassic-tube-tunneling-service) section in the Docker documentation.
-
-**Note:** This is for Automattician use only. For other methods, check out [ngrok](../tools/docker/README.md#using-ngrok-with-jetpack) or [another similar service](https://alternativeto.net/software/ngrok/).
 
 ## Development Workflow
 

--- a/tools/docker/README.md
+++ b/tools/docker/README.md
@@ -320,7 +320,7 @@ define( 'WP_PROXY_HOST', 'socks://host.docker.internal' );
 define( 'WP_PROXY_PORT', '8080' );
 ```
 
-After applying either method, restart your Docker containers:
+After applying either method, restart your Docker container:
 
 ```bash
 jetpack docker down

--- a/tools/docker/README.md
+++ b/tools/docker/README.md
@@ -269,40 +269,17 @@ define( 'JETPACK__SANDBOX_DOMAIN', '{your sandbox}.wordpress.com' );
 
 ## Jurassic Tube Tunneling Service
 
-This is for Automatticians only. More information: PCYsg-snO-p2.
+This is for Automatticians only.
 
-If you have persistent trouble with the `jetpack docker jt-*` commands complaining that "Tunneling scripts are not installed", it could be because Docker wasn't running properly when you ran the installer.
+Jurassic Tube is a tunneling service that allows you to expose your local Docker environment to the internet, enabling you to connect Jetpack to WordPress.com for testing.
 
-To solve this problem, run these commands from the repo root:
+### Setup
 
-```
-jetpack docker up -d
-chmod +x tools/docker/bin/jt/installer.sh && tools/docker/bin/jt/installer.sh
-```
+To set up Jurassic Tube and establish a tunnel to your local machine, follow the instructions here: PCYsg-GJ2-p2
 
-Once you have successfully installed Jurassic Tube, you can use these commands during development:
+### Recommended Proxy Configuration
 
-* Start the tunnel: `jetpack docker jt-up your-username your-subdomain`
-* Break the connection: `jetpack docker jt-down`
-
-You can also set default values:
-
-```shell script
-jetpack docker jt-config username your-username
-jetpack docker jt-config subdomain your-subdomain
-```
-That will let you omit those parameters while initiating the connection:
-```shell script
-jetpack docker jt-up
-```
-
-### Troubleshooting Jurassic Tube
-
-If you're an Automattician and receive this cURL error when connecting Jetpack to WordPress.com:
-
-> cURL error 35: OpenSSL SSL_connect: SSL_ERROR_SYSCALL in connection to jetpack.wordpress.com:443 (Status 500)
-
-You can resolve it using either of these methods:
+When using Jurassic Tube with Docker, you may need to configure proxy settings to ensure proper connectivity with WordPress.com. If you experience connection issues (such as cURL SSL errors), use one of these methods:
 
 **Method 1: Configure Docker Desktop Proxy Settings**
 
@@ -319,6 +296,8 @@ Add the following lines to `tools/docker/wordpress/wp-config.php`:
 define( 'WP_PROXY_HOST', 'socks://host.docker.internal' );
 define( 'WP_PROXY_PORT', '8080' );
 ```
+
+**Note:** If you're not using Autoproxxy or working with Jetpack Boost alongside a Boost Cloud dev environment, these proxy settings may cause issues. Only apply them if needed.
 
 After applying either method, restart your Docker container:
 

--- a/tools/docker/README.md
+++ b/tools/docker/README.md
@@ -324,7 +324,7 @@ After applying either method, restart your Docker containers:
 
 ```bash
 jetpack docker down
-jetpack docker up
+jetpack docker up -d
 ```
 
 ## Using Ngrok with Jetpack

--- a/tools/docker/README.md
+++ b/tools/docker/README.md
@@ -296,6 +296,38 @@ That will let you omit those parameters while initiating the connection:
 jetpack docker jt-up
 ```
 
+### Troubleshooting Jurassic Tube
+
+If you're an Automattician and when connecting Jetpack to WordPress.com you receive the cURL error:
+
+> cURL error 35: OpenSSL SSL_connect: SSL_ERROR_SYSCALL in connection to jetpack.wordpress.com:443 (Status 500)
+
+There are two solutions available:
+
+**Solution 1: Update Docker's Proxy Settings**
+
+1. Open Docker Desktop
+2. Click the gear icon in the top right
+3. Click the "Resources" tab
+4. Click the "Proxy" tab
+5. Toggle "Manual proxy configuration"
+
+**Solution 2: Add Proxy Configuration to wp-config.php**
+
+Add the following to `tools/docker/wordpress/wp-config.php`:
+
+```php
+define( 'WP_PROXY_HOST', 'socks://host.docker.internal' );
+define( 'WP_PROXY_PORT', '8080' );
+```
+
+**Note:** Be sure to restart the Docker container after making the changes:
+
+```bash
+jetpack docker down
+jetpack docker up
+```
+
 ## Using Ngrok with Jetpack
 
 Note: While Ngrok is technically supported for everyone, Jurassic Tube is used by the Jetpack team and is available to all Automatticians.

--- a/tools/docker/README.md
+++ b/tools/docker/README.md
@@ -298,30 +298,29 @@ jetpack docker jt-up
 
 ### Troubleshooting Jurassic Tube
 
-If you're an Automattician and when connecting Jetpack to WordPress.com you receive the cURL error:
+If you're an Automattician and receive this cURL error when connecting Jetpack to WordPress.com:
 
 > cURL error 35: OpenSSL SSL_connect: SSL_ERROR_SYSCALL in connection to jetpack.wordpress.com:443 (Status 500)
 
-There are two solutions available:
+You can resolve it using either of these methods:
 
-**Solution 1: Update Docker's Proxy Settings**
+**Method 1: Configure Docker Desktop Proxy Settings**
 
 1. Open Docker Desktop
 2. Click the gear icon in the top right
-3. Click the "Resources" tab
-4. Click the "Proxy" tab
-5. Toggle "Manual proxy configuration"
+3. Navigate to **Resources** → **Proxy**
+4. Enable "Manual proxy configuration"
 
-**Solution 2: Add Proxy Configuration to wp-config.php**
+**Method 2: Configure Proxy in wp-config.php**
 
-Add the following to `tools/docker/wordpress/wp-config.php`:
+Add the following lines to `tools/docker/wordpress/wp-config.php`:
 
 ```php
 define( 'WP_PROXY_HOST', 'socks://host.docker.internal' );
 define( 'WP_PROXY_PORT', '8080' );
 ```
 
-**Note:** Be sure to restart the Docker container after making the changes:
+After applying either method, restart your Docker containers:
 
 ```bash
 jetpack docker down


### PR DESCRIPTION
## Description
This PR adds a troubleshooting subsection to the Jurassic Tube documentation in the Docker README.

## Changes
- Added a new 'Troubleshooting Jurassic Tube' subsection documenting how to resolve cURL error 35 (SSL_ERROR_SYSCALL) when connecting Jetpack to WordPress.com
- Provides two solutions:
  1. Updating Docker's proxy settings through the Docker Desktop UI
  2. Adding proxy configuration constants to wp-config.php
- Includes instructions to restart Docker containers after making changes

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
- Slack thread I started: p1762822694261659-slack-CDLH4C1UZ 
- Slack thread Nick Pagazani started: p1754045486753419-slack-C05Q5HSS013
- P2 Post: pdWQjU-Ka-p2

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:
- Review newly added section within readme for typos or potential confusing language

## Context
Automatticians sometimes encounter SSL connection errors when using Jurassic Tube to connect Jetpack to WordPress.com. This documentation helps resolve those issues quickly.