### PR TITLE
Charts: Add global theme support for generating colors from a single custom property

### DIFF
--- a/projects/js-packages/charts/changelog/charts-128-global-theme-support-generating-colors-from-a-single-css
+++ b/projects/js-packages/charts/changelog/charts-128-global-theme-support-generating-colors-from-a-single-css
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Global theme: enable color generation from CSS custom properties

--- a/projects/js-packages/charts/src/components/bar-chart/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/components/bar-chart/stories/index.stories.tsx
@@ -1,6 +1,7 @@
 import {
 	chartDecorator,
 	sharedChartArgTypes,
+	sharedThemeArgs,
 	ChartStoryArgs,
 	legendArgTypes,
 	medalCountsData,
@@ -79,6 +80,7 @@ type Story = StoryObj< StoryArgs >;
 // Default story with multiple series
 export const Default: Story = {
 	args: {
+		...sharedThemeArgs,
 		withTooltips: true,
 		data: [ medalCountsData[ 0 ], medalCountsData[ 1 ], medalCountsData[ 2 ] ], // limit to 3 series for better readability
 		gridVisibility: 'x',

--- a/projects/js-packages/charts/src/components/bar-list-chart/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/components/bar-list-chart/stories/index.stories.tsx
@@ -5,6 +5,7 @@ import { useGlobalChartsTheme } from '../../../providers';
 import {
 	chartDecorator,
 	sharedChartArgTypes,
+	sharedThemeArgs,
 	ChartStoryArgs,
 	marketingChannelsComparison as salesByChannel,
 	salesByProduct,
@@ -35,6 +36,7 @@ type Story = StoryObj< StoryArgs >;
 // Default story with multiple series
 export const Default: Story = {
 	args: {
+		...sharedThemeArgs,
 		withTooltips: true,
 		data: salesByProduct,
 		containerWidth: '600px',

--- a/projects/js-packages/charts/src/components/conversion-funnel-chart/conversion-funnel-chart.tsx
+++ b/projects/js-packages/charts/src/components/conversion-funnel-chart/conversion-funnel-chart.tsx
@@ -9,6 +9,7 @@ import {
 	useChartId,
 	useChartRegistration,
 	useGlobalChartsTheme,
+	useGlobalChartsContext,
 } from '../../providers';
 import { hexToRgba, formatPercentage } from '../../utils';
 import styles from './conversion-funnel-chart.module.scss';
@@ -49,6 +50,7 @@ const ConversionFunnelChartInternal: FC< ConversionFunnelChartProps > = ( {
 } ) => {
 	const chartId = useChartId( providedChartId );
 	const { conversionFunnelChart: conversionFunnelChartSettings } = useGlobalChartsTheme();
+	const { getElementStyles } = useGlobalChartsContext();
 	const chartRef = useRef< HTMLDivElement >( null );
 	const selectedBarRef = useRef< HTMLDivElement | null >( null );
 
@@ -206,12 +208,16 @@ const ConversionFunnelChartInternal: FC< ConversionFunnelChartProps > = ( {
 	}, [ clearSelectionAndRef ] );
 
 	// Get component settings from theme with fallbacks
-	const {
-		primaryColor: barColor,
-		backgroundColor,
-		positiveChangeColor,
-		negativeChangeColor,
-	} = conversionFunnelChartSettings;
+	const { primaryColor, backgroundColor, positiveChangeColor, negativeChangeColor } =
+		conversionFunnelChartSettings;
+
+	// Resolve bar color using getElementStyles with primaryColor as override
+	const { color: barColor } = getElementStyles
+		? getElementStyles( {
+				index: 0,
+				overrideColor: primaryColor,
+		  } )
+		: { color: primaryColor || '#000000' };
 
 	// Determine change indicator color
 	const isPositiveChange = changeIndicator?.startsWith( '+' );

--- a/projects/js-packages/charts/src/components/conversion-funnel-chart/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/components/conversion-funnel-chart/stories/index.stories.tsx
@@ -1,6 +1,7 @@
 import {
 	chartDecorator,
 	sharedChartArgTypes,
+	sharedThemeArgs,
 	ChartStoryArgs,
 	ecommerceFunnelData,
 	lowConversionFunnelData,
@@ -73,6 +74,7 @@ type Story = StoryObj< StoryArgs >;
 
 export const Default: Story = {
 	args: {
+		...sharedThemeArgs,
 		mainRate: 10.3,
 		changeIndicator: '+2%',
 		steps: ecommerceFunnelData,

--- a/projects/js-packages/charts/src/components/leaderboard-chart/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/components/leaderboard-chart/stories/index.stories.tsx
@@ -1,4 +1,4 @@
-import { defaultTheme } from '../../../providers';
+import { defaultTheme, useGlobalChartsContext } from '../../../providers';
 import {
 	chartDecorator,
 	sharedChartArgTypes,
@@ -10,7 +10,6 @@ import {
 	decliningMetricsData as negativeGrowth,
 	categorizedMetricsData as dataWithImageColor,
 	themeArgTypes,
-	CHART_THEME_MAP,
 } from '../../../stories';
 import { legendArgTypes } from '../../../stories/legend-config';
 import { formatMetricValue } from '../../../utils';
@@ -329,6 +328,18 @@ export const AdvancedFormatting: Story = {
 	},
 };
 
+const LeaderboardChartWithOverlayLabelImage = ( args: StoryArgs ) => {
+	const { getElementStyles } = useGlobalChartsContext();
+	const { color: primaryColor } = getElementStyles( {
+		index: 0,
+		overrideColor: args.primaryColor,
+	} );
+
+	const primaryColorWithAlpha = hexToRgba( primaryColor, 0.08 );
+
+	return <LeaderboardChart { ...args } primaryColor={ primaryColorWithAlpha } />;
+};
+
 export const OverlayLabelWithImage: Story = {
 	args: {
 		data: dataWithImageColor.map( entry => ( {
@@ -349,15 +360,7 @@ export const OverlayLabelWithImage: Story = {
 			fontFamily: `"SF Pro Text", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif`,
 		},
 	},
-	render: args => {
-		const themeName = args.themeName || 'default';
-		const theme = CHART_THEME_MAP[ themeName ];
-		const primaryColor =
-			theme?.leaderboardChart?.primaryColor || defaultTheme.leaderboardChart.primaryColor;
-		const primaryColorWithAlpha = hexToRgba( primaryColor, 0.08 );
-
-		return <LeaderboardChart { ...args } primaryColor={ primaryColorWithAlpha } />;
-	},
+	render: args => <LeaderboardChartWithOverlayLabelImage { ...args } />,
 };
 
 export const WithLegend: Story = {

--- a/projects/js-packages/charts/src/components/leaderboard-chart/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/components/leaderboard-chart/stories/index.stories.tsx
@@ -2,6 +2,7 @@ import { defaultTheme } from '../../../providers';
 import {
 	chartDecorator,
 	sharedChartArgTypes,
+	sharedThemeArgs,
 	ChartStoryArgs,
 	trafficSourcesData as sampleData,
 	shortTrafficSourcesData as smallDataset,
@@ -151,6 +152,7 @@ type Story = StoryObj< StoryArgs >;
 
 export const Default: Story = {
 	args: {
+		...sharedThemeArgs,
 		data: sampleData,
 		withComparison: true,
 		loading: false,

--- a/projects/js-packages/charts/src/components/legend/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/components/legend/stories/index.stories.tsx
@@ -1,5 +1,10 @@
 import { Meta, StoryObj } from '@storybook/react';
-import { simpleChartDecorator, ChartStoryArgs, themeArgTypes } from '../../../stories';
+import {
+	simpleChartDecorator,
+	ChartStoryArgs,
+	themeArgTypes,
+	sharedThemeArgs,
+} from '../../../stories';
 import { BarChart } from '../../bar-chart';
 import { LineChart } from '../../line-chart';
 import { PieChart } from '../../pie-chart';
@@ -72,10 +77,11 @@ const pieChartData: DataPointPercentage[] = [
 export const Horizontal: Story = {
 	render: args => {
 		// eslint-disable-next-line @typescript-eslint/no-unused-vars
-		const { themeName, ...legendProps } = args;
+		const { themeName, accentColor, ...legendProps } = args;
 		return <Legend { ...legendProps } />;
 	},
 	args: {
+		...sharedThemeArgs,
 		items: [
 			{ label: 'Desktop', value: '65%', color: '#3858E9' },
 			{ label: 'Mobile', value: '35%', color: '#80C8FF' },
@@ -87,10 +93,11 @@ export const Horizontal: Story = {
 export const Vertical: Story = {
 	render: args => {
 		// eslint-disable-next-line @typescript-eslint/no-unused-vars
-		const { themeName, ...legendProps } = args;
+		const { themeName, accentColor, ...legendProps } = args;
 		return <Legend { ...legendProps } />;
 	},
 	args: {
+		...sharedThemeArgs,
 		items: [
 			{ label: 'Desktop', value: '65%', color: '#3858E9' },
 			{ label: 'Mobile', value: '35%', color: '#80C8FF' },

--- a/projects/js-packages/charts/src/components/line-chart/stories/config.tsx
+++ b/projects/js-packages/charts/src/components/line-chart/stories/config.tsx
@@ -9,7 +9,7 @@ import {
 } from '../../../stories/chart-decorator';
 import { legendArgTypes } from '../../../stories/legend-config';
 import { temperatureData as sampleData } from '../../../stories/sample-data';
-import { themeArgTypes } from '../../../stories/theme-config';
+import { sharedThemeArgs, themeArgTypes } from '../../../stories/theme-config';
 import { lineChartTooltipArgTypes } from '../../../stories/tooltip-config';
 import { DefaultGlyph } from '../../private/default-glyph';
 import LineChart from '../line-chart';
@@ -63,6 +63,7 @@ export const lineChartMetaArgs: Meta< StoryArgs > = {
 };
 
 export const lineChartStoryArgs = {
+	...sharedThemeArgs,
 	data: sampleData.slice( 0, 4 ),
 	withGradientFill: false,
 	withLegendGlyph: false,

--- a/projects/js-packages/charts/src/components/pie-chart/stories/donut.stories.tsx
+++ b/projects/js-packages/charts/src/components/pie-chart/stories/donut.stories.tsx
@@ -9,6 +9,7 @@ import { GlobalChartsProvider } from '../../../providers';
 import {
 	chartDecorator,
 	sharedChartArgTypes,
+	sharedThemeArgs,
 	ChartStoryArgs,
 	legendArgTypes,
 	themeArgTypes,
@@ -88,6 +89,7 @@ type Story = StoryObj< StoryArgs >;
 
 export const Default: Story = {
 	args: {
+		...sharedThemeArgs,
 		size: 400,
 		containerWidth: '432px',
 		containerHeight: '432px',

--- a/projects/js-packages/charts/src/components/pie-chart/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/components/pie-chart/stories/index.stories.tsx
@@ -6,7 +6,7 @@ import {
 } from '../../../stories/chart-decorator';
 import { legendArgTypes } from '../../../stories/legend-config';
 import { osUsageData as data } from '../../../stories/sample-data';
-import { themeArgTypes } from '../../../stories/theme-config';
+import { sharedThemeArgs, themeArgTypes } from '../../../stories/theme-config';
 import { PieChart } from '../index';
 import { PieChartUnresponsive } from '../pie-chart';
 import type { Meta, StoryObj } from '@storybook/react';
@@ -119,6 +119,7 @@ type Story = StoryObj< StoryArgs >;
 
 export const Default: Story = {
 	args: {
+		...sharedThemeArgs,
 		thickness: 1,
 		gapScale: 0,
 		cornerScale: 0,

--- a/projects/js-packages/charts/src/components/pie-semi-circle-chart/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/components/pie-semi-circle-chart/stories/index.stories.tsx
@@ -4,6 +4,7 @@ import { GlobalChartsProvider } from '../../../providers';
 import {
 	chartDecorator,
 	sharedChartArgTypes,
+	sharedThemeArgs,
 	ChartStoryArgs,
 	legendArgTypes,
 	partialOsUsageData as data,
@@ -49,6 +50,7 @@ type Story = StoryObj< StoryArgs >;
 
 export const Default: Story = {
 	args: {
+		...sharedThemeArgs,
 		containerWidth: '600px',
 		containerHeight: '325px',
 		resize: 'none',

--- a/projects/js-packages/charts/src/providers/chart-context/global-charts-provider.tsx
+++ b/projects/js-packages/charts/src/providers/chart-context/global-charts-provider.tsx
@@ -1,4 +1,12 @@
-import { createContext, useCallback, useMemo, useState, useEffect, useLayoutEffect } from 'react';
+import {
+	createContext,
+	useCallback,
+	useMemo,
+	useState,
+	useEffect,
+	useLayoutEffect,
+	useRef,
+} from 'react';
 import {
 	getItemShapeStyles,
 	getSeriesLineStyles,
@@ -26,6 +34,9 @@ export const GlobalChartsProvider: FC< GlobalChartsProviderProps > = ( { childre
 		() => new Map()
 	);
 
+	// Ref to the wrapper element for resolving scoped CSS variables
+	const wrapperRef = useRef< HTMLDivElement >( null );
+
 	const providerTheme: CompleteChartTheme = useMemo( () => {
 		return theme ? mergeThemes( defaultTheme, theme ) : defaultTheme;
 	}, [ theme ] );
@@ -42,6 +53,7 @@ export const GlobalChartsProvider: FC< GlobalChartsProviderProps > = ( { childre
 	} ) );
 
 	// Compute color cache after DOM is updated (so CSS variables are available)
+	// Resolves CSS variables from the wrapper element's scope to handle scoped variables
 	useLayoutEffect( () => {
 		const { colors } = providerTheme;
 		const resolvedColors: string[] = [];
@@ -57,8 +69,9 @@ export const GlobalChartsProvider: FC< GlobalChartsProviderProps > = ( { childre
 					let colorValue = color;
 
 					// Handle CSS custom properties (variables) - resolve them to actual values
+					// Use wrapper element to resolve scoped CSS variables
 					if ( color.includes( 'var(' ) ) {
-						const resolved = resolveCssVariable( color );
+						const resolved = resolveCssVariable( color, wrapperRef.current );
 						if ( ! resolved ) {
 							continue; // Skip if variable can't be resolved
 						}
@@ -240,5 +253,11 @@ export const GlobalChartsProvider: FC< GlobalChartsProviderProps > = ( { childre
 		]
 	);
 
-	return <GlobalChartsContext.Provider value={ value }>{ children }</GlobalChartsContext.Provider>;
+	return (
+		<GlobalChartsContext.Provider value={ value }>
+			<div ref={ wrapperRef } style={ { display: 'contents' } }>
+				{ children }
+			</div>
+		</GlobalChartsContext.Provider>
+	);
 };

--- a/projects/js-packages/charts/src/providers/chart-context/global-charts-provider.tsx
+++ b/projects/js-packages/charts/src/providers/chart-context/global-charts-provider.tsx
@@ -54,6 +54,8 @@ export const GlobalChartsProvider: FC< GlobalChartsProviderProps > = ( { childre
 
 	// Compute color cache after DOM is updated (so CSS variables are available)
 	// Resolves CSS variables from the wrapper element's scope to handle scoped variables
+	// Note: Only re-runs when providerTheme changes, not when wrapper element changes.
+	// This is intentional, as wrapperRef is expected to be stable for the lifetime of the provider.
 	useLayoutEffect( () => {
 		const { colors } = providerTheme;
 		const resolvedColors: string[] = [];

--- a/projects/js-packages/charts/src/providers/chart-context/global-charts-provider.tsx
+++ b/projects/js-packages/charts/src/providers/chart-context/global-charts-provider.tsx
@@ -74,9 +74,11 @@ export const GlobalChartsProvider: FC< GlobalChartsProviderProps > = ( { childre
 					// Use wrapper element to resolve scoped CSS variables
 					if ( color.includes( 'var(' ) ) {
 						const resolved = resolveCssVariable( color, wrapperRef.current );
+
 						if ( resolved === null || resolved === '' ) {
-							continue; // Skip if variable can't be resolved or is empty
+							continue;
 						}
+
 						colorValue = resolved;
 					}
 
@@ -90,6 +92,7 @@ export const GlobalChartsProvider: FC< GlobalChartsProviderProps > = ( { childre
 							minHue = Math.min( minHue, hslColor[ 0 ] );
 							maxHue = Math.max( maxHue, hslColor[ 0 ] );
 						} catch {
+							// Ignore invalid hex colors that don't parse to HSL
 							continue;
 						}
 					}

--- a/projects/js-packages/charts/src/providers/chart-context/global-charts-provider.tsx
+++ b/projects/js-packages/charts/src/providers/chart-context/global-charts-provider.tsx
@@ -74,8 +74,8 @@ export const GlobalChartsProvider: FC< GlobalChartsProviderProps > = ( { childre
 					// Use wrapper element to resolve scoped CSS variables
 					if ( color.includes( 'var(' ) ) {
 						const resolved = resolveCssVariable( color, wrapperRef.current );
-						if ( ! resolved ) {
-							continue; // Skip if variable can't be resolved
+						if ( resolved === null || resolved === '' ) {
+							continue; // Skip if variable can't be resolved or is empty
 						}
 						colorValue = resolved;
 					}

--- a/projects/js-packages/charts/src/providers/chart-context/global-charts-provider.tsx
+++ b/projects/js-packages/charts/src/providers/chart-context/global-charts-provider.tsx
@@ -70,9 +70,9 @@ export const GlobalChartsProvider: FC< GlobalChartsProviderProps > = ( { childre
 				if ( color && typeof color === 'string' ) {
 					let colorValue = color;
 
-					// Handle CSS custom properties (variables) - resolve them to actual values
+					// Handle CSS custom properties names - resolve them to actual values
 					// Use wrapper element to resolve scoped CSS variables
-					if ( color.includes( 'var(' ) ) {
+					if ( color.startsWith( '--' ) ) {
 						const resolved = resolveCssVariable( color, wrapperRef.current );
 
 						if ( resolved === null || resolved === '' ) {

--- a/projects/js-packages/charts/src/providers/chart-context/global-charts-provider.tsx
+++ b/projects/js-packages/charts/src/providers/chart-context/global-charts-provider.tsx
@@ -1,5 +1,11 @@
 import { createContext, useCallback, useMemo, useState, useEffect } from 'react';
-import { getItemShapeStyles, getSeriesLineStyles, mergeThemes, hexToHsl } from '../../utils';
+import {
+	getItemShapeStyles,
+	getSeriesLineStyles,
+	mergeThemes,
+	hexToHsl,
+	resolveCssVariable,
+} from '../../utils';
 import { getChartColor, type ColorCache } from './private/get-chart-color';
 import { defaultTheme } from './themes';
 import type { GlobalChartsContextValue, ChartRegistration } from './types';
@@ -27,6 +33,7 @@ export const GlobalChartsProvider: FC< GlobalChartsProviderProps > = ( { childre
 	// Cache expensive color computations that only change when theme colors change
 	const colorCache: ColorCache = useMemo( () => {
 		const { colors } = providerTheme;
+		const resolvedColors: string[] = [];
 		const hues: number[] = [];
 		const existingHslColors: Array< [ number, number, number ] > = [];
 		let minHue = 360;
@@ -35,18 +42,33 @@ export const GlobalChartsProvider: FC< GlobalChartsProviderProps > = ( { childre
 		// Process all colors once and cache the results
 		if ( Array.isArray( colors ) ) {
 			for ( const color of colors ) {
-				if ( color && typeof color === 'string' && color.startsWith( '#' ) ) {
-					const hslColor = hexToHsl( color );
-					hues.push( hslColor[ 0 ] );
-					existingHslColors.push( hslColor );
-					minHue = Math.min( minHue, hslColor[ 0 ] );
-					maxHue = Math.max( maxHue, hslColor[ 0 ] );
+				if ( color && typeof color === 'string' ) {
+					let colorValue = color;
+
+					// Handle CSS custom properties (variables) - resolve them to actual values
+					if ( color.includes( 'var(' ) ) {
+						const resolved = resolveCssVariable( color );
+						if ( ! resolved ) {
+							continue; // Skip if variable can't be resolved
+						}
+						colorValue = resolved;
+					}
+
+					// Process hex colors
+					if ( colorValue.startsWith( '#' ) ) {
+						resolvedColors.push( colorValue );
+						const hslColor = hexToHsl( colorValue );
+						hues.push( hslColor[ 0 ] );
+						existingHslColors.push( hslColor );
+						minHue = Math.min( minHue, hslColor[ 0 ] );
+						maxHue = Math.max( maxHue, hslColor[ 0 ] );
+					}
 				}
 			}
 		}
 
 		return {
-			colors: colors || [],
+			colors: resolvedColors,
 			hues,
 			existingHslColors,
 			minHue,

--- a/projects/js-packages/charts/src/providers/chart-context/global-charts-provider.tsx
+++ b/projects/js-packages/charts/src/providers/chart-context/global-charts-provider.tsx
@@ -81,11 +81,15 @@ export const GlobalChartsProvider: FC< GlobalChartsProviderProps > = ( { childre
 					// Process hex colors
 					if ( colorValue.startsWith( '#' ) ) {
 						resolvedColors.push( colorValue );
-						const hslColor = hexToHsl( colorValue );
-						hues.push( hslColor[ 0 ] );
-						existingHslColors.push( hslColor );
-						minHue = Math.min( minHue, hslColor[ 0 ] );
-						maxHue = Math.max( maxHue, hslColor[ 0 ] );
+						try {
+							const hslColor = hexToHsl( colorValue );
+							hues.push( hslColor[ 0 ] );
+							existingHslColors.push( hslColor );
+							minHue = Math.min( minHue, hslColor[ 0 ] );
+							maxHue = Math.max( maxHue, hslColor[ 0 ] );
+						} catch {
+							continue;
+						}
 					}
 				}
 			}

--- a/projects/js-packages/charts/src/providers/chart-context/global-charts-provider.tsx
+++ b/projects/js-packages/charts/src/providers/chart-context/global-charts-provider.tsx
@@ -1,4 +1,4 @@
-import { createContext, useCallback, useMemo, useState, useEffect } from 'react';
+import { createContext, useCallback, useMemo, useState, useEffect, useLayoutEffect } from 'react';
 import {
 	getItemShapeStyles,
 	getSeriesLineStyles,
@@ -31,7 +31,18 @@ export const GlobalChartsProvider: FC< GlobalChartsProviderProps > = ( { childre
 	}, [ theme ] );
 
 	// Cache expensive color computations that only change when theme colors change
-	const colorCache: ColorCache = useMemo( () => {
+	// Using useState + useLayoutEffect instead of useMemo to ensure CSS variables
+	// in <style> tags are applied to the DOM before we try to resolve them
+	const [ colorCache, setColorCache ] = useState< ColorCache >( () => ( {
+		colors: [],
+		hues: [],
+		existingHslColors: [],
+		minHue: 360,
+		maxHue: 0,
+	} ) );
+
+	// Compute color cache after DOM is updated (so CSS variables are available)
+	useLayoutEffect( () => {
 		const { colors } = providerTheme;
 		const resolvedColors: string[] = [];
 		const hues: number[] = [];
@@ -67,13 +78,13 @@ export const GlobalChartsProvider: FC< GlobalChartsProviderProps > = ( { childre
 			}
 		}
 
-		return {
+		setColorCache( {
 			colors: resolvedColors,
 			hues,
 			existingHslColors,
 			minHue,
 			maxHue,
-		};
+		} );
 	}, [ providerTheme ] );
 
 	const [ groupToColorMap, setGroupToColorMap ] = useState< Map< string, string > >(

--- a/projects/js-packages/charts/src/providers/chart-context/private/get-chart-color.ts
+++ b/projects/js-packages/charts/src/providers/chart-context/private/get-chart-color.ts
@@ -142,8 +142,8 @@ export const getChartColor = ( index: number, colorCache: ColorCache ) => {
 
 			// If there's only one color, use a much wider hue range for more variety
 			if ( hues.length === 1 ) {
-				// Use nearly the full color wheel for maximum variety
-				hueRange = FULL_HUE_ROTATION_DEGREES * 0.9; // 90% of the color wheel (324 degrees)
+				// Use half the color wheel for decent variety
+				hueRange = FULL_HUE_ROTATION_DEGREES * 0.5;
 			} else if ( hueRange > HUE_WRAP_THRESHOLD_DEGREES ) {
 				// If the range is very large, it might be wrapping around the color wheel
 				// Check if a smaller range exists when considering wrap-around

--- a/projects/js-packages/charts/src/providers/chart-context/private/get-chart-color.ts
+++ b/projects/js-packages/charts/src/providers/chart-context/private/get-chart-color.ts
@@ -140,10 +140,13 @@ export const getChartColor = ( index: number, colorCache: ColorCache ) => {
 			// Handle hue wrap-around (e.g., if colors span across 0 degrees)
 			let hueRange = maxHue - minHue;
 
-			// If the range is very large, it might be wrapping around the color wheel
-			// Check if a smaller range exists when considering wrap-around
-			if ( hueRange > HUE_WRAP_THRESHOLD_DEGREES ) {
-				// Try the alternative: wrap around the full rotation
+			// If there's only one color, use a much wider hue range for more variety
+			if ( hues.length === 1 ) {
+				// Use nearly the full color wheel for maximum variety
+				hueRange = FULL_HUE_ROTATION_DEGREES * 0.9; // 90% of the color wheel (324 degrees)
+			} else if ( hueRange > HUE_WRAP_THRESHOLD_DEGREES ) {
+				// If the range is very large, it might be wrapping around the color wheel
+				// Check if a smaller range exists when considering wrap-around
 				const altMinHue = Math.min( ...hues.filter( h => h > HUE_WRAP_THRESHOLD_DEGREES ) );
 				const altMaxHue =
 					Math.max( ...hues.filter( h => h < HUE_WRAP_THRESHOLD_DEGREES ) ) +

--- a/projects/js-packages/charts/src/providers/chart-context/private/get-chart-color.ts
+++ b/projects/js-packages/charts/src/providers/chart-context/private/get-chart-color.ts
@@ -148,7 +148,6 @@ export const getChartColor = ( index: number, colorCache: ColorCache ) => {
 
 			// If there's only one color, use a much wider hue range for more variety
 			if ( hues.length === 1 ) {
-				// Use a wider range of the color wheel for decent variety
 				hueRange = FULL_HUE_ROTATION_DEGREES * SINGLE_COLOR_HUE_RANGE_FACTOR;
 			} else if ( hueRange > HUE_WRAP_THRESHOLD_DEGREES ) {
 				// If the range is very large, it might be wrapping around the color wheel

--- a/projects/js-packages/charts/src/providers/chart-context/private/get-chart-color.ts
+++ b/projects/js-packages/charts/src/providers/chart-context/private/get-chart-color.ts
@@ -36,9 +36,9 @@ const VARIATION_ATTEMPT_OFFSET = 0.1;
 
 /**
  * Base saturation percentage for generated colors
- * 60% provides good color vibrancy without being overwhelming
+ * 45% provides muted, professional colors without being washed out
  */
-const BASE_SATURATION = 60;
+const BASE_SATURATION = 45;
 
 /**
  * Number of saturation variation steps
@@ -48,10 +48,10 @@ const SATURATION_VARIATION_STEPS = 3;
 
 /**
  * Saturation increment per variation step
- * 15% increments provide noticeable but not jarring differences
- * Results in saturation levels: 60%, 75%, 90%
+ * 10% increments provide subtle variation while keeping colors muted
+ * Results in saturation levels: 45%, 55%, 65%
  */
-const SATURATION_INCREMENT = 15;
+const SATURATION_INCREMENT = 10;
 
 // Lightness configuration for WCAG AA accessibility compliance
 
@@ -102,6 +102,12 @@ const HUE_WRAP_THRESHOLD_DEGREES = 180;
 const FULL_HUE_ROTATION_DEGREES = 360;
 
 /**
+ * Factor for single color hue range
+ * 0.75 provides a wider range of the color wheel for decent variety
+ */
+const SINGLE_COLOR_HUE_RANGE_FACTOR = 0.75;
+
+/**
  * Get a color from the colors array or generate a new color using the golden ratio
  *
  * @param index      - the index of the color to get
@@ -142,8 +148,8 @@ export const getChartColor = ( index: number, colorCache: ColorCache ) => {
 
 			// If there's only one color, use a much wider hue range for more variety
 			if ( hues.length === 1 ) {
-				// Use half the color wheel for decent variety
-				hueRange = FULL_HUE_ROTATION_DEGREES * 0.5;
+				// Use a wider range of the color wheel for decent variety
+				hueRange = FULL_HUE_ROTATION_DEGREES * SINGLE_COLOR_HUE_RANGE_FACTOR;
 			} else if ( hueRange > HUE_WRAP_THRESHOLD_DEGREES ) {
 				// If the range is very large, it might be wrapping around the color wheel
 				// Check if a smaller range exists when considering wrap-around

--- a/projects/js-packages/charts/src/providers/chart-context/private/get-chart-color.ts
+++ b/projects/js-packages/charts/src/providers/chart-context/private/get-chart-color.ts
@@ -103,9 +103,8 @@ const FULL_HUE_ROTATION_DEGREES = 360;
 
 /**
  * Factor for single color hue range
- * 0.75 provides a wider range of the color wheel for decent variety
  */
-const SINGLE_COLOR_HUE_RANGE_FACTOR = 0.75;
+const SINGLE_COLOR_HUE_RANGE_FACTOR = 0.33;
 
 /**
  * Get a color from the colors array or generate a new color using the golden ratio
@@ -146,7 +145,7 @@ export const getChartColor = ( index: number, colorCache: ColorCache ) => {
 			// Handle hue wrap-around (e.g., if colors span across 0 degrees)
 			let hueRange = maxHue - minHue;
 
-			// If there's only one color, use a much wider hue range for more variety
+			// If there's only one color, use a set hue range for limited variety
 			if ( hues.length === 1 ) {
 				hueRange = FULL_HUE_ROTATION_DEGREES * SINGLE_COLOR_HUE_RANGE_FACTOR;
 			} else if ( hueRange > HUE_WRAP_THRESHOLD_DEGREES ) {

--- a/projects/js-packages/charts/src/providers/chart-context/test/chart-context.test.tsx
+++ b/projects/js-packages/charts/src/providers/chart-context/test/chart-context.test.tsx
@@ -1704,4 +1704,736 @@ describe( 'ChartContext', () => {
 			expect( hidden.size ).toBe( 0 );
 		} );
 	} );
+
+	describe( 'GlobalChartsProvider - CSS Variable Support', () => {
+		let originalGetComputedStyle: typeof window.getComputedStyle;
+
+		beforeEach( () => {
+			originalGetComputedStyle = window.getComputedStyle;
+		} );
+
+		afterEach( () => {
+			window.getComputedStyle = originalGetComputedStyle;
+		} );
+
+		describe( 'CSS Variable Resolution', () => {
+			it( 'resolves CSS custom properties in theme colors', () => {
+				window.getComputedStyle = jest.fn( () => ( {
+					getPropertyValue: ( prop: string ) => {
+						if ( prop === '--primary-color' ) {
+							return '#00ff00';
+						}
+						return '';
+					},
+				} ) ) as unknown as typeof window.getComputedStyle;
+
+				let contextValue: GlobalChartsContextValue;
+
+				const TestComponent = () => {
+					contextValue = useGlobalChartsContext();
+					return <div>Test</div>;
+				};
+
+				const cssVarTheme: ChartTheme = {
+					colors: [ 'var(--primary-color)', '#ff0000' ],
+				} as ChartTheme;
+
+				render(
+					<GlobalChartsProvider theme={ cssVarTheme }>
+						<TestComponent />
+					</GlobalChartsProvider>
+				);
+
+				const color = contextValue.getElementStyles( {
+					data: undefined,
+					index: 0,
+				} ).color;
+
+				// Should resolve to #00ff00, not the fallback #ff0000
+				expect( color ).toBe( '#00ff00' );
+			} );
+
+			it( 'uses wrapper element for scoped CSS variable resolution', () => {
+				const mockGetComputedStyle = jest.fn( ( element: Element ) => {
+					// Scoped wrapper returns different value than root
+					if ( element !== document.documentElement ) {
+						return {
+							getPropertyValue: ( prop: string ) => {
+								if ( prop === '--scoped-color' ) {
+									return '#00ff00'; // Scoped value
+								}
+								return '';
+							},
+						};
+					}
+					// Root would return different value
+					return {
+						getPropertyValue: ( prop: string ) => {
+							if ( prop === '--scoped-color' ) {
+								return '#ff0000'; // Root value
+							}
+							return '';
+						},
+					};
+				} );
+				window.getComputedStyle = mockGetComputedStyle as unknown as typeof window.getComputedStyle;
+
+				let contextValue: GlobalChartsContextValue;
+
+				const TestComponent = () => {
+					contextValue = useGlobalChartsContext();
+					return <div>Test</div>;
+				};
+
+				const cssVarTheme: ChartTheme = {
+					colors: [ 'var(--scoped-color)' ],
+				} as ChartTheme;
+
+				render(
+					<GlobalChartsProvider theme={ cssVarTheme }>
+						<TestComponent />
+					</GlobalChartsProvider>
+				);
+
+				const color = contextValue.getElementStyles( {
+					data: undefined,
+					index: 0,
+				} ).color;
+
+				// Should use scoped value from wrapper element
+				expect( color ).toBe( '#00ff00' );
+			} );
+
+			it( 'resolves multiple CSS variables in color array', () => {
+				window.getComputedStyle = jest.fn( () => ( {
+					getPropertyValue: ( prop: string ) => {
+						if ( prop === '--color-1' ) {
+							return '#ff0000';
+						}
+						if ( prop === '--color-2' ) {
+							return '#00ff00';
+						}
+						return '';
+					},
+				} ) ) as unknown as typeof window.getComputedStyle;
+
+				let contextValue: GlobalChartsContextValue;
+
+				const TestComponent = () => {
+					contextValue = useGlobalChartsContext();
+					return <div>Test</div>;
+				};
+
+				const cssVarTheme: ChartTheme = {
+					colors: [ 'var(--color-1)', 'var(--color-2)', '#0000ff' ],
+				} as ChartTheme;
+
+				render(
+					<GlobalChartsProvider theme={ cssVarTheme }>
+						<TestComponent />
+					</GlobalChartsProvider>
+				);
+
+				const color1 = contextValue.getElementStyles( {
+					data: undefined,
+					index: 0,
+				} ).color;
+				const color2 = contextValue.getElementStyles( {
+					data: undefined,
+					index: 1,
+				} ).color;
+				const color3 = contextValue.getElementStyles( {
+					data: undefined,
+					index: 2,
+				} ).color;
+
+				expect( color1 ).toBe( '#ff0000' );
+				expect( color2 ).toBe( '#00ff00' );
+				expect( color3 ).toBe( '#0000ff' );
+			} );
+
+			it( 'handles CSS variables with fallback values', () => {
+				window.getComputedStyle = jest.fn( () => ( {
+					getPropertyValue: () => '', // Variable undefined
+				} ) ) as unknown as typeof window.getComputedStyle;
+
+				let contextValue: GlobalChartsContextValue;
+
+				const TestComponent = () => {
+					contextValue = useGlobalChartsContext();
+					return <div>Test</div>;
+				};
+
+				const cssVarTheme: ChartTheme = {
+					colors: [ 'var(--undefined-color, #abcdef)' ],
+				} as ChartTheme;
+
+				render(
+					<GlobalChartsProvider theme={ cssVarTheme }>
+						<TestComponent />
+					</GlobalChartsProvider>
+				);
+
+				const color = contextValue.getElementStyles( {
+					data: undefined,
+					index: 0,
+				} ).color;
+
+				// Should use fallback value
+				expect( color ).toBe( '#abcdef' );
+			} );
+		} );
+
+		describe( 'CSS Variable Edge Cases', () => {
+			it( 'skips CSS variables that resolve to null', () => {
+				window.getComputedStyle = jest.fn( () => ( {
+					getPropertyValue: () => {
+						// Invalid var returns empty, which becomes null
+						return '';
+					},
+				} ) ) as unknown as typeof window.getComputedStyle;
+
+				let contextValue: GlobalChartsContextValue;
+
+				const TestComponent = () => {
+					contextValue = useGlobalChartsContext();
+					return <div>Test</div>;
+				};
+
+				const cssVarTheme: ChartTheme = {
+					colors: [ 'var(--invalid)', '#ff0000' ],
+				} as ChartTheme;
+
+				render(
+					<GlobalChartsProvider theme={ cssVarTheme }>
+						<TestComponent />
+					</GlobalChartsProvider>
+				);
+
+				// Should skip invalid and use second color
+				const color = contextValue.getElementStyles( {
+					data: undefined,
+					index: 0,
+				} ).color;
+
+				expect( color ).toBe( '#ff0000' );
+			} );
+
+			it( 'skips CSS variables that resolve to empty string', () => {
+				window.getComputedStyle = jest.fn( () => ( {
+					getPropertyValue: () => '', // Returns empty string
+				} ) ) as unknown as typeof window.getComputedStyle;
+
+				let contextValue: GlobalChartsContextValue;
+
+				const TestComponent = () => {
+					contextValue = useGlobalChartsContext();
+					return <div>Test</div>;
+				};
+
+				const cssVarTheme: ChartTheme = {
+					colors: [ 'var(--empty)', '#00ff00' ],
+				} as ChartTheme;
+
+				render(
+					<GlobalChartsProvider theme={ cssVarTheme }>
+						<TestComponent />
+					</GlobalChartsProvider>
+				);
+
+				// Empty variable should be skipped, second color becomes first
+				const color = contextValue.getElementStyles( {
+					data: undefined,
+					index: 0,
+				} ).color;
+
+				expect( color ).toBe( '#00ff00' );
+			} );
+
+			it( 'handles CSS variables resolving to non-hex colors', () => {
+				window.getComputedStyle = jest.fn( () => ( {
+					getPropertyValue: ( prop: string ) => {
+						if ( prop === '--rgb-color' ) {
+							return 'rgb(255, 0, 0)'; // Non-hex format
+						}
+						return '';
+					},
+				} ) ) as unknown as typeof window.getComputedStyle;
+
+				let contextValue: GlobalChartsContextValue;
+
+				const TestComponent = () => {
+					contextValue = useGlobalChartsContext();
+					return <div>Test</div>;
+				};
+
+				const cssVarTheme: ChartTheme = {
+					colors: [ 'var(--rgb-color)', '#ff0000' ],
+				} as ChartTheme;
+
+				render(
+					<GlobalChartsProvider theme={ cssVarTheme }>
+						<TestComponent />
+					</GlobalChartsProvider>
+				);
+
+				// Non-hex colors are currently skipped, should use second color
+				const color = contextValue.getElementStyles( {
+					data: undefined,
+					index: 0,
+				} ).color;
+
+				expect( color ).toBe( '#ff0000' );
+			} );
+		} );
+
+		describe( 'Error Handling', () => {
+			it( 'handles invalid hex colors gracefully during HSL conversion', () => {
+				window.getComputedStyle = jest.fn( () => ( {
+					getPropertyValue: () => '',
+				} ) ) as unknown as typeof window.getComputedStyle;
+
+				let contextValue: GlobalChartsContextValue;
+
+				const TestComponent = () => {
+					contextValue = useGlobalChartsContext();
+					return <div>Test</div>;
+				};
+
+				const invalidTheme: ChartTheme = {
+					colors: [ '#invalid', '#ff0000' ],
+				} as ChartTheme;
+
+				// Should not crash
+				expect( () => {
+					render(
+						<GlobalChartsProvider theme={ invalidTheme }>
+							<TestComponent />
+						</GlobalChartsProvider>
+					);
+				} ).not.toThrow();
+
+				// Invalid colors are still added to palette, just don't contribute to HSL calculations
+				const color1 = contextValue.getElementStyles( {
+					data: undefined,
+					index: 0,
+				} ).color;
+				const color2 = contextValue.getElementStyles( {
+					data: undefined,
+					index: 1,
+				} ).color;
+
+				expect( color1 ).toBe( '#invalid' );
+				expect( color2 ).toBe( '#ff0000' );
+			} );
+
+			it( 'handles malformed hex colors in color cache', () => {
+				window.getComputedStyle = jest.fn( () => ( {
+					getPropertyValue: () => '',
+				} ) ) as unknown as typeof window.getComputedStyle;
+
+				let contextValue: GlobalChartsContextValue;
+
+				const TestComponent = () => {
+					contextValue = useGlobalChartsContext();
+					return <div>Test</div>;
+				};
+
+				const malformedTheme: ChartTheme = {
+					colors: [ '#ff', '#gggggg', '#00ff00' ],
+				} as ChartTheme;
+
+				// Should not crash
+				expect( () => {
+					render(
+						<GlobalChartsProvider theme={ malformedTheme }>
+							<TestComponent />
+						</GlobalChartsProvider>
+					);
+				} ).not.toThrow();
+
+				// Malformed colors are still in palette, just don't contribute to HSL calculations
+				const color1 = contextValue.getElementStyles( {
+					data: undefined,
+					index: 0,
+				} ).color;
+				const color2 = contextValue.getElementStyles( {
+					data: undefined,
+					index: 1,
+				} ).color;
+				const color3 = contextValue.getElementStyles( {
+					data: undefined,
+					index: 2,
+				} ).color;
+
+				expect( color1 ).toBe( '#ff' );
+				expect( color2 ).toBe( '#gggggg' );
+				expect( color3 ).toBe( '#00ff00' );
+			} );
+
+			it( 'continues processing colors after encountering an error', () => {
+				window.getComputedStyle = jest.fn( () => ( {
+					getPropertyValue: ( prop: string ) => {
+						if ( prop === '--valid-1' ) {
+							return '#ff0000';
+						}
+						if ( prop === '--invalid' ) {
+							return '#bad'; // Will fail HSL conversion
+						}
+						if ( prop === '--valid-2' ) {
+							return '#0000ff';
+						}
+						return '';
+					},
+				} ) ) as unknown as typeof window.getComputedStyle;
+
+				let contextValue: GlobalChartsContextValue;
+
+				const TestComponent = () => {
+					contextValue = useGlobalChartsContext();
+					return <div>Test</div>;
+				};
+
+				const mixedTheme: ChartTheme = {
+					colors: [ 'var(--valid-1)', 'var(--invalid)', 'var(--valid-2)' ],
+				} as ChartTheme;
+
+				render(
+					<GlobalChartsProvider theme={ mixedTheme }>
+						<TestComponent />
+					</GlobalChartsProvider>
+				);
+
+				// All colors are preserved in order, invalid ones just don't contribute to HSL
+				const color1 = contextValue.getElementStyles( {
+					data: undefined,
+					index: 0,
+				} ).color;
+				const color2 = contextValue.getElementStyles( {
+					data: undefined,
+					index: 1,
+				} ).color;
+				const color3 = contextValue.getElementStyles( {
+					data: undefined,
+					index: 2,
+				} ).color;
+
+				expect( color1 ).toBe( '#ff0000' );
+				expect( color2 ).toBe( '#bad' ); // Invalid color is still in palette
+				expect( color3 ).toBe( '#0000ff' );
+			} );
+		} );
+
+		describe( 'Color Cache Timing', () => {
+			it( 'recomputes color cache when theme colors change with CSS variables', () => {
+				let mockColor = '#ff0000';
+				window.getComputedStyle = jest.fn( () => ( {
+					getPropertyValue: ( prop: string ) => {
+						if ( prop === '--dynamic-color' ) {
+							return mockColor;
+						}
+						return '';
+					},
+				} ) ) as unknown as typeof window.getComputedStyle;
+
+				let contextValue: GlobalChartsContextValue;
+
+				const TestComponent = () => {
+					contextValue = useGlobalChartsContext();
+					return <div>Test</div>;
+				};
+
+				const theme1: ChartTheme = {
+					colors: [ 'var(--dynamic-color)' ],
+				} as ChartTheme;
+
+				const { rerender } = render(
+					<GlobalChartsProvider theme={ theme1 }>
+						<TestComponent />
+					</GlobalChartsProvider>
+				);
+
+				const initialColor = contextValue.getElementStyles( {
+					data: undefined,
+					index: 0,
+				} ).color;
+
+				// Change the mock to return different color
+				mockColor = '#00ff00';
+
+				const theme2: ChartTheme = {
+					colors: [ 'var(--dynamic-color)' ],
+				} as ChartTheme;
+
+				// Re-render with new theme (different object reference)
+				rerender(
+					<GlobalChartsProvider theme={ theme2 }>
+						<TestComponent />
+					</GlobalChartsProvider>
+				);
+
+				const updatedColor = contextValue.getElementStyles( {
+					data: undefined,
+					index: 0,
+				} ).color;
+
+				expect( initialColor ).toBe( '#ff0000' );
+				expect( updatedColor ).toBe( '#00ff00' );
+			} );
+		} );
+
+		describe( 'Integration with CSS Variables', () => {
+			it( 'generates colors based on CSS variable hue range', () => {
+				window.getComputedStyle = jest.fn( () => ( {
+					getPropertyValue: ( prop: string ) => {
+						// Colors with specific hue range (red to orange)
+						if ( prop === '--base-1' ) {
+							return '#ff0000'; // Hue 0
+						}
+						if ( prop === '--base-2' ) {
+							return '#ff8800'; // Hue ~33
+						}
+						return '';
+					},
+				} ) ) as unknown as typeof window.getComputedStyle;
+
+				let contextValue: GlobalChartsContextValue;
+
+				const TestComponent = () => {
+					contextValue = useGlobalChartsContext();
+					return <div>Test</div>;
+				};
+
+				const cssVarTheme: ChartTheme = {
+					colors: [ 'var(--base-1)', 'var(--base-2)' ],
+				} as ChartTheme;
+
+				render(
+					<GlobalChartsProvider theme={ cssVarTheme }>
+						<TestComponent />
+					</GlobalChartsProvider>
+				);
+
+				// Request color beyond palette
+				const generatedColor = contextValue.getElementStyles( {
+					data: undefined,
+					index: 3,
+				} ).color;
+
+				// Should be an HSL color (generated)
+				expect( generatedColor ).toMatch( /^hsl\(\d+,\s*\d+%,\s*\d+%\)$/ );
+			} );
+
+			it( 'mixed static and CSS variable colors work together', () => {
+				window.getComputedStyle = jest.fn( () => ( {
+					getPropertyValue: ( prop: string ) => {
+						if ( prop === '--custom' ) {
+							return '#00ff00';
+						}
+						return '';
+					},
+				} ) ) as unknown as typeof window.getComputedStyle;
+
+				let contextValue: GlobalChartsContextValue;
+
+				const TestComponent = () => {
+					contextValue = useGlobalChartsContext();
+					return <div>Test</div>;
+				};
+
+				const mixedTheme: ChartTheme = {
+					colors: [ '#ff0000', 'var(--custom)', '#0000ff' ],
+				} as ChartTheme;
+
+				render(
+					<GlobalChartsProvider theme={ mixedTheme }>
+						<TestComponent />
+					</GlobalChartsProvider>
+				);
+
+				const color1 = contextValue.getElementStyles( {
+					data: undefined,
+					index: 0,
+				} ).color;
+				const color2 = contextValue.getElementStyles( {
+					data: undefined,
+					index: 1,
+				} ).color;
+				const color3 = contextValue.getElementStyles( {
+					data: undefined,
+					index: 2,
+				} ).color;
+
+				expect( color1 ).toBe( '#ff0000' );
+				expect( color2 ).toBe( '#00ff00' ); // Resolved from CSS var
+				expect( color3 ).toBe( '#0000ff' );
+
+				// Verify group assignments work
+				const groupColor = contextValue.getElementStyles( {
+					data: createMockDataWithGroup( 'test-group' ),
+					index: 0,
+				} ).color;
+
+				expect( [ '#ff0000', '#00ff00', '#0000ff' ] ).toContain( groupColor );
+			} );
+
+			it( 'CSS variable changes reset group color mappings', () => {
+				let mockColor = '#ff0000';
+				window.getComputedStyle = jest.fn( () => ( {
+					getPropertyValue: ( prop: string ) => {
+						if ( prop === '--theme-color' ) {
+							return mockColor;
+						}
+						return '';
+					},
+				} ) ) as unknown as typeof window.getComputedStyle;
+
+				let contextValue: GlobalChartsContextValue;
+
+				const TestComponent = () => {
+					contextValue = useGlobalChartsContext();
+					return <div>Test</div>;
+				};
+
+				const theme1: ChartTheme = {
+					colors: [ 'var(--theme-color)' ],
+				} as ChartTheme;
+
+				const { rerender } = render(
+					<GlobalChartsProvider theme={ theme1 }>
+						<TestComponent />
+					</GlobalChartsProvider>
+				);
+
+				// Create group mapping
+				const initialGroupColor = contextValue.getElementStyles( {
+					data: createMockDataWithGroup( 'test-group' ),
+					index: 0,
+				} ).color;
+
+				expect( initialGroupColor ).toBe( '#ff0000' );
+
+				// Change theme colors
+				mockColor = '#00ff00';
+				const theme2: ChartTheme = {
+					colors: [ 'var(--theme-color)' ],
+				} as ChartTheme;
+
+				rerender(
+					<GlobalChartsProvider theme={ theme2 }>
+						<TestComponent />
+					</GlobalChartsProvider>
+				);
+
+				// Group mapping should be reset and use new color
+				const updatedGroupColor = contextValue.getElementStyles( {
+					data: createMockDataWithGroup( 'test-group' ),
+					index: 0,
+				} ).color;
+
+				expect( updatedGroupColor ).toBe( '#00ff00' );
+			} );
+		} );
+
+		describe( 'Server-Side Rendering', () => {
+			it( 'handles SSR environment where getComputedStyle unavailable', () => {
+				const originalWindow = globalThis.window;
+				const originalDocument = globalThis.document;
+
+				// Simulate SSR by temporarily removing window/document
+				// eslint-disable-next-line @typescript-eslint/no-explicit-any
+				delete ( globalThis as any ).window;
+				// eslint-disable-next-line @typescript-eslint/no-explicit-any
+				delete ( globalThis as any ).document;
+
+				// Restore for test to actually run
+				globalThis.window = originalWindow;
+				globalThis.document = originalDocument;
+
+				// Mock resolveCssVariable to return null (simulating SSR behavior)
+				window.getComputedStyle = jest.fn( () => {
+					throw new Error( 'window is not defined' );
+				} ) as unknown as typeof window.getComputedStyle;
+
+				let contextValue: GlobalChartsContextValue;
+
+				const TestComponent = () => {
+					contextValue = useGlobalChartsContext();
+					return <div>Test</div>;
+				};
+
+				const cssVarTheme: ChartTheme = {
+					colors: [ 'var(--ssr-color)', '#ff0000' ],
+				} as ChartTheme;
+
+				// Should not crash during SSR
+				expect( () => {
+					render(
+						<GlobalChartsProvider theme={ cssVarTheme }>
+							<TestComponent />
+						</GlobalChartsProvider>
+					);
+				} ).not.toThrow();
+
+				// Should fall back to static colors
+				const color = contextValue.getElementStyles( {
+					data: undefined,
+					index: 0,
+				} ).color;
+
+				expect( color ).toBe( '#ff0000' );
+			} );
+		} );
+
+		describe( 'Performance and Caching', () => {
+			it( 'color cache remains stable when theme unchanged with CSS vars', () => {
+				window.getComputedStyle = jest.fn( () => ( {
+					getPropertyValue: ( prop: string ) => {
+						if ( prop === '--stable-color' ) {
+							return '#ff0000';
+						}
+						return '';
+					},
+				} ) ) as unknown as typeof window.getComputedStyle;
+
+				let contextValue: GlobalChartsContextValue;
+
+				const TestComponent = () => {
+					contextValue = useGlobalChartsContext();
+					return <div>Test</div>;
+				};
+
+				const cssVarTheme: ChartTheme = {
+					colors: [ 'var(--stable-color)' ],
+				} as ChartTheme;
+
+				const { rerender } = render(
+					<GlobalChartsProvider theme={ cssVarTheme }>
+						<TestComponent />
+					</GlobalChartsProvider>
+				);
+
+				const initialColor = contextValue.getElementStyles( {
+					data: undefined,
+					index: 0,
+				} ).color;
+
+				// Re-render with same theme
+				rerender(
+					<GlobalChartsProvider theme={ cssVarTheme }>
+						<TestComponent />
+					</GlobalChartsProvider>
+				);
+
+				const afterRerenderColor = contextValue.getElementStyles( {
+					data: undefined,
+					index: 0,
+				} ).color;
+
+				// Colors should remain stable
+				expect( afterRerenderColor ).toBe( initialColor );
+				expect( afterRerenderColor ).toBe( '#ff0000' );
+			} );
+		} );
+	} );
 } );

--- a/projects/js-packages/charts/src/providers/chart-context/test/chart-context.test.tsx
+++ b/projects/js-packages/charts/src/providers/chart-context/test/chart-context.test.tsx
@@ -1735,7 +1735,7 @@ describe( 'ChartContext', () => {
 				};
 
 				const cssVarTheme: ChartTheme = {
-					colors: [ 'var(--primary-color)', '#ff0000' ],
+					colors: [ '--primary-color', '#ff0000' ],
 				} as ChartTheme;
 
 				render(
@@ -1749,7 +1749,6 @@ describe( 'ChartContext', () => {
 					index: 0,
 				} ).color;
 
-				// Should resolve to #00ff00, not the fallback #ff0000
 				expect( color ).toBe( '#00ff00' );
 			} );
 
@@ -1786,7 +1785,7 @@ describe( 'ChartContext', () => {
 				};
 
 				const cssVarTheme: ChartTheme = {
-					colors: [ 'var(--scoped-color)' ],
+					colors: [ '--scoped-color' ],
 				} as ChartTheme;
 
 				render(
@@ -1825,7 +1824,7 @@ describe( 'ChartContext', () => {
 				};
 
 				const cssVarTheme: ChartTheme = {
-					colors: [ 'var(--color-1)', 'var(--color-2)', '#0000ff' ],
+					colors: [ '--color-1', '--color-2', '#0000ff' ],
 				} as ChartTheme;
 
 				render(
@@ -1851,44 +1850,13 @@ describe( 'ChartContext', () => {
 				expect( color2 ).toBe( '#00ff00' );
 				expect( color3 ).toBe( '#0000ff' );
 			} );
-
-			it( 'handles CSS variables with fallback values', () => {
-				window.getComputedStyle = jest.fn( () => ( {
-					getPropertyValue: () => '', // Variable undefined
-				} ) ) as unknown as typeof window.getComputedStyle;
-
-				let contextValue: GlobalChartsContextValue;
-
-				const TestComponent = () => {
-					contextValue = useGlobalChartsContext();
-					return <div>Test</div>;
-				};
-
-				const cssVarTheme: ChartTheme = {
-					colors: [ 'var(--undefined-color, #abcdef)' ],
-				} as ChartTheme;
-
-				render(
-					<GlobalChartsProvider theme={ cssVarTheme }>
-						<TestComponent />
-					</GlobalChartsProvider>
-				);
-
-				const color = contextValue.getElementStyles( {
-					data: undefined,
-					index: 0,
-				} ).color;
-
-				// Should use fallback value
-				expect( color ).toBe( '#abcdef' );
-			} );
 		} );
 
 		describe( 'CSS Variable Edge Cases', () => {
-			it( 'skips CSS variables that resolve to null', () => {
+			it( 'skips CSS variables that are not defined', () => {
 				window.getComputedStyle = jest.fn( () => ( {
 					getPropertyValue: () => {
-						// Invalid var returns empty, which becomes null
+						// Undefined var returns empty string
 						return '';
 					},
 				} ) ) as unknown as typeof window.getComputedStyle;
@@ -1901,7 +1869,7 @@ describe( 'ChartContext', () => {
 				};
 
 				const cssVarTheme: ChartTheme = {
-					colors: [ 'var(--invalid)', '#ff0000' ],
+					colors: [ '--undefined-color', '#ff0000' ],
 				} as ChartTheme;
 
 				render(
@@ -1910,7 +1878,7 @@ describe( 'ChartContext', () => {
 					</GlobalChartsProvider>
 				);
 
-				// Should skip invalid and use second color
+				// Should skip undefined variable and use second color
 				const color = contextValue.getElementStyles( {
 					data: undefined,
 					index: 0,
@@ -1932,7 +1900,7 @@ describe( 'ChartContext', () => {
 				};
 
 				const cssVarTheme: ChartTheme = {
-					colors: [ 'var(--empty)', '#00ff00' ],
+					colors: [ '--undefined-color', '#00ff00' ],
 				} as ChartTheme;
 
 				render(
@@ -1941,7 +1909,7 @@ describe( 'ChartContext', () => {
 					</GlobalChartsProvider>
 				);
 
-				// Empty variable should be skipped, second color becomes first
+				// Undefined variable should be skipped, second color becomes first
 				const color = contextValue.getElementStyles( {
 					data: undefined,
 					index: 0,
@@ -1968,7 +1936,7 @@ describe( 'ChartContext', () => {
 				};
 
 				const cssVarTheme: ChartTheme = {
-					colors: [ 'var(--rgb-color)', '#ff0000' ],
+					colors: [ '--rgb-color', '#ff0000' ],
 				} as ChartTheme;
 
 				render(
@@ -2095,7 +2063,7 @@ describe( 'ChartContext', () => {
 				};
 
 				const mixedTheme: ChartTheme = {
-					colors: [ 'var(--valid-1)', 'var(--invalid)', 'var(--valid-2)' ],
+					colors: [ '--valid-1', '--invalid', '--valid-2' ],
 				} as ChartTheme;
 
 				render(
@@ -2144,7 +2112,7 @@ describe( 'ChartContext', () => {
 				};
 
 				const theme1: ChartTheme = {
-					colors: [ 'var(--dynamic-color)' ],
+					colors: [ '--dynamic-color' ],
 				} as ChartTheme;
 
 				const { rerender } = render(
@@ -2162,7 +2130,7 @@ describe( 'ChartContext', () => {
 				mockColor = '#00ff00';
 
 				const theme2: ChartTheme = {
-					colors: [ 'var(--dynamic-color)' ],
+					colors: [ '--dynamic-color' ],
 				} as ChartTheme;
 
 				// Re-render with new theme (different object reference)
@@ -2205,7 +2173,7 @@ describe( 'ChartContext', () => {
 				};
 
 				const cssVarTheme: ChartTheme = {
-					colors: [ 'var(--base-1)', 'var(--base-2)' ],
+					colors: [ '--base-1', '--base-2' ],
 				} as ChartTheme;
 
 				render(
@@ -2242,7 +2210,7 @@ describe( 'ChartContext', () => {
 				};
 
 				const mixedTheme: ChartTheme = {
-					colors: [ '#ff0000', 'var(--custom)', '#0000ff' ],
+					colors: [ '#ff0000', '--custom', '#0000ff' ],
 				} as ChartTheme;
 
 				render(
@@ -2296,7 +2264,7 @@ describe( 'ChartContext', () => {
 				};
 
 				const theme1: ChartTheme = {
-					colors: [ 'var(--theme-color)' ],
+					colors: [ '--theme-color' ],
 				} as ChartTheme;
 
 				const { rerender } = render(
@@ -2316,7 +2284,7 @@ describe( 'ChartContext', () => {
 				// Change theme colors
 				mockColor = '#00ff00';
 				const theme2: ChartTheme = {
-					colors: [ 'var(--theme-color)' ],
+					colors: [ '--theme-color' ],
 				} as ChartTheme;
 
 				rerender(
@@ -2363,7 +2331,7 @@ describe( 'ChartContext', () => {
 				};
 
 				const cssVarTheme: ChartTheme = {
-					colors: [ 'var(--ssr-color)', '#ff0000' ],
+					colors: [ '--ssr-color', '#ff0000' ],
 				} as ChartTheme;
 
 				// Should not crash during SSR
@@ -2404,7 +2372,7 @@ describe( 'ChartContext', () => {
 				};
 
 				const cssVarTheme: ChartTheme = {
-					colors: [ 'var(--stable-color)' ],
+					colors: [ '--stable-color' ],
 				} as ChartTheme;
 
 				const { rerender } = render(

--- a/projects/js-packages/charts/src/providers/chart-context/themes.ts
+++ b/projects/js-packages/charts/src/providers/chart-context/themes.ts
@@ -43,12 +43,9 @@ const defaultTheme: CompleteChartTheme = {
 		rowGap: 12,
 		columnGap: 4,
 		labelSpacing: 1.5,
-		primaryColor: '#006DAB',
-		secondaryColor: '#98C8DF',
 		deltaColors: [ '#FF8C8F', '#757575', '#1F9828' ], // [negative, neutral, positive]
 	},
 	conversionFunnelChart: {
-		primaryColor: '#006DAB',
 		backgroundColor: '#F3F4F6',
 		positiveChangeColor: '#1F9828',
 		negativeChangeColor: '#FF8C8F',
@@ -107,7 +104,6 @@ const jetpackTheme: ChartTheme = {
 		deltaColors: [ '#FF8C8F', '#757575', '#1F9828' ], // [negative, neutral, positive]
 	},
 	conversionFunnelChart: {
-		primaryColor: '#006DAB',
 		backgroundColor: '#F3F4F6',
 		positiveChangeColor: '#1F9828',
 		negativeChangeColor: '#FF8C8F',
@@ -172,12 +168,9 @@ const wooTheme: ChartTheme = {
 		rowGap: 12,
 		columnGap: 4,
 		labelSpacing: 1.5,
-		primaryColor: '#3858E9',
-		secondaryColor: '#66BDFF',
 		deltaColors: [ '#D63638', '#757575', '#008A20' ], // [negative, neutral, positive]
 	},
 	conversionFunnelChart: {
-		primaryColor: '#3858E9',
 		backgroundColor: '#F3F4F6',
 		positiveChangeColor: '#008A20',
 		negativeChangeColor: '#D63638',

--- a/projects/js-packages/charts/src/stories/chart-decorator.tsx
+++ b/projects/js-packages/charts/src/stories/chart-decorator.tsx
@@ -59,7 +59,7 @@ export const chartDecorator: Decorator = ( Story, context ) => {
  */
 const StoryChartProvider = ( {
 	children,
-	themeName = 'custom',
+	themeName = 'default',
 	accentColor = '#c029dc',
 }: {
 	children: React.ReactNode;
@@ -110,7 +110,7 @@ const StoryChartProvider = ( {
  */
 export const simpleChartDecorator: Decorator = ( Story, { args } ) => {
 	const storyArgs = args as unknown as ChartStoryArgs;
-	const themeName = storyArgs.themeName || 'custom';
+	const themeName = storyArgs.themeName;
 	const accentColor = storyArgs.accentColor;
 
 	return (
@@ -124,13 +124,6 @@ export const simpleChartDecorator: Decorator = ( Story, { args } ) => {
  * Shared argTypes for common chart controls
  */
 export const sharedChartArgTypes = {
-	accentColor: {
-		control: { type: 'color' },
-		description: 'Accent color for the custom theme (used for primary chart elements)',
-		defaultValue: '#c029dc',
-		table: { category: 'Theme' },
-		if: { arg: 'themeName', eq: 'custom' },
-	},
 	maxWidth: {
 		control: {
 			type: 'number',

--- a/projects/js-packages/charts/src/stories/chart-decorator.tsx
+++ b/projects/js-packages/charts/src/stories/chart-decorator.tsx
@@ -87,7 +87,7 @@ const StoryChartProvider = ( {
 				<style>
 					{ `
 						:root {
-							--wpds-color-bg-interactive-brand-strong: ${ accentColor };
+							--wpds-color-bg-interactive-brand: ${ accentColor };
 						}
 					` }
 				</style>

--- a/projects/js-packages/charts/src/stories/chart-decorator.tsx
+++ b/projects/js-packages/charts/src/stories/chart-decorator.tsx
@@ -1,7 +1,7 @@
 import { setLocale } from '@automattic/number-formatters';
 import { useEffect } from 'react';
 import { GlobalChartsProvider } from '../providers';
-import { CHART_THEME_MAP } from './theme-config';
+import { CHART_THEME_MAP, DEFAULT_ACCENT_COLOR } from './theme-config';
 import type { Decorator } from '@storybook/react';
 
 /**
@@ -47,11 +47,6 @@ export const chartDecorator: Decorator = ( Story, context ) => {
 
 	return simpleChartDecorator( StoryWithContainer, context );
 };
-
-/**
- * Default accent color for custom theme in Storybook
- */
-const DEFAULT_ACCENT_COLOR = '#c029dc';
 
 /**
  * Validates that a string is a safe hex color value

--- a/projects/js-packages/charts/src/stories/chart-decorator.tsx
+++ b/projects/js-packages/charts/src/stories/chart-decorator.tsx
@@ -49,6 +49,21 @@ export const chartDecorator: Decorator = ( Story, context ) => {
 };
 
 /**
+ * Default accent color for custom theme in Storybook
+ */
+const DEFAULT_ACCENT_COLOR = '#c029dc';
+
+/**
+ * Validates that a string is a safe hex color value
+ * Prevents XSS by ensuring only valid hex colors are used in CSS
+ * @param color - Color string to validate
+ * @return true if the color is a valid hex format (#RGB or #RRGGBB)
+ */
+const isValidHexColor = ( color: string ): boolean => {
+	return /^#[0-9A-Fa-f]{3}$|^#[0-9A-Fa-f]{6}$/.test( color );
+};
+
+/**
  * Provider wrapper for Storybook chart stories
  * Handles theme setup, CSS variables for custom theme, locale initialization, and GlobalChartsProvider
  * @param root0             - Props object
@@ -60,7 +75,7 @@ export const chartDecorator: Decorator = ( Story, context ) => {
 const StoryChartProvider = ( {
 	children,
 	themeName = 'default',
-	accentColor = '#c029dc',
+	accentColor = DEFAULT_ACCENT_COLOR,
 }: {
 	children: React.ReactNode;
 	themeName?: string;
@@ -77,9 +92,13 @@ const StoryChartProvider = ( {
 
 	const theme = CHART_THEME_MAP[ themeName ];
 
+	// Sanitize accent color to prevent XSS via CSS injection
+	// Falls back to default if invalid hex color is provided
+	const sanitizedAccentColor = isValidHexColor( accentColor ) ? accentColor : DEFAULT_ACCENT_COLOR;
+
 	// Force GlobalChartsProvider to remount when accent color changes for custom theme
 	// This ensures CSS variables are re-resolved after the DOM updates
-	const providerKey = themeName === 'custom' ? `custom-${ accentColor }` : themeName;
+	const providerKey = themeName === 'custom' ? `custom-${ sanitizedAccentColor }` : themeName;
 
 	return (
 		<>
@@ -87,7 +106,7 @@ const StoryChartProvider = ( {
 				<style>
 					{ `
 						:root {
-							--wpds-color-bg-interactive-brand: ${ accentColor };
+							--wpds-color-bg-interactive-brand: ${ sanitizedAccentColor };
 						}
 					` }
 				</style>

--- a/projects/js-packages/charts/src/stories/chart-decorator.tsx
+++ b/projects/js-packages/charts/src/stories/chart-decorator.tsx
@@ -63,7 +63,7 @@ const StoryChartProvider = ( {
 	accentColor = '#c029dc',
 }: {
 	children: React.ReactNode;
-	themeName: string;
+	themeName?: string;
 	accentColor?: string;
 } ) => {
 	// Initialize number formatters with browser locale for Storybook

--- a/projects/js-packages/charts/src/stories/chart-decorator.tsx
+++ b/projects/js-packages/charts/src/stories/chart-decorator.tsx
@@ -49,14 +49,15 @@ export const chartDecorator: Decorator = ( Story, context ) => {
 };
 
 /**
- * Wrapper component that initializes locale for Storybook environment
+ * Provider wrapper for Storybook chart stories
+ * Handles theme setup, CSS variables for custom theme, locale initialization, and GlobalChartsProvider
  * @param root0             - Props object
  * @param root0.children    - Child components to render
- * @param root0.themeName   - Theme name
- * @param root0.accentColor - Accent color for custom theme (CSS variable value)
- * @return JSX element with locale initialization and GlobalChartsProvider
+ * @param root0.themeName   - Theme name to apply
+ * @param root0.accentColor - Accent color for custom theme (injected as CSS variable)
+ * @return JSX element with chart environment setup and GlobalChartsProvider
  */
-const LocaleInitializer = ( {
+const StoryChartProvider = ( {
 	children,
 	themeName = 'custom',
 	accentColor = '#c029dc',
@@ -113,9 +114,9 @@ export const simpleChartDecorator: Decorator = ( Story, { args } ) => {
 	const accentColor = storyArgs.accentColor;
 
 	return (
-		<LocaleInitializer themeName={ themeName } accentColor={ accentColor }>
+		<StoryChartProvider themeName={ themeName } accentColor={ accentColor }>
 			<Story />
-		</LocaleInitializer>
+		</StoryChartProvider>
 	);
 };
 

--- a/projects/js-packages/charts/src/stories/chart-decorator.tsx
+++ b/projects/js-packages/charts/src/stories/chart-decorator.tsx
@@ -2,7 +2,6 @@ import { setLocale } from '@automattic/number-formatters';
 import { useEffect } from 'react';
 import { GlobalChartsProvider } from '../providers';
 import { CHART_THEME_MAP } from './theme-config';
-import type { ChartTheme } from '../types';
 import type { Decorator } from '@storybook/react';
 
 /**
@@ -11,6 +10,7 @@ import type { Decorator } from '@storybook/react';
  */
 export type ChartStoryArgs< T = Record< string, unknown > > = T & {
 	themeName?: string;
+	accentColor?: string;
 	containerWidth?: string;
 	containerHeight?: string;
 	resize?: 'none' | 'both' | 'horizontal' | 'vertical';
@@ -50,17 +50,20 @@ export const chartDecorator: Decorator = ( Story, context ) => {
 
 /**
  * Wrapper component that initializes locale for Storybook environment
- * @param root0          - Props object
- * @param root0.children - Child components to render
- * @param root0.theme    - Chart theme to apply
+ * @param root0             - Props object
+ * @param root0.children    - Child components to render
+ * @param root0.themeName   - Theme name
+ * @param root0.accentColor - Accent color for custom theme (CSS variable value)
  * @return JSX element with locale initialization and GlobalChartsProvider
  */
 const LocaleInitializer = ( {
 	children,
-	theme,
+	themeName = 'custom',
+	accentColor = '#c029dc',
 }: {
 	children: React.ReactNode;
-	theme: Partial< ChartTheme >;
+	themeName: string;
+	accentColor?: string;
 } ) => {
 	// Initialize number formatters with browser locale for Storybook
 	// In WordPress, @automattic/number-formatters automatically uses the WordPress user locale
@@ -71,7 +74,28 @@ const LocaleInitializer = ( {
 		}
 	}, [] );
 
-	return <GlobalChartsProvider theme={ theme }>{ children }</GlobalChartsProvider>;
+	const theme = CHART_THEME_MAP[ themeName ];
+
+	// Force GlobalChartsProvider to remount when accent color changes for custom theme
+	// This ensures CSS variables are re-resolved after the DOM updates
+	const providerKey = themeName === 'custom' ? `custom-${ accentColor }` : themeName;
+
+	return (
+		<>
+			{ themeName === 'custom' && (
+				<style>
+					{ `
+						:root {
+							--wpds-color-bg-interactive-brand-strong: ${ accentColor };
+						}
+					` }
+				</style>
+			) }
+			<GlobalChartsProvider key={ providerKey } theme={ theme }>
+				{ children }
+			</GlobalChartsProvider>
+		</>
+	);
 };
 
 /**
@@ -84,20 +108,12 @@ const LocaleInitializer = ( {
  * @return The story component wrapped in GlobalChartsProvider only
  */
 export const simpleChartDecorator: Decorator = ( Story, { args } ) => {
-	const themeName = ( args as unknown as ChartStoryArgs ).themeName;
-	const theme = CHART_THEME_MAP[ themeName || 'default' ];
+	const storyArgs = args as unknown as ChartStoryArgs;
+	const themeName = storyArgs.themeName || 'custom';
+	const accentColor = storyArgs.accentColor;
 
 	return (
-		<LocaleInitializer theme={ theme }>
-			{ themeName === 'custom' && (
-				<style>
-					{ `
-						:root {
-							--wpds-color-bg-interactive-brand-strong: #3ac200;
-						}
-					` }
-				</style>
-			) }
+		<LocaleInitializer themeName={ themeName } accentColor={ accentColor }>
 			<Story />
 		</LocaleInitializer>
 	);
@@ -107,6 +123,13 @@ export const simpleChartDecorator: Decorator = ( Story, { args } ) => {
  * Shared argTypes for common chart controls
  */
 export const sharedChartArgTypes = {
+	accentColor: {
+		control: { type: 'color' },
+		description: 'Accent color for the custom theme (used for primary chart elements)',
+		defaultValue: '#c029dc',
+		table: { category: 'Theme' },
+		if: { arg: 'themeName', eq: 'custom' },
+	},
 	maxWidth: {
 		control: {
 			type: 'number',

--- a/projects/js-packages/charts/src/stories/chart-decorator.tsx
+++ b/projects/js-packages/charts/src/stories/chart-decorator.tsx
@@ -89,6 +89,15 @@ export const simpleChartDecorator: Decorator = ( Story, { args } ) => {
 
 	return (
 		<LocaleInitializer theme={ theme }>
+			{ themeName === 'custom' && (
+				<style>
+					{ `
+						:root {
+							--wpds-color-bg-interactive-brand-strong: #3ac200;
+						}
+					` }
+				</style>
+			) }
 			<Story />
 		</LocaleInitializer>
 	);

--- a/projects/js-packages/charts/src/stories/chart-decorator.tsx
+++ b/projects/js-packages/charts/src/stories/chart-decorator.tsx
@@ -135,7 +135,7 @@ export const simpleChartDecorator: Decorator = ( Story, { args } ) => {
 };
 
 /**
- * Shared argTypes for common chart controls
+ * Shared argTypes for common chart controls (dimensions, container settings)
  */
 export const sharedChartArgTypes = {
 	maxWidth: {

--- a/projects/js-packages/charts/src/stories/index.ts
+++ b/projects/js-packages/charts/src/stories/index.ts
@@ -1,10 +1,13 @@
 // Shared decorators and story utilities
-export { chartDecorator, simpleChartDecorator, sharedChartArgTypes } from './chart-decorator';
-
-export type { ChartStoryArgs } from './chart-decorator';
+export {
+	chartDecorator,
+	simpleChartDecorator,
+	sharedChartArgTypes,
+	type ChartStoryArgs,
+} from './chart-decorator';
 
 // Theme configuration
-export { themeArgTypes, CHART_THEME_MAP } from './theme-config';
+export { themeArgTypes, sharedThemeArgs, CHART_THEME_MAP } from './theme-config';
 
 // Legend configuration
 export { legendArgTypes } from './legend-config';

--- a/projects/js-packages/charts/src/stories/theme-config.tsx
+++ b/projects/js-packages/charts/src/stories/theme-config.tsx
@@ -5,7 +5,7 @@ import type { ChartTheme } from '../types';
  * Custom theme with earth tones and dashed line styles for demonstration
  */
 export const customTheme: ChartTheme = {
-	colors: [ 'var(--wpds-color-bg-interactive-brand-strong)' ],
+	colors: [ 'var(--wpds-color-bg-interactive-brand)' ],
 	seriesLineStyles: [
 		{},
 		{

--- a/projects/js-packages/charts/src/stories/theme-config.tsx
+++ b/projects/js-packages/charts/src/stories/theme-config.tsx
@@ -5,7 +5,7 @@ import type { ChartTheme } from '../types';
  * Custom theme with earth tones and dashed line styles for demonstration
  */
 export const customTheme: ChartTheme = {
-	colors: [ '#073B3A', '#0B6E4F', '#08A045', '#6BBF59', '#DDB771' ],
+	colors: [ 'var(--wpds-color-bg-interactive-brand-strong)' ],
 	seriesLineStyles: [
 		{
 			strokeWidth: 1,

--- a/projects/js-packages/charts/src/stories/theme-config.tsx
+++ b/projects/js-packages/charts/src/stories/theme-config.tsx
@@ -7,24 +7,14 @@ import type { ChartTheme } from '../types';
 export const customTheme: ChartTheme = {
 	colors: [ 'var(--wpds-color-bg-interactive-brand-strong)' ],
 	seriesLineStyles: [
-		{
-			strokeWidth: 1,
-			strokeDasharray: '8 8',
-			strokeLinecap: 'square',
-		},
+		{},
 		{
 			strokeDasharray: '5 8',
-			strokeWidth: 2,
-			strokeLinecap: 'square',
 		},
 	],
 	gridStyles: {
 		stroke: '#ffe3e3',
 		strokeWidth: 2,
-	},
-	leaderboardChart: {
-		primaryColor: '#073B3A',
-		secondaryColor: '#0B6E4F',
 	},
 } as ChartTheme;
 
@@ -48,5 +38,12 @@ export const themeArgTypes = {
 		defaultValue: 'default',
 		description: 'Select a theme to apply to the chart',
 		table: { category: 'Theme' },
+	},
+	accentColor: {
+		control: { type: 'color' as const },
+		description: 'Accent color for the custom theme (used for primary chart elements)',
+		defaultValue: '#3ac200',
+		table: { category: 'Theme' },
+		if: { arg: 'themeName', eq: 'custom' },
 	},
 };

--- a/projects/js-packages/charts/src/stories/theme-config.tsx
+++ b/projects/js-packages/charts/src/stories/theme-config.tsx
@@ -52,3 +52,11 @@ export const themeArgTypes = {
 		if: { arg: 'themeName', eq: 'custom' },
 	},
 };
+
+/**
+ * Shared default args for theme-related controls in chart stories
+ * These provide actual default values that appear in Storybook controls
+ */
+export const sharedThemeArgs = {
+	accentColor: DEFAULT_ACCENT_COLOR,
+} as const;

--- a/projects/js-packages/charts/src/stories/theme-config.tsx
+++ b/projects/js-packages/charts/src/stories/theme-config.tsx
@@ -42,7 +42,7 @@ export const themeArgTypes = {
 	accentColor: {
 		control: { type: 'color' as const },
 		description: 'Accent color for the custom theme (used for primary chart elements)',
-		defaultValue: '#3ac200',
+		defaultValue: '#c029dc',
 		table: { category: 'Theme' },
 		if: { arg: 'themeName', eq: 'custom' },
 	},

--- a/projects/js-packages/charts/src/stories/theme-config.tsx
+++ b/projects/js-packages/charts/src/stories/theme-config.tsx
@@ -58,5 +58,6 @@ export const themeArgTypes = {
  * These provide actual default values that appear in Storybook controls
  */
 export const sharedThemeArgs = {
+	themeName: 'default',
 	accentColor: DEFAULT_ACCENT_COLOR,
 } as const;

--- a/projects/js-packages/charts/src/stories/theme-config.tsx
+++ b/projects/js-packages/charts/src/stories/theme-config.tsx
@@ -10,7 +10,7 @@ export const DEFAULT_ACCENT_COLOR = '#4a19ab';
  * Custom theme using a CSS variable for dynamic color generation
  */
 export const customTheme: ChartTheme = {
-	colors: [ 'var(--wpds-color-bg-interactive-brand)' ],
+	colors: [ '--wpds-color-bg-interactive-brand' ],
 	seriesLineStyles: [
 		{},
 		{

--- a/projects/js-packages/charts/src/stories/theme-config.tsx
+++ b/projects/js-packages/charts/src/stories/theme-config.tsx
@@ -2,6 +2,11 @@ import { defaultTheme, jetpackTheme, wooTheme } from '../providers';
 import type { ChartTheme } from '../types';
 
 /**
+ * Default accent color for custom theme in Storybook
+ */
+export const DEFAULT_ACCENT_COLOR = '#4a19ab';
+
+/**
  * Custom theme using a CSS variable for dynamic color generation
  */
 export const customTheme: ChartTheme = {
@@ -42,7 +47,7 @@ export const themeArgTypes = {
 	accentColor: {
 		control: { type: 'color' as const },
 		description: 'Accent color for the custom theme (used for primary chart elements)',
-		defaultValue: '#c029dc',
+		defaultValue: DEFAULT_ACCENT_COLOR,
 		table: { category: 'Theme' },
 		if: { arg: 'themeName', eq: 'custom' },
 	},

--- a/projects/js-packages/charts/src/stories/theme-config.tsx
+++ b/projects/js-packages/charts/src/stories/theme-config.tsx
@@ -2,7 +2,7 @@ import { defaultTheme, jetpackTheme, wooTheme } from '../providers';
 import type { ChartTheme } from '../types';
 
 /**
- * Custom theme with earth tones and dashed line styles for demonstration
+ * Custom theme using a CSS variable for dynamic color generation
  */
 export const customTheme: ChartTheme = {
 	colors: [ 'var(--wpds-color-bg-interactive-brand)' ],

--- a/projects/js-packages/charts/src/types.ts
+++ b/projects/js-packages/charts/src/types.ts
@@ -222,8 +222,16 @@ export type ChartTheme = {
  * Useful for merged themes where defaults are provided for all optional properties.
  */
 export type CompleteChartTheme = Required< ChartTheme > & {
-	leaderboardChart: Required< NonNullable< ChartTheme[ 'leaderboardChart' ] > >;
-	conversionFunnelChart: Required< NonNullable< ChartTheme[ 'conversionFunnelChart' ] > >;
+	leaderboardChart: Omit<
+		Required< NonNullable< ChartTheme[ 'leaderboardChart' ] > >,
+		'primaryColor' | 'secondaryColor'
+	> &
+		Pick< NonNullable< ChartTheme[ 'leaderboardChart' ] >, 'primaryColor' | 'secondaryColor' >;
+	conversionFunnelChart: Omit<
+		Required< NonNullable< ChartTheme[ 'conversionFunnelChart' ] > >,
+		'primaryColor'
+	> &
+		Pick< NonNullable< ChartTheme[ 'conversionFunnelChart' ] >, 'primaryColor' >;
 	lineChart: {
 		lineStyles: Record< NonNullable< SeriesDataOptions[ 'type' ] >, LineStyles >;
 	};

--- a/projects/js-packages/charts/src/utils/index.ts
+++ b/projects/js-packages/charts/src/utils/index.ts
@@ -23,3 +23,6 @@ export { mergeThemes } from './merge-themes';
 
 // Color utilities
 export * from './color-utils';
+
+// CSS utilities
+export { resolveCssVariable } from './resolve-css-var';

--- a/projects/js-packages/charts/src/utils/resolve-css-var.ts
+++ b/projects/js-packages/charts/src/utils/resolve-css-var.ts
@@ -1,0 +1,27 @@
+/**
+ * Resolves a CSS custom property (variable) to its computed value
+ *
+ * @param cssVar - A CSS variable string like 'var(--my-color)'
+ * @return The computed value or null if invalid
+ */
+export const resolveCssVariable = ( cssVar: string ): string | null => {
+	if ( typeof window === 'undefined' || typeof document === 'undefined' ) {
+		return null;
+	}
+
+	// Extract the variable name from var(--variable-name)
+	const match = cssVar.match( /var\(\s*(--[^),\s]+)\s*(?:,\s*([^)]+))?\s*\)/ );
+	if ( ! match ) {
+		return null;
+	}
+
+	const varName = match[ 1 ];
+	const fallback = match[ 2 ];
+
+	// Get computed style from root element
+	const computedValue = getComputedStyle( document.documentElement )
+		.getPropertyValue( varName )
+		.trim();
+
+	return computedValue || fallback || null;
+};

--- a/projects/js-packages/charts/src/utils/resolve-css-var.ts
+++ b/projects/js-packages/charts/src/utils/resolve-css-var.ts
@@ -1,7 +1,7 @@
 /**
  * Resolves a CSS custom property (variable) to its computed value
  *
- * @param cssVar  - A CSS variable string like 'var(--my-color)'
+ * @param cssVar  - A CSS variable string like 'var(--my-color)' or 'var(--my-color, fallback)'
  * @param element - Optional DOM element to resolve the variable from (defaults to document.documentElement)
  * @return The computed value or null if invalid
  */
@@ -17,14 +17,46 @@ export const resolveCssVariable = (
 		throw new Error( 'CSS variable is too long' );
 	}
 
-	// Extract the variable name from var(--variable-name)
-	const match = cssVar.match( /var\(\s*(--[^),\s]+)\s*(?:,\s*([^)]+))?\s*\)/ );
-	if ( ! match ) {
+	// Check for basic var() structure
+	if ( ! cssVar.startsWith( 'var(' ) || ! cssVar.endsWith( ')' ) ) {
 		return null;
 	}
 
-	const varName = match[ 1 ];
-	const fallback = match[ 2 ];
+	// Remove 'var(' and trailing ')'
+	const content = cssVar.slice( 4, -1 ).trim();
+
+	// Extract variable name and fallback by parsing with paren counting
+	let varName = '';
+	let fallback: string | undefined;
+	let parenDepth = 0;
+	let commaIndex = -1;
+
+	for ( let i = 0; i < content.length; i++ ) {
+		const char = content[ i ];
+
+		if ( char === '(' ) {
+			parenDepth++;
+		} else if ( char === ')' ) {
+			parenDepth--;
+		} else if ( char === ',' && parenDepth === 0 && commaIndex === -1 ) {
+			// Found the comma separating variable from fallback
+			commaIndex = i;
+		}
+	}
+
+	if ( commaIndex === -1 ) {
+		// No fallback value
+		varName = content.trim();
+	} else {
+		// Has fallback value
+		varName = content.slice( 0, commaIndex ).trim();
+		fallback = content.slice( commaIndex + 1 ).trim();
+	}
+
+	// Validate variable name format (must start with --)
+	if ( ! varName.startsWith( '--' ) || /[,)\s]/.test( varName ) ) {
+		return null;
+	}
 
 	// Get computed style from the specified element or document root
 	const targetElement = element || document.documentElement;

--- a/projects/js-packages/charts/src/utils/resolve-css-var.ts
+++ b/projects/js-packages/charts/src/utils/resolve-css-var.ts
@@ -58,9 +58,16 @@ export const resolveCssVariable = (
 		return null;
 	}
 
-	// Get computed style from the specified element or document root
-	const targetElement = element || document.documentElement;
-	const computedValue = getComputedStyle( targetElement ).getPropertyValue( varName ).trim();
+	const fallbackValue = fallback?.trim() || null;
 
-	return computedValue || fallback?.trim() || null;
+	// Get computed style from the specified element or document root
+	try {
+		const targetElement = element || document.documentElement;
+		const computedValue = getComputedStyle( targetElement ).getPropertyValue( varName ).trim();
+
+		return computedValue || fallbackValue;
+	} catch {
+		// Return fallback if getComputedStyle throws (e.g., detached element)
+		return fallbackValue;
+	}
 };

--- a/projects/js-packages/charts/src/utils/resolve-css-var.ts
+++ b/projects/js-packages/charts/src/utils/resolve-css-var.ts
@@ -9,6 +9,10 @@ export const resolveCssVariable = ( cssVar: string ): string | null => {
 		return null;
 	}
 
+	if ( cssVar.length > 1000 ) {
+		throw new Error( 'CSS variable is too long' );
+	}
+
 	// Extract the variable name from var(--variable-name)
 	const match = cssVar.match( /var\(\s*(--[^),\s]+)\s*(?:,\s*([^)]+))?\s*\)/ );
 	if ( ! match ) {

--- a/projects/js-packages/charts/src/utils/resolve-css-var.ts
+++ b/projects/js-packages/charts/src/utils/resolve-css-var.ts
@@ -53,8 +53,8 @@ export const resolveCssVariable = (
 		fallback = content.slice( commaIndex + 1 ).trim();
 	}
 
-	// Validate variable name format (must start with --)
-	if ( ! varName.startsWith( '--' ) || /[,)\s]/.test( varName ) ) {
+	// Validate variable name format (must start with -- and contain no invalid characters)
+	if ( ! varName.startsWith( '--' ) || /[,()\s]/.test( varName ) ) {
 		return null;
 	}
 

--- a/projects/js-packages/charts/src/utils/resolve-css-var.ts
+++ b/projects/js-packages/charts/src/utils/resolve-css-var.ts
@@ -1,73 +1,31 @@
 /**
  * Resolves a CSS custom property (variable) to its computed value
  *
- * @param cssVar  - A CSS variable string like 'var(--my-color)' or 'var(--my-color, fallback)'
+ * @param varName - A CSS variable name like '--my-color'
  * @param element - Optional DOM element to resolve the variable from (defaults to document.documentElement)
- * @return The computed value or null if invalid
+ * @return The computed value or null if invalid/not found
  */
 export const resolveCssVariable = (
-	cssVar: string,
+	varName: string,
 	element?: HTMLElement | null
 ): string | null => {
 	if ( typeof window === 'undefined' || typeof document === 'undefined' ) {
 		return null;
 	}
 
-	if ( cssVar.length > 1000 ) {
-		throw new Error( 'CSS variable is too long' );
-	}
-
-	// Check for basic var() structure
-	if ( ! cssVar.startsWith( 'var(' ) || ! cssVar.endsWith( ')' ) ) {
+	// Validate variable name format (must start with --)
+	if ( ! varName.startsWith( '--' ) ) {
 		return null;
 	}
-
-	// Remove 'var(' and trailing ')'
-	const content = cssVar.slice( 4, -1 ).trim();
-
-	// Extract variable name and fallback by parsing with paren counting
-	let varName = '';
-	let fallback: string | undefined;
-	let parenDepth = 0;
-	let commaIndex = -1;
-
-	for ( let i = 0; i < content.length; i++ ) {
-		const char = content[ i ];
-
-		if ( char === '(' ) {
-			parenDepth++;
-		} else if ( char === ')' ) {
-			parenDepth--;
-		} else if ( char === ',' && parenDepth === 0 && commaIndex === -1 ) {
-			// Found the comma separating variable from fallback
-			commaIndex = i;
-		}
-	}
-
-	if ( commaIndex === -1 ) {
-		// No fallback value
-		varName = content.trim();
-	} else {
-		// Has fallback value
-		varName = content.slice( 0, commaIndex ).trim();
-		fallback = content.slice( commaIndex + 1 ).trim();
-	}
-
-	// Validate variable name format (must start with -- and contain no invalid characters)
-	if ( ! varName.startsWith( '--' ) || /[,()\s]/.test( varName ) ) {
-		return null;
-	}
-
-	const fallbackValue = fallback?.trim() || null;
 
 	// Get computed style from the specified element or document root
 	try {
 		const targetElement = element || document.documentElement;
 		const computedValue = getComputedStyle( targetElement ).getPropertyValue( varName ).trim();
 
-		return computedValue || fallbackValue;
+		return computedValue || null;
 	} catch {
-		// Return fallback if getComputedStyle throws (e.g., detached element)
-		return fallbackValue;
+		// Return null if getComputedStyle throws (e.g., detached element)
+		return null;
 	}
 };

--- a/projects/js-packages/charts/src/utils/resolve-css-var.ts
+++ b/projects/js-packages/charts/src/utils/resolve-css-var.ts
@@ -30,5 +30,5 @@ export const resolveCssVariable = (
 	const targetElement = element || document.documentElement;
 	const computedValue = getComputedStyle( targetElement ).getPropertyValue( varName ).trim();
 
-	return computedValue || fallback || null;
+	return computedValue || fallback?.trim() || null;
 };

--- a/projects/js-packages/charts/src/utils/resolve-css-var.ts
+++ b/projects/js-packages/charts/src/utils/resolve-css-var.ts
@@ -1,10 +1,14 @@
 /**
  * Resolves a CSS custom property (variable) to its computed value
  *
- * @param cssVar - A CSS variable string like 'var(--my-color)'
+ * @param cssVar  - A CSS variable string like 'var(--my-color)'
+ * @param element - Optional DOM element to resolve the variable from (defaults to document.documentElement)
  * @return The computed value or null if invalid
  */
-export const resolveCssVariable = ( cssVar: string ): string | null => {
+export const resolveCssVariable = (
+	cssVar: string,
+	element?: HTMLElement | null
+): string | null => {
 	if ( typeof window === 'undefined' || typeof document === 'undefined' ) {
 		return null;
 	}
@@ -22,10 +26,9 @@ export const resolveCssVariable = ( cssVar: string ): string | null => {
 	const varName = match[ 1 ];
 	const fallback = match[ 2 ];
 
-	// Get computed style from root element
-	const computedValue = getComputedStyle( document.documentElement )
-		.getPropertyValue( varName )
-		.trim();
+	// Get computed style from the specified element or document root
+	const targetElement = element || document.documentElement;
+	const computedValue = getComputedStyle( targetElement ).getPropertyValue( varName ).trim();
 
 	return computedValue || fallback || null;
 };

--- a/projects/js-packages/charts/src/utils/test/resolve-css-var.test.ts
+++ b/projects/js-packages/charts/src/utils/test/resolve-css-var.test.ts
@@ -140,6 +140,42 @@ describe( 'resolveCssVariable', () => {
 			const result = resolveCssVariable( 'var(--undefined-color,  #ffffff  )' );
 			expect( result ).toBe( '#ffffff' );
 		} );
+
+		it( 'handles fallback values with nested parentheses (rgb)', () => {
+			window.getComputedStyle = jest.fn( () => ( {
+				getPropertyValue: () => '',
+			} ) ) as unknown as typeof window.getComputedStyle;
+
+			const result = resolveCssVariable( 'var(--undefined-color, rgb(255, 0, 0))' );
+			expect( result ).toBe( 'rgb(255, 0, 0)' );
+		} );
+
+		it( 'handles fallback values with nested parentheses (rgba)', () => {
+			window.getComputedStyle = jest.fn( () => ( {
+				getPropertyValue: () => '',
+			} ) ) as unknown as typeof window.getComputedStyle;
+
+			const result = resolveCssVariable( 'var(--undefined-color, rgba(52, 152, 219, 0.5))' );
+			expect( result ).toBe( 'rgba(52, 152, 219, 0.5)' );
+		} );
+
+		it( 'handles fallback values with nested parentheses (hsl)', () => {
+			window.getComputedStyle = jest.fn( () => ( {
+				getPropertyValue: () => '',
+			} ) ) as unknown as typeof window.getComputedStyle;
+
+			const result = resolveCssVariable( 'var(--undefined-color, hsl(200, 70%, 50%))' );
+			expect( result ).toBe( 'hsl(200, 70%, 50%)' );
+		} );
+
+		it( 'handles complex nested calc() in fallback values', () => {
+			window.getComputedStyle = jest.fn( () => ( {
+				getPropertyValue: () => '',
+			} ) ) as unknown as typeof window.getComputedStyle;
+
+			const result = resolveCssVariable( 'var(--spacing, calc(1rem + 2px))' );
+			expect( result ).toBe( 'calc(1rem + 2px)' );
+		} );
 	} );
 
 	describe( 'Invalid input handling', () => {

--- a/projects/js-packages/charts/src/utils/test/resolve-css-var.test.ts
+++ b/projects/js-packages/charts/src/utils/test/resolve-css-var.test.ts
@@ -312,4 +312,152 @@ describe( 'resolveCssVariable', () => {
 			expect( result ).toBe( '1.5' );
 		} );
 	} );
+
+	describe( 'Custom element resolution', () => {
+		it( 'resolves CSS variable from a custom element', () => {
+			const customElement = document.createElement( 'div' );
+			const mockGetComputedStyle = jest.fn( ( element: Element ) => {
+				if ( element === customElement ) {
+					return {
+						getPropertyValue: ( prop: string ) => {
+							if ( prop === '--scoped-color' ) {
+								return '#00ff00';
+							}
+							return '';
+						},
+					};
+				}
+				return {
+					getPropertyValue: () => '',
+				};
+			} );
+			window.getComputedStyle = mockGetComputedStyle as unknown as typeof window.getComputedStyle;
+
+			const result = resolveCssVariable( 'var(--scoped-color)', customElement );
+			expect( result ).toBe( '#00ff00' );
+			expect( mockGetComputedStyle ).toHaveBeenCalledWith( customElement );
+		} );
+
+		it( 'falls back to document root when element is null', () => {
+			const mockGetComputedStyle = jest.fn( ( element: Element ) => {
+				if ( element === document.documentElement ) {
+					return {
+						getPropertyValue: ( prop: string ) => {
+							if ( prop === '--root-color' ) {
+								return '#ff0000';
+							}
+							return '';
+						},
+					};
+				}
+				return {
+					getPropertyValue: () => '',
+				};
+			} );
+			window.getComputedStyle = mockGetComputedStyle as unknown as typeof window.getComputedStyle;
+
+			const result = resolveCssVariable( 'var(--root-color)', null );
+			expect( result ).toBe( '#ff0000' );
+			expect( mockGetComputedStyle ).toHaveBeenCalledWith( document.documentElement );
+		} );
+
+		it( 'falls back to document root when element is undefined', () => {
+			const mockGetComputedStyle = jest.fn( ( element: Element ) => {
+				if ( element === document.documentElement ) {
+					return {
+						getPropertyValue: ( prop: string ) => {
+							if ( prop === '--root-color' ) {
+								return '#ff0000';
+							}
+							return '';
+						},
+					};
+				}
+				return {
+					getPropertyValue: () => '',
+				};
+			} );
+			window.getComputedStyle = mockGetComputedStyle as unknown as typeof window.getComputedStyle;
+
+			const result = resolveCssVariable( 'var(--root-color)', undefined );
+			expect( result ).toBe( '#ff0000' );
+			expect( mockGetComputedStyle ).toHaveBeenCalledWith( document.documentElement );
+		} );
+
+		it( 'resolves scoped CSS variable that differs from root', () => {
+			const scopedElement = document.createElement( 'div' );
+			const mockGetComputedStyle = jest.fn( ( element: Element ) => {
+				if ( element === scopedElement ) {
+					return {
+						getPropertyValue: ( prop: string ) => {
+							if ( prop === '--brand-color' ) {
+								return '#00ff00'; // Scoped value
+							}
+							return '';
+						},
+					};
+				}
+				if ( element === document.documentElement ) {
+					return {
+						getPropertyValue: ( prop: string ) => {
+							if ( prop === '--brand-color' ) {
+								return '#ff0000'; // Root value
+							}
+							return '';
+						},
+					};
+				}
+				return {
+					getPropertyValue: () => '',
+				};
+			} );
+			window.getComputedStyle = mockGetComputedStyle as unknown as typeof window.getComputedStyle;
+
+			// When resolving from scoped element, should get scoped value
+			const scopedResult = resolveCssVariable( 'var(--brand-color)', scopedElement );
+			expect( scopedResult ).toBe( '#00ff00' );
+
+			// When resolving from root (or no element), should get root value
+			const rootResult = resolveCssVariable( 'var(--brand-color)' );
+			expect( rootResult ).toBe( '#ff0000' );
+		} );
+
+		it( 'uses fallback value when scoped variable is not defined', () => {
+			const scopedElement = document.createElement( 'div' );
+			const mockGetComputedStyle = jest.fn( () => ( {
+				getPropertyValue: () => '', // Variable not defined
+			} ) );
+			window.getComputedStyle = mockGetComputedStyle as unknown as typeof window.getComputedStyle;
+
+			const result = resolveCssVariable( 'var(--undefined-scoped, #abcdef)', scopedElement );
+			expect( result ).toBe( '#abcdef' );
+		} );
+
+		it( 'handles complex selector scoped elements', () => {
+			// Simulate an element with specific classes/attributes like .uLgshq-root[data-wpds-theme-provider-id]
+			const themedElement = document.createElement( 'div' );
+			themedElement.className = 'uLgshq-root';
+			themedElement.setAttribute( 'data-wpds-theme-provider-id', ':rj:' );
+
+			const mockGetComputedStyle = jest.fn( ( element: Element ) => {
+				if ( element === themedElement ) {
+					return {
+						getPropertyValue: ( prop: string ) => {
+							if ( prop === '--wpds-color-bg-interactive-brand' ) {
+								return '#c029dc'; // User's custom accent color
+							}
+							return '';
+						},
+					};
+				}
+				return {
+					getPropertyValue: () => '',
+				};
+			} );
+			window.getComputedStyle = mockGetComputedStyle as unknown as typeof window.getComputedStyle;
+
+			const result = resolveCssVariable( 'var(--wpds-color-bg-interactive-brand)', themedElement );
+			expect( result ).toBe( '#c029dc' );
+		} );
+	} );
 } );

--- a/projects/js-packages/charts/src/utils/test/resolve-css-var.test.ts
+++ b/projects/js-packages/charts/src/utils/test/resolve-css-var.test.ts
@@ -138,7 +138,7 @@ describe( 'resolveCssVariable', () => {
 			} ) ) as unknown as typeof window.getComputedStyle;
 
 			const result = resolveCssVariable( 'var(--undefined-color,  #ffffff  )' );
-			expect( result ).toBe( '#ffffff  ' );
+			expect( result ).toBe( '#ffffff' );
 		} );
 	} );
 

--- a/projects/js-packages/charts/src/utils/test/resolve-css-var.test.ts
+++ b/projects/js-packages/charts/src/utils/test/resolve-css-var.test.ts
@@ -27,7 +27,7 @@ describe( 'resolveCssVariable', () => {
 				},
 			} ) ) as unknown as typeof window.getComputedStyle;
 
-			const result = resolveCssVariable( 'var(--test-color)' );
+			const result = resolveCssVariable( '--test-color' );
 			expect( result ).toBe( '#ff0000' );
 		} );
 
@@ -36,7 +36,7 @@ describe( 'resolveCssVariable', () => {
 				getPropertyValue: () => '  #00ff00  ',
 			} ) ) as unknown as typeof window.getComputedStyle;
 
-			const result = resolveCssVariable( 'var(--test-color)' );
+			const result = resolveCssVariable( '--test-color' );
 			expect( result ).toBe( '#00ff00' );
 		} );
 
@@ -50,7 +50,7 @@ describe( 'resolveCssVariable', () => {
 				},
 			} ) ) as unknown as typeof window.getComputedStyle;
 
-			const result = resolveCssVariable( 'var(--my-custom-color)' );
+			const result = resolveCssVariable( '--my-custom-color' );
 			expect( result ).toBe( '#0000ff' );
 		} );
 
@@ -64,128 +64,14 @@ describe( 'resolveCssVariable', () => {
 				},
 			} ) ) as unknown as typeof window.getComputedStyle;
 
-			const result = resolveCssVariable( 'var(--color-123)' );
+			const result = resolveCssVariable( '--color-123' );
 			expect( result ).toBe( 'rgb(255, 0, 0)' );
-		} );
-	} );
-
-	describe( 'Whitespace handling', () => {
-		it( 'handles CSS variables with spaces inside var()', () => {
-			window.getComputedStyle = jest.fn( () => ( {
-				getPropertyValue: ( prop: string ) => {
-					if ( prop === '--test-color' ) {
-						return '#ff0000';
-					}
-					return '';
-				},
-			} ) ) as unknown as typeof window.getComputedStyle;
-
-			const result = resolveCssVariable( 'var( --test-color )' );
-			expect( result ).toBe( '#ff0000' );
-		} );
-
-		it( 'handles CSS variables with extra spaces around var()', () => {
-			window.getComputedStyle = jest.fn( () => ( {
-				getPropertyValue: ( prop: string ) => {
-					if ( prop === '--test-color' ) {
-						return '#ff0000';
-					}
-					return '';
-				},
-			} ) ) as unknown as typeof window.getComputedStyle;
-
-			const result = resolveCssVariable( 'var(  --test-color  )' );
-			expect( result ).toBe( '#ff0000' );
-		} );
-	} );
-
-	describe( 'Fallback values', () => {
-		it( 'returns fallback value when CSS variable is not defined', () => {
-			window.getComputedStyle = jest.fn( () => ( {
-				getPropertyValue: () => '',
-			} ) ) as unknown as typeof window.getComputedStyle;
-
-			const result = resolveCssVariable( 'var(--undefined-color, #123456)' );
-			expect( result ).toBe( '#123456' );
-		} );
-
-		it( 'returns computed value over fallback when variable exists', () => {
-			window.getComputedStyle = jest.fn( () => ( {
-				getPropertyValue: ( prop: string ) => {
-					if ( prop === '--test-color' ) {
-						return '#ff0000';
-					}
-					return '';
-				},
-			} ) ) as unknown as typeof window.getComputedStyle;
-
-			const result = resolveCssVariable( 'var(--test-color, #123456)' );
-			expect( result ).toBe( '#ff0000' );
-		} );
-
-		it( 'handles simple fallback values with spaces', () => {
-			window.getComputedStyle = jest.fn( () => ( {
-				getPropertyValue: () => '',
-			} ) ) as unknown as typeof window.getComputedStyle;
-
-			const result = resolveCssVariable( 'var(--undefined-color, 10px 20px)' );
-			expect( result ).toBe( '10px 20px' );
-		} );
-
-		it( 'handles fallback values with extra whitespace', () => {
-			window.getComputedStyle = jest.fn( () => ( {
-				getPropertyValue: () => '',
-			} ) ) as unknown as typeof window.getComputedStyle;
-
-			const result = resolveCssVariable( 'var(--undefined-color,  #ffffff  )' );
-			expect( result ).toBe( '#ffffff' );
-		} );
-
-		it( 'handles fallback values with nested parentheses (rgb)', () => {
-			window.getComputedStyle = jest.fn( () => ( {
-				getPropertyValue: () => '',
-			} ) ) as unknown as typeof window.getComputedStyle;
-
-			const result = resolveCssVariable( 'var(--undefined-color, rgb(255, 0, 0))' );
-			expect( result ).toBe( 'rgb(255, 0, 0)' );
-		} );
-
-		it( 'handles fallback values with nested parentheses (rgba)', () => {
-			window.getComputedStyle = jest.fn( () => ( {
-				getPropertyValue: () => '',
-			} ) ) as unknown as typeof window.getComputedStyle;
-
-			const result = resolveCssVariable( 'var(--undefined-color, rgba(52, 152, 219, 0.5))' );
-			expect( result ).toBe( 'rgba(52, 152, 219, 0.5)' );
-		} );
-
-		it( 'handles fallback values with nested parentheses (hsl)', () => {
-			window.getComputedStyle = jest.fn( () => ( {
-				getPropertyValue: () => '',
-			} ) ) as unknown as typeof window.getComputedStyle;
-
-			const result = resolveCssVariable( 'var(--undefined-color, hsl(200, 70%, 50%))' );
-			expect( result ).toBe( 'hsl(200, 70%, 50%)' );
-		} );
-
-		it( 'handles complex nested calc() in fallback values', () => {
-			window.getComputedStyle = jest.fn( () => ( {
-				getPropertyValue: () => '',
-			} ) ) as unknown as typeof window.getComputedStyle;
-
-			const result = resolveCssVariable( 'var(--spacing, calc(1rem + 2px))' );
-			expect( result ).toBe( 'calc(1rem + 2px)' );
 		} );
 	} );
 
 	describe( 'Invalid input handling', () => {
-		it( 'returns null for invalid CSS variable syntax', () => {
-			const result = resolveCssVariable( 'not-a-var' );
-			expect( result ).toBeNull();
-		} );
-
-		it( 'returns null for CSS variables without var() wrapper', () => {
-			const result = resolveCssVariable( '--test-color' );
+		it( 'returns null for CSS variables without double dash prefix', () => {
+			const result = resolveCssVariable( 'test-color' );
 			expect( result ).toBeNull();
 		} );
 
@@ -194,49 +80,19 @@ describe( 'resolveCssVariable', () => {
 			expect( result ).toBeNull();
 		} );
 
-		it( 'returns null for CSS variables without double dash prefix', () => {
-			const result = resolveCssVariable( 'var(test-color)' );
+		it( 'returns null for single dash prefix', () => {
+			const result = resolveCssVariable( '-test-color' );
 			expect( result ).toBeNull();
-		} );
-
-		it( 'returns null for malformed var() syntax', () => {
-			const result = resolveCssVariable( 'var(--test-color' );
-			expect( result ).toBeNull();
-		} );
-
-		it( 'returns null for nested var() calls', () => {
-			const result = resolveCssVariable( 'var(var(--test-color))' );
-			expect( result ).toBeNull();
-		} );
-
-		it( 'returns null for variable names with opening parentheses', () => {
-			const result = resolveCssVariable( 'var(--test(name))' );
-			expect( result ).toBeNull();
-		} );
-
-		it( 'returns null for variable names with closing parentheses', () => {
-			const result = resolveCssVariable( 'var(--test)name)' );
-			expect( result ).toBeNull();
-		} );
-
-		it( 'returns null for variable names with both parentheses', () => {
-			const result = resolveCssVariable( 'var(--(test))' );
-			expect( result ).toBeNull();
-		} );
-
-		it( 'throws error for CSS variable string longer than 1000 characters', () => {
-			const longVar = 'var(--' + 'a'.repeat( 1000 ) + ')';
-			expect( () => resolveCssVariable( longVar ) ).toThrow( 'CSS variable is too long' );
 		} );
 	} );
 
 	describe( 'Edge cases', () => {
-		it( 'returns null when computed value is empty and no fallback provided', () => {
+		it( 'returns null when computed value is empty', () => {
 			window.getComputedStyle = jest.fn( () => ( {
 				getPropertyValue: () => '',
 			} ) ) as unknown as typeof window.getComputedStyle;
 
-			const result = resolveCssVariable( 'var(--undefined-color)' );
+			const result = resolveCssVariable( '--undefined-color' );
 			expect( result ).toBeNull();
 		} );
 
@@ -246,18 +102,9 @@ describe( 'resolveCssVariable', () => {
 			} ) );
 			window.getComputedStyle = mockGetComputedStyle as unknown as typeof window.getComputedStyle;
 
-			resolveCssVariable( 'var(--test-color)' );
+			resolveCssVariable( '--test-color' );
 
 			expect( mockGetComputedStyle ).toHaveBeenCalledWith( document.documentElement );
-		} );
-
-		it( 'handles empty fallback values', () => {
-			window.getComputedStyle = jest.fn( () => ( {
-				getPropertyValue: () => '',
-			} ) ) as unknown as typeof window.getComputedStyle;
-
-			const result = resolveCssVariable( 'var(--undefined-color,)' );
-			expect( result ).toBeNull();
 		} );
 
 		it( 'handles CSS variables with only hyphens after prefix', () => {
@@ -270,7 +117,7 @@ describe( 'resolveCssVariable', () => {
 				},
 			} ) ) as unknown as typeof window.getComputedStyle;
 
-			const result = resolveCssVariable( 'var(-----)' );
+			const result = resolveCssVariable( '-----' );
 			expect( result ).toBe( 'value' );
 		} );
 	} );
@@ -281,7 +128,7 @@ describe( 'resolveCssVariable', () => {
 			// eslint-disable-next-line @typescript-eslint/no-explicit-any
 			delete ( globalThis as any ).window;
 
-			const result = resolveCssVariable( 'var(--test-color)' );
+			const result = resolveCssVariable( '--test-color' );
 			expect( result ).toBeNull();
 
 			globalThis.window = originalWindow;
@@ -292,7 +139,7 @@ describe( 'resolveCssVariable', () => {
 			// eslint-disable-next-line @typescript-eslint/no-explicit-any
 			delete ( globalThis as any ).document;
 
-			const result = resolveCssVariable( 'var(--test-color)' );
+			const result = resolveCssVariable( '--test-color' );
 			expect( result ).toBeNull();
 
 			globalThis.document = originalDocument;
@@ -305,7 +152,7 @@ describe( 'resolveCssVariable', () => {
 				getPropertyValue: () => '#3498db',
 			} ) ) as unknown as typeof window.getComputedStyle;
 
-			const result = resolveCssVariable( 'var(--primary-color)' );
+			const result = resolveCssVariable( '--primary-color' );
 			expect( result ).toBe( '#3498db' );
 		} );
 
@@ -314,7 +161,7 @@ describe( 'resolveCssVariable', () => {
 				getPropertyValue: () => 'rgb(52, 152, 219)',
 			} ) ) as unknown as typeof window.getComputedStyle;
 
-			const result = resolveCssVariable( 'var(--primary-color)' );
+			const result = resolveCssVariable( '--primary-color' );
 			expect( result ).toBe( 'rgb(52, 152, 219)' );
 		} );
 
@@ -323,7 +170,7 @@ describe( 'resolveCssVariable', () => {
 				getPropertyValue: () => 'rgba(52, 152, 219, 0.5)',
 			} ) ) as unknown as typeof window.getComputedStyle;
 
-			const result = resolveCssVariable( 'var(--primary-color)' );
+			const result = resolveCssVariable( '--primary-color' );
 			expect( result ).toBe( 'rgba(52, 152, 219, 0.5)' );
 		} );
 
@@ -332,7 +179,7 @@ describe( 'resolveCssVariable', () => {
 				getPropertyValue: () => '16px',
 			} ) ) as unknown as typeof window.getComputedStyle;
 
-			const result = resolveCssVariable( 'var(--font-size)' );
+			const result = resolveCssVariable( '--font-size' );
 			expect( result ).toBe( '16px' );
 		} );
 
@@ -341,7 +188,7 @@ describe( 'resolveCssVariable', () => {
 				getPropertyValue: () => '50%',
 			} ) ) as unknown as typeof window.getComputedStyle;
 
-			const result = resolveCssVariable( 'var(--width)' );
+			const result = resolveCssVariable( '--width' );
 			expect( result ).toBe( '50%' );
 		} );
 
@@ -350,7 +197,7 @@ describe( 'resolveCssVariable', () => {
 				getPropertyValue: () => '1.5rem',
 			} ) ) as unknown as typeof window.getComputedStyle;
 
-			const result = resolveCssVariable( 'var(--spacing)' );
+			const result = resolveCssVariable( '--spacing' );
 			expect( result ).toBe( '1.5rem' );
 		} );
 
@@ -359,28 +206,19 @@ describe( 'resolveCssVariable', () => {
 				getPropertyValue: () => '1.5',
 			} ) ) as unknown as typeof window.getComputedStyle;
 
-			const result = resolveCssVariable( 'var(--line-height)' );
+			const result = resolveCssVariable( '--line-height' );
 			expect( result ).toBe( '1.5' );
 		} );
 	} );
 
 	describe( 'Error handling', () => {
-		it( 'returns null when getComputedStyle throws an error without fallback', () => {
+		it( 'returns null when getComputedStyle throws an error', () => {
 			window.getComputedStyle = jest.fn( () => {
 				throw new Error( 'Cannot read properties of detached element' );
 			} ) as unknown as typeof window.getComputedStyle;
 
-			const result = resolveCssVariable( 'var(--test-color)' );
+			const result = resolveCssVariable( '--test-color' );
 			expect( result ).toBeNull();
-		} );
-
-		it( 'returns fallback value when getComputedStyle throws an error', () => {
-			window.getComputedStyle = jest.fn( () => {
-				throw new Error( 'Cannot read properties of detached element' );
-			} ) as unknown as typeof window.getComputedStyle;
-
-			const result = resolveCssVariable( 'var(--test-color, #ff0000)' );
-			expect( result ).toBe( '#ff0000' );
 		} );
 
 		it( 'handles getPropertyValue throwing an error', () => {
@@ -390,17 +228,8 @@ describe( 'resolveCssVariable', () => {
 				},
 			} ) ) as unknown as typeof window.getComputedStyle;
 
-			const result = resolveCssVariable( 'var(--test-color, #00ff00)' );
-			expect( result ).toBe( '#00ff00' );
-		} );
-
-		it( 'trims fallback value whitespace when error occurs', () => {
-			window.getComputedStyle = jest.fn( () => {
-				throw new Error( 'Element error' );
-			} ) as unknown as typeof window.getComputedStyle;
-
-			const result = resolveCssVariable( 'var(--test-color,  #123456  )' );
-			expect( result ).toBe( '#123456' );
+			const result = resolveCssVariable( '--test-color' );
+			expect( result ).toBeNull();
 		} );
 	} );
 
@@ -424,7 +253,7 @@ describe( 'resolveCssVariable', () => {
 			} );
 			window.getComputedStyle = mockGetComputedStyle as unknown as typeof window.getComputedStyle;
 
-			const result = resolveCssVariable( 'var(--scoped-color)', customElement );
+			const result = resolveCssVariable( '--scoped-color', customElement );
 			expect( result ).toBe( '#00ff00' );
 			expect( mockGetComputedStyle ).toHaveBeenCalledWith( customElement );
 		} );
@@ -447,7 +276,7 @@ describe( 'resolveCssVariable', () => {
 			} );
 			window.getComputedStyle = mockGetComputedStyle as unknown as typeof window.getComputedStyle;
 
-			const result = resolveCssVariable( 'var(--root-color)', null );
+			const result = resolveCssVariable( '--root-color', null );
 			expect( result ).toBe( '#ff0000' );
 			expect( mockGetComputedStyle ).toHaveBeenCalledWith( document.documentElement );
 		} );
@@ -470,7 +299,7 @@ describe( 'resolveCssVariable', () => {
 			} );
 			window.getComputedStyle = mockGetComputedStyle as unknown as typeof window.getComputedStyle;
 
-			const result = resolveCssVariable( 'var(--root-color)', undefined );
+			const result = resolveCssVariable( '--root-color', undefined );
 			expect( result ).toBe( '#ff0000' );
 			expect( mockGetComputedStyle ).toHaveBeenCalledWith( document.documentElement );
 		} );
@@ -505,23 +334,23 @@ describe( 'resolveCssVariable', () => {
 			window.getComputedStyle = mockGetComputedStyle as unknown as typeof window.getComputedStyle;
 
 			// When resolving from scoped element, should get scoped value
-			const scopedResult = resolveCssVariable( 'var(--brand-color)', scopedElement );
+			const scopedResult = resolveCssVariable( '--brand-color', scopedElement );
 			expect( scopedResult ).toBe( '#00ff00' );
 
 			// When resolving from root (or no element), should get root value
-			const rootResult = resolveCssVariable( 'var(--brand-color)' );
+			const rootResult = resolveCssVariable( '--brand-color' );
 			expect( rootResult ).toBe( '#ff0000' );
 		} );
 
-		it( 'uses fallback value when scoped variable is not defined', () => {
+		it( 'returns null when scoped variable is not defined', () => {
 			const scopedElement = document.createElement( 'div' );
 			const mockGetComputedStyle = jest.fn( () => ( {
 				getPropertyValue: () => '', // Variable not defined
 			} ) );
 			window.getComputedStyle = mockGetComputedStyle as unknown as typeof window.getComputedStyle;
 
-			const result = resolveCssVariable( 'var(--undefined-scoped, #abcdef)', scopedElement );
-			expect( result ).toBe( '#abcdef' );
+			const result = resolveCssVariable( '--undefined-scoped', scopedElement );
+			expect( result ).toBeNull();
 		} );
 
 		it( 'handles complex selector scoped elements', () => {
@@ -547,7 +376,7 @@ describe( 'resolveCssVariable', () => {
 			} );
 			window.getComputedStyle = mockGetComputedStyle as unknown as typeof window.getComputedStyle;
 
-			const result = resolveCssVariable( 'var(--wpds-color-bg-interactive-brand)', themedElement );
+			const result = resolveCssVariable( '--wpds-color-bg-interactive-brand', themedElement );
 			expect( result ).toBe( '#c029dc' );
 		} );
 	} );

--- a/projects/js-packages/charts/src/utils/test/resolve-css-var.test.ts
+++ b/projects/js-packages/charts/src/utils/test/resolve-css-var.test.ts
@@ -364,6 +364,46 @@ describe( 'resolveCssVariable', () => {
 		} );
 	} );
 
+	describe( 'Error handling', () => {
+		it( 'returns null when getComputedStyle throws an error without fallback', () => {
+			window.getComputedStyle = jest.fn( () => {
+				throw new Error( 'Cannot read properties of detached element' );
+			} ) as unknown as typeof window.getComputedStyle;
+
+			const result = resolveCssVariable( 'var(--test-color)' );
+			expect( result ).toBeNull();
+		} );
+
+		it( 'returns fallback value when getComputedStyle throws an error', () => {
+			window.getComputedStyle = jest.fn( () => {
+				throw new Error( 'Cannot read properties of detached element' );
+			} ) as unknown as typeof window.getComputedStyle;
+
+			const result = resolveCssVariable( 'var(--test-color, #ff0000)' );
+			expect( result ).toBe( '#ff0000' );
+		} );
+
+		it( 'handles getPropertyValue throwing an error', () => {
+			window.getComputedStyle = jest.fn( () => ( {
+				getPropertyValue: () => {
+					throw new Error( 'Invalid property access' );
+				},
+			} ) ) as unknown as typeof window.getComputedStyle;
+
+			const result = resolveCssVariable( 'var(--test-color, #00ff00)' );
+			expect( result ).toBe( '#00ff00' );
+		} );
+
+		it( 'trims fallback value whitespace when error occurs', () => {
+			window.getComputedStyle = jest.fn( () => {
+				throw new Error( 'Element error' );
+			} ) as unknown as typeof window.getComputedStyle;
+
+			const result = resolveCssVariable( 'var(--test-color,  #123456  )' );
+			expect( result ).toBe( '#123456' );
+		} );
+	} );
+
 	describe( 'Custom element resolution', () => {
 		it( 'resolves CSS variable from a custom element', () => {
 			const customElement = document.createElement( 'div' );

--- a/projects/js-packages/charts/src/utils/test/resolve-css-var.test.ts
+++ b/projects/js-packages/charts/src/utils/test/resolve-css-var.test.ts
@@ -1,0 +1,315 @@
+/**
+ * @jest-environment jsdom
+ */
+import { resolveCssVariable } from '../resolve-css-var';
+
+describe( 'resolveCssVariable', () => {
+	let originalGetComputedStyle: typeof window.getComputedStyle;
+
+	beforeEach( () => {
+		// Store original getComputedStyle
+		originalGetComputedStyle = window.getComputedStyle;
+	} );
+
+	afterEach( () => {
+		// Restore original getComputedStyle
+		window.getComputedStyle = originalGetComputedStyle;
+	} );
+
+	describe( 'Basic functionality', () => {
+		it( 'resolves a CSS variable that exists on the document root', () => {
+			window.getComputedStyle = jest.fn( () => ( {
+				getPropertyValue: ( prop: string ) => {
+					if ( prop === '--test-color' ) {
+						return '#ff0000';
+					}
+					return '';
+				},
+			} ) ) as unknown as typeof window.getComputedStyle;
+
+			const result = resolveCssVariable( 'var(--test-color)' );
+			expect( result ).toBe( '#ff0000' );
+		} );
+
+		it( 'trims whitespace from computed values', () => {
+			window.getComputedStyle = jest.fn( () => ( {
+				getPropertyValue: () => '  #00ff00  ',
+			} ) ) as unknown as typeof window.getComputedStyle;
+
+			const result = resolveCssVariable( 'var(--test-color)' );
+			expect( result ).toBe( '#00ff00' );
+		} );
+
+		it( 'handles CSS variable names with hyphens', () => {
+			window.getComputedStyle = jest.fn( () => ( {
+				getPropertyValue: ( prop: string ) => {
+					if ( prop === '--my-custom-color' ) {
+						return '#0000ff';
+					}
+					return '';
+				},
+			} ) ) as unknown as typeof window.getComputedStyle;
+
+			const result = resolveCssVariable( 'var(--my-custom-color)' );
+			expect( result ).toBe( '#0000ff' );
+		} );
+
+		it( 'handles CSS variable names with numbers', () => {
+			window.getComputedStyle = jest.fn( () => ( {
+				getPropertyValue: ( prop: string ) => {
+					if ( prop === '--color-123' ) {
+						return 'rgb(255, 0, 0)';
+					}
+					return '';
+				},
+			} ) ) as unknown as typeof window.getComputedStyle;
+
+			const result = resolveCssVariable( 'var(--color-123)' );
+			expect( result ).toBe( 'rgb(255, 0, 0)' );
+		} );
+	} );
+
+	describe( 'Whitespace handling', () => {
+		it( 'handles CSS variables with spaces inside var()', () => {
+			window.getComputedStyle = jest.fn( () => ( {
+				getPropertyValue: ( prop: string ) => {
+					if ( prop === '--test-color' ) {
+						return '#ff0000';
+					}
+					return '';
+				},
+			} ) ) as unknown as typeof window.getComputedStyle;
+
+			const result = resolveCssVariable( 'var( --test-color )' );
+			expect( result ).toBe( '#ff0000' );
+		} );
+
+		it( 'handles CSS variables with extra spaces around var()', () => {
+			window.getComputedStyle = jest.fn( () => ( {
+				getPropertyValue: ( prop: string ) => {
+					if ( prop === '--test-color' ) {
+						return '#ff0000';
+					}
+					return '';
+				},
+			} ) ) as unknown as typeof window.getComputedStyle;
+
+			const result = resolveCssVariable( 'var(  --test-color  )' );
+			expect( result ).toBe( '#ff0000' );
+		} );
+	} );
+
+	describe( 'Fallback values', () => {
+		it( 'returns fallback value when CSS variable is not defined', () => {
+			window.getComputedStyle = jest.fn( () => ( {
+				getPropertyValue: () => '',
+			} ) ) as unknown as typeof window.getComputedStyle;
+
+			const result = resolveCssVariable( 'var(--undefined-color, #123456)' );
+			expect( result ).toBe( '#123456' );
+		} );
+
+		it( 'returns computed value over fallback when variable exists', () => {
+			window.getComputedStyle = jest.fn( () => ( {
+				getPropertyValue: ( prop: string ) => {
+					if ( prop === '--test-color' ) {
+						return '#ff0000';
+					}
+					return '';
+				},
+			} ) ) as unknown as typeof window.getComputedStyle;
+
+			const result = resolveCssVariable( 'var(--test-color, #123456)' );
+			expect( result ).toBe( '#ff0000' );
+		} );
+
+		it( 'handles simple fallback values with spaces', () => {
+			window.getComputedStyle = jest.fn( () => ( {
+				getPropertyValue: () => '',
+			} ) ) as unknown as typeof window.getComputedStyle;
+
+			const result = resolveCssVariable( 'var(--undefined-color, 10px 20px)' );
+			expect( result ).toBe( '10px 20px' );
+		} );
+
+		it( 'handles fallback values with extra whitespace', () => {
+			window.getComputedStyle = jest.fn( () => ( {
+				getPropertyValue: () => '',
+			} ) ) as unknown as typeof window.getComputedStyle;
+
+			const result = resolveCssVariable( 'var(--undefined-color,  #ffffff  )' );
+			expect( result ).toBe( '#ffffff  ' );
+		} );
+	} );
+
+	describe( 'Invalid input handling', () => {
+		it( 'returns null for invalid CSS variable syntax', () => {
+			const result = resolveCssVariable( 'not-a-var' );
+			expect( result ).toBeNull();
+		} );
+
+		it( 'returns null for CSS variables without var() wrapper', () => {
+			const result = resolveCssVariable( '--test-color' );
+			expect( result ).toBeNull();
+		} );
+
+		it( 'returns null for empty string', () => {
+			const result = resolveCssVariable( '' );
+			expect( result ).toBeNull();
+		} );
+
+		it( 'returns null for CSS variables without double dash prefix', () => {
+			const result = resolveCssVariable( 'var(test-color)' );
+			expect( result ).toBeNull();
+		} );
+
+		it( 'returns null for malformed var() syntax', () => {
+			const result = resolveCssVariable( 'var(--test-color' );
+			expect( result ).toBeNull();
+		} );
+
+		it( 'returns null for nested var() calls', () => {
+			const result = resolveCssVariable( 'var(var(--test-color))' );
+			expect( result ).toBeNull();
+		} );
+
+		it( 'throws error for CSS variable string longer than 1000 characters', () => {
+			const longVar = 'var(--' + 'a'.repeat( 1000 ) + ')';
+			expect( () => resolveCssVariable( longVar ) ).toThrow( 'CSS variable is too long' );
+		} );
+	} );
+
+	describe( 'Edge cases', () => {
+		it( 'returns null when computed value is empty and no fallback provided', () => {
+			window.getComputedStyle = jest.fn( () => ( {
+				getPropertyValue: () => '',
+			} ) ) as unknown as typeof window.getComputedStyle;
+
+			const result = resolveCssVariable( 'var(--undefined-color)' );
+			expect( result ).toBeNull();
+		} );
+
+		it( 'queries document.documentElement for computed styles', () => {
+			const mockGetComputedStyle = jest.fn( () => ( {
+				getPropertyValue: () => '#ff0000',
+			} ) );
+			window.getComputedStyle = mockGetComputedStyle as unknown as typeof window.getComputedStyle;
+
+			resolveCssVariable( 'var(--test-color)' );
+
+			expect( mockGetComputedStyle ).toHaveBeenCalledWith( document.documentElement );
+		} );
+
+		it( 'handles empty fallback values', () => {
+			window.getComputedStyle = jest.fn( () => ( {
+				getPropertyValue: () => '',
+			} ) ) as unknown as typeof window.getComputedStyle;
+
+			const result = resolveCssVariable( 'var(--undefined-color,)' );
+			expect( result ).toBeNull();
+		} );
+
+		it( 'handles CSS variables with only hyphens after prefix', () => {
+			window.getComputedStyle = jest.fn( () => ( {
+				getPropertyValue: ( prop: string ) => {
+					if ( prop === '-----' ) {
+						return 'value';
+					}
+					return '';
+				},
+			} ) ) as unknown as typeof window.getComputedStyle;
+
+			const result = resolveCssVariable( 'var(-----)' );
+			expect( result ).toBe( 'value' );
+		} );
+	} );
+
+	describe( 'SSR compatibility', () => {
+		it( 'returns null when window is undefined', () => {
+			const originalWindow = globalThis.window;
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			delete ( globalThis as any ).window;
+
+			const result = resolveCssVariable( 'var(--test-color)' );
+			expect( result ).toBeNull();
+
+			globalThis.window = originalWindow;
+		} );
+
+		it( 'returns null when document is undefined', () => {
+			const originalDocument = globalThis.document;
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			delete ( globalThis as any ).document;
+
+			const result = resolveCssVariable( 'var(--test-color)' );
+			expect( result ).toBeNull();
+
+			globalThis.document = originalDocument;
+		} );
+	} );
+
+	describe( 'Real-world value types', () => {
+		it( 'handles hex color values', () => {
+			window.getComputedStyle = jest.fn( () => ( {
+				getPropertyValue: () => '#3498db',
+			} ) ) as unknown as typeof window.getComputedStyle;
+
+			const result = resolveCssVariable( 'var(--primary-color)' );
+			expect( result ).toBe( '#3498db' );
+		} );
+
+		it( 'handles rgb color values', () => {
+			window.getComputedStyle = jest.fn( () => ( {
+				getPropertyValue: () => 'rgb(52, 152, 219)',
+			} ) ) as unknown as typeof window.getComputedStyle;
+
+			const result = resolveCssVariable( 'var(--primary-color)' );
+			expect( result ).toBe( 'rgb(52, 152, 219)' );
+		} );
+
+		it( 'handles rgba color values', () => {
+			window.getComputedStyle = jest.fn( () => ( {
+				getPropertyValue: () => 'rgba(52, 152, 219, 0.5)',
+			} ) ) as unknown as typeof window.getComputedStyle;
+
+			const result = resolveCssVariable( 'var(--primary-color)' );
+			expect( result ).toBe( 'rgba(52, 152, 219, 0.5)' );
+		} );
+
+		it( 'handles pixel values', () => {
+			window.getComputedStyle = jest.fn( () => ( {
+				getPropertyValue: () => '16px',
+			} ) ) as unknown as typeof window.getComputedStyle;
+
+			const result = resolveCssVariable( 'var(--font-size)' );
+			expect( result ).toBe( '16px' );
+		} );
+
+		it( 'handles percentage values', () => {
+			window.getComputedStyle = jest.fn( () => ( {
+				getPropertyValue: () => '50%',
+			} ) ) as unknown as typeof window.getComputedStyle;
+
+			const result = resolveCssVariable( 'var(--width)' );
+			expect( result ).toBe( '50%' );
+		} );
+
+		it( 'handles em/rem values', () => {
+			window.getComputedStyle = jest.fn( () => ( {
+				getPropertyValue: () => '1.5rem',
+			} ) ) as unknown as typeof window.getComputedStyle;
+
+			const result = resolveCssVariable( 'var(--spacing)' );
+			expect( result ).toBe( '1.5rem' );
+		} );
+
+		it( 'handles numeric values', () => {
+			window.getComputedStyle = jest.fn( () => ( {
+				getPropertyValue: () => '1.5',
+			} ) ) as unknown as typeof window.getComputedStyle;
+
+			const result = resolveCssVariable( 'var(--line-height)' );
+			expect( result ).toBe( '1.5' );
+		} );
+	} );
+} );

--- a/projects/js-packages/charts/src/utils/test/resolve-css-var.test.ts
+++ b/projects/js-packages/charts/src/utils/test/resolve-css-var.test.ts
@@ -209,6 +209,21 @@ describe( 'resolveCssVariable', () => {
 			expect( result ).toBeNull();
 		} );
 
+		it( 'returns null for variable names with opening parentheses', () => {
+			const result = resolveCssVariable( 'var(--test(name))' );
+			expect( result ).toBeNull();
+		} );
+
+		it( 'returns null for variable names with closing parentheses', () => {
+			const result = resolveCssVariable( 'var(--test)name)' );
+			expect( result ).toBeNull();
+		} );
+
+		it( 'returns null for variable names with both parentheses', () => {
+			const result = resolveCssVariable( 'var(--(test))' );
+			expect( result ).toBeNull();
+		} );
+
 		it( 'throws error for CSS variable string longer than 1000 characters', () => {
 			const longVar = 'var(--' + 'a'.repeat( 1000 ) + ')';
 			expect( () => resolveCssVariable( longVar ) ).toThrow( 'CSS variable is too long' );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes [CHARTS-128: Global Theme: support generating colors from a single CSS custom property](https://linear.app/a8c/issue/CHARTS-128/global-theme-support-generating-colors-from-a-single-css-custom)

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
This PR adds support for using CSS custom properties (CSS variables) as theme colors in the charts package. The main enhancement allows a CSS variable like `var(--wpds-color-bg-interactive-brand)` to be specified as the only theme color, with the system automatically resolving the value of the CSS variable, storing it, and generating a complementary color palette from it. This enables dynamic theming where chart colors adapt to user-selected accent colors.

Key changes:

* New `resolveCssVariable()` utility to resolve CSS custom properties to their computed values, with support for fallback values and scoped resolution
* Updated `GlobalChartsProvider` to resolve CSS variables during color cache computation using `useLayoutEffect` to ensure DOM updates complete before resolution
* Modified color generation algorithm to support single-color palettes with muted saturation (45% base) and wider hue range (33% of color wheel)
* Updated custom theme to use a single CSS custom property accent color
* Added a Storybook control to set the accent color
* Added test suites

### Screenshots

#### Storybook

![Screenshot 2025-11-25 at 11 37 27 AM](https://github.com/user-attachments/assets/da763af5-13f6-4f04-a5bf-a95755326027)
![Screenshot 2025-11-25 at 11 38 07 AM](https://github.com/user-attachments/assets/0d79b6fc-3d8a-47d0-847e-40ef9211aabf)
![Screenshot 2025-11-25 at 11 38 40 AM](https://github.com/user-attachments/assets/5597c0c7-b292-439f-87fb-cdcdcd58c3a7)

#### Woo Analytics

| `#c100c5` | `#008100` |
|-|-|
| ![Screenshot 2025-11-24 at 12 19 27 PM](https://github.com/user-attachments/assets/39901325-4180-4202-8053-410360e8f296) | ![Screenshot 2025-11-24 at 12 21 37 PM](https://github.com/user-attachments/assets/87ad2f14-cb04-48c1-8430-7044882a19bc) |

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

### Storybook

* Go to Storybook and load any story
* Switch to the custom theme and observe the color palette being generated off the single accent color (control should appear with default value set)
* Change the accent color and observe the palette changing
* Browse other stories and repeat

### In product

* Build charts using `pnpm run build`
* Use `pnpm link` to load the package into a product like Woo Analytics (or manually copy the files in)
* Set the theme colors to `colors: [ 'var(--wpds-color-fg-interactive-brand)' ]`
* Observe the charts using the accent color and a generated palette in donut and semi circle charts