### PR TITLE
Charts: Update wooTheme to use proper defaults that are overridden in Woo Analytics

### DIFF
--- a/projects/js-packages/charts/changelog/charts-woo-theme
+++ b/projects/js-packages/charts/changelog/charts-woo-theme
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Update wooTheme to use default values required by woo

--- a/projects/js-packages/charts/src/providers/chart-context/themes.ts
+++ b/projects/js-packages/charts/src/providers/chart-context/themes.ts
@@ -144,7 +144,7 @@ const wooTheme: ChartTheme = {
 	gridColor: '',
 	gridColorDark: '',
 	svgLabelSmall: { fill: '#757575' },
-	xTickLineStyles: { stroke: 'black' },
+	xTickLineStyles: { stroke: '' },
 	xAxisLineStyles: { stroke: '#DCDCDE', strokeWidth: 1 },
 	legendLabelStyles: {
 		fontSize: '12px',
@@ -153,7 +153,28 @@ const wooTheme: ChartTheme = {
 	},
 	legendContainerStyles: {
 		gap: '8px',
+		rowGap: '8px',
+		columnGap: '16px',
 	},
+	seriesLineStyles: [
+		{
+			strokeWidth: 2,
+		},
+		{
+			strokeDasharray: '4 4',
+			strokeWidth: 1.5,
+			strokeLinecap: 'square',
+		},
+	],
+	legendShapeStyles: [
+		{
+			transform: 'translate(0, 1px)',
+		},
+		{
+			transform: 'translate(0, 1px)',
+			strokeDasharray: '2, 2, 3, 2, 3, 2, 2',
+		},
+	],
 	annotationStyles: {
 		label: {
 			anchorLineStroke: 'black',
@@ -188,6 +209,7 @@ const wooTheme: ChartTheme = {
 				strokeDasharray: '4 4',
 				strokeWidth: 1.5,
 				strokeLinecap: 'square',
+				strokeOpacity: 0.8,
 			},
 		},
 	},


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Update default values for wooTheme in charts to use values overridden in Woo analytics

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Start storybook as per - https://github.com/Automattic/jetpack/tree/1776765fc9f88dc4160a207687f03b048e70a51d/projects/js-packages/charts#local-development-with-storybook
* wooTheme in charts should not see any major visual changes - http://localhost:50240/?path=/story/js-packages-charts-chart-context--with-color-overrides&args=themeName:woo

