### PR TITLE
WooCommerce Analytics: Use Beacon API for reliable event tracking with fallback

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4088,9 +4088,6 @@ importers:
 
   projects/packages/woocommerce-analytics:
     dependencies:
-      '@wordpress/api-fetch':
-        specifier: 7.35.0
-        version: 7.35.0(patch_hash=0c63a888feb97f2f1d416ca013ad85c31b6360b41cc0b6e2b0ae28f778fbdc5b)
       debug:
         specifier: 4.4.3
         version: 4.4.3

--- a/projects/packages/woocommerce-analytics/changelog/wooa7s-661-use-beaconing-apis-for-sending-tracking-events
+++ b/projects/packages/woocommerce-analytics/changelog/wooa7s-661-use-beaconing-apis-for-sending-tracking-events
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Added Beacon API support and replaced @wordpress/api-fetch with native fetch

--- a/projects/packages/woocommerce-analytics/package.json
+++ b/projects/packages/woocommerce-analytics/package.json
@@ -25,7 +25,6 @@
 		"watch": "pnpm build --watch"
 	},
 	"dependencies": {
-		"@wordpress/api-fetch": "7.35.0",
 		"debug": "4.4.3"
 	},
 	"devDependencies": {

--- a/projects/packages/woocommerce-analytics/src/class-universal.php
+++ b/projects/packages/woocommerce-analytics/src/class-universal.php
@@ -86,6 +86,9 @@ class Universal {
 				// Set the assets URL for webpack to find the split assets.
 				wcAnalytics.assets_url = '<?php echo esc_url( plugins_url( '../build/', __DIR__ . '/class-woocommerce-analytics.php' ) ); ?>';
 
+				// Set the REST API tracking endpoint URL.
+				wcAnalytics.trackEndpoint = '<?php echo esc_url( rest_url( 'woocommerce-analytics/v1/track' ) ); ?>';
+
 				// Set common properties for all events.
 				wcAnalytics.commonProps = <?php echo wp_json_encode( $common_properties, JSON_HEX_TAG | JSON_UNESCAPED_SLASHES ); ?>;
 

--- a/projects/packages/woocommerce-analytics/src/client/api-client.ts
+++ b/projects/packages/woocommerce-analytics/src/client/api-client.ts
@@ -1,12 +1,11 @@
 /**
  * External dependencies
  */
-import apiFetch from '@wordpress/api-fetch';
 import debugFactory from 'debug';
 /**
  * Internal dependencies
  */
-import { API_NAMESPACE, API_ENDPOINT, BATCH_SIZE, DEBOUNCE_DELAY } from './constants';
+import { BATCH_SIZE, DEBOUNCE_DELAY } from './constants';
 import type { ApiEvent, ApiFetchResponse } from './types/shared';
 
 const debug = debugFactory( 'wc-analytics:api-client' );
@@ -78,6 +77,32 @@ export class ApiClient {
 	};
 
 	/**
+	 * Send events using the Beacon API for guaranteed delivery
+	 *
+	 * @param events - The events to send.
+	 * @return True if beacon was successfully queued, false otherwise.
+	 */
+	private sendEventsViaBeacon = ( events: ApiEvent[] ): boolean => {
+		// Check if beacon API is available
+		if ( typeof navigator === 'undefined' || ! navigator.sendBeacon ) {
+			debug( 'Beacon API not available' );
+			return false;
+		}
+
+		try {
+			// Convert events to JSON and create a Blob with correct content type
+			const data = JSON.stringify( events );
+			const blob = new Blob( [ data ], { type: 'application/json' } );
+
+			// Send via beacon - returns true if successfully queued
+			return navigator.sendBeacon( window.wcAnalytics.trackEndpoint, blob );
+		} catch ( error ) {
+			debug( 'Beacon API failed: %o', error );
+			return false;
+		}
+	};
+
+	/**
 	 * Flush all pending events immediately
 	 */
 	flush = (): void => {
@@ -93,6 +118,16 @@ export class ApiClient {
 		const eventsToSend = [ ...this.eventQueue ];
 		this.eventQueue = [];
 
+		// Try sending via Beacon API first for guaranteed delivery
+		const beaconSuccess = this.sendEventsViaBeacon( eventsToSend );
+
+		if ( beaconSuccess ) {
+			debug( 'Sent %d events via Beacon API', eventsToSend.length );
+			return;
+		}
+
+		debug( 'Failed to send events via Beacon API, falling back to fetch with keepalive' );
+		// Fallback to fetch with keepalive for request persistence
 		this.sendEvents( eventsToSend );
 	};
 
@@ -109,16 +144,22 @@ export class ApiClient {
 		try {
 			debug( 'Sending %d events to API', events.length );
 
-			const response = await apiFetch< ApiFetchResponse >( {
-				path: `/${ API_NAMESPACE }/${ API_ENDPOINT }`,
+			const response = await fetch( window.wcAnalytics.trackEndpoint, {
 				method: 'POST',
-				data: events,
+				headers: {
+					'Content-Type': 'application/json',
+				},
+				body: JSON.stringify( events ),
+				keepalive: true,
+				credentials: 'same-origin',
 			} );
-			debug( 'API response received: %o', response );
 
-			if ( ! response.success ) {
-				debug( 'Some events failed to send: %o', response.results );
+			if ( ! response.ok ) {
+				throw new Error( `HTTP error! status: ${ response.status }` );
 			}
+
+			const data: ApiFetchResponse = await response.json();
+			debug( 'API response received: %o', data );
 		} catch ( error ) {
 			debug( 'Failed to send events to API: %o', error );
 			// Re-add events to queue for potential retry on next event

--- a/projects/packages/woocommerce-analytics/src/client/api-client.ts
+++ b/projects/packages/woocommerce-analytics/src/client/api-client.ts
@@ -118,17 +118,20 @@ export class ApiClient {
 		const eventsToSend = [ ...this.eventQueue ];
 		this.eventQueue = [];
 
+		if ( ! window.wcAnalytics?.trackEndpoint ) {
+			debug( 'Track endpoint not available' );
+			return;
+		}
+
 		// Try sending via Beacon API first for guaranteed delivery
 		const beaconSuccess = this.sendEventsViaBeacon( eventsToSend );
 
 		if ( beaconSuccess ) {
 			debug( 'Sent %d events via Beacon API', eventsToSend.length );
-			return;
+		} else {
+			debug( 'Failed to send events via Beacon API, falling back to fetch with keepalive' );
+			this.sendEvents( eventsToSend );
 		}
-
-		debug( 'Failed to send events via Beacon API, falling back to fetch with keepalive' );
-		// Fallback to fetch with keepalive for request persistence
-		this.sendEvents( eventsToSend );
 	};
 
 	/**

--- a/projects/packages/woocommerce-analytics/src/client/constants.ts
+++ b/projects/packages/woocommerce-analytics/src/client/constants.ts
@@ -3,7 +3,5 @@ export const EVENT_PREFIX = 'woocommerceanalytics_';
 export const EVENT_NAME_REGEX = /^[a-z_][a-z0-9_]*$/;
 
 // API Configuration
-export const API_NAMESPACE = 'woocommerce-analytics/v1';
-export const API_ENDPOINT = 'track';
 export const BATCH_SIZE = 10;
 export const DEBOUNCE_DELAY = 1000; // 1 second

--- a/projects/packages/woocommerce-analytics/src/client/types/global.d.ts
+++ b/projects/packages/woocommerce-analytics/src/client/types/global.d.ts
@@ -5,6 +5,7 @@
 declare global {
 	interface Window {
 		wcAnalytics?: {
+			trackEndpoint: string;
 			eventQueue: Array< { eventName: string; props?: Record< string, unknown > } >;
 			commonProps: Record< string, unknown >;
 			features: Record< string, boolean >;


### PR DESCRIPTION
Fixes WOOA7S-661

## Proposed changes:
* Implement `navigator.sendBeacon()` as the primary method for sending analytics events
* Add graceful fallback to `fetch()` with `keepalive: true` option for browsers without beacon support
* Pass REST API endpoint URL from server-side to handle plain permalinks correctly (using `rest_url()`)
* Replace `@wordpress/api-fetch` dependency with native `fetch()` API for simpler, more portable code
* Remove unused constants (`API_NAMESPACE`, `API_ENDPOINT`) as endpoint is now fully server-controlled

### Other information:

- [ ] Have you written new tests for your changes, if applicable? - **No tests added** (deferred to future work as agreed)
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable?

## Does this pull request change what data or activity we track or use?
**No.** This PR only changes *how* events are sent to the server, not *what* data is tracked. The tracking endpoint, event payloads, and data handling remain unchanged.


## Testing instructions:

### Prerequisites:
1. WooCommerce site with Jetpack connected
2. Enable proxy tracking: `add_filter('woocommerce_analytics_experimental_proxy_tracking_enabled', '__return_true');` OR enable **WooCommerce Analytics** plugin

### Test 1: Verify Beacon API is used
1. Visit a product page on the WooCommerce site
2. Open DevTools Console and run: `localStorage.setItem('debug', 'wc-analytics:*')`
3. Reload the page
4. In Console, look for: `"Sent X events via Beacon API"`
5. In Network tab, you should **not** see **fetch/XHR** requests to `/wp-json/woocommerce-analytics/v1/track` but can see requests in **All** tab.

<img width="1084" height="397" alt="Screenshot 2025-11-12 at 15 11 42" src="https://github.com/user-attachments/assets/aa6db372-6e0b-4d58-b3dd-a9b8ea4dc03e" />

<img width="1069" height="394" alt="Screenshot 2025-11-12 at 15 11 13" src="https://github.com/user-attachments/assets/3fb300e9-d9b7-4fd0-917c-6aeb7caf8268" />


### Test 2: Verify fallback for browsers without beacon
1. Open DevTools Console and tick `Preserve log` checkbox
2. Log in to the WooCommerce site and go to my account page
3. Run: `navigator.sendBeacon = undefined` (simulates old browser)
4. Click "Log out" 
5. Console should show: `"Failed to send events via Beacon API, falling back to fetch with keepalive"`
6. Network tab should show POST request to `/wp-json/woocommerce-analytics/v1/track` with `keepalive` flag
7. Events should still be tracked successfully

## Key Benefits:
- **Guaranteed event delivery** on page unload (beacon survives navigation)
- **Mobile-friendly** (better iOS Safari support)
- **Plain permalink support** (server controls URL format)
- **Bot filtering** (sophisticated bots disable beaconing)
- **Simpler codebase** (one less dependency)