### PR TITLE
My Jetpack: Add white background to modules list

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/modules-list/styles.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/modules-list/styles.module.scss
@@ -5,6 +5,7 @@
 	:global(.dataviews-wrapper) {
 		border: 1px solid rgba(0, 0, 0, 0.1);
 		border-radius: 8px;
+		background-color: #{gb.$white};
 	}
 
 	:global(thead tr.dataviews-view-table__row) {

--- a/projects/packages/my-jetpack/changelog/fix-myjp-products-list-missing-background
+++ b/projects/packages/my-jetpack/changelog/fix-myjp-products-list-missing-background
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+My Jetpack: Added missing background color for products list.


### PR DESCRIPTION
Fixes MYJP-272

## Changes proposed in this Pull Request

Adds white background color to the modules list in My Jetpack → Products tab.

## Why are these changes being made?

The modules list was missing the white background color that was specified in the Figma designs.

## Testing instructions

1. Navigate to My Jetpack → Products tab
2. Verify that the modules list (table with module toggles) now has a white background
3. Verify that the visual appearance matches the Figma designs linked in MYJP-272

<img width="650" height="176" alt="CleanShot 2025-11-12 at 14 31 53@2x" src="https://github.com/user-attachments/assets/81357834-4d03-44d7-b772-b2e11e663b07" />

<img width="1518" height="1056" alt="CleanShot 2025-11-12 at 14 29 02@2x" src="https://github.com/user-attachments/assets/845f3efb-e6f1-421c-8308-ec9c88f33a01" />

## Does this pull request change what data or activity we track or use?

No

## Jetpack product discussion

MYJP-272