### PR TITLE
Forms: Simplify DataViews footer positioning

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-dashboard-dataviews-footer
+++ b/projects/packages/forms/changelog/fix-forms-dashboard-dataviews-footer
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Simplify DataViews footer positioning by using default sticky behavior

--- a/projects/packages/forms/src/dashboard/inbox/style.scss
+++ b/projects/packages/forms/src/dashboard/inbox/style.scss
@@ -67,35 +67,12 @@
 	@include mixins.flex-column;
 	flex: 1 1 60%;
 
-	// Optionally, fix the footer to bottom of the page and add margin
-	// so the last row is not hidden by the footer.
-	@include mixins.dataviews-footer-spacing;
-
 	.dataviews-wrapper {
 		background: var(--jp-white);
 		flex-grow: 1;
 
 		@media (min-width: #{ (breakpoints.$break-medium + 1) }) {
 			border-right: 1px solid var(--jp-gray-5);
-		}
-	}
-
-	.dataviews-footer {
-		position: fixed;
-		bottom: 0;
-
-		// Match .admin-ui-page__header padding
-		padding-inline: var(--jp-forms-page-padding-inline);
-
-		// Compensation for the width of the sidebar
-		// Set left position when auto-fold is not on the body element.
-		// Adapted from https://github.com/WordPress/gutenberg/blob/4ea86f891145daa12c8b59b18f02fb9fc4d83c5a/packages/base-styles/_mixins.scss#L183-L218
-		left: 0;
-		width: 100%;
-
-		@media (min-width: #{ (breakpoints.$break-medium + 1) }) {
-			left: var(--forms-admin-sidebar-width, variables.$admin-sidebar-width);
-			width: calc(100% - var(--forms-admin-sidebar-width, variables.$admin-sidebar-width));
 		}
 	}
 
@@ -137,37 +114,6 @@
 	}
 }
 
-/*
- * Compensation for the width of the sidebar
- * Auto fold is when on smaller breakpoints, nav menu auto collapses.
- * Adapted from: https://github.com/WordPress/gutenberg/blob/4ea86f891145daa12c8b59b18f02fb9fc4d83c5a/packages/base-styles/_mixins.scss#L183-L218
- */
-.auto-fold .jp-forms__inbox__dataviews .dataviews-footer {
-
-	@media (min-width: #{ (breakpoints.$break-medium + 1) }) {
-		left: var(--forms-admin-sidebar-width, variables.$admin-sidebar-width-collapsed);
-		width: calc(100% - var(--forms-admin-sidebar-width, variables.$admin-sidebar-width-collapsed));
-	}
-
-	@media (min-width: #{ (breakpoints.$break-large + 1) }) {
-		left: var(--forms-admin-sidebar-width, variables.$admin-sidebar-width);
-		width: calc(100% - var(--forms-admin-sidebar-width, variables.$admin-sidebar-width));
-	}
-}
-
-/*
- * Compensation for the width of the sidebar when the Sidebar
- * is manually collapsed.
- * Adapted from: https://github.com/WordPress/gutenberg/blob/4ea86f891145daa12c8b59b18f02fb9fc4d83c5a/packages/base-styles/_mixins.scss#L183-L218
- */
-.folded .jp-forms__inbox__dataviews .dataviews-footer {
-	left: 0;
-
-	@media (min-width: #{ (breakpoints.$break-medium + 1) }) {
-		left: var(--forms-admin-sidebar-width, variables.$admin-sidebar-width-collapsed);
-		width: calc(100% - var(--forms-admin-sidebar-width, variables.$admin-sidebar-width-collapsed));
-	}
-}
 
 /*
  * We need to make the available canvas 100% tall. Without this,


### PR DESCRIPTION
Resolves FORMS-329

## Proposed changes:

Removes custom CSS for footer, let's use WordPress DataViews defaults

### Other information:

- [x] Have you written new tests for your changes, if applicable? N/A - This is a CSS refactoring that maintains existing behavior
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

1. Go to Jetpack → Forms → Responses
2. Select one or more form responses by clicking the checkboxes
3. Verify the bulk actions footer appears at the bottom of the table
4. Verify the footer looks and behaves the same as before the change; test mobile and desktop