### PR TITLE
Fix `Generic.WhiteSpace.HereNowdocIdentifierSpacing` sniff

### DIFF
--- a/projects/plugins/crm/changelog/fix-generic-whitespace-herenowdocidentifierspacing
+++ b/projects/plugins/crm/changelog/fix-generic-whitespace-herenowdocidentifierspacing
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix `Generic.WhiteSpace.HereNowdocIdentifierSpacing` sniff, being added in WPCS 3.2.
+
+

--- a/projects/plugins/crm/tests/codeception/_support/Module/WordPress.php
+++ b/projects/plugins/crm/tests/codeception/_support/Module/WordPress.php
@@ -66,7 +66,7 @@ class WordPress extends Framework implements DependsOnModule {
 	 * @var string
 	 */
 	protected $dependencyMessage
-		= <<< 'EOF'
+		= <<<'EOF'
 Example configuring WPDb
 --
 modules

--- a/projects/plugins/jetpack/changelog/fix-generic-whitespace-herenowdocidentifierspacing
+++ b/projects/plugins/jetpack/changelog/fix-generic-whitespace-herenowdocidentifierspacing
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Fix `Generic.WhiteSpace.HereNowdocIdentifierSpacing` sniff, being added in WPCS 3.2.
+
+

--- a/projects/plugins/jetpack/modules/videopress/class.videopress-edit-attachment.php
+++ b/projects/plugins/jetpack/modules/videopress/class.videopress-edit-attachment.php
@@ -265,7 +265,7 @@ class VideoPress_Edit_Attachment {
 			$poster = "<br><img src=\"{$info->poster}\" width=\"175px\">";
 		}
 
-		$html = <<< HTML
+		$html = <<<HTML
 
 <div class="misc-pub-section misc-pub-shortcode">
 	<strong>Shortcode</strong><br>


### PR DESCRIPTION
Closes MONOREP-216

 <!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Being added in WPCS 3.2.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* 🤷
