### PR TITLE
Boost: Disable defer JS in Divi builder

### DIFF
--- a/projects/plugins/boost/changelog/add-divi-compat
+++ b/projects/plugins/boost/changelog/add-divi-compat
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Compatibility: Added compatibility with divi builder and Deferred JS.

--- a/projects/plugins/boost/compatibility/divi.php
+++ b/projects/plugins/boost/compatibility/divi.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Compatibility functions for Divi Builder
+ *
+ * @package automattic/jetpack-boost
+ */
+
+namespace Automattic\Jetpack_Boost\Compatibility\Divi;
+
+/**
+ * Defer JS can break Divi Builder.
+ */
+function disable_defer_js_for_divi_builder( $should_defer_js ) {
+	$is_divi_builder = filter_input( INPUT_GET, 'et_fb', FILTER_VALIDATE_INT );
+
+	if ( 1 === (int) $is_divi_builder ) {
+		return false;
+	}
+
+	$is_divi_preview = filter_input(
+		INPUT_GET,
+		'et_pb_preview',
+		FILTER_VALIDATE_BOOLEAN,
+		array(
+			'flags' => FILTER_NULL_ON_FAILURE,
+		)
+	);
+
+	if ( true === $is_divi_preview ) {
+		return false;
+	}
+
+	if ( function_exists( 'is_et_pb_preview' ) && is_et_pb_preview() ) {
+		return false;
+	}
+
+	return $should_defer_js;
+}
+
+add_filter( 'jetpack_boost_should_defer_js', __NAMESPACE__ . '\disable_defer_js_for_divi_builder' );

--- a/projects/plugins/boost/compatibility/divi.php
+++ b/projects/plugins/boost/compatibility/divi.php
@@ -30,8 +30,11 @@ function disable_defer_js_for_divi_builder( $should_defer_js ) {
 		return false;
 	}
 
-	if ( function_exists( 'is_et_pb_preview' ) && call_user_func( 'is_et_pb_preview' ) ) {
-		return false;
+	if ( function_exists( 'is_et_pb_preview' ) ) {
+		/** @phan-suppress-next-line PhanUndeclaredFunction */
+		if ( \is_et_pb_preview() ) {
+			return false;
+		}
 	}
 
 	return $should_defer_js;

--- a/projects/plugins/boost/compatibility/divi.php
+++ b/projects/plugins/boost/compatibility/divi.php
@@ -30,7 +30,7 @@ function disable_defer_js_for_divi_builder( $should_defer_js ) {
 		return false;
 	}
 
-	if ( function_exists( 'is_et_pb_preview' ) && is_et_pb_preview() ) {
+	if ( function_exists( 'is_et_pb_preview' ) && call_user_func( 'is_et_pb_preview' ) ) {
 		return false;
 	}
 

--- a/projects/plugins/boost/compatibility/elementor.php
+++ b/projects/plugins/boost/compatibility/elementor.php
@@ -35,35 +35,3 @@ function exclude_elementor_library_custom_post_type( $post_types ) {
 
 add_filter( 'jetpack_boost_critical_css_post_types_singular', __NAMESPACE__ . '\exclude_elementor_library_custom_post_type' );
 add_filter( 'jetpack_boost_critical_css_post_types_archives', __NAMESPACE__ . '\exclude_elementor_library_custom_post_type' );
-
-/**
- * Defer JS can break Divi Builder.
- */
-function disable_defer_js_for_divi_builder( $should_defer_js ) {
-	$is_divi_builder = filter_input( INPUT_GET, 'et_fb', FILTER_VALIDATE_INT );
-
-	if ( 1 === (int) $is_divi_builder ) {
-		return false;
-	}
-
-	$is_divi_preview = filter_input(
-		INPUT_GET,
-		'et_pb_preview',
-		FILTER_VALIDATE_BOOLEAN,
-		array(
-			'flags' => FILTER_NULL_ON_FAILURE,
-		)
-	);
-
-	if ( true === $is_divi_preview ) {
-		return false;
-	}
-
-	if ( function_exists( 'is_et_pb_preview' ) && is_et_pb_preview() ) {
-		return false;
-	}
-
-	return $should_defer_js;
-}
-
-add_filter( 'jetpack_boost_should_defer_js', __NAMESPACE__ . '\disable_defer_js_for_divi_builder' );

--- a/projects/plugins/boost/compatibility/elementor.php
+++ b/projects/plugins/boost/compatibility/elementor.php
@@ -35,3 +35,35 @@ function exclude_elementor_library_custom_post_type( $post_types ) {
 
 add_filter( 'jetpack_boost_critical_css_post_types_singular', __NAMESPACE__ . '\exclude_elementor_library_custom_post_type' );
 add_filter( 'jetpack_boost_critical_css_post_types_archives', __NAMESPACE__ . '\exclude_elementor_library_custom_post_type' );
+
+/**
+ * Defer JS can break Divi Builder.
+ */
+function disable_defer_js_for_divi_builder( $should_defer_js ) {
+	$is_divi_builder = filter_input( INPUT_GET, 'et_fb', FILTER_VALIDATE_INT );
+
+	if ( 1 === (int) $is_divi_builder ) {
+		return false;
+	}
+
+	$is_divi_preview = filter_input(
+		INPUT_GET,
+		'et_pb_preview',
+		FILTER_VALIDATE_BOOLEAN,
+		array(
+			'flags' => FILTER_NULL_ON_FAILURE,
+		)
+	);
+
+	if ( true === $is_divi_preview ) {
+		return false;
+	}
+
+	if ( function_exists( 'is_et_pb_preview' ) && is_et_pb_preview() ) {
+		return false;
+	}
+
+	return $should_defer_js;
+}
+
+add_filter( 'jetpack_boost_should_defer_js', __NAMESPACE__ . '\disable_defer_js_for_divi_builder' );

--- a/projects/plugins/boost/jetpack-boost.php
+++ b/projects/plugins/boost/jetpack-boost.php
@@ -251,6 +251,9 @@ function include_compatibility_files() {
 		require_once __DIR__ . '/compatibility/breakdance.php';
 	}
 
+	// Compatibility with Divi by Elegant Themes.
+	require_once __DIR__ . '/compatibility/divi.php';
+
 	// Exclude known scripts that causes problem when concatenated.
 	require_once __DIR__ . '/compatibility/js-concatenate.php';
 


### PR DESCRIPTION
Fixes HOG-399

## Proposed changes:
* Skip deferring JS if we are inside Divi builder.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
None

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
A12s: You can also use the test site mentioned in HOG-399.

* Enable deferred JS in Boost.
* Install Divi 5.
* Go to **Divi > Theme Builder**.
* We need to get into the Divi builder now, Since you don't likely have any existing templates, you can click **Add Global Header** -> **Build Global Header**: 
<img width="440" height="291" alt="image" src="https://github.com/user-attachments/assets/6fe3a5a4-5ffc-4aab-8756-11e5870cbd98" />
This should take you to the builder.

* Using [Boost Debugger extension](https://chromewebstore.google.com/detail/jetpack-boost-debugger/gjmbcbeedhhjlphdfldjbepeckgjalff), make sure deferred JS is not working.

