### PR TITLE
Forms: Pass requiredText from option block to checkbox field

### DIFF
--- a/projects/packages/forms/changelog/fix-checkbox-required-text-option-block
+++ b/projects/packages/forms/changelog/fix-checkbox-required-text-option-block
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Pass requiredText from option block to checkbox field. Add test coverage.

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -569,11 +569,13 @@ class Contact_Form_Plugin {
 
 				// The following handles when option blocks are a direct inner block for a field e.g. singular checkbox field.
 				if ( 'jetpack/option' === $block_name ) {
-					$atts['label']                            = $inner_block['attrs']['label'] ?? $inner_block['attrs']['defaultLabel'] ?? '';
-					$option_attrs                             = self::get_block_support_classes_and_styles( $block_name, $inner_block['attrs'] );
-					$atts['optionclasses']                    = 'wp-block-jetpack-option';
-					$atts['optionclasses']                   .= isset( $option_attrs['class'] ) ? ' ' . $option_attrs['class'] : '';
-					$atts['optionstyles']                     = $option_attrs['style'] ?? null;
+					$atts['label']          = $inner_block['attrs']['label'] ?? $inner_block['attrs']['defaultLabel'] ?? '';
+					$option_attrs           = self::get_block_support_classes_and_styles( $block_name, $inner_block['attrs'] );
+					$atts['optionclasses']  = 'wp-block-jetpack-option';
+					$atts['optionclasses'] .= isset( $option_attrs['class'] ) ? ' ' . $option_attrs['class'] : '';
+					$atts['optionstyles']   = $option_attrs['style'] ?? null;
+
+					$atts['requiredText']                     = $inner_block['attrs']['requiredText'] ?? ( $atts['requiredText'] ?? null );
 					$add_block_style_classes_to_field_wrapper = true;
 
 					continue;

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -569,13 +569,12 @@ class Contact_Form_Plugin {
 
 				// The following handles when option blocks are a direct inner block for a field e.g. singular checkbox field.
 				if ( 'jetpack/option' === $block_name ) {
-					$atts['label']          = $inner_block['attrs']['label'] ?? $inner_block['attrs']['defaultLabel'] ?? '';
-					$option_attrs           = self::get_block_support_classes_and_styles( $block_name, $inner_block['attrs'] );
-					$atts['optionclasses']  = 'wp-block-jetpack-option';
-					$atts['optionclasses'] .= isset( $option_attrs['class'] ) ? ' ' . $option_attrs['class'] : '';
-					$atts['optionstyles']   = $option_attrs['style'] ?? null;
-
-					$atts['requiredText'] = $inner_block['attrs']['requiredText'] ?? ( $atts['requiredText'] ?? null );
+					$atts['label']                            = $inner_block['attrs']['label'] ?? $inner_block['attrs']['defaultLabel'] ?? '';
+					$option_attrs                             = self::get_block_support_classes_and_styles( $block_name, $inner_block['attrs'] );
+					$atts['optionclasses']                    = 'wp-block-jetpack-option';
+					$atts['optionclasses']                   .= isset( $option_attrs['class'] ) ? ' ' . $option_attrs['class'] : '';
+					$atts['optionstyles']                     = $option_attrs['style'] ?? null;
+					$atts['requiredText']                     = $inner_block['attrs']['requiredText'] ?? ( $atts['requiredText'] ?? null );
 					$add_block_style_classes_to_field_wrapper = true;
 
 					continue;

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -575,7 +575,7 @@ class Contact_Form_Plugin {
 					$atts['optionclasses'] .= isset( $option_attrs['class'] ) ? ' ' . $option_attrs['class'] : '';
 					$atts['optionstyles']   = $option_attrs['style'] ?? null;
 
-					$atts['requiredText']                     = $inner_block['attrs']['requiredText'] ?? ( $atts['requiredText'] ?? null );
+					$atts['requiredText'] = $inner_block['attrs']['requiredText'] ?? ( $atts['requiredText'] ?? null );
 					$add_block_style_classes_to_field_wrapper = true;
 
 					continue;

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
@@ -171,6 +171,32 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 	}
 
 	/**
+	 * Tests that requiredText from jetpack/option block is passed through correctly in checkbox field.
+	 */
+	public function test_gutenblock_render_field_checkbox_with_required_text() {
+		$block     = array(
+			'blockName'   => 'jetpack/field-checkbox',
+			'attrs'       => array(
+				'required' => true,
+			),
+			'innerBlocks' => array(
+				array(
+					'blockName' => 'jetpack/option',
+					'attrs'     => array(
+						'label'        => 'I agree to the terms',
+						'isStandalone' => true,
+						'requiredText' => '(must check)',
+					),
+				),
+			),
+		);
+		$shortcode = Contact_Form_Plugin::gutenblock_render_field_checkbox( array(), '', new WP_Block( $block ) );
+		$expected  = '[contact-field type="checkbox" label="I agree to the terms" optionclasses="wp-block-jetpack-option" requiredText="(must check)" fieldwrapperclasses="wp-block-jetpack-field-checkbox"/]';
+
+		$this->assertEquals( $expected, $shortcode );
+	}
+
+	/**
 	 * Tests the render output of gutenblock_render_field_hidden.
 	 */
 	public function test_gutenblock_render_field_hidden_shortcode() {
@@ -419,6 +445,7 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 					'optionclasses'       => 'wp-block-jetpack-option has-text-color has-swamp-cheese-color',
 					'optionstyles'        => 'font-size:24px;font-style:italic;font-weight:bold;line-height:1.5;letter-spacing:0.1em;',
 					'label'               => 'Option',
+					'requiredText'        => null,
 					'type'                => 'radio',
 					'fieldwrapperclasses' => 'wp-block-jetpack-field-radio',
 				),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes FORMS-394

## Proposed changes:
* Make sure that we get the correct requireText from the option block.
* Added tests to cover this case for the checkbox field. 

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
See FORMS-394

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Create a form with a checkbox and alter the require text to be something other then required. 

Notice that on the frontend it shows up as expected. 

Make sure that there are no regressions with the options field. 

And thre regular checkbox field. 

Do the test still pass? 

