### PR TITLE
jetpack-mu-wpcom: Code block styling improvements

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/code-block-layout-styling-improvements
+++ b/projects/packages/jetpack-mu-wpcom/changelog/code-block-layout-styling-improvements
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Code block (unreleased): Improve styling and layout reliability across for different themes.

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/editor.css
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/editor.css
@@ -15,7 +15,7 @@
  */
 .block-editor-block-list__block {
 
-	.wp-block-code {
+	&.wp-block-code {
 
 		/* A notice is used to warn of experimental status. */
 		.components-notice {

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/editor.css
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/editor.css
@@ -5,87 +5,94 @@
  * because a PRE element is used.
  * The editor does not use PRE, so a base style is provided.
  */
-:root :where(.wp-block-code) {
+:root :where(.block-editor-block-list__block.wp-block-code) {
 	font-family: monospace;
 }
 
-.wp-block-code {
+/*
+ * This includes a block-list class to target the block editor in cases
+ * where the editor styles may be loaded on the site frontend.
+ */
+.block-editor-block-list__block {
 
-	/* A notice is used to warn of experimental status. */
-	.components-notice {
-		margin-top: -10px;
+	.wp-block-code {
 
-		a {
+		/* A notice is used to warn of experimental status. */
+		.components-notice {
+			margin-top: -10px;
 
-			&:not(:hover, :active, :focus) {
-				color: var(--wp-admin-theme-color, #3858e9);
+			a {
+
+				&:not(:hover, :active, :focus) {
+					color: var(--wp-admin-theme-color, #3858e9);
+				}
 			}
+		}
+
+		.components-base-control__field {
+			margin: 0;
+		}
+
+		.components-base-control,
+		.components-base-control__field,
+		.components-input-control__container > button,
+		.components-text-control__input {
+			font-size: inherit;
+		}
+
+		.components-text-control__input {
+			margin-left: -12px;
+			background-color: transparent;
+			color: inherit;
+			font-family: inherit;
+
+			&::placeholder {
+				color: hsl(from currentColor h s l / 0.6);
+			}
+		}
+
+		/* Override CodeMirror's font family to respect theme and editor settings. */
+		.cm-scroller {
+			font-family: inherit;
+		}
+
+		.cm-gutters {
+			color: oklch(from currentColor l c h / 0.6);
+			background-color: transparent;
+			border: none;
+		}
+
+		.cm-gutterElement {
+			backdrop-filter: blur(1em);
+		}
+
+		/* Disable active line highlight on inactive blocks. */
+		&:not(.is-selected) .cm-activeLine {
+			background-color: transparent !important;
 		}
 	}
 
-	.components-base-control__field {
-		margin: 0;
+	.a8c\/code__header {
+		padding: 0 12px;
 	}
 
-	.components-base-control,
-	.components-base-control__field,
-	.components-input-control__container > button,
-	.components-text-control__input {
+	.a8c\/code__btn-copy {
+		text-transform: inherit;
+		font-style: inherit;
+		font-weight: inherit;
 		font-size: inherit;
 	}
 
-	.components-text-control__input {
-		margin-left: -12px;
-		background-color: transparent;
-		color: inherit;
-		font-family: inherit;
+	.a8c\/code__filename.components-base-control {
+		margin: -1px;
+	}
 
-		&::placeholder {
-			color: hsl(from currentColor h s l / 0.6);
+	.a8c\/code__language-select {
+
+		button,
+		.components-input-control__container {
+			background-color: transparent;
+			color: inherit;
 		}
-	}
-
-	/* Override CodeMirror's font family to respect theme and editor settings. */
-	.cm-scroller {
-		font-family: inherit;
-	}
-
-	.cm-gutters {
-		color: oklch(from currentColor l c h / 0.6);
-		background-color: transparent;
-		border: none;
-	}
-
-	.cm-gutterElement {
-		backdrop-filter: blur(1em);
-	}
-
-	/* Disable active line highlight on inactive blocks. */
-	&:not(.is-selected) .cm-activeLine {
-		background-color: transparent !important;
-	}
-}
-
-.a8c\/code__header {
-	padding: 0 12px;
-}
-
-.a8c\/code__btn-copy {
-	text-transform: inherit;
-	font-style: inherit;
-	font-weight: inherit;
-	font-size: inherit;
-}
-
-.a8c\/code__filename.components-base-control {
-	margin: -1px;
-}
-
-.a8c\/code__language-select {
-
-	button,
-	.components-input-control__container {
-		background-color: transparent;
-		color: inherit;
 	}
 }

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/editor.css
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/editor.css
@@ -17,18 +17,6 @@
 
 	&.wp-block-code {
 
-		/* A notice is used to warn of experimental status. */
-		.components-notice {
-			margin-top: -10px;
-
-			a {
-
-				&:not(:hover, :active, :focus) {
-					color: var(--wp-admin-theme-color, #3858e9);
-				}
-			}
-		}
-
 		.components-base-control__field {
 			margin: 0;
 		}

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/style.css
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/style.css
@@ -53,32 +53,29 @@
 		gap: 32px;
 	}
 
+	/* Essential layout and styling for PRE,CODE */
+	pre,
+ code {
+		margin: 0 !important;
+		padding: 0 !important;
+		line-height: inherit !important;
+		background: transparent !important;
+		border: none;
+		border-radius: 0;
+		color: inherit !important;
+		font-size: inherit !important;
+	}
+
 	pre {
 		flex-grow: 2;
 		flex-shrink: 0;
 		display: block;
-		background: none;
-		border: none;
 		word-wrap: normal;
-		color: inherit;
-
-		/* These are essential for layout */
 		white-space: pre !important;
-		margin: 0 !important;
-		line-height: inherit !important;
-
 	}
 
 	code {
-		font-size: inherit !important;
-		margin: 0 !important;
-		padding: 0 !important;
-		line-height: inherit !important;
 		font-family: inherit !important;
-		background: transparent !important;
-		color: inherit !important;
-		border: none;
-		border-radius: 0;
 	}
 
 	/* prevent empty lines from collapsing vertically in rendered views */

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/style.css
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/style.css
@@ -55,7 +55,7 @@
 
 	/* Essential layout and styling for PRE,CODE */
 	pre,
- code {
+	code {
 		margin: 0 !important;
 		padding: 0 !important;
 		line-height: inherit !important;


### PR DESCRIPTION

## Proposed changes:

Improve code block layout and styling.

- Ensure that PRE and CODE elements have proper layout inside the enhanced block.
- Prevent editor styles from leaking into rendered frontend blocks even if the stylesheet is loaded. Some sites will load the block editor on the frontend and bring stylesheet, like those with p2 theme.
- Remove unused notice styling (leftover from #45827).

### Before

- Block header is misaligned from leaking editor styles.
- PRE element inside block has too much padding from theme.

<img width="1368" height="910" alt="Screenshot 2025-11-12 at 17 20 40" src="https://github.com/user-attachments/assets/b84ca851-b80d-4a0a-a71b-2b4dfac32e1d" />

### After

<img width="1368" height="808" alt="Screenshot 2025-11-12 at 17 22 26" src="https://github.com/user-attachments/assets/a1b142f2-d210-45d5-868f-f49495688552" />


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?


## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:


See before/after screenshots. This is a style-only change on an unreleased feature that will undergo extensive testing.