### PR TITLE
jetpack: More locking in CI coverage test

### DIFF
--- a/projects/plugins/jetpack/changelog/add-more-jetpack-test-locking
+++ b/projects/plugins/jetpack/changelog/add-more-jetpack-test-locking
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: CI: More locking for various tests creating a `the/the.php` plugin.
+
+

--- a/projects/plugins/jetpack/tests/php/json-api/Jetpack_Json_Api_Plugins_Endpoints_Test.php
+++ b/projects/plugins/jetpack/tests/php/json-api/Jetpack_Json_Api_Plugins_Endpoints_Test.php
@@ -17,6 +17,7 @@ class Jetpack_Json_Api_Plugins_Endpoints_Test extends WP_UnitTestCase {
 	use \Automattic\Jetpack\PHPUnit\WP_UnitTestCase_Fix;
 
 	private static $super_admin_user_id;
+	private $the_plugin_lock;
 
 	public static function wpSetUpBeforeClass( $factory ) {
 		self::$super_admin_user_id = $factory->user->create( array( 'role' => 'administrator' ) );
@@ -37,6 +38,58 @@ class Jetpack_Json_Api_Plugins_Endpoints_Test extends WP_UnitTestCase {
 
 		// Force direct method. Running the upgrade via PHPUnit can't detect the correct filesystem method.
 		add_filter( 'filesystem_method', array( $this, 'filesystem_method_direct' ) );
+	}
+
+	public function tear_down() {
+		if ( $this->the_plugin_lock ) {
+			$this->remove_the_plugin();
+		}
+	}
+
+	private function install_the_plugin() {
+		// For CI coverage tests, use a lock file to avoid multiple copies of this test from interfering with each other.
+		if ( getenv( 'PHPUNIT_JETPACK_TESTSUITE_IS_PARALLEL' ) === 'true' && ! $this->the_plugin_lock ) {
+			$this->the_plugin_lock = fopen( WP_PLUGIN_DIR . '/.thepluginlock', 'c+' );
+			if ( ! $this->the_plugin_lock ) {
+				throw new RuntimeException( 'Failed to open lockfile ' . WP_PLUGIN_DIR . '/.thepluginlock' );
+			}
+			if ( ! flock( $this->the_plugin_lock, LOCK_EX ) ) {
+				throw new RuntimeException( 'Failed to lock lockfile ' . WP_PLUGIN_DIR . '/.thepluginlock' );
+			}
+		}
+
+		$the_plugin_file = 'the/the.php';
+		$the_real_folder = WP_PLUGIN_DIR . '/the';
+		$the_real_file   = WP_PLUGIN_DIR . '/' . $the_plugin_file;
+
+		/*
+		 * Create an oudated version of 'The' plugin
+		 */
+
+		// Check if 'The' plugin folder is already there.
+		if ( ! file_exists( $the_real_folder ) ) {
+			mkdir( $the_real_folder );
+		}
+		file_put_contents(
+			$the_real_file,
+			'<?php
+			/*
+			 * Plugin Name: The
+			 * Version: 1.0
+			 */'
+		);
+	}
+
+	private function remove_the_plugin() {
+		$the_real_folder = WP_PLUGIN_DIR . '/the';
+		if ( file_exists( $the_real_folder ) ) {
+			static::rmdir( $the_real_folder );
+		}
+
+		if ( $this->the_plugin_lock ) {
+			fclose( $this->the_plugin_lock );
+			$this->the_plugin_lock = null;
+		}
 	}
 
 	/**
@@ -83,34 +136,12 @@ class Jetpack_Json_Api_Plugins_Endpoints_Test extends WP_UnitTestCase {
 		}
 		$plugin_property->setValue( $endpoint, array( 'the/the.php' ) );
 
-		$the_plugin_file = 'the/the.php';
-		$the_real_folder = WP_PLUGIN_DIR . '/the';
-		$the_real_file   = WP_PLUGIN_DIR . '/' . $the_plugin_file;
-
-		/*
-		 * Create an oudated version of 'The' plugin
-		 */
-
-		// Check if 'The' plugin folder is already there.
-		if ( ! file_exists( $the_real_folder ) ) {
-			mkdir( $the_real_folder );
-			$clean = true;
-		}
-		file_put_contents(
-			$the_real_file,
-			'<?php
-			/*
-			 * Plugin Name: The
-			 * Version: 1.0
-			 */'
-		);
+		$this->install_the_plugin();
 
 		// Invoke the upgrade_plugin method.
 		$result = $update_plugin_method->invoke( $endpoint );
 
-		if ( isset( $clean ) ) {
-			$this->rmdir( $the_real_folder );
-		}
+		$this->remove_the_plugin();
 
 		$this->assertTrue( $result );
 	}
@@ -161,28 +192,7 @@ class Jetpack_Json_Api_Plugins_Endpoints_Test extends WP_UnitTestCase {
 		}
 		$plugin_property->setValue( $endpoint, array( 'the/the.php' ) );
 
-		$the_plugin_file = 'the/the.php';
-		$the_real_folder = WP_PLUGIN_DIR . '/the';
-		$the_real_file   = WP_PLUGIN_DIR . '/' . $the_plugin_file;
-
-		/*
-		 * Create an oudated version of 'The' plugin
-		 */
-
-		// Check if 'The' plugin folder is already there.
-		if ( ! file_exists( $the_real_folder ) ) {
-			mkdir( $the_real_folder );
-			$clean = true;
-		}
-
-		file_put_contents(
-			$the_real_file,
-			'<?php
-			/*
-			 * Plugin Name: The
-			 * Version: 1.0
-			 */'
-		);
+		$this->install_the_plugin();
 
 		// Obtain lock.
 		include_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
@@ -196,9 +206,7 @@ class Jetpack_Json_Api_Plugins_Endpoints_Test extends WP_UnitTestCase {
 		WP_Upgrader::release_lock( 'auto_updater' );
 		Constants::set_constant( 'JETPACK_PLUGIN_AUTOUPDATE', false );
 		// clean up.
-		if ( isset( $clean ) ) {
-			$this->rmdir( $the_real_folder );
-		}
+		$this->remove_the_plugin();
 
 		$this->assertTrue( is_wp_error( $result ) );
 	}
@@ -249,28 +257,7 @@ class Jetpack_Json_Api_Plugins_Endpoints_Test extends WP_UnitTestCase {
 		}
 		$plugin_property->setValue( $endpoint, array( 'the/the.php' ) );
 
-		$the_plugin_file = 'the/the.php';
-		$the_real_folder = WP_PLUGIN_DIR . '/the';
-		$the_real_file   = WP_PLUGIN_DIR . '/' . $the_plugin_file;
-
-		/*
-		 * Create an oudated version of 'The' plugin
-		 */
-
-		// Check if 'The' plugin folder is already there.
-		if ( ! file_exists( $the_real_folder ) ) {
-			mkdir( $the_real_folder );
-			$clean = true;
-		}
-
-		file_put_contents(
-			$the_real_file,
-			'<?php
-			/*
-			 * Plugin Name: The
-			 * Version: 1.0
-			 */'
-		);
+		$this->install_the_plugin();
 
 		// Obtain lock.
 		include_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
@@ -284,9 +271,7 @@ class Jetpack_Json_Api_Plugins_Endpoints_Test extends WP_UnitTestCase {
 		WP_Upgrader::release_lock( 'auto_updater' );
 
 		// clean up.
-		if ( isset( $clean ) ) {
-			$this->rmdir( $the_real_folder );
-		}
+		$this->remove_the_plugin();
 
 		$this->assertTrue( $result );
 	}

--- a/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Plugins_Test.php
+++ b/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Plugins_Test.php
@@ -10,12 +10,19 @@ class Jetpack_Sync_Plugins_Test extends Jetpack_Sync_TestBase {
 	const PLUGIN_ZIP = __DIR__ . '/../files/the.1.1.zip';
 
 	protected static $hello_dolly_path;
+	protected static $the_plugin_lock;
 
 	/**
 	 * Set up before class.
 	 */
 	public static function setUpBeforeClass(): void {
 		self::$hello_dolly_path = file_exists( WP_PLUGIN_DIR . '/hello.php' ) ? 'hello.php' : 'hello-dolly/hello.php';
+	}
+
+	public static function tearDownAfterClass(): void {
+		if ( static::$the_plugin_lock ) {
+			self::remove_plugin();
+		}
 	}
 
 	public function test_installing_and_removing_plugin_is_synced() {
@@ -172,6 +179,17 @@ class Jetpack_Sync_Plugins_Test extends Jetpack_Sync_TestBase {
 			'api'    => '',
 		);
 
+		// For CI coverage tests, use a lock file to avoid multiple copies of this test from interfering with each other.
+		if ( getenv( 'PHPUNIT_JETPACK_TESTSUITE_IS_PARALLEL' ) === 'true' && ! static::$the_plugin_lock ) {
+			static::$the_plugin_lock = fopen( WP_PLUGIN_DIR . '/.thepluginlock', 'c+' );
+			if ( ! static::$the_plugin_lock ) {
+				throw new RuntimeException( 'Failed to open lockfile ' . WP_PLUGIN_DIR . '/.thepluginlock' );
+			}
+			if ( ! flock( static::$the_plugin_lock, LOCK_EX ) ) {
+				throw new RuntimeException( 'Failed to lock lockfile ' . WP_PLUGIN_DIR . '/.thepluginlock' );
+			}
+		}
+
 		$upgrader = new Plugin_Upgrader(
 			new Automatic_Upgrader_Skin( $plugin_defaults )
 		);
@@ -197,6 +215,10 @@ class Jetpack_Sync_Plugins_Test extends Jetpack_Sync_TestBase {
 			delete_plugins( array( 'the/the.php' ) );
 			remove_filter( 'pre_http_request', array( 'Jetpack_Sync_TestBase', 'pre_http_request_wordpress_org_updates' ) );
 			wp_cache_delete( 'plugins', 'plugins' );
+		}
+		if ( static::$the_plugin_lock ) {
+			fclose( static::$the_plugin_lock );
+			static::$the_plugin_lock = null;
 		}
 	}
 

--- a/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Plugins_Updates_Test.php
+++ b/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Plugins_Updates_Test.php
@@ -35,9 +35,7 @@ class Jetpack_Sync_Plugins_Updates_Test extends Jetpack_Sync_TestBase {
 	 */
 	public static function set_up_before_class() {
 		parent::set_up_before_class();
-		if ( ! file_exists( WP_PLUGIN_DIR . '/the/the.php' ) ) {
-			Jetpack_Sync_Plugins_Test::install_the_plugin();
-		}
+		Jetpack_Sync_Plugins_Test::install_the_plugin();
 	}
 
 	/**
@@ -45,9 +43,7 @@ class Jetpack_Sync_Plugins_Updates_Test extends Jetpack_Sync_TestBase {
 	 */
 	public static function tear_down_after_class() {
 		parent::tear_down_after_class();
-		if ( file_exists( WP_PLUGIN_DIR . '/the/the.php' ) ) {
-			Jetpack_Sync_Plugins_Test::remove_plugin();
-		}
+		Jetpack_Sync_Plugins_Test::remove_plugin();
 	}
 
 	public function test_updating_a_plugin_is_synced() {


### PR DESCRIPTION
Closes MONOREP-218

 <!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
PR #45851 added some locking for Jetpack_Sync_Themes_Test. We also have some tests that are messing with a plugin, which can also wind up interfering with each other. Add locking for those too.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1762964280572399/1762963867.449579-slack-C034JEXD1RD

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* CI happy?
* Change look reasonable?
* Hard to really test it solves the intermittent failure though 🤷