### PR TITLE
actions: Use node24 runner

### DIFF
--- a/.github/actions/tool-setup/post-run-action/action.yml
+++ b/.github/actions/tool-setup/post-run-action/action.yml
@@ -1,6 +1,6 @@
 name: Post-run proxy log dump
 description: Cat the proxy log as a post-run step
 runs:
-  using: node20
+  using: node24
   main: main.mjs
   post: post.mjs

--- a/projects/github-actions/repo-gardening/action.yml
+++ b/projects/github-actions/repo-gardening/action.yml
@@ -65,5 +65,5 @@ inputs:
     required: false
     default: ""
 runs:
-  using: node20
+  using: node24
   main: "dist/index.js"

--- a/projects/github-actions/repo-gardening/changelog/update-actions-to-node24
+++ b/projects/github-actions/repo-gardening/changelog/update-actions-to-node24
@@ -1,0 +1,4 @@
+Significance: major
+Type: changed
+
+Use the node24 runner instead of the deprecated node20 runner.

--- a/projects/github-actions/required-review/action.yml
+++ b/projects/github-actions/required-review/action.yml
@@ -42,5 +42,5 @@ outputs:
   teams-needed-for-review:
     description: 'JSON-stringified array of team names that are needed to review the PR.'
 runs:
-  using: node20
+  using: node24
   main: dist/index.js

--- a/projects/github-actions/required-review/changelog/update-actions-to-node24
+++ b/projects/github-actions/required-review/changelog/update-actions-to-node24
@@ -1,0 +1,4 @@
+Significance: major
+Type: changed
+
+Use the node24 runner instead of the deprecated node20 runner.

--- a/projects/github-actions/test-results-to-slack/action.yml
+++ b/projects/github-actions/test-results-to-slack/action.yml
@@ -37,5 +37,5 @@ inputs:
     required: false
 
 runs:
-  using: node20
+  using: node24
   main: "dist/index.js"

--- a/projects/github-actions/test-results-to-slack/changelog/update-actions-to-node24
+++ b/projects/github-actions/test-results-to-slack/changelog/update-actions-to-node24
@@ -1,0 +1,4 @@
+Significance: major
+Type: changed
+
+Use the node24 runner instead of the deprecated node20 runner.


### PR DESCRIPTION
Closes MONOREP-219

 <!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
GitHub has deprecated the node20 runner in favor of node24. https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

Update our actions to use that.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
Not really

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Stuff still run ok?
