### PR TITLE
Forms: improve MailPoet subscriber handling

### DIFF
--- a/projects/packages/forms/changelog/update-forms-mailpoet-subscriber-confirmation
+++ b/projects/packages/forms/changelog/update-forms-mailpoet-subscriber-confirmation
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Forms: improve MailPoet subscriber handling.

--- a/projects/packages/forms/src/service/class-mailpoet-integration.php
+++ b/projects/packages/forms/src/service/class-mailpoet-integration.php
@@ -110,6 +110,7 @@ class MailPoet_Integration {
 
 			// Normalize "subscribed" status using MailPoet constant when available.
 			$status_subscribed = class_exists( '\MailPoet\Entities\SubscriberEntity' )
+				// @phan-suppress-next-line PhanUndeclaredClassConstant
 				? \MailPoet\Entities\SubscriberEntity::STATUS_SUBSCRIBED
 				: 'subscribed';
 

--- a/projects/packages/forms/src/service/class-mailpoet-integration.php
+++ b/projects/packages/forms/src/service/class-mailpoet-integration.php
@@ -108,13 +108,18 @@ class MailPoet_Integration {
 		try {
 			$existing = $mailpoet_api->getSubscriber( $email );
 
+			// Normalize "subscribed" status using MailPoet constant when available.
+			$status_subscribed = class_exists( '\MailPoet\Entities\SubscriberEntity' )
+				? \MailPoet\Entities\SubscriberEntity::STATUS_SUBSCRIBED
+				: 'subscribed';
+
 			// If already subscribed to list, do nothing.
 			if ( ! empty( $existing['subscriptions'] ) && is_array( $existing['subscriptions'] ) ) {
 				foreach ( $existing['subscriptions'] as $subscription ) {
 					if (
 						isset( $subscription['segment_id'] ) && isset( $subscription['status'] ) &&
 						(string) $subscription['segment_id'] === (string) $list_id &&
-						'subscribed' === $subscription['status']
+						$status_subscribed === $subscription['status']
 					) {
 						return $existing;
 					}
@@ -124,7 +129,7 @@ class MailPoet_Integration {
 			// Subscriber exists but is not on the target list, so add to list.
 			// If subscriber already confirmed ('subscribed'), do not resend confirmation.
 			$options = array();
-			if ( isset( $existing['status'] ) && 'subscribed' === $existing['status'] ) {
+			if ( isset( $existing['status'] ) && $existing['status'] === $status_subscribed ) {
 				$options['send_confirmation_email'] = false;
 			}
 

--- a/projects/packages/forms/src/service/class-mailpoet-integration.php
+++ b/projects/packages/forms/src/service/class-mailpoet-integration.php
@@ -104,13 +104,45 @@ class MailPoet_Integration {
 	 * @return array|null Subscriber data on success, or null on failure.
 	 */
 	protected static function add_subscriber_to_list( $mailpoet_api, $list_id, $subscriber_data ) {
+		$email = $subscriber_data['email'];
 		try {
-			$subscriber = $mailpoet_api->addSubscriber(
-				$subscriber_data,
-				array( $list_id )
-			);
-			return $subscriber;
+			$existing = $mailpoet_api->getSubscriber( $email );
+
+			// If already subscribed to list, do nothing.
+			if ( ! empty( $existing['subscriptions'] ) && is_array( $existing['subscriptions'] ) ) {
+				foreach ( $existing['subscriptions'] as $subscription ) {
+					if (
+						isset( $subscription['segment_id'] ) && isset( $subscription['status'] ) &&
+						(string) $subscription['segment_id'] === (string) $list_id &&
+						'subscribed' === $subscription['status']
+					) {
+						return $existing;
+					}
+				}
+			}
+
+			// Subscriber exists but is not on the target list, so add to list.
+			// If subscriber already confirmed ('subscribed'), do not resend confirmation.
+			$options = array();
+			if ( isset( $existing['status'] ) && 'subscribed' === $existing['status'] ) {
+				$options['send_confirmation_email'] = false;
+			}
+
+			return $mailpoet_api->subscribeToLists( $email, array( $list_id ), $options );
 		} catch ( \Exception $e ) {
+			// MailPoet returns APIException code 4 if "subscriber does not exist".
+			// In that case, take no action and next try statement will add subscriber.
+			// For other exceptions, return null.
+			$not_found_code = 4;
+			if ( method_exists( $e, 'getCode' ) && (int) $e->getCode() !== $not_found_code ) {
+				return null;
+			}
+		}
+
+		// Subscriber does not exist, so add new subscriber to list and send confirmation email.
+		try {
+			return $mailpoet_api->addSubscriber( $subscriber_data, array( $list_id ) );
+		} catch ( \Exception $e ) { // phpcs:ignore Squiz.PHP.EmptyCatchComment
 			return null;
 		}
 	}

--- a/projects/plugins/jetpack/changelog/update-forms-mailpoet-subscriber-confirmation
+++ b/projects/plugins/jetpack/changelog/update-forms-mailpoet-subscriber-confirmation
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Forms: improve MailPoet subscriber handling.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes [FORMS-392](https://linear.app/a8c/issue/FORMS-392/forms-avoid-sending-repeat-mailpoet-confirmation-emails) and [FORMS-374](https://linear.app/a8c/issue/FORMS-374/forms-add-mailpoet-subscribers-to-multiple-lists)

## Proposed changes:

This PR updates our code for adding subscribers to MailPoet. Before we'd just immediately call the API method to add a new subscriber. But this misses several different possible situations. Now we check if the subscriber exists and take different results based on subscriber status. 
* If subscriber exists and is on the target list, we do nothing
* If subscriber exists and is not on the target list, we add the subscriber to the list using `$mailpoet_api->subscribeToLists`
   - In this case, we also check if the subscriber has already confirmed their email. If so, we set `send_confirmation_email` to false so we do not send repeat confirmation emails. 
* If subscriber does not exist, we add the subscriber as before (which also means leaving `send_confirmation_email` as default to true, so confirmation email will go out. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
See linear issue above. 
Also see Slack: p1762546356789039-slack-C0313FPUG74

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->


* Setup. 
    - Jurassic Ninja. To test emails, you'll need to be on a test site where you can configure MailPoet to send confirmation emails. I was unable to do this on my usual Jurassic tube testing site. The cleanest way to test this is to create a Jurrasic Ninja site with Jetpack, MailPoet, and Jetpack Beta Tester installed. 
   - Jetpack Beta Tester: load this branch for Jetpack
   - MailPoet: For sending email, you'll need a free MailPoet account with key, and you'll need to go to MailPoet > Settings > Send with and add your MailPoet key to use the MailPoet sending service to send emails. 
       - Once set up, go to MailPoet > Lists and create two unique subscriber lists (ie, like First List, Second List). 
   - Email Address: You also need to be able to submit forms as a user with a unique email. You can use https://temp-mail.org/ to set up a temporary inbox to use. 
   
* Testing. 
  - Add a form to a post. Be sure to add First and Last Name field variations, plus Email. 
  - Open the integrations modal, enable MailPoet, and select one of your two unique lists. 
  - Publish your form, submit on the frontend. 
  - Go to MailPoet > Subscribers, and confirm user is added to list. 
  - Initially, a user's status will be 'unconfirmed'. Whatever email you used, go to your inbox, confirm you received a confirmation email, and click to confirm. 
  - Refresh the MailPoet > Subscribers page and confirm your user now has status of 'subscribed'. 
  - Now go back to your post with the form, and update the form to use the second MailPoet list you set up. 
  - Publish and re-submit the form using the same name and email. 
  - Refresh MailPoet > Subscribers and confirm your subscriber is now added to both lists. 
  - Go to your email inbox and confirm you do not get a second confirmation email. 
  - As an extra test, try resubmitting your form once more with all the same details. The submission should be successful, you should see a third form submission in your forms inbox, but nothing will change with your MailPoet subscriber, and no confirmation email will be received by the subscriber. 