### PR TITLE
Forms: persist form title attribute

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-persist-form-title-attribute
+++ b/projects/packages/forms/changelog/fix-forms-persist-form-title-attribute
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Forms: add formTitle on default attributes so it persists throughout parsing and processing

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -209,6 +209,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 			'notificationRecipients' => array(), // Array of user IDs who should receive form response notifications.
 			'disableGoBack'          => $attributes['disableGoBack'] ?? false,
 			'disableSummary'         => $attributes['disableSummary'] ?? false,
+			'formTitle'              => $attributes['formTitle'] ?? '',
 		);
 
 		$attributes = shortcode_atts( $this->defaults, $attributes, 'contact-form' );

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
@@ -2831,6 +2831,7 @@ EOT;
 			'mailpoet'               => '',
 			'emailNotifications'     => 'yes',
 			'disableGoBack'          => false,
+			'formTitle'              => 'Test Form',
 		);
 		// Add a widget ID to the attributes for testing.
 		$expected_attributes                           = $attributes;
@@ -2844,7 +2845,7 @@ EOT;
 		$expected_attributes['disableSummary']         = '';
 		$expected_attributes['confirmationType']       = '';
 		$expected_attributes['hostingerReach']         = '';
-
+		$expected_attributes['formTitle']              = 'Test Form';
 		$form = new Contact_Form(
 			$attributes,
 			"[contact-field label='Name' type='name' required='1'/]"


### PR DESCRIPTION


## Proposed changes:
This PR adds `formTitle` to the default attributes parsed by the form. This way, the attribute persists between renders and process.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
None

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
TBD