### PR TITLE
Forms: fix single input error gap

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-single-input-error-gap
+++ b/projects/packages/forms/changelog/fix-forms-single-input-error-gap
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: address spacing issues on single input forms

--- a/projects/packages/forms/src/contact-form/css/grunion.scss
+++ b/projects/packages/forms/src/contact-form/css/grunion.scss
@@ -382,6 +382,10 @@ that needs to mimic the input element styles */
 
 	&:has(.contact-form__input-error.has-errors) {
 		margin-bottom: calc(var(--wp--style--block-gap, 1.5rem) * 2);
+
+		.wp-block-jetpack-button.wp-block-button {
+			margin-top: var(--wp--style--block-gap, 1.5rem);
+		}
 	}
 }
 


### PR DESCRIPTION
## Proposed changes:
This PR adds special margin for single input blocks on error.

<img width="739" height="391" alt="image" src="https://github.com/user-attachments/assets/3b024fc6-d010-4d24-9919-62bb4135d2ae" />


<img width="731" height="422" alt="image" src="https://github.com/user-attachments/assets/eefe4db7-da0b-443c-8f16-8cd5a83a5d96" />

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1762822669061399-slack-C052XEUUBL4

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Insert forms on a post, some single input, some horizontal, then others. Make them fail by submitting empty, see that the errors do not overlap and behave as expected.