### PR TITLE
Update codesniffer rulesets

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -64,13 +64,13 @@
             "dist": {
                 "type": "path",
                 "url": "projects/packages/codesniffer",
-                "reference": "ba4dbd5164cb2b0e49b07664fe602473888d8c1a"
+                "reference": "03a695db5cb87764b99dce21ec82e38484586d13"
             },
             "require": {
                 "automattic/vipwpcs": "^3.0",
                 "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
-                "mediawiki/mediawiki-codesniffer": "^47.0",
-                "php": ">=8.0",
+                "mediawiki/mediawiki-codesniffer": "^48.0",
+                "php": ">=8.1",
                 "phpcompatibility/phpcompatibility-wp": "^2.1",
                 "phpcsstandards/phpcsutils": "^1.0",
                 "sirbrillig/phpcs-variable-analysis": "^2.10",
@@ -384,16 +384,16 @@
         },
         {
             "name": "composer/semver",
-            "version": "3.4.3",
+            "version": "3.4.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/semver.git",
-                "reference": "4313d26ada5e0c4edfbd1dc481a92ff7bff91f12"
+                "reference": "198166618906cb2de69b95d7d47e5fa8aa1b2b95"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/semver/zipball/4313d26ada5e0c4edfbd1dc481a92ff7bff91f12",
-                "reference": "4313d26ada5e0c4edfbd1dc481a92ff7bff91f12",
+                "url": "https://api.github.com/repos/composer/semver/zipball/198166618906cb2de69b95d7d47e5fa8aa1b2b95",
+                "reference": "198166618906cb2de69b95d7d47e5fa8aa1b2b95",
                 "shasum": ""
             },
             "require": {
@@ -445,7 +445,7 @@
             "support": {
                 "irc": "ircs://irc.libera.chat:6697/composer",
                 "issues": "https://github.com/composer/semver/issues",
-                "source": "https://github.com/composer/semver/tree/3.4.3"
+                "source": "https://github.com/composer/semver/tree/3.4.4"
             },
             "funding": [
                 {
@@ -455,13 +455,9 @@
                 {
                     "url": "https://github.com/composer",
                     "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
-                    "type": "tidelift"
                 }
             ],
-            "time": "2024-09-19T14:15:21+00:00"
+            "time": "2025-08-20T19:15:30+00:00"
         },
         {
             "name": "composer/spdx-licenses",
@@ -800,31 +796,30 @@
         },
         {
             "name": "mediawiki/mediawiki-codesniffer",
-            "version": "v47.0.0",
+            "version": "v48.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wikimedia/mediawiki-tools-codesniffer.git",
-                "reference": "056bb337d5229699356884563431b9cc6521ad14"
+                "reference": "6d46ca2334d5e1c5be10bf28e01f6010cfbff212"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wikimedia/mediawiki-tools-codesniffer/zipball/056bb337d5229699356884563431b9cc6521ad14",
-                "reference": "056bb337d5229699356884563431b9cc6521ad14",
+                "url": "https://api.github.com/repos/wikimedia/mediawiki-tools-codesniffer/zipball/6d46ca2334d5e1c5be10bf28e01f6010cfbff212",
+                "reference": "6d46ca2334d5e1c5be10bf28e01f6010cfbff212",
                 "shasum": ""
             },
             "require": {
-                "composer/semver": "3.4.2 || 3.4.3",
+                "composer/semver": "^3.4.2",
                 "composer/spdx-licenses": "~1.5.2",
                 "ext-json": "*",
                 "ext-mbstring": "*",
-                "php": ">=7.4.0",
-                "phpcsstandards/phpcsextra": "1.2.1",
-                "squizlabs/php_codesniffer": "3.12.2",
-                "symfony/polyfill-php80": "^1.26.0"
+                "php": ">=8.1.0",
+                "phpcsstandards/phpcsextra": "1.4.0",
+                "squizlabs/php_codesniffer": "3.13.2"
             },
             "require-dev": {
                 "ext-dom": "*",
-                "mediawiki/mediawiki-phan-config": "0.15.1",
+                "mediawiki/mediawiki-phan-config": "0.17.0",
                 "mediawiki/minus-x": "1.1.3",
                 "php-parallel-lint/php-console-highlighter": "1.0.0",
                 "php-parallel-lint/php-parallel-lint": "1.4.0",
@@ -833,8 +828,7 @@
             "type": "phpcodesniffer-standard",
             "autoload": {
                 "psr-4": {
-                    "MediaWiki\\Sniffs\\": "MediaWiki/Sniffs/",
-                    "MediaWiki\\Sniffs\\Tests\\": "MediaWiki/Tests/"
+                    "MediaWiki\\Sniffs\\": "MediaWiki/Sniffs/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -848,9 +842,9 @@
                 "mediawiki"
             ],
             "support": {
-                "source": "https://github.com/wikimedia/mediawiki-tools-codesniffer/tree/v47.0.0"
+                "source": "https://github.com/wikimedia/mediawiki-tools-codesniffer/tree/v48.0.0"
             },
-            "time": "2025-05-04T07:30:05+00:00"
+            "time": "2025-09-04T20:12:57+00:00"
         },
         {
             "name": "microsoft/tolerant-php-parser",
@@ -1483,29 +1477,29 @@
         },
         {
             "name": "phpcsstandards/phpcsextra",
-            "version": "1.2.1",
+            "version": "1.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHPCSExtra.git",
-                "reference": "11d387c6642b6e4acaf0bd9bf5203b8cca1ec489"
+                "reference": "fa4b8d051e278072928e32d817456a7fdb57b6ca"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSExtra/zipball/11d387c6642b6e4acaf0bd9bf5203b8cca1ec489",
-                "reference": "11d387c6642b6e4acaf0bd9bf5203b8cca1ec489",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSExtra/zipball/fa4b8d051e278072928e32d817456a7fdb57b6ca",
+                "reference": "fa4b8d051e278072928e32d817456a7fdb57b6ca",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.4",
-                "phpcsstandards/phpcsutils": "^1.0.9",
-                "squizlabs/php_codesniffer": "^3.8.0"
+                "phpcsstandards/phpcsutils": "^1.1.0",
+                "squizlabs/php_codesniffer": "^3.13.0 || ^4.0"
             },
             "require-dev": {
                 "php-parallel-lint/php-console-highlighter": "^1.0",
-                "php-parallel-lint/php-parallel-lint": "^1.3.2",
+                "php-parallel-lint/php-parallel-lint": "^1.4.0",
                 "phpcsstandards/phpcsdevcs": "^1.1.6",
                 "phpcsstandards/phpcsdevtools": "^1.2.1",
-                "phpunit/phpunit": "^4.5 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.0"
+                "phpunit/phpunit": "^4.5 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.3.4"
             },
             "type": "phpcodesniffer-standard",
             "extra": {
@@ -1555,35 +1549,39 @@
                 {
                     "url": "https://opencollective.com/php_codesniffer",
                     "type": "open_collective"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/phpcsstandards",
+                    "type": "thanks_dev"
                 }
             ],
-            "time": "2023-12-08T16:49:07+00:00"
+            "time": "2025-06-14T07:40:39+00:00"
         },
         {
             "name": "phpcsstandards/phpcsutils",
-            "version": "1.0.12",
+            "version": "1.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHPCSUtils.git",
-                "reference": "87b233b00daf83fb70f40c9a28692be017ea7c6c"
+                "reference": "f7eb16f2fa4237d5db9e8fed8050239bee17a9bd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSUtils/zipball/87b233b00daf83fb70f40c9a28692be017ea7c6c",
-                "reference": "87b233b00daf83fb70f40c9a28692be017ea7c6c",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSUtils/zipball/f7eb16f2fa4237d5db9e8fed8050239bee17a9bd",
+                "reference": "f7eb16f2fa4237d5db9e8fed8050239bee17a9bd",
                 "shasum": ""
             },
             "require": {
                 "dealerdirect/phpcodesniffer-composer-installer": "^0.4.1 || ^0.5 || ^0.6.2 || ^0.7 || ^1.0",
                 "php": ">=5.4",
-                "squizlabs/php_codesniffer": "^3.10.0 || 4.0.x-dev@dev"
+                "squizlabs/php_codesniffer": "^3.13.0 || ^4.0"
             },
             "require-dev": {
                 "ext-filter": "*",
                 "php-parallel-lint/php-console-highlighter": "^1.0",
-                "php-parallel-lint/php-parallel-lint": "^1.3.2",
+                "php-parallel-lint/php-parallel-lint": "^1.4.0",
                 "phpcsstandards/phpcsdevcs": "^1.1.6",
-                "yoast/phpunit-polyfills": "^1.1.0 || ^2.0.0"
+                "yoast/phpunit-polyfills": "^1.1.0 || ^2.0.0 || ^3.0.0"
             },
             "type": "phpcodesniffer-standard",
             "extra": {
@@ -1620,6 +1618,7 @@
                 "phpcodesniffer-standard",
                 "phpcs",
                 "phpcs3",
+                "phpcs4",
                 "standards",
                 "static analysis",
                 "tokens",
@@ -1643,9 +1642,13 @@
                 {
                     "url": "https://opencollective.com/php_codesniffer",
                     "type": "open_collective"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/phpcsstandards",
+                    "type": "thanks_dev"
                 }
             ],
-            "time": "2024-05-20T13:34:27+00:00"
+            "time": "2025-08-10T01:04:45+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -2150,16 +2153,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.12.2",
+            "version": "3.13.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/PHP_CodeSniffer",
-                "reference": "faa2b902f228a04a73206edc433b766032281d04"
+                "reference": "20eb737638980e533833ad67d674ba71f7ddd9d9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/PHP_CodeSniffer/zipball/faa2b902f228a04a73206edc433b766032281d04",
-                "reference": "faa2b902f228a04a73206edc433b766032281d04",
+                "url": "https://api.github.com/repos/Automattic/PHP_CodeSniffer/zipball/20eb737638980e533833ad67d674ba71f7ddd9d9",
+                "reference": "20eb737638980e533833ad67d674ba71f7ddd9d9",
                 "shasum": ""
             },
             "require": {
@@ -3124,16 +3127,16 @@
         },
         {
             "name": "wp-coding-standards/wpcs",
-            "version": "3.1.0",
+            "version": "3.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/WordPress/WordPress-Coding-Standards.git",
-                "reference": "9333efcbff231f10dfd9c56bb7b65818b4733ca7"
+                "reference": "d2421de7cec3274ae622c22c744de9a62c7925af"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/9333efcbff231f10dfd9c56bb7b65818b4733ca7",
-                "reference": "9333efcbff231f10dfd9c56bb7b65818b4733ca7",
+                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/d2421de7cec3274ae622c22c744de9a62c7925af",
+                "reference": "d2421de7cec3274ae622c22c744de9a62c7925af",
                 "shasum": ""
             },
             "require": {
@@ -3142,13 +3145,13 @@
                 "ext-tokenizer": "*",
                 "ext-xmlreader": "*",
                 "php": ">=5.4",
-                "phpcsstandards/phpcsextra": "^1.2.1",
-                "phpcsstandards/phpcsutils": "^1.0.10",
-                "squizlabs/php_codesniffer": "^3.9.0"
+                "phpcsstandards/phpcsextra": "^1.4.0",
+                "phpcsstandards/phpcsutils": "^1.1.0",
+                "squizlabs/php_codesniffer": "^3.13.0"
             },
             "require-dev": {
                 "php-parallel-lint/php-console-highlighter": "^1.0.0",
-                "php-parallel-lint/php-parallel-lint": "^1.3.2",
+                "php-parallel-lint/php-parallel-lint": "^1.4.0",
                 "phpcompatibility/php-compatibility": "^9.0",
                 "phpcsstandards/phpcsdevtools": "^1.2.0",
                 "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.0"
@@ -3186,7 +3189,7 @@
                     "type": "custom"
                 }
             ],
-            "time": "2024-03-25T16:39:00+00:00"
+            "time": "2025-07-24T20:08:31+00:00"
         }
     ],
     "aliases": [],

--- a/projects/packages/boost-speed-score/changelog/update-codesniffer-rulesets
+++ b/projects/packages/boost-speed-score/changelog/update-codesniffer-rulesets
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Replace `MediaWiki.Usage.NestedFunctions` with `Squiz.PHP.InnerFunctions`.
+
+

--- a/projects/packages/boost-speed-score/tests/php/lib/Url_Test.php
+++ b/projects/packages/boost-speed-score/tests/php/lib/Url_Test.php
@@ -24,7 +24,7 @@ class Url_Test extends Base_TestCase {
 		// Dumb, but functional remove_query_arg polyfill.
 		// @phan-suppress-next-line PhanPluginUnreachableCode
 		if ( ! function_exists( 'remove_query_arg' ) ) {
-			// phpcs:ignore MediaWiki.Usage.NestedFunctions.NestedFunction
+			// phpcs:ignore Squiz.PHP.InnerFunctions.NotAllowed
 			function remove_query_arg( $parameters, $url ) {
 				foreach ( $parameters as $parameter ) {
 					$url = preg_replace( sprintf( '~&?%s=[^&]+~', preg_quote( $parameter, '~' ) ), '', $url );
@@ -35,7 +35,7 @@ class Url_Test extends Base_TestCase {
 
 		// wp_parse_url in new PHP versions is the same as the native parse_url.
 		if ( ! function_exists( 'wp_parse_url' ) ) {
-			// phpcs:ignore MediaWiki.Usage.NestedFunctions.NestedFunction
+			// phpcs:ignore Squiz.PHP.InnerFunctions.NotAllowed
 			function wp_parse_url( $url ) {
 				return parse_url( $url );
 			}

--- a/projects/packages/classic-theme-helper/changelog/update-codesniffer-rulesets
+++ b/projects/packages/classic-theme-helper/changelog/update-codesniffer-rulesets
@@ -1,5 +1,5 @@
 Significance: patch
 Type: changed
-Comment: Replace `MediaWiki.Usage.NestedFunctions` with `Squiz.PHP.InnerFunctions`.
+Comment: Remove `MediaWiki.Usage.NestedFunctions`,  `Squiz.PHP.InnerFunctions` is ok with function→class→function.
 
 

--- a/projects/packages/classic-theme-helper/changelog/update-codesniffer-rulesets
+++ b/projects/packages/classic-theme-helper/changelog/update-codesniffer-rulesets
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Replace `MediaWiki.Usage.NestedFunctions` with `Squiz.PHP.InnerFunctions`.
+
+

--- a/projects/packages/classic-theme-helper/src/content-options/customizer.php
+++ b/projects/packages/classic-theme-helper/src/content-options/customizer.php
@@ -74,7 +74,7 @@ if ( ! function_exists( 'jetpack_content_options_customize_register' ) ) {
 				/**
 				 * Render the control's content.
 				 */
-				public function render_content() { // phpcs:ignore Squiz.PHP.InnerFunctions.NotAllowed
+				public function render_content() {
 					?>
 					<span class="customize-control-title"><?php echo wp_kses_post( $this->label ); ?></span>
 					<?php

--- a/projects/packages/classic-theme-helper/src/content-options/customizer.php
+++ b/projects/packages/classic-theme-helper/src/content-options/customizer.php
@@ -74,7 +74,7 @@ if ( ! function_exists( 'jetpack_content_options_customize_register' ) ) {
 				/**
 				 * Render the control's content.
 				 */
-				public function render_content() { // phpcs:ignore MediaWiki.Usage.NestedFunctions.NestedFunction
+				public function render_content() { // phpcs:ignore Squiz.PHP.InnerFunctions.NotAllowed
 					?>
 					<span class="customize-control-title"><?php echo wp_kses_post( $this->label ); ?></span>
 					<?php

--- a/projects/packages/codesniffer/Jetpack/ruleset.xml
+++ b/projects/packages/codesniffer/Jetpack/ruleset.xml
@@ -26,7 +26,7 @@
 	-->
 	<rule ref="MediaWiki.Usage.InArrayUsage" />
 	<rule ref="MediaWiki.Usage.MagicConstantClosure" />
-	<rule ref="MediaWiki.Usage.NestedFunctions" />
+	<rule ref="Squiz.PHP.InnerFunctions" /> <!-- Formerly MediaWiki.Usage.NestedFunctions -->
 	<rule ref="MediaWiki.Usage.PlusStringConcat" />
 	<rule ref="MediaWiki.Usage.ReferenceThis" />
 	<rule ref="MediaWiki.WhiteSpace.EmptyLinesBetweenUse" />

--- a/projects/packages/codesniffer/changelog/update-codesniffer-rulesets
+++ b/projects/packages/codesniffer/changelog/update-codesniffer-rulesets
@@ -1,0 +1,4 @@
+Significance: major
+Type: removed
+
+Drop support for PHP 8.0, following upstream `mediawiki/mediawiki-codesniffer` package.

--- a/projects/packages/codesniffer/changelog/update-codesniffer-rulesets#2
+++ b/projects/packages/codesniffer/changelog/update-codesniffer-rulesets#2
@@ -1,0 +1,4 @@
+Significance: major
+Type: changed
+
+Update `mediawiki/mediawiki-codesniffer` to v48.0.0.

--- a/projects/packages/codesniffer/changelog/update-codesniffer-rulesets#3
+++ b/projects/packages/codesniffer/changelog/update-codesniffer-rulesets#3
@@ -1,0 +1,4 @@
+Significance: major
+Type: changed
+
+Replace `MediaWiki.Usage.NestedFunctions` with `Squiz.PHP.InnerFunctions`.

--- a/projects/packages/codesniffer/changelog/update-codesniffer-rulesets#4
+++ b/projects/packages/codesniffer/changelog/update-codesniffer-rulesets#4
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update tests for WPCS adding `Generic.Strings.UnnecessaryHeredoc`.
+
+

--- a/projects/packages/codesniffer/composer.json
+++ b/projects/packages/codesniffer/composer.json
@@ -12,9 +12,9 @@
 		"testing"
 	],
 	"require": {
-		"php": ">=8.0",
+		"php": ">=8.1",
 		"dealerdirect/phpcodesniffer-composer-installer": "^1.0",
-		"mediawiki/mediawiki-codesniffer": "^47.0",
+		"mediawiki/mediawiki-codesniffer": "^48.0",
 		"phpcompatibility/phpcompatibility-wp": "^2.1",
 		"sirbrillig/phpcs-variable-analysis": "^2.10",
 		"wp-coding-standards/wpcs": "^3.0",

--- a/projects/packages/codesniffer/tests/php/integration/files/PhpunitAttributes_TestWith_NoKeepTest.php.fixed
+++ b/projects/packages/codesniffer/tests/php/integration/files/PhpunitAttributes_TestWith_NoKeepTest.php.fixed
@@ -3,7 +3,7 @@
 // phpcs:disable Squiz.Commenting.ClassComment.Missing, Squiz.Commenting.FunctionComment.Missing
 // phpcs:disable Generic.Files.OneObjectStructurePerFile.MultipleFound
 // phpcs:disable Jetpack.PHPUnit.TestClassName.DoesNotMatchFileName
-// phpcs:disable Squiz.Strings.DoubleQuoteUsage.NotRequired, WordPress.Arrays.ArrayDeclarationSpacing, Universal.Arrays.DisallowShortArraySyntax, PHPCompatibility.Syntax.NewFlexibleHeredocNowdoc
+// phpcs:disable Squiz.Strings.DoubleQuoteUsage.NotRequired, WordPress.Arrays.ArrayDeclarationSpacing, Universal.Arrays.DisallowShortArraySyntax, PHPCompatibility.Syntax.NewFlexibleHeredocNowdoc, Generic.Strings.UnnecessaryHeredoc.Found
 
 
 use PHPUnit\Framework\Attributes\TestWith;

--- a/projects/packages/codesniffer/tests/php/integration/files/PhpunitAttributes_TestWith_Test.php.fixed
+++ b/projects/packages/codesniffer/tests/php/integration/files/PhpunitAttributes_TestWith_Test.php.fixed
@@ -3,7 +3,7 @@
 // phpcs:disable Squiz.Commenting.ClassComment.Missing, Squiz.Commenting.FunctionComment.Missing
 // phpcs:disable Generic.Files.OneObjectStructurePerFile.MultipleFound
 // phpcs:disable Jetpack.PHPUnit.TestClassName.DoesNotMatchFileName
-// phpcs:disable Squiz.Strings.DoubleQuoteUsage.NotRequired, WordPress.Arrays.ArrayDeclarationSpacing, Universal.Arrays.DisallowShortArraySyntax, PHPCompatibility.Syntax.NewFlexibleHeredocNowdoc
+// phpcs:disable Squiz.Strings.DoubleQuoteUsage.NotRequired, WordPress.Arrays.ArrayDeclarationSpacing, Universal.Arrays.DisallowShortArraySyntax, PHPCompatibility.Syntax.NewFlexibleHeredocNowdoc, Generic.Strings.UnnecessaryHeredoc.Found
 
 
 use PHPUnit\Framework\Attributes\TestWith;

--- a/projects/packages/codesniffer/tests/php/integration/files/PhpunitAttributes_TestWith_Test.php.tolint
+++ b/projects/packages/codesniffer/tests/php/integration/files/PhpunitAttributes_TestWith_Test.php.tolint
@@ -3,7 +3,7 @@
 // phpcs:disable Squiz.Commenting.ClassComment.Missing, Squiz.Commenting.FunctionComment.Missing
 // phpcs:disable Generic.Files.OneObjectStructurePerFile.MultipleFound
 // phpcs:disable Jetpack.PHPUnit.TestClassName.DoesNotMatchFileName
-// phpcs:disable Squiz.Strings.DoubleQuoteUsage.NotRequired, WordPress.Arrays.ArrayDeclarationSpacing, Universal.Arrays.DisallowShortArraySyntax, PHPCompatibility.Syntax.NewFlexibleHeredocNowdoc
+// phpcs:disable Squiz.Strings.DoubleQuoteUsage.NotRequired, WordPress.Arrays.ArrayDeclarationSpacing, Universal.Arrays.DisallowShortArraySyntax, PHPCompatibility.Syntax.NewFlexibleHeredocNowdoc, Generic.Strings.UnnecessaryHeredoc.Found
 
 
 use PHPUnit\Framework\Attributes\TestWith;

--- a/projects/packages/codesniffer/tests/php/integration/files/mediawiki-imports.php.report
+++ b/projects/packages/codesniffer/tests/php/integration/files/mediawiki-imports.php.report
@@ -15,7 +15,7 @@
  58 | ERROR   | [ ] Found slow in_array( …, array_flip() ), should be array_key_exists() or isset() (MediaWiki.Usage.InArrayUsage.Found)
  65 | WARNING | [ ] Avoid use of __METHOD__ magic constant in closure (MediaWiki.Usage.MagicConstantClosure.FoundConstantMethod)
  65 | WARNING | [ ] Avoid use of __FUNCTION__ magic constant in closure (MediaWiki.Usage.MagicConstantClosure.FoundConstantFunction)
- 71 | ERROR   | [ ] Function nested is nested inside of another function or closure (MediaWiki.Usage.NestedFunctions.NestedFunction)
+ 71 | ERROR   | [ ] The use of inner functions is forbidden (Squiz.PHP.InnerFunctions.NotAllowed)
  75 | ERROR   | [ ] Use "." for string concat (MediaWiki.Usage.PlusStringConcat.Found)
  76 | ERROR   | [ ] Use ".=" for string concat (MediaWiki.Usage.PlusStringConcat.Found)
  79 | ERROR   | [ ] The ampersand in "&$this" must be removed. If you plan to get back another instance of this class, assign $this to a temporary variable. (MediaWiki.Usage.ReferenceThis.Found)

--- a/projects/packages/jetpack-mu-wpcom/changelog/update-codesniffer-rulesets
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-codesniffer-rulesets
@@ -1,5 +1,5 @@
 Significance: patch
 Type: changed
-Comment: Replace `MediaWiki.Usage.NestedFunctions` with `Squiz.PHP.InnerFunctions`.
+Comment: Replace `MediaWiki.Usage.NestedFunctions` with `Squiz.PHP.InnerFunctions`. Remove some where `Squiz.PHP.InnerFunctions` is ok with function→class→function.
 
 

--- a/projects/packages/jetpack-mu-wpcom/changelog/update-codesniffer-rulesets
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-codesniffer-rulesets
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Replace `MediaWiki.Usage.NestedFunctions` with `Squiz.PHP.InnerFunctions`.
+
+

--- a/projects/packages/jetpack-mu-wpcom/src/features/custom-css/custom-css.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/custom-css/custom-css.php
@@ -1228,7 +1228,7 @@ if ( ! function_exists( 'safecss_class' ) ) :
 			/**
 			 * Optimises $css after parsing.
 			 */
-			public function postparse() { // phpcs:ignore MediaWiki.Usage.NestedFunctions.NestedFunction
+			public function postparse() { // phpcs:ignore Squiz.PHP.InnerFunctions.NotAllowed
 
 				/** This action is documented in modules/custom-css/custom-css.php */
 				do_action( 'csstidy_optimize_postparse', $this );
@@ -1239,7 +1239,7 @@ if ( ! function_exists( 'safecss_class' ) ) :
 			/**
 			 * Optimises a sub-value.
 			 */
-			public function subvalue() { // phpcs:ignore MediaWiki.Usage.NestedFunctions.NestedFunction
+			public function subvalue() { // phpcs:ignore Squiz.PHP.InnerFunctions.NotAllowed
 
 				/** This action is documented in modules/custom-css/custom-css.php */
 				do_action( 'csstidy_optimize_subvalue', $this );

--- a/projects/packages/jetpack-mu-wpcom/src/features/custom-css/custom-css.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/custom-css/custom-css.php
@@ -1228,7 +1228,7 @@ if ( ! function_exists( 'safecss_class' ) ) :
 			/**
 			 * Optimises $css after parsing.
 			 */
-			public function postparse() { // phpcs:ignore Squiz.PHP.InnerFunctions.NotAllowed
+			public function postparse() {
 
 				/** This action is documented in modules/custom-css/custom-css.php */
 				do_action( 'csstidy_optimize_postparse', $this );
@@ -1239,7 +1239,7 @@ if ( ! function_exists( 'safecss_class' ) ) :
 			/**
 			 * Optimises a sub-value.
 			 */
-			public function subvalue() { // phpcs:ignore Squiz.PHP.InnerFunctions.NotAllowed
+			public function subvalue() {
 
 				/** This action is documented in modules/custom-css/custom-css.php */
 				do_action( 'csstidy_optimize_subvalue', $this );

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-plugins/wpcom-plugins.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-plugins/wpcom-plugins.php
@@ -31,7 +31,7 @@ function wpcom_plugins_show_banner() {
 	 * @param string $string The string to check.
 	 * @return bool True if the string has been translated, false otherwise.
 	 */
-	function should_use_new_translation( $string ) { // phpcs:ignore MediaWiki.Usage.NestedFunctions.NestedFunction
+	function should_use_new_translation( $string ) { // phpcs:ignore Squiz.PHP.InnerFunctions.NotAllowed
 		if ( function_exists( 'wpcom_launchpad_has_translation' ) ) {
 			return wpcom_launchpad_has_translation( $string, 'jetpack-mu-wpcom' );
 		}

--- a/projects/plugins/crm/.phpcs.dir.xml
+++ b/projects/plugins/crm/.phpcs.dir.xml
@@ -42,7 +42,10 @@
 	<!-- Custom JPCRM escape function -->
 	<rule ref="WordPress.Security.EscapeOutput">
 		<properties>
-			<property name="customAutoEscapedFunctions" type="array" value="jpcrm_esc_link,jpcrm_get_avatar"/>
+			<property name="customAutoEscapedFunctions" type="array">
+				<element value="jpcrm_esc_link"/>
+				<element value="jpcrm_get_avatar"/>
+			</property>
 		</properties>
 	</rule>
 </ruleset>

--- a/projects/plugins/crm/changelog/update-codesniffer-rulesets
+++ b/projects/plugins/crm/changelog/update-codesniffer-rulesets
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Remove deprecated syntax in .phpcs.dir.xml
+
+

--- a/projects/plugins/jetpack/changelog/update-codesniffer-rulesets
+++ b/projects/plugins/jetpack/changelog/update-codesniffer-rulesets
@@ -1,5 +1,5 @@
 Significance: patch
 Type: other
-Comment: Replace `MediaWiki.Usage.NestedFunctions` with `Squiz.PHP.InnerFunctions`.
+Comment: Replace `MediaWiki.Usage.NestedFunctions` with `Squiz.PHP.InnerFunctions`. Remove some where `Squiz.PHP.InnerFunctions` is ok with function→class→function.
 
 

--- a/projects/plugins/jetpack/changelog/update-codesniffer-rulesets
+++ b/projects/plugins/jetpack/changelog/update-codesniffer-rulesets
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Replace `MediaWiki.Usage.NestedFunctions` with `Squiz.PHP.InnerFunctions`.
+
+

--- a/projects/plugins/jetpack/modules/custom-post-types/testimonial.php
+++ b/projects/plugins/jetpack/modules/custom-post-types/testimonial.php
@@ -5,7 +5,6 @@
  * @package automattic/jetpack
  *
  * @phpcs:disable Generic.Files.OneObjectStructurePerFile.MultipleFound
- * @phpcs:disable Squiz.PHP.InnerFunctions.NotAllowed
  */
 
 // phpcs:disable Universal.Files.SeparateFunctionsFromOO.Mixed -- TODO: Move classes to appropriately-named class files.

--- a/projects/plugins/jetpack/modules/custom-post-types/testimonial.php
+++ b/projects/plugins/jetpack/modules/custom-post-types/testimonial.php
@@ -5,7 +5,7 @@
  * @package automattic/jetpack
  *
  * @phpcs:disable Generic.Files.OneObjectStructurePerFile.MultipleFound
- * @phpcs:disable MediaWiki.Usage.NestedFunctions.NestedFunction
+ * @phpcs:disable Squiz.PHP.InnerFunctions.NotAllowed
  */
 
 // phpcs:disable Universal.Files.SeparateFunctionsFromOO.Mixed -- TODO: Move classes to appropriately-named class files.

--- a/projects/plugins/jetpack/modules/theme-tools/content-options/customizer.php
+++ b/projects/plugins/jetpack/modules/theme-tools/content-options/customizer.php
@@ -75,7 +75,7 @@ if ( ! function_exists( 'jetpack_content_options_customize_register' ) ) {
 				/**
 				 * Render the control's content.
 				 */
-				public function render_content() { // phpcs:ignore Squiz.PHP.InnerFunctions.NotAllowed
+				public function render_content() {
 					?>
 					<span class="customize-control-title"><?php echo wp_kses_post( $this->label ); ?></span>
 					<?php

--- a/projects/plugins/jetpack/modules/theme-tools/content-options/customizer.php
+++ b/projects/plugins/jetpack/modules/theme-tools/content-options/customizer.php
@@ -75,7 +75,7 @@ if ( ! function_exists( 'jetpack_content_options_customize_register' ) ) {
 				/**
 				 * Render the control's content.
 				 */
-				public function render_content() { // phpcs:ignore MediaWiki.Usage.NestedFunctions.NestedFunction
+				public function render_content() { // phpcs:ignore Squiz.PHP.InnerFunctions.NotAllowed
 					?>
 					<span class="customize-control-title"><?php echo wp_kses_post( $this->label ); ?></span>
 					<?php

--- a/projects/plugins/jetpack/tests/php/modules/sitemaps/Jetpack_Sitemap_Manager_Test.php
+++ b/projects/plugins/jetpack/tests/php/modules/sitemaps/Jetpack_Sitemap_Manager_Test.php
@@ -68,7 +68,7 @@ class Jetpack_Sitemap_Manager_Test extends WP_UnitTestCase {
 		delete_option( 'jetpack_sitemap_location' );
 
 		// Set the location.
-		function add_location( $string ) { // phpcs:ignore MediaWiki.Usage.NestedFunctions.NestedFunction,Squiz.Commenting.FunctionComment.WrongStyle
+		function add_location( $string ) { // phpcs:ignore Squiz.PHP.InnerFunctions.NotAllowed,Squiz.Commenting.FunctionComment.WrongStyle
 			$string .= '/blah';
 			return $string;
 		}

--- a/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Functions_Test.php
+++ b/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Functions_Test.php
@@ -1310,7 +1310,7 @@ class Jetpack_Sync_Functions_Test extends Jetpack_Sync_TestBase {
 		 *
 		 * @return boolean
 		 */
-		function is_wpe() { // phpcs:ignore MediaWiki.Usage.NestedFunctions.NestedFunction
+		function is_wpe() { // phpcs:ignore Squiz.PHP.InnerFunctions.NotAllowed
 			return true;
 		}
 

--- a/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Post_Test.php
+++ b/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Post_Test.php
@@ -580,7 +580,7 @@ class Jetpack_Sync_Post_Test extends Jetpack_Sync_TestBase {
 		 * @phan-suppress PhanRedefineFunction
 		 * @todo Defining this function mid-test here seems risky. Is there a better way we can test this?
 		 */
-		function amp_get_permalink( $post_id ) { // phpcs:ignore MediaWiki.Usage.NestedFunctions.NestedFunction
+		function amp_get_permalink( $post_id ) { // phpcs:ignore Squiz.PHP.InnerFunctions.NotAllowed
 			return "http://example.com/?p=$post_id&amp";
 		}
 

--- a/projects/plugins/wpcomsh/changelog/update-codesniffer-rulesets
+++ b/projects/plugins/wpcomsh/changelog/update-codesniffer-rulesets
@@ -1,5 +1,5 @@
 Significance: patch
 Type: changed
-Comment: Replace `MediaWiki.Usage.NestedFunctions` with `Squiz.PHP.InnerFunctions`.
+Comment: Remove `MediaWiki.Usage.NestedFunctions`,  `Squiz.PHP.InnerFunctions` is ok with function→class→function.
 
 

--- a/projects/plugins/wpcomsh/changelog/update-codesniffer-rulesets
+++ b/projects/plugins/wpcomsh/changelog/update-codesniffer-rulesets
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Replace `MediaWiki.Usage.NestedFunctions` with `Squiz.PHP.InnerFunctions`.
+
+

--- a/projects/plugins/wpcomsh/footer-credit/footer-credit/customizer.php
+++ b/projects/plugins/wpcomsh/footer-credit/footer-credit/customizer.php
@@ -33,7 +33,7 @@ function footercredits_register( $wp_customize ) {
 		/**
 		 * Enqueue scripts and styles.
 		 */
-		public function enqueue() { // phpcs:ignore Squiz.PHP.InnerFunctions.NotAllowed
+		public function enqueue() {
 			if ( ! apply_filters( 'wpcom_better_footer_credit_can_customize', true ) ) {
 				wp_enqueue_script( 'footercredit-control', plugins_url( 'js/control.js', __FILE__ ), array( 'jquery' ), WPCOMSH_VERSION, true );
 				wp_enqueue_style( 'footercredit-control-styles', plugins_url( 'css/control.css', __FILE__ ), array(), WPCOMSH_VERSION );
@@ -43,7 +43,7 @@ function footercredits_register( $wp_customize ) {
 		/**
 		 * Render Footer Credits settings in Customizer.
 		 */
-		public function render_content() { // phpcs:ignore Squiz.PHP.InnerFunctions.NotAllowed
+		public function render_content() {
 			?>
 			<label>
 				<?php if ( ! empty( $this->label ) ) : ?>

--- a/projects/plugins/wpcomsh/footer-credit/footer-credit/customizer.php
+++ b/projects/plugins/wpcomsh/footer-credit/footer-credit/customizer.php
@@ -33,7 +33,7 @@ function footercredits_register( $wp_customize ) {
 		/**
 		 * Enqueue scripts and styles.
 		 */
-		public function enqueue() { // phpcs:ignore MediaWiki.Usage.NestedFunctions.NestedFunction
+		public function enqueue() { // phpcs:ignore Squiz.PHP.InnerFunctions.NotAllowed
 			if ( ! apply_filters( 'wpcom_better_footer_credit_can_customize', true ) ) {
 				wp_enqueue_script( 'footercredit-control', plugins_url( 'js/control.js', __FILE__ ), array( 'jquery' ), WPCOMSH_VERSION, true );
 				wp_enqueue_style( 'footercredit-control-styles', plugins_url( 'css/control.css', __FILE__ ), array(), WPCOMSH_VERSION );
@@ -43,7 +43,7 @@ function footercredits_register( $wp_customize ) {
 		/**
 		 * Render Footer Credits settings in Customizer.
 		 */
-		public function render_content() { // phpcs:ignore MediaWiki.Usage.NestedFunctions.NestedFunction
+		public function render_content() { // phpcs:ignore Squiz.PHP.InnerFunctions.NotAllowed
 			?>
 			<label>
 				<?php if ( ! empty( $this->label ) ) : ?>


### PR DESCRIPTION
Closes MONOREP-220

 <!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* squizlabs/php_codesniffer 3.12.2 → 3.13.2
* mediawiki/mediawiki-codesniffer 47.0.0 → 48.0.0
* phpcompatibility/phpcompatibility-wp 2.1.7 → 2.1.8
* phpcsstandards/phpcsextra 1.2.1 → 1.4.0
* phpcsstandards/phpcsutils 1.0.12 → 1.1.1
* wp-coding-standards/wpcs 3.1.0 → 3.2.0

mediawiki/mediawiki-codesniffer v48 drops support for PHP 8.0, so we do as well. We run it with a later version anyway (8.2, soon 8.4).

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* CI happy?
