### PR TITLE
Phan: Address PhanPossiblyUndeclaredVariable violations

### DIFF
--- a/projects/packages/analyzer/.phan/baseline.php
+++ b/projects/packages/analyzer/.phan/baseline.php
@@ -11,16 +11,13 @@ return [
     // # Issue statistics:
     // PhanUndeclaredProperty : 25+ occurrences
     // PhanTypeMismatchArgument : 8 occurrences
-    // PhanPossiblyUndeclaredVariable : 7 occurrences
     // PhanParamSignatureMismatch : 6 occurrences
     // PhanPluginDuplicateConditionalNullCoalescing : 6 occurrences
     // PhanTypeMismatchReturnProbablyReal : 6 occurrences
     // PhanUndeclaredClassMethod : 6 occurrences
     // PhanUndeclaredMethod : 6 occurrences
     // PhanTypeArraySuspiciousNullable : 5 occurrences
-    // PhanTypeMismatchArgumentNullable : 5 occurrences
     // PhanUndeclaredTypeParameter : 4 occurrences
-    // PhanNonClassMethodCall : 2 occurrences
     // PhanPluginDuplicateCatchStatementBody : 2 occurrences
     // PhanTypeMismatchDeclaredParam : 2 occurrences
     // PhanUndeclaredClassStaticProperty : 2 occurrences
@@ -49,7 +46,6 @@ return [
         'src/api/class-model.php' => ['PhanTypeArraySuspiciousNullable'],
         'src/api/class-plugin-downloader.php' => ['PhanPluginDuplicateExpressionAssignmentOperation'],
         'src/class-declarations.php' => ['PhanPluginDuplicateCatchStatementBody'],
-        'src/class-differences.php' => ['PhanNonClassMethodCall', 'PhanPossiblyUndeclaredVariable', 'PhanTypeMismatchArgumentNullable'],
         'src/class-invocations.php' => ['PhanPluginDuplicateCatchStatementBody'],
         'src/class-utils.php' => ['PhanTypeMismatchArgument', 'PhanUndeclaredMethod', 'PhanUndeclaredProperty', 'PhanUndeclaredTypeParameter'],
         'src/class-warnings.php' => ['PhanUndeclaredMethod'],

--- a/projects/packages/analyzer/changelog/fix-phan-PhanPossiblyUndeclaredVariable
+++ b/projects/packages/analyzer/changelog/fix-phan-PhanPossiblyUndeclaredVariable
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Phan: Address PhanPossiblyUndeclaredVariable violations.

--- a/projects/packages/analyzer/src/class-differences.php
+++ b/projects/packages/analyzer/src/class-differences.php
@@ -36,6 +36,7 @@ class Differences extends PersistentList {
 			$moved                 = false;
 			$moved_with_empty_file = false;
 			$deprecated            = false;
+			$new_declaration       = false;
 			foreach ( $new_declarations->get() as $new_declaration ) {
 
 				if ( $prev_declaration->match( $new_declaration ) ) {
@@ -69,7 +70,7 @@ class Differences extends PersistentList {
 			}
 
 			// Add differences for any detected deprecations.
-			if ( $deprecated ) {
+			if ( $deprecated && $new_declaration ) {
 				switch ( $new_declaration->type() ) {
 					case 'method':
 						$this->add( new Differences\Class_Method_Deprecated( $prev_declaration ) );
@@ -82,7 +83,7 @@ class Differences extends PersistentList {
 				}
 				$deprecated_total++;
 
-			} elseif ( $matched && $moved ) {
+			} elseif ( $matched && $moved && $new_declaration ) {
 				switch ( $prev_declaration->type() ) {
 					case 'class':
 						$this->add( new Differences\Class_Moved( $prev_declaration, $new_declaration ) );

--- a/projects/packages/analyzer/src/class-differences.php
+++ b/projects/packages/analyzer/src/class-differences.php
@@ -57,7 +57,7 @@ class Differences extends PersistentList {
 							$moved = true;
 						}
 					}
-					$matched = true;
+					$matched = $new_declaration;
 					break;
 				} elseif ( $prev_declaration->partial_match( $new_declaration ) ) {
 					// TODO this is to catch things like function args changed, method the same
@@ -70,7 +70,7 @@ class Differences extends PersistentList {
 			}
 
 			// Add differences for any detected deprecations.
-			if ( $deprecated && $new_declaration ) {
+			if ( $deprecated && $matched ) {
 				switch ( $new_declaration->type() ) {
 					case 'method':
 						$this->add( new Differences\Class_Method_Deprecated( $prev_declaration ) );
@@ -83,7 +83,7 @@ class Differences extends PersistentList {
 				}
 				$deprecated_total++;
 
-			} elseif ( $matched && $moved && $new_declaration ) {
+			} elseif ( $matched && $moved ) {
 				switch ( $prev_declaration->type() ) {
 					case 'class':
 						$this->add( new Differences\Class_Moved( $prev_declaration, $new_declaration ) );

--- a/projects/packages/backup/.phan/baseline.php
+++ b/projects/packages/backup/.phan/baseline.php
@@ -12,11 +12,10 @@ return [
     // PhanTypeMismatchReturnProbablyReal : 15+ occurrences
     // PhanTypeMismatchReturn : 6 occurrences
     // PhanUndeclaredStaticMethod : 2 occurrences
-    // PhanPossiblyUndeclaredVariable : 1 occurrence
 
     // Currently, file_suppressions and directory_suppressions are the only supported suppressions
     'file_suppressions' => [
-        'src/class-jetpack-backup.php' => ['PhanPossiblyUndeclaredVariable', 'PhanTypeMismatchReturn', 'PhanTypeMismatchReturnProbablyReal', 'PhanUndeclaredStaticMethod'],
+        'src/class-jetpack-backup.php' => ['PhanTypeMismatchReturn', 'PhanTypeMismatchReturnProbablyReal', 'PhanUndeclaredStaticMethod'],
         'src/class-rest-controller.php' => ['PhanTypeMismatchReturn', 'PhanTypeMismatchReturnProbablyReal'],
     ],
     // 'directory_suppressions' => ['src/directory_name' => ['PhanIssueName1', 'PhanIssueName2']] can be manually added if needed.

--- a/projects/packages/backup/changelog/fix-phan-PhanPossiblyUndeclaredVariable
+++ b/projects/packages/backup/changelog/fix-phan-PhanPossiblyUndeclaredVariable
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Phan: Address PhanPossiblyUndeclaredVariable violations.

--- a/projects/packages/backup/src/class-jetpack-backup.php
+++ b/projects/packages/backup/src/class-jetpack-backup.php
@@ -717,15 +717,12 @@ class Jetpack_Backup {
 				return $upsell_products[ $bytes_1tb ];
 			}
 
+			$matched_bytes = $bytes_10gb;
 			foreach ( $upsell_products as $bytes => $product ) {
 				if ( $bytes > $additional_bytes_needed ) {
 					$matched_bytes = $bytes;
 					break;
 				}
-			}
-
-			if ( ! $matched_bytes ) {
-				$matched_bytes = $bytes_10gb;
 			}
 
 			return $upsell_products[ $matched_bytes ];

--- a/projects/packages/connection/.phan/baseline.php
+++ b/projects/packages/connection/.phan/baseline.php
@@ -21,14 +21,13 @@ return [
     // PhanDeprecatedFunction : 2 occurrences
     // PhanNonClassMethodCall : 2 occurrences
     // PhanPluginUnreachableCode : 2 occurrences
-    // PhanPossiblyUndeclaredVariable : 2 occurrences
     // PhanTypeMismatchPropertyDefault : 2 occurrences
-    // PhanTypeMismatchReturnNullable : 2 occurrences
     // PhanTypePossiblyInvalidDimOffset : 2 occurrences
     // PhanPluginDuplicateAdjacentStatement : 1 occurrence
     // PhanPluginSimplifyExpressionBool : 1 occurrence
     // PhanTypeMismatchArgumentNullable : 1 occurrence
     // PhanTypeMismatchDeclaredParamNullable : 1 occurrence
+    // PhanTypeMismatchReturnNullable : 1 occurrence
     // PhanUndeclaredClassMethod : 1 occurrence
 
     // Currently, file_suppressions and directory_suppressions are the only supported suppressions
@@ -40,7 +39,6 @@ return [
         'src/class-error-handler.php' => ['PhanTypeMismatchReturnProbablyReal'],
         'src/class-heartbeat.php' => ['PhanTypeMismatchPropertyDefault'],
         'src/class-manager.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchArgument', 'PhanTypeMismatchDeclaredParamNullable', 'PhanTypeMismatchDefault', 'PhanTypeMismatchPropertyProbablyReal', 'PhanTypeMismatchReturn', 'PhanTypeMismatchReturnNullable', 'PhanTypeMismatchReturnProbablyReal'],
-        'src/class-nonce-handler.php' => ['PhanPossiblyUndeclaredVariable', 'PhanTypeMismatchReturnNullable'],
         'src/class-partner-coupon.php' => ['PhanPluginDuplicateConditionalNullCoalescing'],
         'src/class-partner.php' => ['PhanTypeMismatchPropertyProbablyReal'],
         'src/class-rest-authentication.php' => ['PhanTypeMismatchPropertyDefault', 'PhanTypeMismatchPropertyProbablyReal'],

--- a/projects/packages/connection/changelog/fix-phan-PhanPossiblyUndeclaredVariable
+++ b/projects/packages/connection/changelog/fix-phan-PhanPossiblyUndeclaredVariable
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Phan: Address PhanPossiblyUndeclaredVariable violations.

--- a/projects/packages/connection/src/class-nonce-handler.php
+++ b/projects/packages/connection/src/class-nonce-handler.php
@@ -107,8 +107,6 @@ class Nonce_Handler {
 						'no'
 					)
 				);
-			} else {
-				$return = false;
 			}
 		} finally {
 			$this->db->show_errors( $show_errors );

--- a/projects/packages/connection/src/class-nonce-handler.php
+++ b/projects/packages/connection/src/class-nonce-handler.php
@@ -90,6 +90,8 @@ class Nonce_Handler {
 		// Raw query so we can avoid races: add_option will also update.
 		$show_errors = $this->db->hide_errors();
 
+		$return = false;
+
 		// Running `try...finally` to make sure that we re-enable errors in case of an exception.
 		try {
 			$old_nonce = $this->db->get_row(

--- a/projects/packages/image-cdn/.phan/baseline.php
+++ b/projects/packages/image-cdn/.phan/baseline.php
@@ -13,11 +13,9 @@ return [
     // PhanPluginSimplifyExpressionBool : 6 occurrences
     // PhanPluginDuplicateConditionalNullCoalescing : 4 occurrences
     // PhanTypeMismatchArgumentProbablyReal : 4 occurrences
-    // PhanPossiblyUndeclaredVariable : 2 occurrences
     // PhanTypeMismatchPropertyProbablyReal : 2 occurrences
     // PhanNonClassMethodCall : 1 occurrence
     // PhanTypeArraySuspicious : 1 occurrence
-    // PhanTypeMismatchArgumentNullable : 1 occurrence
     // PhanTypeMismatchArgumentNullableInternal : 1 occurrence
     // PhanTypeMismatchReturn : 1 occurrence
     // PhanTypeMismatchReturnProbablyReal : 1 occurrence
@@ -28,10 +26,10 @@ return [
     // Currently, file_suppressions and directory_suppressions are the only supported suppressions
     'file_suppressions' => [
         'src/class-image-cdn-image-sizes.php' => ['PhanPluginSimplifyExpressionBool'],
-        'src/class-image-cdn.php' => ['PhanNonClassMethodCall', 'PhanPluginDuplicateConditionalNullCoalescing', 'PhanPluginSimplifyExpressionBool', 'PhanPossiblyUndeclaredVariable', 'PhanTypeArraySuspicious', 'PhanTypeMismatchPropertyProbablyReal', 'PhanTypeMismatchReturn', 'PhanTypeMismatchReturnProbablyReal', 'PhanTypePossiblyInvalidDimOffset'],
+        'src/class-image-cdn.php' => ['PhanNonClassMethodCall', 'PhanPluginDuplicateConditionalNullCoalescing', 'PhanPluginSimplifyExpressionBool', 'PhanTypeArraySuspicious', 'PhanTypeMismatchPropertyProbablyReal', 'PhanTypeMismatchReturn', 'PhanTypeMismatchReturnProbablyReal', 'PhanTypePossiblyInvalidDimOffset'],
         'src/compatibility/photon.php' => ['PhanTypeMismatchArgumentNullableInternal'],
         'tests/php/Image_CDN_Core_Test.php' => ['PhanTypeMismatchArgumentProbablyReal', 'PhanTypeObjectUnsetDeclaredProperty'],
-        'tests/php/Image_CDN_Test.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanPossiblyUndeclaredVariable', 'PhanTypeMismatchArgumentNullable', 'PhanTypeMismatchPropertyProbablyReal', 'PhanUndeclaredMethod', 'PhanUndeclaredStaticMethod'],
+        'tests/php/Image_CDN_Test.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchPropertyProbablyReal', 'PhanUndeclaredMethod', 'PhanUndeclaredStaticMethod'],
     ],
     // 'directory_suppressions' => ['src/directory_name' => ['PhanIssueName1', 'PhanIssueName2']] can be manually added if needed.
     // (directory_suppressions will currently be ignored by subsequent calls to --save-baseline, but may be preserved in future Phan releases)

--- a/projects/packages/image-cdn/changelog/fix-phan-PhanPossiblyUndeclaredVariable
+++ b/projects/packages/image-cdn/changelog/fix-phan-PhanPossiblyUndeclaredVariable
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Phan: Address PhanPossiblyUndeclaredVariable violations.

--- a/projects/packages/image-cdn/src/class-image-cdn.php
+++ b/projects/packages/image-cdn/src/class-image-cdn.php
@@ -363,8 +363,10 @@ final class Image_CDN {
 			}
 
 			// Identify image source.
-			$src_orig = $processor->get_attribute( 'src' );
-			$src      = $src_orig;
+			$src_orig             = $processor->get_attribute( 'src' );
+			$src                  = $src_orig;
+			$placeholder_src      = null;
+			$placeholder_src_orig = null;
 
 			/*
 			 * Only examine tags that are considered an image,
@@ -648,14 +650,12 @@ final class Image_CDN {
 					$processor->set_attribute( 'src', $photon_url );
 
 					// If Lazy Load is in use, pass placeholder image through Photon.
-					if ( isset( $placeholder_src ) && self::validate_image_url( $placeholder_src ) ) {
+					if ( $placeholder_src !== null && self::validate_image_url( $placeholder_src ) ) {
 						$placeholder_src = Image_CDN_Core::cdn_url( $placeholder_src );
 
-						if ( isset( $placeholder_src_orig ) && $placeholder_src !== $placeholder_src_orig ) {
+						if ( $placeholder_src !== $placeholder_src_orig ) {
 							$processor->set_attribute( $source_type, $placeholder_src );
 						}
-
-						unset( $placeholder_src );
 					}
 
 					// If we are not transforming the image with resize, fit, or letterbox (lb), then we should remove

--- a/projects/packages/image-cdn/src/class-image-cdn.php
+++ b/projects/packages/image-cdn/src/class-image-cdn.php
@@ -651,7 +651,7 @@ final class Image_CDN {
 					if ( isset( $placeholder_src ) && self::validate_image_url( $placeholder_src ) ) {
 						$placeholder_src = Image_CDN_Core::cdn_url( $placeholder_src );
 
-						if ( $placeholder_src !== $placeholder_src_orig ) {
+						if ( isset( $placeholder_src_orig ) && $placeholder_src !== $placeholder_src_orig ) {
 							$processor->set_attribute( $source_type, $placeholder_src );
 						}
 

--- a/projects/packages/image-cdn/tests/php/Image_CDN_Test.php
+++ b/projects/packages/image-cdn/tests/php/Image_CDN_Test.php
@@ -143,10 +143,10 @@ class Image_CDN_Test extends Image_CDN_Attachment_TestCase {
 	 * @return int Post ID (attachment) of the image.
 	 */
 	protected function helper_get_image( $size = 'large', $meta = true ) {
-		if ( 'large' === $size ) { // 1600x1200
-			$filename = __DIR__ . '/sample-content/test-image-large.png';
-		} elseif ( 'medium' === $size ) { // 1024x768
+		if ( 'medium' === $size ) { // 1024x768
 			$filename = __DIR__ . '/sample-content/test-image-medium.png';
+		} else { // 1600x1200 - default to 'large'
+			$filename = __DIR__ . '/sample-content/test-image-large.png';
 		}
 		// Add sizes that exist before uploading the file.
 		add_image_size( 'jetpack_soft_defined', 700, 500, false ); // Intentionally not a 1.33333 ratio.

--- a/projects/packages/publicize/.phan/baseline.php
+++ b/projects/packages/publicize/.phan/baseline.php
@@ -14,7 +14,6 @@ return [
     // PhanPluginUnreachableCode : 4 occurrences
     // PhanTypeMismatchArgument : 3 occurrences
     // PhanUndeclaredClassMethod : 3 occurrences
-    // PhanPossiblyUndeclaredVariable : 2 occurrences
     // PhanTypeMismatchArgumentNullable : 2 occurrences
     // PhanTypeMismatchReturnProbablyReal : 2 occurrences
     // PhanTypeMissingReturn : 2 occurrences
@@ -35,7 +34,7 @@ return [
         'src/class-keyring-helper.php' => ['PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchDefault'],
         'src/class-publicize-base.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanPluginSimplifyExpressionBool', 'PhanSuspiciousMagicConstant', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentNullable', 'PhanTypeMismatchArgumentNullableInternal', 'PhanTypeMismatchDimFetch'],
         'src/class-publicize-ui.php' => ['PhanPluginDuplicateExpressionAssignmentOperation', 'PhanTypeMismatchReturnProbablyReal'],
-        'src/class-publicize.php' => ['PhanParamSignatureMismatch', 'PhanPossiblyUndeclaredVariable', 'PhanTypeMismatchArgument', 'PhanTypeMissingReturn'],
+        'src/class-publicize.php' => ['PhanParamSignatureMismatch', 'PhanTypeMismatchArgument', 'PhanTypeMissingReturn'],
         'src/class-rest-controller.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchReturnProbablyReal'],
         'src/rest-api/class-connections-controller.php' => ['PhanPluginMixedKeyNoKey', 'PhanTypeSuspiciousNonTraversableForeach'],
         'src/rest-api/class-connections-post-field.php' => ['PhanPluginDuplicateConditionalNullCoalescing'],

--- a/projects/packages/publicize/changelog/fix-phan-PhanPossiblyUndeclaredVariable
+++ b/projects/packages/publicize/changelog/fix-phan-PhanPossiblyUndeclaredVariable
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Phan: Address PhanPossiblyUndeclaredVariable violations.

--- a/projects/packages/publicize/src/class-publicize.php
+++ b/projects/packages/publicize/src/class-publicize.php
@@ -653,8 +653,8 @@ class Publicize extends Publicize_Base {
 
 		$error_data = array(
 			'user_can_refresh' => $user_can_refresh,
-			'refresh_text'     => $refresh_text,
-			'refresh_url'      => $refresh_url,
+			'refresh_text'     => $refresh_text ?? '',
+			'refresh_url'      => $refresh_url ?? '',
 		);
 
 		$this->test_connection_results[ $id ] = new WP_Error( $connection_error_code, $connection_test_message, $error_data );

--- a/projects/packages/publicize/src/class-publicize.php
+++ b/projects/packages/publicize/src/class-publicize.php
@@ -653,8 +653,8 @@ class Publicize extends Publicize_Base {
 
 		$error_data = array(
 			'user_can_refresh' => $user_can_refresh,
-			'refresh_text'     => $refresh_text ?? '',
-			'refresh_url'      => $refresh_url ?? '',
+			'refresh_text'     => $refresh_text ?? null,
+			'refresh_url'      => $refresh_url ?? null,
 		);
 
 		$this->test_connection_results[ $id ] = new WP_Error( $connection_error_code, $connection_test_message, $error_data );

--- a/projects/packages/search/.phan/baseline.php
+++ b/projects/packages/search/.phan/baseline.php
@@ -20,7 +20,6 @@ return [
     // PhanImpossibleCondition : 2 occurrences
     // PhanDeprecatedPartiallySupportedCallable : 1 occurrence
     // PhanPluginSimplifyExpressionBool : 1 occurrence
-    // PhanPossiblyUndeclaredVariable : 1 occurrence
     // PhanTypeInvalidDimOffset : 1 occurrence
     // PhanTypeMismatchDeclaredParamNullable : 1 occurrence
     // PhanTypeMismatchDefault : 1 occurrence
@@ -38,7 +37,7 @@ return [
         'src/classic-search/class-classic-search.php' => ['PhanTypeInvalidDimOffset', 'PhanTypeMismatchDeclaredParamNullable', 'PhanTypeMismatchProperty', 'PhanTypeMismatchReturn', 'PhanTypePossiblyInvalidDimOffset'],
         'src/customizer/customize-controls/class-excluded-post-types-control.php' => ['PhanTypeMismatchReturnProbablyReal'],
         'src/instant-search/class-instant-search.php' => ['PhanTypeMismatchProperty', 'PhanTypeMismatchReturn', 'PhanTypeMismatchReturnProbablyReal'],
-        'src/widgets/class-search-widget.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanPossiblyUndeclaredVariable', 'PhanTypeMismatchArgument'],
+        'src/widgets/class-search-widget.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchArgument'],
         'src/wpes/class-query-builder.php' => ['PhanImpossibleCondition', 'PhanTypeMismatchDimAssignment', 'PhanTypeMismatchReturnProbablyReal'],
         'tests/php/Helpers_Test.php' => ['PhanPluginMixedKeyNoKey', 'PhanTypeMismatchArgument'],
         'tests/php/Plan_Test.php' => ['PhanDeprecatedFunction', 'PhanTypeMismatchArgumentProbablyReal'],

--- a/projects/packages/search/changelog/fix-phan-PhanPossiblyUndeclaredVariable
+++ b/projects/packages/search/changelog/fix-phan-PhanPossiblyUndeclaredVariable
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Phan: Address PhanPossiblyUndeclaredVariable violations.

--- a/projects/packages/search/src/widgets/class-search-widget.php
+++ b/projects/packages/search/src/widgets/class-search-widget.php
@@ -341,7 +341,7 @@ class Search_Widget extends \WP_Widget {
 			}
 		}
 
-		if ( empty( $filters ) && empty( $instance['search_box_enabled'] ) && empty( $instance['user_sort_enabled'] ) ) {
+		if ( ! $filters && empty( $instance['search_box_enabled'] ) && empty( $instance['user_sort_enabled'] ) ) {
 			return;
 		}
 
@@ -396,7 +396,7 @@ class Search_Widget extends \WP_Widget {
 			<?php
 		endif;
 
-		if ( ! empty( $filters ) ) {
+		if ( $filters ) {
 			/**
 			 * Responsible for rendering filters to narrow down search results.
 			 *
@@ -467,7 +467,7 @@ class Search_Widget extends \WP_Widget {
 
 		Template_Tags::render_widget_search_form( array(), '', '' );
 
-		if ( ! empty( $filters ) ) {
+		if ( $filters ) {
 			/**
 			 * Responsible for rendering filters to narrow down search results.
 			 *

--- a/projects/packages/search/src/widgets/class-search-widget.php
+++ b/projects/packages/search/src/widgets/class-search-widget.php
@@ -325,8 +325,7 @@ class Search_Widget extends \WP_Widget {
 	 * @since 8.3.0
 	 */
 	public function widget_non_instant( $args, $instance ) {
-		$filters         = array();
-		$display_filters = false;
+		$filters = array();
 
 		// Search instance must have been initialized before widget render.
 		if ( is_search() ) {
@@ -340,13 +339,9 @@ class Search_Widget extends \WP_Widget {
 			if ( ! Helper::are_filters_by_widget_disabled() && ! $this->should_display_sitewide_filters() ) {
 				$filters = array_filter( $filters, array( $this, 'is_for_current_widget' ) );
 			}
-
-			if ( ! empty( $filters ) ) {
-				$display_filters = true;
-			}
 		}
 
-		if ( ! $display_filters && empty( $instance['search_box_enabled'] ) && empty( $instance['user_sort_enabled'] ) ) {
+		if ( empty( $filters ) && empty( $instance['search_box_enabled'] ) && empty( $instance['user_sort_enabled'] ) ) {
 			return;
 		}
 
@@ -401,7 +396,7 @@ class Search_Widget extends \WP_Widget {
 			<?php
 		endif;
 
-		if ( $display_filters ) {
+		if ( ! empty( $filters ) ) {
 			/**
 			 * Responsible for rendering filters to narrow down search results.
 			 *
@@ -446,8 +441,6 @@ class Search_Widget extends \WP_Widget {
 			$filters = array_filter( $filters, array( $this, 'is_for_current_widget' ) );
 		}
 
-		$display_filters = ! empty( $filters );
-
 		$title = ! empty( $instance['title'] ) ? $instance['title'] : '';
 
 		/** This filter is documented in core/src/wp-includes/default-widgets.php */
@@ -474,7 +467,7 @@ class Search_Widget extends \WP_Widget {
 
 		Template_Tags::render_widget_search_form( array(), '', '' );
 
-		if ( $display_filters ) {
+		if ( ! empty( $filters ) ) {
 			/**
 			 * Responsible for rendering filters to narrow down search results.
 			 *

--- a/projects/packages/search/src/widgets/class-search-widget.php
+++ b/projects/packages/search/src/widgets/class-search-widget.php
@@ -325,6 +325,7 @@ class Search_Widget extends \WP_Widget {
 	 * @since 8.3.0
 	 */
 	public function widget_non_instant( $args, $instance ) {
+		$filters         = array();
 		$display_filters = false;
 
 		// Search instance must have been initialized before widget render.

--- a/projects/packages/sync/.phan/baseline.php
+++ b/projects/packages/sync/.phan/baseline.php
@@ -11,13 +11,12 @@ return [
     // # Issue statistics:
     // PhanTypeMismatchArgument : 40+ occurrences
     // PhanPluginDuplicateConditionalNullCoalescing : 30+ occurrences
-    // PhanTypeMismatchReturnProbablyReal : 30+ occurrences
+    // PhanTypeMismatchReturnProbablyReal : 25+ occurrences
     // PhanTypeMismatchReturn : 20+ occurrences
     // PhanParamSignatureMismatch : 10+ occurrences
     // PhanTypeMismatchArgumentProbablyReal : 10+ occurrences
     // PhanPluginSimplifyExpressionBool : 9 occurrences
     // PhanPluginDuplicateSwitchCaseLooseEquality : 6 occurrences
-    // PhanPossiblyUndeclaredVariable : 4 occurrences
     // PhanTypeExpectedObjectPropAccess : 4 occurrences
     // PhanNonClassMethodCall : 3 occurrences
     // PhanTypeArraySuspiciousNullable : 3 occurrences
@@ -50,13 +49,13 @@ return [
         'src/class-rest-sender.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchArgumentProbablyReal'],
         'src/class-sender.php' => ['PhanNonClassMethodCall', 'PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchProperty', 'PhanTypeMismatchReturnProbablyReal'],
         'src/class-server.php' => ['PhanTypeMismatchDeclaredParam', 'PhanTypeMismatchReturnProbablyReal'],
-        'src/class-settings.php' => ['PhanPossiblyUndeclaredVariable', 'PhanTypeMismatchArgumentProbablyReal'],
+        'src/class-settings.php' => ['PhanTypeMismatchArgumentProbablyReal'],
         'src/class-utils.php' => ['PhanTypeExpectedObjectPropAccess'],
         'src/modules/class-callables.php' => ['PhanParamSignatureMismatch', 'PhanTypeArraySuspicious', 'PhanTypeMismatchArgument'],
         'src/modules/class-comments.php' => ['PhanTypeMismatchReturn', 'PhanTypeMismatchReturnProbablyReal'],
         'src/modules/class-constants.php' => ['PhanParamSignatureMismatch'],
         'src/modules/class-full-sync-immediately.php' => ['PhanPluginSimplifyExpressionBool', 'PhanTypeMismatchReturn'],
-        'src/modules/class-full-sync.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanPluginSimplifyExpressionBool', 'PhanPossiblyUndeclaredVariable'],
+        'src/modules/class-full-sync.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanPluginSimplifyExpressionBool'],
         'src/modules/class-module.php' => ['PhanTypeMismatchArgument', 'PhanTypeMismatchReturnProbablyReal'],
         'src/modules/class-network-options.php' => ['PhanParamSignatureMismatch'],
         'src/modules/class-options.php' => ['PhanParamSignatureMismatch', 'PhanTypeMismatchReturnProbablyReal'],

--- a/projects/packages/sync/changelog/fix-phan-PhanPossiblyUndeclaredVariable
+++ b/projects/packages/sync/changelog/fix-phan-PhanPossiblyUndeclaredVariable
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Phan: Address PhanPossiblyUndeclaredVariable violations.

--- a/projects/packages/sync/src/class-settings.php
+++ b/projects/packages/sync/src/class-settings.php
@@ -283,6 +283,7 @@ class Settings {
 			/**
 			 * Regular option update and handling
 			 */
+			$updated = false;
 			if ( self::is_network_setting( $setting ) ) {
 				if ( is_multisite() && is_main_site() ) {
 					$updated = update_site_option( self::SETTINGS_OPTION_PREFIX . $setting, $value );

--- a/projects/packages/sync/src/modules/class-full-sync.php
+++ b/projects/packages/sync/src/modules/class-full-sync.php
@@ -340,6 +340,10 @@ class Full_Sync extends Module {
 				$id        = 'comment_ID';
 				$where_sql = Settings::get_comments_filter_sql();
 				break;
+			default:
+				// This should never be reached due to the guard condition above,
+				// but Phan complains so let's make it happy.
+				return array();
 		}
 
 		// TODO: Call $wpdb->prepare on the following query.

--- a/projects/packages/videopress/.phan/baseline.php
+++ b/projects/packages/videopress/.phan/baseline.php
@@ -19,7 +19,6 @@ return [
     // PhanNonClassMethodCall : 4 occurrences
     // PhanTypeArraySuspiciousNullable : 4 occurrences
     // PhanTypeMismatchArgument : 4 occurrences
-    // PhanPossiblyUndeclaredVariable : 2 occurrences
     // PhanTypeInvalidDimOffset : 2 occurrences
     // PhanUndeclaredExtendedClass : 2 occurrences
     // PhanUndeclaredMethod : 2 occurrences
@@ -53,7 +52,7 @@ return [
         'src/videopress-divi/class-videopress-divi-extension.php' => ['PhanCommentOverrideOnNonOverrideMethod', 'PhanUndeclaredClass', 'PhanUndeclaredClassMethod', 'PhanUndeclaredExtendedClass', 'PhanUndeclaredMethod', 'PhanUndeclaredMethodInCallable'],
         'src/videopress-divi/class-videopress-divi-module.php' => ['PhanUndeclaredExtendedClass'],
         'tests/php/Uploader_Test.php' => ['PhanTypeMismatchArgumentProbablyReal'],
-        'tests/php/VideoPress_Uploader_Test.php' => ['PhanPossiblyUndeclaredVariable', 'PhanTypeMismatchArgument'],
+        'tests/php/VideoPress_Uploader_Test.php' => ['PhanTypeMismatchArgument'],
     ],
     // 'directory_suppressions' => ['src/directory_name' => ['PhanIssueName1', 'PhanIssueName2']] can be manually added if needed.
     // (directory_suppressions will currently be ignored by subsequent calls to --save-baseline, but may be preserved in future Phan releases)

--- a/projects/packages/videopress/changelog/fix-phan-PhanPossiblyUndeclaredVariable
+++ b/projects/packages/videopress/changelog/fix-phan-PhanPossiblyUndeclaredVariable
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Phan: Address PhanPossiblyUndeclaredVariable violations.

--- a/projects/packages/videopress/tests/php/VideoPress_Uploader_Test.php
+++ b/projects/packages/videopress/tests/php/VideoPress_Uploader_Test.php
@@ -172,8 +172,10 @@ class VideoPress_Uploader_Test extends BaseTestCase {
 			$callback = array( $this, 'return_valid_response' );
 		} elseif ( 'empty' === $response_from_server ) {
 			$callback = array( $this, 'return_empty_response' );
-		} else {
+		} elseif ( 'error' === $response_from_server ) {
 			$callback = array( $this, 'return_wp_error' );
+		} else {
+			$this->fail( "Unsupported response '$response_from_server'" );
 		}
 		$u = new Uploader( $this->valid_attachment_id );
 		if ( $throw ) {

--- a/projects/packages/videopress/tests/php/VideoPress_Uploader_Test.php
+++ b/projects/packages/videopress/tests/php/VideoPress_Uploader_Test.php
@@ -172,7 +172,7 @@ class VideoPress_Uploader_Test extends BaseTestCase {
 			$callback = array( $this, 'return_valid_response' );
 		} elseif ( 'empty' === $response_from_server ) {
 			$callback = array( $this, 'return_empty_response' );
-		} elseif ( 'error' === $response_from_server ) {
+		} else {
 			$callback = array( $this, 'return_wp_error' );
 		}
 		$u = new Uploader( $this->valid_attachment_id );

--- a/projects/plugins/boost/.phan/baseline.php
+++ b/projects/plugins/boost/.phan/baseline.php
@@ -18,12 +18,10 @@ return [
     // PhanUndeclaredClassConstant : 4 occurrences
     // PhanUndeclaredFunction : 4 occurrences
     // PhanPluginUseReturnValueInternalKnown : 2 occurrences
-    // PhanPossiblyUndeclaredVariable : 2 occurrences
-    // PhanTypeMismatchArgumentNullableInternal : 2 occurrences
     // PhanTypeMismatchPropertyDefault : 2 occurrences
     // PhanCoalescingNeverNull : 1 occurrence
     // PhanRedefineFunction : 1 occurrence
-    // PhanTypeInvalidUnaryOperandIncOrDec : 1 occurrence
+    // PhanTypeMismatchArgumentNullableInternal : 1 occurrence
     // PhanTypeMismatchProperty : 1 occurrence
     // PhanTypeMissingReturn : 1 occurrence
     // PhanUndeclaredClassMethod : 1 occurrence
@@ -37,7 +35,7 @@ return [
         'app/lib/class-cli.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchArgument'],
         'app/lib/critical-css/class-critical-css-state.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeArraySuspiciousNullable'],
         'app/lib/minify/class-concatenate-css.php' => ['PhanPluginUseReturnValueInternalKnown', 'PhanTypeMismatchArgument'],
-        'app/lib/minify/class-concatenate-js.php' => ['PhanPluginUseReturnValueInternalKnown', 'PhanPossiblyUndeclaredVariable', 'PhanTypeInvalidUnaryOperandIncOrDec', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentNullableInternal'],
+        'app/lib/minify/class-concatenate-js.php' => ['PhanPluginUseReturnValueInternalKnown', 'PhanTypeMismatchArgument'],
         'app/lib/minify/class-dependency-path-mapping.php' => ['PhanUndeclaredConstant'],
         'app/lib/minify/functions-helpers.php' => ['PhanTypeMismatchArgumentNullableInternal', 'PhanUndeclaredClassMethod', 'PhanUndeclaredClassReference', 'PhanUndeclaredConstant'],
         'app/modules/image-guide/class-image-guide-proxy.php' => ['PhanPluginDuplicateConditionalNullCoalescing'],

--- a/projects/plugins/boost/app/lib/minify/class-concatenate-js.php
+++ b/projects/plugins/boost/app/lib/minify/class-concatenate-js.php
@@ -83,6 +83,7 @@ class Concatenate_JS extends WP_Scripts {
 		$level = 0;
 
 		$using_strict = false;
+		$strict_count = 0;
 		foreach ( $this->to_do as $key => $handle ) {
 			$script_is_strict = false;
 			if ( in_array( $handle, $this->done, true ) || ! isset( $this->registered[ $handle ] ) ) {
@@ -140,6 +141,7 @@ class Concatenate_JS extends WP_Scripts {
 				$do_concat = false;
 			}
 
+			$js_realpath = false;
 			if ( $do_concat ) {
 				// Resolve paths and concat scripts that exist in the filesystem
 				$js_realpath = $this->dependency_path_mapping->dependency_src_to_fs_path( $js_url );

--- a/projects/plugins/boost/changelog/fix-phan-PhanPossiblyUndeclaredVariable
+++ b/projects/plugins/boost/changelog/fix-phan-PhanPossiblyUndeclaredVariable
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Phan: Address PhanPossiblyUndeclaredVariable violations.

--- a/projects/plugins/jetpack/.phan/baseline.php
+++ b/projects/plugins/jetpack/.phan/baseline.php
@@ -16,10 +16,8 @@ return [
     // PhanTypeMismatchReturnProbablyReal : 120+ occurrences
     // PhanTypePossiblyInvalidDimOffset : 90+ occurrences
     // PhanDeprecatedFunction : 60+ occurrences
-    // PhanPossiblyUndeclaredVariable : 55+ occurrences
     // PhanTypeArraySuspiciousNullable : 55+ occurrences
     // PhanRedefineFunction : 45+ occurrences
-    // PhanTypeMismatchArgumentNullable : 45+ occurrences
     // PhanPluginDuplicateAdjacentStatement : 40+ occurrences
     // PhanTypeExpectedObjectPropAccess : 30+ occurrences
     // PhanTypeMismatchDefault : 25+ occurrences
@@ -30,6 +28,7 @@ return [
     // PhanTypeArraySuspicious : 20+ occurrences
     // PhanTypeMismatchDimFetch : 20+ occurrences
     // PhanSuspiciousMagicConstant : 15+ occurrences
+    // PhanTypeMismatchArgumentNullable : 15+ occurrences
     // PhanTypeMismatchPropertyDefault : 15+ occurrences
     // PhanTypeSuspiciousNonTraversableForeach : 15+ occurrences
     // PhanPluginDuplicateExpressionAssignmentOperation : 10+ occurrences
@@ -48,6 +47,7 @@ return [
     // PhanCommentAbstractOnInheritedMethod : 6 occurrences
     // PhanTypeInvalidLeftOperandOfNumericOp : 6 occurrences
     // PhanDeprecatedClass : 5 occurrences
+    // PhanPossiblyUndeclaredVariable : 5 occurrences
     // PhanTypeMismatchDimAssignment : 5 occurrences
     // PhanTypeInvalidDimOffset : 4 occurrences
     // PhanTypeInvalidLeftOperandOfAdd : 4 occurrences
@@ -125,7 +125,7 @@ return [
         '_inc/lib/core-api/wpcom-endpoints/service-api-keys.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeArraySuspicious', 'PhanTypeMismatchReturnProbablyReal'],
         '_inc/lib/debugger/class-jetpack-cxn-test-base.php' => ['PhanDeprecatedFunctionInternal', 'PhanTypeArraySuspiciousNullable', 'PhanTypeMismatchArgumentInternal', 'PhanTypeMismatchReturn'],
         '_inc/lib/debugger/class-jetpack-cxn-tests.php' => ['PhanPluginSimplifyExpressionBool'],
-        '_inc/lib/debugger/class-jetpack-debug-data.php' => ['PhanPossiblyUndeclaredVariable', 'PhanTypeMismatchArgument'],
+        '_inc/lib/debugger/class-jetpack-debug-data.php' => ['PhanTypeMismatchArgument'],
         '_inc/lib/debugger/class-jetpack-debugger.php' => ['PhanTypeMismatchArgumentProbablyReal'],
         '_inc/lib/debugger/debug-functions.php' => ['PhanTypeMismatchReturnProbablyReal'],
         '_inc/lib/icalendar-reader.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanPluginDuplicateExpressionAssignmentOperation', 'PhanPossiblyUndeclaredVariable', 'PhanTypeInvalidLeftOperandOfNumericOp', 'PhanTypeMismatchArgumentNullableInternal', 'PhanTypeMismatchDimFetch', 'PhanTypeMismatchReturnProbablyReal', 'PhanTypePossiblyInvalidDimOffset'],
@@ -143,12 +143,12 @@ return [
         'class.jetpack-heartbeat.php' => ['PhanTypeMismatchPropertyDefault'],
         'class.jetpack-modules-list-table.php' => ['PhanCommentAbstractOnInheritedMethod'],
         'class.jetpack-network-sites-list-table.php' => ['PhanCommentAbstractOnInheritedMethod'],
-        'class.jetpack-network.php' => ['PhanPossiblyUndeclaredVariable', 'PhanTypeMismatchArgumentNullable', 'PhanTypeMismatchReturnNullable', 'PhanTypeMismatchReturnProbablyReal'],
+        'class.jetpack-network.php' => ['PhanTypeMismatchReturnNullable', 'PhanTypeMismatchReturnProbablyReal'],
         'class.jetpack-post-images.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchArgument', 'PhanTypeMismatchDefault', 'PhanTypeMismatchReturnProbablyReal'],
         'class.jetpack-twitter-cards.php' => ['PhanPluginSimplifyExpressionBool', 'PhanTypeArraySuspiciousNullable', 'PhanTypeMismatchArgument', 'PhanTypePossiblyInvalidDimOffset'],
-        'class.jetpack.php' => ['PhanDeprecatedFunction', 'PhanPluginDuplicateConditionalNullCoalescing', 'PhanPossiblyUndeclaredVariable', 'PhanTypeArraySuspiciousNullable', 'PhanTypeExpectedObjectPropAccess', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentNullableInternal', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchDefault', 'PhanTypeMismatchPropertyDefault', 'PhanTypeMismatchReturn', 'PhanTypeMismatchReturnProbablyReal'],
-        'class.json-api-endpoints.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanPluginSimplifyExpressionBool', 'PhanPossiblyUndeclaredVariable', 'PhanTypeArraySuspiciousNullable', 'PhanTypeComparisonToArray', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentInternal', 'PhanTypeMismatchArgumentNullable', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchReturnProbablyReal'],
-        'class.json-api.php' => ['PhanPluginDuplicateSwitchCaseLooseEquality', 'PhanPluginSimplifyExpressionBool', 'PhanPossiblyUndeclaredVariable', 'PhanTypeArraySuspicious', 'PhanTypeArraySuspiciousNullable', 'PhanTypeMismatchArgumentNullable', 'PhanTypeMismatchProperty', 'PhanTypeMismatchPropertyDefault', 'PhanTypeMismatchReturnProbablyReal'],
+        'class.jetpack.php' => ['PhanDeprecatedFunction', 'PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeArraySuspiciousNullable', 'PhanTypeExpectedObjectPropAccess', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentNullableInternal', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchDefault', 'PhanTypeMismatchPropertyDefault', 'PhanTypeMismatchReturn', 'PhanTypeMismatchReturnProbablyReal'],
+        'class.json-api-endpoints.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanPluginSimplifyExpressionBool', 'PhanTypeArraySuspiciousNullable', 'PhanTypeComparisonToArray', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentInternal', 'PhanTypeMismatchArgumentNullable', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchReturnProbablyReal'],
+        'class.json-api.php' => ['PhanPluginDuplicateSwitchCaseLooseEquality', 'PhanPluginSimplifyExpressionBool', 'PhanTypeArraySuspicious', 'PhanTypeArraySuspiciousNullable', 'PhanTypeMismatchProperty', 'PhanTypeMismatchPropertyDefault', 'PhanTypeMismatchReturnProbablyReal'],
         'enhanced-open-graph.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeArraySuspiciousNullable'],
         'extensions/blocks/ai-chat/ai-chat.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchArgument'],
         'extensions/blocks/blog-stats/blog-stats.php' => ['PhanTypeMismatchReturnProbablyReal'],
@@ -173,7 +173,7 @@ return [
         'extensions/blocks/repeat-visitor/repeat-visitor.php' => ['PhanPluginDuplicateConditionalNullCoalescing'],
         'extensions/blocks/sharing-button/class-sharing-source-block.php' => ['PhanTypeMismatchArgument', 'PhanTypeMismatchReturnProbablyReal'],
         'extensions/blocks/slideshow/slideshow.php' => ['PhanPluginSimplifyExpressionBool', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentInternal', 'PhanTypeMismatchReturnProbablyReal'],
-        'extensions/blocks/story/story.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanPossiblyUndeclaredVariable'],
+        'extensions/blocks/story/story.php' => ['PhanPluginDuplicateConditionalNullCoalescing'],
         'extensions/blocks/subscriptions/subscriptions.php' => ['PhanPluginDuplicateConditionalNullCoalescing'],
         'extensions/blocks/top-posts/top-posts.php' => ['PhanTypeMismatchReturnProbablyReal'],
         'extensions/blocks/wordads/wordads.php' => ['PhanTypeMismatchArgument'],
@@ -232,9 +232,9 @@ return [
         'json-endpoints/class.wpcom-json-api-update-customcss.php' => ['PhanTypeMismatchReturn'],
         'json-endpoints/class.wpcom-json-api-update-media-endpoint.php' => ['PhanTypeMismatchReturn'],
         'json-endpoints/class.wpcom-json-api-update-media-v1-1-endpoint.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchArgument', 'PhanTypeMismatchReturn'],
-        'json-endpoints/class.wpcom-json-api-update-post-endpoint.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanPluginSimplifyExpressionBool', 'PhanPossiblyUndeclaredVariable', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentNullable', 'PhanTypeMismatchReturn', 'PhanTypePossiblyInvalidDimOffset'],
+        'json-endpoints/class.wpcom-json-api-update-post-endpoint.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanPluginSimplifyExpressionBool', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentNullable', 'PhanTypeMismatchReturn', 'PhanTypePossiblyInvalidDimOffset'],
         'json-endpoints/class.wpcom-json-api-update-post-v1-1-endpoint.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanPluginSimplifyExpressionBool', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentNullable', 'PhanTypeMismatchReturn', 'PhanTypePossiblyInvalidDimOffset'],
-        'json-endpoints/class.wpcom-json-api-update-post-v1-2-endpoint.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanPluginSimplifyExpressionBool', 'PhanPossiblyUndeclaredVariable', 'PhanTypeArraySuspiciousNullable', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentNullable', 'PhanTypePossiblyInvalidDimOffset'],
+        'json-endpoints/class.wpcom-json-api-update-post-v1-2-endpoint.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanPluginSimplifyExpressionBool', 'PhanTypeArraySuspiciousNullable', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentNullable', 'PhanTypePossiblyInvalidDimOffset'],
         'json-endpoints/class.wpcom-json-api-update-site-homepage-endpoint.php' => ['PhanTypeMismatchReturn'],
         'json-endpoints/class.wpcom-json-api-update-site-logo-endpoint.php' => ['PhanTypeMismatchReturn'],
         'json-endpoints/class.wpcom-json-api-update-taxonomy-endpoint.php' => ['PhanTypeMismatchArgument', 'PhanTypeMismatchReturn'],
@@ -255,7 +255,7 @@ return [
         'json-endpoints/jetpack/class.jetpack-json-api-log-endpoint.php' => ['PhanTypeMismatchPropertyDefault'],
         'json-endpoints/jetpack/class.jetpack-json-api-modules-endpoint.php' => ['PhanParamSignatureMismatch', 'PhanTypeMismatchArgument'],
         'json-endpoints/jetpack/class.jetpack-json-api-plugins-endpoint.php' => ['PhanParamSignatureMismatch', 'PhanPluginDuplicateExpressionAssignmentOperation', 'PhanTypeMismatchArgument'],
-        'json-endpoints/jetpack/class.jetpack-json-api-plugins-install-endpoint.php' => ['PhanPossiblyUndeclaredVariable', 'PhanTypeMismatchDimAssignment'],
+        'json-endpoints/jetpack/class.jetpack-json-api-plugins-install-endpoint.php' => ['PhanTypeMismatchDimAssignment'],
         'json-endpoints/jetpack/class.jetpack-json-api-plugins-modify-endpoint.php' => ['PhanTypeInvalidLeftOperandOfBitwiseOp', 'PhanTypeInvalidRightOperandOfBitwiseOp', 'PhanTypeMismatchArgumentProbablyReal'],
         'json-endpoints/jetpack/class.jetpack-json-api-plugins-modify-v1-2-endpoint.php' => ['PhanTypeInvalidLeftOperandOfBitwiseOp', 'PhanTypeInvalidRightOperandOfBitwiseOp'],
         'json-endpoints/jetpack/class.jetpack-json-api-plugins-new-endpoint.php' => ['PhanParamSignatureMismatch', 'PhanTypeMismatchArgument', 'PhanTypeMissingReturn'],
@@ -304,7 +304,6 @@ return [
         'modules/shortcodes/archives.php' => ['PhanPluginSimplifyExpressionBool'],
         'modules/shortcodes/brightcove.php' => ['PhanTypeMismatchArgument'],
         'modules/shortcodes/class.filter-embedded-html-objects.php' => ['PhanTypeMismatchPropertyDefault'],
-        'modules/shortcodes/crowdsignal.php' => ['PhanPossiblyUndeclaredVariable'],
         'modules/shortcodes/dailymotion.php' => ['PhanTypeMismatchArgument'],
         'modules/shortcodes/flickr.php' => ['PhanTypeMismatchReturn'],
         'modules/shortcodes/getty.php' => ['PhanTypeMismatchArgument'],
@@ -342,9 +341,9 @@ return [
         'modules/sitemaps/sitemap-logger.php' => ['PhanTypeMismatchProperty'],
         'modules/sitemaps/sitemaps.php' => ['PhanTypeMismatchArgument'],
         'modules/stats.php' => ['PhanSuspiciousMagicConstant', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchReturn', 'PhanTypeMismatchReturnNullable', 'PhanTypeMismatchReturnProbablyReal'],
-        'modules/subscriptions.php' => ['PhanPossiblyUndeclaredVariable', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchDefault', 'PhanTypeMismatchReturnProbablyReal', 'PhanTypeSuspiciousNonTraversableForeach'],
+        'modules/subscriptions.php' => ['PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchDefault', 'PhanTypeMismatchReturnProbablyReal', 'PhanTypeSuspiciousNonTraversableForeach'],
         'modules/subscriptions/subscribe-modal/class-jetpack-subscribe-modal.php' => ['PhanTypeMismatchReturnNullable'],
-        'modules/subscriptions/views.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanPossiblyUndeclaredVariable', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentNullable', 'PhanTypeMismatchArgumentNullableInternal', 'PhanTypePossiblyInvalidDimOffset'],
+        'modules/subscriptions/views.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchArgument', 'PhanTypePossiblyInvalidDimOffset'],
         'modules/theme-tools/content-options.php' => ['PhanRedefineFunction'],
         'modules/theme-tools/content-options/author-bio.php' => ['PhanRedefineFunction', 'PhanTypeMismatchArgument'],
         'modules/theme-tools/content-options/blog-display.php' => ['PhanPluginDuplicateExpressionAssignmentOperation', 'PhanRedefineFunction'],
@@ -383,7 +382,7 @@ return [
         'modules/widgets/class-jetpack-instagram-widget.php' => ['PhanTypeMismatchArgument', 'PhanTypeMismatchReturn', 'PhanTypePossiblyInvalidDimOffset'],
         'modules/widgets/contact-info.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchArgument'],
         'modules/widgets/facebook-likebox.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchArgument', 'PhanTypePossiblyInvalidDimOffset'],
-        'modules/widgets/flickr.php' => ['PhanPossiblyUndeclaredVariable', 'PhanTypeMismatchArgumentNullable'],
+        'modules/widgets/flickr.php' => ['PhanTypeMismatchArgumentNullable'],
         'modules/widgets/flickr/form.php' => ['PhanTypeMismatchArgument'],
         'modules/widgets/follow-button.php' => ['PhanPluginUseReturnValueInternalKnown'],
         'modules/widgets/gallery.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchReturnProbablyReal'],
@@ -451,14 +450,14 @@ return [
         'tests/php/modules/shortcodes/Jetpack_Shortcodes_Vimeo_Test.php' => ['PhanTypeMismatchArgumentProbablyReal'],
         'tests/php/modules/sitemaps/Jetpack_Sitemap_Buffer_Test.php' => ['PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchPropertyProbablyReal'],
         'tests/php/modules/sitemaps/Jetpack_Sitemap_Librarian_Test.php' => ['PhanTypeMismatchArgument'],
-        'tests/php/modules/subscriptions/Jetpack_Subscriptions_Test.php' => ['PhanDeprecatedProperty', 'PhanPluginDuplicateConditionalNullCoalescing', 'PhanPossiblyUndeclaredVariable', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentProbablyReal'],
+        'tests/php/modules/subscriptions/Jetpack_Subscriptions_Test.php' => ['PhanDeprecatedProperty', 'PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentProbablyReal'],
         'tests/php/modules/widgets/Contact_Info_Widget_Test.php' => ['PhanTypeMismatchArgumentProbablyReal'],
         'tests/php/modules/widgets/Jetpack_Display_Posts_Widget_Test.php' => ['PhanTypeMismatchArgumentProbablyReal'],
         'tests/php/sync/Jetpack_Sync_Checksum_Smoke_Test.php' => ['PhanTypeMismatchArgument', 'PhanTypeMismatchReturn'],
         'tests/php/sync/Jetpack_Sync_Checksum_Test.php' => ['PhanTypeArraySuspiciousNullable', 'PhanTypeMismatchReturn'],
         'tests/php/sync/Jetpack_Sync_Comments_Test.php' => ['PhanTypeMismatchArgument'],
-        'tests/php/sync/Jetpack_Sync_Full_Immediately_Test.php' => ['PhanPluginDuplicateAdjacentStatement', 'PhanPossiblyUndeclaredVariable', 'PhanTypeArraySuspiciousNullable', 'PhanTypeMismatchArgumentNullable', 'PhanTypeMismatchArgumentProbablyReal'],
-        'tests/php/sync/Jetpack_Sync_Full_Test.php' => ['PhanPluginDuplicateAdjacentStatement', 'PhanPossiblyUndeclaredVariable', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentNullable', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchArgumentReal'],
+        'tests/php/sync/Jetpack_Sync_Full_Immediately_Test.php' => ['PhanPluginDuplicateAdjacentStatement', 'PhanTypeArraySuspiciousNullable', 'PhanTypeMismatchArgumentProbablyReal'],
+        'tests/php/sync/Jetpack_Sync_Full_Test.php' => ['PhanPluginDuplicateAdjacentStatement', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchArgumentReal'],
         'tests/php/sync/Jetpack_Sync_Functions_Test.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMissingReturn'],
         'tests/php/sync/Jetpack_Sync_Import_Test.php' => ['PhanRedefineClass'],
         'tests/php/sync/Jetpack_Sync_Integration_Test.php' => ['PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchPropertyProbablyReal'],

--- a/projects/plugins/jetpack/_inc/lib/debugger/class-jetpack-debug-data.php
+++ b/projects/plugins/jetpack/_inc/lib/debugger/class-jetpack-debug-data.php
@@ -226,12 +226,12 @@ class Jetpack_Debug_Data {
 		);
 		$debug_info['blog_token']   = array(
 			'label'   => 'Blog Public Key',
-			'value'   => ( $blog_token ) ? $blog_key : 'Not set.',
+			'value'   => $blog_key ?? 'Not set.',
 			'private' => false,
 		);
 		$debug_info['user_token']   = array(
 			'label'   => 'User Public Key',
-			'value'   => ( $user_token ) ? $user_key : 'Not set.',
+			'value'   => $user_key ?? 'Not set.',
 			'private' => false,
 		);
 

--- a/projects/plugins/jetpack/changelog/fix-phan-PhanPossiblyUndeclaredVariable
+++ b/projects/plugins/jetpack/changelog/fix-phan-PhanPossiblyUndeclaredVariable
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Phan: Address PhanPossiblyUndeclaredVariable violations.

--- a/projects/plugins/jetpack/class.jetpack-network.php
+++ b/projects/plugins/jetpack/class.jetpack-network.php
@@ -387,8 +387,8 @@ class Jetpack_Network {
 			$classname = 'error';
 		}
 		?>
-		<div id="message" class="<?php echo esc_attr( $classname ); ?> jetpack-message jp-connect" style="display:block !important;">
-			<p><?php echo esc_html( $notice ); ?></p>
+		<div id="message" class="<?php echo esc_attr( $classname ?? '' ); ?> jetpack-message jp-connect" style="display:block !important;">
+			<p><?php echo esc_html( $notice ?? '' ); ?></p>
 		</div>
 		<?php
 	}

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -4586,6 +4586,7 @@ endif;
 	 */
 	public static function permit_ssl( $force_recheck = false ) {
 		// Do some fancy tests to see if ssl is being supported.
+		$ssl = false;
 		if ( ! $force_recheck ) {
 			$ssl = get_transient( 'jetpack_https_test' );
 		}

--- a/projects/plugins/jetpack/class.json-api-endpoints.php
+++ b/projects/plugins/jetpack/class.json-api-endpoints.php
@@ -1589,7 +1589,7 @@ abstract class WPCOM_JSON_API_Endpoint {
 
 		if ( $site_id > -1 ) {
 			$author['site_ID']      = (int) $site_id;
-			$author['site_visible'] = $site_visible;
+			$author['site_visible'] = $site_visible ?? false;
 		}
 
 		// Only include WordPress.com user data when author_wpcom_data is enabled.

--- a/projects/plugins/jetpack/class.json-api-endpoints.php
+++ b/projects/plugins/jetpack/class.json-api-endpoints.php
@@ -1589,7 +1589,7 @@ abstract class WPCOM_JSON_API_Endpoint {
 
 		if ( $site_id > -1 ) {
 			$author['site_ID']      = (int) $site_id;
-			$author['site_visible'] = $site_visible ?? false;
+			$author['site_visible'] = $site_visible ?? null;
 		}
 
 		// Only include WordPress.com user data when author_wpcom_data is enabled.

--- a/projects/plugins/jetpack/class.json-api.php
+++ b/projects/plugins/jetpack/class.json-api.php
@@ -476,8 +476,8 @@ class WPCOM_JSON_API {
 		}
 
 		// Find which endpoint to serve.
-		$found = false;
-
+		$found       = false;
+		$path_pieces = array();
 		foreach ( $this->endpoints as $endpoint_path_versions => $endpoints_by_method ) {
 			// @todo Determine if anything depends on this being serialized rather than e.g. JSON.
 			// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_unserialize -- Legacy, possibly depended on elsewhere.

--- a/projects/plugins/jetpack/class.json-api.php
+++ b/projects/plugins/jetpack/class.json-api.php
@@ -476,7 +476,8 @@ class WPCOM_JSON_API {
 		}
 
 		// Find which endpoint to serve.
-		$found = false;
+		$found       = false;
+		$path_pieces = array();
 		foreach ( $this->endpoints as $endpoint_path_versions => $endpoints_by_method ) {
 			// @todo Determine if anything depends on this being serialized rather than e.g. JSON.
 			// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_unserialize -- Legacy, possibly depended on elsewhere.
@@ -499,6 +500,7 @@ class WPCOM_JSON_API {
 				$endpoint_path = untrailingslashit( $endpoint_path );
 				if ( $is_help ) {
 					// Truncate path at help depth.
+					// @phan-suppress-next-line PhanPossiblyUndeclaredVariable -- $depth is set when $is_help is true.
 					$endpoint_path = implode( '/', array_slice( explode( '/', $endpoint_path ), 0, $depth ) );
 				}
 
@@ -557,6 +559,7 @@ class WPCOM_JSON_API {
 			 */
 			do_action( 'wpcom_json_api_output', 'help' );
 			$proxied = function_exists( 'wpcom_is_proxied_request' ) ? wpcom_is_proxied_request() : false;
+			// @phan-suppress-next-line PhanPossiblyUndeclaredVariable -- $help_content_type is set when $is_help is true.
 			if ( 'json' === $help_content_type ) {
 				$docs = array();
 				foreach ( $matching_endpoints as $matching_endpoint ) {
@@ -576,13 +579,16 @@ class WPCOM_JSON_API {
 			exit( 0 );
 		}
 
+		// @phan-suppress-next-line PhanPossiblyUndeclaredVariable -- $endpoint is set when $find_all_matching_endpoints is false, which is guaranteed here.
 		if ( $endpoint->in_testing && ! WPCOM_JSON_API__DEBUG ) {
 			return $this->output( 404, '', 'text/plain' );
 		}
 
 		/** This action is documented in class.json-api.php */
+		// @phan-suppress-next-line PhanPossiblyUndeclaredVariable -- $endpoint is set when $find_all_matching_endpoints is false, which is guaranteed here.
 		do_action( 'wpcom_json_api_output', $endpoint->stat );
 
+		// @phan-suppress-next-line PhanPossiblyUndeclaredVariable -- $endpoint is set when $find_all_matching_endpoints is false, which is guaranteed here.
 		$response = $this->process_request( $endpoint, $path_pieces );
 
 		if ( ! $response && ! is_array( $response ) ) {

--- a/projects/plugins/jetpack/class.json-api.php
+++ b/projects/plugins/jetpack/class.json-api.php
@@ -579,16 +579,16 @@ class WPCOM_JSON_API {
 			exit( 0 );
 		}
 
-		// @phan-suppress-next-line PhanPossiblyUndeclaredVariable -- $endpoint is set when $find_all_matching_endpoints is false, which is guaranteed here.
+		// @phan-suppress-next-line PhanPossiblyUndeclaredVariable -- $endpoint is set when $find_all_matching_endpoints is false and $found is true, which is guaranteed here.
 		if ( $endpoint->in_testing && ! WPCOM_JSON_API__DEBUG ) {
 			return $this->output( 404, '', 'text/plain' );
 		}
 
 		/** This action is documented in class.json-api.php */
-		// @phan-suppress-next-line PhanPossiblyUndeclaredVariable -- $endpoint is set when $find_all_matching_endpoints is false, which is guaranteed here.
+		// @phan-suppress-next-line PhanPossiblyUndeclaredVariable -- $endpoint is set when $find_all_matching_endpoints is false and $found is true, which is guaranteed here.
 		do_action( 'wpcom_json_api_output', $endpoint->stat );
 
-		// @phan-suppress-next-line PhanPossiblyUndeclaredVariable -- $endpoint is set when $find_all_matching_endpoints is false, which is guaranteed here.
+		// @phan-suppress-next-line PhanPossiblyUndeclaredVariable -- $endpoint is set when $find_all_matching_endpoints is false and $found is true, which is guaranteed here.
 		$response = $this->process_request( $endpoint, $path_pieces );
 
 		if ( ! $response && ! is_array( $response ) ) {

--- a/projects/plugins/jetpack/class.json-api.php
+++ b/projects/plugins/jetpack/class.json-api.php
@@ -476,8 +476,8 @@ class WPCOM_JSON_API {
 		}
 
 		// Find which endpoint to serve.
-		$found       = false;
-		$path_pieces = array();
+		$found = false;
+
 		foreach ( $this->endpoints as $endpoint_path_versions => $endpoints_by_method ) {
 			// @todo Determine if anything depends on this being serialized rather than e.g. JSON.
 			// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_unserialize -- Legacy, possibly depended on elsewhere.

--- a/projects/plugins/jetpack/extensions/blocks/story/story.php
+++ b/projects/plugins/jetpack/extensions/blocks/story/story.php
@@ -187,6 +187,10 @@ function enrich_video_meta( $media_file ) {
  * @return string
  */
 function render_image( $media ) {
+	$src    = '';
+	$width  = null;
+	$height = null;
+
 	if ( empty( $media['id'] ) || empty( $media['url'] ) ) {
 		return __( 'Error retrieving media', 'jetpack' );
 	}
@@ -215,7 +219,6 @@ function render_image( $media ) {
 		);
 	}
 
-	// @phan-suppress-next-line PhanPossiblyUndeclaredVariable -- $width and $height are set when $image is truthy, and other scenarios return early.
 	$crop_class = get_image_crop_class( $width, $height );
 	// need to specify the size of the embed so it picks an image that is large enough for the `src` attribute
 	// `sizes` is optimized for 1080x1920 (9:16) images

--- a/projects/plugins/jetpack/extensions/blocks/story/story.php
+++ b/projects/plugins/jetpack/extensions/blocks/story/story.php
@@ -196,7 +196,7 @@ function render_image( $media ) {
 	}
 
 	// if image does not match.
-	if ( ! $image || isset( $media['url'] ) && ! is_same_resource( $media['url'], $src ) ) {
+	if ( ! $image || isset( $media['url'] ) && ! is_same_resource( $media['url'], $src ?? '' ) ) {
 		$width  = isset( $media['width'] ) ? $media['width'] : null;
 		$height = isset( $media['height'] ) ? $media['height'] : null;
 		$title  = isset( $media['title'] ) ? $media['title'] : '';
@@ -215,6 +215,7 @@ function render_image( $media ) {
 		);
 	}
 
+	// @phan-suppress-next-line PhanPossiblyUndeclaredVariable -- $width and $height are set when $image is truthy, and other scenarios return early.
 	$crop_class = get_image_crop_class( $width, $height );
 	// need to specify the size of the embed so it picks an image that is large enough for the `src` attribute
 	// `sizes` is optimized for 1080x1920 (9:16) images

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-update-post-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-update-post-endpoint.php
@@ -543,6 +543,7 @@ class WPCOM_JSON_API_Update_Post_Endpoint extends WPCOM_JSON_API_Post_Endpoint {
 
 			$post_id = wp_insert_post( add_magic_quotes( $insert ), true );
 		} else {
+			// @phan-suppress-next-line PhanPossiblyUndeclaredVariable -- $post is set and validated several blocks earlier if $new (only set once) is falsy.
 			$insert['ID'] = $post->ID;
 
 			// wp_update_post ignores date unless edit_date is set

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-update-post-v1-2-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-update-post-v1-2-endpoint.php
@@ -621,6 +621,7 @@ class WPCOM_JSON_API_Update_Post_v1_2_Endpoint extends WPCOM_JSON_API_Update_Pos
 				$post_id = wp_insert_post( add_magic_quotes( $insert ), true );
 			}
 		} else {
+			// @phan-suppress-next-line PhanPossiblyUndeclaredVariable -- $post is set and validated several blocks earlier if $new (only set once) is falsy.
 			$insert['ID'] = $post->ID;
 
 			// wp_update_post ignores date unless edit_date is set

--- a/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-plugins-install-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-plugins-install-endpoint.php
@@ -105,6 +105,7 @@ class Jetpack_JSON_API_Plugins_Install_Endpoint extends Jetpack_JSON_API_Plugins
 		}
 
 		// No errors, install worked. Now replace the slug with the actual plugin id
+		// @phan-suppress-next-line PhanPossiblyUndeclaredVariable -- we return early if there is an issue; otherwise $index and $slug are set in the foreach loop
 		$this->plugins[ $index ] = Plugins_Installer::get_plugin_id_by_slug( $slug );
 
 		return true;

--- a/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-plugins-install-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-plugins-install-endpoint.php
@@ -105,6 +105,7 @@ class Jetpack_JSON_API_Plugins_Install_Endpoint extends Jetpack_JSON_API_Plugins
 		}
 
 		// No errors, install worked. Now replace the slug with the actual plugin id
+		// @todo This code looks a bit suspect; why do we loop through plugins and only look at the last one?
 		// @phan-suppress-next-line PhanPossiblyUndeclaredVariable -- we return early if there is an issue; otherwise $index and $slug are set in the foreach loop
 		$this->plugins[ $index ] = Plugins_Installer::get_plugin_id_by_slug( $slug );
 

--- a/projects/plugins/jetpack/modules/shortcodes/crowdsignal.php
+++ b/projects/plugins/jetpack/modules/shortcodes/crowdsignal.php
@@ -647,7 +647,7 @@ if (
 								'back_color' => $back_color,
 								'align'      => $attributes['align'],
 								'style'      => $attributes['style'],
-								'id'         => $survey,
+								'id'         => $survey ?? null,
 								'site'       => $attributes['site'],
 							)
 						);

--- a/projects/plugins/jetpack/modules/subscriptions.php
+++ b/projects/plugins/jetpack/modules/subscriptions.php
@@ -566,6 +566,7 @@ class Jetpack_Subscriptions {
 			if ( $async ) {
 				XMLRPC_Async_Call::add_call( 'jetpack.subscribeToSite', 0, $email, $post_id, serialize( $extra_data ) ); //phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize
 			} else {
+				// @phan-suppress-next-line PhanPossiblyUndeclaredVariable -- $xml is set when $async is false
 				$xml->addCall( 'jetpack.subscribeToSite', $email, $post_id, serialize( $extra_data ) ); //phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize
 			}
 		}
@@ -575,17 +576,22 @@ class Jetpack_Subscriptions {
 		}
 
 		// Call.
+		// @phan-suppress-next-line PhanPossiblyUndeclaredVariable -- $xml is set when $async is false, otherwise we return early
 		$xml->query();
 
+		// @phan-suppress-next-line PhanPossiblyUndeclaredVariable -- $xml is set when $async is false, otherwise we return early
 		if ( $xml->isError() ) {
+			// @phan-suppress-next-line PhanPossiblyUndeclaredVariable -- $xml is set when $async is false, otherwise we return early
 			return $xml->get_jetpack_error();
 		}
 
+		// @phan-suppress-next-line PhanPossiblyUndeclaredVariable -- $xml is set when $async is false
 		$responses = $xml->getResponse();
 
 		$r = array();
 		foreach ( (array) $responses as $response ) {
 			if ( isset( $response['faultCode'] ) || isset( $response['faultString'] ) ) {
+				// @phan-suppress-next-line PhanPossiblyUndeclaredVariable -- $xml is set when $async is false
 				$r[] = $xml->get_jetpack_error( $response['faultCode'], $response['faultString'] );
 				continue;
 			}

--- a/projects/plugins/jetpack/modules/subscriptions/views.php
+++ b/projects/plugins/jetpack/modules/subscriptions/views.php
@@ -748,18 +748,6 @@ class Jetpack_Subscriptions_Widget extends WP_Widget {
 			$subscribe_logged_in = ! empty( $instance['subscribe_logged_in'] ) ? esc_attr( stripslashes( $instance['subscribe_logged_in'] ) ) : '';
 			$subscribe_button    = ! empty( $instance['subscribe_button'] ) ? esc_attr( stripslashes( $instance['subscribe_button'] ) ) : '';
 			$subscribers_total   = self::fetch_subscriber_count();
-		}
-
-		if ( self::is_jetpack() ) {
-			$title                 = ! empty( $instance['title'] ) ? stripslashes( $instance['title'] ) : '';
-			$subscribe_text        = ! empty( $instance['subscribe_text'] ) ? stripslashes( $instance['subscribe_text'] ) : '';
-			$subscribe_placeholder = ! empty( $instance['subscribe_placeholder'] ) ? stripslashes( $instance['subscribe_placeholder'] ) : '';
-			$subscribe_button      = ! empty( $instance['subscribe_button'] ) ? stripslashes( $instance['subscribe_button'] ) : '';
-			$success_message       = ! empty( $instance['success_message'] ) ? stripslashes( $instance['success_message'] ) : '';
-			$subscribers_total     = self::fetch_subscriber_count();
-		}
-
-		if ( self::is_wpcom() ) :
 			?>
 			<p>
 				<label for="<?php echo esc_attr( $this->get_field_id( 'title' ) ); ?>">
@@ -813,9 +801,15 @@ class Jetpack_Subscriptions_Widget extends WP_Widget {
 				</label>
 			</p>
 			<?php
-		endif;
+		}
 
-		if ( self::is_jetpack() ) :
+		if ( self::is_jetpack() ) {
+			$title                 = ! empty( $instance['title'] ) ? stripslashes( $instance['title'] ) : '';
+			$subscribe_text        = ! empty( $instance['subscribe_text'] ) ? stripslashes( $instance['subscribe_text'] ) : '';
+			$subscribe_placeholder = ! empty( $instance['subscribe_placeholder'] ) ? stripslashes( $instance['subscribe_placeholder'] ) : '';
+			$subscribe_button      = ! empty( $instance['subscribe_button'] ) ? stripslashes( $instance['subscribe_button'] ) : '';
+			$success_message       = ! empty( $instance['success_message'] ) ? stripslashes( $instance['success_message'] ) : '';
+			$subscribers_total     = self::fetch_subscriber_count();
 			?>
 			<p>
 				<label for="<?php echo esc_attr( $this->get_field_id( 'title' ) ); ?>">
@@ -869,7 +863,7 @@ class Jetpack_Subscriptions_Widget extends WP_Widget {
 				</label>
 			</p>
 			<?php
-		endif;
+		}
 	}
 }
 

--- a/projects/plugins/jetpack/modules/widgets/flickr.php
+++ b/projects/plugins/jetpack/modules/widgets/flickr.php
@@ -144,6 +144,9 @@ if ( ! class_exists( 'Jetpack_Flickr_Widget' ) ) {
 						case 'large':
 							$src = $photo->get_enclosure()->get_link();
 							break;
+						default:
+							$src = '';
+							break;
 					}
 
 					$photos .= '<a href="' . esc_url( $photo->get_permalink(), array( 'http', 'https' ) ) . '" ';

--- a/projects/plugins/jetpack/tests/php/modules/subscriptions/Jetpack_Subscriptions_Test.php
+++ b/projects/plugins/jetpack/tests/php/modules/subscriptions/Jetpack_Subscriptions_Test.php
@@ -286,7 +286,7 @@ class Jetpack_Subscriptions_Test extends WP_UnitTestCase {
 	 */
 	#[DataProvider( 'matrix_access' )]
 	public function test_subscriber_access_level( $type_user_id, $logged, $token_set, $post_access_level, $should_email_be_sent, $should_user_access_post, $subscription_end_date = null, $status = null ) {
-		$user_id = 0;
+		$user_id = null;
 		if ( $type_user_id !== null ) {
 			$user_id = $this->{$type_user_id};
 		}

--- a/projects/plugins/jetpack/tests/php/modules/subscriptions/Jetpack_Subscriptions_Test.php
+++ b/projects/plugins/jetpack/tests/php/modules/subscriptions/Jetpack_Subscriptions_Test.php
@@ -286,6 +286,7 @@ class Jetpack_Subscriptions_Test extends WP_UnitTestCase {
 	 */
 	#[DataProvider( 'matrix_access' )]
 	public function test_subscriber_access_level( $type_user_id, $logged, $token_set, $post_access_level, $should_email_be_sent, $should_user_access_post, $subscription_end_date = null, $status = null ) {
+		$user_id = 0;
 		if ( $type_user_id !== null ) {
 			$user_id = $this->{$type_user_id};
 		}

--- a/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Full_Immediately_Test.php
+++ b/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Full_Immediately_Test.php
@@ -334,6 +334,7 @@ class Jetpack_Sync_Full_Immediately_Test extends Jetpack_Sync_TestBase {
 	public function test_full_sync_sends_all_users() {
 		self::factory()->user->create( array( 'role' => 'subscriber' ) );
 		$first_user_id = self::factory()->user->create( array( 'role' => 'contributor' ) );
+		$user_id       = 0; // Phan thinks the for loop might not run and thus $user_id might not be declared, so let's initialize it.
 		for ( $i = 0; $i < 9; $i++ ) {
 			$user_id = self::factory()->user->create( array( 'role' => 'contributor' ) );
 		}
@@ -908,6 +909,7 @@ class Jetpack_Sync_Full_Immediately_Test extends Jetpack_Sync_TestBase {
 
 	public function create_dummy_data_and_reset_sync_status() {
 		// lets create a bunch of posts
+		$post = 0; // Phan thinks the for loop might not run and thus $post might not be declared, so let's initialize it.
 		for ( $i = 0; $i < $this->test_posts_count; $i++ ) {
 			$post = self::factory()->post->create();
 		}

--- a/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Full_Test.php
+++ b/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Full_Test.php
@@ -467,6 +467,7 @@ class Jetpack_Sync_Full_Test extends Jetpack_Sync_TestBase {
 	public function test_full_sync_sends_all_users() {
 		self::factory()->user->create( array( 'role' => 'subscriber' ) );
 		$first_user_id = self::factory()->user->create( array( 'role' => 'contributor' ) );
+		$user_id       = 0; // Phan thinks the for loop might not run and thus $user_id might not be declared, so let's initialize it.
 		for ( $i = 0; $i < 9; $i++ ) {
 			$user_id = self::factory()->user->create( array( 'role' => 'contributor' ) );
 		}
@@ -1157,6 +1158,7 @@ class Jetpack_Sync_Full_Test extends Jetpack_Sync_TestBase {
 
 	public function create_dummy_data_and_empty_the_queue() {
 		// lets create a bunch of posts
+		$post = 0; // Phan thinks the for loop might not run and thus $post might not be declared, so let's initialize it.
 		for ( $i = 0; $i < $this->test_posts_count; $i++ ) {
 			$post = self::factory()->post->create();
 		}

--- a/projects/plugins/vaultpress/.phan/baseline.php
+++ b/projects/plugins/vaultpress/.phan/baseline.php
@@ -11,16 +11,14 @@ return [
     // # Issue statistics:
     // PhanUndeclaredClassMethod : 15+ occurrences
     // PhanPluginSimplifyExpressionBool : 8 occurrences
-    // PhanTypeMismatchArgumentNullableInternal : 8 occurrences
     // PhanUndeclaredConstant : 8 occurrences
     // PhanTypeMismatchArgument : 7 occurrences
-    // PhanPossiblyUndeclaredVariable : 6 occurrences
+    // PhanTypeMismatchArgumentNullableInternal : 6 occurrences
     // PhanTypePossiblyInvalidDimOffset : 6 occurrences
     // PhanPluginUnreachableCode : 5 occurrences
     // PhanTypeArraySuspiciousNullable : 5 occurrences
     // PhanTypeMismatchArgumentProbablyReal : 5 occurrences
     // PhanPluginDuplicateConditionalNullCoalescing : 4 occurrences
-    // PhanUndeclaredVariableDim : 4 occurrences
     // PhanCommentParamWithoutRealParam : 3 occurrences
     // PhanTypeMismatchDimFetch : 3 occurrences
     // PhanUndeclaredFunction : 3 occurrences
@@ -33,7 +31,6 @@ return [
     // PhanUndeclaredMethod : 2 occurrences
     // PhanUndeclaredVariable : 2 occurrences
     // PhanAccessMethodProtected : 1 occurrence
-    // PhanParamSpecial1 : 1 occurrence
     // PhanPluginDuplicateExpressionAssignment : 1 occurrence
     // PhanTypeInvalidRightOperandOfNumericOp : 1 occurrence
     // PhanTypeMismatchArgumentInternal : 1 occurrence
@@ -42,12 +39,12 @@ return [
 
     // Currently, file_suppressions and directory_suppressions are the only supported suppressions
     'file_suppressions' => [
-        'class.vaultpress-database.php' => ['PhanParamSpecial1', 'PhanPluginDuplicateConditionalNullCoalescing', 'PhanPossiblyUndeclaredVariable', 'PhanTypeArraySuspiciousNullable', 'PhanTypeMismatchArgumentInternal', 'PhanTypeMismatchArgumentNullableInternal', 'PhanTypeNonVarPassByRef', 'PhanTypeObjectUnsetDeclaredProperty', 'PhanUndeclaredConstant', 'PhanUndeclaredVariableDim'],
-        'class.vaultpress-filesystem.php' => ['PhanPluginNeverReturnMethod', 'PhanPluginSimplifyExpressionBool', 'PhanPluginUnreachableCode', 'PhanPossiblyUndeclaredVariable', 'PhanTypeMismatchArgumentNullableInternal', 'PhanTypeNonVarPassByRef', 'PhanTypeSuspiciousStringExpression', 'PhanUndeclaredVariable'],
+        'class.vaultpress-database.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeArraySuspiciousNullable', 'PhanTypeMismatchArgumentInternal', 'PhanTypeNonVarPassByRef', 'PhanTypeObjectUnsetDeclaredProperty', 'PhanUndeclaredConstant'],
+        'class.vaultpress-filesystem.php' => ['PhanPluginNeverReturnMethod', 'PhanPluginSimplifyExpressionBool', 'PhanPluginUnreachableCode', 'PhanTypeMismatchArgumentNullableInternal', 'PhanTypeNonVarPassByRef', 'PhanTypeSuspiciousStringExpression', 'PhanUndeclaredVariable'],
         'class.vaultpress-hotfixes.php' => ['PhanDeprecatedFunction', 'PhanPluginSimplifyExpressionBool', 'PhanRedefineFunction', 'PhanTypeMismatchArgumentNullableInternal', 'PhanTypePossiblyInvalidDimOffset'],
         'cron-tasks.php' => ['PhanRedefineFunction'],
-        'vaultpress.php' => ['PhanAccessMethodProtected', 'PhanDeprecatedFunction', 'PhanPluginDuplicateConditionalNullCoalescing', 'PhanPluginDuplicateExpressionAssignment', 'PhanPluginNeverReturnMethod', 'PhanPluginSimplifyExpressionBool', 'PhanPluginUnreachableCode', 'PhanPossiblyUndeclaredVariable', 'PhanTypeArraySuspiciousNullable', 'PhanTypeExpectedObjectPropAccessButGotNull', 'PhanTypeInvalidRightOperandOfNumericOp', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentNullableInternal', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchDimFetch', 'PhanTypePossiblyInvalidDimOffset', 'PhanTypeSuspiciousStringExpression', 'PhanUndeclaredClassMethod', 'PhanUndeclaredClassReference', 'PhanUndeclaredConstant', 'PhanUndeclaredFunction', 'PhanUndeclaredMethod', 'PhanUndeclaredVariable'],
-        'vp-scanner.php' => ['PhanCommentParamWithoutRealParam', 'PhanPossiblyUndeclaredVariable', 'PhanTypeMismatchArgumentNullableInternal', 'PhanUndeclaredFunction'],
+        'vaultpress.php' => ['PhanAccessMethodProtected', 'PhanDeprecatedFunction', 'PhanPluginDuplicateConditionalNullCoalescing', 'PhanPluginDuplicateExpressionAssignment', 'PhanPluginNeverReturnMethod', 'PhanPluginSimplifyExpressionBool', 'PhanPluginUnreachableCode', 'PhanTypeArraySuspiciousNullable', 'PhanTypeExpectedObjectPropAccessButGotNull', 'PhanTypeInvalidRightOperandOfNumericOp', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentNullableInternal', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchDimFetch', 'PhanTypePossiblyInvalidDimOffset', 'PhanTypeSuspiciousStringExpression', 'PhanUndeclaredClassMethod', 'PhanUndeclaredClassReference', 'PhanUndeclaredConstant', 'PhanUndeclaredFunction', 'PhanUndeclaredMethod', 'PhanUndeclaredVariable'],
+        'vp-scanner.php' => ['PhanCommentParamWithoutRealParam', 'PhanTypeMismatchArgumentNullableInternal', 'PhanUndeclaredFunction'],
     ],
     // 'directory_suppressions' => ['src/directory_name' => ['PhanIssueName1', 'PhanIssueName2']] can be manually added if needed.
     // (directory_suppressions will currently be ignored by subsequent calls to --save-baseline, but may be preserved in future Phan releases)

--- a/projects/plugins/vaultpress/changelog/fix-phan-PhanPossiblyUndeclaredVariable
+++ b/projects/plugins/vaultpress/changelog/fix-phan-PhanPossiblyUndeclaredVariable
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Phan: Address PhanPossiblyUndeclaredVariable violations.

--- a/projects/plugins/vaultpress/class.vaultpress-database.php
+++ b/projects/plugins/vaultpress/class.vaultpress-database.php
@@ -169,6 +169,9 @@ class VaultPress_Database {
 		if ( !is_object( $data ) || !is_object( $datatypes ) )
 			return false;
 
+		$keys = array();
+		$vals = array();
+
 		foreach ( array_keys( (array)$data ) as $key )
 			$keys[] = sprintf( "`%s`", esc_sql( $key ) );
 		foreach ( (array)$data as $key => $val ) {

--- a/projects/plugins/vaultpress/class.vaultpress-filesystem.php
+++ b/projects/plugins/vaultpress/class.vaultpress-filesystem.php
@@ -75,10 +75,13 @@ class VaultPress_Filesystem {
 		if ( !function_exists( 'exec' ) )
 			return false;
 		$out = array();
-		if ( 'md5' == $method )
+		if ( 'md5' === $method ) {
 			$method_bin = 'md5sum';
-		if ( 'sha1' == $method )
+		} elseif ( 'sha1' === $method ) {
 			$method_bin = 'sha1sum';
+		} else {
+			return false;
+		}
 		$checksum = '';
 		exec( sprintf( '%s %s', escapeshellcmd( $method_bin ), escapeshellarg( $file ) ), $out );
 		if ( !empty( $out ) )

--- a/projects/plugins/vaultpress/vaultpress.php
+++ b/projects/plugins/vaultpress/vaultpress.php
@@ -1016,8 +1016,8 @@ class VaultPress {
 	function ui_logo() {
 		if ( ! class_exists( 'Jetpack_Logo' ) ) {
 			require_once VAULTPRESS__PLUGIN_DIR . 'class-jetpack-logo.php';
-			$jetpack_logo = new Jetpack_Logo();
 		}
+		$jetpack_logo = new Jetpack_Logo();
 
 		return $jetpack_logo->output();
 	}

--- a/projects/plugins/vaultpress/vp-scanner.php
+++ b/projects/plugins/vaultpress/vp-scanner.php
@@ -65,7 +65,7 @@ class VP_FileScan {
 				}
 				if ( count( $files ) >= $limit ) {
 					closedir( $handle );
-					return array( $_return_offset, $_return_dir );
+					return array( $_return_offset ?? 0, $_return_dir ?? null );
 				}
 			}
 			closedir( $handle );

--- a/projects/plugins/wpcomsh/.phan/baseline.php
+++ b/projects/plugins/wpcomsh/.phan/baseline.php
@@ -22,7 +22,6 @@ return [
     // PhanDeprecatedFunction : 1 occurrence
     // PhanDeprecatedProperty : 1 occurrence
     // PhanPluginUseReturnValueInternalKnown : 1 occurrence
-    // PhanPossiblyUndeclaredVariable : 1 occurrence
     // PhanTypeObjectUnsetDeclaredProperty : 1 occurrence
     // PhanUndeclaredClassConstant : 1 occurrence
     // PhanUndeclaredClassStaticProperty : 1 occurrence
@@ -41,7 +40,7 @@ return [
         'footer-credit/theme-optimizations.php' => ['PhanUndeclaredConstant', 'PhanUndeclaredStaticMethod'],
         'functions.php' => ['PhanUndeclaredClassStaticProperty'],
         'imports/playground/class-sql-importer.php' => ['PhanUndeclaredConstant'],
-        'safeguard/utils.php' => ['PhanPossiblyUndeclaredVariable', 'PhanTypeMismatchArgument'],
+        'safeguard/utils.php' => ['PhanTypeMismatchArgument'],
         'tests/AnyoneCanRegisterNoticeTest.php' => ['PhanTypeMismatchArgument', 'PhanTypeVoidArgument', 'PhanTypeVoidAssignment'],
         'tests/FrontendNoticesTest.php' => ['PhanUndeclaredStaticMethod'],
         'tests/PlanNoticesTest.php' => ['PhanDeprecatedProperty', 'PhanPluginUseReturnValueInternalKnown', 'PhanUndeclaredStaticMethod'],

--- a/projects/plugins/wpcomsh/changelog/fix-phan-PhanPossiblyUndeclaredVariable
+++ b/projects/plugins/wpcomsh/changelog/fix-phan-PhanPossiblyUndeclaredVariable
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Phan: Address PhanPossiblyUndeclaredVariable violations.

--- a/projects/plugins/wpcomsh/safeguard/utils.php
+++ b/projects/plugins/wpcomsh/safeguard/utils.php
@@ -198,6 +198,7 @@ function get_plugin_data_from_package( $package ) {
 		return new WP_Error( 'process_package_fails', 'Invalid plugin file.' );
 	}
 
+	$plugin_folder     = false;
 	$tmp_plugin_folder = uncompress_package( $package );
 	if ( is_wp_error( $tmp_plugin_folder ) ) {
 		return $tmp_plugin_folder;


### PR DESCRIPTION
Closes MONOREP-221

 <!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This addresses `PhanPossiblyUndeclaredVariable` violations, skipping the following:

* `packages/block-delimiter`
* `plugins/crm`
* `plugins/super-cache`
* `icalendar-reader` and `markdown` libs

Fixes include:
* Suppressions due to false positives (Phan sometimes gets confused when a var is defined under a specific condition, and later on is used under a different block gated by the same condition)
* Declaring vars in an broader scope
* Using null coalescence
* Rearranging logic (`projects/packages/backup/src/class-jetpack-backup.php` and `projects/plugins/jetpack/modules/subscriptions/views.php`)
* Adding fallback values with an `else` or `default` case

Edge cases aside, there was one actual bug in `projects/plugins/vaultpress/vaultpress.php` that may have prevented the Jetpack logo from showing.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

The goal was to keep things as close to the original functionality as possible. CI should be happy.