### PR TITLE
My Jetpack: Respect `jetpack_ai_enabled` filter in overview page

### DIFF
--- a/projects/packages/my-jetpack/changelog/fix-jetpack-ai-enabled-filter
+++ b/projects/packages/my-jetpack/changelog/fix-jetpack-ai-enabled-filter
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Respect jetpack_ai_enabled filter in My Jetpack overview page.
+
+

--- a/projects/packages/my-jetpack/src/products/class-jetpack-ai.php
+++ b/projects/packages/my-jetpack/src/products/class-jetpack-ai.php
@@ -536,6 +536,30 @@ class Jetpack_Ai extends Product {
 	}
 
 	/**
+	 * Checks whether the Product is active
+	 *
+	 * Overrides the parent method to respect the jetpack_ai_enabled filter.
+	 *
+	 * @return boolean
+	 */
+	public static function is_active() {
+		/**
+		 * Filter to enable/disable Jetpack AI.
+		 *
+		 * @since $$next-version$$
+		 *
+		 * @param boolean $enabled True if Jetpack AI should be enabled, false otherwise. Default true.
+		 */
+		$is_enabled = apply_filters( 'jetpack_ai_enabled', true );
+
+		if ( ! $is_enabled ) {
+			return false;
+		}
+
+		return parent::is_active();
+	}
+
+	/**
 	 * Get data about the AI Assistant feature
 	 *
 	 * @return array

--- a/projects/packages/my-jetpack/src/products/class-jetpack-ai.php
+++ b/projects/packages/my-jetpack/src/products/class-jetpack-ai.php
@@ -552,11 +552,7 @@ class Jetpack_Ai extends Product {
 		 */
 		$is_enabled = apply_filters( 'jetpack_ai_enabled', true );
 
-		if ( ! $is_enabled ) {
-			return false;
-		}
-
-		return parent::is_active();
+		return $is_enabled && parent::is_active();
 	}
 
 	/**

--- a/projects/packages/my-jetpack/tests/php/Jetpack_Ai_Product_Test.php
+++ b/projects/packages/my-jetpack/tests/php/Jetpack_Ai_Product_Test.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Automattic\Jetpack\My_Jetpack;
+
+use Automattic\Jetpack\My_Jetpack\Products\Jetpack_Ai;
+use PHPUnit\Framework\TestCase;
+use WorDBless\Options as WorDBless_Options;
+use WorDBless\Users as WorDBless_Users;
+
+/**
+ * Unit tests for the Jetpack AI product.
+ *
+ * @package automattic/my-jetpack
+ */
+class Jetpack_Ai_Product_Test extends TestCase {
+
+	/**
+	 * The current user id.
+	 *
+	 * @var int
+	 */
+	private static $user_id;
+
+	/**
+	 * Setting up the test.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		$this->install_mock_plugins();
+		wp_cache_delete( 'plugins', 'plugins' );
+
+		self::$user_id = wp_insert_user(
+			array(
+				'user_login' => 'test_admin',
+				'user_pass'  => '123',
+				'role'       => 'administrator',
+			)
+		);
+		wp_set_current_user( self::$user_id );
+	}
+
+	/**
+	 * Installs the mock Jetpack plugin
+	 *
+	 * @return void
+	 */
+	public function install_mock_plugins() {
+		if ( ! file_exists( WP_PLUGIN_DIR . '/jetpack' ) ) {
+			mkdir( WP_PLUGIN_DIR . '/jetpack', 0777, true );
+		}
+		copy( __DIR__ . '/assets/jetpack-mock-plugin.txt', WP_PLUGIN_DIR . '/jetpack/jetpack.php' );
+	}
+
+	/**
+	 * Returning the environment into its initial state.
+	 */
+	public function tearDown(): void {
+		parent::tearDown();
+		WorDBless_Options::init()->clear_options();
+		WorDBless_Users::init()->clear_all_users();
+		// Remove all filters to avoid interference between tests.
+		remove_all_filters( 'jetpack_ai_enabled' );
+	}
+
+	/**
+	 * Tests that Jetpack AI is active when the plugin is active
+	 */
+	public function test_jetpack_ai_is_active_when_plugin_active() {
+		activate_plugins( 'jetpack/jetpack.php' );
+		$this->assertTrue( Jetpack_Ai::is_plugin_active() );
+	}
+
+	/**
+	 * Tests that Jetpack AI respects the jetpack_ai_enabled filter when set to false
+	 */
+	public function test_jetpack_ai_respects_filter_when_disabled() {
+		activate_plugins( 'jetpack/jetpack.php' );
+
+		// Add filter to disable AI
+		add_filter( 'jetpack_ai_enabled', '__return_false', 99 );
+
+		// is_active() should return false when the filter is false
+		$this->assertFalse( Jetpack_Ai::is_active() );
+	}
+
+	/**
+	 * Tests that Jetpack AI is active when the filter returns true
+	 */
+	public function test_jetpack_ai_respects_filter_when_enabled() {
+		activate_plugins( 'jetpack/jetpack.php' );
+
+		// Add filter to enable AI (default behavior)
+		add_filter( 'jetpack_ai_enabled', '__return_true', 99 );
+
+		// Since AI has free offering and doesn't require a plan, is_active() should return true
+		$this->assertTrue( Jetpack_Ai::is_active() );
+	}
+}


### PR DESCRIPTION
Fixes MYJP-271

## Proposed changes:

Fixes a bug where the Jetpack AI product would show as "Active" in My Jetpack even when the `jetpack_ai_enabled` filter was set to false.

**Root cause:** The `Jetpack_Ai` class did not check the `jetpack_ai_enabled` filter before determining if the product is active.

**Solution:** Override the `is_active()` method in the Jetpack_Ai class to check the `jetpack_ai_enabled` filter, following the same pattern used in the AI Assistant plugin itself (see `projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/ai-assistant-plugin.php:31`).

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

MYJP-271

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

### Manual Testing:
1. Install Jetpack on a test site
2. Add the following to an MU plugin or to `projects/plugins/jetpack/jetpack.php` (around line 105):
   ```php
   add_filter( 'jetpack_ai_enabled', '__return_false', 99 );
   ```
3. Go to My Jetpack (wp-admin -> Jetpack -> My Jetpack)
4. **Verify:** AI product no longer shows up in overview
5. Remove or comment out the filter
6. **Verify:** AI now shows as active again (if Jetpack plugin is active)

### Unit Tests:
```bash
cd projects/packages/my-jetpack
composer phpunit -- --filter Jetpack_Ai_Product_Test
```

All 3 tests should pass, including:
- `test_jetpack_ai_respects_filter_when_disabled` - Verifies AI is inactive when filter returns false
- `test_jetpack_ai_respects_filter_when_enabled` - Verifies AI is active when filter returns true
- `test_jetpack_ai_enabled_by_default` - Verifies default behavior (enabled)