### PR TITLE
Global Styles: Fix exempt logic for Summer Special blog sticker

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/dotthem-119-global-styles-not-gated-after-downgrading-from-premium
+++ b/projects/packages/jetpack-mu-wpcom/changelog/dotthem-119-global-styles-not-gated-after-downgrading-from-premium
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Global Styles: Fix exempt logic for Summer Special blog sticker

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/index.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/index.php
@@ -349,8 +349,6 @@ function wpcom_global_styles_in_use() {
  * @return bool Whether the site is exempt from Premium Global Styles.
  */
 function wpcom_premium_global_styles_is_site_exempt( $blog_id = 0 ) {
-	$is_simple = false;
-	$is_atomic = false;
 	if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
 		$blog      = get_blog_details( $blog_id, false );
 		$is_simple = is_blog_wpcom( $blog );
@@ -358,6 +356,9 @@ function wpcom_premium_global_styles_is_site_exempt( $blog_id = 0 ) {
 	} elseif ( defined( 'IS_ATOMIC' ) && IS_ATOMIC ) {
 		$is_simple = false;
 		$is_atomic = true;
+	} else {
+		$is_simple = false;
+		$is_atomic = false;
 	}
 
 	if ( ! $is_simple && ! $is_atomic ) {

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/index.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/index.php
@@ -349,21 +349,33 @@ function wpcom_global_styles_in_use() {
  * @return bool Whether the site is exempt from Premium Global Styles.
  */
 function wpcom_premium_global_styles_is_site_exempt( $blog_id = 0 ) {
-	$is_summer_special = wpcom_has_blog_sticker( 'summer-special-2025', $blog_id );
-	$is_simple         = defined( 'IS_WPCOM' ) && IS_WPCOM;
+	$is_simple = false;
+	$is_atomic = false;
+	if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
+		$blog      = get_blog_details( $blog_id, false );
+		$is_simple = is_blog_wpcom( $blog );
+		$is_atomic = is_blog_atomic( $blog );
+	} elseif ( defined( 'IS_ATOMIC' ) && IS_ATOMIC ) {
+		$is_simple = false;
+		$is_atomic = true;
+	}
+
+	if ( ! $is_simple && ! $is_atomic ) {
+		return false;
+	}
 
 	// If the exemption check has already been performed, just return if the site is exempt.
 	if ( wpcom_has_blog_sticker( 'wpcom-premium-global-styles-exemption-checked', $blog_id ) ) {
 		return wpcom_has_blog_sticker( 'wpcom-premium-global-styles-exempt', $blog_id );
 	}
 
-	// Sites created after we made GS a paid feature (2022-12-15) are never exempt.
-	if ( $blog_id >= 213403000 && ! $is_summer_special ) {
+	// Simple sites created after we made GS a paid feature (2022-12-15) are never exempt.
+	if ( $is_simple && $blog_id >= 213403000 ) {
 		return false;
 	}
 
-	// Summer special sites created before 2025-10-11 are exempt. Quick workaround until we refine the exempt logic for AT sites.
-	if ( $blog_id <= 249177000 && $is_summer_special && ! $is_simple ) {
+	// Atomic sites created before we started limiting GS on Summer Special sites (2025-10-11) are always exempt.
+	if ( $is_atomic && $blog_id <= 249177000 ) {
 		return true;
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes DOTTHEM-119

## Proposed changes:

Changes the exemption logic for Global Styles since it was mistakenly assuming that all sites with Summer Special sticker were Atomic sites.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
N/A

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
- Apply these changes to your sandbox
- Create a new Simple site with the Premium plan
- Sandbox the domain of the new simple site
- Go to the Site Editor and add some Global Styles
- You won't be prompted to upgrade (as expected)
- ⚠️ **Important: Sandbox the `wordpress.com` domain** ⚠️ (otherwise the SA won't pick up these changes and will apply the `wpcom-premium-global-styles-exempt` sticker)
- Go to SA and remove the Premium plan
- Reload the Site Editor
- Make sure you're asked to upgrade now
- ⚠️ **Important: Sandbox MC**
- Open the Blog RC of your site using the sandboxed MC domain
- Make sure the `wpcom-premium-global-styles-exempt` sticker has not been applied
- Make sure the `wpcom-premium-global-styles-exemption-checked` sticker has not been applied either.
