### PR TITLE
Boost: Routinely delete expired boost transients

### DIFF
--- a/projects/packages/boost-core/changelog/add-transient-cleanup
+++ b/projects/packages/boost-core/changelog/add-transient-cleanup
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+General: added a daily cleanup of expired transients.

--- a/projects/packages/boost-core/src/lib/class-transient.php
+++ b/projects/packages/boost-core/src/lib/class-transient.php
@@ -73,6 +73,34 @@ class Transient {
 	}
 
 	/**
+	 * Delete all expired transients.
+	 *
+	 * @return int The number of deleted transients.
+	 */
+	public static function delete_expired() {
+		global $wpdb;
+
+		//phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$option_names = $wpdb->get_col(
+			$wpdb->prepare(
+				"SELECT option_name FROM $wpdb->options WHERE option_name LIKE %s",
+				self::OPTION_PREFIX . '%'
+			)
+		);
+
+		$count = 0;
+		foreach ( $option_names as $option_name ) {
+			$value = get_option( $option_name );
+			if ( isset( $value['expire'] ) && $value['expire'] < time() ) {
+				delete_option( $option_name );
+				++$count;
+			}
+		}
+
+		return $count;
+	}
+
+	/**
 	 * Delete all `Transient` values with certain prefix from database.
 	 *
 	 * @param string $prefix Cache key prefix.

--- a/projects/plugins/boost/app/class-jetpack-boost.php
+++ b/projects/plugins/boost/app/class-jetpack-boost.php
@@ -130,6 +130,8 @@ class Jetpack_Boost {
 
 		add_action( 'jetpack_boost_handle_version_change_cron', array( $this, 'handle_version_change' ) );
 
+		add_action( 'jetpack_boost_general_cleanup', array( Transient::class, 'delete_expired' ) );
+
 		// Fired when plugin ready.
 		do_action( 'jetpack_boost_loaded', $this );
 
@@ -196,6 +198,11 @@ class Jetpack_Boost {
 			// Schedule the cronjob to preload the cache for Cornerstone Pages.
 			( new Cache_Preload() )->schedule_cornerstone_cronjob();
 		}
+
+		// Setup a cleanup job
+		if ( ! wp_next_scheduled( 'jetpack_boost_general_cleanup' ) ) {
+			wp_schedule_event( time(), 'daily', 'jetpack_boost_general_cleanup' );
+		}
 	}
 
 	/**
@@ -252,6 +259,11 @@ class Jetpack_Boost {
 
 		$modules_setup = new Modules_Setup();
 
+		// Setup a cleanup job
+		if ( ! wp_next_scheduled( 'jetpack_boost_general_cleanup' ) ) {
+			wp_schedule_event( time(), 'daily', 'jetpack_boost_general_cleanup' );
+		}
+
 		/*
 		 * Check what modules are already active (from a previous activation for example).
 		 * If there are active modules, we need to ensure each module-related event is triggered again.
@@ -272,6 +284,8 @@ class Jetpack_Boost {
 	 */
 	public function deactivate() {
 		do_action( 'jetpack_boost_deactivate' );
+
+		wp_clear_scheduled_hook( 'jetpack_boost_routine_cleanup' );
 
 		// Tell Minify JS/CSS to clean up.
 		jetpack_boost_page_optimize_deactivate();

--- a/projects/plugins/boost/changelog/add-transient-cleanup
+++ b/projects/plugins/boost/changelog/add-transient-cleanup
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+General: added a daily cleanup of expired transients.


### PR DESCRIPTION
Fixes HOG-29

## Proposed changes:
* Add a Boost daily general cleanup cron job.
* Delete all expired transients when the cron job runs.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
- Create a transient; an easy way is to use the concatenate JS/CSS features.
- Look for option names like `jb_transient_%` in wp_options.
- Manually set the expiry in the value to a past timestamp, e.g. 1763066915.
- Using any cron debugging tools, run the scheduled hook for `jetpack_boost_general_cleanup`.
- Ensure that the transient got deleted.