### PR TITLE
CI: Yet again add more locking to prevent parallel tests from colliding

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-jetpack-users-test-theme-lock
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-users-test-theme-lock
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+Comment: CI: Use shared locking in Jetpack_Sync_Users_Test to avoid parallel tests from interfering.
+

--- a/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Users_Test.php
+++ b/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Users_Test.php
@@ -15,6 +15,44 @@ class Jetpack_Sync_Users_Test extends Jetpack_Sync_TestBase {
 	protected $user_id;
 
 	/**
+	 * Lock file.
+	 *
+	 * @var resource|null
+	 */
+	protected static $lockfile = null;
+
+	/**
+	 * Set up before class.
+	 *
+	 * @throws RuntimeException If locking is needed and fails.
+	 */
+	public static function set_up_before_class() {
+		parent::set_up_before_class();
+
+		// For CI coverage tests, use a lock file to avoid multiple copies of this test from interfering with each other.
+		if ( getenv( 'PHPUNIT_JETPACK_TESTSUITE_IS_PARALLEL' ) === 'true' ) {
+			static::$lockfile = fopen( WP_CONTENT_DIR . '/themes/.jplock', 'c+' );
+			if ( ! static::$lockfile ) {
+				throw new RuntimeException( 'Failed to open lockfile ' . WP_CONTENT_DIR . '/themes/.jplock' );
+			}
+			if ( ! flock( static::$lockfile, LOCK_SH ) ) {
+				throw new RuntimeException( 'Failed to lock lockfile ' . WP_CONTENT_DIR . '/themes/.jplock' );
+			}
+		}
+	}
+
+	/**
+	 * Tear down after class.
+	 */
+	public static function tear_down_after_class() {
+		parent::tear_down_after_class();
+
+		if ( static::$lockfile ) {
+			fclose( static::$lockfile );
+		}
+	}
+
+	/**
 	 * Set up.
 	 */
 	public function set_up() {


### PR DESCRIPTION
Closes MONOREP-222

 <!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

As done in #45851 and #45902, this adds locking to prevent parallel tests from colliding.

It seems Sync is the main culprit; perhaps if this continues to be an issue we should add locking to the `Jetpack_Sync_TestBase` class.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Did this break CI?
* Does this change make sense?

