### PR TITLE
fix: Mitigate editor assets endpoint hook errors

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-block-editor-assets.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-block-editor-assets.php
@@ -475,9 +475,13 @@ class WPCOM_REST_API_V2_Endpoint_Block_Editor_Assets extends WP_REST_Controller 
 	/**
 	 * Removes hooks from problematic plugins that cause errors in this endpoint.
 	 *
-	 * This method removes hooks from specific plugins that are known to cause
-	 * 500 errors when the enqueue_block_editor_assets action is triggered in
-	 * the REST API context.
+	 * Some plugins conditionally load admin-only code based on is_admin(), which
+	 * returns false in REST API contexts. When these plugins hook into
+	 * enqueue_block_editor_assets without checking the context, they may call
+	 * undefined functions that were never loaded, causing fatal errors.
+	 *
+	 * This method preemptively removes hooks from known problematic plugins before
+	 * the enqueue_block_editor_assets action fires, preventing fatal errors.
 	 */
 	private function remove_problematic_plugin_hooks() {
 		global $wp_filter;

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-block-editor-assets.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-block-editor-assets.php
@@ -520,18 +520,34 @@ class WPCOM_REST_API_V2_Endpoint_Block_Editor_Assets extends WP_REST_Controller 
 	 * @return bool True if the callback belongs to the plugin, false otherwise.
 	 */
 	private function is_callback_from_plugin( $callback, $plugin_slug ) {
-		// Handle object method callbacks [object, 'method_name']
+		// Handle array-based callbacks: object methods or static class methods
 		if ( is_array( $callback ) && count( $callback ) === 2 ) {
-			$object = $callback[0];
-			if ( is_object( $object ) ) {
+			$class_or_object = $callback[0];
+
+			// Handle object method callbacks [object, 'method_name']
+			if ( is_object( $class_or_object ) ) {
 				try {
-					$reflection = new ReflectionClass( $object );
+					$reflection = new ReflectionClass( $class_or_object );
 					$file_path  = $reflection->getFileName();
 					if ( $file_path && $this->is_file_from_plugin( $file_path, $plugin_slug ) ) {
 						return true;
 					}
 				} catch ( ReflectionException $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
 					// Failed to reflect on this object (e.g., internal class, anonymous class).
+					// Continue checking other callback types.
+				}
+			}
+
+			// Handle static method array callbacks ['ClassName', 'method_name']
+			if ( is_string( $class_or_object ) && class_exists( $class_or_object ) ) {
+				try {
+					$reflection = new ReflectionClass( $class_or_object );
+					$file_path  = $reflection->getFileName();
+					if ( $file_path && $this->is_file_from_plugin( $file_path, $plugin_slug ) ) {
+						return true;
+					}
+				} catch ( ReflectionException $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
+					// Failed to reflect on this class (e.g., internal class).
 					// Continue checking other callback types.
 				}
 			}

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-block-editor-assets.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-block-editor-assets.php
@@ -523,7 +523,7 @@ class WPCOM_REST_API_V2_Endpoint_Block_Editor_Assets extends WP_REST_Controller 
 				try {
 					$reflection = new ReflectionClass( $object );
 					$file_path  = $reflection->getFileName();
-					if ( $file_path && str_contains( $file_path, '/plugins/' . $plugin_slug . '/' ) ) {
+					if ( $file_path && $this->is_file_from_plugin( $file_path, $plugin_slug ) ) {
 						return true;
 					}
 				} catch ( ReflectionException $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
@@ -540,7 +540,7 @@ class WPCOM_REST_API_V2_Endpoint_Block_Editor_Assets extends WP_REST_Controller 
 				try {
 					$reflection = new ReflectionClass( $class_name );
 					$file_path  = $reflection->getFileName();
-					if ( $file_path && str_contains( $file_path, '/plugins/' . $plugin_slug . '/' ) ) {
+					if ( $file_path && $this->is_file_from_plugin( $file_path, $plugin_slug ) ) {
 						return true;
 					}
 				} catch ( ReflectionException $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
@@ -555,12 +555,40 @@ class WPCOM_REST_API_V2_Endpoint_Block_Editor_Assets extends WP_REST_Controller 
 			try {
 				$reflection = new ReflectionFunction( $callback );
 				$file_path  = $reflection->getFileName();
-				if ( $file_path && str_contains( $file_path, '/plugins/' . $plugin_slug . '/' ) ) {
+				if ( $file_path && $this->is_file_from_plugin( $file_path, $plugin_slug ) ) {
 					return true;
 				}
 			} catch ( ReflectionException $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
 				// Failed to reflect on this function (e.g., internal function).
 				// Continue to return false.
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Checks if a file path belongs to a specific plugin.
+	 *
+	 * @param string $file_path The file path to check.
+	 * @param string $plugin_slug The plugin slug to match against.
+	 * @return bool True if the file belongs to the plugin, false otherwise.
+	 */
+	private function is_file_from_plugin( $file_path, $plugin_slug ) {
+		// Normalize the file path for consistent comparison
+		$file_path = wp_normalize_path( $file_path );
+
+		// Check in standard plugins directory
+		$plugin_dir = wp_normalize_path( WP_PLUGIN_DIR );
+		if ( str_contains( $file_path, $plugin_dir . '/' . $plugin_slug . '/' ) ) {
+			return true;
+		}
+
+		// Check in mu-plugins directory if defined
+		if ( defined( 'WPMU_PLUGIN_DIR' ) ) {
+			$mu_plugin_dir = wp_normalize_path( WPMU_PLUGIN_DIR );
+			if ( str_contains( $file_path, $mu_plugin_dir . '/' . $plugin_slug . '/' ) ) {
+				return true;
 			}
 		}
 

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-block-editor-assets.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-block-editor-assets.php
@@ -486,133 +486,87 @@ class WPCOM_REST_API_V2_Endpoint_Block_Editor_Assets extends WP_REST_Controller 
 	private function remove_problematic_plugin_hooks() {
 		global $wp_filter;
 
-		// List of problematic plugins and their callback patterns
+		// Only target the enqueue_block_editor_assets hook
+		if ( ! isset( $wp_filter['enqueue_block_editor_assets'] ) ) {
+			return;
+		}
+
 		$problematic_plugins = array(
-			'wpforms-lite' => array(
-				'enqueue_block_editor_assets',
-			),
+			'wpforms-lite/wpforms.php',
 		);
 
-		foreach ( $problematic_plugins as $plugin_slug => $hook_names ) {
-			foreach ( $hook_names as $hook_name ) {
-				if ( ! isset( $wp_filter[ $hook_name ] ) ) {
-					continue;
+		// Early return if no problematic plugins are active
+		$has_active_problematic_plugin = false;
+		foreach ( $problematic_plugins as $plugin_file ) {
+			if ( is_plugin_active( $plugin_file ) ) {
+				$has_active_problematic_plugin = true;
+				break;
+			}
+		}
+
+		if ( ! $has_active_problematic_plugin ) {
+			return;
+		}
+
+		$plugin_slugs = array_map(
+			function ( $plugin_file ) {
+				return dirname( $plugin_file );
+			},
+			$problematic_plugins
+		);
+
+		// Collect callbacks to remove (improves performance by separating detection from removal)
+		$callbacks_to_remove = array();
+
+		foreach ( $wp_filter['enqueue_block_editor_assets']->callbacks as $priority => $callbacks ) {
+			foreach ( $callbacks as $callback_data ) {
+				$callback  = $callback_data['function'];
+				$file_path = null;
+
+				// Handle object method callbacks: [$object, 'method_name']
+				if ( is_array( $callback ) && count( $callback ) === 2 && is_object( $callback[0] ) ) {
+					try {
+						$reflection = new ReflectionClass( $callback[0] );
+						$file_path  = $reflection->getFileName();
+					} catch ( ReflectionException $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
+						// Skip if reflection fails
+						continue;
+					}
 				}
 
-				// Iterate through all priorities for this hook
-				foreach ( $wp_filter[ $hook_name ]->callbacks as $priority => $callbacks ) {
-					foreach ( $callbacks as $callback_data ) {
-						// Check if this callback belongs to the problematic plugin
-						if ( $this->is_callback_from_plugin( $callback_data['function'], $plugin_slug ) ) {
-							remove_action( $hook_name, $callback_data['function'], $priority );
+				// Handle function name callbacks: 'function_name'
+				if ( is_string( $callback ) && function_exists( $callback ) && ! str_contains( $callback, '::' ) ) {
+					try {
+						$reflection = new ReflectionFunction( $callback );
+						$file_path  = $reflection->getFileName();
+					} catch ( ReflectionException $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
+						// Skip if reflection fails
+						continue;
+					}
+				}
+
+				// Check if file belongs to any problematic plugin
+				if ( $file_path ) {
+					$normalized_path = wp_normalize_path( $file_path );
+					$plugin_dir      = wp_normalize_path( WP_PLUGIN_DIR );
+
+					foreach ( $plugin_slugs as $plugin_slug ) {
+						if ( str_contains( $normalized_path, $plugin_dir . '/' . $plugin_slug . '/' ) ) {
+							$callbacks_to_remove[] = array(
+								'callback' => $callback,
+								'priority' => $priority,
+							);
+							break;
 						}
 					}
 				}
 			}
 		}
-	}
 
-	/**
-	 * Checks if a callback function belongs to a specific plugin.
-	 *
-	 * @param callable|array $callback The callback to check.
-	 * @param string         $plugin_slug The plugin slug to match against.
-	 * @return bool True if the callback belongs to the plugin, false otherwise.
-	 */
-	private function is_callback_from_plugin( $callback, $plugin_slug ) {
-		// Handle array-based callbacks: object methods or static class methods
-		if ( is_array( $callback ) && count( $callback ) === 2 ) {
-			$class_or_object = $callback[0];
-
-			// Handle object method callbacks [object, 'method_name']
-			if ( is_object( $class_or_object ) ) {
-				try {
-					$reflection = new ReflectionClass( $class_or_object );
-					$file_path  = $reflection->getFileName();
-					if ( $file_path && $this->is_file_from_plugin( $file_path, $plugin_slug ) ) {
-						return true;
-					}
-				} catch ( ReflectionException $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
-					// Failed to reflect on this object (e.g., internal class, anonymous class).
-					// Continue checking other callback types.
-				}
-			}
-
-			// Handle static method array callbacks ['ClassName', 'method_name']
-			if ( is_string( $class_or_object ) && class_exists( $class_or_object ) ) {
-				try {
-					$reflection = new ReflectionClass( $class_or_object );
-					$file_path  = $reflection->getFileName();
-					if ( $file_path && $this->is_file_from_plugin( $file_path, $plugin_slug ) ) {
-						return true;
-					}
-				} catch ( ReflectionException $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
-					// Failed to reflect on this class (e.g., internal class).
-					// Continue checking other callback types.
-				}
-			}
+		// Remove all identified callbacks
+		foreach ( $callbacks_to_remove as $item ) {
+			remove_action( 'enqueue_block_editor_assets', $item['callback'], $item['priority'] );
 		}
-
-		// Handle static method callbacks 'ClassName::method_name'
-		if ( is_string( $callback ) && str_contains( $callback, '::' ) ) {
-			list( $class_name, ) = explode( '::', $callback, 2 );
-			if ( class_exists( $class_name ) ) {
-				try {
-					$reflection = new ReflectionClass( $class_name );
-					$file_path  = $reflection->getFileName();
-					if ( $file_path && $this->is_file_from_plugin( $file_path, $plugin_slug ) ) {
-						return true;
-					}
-				} catch ( ReflectionException $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
-					// Failed to reflect on this class (e.g., internal class).
-					// Continue checking other callback types.
-				}
-			}
-		}
-
-		// Handle function name callbacks
-		if ( is_string( $callback ) && function_exists( $callback ) ) {
-			try {
-				$reflection = new ReflectionFunction( $callback );
-				$file_path  = $reflection->getFileName();
-				if ( $file_path && $this->is_file_from_plugin( $file_path, $plugin_slug ) ) {
-					return true;
-				}
-			} catch ( ReflectionException $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
-				// Failed to reflect on this function (e.g., internal function).
-				// Continue to return false.
-			}
-		}
-
-		return false;
-	}
-
-	/**
-	 * Checks if a file path belongs to a specific plugin.
-	 *
-	 * @param string $file_path The file path to check.
-	 * @param string $plugin_slug The plugin slug to match against.
-	 * @return bool True if the file belongs to the plugin, false otherwise.
-	 */
-	private function is_file_from_plugin( $file_path, $plugin_slug ) {
-		// Normalize the file path for consistent comparison
-		$file_path = wp_normalize_path( $file_path );
-
-		// Check in standard plugins directory
-		$plugin_dir = wp_normalize_path( WP_PLUGIN_DIR );
-		if ( str_contains( $file_path, $plugin_dir . '/' . $plugin_slug . '/' ) ) {
-			return true;
-		}
-
-		// Check in mu-plugins directory if defined
-		if ( defined( 'WPMU_PLUGIN_DIR' ) ) {
-			$mu_plugin_dir = wp_normalize_path( WPMU_PLUGIN_DIR );
-			if ( str_contains( $file_path, $mu_plugin_dir . '/' . $plugin_slug . '/' ) ) {
-				return true;
-			}
-		}
-
-		return false;
 	}
 
 	/**

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-block-editor-assets.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-block-editor-assets.php
@@ -214,6 +214,9 @@ class WPCOM_REST_API_V2_Endpoint_Block_Editor_Assets extends WP_REST_Controller 
 			// Enqueue all core WordPress editor assets
 			$this->enqueue_core_editor_assets();
 
+			// Remove problematic plugin hooks before triggering block editor asset actions
+			$this->remove_problematic_plugin_hooks();
+
 			// Trigger block editor asset actions with forced script/style loading
 			add_filter( 'should_load_block_editor_scripts_and_styles', '__return_true' );
 			do_action( 'enqueue_block_assets' );
@@ -467,6 +470,86 @@ class WPCOM_REST_API_V2_Endpoint_Block_Editor_Assets extends WP_REST_Controller 
 			$current_screen->is_block_editor( true );
 			$current_screen->post_type = $post_type;
 		}
+	}
+
+	/**
+	 * Removes hooks from problematic plugins that cause errors in this endpoint.
+	 *
+	 * This method removes hooks from specific plugins that are known to cause
+	 * 500 errors when the enqueue_block_editor_assets action is triggered in
+	 * the REST API context.
+	 */
+	private function remove_problematic_plugin_hooks() {
+		global $wp_filter;
+
+		// List of problematic plugins and their callback patterns
+		$problematic_plugins = array(
+			'wpforms-lite' => array(
+				'enqueue_block_editor_assets',
+			),
+		);
+
+		foreach ( $problematic_plugins as $plugin_slug => $hook_names ) {
+			foreach ( $hook_names as $hook_name ) {
+				if ( ! isset( $wp_filter[ $hook_name ] ) ) {
+					continue;
+				}
+
+				// Iterate through all priorities for this hook
+				foreach ( $wp_filter[ $hook_name ]->callbacks as $priority => $callbacks ) {
+					foreach ( $callbacks as $callback_data ) {
+						// Check if this callback belongs to the problematic plugin
+						if ( $this->is_callback_from_plugin( $callback_data['function'], $plugin_slug ) ) {
+							remove_action( $hook_name, $callback_data['function'], $priority );
+						}
+					}
+				}
+			}
+		}
+	}
+
+	/**
+	 * Checks if a callback function belongs to a specific plugin.
+	 *
+	 * @param callable|array $callback The callback to check.
+	 * @param string         $plugin_slug The plugin slug to match against.
+	 * @return bool True if the callback belongs to the plugin, false otherwise.
+	 */
+	private function is_callback_from_plugin( $callback, $plugin_slug ) {
+		// Handle object method callbacks [object, 'method_name']
+		if ( is_array( $callback ) && count( $callback ) === 2 ) {
+			$object = $callback[0];
+			if ( is_object( $object ) ) {
+				$reflection = new ReflectionClass( $object );
+				$file_path  = $reflection->getFileName();
+				if ( $file_path && str_contains( $file_path, '/plugins/' . $plugin_slug . '/' ) ) {
+					return true;
+				}
+			}
+		}
+
+		// Handle static method callbacks 'ClassName::method_name'
+		if ( is_string( $callback ) && str_contains( $callback, '::' ) ) {
+			list( $class_name, ) = explode( '::', $callback, 2 );
+			if ( class_exists( $class_name ) ) {
+				$reflection = new ReflectionClass( $class_name );
+				$file_path  = $reflection->getFileName();
+				if ( $file_path && str_contains( $file_path, '/plugins/' . $plugin_slug . '/' ) ) {
+					return true;
+				}
+			}
+		}
+
+		// Handle function name callbacks
+		if ( is_string( $callback ) && function_exists( $callback ) ) {
+			$reflection = new ReflectionFunction( $callback );
+			$file_path  = $reflection->getFileName();
+			if ( $file_path && str_contains( $file_path, '/plugins/' . $plugin_slug . '/' ) ) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	/**

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-block-editor-assets.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-block-editor-assets.php
@@ -520,10 +520,15 @@ class WPCOM_REST_API_V2_Endpoint_Block_Editor_Assets extends WP_REST_Controller 
 		if ( is_array( $callback ) && count( $callback ) === 2 ) {
 			$object = $callback[0];
 			if ( is_object( $object ) ) {
-				$reflection = new ReflectionClass( $object );
-				$file_path  = $reflection->getFileName();
-				if ( $file_path && str_contains( $file_path, '/plugins/' . $plugin_slug . '/' ) ) {
-					return true;
+				try {
+					$reflection = new ReflectionClass( $object );
+					$file_path  = $reflection->getFileName();
+					if ( $file_path && str_contains( $file_path, '/plugins/' . $plugin_slug . '/' ) ) {
+						return true;
+					}
+				} catch ( ReflectionException $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
+					// Failed to reflect on this object (e.g., internal class, anonymous class).
+					// Continue checking other callback types.
 				}
 			}
 		}
@@ -532,20 +537,30 @@ class WPCOM_REST_API_V2_Endpoint_Block_Editor_Assets extends WP_REST_Controller 
 		if ( is_string( $callback ) && str_contains( $callback, '::' ) ) {
 			list( $class_name, ) = explode( '::', $callback, 2 );
 			if ( class_exists( $class_name ) ) {
-				$reflection = new ReflectionClass( $class_name );
-				$file_path  = $reflection->getFileName();
-				if ( $file_path && str_contains( $file_path, '/plugins/' . $plugin_slug . '/' ) ) {
-					return true;
+				try {
+					$reflection = new ReflectionClass( $class_name );
+					$file_path  = $reflection->getFileName();
+					if ( $file_path && str_contains( $file_path, '/plugins/' . $plugin_slug . '/' ) ) {
+						return true;
+					}
+				} catch ( ReflectionException $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
+					// Failed to reflect on this class (e.g., internal class).
+					// Continue checking other callback types.
 				}
 			}
 		}
 
 		// Handle function name callbacks
 		if ( is_string( $callback ) && function_exists( $callback ) ) {
-			$reflection = new ReflectionFunction( $callback );
-			$file_path  = $reflection->getFileName();
-			if ( $file_path && str_contains( $file_path, '/plugins/' . $plugin_slug . '/' ) ) {
-				return true;
+			try {
+				$reflection = new ReflectionFunction( $callback );
+				$file_path  = $reflection->getFileName();
+				if ( $file_path && str_contains( $file_path, '/plugins/' . $plugin_slug . '/' ) ) {
+					return true;
+				}
+			} catch ( ReflectionException $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
+				// Failed to reflect on this function (e.g., internal function).
+				// Continue to return false.
 			}
 		}
 

--- a/projects/plugins/jetpack/changelog/fix-mitigate-editor-assets-endpoint-hook-errors
+++ b/projects/plugins/jetpack/changelog/fix-mitigate-editor-assets-endpoint-hook-errors
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Editor assets endpoint: mitigate hook errors originating from plugins referencing conditionally defined functions via `is_admin()`, which is false for the REST API.

--- a/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_Block_Editor_Assets_Test.php
+++ b/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_Block_Editor_Assets_Test.php
@@ -1215,7 +1215,12 @@ class WPCOM_REST_API_V2_Endpoint_Block_Editor_Assets_Test extends Jetpack_REST_T
 			unlink( $plugin_file );
 		}
 		if ( $created_plugin_dir ) {
-			rmdir( $plugins_dir );
+			// Only remove directory if it's empty (to avoid failures if other files exist)
+			$dir_contents = scandir( $plugins_dir );
+			$is_empty     = count( $dir_contents ) === 2; // Only '.' and '..' remain
+			if ( $is_empty ) {
+				rmdir( $plugins_dir );
+			}
 		}
 	}
 }

--- a/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_Block_Editor_Assets_Test.php
+++ b/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_Block_Editor_Assets_Test.php
@@ -1223,4 +1223,82 @@ class WPCOM_REST_API_V2_Endpoint_Block_Editor_Assets_Test extends Jetpack_REST_T
 			}
 		}
 	}
+
+	/**
+	 * Test that wpforms-lite static method array callback is not executed after hook removal.
+	 *
+	 * This test verifies that static method callbacks in array format ['ClassName', 'method_name']
+	 * are properly detected and removed from the enqueue_block_editor_assets hook.
+	 *
+	 * @phan-suppress PhanUndeclaredClassStaticProperty, PhanUndeclaredClassInCallable
+	 */
+	public function test_wpforms_static_array_callback_is_not_executed_after_hook_removal() {
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'editor' ) ) );
+
+		// Create a mock wpforms-lite plugin directory and class file
+		$plugins_dir         = WP_PLUGIN_DIR . '/wpforms-lite';
+		$plugin_file         = $plugins_dir . '/wpforms-static-mock.php';
+		$created_plugin_dir  = false;
+		$created_plugin_file = false;
+
+		// Create temporary plugin structure if it doesn't exist
+		if ( ! is_dir( $plugins_dir ) ) {
+			mkdir( $plugins_dir, 0777, true );
+			$created_plugin_dir = true;
+		}
+
+		if ( ! file_exists( $plugin_file ) ) {
+			file_put_contents(
+				$plugin_file,
+				'<?php
+				if ( ! class_exists( "WPForms_Static_Mock_Class" ) ) {
+					class WPForms_Static_Mock_Class {
+						public static $callback_executed = false;
+						public static function static_callback() {
+							self::$callback_executed = true;
+						}
+					}
+				}'
+			);
+			$created_plugin_file = true;
+		}
+
+		// Include the mock plugin file
+		require_once $plugin_file;
+
+		// Reset the static flag
+		WPForms_Static_Mock_Class::$callback_executed = false;
+
+		// Add static callback from the mock wpforms-lite plugin using array format
+		add_action( 'enqueue_block_editor_assets', array( 'WPForms_Static_Mock_Class', 'static_callback' ), 10 );
+
+		// Verify the hook is registered before the request
+		$this->assertTrue( has_action( 'enqueue_block_editor_assets', array( 'WPForms_Static_Mock_Class', 'static_callback' ) ) !== false, 'Hook should be registered before request' );
+
+		// Make the REST request - this should trigger remove_problematic_plugin_hooks
+		$request  = new WP_REST_Request( Requests::GET, '/wpcom/v2/editor-assets' );
+		$response = $this->server->dispatch( $request );
+
+		// Should return 200
+		$this->assertEquals( 200, $response->get_status() );
+
+		// CRITICAL: The callback should NOT have executed because it was removed
+		$this->assertFalse( WPForms_Static_Mock_Class::$callback_executed, 'WPForms static array callback should NOT execute after hook removal' );
+
+		// Clean up
+		remove_action( 'enqueue_block_editor_assets', array( 'WPForms_Static_Mock_Class', 'static_callback' ), 10 );
+
+		// Remove temporary files if we created them
+		if ( $created_plugin_file ) {
+			unlink( $plugin_file );
+		}
+		if ( $created_plugin_dir ) {
+			// Only remove directory if it's empty (to avoid failures if other files exist)
+			$dir_contents = scandir( $plugins_dir );
+			$is_empty     = count( $dir_contents ) === 2; // Only '.' and '..' remain
+			if ( $is_empty ) {
+				rmdir( $plugins_dir );
+			}
+		}
+	}
 }

--- a/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_Block_Editor_Assets_Test.php
+++ b/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_Block_Editor_Assets_Test.php
@@ -1185,6 +1185,17 @@ class WPCOM_REST_API_V2_Endpoint_Block_Editor_Assets_Test extends Jetpack_REST_T
 		// Include the mock plugin file
 		require_once $plugin_file;
 
+		// Mock is_plugin_active() to return true for wpforms-lite (simulates production scenario)
+		add_filter(
+			'option_active_plugins',
+			function ( $plugins ) {
+				if ( ! in_array( 'wpforms-lite/wpforms.php', $plugins, true ) ) {
+					$plugins[] = 'wpforms-lite/wpforms.php';
+				}
+				return $plugins;
+			}
+		);
+
 		// Reset the static flag
 		WPForms_Mock_Class::$callback_executed = false;
 
@@ -1209,84 +1220,6 @@ class WPCOM_REST_API_V2_Endpoint_Block_Editor_Assets_Test extends Jetpack_REST_T
 
 		// Clean up
 		remove_action( 'enqueue_block_editor_assets', array( $wpforms_instance, 'mock_callback' ), 10 );
-
-		// Remove temporary files if we created them
-		if ( $created_plugin_file ) {
-			unlink( $plugin_file );
-		}
-		if ( $created_plugin_dir ) {
-			// Only remove directory if it's empty (to avoid failures if other files exist)
-			$dir_contents = scandir( $plugins_dir );
-			$is_empty     = count( $dir_contents ) === 2; // Only '.' and '..' remain
-			if ( $is_empty ) {
-				rmdir( $plugins_dir );
-			}
-		}
-	}
-
-	/**
-	 * Test that wpforms-lite static method array callback is not executed after hook removal.
-	 *
-	 * This test verifies that static method callbacks in array format ['ClassName', 'method_name']
-	 * are properly detected and removed from the enqueue_block_editor_assets hook.
-	 *
-	 * @phan-suppress PhanUndeclaredClassStaticProperty, PhanUndeclaredClassInCallable
-	 */
-	public function test_wpforms_static_array_callback_is_not_executed_after_hook_removal() {
-		wp_set_current_user( self::factory()->user->create( array( 'role' => 'editor' ) ) );
-
-		// Create a mock wpforms-lite plugin directory and class file
-		$plugins_dir         = WP_PLUGIN_DIR . '/wpforms-lite';
-		$plugin_file         = $plugins_dir . '/wpforms-static-mock.php';
-		$created_plugin_dir  = false;
-		$created_plugin_file = false;
-
-		// Create temporary plugin structure if it doesn't exist
-		if ( ! is_dir( $plugins_dir ) ) {
-			mkdir( $plugins_dir, 0777, true );
-			$created_plugin_dir = true;
-		}
-
-		if ( ! file_exists( $plugin_file ) ) {
-			file_put_contents(
-				$plugin_file,
-				'<?php
-				if ( ! class_exists( "WPForms_Static_Mock_Class" ) ) {
-					class WPForms_Static_Mock_Class {
-						public static $callback_executed = false;
-						public static function static_callback() {
-							self::$callback_executed = true;
-						}
-					}
-				}'
-			);
-			$created_plugin_file = true;
-		}
-
-		// Include the mock plugin file
-		require_once $plugin_file;
-
-		// Reset the static flag
-		WPForms_Static_Mock_Class::$callback_executed = false;
-
-		// Add static callback from the mock wpforms-lite plugin using array format
-		add_action( 'enqueue_block_editor_assets', array( 'WPForms_Static_Mock_Class', 'static_callback' ), 10 );
-
-		// Verify the hook is registered before the request
-		$this->assertTrue( has_action( 'enqueue_block_editor_assets', array( 'WPForms_Static_Mock_Class', 'static_callback' ) ) !== false, 'Hook should be registered before request' );
-
-		// Make the REST request - this should trigger remove_problematic_plugin_hooks
-		$request  = new WP_REST_Request( Requests::GET, '/wpcom/v2/editor-assets' );
-		$response = $this->server->dispatch( $request );
-
-		// Should return 200
-		$this->assertEquals( 200, $response->get_status() );
-
-		// CRITICAL: The callback should NOT have executed because it was removed
-		$this->assertFalse( WPForms_Static_Mock_Class::$callback_executed, 'WPForms static array callback should NOT execute after hook removal' );
-
-		// Clean up
-		remove_action( 'enqueue_block_editor_assets', array( 'WPForms_Static_Mock_Class', 'static_callback' ), 10 );
 
 		// Remove temporary files if we created them
 		if ( $created_plugin_file ) {

--- a/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_Block_Editor_Assets_Test.php
+++ b/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_Block_Editor_Assets_Test.php
@@ -1148,6 +1148,8 @@ class WPCOM_REST_API_V2_Endpoint_Block_Editor_Assets_Test extends Jetpack_REST_T
 	 *
 	 * This test creates a mock wpforms-lite plugin structure and verifies
 	 * that callbacks from that plugin are removed before execution.
+	 *
+	 * @phan-suppress PhanUndeclaredClassMethod, PhanUndeclaredClassStaticProperty, PhanUndeclaredClassInCallable
 	 */
 	public function test_wpforms_callback_is_not_executed_after_hook_removal() {
 		wp_set_current_user( self::factory()->user->create( array( 'role' => 'editor' ) ) );
@@ -1168,10 +1170,12 @@ class WPCOM_REST_API_V2_Endpoint_Block_Editor_Assets_Test extends Jetpack_REST_T
 			file_put_contents(
 				$plugin_file,
 				'<?php
-				class WPForms_Mock_Class {
-					public static $callback_executed = false;
-					public function mock_callback() {
-						self::$callback_executed = true;
+				if ( ! class_exists( "WPForms_Mock_Class" ) ) {
+					class WPForms_Mock_Class {
+						public static $callback_executed = false;
+						public function mock_callback() {
+							self::$callback_executed = true;
+						}
 					}
 				}'
 			);

--- a/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_Block_Editor_Assets_Test.php
+++ b/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_Block_Editor_Assets_Test.php
@@ -1142,4 +1142,76 @@ class WPCOM_REST_API_V2_Endpoint_Block_Editor_Assets_Test extends Jetpack_REST_T
 		$this->assertStringContainsString( 'jetpack-ie.js', $data['scripts'], 'Jetpack script in conditional comment should be preserved when excluding core' );
 		$this->assertStringContainsString( 'jetpack-ie-compat', $data['scripts'], 'Jetpack script handle should be preserved' );
 	}
+
+	/**
+	 * Test that wpforms-lite callback is not executed after hook removal.
+	 *
+	 * This test creates a mock wpforms-lite plugin structure and verifies
+	 * that callbacks from that plugin are removed before execution.
+	 */
+	public function test_wpforms_callback_is_not_executed_after_hook_removal() {
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'editor' ) ) );
+
+		// Create a mock wpforms-lite plugin directory and class file
+		$plugins_dir         = WP_PLUGIN_DIR . '/wpforms-lite';
+		$plugin_file         = $plugins_dir . '/wpforms-mock.php';
+		$created_plugin_dir  = false;
+		$created_plugin_file = false;
+
+		// Create temporary plugin structure if it doesn't exist
+		if ( ! is_dir( $plugins_dir ) ) {
+			mkdir( $plugins_dir, 0777, true );
+			$created_plugin_dir = true;
+		}
+
+		if ( ! file_exists( $plugin_file ) ) {
+			file_put_contents(
+				$plugin_file,
+				'<?php
+				class WPForms_Mock_Class {
+					public static $callback_executed = false;
+					public function mock_callback() {
+						self::$callback_executed = true;
+					}
+				}'
+			);
+			$created_plugin_file = true;
+		}
+
+		// Include the mock plugin file
+		require_once $plugin_file;
+
+		// Reset the static flag
+		WPForms_Mock_Class::$callback_executed = false;
+
+		// Create an instance of the mock class (needed for object method callback detection)
+		$wpforms_instance = new WPForms_Mock_Class();
+
+		// Add callback from the mock wpforms-lite plugin using instance method
+		add_action( 'enqueue_block_editor_assets', array( $wpforms_instance, 'mock_callback' ), 10 );
+
+		// Verify the hook is registered before the request
+		$this->assertTrue( has_action( 'enqueue_block_editor_assets', array( $wpforms_instance, 'mock_callback' ) ) !== false, 'Hook should be registered before request' );
+
+		// Make the REST request - this should trigger remove_problematic_plugin_hooks
+		$request  = new WP_REST_Request( Requests::GET, '/wpcom/v2/editor-assets' );
+		$response = $this->server->dispatch( $request );
+
+		// Should return 200
+		$this->assertEquals( 200, $response->get_status() );
+
+		// CRITICAL: The callback should NOT have executed because it was removed
+		$this->assertFalse( WPForms_Mock_Class::$callback_executed, 'WPForms callback should NOT execute after hook removal - this test MUST fail when remove_problematic_plugin_hooks() is disabled' );
+
+		// Clean up
+		remove_action( 'enqueue_block_editor_assets', array( $wpforms_instance, 'mock_callback' ), 10 );
+
+		// Remove temporary files if we created them
+		if ( $created_plugin_file ) {
+			unlink( $plugin_file );
+		}
+		if ( $created_plugin_dir ) {
+			rmdir( $plugins_dir );
+		}
+	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fix CMM-937. 

Sometimes, plugins conditionally define functions based on `is_admin()`. For REST API endpoints, `is_admin()` is false. This can result in invocations of undefined functions when applying hooks—e.g., `enqueue_block_editor_assets`. 

As a specific example, [`wpforms-lite`](https://wordpress.org/plugins/wpforms-lite/) conditionally [registers `wpforms_admin_upgrade_link`](https://plugins.trac.wordpress.org/browser/wpforms-lite/trunk/src/WPForms.php?rev=3367762#L242) during `plugins_loaded`. Because `plugins_loaded` occurs before the REST API endpoint runs, we cannot influence `is_admin()`'s return before `wpforms-lite` evaluates whether to define its function. This results in a fatal error when applying `enqueue_block_editor_assets`. 

<details><summary>Example wpforms-lite fatal error</summary>
<p>

```
PHP Fatal error:  Uncaught Error: Call to undefined function WPForms\Admin\Education\wpforms_admin_upgrade_link() in /srv/htdocs/wp-content/plugins/wpforms-lite/src/Admin/Education/StringsTrait.php:178
Stack trace:
#0 /srv/htdocs/wp-content/plugins/wpforms-lite/src/Admin/Education/StringsTrait.php(97): WPForms\Integrations\Gutenberg\FormSelector->get_upgrade_strings('Pro', '%name%', 'gutenberg')
#1 /srv/htdocs/wp-content/plugins/wpforms-lite/src/Integrations/Gutenberg/FormSelector.php(404): WPForms\Integrations\Gutenberg\FormSelector->get_js_strings()
#2 /srv/htdocs/wp-content/plugins/wpforms-lite/src/Lite/Integrations/Gutenberg/FormSelector.php(80): WPForms\Integrations\Gutenberg\FormSelector->enqueue_block_editor_assets()
#3 /srv/htdocs/__wp__/wp-includes/class-wp-hook.php(324): WPForms\Lite\Integrations\Gutenberg\FormSelector->enqueue_block_editor_assets('')
#4 /srv/htdocs/__wp__/wp-includes/class-wp-hook.php(348): WP_Hook->apply_filters(NULL, Array)
#5 /srv/htdocs/__wp__/wp-includes/plugin.php(517): WP_Hook->do_action(Array)
#6 /srv/htdocs/wp-content/plugins/jetpack-dev/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-block-editor-assets.php(220): do_action('enqueue_block_e...')
#7 /srv/htdocs/__wp__/wp-includes/rest-api/class-wp-rest-server.php(1292): WPCOM_REST_API_V2_Endpoint_Block_Editor_Assets->get_items(Object(WP_REST_Request))
#8 /srv/htdocs/__wp__/wp-includes/rest-api/class-wp-rest-server.php(1125): WP_REST_Server->respond_to_request(Object(WP_REST_Request), '/wpcom/v2/edito...', Array, NULL)
#9 /srv/htdocs/__wp__/wp-includes/rest-api/class-wp-rest-server.php(439): WP_REST_Server->dispatch(Object(WP_REST_Request))
#10 /srv/htdocs/__wp__/wp-includes/rest-api.php(459): WP_REST_Server->serve_request('/wpcom/v2/edito...')
#11 /srv/htdocs/__wp__/wp-includes/class-wp-hook.php(324): rest_api_loaded(Object(WP))
#12 /srv/htdocs/__wp__/wp-includes/class-wp-hook.php(348): WP_Hook->apply_filters('', Array)
#13 /srv/htdocs/__wp__/wp-includes/plugin.php(565): WP_Hook->do_action(Array)
#14 /srv/htdocs/__wp__/wp-includes/class-wp.php(418): do_action_ref_array('parse_request', Array)
#15 /srv/htdocs/__wp__/wp-includes/class-wp.php(818): WP->parse_request('')
#16 /srv/htdocs/__wp__/wp-includes/functions.php(1342): WP->main('')
#17 /srv/htdocs/__wp__/wp-blog-header.php(16): wp()
#18 /srv/htdocs/__wp__/index.php(17): require('/srv/htdocs/__w...')
#19 {main}
  thrown in /srv/htdocs/wp-content/plugins/wpforms-lite/src/Admin/Education/StringsTrait.php on line 178
```

</p>
</details> 

We cannot catch the fatal errors with try-catch as they occur in a different context from the invocation of `do_action( 'enqueue_block_editor_assets' );`—WordPress invokes each hook itself, we do not. 

To workaround this, the changes remove hooks based on name and/or file paths. This workaround is not ideal, but appears the only option. Gutenberg core is [experimenting](https://github.com/WordPress/gutenberg/pull/73028) with REST API endpoints for editor assets as well; presumably that exploration will eventually encounter this issue and identify a core-provided solution. 

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Strategically remove problematic hooks from plugins to avoid fatal errors. 

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Install and activate the [`wpforms-lite`](https://wordpress.org/plugins/wpforms-lite/) plugin for your site. 
2. Perform a request to the editor assets endpoint via the API Console, `curl`, etc. 
3. **Verify** a 200 response including the expected editor assets. 