### PR TITLE
wpcomsh: Prevent warnings in Custom Colors feature

### DIFF
--- a/projects/plugins/wpcomsh/changelog/fix-wpcomsh-custom_colors_warnings
+++ b/projects/plugins/wpcomsh/changelog/fix-wpcomsh-custom_colors_warnings
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Custom Colors: Prevent warnings when handling malformed data.

--- a/projects/plugins/wpcomsh/custom-colors/colors.php
+++ b/projects/plugins/wpcomsh/custom-colors/colors.php
@@ -1494,6 +1494,10 @@ class Colors_Manager_Common {
 	public static function css_rule( $rule, $color ) {
 		$css = '';
 
+		if ( ! isset( $rule[0] ) || ! isset( $rule[1] ) ) {
+			return $css;
+		}
+
 		if ( isset( $rule[2] ) ) {
 			// we'll need it in either case
 			if ( ! class_exists( 'Jetpack_color' ) ) {
@@ -1555,9 +1559,8 @@ class Colors_Manager_Common {
 				$color = $working_color->toCSS( 'rgba', intval( $number ) );
 			}
 		}
-		if ( isset( $rule[0] ) && isset( $rule[1] ) ) {
-			$css .= "{$rule[0]} { {$rule[1]}: {$color};}\n";
-		}
+
+		$css .= "{$rule[0]} { {$rule[1]}: {$color};}\n";
 		return $css;
 	}
 

--- a/projects/plugins/wpcomsh/custom-colors/colors.php
+++ b/projects/plugins/wpcomsh/custom-colors/colors.php
@@ -1736,7 +1736,7 @@ class Colors_Manager_Common {
 			)
 		);
 
-		if ( empty( $top_palette ) ) {
+		if ( ! $top_palette ) {
 			return array();
 		}
 

--- a/projects/plugins/wpcomsh/custom-colors/colors.php
+++ b/projects/plugins/wpcomsh/custom-colors/colors.php
@@ -1735,6 +1735,11 @@ class Colors_Manager_Common {
 				),
 			)
 		);
+
+		if ( empty( $top_palette ) ) {
+			return array();
+		}
+
 		$top_palette = $top_palette[0];
 
 		$equivalent_color_hex = $top_palette['colors'][ $role ];

--- a/projects/plugins/wpcomsh/custom-colors/colors.php
+++ b/projects/plugins/wpcomsh/custom-colors/colors.php
@@ -1555,7 +1555,9 @@ class Colors_Manager_Common {
 				$color = $working_color->toCSS( 'rgba', intval( $number ) );
 			}
 		}
-		$css .= "{$rule[0]} { {$rule[1]}: {$color};}\n";
+		if ( isset( $rule[0] ) && isset( $rule[1] ) ) {
+			$css .= "{$rule[0]} { {$rule[1]}: {$color};}\n";
+		}
 		return $css;
 	}
 

--- a/projects/plugins/wpcomsh/custom-colors/colors.php
+++ b/projects/plugins/wpcomsh/custom-colors/colors.php
@@ -404,7 +404,7 @@ class Colors_Manager_Common {
 	 */
 	public static function get_colors() {
 		$opts   = get_theme_mod( 'colors_manager', array( 'colors' => false ) );
-		$colors = ( $opts['colors'] ) ? $opts['colors'] : self::$default_colors;
+		$colors = ! empty( $opts['colors'] ) ? $opts['colors'] : self::$default_colors;
 		unset( $colors['undefined'] );
 		return $colors;
 	}


### PR DESCRIPTION
Closes MONOREP-223

 <!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR addresses just shy of 1M error log entries/month on WP Cloud caused by the Custom Colors feature.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
```
PHP Warning: Undefined array key "colors" in /wordpress/plugins/wpcomsh/8.1.0-alpha+rolling.1762969005.gba3d7df/custom-colors/colors.php on line 407
```

For the above, I added an `empty()` check to account for the 'color' key either not existing or having a falsy value.

```
PHP Warning: Undefined array key 1 in /wordpress/plugins/wpcomsh/8.1.0-alpha+rolling.1763028843.g4973846/custom-colors/colors.php on line 1558
```

For the above, we ensure the keys exist before using them. I could probably have moved this inside the preceding block (`if ( isset( $rule[2] ) ) {`) but there's a slight possibility `2` could exist and `0` and/or `1` not.

```
PHP Warning: Undefined array key 0 in /wordpress/plugins/wpcomsh/8.1.0-alpha+rolling.1762969005.gba3d7df/custom-colors/colors.php on line 1736
PHP Warning: Trying to access array offset on null in /wordpress/plugins/wpcomsh/8.1.0-alpha+rolling.1762969005.gba3d7df/custom-colors/colors.php on line 1738
PHP Warning: Trying to access array offset on null in /wordpress/plugins/wpcomsh/8.1.0-alpha+rolling.1762969005.gba3d7df/custom-colors/colors.php on line 1740
PHP Warning: foreach() argument must be of type array|object, null given in /wordpress/plugins/wpcomsh/8.1.0-alpha+rolling.1762969005.gba3d7df/custom-colors/colors.php on line 1740
```

For the above, we return early with an empty array, which is what would happen if the for loop doesn't process anything.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

