### PR TITLE
jetpack-mu-wpcom Code block: Improve edit header

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-code-block-header-edit
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-code-block-header-edit
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Small change to unreleased feature.
+
+

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/block-definition/block-definition.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/block-definition/block-definition.tsx
@@ -168,23 +168,21 @@ const blockEdit = withColors(
 						__nextHasNoMarginBottom
 					/>
 					<ToggleControl
+						label={ __( 'Show File Name', 'jetpack-mu-wpcom' ) }
+						checked={ attributes.showFileName }
+						onChange={ ( next: boolean ) => setAttributes( { showFileName: next } ) }
+						__nextHasNoMarginBottom
+					/>
+					<ToggleControl
 						label={ __( 'Show Copy Button', 'jetpack-mu-wpcom' ) }
 						checked={ attributes.showCopyButton }
-						onChange={ ( next: boolean ) =>
-							setAttributes( {
-								showCopyButton: next,
-							} )
-						}
+						onChange={ ( next: boolean ) => setAttributes( { showCopyButton: next } ) }
 						__nextHasNoMarginBottom
 					/>
 					<ToggleControl
 						label={ __( 'Show Line Numbers', 'jetpack-mu-wpcom' ) }
 						checked={ attributes.showLineNumbers }
-						onChange={ ( next: boolean ) =>
-							setAttributes( {
-								showLineNumbers: next,
-							} )
-						}
+						onChange={ ( next: boolean ) => setAttributes( { showLineNumbers: next } ) }
 						__nextHasNoMarginBottom
 					/>
 					<TextControl
@@ -279,11 +277,6 @@ const Chrome = ( { isLoading = false, ...props }: ChromeProps ) => {
 		style: blockStyle( props.attributes ),
 	} );
 
-	const wpElementButtonClass =
-		typeof __experimentalGetElementClassName === 'function'
-			? __experimentalGetElementClassName( 'button' )
-			: 'wp-element-button';
-
 	if ( ( globalThis as { SCRIPT_DEBUG?: unknown } ).SCRIPT_DEBUG ) {
 		if ( typeof __experimentalGetElementClassName !== 'function' ) {
 			// eslint-disable-next-line no-console -- Console message in debug.
@@ -293,22 +286,41 @@ const Chrome = ( { isLoading = false, ...props }: ChromeProps ) => {
 
 	return (
 		<div { ...blockProps }>
-			<div className="a8c/code__header">
-				<Filename { ...props } />
-				{ ( props.isSelected ||
-					props.attributes.showCopyButton ||
-					props.attributes.showLanguageName ) && (
-					<div className="a8c/code__header-right">
-						{ props.attributes.showCopyButton && (
-							<button className={ `${ wpElementButtonClass } a8c/code__btn-copy` } type="button">
-								{ __( 'Copy', 'jetpack-mu-wpcom' ) }
-							</button>
-						) }
-						<DisplayLanguage { ...props } />
-					</div>
-				) }
-			</div>
+			<BlockHeader { ...props } />
 			{ props.children }
+		</div>
+	);
+};
+
+const BlockHeader = ( props: Props ) => {
+	if (
+		! props.attributes.showFileName &&
+		! props.attributes.showCopyButton &&
+		! props.attributes.showLanguageName
+	) {
+		return null;
+	}
+
+	const wpElementButtonClass =
+		typeof __experimentalGetElementClassName === 'function'
+			? __experimentalGetElementClassName( 'button' )
+			: 'wp-element-button';
+
+	return (
+		<div className="a8c/code__header">
+			<Filename { ...props } />
+			{ ( props.isSelected ||
+				props.attributes.showCopyButton ||
+				props.attributes.showLanguageName ) && (
+				<div className="a8c/code__header-right">
+					{ props.attributes.showCopyButton && (
+						<button className={ `${ wpElementButtonClass } a8c/code__btn-copy` } type="button">
+							{ __( 'Copy', 'jetpack-mu-wpcom' ) }
+						</button>
+					) }
+					<DisplayLanguage { ...props } />
+				</div>
+			) }
 		</div>
 	);
 };
@@ -322,26 +334,27 @@ const Filename = ( props: Props ) => {
 			( [ , languageName ] ) => props.attributes.language === languageName
 		)?.[ 0 ] ?? 'txt';
 
+	const { PlainText } = wpBlockEditor;
+
 	if ( isSelected ) {
 		return (
-			<TextControl
-				label={ __( 'Filename', 'jetpack-mu-wpcom' ) }
-				hideLabelFromVision
+			<PlainText
+				__experimentalVersion={ 2 }
+				value={ filename }
+				onChange={ ( nextValue: string ) => {
+					setAttributes!( { filename: nextValue } );
+				} }
+				disableLineBreaks
 				className="a8c/code__filename"
 				placeholder={ sprintf(
 					/* translators: Placeholder for a filename input. %s is a file extension, like "txt". */
 					__( 'filename.%s', 'jetpack-mu-wpcom' ),
 					placeholderExtension
 				) }
-				value={ filename }
-				onChange={ ( nextValue: string ) => {
-					setAttributes!( { filename: nextValue } );
-				} }
-				__next40pxDefaultSize
-				__nextHasNoMarginBottom
 			/>
 		);
 	}
+
 	if ( filename ) {
 		return <span className="a8c/code__filename">{ filename }</span>;
 	}

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/block-definition/block-definition.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/block-definition/block-definition.tsx
@@ -148,12 +148,9 @@ const blockEdit = withColors(
 							focusOnMount: true,
 						} }
 						renderToggle={ ( { isOpen, onToggle }: { isOpen: boolean; onToggle: () => void } ) => (
-							<Button
-								onClick={ onToggle }
-								aria-expanded={ isOpen }
-								aria-haspopup="true"
-								children={ props.attributes.language || emptyLanguageOption.label }
-							/>
+							<Button onClick={ onToggle } aria-expanded={ isOpen } aria-haspopup="true">
+								{ props.attributes.language || emptyLanguageOption.label }
+							</Button>
 						) }
 						renderContent={ ( { onClose }: { onClose: () => void } ) => (
 							<NavigableMenu role="menu" stopNavigationEvents>

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/block-definition/block-definition.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/block-definition/block-definition.tsx
@@ -181,7 +181,7 @@ const blockEdit = withColors(
 				<ColorTools { ...props } />
 			</InspectorControls>
 			<InspectorControls>
-				<PanelBody title="Code Settings">
+				<PanelBody title="Settings">
 					<SelectControl
 						label={ __( 'Language', 'jetpack-mu-wpcom' ) }
 						value={ attributes.language }
@@ -196,7 +196,7 @@ const blockEdit = withColors(
 						__nextHasNoMarginBottom
 					/>
 					<ToggleControl
-						label={ __( 'Show Language Name', 'jetpack-mu-wpcom' ) }
+						label={ __( 'Show language name', 'jetpack-mu-wpcom' ) }
 						checked={ attributes.showLanguageName }
 						onChange={ ( next: boolean ) =>
 							setAttributes( {
@@ -206,25 +206,25 @@ const blockEdit = withColors(
 						__nextHasNoMarginBottom
 					/>
 					<ToggleControl
-						label={ __( 'Show File Name', 'jetpack-mu-wpcom' ) }
+						label={ __( 'Show filename', 'jetpack-mu-wpcom' ) }
 						checked={ attributes.showFileName }
 						onChange={ ( next: boolean ) => setAttributes( { showFileName: next } ) }
 						__nextHasNoMarginBottom
 					/>
 					<ToggleControl
-						label={ __( 'Show Copy Button', 'jetpack-mu-wpcom' ) }
+						label={ __( 'Show copy button', 'jetpack-mu-wpcom' ) }
 						checked={ attributes.showCopyButton }
 						onChange={ ( next: boolean ) => setAttributes( { showCopyButton: next } ) }
 						__nextHasNoMarginBottom
 					/>
 					<ToggleControl
-						label={ __( 'Show Line Numbers', 'jetpack-mu-wpcom' ) }
+						label={ __( 'Show line numbers', 'jetpack-mu-wpcom' ) }
 						checked={ attributes.showLineNumbers }
 						onChange={ ( next: boolean ) => setAttributes( { showLineNumbers: next } ) }
 						__nextHasNoMarginBottom
 					/>
 					<TextControl
-						label={ __( 'Line Numbers Start At', 'jetpack-mu-wpcom' ) }
+						label={ __( 'Line numbers start at', 'jetpack-mu-wpcom' ) }
 						type="number"
 						value={ attributes.lineNumbersStartAt }
 						disabled={ ! attributes.showLineNumbers }

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/block-definition/block-definition.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/block-definition/block-definition.tsx
@@ -29,12 +29,12 @@ import { ColorTools } from './color-tools.tsx';
 import { transforms } from './transforms.ts';
 
 const {
-	InspectorControls,
+	__experimentalGetElementClassName,
 	BlockControls,
+	InspectorControls,
 	PlainText,
 	useBlockProps,
 	withColors,
-	__experimentalGetElementClassName,
 }: Window[ 'wp' ][ 'blockEditor' ] = wpBlockEditor;
 
 const { registerBlockStyle }: Window[ 'wp' ][ 'blocks' ] = wpBlocks;

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/block-definition/block-definition.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/block-definition/block-definition.tsx
@@ -31,6 +31,7 @@ import { transforms } from './transforms.ts';
 const {
 	InspectorControls,
 	BlockControls,
+	PlainText,
 	useBlockProps,
 	withColors,
 	__experimentalGetElementClassName,
@@ -356,9 +357,7 @@ const BlockHeader = ( props: Props ) => {
 	return (
 		<div className="a8c/code__header">
 			<Filename { ...props } />
-			{ ( props.isSelected ||
-				props.attributes.showCopyButton ||
-				props.attributes.showLanguageName ) && (
+			{ ( props.attributes.showCopyButton || props.attributes.showLanguageName ) && (
 				<div className="a8c/code__header-right">
 					{ props.attributes.showCopyButton && (
 						<button className={ `${ wpElementButtonClass } a8c/code__btn-copy` } type="button">
@@ -375,17 +374,18 @@ const BlockHeader = ( props: Props ) => {
 };
 
 const Filename = ( props: Props ) => {
+	if ( ! props.attributes.showFileName ) {
+		return null;
+	}
 	const { setAttributes, isSelected = false } = props;
 	const { filename } = props.attributes;
 
-	const placeholderExtension =
-		extensionToLang.find(
-			( [ , languageName ] ) => props.attributes.language === languageName
-		)?.[ 0 ] ?? 'txt';
-
-	const { PlainText } = wpBlockEditor;
-
 	if ( isSelected ) {
+		const placeholderExtension =
+			extensionToLang.find(
+				( [ , languageName ] ) => props.attributes.language === languageName
+			)?.[ 0 ] ?? 'txt';
+
 		return (
 			<PlainText
 				__experimentalVersion={ 2 }

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/block-definition/block-definition.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/block-definition/block-definition.tsx
@@ -198,29 +198,33 @@ const blockEdit = withColors(
 					<ToggleControl
 						label={ __( 'Show language name', 'jetpack-mu-wpcom' ) }
 						checked={ attributes.showLanguageName }
-						onChange={ ( next: boolean ) =>
-							setAttributes( {
-								showLanguageName: next,
-							} )
-						}
+						onChange={ ( next: boolean ) => {
+							setAttributes( { showLanguageName: next } );
+						} }
 						__nextHasNoMarginBottom
 					/>
 					<ToggleControl
 						label={ __( 'Show filename', 'jetpack-mu-wpcom' ) }
 						checked={ attributes.showFileName }
-						onChange={ ( next: boolean ) => setAttributes( { showFileName: next } ) }
+						onChange={ ( next: boolean ) => {
+							setAttributes( { showFileName: next } );
+						} }
 						__nextHasNoMarginBottom
 					/>
 					<ToggleControl
 						label={ __( 'Show copy button', 'jetpack-mu-wpcom' ) }
 						checked={ attributes.showCopyButton }
-						onChange={ ( next: boolean ) => setAttributes( { showCopyButton: next } ) }
+						onChange={ ( next: boolean ) => {
+							setAttributes( { showCopyButton: next } );
+						} }
 						__nextHasNoMarginBottom
 					/>
 					<ToggleControl
 						label={ __( 'Show line numbers', 'jetpack-mu-wpcom' ) }
 						checked={ attributes.showLineNumbers }
-						onChange={ ( next: boolean ) => setAttributes( { showLineNumbers: next } ) }
+						onChange={ ( next: boolean ) => {
+							setAttributes( { showLineNumbers: next } );
+						} }
 						__nextHasNoMarginBottom
 					/>
 					{ attributes.showLineNumbers && (

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/block-definition/block-definition.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/block-definition/block-definition.tsx
@@ -223,36 +223,38 @@ const blockEdit = withColors(
 						onChange={ ( next: boolean ) => setAttributes( { showLineNumbers: next } ) }
 						__nextHasNoMarginBottom
 					/>
-					<TextControl
-						label={ __( 'Line numbers start at', 'jetpack-mu-wpcom' ) }
-						type="number"
-						value={ attributes.lineNumbersStartAt }
-						disabled={ ! attributes.showLineNumbers }
-						onChange={ ( _nextLineNumbersStartAt: string ) => {
-							let nextLineNumbersStartAt = Number( _nextLineNumbersStartAt );
+					{ attributes.showLineNumbers && (
+						<TextControl
+							label={ __( 'Line numbers start at', 'jetpack-mu-wpcom' ) }
+							type="number"
+							value={ attributes.lineNumbersStartAt }
+							disabled={ ! attributes.showLineNumbers }
+							onChange={ ( _nextLineNumbersStartAt: string ) => {
+								let nextLineNumbersStartAt = Number( _nextLineNumbersStartAt );
 
-							if ( ! Number.isFinite( nextLineNumbersStartAt ) ) {
-								nextLineNumbersStartAt = 1;
-							}
-							if ( ! Number.isInteger( nextLineNumbersStartAt ) ) {
-								nextLineNumbersStartAt = 1;
-							}
+								if ( ! Number.isFinite( nextLineNumbersStartAt ) ) {
+									nextLineNumbersStartAt = 1;
+								}
+								if ( ! Number.isInteger( nextLineNumbersStartAt ) ) {
+									nextLineNumbersStartAt = 1;
+								}
 
-							// Clamp to the allowed range
-							nextLineNumbersStartAt = Math.max(
-								LINE_NUMBER_START_MIN,
-								Math.min( LINE_NUMBER_START_MAX, nextLineNumbersStartAt )
-							);
+								// Clamp to the allowed range
+								nextLineNumbersStartAt = Math.max(
+									LINE_NUMBER_START_MIN,
+									Math.min( LINE_NUMBER_START_MAX, nextLineNumbersStartAt )
+								);
 
-							setAttributes( {
-								lineNumbersStartAt: nextLineNumbersStartAt,
-							} );
-						} }
-						min={ LINE_NUMBER_START_MIN }
-						max={ LINE_NUMBER_START_MAX }
-						__next40pxDefaultSize
-						__nextHasNoMarginBottom
-					/>
+								setAttributes( {
+									lineNumbersStartAt: nextLineNumbersStartAt,
+								} );
+							} }
+							min={ LINE_NUMBER_START_MIN }
+							max={ LINE_NUMBER_START_MAX }
+							__next40pxDefaultSize
+							__nextHasNoMarginBottom
+						/>
+					) }
 				</PanelBody>
 			</InspectorControls>
 			<React.Suspense fallback={ <Loading { ...props } /> }>

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/block-definition/block-definition.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/block-definition/block-definition.tsx
@@ -341,11 +341,9 @@ const Chrome = ( { isLoading = false, ...props }: ChromeProps ) => {
 };
 
 const BlockHeader = ( props: Props ) => {
-	if (
-		! props.attributes.showFileName &&
-		! props.attributes.showCopyButton &&
-		! props.attributes.showLanguageName
-	) {
+	const showLanguage = props.attributes.showLanguageName && props.attributes.language;
+
+	if ( ! props.attributes.showFileName && ! props.attributes.showCopyButton && ! showLanguage ) {
 		return null;
 	}
 
@@ -354,19 +352,18 @@ const BlockHeader = ( props: Props ) => {
 			? __experimentalGetElementClassName( 'button' )
 			: 'wp-element-button';
 
+	const showRight = props.attributes.showCopyButton || showLanguage;
 	return (
 		<div className="a8c/code__header">
 			<Filename { ...props } />
-			{ ( props.attributes.showCopyButton || props.attributes.showLanguageName ) && (
+			{ showRight && (
 				<div className="a8c/code__header-right">
 					{ props.attributes.showCopyButton && (
 						<button className={ `${ wpElementButtonClass } a8c/code__btn-copy` } type="button">
 							{ __( 'Copy', 'jetpack-mu-wpcom' ) }
 						</button>
 					) }
-					{ props.attributes.showLanguageName && props.attributes.language ? (
-						<span>{ props.attributes.language }</span>
-					) : null }
+					{ showLanguage ? <span>{ props.attributes.language }</span> : null }
 				</div>
 			) }
 		</div>

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/block-definition/block-definition.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/block-definition/block-definition.tsx
@@ -45,12 +45,12 @@ const LINE_NUMBER_START_MAX = 10_000;
 type Props = EditBlockProps | SaveBlockProps;
 
 const emptyLanguageOption = {
-	key: '',
-	name: __( 'Plain text', 'jetpack-mu-wpcom' ) as string,
+	value: '',
+	label: __( 'Plain text', 'jetpack-mu-wpcom' ) as string,
 };
-const customSelectLanguageOptions: {
-	readonly key: string;
-	readonly name: string;
+const selectLanguageOptions: {
+	readonly value: string;
+	readonly label: string;
 }[] = [ emptyLanguageOption ];
 {
 	const langNames = new Set< string >();
@@ -60,19 +60,12 @@ const customSelectLanguageOptions: {
 	const sortedLangNames = Array.of( ...langNames );
 	sortedLangNames.sort( ( a, b ) => a.localeCompare( b ) );
 	sortedLangNames.forEach( lang =>
-		customSelectLanguageOptions.push( {
-			key: lang,
-			name: lang,
+		selectLanguageOptions.push( {
+			value: lang,
+			label: lang,
 		} )
 	);
 }
-const selectLanguageOptions: ReadonlyArray< {
-	readonly value: string;
-	readonly label: string;
-} > = customSelectLanguageOptions.map( ( { key, name } ) => ( {
-	value: key,
-	label: name,
-} ) );
 
 /**
  * Filter to enhance the core code block.

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/block-definition/block-definition.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/block-definition/block-definition.tsx
@@ -152,7 +152,7 @@ const blockEdit = withColors(
 								onClick={ onToggle }
 								aria-expanded={ isOpen }
 								aria-haspopup="true"
-								children={ props.attributes.language || emptyLanguageOption.name }
+								children={ props.attributes.language || emptyLanguageOption.label }
 							/>
 						) }
 						renderContent={ ( { onClose }: { onClose: () => void } ) => (

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/block-definition/block-definition.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/block-definition/block-definition.tsx
@@ -5,11 +5,16 @@ import * as wpBlockEditor from '@wordpress/block-editor';
 // @ts-expect-error No types.
 import * as wpBlocks from '@wordpress/blocks';
 import {
-	CustomSelectControl,
+	Button,
+	Dropdown,
+	MenuGroup,
+	MenuItem,
+	NavigableMenu,
 	PanelBody,
 	SelectControl,
 	TextControl,
 	ToggleControl,
+	ToolbarGroup,
 } from '@wordpress/components';
 import { addFilter } from '@wordpress/hooks';
 import { __, sprintf } from '@wordpress/i18n';
@@ -25,6 +30,7 @@ import { transforms } from './transforms.ts';
 
 const {
 	InspectorControls,
+	BlockControls,
 	useBlockProps,
 	withColors,
 	__experimentalGetElementClassName,
@@ -139,6 +145,47 @@ const blockEdit = withColors(
 
 	return (
 		<>
+			<BlockControls>
+				<ToolbarGroup>
+					<Dropdown
+						popoverProps={ {
+							isAlternate: true,
+							position: 'bottom right left',
+							focusOnMount: true,
+						} }
+						renderToggle={ ( { isOpen, onToggle }: { isOpen: boolean; onToggle: () => void } ) => (
+							<Button
+								onClick={ onToggle }
+								aria-expanded={ isOpen }
+								aria-haspopup="true"
+								children={ props.attributes.language || emptyLanguageOption.name }
+							/>
+						) }
+						renderContent={ ( { onClose }: { onClose: () => void } ) => (
+							<NavigableMenu role="menu" stopNavigationEvents>
+								<MenuGroup>
+									{ selectLanguageOptions.map( option => (
+										<MenuItem
+											key={ option.value }
+											role="menuitemradio"
+											isSelected={ option.value === props.attributes.language }
+											onClick={ () => {
+												props.setAttributes( {
+													language: option.value,
+													languageConfidence: 'certain',
+												} );
+												onClose();
+											} }
+										>
+											{ option.label }
+										</MenuItem>
+									) ) }
+								</MenuGroup>
+							</NavigableMenu>
+						) }
+					/>
+				</ToolbarGroup>
+			</BlockControls>
 			<InspectorControls group="color">
 				<ColorTools { ...props } />
 			</InspectorControls>
@@ -318,7 +365,9 @@ const BlockHeader = ( props: Props ) => {
 							{ __( 'Copy', 'jetpack-mu-wpcom' ) }
 						</button>
 					) }
-					<DisplayLanguage { ...props } />
+					{ props.attributes.showLanguageName && props.attributes.language ? (
+						<span>{ props.attributes.language }</span>
+					) : null }
 				</div>
 			) }
 		</div>
@@ -359,46 +408,6 @@ const Filename = ( props: Props ) => {
 		return <span className="a8c/code__filename">{ filename }</span>;
 	}
 	return null;
-};
-
-const DisplayLanguage = ( props: Props ) => {
-	const { attributes, setAttributes } = props;
-
-	if ( props.isSelected ) {
-		return (
-			<CustomSelectControl
-				className="a8c/code__language-select"
-				label={ __( 'Language', 'jetpack-mu-wpcom' ) }
-				hideLabelFromVision
-				value={
-					attributes.language
-						? {
-								key: attributes.language,
-								name: attributes.language,
-						  }
-						: emptyLanguageOption
-				}
-				options={ customSelectLanguageOptions }
-				onChange={ ( {
-					selectedItem: { key: newLanguage },
-				}: {
-					selectedItem: { name: string; key: string };
-				} ) => {
-					setAttributes!( {
-						language: newLanguage,
-						languageConfidence: 'certain',
-					} );
-				} }
-				__next40pxDefaultSize
-			/>
-		);
-	}
-
-	if ( ! props.attributes.showLanguageName || ! attributes.language ) {
-		return null;
-	}
-
-	return <span>{ attributes.language }</span>;
 };
 
 /**

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/class-code-block.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/class-code-block.php
@@ -191,7 +191,6 @@ abstract class Code_Block {
 		$args['selectors'] = array(
 			'root'       => '.wp-block-code',
 			'typography' => array(
-				'root'        => '.wp-block-code',
 
 				/*
 				 * These are experimental at the moment. The camelCase form appears to be used, but

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/class-code-block.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/class-code-block.php
@@ -262,6 +262,10 @@ abstract class Code_Block {
 				'type'    => 'boolean',
 				'default' => false,
 			),
+			'showFileName'            => array(
+				'type'    => 'boolean',
+				'default' => false,
+			),
 			'showCopyButton'          => array(
 				'type'    => 'boolean',
 				'default' => false,
@@ -420,7 +424,7 @@ abstract class Code_Block {
 
 		$attrs = get_block_wrapper_attributes( $extra_attrs );
 
-		$filename_html = ! empty( $attributes['filename'] )
+		$filename_html = ( ( $attributes['showCopyButton'] ?? false ) && ! empty( $attributes['filename'] ) )
 			? \sprintf( '<span class="a8c/code__filename">%s</span>', esc_html( $attributes['filename'] ) )
 			: '';
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/common/block.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/common/block.ts
@@ -24,6 +24,7 @@ export interface Attributes {
 	 */
 	triggerCodeUpdate: boolean;
 
+	showFileName: boolean;
 	showCopyButton: boolean;
 
 	showLanguageName: boolean;

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/editor.css
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/editor.css
@@ -17,28 +17,6 @@
 
 	&.wp-block-code {
 
-		.components-base-control__field {
-			margin: 0;
-		}
-
-		.components-base-control,
-		.components-base-control__field,
-		.components-input-control__container > button,
-		.components-text-control__input {
-			font-size: inherit;
-		}
-
-		.components-text-control__input {
-			margin-left: -12px;
-			background-color: transparent;
-			color: inherit;
-			font-family: inherit;
-
-			&::placeholder {
-				color: hsl(from currentColor h s l / 0.6);
-			}
-		}
-
 		/* Override CodeMirror's font family to respect theme and editor settings. */
 		.cm-scroller {
 			font-family: inherit;

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/editor.css
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/editor.css
@@ -60,19 +60,11 @@
 		}
 	}
 
-	.a8c\/code__header {
-		padding: 0 12px;
-	}
-
 	.a8c\/code__btn-copy {
 		text-transform: inherit;
 		font-style: inherit;
 		font-weight: inherit;
 		font-size: inherit;
-	}
-
-	.a8c\/code__filename.components-base-control {
-		margin: -1px;
 	}
 
 	.a8c\/code__language-select {

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/editor.css
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/editor.css
@@ -66,13 +66,4 @@
 		font-weight: inherit;
 		font-size: inherit;
 	}
-
-	.a8c\/code__language-select {
-
-		button,
-		.components-input-control__container {
-			background-color: transparent;
-			color: inherit;
-		}
-	}
 }

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/style.css
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/style.css
@@ -316,10 +316,6 @@
 	justify-content: flex-end;
 	font-size: 0.8em;
 	min-height: 40px;
-
-	.a8c\/code__language-select {
-		margin-right: -12px;
-	}
 }
 
 .a8c\/code__header-right {
@@ -330,9 +326,6 @@
 
 .a8c\/code__filename {
 	flex: 1 0 0;
-	font-size: inherit;
 	font-weight: 700;
 	line-height: 1.3;
-	font-family: inherit !important;
-	border: 1px solid transparent;
 }

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/style.css
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/style.css
@@ -53,24 +53,24 @@
 		gap: 32px;
 	}
 
-	/* Essential layout and styling for PRE,CODE */
+	/* Essential layout and styling for PRE, CODE */
 	pre,
 	code {
 		margin: 0 !important;
 		padding: 0 !important;
 		line-height: inherit !important;
 		background: transparent !important;
-		border: none;
-		border-radius: 0;
+		border: none !important;
+		border-radius: 0 !important;
 		color: inherit !important;
 		font-size: inherit !important;
 	}
 
 	pre {
-		flex-grow: 2;
-		flex-shrink: 0;
-		display: block;
-		word-wrap: normal;
+		flex-grow: 2 !important;
+		flex-shrink: 0 !important;
+		display: block !important;
+		word-wrap: normal !important;
 		white-space: pre !important;
 	}
 
@@ -78,18 +78,17 @@
 		font-family: inherit !important;
 	}
 
+	/* Line number layout */
+	.cm-line::before {
+		box-sizing: content-box !important;
+	}
+
 	/* prevent empty lines from collapsing vertically in rendered views */
 	.cm-line:empty::after {
 		content: "\A0";
 	}
 
-	/* prevent empty lines from collapsing vertically in rendered views */
-	.cm-line::before {
-
-		/* Essential for layout */
-		box-sizing: content-box !important;
-	}
-
+	/* Match the editor */
 	.cm-line {
 		padding: 0 2px 0 6px;
 	}

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/style.css
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/style.css
@@ -327,4 +327,5 @@
 	flex: 1 0 0;
 	font-weight: 700;
 	line-height: 1.3;
+	word-break: break-word;
 }

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/types/global.d.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/types/global.d.ts
@@ -25,6 +25,8 @@ declare global {
 		wp: {
 			blockEditor: {
 				InspectorControls: JSXElementConstructor< any >;
+				BlockControls: JSXElementConstructor< any >;
+				PlainText: JSXElementConstructor< any >;
 				store: Store;
 				useBlockProps: any;
 				withColors: (


### PR DESCRIPTION
## Proposed changes:

- Remove "block control" type interactions from the block header
- Use `PlainText` component for filename
- Move language selection to toolbar (out of header)
- Render block header only when necessary.
- Hide "line number start at" settings if line numbers are not shown.

This also removes a `typography.root` selector. This would split typography into a separate CSS rule with an identical selector. It's removed here to prevent the redundant selector from being created.

### Before

https://github.com/user-attachments/assets/5e610792-a1a1-4d33-acfd-09daccaa9925




### After

https://github.com/user-attachments/assets/80d55753-ee87-4152-97a1-d0bd3bb743ba


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?


## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
See demo videos.

The block is unreleased and will undergo extensive testing soon.
