### PR TITLE
Forms: remove related-posts from API calls

### DIFF
--- a/projects/packages/forms/changelog/update-forms-remove-related-posts
+++ b/projects/packages/forms/changelog/update-forms-remove-related-posts
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Forms: remove related-posts from API calls

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -269,7 +269,7 @@ class Contact_Form_Plugin {
 		add_filter( 'rest_api_allowed_post_types', array( $this, 'allow_feedback_rest_api_type' ) );
 
 		// Don't let related posts hook into feedback post type.
-		add_filter( 'jetpack_related_posts_allowed_post_types', array( $this, 'remove_from_related_posts_allowed_post_types' ) );
+		add_filter( 'jetpack_related_posts_rest_api_allowed_post_types', array( $this, 'remove_from_related_posts_allowed_post_types' ) );
 
 		// Add "spam" as a post status
 		register_post_status(

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -268,6 +268,9 @@ class Contact_Form_Plugin {
 		// Add to REST API post type allowed list.
 		add_filter( 'rest_api_allowed_post_types', array( $this, 'allow_feedback_rest_api_type' ) );
 
+		// Don't let related posts hook into feedback post type.
+		add_filter( 'jetpack_related_posts_allowed_post_types', array( $this, 'remove_from_related_posts_allowed_post_types' ) );
+
 		// Add "spam" as a post status
 		register_post_status(
 			'spam',
@@ -349,6 +352,16 @@ class Contact_Form_Plugin {
 				4
 			);
 		}
+	}
+
+	/**
+	 * Remove feedback post type from the allowed post types for related posts.
+	 *
+	 * @param array $post_types The allowed post types.
+	 * @return array The allowed post types.
+	 */
+	public static function remove_from_related_posts_allowed_post_types( $post_types ) {
+		return array_diff( $post_types, array( 'feedback' ) );
 	}
 
 	/**

--- a/projects/plugins/jetpack/changelog/update-forms-remove-related-posts
+++ b/projects/plugins/jetpack/changelog/update-forms-remove-related-posts
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Forms: remove related-posts from API calls

--- a/projects/plugins/jetpack/modules/related-posts/jetpack-related-posts.php
+++ b/projects/plugins/jetpack/modules/related-posts/jetpack-related-posts.php
@@ -2033,6 +2033,16 @@ EOT;
 	public function rest_register_related_posts() {
 		/** This filter is already documented in class.json-api-endpoints.php */
 		$post_types = apply_filters( 'rest_api_allowed_post_types', array( 'post', 'page', 'revision' ) );
+
+		/**
+		 * Filter the post types that are allowed to have related posts.
+		 *
+		 * @since $$next-version$$
+		 *
+		 * @param array $post_types The post types that are allowed to have related posts.
+		 */
+		$post_types = apply_filters( 'jetpack_related_posts_allowed_post_types', $post_types );
+
 		foreach ( $post_types as $post_type ) {
 			register_rest_field(
 				$post_type,

--- a/projects/plugins/jetpack/modules/related-posts/jetpack-related-posts.php
+++ b/projects/plugins/jetpack/modules/related-posts/jetpack-related-posts.php
@@ -2041,7 +2041,7 @@ EOT;
 		 *
 		 * @param array $post_types The post types that are allowed to have related posts.
 		 */
-		$post_types = apply_filters( 'jetpack_related_posts_allowed_post_types', $post_types );
+		$post_types = apply_filters( 'jetpack_related_posts_rest_api_allowed_post_types', $post_types );
 
 		foreach ( $post_types as $post_type ) {
 			register_rest_field(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Cleans up "related posts" entry (and related options etc queries) from API calls for form feedback posts.
* Adds new filter to related posts letting developers control what custom post type API calls related posts hooks into

Before, related posts hooks into these:

<img width="299" height="254" alt="Screenshot 2025-11-13 at 21 01 31" src="https://github.com/user-attachments/assets/778b9023-12de-4b82-a965-1715938912ff" />

After the change, it tries to hook into these:

<img width="296" height="227" alt="Screenshot 2025-11-13 at 21 01 34" src="https://github.com/user-attachments/assets/581ca5f9-d36b-4992-aa87-538dd25a8a9b" />

API responses before:

<img width="332" height="509" alt="image" src="https://github.com/user-attachments/assets/26ef9e14-13a0-4b82-96c5-3390b7c49a70" />

API responses after:

<img width="323" height="481" alt="image" src="https://github.com/user-attachments/assets/64aa6c18-a184-4390-9f81-47b21c3e726e" />


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

