### PR TITLE
Global styles experiment: return early

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/dotcom-14917-global-styles-on-personal-bridge-explat-and-the-gating-logic-owner
+++ b/projects/packages/jetpack-mu-wpcom/changelog/dotcom-14917-global-styles-on-personal-bridge-explat-and-the-gating-logic-owner
@@ -1,0 +1,4 @@
+Significance: patch
+Type: security
+
+Implemented a guard against non user objects when assigning an experiment variation

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/index.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/index.php
@@ -818,6 +818,9 @@ function is_global_styles_on_personal_plan() {
 			return false;
 		}
 		$wpcom_blog_owner = get_userdata( $wpcom_blog_owner_id );
+		if ( ! $wpcom_blog_owner ) {
+			return false;
+		}
 		// WP.com: Direct ExPlat assignment.
 		$assignment = \ExPlat\assign_given_user( $experiment_key, $wpcom_blog_owner );
 		$enabled    = ( null !== $assignment );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

During the wpcom deploy, there was a failing check that needs to be addressed.

Fixes
https://linear.app/a8c/issue/DOTCOM-14917/global-styles-on-personal-bridge-explat-and-the-gating-logic-on-atomic

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Added a guard against empty user data for the owner id.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Follow the instructions in https://github.com/Automattic/jetpack/pull/45797

