### PR TITLE
Forms: render badges in unread/read column when visible

### DIFF
--- a/projects/packages/forms/changelog/update-forms-unread-status-column
+++ b/projects/packages/forms/changelog/update-forms-unread-status-column
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Forms: render badges in unread/read column when visible

--- a/projects/packages/forms/src/dashboard/inbox/dataviews/index.js
+++ b/projects/packages/forms/src/dashboard/inbox/dataviews/index.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import jetpackAnalytics from '@automattic/jetpack-analytics';
+import { Badge } from '@automattic/ui';
 import {
 	ExternalLink,
 	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
@@ -359,6 +360,13 @@ export default function InboxView() {
 				],
 				filterBy: { operators: [ 'is' ] },
 				enableSorting: false,
+				render: ( { item } ) => {
+					return (
+						<Badge intent={ item.is_unread ? 'success' : 'default' }>
+							{ item.is_unread ? __( 'Unread', 'jetpack-forms' ) : __( 'Read', 'jetpack-forms' ) }
+						</Badge>
+					);
+				},
 			},
 			{
 				id: 'ip',

--- a/projects/packages/forms/src/dashboard/inbox/dataviews/index.js
+++ b/projects/packages/forms/src/dashboard/inbox/dataviews/index.js
@@ -353,7 +353,7 @@ export default function InboxView() {
 			},
 			{
 				id: 'read_status',
-				label: __( 'Read status', 'jetpack-forms' ),
+				label: __( 'Status', 'jetpack-forms' ),
 				elements: [
 					{ label: __( 'Unread', 'jetpack-forms' ), value: 'unread' },
 					{ label: __( 'Read', 'jetpack-forms' ), value: 'read' },
@@ -362,7 +362,7 @@ export default function InboxView() {
 				enableSorting: false,
 				render: ( { item } ) => {
 					return (
-						<Badge intent={ item.is_unread ? 'success' : 'default' }>
+						<Badge intent="default">
 							{ item.is_unread ? __( 'Unread', 'jetpack-forms' ) : __( 'Read', 'jetpack-forms' ) }
 						</Badge>
 					);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->



## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Change status name from "Read status" to just "Status"
* When users make "status" column visible, render something instead of empty column

Previously, we didn't render anything:

<img width="1058" height="303" alt="image" src="https://github.com/user-attachments/assets/ffa65570-ed4e-4826-ac9e-fb5cc923580a" />


Now we do:

<img width="1321" height="404" alt="Screenshot 2025-11-14 at 20 29 00" src="https://github.com/user-attachments/assets/cbb5ebca-16e7-438a-a566-a4c232e47289" />





### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* In the inbox
* Mark something as unread
* From cog icon ⚙️ make "read status" visible

