### PR TITLE
wpcomsh: Prevent PHP warnings in widgets

### DIFF
--- a/projects/plugins/wpcomsh/changelog/fix-wpcomsh-widget_warnings
+++ b/projects/plugins/wpcomsh/changelog/fix-wpcomsh-widget_warnings
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Widgets: Prevent PHP warnings when variables are undefined or malformed.

--- a/projects/plugins/wpcomsh/widgets/class-jetpack-widget-twitter.php
+++ b/projects/plugins/wpcomsh/widgets/class-jetpack-widget-twitter.php
@@ -33,7 +33,7 @@ class Jetpack_Widget_Twitter extends WP_Widget {
 	 * @param array $instance Widget instance.
 	 */
 	public function widget( $args, $instance ) {
-		$account = trim( rawurlencode( $instance['account'] ) );
+		$account = trim( rawurlencode( $instance['account'] ?? '' ) );
 
 		if ( empty( $account ) ) {
 			if ( current_user_can( 'edit_theme_options' ) ) {

--- a/projects/plugins/wpcomsh/widgets/class-music-player-widget.php
+++ b/projects/plugins/wpcomsh/widgets/class-music-player-widget.php
@@ -57,8 +57,10 @@ class Music_Player_Widget extends WP_Widget {
 			echo $args['after_title']; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		}
 
-		$shortcode = wp_kses( $instance['shortcode'] ?? '', array() );
-		echo do_shortcode( $shortcode );
+		if ( isset( $instance['shortcode'] ) ) {
+			$shortcode = wp_kses( $instance['shortcode'], array() );
+			echo do_shortcode( $shortcode );
+		}
 		echo $args['after_widget']; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 
 		/** This action is documented in jetpack/modules/widgets/gravatar-profile.php */

--- a/projects/plugins/wpcomsh/widgets/class-music-player-widget.php
+++ b/projects/plugins/wpcomsh/widgets/class-music-player-widget.php
@@ -57,8 +57,8 @@ class Music_Player_Widget extends WP_Widget {
 			echo $args['after_title']; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		}
 
-		$instance['shortcode'] = wp_kses( $instance['shortcode'], array() );
-		echo do_shortcode( $instance['shortcode'] );
+		$shortcode = wp_kses( $instance['shortcode'] ?? '', array() );
+		echo do_shortcode( $shortcode );
 		echo $args['after_widget']; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 
 		/** This action is documented in jetpack/modules/widgets/gravatar-profile.php */

--- a/projects/plugins/wpcomsh/widgets/class-pd-top-rated.php
+++ b/projects/plugins/wpcomsh/widgets/class-pd-top-rated.php
@@ -79,7 +79,7 @@ class PD_Top_Rated extends WP_Widget {
 					}
 				}
 
-				if ( count( $current_category ) > 0 && (int) $current_category[0]->cat_ID > 0 ) {
+				if ( is_array( $current_category ) && count( $current_category ) > 0 && (int) $current_category[0]->cat_ID > 0 ) {
 					$args     = array(
 						'category' => $current_category[0]->cat_ID,
 						'fields'   => 'ids',

--- a/projects/plugins/wpcomsh/widgets/class-pd-top-rated.php
+++ b/projects/plugins/wpcomsh/widgets/class-pd-top-rated.php
@@ -64,6 +64,7 @@ class PD_Top_Rated extends WP_Widget {
 			echo 'PDRTJS_TOP = new PDRTJS_RATING_TOP( ' . esc_html( (string) $posts_rating_id ) . ', ' . esc_html( (string) $pages_rating_id ) . ', ' . esc_html( (string) $comments_rating_id ) . ", '" . (int) $instance['show_posts'] . (int) $instance['show_pages'] . (int) $instance['show_comments'] . "', " . (int) $instance['item_count'] . ' );';
 
 			if ( $instance['show_posts'] === 1 && $instance['filter_by_category'] === 1 ) {
+				$current_category = array();
 				if ( is_single() ) { // get all posts in current category
 					global $post;
 					if ( ! empty( $post ) ) {
@@ -78,7 +79,7 @@ class PD_Top_Rated extends WP_Widget {
 					}
 				}
 
-				if ( is_array( $current_category ) && (int) $current_category[0]->cat_ID > 0 ) {
+				if ( count( $current_category ) > 0 && (int) $current_category[0]->cat_ID > 0 ) {
 					$args     = array(
 						'category' => $current_category[0]->cat_ID,
 						'fields'   => 'ids',

--- a/projects/plugins/wpcomsh/widgets/class-pd-top-rated.php
+++ b/projects/plugins/wpcomsh/widgets/class-pd-top-rated.php
@@ -79,7 +79,7 @@ class PD_Top_Rated extends WP_Widget {
 					}
 				}
 
-				if ( is_array( $current_category ) && count( $current_category ) > 0 && (int) $current_category[0]->cat_ID > 0 ) {
+				if ( is_array( $current_category ) && isset( $current_category[0]->cat_ID ) && (int) $current_category[0]->cat_ID > 0 ) {
 					$args     = array(
 						'category' => $current_category[0]->cat_ID,
 						'fields'   => 'ids',


### PR DESCRIPTION
Closes MONOREP-224

 <!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This addresses just shy of 1M PHP warnings in the widgets.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

```
PHP Warning: Undefined array key "account" in /wordpress/plugins/wpcomsh/8.1.0-alpha+rolling.1763028843.g4973846/widgets/class-jetpack-widget-twitter.php on line 36
```
For the above, I added a fallback empty string if the key doesn't exist. There's already a mechanism to surface an error if the (cleaned) value is empty.

```
PHP Warning: Undefined array key "shortcode" in /wordpress/plugins/wpcomsh/8.1.0-alpha+rolling.1763028843.g4973846/widgets/class-music-player-widget.php on line 60
```
For the above, I don't process the key if it's not set. The `do_shortcode()` call simply returns the value if it has no shortcodes, so it should be safe.

```
PHP Warning: Undefined variable $current_category in /wordpress/plugins/wpcomsh/8.1.0-alpha+rolling.1763028843.g4973846/widgets/class-pd-top-rated.php on line 81
```
For the above, we initialize the var as an array. Docs indicate `get_the_category()` returns an array, but it returns an `apply_filter()` so can't be trusted, so I left the `is_array()` check. I added a `count()` to guard things a bit better.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Is CI happy? And is there a better way to handle the issues?
