### PR TITLE
Forms: use first/last name for author

### DIFF
--- a/projects/packages/forms/changelog/update-forms-author-first-last-name
+++ b/projects/packages/forms/changelog/update-forms-author-first-last-name
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Forms: use first/last name for author.

--- a/projects/packages/forms/src/contact-form/class-feedback-author.php
+++ b/projects/packages/forms/src/contact-form/class-feedback-author.php
@@ -49,6 +49,64 @@ class Feedback_Author {
 	}
 
 	/**
+	 * Compute author name from either submission data (array + form) or stored fields (Feedback).
+	 *
+	 * Rules:
+	 * - If First/Last name fields exist (by known ids), return "First Last" trimmed.
+	 * - Otherwise, return the single Name field value.
+	 * - Applies the pre_comment_author_name filter and standard sanitization.
+	 *
+	 * @param Feedback|array    $source Submission array or Feedback instance.
+	 * @param Contact_Form|null $form The form object (required when $source is submission array).
+	 * @return string Filtered display name.
+	 */
+	public static function get_computed_author_name( $source, $form = null ) {
+		$is_from_feedback_object = is_object( $source ) && $source instanceof Feedback;
+		$final_name              = '';
+
+		if ( $is_from_feedback_object ) {
+			$first_name  = $source->get_field_value_by_form_field_id( 'first-name' );
+			$last_name   = $source->get_field_value_by_form_field_id( 'last-name' );
+			$full_name   = trim( $first_name . ' ' . $last_name );
+			$single_name = '';
+			if ( method_exists( $source, 'get_fields' ) ) {
+				foreach ( $source->get_fields() as $field ) {
+					if ( method_exists( $field, 'get_type' ) && $field->get_type() === 'name' ) {
+						$single_name = $field->get_render_value();
+						break;
+					}
+				}
+			}
+
+			// Return the full name if it exists, otherwise return the single name.
+			$final_name = $full_name ? $full_name : $single_name;
+		} elseif ( is_array( $source ) ) {
+			$first_name = isset( $source['first-name'] ) ? wp_unslash( $source['first-name'] ) : '';
+			$last_name  = isset( $source['last-name'] ) ? wp_unslash( $source['last-name'] ) : '';
+			$full_name  = trim( $first_name . ' ' . $last_name );
+
+			$single_name = '';
+			if ( $form && method_exists( $form, 'get_field_ids' ) ) {
+				$field_ids = $form->get_field_ids();
+				if ( isset( $field_ids['name'] ) && isset( $source[ $field_ids['name'] ] ) ) {
+					$single_name = wp_unslash( $source[ $field_ids['name'] ] );
+				}
+			}
+
+			// Return the full name if it exists, otherwise return the single name.
+			$final_name = $full_name ? $full_name : $single_name;
+		}
+
+		// Apply standard filtering/sanitization used for author names.
+		return Contact_Form_Plugin::strip_tags(
+			stripslashes(
+				/** This filter is already documented in core/wp-includes/comment-functions.php */
+				apply_filters( 'pre_comment_author_name', addslashes( $final_name ) )
+			)
+		);
+	}
+
+	/**
 	 * Create a Feedback_Author instance from the submission data.
 	 *
 	 * @param array        $post_data The post data from the form submission.
@@ -74,6 +132,10 @@ class Feedback_Author {
 	 * @return string Filter value for the author information.
 	 */
 	private static function get_computed_author_info( $post_data, $type, $filter, $form ) {
+		// Handle name specially to support First/Last variations.
+		if ( $type === 'name' ) {
+			return self::get_computed_author_name( $post_data, $form );
+		}
 		$field_ids = $form->get_field_ids();
 		if ( isset( $field_ids[ $type ] ) ) {
 			$key   = $field_ids[ $type ];

--- a/projects/packages/forms/src/contact-form/class-feedback.php
+++ b/projects/packages/forms/src/contact-form/class-feedback.php
@@ -242,7 +242,7 @@ class Feedback {
 		$this->notification_recipients = $parsed_content['notification_recipients'] ?? array();
 
 		$this->author_data = new Feedback_Author(
-			$this->get_first_field_of_type( 'name', 'pre_comment_author_name' ),
+			Feedback_Author::get_computed_author_name( $this ),
 			$this->get_first_field_of_type( 'email', 'pre_comment_author_email' ),
 			$this->get_first_field_of_type( 'url', 'pre_comment_author_url' )
 		);

--- a/projects/plugins/jetpack/changelog/update-forms-author-first-last-name
+++ b/projects/plugins/jetpack/changelog/update-forms-author-first-last-name
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Forms: use first/last name for author.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes [FORMS-393](https://linear.app/a8c/issue/FORMS-393/forms-map-firstlast-name-fields-to-author)

## Proposed changes:

We added first and last variations for name. But we do not handle those properly post-submission by using them for author name in place of the single 'name' field when they are present.

Before this PR, existing code would grab the first 'name' field of any kind and use that. So that means it would find first or last, and use that alone. This PR ensure we detect both and combine them when present. If not present, we fall back to the single 'name' fields as before (or else email). 

Caveats: There maybe languages/locales where names are reversed. We can figure out if/how to handle that separately. 

**Before**
<img width="527" height="492" alt="author-first-last-before" src="https://github.com/user-attachments/assets/39ee96d7-7180-47fb-aacf-7865944f6b3a" />

**After**
<img width="531" height="515" alt="author-first-last-after" src="https://github.com/user-attachments/assets/3b858ee0-c3fa-4429-b347-5350c47943e0" />

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
See linear issue. 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Add a form with first and last name variations, publish, and submit. 
* Go to form submissions and confirm we show the names together as author in the submission list and single submission view. 
* Confirm no regressions by adding a form with a single name field (no first/last name), and confirm that's still used as before. 

