### PR TITLE
Social: Fix connection icon not reflecting the change when profile picture is updated

### DIFF
--- a/projects/js-packages/publicize-components/changelog/fix-social-connection-icon-update
+++ b/projects/js-packages/publicize-components/changelog/fix-social-connection-icon-update
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Social: Fix connection icon not reflecting the change when profile picture is updated.

--- a/projects/js-packages/publicize-components/src/components/connection-icon/index.jsx
+++ b/projects/js-packages/publicize-components/src/components/connection-icon/index.jsx
@@ -7,9 +7,11 @@ import './style.scss';
 
 const ConnectionIcon = props => {
 	const { checked, serviceName, label, onClick, profilePicture } = props;
-	const [ hasDisplayPicture, setHasDisplayPicture ] = useState( !! profilePicture );
+	const [ imageErrorFor, setImageErrorFor ] = useState( null );
 
-	const onError = useCallback( () => setHasDisplayPicture( false ), [] );
+	const onError = useCallback( () => setImageErrorFor( profilePicture ), [ profilePicture ] );
+
+	const hasDisplayPicture = !! profilePicture && imageErrorFor !== profilePicture;
 
 	const handleKeyDown = useCallback(
 		ev => {

--- a/projects/plugins/jetpack/changelog/fix-social-connection-icon-update
+++ b/projects/plugins/jetpack/changelog/fix-social-connection-icon-update
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Social: Fix connection icon not reflecting the change when profile picture is updated.

--- a/projects/plugins/social/changelog/fix-social-connection-icon-update
+++ b/projects/plugins/social/changelog/fix-social-connection-icon-update
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix connection icon not reflecting the change when profile picture is updated.


### PR DESCRIPTION
Related to SOCIAL-51

Currently in `ConnectionIcon` component, if the initial `profilePicture` has error loading, it remains in the same state if the subsequent changes to the profile picture fix the loading issue.

For example, if a connection has a profile pitcture that has its URL expired, it will err on initial load. Ideally, connection test result returns the updated profile picture when available but it's not updated in the icon because the state for the image error is set on the initial error which is never changed when a new image is received.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Update the `ConnectionIcon` component to properly reflect changes when the profile picture is updated. It now stores the error per URL instead of the boolean flag. So, if the URL changes, it also changes the error associated with it

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Test this on a site which has a Threads, Instagram or a LinkedIn connection with an expired profile picture link
* Apply 196015-ghe-Automattic/wpcom to your sandbox
* Point your site and the public API to your sandbox
* Share a post to the account which has the expired profile picture
* Go to Jetpack > Social page
* Confirm that the profile picture is updated after the connection tests API call finishes.

<table>
    <tbody>
        <tr>
            <th>BEFORE</th>
            <th>AFTER</th>
        </tr>
        <tr>
            <td>

https://github.com/user-attachments/assets/2dc1133f-7866-441f-ae4f-0b862d78edfe

</td>
            <td>

https://github.com/user-attachments/assets/3cb94efe-452b-4fb5-a0ab-7947cf19aa27

</td>
        </tr>
    </tbody>
</table>