### PR TITLE
DO NOT MERGE Forms: enable Hostinger Reach integration

### DIFF
--- a/projects/packages/forms/changelog/update-forms-hostinger-feature-flag
+++ b/projects/packages/forms/changelog/update-forms-hostinger-feature-flag
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Forms: enable Hostinger Reach integration.

--- a/projects/packages/forms/src/class-jetpack-forms.php
+++ b/projects/packages/forms/src/class-jetpack-forms.php
@@ -105,7 +105,7 @@ class Jetpack_Forms {
 		 *
 		 * @param bool false Whether Hostinger Reach integration be enabled. Default is false.
 		 */
-		return apply_filters( 'jetpack_forms_hostinger_reach_enable', false );
+		return apply_filters( 'jetpack_forms_hostinger_reach_enable', true );
 	}
 
 	/**

--- a/projects/plugins/jetpack/changelog/update-forms-hostinger-feature-flag
+++ b/projects/plugins/jetpack/changelog/update-forms-hostinger-feature-flag
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Forms: enable Hostinger Reach integration.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

DO NOT MERGE: We're waiting for partner approval before merging. 

Fixes [FORMS-413](https://linear.app/a8c/issue/FORMS-413/forms-enable-hostinger-reach-feature-flag)

## Proposed changes:

Enables Hostinger Reach integration by flipping feature flag default from false to true. While the integration was already tested when merged, it would worth re-testing before we release. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
See [Linear project.](https://linear.app/a8c/project/forms-hostinger-reach-integration-33af24f5b007/overview) 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No. 

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* **Integrations dashboard.** Confirm Hostinger shows in the dashboard integrations list, and that you can install, activate, and connect the service.
   - **Install/Activate plugin**. If not done already, install plugin from from the integrations dashboard, confirm plugin installs and activates, and confirm that card status updates once done.
   - **Connect site**. If you haven't connected Hostinger Reach already, you'll see button to complete setup. Click that to go to Hostinger settings page in your WordPress admin. Click the 'Connect Site' button and set up a free account.
   - **Confirm connected state.** After connecting site, go back to integrations dashboard. If needed click Refresh Status. Confirm that you no longer see buttons to install, activate, or complete setup, but rather just a link to the Hostinger dashboard. Confirm that links works. 
 
* **Integrations modal.** Confirm Hostinger Reach shows in the block modal, and that you can enable it for the form and add a group name.
   - **Create form**. Create post with a new form. Be sure to include First Name, Last Name, and Email fields. 
   - **Integrations modal.** Open the integrations modal. Confirm you see Hostinger Reach. Enable the integration with the header toggle. Add a Group Name.  
   - **Active integrations.** Close the modal and confirm that the Hostinger icon now shows on the block sidebar. 
  
* **Form submission.** Go to the frontend and submit your form.
  - **No submit errors.** Confirm no submit errors. 
  - **Contact added to Hostinger.** Confirm contact is added to your Hostinger Reach account, and with the group name you added (or the default "Jetpack Forms" if you did not add a group name).

