### PR TITLE
Add missing warning banner for non premium styles in editor

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/improve-gs-detection-logic
+++ b/projects/packages/jetpack-mu-wpcom/changelog/improve-gs-detection-logic
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Global styles Gating: Fixes a case where GS use was not detected in the editor

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/use-global-styles-config.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/use-global-styles-config.js
@@ -40,13 +40,10 @@ export function useGlobalStylesConfig() {
 		const themeBaseCss = ( _themeBaseGlobalStyles?.styles?.css ?? '' ).replace( /\s+/g, '' );
 		const customCss = ( globalStylesConfig?.styles.css ?? '' ).replace( /\s+/g, '' );
 
-		// If the global styles are empty, set the styles to an empty object.
-		// Gutenberg saves the css property even if it's empty, so we need to check for that.
-		if (
-			( themeBaseCss === customCss || '' === globalStylesConfig.styles.css ) &&
-			Object.keys( globalStylesConfig.styles ).length === 1
-		) {
-			globalStylesConfig.styles = {};
+		// Gutenberg saves the css property even if it's empty or unchanged from the theme.
+		// Disregard the styles.css property in either of those cases.
+		if ( themeBaseCss === customCss || '' === globalStylesConfig.styles.css ) {
+			delete globalStylesConfig.styles.css;
 		}
 
 		// Determine if the global Styles are in use on the current site.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes DOTTHEM-102

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
The "I see you're using global styles..." notice was not being displayed inside the editor for certain global styles edits, despite the style edits not being displayed without access to GS.

This change improves the in-editor algorithm for detecting global styles changes that was updated in #43554 so that it displays the notice for all global styles changes, but does not show the notice if any custom CSS is empty or is identical to the custom CSS shipped in the theme.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->


1. Apply changes to your sandbox
2. Apply the Vitrum theme to a site that doesn't have access to global styles (i.e. is personal plan, isn't part of an experiment)
3. Open the editor and choose a different colour in Styles → Colours → Background 
4. Notice that you get the global styles notice, whereas before you didn't.

Before | After
-------|------
<img width="1323" height="969" alt="Screenshot 2025-11-17 at 14 53 12" src="https://github.com/user-attachments/assets/d2a669f5-d80f-4c98-91c3-22a697bfa2d9" /> | <img width="1323" height="969" alt="Screenshot 2025-11-17 at 14 54 06" src="https://github.com/user-attachments/assets/13c8809d-4195-4486-8673-10406f621ea4" />

5. Sandbox a free site
6. Activate Vitrum theme (via the BRC)
7. Go to Site Editor → Global Styles → Additional CSS
8. Note that there's some existing CSS which gets shipped with the theme
9. Note that you do not get the GS notice
10. Change the CSS
11. Note that you do get the GS notice.
12. Buy the Custom Design Add-on
13. Note that you no longer get the GS notice when changing the custom CSS.
