### PR TITLE
Forms: handle first/last names in feedback classes

### DIFF
--- a/projects/packages/forms/changelog/update-forms-author-first-last-name
+++ b/projects/packages/forms/changelog/update-forms-author-first-last-name
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Forms: use first/last name for author.

--- a/projects/packages/forms/src/contact-form/class-feedback-author.php
+++ b/projects/packages/forms/src/contact-form/class-feedback-author.php
@@ -49,6 +49,64 @@ class Feedback_Author {
 	}
 
 	/**
+	 * Compute author name from either submission data (array + form) or stored fields (Feedback).
+	 *
+	 * Rules:
+	 * - If First/Last name fields exist (by known ids), return "First Last" trimmed.
+	 * - Otherwise, return the single Name field value.
+	 * - Applies the pre_comment_author_name filter and standard sanitization.
+	 *
+	 * @param Feedback|array    $source Submission array or Feedback instance.
+	 * @param Contact_Form|null $form The form object (required when $source is submission array).
+	 * @return string Filtered display name.
+	 */
+	public static function get_computed_author_name( $source, $form = null ) {
+		$is_from_feedback_object = is_object( $source ) && $source instanceof Feedback;
+		$final_name              = '';
+
+		if ( $is_from_feedback_object ) {
+			$first_name  = $source->get_field_value_by_form_field_id( 'first-name' );
+			$last_name   = $source->get_field_value_by_form_field_id( 'last-name' );
+			$full_name   = trim( $first_name . ' ' . $last_name );
+			$single_name = '';
+			if ( method_exists( $source, 'get_fields' ) ) {
+				foreach ( $source->get_fields() as $field ) {
+					if ( method_exists( $field, 'get_type' ) && $field->get_type() === 'name' ) {
+						$single_name = $field->get_render_value();
+						break;
+					}
+				}
+			}
+
+			// Return the full name if it exists, otherwise return the single name.
+			$final_name = $full_name ? $full_name : $single_name;
+		} elseif ( is_array( $source ) ) {
+			$first_name = isset( $source['first-name'] ) ? wp_unslash( $source['first-name'] ) : '';
+			$last_name  = isset( $source['last-name'] ) ? wp_unslash( $source['last-name'] ) : '';
+			$full_name  = trim( $first_name . ' ' . $last_name );
+
+			$single_name = '';
+			if ( $form && method_exists( $form, 'get_field_ids' ) ) {
+				$field_ids = $form->get_field_ids();
+				if ( isset( $field_ids['name'] ) && isset( $source[ $field_ids['name'] ] ) ) {
+					$single_name = wp_unslash( $source[ $field_ids['name'] ] );
+				}
+			}
+
+			// Return the full name if it exists, otherwise return the single name.
+			$final_name = $full_name ? $full_name : $single_name;
+		}
+
+		// Apply standard filtering/sanitization used for author names.
+		return Contact_Form_Plugin::strip_tags(
+			stripslashes(
+				/** This filter is already documented in core/wp-includes/comment-functions.php */
+				apply_filters( 'pre_comment_author_name', addslashes( $final_name ) )
+			)
+		);
+	}
+
+	/**
 	 * Create a Feedback_Author instance from the submission data.
 	 *
 	 * @param array        $post_data The post data from the form submission.
@@ -74,6 +132,10 @@ class Feedback_Author {
 	 * @return string Filter value for the author information.
 	 */
 	private static function get_computed_author_info( $post_data, $type, $filter, $form ) {
+		// Handle name specially to support First/Last variations.
+		if ( $type === 'name' ) {
+			return self::get_computed_author_name( $post_data, $form );
+		}
 		$field_ids = $form->get_field_ids();
 		if ( isset( $field_ids[ $type ] ) ) {
 			$key   = $field_ids[ $type ];

--- a/projects/packages/forms/src/contact-form/class-feedback-author.php
+++ b/projects/packages/forms/src/contact-form/class-feedback-author.php
@@ -36,74 +36,34 @@ class Feedback_Author {
 	private $url;
 
 	/**
+	 * The first name of the author.
+	 *
+	 * @var string
+	 */
+	private $first_name = '';
+
+	/**
+	 * The last name of the author.
+	 *
+	 * @var string
+	 */
+	private $last_name = '';
+
+	/**
 	 * Constructor for Feedback_Author.
 	 *
 	 * @param string $name  The name of the author.
 	 * @param string $email The email of the author.
 	 * @param string $url   The URL of the author.
+	 * @param string $first_name The first name of the author.
+	 * @param string $last_name  The last name of the author.
 	 */
-	public function __construct( $name = '', $email = '', $url = '' ) {
-		$this->name  = $name;
-		$this->email = $email;
-		$this->url   = $url;
-	}
-
-	/**
-	 * Compute author name from either submission data (array + form) or stored fields (Feedback).
-	 *
-	 * Rules:
-	 * - If First/Last name fields exist (by known ids), return "First Last" trimmed.
-	 * - Otherwise, return the single Name field value.
-	 * - Applies the pre_comment_author_name filter and standard sanitization.
-	 *
-	 * @param Feedback|array    $source Submission array or Feedback instance.
-	 * @param Contact_Form|null $form The form object (required when $source is submission array).
-	 * @return string Filtered display name.
-	 */
-	public static function get_computed_author_name( $source, $form = null ) {
-		$is_from_feedback_object = is_object( $source ) && $source instanceof Feedback;
-		$final_name              = '';
-
-		if ( $is_from_feedback_object ) {
-			$first_name  = $source->get_field_value_by_form_field_id( 'first-name' );
-			$last_name   = $source->get_field_value_by_form_field_id( 'last-name' );
-			$full_name   = trim( $first_name . ' ' . $last_name );
-			$single_name = '';
-			if ( method_exists( $source, 'get_fields' ) ) {
-				foreach ( $source->get_fields() as $field ) {
-					if ( method_exists( $field, 'get_type' ) && $field->get_type() === 'name' ) {
-						$single_name = $field->get_render_value();
-						break;
-					}
-				}
-			}
-
-			// Return the full name if it exists, otherwise return the single name.
-			$final_name = $full_name ? $full_name : $single_name;
-		} elseif ( is_array( $source ) ) {
-			$first_name = isset( $source['first-name'] ) ? wp_unslash( $source['first-name'] ) : '';
-			$last_name  = isset( $source['last-name'] ) ? wp_unslash( $source['last-name'] ) : '';
-			$full_name  = trim( $first_name . ' ' . $last_name );
-
-			$single_name = '';
-			if ( $form && method_exists( $form, 'get_field_ids' ) ) {
-				$field_ids = $form->get_field_ids();
-				if ( isset( $field_ids['name'] ) && isset( $source[ $field_ids['name'] ] ) ) {
-					$single_name = wp_unslash( $source[ $field_ids['name'] ] );
-				}
-			}
-
-			// Return the full name if it exists, otherwise return the single name.
-			$final_name = $full_name ? $full_name : $single_name;
-		}
-
-		// Apply standard filtering/sanitization used for author names.
-		return Contact_Form_Plugin::strip_tags(
-			stripslashes(
-				/** This filter is already documented in core/wp-includes/comment-functions.php */
-				apply_filters( 'pre_comment_author_name', addslashes( $final_name ) )
-			)
-		);
+	public function __construct( $name = '', $email = '', $url = '', $first_name = '', $last_name = '' ) {
+		$this->name       = $name;
+		$this->email      = $email;
+		$this->url        = $url;
+		$this->first_name = $first_name;
+		$this->last_name  = $last_name;
 	}
 
 	/**
@@ -114,10 +74,14 @@ class Feedback_Author {
 	 * @return Feedback_Author The Feedback_Author instance.
 	 */
 	public static function from_submission( $post_data, $form ) {
+		$first = isset( $post_data['first-name'] ) ? wp_unslash( $post_data['first-name'] ) : '';
+		$last  = isset( $post_data['last-name'] ) ? wp_unslash( $post_data['last-name'] ) : '';
 		return new self(
 			self::get_computed_author_info( $post_data, 'name', 'pre_comment_author_name', $form ),
 			self::get_computed_author_info( $post_data, 'email', 'pre_comment_author_email', $form ),
-			self::get_computed_author_info( $post_data, 'url', 'pre_comment_author_url', $form )
+			self::get_computed_author_info( $post_data, 'url', 'pre_comment_author_url', $form ),
+			$first,
+			$last
 		);
 	}
 
@@ -132,10 +96,6 @@ class Feedback_Author {
 	 * @return string Filter value for the author information.
 	 */
 	private static function get_computed_author_info( $post_data, $type, $filter, $form ) {
-		// Handle name specially to support First/Last variations.
-		if ( $type === 'name' ) {
-			return self::get_computed_author_name( $post_data, $form );
-		}
 		$field_ids = $form->get_field_ids();
 		if ( isset( $field_ids[ $type ] ) ) {
 			$key   = $field_ids[ $type ];
@@ -167,7 +127,8 @@ class Feedback_Author {
 	 * @return string The display name of the author.
 	 */
 	public function get_display_name(): string {
-		return empty( $this->name ) ? $this->email : $this->name;
+		$name = $this->get_name();
+		return empty( $name ) ? $this->email : $name;
 	}
 
 	/**
@@ -187,6 +148,16 @@ class Feedback_Author {
 	 * @return string The name of the author.
 	 */
 	public function get_name() {
+		if ( $this->first_name && $this->last_name ) {
+			$raw = trim( $this->first_name . ' ' . $this->last_name );
+			return Contact_Form_Plugin::strip_tags(
+				stripslashes(
+					/** This filter is already documented in core/wp-includes/comment-functions.php */
+					apply_filters( 'pre_comment_author_name', addslashes( $raw ) )
+				)
+			);
+		}
+		// This name value is filtered upstream when class is instantiated.
 		return $this->name;
 	}
 
@@ -206,5 +177,23 @@ class Feedback_Author {
 	 */
 	public function get_url() {
 		return $this->url;
+	}
+
+	/**
+	 * Get the first name of the author (if provided separately).
+	 *
+	 * @return string
+	 */
+	public function get_first_name() {
+		return $this->first_name;
+	}
+
+	/**
+	 * Get the last name of the author (if provided separately).
+	 *
+	 * @return string
+	 */
+	public function get_last_name() {
+		return $this->last_name;
 	}
 }

--- a/projects/packages/forms/src/contact-form/class-feedback.php
+++ b/projects/packages/forms/src/contact-form/class-feedback.php
@@ -242,9 +242,11 @@ class Feedback {
 		$this->notification_recipients = $parsed_content['notification_recipients'] ?? array();
 
 		$this->author_data = new Feedback_Author(
-			Feedback_Author::get_computed_author_name( $this ),
+			$this->get_first_field_of_type( 'name', 'pre_comment_author_name' ),
 			$this->get_first_field_of_type( 'email', 'pre_comment_author_email' ),
-			$this->get_first_field_of_type( 'url', 'pre_comment_author_url' )
+			$this->get_first_field_of_type( 'url', 'pre_comment_author_url' ),
+			$this->get_field_value_by_form_field_id( 'first-name' ),
+			$this->get_field_value_by_form_field_id( 'last-name' )
 		);
 
 		$this->comment_content = $this->get_first_field_of_type( 'textarea' );
@@ -727,6 +729,24 @@ class Feedback {
 	 */
 	public function get_author_name() {
 		return $this->author_data->get_name();
+	}
+
+	/**
+	 * Get the author's first name of a feedback entry.
+	 *
+	 * @return string
+	 */
+	public function get_author_first_name() {
+		return $this->author_data->get_first_name();
+	}
+
+	/**
+	 * Get the author's last name of a feedback entry.
+	 *
+	 * @return string
+	 */
+	public function get_author_last_name() {
+		return $this->author_data->get_last_name();
 	}
 
 	/**

--- a/projects/packages/forms/src/contact-form/class-feedback.php
+++ b/projects/packages/forms/src/contact-form/class-feedback.php
@@ -242,7 +242,7 @@ class Feedback {
 		$this->notification_recipients = $parsed_content['notification_recipients'] ?? array();
 
 		$this->author_data = new Feedback_Author(
-			$this->get_first_field_of_type( 'name', 'pre_comment_author_name' ),
+			Feedback_Author::get_computed_author_name( $this ),
 			$this->get_first_field_of_type( 'email', 'pre_comment_author_email' ),
 			$this->get_first_field_of_type( 'url', 'pre_comment_author_url' )
 		);

--- a/projects/packages/forms/tests/php/contact-form/Feedback_Author_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Feedback_Author_Test.php
@@ -28,17 +28,9 @@ class Feedback_Author_Test extends BaseTestCase {
 
 		$this->assertEquals( 'John Doe', $author->get_name() );
 		$this->assertEquals( 'John Doe', $author->get_display_name() );
+		$this->assertSame( 'John', $author->get_first_name() );
+		$this->assertSame( 'Doe', $author->get_last_name() );
 	}
-
-	/**
-	 * Minimal: getters for first and last name return raw values.
-	 */
-	public function test_first_last_getters() {
-		$author = new Feedback_Author( '', '', '', 'Alice', 'Smith' );
-		$this->assertSame( 'Alice', $author->get_first_name() );
-		$this->assertSame( 'Smith', $author->get_last_name() );
-	}
-
 	/**
 	 * Minimal: when only one of first/last is present, fall back to single name.
 	 */
@@ -46,6 +38,33 @@ class Feedback_Author_Test extends BaseTestCase {
 		$author = new Feedback_Author( 'Single Name', 's@example.com', '', 'Bob', '' );
 		$this->assertEquals( 'Single Name', $author->get_name() );
 		$this->assertEquals( 'Single Name', $author->get_display_name() );
+	}
+
+	/**
+	 * When both first/last are present and differ from single name, combined name takes precedence.
+	 */
+	public function test_first_last_override_single_name_when_both_present() {
+		$author = new Feedback_Author( 'Some Other Name', 'x@example.com', '', 'Alice', 'Jones' );
+		$this->assertEquals( 'Alice Jones', $author->get_name() );
+		$this->assertEquals( 'Alice Jones', $author->get_display_name() );
+	}
+
+	/**
+	 * When only last name is provided and single name exists, fall back to single name.
+	 */
+	public function test_only_lastname_with_single_name_falls_back_to_single() {
+		$author = new Feedback_Author( 'Single Name', 'x@example.com', '', '', 'Jones' );
+		$this->assertEquals( 'Single Name', $author->get_name() );
+		$this->assertEquals( 'Single Name', $author->get_display_name() );
+	}
+
+	/**
+	 * When only last name is provided and single name is missing, fall back to email in display.
+	 */
+	public function test_only_lastname_without_single_name_falls_back_to_email() {
+		$author = new Feedback_Author( '', 'x@example.com', '', '', 'Jones' );
+		$this->assertSame( '', $author->get_name() );
+		$this->assertEquals( 'x@example.com', $author->get_display_name() );
 	}
 
 	/**

--- a/projects/packages/forms/tests/php/contact-form/Feedback_Author_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Feedback_Author_Test.php
@@ -21,6 +21,34 @@ use WorDBless\BaseTestCase;
 class Feedback_Author_Test extends BaseTestCase {
 
 	/**
+	 * Minimal: combining first and last name yields full name in name/display.
+	 */
+	public function test_combined_first_last_in_name_and_display() {
+		$author = new Feedback_Author( '', 'john@example.com', '', 'John', 'Doe' );
+
+		$this->assertEquals( 'John Doe', $author->get_name() );
+		$this->assertEquals( 'John Doe', $author->get_display_name() );
+	}
+
+	/**
+	 * Minimal: getters for first and last name return raw values.
+	 */
+	public function test_first_last_getters() {
+		$author = new Feedback_Author( '', '', '', 'Alice', 'Smith' );
+		$this->assertSame( 'Alice', $author->get_first_name() );
+		$this->assertSame( 'Smith', $author->get_last_name() );
+	}
+
+	/**
+	 * Minimal: when only one of first/last is present, fall back to single name.
+	 */
+	public function test_partial_first_or_last_falls_back_to_single_name() {
+		$author = new Feedback_Author( 'Single Name', 's@example.com', '', 'Bob', '' );
+		$this->assertEquals( 'Single Name', $author->get_name() );
+		$this->assertEquals( 'Single Name', $author->get_display_name() );
+	}
+
+	/**
 	 * Test constructor with all parameters.
 	 */
 	public function test_constructor_with_all_parameters() {

--- a/projects/packages/forms/tests/php/contact-form/Feedback_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Feedback_Test.php
@@ -3145,18 +3145,22 @@ class Feedback_Test extends BaseTestCase {
 	 * Minimal: submission with first-name/last-name sets author name and first/last getters.
 	 */
 	public function test_author_first_last_on_submission() {
-		// Form can be minimal; we rely on explicit first/last ids in post data.
 		$form = new Contact_Form(
 			array(
 				'title'       => 'Test Form',
 				'description' => 'This is a test form.',
 			),
-			"[contact-field label='Message' type='textarea' required='1'/]"
+			"
+			[contact-field label='First name' type='name' id='first-name'/]
+			[contact-field label='Last name' type='name' id='last-name'/]
+			[contact-field label='Email' type='email' id='email'/]
+			"
 		);
 
 		$post_data = array(
 			'first-name' => 'Jane',
 			'last-name'  => 'Doe',
+			'email'      => 'jane@example.com',
 		);
 
 		$response = Feedback::from_submission( $post_data, $form );

--- a/projects/packages/forms/tests/php/contact-form/Feedback_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Feedback_Test.php
@@ -3140,4 +3140,29 @@ class Feedback_Test extends BaseTestCase {
 
 		remove_filter( 'jetpack_get_country_from_ip', $filter_callback, 10 );
 	}
+
+	/**
+	 * Minimal: submission with first-name/last-name sets author name and first/last getters.
+	 */
+	public function test_author_first_last_on_submission() {
+		// Form can be minimal; we rely on explicit first/last ids in post data.
+		$form = new Contact_Form(
+			array(
+				'title'       => 'Test Form',
+				'description' => 'This is a test form.',
+			),
+			"[contact-field label='Message' type='textarea' required='1'/]"
+		);
+
+		$post_data = array(
+			'first-name' => 'Jane',
+			'last-name'  => 'Doe',
+		);
+
+		$response = Feedback::from_submission( $post_data, $form );
+
+		$this->assertEquals( 'Jane Doe', $response->get_author_name(), 'Author name should combine first and last' );
+		$this->assertSame( 'Jane', $response->get_author_first_name(), 'First name getter should return raw first name' );
+		$this->assertSame( 'Doe', $response->get_author_last_name(), 'Last name getter should return raw last name' );
+	}
 }

--- a/projects/plugins/jetpack/changelog/update-forms-author-first-last-name
+++ b/projects/plugins/jetpack/changelog/update-forms-author-first-last-name
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Forms: use first/last name for author.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes [FORMS-393](https://linear.app/a8c/issue/FORMS-393/forms-map-firstlast-name-fields-to-author)

## Proposed changes:

We added first and last variations for name. But we do not handle those properly post-submission. For example, before this PR, existing code would grab the first 'name' field of any kind and use that as the author name for a form response. So that means it would find first or last, and use that alone. 

This PR adds proper handling of first and last names to the Feedback and Feedback_Author classes. Changes include:
* getters for first and last name
* updating the get_name method to return 'First Last' if possible or fall back to single name field as before
* update Feedback_Author class to take in first and last name when instantiated
* added tests

Caveats: There maybe languages/locales where names are reversed. We can figure out if/how to handle that separately. 

**Before**
<img width="527" height="492" alt="author-first-last-before" src="https://github.com/user-attachments/assets/39ee96d7-7180-47fb-aacf-7865944f6b3a" />

**After**
<img width="531" height="515" alt="author-first-last-after" src="https://github.com/user-attachments/assets/3b858ee0-c3fa-4429-b347-5350c47943e0" />

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
See linear issue. 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Add a form with first and last name variations, publish, and submit on frontend. 
* Go to form submissions and confirm we show the names together as author in the submission list and single submission view. 
* Confirm no regressions by adding a form with a single name field (no first/last name), and confirm that's still used as before. 
* Confirm PHP tests pass