### PR TITLE
Forms: Add fallback for JWT decoding for cached forms

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-jwt-fallback
+++ b/projects/packages/forms/changelog/fix-forms-jwt-fallback
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: Add fallback for JWT decoding for cached forms

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -352,6 +352,11 @@ class Contact_Form extends Contact_Form_Shortcode {
 			}
 		}
 
+		// At this point, $data should not be null (we return early if it is), but adding check for static analysis
+		if ( $data === null ) {
+			return null;
+		}
+
 		$form                   = new self( $data['attributes'], $data['content'], empty( $data['attributes']['id'] ) );
 		$form->source           = Feedback_Source::from_serialized( $source );
 		$form->hash             = $data['hash'];

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -261,21 +261,72 @@ class Contact_Form extends Contact_Form_Shortcode {
 	 * @throws \Exception If the JWT token is invalid or cannot be decoded and $throw_exception is true.
 	 */
 	public static function get_instance_from_jwt( $jwt_token, $throw_exception = false ) {
-		$secret = self::get_secret();
+		$secret_info   = self::get_secret();
+		$secret        = $secret_info['secret'];
+		$secret_source = $secret_info['source'];
+		$data          = null;
+		$exception     = null;
 
 		try {
 			$data = JWT::decode( $jwt_token, $secret, array( 'HS256' ), true );
 		} catch ( \Exception $e ) {
+			$exception = $e;
+
+			// If signature verification failed, try fallback secrets for backward compatibility
+			// This handles cases where tokens were created with a different secret source
+			if ( strpos( $e->getMessage(), 'Signature verification failed' ) !== false ) {
+				$fallback_secrets = self::get_fallback_secrets( $secret_source );
+
+				foreach ( $fallback_secrets as $fallback ) {
+					$fallback_secret = $fallback['secret'];
+
+					if ( empty( $fallback_secret ) || $fallback_secret === $secret ) {
+						continue;
+					}
+
+					try {
+						$data = JWT::decode( $jwt_token, $fallback_secret, array( 'HS256' ), true );
+
+						// Successfully decoded with fallback secret - log for debugging
+						do_action(
+							'jetpack_forms_log',
+							'jwt_decoded_with_fallback_secret',
+							array(
+								'original_source' => $secret_source,
+								'fallback_source' => $fallback['source'],
+							)
+						);
+
+						$exception = null;
+						break;
+					} catch ( \Exception $fallback_e ) {
+						// Continue trying other fallback secrets
+						continue;
+					}
+				}
+			}
+		}
+
+		if ( $exception !== null && $data === null ) {
+			do_action(
+				'jetpack_forms_log',
+				'jwt_decode_failed',
+				array(
+					'error'         => $exception->getMessage(),
+					'secret_source' => $secret_source,
+				)
+			);
+
 			// Re-throw with more context about the failure.
 			if ( $throw_exception ) {
 				throw new \Exception(
 					sprintf(
 						/* translators: %s is the original exception message */
 						__( 'Failed to decode JWT token: %s', 'jetpack-forms' ),
-						$e->getMessage()
+						$exception->getMessage()
 					),
 					0,
-					$e
+					$exception
 				);
 			}
 
@@ -387,7 +438,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 	/**
 	 * Helper function to get the secret from the Tokens class.
 	 *
-	 * @return string The secret from the Tokens class, or a default secret if not available.
+	 * @return array Array with 'secret' and 'source' keys. The source is one of: 'filter', 'tokens', 'option', or 'generated'.
 	 */
 	private static function get_secret() {
 
@@ -400,13 +451,19 @@ class Contact_Form extends Contact_Form_Shortcode {
 		 */
 		$secret = apply_filters( 'jetpack_forms_secret_jwt', '' );
 		if ( is_string( $secret ) && ! empty( $secret ) ) {
-			return $secret;
+			return array(
+				'secret' => $secret,
+				'source' => 'filter',
+			);
 		}
 
 		$token = ( new Tokens() )->get_access_token();
 
 		if ( ! empty( $token->secret ) ) {
-			return $token->secret;
+			return array(
+				'secret' => $token->secret,
+				'source' => 'tokens',
+			);
 		}
 
 		$secret = get_option( 'jetpack_forms_secret_key', false );
@@ -414,9 +471,73 @@ class Contact_Form extends Contact_Form_Shortcode {
 			// Generate a fallback secret if we don't have one from Tokens.
 			$secret = wp_generate_password( 64, true, true );
 			update_option( 'jetpack_forms_secret_key', $secret );
+
+			return array(
+				'secret' => $secret,
+				'source' => 'generated',
+			);
 		}
 
-		return $secret;
+		return array(
+			'secret' => $secret,
+			'source' => 'option',
+		);
+	}
+
+	/**
+	 * Get fallback secrets to try when the primary secret fails.
+	 * This helps with backward compatibility when secrets change and the page is cached.
+	 *
+	 * @param string $current_source The current secret source.
+	 * @return array Array of fallback secrets with their sources. Each element is an array with 'secret' and 'source' keys.
+	 */
+	private static function get_fallback_secrets( $current_source ) {
+		$fallbacks = array();
+
+		// If current source is filter, try tokens and option
+		if ( $current_source === 'filter' ) {
+			$token = ( new Tokens() )->get_access_token();
+
+			if ( ! empty( $token->secret ) ) {
+				$fallbacks[] = array(
+					'secret' => $token->secret,
+					'source' => 'tokens',
+				);
+			}
+
+			$option_secret = get_option( 'jetpack_forms_secret_key', false );
+
+			if ( ! empty( $option_secret ) ) {
+				$fallbacks[] = array(
+					'secret' => $option_secret,
+					'source' => 'option',
+				);
+			}
+		}
+
+		// If current source is tokens, try option
+		if ( $current_source === 'tokens' ) {
+			$option_secret = get_option( 'jetpack_forms_secret_key', false );
+
+			if ( ! empty( $option_secret ) ) {
+				$fallbacks[] = array(
+					'secret' => $option_secret,
+					'source' => 'option',
+				);
+			}
+		}
+
+		// Always try the filter as a fallback (in case it was added after tokens were created)
+		$filter_secret = apply_filters( 'jetpack_forms_secret_jwt', '' );
+
+		if ( is_string( $filter_secret ) && ! empty( $filter_secret ) ) {
+			$fallbacks[] = array(
+				'secret' => $filter_secret,
+				'source' => 'filter',
+			);
+		}
+
+		return $fallbacks;
 	}
 
 	/**
@@ -436,6 +557,8 @@ class Contact_Form extends Contact_Form_Shortcode {
 	public function get_jwt() {
 		$attributes   = $this->attributes;
 		$this->source = Feedback_Source::get_current( $attributes );
+		$secret_info  = self::get_secret();
+
 		return JWT::encode(
 			array(
 				'attributes' => $attributes,
@@ -443,7 +566,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 				'hash'       => $this->hash,
 				'source'     => $this->source->serialize(),
 			),
-			self::get_secret()
+			$secret_info['secret']
 		);
 	}
 

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
@@ -2889,6 +2889,51 @@ EOT;
 		Constants::clear_single_constant( 'JETPACK_BLOG_TOKEN' );
 	}
 
+	public function test_get_instance_from_jwt_uses_fallback_secrets() {
+		// Clear any existing constants and options
+		Constants::clear_single_constant( 'JETPACK_BLOG_TOKEN' );
+		delete_option( 'jetpack_forms_secret_key' );
+		remove_all_filters( 'jetpack_forms_secret_jwt' );
+
+		// Set up option secret (this is what was used before the filter was added)
+		$option_secret = 'option-secret-' . wp_generate_password( 32, false );
+		update_option( 'jetpack_forms_secret_key', $option_secret );
+
+		// Create a form and encode it with the option secret
+		// This simulates forms that were published before the filter was added
+		$form = new Contact_Form(
+			array(
+				'to'      => 'test@email.com',
+				'subject' => 'Test Form',
+			),
+			"[contact-field label='Name' type='name' required='1'/]"
+		);
+
+		$jwt = $form->get_jwt();
+		$this->assertNotEmpty( $jwt, 'JWT should not be empty' );
+
+		// Now add the filter (simulating the filter being added after forms were published)
+		// The filter becomes the primary secret source
+		$filter_secret = 'filter-secret-' . wp_generate_password( 32, false );
+		add_filter(
+			'jetpack_forms_secret_jwt',
+			function () use ( $filter_secret ) {
+				return $filter_secret;
+			}
+		);
+
+		// Verify it succeeds with option fallback when the filter secret (primary) does not match
+		$form_copy = Contact_Form::get_instance_from_jwt( $jwt );
+		$this->assertNotNull( $form_copy, 'Should recover form using fallback secret (option) when primary secret (filter) does not match' );
+		$this->assertTrue( $form_copy->has_verified_jwt, 'Form should have verified JWT with fallback secret' );
+		$this->assertEquals( $form->get_attribute( 'to' ), $form_copy->get_attribute( 'to' ), 'Form attributes should match' );
+		$this->assertEquals( $form->get_attribute( 'subject' ), $form_copy->get_attribute( 'subject' ), 'Form attributes should match' );
+
+		// Clean up
+		remove_all_filters( 'jetpack_forms_secret_jwt' );
+		delete_option( 'jetpack_forms_secret_key' );
+	}
+
 	/**
 	 * Test compute_id method with basic attributes
 	 */


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Part of FORMS-341

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Adds fallback options for JWT decryption, logging when a fallback is used
### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

BEFORE applying this PR:
* Sandbox a simple site and remove the secret filter, so that forms will be published with an option instead
* Publish a form
* Go to the published post and leave the tab open without refreshing
* Re-add the secret filter,
* Submit a response. It should fail. Do NOT refresh the page.

---

* Apply this PR to your sandbox
* Submit the response again. Check that it works
* Check logstash, the fallback decoding should be logged
* Check that there is no regression with other forms