### PR TITLE
docker: Use a reserved TLD for the email address

### DIFF
--- a/tools/docker/mu-plugins/allow_emails_from_localhost.php
+++ b/tools/docker/mu-plugins/allow_emails_from_localhost.php
@@ -24,7 +24,7 @@ namespace Jetpack\Docker\MuPlugin\AllowEmailsFromLocalhost;
  */
 function jetpack_allow_emails_from_localhost( $from_email ) {
 	if ( $from_email === 'wordpress@localhost' ) {
-		return 'wordpress@jetpack.docker';
+		return 'wordpress@jetpack.docker.localhost';
 
 	}
 	return $from_email;


### PR DESCRIPTION
Closes MONOREP-225

 <!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
PHPMailer does not like an email address with a dotless domain, such as `wordpress@localhost`. #44983 added a plugin to rewrite this address, but chose a domain that could theoretically exist on the Internet. It would be safer to use one of the RFC 6761 reserved TLDs.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
https://github.com/Automattic/jetpack/pull/44983#discussion_r2503996973

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Using the Jetpack dev env, visit `http://localhost/wp-admin/` and send yourself a password reset email. Check the MailPit instance to see that the email was sent.
