### PR TITLE
Forms Update to use words in the single response actions.

### DIFF
--- a/projects/packages/forms/changelog/update-forms-update-to-words-menu
+++ b/projects/packages/forms/changelog/update-forms-update-to-words-menu
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Forms: update the icons to now be label

--- a/projects/packages/forms/changelog/update-forms-update-to-words-menu
+++ b/projects/packages/forms/changelog/update-forms-update-to-words-menu
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Forms: update the icons to now be label
+Forms: update the icons to now be labels

--- a/projects/packages/forms/src/dashboard/components/response-actions/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/response-actions/index.tsx
@@ -91,7 +91,6 @@ const ResponseActions = ( {
 	}, [ response, registry, onActionComplete ] );
 
 	const sharedProps = {
-		variant: 'tertiary',
 		showTooltip: true,
 		size: 'compact',
 	};

--- a/projects/packages/forms/src/dashboard/components/response-actions/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/response-actions/index.tsx
@@ -4,6 +4,7 @@
 import { Button } from '@wordpress/components';
 import { useRegistry } from '@wordpress/data';
 import { useCallback, useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
@@ -90,7 +91,7 @@ const ResponseActions = ( {
 	}, [ response, registry, onActionComplete ] );
 
 	const sharedProps = {
-		iconSize: 24,
+		variant: 'tertiary',
 		showTooltip: true,
 		size: 'compact',
 	};
@@ -102,18 +103,22 @@ const ResponseActions = ( {
 					{ ...sharedProps }
 					onClick={ handleMarkAsRead }
 					isBusy={ isTogglingReadStatus }
-					label={ markAsReadAction.label }
-					icon={ markAsReadAction.icon }
-				></Button>
+					label={ __( 'Mark as read', 'jetpack-forms' ) }
+					aria-label={ __( 'Mark as read', 'jetpack-forms' ) }
+				>
+					{ markAsReadAction.label }
+				</Button>
 			) }
 			{ ! response.is_unread && (
 				<Button
 					{ ...sharedProps }
 					onClick={ handleMarkAsUnread }
 					isBusy={ isTogglingReadStatus }
-					label={ markAsUnreadAction.label }
-					icon={ markAsUnreadAction.icon }
-				></Button>
+					label={ __( 'Mark as unread', 'jetpack-forms' ) }
+					aria-label={ __( 'Mark as unread', 'jetpack-forms' ) }
+				>
+					{ markAsUnreadAction.label }
+				</Button>
 			) }
 		</>
 	);
@@ -121,64 +126,76 @@ const ResponseActions = ( {
 	switch ( response.status ) {
 		case 'spam':
 			return (
-				<div>
+				<div className="jp-forms__response-actions">
 					{ readUnreadButtons }
 					<Button
 						{ ...sharedProps }
 						onClick={ handleMarkAsNotSpam }
 						isBusy={ isMarkingAsNotSpam }
-						label={ markAsNotSpamAction.label }
-						icon={ markAsNotSpamAction.icon }
-					></Button>
+						label={ __( 'Mark as not spam', 'jetpack-forms' ) }
+						aria-label={ __( 'Mark as not spam', 'jetpack-forms' ) }
+					>
+						{ markAsNotSpamAction.label }
+					</Button>
 					<Button
 						{ ...sharedProps }
 						onClick={ handleMoveToTrash }
 						isBusy={ isMovingToTrash }
-						label={ moveToTrashAction.label }
-						icon={ moveToTrashAction.icon }
-					></Button>
+						label={ __( 'Move to trash', 'jetpack-forms' ) }
+						aria-label={ __( 'Move to trash', 'jetpack-forms' ) }
+					>
+						{ moveToTrashAction.label }
+					</Button>
 				</div>
 			);
 
 		case 'trash':
 			return (
-				<div>
+				<div className="jp-forms__response-actions">
 					{ readUnreadButtons }
 					<Button
 						{ ...sharedProps }
 						onClick={ handleRestore }
 						isBusy={ isRestoring }
-						label={ restoreAction.label }
-						icon={ restoreAction.icon }
-					></Button>
+						label={ __( 'Restore from trash', 'jetpack-forms' ) }
+						aria-label={ __( 'Restore from trash', 'jetpack-forms' ) }
+					>
+						{ restoreAction.label }
+					</Button>
 					<Button
 						{ ...sharedProps }
 						onClick={ handleDelete }
 						isBusy={ isDeleting }
-						label={ deleteAction.label }
-						icon={ deleteAction.icon }
-					></Button>
+						label={ __( 'Delete permanently', 'jetpack-forms' ) }
+						aria-label={ __( 'Delete permanently', 'jetpack-forms' ) }
+					>
+						{ deleteAction.label }
+					</Button>
 				</div>
 			);
 
 		default: // 'publish' (inbox) or any other status
 			return (
-				<div>
+				<div className="jp-forms__response-actions">
 					{ readUnreadButtons }
 					<Button
 						{ ...sharedProps }
 						onClick={ handleMarkAsSpam }
 						isBusy={ isMarkingAsSpam }
-						label={ markAsSpamAction.label }
-						icon={ markAsSpamAction.icon }
-					></Button>
+						label={ __( 'Mark as spam', 'jetpack-forms' ) }
+						aria-label={ __( 'Mark as spam', 'jetpack-forms' ) }
+					>
+						{ markAsSpamAction.label }
+					</Button>
 					<Button
 						{ ...sharedProps }
 						onClick={ handleMoveToTrash }
 						isBusy={ isMovingToTrash }
-						label={ moveToTrashAction.label }
-						icon={ moveToTrashAction.icon }
-					></Button>
+						label={ __( 'Move to trash', 'jetpack-forms' ) }
+						aria-label={ __( 'Move to trash', 'jetpack-forms' ) }
+					>
+						{ moveToTrashAction.label }
+					</Button>
 				</div>
 			);
 	}

--- a/projects/packages/forms/src/dashboard/components/response-navigation/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/response-navigation/index.tsx
@@ -34,7 +34,8 @@ const ResponseNavigation = ( {
 					{ ...sharedProps }
 					disabled={ ! hasPrevious }
 					icon={ chevronUp }
-					label={ __( 'Previous', 'jetpack-forms' ) }
+					label={ __( 'Previous response', 'jetpack-forms' ) }
+					aria-label={ __( 'Previous response', 'jetpack-forms' ) }
 					onClick={ onPrevious }
 				></Button>
 			) }
@@ -43,7 +44,8 @@ const ResponseNavigation = ( {
 					{ ...sharedProps }
 					disabled={ ! hasNext }
 					icon={ chevronDown }
-					label={ __( 'Next', 'jetpack-forms' ) }
+					label={ __( 'Next response', 'jetpack-forms' ) }
+					aria-label={ __( 'Next response', 'jetpack-forms' ) }
 					onClick={ onNext }
 				></Button>
 			) }
@@ -51,7 +53,8 @@ const ResponseNavigation = ( {
 				<Button
 					{ ...sharedProps }
 					icon={ close }
-					label={ __( 'Close', 'jetpack-forms' ) }
+					label={ __( 'Close response', 'jetpack-forms' ) }
+					aria-label={ __( 'Close response', 'jetpack-forms' ) }
 					onClick={ onClose }
 				></Button>
 			) }

--- a/projects/packages/forms/src/dashboard/components/response-view/single.tsx
+++ b/projects/packages/forms/src/dashboard/components/response-view/single.tsx
@@ -141,7 +141,7 @@ const SingleResponseView = ( {
 					<HStack alignment="left">
 						<ResponseActions onActionComplete={ handleActionComplete } response={ sidePanelItem } />
 					</HStack>
-					<HStack alignment="right" style={ { width: '96px', minWidth: '96px' } }>
+					<HStack alignment="right" className="jp-forms__response-navigation-container">
 						<ResponseNavigation { ...navigationProps } onClose={ onRequestClose } />
 					</HStack>
 				</HStack>

--- a/projects/packages/forms/src/dashboard/components/response-view/single.tsx
+++ b/projects/packages/forms/src/dashboard/components/response-view/single.tsx
@@ -141,7 +141,7 @@ const SingleResponseView = ( {
 					<HStack alignment="left">
 						<ResponseActions onActionComplete={ handleActionComplete } response={ sidePanelItem } />
 					</HStack>
-					<HStack alignment="right">
+					<HStack alignment="right" style={ { width: '96px', minWidth: '96px' } }>
 						<ResponseNavigation { ...navigationProps } onClose={ onRequestClose } />
 					</HStack>
 				</HStack>

--- a/projects/packages/forms/src/dashboard/components/response-view/style.scss
+++ b/projects/packages/forms/src/dashboard/components/response-view/style.scss
@@ -130,6 +130,11 @@
 	}
 }
 
+.jp-forms__response-actions .components-button {
+	padding-left: 8px;
+	padding-right: 8px;
+}
+
 .jp-forms__inbox__tip-container {
 	border-top: 1px solid var(--jp-forms-border-color);
 	margin: 8px 0 0 0;

--- a/projects/packages/forms/src/dashboard/components/response-view/style.scss
+++ b/projects/packages/forms/src/dashboard/components/response-view/style.scss
@@ -101,6 +101,11 @@
 .jp-forms__inbox-response-data-value {
 	white-space: pre-wrap;
 }
+// for increased specificity.
+.jp-forms__response-navigation-container.jp-forms__response-navigation-container {
+	width: auto;
+	min-width: fit-content;
+}
 
 .response-country-flag {
 	font-size: 16px;

--- a/projects/packages/forms/src/dashboard/inbox/dataviews/actions.tsx
+++ b/projects/packages/forms/src/dashboard/inbox/dataviews/actions.tsx
@@ -685,7 +685,7 @@ export const markAsReadAction: Action = {
 	id: 'mark-as-read',
 	isPrimary: false,
 	icon: <Icon icon={ seen } />,
-	label: __( 'Mark as read', 'jetpack-forms' ),
+	label: __( 'Read', 'jetpack-forms' ),
 	isEligible: item => item.is_unread,
 	supportsBulk: true,
 	async callback( items, { registry } ) {
@@ -800,7 +800,7 @@ export const markAsUnreadAction: Action = {
 	id: 'mark-as-unread',
 	isPrimary: false,
 	icon: <Icon icon={ unseen } />,
-	label: __( 'Mark as unread', 'jetpack-forms' ),
+	label: __( 'Unread', 'jetpack-forms' ),
 	isEligible: item => ! item.is_unread,
 	supportsBulk: true,
 	async callback( items, { registry } ) {


### PR DESCRIPTION
Resolves FORMS-408

This PR updates the icons to now be buttons. 

In order to make this happen. We use a single word an tooltips to make things a bit more clear. 

Before:

<img width="345" height="133" alt="Screenshot 2025-11-14 at 1 05 06 PM" src="https://github.com/user-attachments/assets/6f5e7bdc-115c-48cb-9b6f-827fae83342c" />

After:
<img width="357" height="123" alt="Screenshot 2025-11-14 at 1 04 41 PM" src="https://github.com/user-attachments/assets/2184f021-2209-40ac-bd31-46b240d56b12" />


## Proposed changes:
* Update the design to use a single word instead of the icons. 
* Added a tooltip to show clarify the action even more. 
* Made sure that the other icons only take up as little space as possible so that things to end up in two lines. 
* Decreased the hotizontal spacing even more  that the current buttons take up so that things don't end up in two lines. 

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
no
## Does this pull request change what data or activity we track or use?
no

## Testing instructions:
Go to the Dashboard. 
* Notice that now the icons are gone for the actions. 
* Open up a single view. Notice the new copy. notice the new tooltips and the aria labels. 
* Resize the window notice that we don't end up in a state where the actions are on two lines in english. 



