### PR TITLE
CI: Prevent Jetpack Sync tests from colliding when running in parallel

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-tests-add_sync_locking
+++ b/projects/plugins/jetpack/changelog/fix-tests-add_sync_locking
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: CI: Use shared locking in Jetpack Sync tests to avoid parallel tests from interfering.
+
+

--- a/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Plugins_Test.php
+++ b/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Plugins_Test.php
@@ -10,7 +10,6 @@ class Jetpack_Sync_Plugins_Test extends Jetpack_Sync_TestBase {
 	const PLUGIN_ZIP = __DIR__ . '/../files/the.1.1.zip';
 
 	protected static $hello_dolly_path;
-	protected static $the_plugin_lock;
 
 	/**
 	 * Set up before class.
@@ -179,17 +178,6 @@ class Jetpack_Sync_Plugins_Test extends Jetpack_Sync_TestBase {
 			'api'    => '',
 		);
 
-		// For CI coverage tests, use a lock file to avoid multiple copies of this test from interfering with each other.
-		if ( getenv( 'PHPUNIT_JETPACK_TESTSUITE_IS_PARALLEL' ) === 'true' && ! static::$the_plugin_lock ) {
-			static::$the_plugin_lock = fopen( WP_PLUGIN_DIR . '/.thepluginlock', 'c+' );
-			if ( ! static::$the_plugin_lock ) {
-				throw new RuntimeException( 'Failed to open lockfile ' . WP_PLUGIN_DIR . '/.thepluginlock' );
-			}
-			if ( ! flock( static::$the_plugin_lock, LOCK_EX ) ) {
-				throw new RuntimeException( 'Failed to lock lockfile ' . WP_PLUGIN_DIR . '/.thepluginlock' );
-			}
-		}
-
 		$upgrader = new Plugin_Upgrader(
 			new Automatic_Upgrader_Skin( $plugin_defaults )
 		);
@@ -215,10 +203,6 @@ class Jetpack_Sync_Plugins_Test extends Jetpack_Sync_TestBase {
 			delete_plugins( array( 'the/the.php' ) );
 			remove_filter( 'pre_http_request', array( 'Jetpack_Sync_TestBase', 'pre_http_request_wordpress_org_updates' ) );
 			wp_cache_delete( 'plugins', 'plugins' );
-		}
-		if ( static::$the_plugin_lock ) {
-			fclose( static::$the_plugin_lock );
-			static::$the_plugin_lock = null;
 		}
 	}
 

--- a/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Plugins_Test.php
+++ b/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Plugins_Test.php
@@ -14,8 +14,7 @@ class Jetpack_Sync_Plugins_Test extends Jetpack_Sync_TestBase {
 	/**
 	 * Set up before class.
 	 */
-	public static function set_up_before_class(): void {
-		parent::set_up_before_class();
+	public static function setUpBeforeClass(): void {
 		self::$hello_dolly_path = file_exists( WP_PLUGIN_DIR . '/hello.php' ) ? 'hello.php' : 'hello-dolly/hello.php';
 	}
 

--- a/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Plugins_Test.php
+++ b/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Plugins_Test.php
@@ -14,14 +14,9 @@ class Jetpack_Sync_Plugins_Test extends Jetpack_Sync_TestBase {
 	/**
 	 * Set up before class.
 	 */
-	public static function setUpBeforeClass(): void {
+	public static function set_up_before_class(): void {
+		parent::set_up_before_class();
 		self::$hello_dolly_path = file_exists( WP_PLUGIN_DIR . '/hello.php' ) ? 'hello.php' : 'hello-dolly/hello.php';
-	}
-
-	public static function tearDownAfterClass(): void {
-		if ( static::$the_plugin_lock ) {
-			self::remove_plugin();
-		}
 	}
 
 	public function test_installing_and_removing_plugin_is_synced() {

--- a/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Plugins_Updates_Test.php
+++ b/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Plugins_Updates_Test.php
@@ -42,8 +42,8 @@ class Jetpack_Sync_Plugins_Updates_Test extends Jetpack_Sync_TestBase {
 	 * Tear down after class.
 	 */
 	public static function tear_down_after_class() {
-		parent::tear_down_after_class();
 		Jetpack_Sync_Plugins_Test::remove_plugin();
+		parent::tear_down_after_class();
 	}
 
 	public function test_updating_a_plugin_is_synced() {

--- a/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Search_Test.php
+++ b/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Search_Test.php
@@ -53,10 +53,9 @@ class Jetpack_Sync_Search_Test extends Jetpack_Sync_TestBase {
 	 * @return void
 	 */
 	public static function tear_down_after_class() {
-		parent::tear_down_after_class();
-
 		\Jetpack::deactivate_module( 'search' );
 		remove_filter( 'jetpack_sync_post_meta_whitelist', array( 'Automattic\\Jetpack\\Sync\\Modules\\Search', 'add_search_post_meta_whitelist' ), 10 );
+		parent::tear_down_after_class();
 	}
 
 	/**

--- a/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_TestBase.php
+++ b/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_TestBase.php
@@ -9,6 +9,8 @@ use Automattic\Jetpack\Sync\Modules\Posts;
 use Automattic\Jetpack\Sync\Replicastore;
 use Automattic\Jetpack\Sync\Sender;
 use Automattic\Jetpack\Sync\Server;
+use PHPUnit\Framework\Attributes\AfterClass;
+use PHPUnit\Framework\Attributes\BeforeClass;
 
 require_once __DIR__ . '/Jetpack_Sync_TestBase.php';
 
@@ -44,13 +46,14 @@ abstract class Jetpack_Sync_TestBase extends WP_UnitTestCase {
 	protected static $lockfile = null;
 
 	/**
-	 * Set up before class.
+	 * Set up lockfile before running anything.
 	 *
 	 * @throws RuntimeException If locking is needed and fails.
+	 *
+	 * @beforeClass 1000000
 	 */
-	public static function set_up_before_class() {
-		parent::set_up_before_class();
-
+	#[BeforeClass( 1000000 )]
+	public static function set_up_lockfile() {
 		// For CI coverage tests, use a lock file to avoid parallel runs of tests from interfering with each other.
 		if ( getenv( 'PHPUNIT_JETPACK_TESTSUITE_IS_PARALLEL' ) === 'true' ) {
 			static::$lockfile = fopen( sys_get_temp_dir() . '/jetpack-sync-test.lock', 'c+' );
@@ -64,11 +67,12 @@ abstract class Jetpack_Sync_TestBase extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tear down after class.
+	 * Tear down lockfile after running everything.
+	 *
+	 * @afterClass -1000000
 	 */
-	public static function tear_down_after_class() {
-		parent::tear_down_after_class();
-
+	#[AfterClass( -1000000 )]
+	public static function tear_down_lockfile() {
 		if ( static::$lockfile ) {
 			fclose( static::$lockfile );
 		}

--- a/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_TestBase.php
+++ b/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_TestBase.php
@@ -57,7 +57,7 @@ abstract class Jetpack_Sync_TestBase extends WP_UnitTestCase {
 			if ( ! static::$lockfile ) {
 				throw new RuntimeException( 'Failed to open lockfile ' . sys_get_temp_dir() . '/jetpack-sync-test.lock' );
 			}
-			if ( ! flock( static::$lockfile, LOCK_SH ) ) {
+			if ( ! flock( static::$lockfile, LOCK_EX ) ) {
 				throw new RuntimeException( 'Failed to lock lockfile ' . sys_get_temp_dir() . '/jetpack-sync-test.lock' );
 			}
 		}

--- a/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_TestBase.php
+++ b/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_TestBase.php
@@ -37,6 +37,44 @@ abstract class Jetpack_Sync_TestBase extends WP_UnitTestCase {
 	protected $server_event_storage;
 
 	/**
+	 * Lock file.
+	 *
+	 * @var resource|null
+	 */
+	protected static $lockfile = null;
+
+	/**
+	 * Set up before class.
+	 *
+	 * @throws RuntimeException If locking is needed and fails.
+	 */
+	public static function set_up_before_class() {
+		parent::set_up_before_class();
+
+		// For CI coverage tests, use a lock file to avoid parallel runs of tests from interfering with each other.
+		if ( getenv( 'PHPUNIT_JETPACK_TESTSUITE_IS_PARALLEL' ) === 'true' ) {
+			static::$lockfile = fopen( sys_get_temp_dir() . '/jetpack-sync-test.lock', 'c+' );
+			if ( ! static::$lockfile ) {
+				throw new RuntimeException( 'Failed to open lockfile ' . sys_get_temp_dir() . '/jetpack-sync-test.lock' );
+			}
+			if ( ! flock( static::$lockfile, LOCK_SH ) ) {
+				throw new RuntimeException( 'Failed to lock lockfile ' . sys_get_temp_dir() . '/jetpack-sync-test.lock' );
+			}
+		}
+	}
+
+	/**
+	 * Tear down after class.
+	 */
+	public static function tear_down_after_class() {
+		parent::tear_down_after_class();
+
+		if ( static::$lockfile ) {
+			fclose( static::$lockfile );
+		}
+	}
+
+	/**
 	 * Set up.
 	 */
 	public function set_up() {

--- a/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Themes_Test.php
+++ b/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Themes_Test.php
@@ -52,30 +52,12 @@ class Jetpack_Sync_Themes_Test extends Jetpack_Sync_TestBase {
 	);
 
 	/**
-	 * Lock file.
-	 *
-	 * @var resource|null
-	 */
-	protected static $lockfile = null;
-
-	/**
 	 * Move Dummy Themes to proper location for testing.
 	 *
 	 * @throws RuntimeException If locking is needed and fails.
 	 */
 	public static function set_up_before_class() {
 		parent::set_up_before_class();
-
-		// For CI coverage tests, use a lock file to avoid multiple copies of this test from interfering with each other.
-		if ( getenv( 'PHPUNIT_JETPACK_TESTSUITE_IS_PARALLEL' ) === 'true' ) {
-			static::$lockfile = fopen( WP_CONTENT_DIR . '/themes/.jplock', 'c+' );
-			if ( ! static::$lockfile ) {
-				throw new RuntimeException( 'Failed to open lockfile ' . WP_CONTENT_DIR . '/themes/.jplock' );
-			}
-			if ( ! flock( static::$lockfile, LOCK_EX ) ) {
-				throw new RuntimeException( 'Failed to lock lockfile ' . WP_CONTENT_DIR . '/themes/.jplock' );
-			}
-		}
 
 		// Copy themes from tests/php/files/ to wp-content/themes.
 		foreach ( static::$themes as $theme ) {
@@ -105,10 +87,6 @@ class Jetpack_Sync_Themes_Test extends Jetpack_Sync_TestBase {
 			}
 
 			rmdir( $dest_dir );
-		}
-
-		if ( static::$lockfile ) {
-			fclose( static::$lockfile );
 		}
 	}
 

--- a/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Themes_Test.php
+++ b/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Themes_Test.php
@@ -76,8 +76,6 @@ class Jetpack_Sync_Themes_Test extends Jetpack_Sync_TestBase {
 	 * Remove Dummy Themes.
 	 */
 	public static function tear_down_after_class() {
-		parent::tear_down_after_class();
-
 		// Remove themes previously copied from tests/php/files/ to wp-content/themes.
 		foreach ( static::$themes as $theme ) {
 			$dest_dir = WP_CONTENT_DIR . '/themes/' . $theme;
@@ -88,6 +86,7 @@ class Jetpack_Sync_Themes_Test extends Jetpack_Sync_TestBase {
 
 			rmdir( $dest_dir );
 		}
+		parent::tear_down_after_class();
 	}
 
 	/**


### PR DESCRIPTION
Closes MONOREP-226

 <!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Like done in #45851 and #45902 (which will probably be reverted), this adds the locking code to prevent parallel tests from colliding, but this time at a base class level.

See comment here: https://github.com/Automattic/jetpack/pull/45923#discussion_r2527049207

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

I haven't yet tested this, but presumably running multiple Sync-related tests at the same time should generate the lock file and things should take turns.