### PR TITLE
Forms: adds a new jwt validation error filter

### DIFF
--- a/projects/packages/forms/changelog/add-jwt-validation-filter
+++ b/projects/packages/forms/changelog/add-jwt-validation-filter
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Forms: add a new filter for the JWT token error.

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -271,11 +271,11 @@ class Contact_Form extends Contact_Form_Shortcode {
 				/**
 				 * Filter the failure to decode a JWT token for a contact form.
 				 *
-				 * @param null|string $value The value to return. Default null.
+				 * @param null $value The value to return. Default null.
 				 * @param string      $jwt_token The JWT token that failed to decode.
 				 * @param \Exception  $e The exception that was thrown during decoding.
 				 *
-				 * @return null|string The value to return.
+				 * @return Contact_Form|null The value to return.
 				 */
 				$filtered = apply_filters( 'jetpack_forms_jwt_decode_failure', null, $jwt_token, $e );
 				if ( $filtered !== null ) {

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -323,6 +323,17 @@ class Contact_Form extends Contact_Form_Shortcode {
 	}
 
 	/**
+	 * Set the source object for the contact form.
+	 *
+	 * @param Feedback_Source $source The source object.
+	 *
+	 * @return void
+	 */
+	public function set_source( $source ) {
+		$this->source = $source;
+	}
+
+	/**
 	 * Get the context for the contact form based on the attributes and post.
 	 *
 	 * @param array        $attributes The attributes of the contact form.

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -268,6 +268,19 @@ class Contact_Form extends Contact_Form_Shortcode {
 		} catch ( \Exception $e ) {
 			// Re-throw with more context about the failure.
 			if ( $throw_exception ) {
+				/**
+				 * Filter the failure to decode a JWT token for a contact form.
+				 *
+				 * @param null|string $value The value to return. Default null.
+				 * @param string      $jwt_token The JWT token that failed to decode.
+				 * @param \Exception  $e The exception that was thrown during decoding.
+				 *
+				 * @return null|string The value to return.
+				 */
+				$filtered = apply_filters( 'jetpack_forms_jwt_decode_failure', null, $jwt_token, $e );
+				if ( $filtered !== null ) {
+					return $filtered;
+				}
 				throw new \Exception(
 					sprintf(
 						/* translators: %s is the original exception message */
@@ -279,7 +292,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 				);
 			}
 
-			return null;
+			return apply_filters( 'jetpack_forms_jwt_decode_failure', null, $jwt_token, $e );
 		}
 
 		$source = $data['source'] ?? array();

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
@@ -2889,6 +2889,99 @@ EOT;
 		Constants::clear_single_constant( 'JETPACK_BLOG_TOKEN' );
 	}
 
+	public function test_jetpack_forms_jwt_decode_failure_filter_with_throw_exception() {
+		Constants::set_constant( 'JETPACK_BLOG_TOKEN', 'test.token' );
+
+		// Create a mock form instance to return from the filter
+		$mock_form = new Contact_Form(
+			array(
+				'to' => 'test@example.com',
+			),
+			"[contact-field label='Name' type='name' required='1'/]"
+		);
+
+		// Add filter to return the mock form instead of throwing exception
+		$filter_called = false;
+		add_filter(
+			'jetpack_forms_jwt_decode_failure',
+			function ( $value, $jwt_token, $exception ) use ( $mock_form, &$filter_called ) {
+				$filter_called = true;
+				$this->assertNull( $value, 'Filter should receive null as first parameter' );
+				$this->assertEquals( 'invalid_jwt_token', $jwt_token, 'Filter should receive the JWT token' );
+				$this->assertInstanceOf( \Exception::class, $exception, 'Filter should receive an Exception instance' );
+				return $mock_form;
+			},
+			10,
+			3
+		);
+
+		// Call with throw_exception = true, but filter should prevent exception
+		$result = Contact_Form::get_instance_from_jwt( 'invalid_jwt_token', true );
+
+		$this->assertTrue( $filter_called, 'Filter should have been called' );
+		$this->assertSame( $mock_form, $result, 'Filter should return the mock form instead of throwing exception' );
+
+		remove_all_filters( 'jetpack_forms_jwt_decode_failure' );
+		Constants::clear_single_constant( 'JETPACK_BLOG_TOKEN' );
+	}
+
+	public function test_jetpack_forms_jwt_decode_failure_filter_without_throw_exception() {
+		Constants::set_constant( 'JETPACK_BLOG_TOKEN', 'test.token' );
+
+		// Add filter to return a custom value
+		$custom_return_value = 'custom_fallback';
+		$filter_called       = false;
+		add_filter(
+			'jetpack_forms_jwt_decode_failure',
+			function ( $value, $jwt_token, $exception ) use ( $custom_return_value, &$filter_called ) {
+				$filter_called = true;
+				$this->assertNull( $value, 'Filter should receive null as first parameter' );
+				$this->assertEquals( 'invalid_jwt_token', $jwt_token, 'Filter should receive the JWT token' );
+				$this->assertInstanceOf( \Exception::class, $exception, 'Filter should receive an Exception instance' );
+				return $custom_return_value;
+			},
+			10,
+			3
+		);
+
+		// Call with throw_exception = false
+		$result = Contact_Form::get_instance_from_jwt( 'invalid_jwt_token', false );
+
+		$this->assertTrue( $filter_called, 'Filter should have been called' );
+		$this->assertEquals( $custom_return_value, $result, 'Filter should return the custom value' );
+
+		remove_all_filters( 'jetpack_forms_jwt_decode_failure' );
+		Constants::clear_single_constant( 'JETPACK_BLOG_TOKEN' );
+	}
+
+	public function test_jetpack_forms_jwt_decode_failure_filter_returns_null_still_throws() {
+		Constants::set_constant( 'JETPACK_BLOG_TOKEN', 'test.token' );
+
+		// Add filter that returns null (should allow exception to be thrown)
+		$filter_called = false;
+		add_filter(
+			'jetpack_forms_jwt_decode_failure',
+			function ( $value, $jwt_token, $exception ) use ( &$filter_called ) {
+				$filter_called = true;
+				$this->assertNull( $value, 'Filter should receive null as first parameter' );
+				$this->assertEquals( 'invalid_jwt_token', $jwt_token, 'Filter should receive the JWT token' );
+				$this->assertInstanceOf( \Exception::class, $exception, 'Filter should receive an Exception instance' );
+				return null; // Returning null means "don't override default behavior"
+			},
+			10,
+			3
+		);
+
+		$this->expectException( \Exception::class );
+		$this->expectExceptionMessage( 'Failed to decode JWT token' );
+
+		Contact_Form::get_instance_from_jwt( 'invalid_jwt_token', true );
+
+		// Note: Code after exception won't be reached, but filter will have been called
+		remove_all_filters( 'jetpack_forms_jwt_decode_failure' );
+		Constants::clear_single_constant( 'JETPACK_BLOG_TOKEN' );
+	}
+
 	/**
 	 * Test compute_id method with basic attributes
 	 */


### PR DESCRIPTION
Part of FORMS-341

This Pr add a new filter so that we can inspect this error even more. 

## Proposed changes:
* Adds a new `jetpack_forms_jwt_decode_failure` filter so that we can inspect this error even more. 

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
See p1763155053759989-slack-C052XEUUBL4 

## Does this pull request change what data or activity we track or use?


## Testing instructions:
* Do the tests pass? 
* Add code that starts listening to this new filter. 
* submit the form. 
* The form submission should work as before. 
* Break the jwt token. 
* Notice that the code is called works. 