### PR TITLE
Forms: Update unread indicator

### DIFF
--- a/projects/packages/forms/changelog/update-forms-move-unread-indicator
+++ b/projects/packages/forms/changelog/update-forms-move-unread-indicator
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Forms: make the unread indicater more like designed

--- a/projects/packages/forms/changelog/update-forms-move-unread-indicator
+++ b/projects/packages/forms/changelog/update-forms-move-unread-indicator
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Forms: make the unread indicater more like designed
+Forms: make the unread indicator more like designed

--- a/projects/packages/forms/src/dashboard/inbox/dataviews/index.js
+++ b/projects/packages/forms/src/dashboard/inbox/dataviews/index.js
@@ -379,7 +379,7 @@ export default function InboxView() {
 								{ ! item.country_code && <Icon icon={ globe } size={ 20 } /> }
 								{ item.country_code && <Flag countryCode={ item.country_code } /> }
 							</span>
-							{ item.ip || '' }
+							{ wrapperUnread( item.is_unread, item.ip || '' ) }
 						</>
 					);
 				},

--- a/projects/packages/forms/src/dashboard/inbox/style.scss
+++ b/projects/packages/forms/src/dashboard/inbox/style.scss
@@ -130,9 +130,16 @@
 
 	.jp-forms__inbox__unread-indicator {
 		color: #d63638;
+		background-color: #d63638;
+		overflow: hidden;
 		font-size: 8px;
+		width: 8px;
+		height: 8px;
+		border-radius: 50%;
+		border: 1px solid #fff;
 		position: absolute;
-		left: -12px;
+		left: 24px;
+		top: 2px;
 		cursor: pointer;
 	}
 }


### PR DESCRIPTION
This PR updates the unread indicator to be more like it was designed. 

Before:
<img width="1058" height="135" alt="Screenshot 2025-11-14 at 5 08 26 PM" src="https://github.com/user-attachments/assets/9e10692e-05dd-424f-a3aa-3332a027cd86" />

After: 
<img width="902" height="140" alt="Screenshot 2025-11-14 at 4 56 50 PM" src="https://github.com/user-attachments/assets/f3216455-15f2-4775-b45c-433092b0092b" />

## Proposed changes:

* Update the design of the Unread indicator to be more like designed/

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
See p1HpG7-xmp-p2

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:
Visit the dashboard. Mark something as unread. 
Notice the new design.