### PR TITLE
Likes: fix disabled bug

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-like-disabled-with-block
+++ b/projects/plugins/jetpack/changelog/fix-like-disabled-with-block
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Likes: enabled sitewide setting when block is rendered

--- a/projects/plugins/jetpack/extensions/blocks/like/like.php
+++ b/projects/plugins/jetpack/extensions/blocks/like/like.php
@@ -130,6 +130,10 @@ function render_block( $attr, $content, $block ) {
 		. "<div class='likes-widget-placeholder post-likes-widget-placeholder' style='height: 55px;'><span class='loading'>" . esc_html__( 'Loading…', 'jetpack' ) . '</span></div>'
 		. "<span class='sd-text-color'></span><a class='sd-link-color'></a>"
 		. '</div>';
+
+	// Force likes to be enabled for the block.
+	add_filter( 'wpl_is_enabled_sitewide', '__return_true' );
+
 	return sprintf(
 		'<div class="%1$s">%2$s</div>',
 		esc_attr( Blocks::classes( Blocks::get_block_feature( __DIR__ ), $attr ) ),


### PR DESCRIPTION
Closes https://linear.app/a8c/issue/CML-1013/likes-notification-and-email-delivery-issue-for-renwulfcreationscom-no

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Enable likes option sitewide when the Likes button is rendered

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

Currently the Likes block enables the ability to like a post, but without the `wpl_is_enabled_sitewide` setting enabled we do not have notifications being handled. Forcing this to be true should solve the issue.

I chose to use the sitewide setting rather than the post since this block could and likely exists in a template or reusable block.

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Disable Likes on your tests site wide sharing options.
2. Create a new post and make sure the Like option is also disabled in the post settings.
3. Publish the post and make sure there is no like button or ability to like the post.
4. Add a Like button to the post, save, and try again.
5. You should be able to like the post AND the owner should get a notificatio.