### PR TITLE
Charts: Allow consumers to override chart container styles

### DIFF
--- a/projects/js-packages/charts/changelog/charts-132-allow-consumers-to-override-chart-styles
+++ b/projects/js-packages/charts/changelog/charts-132-allow-consumers-to-override-chart-styles
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Remove inline styles from containers to allow consumer overrides

--- a/projects/js-packages/charts/src/components/bar-chart/bar-chart.module.scss
+++ b/projects/js-packages/charts/src/components/bar-chart/bar-chart.module.scss
@@ -2,6 +2,10 @@
 	display: flex;
 	flex-direction: column;
 
+	&--legend-top {
+		flex-direction: column-reverse;
+	}
+
 	svg {
 		overflow: visible;
 	}

--- a/projects/js-packages/charts/src/components/bar-chart/bar-chart.tsx
+++ b/projects/js-packages/charts/src/components/bar-chart/bar-chart.tsx
@@ -315,17 +315,21 @@ const BarChartInternal: FC< BarChartProps > = ( {
 			} }
 		>
 			<div
-				className={ clsx( 'bar-chart', styles[ 'bar-chart' ], className, {
-					[ styles[ `bar-chart__animated${ horizontal ? '-horizontal' : '' }` ] ]: animation,
-				} ) }
+				className={ clsx(
+					'bar-chart',
+					styles[ 'bar-chart' ],
+					{
+						[ styles[ `bar-chart__animated${ horizontal ? '-horizontal' : '' }` ] ]: animation,
+						[ styles[ 'bar-chart--legend-top' ] ]: showLegend && legendPosition === 'top',
+					},
+					className
+				) }
 				data-testid="bar-chart"
 				role="grid"
 				aria-label={ __( 'Bar chart', 'jetpack-charts' ) }
 				style={ {
 					width,
 					height,
-					display: 'flex',
-					flexDirection: showLegend && legendPosition === 'top' ? 'column-reverse' : 'column',
 				} }
 				tabIndex={ 0 }
 				onKeyDown={ onChartKeyDown }

--- a/projects/js-packages/charts/src/components/leaderboard-chart/leaderboard-chart.module.scss
+++ b/projects/js-packages/charts/src/components/leaderboard-chart/leaderboard-chart.module.scss
@@ -11,7 +11,7 @@
 		gap: 16px;
 	}
 
-	&.loading {
+	&--loading {
 		opacity: 0.5;
 	}
 }

--- a/projects/js-packages/charts/src/components/leaderboard-chart/leaderboard-chart.module.scss
+++ b/projects/js-packages/charts/src/components/leaderboard-chart/leaderboard-chart.module.scss
@@ -1,5 +1,15 @@
 .leaderboardChart {
+	display: flex;
+	flex-direction: column;
 	transition: opacity 0.3s ease-in-out;
+
+	&--legend-top {
+		flex-direction: column-reverse;
+	}
+
+	&--with-legend {
+		gap: 16px;
+	}
 
 	&.loading {
 		opacity: 0.5;

--- a/projects/js-packages/charts/src/components/leaderboard-chart/leaderboard-chart.tsx
+++ b/projects/js-packages/charts/src/components/leaderboard-chart/leaderboard-chart.tsx
@@ -280,13 +280,14 @@ const LeaderboardChartInternal: FC< LeaderboardChartProps > = ( {
 			} }
 		>
 			<div
-				className={ clsx( styles.leaderboardChart, loading && styles.loading, className ) }
-				style={ {
-					...style,
-					display: 'flex',
-					flexDirection: showLegend && legendPosition === 'top' ? 'column-reverse' : 'column',
-					gap: showLegend ? '16px' : '0',
-				} }
+				className={ clsx(
+					styles.leaderboardChart,
+					loading && styles.loading,
+					showLegend && legendPosition === 'top' && styles[ 'leaderboardChart--legend-top' ],
+					showLegend && styles[ 'leaderboardChart--with-legend' ],
+					className
+				) }
+				style={ style }
 			>
 				{ allSeriesHidden ? (
 					<div className={ styles.emptyState }>

--- a/projects/js-packages/charts/src/components/leaderboard-chart/leaderboard-chart.tsx
+++ b/projects/js-packages/charts/src/components/leaderboard-chart/leaderboard-chart.tsx
@@ -256,7 +256,11 @@ const LeaderboardChartInternal: FC< LeaderboardChartProps > = ( {
 				} }
 			>
 				<div
-					className={ clsx( styles.leaderboardChart, loading && styles.loading, className ) }
+					className={ clsx(
+						styles.leaderboardChart,
+						{ [ styles[ 'leaderboardChart--loading' ] ]: loading },
+						className
+					) }
 					style={ style }
 				>
 					<div className={ styles.emptyState }>
@@ -282,9 +286,11 @@ const LeaderboardChartInternal: FC< LeaderboardChartProps > = ( {
 			<div
 				className={ clsx(
 					styles.leaderboardChart,
-					loading && styles.loading,
-					showLegend && legendPosition === 'top' && styles[ 'leaderboardChart--legend-top' ],
-					showLegend && styles[ 'leaderboardChart--with-legend' ],
+					{
+						[ styles[ 'leaderboardChart--loading' ] ]: loading,
+						[ styles[ 'leaderboardChart--with-legend' ] ]: showLegend,
+						[ styles[ 'leaderboardChart--legend-top' ] ]: showLegend && legendPosition === 'top',
+					},
 					className
 				) }
 				style={ style }

--- a/projects/js-packages/charts/src/components/line-chart/line-chart.module.scss
+++ b/projects/js-packages/charts/src/components/line-chart/line-chart.module.scss
@@ -1,6 +1,11 @@
 .line-chart {
 	display: flex;
 	flex-direction: column;
+	position: relative;
+
+	&--legend-top {
+		flex-direction: column-reverse;
+	}
 
 	svg {
 		overflow: visible;

--- a/projects/js-packages/charts/src/components/line-chart/line-chart.module.scss
+++ b/projects/js-packages/charts/src/components/line-chart/line-chart.module.scss
@@ -3,6 +3,15 @@
 	flex-direction: column;
 	position: relative;
 
+	&--animated {
+
+		path {
+			transform-origin: 0 95%;
+			transform: scaleY(0);
+			animation: rise 1s ease-out forwards;
+		}
+	}
+
 	&--legend-top {
 		flex-direction: column-reverse;
 	}
@@ -108,14 +117,6 @@
 		width: 10px;
 		height: 10px;
 	}
-}
-
-/* in your CSS or styled-component */
-
-.line-chart__animated path {
-	transform-origin: 0 95%;
-	transform: scaleY(0);
-	animation: rise 1s ease-out forwards;
 }
 
 @keyframes rise {

--- a/projects/js-packages/charts/src/components/line-chart/line-chart.tsx
+++ b/projects/js-packages/charts/src/components/line-chart/line-chart.tsx
@@ -441,8 +441,8 @@ const LineChartInternal = forwardRef< SingleChartRef, LineChartProps >(
 					className={ clsx(
 						'line-chart',
 						styles[ 'line-chart' ],
-						animation ? styles[ 'line-chart__animated' ] : null,
-						showLegend && legendPosition === 'top' ? styles[ 'line-chart--legend-top' ] : null,
+						{ [ styles[ 'line-chart--animated' ] ]: animation },
+						{ [ styles[ 'line-chart--legend-top' ] ]: showLegend && legendPosition === 'top' },
 						className
 					) }
 					data-testid="line-chart"

--- a/projects/js-packages/charts/src/components/line-chart/line-chart.tsx
+++ b/projects/js-packages/charts/src/components/line-chart/line-chart.tsx
@@ -442,15 +442,13 @@ const LineChartInternal = forwardRef< SingleChartRef, LineChartProps >(
 						'line-chart',
 						styles[ 'line-chart' ],
 						animation ? styles[ 'line-chart__animated' ] : null,
+						showLegend && legendPosition === 'top' ? styles[ 'line-chart--legend-top' ] : null,
 						className
 					) }
 					data-testid="line-chart"
 					style={ {
 						width,
 						height,
-						display: 'flex',
-						flexDirection: showLegend && legendPosition === 'top' ? 'column-reverse' : 'column',
-						position: 'relative',
 					} }
 				>
 					<div

--- a/projects/js-packages/charts/src/components/pie-chart/pie-chart.module.scss
+++ b/projects/js-packages/charts/src/components/pie-chart/pie-chart.module.scss
@@ -4,4 +4,8 @@
 	overflow: hidden;
 	align-items: center;
 	gap: 20px;
+
+	&--legend-top {
+		flex-direction: column-reverse;
+	}
 }

--- a/projects/js-packages/charts/src/components/pie-chart/pie-chart.tsx
+++ b/projects/js-packages/charts/src/components/pie-chart/pie-chart.tsx
@@ -281,7 +281,7 @@ const PieChartInternal = ( {
 				className={ clsx(
 					'pie-chart',
 					styles[ 'pie-chart' ],
-					showLegend && legendPosition === 'top' ? styles[ 'pie-chart--legend-top' ] : null,
+					{ [ styles[ 'pie-chart--legend-top' ] ]: showLegend && legendPosition === 'top' },
 					className
 				) }
 			>

--- a/projects/js-packages/charts/src/components/pie-chart/pie-chart.tsx
+++ b/projects/js-packages/charts/src/components/pie-chart/pie-chart.tsx
@@ -278,11 +278,12 @@ const PieChartInternal = ( {
 		>
 			<div
 				ref={ containerRef }
-				className={ clsx( 'pie-chart', styles[ 'pie-chart' ], className ) }
-				style={ {
-					display: 'flex',
-					flexDirection: showLegend && legendPosition === 'top' ? 'column-reverse' : 'column',
-				} }
+				className={ clsx(
+					'pie-chart',
+					styles[ 'pie-chart' ],
+					showLegend && legendPosition === 'top' ? styles[ 'pie-chart--legend-top' ] : null,
+					className
+				) }
 			>
 				<svg
 					viewBox={ `0 0 ${ width } ${ adjustedHeight }` }

--- a/projects/js-packages/charts/src/components/pie-semi-circle-chart/pie-semi-circle-chart.module.scss
+++ b/projects/js-packages/charts/src/components/pie-semi-circle-chart/pie-semi-circle-chart.module.scss
@@ -4,6 +4,10 @@
 	text-align: center;
 	gap: 20px;
 
+	&--legend-top {
+		flex-direction: column-reverse;
+	}
+
 	.label {
 		margin-bottom: 0; // Add space between label and pie chart
 		font-weight: 600; // Make label more prominent than note

--- a/projects/js-packages/charts/src/components/pie-semi-circle-chart/pie-semi-circle-chart.tsx
+++ b/projects/js-packages/charts/src/components/pie-semi-circle-chart/pie-semi-circle-chart.tsx
@@ -296,9 +296,10 @@ const PieSemiCircleChartInternal: FC< PieSemiCircleChartProps > = ( {
 				className={ clsx(
 					'pie-semi-circle-chart',
 					styles[ 'pie-semi-circle-chart' ],
-					showLegend && legendPosition === 'top'
-						? styles[ 'pie-semi-circle-chart--legend-top' ]
-						: null,
+					{
+						[ styles[ 'pie-semi-circle-chart--legend-top' ] ]:
+							showLegend && legendPosition === 'top',
+					},
 					className
 				) }
 				data-testid="pie-chart-container"

--- a/projects/js-packages/charts/src/components/pie-semi-circle-chart/pie-semi-circle-chart.tsx
+++ b/projects/js-packages/charts/src/components/pie-semi-circle-chart/pie-semi-circle-chart.tsx
@@ -293,12 +293,15 @@ const PieSemiCircleChartInternal: FC< PieSemiCircleChartProps > = ( {
 		>
 			<div
 				ref={ containerRef }
-				className={ clsx( 'pie-semi-circle-chart', styles[ 'pie-semi-circle-chart' ], className ) }
+				className={ clsx(
+					'pie-semi-circle-chart',
+					styles[ 'pie-semi-circle-chart' ],
+					showLegend && legendPosition === 'top'
+						? styles[ 'pie-semi-circle-chart--legend-top' ]
+						: null,
+					className
+				) }
 				data-testid="pie-chart-container"
-				style={ {
-					display: 'flex',
-					flexDirection: showLegend && legendPosition === 'top' ? 'column-reverse' : 'column',
-				} }
 			>
 				<svg
 					width={ width }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes [CHARTS-132: Allow consumers to override chart styles](https://linear.app/a8c/issue/CHARTS-132/allow-consumers-to-override-chart-styles)

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Inline styles require very specific CSS rules or `!important` to override, eg. https://github.com/woocommerce/woocommerce-analytics/pull/1374#discussion_r2525242836

This PR moves inline styles on the chart containers to CSS makes overrides much easier.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

For each of Bar Chart, Line Chart, Leaderboard Chart, Pie Chart and Pie Semi Circle Chart:
* Regression test the legend stories; in particular the legend position setting. There should be no functional changes.


