### PR TITLE
Import the fonts selected as default on the customizer so we can get the working version of Libre Baskerville

### DIFF
--- a/projects/plugins/jetpack/changelog/DOTTHEM-52-macronized-vowels-not-rendering-correctly-when-libre-baskerville-is
+++ b/projects/plugins/jetpack/changelog/DOTTHEM-52-macronized-vowels-not-rendering-correctly-when-libre-baskerville-is
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Import the fonts selected as default on the customizer.

--- a/projects/plugins/jetpack/modules/google-fonts/current/class-jetpack-google-font-face.php
+++ b/projects/plugins/jetpack/modules/google-fonts/current/class-jetpack-google-font-face.php
@@ -66,6 +66,7 @@ class Jetpack_Google_Font_Face {
 		$fonts_to_print    = array();
 
 		$this->collect_global_styles_fonts();
+		$this->collect_selected_fonts();
 		$fonts_in_use = array_values( array_unique( $this->fonts_in_use, SORT_STRING ) );
 		$fonts_in_use = array_map(
 			function ( $font_slug ) use ( $font_slug_aliases ) {
@@ -83,6 +84,30 @@ class Jetpack_Google_Font_Face {
 
 		if ( ! empty( $fonts_to_print ) ) {
 			wp_print_font_faces( $fonts_to_print );
+		}
+	}
+
+	/**
+	 * Collect fonts selected in the Jetpack Fonts module.
+	 */
+	public function collect_selected_fonts() {
+		if ( ! class_exists( '\Jetpack_Fonts' ) ) {
+			return;
+		}
+
+		$jetpack_fonts_instance = \Jetpack_Fonts::get_instance();
+
+		$selected_fonts = array_unique(
+			array_map(
+				function ( $font ) {
+					return $this->format_font( $font['cssName'] );
+				},
+				(array) $jetpack_fonts_instance->get( 'selected_fonts' )
+			)
+		);
+
+		foreach ( $selected_fonts as $font_slug ) {
+			$this->add_font( $font_slug );
 		}
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

