### PR TITLE
Site Settings endpoint: Add Big Sky options 

### DIFF
--- a/projects/plugins/jetpack/changelog/update-site-settings-endpoint-options
+++ b/projects/plugins/jetpack/changelog/update-site-settings-endpoint-options
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Site Settings endpoint: Add AI Site Builder options (Big Sky)

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
@@ -140,6 +140,8 @@ new WPCOM_JSON_API_Site_Settings_Endpoint(
 			'jetpack_waf_share_debug_data'              => '(bool) Whether the WAF should share debug data with Jetpack',
 			'jetpack_waf_automatic_rules_last_updated_timestamp' => '(int) Timestamp of the last time the automatic rules were updated',
 			'mcp_abilities'                             => '(array) List of MCP Abilities',
+			'big_sky_enable'                            => '(bool) Whether Big Sky is enabled',
+			'big_sky_site_metadata'                     => '(array) Site metadata for Big Sky',
 		),
 
 		'response_format'     => array(
@@ -521,6 +523,8 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 						'is_fully_managed_agency_site'     => (bool) get_option( 'is_fully_managed_agency_site' ),
 						'wpcom_hide_action_bar'            => (bool) get_option( 'wpcom_hide_action_bar' ),
 						'mcp_abilities'                    => $mcp_abilities,
+						'big_sky_enable'                   => (bool) get_option( 'big_sky_enable' ),
+						'big_sky_site_metadata'            => $this->get_big_sky_site_metadata(),
 					);
 
 					require_once JETPACK__PLUGIN_DIR . '/modules/memberships/class-jetpack-memberships.php';
@@ -737,6 +741,47 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 
 		update_option( 'mcp_abilities', $value );
 
+		return true;
+	}
+
+	/**
+	 * Get Big Sky site metadata.
+	 *
+	 * @return array|false
+	 */
+	public function get_big_sky_site_metadata(): array|false {
+		$big_sky_site_metadata = get_option( 'big_sky_site_metadata' );
+		if ( false === $big_sky_site_metadata ) {
+			return false;
+		}
+		// Ensure the option is a string before decoding.
+		if ( ! is_string( $big_sky_site_metadata ) ) {
+			return false;
+		}
+		// The option is stored as a JSON string
+		$big_sky_site_metadata = json_decode( $big_sky_site_metadata, true );
+		if ( ! is_array( $big_sky_site_metadata ) ) {
+			return false;
+		}
+		return $big_sky_site_metadata;
+	}
+
+	/**
+	 * Set Big Sky site metadata.
+	 *
+	 * @param array $value Big Sky site metadata.
+	 *
+	 * @return bool|WP_Error
+	 */
+	public function set_big_sky_site_metadata( $value ) {
+		if ( ! is_array( $value ) ) {
+			return new WP_Error( 'invalid_format', __( 'Big Sky site metadata must be an array', 'jetpack' ) );
+		}
+		$encoded_value = wp_json_encode( $value );
+		if ( false === $encoded_value ) {
+			return new WP_Error( 'json_encode_failed', __( 'Failed to encode Big Sky site metadata to JSON', 'jetpack' ) );
+		}
+		update_option( 'big_sky_site_metadata', $encoded_value );
 		return true;
 	}
 
@@ -1316,6 +1361,19 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 						return $result;
 					}
 					$updated[ $key ] = $this->get_site_mcp_abilities();
+					break;
+
+				case 'big_sky_enable':
+					update_option( 'big_sky_enable', (int) (bool) $value );
+					$updated[ $key ] = (int) (bool) $value;
+					break;
+
+				case 'big_sky_site_metadata':
+					$result = $this->set_big_sky_site_metadata( $value );
+					if ( is_wp_error( $result ) ) {
+						return $result;
+					}
+					$updated[ $key ] = $this->get_big_sky_site_metadata();
 					break;
 
 				default:

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
@@ -746,6 +746,8 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 
 	/**
 	 * Get Big Sky site metadata.
+	 * The data is stored in the database as a JSON string.
+	 * This function decodes the JSON string into an array for easier use in clients.
 	 *
 	 * @return array|false
 	 */

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
@@ -749,7 +749,7 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 	 *
 	 * @return array|false
 	 */
-	public function get_big_sky_site_metadata(): array|false {
+	public function get_big_sky_site_metadata() {
 		$big_sky_site_metadata = get_option( 'big_sky_site_metadata' );
 		if ( false === $big_sky_site_metadata ) {
 			return false;

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-v1-4-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-v1-4-endpoint.php
@@ -154,6 +154,8 @@ new WPCOM_JSON_API_Site_Settings_V1_4_Endpoint(
 			'is_fully_managed_agency_site'              => '(bool) Whether the site is a fully managed agency site',
 			'wpcom_hide_action_bar'                     => '(bool) Whether to hide the Action bar',
 			'mcp_abilities'                             => '(array) List of MCP Abilities',
+			'big_sky_enable'                            => '(bool) Whether Big Sky is enabled',
+			'big_sky_site_metadata'                     => '(array) Site metadata for Big Sky',
 		),
 
 		'response_format' => array(

--- a/projects/plugins/jetpack/tests/php/json-api/WPCOM_JSON_API_Site_Settings_V1_4_Endpoint_Test.php
+++ b/projects/plugins/jetpack/tests/php/json-api/WPCOM_JSON_API_Site_Settings_V1_4_Endpoint_Test.php
@@ -142,7 +142,14 @@ class WPCOM_JSON_API_Site_Settings_V1_4_Endpoint_Test extends WP_UnitTestCase {
 	 */
 	#[DataProvider( 'setting_value_pairs_get_request' )]
 	public function test_get_settings_contains_keys_values( $option_name, $setting_name, $setting_value ) {
-		update_option( $option_name, $setting_value );
+		// big_sky_site_metadata is stored as a JSON string in the database.
+		// The conversion layer (set_big_sky_site_metadata/get_big_sky_site_metadata) is tested
+		// in the POST tests. Here we just need to set up the data in the correct storage format.
+		if ( 'big_sky_site_metadata' === $option_name && is_array( $setting_value ) ) {
+			update_option( $option_name, wp_json_encode( $setting_value ) );
+		} else {
+			update_option( $option_name, $setting_value );
+		}
 
 		$response = $this->make_get_request();
 		$settings = $response['settings'];
@@ -316,6 +323,8 @@ class WPCOM_JSON_API_Site_Settings_V1_4_Endpoint_Test extends WP_UnitTestCase {
 					'page_for_posts'                       => '(string) The page ID of the page to use as the site\'s posts page. It will apply only if \'show_on_front\' is set to \'page\'.',
 					'subscription_options'                 => '(array) Array of two options used in subscription email templates: \'invitation\' and \'comment_follow\' strings.',
 					'mcp_abilities'                        => '(array) List of MCP Abilities',
+					'big_sky_enable'                       => '(bool) Whether Big Sky is enabled',
+					'big_sky_site_metadata'                => '(array) Site metadata for Big Sky',
 				),
 
 				'response_format' => array(
@@ -368,6 +377,8 @@ class WPCOM_JSON_API_Site_Settings_V1_4_Endpoint_Test extends WP_UnitTestCase {
 					),
 				),
 			),
+			'big_sky_enable'                 => array( 'big_sky_enable', false ),
+			'big_sky_site_metadata'          => array( 'big_sky_site_metadata', false ),
 		);
 	}
 
@@ -407,6 +418,8 @@ class WPCOM_JSON_API_Site_Settings_V1_4_Endpoint_Test extends WP_UnitTestCase {
 					),
 				),
 			),
+			'big_sky_enable'                 => array( 'big_sky_enable', 'big_sky_enable', true ),
+			'big_sky_site_metadata'          => array( 'big_sky_site_metadata', 'big_sky_site_metadata', array( 'test' => 'test value' ) ),
 		);
 	}
 
@@ -466,6 +479,8 @@ class WPCOM_JSON_API_Site_Settings_V1_4_Endpoint_Test extends WP_UnitTestCase {
 					),
 				),
 			),
+			'big_sky_enable'                            => array( 'big_sky_enable', true, 1 ),
+			'big_sky_site_metadata'                     => array( 'big_sky_site_metadata', array( 'test' => 'test value' ), array( 'test' => 'test value' ) ),
 		);
 	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

Adds necessary options to the /sites/settings endpoints in order to be able to update them from Calypso. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- In wpcom sandbox, run `bin/jetpack-downloader test jetpack update/site-settings-endpoint-options`
- Sandbox public-api
- https://developer.wordpress.com/docs/api/console/ -> `WP.COM API GET v1.4/sites/dsmartbigskysandboxed.wordpress.com/settings` -> look for big_sky_ options in settings

To test updating the values, you can try with https://github.com/Automattic/wp-calypso/pull/107112

