### PR TITLE
Tooling: Enable linting run on `trunk`

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -23,7 +23,6 @@ jobs:
   ### Job to categorize changed files. Other jobs depend on this to know when they should run.
   ### On trunk pushes, all jobs run (no file filtering).
   changed_files:
-    if: github.event_name == 'pull_request'
     name: detect changed files
     runs-on: ubuntu-latest
     timeout-minutes: 1  # 2025-11-06: Successful runs seem to take a few seconds
@@ -68,9 +67,11 @@ jobs:
       phanstubs: ${{ steps.filter.outputs.phanstubs == 'true' }}
 
     steps:
-      - uses: actions/checkout@v5
+      - if: github.event_name == 'pull_request'
+        uses: actions/checkout@v5
 
-      - uses: dorny/paths-filter@v3
+      - if: github.event_name == 'pull_request'
+        uses: dorny/paths-filter@v3
         id: filter
         with:
           list-files: json
@@ -160,7 +161,8 @@ jobs:
               # If auto-generated Phan stub files are changed, we may want to post a warning to the PR.
               - '.phan/stubs/**'
 
-      - id: filterPHP
+      - if: github.event_name == 'pull_request'
+        id: filterPHP
         shell: bash
         env:
           PHP_FILES: ${{ steps.filter.outputs.php_files }}
@@ -170,7 +172,8 @@ jobs:
           echo "Excluded files:"
           jq --argjson files "$EXCLUDED_FILES" -nr '" - " + $files[]'
 
-      - id: filterJS
+      - if: github.event_name == 'pull_request'
+        id: filterJS
         shell: bash
         env:
           JS_FILES: ${{ steps.filter.outputs.js_files }}
@@ -180,7 +183,8 @@ jobs:
           echo "Excluded files:"
           jq --argjson files "$EXCLUDED_FILES" -nr '" - " + $files[]'
 
-      - id: filterExcludeList
+      - if: github.event_name == 'pull_request'
+        id: filterExcludeList
         shell: bash
         env:
           FILES: ${{ steps.filter.outputs.excludelist_files }}

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -6,7 +6,11 @@
 
 name: Linting
 
-on: pull_request
+on:
+  pull_request:
+  push:
+    branches:
+      - trunk
 concurrency:
   group: linting-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
@@ -17,7 +21,9 @@ env:
 jobs:
 
   ### Job to categorize changed files. Other jobs depend on this to know when they should run.
+  ### On trunk pushes, all jobs run (no file filtering).
   changed_files:
+    if: github.event_name == 'pull_request'
     name: detect changed files
     runs-on: ubuntu-latest
     timeout-minutes: 1  # 2025-11-06: Successful runs seem to take a few seconds
@@ -186,6 +192,9 @@ jobs:
 
   ### Runs `php -l` over all PHP files, in all relevant PHP versions
   # Local equivalent: `composer php:lint`
+  # We don't use an `if` here because GH Actions had issues expanding the name when we did. See also:
+  #    - https://github.com/Automattic/jetpack/pull/17940
+  #    - https://github.com/Automattic/jetpack/pull/18979
   php_lint:
     name: PHP lint (${{ matrix.php-versions }})
     runs-on: ubuntu-latest
@@ -224,11 +233,13 @@ jobs:
 
   ### Runs phpcs on all PHP files not listed in phpcs-excludelist.json.
   # Local equivalent: `composer phpcs:lint:required`
+  # On trunk: runs on all non-excluded PHP files
+  # On PRs: runs only if PHP files or relevant config changed
   phpcs:
     name: PHP Code Sniffer (non-excluded files only)
     runs-on: ubuntu-latest
     needs: changed_files
-    if: needs.changed_files.outputs.php == 'true' || needs.changed_files.outputs.misc_php == 'true'
+    if: github.event_name == 'push' || needs.changed_files.outputs.php == 'true' || needs.changed_files.outputs.misc_php == 'true'
     timeout-minutes: 5  # 2025-11-06: Successful runs seem to take ~2 minutes. Leaving some extra for future expansion.
 
     steps:
@@ -250,11 +261,13 @@ jobs:
 
   ### Runs PHPCompatibility over all PHP files.
   # Local equivalent: `composer phpcs:compatibility`
+  # On trunk: runs on all PHP files
+  # On PRs: runs only if PHP files or relevant config changed
   phpcompatibility:
     name: PHP Compatibility
     runs-on: ubuntu-latest
     needs: changed_files
-    if: needs.changed_files.outputs.php == 'true' || needs.changed_files.outputs.misc_php == 'true'
+    if: github.event_name == 'push' || needs.changed_files.outputs.php == 'true' || needs.changed_files.outputs.misc_php == 'true'
     timeout-minutes: 5  # 2025-11-06: Successful runs seem to take ~1 minute. Leaving some extra for future expansion.
 
     steps:
@@ -283,7 +296,7 @@ jobs:
     name: PHP Code Sniffer (changes to excluded files only)
     runs-on: ubuntu-latest
     needs: changed_files
-    if: needs.changed_files.outputs.php_excluded_files != '[]'
+    if: github.event_name == 'pull_request' && needs.changed_files.outputs.php_excluded_files != '[]'
     continue-on-error: true
     timeout-minutes: 5  # 2025-11-06: Successful runs seem to take 30 seconds. Leaving some extra for future expansion.
 
@@ -316,11 +329,13 @@ jobs:
 
   ### Runs eslint on JS files not listed in eslint-excludelist.json
   # Local equivalent: `pnpm run lint-required`
+  # On trunk: runs on all non-excluded JS files
+  # On PRs: runs only if JS files or relevant config changed
   eslint:
     name: ESLint (non-excluded files only)
     runs-on: ubuntu-latest
     needs: changed_files
-    if: needs.changed_files.outputs.js == 'true' || needs.changed_files.outputs.misc_js == 'true'
+    if: github.event_name == 'push' || needs.changed_files.outputs.js == 'true' || needs.changed_files.outputs.misc_js == 'true'
     timeout-minutes: 10  # 2025-11-06: Runs now take ~5 minutes due to now installing all php/js deps to ensure valid linting.
 
     steps:
@@ -342,7 +357,7 @@ jobs:
     name: ESLint (changes to excluded files only)
     runs-on: ubuntu-latest
     needs: changed_files
-    if: needs.changed_files.outputs.js_excluded_files != '[]'
+    if: github.event_name == 'pull_request' && needs.changed_files.outputs.js_excluded_files != '[]'
     continue-on-error: true
     timeout-minutes: 10  # 2025-11-06: Takes about a minute, but rarely runs.
 
@@ -367,11 +382,13 @@ jobs:
 
   ### Runs lint-style on all CSS/SCSS files in the monorepo except those ignored in .stylelintignore.
   # Local equivalent: `pnpm run lint-style .`
+  # On trunk: runs on all CSS/SCSS files
+  # On PRs: runs only if CSS/SCSS files or relevant config changed
   lint_style:
     name: Stylelint
     runs-on: ubuntu-latest
     needs: changed_files
-    if: needs.changed_files.outputs.css == 'true' || needs.changed_files.outputs.misc_css == 'true'
+    if: github.event_name == 'push' || needs.changed_files.outputs.css == 'true' || needs.changed_files.outputs.misc_css == 'true'
     timeout-minutes: 5  # 2025-11-06: Takes a bit more than a minute, so give a little wiggle room.
 
     steps:
@@ -387,11 +404,13 @@ jobs:
 
   ### Lints GitHub Actions yaml files.
   # Local equivalent: `./tools/js-tools/lint-gh-actions.mjs <files>`
+  # On trunk: runs on all GitHub Actions yaml files
+  # On PRs: runs only if GitHub Actions files or relevant config changed
   lint_gh_actions:
     name: Lint GitHub Actions yaml files
     runs-on: ubuntu-latest
     needs: changed_files
-    if: needs.changed_files.outputs.ghactionsfiles == 'true' || needs.changed_files.outputs.misc == 'true'
+    if: github.event_name == 'push' || needs.changed_files.outputs.ghactionsfiles == 'true' || needs.changed_files.outputs.misc == 'true'
     timeout-minutes: 5  # 2025-11-06: Takes less than a minute.
     steps:
       - uses: actions/checkout@v5
@@ -418,11 +437,13 @@ jobs:
 
   ### Runs tools/cleanup-excludelists.sh and checks for any changes
   # Local equivalent: `tools/cleanup-excludelists.sh`
+  # On trunk: always runs
+  # On PRs: runs only if excludelist-related files changed
   check_excludelists:
     name: Check linter exclude lists
     runs-on: ubuntu-latest
     needs: changed_files
-    if: needs.changed_files.outputs.excludelist == 'true'
+    if: github.event_name == 'push' || needs.changed_files.outputs.excludelist == 'true'
     timeout-minutes: 10  # 2025-11-06: The check itself takes 2 minutes.
     steps:
       - uses: actions/checkout@v5
@@ -443,6 +464,7 @@ jobs:
   # Local equivalent: Probably `tools/check-changelogger-use.php origin/trunk HEAD`
   changelogger_used:
     name: Changelogger use
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 5  # 2025-11-06: Takes a few seconds.
     steps:
@@ -484,11 +506,13 @@ jobs:
   ### Checks that lock files are up to date.
   # Local equivalent: .github/files/check-lock-files.sh
   # Note that may modify lock files in your working tree!
+  # On trunk: always runs
+  # On PRs: runs only if lock files or relevant config changed
   lock_files:
     name: "Lock files are up to date"
     runs-on: ubuntu-latest
     needs: changed_files
-    if: needs.changed_files.outputs.lockfiles == 'true' || needs.changed_files.outputs.misc == 'true'
+    if: github.event_name == 'push' || needs.changed_files.outputs.lockfiles == 'true' || needs.changed_files.outputs.misc == 'true'
     timeout-minutes: 7  # 2025-11-06: Successful runs seem to take about 2 minutes.
     steps:
       - uses: actions/checkout@v5
@@ -500,11 +524,13 @@ jobs:
 
   ### Check that monorepo packages are correctly referenced.
   # Local equivalent: tools/check-intra-monorepo-deps.sh -v && .github/files/check-monorepo-package-repos.sh
+  # On trunk: always runs
+  # On PRs: runs only if lock files or relevant config changed
   monorepo_package_refs:
     name: Monorepo package version refs
     runs-on: ubuntu-latest
     needs: changed_files
-    if: needs.changed_files.outputs.lockfiles == 'true' || needs.changed_files.outputs.misc == 'true'
+    if: github.event_name == 'push' || needs.changed_files.outputs.lockfiles == 'true' || needs.changed_files.outputs.misc == 'true'
     timeout-minutes: 7  # 2025-11-06: Takes a minute or two.
     steps:
       - uses: actions/checkout@v5
@@ -534,7 +560,7 @@ jobs:
     name: Phan stubs
     runs-on: ubuntu-latest
     needs: changed_files
-    if: needs.changed_files.outputs.phanstubs == 'true' && github.event.pull_request.user.login != 'matticbot'
+    if: github.event_name == 'pull_request' && needs.changed_files.outputs.phanstubs == 'true' && github.event.pull_request.user.login != 'matticbot'
     timeout-minutes: 5  # 2025-11-06: Probably takes about a minute, but shouldn't run often.
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -52,7 +52,7 @@ jobs:
       # Whether any miscellaneous files related to JS linting have changed.
       misc_js: ${{ steps.filter.outputs.misc == 'true' || steps.filter.outputs.misc_js == 'true' }}
 
-      # Whether any miscellaneous files related to JS linting have changed.
+      # Whether any miscellaneous files related to CSS linting have changed.
       misc_css: ${{ steps.filter.outputs.misc == 'true' || steps.filter.outputs.misc_css == 'true' }}
 
       # JSON string holding an array of files in phpcs-excludelist.json that have changed.


### PR DESCRIPTION
Closes MONOREP-229

 <!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

To allow this, I've gated the various jobs to run on the events they should run.

In particular, I'll note that this relies on `needs` being okay when the `if` is valid and `bool` conditions short-circuiting. 🤞

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Is CI happy in this PR?
* Does the workflow run successfully in `trunk`?

