### PR TITLE
Fix/double registration of core video block

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-double-registration-of-core-video-block
+++ b/projects/plugins/jetpack/changelog/fix-double-registration-of-core-video-block
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Fixes a compatability bug with the Gutenberg plugin"

--- a/projects/plugins/jetpack/modules/videopress/class.videopress-gutenberg.php
+++ b/projects/plugins/jetpack/modules/videopress/class.videopress-gutenberg.php
@@ -38,7 +38,9 @@ class VideoPress_Gutenberg {
 	 * Initialize the VideoPress Gutenberg extension
 	 */
 	private function __construct() {
-		add_action( 'init', array( $this, 'register_video_block_with_videopress' ) );
+		// Run late to avoid race condition with other plugins that register the video block
+		// Jetpack's jetpack_register_block function bails if the block is already registered
+		add_action( 'init', array( $this, 'register_video_block_with_videopress', 99 ) );
 		add_action( 'jetpack_register_gutenberg_extensions', array( $this, 'set_extension_availability' ) );
 		add_action( 'enqueue_block_editor_assets', array( $this, 'override_video_upload' ) );
 		add_action( 'enqueue_block_editor_assets', array( $this, 'add_resumable_upload_support' ) );

--- a/projects/plugins/jetpack/modules/videopress/class.videopress-gutenberg.php
+++ b/projects/plugins/jetpack/modules/videopress/class.videopress-gutenberg.php
@@ -40,7 +40,7 @@ class VideoPress_Gutenberg {
 	private function __construct() {
 		// Run late to avoid race condition with other plugins that register the video block
 		// Jetpack's jetpack_register_block function bails if the block is already registered
-		add_action( 'init', array( $this, 'register_video_block_with_videopress', 99 ) );
+		add_action( 'init', array( $this, 'register_video_block_with_videopress' ), 99 );
 		add_action( 'jetpack_register_gutenberg_extensions', array( $this, 'set_extension_availability' ) );
 		add_action( 'enqueue_block_editor_assets', array( $this, 'override_video_upload' ) );
 		add_action( 'enqueue_block_editor_assets', array( $this, 'add_resumable_upload_support' ) );


### PR DESCRIPTION
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* This PR fixes a compatibility issue with the Gutenberg plugin, where both plugins are trying to register core/video to implement some additional functionality.
* This PR makes sure Jetpack's code runs last (priority 99) because it checks and bails if the block has already been registered.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Set up a test site with Jetapck and Gutenberg 21.4 or later
* Connect Jetpack and activate the videopress module
* Without this change applied, you will not be able to add the Video block in the post editor while the Gutenberg plugin is active
* Once this patch is applied, the video block should be accessible again with both Jetpack and VideoPress active.

