### PR TITLE
Forms: move empty state as component for inbox

### DIFF
--- a/projects/packages/forms/changelog/update-forms-inbox-empty-response-component
+++ b/projects/packages/forms/changelog/update-forms-inbox-empty-response-component
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Forms: move empty state as component for inbox

--- a/projects/packages/forms/src/dashboard/components/empty-responses/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/empty-responses/index.tsx
@@ -3,8 +3,8 @@ import {
 	__experimentalVStack as VStack, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 } from '@wordpress/components';
 import { __, _n, sprintf } from '@wordpress/i18n';
-import useConfigValue from '../../hooks/use-config-value.ts';
-import CreateFormButton from '../components/create-form-button/index.tsx';
+import useConfigValue from '../../../hooks/use-config-value.ts';
+import CreateFormButton from '../create-form-button';
 
 const EmptyWrapper = ( { heading = '', body = '', actions = null } ) => (
 	<VStack alignment="center" spacing="2">

--- a/projects/packages/forms/src/dashboard/components/empty-responses/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/empty-responses/index.tsx
@@ -4,7 +4,7 @@ import {
 } from '@wordpress/components';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import useConfigValue from '../../../hooks/use-config-value.ts';
-import CreateFormButton from '../create-form-button';
+import CreateFormButton from '../create-form-button/index.tsx';
 
 const EmptyWrapper = ( { heading = '', body = '', actions = null } ) => (
 	<VStack alignment="center" spacing="2">

--- a/projects/packages/forms/src/dashboard/inbox/stage/index.js
+++ b/projects/packages/forms/src/dashboard/inbox/stage/index.js
@@ -20,6 +20,7 @@ import { useSearchParams } from 'react-router';
  */
 import useConfigValue from '../../../hooks/use-config-value.ts';
 import CreateFormButton from '../../components/create-form-button/index.tsx';
+import EmptyResponses from '../../components/empty-responses/index.tsx';
 import EmptySpamButton from '../../components/empty-spam-button/index.tsx';
 import EmptyTrashButton from '../../components/empty-trash-button/index.tsx';
 import ExportResponsesButton from '../../components/export-responses/button.tsx';
@@ -30,7 +31,6 @@ import { ResponseMobileView, SingleResponseView } from '../../components/inspect
 import IntegrationsButton from '../../components/integrations-button/index.tsx';
 import Page from '../../components/page/index.tsx';
 import useInboxData from '../../hooks/use-inbox-data.ts';
-import EmptyResponses from '../empty-responses.tsx';
 import { getPath, getItemId } from '../utils.js';
 import {
 	viewAction,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Part of FORMS-391

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*  Move empty responses file to components where it belongs.


<img width="1142" height="623" alt="image" src="https://github.com/user-attachments/assets/8f79f07e-3304-4249-ac3d-6da6ae8e13a9" />


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Empty inbox continues to work as before.
