### PR TITLE
Forms: fix spacing within advanced editor panel

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-advanced-panel-spacing
+++ b/projects/packages/forms/changelog/fix-forms-advanced-panel-spacing
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: fix spacing within advanced editor panel

--- a/projects/packages/forms/src/blocks/contact-form/edit.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/edit.tsx
@@ -937,9 +937,11 @@ function JetpackContactFormEdit( {
 						__nextHasNoMarginBottom={ true }
 						__next40pxDefaultSize={ true }
 					/>
-					<ExternalLink href="https://developer.mozilla.org/docs/Glossary/Accessible_name">
-						{ __( 'Read more.', 'jetpack-forms' ) }
-					</ExternalLink>
+					<p>
+						<ExternalLink href="https://developer.mozilla.org/docs/Glossary/Accessible_name">
+							{ __( 'Read more.', 'jetpack-forms' ) }
+						</ExternalLink>
+					</p>
 				</InspectorAdvancedControls>
 				<BlockContextProvider
 					value={ {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Latest Gutenberg and WP 6.9 adds new "Styles" section to Advanced block settings panel, but in Forms it bumps against one of our own panel.

This change adds some margin below our own panel content.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Before

<img width="283" height="475" alt="Screenshot 2025-11-18 at 12 29 29" src="https://github.com/user-attachments/assets/4b2205e4-1094-4a80-8df8-8d4043270e4e" />


After

<img width="283" height="490" alt="Screenshot 2025-11-18 at 12 29 23" src="https://github.com/user-attachments/assets/f9d1a98f-2701-450f-adcb-eca81717573e" />


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- With latest Gutenberg
- Form block selected
- See advanced panel
