### PR TITLE
e2e tests: add Playwright CTRF reporter

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4303,6 +4303,9 @@ importers:
       config:
         specifier: 4.1.1
         version: 4.1.1
+      playwright-ctrf-json-reporter:
+        specifier: ^0.0.26
+        version: 0.0.26
 
   projects/plugins/boost:
     dependencies:
@@ -4466,6 +4469,9 @@ importers:
       config:
         specifier: 4.1.1
         version: 4.1.1
+      playwright-ctrf-json-reporter:
+        specifier: ^0.0.26
+        version: 0.0.26
       typescript:
         specifier: 5.9.3
         version: 5.9.3
@@ -4566,6 +4572,9 @@ importers:
       config:
         specifier: 4.1.1
         version: 4.1.1
+      playwright-ctrf-json-reporter:
+        specifier: ^0.0.26
+        version: 0.0.26
       typescript:
         specifier: 5.9.3
         version: 5.9.3
@@ -5197,6 +5206,9 @@ importers:
       config:
         specifier: 4.1.1
         version: 4.1.1
+      playwright-ctrf-json-reporter:
+        specifier: ^0.0.26
+        version: 0.0.26
       typescript:
         specifier: 5.9.3
         version: 5.9.3
@@ -5275,6 +5287,9 @@ importers:
       config:
         specifier: 4.1.1
         version: 4.1.1
+      playwright-ctrf-json-reporter:
+        specifier: ^0.0.26
+        version: 0.0.26
 
   projects/plugins/protect:
     dependencies:
@@ -5399,6 +5414,9 @@ importers:
       config:
         specifier: 4.1.1
         version: 4.1.1
+      playwright-ctrf-json-reporter:
+        specifier: ^0.0.26
+        version: 0.0.26
       typescript:
         specifier: 5.9.3
         version: 5.9.3
@@ -5422,6 +5440,9 @@ importers:
       config:
         specifier: 4.1.1
         version: 4.1.1
+      playwright-ctrf-json-reporter:
+        specifier: ^0.0.26
+        version: 0.0.26
       typescript:
         specifier: 5.9.3
         version: 5.9.3
@@ -5449,6 +5470,9 @@ importers:
       config:
         specifier: 4.1.1
         version: 4.1.1
+      playwright-ctrf-json-reporter:
+        specifier: ^0.0.26
+        version: 0.0.26
       typescript:
         specifier: 5.9.3
         version: 5.9.3
@@ -5546,6 +5570,9 @@ importers:
       config:
         specifier: 4.1.1
         version: 4.1.1
+      playwright-ctrf-json-reporter:
+        specifier: ^0.0.26
+        version: 0.0.26
       typescript:
         specifier: 5.9.3
         version: 5.9.3
@@ -5669,6 +5696,9 @@ importers:
       config:
         specifier: 4.1.1
         version: 4.1.1
+      playwright-ctrf-json-reporter:
+        specifier: ^0.0.26
+        version: 0.0.26
       typescript:
         specifier: 5.9.3
         version: 5.9.3
@@ -5805,6 +5835,9 @@ importers:
       lodash-es:
         specifier: 4.17.21
         version: 4.17.21
+      playwright-ctrf-json-reporter:
+        specifier: ^0.0.26
+        version: 0.0.26
       shell-escape:
         specifier: 0.2.0
         version: 0.2.0
@@ -14498,6 +14531,9 @@ packages:
     resolution: {integrity: sha512-hutraynyn31F+Bifme+Ps9Vq59hKuUCz7H1kDOcBs+2oGguKkWTU50bBWrtz34OUWmIwpBTWDxaRPXrIXkgvmQ==}
     engines: {node: '>=18'}
     hasBin: true
+
+  playwright-ctrf-json-reporter@0.0.26:
+    resolution: {integrity: sha512-3BtV0R5Vstwu02ARwAlegdCwMhBJC3GYm+0CVBrHOryQACk+TraqD+ZZxLMPhUnlddGFwkHcU57KxPiZb6/k1A==}
 
   playwright@1.55.1:
     resolution: {integrity: sha512-cJW4Xd/G3v5ovXtJJ52MAOclqeac9S/aGGgRzLabuF8TnIb6xHvMzKIa6JmrRzUkeXJgfL1MhukP0NK6l39h3A==}
@@ -29502,6 +29538,8 @@ snapshots:
   playwright-core@1.55.1: {}
 
   playwright-core@1.56.1: {}
+
+  playwright-ctrf-json-reporter@0.0.26: {}
 
   playwright@1.55.1:
     dependencies:

--- a/projects/plugins/automattic-for-agencies-client/changelog/e2e-add-ctrf-and-junit-reporters
+++ b/projects/plugins/automattic-for-agencies-client/changelog/e2e-add-ctrf-and-junit-reporters
@@ -1,0 +1,5 @@
+Significance: patch
+Type: added
+Comment: dev: added a new reporter for e2e tests
+
+

--- a/projects/plugins/automattic-for-agencies-client/tests/e2e/package.json
+++ b/projects/plugins/automattic-for-agencies-client/tests/e2e/package.json
@@ -20,7 +20,8 @@
 		"@playwright/test": "1.55.1",
 		"_jetpack-e2e-commons": "workspace:*",
 		"allure-playwright": "2.15.1",
-		"config": "4.1.1"
+		"config": "4.1.1",
+		"playwright-ctrf-json-reporter": "^0.0.26"
 	},
 	"ci": {
 		"targets": [

--- a/projects/plugins/boost/changelog/e2e-add-ctrf-and-junit-reporters
+++ b/projects/plugins/boost/changelog/e2e-add-ctrf-and-junit-reporters
@@ -1,0 +1,5 @@
+Significance: patch
+Type: added
+Comment: dev: added a new reporter for e2e tests
+
+

--- a/projects/plugins/boost/tests/e2e/package.json
+++ b/projects/plugins/boost/tests/e2e/package.json
@@ -25,6 +25,7 @@
 		"_jetpack-e2e-commons": "workspace:*",
 		"allure-playwright": "2.15.1",
 		"config": "4.1.1",
+		"playwright-ctrf-json-reporter": "^0.0.26",
 		"typescript": "5.9.3"
 	},
 	"ci": {

--- a/projects/plugins/classic-theme-helper-plugin/changelog/e2e-add-ctrf-and-junit-reporters
+++ b/projects/plugins/classic-theme-helper-plugin/changelog/e2e-add-ctrf-and-junit-reporters
@@ -1,0 +1,5 @@
+Significance: patch
+Type: added
+Comment: dev: added a new reporter for e2e tests
+
+

--- a/projects/plugins/classic-theme-helper-plugin/tests/e2e/package.json
+++ b/projects/plugins/classic-theme-helper-plugin/tests/e2e/package.json
@@ -23,6 +23,7 @@
 		"_jetpack-e2e-commons": "workspace:*",
 		"allure-playwright": "2.15.1",
 		"config": "4.1.1",
+		"playwright-ctrf-json-reporter": "^0.0.26",
 		"typescript": "5.9.3"
 	},
 	"ci": {

--- a/projects/plugins/jetpack/changelog/e2e-add-ctrf-and-junit-reporters
+++ b/projects/plugins/jetpack/changelog/e2e-add-ctrf-and-junit-reporters
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: dev: added a new reporter for e2e tests
+
+

--- a/projects/plugins/jetpack/tests/e2e/package.json
+++ b/projects/plugins/jetpack/tests/e2e/package.json
@@ -31,6 +31,7 @@
 		"_jetpack-e2e-commons": "workspace:*",
 		"allure-playwright": "2.15.1",
 		"config": "4.1.1",
+		"playwright-ctrf-json-reporter": "^0.0.26",
 		"typescript": "5.9.3"
 	},
 	"ci": {

--- a/projects/plugins/paypal-payment-buttons/changelog/e2e-add-ctrf-and-junit-reporters
+++ b/projects/plugins/paypal-payment-buttons/changelog/e2e-add-ctrf-and-junit-reporters
@@ -1,0 +1,5 @@
+Significance: patch
+Type: added
+Comment: dev: added a new reporter for e2e tests
+
+

--- a/projects/plugins/paypal-payment-buttons/tests/e2e/package.json
+++ b/projects/plugins/paypal-payment-buttons/tests/e2e/package.json
@@ -20,7 +20,8 @@
 		"@playwright/test": "1.55.1",
 		"_jetpack-e2e-commons": "workspace:*",
 		"allure-playwright": "2.15.1",
-		"config": "4.1.1"
+		"config": "4.1.1",
+		"playwright-ctrf-json-reporter": "^0.0.26"
 	},
 	"ci": {
 		"targets": [

--- a/projects/plugins/protect/changelog/e2e-add-ctrf-and-junit-reporters
+++ b/projects/plugins/protect/changelog/e2e-add-ctrf-and-junit-reporters
@@ -1,0 +1,5 @@
+Significance: patch
+Type: added
+Comment: dev: added a new reporter for e2e tests
+
+

--- a/projects/plugins/protect/tests/e2e/package.json
+++ b/projects/plugins/protect/tests/e2e/package.json
@@ -24,6 +24,7 @@
 		"_jetpack-e2e-commons": "workspace:*",
 		"allure-playwright": "2.15.1",
 		"config": "4.1.1",
+		"playwright-ctrf-json-reporter": "^0.0.26",
 		"typescript": "5.9.3"
 	},
 	"ci": {

--- a/projects/plugins/search/changelog/e2e-add-ctrf-and-junit-reporters
+++ b/projects/plugins/search/changelog/e2e-add-ctrf-and-junit-reporters
@@ -1,0 +1,5 @@
+Significance: patch
+Type: added
+Comment: dev: added a new reporter for e2e tests
+
+

--- a/projects/plugins/search/tests/e2e/package.json
+++ b/projects/plugins/search/tests/e2e/package.json
@@ -25,6 +25,7 @@
 		"_jetpack-e2e-commons": "workspace:*",
 		"allure-playwright": "2.15.1",
 		"config": "4.1.1",
+		"playwright-ctrf-json-reporter": "^0.0.26",
 		"typescript": "5.9.3"
 	},
 	"ci": {

--- a/projects/plugins/social/changelog/e2e-add-ctrf-and-junit-reporters
+++ b/projects/plugins/social/changelog/e2e-add-ctrf-and-junit-reporters
@@ -1,0 +1,5 @@
+Significance: patch
+Type: added
+Comment: dev: added a new reporter for e2e tests
+
+

--- a/projects/plugins/social/tests/e2e/package.json
+++ b/projects/plugins/social/tests/e2e/package.json
@@ -26,6 +26,7 @@
 		"_jetpack-e2e-commons": "workspace:*",
 		"allure-playwright": "2.15.1",
 		"config": "4.1.1",
+		"playwright-ctrf-json-reporter": "^0.0.26",
 		"typescript": "5.9.3"
 	},
 	"ci": {

--- a/projects/plugins/starter-plugin/changelog/e2e-add-ctrf-and-junit-reporters
+++ b/projects/plugins/starter-plugin/changelog/e2e-add-ctrf-and-junit-reporters
@@ -1,0 +1,5 @@
+Significance: patch
+Type: added
+Comment: dev: added a new reporter for e2e tests
+
+

--- a/projects/plugins/starter-plugin/tests/e2e/package.json
+++ b/projects/plugins/starter-plugin/tests/e2e/package.json
@@ -24,6 +24,7 @@
 		"_jetpack-e2e-commons": "workspace:*",
 		"allure-playwright": "2.15.1",
 		"config": "4.1.1",
+		"playwright-ctrf-json-reporter": "^0.0.26",
 		"typescript": "5.9.3"
 	},
 	"ci": {

--- a/projects/plugins/videopress/changelog/e2e-add-ctrf-and-junit-reporters
+++ b/projects/plugins/videopress/changelog/e2e-add-ctrf-and-junit-reporters
@@ -1,0 +1,5 @@
+Significance: patch
+Type: added
+Comment: dev: added a new reporter for e2e tests
+
+

--- a/projects/plugins/videopress/tests/e2e/package.json
+++ b/projects/plugins/videopress/tests/e2e/package.json
@@ -24,6 +24,7 @@
 		"_jetpack-e2e-commons": "workspace:*",
 		"allure-playwright": "2.15.1",
 		"config": "4.1.1",
+		"playwright-ctrf-json-reporter": "^0.0.26",
 		"typescript": "5.9.3"
 	},
 	"ci": {

--- a/tools/e2e-commons/package.json
+++ b/tools/e2e-commons/package.json
@@ -42,6 +42,7 @@
 		"config": "4.1.1",
 		"localtunnel": "2.0.2",
 		"lodash-es": "4.17.21",
+		"playwright-ctrf-json-reporter": "^0.0.26",
 		"shell-escape": "0.2.0",
 		"typescript": "5.9.3",
 		"winston": "3.17.0",

--- a/tools/e2e-commons/playwright.config.default.ts
+++ b/tools/e2e-commons/playwright.config.default.ts
@@ -16,6 +16,21 @@ const reporter: ReporterDescription[] = [
 			suiteTitle: false,
 		},
 	],
+	[
+		'junit',
+		{
+			outputFile: `${ config.get( 'dirs.output' ) }/results.xml`,
+			stripANSIControlSequences: true,
+			includeProjectInTestName: true,
+		},
+	],
+	[
+		'playwright-ctrf-json-reporter',
+		{
+			outputDir: `${ config.get( 'dirs.output' ) }`,
+			outputFile: `ctrf-report-${ Date.now() }.json`,
+		},
+	],
 ];
 
 if ( process.env.CI ) {


### PR DESCRIPTION
Contributes to QAO-173

## Proposed changes:

Added and configured Playwright CTRF reporter for e2e tests. 
Configured the builtin JUnit reporter.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
n/a

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:

Check the e2e tests CI artefacts. There should be a `results.xml` and a `ctrf-report-<timestamp>.json` files present.

