### PR TITLE
jetpack-mu-wpcom Code Block: Add raw transform

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/code-block-add-raw-transform
+++ b/projects/packages/jetpack-mu-wpcom/changelog/code-block-add-raw-transform
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Unreleased code block: Add raw transform

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/block-definition/transforms.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/block-definition/transforms.ts
@@ -170,6 +170,44 @@ export const transforms = {
 				return block;
 			},
 		},
+
+		{
+			type: 'raw',
+			priority: 5,
+			isMatch: ( node: Node ) =>
+				node.nodeName === 'PRE' &&
+				( node as HTMLPreElement ).children.length === 1 &&
+				( node as HTMLPreElement ).firstChild!.nodeName === 'CODE',
+			transform: ( node: HTMLPreElement ) => {
+				// This structure was validated by the match already.
+				const codeElement = node.firstChild as HTMLElement;
+
+				const blockAttributes: Partial< Attributes > = {
+					content: RichTextData.fromPlainText( codeElement.textContent || '' ),
+				};
+
+				const detectedLanguage = externalLanguageToBlockLanguage(
+					codeElement.classList[ 0 ]?.substring( 'language-'.length )
+				);
+
+				if ( typeof detectedLanguage === 'string' ) {
+					blockAttributes.language = detectedLanguage;
+					blockAttributes.languageConfidence = 'certain';
+				}
+
+				return createBlock< Attributes >( BLOCK_NAME, blockAttributes );
+			},
+			schema: {
+				pre: {
+					children: {
+						code: {
+							classes: [ /^language-/i ],
+							children: { '#text': {} },
+						},
+					},
+				},
+			},
+		},
 	],
 };
 


### PR DESCRIPTION
## Proposed changes:

Add a raw transform to the code block to handle things like pasting HTML:

```html
<pre><code class="language-php">&lt;?php // Code!</code></pre>
```

Note that due to https://github.com/WordPress/gutenberg/issues/70612, the language class cannot correctly be processed. However, the implementation is tested and correct for when that issue is fixed and the language class will be correctly processed.


https://github.com/user-attachments/assets/b26889fe-a84b-4e1b-ac4f-7e3c05bed3be

(The above paste recognized HTML language. It is using patched version of Gutenberg.)

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?



## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:

Try pasting the example into the block editor: `<pre><code class="language-php">&lt;?php // Code!</code></pre>`. A "plain text" code block will be created, the langauge cannot correctly be processed (see https://github.com/WordPress/gutenberg/issues/70612).