### PR TITLE
cli: Improve escaping in `jetpack rsync` config keys

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5735,6 +5735,9 @@ importers:
       configstore:
         specifier: 7.0.0
         version: 7.0.0
+      dot-prop:
+        specifier: ^9.0.0
+        version: 9.0.0
       enquirer:
         specifier: 2.4.1
         version: 2.4.1

--- a/tools/cli/commands/rsync.js
+++ b/tools/cli/commands/rsync.js
@@ -7,6 +7,7 @@ import util from 'util';
 import chalk from 'chalk';
 import chokidar from 'chokidar';
 import Configstore from 'configstore';
+import { escapePath } from 'dot-prop';
 import enquirer from 'enquirer';
 import { execa } from 'execa';
 import pDebounce from 'p-debounce';
@@ -21,17 +22,6 @@ const rsyncConfigStore = new Configstore( 'automattic/jetpack-cli/rsync' );
 let isOpenrsync = false;
 
 /**
- * Escapes dots in a string. Useful when saving destination as key in Configstore. Otherwise it tries strings with dots
- * as nested objects.
- *
- * @param { string } key - String of the destination key.
- * @return { string } - Returns the key with escaped periods.
- */
-function escapeKey( key ) {
-	return key.replace( /\./g, '\\.' );
-}
-
-/**
  * Stores the destination in the configstore.
  * Takes an optional alias arg.
  *
@@ -40,7 +30,7 @@ function escapeKey( key ) {
  */
 function setRsyncDest( pluginDestPath, alias = false ) {
 	const key = alias || pluginDestPath;
-	rsyncConfigStore.set( escapeKey( key ), pluginDestPath );
+	rsyncConfigStore.set( escapePath( key ), pluginDestPath );
 }
 
 /**
@@ -301,7 +291,7 @@ async function promptToManageConfig() {
 				}
 			} );
 	};
-	const clearOne = key => rsyncConfigStore.delete( escapeKey( key ) );
+	const clearOne = key => rsyncConfigStore.delete( escapePath( key ) );
 	const configManage = await enquirer.prompt( {
 		type: 'select',
 		name: 'manageConfig',
@@ -641,13 +631,13 @@ async function promptForSetAlias( pluginDestPath ) {
 		message: 'Enter an alias for easier reference? (Press enter to skip.)',
 	} );
 	const alias = aliasSetPrompt.alias || pluginDestPath;
-	if ( rsyncConfigStore.has( escapeKey( alias ) ) ) {
+	if ( rsyncConfigStore.has( escapePath( alias ) ) ) {
 		const alreadyFound = await enquirer.prompt( {
 			name: 'overwrite',
 			type: 'confirm',
 			initial: true,
 			// prettier-ignore
-			message: `This alias already exists for dest: ${ rsyncConfigStore.get( escapeKey( alias ) ) }. Overwrite it?`,
+			message: `This alias already exists for dest: ${ rsyncConfigStore.get( escapePath( alias ) ) }. Overwrite it?`,
 		} );
 		if ( ! alreadyFound.overwrite ) {
 			console.log( 'Okay!' );
@@ -666,9 +656,9 @@ async function promptForSetAlias( pluginDestPath ) {
  * @return {object} argv object with the project property.
  */
 async function maybePromptForDest( argv ) {
-	if ( rsyncConfigStore.has( argv.dest ) ) {
-		console.log( `Alias found, using dest: ${ rsyncConfigStore.get( argv.dest ) }` );
-		argv.dest = rsyncConfigStore.get( argv.dest );
+	if ( rsyncConfigStore.has( escapePath( argv.dest ) ) ) {
+		console.log( `Alias found, using dest: ${ rsyncConfigStore.get( escapePath( argv.dest ) ) }` );
+		argv.dest = rsyncConfigStore.get( escapePath( argv.dest ) );
 		return argv;
 	}
 	if ( argv.dest ) {
@@ -692,7 +682,7 @@ async function maybePromptForDest( argv ) {
 		if ( 'Create new' === response.dest ) {
 			argv.dest = await promptNewDest();
 		} else {
-			argv.dest = rsyncConfigStore.get( escapeKey( response.dest ) );
+			argv.dest = rsyncConfigStore.get( escapePath( response.dest ) );
 		}
 	}
 	return argv;

--- a/tools/cli/commands/rsync.js
+++ b/tools/cli/commands/rsync.js
@@ -656,7 +656,7 @@ async function promptForSetAlias( pluginDestPath ) {
  * @return {object} argv object with the project property.
  */
 async function maybePromptForDest( argv ) {
-	if ( rsyncConfigStore.has( escapePath( argv.dest ) ) ) {
+	if ( typeof argv.dest === 'string' && rsyncConfigStore.has( escapePath( argv.dest ) ) ) {
 		console.log( `Alias found, using dest: ${ rsyncConfigStore.get( escapePath( argv.dest ) ) }` );
 		argv.dest = rsyncConfigStore.get( escapePath( argv.dest ) );
 		return argv;

--- a/tools/cli/package.json
+++ b/tools/cli/package.json
@@ -26,6 +26,7 @@
 		"chalk": "5.6.2",
 		"chokidar": "4.0.3",
 		"configstore": "7.0.0",
+		"dot-prop": "^9.0.0",
 		"enquirer": "2.4.1",
 		"envfile": "7.1.0",
 		"execa": "7.0.0",


### PR DESCRIPTION
Closes MONOREP-230

 <!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Instead of rolling our own escaping function, use the escaping function provided by the same package that `configstore` uses for parsing the keys.

Also, I found one code path that wasn't applying the escaping where it should have been.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
Fixes https://github.com/Automattic/jetpack/security/code-scanning/118

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Try it out with keys containing backslashes and open brackets in addition to dots.
