### PR TITLE
jetpack-mu-wpcom Code Block: Add html transform

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/code-block-html-transform
+++ b/projects/packages/jetpack-mu-wpcom/changelog/code-block-html-transform
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add block transform from core/html.

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/block-definition/transforms.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/block-definition/transforms.ts
@@ -46,6 +46,18 @@ export const transforms = {
 
 		{
 			type: 'block',
+			blocks: [ 'core/html' ],
+			transform: ( { content: text }: { content: string } ) => {
+				return createBlock( 'core/code', {
+					content: RichTextData.fromPlainText( text ),
+					language: 'HTML',
+					languageConfidence: 'certain',
+				} );
+			},
+		},
+
+		{
+			type: 'block',
 			blocks: [ 'kevinbatdorf/code-block-pro' ],
 			transform: ( {
 				code,

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/block-definition/transforms.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/block-definition/transforms.ts
@@ -47,6 +47,7 @@ export const transforms = {
 		{
 			type: 'block',
 			blocks: [ 'core/html' ],
+			priority: 5,
 			transform: ( { content: text }: { content: string } ) => {
 				return createBlock( 'core/code', {
 					content: RichTextData.fromPlainText( text ),


### PR DESCRIPTION
## Proposed changes:

Add a transform from core/html to core/code with the HTML language set.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?


## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
- Add a core/html block.
- Transform to "Code" block.
- The content should be preserved and the `HTML` language set.


https://github.com/user-attachments/assets/b874a4c4-a3b3-4819-8c32-2ce9db709d22

