### PR TITLE
Code block: Add syntaxhighlighter/code transform to

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/code-block-add-syntax-highlighter-xform
+++ b/projects/packages/jetpack-mu-wpcom/changelog/code-block-add-syntax-highlighter-xform
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Unreleased code block: Add transform to syntax highlighter.

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/block-definition/block-definition.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/block-definition/block-definition.tsx
@@ -107,11 +107,13 @@ function filterBlockRegistration( settings: any ) {
 	}
 
 	if ( ! settings.transforms ) {
-		settings.transforms = { from: transforms.from };
-	} else if ( ! settings.transforms.from ) {
-		settings.transforms.from = transforms.from;
+		settings.transforms = {
+			from: transforms.from,
+			to: transforms.to,
+		};
 	} else {
-		settings.transforms.from.push( ...transforms.from );
+		settings.transforms.from = [ ...transforms.from, ...settings.transforms.from ];
+		settings.transforms.to = [ ...transforms.to, ...settings.transforms.to ];
 	}
 
 	return settings;

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/block-definition/transforms.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/block-definition/transforms.ts
@@ -222,6 +222,7 @@ export const transforms = {
 			},
 		},
 	],
+
 	to: [
 		{
 			type: 'block',

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/block-definition/transforms.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/block-definition/transforms.ts
@@ -222,6 +222,15 @@ export const transforms = {
 			},
 		},
 	],
+	to: [
+		{
+			type: 'block',
+			blocks: [ 'syntaxhighlighter/code' ],
+			transform: ( { content }: Attributes ) => {
+				return createBlock( 'syntaxhighlighter/code', { content: content.toPlainText() } );
+			},
+		},
+	],
 };
 
 /**

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/block-definition/transforms.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/block-definition/transforms.ts
@@ -11,6 +11,13 @@ const { createBlock }: Window[ 'wp' ][ 'blocks' ] = wpBlocks;
 
 const CODE_FENCE_REGEXP = /^```([a-z0-9+-]*)$/i;
 
+interface SyntaxHighlighterCodeAttributes {
+	content?: string;
+	language?: string;
+	lineNumbers?: boolean;
+	firstLineNumber?: string;
+}
+
 export const transforms = {
 	from: [
 		// Handle code fence openers, e.g. ```js
@@ -97,15 +104,7 @@ export const transforms = {
 		{
 			type: 'block',
 			blocks: [ 'syntaxhighlighter/code' ],
-			transform: ( {
-				content = '',
-				...attributes
-			}: {
-				content?: string;
-				language?: string;
-				lineNumbers?: boolean;
-				firstLineNumber?: string;
-			} ) => {
+			transform: ( { content = '', ...attributes }: SyntaxHighlighterCodeAttributes ) => {
 				const blockAttributes: Partial< Attributes > = {
 					content: RichTextData.fromPlainText( content ),
 				};
@@ -227,8 +226,13 @@ export const transforms = {
 		{
 			type: 'block',
 			blocks: [ 'syntaxhighlighter/code' ],
-			transform: ( { content }: Attributes ) => {
-				return createBlock( 'syntaxhighlighter/code', { content: content.toPlainText() } );
+			transform: ( attributes: Attributes ) => {
+				const blockAttributes: SyntaxHighlighterCodeAttributes = {
+					content: attributes.content.toPlainText(),
+					lineNumbers: Boolean( attributes.showLineNumbers ),
+					firstLineNumber: String( attributes.lineNumbersStartAt || 1 ),
+				};
+				return createBlock( 'syntaxhighlighter/code', blockAttributes );
 			},
 		},
 	],


### PR DESCRIPTION


## Proposed changes:

Fixes the `syntaxhighlighter/code` transforms so that the code and some attributes are better preserved.

Notice that before line breaks were not handled correctly:

<img width="1116" height="1124" alt="sh-xform-before" src="https://github.com/user-attachments/assets/b1bf45a9-081b-48d7-ada4-7fb7413fd55e" />

After, the block survives a round-trip transform:

<img width="1116" height="1262" alt="sh-xform-after" src="https://github.com/user-attachments/assets/26e44037-6c19-4a09-a37c-8275035af999" />


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?



## Does this pull request change what data or activity we track or use?
no

## Testing instructions:

Create a code block, use interesting HTML special syntax and line breaks.
Confirm that the block and its content survive a round trip, transforming to `syntaxhighlighter/code` and back.
