### PR TITLE
Forms: update dashboard header buttons

### DIFF
--- a/projects/packages/forms/changelog/update-forms-dashboard-buttons
+++ b/projects/packages/forms/changelog/update-forms-dashboard-buttons
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Forms: update dashboard header buttons.

--- a/projects/packages/forms/src/dashboard/components/create-form-button/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/create-form-button/index.tsx
@@ -27,7 +27,7 @@ type CreateFormButtonProps = {
  * @return {JSX.Element}                 The button to create a new form.
  */
 export default function CreateFormButton( {
-	label = __( 'Create a free form', 'jetpack-forms' ),
+	label = __( 'Create a form', 'jetpack-forms' ),
 	showPatterns = false,
 	variant = 'secondary',
 }: CreateFormButtonProps ): JSX.Element {

--- a/projects/packages/forms/src/dashboard/components/export-responses/button.tsx
+++ b/projects/packages/forms/src/dashboard/components/export-responses/button.tsx
@@ -23,6 +23,7 @@ const ExportResponsesButton = ( { isPrimary = false }: { isPrimary?: boolean } )
 		autoConnectGdrive,
 		exportLabel,
 	} = useExportResponses();
+
 	const { totalItems, isLoadingData } = useInboxData();
 	const isEmpty = isLoadingData || totalItems === 0;
 	const isDisabled = isEmpty || userCanExport === false;

--- a/projects/packages/forms/src/dashboard/inbox/stage/index.js
+++ b/projects/packages/forms/src/dashboard/inbox/stage/index.js
@@ -463,18 +463,21 @@ export default function InboxView() {
 
 	// Conditional header actions based on status filter
 	const headerActions = useMemo( () => {
-		const headerActionsArray = [ <ExportResponsesButton key="export" /> ];
+		const exportIsPrimary = statusFilter !== 'trash' && statusFilter !== 'spam';
+		const headerActionsArray = [
+			<ExportResponsesButton key="export" isPrimary={ exportIsPrimary } />,
+		];
 
 		if ( statusFilter === 'trash' ) {
 			headerActionsArray.push( <EmptyTrashButton key="empty-trash" /> );
 		} else if ( statusFilter === 'spam' ) {
 			headerActionsArray.push( <EmptySpamButton key="empty-spam" /> );
 		} else {
+			headerActionsArray.unshift( <CreateFormButton key="create" /> );
 			// Only show Create Form and Integrations buttons on inbox (when not in trash or spam)
 			if ( enableIntegrationsTab ) {
 				headerActionsArray.unshift( <IntegrationsButton key="integrations" /> );
 			}
-			headerActionsArray.unshift( <CreateFormButton key="create" variant="primary" /> );
 		}
 
 		return headerActionsArray;

--- a/projects/plugins/jetpack/changelog/update-forms-dashboard-buttons
+++ b/projects/plugins/jetpack/changelog/update-forms-dashboard-buttons
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Forms: update dashboard header buttons.


### PR DESCRIPTION
## Proposed changes:

Fixes / updates our forms dashboard header buttons. Specifically: 
* Change 'Create a free form' to 'Create a form' and sets to 'secondary' style
* Moves 'Manage integrations' button to be first
* Make Export button primary for inbox, secondary for spam/trash (Empty buttons are primary there) 

**Inbox**
<img width="1333" height="173" alt="dashboar-buttons" src="https://github.com/user-attachments/assets/11a98442-c784-4461-960e-22e87b96c3a8" />

**Spam**
<img width="1335" height="169" alt="spam-buttons" src="https://github.com/user-attachments/assets/53441432-d2c0-4476-ac5c-bcb32fd3f307" />


**Trash**
<img width="1344" height="168" alt="trash-buttons" src="https://github.com/user-attachments/assets/9d894ec9-66e9-4720-92d7-c1c2dd9958c3" />


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
Slack: p1763489942914839/1762955132.932929-slack-C052XEUUBL4

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No. 

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Will add when ready.