### PR TITLE
Forms: Fix dark theme outline form

### DIFF
--- a/projects/packages/forms/changelog/fix-darktheme-outline-form
+++ b/projects/packages/forms/changelog/fix-darktheme-outline-form
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: Improve dark theme compatibility and outline form style

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -1075,7 +1075,7 @@
 :where(.is-style-outlined .jetpack-contact-form .jetpack-field .notched-label__filler),
 :where(.is-style-outlined .jetpack-contact-form .jetpack-field .notched-label__trailing) {
 	border: var(--jetpack--contact-form--border);
-	background-color: var(--jetpack--contact-form--input-background);
+	background-color: var(--jetpack--contact-form--background-color, #fff);
 }
 
 :where(.wp-block-jetpack-contact-form.is-style-outlined) {

--- a/projects/packages/forms/src/blocks/contact-form/util/form-styles.js
+++ b/projects/packages/forms/src/blocks/contact-form/util/form-styles.js
@@ -136,6 +136,9 @@ window.jetpackForms.generateStyleVariables = function ( formNode ) {
 		inputBackground === 'transparent' ||
 		inputBackground === '#00000000';
 
+	const borderWidthOutline =
+		( parseFloat( borderWidth ) > 1 ? parseFloat( borderWidth ) : 1 ) + 'px';
+
 	styleProbe.remove();
 
 	return {
@@ -147,6 +150,7 @@ window.jetpackForms.generateStyleVariables = function ( formNode ) {
 		'--jetpack--contact-form--border': border,
 		'--jetpack--contact-form--border-color': borderColor,
 		'--jetpack--contact-form--border-size': borderWidth,
+		'--jetpack--contact-form--border-size-outline': borderWidthOutline,
 		'--jetpack--contact-form--border-style': borderStyle,
 		'--jetpack--contact-form--border-radius': borderRadius,
 		...( inputBackgroundIsTransparent

--- a/projects/packages/forms/src/blocks/contact-form/util/form-styles.js
+++ b/projects/packages/forms/src/blocks/contact-form/util/form-styles.js
@@ -76,7 +76,6 @@ window.jetpackForms.generateStyleVariables = function ( formNode ) {
 	}
 
 	const _document = window[ 'editor-canvas' ] ? window[ 'editor-canvas' ].document : document;
-	const bodyNode = _document.querySelector( 'body' );
 
 	const styleProbe = _document.createElement( 'div' );
 	styleProbe.className = STYLE_PROBE_CLASS;
@@ -90,7 +89,7 @@ window.jetpackForms.generateStyleVariables = function ( formNode ) {
 	const buttonOutlineNode = styleProbe.querySelector( '.btn-outline' );
 	const inputNode = styleProbe.querySelector( 'input[type="text"]' );
 
-	const backgroundColor = window.jetpackForms.getBackgroundColor( bodyNode );
+	const backgroundColor = window.jetpackForms.getBackgroundColor( formRootNode );
 	const inputBackgroundFallback = window.jetpackForms.getBackgroundColor( inputNode );
 
 	const bodyTextColor = window.getComputedStyle( formRootNode ).color;

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -1066,6 +1066,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 				id='" . $element_id . "'
 				method='post'
 				class='" . esc_attr( $form_classes ) . "' $form_aria_label
+				data-wp-init='callbacks.initializeForm'
 				data-wp-on--submit=\"actions.onFormSubmit\"
 				data-wp-on--reset=\"actions.onFormReset\"
 				data-wp-class--submission-success=\"context.submissionSuccess\"

--- a/projects/packages/forms/src/contact-form/css/combobox.scss
+++ b/projects/packages/forms/src/contact-form/css/combobox.scss
@@ -19,7 +19,7 @@
 		border: 0 solid #ddd;
 		border-radius: 4px;
 		background: transparent;
-		background-color: transparent;
+		box-shadow: none;
 		cursor: pointer;
 		display: flex;
 		align-items: center;

--- a/projects/packages/forms/src/contact-form/css/grunion.scss
+++ b/projects/packages/forms/src/contact-form/css/grunion.scss
@@ -672,9 +672,9 @@ that needs to mimic the input element styles */
 :where(.wp-block-jetpack-contact-form.is-style-outlined) .notched-label__leading {
 	border-color: var(--jetpack--contact-form--border-color);
 	border-style: var(--jetpack--contact-form--border-style);
-	border-top-width: var(--jetpack--contact-form--border-top-size, var(--jetpack--contact-form--border-size));
-	border-bottom-width: var(--jetpack--contact-form--border-bottom-size, var(--jetpack--contact-form--border-size));
-	border-left-width: var(--jetpack--contact-form--border-left-size, var(--jetpack--contact-form--border-size));
+	border-top-width: var(--jetpack--contact-form--border-top-size, var(--jetpack--contact-form--border-size-outline));
+	border-bottom-width: var(--jetpack--contact-form--border-bottom-size, var(--jetpack--contact-form--border-size-outline));
+	border-left-width: var(--jetpack--contact-form--border-left-size, var(--jetpack--contact-form--border-size-outline));
 	border-radius: var(--jetpack--contact-form--border-radius);
 	width: var(--jetpack--contact-form--notch-width);
 	max-width: 100px;
@@ -687,8 +687,8 @@ that needs to mimic the input element styles */
 :where(.wp-block-jetpack-contact-form.is-style-outlined) .notched-label__notch {
 	border-color: var(--jetpack--contact-form--border-color);
 	border-style: var(--jetpack--contact-form--border-style);
-	border-top-width: var(--jetpack--contact-form--border-top-size, var(--jetpack--contact-form--border-size));
-	border-bottom-width: var(--jetpack--contact-form--border-bottom-size, var(--jetpack--contact-form--border-size));
+	border-top-width: var(--jetpack--contact-form--border-top-size, var(--jetpack--contact-form--border-size-outline));
+	border-bottom-width: var(--jetpack--contact-form--border-bottom-size, var(--jetpack--contact-form--border-size-outline));
 	border-radius: unset !important;
 	padding: 0 4px;
 	transition: border 150ms linear;
@@ -700,8 +700,8 @@ that needs to mimic the input element styles */
 :where(.wp-block-jetpack-contact-form.is-style-outlined) .notched-label__filler {
 	border-color: var(--jetpack--contact-form--border-color);
 	border-style: var(--jetpack--contact-form--border-style);
-	border-top-width: var(--jetpack--contact-form--border-top-size, var(--jetpack--contact-form--border-size));
-	border-bottom-width: var(--jetpack--contact-form--border-bottom-size, var(--jetpack--contact-form--border-size));
+	border-top-width: var(--jetpack--contact-form--border-top-size, var(--jetpack--contact-form--border-size-outline));
+	border-bottom-width: var(--jetpack--contact-form--border-bottom-size, var(--jetpack--contact-form--border-size-outline));
 	flex-grow: 1;
 	border-left: none !important;
 	border-right: none !important;
@@ -712,9 +712,9 @@ that needs to mimic the input element styles */
 :where(.wp-block-jetpack-contact-form.is-style-outlined) .notched-label__trailing {
 	border-color: var(--jetpack--contact-form--border-color);
 	border-style: var(--jetpack--contact-form--border-style);
-	border-top-width: var(--jetpack--contact-form--border-top-size, var(--jetpack--contact-form--border-size));
-	border-right-width: var(--jetpack--contact-form--border-right-size, var(--jetpack--contact-form--border-size));
-	border-bottom-width: var(--jetpack--contact-form--border-bottom-size, var(--jetpack--contact-form--border-size));
+	border-top-width: var(--jetpack--contact-form--border-top-size, var(--jetpack--contact-form--border-size-outline));
+	border-right-width: var(--jetpack--contact-form--border-right-size, var(--jetpack--contact-form--border-size-outline));
+	border-bottom-width: var(--jetpack--contact-form--border-bottom-size, var(--jetpack--contact-form--border-size-outline));
 	border-radius: var(--jetpack--contact-form--border-radius);
 	flex-grow: 1;
 	max-width: 100px;

--- a/projects/packages/forms/src/contact-form/css/grunion.scss
+++ b/projects/packages/forms/src/contact-form/css/grunion.scss
@@ -619,6 +619,10 @@ that needs to mimic the input element styles */
 	flex-direction: row-reverse;
 }
 
+.contact-form .is-style-outlined .grunion-field-wrap:not(.grunion-field-checkbox-wrap):not(.grunion-field-consent-wrap):not(.grunion-field-checkbox-multiple-wrap):not(.grunion-field-radio-wrap):not(.grunion-field-select-wrap):not(.grunion-field-file-wrap), {
+	background-color: var(--jetpack--contact-form--background-color, transparent);
+}
+
 .contact-form .is-style-outlined .grunion-field-wrap .grunion-checkbox-multiple-options,
 .contact-form .is-style-outlined .grunion-field-wrap .grunion-radio-options {
 	padding: var(--jetpack--contact-form--input-padding, 16px);
@@ -677,7 +681,7 @@ that needs to mimic the input element styles */
 	border-right: none !important;
 	border-top-right-radius: unset !important;
 	border-bottom-right-radius: unset !important;
-	background-color: var(--jetpack--contact-form--input-background);
+	background-color: var(--jetpack--contact-form--background-color);
 }
 
 :where(.wp-block-jetpack-contact-form.is-style-outlined) .notched-label__notch {
@@ -690,7 +694,7 @@ that needs to mimic the input element styles */
 	transition: border 150ms linear;
 	border-left: none !important;
 	border-right: none !important;
-	background-color: var(--jetpack--contact-form--input-background);
+	background-color: var(--jetpack--contact-form--background-color);
 }
 
 :where(.wp-block-jetpack-contact-form.is-style-outlined) .notched-label__filler {
@@ -702,7 +706,7 @@ that needs to mimic the input element styles */
 	border-left: none !important;
 	border-right: none !important;
 	border-radius: unset !important;
-	background-color: var(--jetpack--contact-form--input-background);
+	background-color: var(--jetpack--contact-form--background-color);
 }
 
 :where(.wp-block-jetpack-contact-form.is-style-outlined) .notched-label__trailing {
@@ -717,18 +721,18 @@ that needs to mimic the input element styles */
 	border-left: none !important;
 	border-top-left-radius: unset !important;
 	border-bottom-left-radius: unset !important;
-	background-color: var(--jetpack--contact-form--input-background);
+	background-color: var(--jetpack--contact-form--background-color);
 }
 
 /* Preserve the background color for the checkbox multiple and radio
  * wrap when using the old checkbox multiple and radio blocks. */
 .contact-form .is-style-outlined .grunion-field-checkbox-multiple-wrap:not(.wp-block-jetpack-field-checkbox-multiple),
 .contact-form .is-style-outlined .grunion-field-radio-wrap:not(.wp-block-jetpack-field-radio) {
-	background-color: var(--jetpack--contact-form--input-background);
+	background-color: var(--jetpack--contact-form--background-color);
 }
 
 :where(.wp-block-jetpack-contact-form.is-style-outlined) .wp-block-jetpack-options {
-	background-color: var(--jetpack--contact-form--input-background);
+	background-color: var(--jetpack--contact-form--background-color);
 }
 
 
@@ -756,6 +760,7 @@ on production builds, the attributes are being reordered, causing side-effects
 	pointer-events: none;
 	transition: all 150ms cubic-bezier(0.4, 0, 0.2, 1);
 	margin: 0;
+	background-color: transparent;
 }
 
 .contact-form .is-style-outlined .grunion-field-wrap .notched-label .grunion-label-text {
@@ -1063,7 +1068,7 @@ on production builds, the attributes are being reordered, causing side-effects
 	transition: opacity 0.1s ease-in-out, scale 0.15s ease-in-out;
 
 	font-size: inherit;
-	border: solid var(--jetpack--contact-form--inverted-text-color, var(--jetpack--contact-form--input-background));
+	border: solid var(--jetpack--contact-form--background-color);
 	border-width: 0 2px 2px 0;
 	transform: translate(-50%, -60%) rotate(40deg);
 	top: 0;

--- a/projects/packages/forms/src/contact-form/css/grunion.scss
+++ b/projects/packages/forms/src/contact-form/css/grunion.scss
@@ -853,7 +853,7 @@ on production builds, the attributes are being reordered, causing side-effects
 .contact-form .is-style-outlined .grunion-field-wrap select:not(.jetpack-field__input-element) {
 	background: none !important; /* Need to override styles coming from the style attribute*/
 	border-color: transparent !important; /* Need to override styles coming from the style attribute*/
-	color: var(--jetpack--contact-form--body-text-color) !important; /* Need to override styles coming from the style attribute*/
+	color: var(--jetpack--contact-form--body-text-color); /* Need to override styles coming from the style attribute*/
 	border-radius: unset !important; /* Need to override styles coming from the style attribute*/
 	outline: none;
 	padding-left: calc(min(100px, var(--jetpack--contact-form--notch-width)) + 4px);

--- a/projects/packages/forms/src/contact-form/css/grunion.scss
+++ b/projects/packages/forms/src/contact-form/css/grunion.scss
@@ -853,6 +853,7 @@ on production builds, the attributes are being reordered, causing side-effects
 .contact-form .is-style-outlined .grunion-field-wrap select:not(.jetpack-field__input-element) {
 	background: none !important; /* Need to override styles coming from the style attribute*/
 	border-color: transparent !important; /* Need to override styles coming from the style attribute*/
+	color: var(--jetpack--contact-form--body-text-color) !important; /* Need to override styles coming from the style attribute*/
 	border-radius: unset !important; /* Need to override styles coming from the style attribute*/
 	outline: none;
 	padding-left: calc(min(100px, var(--jetpack--contact-form--notch-width)) + 4px);

--- a/projects/packages/forms/src/contact-form/css/phone-field.scss
+++ b/projects/packages/forms/src/contact-form/css/phone-field.scss
@@ -156,6 +156,10 @@
 					font-size: 0.8em;
 				}
 			}
+
+			&:has(~.jetpack-field__input-phone-wrapper.is-combobox-open) .notched-label__label {
+				background-color: var(--jetpack--contact-form--background-color);
+			}
 		}
 
 		.notched-label:has(~* .jetpack-field__input-element:focus) .notched-label__notch,

--- a/projects/packages/forms/src/contact-form/css/phone-field.scss
+++ b/projects/packages/forms/src/contact-form/css/phone-field.scss
@@ -121,8 +121,10 @@
 	.is-style-outlined & {
 
 		.jetpack-field__input-phone-wrapper {
-			z-index: unset;
 			border-color: transparent !important;
+			background-color: transparent !important;
+			border-radius: unset;
+			z-index: 3;
 
 			&:has(.jetpack-field__input-element:focus) {
 				outline: unset;
@@ -134,6 +136,7 @@
 				// while no input element is selected, force transparent so label is visible
 				.jetpack-field__input-element {
 					background-color: transparent !important;
+					box-shadow: none !important;
 				}
 
 				.jetpack-field__input-prefix:not(:has(~ .has-placeholder),:has(~ .has-value)) {

--- a/projects/packages/forms/src/modules/form/view.js
+++ b/projects/packages/forms/src/modules/form/view.js
@@ -562,6 +562,32 @@ const { state, actions } = store( NAMESPACE, {
 	},
 
 	callbacks: {
+		initializeForm() {
+			const { ref } = getElement();
+			const innerDiv = ref.querySelector( '.wp-block-jetpack-contact-form' );
+
+			if ( innerDiv ) {
+				let backgroundColorCss = '';
+				const backgroundColor = window.getComputedStyle( innerDiv ).backgroundColor;
+				if (
+					! (
+						! backgroundColor ||
+						backgroundColor === 'rgba(0, 0, 0, 0)' ||
+						backgroundColor === 'transparent'
+					)
+				) {
+					backgroundColorCss = `--jetpack--contact-form--background-color: ${ backgroundColor }`;
+				}
+				const bodyTextColor = window.getComputedStyle( innerDiv ).color;
+				const style = innerDiv.getAttribute( 'style' ) ?? '';
+				innerDiv.setAttribute(
+					'style',
+					style +
+						`; ${ backgroundColorCss }; --jetpack--contact-form--body-text-color: ${ bodyTextColor };`
+				);
+			}
+		},
+
 		initializeField() {
 			const context = getContext();
 			const { fieldId, fieldType, fieldLabel, fieldValue, fieldIsRequired, fieldExtra } = context;

--- a/projects/plugins/jetpack/changelog/fix-darktheme-outline-form
+++ b/projects/plugins/jetpack/changelog/fix-darktheme-outline-form
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Forms: Improve dark theme vomatibility and outline form style


### PR DESCRIPTION
Related to FORMS-299

This PR addresses some of the default behaviour of outline forms. To make them work more like expected. 

## Proposed changes:
* It implements the form input to match the background colour of the form. This works even when the form adds a custom colour for the whole form.
* It make sure that there is a border that is applied to the outline form. If the theme doesn't set one for the input fields.
* It adds a default color for the input field. that matches the body text colour. So that form inputs be default are readable. 
* It fixes the checkboxes input to work 

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
This PR is related to https://github.com/Automattic/jetpack/pull/45866 
When I was working on https://github.com/Automattic/jetpack/pull/45866 I noticed that the outline form doesn't quite work as expected. 
The solution was getting to complex so I decided to create a new PR for the outline form to make it work more like it should work. 

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
You will need a few different variations of the outline form. 
All on the same page. 
Create a default one. 
Create one with plate colors that are coming from the form. 
Create one with custom colors that are coming from the form. 
Create one with palate colors coming from the input fields. 
Create one with custom colors coming from the input fields. 

Add the following inputs. 
Default inputs. ( text, email, name, textare )
Phone field with and without international fields. 
Image selection. 
Single Checkboxes. Consent and regular checkboxs.
Radio buttons. 
file upload

switch between different themes. ( not that the palate color might produce unreadable results) go to the editor and make sure that in the editor you see the same "unreadable error". 


