### PR TITLE
Forms: add examples for first/last name field variations

### DIFF
--- a/projects/packages/forms/changelog/update-form-name-variations-example
+++ b/projects/packages/forms/changelog/update-form-name-variations-example
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Forms: add examples for first/last name field variations

--- a/projects/packages/forms/src/blocks/field-name/variations.js
+++ b/projects/packages/forms/src/blocks/field-name/variations.js
@@ -46,6 +46,22 @@ const variations = [
 			[ 'jetpack/label', { label: DEFAULT_FIRST_NAME_LABEL } ],
 			[ 'jetpack/input', { type: 'text' } ],
 		],
+		example: {
+			innerBlocks: [
+				{
+					name: 'jetpack/label',
+					attributes: {
+						label: DEFAULT_FIRST_NAME_LABEL,
+					},
+				},
+				{
+					name: 'jetpack/input',
+					attributes: {
+						type: 'text',
+					},
+				},
+			],
+		},
 	},
 	{
 		name: LAST_NAME_ID,
@@ -61,6 +77,22 @@ const variations = [
 			[ 'jetpack/label', { label: DEFAULT_LAST_NAME_LABEL } ],
 			[ 'jetpack/input', { type: 'text' } ],
 		],
+		example: {
+			innerBlocks: [
+				{
+					name: 'jetpack/label',
+					attributes: {
+						label: DEFAULT_LAST_NAME_LABEL,
+					},
+				},
+				{
+					name: 'jetpack/input',
+					attributes: {
+						type: 'text',
+					},
+				},
+			],
+		},
 	},
 ];
 

--- a/projects/packages/forms/src/blocks/field-name/variations.js
+++ b/projects/packages/forms/src/blocks/field-name/variations.js
@@ -24,6 +24,7 @@ const variations = [
 		description: __( 'Collect the visitor’s name.', 'jetpack-forms' ),
 		icon,
 		scope: [ 'transform' ],
+		isActive: ( { id } ) => ! [ FIRST_NAME_ID, LAST_NAME_ID ].includes( id ),
 		attributes: {
 			id: '',
 		},


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Follow-up to FORMS-293

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds examples for first/last name variations
* Add "active" logic for "name" variation

### Before

No dot showing active variation for name:
<img width="1017" height="406" alt="Screenshot 2025-11-18 at 22 43 11" src="https://github.com/user-attachments/assets/b9723f7b-128a-46c9-8b28-5e709d5ea546" />

"Name" preview for "first name" variation:
<img width="663" height="272" alt="Screenshot 2025-11-18 at 22 41 40" src="https://github.com/user-attachments/assets/bade27a9-7394-4a4f-8fbc-0fb86ebdc9cb" />

### After

<img width="290" height="351" alt="Screenshot 2025-11-18 at 22 42 13" src="https://github.com/user-attachments/assets/77ef8e7d-8f97-412b-8622-1d11de38be35" />

<img width="668" height="276" alt="Screenshot 2025-11-18 at 22 39 47" src="https://github.com/user-attachments/assets/e53356a4-a53f-49dc-9717-90a952858c3b" />

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Find last/first name variations via block picker and check their previews match
* Select name field, switch variation from sidebar; see how dot changes correctly to right variation as you switch

