### PR TITLE
Tooling: Run Phan against Woo versions

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -589,3 +589,35 @@ jobs:
             gh api "/repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/reviews" -X POST --input - <<<"$REQ"
             exit 1
           fi
+
+  phan-woocommerce:
+    name: Static analysis (old WooCommerce)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20 # 2024-05-02: Takes about 5 minutes.
+    steps:
+      - uses: actions/checkout@v5
+      - name: Setup tools
+        uses: ./.github/actions/tool-setup
+      - name: Pnpm install
+        run: pnpm install
+      - name: Add back removed packages in case of a release branch.
+        run: |
+          echo "Checking for non-mirrored require-dev packages, in case this is testing a release branch"
+          for FILE in projects/*/*/composer.json; do
+            PKGS=()
+            readarray -t PKGS < <( jq -r '.extra["non-mirrored-require-dev"] // empty | .[] | . += "=@dev"' "$FILE" )
+            if [[ ${#PKGS[@]} -gt 0 ]]; then
+              echo "::group::Adding packages for $FILE: ${PKGS[*]}"
+              # Make sure monorepo repositories entry is present.
+              JSON=$( jq --tab '.repositories //= [] | if any( .repositories[]; .type == "path" and ( .url | startswith( "../" ) ) and .options?.monorepo? ) then . else .repositories += [ { type: "path", url: "../../packages/*", options: { monorepo: true } } ] end' "$FILE" )
+              echo "$JSON" > "$FILE"
+              composer require --working-dir="${FILE%/composer.json}" --dev "${PKGS[@]}"
+              echo "::endgroup::"
+            fi
+          done
+      - name: Run Phan against WooCommerce 7.0 stubs
+        env:
+          WOO_VERSION: '7.0'
+        run: |
+          composer require --dev "php-stubs/woocommerce-stubs:${WOO_VERSION}"
+          pnpm jetpack phan --all -v --format github

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -543,7 +543,7 @@ jobs:
           exit 1
 
   phan-woocommerce:
-    name: Static analysis (WooCommerce)
+    name: Static analysis (old WooCommerce)
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -573,9 +573,3 @@ jobs:
         run: |
           composer require --dev "php-stubs/woocommerce-stubs:${WOO_VERSION}"
           pnpm jetpack phan --all -v --format github
-      - name: Run Phan against WooCommerce 7.0 stubs
-        env:
-          WOO_VERSION: '10.*'
-        run: |
-          composer require --dev "php-stubs/woocommerce-stubs:${WOO_VERSION}"
-          pnpm jetpack phan --all -v --format github

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -541,3 +541,41 @@ jobs:
             echo "::error::Phan baselines have changed (good job!). Run \`jetpack phan --update-baseline ${PROJECTS[*]}\` to update them."
           fi
           exit 1
+
+  phan-woocommerce:
+    name: Static analysis (WooCommerce)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v5
+      - name: Setup tools
+        uses: ./.github/actions/tool-setup
+      - name: Pnpm install
+        run: pnpm install
+      - name: Add back removed packages in case of a release branch.
+        run: |
+          echo "Checking for non-mirrored require-dev packages, in case this is testing a release branch"
+          for FILE in projects/*/*/composer.json; do
+            PKGS=()
+            readarray -t PKGS < <( jq -r '.extra["non-mirrored-require-dev"] // empty | .[] | . += "=@dev"' "$FILE" )
+            if [[ ${#PKGS[@]} -gt 0 ]]; then
+              echo "::group::Adding packages for $FILE: ${PKGS[*]}"
+              # Make sure monorepo repositories entry is present.
+              JSON=$( jq --tab '.repositories //= [] | if any( .repositories[]; .type == "path" and ( .url | startswith( "../" ) ) and .options?.monorepo? ) then . else .repositories += [ { type: "path", url: "../../packages/*", options: { monorepo: true } } ] end' "$FILE" )
+              echo "$JSON" > "$FILE"
+              composer require --working-dir="${FILE%/composer.json}" --dev "${PKGS[@]}"
+              echo "::endgroup::"
+            fi
+          done
+      - name: Run Phan against WooCommerce 7.0 stubs
+        env:
+          WOO_VERSION: '7.0'
+        run: |
+          composer require --dev "php-stubs/woocommerce-stubs:${WOO_VERSION}"
+          pnpm jetpack phan --all -v --format github
+      - name: Run Phan against WooCommerce 7.0 stubs
+        env:
+          WOO_VERSION: '10.*'
+        run: |
+          composer require --dev "php-stubs/woocommerce-stubs:${WOO_VERSION}"
+          pnpm jetpack phan --all -v --format github

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -541,35 +541,3 @@ jobs:
             echo "::error::Phan baselines have changed (good job!). Run \`jetpack phan --update-baseline ${PROJECTS[*]}\` to update them."
           fi
           exit 1
-
-  phan-woocommerce:
-    name: Static analysis (old WooCommerce)
-    runs-on: ubuntu-latest
-    timeout-minutes: 20
-    steps:
-      - uses: actions/checkout@v5
-      - name: Setup tools
-        uses: ./.github/actions/tool-setup
-      - name: Pnpm install
-        run: pnpm install
-      - name: Add back removed packages in case of a release branch.
-        run: |
-          echo "Checking for non-mirrored require-dev packages, in case this is testing a release branch"
-          for FILE in projects/*/*/composer.json; do
-            PKGS=()
-            readarray -t PKGS < <( jq -r '.extra["non-mirrored-require-dev"] // empty | .[] | . += "=@dev"' "$FILE" )
-            if [[ ${#PKGS[@]} -gt 0 ]]; then
-              echo "::group::Adding packages for $FILE: ${PKGS[*]}"
-              # Make sure monorepo repositories entry is present.
-              JSON=$( jq --tab '.repositories //= [] | if any( .repositories[]; .type == "path" and ( .url | startswith( "../" ) ) and .options?.monorepo? ) then . else .repositories += [ { type: "path", url: "../../packages/*", options: { monorepo: true } } ] end' "$FILE" )
-              echo "$JSON" > "$FILE"
-              composer require --working-dir="${FILE%/composer.json}" --dev "${PKGS[@]}"
-              echo "::endgroup::"
-            fi
-          done
-      - name: Run Phan against WooCommerce 7.0 stubs
-        env:
-          WOO_VERSION: '7.0'
-        run: |
-          composer require --dev "php-stubs/woocommerce-stubs:${WOO_VERSION}"
-          pnpm jetpack phan --all -v --format github


### PR DESCRIPTION
Closes MONOREP-232

 <!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR runs Phan against older Woo stubs. I've put the new test in the linting workflow (now that said workflow runs on `trunk` as well).

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

We've had a few cases where Jetpack releases have unleashed some fatals because an assumption that users ran fairly recent WooCommerce versions.

p1759248959778399/1759158780.923629-slack-CK365S85V
p1763478353571209/1763474992.105219-slack-CK365S85V
p1759758846239149/1759158780.923629-slack-CK365S85V

If there's a need we could consider generating new `woocommerce-internal` stubs, but that'd be for another PR should we want.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Hopefully there's a new "Static analysis (WooCommerce)" job in the CI that completes successfully.