### PR TITLE
Jetpack: Remove branding block icon colour

### DIFF
--- a/projects/js-packages/shared-extension-utils/changelog/update-branding-icon-colour
+++ b/projects/js-packages/shared-extension-utils/changelog/update-branding-icon-colour
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Jetpack: Remove block icon color

--- a/projects/js-packages/shared-extension-utils/src/block-icons.js
+++ b/projects/js-packages/shared-extension-utils/src/block-icons.js
@@ -1,25 +1,10 @@
-import colorStudio from '@automattic/color-studio';
-import { isWpcomPlatformSite } from '@automattic/jetpack-script-data';
-
-/**
- * Constants
- */
-const PALETTE = colorStudio.colors;
-const COLOR_JETPACK = PALETTE[ 'Jetpack Green 40' ];
-
 /**
  * Returns the icon color for Jetpack blocks.
  *
  * Green in the Jetpack context, otherwise black for Simple sites or Atomic sites.
  *
- * @return {string} HEX color for block editor icons
+ * @return {null} HEX color for block editor icons
  */
 export function getIconColor() {
-	if ( isWpcomPlatformSite() ) {
-		// Return null to match core block styling
-		return null;
-	}
-
-	// Jetpack Green
-	return COLOR_JETPACK;
+	return null;
 }

--- a/projects/js-packages/shared-extension-utils/src/get-icon-color.js
+++ b/projects/js-packages/shared-extension-utils/src/get-icon-color.js
@@ -1,23 +1,10 @@
-import { isWpcomPlatformSite } from '@automattic/jetpack-script-data';
-
-/**
- * Constants
- */
-const JETPACK_GREEN_40 = '#069e08';
-
 /**
  * Returns the icon color for Jetpack blocks.
  *
  * Green in the Jetpack context, otherwise black for Simple sites or Atomic sites.
  *
- * @return {string} HEX color for block editor icons
+ * @return {null} HEX color for block editor icons
  */
 export default function getIconColor() {
-	if ( isWpcomPlatformSite() ) {
-		// Return null to match core block styling
-		return null;
-	}
-
-	// Jetpack Green
-	return JETPACK_GREEN_40;
+	return null;
 }

--- a/projects/packages/forms/changelog/update-branding-icon-colour
+++ b/projects/packages/forms/changelog/update-branding-icon-colour
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Jetpack: Remove block icon color

--- a/projects/packages/forms/src/blocks/shared/util/block-icons.js
+++ b/projects/packages/forms/src/blocks/shared/util/block-icons.js
@@ -1,25 +1,10 @@
-import colorStudio from '@automattic/color-studio';
-import { isWpcomPlatformSite } from '@automattic/jetpack-script-data';
-
-/**
- * Constants
- */
-const PALETTE = colorStudio.colors;
-const COLOR_JETPACK = PALETTE[ 'Jetpack Green 40' ];
-
 /**
  * Returns the icon color for Jetpack blocks.
  *
  * Green in the Jetpack context, otherwise black for Simple sites or Atomic sites.
  *
- * @return {string} HEX color for block editor icons
+ * @return {null} HEX color for block editor icons
  */
 export function getIconColor() {
-	if ( isWpcomPlatformSite() ) {
-		// Return null to match core block styling
-		return null;
-	}
-
-	// Jetpack Green
-	return COLOR_JETPACK;
+	return null;
 }

--- a/projects/plugins/backup/changelog/update-branding-icon-colour
+++ b/projects/plugins/backup/changelog/update-branding-icon-colour
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Jetpack: Remove block icon color

--- a/projects/plugins/boost/changelog/update-branding-icon-colour
+++ b/projects/plugins/boost/changelog/update-branding-icon-colour
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Jetpack: Remove block icon color

--- a/projects/plugins/classic-theme-helper-plugin/changelog/update-branding-icon-colour
+++ b/projects/plugins/classic-theme-helper-plugin/changelog/update-branding-icon-colour
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Jetpack: Remove block icon color

--- a/projects/plugins/crm/changelog/update-branding-icon-colour
+++ b/projects/plugins/crm/changelog/update-branding-icon-colour
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Jetpack: Remove block icon color

--- a/projects/plugins/jetpack/changelog/update-branding-icon-colour
+++ b/projects/plugins/jetpack/changelog/update-branding-icon-colour
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Jetpack: Remove block icon color

--- a/projects/plugins/mu-wpcom-plugin/changelog/update-branding-icon-colour
+++ b/projects/plugins/mu-wpcom-plugin/changelog/update-branding-icon-colour
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Jetpack: Remove block icon color

--- a/projects/plugins/paypal-payment-buttons/changelog/update-branding-icon-colour
+++ b/projects/plugins/paypal-payment-buttons/changelog/update-branding-icon-colour
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Jetpack: Remove block icon color

--- a/projects/plugins/protect/changelog/update-branding-icon-colour
+++ b/projects/plugins/protect/changelog/update-branding-icon-colour
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Jetpack: Remove block icon color

--- a/projects/plugins/search/changelog/update-branding-icon-colour
+++ b/projects/plugins/search/changelog/update-branding-icon-colour
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Jetpack: Remove block icon color

--- a/projects/plugins/social/changelog/update-branding-icon-colour
+++ b/projects/plugins/social/changelog/update-branding-icon-colour
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Jetpack: Remove block icon color

--- a/projects/plugins/starter-plugin/changelog/update-branding-icon-colour
+++ b/projects/plugins/starter-plugin/changelog/update-branding-icon-colour
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Jetpack: Remove block icon color

--- a/projects/plugins/videopress/changelog/update-branding-icon-colour
+++ b/projects/plugins/videopress/changelog/update-branding-icon-colour
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Jetpack: Remove block icon color

--- a/projects/plugins/wpcomsh/changelog/update-branding-icon-colour
+++ b/projects/plugins/wpcomsh/changelog/update-branding-icon-colour
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Jetpack: Remove block icon color


### PR DESCRIPTION

Part of FORMS-265 (CIAB sites)

Product convo for WP.com and Jetpack p1763050188308419-slack-C029GN3KD

Currently all the jetpack block icon are colour with the jetpack green brand colour. There is an expection for the .com platform where we treat them as plain block. 

This PR make all the jetpack block be the default block colour. We do this to simplify things. 

Before:
<img width="376" height="1032" alt="Screenshot 2025-11-18 at 2 02 23 PM" src="https://github.com/user-attachments/assets/4726670f-d971-4be1-a2f0-39fec18a08eb" />

After:
<img width="358" height="1028" alt="Screenshot 2025-11-18 at 2 02 03 PM" src="https://github.com/user-attachments/assets/6e611c1a-3129-489f-9726-2f0bcd5e32fb" />


## Proposed changes:
* All the getIconColor functions should return null. 
* We don't remove all the instances of the getIconColor call since if we want to add this functionality back we want have it still there. 

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Open up the editor. 
Notice that all the jetpack blocks icons are the same as the default icon color. 
