### PR TITLE
WooCommerce Analytics: Add backwards compatibility for add_request_timestamp_and_nocache()

### DIFF
--- a/projects/packages/woocommerce-analytics/changelog/fix-wc-analytics-add-request-timestamp-compatibility
+++ b/projects/packages/woocommerce-analytics/changelog/fix-wc-analytics-add-request-timestamp-compatibility
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix compatibility issue with WooCommerce older than 9.7.0

--- a/projects/packages/woocommerce-analytics/src/class-wc-analytics-tracking.php
+++ b/projects/packages/woocommerce-analytics/src/class-wc-analytics-tracking.php
@@ -229,7 +229,14 @@ class WC_Analytics_Tracking extends WC_Tracks {
 		// Add request timestamp and nocache to all pixels.
 		$pixels_to_send = array();
 		foreach ( self::$pixel_batch_queue as $pixel ) {
-			$pixels_to_send[] = WC_Tracks_Client::add_request_timestamp_and_nocache( $pixel );
+			// Check if the method exists for backwards compatibility with older WooCommerce versions.
+			if ( method_exists( WC_Tracks_Client::class, 'add_request_timestamp_and_nocache' ) ) {
+				$pixels_to_send[] = WC_Tracks_Client::add_request_timestamp_and_nocache( $pixel );
+			} else {
+				// Fallback for older versions - add timestamp and nocache parameters manually.
+				// Remove this fallback when WooCommerce minimum version is 9.7.0+.
+				$pixels_to_send[] = $pixel . '&_rt=' . WC_Tracks_Client::build_timestamp() . '&_=_';
+			}
 		}
 
 		// Send with Requests library for true parallel batching.


### PR DESCRIPTION
Fixes p1763474992105219-slack-CK365S85V

## Proposed changes:
* Add backwards compatibility check for `WC_Tracks_Client::add_request_timestamp_and_nocache()` method which was introduced in WooCommerce 9.7.0
* When the method exists (WooCommerce 9.7.0+), uses the native implementation
* When the method doesn't exist (older WooCommerce versions), falls back to manually appending timestamp and nocache parameters (`&_rt={timestamp}&_=_`) to replicate the exact same behavior
* Prevents fatal error: `Call to undefined method WC_Tracks_Client::add_request_timestamp_and_nocache()`

### Other information:

- [x] Have you written new tests for your changes, if applicable? N/A - This is a backwards compatibility fix with no functional changes
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
N/A - Backwards compatibility fix

## Does this pull request change what data or activity we track or use?
No - This maintains identical tracking behavior across WooCommerce versions

## Testing instructions:

### Setup
1. Install WooCommerce version < 9.7.0 (e.g., 9.6.0 or earlier)
2. Install Jetpack with this branch
3. Enable WooCommerce Analytics

### Testing
1. Navigate to any WooCommerce page that triggers analytics tracking (e.g., product page, cart, checkout)
2. Verify no fatal errors occur
3. Check browser network tab and confirm tracking pixels are being sent with `_rt` and `_` parameters
4. Upgrade to WooCommerce 9.7.0+
5. Verify tracking still works correctly with the native method

### Expected behavior
* No fatal errors on older WooCommerce versions
* Tracking pixels include timestamp and nocache parameters regardless of WooCommerce version
* Identical tracking behavior across all WooCommerce versions