### PR TITLE
Update expiring renewal prompt to show all included products

### DIFF
--- a/projects/packages/my-jetpack/changelog/fix-expiring-prompt-bundle-products
+++ b/projects/packages/my-jetpack/changelog/fix-expiring-prompt-bundle-products
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+My Jetpack: Fix expiring renewal prompt to show all products

--- a/projects/packages/my-jetpack/src/class-red-bubble-notifications.php
+++ b/projects/packages/my-jetpack/src/class-red-bubble-notifications.php
@@ -268,6 +268,7 @@ class Red_Bubble_Notifications {
 							if ( $bundle_product::is_bundle_product() &&
 								$bundle_product::has_paid_plan_for_product() &&
 								! $bundle_product::is_paid_plan_expired() &&
+								! $bundle_product::is_paid_plan_expiring() &&
 								method_exists( $bundle_product, 'get_supported_products' ) &&
 								in_array( $key, $bundle_product::get_supported_products(), true ) ) {
 								$is_covered_by_active_bundle = true;

--- a/projects/plugins/backup/changelog/fix-expiring-prompt-bundle-products
+++ b/projects/plugins/backup/changelog/fix-expiring-prompt-bundle-products
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+My Jetpack: Fix expiring renewal prompt to show all products

--- a/projects/plugins/boost/changelog/fix-expiring-prompt-bundle-products
+++ b/projects/plugins/boost/changelog/fix-expiring-prompt-bundle-products
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+My Jetpack: Fix expiring renewal prompt to show all products

--- a/projects/plugins/jetpack/changelog/fix-expiring-prompt-bundle-products
+++ b/projects/plugins/jetpack/changelog/fix-expiring-prompt-bundle-products
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+My Jetpack: Fix expiring renewal prompt to show all products

--- a/projects/plugins/protect/changelog/fix-expiring-prompt-bundle-products
+++ b/projects/plugins/protect/changelog/fix-expiring-prompt-bundle-products
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+My Jetpack: Fix expiring renewal prompt to show all products

--- a/projects/plugins/search/changelog/fix-expiring-prompt-bundle-products
+++ b/projects/plugins/search/changelog/fix-expiring-prompt-bundle-products
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+My Jetpack: Fix expiring renewal prompt to show all products

--- a/projects/plugins/social/changelog/fix-expiring-prompt-bundle-products
+++ b/projects/plugins/social/changelog/fix-expiring-prompt-bundle-products
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+My Jetpack: Fix expiring renewal prompt to show all products

--- a/projects/plugins/starter-plugin/changelog/fix-expiring-prompt-bundle-products
+++ b/projects/plugins/starter-plugin/changelog/fix-expiring-prompt-bundle-products
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+My Jetpack: Fix expiring renewal prompt to show all products

--- a/projects/plugins/videopress/changelog/fix-expiring-prompt-bundle-products
+++ b/projects/plugins/videopress/changelog/fix-expiring-prompt-bundle-products
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+My Jetpack: Fix expiring renewal prompt to show all products


### PR DESCRIPTION
Fixes MYJP-267

## Proposed changes:
The impacted products were not correctly listed when the plan was expiring, and they were correctly listed when plan was already expired:
<img width="2200" height="782" alt="claude-2" src="https://github.com/user-attachments/assets/461785b5-2392-49e4-9cb5-810d96fc2904" />
<img width="2272" height="676" alt="claude-3" src="https://github.com/user-attachments/assets/e531fc20-92a4-462c-ab12-d5557cb0d024" />

That was due to a bug in the condition for finding the parent bundle for the product.
This was fixed by updating the condition to also cover the case the plan is being expired, but not yet expired.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

## Does this pull request change what data or activity we track or use?

## Testing instructions:
1. Start the Jurassic Ninja site with this branch
2. Connect site and yourself to Jetpack
3. Go to SA and add yourself the Jetpack Complete plan, that is set to expire within couple of days
4. Go to My Jetpack, and you should be able to see the prompt with correctly listed impacted products:
<img width="2266" height="692" alt="CleanShot 2025-11-19 at 17 02 19@2x" src="https://github.com/user-attachments/assets/cc69e67a-0518-4b80-aea8-4607102d7de2" />

