### PR TITLE
jetpack-mu-wpcom Code Block: Fix filename render typo

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/code-block-fixes
+++ b/projects/packages/jetpack-mu-wpcom/changelog/code-block-fixes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Unreleased code block: General fixes and improvements.

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/class-code-block.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/class-code-block.php
@@ -423,7 +423,7 @@ abstract class Code_Block {
 
 		$attrs = get_block_wrapper_attributes( $extra_attrs );
 
-		$filename_html = ( ( $attributes['showCopyButton'] ?? false ) && ! empty( $attributes['filename'] ) )
+		$filename_html = ( ( $attributes['showFileName'] ?? false ) && ! empty( $attributes['filename'] ) )
 			? \sprintf( '<span class="a8c/code__filename">%s</span>', esc_html( $attributes['filename'] ) )
 			: '';
 


### PR DESCRIPTION


## Proposed changes:

- Fix a bug where the wrong variable was used to display the filename rendered on the frontend.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?


## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:

