### PR TITLE
Forms: protect against invalid attrs

### DIFF
--- a/projects/packages/forms/changelog/update-forms-protect-against-invalid-attrs
+++ b/projects/packages/forms/changelog/update-forms-protect-against-invalid-attrs
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Forms: protect against invalid attrs when merging new values

--- a/projects/packages/forms/src/contact-form/class-util.php
+++ b/projects/packages/forms/src/contact-form/class-util.php
@@ -412,6 +412,10 @@ class Util {
 					);
 				}
 				$attrs = json_decode( rtrim( $match['attrs'], ' ' ), true );
+				// Ensure $attrs is an array before merging (json_decode can return null on invalid JSON).
+				if ( ! is_array( $attrs ) ) {
+					$attrs = array();
+				}
 				$attrs = array_merge( $attrs, $new_attr );
 				return str_replace(
 					$match['attrs'],


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Reported at p1763554432894829-slack-CDLH4C1UZ

`json_decode()` can return null if the JSON is invalid, and then `array_merge()` is called with null, causing the error.

Full error:


`PHP Fatal error: Uncaught TypeError: array_merge(): Argument #1 must be of type array, null given in /wordpress/plugins/jetpack/15.3-a.5/jetpack_vendor/automattic/jetpack-forms/src/contact-form/class-util.php:415 Stack trace: #0 /wordpress/plugins/jetpack/15.3-a.5/jetpack_vendor/automattic/jetpack-forms/src/contact-form/class-util.php(415): array_merge(NULL, Array) #1 [internal function]: Automattic\Jetpack\Forms\ContactForm\Util::Automattic\Jetpack\Forms\ContactForm\{closure}(Array) #2 /wordpress/plugins/jetpack/15.3-a.5/jetpack_vendor/automattic/jetpack-forms/src/contact-form/class-util.php(399): preg_replace_callback('/<!--\\s+(?P<clo...', Object(Closure), '\n<div class="wp...') #3 /wordpress/plugins/jetpack/15.3-a.5/jetpack_vendor/automattic/jetpack-forms/src/contact-form/class-util.php(180): Automattic\Jetpack\Forms\ContactForm\Util::grunion_contact_form_apply_block_attribute('\n<div class="wp...', Array) #4 /wordpress/core/6.8.3/wp-includes/class-wp-hook.php(324): Automattic\Jetpack\Forms\ContactForm\Util::grunion_contact_form_set_block_template_attribute('/wordpress/core...') #5 /wordpress/core/6.8.3/wp-includes/plugin.php(205): WP_Hook->apply_filters('/wordpress/core...', Array) #6 /wordpress/core/6.8.3/wp-includes/template-loader.php(104): apply_filters('template_includ...', '/wordpress/core...') #7 /wordpress/core/6.8.3/wp-blog-header.php(19): require_once('/wordpress/core...') #8 /wordpress/core/6.8.3/index.php(17): require('/wordpress/core...') #9 {main} thrown in /wordpress/plugins/jetpack/15.3-a.5/jetpack_vendor/automattic/jetpack-forms/src/contact-form/class-util.php on line 415`



## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add a small defence against malfunctioning attr JSON. Ensures `json_decode()` returns an array before merging. If it's null or not an array, treat it as an empty array.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Not sure :-)