### PR TITLE
Phan: Address issues discovered while testing against old WooCommerce stubs

### DIFF
--- a/projects/packages/sync/changelog/fix-phan-issues_in_old_woo
+++ b/projects/packages/sync/changelog/fix-phan-issues_in_old_woo
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Improve compatibility with old WooCommerce versions.

--- a/projects/packages/sync/src/modules/class-woocommerce-products.php
+++ b/projects/packages/sync/src/modules/class-woocommerce-products.php
@@ -445,7 +445,8 @@ class WooCommerce_Products extends Module {
 	 * @return array
 	 */
 	private function get_product_cogs_data( $ids, $order = '' ) {
-		$is_cogs_enabled = class_exists( '\Automattic\WooCommerce\Utilities\FeaturesUtil' ) && \Automattic\WooCommerce\Utilities\FeaturesUtil::feature_is_enabled( 'cost_of_goods_sold' );
+		// @phan-suppress-next-line PhanUndeclaredClassReference, PhanUndeclaredClassMethod -- we're checking for the class and method before using them.
+		$is_cogs_enabled = class_exists( '\Automattic\WooCommerce\Utilities\FeaturesUtil' ) && method_exists( '\Automattic\WooCommerce\Utilities\FeaturesUtil', 'feature_is_enabled' ) && \Automattic\WooCommerce\Utilities\FeaturesUtil::feature_is_enabled( 'cost_of_goods_sold' );
 
 		if ( ! $is_cogs_enabled ) {
 			return array();

--- a/projects/packages/sync/src/modules/class-woocommerce-products.php
+++ b/projects/packages/sync/src/modules/class-woocommerce-products.php
@@ -445,7 +445,7 @@ class WooCommerce_Products extends Module {
 	 * @return array
 	 */
 	private function get_product_cogs_data( $ids, $order = '' ) {
-		// @phan-suppress-next-line PhanUndeclaredClassReference, PhanUndeclaredClassMethod -- we're checking for the class and method before using them.
+		// @phan-suppress-current-line UnusedPluginSuppression @phan-suppress-next-line PhanUndeclaredClassReference, PhanUndeclaredClassMethod -- we're checking for the class and method before using them. See also: https://github.com/phan/phan/issues/1204
 		$is_cogs_enabled = class_exists( '\Automattic\WooCommerce\Utilities\FeaturesUtil' ) && method_exists( '\Automattic\WooCommerce\Utilities\FeaturesUtil', 'feature_is_enabled' ) && \Automattic\WooCommerce\Utilities\FeaturesUtil::feature_is_enabled( 'cost_of_goods_sold' );
 
 		if ( ! $is_cogs_enabled ) {

--- a/projects/packages/sync/src/modules/class-woocommerce-products.php
+++ b/projects/packages/sync/src/modules/class-woocommerce-products.php
@@ -7,7 +7,6 @@
 
 namespace Automattic\Jetpack\Sync\Modules;
 
-use Automattic\WooCommerce\Enums\ProductType;
 use DateTimeZone;
 use WC_DateTime;
 use WP_Error;
@@ -292,10 +291,12 @@ class WooCommerce_Products extends Module {
 			);
 
 			$post_type = $post->post_type;
+			// ProductType::VARIATION and ProductType::SIMPLE have only existed since WooCommerce 9.7, so
+			// we can't rely on that existing, but using the strings is probably safe enough.
 			if ( 'product_variation' === $post_type ) {
-				$product_type = ProductType::VARIATION;
+				$product_type = 'variation';
 			} elseif ( 'product' === $post_type ) {
-				$product_type = $product_types[ $post->ID ] ?? ProductType::SIMPLE;
+				$product_type = $product_types[ $post->ID ] ?? 'simple';
 			} else {
 				$product_type = null;
 			}

--- a/projects/packages/sync/src/modules/class-woocommerce-products.php
+++ b/projects/packages/sync/src/modules/class-woocommerce-products.php
@@ -445,8 +445,8 @@ class WooCommerce_Products extends Module {
 	 * @return array
 	 */
 	private function get_product_cogs_data( $ids, $order = '' ) {
-		// @phan-suppress-current-line UnusedPluginSuppression @phan-suppress-next-line PhanUndeclaredClassReference, PhanUndeclaredClassMethod -- we're checking for the class and method before using them. See also: https://github.com/phan/phan/issues/1204
-		$is_cogs_enabled = class_exists( '\Automattic\WooCommerce\Utilities\FeaturesUtil' ) && method_exists( '\Automattic\WooCommerce\Utilities\FeaturesUtil', 'feature_is_enabled' ) && \Automattic\WooCommerce\Utilities\FeaturesUtil::feature_is_enabled( 'cost_of_goods_sold' );
+		// @phan-suppress-current-line UnusedPluginSuppression @phan-suppress-next-line PhanUndeclaredClassMethod -- we're checking for the class (around since WooCommerce 7.1) before calling the method (introduced as part of the original class). See also: https://github.com/phan/phan/issues/1204
+		$is_cogs_enabled = class_exists( '\Automattic\WooCommerce\Utilities\FeaturesUtil' ) && \Automattic\WooCommerce\Utilities\FeaturesUtil::feature_is_enabled( 'cost_of_goods_sold' );
 
 		if ( ! $is_cogs_enabled ) {
 			return array();

--- a/projects/packages/woocommerce-analytics/changelog/fix-phan-issues_in_old_woo
+++ b/projects/packages/woocommerce-analytics/changelog/fix-phan-issues_in_old_woo
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Improve compatibility with old WooCommerce versions.

--- a/projects/packages/woocommerce-analytics/src/class-wc-analytics-tracking.php
+++ b/projects/packages/woocommerce-analytics/src/class-wc-analytics-tracking.php
@@ -231,7 +231,7 @@ class WC_Analytics_Tracking extends WC_Tracks {
 		foreach ( self::$pixel_batch_queue as $pixel ) {
 			// Check if the method exists for backwards compatibility with older WooCommerce versions.
 			if ( method_exists( WC_Tracks_Client::class, 'add_request_timestamp_and_nocache' ) ) {
-				// @phan-suppress-next-line PhanUndeclaredStaticMethod -- We verify the method exists before using it.
+				// @phan-suppress-current-line UnusedPluginSuppression @phan-suppress-next-line PhanUndeclaredStaticMethod -- We verify the method exists before using it. See also: https://github.com/phan/phan/issues/1204
 				$pixels_to_send[] = WC_Tracks_Client::add_request_timestamp_and_nocache( $pixel );
 			} else {
 				// Fallback for older versions - add timestamp and nocache parameters manually.
@@ -388,7 +388,7 @@ class WC_Analytics_Tracking extends WC_Tracks {
 			$data = parent::get_server_details();
 		} elseif ( method_exists( WC_Site_Tracking::class, 'get_server_details' ) ) {
 			// WC < 6.8
-			$data = WC_Site_Tracking::get_server_details(); // @phan-suppress-current-line PhanUndeclaredStaticMethod -- method is available in WC < 6.8
+			$data = WC_Site_Tracking::get_server_details(); // @phan-suppress-current-line PhanUndeclaredStaticMethod -- method is available in WC < 6.8. See also: https://github.com/phan/phan/issues/1204
 		}
 
 		return array_merge(
@@ -414,7 +414,7 @@ class WC_Analytics_Tracking extends WC_Tracks {
 			return parent::get_blog_details( $blog_id );
 		} elseif ( method_exists( WC_Site_Tracking::class, 'get_blog_details' ) ) {
 			// WC < 6.8
-			return WC_Site_Tracking::get_blog_details( $blog_id ); // @phan-suppress-current-line PhanUndeclaredStaticMethod -- method is available in WC < 6.8
+			return WC_Site_Tracking::get_blog_details( $blog_id ); // @phan-suppress-current-line PhanUndeclaredStaticMethod -- method is available in WC < 6.8. See also: https://github.com/phan/phan/issues/1204
 		}
 		return array();
 	}

--- a/projects/packages/woocommerce-analytics/src/class-wc-analytics-tracking.php
+++ b/projects/packages/woocommerce-analytics/src/class-wc-analytics-tracking.php
@@ -231,6 +231,7 @@ class WC_Analytics_Tracking extends WC_Tracks {
 		foreach ( self::$pixel_batch_queue as $pixel ) {
 			// Check if the method exists for backwards compatibility with older WooCommerce versions.
 			if ( method_exists( WC_Tracks_Client::class, 'add_request_timestamp_and_nocache' ) ) {
+				// @phan-suppress-next-line PhanUndeclaredStaticMethod -- We verify the method exists before using it.
 				$pixels_to_send[] = WC_Tracks_Client::add_request_timestamp_and_nocache( $pixel );
 			} else {
 				// Fallback for older versions - add timestamp and nocache parameters manually.

--- a/projects/packages/woocommerce-analytics/src/class-woo-analytics-trait.php
+++ b/projects/packages/woocommerce-analytics/src/class-woo-analytics-trait.php
@@ -172,6 +172,7 @@ trait Woo_Analytics_Trait {
 
 		$this->cart_checkout_templates_in_use = wp_is_block_theme()
 			&& class_exists( '\Automattic\WooCommerce\Blocks\Package' )
+			// @phan-suppress-next-line PhanUndeclaredClassMethod -- If the class exists (as of WooCommerce 8.5.0), the method exists.
 			&& version_compare( \Automattic\WooCommerce\Blocks\Package::get_version(), '10.6.0', '>=' );
 
 		// Cart/Checkout *pages* are in use if the templates are not in use. Return their content and do nothing else.
@@ -260,6 +261,7 @@ trait Woo_Analytics_Trait {
 	public function get_common_properties() {
 		$site_info = array(
 			'blog_id'        => Jetpack_Connection::get_site_id(),
+			// @phan-suppress-next-line PhanUndeclaredConstantOfClass -- The constant has only existed since WooCommerce 8.4, but we check for its existence.
 			'store_id'       => defined( '\\WC_Install::STORE_ID_OPTION' ) ? get_option( \WC_Install::STORE_ID_OPTION ) : false,
 			'ui'             => $this->get_user_id(),
 			'url'            => home_url(),

--- a/projects/packages/woocommerce-analytics/src/class-woo-analytics-trait.php
+++ b/projects/packages/woocommerce-analytics/src/class-woo-analytics-trait.php
@@ -172,7 +172,7 @@ trait Woo_Analytics_Trait {
 
 		$this->cart_checkout_templates_in_use = wp_is_block_theme()
 			&& class_exists( '\Automattic\WooCommerce\Blocks\Package' )
-			// @phan-suppress-next-line PhanUndeclaredClassMethod -- If the class exists (as of WooCommerce 8.5.0), the method exists.
+			// @phan-suppress-current-line UnusedPluginSuppression @phan-suppress-next-line PhanUndeclaredClassMethod -- If the class exists (as of WooCommerce 8.5.0), the method exists. See also: https://github.com/phan/phan/issues/1204
 			&& version_compare( \Automattic\WooCommerce\Blocks\Package::get_version(), '10.6.0', '>=' );
 
 		// Cart/Checkout *pages* are in use if the templates are not in use. Return their content and do nothing else.
@@ -261,7 +261,7 @@ trait Woo_Analytics_Trait {
 	public function get_common_properties() {
 		$site_info = array(
 			'blog_id'        => Jetpack_Connection::get_site_id(),
-			// @phan-suppress-next-line PhanUndeclaredConstantOfClass -- The constant has only existed since WooCommerce 8.4, but we check for its existence.
+			// @phan-suppress-current-line UnusedPluginSuppression @phan-suppress-next-line PhanUndeclaredConstantOfClass -- The constant has only existed since WooCommerce 8.4, but we check for its existence. See also: https://github.com/phan/phan/issues/1204
 			'store_id'       => defined( '\\WC_Install::STORE_ID_OPTION' ) ? get_option( \WC_Install::STORE_ID_OPTION ) : false,
 			'ui'             => $this->get_user_id(),
 			'url'            => home_url(),

--- a/projects/plugins/wpcomsh/changelog/fix-phan-issues_in_old_woo
+++ b/projects/plugins/wpcomsh/changelog/fix-phan-issues_in_old_woo
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Suppress Phan confusion.
+
+

--- a/projects/plugins/wpcomsh/woa.php
+++ b/projects/plugins/wpcomsh/woa.php
@@ -429,8 +429,8 @@ function wpcomsh_woa_post_process_store_woocommerce_connection_details( $args, $
 
 	WP_CLI::success( 'WooCommerce connection details stored' );
 
-	// @phan-suppress-current-line UnusedPluginSuppression @phan-suppress-next-line PhanUndeclaredStaticMethod -- We check if the class and method exist before using them; see https://github.com/phan/phan/issues/1204
 	if ( class_exists( 'WC_Helper' ) && method_exists( 'WC_Helper', 'refresh_helper_subscriptions' ) ) {
+		// @phan-suppress-current-line UnusedPluginSuppression @phan-suppress-next-line PhanUndeclaredStaticMethod -- We check if the class and method exist before using them; see https://github.com/phan/phan/issues/1204
 		WC_Helper::refresh_helper_subscriptions();
 
 		WP_CLI::success( 'Cleared WooCommerce Helper cache' );

--- a/projects/plugins/wpcomsh/woa.php
+++ b/projects/plugins/wpcomsh/woa.php
@@ -429,6 +429,7 @@ function wpcomsh_woa_post_process_store_woocommerce_connection_details( $args, $
 
 	WP_CLI::success( 'WooCommerce connection details stored' );
 
+	// @phan-suppress-next-line PhanUndeclaredStaticMethod, UnusedPluginSuppression -- We check if the class and method exist before using them; see https://github.com/phan/phan/issues/1204
 	if ( class_exists( 'WC_Helper' ) && method_exists( 'WC_Helper', 'refresh_helper_subscriptions' ) ) {
 		WC_Helper::refresh_helper_subscriptions();
 

--- a/projects/plugins/wpcomsh/woa.php
+++ b/projects/plugins/wpcomsh/woa.php
@@ -429,7 +429,7 @@ function wpcomsh_woa_post_process_store_woocommerce_connection_details( $args, $
 
 	WP_CLI::success( 'WooCommerce connection details stored' );
 
-	// @phan-suppress-next-line PhanUndeclaredStaticMethod, UnusedPluginSuppression -- We check if the class and method exist before using them; see https://github.com/phan/phan/issues/1204
+	// @phan-suppress-current-line UnusedPluginSuppression @phan-suppress-next-line PhanUndeclaredStaticMethod -- We check if the class and method exist before using them; see https://github.com/phan/phan/issues/1204
 	if ( class_exists( 'WC_Helper' ) && method_exists( 'WC_Helper', 'refresh_helper_subscriptions' ) ) {
 		WC_Helper::refresh_helper_subscriptions();
 


### PR DESCRIPTION
Closes MONOREP-234

 <!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

In preparation to running static analysis against old Woo 7.0 stubs, this PR addresses some existing issues. In most cases we just add Phan suppressions (see phan/phan#1204). However, Sync had two real compatibility fixes:

* 9339cac202: we referenced some class constant that might not be present; I've changed those instances to use the relevant strings
* 4bcb8d65e9: ~we called a method that may not always exist; I've added a check~ The method does indeed always exist.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

CI should be happy here, but also Phan should run against old Woo stubs with no errors:

```
composer require --dev "php-stubs/woocommerce-stubs:7.0"
pnpm jetpack phan --all
```