### PR TITLE
actions: Try GitHubSecurityLab/actions-permissions

### DIFF
--- a/.github/workflows/gardening.yml
+++ b/.github/workflows/gardening.yml
@@ -22,6 +22,10 @@ jobs:
     if: github.event_name == 'pull_request_target' || github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
     timeout-minutes: 10  # 2025-11-06: Successful runs seem to take a minute or two, primarily since we wait for previous runs to complete.
     steps:
+      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
+        with:
+          config: ${{ vars.PERMISSIONS_CONFIG }}
+
       - name: Checkout
         uses: actions/checkout@v5
 

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -25,7 +25,8 @@ jobs:
   changed_files:
     name: detect changed files
     runs-on: ubuntu-latest
-    timeout-minutes: 1  # 2025-11-06: Successful runs seem to take a few seconds
+    #timeout-minutes: 1  # 2025-11-06: Successful runs seem to take a few seconds
+    timeout-minutes: 2  # 2025-11-19: Successful runs seem to take a few seconds, but GitHubSecurityLab/actions-permissions/monitor takes a minute to start.
     outputs:
       # Whether any PHP files have changed.
       php: ${{ steps.filter.outputs.php }}
@@ -469,7 +470,8 @@ jobs:
   copied_files:
     name: Copied files are in sync
     runs-on: ubuntu-latest
-    timeout-minutes: 1  # 2025-11-06: Successful runs seem to take a few seconds.
+    #timeout-minutes: 1  # 2025-11-06: Successful runs seem to take a few seconds.
+    timeout-minutes: 2  # 2025-11-19: Successful runs seem to take a few seconds, but GitHubSecurityLab/actions-permissions/monitor takes a minute to start.
 
     steps:
       - uses: GitHubSecurityLab/actions-permissions/monitor@v1

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -67,6 +67,10 @@ jobs:
       phanstubs: ${{ steps.filter.outputs.phanstubs == 'true' }}
 
     steps:
+      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
+        with:
+          config: ${{ vars.PERMISSIONS_CONFIG }}
+
       - if: github.event_name == 'pull_request'
         uses: actions/checkout@v5
 
@@ -213,6 +217,10 @@ jobs:
         experimental: [ false ]
 
     steps:
+      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
+        with:
+          config: ${{ vars.PERMISSIONS_CONFIG }}
+
       - uses: actions/checkout@v5
 
       - name: Setup tools
@@ -247,6 +255,10 @@ jobs:
     timeout-minutes: 5  # 2025-11-06: Successful runs seem to take ~2 minutes. Leaving some extra for future expansion.
 
     steps:
+      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
+        with:
+          config: ${{ vars.PERMISSIONS_CONFIG }}
+
       - uses: actions/checkout@v5
 
       - name: Setup tools
@@ -275,6 +287,10 @@ jobs:
     timeout-minutes: 5  # 2025-11-06: Successful runs seem to take ~1 minute. Leaving some extra for future expansion.
 
     steps:
+      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
+        with:
+          config: ${{ vars.PERMISSIONS_CONFIG }}
+
       - uses: actions/checkout@v5
 
       - name: Setup tools
@@ -305,6 +321,10 @@ jobs:
     timeout-minutes: 5  # 2025-11-06: Successful runs seem to take 30 seconds. Leaving some extra for future expansion.
 
     steps:
+      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
+        with:
+          config: ${{ vars.PERMISSIONS_CONFIG }}
+
       # We don't need full git history, but phpcs-changed does need everything up to the merge-base.
       - uses: actions/checkout@v5
         with:
@@ -343,6 +363,10 @@ jobs:
     timeout-minutes: 10  # 2025-11-06: Runs now take ~5 minutes due to now installing all php/js deps to ensure valid linting.
 
     steps:
+      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
+        with:
+          config: ${{ vars.PERMISSIONS_CONFIG }}
+
       - uses: actions/checkout@v5
 
       - name: Setup tools
@@ -366,6 +390,10 @@ jobs:
     timeout-minutes: 10  # 2025-11-06: Takes about a minute, but rarely runs.
 
     steps:
+      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
+        with:
+          config: ${{ vars.PERMISSIONS_CONFIG }}
+
       # We don't need full git history, but eslint-changed does need everything up to the merge-base.
       - uses: actions/checkout@v5
         with:
@@ -396,6 +424,10 @@ jobs:
     timeout-minutes: 5  # 2025-11-06: Takes a bit more than a minute, so give a little wiggle room.
 
     steps:
+      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
+        with:
+          config: ${{ vars.PERMISSIONS_CONFIG }}
+
       - uses: actions/checkout@v5
 
       - name: Setup tools
@@ -417,6 +449,10 @@ jobs:
     if: github.event_name == 'push' || needs.changed_files.outputs.ghactionsfiles == 'true' || needs.changed_files.outputs.misc == 'true'
     timeout-minutes: 5  # 2025-11-06: Takes less than a minute.
     steps:
+      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
+        with:
+          config: ${{ vars.PERMISSIONS_CONFIG }}
+
       - uses: actions/checkout@v5
 
       - name: Setup tools
@@ -436,6 +472,10 @@ jobs:
     timeout-minutes: 1  # 2025-11-06: Successful runs seem to take a few seconds.
 
     steps:
+      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
+        with:
+          config: ${{ vars.PERMISSIONS_CONFIG }}
+
       - uses: actions/checkout@v5
       - run: ./tools/check-copied-files.sh
 
@@ -450,6 +490,10 @@ jobs:
     if: github.event_name == 'push' || needs.changed_files.outputs.excludelist == 'true'
     timeout-minutes: 10  # 2025-11-06: The check itself takes 2 minutes.
     steps:
+      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
+        with:
+          config: ${{ vars.PERMISSIONS_CONFIG }}
+
       - uses: actions/checkout@v5
 
       - name: Setup tools
@@ -472,6 +516,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5  # 2025-11-06: Takes a few seconds.
     steps:
+      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
+        with:
+          config: ${{ vars.PERMISSIONS_CONFIG }}
+
       # We don't need full git history, but tools/check-changelogger-use.php does need everything up to the merge-base.
       - uses: actions/checkout@v5
         with:
@@ -497,6 +545,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5  # 2025-11-06: Takes less than a minute.
     steps:
+      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
+        with:
+          config: ${{ vars.PERMISSIONS_CONFIG }}
+
       - uses: actions/checkout@v5
 
       - name: Setup tools
@@ -519,6 +571,10 @@ jobs:
     if: github.event_name == 'push' || needs.changed_files.outputs.lockfiles == 'true' || needs.changed_files.outputs.misc == 'true'
     timeout-minutes: 7  # 2025-11-06: Successful runs seem to take about 2 minutes.
     steps:
+      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
+        with:
+          config: ${{ vars.PERMISSIONS_CONFIG }}
+
       - uses: actions/checkout@v5
 
       - name: Setup tools
@@ -537,6 +593,10 @@ jobs:
     if: github.event_name == 'push' || needs.changed_files.outputs.lockfiles == 'true' || needs.changed_files.outputs.misc == 'true'
     timeout-minutes: 7  # 2025-11-06: Takes a minute or two.
     steps:
+      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
+        with:
+          config: ${{ vars.PERMISSIONS_CONFIG }}
+
       - uses: actions/checkout@v5
       - name: Setup tools
         uses: ./.github/actions/tool-setup
@@ -551,6 +611,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5  # 2025-11-06: Takes a minute or two.
     steps:
+      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
+        with:
+          config: ${{ vars.PERMISSIONS_CONFIG }}
+
       - uses: actions/checkout@v5
 
       - name: Setup tools
@@ -567,6 +631,10 @@ jobs:
     if: github.event_name == 'pull_request' && needs.changed_files.outputs.phanstubs == 'true' && github.event.pull_request.user.login != 'matticbot'
     timeout-minutes: 5  # 2025-11-06: Probably takes about a minute, but shouldn't run often.
     steps:
+      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
+        with:
+          config: ${{ vars.PERMISSIONS_CONFIG }}
+
       - uses: actions/checkout@v5
       - uses: ./.github/actions/deepen-to-merge-base
         id: deepen


### PR DESCRIPTION
Closes MONOREP-235

 <!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
GitHub's code scanner keeps complaining at us about permissions. Let's try the `GitHubSecurityLab/actions-permissions` action they mentioned in [a blog post a few years ago][1] to see how it does on a few of our workflows at analyzing which permissions are required.

[1]: https://github.blog/security/new-tool-to-secure-your-github-actions/

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* CI happy?
