### PR TITLE
Forms: add wh feature mvp

### DIFF
--- a/projects/packages/forms/changelog/add-forms-feature-wh-mvp
+++ b/projects/packages/forms/changelog/add-forms-feature-wh-mvp
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Forms: add trigger feature MVP - needs splitting

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -1556,6 +1556,7 @@ class Contact_Form_Plugin {
 			}
 
 			if ( ! empty( $form->attributes['salesforceData'] ) || ! empty( $form->attributes['postToUrl'] ) ) {
+				// this enables both salesforce and webhook (postToUrl) integrations
 				Post_To_Url::init();
 			}
 			// Process the form

--- a/projects/packages/forms/src/service/class-generic-webhook-provider.php
+++ b/projects/packages/forms/src/service/class-generic-webhook-provider.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Generic Webhook Provider for Jetpack Contact Forms.
+ *
+ * @package automattic/jetpack-forms
+ */
+
+namespace Automattic\Jetpack\Forms\Service;
+
+/**
+ * Generic webhook provider for standard webhook integrations.
+ *
+ * This provider handles the standard postToUrl attribute configuration
+ * without any service-specific modifications.
+ */
+class Generic_Webhook_Provider extends Webhook_Provider {
+	/**
+	 * Build setup from postToUrl attribute.
+	 *
+	 * @param array $attributes Form attributes.
+	 * @return array|false Setup configuration or false if invalid/disabled.
+	 */
+	protected function build_setup( $attributes ) {
+		$defaults = array(
+			'url'      => '',
+			'verified' => false,
+			'format'   => 'json',
+			'enabled'  => false,
+		);
+
+		$setup = wp_parse_args(
+			! empty( $attributes['postToUrl'] ) ? $attributes['postToUrl'] : array(),
+			$defaults
+		);
+
+		if ( empty( $setup['enabled'] ) || empty( $setup['url'] ) ) {
+			return false;
+		}
+
+		if ( ! in_array( $setup['format'], array( 'urlencoded', 'json' ), true ) ) {
+			return false;
+		}
+
+		return $setup;
+	}
+
+	/**
+	 * No transformation needed for generic webhooks.
+	 *
+	 * Generic webhooks receive the data as-is from the form.
+	 *
+	 * @param array                                              $form_data    Base form data.
+	 * @param \Automattic\Jetpack\Forms\ContactForm\Contact_Form $form         The Contact_Form instance.
+	 * @param array                                              $entry_values The feedback entry values.
+	 * @return array Unmodified form data.
+	 */
+	public function transform_data( $form_data, $form, $entry_values ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		return $form_data;
+	}
+}

--- a/projects/packages/forms/src/service/class-post-to-url.php
+++ b/projects/packages/forms/src/service/class-post-to-url.php
@@ -12,7 +12,8 @@ use WP_Error;
 /**
  * Class Post_To_Url
  *
- * Hooks on Jetpack's Contact form to post form data to some URL.
+ * Hooks on Jetpack's Contact form to post form data to webhooks.
+ * Uses provider pattern to support different webhook services (generic, Salesforce, etc.)
  */
 class Post_To_Url {
 	/**
@@ -21,6 +22,13 @@ class Post_To_Url {
 	 * @var Post_To_Url
 	 */
 	private static $instance = null;
+
+	/**
+	 * Current webhook provider
+	 *
+	 * @var Webhook_Provider
+	 */
+	private $provider;
 
 	/**
 	 * Initialize and return singleton instance.
@@ -46,41 +54,22 @@ class Post_To_Url {
 	}
 
 	/**
-	 * Get the setup for the post to URL.
-	 * This is a helper function to get the setup for the post to URL.
-	 * It will return false if the setup is not valid.
+	 * Determine which provider to use based on form attributes.
 	 *
-	 * @param array $attributes - the attributes of the contact form.
-	 * @return array|bool
+	 * @param array $attributes Form attributes.
+	 * @return Webhook_Provider|null The appropriate webhook provider or null.
 	 */
-	private function get_setup( $attributes = array() ) {
-		$defaults = array(
-			'url'      => '',
-			'verified' => false,
-			'format'   => 'urlencoded',
-			'enabled'  => false,
-		);
-
-		// Backwards compatibility setup for Salesforce.
+	private function get_provider( $attributes ) {
+		// Check for Salesforce first (backwards compatibility)
 		if ( ! empty( $attributes['salesforceData'] ) && ! empty( $attributes['salesforceData']['organizationId'] ) ) {
-			$defaults['url']      = 'https://webto.salesforce.com/servlet/servlet.WebToLead?encoding=UTF-8';
-			$defaults['format']   = 'urlencoded';
-			$defaults['enabled']  = true;
-			$defaults['verified'] = true;
+			return new Salesforce_Webhook_Provider( $attributes );
 		}
 
-		// if new setup for postToUrl is present, use it on top of the defaults (hence, salesforceData will be stepped on)
-		$setup = wp_parse_args( ! empty( $attributes['postToUrl'] ) ? $attributes['postToUrl'] : array(), $defaults );
-		if ( empty( $setup['enabled'] ) || empty( $setup['url'] ) ) {
-			return false;
+		if ( apply_filters( 'jetpack_forms_webhooks_enabled', false ) ) {
+			return new Generic_Webhook_Provider( $attributes );
 		}
 
-		if ( ! in_array( $setup['format'], array( 'urlencoded', 'json' ), true ) ) {
-			return false;
-		}
-
-		// TODO: eventually, I'd like us to verify the URL and invalidate the setup, but for now, we'll just trust the user.
-		return $setup;
+		return null;
 	}
 
 	/**
@@ -111,13 +100,25 @@ class Post_To_Url {
 			return;
 		}
 
-		$setup = $this->get_setup( $form->attributes );
+		// Get appropriate provider based on form attributes
+		$this->provider = $this->get_provider( $form->attributes );
+
+		if ( ! $this->provider || ! $this->provider->is_enabled() ) {
+			// no provider found or provider is not enabled
+			return;
+		}
+
+		$setup = $this->provider->get_setup();
 
 		if ( ! $setup ) {
 			return;
 		}
 
-		$form_data = $this->get_form_data( $form, $entry_values );
+		// Get base form data
+		$form_data = $this->get_form_data( $form );
+
+		// Let provider transform the data
+		$form_data = $this->provider->transform_data( $form_data, $form, $entry_values );
 
 		$result = $this->post_to_url( $form_data, $setup );
 
@@ -152,7 +153,7 @@ class Post_To_Url {
 		$url        = $options['url'];
 		$format     = $options['format'] === 'urlencoded' ? 'application/x-www-form-urlencoded' : 'application/json';
 		$args       = array(
-			'body'      => $data,
+			'body'      => $format === 'urlencoded' ? $data : wp_json_encode( $data ),
 			'headers'   => array(
 				'Content-Type' => $format,
 				'user-agent'   => $user_agent,
@@ -164,24 +165,20 @@ class Post_To_Url {
 	}
 
 	/**
-	 * Gather fields key/value pairs from the form
-	 * Sanitizes the hidden fields values
+	 * Gather base fields key/value pairs from the form.
+	 * Sanitizes the hidden fields values.
+	 * Service-specific fields are added by the provider's transform_data method.
 	 *
 	 * @param \Automattic\Jetpack\Forms\ContactForm\Contact_Form $form The form instance being processed/submitted.
-	 * @param array                                              $entry_values The feedback entry values.
+	 * @return array Base form data with field id => value pairs.
 	 */
-	private function get_form_data( $form, $entry_values ) {
+	private function get_form_data( $form ) {
 		$fields = array();
 		foreach ( $form->fields as $field ) {
 			$fields[ $field->get_attribute( 'id' ) ] = $field->value;
 		}
 
-		// Right in the middle, backwards compatibility for salesforceData implementation.
-		if ( ! empty( $form->attributes['salesforceData'] ) && ! empty( $form->attributes['salesforceData']['organizationId'] ) ) {
-			$fields['oid']         = sanitize_text_field( $form->attributes['salesforceData']['organizationId'] );
-			$fields['lead_source'] = $entry_values['entry_permalink'];
-		}
-
+		// Generic hidden fields support
 		if ( ! empty( $form->attributes['hiddenFields'] ) ) {
 			foreach ( $form->attributes['hiddenFields'] as $hidden_field ) {
 				$fields[ $hidden_field['name'] ] = sanitize_text_field( $hidden_field['value'] );

--- a/projects/packages/forms/src/service/class-post-to-url.php
+++ b/projects/packages/forms/src/service/class-post-to-url.php
@@ -153,7 +153,7 @@ class Post_To_Url {
 		$url        = $options['url'];
 		$format     = $options['format'] === 'urlencoded' ? 'application/x-www-form-urlencoded' : 'application/json';
 		$args       = array(
-			'body'      => $format === 'urlencoded' ? $data : wp_json_encode( $data ),
+			'body'      => $options['format'] === 'urlencoded' ? $data : wp_json_encode( $data ),
 			'headers'   => array(
 				'Content-Type' => $format,
 				'user-agent'   => $user_agent,

--- a/projects/packages/forms/src/service/class-salesforce-webhook-provider.php
+++ b/projects/packages/forms/src/service/class-salesforce-webhook-provider.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * Salesforce Webhook Provider for Jetpack Contact Forms.
+ *
+ * @package automattic/jetpack-forms
+ */
+
+namespace Automattic\Jetpack\Forms\Service;
+
+/**
+ * Salesforce-specific webhook provider.
+ *
+ * Handles Salesforce Web-to-Lead integration with service-specific
+ * configuration and data transformation.
+ */
+class Salesforce_Webhook_Provider extends Webhook_Provider {
+	/**
+	 * Build Salesforce Web-to-Lead setup.
+	 *
+	 * @param array $attributes Form attributes.
+	 * @return array|false Salesforce setup configuration or false if salesforceData is not present.
+	 */
+	protected function build_setup( $attributes ) {
+		// Only handle if salesforceData is present
+		if ( empty( $attributes['salesforceData'] ) || empty( $attributes['salesforceData']['organizationId'] ) ) {
+			return false;
+		}
+
+		return array(
+			'url'      => 'https://webto.salesforce.com/servlet/servlet.WebToLead?encoding=UTF-8',
+			'format'   => 'urlencoded',
+			'enabled'  => true,
+			'verified' => true,
+		);
+	}
+
+	/**
+	 * Add Salesforce-specific fields to form data.
+	 *
+	 * Adds the organization ID (oid) and lead source fields required
+	 * by Salesforce Web-to-Lead.
+	 *
+	 * @param array                                              $form_data    Base form data.
+	 * @param \Automattic\Jetpack\Forms\ContactForm\Contact_Form $form         The Contact_Form instance.
+	 * @param array                                              $entry_values The feedback entry values.
+	 * @return array Form data with Salesforce-specific fields added.
+	 */
+	public function transform_data( $form_data, $form, $entry_values ) {
+		if ( ! empty( $form->attributes['salesforceData']['organizationId'] ) ) {
+			$form_data['oid']         = sanitize_text_field( $form->attributes['salesforceData']['organizationId'] );
+			$form_data['lead_source'] = $entry_values['entry_permalink'] ?? '';
+		}
+
+		return $form_data;
+	}
+}

--- a/projects/packages/forms/src/service/class-webhook-provider.php
+++ b/projects/packages/forms/src/service/class-webhook-provider.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * Abstract Webhook Provider for Jetpack Contact Forms.
+ *
+ * @package automattic/jetpack-forms
+ */
+
+namespace Automattic\Jetpack\Forms\Service;
+
+/**
+ * Abstract class for webhook providers.
+ *
+ * Providers handle service-specific setup and data transformation.
+ * This allows Post_To_Url to remain generic while supporting different webhook services.
+ */
+abstract class Webhook_Provider {
+	/**
+	 * Cached setup configuration
+	 *
+	 * @var array|false
+	 */
+	protected $setup;
+
+	/**
+	 * Constructor - sets up the provider with form attributes.
+	 *
+	 * @param array $attributes Form attributes from the contact form.
+	 */
+	public function __construct( $attributes ) {
+		$this->setup = $this->build_setup( $attributes );
+	}
+
+	/**
+	 * Build the webhook setup configuration.
+	 *
+	 * @param array $attributes Form attributes from the contact form.
+	 * @return array|false Setup array with 'url', 'format', 'enabled', 'verified', or false if invalid/disabled.
+	 */
+	abstract protected function build_setup( $attributes );
+
+	/**
+	 * Get the cached setup configuration.
+	 *
+	 * @return array|false Setup configuration or false if invalid/disabled.
+	 */
+	public function get_setup() {
+		return $this->setup;
+	}
+
+	/**
+	 * Check if the webhook is enabled.
+	 *
+	 * @return bool True if the webhook is enabled and configured.
+	 */
+	public function is_enabled() {
+		return ! empty( $this->setup['enabled'] );
+	}
+
+	/**
+	 * Transform form data for this specific webhook service.
+	 *
+	 * Allows providers to add service-specific fields or modify existing data.
+	 *
+	 * @param array                                              $form_data    Base form data (field id => value pairs).
+	 * @param \Automattic\Jetpack\Forms\ContactForm\Contact_Form $form         The Contact_Form instance.
+	 * @param array                                              $entry_values The feedback entry values.
+	 * @return array Transformed form data ready for posting.
+	 */
+	abstract public function transform_data( $form_data, $form, $entry_values );
+}

--- a/projects/packages/forms/tests/php/service/Webhook_Provider_Test.php
+++ b/projects/packages/forms/tests/php/service/Webhook_Provider_Test.php
@@ -1,0 +1,296 @@
+<?php
+/**
+ * Unit Tests for Webhook Providers.
+ *
+ * @package automattic/jetpack-forms
+ */
+
+namespace Automattic\Jetpack\Forms\Service;
+
+use Automattic\Jetpack\Forms\ContactForm\Contact_Form;
+use PHPUnit\Framework\Attributes\CoversClass;
+use WorDBless\BaseTestCase;
+
+/**
+ * Test class for Webhook Providers
+ *
+ * @covers Automattic\Jetpack\Forms\Service\Generic_Webhook_Provider
+ * @covers Automattic\Jetpack\Forms\Service\Salesforce_Webhook_Provider
+ */
+#[CoversClass( Generic_Webhook_Provider::class )]
+#[CoversClass( Salesforce_Webhook_Provider::class )]
+class Webhook_Provider_Test extends BaseTestCase {
+
+	/**
+	 * Test Generic_Webhook_Provider::get_setup with valid configuration.
+	 */
+	public function test_generic_provider_get_setup_with_valid_config() {
+		$attributes = array(
+			'postToUrl' => array(
+				'enabled' => true,
+				'url'     => 'https://example.com/webhook',
+				'format'  => 'json',
+			),
+		);
+
+		$provider = new Generic_Webhook_Provider( $attributes );
+		$setup    = $provider->get_setup();
+
+		$this->assertIsArray( $setup );
+		$this->assertTrue( $setup['enabled'] );
+		$this->assertTrue( $provider->is_enabled() );
+		$this->assertEquals( 'https://example.com/webhook', $setup['url'] );
+		$this->assertEquals( 'json', $setup['format'] );
+		$this->assertFalse( $setup['verified'] );
+	}
+
+	/**
+	 * Test Generic_Webhook_Provider::get_setup with disabled configuration.
+	 */
+	public function test_generic_provider_get_setup_with_disabled_config() {
+		$attributes = array(
+			'postToUrl' => array(
+				'enabled' => false,
+				'url'     => 'https://example.com/webhook',
+			),
+		);
+
+		$provider = new Generic_Webhook_Provider( $attributes );
+		$setup    = $provider->get_setup();
+
+		$this->assertFalse( $setup );
+		$this->assertFalse( $provider->is_enabled() );
+	}
+
+	/**
+	 * Test Generic_Webhook_Provider::get_setup with missing URL.
+	 */
+	public function test_generic_provider_get_setup_with_missing_url() {
+		$attributes = array(
+			'postToUrl' => array(
+				'enabled' => true,
+				'format'  => 'json',
+			),
+		);
+
+		$provider = new Generic_Webhook_Provider( $attributes );
+		$setup    = $provider->get_setup();
+
+		$this->assertFalse( $setup );
+		$this->assertFalse( $provider->is_enabled() );
+	}
+
+	/**
+	 * Test Generic_Webhook_Provider::get_setup with invalid format.
+	 */
+	public function test_generic_provider_get_setup_with_invalid_format() {
+		$attributes = array(
+			'postToUrl' => array(
+				'enabled' => true,
+				'url'     => 'https://example.com/webhook',
+				'format'  => 'xml', // Invalid format
+			),
+		);
+
+		$provider = new Generic_Webhook_Provider( $attributes );
+		$setup    = $provider->get_setup();
+
+		$this->assertFalse( $setup );
+		$this->assertFalse( $provider->is_enabled() );
+	}
+
+	/**
+	 * Test Generic_Webhook_Provider::get_setup defaults to urlencoded.
+	 */
+	public function test_generic_provider_get_setup_defaults_to_urlencoded() {
+		$attributes = array(
+			'postToUrl' => array(
+				'enabled' => true,
+				'url'     => 'https://example.com/webhook',
+			),
+		);
+
+		$provider = new Generic_Webhook_Provider( $attributes );
+		$setup    = $provider->get_setup();
+
+		$this->assertIsArray( $setup );
+		$this->assertTrue( $provider->is_enabled() );
+		$this->assertEquals( 'urlencoded', $setup['format'] );
+	}
+
+	/**
+	 * Test Generic_Webhook_Provider::transform_data doesn't modify data.
+	 */
+	public function test_generic_provider_transform_data_unchanged() {
+		$attributes = array(
+			'postToUrl' => array(
+				'enabled' => true,
+				'url'     => 'https://example.com/webhook',
+			),
+		);
+
+		$provider = new Generic_Webhook_Provider( $attributes );
+
+		$form_data = array(
+			'name'  => 'John Doe',
+			'email' => 'john@example.com',
+		);
+
+		$form         = $this->getMockBuilder( Contact_Form::class )
+			->disableOriginalConstructor()
+			->getMock();
+		$entry_values = array( 'entry_permalink' => 'https://example.com/post/123' );
+
+		$result = $provider->transform_data( $form_data, $form, $entry_values );
+
+		$this->assertEquals( $form_data, $result );
+	}
+
+	/**
+	 * Test Salesforce_Webhook_Provider::get_setup with valid salesforceData.
+	 */
+	public function test_salesforce_provider_get_setup_with_valid_config() {
+		$attributes = array(
+			'salesforceData' => array(
+				'organizationId' => '00D123456789ABC',
+			),
+		);
+
+		$provider = new Salesforce_Webhook_Provider( $attributes );
+		$setup    = $provider->get_setup();
+
+		$this->assertIsArray( $setup );
+		$this->assertTrue( $setup['enabled'] );
+		$this->assertTrue( $provider->is_enabled() );
+		$this->assertTrue( $setup['verified'] );
+		$this->assertEquals( 'https://webto.salesforce.com/servlet/servlet.WebToLead?encoding=UTF-8', $setup['url'] );
+		$this->assertEquals( 'urlencoded', $setup['format'] );
+	}
+
+	/**
+	 * Test Salesforce_Webhook_Provider::get_setup without salesforceData.
+	 */
+	public function test_salesforce_provider_get_setup_without_salesforce_data() {
+		$attributes = array();
+
+		$provider = new Salesforce_Webhook_Provider( $attributes );
+		$setup    = $provider->get_setup();
+
+		$this->assertFalse( $setup );
+		$this->assertFalse( $provider->is_enabled() );
+	}
+
+	/**
+	 * Test Salesforce_Webhook_Provider::get_setup without organizationId.
+	 */
+	public function test_salesforce_provider_get_setup_without_organization_id() {
+		$attributes = array(
+			'salesforceData' => array(),
+		);
+
+		$provider = new Salesforce_Webhook_Provider( $attributes );
+		$setup    = $provider->get_setup();
+
+		$this->assertFalse( $setup );
+		$this->assertFalse( $provider->is_enabled() );
+	}
+
+	/**
+	 * Test Salesforce_Webhook_Provider::transform_data adds Salesforce fields.
+	 */
+	public function test_salesforce_provider_transform_data_adds_fields() {
+		$attributes = array(
+			'salesforceData' => array(
+				'organizationId' => '00D123456789ABC',
+			),
+		);
+
+		$provider = new Salesforce_Webhook_Provider( $attributes );
+
+		$form_data = array(
+			'first_name' => 'John',
+			'last_name'  => 'Doe',
+			'email'      => 'john@example.com',
+		);
+
+		$form             = $this->getMockBuilder( Contact_Form::class )
+			->disableOriginalConstructor()
+			->getMock();
+		$form->attributes = array(
+			'salesforceData' => array(
+				'organizationId' => '00D123456789ABC',
+			),
+		);
+		$entry_values     = array( 'entry_permalink' => 'https://example.com/post/123' );
+
+		$result = $provider->transform_data( $form_data, $form, $entry_values );
+
+		$this->assertArrayHasKey( 'oid', $result );
+		$this->assertArrayHasKey( 'lead_source', $result );
+		$this->assertSame( '00D123456789ABC', $result['oid'] );
+		$this->assertEquals( 'https://example.com/post/123', $result['lead_source'] );
+		// Original data should still be present
+		$this->assertEquals( 'John', $result['first_name'] );
+		$this->assertEquals( 'Doe', $result['last_name'] );
+		$this->assertEquals( 'john@example.com', $result['email'] );
+	}
+
+	/**
+	 * Test Salesforce_Webhook_Provider::transform_data sanitizes organizationId.
+	 */
+	public function test_salesforce_provider_transform_data_sanitizes_org_id() {
+		$attributes = array(
+			'salesforceData' => array(
+				'organizationId' => '<script>alert("xss")</script>00D123',
+			),
+		);
+
+		$provider = new Salesforce_Webhook_Provider( $attributes );
+
+		$form_data = array(
+			'email' => 'john@example.com',
+		);
+
+		$form             = $this->getMockBuilder( Contact_Form::class )
+			->disableOriginalConstructor()
+			->getMock();
+		$form->attributes = array(
+			'salesforceData' => array(
+				'organizationId' => '<script>alert("xss")</script>00D123',
+			),
+		);
+		$entry_values     = array( 'entry_permalink' => 'https://example.com/post/123' );
+
+		$result = $provider->transform_data( $form_data, $form, $entry_values );
+
+		$this->assertStringNotContainsString( '<script>', $result['oid'] );
+		$this->assertStringNotContainsString( 'alert', $result['oid'] );
+	}
+
+	/**
+	 * Test Salesforce_Webhook_Provider::transform_data without salesforceData.
+	 */
+	public function test_salesforce_provider_transform_data_without_salesforce_data() {
+		$attributes = array();
+
+		$provider = new Salesforce_Webhook_Provider( $attributes );
+
+		$form_data = array(
+			'email' => 'john@example.com',
+		);
+
+		$form             = $this->getMockBuilder( Contact_Form::class )
+			->disableOriginalConstructor()
+			->getMock();
+		$form->attributes = array();
+		$entry_values     = array( 'entry_permalink' => 'https://example.com/post/123' );
+
+		$result = $provider->transform_data( $form_data, $form, $entry_values );
+
+		// Should not add Salesforce fields
+		$this->assertArrayNotHasKey( 'oid', $result );
+		$this->assertArrayNotHasKey( 'lead_source', $result );
+		// Original data should be unchanged
+		$this->assertEquals( $form_data, $result );
+	}
+}

--- a/projects/packages/forms/tests/php/service/Webhook_Provider_Test.php
+++ b/projects/packages/forms/tests/php/service/Webhook_Provider_Test.php
@@ -100,7 +100,7 @@ class Webhook_Provider_Test extends BaseTestCase {
 	}
 
 	/**
-	 * Test Generic_Webhook_Provider::get_setup defaults to urlencoded.
+	 * Test Generic_Webhook_Provider::get_setup defaults to json.
 	 */
 	public function test_generic_provider_get_setup_defaults_to_urlencoded() {
 		$attributes = array(
@@ -115,7 +115,7 @@ class Webhook_Provider_Test extends BaseTestCase {
 
 		$this->assertIsArray( $setup );
 		$this->assertTrue( $provider->is_enabled() );
-		$this->assertEquals( 'urlencoded', $setup['format'] );
+		$this->assertEquals( 'json', $setup['format'] );
 	}
 
 	/**


### PR DESCRIPTION


## Proposed changes:
This is an exploration PR, likely to be split if it ever goes for production.

According to Claude:

New Files Created:

  1. class-webhook-provider.php - Abstract base class defining the provider interface
  2. class-generic-webhook-provider.php - Default provider for standard webhooks (postToUrl)
  3. class-salesforce-webhook-provider.php - Salesforce-specific provider (salesforceData)
  4. Webhook_Provider_Test.php - Comprehensive tests for all providers (11 test methods)

  Refactored:

  - class-post-to-url.php - Now completely generic, uses providers for service-specific logic

  What Changed:

  Before:
  - Salesforce logic hardcoded in get_setup() (lines 65-70)
  - Salesforce fields added in get_form_data() (lines 180-183)
  - Generic webhook class knew about Salesforce

  After:
  - Post_To_Url::get_provider() selects appropriate provider based on form attributes
  - Provider handles setup configuration via get_setup()
  - Provider transforms data via transform_data()
  - Post_To_Url is now 100% generic

  Key Design Decisions:

  1. Simple instantiation - No filters/hooks, just new Provider_Class()
  2. Backwards compatible - Salesforce checks first for existing forms
  3. Extensible - New services just need a new provider class
  4. Separation of concerns - Each provider knows only about its own service


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
TBD

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
TBD

