### PR TITLE
jetpack-mu-wpcom Code Block: Restore language- class prefix

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/code-block-language-class
+++ b/projects/packages/jetpack-mu-wpcom/changelog/code-block-language-class
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Unreleased code block: Restore language- prefix to language class.

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/class-code-block-html-replacer.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/class-code-block-html-replacer.php
@@ -56,6 +56,7 @@ class Code_Block_HTML_Replacer extends WP_HTML_Processor {
 
 		if ( $language_name ) {
 			$processor->add_class(
+				'language-' .
 				\strtr(
 					\strtolower( $language_name ),
 					array(


### PR DESCRIPTION

## Proposed changes:

Fix a small regression from https://github.com/Automattic/jetpack/pull/45389 where the `language-` class name prefix was unintentionally omitted. For example:

```diff
-<pre><code class="python">…</code></pre>
+<pre><code class="language-python">…</code></pre>
```

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?



## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
Add a code block with a language and verify that the CODE element has a `language-{{LANGUAGE_NAME}}` class.