### PR TITLE
Social: Update the UI for cases when user connection to WordPress.com is required. 

### DIFF
--- a/projects/js-packages/publicize-components/changelog/update-social-clean-up-sidebar-components
+++ b/projects/js-packages/publicize-components/changelog/update-social-clean-up-sidebar-components
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Social: Update the UI for cases when user connection to WordPress.com is required. 

--- a/projects/js-packages/publicize-components/src/components/block-editor/components/pre-publish-panels.tsx
+++ b/projects/js-packages/publicize-components/src/components/block-editor/components/pre-publish-panels.tsx
@@ -6,7 +6,6 @@ import useSocialMediaConnections from '../../../hooks/use-social-media-connectio
 import { useSyncPostDataToStore } from '../../../hooks/use-sync-post-data-to-store';
 import PublicizePanel from '../../panel';
 import SocialImageGeneratorPanel from '../../social-image-generator/panel';
-import { UpsellNotice } from './upsell';
 
 const PrePublishPanels = () => {
 	useSyncPostDataToStore();
@@ -21,9 +20,7 @@ const PrePublishPanels = () => {
 				title={ __( 'Share this post', 'jetpack-publicize-components' ) }
 				icon={ <JetpackEditorPanelLogo /> }
 			>
-				<PublicizePanel prePublish={ true }>
-					<UpsellNotice />
-				</PublicizePanel>
+				<PublicizePanel prePublish={ true } />
 			</PluginPrePublishPanel>
 
 			{ postCanUseSig && (

--- a/projects/js-packages/publicize-components/src/components/block-editor/components/social-settings.tsx
+++ b/projects/js-packages/publicize-components/src/components/block-editor/components/social-settings.tsx
@@ -10,7 +10,6 @@ import SocialImageGeneratorPanel from '../../social-image-generator/panel';
 import SocialPreviewsModal from '../../social-previews/modal';
 import SocialPreviewsPanel from '../../social-previews/panel';
 import { Placeholder } from './placeholder';
-import { UpsellNotice } from './upsell';
 
 const RenderSettings = () => {
 	const postCanUseSig = usePostCanUseSig();
@@ -22,10 +21,7 @@ const RenderSettings = () => {
 
 	return (
 		<ThemeProvider targetDom={ document.body }>
-			{ /* Share post panel */ }
-			<PublicizePanel>
-				<UpsellNotice />
-			</PublicizePanel>
+			<PublicizePanel />
 
 			{ /* Social Image Generator panel */ }
 			{ postCanUseSig && <SocialImageGeneratorPanel /> }

--- a/projects/js-packages/publicize-components/src/components/form/connections-list.tsx
+++ b/projects/js-packages/publicize-components/src/components/form/connections-list.tsx
@@ -1,4 +1,6 @@
 import { Disabled } from '@wordpress/components';
+import { useSelect } from '@wordpress/data';
+import { store as editorStore } from '@wordpress/editor';
 import usePublicizeConfig from '../../hooks/use-publicize-config';
 import { ConnectionsToggleList } from '../connections-toggle-list';
 import { BrokenConnectionsNotice } from './broken-connections-notice';
@@ -7,10 +9,18 @@ import { SettingsButton } from './settings-button';
 
 export const ConnectionsList: React.FC = () => {
 	const { needsUserConnection, isPublicizeEnabled } = usePublicizeConfig();
+	const isPostPublished = useSelect( select => select( editorStore ).isCurrentPostPublished(), [] );
+
+	const disableConnectionsList =
+		// We want to disable the connections list if Publicize is disabled
+		! isPublicizeEnabled ||
+		// or if the user needs to connect their WordPress.com account
+		// to reshare a published post.
+		( isPostPublished && needsUserConnection );
 
 	return (
 		<div>
-			<Disabled isDisabled={ ! isPublicizeEnabled }>
+			<Disabled isDisabled={ disableConnectionsList }>
 				<ConnectionsToggleList />
 			</Disabled>
 			{ isPublicizeEnabled ? (

--- a/projects/js-packages/publicize-components/src/components/form/empty-state.tsx
+++ b/projects/js-packages/publicize-components/src/components/form/empty-state.tsx
@@ -1,18 +1,12 @@
 /* eslint-disable @wordpress/no-unsafe-wp-apis */
-import { getUserConnectionUrl } from '@automattic/jetpack-connection';
-import {
-	Flex,
-	FlexBlock,
-	Notice,
-	PanelRow,
-	__experimentalText as Text,
-} from '@wordpress/components';
+import { Flex, FlexBlock, PanelRow, __experimentalText as Text } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import illustration from '../../assets/illustration.png';
 import usePublicizeConfig from '../../hooks/use-publicize-config';
 import useSocialMediaConnections from '../../hooks/use-social-media-connections';
 import { SettingsButton } from './settings-button';
 import styles from './styles.module.scss';
+import { UserConnectionNotice } from './user-connection-notice';
 
 /**
  * Empty state component for Publicize form.
@@ -35,22 +29,7 @@ export function EmptyState() {
 					! hasConnections && <img className={ styles.illustration } src={ illustration } alt="" />
 				}
 				{ needsUserConnection ? (
-					<Notice
-						status="warning"
-						isDismissible={ false }
-						actions={ [
-							{
-								url: getUserConnectionUrl(),
-								label: __( 'Connect now', 'jetpack-publicize-components' ),
-								variant: 'link',
-							},
-						] }
-					>
-						{ __(
-							'You must connect your WordPress.com account to be able to connect social media accounts.',
-							'jetpack-publicize-components'
-						) }
-					</Notice>
+					<UserConnectionNotice />
 				) : (
 					<>
 						<Text className={ styles[ 'connect-account-text' ] }>

--- a/projects/js-packages/publicize-components/src/components/form/index.tsx
+++ b/projects/js-packages/publicize-components/src/components/form/index.tsx
@@ -14,7 +14,6 @@ import useMediaDetails from '../../hooks/use-media-details';
 import useMediaRestrictions from '../../hooks/use-media-restrictions';
 import usePublicizeConfig from '../../hooks/use-publicize-config';
 import useSocialMediaConnections from '../../hooks/use-social-media-connections';
-import { getSocialScriptData } from '../../utils/script-data';
 import { ThemedConnectionsModal as ManageConnectionsModal } from '../manage-connections-modal';
 import { SocialPostModal } from '../social-post-modal/modal';
 import { ConnectionsList } from './connections-list';
@@ -49,14 +48,9 @@ export default function PublicizeForm() {
 
 	const Wrapper = isPublicizeDisabledBySitePlan ? Disabled : Fragment;
 
-	const { feature_flags } = getSocialScriptData();
-
 	return (
 		<Wrapper>
-			{
-				// Render modal only once
-				feature_flags.useAdminUiV1 ? <ManageConnectionsModal /> : null
-			}
+			<ManageConnectionsModal />
 			{ hasConnections ? (
 				<PanelRow>
 					<ConnectionsList />

--- a/projects/js-packages/publicize-components/src/components/form/index.tsx
+++ b/projects/js-packages/publicize-components/src/components/form/index.tsx
@@ -7,8 +7,6 @@
  */
 
 import { Disabled, PanelRow } from '@wordpress/components';
-import { useSelect } from '@wordpress/data';
-import { store as editorStore } from '@wordpress/editor';
 import { Fragment } from '@wordpress/element';
 import useAttachedMedia from '../../hooks/use-attached-media';
 import useFeaturedImage from '../../hooks/use-featured-image';
@@ -41,8 +39,6 @@ export default function PublicizeForm() {
 		useMediaDetails( mediaId )[ 0 ]
 	);
 
-	const isPostPublished = useSelect( select => select( editorStore ).isCurrentPostPublished(), [] );
-
 	const showSharePostForm =
 		isPublicizeEnabled &&
 		( hasEnabledConnections ||
@@ -69,9 +65,7 @@ export default function PublicizeForm() {
 			<EmptyState />
 			{ hasConnections ? (
 				<>
-					{ feature_flags.useEditorPreview && isPublicizeEnabled && ! isPostPublished ? (
-						<SocialPostModal />
-					) : null }
+					<SocialPostModal />
 					<EnhancedFeaturesNudge />
 				</>
 			) : null }
@@ -81,7 +75,6 @@ export default function PublicizeForm() {
 					{ showSharePostForm && <SharePostForm analyticsData={ { location: 'editor' } } /> }
 				</Fragment>
 			) }
-			{ isPostPublished ? <SocialPostModal /> : null }
 		</Wrapper>
 	);
 }

--- a/projects/js-packages/publicize-components/src/components/form/user-connection-notice.tsx
+++ b/projects/js-packages/publicize-components/src/components/form/user-connection-notice.tsx
@@ -1,0 +1,43 @@
+import { getUserConnectionUrl } from '@automattic/jetpack-connection';
+import { Notice } from '@wordpress/components';
+import { useSelect } from '@wordpress/data';
+import { store as editorStore } from '@wordpress/editor';
+import { __, _x } from '@wordpress/i18n';
+
+/**
+ * Notice to prompt user to connect their WordPress.com account.
+ *
+ * @return React element
+ */
+export function UserConnectionNotice() {
+	const isPostPublished = useSelect( select => select( editorStore ).isCurrentPostPublished(), [] );
+
+	return (
+		<Notice
+			status="warning"
+			isDismissible={ false }
+			actions={ [
+				{
+					url: getUserConnectionUrl(),
+					label: __( 'Connect now', 'jetpack-publicize-components' ),
+					variant: 'link',
+				},
+			] }
+		>
+			{
+				// When the post is published, the user needs to connect to re-share posts.
+				// So, that has the priority over adding connections.
+				isPostPublished
+					? _x(
+							'You must connect your WordPress.com account to be able to re-share posts.',
+							'',
+							'jetpack-publicize-components'
+					  )
+					: __(
+							'You must connect your WordPress.com account to be able to connect social media accounts.',
+							'jetpack-publicize-components'
+					  )
+			}
+		</Notice>
+	);
+}

--- a/projects/js-packages/publicize-components/src/components/panel/auto-share-toggle.tsx
+++ b/projects/js-packages/publicize-components/src/components/panel/auto-share-toggle.tsx
@@ -1,0 +1,31 @@
+import { CheckboxControl, PanelRow } from '@wordpress/components';
+import { useSelect } from '@wordpress/data';
+import { store as editorStore } from '@wordpress/editor';
+import { __ } from '@wordpress/i18n';
+import usePublicizeConfig from '../../hooks/use-publicize-config';
+
+/**
+ * Auto-share toggle component
+ *
+ * @return The auto-share toggle component
+ */
+export function AutoShareToggle() {
+	const { isPublicizeEnabled, togglePublicizeFeature } = usePublicizeConfig();
+	const isPostPublished = useSelect( select => select( editorStore ).isCurrentPostPublished(), [] );
+
+	// We do not want to show the toggle if the post is already published.
+	if ( isPostPublished ) {
+		return null;
+	}
+
+	return (
+		<PanelRow>
+			<CheckboxControl
+				label={ __( 'Auto-share post', 'jetpack-publicize-components' ) }
+				onChange={ togglePublicizeFeature }
+				checked={ isPublicizeEnabled }
+				__nextHasNoMarginBottom={ true }
+			/>
+		</PanelRow>
+	);
+}

--- a/projects/js-packages/publicize-components/src/components/panel/description.tsx
+++ b/projects/js-packages/publicize-components/src/components/panel/description.tsx
@@ -1,0 +1,46 @@
+/* eslint-disable @wordpress/no-unsafe-wp-apis */
+import { PanelRow, __experimentalText as Text } from '@wordpress/components';
+import { useSelect } from '@wordpress/data';
+import { store as editorStore } from '@wordpress/editor';
+import { __, _x } from '@wordpress/i18n';
+import usePublicizeConfig from '../../hooks/use-publicize-config';
+import useSelectSocialMediaConnections from '../../hooks/use-social-media-connections';
+import styles from './styles.module.scss';
+
+/**
+ * Description component for the Publicize panel.
+ *
+ * @return The description component.
+ */
+export function Description() {
+	const { hasEnabledConnections } = useSelectSocialMediaConnections();
+	const isPostPublished = useSelect( select => select( editorStore ).isCurrentPostPublished(), [] );
+
+	const { isPublicizeEnabled } = usePublicizeConfig();
+
+	return (
+		<PanelRow>
+			<Text className={ styles.description }>
+				{ ( () => {
+					if ( isPostPublished ) {
+						return __(
+							'Enable the social media accounts where you want to re-share your post, then click on the "Preview and Share" button below.',
+							'jetpack-publicize-components'
+						);
+					}
+
+					return isPublicizeEnabled && hasEnabledConnections
+						? __(
+								'When the post is published, it will be shared automatically on:',
+								'jetpack-publicize-components'
+						  )
+						: _x(
+								'After the post is published, you can preview, and manually share or schedule it.',
+								'',
+								'jetpack-publicize-components'
+						  );
+				} )() }
+			</Text>
+		</PanelRow>
+	);
+}

--- a/projects/js-packages/publicize-components/src/components/panel/index.tsx
+++ b/projects/js-packages/publicize-components/src/components/panel/index.tsx
@@ -4,12 +4,7 @@
  */
 /* eslint-disable @wordpress/no-unsafe-wp-apis */
 import { siteHasFeature } from '@automattic/jetpack-script-data';
-import {
-	CheckboxControl,
-	PanelBody,
-	PanelRow,
-	__experimentalText as Text,
-} from '@wordpress/components';
+import { PanelBody, PanelRow, __experimentalText as Text } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
 import { Fragment } from '@wordpress/element';
@@ -22,6 +17,7 @@ import { features } from '../../utils/constants';
 import PublicizeForm from '../form';
 import { ManualSharing } from '../manual-sharing';
 import { ReSharingPanel } from '../resharing-panel';
+import { AutoShareToggle } from './auto-share-toggle';
 import styles from './styles.module.scss';
 import './global.scss';
 import { UpsellNotice } from './upsell';
@@ -36,7 +32,7 @@ const PublicizePanel = ( { prePublish }: PublicizePanelProps ) => {
 
 	const refreshConnections = useRefreshConnections();
 
-	const { isPublicizeEnabled, hidePublicizeFeature, togglePublicizeFeature } = usePublicizeConfig();
+	const { isPublicizeEnabled, hidePublicizeFeature } = usePublicizeConfig();
 
 	// Refresh connections when the post is just published.
 	usePostJustPublished(
@@ -68,15 +64,6 @@ const PublicizePanel = ( { prePublish }: PublicizePanelProps ) => {
 							{ ! isPostPublished ? (
 								<>
 									<PanelRow>
-										<CheckboxControl
-											label={ __( 'Auto-share post', 'jetpack-publicize-components' ) }
-											onChange={ togglePublicizeFeature }
-											checked={ isPublicizeEnabled && hasConnections }
-											disabled={ ! hasConnections }
-											__nextHasNoMarginBottom={ true }
-										/>
-									</PanelRow>
-									<PanelRow>
 										<Text className={ styles.description }>
 											{ isPublicizeEnabled && hasEnabledConnections
 												? __(
@@ -101,6 +88,7 @@ const PublicizePanel = ( { prePublish }: PublicizePanelProps ) => {
 									</Text>
 								</PanelRow>
 							) }
+							<AutoShareToggle />
 						</>
 					) : null }
 					<PublicizeForm />

--- a/projects/js-packages/publicize-components/src/components/panel/index.tsx
+++ b/projects/js-packages/publicize-components/src/components/panel/index.tsx
@@ -24,14 +24,13 @@ import { ManualSharing } from '../manual-sharing';
 import { ReSharingPanel } from '../resharing-panel';
 import styles from './styles.module.scss';
 import './global.scss';
-import type { ReactNode } from 'react';
+import { UpsellNotice } from './upsell';
 
 type PublicizePanelProps = {
 	prePublish?: boolean;
-	children: ReactNode;
 };
 
-const PublicizePanel = ( { prePublish, children }: PublicizePanelProps ) => {
+const PublicizePanel = ( { prePublish }: PublicizePanelProps ) => {
 	const { refresh, hasConnections, hasEnabledConnections } = useSelectSocialMediaConnections();
 	const isPostPublished = useSelect( select => select( editorStore ).isCurrentPostPublished(), [] );
 
@@ -61,7 +60,7 @@ const PublicizePanel = ( { prePublish, children }: PublicizePanelProps ) => {
 
 	return (
 		<PanelWrapper { ...wrapperProps }>
-			{ children }
+			<UpsellNotice />
 			{ ! hidePublicizeFeature && (
 				<Fragment>
 					{ hasConnections ? (

--- a/projects/js-packages/publicize-components/src/components/panel/index.tsx
+++ b/projects/js-packages/publicize-components/src/components/panel/index.tsx
@@ -2,13 +2,12 @@
  * Publicize sharing panel based on the
  * Jetpack plugin implementation.
  */
-/* eslint-disable @wordpress/no-unsafe-wp-apis */
 import { siteHasFeature } from '@automattic/jetpack-script-data';
-import { PanelBody, PanelRow, __experimentalText as Text } from '@wordpress/components';
+import { PanelBody } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
 import { Fragment } from '@wordpress/element';
-import { __, _x } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import usePublicizeConfig from '../../hooks/use-publicize-config';
 import useRefreshConnections from '../../hooks/use-refresh-connections';
 import { usePostJustPublished } from '../../hooks/use-saving-post';
@@ -18,9 +17,10 @@ import PublicizeForm from '../form';
 import { ManualSharing } from '../manual-sharing';
 import { ReSharingPanel } from '../resharing-panel';
 import { AutoShareToggle } from './auto-share-toggle';
+import { Description } from './description';
 import styles from './styles.module.scss';
-import './global.scss';
 import { UpsellNotice } from './upsell';
+import './global.scss';
 
 type PublicizePanelProps = {
 	prePublish?: boolean;
@@ -32,7 +32,7 @@ const PublicizePanel = ( { prePublish }: PublicizePanelProps ) => {
 
 	const refreshConnections = useRefreshConnections();
 
-	const { isPublicizeEnabled, hidePublicizeFeature } = usePublicizeConfig();
+	const { hidePublicizeFeature } = usePublicizeConfig();
 
 	// Refresh connections when the post is just published.
 	usePostJustPublished(
@@ -61,34 +61,8 @@ const PublicizePanel = ( { prePublish }: PublicizePanelProps ) => {
 				<Fragment>
 					{ hasConnections ? (
 						<>
-							{ ! isPostPublished ? (
-								<>
-									<PanelRow>
-										<Text className={ styles.description }>
-											{ isPublicizeEnabled && hasEnabledConnections
-												? __(
-														'When the post is published, it will be shared automatically on:',
-														'jetpack-publicize-components'
-												  )
-												: _x(
-														'After the post is published, you can preview, and manually share or schedule it.',
-														'',
-														'jetpack-publicize-components'
-												  ) }
-										</Text>
-									</PanelRow>
-								</>
-							) : (
-								<PanelRow>
-									<Text className={ styles.description }>
-										{ __(
-											'Enable the social media accounts where you want to re-share your post, then click on the "Preview and Share" button below.',
-											'jetpack-publicize-components'
-										) }
-									</Text>
-								</PanelRow>
-							) }
 							<AutoShareToggle />
+							<Description />
 						</>
 					) : null }
 					<PublicizeForm />

--- a/projects/js-packages/publicize-components/src/components/panel/upsell.tsx
+++ b/projects/js-packages/publicize-components/src/components/panel/upsell.tsx
@@ -6,7 +6,7 @@ import { store as editorStore } from '@wordpress/editor';
 import { __, _x, sprintf } from '@wordpress/i18n';
 import { external } from '@wordpress/icons';
 import clsx from 'clsx';
-import usePublicizeConfig from '../../../hooks/use-publicize-config';
+import usePublicizeConfig from '../../hooks/use-publicize-config';
 
 /**
  * Upsell notice for the Publicize feature.

--- a/projects/js-packages/publicize-components/src/components/social-post-modal/modal.tsx
+++ b/projects/js-packages/publicize-components/src/components/social-post-modal/modal.tsx
@@ -9,6 +9,7 @@ import { store as editorStore } from '@wordpress/editor';
 import { useCallback } from '@wordpress/element';
 import { __, _x } from '@wordpress/i18n';
 import { close } from '@wordpress/icons';
+import usePublicizeConfig from '../../hooks/use-publicize-config';
 import useSocialMediaConnections from '../../hooks/use-social-media-connections';
 import { store as socialStore } from '../../social-store';
 import { PreviewSection } from './preview-section';
@@ -60,6 +61,7 @@ export function SocialPostModal() {
 	const { recordEvent } = useAnalytics();
 	const { hasConnections } = useSocialMediaConnections();
 	const isPostPublished = useSelect( select => select( editorStore ).isCurrentPostPublished(), [] );
+	const { needsUserConnection } = usePublicizeConfig();
 
 	const handleOpenModal = useCallback( () => {
 		if ( ! isModalOpen ) {
@@ -76,7 +78,11 @@ export function SocialPostModal() {
 		}
 	}, [ closeSharePostModal ] );
 
-	if ( ! hasConnections ) {
+	if (
+		! hasConnections ||
+		// Resharing for published posts cannot work without user connection.
+		( isPostPublished && needsUserConnection )
+	) {
 		return null;
 	}
 

--- a/projects/js-packages/publicize-components/src/components/social-post-modal/settings-section.tsx
+++ b/projects/js-packages/publicize-components/src/components/social-post-modal/settings-section.tsx
@@ -1,5 +1,4 @@
-import { getUserConnectionUrl } from '@automattic/jetpack-connection';
-import { Notice, Panel } from '@wordpress/components';
+import { Panel } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
 import { __, _x } from '@wordpress/i18n';
@@ -27,7 +26,7 @@ export function SettingsSection( { onReShared } ) {
 	const isSavingPost = useSelect( select => select( editorStore ).isSavingPost(), [] );
 	const postId = useSelect( select => select( editorStore ).getCurrentPostId(), [] );
 
-	const { isRePublicizeUpgradableViaUpsell, needsUserConnection } = usePublicizeConfig();
+	const { isRePublicizeUpgradableViaUpsell } = usePublicizeConfig();
 	const isReSharingPossible = useIsReSharingPossible();
 	const { enabledConnections } = useSocialMediaConnections();
 
@@ -65,24 +64,6 @@ export function SettingsSection( { onReShared } ) {
 					) }
 				</p>
 				<SharePostForm analyticsData={ { location: 'preview-modal' } } />
-				{ needsUserConnection && isPostPublished && (
-					<Notice
-						status={ 'warning' }
-						isDismissible={ false }
-						actions={ [
-							{
-								url: getUserConnectionUrl(),
-								label: __( 'Connect now', 'jetpack-publicize-components' ),
-								variant: 'link',
-							},
-						] }
-					>
-						{ __(
-							'You must connect your WordPress.com account to be able to re-share posts.',
-							'jetpack-publicize-components'
-						) }
-					</Notice>
-				) }
 				{ isPostPublished && ! isRePublicizeUpgradableViaUpsell && (
 					<div className={ styles[ 'share-actions' ] }>
 						<ScheduleButton


### PR DESCRIPTION
Completes SOCIAL-234

Currently, resharing is possible only if there is user connection but we still show the unnecessary UI. We instead want to hide the unnecessary UI and only show the notice that the user needs to connect their wp.com account.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Move auto-share toggle and the Social panel description to their own components to similify the consumer component
* Update the "Preview and share" button logic to always show it except when resharing without user connection
* Consolidate user connection notices into a single component

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* With only a site connection, go to Jetpack sidebar in the editor
* Confirm that you see the notice to connect your WPCOM account
* Complete the user connection and add some social media accounts.
* Now as a secondary author or admin, go to social sidebar
* Confirm that you see the notice to connect WPCOM account
* As the primary admin, mark a connection or two as shared on Jetpack > Social
* Now as secondary user, add new post
* Confirm that you see the shared connections in the sidebar with the notice to connect wpcom account
* Now edit an existing post as the secondary user
* Confirm that you don't see the "Preview & Share" button
* Confirm that the connections are disabled
* Confirm that you instead see the notice to connect the wpcom account

<img width="271" height="359" alt="image" src="https://github.com/user-attachments/assets/8acaf195-b958-4835-8065-ff02ad985006" />
