### PR TITLE
jetpack-mu-wpcom Code Block: Ensure block scrolls as expected

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/code-block-ensure-no-max-width-scroll-break
+++ b/projects/packages/jetpack-mu-wpcom/changelog/code-block-ensure-no-max-width-scroll-break
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Unreleased code block: Ensure PRE element does not break scroll behavior.

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/style.css
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/style.css
@@ -56,6 +56,7 @@
 	/* Essential layout and styling for PRE, CODE */
 	pre,
 	code {
+		max-width: none !important;
 		margin: 0 !important;
 		padding: 0 !important;
 		line-height: inherit !important;


### PR DESCRIPTION
## Proposed changes:

Fix an issue where themes may add a `max-width` to `PRE` elements and break the layout structure that allows the code block to scroll.

| before | after |
|--------|--------|
| <img width="1204" height="238" alt="Screenshot 2025-11-20 at 14 20 57" src="https://github.com/user-attachments/assets/08846e53-b761-4b99-97b4-ddb945535a0b" /> | <img width="1204" height="238" alt="Screenshot 2025-11-20 at 14 20 26" src="https://github.com/user-attachments/assets/c3dd7940-4f1c-4bf3-8167-f0dc75c8e8aa" /> |


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?



## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:

See screenshots.
Add a code block with long lines. Ensure content scrolls as expected.
The issue was present on sites with P2 theme.