### PR TITLE
Forms: consistently open sidebar or modal on small and medium screens

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-inbox-modal-on-small-screen
+++ b/projects/packages/forms/changelog/fix-forms-inbox-modal-on-small-screen
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fixed
+
+Forms: consistently open sidebar or modal on small and medium screens

--- a/projects/packages/forms/src/dashboard/components/inspector/style.scss
+++ b/projects/packages/forms/src/dashboard/components/inspector/style.scss
@@ -18,11 +18,7 @@
 
 .jp-forms__inbox-response-header {
 	margin: 24px 0 0;
-	padding: 0 16px 0 0;
-
-	@media (min-width: #{ (breakpoints.$break-medium + 1) }) {
-		padding: 0 16px;
-	}
+	padding: 0 16px;
 }
 
 .jp-forms__inbox-response-header-title {
@@ -143,18 +139,13 @@
 
 .jp-forms__inbox__tip-container {
 	border-top: 1px solid var(--jp-forms-border-color);
-	margin: 8px 0 0 0;
-	padding: 16px 0;
+	margin: 8px 0 57px 0; // Compensate for fixed footer from DataViews
+	padding: 16px;
 	text-wrap: balance;
 
 	// https://wordpress.github.io/gutenberg/?path=/docs/components-tip--docs
 	.components-tip {
 		align-items: anchor-center;
-	}
-
-	@media (min-width: #{ (breakpoints.$break-medium + 1) }) {
-		padding: 16px 16px;
-		margin-bottom: 57px; // Compensate for fixed footer from DataViews
 	}
 }
 
@@ -170,9 +161,12 @@
 	}
 }
 
-
-// Styling override when loaded in modal on mobile
+// Styling override when loaded in modal
 .components-modal__content {
+
+	.jp-forms__inbox-response-header {
+		padding-left: 0;
+	}
 
 	.jp-forms__inbox-response-title,
 	.jp-forms__inbox-response-subtitle,
@@ -180,6 +174,11 @@
 	.jp-forms__inbox-response-data {
 		padding-left: 0;
 		padding-right: 0;
+	}
+
+	.jp-forms__inbox__tip-container {
+		margin-bottom: 0;
+		margin-left: 0;
 	}
 
 	.jp-forms__inbox-file-preview-modal {

--- a/projects/packages/forms/src/dashboard/components/layout/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/layout/index.tsx
@@ -31,10 +31,8 @@ const Layout = () => {
 
 	return (
 		<div className="jp-forms-layout">
-			<div className="jp-forms-layout__content">
-				{ ! isLoadingConfig && <Outlet /> }
-				{ isIntegrationsOpen && showDashboardIntegrations && <Integrations /> }
-			</div>
+			{ ! isLoadingConfig && <Outlet /> }
+			{ isIntegrationsOpen && showDashboardIntegrations && <Integrations /> }
 		</div>
 	);
 };

--- a/projects/packages/forms/src/dashboard/inbox/stage/index.js
+++ b/projects/packages/forms/src/dashboard/inbox/stage/index.js
@@ -46,6 +46,7 @@ import {
 import { useView, defaultLayouts } from './views.js';
 
 const EMPTY_ARRAY = [];
+const NO_SIDEBAR_BREAKPOINT = 1000;
 
 const updateSidebarWidth = () => {
 	const wrapper = document.querySelector( '.dataviews-wrapper' );
@@ -94,8 +95,9 @@ export default function InboxView() {
 		{ box: 'border-box' }
 	);
 
-	const selectedResponses = searchParams.get( 'r' );
+	const isResponseInModal = containerWidth <= NO_SIDEBAR_BREAKPOINT;
 	const isMobileViewport = useViewportMatch( 'medium', '<' );
+	const selectedResponses = searchParams.get( 'r' );
 	const [ isResponseModalOpen, setIsResponseModalOpen ] = useState( false );
 	const [ responseModal, setResponseModal ] = useState( null );
 
@@ -115,10 +117,10 @@ export default function InboxView() {
 	);
 
 	useEffect( () => {
-		if ( ! isMobileViewport ) {
+		if ( ! isResponseInModal && isResponseModalOpen ) {
 			closeResponseModal();
 		}
-	}, [ isMobileViewport, closeResponseModal ] );
+	}, [ isResponseInModal, closeResponseModal, isResponseModalOpen ] );
 
 	useEffect( () => {
 		return setupSidebarWidthObserver();
@@ -205,7 +207,7 @@ export default function InboxView() {
 	// Manage sidebar visibility based on selection
 	// Only show sidebar when exactly one item is selected on desktop
 	useEffect( () => {
-		if ( isMobileViewport ) {
+		if ( isResponseInModal ) {
 			// Don't manage sidebar on mobile
 			return;
 		}
@@ -230,7 +232,7 @@ export default function InboxView() {
 		if ( ! sidePanelItem || getItemId( sidePanelItem ) !== getItemId( recordToShow ) ) {
 			setSidePanelItem( recordToShow );
 		}
-	}, [ isMobileViewport, records, selection, sidePanelItem ] );
+	}, [ isResponseInModal, records, selection, sidePanelItem ] );
 
 	const paginationInfo = useMemo(
 		() => ( { totalItems, totalPages } ),
@@ -261,7 +263,7 @@ export default function InboxView() {
 							</span>
 						) : null;
 
-					const handleClick = isMobileViewport ? () => openResponseModal( item ) : undefined;
+					const handleClick = isResponseInModal ? () => openResponseModal( item ) : undefined;
 
 					return (
 						<div
@@ -393,13 +395,14 @@ export default function InboxView() {
 			filterOptions?.date,
 			filterOptions?.source,
 			isMobileViewport,
+			isResponseInModal,
 			openResponseModal,
 			dateSettings.formats.date,
 		]
 	);
 
 	const actions = useMemo( () => {
-		const mobileViewAction = {
+		const modalViewAction = {
 			...viewAction,
 			RenderModal: ( { items, closeModal } ) => {
 				jetpackAnalytics.tracks.recordEvent( 'jetpack_forms_inbox_action_click', {
@@ -411,10 +414,11 @@ export default function InboxView() {
 
 				return <ResponseMobileView response={ item } closeModal={ closeModal } />;
 			},
+			modalSize: 'large',
 			hideModalHeader: true,
 		};
 
-		const desktopViewAction = {
+		const sidebarViewAction = {
 			...viewAction,
 			callback( items ) {
 				jetpackAnalytics.tracks.recordEvent( 'jetpack_forms_inbox_action_click', {
@@ -430,7 +434,7 @@ export default function InboxView() {
 			},
 		};
 
-		const viewResponseAction = isMobileViewport ? mobileViewAction : desktopViewAction;
+		const viewResponseAction = isResponseInModal ? modalViewAction : sidebarViewAction;
 
 		const primaryActions = [ viewResponseAction ];
 		const secondaryActions = [ markAsUnreadAction, editFormAction ];
@@ -449,7 +453,7 @@ export default function InboxView() {
 					...secondaryActions,
 				];
 		}
-	}, [ isMobileViewport, onChangeSelection, statusFilter ] );
+	}, [ isResponseInModal, onChangeSelection, statusFilter ] );
 
 	const resetPage = useCallback( () => {
 		view.page = 1;
@@ -538,10 +542,12 @@ export default function InboxView() {
 	);
 
 	return (
-		<>
-			<div ref={ containerRef } className="jp-forms-layout__surface is-stage">
-				{ pageContent }
-			</div>
+		<div
+			className="jp-forms-layout__content"
+			ref={ containerRef }
+			style={ { border: '1px solid red' } }
+		>
+			<div className="jp-forms-layout__surface is-stage">{ pageContent }</div>
 			{ isResponseModalOpen && (
 				<Modal
 					title={ __( 'Response', 'jetpack-forms' ) }
@@ -551,18 +557,18 @@ export default function InboxView() {
 					{ responseModal }
 				</Modal>
 			) }
-			{ selection.length === 1 && sidePanelItem && ! isMobileViewport && (
+			{ selection.length === 1 && sidePanelItem && ! isResponseInModal && (
 				<div className="jp-forms-layout__surface is-inspector">
 					<SingleResponseView
 						sidePanelItem={ sidePanelItem }
 						setSidePanelItem={ setSidePanelItem }
 						isLoadingData={ isLoadingData }
-						isMobile={ isMobileViewport }
+						isMobile={ isResponseInModal }
 						onChangeSelection={ onChangeSelection }
 						selection={ selection }
 					/>
 				</div>
 			) }
-		</>
+		</div>
 	);
 }

--- a/projects/packages/forms/src/dashboard/inbox/stage/index.js
+++ b/projects/packages/forms/src/dashboard/inbox/stage/index.js
@@ -540,11 +540,7 @@ export default function InboxView() {
 	);
 
 	return (
-		<div
-			className="jp-forms-layout__content"
-			ref={ containerRef }
-			style={ { border: '1px solid red' } }
-		>
+		<div className="jp-forms-layout__content" ref={ containerRef }>
 			<div className="jp-forms-layout__surface is-stage">{ pageContent }</div>
 			{ isResponseModalOpen && (
 				<Modal

--- a/projects/packages/forms/src/dashboard/inbox/stage/index.js
+++ b/projects/packages/forms/src/dashboard/inbox/stage/index.js
@@ -46,7 +46,6 @@ import {
 import { useView, defaultLayouts } from './views.js';
 
 const EMPTY_ARRAY = [];
-const NO_SIDEBAR_BREAKPOINT = 1000;
 
 const updateSidebarWidth = () => {
 	const wrapper = document.querySelector( '.dataviews-wrapper' );
@@ -94,8 +93,7 @@ export default function InboxView() {
 		},
 		{ box: 'border-box' }
 	);
-
-	const isResponseInModal = containerWidth <= NO_SIDEBAR_BREAKPOINT;
+	const isResponseInModal = containerWidth <= 1000;
 	const isMobileViewport = useViewportMatch( 'medium', '<' );
 	const selectedResponses = searchParams.get( 'r' );
 	const [ isResponseModalOpen, setIsResponseModalOpen ] = useState( false );

--- a/projects/packages/forms/src/dashboard/inbox/stage/index.js
+++ b/projects/packages/forms/src/dashboard/inbox/stage/index.js
@@ -547,6 +547,7 @@ export default function InboxView() {
 					title={ __( 'Response', 'jetpack-forms' ) }
 					__experimentalHideHeader={ true }
 					onRequestClose={ closeResponseModal }
+					size="fill"
 				>
 					{ responseModal }
 				</Modal>

--- a/projects/packages/forms/src/dashboard/inbox/stage/index.js
+++ b/projects/packages/forms/src/dashboard/inbox/stage/index.js
@@ -412,7 +412,7 @@ export default function InboxView() {
 
 				return <ResponseMobileView response={ item } closeModal={ closeModal } />;
 			},
-			modalSize: 'large',
+			modalSize: 'fill',
 			hideModalHeader: true,
 		};
 
@@ -542,7 +542,7 @@ export default function InboxView() {
 	return (
 		<div className="jp-forms-layout__content" ref={ containerRef }>
 			<div className="jp-forms-layout__surface is-stage">{ pageContent }</div>
-			{ isResponseModalOpen && (
+			{ selection.length === 1 && isResponseModalOpen && (
 				<Modal
 					title={ __( 'Response', 'jetpack-forms' ) }
 					__experimentalHideHeader={ true }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Follow up to earlier fix for FORMS-423
Fixes FORMS-365

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds some styling and logic on when we open modal vs sidebar
* Makes all modals "fill" size, to take all the space on the screen

There's more follow-ups I think to do to make logic more robus e.g. when changing screen size after page has already loaded (modal and sidebar can be open at the same time now), as well as generally just simplify code much more. That's all better done after https://github.com/Automattic/jetpack/pull/45989 lands. Meanwhile this improves things already for the release.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Test opening responses in different screen sizes

