### PR TITLE
likes-settings: Stop fatal error in the rare event the sharing-opt ions is malformed

### DIFF
--- a/projects/plugins/jetpack/changelog/settings-update-likes
+++ b/projects/plugins/jetpack/changelog/settings-update-likes
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: likes-settings: Stop fatal error in the rare event the sharing-options is malformed
+
+

--- a/projects/plugins/jetpack/modules/likes/jetpack-likes-settings.php
+++ b/projects/plugins/jetpack/modules/likes/jetpack-likes-settings.php
@@ -471,6 +471,13 @@ class Jetpack_Likes_Settings {
 		$setting['disabled'] = get_option( 'disabled_likes' );
 		$sharing             = get_option( 'sharing-options', array() );
 
+		if ( ! is_array( $sharing ) ) {
+			$sharing = array();
+		}
+		if ( ! isset( $sharing['global'] ) || ! is_array( $sharing['global'] ) ) {
+			$sharing['global'] = array();
+		}
+
 		// Default visibility settings
 		if ( ! isset( $sharing['global']['show'] ) ) {
 			$sharing['global']['show'] = array( 'post', 'page' );


### PR DESCRIPTION
Stopping a rare fatal error when the data coming from `$sharing             = get_option( 'sharing-options', array() );` is the wrong shape.

## Proposed changes:
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

## Does this pull request change what data or activity we track or use?

## Testing instructions:

* Go to '..'
*

