### PR TITLE
pr-is-up-to-date: Fail workflow if updating GitHub status fails

### DIFF
--- a/projects/github-actions/pr-is-up-to-date/changelog/fix-pr-is-up-to-date-fail
+++ b/projects/github-actions/pr-is-up-to-date/changelog/fix-pr-is-up-to-date-fail
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fail the workflow if updating the GitHub status fails.

--- a/projects/github-actions/pr-is-up-to-date/funcs.sh
+++ b/projects/github-actions/pr-is-up-to-date/funcs.sh
@@ -180,7 +180,7 @@ function should_process_pr {
 function update_github_status {
 	if [[ -n "$CI" ]]; then
 		echo "::group::Setting GitHub status"
-		curl -v \
+		curl -v --fail-with-body \
 			--url "${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/statuses/${1}" \
 			--header "authorization: Bearer $API_TOKEN" \
 			--header 'content-type: application/json' \


### PR DESCRIPTION
Closes MONOREP-237

 <!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
If the status update fails for some reason, the workflow should fail to make the failure visible to users.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1763653706347359-slack-C05Q5HSS013

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* 🤷