### PR TITLE
Global Styles on Personal: Update status endpoint

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/dotcom-15278-global-styles-on-personal-abc-api-changes
+++ b/projects/packages/jetpack-mu-wpcom/changelog/dotcom-15278-global-styles-on-personal-abc-api-changes
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+We now include the experiment variation in the global styles status response

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/api/class-global-styles-status-rest-api.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/api/class-global-styles-status-rest-api.php
@@ -68,6 +68,7 @@ class Global_Styles_Status_Rest_API extends WP_REST_Controller {
 			'globalStylesInUse'          => wpcom_global_styles_in_use(),
 			'shouldLimitGlobalStyles'    => wpcom_should_limit_global_styles(),
 			'globalStylesInPersonalPlan' => is_global_styles_on_personal_plan(),
+			'variation'                  => get_global_styles_on_personal_variation(),
 		);
 	}
 }

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/index.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/index.php
@@ -816,14 +816,12 @@ function get_global_styles_on_personal_variation() {
 	);
 
 	// Cache lookup.
-	$found     = null;
+	$found     = false;
 	$variation = wp_cache_get( $cache_key, $cache_group, false, $found );
 	$found     = apply_filters( 'wpcom_global_styles_experiment_cache', $found );
 	if ( true === $found ) {
 		return (bool) $variation;
 	}
-
-	$found = null;
 
 	if ( $is_atomic ) {
 		// Atomic: ask WP.com assignment API for this user.

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/index.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/index.php
@@ -816,14 +816,14 @@ function get_global_styles_on_personal_variation() {
 	);
 
 	// Cache lookup.
-	$variation = null;
-	$cached    = wp_cache_get( $cache_key, $cache_group, false, $variation );
-	$variation = apply_filters( 'wpcom_global_styles_experiment_cache', $variation );
-	if ( true === $variation ) {
-		return (bool) $cached;
+	$found     = null;
+	$variation = wp_cache_get( $cache_key, $cache_group, false, $found );
+	$found     = apply_filters( 'wpcom_global_styles_experiment_cache', $found );
+	if ( true === $found ) {
+		return (bool) $variation;
 	}
 
-	$variation = null;
+	$found = null;
 
 	if ( $is_atomic ) {
 		// Atomic: ask WP.com assignment API for this user.

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/index.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/index.php
@@ -784,6 +784,69 @@ function wpcom_global_styles_is_previewing_premium_theme_without_premium_plan( $
 }
 
 /**
+ * Returns the experiment variation. The code is bad, it's duplicated. It's a tradeoff since this code will be deleted
+ * after the experiment and it's easier to duplicate than to refactor the original given testing complexities and time constraints.
+ * Yes, this is inefficient and duplicates a lot of code, I know.
+ *
+ * @return bool Whether the site has access to Global Styles with a Personal plan.
+ */
+function get_global_styles_on_personal_variation() {
+	// Environment guard: only WP.com or Atomic.
+	$is_wpcom  = defined( 'IS_WPCOM' ) && IS_WPCOM;
+	$is_atomic = defined( 'IS_ATOMIC' ) && IS_ATOMIC;
+	if ( ! $is_wpcom && ! $is_atomic ) {
+		return false;
+	}
+
+	$wpcom_blog_owner_id = null;
+	$wpcom_blog_id       = get_wpcom_blog_id();
+	if ( function_exists( 'wpcom_get_blog_owner' ) ) {
+		$wpcom_blog_owner_id = wpcom_get_blog_owner( $wpcom_blog_id );
+	}
+
+	if ( ! $wpcom_blog_id ) {
+		return false;
+	}
+
+	$experiment_key = 'calypso_plans_global_styles_personal_20251124_v5';
+	$cache_group    = 'a8c_experiments';
+	$cache_key      = sprintf(
+		'global-styles-personal-variation-%d',
+		$wpcom_blog_id
+	);
+
+	// Cache lookup.
+	$variation = null;
+	$cached    = wp_cache_get( $cache_key, $cache_group, false, $variation );
+	$variation = apply_filters( 'wpcom_global_styles_experiment_cache', $variation );
+	if ( true === $variation ) {
+		return (bool) $cached;
+	}
+
+	$variation = null;
+
+	if ( $is_atomic ) {
+		// Atomic: ask WP.com assignment API for this user.
+		$variation = wpcom_global_styles_assignment_api_request( $wpcom_blog_id );
+	} elseif ( function_exists( '\ExPlat\assign_given_user' ) && function_exists( 'wpcom_get_blog_owner' ) ) {
+		if ( ! $wpcom_blog_owner_id ) {
+			return false;
+		}
+		$wpcom_blog_owner = get_userdata( $wpcom_blog_owner_id );
+		if ( ! $wpcom_blog_owner ) {
+			return false;
+		}
+		// WP.com: Direct ExPlat assignment.
+		$variation = \ExPlat\assign_given_user( $experiment_key, $wpcom_blog_owner );
+	}
+
+	// Cache for a month to avoid duplicate calls.
+	wp_cache_set( $cache_key, $variation, $cache_group, MONTH_IN_SECONDS );
+
+	return $variation;
+}
+
+/**
  * Checks whether the site has access to Global Styles with a Personal plan as part of an A/B test.
  *
  * @return bool Whether the site has access to Global Styles with a Personal plan.

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/index.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/index.php
@@ -820,7 +820,7 @@ function get_global_styles_on_personal_variation() {
 	$variation = wp_cache_get( $cache_key, $cache_group, false, $found );
 	$found     = apply_filters( 'wpcom_global_styles_experiment_cache', $found );
 	if ( true === $found ) {
-		return (bool) $variation;
+		return $variation;
 	}
 
 	if ( $is_atomic ) {

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/index.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/index.php
@@ -729,7 +729,7 @@ function wpcom_site_has_global_styles_feature( $blog_id = 0 ) {
  * Returns false on errors or when not assigned.
  *
  * @param int $blog_id The WPCOM blog ID.
- * @return bool Whether the site is assigned to a non-null variation for the experiment.
+ * @return bool|string The experiment variation if the site has access to Global Styles with a Personal plan, false otherwise.
  */
 function wpcom_global_styles_assignment_api_request( $blog_id ) {
 	$response = Automattic\Jetpack\Connection\Client::wpcom_json_api_request_as_user(
@@ -755,7 +755,7 @@ function wpcom_global_styles_assignment_api_request( $blog_id ) {
 		return false;
 	}
 
-	return 'treatment' === $data['variation'];
+	return $data['variation'];
 }
 
 /**
@@ -784,11 +784,9 @@ function wpcom_global_styles_is_previewing_premium_theme_without_premium_plan( $
 }
 
 /**
- * Returns the experiment variation. The code is bad, it's duplicated. It's a tradeoff since this code will be deleted
- * after the experiment and it's easier to duplicate than to refactor the original given testing complexities and time constraints.
- * Yes, this is inefficient and duplicates a lot of code, I know.
+ * Returns the experiment variation.
  *
- * @return bool Whether the site has access to Global Styles with a Personal plan.
+ * @return bool|string The experiment variation if the site has access to Global Styles with a Personal plan, false otherwise.
  */
 function get_global_styles_on_personal_variation() {
 	// Environment guard: only WP.com or Atomic.
@@ -850,60 +848,8 @@ function get_global_styles_on_personal_variation() {
  * @return bool Whether the site has access to Global Styles with a Personal plan.
  */
 function is_global_styles_on_personal_plan() {
-	// Environment guard: only WP.com or Atomic.
-	$is_wpcom  = defined( 'IS_WPCOM' ) && IS_WPCOM;
-	$is_atomic = defined( 'IS_ATOMIC' ) && IS_ATOMIC;
-	if ( ! $is_wpcom && ! $is_atomic ) {
-		return false;
-	}
-
-	$wpcom_blog_owner_id = null;
-	$wpcom_blog_id       = get_wpcom_blog_id();
-	if ( function_exists( 'wpcom_get_blog_owner' ) ) {
-		$wpcom_blog_owner_id = wpcom_get_blog_owner( $wpcom_blog_id );
-	}
-
-	if ( ! $wpcom_blog_id ) {
-		return false;
-	}
-
-	$experiment_key = 'calypso_plans_global_styles_personal_20251124_v5';
-	$cache_group    = 'a8c_experiments';
-	$cache_key      = sprintf(
-		'global-styles-personal-%d',
-		$wpcom_blog_id
-	);
-
-	// Cache lookup.
-	$found  = false;
-	$cached = wp_cache_get( $cache_key, $cache_group, false, $found );
-	$found  = apply_filters( 'wpcom_global_styles_experiment_cache', $found );
-	if ( true === $found ) {
-		return (bool) $cached;
-	}
-
-	$enabled = false;
-
-	if ( $is_atomic ) {
-		// Atomic: ask WP.com assignment API for this user.
-		$enabled = wpcom_global_styles_assignment_api_request( $wpcom_blog_id );
-	} elseif ( function_exists( '\ExPlat\assign_given_user' ) && function_exists( 'wpcom_get_blog_owner' ) ) {
-		if ( ! $wpcom_blog_owner_id ) {
-			return false;
-		}
-		$wpcom_blog_owner = get_userdata( $wpcom_blog_owner_id );
-		if ( ! $wpcom_blog_owner ) {
-			return false;
-		}
-		// WP.com: Direct ExPlat assignment.
-		$assignment = \ExPlat\assign_given_user( $experiment_key, $wpcom_blog_owner );
-		$enabled    = ( null !== $assignment );
-	}
-
-	// Cache for a month to avoid duplicate calls.
-	wp_cache_set( $cache_key, $enabled, $cache_group, MONTH_IN_SECONDS );
-
-	return $enabled;
+	$variation = get_global_styles_on_personal_variation();
+	return $variation === 'treatment1' || $variation === 'treatment2';
 }
 
 /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes:
- https://linear.app/a8c/issue/DOTCOM-15278/global-styles-on-personal-abc-api-changes

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* We now return the experiment variation in the global styles endpoint.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Follow the instructions here: https://github.com/Automattic/wp-calypso/pull/107248

