### PR TITLE
Forms: fix name variation isActive setting

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-name-variation-isactive
+++ b/projects/packages/forms/changelog/fix-forms-name-variation-isactive
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: fix name variation isActive setting.

--- a/projects/packages/forms/src/blocks/field-name/variations.js
+++ b/projects/packages/forms/src/blocks/field-name/variations.js
@@ -22,7 +22,6 @@ const variations = [
 		description: __( 'Collect the visitor’s name.', 'jetpack-forms' ),
 		icon,
 		scope: [ 'transform' ],
-		isActive: ( { id } ) => ! [ FIRST_NAME_ID, LAST_NAME_ID ].includes( id ),
 		attributes: {
 			id: '',
 		},

--- a/projects/plugins/jetpack/changelog/fix-forms-name-variation-isactive
+++ b/projects/plugins/jetpack/changelog/fix-forms-name-variation-isactive
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Forms: fix name variation isActive setting.


### PR DESCRIPTION
## Proposed changes:

[This PR](https://github.com/Automattic/jetpack/pull/45985) set the Name > Name variation to active if the name field is present and doesn't have the first-name or last-name IDs actively. But because both the core Name block and the Name Variation have empty IDs, this leads to use setting Name variation as active when the core Name block is inserted. This is breaking some E2E tests. 

This PR is a quick fix that just leaves isActive unset for the name variation as it was before. 

I'll work on a longer-term solution as a follow up. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
Slack: p1763586367177249-slack-C034JEXD1RD

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Insert a form on page or post
* Try inserting name vs first name vs last name blocks/variations and confirm no issues
* Try transforming between name vs first name vs last name variations and confirm no issues