### PR TITLE
Forms: Update copy and fix spam age check

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-spam-scheduled-trash
+++ b/projects/packages/forms/changelog/fix-forms-spam-scheduled-trash
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: Trash old spam instead of fully deleting

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -22,6 +22,7 @@ use WP_Block;
 use WP_Block_Patterns_Registry;
 use WP_Block_Type_Registry;
 use WP_Error;
+use WP_Post;
 
 // Load the Form_Submission_Error class.
 require_once __DIR__ . '/class-form-submission-error.php';
@@ -3390,7 +3391,7 @@ class Contact_Form_Plugin {
 	 * @param string  $old_status The old post status.
 	 * @param WP_Post $post       The post object.
 	 */
-	public function track_spam_status_change( $new_status, $old_status, $post ) {
+	public function track_spam_status_change( $new_status, $old_status, WP_Post $post ) {
 		// Only track for feedback posts
 		if ( 'feedback' !== $post->post_type ) {
 			return;

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -299,6 +299,9 @@ class Contact_Form_Plugin {
 			)
 		);
 
+		// Track when post status changes to 'spam' for accurate deletion timing
+		add_action( 'transition_post_status', array( $this, 'track_spam_status_change' ), 10, 3 );
+
 		// POST handler
 		if (
 			isset( $_SERVER['REQUEST_METHOD'] ) && 'POST' === strtoupper( sanitize_text_field( wp_unslash( $_SERVER['REQUEST_METHOD'] ) ) )
@@ -3377,6 +3380,30 @@ class Contact_Form_Plugin {
 			return 'publish';
 		}
 		return $current_status;
+	}
+
+	/**
+	 * Tracks when a feedback post status changes to 'spam' and stores the timestamp.
+	 * This allows us to accurately determine when spam was marked, independent of other post updates.
+	 *
+	 * @param string  $new_status The new post status.
+	 * @param string  $old_status The old post status.
+	 * @param WP_Post $post       The post object.
+	 */
+	public function track_spam_status_change( $new_status, $old_status, $post ) {
+		// Only track for feedback posts
+		if ( 'feedback' !== $post->post_type ) {
+			return;
+		}
+
+		// Only track when status changes TO spam (not from spam to something else)
+		if ( 'spam' === $new_status && 'spam' !== $old_status ) {
+			// Store the current GMT timestamp when status changes to spam
+			update_post_meta( $post->ID, '_spam_status_changed_gmt', current_time( 'mysql', 1 ) );
+		} elseif ( 'spam' === $old_status && 'spam' !== $new_status ) {
+			// Remove the meta when post is no longer spam
+			delete_post_meta( $post->ID, '_spam_status_changed_gmt' );
+		}
 	}
 
 	/**

--- a/projects/packages/forms/src/contact-form/class-util.php
+++ b/projects/packages/forms/src/contact-form/class-util.php
@@ -247,7 +247,7 @@ class Util {
 			"
 			SELECT `ID`
 			FROM $wpdb->posts
-			WHERE DATE_SUB( %s, INTERVAL 15 DAY ) > `post_date_gmt`
+			WHERE DATE_SUB( %s, INTERVAL 15 DAY ) > `post_modified_gmt`
 				AND `post_type` = 'feedback'
 				AND `post_status` = 'spam'
 			LIMIT %d

--- a/projects/packages/forms/src/contact-form/class-util.php
+++ b/projects/packages/forms/src/contact-form/class-util.php
@@ -258,8 +258,8 @@ class Util {
 		$post_ids = $wpdb->get_col( $sql ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 
 		foreach ( (array) $post_ids as $post_id ) {
-			// force a full delete, skip the trash
-			wp_delete_post( $post_id, true );
+			// move to trash
+			wp_trash_post( $post_id );
 		}
 
 		if (

--- a/projects/packages/forms/src/contact-form/class-util.php
+++ b/projects/packages/forms/src/contact-form/class-util.php
@@ -242,14 +242,16 @@ class Util {
 
 		$grunion_delete_limit = 100;
 
-		$now_gmt  = current_time( 'mysql', 1 );
+		$now_gmt = current_time( 'mysql', 1 );
+		// Use the spam status changed date if available, otherwise fall back to post_date_gmt for backward compatibility
 		$sql      = $wpdb->prepare(
 			"
-			SELECT `ID`
-			FROM $wpdb->posts
-			WHERE DATE_SUB( %s, INTERVAL 15 DAY ) > `post_modified_gmt`
-				AND `post_type` = 'feedback'
-				AND `post_status` = 'spam'
+			SELECT p.`ID`
+			FROM $wpdb->posts p
+			LEFT JOIN $wpdb->postmeta pm ON p.`ID` = pm.`post_id` AND pm.`meta_key` = '_spam_status_changed_gmt'
+			WHERE DATE_SUB( %s, INTERVAL 15 DAY ) > COALESCE( pm.`meta_value`, p.`post_date_gmt` )
+				AND p.`post_type` = 'feedback'
+				AND p.`post_status` = 'spam'
 			LIMIT %d
 		",
 			$now_gmt,

--- a/projects/packages/forms/src/contact-form/class-util.php
+++ b/projects/packages/forms/src/contact-form/class-util.php
@@ -260,8 +260,8 @@ class Util {
 		$post_ids = $wpdb->get_col( $sql ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 
 		foreach ( (array) $post_ids as $post_id ) {
-			// move to trash
-			wp_trash_post( $post_id );
+			// force a full delete, skip the trash
+			wp_delete_post( $post_id, true );
 		}
 
 		if (

--- a/projects/packages/forms/src/dashboard/components/empty-responses/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/empty-responses/index.tsx
@@ -56,7 +56,10 @@ const EmptyResponses = ( { status, isSearch, readStatusFilter }: EmptyResponsesP
 	}
 
 	const noSpamHeading = __( 'Lucky you, no spam!', 'jetpack-forms' );
-	const noSpamMessage = __( 'Spam responses are moved to trash after 15 days.', 'jetpack-forms' );
+	const noSpamMessage = __(
+		'Spam responses are permanently deleted after 15 days.',
+		'jetpack-forms'
+	);
 	if ( status === 'spam' ) {
 		return <EmptyWrapper heading={ noSpamHeading } body={ noSpamMessage } />;
 	}

--- a/projects/packages/forms/src/dashboard/components/inspector/body.tsx
+++ b/projects/packages/forms/src/dashboard/components/inspector/body.tsx
@@ -391,7 +391,9 @@ const ResponseViewBody = ( {
 			</div>
 			{ response.status === 'spam' && (
 				<div className="jp-forms__inbox__tip-container">
-					<Tip>{ __( 'Spam responses are moved to trash after 15 days.', 'jetpack-forms' ) }</Tip>
+					<Tip>
+						{ __( 'Spam responses are permanently deleted after 15 days.', 'jetpack-forms' ) }
+					</Tip>
 				</div>
 			) }
 			{ response.status === 'trash' && (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes FORMS-426

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Updates the copy to tell spam is going to be permanently deleted
* Uses the response modification date instead of creation date to determine if 15 days has passed since it was marked as spam, as the only changes for responses after submission are their status

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Tip: Test this one locally to easily change the time from 15 days to something manageable like 1 minute

* Before applying this PR, move an old response to spam. This will be the fallback response, it will use the post creation time to determine how long ago it was marked as spam (current implementation)
* Apply this PR
* Go to the dashboard and mark another old response as spam. This will be the response with updated post meta, it will use a new post meta value with the actual time of status change (new implementation)
* Run the cron job with `wp cron event run grunion_scheduled_delete`
* Check that the fallback response is deleted, but not the response with updated post meta.
* Modify the time in the query from 15 days to something more manageable like 1 minute
* Wait for 1 minute (or however much you changed the check to)
* Run the cron job again
* Check that the new spam is deleted
* Check that when the spam page is empty, the message says spam will be deleted in 15 days