### PR TITLE
CI: Update timeouts and comments (part 2)

### DIFF
--- a/.github/workflows/build-docker-monorepo.yml
+++ b/.github/workflows/build-docker-monorepo.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    timeout-minutes: 5  # 2025-03-04: Takes just a few seconds.
+    timeout-minutes: 5  # 2025-11-20: Takes just a few seconds.
     outputs:
       php-version: ${{ steps.buildargs.outputs.php-version }}
       composer-version: ${{ steps.buildargs.outputs.composer-version }}
@@ -72,7 +72,7 @@ jobs:
     permissions:
       packages: write
       contents: read
-    timeout-minutes: 15  # 2025-03-04: Arm64 build takes about 5 minutes, amd64 build about 3.
+    timeout-minutes: 20  # 2025-11-20: Arm64 build takes about 6 minutes, amd64 build about 3.
     strategy:
       matrix:
         include:
@@ -148,7 +148,7 @@ jobs:
     permissions:
       packages: write
       contents: read
-    timeout-minutes: 5  # 2025-03-04: Merge takes less than a minute.
+    timeout-minutes: 5  # 2025-11-20: Merge takes less than a minute.
 
     steps:
       - name: Download digests

--- a/.github/workflows/build-docker-monorepo.yml
+++ b/.github/workflows/build-docker-monorepo.yml
@@ -72,7 +72,7 @@ jobs:
     permissions:
       packages: write
       contents: read
-    timeout-minutes: 20  # 2025-11-20: Arm64 build takes about 6 minutes, amd64 build about 3.
+    timeout-minutes: 15  # 2025-11-20: Arm64 build takes about 6 minutes, amd64 build about 3.
     strategy:
       matrix:
         include:

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    timeout-minutes: 5  # 2025-03-04: Takes just a few seconds.
+    timeout-minutes: 5  # 2025-11-20: Takes just a few seconds.
     outputs:
       php-version: ${{ steps.buildargs.outputs.php-version }}
       composer-version: ${{ steps.buildargs.outputs.composer-version }}
@@ -74,7 +74,7 @@ jobs:
     permissions:
       packages: write
       contents: read
-    timeout-minutes: 15  # 2025-03-04: Arm64 build takes about 5 minutes, amd64 build about 3.
+    timeout-minutes: 20  # 2025-11-20: Arm64 build takes about 6 minutes, amd64 build about 3.
     strategy:
       matrix:
         include:
@@ -149,7 +149,7 @@ jobs:
     permissions:
       packages: write
       contents: read
-    timeout-minutes: 5  # 2025-03-04: Merge takes less than a minute.
+    timeout-minutes: 5  # 2025-11-20: Merge takes less than a minute.
 
     steps:
       - name: Download digests

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -74,7 +74,7 @@ jobs:
     permissions:
       packages: write
       contents: read
-    timeout-minutes: 20  # 2025-11-20: Arm64 build takes about 6 minutes, amd64 build about 3.
+    timeout-minutes: 15  # 2025-11-20: Arm64 build takes about 6 minutes, amd64 build about 3.
     strategy:
       matrix:
         include:

--- a/.github/workflows/coverage-check.yml
+++ b/.github/workflows/coverage-check.yml
@@ -25,7 +25,7 @@ jobs:
     if: >
       ( github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name ) &&
       ( github.event_name == 'workflow_dispatch' || github.event.label.name == 'I don''t care about code coverage for this PR' || github.event.label.name == 'Covered by non-unit tests' || github.event.label.name == 'Coverage tests to be added later' )
-    timeout-minutes: 5  # 2025-02-06: Should be pretty quick.
+    timeout-minutes: 5  # 2025-11-20: Less than 30 seconds.
     steps:
       - name: Checkout
         uses: actions/checkout@v5

--- a/.github/workflows/delete-mirror-branches.yml
+++ b/.github/workflows/delete-mirror-branches.yml
@@ -6,7 +6,7 @@ jobs:
   delete:
     name: Delete `${{ github.event.ref }}`
     runs-on: ubuntu-latest
-    timeout-minutes: 5  # 2022-11-21: Shouldn't take long.
+    timeout-minutes: 5  # 2025-11-20: Less than a minute.
     if: github.event_name == 'delete' && github.repository == 'Automattic/jetpack' && github.event.ref == 'prerelease'
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -70,7 +70,7 @@ jobs:
     name: "E2E: Build ${{ matrix.buildGroup }}"
     runs-on: ubuntu-latest
     needs: create-test-matrix
-    timeout-minutes: 30 # 2025-11-20: These can vary dramatically, but most builds are around 5 minutes.
+    timeout-minutes: 25 # 2025-11-20: These can vary dramatically, but most builds are around 5 minutes.
     if: needs.create-test-matrix.outputs.build-matrix != '[]'
     strategy:
       fail-fast: false
@@ -145,7 +145,7 @@ jobs:
     if: >
       always() && ! cancelled() && ! failure() &&
       needs.create-test-matrix.result == 'success' && needs.create-test-matrix.outputs.matrix != '[]'
-    timeout-minutes: 60 # 2025-11-20: These can vary dramatically, but most runs are 3-10 minutes.
+    timeout-minutes: 25 # 2025-11-20: These can vary dramatically, but most runs are 3-10 minutes.
     env:
       WP_DEBUG_PATH: '${{ github.workspace }}/tools/docker/wordpress/wp-content/debug.log'
       PROJECT_NAME: '${{ matrix.project }}' # used in tests for enhanced reporting of global projects

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -20,7 +20,7 @@ jobs:
   create-test-matrix:
     name: "Determine tests matrix"
     runs-on: ubuntu-latest
-    timeout-minutes: 5  # 2023-09-15: The pnpm install may take a few minutes on cache miss.
+    timeout-minutes: 5  # 2025-11-20: The pnpm install may take a few minutes on cache miss.
     # Only run tests in the main repository
     if: github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
     outputs:
@@ -70,7 +70,7 @@ jobs:
     name: "E2E: Build ${{ matrix.buildGroup }}"
     runs-on: ubuntu-latest
     needs: create-test-matrix
-    timeout-minutes: 30
+    timeout-minutes: 30 # 2025-11-20: These can vary dramatically, but most builds are around 5 minutes.
     if: needs.create-test-matrix.outputs.build-matrix != '[]'
     strategy:
       fail-fast: false
@@ -145,7 +145,7 @@ jobs:
     if: >
       always() && ! cancelled() && ! failure() &&
       needs.create-test-matrix.result == 'success' && needs.create-test-matrix.outputs.matrix != '[]'
-    timeout-minutes: 60
+    timeout-minutes: 60 # 2025-11-20: These can vary dramatically, but most runs are 3-10 minutes.
     env:
       WP_DEBUG_PATH: '${{ github.workspace }}/tools/docker/wordpress/wp-content/debug.log'
       PROJECT_NAME: '${{ matrix.project }}' # used in tests for enhanced reporting of global projects

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -631,7 +631,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: changed_files
     if: github.event_name == 'pull_request' && needs.changed_files.outputs.phanstubs == 'true' && github.event.pull_request.user.login != 'matticbot'
-    timeout-minutes: 5  # 2025-11-06: Probably takes about a minute, but shouldn't run often.
+    timeout-minutes: 5  # 2025-11-06: Probably takes about a minute.
     steps:
       - uses: GitHubSecurityLab/actions-permissions/monitor@v1
         with:

--- a/.github/workflows/post-build.yml
+++ b/.github/workflows/post-build.yml
@@ -36,7 +36,7 @@ jobs:
   setup:
     name: Setup
     runs-on: ubuntu-latest
-    timeout-minutes: 2  # 2022-12-20: Seems like it should be fast.
+    timeout-minutes: 2  # 2025-11-20: Takes a few seconds.
     outputs:
       upgrade_check: ${{ steps.upgrade_check.outputs.id }}
       wpcom_filename_check: ${{ steps.wpcom_filename_check.outputs.id }}
@@ -83,7 +83,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: setup
     if: github.event.workflow_run.conclusion != 'success'
-    timeout-minutes: 2  # 2022-08-26: Seems like it should be fast.
+    timeout-minutes: 2  # 2025-11-20: Seems like it should be fast.
     steps:
       - uses: actions/checkout@v5
 
@@ -123,7 +123,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: setup
     if: github.event.workflow_run.conclusion == 'success'
-    timeout-minutes: 2  # 2022-08-26: Seems like it should be fast.
+    timeout-minutes: 2  # 2025-11-20: Takes a few seconds.
     outputs:
       zip_url: ${{ steps.run.outputs.zip_url }}
       any_plugins: ${{ steps.run.outputs.any_plugins }}
@@ -199,7 +199,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [ setup, find_artifact ]
     if: needs.find_artifact.outputs.any_plugins == 'false'
-    timeout-minutes: 2  # 2022-08-26: Seems like it should be fast.
+    timeout-minutes: 2  # 2025-11-20: Takes a few seconds.
     steps:
       - uses: actions/checkout@v5
 
@@ -241,7 +241,7 @@ jobs:
     if: needs.find_artifact.outputs.any_plugins == 'true'
     outputs:
       matrix: ${{ steps.matrix.outputs.matrix }}
-    timeout-minutes: 5  # 2025-03-13: Should be just a few seconds.
+    timeout-minutes: 5  # 2025-11-20: Takes a few seconds.
 
     steps:
       - uses: actions/checkout@v5
@@ -302,7 +302,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [ setup, find_artifact, prepare_upgrade_test ]
     if: needs.find_artifact.outputs.any_plugins == 'true'
-    timeout-minutes: 15  # 2025-11-06: Successful runs seem to take about 3 minutes, but give some extra time for the downloads.
+    timeout-minutes: 15  # 2025-11-20: Successful runs seem to take about 2 minutes, but give some extra time for the downloads.
     strategy:
       fail-fast: false
       matrix:
@@ -380,7 +380,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [ setup, find_artifact, upgrade_test ]
     if: always() && needs.find_artifact.outputs.any_plugins == 'true'
-    timeout-minutes: 5  # 2025-03-13: Should be just a few seconds.
+    timeout-minutes: 5  # 2025-11-20: Takes a few seconds.
 
     steps:
       - uses: actions/checkout@v5
@@ -412,7 +412,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [ setup, find_artifact ]
     if: needs.find_artifact.outputs.any_plugins == 'true'
-    timeout-minutes: 15  # 2025-03-03: Guess. Leave time for the downloads.
+    timeout-minutes: 15  # 2025-11-20: Less than a minute, but leave time for the downloads.
     steps:
       - uses: actions/checkout@v5
         with:

--- a/.github/workflows/pr-is-up-to-date.yml
+++ b/.github/workflows/pr-is-up-to-date.yml
@@ -12,7 +12,7 @@ jobs:
   check:
     name: Check
     runs-on: ubuntu-latest
-    timeout-minutes: 5  # 2021-03-23: The run on push to the tag might take a minute or two.
+    timeout-minutes: 5 # 2025-11-20: The run on push to the tag might take a minute or two.
     steps:
 
       # We basically have two workflows in one here, one for pushes to trunk and one for PRs and pushes to tags.

--- a/.github/workflows/slack-branch-existence-notification.yml
+++ b/.github/workflows/slack-branch-existence-notification.yml
@@ -7,7 +7,7 @@ jobs:
   notify:
     name: Notify
     runs-on: ubuntu-latest
-    timeout-minutes: 5  # 2022-11-22: Shouldn't take long.
+    timeout-minutes: 5 # 2025-11-20: Takes a few seconds.
     if: github.event.ref == 'prerelease'
 
     steps:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   stale:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 10 # 2025-11-20: Takes less than a minute.
     steps:
       - uses: actions/stale@v10
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
   create-matrix:
     name: 'Determine tests matrix'
     runs-on: ubuntu-latest
-    timeout-minutes: 1 # 2021-02-03: Should only take a second.
+    timeout-minutes: 2 # 2025-11-20: Takes a few seconds.
     outputs:
       matrix: ${{ steps.create-matrix.outputs.matrix }}
     steps:
@@ -314,7 +314,7 @@ jobs:
   publish-coverage-data:
     name: Publish coverage data
     runs-on: ubuntu-latest
-    timeout-minutes: 10 # 2025-01-10 Wild guess
+    timeout-minutes: 10 # 2025-11-20 Takes about 2 minutes.
     needs: run-tests
     if: always() && needs.run-tests.outputs.did-coverage == 'true' && github.repository == 'Automattic/jetpack' && ( github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name || github.event_name == 'push' && github.ref == 'refs/heads/trunk' )
     steps:
@@ -349,7 +349,7 @@ jobs:
   storybook-test:
     name: Storybook tests
     runs-on: ubuntu-latest
-    timeout-minutes: 20 # 2024-02-23 Wild guess
+    timeout-minutes: 20 # 2025-11-20: Takes about 4 minutes
     steps:
       - uses: actions/checkout@v5
 
@@ -405,7 +405,7 @@ jobs:
   plugin-deps:
     name: Check plugin monorepo dep versions
     runs-on: ubuntu-latest
-    timeout-minutes: 2 # 2022-09-08: Should only take a few seconds.
+    timeout-minutes: 5 # 2025-11-20: Takes less than a minute.
     steps:
       - uses: actions/checkout@v5
       - name: Setup tools


### PR DESCRIPTION
Closes MONOREP-246

 <!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

In #45803 I did some (I'm not sure why I didn't do them all). This PR wraps it up so that all timeouts and comments are based on observations in November 2025.

Well, with one exception. I bumped the Phan run timeout and comment in #46036.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

As long as nothing times out (any changes should have bumped upward), this should be safe.