### PR TITLE
Forms: use better default strategy for input styling

### DIFF
--- a/projects/packages/forms/changelog/add-claude-code-changelog-skill
+++ b/projects/packages/forms/changelog/add-claude-code-changelog-skill
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Add fallback values to CSS custom properties to improve form styling compatibility across themes

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -472,6 +472,7 @@
 			justify-content: center;
 			width: 1em;
 			transform: translateY(-0.35em);
+			background-color: var(--jetpack--contact-form--input-background, field);
 		}
 
 		&[type="radio"]::before {

--- a/projects/packages/forms/src/blocks/contact-form/util/form-styles.js
+++ b/projects/packages/forms/src/blocks/contact-form/util/form-styles.js
@@ -92,7 +92,7 @@ window.jetpackForms.generateStyleVariables = function ( formNode ) {
 
 	const backgroundColor = window.jetpackForms.getBackgroundColor( bodyNode );
 	const inputBackgroundFallback = window.jetpackForms.getBackgroundColor( inputNode );
-	const inputBackground = window.getComputedStyle( inputNode ).backgroundColor;
+
 	const bodyTextColor = window.getComputedStyle( formRootNode ).color;
 	const invertedBodyTextColor = window.jetpackForms.getInverseReadableColor( bodyTextColor );
 	const {
@@ -130,7 +130,12 @@ window.jetpackForms.generateStyleVariables = function ( formNode ) {
 		lineHeight,
 		height: inputHeight,
 		backdropFilter: inputBackdropFilter,
+		backgroundColor: inputBackground,
 	} = window.getComputedStyle( inputNode );
+	const inputBackgroundIsTransparent =
+		inputBackground === 'rgba(0, 0, 0, 0)' ||
+		inputBackground === 'transparent' ||
+		inputBackground === '#00000000';
 
 	styleProbe.remove();
 
@@ -145,7 +150,9 @@ window.jetpackForms.generateStyleVariables = function ( formNode ) {
 		'--jetpack--contact-form--border-size': borderWidth,
 		'--jetpack--contact-form--border-style': borderStyle,
 		'--jetpack--contact-form--border-radius': borderRadius,
-		'--jetpack--contact-form--input-background': inputBackground,
+		...( inputBackgroundIsTransparent
+			? {}
+			: { '--jetpack--contact-form--input-background': inputBackground } ),
 		'--jetpack--contact-form--input-background-fallback': inputBackgroundFallback,
 		'--jetpack--contact-form--input-padding': inputPadding,
 		'--jetpack--contact-form--input-padding-top': inputPaddingTop,

--- a/projects/packages/forms/src/blocks/dropzone/editor.scss
+++ b/projects/packages/forms/src/blocks/dropzone/editor.scss
@@ -4,6 +4,7 @@
 	margin-bottom: 0.25em;
 	border: 1px dashed var(--jp-form-color-border, rgba(125, 125, 125, 0.3));
 	border-radius: var(--jetpack--contact-form--border-radius, 0);
+	background-color: var(--jetpack--contact-form--input-background, field);
 }
 
 // Reset the flex property for the dropzone innerblock

--- a/projects/packages/forms/src/contact-form/css/combobox.scss
+++ b/projects/packages/forms/src/contact-form/css/combobox.scss
@@ -9,11 +9,17 @@
 		background-color: inherit;
 	}
 
+	// special override for aggressive themes (2021) that set background-color
+	.has-background & button.jetpack-combobox-trigger:not(:active):not(:hover):not(.has-background) {
+		background-color: transparent;
+	}
+
 	.jetpack-combobox-trigger {
 		width: 100%;
 		border: 0 solid #ddd;
 		border-radius: 4px;
 		background: transparent;
+		background-color: transparent;
 		cursor: pointer;
 		display: flex;
 		align-items: center;
@@ -34,6 +40,7 @@
 
 		&:hover {
 			text-decoration: none;
+			background-color: transparent;
 		}
 
 		.jetpack-combobox-trigger-arrow {

--- a/projects/packages/forms/src/contact-form/css/grunion.scss
+++ b/projects/packages/forms/src/contact-form/css/grunion.scss
@@ -70,7 +70,7 @@ that needs to mimic the input element styles */
 	font: inherit;
 	border: 1px solid #8c8f94;
 	border-radius: 0;
-	background-color: var(--jetpack--contact-form--input-background);
+	background-color: var(--jetpack--contact-form--input-background, field);
 }
 
 :where(.contact-form textarea) {
@@ -552,7 +552,7 @@ that needs to mimic the input element styles */
 }
 
 .contact-form :where(.contact-form__select-wrapper) {
-	background-color: var(--jetpack--contact-form--input-background);
+	background-color: var(--jetpack--contact-form--input-background, field);
 	border: var(--jetpack--contact-form--border);
 	border-color: var(--jetpack--contact-form--border-color);
 	border-radius: var(--jetpack--contact-form--border-radius);
@@ -1033,6 +1033,7 @@ on production builds, the attributes are being reordered, causing side-effects
 	color: currentColor;
 	outline-offset: 1px;
 	transform: translateY(0.15em);
+	background-color: var(--jetpack--contact-form--input-background, field);
 }
 
 .contact-form .grunion-field-wrap:not(.is-style-plain) input.radio {

--- a/projects/packages/forms/src/contact-form/css/grunion.scss
+++ b/projects/packages/forms/src/contact-form/css/grunion.scss
@@ -1025,6 +1025,7 @@ on production builds, the attributes are being reordered, causing side-effects
 	width: 1em;
 	min-width: 1em;
 	height: 1em;
+	min-height: 1em;
 	margin-inline-end: calc(var(--jetpack--contact-form--font-size) / 2);
 	padding: 0;
 

--- a/projects/packages/forms/src/contact-form/css/phone-field.scss
+++ b/projects/packages/forms/src/contact-form/css/phone-field.scss
@@ -9,6 +9,7 @@
 		display: flex;
 		gap: 8px;
 		background-color: var(--jetpack--contact-form--input-background);
+		color: var(--jetpack--contact-form--text-color, fieldText);
 		border-color: var(--jetpack--contact-form--border-color, currentColor);
 		border-width: var(--jetpack--contact-form--border-size);
 		border-style: var(--jetpack--contact-form--border-style);


### PR DESCRIPTION

Fixes FORMS-299

## Proposed changes:
This PR attempts to stabilize the fallback strategy for input background. The problem is one of balance between defaults, theme overrides and form elements trying to blend with the themes.
We're now trying to selectively declare the variable so it can be defaulted and we're using the default browsers use to style the inputs: `field` and `fieldText` to refer to CSS `background-color` and `color` properties.

Themes might always incur in overrides or lack of styling out of our control, we do our best to probe the styles and

Some themes were selected for showing symptoms of the issue, others because of popularity. Tested with:
- 2025
- 2024
- 2023
- 2021
- 2020
- Dravix
- Assembler
- Astra
- Hey
- Independent Publisher 2
- Livro
- Maywood
- Retrospect
- Rivington
- Shopall
- 2016
- 2010
- Varia
- Zoologist

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
None

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Add a form with as many fields as possible. Verify they look the same on editor and frontend.
Change both form and input backgrounds and verify again.
Some themes might lack styling or have purposely transparent backgrounds on inputs. This leads to unexpected results and will be defaulted to `field` color which, depending on dark/light theme, might become white/black.
See that input text is readable (good contrast), unless theme or custom colors make it otherwise.