### PR TITLE
Backport backup 3.7.1 changes

### DIFF
--- a/projects/js-packages/charts/CHANGELOG.md
+++ b/projects/js-packages/charts/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.49.1] - 2025-11-20
+### Changed
+- Update package dependencies. [#46022]
+
+### Fixed
+- Localize numbers in legend labels and tooltips [#45991]
+
 ## [0.49.0] - 2025-11-19
 ### Added
 - Add animation in circular shaped charts. [#45870]
@@ -563,6 +570,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed lints following ESLint rule changes for TS [#40584]
 - Fixing a bug in Chart storybook data. [#40640]
 
+[0.49.1]: https://github.com/Automattic/charts/compare/v0.49.0...v0.49.1
 [0.49.0]: https://github.com/Automattic/charts/compare/v0.48.0...v0.49.0
 [0.48.0]: https://github.com/Automattic/charts/compare/v0.47.0...v0.48.0
 [0.47.0]: https://github.com/Automattic/charts/compare/v0.46.3...v0.47.0

--- a/projects/js-packages/charts/changelog/charts-130-charts-i18n-numbers-render-unlocalised-in-chart-components
+++ b/projects/js-packages/charts/changelog/charts-130-charts-i18n-numbers-render-unlocalised-in-chart-components
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Localize numbers in legend labels and tooltips

--- a/projects/js-packages/charts/changelog/renovate-major-storybook-monorepo
+++ b/projects/js-packages/charts/changelog/renovate-major-storybook-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/js-packages/charts/package.json
+++ b/projects/js-packages/charts/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/charts",
-	"version": "0.49.0",
+	"version": "0.49.1",
 	"description": "Display charts within Automattic products.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/charts/#readme",
 	"bugs": {

--- a/projects/js-packages/licensing/CHANGELOG.md
+++ b/projects/js-packages/licensing/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.2.16 - 2025-11-20
+### Changed
+- Update dependencies. [#46031]
+
 ## 1.2.15 - 2025-11-18
 ### Changed
 - Update dependencies. [#45493]

--- a/projects/js-packages/licensing/changelog/force-a-release
+++ b/projects/js-packages/licensing/changelog/force-a-release
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update dependencies.

--- a/projects/js-packages/licensing/package.json
+++ b/projects/js-packages/licensing/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-licensing",
-	"version": "1.2.15",
+	"version": "1.2.16",
 	"private": true,
 	"description": "Jetpack licensing flow",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/licensing/#readme",

--- a/projects/js-packages/shared-extension-utils/CHANGELOG.md
+++ b/projects/js-packages/shared-extension-utils/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.3.27] - 2025-11-20
 ### Fixed
-- Jetpack: remove getIconColor functions from block icons [#45992]
+- Jetpack: Remove getIconColor functions from block icons. [#45992]
 
 ## [1.3.26] - 2025-11-18
 ### Changed

--- a/projects/packages/backup/CHANGELOG.md
+++ b/projects/packages/backup/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.2.31] - 2025-11-20
+### Changed
+- Update package dependencies. [#46022]
+
+### Fixed
+- Phan: Address PhanPossiblyUndeclaredVariable violations. [#45911]
+
 ## [4.2.30] - 2025-11-18
 ### Changed
 - Update dependencies. [#45553]
@@ -979,6 +986,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add API endpoints and Jetpack Backup package for managing Help…
 
+[4.2.31]: https://github.com/Automattic/jetpack-backup/compare/v4.2.30...v4.2.31
 [4.2.30]: https://github.com/Automattic/jetpack-backup/compare/v4.2.29...v4.2.30
 [4.2.29]: https://github.com/Automattic/jetpack-backup/compare/v4.2.28...v4.2.29
 [4.2.28]: https://github.com/Automattic/jetpack-backup/compare/v4.2.27...v4.2.28

--- a/projects/packages/backup/changelog/fix-phan-PhanPossiblyUndeclaredVariable
+++ b/projects/packages/backup/changelog/fix-phan-PhanPossiblyUndeclaredVariable
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Phan: Address PhanPossiblyUndeclaredVariable violations.

--- a/projects/packages/backup/changelog/renovate-major-storybook-monorepo
+++ b/projects/packages/backup/changelog/renovate-major-storybook-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/packages/backup/src/class-package-version.php
+++ b/projects/packages/backup/src/class-package-version.php
@@ -16,7 +16,7 @@ namespace Automattic\Jetpack\Backup;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '4.2.30';
+	const PACKAGE_VERSION = '4.2.31';
 
 	const PACKAGE_SLUG = 'backup';
 

--- a/projects/packages/my-jetpack/CHANGELOG.md
+++ b/projects/packages/my-jetpack/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.28.6] - 2025-11-20
+### Changed
+- Update package dependencies. [#46022]
+
+### Fixed
+- My Jetpack: Fix expiring renewal prompt to show all products. [#45995]
+- Redirect partner coupon redemption requests to Jetpack dashboard to ensure coupon can be redeemed. [#45994]
+
 ## [5.28.5] - 2025-11-19
 ### Changed
 - Update dependencies. [#45493]
@@ -2427,6 +2435,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Created package
 
+[5.28.6]: https://github.com/Automattic/jetpack-my-jetpack/compare/5.28.5...5.28.6
 [5.28.5]: https://github.com/Automattic/jetpack-my-jetpack/compare/5.28.4...5.28.5
 [5.28.4]: https://github.com/Automattic/jetpack-my-jetpack/compare/5.28.3...5.28.4
 [5.28.3]: https://github.com/Automattic/jetpack-my-jetpack/compare/5.28.2...5.28.3

--- a/projects/packages/my-jetpack/changelog/fix-expiring-prompt-bundle-products
+++ b/projects/packages/my-jetpack/changelog/fix-expiring-prompt-bundle-products
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-My Jetpack: Fix expiring renewal prompt to show all products

--- a/projects/packages/my-jetpack/changelog/fix-partner-coupon-redemption
+++ b/projects/packages/my-jetpack/changelog/fix-partner-coupon-redemption
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Redirect partner coupon redemption requests to Jetpack dashboard to ensure coupon can be redeemed.

--- a/projects/packages/my-jetpack/changelog/renovate-major-storybook-monorepo
+++ b/projects/packages/my-jetpack/changelog/renovate-major-storybook-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-my-jetpack",
-	"version": "5.28.5",
+	"version": "5.28.6",
 	"private": true,
 	"description": "WP Admin page with information and configuration shared among all Jetpack stand-alone plugins",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/my-jetpack/#readme",

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -39,7 +39,7 @@ class Initializer {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '5.28.5';
+	const PACKAGE_VERSION = '5.28.6';
 
 	/**
 	 * HTML container ID for the IDC screen on My Jetpack page.

--- a/projects/plugins/backup/CHANGELOG.md
+++ b/projects/plugins/backup/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [3.7.1] - 2025-11-20
+### Fixed
+- Jetpack: Remove getIconColor functions for block icons. [#45992]
+- My Jetpack: Fix expiring renewal prompt to show all products. [#45995]
+
 ## [3.6] - 2025-11-12
 ### Added
 - Tested up to WordPress 6.9. [#45571]
@@ -337,6 +342,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Use `absoluteRuntime` in babel JS build to avoid module not found errors.
 
 [2.2-beta]: https://github.com/Automattic/jetpack-backup-plugin/compare/2.1...2.2-beta
+[3.7.1]: https://github.com/Automattic/jetpack-backup-plugin/compare/3.6...3.7.1
 [3.6]: https://github.com/Automattic/jetpack-backup-plugin/compare/3.5...3.6
 [3.5]: https://github.com/Automattic/jetpack-backup-plugin/compare/3.4...3.5
 [3.4]: https://github.com/Automattic/jetpack-backup-plugin/compare/3.3...3.4

--- a/projects/plugins/backup/changelog/fix-expiring-prompt-bundle-products
+++ b/projects/plugins/backup/changelog/fix-expiring-prompt-bundle-products
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-My Jetpack: Fix expiring renewal prompt to show all products

--- a/projects/plugins/backup/changelog/prerelease
+++ b/projects/plugins/backup/changelog/prerelease
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Update composer.lock.
-
-

--- a/projects/plugins/backup/changelog/update-remove-getIconColor
+++ b/projects/plugins/backup/changelog/update-remove-getIconColor
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Jetpack: remove getIconColor functions for block icons

--- a/projects/plugins/backup/changelog/update-tooling-update_stable_tag_in_backport
+++ b/projects/plugins/backup/changelog/update-tooling-update_stable_tag_in_backport
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Update stable tag in trunk.
-
-

--- a/projects/plugins/backup/composer.json
+++ b/projects/plugins/backup/composer.json
@@ -35,7 +35,7 @@
 	"minimum-stability": "dev",
 	"prefer-stable": true,
 	"config": {
-		"autoloader-suffix": "9559eef123208b7d1b9c15b978567267_backupⓥ3_6",
+		"autoloader-suffix": "9559eef123208b7d1b9c15b978567267_backupⓥ3_7_1",
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true

--- a/projects/plugins/backup/jetpack-backup.php
+++ b/projects/plugins/backup/jetpack-backup.php
@@ -4,7 +4,7 @@
  * Plugin Name: Jetpack VaultPress Backup
  * Plugin URI: https://jetpack.com/jetpack-backup
  * Description: Easily restore or download a backup of your site from a specific moment in time.
- * Version: 3.6
+ * Version: 3.7.1
  * Author: Automattic - Jetpack Backup team
  * Author URI: https://jetpack.com/
  * License: GPLv2 or later

--- a/projects/plugins/backup/readme.txt
+++ b/projects/plugins/backup/readme.txt
@@ -175,15 +175,10 @@ No, Jetpack VaultPress Backup does not currently support split site or split hom
 2. Your site backups are stored in multiple locations on our world-class cloud infrastructure so you can recover them at any moment.
 
 == Changelog ==
-### 3.6 - 2025-11-12
-#### Added
-- Tested up to WordPress 6.9.
-
-#### Changed
-- Update package dependencies.
-
+### 3.7.1 - 2025-11-20
 #### Fixed
-- My Jetpack page: Fix visual compatibility issue with Hello Dolly plugin.
+- Jetpack: Remove getIconColor functions for block icons.
+- My Jetpack: Fix expiring renewal prompt to show all products.
 
 --------
 

--- a/projects/plugins/backup/readme.txt
+++ b/projects/plugins/backup/readme.txt
@@ -4,7 +4,7 @@ Tags: jetpack, backup, restore
 Requires at least: 6.7
 Requires PHP: 7.2
 Tested up to: 6.9
-Stable tag: 3.6
+Stable tag: 3.7.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 


### PR DESCRIPTION
Closes MONOREP-247

 <!--- This template is used for backporting changes made during a plugin release back to trunk. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Backports changes for backup 3.7.1

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/a
## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Proofread changes.