### PR TITLE
Backport paypal-payment-buttons 0.3.2 changes

### DIFF
--- a/projects/packages/paypal-payments/CHANGELOG.md
+++ b/projects/packages/paypal-payments/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.14] - 2025-11-20
+### Fixed
+- Jetpack: Remove getIconColor functions from block icons. [#45992]
+
 ## [0.5.13] - 2025-11-18
 ### Changed
 - Update dependencies. [#45745]
@@ -111,6 +115,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Simple Payments: Move Simple Payments block to PayPal Payments package. [#43413]
 
+[0.5.14]: https://github.com/Automattic/jetpack-paypal-payments/compare/v0.5.13...v0.5.14
 [0.5.13]: https://github.com/Automattic/jetpack-paypal-payments/compare/v0.5.12...v0.5.13
 [0.5.12]: https://github.com/Automattic/jetpack-paypal-payments/compare/v0.5.11...v0.5.12
 [0.5.11]: https://github.com/Automattic/jetpack-paypal-payments/compare/v0.5.10...v0.5.11

--- a/projects/packages/paypal-payments/changelog/update-remove-getIconColor
+++ b/projects/packages/paypal-payments/changelog/update-remove-getIconColor
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Jetpack: remove getIconColor functions from block icons

--- a/projects/packages/paypal-payments/package.json
+++ b/projects/packages/paypal-payments/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-paypal-payments",
-	"version": "0.5.13",
+	"version": "0.5.14",
 	"private": true,
 	"description": "Add PayPal, credit, and debit card payment buttons with minimal setup. Good for collecting donations or payments for products and services.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/paypal-payments/#readme",

--- a/projects/packages/paypal-payments/src/class-paypal-payments.php
+++ b/projects/packages/paypal-payments/src/class-paypal-payments.php
@@ -12,5 +12,5 @@ namespace Automattic\Jetpack;
  */
 class PayPal_Payments {
 
-	const PACKAGE_VERSION = '0.5.13';
+	const PACKAGE_VERSION = '0.5.14';
 }

--- a/projects/plugins/paypal-payment-buttons/CHANGELOG.md
+++ b/projects/plugins/paypal-payment-buttons/CHANGELOG.md
@@ -5,10 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.3.2 - 2025-11-20
+### Added
+- Tested up to WordPress 6.9. [#45571]
+
+### Changed
+- Update package dependencies. [#45478] [#45676] [#45756] [#45915] [#45958]
+
+### Fixed
+- Jetpack: Remove getIconColor functions for block icons. [#45992]
+
 ## 0.3.1 - 2025-10-09
 ### Changed
 - Update package dependencies. [#45173] [#45200] [#45229] [#45298] [#45299] [#45334]
-- Update short description for plugin [#45443]
+- Update short description for plugin. [#45443]
 
 ## 0.3.0 - 2025-09-16
 ### Changed
@@ -19,6 +29,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 0.2.0 - 2025-07-25
 ### Added
-- Initial release setup and plugin structure [#44479]
-- Integration with paypal-payments package for core functionality [#44479]
-- Working PayPal Payment Button block with availability data [#44479]
+- Initial release setup and plugin structure. [#44479]
+- Integration with paypal-payments package for core functionality. [#44479]
+- Working PayPal Payment Button block with availability data. [#44479]

--- a/projects/plugins/paypal-payment-buttons/changelog/e2e-add-ctrf-and-junit-reporters
+++ b/projects/plugins/paypal-payment-buttons/changelog/e2e-add-ctrf-and-junit-reporters
@@ -1,5 +1,0 @@
-Significance: patch
-Type: added
-Comment: dev: added a new reporter for e2e tests
-
-

--- a/projects/plugins/paypal-payment-buttons/changelog/prerelease
+++ b/projects/plugins/paypal-payment-buttons/changelog/prerelease
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Update composer.lock.
-
-

--- a/projects/plugins/paypal-payment-buttons/changelog/prerelease#2
+++ b/projects/plugins/paypal-payment-buttons/changelog/prerelease#2
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Update composer.lock.
-
-

--- a/projects/plugins/paypal-payment-buttons/changelog/renovate-concurrently-9.x
+++ b/projects/plugins/paypal-payment-buttons/changelog/renovate-concurrently-9.x
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/plugins/paypal-payment-buttons/changelog/renovate-config-4.x
+++ b/projects/plugins/paypal-payment-buttons/changelog/renovate-config-4.x
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/plugins/paypal-payment-buttons/changelog/renovate-js-unit-testing-packages
+++ b/projects/plugins/paypal-payment-buttons/changelog/renovate-js-unit-testing-packages
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/plugins/paypal-payment-buttons/changelog/renovate-lock-file-maintenance
+++ b/projects/plugins/paypal-payment-buttons/changelog/renovate-lock-file-maintenance
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/plugins/paypal-payment-buttons/changelog/renovate-wordpress-monorepo
+++ b/projects/plugins/paypal-payment-buttons/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/plugins/paypal-payment-buttons/changelog/update-jetpack-tested-to-ver-wp
+++ b/projects/plugins/paypal-payment-buttons/changelog/update-jetpack-tested-to-ver-wp
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Tested up to WordPress 6.9

--- a/projects/plugins/paypal-payment-buttons/changelog/update-paypal-payment-buttons-readme-stable-0.3.1
+++ b/projects/plugins/paypal-payment-buttons/changelog/update-paypal-payment-buttons-readme-stable-0.3.1
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Only updating stable tag for cleanliness
-
-

--- a/projects/plugins/paypal-payment-buttons/changelog/update-php8.4-set_as_default
+++ b/projects/plugins/paypal-payment-buttons/changelog/update-php8.4-set_as_default
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Update composer.lock
-
-

--- a/projects/plugins/paypal-payment-buttons/changelog/update-remove-getIconColor
+++ b/projects/plugins/paypal-payment-buttons/changelog/update-remove-getIconColor
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Jetpack: remove getIconColor functions for block icons

--- a/projects/plugins/paypal-payment-buttons/composer.json
+++ b/projects/plugins/paypal-payment-buttons/composer.json
@@ -68,6 +68,6 @@
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true
 		},
-		"autoloader-suffix": "c4802e05bbcf59fd3b6350e8d3e5482c_paypal_payment_buttonsⓥ0_3_1"
+		"autoloader-suffix": "c4802e05bbcf59fd3b6350e8d3e5482c_paypal_payment_buttonsⓥ0_3_2"
 	}
 }

--- a/projects/plugins/paypal-payment-buttons/paypal-payment-buttons.php
+++ b/projects/plugins/paypal-payment-buttons/paypal-payment-buttons.php
@@ -4,7 +4,7 @@
  * Plugin Name: PayPal Payment Buttons
  * Plugin URI: https://wordpress.org/plugins/paypal-payment-buttons
  * Description: Add PayPal payment buttons to your WordPress site with ease.
- * Version: 0.3.1
+ * Version: 0.3.2
  * Author: Automattic
  * Author URI: https://jetpack.com/
  * License: GPLv2 or later

--- a/projects/plugins/paypal-payment-buttons/readme.txt
+++ b/projects/plugins/paypal-payment-buttons/readme.txt
@@ -80,8 +80,13 @@ By repeating the process above, you can add as many PayPal Payment Buttons block
 It is possible to perform test payments with the PayPal Payment Buttons block. To get started you would need to create a [PayPal Developer account](https://developer.paypal.com/home/). Once you are logged into your PayPal developer account, you can access or create new sandbox accounts. You will need to make note of your sandbox business account and personal account email addresses and passwords. Once you have this information, you would login to the [PayPal Sandbox site](https://www.sandbox.paypal.com/) with the sandbox business account. Create a [payment button on the PayPal sandbox site](https://www.sandbox.paypal.com/ncp/buttons/create?utm_source=wp&at_code=wp). Follow the instructions above to add the payment button code to your PayPal Payment Buttons block. Publish the post or page that contains the block. Then use the sandbox personal account to complete the purchase. All successful test payments will show up in the business sandbox account on the PayPal Sandbox.
 
 == Changelog ==
-### 0.3.1 - 2025-10-09
+### 0.3.2 - 2025-11-20
+#### Added
+- Tested up to WordPress 6.9.
+
 #### Changed
 - Update package dependencies.
-- Update short description for plugin
+
+#### Fixed
+- Jetpack: Remove getIconColor functions for block icons.
 

--- a/projects/plugins/paypal-payment-buttons/readme.txt
+++ b/projects/plugins/paypal-payment-buttons/readme.txt
@@ -4,7 +4,7 @@ Tags: paypal, payments, ecommerce, blocks, checkout
 Requires at least: 6.7
 Requires PHP: 7.2
 Tested up to: 6.9
-Stable tag: 0.3.1
+Stable tag: 0.3.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 


### PR DESCRIPTION
Closes MONOREP-248

 <!--- This template is used for backporting changes made during a plugin release back to trunk. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Backports changes for paypal-payment-buttons 0.3.2

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/a
## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Proofread changes.