### PR TITLE
Backport social 7.3.0, videopress 2.7, search 5.2.2, vaultpress 4.0.6, protect 4.4.1 changes

### DIFF
--- a/projects/js-packages/publicize-components/CHANGELOG.md
+++ b/projects/js-packages/publicize-components/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.1] - 2025-11-21
+### Changed
+- Social: Replace ConnectionIcon component with the implementation of ConnectionImage component. [#45972]
+- Update package dependencies. [#46022]
+
 ## [1.6.0] - 2025-11-19
 ### Changed
 - Update auto-share UI and the corresponding descriptions. [#45970]
@@ -1420,6 +1425,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Updated package dependencies. [#24470]
 
+[1.6.1]: https://github.com/Automattic/jetpack-publicize-components/compare/v1.6.0...v1.6.1
 [1.6.0]: https://github.com/Automattic/jetpack-publicize-components/compare/v1.5.1...v1.6.0
 [1.5.1]: https://github.com/Automattic/jetpack-publicize-components/compare/v1.5.0...v1.5.1
 [1.5.0]: https://github.com/Automattic/jetpack-publicize-components/compare/v1.4.8...v1.5.0

--- a/projects/js-packages/publicize-components/changelog/renovate-major-storybook-monorepo
+++ b/projects/js-packages/publicize-components/changelog/renovate-major-storybook-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/js-packages/publicize-components/changelog/update-social-replace-connection-icon-component
+++ b/projects/js-packages/publicize-components/changelog/update-social-replace-connection-icon-component
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Social: Replace ConnectionIcon component with the implementation of ConnectionImage component.

--- a/projects/js-packages/publicize-components/package.json
+++ b/projects/js-packages/publicize-components/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-publicize-components",
-	"version": "1.6.0",
+	"version": "1.6.1",
 	"private": true,
 	"description": "A library of JS components required by the Publicize editor plugin",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/publicize-components/#readme",

--- a/projects/js-packages/scan/CHANGELOG.md
+++ b/projects/js-packages/scan/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.1] - 2025-11-21
+### Changed
+- Replace icons removed from @wordpress/icons with alternatives. [#45760]
+- Update dependencies. [#45488]
+- Update package dependencies. [#45551] [#45652] [#45735] [#45737] [#45915] [#45958] [#46022]
+
 ## [1.2.0] - 2025-10-10
 ### Added
 - Add missing types. [#44787]
@@ -151,6 +157,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 - Updated dependencies. [#39754]
 
+[1.2.1]: https://github.com/Automattic/jetpack-scan/compare/v1.2.0...v1.2.1
 [1.2.0]: https://github.com/Automattic/jetpack-scan/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/Automattic/jetpack-scan/compare/v1.0.2...v1.1.0
 [1.0.2]: https://github.com/Automattic/jetpack-scan/compare/v1.0.1...v1.0.2

--- a/projects/js-packages/scan/changelog/force-a-release
+++ b/projects/js-packages/scan/changelog/force-a-release
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update dependencies.

--- a/projects/js-packages/scan/changelog/renovate-@wordpressdataviews
+++ b/projects/js-packages/scan/changelog/renovate-@wordpressdataviews
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/js-packages/scan/changelog/renovate-@wordpressdataviews#2
+++ b/projects/js-packages/scan/changelog/renovate-@wordpressdataviews#2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/js-packages/scan/changelog/renovate-definitelytyped
+++ b/projects/js-packages/scan/changelog/renovate-definitelytyped
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/js-packages/scan/changelog/renovate-js-unit-testing-packages
+++ b/projects/js-packages/scan/changelog/renovate-js-unit-testing-packages
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/js-packages/scan/changelog/renovate-major-storybook-monorepo
+++ b/projects/js-packages/scan/changelog/renovate-major-storybook-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/js-packages/scan/changelog/renovate-typescript-5.x
+++ b/projects/js-packages/scan/changelog/renovate-typescript-5.x
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/js-packages/scan/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/scan/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/js-packages/scan/changelog/renovate-wordpress-monorepo#2
+++ b/projects/js-packages/scan/changelog/renovate-wordpress-monorepo#2
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Revert dataviews test hack from #45551. No longer necessary after the ESM-fixing hack in this PR.
-
-

--- a/projects/js-packages/scan/changelog/update-replace-removed-wordpress-icons
+++ b/projects/js-packages/scan/changelog/update-replace-removed-wordpress-icons
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Replace icons removed from @wordpress/icons with alternatives.

--- a/projects/js-packages/scan/package.json
+++ b/projects/js-packages/scan/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-scan",
-	"version": "1.2.0",
+	"version": "1.2.1",
 	"private": false,
 	"description": "A JS client for consuming Jetpack Scan services",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/scan/#readme",

--- a/projects/packages/publicize/CHANGELOG.md
+++ b/projects/packages/publicize/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.67.5] - 2025-11-21
+### Fixed
+- Phan: Address PhanPossiblyUndeclaredVariable violations. [#45911]
+
 ## [0.67.4] - 2025-11-19
 ### Changed
 - Update dependencies. [#45745]
@@ -1155,6 +1159,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies.
 - Update package.json metadata.
 
+[0.67.5]: https://github.com/Automattic/jetpack-publicize/compare/v0.67.4...v0.67.5
 [0.67.4]: https://github.com/Automattic/jetpack-publicize/compare/v0.67.3...v0.67.4
 [0.67.3]: https://github.com/Automattic/jetpack-publicize/compare/v0.67.2...v0.67.3
 [0.67.2]: https://github.com/Automattic/jetpack-publicize/compare/v0.67.1...v0.67.2

--- a/projects/packages/publicize/changelog/fix-phan-PhanPossiblyUndeclaredVariable
+++ b/projects/packages/publicize/changelog/fix-phan-PhanPossiblyUndeclaredVariable
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Phan: Address PhanPossiblyUndeclaredVariable violations.

--- a/projects/packages/publicize/package.json
+++ b/projects/packages/publicize/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-publicize",
-	"version": "0.67.4",
+	"version": "0.67.5",
 	"private": true,
 	"description": "Publicize makes it easy to share your site’s posts on several social media networks automatically when you publish a new post.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/publicize/#readme",

--- a/projects/packages/search/CHANGELOG.md
+++ b/projects/packages/search/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.54.5] - 2025-11-21
+### Fixed
+- Phan: Address PhanPossiblyUndeclaredVariable violations. [#45911]
+
 ## [0.54.4] - 2025-11-18
 ### Changed
 - Update dependencies. [#45745]
@@ -1390,6 +1394,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies.
 - Update PHPUnit configs to include just what needs coverage rather than include everything then try to exclude stuff that doesn't.
 
+[0.54.5]: https://github.com/Automattic/jetpack-search/compare/v0.54.4...v0.54.5
 [0.54.4]: https://github.com/Automattic/jetpack-search/compare/v0.54.3...v0.54.4
 [0.54.3]: https://github.com/Automattic/jetpack-search/compare/v0.54.2...v0.54.3
 [0.54.2]: https://github.com/Automattic/jetpack-search/compare/v0.54.1...v0.54.2

--- a/projects/packages/search/changelog/fix-phan-PhanPossiblyUndeclaredVariable
+++ b/projects/packages/search/changelog/fix-phan-PhanPossiblyUndeclaredVariable
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Phan: Address PhanPossiblyUndeclaredVariable violations.

--- a/projects/packages/search/src/class-package.php
+++ b/projects/packages/search/src/class-package.php
@@ -15,7 +15,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Search package general information
  */
 class Package {
-	const VERSION = '0.54.4';
+	const VERSION = '0.54.5';
 	const SLUG    = 'search';
 
 	/**

--- a/projects/packages/videopress/CHANGELOG.md
+++ b/projects/packages/videopress/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.32.16] - 2025-11-21
+### Changed
+- Update package dependencies. [#46022]
+
+### Fixed
+- Phan: Address PhanPossiblyUndeclaredVariable violations. [#45911]
+
 ## [0.32.15] - 2025-11-18
 ### Changed
 - Update dependencies. [#45553]
@@ -1781,6 +1788,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Created empty package [#24952]
 
+[0.32.16]: https://github.com/Automattic/jetpack-videopress/compare/v0.32.15...v0.32.16
 [0.32.15]: https://github.com/Automattic/jetpack-videopress/compare/v0.32.14...v0.32.15
 [0.32.14]: https://github.com/Automattic/jetpack-videopress/compare/v0.32.13...v0.32.14
 [0.32.13]: https://github.com/Automattic/jetpack-videopress/compare/v0.32.12...v0.32.13

--- a/projects/packages/videopress/changelog/fix-phan-PhanPossiblyUndeclaredVariable
+++ b/projects/packages/videopress/changelog/fix-phan-PhanPossiblyUndeclaredVariable
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Phan: Address PhanPossiblyUndeclaredVariable violations.

--- a/projects/packages/videopress/changelog/renovate-major-storybook-monorepo
+++ b/projects/packages/videopress/changelog/renovate-major-storybook-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/packages/videopress/package.json
+++ b/projects/packages/videopress/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-videopress",
-	"version": "0.32.15",
+	"version": "0.32.16",
 	"private": true,
 	"description": "VideoPress package",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/videopress/#readme",

--- a/projects/packages/videopress/src/class-package-version.php
+++ b/projects/packages/videopress/src/class-package-version.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\VideoPress;
  * The Package_Version class.
  */
 class Package_Version {
-	const PACKAGE_VERSION = '0.32.15';
+	const PACKAGE_VERSION = '0.32.16';
 
 	const PACKAGE_SLUG = 'videopress';
 

--- a/projects/plugins/protect/CHANGELOG.md
+++ b/projects/plugins/protect/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 4.4.1 - 2025-11-21
+### Added
+- Tested up to WordPress 6.9. [#45571]
+
+### Changed
+- Replace icons removed from @wordpress/icons with alternatives. [#45760]
+- Update dependencies. [#45488]
+- Update package dependencies. [#45478] [#45652] [#45676] [#45737] [#45756] [#45915] [#45932]
+
+### Fixed
+- Jetpack: remove getIconColor functions for block icons [#45992]
+- My Jetpack: Fix expiring renewal prompt to show all products [#45995]
+- My Jetpack page: fix visual compatibility issue with Hello Dolly plugin. [#45474]
+
 ## 4.4.0 - 2025-10-10
 ### Added
 - Add typecheck script. [#44787]

--- a/projects/plugins/protect/changelog/e2e-add-ctrf-and-junit-reporters
+++ b/projects/plugins/protect/changelog/e2e-add-ctrf-and-junit-reporters
@@ -1,5 +1,0 @@
-Significance: patch
-Type: added
-Comment: dev: added a new reporter for e2e tests
-
-

--- a/projects/plugins/protect/changelog/fix-expiring-prompt-bundle-products
+++ b/projects/plugins/protect/changelog/fix-expiring-prompt-bundle-products
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-My Jetpack: Fix expiring renewal prompt to show all products

--- a/projects/plugins/protect/changelog/fix-jetpack-hello-dolly
+++ b/projects/plugins/protect/changelog/fix-jetpack-hello-dolly
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-My Jetpack page: fix visual compatibility issue with Hello Dolly plugin.

--- a/projects/plugins/protect/changelog/force-a-release
+++ b/projects/plugins/protect/changelog/force-a-release
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update dependencies.

--- a/projects/plugins/protect/changelog/prerelease
+++ b/projects/plugins/protect/changelog/prerelease
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Update composer.lock.
-
-

--- a/projects/plugins/protect/changelog/prerelease#2
+++ b/projects/plugins/protect/changelog/prerelease#2
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Update composer.lock.
-
-

--- a/projects/plugins/protect/changelog/prerelease#3
+++ b/projects/plugins/protect/changelog/prerelease#3
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Update composer.lock.
-
-

--- a/projects/plugins/protect/changelog/prerelease#4
+++ b/projects/plugins/protect/changelog/prerelease#4
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Update composer.lock.
-
-

--- a/projects/plugins/protect/changelog/prerelease#5
+++ b/projects/plugins/protect/changelog/prerelease#5
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Update composer.lock.
-
-

--- a/projects/plugins/protect/changelog/renovate-concurrently-9.x
+++ b/projects/plugins/protect/changelog/renovate-concurrently-9.x
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/plugins/protect/changelog/renovate-config-4.x
+++ b/projects/plugins/protect/changelog/renovate-config-4.x
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/plugins/protect/changelog/renovate-definitelytyped
+++ b/projects/plugins/protect/changelog/renovate-definitelytyped
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/plugins/protect/changelog/renovate-lock-file-maintenance
+++ b/projects/plugins/protect/changelog/renovate-lock-file-maintenance
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/plugins/protect/changelog/renovate-tanstack-query-monorepo
+++ b/projects/plugins/protect/changelog/renovate-tanstack-query-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/plugins/protect/changelog/renovate-typescript-5.x
+++ b/projects/plugins/protect/changelog/renovate-typescript-5.x
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/plugins/protect/changelog/renovate-wordpress-monorepo
+++ b/projects/plugins/protect/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/plugins/protect/changelog/renovate-wordpress-monorepo#25
+++ b/projects/plugins/protect/changelog/renovate-wordpress-monorepo#25
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Gutenberg packages' ESM builds don't fully specify their imports. Set `resolve.fullySpecified` in Webpack config for these packages.
-
-

--- a/projects/plugins/protect/changelog/update-crew_refs
+++ b/projects/plugins/protect/changelog/update-crew_refs
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Update references from Crew to the Monorepo team.
-
-

--- a/projects/plugins/protect/changelog/update-jetpack-tested-to-ver-wp
+++ b/projects/plugins/protect/changelog/update-jetpack-tested-to-ver-wp
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Tested up to WordPress 6.9

--- a/projects/plugins/protect/changelog/update-php8.4-set_as_default
+++ b/projects/plugins/protect/changelog/update-php8.4-set_as_default
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Update composer.lock
-
-

--- a/projects/plugins/protect/changelog/update-remove-getIconColor
+++ b/projects/plugins/protect/changelog/update-remove-getIconColor
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Jetpack: remove getIconColor functions for block icons

--- a/projects/plugins/protect/changelog/update-replace-removed-wordpress-icons
+++ b/projects/plugins/protect/changelog/update-replace-removed-wordpress-icons
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Replace icons removed from @wordpress/icons with alternatives.

--- a/projects/plugins/protect/changelog/update-tooling-update_stable_tag_in_backport
+++ b/projects/plugins/protect/changelog/update-tooling-update_stable_tag_in_backport
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Update stable tag in trunk.
-
-

--- a/projects/plugins/protect/composer.json
+++ b/projects/plugins/protect/composer.json
@@ -81,6 +81,6 @@
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true
 		},
-		"autoloader-suffix": "c4802e05bbcf59fd3b6350e8d3e5482c_protectⓥ4_4_0"
+		"autoloader-suffix": "c4802e05bbcf59fd3b6350e8d3e5482c_protectⓥ4_4_1"
 	}
 }

--- a/projects/plugins/protect/jetpack-protect.php
+++ b/projects/plugins/protect/jetpack-protect.php
@@ -3,7 +3,7 @@
  * Plugin Name: Jetpack Protect
  * Plugin URI: https://wordpress.org/plugins/jetpack-protect
  * Description: Security tools that keep your site safe and sound, from posts to plugins.
- * Version: 4.4.0
+ * Version: 4.4.1
  * Author: Automattic - Jetpack Security team
  * Author URI: https://jetpack.com/protect/
  * License: GPLv2 or later
@@ -32,7 +32,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit( 0 );
 }
 
-define( 'JETPACK_PROTECT_VERSION', '4.4.0' );
+define( 'JETPACK_PROTECT_VERSION', '4.4.1' );
 define( 'JETPACK_PROTECT_DIR', plugin_dir_path( __FILE__ ) );
 define( 'JETPACK_PROTECT_ROOT_FILE', __FILE__ );
 define( 'JETPACK_PROTECT_ROOT_FILE_RELATIVE_PATH', plugin_basename( __FILE__ ) );

--- a/projects/plugins/protect/readme.txt
+++ b/projects/plugins/protect/readme.txt
@@ -178,18 +178,17 @@ The new Jetpack Protect plugin is different from the Jetpack feature formerly kn
 4. The Jetpack Firewall is a web application firewall (known as WAF) designed to protect your WordPress site from malicious requests.
 
 == Changelog ==
-### 4.4.0 - 2025-10-10
+### 4.4.1 - 2025-11-21
 #### Added
-- Add typecheck script.
-- Add typecheck support for E2E tests.
+- Tested up to WordPress 6.9.
 
 #### Changed
-- My Jetpack: Fix multisite availability check for restricted products and modules.
-- My Jetpack: Unify the user connection flow with a unified screen.
-- Remove CRM installation nudge for Complete plan users.
+- Replace icons removed from @wordpress/icons with alternatives.
+- Update dependencies.
 - Update package dependencies.
 
 #### Fixed
-- I18n: Improve context hints in comments for translators.
-- My Jetpack: Prevent expiration alerts for products covered by active bundles.
+- Jetpack: remove getIconColor functions for block icons
+- My Jetpack: Fix expiring renewal prompt to show all products
+- My Jetpack page: fix visual compatibility issue with Hello Dolly plugin.
 

--- a/projects/plugins/protect/readme.txt
+++ b/projects/plugins/protect/readme.txt
@@ -4,7 +4,7 @@ Tags: jetpack, protect, security, malware, scan
 Requires at least: 6.7
 Requires PHP: 7.2
 Tested up to: 6.9
-Stable tag: 4.4.0
+Stable tag: 4.4.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 

--- a/projects/plugins/search/CHANGELOG.md
+++ b/projects/plugins/search/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.2.2] - 2025-11-21
+### Fixed
+- Jetpack: Remove getIconColor functions for block icons. [#45992]
+- My Jetpack: Fix expiring renewal prompt to show all products. [#45995]
+
 ## [5.2.0] - 2025-11-12
 ### Added
 - Instant Search: Add global WooCommerce Product Attributes as filter options. [#45416]
@@ -258,6 +263,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [1.1.0-beta]: https://github.com/Automattic/jetpack-search-plugin/compare/1.0.0...1.1.0-beta
 [1.2.0-beta]: https://github.com/Automattic/jetpack-search-plugin/compare/1.1.0...1.2.0-beta
+[5.2.2]: https://github.com/Automattic/jetpack-search-plugin/compare/5.2.0...5.2.2
 [5.2.0]: https://github.com/Automattic/jetpack-search-plugin/compare/5.1.0...5.2.0
 [5.1.0]: https://github.com/Automattic/jetpack-search-plugin/compare/5.0.0...5.1.0
 [5.0.0]: https://github.com/Automattic/jetpack-search-plugin/compare/4.1.0...5.0.0

--- a/projects/plugins/search/changelog/e2e-add-ctrf-and-junit-reporters
+++ b/projects/plugins/search/changelog/e2e-add-ctrf-and-junit-reporters
@@ -1,5 +1,0 @@
-Significance: patch
-Type: added
-Comment: dev: added a new reporter for e2e tests
-
-

--- a/projects/plugins/search/changelog/fix-expiring-prompt-bundle-products
+++ b/projects/plugins/search/changelog/fix-expiring-prompt-bundle-products
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-My Jetpack: Fix expiring renewal prompt to show all products

--- a/projects/plugins/search/changelog/prerelease
+++ b/projects/plugins/search/changelog/prerelease
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Update composer.lock.
-
-

--- a/projects/plugins/search/changelog/update-remove-getIconColor
+++ b/projects/plugins/search/changelog/update-remove-getIconColor
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Jetpack: remove getIconColor functions for block icons

--- a/projects/plugins/search/changelog/update-tooling-update_stable_tag_in_backport
+++ b/projects/plugins/search/changelog/update-tooling-update_stable_tag_in_backport
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Update stable tag in trunk.
-
-

--- a/projects/plugins/search/composer.json
+++ b/projects/plugins/search/composer.json
@@ -66,7 +66,7 @@
 	},
 	"config": {
 		"sort-packages": true,
-		"autoloader-suffix": "b462338fb66be23595d68a93345c9e3d_jetpack_searchⓥ5_2_0",
+		"autoloader-suffix": "b462338fb66be23595d68a93345c9e3d_jetpack_searchⓥ5_2_2",
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true,

--- a/projects/plugins/search/jetpack-search.php
+++ b/projects/plugins/search/jetpack-search.php
@@ -4,7 +4,7 @@
  * Plugin Name: Jetpack Search
  * Plugin URI: https://jetpack.com/search/
  * Description: Easily add cloud-powered instant search and filters to your website or WooCommerce store with advanced algorithms that boost your search results based on traffic to your site.
- * Version: 5.2.0
+ * Version: 5.2.2
  * Author: Automattic - Jetpack Search team
  * Author URI: https://jetpack.com/
  * License: GPLv2 or later
@@ -26,7 +26,7 @@ define( 'JETPACK_SEARCH_PLUGIN__DIR', plugin_dir_path( __FILE__ ) );
 define( 'JETPACK_SEARCH_PLUGIN__FILE', __FILE__ );
 define( 'JETPACK_SEARCH_PLUGIN__FILE_RELATIVE_PATH', plugin_basename( __FILE__ ) );
 define( 'JETPACK_SEARCH_PLUGIN__SLUG', 'jetpack-search' );
-define( 'JETPACK_SEARCH_PLUGIN__VERSION', '5.2.0' );
+define( 'JETPACK_SEARCH_PLUGIN__VERSION', '5.2.2' );
 defined( 'JETPACK_CLIENT__AUTH_LOCATION' ) || define( 'JETPACK_CLIENT__AUTH_LOCATION', 'header' );
 
 defined( 'JETPACK__API_BASE' ) || define( 'JETPACK__API_BASE', 'https://jetpack.wordpress.com/jetpack.' );

--- a/projects/plugins/search/readme.txt
+++ b/projects/plugins/search/readme.txt
@@ -122,17 +122,10 @@ If you are using the Jetpack Search free option, and you have more than 5000 rec
 5. Manage all of your Jetpack products, including Search, in a single place.
 
 == Changelog ==
-### 5.2.0 - 2025-11-12
-#### Added
-- Instant Search: Add global WooCommerce Product Attributes as filter options.
-- Tested up to WordPress 6.9.
-
-#### Changed
-- Instant Search: Fix issue where Safari's 'Use advanced tracking and fingerprinting protection' setting breaks Search.
-- Update package dependencies.
-
+### 5.2.2 - 2025-11-21
 #### Fixed
-- My Jetpack page: fix visual compatibility issue with Hello Dolly plugin.
+- Jetpack: Remove getIconColor functions for block icons.
+- My Jetpack: Fix expiring renewal prompt to show all products.
 
 == Testimonials ==
 

--- a/projects/plugins/search/readme.txt
+++ b/projects/plugins/search/readme.txt
@@ -4,7 +4,7 @@ Tags: search, filter, woocommerce search, ajax search, product search, free clou
 Requires at least: 6.7
 Requires PHP: 7.2
 Tested up to: 6.9
-Stable tag: 5.2.0
+Stable tag: 5.2.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 

--- a/projects/plugins/social/CHANGELOG.md
+++ b/projects/plugins/social/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 7.3.0 - 2025-11-21
+### Added
+- Tested up to WordPress 6.9. [#45571]
+
+### Changed
+- Don't translate product names. [#43961]
+- Improve auto-share UI in the editor by streamlining the notices and descriptions. [#45970]
+- Update package dependencies. [#45478] [#45652] [#45676] [#45756]
+- Update the connections list in the editor to a vertical toggle list with labels and icons. [#45939]
+
+### Fixed
+- Fix connection icon not reflecting the change when profile picture is updated. [#45937]
+- Jetpack: Remove getIconColor functions for block icons. [#45992]
+- My Jetpack: Fix expiring renewal prompt to show all products [#45995]
+- My Jetpack: Fix visual compatibility issue with Hello Dolly plugin. [#45474]
+
 ## 7.2.0 - 2025-10-10
 ### Added
 - Add typecheck support for E2E tests. [#44788]

--- a/projects/plugins/social/changelog/e2e-add-ctrf-and-junit-reporters
+++ b/projects/plugins/social/changelog/e2e-add-ctrf-and-junit-reporters
@@ -1,5 +1,0 @@
-Significance: patch
-Type: added
-Comment: dev: added a new reporter for e2e tests
-
-

--- a/projects/plugins/social/changelog/fix-expiring-prompt-bundle-products
+++ b/projects/plugins/social/changelog/fix-expiring-prompt-bundle-products
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-My Jetpack: Fix expiring renewal prompt to show all products

--- a/projects/plugins/social/changelog/fix-jetpack-hello-dolly
+++ b/projects/plugins/social/changelog/fix-jetpack-hello-dolly
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-My Jetpack page: fix visual compatibility issue with Hello Dolly plugin.

--- a/projects/plugins/social/changelog/fix-social-connection-icon-update
+++ b/projects/plugins/social/changelog/fix-social-connection-icon-update
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Fix connection icon not reflecting the change when profile picture is updated.

--- a/projects/plugins/social/changelog/prerelease
+++ b/projects/plugins/social/changelog/prerelease
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Update composer.lock.
-
-

--- a/projects/plugins/social/changelog/prerelease#2
+++ b/projects/plugins/social/changelog/prerelease#2
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Update composer.lock.
-
-

--- a/projects/plugins/social/changelog/prerelease#3
+++ b/projects/plugins/social/changelog/prerelease#3
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Update composer.lock.
-
-

--- a/projects/plugins/social/changelog/prerelease#4
+++ b/projects/plugins/social/changelog/prerelease#4
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Update composer.lock.
-
-

--- a/projects/plugins/social/changelog/prerelease#5
+++ b/projects/plugins/social/changelog/prerelease#5
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Update composer.lock.
-
-

--- a/projects/plugins/social/changelog/renovate-concurrently-9.x
+++ b/projects/plugins/social/changelog/renovate-concurrently-9.x
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/plugins/social/changelog/renovate-config-4.x
+++ b/projects/plugins/social/changelog/renovate-config-4.x
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/plugins/social/changelog/renovate-lock-file-maintenance
+++ b/projects/plugins/social/changelog/renovate-lock-file-maintenance
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/plugins/social/changelog/renovate-typescript-5.x
+++ b/projects/plugins/social/changelog/renovate-typescript-5.x
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/plugins/social/changelog/update-crew_refs
+++ b/projects/plugins/social/changelog/update-crew_refs
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Update references from Crew to the Monorepo team.
-
-

--- a/projects/plugins/social/changelog/update-dont-translate-product-names
+++ b/projects/plugins/social/changelog/update-dont-translate-product-names
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Don't translate product names.

--- a/projects/plugins/social/changelog/update-jetpack-tested-to-ver-wp
+++ b/projects/plugins/social/changelog/update-jetpack-tested-to-ver-wp
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Tested up to WordPress 6.9

--- a/projects/plugins/social/changelog/update-php8.4-set_as_default
+++ b/projects/plugins/social/changelog/update-php8.4-set_as_default
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Update composer.lock
-
-

--- a/projects/plugins/social/changelog/update-remove-getIconColor
+++ b/projects/plugins/social/changelog/update-remove-getIconColor
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Jetpack: remove getIconColor functions for block icons

--- a/projects/plugins/social/changelog/update-social-connection-toggles
+++ b/projects/plugins/social/changelog/update-social-connection-toggles
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update the connections list in the editor to a vertical toggle list with labels and icons.

--- a/projects/plugins/social/changelog/update-social-empty-state-n-descriptions
+++ b/projects/plugins/social/changelog/update-social-empty-state-n-descriptions
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Improve auto-share UI in the editor by streamlining the notices and descriptions.

--- a/projects/plugins/social/changelog/update-tooling-update_stable_tag_in_backport
+++ b/projects/plugins/social/changelog/update-tooling-update_stable_tag_in_backport
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Update stable tag in trunk.
-
-

--- a/projects/plugins/social/composer.json
+++ b/projects/plugins/social/composer.json
@@ -84,6 +84,6 @@
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true
 		},
-		"autoloader-suffix": "c4802e05bbcf59fd3b6350e8d3e5482c_socialⓥ7_2_0"
+		"autoloader-suffix": "c4802e05bbcf59fd3b6350e8d3e5482c_socialⓥ7_3_0"
 	}
 }

--- a/projects/plugins/social/jetpack-social.php
+++ b/projects/plugins/social/jetpack-social.php
@@ -4,7 +4,7 @@
  * Plugin Name: Jetpack Social
  * Plugin URI: https://wordpress.org/plugins/jetpack-social
  * Description: Share your site’s posts on several social media networks automatically when you publish a new post.
- * Version: 7.2.0
+ * Version: 7.3.0
  * Author: Automattic - Jetpack Social team
  * Author URI: https://jetpack.com/social/
  * License: GPLv2 or later

--- a/projects/plugins/social/readme.txt
+++ b/projects/plugins/social/readme.txt
@@ -104,18 +104,21 @@ The easiest way is to use the Custom Message option in the publishing options bo
 6. Managing Social media accounts in the post editor
 
 == Changelog ==
-### 7.2.0 - 2025-10-10
+### 7.3.0 - 2025-11-21
 #### Added
-- Add typecheck support for E2E tests.
+- Tested up to WordPress 6.9.
 
 #### Changed
-- Remove CRM installation nudge for Complete plan users.
-- My Jetpack: Fix multisite availability check for restricted products and modules.
-- Update dependencies.
+- Don't translate product names.
+- Improve auto-share UI in the editor by streamlining the notices and descriptions.
 - Update package dependencies.
+- Update the connections list in the editor to a vertical toggle list with labels and icons.
 
 #### Fixed
-- Fixes an issue with Social where default image id could not be cleared.
+- Fix connection icon not reflecting the change when profile picture is updated.
+- Jetpack: Remove getIconColor functions for block icons.
+- My Jetpack: Fix expiring renewal prompt to show all products
+- My Jetpack: Fix visual compatibility issue with Hello Dolly plugin.
 
 == Upgrade Notice ==
 

--- a/projects/plugins/social/readme.txt
+++ b/projects/plugins/social/readme.txt
@@ -4,7 +4,7 @@ Tags: social media automation, social media scheduling, auto share, social shari
 Requires at least: 6.7
 Requires PHP: 7.2
 Tested up to: 6.9
-Stable tag: 7.2.0
+Stable tag: 7.3.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 

--- a/projects/plugins/vaultpress/CHANGELOG.md
+++ b/projects/plugins/vaultpress/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## 4.0.6 - 2025-11-21
+### Fixed
+- Phan: Address PhanPossiblyUndeclaredVariable violations. [#45911]
+
 ## 4.0.4 - 2025-11-12
 ### Added
 - Tested up to WordPress 6.9. [#45571]

--- a/projects/plugins/vaultpress/changelog/fix-phan-PhanPossiblyUndeclaredVariable
+++ b/projects/plugins/vaultpress/changelog/fix-phan-PhanPossiblyUndeclaredVariable
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Phan: Address PhanPossiblyUndeclaredVariable violations.

--- a/projects/plugins/vaultpress/changelog/update-tooling-update_stable_tag_in_backport
+++ b/projects/plugins/vaultpress/changelog/update-tooling-update_stable_tag_in_backport
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Update stable tag in trunk.
-
-

--- a/projects/plugins/vaultpress/composer.json
+++ b/projects/plugins/vaultpress/composer.json
@@ -39,7 +39,7 @@
 	"minimum-stability": "dev",
 	"prefer-stable": true,
 	"config": {
-		"autoloader-suffix": "9559eef123208b7d1b9c15b978567267_vaultpressⓥ4_0_4",
+		"autoloader-suffix": "9559eef123208b7d1b9c15b978567267_vaultpressⓥ4_0_6",
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true
 		}

--- a/projects/plugins/vaultpress/readme.txt
+++ b/projects/plugins/vaultpress/readme.txt
@@ -3,7 +3,7 @@ Contributors: automattic, annezazu, apokalyptik, bjorsch, briancolinger, dsmart,
 Tags: security, malware, virus, archive, back up, back ups, backup, backups, scanning, restore, wordpress backup, site backup, website backup
 Requires at least: 5.2
 Tested up to: 6.9
-Stable tag: 4.0.4
+Stable tag: 4.0.6
 Requires PHP: 7.2
 License: GPLv2
 

--- a/projects/plugins/vaultpress/readme.txt
+++ b/projects/plugins/vaultpress/readme.txt
@@ -32,12 +32,9 @@ View our full list of FAQs at [http://help.vaultpress.com/faq/](http://help.vaul
 A Jetpack VaultPress subscription is for a single WordPress site.
 
 == Changelog ==
-### 4.0.4 - 2025-11-12
-#### Added
-- Tested up to WordPress 6.9.
-
-#### Changed
-- Update package dependencies.
+### 4.0.6 - 2025-11-21
+#### Fixed
+- Phan: Address PhanPossiblyUndeclaredVariable violations.
 
 --------
 

--- a/projects/plugins/vaultpress/vaultpress.php
+++ b/projects/plugins/vaultpress/vaultpress.php
@@ -3,7 +3,7 @@
  * Plugin Name: VaultPress
  * Plugin URI: http://vaultpress.com/?utm_source=plugin-uri&amp;utm_medium=plugin-description&amp;utm_campaign=1.0
  * Description: Protect your content, themes, plugins, and settings with <strong>realtime backup</strong> and <strong>automated security scanning</strong> from <a href="http://vaultpress.com/?utm_source=wp-admin&amp;utm_medium=plugin-description&amp;utm_campaign=1.0" rel="nofollow">VaultPress</a>. Activate, enter your registration key, and never worry again. <a href="http://vaultpress.com/help/?utm_source=wp-admin&amp;utm_medium=plugin-description&amp;utm_campaign=1.0" rel="nofollow">Need some help?</a>
- * Version: 4.0.4
+ * Version: 4.0.6
  * Author: Automattic
  * Author URI: http://vaultpress.com/?utm_source=author-uri&amp;utm_medium=plugin-description&amp;utm_campaign=1.0
  * License: GPL2+
@@ -17,7 +17,7 @@
 defined( 'ABSPATH' ) || die( 0 );
 
 define( 'VAULTPRESS__MINIMUM_PHP_VERSION', '7.2' );
-define( 'VAULTPRESS__VERSION', '4.0.4' );
+define( 'VAULTPRESS__VERSION', '4.0.6' );
 define( 'VAULTPRESS__PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 
 /**

--- a/projects/plugins/videopress/CHANGELOG.md
+++ b/projects/plugins/videopress/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 2.7 - 2025-11-21
+### Added
+- Tested up to WordPress 6.9. [#45571]
+
+### Changed
+- Update dependencies. [#45488]
+- Update package dependencies. [#45478] [#45652] [#45676] [#45756] [#45915]
+
+### Fixed
+- Jetpack: Remove getIconColor functions for block icons. [#45992]
+- My Jetpack: Fix expiring renewal prompt to show all products. [#45995]
+- My Jetpack: Fix visual compatibility issue with Hello Dolly plugin. [#45474]
+
 ## 2.6 - 2025-10-10
 ### Added
 - Add typecheck support for E2E tests. [#44788]

--- a/projects/plugins/videopress/changelog/e2e-add-ctrf-and-junit-reporters
+++ b/projects/plugins/videopress/changelog/e2e-add-ctrf-and-junit-reporters
@@ -1,5 +1,0 @@
-Significance: patch
-Type: added
-Comment: dev: added a new reporter for e2e tests
-
-

--- a/projects/plugins/videopress/changelog/fix-expiring-prompt-bundle-products
+++ b/projects/plugins/videopress/changelog/fix-expiring-prompt-bundle-products
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-My Jetpack: Fix expiring renewal prompt to show all products

--- a/projects/plugins/videopress/changelog/fix-jetpack-hello-dolly
+++ b/projects/plugins/videopress/changelog/fix-jetpack-hello-dolly
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-My Jetpack page: fix visual compatibility issue with Hello Dolly plugin.

--- a/projects/plugins/videopress/changelog/force-a-release
+++ b/projects/plugins/videopress/changelog/force-a-release
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update dependencies.

--- a/projects/plugins/videopress/changelog/prerelease
+++ b/projects/plugins/videopress/changelog/prerelease
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Update composer.lock.
-
-

--- a/projects/plugins/videopress/changelog/prerelease#2
+++ b/projects/plugins/videopress/changelog/prerelease#2
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Update composer.lock.
-
-

--- a/projects/plugins/videopress/changelog/prerelease#3
+++ b/projects/plugins/videopress/changelog/prerelease#3
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Update composer.lock.
-
-

--- a/projects/plugins/videopress/changelog/prerelease#4
+++ b/projects/plugins/videopress/changelog/prerelease#4
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Update composer.lock.
-
-

--- a/projects/plugins/videopress/changelog/prerelease#5
+++ b/projects/plugins/videopress/changelog/prerelease#5
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Update composer.lock.
-
-

--- a/projects/plugins/videopress/changelog/renovate-concurrently-9.x
+++ b/projects/plugins/videopress/changelog/renovate-concurrently-9.x
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/plugins/videopress/changelog/renovate-config-4.x
+++ b/projects/plugins/videopress/changelog/renovate-config-4.x
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/plugins/videopress/changelog/renovate-lock-file-maintenance
+++ b/projects/plugins/videopress/changelog/renovate-lock-file-maintenance
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/plugins/videopress/changelog/renovate-typescript-5.x
+++ b/projects/plugins/videopress/changelog/renovate-typescript-5.x
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/plugins/videopress/changelog/renovate-wordpress-monorepo
+++ b/projects/plugins/videopress/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/plugins/videopress/changelog/update-crew_refs
+++ b/projects/plugins/videopress/changelog/update-crew_refs
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Update references from Crew to the Monorepo team.
-
-

--- a/projects/plugins/videopress/changelog/update-jetpack-tested-to-ver-wp
+++ b/projects/plugins/videopress/changelog/update-jetpack-tested-to-ver-wp
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Tested up to WordPress 6.9

--- a/projects/plugins/videopress/changelog/update-php8.4-set_as_default
+++ b/projects/plugins/videopress/changelog/update-php8.4-set_as_default
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Update composer.lock
-
-

--- a/projects/plugins/videopress/changelog/update-remove-getIconColor
+++ b/projects/plugins/videopress/changelog/update-remove-getIconColor
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Jetpack: remove getIconColor functions for block icons

--- a/projects/plugins/videopress/changelog/update-tooling-update_stable_tag_in_backport
+++ b/projects/plugins/videopress/changelog/update-tooling-update_stable_tag_in_backport
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Update stable tag in trunk.
-
-

--- a/projects/plugins/videopress/composer.json
+++ b/projects/plugins/videopress/composer.json
@@ -54,6 +54,6 @@
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true
 		},
-		"autoloader-suffix": "c4802e05bbcf59fd3b6350e8d3e5482c_videopressⓥ2_6"
+		"autoloader-suffix": "c4802e05bbcf59fd3b6350e8d3e5482c_videopressⓥ2_7"
 	}
 }

--- a/projects/plugins/videopress/jetpack-videopress.php
+++ b/projects/plugins/videopress/jetpack-videopress.php
@@ -4,7 +4,7 @@
  * Plugin Name: Jetpack VideoPress
  * Plugin URI: https://wordpress.org/plugins/jetpack-videopress
  * Description: High quality, ad-free video.
- * Version: 2.6
+ * Version: 2.7
  * Author: Automattic - Jetpack Video team
  * Author URI: https://jetpack.com/videopress/
  * License: GPLv2 or later

--- a/projects/plugins/videopress/readme.txt
+++ b/projects/plugins/videopress/readme.txt
@@ -83,12 +83,16 @@ The file size limit is 5 GB. However, on slower networks, there is a chance the 
 4. Edit your video details, cover image, and privacy from your VideoPress library.
 
 == Changelog ==
-### 2.6 - 2025-10-10
+### 2.7 - 2025-11-21
 #### Added
-- Add typecheck support for E2E tests.
+- Tested up to WordPress 6.9.
 
 #### Changed
-- Remove CRM installation nudge for Complete plan users.
-- My Jetpack: Fix multisite availability check for restricted products and modules.
+- Update dependencies.
 - Update package dependencies.
+
+#### Fixed
+- Jetpack: Remove getIconColor functions for block icons.
+- My Jetpack: Fix expiring renewal prompt to show all products.
+- My Jetpack: Fix visual compatibility issue with Hello Dolly plugin.
 

--- a/projects/plugins/videopress/readme.txt
+++ b/projects/plugins/videopress/readme.txt
@@ -3,7 +3,7 @@ Contributors: automattic, retrofox, oskosk, thehenridev, renatoagds, lhkowalski,
 Tags: video, video-hosting, video-player, cdn, video-streaming
 Requires at least: 6.7
 Tested up to: 6.9
-Stable tag: 2.6
+Stable tag: 2.7
 Requires PHP: 7.2
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
Closes MONOREP-249

 <!--- This template is used for backporting changes made during a plugin release back to trunk. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Backports changes for social 7.3.0, videopress 2.7, search 5.2.2, vaultpress 4.0.6, protect 4.4.1

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/a
## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Proofread changes.