### PR TITLE
Help Center: Use the new endpoint

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/HAPD-2967-refactor-help-center-search-api-to-support-a4a
+++ b/projects/packages/jetpack-mu-wpcom/changelog/HAPD-2967-refactor-help-center-search-api-to-support-a4a
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+The Help Center search endpoint is changing, we need to update the URL

--- a/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-wp-rest-help-center-search.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-wp-rest-help-center-search.php
@@ -57,6 +57,7 @@ class WP_REST_Help_Center_Search extends \WP_REST_Controller {
 		$query   = $request['query'];
 		$locale  = $request['locale'];
 		$section = $request['section'];
+		$source  = $request['source'];
 
 		$query_parameters = array(
 			'query'  => $query,
@@ -67,8 +68,12 @@ class WP_REST_Help_Center_Search extends \WP_REST_Controller {
 			$query_parameters['section'] = $section;
 		}
 
+		if ( ! empty( $source ) ) {
+			$query_parameters['source'] = $source;
+		}
+
 		$body = Client::wpcom_json_api_request_as_user(
-			'/help/search/wpcom?' . http_build_query( $query_parameters )
+			'/help/search?' . http_build_query( $query_parameters )
 		);
 
 		if ( is_wp_error( $body ) ) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Part of https://linear.app/a8c/issue/HAPD-2967/refactor-help-center-search-api-to-support-a4a

**TO BE MERGED AFTER 196569-ghe-Automattic/wpcom IS DEPLOYED**

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* We want to change the Help Center Search API to be more general and not so focused on WPCOM. This PR updates the Help Center Jetpack endpoints to call the updated API.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* rsync mu-wpcom-plugin to your Atomic website.
* Test that the Help Center search works.