### PR TITLE
Forms: fix outlined leading radius

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-outlined-leading-radius
+++ b/projects/packages/forms/changelog/fix-forms-outlined-leading-radius
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: outlined style leading notch was missing base border settings

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -1080,6 +1080,8 @@
 
 	.notched-label__leading {
 		border-color: var(--jetpack--contact-form--border-color);
+		border-style: var(--jetpack--contact-form--border-style);
+		border-radius: var(--jetpack--contact-form--border-radius);
 		width: var(--jetpack--contact-form--notch-width);
 		border-right: none !important;
 		border-top-right-radius: unset !important;


### PR DESCRIPTION
Fixes FORMS-424

## Proposed changes:
This PR adds initial border style settings for the leading notch used on Outlined styles.

Before:
<img width="672" height="518" alt="image" src="https://github.com/user-attachments/assets/30b54cfc-4b5f-4e57-a456-352785cf2948" />

After:
<img width="684" height="518" alt="image" src="https://github.com/user-attachments/assets/99e0e515-4924-4344-8b33-a1e7101b60db" />



### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1763644719158009-slack-C086RGTJT1D

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Use a theme showing the symptoms, like Assembler. Insert a form, see that inputs have their border radius as set by theme.
Switch the form style to Outlined. See that border radius on the inputs, until changed, remain the same as before switching the style.
Confirm the frontend reflects the style.
Try one or two more themes to confirm no regressions.