### PR TITLE
Forms: Remove height hacks and use viewport-based height calculation

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-dashboard-layout-height-hacks
+++ b/projects/packages/forms/changelog/fix-forms-dashboard-layout-height-hacks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Remove height hacks in dashboard layout and use viewport-based height calculation

--- a/projects/packages/forms/src/dashboard/components/layout/style.scss
+++ b/projects/packages/forms/src/dashboard/components/layout/style.scss
@@ -12,8 +12,6 @@ body.jetpack_page_jetpack-forms-admin {
 
 	#wpbody-content {
 		display: flex;
-		height: 100%;
-		min-height: 100%;
 	}
 }
 

--- a/projects/packages/forms/src/dashboard/components/layout/style.scss
+++ b/projects/packages/forms/src/dashboard/components/layout/style.scss
@@ -9,10 +9,6 @@ body.jetpack_page_jetpack-forms-admin {
 	#wpcontent {
 		padding-left: 0;
 	}
-
-	#wpbody-content {
-		display: flex;
-	}
 }
 
 .jp-forms-layout {

--- a/projects/packages/forms/src/dashboard/inbox/style.scss
+++ b/projects/packages/forms/src/dashboard/inbox/style.scss
@@ -157,27 +157,11 @@
 	cursor: pointer;
 }
 
-
-/*
- * We need to make the available canvas 100% tall. Without this,
- * no flex values will work, they will only use the available space.
- */
-body[class*="_page_jetpack-forms"],
-body.jetpack_page_jetpack-forms-admin {
-
-	#wpwrap,
-	#wpcontent,
-	#wpbody,
-	#wpbody-content {
-		height: 100%;
-	}
-}
-
 #jp-forms-dashboard {
 	display: flex;
 	flex-direction: column;
 	flex: 1 1 auto;
-	height: 100%;
+	height: calc(100vh - var(--wp-admin-bar-height, 32px));
 
 	// First child is the router wrapper
 	> div:first-child {


### PR DESCRIPTION
Part of FORMS-427

## Proposed changes:
  * Removes CSS height hacks that forced 100% height across multiple WordPress admin elements
  * Replaces the height approach with a cleaner viewport-based calculation using `calc(100vh - var(--wp-admin-bar-height, 32px))`
  * Simplifies the CSS by removing unnecessary rules for `#wpwrap`, `#wpcontent`, `#wpbody`, and `#wpbody-content`
  * Improves maintainability by reducing CSS specificity and complexity

The change fixes the issue with the tradeoff of not having the DV footer fixed to the bottom, I think is reasonable given the complexity we're seeing.

  ### Other information:

  - [x] Have you written new tests for your changes, if applicable?
  - [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
  - [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1763725026555969-slack-C052XEUUBL4

  ## Does this pull request change what data or activity we track or use?
  No

  ## Testing instructions:

Check both on local/JN and with a sandboxed simple site.

  * Navigate to the Forms dashboard/inbox
  * Verify that the dashboard layout renders correctly with proper height
  * The dashboard should fill the available viewport height minus the admin bar
  * Check that there are no layout issues with scrolling or overflow
  * Test with the admin bar visible (logged in) and without it (if applicable)
  * Verify the issue is solved