### PR TITLE
wpcomsh: Resolve warnings in managed plugins

### DIFF
--- a/projects/plugins/wpcomsh/changelog/fix-wpcomsh-resolve_warnings_in_managed_plugins
+++ b/projects/plugins/wpcomsh/changelog/fix-wpcomsh-resolve_warnings_in_managed_plugins
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Managed Plugins: Handle malformed data gracefully.

--- a/projects/plugins/wpcomsh/feature-plugins/managed-plugins.php
+++ b/projects/plugins/wpcomsh/feature-plugins/managed-plugins.php
@@ -597,7 +597,7 @@ add_action( 'deleted_plugin', 'wpcomsh_update_managed_plugins', 100 );
 function wpcomsh_handle_update_managed_plugins_list( $upgrader, $hook_extra ): void {
 	$is_plugin_operation = isset( $hook_extra['type'] ) && 'plugin' === $hook_extra['type'];
 	$is_valid_action     = isset( $hook_extra['action'] ) && in_array( $hook_extra['action'], array( 'install', 'update' ), true );
-	$is_update_action    = 'update' === $hook_extra['action'];
+	$is_update_action    = isset( $hook_extra['action'] ) && 'update' === $hook_extra['action'];
 	$has_managed_plugins = get_option( 'wpcomsh_at_managed_plugins', false );
 
 	if ( $is_plugin_operation && $is_valid_action ) {

--- a/projects/plugins/wpcomsh/feature-plugins/managed-plugins.php
+++ b/projects/plugins/wpcomsh/feature-plugins/managed-plugins.php
@@ -552,7 +552,7 @@ add_filter( 'atomic_managed_theme_auto_update_debug_label', 'wpcomsh_atomic_mana
  * @return mixed
  */
 function wpcomsh_remove_managed_plugins_from_update_plugins( $current ) {
-	if ( is_object( $current ) && is_array( $current->response ) ) {
+	if ( is_object( $current ) && isset( $current->response ) && is_array( $current->response ) ) {
 		foreach ( array_keys( $current->response ) as $plugin_key ) {
 			if ( wpcomsh_is_managed_plugin( $plugin_key ) ) {
 				unset( $current->response[ $plugin_key ] );


### PR DESCRIPTION
Closes MONOREP-250

 <!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR tackles about 165K warnings per month.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
```
PHP Warning: Undefined property: stdClass::$response in /wordpress/plugins/wpcomsh/8.1.0-alpha+rolling.1763722686.g3d7e3e4/feature-plugins/managed-plugins.php on line 555
```

The above adds an `isset()` check before trying to use the `response` property. It should be safe, as it would skip the for loop regardless.

```
PHP Warning: Undefined array key "action" in /wordpress/plugins/wpcomsh/8.1.0-alpha+rolling.1763660852.g805712d/feature-plugins/managed-plugins.php on line 600
```

The above adds an `isset()` check like the line just before it; this continues to evaluate to `false` in such scenarios.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Do these changes make sense?