### PR TITLE
Forms: improve name field variation handling

### DIFF
--- a/projects/packages/forms/changelog/udpate-form-name-variations
+++ b/projects/packages/forms/changelog/udpate-form-name-variations
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Forms: improve name variation handling.

--- a/projects/packages/forms/src/blocks/field-name/edit.js
+++ b/projects/packages/forms/src/blocks/field-name/edit.js
@@ -6,6 +6,7 @@ import useNameFieldTransforms from './hooks/use-name-field-transforms.js';
 import {
 	isFirstNameVariationId,
 	isLastNameVariationId,
+	isNameVariationId,
 	FIRST_NAME_ID,
 	LAST_NAME_ID,
 	NAME_ID,
@@ -26,9 +27,11 @@ export default function NameFieldEdit( props ) {
 			setAttributes( { fieldVariant: FIRST_NAME_ID } );
 		} else if ( isLastNameVariationId( id ) ) {
 			setAttributes( { fieldVariant: LAST_NAME_ID } );
+		} else if ( isNameVariationId( id ) ) {
+			setAttributes( { fieldVariant: NAME_ID } );
 		} else {
 			// Default to base 'name' variant for any other case (empty id or 'name' id)
-			setAttributes( { fieldVariant: NAME_ID } );
+			setAttributes( { fieldVariant: '' } );
 		}
 	}, [ clientId, fieldVariant, id, setAttributes ] );
 

--- a/projects/packages/forms/src/blocks/field-name/edit.js
+++ b/projects/packages/forms/src/blocks/field-name/edit.js
@@ -1,12 +1,39 @@
+import { useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import JetpackField from '../shared/components/jetpack-field.js';
 import useFormWrapper from '../shared/hooks/use-form-wrapper.js';
 import useNameFieldTransforms from './hooks/use-name-field-transforms.js';
+import {
+	isFirstNameVariationId,
+	isLastNameVariationId,
+	FIRST_NAME_ID,
+	LAST_NAME_ID,
+	NAME_ID,
+} from './variations.js';
 
 export default function NameFieldEdit( props ) {
+	const { clientId, attributes, setAttributes } = props;
+	const { id, fieldVariant } = attributes || {};
+
 	useFormWrapper( props );
 
-	useNameFieldTransforms( { clientId: props.clientId, id: props.attributes?.id } );
+	// Initialize fieldVariant for backward compatibility with existing Name field blocks.
+	useEffect( () => {
+		if ( fieldVariant ) {
+			return;
+		}
+		if ( isFirstNameVariationId( id ) ) {
+			setAttributes( { fieldVariant: FIRST_NAME_ID } );
+		} else if ( isLastNameVariationId( id ) ) {
+			setAttributes( { fieldVariant: LAST_NAME_ID } );
+		} else {
+			// Default to base 'name' variant for any other case (empty id or 'name' id)
+			setAttributes( { fieldVariant: NAME_ID } );
+		}
+	}, [ clientId, fieldVariant, id, setAttributes ] );
+
+	// Update HTML IDs and labels when transforming between variations.
+	useNameFieldTransforms( { clientId, fieldVariant } );
 
 	return (
 		<JetpackField

--- a/projects/packages/forms/src/blocks/field-name/edit.js
+++ b/projects/packages/forms/src/blocks/field-name/edit.js
@@ -1,12 +1,12 @@
 import { __ } from '@wordpress/i18n';
 import JetpackField from '../shared/components/jetpack-field.js';
 import useFormWrapper from '../shared/hooks/use-form-wrapper.js';
-import useSetFieldIdAndLabel from './hooks/use-name-label-sync.js';
+import useNameFieldTransforms from './hooks/use-name-field-transforms.js';
 
 export default function NameFieldEdit( props ) {
 	useFormWrapper( props );
 
-	useSetFieldIdAndLabel( { clientId: props.clientId, id: props.attributes?.id } );
+	useNameFieldTransforms( { clientId: props.clientId, id: props.attributes?.id } );
 
 	return (
 		<JetpackField

--- a/projects/packages/forms/src/blocks/field-name/edit.js
+++ b/projects/packages/forms/src/blocks/field-name/edit.js
@@ -1,12 +1,12 @@
 import { __ } from '@wordpress/i18n';
 import JetpackField from '../shared/components/jetpack-field.js';
 import useFormWrapper from '../shared/hooks/use-form-wrapper.js';
-import useNameLabelSync from './hooks/use-name-label-sync.js';
+import useSetFieldIdAndLabel from './hooks/use-name-label-sync.js';
 
 export default function NameFieldEdit( props ) {
 	useFormWrapper( props );
 
-	useNameLabelSync( { clientId: props.clientId, id: props.attributes?.id } );
+	useSetFieldIdAndLabel( { clientId: props.clientId, id: props.attributes?.id } );
 
 	return (
 		<JetpackField

--- a/projects/packages/forms/src/blocks/field-name/hooks/use-name-field-transforms.js
+++ b/projects/packages/forms/src/blocks/field-name/hooks/use-name-field-transforms.js
@@ -33,7 +33,7 @@ const getDefaultLabelForId = id => {
  * @param {string} params.clientId - Name field block clientId.
  * @param {string} params.id       - Current field id (used to infer variant).
  */
-export default function useSetFieldIdAndLabel( { clientId, id } ) {
+export default function useNameFieldTransforms( { clientId, id } ) {
 	const prevIdRef = useRef( id );
 	const { updateBlockAttributes } = useDispatch( blockEditorStore );
 

--- a/projects/packages/forms/src/blocks/field-name/hooks/use-name-field-transforms.js
+++ b/projects/packages/forms/src/blocks/field-name/hooks/use-name-field-transforms.js
@@ -1,6 +1,6 @@
 import { store as blockEditorStore } from '@wordpress/block-editor';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { useEffect, useMemo, useRef } from '@wordpress/element';
+import { useEffect, useRef } from '@wordpress/element';
 import { generateUniqueFormFieldId } from '../../shared/util/generate-unique-id.js';
 import {
 	FIRST_NAME_ID,
@@ -9,9 +9,6 @@ import {
 	DEFAULT_FIRST_NAME_LABEL,
 	DEFAULT_LAST_NAME_LABEL,
 	DEFAULT_NAME_LABEL,
-	isFirstNameVariationId,
-	isLastNameVariationId,
-	isKnownNameVariationId,
 } from '../variations.js';
 
 const getDefaultLabelForId = id => {
@@ -21,21 +18,24 @@ const getDefaultLabelForId = id => {
 };
 
 /**
- * Ensure Name-field variations keep correct, unique ids and default labels.
+ * Manages unique IDs and default labels for Name field variations during transforms.
  *
  * Behavior:
  * - On transform to Name/First/Last, assigns a unique id based on the variant
  * (e.g., 'name', 'name-2', 'first-name', 'first-name-2') and sets the default label.
  * - On transform back to the base Name field (empty id), clears id and restores the base label.
- * - No-ops when id is custom/non-variant.
+ * - No-ops when fieldVariant is custom/non-variant.
  *
- * @param {object} params          - Hook parameters.
- * @param {string} params.clientId - Name field block clientId.
- * @param {string} params.id       - Current field id (used to infer variant).
+ * @param {object} params              - Hook parameters.
+ * @param {string} params.clientId     - Name field block clientId.
+ * @param {string} params.fieldVariant - Current field variant ('name' | 'first-name' | 'last-name').
  */
-export default function useNameFieldTransforms( { clientId, id } ) {
-	const prevIdRef = useRef( id );
+export default function useNameFieldTransforms( { clientId, fieldVariant } ) {
+	const prevVariantRef = useRef( fieldVariant || NAME_ID );
+	const isTransforming = prevVariantRef.current !== fieldVariant;
 	const { updateBlockAttributes } = useDispatch( blockEditorStore );
+	const baseId = fieldVariant || NAME_ID;
+	const finalLabel = getDefaultLabelForId( baseId );
 
 	const existingFieldIds = useSelect(
 		select => {
@@ -53,6 +53,8 @@ export default function useNameFieldTransforms( { clientId, id } ) {
 		[ clientId ]
 	);
 
+	const finalId = generateUniqueFormFieldId( baseId, existingFieldIds );
+
 	const labelClientId = useSelect(
 		select => {
 			const block = select( blockEditorStore ).getBlock( clientId );
@@ -62,63 +64,23 @@ export default function useNameFieldTransforms( { clientId, id } ) {
 		[ clientId ]
 	);
 
-	// Derive block context details once per ID change.
-	const context = useMemo( () => {
-		const newId = id;
-		const prevId = prevIdRef.current;
-		const isTransformingToBaseBlock =
-			isKnownNameVariationId( prevId ) && ( newId === undefined || newId === '' );
-		const isTransformingToVariation = isKnownNameVariationId( newId ) && newId !== prevId;
-
-		let baseId = NAME_ID;
-		if ( isFirstNameVariationId( newId ) ) {
-			baseId = FIRST_NAME_ID;
-		} else if ( isLastNameVariationId( newId ) ) {
-			baseId = LAST_NAME_ID;
-		}
-
-		return {
-			isTransformingToBaseBlock,
-			isTransformingToVariation,
-			baseId,
-			label: getDefaultLabelForId( baseId ),
-		};
-	}, [ id ] );
-
 	// Set HTML ID on the name field block.
 	useEffect( () => {
-		if ( context.isTransformingToBaseBlock ) {
-			// Only clear the id if it isn't already empty to avoid loops.
-			if ( id !== '' ) {
-				updateBlockAttributes( clientId, { id: '' } );
-			}
-			return;
+		if ( isTransforming ) {
+			updateBlockAttributes( clientId, { id: finalId } );
 		}
-		if ( context.isTransformingToVariation ) {
-			const uniqueId = generateUniqueFormFieldId( context.baseId, existingFieldIds );
-			// Only set the id when it actually changes to avoid loops.
-			if ( id !== uniqueId ) {
-				updateBlockAttributes( clientId, { id: uniqueId } );
-			}
-		}
-	}, [ context, id, clientId, updateBlockAttributes, existingFieldIds ] );
+	}, [ finalId, clientId, updateBlockAttributes, isTransforming ] );
 
 	// Set label on the label block.
 	useEffect( () => {
-		if ( ! labelClientId ) {
+		if ( ! labelClientId || ! isTransforming ) {
 			return;
 		}
-		if ( context.isTransformingToBaseBlock ) {
-			updateBlockAttributes( labelClientId, { label: DEFAULT_NAME_LABEL } );
-			return;
-		}
-		if ( context.isTransformingToVariation ) {
-			updateBlockAttributes( labelClientId, { label: context.label } );
-		}
-	}, [ context, labelClientId, updateBlockAttributes ] );
+		updateBlockAttributes( labelClientId, { label: finalLabel } );
+	}, [ finalLabel, labelClientId, updateBlockAttributes, isTransforming ] );
 
-	// Track previous ID.
+	// Track previous variant.
 	useEffect( () => {
-		prevIdRef.current = id;
-	}, [ id ] );
+		prevVariantRef.current = fieldVariant;
+	}, [ fieldVariant ] );
 }

--- a/projects/packages/forms/src/blocks/field-name/hooks/use-name-field-transforms.js
+++ b/projects/packages/forms/src/blocks/field-name/hooks/use-name-field-transforms.js
@@ -23,16 +23,15 @@ const getDefaultLabelForId = id => {
  * Behavior:
  * - On transform to Name/First/Last, assigns a unique id based on the variant
  * (e.g., 'name', 'name-2', 'first-name', 'first-name-2') and sets the default label.
- * - On transform back to the base Name field (empty id), clears id and restores the base label.
- * - No-ops when fieldVariant is custom/non-variant.
+ * - No-ops when fieldVariant is empty or custom/non-variant.
  *
  * @param {object} params              - Hook parameters.
  * @param {string} params.clientId     - Name field block clientId.
  * @param {string} params.fieldVariant - Current field variant ('name' | 'first-name' | 'last-name').
  */
 export default function useNameFieldTransforms( { clientId, fieldVariant } ) {
-	const prevVariantRef = useRef( fieldVariant || NAME_ID );
-	const isTransforming = prevVariantRef.current !== fieldVariant;
+	const prevVariantRef = useRef( fieldVariant );
+	const isTransforming = !! fieldVariant && prevVariantRef.current !== fieldVariant;
 	const { updateBlockAttributes } = useDispatch( blockEditorStore );
 	const baseId = fieldVariant || NAME_ID;
 	const finalLabel = getDefaultLabelForId( baseId );

--- a/projects/packages/forms/src/blocks/field-name/hooks/use-name-label-sync.js
+++ b/projects/packages/forms/src/blocks/field-name/hooks/use-name-label-sync.js
@@ -66,9 +66,9 @@ export default function useSetFieldIdAndLabel( { clientId, id } ) {
 	const context = useMemo( () => {
 		const newId = id;
 		const prevId = prevIdRef.current;
-		const isBaseFormBlock =
+		const isTransformingToBaseBlock =
 			isKnownNameVariationId( prevId ) && ( newId === undefined || newId === '' );
-		const isTransform = isKnownNameVariationId( newId ) && newId !== prevId;
+		const isTransformingToVariation = isKnownNameVariationId( newId ) && newId !== prevId;
 
 		let baseId = NAME_ID;
 		if ( isFirstNameVariationId( newId ) ) {
@@ -78,8 +78,8 @@ export default function useSetFieldIdAndLabel( { clientId, id } ) {
 		}
 
 		return {
-			isBaseFormBlock,
-			isTransform,
+			isTransformingToBaseBlock,
+			isTransformingToVariation,
 			baseId,
 			label: getDefaultLabelForId( baseId ),
 		};
@@ -87,14 +87,14 @@ export default function useSetFieldIdAndLabel( { clientId, id } ) {
 
 	// Set HTML ID on the name field block.
 	useEffect( () => {
-		if ( context.isBaseFormBlock ) {
+		if ( context.isTransformingToBaseBlock ) {
 			// Only clear the id if it isn't already empty to avoid loops.
 			if ( id !== '' ) {
 				updateBlockAttributes( clientId, { id: '' } );
 			}
 			return;
 		}
-		if ( context.isTransform ) {
+		if ( context.isTransformingToVariation ) {
 			const uniqueId = generateUniqueFormFieldId( context.baseId, existingFieldIds );
 			// Only set the id when it actually changes to avoid loops.
 			if ( id !== uniqueId ) {
@@ -108,16 +108,16 @@ export default function useSetFieldIdAndLabel( { clientId, id } ) {
 		if ( ! labelClientId ) {
 			return;
 		}
-		if ( context.isBaseFormBlock ) {
+		if ( context.isTransformingToBaseBlock ) {
 			updateBlockAttributes( labelClientId, { label: DEFAULT_NAME_LABEL } );
 			return;
 		}
-		if ( context.isTransform ) {
+		if ( context.isTransformingToVariation ) {
 			updateBlockAttributes( labelClientId, { label: context.label } );
 		}
 	}, [ context, labelClientId, updateBlockAttributes ] );
 
-	// Effect C: track previous id
+	// Track previous ID.
 	useEffect( () => {
 		prevIdRef.current = id;
 	}, [ id ] );

--- a/projects/packages/forms/src/blocks/field-name/hooks/use-name-label-sync.js
+++ b/projects/packages/forms/src/blocks/field-name/hooks/use-name-label-sync.js
@@ -1,15 +1,18 @@
 import { store as blockEditorStore } from '@wordpress/block-editor';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { useEffect, useRef } from '@wordpress/element';
+import { useEffect, useMemo, useRef } from '@wordpress/element';
+import { generateUniqueFormFieldId } from '../../shared/util/generate-unique-id.js';
 import {
 	FIRST_NAME_ID,
 	LAST_NAME_ID,
+	NAME_ID,
 	DEFAULT_FIRST_NAME_LABEL,
 	DEFAULT_LAST_NAME_LABEL,
 	DEFAULT_NAME_LABEL,
+	isFirstNameVariationId,
+	isLastNameVariationId,
+	isKnownNameVariationId,
 } from '../variations.js';
-
-const isKnownId = id => id === FIRST_NAME_ID || id === LAST_NAME_ID;
 
 const getDefaultLabelForId = id => {
 	if ( id === FIRST_NAME_ID ) return DEFAULT_FIRST_NAME_LABEL;
@@ -18,16 +21,37 @@ const getDefaultLabelForId = id => {
 };
 
 /**
- * Sync the nested label text with the Name field's variation id when users transform
- * between known variations (first-name/last-name).
+ * Ensure Name-field variations keep correct, unique ids and default labels.
  *
- * @param {object} params          - Parameters.
- * @param {string} params.clientId - Block clientId for the Name field
- * @param {string} params.id       - Current variation id (e.g., 'first-name' | 'last-name')
+ * Behavior:
+ * - On transform to Name/First/Last, assigns a unique id based on the variant
+ * (e.g., 'name', 'name-2', 'first-name', 'first-name-2') and sets the default label.
+ * - On transform back to the base Name field (empty id), clears id and restores the base label.
+ * - No-ops when id is custom/non-variant.
+ *
+ * @param {object} params          - Hook parameters.
+ * @param {string} params.clientId - Name field block clientId.
+ * @param {string} params.id       - Current field id (used to infer variant).
  */
-export default function useNameLabelSync( { clientId, id } ) {
+export default function useSetFieldIdAndLabel( { clientId, id } ) {
 	const prevIdRef = useRef( id );
 	const { updateBlockAttributes } = useDispatch( blockEditorStore );
+
+	const existingFieldIds = useSelect(
+		select => {
+			const { getBlock, getBlocks, getBlockParents } = select( blockEditorStore );
+			const parentIds = getBlockParents( clientId ) || [];
+			const formRootId = parentIds.find( parentId => {
+				const parent = getBlock( parentId );
+				return parent?.name === 'jetpack/contact-form';
+			} );
+			const siblings = formRootId ? getBlocks( formRootId ) : getBlocks();
+			return siblings
+				.filter( block => block.clientId !== clientId && block.attributes?.id )
+				.map( block => block.attributes.id );
+		},
+		[ clientId ]
+	);
 
 	const labelClientId = useSelect(
 		select => {
@@ -38,44 +62,63 @@ export default function useNameLabelSync( { clientId, id } ) {
 		[ clientId ]
 	);
 
-	const currentLabel = useSelect(
-		select => {
-			return labelClientId
-				? select( blockEditorStore ).getBlockAttributes( labelClientId )?.label
-				: undefined;
-		},
-		[ labelClientId ]
-	);
-
-	useEffect( () => {
+	// Derive block context details once per ID change.
+	const context = useMemo( () => {
 		const newId = id;
 		const prevId = prevIdRef.current;
+		const isBaseFormBlock =
+			isKnownNameVariationId( prevId ) && ( newId === undefined || newId === '' );
+		const isTransform = isKnownNameVariationId( newId ) && newId !== prevId;
 
-		if ( ! labelClientId ) {
-			prevIdRef.current = newId;
+		let baseId = NAME_ID;
+		if ( isFirstNameVariationId( newId ) ) {
+			baseId = FIRST_NAME_ID;
+		} else if ( isLastNameVariationId( newId ) ) {
+			baseId = LAST_NAME_ID;
+		}
+
+		return {
+			isBaseFormBlock,
+			isTransform,
+			baseId,
+			label: getDefaultLabelForId( baseId ),
+		};
+	}, [ id ] );
+
+	// Set HTML ID on the name field block.
+	useEffect( () => {
+		if ( context.isBaseFormBlock ) {
+			// Only clear the id if it isn't already empty to avoid loops.
+			if ( id !== '' ) {
+				updateBlockAttributes( clientId, { id: '' } );
+			}
 			return;
 		}
-
-		// Handle transforms between known variations.
-		if ( isKnownId( newId ) && newId !== prevId ) {
-			const nextDefault = getDefaultLabelForId( newId );
-			// Ensure the parent block id matches the variation id.
-			if ( newId ) {
-				updateBlockAttributes( clientId, { id: newId } );
+		if ( context.isTransform ) {
+			const uniqueId = generateUniqueFormFieldId( context.baseId, existingFieldIds );
+			// Only set the id when it actually changes to avoid loops.
+			if ( id !== uniqueId ) {
+				updateBlockAttributes( clientId, { id: uniqueId } );
 			}
-			// Always set the label to the default for the selected variation.
-			updateBlockAttributes( labelClientId, { label: nextDefault } );
 		}
+	}, [ context, id, clientId, updateBlockAttributes, existingFieldIds ] );
 
-		// Handle transforms from a known variation back to the base Name (no id).
-		const becameBase = isKnownId( prevId ) && ( newId === undefined || newId === '' );
-		if ( becameBase ) {
-			// Clear the parent block id when returning to base.
-			updateBlockAttributes( clientId, { id: '' } );
-			// Always set the label back to the base default.
+	// Set label on the label block.
+	useEffect( () => {
+		if ( ! labelClientId ) {
+			return;
+		}
+		if ( context.isBaseFormBlock ) {
 			updateBlockAttributes( labelClientId, { label: DEFAULT_NAME_LABEL } );
+			return;
 		}
+		if ( context.isTransform ) {
+			updateBlockAttributes( labelClientId, { label: context.label } );
+		}
+	}, [ context, labelClientId, updateBlockAttributes ] );
 
-		prevIdRef.current = newId;
-	}, [ id, clientId, labelClientId, currentLabel, updateBlockAttributes ] );
+	// Effect C: track previous id
+	useEffect( () => {
+		prevIdRef.current = id;
+	}, [ id ] );
 }

--- a/projects/packages/forms/src/blocks/field-name/index.js
+++ b/projects/packages/forms/src/blocks/field-name/index.js
@@ -10,23 +10,20 @@ import variations from './variations.js';
 
 const name = 'field-name';
 
-// We define variations for Name, First name, and Last name.
-// For this block only, override transforms to remove the generic self-transform
-// to `jetpack/field-name`, so the Transform menu doesn’t show duplicate “Name”.
-// Other blocks still use the shared transforms (and can transform to Name/its variations).
-function notSelfNameTransform( transform ) {
-	return ! (
-		Array.isArray( transform.blocks ) && transform.blocks.includes( 'jetpack/field-name' )
-	);
-}
-
 const transforms = {
 	...transformsSource,
-	to: transformsSource.to.filter( notSelfNameTransform ),
+	to: transformsSource.to.filter( transform => ! transform.blocks.includes( 'jetpack/' + name ) ),
 };
 
 const settings = {
 	...defaultSettings,
+	attributes: {
+		...defaultSettings.attributes,
+		fieldVariant: {
+			type: 'string', // 'name' | 'first-name' | 'last-name'
+			default: '',
+		},
+	},
 	title: __( 'Name field', 'jetpack-forms' ),
 	description: __( 'Collect the site visitor’s name.', 'jetpack-forms' ),
 	icon: {
@@ -34,8 +31,8 @@ const settings = {
 			<Path d="M8.25 11.5C9.63071 11.5 10.75 10.3807 10.75 9C10.75 7.61929 9.63071 6.5 8.25 6.5C6.86929 6.5 5.75 7.61929 5.75 9C5.75 10.3807 6.86929 11.5 8.25 11.5ZM8.25 10C8.80228 10 9.25 9.55228 9.25 9C9.25 8.44772 8.80228 8 8.25 8C7.69772 8 7.25 8.44772 7.25 9C7.25 9.55228 7.69772 10 8.25 10ZM13 15.5V17.5H11.5V15.5C11.5 14.8096 10.9404 14.25 10.25 14.25H6.25C5.55964 14.25 5 14.8096 5 15.5V17.5H3.5V15.5C3.5 13.9812 4.73122 12.75 6.25 12.75H10.25C11.7688 12.75 13 13.9812 13 15.5ZM20.5 11H14.5V9.5H20.5V11ZM20.5 14.5H14.5V13H20.5V14.5Z" />
 		),
 	},
-	transforms,
 	variations,
+	transforms,
 	edit,
 	deprecated,
 	save,

--- a/projects/packages/forms/src/blocks/field-name/variations.js
+++ b/projects/packages/forms/src/blocks/field-name/variations.js
@@ -10,20 +10,31 @@ const icon = {
 
 export const FIRST_NAME_ID = 'first-name';
 export const LAST_NAME_ID = 'last-name';
+export const NAME_ID = 'name';
 
 export const DEFAULT_FIRST_NAME_LABEL = __( 'First name', 'jetpack-forms' );
 export const DEFAULT_LAST_NAME_LABEL = __( 'Last name', 'jetpack-forms' );
 export const DEFAULT_NAME_LABEL = __( 'Name', 'jetpack-forms' );
 
+// Predicates to consistently recognize variation ids (allows suffixed forms like name-2).
+export const isNameVariationId = id => typeof id === 'string' && /^name(?:-\d+)?$/.test( id );
+export const isFirstNameVariationId = id =>
+	typeof id === 'string' && /^first-name(?:-\d+)?$/.test( id );
+export const isLastNameVariationId = id =>
+	typeof id === 'string' && /^last-name(?:-\d+)?$/.test( id );
+export const isKnownNameVariationId = id =>
+	isNameVariationId( id ) || isFirstNameVariationId( id ) || isLastNameVariationId( id );
+
 const variations = [
 	{
-		name: 'name',
+		name: NAME_ID,
 		title: DEFAULT_NAME_LABEL,
 		description: __( 'Collect the visitor’s name.', 'jetpack-forms' ),
 		icon,
 		scope: [ 'transform' ],
+		isActive: ( { id } ) => isNameVariationId( id ),
 		attributes: {
-			id: '',
+			id: NAME_ID,
 		},
 		innerBlocks: [
 			[ 'jetpack/label', { label: DEFAULT_NAME_LABEL } ],
@@ -36,7 +47,7 @@ const variations = [
 		description: __( 'Collect the visitor’s first name.', 'jetpack-forms' ),
 		icon,
 		scope: [ 'inserter', 'transform' ],
-		isActive: [ 'id' ],
+		isActive: ( { id } ) => isFirstNameVariationId( id ),
 		attributes: {
 			id: FIRST_NAME_ID,
 		},
@@ -67,7 +78,7 @@ const variations = [
 		description: __( 'Collect the visitor’s last name.', 'jetpack-forms' ),
 		icon,
 		scope: [ 'inserter', 'transform' ],
-		isActive: [ 'id' ],
+		isActive: ( { id } ) => isLastNameVariationId( id ),
 		attributes: {
 			id: LAST_NAME_ID,
 		},

--- a/projects/packages/forms/src/blocks/field-name/variations.js
+++ b/projects/packages/forms/src/blocks/field-name/variations.js
@@ -21,6 +21,7 @@ export const isFirstNameVariationId = id =>
 	typeof id === 'string' && /^first-name(?:-\d+)?$/.test( id );
 export const isLastNameVariationId = id =>
 	typeof id === 'string' && /^last-name(?:-\d+)?$/.test( id );
+export const isNameVariationId = id => typeof id === 'string' && /^name(?:-\d+)?$/.test( id );
 
 const variations = [
 	{

--- a/projects/packages/forms/src/blocks/field-name/variations.js
+++ b/projects/packages/forms/src/blocks/field-name/variations.js
@@ -16,25 +16,23 @@ export const DEFAULT_FIRST_NAME_LABEL = __( 'First name', 'jetpack-forms' );
 export const DEFAULT_LAST_NAME_LABEL = __( 'Last name', 'jetpack-forms' );
 export const DEFAULT_NAME_LABEL = __( 'Name', 'jetpack-forms' );
 
-// Predicates to consistently recognize variation ids (allows suffixed forms like name-2).
-export const isNameVariationId = id => typeof id === 'string' && /^name(?:-\d+)?$/.test( id );
+// Variation ids can have suffixed forms like first-name-2 to avoid duplicates.
 export const isFirstNameVariationId = id =>
 	typeof id === 'string' && /^first-name(?:-\d+)?$/.test( id );
 export const isLastNameVariationId = id =>
 	typeof id === 'string' && /^last-name(?:-\d+)?$/.test( id );
-export const isKnownNameVariationId = id =>
-	isNameVariationId( id ) || isFirstNameVariationId( id ) || isLastNameVariationId( id );
 
 const variations = [
 	{
 		name: NAME_ID,
 		title: DEFAULT_NAME_LABEL,
-		description: __( 'Collect the visitor’s name.', 'jetpack-forms' ),
+		description: __( 'Collect the site visitor’s name.', 'jetpack-forms' ),
 		icon,
 		scope: [ 'transform' ],
-		isActive: ( { id } ) => isNameVariationId( id ),
+		isActive: blockAttributes => blockAttributes.fieldVariant === NAME_ID,
 		attributes: {
-			id: NAME_ID,
+			id: '',
+			fieldVariant: NAME_ID,
 		},
 		innerBlocks: [
 			[ 'jetpack/label', { label: DEFAULT_NAME_LABEL } ],
@@ -47,9 +45,10 @@ const variations = [
 		description: __( 'Collect the visitor’s first name.', 'jetpack-forms' ),
 		icon,
 		scope: [ 'inserter', 'transform' ],
-		isActive: ( { id } ) => isFirstNameVariationId( id ),
+		isActive: blockAttributes => blockAttributes.fieldVariant === FIRST_NAME_ID,
 		attributes: {
 			id: FIRST_NAME_ID,
+			fieldVariant: FIRST_NAME_ID,
 		},
 		innerBlocks: [
 			[ 'jetpack/label', { label: DEFAULT_FIRST_NAME_LABEL } ],
@@ -78,9 +77,10 @@ const variations = [
 		description: __( 'Collect the visitor’s last name.', 'jetpack-forms' ),
 		icon,
 		scope: [ 'inserter', 'transform' ],
-		isActive: ( { id } ) => isLastNameVariationId( id ),
+		isActive: blockAttributes => blockAttributes.fieldVariant === LAST_NAME_ID,
 		attributes: {
 			id: LAST_NAME_ID,
+			fieldVariant: LAST_NAME_ID,
 		},
 		innerBlocks: [
 			[ 'jetpack/label', { label: DEFAULT_LAST_NAME_LABEL } ],

--- a/projects/packages/forms/src/blocks/shared/util/generate-unique-id.js
+++ b/projects/packages/forms/src/blocks/shared/util/generate-unique-id.js
@@ -6,10 +6,10 @@
  * @return {string} Unique id, e.g., 'name', 'name-2', 'name-3'
  */
 export function generateUniqueFormFieldId( baseId, usedIds ) {
-	if ( ! baseId || ! Array.isArray( usedIds ) ) {
-		return baseId;
+	if ( ! baseId ) {
+		return '';
 	}
-	if ( ! usedIds.includes( baseId ) ) {
+	if ( ! Array.isArray( usedIds ) || ! usedIds.includes( baseId ) ) {
 		return baseId;
 	}
 	let i = 2;

--- a/projects/packages/forms/src/blocks/shared/util/generate-unique-id.js
+++ b/projects/packages/forms/src/blocks/shared/util/generate-unique-id.js
@@ -1,0 +1,20 @@
+/**
+ * Generate a unique id by appending an incrementing numeric suffix when needed.
+ *
+ * @param {string}   baseId  - Base id (e.g., 'name', 'first-name', 'last-name')
+ * @param {string[]} usedIds - List of ids already in use
+ * @return {string} Unique id, e.g., 'name', 'name-2', 'name-3'
+ */
+export function generateUniqueFormFieldId( baseId, usedIds ) {
+	if ( ! baseId || ! Array.isArray( usedIds ) ) {
+		return baseId;
+	}
+	if ( ! usedIds.includes( baseId ) ) {
+		return baseId;
+	}
+	let i = 2;
+	while ( usedIds.includes( `${ baseId }-${ i }` ) ) {
+		i++;
+	}
+	return `${ baseId }-${ i }`;
+}

--- a/projects/plugins/jetpack/changelog/udpate-form-name-variations
+++ b/projects/plugins/jetpack/changelog/udpate-form-name-variations
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Forms: improve name variation handling.


### PR DESCRIPTION
## Proposed changes:

Improves how we handle Name field variations, including transforming between them. 
* **Add fieldVariant attribute.** Adds this attribute to the name field as a better of way of tracking which variation of the name block is being used at any given time. We were relying on HTML ID, but that's fragile. 
* **Adds ID for Name variation.** Applies 'name' HTML ID to Name Variation so it can be distinguished from base Name field block, for which ID is blank.
  - This also fixes a small issue where Name variation wasn't property identified in dropdown in block sidebar (see screenshot below)
* **Avoids duplicate IDs**. We were adding 'name' / 'first-name' / 'last-name' to any variation, which would allow duplicates. Added a method that checks if IDs exist, and if so, increments them (ie, will get name-2, name-3, etc).
* **Sets isActive.** Updates isActive property when registering variation so we correctly know if a given variation is active.
* **Updates useNameFieldTransforms hook.** Refactors this hook and updates it to handle both ID and field label when transforming between name variations. 

Please see product discussion section below for more context.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
See Slack: p1763586367177249-slack-C034JEXD1

The initial need for this arose because [this PR](https://github.com/Automattic/jetpack/pull/45985) defined isActive for the Name Variation if the ID field was empty. But this caused a mix up between the base Name block and the Name variation, and broke some tests. I removed that as a quick testing fix. But this PR offers a stronger fix. The Name variation now has a 'name' ID, which allows us to distinguish between Name base block and Name variation. 

If you are wondering why need both, when we transform from first/last name to just name, we need to clear the ID field. Simple but oddly tricky for a variety of reasons, and requires that the variation we're changing to sets the ID field. For a variety of reason we do not want to explicit the ID field for the core Name block to '' or 'name'. So we added a variation for that. But then we had block + variation that are near identical except for the ID field. 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No. 

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Add a form to a post. Include a name field. 
* Transform the name field in many different directions name block <> first name <> last name <> name variation etc. 
  - Confirm the label updates
  - Confirm the HTML ID in the block sidebar - should be blank, 'name', 'first-name', 'last-name' for core block name variation, first name variation, last name variation, respectively. 
* Add more than one first/last/name variation to a page, and confirm that the HTML increments to first-name-2, last-name-2, name-2, etc. 
* Confirm we correctly identify the variation in this dropdown: 
<img width="1253" height="334" alt="name-variation-dropdown" src="https://github.com/user-attachments/assets/5e25c07b-131c-41ec-82d5-e7c370e1eea3" />
