### PR TITLE
Google Analytics: Provide fallback when $woocommmerce_loop global is not set

### DIFF
--- a/projects/packages/google-analytics/changelog/fix-google-analytics-warnings_when_global_is_not_set
+++ b/projects/packages/google-analytics/changelog/fix-google-analytics-warnings_when_global_is_not_set
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Provide fallback value when $woocommerce_loop global is not set.

--- a/projects/packages/google-analytics/src/class-universal.php
+++ b/projects/packages/google-analytics/src/class-universal.php
@@ -421,7 +421,7 @@ class Universal {
 			'name'     => $product->get_title(),
 			'category' => Utils::get_product_categories_concatenated( $product ),
 			'list'     => $list,
-			'position' => $woocommerce_loop['loop'],
+			'position' => $woocommerce_loop['loop'] ?? null,
 		);
 		// @phan-suppress-next-line PhanUndeclaredFunction
 		\wc_enqueue_js( "ga( 'ec:addImpression', " . wp_json_encode( $item_details ) . ' );' );
@@ -454,7 +454,7 @@ class Universal {
 			'id'       => $product_sku_or_id,
 			'name'     => $product->get_title(),
 			'category' => Utils::get_product_categories_concatenated( $product ),
-			'position' => $woocommerce_loop['loop'],
+			'position' => $woocommerce_loop['loop'] ?? null,
 		);
 
 		// @phan-suppress-next-line PhanUndeclaredFunction


### PR DESCRIPTION
Closes MONOREP-251

 <!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

There are two related warnings this PR addresses:
```
PHP Warning: Trying to access array offset on null in /wordpress/plugins/wpcomsh/8.1.0-alpha+rolling.1763750826.gc87d55a/jetpack_vendor/automattic/jetpack-google-analytics/src/class-universal.php on line 424
PHP Warning: Trying to access array offset on null in /wordpress/plugins/wpcomsh/8.1.0-alpha+rolling.1763750826.gc87d55a/jetpack_vendor/automattic/jetpack-google-analytics/src/class-universal.php on line 457
```

This happens when the `$woocommerce_loop` global is not set. The fix should be fairly safe: provide a fallback of `null` to the 'position' key, which in turn gets passed along to Google Analytics.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

