### PR TITLE
LESS: Address issues in legacy library

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-address_lessc_preprocessor_issues
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-address_lessc_preprocessor_issues
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+LESS: Clean up various issues in legacy library.

--- a/projects/packages/jetpack-mu-wpcom/src/features/custom-css/custom-css/preprocessors/lessc.inc.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/custom-css/custom-css/preprocessors/lessc.inc.php
@@ -3500,7 +3500,7 @@ class lessc_parser {
 		if ($eatWhitespace === null) $eatWhitespace = $this->eatWhiteDefault;
 
 		$r = '/'.$regex.($eatWhitespace && !$this->writeComments ? '\s*' : '').'/Ais';
-		if (preg_match($r, $this->buffer, $out, null, $this->count)) {
+		if (preg_match($r, $this->buffer, $out, 0, $this->count)) {
 			$this->count += strlen($out[0]);
 			if ($eatWhitespace && $this->writeComments) $this->whitespace();
 			return true;
@@ -3531,7 +3531,7 @@ class lessc_parser {
 	protected function peek($regex, &$out = null, $from=null) {
 		if (is_null($from)) $from = $this->count;
 		$r = '/'.$regex.'/Ais';
-		$result = preg_match($r, $this->buffer, $out, null, $from);
+		$result = preg_match($r, $this->buffer, $out, 0, $from);
 
 		return $result;
 	}

--- a/projects/packages/jetpack-mu-wpcom/src/features/custom-css/custom-css/preprocessors/lessc.inc.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/custom-css/custom-css/preprocessors/lessc.inc.php
@@ -1270,7 +1270,7 @@ class lessc {
 
 	protected function lib_luma($color) {
 	    $color = $this->coerceColor($color);
-	    return (0.2126 * (float)$color[0] / 255) + (0.7152 * (float)$color[1] / 255) + (0.0722 * (float)$color[2] / 255);
+	    return (0.2126 * $color[1] / 255) + (0.7152 * $color[2] / 255) + (0.0722 * $color[3] / 255);
 	}
 
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/custom-css/custom-css/preprocessors/lessc.inc.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/custom-css/custom-css/preprocessors/lessc.inc.php
@@ -1270,7 +1270,7 @@ class lessc {
 
 	protected function lib_luma($color) {
 	    $color = $this->coerceColor($color);
-	    return (0.2126 * $color[0] / 255) + (0.7152 * $color[1] / 255) + (0.0722 * $color[2] / 255);
+	    return (0.2126 * (float)$color[0] / 255) + (0.7152 * (float)$color[1] / 255) + (0.0722 * (float)$color[2] / 255);
 	}
 
 
@@ -1570,7 +1570,7 @@ class lessc {
 				$width = strlen($colorStr) == 3 ? 16 : 256;
 
 				for ($i = 3; $i > 0; $i--) { // 3 2 1
-					$t = $num % $width;
+					$t = (int) $num % $width;
 					$num /= $width;
 
 					$c[$i] = $t * (256/$width) + $t * floor(16/$width);

--- a/projects/packages/jetpack-mu-wpcom/src/features/custom-css/custom-css/preprocessors/lessc.inc.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/custom-css/custom-css/preprocessors/lessc.inc.php
@@ -663,7 +663,7 @@ class lessc {
 
 		// check for a rest
 		$last = end($args);
-		if ($last[0] == "rest") {
+		if (isset($last[0]) && $last[0] == "rest") {
 			$argsCount = is_countable( $args ) ? count( $args ) : 0;
 			$rest = array_slice($orderedValues, $argsCount - 1);
 			$this->set($last[1], $this->reduce(array("list", " ", $rest)));

--- a/projects/packages/jetpack-mu-wpcom/src/features/custom-css/custom-css/preprocessors/lessc.inc.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/custom-css/custom-css/preprocessors/lessc.inc.php
@@ -36,6 +36,7 @@
  * The `lessc_formatter` takes a CSS tree, and dumps it to a formatted string,
  * handling things like indentation.
  */
+#[\AllowDynamicProperties]
 class lessc {
 	static public $VERSION = "v0.5.0";
 
@@ -2273,6 +2274,7 @@ class lessc {
 
 // responsible for taking a string of LESS code and converting it into a
 // syntax tree
+#[\AllowDynamicProperties]
 class lessc_parser {
 	static protected $nextBlockId = 0; // used to uniquely identify blocks
 
@@ -3754,6 +3756,7 @@ class lessc_formatter_classic {
 	}
 }
 
+#[\AllowDynamicProperties]
 class lessc_formatter_compressed extends lessc_formatter_classic {
 	public $disableSingle = true;
 	public $open = "{";


### PR DESCRIPTION
Closes MONOREP-252

 <!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This addresses lots of warnings, deprecations, and fatals in the `lessphp` LESS library (https://github.com/leafo/lessphp). The library hasn't been updated in years, but it's been patched here and there to maintain compatibility.

In my edits I tried to respect the library's current style; it seems to not be linted anyway.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
```
PHP Deprecated: Creation of dynamic property lessc::$env is deprecated in /wordpress/plugins/wpcomsh/8.1.0-alpha+rolling.1763722686.g3d7e3e4/jetpack_vendor/automattic/jetpack-mu-wpcom/src/features/custom-css/custom-css/preprocessors/lessc.inc.php on line 1892
```

The above (and a dozen other variants) are resolved by adding the `#[\AllowDynamicProperties]` attribute to the relevant classes. Were it not a copy/pasted library the better solution is to add them as properties, but this way allows us to reduce lines-of-code changes for easier comparison to the original.

```
PHP Deprecated: preg_match(): Passing null to parameter #4 ($flags) of type int is deprecated in /wordpress/plugins/wpcomsh/8.1.0-alpha+rolling.1763722686.g3d7e3e4/jetpack_vendor/automattic/jetpack-mu-wpcom/src/features/custom-css/custom-css/preprocessors/lessc.inc.php on line 3503
PHP Deprecated: preg_match(): Passing null to parameter #4 ($flags) of type int is deprecated in /wordpress/plugins/wpcomsh/8.1.0-alpha+rolling.1763722686.g3d7e3e4/jetpack_vendor/automattic/jetpack-mu-wpcom/src/features/custom-css/custom-css/preprocessors/lessc.inc.php on line 3534
```

For the above, the flags param expects an `int`, and `null` ultimately is treated as `0`, so I updated them to use `0` explicitly.

```
PHP Warning: Trying to access array offset on false in /wordpress/plugins/wpcomsh/8.1.0-alpha+rolling.1763722686.g3d7e3e4/jetpack_vendor/automattic/jetpack-mu-wpcom/src/features/custom-css/custom-css/preprocessors/lessc.inc.php on line 665
```

For the above, we now make sure the key exists before trying to access its value.

```
PHP Fatal error: Uncaught TypeError: Unsupported operand types: string * float in /wordpress/plugins/wpcomsh/8.1.0-alpha+rolling.1763722686.g3d7e3e4/jetpack_vendor/automattic/jetpack-mu-wpcom/src/features/custom-css/custom-css/preprocessors/lessc.inc.php:1272
```

~For the above, we cast the values to float. A non-numeric string would become `0`, which then can be used in math operations.~

Correction (h/t @anomiex): For the above, the keys were off by one, with `$color[0]` being a string that was used to determine how to process the remaining keys.

```
PHP Deprecated: Implicit conversion from float 22909.63671875 to int loses precision in /wordpress/plugins/wpcomsh/8.1.0-alpha+rolling.1763722686.g3d7e3e4/jetpack_vendor/automattic/jetpack-mu-wpcom/src/features/custom-css/custom-css/preprocessors/lessc.inc.php on line 1572
```

For the above, we cast the value to int so we can do modulo math.


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

