### PR TITLE
CSSTidy: Prevent warnings when constants are already defined

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-prevent_warnings_with_csstidy
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-prevent_warnings_with_csstidy
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Prevent warnings when constants are already defined.

--- a/projects/packages/jetpack-mu-wpcom/src/features/custom-css/csstidy/data.inc.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/custom-css/csstidy/data.inc.php
@@ -23,14 +23,14 @@
  * @author Florian Schmitz (floele at gmail dot com) 2005, Nikolay Matsievsky (speed at webo dot name) 2010
  */
 
-define( 'AT_START', 1 );
-define( 'AT_END', 2 );
-define( 'SEL_START', 3 );
-define( 'SEL_END', 4 );
-define( 'PROPERTY', 5 );
-define( 'VALUE', 6 );
-define( 'COMMENT', 7 );
-define( 'DEFAULT_AT', 41 );
+defined( 'AT_START' ) || define( 'AT_START', 1 );
+defined( 'AT_END' ) || define( 'AT_END', 2 );
+defined( 'SEL_START' ) || define( 'SEL_START', 3 );
+defined( 'SEL_END' ) || define( 'SEL_END', 4 );
+defined( 'PROPERTY' ) || define( 'PROPERTY', 5 );
+defined( 'VALUE' ) || define( 'VALUE', 6 );
+defined( 'COMMENT' ) || define( 'COMMENT', 7 );
+defined( 'DEFAULT_AT' ) || define( 'DEFAULT_AT', 41 );
 
 /**
  * All whitespace allowed in CSS


### PR DESCRIPTION
Closes MONOREP-253

 <!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR resolves about 700K log entries/month of this nature:
```
PHP Warning: Constant AT_START already defined in /wordpress/plugins/wpcomsh/8.1.0-alpha+rolling.1763750826.gc87d55a/jetpack_vendor/automattic/jetpack-mu-wpcom/src/features/custom-css/csstidy/data.inc.php on line 26
```

The solution used here is to wrap the constants in `defined()` checks. This will remove the warning and the functionality will remain as it was before (the constant remains unchanged).

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
There have been new versions of CSSTidy, but they still (as of v2.2.1) define those constants (with a comment acknowledging this should be fixed):
https://github.com/Cerdic/CSSTidy/blob/v2.2.1/class.csstidy.php#L35-L47

The version we use is customized (filename changes, code modernization, etc.) so updating that here is out of scope.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

