### PR TITLE
Forms: Add form response webhooks

### DIFF
--- a/projects/packages/forms/changelog/add-form-response-webhooks
+++ b/projects/packages/forms/changelog/add-form-response-webhooks
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Forms: add form response webhook support.

--- a/projects/packages/forms/changelog/add-form-webhook-support
+++ b/projects/packages/forms/changelog/add-form-webhook-support
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Enable form webhooks feature based on current plan support

--- a/projects/packages/forms/changelog/add-form-webhooks-skipped-logging
+++ b/projects/packages/forms/changelog/add-form-webhooks-skipped-logging
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Form Webhooks: add logging and filter flag for initialization

--- a/projects/packages/forms/changelog/add-forms-webhooks-prettyfication
+++ b/projects/packages/forms/changelog/add-forms-webhooks-prettyfication
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Form Webhooks: clean up and consolidate webhooks to take over the unused-yet-present postToUrl

--- a/projects/packages/forms/src/blocks/contact-form/attributes.ts
+++ b/projects/packages/forms/src/blocks/contact-form/attributes.ts
@@ -85,4 +85,8 @@ export default {
 		type: 'array',
 		default: [],
 	},
+	webhooks: {
+		type: 'array',
+		default: [],
+	},
 };

--- a/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
+++ b/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
@@ -62,6 +62,7 @@ class Contact_Form_Block {
 	public static function register_feature( $features ) {
 		// Features that are only available to users with a paid plan.
 		$features['multistep-form'] = Current_Plan::supports( 'multistep-form' );
+		$features['form-webhooks']  = Current_Plan::supports( 'form-webhooks' );
 
 		return $features;
 	}

--- a/projects/packages/forms/src/blocks/contact-form/components/webhooks-settings.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/webhooks-settings.js
@@ -6,23 +6,22 @@ const WebhooksSettings = ( { setAttributes, webhooks } ) => {
 	// For now, we only support one webhook, but the data structure supports multiple
 	const firstWebhook = webhooks?.[ 0 ] || null;
 
+	const [ localWebhookId, setLocalWebhookId ] = useState( firstWebhook?.webhook_id || '' );
 	const [ localWebhookUrl, setLocalWebhookUrl ] = useState( firstWebhook?.url || '' );
 	const [ localWebhookEnabled, setLocalWebhookEnabled ] = useState(
 		firstWebhook?.enabled || false
 	);
 
-	// Generate a unique webhook ID if we don't have one
-	const webhookId = firstWebhook?.webhook_id || 'webhook-1';
-
 	// Sync local state with attributes when webhook changes
 	useEffect( () => {
 		if ( firstWebhook ) {
+			setLocalWebhookId( firstWebhook.webhook_id || '' );
 			setLocalWebhookUrl( firstWebhook.url || '' );
 			setLocalWebhookEnabled( firstWebhook.enabled || false );
 		}
 	}, [ firstWebhook ] );
 
-	const updateWebhook = ( url, enabled ) => {
+	const updateWebhook = ( id, url, enabled ) => {
 		if ( ! url && ! enabled ) {
 			// If URL is empty and webhook is disabled, remove it from the array
 			setAttributes( { webhooks: [] } );
@@ -30,7 +29,7 @@ const WebhooksSettings = ( { setAttributes, webhooks } ) => {
 		}
 
 		const webhook = {
-			webhook_id: webhookId,
+			webhook_id: id || '',
 			url: url || '',
 			format: 'json', // Default to json, no UI for changing this yet
 			method: 'post', // Default to post, no UI for changing this yet
@@ -58,24 +57,41 @@ const WebhooksSettings = ( { setAttributes, webhooks } ) => {
 				checked={ localWebhookEnabled }
 				onChange={ value => {
 					setLocalWebhookEnabled( value );
-					updateWebhook( localWebhookUrl, value );
+					updateWebhook( localWebhookId, localWebhookUrl, value );
 				} }
 				__nextHasNoMarginBottom={ true }
 			/>
 			{ localWebhookEnabled && (
-				<TextControl
-					label={ __( 'Webhook URL', 'jetpack-forms' ) }
-					value={ localWebhookUrl }
-					onChange={ value => {
-						setLocalWebhookUrl( value );
-						updateWebhook( value, localWebhookEnabled );
-					} }
-					placeholder="https://example.com/webhook"
-					help={ __( 'Enter the URL where form submission data should be sent.', 'jetpack-forms' ) }
-					type="url"
-					__nextHasNoMarginBottom={ true }
-					__next40pxDefaultSize={ true }
-				/>
+				<>
+					<TextControl
+						label={ __( 'Webhook ID', 'jetpack-forms' ) }
+						value={ localWebhookId }
+						onChange={ value => {
+							setLocalWebhookId( value );
+							updateWebhook( value, localWebhookUrl, localWebhookEnabled );
+						} }
+						placeholder="webhook-1"
+						help={ __( 'A unique identifier for this webhook.', 'jetpack-forms' ) }
+						__nextHasNoMarginBottom={ true }
+						__next40pxDefaultSize={ true }
+					/>
+					<TextControl
+						label={ __( 'Webhook URL', 'jetpack-forms' ) }
+						value={ localWebhookUrl }
+						onChange={ value => {
+							setLocalWebhookUrl( value );
+							updateWebhook( localWebhookId, value, localWebhookEnabled );
+						} }
+						placeholder="https://example.com/webhook"
+						help={ __(
+							'Enter the URL where form submission data should be sent.',
+							'jetpack-forms'
+						) }
+						type="url"
+						__nextHasNoMarginBottom={ true }
+						__next40pxDefaultSize={ true }
+					/>
+				</>
 			) }
 		</>
 	);

--- a/projects/packages/forms/src/blocks/contact-form/components/webhooks-settings.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/webhooks-settings.js
@@ -32,7 +32,7 @@ const WebhooksSettings = ( { setAttributes, webhooks } ) => {
 			webhook_id: id || '',
 			url: url || '',
 			format: 'json', // Default to json, no UI for changing this yet
-			method: 'post', // Default to post, no UI for changing this yet
+			method: 'POST', // Default to POST, no UI for changing this yet
 			enabled: enabled,
 		};
 

--- a/projects/packages/forms/src/blocks/contact-form/components/webhooks-settings.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/webhooks-settings.js
@@ -1,0 +1,84 @@
+import { TextControl, ToggleControl, ExternalLink } from '@wordpress/components';
+import { useState, useEffect, createInterpolateElement } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+
+const WebhooksSettings = ( { setAttributes, webhooks } ) => {
+	// For now, we only support one webhook, but the data structure supports multiple
+	const firstWebhook = webhooks?.[ 0 ] || null;
+
+	const [ localWebhookUrl, setLocalWebhookUrl ] = useState( firstWebhook?.url || '' );
+	const [ localWebhookEnabled, setLocalWebhookEnabled ] = useState(
+		firstWebhook?.enabled || false
+	);
+
+	// Generate a unique webhook ID if we don't have one
+	const webhookId = firstWebhook?.webhook_id || 'webhook-1';
+
+	// Sync local state with attributes when webhook changes
+	useEffect( () => {
+		if ( firstWebhook ) {
+			setLocalWebhookUrl( firstWebhook.url || '' );
+			setLocalWebhookEnabled( firstWebhook.enabled || false );
+		}
+	}, [ firstWebhook ] );
+
+	const updateWebhook = ( url, enabled ) => {
+		if ( ! url && ! enabled ) {
+			// If URL is empty and webhook is disabled, remove it from the array
+			setAttributes( { webhooks: [] } );
+			return;
+		}
+
+		const webhook = {
+			webhook_id: webhookId,
+			url: url || '',
+			format: 'json', // Default to json, no UI for changing this yet
+			method: 'post', // Default to post, no UI for changing this yet
+			enabled: enabled,
+		};
+
+		setAttributes( { webhooks: [ webhook ] } );
+	};
+
+	return (
+		<>
+			<ToggleControl
+				label={ __( 'Enable webhook', 'jetpack-forms' ) }
+				help={ createInterpolateElement(
+					__(
+						'Send form submission data to an external URL. <webhookDocsLink>Learn more about webhooks.</webhookDocsLink>',
+						'jetpack-forms'
+					),
+					{
+						webhookDocsLink: (
+							<ExternalLink href="https://jetpack.com/support/jetpack-forms/webhooks/" />
+						),
+					}
+				) }
+				checked={ localWebhookEnabled }
+				onChange={ value => {
+					setLocalWebhookEnabled( value );
+					updateWebhook( localWebhookUrl, value );
+				} }
+				__nextHasNoMarginBottom={ true }
+			/>
+			{ localWebhookEnabled && (
+				<TextControl
+					label={ __( 'Webhook URL', 'jetpack-forms' ) }
+					value={ localWebhookUrl }
+					onChange={ value => {
+						setLocalWebhookUrl( value );
+						updateWebhook( value, localWebhookEnabled );
+					} }
+					placeholder="https://example.com/webhook"
+					help={ __( 'Enter the URL where form submission data should be sent.', 'jetpack-forms' ) }
+					type="url"
+					__nextHasNoMarginBottom={ true }
+					__next40pxDefaultSize={ true }
+				/>
+			) }
+		</>
+	);
+};
+
+export default WebhooksSettings;

--- a/projects/packages/forms/src/blocks/contact-form/edit.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/edit.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { ThemeProvider } from '@automattic/jetpack-components';
-import { useModuleStatus } from '@automattic/jetpack-shared-extension-utils';
+import { useModuleStatus, hasFeatureFlag } from '@automattic/jetpack-shared-extension-utils';
 import {
 	URLInput,
 	InspectorAdvancedControls,
@@ -180,7 +180,7 @@ function JetpackContactFormEdit( {
 		webhooks,
 	} = attributes;
 	const showFormIntegrations = useConfigValue( 'isIntegrationsEnabled' );
-	const showWebhooks = useConfigValue( 'isWebhooksEnabled' );
+	const showWebhooks = useConfigValue( 'isWebhooksEnabled' ) && hasFeatureFlag( 'form-webhooks' );
 	const instanceId = useInstanceId( JetpackContactFormEdit );
 
 	// Backward compatibility for the deprecated customThankyou attribute.

--- a/projects/packages/forms/src/blocks/contact-form/edit.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/edit.tsx
@@ -50,6 +50,7 @@ import { childBlocks } from './child-blocks.js';
 import { ContactFormPlaceholder } from './components/jetpack-contact-form-placeholder.js';
 import ContactFormSkeletonLoader from './components/jetpack-contact-form-skeleton-loader.js';
 import NotificationsSettings from './components/notifications-settings.js';
+import WebhooksSettings from './components/webhooks-settings.js';
 import useFormBlockDefaults from './shared/hooks/use-form-block-defaults.js';
 import VariationPicker from './variation-picker.js';
 import './util/form-styles.js';
@@ -166,8 +167,10 @@ function JetpackContactFormEdit( {
 		disableGoBack,
 		disableSummary,
 		notificationRecipients,
+		webhooks,
 	} = attributes;
 	const showFormIntegrations = useConfigValue( 'isIntegrationsEnabled' );
+	const showWebhooks = useConfigValue( 'isWebhooksEnabled' );
 	const instanceId = useInstanceId( JetpackContactFormEdit );
 
 	// Backward compatibility for the deprecated customThankyou attribute.
@@ -912,6 +915,15 @@ function JetpackContactFormEdit( {
 						<Suspense fallback={ <div /> }>
 							<IntegrationControls attributes={ attributes } setAttributes={ setAttributes } />
 						</Suspense>
+					) }
+					{ showWebhooks && (
+						<PanelBody
+							title={ __( 'Webhooks', 'jetpack-forms' ) }
+							className="jetpack-contact-form__panel"
+							initialOpen={ false }
+						>
+							<WebhooksSettings webhooks={ webhooks } setAttributes={ setAttributes } />
+						</PanelBody>
 					) }
 					<PanelBody
 						title={ __( 'Responses storage', 'jetpack-forms' ) }

--- a/projects/packages/forms/src/blocks/contact-form/edit.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/edit.tsx
@@ -119,6 +119,14 @@ type CustomThankyouType =
 	| 'message' // custom message
 	| 'redirect'; // redirect to a new URL
 
+type Webhook = {
+	webhook_id: string;
+	url: string;
+	format: 'urlencoded' | 'json';
+	method: 'POST' | 'GET' | 'PUT';
+	enabled: boolean;
+};
+
 type JetpackContactFormAttributes = {
 	to: string;
 	subject: string;
@@ -134,7 +142,9 @@ type JetpackContactFormAttributes = {
 	disableGoBack: boolean;
 	disableSummary: boolean;
 	notificationRecipients: string[];
+	webhooks: Webhook[];
 };
+
 type JetpackContactFormEditProps = {
 	name: string;
 	attributes: JetpackContactFormAttributes;

--- a/projects/packages/forms/src/class-jetpack-forms.php
+++ b/projects/packages/forms/src/class-jetpack-forms.php
@@ -124,4 +124,18 @@ class Jetpack_Forms {
 		 */
 		return apply_filters( 'jetpack_forms_is_integrations_enabled', true );
 	}
+
+	/**
+	 * Returns true if webhooks are enabled.
+	 *
+	 * @return boolean
+	 */
+	public static function is_webhooks_enabled() {
+		/**
+		 * Whether to enable webhooks for Jetpack Forms.
+		 *
+		 * @param bool false Whether webhooks should be enabled. Default false.
+		 */
+		return apply_filters( 'jetpack_forms_webhooks_enabled', false );
+	}
 }

--- a/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
@@ -1494,6 +1494,7 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 			'siteURL'                 => ( new Status() )->get_site_suffix(),
 			'hasFeedback'             => ( new Forms_Dashboard() )->has_feedback(),
 			'isIntegrationsEnabled'   => Jetpack_Forms::is_integrations_enabled(),
+			'isWebhooksEnabled'       => Jetpack_Forms::is_webhooks_enabled(),
 			'dashboardURL'            => Forms_Dashboard::get_forms_admin_url(),
 			// New data.
 			'canInstallPlugins'       => current_user_can( 'install_plugins' ),

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -1593,7 +1593,7 @@ class Contact_Form_Plugin {
 				);
 			}
 
-			if ( ! empty( $form->attributes['webhooks'] ) ) {
+			if ( Jetpack_Forms::is_webhooks_enabled() && ! empty( $form->attributes['webhooks'] ) ) {
 				Form_Webhooks::init();
 			}
 			// Process the form

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -11,6 +11,7 @@ use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Constants;
 use Automattic\Jetpack\Extensions\Contact_Form\Contact_Form_Block;
 use Automattic\Jetpack\Forms\Jetpack_Forms;
+use Automattic\Jetpack\Forms\Service\Form_Webhooks;
 use Automattic\Jetpack\Forms\Service\Hostinger_Reach_Integration;
 use Automattic\Jetpack\Forms\Service\MailPoet_Integration;
 use Automattic\Jetpack\Forms\Service\Post_To_Url;
@@ -1581,6 +1582,10 @@ class Contact_Form_Plugin {
 			if ( ! empty( $form->attributes['salesforceData'] ) || ! empty( $form->attributes['postToUrl'] ) ) {
 				Post_To_Url::init();
 			}
+
+			if ( ! empty( $form->attributes['webhooks'] ) ) {
+				Form_Webhooks::init();
+			}
 			// Process the form
 			return $form->process_submission();
 		}
@@ -1753,6 +1758,10 @@ class Contact_Form_Plugin {
 
 		if ( ! empty( $form->attributes['salesforceData'] ) || ! empty( $form->attributes['postToUrl'] ) ) {
 			Post_To_Url::init();
+		}
+
+		if ( ! empty( $form->attributes['webhooks'] ) ) {
+			Form_Webhooks::init();
 		}
 
 		// Process the form

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -1579,8 +1579,18 @@ class Contact_Form_Plugin {
 				return $form->errors;
 			}
 
-			if ( ! empty( $form->attributes['salesforceData'] ) || ! empty( $form->attributes['postToUrl'] ) ) {
+			if ( ! empty( $form->attributes['salesforceData'] ) ) {
 				Post_To_Url::init();
+			}
+
+			// Deprecate postToUrl, migrate to webhooks in case someone put it to work.
+			if ( ! empty( $form->attributes['postToUrl'] ) ) {
+				// webhooks should be a collection.
+				// Turn postToUrl into a collection and merge with existing webhooks.
+				$form->attributes['webhooks'] = array_merge(
+					$form->attributes['webhooks'] ?? array(),
+					array( $form->attributes['postToUrl'] )
+				);
 			}
 
 			if ( ! empty( $form->attributes['webhooks'] ) ) {
@@ -1756,8 +1766,18 @@ class Contact_Form_Plugin {
 			return $validation_error;
 		}
 
-		if ( ! empty( $form->attributes['salesforceData'] ) || ! empty( $form->attributes['postToUrl'] ) ) {
+		if ( ! empty( $form->attributes['salesforceData'] ) ) {
 			Post_To_Url::init();
+		}
+
+		// Deprecate postToUrl, migrate to webhooks in case someone put it to work.
+		if ( ! empty( $form->attributes['postToUrl'] ) ) {
+			// webhooks should be a collection.
+			// Turn postToUrl into a collection and merge with existing webhooks.
+			$form->attributes['webhooks'] = array_merge(
+				$form->attributes['webhooks'] ?? array(),
+				array( $form->attributes['postToUrl'] )
+			);
 		}
 
 		if ( ! empty( $form->attributes['webhooks'] ) ) {

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -207,6 +207,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 			'saveResponses'          => 'yes',
 			'emailNotifications'     => 'yes',
 			'notificationRecipients' => array(), // Array of user IDs who should receive form response notifications.
+			'webhooks'               => array(), // Array of webhooks to send the form data to.
 			'disableGoBack'          => $attributes['disableGoBack'] ?? false,
 			'disableSummary'         => $attributes['disableSummary'] ?? false,
 			'formTitle'              => $attributes['formTitle'] ?? '',

--- a/projects/packages/forms/src/service/class-form-webhooks.php
+++ b/projects/packages/forms/src/service/class-form-webhooks.php
@@ -171,12 +171,12 @@ class Form_Webhooks {
 			}
 
 			// Validate format
-			if ( ! array_key_exists( $setup['format'], self::VALID_FORMATS_MAP ) ) {
+			if ( ! array_key_exists( strtolower( $setup['format'] ), self::VALID_FORMATS_MAP ) ) {
 				continue;
 			}
 
 			// Validate method
-			if ( ! in_array( $setup['method'], self::VALID_METHODS, true ) ) {
+			if ( ! in_array( strtoupper( $setup['method'] ), self::VALID_METHODS, true ) ) {
 				continue;
 			}
 

--- a/projects/packages/forms/src/service/class-form-webhooks.php
+++ b/projects/packages/forms/src/service/class-form-webhooks.php
@@ -166,17 +166,24 @@ class Form_Webhooks {
 			);
 
 			// Validate webhook configuration
-			if ( empty( $setup['enabled'] ) || empty( $setup['url'] ) ) {
+			if ( empty( $setup['enabled'] ) ) {
+				continue;
+			}
+			// Validate webhook configuration
+			if ( empty( $setup['url'] ) ) {
+				do_action( 'jetpack_forms_log', 'webhook_skipped', 'url_empty' );
 				continue;
 			}
 
 			// Validate format
 			if ( ! array_key_exists( strtolower( $setup['format'] ), self::VALID_FORMATS_MAP ) ) {
+				do_action( 'jetpack_forms_log', 'webhook_skipped', 'format_invalid', $setup );
 				continue;
 			}
 
 			// Validate method
 			if ( ! in_array( strtoupper( $setup['method'] ), self::VALID_METHODS, true ) ) {
+				do_action( 'jetpack_forms_log', 'webhook_skipped', 'method_invalid', $setup );
 				continue;
 			}
 
@@ -232,6 +239,7 @@ class Form_Webhooks {
 			),
 			'sslverify' => true,
 		);
+
 		return wp_remote_request( $url, $args );
 	}
 

--- a/projects/packages/forms/src/service/class-form-webhooks.php
+++ b/projects/packages/forms/src/service/class-form-webhooks.php
@@ -153,6 +153,20 @@ class Form_Webhooks {
 	private function send_webhook( $data, $webhook ) {
 		global $wp_version;
 
+		/**
+		 * Filters the form data before sending it to the webhook.
+		 *
+		 * Allows developers to modify or augment the form data before it's sent to the webhook endpoint.
+		 *
+		 * @since $$next-version$$
+		 *
+		 * @param string $webhook_id The unique identifier for this webhook.
+		 * @param array  $form_data  The form data to be sent (field IDs as keys, values as values).
+		 *
+		 * @return array The form data to be sent (field IDs as keys, values as values).
+		 */
+		$data = apply_filters( 'jetpack_forms_before_webhook_request', $webhook['webhook_id'], $data );
+
 		$user_agent = "WordPress/{$wp_version} | Jetpack/" . constant( 'JETPACK__VERSION' ) . '; ' . get_bloginfo( 'url' );
 		$url        = $webhook['url'];
 		$format     = $webhook['format'] === 'urlencoded' ? 'application/x-www-form-urlencoded' : 'application/json';

--- a/projects/packages/forms/src/service/class-form-webhooks.php
+++ b/projects/packages/forms/src/service/class-form-webhooks.php
@@ -55,7 +55,7 @@ class Form_Webhooks {
 	 *
 	 * @return null|void
 	 */
-	public function send_webhooks( $post_id, $fields, $is_spam, $entry_values ) {
+	public function send_webhooks( $post_id, $fields, $is_spam, $entry_values ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 		// Try and get the form from any of the fields
 		$form = null;
 		foreach ( $fields as $field ) {
@@ -83,22 +83,34 @@ class Form_Webhooks {
 
 		// Iterate through each webhook and send the request
 		foreach ( $webhooks as $webhook ) {
-			$result = $this->send_webhook( $form_data, $webhook );
-
-			if ( is_wp_error( $result ) ) {
-				// phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- figuring out what to do with the error.
-				$message = sprintf(
-					'JETPACK %s - Jetpack Forms: Webhook request to "%s" failed: "%s" at %s',
-					constant( 'JETPACK__VERSION' ),
-					$webhook['url'],
-					$result->get_error_message(),
-					$entry_values['entry_permalink']
-				);
-				// TODO: not sure what to do with the error. Is not useful at frontend and it would be difficult to
-				// solve for a non tech-savvy user. We should log it somewhere, but it could turn messy.
-				// Maybe email the owner?
-			}
+			$response = $this->send_webhook( $form_data, $webhook );
+			$this->log_response_to_post_meta( $post_id, $response );
 		}
+	}
+
+	/**
+	 * Log the response to post meta.
+	 *
+	 * @param int   $post_id The post ID.
+	 * @param array $response The response from the webhook.
+	 */
+	private function log_response_to_post_meta( $post_id, $response ) {
+		if ( is_wp_error( $response ) ) {
+			update_post_meta( $post_id, '_jetpack_forms_webhook_error', sanitize_text_field( $response->get_error_message() ) );
+			return $response;
+		}
+
+		$response_body = wp_remote_retrieve_body( $response );
+		$response_data = json_decode( $response_body, true );
+
+		$response_data = array(
+			'timestamp' => gmdate( 'Y-m-d H:i:s', time() ),
+			'http_code' => wp_remote_retrieve_response_code( $response ),
+			'headers'   => wp_remote_retrieve_headers( $response )->getAll(),
+			'body'      => $response_data ?? $response_body, // If the response is not JSON, return the body as is.
+		);
+
+		update_post_meta( $post_id, '_jetpack_forms_webhook_response', sanitize_text_field( wp_json_encode( $response_data ) ) );
 	}
 
 	/**
@@ -185,7 +197,6 @@ class Form_Webhooks {
 			'sslverify' => true,
 		);
 
-		// phpcs:ignore Universal.CodeAnalysis.ConstructorDestructorReturn.ReturnValueFound -- this is no constructor
 		return wp_remote_request( $url, $args );
 	}
 

--- a/projects/packages/forms/src/service/class-form-webhooks.php
+++ b/projects/packages/forms/src/service/class-form-webhooks.php
@@ -1,0 +1,198 @@
+<?php
+/**
+ * Form Webhooks for Jetpack Contact Forms.
+ *
+ * @package automattic/jetpack-forms
+ */
+
+namespace Automattic\Jetpack\Forms\Service;
+
+use WP_Error;
+
+/**
+ * Class Form_Webhooks
+ *
+ * Hooks on Jetpack's Contact form to send form data to configured webhooks.
+ */
+class Form_Webhooks {
+	/**
+	 * Singleton instance
+	 *
+	 * @var Form_Webhooks
+	 */
+	private static $instance = null;
+
+	/**
+	 * Initialize and return singleton instance.
+	 *
+	 * @return Form_Webhooks
+	 */
+	public static function init() {
+		if ( null === self::$instance ) {
+			self::$instance = new self();
+		}
+
+		return self::$instance;
+	}
+
+	/**
+	 * Form_Webhooks class constructor.
+	 * Hooks on `grunion_after_feedback_post_inserted` action to send form data to configured webhooks.
+	 * NOTE: As a singleton, this constructor is private and only callable from ::init, which will return the singleton instance,
+	 * effectively preventing multiple instances of this class (hence, multiple hooks triggering the webhook requests).
+	 */
+	private function __construct() {
+		add_action( 'grunion_after_feedback_post_inserted', array( $this, 'send_webhooks' ), 10, 4 );
+	}
+
+	/**
+	 * Send form data to configured webhooks.
+	 *
+	 * @param int   $post_id - the post_id for the CPT that is created.
+	 * @param array $fields - a collection of Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field instances.
+	 * @param bool  $is_spam - marked as spam by Akismet(?).
+	 * @param array $entry_values - extra fields added to from the contact form.
+	 *
+	 * @return null|void
+	 */
+	public function send_webhooks( $post_id, $fields, $is_spam, $entry_values ) {
+		// Try and get the form from any of the fields
+		$form = null;
+		foreach ( $fields as $field ) {
+			if ( ! empty( $field->form ) ) {
+				$form = $field->form;
+				break;
+			}
+		}
+		if ( ! $form || ! is_a( $form, 'Automattic\Jetpack\Forms\ContactForm\Contact_Form' ) ) {
+			return;
+		}
+
+		// if spam (hinted by akismet?), don't process
+		if ( $is_spam ) {
+			return;
+		}
+
+		$webhooks = $this->get_enabled_webhooks( $form->attributes );
+
+		if ( empty( $webhooks ) ) {
+			return;
+		}
+
+		$form_data = $this->get_form_data( $form );
+
+		// Iterate through each webhook and send the request
+		foreach ( $webhooks as $webhook ) {
+			$result = $this->send_webhook( $form_data, $webhook );
+
+			if ( is_wp_error( $result ) ) {
+				// phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- figuring out what to do with the error.
+				$message = sprintf(
+					'JETPACK %s - Jetpack Forms: Webhook request to "%s" failed: "%s" at %s',
+					constant( 'JETPACK__VERSION' ),
+					$webhook['url'],
+					$result->get_error_message(),
+					$entry_values['entry_permalink']
+				);
+				// TODO: not sure what to do with the error. Is not useful at frontend and it would be difficult to
+				// solve for a non tech-savvy user. We should log it somewhere, but it could turn messy.
+				// Maybe email the owner?
+			}
+		}
+	}
+
+	/**
+	 * Get the enabled webhooks from the form attributes.
+	 *
+	 * @param array $attributes - the attributes of the contact form.
+	 * @return array Array of enabled webhooks.
+	 */
+	private function get_enabled_webhooks( $attributes = array() ) {
+		if ( empty( $attributes['webhooks'] ) || ! is_array( $attributes['webhooks'] ) ) {
+			return array();
+		}
+
+		$enabled_webhooks = array();
+		foreach ( $attributes['webhooks'] as $webhook ) {
+			// Validate webhook configuration
+			if ( empty( $webhook['enabled'] ) || empty( $webhook['url'] ) ) {
+				continue;
+			}
+
+			// Validate format
+			$format = ! empty( $webhook['format'] ) ? $webhook['format'] : 'json';
+			if ( ! in_array( $format, array( 'urlencoded', 'json' ), true ) ) {
+				continue;
+			}
+
+			// Validate method
+			$method = ! empty( $webhook['method'] ) ? strtoupper( $webhook['method'] ) : 'POST';
+			if ( ! in_array( $method, array( 'POST', 'GET', 'PUT' ), true ) ) {
+				continue;
+			}
+
+			$enabled_webhooks[] = array(
+				'webhook_id' => ! empty( $webhook['webhook_id'] ) ? $webhook['webhook_id'] : '',
+				'url'        => $webhook['url'],
+				'format'     => $format,
+				'method'     => $method,
+			);
+		}
+
+		return $enabled_webhooks;
+	}
+
+	/**
+	 * Send webhook request
+	 *
+	 * @param array $data The data key/value pairs to send.
+	 * @param array $webhook Webhook configuration.
+	 *
+	 * @return array|WP_Error The result value from wp_remote_request
+	 */
+	private function send_webhook( $data, $webhook ) {
+		global $wp_version;
+
+		$user_agent = "WordPress/{$wp_version} | Jetpack/" . constant( 'JETPACK__VERSION' ) . '; ' . get_bloginfo( 'url' );
+		$url        = $webhook['url'];
+		$format     = $webhook['format'] === 'urlencoded' ? 'application/x-www-form-urlencoded' : 'application/json';
+		$method     = $webhook['method'];
+
+		// Encode body based on format
+		$body = $webhook['format'] === 'json' ? wp_json_encode( $data ) : $data;
+
+		$args = array(
+			'method'    => $method,
+			'body'      => $body,
+			'headers'   => array(
+				'Content-Type' => $format,
+				'user-agent'   => $user_agent,
+			),
+			'sslverify' => true,
+		);
+
+		// phpcs:ignore Universal.CodeAnalysis.ConstructorDestructorReturn.ReturnValueFound -- this is no constructor
+		return wp_remote_request( $url, $args );
+	}
+
+	/**
+	 * Gather fields key/value pairs from the form
+	 * Sanitizes the hidden fields values
+	 *
+	 * @param \Automattic\Jetpack\Forms\ContactForm\Contact_Form $form The form instance being processed/submitted.
+	 */
+	private function get_form_data( $form ) {
+		$fields = array();
+		foreach ( $form->fields as $field ) {
+			$fields[ $field->get_attribute( 'id' ) ] = $field->value;
+		}
+
+		if ( ! empty( $form->attributes['hiddenFields'] ) ) {
+			foreach ( $form->attributes['hiddenFields'] as $hidden_field ) {
+				$fields[ $hidden_field['name'] ] = sanitize_text_field( $hidden_field['value'] );
+			}
+		}
+
+		return $fields;
+	}
+}

--- a/projects/packages/forms/src/service/class-form-webhooks.php
+++ b/projects/packages/forms/src/service/class-form-webhooks.php
@@ -91,8 +91,8 @@ class Form_Webhooks {
 	/**
 	 * Log the response to post meta.
 	 *
-	 * @param int   $post_id The post ID.
-	 * @param array $response The response from the webhook.
+	 * @param int            $post_id The post ID.
+	 * @param array|WP_Error $response The response from the webhook or the WP_Error if the request failed.
 	 */
 	private function log_response_to_post_meta( $post_id, $response ) {
 		if ( is_wp_error( $response ) ) {

--- a/projects/packages/forms/src/service/class-form-webhooks.php
+++ b/projects/packages/forms/src/service/class-form-webhooks.php
@@ -22,6 +22,31 @@ class Form_Webhooks {
 	 */
 	private static $instance = null;
 
+	private const FORMAT_URL_ENCODED       = 'urlencoded';
+	private const FORMAT_JSON              = 'json';
+	private const METHOD_POST              = 'POST';
+	private const METHOD_GET               = 'GET';
+	private const METHOD_PUT               = 'PUT';
+	private const CONTENT_TYPE_URL_ENCODED = 'application/x-www-form-urlencoded';
+	private const CONTENT_TYPE_JSON        = 'application/json';
+
+	/**
+	 * Valid methods for webhook requests.
+	 *
+	 * @var array
+	 */
+	private const VALID_METHODS = array( self::METHOD_POST, self::METHOD_GET, self::METHOD_PUT );
+
+	/**
+	 * Valid formats for webhook requests.
+	 *
+	 * @var array
+	 */
+	private const VALID_FORMATS_MAP = array(
+		self::FORMAT_URL_ENCODED => self::CONTENT_TYPE_URL_ENCODED,
+		self::FORMAT_JSON        => self::CONTENT_TYPE_JSON,
+	);
+
 	/**
 	 * Initialize and return singleton instance.
 	 *
@@ -126,28 +151,40 @@ class Form_Webhooks {
 
 		$enabled_webhooks = array();
 		foreach ( $attributes['webhooks'] as $webhook ) {
+			$defaults = array(
+				'webhook_id' => '',
+				'url'        => '',
+				'method'     => self::METHOD_POST,
+				'verified'   => false,
+				'format'     => self::FORMAT_JSON,
+				'enabled'    => false,
+			);
+
+			$setup = wp_parse_args(
+				is_array( $webhook ) && ! empty( $webhook ) ? $webhook : array(),
+				$defaults
+			);
+
 			// Validate webhook configuration
-			if ( empty( $webhook['enabled'] ) || empty( $webhook['url'] ) ) {
+			if ( empty( $setup['enabled'] ) || empty( $setup['url'] ) ) {
 				continue;
 			}
 
 			// Validate format
-			$format = ! empty( $webhook['format'] ) ? $webhook['format'] : 'json';
-			if ( ! in_array( $format, array( 'urlencoded', 'json' ), true ) ) {
+			if ( ! array_key_exists( $setup['format'], self::VALID_FORMATS_MAP ) ) {
 				continue;
 			}
 
 			// Validate method
-			$method = ! empty( $webhook['method'] ) ? strtoupper( $webhook['method'] ) : 'POST';
-			if ( ! in_array( $method, array( 'POST', 'GET', 'PUT' ), true ) ) {
+			if ( ! in_array( $setup['method'], self::VALID_METHODS, true ) ) {
 				continue;
 			}
 
 			$enabled_webhooks[] = array(
-				'webhook_id' => ! empty( $webhook['webhook_id'] ) ? $webhook['webhook_id'] : '',
-				'url'        => $webhook['url'],
-				'format'     => $format,
-				'method'     => $method,
+				'webhook_id' => $setup['webhook_id'],
+				'url'        => $setup['url'],
+				'format'     => $setup['format'],
+				'method'     => $setup['method'],
 			);
 		}
 
@@ -169,24 +206,23 @@ class Form_Webhooks {
 		 * Filters the form data before sending it to the webhook.
 		 *
 		 * Allows developers to modify or augment the form data before it's sent to the webhook endpoint.
+		 * NOTE: data has to be the first argument so it can be defaulted.
 		 *
 		 * @since $$next-version$$
 		 *
-		 * @param string $webhook_id The unique identifier for this webhook.
 		 * @param array  $form_data  The form data to be sent (field IDs as keys, values as values).
+		 * @param string $webhook_id The unique identifier for this webhook.
 		 *
 		 * @return array The form data to be sent (field IDs as keys, values as values).
 		 */
-		$data = apply_filters( 'jetpack_forms_before_webhook_request', $webhook['webhook_id'], $data );
+		$data = apply_filters( 'jetpack_forms_before_webhook_request', $data, $webhook['webhook_id'] );
 
 		$user_agent = "WordPress/{$wp_version} | Jetpack/" . constant( 'JETPACK__VERSION' ) . '; ' . get_bloginfo( 'url' );
 		$url        = $webhook['url'];
-		$format     = $webhook['format'] === 'urlencoded' ? 'application/x-www-form-urlencoded' : 'application/json';
+		$format     = self::VALID_FORMATS_MAP[ $webhook['format'] ];
 		$method     = $webhook['method'];
-
 		// Encode body based on format
-		$body = $webhook['format'] === 'json' ? wp_json_encode( $data ) : $data;
-
+		$body = $webhook['format'] === self::FORMAT_JSON ? wp_json_encode( $data ) : $data;
 		$args = array(
 			'method'    => $method,
 			'body'      => $body,
@@ -196,7 +232,6 @@ class Form_Webhooks {
 			),
 			'sslverify' => true,
 		);
-
 		return wp_remote_request( $url, $args );
 	}
 

--- a/projects/packages/forms/src/types/index.ts
+++ b/projects/packages/forms/src/types/index.ts
@@ -234,6 +234,8 @@ export interface FormsConfigData {
 	isHostingerReachEnabled?: boolean;
 	/** Whether integrations UI is enabled (feature-flagged). */
 	isIntegrationsEnabled?: boolean;
+	/** Whether webhooks are enabled (feature-flagged). */
+	isWebhooksEnabled?: boolean;
 	/** Whether the current user can install plugins (install_plugins). */
 	canInstallPlugins?: boolean;
 	/** Whether the current user can activate plugins (activate_plugins). */

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
@@ -3824,4 +3824,33 @@ class Contact_Form_Test extends BaseTestCase {
 		$this->assertIsString( $result5, 'Parse should return a string with multiple fields' );
 		$this->assertStringNotContainsString( 'is-single-input-form', $result5, 'Should not have single-input-form class with multiple fields' );
 	}
+
+	/**
+	 * Test is_webhooks_enabled returns false by default.
+	 */
+	public function test_is_webhooks_enabled_default() {
+		$this->assertFalse( \Automattic\Jetpack\Forms\Jetpack_Forms::is_webhooks_enabled() );
+	}
+
+	/**
+	 * Test is_webhooks_enabled filter can be used to enable webhooks.
+	 */
+	public function test_is_webhooks_enabled_filter_enable() {
+		add_filter( 'jetpack_forms_webhooks_enabled', '__return_true' );
+
+		$this->assertTrue( \Automattic\Jetpack\Forms\Jetpack_Forms::is_webhooks_enabled() );
+
+		remove_filter( 'jetpack_forms_webhooks_enabled', '__return_true' );
+	}
+
+	/**
+	 * Test is_webhooks_enabled filter can be used to keep webhooks disabled.
+	 */
+	public function test_is_webhooks_enabled_filter_disable() {
+		add_filter( 'jetpack_forms_webhooks_enabled', '__return_false' );
+
+		$this->assertFalse( \Automattic\Jetpack\Forms\Jetpack_Forms::is_webhooks_enabled() );
+
+		remove_filter( 'jetpack_forms_webhooks_enabled', '__return_false' );
+	}
 }

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
@@ -2652,6 +2652,7 @@ class Contact_Form_Test extends BaseTestCase {
 		$expected_attributes['saveResponses']          = 'yes';
 		$expected_attributes['disableGoBack']          = '';
 		$expected_attributes['notificationRecipients'] = array();
+		$expected_attributes['webhooks']               = array();
 		$expected_attributes['disableSummary']         = '';
 		$expected_attributes['confirmationType']       = '';
 		$expected_attributes['hostingerReach']         = '';

--- a/projects/packages/forms/tests/php/service/Form_Webhooks_Test.php
+++ b/projects/packages/forms/tests/php/service/Form_Webhooks_Test.php
@@ -570,6 +570,187 @@ class Form_Webhooks_Test extends BaseTestCase {
 	}
 
 	/**
+	 * Test logging action is triggered when webhook URL is empty.
+	 */
+	public function test_send_webhooks_logs_empty_url() {
+		$form   = $this->create_mock_form(
+			array(
+				'webhooks' => array(
+					array(
+						'webhook_id' => 'test-webhook',
+						'url'        => '',
+						'format'     => 'json',
+						'method'     => 'POST',
+						'enabled'    => true,
+					),
+				),
+			)
+		);
+		$fields = array( $this->create_mock_field( $form, 'test-field', 'test value' ) );
+
+		$logged_events = array();
+		add_action(
+			'jetpack_forms_log',
+			function ( $event, $reason, $data = null ) use ( &$logged_events ) {
+				$logged_events[] = array(
+					'event'  => $event,
+					'reason' => $reason,
+					'data'   => $data,
+				);
+			},
+			10,
+			3
+		);
+
+		$webhooks = Form_Webhooks::init();
+		$webhooks->send_webhooks( 123, $fields, false, array() );
+
+		$this->assertCount( 1, $logged_events );
+		// @phan-suppress-next-line PhanTypeArraySuspiciousNull, PhanTypeInvalidDimOffset
+		$this->assertEquals( 'webhook_skipped', $logged_events[0]['event'] );
+		// @phan-suppress-next-line PhanTypeArraySuspiciousNull, PhanTypeInvalidDimOffset
+		$this->assertEquals( 'url_empty', $logged_events[0]['reason'] );
+	}
+
+	/**
+	 * Test logging action is triggered when webhook format is invalid.
+	 */
+	public function test_send_webhooks_logs_invalid_format() {
+		$form   = $this->create_mock_form(
+			array(
+				'webhooks' => array(
+					array(
+						'webhook_id' => 'test-webhook',
+						'url'        => 'https://example.com/webhook',
+						'format'     => 'xml',
+						'method'     => 'POST',
+						'enabled'    => true,
+					),
+				),
+			)
+		);
+		$fields = array( $this->create_mock_field( $form, 'test-field', 'test value' ) );
+
+		$logged_events = array();
+		add_action(
+			'jetpack_forms_log',
+			function ( $event, $reason, $data = null ) use ( &$logged_events ) {
+				$logged_events[] = array(
+					'event'  => $event,
+					'reason' => $reason,
+					'data'   => $data,
+				);
+			},
+			10,
+			3
+		);
+
+		$webhooks = Form_Webhooks::init();
+		$webhooks->send_webhooks( 123, $fields, false, array() );
+
+		$this->assertCount( 1, $logged_events );
+		// @phan-suppress-next-line PhanTypeArraySuspiciousNull, PhanTypeInvalidDimOffset
+		$this->assertEquals( 'webhook_skipped', $logged_events[0]['event'] );
+		// @phan-suppress-next-line PhanTypeArraySuspiciousNull, PhanTypeInvalidDimOffset
+		$this->assertEquals( 'format_invalid', $logged_events[0]['reason'] );
+		// @phan-suppress-next-line PhanTypeArraySuspiciousNull, PhanTypeInvalidDimOffset
+		$this->assertIsArray( $logged_events[0]['data'] );
+		// @phan-suppress-next-line PhanTypeArraySuspiciousNull, PhanTypeInvalidDimOffset
+		$this->assertEquals( 'xml', $logged_events[0]['data']['format'] );
+	}
+
+	/**
+	 * Test logging action is triggered when webhook method is invalid.
+	 */
+	public function test_send_webhooks_logs_invalid_method() {
+		$form   = $this->create_mock_form(
+			array(
+				'webhooks' => array(
+					array(
+						'webhook_id' => 'test-webhook',
+						'url'        => 'https://example.com/webhook',
+						'format'     => 'json',
+						'method'     => 'DELETE',
+						'enabled'    => true,
+					),
+				),
+			)
+		);
+		$fields = array( $this->create_mock_field( $form, 'test-field', 'test value' ) );
+
+		$logged_events = array();
+		add_action(
+			'jetpack_forms_log',
+			function ( $event, $reason, $data = null ) use ( &$logged_events ) {
+				$logged_events[] = array(
+					'event'  => $event,
+					'reason' => $reason,
+					'data'   => $data,
+				);
+			},
+			10,
+			3
+		);
+
+		$webhooks = Form_Webhooks::init();
+		$webhooks->send_webhooks( 123, $fields, false, array() );
+
+		$this->assertCount( 1, $logged_events );
+		// @phan-suppress-next-line PhanTypeArraySuspiciousNull, PhanTypeInvalidDimOffset
+		$this->assertEquals( 'webhook_skipped', $logged_events[0]['event'] );
+		// @phan-suppress-next-line PhanTypeArraySuspiciousNull, PhanTypeInvalidDimOffset
+		$this->assertEquals( 'method_invalid', $logged_events[0]['reason'] );
+		// @phan-suppress-next-line PhanTypeArraySuspiciousNull, PhanTypeInvalidDimOffset
+		$this->assertIsArray( $logged_events[0]['data'] );
+		// @phan-suppress-next-line PhanTypeArraySuspiciousNull, PhanTypeInvalidDimOffset
+		$this->assertEquals( 'DELETE', $logged_events[0]['data']['method'] );
+	}
+
+	/**
+	 * Test webhook method validation is case-insensitive.
+	 */
+	public function test_send_webhooks_accepts_lowercase_method() {
+		$form   = $this->create_mock_form(
+			array(
+				'webhooks' => array(
+					array(
+						'webhook_id' => 'test-webhook',
+						'url'        => 'https://example.com/webhook',
+						'format'     => 'json',
+						'method'     => 'post', // lowercase should be accepted
+						'enabled'    => true,
+					),
+				),
+			)
+		);
+		$fields = array( $this->create_mock_field( $form, 'test-field', 'test value' ) );
+
+		$captured_request = null;
+		add_filter(
+			'pre_http_request',
+			function ( $preempt, $args, $url ) use ( &$captured_request ) {
+				$captured_request = array(
+					'url'  => $url,
+					'args' => $args,
+				);
+				return array(
+					'response' => array( 'code' => 200 ),
+					'body'     => '{"success":true}',
+					'headers'  => new CaseInsensitiveDictionary( array( 'Content-Type' => 'application/json' ) ),
+				);
+			},
+			10,
+			3
+		);
+
+		$webhooks = Form_Webhooks::init();
+		$webhooks->send_webhooks( 123, $fields, false, array() );
+
+		$this->assertNotNull( $captured_request, 'HTTP request should be made even with lowercase method' );
+		$this->assertEquals( 'post', $captured_request['args']['method'] );
+	}
+
+	/**
 	 * Helper method to create a mock form.
 	 *
 	 * @param array $attributes Form attributes.

--- a/projects/packages/forms/tests/php/service/Form_Webhooks_Test.php
+++ b/projects/packages/forms/tests/php/service/Form_Webhooks_Test.php
@@ -1,0 +1,619 @@
+<?php
+/**
+ * Unit Tests for Form_Webhooks.
+ *
+ * @package automattic/jetpack-forms
+ */
+
+namespace Automattic\Jetpack\Forms\Service;
+
+use Automattic\Jetpack\Forms\ContactForm\Contact_Form;
+use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field;
+use PHPUnit\Framework\Attributes\CoversClass;
+use WorDBless\BaseTestCase;
+use WpOrg\Requests\Utility\CaseInsensitiveDictionary;
+
+/**
+ * Test class for Form_Webhooks
+ *
+ * @covers Automattic\Jetpack\Forms\Service\Form_Webhooks
+ */
+#[CoversClass( Form_Webhooks::class )]
+class Form_Webhooks_Test extends BaseTestCase {
+
+	/**
+	 * Test webhook is not sent when no webhooks are configured.
+	 */
+	public function test_send_webhooks_does_nothing_when_no_webhooks_configured() {
+		$form   = $this->create_mock_form( array() );
+		$fields = array( $this->create_mock_field( $form, 'test-field', 'test value' ) );
+
+		// Mock wp_remote_request should not be called
+		$this->assertFalse( has_filter( 'pre_http_request' ) );
+
+		$webhooks = Form_Webhooks::init();
+		$webhooks->send_webhooks( 123, $fields, false, array() );
+	}
+
+	/**
+	 * Test webhook is not sent when webhook is disabled.
+	 */
+	public function test_send_webhooks_skips_disabled_webhooks() {
+		$form   = $this->create_mock_form(
+			array(
+				'webhooks' => array(
+					array(
+						'webhook_id' => 'test-webhook',
+						'url'        => 'https://example.com/webhook',
+						'format'     => 'json',
+						'method'     => 'POST',
+						'enabled'    => false,
+					),
+				),
+			)
+		);
+		$fields = array( $this->create_mock_field( $form, 'test-field', 'test value' ) );
+
+		// Track if HTTP request was made
+		$http_request_made = false;
+		add_filter(
+			'pre_http_request',
+			function () use ( &$http_request_made ) {
+				$http_request_made = true;
+				return array(
+					'response' => array( 'code' => 200 ),
+					'body'     => '{"success":true}',
+				);
+			}
+		);
+
+		$webhooks = Form_Webhooks::init();
+		$webhooks->send_webhooks( 123, $fields, false, array() );
+
+		$this->assertFalse( $http_request_made, 'HTTP request should not be made for disabled webhook' );
+	}
+
+	/**
+	 * Test webhook is not sent when URL is missing.
+	 */
+	public function test_send_webhooks_skips_webhooks_without_url() {
+		$form   = $this->create_mock_form(
+			array(
+				'webhooks' => array(
+					array(
+						'webhook_id' => 'test-webhook',
+						'url'        => '',
+						'format'     => 'json',
+						'method'     => 'POST',
+						'enabled'    => true,
+					),
+				),
+			)
+		);
+		$fields = array( $this->create_mock_field( $form, 'test-field', 'test value' ) );
+
+		// Track if HTTP request was made
+		$http_request_made = false;
+		add_filter(
+			'pre_http_request',
+			function () use ( &$http_request_made ) {
+				$http_request_made = true;
+				return array(
+					'response' => array( 'code' => 200 ),
+					'body'     => '{"success":true}',
+				);
+			}
+		);
+
+		$webhooks = Form_Webhooks::init();
+		$webhooks->send_webhooks( 123, $fields, false, array() );
+
+		$this->assertFalse( $http_request_made, 'HTTP request should not be made for webhook without URL' );
+	}
+
+	/**
+	 * Test webhook is not sent for spam submissions.
+	 */
+	public function test_send_webhooks_skips_spam_submissions() {
+		$form   = $this->create_mock_form(
+			array(
+				'webhooks' => array(
+					array(
+						'webhook_id' => 'test-webhook',
+						'url'        => 'https://example.com/webhook',
+						'format'     => 'json',
+						'method'     => 'POST',
+						'enabled'    => true,
+					),
+				),
+			)
+		);
+		$fields = array( $this->create_mock_field( $form, 'test-field', 'test value' ) );
+
+		// Track if HTTP request was made
+		$http_request_made = false;
+		add_filter(
+			'pre_http_request',
+			function () use ( &$http_request_made ) {
+				$http_request_made = true;
+				return array(
+					'response' => array( 'code' => 200 ),
+					'body'     => '{"success":true}',
+				);
+			}
+		);
+
+		$webhooks = Form_Webhooks::init();
+		$webhooks->send_webhooks( 123, $fields, true, array() ); // is_spam = true
+
+		$this->assertFalse( $http_request_made, 'HTTP request should not be made for spam submissions' );
+	}
+
+	/**
+	 * Test webhook sends JSON formatted data.
+	 */
+	public function test_send_webhooks_sends_json_data() {
+		$form         = $this->create_mock_form(
+			array(
+				'webhooks' => array(
+					array(
+						'webhook_id' => 'test-webhook',
+						'url'        => 'https://example.com/webhook',
+						'format'     => 'json',
+						'method'     => 'POST',
+						'enabled'    => true,
+					),
+				),
+			)
+		);
+		$field1       = $this->create_mock_field( $form, 'name', 'John Doe' );
+		$field2       = $this->create_mock_field( $form, 'email', 'john@example.com' );
+		$form->fields = array( $field1, $field2 );
+		$fields       = array( $field1, $field2 );
+
+		$captured_request = null;
+		add_filter(
+			'pre_http_request',
+			function ( $preempt, $args, $url ) use ( &$captured_request ) {
+				$captured_request = array(
+					'url'  => $url,
+					'args' => $args,
+				);
+				return array(
+					'response' => array( 'code' => 200 ),
+					'body'     => '{"success":true}',
+					'headers'  => new CaseInsensitiveDictionary( array( 'Content-Type' => 'application/json' ) ),
+				);
+			},
+			10,
+			3
+		);
+
+		$webhooks = Form_Webhooks::init();
+		$webhooks->send_webhooks( 123, $fields, false, array() );
+
+		$this->assertNotNull( $captured_request, 'HTTP request should be made' );
+		$this->assertEquals( 'https://example.com/webhook', $captured_request['url'] );
+		$this->assertEquals( 'POST', $captured_request['args']['method'] );
+		$this->assertEquals( 'application/json', $captured_request['args']['headers']['Content-Type'] );
+
+		$body_data = json_decode( $captured_request['args']['body'], true );
+		// @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+		$this->assertEquals( 'John Doe', $body_data['name'] );
+		// @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+		$this->assertEquals( 'john@example.com', $body_data['email'] );
+	}
+
+	/**
+	 * Test webhook sends URL-encoded data.
+	 */
+	public function test_send_webhooks_sends_urlencoded_data() {
+		$form         = $this->create_mock_form(
+			array(
+				'webhooks' => array(
+					array(
+						'webhook_id' => 'test-webhook',
+						'url'        => 'https://example.com/webhook',
+						'format'     => 'urlencoded',
+						'method'     => 'POST',
+						'enabled'    => true,
+					),
+				),
+			)
+		);
+		$field1       = $this->create_mock_field( $form, 'name', 'John Doe' );
+		$field2       = $this->create_mock_field( $form, 'email', 'john@example.com' );
+		$form->fields = array( $field1, $field2 );
+		$fields       = array( $field1, $field2 );
+
+		$captured_request = null;
+		add_filter(
+			'pre_http_request',
+			function ( $preempt, $args, $url ) use ( &$captured_request ) {
+				$captured_request = array(
+					'url'  => $url,
+					'args' => $args,
+				);
+				return array(
+					'response' => array( 'code' => 200 ),
+					'body'     => '{"success":true}',
+					'headers'  => new CaseInsensitiveDictionary( array( 'Content-Type' => 'application/x-www-form-urlencoded' ) ),
+				);
+			},
+			10,
+			3
+		);
+
+		$webhooks = Form_Webhooks::init();
+		$webhooks->send_webhooks( 123, $fields, false, array() );
+
+		$this->assertNotNull( $captured_request, 'HTTP request should be made' );
+		$this->assertEquals( 'application/x-www-form-urlencoded', $captured_request['args']['headers']['Content-Type'] );
+		$this->assertIsArray( $captured_request['args']['body'] );
+		$this->assertEquals( 'John Doe', $captured_request['args']['body']['name'] );
+		$this->assertEquals( 'john@example.com', $captured_request['args']['body']['email'] );
+	}
+
+	/**
+	 * Test webhook skips invalid format.
+	 */
+	public function test_send_webhooks_skips_invalid_format() {
+		$form   = $this->create_mock_form(
+			array(
+				'webhooks' => array(
+					array(
+						'webhook_id' => 'test-webhook',
+						'url'        => 'https://example.com/webhook',
+						'format'     => 'xml', // Invalid format
+						'method'     => 'POST',
+						'enabled'    => true,
+					),
+				),
+			)
+		);
+		$fields = array( $this->create_mock_field( $form, 'test-field', 'test value' ) );
+
+		$http_request_made = false;
+		add_filter(
+			'pre_http_request',
+			function () use ( &$http_request_made ) {
+				$http_request_made = true;
+				return array(
+					'response' => array( 'code' => 200 ),
+					'body'     => '{"success":true}',
+				);
+			}
+		);
+
+		$webhooks = Form_Webhooks::init();
+		$webhooks->send_webhooks( 123, $fields, false, array() );
+
+		$this->assertFalse( $http_request_made, 'HTTP request should not be made for invalid format' );
+	}
+
+	/**
+	 * Test webhook skips invalid method.
+	 */
+	public function test_send_webhooks_skips_invalid_method() {
+		$form   = $this->create_mock_form(
+			array(
+				'webhooks' => array(
+					array(
+						'webhook_id' => 'test-webhook',
+						'url'        => 'https://example.com/webhook',
+						'format'     => 'json',
+						'method'     => 'DELETE', // Invalid method
+						'enabled'    => true,
+					),
+				),
+			)
+		);
+		$fields = array( $this->create_mock_field( $form, 'test-field', 'test value' ) );
+
+		$http_request_made = false;
+		add_filter(
+			'pre_http_request',
+			function () use ( &$http_request_made ) {
+				$http_request_made = true;
+				return array(
+					'response' => array( 'code' => 200 ),
+					'body'     => '{"success":true}',
+				);
+			}
+		);
+
+		$webhooks = Form_Webhooks::init();
+		$webhooks->send_webhooks( 123, $fields, false, array() );
+
+		$this->assertFalse( $http_request_made, 'HTTP request should not be made for invalid method' );
+	}
+
+	/**
+	 * Test webhook uses GET method when specified.
+	 */
+	public function test_send_webhooks_uses_get_method() {
+		$form   = $this->create_mock_form(
+			array(
+				'webhooks' => array(
+					array(
+						'webhook_id' => 'test-webhook',
+						'url'        => 'https://example.com/webhook',
+						'format'     => 'json',
+						'method'     => 'GET',
+						'enabled'    => true,
+					),
+				),
+			)
+		);
+		$fields = array( $this->create_mock_field( $form, 'test-field', 'test value' ) );
+
+		$captured_request = null;
+		add_filter(
+			'pre_http_request',
+			function ( $preempt, $args, $url ) use ( &$captured_request ) {
+				$captured_request = array(
+					'url'  => $url,
+					'args' => $args,
+				);
+				return array(
+					'response' => array( 'code' => 200 ),
+					'body'     => '{"success":true}',
+					'headers'  => new CaseInsensitiveDictionary( array( 'Content-Type' => 'application/json' ) ),
+				);
+			},
+			10,
+			3
+		);
+
+		$webhooks = Form_Webhooks::init();
+		$webhooks->send_webhooks( 123, $fields, false, array() );
+
+		$this->assertNotNull( $captured_request );
+		$this->assertEquals( 'GET', $captured_request['args']['method'] );
+	}
+
+	/**
+	 * Test jetpack_forms_before_webhook_request filter is applied.
+	 */
+	public function test_send_webhooks_applies_filter() {
+		$form   = $this->create_mock_form(
+			array(
+				'webhooks' => array(
+					array(
+						'webhook_id' => 'test-webhook',
+						'url'        => 'https://example.com/webhook',
+						'format'     => 'json',
+						'method'     => 'POST',
+						'enabled'    => true,
+					),
+				),
+			)
+		);
+		$fields = array( $this->create_mock_field( $form, 'email', 'john@example.com' ) );
+
+		// Add filter to modify data
+		add_filter(
+			'jetpack_forms_before_webhook_request',
+			function ( $data, $webhook_id ) {
+				$this->assertEquals( 'test-webhook', $webhook_id );
+				$data['custom_field'] = 'custom_value';
+				return $data;
+			},
+			10,
+			2
+		);
+
+		$captured_request = null;
+		add_filter(
+			'pre_http_request',
+			function ( $preempt, $args, $url ) use ( &$captured_request ) {
+				$captured_request = array(
+					'url'  => $url,
+					'args' => $args,
+				);
+				return array(
+					'response' => array( 'code' => 200 ),
+					'body'     => '{"success":true}',
+					'headers'  => new CaseInsensitiveDictionary( array( 'Content-Type' => 'application/json' ) ),
+				);
+			},
+			10,
+			3
+		);
+
+		$webhooks = Form_Webhooks::init();
+		$webhooks->send_webhooks( 123, $fields, false, array() );
+
+		// @phan-suppress-next-line PhanTypeArraySuspiciousNull, PhanTypeMismatchArgumentInternal
+		$body_data = json_decode( $captured_request['args']['body'], true );
+		// @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+		$this->assertEquals( 'custom_value', $body_data['custom_field'] );
+	}
+
+	/**
+	 * Test webhook logs successful response to post meta.
+	 */
+	public function test_send_webhooks_logs_successful_response() {
+		$post_id = 123;
+		$form    = $this->create_mock_form(
+			array(
+				'webhooks' => array(
+					array(
+						'webhook_id' => 'test-webhook',
+						'url'        => 'https://example.com/webhook',
+						'format'     => 'json',
+						'method'     => 'POST',
+						'enabled'    => true,
+					),
+				),
+			)
+		);
+		$fields  = array( $this->create_mock_field( $form, 'test-field', 'test value' ) );
+
+		add_filter(
+			'pre_http_request',
+			function () {
+				return array(
+					'response' => array( 'code' => 200 ),
+					'body'     => '{"success":true}',
+					'headers'  => new CaseInsensitiveDictionary( array( 'Content-Type' => 'application/json' ) ),
+				);
+			}
+		);
+
+		$webhooks = Form_Webhooks::init();
+		$webhooks->send_webhooks( $post_id, $fields, false, array() );
+
+		$response_meta = get_post_meta( $post_id, '_jetpack_forms_webhook_response', true );
+		$this->assertNotEmpty( $response_meta );
+
+		$response_data = json_decode( $response_meta, true );
+		// @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+		$this->assertEquals( 200, $response_data['http_code'] );
+		$this->assertArrayHasKey( 'timestamp', $response_data );
+	}
+
+	/**
+	 * Test webhook logs error to post meta.
+	 */
+	public function test_send_webhooks_logs_error() {
+		$post_id = 456;
+		$form    = $this->create_mock_form(
+			array(
+				'webhooks' => array(
+					array(
+						'webhook_id' => 'test-webhook',
+						'url'        => 'https://example.com/webhook',
+						'format'     => 'json',
+						'method'     => 'POST',
+						'enabled'    => true,
+					),
+				),
+			)
+		);
+		$fields  = array( $this->create_mock_field( $form, 'test-field', 'test value' ) );
+
+		add_filter(
+			'pre_http_request',
+			function () {
+				return new \WP_Error( 'http_request_failed', 'Connection timeout' );
+			}
+		);
+
+		$webhooks = Form_Webhooks::init();
+		$webhooks->send_webhooks( $post_id, $fields, false, array() );
+
+		$error_meta = get_post_meta( $post_id, '_jetpack_forms_webhook_error', true );
+		$this->assertEquals( 'Connection timeout', $error_meta );
+	}
+
+	/**
+	 * Test webhook includes hidden fields in data.
+	 */
+	public function test_send_webhooks_includes_hidden_fields() {
+		$form         = $this->create_mock_form(
+			array(
+				'webhooks'     => array(
+					array(
+						'webhook_id' => 'test-webhook',
+						'url'        => 'https://example.com/webhook',
+						'format'     => 'json',
+						'method'     => 'POST',
+						'enabled'    => true,
+					),
+				),
+				'hiddenFields' => array(
+					array(
+						'name'  => 'utm_source',
+						'value' => 'google',
+					),
+					array(
+						'name'  => 'utm_campaign',
+						'value' => 'summer_2025',
+					),
+				),
+			)
+		);
+		$field1       = $this->create_mock_field( $form, 'email', 'john@example.com' );
+		$form->fields = array( $field1 );
+		$fields       = array( $field1 );
+
+		$captured_request = null;
+		add_filter(
+			'pre_http_request',
+			function ( $preempt, $args, $url ) use ( &$captured_request ) {
+				$captured_request = array(
+					'url'  => $url,
+					'args' => $args,
+				);
+				return array(
+					'response' => array( 'code' => 200 ),
+					'body'     => '{"success":true}',
+					'headers'  => new CaseInsensitiveDictionary( array( 'Content-Type' => 'application/json' ) ),
+				);
+			},
+			10,
+			3
+		);
+
+		$webhooks = Form_Webhooks::init();
+		$webhooks->send_webhooks( 123, $fields, false, array() );
+
+		// @phan-suppress-next-line PhanTypeArraySuspiciousNull, PhanTypeMismatchArgumentInternal
+		$body_data = json_decode( $captured_request['args']['body'], true );
+		// @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+		$this->assertEquals( 'john@example.com', $body_data['email'] );
+		// @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+		$this->assertEquals( 'google', $body_data['utm_source'] );
+		// @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+		$this->assertEquals( 'summer_2025', $body_data['utm_campaign'] );
+	}
+
+	/**
+	 * Helper method to create a mock form.
+	 *
+	 * @param array $attributes Form attributes.
+	 * @return Contact_Form Mock form instance.
+	 */
+	private function create_mock_form( $attributes ) {
+		$form = $this->getMockBuilder( Contact_Form::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$form->attributes = $attributes;
+		$form->fields     = array();
+
+		return $form;
+	}
+
+	/**
+	 * Helper method to create a mock field.
+	 *
+	 * @param Contact_Form $form Parent form.
+	 * @param string       $id Field ID.
+	 * @param mixed        $value Field value.
+	 * @return Contact_Form_Field Mock field instance.
+	 */
+	private function create_mock_field( $form, $id, $value ) {
+		$field = $this->getMockBuilder( Contact_Form_Field::class )
+			->disableOriginalConstructor()
+			->onlyMethods( array( 'get_attribute' ) )
+			->getMock();
+
+		$field->form  = $form;
+		$field->value = $value;
+
+		$field->expects( $this->any() )
+			->method( 'get_attribute' )
+			->willReturnCallback(
+				function ( $attr ) use ( $id ) {
+					if ( $attr === 'id' ) {
+						return $id;
+					}
+					return null;
+				}
+			);
+
+		return $field;
+	}
+}

--- a/projects/packages/plans/changelog/add-form-webhook-support
+++ b/projects/packages/plans/changelog/add-form-webhook-support
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Add form-webhooks support on free Jetpack plans

--- a/projects/packages/plans/src/class-current-plan.php
+++ b/projects/packages/plans/src/class-current-plan.php
@@ -64,6 +64,7 @@ class Current_Plan {
 				'core/cover',
 				'core/audio',
 				'multistep-form',
+				'form-webhooks',
 			),
 		),
 		'personal' => array(

--- a/projects/plugins/jetpack/changelog/add-form-response-webhooks
+++ b/projects/plugins/jetpack/changelog/add-form-response-webhooks
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Forms: add form response webhook support.

--- a/projects/plugins/wpcomsh/changelog/add-form-webhook-support
+++ b/projects/plugins/wpcomsh/changelog/add-form-webhook-support
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Add form-webhooks feature support for WordPress.com plans

--- a/projects/plugins/wpcomsh/wpcom-features/class-wpcom-features.php
+++ b/projects/plugins/wpcomsh/wpcom-features/class-wpcom-features.php
@@ -417,6 +417,7 @@ class WPCOM_Features {
 	public const EMAIL_SUBSCRIPTION                = 'email-subscription';
 	public const EMAIL_FORWARDS_EXTENDED_LIMIT     = 'email-forwards-extended-limit';
 	public const FIELD_FILE                        = 'field-file';
+	public const FORM_WEBHOOKS                     = 'form-webhooks';
 	public const FREE_BLOG                         = 'free-blog';
 	public const FULL_ACTIVITY_LOG                 = 'full-activity-log';
 	public const GITHUB_DEPLOYMENTS                = 'github-deployments';
@@ -782,6 +783,10 @@ class WPCOM_Features {
 		self::FIELD_FILE                        => array(
 			self::WPCOM_PERSONAL_AND_HIGHER_PLANS,
 			self::JETPACK_COMPLETE_PLANS,
+		),
+		self::FORM_WEBHOOKS                     => array(
+			self::WPCOM_BUSINESS_AND_HIGHER_PLANS,
+			self::JETPACK_ALL_SITES,
 		),
 		self::FREE_BLOG                         => array(
 			self::WPCOM_ALL_SITES,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
This PR adds the basic form webhook functionality to allow users to integrate with external services.

- Webhook Configuration UI: Added webhook settings panel in the Jetpack Forms block editor sidebar with:
    - Toggle to enable/disable webhooks
    - Webhook ID input field for unique webhook identification
    - Webhook URL input field for the external endpoint
    - Feature gated behind jetpack_forms_webhooks_enabled filter (default: false)
- Webhook Processing: Form submissions now trigger POST requests to configured webhook URLs with:
    - JSON format support (properly encoded as JSON string, not URL-encoded)
    - Form submission data sent as payload
    - Webhook responses logged to post meta for debugging/tracking
    - jetpack_forms_before_webhook_request filter to allow modification of data before sending (parameters: webhook_id, form_data)
- Data Structure: Webhook configuration stored in block attributes as array supporting:
    - webhook_id: unique identifier
    - url: endpoint URL
    - format: 'json' (default, hardcoded for now)
    - method: 'POST' (default, hardcoded for now)
    - enabled: boolean toggle

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Enable webhooks via the filter flag:
   ```php
   add_filter( 'jetpack_forms_webhooks_enabled', '__return_true' );
   ```
*  Create a form with webhook configuration in the block editor
* Enter a webhook URL (e.g., https://webhook.site/unique-url for testing)
  * Publish/update the post and submit the form
  * Verify the webhook endpoint receives the form data in JSON format
  * Check the feedback CPT post meta for _jetpack_forms_webhook_response to see logged responses
* Verify that without the filter flag enabled, webhooks are not initialized even if configured in the form