### PR TITLE
A4A Client: defer connection check to plugins_loaded hook

### DIFF
--- a/projects/plugins/automattic-for-agencies-client/changelog/fix-a4a-defer-connection-check
+++ b/projects/plugins/automattic-for-agencies-client/changelog/fix-a4a-defer-connection-check
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+
+A4A Client: defer connection check to plugins_loaded hook to prevent fatal errors when WordPress core functions are not yet available.
+

--- a/projects/plugins/automattic-for-agencies-client/src/class-automattic-for-agencies-client.php
+++ b/projects/plugins/automattic-for-agencies-client/src/class-automattic-for-agencies-client.php
@@ -37,6 +37,19 @@ class Automattic_For_Agencies_Client {
 		add_action( 'load-settings_page_' . AUTOMATTIC_FOR_AGENCIES_CLIENT_SLUG, array( static::class, 'load_scripts_styles' ) );
 
 		// Display a modal when trying to deactivate the plugin.
+		// Hook to plugins_loaded at priority 20 to ensure connection package is initialized
+		// and WordPress core functions (like get_user_by) are available.
+		add_action( 'plugins_loaded', array( static::class, 'init_deactivation_handler' ), 20 );
+	}
+
+	/**
+	 * Initialize the deactivation handler if the site is connected.
+	 *
+	 * @since 0.1.0
+	 *
+	 * @return void
+	 */
+	public static function init_deactivation_handler() {
 		$manager = new Connection_Manager( 'automattic-for-agencies-client' );
 		if ( $manager->is_connected() ) {
 			Deactivation_Handler::init( AUTOMATTIC_FOR_AGENCIES_CLIENT_SLUG, __DIR__ . '/admin/deactivation-dialog.php' );


### PR DESCRIPTION
Fixes #

## Proposed changes:

### Problem

The A4A Client plugin experiences fatal errors on Atomic sites because `$manager->is_connected()` runs too early in `init()`, before WordPress core functions like `get_user_by()` are available. This was introduced in PR #37337.

### Solution

Move the connection check from `init()` to the `plugins_loaded` hook (priority 20) so:
- WordPress core functions are available
- Connection package is initialized first (priority 1)
- Deactivation handler still initializes early enough

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Spin up a JN site with the A4A client plugin installed on top of this branch (e.g., `/wp-admin/admin.php?page=jetpack-beta&plugin=automattic-for-agencies-client`)
* With a disconnected site, deactivate the plugin. Verify no interstitial connection pop-up is shown and the plugin deactivates right away.
* Re-activate the plugin, and connect the site.
* Deactivate the plugin, verify the disconnect dialog pops up before deactivating the plugin.
