### PR TITLE
eslint-changed: Fix running from a git subdir

### DIFF
--- a/projects/js-packages/eslint-changed/changelog/fix-eslint-changed-git-subdir
+++ b/projects/js-packages/eslint-changed/changelog/fix-eslint-changed-git-subdir
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Do the right thing when running with `--git` from a subdirectory of the repository.

--- a/projects/js-packages/eslint-changed/src/cli.js
+++ b/projects/js-packages/eslint-changed/src/cli.js
@@ -215,12 +215,13 @@ async function main( process, argv, program ) {
 			newRef = ':0';
 			args.push( '--staged' );
 		}
-		args = args.concat( program.args );
+		args.push( '--' );
+		args = args.concat( program.args.length ? program.args : [ '.' ] );
 
 		debug( 'Running git diff command:', git, args.join( ' ' ) );
 		diff = parseDiff( doCmd( git, args ) );
 		if ( ! argv.inDiffOnly && program.args.length ) {
-			files = program.args;
+			files = program.args.map( p => path.relative( diffBase, path.resolve( process.cwd(), p ) ) );
 			debug( 'Determined files from command line:', files );
 		} else {
 			files = getFilesFromDiff( diff );
@@ -247,7 +248,7 @@ async function main( process, argv, program ) {
 				content = doCmd( git, args );
 				debug( 'Executing ESLint for orig file' );
 				ret = await eslint.lintText( content, {
-					filePath: file,
+					filePath: path.resolve( diffBase, file ),
 				} );
 				eslintOrig = eslintOrig.concat( ret );
 			}
@@ -261,7 +262,7 @@ async function main( process, argv, program ) {
 			}
 			debug( 'Executing ESLint for new file' );
 			ret = await eslint.lintText( content, {
-				filePath: file,
+				filePath: path.resolve( diffBase, file ),
 			} );
 			eslintNew = eslintNew.concat( ret );
 		}

--- a/projects/js-packages/eslint-changed/tests/cli.test.js
+++ b/projects/js-packages/eslint-changed/tests/cli.test.js
@@ -1067,6 +1067,175 @@ describe( 'bin/eslint-changed.js', () => {
 			expect( output ).toEqual( expectOutput );
 		} );
 
+		test( 'Works when run from a subdirectory', async () => {
+			await mktmpdirgit(
+				[
+					{
+						files: {
+							'eslint.config.mjs': eslintconfig,
+							'a/1.js': "var x = 'Hello, world!';\n\n\n\n\n\n\n\n\n\n\n\nconsole.log( x )\n",
+							'a/2.js': "var x = 'Hello, world!';\n\n\n\n\n\n\n\n\n\n\n\nconsole.log( x )\n",
+							'b/3.js': "var x = 'Hello, world!';\n\n\n\n\n\n\n\n\n\n\n\nconsole.log( x )\n",
+						},
+					},
+				],
+				{
+					'a/2.js': "var y = 'Hello, world!';\n\n\n\n\n\n\n\n\n\n\n\nconsole.log( x )\n",
+					'b/3.js': "var y = 'Hello, world!';\n\n\n\n\n\n\n\n\n\n\n\nconsole.log( x )\n",
+				}
+			);
+
+			const data = await runEslintChanged( [ '--format=json', '--git' ], {
+				cwd: path.join( tmpdir, 'a' ),
+			} );
+			expect( data.exitCode ).toBe( 1 );
+
+			expect( data.stdout ).toBeValidJSON();
+			const output = JSON.parse( data.stdout );
+			expect( output ).toBeInstanceOf( Array );
+			const expectOutput = [
+				{
+					filePath: path.join( tmpdir, 'a/2.js' ),
+					messages: [
+						{
+							ruleId: 'no-unused-vars',
+							severity: 2,
+							message: "'y' is assigned a value but never used.",
+							line: 1,
+							column: 5,
+							nodeType: 'Identifier',
+							messageId: 'unusedVar',
+							endLine: 1,
+							endColumn: 6,
+							suggestions: [
+								{
+									data: {
+										varName: 'y',
+									},
+									desc: "Remove unused variable 'y'.",
+									fix: {
+										range: [ 0, 24 ],
+										text: '',
+									},
+									messageId: 'removeVar',
+								},
+							],
+						},
+						{
+							ruleId: 'no-undef',
+							severity: 2,
+							message: "'x' is not defined.",
+							line: 13,
+							column: 14,
+							nodeType: 'Identifier',
+							messageId: 'undef',
+							endLine: 13,
+							endColumn: 15,
+						},
+					],
+					errorCount: 2,
+					fatalErrorCount: 0,
+					warningCount: 0,
+					fixableErrorCount: 0,
+					fixableWarningCount: 0,
+					source: "var y = 'Hello, world!';\n\n\n\n\n\n\n\n\n\n\n\nconsole.log( x )\n",
+					suppressedMessages: [],
+					usedDeprecatedRules,
+				},
+			];
+			expect( output ).toEqual( expectOutput );
+		} );
+
+		test( 'Works when run from a subdirectory, naming relative files', async () => {
+			await mktmpdirgit(
+				[
+					{
+						files: {
+							'eslint.config.mjs': eslintconfig,
+							'x/1.js': "var x = 'Hello, world!';\n\n\n\n\n\n\n\n\n\n\n\nconsole.log( x )\n",
+							'x/2.js': "var x = 'Hello, world!';\n\n\n\n\n\n\n\n\n\n\n\nconsole.log( x )\n",
+							'x/3.js': "var x = 'Hello, world!';\n\n\n\n\n\n\n\n\n\n\n\nconsole.log( x )\n",
+						},
+					},
+				],
+				{
+					'x/2.js': "var y = 'Hello, world!';\n\n\n\n\n\n\n\n\n\n\n\nconsole.log( x )\n",
+					'x/3.js': "var y = 'Hello, world!';\n\n\n\n\n\n\n\n\n\n\n\nconsole.log( x )\n",
+				}
+			);
+			const data = await runEslintChanged( [ '--format=json', '--git', '1.js', '2.js' ], {
+				cwd: path.join( tmpdir, 'x' ),
+			} );
+			expect( data.exitCode ).toBe( 1 );
+
+			expect( data.stdout ).toBeValidJSON();
+			const output = JSON.parse( data.stdout );
+			expect( output ).toBeInstanceOf( Array );
+			const expectOutput = [
+				{
+					filePath: path.join( tmpdir, 'x/1.js' ),
+					messages: [],
+					errorCount: 0,
+					fatalErrorCount: 0,
+					warningCount: 0,
+					fixableErrorCount: 0,
+					fixableWarningCount: 0,
+					source: "var x = 'Hello, world!';\n\n\n\n\n\n\n\n\n\n\n\nconsole.log( x )\n",
+					suppressedMessages: [],
+					usedDeprecatedRules,
+				},
+				{
+					filePath: path.join( tmpdir, 'x/2.js' ),
+					messages: [
+						{
+							ruleId: 'no-unused-vars',
+							severity: 2,
+							message: "'y' is assigned a value but never used.",
+							line: 1,
+							column: 5,
+							nodeType: 'Identifier',
+							messageId: 'unusedVar',
+							endLine: 1,
+							endColumn: 6,
+							suggestions: [
+								{
+									data: {
+										varName: 'y',
+									},
+									desc: "Remove unused variable 'y'.",
+									fix: {
+										range: [ 0, 24 ],
+										text: '',
+									},
+									messageId: 'removeVar',
+								},
+							],
+						},
+						{
+							ruleId: 'no-undef',
+							severity: 2,
+							message: "'x' is not defined.",
+							line: 13,
+							column: 14,
+							nodeType: 'Identifier',
+							messageId: 'undef',
+							endLine: 13,
+							endColumn: 15,
+						},
+					],
+					errorCount: 2,
+					fatalErrorCount: 0,
+					warningCount: 0,
+					fixableErrorCount: 0,
+					fixableWarningCount: 0,
+					source: "var y = 'Hello, world!';\n\n\n\n\n\n\n\n\n\n\n\nconsole.log( x )\n",
+					suppressedMessages: [],
+					usedDeprecatedRules,
+				},
+			];
+			expect( output ).toEqual( expectOutput );
+		} );
+
 		describe( '--eslint-options works', () => {
 			const eslintOptionsRepo = [
 				[


### PR DESCRIPTION
Closes MONOREP-255

 <!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
When running with `--git` from a subdirectory of the repo, we need to make a few adjustments to get things working correctly:

* Pass `.` to `git diff` if no command line files are passed, as it's almost certain the user only wants files in the current subdirectory linted.
* When command line files are passed, the `files` array needs to have them relative to `diffBase` rather than `process.cwd()`.
* Pass absolute file names to `eslint`, as otherwise it interprets them relative to `process.cwd()` when they're actually relative to `diffBase`.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
Fixes #46060

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* CI happy?
* Try it with the test case in #46060 as well.

