### PR TITLE
Forms: Prefix notification IDs to prevent conflicts

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-notification-ids-prefix
+++ b/projects/packages/forms/changelog/fix-forms-notification-ids-prefix
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Prefix notification IDs to prevent conflicts with other plugins

--- a/projects/packages/forms/src/dashboard/components/empty-spam-button/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/empty-spam-button/index.tsx
@@ -87,7 +87,7 @@ const EmptySpamButton = ( {
 								),
 								formatNumber( deleted )
 						  );
-				createSuccessNotice( successMessage, { type: 'snackbar', id: 'empty-spam' } );
+				createSuccessNotice( successMessage, { type: 'snackbar', id: 'jp-forms-empty-spam' } );
 			} )
 			.catch( () => {
 				createErrorNotice( __( 'Could not empty spam.', 'jetpack-forms' ), {

--- a/projects/packages/forms/src/dashboard/components/empty-trash-button/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/empty-trash-button/index.tsx
@@ -87,7 +87,7 @@ const EmptyTrashButton = ( {
 								),
 								formatNumber( deleted )
 						  );
-				createSuccessNotice( successMessage, { type: 'snackbar', id: 'empty-trash' } );
+				createSuccessNotice( successMessage, { type: 'snackbar', id: 'jp-forms-empty-trash' } );
 			} )
 			.catch( () => {
 				createErrorNotice( __( 'Could not empty trash.', 'jetpack-forms' ), {

--- a/projects/packages/forms/src/dashboard/inbox/stage/actions.tsx
+++ b/projects/packages/forms/src/dashboard/inbox/stage/actions.tsx
@@ -312,7 +312,7 @@ export const markAsSpamAction: Action = {
 			if ( ! isUndo ) {
 				createSuccessNotice( successMessage, {
 					type: 'snackbar',
-					id: 'mark-as-spam-action',
+					id: 'jp-forms-mark-as-spam-action',
 					actions: [
 						{
 							label: __( 'Undo', 'jetpack-forms' ),
@@ -399,7 +399,7 @@ export const markAsNotSpamAction: Action = {
 			if ( ! isUndo ) {
 				createSuccessNotice( successMessage, {
 					type: 'snackbar',
-					id: 'mark-as-not-spam-action',
+					id: 'jp-forms-mark-as-not-spam-action',
 					actions: [
 						{
 							label: __( 'Undo', 'jetpack-forms' ),
@@ -484,7 +484,7 @@ export const restoreAction: Action = {
 			if ( ! isUndo ) {
 				createSuccessNotice( successMessage, {
 					type: 'snackbar',
-					id: 'restore-action',
+					id: 'jp-forms-restore-action',
 					actions: [
 						{
 							label: __( 'Undo', 'jetpack-forms' ),
@@ -567,7 +567,7 @@ export const moveToTrashAction: Action = {
 
 				createSuccessNotice( successMessage, {
 					type: 'snackbar',
-					id: 'move-to-trash-action',
+					id: 'jp-forms-move-to-trash-action',
 					actions: [
 						{
 							label: __( 'Undo', 'jetpack-forms' ),
@@ -648,7 +648,7 @@ export const deleteAction: Action = {
 							items.length
 					  );
 
-			createSuccessNotice( successMessage, { type: 'snackbar', id: 'move-to-trash-action' } );
+			createSuccessNotice( successMessage, { type: 'snackbar', id: 'jp-forms-delete-action' } );
 
 			// Update the URL to remove references to deleted items.
 			// Parse the hash to extract just the query params (e.g., #/responses?r=1,2,3)
@@ -774,7 +774,7 @@ export const markAsReadAction: Action = {
 
 			createSuccessNotice( successMessage, {
 				type: 'snackbar',
-				id: 'mark-as-read-action',
+				id: 'jp-forms-mark-as-read-action',
 				actions: [
 					{
 						label: __( 'Undo', 'jetpack-forms' ),
@@ -882,7 +882,7 @@ export const markAsUnreadAction: Action = {
 
 			createSuccessNotice( successMessage, {
 				type: 'snackbar',
-				id: 'mark-as-unread-action',
+				id: 'jp-forms-mark-as-unread-action',
 				actions: [
 					{
 						label: __( 'Undo', 'jetpack-forms' ),


### PR DESCRIPTION
## Proposed changes:
* Prefix all notification IDs in the Forms package with `jp-forms-` to prevent conflicts with other plugins that may use generic notification IDs like 'empty-spam', 'empty-trash', etc.
* Updated notification IDs in the following components:
  - Empty Spam Button: `empty-spam` → `jp-forms-empty-spam`
  - Empty Trash Button: `empty-trash` → `jp-forms-empty-trash`
  - Mark as Spam Action: `mark-as-spam-action` → `jp-forms-mark-as-spam-action`
  - Mark as Not Spam Action: `mark-as-not-spam-action` → `jp-forms-mark-as-not-spam-action`
  - Restore Action: `restore-action` → `jp-forms-restore-action`
  - Move to Trash Action: `move-to-trash-action` → `jp-forms-move-to-trash-action`
  - Delete Action: `move-to-trash-action` → `jp-forms-delete-action` (also fixed incorrect ID)
  - Mark as Read Action: `mark-as-read-action` → `jp-forms-mark-as-read-action`
  - Mark as Unread Action: `mark-as-unread-action` → `jp-forms-mark-as-unread-action`

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion


## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

* Enable Jetpack Forms on a WordPress site
* Go to the Forms dashboard (Jetpack > Forms)
* Test the following actions and verify that success notifications appear correctly:
  1. Mark a response as spam - verify "Marked as spam" notification appears
  2. Mark a response as not spam - verify notification appears
  3. Move a response to trash - verify "Moved to trash" notification appears
  4. Restore a response from trash - verify "Restored from trash" notification appears
  5. Empty spam folder (if there are spam items) - verify "Emptied spam" notification appears
  6. Empty trash folder (if there are trash items) - verify "Emptied trash" notification appears
  7. Mark responses as read/unread - verify notifications appear
  8. Delete responses permanently - verify "Deleted" notification appears
* Verify that the notifications work correctly and don't conflict with any other plugin notifications
* Ensure undo actions still work correctly for applicable notifications