### PR TITLE
Register ExPlat client in Jetpack Mu Wpcom

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/dotcom-15298-explat-fix-experiment-endpoint-in-atomic-sites
+++ b/projects/packages/jetpack-mu-wpcom/changelog/dotcom-15298-explat-fix-experiment-endpoint-in-atomic-sites
@@ -1,4 +1,4 @@
 Significance: patch
 Type: added
 
-Add ExPlat Client Atomic experiemnts
+- Initialize ExPlat Proxy in Jetpack Mu Wpcom

--- a/projects/packages/jetpack-mu-wpcom/changelog/dotcom-15298-explat-fix-experiment-endpoint-in-atomic-sites
+++ b/projects/packages/jetpack-mu-wpcom/changelog/dotcom-15298-explat-fix-experiment-endpoint-in-atomic-sites
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add ExPlat Client Atomic experiemnts

--- a/projects/packages/jetpack-mu-wpcom/changelog/dotcom-15298-explat-fix-experiment-endpoint-in-atomic-sites#2
+++ b/projects/packages/jetpack-mu-wpcom/changelog/dotcom-15298-explat-fix-experiment-endpoint-in-atomic-sites#2
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update package dependencies.

--- a/projects/packages/jetpack-mu-wpcom/composer.json
+++ b/projects/packages/jetpack-mu-wpcom/composer.json
@@ -22,7 +22,8 @@
 		"automattic/jetpack-subscribers-dashboard": "@dev",
 		"automattic/scheduled-updates": "@dev",
 		"scssphp/scssphp": "2.0.1",
-		"symfony/filesystem": "^6.0.0"
+		"symfony/filesystem": "^6.0.0",
+		"automattic/jetpack-explat": "^0.4.0@dev"
 	},
 	"require-dev": {
 		"yoast/phpunit-polyfills": "^4.0.0",

--- a/projects/packages/jetpack-mu-wpcom/composer.json
+++ b/projects/packages/jetpack-mu-wpcom/composer.json
@@ -23,7 +23,7 @@
 		"automattic/scheduled-updates": "@dev",
 		"scssphp/scssphp": "2.0.1",
 		"symfony/filesystem": "^6.0.0",
-		"automattic/jetpack-explat": "^0.4.0@dev"
+		"automattic/jetpack-explat": "@dev"
 	},
 	"require-dev": {
 		"yoast/phpunit-polyfills": "^4.0.0",

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -259,6 +259,7 @@ class Jetpack_Mu_Wpcom {
 	 * Load features that don't need any special loading considerations.
 	 */
 	public static function load_features() {
+		\Automattic\Jetpack\ExPlat::init();
 
 		// Please keep the features in alphabetical order.
 		require_once __DIR__ . '/features/100-year-plan/enhanced-ownership.php';

--- a/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-help-center.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-help-center.php
@@ -9,6 +9,7 @@ namespace A8C\FSE;
 
 use Automattic\Jetpack\Connection\Client;
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
+use Automattic\Jetpack\ExPlat as ExPlat_Proxy;
 use Automattic\Jetpack\Status\Host;
 
 /**
@@ -417,6 +418,8 @@ class Help_Center {
 	 * Register the Help Center endpoints.
 	 */
 	public function register_rest_api() {
+		ExPlat_Proxy::init();
+
 		require_once __DIR__ . '/class-wp-rest-help-center-authenticate.php';
 		$controller = new WP_REST_Help_Center_Authenticate();
 		$controller->register_rest_route();

--- a/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-help-center.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-help-center.php
@@ -9,7 +9,6 @@ namespace A8C\FSE;
 
 use Automattic\Jetpack\Connection\Client;
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
-use Automattic\Jetpack\ExPlat as ExPlat_Proxy;
 use Automattic\Jetpack\Status\Host;
 
 /**
@@ -418,8 +417,6 @@ class Help_Center {
 	 * Register the Help Center endpoints.
 	 */
 	public function register_rest_api() {
-		ExPlat_Proxy::init();
-
 		require_once __DIR__ . '/class-wp-rest-help-center-authenticate.php';
 		$controller = new WP_REST_Help_Center_Authenticate();
 		$controller->register_rest_route();

--- a/projects/plugins/mu-wpcom-plugin/changelog/dotcom-15298-explat-fix-experiment-endpoint-in-atomic-sites
+++ b/projects/plugins/mu-wpcom-plugin/changelog/dotcom-15298-explat-fix-experiment-endpoint-in-atomic-sites
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock.
+
+

--- a/projects/plugins/mu-wpcom-plugin/composer.lock
+++ b/projects/plugins/mu-wpcom-plugin/composer.lock
@@ -747,6 +747,82 @@
             }
         },
         {
+            "name": "automattic/jetpack-explat",
+            "version": "dev-trunk",
+            "dist": {
+                "type": "path",
+                "url": "../../packages/explat",
+                "reference": "1da7eabd28e234c67a03fc7bff5760b383a0d91d"
+            },
+            "require": {
+                "automattic/jetpack-connection": "@dev",
+                "php": ">=7.2"
+            },
+            "require-dev": {
+                "automattic/jetpack-changelogger": "@dev",
+                "automattic/phpunit-select-config": "@dev",
+                "yoast/phpunit-polyfills": "^4.0.0"
+            },
+            "suggest": {
+                "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
+            },
+            "type": "jetpack-library",
+            "extra": {
+                "autotagger": true,
+                "branch-alias": {
+                    "dev-trunk": "0.4.x-dev"
+                },
+                "changelogger": {
+                    "link-template": "https://github.com/Automattic/jetpack-explat/compare/v${old}...v${new}"
+                },
+                "mirror-repo": "Automattic/jetpack-explat",
+                "textdomain": "jetpack-explat",
+                "version-constants": {
+                    "::PACKAGE_VERSION": "src/class-explat.php"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "scripts": {
+                "phpunit": [
+                    "phpunit-select-config phpunit.#.xml.dist --colors=always"
+                ],
+                "test-coverage": [
+                    "pnpm concurrently --names php,js 'php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\"' 'pnpm:test-coverage'"
+                ],
+                "test-php": [
+                    "@composer phpunit"
+                ],
+                "test-js": [
+                    "pnpm run test"
+                ],
+                "test-js-watch": [
+                    "Composer\\Config::disableProcessTimeout",
+                    "pnpm run test --watch"
+                ],
+                "build-development": [
+                    "pnpm run build"
+                ],
+                "build-production": [
+                    "NODE_ENV=production pnpm run build"
+                ],
+                "watch": [
+                    "Composer\\Config::disableProcessTimeout",
+                    "pnpm run watch"
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "A package for running A/B tests on the Experimentation Platform (ExPlat) in the plugin.",
+            "transport-options": {
+                "relative": true
+            }
+        },
+        {
             "name": "automattic/jetpack-google-analytics",
             "version": "dev-trunk",
             "dist": {
@@ -1090,7 +1166,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/jetpack-mu-wpcom",
-                "reference": "fdfedd6fe57939a8494f8fec2cb679652bf4f096"
+                "reference": "75008c61da853b1712d860e0dc4faaf1ae740594"
             },
             "require": {
                 "automattic/block-delimiter": "@dev",
@@ -1099,6 +1175,7 @@
                 "automattic/jetpack-classic-theme-helper": "@dev",
                 "automattic/jetpack-compat": "@dev",
                 "automattic/jetpack-connection": "@dev",
+                "automattic/jetpack-explat": "@dev",
                 "automattic/jetpack-google-analytics": "@dev",
                 "automattic/jetpack-masterbar": "@dev",
                 "automattic/jetpack-redirect": "@dev",

--- a/projects/plugins/wpcomsh/changelog/dotcom-15298-explat-fix-experiment-endpoint-in-atomic-sites
+++ b/projects/plugins/wpcomsh/changelog/dotcom-15298-explat-fix-experiment-endpoint-in-atomic-sites
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Added automattic/explat dependency

--- a/projects/plugins/wpcomsh/changelog/dotcom-15298-explat-fix-experiment-endpoint-in-atomic-sites#2
+++ b/projects/plugins/wpcomsh/changelog/dotcom-15298-explat-fix-experiment-endpoint-in-atomic-sites#2
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update package dependencies.

--- a/projects/plugins/wpcomsh/composer.json
+++ b/projects/plugins/wpcomsh/composer.json
@@ -16,7 +16,8 @@
 		"automattic/jetpack-config": "@dev",
 		"automattic/jetpack-post-list": "@dev",
 		"automattic/jetpack-mu-wpcom": "@dev",
-		"tubalmartin/cssmin": "^4.1"
+		"tubalmartin/cssmin": "^4.1",
+		"automattic/jetpack-explat": "^0.4.0@dev"
 	},
 	"require-dev": {
 		"automattic/jetpack-changelogger": "@dev",

--- a/projects/plugins/wpcomsh/composer.json
+++ b/projects/plugins/wpcomsh/composer.json
@@ -17,7 +17,7 @@
 		"automattic/jetpack-post-list": "@dev",
 		"automattic/jetpack-mu-wpcom": "@dev",
 		"tubalmartin/cssmin": "^4.1",
-		"automattic/jetpack-explat": "^0.4.0@dev"
+		"automattic/jetpack-explat": "@dev"
 	},
 	"require-dev": {
 		"automattic/jetpack-changelogger": "@dev",

--- a/projects/plugins/wpcomsh/composer.lock
+++ b/projects/plugins/wpcomsh/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "53dbcf5d5dc3d70f4292b70c3b1690d9",
+    "content-hash": "1988d49c2dfe6aa1ff072a3bed878b0d",
     "packages": [
         {
             "name": "automattic/at-pressable-podcasting",
@@ -1375,7 +1375,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/jetpack-mu-wpcom",
-                "reference": "b4c0d7bf761da4e6b9cf61f5b8ca78e309bc8bd5"
+                "reference": "75008c61da853b1712d860e0dc4faaf1ae740594"
             },
             "require": {
                 "automattic/block-delimiter": "@dev",
@@ -1384,7 +1384,7 @@
                 "automattic/jetpack-classic-theme-helper": "@dev",
                 "automattic/jetpack-compat": "@dev",
                 "automattic/jetpack-connection": "@dev",
-                "automattic/jetpack-explat": "^0.4.0@dev",
+                "automattic/jetpack-explat": "@dev",
                 "automattic/jetpack-google-analytics": "@dev",
                 "automattic/jetpack-masterbar": "@dev",
                 "automattic/jetpack-redirect": "@dev",

--- a/projects/plugins/wpcomsh/composer.lock
+++ b/projects/plugins/wpcomsh/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0e4d4ae316d741336ec911f12177ce14",
+    "content-hash": "53dbcf5d5dc3d70f4292b70c3b1690d9",
     "packages": [
         {
             "name": "automattic/at-pressable-podcasting",
@@ -956,6 +956,82 @@
             }
         },
         {
+            "name": "automattic/jetpack-explat",
+            "version": "dev-trunk",
+            "dist": {
+                "type": "path",
+                "url": "../../packages/explat",
+                "reference": "1da7eabd28e234c67a03fc7bff5760b383a0d91d"
+            },
+            "require": {
+                "automattic/jetpack-connection": "@dev",
+                "php": ">=7.2"
+            },
+            "require-dev": {
+                "automattic/jetpack-changelogger": "@dev",
+                "automattic/phpunit-select-config": "@dev",
+                "yoast/phpunit-polyfills": "^4.0.0"
+            },
+            "suggest": {
+                "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
+            },
+            "type": "jetpack-library",
+            "extra": {
+                "autotagger": true,
+                "branch-alias": {
+                    "dev-trunk": "0.4.x-dev"
+                },
+                "changelogger": {
+                    "link-template": "https://github.com/Automattic/jetpack-explat/compare/v${old}...v${new}"
+                },
+                "mirror-repo": "Automattic/jetpack-explat",
+                "textdomain": "jetpack-explat",
+                "version-constants": {
+                    "::PACKAGE_VERSION": "src/class-explat.php"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "scripts": {
+                "phpunit": [
+                    "phpunit-select-config phpunit.#.xml.dist --colors=always"
+                ],
+                "test-coverage": [
+                    "pnpm concurrently --names php,js 'php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\"' 'pnpm:test-coverage'"
+                ],
+                "test-php": [
+                    "@composer phpunit"
+                ],
+                "test-js": [
+                    "pnpm run test"
+                ],
+                "test-js-watch": [
+                    "Composer\\Config::disableProcessTimeout",
+                    "pnpm run test --watch"
+                ],
+                "build-development": [
+                    "pnpm run build"
+                ],
+                "build-production": [
+                    "NODE_ENV=production pnpm run build"
+                ],
+                "watch": [
+                    "Composer\\Config::disableProcessTimeout",
+                    "pnpm run watch"
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "A package for running A/B tests on the Experimentation Platform (ExPlat) in the plugin.",
+            "transport-options": {
+                "relative": true
+            }
+        },
+        {
             "name": "automattic/jetpack-google-analytics",
             "version": "dev-trunk",
             "dist": {
@@ -1299,7 +1375,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/jetpack-mu-wpcom",
-                "reference": "fdfedd6fe57939a8494f8fec2cb679652bf4f096"
+                "reference": "b4c0d7bf761da4e6b9cf61f5b8ca78e309bc8bd5"
             },
             "require": {
                 "automattic/block-delimiter": "@dev",
@@ -1308,6 +1384,7 @@
                 "automattic/jetpack-classic-theme-helper": "@dev",
                 "automattic/jetpack-compat": "@dev",
                 "automattic/jetpack-connection": "@dev",
+                "automattic/jetpack-explat": "^0.4.0@dev",
                 "automattic/jetpack-google-analytics": "@dev",
                 "automattic/jetpack-masterbar": "@dev",
                 "automattic/jetpack-redirect": "@dev",
@@ -5429,6 +5506,7 @@
         "automattic/jetpack-changelogger": 20,
         "automattic/jetpack-composer-plugin": 20,
         "automattic/jetpack-config": 20,
+        "automattic/jetpack-explat": 20,
         "automattic/jetpack-mu-wpcom": 20,
         "automattic/jetpack-post-list": 20,
         "automattic/phpunit-select-config": 20


### PR DESCRIPTION
Fixes DOTCOM-15298

## Proposed changes:
ExPlat endpoint was only registered when the site had admin-style set to Default (vs wp-admin). This is unexpected and it should be registered in all sites.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
1. Apply this to an atomic site using the Jetpack Beta Plugins (WordPress.com Features module).
2. Visit `/wp-json/jetpack/v4/explat/assignments?experiment_name=wpcom_help_center_ai_workflow_and_prompt_changes&platform=wpcom&as_connected_user=true&_locale=user`
3. You shouldn't get 404.
