### PR TITLE
actions: Set permissions in linting and gardening workflows

### DIFF
--- a/.github/workflows/gardening.yml
+++ b/.github/workflows/gardening.yml
@@ -15,6 +15,20 @@ concurrency:
   group: gardening-${{ github.event_name }}-${{ github.event.action }}-${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.ref || github.run_id }}
   cancel-in-progress: true
 
+permissions:
+  # ./.github/actions/turnstile
+  actions: read
+  # actions/checkout
+  contents: read
+  # ./projects/github-actions/repo-gardening
+  #   read: octokit.rest.issues.listComments, octokit.rest.issues.get, octokit.rest.issues.listLabelsForRepo, octokit.rest.issues.listLabelsOnIssue, octokit.rest.issues.listMilestones
+  #   write: octokit.rest.issues.addAssignees, octokit.rest.issues.addLabels, octokit.rest.issues.createComment, octokit.rest.issues.removeLabel, octokit.rest.issues.update, octokit.rest.issues.updateComment
+  issues: write
+  # ./projects/github-actions/repo-gardening
+  #   read: octokit.rest.issues.listComments, octokit.rest.pulls.listFiles, octokit.rest.issues.listLabelsForRepo, octokit.rest.issues.listLabelsOnIssue, octokit.rest.issues.listMilestonesoctokit.rest.issues.listMilestones
+  #   write: octokit.rest.issues.addAssignees, octokit.rest.issues.addLabels, octokit.rest.issues.createComment, octokit.rest.issues.removeLabel, octokit.rest.issues.update, octokit.rest.issues.updateComment
+  pull-requests: write
+
 jobs:
   repo-gardening:
     name: "Manage labels and assignees"
@@ -22,10 +36,6 @@ jobs:
     if: github.event_name == 'pull_request_target' || github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
     timeout-minutes: 10  # 2025-11-06: Successful runs seem to take a minute or two, primarily since we wait for previous runs to complete.
     steps:
-      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
-        with:
-          config: ${{ vars.PERMISSIONS_CONFIG }}
-
       - name: Checkout
         uses: actions/checkout@v5
 

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -18,6 +18,10 @@ concurrency:
 env:
   COMPOSER_ROOT_VERSION: "dev-trunk"
 
+permissions:
+  # actions/checkout
+  contents: read
+
 jobs:
 
   ### Job to categorize changed files. Other jobs depend on this to know when they should run.
@@ -25,8 +29,10 @@ jobs:
   changed_files:
     name: detect changed files
     runs-on: ubuntu-latest
-    #timeout-minutes: 1  # 2025-11-06: Successful runs seem to take a few seconds
-    timeout-minutes: 2  # 2025-11-19: Successful runs seem to take a few seconds, but GitHubSecurityLab/actions-permissions/monitor takes a minute to start.
+    timeout-minutes: 1  # 2025-11-06: Successful runs seem to take a few seconds
+    permissions:
+      # dorny/paths-filter
+      pull-requests: read
     outputs:
       # Whether any PHP files have changed.
       php: ${{ steps.filter.outputs.php }}
@@ -68,10 +74,6 @@ jobs:
       phanstubs: ${{ steps.filter.outputs.phanstubs == 'true' }}
 
     steps:
-      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
-        with:
-          config: ${{ vars.PERMISSIONS_CONFIG }}
-
       - if: github.event_name == 'pull_request'
         uses: actions/checkout@v5
 
@@ -218,10 +220,6 @@ jobs:
         experimental: [ false ]
 
     steps:
-      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
-        with:
-          config: ${{ vars.PERMISSIONS_CONFIG }}
-
       - uses: actions/checkout@v5
 
       - name: Setup tools
@@ -256,10 +254,6 @@ jobs:
     timeout-minutes: 5  # 2025-11-06: Successful runs seem to take ~2 minutes. Leaving some extra for future expansion.
 
     steps:
-      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
-        with:
-          config: ${{ vars.PERMISSIONS_CONFIG }}
-
       - uses: actions/checkout@v5
 
       - name: Setup tools
@@ -288,10 +282,6 @@ jobs:
     timeout-minutes: 5  # 2025-11-06: Successful runs seem to take ~1 minute. Leaving some extra for future expansion.
 
     steps:
-      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
-        with:
-          config: ${{ vars.PERMISSIONS_CONFIG }}
-
       - uses: actions/checkout@v5
 
       - name: Setup tools
@@ -322,10 +312,6 @@ jobs:
     timeout-minutes: 5  # 2025-11-06: Successful runs seem to take 30 seconds. Leaving some extra for future expansion.
 
     steps:
-      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
-        with:
-          config: ${{ vars.PERMISSIONS_CONFIG }}
-
       # We don't need full git history, but phpcs-changed does need everything up to the merge-base.
       - uses: actions/checkout@v5
         with:
@@ -364,10 +350,6 @@ jobs:
     timeout-minutes: 10  # 2025-11-06: Runs now take ~5 minutes due to now installing all php/js deps to ensure valid linting.
 
     steps:
-      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
-        with:
-          config: ${{ vars.PERMISSIONS_CONFIG }}
-
       - uses: actions/checkout@v5
 
       - name: Setup tools
@@ -391,10 +373,6 @@ jobs:
     timeout-minutes: 10  # 2025-11-06: Takes about a minute, but rarely runs.
 
     steps:
-      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
-        with:
-          config: ${{ vars.PERMISSIONS_CONFIG }}
-
       # We don't need full git history, but eslint-changed does need everything up to the merge-base.
       - uses: actions/checkout@v5
         with:
@@ -425,10 +403,6 @@ jobs:
     timeout-minutes: 5  # 2025-11-06: Takes a bit more than a minute, so give a little wiggle room.
 
     steps:
-      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
-        with:
-          config: ${{ vars.PERMISSIONS_CONFIG }}
-
       - uses: actions/checkout@v5
 
       - name: Setup tools
@@ -450,10 +424,6 @@ jobs:
     if: github.event_name == 'push' || needs.changed_files.outputs.ghactionsfiles == 'true' || needs.changed_files.outputs.misc == 'true'
     timeout-minutes: 5  # 2025-11-06: Takes less than a minute.
     steps:
-      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
-        with:
-          config: ${{ vars.PERMISSIONS_CONFIG }}
-
       - uses: actions/checkout@v5
 
       - name: Setup tools
@@ -470,14 +440,9 @@ jobs:
   copied_files:
     name: Copied files are in sync
     runs-on: ubuntu-latest
-    #timeout-minutes: 1  # 2025-11-06: Successful runs seem to take a few seconds.
-    timeout-minutes: 2  # 2025-11-19: Successful runs seem to take a few seconds, but GitHubSecurityLab/actions-permissions/monitor takes a minute to start.
+    timeout-minutes: 1  # 2025-11-06: Successful runs seem to take a few seconds.
 
     steps:
-      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
-        with:
-          config: ${{ vars.PERMISSIONS_CONFIG }}
-
       - uses: actions/checkout@v5
       - run: ./tools/check-copied-files.sh
 
@@ -492,10 +457,6 @@ jobs:
     if: github.event_name == 'push' || needs.changed_files.outputs.excludelist == 'true'
     timeout-minutes: 10  # 2025-11-06: The check itself takes 2 minutes.
     steps:
-      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
-        with:
-          config: ${{ vars.PERMISSIONS_CONFIG }}
-
       - uses: actions/checkout@v5
 
       - name: Setup tools
@@ -518,10 +479,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5  # 2025-11-06: Takes a few seconds.
     steps:
-      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
-        with:
-          config: ${{ vars.PERMISSIONS_CONFIG }}
-
       # We don't need full git history, but tools/check-changelogger-use.php does need everything up to the merge-base.
       - uses: actions/checkout@v5
         with:
@@ -547,10 +504,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5  # 2025-11-06: Takes less than a minute.
     steps:
-      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
-        with:
-          config: ${{ vars.PERMISSIONS_CONFIG }}
-
       - uses: actions/checkout@v5
 
       - name: Setup tools
@@ -573,10 +526,6 @@ jobs:
     if: github.event_name == 'push' || needs.changed_files.outputs.lockfiles == 'true' || needs.changed_files.outputs.misc == 'true'
     timeout-minutes: 7  # 2025-11-06: Successful runs seem to take about 2 minutes.
     steps:
-      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
-        with:
-          config: ${{ vars.PERMISSIONS_CONFIG }}
-
       - uses: actions/checkout@v5
 
       - name: Setup tools
@@ -595,10 +544,6 @@ jobs:
     if: github.event_name == 'push' || needs.changed_files.outputs.lockfiles == 'true' || needs.changed_files.outputs.misc == 'true'
     timeout-minutes: 7  # 2025-11-06: Takes a minute or two.
     steps:
-      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
-        with:
-          config: ${{ vars.PERMISSIONS_CONFIG }}
-
       - uses: actions/checkout@v5
       - name: Setup tools
         uses: ./.github/actions/tool-setup
@@ -613,10 +558,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5  # 2025-11-06: Takes a minute or two.
     steps:
-      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
-        with:
-          config: ${{ vars.PERMISSIONS_CONFIG }}
-
       - uses: actions/checkout@v5
 
       - name: Setup tools
@@ -632,11 +573,10 @@ jobs:
     needs: changed_files
     if: github.event_name == 'pull_request' && needs.changed_files.outputs.phanstubs == 'true' && github.event.pull_request.user.login != 'matticbot'
     timeout-minutes: 5  # 2025-11-06: Probably takes about a minute.
+    permissions:
+      # Post review
+      pull-requests: write
     steps:
-      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
-        with:
-          config: ${{ vars.PERMISSIONS_CONFIG }}
-
       - uses: actions/checkout@v5
       - uses: ./.github/actions/deepen-to-merge-base
         id: deepen
@@ -665,10 +605,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10 # 2025-11-20: Takes around 3 minutes.
     steps:
-      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
-        with:
-          config: ${{ vars.PERMISSIONS_CONFIG }}
-
       - uses: actions/checkout@v5
       - name: Setup tools
         uses: ./.github/actions/tool-setup
@@ -692,10 +628,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 25 # 2025-11-20: Up to about 10 minutes now that we're running against the old WP and Woo stubs too.
     steps:
-      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
-        with:
-          config: ${{ vars.PERMISSIONS_CONFIG }}
-
       - uses: actions/checkout@v5
       - name: Setup tools
         uses: ./.github/actions/tool-setup

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -31,6 +31,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 1  # 2025-11-06: Successful runs seem to take a few seconds
     permissions:
+      # actions/checkout
+      contents: read
       # dorny/paths-filter
       pull-requests: read
     outputs:
@@ -574,7 +576,9 @@ jobs:
     if: github.event_name == 'pull_request' && needs.changed_files.outputs.phanstubs == 'true' && github.event.pull_request.user.login != 'matticbot'
     timeout-minutes: 5  # 2025-11-06: Probably takes about a minute.
     permissions:
-      # Post review
+      # actions/checkout
+      contents: read
+      # step "Warn about stubs"
       pull-requests: write
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
Closes MONOREP-256

 <!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
I'm not sure quite how much I trust
`GitHubSecurityLab/actions-permissions/monitor`. It identified most of these, but it didn't cover all code paths.

Overall it's probably useful as one tool in the toolbox, but can't be relied on to catch everything.

What it did find:
* `dorny/paths-filter` needs `pull-requests: read`.
* repo-gardening seems to need `issues: write` and `pull-requests: write`.

What it didn't:
* `actions/checkout` supposedly needs `contents: read`, but it wasn't flagged. Maybe it only needs it for private repos?
* Our `./.github/actions/turnstile` should need `actions: read`, but it wasn't flagged. Maybe it only needs it for private repos?
* Linting / Phan stubs / Warn about stubs will need `pull-requests: write`, which wasn't flagged because it was never triggered.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
Follow-up to #46004

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* CI happy?
* Try making a PR that triggers the Linting / Phan stubs message.
  * [x] https://github.com/anomiex/jetpack/pull/47#discussion_r2557431070
* ~~No idea how to test the gardening project parts. Maybe @jeherve knows?~~ Oh, that part uses a different token (`triage_projects_token`), so the permissions in the workflow don't matter for it.
