### PR TITLE
 Forms: Use fallback page value on feedback source if variable is polluted

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-polluted-page
+++ b/projects/packages/forms/changelog/fix-forms-polluted-page
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: Use fallback page value on feedback source if variable is polluted

--- a/projects/packages/forms/src/contact-form/class-feedback-source.php
+++ b/projects/packages/forms/src/contact-form/class-feedback-source.php
@@ -75,8 +75,13 @@ class Feedback_Source {
 			$this->id = $id;
 		}
 
+		if ( is_numeric( $page_number ) ) {
+			$this->page_number = $page_number > 0 ? $page_number : 1;
+		} else {
+			$this->page_number = 1;
+		}
+
 		$this->title       = $title;
-		$this->page_number = $page_number;
 		$this->permalink   = empty( $request_url ) ? home_url() : $request_url;
 		$this->source_type = $source_type; // possible source types: single, widget, block_template, block_template_part
 		$this->request_url = $request_url;

--- a/projects/packages/forms/tests/php/contact-form/Feedback_Source_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Feedback_Source_Test.php
@@ -299,29 +299,6 @@ class Feedback_Source_Test extends BaseTestCase {
 	}
 
 	/**
-	 * Test constructor with non-numeric page number (e.g., WP_Post object from polluted global $page)
-	 */
-	public function test_constructor_with_non_numeric_page_number() {
-		// Create a post to simulate a polluted global $page variable
-		$post_id = wp_insert_post(
-			array(
-				'post_title'  => 'Test Post',
-				'post_status' => 'publish',
-				'post_type'   => 'post',
-			)
-		);
-		$post    = \get_post( $post_id );
-
-		// Pass a WP_Post object as page_number to simulate the bug
-		$entry = new Feedback_Source( $post_id, '', $post );
-
-		// Page number should default to 1 when non-numeric value is provided
-		$this->assertSame( 1, $entry->get_page_number() );
-		$this->assertEquals( $post_id, $entry->get_id() );
-		$this->assertEquals( 'Test Post', $entry->get_title() );
-	}
-
-	/**
 	 * Test constructor overwrites ID when post is not public
 	 */
 	public function test_constructor_overwrites_id_for_non_public_post() {

--- a/projects/packages/forms/tests/php/contact-form/Feedback_Source_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Feedback_Source_Test.php
@@ -299,6 +299,29 @@ class Feedback_Source_Test extends BaseTestCase {
 	}
 
 	/**
+	 * Test constructor with non-numeric page number (e.g., WP_Post object from polluted global $page)
+	 */
+	public function test_constructor_with_non_numeric_page_number() {
+		// Create a post to simulate a polluted global $page variable
+		$post_id = wp_insert_post(
+			array(
+				'post_title'  => 'Test Post',
+				'post_status' => 'publish',
+				'post_type'   => 'post',
+			)
+		);
+		$post    = \get_post( $post_id );
+
+		// Pass a WP_Post object as page_number to simulate the bug
+		$entry = new Feedback_Source( $post_id, '', $post );
+
+		// Page number should default to 1 when non-numeric value is provided
+		$this->assertSame( 1, $entry->get_page_number() );
+		$this->assertEquals( $post_id, $entry->get_id() );
+		$this->assertEquals( 'Test Post', $entry->get_title() );
+	}
+
+	/**
 	 * Test constructor overwrites ID when post is not public
 	 */
 	public function test_constructor_overwrites_id_for_non_public_post() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes FORMS-428

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Makes sure the page is numeric, as the night is dark and full of terrors (like themes polluting global variables)

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Check that tests passes
* If you have a theme that changes the $page variable, you can test with it (check the Linear issue for reproduction steps), though a code inspection should be enough
