### PR TITLE
DO NOT MERGE: Forms: try adding synced patterns

### DIFF
--- a/projects/packages/forms/changelog/try-forms-synced-patterns
+++ b/projects/packages/forms/changelog/try-forms-synced-patterns
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Forms: add synced patterns.

--- a/projects/packages/forms/src/blocks/contact-form/attributes.ts
+++ b/projects/packages/forms/src/blocks/contact-form/attributes.ts
@@ -61,6 +61,10 @@ export default {
 			groupName: '',
 		},
 	},
+	jetpackFormId: {
+		type: 'string',
+		default: '',
+	},
 	saveResponses: {
 		type: 'boolean',
 		default: true,

--- a/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
+++ b/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
@@ -798,6 +798,75 @@ class Contact_Form_Block {
 	}
 
 	/**
+	 * Enqueue a small inline script in the block editor to add a "View all forms" button
+	 * in the post status sidebar when editing Jetpack Forms synced patterns (wp_block posts
+	 * in the jetpack-forms category).
+	 *
+	 * @return void
+	 */
+	public static function add_pattern_editor_back_link() {
+		if ( ! function_exists( 'get_current_screen' ) ) {
+			return;
+		}
+
+		$screen = get_current_screen();
+
+		if ( ! $screen || 'wp_block' !== $screen->post_type ) {
+			return;
+		}
+
+		$post_id = isset( $_GET['post'] ) ? absint( $_GET['post'] ) : 0; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+
+		if ( ! $post_id || ! taxonomy_exists( 'wp_pattern_category' ) || ! has_term( 'jetpack-forms', 'wp_pattern_category', $post_id ) ) {
+			return;
+		}
+
+		$dashboard_url = admin_url( 'admin.php?page=jetpack-forms-admin#/forms' );
+		$label         = esc_js( __( 'View all forms', 'jetpack-forms' ) );
+
+		$inline_script = "
+( function( wp ) {
+	if (
+		! wp ||
+		! wp.plugins ||
+		! wp.editPost ||
+		! wp.element ||
+		! wp.components
+	) {
+		return;
+	}
+
+	var registerPlugin = wp.plugins.registerPlugin;
+	var PluginPostStatusInfo = wp.editPost.PluginPostStatusInfo;
+	var el = wp.element.createElement;
+	var Button = wp.components.Button;
+
+	var BackToFormsControls = function() {
+		return el(
+			PluginPostStatusInfo,
+			{ className: 'jetpack-forms-back-to-dashboard' },
+			el(
+				Button,
+				{
+					isSecondary: true,
+					isSmall: true,
+					href: '" . esc_url( $dashboard_url ) . "',
+				},
+				'{$label}'
+			)
+		);
+	};
+
+	registerPlugin( 'jetpack-forms-back-to-dashboard', {
+		render: BackToFormsControls,
+	} );
+} )( window.wp );
+";
+
+		wp_add_inline_script( 'wp-edit-post', $inline_script );
+	}
+
+	/**
 	 * Add REST API endpoints to the block editor preload list.
 	 *
 	 * @param array $paths Existing paths to preload.

--- a/projects/packages/forms/src/blocks/contact-form/edit.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/edit.tsx
@@ -14,10 +14,12 @@ import {
 	BlockControls,
 	BlockContextProvider,
 } from '@wordpress/block-editor';
-import { createBlock } from '@wordpress/blocks';
+import { createBlock, serialize } from '@wordpress/blocks';
 import {
+	Button,
 	ExternalLink,
 	PanelBody,
+	__experimentalText as Text, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 	TextareaControl,
 	TextControl,
 	ToggleControl,
@@ -25,9 +27,9 @@ import {
 } from '@wordpress/components';
 import { useInstanceId } from '@wordpress/compose';
 import { store as coreStore } from '@wordpress/core-data';
-import { useSelect, useDispatch } from '@wordpress/data';
+import { useSelect, useDispatch, select as wpDataSelect } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
-import { useRef, useEffect, useCallback, lazy, Suspense } from '@wordpress/element';
+import { useRef, useEffect, useCallback, useState, lazy, Suspense } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
 /*
@@ -138,6 +140,7 @@ type JetpackContactFormAttributes = {
 	confirmationType: 'text' | 'redirect';
 	formTitle: string;
 	variationName: string;
+	jetpackFormId?: string;
 	emailNotifications: boolean;
 	disableGoBack: boolean;
 	disableSummary: boolean;
@@ -173,6 +176,7 @@ function JetpackContactFormEdit( {
 		confirmationType,
 		formTitle,
 		variationName,
+		jetpackFormId,
 		emailNotifications,
 		disableGoBack,
 		disableSummary,
@@ -204,6 +208,13 @@ function JetpackContactFormEdit( {
 	}, [ confirmationType, customThankyou, setAttributes ] );
 
 	const steps = useFormSteps( clientId );
+
+	// Ensure a stable form identifier for inline/non-SP forms.
+	useEffect( () => {
+		if ( ! jetpackFormId ) {
+			setAttributes( { jetpackFormId: `inline-${ clientId }` } );
+		}
+	}, [ jetpackFormId, clientId, setAttributes ] );
 
 	// Get current step info for context
 	const currentStepInfo = useSelect(
@@ -301,8 +312,73 @@ function JetpackContactFormEdit( {
 	const { isLoadingModules, isChangingStatus, isModuleActive, changeStatus } =
 		useModuleStatus( 'contact-form' );
 
-	const { replaceInnerBlocks, __unstableMarkNextChangeAsNotPersistent, updateBlockAttributes } =
-		useDispatch( blockEditorStore );
+	const {
+		replaceInnerBlocks,
+		__unstableMarkNextChangeAsNotPersistent,
+		updateBlockAttributes,
+		replaceBlocks,
+	} = useDispatch( blockEditorStore );
+	const { saveEntityRecord } = useDispatch( coreStore );
+
+	const jetpackFormsPatternCategory = useSelect( select => {
+		try {
+			const records = select( coreStore ).getEntityRecords( 'taxonomy', 'wp_pattern_category', {
+				slug: 'jetpack-forms',
+			} );
+			return records && records.length ? records[ 0 ] : null;
+		} catch {
+			return null;
+		}
+	}, [] );
+
+	const [ sharedFormTitle, setSharedFormTitle ] = useState( '' );
+	const [ isSavingSharedForm, setIsSavingSharedForm ] = useState( false );
+
+	// Detect if we are editing a synced pattern (wp_block) already.
+	const isEditingPattern = useSelect( select => {
+		const editor = select( editorStore );
+		const postType =
+			typeof editor?.getCurrentPostType === 'function' ? editor.getCurrentPostType() : null;
+		return postType === 'wp_block';
+	}, [] );
+
+	const handleSaveAsSharedForm = useCallback( async () => {
+		if ( ! sharedFormTitle ) {
+			return;
+		}
+
+		setIsSavingSharedForm( true );
+		try {
+			const formBlock = wpDataSelect( blockEditorStore ).getBlock( clientId );
+
+			if ( ! formBlock ) {
+				return;
+			}
+
+			const content = serialize( [ formBlock ] );
+
+			const newPattern = ( await saveEntityRecord( 'postType', 'wp_block', {
+				title: sharedFormTitle,
+				content,
+				status: 'publish',
+				wp_pattern_category: jetpackFormsPatternCategory?.id
+					? [ jetpackFormsPatternCategory.id ]
+					: undefined,
+				wp_pattern_sync_status: 'full',
+			} ) ) as { id?: number } | null;
+
+			if ( newPattern?.id ) {
+				const reusableRefBlock = createBlock( 'core/block', { ref: newPattern.id } );
+				replaceBlocks( clientId, reusableRefBlock );
+			}
+		} catch ( error ) {
+			// Swallow errors for this spike; the reusable conversion flow will surface its own.
+			// eslint-disable-next-line no-console
+			console.error( error );
+		} finally {
+			setIsSavingSharedForm( false );
+		}
+	}, [ saveEntityRecord, replaceBlocks, clientId, sharedFormTitle, jetpackFormsPatternCategory ] );
 
 	const currentInnerBlocks = useSelect(
 		select => select( blockEditorStore ).getBlocks( clientId ),
@@ -832,6 +908,60 @@ function JetpackContactFormEdit( {
 					{ variationName === 'multistep' && <StepControls formClientId={ clientId } /> }
 				</BlockControls>
 				<InspectorControls>
+					<PanelBody
+						title={ __( 'Shared form', 'jetpack-forms' ) }
+						initialOpen={ true }
+						className="jetpack-contact-form__panel jetpack-contact-form__shared-form-panel"
+					>
+						{ isEditingPattern ? (
+							<>
+								<Text as="p" variant="muted">
+									{ __(
+										"You're editing a shared form pattern. Changes here update every place this form is used.",
+										'jetpack-forms'
+									) }
+								</Text>
+								<Button
+									variant="secondary"
+									href={
+										(
+											window as unknown as {
+												jpFormsBlocks?: { defaults?: { formsResponsesUrl?: string } };
+											}
+										 ).jpFormsBlocks?.defaults?.formsResponsesUrl ||
+										'/wp-admin/admin.php?page=jetpack-forms-admin#/forms'
+									}
+									__next40pxDefaultSize={ true }
+									style={ { marginTop: '8px' } }
+								>
+									{ __( 'View forms', 'jetpack-forms' ) }
+								</Button>
+							</>
+						) : (
+							<>
+								<TextControl
+									label={ __( 'Form name', 'jetpack-forms' ) }
+									value={ sharedFormTitle }
+									onChange={ setSharedFormTitle }
+									placeholder={ postTitle }
+									__nextHasNoMarginBottom={ true }
+									__next40pxDefaultSize={ true }
+								/>
+								<Button
+									variant="secondary"
+									onClick={ handleSaveAsSharedForm }
+									disabled={ ! sharedFormTitle || isSavingSharedForm }
+									isBusy={ isSavingSharedForm }
+									__next40pxDefaultSize={ true }
+									style={ { marginTop: '8px' } }
+								>
+									{ isSavingSharedForm
+										? __( 'Saving shared form…', 'jetpack-forms' )
+										: __( 'Save as shared form', 'jetpack-forms' ) }
+								</Button>
+							</>
+						) }
+					</PanelBody>
 					<PanelBody
 						title={ __( 'Action after submit', 'jetpack-forms' ) }
 						initialOpen={ false }

--- a/projects/packages/forms/src/class-jetpack-forms.php
+++ b/projects/packages/forms/src/class-jetpack-forms.php
@@ -9,6 +9,7 @@ namespace Automattic\Jetpack\Forms;
 
 use Automattic\Jetpack\Forms\ContactForm\Util;
 use Automattic\Jetpack\Forms\Dashboard\Dashboard;
+use Automattic\Jetpack\Forms\Dashboard\Forms_Endpoint;
 /**
  * Understands the Jetpack Forms package.
  */
@@ -25,6 +26,7 @@ class Jetpack_Forms {
 		if ( self::is_feedback_dashboard_enabled() ) {
 			$dashboard = new Dashboard();
 			$dashboard->init();
+			Forms_Endpoint::init();
 		}
 
 		if ( is_admin() && apply_filters_deprecated( 'tmp_grunion_allow_editor_view', array( true ), '0.30.5', '', 'This functionality will be removed in an upcoming version.' ) ) {
@@ -32,6 +34,14 @@ class Jetpack_Forms {
 		}
 
 		add_action( 'init', '\Automattic\Jetpack\Forms\ContactForm\Util::register_pattern' );
+
+		// Add editor affordances when editing Jetpack Forms patterns.
+		if ( is_admin() ) {
+			add_action(
+				'enqueue_block_editor_assets',
+				array( '\Automattic\Jetpack\Extensions\Contact_Form\Contact_Form_Block', 'add_pattern_editor_back_link' )
+			);
+		}
 
 		// Add hook to delete file attachments when a feedback post is deleted
 		add_action( 'before_delete_post', array( '\Automattic\Jetpack\Forms\ContactForm\Contact_Form', 'delete_feedback_files' ) );

--- a/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
@@ -940,6 +940,17 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 			$args['comment_status'] = $request['is_unread'] ? Feedback::STATUS_UNREAD : Feedback::STATUS_READ;
 		}
 
+		if ( isset( $request['form_id'] ) && '' !== $request['form_id'] ) {
+			$meta_query = isset( $args['meta_query'] ) && is_array( $args['meta_query'] ) ? $args['meta_query'] : array();
+
+			$meta_query[] = array(
+				'key'   => '_jetpack_form_id',
+				'value' => sanitize_text_field( wp_unslash( $request['form_id'] ) ),
+			);
+
+			$args['meta_query'] = $meta_query;
+		}
+
 		return $args;
 	}
 
@@ -985,6 +996,12 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 			'sanitize_callback' => function ( $param ) {
 				return array_map( 'absint', (array) $param );
 			},
+			'validate_callback' => 'rest_validate_request_arg',
+		);
+		$query_params['form_id']        = array(
+			'description'       => __( 'Limit result set to items submitted to a specific form.', 'jetpack-forms' ),
+			'type'              => 'string',
+			'sanitize_callback' => 'sanitize_text_field',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		return $query_params;

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -3006,7 +3006,7 @@ class Contact_Form_Plugin {
 	}
 
 	/**
-	 * Create a new page with a Form block
+	 * Create a new shared form as a synced pattern containing a Form block.
 	 */
 	public function create_new_form() {
 		if ( ! isset( $_POST['newFormNonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['newFormNonce'] ) ), 'create_new_form' ) ) {
@@ -3030,18 +3030,20 @@ class Contact_Form_Plugin {
 			$pattern_content = $pattern['content'];
 		}
 
-		// If no pattern found or specified, use a default form block
+		// If no pattern found or specified, use a default form block.
 		if ( empty( $pattern_content ) ) {
 			$pattern_content = '<!-- wp:jetpack/contact-form -->
 														<div class="wp-block-jetpack-contact-form"></div>
 													<!-- /wp:jetpack/contact-form -->';
 		}
 
+		// Create a synced pattern (reusable block) that represents the shared form.
 		$post_id = wp_insert_post(
 			array(
-				'post_type'    => 'page',
-				'post_title'   => esc_html__( 'Jetpack Forms', 'jetpack-forms' ),
+				'post_type'    => 'wp_block',
+				'post_title'   => esc_html__( 'Jetpack Form', 'jetpack-forms' ),
 				'post_content' => $pattern_content,
+				'post_status'  => 'publish',
 			)
 		);
 
@@ -3051,9 +3053,66 @@ class Contact_Form_Plugin {
 				500
 			);
 		} else {
+			// Assign the Jetpack Forms pattern category if the taxonomy exists.
+			if ( taxonomy_exists( 'wp_pattern_category' ) ) {
+				wp_set_object_terms( $post_id, 'jetpack-forms', 'wp_pattern_category', true );
+			}
+
+			// Ensure the pattern content includes a stable jetpackFormId attribute so
+			// responses can be grouped by this shared form across all placements.
+			if ( ! is_wp_error( $post_id ) ) {
+				$pattern_post = get_post( $post_id );
+				if ( $pattern_post && ! empty( $pattern_post->post_content ) ) {
+					$blocks     = parse_blocks( $pattern_post->post_content );
+					$form_id    = (string) $post_id;
+					$updated    = false;
+					$update_ids = function ( &$block ) use ( $form_id, &$update_ids, &$updated ) {
+						if ( isset( $block['blockName'] ) && 'jetpack/contact-form' === $block['blockName'] ) {
+							if ( ! isset( $block['attrs'] ) || ! is_array( $block['attrs'] ) ) {
+								$block['attrs'] = array();
+							}
+							if ( empty( $block['attrs']['jetpackFormId'] ) ) {
+								$block['attrs']['jetpackFormId'] = $form_id;
+								$updated                         = true;
+							}
+						}
+						if ( ! empty( $block['innerBlocks'] ) && is_array( $block['innerBlocks'] ) ) {
+							foreach ( $block['innerBlocks'] as &$inner_block ) {
+								$update_ids( $inner_block );
+							}
+						}
+					};
+
+					foreach ( $blocks as &$block ) {
+						$update_ids( $block );
+					}
+
+					if ( $updated ) {
+						$new_content = serialize_blocks( $blocks );
+						wp_update_post(
+							array(
+								'ID'           => $post_id,
+								'post_content' => $new_content,
+							)
+						);
+					}
+				}
+			}
+
+			$edit_url = admin_url(
+				add_query_arg(
+					array(
+						'post'      => (int) $post_id,
+						'action'    => 'edit',
+						'post_type' => 'wp_block',
+					),
+					'post.php'
+				)
+			);
+
 			wp_send_json(
 				array(
-					'post_url' => admin_url( 'post.php?post=' . intval( $post_id ) . '&action=edit' ),
+					'post_url' => $edit_url,
 				)
 			);
 		}

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -217,6 +217,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 			'disableGoBack'          => $attributes['disableGoBack'] ?? false,
 			'disableSummary'         => $attributes['disableSummary'] ?? false,
 			'formTitle'              => $attributes['formTitle'] ?? '',
+			'jetpackFormId'          => $attributes['jetpackFormId'] ?? null,
 		);
 
 		$attributes = shortcode_atts( $this->defaults, $attributes, 'contact-form' );
@@ -1098,6 +1099,12 @@ class Contact_Form extends Contact_Form_Shortcode {
 				$r .= '<input type="submit" style="display: none;" />';
 			}
 			$r .= "<input type='hidden' name='jetpack_contact_form_jwt' value='" . esc_attr( $form->get_jwt() ) . "' />\n";
+
+			$jetpack_form_id = $form->get_attribute( 'jetpackFormId' );
+			if ( ! empty( $jetpack_form_id ) ) {
+				$r .= "<input type='hidden' name='_jetpack_form_id' value='" . esc_attr( $jetpack_form_id ) . "' />\n";
+			}
+
 			$r .= $form->body;
 
 			if ( $is_multistep ) {

--- a/projects/packages/forms/src/contact-form/class-feedback.php
+++ b/projects/packages/forms/src/contact-form/class-feedback.php
@@ -169,6 +169,16 @@ class Feedback {
 	protected $source;
 
 	/**
+	 * The logical form identifier associated with this feedback entry.
+	 *
+	 * This value is intended to be a stable identifier for a given form definition,
+	 * regardless of where that form is embedded (e.g. synced patterns, inline forms).
+	 *
+	 * @var string|null
+	 */
+	protected $form_id = null;
+
+	/**
 	 * The notification recipients of the feedback entry.
 	 *
 	 * @var array
@@ -223,8 +233,9 @@ class Feedback {
 		$this->feedback_time      = $feedback_post->post_date;
 		$this->is_unread          = $feedback_post->comment_status === self::STATUS_UNREAD;
 
-		$this->fields = $parsed_content['fields'] ?? array();
-		$source_id    = $feedback_post->post_parent ? (int) $feedback_post->post_parent : 0;
+		$this->fields  = $parsed_content['fields'] ?? array();
+		$this->form_id = $parsed_content['form_id'] ?? null;
+		$source_id     = $feedback_post->post_parent ? (int) $feedback_post->post_parent : 0;
 
 		$this->source = new Feedback_Source(
 			$parsed_content['source_id'] ?? $source_id,
@@ -291,6 +302,11 @@ class Feedback {
 	private function load_from_submission( $post_data, $form, $current_post = null, $current_page_number = 1 ) {
 
 		$this->source = Feedback_Source::from_submission( $current_post, $current_page_number );
+
+		if ( isset( $post_data['_jetpack_form_id'] ) ) {
+			$this->form_id = sanitize_text_field( wp_unslash( $post_data['_jetpack_form_id'] ) );
+		}
+
 		// If post_data is provided, use it to populate fields.
 		$this->fields          = $this->get_computed_fields( $post_data, $form );
 		$this->ip_address      = Contact_Form_Plugin::get_ip_address();
@@ -998,6 +1014,15 @@ class Feedback {
 	}
 
 	/**
+	 * Get the logical form identifier associated with this feedback entry.
+	 *
+	 * @return string|null
+	 */
+	public function get_form_id() {
+		return $this->form_id;
+	}
+
+	/**
 	 * Gets the notification recipients of the feedback entry.
 	 *
 	 * @return array
@@ -1225,6 +1250,10 @@ class Feedback {
 			)
 		);
 
+		if ( ! is_wp_error( $post_id ) && $post_id && ! empty( $this->form_id ) ) {
+			update_post_meta( $post_id, '_jetpack_form_id', $this->form_id );
+		}
+
 		$feedback_post = get_post( $post_id );
 		return $feedback_post ?? 0;
 	}
@@ -1239,6 +1268,7 @@ class Feedback {
 		$fields_to_serialize = array_merge(
 			array(
 				'subject'                 => $this->subject,
+				'form_id'                 => $this->form_id,
 				'ip'                      => $this->ip_address,
 				'country_code'            => $this->country_code,
 				'user_agent'              => $this->user_agent,

--- a/projects/packages/forms/src/contact-form/class-util.php
+++ b/projects/packages/forms/src/contact-form/class-util.php
@@ -46,6 +46,17 @@ class Util {
 		$category_slug = 'forms';
 		register_block_pattern_category( $category_slug, array( 'label' => __( 'Forms', 'jetpack-forms' ) ) );
 
+		// Category for synced patterns (shared forms) managed via the Jetpack Forms dashboard.
+		if ( function_exists( 'register_block_pattern_category' ) ) {
+			register_block_pattern_category(
+				'jetpack-forms',
+				array(
+					/* translators: Block pattern category name. */
+					'label' => __( 'Jetpack Forms', 'jetpack-forms' ),
+				)
+			);
+		}
+
 		$patterns = array(
 			'contact-form'         => array(
 				'title'      => __( 'Contact Form', 'jetpack-forms' ),

--- a/projects/packages/forms/src/dashboard/class-dashboard.php
+++ b/projects/packages/forms/src/dashboard/class-dashboard.php
@@ -11,6 +11,11 @@ use Automattic\Jetpack\Admin_UI\Admin_Menu;
 use Automattic\Jetpack\Assets;
 use Automattic\Jetpack\Connection\Initial_State as Connection_Initial_State;
 use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin;
+
+// Ensure the Forms_Endpoint class is available even before Composer's classmap is regenerated.
+if ( ! class_exists( Forms_Endpoint::class ) ) {
+	require_once __DIR__ . '/class-forms-endpoint.php';
+}
 use Automattic\Jetpack\Tracking;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -109,6 +114,7 @@ class Dashboard {
 			$filters_locale_path,
 			$initial_responses_path,
 			$initial_responses_locale_path,
+			'/jetpack-forms/v1/forms',
 		);
 		$preload_data_raw              = array_reduce( $preload_paths, 'rest_preload_api_request', array() );
 

--- a/projects/packages/forms/src/dashboard/class-forms-endpoint.php
+++ b/projects/packages/forms/src/dashboard/class-forms-endpoint.php
@@ -1,0 +1,264 @@
+<?php
+/**
+ * REST endpoints for Jetpack Forms dashboard (Forms list and stats).
+ *
+ * @package automattic/jetpack-forms
+ */
+
+namespace Automattic\Jetpack\Forms\Dashboard;
+
+use Automattic\Jetpack\Forms\ContactForm\Feedback;
+use WP_Query;
+use WP_REST_Request;
+use WP_REST_Response;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
+/**
+ * Class Forms_Endpoint
+ *
+ * Provides custom REST API endpoints for the Jetpack Forms dashboard.
+ */
+class Forms_Endpoint {
+
+	const REST_NAMESPACE = 'jetpack-forms/v1';
+
+	/**
+	 * Initialize the REST API endpoints.
+	 *
+	 * @return void
+	 */
+	public static function init() {
+		add_action(
+			'rest_api_init',
+			array( __CLASS__, 'register_routes' )
+		);
+	}
+
+	/**
+	 * Registers REST API routes.
+	 *
+	 * @return void
+	 */
+	public static function register_routes() {
+		register_rest_route(
+			self::REST_NAMESPACE,
+			'/forms',
+			array(
+				'methods'             => \WP_REST_Server::READABLE,
+				'callback'            => array( __CLASS__, 'get_forms' ),
+				'permission_callback' => array( __CLASS__, 'permissions_check' ),
+				'args'                => array(
+					'page'     => array(
+						'type'              => 'integer',
+						'default'           => 1,
+						'sanitize_callback' => 'absint',
+					),
+					'per_page' => array(
+						'type'              => 'integer',
+						'default'           => 20,
+						'sanitize_callback' => 'absint',
+					),
+					'search'   => array(
+						'type'              => 'string',
+						'required'          => false,
+						'sanitize_callback' => 'sanitize_text_field',
+					),
+				),
+			)
+		);
+
+		register_rest_route(
+			self::REST_NAMESPACE,
+			'/forms/(?P<form_id>[A-Za-z0-9_-]+)/stats',
+			array(
+				'methods'             => \WP_REST_Server::READABLE,
+				'callback'            => array( __CLASS__, 'get_form_stats' ),
+				'permission_callback' => array( __CLASS__, 'permissions_check' ),
+				'args'                => array(
+					'form_id' => array(
+						'type'              => 'string',
+						'required'          => true,
+						'sanitize_callback' => 'sanitize_text_field',
+					),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Basic permissions check for Forms dashboard routes.
+	 *
+	 * @return bool
+	 */
+	public static function permissions_check() {
+		return current_user_can( 'edit_pages' );
+	}
+
+	/**
+	 * Returns a paginated list of synced patterns used as managed forms.
+	 *
+	 * @param WP_REST_Request $request The REST request.
+	 *
+	 * @return WP_REST_Response
+	 */
+	public static function get_forms( WP_REST_Request $request ) {
+		$page     = max( 1, (int) $request->get_param( 'page' ) );
+		$per_page = max( 1, min( 100, (int) $request->get_param( 'per_page' ) ) );
+		$search   = $request->get_param( 'search' );
+
+		$args = array(
+			'post_type'      => 'wp_block',
+			'post_status'    => 'publish',
+			'posts_per_page' => $per_page,
+			'paged'          => $page,
+			'orderby'        => 'modified',
+			'order'          => 'DESC',
+			'tax_query'      => array(
+				array(
+					'taxonomy' => 'wp_pattern_category',
+					'field'    => 'slug',
+					'terms'    => 'jetpack-forms',
+				),
+			),
+		);
+
+		if ( ! empty( $search ) ) {
+			$args['s'] = $search;
+		}
+
+		$query = new WP_Query( $args );
+
+		$items = array();
+
+		foreach ( $query->posts as $post ) {
+			// Determine the canonical form_id for this shared form by inspecting the pattern content.
+			$form_id = null;
+			$blocks  = parse_blocks( $post->post_content );
+
+			$find_form_id = function ( $block ) use ( &$find_form_id, &$form_id ) {
+				if ( isset( $block['blockName'] ) && 'jetpack/contact-form' === $block['blockName'] ) {
+					if ( ! empty( $block['attrs']['jetpackFormId'] ) && is_string( $block['attrs']['jetpackFormId'] ) ) {
+						$form_id = $block['attrs']['jetpackFormId'];
+						return;
+					}
+				}
+				if ( ! empty( $block['innerBlocks'] ) && is_array( $block['innerBlocks'] ) ) {
+					foreach ( $block['innerBlocks'] as $inner_block ) {
+						if ( null === $form_id ) {
+							$find_form_id( $inner_block );
+						}
+					}
+				}
+			};
+
+			foreach ( $blocks as $block ) {
+				if ( null !== $form_id ) {
+					break;
+				}
+				$find_form_id( $block );
+			}
+
+			// Fallback to the wp_block ID if no form_id attribute is found.
+			if ( null === $form_id ) {
+				$form_id = (string) $post->ID;
+			}
+
+			// Count responses associated with this form (via form_id meta).
+			$responses_query = new WP_Query(
+				array(
+					'post_type'      => Feedback::POST_TYPE,
+					'post_status'    => array( 'publish', 'draft', 'spam', 'trash', 'jp-temp-feedback' ),
+					'posts_per_page' => 1,
+					'fields'         => 'ids',
+					'meta_query'     => array(
+						array(
+							'key'   => '_jetpack_form_id',
+							'value' => $form_id,
+						),
+					),
+				)
+			);
+
+			$items[] = array(
+				'id'             => $post->ID,
+				'title'          => get_the_title( $post ),
+				'modified'       => $post->post_modified,
+				'formId'         => $form_id,
+				'responsesCount' => (int) $responses_query->found_posts,
+			);
+		}
+
+		$response = array(
+			'items'       => $items,
+			'totalItems'  => (int) $query->found_posts,
+			'totalPages'  => (int) $query->max_num_pages,
+			'currentPage' => $page,
+		);
+
+		return rest_ensure_response( $response );
+	}
+
+	/**
+	 * Returns basic statistics for a given form, based on stored feedback entries.
+	 *
+	 * @param WP_REST_Request $request The REST request.
+	 *
+	 * @return WP_REST_Response
+	 */
+	public static function get_form_stats( WP_REST_Request $request ) {
+		$form_id = $request->get_param( 'form_id' );
+
+		if ( empty( $form_id ) ) {
+			return new WP_REST_Response(
+				array(
+					'message' => __( 'Missing form_id parameter.', 'jetpack-forms' ),
+				),
+				400
+			);
+		}
+
+		$form_id = sanitize_text_field( wp_unslash( $form_id ) );
+
+		$base_args = array(
+			'post_type'      => Feedback::POST_TYPE,
+			'post_status'    => array( 'publish', 'draft', 'spam', 'trash', 'jp-temp-feedback' ),
+			'posts_per_page' => 1,
+			'fields'         => 'ids',
+			'meta_query'     => array(
+				array(
+					'key'   => '_jetpack_form_id',
+					'value' => $form_id,
+				),
+			),
+		);
+
+		$total_query = new WP_Query( $base_args );
+		$total       = (int) $total_query->found_posts;
+
+		$last_7_days_query = new WP_Query(
+			array_merge(
+				$base_args,
+				array(
+					'date_query' => array(
+						array(
+							'column' => 'post_date_gmt',
+							'after'  => '7 days ago',
+						),
+					),
+				)
+			)
+		);
+
+		$last_7_days = (int) $last_7_days_query->found_posts;
+
+		$stats = array(
+			'total_responses'       => $total,
+			'responses_last_7_days' => $last_7_days,
+		);
+
+		return rest_ensure_response( $stats );
+	}
+}

--- a/projects/packages/forms/src/dashboard/components/empty-forms/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/empty-forms/index.tsx
@@ -1,0 +1,23 @@
+import { __ } from '@wordpress/i18n';
+/**
+ * Internal dependencies
+ */
+import CreateFormButton from '../create-form-button/index.tsx';
+import { EmptyWrapper } from '../empty-responses/index.tsx';
+
+const EmptyForms = () => {
+	return (
+		<EmptyWrapper
+			heading={ __( "You're set up. No forms yet.", 'jetpack-forms' ) }
+			body={ __(
+				'Create a shared form pattern to manage and reuse it across your site.',
+				'jetpack-forms'
+			) }
+			actions={
+				<CreateFormButton label={ __( 'Create a new form', 'jetpack-forms' ) } variant="primary" />
+			}
+		/>
+	);
+};
+
+export default EmptyForms;

--- a/projects/packages/forms/src/dashboard/components/empty-responses/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/empty-responses/index.tsx
@@ -6,7 +6,7 @@ import { __, _n, sprintf } from '@wordpress/i18n';
 import useConfigValue from '../../../hooks/use-config-value.ts';
 import CreateFormButton from '../create-form-button/index.tsx';
 
-const EmptyWrapper = ( { heading = '', body = '', actions = null } ) => (
+export const EmptyWrapper = ( { heading = '', body = '', actions = null } ) => (
 	<VStack alignment="center" spacing="2">
 		{ heading && (
 			<Text as="h3" weight="500" size="15">

--- a/projects/packages/forms/src/dashboard/components/forms-stats-sidebar/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/forms-stats-sidebar/index.tsx
@@ -1,0 +1,95 @@
+import apiFetch from '@wordpress/api-fetch';
+import { useEffect, useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import Page from '../../components/page/index.tsx';
+
+type FormStats = {
+	total_responses: number;
+	responses_last_7_days: number;
+};
+
+type Props = {
+	formId: string;
+	isOpen: boolean;
+	onClose: () => void;
+};
+
+/**
+ * Sidebar component to display basic stats for a single form.
+ *
+ * @param {Props} props - Component props.
+ * @return {JSX.Element | null} Sidebar content.
+ */
+export default function FormsStatsSidebar( { formId, isOpen, onClose }: Props ) {
+	const [ stats, setStats ] = useState< FormStats | null >( null );
+	const [ isLoading, setIsLoading ] = useState( false );
+
+	useEffect( () => {
+		if ( ! isOpen || ! formId ) {
+			return;
+		}
+
+		let isMounted = true;
+
+		setIsLoading( true );
+
+		apiFetch< FormStats >( {
+			path: `/jetpack-forms/v1/forms/${ encodeURIComponent( formId ) }/stats`,
+		} )
+			.then( response => {
+				if ( ! isMounted ) {
+					return;
+				}
+				setStats( response );
+				setIsLoading( false );
+			} )
+			.catch( () => {
+				if ( ! isMounted ) {
+					return;
+				}
+				setStats( null );
+				setIsLoading( false );
+			} );
+
+		return () => {
+			isMounted = false;
+		};
+	}, [ formId, isOpen ] );
+
+	if ( ! isOpen ) {
+		return null;
+	}
+
+	return (
+		<div className="jp-forms-layout__surface is-inspector">
+			<Page
+				showSidebarToggle={ false }
+				hasPadding={ true }
+				title={ __( 'Form stats', 'jetpack-forms' ) }
+				subTitle=""
+				actions={
+					<button type="button" onClick={ onClose } className="button button-link">
+						{ __( 'Close', 'jetpack-forms' ) }
+					</button>
+				}
+			>
+				{ isLoading && <p>{ __( 'Loading stats…', 'jetpack-forms' ) }</p> }
+				{ ! isLoading && stats && (
+					<ul className="jp-forms-stats-list">
+						<li>
+							<strong>{ __( 'Total submissions', 'jetpack-forms' ) }:</strong>{ ' ' }
+							{ stats.total_responses }
+						</li>
+						<li>
+							<strong>{ __( 'Last 7 days', 'jetpack-forms' ) }:</strong>{ ' ' }
+							{ stats.responses_last_7_days }
+						</li>
+					</ul>
+				) }
+				{ ! isLoading && ! stats && (
+					<p>{ __( 'No stats available for this form yet.', 'jetpack-forms' ) }</p>
+				) }
+			</Page>
+		</div>
+	);
+}

--- a/projects/packages/forms/src/dashboard/components/forms-view-toggle-button/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/forms-view-toggle-button/index.tsx
@@ -1,0 +1,40 @@
+import { Button } from '@wordpress/components';
+import { useCallback, useMemo } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { useLocation, useNavigate } from 'react-router';
+
+/**
+ * Header button to toggle between Forms list and Responses inbox.
+ *
+ * The label and target route depend on the current location.
+ *
+ * @return {JSX.Element} Toggle button component.
+ */
+export default function FormsViewToggleButton(): JSX.Element {
+	const location = useLocation();
+	const navigate = useNavigate();
+
+	const { label, target } = useMemo( () => {
+		const isFormsRoute = location.pathname === '/forms';
+
+		return isFormsRoute
+			? {
+					label: __( 'View responses', 'jetpack-forms' ),
+					target: '/responses',
+			  }
+			: {
+					label: __( 'View forms', 'jetpack-forms' ),
+					target: '/forms',
+			  };
+	}, [ location.pathname ] );
+
+	const handleClick = useCallback( () => {
+		navigate( target );
+	}, [ navigate, target ] );
+
+	return (
+		<Button size="compact" variant="primary" onClick={ handleClick }>
+			{ label }
+		</Button>
+	);
+}

--- a/projects/packages/forms/src/dashboard/forms/index.tsx
+++ b/projects/packages/forms/src/dashboard/forms/index.tsx
@@ -1,0 +1,2 @@
+import './style.scss';
+export { default } from './stage/index.tsx';

--- a/projects/packages/forms/src/dashboard/forms/stage/index.tsx
+++ b/projects/packages/forms/src/dashboard/forms/stage/index.tsx
@@ -15,7 +15,6 @@ import useFormsData from '../../hooks/use-forms-data.ts';
 import { defaultLayouts, useView } from '../views.ts';
 
 const EMPTY_ARRAY: never[] = [];
-const MOBILE_BREAKPOINT = 780;
 
 /**
  * Forms list DataViews implementation.
@@ -25,7 +24,6 @@ const MOBILE_BREAKPOINT = 780;
 export default function FormsStage() {
 	const [ view, setView ] = useView();
 	const dateSettings = getDateSettings();
-	const [ containerWidth, setContainerWidth ] = useState( 0 );
 	const [ selectedFormId, setSelectedFormId ] = useState< string | null >( null );
 	const navigate = useNavigate();
 	const enableIntegrationsTab = useConfigValue( 'isIntegrationsEnabled' );
@@ -116,8 +114,12 @@ export default function FormsStage() {
 		[ totalItems, totalPages ]
 	);
 
+	// The admin-ui DataViews View type does not exactly match our lightweight
+	// view shape used for the Forms list, so we keep the runtime behavior but
+	// relax the TypeScript typing here for this spike.
 	const onChangeView = useCallback(
-		( newView: typeof view ) => {
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		( newView: any ) => {
 			setView( newView );
 		},
 		[ setView ]
@@ -137,14 +139,12 @@ export default function FormsStage() {
 
 	const getItemId = useCallback( ( item: { id: number } ) => String( item.id ), [] );
 
-	const handleResize = useCallback( ( width: number ) => setContainerWidth( width ), [] );
-
 	const pageContent = (
 		<Page
 			title={
 				<div className="jp-forms-page-header-title">
 					<JetpackLogo showText={ false } width={ 20 } />
-					{ __( 'Forms > View Forms', 'jetpack-forms' ) }
+					{ __( 'Forms', 'jetpack-forms' ) }
 				</div>
 			}
 			subTitle={ __( 'Below is a list of all your re-usable forms', 'jetpack-forms' ) }
@@ -157,18 +157,22 @@ export default function FormsStage() {
 				data={ records || EMPTY_ARRAY }
 				isLoading={ isLoading }
 				empty={ <EmptyForms /> }
-				view={ view }
+				// The admin-ui DataViews typing currently expects a more specific View
+				// shape (e.g. activity views). Our forms view matches the inbox view
+				// structure used elsewhere but doesn't align perfectly with those TS
+				// unions, so we cast here for this spike implementation.
+				// eslint-disable-next-line @typescript-eslint/no-explicit-any
+				view={ view as any }
 				onChangeView={ onChangeView }
 				getItemId={ getItemId }
 				defaultLayouts={ defaultLayouts }
-				onResize={ handleResize }
 			>
 				<div className="jp-forms-view-actions">
 					<div
 						style={ {
 							display: 'flex',
 							gap: '8px',
-							justifyContent: containerWidth < MOBILE_BREAKPOINT ? 'space-between' : 'flex-end',
+							justifyContent: 'flex-end',
 						} }
 					>
 						<DataViews.Search />

--- a/projects/packages/forms/src/dashboard/forms/stage/index.tsx
+++ b/projects/packages/forms/src/dashboard/forms/stage/index.tsx
@@ -1,0 +1,196 @@
+import { JetpackLogo } from '@automattic/jetpack-components';
+import { DataViews } from '@wordpress/dataviews/wp';
+import { dateI18n, getSettings as getDateSettings } from '@wordpress/date';
+import { useCallback, useMemo, useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { useNavigate } from 'react-router';
+import useConfigValue from '../../../hooks/use-config-value.ts';
+import CreateFormButton from '../../components/create-form-button/index.tsx';
+import EmptyForms from '../../components/empty-forms/index.tsx';
+import FormsStatsSidebar from '../../components/forms-stats-sidebar/index.tsx';
+import FormsViewToggleButton from '../../components/forms-view-toggle-button/index.tsx';
+import IntegrationsButton from '../../components/integrations-button/index.tsx';
+import Page from '../../components/page/index.tsx';
+import useFormsData from '../../hooks/use-forms-data.ts';
+import { defaultLayouts, useView } from '../views.ts';
+
+const EMPTY_ARRAY: never[] = [];
+const MOBILE_BREAKPOINT = 780;
+
+/**
+ * Forms list DataViews implementation.
+ *
+ * @return {import('react').JSX.Element} The DataViews component for Forms.
+ */
+export default function FormsStage() {
+	const [ view, setView ] = useView();
+	const dateSettings = getDateSettings();
+	const [ containerWidth, setContainerWidth ] = useState( 0 );
+	const [ selectedFormId, setSelectedFormId ] = useState< string | null >( null );
+	const navigate = useNavigate();
+	const enableIntegrationsTab = useConfigValue( 'isIntegrationsEnabled' );
+
+	const { records, isLoading, totalItems, totalPages } = useFormsData(
+		view.page,
+		view.perPage,
+		view.search
+	);
+
+	const handleOpenStats = useCallback(
+		( formId: string ) => () => setSelectedFormId( formId ),
+		[]
+	);
+
+	const handleViewResponses = useCallback(
+		( formId: string ) => () => navigate( `/responses?form_id=${ encodeURIComponent( formId ) }` ),
+		[ navigate ]
+	);
+
+	const fields = useMemo(
+		() => [
+			{
+				id: 'title',
+				label: __( 'Form', 'jetpack-forms' ),
+				getValue: ( { item } ) => item.title,
+				render: ( { item } ) => (
+					<button
+						type="button"
+						className="jp-forms-forms-title-button button-link"
+						onClick={ handleOpenStats( item.formId ) }
+					>
+						{ item.title || __( '(no title)', 'jetpack-forms' ) }
+					</button>
+				),
+				enableSorting: false,
+				enableHiding: false,
+			},
+			{
+				id: 'modified',
+				label: __( 'Last modified', 'jetpack-forms' ),
+				render: ( { item } ) => dateI18n( dateSettings.formats.datetime, item.modified ),
+				enableSorting: false,
+			},
+			{
+				id: 'responses',
+				label: __( 'Responses', 'jetpack-forms' ),
+				getValue: ( { item } ) => item.responsesCount ?? 0,
+				render: ( { item } ) => item.responsesCount ?? 0,
+				enableSorting: false,
+			},
+			{
+				id: 'actions',
+				label: __( 'Actions', 'jetpack-forms' ),
+				enableSorting: false,
+				render: ( { item } ) => {
+					const editUrl = `post.php?post=${ item.id }&action=edit&post_type=wp_block`;
+
+					return (
+						<div className="jp-forms-forms-actions">
+							<a href={ editUrl } className="jp-forms-forms-actions__link">
+								{ __( 'Edit form', 'jetpack-forms' ) }
+							</a>
+							<button
+								type="button"
+								className="jp-forms-forms-actions__link button-link"
+								onClick={ handleViewResponses( item.formId ) }
+							>
+								{ __( 'View responses', 'jetpack-forms' ) }
+							</button>
+							<button
+								type="button"
+								className="jp-forms-forms-actions__link button-link"
+								onClick={ handleOpenStats( item.formId ) }
+							>
+								{ __( 'View stats', 'jetpack-forms' ) }
+							</button>
+						</div>
+					);
+				},
+			},
+		],
+		[ dateSettings.formats.datetime, handleOpenStats, handleViewResponses ]
+	);
+
+	const paginationInfo = useMemo(
+		() => ( { totalItems, totalPages } ),
+		[ totalItems, totalPages ]
+	);
+
+	const onChangeView = useCallback(
+		( newView: typeof view ) => {
+			setView( newView );
+		},
+		[ setView ]
+	);
+
+	const headerActions = useMemo( () => {
+		const actions = [ <FormsViewToggleButton key="toggle-view" /> ];
+
+		if ( enableIntegrationsTab ) {
+			actions.push( <IntegrationsButton key="integrations" /> );
+		}
+
+		actions.push( <CreateFormButton key="create" /> );
+
+		return actions;
+	}, [ enableIntegrationsTab ] );
+
+	const getItemId = useCallback( ( item: { id: number } ) => String( item.id ), [] );
+
+	const handleResize = useCallback( ( width: number ) => setContainerWidth( width ), [] );
+
+	const pageContent = (
+		<Page
+			title={
+				<div className="jp-forms-page-header-title">
+					<JetpackLogo showText={ false } width={ 20 } />
+					{ __( 'Forms', 'jetpack-forms' ) }
+				</div>
+			}
+			subTitle={ __( 'Manage your shared forms in one place.', 'jetpack-forms' ) }
+			actions={ headerActions }
+			hasPadding={ false }
+		>
+			<DataViews
+				paginationInfo={ paginationInfo }
+				fields={ fields }
+				data={ records || EMPTY_ARRAY }
+				isLoading={ isLoading }
+				empty={ <EmptyForms /> }
+				view={ view }
+				onChangeView={ onChangeView }
+				getItemId={ getItemId }
+				defaultLayouts={ defaultLayouts }
+				onResize={ handleResize }
+			>
+				<div className="jp-forms-view-actions">
+					<div
+						style={ {
+							display: 'flex',
+							gap: '8px',
+							justifyContent: containerWidth < MOBILE_BREAKPOINT ? 'space-between' : 'flex-end',
+						} }
+					>
+						<DataViews.Search />
+						<DataViews.ViewConfig />
+					</div>
+				</div>
+				<div className="jp-forms-dataviews-layout-container">
+					<DataViews.Layout />
+					<DataViews.Footer />
+				</div>
+			</DataViews>
+		</Page>
+	);
+
+	return (
+		<>
+			<div className="jp-forms-layout__surface is-stage is-forms-stage">{ pageContent }</div>
+			<FormsStatsSidebar
+				formId={ selectedFormId ?? '' }
+				isOpen={ !! selectedFormId }
+				onClose={ handleOpenStats( '' ) }
+			/>
+		</>
+	);
+}

--- a/projects/packages/forms/src/dashboard/forms/stage/index.tsx
+++ b/projects/packages/forms/src/dashboard/forms/stage/index.tsx
@@ -144,10 +144,10 @@ export default function FormsStage() {
 			title={
 				<div className="jp-forms-page-header-title">
 					<JetpackLogo showText={ false } width={ 20 } />
-					{ __( 'Forms', 'jetpack-forms' ) }
+					{ __( 'Forms > View Forms', 'jetpack-forms' ) }
 				</div>
 			}
-			subTitle={ __( 'Manage your shared forms in one place.', 'jetpack-forms' ) }
+			subTitle={ __( 'Below is a list of all your re-usable forms', 'jetpack-forms' ) }
 			actions={ headerActions }
 			hasPadding={ false }
 		>

--- a/projects/packages/forms/src/dashboard/forms/style.scss
+++ b/projects/packages/forms/src/dashboard/forms/style.scss
@@ -1,0 +1,26 @@
+.jp-forms-layout__surface.is-stage.is-forms-stage {
+
+	.jp-forms-view-actions {
+		display: flex;
+		justify-content: flex-end;
+		padding: 16px 24px 0;
+	}
+
+	.jp-forms-dataviews-layout-container {
+		display: flex;
+		flex-direction: column;
+		padding: 0 24px 24px;
+	}
+
+	.jp-forms-forms-actions {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 8px;
+		justify-content: flex-end;
+	}
+
+	.jp-forms-forms-actions__link {
+		font-size: 12px;
+	}
+}
+

--- a/projects/packages/forms/src/dashboard/forms/style.scss
+++ b/projects/packages/forms/src/dashboard/forms/style.scss
@@ -22,5 +22,22 @@
 	.jp-forms-forms-actions__link {
 		font-size: 12px;
 	}
+
+	// Adjust column widths in the Forms DataViews table so the Actions column
+	// has more space, especially when the inspector sidebar is open.
+	.dataviews-view-table__row {
+		// Narrow the Responses column (3rd column).
+		td:nth-child(3) {
+			width: 80px;
+			max-width: 80px;
+			text-align: right;
+		}
+
+		// Give the Actions column (4th column) a minimum width so its links
+		// have more room before wrapping.
+		td:nth-child(4) {
+			min-width: 220px;
+		}
+	}
 }
 

--- a/projects/packages/forms/src/dashboard/forms/style.scss
+++ b/projects/packages/forms/src/dashboard/forms/style.scss
@@ -3,13 +3,13 @@
 	.jp-forms-view-actions {
 		display: flex;
 		justify-content: flex-end;
-		padding: 16px 24px 0;
+		padding: 8px 24px;
 	}
 
 	.jp-forms-dataviews-layout-container {
 		display: flex;
 		flex-direction: column;
-		padding: 0 24px 24px;
+		padding: 8px 24px 24px;
 	}
 
 	.jp-forms-forms-actions {

--- a/projects/packages/forms/src/dashboard/forms/views.ts
+++ b/projects/packages/forms/src/dashboard/forms/views.ts
@@ -1,0 +1,70 @@
+/**
+ * WordPress dependencies
+ */
+import { useEvent } from '@wordpress/compose';
+import { useEffect, useState } from '@wordpress/element';
+import { useSearchParams } from 'react-router';
+
+const LAYOUT_TABLE = 'table';
+
+export const defaultView = {
+	type: LAYOUT_TABLE,
+	search: '',
+	page: 1,
+	perPage: 20,
+	fields: [ 'title', 'modified', 'responses', 'actions' ],
+};
+
+export const defaultLayouts = {
+	[ LAYOUT_TABLE ]: {},
+};
+
+/**
+ * Hook to manage view state for the Forms list based on URL parameters.
+ *
+ * Currently only syncs the `search` parameter with the URL.
+ *
+ * @return {[typeof defaultView, ( newView: typeof defaultView ) => void]} The [ state, setState ] tuple.
+ */
+export function useView() {
+	const [ searchParams, setSearchParams ] = useSearchParams();
+	const urlSearch = searchParams.get( 'search' );
+	const [ view, setView ] = useState( () => ( {
+		...defaultView,
+		search: urlSearch ?? '',
+	} ) );
+
+	const setViewWithUrlUpdate = useEvent( newView => {
+		setView( newView );
+		if ( newView.search !== urlSearch ) {
+			setSearchParams( previousSearchParams => {
+				const _searchParams = new URLSearchParams( previousSearchParams );
+				if ( newView.search ) {
+					_searchParams.set( 'search', newView.search );
+				} else {
+					_searchParams.delete( 'search' );
+				}
+				return _searchParams;
+			} );
+		}
+	} );
+
+	const onUrlSearchChange = useEvent( () => {
+		setView( previousView => {
+			const newValue = urlSearch ?? '';
+			if ( newValue === previousView.search ) {
+				return previousView;
+			}
+			return {
+				...previousView,
+				search: newValue,
+			};
+		} );
+	} );
+
+	useEffect( () => {
+		onUrlSearchChange();
+	}, [ onUrlSearchChange, urlSearch ] );
+
+	return [ view, setViewWithUrlUpdate ] as const;
+}

--- a/projects/packages/forms/src/dashboard/forms/views.ts
+++ b/projects/packages/forms/src/dashboard/forms/views.ts
@@ -10,6 +10,7 @@ const LAYOUT_TABLE = 'table';
 export const defaultView = {
 	type: LAYOUT_TABLE,
 	search: '',
+	filters: [],
 	page: 1,
 	perPage: 20,
 	fields: [ 'title', 'modified', 'responses', 'actions' ],

--- a/projects/packages/forms/src/dashboard/hooks/use-forms-data.ts
+++ b/projects/packages/forms/src/dashboard/hooks/use-forms-data.ts
@@ -1,0 +1,91 @@
+/**
+ * External dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+import { useEffect, useState } from '@wordpress/element';
+
+type FormSummary = {
+	id: number;
+	title: string;
+	modified: string;
+	formId: string;
+	responsesCount?: number;
+};
+
+type UseFormsDataReturn = {
+	records: FormSummary[];
+	isLoading: boolean;
+	totalItems: number;
+	totalPages: number;
+};
+
+/**
+ * Fetches and memoizes Forms (synced patterns) data for the Forms dashboard view.
+ *
+ * @param {number} page    - Current page.
+ * @param {number} perPage - Items per page.
+ * @param {string} search  - Search term.
+ *
+ * @return {UseFormsDataReturn} Forms data for the current query.
+ */
+export default function useFormsData(
+	page: number,
+	perPage: number,
+	search: string
+): UseFormsDataReturn {
+	const [ records, setRecords ] = useState< FormSummary[] >( [] );
+	const [ isLoading, setIsLoading ] = useState( false );
+	const [ totalItems, setTotalItems ] = useState( 0 );
+	const [ totalPages, setTotalPages ] = useState( 0 );
+
+	useEffect( () => {
+		let isMounted = true;
+
+		const params = new URLSearchParams();
+		params.set( 'page', String( page ) );
+		params.set( 'per_page', String( perPage ) );
+
+		if ( search ) {
+			params.set( 'search', search );
+		}
+
+		setIsLoading( true );
+
+		apiFetch< {
+			items: FormSummary[];
+			totalItems: number;
+			totalPages: number;
+		} >( {
+			path: `/jetpack-forms/v1/forms?${ params.toString() }`,
+		} )
+			.then( response => {
+				if ( ! isMounted ) {
+					return;
+				}
+				setRecords( response.items || [] );
+				setTotalItems( response.totalItems || 0 );
+				setTotalPages( response.totalPages || 0 );
+				setIsLoading( false );
+			} )
+			.catch( () => {
+				if ( ! isMounted ) {
+					return;
+				}
+				setRecords( [] );
+				setTotalItems( 0 );
+				setTotalPages( 0 );
+				setIsLoading( false );
+			} );
+
+		return () => {
+			isMounted = false;
+		};
+	}, [ page, perPage, search ] );
+
+	return {
+		records,
+		isLoading,
+		totalItems,
+		totalPages,
+	};
+}

--- a/projects/packages/forms/src/dashboard/hooks/use-inbox-data.ts
+++ b/projects/packages/forms/src/dashboard/hooks/use-inbox-data.ts
@@ -214,6 +214,9 @@ export default function useInboxData(): UseInboxDataReturn {
 		if ( currentQuery?.is_unread !== undefined ) {
 			params.is_unread = currentQuery.is_unread;
 		}
+		if ( currentQuery?.form_id ) {
+			params.form_id = currentQuery.form_id;
+		}
 
 		return params;
 	}, [ currentQuery ] );

--- a/projects/packages/forms/src/dashboard/inbox/stage/index.js
+++ b/projects/packages/forms/src/dashboard/inbox/stage/index.js
@@ -532,7 +532,7 @@ export default function InboxView() {
 			title={
 				<div className="jp-forms-page-header-title">
 					<JetpackLogo showText={ false } width={ 20 } />
-					{ __( 'Forms > View Responses', 'jetpack-forms' ) }
+					{ __( 'Form Responses', 'jetpack-forms' ) }
 				</div>
 			}
 			subTitle={ __( 'View and manage all your form submissions in one place.', 'jetpack-forms' ) }

--- a/projects/packages/forms/src/dashboard/inbox/stage/index.js
+++ b/projects/packages/forms/src/dashboard/inbox/stage/index.js
@@ -4,6 +4,7 @@
 import jetpackAnalytics from '@automattic/jetpack-analytics';
 import { JetpackLogo } from '@automattic/jetpack-components';
 import { Badge } from '@automattic/ui';
+import apiFetch from '@wordpress/api-fetch';
 import { ExternalLink, Modal } from '@wordpress/components';
 import { useResizeObserver, useViewportMatch } from '@wordpress/compose';
 import { DataViews } from '@wordpress/dataviews/wp';
@@ -25,6 +26,7 @@ import EmptySpamButton from '../../components/empty-spam-button/index.tsx';
 import EmptyTrashButton from '../../components/empty-trash-button/index.tsx';
 import ExportResponsesButton from '../../components/export-responses/button.tsx';
 import Flag from '../../components/flag/index.tsx';
+import FormsViewToggleButton from '../../components/forms-view-toggle-button/index.tsx';
 import Gravatar from '../../components/gravatar/index.tsx';
 import InboxStatusToggle from '../../components/inbox-status-toggle/index.tsx';
 import { ResponseMobileView, SingleResponseView } from '../../components/inspector/index.tsx';
@@ -138,6 +140,38 @@ export default function InboxView() {
 		totalPages,
 	} = useInboxData();
 
+	const [ formFilterOptions, setFormFilterOptions ] = useState( [] );
+
+	// Fetch Jetpack Forms synced patterns to populate the "Form" filter.
+	useEffect( () => {
+		let isMounted = true;
+
+		apiFetch( {
+			path: '/jetpack-forms/v1/forms?per_page=100',
+		} )
+			.then( response => {
+				if ( ! isMounted ) {
+					return;
+				}
+				const items = response?.items || [];
+				const options = items.map( item => ( {
+					value: item.formId || String( item.id ),
+					label: decodeEntities( item.title ) || __( '(no title)', 'jetpack-forms' ),
+				} ) );
+				setFormFilterOptions( options );
+			} )
+			.catch( () => {
+				if ( ! isMounted ) {
+					return;
+				}
+				setFormFilterOptions( [] );
+			} );
+
+		return () => {
+			isMounted = false;
+		};
+	}, [] );
+
 	useEffect( () => {
 		const _filters = view.filters?.reduce( ( accumulator, { field, value } ) => {
 			if ( ! value ) {
@@ -145,6 +179,9 @@ export default function InboxView() {
 			}
 			if ( field === 'source' ) {
 				accumulator.parent = value;
+			}
+			if ( field === 'form' ) {
+				accumulator.form_id = value;
 			}
 			if ( field === 'date' ) {
 				const [ year, month ] = value.split( '/' ).map( Number );
@@ -156,19 +193,21 @@ export default function InboxView() {
 			}
 			return accumulator;
 		}, {} );
+		const formId = searchParams.get( 'form_id' );
 		const _queryArgs = {
 			order: 'desc',
 			orderby: 'date',
 			per_page: view.perPage,
 			page: view.page,
 			...( view.search ? { search: view.search } : {} ),
+			...( formId ? { form_id: formId } : {} ),
 			..._filters,
 			status: statusFilter,
 		};
 		// We need to keep the current query args in the store to be used in `export`
 		// and for getting the total records per `status`.
 		setCurrentQuery( _queryArgs );
-	}, [ view, statusFilter, setCurrentQuery ] );
+	}, [ view, statusFilter, setCurrentQuery, searchParams ] );
 
 	const selection = selectedResponses?.split( ',' ) || EMPTY_ARRAY;
 
@@ -356,6 +395,13 @@ export default function InboxView() {
 				enableSorting: false,
 			},
 			{
+				id: 'form',
+				label: __( 'Form', 'jetpack-forms' ),
+				elements: formFilterOptions,
+				filterBy: { operators: [ 'is' ] },
+				enableSorting: false,
+			},
+			{
 				id: 'read_status',
 				label: __( 'Status', 'jetpack-forms' ),
 				elements: [
@@ -392,6 +438,7 @@ export default function InboxView() {
 		[
 			filterOptions?.date,
 			filterOptions?.source,
+			formFilterOptions,
 			isMobileViewport,
 			openResponseModal,
 			dateSettings.formats.date,
@@ -460,10 +507,7 @@ export default function InboxView() {
 
 	// Conditional header actions based on status filter
 	const headerActions = useMemo( () => {
-		const exportIsPrimary = statusFilter !== 'trash' && statusFilter !== 'spam';
-		const headerActionsArray = [
-			<ExportResponsesButton key="export" isPrimary={ exportIsPrimary } />,
-		];
+		const headerActionsArray = [ <FormsViewToggleButton key="toggle-view" /> ];
 
 		if ( statusFilter === 'trash' ) {
 			headerActionsArray.push( <EmptyTrashButton key="empty-trash" /> );
@@ -475,7 +519,10 @@ export default function InboxView() {
 			if ( isIntegrationsEnabled && showDashboardIntegrations ) {
 				headerActionsArray.unshift( <IntegrationsButton key="integrations" /> );
 			}
+			headerActionsArray.push( <CreateFormButton key="create" /> );
 		}
+
+		headerActionsArray.push( <ExportResponsesButton key="export" isPrimary={ false } /> );
 
 		return headerActionsArray;
 	}, [ statusFilter, isIntegrationsEnabled, showDashboardIntegrations ] );

--- a/projects/packages/forms/src/dashboard/inbox/stage/index.js
+++ b/projects/packages/forms/src/dashboard/inbox/stage/index.js
@@ -514,10 +514,10 @@ export default function InboxView() {
 		} else if ( statusFilter === 'spam' ) {
 			headerActionsArray.push( <EmptySpamButton key="empty-spam" /> );
 		} else {
-			headerActionsArray.unshift( <CreateFormButton key="create" /> );
+			// headerActionsArray.unshift( <CreateFormButton key="create" /> );
 			// Only show Create Form and Integrations buttons on inbox (when not in trash or spam)
 			if ( isIntegrationsEnabled && showDashboardIntegrations ) {
-				headerActionsArray.unshift( <IntegrationsButton key="integrations" /> );
+				headerActionsArray.push( <IntegrationsButton key="integrations" /> );
 			}
 			headerActionsArray.push( <CreateFormButton key="create" /> );
 		}
@@ -532,7 +532,7 @@ export default function InboxView() {
 			title={
 				<div className="jp-forms-page-header-title">
 					<JetpackLogo showText={ false } width={ 20 } />
-					{ __( 'Forms', 'jetpack-forms' ) }
+					{ __( 'Forms > View Responses', 'jetpack-forms' ) }
 				</div>
 			}
 			subTitle={ __( 'View and manage all your form submissions in one place.', 'jetpack-forms' ) }

--- a/projects/packages/forms/src/dashboard/index.tsx
+++ b/projects/packages/forms/src/dashboard/index.tsx
@@ -9,6 +9,7 @@ import { RouterProvider } from 'react-router/dom';
  * Internal dependencies
  */
 import Layout from './components/layout/index.tsx';
+import Forms from './forms/index.tsx';
 import Inbox from './inbox/index.js';
 import DashboardNotices from './notices-list.tsx';
 import './style.scss';
@@ -43,6 +44,10 @@ function initFormsDashboard() {
 				{
 					path: 'responses',
 					element: <Inbox />,
+				},
+				{
+					path: 'forms',
+					element: <Forms />,
 				},
 				{
 					path: 'integrations',


### PR DESCRIPTION
Resolves FORMS-368

## Proposed changes:

This is a spike/test to offer centralized form management based on synced patterns. Broadly, here's what's done: 
* Dashboard > Forms Screen
   - Add new 'Forms' screen that pulls a list of forms from synced patterns. 
   - This does not include forms added via blocks in pages and posts yet.
   - List is loaded in a dataviews table with minimal info
   - Added link to Edit form in site editor,
   - Added link to View responses -> goes to responses screen with responses filtered by form
   - Added link to View stats -> opens side panel like individual response with demo stats data 
* Dashboard > Responses Screen
   - Added filtering based on Form
* Dashboard > Navigation 
   - Added View Responses / View Forms button to toggle between screens
   - Updated Create Form button to create a new synced pattern with form block added
* Site Editor
   - Add Jetpack Forms pattern category - new forms are automatically created there
   - When adding/editing form pattern, there's a button to View Forms to go back to Jetpack > Forms list
* Block Editor
   - Central form patterns show in the block inserter
   - To edit a form, you cannot do it directly from the page/post - you must go to site editor
   - Added Shared Forms panel that allows you to save a form block as a synced pattern
* Backend/Other
   - Added endpoint to fetch forms
   - Added block attribute ID to each form block (regardless of where inserted, all synced pattern have the same form id)
   - Some other needed backend logic
   
**SCREENSHOT**
<img width="1348" height="725" alt="forms-list" src="https://github.com/user-attachments/assets/cc420297-4efb-425c-ad60-08f86259c8eb" />

**VIDEO DEMO**

https://github.com/user-attachments/assets/790206e3-d2dc-4c18-a0eb-4cce25e1513c


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

You can load this up and trying playing around with forms dashboard and forms block to tests synced pattern behaviors.

