### PR TITLE
Blocks: add filter to disable Jetpack block collection in editor.

### DIFF
--- a/projects/plugins/jetpack/changelog/update-blocks-filter-block-collection
+++ b/projects/plugins/jetpack/changelog/update-blocks-filter-block-collection
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Blocks: add filter to disable Jetpack block collection in editor.

--- a/projects/plugins/jetpack/class.jetpack-gutenberg.php
+++ b/projects/plugins/jetpack/class.jetpack-gutenberg.php
@@ -763,6 +763,8 @@ class Jetpack_Gutenberg {
 			$modules              = $module_list_endpoint->get_modules();
 		}
 
+		$is_wpcom_platform = ( new Host() )->is_wpcom_platform();
+
 		$jetpack_plan  = Jetpack_Plan::get();
 		$initial_state = array(
 			'available_blocks'        => self::get_availability(),
@@ -810,7 +812,12 @@ class Jetpack_Gutenberg {
 			 *
 			 * @param boolean true Enable Jetpack block collection in block categories. Defaults to true.
 			 */
-			'registerBlockCollection' => apply_filters( 'jetpack_register_block_collection', true ),
+			'registerBlockCollection' => apply_filters(
+				'jetpack_register_block_collection',
+				function () use ( $is_wpcom_platform ) {
+					return ! $is_wpcom_platform;
+				}
+			),
 			/**
 			 * Add your own feature flags to the block editor.
 			 *

--- a/projects/plugins/jetpack/class.jetpack-gutenberg.php
+++ b/projects/plugins/jetpack/class.jetpack-gutenberg.php
@@ -763,8 +763,6 @@ class Jetpack_Gutenberg {
 			$modules              = $module_list_endpoint->get_modules();
 		}
 
-		$is_wpcom_platform = ( new Host() )->is_wpcom_platform();
-
 		$jetpack_plan  = Jetpack_Plan::get();
 		$initial_state = array(
 			'available_blocks'        => self::get_availability(),
@@ -812,12 +810,7 @@ class Jetpack_Gutenberg {
 			 *
 			 * @param boolean true Enable Jetpack block collection in block categories. Defaults to true.
 			 */
-			'registerBlockCollection' => apply_filters(
-				'jetpack_register_block_collection',
-				function () use ( $is_wpcom_platform ) {
-					return ! $is_wpcom_platform;
-				}
-			),
+			'registerBlockCollection' => apply_filters( 'jetpack_register_block_collection', true ),
 			/**
 			 * Add your own feature flags to the block editor.
 			 *

--- a/projects/plugins/jetpack/class.jetpack-gutenberg.php
+++ b/projects/plugins/jetpack/class.jetpack-gutenberg.php
@@ -765,10 +765,10 @@ class Jetpack_Gutenberg {
 
 		$jetpack_plan  = Jetpack_Plan::get();
 		$initial_state = array(
-			'available_blocks' => self::get_availability(),
-			'blocks_variation' => $blocks_variation,
-			'modules'          => $modules,
-			'jetpack'          => array(
+			'available_blocks'        => self::get_availability(),
+			'blocks_variation'        => $blocks_variation,
+			'modules'                 => $modules,
+			'jetpack'                 => array(
 				'is_active'                     => Jetpack::is_connection_ready(),
 				'is_current_user_connected'     => $is_current_user_connected,
 				/** This filter is documented in class.jetpack-gutenberg.php */
@@ -795,14 +795,22 @@ class Jetpack_Gutenberg {
 				 */
 				'republicize_enabled'           => apply_filters( 'jetpack_block_editor_republicize_feature', true ),
 			),
-			'siteFragment'     => $status->get_site_suffix(),
-			'adminUrl'         => esc_url( admin_url() ),
-			'tracksUserData'   => $user_data,
-			'wpcomBlogId'      => $blog_id,
-			'allowedMimeTypes' => wp_get_mime_types(),
-			'siteLocale'       => str_replace( '_', '-', get_locale() ),
-			'ai-assistant'     => $ai_assistant_state,
-			'screenBase'       => $screen_base,
+			'siteFragment'            => $status->get_site_suffix(),
+			'adminUrl'                => esc_url( admin_url() ),
+			'tracksUserData'          => $user_data,
+			'wpcomBlogId'             => $blog_id,
+			'allowedMimeTypes'        => wp_get_mime_types(),
+			'siteLocale'              => str_replace( '_', '-', get_locale() ),
+			'ai-assistant'            => $ai_assistant_state,
+			'screenBase'              => $screen_base,
+			/**
+			 * Should all blocks get registered the Jetpack block collection in addition to their own categories?
+			 *
+			 * @since $$next-version$$
+			 *
+			 * @param boolean true Enable Jetpack block collection in block categories. Defaults to true.
+			 */
+			'registerBlockCollection' => apply_filters( 'jetpack_register_block_collection', true ),
 			/**
 			 * Add your own feature flags to the block editor.
 			 *
@@ -812,8 +820,8 @@ class Jetpack_Gutenberg {
 			 *
 			 * @param array true Enable the RePublicize UI in the block editor context. Defaults to true.
 			 */
-			'feature_flags'    => apply_filters( 'jetpack_block_editor_feature_flags', array() ),
-			'pluginBasePath'   => plugins_url( '', Constants::get_constant( 'JETPACK__PLUGIN_FILE' ) ),
+			'feature_flags'           => apply_filters( 'jetpack_block_editor_feature_flags', array() ),
+			'pluginBasePath'          => plugins_url( '', Constants::get_constant( 'JETPACK__PLUGIN_FILE' ) ),
 		);
 
 		wp_localize_script(

--- a/projects/plugins/jetpack/extensions/shared/block-category.js
+++ b/projects/plugins/jetpack/extensions/shared/block-category.js
@@ -1,12 +1,8 @@
-import { isWpcomPlatformSite } from '@automattic/jetpack-script-data';
 import { JetpackLogo } from '@automattic/jetpack-shared-extension-utils/icons';
 import { getCategories, setCategories, registerBlockCollection } from '@wordpress/blocks';
 import { __ } from '@wordpress/i18n';
 
-const isWpcom = isWpcomPlatformSite();
-
-// We do not want the Jetpack collection on WordPress.com (Simple or Atomic).
-if ( ! isWpcom ) {
+if ( window?.Jetpack_Editor_Initial_State?.registerBlockCollection ) {
 	registerBlockCollection( 'jetpack', {
 		title: 'Jetpack',
 		icon: <JetpackLogo />,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Part of FORMS-265

Will allow hiding Jetpack block collection via filter.

Note that "collection" is separate from "categories": https://developer.wordpress.org/block-editor/reference-guides/packages/packages-blocks/#registerblockcollection

<img width="349" height="443" alt="Screenshot 2025-11-25 at 13 10 53" src="https://github.com/user-attachments/assets/472200c0-07a5-4833-acb1-43ef62dbdd19" />

Note also that we're making the Jetpack category visible on WP.com by design. Convo; p1763050188308419-slack-C029GN3KD

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds filter to control if we register block collection or not.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Add filter to somewhere on your site: `add_filter( 'jetpack_register_block_collection', '__return_false' );`
* See the block collection gone.
* Each Jetpack block is still registered in its own category (growth, forms, monetize, widgets, embeds...).

