### PR TITLE
Social: Fix the incorrect format of feature flag for unified UI v1

### DIFF
--- a/projects/plugins/wpcomsh/changelog/fix-social-unified-ui-ff
+++ b/projects/plugins/wpcomsh/changelog/fix-social-unified-ui-ff
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Social: Fix the incorrect format of feature flag for unified UI v1.

--- a/projects/plugins/wpcomsh/wpcom-features/class-wpcom-features.php
+++ b/projects/plugins/wpcomsh/wpcom-features/class-wpcom-features.php
@@ -1235,11 +1235,11 @@ class WPCOM_Features {
 			self::WPCOM_ALL_SITES,
 		),
 		self::SOCIAL_UNIFIED_UI_V1              => array(
-			self::WPCOM_ALL_SITES,
-			self::JETPACK_ALL_SITES,
-			// The feature is not available yet
 			array(
+				// The feature is not available yet.
 				'before' => '2004-01-00',
+				self::WPCOM_ALL_SITES,
+				self::JETPACK_ALL_SITES,
 			),
 		),
 		self::SOCIAL_EDITOR_PREVIEW             => array(


### PR DESCRIPTION
Related to 196827-ghe-Automattic/wpcom and #46061

The feature

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Fix the feature flag format for Social unified UI v1

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Follow the instructions in 196827-ghe-Automattic/wpcom