### PR TITLE
Podcast block: Prevent warnings when data is malformed

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/class-jetpack-podcast-helper.php
+++ b/projects/plugins/jetpack/_inc/lib/class-jetpack-podcast-helper.php
@@ -491,7 +491,7 @@ class Jetpack_Podcast_Helper {
 	 */
 	protected function get_audio_enclosure( SimplePie\Item $episode ) {
 		foreach ( (array) $episode->get_enclosures() as $enclosure ) {
-			if ( str_starts_with( $enclosure->type, 'audio/' ) ) {
+			if ( is_string( $enclosure->type ) && str_starts_with( $enclosure->type, 'audio/' ) ) {
 				return $enclosure;
 			}
 		}

--- a/projects/plugins/jetpack/_inc/lib/class-jetpack-podcast-helper.php
+++ b/projects/plugins/jetpack/_inc/lib/class-jetpack-podcast-helper.php
@@ -491,7 +491,7 @@ class Jetpack_Podcast_Helper {
 	 */
 	protected function get_audio_enclosure( SimplePie\Item $episode ) {
 		foreach ( (array) $episode->get_enclosures() as $enclosure ) {
-			if ( is_string( $enclosure->type ) && str_starts_with( $enclosure->type, 'audio/' ) ) {
+			if ( str_starts_with( $enclosure->type ?? '', 'audio/' ) ) {
 				return $enclosure;
 			}
 		}

--- a/projects/plugins/jetpack/changelog/fix-jetpack-podcast-helper_warnings
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-podcast-helper_warnings
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Podcasts block: Prevent warnings when podcast content is malformed.


### PR DESCRIPTION
Closes MONOREP-259

 <!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR addresses the following warnings:
```
PHP Deprecated: str_starts_with(): Passing null to parameter #1 ($haystack) of type string is deprecated in /wordpress/plugins/jetpack/15.3-a.9/_inc/lib/class-jetpack-podcast-helper.php on line 494
```

We now use an empty string as the fallback if `$enclosure` is not an object or if the `type` property` is null.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

