### PR TITLE
Add state endpoint to new agents-manager feature in jetpack-mu-wpcom

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-agents-manager-feature
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-agents-manager-feature
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add Agents Manager feature with REST API endpoints for managing agent state and preferences

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -322,6 +322,9 @@ class Jetpack_Mu_Wpcom {
 		if ( ! class_exists( 'A8C\FSE\Help_Center' ) ) {
 			require_once __DIR__ . '/features/help-center/class-help-center.php';
 		}
+		if ( ! class_exists( 'A8C\FSE\Agents_Manager' ) ) {
+			require_once __DIR__ . '/features/agents-manager/class-agents-manager.php';
+		}
 		require_once __DIR__ . '/features/html-block-restricted-tags/html-block-restricted-tags.php';
 		require_once __DIR__ . '/features/marketing/marketing.php';
 		require_once __DIR__ . '/features/pages/pages.php';

--- a/projects/packages/jetpack-mu-wpcom/src/features/agents-manager/README.md
+++ b/projects/packages/jetpack-mu-wpcom/src/features/agents-manager/README.md
@@ -21,9 +21,12 @@ Retrieves the current agents manager state from user preferences.
 **Response:**
 ```json
 {
-  "agents_manager_open": true,
-  "agents_manager_minimized": false,
-  "agents_manager_router_history": { ... }
+  "calypso_preferences": {
+    "agents_manager_open": true,
+    "agents_manager_docked": false,
+    "agents_manager_floating_position": "right",
+    "agents_manager_router_history": { ... }
+  }
 }
 ```
 
@@ -35,7 +38,8 @@ Updates the agents manager state in user preferences.
 ```json
 {
   "agents_manager_open": true,
-  "agents_manager_minimized": false,
+  "agents_manager_docked": false,
+  "agents_manager_floating_position": "left",
   "agents_manager_router_history": { ... }
 }
 ```

--- a/projects/packages/jetpack-mu-wpcom/src/features/agents-manager/README.md
+++ b/projects/packages/jetpack-mu-wpcom/src/features/agents-manager/README.md
@@ -1,0 +1,74 @@
+# Agents Manager
+
+The Agents Manager provides REST API endpoints for managing AI agent-related state and preferences for WordPress.com users.
+
+## Features
+
+- Persisted open state management via REST API
+- Router history cleanup to prevent preference bloat
+
+## REST API Endpoints
+
+### Open State
+
+**Namespace:** `agents-manager`
+**Route:** `/open-state`
+
+#### GET `/wp-json/agents-manager/open-state`
+
+Retrieves the current agents manager state from user preferences.
+
+**Response:**
+```json
+{
+  "agents_manager_open": true,
+  "agents_manager_minimized": false,
+  "agents_manager_router_history": { ... }
+}
+```
+
+#### POST `/wp-json/agents-manager/open-state`
+
+Updates the agents manager state in user preferences.
+
+**Request body:**
+```json
+{
+  "agents_manager_open": true,
+  "agents_manager_minimized": false,
+  "agents_manager_router_history": { ... }
+}
+```
+
+All parameters are optional; only provided parameters will be updated.
+
+## Router History Cleanup
+
+The Agents Manager automatically limits router history entries to 50 via the `calypso_preferences_update` filter. When the limit is exceeded, it keeps the last 49 entries and prepends a root entry to ensure the back button always works.
+
+## Development
+
+This feature is loaded for WordPress.com-connected users via the `load_wpcom_user_features()` method in `Jetpack_Mu_Wpcom`.
+
+To develop this feature, follow the standard [`jetpack-mu-wpcom` development process](https://github.com/Automattic/jetpack/blob/trunk/projects/packages/jetpack-mu-wpcom/README.md).
+
+### How to develop the Help Center
+
+This currently gets loaded via the help-center Calypso app.
+
+#### In Calypso
+
+Follow the classic Calypso development setup. Run `yarn start` and edit away. Nothing else should be needed.
+
+#### In Simple sites
+
+0. Go to Calypso repository root.
+1. cd into `apps/help-center` (note: This currently gets loaded via `help-center`).
+2. run `yarn dev --sync`.
+3. Sandbox your site and `widgets.wp.com`.
+4. Your changes should be reflected on the site live.
+
+
+## Deployment
+
+After every change to the Agents Manager PHP files, deploy `jetpack-mu-wpcom`.

--- a/projects/packages/jetpack-mu-wpcom/src/features/agents-manager/agents-manager.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/agents-manager/agents-manager.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * Plugin Name: Agents Manager
+ * Description: This plugin loads the Agents Manager.
+ * Text Domain: jetpack-mu-wpcom
+ * Author: Automattic
+ * Author URI: https://automattic.com/
+ * Requires Plugins: jetpack
+ * Note: This file is used to load the Agents Manager as a standalone plugin. It's not used by Jetpack.
+ *
+ * @package automattic/jetpack-mu-wpcom
+ */
+
+/**
+ * Load the Agents Manager class.
+ */
+require_once __DIR__ . '/class-agents-manager.php';

--- a/projects/packages/jetpack-mu-wpcom/src/features/agents-manager/class-agents-manager.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/agents-manager/class-agents-manager.php
@@ -1,0 +1,97 @@
+<?php
+/**
+ * Agents manager
+ *
+ * @package automattic/jetpack-mu-wpcom
+ */
+
+namespace A8C\FSE;
+
+/**
+ * Class Agents_Manager
+ */
+class Agents_Manager {
+	/**
+	 * Class instance.
+	 *
+	 * @var Agents_Manager
+	 */
+	private static $instance = null;
+
+	/**
+	 * Agents_Manager constructor.
+	 */
+	public function __construct() {
+		add_action( 'rest_api_init', array( $this, 'register_rest_api' ) );
+		add_filter( 'calypso_preferences_update', array( $this, 'calypso_preferences_update' ) );
+	}
+
+	/**
+	 * Update the calypso preferences.
+	 *
+	 * @param \stdClass $preferences The preferences.
+	 * @return \stdClass The preferences.
+	 */
+	public function calypso_preferences_update( $preferences ) {
+		// Check if agents_manager_router_history exists and is a valid array structure
+		if ( ! isset( $preferences->agents_manager_router_history ) ||
+			! is_array( $preferences->agents_manager_router_history ) ) {
+			return $preferences;
+		}
+
+		$router_history = $preferences->agents_manager_router_history;
+
+		// Check if entries exist and is an array
+		if ( ! isset( $router_history['entries'] ) ||
+			! is_array( $router_history['entries'] ) ) {
+			return $preferences;
+		}
+
+		$entries = $router_history['entries'];
+
+		// Limit entries to 50 to prevent spamming entries in the router history.
+		if ( count( $entries ) > 50 ) {
+			// Keep only the last 49 entries and add the root entry at the beginning.
+			$entries = array_slice( $entries, -49 );
+			// Keep the start at root so the back button always works.
+			array_unshift(
+				$entries,
+				array(
+					'pathname' => '/',
+					'search'   => '',
+					'hash'     => '',
+					'key'      => 'default',
+					'state'    => null,
+				)
+			);
+
+			// Update the preferences object directly
+			$preferences->agents_manager_router_history['entries'] = $entries;
+			$preferences->agents_manager_router_history['index']   = 49;
+		}
+
+		return $preferences;
+	}
+
+	/**
+	 * Creates instance.
+	 *
+	 * @return void
+	 */
+	public static function init() {
+		if ( self::$instance === null ) {
+			self::$instance = new self();
+		}
+	}
+
+	/**
+	 * Register the Agents Manager endpoints.
+	 */
+	public function register_rest_api() {
+		require_once __DIR__ . '/class-wp-rest-agents-manager-persisted-open-state.php';
+		$controller = new WP_REST_Agents_Manager_Persisted_Open_State();
+		$controller->register_rest_route();
+	}
+}
+
+add_action( 'init', array( __NAMESPACE__ . '\Agents_Manager', 'init' ) );

--- a/projects/packages/jetpack-mu-wpcom/src/features/agents-manager/class-wp-rest-agents-manager-persisted-open-state.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/agents-manager/class-wp-rest-agents-manager-persisted-open-state.php
@@ -1,0 +1,132 @@
+<?php
+/**
+ * WP_REST_Agents_Manager_Persisted_Open_State file.
+ *
+ * @package automattic/jetpack-mu-wpcom
+ */
+
+namespace A8C\FSE;
+
+use Automattic\Jetpack\Connection\Client;
+
+/**
+ * Class WP_REST_Agents_Manager_Persisted_Open_State.
+ */
+class WP_REST_Agents_Manager_Persisted_Open_State extends \WP_REST_Controller {
+
+	/**
+	 * WP_REST_Agents_Manager_Persisted_Open_State constructor.
+	 */
+	public function __construct() {
+		$this->namespace = 'agents-manager';
+		$this->rest_base = '/open-state';
+	}
+
+	/**
+	 * Register available routes.
+	 */
+	public function register_rest_route() {
+		register_rest_route(
+			$this->namespace,
+			$this->rest_base,
+			array(
+				// Get the open state.
+				array(
+					'methods'             => \WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_state' ),
+					'permission_callback' => 'is_user_logged_in',
+				),
+				// Set the open state
+				array(
+					'methods'             => \WP_REST_Server::EDITABLE,
+					'callback'            => array( $this, 'set_state' ),
+					'permission_callback' => 'is_user_logged_in',
+				),
+			)
+		);
+	}
+
+	/**
+	 * Get chat_id and last_chat_id from user preferences.
+	 */
+	public function get_state() {
+		// Forward the request body to the support chat endpoint.
+		$body = Client::wpcom_json_api_request_as_user(
+			'/me/preferences',
+			'2',
+			array( 'method' => 'GET' )
+		);
+
+		if ( is_wp_error( $body ) ) {
+			return $body;
+		}
+
+		$response = json_decode( wp_remote_retrieve_body( $body ) );
+
+		$is_open        = $response->agents_manager_open ?? false;
+		$is_docked      = $response->agents_manager_docked ?? false;
+		$router_history = $response->agents_manager_router_history ?? null;
+
+		$projected_response = array(
+			'agents_manager_open'           => (bool) $is_open,
+			'agents_manager_docked'         => (bool) $is_docked,
+			'agents_manager_router_history' => $router_history,
+		);
+
+		return rest_ensure_response( $projected_response );
+	}
+
+	/**
+	 * Set chat_id or last_chat_id from user preferences.
+	 *
+	 * @param \WP_REST_Request $request The request sent to the API.
+	 */
+	public function set_state( \WP_REST_Request $request ) {
+		$state          = $request['agents_manager_open'];
+		$router_history = $request['agents_manager_router_history'];
+		$docked         = $request['agents_manager_docked'];
+
+		$data = array(
+			'calypso_preferences' => array(),
+		);
+
+		if ( $request->has_param( 'agents_manager_open' ) ) {
+			$data['calypso_preferences']['agents_manager_open'] = $state;
+		}
+
+		if ( $request->has_param( 'agents_manager_router_history' ) ) {
+			$data['calypso_preferences']['agents_manager_router_history'] = $router_history;
+		}
+
+		if ( $request->has_param( 'agents_manager_docked' ) ) {
+			$data['calypso_preferences']['agents_manager_docked'] = $docked;
+		}
+
+		$body = Client::wpcom_json_api_request_as_user(
+			'/me/preferences',
+			'2',
+			array( 'method' => 'POST' ),
+			$data
+		);
+
+		if ( is_wp_error( $body ) ) {
+			return $body;
+		}
+
+		$response = json_decode( wp_remote_retrieve_body( $body ) );
+
+		$is_open        = $response->calypso_preferences->agents_manager_open ?? false;
+		$router_history = $response->calypso_preferences->agents_manager_router_history ?? null;
+		$is_docked      = $response->calypso_preferences->agents_manager_docked ?? false;
+
+		$projected_response = array(
+			'calypso_preferences' => array(
+				'agents_manager_open'           => (bool) $is_open,
+				'agents_manager_router_history' => $router_history,
+				'agents_manager_docked'         => (bool) $is_docked,
+			),
+		);
+
+		return rest_ensure_response( $projected_response );
+	}
+}

--- a/projects/packages/jetpack-mu-wpcom/src/features/agents-manager/class-wp-rest-agents-manager-persisted-open-state.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/agents-manager/class-wp-rest-agents-manager-persisted-open-state.php
@@ -65,15 +65,17 @@ class WP_REST_Agents_Manager_Persisted_Open_State extends \WP_REST_Controller {
 
 		$calypso_preferences = $response->calypso_preferences ?? (object) array();
 
-		$is_open        = $calypso_preferences->agents_manager_open ?? false;
-		$is_docked      = $calypso_preferences->agents_manager_docked ?? false;
-		$router_history = $calypso_preferences->agents_manager_router_history ?? null;
+		$is_open           = $calypso_preferences->agents_manager_open ?? false;
+		$is_docked         = $calypso_preferences->agents_manager_docked ?? false;
+		$floating_position = $calypso_preferences->agents_manager_floating_position ?? 'right';
+		$router_history    = $calypso_preferences->agents_manager_router_history ?? null;
 
 		$projected_response = array(
 			'calypso_preferences' => array(
-				'agents_manager_open'           => (bool) $is_open,
-				'agents_manager_docked'         => (bool) $is_docked,
-				'agents_manager_router_history' => $router_history,
+				'agents_manager_open'              => (bool) $is_open,
+				'agents_manager_docked'            => (bool) $is_docked,
+				'agents_manager_floating_position' => $floating_position,
+				'agents_manager_router_history'    => $router_history,
 			),
 		);
 
@@ -86,9 +88,10 @@ class WP_REST_Agents_Manager_Persisted_Open_State extends \WP_REST_Controller {
 	 * @param \WP_REST_Request $request The request sent to the API.
 	 */
 	public function set_state( \WP_REST_Request $request ) {
-		$state          = $request['agents_manager_open'];
-		$router_history = $request['agents_manager_router_history'];
-		$docked         = $request['agents_manager_docked'];
+		$state             = $request['agents_manager_open'];
+		$router_history    = $request['agents_manager_router_history'];
+		$docked            = $request['agents_manager_docked'];
+		$floating_position = $request['agents_manager_floating_position'];
 
 		$data = array(
 			'calypso_preferences' => array(),
@@ -106,6 +109,10 @@ class WP_REST_Agents_Manager_Persisted_Open_State extends \WP_REST_Controller {
 			$data['calypso_preferences']['agents_manager_docked'] = $docked;
 		}
 
+		if ( $request->has_param( 'agents_manager_floating_position' ) ) {
+			$data['calypso_preferences']['agents_manager_floating_position'] = $floating_position;
+		}
+
 		$body = Client::wpcom_json_api_request_as_user(
 			'/me/preferences',
 			'2',
@@ -119,15 +126,17 @@ class WP_REST_Agents_Manager_Persisted_Open_State extends \WP_REST_Controller {
 
 		$response = json_decode( wp_remote_retrieve_body( $body ) );
 
-		$is_open        = $response->calypso_preferences->agents_manager_open ?? false;
-		$router_history = $response->calypso_preferences->agents_manager_router_history ?? null;
-		$is_docked      = $response->calypso_preferences->agents_manager_docked ?? false;
+		$is_open           = $response->calypso_preferences->agents_manager_open ?? false;
+		$is_docked         = $response->calypso_preferences->agents_manager_docked ?? false;
+		$floating_position = $response->calypso_preferences->agents_manager_floating_position ?? 'right';
+		$router_history    = $response->calypso_preferences->agents_manager_router_history ?? null;
 
 		$projected_response = array(
 			'calypso_preferences' => array(
-				'agents_manager_open'           => (bool) $is_open,
-				'agents_manager_router_history' => $router_history,
-				'agents_manager_docked'         => (bool) $is_docked,
+				'agents_manager_open'              => (bool) $is_open,
+				'agents_manager_docked'            => (bool) $is_docked,
+				'agents_manager_floating_position' => $floating_position,
+				'agents_manager_router_history'    => $router_history,
 			),
 		);
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/agents-manager/class-wp-rest-agents-manager-persisted-open-state.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/agents-manager/class-wp-rest-agents-manager-persisted-open-state.php
@@ -63,14 +63,18 @@ class WP_REST_Agents_Manager_Persisted_Open_State extends \WP_REST_Controller {
 
 		$response = json_decode( wp_remote_retrieve_body( $body ) );
 
-		$is_open        = $response->agents_manager_open ?? false;
-		$is_docked      = $response->agents_manager_docked ?? false;
-		$router_history = $response->agents_manager_router_history ?? null;
+		$calypso_preferences = $response->calypso_preferences ?? (object) array();
+
+		$is_open        = $calypso_preferences->agents_manager_open ?? false;
+		$is_docked      = $calypso_preferences->agents_manager_docked ?? false;
+		$router_history = $calypso_preferences->agents_manager_router_history ?? null;
 
 		$projected_response = array(
-			'agents_manager_open'           => (bool) $is_open,
-			'agents_manager_docked'         => (bool) $is_docked,
-			'agents_manager_router_history' => $router_history,
+			'calypso_preferences' => array(
+				'agents_manager_open'           => (bool) $is_open,
+				'agents_manager_docked'         => (bool) $is_docked,
+				'agents_manager_router_history' => $router_history,
+			),
 		);
 
 		return rest_ensure_response( $projected_response );

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/agents-manager/Agents_Manager_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/agents-manager/Agents_Manager_Test.php
@@ -36,6 +36,21 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
+	 * Tear down test fixtures.
+	 */
+	public function tear_down() {
+		// Remove hooks added by the Agents_Manager constructor.
+		remove_action( 'rest_api_init', array( $this->agents_manager, 'register_rest_api' ) );
+		remove_filter( 'calypso_preferences_update', array( $this->agents_manager, 'calypso_preferences_update' ) );
+
+		// Reset the REST server to clear any registered routes.
+		global $wp_rest_server;
+		$wp_rest_server = null;
+
+		parent::tear_down();
+	}
+
+	/**
 	 * Tests that calypso_preferences_update returns preferences unchanged
 	 * when agents_manager_router_history is not set.
 	 */

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/agents-manager/Agents_Manager_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/agents-manager/Agents_Manager_Test.php
@@ -246,19 +246,23 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 		if ( PHP_VERSION_ID < 80500 ) {
 			$property->setAccessible( true );
 		}
-		$property->setValue( null, null );
+
+		// Use an instance for Phan compatibility when accessing static property.
+		$dummy = $this->agents_manager;
+
+		$property->setValue( $dummy, null );
 
 		Agents_Manager::init();
 
-		$instance1 = $property->getValue( null );
+		$instance1 = $property->getValue( $dummy );
 		$this->assertInstanceOf( Agents_Manager::class, $instance1 );
 
 		Agents_Manager::init();
 
-		$instance2 = $property->getValue( null );
+		$instance2 = $property->getValue( $dummy );
 		$this->assertSame( $instance1, $instance2 );
 
 		// Reset back to null for other tests
-		$property->setValue( null, null );
+		$property->setValue( $dummy, null );
 	}
 }

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/agents-manager/Agents_Manager_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/agents-manager/Agents_Manager_Test.php
@@ -243,7 +243,9 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 		// Reset the static instance for testing
 		$reflection = new \ReflectionClass( Agents_Manager::class );
 		$property   = $reflection->getProperty( 'instance' );
-		$property->setAccessible( true );
+		if ( PHP_VERSION_ID < 80500 ) {
+			$property->setAccessible( true );
+		}
 		$property->setValue( null, null );
 
 		Agents_Manager::init();

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/agents-manager/Agents_Manager_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/agents-manager/Agents_Manager_Test.php
@@ -1,0 +1,247 @@
+<?php
+/**
+ * Agents Manager Tests File
+ *
+ * @package automattic/jetpack-mu-wpcom
+ */
+
+namespace A8C\FSE;
+
+use Automattic\Jetpack\Jetpack_Mu_Wpcom;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+require_once Jetpack_Mu_Wpcom::PKG_DIR . 'src/features/agents-manager/class-agents-manager.php';
+
+/**
+ * Class Agents_Manager_Test
+ *
+ * @covers \A8C\FSE\Agents_Manager
+ */
+#[CoversClass( Agents_Manager::class )]
+class Agents_Manager_Test extends \WorDBless\BaseTestCase {
+
+	/**
+	 * The Agents_Manager instance.
+	 *
+	 * @var Agents_Manager
+	 */
+	private $agents_manager;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function set_up() {
+		parent::set_up();
+		$this->agents_manager = new Agents_Manager();
+	}
+
+	/**
+	 * Tests that calypso_preferences_update returns preferences unchanged
+	 * when agents_manager_router_history is not set.
+	 */
+	public function test_calypso_preferences_update_returns_unchanged_when_no_router_history() {
+		$preferences = (object) array(
+			'some_other_preference' => 'value',
+		);
+
+		$result = $this->agents_manager->calypso_preferences_update( $preferences );
+
+		$this->assertEquals( $preferences, $result );
+	}
+
+	/**
+	 * Tests that calypso_preferences_update returns preferences unchanged
+	 * when agents_manager_router_history is not an array.
+	 */
+	public function test_calypso_preferences_update_returns_unchanged_when_router_history_not_array() {
+		$preferences = (object) array(
+			'agents_manager_router_history' => 'not an array',
+		);
+
+		$result = $this->agents_manager->calypso_preferences_update( $preferences );
+
+		$this->assertEquals( $preferences, $result );
+	}
+
+	/**
+	 * Tests that calypso_preferences_update returns preferences unchanged
+	 * when entries is not set in router_history.
+	 */
+	public function test_calypso_preferences_update_returns_unchanged_when_no_entries() {
+		$preferences = (object) array(
+			'agents_manager_router_history' => array(
+				'index' => 0,
+			),
+		);
+
+		$result = $this->agents_manager->calypso_preferences_update( $preferences );
+
+		$this->assertEquals( $preferences, $result );
+	}
+
+	/**
+	 * Tests that calypso_preferences_update returns preferences unchanged
+	 * when entries is not an array.
+	 */
+	public function test_calypso_preferences_update_returns_unchanged_when_entries_not_array() {
+		$preferences = (object) array(
+			'agents_manager_router_history' => array(
+				'entries' => 'not an array',
+			),
+		);
+
+		$result = $this->agents_manager->calypso_preferences_update( $preferences );
+
+		$this->assertEquals( $preferences, $result );
+	}
+
+	/**
+	 * Tests that calypso_preferences_update does not modify entries
+	 * when there are 50 or fewer entries.
+	 */
+	public function test_calypso_preferences_update_does_not_modify_when_50_or_fewer_entries() {
+		$entries = array();
+		for ( $i = 0; $i < 50; $i++ ) {
+			$entries[] = array(
+				'pathname' => '/page-' . $i,
+				'search'   => '',
+				'hash'     => '',
+				'key'      => 'key-' . $i,
+				'state'    => null,
+			);
+		}
+
+		$preferences = (object) array(
+			'agents_manager_router_history' => array(
+				'entries' => $entries,
+				'index'   => 49,
+			),
+		);
+
+		$result = $this->agents_manager->calypso_preferences_update( $preferences );
+
+		$this->assertCount( 50, $result->agents_manager_router_history['entries'] );
+		$this->assertEquals( 49, $result->agents_manager_router_history['index'] );
+	}
+
+	/**
+	 * Tests that calypso_preferences_update limits entries to 50
+	 * when there are more than 50 entries.
+	 */
+	public function test_calypso_preferences_update_limits_entries_when_over_50() {
+		$entries = array();
+		for ( $i = 0; $i < 60; $i++ ) {
+			$entries[] = array(
+				'pathname' => '/page-' . $i,
+				'search'   => '',
+				'hash'     => '',
+				'key'      => 'key-' . $i,
+				'state'    => null,
+			);
+		}
+
+		$preferences = (object) array(
+			'agents_manager_router_history' => array(
+				'entries' => $entries,
+				'index'   => 59,
+			),
+		);
+
+		$result = $this->agents_manager->calypso_preferences_update( $preferences );
+
+		$this->assertCount( 50, $result->agents_manager_router_history['entries'] );
+		$this->assertEquals( 49, $result->agents_manager_router_history['index'] );
+	}
+
+	/**
+	 * Tests that calypso_preferences_update adds root entry at the beginning
+	 * when entries are trimmed.
+	 */
+	public function test_calypso_preferences_update_adds_root_entry_when_trimmed() {
+		$entries = array();
+		for ( $i = 0; $i < 60; $i++ ) {
+			$entries[] = array(
+				'pathname' => '/page-' . $i,
+				'search'   => '',
+				'hash'     => '',
+				'key'      => 'key-' . $i,
+				'state'    => null,
+			);
+		}
+
+		$preferences = (object) array(
+			'agents_manager_router_history' => array(
+				'entries' => $entries,
+				'index'   => 59,
+			),
+		);
+
+		$result = $this->agents_manager->calypso_preferences_update( $preferences );
+
+		$first_entry = $result->agents_manager_router_history['entries'][0];
+
+		$this->assertEquals( '/', $first_entry['pathname'] );
+		$this->assertSame( '', $first_entry['search'] );
+		$this->assertSame( '', $first_entry['hash'] );
+		$this->assertEquals( 'default', $first_entry['key'] );
+		$this->assertNull( $first_entry['state'] );
+	}
+
+	/**
+	 * Tests that calypso_preferences_update keeps the last 49 entries
+	 * when entries are trimmed.
+	 */
+	public function test_calypso_preferences_update_keeps_last_49_entries() {
+		$entries = array();
+		for ( $i = 0; $i < 60; $i++ ) {
+			$entries[] = array(
+				'pathname' => '/page-' . $i,
+				'search'   => '',
+				'hash'     => '',
+				'key'      => 'key-' . $i,
+				'state'    => null,
+			);
+		}
+
+		$preferences = (object) array(
+			'agents_manager_router_history' => array(
+				'entries' => $entries,
+				'index'   => 59,
+			),
+		);
+
+		$result = $this->agents_manager->calypso_preferences_update( $preferences );
+
+		// The second entry should be page-11 (60 - 49 = 11, so entries 11-59 are kept)
+		$second_entry = $result->agents_manager_router_history['entries'][1];
+		$this->assertEquals( '/page-11', $second_entry['pathname'] );
+
+		// The last entry should be page-59
+		$last_entry = $result->agents_manager_router_history['entries'][49];
+		$this->assertEquals( '/page-59', $last_entry['pathname'] );
+	}
+
+	/**
+	 * Tests that the init method creates a singleton instance.
+	 */
+	public function test_init_creates_singleton_instance() {
+		// Reset the static instance for testing
+		$reflection = new \ReflectionClass( Agents_Manager::class );
+		$property   = $reflection->getProperty( 'instance' );
+		$property->setAccessible( true );
+		$property->setValue( null, null );
+
+		Agents_Manager::init();
+
+		$instance1 = $property->getValue( null );
+		$this->assertInstanceOf( Agents_Manager::class, $instance1 );
+
+		Agents_Manager::init();
+
+		$instance2 = $property->getValue( null );
+		$this->assertSame( $instance1, $instance2 );
+
+		// Reset back to null for other tests
+		$property->setValue( null, null );
+	}
+}

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/agents-manager/WP_REST_Agents_Manager_Persisted_Open_State_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/agents-manager/WP_REST_Agents_Manager_Persisted_Open_State_Test.php
@@ -36,6 +36,17 @@ class WP_REST_Agents_Manager_Persisted_Open_State_Test extends \WorDBless\BaseTe
 	}
 
 	/**
+	 * Tear down test fixtures.
+	 */
+	public function tear_down() {
+		// Reset the REST server to clear registered routes.
+		global $wp_rest_server;
+		$wp_rest_server = null;
+
+		parent::tear_down();
+	}
+
+	/**
 	 * Tests that the constructor sets the correct namespace.
 	 */
 	public function test_constructor_sets_correct_namespace() {

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/agents-manager/WP_REST_Agents_Manager_Persisted_Open_State_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/agents-manager/WP_REST_Agents_Manager_Persisted_Open_State_Test.php
@@ -52,7 +52,9 @@ class WP_REST_Agents_Manager_Persisted_Open_State_Test extends \WorDBless\BaseTe
 	public function test_constructor_sets_correct_namespace() {
 		$reflection = new \ReflectionClass( $this->controller );
 		$property   = $reflection->getProperty( 'namespace' );
-		$property->setAccessible( true );
+		if ( PHP_VERSION_ID < 80500 ) {
+			$property->setAccessible( true );
+		}
 
 		$this->assertEquals( 'agents-manager', $property->getValue( $this->controller ) );
 	}
@@ -63,7 +65,9 @@ class WP_REST_Agents_Manager_Persisted_Open_State_Test extends \WorDBless\BaseTe
 	public function test_constructor_sets_correct_rest_base() {
 		$reflection = new \ReflectionClass( $this->controller );
 		$property   = $reflection->getProperty( 'rest_base' );
-		$property->setAccessible( true );
+		if ( PHP_VERSION_ID < 80500 ) {
+			$property->setAccessible( true );
+		}
 
 		$this->assertEquals( '/open-state', $property->getValue( $this->controller ) );
 	}

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/agents-manager/WP_REST_Agents_Manager_Persisted_Open_State_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/agents-manager/WP_REST_Agents_Manager_Persisted_Open_State_Test.php
@@ -1,0 +1,141 @@
+<?php
+/**
+ * WP_REST_Agents_Manager_Persisted_Open_State Tests File
+ *
+ * @package automattic/jetpack-mu-wpcom
+ */
+
+namespace A8C\FSE;
+
+use Automattic\Jetpack\Jetpack_Mu_Wpcom;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+require_once Jetpack_Mu_Wpcom::PKG_DIR . 'src/features/agents-manager/class-wp-rest-agents-manager-persisted-open-state.php';
+
+/**
+ * Class WP_REST_Agents_Manager_Persisted_Open_State_Test
+ *
+ * @covers \A8C\FSE\WP_REST_Agents_Manager_Persisted_Open_State
+ */
+#[CoversClass( WP_REST_Agents_Manager_Persisted_Open_State::class )]
+class WP_REST_Agents_Manager_Persisted_Open_State_Test extends \WorDBless\BaseTestCase {
+
+	/**
+	 * The controller instance.
+	 *
+	 * @var WP_REST_Agents_Manager_Persisted_Open_State
+	 */
+	private $controller;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function set_up() {
+		parent::set_up();
+		$this->controller = new WP_REST_Agents_Manager_Persisted_Open_State();
+	}
+
+	/**
+	 * Tests that the constructor sets the correct namespace.
+	 */
+	public function test_constructor_sets_correct_namespace() {
+		$reflection = new \ReflectionClass( $this->controller );
+		$property   = $reflection->getProperty( 'namespace' );
+		$property->setAccessible( true );
+
+		$this->assertEquals( 'agents-manager', $property->getValue( $this->controller ) );
+	}
+
+	/**
+	 * Tests that the constructor sets the correct rest_base.
+	 */
+	public function test_constructor_sets_correct_rest_base() {
+		$reflection = new \ReflectionClass( $this->controller );
+		$property   = $reflection->getProperty( 'rest_base' );
+		$property->setAccessible( true );
+
+		$this->assertEquals( '/open-state', $property->getValue( $this->controller ) );
+	}
+
+	/**
+	 * Tests that register_rest_route registers the expected routes.
+	 */
+	public function test_register_rest_route_registers_routes() {
+		// Register the routes.
+		$this->controller->register_rest_route();
+
+		// Get registered routes.
+		$routes = rest_get_server()->get_routes();
+
+		// Check that the route is registered.
+		$this->assertArrayHasKey( '/agents-manager/open-state', $routes );
+
+		$route_data = $routes['/agents-manager/open-state'];
+
+		// Check that both GET and POST methods are registered.
+		$methods = array();
+		foreach ( $route_data as $endpoint ) {
+			if ( isset( $endpoint['methods'] ) ) {
+				$methods = array_merge( $methods, array_keys( $endpoint['methods'] ) );
+			}
+		}
+
+		$this->assertContains( 'GET', $methods );
+		$this->assertContains( 'POST', $methods );
+	}
+
+	/**
+	 * Tests that the GET endpoint requires authentication.
+	 */
+	public function test_get_endpoint_requires_authentication() {
+		// Register the routes.
+		$this->controller->register_rest_route();
+
+		// Get registered routes.
+		$routes     = rest_get_server()->get_routes();
+		$route_data = $routes['/agents-manager/open-state'];
+
+		// Find the GET endpoint.
+		$get_endpoint = null;
+		foreach ( $route_data as $endpoint ) {
+			if ( isset( $endpoint['methods']['GET'] ) && $endpoint['methods']['GET'] ) {
+				$get_endpoint = $endpoint;
+				break;
+			}
+		}
+
+		$this->assertNotNull( $get_endpoint );
+		$this->assertEquals( 'is_user_logged_in', $get_endpoint['permission_callback'] );
+	}
+
+	/**
+	 * Tests that the POST endpoint requires authentication.
+	 */
+	public function test_post_endpoint_requires_authentication() {
+		// Register the routes.
+		$this->controller->register_rest_route();
+
+		// Get registered routes.
+		$routes     = rest_get_server()->get_routes();
+		$route_data = $routes['/agents-manager/open-state'];
+
+		// Find the POST endpoint.
+		$post_endpoint = null;
+		foreach ( $route_data as $endpoint ) {
+			if ( isset( $endpoint['methods']['POST'] ) && $endpoint['methods']['POST'] ) {
+				$post_endpoint = $endpoint;
+				break;
+			}
+		}
+
+		$this->assertNotNull( $post_endpoint );
+		$this->assertEquals( 'is_user_logged_in', $post_endpoint['permission_callback'] );
+	}
+
+	/**
+	 * Tests that the controller extends WP_REST_Controller.
+	 */
+	public function test_controller_extends_wp_rest_controller() {
+		$this->assertInstanceOf( \WP_REST_Controller::class, $this->controller );
+	}
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes DOTCOM-15318

Paired with https://github.com/Automattic/wp-calypso/pull/107246

## Proposed changes:
* Adds new endpoints for agent manager state.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

### Does this pull request change what data or activity we track or use?
No

## Testing instructions:
* Switch to https://github.com/Automattic/wp-calypso/pull/107246 and sandbox `widgets.wp.com`. Run `yarn dev --sync` from `apps/help-center`.
* On WoA sandboxed site, install Jetpack Beta and switch the WordPress.com Site Helper to this branch.
* https://jakeomwoadev.wpcomstaging.com/wp-admin/?flags=unified-agent (switch to your sandboxed atomic site)
* Switch to sidebar.
* Refresh -- ensure it works.

