### PR TITLE
Forms: fix inbox reponse email copy button alignment

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-email-field-copy
+++ b/projects/packages/forms/changelog/fix-forms-email-field-copy
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fixed
+
+Forms: fix inbox reponse email copy button alignment

--- a/projects/packages/forms/src/dashboard/components/response-view/field-email/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/response-view/field-email/index.tsx
@@ -5,7 +5,7 @@ import CopyClipboardButton from '../../../components/copy-clipboard-button';
 
 const FieldEmail = ( { email } ) => {
 	return (
-		<HStack align="center" spacing="2">
+		<HStack alignment="center" justify="left" spacing="2">
 			<a href={ `mailto:${ email }` }>{ email }</a>
 			<CopyClipboardButton text={ email } />
 		</HStack>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Fix alignment of "copy" button relative to the email in inbox response sidebar.

https://wordpress.github.io/gutenberg/?path=/docs/components-hstack--docs

Before
<img width="430" height="98" alt="image" src="https://github.com/user-attachments/assets/166550ff-dd64-449e-9312-d3d7dd10370e" />


After

<img width="430" height="96" alt="Screenshot 2025-11-25 at 19 16 08" src="https://github.com/user-attachments/assets/7c24667b-08b7-4ca7-aa03-4b7628c52579" />


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

