### PR TITLE
Forms: introduce webhook provider files

### DIFF
--- a/projects/packages/forms/changelog/add-forms-webhook-providers
+++ b/projects/packages/forms/changelog/add-forms-webhook-providers
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Introduce webhook provider architecture with Generic and Salesforce providers

--- a/projects/packages/forms/src/service/class-generic-webhook-provider.php
+++ b/projects/packages/forms/src/service/class-generic-webhook-provider.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Generic Webhook Provider for Jetpack Contact Forms.
+ *
+ * @package automattic/jetpack-forms
+ */
+
+namespace Automattic\Jetpack\Forms\Service;
+
+/**
+ * Generic webhook provider for standard webhook integrations.
+ *
+ * This provider handles the standard postToUrl attribute configuration
+ * without any service-specific modifications.
+ */
+class Generic_Webhook_Provider extends Webhook_Provider {
+	/**
+	 * Build setup from postToUrl attribute.
+	 *
+	 * @param array $attributes Form attributes.
+	 * @return array|false Setup configuration or false if invalid/disabled.
+	 */
+	protected function build_setup( $attributes ) {
+		$defaults = array(
+			'url'      => '',
+			'verified' => false,
+			'format'   => 'json',
+			'enabled'  => false,
+		);
+
+		$setup = wp_parse_args(
+			! empty( $attributes['postToUrl'] ) ? $attributes['postToUrl'] : array(),
+			$defaults
+		);
+
+		if ( empty( $setup['enabled'] ) || empty( $setup['url'] ) ) {
+			return false;
+		}
+
+		if ( ! in_array( $setup['format'], array( 'urlencoded', 'json' ), true ) ) {
+			return false;
+		}
+
+		return $setup;
+	}
+
+	/**
+	 * No transformation needed for generic webhooks.
+	 *
+	 * Generic webhooks receive the data as-is from the form.
+	 *
+	 * @param array                                              $form_data    Base form data.
+	 * @param \Automattic\Jetpack\Forms\ContactForm\Contact_Form $form         The Contact_Form instance.
+	 * @param array                                              $entry_values The feedback entry values.
+	 * @return array Unmodified form data.
+	 */
+	public function transform_data( $form_data, $form, $entry_values ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		return $form_data;
+	}
+}

--- a/projects/packages/forms/src/service/class-salesforce-webhook-provider.php
+++ b/projects/packages/forms/src/service/class-salesforce-webhook-provider.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * Salesforce Webhook Provider for Jetpack Contact Forms.
+ *
+ * @package automattic/jetpack-forms
+ */
+
+namespace Automattic\Jetpack\Forms\Service;
+
+/**
+ * Salesforce-specific webhook provider.
+ *
+ * Handles Salesforce Web-to-Lead integration with service-specific
+ * configuration and data transformation.
+ */
+class Salesforce_Webhook_Provider extends Webhook_Provider {
+	/**
+	 * Build Salesforce Web-to-Lead setup.
+	 *
+	 * @param array $attributes Form attributes.
+	 * @return array|false Salesforce setup configuration or false if salesforceData is not present.
+	 */
+	protected function build_setup( $attributes ) {
+		// Only handle if salesforceData is present
+		if ( empty( $attributes['salesforceData'] ) || empty( $attributes['salesforceData']['organizationId'] ) ) {
+			return false;
+		}
+
+		return array(
+			'url'      => 'https://webto.salesforce.com/servlet/servlet.WebToLead?encoding=UTF-8',
+			'format'   => 'urlencoded',
+			'enabled'  => true,
+			'verified' => true,
+		);
+	}
+
+	/**
+	 * Add Salesforce-specific fields to form data.
+	 *
+	 * Adds the organization ID (oid) and lead source fields required
+	 * by Salesforce Web-to-Lead.
+	 *
+	 * @param array                                              $form_data    Base form data.
+	 * @param \Automattic\Jetpack\Forms\ContactForm\Contact_Form $form         The Contact_Form instance.
+	 * @param array                                              $entry_values The feedback entry values.
+	 * @return array Form data with Salesforce-specific fields added.
+	 */
+	public function transform_data( $form_data, $form, $entry_values ) {
+		if ( ! empty( $form->attributes['salesforceData']['organizationId'] ) ) {
+			$form_data['oid']         = sanitize_text_field( $form->attributes['salesforceData']['organizationId'] );
+			$form_data['lead_source'] = $entry_values['entry_permalink'] ?? '';
+		}
+
+		return $form_data;
+	}
+}

--- a/projects/packages/forms/src/service/class-webhook-provider.php
+++ b/projects/packages/forms/src/service/class-webhook-provider.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * Abstract Webhook Provider for Jetpack Contact Forms.
+ *
+ * @package automattic/jetpack-forms
+ */
+
+namespace Automattic\Jetpack\Forms\Service;
+
+/**
+ * Abstract class for webhook providers.
+ *
+ * Providers handle service-specific setup and data transformation.
+ * This allows Post_To_Url to remain generic while supporting different webhook services.
+ */
+abstract class Webhook_Provider {
+	/**
+	 * Cached setup configuration
+	 *
+	 * @var array|false
+	 */
+	protected $setup;
+
+	/**
+	 * Constructor - sets up the provider with form attributes.
+	 *
+	 * @param array $attributes Form attributes from the contact form.
+	 */
+	public function __construct( $attributes ) {
+		$this->setup = $this->build_setup( $attributes );
+	}
+
+	/**
+	 * Build the webhook setup configuration.
+	 *
+	 * @param array $attributes Form attributes from the contact form.
+	 * @return array|false Setup array with 'url', 'format', 'enabled', 'verified', or false if invalid/disabled.
+	 */
+	abstract protected function build_setup( $attributes );
+
+	/**
+	 * Get the cached setup configuration.
+	 *
+	 * @return array|false Setup configuration or false if invalid/disabled.
+	 */
+	public function get_setup() {
+		return $this->setup;
+	}
+
+	/**
+	 * Check if the webhook is enabled.
+	 *
+	 * @return bool True if the webhook is enabled and configured.
+	 */
+	public function is_enabled() {
+		return ! empty( $this->setup['enabled'] );
+	}
+
+	/**
+	 * Transform form data for this specific webhook service.
+	 *
+	 * Allows providers to add service-specific fields or modify existing data.
+	 *
+	 * @param array                                              $form_data    Base form data (field id => value pairs).
+	 * @param \Automattic\Jetpack\Forms\ContactForm\Contact_Form $form         The Contact_Form instance.
+	 * @param array                                              $entry_values The feedback entry values.
+	 * @return array Transformed form data ready for posting.
+	 */
+	abstract public function transform_data( $form_data, $form, $entry_values );
+}

--- a/projects/packages/forms/tests/php/service/Webhook_Provider_Test.php
+++ b/projects/packages/forms/tests/php/service/Webhook_Provider_Test.php
@@ -1,0 +1,296 @@
+<?php
+/**
+ * Unit Tests for Webhook Providers.
+ *
+ * @package automattic/jetpack-forms
+ */
+
+namespace Automattic\Jetpack\Forms\Service;
+
+use Automattic\Jetpack\Forms\ContactForm\Contact_Form;
+use PHPUnit\Framework\Attributes\CoversClass;
+use WorDBless\BaseTestCase;
+
+/**
+ * Test class for Webhook Providers
+ *
+ * @covers Automattic\Jetpack\Forms\Service\Generic_Webhook_Provider
+ * @covers Automattic\Jetpack\Forms\Service\Salesforce_Webhook_Provider
+ */
+#[CoversClass( Generic_Webhook_Provider::class )]
+#[CoversClass( Salesforce_Webhook_Provider::class )]
+class Webhook_Provider_Test extends BaseTestCase {
+
+	/**
+	 * Test Generic_Webhook_Provider::get_setup with valid configuration.
+	 */
+	public function test_generic_provider_get_setup_with_valid_config() {
+		$attributes = array(
+			'postToUrl' => array(
+				'enabled' => true,
+				'url'     => 'https://example.com/webhook',
+				'format'  => 'json',
+			),
+		);
+
+		$provider = new Generic_Webhook_Provider( $attributes );
+		$setup    = $provider->get_setup();
+
+		$this->assertIsArray( $setup );
+		$this->assertTrue( $setup['enabled'] );
+		$this->assertTrue( $provider->is_enabled() );
+		$this->assertEquals( 'https://example.com/webhook', $setup['url'] );
+		$this->assertEquals( 'json', $setup['format'] );
+		$this->assertFalse( $setup['verified'] );
+	}
+
+	/**
+	 * Test Generic_Webhook_Provider::get_setup with disabled configuration.
+	 */
+	public function test_generic_provider_get_setup_with_disabled_config() {
+		$attributes = array(
+			'postToUrl' => array(
+				'enabled' => false,
+				'url'     => 'https://example.com/webhook',
+			),
+		);
+
+		$provider = new Generic_Webhook_Provider( $attributes );
+		$setup    = $provider->get_setup();
+
+		$this->assertFalse( $setup );
+		$this->assertFalse( $provider->is_enabled() );
+	}
+
+	/**
+	 * Test Generic_Webhook_Provider::get_setup with missing URL.
+	 */
+	public function test_generic_provider_get_setup_with_missing_url() {
+		$attributes = array(
+			'postToUrl' => array(
+				'enabled' => true,
+				'format'  => 'json',
+			),
+		);
+
+		$provider = new Generic_Webhook_Provider( $attributes );
+		$setup    = $provider->get_setup();
+
+		$this->assertFalse( $setup );
+		$this->assertFalse( $provider->is_enabled() );
+	}
+
+	/**
+	 * Test Generic_Webhook_Provider::get_setup with invalid format.
+	 */
+	public function test_generic_provider_get_setup_with_invalid_format() {
+		$attributes = array(
+			'postToUrl' => array(
+				'enabled' => true,
+				'url'     => 'https://example.com/webhook',
+				'format'  => 'xml', // Invalid format
+			),
+		);
+
+		$provider = new Generic_Webhook_Provider( $attributes );
+		$setup    = $provider->get_setup();
+
+		$this->assertFalse( $setup );
+		$this->assertFalse( $provider->is_enabled() );
+	}
+
+	/**
+	 * Test Generic_Webhook_Provider::get_setup defaults to json.
+	 */
+	public function test_generic_provider_get_setup_defaults_to_urlencoded() {
+		$attributes = array(
+			'postToUrl' => array(
+				'enabled' => true,
+				'url'     => 'https://example.com/webhook',
+			),
+		);
+
+		$provider = new Generic_Webhook_Provider( $attributes );
+		$setup    = $provider->get_setup();
+
+		$this->assertIsArray( $setup );
+		$this->assertTrue( $provider->is_enabled() );
+		$this->assertEquals( 'json', $setup['format'] );
+	}
+
+	/**
+	 * Test Generic_Webhook_Provider::transform_data doesn't modify data.
+	 */
+	public function test_generic_provider_transform_data_unchanged() {
+		$attributes = array(
+			'postToUrl' => array(
+				'enabled' => true,
+				'url'     => 'https://example.com/webhook',
+			),
+		);
+
+		$provider = new Generic_Webhook_Provider( $attributes );
+
+		$form_data = array(
+			'name'  => 'John Doe',
+			'email' => 'john@example.com',
+		);
+
+		$form         = $this->getMockBuilder( Contact_Form::class )
+			->disableOriginalConstructor()
+			->getMock();
+		$entry_values = array( 'entry_permalink' => 'https://example.com/post/123' );
+
+		$result = $provider->transform_data( $form_data, $form, $entry_values );
+
+		$this->assertEquals( $form_data, $result );
+	}
+
+	/**
+	 * Test Salesforce_Webhook_Provider::get_setup with valid salesforceData.
+	 */
+	public function test_salesforce_provider_get_setup_with_valid_config() {
+		$attributes = array(
+			'salesforceData' => array(
+				'organizationId' => '00D123456789ABC',
+			),
+		);
+
+		$provider = new Salesforce_Webhook_Provider( $attributes );
+		$setup    = $provider->get_setup();
+
+		$this->assertIsArray( $setup );
+		$this->assertTrue( $setup['enabled'] );
+		$this->assertTrue( $provider->is_enabled() );
+		$this->assertTrue( $setup['verified'] );
+		$this->assertEquals( 'https://webto.salesforce.com/servlet/servlet.WebToLead?encoding=UTF-8', $setup['url'] );
+		$this->assertEquals( 'urlencoded', $setup['format'] );
+	}
+
+	/**
+	 * Test Salesforce_Webhook_Provider::get_setup without salesforceData.
+	 */
+	public function test_salesforce_provider_get_setup_without_salesforce_data() {
+		$attributes = array();
+
+		$provider = new Salesforce_Webhook_Provider( $attributes );
+		$setup    = $provider->get_setup();
+
+		$this->assertFalse( $setup );
+		$this->assertFalse( $provider->is_enabled() );
+	}
+
+	/**
+	 * Test Salesforce_Webhook_Provider::get_setup without organizationId.
+	 */
+	public function test_salesforce_provider_get_setup_without_organization_id() {
+		$attributes = array(
+			'salesforceData' => array(),
+		);
+
+		$provider = new Salesforce_Webhook_Provider( $attributes );
+		$setup    = $provider->get_setup();
+
+		$this->assertFalse( $setup );
+		$this->assertFalse( $provider->is_enabled() );
+	}
+
+	/**
+	 * Test Salesforce_Webhook_Provider::transform_data adds Salesforce fields.
+	 */
+	public function test_salesforce_provider_transform_data_adds_fields() {
+		$attributes = array(
+			'salesforceData' => array(
+				'organizationId' => '00D123456789ABC',
+			),
+		);
+
+		$provider = new Salesforce_Webhook_Provider( $attributes );
+
+		$form_data = array(
+			'first_name' => 'John',
+			'last_name'  => 'Doe',
+			'email'      => 'john@example.com',
+		);
+
+		$form             = $this->getMockBuilder( Contact_Form::class )
+			->disableOriginalConstructor()
+			->getMock();
+		$form->attributes = array(
+			'salesforceData' => array(
+				'organizationId' => '00D123456789ABC',
+			),
+		);
+		$entry_values     = array( 'entry_permalink' => 'https://example.com/post/123' );
+
+		$result = $provider->transform_data( $form_data, $form, $entry_values );
+
+		$this->assertArrayHasKey( 'oid', $result );
+		$this->assertArrayHasKey( 'lead_source', $result );
+		$this->assertSame( '00D123456789ABC', $result['oid'] );
+		$this->assertEquals( 'https://example.com/post/123', $result['lead_source'] );
+		// Original data should still be present
+		$this->assertEquals( 'John', $result['first_name'] );
+		$this->assertEquals( 'Doe', $result['last_name'] );
+		$this->assertEquals( 'john@example.com', $result['email'] );
+	}
+
+	/**
+	 * Test Salesforce_Webhook_Provider::transform_data sanitizes organizationId.
+	 */
+	public function test_salesforce_provider_transform_data_sanitizes_org_id() {
+		$attributes = array(
+			'salesforceData' => array(
+				'organizationId' => '<script>alert("xss")</script>00D123',
+			),
+		);
+
+		$provider = new Salesforce_Webhook_Provider( $attributes );
+
+		$form_data = array(
+			'email' => 'john@example.com',
+		);
+
+		$form             = $this->getMockBuilder( Contact_Form::class )
+			->disableOriginalConstructor()
+			->getMock();
+		$form->attributes = array(
+			'salesforceData' => array(
+				'organizationId' => '<script>alert("xss")</script>00D123',
+			),
+		);
+		$entry_values     = array( 'entry_permalink' => 'https://example.com/post/123' );
+
+		$result = $provider->transform_data( $form_data, $form, $entry_values );
+
+		$this->assertStringNotContainsString( '<script>', $result['oid'] );
+		$this->assertStringNotContainsString( 'alert', $result['oid'] );
+	}
+
+	/**
+	 * Test Salesforce_Webhook_Provider::transform_data without salesforceData.
+	 */
+	public function test_salesforce_provider_transform_data_without_salesforce_data() {
+		$attributes = array();
+
+		$provider = new Salesforce_Webhook_Provider( $attributes );
+
+		$form_data = array(
+			'email' => 'john@example.com',
+		);
+
+		$form             = $this->getMockBuilder( Contact_Form::class )
+			->disableOriginalConstructor()
+			->getMock();
+		$form->attributes = array();
+		$entry_values     = array( 'entry_permalink' => 'https://example.com/post/123' );
+
+		$result = $provider->transform_data( $form_data, $form, $entry_values );
+
+		// Should not add Salesforce fields
+		$this->assertArrayNotHasKey( 'oid', $result );
+		$this->assertArrayNotHasKey( 'lead_source', $result );
+		// Original data should be unchanged
+		$this->assertEquals( $form_data, $result );
+	}
+}


### PR DESCRIPTION
Fixes FORMS-435

## Proposed changes:
* Introduces an abstract `Webhook_Provider` class to encapsulate webhook setup and data transformation logic
* Adds `Generic_Webhook_Provider` for standard webhook integrations using the `postToUrl` attribute
* Adds `Salesforce_Webhook_Provider` for Salesforce Web-to-Lead integration with service-specific configuration
* Provides a foundation for adding additional webhook service providers in the future
* Includes comprehensive PHPUnit tests for both providers covering validation, setup, and data transformation

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

* Run `jetpack test php packages/forms --verbose`
* Verify all webhook provider tests pass
* Tests cover: configuration validation, setup building, data transformation, and security (XSS sanitization)
