### PR TITLE
Media Summary: allow skipping excerpt and text counts

### DIFF
--- a/projects/plugins/jetpack/changelog/update-media-summary
+++ b/projects/plugins/jetpack/changelog/update-media-summary
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Media Summary: allow skipping excerpt and text counts


### PR DESCRIPTION
Adds optional arguments to `Jetpack_Media_Summary::get()` that allow computing excerpt and text stats when the callers only need media data.

## Proposed changes:

* New args `$include_excerpt` and `$include_counts` which default to true.
* If turned off, we can skip `get_excerpt()`, `get_word_count()`, `get_word_remaining_count()`, and `get_link_count()`.
* Internal cache key honors these.

The idea is to let callers who only care about media (Open Graph helpers) skip the expensive excerpts pipeline (wpautop -> wp_kses -> word counting) and reduces time spent in `Jetpack_Media_Summary::get()` on these paths. Seeing savings of around ~10ms on a typical post.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

## Does this pull request change what data or activity we track or use?

## Testing instructions:

* Verify `Jetpack_Media_Summary::get( $post->ID )` returns the same info before and after

