### PR TITLE
actions: Set permissions for various smaller workflows

### DIFF
--- a/.github/actions/turnstile/README.md
+++ b/.github/actions/turnstile/README.md
@@ -52,6 +52,10 @@ jobs:
 
 If you want to limit the maximum amount of time spent waiting, use GitHub's [timeout-minutes](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepstimeout-minutes) on the step. If you want to continue if the timeout expires, use GitHub's [continue-on-error](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepscontinue-on-error) on the step.
 
+### Permissions
+
+When using `github.token`, this may need the `actions: read` workflow permission.
+
 ## How?
 
 Using the current run's run ID, it first hits GitHub's [workflow run API](https://docs.github.com/en/rest/actions/workflow-runs#get-a-workflow-run) to fetch the workflow ID and head branch.

--- a/.github/workflows/autotagger.yml
+++ b/.github/workflows/autotagger.yml
@@ -7,6 +7,13 @@ on:
       - prerelease
       - '*/branch-*'
 
+permissions:
+  # ./.github/actions/turnstile
+  actions: read
+  # read: actions/checkout
+  # write: `git push`
+  contents: write
+
 jobs:
   tag:
     name: Tag

--- a/.github/workflows/check-actions-rate-limit.yml
+++ b/.github/workflows/check-actions-rate-limit.yml
@@ -6,6 +6,7 @@ jobs:
   check:
     name: Check Actions rate limit
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
       - name: Check rate limit
         env:

--- a/.github/workflows/coverage-check.yml
+++ b/.github/workflows/coverage-check.yml
@@ -14,9 +14,9 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  checks: read
-  pull-requests: write
-  statuses: write
+  # actions/checkout
+  contents: read
+  # Everything else uses an app token, so no need for permissions.
 
 jobs:
   code-coverage-label:

--- a/.github/workflows/delete-mirror-branches.yml
+++ b/.github/workflows/delete-mirror-branches.yml
@@ -2,6 +2,11 @@ name: Delete mirror branches
 on:
   delete:
 
+permissions:
+  # actions/checkout
+  contents: read
+  # Deletion step uses secrets.API_TOKEN_GITHUB, so no need for permissions.
+
 jobs:
   delete:
     name: Delete `${{ github.event.ref }}`

--- a/.github/workflows/phpcompatibility-dev.yml
+++ b/.github/workflows/phpcompatibility-dev.yml
@@ -10,6 +10,10 @@ concurrency:
   group: phpcompatibility-dev-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  # actions/checkout
+  contents: read
+
 env:
   COMPOSER_ROOT_VERSION: "dev-trunk"
 
@@ -18,6 +22,11 @@ jobs:
     name: detect changed files
     runs-on: ubuntu-latest
     timeout-minutes: 1  # 2025-11-06: Successful runs seem to take a few seconds.
+    permissions:
+      # actions/checkout
+      contents: read
+      # dorny/paths-filter
+      pull-requests: read
     outputs:
       php: ${{ steps.filter.outputs.php }}
       misc: ${{ steps.filter.outputs.misc }}

--- a/.github/workflows/pr-is-up-to-date.yml
+++ b/.github/workflows/pr-is-up-to-date.yml
@@ -8,6 +8,11 @@ on:
       - pr-update-to
       - pr-update-to-projects/**
 
+permissions:
+  # ./.github/actions/turnstile
+  actions: read
+  # Note everything else, including actions/checkout, is using secrets.API_TOKEN_GITHUB, so no need for permissions.
+
 jobs:
   check:
     name: Check

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -23,6 +23,11 @@ on:
 concurrency:
   group: renovate-${{ github.ref }}
 
+permissions:
+  # actions/checkout
+  contents: read
+  # Note renovatebot/github-action is passed secrets.RENOVATE_TOKEN, so no need for permissions.
+
 jobs:
   renovate:
     name: Renovate

--- a/.github/workflows/slack-branch-existence-notification.yml
+++ b/.github/workflows/slack-branch-existence-notification.yml
@@ -3,6 +3,10 @@ on:
   create:
   delete:
 
+permissions:
+  # actions/checkout
+  contents: read
+
 jobs:
   notify:
     name: Notify

--- a/.github/workflows/slack-workflow-failed.yml
+++ b/.github/workflows/slack-workflow-failed.yml
@@ -17,6 +17,10 @@ on:
       - Update Phan stubs
     branches: [ 'trunk', 'prerelease', '*/branch-*' ]
 
+permissions:
+  # actions/checkout
+  contents: read
+
 jobs:
   notify:
     name: Notify failure

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -9,6 +9,12 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     timeout-minutes: 10 # 2025-11-20: Takes less than a minute.
+    permissions:
+      # Per actions/stale docs
+      actions: write
+      contents: write
+      issues: write
+      pull-requests: write
     steps:
       - uses: actions/stale@v10
         with:

--- a/.github/workflows/update-jetpack-staging-sites.yml
+++ b/.github/workflows/update-jetpack-staging-sites.yml
@@ -5,6 +5,10 @@ name: Update Jetpack Staging Test Sites
 on:
   workflow_dispatch:
 
+permissions:
+  # actions/checkout
+  contents: read
+
 jobs:
   run_shell_script:
     runs-on: ubuntu-latest

--- a/.github/workflows/update-phan-stubs.yml
+++ b/.github/workflows/update-phan-stubs.yml
@@ -6,9 +6,8 @@ on:
 concurrency:
   group: update-phan-stubs-${{ github.ref }}
 
-permissions:
-  contents: write
-  pull-requests: write
+# We use secrets.STUB_UPDATE_TOKEN_GITHUB for everything here (other than some public API queries against other repos), so no need for permissions.
+permissions: {}
 
 env:
   GIT_AUTHOR_NAME: matticbot


### PR DESCRIPTION
Closes MONOREP-263

 <!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Mostly through static analysis. A few made use of docs for other actions.

See inline comments for the main notes on what things need. Other notes:

* `.github/actions/turnstile` - It has docs, may as well mention it (theoretically) needing `actions: read`.
* coverage-check: Already had some set, but it turns out it doesn't need most of them anymore. It uses the app token for almost everything instead of the default Actions token.
* update-phan-stubs: This one also had permissions set that it doesn't need. It even uses a matticbot token for the checkout, so none needed at all.

Also the following already had permissions that seem correct:

* build-docker
* build-docker-monorepo
* post-build

Leaving build, e2e-tests, tests, and wpcloud for a later PR.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
Followup to #46067

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* CI happy?
* Try triggering various workflows in other contexts that aren't already done in this PR.
  * [x] autotagger: Something very similar in https://github.com/anomiex/testing/actions/runs/19678462964
  * [x] check-actions-rate-limit: https://github.com/Automattic/jetpack/actions/runs/19684735272
  * [ ] coverage-check: 
  * [ ] delete-mirror-branches: 
  * [x] phpcompatibility-dev: https://github.com/Automattic/jetpack/actions/runs/19684667135
  * [ ] pr-is-up-to-date: https://github.com/Automattic/jetpack/actions/runs/19684667032, (still needs one for the other code path)
  * [ ] renovate: 
  * [ ] slack-branch-existence-notification: 
  * [ ] slack-workflow-failed: 
  * [x] stale: https://github.com/Automattic/jetpack/actions/runs/19685127579
  * [x] update-jetpack-staging-sites: https://github.com/Automattic/jetpack/actions/runs/19685195273
  * [x] update-phan-stubs: https://github.com/anomiex/jetpack/actions/runs/19683314789, https://github.com/anomiex/jetpack/actions/runs/19683363255