### PR TITLE
OG tags: use media-only Jetpack_Media_Summary()

### DIFF
--- a/projects/plugins/jetpack/changelog/update-enhanced-open-graph
+++ b/projects/plugins/jetpack/changelog/update-enhanced-open-graph
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+OG tags: use media-only Jetpack_Media_Summary::get

--- a/projects/plugins/jetpack/enhanced-open-graph.php
+++ b/projects/plugins/jetpack/enhanced-open-graph.php
@@ -35,7 +35,14 @@ function enhanced_og_image( $tags ) {
 		return $tags;
 	}
 
-	$summary = Jetpack_Media_Summary::get( $post->ID );
+	$summary = Jetpack_Media_Summary::get(
+		$post->ID,
+		0,
+		array(
+			'include_excerpt' => false,
+			'include_count'   => false,
+		)
+	);
 
 	if ( 'image' !== $summary['type'] ) {
 		return $tags;
@@ -70,7 +77,14 @@ function enhanced_og_gallery( $tags ) {
 		return $tags;
 	}
 
-	$summary = Jetpack_Media_Summary::get( $post->ID );
+	$summary = Jetpack_Media_Summary::get(
+		$post->ID,
+		0,
+		array(
+			'include_excerpt' => false,
+			'include_count'   => false,
+		)
+	);
 
 	if ( 'gallery' !== $summary['type'] ) {
 		return $tags;
@@ -117,7 +131,14 @@ function enhanced_og_video( $tags ) {
 		return $tags;
 	}
 
-	$summary = Jetpack_Media_Summary::get( $post->ID );
+	$summary = Jetpack_Media_Summary::get(
+		$post->ID,
+		0,
+		array(
+			'include_excerpt' => false,
+			'include_count'   => false,
+		)
+	);
 
 	if ( 'video' !== $summary['type'] ) {
 		if ( $summary['count']['video'] > 0 && $summary['count']['image'] < 1 ) {


### PR DESCRIPTION
Update the enhanced-open-graph.php helpers to use the new "media-only" mode in Jetpack_Media_Summary::get() (added in #46091).

Basically, we are removing the amount of unused work. Calling into `::get()` with the default arguments involves processing the excerpt, which goes down chains of wpautop and wp_kses, but that's not needed when generated the opengraph tags. We only look at the media that's included in these three functions, so they can skip the excerpt processing stuff.

On a specific blog with longish posts, I saw this saving about ~10ms when generating the OpenGraph tags.

## Proposed changes:
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

## Does this pull request change what data or activity we track or use?

## Testing instructions:

* Go to '..'
*

