### PR TITLE
Forms: Fix notices positioning on dashboard

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-notices-layout
+++ b/projects/packages/forms/changelog/fix-forms-notices-layout
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: Fix notices positioning on dashboard

--- a/projects/packages/forms/src/dashboard/inbox/style.scss
+++ b/projects/packages/forms/src/dashboard/inbox/style.scss
@@ -161,7 +161,7 @@
 	display: flex;
 	flex-direction: column;
 	flex: 1 1 auto;
-	height: calc(100vh - var(--wp-admin-bar-height, 32px));
+	position: relative;
 
 	// First child is the router wrapper
 	> div:first-child {

--- a/projects/packages/forms/src/dashboard/inbox/style.scss
+++ b/projects/packages/forms/src/dashboard/inbox/style.scss
@@ -162,6 +162,8 @@
 	flex-direction: column;
 	flex: 1 1 auto;
 	position: relative;
+	// 3px fixes the flickering issue when the notices are displayed.
+	height: calc(100vh - var(--wp-admin-bar-height, 32px) - 3px);
 
 	// First child is the router wrapper
 	> div:first-child {

--- a/projects/packages/forms/src/dashboard/inbox/style.scss
+++ b/projects/packages/forms/src/dashboard/inbox/style.scss
@@ -161,9 +161,7 @@
 	display: flex;
 	flex-direction: column;
 	flex: 1 1 auto;
-	position: relative;
-	// 3px fixes the flickering issue when the notices are displayed.
-	height: calc(100vh - var(--wp-admin-bar-height, 32px) - 3px);
+	height: calc(100vh - var(--wp-admin-bar-height, 32px));
 
 	// First child is the router wrapper
 	> div:first-child {

--- a/projects/packages/forms/src/dashboard/style.scss
+++ b/projects/packages/forms/src/dashboard/style.scss
@@ -34,7 +34,7 @@ body.jetpack_page_jetpack-forms-admin {
 
 // Adjust the position of the notices.
 .forms-dashboard-notices {
-	position: sticky;
+	position: absolute;
 	right: 0;
 	bottom: 44px;
 	padding-left: 24px;

--- a/projects/packages/forms/src/dashboard/style.scss
+++ b/projects/packages/forms/src/dashboard/style.scss
@@ -34,7 +34,7 @@ body.jetpack_page_jetpack-forms-admin {
 
 // Adjust the position of the notices.
 .forms-dashboard-notices {
-	position: absolute;
+	position: fixed;
 	right: 0;
 	bottom: 44px;
 	padding-left: 24px;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Changes the notices container positioning to be relative to the window, aligning with WP admin. This fixes both flickering and the notices taking space below the table

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p8oabR-1IP-p2#comment-8700

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Test with multiple browsers, as the flickering does not happen on Firefox, but does on Chrome.

* Go to the dashboard
* Make sure the viewport is bigger than the sidebar, there should be space after the last sidebar item
* Select one response
* Mark it as read/unread
* Check that the notices positioning is fixed and relative to the window
* Check that there is no flickering

| Before | After |
| - | - |
| <img width="466" height="238" alt="Screenshot from 2025-11-25 22-43-03" src="https://github.com/user-attachments/assets/4ccc728f-b00a-4ad1-a1cc-8d3e66a2ae92" /> | <img width="429" height="256" alt="Screenshot from 2025-11-26 12-21-05" src="https://github.com/user-attachments/assets/f076685b-2362-4876-93bd-3b72794c435f" /> |