### PR TITLE
SOCIAL-247 Update sidebar labels

### DIFF
--- a/projects/js-packages/publicize-components/changelog/update-SOCIAL-247-update-labels
+++ b/projects/js-packages/publicize-components/changelog/update-SOCIAL-247-update-labels
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated Jetpack sidebar labels for post editor sidebar.

--- a/projects/js-packages/publicize-components/src/components/block-editor/components/placeholder.tsx
+++ b/projects/js-packages/publicize-components/src/components/block-editor/components/placeholder.tsx
@@ -27,7 +27,7 @@ export const Placeholder = () => {
 	return (
 		<PanelBody
 			className="jetpack-publicize__placeholder"
-			title={ __( 'Share to Social Media', 'jetpack-publicize-components' ) }
+			title={ __( 'Share to social media', 'jetpack-publicize-components' ) }
 			initialOpen={ false }
 			onToggle={ trackPlaceholderView }
 		>

--- a/projects/js-packages/publicize-components/src/components/block-editor/components/pre-publish-panels.tsx
+++ b/projects/js-packages/publicize-components/src/components/block-editor/components/pre-publish-panels.tsx
@@ -13,7 +13,7 @@ const PrePublishPanels = () => {
 	return (
 		<PluginPrePublishPanel
 			initialOpen={ hasEnabledConnections }
-			title={ __( 'Share to Social Media', 'jetpack-publicize-components' ) }
+			title={ __( 'Share to social media', 'jetpack-publicize-components' ) }
 			icon={ <JetpackEditorPanelLogo /> }
 		>
 			<PublicizePanel prePublish={ true } />

--- a/projects/js-packages/publicize-components/src/components/block-editor/components/social-settings.tsx
+++ b/projects/js-packages/publicize-components/src/components/block-editor/components/social-settings.tsx
@@ -21,7 +21,7 @@ const RenderSettings = () => {
 
 			{ /* Social Previews panel */ }
 			{ isModalOpened && <SocialPreviewsModal onClose={ closeModal } /> }
-			<PanelBody title={ __( 'Link Preview', 'jetpack-publicize-components' ) }>
+			<PanelBody title={ __( 'Link preview', 'jetpack-publicize-components' ) }>
 				<SocialPreviewsPanel openModal={ openModal } />
 			</PanelBody>
 		</ThemeProvider>

--- a/projects/js-packages/publicize-components/src/components/panel/index.tsx
+++ b/projects/js-packages/publicize-components/src/components/panel/index.tsx
@@ -51,7 +51,7 @@ const PublicizePanel = ( { prePublish }: PublicizePanelProps ) => {
 	const wrapperProps = prePublish
 		? {}
 		: {
-				title: __( 'Share to Social Media', 'jetpack-publicize-components' ),
+				title: __( 'Share to social media', 'jetpack-publicize-components' ),
 				className: styles.panel,
 		  };
 

--- a/projects/js-packages/publicize-components/src/components/social-previews/panel.js
+++ b/projects/js-packages/publicize-components/src/components/social-previews/panel.js
@@ -30,7 +30,7 @@ const SocialPreviewsPanel = ( { openModal } ) => {
 			<Button
 				variant="secondary"
 				onClick={ openModal }
-				label={ __( 'Open Link Preview', 'jetpack-publicize-components' ) }
+				label={ __( 'Open link preview', 'jetpack-publicize-components' ) }
 			>
 				{ _x(
 					'Preview',

--- a/projects/plugins/jetpack/changelog/update-SOCIAL-247-update-labels
+++ b/projects/plugins/jetpack/changelog/update-SOCIAL-247-update-labels
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Updated Jetpack sidebar labels for post editor sidebar.

--- a/projects/plugins/jetpack/extensions/shared/jetpack-likes-and-sharing-panel.js
+++ b/projects/plugins/jetpack/extensions/shared/jetpack-likes-and-sharing-panel.js
@@ -20,7 +20,7 @@ registerPlugin( 'jetpack-likes-and-sharing-panel', {
 						<JetpackPluginSidebar>
 							<PanelBody
 								className="jetpack-likes-sharing-panel"
-								title={ __( 'Insert Likes and Sharing', 'jetpack' ) }
+								title={ __( 'Insert likes and sharing', 'jetpack' ) }
 								initialOpen={ false }
 							>
 								{ fills }

--- a/projects/plugins/jetpack/tests/e2e/specs/editor/sidebar-social.test.ts
+++ b/projects/plugins/jetpack/tests/e2e/specs/editor/sidebar-social.test.ts
@@ -12,10 +12,10 @@ test.describe( 'Editor sidebar: Social', () => {
 		const settingsSidebar = editor.getEditorSettingsSidebar();
 
 		const socialPanel = settingsSidebar.getByRole( 'button', {
-			name: 'Share to Social Media',
+			name: 'Share to social media',
 		} );
 
-		logger.debug( 'Expand "Share to Social Media" panel' );
+		logger.debug( 'Expand "Share to social media" panel' );
 		await socialPanel.click();
 
 		const activateSocialLink = settingsSidebar.getByRole( 'link', {

--- a/projects/plugins/social/changelog/update-SOCIAL-247-update-labels
+++ b/projects/plugins/social/changelog/update-SOCIAL-247-update-labels
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix e2e tests for link preview in the editor sidebar.

--- a/projects/plugins/social/tests/e2e/specs/social-sidebar.test.ts
+++ b/projects/plugins/social/tests/e2e/specs/social-sidebar.test.ts
@@ -21,7 +21,7 @@ test( 'Jetpack Social sidebar', async ( { page, admin, editor } ) => {
 		await editor.openSettings( 'Jetpack Social' );
 		const previewButton = editor
 			.getEditorSettingsSidebar()
-			.getByRole( 'button', { name: 'Open Link Preview', exact: true } );
+			.getByRole( 'button', { name: 'Open link preview', exact: true } );
 		await expect( previewButton ).toBeVisible();
 	} );
 } );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes SOCIAL-247

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Updating sidebar labels to avoid capital letters for words that are not feature names
* Follow-up to https://github.com/Automattic/jetpack/pull/46007#issuecomment-3575859886

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to a JN site with Jetpack Social
* Verify that the sidebar labels look like on the screenshot below

<img width="291" height="315" alt="SCR-20251126-ojsm" src="https://github.com/user-attachments/assets/f99462b0-a978-4bf4-a7ce-869290742c6c" />

