### PR TITLE
Forms: add comprehensive webhook functionality

### DIFF
--- a/projects/packages/forms/changelog/add-forms-webhooks-prettyfication
+++ b/projects/packages/forms/changelog/add-forms-webhooks-prettyfication
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Form Webhooks: clean up and consolidate webhooks to take over the unused-yet-present postToUrl

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -1556,8 +1556,18 @@ class Contact_Form_Plugin {
 				return $form->errors;
 			}
 
-			if ( ! empty( $form->attributes['salesforceData'] ) || ! empty( $form->attributes['postToUrl'] ) ) {
+			if ( ! empty( $form->attributes['salesforceData'] ) ) {
 				Post_To_Url::init();
+			}
+
+			// Deprecate postToUrl, migrate to webhooks in case someone put it to work.
+			if ( ! empty( $form->attributes['postToUrl'] ) ) {
+				// webhooks should be a collection.
+				// Turn postToUrl into a collection and merge with existing webhooks.
+				$form->attributes['webhooks'] = array_merge(
+					$form->attributes['webhooks'] ?? array(),
+					array( $form->attributes['postToUrl'] )
+				);
 			}
 
 			if ( ! empty( $form->attributes['webhooks'] ) ) {
@@ -1727,8 +1737,18 @@ class Contact_Form_Plugin {
 			return $form->errors;
 		}
 
-		if ( ! empty( $form->attributes['salesforceData'] ) || ! empty( $form->attributes['postToUrl'] ) ) {
+		if ( ! empty( $form->attributes['salesforceData'] ) ) {
 			Post_To_Url::init();
+		}
+
+		// Deprecate postToUrl, migrate to webhooks in case someone put it to work.
+		if ( ! empty( $form->attributes['postToUrl'] ) ) {
+			// webhooks should be a collection.
+			// Turn postToUrl into a collection and merge with existing webhooks.
+			$form->attributes['webhooks'] = array_merge(
+				$form->attributes['webhooks'] ?? array(),
+				array( $form->attributes['postToUrl'] )
+			);
 		}
 
 		if ( ! empty( $form->attributes['webhooks'] ) ) {

--- a/projects/packages/forms/src/service/class-form-webhooks.php
+++ b/projects/packages/forms/src/service/class-form-webhooks.php
@@ -151,28 +151,40 @@ class Form_Webhooks {
 
 		$enabled_webhooks = array();
 		foreach ( $attributes['webhooks'] as $webhook ) {
+			$defaults = array(
+				'webhook_id' => '',
+				'url'        => '',
+				'method'     => self::METHOD_POST,
+				'verified'   => false,
+				'format'     => self::FORMAT_JSON,
+				'enabled'    => false,
+			);
+
+			$setup = wp_parse_args(
+				is_array( $webhook ) && ! empty( $webhook ) ? $webhook : array(),
+				$defaults
+			);
+
 			// Validate webhook configuration
-			if ( empty( $webhook['enabled'] ) || empty( $webhook['url'] ) ) {
+			if ( empty( $setup['enabled'] ) || empty( $setup['url'] ) ) {
 				continue;
 			}
 
 			// Validate format
-			$format = ! empty( $webhook['format'] ) ? $webhook['format'] : 'json';
-			if ( ! in_array( $format, array( 'urlencoded', 'json' ), true ) ) {
+			if ( ! array_key_exists( $setup['format'], self::VALID_FORMATS_MAP ) ) {
 				continue;
 			}
 
 			// Validate method
-			$method = ! empty( $webhook['method'] ) ? strtoupper( $webhook['method'] ) : 'POST';
-			if ( ! in_array( $method, array( 'POST', 'GET', 'PUT' ), true ) ) {
+			if ( ! in_array( $setup['method'], self::VALID_METHODS, true ) ) {
 				continue;
 			}
 
 			$enabled_webhooks[] = array(
-				'webhook_id' => ! empty( $webhook['webhook_id'] ) ? $webhook['webhook_id'] : '',
-				'url'        => $webhook['url'],
-				'format'     => $format,
-				'method'     => $method,
+				'webhook_id' => $setup['webhook_id'],
+				'url'        => $setup['url'],
+				'format'     => $setup['format'],
+				'method'     => $setup['method'],
 			);
 		}
 

--- a/projects/packages/forms/src/service/class-form-webhooks.php
+++ b/projects/packages/forms/src/service/class-form-webhooks.php
@@ -218,12 +218,10 @@ class Form_Webhooks {
 
 		$user_agent = "WordPress/{$wp_version} | Jetpack/" . constant( 'JETPACK__VERSION' ) . '; ' . get_bloginfo( 'url' );
 		$url        = $webhook['url'];
-		$format     = $webhook['format'] === 'urlencoded' ? 'application/x-www-form-urlencoded' : 'application/json';
+		$format     = self::VALID_FORMATS_MAP[ $webhook['format'] ];
 		$method     = $webhook['method'];
-
 		// Encode body based on format
-		$body = $webhook['format'] === 'json' ? wp_json_encode( $data ) : $data;
-
+		$body = $webhook['format'] === self::FORMAT_JSON ? wp_json_encode( $data ) : $data;
 		$args = array(
 			'method'    => $method,
 			'body'      => $body,
@@ -233,7 +231,6 @@ class Form_Webhooks {
 			),
 			'sslverify' => true,
 		);
-
 		return wp_remote_request( $url, $args );
 	}
 

--- a/projects/packages/forms/src/service/class-form-webhooks.php
+++ b/projects/packages/forms/src/service/class-form-webhooks.php
@@ -206,15 +206,16 @@ class Form_Webhooks {
 		 * Filters the form data before sending it to the webhook.
 		 *
 		 * Allows developers to modify or augment the form data before it's sent to the webhook endpoint.
+		 * NOTE: data has to be the first argument so it can be defaulted.
 		 *
 		 * @since $$next-version$$
 		 *
-		 * @param string $webhook_id The unique identifier for this webhook.
 		 * @param array  $form_data  The form data to be sent (field IDs as keys, values as values).
+		 * @param string $webhook_id The unique identifier for this webhook.
 		 *
 		 * @return array The form data to be sent (field IDs as keys, values as values).
 		 */
-		$data = apply_filters( 'jetpack_forms_before_webhook_request', $webhook['webhook_id'], $data );
+		$data = apply_filters( 'jetpack_forms_before_webhook_request', $data, $webhook['webhook_id'] );
 
 		$user_agent = "WordPress/{$wp_version} | Jetpack/" . constant( 'JETPACK__VERSION' ) . '; ' . get_bloginfo( 'url' );
 		$url        = $webhook['url'];

--- a/projects/packages/forms/src/service/class-form-webhooks.php
+++ b/projects/packages/forms/src/service/class-form-webhooks.php
@@ -22,6 +22,31 @@ class Form_Webhooks {
 	 */
 	private static $instance = null;
 
+	private const FORMAT_URL_ENCODED       = 'urlencoded';
+	private const FORMAT_JSON              = 'json';
+	private const METHOD_POST              = 'POST';
+	private const METHOD_GET               = 'GET';
+	private const METHOD_PUT               = 'PUT';
+	private const CONTENT_TYPE_URL_ENCODED = 'application/x-www-form-urlencoded';
+	private const CONTENT_TYPE_JSON        = 'application/json';
+
+	/**
+	 * Valid methods for webhook requests.
+	 *
+	 * @var array
+	 */
+	private const VALID_METHODS = array( self::METHOD_POST, self::METHOD_GET, self::METHOD_PUT );
+
+	/**
+	 * Valid formats for webhook requests.
+	 *
+	 * @var array
+	 */
+	private const VALID_FORMATS_MAP = array(
+		self::FORMAT_URL_ENCODED => self::CONTENT_TYPE_URL_ENCODED,
+		self::FORMAT_JSON        => self::CONTENT_TYPE_JSON,
+	);
+
 	/**
 	 * Initialize and return singleton instance.
 	 *

--- a/projects/packages/forms/tests/php/service/Form_Webhooks_Test.php
+++ b/projects/packages/forms/tests/php/service/Form_Webhooks_Test.php
@@ -198,7 +198,9 @@ class Form_Webhooks_Test extends BaseTestCase {
 		$this->assertEquals( 'application/json', $captured_request['args']['headers']['Content-Type'] );
 
 		$body_data = json_decode( $captured_request['args']['body'], true );
+		// @phan-suppress-next-line PhanTypeArraySuspiciousNullable
 		$this->assertEquals( 'John Doe', $body_data['name'] );
+		// @phan-suppress-next-line PhanTypeArraySuspiciousNullable
 		$this->assertEquals( 'john@example.com', $body_data['email'] );
 	}
 
@@ -422,7 +424,9 @@ class Form_Webhooks_Test extends BaseTestCase {
 		$webhooks = Form_Webhooks::init();
 		$webhooks->send_webhooks( 123, $fields, false, array() );
 
+		// @phan-suppress-next-line PhanTypeArraySuspiciousNull, PhanTypeMismatchArgumentInternal
 		$body_data = json_decode( $captured_request['args']['body'], true );
+		// @phan-suppress-next-line PhanTypeArraySuspiciousNullable
 		$this->assertEquals( 'custom_value', $body_data['custom_field'] );
 	}
 
@@ -464,6 +468,7 @@ class Form_Webhooks_Test extends BaseTestCase {
 		$this->assertNotEmpty( $response_meta );
 
 		$response_data = json_decode( $response_meta, true );
+		// @phan-suppress-next-line PhanTypeArraySuspiciousNullable
 		$this->assertEquals( 200, $response_data['http_code'] );
 		$this->assertArrayHasKey( 'timestamp', $response_data );
 	}
@@ -554,9 +559,13 @@ class Form_Webhooks_Test extends BaseTestCase {
 		$webhooks = Form_Webhooks::init();
 		$webhooks->send_webhooks( 123, $fields, false, array() );
 
+		// @phan-suppress-next-line PhanTypeArraySuspiciousNull, PhanTypeMismatchArgumentInternal
 		$body_data = json_decode( $captured_request['args']['body'], true );
+		// @phan-suppress-next-line PhanTypeArraySuspiciousNullable
 		$this->assertEquals( 'john@example.com', $body_data['email'] );
+		// @phan-suppress-next-line PhanTypeArraySuspiciousNullable
 		$this->assertEquals( 'google', $body_data['utm_source'] );
+		// @phan-suppress-next-line PhanTypeArraySuspiciousNullable
 		$this->assertEquals( 'summer_2025', $body_data['utm_campaign'] );
 	}
 

--- a/projects/packages/forms/tests/php/service/Form_Webhooks_Test.php
+++ b/projects/packages/forms/tests/php/service/Form_Webhooks_Test.php
@@ -1,0 +1,610 @@
+<?php
+/**
+ * Unit Tests for Form_Webhooks.
+ *
+ * @package automattic/jetpack-forms
+ */
+
+namespace Automattic\Jetpack\Forms\Service;
+
+use Automattic\Jetpack\Forms\ContactForm\Contact_Form;
+use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field;
+use PHPUnit\Framework\Attributes\CoversClass;
+use WorDBless\BaseTestCase;
+use WpOrg\Requests\Utility\CaseInsensitiveDictionary;
+
+/**
+ * Test class for Form_Webhooks
+ *
+ * @covers Automattic\Jetpack\Forms\Service\Form_Webhooks
+ */
+#[CoversClass( Form_Webhooks::class )]
+class Form_Webhooks_Test extends BaseTestCase {
+
+	/**
+	 * Test webhook is not sent when no webhooks are configured.
+	 */
+	public function test_send_webhooks_does_nothing_when_no_webhooks_configured() {
+		$form   = $this->create_mock_form( array() );
+		$fields = array( $this->create_mock_field( $form, 'test-field', 'test value' ) );
+
+		// Mock wp_remote_request should not be called
+		$this->assertFalse( has_filter( 'pre_http_request' ) );
+
+		$webhooks = Form_Webhooks::init();
+		$webhooks->send_webhooks( 123, $fields, false, array() );
+	}
+
+	/**
+	 * Test webhook is not sent when webhook is disabled.
+	 */
+	public function test_send_webhooks_skips_disabled_webhooks() {
+		$form   = $this->create_mock_form(
+			array(
+				'webhooks' => array(
+					array(
+						'webhook_id' => 'test-webhook',
+						'url'        => 'https://example.com/webhook',
+						'format'     => 'json',
+						'method'     => 'POST',
+						'enabled'    => false,
+					),
+				),
+			)
+		);
+		$fields = array( $this->create_mock_field( $form, 'test-field', 'test value' ) );
+
+		// Track if HTTP request was made
+		$http_request_made = false;
+		add_filter(
+			'pre_http_request',
+			function () use ( &$http_request_made ) {
+				$http_request_made = true;
+				return array(
+					'response' => array( 'code' => 200 ),
+					'body'     => '{"success":true}',
+				);
+			}
+		);
+
+		$webhooks = Form_Webhooks::init();
+		$webhooks->send_webhooks( 123, $fields, false, array() );
+
+		$this->assertFalse( $http_request_made, 'HTTP request should not be made for disabled webhook' );
+	}
+
+	/**
+	 * Test webhook is not sent when URL is missing.
+	 */
+	public function test_send_webhooks_skips_webhooks_without_url() {
+		$form   = $this->create_mock_form(
+			array(
+				'webhooks' => array(
+					array(
+						'webhook_id' => 'test-webhook',
+						'url'        => '',
+						'format'     => 'json',
+						'method'     => 'POST',
+						'enabled'    => true,
+					),
+				),
+			)
+		);
+		$fields = array( $this->create_mock_field( $form, 'test-field', 'test value' ) );
+
+		// Track if HTTP request was made
+		$http_request_made = false;
+		add_filter(
+			'pre_http_request',
+			function () use ( &$http_request_made ) {
+				$http_request_made = true;
+				return array(
+					'response' => array( 'code' => 200 ),
+					'body'     => '{"success":true}',
+				);
+			}
+		);
+
+		$webhooks = Form_Webhooks::init();
+		$webhooks->send_webhooks( 123, $fields, false, array() );
+
+		$this->assertFalse( $http_request_made, 'HTTP request should not be made for webhook without URL' );
+	}
+
+	/**
+	 * Test webhook is not sent for spam submissions.
+	 */
+	public function test_send_webhooks_skips_spam_submissions() {
+		$form   = $this->create_mock_form(
+			array(
+				'webhooks' => array(
+					array(
+						'webhook_id' => 'test-webhook',
+						'url'        => 'https://example.com/webhook',
+						'format'     => 'json',
+						'method'     => 'POST',
+						'enabled'    => true,
+					),
+				),
+			)
+		);
+		$fields = array( $this->create_mock_field( $form, 'test-field', 'test value' ) );
+
+		// Track if HTTP request was made
+		$http_request_made = false;
+		add_filter(
+			'pre_http_request',
+			function () use ( &$http_request_made ) {
+				$http_request_made = true;
+				return array(
+					'response' => array( 'code' => 200 ),
+					'body'     => '{"success":true}',
+				);
+			}
+		);
+
+		$webhooks = Form_Webhooks::init();
+		$webhooks->send_webhooks( 123, $fields, true, array() ); // is_spam = true
+
+		$this->assertFalse( $http_request_made, 'HTTP request should not be made for spam submissions' );
+	}
+
+	/**
+	 * Test webhook sends JSON formatted data.
+	 */
+	public function test_send_webhooks_sends_json_data() {
+		$form         = $this->create_mock_form(
+			array(
+				'webhooks' => array(
+					array(
+						'webhook_id' => 'test-webhook',
+						'url'        => 'https://example.com/webhook',
+						'format'     => 'json',
+						'method'     => 'POST',
+						'enabled'    => true,
+					),
+				),
+			)
+		);
+		$field1       = $this->create_mock_field( $form, 'name', 'John Doe' );
+		$field2       = $this->create_mock_field( $form, 'email', 'john@example.com' );
+		$form->fields = array( $field1, $field2 );
+		$fields       = array( $field1, $field2 );
+
+		$captured_request = null;
+		add_filter(
+			'pre_http_request',
+			function ( $preempt, $args, $url ) use ( &$captured_request ) {
+				$captured_request = array(
+					'url'  => $url,
+					'args' => $args,
+				);
+				return array(
+					'response' => array( 'code' => 200 ),
+					'body'     => '{"success":true}',
+					'headers'  => new CaseInsensitiveDictionary( array( 'Content-Type' => 'application/json' ) ),
+				);
+			},
+			10,
+			3
+		);
+
+		$webhooks = Form_Webhooks::init();
+		$webhooks->send_webhooks( 123, $fields, false, array() );
+
+		$this->assertNotNull( $captured_request, 'HTTP request should be made' );
+		$this->assertEquals( 'https://example.com/webhook', $captured_request['url'] );
+		$this->assertEquals( 'POST', $captured_request['args']['method'] );
+		$this->assertEquals( 'application/json', $captured_request['args']['headers']['Content-Type'] );
+
+		$body_data = json_decode( $captured_request['args']['body'], true );
+		$this->assertEquals( 'John Doe', $body_data['name'] );
+		$this->assertEquals( 'john@example.com', $body_data['email'] );
+	}
+
+	/**
+	 * Test webhook sends URL-encoded data.
+	 */
+	public function test_send_webhooks_sends_urlencoded_data() {
+		$form         = $this->create_mock_form(
+			array(
+				'webhooks' => array(
+					array(
+						'webhook_id' => 'test-webhook',
+						'url'        => 'https://example.com/webhook',
+						'format'     => 'urlencoded',
+						'method'     => 'POST',
+						'enabled'    => true,
+					),
+				),
+			)
+		);
+		$field1       = $this->create_mock_field( $form, 'name', 'John Doe' );
+		$field2       = $this->create_mock_field( $form, 'email', 'john@example.com' );
+		$form->fields = array( $field1, $field2 );
+		$fields       = array( $field1, $field2 );
+
+		$captured_request = null;
+		add_filter(
+			'pre_http_request',
+			function ( $preempt, $args, $url ) use ( &$captured_request ) {
+				$captured_request = array(
+					'url'  => $url,
+					'args' => $args,
+				);
+				return array(
+					'response' => array( 'code' => 200 ),
+					'body'     => '{"success":true}',
+					'headers'  => new CaseInsensitiveDictionary( array( 'Content-Type' => 'application/x-www-form-urlencoded' ) ),
+				);
+			},
+			10,
+			3
+		);
+
+		$webhooks = Form_Webhooks::init();
+		$webhooks->send_webhooks( 123, $fields, false, array() );
+
+		$this->assertNotNull( $captured_request, 'HTTP request should be made' );
+		$this->assertEquals( 'application/x-www-form-urlencoded', $captured_request['args']['headers']['Content-Type'] );
+		$this->assertIsArray( $captured_request['args']['body'] );
+		$this->assertEquals( 'John Doe', $captured_request['args']['body']['name'] );
+		$this->assertEquals( 'john@example.com', $captured_request['args']['body']['email'] );
+	}
+
+	/**
+	 * Test webhook skips invalid format.
+	 */
+	public function test_send_webhooks_skips_invalid_format() {
+		$form   = $this->create_mock_form(
+			array(
+				'webhooks' => array(
+					array(
+						'webhook_id' => 'test-webhook',
+						'url'        => 'https://example.com/webhook',
+						'format'     => 'xml', // Invalid format
+						'method'     => 'POST',
+						'enabled'    => true,
+					),
+				),
+			)
+		);
+		$fields = array( $this->create_mock_field( $form, 'test-field', 'test value' ) );
+
+		$http_request_made = false;
+		add_filter(
+			'pre_http_request',
+			function () use ( &$http_request_made ) {
+				$http_request_made = true;
+				return array(
+					'response' => array( 'code' => 200 ),
+					'body'     => '{"success":true}',
+				);
+			}
+		);
+
+		$webhooks = Form_Webhooks::init();
+		$webhooks->send_webhooks( 123, $fields, false, array() );
+
+		$this->assertFalse( $http_request_made, 'HTTP request should not be made for invalid format' );
+	}
+
+	/**
+	 * Test webhook skips invalid method.
+	 */
+	public function test_send_webhooks_skips_invalid_method() {
+		$form   = $this->create_mock_form(
+			array(
+				'webhooks' => array(
+					array(
+						'webhook_id' => 'test-webhook',
+						'url'        => 'https://example.com/webhook',
+						'format'     => 'json',
+						'method'     => 'DELETE', // Invalid method
+						'enabled'    => true,
+					),
+				),
+			)
+		);
+		$fields = array( $this->create_mock_field( $form, 'test-field', 'test value' ) );
+
+		$http_request_made = false;
+		add_filter(
+			'pre_http_request',
+			function () use ( &$http_request_made ) {
+				$http_request_made = true;
+				return array(
+					'response' => array( 'code' => 200 ),
+					'body'     => '{"success":true}',
+				);
+			}
+		);
+
+		$webhooks = Form_Webhooks::init();
+		$webhooks->send_webhooks( 123, $fields, false, array() );
+
+		$this->assertFalse( $http_request_made, 'HTTP request should not be made for invalid method' );
+	}
+
+	/**
+	 * Test webhook uses GET method when specified.
+	 */
+	public function test_send_webhooks_uses_get_method() {
+		$form   = $this->create_mock_form(
+			array(
+				'webhooks' => array(
+					array(
+						'webhook_id' => 'test-webhook',
+						'url'        => 'https://example.com/webhook',
+						'format'     => 'json',
+						'method'     => 'GET',
+						'enabled'    => true,
+					),
+				),
+			)
+		);
+		$fields = array( $this->create_mock_field( $form, 'test-field', 'test value' ) );
+
+		$captured_request = null;
+		add_filter(
+			'pre_http_request',
+			function ( $preempt, $args, $url ) use ( &$captured_request ) {
+				$captured_request = array(
+					'url'  => $url,
+					'args' => $args,
+				);
+				return array(
+					'response' => array( 'code' => 200 ),
+					'body'     => '{"success":true}',
+					'headers'  => new CaseInsensitiveDictionary( array( 'Content-Type' => 'application/json' ) ),
+				);
+			},
+			10,
+			3
+		);
+
+		$webhooks = Form_Webhooks::init();
+		$webhooks->send_webhooks( 123, $fields, false, array() );
+
+		$this->assertNotNull( $captured_request );
+		$this->assertEquals( 'GET', $captured_request['args']['method'] );
+	}
+
+	/**
+	 * Test jetpack_forms_before_webhook_request filter is applied.
+	 */
+	public function test_send_webhooks_applies_filter() {
+		$form   = $this->create_mock_form(
+			array(
+				'webhooks' => array(
+					array(
+						'webhook_id' => 'test-webhook',
+						'url'        => 'https://example.com/webhook',
+						'format'     => 'json',
+						'method'     => 'POST',
+						'enabled'    => true,
+					),
+				),
+			)
+		);
+		$fields = array( $this->create_mock_field( $form, 'email', 'john@example.com' ) );
+
+		// Add filter to modify data
+		add_filter(
+			'jetpack_forms_before_webhook_request',
+			function ( $data, $webhook_id ) {
+				$this->assertEquals( 'test-webhook', $webhook_id );
+				$data['custom_field'] = 'custom_value';
+				return $data;
+			},
+			10,
+			2
+		);
+
+		$captured_request = null;
+		add_filter(
+			'pre_http_request',
+			function ( $preempt, $args, $url ) use ( &$captured_request ) {
+				$captured_request = array(
+					'url'  => $url,
+					'args' => $args,
+				);
+				return array(
+					'response' => array( 'code' => 200 ),
+					'body'     => '{"success":true}',
+					'headers'  => new CaseInsensitiveDictionary( array( 'Content-Type' => 'application/json' ) ),
+				);
+			},
+			10,
+			3
+		);
+
+		$webhooks = Form_Webhooks::init();
+		$webhooks->send_webhooks( 123, $fields, false, array() );
+
+		$body_data = json_decode( $captured_request['args']['body'], true );
+		$this->assertEquals( 'custom_value', $body_data['custom_field'] );
+	}
+
+	/**
+	 * Test webhook logs successful response to post meta.
+	 */
+	public function test_send_webhooks_logs_successful_response() {
+		$post_id = 123;
+		$form    = $this->create_mock_form(
+			array(
+				'webhooks' => array(
+					array(
+						'webhook_id' => 'test-webhook',
+						'url'        => 'https://example.com/webhook',
+						'format'     => 'json',
+						'method'     => 'POST',
+						'enabled'    => true,
+					),
+				),
+			)
+		);
+		$fields  = array( $this->create_mock_field( $form, 'test-field', 'test value' ) );
+
+		add_filter(
+			'pre_http_request',
+			function () {
+				return array(
+					'response' => array( 'code' => 200 ),
+					'body'     => '{"success":true}',
+					'headers'  => new CaseInsensitiveDictionary( array( 'Content-Type' => 'application/json' ) ),
+				);
+			}
+		);
+
+		$webhooks = Form_Webhooks::init();
+		$webhooks->send_webhooks( $post_id, $fields, false, array() );
+
+		$response_meta = get_post_meta( $post_id, '_jetpack_forms_webhook_response', true );
+		$this->assertNotEmpty( $response_meta );
+
+		$response_data = json_decode( $response_meta, true );
+		$this->assertEquals( 200, $response_data['http_code'] );
+		$this->assertArrayHasKey( 'timestamp', $response_data );
+	}
+
+	/**
+	 * Test webhook logs error to post meta.
+	 */
+	public function test_send_webhooks_logs_error() {
+		$post_id = 456;
+		$form    = $this->create_mock_form(
+			array(
+				'webhooks' => array(
+					array(
+						'webhook_id' => 'test-webhook',
+						'url'        => 'https://example.com/webhook',
+						'format'     => 'json',
+						'method'     => 'POST',
+						'enabled'    => true,
+					),
+				),
+			)
+		);
+		$fields  = array( $this->create_mock_field( $form, 'test-field', 'test value' ) );
+
+		add_filter(
+			'pre_http_request',
+			function () {
+				return new \WP_Error( 'http_request_failed', 'Connection timeout' );
+			}
+		);
+
+		$webhooks = Form_Webhooks::init();
+		$webhooks->send_webhooks( $post_id, $fields, false, array() );
+
+		$error_meta = get_post_meta( $post_id, '_jetpack_forms_webhook_error', true );
+		$this->assertEquals( 'Connection timeout', $error_meta );
+	}
+
+	/**
+	 * Test webhook includes hidden fields in data.
+	 */
+	public function test_send_webhooks_includes_hidden_fields() {
+		$form         = $this->create_mock_form(
+			array(
+				'webhooks'     => array(
+					array(
+						'webhook_id' => 'test-webhook',
+						'url'        => 'https://example.com/webhook',
+						'format'     => 'json',
+						'method'     => 'POST',
+						'enabled'    => true,
+					),
+				),
+				'hiddenFields' => array(
+					array(
+						'name'  => 'utm_source',
+						'value' => 'google',
+					),
+					array(
+						'name'  => 'utm_campaign',
+						'value' => 'summer_2025',
+					),
+				),
+			)
+		);
+		$field1       = $this->create_mock_field( $form, 'email', 'john@example.com' );
+		$form->fields = array( $field1 );
+		$fields       = array( $field1 );
+
+		$captured_request = null;
+		add_filter(
+			'pre_http_request',
+			function ( $preempt, $args, $url ) use ( &$captured_request ) {
+				$captured_request = array(
+					'url'  => $url,
+					'args' => $args,
+				);
+				return array(
+					'response' => array( 'code' => 200 ),
+					'body'     => '{"success":true}',
+					'headers'  => new CaseInsensitiveDictionary( array( 'Content-Type' => 'application/json' ) ),
+				);
+			},
+			10,
+			3
+		);
+
+		$webhooks = Form_Webhooks::init();
+		$webhooks->send_webhooks( 123, $fields, false, array() );
+
+		$body_data = json_decode( $captured_request['args']['body'], true );
+		$this->assertEquals( 'john@example.com', $body_data['email'] );
+		$this->assertEquals( 'google', $body_data['utm_source'] );
+		$this->assertEquals( 'summer_2025', $body_data['utm_campaign'] );
+	}
+
+	/**
+	 * Helper method to create a mock form.
+	 *
+	 * @param array $attributes Form attributes.
+	 * @return Contact_Form Mock form instance.
+	 */
+	private function create_mock_form( $attributes ) {
+		$form = $this->getMockBuilder( Contact_Form::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$form->attributes = $attributes;
+		$form->fields     = array();
+
+		return $form;
+	}
+
+	/**
+	 * Helper method to create a mock field.
+	 *
+	 * @param Contact_Form $form Parent form.
+	 * @param string       $id Field ID.
+	 * @param mixed        $value Field value.
+	 * @return Contact_Form_Field Mock field instance.
+	 */
+	private function create_mock_field( $form, $id, $value ) {
+		$field = $this->getMockBuilder( Contact_Form_Field::class )
+			->disableOriginalConstructor()
+			->onlyMethods( array( 'get_attribute' ) )
+			->getMock();
+
+		$field->form  = $form;
+		$field->value = $value;
+
+		$field->expects( $this->any() )
+			->method( 'get_attribute' )
+			->willReturnCallback(
+				function ( $attr ) use ( $id ) {
+					if ( $attr === 'id' ) {
+						return $id;
+					}
+					return null;
+				}
+			);
+
+		return $field;
+	}
+}


### PR DESCRIPTION
Fixes #

## Proposed changes:
* Adds complete webhook functionality for Jetpack Contact Forms
* Implements `Form_Webhooks` class that hooks into form submissions and sends data to configured webhook endpoints
* Adds webhook settings UI panel in the form block editor with toggle, URL, and ID inputs
* Supports multiple webhooks per form (UI currently shows one, but data structure supports multiple)
* Supports JSON and URL-encoded formats, and POST/GET/PUT HTTP methods
* Includes `jetpack_forms_before_webhook_request` filter for developers to modify data before sending
* Logs webhook responses and errors to post meta for debugging
* Validates webhook configuration (enabled status, URL presence, valid format/method)
* Skips webhook processing for spam submissions

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

* Run `jetpack test php packages/forms --verbose`
* Verify webhook functionality tests pass
* Test in the editor:
  1. Create or edit a Jetpack Contact Form
  2. In the form settings sidebar, find the "Webhooks" panel
  3. Enable the webhook toggle
  4. Enter a webhook URL (e.g., https://webhook.site/unique-url for testing)
  5. Optionally add a webhook ID for identification
  6. Publish/update the post and submit the form
  7. Verify the webhook endpoint receives the form data in JSON format
  8. Check the feedback CPT post meta for `_jetpack_forms_webhook_response` to see logged responses
