### PR TITLE
Forms: fix submission on deleted page/post

### DIFF
--- a/projects/packages/forms/changelog/fix-form-submission-on-deleted-page
+++ b/projects/packages/forms/changelog/fix-form-submission-on-deleted-page
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: reject form submissions when the parent post/page with the form has been deleted or is no longer published.

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -1562,6 +1562,12 @@ class Contact_Form_Plugin {
 				);
 			}
 
+			// Validate that the parent post/page where the form lives still exists and is published
+			$validation_error = $this->validate_parent_post( $form );
+			if ( $validation_error ) {
+				return $validation_error;
+			}
+
 			$form->validate();
 
 			if ( $form->has_errors() ) {
@@ -1735,6 +1741,12 @@ class Contact_Form_Plugin {
 			return $form->errors;
 		}
 
+		// Validate that the parent post/page where the form lives still exists and is published (legacy submission path where we don't have a JWT)
+		$validation_error = $this->validate_parent_post( $form );
+		if ( $validation_error ) {
+			return $validation_error;
+		}
+
 		if ( ! empty( $form->attributes['salesforceData'] ) || ! empty( $form->attributes['postToUrl'] ) ) {
 			Post_To_Url::init();
 		}
@@ -1817,6 +1829,35 @@ class Contact_Form_Plugin {
 			)
 		);
 		die();
+	}
+
+	/**
+	 * Validates that the parent post/page where the form lives still exists and is published.
+	 *
+	 * @param Contact_Form $form The contact form instance.
+	 * @return Form_Submission_Error|null Returns a Form_Submission_Error if validation fails, null otherwise.
+	 */
+	private function validate_parent_post( Contact_Form $form ) {
+		$source    = $form->get_source();
+		$source_id = $source->get_id();
+
+		// Only check for regular posts/pages (numeric IDs), not widgets or templates
+		if ( is_numeric( $source_id ) && $source_id > 0 ) {
+			$parent_post = get_post( (int) $source_id );
+
+			// If the parent post doesn't exist or is not published, reject the submission
+			if ( ! $parent_post || 'publish' !== $parent_post->post_status ) {
+				/** This action is documented already in this file. */
+				do_action( 'jetpack_forms_log', 'submission_rejected_parent_not_published' );
+
+				return Form_Submission_Error::system_error(
+					'form_unavailable',
+					__( 'This form is no longer available.', 'jetpack-forms' )
+				);
+			}
+		}
+
+		return null;
 	}
 
 	/**

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -1562,7 +1562,7 @@ class Contact_Form_Plugin {
 				);
 			}
 
-			// Validate that the parent post/page where the form lives still exists and is published
+			// Validate that the parent post/page where the form lives still exists and is not trashed/deleted
 			$validation_error = $this->validate_parent_post( $form );
 			if ( $validation_error ) {
 				return $validation_error;
@@ -1741,7 +1741,7 @@ class Contact_Form_Plugin {
 			return $form->errors;
 		}
 
-		// Validate that the parent post/page where the form lives still exists and is published (legacy submission path where we don't have a JWT)
+		// Validate that the parent post/page where the form lives still exists and is not trashed/deleted (legacy submission path where we don't have a JWT)
 		$validation_error = $this->validate_parent_post( $form );
 		if ( $validation_error ) {
 			return $validation_error;
@@ -1832,7 +1832,7 @@ class Contact_Form_Plugin {
 	}
 
 	/**
-	 * Validates that the parent post/page where the form lives still exists and is published.
+	 * Validates that the parent post/page where the form lives still exists and is not trashed/deleted.
 	 *
 	 * @param Contact_Form $form The contact form instance.
 	 * @return Form_Submission_Error|null Returns a Form_Submission_Error if validation fails, null otherwise.
@@ -1845,10 +1845,10 @@ class Contact_Form_Plugin {
 		if ( is_numeric( $source_id ) && $source_id > 0 ) {
 			$parent_post = get_post( (int) $source_id );
 
-			// If the parent post doesn't exist or is not published, reject the submission
-			if ( ! $parent_post || 'publish' !== $parent_post->post_status ) {
+			// If the parent post doesn't exist or is not trashed/deleted, reject the submission
+			if ( ! $parent_post || in_array( $parent_post->post_status, array( 'trash', 'auto-draft' ), true ) ) {
 				/** This action is documented already in this file. */
-				do_action( 'jetpack_forms_log', 'submission_rejected_parent_not_published' );
+				do_action( 'jetpack_forms_log', 'submission_rejected_parent_trashed_or_deleted' );
 
 				return Form_Submission_Error::system_error(
 					'form_unavailable',

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
@@ -666,54 +666,6 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 		$this->teardown_post_for_test( $previous_post );
 	}
 
-	public function test_process_form_with_draft_parent_post() {
-		global $post;
-		$previous_post = $this->setup_token_test( null, 'Test User' );
-		$post_id       = $post->ID;
-
-		// Change the parent post to draft after JWT is created
-		wp_update_post(
-			array(
-				'ID'          => $post_id,
-				'post_status' => 'draft',
-			)
-		);
-
-		$plugin = Contact_Form_Plugin::init();
-		$result = $plugin->process_form_submission();
-
-		$this->assertInstanceOf( Form_Submission_Error::class, $result, 'Expected a Form_Submission_Error when parent post is draft.' );
-		$this->assertEquals( 'form_unavailable', $result->get_error_code(), 'Expected the error code to be "form_unavailable".' );
-		$this->assertEquals( 'This form is no longer available.', $result->get_error_message(), 'Expected appropriate error message.' );
-		$this->assertTrue( $result->is_system_type(), 'Expected this to be a system error.' );
-
-		$this->teardown_post_for_test( $previous_post );
-	}
-
-	public function test_process_form_with_pending_parent_post() {
-		global $post;
-		$previous_post = $this->setup_token_test( null, 'Test User' );
-		$post_id       = $post->ID;
-
-		// Change the parent post to pending after JWT is created
-		wp_update_post(
-			array(
-				'ID'          => $post_id,
-				'post_status' => 'pending',
-			)
-		);
-
-		$plugin = Contact_Form_Plugin::init();
-		$result = $plugin->process_form_submission();
-
-		$this->assertInstanceOf( Form_Submission_Error::class, $result, 'Expected a Form_Submission_Error when parent post is pending.' );
-		$this->assertEquals( 'form_unavailable', $result->get_error_code(), 'Expected the error code to be "form_unavailable".' );
-		$this->assertEquals( 'This form is no longer available.', $result->get_error_message(), 'Expected appropriate error message.' );
-		$this->assertTrue( $result->is_system_type(), 'Expected this to be a system error.' );
-
-		$this->teardown_post_for_test( $previous_post );
-	}
-
 	private function setup_token_test( $token = null, $name = null ) {
 		global $post;
 		$this->get_current_user = wp_get_current_user();

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
@@ -586,7 +586,7 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 		);
 	}
 
-	public function test_process_from_with_jwt() {
+	public function test_process_form_with_jwt() {
 		$previous_post = $this->setup_token_test( null, 'Test User' );
 
 		$plugin = Contact_Form_Plugin::init();
@@ -598,7 +598,7 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 		$this->teardown_post_for_test( $previous_post );
 	}
 
-	public function test_process_from_with_jwt_validation_error() {
+	public function test_process_form_with_jwt_validation_error() {
 		$previous_post = $this->setup_token_test( null );
 
 		$plugin = Contact_Form_Plugin::init();
@@ -610,7 +610,7 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 		$this->teardown_post_for_test( $previous_post );
 	}
 
-	public function test_process_from_with_fake_jwt() {
+	public function test_process_form_with_fake_jwt() {
 		$previous_post = $this->setup_token_test( 'fake.jwt.token' );
 
 		$plugin = Contact_Form_Plugin::init();
@@ -618,6 +618,97 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 
 		$this->assertInstanceOf( Form_Submission_Error::class, $result, 'Expected a Form_Submission_Error when processing the form submission with invalid JWT.' );
 		$this->assertEquals( 'invalid_jwt', $result->get_error_code(), 'Expected the error code to be "invalid_jwt".' );
+		$this->assertTrue( $result->is_system_type(), 'Expected this to be a system error.' );
+
+		$this->teardown_post_for_test( $previous_post );
+	}
+
+	public function test_process_form_with_deleted_parent_post() {
+		global $post;
+		$previous_post = $this->setup_token_test( null, 'Test User' );
+		$post_id       = $post->ID;
+
+		// Delete the parent post after JWT is created
+		wp_delete_post( $post_id, true );
+
+		$plugin = Contact_Form_Plugin::init();
+		$result = $plugin->process_form_submission();
+
+		$this->assertInstanceOf( Form_Submission_Error::class, $result, 'Expected a Form_Submission_Error when parent post is deleted.' );
+		$this->assertEquals( 'form_unavailable', $result->get_error_code(), 'Expected the error code to be "form_unavailable".' );
+		$this->assertEquals( 'This form is no longer available.', $result->get_error_message(), 'Expected appropriate error message.' );
+		$this->assertTrue( $result->is_system_type(), 'Expected this to be a system error.' );
+
+		$post = $previous_post; // Restore the previous post.
+		remove_filter( 'jetpack_contact_form_is_spam', array( $this, 'return_error_for_test' ) );
+		unset( $_POST['contact-form-hash'] );
+		unset( $_POST['jetpack_contact_form_jwt'] );
+		unset( $_POST['contact-form-id'] );
+		unset( $_POST[ 'g' . $post_id . '-name' ] );
+	}
+
+	public function test_process_form_with_trashed_parent_post() {
+		global $post;
+		$previous_post = $this->setup_token_test( null, 'Test User' );
+		$post_id       = $post->ID;
+
+		// Move the parent post to trash after JWT is created
+		wp_trash_post( $post_id );
+
+		$plugin = Contact_Form_Plugin::init();
+		$result = $plugin->process_form_submission();
+
+		$this->assertInstanceOf( Form_Submission_Error::class, $result, 'Expected a Form_Submission_Error when parent post is trashed.' );
+		$this->assertEquals( 'form_unavailable', $result->get_error_code(), 'Expected the error code to be "form_unavailable".' );
+		$this->assertEquals( 'This form is no longer available.', $result->get_error_message(), 'Expected appropriate error message.' );
+		$this->assertTrue( $result->is_system_type(), 'Expected this to be a system error.' );
+
+		$this->teardown_post_for_test( $previous_post );
+	}
+
+	public function test_process_form_with_draft_parent_post() {
+		global $post;
+		$previous_post = $this->setup_token_test( null, 'Test User' );
+		$post_id       = $post->ID;
+
+		// Change the parent post to draft after JWT is created
+		wp_update_post(
+			array(
+				'ID'          => $post_id,
+				'post_status' => 'draft',
+			)
+		);
+
+		$plugin = Contact_Form_Plugin::init();
+		$result = $plugin->process_form_submission();
+
+		$this->assertInstanceOf( Form_Submission_Error::class, $result, 'Expected a Form_Submission_Error when parent post is draft.' );
+		$this->assertEquals( 'form_unavailable', $result->get_error_code(), 'Expected the error code to be "form_unavailable".' );
+		$this->assertEquals( 'This form is no longer available.', $result->get_error_message(), 'Expected appropriate error message.' );
+		$this->assertTrue( $result->is_system_type(), 'Expected this to be a system error.' );
+
+		$this->teardown_post_for_test( $previous_post );
+	}
+
+	public function test_process_form_with_pending_parent_post() {
+		global $post;
+		$previous_post = $this->setup_token_test( null, 'Test User' );
+		$post_id       = $post->ID;
+
+		// Change the parent post to pending after JWT is created
+		wp_update_post(
+			array(
+				'ID'          => $post_id,
+				'post_status' => 'pending',
+			)
+		);
+
+		$plugin = Contact_Form_Plugin::init();
+		$result = $plugin->process_form_submission();
+
+		$this->assertInstanceOf( Form_Submission_Error::class, $result, 'Expected a Form_Submission_Error when parent post is pending.' );
+		$this->assertEquals( 'form_unavailable', $result->get_error_code(), 'Expected the error code to be "form_unavailable".' );
+		$this->assertEquals( 'This form is no longer available.', $result->get_error_message(), 'Expected appropriate error message.' );
 		$this->assertTrue( $result->is_system_type(), 'Expected this to be a system error.' );
 
 		$this->teardown_post_for_test( $previous_post );

--- a/projects/plugins/jetpack/changelog/fix-form-submission-on-deleted-page
+++ b/projects/plugins/jetpack/changelog/fix-form-submission-on-deleted-page
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Forms: reject form submissions when the parent post/page with the form has been deleted or is no longer published.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes FORMS-429

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Validate the parent post and reject the submission if the post/page doesn't exist or is not published.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
 
* Without applying these changes, create a post or page with a form.
* Make a form submission and in the Network tab of the developer tools, look for the ajax request.
* Right-click on it and copy as curl. Save it for later.
<img width="561" height="755" alt="Screenshot 2025-11-26 at 15 53 45" src="https://github.com/user-attachments/assets/6e615fb6-7bd5-41df-9205-23cdef1a6ff1" />

* Delete the post/page containing the form.
* Paste the curl request in a terminal and check that, without the patch, you'll receive a successful response:
```{"success":true,"data":[{"label":"Name","value":"Joe"}],"refreshArgs":{"contact-form-id":"276","contact-form-sent":279,"contact-form-hash":"b3f652f2803211b86f9d6448a1d099044132d969","_wpnonce":"801asdfasdf"}}```
* Apply the patch and make the same request again and check that you receive an error response
```{"success":false,"data":{"error":"An error occurred. Please try again later.","code":"form_unavailable"}}```
