### PR TITLE
 Forms: Fix spam status change tracking when post is not available

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-spam-status-change
+++ b/projects/packages/forms/changelog/fix-forms-spam-status-change
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: Fix spam status change tracking when post is not available

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -3400,11 +3400,16 @@ class Contact_Form_Plugin {
 	 * Tracks when a feedback post status changes to 'spam' and stores the timestamp.
 	 * This allows us to accurately determine when spam was marked, independent of other post updates.
 	 *
-	 * @param string  $new_status The new post status.
-	 * @param string  $old_status The old post status.
-	 * @param WP_Post $post       The post object.
+	 * @param string       $new_status The new post status.
+	 * @param string       $old_status The old post status.
+	 * @param WP_Post|null $post       The post object, when available.
 	 */
-	public function track_spam_status_change( $new_status, $old_status, WP_Post $post ) {
+	public function track_spam_status_change( $new_status, $old_status, ?WP_Post $post = null ) {
+		if ( ! $post instanceof WP_Post ) {
+			// Some callers fire the action without a populated post object (e.g. failed get_post lookups).
+			return;
+		}
+
 		// Only track for feedback posts
 		if ( 'feedback' !== $post->post_type ) {
 			return;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Follow-up to:
- https://github.com/Automattic/jetpack/pull/46033

Related to FORMS-426

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Fixes an issue where $post is null on status change, causing a TypeError

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1764141905947689-slack-C06QF6JJDTM

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Check the code