### PR TITLE
SSO: Revised copy for flagging external collaborators

### DIFF
--- a/projects/packages/connection/changelog/edi-56-clean-up-contractor-language
+++ b/projects/packages/connection/changelog/edi-56-clean-up-contractor-language
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+SSO: Revised copy for flagging external collaborators

--- a/projects/packages/connection/src/sso/class-user-admin.php
+++ b/projects/packages/connection/src/sso/class-user-admin.php
@@ -795,7 +795,7 @@ class User_Admin extends Base_Admin {
 									type="checkbox"
 									id="user_external_contractor"
 									>
-								<?php esc_html_e( 'This user is a contractor, freelancer, consultant, or agency.', 'jetpack-connection' ); ?>
+								<?php esc_html_e( 'Mark as external collaborator', 'jetpack-connection' ); ?>
 							</label>
 						</fieldset>
 					</td>


### PR DESCRIPTION
Part of EDI-56
Counterpart of https://github.com/Automattic/wp-calypso/pull/103244 and 196944-ghe-Automattic/wpcom

## Proposed changes

Updates the label on the user form checkbox to designate an external collaborator:

Before | After
--- | ---
<img width="677" height="270" alt="Screenshot 2025-11-26 at 17 22 57" src="https://github.com/user-attachments/assets/d6d717dc-f3d1-4a28-a4d7-489cc3371213" /> | <img width="613" height="266" alt="Screenshot 2025-11-26 at 17 22 48" src="https://github.com/user-attachments/assets/8d7fa56f-c588-4bc8-bbbe-b13cc324238e" />


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
N/A

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
- Apply these changes to your self-hosted JP site or Atomic site
- Make sure the SSO module is enabled
- Go to `/wp-admin/user-new.php`
- Confirm that the label next to the "External User" checkbox now reads "Mark as external collaborator"