### PR TITLE
Google Sheets block: Stop always showing permissions message

### DIFF
--- a/projects/plugins/jetpack/changelog/google-sheets-embed
+++ b/projects/plugins/jetpack/changelog/google-sheets-embed
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+GSheets embed: Give time for the iframe to finish before showing an error

--- a/projects/plugins/jetpack/extensions/blocks/google-docs-embed/view.js
+++ b/projects/plugins/jetpack/extensions/blocks/google-docs-embed/view.js
@@ -41,10 +41,13 @@ const showError = () => {
 
 			// Add on load event for the iframe to check it's visibility.
 			embedIframe.addEventListener( 'load', function () {
-				if ( Object.keys( this.contentWindow ).length === 0 ) {
-					// Remove iframe and show an error msg
-					embed.innerHTML = privateErrorMsg;
-				}
+				// Give a little time for any internal redirects/navigation to complete before checking
+				setTimeout( () => {
+					if ( Object.keys( this.contentWindow ).length === 0 ) {
+						// Remove iframe and show an error msg
+						embed.innerHTML = privateErrorMsg;
+					}
+				}, 100 );
 			} );
 
 			return;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes JETPACK-989

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Add a small timeout before deciding that the google sheets iframe hasn't worked or is private.

The Google Sheets embed block always displayed a permissions-related error message when viewing the site, even if the user had permission to view the spreadsheet.

The iframe was firing the load event, but its `contentWindow` prop still did not have any entries.

This solution of adding a timeout might not be the cleanest solution, but it does appear to fix the issue.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Open the post-editor
2. Add a google sheets embed block
3. Tell it to embed this url:[ https://docs.google.com/spreadsheets/d/1clUYYvQpTDZMNS-3yoXNN6qiRUt-Jgq9Az9NmqZGDnw/edit?usp=sharing](https://docs.google.com/spreadsheets/d/1clUYYvQpTDZMNS-3yoXNN6qiRUt-Jgq9Az9NmqZGDnw/edit?usp=sharing) - it's a public document accessible to anyone on the internet with the url
4. The editor preview shows the embedded spreadsheet
5. Save, and view the front end

Please test embedding slides and gdocs too.

Before | After
-------|------
<img width="769" height="638" alt="Screenshot 2025-11-26 at 17 07 52" src="https://github.com/user-attachments/assets/e90459f2-6233-4029-806a-0120b6bbc73d" /> | <img width="769" height="638" alt="Screenshot 2025-11-26 at 17 05 58" src="https://github.com/user-attachments/assets/9d022176-7f37-42c6-9118-6eec77d2d993" />
