### PR TITLE
Forms: Add webhook logging and initialization flag

### DIFF
--- a/projects/packages/forms/changelog/add-form-webhooks-skipped-logging
+++ b/projects/packages/forms/changelog/add-form-webhooks-skipped-logging
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Form Webhooks: add logging and filter flag for initialization

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -1570,7 +1570,7 @@ class Contact_Form_Plugin {
 				);
 			}
 
-			if ( ! empty( $form->attributes['webhooks'] ) ) {
+			if ( Jetpack_Forms::is_webhooks_enabled() && ! empty( $form->attributes['webhooks'] ) ) {
 				Form_Webhooks::init();
 			}
 			// Process the form

--- a/projects/packages/forms/src/service/class-form-webhooks.php
+++ b/projects/packages/forms/src/service/class-form-webhooks.php
@@ -166,17 +166,24 @@ class Form_Webhooks {
 			);
 
 			// Validate webhook configuration
-			if ( empty( $setup['enabled'] ) || empty( $setup['url'] ) ) {
+			if ( empty( $setup['enabled'] ) ) {
+				continue;
+			}
+			// Validate webhook configuration
+			if ( empty( $setup['url'] ) ) {
+				do_action( 'jetpack_forms_log', 'webhook_skipped', 'url_empty' );
 				continue;
 			}
 
 			// Validate format
 			if ( ! array_key_exists( strtolower( $setup['format'] ), self::VALID_FORMATS_MAP ) ) {
+				do_action( 'jetpack_forms_log', 'webhook_skipped', 'format_invalid', $setup );
 				continue;
 			}
 
 			// Validate method
 			if ( ! in_array( strtoupper( $setup['method'] ), self::VALID_METHODS, true ) ) {
+				do_action( 'jetpack_forms_log', 'webhook_skipped', 'method_invalid', $setup );
 				continue;
 			}
 
@@ -232,6 +239,7 @@ class Form_Webhooks {
 			),
 			'sslverify' => true,
 		);
+
 		return wp_remote_request( $url, $args );
 	}
 

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
@@ -4014,4 +4014,33 @@ EOT;
 		$this->assertIsString( $result5, 'Parse should return a string with multiple fields' );
 		$this->assertStringNotContainsString( 'is-single-input-form', $result5, 'Should not have single-input-form class with multiple fields' );
 	}
+
+	/**
+	 * Test is_webhooks_enabled returns false by default.
+	 */
+	public function test_is_webhooks_enabled_default() {
+		$this->assertFalse( \Automattic\Jetpack\Forms\Jetpack_Forms::is_webhooks_enabled() );
+	}
+
+	/**
+	 * Test is_webhooks_enabled filter can be used to enable webhooks.
+	 */
+	public function test_is_webhooks_enabled_filter_enable() {
+		add_filter( 'jetpack_forms_webhooks_enabled', '__return_true' );
+
+		$this->assertTrue( \Automattic\Jetpack\Forms\Jetpack_Forms::is_webhooks_enabled() );
+
+		remove_filter( 'jetpack_forms_webhooks_enabled', '__return_true' );
+	}
+
+	/**
+	 * Test is_webhooks_enabled filter can be used to keep webhooks disabled.
+	 */
+	public function test_is_webhooks_enabled_filter_disable() {
+		add_filter( 'jetpack_forms_webhooks_enabled', '__return_false' );
+
+		$this->assertFalse( \Automattic\Jetpack\Forms\Jetpack_Forms::is_webhooks_enabled() );
+
+		remove_filter( 'jetpack_forms_webhooks_enabled', '__return_false' );
+	}
 }

--- a/projects/packages/forms/tests/php/service/Form_Webhooks_Test.php
+++ b/projects/packages/forms/tests/php/service/Form_Webhooks_Test.php
@@ -606,7 +606,9 @@ class Form_Webhooks_Test extends BaseTestCase {
 		$webhooks->send_webhooks( 123, $fields, false, array() );
 
 		$this->assertCount( 1, $logged_events );
+		// @phan-suppress-next-line PhanTypeArraySuspiciousNull, PhanTypeInvalidDimOffset
 		$this->assertEquals( 'webhook_skipped', $logged_events[0]['event'] );
+		// @phan-suppress-next-line PhanTypeArraySuspiciousNull, PhanTypeInvalidDimOffset
 		$this->assertEquals( 'url_empty', $logged_events[0]['reason'] );
 	}
 
@@ -647,9 +649,13 @@ class Form_Webhooks_Test extends BaseTestCase {
 		$webhooks->send_webhooks( 123, $fields, false, array() );
 
 		$this->assertCount( 1, $logged_events );
+		// @phan-suppress-next-line PhanTypeArraySuspiciousNull, PhanTypeInvalidDimOffset
 		$this->assertEquals( 'webhook_skipped', $logged_events[0]['event'] );
+		// @phan-suppress-next-line PhanTypeArraySuspiciousNull, PhanTypeInvalidDimOffset
 		$this->assertEquals( 'format_invalid', $logged_events[0]['reason'] );
+		// @phan-suppress-next-line PhanTypeArraySuspiciousNull, PhanTypeInvalidDimOffset
 		$this->assertIsArray( $logged_events[0]['data'] );
+		// @phan-suppress-next-line PhanTypeArraySuspiciousNull, PhanTypeInvalidDimOffset
 		$this->assertEquals( 'xml', $logged_events[0]['data']['format'] );
 	}
 
@@ -690,9 +696,13 @@ class Form_Webhooks_Test extends BaseTestCase {
 		$webhooks->send_webhooks( 123, $fields, false, array() );
 
 		$this->assertCount( 1, $logged_events );
+		// @phan-suppress-next-line PhanTypeArraySuspiciousNull, PhanTypeInvalidDimOffset
 		$this->assertEquals( 'webhook_skipped', $logged_events[0]['event'] );
+		// @phan-suppress-next-line PhanTypeArraySuspiciousNull, PhanTypeInvalidDimOffset
 		$this->assertEquals( 'method_invalid', $logged_events[0]['reason'] );
+		// @phan-suppress-next-line PhanTypeArraySuspiciousNull, PhanTypeInvalidDimOffset
 		$this->assertIsArray( $logged_events[0]['data'] );
+		// @phan-suppress-next-line PhanTypeArraySuspiciousNull, PhanTypeInvalidDimOffset
 		$this->assertEquals( 'DELETE', $logged_events[0]['data']['method'] );
 	}
 

--- a/projects/packages/forms/tests/php/service/Form_Webhooks_Test.php
+++ b/projects/packages/forms/tests/php/service/Form_Webhooks_Test.php
@@ -570,6 +570,177 @@ class Form_Webhooks_Test extends BaseTestCase {
 	}
 
 	/**
+	 * Test logging action is triggered when webhook URL is empty.
+	 */
+	public function test_send_webhooks_logs_empty_url() {
+		$form   = $this->create_mock_form(
+			array(
+				'webhooks' => array(
+					array(
+						'webhook_id' => 'test-webhook',
+						'url'        => '',
+						'format'     => 'json',
+						'method'     => 'POST',
+						'enabled'    => true,
+					),
+				),
+			)
+		);
+		$fields = array( $this->create_mock_field( $form, 'test-field', 'test value' ) );
+
+		$logged_events = array();
+		add_action(
+			'jetpack_forms_log',
+			function ( $event, $reason, $data = null ) use ( &$logged_events ) {
+				$logged_events[] = array(
+					'event'  => $event,
+					'reason' => $reason,
+					'data'   => $data,
+				);
+			},
+			10,
+			3
+		);
+
+		$webhooks = Form_Webhooks::init();
+		$webhooks->send_webhooks( 123, $fields, false, array() );
+
+		$this->assertCount( 1, $logged_events );
+		$this->assertEquals( 'webhook_skipped', $logged_events[0]['event'] );
+		$this->assertEquals( 'url_empty', $logged_events[0]['reason'] );
+	}
+
+	/**
+	 * Test logging action is triggered when webhook format is invalid.
+	 */
+	public function test_send_webhooks_logs_invalid_format() {
+		$form   = $this->create_mock_form(
+			array(
+				'webhooks' => array(
+					array(
+						'webhook_id' => 'test-webhook',
+						'url'        => 'https://example.com/webhook',
+						'format'     => 'xml',
+						'method'     => 'POST',
+						'enabled'    => true,
+					),
+				),
+			)
+		);
+		$fields = array( $this->create_mock_field( $form, 'test-field', 'test value' ) );
+
+		$logged_events = array();
+		add_action(
+			'jetpack_forms_log',
+			function ( $event, $reason, $data = null ) use ( &$logged_events ) {
+				$logged_events[] = array(
+					'event'  => $event,
+					'reason' => $reason,
+					'data'   => $data,
+				);
+			},
+			10,
+			3
+		);
+
+		$webhooks = Form_Webhooks::init();
+		$webhooks->send_webhooks( 123, $fields, false, array() );
+
+		$this->assertCount( 1, $logged_events );
+		$this->assertEquals( 'webhook_skipped', $logged_events[0]['event'] );
+		$this->assertEquals( 'format_invalid', $logged_events[0]['reason'] );
+		$this->assertIsArray( $logged_events[0]['data'] );
+		$this->assertEquals( 'xml', $logged_events[0]['data']['format'] );
+	}
+
+	/**
+	 * Test logging action is triggered when webhook method is invalid.
+	 */
+	public function test_send_webhooks_logs_invalid_method() {
+		$form   = $this->create_mock_form(
+			array(
+				'webhooks' => array(
+					array(
+						'webhook_id' => 'test-webhook',
+						'url'        => 'https://example.com/webhook',
+						'format'     => 'json',
+						'method'     => 'DELETE',
+						'enabled'    => true,
+					),
+				),
+			)
+		);
+		$fields = array( $this->create_mock_field( $form, 'test-field', 'test value' ) );
+
+		$logged_events = array();
+		add_action(
+			'jetpack_forms_log',
+			function ( $event, $reason, $data = null ) use ( &$logged_events ) {
+				$logged_events[] = array(
+					'event'  => $event,
+					'reason' => $reason,
+					'data'   => $data,
+				);
+			},
+			10,
+			3
+		);
+
+		$webhooks = Form_Webhooks::init();
+		$webhooks->send_webhooks( 123, $fields, false, array() );
+
+		$this->assertCount( 1, $logged_events );
+		$this->assertEquals( 'webhook_skipped', $logged_events[0]['event'] );
+		$this->assertEquals( 'method_invalid', $logged_events[0]['reason'] );
+		$this->assertIsArray( $logged_events[0]['data'] );
+		$this->assertEquals( 'DELETE', $logged_events[0]['data']['method'] );
+	}
+
+	/**
+	 * Test webhook method validation is case-insensitive.
+	 */
+	public function test_send_webhooks_accepts_lowercase_method() {
+		$form   = $this->create_mock_form(
+			array(
+				'webhooks' => array(
+					array(
+						'webhook_id' => 'test-webhook',
+						'url'        => 'https://example.com/webhook',
+						'format'     => 'json',
+						'method'     => 'post', // lowercase should be accepted
+						'enabled'    => true,
+					),
+				),
+			)
+		);
+		$fields = array( $this->create_mock_field( $form, 'test-field', 'test value' ) );
+
+		$captured_request = null;
+		add_filter(
+			'pre_http_request',
+			function ( $preempt, $args, $url ) use ( &$captured_request ) {
+				$captured_request = array(
+					'url'  => $url,
+					'args' => $args,
+				);
+				return array(
+					'response' => array( 'code' => 200 ),
+					'body'     => '{"success":true}',
+					'headers'  => new CaseInsensitiveDictionary( array( 'Content-Type' => 'application/json' ) ),
+				);
+			},
+			10,
+			3
+		);
+
+		$webhooks = Form_Webhooks::init();
+		$webhooks->send_webhooks( 123, $fields, false, array() );
+
+		$this->assertNotNull( $captured_request, 'HTTP request should be made even with lowercase method' );
+		$this->assertEquals( 'post', $captured_request['args']['method'] );
+	}
+
+	/**
 	 * Helper method to create a mock form.
 	 *
 	 * @param array $attributes Form attributes.


### PR DESCRIPTION
## Proposed changes

This PR adds enhanced logging and a feature flag for the webhook functionality in Jetpack Forms:

- Add logging for skipped webhooks (invalid format, method, or empty URL)
- Add `jetpack_forms_webhooks_enabled` filter flag to control webhook initialization
- Improve webhook validation by logging specific skip reasons via `jetpack_forms_log` action
- Fix method validation to be case-insensitive (convert to uppercase before comparison)

## Does this pull request change what data or activity we track or use?
No

## Testing instructions

1. Enable webhooks via the filter flag:
   ```php
   add_filter( 'jetpack_forms_webhooks_enabled', '__return_true' );
   ```

2. Create a form with webhook configuration in the block editor

3. Test logging for skipped webhooks:
   - Try an empty webhook URL (should log `webhook_skipped` with reason `url_empty`)
   - Try an invalid format value (should log `webhook_skipped` with reason `format_invalid`)
   - Try an invalid method value (should log `webhook_skipped` with reason `method_invalid`)

4. Verify that without the filter flag enabled, webhooks are not initialized even if configured in the form

5. Hook into the `jetpack_forms_log` action to capture the logging:
   ```php
   add_action( 'jetpack_forms_log', function( $event, $reason, $data = null ) {
       error_log( "Forms Log - Event: $event, Reason: $reason" );
       if ( $data ) {
           error_log( print_r( $data, true ) );
       }
   }, 10, 3 );
   ```