### PR TITLE
Forms: add integration display filters

### DIFF
--- a/projects/packages/forms/changelog/add-forms-integrations-display-filters
+++ b/projects/packages/forms/changelog/add-forms-integrations-display-filters
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Forms: add integrations display filters.

--- a/projects/packages/forms/src/blocks/contact-form/edit.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/edit.tsx
@@ -179,8 +179,9 @@ function JetpackContactFormEdit( {
 		notificationRecipients,
 		webhooks,
 	} = attributes;
-	const showFormIntegrations = useConfigValue( 'isIntegrationsEnabled' );
+	const isIntegrationsEnabled = useConfigValue( 'isIntegrationsEnabled' );
 	const showWebhooks = useConfigValue( 'isWebhooksEnabled' ) && hasFeatureFlag( 'form-webhooks' );
+	const showBlockIntegrations = useConfigValue( 'showBlockIntegrations' );
 	const instanceId = useInstanceId( JetpackContactFormEdit );
 
 	// Backward compatibility for the deprecated customThankyou attribute.
@@ -921,7 +922,7 @@ function JetpackContactFormEdit( {
 							setAttributes={ setAttributes }
 						/>
 					</PanelBody>
-					{ showFormIntegrations && (
+					{ isIntegrationsEnabled && showBlockIntegrations && (
 						<Suspense fallback={ <div /> }>
 							<IntegrationControls attributes={ attributes } setAttributes={ setAttributes } />
 						</Suspense>

--- a/projects/packages/forms/src/class-jetpack-forms.php
+++ b/projects/packages/forms/src/class-jetpack-forms.php
@@ -138,4 +138,40 @@ class Jetpack_Forms {
 		 */
 		return apply_filters( 'jetpack_forms_webhooks_enabled', false );
 	}
+
+	/**
+	 * Returns true if the Integrations UI should be shown in the Forms dashboard.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @return boolean
+	 */
+	public static function show_dashboard_integrations() {
+		/**
+		 * Whether to show Integrations UI in the Forms dashboard.
+		 *
+		 * @since $$next-version$$
+		 *
+		 * @param bool true Whether to show the Integrations UI in the dashboard. Default true.
+		 */
+		return apply_filters( 'jetpack_forms_show_dashboard_integrations', true );
+	}
+
+	/**
+	 * Returns true if the Integrations UI should be shown in the Form block editor.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @return boolean
+	 */
+	public static function show_block_integrations() {
+		/**
+		 * Whether to show Integrations UI in the Form block editor.
+		 *
+		 * @since $$next-version$$
+		 *
+		 * @param bool true Whether to show the Integrations UI in the editor. Default true.
+		 */
+		return apply_filters( 'jetpack_forms_show_block_integrations', true );
+	}
 }

--- a/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
@@ -1484,24 +1484,26 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 	public function get_forms_config( WP_REST_Request $request ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 		$config = array(
 			// From jpFormsBlocks in class-contact-form-block.php.
-			'formsResponsesUrl'       => Forms_Dashboard::get_forms_admin_url(),
-			'isMailPoetEnabled'       => Jetpack_Forms::is_mailpoet_enabled(),
-			'isHostingerReachEnabled' => Jetpack_Forms::is_hostinger_reach_enabled(),
+			'formsResponsesUrl'         => Forms_Dashboard::get_forms_admin_url(),
+			'isMailPoetEnabled'         => Jetpack_Forms::is_mailpoet_enabled(),
+			'isHostingerReachEnabled'   => Jetpack_Forms::is_hostinger_reach_enabled(),
 			// From config in class-dashboard.php.
-			'blogId'                  => get_current_blog_id(),
-			'gdriveConnectSupportURL' => esc_url( Redirect::get_url( 'jetpack-support-contact-form-export' ) ),
-			'pluginAssetsURL'         => Jetpack_Forms::assets_url(),
-			'siteURL'                 => ( new Status() )->get_site_suffix(),
-			'hasFeedback'             => ( new Forms_Dashboard() )->has_feedback(),
-			'isIntegrationsEnabled'   => Jetpack_Forms::is_integrations_enabled(),
-			'isWebhooksEnabled'       => Jetpack_Forms::is_webhooks_enabled(),
-			'dashboardURL'            => Forms_Dashboard::get_forms_admin_url(),
+			'blogId'                    => get_current_blog_id(),
+			'gdriveConnectSupportURL'   => esc_url( Redirect::get_url( 'jetpack-support-contact-form-export' ) ),
+			'pluginAssetsURL'           => Jetpack_Forms::assets_url(),
+			'siteURL'                   => ( new Status() )->get_site_suffix(),
+			'hasFeedback'               => ( new Forms_Dashboard() )->has_feedback(),
+			'isIntegrationsEnabled'     => Jetpack_Forms::is_integrations_enabled(),
+			'isWebhooksEnabled'         => Jetpack_Forms::is_webhooks_enabled(),			
+			'showDashboardIntegrations' => Jetpack_Forms::show_dashboard_integrations(),
+			'showBlockIntegrations'     => Jetpack_Forms::show_block_integrations(),
+			'dashboardURL'              => Forms_Dashboard::get_forms_admin_url(),
 			// New data.
-			'canInstallPlugins'       => current_user_can( 'install_plugins' ),
-			'canActivatePlugins'      => current_user_can( 'activate_plugins' ),
-			'exportNonce'             => wp_create_nonce( 'feedback_export' ),
-			'newFormNonce'            => wp_create_nonce( 'create_new_form' ),
-			'emptyTrashDays'          => defined( 'EMPTY_TRASH_DAYS' ) ? EMPTY_TRASH_DAYS : 0,
+			'canInstallPlugins'         => current_user_can( 'install_plugins' ),
+			'canActivatePlugins'        => current_user_can( 'activate_plugins' ),
+			'exportNonce'               => wp_create_nonce( 'feedback_export' ),
+			'newFormNonce'              => wp_create_nonce( 'create_new_form' ),
+			'emptyTrashDays'            => defined( 'EMPTY_TRASH_DAYS' ) ? EMPTY_TRASH_DAYS : 0,
 		);
 
 		return rest_ensure_response( $config );

--- a/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
@@ -1494,7 +1494,7 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 			'siteURL'                   => ( new Status() )->get_site_suffix(),
 			'hasFeedback'               => ( new Forms_Dashboard() )->has_feedback(),
 			'isIntegrationsEnabled'     => Jetpack_Forms::is_integrations_enabled(),
-			'isWebhooksEnabled'         => Jetpack_Forms::is_webhooks_enabled(),			
+			'isWebhooksEnabled'         => Jetpack_Forms::is_webhooks_enabled(),
 			'showDashboardIntegrations' => Jetpack_Forms::show_dashboard_integrations(),
 			'showBlockIntegrations'     => Jetpack_Forms::show_block_integrations(),
 			'dashboardURL'              => Forms_Dashboard::get_forms_admin_url(),

--- a/projects/packages/forms/src/dashboard/components/layout/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/layout/index.tsx
@@ -17,8 +17,10 @@ const Layout = () => {
 	const location = useLocation();
 	const [ isSm ] = useBreakpointMatch( 'sm' );
 
-	const enableIntegrationsTab = useConfigValue( 'isIntegrationsEnabled' );
-	const isLoadingConfig = enableIntegrationsTab === undefined;
+	const isIntegrationsEnabled = useConfigValue( 'isIntegrationsEnabled' );
+	const showDashboardIntegrations = useConfigValue( 'showDashboardIntegrations' );
+	const isLoadingConfig =
+		isIntegrationsEnabled === undefined || showDashboardIntegrations === undefined;
 
 	const isIntegrationsOpen = location.pathname === '/integrations';
 
@@ -32,7 +34,9 @@ const Layout = () => {
 		<div className="jp-forms-layout">
 			<div className="jp-forms-layout__content">
 				{ ! isLoadingConfig && <Outlet /> }
-				{ isIntegrationsOpen && <Integrations /> }
+				{ isIntegrationsOpen && isIntegrationsEnabled && showDashboardIntegrations && (
+					<Integrations />
+				) }
 			</div>
 		</div>
 	);

--- a/projects/packages/forms/src/dashboard/inbox/stage/index.js
+++ b/projects/packages/forms/src/dashboard/inbox/stage/index.js
@@ -125,7 +125,8 @@ export default function InboxView() {
 		return setupSidebarWidthObserver();
 	}, [] );
 
-	const enableIntegrationsTab = useConfigValue( 'isIntegrationsEnabled' );
+	const isIntegrationsEnabled = useConfigValue( 'isIntegrationsEnabled' );
+	const showDashboardIntegrations = useConfigValue( 'showDashboardIntegrations' );
 
 	const {
 		setCurrentQuery,
@@ -476,13 +477,13 @@ export default function InboxView() {
 		} else {
 			headerActionsArray.unshift( <CreateFormButton key="create" /> );
 			// Only show Create Form and Integrations buttons on inbox (when not in trash or spam)
-			if ( enableIntegrationsTab ) {
+			if ( isIntegrationsEnabled && showDashboardIntegrations ) {
 				headerActionsArray.unshift( <IntegrationsButton key="integrations" /> );
 			}
 		}
 
 		return headerActionsArray;
-	}, [ statusFilter, enableIntegrationsTab ] );
+	}, [ statusFilter, isIntegrationsEnabled, showDashboardIntegrations ] );
 
 	const pageContent = (
 		<Page

--- a/projects/packages/forms/src/types/index.ts
+++ b/projects/packages/forms/src/types/index.ts
@@ -236,6 +236,10 @@ export interface FormsConfigData {
 	isIntegrationsEnabled?: boolean;
 	/** Whether webhooks are enabled (feature-flagged). */
 	isWebhooksEnabled?: boolean;
+	/** Whether to show integrations in the Forms dashboard UI. */
+	showDashboardIntegrations?: boolean;
+	/** Whether to show integrations in the Form block editor UI. */
+	showBlockIntegrations?: boolean;
 	/** Whether the current user can install plugins (install_plugins). */
 	canInstallPlugins?: boolean;
 	/** Whether the current user can activate plugins (activate_plugins). */

--- a/projects/plugins/jetpack/changelog/add-forms-integrations-display-filters
+++ b/projects/plugins/jetpack/changelog/add-forms-integrations-display-filters
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Forms: add integrations display filters.


### PR DESCRIPTION
## Proposed changes:

This PR
* adds a filter to show/hide integrations on the forms dashboard (`jetpack_forms_show_dashboard_integrations`)
* adds a filter to show/hide integrations in the block editor (`jetpack_forms_show_block_integrations`)
* passes the values of these filters to the frontend via our `config` endpoint
* conditionally shows/hides the integration modal based on those values

Context: Right now, we have a single `jetpack_forms_is_integrations_enabled` filter. We're using it to hide the integrations modal in CIAB. But for CIAB, we want to hide integrations in the dashboard and show them in the block editor. The current filter doesn't allow that nuance.

Separately, we'll be updating the `is_integrations_enabled` filter to be more complete. Disabling integrations should  will prevent integrations API request and post-submission processing of integrations, neither of which it's doing now. So this will be the wrong filter to use if the goal is just to hide integrations in the dashboard. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
Slack: p1763398457134859-slack-C052XEUUBL4

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Ensure you can see integrations modal in both dashboard and block editor to start. 

Add the following filter. Confirm integrations still show in block editor but not in dashboard.
`add_filter( 'jetpack_forms_show_dashboard_integrations', '__return_false', 20 );`

Remove the last filter and add the following. Confirm integrations still show in dashboard but not in block editor.
`add_filter( 'jetpack_forms_show_block_integrations', '__return_false', 20 );`