### PR TITLE
actions: Set permissions for build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,10 @@ concurrency:
   group: build-${{ github.event_name == 'push' && github.run_id || 'pr' }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  # actions/checkout, actions/upload-artifact, actions/download-artifact
+  contents: read
+
 env:
   COMPOSER_ROOT_VERSION: "dev-trunk"
 
@@ -20,6 +24,11 @@ jobs:
     name: Build all projects
     runs-on: ubuntu-latest
     timeout-minutes: 30  # 2025-11-06: Build times have crept up to ~15–20 minutes as we've added more projects, bump to 30.
+    permissions:
+      # actions/checkout, actions/upload-artifact
+      contents: read
+      # Comment posting
+      pull-requests: write
     env:
       # Hard-code a specific directory to avoid paths in vendor/composer/installed.json changing every build.
       BUILD_BASE: /tmp/jetpack-build
@@ -262,6 +271,12 @@ jobs:
     name: Push to mirror repos
     runs-on: ubuntu-latest
     needs: build
+    permissions:
+      # .github/actions/turnstile
+      actions: read
+      # actions/checkout, actions/download-artifact
+      contents: read
+      # push-to-mirrors uses secrets.API_TOKEN_GITHUB, so no need for permissions
 
     if: github.event_name == 'push' && github.repository == 'Automattic/jetpack'
 


### PR DESCRIPTION
Closes MONOREP-265

 <!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Set permissions for build workflow

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* CI happy?
