### PR TITLE
actions: Set workflow permissions for test and wpcloud

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,6 +10,11 @@ concurrency:
   group: tests-${{ github.event_name }}-${{ github.ref }}-${{ github.event_name == 'push' && github.ref == 'refs/heads/trunk' && github.run_id || '' }}
   cancel-in-progress: true
 
+permissions:
+  # actions/checkout, actions/upload-artifact, actions/download-artifact
+  contents: read
+  # Note posting the coverage comment uses an app token, so no need for permissions
+
 env:
   COMPOSER_ROOT_VERSION: 'dev-trunk'
 

--- a/.github/workflows/wpcloud.yml
+++ b/.github/workflows/wpcloud.yml
@@ -9,6 +9,10 @@ concurrency:
   cancel-in-progress: false
   # Concurrency is set up to make sure we can only run one WP Cloud testing job at the same time.
 
+permissions:
+  # actions/checkout, actions/cache?
+  contents: read
+
 jobs:
   build:
     name: Install the Monorepo and build wpcomsh


### PR DESCRIPTION
Closes MONOREP-266

 <!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Set workflow permissions for test and wpcloud

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* CI happy?
* ~~Probably we'll have to do the "make a PR depending on this one" to get wpcloud to fully run.~~ Nope, "touches infrastructure file" triggered.
