### PR TITLE
Forms: fix long email wrap

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-long-email-wrap
+++ b/projects/packages/forms/changelog/fix-forms-long-email-wrap
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fixed
+
+Forms: wrap long emails in response

--- a/projects/packages/forms/src/dashboard/components/inspector/body.tsx
+++ b/projects/packages/forms/src/dashboard/components/inspector/body.tsx
@@ -286,6 +286,8 @@ const ResponseViewBody = ( {
 	const gravatarEmail = response.author_email || response.ip;
 	const defaultImage = response.author_name || response.author_email ? 'initials' : 'mp';
 
+	const responseAuthorEmailParts = response.author_email?.split( '@' ) ?? [];
+
 	return (
 		<>
 			<div ref={ ref } className="jp-forms__inbox-response">
@@ -301,7 +303,10 @@ const ResponseViewBody = ( {
 							<h3 className="jp-forms__inbox-response-name">{ displayName }</h3>
 							{ response.author_email && displayName !== response.author_email && (
 								<p className="jp-forms__inbox-response-email">
-									<a href={ `mailto:${ response.author_email }` }>{ response.author_email }</a>
+									<a href={ `mailto:${ response.author_email }` }>
+										{ responseAuthorEmailParts[ 0 ] }
+										<wbr />@{ responseAuthorEmailParts[ 1 ] }
+									</a>
 									<CopyClipboardButton text={ response.author_email } />
 								</p>
 							) }

--- a/projects/packages/forms/src/dashboard/components/inspector/style.scss
+++ b/projects/packages/forms/src/dashboard/components/inspector/style.scss
@@ -73,13 +73,13 @@
 
 	@include mixins.flex-center;
 	flex-shrink: 0;
-	gap: 4px;
 	font-size: 14px;
 	font-weight: 500;
-	height: 24px;
+	gap: 4px;
 	line-height: 24px;
-	text-overflow: ellipsis;
-	white-space: nowrap;
+	max-width: 100%;
+	min-height: 24px;
+	word-break: break-word;
 }
 
 .jp-forms__inbox-response-meta {

--- a/projects/packages/forms/src/dashboard/components/response-view/field-email/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/response-view/field-email/index.tsx
@@ -2,6 +2,7 @@ import {
 	__experimentalHStack as HStack, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 } from '@wordpress/components';
 import CopyClipboardButton from '../../../components/copy-clipboard-button';
+import './style.scss';
 
 const FieldEmail = ( { email } ) => {
 	const emailParts = email.split( '@' );

--- a/projects/packages/forms/src/dashboard/components/response-view/field-email/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/response-view/field-email/index.tsx
@@ -4,9 +4,19 @@ import {
 import CopyClipboardButton from '../../../components/copy-clipboard-button';
 
 const FieldEmail = ( { email } ) => {
+	const emailParts = email.split( '@' );
+
 	return (
-		<HStack alignment="center" justify="left" spacing="2">
-			<a href={ `mailto:${ email }` }>{ email }</a>
+		<HStack
+			alignment="center"
+			className="jp-forms__inbox-response-field-email"
+			justify="left"
+			spacing="2"
+		>
+			<a href={ `mailto:${ email }` }>
+				{ emailParts[ 0 ] }
+				<wbr />@{ emailParts[ 1 ] }
+			</a>
 			<CopyClipboardButton text={ email } />
 		</HStack>
 	);

--- a/projects/packages/forms/src/dashboard/components/response-view/field-email/style.scss
+++ b/projects/packages/forms/src/dashboard/components/response-view/field-email/style.scss
@@ -1,0 +1,3 @@
+.jp-forms__inbox-response-field-email a {
+	word-break: break-word;
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes FORMS-440



## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Wraps emails in response header and response field so that long emails wrap to multiple lines.
* Adds "safe breaking point" just before `@` so that we preferably move the domain to a new line instead of cutting it in half, problem screenshot:
    <img width="426" height="114" alt="Screenshot 2025-11-27 at 12 57 18" src="https://github.com/user-attachments/assets/7845d302-7fb6-48e3-a153-eaed6e2f5053" />


Before
<img width="433" height="100" alt="image" src="https://github.com/user-attachments/assets/594e8a14-ebe2-42aa-8cf3-dfc0938f1451" />

<img width="423" height="86" alt="Screenshot 2025-11-27 at 12 57 24" src="https://github.com/user-attachments/assets/dd859316-9c0f-481f-8649-4d9b75e0dc37" />

After
<img width="411" height="109" alt="Screenshot 2025-11-27 at 12 40 46" src="https://github.com/user-attachments/assets/3b2fa7b9-92a5-4a81-877e-ad94bb76ab33" />
<img width="437" height="103" alt="Screenshot 2025-11-27 at 12 57 41" src="https://github.com/user-attachments/assets/fa4e6d80-636b-4dc7-838b-157eb7897987" />

Also ensures that [the previous fix](https://github.com/Automattic/jetpack/pull/46088) that pushed copy-button to the side doesn't happen on shorter emails:
<img width="431" height="91" alt="Screenshot 2025-11-27 at 12 58 13" src="https://github.com/user-attachments/assets/b7d23c66-6a37-4b04-a846-e4323b3e54db" />

Also crazy domains:
<img width="410" height="127" alt="image" src="https://github.com/user-attachments/assets/d52a56e4-2428-498a-a4c6-be5e5cd634c1" />


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Submit responses with long emails such as `loremipsumsitametdolorsitamet.ipdolor@example.org` and slightly longer `loremipsumsitametdolorsitamet.ipdolor@example.org`
* Test also short emails continue work
