### PR TITLE
Forms: Fix checkbox styling and block interaction in editor

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-checkbox-disabled
+++ b/projects/packages/forms/changelog/fix-forms-checkbox-disabled
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix checkbox styling and block interaction in editor by removing disabled attribute and using CSS pointer-events instead

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -473,6 +473,7 @@
 			width: 1em;
 			transform: translateY(-0.35em);
 			background-color: var(--jetpack--contact-form--input-background, field);
+			pointer-events: none;
 		}
 
 		&[type="radio"]::before {

--- a/projects/packages/forms/src/blocks/option/edit.js
+++ b/projects/packages/forms/src/blocks/option/edit.js
@@ -68,7 +68,6 @@ const OptionEdit = ( { attributes, clientId, context, name, setAttributes } ) =>
 					<input
 						className="jetpack-field-option__checkbox"
 						checked={ !! defaultValue }
-						disabled
 						type={ type }
 					/>
 				) }
@@ -102,7 +101,7 @@ const OptionEdit = ( { attributes, clientId, context, name, setAttributes } ) =>
 
 	return (
 		<li { ...blockProps }>
-			<input type={ type } disabled className="jetpack-option__type" tabIndex="-1" />
+			<input type={ type } className="jetpack-option__type" tabIndex="-1" />
 			<RichText
 				ref={ useEnterRef }
 				identifier="label"


### PR DESCRIPTION
Part of FORMS-437

## Proposed changes:
* Removed the `disabled` attribute from checkbox inputs in the Forms block editor
* Added `pointer-events: none` CSS to prevent direct checkbox interaction while maintaining block functionality
* This allows checkboxes to be styled correctly and enables proper block interaction (dragging, selecting) in the editor
* The checkboxes remain non-interactive for users while being properly integrated with the block editor UI


Before:
<img width="465" height="366" alt="image" src="https://github.com/user-attachments/assets/0067f465-d750-4a81-8f31-474b55d3e48f" />

After:
<img width="412" height="379" alt="image" src="https://github.com/user-attachments/assets/c2c00fbc-346b-478d-8578-b0023e7871c5" />


### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

### Before the fix:
* Open the WordPress block editor
* Add a Jetpack Form block
* Add checkbox or radio button options
* Try to drag the block or interact with the block controls
* Notice that styling may appear incorrect and block interaction is limited

### After the fix:
* The checkboxes/radio buttons should display with proper styling
* You should be able to drag the Form block normally
* Block selection and interaction should work smoothly
* The checkboxes themselves remain non-interactive (as expected in the editor view)
* The visual appearance should match the expected form field design

### Visual check:
* Verify that checkbox/radio button pseudo-elements (::before) render correctly
* Confirm that the form block can be selected, moved, and manipulated like other blocks
* Ensure there are no visual regressions in checkbox/radio styling