### PR TITLE
Changelogger: Suppress deprecation notice from add() method

### DIFF
--- a/projects/packages/changelogger/changelog/fix-changelogger-test
+++ b/projects/packages/changelogger/changelog/fix-changelogger-test
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update tests to use addCommand() instead of deprecated add() method

--- a/projects/packages/changelogger/tests/php/tests/src/ApplicationTest.php
+++ b/projects/packages/changelogger/tests/php/tests/src/ApplicationTest.php
@@ -72,7 +72,9 @@ class ApplicationTest extends TestCase {
 
 		$command = new Command( 'testDoRun' );
 		$command->setCode( $callback );
-		$app->addCommand( $command );
+		// Trying to change add to addCommand makes the test fail with older PHP versions.
+		// @phan-suppress-next-line PhanDeprecatedFunction -- While deprecated, it's still good.
+		$app->add( $command );
 
 		$tester = new ApplicationTester( $app );
 

--- a/projects/packages/changelogger/tests/php/tests/src/ApplicationTest.php
+++ b/projects/packages/changelogger/tests/php/tests/src/ApplicationTest.php
@@ -72,7 +72,7 @@ class ApplicationTest extends TestCase {
 
 		$command = new Command( 'testDoRun' );
 		$command->setCode( $callback );
-		$app->add( $command );
+		$app->addCommand( $command );
 
 		$tester = new ApplicationTester( $app );
 


### PR DESCRIPTION
PR checks failing due to:

```
FILE: projects/packages/changelogger/tests/php/tests/src/ApplicationTest.php
------------------------------------------------------------------------------------------------
FOUND 1 ISSUE
------------------------------------------------------------------------------------------------
75 | DeprecatedError PhanDeprecatedFunction Call to deprecated function
   | \Automattic\Jetpack\Changelogger\Application::add() defined at
   | vendor/symfony/console/Application.php:556 (Deprecated because: since Symfony 7.4, use
   | Application::addCommand() instead)
------------------------------------------------------------------------------------------------
```

## Proposed changes:
* ~Updated ApplicationTest.php to use `addCommand()` instead of the deprecated `add()` method~
* ~This change modernizes the test code to use the current Symfony Console API~
* The `add()` method has been deprecated in favor of `addCommand()` in newer versions of Symfony Console. Sadly, trying to use the new method triggers errors on older PHP versions. Ignore for now.



### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

* Run Phan analysis on the changelogger package to verify there are no deprecation warnings:
  ```bash
  jetpack phan packages/changelogger
  ```
* Verify that there are no deprecation warnings related to the `add()` method
* The analysis should pass cleanly without any warnings about deprecated method usage