### PR TITLE
Code Editor: Fix after private-api removal

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-code-editor
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-code-editor
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Gutenberg removed the feature used to render the improved code editor. Fix it by switching to an alternate implementation.

--- a/projects/packages/jetpack-mu-wpcom/src/features/code-editor/class-code-editor.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/code-editor/class-code-editor.php
@@ -89,17 +89,7 @@ abstract class Code_Editor {
 			wp_enqueue_script_module( self::MODULE_PREFIX . 'code-editor' );
 
 			// Enqueue code editor script dependencies.
-			wp_enqueue_script( 'react' );
-			wp_enqueue_script( 'wp-blocks' );
-			wp_enqueue_script( 'wp-components' );
-			wp_enqueue_script( 'wp-compose' );
-			wp_enqueue_script( 'wp-core-data' );
-			wp_enqueue_script( 'wp-data' );
-			wp_enqueue_script( 'wp-editor' );
 			wp_enqueue_script( 'wp-i18n' );
-			wp_enqueue_script( 'wp-keyboard-shortcuts' );
-			wp_enqueue_script( 'wp-plugins' );
-			wp_enqueue_script( 'wp-private-apis' );
 		}
 
 		/**

--- a/projects/packages/jetpack-mu-wpcom/src/features/code-editor/code-editor/code-editor.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/code-editor/code-editor/code-editor.tsx
@@ -1,402 +1,173 @@
-// eslint-disable-next-line jsdoc/check-tag-names
-/** @jsxRuntime classic */
 /**
  * Load a featureful editor in the "code editor" view of the Block and Site Editors.
  *
  * The dependency extraction webpack plugin with modules does not like the jsx-runtime import.
  */
 import type { EditorView } from '@codemirror/view';
-import type { JSXElementConstructor, JSX } from 'react';
 
-const React = window.React;
-const { __unstableSerializeAndClean } = window.wp.blocks;
-const { Button, VisuallyHidden } = window.wp.components;
-const { useInstanceId } = window.wp.compose;
-const { store: coreStore } = window.wp.coreData;
-const { useDispatch, useSelect } = window.wp.data;
-const { store: editorStore, PostTitleRaw, privateApis: editorPrivateApis } = window.wp.editor;
-const { __ } = window.wp.i18n;
-const { store: keyboardShortcutsStore } = window.wp.keyboardShortcuts;
-const { registerPlugin } = window.wp.plugins;
-const { __dangerousOptInToUnstableAPIsOnlyForCoreModules } = window.wp.privateApis;
+// @ts-expect-error Script globals should be exported
+const { __ }: typeof import('@wordpress/i18n') = window.wp.i18n;
 
-const isSiteEditor = !! document.querySelector( '#site-editor.edit-site' );
+const codeEditorTextareaSelector = 'textarea.editor-post-text-editor';
 
-let EditorContentSlotFill:
-	| {
-			name: string | symbol;
-			Fill: {
-				// eslint-disable-next-line @typescript-eslint/no-explicit-any
-				( props: any ): JSX.Element;
-				displayName: string;
-			};
-			Slot: {
-				// eslint-disable-next-line @typescript-eslint/no-explicit-any
-				( props: any ): JSX.Element;
-				displayName: string;
-			};
-	  }
-	| undefined;
+/**
+ * Null = editor not loaded
+ * true = editor is loading
+ * EditorView = editor is loaded
+ */
+let editor: EditorView | true | null = null;
+
+// Prevent a flash of the textarea before we cover it.
 {
-	const unlockModuleCandidates = isSiteEditor
-		? [
-				'@wordpress/edit-widgets',
-				'@wordpress/customize-widgets',
-				'@wordpress/block-directory',
-				// '@wordpress/block-editor',
-				// '@wordpress/block-library',
-				// '@wordpress/blocks',
-				// '@wordpress/commands',
-				// '@wordpress/components',
-				// '@wordpress/core-commands',
-				// '@wordpress/core-data',
-				// '@wordpress/data',
-				// '@wordpress/edit-post',
-				// '@wordpress/editor',
-				// '@wordpress/format-library',
-				// '@wordpress/patterns',
-				// '@wordpress/preferences',
-				'@wordpress/reusable-blocks',
-				// '@wordpress/router',
-				// '@wordpress/dataviews',
-				// '@wordpress/fields',
-				// '@wordpress/media-utils',
-				// '@wordpress/upload-media',
-		  ]
-		: [
-				'@wordpress/edit-site',
-				'@wordpress/block-directory',
-				// '@wordpress/block-editor',
-				// '@wordpress/block-library',
-				// '@wordpress/blocks',
-				// '@wordpress/commands',
-				// '@wordpress/components',
-				// '@wordpress/core-commands',
-				// '@wordpress/core-data',
-				'@wordpress/customize-widgets',
-				// '@wordpress/data',
-				// '@wordpress/edit-post',
-				'@wordpress/edit-widgets',
-				// '@wordpress/editor',
-				// '@wordpress/format-library',
-				// '@wordpress/patterns',
-				// '@wordpress/preferences',
-				'@wordpress/reusable-blocks',
-				// '@wordpress/router',
-				'@wordpress/dataviews',
-				// '@wordpress/fields',
-				// '@wordpress/media-utils',
-				// '@wordpress/upload-media',
-		  ];
+	const styleElement = document.createElement( 'style' );
+	styleElement.textContent = `
+${ codeEditorTextareaSelector } {
+  visibility: hidden;
+}`;
+	document.head.appendChild( styleElement );
+}
 
-	const unlockString =
-		'I acknowledge private features are not for use in themes or plugins and doing so will break in the next version of WordPress.';
+const observer = new MutationObserver( () => {
+	const codeEditorTextarea: ReactHTMLTextAreaElement | null = document.querySelector(
+		codeEditorTextareaSelector
+	);
 
-	for ( const unlockModule of unlockModuleCandidates ) {
-		try {
-			const { unlock } = __dangerousOptInToUnstableAPIsOnlyForCoreModules(
-				unlockString,
-				unlockModule
-			);
-
-			const unlocked = unlock( editorPrivateApis );
-			EditorContentSlotFill = unlocked.EditorContentSlotFill;
-			break;
-		} catch {
-			// Silence is golden.
+	// If there's a textarea
+	if ( codeEditorTextarea ) {
+		// And the editor isn't loaded or initializing
+		if ( ! editor ) {
+			// Do it
+			setupEditor( codeEditorTextarea );
 		}
 	}
-}
+	// If there's no textarea but the editor is loaded
+	// we should "unmount" it.
+	else if ( editor && editor !== true ) {
+		const parent = editor.dom.parentElement;
+		editor?.destroy();
+		editor = null;
+		parent?.remove();
+	}
+} );
+observer.observe( document.body, { subtree: true, childList: true } );
 
-if ( EditorContentSlotFill !== undefined ) {
-	registerPlugin( 'a8c-code-editor--replace-editor', {
-		render: function CodeEditorFill() {
-			// eslint-disable-next-line @typescript-eslint/no-explicit-any
-			const mode = useSelect( ( select: any ) => {
-				return select( editorStore ).getEditorMode();
-			}, [] );
+const setupEditor = async ( target: ReactHTMLTextAreaElement ): Promise< void > => {
+	const containerElement = target.parentElement!;
+	// We'll use absolute positioning to place the editor.
+	// This must be set early so that we can calculate the top offset.
+	containerElement.style.setProperty( 'position', 'relative' );
 
-			if ( mode !== 'text' ) {
-				return null;
-			}
+	// Prevent possible double-loading of the editor by using "true" as an in-progress state.
+	editor = true;
+	const {
+		Autocomplete,
+		Commands,
+		HtmlLanguage,
+		Language,
+		Lint,
+		Search,
+		State,
+		View,
+		syntaxHighlightingStyle,
+		theme,
+	} =
+		// The feature registers this module for import.
+		// eslint-disable-next-line import/no-unresolved
+		await import( '@a8cCodeEditor/codemirror-bundle' );
 
-			return (
-				<EditorContentSlotFill.Fill>
-					<TextEditor />
-				</EditorContentSlotFill.Fill>
-			);
-		},
-	} );
-}
+	target._valueTracker?.stopTracking();
 
-/**
- * Render the Editor
- *
- * @return The editor element.
- */
-function TextEditor(): JSX.Element {
-	const { switchEditorMode } = useDispatch( editorStore );
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	const { shortcut, isRichEditingEnabled } = useSelect( ( select: any ) => {
-		const { getEditorSettings } = select( editorStore );
-		const { getShortcutRepresentation } = select( keyboardShortcutsStore );
+	const div = document.createElement( 'div' );
 
-		return {
-			shortcut: getShortcutRepresentation( 'core/editor/toggle-mode' ),
-			isRichEditingEnabled: getEditorSettings().richEditingEnabled,
-		};
-	}, [] );
+	const containerStyleMap = containerElement.computedStyleMap();
+	const left = containerStyleMap.get( 'padding-left' )?.toString() || '0';
+	const right = containerStyleMap.get( 'padding-right' )?.toString() || '0';
 
-	return (
-		<div className="editor-text-editor">
-			{ isRichEditingEnabled && (
-				<div className="editor-text-editor__toolbar">
-					<h2>{ __( 'Editing code', 'jetpack-mu-wpcom' ) }</h2>
-					<Button
-						__next40pxDefaultSize
-						variant="tertiary"
-						onClick={ () => switchEditorMode( 'visual' ) }
-						shortcut={ shortcut }
-					>
-						{ __( 'Exit code editor', 'jetpack-mu-wpcom' ) }
-					</Button>
-				</div>
-			) }
-			<div className="editor-text-editor__body">
-				<PostTitleRaw />
-				<React.Suspense fallback={ <div /> }>
-					<CodeEditor />
-				</React.Suspense>
-			</div>
-		</div>
-	);
-}
+	const top = `${ target.offsetTop }px`;
+	div.style = `position: absolute; top: ${ top }; left: ${ left }; right: ${ right }; height: calc(100% - ${ top });`;
 
-/**
- * Render the code editor
- *
- * @return The code editor element.
- */
-function CodeEditor(): JSX.Element {
-	const instanceId = useInstanceId( CodeEditor );
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	const { content, blocks, type, id } = useSelect( ( select: any ) => {
-		const { getEditedEntityRecord } = select( coreStore );
-		const { getCurrentPostType, getCurrentPostId } = select( editorStore );
-		const _type = getCurrentPostType();
-		const _id = getCurrentPostId();
-		const editedRecord = getEditedEntityRecord( 'postType', _type, _id );
-
-		return {
-			content: editedRecord?.content,
-			blocks: editedRecord?.blocks,
-			type: _type,
-			id: _id,
-		};
-	}, [] );
-
-	// Replicates the logic found in getEditedPostContent().
-	const value = React.useMemo( () => {
-		if ( content instanceof Function ) {
-			return content( { blocks } );
-		} else if ( blocks ) {
-			// If we have parsed blocks already, they should be our source of truth.
-			// Parsing applies block deprecations and legacy block conversions that
-			// unparsed content will not have.
-			return __unstableSerializeAndClean( blocks );
-		}
-		return content;
-	}, [ content, blocks ] );
-
-	return (
-		<>
-			<VisuallyHidden as="label" htmlFor={ `post-content-${ instanceId }` }>
-				{ __( 'Type text or HTML', 'jetpack-mu-wpcom' ) }
-			</VisuallyHidden>
-			<CM initialValue={ value } type={ type } id={ id } />
-		</>
-	);
-}
-
-const cm_lazy = ( cm_module: typeof import('@a8cCodeEditor/codemirror-bundle') ) => {
-	return function CodeMirror( props: { initialValue: string; type: string; id: string } ) {
-		const {
-			Autocomplete,
-			Commands,
-			HtmlLanguage,
-			Language,
-			Lint,
-			Search,
-			State,
-			View,
-			syntaxHighlightingStyle,
-			theme,
-		} = cm_module;
-
-		const { initialValue, type, id } = props;
-
-		const ref: React.RefObject< HTMLDivElement > = React.useRef( null );
-
-		const viewRef: React.MutableRefObject< EditorView | undefined > = React.useRef( undefined );
-
-		const { editEntityRecord } = useDispatch( coreStore );
-		const updateCode = React.useCallback(
-			( code: string ) => {
-				editEntityRecord( 'postType', type, id, {
-					content: code,
-					blocks: undefined,
-					selection: undefined,
-				} );
-			},
-			[ type, id, editEntityRecord ]
-		);
-
-		const updateListener = React.useRef(
+	editor = new View.EditorView( {
+		doc: target.value,
+		parent: div,
+		extensions: [
+			View.EditorView.theme( theme ),
+			View.EditorView.theme( {
+				'&': {
+					fontSize: '16px',
+				},
+				'&.cm-focused': {
+					boxShadow:
+						'0 0 0 var(--wp-admin-border-width-focus, 2px) var(--wp-admin-theme-color, #3858e9)',
+				},
+				'& .cm-gutterElement': {
+					lineHeight: 2.4,
+				},
+				'& .cm-content': {
+					padding: '16px 0',
+					lineHeight: 2.4,
+				},
+				'& .cm-line': { padding: '0 16px' },
+			} ),
+			View.EditorView.lineWrapping,
+			View.lineNumbers(),
+			View.highlightActiveLineGutter(),
+			View.highlightSpecialChars(),
+			Commands.history(),
+			Language.foldGutter(),
+			View.drawSelection(),
+			View.dropCursor(),
+			State.EditorState.allowMultipleSelections.of( true ),
+			Language.indentOnInput(),
+			Language.syntaxHighlighting( syntaxHighlightingStyle ),
+			Language.bracketMatching(),
+			Autocomplete.closeBrackets(),
+			Autocomplete.autocompletion(),
+			View.rectangularSelection(),
+			View.crosshairCursor(),
+			View.highlightActiveLine(),
+			View.placeholder( __( 'Type text or HTML', 'jetpack-mu-wpcom' ) ),
+			Search.highlightSelectionMatches(),
+			View.keymap.of( [
+				...Autocomplete.closeBracketsKeymap,
+				...Commands.defaultKeymap,
+				...Search.searchKeymap,
+				...Commands.historyKeymap,
+				...Language.foldKeymap,
+				...Autocomplete.completionKeymap,
+				...Lint.lintKeymap,
+				Commands.indentWithTab,
+			] ),
 			State.EditorState.transactionExtender.of( transaction => {
+				if ( ! target ) {
+					return null;
+				}
 				if ( transaction.docChanged ) {
-					const code = transaction.newDoc.toString();
-					updateCode( code );
+					const newValue = transaction.newDoc.toString();
+					target.value = newValue;
+					target.dispatchEvent( new InputEvent( 'input', { bubbles: true } ) );
 				}
 				return null;
-			} )
-		);
-
-		React.useEffect(
-			() => {
-				if ( viewRef.current ) {
-					return;
-				}
-
-				viewRef.current = new View.EditorView( {
-					doc: initialValue,
-					extensions: [
-						View.EditorView.theme( theme ),
-						View.EditorView.theme( {
-							'&': {
-								fontSize: '16px',
-							},
-							'&.cm-focused': {
-								boxShadow:
-									'0 0 0 var(--wp-admin-border-width-focus, 2px) var(--wp-admin-theme-color, #3858e9)',
-							},
-							'& .cm-gutterElement': {
-								lineHeight: 2.4,
-							},
-							'& .cm-content': {
-								padding: '16px 0',
-								lineHeight: 2.4,
-							},
-							'& .cm-line': { padding: '0 16px' },
-						} ),
-						View.EditorView.lineWrapping,
-						View.lineNumbers(),
-						View.highlightActiveLineGutter(),
-						View.highlightSpecialChars(),
-						Commands.history(),
-						Language.foldGutter(),
-						View.drawSelection(),
-						View.dropCursor(),
-						State.EditorState.allowMultipleSelections.of( true ),
-						Language.indentOnInput(),
-						Language.syntaxHighlighting( syntaxHighlightingStyle ),
-						Language.bracketMatching(),
-						Autocomplete.closeBrackets(),
-						Autocomplete.autocompletion(),
-						View.rectangularSelection(),
-						View.crosshairCursor(),
-						View.highlightActiveLine(),
-						Search.highlightSelectionMatches(),
-						View.keymap.of( [
-							...Autocomplete.closeBracketsKeymap,
-							...Commands.defaultKeymap,
-							...Search.searchKeymap,
-							...Commands.historyKeymap,
-							...Language.foldKeymap,
-							...Autocomplete.completionKeymap,
-							...Lint.lintKeymap,
-							Commands.indentWithTab,
-						] ),
-
-						updateListener.current,
-						HtmlLanguage.html( {
-							autoCloseTags: true,
-							matchClosingTags: true,
-							extraGlobalAttributes: {
-								'data-wp-namespace': [ '' ],
-							},
-						} ),
-					],
-					parent: ref.current!,
-				} );
-				return () => {
-					viewRef.current?.destroy();
-					viewRef.current = undefined;
-				};
-			},
-
-			// The initialValue is not included here. It is only used to initialize the editor.
-			// From that point, the editor has control of the post content and pushes changes
-			// to the store.
-			// eslint-disable-next-line react-hooks/exhaustive-deps
-			[
-				Autocomplete,
-				Commands,
-				HtmlLanguage,
-				Language,
-				Lint.lintKeymap,
-				Search,
-				State.EditorState.allowMultipleSelections,
-				View,
-				syntaxHighlightingStyle,
-				theme,
-				id,
-			]
-		);
-
-		return <div ref={ ref } />;
-	};
+			} ),
+			HtmlLanguage.html( {
+				autoCloseTags: true,
+				matchClosingTags: true,
+				extraGlobalAttributes: {
+					'data-wp-namespace': [ '' ],
+				},
+			} ),
+		],
+	} );
+	containerElement.appendChild( div );
 };
 
-const CM = React.lazy( async () => {
-	// The feature registers this module for import.
-	// eslint-disable-next-line import/no-unresolved
-	const cm = await import( '@a8cCodeEditor/codemirror-bundle' );
-
-	return { default: cm_lazy( cm ) };
-} );
-
-/* eslint-disable @typescript-eslint/no-explicit-any */
-declare global {
-	interface Window {
-		React: typeof import('react');
-
-		wp: {
-			blocks: {
-				__unstableSerializeAndClean: ( blocks: object[] ) => object[];
-			};
-			components: typeof import('@wordpress/components');
-			compose: typeof import('@wordpress/compose');
-			coreData: {
-				store: any;
-			};
-			data: {
-				useDispatch: ( store: any ) => any;
-				useSelect: (
-					selectOrStore: any | ( ( select: ( store: any ) => any ) => any ),
-					dependencies?: unknown[]
-				) => any;
-			};
-			editor: {
-				PostTitleRaw: JSXElementConstructor< any >;
-				privateApis: any;
-				store: any;
-			};
-			i18n: typeof import('@wordpress/i18n');
-			keyboardShortcuts: {
-				store: any;
-			};
-			plugins: typeof import('@wordpress/plugins');
-			privateApis: typeof import('@wordpress/private-apis');
-		};
-	}
+interface ReactHTMLTextAreaElement extends HTMLTextAreaElement {
+	/** React internals 😬 */
+	_valueTracker?: {
+		getValue: () => string;
+		setValue: ( value: string ) => void;
+		/**
+		 * This seems to remove the tracking and _valueTracker
+		 */
+		stopTracking: () => void;
+	};
 }

--- a/projects/packages/jetpack-mu-wpcom/src/features/code-editor/code-editor/code-editor.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/code-editor/code-editor/code-editor.tsx
@@ -82,9 +82,10 @@ const setupEditor = async ( target: ReactHTMLTextAreaElement ): Promise< void > 
 	const containerStyleMap = containerElement.computedStyleMap();
 	const left = containerStyleMap.get( 'padding-left' )?.toString() || '0';
 	const right = containerStyleMap.get( 'padding-right' )?.toString() || '0';
+	const paddingBottom = containerStyleMap.get( 'padding-bottom' )?.toString() || '12px';
 
 	const top = `${ target.offsetTop }px`;
-	div.style = `position: absolute; top: ${ top }; left: ${ left }; right: ${ right }; height: calc(100% - ${ top });`;
+	div.style = `position: absolute; top: ${ top }; left: ${ left }; right: ${ right }; padding-bottom: ${ paddingBottom };`;
 
 	editor = new View.EditorView( {
 		doc: target.value,

--- a/projects/packages/jetpack-mu-wpcom/src/features/code-editor/site-additional-css/site-additional-css.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/code-editor/site-additional-css/site-additional-css.ts
@@ -66,7 +66,6 @@ const setupEditor = async (
 	target: ReactHTMLTextAreaElement,
 	cssParseStartsAtStyles: boolean
 ): Promise< void > => {
-	// biome-ignore lint/style/noNonNullAssertion: Please.
 	const controlElement = target.parentElement!;
 	// We'll use absolute positioning to place the editor.
 	// This must be set early so that we can calculate the top offset.


### PR DESCRIPTION


## Proposed changes:

Fixes the improved code editor feature after the `EditorContentSlotFill` private API it relied on was removed in https://github.com/WordPress/gutenberg/pull/72681.

This implements the code editor replacement using the [same technique that was used for the CSS editors](https://github.com/Automattic/jetpack/blob/72f4f7798cd31e5a61852f1126a8f7d222f60aab/projects/packages/jetpack-mu-wpcom/src/features/code-editor/site-additional-css/site-additional-css.ts).



### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?



## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:

Test this out on a WordPress.com simple site.
Without this patch, the improved editor is unavailable and the regular editor is used.

With this patch, the improved editor is shown.

Interact with the improved editor and ensure that changes are correctly synced between the visual and code editors.

