### PR TITLE
Forms: fix csv export labels

### DIFF
--- a/projects/packages/forms/changelog/fix-form-csv-export-labels
+++ b/projects/packages/forms/changelog/fix-form-csv-export-labels
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: Fix CSV export metadata header collisions by wrapping system-generated fields in brackets.

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -2441,17 +2441,17 @@ class Contact_Form_Plugin {
 			}
 			$fields             = $feedback->get_compiled_fields( 'personal_export', 'all' );
 			$post_export_data[] = array(
-				'name'  => __( 'Date', 'jetpack-forms' ),
+				'name'  => '[' . __( 'Date', 'jetpack-forms' ) . ']',
 				'value' => $feedback->get_time(),
 			);
 
 			$post_export_data[] = array(
-				'name'  => __( 'Source Title', 'jetpack-forms' ),
+				'name'  => '[' . __( 'Source Title', 'jetpack-forms' ) . ']',
 				'value' => $feedback->get_entry_title(),
 			);
 
 			$post_export_data[] = array(
-				'name'  => __( 'Source URL:', 'jetpack-forms' ),
+				'name'  => '[' . __( 'Source URL', 'jetpack-forms' ) . ']',
 				'value' => $feedback->get_entry_permalink(),
 			);
 
@@ -2463,17 +2463,17 @@ class Contact_Form_Plugin {
 			}
 
 			$post_export_data[] = array(
-				'name'  => __( 'Consent', 'jetpack-forms' ),
+				'name'  => '[' . __( 'Consent', 'jetpack-forms' ) . ']',
 				'value' => $feedback->has_consent() ? __( 'Yes', 'jetpack-forms' ) : __( 'No', 'jetpack-forms' ),
 			);
 
 			$post_export_data[] = array(
-				'name'  => __( 'IP Address', 'jetpack-forms' ),
+				'name'  => '[' . __( 'IP Address', 'jetpack-forms' ) . ']',
 				'value' => $feedback->get_ip_address(),
 			);
 
 			$post_export_data[] = array(
-				'name'  => __( 'Country code', 'jetpack-forms' ),
+				'name'  => '[' . __( 'Country code', 'jetpack-forms' ) . ']',
 				'value' => $feedback->get_country_code(),
 			);
 

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -2714,10 +2714,10 @@ class Contact_Form_Plugin {
 			if ( ! $feedback instanceof Feedback ) {
 				continue; // Skip if the feedback is not an instance of Feedback.
 			}
-			$results[ __( 'ID', 'jetpack-forms' ) ][]     = $feedback_id;
-			$results[ __( 'Date', 'jetpack-forms' ) ][]   = $feedback->get_time();
-			$results[ __( 'Title', 'jetpack-forms' ) ][]  = $feedback->get_entry_title();
-			$results[ __( 'Source', 'jetpack-forms' ) ][] = $feedback->get_entry_short_permalink();
+			$results[ '[' . __( 'ID', 'jetpack-forms' ) . ']' ][]     = $feedback_id;
+			$results[ '[' . __( 'Date', 'jetpack-forms' ) . ']' ][]   = $feedback->get_time();
+			$results[ '[' . __( 'Title', 'jetpack-forms' ) . ']' ][]  = $feedback->get_entry_title();
+			$results[ '[' . __( 'Source', 'jetpack-forms' ) . ']' ][] = $feedback->get_entry_short_permalink();
 			/**
 			 * Go through all the possible fields and check if the field is available
 			 * in the current feedback.
@@ -2733,10 +2733,10 @@ class Contact_Form_Plugin {
 				$results[ $single_field_name ][] = isset( $compiled_fields[ $single_field_name ] ) ? $compiled_fields[ $single_field_name ] : '';
 			}
 
-			$results[ __( 'Consent', 'jetpack-forms' ) ][]      = $feedback->has_consent() ? __( 'Yes', 'jetpack-forms' ) : __( 'No', 'jetpack-forms' );
-			$results[ __( 'IP Address', 'jetpack-forms' ) ][]   = $feedback->get_ip_address();
-			$results[ __( 'Country code', 'jetpack-forms' ) ][] = $feedback->get_country_code();
-			$results[ __( 'Browser', 'jetpack-forms' ) ][]      = $feedback->get_browser();
+			$results[ '[' . __( 'Consent', 'jetpack-forms' ) . ']' ][]      = $feedback->has_consent() ? __( 'Yes', 'jetpack-forms' ) : __( 'No', 'jetpack-forms' );
+			$results[ '[' . __( 'IP Address', 'jetpack-forms' ) . ']' ][]   = $feedback->get_ip_address();
+			$results[ '[' . __( 'Country code', 'jetpack-forms' ) . ']' ][] = $feedback->get_country_code();
+			$results[ '[' . __( 'Browser', 'jetpack-forms' ) . ']' ][]      = $feedback->get_browser();
 
 		}
 		return $results;

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
@@ -698,18 +698,17 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 
 		$this->assertEquals(
 			array(
-
-				'ID'           => array( $post_id_1, $post_id_2 ),
-				'Date'         => array( $post_1->post_date, $post_2->post_date ),
-				'Title'        => array( $current_post->post_title, $current_post->post_title ),
-				'field_A'      => array( 'value1', 'value1' ),
-				'field_B'      => array( 'value2', '' ),
-				'field_C'      => array( '', 'value2' ),
-				'Source'       => array( '/?p=' . $current_post->ID, '/?p=' . $current_post->ID ),
-				'Consent'      => array( $default_consent, $default_consent ),
-				'IP Address'   => array( $ip, $ip ),
-				'Country code' => array( $country_code, $country_code ),
-				'Browser'      => array( null, null ), // No browser for legacy feedback
+				'[ID]'           => array( $post_id_1, $post_id_2 ),
+				'[Date]'         => array( $post_1->post_date, $post_2->post_date ),
+				'[Title]'        => array( $current_post->post_title, $current_post->post_title ),
+				'field_A'        => array( 'value1', 'value1' ),
+				'field_B'        => array( 'value2', '' ),
+				'field_C'        => array( '', 'value2' ),
+				'[Source]'       => array( '/?p=' . $current_post->ID, '/?p=' . $current_post->ID ),
+				'[Consent]'      => array( $default_consent, $default_consent ),
+				'[IP Address]'   => array( $ip, $ip ),
+				'[Country code]' => array( $country_code, $country_code ),
+				'[Browser]'      => array( null, null ), // No browser for legacy feedback
 			),
 			$plugin->get_export_feedback_data( $post_ids )
 		);
@@ -832,13 +831,13 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 
 		// Verify the basic structure
 		$this->assertIsArray( $result );
-		$this->assertTrue( isset( $result['ID'] ) );
-		$this->assertTrue( isset( $result['Date'] ) );
-		$this->assertTrue( isset( $result['Title'] ) );
-		$this->assertTrue( isset( $result['Source'] ) );
-		$this->assertTrue( isset( $result['Consent'] ) );
-		$this->assertTrue( isset( $result['IP Address'] ) );
-		$this->assertTrue( isset( $result['Browser'] ) );
+		$this->assertTrue( isset( $result['[ID]'] ) );
+		$this->assertTrue( isset( $result['[Date]'] ) );
+		$this->assertTrue( isset( $result['[Title]'] ) );
+		$this->assertTrue( isset( $result['[Source]'] ) );
+		$this->assertTrue( isset( $result['[Consent]'] ) );
+		$this->assertTrue( isset( $result['[IP Address]'] ) );
+		$this->assertTrue( isset( $result['[Browser]'] ) );
 
 		$equals = array(
 			'Name'    => array( 'Test "Quotes" User' ),
@@ -849,8 +848,8 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 		);
 
 		// Each field should be an array with one entry
-		$this->assertCount( 1, $result['ID'] );
-		$this->assertEquals( $post_id, $result['ID'][0] );
+		$this->assertCount( 1, $result['[ID]'] );
+		$this->assertEquals( $post_id, $result['[ID]'][0] );
 
 		foreach ( $equals as $key => $value ) {
 			$this->assertTrue( isset( $result[ $key ] ) );
@@ -862,7 +861,6 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 	}
 
 	public function test_interpersonal_data_exporter() {
-
 		$post_id = Utility::create_legacy_feedback(
 			array(
 				'1_field' => 'value1',
@@ -880,15 +878,15 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 			'item_id'     => 'feedback-' . $post_id,
 			'data'        => array(
 				array(
-					'name'  => 'Date',
+					'name'  => '[Date]',
 					'value' => get_post_field( 'post_date', $post_id ),
 				),
 				array(
-					'name'  => 'Source Title',
+					'name'  => '[Source Title]',
 					'value' => '(deleted) Cool Post Title', // the default value in the create_legacy_feedback
 				),
 				array(
-					'name'  => 'Source URL:',
+					'name'  => '[Source URL]',
 					'value' => '',
 				),
 				array(
@@ -904,15 +902,15 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 					'value' => 'hello@example.com',
 				),
 				array(
-					'name'  => 'Consent',
+					'name'  => '[Consent]',
 					'value' => 'No',
 				),
 				array(
-					'name'  => 'IP Address',
+					'name'  => '[IP Address]',
 					'value' => 'https://127.0.0.1',
 				), // same as the default value in the create_legacy_feedback
 				array(
-					'name'  => 'Country code',
+					'name'  => '[Country code]',
 					'value' => null,
 				), // no country code for legacy feedback
 			),

--- a/projects/plugins/jetpack/changelog/fix-form-csv-export-labels
+++ b/projects/plugins/jetpack/changelog/fix-form-csv-export-labels
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Forms: Fix CSV export metadata header collisions by wrapping system-generated fields in brackets.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes FORMS-438

When importing form responses to CSV, the metadata headers we add (Date, Title, Source, etc) could collide with user-defined form fields, resulting in the exports missing data.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Wrap metadata headers in brackets

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a form with a Date picker, or any input with a label that collides with the metadata headers (Title, Source, Browser, etc).
* Submit a few responses.
* Go to the Form responses dashboard and export the responses to CSV.
* Check that there are no rows with missing data in the Date field (or any other metadata field).


