### PR TITLE
Forms: Fix checkbox checkmark border color for better contrast

### DIFF
--- a/projects/packages/forms/changelog/fix-form-checkboxes-colors
+++ b/projects/packages/forms/changelog/fix-form-checkboxes-colors
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix checkbox checkmark border color to use text color for better contrast

--- a/projects/packages/forms/src/contact-form/css/grunion.scss
+++ b/projects/packages/forms/src/contact-form/css/grunion.scss
@@ -11,6 +11,7 @@
 	--jetpack--contact-form--input-padding: 16px;
 	--jetpack--contact-form--font-size: 16px;
 	--jetpack--contact-form--error-color: #b32d2e;
+	// mind that this is not really "inverted", just fixed to white.
 	--jetpack--contact-form--inverted-text-color: #fff;
 }
 
@@ -738,7 +739,6 @@ that needs to mimic the input element styles */
 :where(.wp-block-jetpack-contact-form.is-style-outlined) .wp-block-jetpack-options {
 	background-color: var(--jetpack--contact-form--input-background);
 }
-
 
 /*
 For some reason, when keeping the rule below together with the above selector,

--- a/projects/packages/forms/src/contact-form/css/grunion.scss
+++ b/projects/packages/forms/src/contact-form/css/grunion.scss
@@ -1049,12 +1049,6 @@ on production builds, the attributes are being reordered, causing side-effects
 	border-radius: 50%;
 }
 
-.contact-form .is-style-list input.consent:checked,
-.contact-form .is-style-list input.checkbox:checked,
-.contact-form .grunion-field-wrap:not(.is-style-plain) input.checkbox-multiple:checked {
-	background-color: currentColor;
-
-}
 
 .contact-form .is-style-list input.consent::before,
 .contact-form .is-style-list input.checkbox::before,

--- a/projects/packages/forms/src/contact-form/css/grunion.scss
+++ b/projects/packages/forms/src/contact-form/css/grunion.scss
@@ -1075,6 +1075,12 @@ on production builds, the attributes are being reordered, causing side-effects
 	left: 0;
 }
 
+.contact-form .is-style-list input.consent:checked::after {
+	// consent checkboxes are sometimes scaled.
+	// Keep it centered and with same angle.
+	transform: rotate(30deg) scale(0.7) translate(-40%, -15%);
+}
+
 .contact-form .is-style-list input.consent:checked::before,
 .contact-form .is-style-list input.checkbox:checked::before,
 .contact-form .grunion-field-wrap:not(.is-style-plain) input.checkbox-multiple:checked::before {

--- a/projects/packages/forms/src/contact-form/css/grunion.scss
+++ b/projects/packages/forms/src/contact-form/css/grunion.scss
@@ -1065,7 +1065,10 @@ on production builds, the attributes are being reordered, causing side-effects
 	transition: opacity 0.1s ease-in-out, scale 0.15s ease-in-out;
 
 	font-size: inherit;
-	border: solid var(--jetpack--contact-form--inverted-text-color, var(--jetpack--contact-form--input-background));
+	// if checkboxes bg are --jetpack--contact-form--input-background,
+	// then border-color should text color
+	border-color: var(--jetpack--contact-form--text-color, fieldText);
+	border-style: solid;
 	border-width: 0 2px 2px 0;
 	transform: translate(-50%, -60%) rotate(40deg);
 	top: 0;


### PR DESCRIPTION
Part of FORMS-437

## Proposed changes:
* Changed checkbox checkmark border color from inverted-text-color to text-color for better contrast with input backgrounds
* Fixed consent checkbox positioning to maintain proper centering and rotation when scaled
* Removed unused background-color rule that was causing checkboxes to inherit currentColor incorrectly
* Added clarifying comment that --jetpack--contact-form--inverted-text-color is fixed to white, not truly inverted

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1764251172431619-slack-C052XEUUBL4

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

* Create a new post or page with the Jetpack Contact Form block
* Add checkbox fields to the form using the Checkbox Group style (list style)
* Also add a consent checkbox
* Change the theme to one with a light background for input fields
* Verify that the checkmark inside checked checkboxes is visible and has good contrast
* Test with different themes that have different input background colors
* Verify that the consent checkbox checkmark appears properly centered when checked
* Before this fix, the checkmark border color would match the inverted text color (white), making it invisible on light input backgrounds
* After this fix, the checkmark border color matches the text color, ensuring it's always visible

Before / After:
- **Before**: Checkmark was white on white background (invisible)
- **After**: Checkmark uses text color, ensuring proper contrast with input background