### PR TITLE
Forms: fix rename column names export

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-rename-column-names-export
+++ b/projects/packages/forms/changelog/fix-forms-rename-column-names-export
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: remove clashing between meta and field names

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -2705,7 +2705,8 @@ class Contact_Form_Plugin {
 	 * @return array
 	 */
 	private function format_feedback_data_for_csv( $feedback_data, $field_names ) {
-		$results = array();
+		$results            = array();
+		$prefix_meta_fields = ' '; // Prefix all meta fields with a space to ensure that they don't clash with form field names.
 		foreach ( $feedback_data as $feedback_id => $data ) {
 
 			$feedback        = $data['response'];
@@ -2714,10 +2715,11 @@ class Contact_Form_Plugin {
 			if ( ! $feedback instanceof Feedback ) {
 				continue; // Skip if the feedback is not an instance of Feedback.
 			}
-			$results[ __( 'ID', 'jetpack-forms' ) ][]     = $feedback_id;
-			$results[ __( 'Date', 'jetpack-forms' ) ][]   = $feedback->get_time();
-			$results[ __( 'Title', 'jetpack-forms' ) ][]  = $feedback->get_entry_title();
-			$results[ __( 'Source', 'jetpack-forms' ) ][] = $feedback->get_entry_short_permalink();
+
+			$results[ $prefix_meta_fields . __( 'ID', 'jetpack-forms' ) ][]     = $feedback_id;
+			$results[ $prefix_meta_fields . __( 'Date', 'jetpack-forms' ) ][]   = $feedback->get_time();
+			$results[ $prefix_meta_fields . __( 'Title', 'jetpack-forms' ) ][]  = $feedback->get_entry_title();
+			$results[ $prefix_meta_fields . __( 'Source', 'jetpack-forms' ) ][] = $feedback->get_entry_short_permalink();
 			/**
 			 * Go through all the possible fields and check if the field is available
 			 * in the current feedback.
@@ -2726,17 +2728,18 @@ class Contact_Form_Plugin {
 			 * If it is not - add an empty string, which is just a placeholder in the CSV.
 			 */
 			foreach ( $field_names as $single_field_name ) {
-				if ( ! isset( $results[ $single_field_name ] ) ) {
-					$results[ $single_field_name ] = array();
+				$trimmed_field_name = trim( $single_field_name );
+				if ( ! isset( $results[ $trimmed_field_name ] ) ) {
+					$results[ $trimmed_field_name ] = array();
 				}
 				// Use the compiled fields directly (which already have incremented labels)
-				$results[ $single_field_name ][] = isset( $compiled_fields[ $single_field_name ] ) ? $compiled_fields[ $single_field_name ] : '';
+				$results[ $trimmed_field_name ][] = isset( $compiled_fields[ $trimmed_field_name ] ) ? $compiled_fields[ $trimmed_field_name ] : '';
 			}
 
-			$results[ __( 'Consent', 'jetpack-forms' ) ][]      = $feedback->has_consent() ? __( 'Yes', 'jetpack-forms' ) : __( 'No', 'jetpack-forms' );
-			$results[ __( 'IP Address', 'jetpack-forms' ) ][]   = $feedback->get_ip_address();
-			$results[ __( 'Country code', 'jetpack-forms' ) ][] = $feedback->get_country_code();
-			$results[ __( 'Browser', 'jetpack-forms' ) ][]      = $feedback->get_browser();
+			$results[ $prefix_meta_fields . __( 'Consent', 'jetpack-forms' ) ][]      = $feedback->has_consent() ? __( 'Yes', 'jetpack-forms' ) : __( 'No', 'jetpack-forms' );
+			$results[ $prefix_meta_fields . __( 'IP Address', 'jetpack-forms' ) ][]   = $feedback->get_ip_address();
+			$results[ $prefix_meta_fields . __( 'Country code', 'jetpack-forms' ) ][] = $feedback->get_country_code();
+			$results[ $prefix_meta_fields . __( 'Browser', 'jetpack-forms' ) ][]      = $feedback->get_browser();
 
 		}
 		return $results;

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
@@ -686,6 +686,7 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 			array(
 				'1_field_A' => 'value1',
 				'2_field_C' => 'value2',
+				'3_Date'    => '2024-01-01',
 			)
 		);
 		$post_2     = get_post( $post_id_2 );
@@ -695,21 +696,21 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 		$ip              = 'https://127.0.0.1';
 
 		$country_code = null; // No country code for legacy feedback
-
+		$prefix_meta  = ' ';
 		$this->assertEquals(
 			array(
-
-				'ID'           => array( $post_id_1, $post_id_2 ),
-				'Date'         => array( $post_1->post_date, $post_2->post_date ),
-				'Title'        => array( $current_post->post_title, $current_post->post_title ),
-				'field_A'      => array( 'value1', 'value1' ),
-				'field_B'      => array( 'value2', '' ),
-				'field_C'      => array( '', 'value2' ),
-				'Source'       => array( '/?p=' . $current_post->ID, '/?p=' . $current_post->ID ),
-				'Consent'      => array( $default_consent, $default_consent ),
-				'IP Address'   => array( $ip, $ip ),
-				'Country code' => array( $country_code, $country_code ),
-				'Browser'      => array( null, null ), // No browser for legacy feedback
+				$prefix_meta . 'ID'           => array( $post_id_1, $post_id_2 ),
+				$prefix_meta . 'Date'         => array( $post_1->post_date, $post_2->post_date ),
+				$prefix_meta . 'Title'        => array( $current_post->post_title, $current_post->post_title ),
+				'field_A'                     => array( 'value1', 'value1' ),
+				'field_B'                     => array( 'value2', '' ),
+				'field_C'                     => array( '', 'value2' ),
+				'Date'                        => array( '', '2024-01-01' ),
+				$prefix_meta . 'Source'       => array( '/?p=' . $current_post->ID, '/?p=' . $current_post->ID ),
+				$prefix_meta . 'Consent'      => array( $default_consent, $default_consent ),
+				$prefix_meta . 'IP Address'   => array( $ip, $ip ),
+				$prefix_meta . 'Country code' => array( $country_code, $country_code ),
+				$prefix_meta . 'Browser'      => array( null, null ), // No browser for legacy feedback
 			),
 			$plugin->get_export_feedback_data( $post_ids )
 		);
@@ -830,15 +831,17 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 		$plugin       = Contact_Form_Plugin::init();
 		$result       = $plugin->get_export_feedback_data( array( $post_id ) );
 
+		$prefix_meta = ' ';
+
 		// Verify the basic structure
 		$this->assertIsArray( $result );
-		$this->assertTrue( isset( $result['ID'] ) );
-		$this->assertTrue( isset( $result['Date'] ) );
-		$this->assertTrue( isset( $result['Title'] ) );
-		$this->assertTrue( isset( $result['Source'] ) );
-		$this->assertTrue( isset( $result['Consent'] ) );
-		$this->assertTrue( isset( $result['IP Address'] ) );
-		$this->assertTrue( isset( $result['Browser'] ) );
+		$this->assertTrue( isset( $result[ $prefix_meta . 'ID' ] ) );
+		$this->assertTrue( isset( $result[ $prefix_meta . 'Date' ] ) );
+		$this->assertTrue( isset( $result[ $prefix_meta . 'Title' ] ) );
+		$this->assertTrue( isset( $result[ $prefix_meta . 'Source' ] ) );
+		$this->assertTrue( isset( $result[ $prefix_meta . 'Consent' ] ) );
+		$this->assertTrue( isset( $result[ $prefix_meta . 'IP Address' ] ) );
+		$this->assertTrue( isset( $result[ $prefix_meta . 'Browser' ] ) );
 
 		$equals = array(
 			'Name'    => array( 'Test "Quotes" User' ),
@@ -849,8 +852,8 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 		);
 
 		// Each field should be an array with one entry
-		$this->assertCount( 1, $result['ID'] );
-		$this->assertEquals( $post_id, $result['ID'][0] );
+		$this->assertCount( 1, $result[ $prefix_meta . 'ID' ] );
+		$this->assertEquals( $post_id, $result[ $prefix_meta . 'ID' ][0] );
 
 		foreach ( $equals as $key => $value ) {
 			$this->assertTrue( isset( $result[ $key ] ) );

--- a/projects/plugins/jetpack/changelog/fix-forms-rename-column-names-export
+++ b/projects/plugins/jetpack/changelog/fix-forms-rename-column-names-export
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Forms: remove clashing between meta dn field names on export


### PR DESCRIPTION
Fixes [FORMS-438](https://linear.app/a8c/issue/FORMS-438)

Alternative to https://github.com/Automattic/jetpack/pull/46128 

## Proposed changes:
* Prefix meta fields with a space. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1764263295770109-slack-C052XEUUBL4

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:
Create a form with the same label as we currently some of the meta fields. Such as "Date", "ID" etc. 

Create some for submissions. 

Notice that when you export them they appear in the list as expected.