### PR TITLE
Forms: fix dashboard bubble overlap

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-dashboard-bubble-overlap
+++ b/projects/packages/forms/changelog/fix-forms-dashboard-bubble-overlap
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: make the filter count not be cut off

--- a/projects/packages/forms/src/dashboard/inbox/stage/index.js
+++ b/projects/packages/forms/src/dashboard/inbox/stage/index.js
@@ -521,7 +521,7 @@ export default function InboxView() {
 						style={ {
 							display: 'flex',
 							gap: '8px',
-							justifyContent: containerWidth < 600 ? 'space-between' : 'flex-end',
+							justifyContent: containerWidth < 600 ? 'unset' : 'flex-end',
 						} }
 					>
 						<DataViews.Search />

--- a/projects/packages/forms/src/dashboard/inbox/style.scss
+++ b/projects/packages/forms/src/dashboard/inbox/style.scss
@@ -8,7 +8,6 @@
 .jp-forms-view-actions {
 	border-bottom: 1px solid var(--wpds-color-stroke-surface-neutral-weak);
 	padding-inline: variables.$grid-unit * 2.5;
-	padding-block-start: variables.$grid-unit;
 	overflow-x: auto;
 	width: 100%;
 	box-sizing: border-box;
@@ -21,27 +20,25 @@
 	left: 0;
 	background: var(--wpds-color-bg-surface-neutral-strong, #fff);
 	justify-content: space-between;
-	align-items: center;
 	gap: 8px;
-
-	// On small stacks, switch to column stacking
-	flex-direction: row;
-
-	@container (width < 500px) {
-
-		& {
-			flex-direction: column;
-			align-items: flex-start;
-		}
-
-		// Jetpack Forms specific: Make all child divs full width on mobile
-		> div {
-			width: 100%;
-		}
-	}
+	flex-direction: column;
+	align-items: flex-start;
 
 	> div:not(:empty) {
 		min-height: 48px;
+		width: 100%;
+	}
+
+	@media (min-width: #{ (breakpoints.$break-small + 1) }) {
+
+		& {
+			flex-direction: row;
+			align-items: center;
+		}
+
+		> div:not(:empty) {
+			min-height: 0;
+		}
 	}
 
 	// Jetpack Forms specific: Tab styling

--- a/projects/packages/forms/src/dashboard/inbox/style.scss
+++ b/projects/packages/forms/src/dashboard/inbox/style.scss
@@ -8,6 +8,7 @@
 .jp-forms-view-actions {
 	border-bottom: 1px solid var(--wpds-color-stroke-surface-neutral-weak);
 	padding-inline: variables.$grid-unit * 2.5;
+	padding-block-start: variables.$grid-unit;
 	overflow-x: auto;
 	width: 100%;
 	box-sizing: border-box;


### PR DESCRIPTION
Before: 
<img width="878" height="195" alt="Screenshot 2025-11-27 at 9 25 00 PM" src="https://github.com/user-attachments/assets/ded1798e-1ac7-45f7-8233-5634aaac65e5" />

After:

<img width="884" height="205" alt="Screenshot 2025-11-27 at 9 24 37 PM" src="https://github.com/user-attachments/assets/e3551dbb-23e0-4bc7-be7e-5ee3b1d4f37c" />

## Proposed changes:
* Increase the padding.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
Bug report p8oabR-1IP-p2#comment-8716

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Go to the forms dashboard. Select a filter.

