### PR TITLE
Forms: remove empty link from responses dashboard

### DIFF
--- a/projects/packages/forms/changelog/fix-remove-link-forms-dashboard-when-empty
+++ b/projects/packages/forms/changelog/fix-remove-link-forms-dashboard-when-empty
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: do not link to to empty source_link

--- a/projects/packages/forms/src/dashboard/components/inspector/body.tsx
+++ b/projects/packages/forms/src/dashboard/components/inspector/body.tsx
@@ -331,9 +331,12 @@ const ResponseViewBody = ( {
 							<tr>
 								<th>{ __( 'Source:', 'jetpack-forms' ) }</th>
 								<td>
-									<ExternalLink href={ response.entry_permalink }>
-										{ decodeEntities( response.entry_title ) || getPath( response ) }
-									</ExternalLink>
+									{ response.entry_permalink && (
+										<ExternalLink href={ response.entry_permalink }>
+											{ decodeEntities( response.entry_title ) || getPath( response ) }
+										</ExternalLink>
+									) }
+									{ ! response.entry_permalink && decodeEntities( response.entry_title ) }
 								</td>
 							</tr>
 							<tr>

--- a/projects/packages/forms/src/dashboard/inbox/stage/index.js
+++ b/projects/packages/forms/src/dashboard/inbox/stage/index.js
@@ -340,6 +340,9 @@ export default function InboxView() {
 				id: 'source',
 				label: __( 'Source', 'jetpack-forms' ),
 				render: ( { item } ) => {
+					if ( ! item.entry_permalink ) {
+						return wrapperUnread( item.is_unread, decodeEntities( item.entry_title ) );
+					}
 					return (
 						<ExternalLink href={ item.entry_permalink }>
 							{ wrapperUnread(

--- a/projects/plugins/jetpack/changelog/fix-remove-link-forms-dashboard-when-empty
+++ b/projects/plugins/jetpack/changelog/fix-remove-link-forms-dashboard-when-empty
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Forms: do not link to empty source link


### PR DESCRIPTION
Before:

<img width="903" height="170" alt="Screenshot 2025-11-27 at 9 42 02 PM" src="https://github.com/user-attachments/assets/1db3884b-c80d-4174-89d5-6389a2ea726c" />

After:

<img width="954" height="180" alt="Screenshot 2025-11-27 at 9 39 21 PM" src="https://github.com/user-attachments/assets/ef0fe7be-3ac1-4a50-bc06-2a3ccf917562" />

## Proposed changes:

* Do not link to empty source permalink. Just return the title instead.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
See p8oabR-1IP-p2#comment-8705

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Create a form on a page. 
Submit the form. 
Trash the page. 

Notice that the source permalink don't link to the source any more. 
