### PR TITLE
Add plan-based feature support for form webhooks

### DIFF
--- a/projects/packages/forms/changelog/add-form-webhook-support
+++ b/projects/packages/forms/changelog/add-form-webhook-support
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Enable form webhooks feature based on current plan support

--- a/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
+++ b/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
@@ -62,6 +62,7 @@ class Contact_Form_Block {
 	public static function register_feature( $features ) {
 		// Features that are only available to users with a paid plan.
 		$features['multistep-form'] = Current_Plan::supports( 'multistep-form' );
+		$features['form-webhooks']  = Current_Plan::supports( 'form-webhooks' );
 
 		return $features;
 	}

--- a/projects/packages/forms/src/blocks/contact-form/edit.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/edit.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { ThemeProvider } from '@automattic/jetpack-components';
-import { useModuleStatus } from '@automattic/jetpack-shared-extension-utils';
+import { useModuleStatus, hasFeatureFlag } from '@automattic/jetpack-shared-extension-utils';
 import {
 	URLInput,
 	InspectorAdvancedControls,
@@ -180,7 +180,7 @@ function JetpackContactFormEdit( {
 		webhooks,
 	} = attributes;
 	const showFormIntegrations = useConfigValue( 'isIntegrationsEnabled' );
-	const showWebhooks = useConfigValue( 'isWebhooksEnabled' );
+	const showWebhooks = useConfigValue( 'isWebhooksEnabled' ) && hasFeatureFlag( 'form-webhooks' );
 	const instanceId = useInstanceId( JetpackContactFormEdit );
 
 	// Backward compatibility for the deprecated customThankyou attribute.

--- a/projects/packages/plans/changelog/add-form-webhook-support
+++ b/projects/packages/plans/changelog/add-form-webhook-support
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Add form-webhooks support on free Jetpack plans

--- a/projects/packages/plans/src/class-current-plan.php
+++ b/projects/packages/plans/src/class-current-plan.php
@@ -64,6 +64,7 @@ class Current_Plan {
 				'core/cover',
 				'core/audio',
 				'multistep-form',
+				'form-webhooks',
 			),
 		),
 		'personal' => array(

--- a/projects/plugins/wpcomsh/changelog/add-form-webhook-support
+++ b/projects/plugins/wpcomsh/changelog/add-form-webhook-support
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Add form-webhooks feature support for WordPress.com plans

--- a/projects/plugins/wpcomsh/wpcom-features/class-wpcom-features.php
+++ b/projects/plugins/wpcomsh/wpcom-features/class-wpcom-features.php
@@ -417,6 +417,7 @@ class WPCOM_Features {
 	public const EMAIL_SUBSCRIPTION                = 'email-subscription';
 	public const EMAIL_FORWARDS_EXTENDED_LIMIT     = 'email-forwards-extended-limit';
 	public const FIELD_FILE                        = 'field-file';
+	public const FORM_WEBHOOKS                     = 'form-webhooks';
 	public const FREE_BLOG                         = 'free-blog';
 	public const FULL_ACTIVITY_LOG                 = 'full-activity-log';
 	public const GITHUB_DEPLOYMENTS                = 'github-deployments';
@@ -782,6 +783,10 @@ class WPCOM_Features {
 		self::FIELD_FILE                        => array(
 			self::WPCOM_PERSONAL_AND_HIGHER_PLANS,
 			self::JETPACK_COMPLETE_PLANS,
+		),
+		self::FORM_WEBHOOKS                     => array(
+			self::WPCOM_BUSINESS_AND_HIGHER_PLANS,
+			self::JETPACK_ALL_SITES,
 		),
 		self::FREE_BLOG                         => array(
 			self::WPCOM_ALL_SITES,


### PR DESCRIPTION
## Proposed changes:
* Enable form webhooks feature based on current plan support
* Add form-webhooks support on free Jetpack plans
* Add form-webhooks feature support for WordPress.com business and higher plans
* Check both feature flag and configuration to enable webhook settings in the editor

Related: 197127-ghe-Automattic/wpcom

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

* This PR adds plan-based feature gating for form webhooks
* Verify that form webhook settings appear in the block editor for:
  - Free Jetpack plans
  - WordPress.com Business and higher plans
* Verify that the webhook settings panel is properly gated by both the isWebhooksEnabled config and the form-webhooks feature flag
* Test on both Jetpack and WordPress.com sites to ensure plan support is correctly detected