### PR TITLE
Forms: Fix preview only image formats and PDF to open in the browser.

### DIFF
--- a/projects/packages/forms/changelog/fix-preview-only-image-formats
+++ b/projects/packages/forms/changelog/fix-preview-only-image-formats
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Not really important
+
+

--- a/projects/packages/forms/changelog/fix-preview-only-image-formats
+++ b/projects/packages/forms/changelog/fix-preview-only-image-formats
@@ -1,5 +1,5 @@
 Significance: patch
 Type: fixed
-Comment: Not really important
+Comment: Restricts inline file preview to only image formats and PDFs, forces download for other file types for security.
 
 

--- a/projects/packages/forms/src/contact-form/class-feedback-field.php
+++ b/projects/packages/forms/src/contact-form/class-feedback-field.php
@@ -506,6 +506,11 @@ class Feedback_Field {
 	 * @return bool True if the file is previewable, false otherwise.
 	 */
 	private function is_previewable_file( $file ) {
+
+		if ( function_exists( '\Automattic\Jetpack\UnauthFileUpload\is_file_previable' ) ) {
+			return \Automattic\Jetpack\UnauthFileUpload\is_file_previable( $file['name'] );
+		}
+
 		$file_type = strtolower( pathinfo( $file['name'], PATHINFO_EXTENSION ) );
 		// Check if the file is previewable based on its type or extension.
 		// Note: This is a simplified check and does not match if the file is allowed to be uploaded by the server.

--- a/projects/packages/forms/src/contact-form/class-feedback-field.php
+++ b/projects/packages/forms/src/contact-form/class-feedback-field.php
@@ -501,7 +501,7 @@ class Feedback_Field {
 
 	/**
 	 * Checks if the file is previewable based on its type or extension.
-	 * We only allow image formats to be previewed in the modal.
+	 * Only image formats are allowed to be previewed in the modal. PDFs may be previewed in the browser elsewhere, but not in the modal.
 	 *
 	 * @param array $file File data.
 	 * @return bool True if the file is previewable, false otherwise.

--- a/projects/packages/forms/src/contact-form/class-feedback-field.php
+++ b/projects/packages/forms/src/contact-form/class-feedback-field.php
@@ -501,16 +501,12 @@ class Feedback_Field {
 
 	/**
 	 * Checks if the file is previewable based on its type or extension.
+	 * We only allow image formats to be previewed in the modal.
 	 *
 	 * @param array $file File data.
 	 * @return bool True if the file is previewable, false otherwise.
 	 */
 	private function is_previewable_file( $file ) {
-
-		if ( function_exists( '\Automattic\Jetpack\UnauthFileUpload\is_file_previable' ) ) {
-			return \Automattic\Jetpack\UnauthFileUpload\is_file_previable( $file['name'] );
-		}
-
 		$file_type = strtolower( pathinfo( $file['name'], PATHINFO_EXTENSION ) );
 		// Check if the file is previewable based on its type or extension.
 		// Note: This is a simplified check and does not match if the file is allowed to be uploaded by the server.

--- a/projects/plugins/jetpack/changelog/fix-preview-only-image-formats
+++ b/projects/plugins/jetpack/changelog/fix-preview-only-image-formats
@@ -1,5 +1,5 @@
 Significance: patch
 Type: other
-Comment: Not really important
+Comment: Restricts inline file preview to only image formats and PDFs, forces download for other file types for security.
 
 

--- a/projects/plugins/jetpack/changelog/fix-preview-only-image-formats
+++ b/projects/plugins/jetpack/changelog/fix-preview-only-image-formats
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Not really important
+
+

--- a/projects/plugins/jetpack/tests/php/Unauth_File_Upload_Test.php
+++ b/projects/plugins/jetpack/tests/php/Unauth_File_Upload_Test.php
@@ -27,8 +27,8 @@ class Unauth_File_Upload_Test extends WP_UnitTestCase {
 	 * @dataProvider provider_is_file_type_previable
 	 */
 	#[DataProvider( 'provider_is_file_type_previable' )]
-	public function test_is_file_type_previable( $mime_type, $expected ) {
-		$this->assertEquals( $expected, \Automattic\Jetpack\UnauthFileUpload\is_file_type_previable( $mime_type ) );
+	public function is_file_type_previewable( $mime_type, $expected ) {
+		$this->assertEquals( $expected, \Automattic\Jetpack\UnauthFileUpload\is_file_type_previewable( $mime_type ) );
 	}
 
 	/**

--- a/projects/plugins/jetpack/tests/php/Unauth_File_Upload_Test.php
+++ b/projects/plugins/jetpack/tests/php/Unauth_File_Upload_Test.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * Test the Unauthenticated File Upload functions.
+ *
+ * @package Automattic/jetpack
+ */
+
+use PHPUnit\Framework\Attributes\DataProvider;
+
+/**
+ * Testing class for Unauthenticated File Upload functions.
+ */
+class Unauth_File_Upload_Test extends WP_UnitTestCase {
+	use \Automattic\Jetpack\PHPUnit\WP_UnitTestCase_Fix;
+
+	/**
+	 * Set up before tests.
+	 */
+	public function set_up() {
+		parent::set_up();
+		require_once JETPACK__PLUGIN_DIR . 'unauth-file-upload.php';
+	}
+
+	/**
+	 * Test the is_file_type_previable function with various MIME types.
+	 *
+	 * @dataProvider provider_is_file_type_previable
+	 */
+	#[DataProvider( 'provider_is_file_type_previable' )]
+	public function test_is_file_type_previable( $mime_type, $expected ) {
+		$this->assertEquals( $expected, \Automattic\Jetpack\UnauthFileUpload\is_file_type_previable( $mime_type ) );
+	}
+
+	/**
+	 * Data provider for test_is_file_type_previable.
+	 *
+	 * @return array Test cases with MIME types and expected results.
+	 */
+	public static function provider_is_file_type_previable() {
+		return array(
+			// Previable image types
+			array( 'image/jpeg', true ),
+			array( 'image/png', true ),
+			array( 'image/gif', true ),
+			array( 'image/webp', true ),
+
+			// Previable document type
+			array( 'application/pdf', true ),
+
+			// Non-previable image types
+			array( 'image/svg+xml', false ),
+			array( 'image/bmp', false ),
+			array( 'image/tiff', false ),
+
+			// Non-previable document types
+			array( 'application/msword', false ),
+			array( 'application/vnd.openxmlformats-officedocument.wordprocessingml.document', false ),
+			array( 'application/vnd.ms-excel', false ),
+			array( 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet', false ),
+
+			// Other common non-previable types
+			array( 'application/zip', false ),
+			array( 'application/x-zip-compressed', false ),
+			array( 'text/plain', false ),
+			array( 'text/html', false ),
+			array( 'application/json', false ),
+			array( 'video/mp4', false ),
+			array( 'audio/mpeg', false ),
+
+			// Edge cases
+			array( '', false ),
+			array( 'application/octet-stream', false ),
+			array( 'invalid/type', false ),
+		);
+	}
+}

--- a/projects/plugins/jetpack/unauth-file-upload.php
+++ b/projects/plugins/jetpack/unauth-file-upload.php
@@ -78,7 +78,7 @@ function handle_file_download() {
 	$file['type']    = $file['type'] ?? 'application/octet-stream';
 	$file['name']    = $file['name'] ?? '';
 
-	$is_preview = isset( $_GET['preview'] ) && 'true' === $_GET['preview'] && is_file_previable( $file['name'] );
+	$is_preview = isset( $_GET['preview'] ) && 'true' === $_GET['preview'] && is_file_type_previable( $file['type'] );
 
 	// Clean output buffer
 	if ( ob_get_length() ) {
@@ -167,15 +167,21 @@ function get_file_content( $file_content, $file_id ) {
 }
 
 /**
- * Check which file extensions can be previewed in the browser without downloading them.
+ * Check which file type is previewable in the browser without downloading them.
  *
- * @param string $file_name The name of the file.
+ * Allow images with extensions jpg, jpeg, png, gif, webp and pdf files.
+ *
+ * @param string $file_type The MIME type of the file.
  * @return bool True if the file is previable, false otherwise.
  */
-function is_file_previable( $file_name ) {
-	// List of file extensions that we can preview in the browser without downloading them.
-	$previable_extensions = array( 'jpg', 'jpeg', 'png', 'gif', 'webp', 'pdf' );
-	$extension            = pathinfo( $file_name, PATHINFO_EXTENSION );
+function is_file_type_previable( $file_type ) {
+	$previable_types = array(
+		'image/jpeg',
+		'image/png',
+		'image/gif',
+		'image/webp',
+		'application/pdf',
+	);
 
-	return in_array( strtolower( $extension ), $previable_extensions, true );
+	return in_array( $file_type, $previable_types, true );
 }

--- a/projects/plugins/jetpack/unauth-file-upload.php
+++ b/projects/plugins/jetpack/unauth-file-upload.php
@@ -78,7 +78,7 @@ function handle_file_download() {
 	$file['type']    = $file['type'] ?? 'application/octet-stream';
 	$file['name']    = $file['name'] ?? '';
 
-	$is_preview = isset( $_GET['preview'] ) && 'true' === $_GET['preview'];
+	$is_preview = isset( $_GET['preview'] ) && 'true' === $_GET['preview'] && is_file_previable( $file['name'] );
 
 	// Clean output buffer
 	if ( ob_get_length() ) {
@@ -164,4 +164,17 @@ function get_file_content( $file_content, $file_id ) {
 		'type'    => $type,
 		'name'    => $filename,
 	);
+}
+
+/**
+ * Determine if a file is previable based on its extension.
+ *
+ * @param string $file_name The name of the file.
+ * @return bool True if the file is previable, false otherwise.
+ */
+function is_file_previable( $file_name ) {
+	$previable_extensions = array( 'jpg', 'jpeg', 'png', 'gif', 'bmp', 'tiff', 'webp', 'pdf' );
+	$extension            = pathinfo( $file_name, PATHINFO_EXTENSION );
+
+	return in_array( strtolower( $extension ), $previable_extensions, true );
 }

--- a/projects/plugins/jetpack/unauth-file-upload.php
+++ b/projects/plugins/jetpack/unauth-file-upload.php
@@ -167,13 +167,14 @@ function get_file_content( $file_content, $file_id ) {
 }
 
 /**
- * Determine if a file is previable based on its extension.
+ * Check which file extensions can be previewed in the browser without downloading them.
  *
  * @param string $file_name The name of the file.
  * @return bool True if the file is previable, false otherwise.
  */
 function is_file_previable( $file_name ) {
-	$previable_extensions = array( 'jpg', 'jpeg', 'png', 'gif', 'bmp', 'tiff', 'webp', 'pdf' );
+	// List of file extensions that we can preview in the browser without downloading them.
+	$previable_extensions = array( 'jpg', 'jpeg', 'png', 'gif', 'webp', 'pdf' );
 	$extension            = pathinfo( $file_name, PATHINFO_EXTENSION );
 
 	return in_array( strtolower( $extension ), $previable_extensions, true );

--- a/projects/plugins/jetpack/unauth-file-upload.php
+++ b/projects/plugins/jetpack/unauth-file-upload.php
@@ -78,7 +78,7 @@ function handle_file_download() {
 	$file['type']    = $file['type'] ?? 'application/octet-stream';
 	$file['name']    = $file['name'] ?? '';
 
-	$is_preview = isset( $_GET['preview'] ) && 'true' === $_GET['preview'] && is_file_type_previable( $file['type'] );
+	$is_preview = isset( $_GET['preview'] ) && 'true' === $_GET['preview'] && is_file_type_previewable( $file['type'] );
 
 	// Clean output buffer
 	if ( ob_get_length() ) {
@@ -174,7 +174,7 @@ function get_file_content( $file_content, $file_id ) {
  * @param string $file_type The MIME type of the file.
  * @return bool True if the file is previable, false otherwise.
  */
-function is_file_type_previable( $file_type ) {
+function is_file_type_previewable( $file_type ) {
 	$previable_types = array(
 		'image/jpeg',
 		'image/png',


### PR DESCRIPTION
This PR makes so that we restrict the file types that can possible be open in the new tab. 

All other file formats will be forced to be downloaded. 

## Proposed changes:
* Check if the file that is about to be return is in the allowed list of files names that can be previewed if not. Download the file instead. 

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1763987216674839-slack-CRA4UEQQ3

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Upload a PDF document in a file field. 
Upload an image. 

Upload a word doc. 

Notice that you can preview the image, pdf but not the Word Doc. This file is downloaded to your computer instead. 
