### PR TITLE
Forms: removes a php warning on forms where the $page global is set to a non integer

### DIFF
--- a/projects/packages/forms/changelog/fix-php-warning-on-forms
+++ b/projects/packages/forms/changelog/fix-php-warning-on-forms
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
- Forms: fix PHP warning when global gets over written
+ Forms: fix PHP warning when global gets overwritten

--- a/projects/packages/forms/changelog/fix-php-warning-on-forms
+++ b/projects/packages/forms/changelog/fix-php-warning-on-forms
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+ Forms: fix PHP warning when global gets over written

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -169,7 +169,8 @@ class Contact_Form extends Contact_Form_Shortcode {
 		}
 
 		if ( $set_id ) {
-			$attributes['id'] = self::compute_id( $attributes, $this->current_post, $page );
+			$page_number      = is_int( $page ) ? $page : 1;
+			$attributes['id'] = self::compute_id( $attributes, $this->current_post, $page_number );
 		}
 		$this->hash = sha1( wp_json_encode( $attributes ) );
 

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -169,7 +169,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 		}
 
 		if ( $set_id ) {
-			$page_number      = is_int( $page ) ? $page : 1;
+			$page_number      = is_numeric( $page ) ? intval( $page ) : 1;
 			$attributes['id'] = self::compute_id( $attributes, $this->current_post, $page_number );
 		}
 		$this->hash = sha1( wp_json_encode( $attributes ) );

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
@@ -2447,6 +2447,22 @@ class Contact_Form_Test extends BaseTestCase {
 	}
 
 	/**
+	 * Tests that the constructor handles non-integer $page global without warnings.
+	 */
+	public function test_constructor_handles_non_integer_page_global() {
+		global $page;
+		$original_page = $page;
+		$page          = 'not-an-integer'; // Simulating theme overwriting $page
+
+		$attributes = array( 'to' => 'test@example.com' );
+		$form       = new Contact_Form( $attributes );
+
+		// Verify no warnings and form is created successfully
+		$this->assertInstanceOf( Contact_Form::class, $form );
+		$page = $original_page; // Restore original value
+	}
+
+	/**
 	 * Tests get_default_to method with null post author ID.
 	 */
 	public function test_get_default_to_with_null_post_author() {


### PR DESCRIPTION
Some themes overwrite the $page global. 

Which should be in integer. We convert it to an interger before trying to use it. 

## Proposed changes:
* Make sure that we only pass a integert into the compute_id method.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
See p1764374805068119-slack-C06QF6JJDTM

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Do the tests pass? 
Load a page with the form. 
Load submit the form. Notice that it produces PHP Warnings.