### PR TITLE
Cookie Consent Widget: ensure form headings are properly displayed

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-echo-to-esc-html-x
+++ b/projects/plugins/jetpack/changelog/fix-echo-to-esc-html-x
@@ -1,3 +1,4 @@
 Significance: patch
-Type: fixed
-Comment: Fix two esc_html_x calls by adding echo in form.php
+Type: bugfix
+
+Cookies & Consents Banner Widget: ensure form headings are properly displayed.

--- a/projects/plugins/jetpack/changelog/fix-echo-to-esc-html-x
+++ b/projects/plugins/jetpack/changelog/fix-echo-to-esc-html-x
@@ -1,0 +1,3 @@
+Significance: patch
+Type: fixed
+Comment: Fix two esc_html_x calls by adding echo in form.php

--- a/projects/plugins/jetpack/modules/widgets/eu-cookie-law/form.php
+++ b/projects/plugins/jetpack/modules/widgets/eu-cookie-law/form.php
@@ -152,7 +152,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 <p>
 	<strong>
-		<?php esc_html_x( 'Capture consent & hide the banner', 'action', 'jetpack' ); ?>
+		<?php echo esc_html_x( 'Capture consent & hide the banner', 'action', 'jetpack' ); ?>
 	</strong>
 	<ul>
 		<li>
@@ -214,7 +214,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 <p>
 	<strong>
-		<?php esc_html_x( 'Consent expires after', 'action', 'jetpack' ); ?>
+		<?php echo esc_html_x( 'Consent expires after', 'action', 'jetpack' ); ?>
 	</strong>
 	<ul>
 		<li>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
This PR updates two string outputs in form.php by replacing:

- `esc_html_x()` → `echo esc_html_x()`

Previously, the function calls were missing echo, which meant the localized strings were being retrieved but not actually rendered in the HTML output. By adding echo, the strings are now correctly displayed to users in the form.

This ensures that:

- Translated text is properly visible in the UI.
- The form behaves as expected with internationalization/localization.
- No other logic or functionality is affected beyond outputting the strings.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* Start from a site connected to WordPress.com
* Go to Jetpack > Settings, and enable the Extra Sidebar Widgets feature
* Activate a classic theme like Twenty Ten
* Install and activate the Classic widgets plugin
* Go to Appearance > Widgets
* Drag a Cookies & Consents Banner widget to one of the widget areas
* Check that each area of the widget settings has a heading.


