### PR TITLE
Update phpcs deps so phpcompatibility-dev test can run

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
 		"php-stubs/wp-cli-stubs": "^2.10",
 		"phpcompatibility/phpcompatibility-wp": "^2.1",
 		"sirbrillig/phpcs-changed": "^2.11.5",
-		"squizlabs/php_codesniffer": "^3.6.2"
+		"squizlabs/php_codesniffer": "^3.6.2 || ^4.0.0"
 	},
 	"scripts": {
 		"php:lint": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b04ff76322c12d38af630ee4b7633fe0",
+    "content-hash": "3b01a7896c43a503756c97f1b1809faf",
     "packages": [],
     "packages-dev": [
         {
@@ -198,12 +198,12 @@
             "dist": {
                 "type": "path",
                 "url": "projects/packages/phpcs-filter",
-                "reference": "ec72456a83f9569f5d2867e4155accda4be95bb5"
+                "reference": "2ba3e32d86c44977977e422380bf0501c30c5427"
             },
             "require": {
                 "automattic/ignorefile": "@dev",
                 "php": ">=7.2",
-                "squizlabs/php_codesniffer": "^3.6.1"
+                "squizlabs/php_codesniffer": "^3.6.1 || ^4.0.0"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev",

--- a/projects/packages/phpcs-filter/changelog/fix-phpcompatibility-dev-run
+++ b/projects/packages/phpcs-filter/changelog/fix-phpcompatibility-dev-run
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Indicate compatibility with (our patched version of) phpcs 4.x.

--- a/projects/packages/phpcs-filter/composer.json
+++ b/projects/packages/phpcs-filter/composer.json
@@ -15,7 +15,7 @@
 	"require": {
 		"php": ">=7.2",
 		"automattic/ignorefile": "@dev",
-		"squizlabs/php_codesniffer": "^3.6.1"
+		"squizlabs/php_codesniffer": "^3.6.1 || ^4.0.0"
 	},
 	"require-dev": {
 		"automattic/jetpack-changelogger": "@dev",

--- a/projects/packages/phpcs-filter/tests/php/JetpackPhpcsFilterTest.php
+++ b/projects/packages/phpcs-filter/tests/php/JetpackPhpcsFilterTest.php
@@ -35,7 +35,6 @@ class JetpackPhpcsFilterTest extends TestCase {
 	public function setUp(): void {
 		parent::setUp();
 		$this->oldcwd = getcwd();
-		Config::setConfigData( 'jetpack-filter-basedir', null, true );
 	}
 
 	/**
@@ -67,6 +66,7 @@ class JetpackPhpcsFilterTest extends TestCase {
 		chdir( __DIR__ . '/../../tests/fixtures/phpcsignore' );
 
 		$config = new Config();
+		$config->setConfigData( 'jetpack-filter-basedir', null, true );
 
 		// When run from the base of the repo, it reads tests/fixtures/.phpcsignore and so ignores everything.
 		chdir( __DIR__ . '/../../' );
@@ -88,7 +88,7 @@ class JetpackPhpcsFilterTest extends TestCase {
 
 		// Set the base dir config and it uses that.
 		chdir( __DIR__ . '/../../' );
-		Config::setConfigData( 'jetpack-filter-basedir', 'tests/fixtures/phpcsignore', true );
+		$config->setConfigData( 'jetpack-filter-basedir', 'tests/fixtures/phpcsignore', true );
 		$di     = new RecursiveDirectoryIterator( 'tests/fixtures/phpcsignore', RecursiveDirectoryIterator::SKIP_DOTS | RecursiveDirectoryIterator::FOLLOW_SYMLINKS );
 		$filter = new RecursiveIteratorIterator( new JetpackPhpcsFilter( $di, 'tests/fixtures/phpcsignore', $config, new Ruleset( $config ) ) );
 		$files  = array();
@@ -105,6 +105,7 @@ class JetpackPhpcsFilterTest extends TestCase {
 		chdir( __DIR__ . '/../../tests/fixtures/phpcsignore' );
 
 		$config = new Config( array( '--runtime-set', 'jetpack-filter-use-gitignore', '0' ) );
+		$config->setConfigData( 'jetpack-filter-basedir', null, true );
 
 		chdir( __DIR__ . '/../../tests/fixtures/phpcsignore' );
 		$di     = new RecursiveDirectoryIterator( '.', RecursiveDirectoryIterator::SKIP_DOTS | RecursiveDirectoryIterator::FOLLOW_SYMLINKS );
@@ -140,6 +141,7 @@ class JetpackPhpcsFilterTest extends TestCase {
 		chdir( __DIR__ . '/../../tests/fixtures/phpcsignore' );
 
 		$config = new Config( array( '--runtime-set', 'jetpack-filter-no-ignore', '1' ) );
+		$config->setConfigData( 'jetpack-filter-basedir', null, true );
 
 		chdir( __DIR__ . '/../../tests/fixtures/phpcsignore' );
 		$di     = new RecursiveDirectoryIterator( '.', RecursiveDirectoryIterator::SKIP_DOTS | RecursiveDirectoryIterator::FOLLOW_SYMLINKS );
@@ -196,7 +198,8 @@ class JetpackPhpcsFilterTest extends TestCase {
 		$expect = json_decode( file_get_contents( 'expect.json' ), true );
 		$this->assertIsArray( $expect, 'expect.json contains a JSON object' );
 
-		$config         = new Config();
+		$config = new Config();
+		$config->setConfigData( 'jetpack-filter-basedir', null, true );
 		$config->filter = 'Automattic\\JetpackPhpcsFilter';
 		$config->files  = array( $path );
 		$ruleset        = new Ruleset( $config );

--- a/projects/packages/phpcs-filter/tests/php/StdinBootstrapTest.php
+++ b/projects/packages/phpcs-filter/tests/php/StdinBootstrapTest.php
@@ -21,6 +21,7 @@ class StdinBootstrapTest extends TestCase {
 	private function runPhpcs( $args, $content ) {
 		$args = array_merge(
 			array(
+				'-q',
 				'--report=json',
 				'--bootstrap=' . __DIR__ . '/../../stdin-bootstrap.php',
 				'--filter=Automattic\\JetpackPhpcsFilter',
@@ -107,7 +108,7 @@ class StdinBootstrapTest extends TestCase {
 		$iter = new RecursiveIteratorIterator( new RecursiveDirectoryIterator( $dir, RecursiveDirectoryIterator::SKIP_DOTS | RecursiveDirectoryIterator::CURRENT_AS_PATHNAME ) );
 		foreach ( $iter as $path ) {
 			$file = substr( $path, $l );
-			if ( $file === 'excludedfile.php' || $file === 'exclude-pattern/excluded1.php' || substr( $file, -4 ) !== '.php' ) {
+			if ( $file === 'excludedfile.php' || $file === 'exclude-pattern/excludedfile.php' || $file === 'exclude-pattern/excluded1.php' || $file === 'exclude-pattern/excluded2.php' || substr( $file, -4 ) !== '.php' ) {
 				continue;
 			}
 			$contents = file_get_contents( $path );

--- a/projects/plugins/super-cache/changelog/fix-phpcompatibility-dev-run
+++ b/projects/plugins/super-cache/changelog/fix-phpcompatibility-dev-run
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Suppress phpcompatibility sniffs that apply to code that is properly guarded with a version check.
+
+

--- a/projects/plugins/super-cache/wp-cache.php
+++ b/projects/plugins/super-cache/wp-cache.php
@@ -471,10 +471,12 @@ function wp_cache_manager_error_checks() {
 		return false;
 	}
 
+	// phpcs:ignore PHPCompatibility.IniDirectives.RemovedIniDirectives.safe_modeDeprecatedRemoved -- Version is checked before access.
 	if ( PHP_VERSION_ID < 50300 && ( ini_get( 'safe_mode' ) === '1' || strtolower( ini_get( 'safe_mode' ) ) === 'on' ) ) { // @codingStandardsIgnoreLine
 		echo '<div class="notice notice-error"><h4>' . esc_html__( 'Warning! PHP Safe Mode Enabled!', 'wp-super-cache' ) . '</h4>';
 		echo '<p>' . esc_html__( 'You may experience problems running this plugin because SAFE MODE is enabled.', 'wp-super-cache' ) . '<br />';
 
+		// phpcs:ignore PHPCompatibility.IniDirectives.RemovedIniDirectives.safe_mode_gidDeprecatedRemoved -- Version is checked before access.
 		if ( ! ini_get( 'safe_mode_gid' ) ) { // @codingStandardsIgnoreLine
 			esc_html_e( 'Your server is set up to check the owner of PHP scripts before allowing them to read and write files.', 'wp-super-cache' );
 			echo '<br />';

--- a/projects/plugins/vaultpress/changelog/fix-phpcompatibility-dev-run
+++ b/projects/plugins/vaultpress/changelog/fix-phpcompatibility-dev-run
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Switch cases end with `:`, not `;`.
+
+

--- a/projects/plugins/vaultpress/vaultpress.php
+++ b/projects/plugins/vaultpress/vaultpress.php
@@ -2605,7 +2605,7 @@ JS;
 			return;
 
 		switch( $type ) {
-			case 'editedtables';
+			case 'editedtables':
 				$vaultpress_pings[$type] = $data;
 				return;
 			case 'uploads':


### PR DESCRIPTION
Closes MONOREP-272

 <!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
PHPCompatibility upstream now depends on 4.0.1. We can't bump everything to that yet, but we can do an `||` dep in the places needed for that run.

Then fix some new sniffs.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1764582817914169-slack-C05Q5HSS013

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* CI happy?