### PR TITLE
changelogger: Actually update tests to use `addCommand()`

### DIFF
--- a/projects/packages/changelogger/changelog/fix-changelogger-symfony-console-add
+++ b/projects/packages/changelogger/changelog/fix-changelogger-symfony-console-add
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Actually update tests to use addCommand() instead of deprecated add() method
+
+

--- a/projects/packages/changelogger/tests/php/tests/src/ApplicationTest.php
+++ b/projects/packages/changelogger/tests/php/tests/src/ApplicationTest.php
@@ -72,9 +72,13 @@ class ApplicationTest extends TestCase {
 
 		$command = new Command( 'testDoRun' );
 		$command->setCode( $callback );
-		// Trying to change add to addCommand makes the test fail with older PHP versions.
-		// @phan-suppress-next-line PhanDeprecatedFunction -- While deprecated, it's still good.
-		$app->add( $command );
+		// @todo Remove test and else branch when we drop support for symfony/console <7.4 (i.e. PHP <8.2)
+		if ( is_callable( array( $app, 'addCommand' ) ) ) {
+			$app->addCommand( $command );
+		} else {
+			// @phan-suppress-next-line PhanDeprecatedFunction -- Guarded.
+			$app->add( $command );
+		}
 
 		$tester = new ApplicationTester( $app );
 


### PR DESCRIPTION
Closes MONOREP-273

 <!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
PR #46126 left the call to `add()` with a Phan suppression. This changes it to use an `is_callable()` check to determine the correct method to call, and adds a `@todo` comment flagging it for future cleanup.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* CI happy?
