### PR TITLE
Forms: Fix checkbox styling with filter invert and correct border color

### DIFF
--- a/projects/packages/forms/changelog/fix-form-checkbox-style-solution
+++ b/projects/packages/forms/changelog/fix-form-checkbox-style-solution
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix checkbox styling in forms by using filter invert and correct border color variable

--- a/projects/packages/forms/src/contact-form/css/grunion.scss
+++ b/projects/packages/forms/src/contact-form/css/grunion.scss
@@ -1071,7 +1071,8 @@ on production builds, the attributes are being reordered, causing side-effects
 	transition: opacity 0.1s ease-in-out, scale 0.15s ease-in-out;
 
 	font-size: inherit;
-	border: solid var(--jetpack--contact-form--inverted-text-color, var(--jetpack--contact-form--input-background));
+	border-style: solid;
+	border-color: var(--jetpack--contact-form--text-color);
 	border-width: 0 2px 2px 0;
 	transform: translate(-50%, -60%) rotate(40deg);
 	top: 0;

--- a/projects/packages/forms/src/contact-form/css/grunion.scss
+++ b/projects/packages/forms/src/contact-form/css/grunion.scss
@@ -1052,7 +1052,7 @@ on production builds, the attributes are being reordered, causing side-effects
 .contact-form .is-style-list input.consent:checked,
 .contact-form .is-style-list input.checkbox:checked,
 .contact-form .grunion-field-wrap:not(.is-style-plain) input.checkbox-multiple:checked {
-	background-color: currentColor;
+	filter: invert(1);
 
 }
 


### PR DESCRIPTION
This is an alternative to https://github.com/Automattic/jetpack/pull/46129 getting to the same "contrast" goal but with an inverted approach.

## Proposed changes:

* Replace `background-color: currentColor` with `filter: invert(1)` for checked checkbox state
* Split the border rule declaration for the checkbox checkmark
* Use `--jetpack--contact-form--text-color` variable for border color instead of `--jetpack--contact-form--inverted-text-color`

These changes fix checkbox styling issues where checkboxes appeared unclickable with white text on dark backgrounds, and ensure the checkbox color settings apply correctly to both the text and checkbox box.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

Related to checkbox styling improvements and color consistency issues reported by users.

## Does this pull request change what data or activity we track or use?

No, this is purely a CSS styling fix.

## Testing instructions:

* Create a new Jetpack form with checkbox fields (Multiple Choice Checkbox, Single Checkbox, or Consent field)
* Apply the List style to the form
* Set a custom text color using the "Option Color" setting
* Verify that checked checkboxes display correctly with proper contrast
* Test on both light and dark backgrounds
* Verify the checkmark appears with correct color using the text color variable
* Check that the checkbox border color matches the text color appropriately

### Before / After

**Before**: Checkboxes used `background-color: currentColor` which didn't provide proper styling and the border used an inverted text color variable.

**After**: Checkboxes use `filter: invert(1)` for the checked state and the border uses the correct text color variable, providing consistent and accessible checkbox styling.