### PR TITLE
Forms: Fix button width on mobile devices

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-buttons-mobile-behavior
+++ b/projects/packages/forms/changelog/fix-forms-buttons-mobile-behavior
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Make form buttons take full width on mobile devices

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -116,6 +116,14 @@
 					flex-basis: 100%;
 					max-width: none;
 				}
+
+				&.wp-block-jetpack-button {
+					flex-basis: 100%;
+
+					.wp-block-button__link {
+						width: 100%;
+					}
+				}
 			}
 
 			&[data-type="jetpack/field-checkbox"],

--- a/projects/packages/forms/src/contact-form/css/grunion.scss
+++ b/projects/packages/forms/src/contact-form/css/grunion.scss
@@ -460,6 +460,14 @@ that needs to mimic the input element styles */
 		flex-basis: 100%;
 		max-width: none;
 	}
+
+	.wp-block-jetpack-contact-form .wp-block-jetpack-button {
+		flex-basis: 100%;
+
+		.wp-block-button__link {
+			width: 100%;
+		}
+	}
 }
 
 .grunion-field-consent-wrap {


### PR DESCRIPTION
Part of https://github.com/Automattic/big-sky-plugin/issues/4708

## Proposed changes:
* Make form buttons take full width on mobile devices to match the behavior of other form fields

**Before:** Buttons did not take full width on mobile

https://github.com/user-attachments/assets/33a1bc7c-ad66-475c-8bbf-244b6fdcfece



**After:** Buttons take full width on mobile, consistent with other form fields


https://github.com/user-attachments/assets/aa94f57b-d1da-459d-a945-5c6c9e13b62b



### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
https://github.com/Automattic/big-sky-plugin/issues/4708

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

* Install the Jetpack Forms block on a WordPress site
* Create a new post or page and add a simple form field to the form, here's the code for the form on the video:

```
<!-- wp:group {"metadata":{"name":"Newsletter"},"align":"full","className":"alignfull is-style-default","style":{"spacing":{"margin":{"top":"0","bottom":"0"},"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50"}}},"layout":{"type":"constrained","justifyContent":"center"}} -->
<div class="wp-block-group alignfull is-style-default" style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50)"><!-- wp:group {"align":"wide","style":{"spacing":{"blockGap":"var:preset|spacing|20"}},"layout":{"type":"constrained","justifyContent":"left"}} -->
<div class="wp-block-group alignwide"><!-- wp:group {"layout":{"type":"flex","orientation":"vertical"}} -->
<div class="wp-block-group"><!-- wp:heading -->
<h2 class="wp-block-heading">Subscribe</h2>
<!-- /wp:heading -->

<!-- wp:paragraph -->
<p>Be the first to know about sales, new arrivals, and offers.</p>
<!-- /wp:paragraph --></div>
<!-- /wp:group -->

<!-- wp:jetpack/contact-form {"customThankyouHeading":"Thank you for subscribing!","customThankyouMessage":"Please check your email to confirming your subscription.","confirmationType":"text","jetpackCRM":true,"salesforceData":{"organizationId":"","sendToSalesforce":false},"mailpoet":{"listId":"1","listName":"Mailing list","enabledForForm":true},"saveResponses":false,"emailNotifications":false,"disableGoBack":true,"className":"is-style-outlined"} -->
<div class="wp-block-jetpack-contact-form is-style-outlined"><!-- wp:jetpack/field-email {"required":true,"requiredIndicator":false,"width":"auto"} -->
<div><!-- wp:jetpack/label {"label":"Enter your email…","requiredIndicator":false,"lock":{"move":false,"remove":false}} /-->

<!-- wp:jetpack/input {"lock":{"move":false,"remove":false}} /--></div>
<!-- /wp:jetpack/field-email -->

<!-- wp:jetpack/button {"element":"button","text":"Subscribe","width":"","lock":{"move":false,"remove":false}} /--></div>
<!-- /wp:jetpack/contact-form --></div>
<!-- /wp:group --></div>
<!-- /wp:group -->
```
* Preview the page on a mobile device or use browser DevTools mobile view (viewport width < 600px)
* Verify that the button takes the full width of the form container, matching the behavior of other form fields like text inputs
* Compare with text input fields to ensure consistent width behavior
* Confirm the same behavior on frontend

