### PR TITLE
Revert "Forms: add integration display filters"

### DIFF
--- a/projects/packages/forms/changelog/add-forms-integrations-display-filters
+++ b/projects/packages/forms/changelog/add-forms-integrations-display-filters
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Forms: add integrations display filters.

--- a/projects/packages/forms/src/blocks/contact-form/edit.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/edit.tsx
@@ -179,9 +179,8 @@ function JetpackContactFormEdit( {
 		notificationRecipients,
 		webhooks,
 	} = attributes;
-	const isIntegrationsEnabled = useConfigValue( 'isIntegrationsEnabled' );
+	const showFormIntegrations = useConfigValue( 'isIntegrationsEnabled' );
 	const showWebhooks = useConfigValue( 'isWebhooksEnabled' ) && hasFeatureFlag( 'form-webhooks' );
-	const showBlockIntegrations = useConfigValue( 'showBlockIntegrations' );
 	const instanceId = useInstanceId( JetpackContactFormEdit );
 
 	// Backward compatibility for the deprecated customThankyou attribute.
@@ -922,7 +921,7 @@ function JetpackContactFormEdit( {
 							setAttributes={ setAttributes }
 						/>
 					</PanelBody>
-					{ isIntegrationsEnabled && showBlockIntegrations && (
+					{ showFormIntegrations && (
 						<Suspense fallback={ <div /> }>
 							<IntegrationControls attributes={ attributes } setAttributes={ setAttributes } />
 						</Suspense>

--- a/projects/packages/forms/src/class-jetpack-forms.php
+++ b/projects/packages/forms/src/class-jetpack-forms.php
@@ -138,40 +138,4 @@ class Jetpack_Forms {
 		 */
 		return apply_filters( 'jetpack_forms_webhooks_enabled', false );
 	}
-
-	/**
-	 * Returns true if the Integrations UI should be shown in the Forms dashboard.
-	 *
-	 * @since $$next-version$$
-	 *
-	 * @return boolean
-	 */
-	public static function show_dashboard_integrations() {
-		/**
-		 * Whether to show Integrations UI in the Forms dashboard.
-		 *
-		 * @since $$next-version$$
-		 *
-		 * @param bool true Whether to show the Integrations UI in the dashboard. Default true.
-		 */
-		return apply_filters( 'jetpack_forms_show_dashboard_integrations', true );
-	}
-
-	/**
-	 * Returns true if the Integrations UI should be shown in the Form block editor.
-	 *
-	 * @since $$next-version$$
-	 *
-	 * @return boolean
-	 */
-	public static function show_block_integrations() {
-		/**
-		 * Whether to show Integrations UI in the Form block editor.
-		 *
-		 * @since $$next-version$$
-		 *
-		 * @param bool true Whether to show the Integrations UI in the editor. Default true.
-		 */
-		return apply_filters( 'jetpack_forms_show_block_integrations', true );
-	}
 }

--- a/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
@@ -1484,26 +1484,24 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 	public function get_forms_config( WP_REST_Request $request ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 		$config = array(
 			// From jpFormsBlocks in class-contact-form-block.php.
-			'formsResponsesUrl'         => Forms_Dashboard::get_forms_admin_url(),
-			'isMailPoetEnabled'         => Jetpack_Forms::is_mailpoet_enabled(),
-			'isHostingerReachEnabled'   => Jetpack_Forms::is_hostinger_reach_enabled(),
+			'formsResponsesUrl'       => Forms_Dashboard::get_forms_admin_url(),
+			'isMailPoetEnabled'       => Jetpack_Forms::is_mailpoet_enabled(),
+			'isHostingerReachEnabled' => Jetpack_Forms::is_hostinger_reach_enabled(),
 			// From config in class-dashboard.php.
-			'blogId'                    => get_current_blog_id(),
-			'gdriveConnectSupportURL'   => esc_url( Redirect::get_url( 'jetpack-support-contact-form-export' ) ),
-			'pluginAssetsURL'           => Jetpack_Forms::assets_url(),
-			'siteURL'                   => ( new Status() )->get_site_suffix(),
-			'hasFeedback'               => ( new Forms_Dashboard() )->has_feedback(),
-			'isIntegrationsEnabled'     => Jetpack_Forms::is_integrations_enabled(),
-			'isWebhooksEnabled'         => Jetpack_Forms::is_webhooks_enabled(),
-			'showDashboardIntegrations' => Jetpack_Forms::show_dashboard_integrations(),
-			'showBlockIntegrations'     => Jetpack_Forms::show_block_integrations(),
-			'dashboardURL'              => Forms_Dashboard::get_forms_admin_url(),
+			'blogId'                  => get_current_blog_id(),
+			'gdriveConnectSupportURL' => esc_url( Redirect::get_url( 'jetpack-support-contact-form-export' ) ),
+			'pluginAssetsURL'         => Jetpack_Forms::assets_url(),
+			'siteURL'                 => ( new Status() )->get_site_suffix(),
+			'hasFeedback'             => ( new Forms_Dashboard() )->has_feedback(),
+			'isIntegrationsEnabled'   => Jetpack_Forms::is_integrations_enabled(),
+			'isWebhooksEnabled'       => Jetpack_Forms::is_webhooks_enabled(),
+			'dashboardURL'            => Forms_Dashboard::get_forms_admin_url(),
 			// New data.
-			'canInstallPlugins'         => current_user_can( 'install_plugins' ),
-			'canActivatePlugins'        => current_user_can( 'activate_plugins' ),
-			'exportNonce'               => wp_create_nonce( 'feedback_export' ),
-			'newFormNonce'              => wp_create_nonce( 'create_new_form' ),
-			'emptyTrashDays'            => defined( 'EMPTY_TRASH_DAYS' ) ? EMPTY_TRASH_DAYS : 0,
+			'canInstallPlugins'       => current_user_can( 'install_plugins' ),
+			'canActivatePlugins'      => current_user_can( 'activate_plugins' ),
+			'exportNonce'             => wp_create_nonce( 'feedback_export' ),
+			'newFormNonce'            => wp_create_nonce( 'create_new_form' ),
+			'emptyTrashDays'          => defined( 'EMPTY_TRASH_DAYS' ) ? EMPTY_TRASH_DAYS : 0,
 		);
 
 		return rest_ensure_response( $config );

--- a/projects/packages/forms/src/dashboard/components/layout/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/layout/index.tsx
@@ -17,10 +17,8 @@ const Layout = () => {
 	const location = useLocation();
 	const [ isSm ] = useBreakpointMatch( 'sm' );
 
-	const isIntegrationsEnabled = useConfigValue( 'isIntegrationsEnabled' );
-	const showDashboardIntegrations = useConfigValue( 'showDashboardIntegrations' );
-	const isLoadingConfig =
-		isIntegrationsEnabled === undefined || showDashboardIntegrations === undefined;
+	const enableIntegrationsTab = useConfigValue( 'isIntegrationsEnabled' );
+	const isLoadingConfig = enableIntegrationsTab === undefined;
 
 	const isIntegrationsOpen = location.pathname === '/integrations';
 
@@ -34,9 +32,7 @@ const Layout = () => {
 		<div className="jp-forms-layout">
 			<div className="jp-forms-layout__content">
 				{ ! isLoadingConfig && <Outlet /> }
-				{ isIntegrationsOpen && isIntegrationsEnabled && showDashboardIntegrations && (
-					<Integrations />
-				) }
+				{ isIntegrationsOpen && <Integrations /> }
 			</div>
 		</div>
 	);

--- a/projects/packages/forms/src/dashboard/inbox/stage/index.js
+++ b/projects/packages/forms/src/dashboard/inbox/stage/index.js
@@ -125,8 +125,7 @@ export default function InboxView() {
 		return setupSidebarWidthObserver();
 	}, [] );
 
-	const isIntegrationsEnabled = useConfigValue( 'isIntegrationsEnabled' );
-	const showDashboardIntegrations = useConfigValue( 'showDashboardIntegrations' );
+	const enableIntegrationsTab = useConfigValue( 'isIntegrationsEnabled' );
 
 	const {
 		setCurrentQuery,
@@ -477,13 +476,13 @@ export default function InboxView() {
 		} else {
 			headerActionsArray.unshift( <CreateFormButton key="create" /> );
 			// Only show Create Form and Integrations buttons on inbox (when not in trash or spam)
-			if ( isIntegrationsEnabled && showDashboardIntegrations ) {
+			if ( enableIntegrationsTab ) {
 				headerActionsArray.unshift( <IntegrationsButton key="integrations" /> );
 			}
 		}
 
 		return headerActionsArray;
-	}, [ statusFilter, isIntegrationsEnabled, showDashboardIntegrations ] );
+	}, [ statusFilter, enableIntegrationsTab ] );
 
 	const pageContent = (
 		<Page

--- a/projects/packages/forms/src/types/index.ts
+++ b/projects/packages/forms/src/types/index.ts
@@ -236,10 +236,6 @@ export interface FormsConfigData {
 	isIntegrationsEnabled?: boolean;
 	/** Whether webhooks are enabled (feature-flagged). */
 	isWebhooksEnabled?: boolean;
-	/** Whether to show integrations in the Forms dashboard UI. */
-	showDashboardIntegrations?: boolean;
-	/** Whether to show integrations in the Form block editor UI. */
-	showBlockIntegrations?: boolean;
 	/** Whether the current user can install plugins (install_plugins). */
 	canInstallPlugins?: boolean;
 	/** Whether the current user can activate plugins (activate_plugins). */

--- a/projects/plugins/jetpack/changelog/add-forms-integrations-display-filters
+++ b/projects/plugins/jetpack/changelog/add-forms-integrations-display-filters
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-Forms: add integrations display filters.


### PR DESCRIPTION
Reverts Automattic/jetpack#46112

I found during deployment that adding the filters in the above PR somehow breaks the forms screen on WordPress.com simple sites. I'm reverting, and will re-prep the PR above, test on Simple, and resolve any remaining issues before deploying again. 

## Does this pull request change what data or activity we track or use?

No. 

## Testing

This is a revert. I will quick test for safety, but otherwise not testing needed and I'll deploy when tests pass. 