### PR TITLE
Forms: Add a new filter that lets us control if we want to show the powered by Jetpack in the email

### DIFF
--- a/projects/packages/forms/changelog/add-forms-email-logo-filter
+++ b/projects/packages/forms/changelog/add-forms-email-logo-filter
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Forms: add a new fiter that lets us control when we want to so show the powered by wording in the email

--- a/projects/packages/forms/changelog/add-forms-email-logo-filter
+++ b/projects/packages/forms/changelog/add-forms-email-logo-filter
@@ -1,4 +1,4 @@
 Significance: minor
 Type: added
 
-Forms: add a new fiter that lets us control when we want to so show the powered by wording in the email
+Forms: add a new filter that lets us control when we want to so show the powered by wording in the email.

--- a/projects/packages/forms/changelog/add-forms-email-logo-filter
+++ b/projects/packages/forms/changelog/add-forms-email-logo-filter
@@ -1,4 +1,4 @@
 Significance: minor
 Type: added
 
-Forms: add a new filter that lets us control when we want to so show the powered by wording in the email.
+Forms: add a new filter that lets us control when we want to to show the powered by wording in the email.

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -2559,8 +2559,6 @@ class Contact_Form extends Contact_Form_Shortcode {
 		 */
 		$message = apply_filters( 'contact_form_message', implode( '', $message ), $message );
 
-		/**
-		 * Filters whether to include the email logo in the response email.
 		// This is called after `contact_form_message`, in order to preserve back-compat
 		$message = self::wrap_message_in_html_tags( $title, $message, $footer, $actions );
 

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -2561,17 +2561,8 @@ class Contact_Form extends Contact_Form_Shortcode {
 
 		/**
 		 * Filters whether to include the email logo in the response email.
-		 *
-		 * @module contact-form
-		 *
-		 * @since $$next-version$$
-		 *
-		 * @param bool $has_email_logo Whether to include the email logo. Default true.
-		 */
-		$has_email_logo = apply_filters( 'jetpack_forms_email_logo_in_response', true );
-
 		// This is called after `contact_form_message`, in order to preserve back-compat
-		$message = self::wrap_message_in_html_tags( $title, $message, $footer, $actions, $has_email_logo );
+		$message = self::wrap_message_in_html_tags( $title, $message, $footer, $actions );
 
 		update_post_meta( $post_id, '_feedback_email', $this->addslashes_deep( compact( 'to', 'message' ) ) );
 
@@ -2859,11 +2850,10 @@ class Contact_Form extends Contact_Form_Shortcode {
 	 * @param string $body - the message body.
 	 * @param string $footer - the footer containing meta information.
 	 * @param string $actions - HTML for actions displayed in the email.
-	 * @param bool   $has_email_logo Whether to include the email logo.
 	 *
 	 * @return string
 	 */
-	public static function wrap_message_in_html_tags( $title, $body, $footer, $actions = '', $has_email_logo = true ) {
+	public static function wrap_message_in_html_tags( $title, $body, $footer, $actions = '' ) {
 		// Don't do anything if the message was already wrapped in HTML tags
 		// That could have be done by a plugin via filters
 		if ( str_contains( $body, '<html' ) ) {
@@ -2896,13 +2886,18 @@ class Contact_Form extends Contact_Form_Shortcode {
 		 */
 		require apply_filters( 'jetpack_forms_response_email_template', __DIR__ . '/templates/email-response.php' );
 
-		$logo_html = '';
-		if ( $has_email_logo ) {
-
-			// Add the logo styles at the end.
-			$style = str_replace( '</style>', '.powered-by a {text-decoration: none;} @media only screen and (max-width: 640px) { .powered-by { padding: 0 16px 16px!important; }} </style>', $style );
-
-			$logo_html = str_replace(
+		/**
+		 * Filtert the HTML for the powered by section in the email.
+		 *
+		 * @module contact-form
+		 *
+		 * @since $$next-version$$
+		 *
+		 * @param string $powered_by_html The HTML for the powered by section in the email.
+		 */
+		$powered_by_html = apply_filters(
+			'jetpack_forms_email_powered_by_html',
+			str_replace(
 				"\t",
 				'',
 				'
@@ -2916,8 +2911,8 @@ class Contact_Form extends Contact_Form_Shortcode {
 					) . '
 					</td>
 				</tr>'
-			);
-		}
+			)
+		);
 
 		$html_message = sprintf(
 			// The tabs are just here so that the raw code is correctly formatted for developers
@@ -2935,7 +2930,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 			$style,
 			$tracking_pixel,
 			$actions,
-			$logo_html
+			$powered_by_html
 		);
 
 		return $html_message;

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -2559,8 +2559,19 @@ class Contact_Form extends Contact_Form_Shortcode {
 		 */
 		$message = apply_filters( 'contact_form_message', implode( '', $message ), $message );
 
+		/**
+		 * Filters whether to include the email logo in the response email.
+		 *
+		 * @module contact-form
+		 *
+		 * @since $$next-version$$
+		 *
+		 * @param bool $has_email_logo Whether to include the email logo. Default true.
+		 */
+		$has_email_logo = apply_filters( 'jetpack_forms_email_logo_in_response', true );
+
 		// This is called after `contact_form_message`, in order to preserve back-compat
-		$message = self::wrap_message_in_html_tags( $title, $message, $footer, $actions );
+		$message = self::wrap_message_in_html_tags( $title, $message, $footer, $actions, $has_email_logo );
 
 		update_post_meta( $post_id, '_feedback_email', $this->addslashes_deep( compact( 'to', 'message' ) ) );
 
@@ -2848,10 +2859,11 @@ class Contact_Form extends Contact_Form_Shortcode {
 	 * @param string $body - the message body.
 	 * @param string $footer - the footer containing meta information.
 	 * @param string $actions - HTML for actions displayed in the email.
+	 * @param bool   $has_email_logo Whether to include the email logo.
 	 *
 	 * @return string
 	 */
-	public static function wrap_message_in_html_tags( $title, $body, $footer, $actions = '' ) {
+	public static function wrap_message_in_html_tags( $title, $body, $footer, $actions = '', $has_email_logo = true ) {
 		// Don't do anything if the message was already wrapped in HTML tags
 		// That could have be done by a plugin via filters
 		if ( str_contains( $body, '<html' ) ) {
@@ -2883,6 +2895,30 @@ class Contact_Form extends Contact_Form_Shortcode {
 		 * @param string the filename of the HTML template used for response emails to the form owner.
 		 */
 		require apply_filters( 'jetpack_forms_response_email_template', __DIR__ . '/templates/email-response.php' );
+
+		$logo_html = '';
+		if ( $has_email_logo ) {
+
+			// Add the logo styles at the end.
+			$style = str_replace( '</style>', '.powered-by a {text-decoration: none;} @media only screen and (max-width: 640px) { .powered-by { padding: 0 16px 16px!important; }} </style>', $style );
+
+			$logo_html = str_replace(
+				"\t",
+				'',
+				'
+				<tr>
+					<td class="content-block powered-by">
+					' .
+					sprintf(
+						// translators: %1$s is a link to the Jetpack Forms page.
+						__( 'Powered by %1$s', 'jetpack-forms' ),
+						'<a href="https://jetpack.com/forms/?utm_source=jetpack-forms&utm_medium=email&utm_campaign=form-submissions">Jetpack Forms</a>'
+					) . '
+					</td>
+				</tr>'
+			);
+		}
+
 		$html_message = sprintf(
 			// The tabs are just here so that the raw code is correctly formatted for developers
 			// They're removed so that they don't affect the final message sent to users
@@ -2898,7 +2934,8 @@ class Contact_Form extends Contact_Form_Shortcode {
 			$footer,
 			$style,
 			$tracking_pixel,
-			$actions
+			$actions,
+			$logo_html
 		);
 
 		return $html_message;

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -2885,7 +2885,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 		require apply_filters( 'jetpack_forms_response_email_template', __DIR__ . '/templates/email-response.php' );
 
 		/**
-		 * Filtert the HTML for the powered by section in the email.
+		 * Filter the HTML for the powered by section in the email.
 		 *
 		 * @module contact-form
 		 *

--- a/projects/packages/forms/src/contact-form/templates/email-response.php
+++ b/projects/packages/forms/src/contact-form/templates/email-response.php
@@ -114,6 +114,10 @@ $style = '<style media="all" type="text/css">
 		width: 640px;
 	}
 
+	.powered-by a {
+		text-decoration: none;
+	}
+
 	.content {
 		box-sizing: border-box;
 		display: block;
@@ -197,10 +201,6 @@ $style = '<style media="all" type="text/css">
 		font-weight: normal;
 		margin: 0;
 		margin-bottom: 16px;
-	}
-
-	.powered-by a {
-		text-decoration: none;
 	}
 
 	@media only screen and (max-width: 640px) {

--- a/projects/packages/forms/src/contact-form/templates/email-response.php
+++ b/projects/packages/forms/src/contact-form/templates/email-response.php
@@ -10,6 +10,7 @@
  * %6$s style HTML tag.
  * %7$s tracking pixel
  * %8$s is the actions HTML.
+ * %9$s is powered by email logo.
  *
  * @package automattic/jetpack
  */
@@ -57,16 +58,7 @@ $template = '
 								<p>%5$s</p>
 							</td>
 						</tr>
-						<tr>
-							<td class="content-block powered-by">
-								' .
-								sprintf(
-									// translators: %1$s is a link to the Jetpack Forms page.
-									__( 'Powered by %1$s', 'jetpack-forms' ),
-									'<a href="https://jetpack.com/forms/?utm_source=jetpack-forms&utm_medium=email&utm_campaign=form-submissions">Jetpack Forms</a>'
-								) . '
-							</td>
-						</tr>
+						%9$s
 						</table>
 					</div>
 				</div>
@@ -175,7 +167,7 @@ $style = '<style media="all" type="text/css">
 	.actions .button_block .pad a span {
 		mso-text-raise: 15pt;
 	}
-	
+
 	.actions .button_block .pad i {
 		letter-spacing: 25px;
 		mso-font-width: -100%;
@@ -207,10 +199,6 @@ $style = '<style media="all" type="text/css">
 		margin-bottom: 16px;
 	}
 
-	.powered-by a {
-		text-decoration: none;
-	}
-
 	@media only screen and (max-width: 640px) {
 		.main p,
 		.main td,
@@ -220,10 +208,6 @@ $style = '<style media="all" type="text/css">
 
 		.wrapper {
 			padding: 8px 16px !important;
-		}
-
-		.powered-by {
-			padding: 0 16px 16px!important;
 		}
 
 		.content {

--- a/projects/packages/forms/src/contact-form/templates/email-response.php
+++ b/projects/packages/forms/src/contact-form/templates/email-response.php
@@ -199,6 +199,10 @@ $style = '<style media="all" type="text/css">
 		margin-bottom: 16px;
 	}
 
+	.powered-by a {
+		text-decoration: none;
+	}
+
 	@media only screen and (max-width: 640px) {
 		.main p,
 		.main td,
@@ -229,6 +233,10 @@ $style = '<style media="all" type="text/css">
 		.collapse { display: none; }
 
 		h1 { padding:0 16px; }
+
+		.powered-by {
+			padding: 0 16px 16px!important;
+		}
 	}
 
 	@media all {

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
@@ -848,7 +848,10 @@ class Contact_Form_Test extends BaseTestCase {
 	/**
 	 * Tests that the email does not contain "Powered by".
 	 */
-	public function test_no_powered_by_jetpack_in_email_header() {
+	public function test_jetpack_forms_email_powered_by_html_filter() {
+
+		$this->assertStringContainsString( 'Powered by', Contact_Form::wrap_message_in_html_tags( '$title', '$message', '$footer', '$actions' ) );
+
 		add_filter( 'jetpack_forms_email_powered_by_html', '__return_empty_string' );
 		$this->assertStringNotContainsString( 'Powered by', Contact_Form::wrap_message_in_html_tags( '$title', '$message', '$footer', '$actions' ) );
 		remove_filter( 'jetpack_forms_email_powered_by_html', '__return_empty_string' );

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
@@ -846,6 +846,13 @@ class Contact_Form_Test extends BaseTestCase {
 	}
 
 	/**
+	 * Tests that the email does not contain "powered".
+	 */
+	public function test_no_powered_by_jetpack_in_email_header() {
+		$this->assertStringNotContainsString( 'powered', Contact_Form::wrap_message_in_html_tags( '$title', '$message', '$footer', '$actions', false ) );
+	}
+
+	/**
 	 * This method is hooked to the wp-mail filter.
 	 *
 	 * @param array $args A compacted array of wp_mail() arguments, including the "to" email,

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
@@ -846,10 +846,12 @@ class Contact_Form_Test extends BaseTestCase {
 	}
 
 	/**
-	 * Tests that the email does not contain "powered".
+	 * Tests that the email does not contain "Powered by".
 	 */
 	public function test_no_powered_by_jetpack_in_email_header() {
-		$this->assertStringNotContainsString( 'powered', Contact_Form::wrap_message_in_html_tags( '$title', '$message', '$footer', '$actions', false ) );
+		add_filter( 'jetpack_forms_email_powered_by_html', '__return_empty_string' );
+		$this->assertStringNotContainsString( 'Powered by', Contact_Form::wrap_message_in_html_tags( '$title', '$message', '$footer', '$actions' ) );
+		remove_filter( 'jetpack_forms_email_powered_by_html', '__return_empty_string' );
 	}
 
 	/**


### PR DESCRIPTION
Part of FORMS-265

This Pr is an alternative approach of removing the "Powered by Jetpack" from the email. 

## Proposed changes:
* Adds a new filter `jetpack_forms_email_powered_by_html` that lets you control the "Powered by Jetpack" HTML 

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion


## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Add the line `add_filters( 'jetpack_forms_email_powered_by_html',  '__return_empty_string' ); to your `0-sandbox.php` file. 

Notice that the emails that go our do not contain info about "Powered by Jetpack." 

Remove the filter. Notice the new emails look as before. 

Without filter
<img width="753" height="571" alt="Screenshot 2025-12-31 at 10 24 36 AM" src="https://github.com/user-attachments/assets/3e0af0af-52e5-4fa8-866c-4376d5ac7ef0" />

With filter
<img width="762" height="577" alt="Screenshot 2025-12-31 at 10 24 33 AM" src="https://github.com/user-attachments/assets/29425465-ea51-4011-9e3c-9d3e3e1b092b" />



