### PR TITLE
Form: Fixes the flickering when moving between different responses.

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-flickering
+++ b/projects/packages/forms/changelog/fix-forms-flickering
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: Fix the clifering between the sidebar loading on different browser widths

--- a/projects/packages/forms/changelog/fix-forms-flickering
+++ b/projects/packages/forms/changelog/fix-forms-flickering
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Forms: Fix the clifering between the sidebar loading on different browser widths
+Forms: Fix the flickering between the sidebar loading on different browser widths

--- a/projects/packages/forms/src/dashboard/inbox/stage/index.js
+++ b/projects/packages/forms/src/dashboard/inbox/stage/index.js
@@ -46,7 +46,6 @@ import {
 import { useView, defaultLayouts } from './views.js';
 
 const EMPTY_ARRAY = [];
-const MOBILE_BREAKPOINT = 780;
 
 const updateSidebarWidth = () => {
 	const wrapper = document.querySelector( '.dataviews-wrapper' );
@@ -94,7 +93,7 @@ export default function InboxView() {
 		},
 		{ box: 'border-box' }
 	);
-	const isMobile = containerWidth <= MOBILE_BREAKPOINT;
+
 	const selectedResponses = searchParams.get( 'r' );
 	const isMobileViewport = useViewportMatch( 'medium', '<' );
 	const [ isResponseModalOpen, setIsResponseModalOpen ] = useState( false );
@@ -227,11 +226,7 @@ export default function InboxView() {
 		}
 
 		// Update sidebar if item changed or needs refresh
-		if (
-			! sidePanelItem ||
-			getItemId( sidePanelItem ) !== getItemId( recordToShow ) ||
-			sidePanelItem !== recordToShow
-		) {
+		if ( ! sidePanelItem || getItemId( sidePanelItem ) !== getItemId( recordToShow ) ) {
 			setSidePanelItem( recordToShow );
 		}
 	}, [ isMobileViewport, records, selection, sidePanelItem ] );
@@ -561,7 +556,7 @@ export default function InboxView() {
 						sidePanelItem={ sidePanelItem }
 						setSidePanelItem={ setSidePanelItem }
 						isLoadingData={ isLoadingData }
-						isMobile={ isMobile }
+						isMobile={ isMobileViewport }
 						onChangeSelection={ onChangeSelection }
 						selection={ selection }
 					/>


### PR DESCRIPTION
This PR fixes the flicker that we see when transition between the different responses 

See p8oabR-1IP-p2#comment-8702

## Proposed changes:
* Remove the isMobile constant to make sure that we only redraw the response when needed. 
* When comparing whether we should set the sidebar item only compare the IDs. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
See p8oabR-1IP-p2#comment-8702

## Does this pull request change what data or activity we track or use?
No 


## Testing instructions:
Go to the form dashboard. 
On Trunk Notice the behaviour by resizing your window to 1200px. 
And clicking the next response or using the down key. 

Now switch to this Branch. 
And rebuild it. Notice that the flickering is gone.