### PR TITLE
Jetpack Logo: add support for customized title in shared component.

### DIFF
--- a/projects/js-packages/components/changelog/update-jetpack-logo-add-support-for-title
+++ b/projects/js-packages/components/changelog/update-jetpack-logo-add-support-for-title
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Jetpack Logo: add support for customized title in shared component.

--- a/projects/js-packages/components/components/jetpack-logo/index.tsx
+++ b/projects/js-packages/components/components/jetpack-logo/index.tsx
@@ -8,9 +8,11 @@ const JetpackLogo: FC< JetpackLogoProps > = ( {
 	showText = true,
 	className,
 	height = 32,
+	title,
 	...otherProps
 } ) => {
 	const viewBox = showText ? '0 0 118 32' : '0 0 32 32';
+	const logoTitle = title ?? __( 'Jetpack Logo', 'jetpack-components' );
 
 	return (
 		<svg
@@ -25,7 +27,7 @@ const JetpackLogo: FC< JetpackLogoProps > = ( {
 			// role="img" is required to prevent VoiceOver on Safari reading the content of the SVG
 			role="img"
 		>
-			<title id="jetpack-logo-title">{ __( 'Jetpack Logo', 'jetpack-components' ) }</title>
+			<title id="jetpack-logo-title">{ logoTitle }</title>
 			<path
 				fill={ logoColor }
 				d="M16,0C7.2,0,0,7.2,0,16s7.2,16,16,16s16-7.2,16-16S24.8,0,16,0z M15,19H7l8-16V19z M17,29V13h8L17,29z"

--- a/projects/js-packages/components/components/jetpack-logo/types.ts
+++ b/projects/js-packages/components/components/jetpack-logo/types.ts
@@ -4,4 +4,5 @@ export type JetpackLogoProps = {
 	height?: number;
 	showText?: boolean;
 	logoColor?: string;
+	title?: string;
 };

--- a/projects/js-packages/shared-extension-utils/changelog/update-jetpack-logo-add-support-for-title
+++ b/projects/js-packages/shared-extension-utils/changelog/update-jetpack-logo-add-support-for-title
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Jetpack Logo: add support for customized title in shared component.

--- a/projects/js-packages/shared-extension-utils/src/components/jetpack-editor-panel-logo/index.jsx
+++ b/projects/js-packages/shared-extension-utils/src/components/jetpack-editor-panel-logo/index.jsx
@@ -1,4 +1,5 @@
 import { JetpackLogo } from '@automattic/jetpack-components';
+import { __ } from '@wordpress/i18n';
 
 import './style.scss';
 
@@ -13,6 +14,7 @@ const JetpackEditorPanelLogo = () => (
 		height={ 16 }
 		logoColor="#1E1E1E"
 		showText={ false }
+		title={ __( 'This feature is powered by Jetpack', 'jetpack-shared-extension-utils' ) }
 	/>
 );
 


### PR DESCRIPTION
This PR adds a `title` prop to the `JetpackLogo` component to allow customization of the SVG title for better accessibility and context-specific screen reader support.

Fixes MYJP-278

## Proposed changes:

- Added an optional `title` prop to the `JetpackLogo` component (`JetpackLogoProps`).
- Updated the component to use the custom title when provided, falling back to the default "Jetpack Logo" when not specified.
- Updated `JetpackEditorPanelLogo` to use a more descriptive title: "This feature is powered by Jetpack".

## Screenshots

Before | After
--|--
<img width="185" height="79" alt="image" src="https://github.com/user-attachments/assets/4f1d642b-9ec0-4dbd-82ab-7641cddc234e" /> | <img width="192" height="93" alt="image" src="https://github.com/user-attachments/assets/fd334d69-a96b-4580-a89e-a9dccc77ef36" />
<img width="322" height="107" alt="image" src="https://github.com/user-attachments/assets/c28a4311-698a-49f6-b3ce-02079f646e0c" /> | <img width="324" height="117" alt="image" src="https://github.com/user-attachments/assets/5522eb31-e083-491f-9725-eaee52944255" />


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

p1764615067356539-slack-C0D96691V

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

- Fire up this branch.
- Verify the default behavior works (when title prop is not provided):
  - The logo should have the default title "Jetpack Logo".
- Verify custom title works:
  - Check `JetpackEditorPanelLogo` in the editor to confirm it uses "This feature is powered by Jetpack" as the title.
  - You can inspect the SVG element to verify the <title> tag contains the correct text.
- Screen reader testing (optional but recommended):
  - Use a screen reader to verify the custom title is announced correctly when focusing on the logo.