### PR TITLE
e2e tests: enhance CTRF test report with extra env information

### DIFF
--- a/tools/e2e-commons/playwright.config.default.ts
+++ b/tools/e2e-commons/playwright.config.default.ts
@@ -29,6 +29,10 @@ const reporter: ReporterDescription[] = [
 		{
 			outputDir: `${ config.get( 'dirs.output' ) }`,
 			outputFile: `ctrf-report-${ Date.now() }.json`,
+			branchName: process.env.GITHUB_REF_NAME || '',
+			commit: process.env.GITHUB_SHA || '',
+			appName: 'jetpack',
+			repositoryName: process.env.GITHUB_REPOSITORY || '',
 		},
 	],
 ];


### PR DESCRIPTION
Contributes to QAO-173

## Proposed changes:

Add extra information in the CTRF e2e tests report: branch name, commit id, repo name, etc.


## Testing instructions:
* Download the e2e tests artefacts from CI and check a CTRF JSON file.

