### PR TITLE
Forms: replace jetpack buttons with core button

### DIFF
--- a/projects/packages/forms/changelog/add-core-button-submit
+++ b/projects/packages/forms/changelog/add-core-button-submit
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Forms: allow using the Gutenberg Core Button block as the submit control in Contact Form. The block gets the same interactivity bindings and loading spinner as the Jetpack Button, and all form variations now insert a core button by default.

--- a/projects/packages/forms/changelog/replace-forms-jetpack-buttons-core
+++ b/projects/packages/forms/changelog/replace-forms-jetpack-buttons-core
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Forms: use core/button instead of jetpack/button

--- a/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
+++ b/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
@@ -113,7 +113,7 @@ class Contact_Form_Block {
 	public static function render_submit_button( $content, $parsed_block ) {
 		$class = $parsed_block['attrs']['className'] ?? '';
 		if ( ! str_contains( $class, 'jetpack-form-submit-button' ) ) {
-			return $content; // Not our submit button.
+			return $content;
 		}
 
 		if ( ! class_exists( '\WP_HTML_Tag_Processor' ) ) {

--- a/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
+++ b/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
@@ -47,7 +47,6 @@ class Contact_Form_Block {
 
 		add_filter( 'render_block_data', array( __CLASS__, 'find_nested_html_block' ), 10, 3 );
 		add_filter( 'render_block_core/html', array( __CLASS__, 'render_wrapped_html_block' ), 10, 2 );
-		add_filter( 'render_block_core/button', array( __CLASS__, 'render_submit_button' ), 10, 2 );
 		add_filter( 'jetpack_block_editor_feature_flags', array( __CLASS__, 'register_feature' ) );
 		add_filter( 'pre_render_block', array( __CLASS__, 'pre_render_contact_form' ), 10, 3 );
 
@@ -101,35 +100,6 @@ class Contact_Form_Block {
 		}
 
 		return $content;
-	}
-
-	/**
-	 * Add Jetpack Forms interactivity attributes to core/button blocks that live inside a contact form.
-	 *
-	 * @param string $content Rendered HTML of the core/button block.
-	 * @param array  $parsed_block Parsed block array.
-	 * @return string Possibly modified HTML.
-	 */
-	public static function render_submit_button( $content, $parsed_block ) {
-		$class = $parsed_block['attrs']['className'] ?? '';
-		if ( ! str_contains( $class, 'jetpack-form-submit-button' ) ) {
-			return $content;
-		}
-
-		if ( ! class_exists( \WP_HTML_Tag_Processor::class ) ) {
-			return $content;
-		}
-
-		$p = new \WP_HTML_Tag_Processor( $content );
-		if ( ! $p->next_tag( array( 'tag_name' => 'button' ) ) ) {
-			return $content;
-		}
-
-		$p->set_attribute( 'data-wp-class--is-submitting', 'state.isSubmitting' );
-		$p->set_attribute( 'data-wp-bind--aria-disabled', 'state.isAriaDisabled' );
-		$p->set_attribute( 'data-wp-bind--disabled', 'state.isAriaDisabled' );
-
-		return $p->get_updated_html();
 	}
 
 	/**

--- a/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
+++ b/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
@@ -104,7 +104,7 @@ class Contact_Form_Block {
 	}
 
 	/**
-	 * Add Jetpack Forms interactivity attributes to core/buttons blocks that live inside a contact form.
+	 * Add Jetpack Forms interactivity attributes to core/button blocks that live inside a contact form.
 	 *
 	 * @param string $content Rendered HTML of the core/button block.
 	 * @param array  $parsed_block Parsed block array.

--- a/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
+++ b/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
@@ -47,7 +47,7 @@ class Contact_Form_Block {
 
 		add_filter( 'render_block_data', array( __CLASS__, 'find_nested_html_block' ), 10, 3 );
 		add_filter( 'render_block_core/html', array( __CLASS__, 'render_wrapped_html_block' ), 10, 2 );
-		add_filter( 'render_block_core/buttons', array( __CLASS__, 'render_buttons_block' ), 10, 2 );
+		add_filter( 'render_block_core/button', array( __CLASS__, 'render_submit_button' ), 10, 2 );
 		add_filter( 'jetpack_block_editor_feature_flags', array( __CLASS__, 'register_feature' ) );
 		add_filter( 'pre_render_block', array( __CLASS__, 'pre_render_contact_form' ), 10, 3 );
 
@@ -106,50 +106,29 @@ class Contact_Form_Block {
 	/**
 	 * Add Jetpack Forms interactivity attributes to core/buttons blocks that live inside a contact form.
 	 *
-	 * @param string $content       Rendered block HTML.
-	 * @param array  $parsed_block  Parsed block data.
-	 *
-	 * @return string
+	 * @param string $content Rendered HTML of the core/button block.
+	 * @param array  $parsed_block Parsed block array.
+	 * @return string Possibly modified HTML.
 	 */
-	public static function render_buttons_block( $content, $parsed_block ) {
-		// We don't need the parsed_block details anymore; suppress unused-variable warning.
-		unset( $parsed_block );
-		// We simply scan the content for our marker class; if absent, return early.
-		if ( ! str_contains( $content, 'jetpack-form-submit-button' ) ) {
-			return $content;
+	public static function render_submit_button( $content, $parsed_block ) {
+		$class = $parsed_block['attrs']['className'] ?? '';
+		if ( ! str_contains( $class, 'jetpack-form-submit-button' ) ) {
+			return $content; // Not our submit button.
 		}
 
 		if ( ! class_exists( '\WP_HTML_Tag_Processor' ) ) {
 			return $content;
 		}
 
-		$processor = new \WP_HTML_Tag_Processor( $content );
-		$modified  = false;
-
-		// Find wrapper div with marker class.
-		while ( $processor->next_tag( array( 'tag_name' => 'div' ) ) ) {
-			$class_attr = $processor->get_attribute( 'class' );
-			if ( $class_attr && str_contains( $class_attr, 'jetpack-form-submit-button' ) ) {
-				// Ensure interactivity root attribute on wrapper.
-				if ( ! $processor->get_attribute( 'data-wp-interactive' ) ) {
-					$processor->set_attribute( 'data-wp-interactive', 'jetpack/form' );
-				}
-				// Save bookmark to return later.
-				$processor->set_bookmark( 'wrapper' );
-
-				// Dive into its children to find first link or button.
-				if ( $processor->next_tag( array( 'tag_name' => array( 'a', 'button' ) ) ) ) {
-					$processor->set_attribute( 'data-wp-class--is-submitting', 'state.isSubmitting' );
-					$processor->set_attribute( 'data-wp-bind--aria-disabled', 'state.isAriaDisabled' );
-					$modified = true;
-				}
-
-				// Jump back to wrapper to continue outer loop safely.
-				$processor->seek( 'wrapper' );
-			}
+		$p = new \WP_HTML_Tag_Processor( $content );
+		if ( ! $p->next_tag( array( 'tag_name' => array( 'button', 'a' ) ) ) ) {
+			return $content;
 		}
 
-		return $modified ? $processor->get_updated_html() : $content;
+		$p->set_attribute( 'data-wp-class--is-submitting', 'state.isSubmitting' );
+		$p->set_attribute( 'data-wp-bind--aria-disabled', 'state.isAriaDisabled' );
+
+		return $p->get_updated_html();
 	}
 
 	/**

--- a/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
+++ b/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
@@ -127,6 +127,7 @@ class Contact_Form_Block {
 
 		$p->set_attribute( 'data-wp-class--is-submitting', 'state.isSubmitting' );
 		$p->set_attribute( 'data-wp-bind--aria-disabled', 'state.isAriaDisabled' );
+		$p->set_attribute( 'data-wp-bind--disabled', 'state.isAriaDisabled' );
 
 		return $p->get_updated_html();
 	}

--- a/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
+++ b/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
@@ -121,7 +121,7 @@ class Contact_Form_Block {
 		}
 
 		$p = new \WP_HTML_Tag_Processor( $content );
-		if ( ! $p->next_tag( array( 'tag_name' => array( 'button', 'a' ) ) ) ) {
+		if ( ! $p->next_tag( array( 'tag_name' => 'button' ) ) ) {
 			return $content;
 		}
 

--- a/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
+++ b/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
@@ -47,6 +47,7 @@ class Contact_Form_Block {
 
 		add_filter( 'render_block_data', array( __CLASS__, 'find_nested_html_block' ), 10, 3 );
 		add_filter( 'render_block_core/html', array( __CLASS__, 'render_wrapped_html_block' ), 10, 2 );
+		add_filter( 'render_block_core/buttons', array( __CLASS__, 'render_buttons_block' ), 10, 2 );
 		add_filter( 'jetpack_block_editor_feature_flags', array( __CLASS__, 'register_feature' ) );
 		add_filter( 'pre_render_block', array( __CLASS__, 'pre_render_contact_form' ), 10, 3 );
 
@@ -100,6 +101,55 @@ class Contact_Form_Block {
 		}
 
 		return $content;
+	}
+
+	/**
+	 * Add Jetpack Forms interactivity attributes to core/buttons blocks that live inside a contact form.
+	 *
+	 * @param string $content       Rendered block HTML.
+	 * @param array  $parsed_block  Parsed block data.
+	 *
+	 * @return string
+	 */
+	public static function render_buttons_block( $content, $parsed_block ) {
+		// We don't need the parsed_block details anymore; suppress unused-variable warning.
+		unset( $parsed_block );
+		// We simply scan the content for our marker class; if absent, return early.
+		if ( ! str_contains( $content, 'jetpack-form-submit-button' ) ) {
+			return $content;
+		}
+
+		if ( ! class_exists( '\WP_HTML_Tag_Processor' ) ) {
+			return $content;
+		}
+
+		$processor = new \WP_HTML_Tag_Processor( $content );
+		$modified  = false;
+
+		// Find wrapper div with marker class.
+		while ( $processor->next_tag( array( 'tag_name' => 'div' ) ) ) {
+			$class_attr = $processor->get_attribute( 'class' );
+			if ( $class_attr && str_contains( $class_attr, 'jetpack-form-submit-button' ) ) {
+				// Ensure interactivity root attribute on wrapper.
+				if ( ! $processor->get_attribute( 'data-wp-interactive' ) ) {
+					$processor->set_attribute( 'data-wp-interactive', 'jetpack/form' );
+				}
+				// Save bookmark to return later.
+				$processor->set_bookmark( 'wrapper' );
+
+				// Dive into its children to find first link or button.
+				if ( $processor->next_tag( array( 'tag_name' => array( 'a', 'button' ) ) ) ) {
+					$processor->set_attribute( 'data-wp-class--is-submitting', 'state.isSubmitting' );
+					$processor->set_attribute( 'data-wp-bind--aria-disabled', 'state.isAriaDisabled' );
+					$modified = true;
+				}
+
+				// Jump back to wrapper to continue outer loop safely.
+				$processor->seek( 'wrapper' );
+			}
+		}
+
+		return $modified ? $processor->get_updated_html() : $content;
 	}
 
 	/**

--- a/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
+++ b/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
@@ -116,7 +116,7 @@ class Contact_Form_Block {
 			return $content;
 		}
 
-		if ( ! class_exists( '\WP_HTML_Tag_Processor' ) ) {
+		if ( ! class_exists( \WP_HTML_Tag_Processor::class ) ) {
 			return $content;
 		}
 

--- a/projects/packages/forms/src/blocks/contact-form/edit.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/edit.tsx
@@ -732,7 +732,6 @@ function JetpackContactFormEdit( {
 				text: __( 'Submit', 'jetpack-forms' ),
 				type: 'submit',
 				tagName: 'button',
-				className: 'wp-block-jetpack-button jetpack-form-submit-button',
 			} );
 		}
 

--- a/projects/packages/forms/src/blocks/contact-form/edit.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/edit.tsx
@@ -212,7 +212,7 @@ function JetpackContactFormEdit( {
 	);
 
 	const findButtonsBlock = useCallback(
-		block => block.name === 'core/buttons' || block.name === 'jetpack/button',
+		block => block.name === 'core/button' || block.name === 'jetpack/button',
 		[]
 	);
 
@@ -240,7 +240,7 @@ function JetpackContactFormEdit( {
 
 				const isSingleButtonBlock =
 					innerBlocksData.length === 1 &&
-					( innerBlocksData[ 0 ].name === 'core/buttons' ||
+					( innerBlocksData[ 0 ].name === 'core/button' ||
 						innerBlocksData[ 0 ].name === 'jetpack/button' );
 
 				const title = getEditedPostAttribute( 'title' );
@@ -350,7 +350,7 @@ function JetpackContactFormEdit( {
 			// Find the submit button
 			const submitButtonIndex = currentInnerBlocks.findIndex(
 				block =>
-					( block.name === 'core/buttons' || block.name === 'jetpack/button' ) &&
+					( block.name === 'core/button' || block.name === 'jetpack/button' ) &&
 					( block.attributes?.customVariant === 'submit' || block.attributes?.element === 'button' )
 			);
 
@@ -728,14 +728,12 @@ function JetpackContactFormEdit( {
 		// Ensure we have a submit button at the end of the form.
 		if ( ! finalSubmitButton ) {
 			// Create a fresh submit button if none was found.
-			finalSubmitButton = createBlock( 'core/buttons', {}, [
-				createBlock( 'core/button', {
-					text: __( 'Submit', 'jetpack-forms' ),
-					type: 'submit',
-					tagName: 'button',
-					className: 'wp-block-jetpack-button jetpack-form-submit-button',
-				} ),
-			] );
+			finalSubmitButton = createBlock( 'core/button', {
+				text: __( 'Submit', 'jetpack-forms' ),
+				type: 'submit',
+				tagName: 'button',
+				className: 'wp-block-jetpack-button jetpack-form-submit-button',
+			} );
 		}
 
 		const finalBlocks = [ ...flattenedInnerBlocks, finalSubmitButton ];

--- a/projects/packages/forms/src/blocks/contact-form/edit.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/edit.tsx
@@ -486,7 +486,7 @@ function JetpackContactFormEdit( {
 		// Helper functions
 		const findButtonBlock = () => {
 			const buttonIndex = currentInnerBlocks.findIndex(
-				block => block.name === 'core/buttons' || block.name === 'jetpack/button'
+				block => block.name === 'core/button' || block.name === 'jetpack/button'
 			);
 			return buttonIndex !== -1
 				? {

--- a/projects/packages/forms/src/blocks/contact-form/edit.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/edit.tsx
@@ -211,10 +211,12 @@ function JetpackContactFormEdit( {
 		[ clientId, steps ]
 	);
 
-	const submitButton = useFindBlockRecursively(
-		clientId,
-		block => block.name === 'jetpack/button'
+	const findButtonsBlock = useCallback(
+		block => block.name === 'core/buttons' || block.name === 'jetpack/button',
+		[]
 	);
+
+	const submitButton = useFindBlockRecursively( clientId, findButtonsBlock );
 
 	const { postTitle, hasAnyInnerBlocks, postAuthorEmail, selectedBlockClientId, onlySubmitBlock } =
 		useSelect(
@@ -236,6 +238,11 @@ function JetpackContactFormEdit( {
 				const { getUser } = select( coreStore );
 				const innerBlocksData = getBlocks( clientId );
 
+				const isSingleButtonBlock =
+					innerBlocksData.length === 1 &&
+					( innerBlocksData[ 0 ].name === 'core/buttons' ||
+						innerBlocksData[ 0 ].name === 'jetpack/button' );
+
 				const title = getEditedPostAttribute( 'title' );
 				const authorId = getEditedPostAttribute( 'author' );
 				const authorEmail = authorId && getUser( authorId )?.email;
@@ -245,8 +252,7 @@ function JetpackContactFormEdit( {
 					hasAnyInnerBlocks: innerBlocksData.length > 0,
 					postAuthorEmail: authorEmail,
 					selectedBlockClientId: selectedStepBlockId,
-					onlySubmitBlock:
-						innerBlocksData.length === 1 && innerBlocksData[ 0 ].name === 'jetpack/button',
+					onlySubmitBlock: isSingleButtonBlock,
 				};
 			},
 			[ clientId ]
@@ -344,7 +350,7 @@ function JetpackContactFormEdit( {
 			// Find the submit button
 			const submitButtonIndex = currentInnerBlocks.findIndex(
 				block =>
-					block.name === 'jetpack/button' &&
+					( block.name === 'core/buttons' || block.name === 'jetpack/button' ) &&
 					( block.attributes?.customVariant === 'submit' || block.attributes?.element === 'button' )
 			);
 
@@ -479,7 +485,9 @@ function JetpackContactFormEdit( {
 
 		// Helper functions
 		const findButtonBlock = () => {
-			const buttonIndex = currentInnerBlocks.findIndex( block => block.name === 'jetpack/button' );
+			const buttonIndex = currentInnerBlocks.findIndex(
+				block => block.name === 'core/buttons' || block.name === 'jetpack/button'
+			);
 			return buttonIndex !== -1
 				? {
 						block: currentInnerBlocks[ buttonIndex ],
@@ -720,10 +728,14 @@ function JetpackContactFormEdit( {
 		// Ensure we have a submit button at the end of the form.
 		if ( ! finalSubmitButton ) {
 			// Create a fresh submit button if none was found.
-			finalSubmitButton = createBlock( 'jetpack/button', {
-				element: 'button',
-				text: __( 'Submit', 'jetpack-forms' ),
-			} );
+			finalSubmitButton = createBlock( 'core/buttons', {}, [
+				createBlock( 'core/button', {
+					text: __( 'Submit', 'jetpack-forms' ),
+					type: 'submit',
+					tagName: 'button',
+					className: 'wp-block-jetpack-button jetpack-form-submit-button',
+				} ),
+			] );
 		}
 
 		const finalBlocks = [ ...flattenedInnerBlocks, finalSubmitButton ];

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -54,7 +54,8 @@
 			flex: 1 1 100%;
 		}
 
-		.wp-block:not(.wp-block-buttons):not(.wp-block-button) {
+		// .wp-block:not(.wp-block-buttons):not(.wp-block-button) {
+		.wp-block {
 			flex: 0 0 100%;
 			margin-top: 0;
 			margin-bottom: 0;

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -54,7 +54,6 @@
 			flex: 1 1 100%;
 		}
 
-		// .wp-block:not(.wp-block-buttons):not(.wp-block-button) {
 		.wp-block {
 			flex: 0 0 100%;
 			margin-top: 0;

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -55,7 +55,6 @@
 		}
 
 		.wp-block {
-			flex: 1 1 100%;
 			margin-top: 0;
 			margin-bottom: 0;
 			max-width: 100%;

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -54,7 +54,8 @@
 			flex: 1 1 100%;
 		}
 
-		.wp-block {
+		.wp-block:not(.wp-block-buttons):not(.wp-block-button) {
+			flex: 0 0 100%;
 			margin-top: 0;
 			margin-bottom: 0;
 			max-width: 100%;

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -67,6 +67,7 @@
 				min-height: var(--jetpack--contact-form--input-height, auto);
 				align-self: flex-end;
 				line-height: 1;
+				margin-block: 0;
 
 				.wp-block-button__link {
 					min-height: var(--jetpack--contact-form--input-height, auto);

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -61,6 +61,7 @@
 			margin-bottom: 0;
 			max-width: 100%;
 
+			&.wp-block-button,
 			&.wp-block-jetpack-button {
 				flex: 0 0 auto;
 				min-height: var(--jetpack--contact-form--input-height, auto);
@@ -87,6 +88,7 @@
 				box-sizing: border-box;
 			}
 
+			&.wp-block-button__width-25,
 			&.jetpack-field__width-25 {
 				flex: 1 1 calc(25% - calc(var(--wp--style--block-gap, 1.5rem) * 1));
 				max-width: 25%;
@@ -97,14 +99,28 @@
 				max-width: 33.33%;
 			}
 
+			&.wp-block-button__width-50,
 			&.jetpack-field__width-50 {
 				flex: 1 1 calc(50% - calc(var(--wp--style--block-gap, 1.5rem) * 1));
 				max-width: 50%;
 			}
 
+			&.wp-block-button__width-75,
 			&.jetpack-field__width-75 {
 				flex: 1 1 calc(75% - calc(var(--wp--style--block-gap, 1.5rem) * 1));
 				max-width: 75%;
+			}
+
+			&.wp-block-button__width-100 {
+				flex: 1 1 100%;
+				max-width: 100%;
+			}
+
+			&.wp-block-button.has-custom-width {
+
+				.wp-block-button__link {
+					width: 100%;
+				}
 			}
 
 			&.jetpack-field__width-auto {

--- a/projects/packages/forms/src/blocks/contact-form/variations.js
+++ b/projects/packages/forms/src/blocks/contact-form/variations.js
@@ -671,7 +671,7 @@ const variations = [
 					[
 						'core/button',
 						{
-							text: __( 'Send Feedback', 'jetpack-forms' ),
+							text: __( 'Send feedback', 'jetpack-forms' ),
 							tagName: 'button',
 							className: 'jetpack-form-submit-button',
 							type: 'submit',

--- a/projects/packages/forms/src/blocks/contact-form/variations.js
+++ b/projects/packages/forms/src/blocks/contact-form/variations.js
@@ -66,12 +66,20 @@ const variations = [
 				],
 			],
 			[
-				'jetpack/button',
-				{
-					text: __( 'Contact Us', 'jetpack-forms' ),
-					element: 'button',
-					lock: { remove: true },
-				},
+				'core/buttons',
+				{},
+				[
+					[
+						'core/button',
+						{
+							text: __( 'Contact Us', 'jetpack-forms' ),
+							tagName: 'button',
+							className: 'jetpack-form-submit-button',
+							type: 'submit',
+							element: 'button',
+						},
+					],
+				],
 			],
 		],
 		attributes: {
@@ -145,12 +153,20 @@ const variations = [
 				],
 			],
 			[
-				'jetpack/button',
-				{
-					text: __( 'Send RSVP', 'jetpack-forms' ),
-					element: 'button',
-					lock: { remove: true },
-				},
+				'core/buttons',
+				{},
+				[
+					[
+						'core/button',
+						{
+							text: __( 'Send RSVP', 'jetpack-forms' ),
+							tagName: 'button',
+							className: 'jetpack-form-submit-button',
+							type: 'submit',
+							element: 'button',
+						},
+					],
+				],
 			],
 		],
 		attributes: {
@@ -298,12 +314,20 @@ const variations = [
 				],
 			],
 			[
-				'jetpack/button',
-				{
-					text: __( 'Send', 'jetpack-forms' ),
-					element: 'button',
-					lock: { remove: true },
-				},
+				'core/buttons',
+				{},
+				[
+					[
+						'core/button',
+						{
+							text: __( 'Send', 'jetpack-forms' ),
+							tagName: 'button',
+							className: 'jetpack-form-submit-button',
+							type: 'submit',
+							element: 'button',
+						},
+					],
+				],
 			],
 		],
 		attributes: {
@@ -487,12 +511,20 @@ const variations = [
 				],
 			],
 			[
-				'jetpack/button',
-				{
-					text: __( 'Book appointment', 'jetpack-forms' ),
-					element: 'button',
-					lock: { remove: true },
-				},
+				'core/buttons',
+				{},
+				[
+					[
+						'core/button',
+						{
+							text: __( 'Book appointment', 'jetpack-forms' ),
+							tagName: 'button',
+							className: 'jetpack-form-submit-button',
+							type: 'submit',
+							element: 'button',
+						},
+					],
+				],
 			],
 		],
 		attributes: {
@@ -633,12 +665,20 @@ const variations = [
 				],
 			],
 			[
-				'jetpack/button',
-				{
-					text: __( 'Send Feedback', 'jetpack-forms' ),
-					element: 'button',
-					lock: { remove: true },
-				},
+				'core/buttons',
+				{},
+				[
+					[
+						'core/button',
+						{
+							text: __( 'Send Feedback', 'jetpack-forms' ),
+							tagName: 'button',
+							className: 'jetpack-form-submit-button',
+							type: 'submit',
+							element: 'button',
+						},
+					],
+				],
 			],
 		],
 		attributes: {
@@ -956,12 +996,20 @@ const variations = [
 				[ [ 'jetpack/label' ], [ 'jetpack/input', { type: 'checkbox' } ] ],
 			],
 			[
-				'jetpack/button',
-				{
-					text: __( 'Subscribe', 'jetpack-forms' ),
-					element: 'button',
-					lock: { remove: true },
-				},
+				'core/buttons',
+				{},
+				[
+					[
+						'core/button',
+						{
+							text: __( 'Subscribe', 'jetpack-forms' ),
+							tagName: 'button',
+							className: 'jetpack-form-submit-button',
+							type: 'submit',
+							element: 'button',
+						},
+					],
+				],
 			],
 		],
 		attributes: {},

--- a/projects/packages/forms/src/blocks/contact-form/variations.js
+++ b/projects/packages/forms/src/blocks/contact-form/variations.js
@@ -70,7 +70,6 @@ const variations = [
 				{
 					text: __( 'Contact us', 'jetpack-forms' ),
 					tagName: 'button',
-					className: 'jetpack-form-submit-button',
 					type: 'submit',
 					element: 'button',
 				},
@@ -151,7 +150,6 @@ const variations = [
 				{
 					text: __( 'Send RSVP', 'jetpack-forms' ),
 					tagName: 'button',
-					className: 'jetpack-form-submit-button',
 					type: 'submit',
 					element: 'button',
 				},
@@ -306,7 +304,6 @@ const variations = [
 				{
 					text: __( 'Send', 'jetpack-forms' ),
 					tagName: 'button',
-					className: 'jetpack-form-submit-button',
 					type: 'submit',
 					element: 'button',
 				},
@@ -497,7 +494,6 @@ const variations = [
 				{
 					text: __( 'Book appointment', 'jetpack-forms' ),
 					tagName: 'button',
-					className: 'jetpack-form-submit-button',
 					type: 'submit',
 					element: 'button',
 				},
@@ -645,7 +641,6 @@ const variations = [
 				{
 					text: __( 'Send feedback', 'jetpack-forms' ),
 					tagName: 'button',
-					className: 'jetpack-form-submit-button',
 					type: 'submit',
 					element: 'button',
 				},
@@ -970,7 +965,6 @@ const variations = [
 				{
 					text: __( 'Subscribe', 'jetpack-forms' ),
 					tagName: 'button',
-					className: 'jetpack-form-submit-button',
 					type: 'submit',
 					element: 'button',
 				},

--- a/projects/packages/forms/src/blocks/contact-form/variations.js
+++ b/projects/packages/forms/src/blocks/contact-form/variations.js
@@ -71,7 +71,6 @@ const variations = [
 					text: __( 'Contact us', 'jetpack-forms' ),
 					tagName: 'button',
 					type: 'submit',
-					element: 'button',
 				},
 			],
 		],
@@ -151,7 +150,6 @@ const variations = [
 					text: __( 'Send RSVP', 'jetpack-forms' ),
 					tagName: 'button',
 					type: 'submit',
-					element: 'button',
 				},
 			],
 		],
@@ -214,10 +212,10 @@ const variations = [
 					],
 				},
 				{
-					name: 'jetpack/button',
+					name: 'core/button',
 					attributes: {
 						text: __( 'Send RSVP', 'jetpack-forms' ),
-						element: 'button',
+						tagName: 'button',
 						lock: { remove: true },
 					},
 				},
@@ -305,7 +303,6 @@ const variations = [
 					text: __( 'Send', 'jetpack-forms' ),
 					tagName: 'button',
 					type: 'submit',
-					element: 'button',
 				},
 			],
 		],
@@ -397,10 +394,10 @@ const variations = [
 					],
 				},
 				{
-					name: 'jetpack/button',
+					name: 'core/button',
 					attributes: {
 						text: __( 'Send', 'jetpack-forms' ),
-						element: 'button',
+						tagName: 'button',
 						lock: { remove: true },
 					},
 				},
@@ -495,7 +492,6 @@ const variations = [
 					text: __( 'Book appointment', 'jetpack-forms' ),
 					tagName: 'button',
 					type: 'submit',
-					element: 'button',
 				},
 			],
 		],
@@ -571,10 +567,10 @@ const variations = [
 					],
 				},
 				{
-					name: 'jetpack/button',
+					name: 'core/button',
 					attributes: {
 						text: __( 'Book appointment', 'jetpack-forms' ),
-						element: 'button',
+						tagName: 'button',
 						lock: { remove: true },
 					},
 				},
@@ -642,7 +638,6 @@ const variations = [
 					text: __( 'Send feedback', 'jetpack-forms' ),
 					tagName: 'button',
 					type: 'submit',
-					element: 'button',
 				},
 			],
 		],
@@ -688,10 +683,10 @@ const variations = [
 					],
 				},
 				{
-					name: 'jetpack/button',
+					name: 'core/button',
 					attributes: {
 						text: __( 'Send Feedback', 'jetpack-forms' ),
-						element: 'button',
+						tagName: 'button',
 						lock: { remove: true },
 					},
 				},
@@ -893,9 +888,9 @@ const variations = [
 				{ layout: { type: 'flex', justifyContent: 'right' } },
 				[
 					[
-						'jetpack/button',
+						'core/button',
 						{
-							element: 'button',
+							tagName: 'button',
 							uniqueId: 'previous-step',
 							customVariant: 'previous',
 							text: __( '← Back', 'jetpack-forms' ),
@@ -904,9 +899,9 @@ const variations = [
 						},
 					],
 					[
-						'jetpack/button',
+						'core/button',
 						{
-							element: 'button',
+							tagName: 'button',
 							uniqueId: 'next-step',
 							customVariant: 'next',
 							text: __( 'Next →', 'jetpack-forms' ),
@@ -914,9 +909,9 @@ const variations = [
 						},
 					],
 					[
-						'jetpack/button',
+						'core/button',
 						{
-							element: 'button',
+							tagName: 'button',
 							uniqueId: 'submit-step',
 							customVariant: 'submit',
 							text: __( 'Submit', 'jetpack-forms' ),
@@ -966,7 +961,6 @@ const variations = [
 					text: __( 'Subscribe', 'jetpack-forms' ),
 					tagName: 'button',
 					type: 'submit',
-					element: 'button',
 				},
 			],
 		],
@@ -998,10 +992,10 @@ const variations = [
 					],
 				},
 				{
-					name: 'jetpack/button',
+					name: 'core/button',
 					attributes: {
 						text: __( 'Subscribe', 'jetpack-forms' ),
-						element: 'button',
+						tagName: 'button',
 						lock: { remove: true },
 					},
 				},

--- a/projects/packages/forms/src/blocks/contact-form/variations.js
+++ b/projects/packages/forms/src/blocks/contact-form/variations.js
@@ -66,20 +66,14 @@ const variations = [
 				],
 			],
 			[
-				'core/buttons',
-				{},
-				[
-					[
-						'core/button',
-						{
-							text: __( 'Contact us', 'jetpack-forms' ),
-							tagName: 'button',
-							className: 'jetpack-form-submit-button',
-							type: 'submit',
-							element: 'button',
-						},
-					],
-				],
+				'core/button',
+				{
+					text: __( 'Contact us', 'jetpack-forms' ),
+					tagName: 'button',
+					className: 'jetpack-form-submit-button',
+					type: 'submit',
+					element: 'button',
+				},
 			],
 		],
 		attributes: {
@@ -153,20 +147,14 @@ const variations = [
 				],
 			],
 			[
-				'core/buttons',
-				{},
-				[
-					[
-						'core/button',
-						{
-							text: __( 'Send RSVP', 'jetpack-forms' ),
-							tagName: 'button',
-							className: 'jetpack-form-submit-button',
-							type: 'submit',
-							element: 'button',
-						},
-					],
-				],
+				'core/button',
+				{
+					text: __( 'Send RSVP', 'jetpack-forms' ),
+					tagName: 'button',
+					className: 'jetpack-form-submit-button',
+					type: 'submit',
+					element: 'button',
+				},
 			],
 		],
 		attributes: {
@@ -314,20 +302,14 @@ const variations = [
 				],
 			],
 			[
-				'core/buttons',
-				{},
-				[
-					[
-						'core/button',
-						{
-							text: __( 'Send', 'jetpack-forms' ),
-							tagName: 'button',
-							className: 'jetpack-form-submit-button',
-							type: 'submit',
-							element: 'button',
-						},
-					],
-				],
+				'core/button',
+				{
+					text: __( 'Send', 'jetpack-forms' ),
+					tagName: 'button',
+					className: 'jetpack-form-submit-button',
+					type: 'submit',
+					element: 'button',
+				},
 			],
 		],
 		attributes: {
@@ -511,20 +493,14 @@ const variations = [
 				],
 			],
 			[
-				'core/buttons',
-				{},
-				[
-					[
-						'core/button',
-						{
-							text: __( 'Book appointment', 'jetpack-forms' ),
-							tagName: 'button',
-							className: 'jetpack-form-submit-button',
-							type: 'submit',
-							element: 'button',
-						},
-					],
-				],
+				'core/button',
+				{
+					text: __( 'Book appointment', 'jetpack-forms' ),
+					tagName: 'button',
+					className: 'jetpack-form-submit-button',
+					type: 'submit',
+					element: 'button',
+				},
 			],
 		],
 		attributes: {
@@ -665,20 +641,14 @@ const variations = [
 				],
 			],
 			[
-				'core/buttons',
-				{},
-				[
-					[
-						'core/button',
-						{
-							text: __( 'Send feedback', 'jetpack-forms' ),
-							tagName: 'button',
-							className: 'jetpack-form-submit-button',
-							type: 'submit',
-							element: 'button',
-						},
-					],
-				],
+				'core/button',
+				{
+					text: __( 'Send feedback', 'jetpack-forms' ),
+					tagName: 'button',
+					className: 'jetpack-form-submit-button',
+					type: 'submit',
+					element: 'button',
+				},
 			],
 		],
 		attributes: {
@@ -996,20 +966,14 @@ const variations = [
 				[ [ 'jetpack/label' ], [ 'jetpack/input', { type: 'checkbox' } ] ],
 			],
 			[
-				'core/buttons',
-				{},
-				[
-					[
-						'core/button',
-						{
-							text: __( 'Subscribe', 'jetpack-forms' ),
-							tagName: 'button',
-							className: 'jetpack-form-submit-button',
-							type: 'submit',
-							element: 'button',
-						},
-					],
-				],
+				'core/button',
+				{
+					text: __( 'Subscribe', 'jetpack-forms' ),
+					tagName: 'button',
+					className: 'jetpack-form-submit-button',
+					type: 'submit',
+					element: 'button',
+				},
 			],
 		],
 		attributes: {},

--- a/projects/packages/forms/src/blocks/contact-form/variations.js
+++ b/projects/packages/forms/src/blocks/contact-form/variations.js
@@ -72,7 +72,7 @@ const variations = [
 					[
 						'core/button',
 						{
-							text: __( 'Contact Us', 'jetpack-forms' ),
+							text: __( 'Contact us', 'jetpack-forms' ),
 							tagName: 'button',
 							className: 'jetpack-form-submit-button',
 							type: 'submit',

--- a/projects/packages/forms/src/blocks/dropzone/index.js
+++ b/projects/packages/forms/src/blocks/dropzone/index.js
@@ -11,7 +11,7 @@ const settings = {
 	description: __( 'A dropzone for file uploads.', 'jetpack-forms' ),
 	parent: [ 'jetpack/field-file' ],
 	allowedBlocks: [
-		'core/buttons',
+		'core/button',
 		'core/heading',
 		'core/image',
 		'core/list',

--- a/projects/packages/forms/src/blocks/shared/hooks/use-form-wrapper.js
+++ b/projects/packages/forms/src/blocks/shared/hooks/use-form-wrapper.js
@@ -29,7 +29,6 @@ export default function useFormWrapper( { attributes, clientId, name } ) {
 						text: __( 'Submit', 'jetpack-forms' ),
 						type: 'submit',
 						tagName: 'button',
-						className: 'wp-block-jetpack-button jetpack-form-submit-button',
 					} ),
 				] )
 			);

--- a/projects/packages/forms/src/blocks/shared/hooks/use-form-wrapper.js
+++ b/projects/packages/forms/src/blocks/shared/hooks/use-form-wrapper.js
@@ -25,14 +25,12 @@ export default function useFormWrapper( { attributes, clientId, name } ) {
 				clientId,
 				createBlock( FORM_BLOCK_NAME, {}, [
 					createBlock( name, attributes, getBlocks( clientId ) ),
-					createBlock( 'core/buttons', { lock: { remove: true } }, [
-						createBlock( 'core/button', {
-							text: __( 'Submit', 'jetpack-forms' ),
-							type: 'submit',
-							tagName: 'button',
-							className: 'wp-block-jetpack-button jetpack-form-submit-button',
-						} ),
-					] ),
+					createBlock( 'core/button', {
+						text: __( 'Submit', 'jetpack-forms' ),
+						type: 'submit',
+						tagName: 'button',
+						className: 'wp-block-jetpack-button jetpack-form-submit-button',
+					} ),
 				] )
 			);
 		}

--- a/projects/packages/forms/src/blocks/shared/hooks/use-form-wrapper.js
+++ b/projects/packages/forms/src/blocks/shared/hooks/use-form-wrapper.js
@@ -25,11 +25,14 @@ export default function useFormWrapper( { attributes, clientId, name } ) {
 				clientId,
 				createBlock( FORM_BLOCK_NAME, {}, [
 					createBlock( name, attributes, getBlocks( clientId ) ),
-					createBlock( 'jetpack/button', {
-						text: __( 'Submit', 'jetpack-forms' ),
-						element: 'button',
-						lock: { remove: true },
-					} ),
+					createBlock( 'core/buttons', { lock: { remove: true } }, [
+						createBlock( 'core/button', {
+							text: __( 'Submit', 'jetpack-forms' ),
+							type: 'submit',
+							tagName: 'button',
+							className: 'wp-block-jetpack-button jetpack-form-submit-button',
+						} ),
+					] ),
 				] )
 			);
 		}

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -1270,6 +1270,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 
 	/**
 	 * Prepare the submit button for the contact form.
+	 * Add interactivity attributes to the LAST submit button found in the content.
 	 *
 	 * @param string $content - the content of the submit button.
 	 *

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -1178,7 +1178,8 @@ class Contact_Form extends Contact_Form_Shortcode {
 				$r = preg_replace( '/<div class="wp-block-jetpack-form-step-navigation__wrapper/', self::render_error_wrapper() . ' <div class="wp-block-jetpack-form-step-navigation__wrapper', $r, 1 );
 			} elseif ( $has_submit_button_block && ! $is_single_input_form ) {
 				// Place the error wrapper before the FIRST button block only to avoid duplicates (e.g., navigation buttons in multistep forms).
-				// Replace only the first occurrence for both Jetpack (legacy) and core Button blocks.
+				// Replace only the first occurrence of a wp-block-jetpack-button prepending it with the error wrapper.
+				// Fallback with same strategy for new core button blocks.
 				$r = preg_replace( '/<div class="wp-block-jetpack-button/', self::render_error_wrapper() . ' <div class="wp-block-jetpack-button', $r, 1 );
 				if ( str_contains( $r, 'wp-block-button' ) ) {
 					$r = preg_replace( '/<div class="wp-block-button/', self::render_error_wrapper() . ' <div class="wp-block-button', $r, 1 );

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -1178,10 +1178,10 @@ class Contact_Form extends Contact_Form_Shortcode {
 				$r = preg_replace( '/<div class="wp-block-jetpack-form-step-navigation__wrapper/', self::render_error_wrapper() . ' <div class="wp-block-jetpack-form-step-navigation__wrapper', $r, 1 );
 			} elseif ( $has_submit_button_block && ! $is_single_input_form ) {
 				// Place the error wrapper before the FIRST button block only to avoid duplicates (e.g., navigation buttons in multistep forms).
-				// Replace only the first occurrence for both Jetpack and core Buttons blocks.
+				// Replace only the first occurrence for both Jetpack (legacy) and core Button blocks.
 				$r = preg_replace( '/<div class="wp-block-jetpack-button/', self::render_error_wrapper() . ' <div class="wp-block-jetpack-button', $r, 1 );
-				if ( str_contains( $r, 'wp-block-buttons' ) ) {
-					$r = preg_replace( '/<div class="wp-block-buttons/', self::render_error_wrapper() . ' <div class="wp-block-buttons', $r, 1 );
+				if ( str_contains( $r, 'wp-block-button' ) ) {
+					$r = preg_replace( '/<div class="wp-block-button/', self::render_error_wrapper() . ' <div class="wp-block-button', $r, 1 );
 				}
 			}
 

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -1143,7 +1143,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 			 * @param int $id Contact Form ID.
 			 */
 			$url                     = apply_filters( 'grunion_contact_form_form_action', $url, $GLOBALS['post'], $id, $page );
-			$has_submit_button_block = str_contains( $content, 'wp-block-jetpack-button' ) || str_contains( $content, 'wp-block-buttons' );
+			$has_submit_button_block = str_contains( $content, 'wp-block-jetpack-button' ) || str_contains( $content, 'wp-block-button' );
 			$form_classes            = 'contact-form commentsblock';
 			if ( $submission_success ) {
 				$form_classes .= ' submission-success';

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -1143,7 +1143,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 			 * @param int $id Contact Form ID.
 			 */
 			$url                     = apply_filters( 'grunion_contact_form_form_action', $url, $GLOBALS['post'], $id, $page );
-			$has_submit_button_block = str_contains( $content, 'wp-block-jetpack-button' );
+			$has_submit_button_block = str_contains( $content, 'wp-block-jetpack-button' ) || str_contains( $content, 'wp-block-buttons' );
 			$form_classes            = 'contact-form commentsblock';
 			if ( $submission_success ) {
 				$form_classes .= ' submission-success';
@@ -1178,8 +1178,11 @@ class Contact_Form extends Contact_Form_Shortcode {
 				$r = preg_replace( '/<div class="wp-block-jetpack-form-step-navigation__wrapper/', self::render_error_wrapper() . ' <div class="wp-block-jetpack-form-step-navigation__wrapper', $r, 1 );
 			} elseif ( $has_submit_button_block && ! $is_single_input_form ) {
 				// Place the error wrapper before the FIRST button block only to avoid duplicates (e.g., navigation buttons in multistep forms).
-				// Replace only the first occurrence.
+				// Replace only the first occurrence for both Jetpack and core Buttons blocks.
 				$r = preg_replace( '/<div class="wp-block-jetpack-button/', self::render_error_wrapper() . ' <div class="wp-block-jetpack-button', $r, 1 );
+				if ( str_contains( $r, 'wp-block-buttons' ) ) {
+					$r = preg_replace( '/<div class="wp-block-buttons/', self::render_error_wrapper() . ' <div class="wp-block-buttons', $r, 1 );
+				}
 			}
 
 			// In new versions of the contact form block the button is an inner block

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -1186,6 +1186,10 @@ class Contact_Form extends Contact_Form_Shortcode {
 				}
 			}
 
+			if ( $has_submit_button_block ) {
+				$r = self::prepare_submit_button( $r );
+			}
+
 			// In new versions of the contact form block the button is an inner block
 			// so the button does not need to be constructed server-side.
 			if ( ! $has_submit_button_block ) {
@@ -1262,6 +1266,48 @@ class Contact_Form extends Contact_Form_Shortcode {
 		 * @param string $r The contact form HTML.
 		 */
 		return apply_filters( 'jetpack_contact_form_html', $r );
+	}
+
+	/**
+	 * Prepare the submit button for the contact form.
+	 *
+	 * @param string $content - the content of the submit button.
+	 *
+	 * @return string - the prepared content of the submit button.
+	 */
+	private static function prepare_submit_button( $content ) {
+		if ( ! class_exists( \WP_HTML_Tag_Processor::class ) ) {
+			return $content;
+		}
+		$button_count = 0;
+		$p            = new \WP_HTML_Tag_Processor( $content );
+		while ( $p->next_tag(
+			array(
+				'tag_name' => 'button',
+				'type'     => 'submit',
+			)
+		) ) {
+			++$button_count;
+		}
+		if ( $button_count === 0 ) {
+			return $content;
+		}
+		$occurrence = 0;
+		$p          = new \WP_HTML_Tag_Processor( $content );
+		while ( $p->next_tag(
+			array(
+				'tag_name' => 'button',
+				'type'     => 'submit',
+			)
+		) ) {
+			if ( $occurrence === $button_count ) {
+				$p->set_attribute( 'data-wp-class--is-submitting', 'state.isSubmitting' );
+				$p->set_attribute( 'data-wp-bind--aria-disabled', 'state.isAriaDisabled' );
+				$p->set_attribute( 'data-wp-bind--disabled', 'state.isAriaDisabled' );
+			}
+			++$occurrence;
+		}
+		return $p->get_updated_html();
 	}
 
 	/**

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -1301,7 +1301,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 				'type'     => 'submit',
 			)
 		) ) {
-			if ( $occurrence === $button_count ) {
+			if ( $occurrence === $button_count - 1 ) {
 				$p->set_attribute( 'data-wp-class--is-submitting', 'state.isSubmitting' );
 				$p->set_attribute( 'data-wp-bind--aria-disabled', 'state.isAriaDisabled' );
 				$p->set_attribute( 'data-wp-bind--disabled', 'state.isAriaDisabled' );

--- a/projects/packages/forms/src/contact-form/class-util.php
+++ b/projects/packages/forms/src/contact-form/class-util.php
@@ -52,7 +52,12 @@ class Util {
                         <!-- wp:jetpack/field-name {"required":true} /-->
                         <!-- wp:jetpack/field-email {"required":true} /-->
                         <!-- wp:jetpack/field-textarea /-->
-                        <!-- wp:jetpack/button {"element":"button","text":"Contact Us","lock":{"remove":true}} /-->
+						<!-- wp:buttons {"lock":{"move":false,"remove":true}} -->
+							<div class="wp-block-buttons">
+							<!-- wp:button {"tagName":"button","type":"submit","className":"jetpack-form-submit-button"} -->
+								<div class="wp-block-button jetpack-form-submit-button"><button type="submit" class="wp-block-button__link wp-element-button">Contact us</button></div>
+							<!-- /wp:button --></div>
+						<!-- /wp:buttons -->
                     </div>
                     <!-- /wp:jetpack/contact-form -->',
 			),
@@ -65,7 +70,12 @@ class Util {
                         <!-- wp:jetpack/field-name {"required":true} /-->
                         <!-- wp:jetpack/field-email {"required":true} /-->
                         <!-- wp:jetpack/field-consent /-->
-                        <!-- wp:jetpack/button {"element":"button","text":"Subscribe","lock":{"remove":true}} /-->
+                        <!-- wp:buttons {"lock":{"move":false,"remove":true}} -->
+							<div class="wp-block-buttons">
+							<!-- wp:button {"tagName":"button","type":"submit","className":"jetpack-form-submit-button"} -->
+								<div class="wp-block-button jetpack-form-submit-button"><button type="submit" class="wp-block-button__link wp-element-button">Subscribe</button></div>
+							<!-- /wp:button --></div>
+						<!-- /wp:buttons -->
                     </div>
                     <!-- /wp:jetpack/contact-form -->',
 			),
@@ -79,7 +89,12 @@ class Util {
                         <!-- wp:jetpack/field-email {"required":true} /-->
                         <!-- wp:jetpack/field-radio {"label":"Attending?","required":true,"options":["Yes","No"]} /-->
                         <!-- wp:jetpack/field-textarea {"label":"Other Details"} /-->
-                        <!-- wp:jetpack/button {"element":"button","text":"Send RSVP","lock":{"remove":true}} /-->
+                        <!-- wp:buttons {"lock":{"move":false,"remove":true}} -->
+							<div class="wp-block-buttons">
+							<!-- wp:button {"tagName":"button","type":"submit","className":"jetpack-form-submit-button"} -->
+								<div class="wp-block-button jetpack-form-submit-button"><button type="submit" class="wp-block-button__link wp-element-button">Send RSVP</button></div>
+							<!-- /wp:button --></div>
+						<!-- /wp:buttons -->
                     </div>
                     <!-- /wp:jetpack/contact-form -->',
 			),
@@ -94,7 +109,12 @@ class Util {
                         <!-- wp:jetpack/field-telephone {"label":"Phone Number"} /-->
                         <!-- wp:jetpack/field-select {"label":"How did you hear about us?","options":["Search Engine","Social Media","TV","Radio","Friend or Family"]} /-->
                         <!-- wp:jetpack/field-textarea {"label":"Other Details"} /-->
-                        <!-- wp:jetpack/button {"element":"button","text":"Send","lock":{"remove":true}} /-->
+                        <!-- wp:buttons {"lock":{"move":false,"remove":true}} -->
+							<div class="wp-block-buttons">
+							<!-- wp:button {"tagName":"button","type":"submit","className":"jetpack-form-submit-button"} -->
+								<div class="wp-block-button jetpack-form-submit-button"><button type="submit" class="wp-block-button__link wp-element-button">Send</button></div>
+							<!-- /wp:button --></div>
+						<!-- /wp:buttons -->
                     </div>
                     <!-- /wp:jetpack/contact-form -->',
 			),
@@ -110,7 +130,12 @@ class Util {
                         <!-- wp:jetpack/field-date {"label":"Date","required":true} /-->
                         <!-- wp:jetpack/field-radio {"label":"Time","required":true,"options":["Morning","Afternoon"]} /-->
                         <!-- wp:jetpack/field-textarea {"label":"Notes"} /-->
-                        <!-- wp:jetpack/button {"element":"button","text":"Book Appointment","lock":{"remove":true}} /-->
+                        <!-- wp:buttons {"lock":{"move":false,"remove":true}} -->
+							<div class="wp-block-buttons">
+							<!-- wp:button {"tagName":"button","type":"submit","className":"jetpack-form-submit-button"} -->
+								<div class="wp-block-button jetpack-form-submit-button"><button type="submit" class="wp-block-button__link wp-element-button">Book Appointment</button></div>
+							<!-- /wp:button --></div>
+						<!-- /wp:buttons -->
                     </div>
                     <!-- /wp:jetpack/contact-form -->',
 			),
@@ -127,7 +152,12 @@ class Util {
 						<!-- wp:jetpack/input-rating /--></div>
 						<!-- /wp:jetpack/field-rating -->
                         <!-- wp:jetpack/field-textarea {"label":"How could we improve?"} /-->
-                        <!-- wp:jetpack/button {"element":"button","text":"Send Feedback","lock":{"remove":true}} /-->
+                        <!-- wp:buttons {"lock":{"move":false,"remove":true}} -->
+							<div class="wp-block-buttons">
+							<!-- wp:button {"tagName":"button","type":"submit","className":"jetpack-form-submit-button"} -->
+								<div class="wp-block-button jetpack-form-submit-button"><button type="submit" class="wp-block-button__link wp-element-button">Send Feedback</button></div>
+							<!-- /wp:button --></div>
+						<!-- /wp:buttons -->
                     </div>
                     <!-- /wp:jetpack/contact-form -->',
 			),
@@ -143,7 +173,12 @@ class Util {
 						<!-- wp:jetpack/field-telephone {"label":"Phone","id":"phone"} /-->
 						<!-- wp:jetpack/field-text {"label":"Company","id":"company"} /-->
 						<!-- wp:jetpack/field-text {"label":"Job Title","id":"title"} /-->
-						<!-- wp:jetpack/button {"element":"button","text":"Submit","lock":{"remove":true}} /-->
+						<!-- wp:buttons {"lock":{"move":false,"remove":true}} -->
+							<div class="wp-block-buttons">
+							<!-- wp:button {"tagName":"button","type":"submit","className":"jetpack-form-submit-button"} -->
+								<div class="wp-block-button jetpack-form-submit-button"><button type="submit" class="wp-block-button__link wp-element-button">Submit</button></div>
+							<!-- /wp:button --></div>
+						<!-- /wp:buttons -->
 					</div>
 					<!-- /wp:jetpack/contact-form -->',
 			),

--- a/projects/packages/forms/src/contact-form/class-util.php
+++ b/projects/packages/forms/src/contact-form/class-util.php
@@ -52,8 +52,8 @@ class Util {
                         <!-- wp:jetpack/field-name {"required":true} /-->
                         <!-- wp:jetpack/field-email {"required":true} /-->
                         <!-- wp:jetpack/field-textarea /-->
-						<!-- wp:button {"tagName":"button","type":"submit","className":"jetpack-form-submit-button"} -->
-							<div class="wp-block-button jetpack-form-submit-button"><button type="submit" class="wp-block-button__link wp-element-button">Contact us</button></div>
+						<!-- wp:button {"tagName":"button","type":"submit"} -->
+							<div class="wp-block-button"><button type="submit" class="wp-block-button__link wp-element-button">Contact us</button></div>
 						<!-- /wp:button -->
                     </div>
                     <!-- /wp:jetpack/contact-form -->',
@@ -67,8 +67,8 @@ class Util {
                         <!-- wp:jetpack/field-name {"required":true} /-->
                         <!-- wp:jetpack/field-email {"required":true} /-->
                         <!-- wp:jetpack/field-consent /-->
-						<!-- wp:button {"tagName":"button","type":"submit","className":"jetpack-form-submit-button"} -->
-							<div class="wp-block-button jetpack-form-submit-button"><button type="submit" class="wp-block-button__link wp-element-button">Subscribe</button></div>
+						<!-- wp:button {"tagName":"button","type":"submit"} -->
+							<div class="wp-block-button"><button type="submit" class="wp-block-button__link wp-element-button">Subscribe</button></div>
 						<!-- /wp:button -->
                     </div>
                     <!-- /wp:jetpack/contact-form -->',
@@ -83,8 +83,8 @@ class Util {
                         <!-- wp:jetpack/field-email {"required":true} /-->
                         <!-- wp:jetpack/field-radio {"label":"Attending?","required":true,"options":["Yes","No"]} /-->
                         <!-- wp:jetpack/field-textarea {"label":"Other Details"} /-->
-						<!-- wp:button {"tagName":"button","type":"submit","className":"jetpack-form-submit-button"} -->
-							<div class="wp-block-button jetpack-form-submit-button"><button type="submit" class="wp-block-button__link wp-element-button">Send RSVP</button></div>
+						<!-- wp:button {"tagName":"button","type":"submit"} -->
+							<div class="wp-block-button"><button type="submit" class="wp-block-button__link wp-element-button">Send RSVP</button></div>
 						<!-- /wp:button -->
                     </div>
                     <!-- /wp:jetpack/contact-form -->',
@@ -100,8 +100,8 @@ class Util {
                         <!-- wp:jetpack/field-telephone {"label":"Phone Number"} /-->
                         <!-- wp:jetpack/field-select {"label":"How did you hear about us?","options":["Search Engine","Social Media","TV","Radio","Friend or Family"]} /-->
                         <!-- wp:jetpack/field-textarea {"label":"Other Details"} /-->
-						<!-- wp:button {"tagName":"button","type":"submit","className":"jetpack-form-submit-button"} -->
-							<div class="wp-block-button jetpack-form-submit-button"><button type="submit" class="wp-block-button__link wp-element-button">Send</button></div>
+						<!-- wp:button {"tagName":"button","type":"submit"} -->
+							<div class="wp-block-button"><button type="submit" class="wp-block-button__link wp-element-button">Send</button></div>
 						<!-- /wp:button -->
                     </div>
                     <!-- /wp:jetpack/contact-form -->',
@@ -118,8 +118,8 @@ class Util {
                         <!-- wp:jetpack/field-date {"label":"Date","required":true} /-->
                         <!-- wp:jetpack/field-radio {"label":"Time","required":true,"options":["Morning","Afternoon"]} /-->
                         <!-- wp:jetpack/field-textarea {"label":"Notes"} /-->
-						<!-- wp:button {"tagName":"button","type":"submit","className":"jetpack-form-submit-button"} -->
-							<div class="wp-block-button jetpack-form-submit-button"><button type="submit" class="wp-block-button__link wp-element-button">Book Appointment</button></div>
+						<!-- wp:button {"tagName":"button","type":"submit"} -->
+							<div class="wp-block-button"><button type="submit" class="wp-block-button__link wp-element-button">Book Appointment</button></div>
 						<!-- /wp:button -->
                     </div>
                     <!-- /wp:jetpack/contact-form -->',
@@ -137,8 +137,8 @@ class Util {
 						<!-- wp:jetpack/input-rating /--></div>
 						<!-- /wp:jetpack/field-rating -->
                         <!-- wp:jetpack/field-textarea {"label":"How could we improve?"} /-->
-						<!-- wp:button {"tagName":"button","type":"submit","className":"jetpack-form-submit-button"} -->
-							<div class="wp-block-button jetpack-form-submit-button"><button type="submit" class="wp-block-button__link wp-element-button">Send Feedback</button></div>
+						<!-- wp:button {"tagName":"button","type":"submit"} -->
+							<div class="wp-block-button"><button type="submit" class="wp-block-button__link wp-element-button">Send Feedback</button></div>
 						<!-- /wp:button -->
                     </div>
                     <!-- /wp:jetpack/contact-form -->',
@@ -155,8 +155,8 @@ class Util {
 						<!-- wp:jetpack/field-telephone {"label":"Phone","id":"phone"} /-->
 						<!-- wp:jetpack/field-text {"label":"Company","id":"company"} /-->
 						<!-- wp:jetpack/field-text {"label":"Job Title","id":"title"} /-->
-						<!-- wp:button {"tagName":"button","type":"submit","className":"jetpack-form-submit-button"} -->
-							<div class="wp-block-button jetpack-form-submit-button"><button type="submit" class="wp-block-button__link wp-element-button">Submit</button></div>
+						<!-- wp:button {"tagName":"button","type":"submit"} -->
+							<div class="wp-block-button"><button type="submit" class="wp-block-button__link wp-element-button">Submit</button></div>
 						<!-- /wp:button -->
 					</div>
 					<!-- /wp:jetpack/contact-form -->',

--- a/projects/packages/forms/src/contact-form/class-util.php
+++ b/projects/packages/forms/src/contact-form/class-util.php
@@ -52,12 +52,9 @@ class Util {
                         <!-- wp:jetpack/field-name {"required":true} /-->
                         <!-- wp:jetpack/field-email {"required":true} /-->
                         <!-- wp:jetpack/field-textarea /-->
-						<!-- wp:buttons {"lock":{"move":false,"remove":true}} -->
-							<div class="wp-block-buttons">
-							<!-- wp:button {"tagName":"button","type":"submit","className":"jetpack-form-submit-button"} -->
-								<div class="wp-block-button jetpack-form-submit-button"><button type="submit" class="wp-block-button__link wp-element-button">Contact us</button></div>
-							<!-- /wp:button --></div>
-						<!-- /wp:buttons -->
+						<!-- wp:button {"tagName":"button","type":"submit","className":"jetpack-form-submit-button"} -->
+							<div class="wp-block-button jetpack-form-submit-button"><button type="submit" class="wp-block-button__link wp-element-button">Contact us</button></div>
+						<!-- /wp:button -->
                     </div>
                     <!-- /wp:jetpack/contact-form -->',
 			),
@@ -70,12 +67,9 @@ class Util {
                         <!-- wp:jetpack/field-name {"required":true} /-->
                         <!-- wp:jetpack/field-email {"required":true} /-->
                         <!-- wp:jetpack/field-consent /-->
-                        <!-- wp:buttons {"lock":{"move":false,"remove":true}} -->
-							<div class="wp-block-buttons">
-							<!-- wp:button {"tagName":"button","type":"submit","className":"jetpack-form-submit-button"} -->
-								<div class="wp-block-button jetpack-form-submit-button"><button type="submit" class="wp-block-button__link wp-element-button">Subscribe</button></div>
-							<!-- /wp:button --></div>
-						<!-- /wp:buttons -->
+						<!-- wp:button {"tagName":"button","type":"submit","className":"jetpack-form-submit-button"} -->
+							<div class="wp-block-button jetpack-form-submit-button"><button type="submit" class="wp-block-button__link wp-element-button">Subscribe</button></div>
+						<!-- /wp:button -->
                     </div>
                     <!-- /wp:jetpack/contact-form -->',
 			),
@@ -89,12 +83,9 @@ class Util {
                         <!-- wp:jetpack/field-email {"required":true} /-->
                         <!-- wp:jetpack/field-radio {"label":"Attending?","required":true,"options":["Yes","No"]} /-->
                         <!-- wp:jetpack/field-textarea {"label":"Other Details"} /-->
-                        <!-- wp:buttons {"lock":{"move":false,"remove":true}} -->
-							<div class="wp-block-buttons">
-							<!-- wp:button {"tagName":"button","type":"submit","className":"jetpack-form-submit-button"} -->
-								<div class="wp-block-button jetpack-form-submit-button"><button type="submit" class="wp-block-button__link wp-element-button">Send RSVP</button></div>
-							<!-- /wp:button --></div>
-						<!-- /wp:buttons -->
+						<!-- wp:button {"tagName":"button","type":"submit","className":"jetpack-form-submit-button"} -->
+							<div class="wp-block-button jetpack-form-submit-button"><button type="submit" class="wp-block-button__link wp-element-button">Send RSVP</button></div>
+						<!-- /wp:button -->
                     </div>
                     <!-- /wp:jetpack/contact-form -->',
 			),
@@ -109,12 +100,9 @@ class Util {
                         <!-- wp:jetpack/field-telephone {"label":"Phone Number"} /-->
                         <!-- wp:jetpack/field-select {"label":"How did you hear about us?","options":["Search Engine","Social Media","TV","Radio","Friend or Family"]} /-->
                         <!-- wp:jetpack/field-textarea {"label":"Other Details"} /-->
-                        <!-- wp:buttons {"lock":{"move":false,"remove":true}} -->
-							<div class="wp-block-buttons">
-							<!-- wp:button {"tagName":"button","type":"submit","className":"jetpack-form-submit-button"} -->
-								<div class="wp-block-button jetpack-form-submit-button"><button type="submit" class="wp-block-button__link wp-element-button">Send</button></div>
-							<!-- /wp:button --></div>
-						<!-- /wp:buttons -->
+						<!-- wp:button {"tagName":"button","type":"submit","className":"jetpack-form-submit-button"} -->
+							<div class="wp-block-button jetpack-form-submit-button"><button type="submit" class="wp-block-button__link wp-element-button">Send</button></div>
+						<!-- /wp:button -->
                     </div>
                     <!-- /wp:jetpack/contact-form -->',
 			),
@@ -130,12 +118,9 @@ class Util {
                         <!-- wp:jetpack/field-date {"label":"Date","required":true} /-->
                         <!-- wp:jetpack/field-radio {"label":"Time","required":true,"options":["Morning","Afternoon"]} /-->
                         <!-- wp:jetpack/field-textarea {"label":"Notes"} /-->
-                        <!-- wp:buttons {"lock":{"move":false,"remove":true}} -->
-							<div class="wp-block-buttons">
-							<!-- wp:button {"tagName":"button","type":"submit","className":"jetpack-form-submit-button"} -->
-								<div class="wp-block-button jetpack-form-submit-button"><button type="submit" class="wp-block-button__link wp-element-button">Book Appointment</button></div>
-							<!-- /wp:button --></div>
-						<!-- /wp:buttons -->
+						<!-- wp:button {"tagName":"button","type":"submit","className":"jetpack-form-submit-button"} -->
+							<div class="wp-block-button jetpack-form-submit-button"><button type="submit" class="wp-block-button__link wp-element-button">Book Appointment</button></div>
+						<!-- /wp:button -->
                     </div>
                     <!-- /wp:jetpack/contact-form -->',
 			),
@@ -152,12 +137,9 @@ class Util {
 						<!-- wp:jetpack/input-rating /--></div>
 						<!-- /wp:jetpack/field-rating -->
                         <!-- wp:jetpack/field-textarea {"label":"How could we improve?"} /-->
-                        <!-- wp:buttons {"lock":{"move":false,"remove":true}} -->
-							<div class="wp-block-buttons">
-							<!-- wp:button {"tagName":"button","type":"submit","className":"jetpack-form-submit-button"} -->
-								<div class="wp-block-button jetpack-form-submit-button"><button type="submit" class="wp-block-button__link wp-element-button">Send Feedback</button></div>
-							<!-- /wp:button --></div>
-						<!-- /wp:buttons -->
+						<!-- wp:button {"tagName":"button","type":"submit","className":"jetpack-form-submit-button"} -->
+							<div class="wp-block-button jetpack-form-submit-button"><button type="submit" class="wp-block-button__link wp-element-button">Send Feedback</button></div>
+						<!-- /wp:button -->
                     </div>
                     <!-- /wp:jetpack/contact-form -->',
 			),
@@ -173,12 +155,9 @@ class Util {
 						<!-- wp:jetpack/field-telephone {"label":"Phone","id":"phone"} /-->
 						<!-- wp:jetpack/field-text {"label":"Company","id":"company"} /-->
 						<!-- wp:jetpack/field-text {"label":"Job Title","id":"title"} /-->
-						<!-- wp:buttons {"lock":{"move":false,"remove":true}} -->
-							<div class="wp-block-buttons">
-							<!-- wp:button {"tagName":"button","type":"submit","className":"jetpack-form-submit-button"} -->
-								<div class="wp-block-button jetpack-form-submit-button"><button type="submit" class="wp-block-button__link wp-element-button">Submit</button></div>
-							<!-- /wp:button --></div>
-						<!-- /wp:buttons -->
+						<!-- wp:button {"tagName":"button","type":"submit","className":"jetpack-form-submit-button"} -->
+							<div class="wp-block-button jetpack-form-submit-button"><button type="submit" class="wp-block-button__link wp-element-button">Submit</button></div>
+						<!-- /wp:button -->
 					</div>
 					<!-- /wp:jetpack/contact-form -->',
 			),

--- a/projects/packages/forms/src/contact-form/css/grunion.scss
+++ b/projects/packages/forms/src/contact-form/css/grunion.scss
@@ -1324,7 +1324,7 @@ on production builds, the attributes are being reordered, causing side-effects
 	display: none;
 }
 
-.jetpack-form-submit-button.is-submitting button::after {
+.jetpack-form-submit-button button.is-submitting::after {
 	content: "";
 	display: inline-block;
 	width: 1em;

--- a/projects/packages/forms/src/contact-form/css/grunion.scss
+++ b/projects/packages/forms/src/contact-form/css/grunion.scss
@@ -48,6 +48,7 @@
 	display: block;
 }
 
+.contact-form .wp-block-button:has(button.is-hidden),
 .contact-form .wp-block-jetpack-button:has(button.is-hidden) {
 	display: none;
 }
@@ -361,7 +362,7 @@ that needs to mimic the input element styles */
 	gap: var(--wp--style--block-gap, 1.5rem);
 }
 
-.wp-block-jetpack-contact-form > *:not(.wp-block-jetpack-button) {
+.wp-block-jetpack-contact-form > *:not(.wp-block-jetpack-button,.wp-block-button) {
 	flex: 0 0 100%;
 	box-sizing: border-box;
 }
@@ -388,12 +389,15 @@ that needs to mimic the input element styles */
 	&:has(.contact-form__input-error.has-errors) {
 		margin-bottom: calc(var(--wp--style--block-gap, 1.5rem) * 2);
 
-		.wp-block-jetpack-button.wp-block-button {
+		// buttons on single input form need to be pushed down to avoid overlap
+		// but only if they are not animated or outlined.
+		:is(.wp-block-button.wp-block-button, .wp-block-jetpack-button.wp-block-button):not(.is-style-animated *):not(.is-style-outlined *) {
 			margin-top: var(--wp--style--block-gap, 1.5rem);
 		}
 	}
 }
 
+.wp-block-jetpack-contact-form .wp-block-button,
 .wp-block-jetpack-contact-form .wp-block-jetpack-button {
 	min-height: var(--jetpack--contact-form--input-height, auto);
 	align-self: flex-end;
@@ -468,6 +472,7 @@ that needs to mimic the input element styles */
 		max-width: none;
 	}
 
+	.wp-block-jetpack-contact-form .wp-block-button,
 	.wp-block-jetpack-contact-form .wp-block-jetpack-button {
 		flex-basis: 100%;
 

--- a/projects/packages/forms/src/contact-form/css/grunion.scss
+++ b/projects/packages/forms/src/contact-form/css/grunion.scss
@@ -1331,7 +1331,7 @@ on production builds, the attributes are being reordered, causing side-effects
 	display: none;
 }
 
-.jetpack-form-submit-button button.is-submitting::after {
+.jetpack-form-submit-button:not(.wp-block-button) button.is-submitting::after {
 	content: "";
 	display: inline-block;
 	width: 1em;

--- a/projects/packages/forms/src/contact-form/css/grunion.scss
+++ b/projects/packages/forms/src/contact-form/css/grunion.scss
@@ -893,7 +893,6 @@ on production builds, the attributes are being reordered, causing side-effects
 .contact-form .is-style-animated .grunion-field-wrap:not(.no-label) > input:not([type="checkbox"]):not([type="radio"]):not([type="range"]),
 .contact-form .is-style-animated .grunion-field-wrap:not(.no-label) > textarea,
 .contact-form .is-style-animated .grunion-field-wrap:not(.no-label) select:not(.jetpack-field__input-element) {
-	padding-top: 1.4em;
 	padding-left: var(--field-padding);
 	padding-right: var(--field-padding);
 }

--- a/projects/packages/forms/src/contact-form/css/grunion.scss
+++ b/projects/packages/forms/src/contact-form/css/grunion.scss
@@ -1336,10 +1336,10 @@ on production builds, the attributes are being reordered, causing side-effects
 	border: 2px solid currentColor;
 	border-right-color: transparent;
 	border-radius: 50%;
-	animation: jp-spinner 0.75s linear infinite;
+	animation: jp-forms-submit-spinner 0.75s linear infinite;
 }
 
-@keyframes jp-spinner {
+@keyframes jp-forms-submit-spinner {
 
 	to {
 		transform: rotate(360deg);

--- a/projects/packages/forms/src/contact-form/css/grunion.scss
+++ b/projects/packages/forms/src/contact-form/css/grunion.scss
@@ -434,6 +434,7 @@ that needs to mimic the input element styles */
 	}
 }
 
+.wp-block-jetpack-contact-form .wp-block-button__width-25,
 .wp-block-jetpack-contact-form .grunion-field-width-25-wrap {
 	flex: 1 1 calc(25% - calc(var(--wp--style--block-gap, 1.5rem) * 1));
 	max-width: 25%;
@@ -444,11 +445,13 @@ that needs to mimic the input element styles */
 	max-width: 33.33%;
 }
 
+.wp-block-jetpack-contact-form .wp-block-button__width-50,
 .wp-block-jetpack-contact-form .grunion-field-width-50-wrap {
 	flex: 1 1 calc(50% - calc(var(--wp--style--block-gap, 1.5rem) * 1));
 	max-width: 50%;
 }
 
+.wp-block-jetpack-contact-form .wp-block-button__width-75,
 .wp-block-jetpack-contact-form .grunion-field-width-75-wrap {
 	flex: 1 1 calc(75% - calc(var(--wp--style--block-gap, 1.5rem) * 1));
 	max-width: 75%;

--- a/projects/packages/forms/src/contact-form/css/grunion.scss
+++ b/projects/packages/forms/src/contact-form/css/grunion.scss
@@ -1331,16 +1331,27 @@ on production builds, the attributes are being reordered, causing side-effects
 	display: none;
 }
 
-.jetpack-form-submit-button:not(.wp-block-button) button.is-submitting::after {
-	content: "";
-	display: inline-block;
-	width: 1em;
-	height: 1em;
-	margin-left: 0.5em;
-	border: 2px solid currentColor;
-	border-right-color: transparent;
-	border-radius: 50%;
-	animation: jp-forms-submit-spinner 0.75s linear infinite;
+// hide spinner for any legacy jetpack button
+.contact-form .wp-block-jetpack-button .is-submitting .spinner {
+	display: none;
+}
+
+// use new ::after approach for animated spinner inside forms
+.contact-form .wp-block-jetpack-button button[type="submit"].is-submitting:last-of-type,
+.contact-form .wp-block-button button[type="submit"].is-submitting:last-of-type {
+
+	&::after {
+
+		content: "";
+		display: inline-block;
+		width: 1em;
+		height: 1em;
+		margin-left: 0.5em;
+		border: 2px solid currentColor;
+		border-right-color: transparent;
+		border-radius: 50%;
+		animation: jp-forms-submit-spinner 0.75s linear infinite;
+	}
 }
 
 @keyframes jp-forms-submit-spinner {

--- a/projects/packages/forms/src/contact-form/css/grunion.scss
+++ b/projects/packages/forms/src/contact-form/css/grunion.scss
@@ -1324,7 +1324,6 @@ on production builds, the attributes are being reordered, causing side-effects
 	display: none;
 }
 
-.jetpack-form-submit-button.is-submitting .wp-block-button__link::after,
 .jetpack-form-submit-button.is-submitting button::after {
 	content: "";
 	display: inline-block;

--- a/projects/packages/forms/src/contact-form/css/grunion.scss
+++ b/projects/packages/forms/src/contact-form/css/grunion.scss
@@ -1323,3 +1323,23 @@ on production builds, the attributes are being reordered, causing side-effects
 .contact-form-ajax-submission:not(.submission-success) {
 	display: none;
 }
+
+.jetpack-form-submit-button.is-submitting .wp-block-button__link::after,
+.jetpack-form-submit-button.is-submitting button::after {
+	content: "";
+	display: inline-block;
+	width: 1em;
+	height: 1em;
+	margin-left: 0.5em;
+	border: 2px solid currentColor;
+	border-right-color: transparent;
+	border-radius: 50%;
+	animation: jp-spinner 0.75s linear infinite;
+}
+
+@keyframes jp-spinner {
+
+	to {
+		transform: rotate(360deg);
+	}
+}

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Block_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Block_Test.php
@@ -260,7 +260,9 @@ class Contact_Form_Block_Test extends BaseTestCase {
 		// Use reflection to access private method
 		$reflection   = new \ReflectionClass( Contact_Form_Block::class );
 		$count_method = $reflection->getMethod( 'count_form_steps_in_block' );
-		$count_method->setAccessible( true );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$count_method->setAccessible( true );
+		}
 
 		$result = $count_method->invoke( null, $block_structure );
 		$this->assertEquals( $expected_steps, $result );
@@ -401,7 +403,9 @@ class Contact_Form_Block_Test extends BaseTestCase {
 		// Use reflection to set the private static property for testing
 		$reflection          = new \ReflectionClass( Contact_Form_Block::class );
 		$step_count_property = $reflection->getProperty( 'form_step_count' );
-		$step_count_property->setAccessible( true );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$step_count_property->setAccessible( true );
+		}
 		$step_count_property->setValue( null, 5 );
 
 		$result = Contact_Form_Block::get_form_step_count();

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Block_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Block_Test.php
@@ -167,7 +167,7 @@ class Contact_Form_Block_Test extends BaseTestCase {
 	 */
 	public static function data_provider_test_render_submit_button() {
 		// Skip HTML Tag Processor tests if the class doesn't exist (WordPress < 6.2)
-		if ( ! class_exists( '\WP_HTML_Tag_Processor' ) ) {
+		if ( ! class_exists( \WP_HTML_Tag_Processor::class ) ) {
 			return array(
 				'no html tag processor' => array(
 					'<button>Submit</button>',

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Block_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Block_Test.php
@@ -150,4 +150,283 @@ class Contact_Form_Block_Test extends BaseTestCase {
 			),
 		);
 	}
+
+	/**
+	 * Test that ::render_submit_button adds interactivity attributes to submit buttons.
+	 *
+	 * @dataProvider data_provider_test_render_submit_button
+	 */
+	#[DataProvider( 'data_provider_test_render_submit_button' )]
+	public function test_render_submit_button( $content, $parsed_block, $expected ) {
+		$result = Contact_Form_Block::render_submit_button( $content, $parsed_block );
+		$this->assertEquals( $expected, $result );
+	}
+
+	/**
+	 * Data provider for test_render_submit_button.
+	 */
+	public static function data_provider_test_render_submit_button() {
+		// Skip HTML Tag Processor tests if the class doesn't exist (WordPress < 6.2)
+		if ( ! class_exists( '\WP_HTML_Tag_Processor' ) ) {
+			return array(
+				'no html tag processor' => array(
+					'<button>Submit</button>',
+					array( 'attrs' => array( 'className' => 'jetpack-form-submit-button' ) ),
+					'<button>Submit</button>',
+				),
+			);
+		}
+
+		return array(
+			'submit button with jetpack class'  => array(
+				'<button class="wp-block-button__link jetpack-form-submit-button">Submit</button>',
+				array( 'attrs' => array( 'className' => 'jetpack-form-submit-button' ) ),
+				'<button data-wp-bind--aria-disabled="state.isAriaDisabled" data-wp-class--is-submitting="state.isSubmitting" class="wp-block-button__link jetpack-form-submit-button">Submit</button>',
+			),
+			'button without jetpack class'      => array(
+				'<button class="wp-block-button__link">Submit</button>',
+				array( 'attrs' => array( 'className' => 'wp-block-button__link' ) ),
+				'<button class="wp-block-button__link">Submit</button>',
+			),
+			'submit button with multiple classes including jetpack' => array(
+				'<button class="my-custom-class jetpack-form-submit-button another-class">Submit</button>',
+				array( 'attrs' => array( 'className' => 'my-custom-class jetpack-form-submit-button another-class' ) ),
+				'<button data-wp-bind--aria-disabled="state.isAriaDisabled" data-wp-class--is-submitting="state.isSubmitting" class="my-custom-class jetpack-form-submit-button another-class">Submit</button>',
+			),
+			'block with no className attribute' => array(
+				'<button>Submit</button>',
+				array( 'attrs' => array() ),
+				'<button>Submit</button>',
+			),
+			'block with empty className'        => array(
+				'<button>Submit</button>',
+				array( 'attrs' => array( 'className' => '' ) ),
+				'<button>Submit</button>',
+			),
+			'content without button tag'        => array(
+				'<div class="jetpack-form-submit-button">Not a button</div>',
+				array( 'attrs' => array( 'className' => 'jetpack-form-submit-button' ) ),
+				'<div class="jetpack-form-submit-button">Not a button</div>',
+			),
+		);
+	}
+
+	/**
+	 * Test that ::render_wrapped_html_block wraps HTML blocks with jetpack form parent.
+	 */
+	public function test_render_wrapped_html_block() {
+		$content = '<p>Some HTML content</p>';
+
+		// Test with hasJPFormParent flag
+		$parsed_block_with_parent = array( 'hasJPFormParent' => true );
+		$result                   = Contact_Form_Block::render_wrapped_html_block( $content, $parsed_block_with_parent );
+		$this->assertEquals( '<div><p>Some HTML content</p></div>', $result );
+
+		// Test without hasJPFormParent flag
+		$parsed_block_without_parent = array();
+		$result                      = Contact_Form_Block::render_wrapped_html_block( $content, $parsed_block_without_parent );
+		$this->assertEquals( '<p>Some HTML content</p>', $result );
+
+		// Test with hasJPFormParent set to false
+		$parsed_block_false_parent = array( 'hasJPFormParent' => false );
+		$result                    = Contact_Form_Block::render_wrapped_html_block( $content, $parsed_block_false_parent );
+		$this->assertEquals( '<p>Some HTML content</p>', $result );
+	}
+
+	/**
+	 * Test that ::register_feature adds multistep-form feature.
+	 */
+	public function test_register_feature() {
+		$input_features = array( 'existing-feature' => true );
+
+		// We can't easily mock static methods, so we'll test the structure
+		$result = Contact_Form_Block::register_feature( $input_features );
+
+		// Should preserve existing features
+		$this->assertTrue( $result['existing-feature'] );
+
+		// Should add multistep-form feature
+		$this->assertArrayHasKey( 'multistep-form', $result );
+		$this->assertIsBool( $result['multistep-form'] );
+	}
+
+	/**
+	 * Test form step counting functionality.
+	 *
+	 * @dataProvider data_provider_test_form_step_counting
+	 */
+	#[DataProvider( 'data_provider_test_form_step_counting' )]
+	public function test_form_step_counting( $block_structure, $expected_steps ) {
+		// Use reflection to access private method
+		$reflection   = new \ReflectionClass( Contact_Form_Block::class );
+		$count_method = $reflection->getMethod( 'count_form_steps_in_block' );
+		$count_method->setAccessible( true );
+
+		$result = $count_method->invoke( null, $block_structure );
+		$this->assertEquals( $expected_steps, $result );
+	}
+
+	/**
+	 * Data provider for form step counting tests.
+	 */
+	public static function data_provider_test_form_step_counting() {
+		return array(
+			'no inner blocks'                => array(
+				array(
+					'blockName'   => 'jetpack/contact-form',
+					'innerBlocks' => array(),
+				),
+				0,
+			),
+			'single form step'               => array(
+				array(
+					'blockName'   => 'jetpack/contact-form',
+					'innerBlocks' => array(
+						array(
+							'blockName'   => 'jetpack/form-step',
+							'innerBlocks' => array(),
+						),
+					),
+				),
+				1,
+			),
+			'multiple form steps'            => array(
+				array(
+					'blockName'   => 'jetpack/contact-form',
+					'innerBlocks' => array(
+						array(
+							'blockName'   => 'jetpack/form-step',
+							'innerBlocks' => array(),
+						),
+						array(
+							'blockName'   => 'jetpack/form-step',
+							'innerBlocks' => array(),
+						),
+						array(
+							'blockName'   => 'jetpack/form-step',
+							'innerBlocks' => array(),
+						),
+					),
+				),
+				3,
+			),
+			'nested form steps in container' => array(
+				array(
+					'blockName'   => 'jetpack/contact-form',
+					'innerBlocks' => array(
+						array(
+							'blockName'   => 'jetpack/form-step-container',
+							'innerBlocks' => array(
+								array(
+									'blockName'   => 'jetpack/form-step',
+									'innerBlocks' => array(),
+								),
+								array(
+									'blockName'   => 'jetpack/form-step',
+									'innerBlocks' => array(),
+								),
+							),
+						),
+					),
+				),
+				2,
+			),
+			'mixed blocks with form steps'   => array(
+				array(
+					'blockName'   => 'jetpack/contact-form',
+					'innerBlocks' => array(
+						array(
+							'blockName'   => 'jetpack/field-text',
+							'innerBlocks' => array(),
+						),
+						array(
+							'blockName'   => 'jetpack/form-step',
+							'innerBlocks' => array(),
+						),
+						array(
+							'blockName'   => 'jetpack/field-email',
+							'innerBlocks' => array(),
+						),
+						array(
+							'blockName'   => 'jetpack/form-step',
+							'innerBlocks' => array(),
+						),
+					),
+				),
+				2,
+			),
+		);
+	}
+
+	/**
+	 * Test pre_render_contact_form hook processing.
+	 */
+	public function test_pre_render_contact_form() {
+		$contact_form_block = array(
+			'blockName'   => 'jetpack/contact-form',
+			'innerBlocks' => array(
+				array(
+					'blockName'   => 'jetpack/form-step',
+					'innerBlocks' => array(),
+				),
+				array(
+					'blockName'   => 'jetpack/form-step',
+					'innerBlocks' => array(),
+				),
+			),
+		);
+
+		$other_block = array(
+			'blockName'   => 'core/paragraph',
+			'innerBlocks' => array(),
+		);
+
+		// Test that it returns null for non-contact-form blocks
+		$result = Contact_Form_Block::pre_render_contact_form( null, $other_block );
+		$this->assertNull( $result );
+
+		// Test that it processes contact form blocks and returns null (lets normal rendering continue)
+		$result = Contact_Form_Block::pre_render_contact_form( null, $contact_form_block );
+		$this->assertNull( $result );
+
+		// Test that step count is updated after processing
+		$step_count = Contact_Form_Block::get_form_step_count();
+		$this->assertEquals( 2, $step_count );
+	}
+
+	/**
+	 * Test get_form_step_count method.
+	 */
+	public function test_get_form_step_count() {
+		// Use reflection to set the private static property for testing
+		$reflection          = new \ReflectionClass( Contact_Form_Block::class );
+		$step_count_property = $reflection->getProperty( 'form_step_count' );
+		$step_count_property->setAccessible( true );
+		$step_count_property->setValue( null, 5 );
+
+		$result = Contact_Form_Block::get_form_step_count();
+		$this->assertEquals( 5, $result );
+
+		// Reset to default
+		$step_count_property->setValue( null, 1 );
+	}
+
+	/**
+	 * Test can_manage_block method behavior.
+	 */
+	public function test_can_manage_block() {
+		// Test the filter override
+		add_filter( 'jetpack_contact_form_can_manage_block', '__return_true' );
+		$this->assertTrue( Contact_Form_Block::can_manage_block() );
+		remove_filter( 'jetpack_contact_form_can_manage_block', '__return_true' );
+
+		add_filter( 'jetpack_contact_form_can_manage_block', '__return_false' );
+
+		// When not in Jetpack context (class doesn't exist), should return true
+		if ( ! class_exists( 'Jetpack' ) ) {
+			$this->assertTrue( Contact_Form_Block::can_manage_block() );
+		}
+
+		remove_filter( 'jetpack_contact_form_can_manage_block', '__return_false' );
+	}
 }

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Block_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Block_Test.php
@@ -152,66 +152,6 @@ class Contact_Form_Block_Test extends BaseTestCase {
 	}
 
 	/**
-	 * Test that ::render_submit_button adds interactivity attributes to submit buttons.
-	 *
-	 * @dataProvider data_provider_test_render_submit_button
-	 */
-	#[DataProvider( 'data_provider_test_render_submit_button' )]
-	public function test_render_submit_button( $content, $parsed_block, $expected ) {
-		$result = Contact_Form_Block::render_submit_button( $content, $parsed_block );
-		$this->assertEquals( $expected, $result );
-	}
-
-	/**
-	 * Data provider for test_render_submit_button.
-	 */
-	public static function data_provider_test_render_submit_button() {
-		// Skip HTML Tag Processor tests if the class doesn't exist (WordPress < 6.2)
-		if ( ! class_exists( \WP_HTML_Tag_Processor::class ) ) {
-			return array(
-				'no html tag processor' => array(
-					'<button>Submit</button>',
-					array( 'attrs' => array( 'className' => 'jetpack-form-submit-button' ) ),
-					'<button>Submit</button>',
-				),
-			);
-		}
-
-		return array(
-			'submit button with jetpack class'  => array(
-				'<button class="wp-block-button__link jetpack-form-submit-button">Submit</button>',
-				array( 'attrs' => array( 'className' => 'jetpack-form-submit-button' ) ),
-				'<button data-wp-bind--aria-disabled="state.isAriaDisabled" data-wp-bind--disabled="state.isAriaDisabled" data-wp-class--is-submitting="state.isSubmitting" class="wp-block-button__link jetpack-form-submit-button">Submit</button>',
-			),
-			'button without jetpack class'      => array(
-				'<button class="wp-block-button__link">Submit</button>',
-				array( 'attrs' => array( 'className' => 'wp-block-button__link' ) ),
-				'<button class="wp-block-button__link">Submit</button>',
-			),
-			'submit button with multiple classes including jetpack' => array(
-				'<button class="my-custom-class jetpack-form-submit-button another-class">Submit</button>',
-				array( 'attrs' => array( 'className' => 'my-custom-class jetpack-form-submit-button another-class' ) ),
-				'<button data-wp-bind--aria-disabled="state.isAriaDisabled" data-wp-bind--disabled="state.isAriaDisabled" data-wp-class--is-submitting="state.isSubmitting" class="my-custom-class jetpack-form-submit-button another-class">Submit</button>',
-			),
-			'block with no className attribute' => array(
-				'<button>Submit</button>',
-				array( 'attrs' => array() ),
-				'<button>Submit</button>',
-			),
-			'block with empty className'        => array(
-				'<button>Submit</button>',
-				array( 'attrs' => array( 'className' => '' ) ),
-				'<button>Submit</button>',
-			),
-			'content without button tag'        => array(
-				'<div class="jetpack-form-submit-button">Not a button</div>',
-				array( 'attrs' => array( 'className' => 'jetpack-form-submit-button' ) ),
-				'<div class="jetpack-form-submit-button">Not a button</div>',
-			),
-		);
-	}
-
-	/**
 	 * Test that ::render_wrapped_html_block wraps HTML blocks with jetpack form parent.
 	 */
 	public function test_render_wrapped_html_block() {

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Block_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Block_Test.php
@@ -181,7 +181,7 @@ class Contact_Form_Block_Test extends BaseTestCase {
 			'submit button with jetpack class'  => array(
 				'<button class="wp-block-button__link jetpack-form-submit-button">Submit</button>',
 				array( 'attrs' => array( 'className' => 'jetpack-form-submit-button' ) ),
-				'<button data-wp-bind--aria-disabled="state.isAriaDisabled" data-wp-class--is-submitting="state.isSubmitting" class="wp-block-button__link jetpack-form-submit-button">Submit</button>',
+				'<button data-wp-bind--aria-disabled="state.isAriaDisabled" data-wp-bind--disabled="state.isAriaDisabled" data-wp-class--is-submitting="state.isSubmitting" class="wp-block-button__link jetpack-form-submit-button">Submit</button>',
 			),
 			'button without jetpack class'      => array(
 				'<button class="wp-block-button__link">Submit</button>',
@@ -191,7 +191,7 @@ class Contact_Form_Block_Test extends BaseTestCase {
 			'submit button with multiple classes including jetpack' => array(
 				'<button class="my-custom-class jetpack-form-submit-button another-class">Submit</button>',
 				array( 'attrs' => array( 'className' => 'my-custom-class jetpack-form-submit-button another-class' ) ),
-				'<button data-wp-bind--aria-disabled="state.isAriaDisabled" data-wp-class--is-submitting="state.isSubmitting" class="my-custom-class jetpack-form-submit-button another-class">Submit</button>',
+				'<button data-wp-bind--aria-disabled="state.isAriaDisabled" data-wp-bind--disabled="state.isAriaDisabled" data-wp-class--is-submitting="state.isSubmitting" class="my-custom-class jetpack-form-submit-button another-class">Submit</button>',
 			),
 			'block with no className attribute' => array(
 				'<button>Submit</button>',


### PR DESCRIPTION
This is a takeover from https://github.com/Automattic/jetpack/pull/45007 

Resolves FORMS-83

## Proposed changes:
Following the original PR, this is a simpler approach just using core/button to replace jetpack/button

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
None

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

(verbatim from original PR)

1. **Existing post smoke-test**  
   * Open a post containing a Contact Form created **before** this patch (uses Jetpack Button).  
   * Confirm there are no editor errors; publish / update.  
   * View front-end and submit the form – it should behave as it always did.

2. **New form**  
   * Insert a fresh **Contact Form** block.  
   * Verify the submit control is a Core Button in a Core Buttons wrapper.  
   * Publish and submit on the front-end – spinner, disable state and success/error handling should work.

3. **Variations**  
   * Insert each Contact-Form variation (RSVP, Registration, Feedback, etc.).  
   * Confirm each uses a Core Button and submits correctly.

4. **Editor layout**  
   * Editing experience should respect the different core/block options when saving.