### PR TITLE
Forms: Set "from" field as primary on dashboard

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-dashboard-primary-field
+++ b/projects/packages/forms/changelog/fix-forms-dashboard-primary-field
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: Set "from" field as primary on dashboard

--- a/projects/packages/forms/src/dashboard/inbox/stage/views.js
+++ b/projects/packages/forms/src/dashboard/inbox/stage/views.js
@@ -13,7 +13,8 @@ export const defaultView = {
 	filters: [],
 	page: 1,
 	perPage: 20,
-	fields: [ 'from', 'date', 'source', 'ip' ],
+	titleField: 'from',
+	fields: [ 'date', 'source', 'ip' ],
 };
 
 export const defaultLayouts = {

--- a/projects/packages/forms/src/dashboard/inbox/style.scss
+++ b/projects/packages/forms/src/dashboard/inbox/style.scss
@@ -144,7 +144,7 @@
 
 .jp-forms__inbox__author-field__email {
 	font-size: 11px;
-	filter: opacity(0.8);
+	filter: opacity(0.6);
 }
 
 .jp-forms__inbox__unread-indicator {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes an issue introduced when updating the dataviews package, where the column spacing is broken
Update PR: https://github.com/Automattic/jetpack/pull/45914

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Sets the "from" field as the title field, marking it as primary

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Without updating the dataviews package, go to the dashboard
* Check that the "from" column still works as before, the only change is the bold style on the text
* Checkout the PR linked above, updating the dataviews package, `pnpm install` and restart watch build
* Check that there is a big gap after the checkbox in the dashboard
* Apply this code on top of the linked PR
* Check that the gap is fixed, with the "from" field taking the available space

| Before | After |
| - | - |
| <img width="1089" height="176" alt="Screenshot from 2025-12-02 17-41-46" src="https://github.com/user-attachments/assets/612185e1-5090-4995-9edc-dcb61822ef6d" /> | <img width="1089" height="176" alt="Screenshot from 2025-12-02 17-42-40" src="https://github.com/user-attachments/assets/eb344558-df4a-4953-a44c-6aeaed086adf" /> |
