### PR TITLE
Forms: Set dashboard dataview background color explicitly

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-dashboard-background
+++ b/projects/packages/forms/changelog/fix-forms-dashboard-background
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Just a background color for compatibility with an incoming dependency update
+
+

--- a/projects/packages/forms/src/dashboard/inbox/style.scss
+++ b/projects/packages/forms/src/dashboard/inbox/style.scss
@@ -63,6 +63,7 @@
 	flex-grow: 1;
 	display: flex;
 	flex-direction: column;
+	background-color: var(--wpds-color-bg-surface-neutral-strong, #fff);
 }
 
 .jp-forms-filters-container:not(:empty) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes an issue introduced when updating the dataviews package, where the heading and footer lose the background color
Update PR: https://github.com/Automattic/jetpack/pull/45914

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add the background color explicitly

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Without updating the dataviews package, go to the dashboard
* Check that there is no change
* Checkout the PR linked above, updating the dataviews package, `pnpm install` and restart watch build
* Check that table heading and footer have a transparent background, causing a visual problem with text rendered on top of other text 
* Apply this code on top of the linked PR
* Check that the issue is fixed

| Before | After |
| - | - |
| <img width="1089" height="301" alt="Screenshot from 2025-12-02 18-27-42" src="https://github.com/user-attachments/assets/835144a5-174d-4426-b835-268d4dcf993c" /> | <img width="1089" height="301" alt="Screenshot from 2025-12-02 18-27-47" src="https://github.com/user-attachments/assets/55147d1a-0b0a-4664-8756-7eb853aa9a98" /> |
