### PR TITLE
jetpack-mu-wpcom Code Editor: Fix an issue with Firefox compatibility

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/improved-code-editor-fix-computedstylemap-ff
+++ b/projects/packages/jetpack-mu-wpcom/changelog/improved-code-editor-fix-computedstylemap-ff
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix an issue with Firefox where `getComputedStyleMap()` causes an undefined function error.

--- a/projects/packages/jetpack-mu-wpcom/src/features/code-editor/code-editor/code-editor.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/code-editor/code-editor/code-editor.tsx
@@ -18,14 +18,12 @@ const codeEditorTextareaSelector = 'textarea.editor-post-text-editor';
 let editor: EditorView | true | null = null;
 
 // Prevent a flash of the textarea before we cover it.
-{
-	const styleElement = document.createElement( 'style' );
-	styleElement.textContent = `
+const styleElement = document.createElement( 'style' );
+styleElement.textContent = `
 ${ codeEditorTextareaSelector } {
   visibility: hidden;
 }`;
-	document.head.appendChild( styleElement );
-}
+document.head.appendChild( styleElement );
 
 const observer = new MutationObserver( () => {
 	const codeEditorTextarea: ReactHTMLTextAreaElement | null = document.querySelector(
@@ -37,7 +35,11 @@ const observer = new MutationObserver( () => {
 		// And the editor isn't loaded or initializing
 		if ( ! editor ) {
 			// Do it
-			setupEditor( codeEditorTextarea );
+			setupEditor( codeEditorTextarea ).catch( () => {
+				// Clean up in case of problems.
+				styleElement.remove();
+				observer.disconnect();
+			} );
 		}
 	}
 	// If there's no textarea but the editor is loaded

--- a/projects/packages/jetpack-mu-wpcom/src/features/code-editor/code-editor/code-editor.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/code-editor/code-editor/code-editor.tsx
@@ -81,10 +81,10 @@ const setupEditor = async ( target: ReactHTMLTextAreaElement ): Promise< void > 
 
 	const div = document.createElement( 'div' );
 
-	const containerStyleMap = containerElement.computedStyleMap();
-	const left = containerStyleMap.get( 'padding-left' )?.toString() || '0';
-	const right = containerStyleMap.get( 'padding-right' )?.toString() || '0';
-	const paddingBottom = containerStyleMap.get( 'padding-bottom' )?.toString() || '12px';
+	const styles = getComputedStyle( containerElement );
+	const left = styles.paddingLeft || '0';
+	const right = styles.paddingRight || '0';
+	const paddingBottom = styles.paddingBottom || '12px';
 
 	const top = `${ target.offsetTop }px`;
 	div.style = `position: absolute; top: ${ top }; left: ${ left }; right: ${ right }; padding-bottom: ${ paddingBottom };`;

--- a/projects/packages/jetpack-mu-wpcom/src/features/code-editor/site-additional-css/site-additional-css.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/code-editor/site-additional-css/site-additional-css.ts
@@ -11,14 +11,12 @@ const additionalCssTextareaSelector =
 	'.block-editor-global-styles-advanced-panel__custom-css-input textarea';
 
 // Prevent a flash of the textarea before we cover it.
-{
-	const styleElement = document.createElement( 'style' );
-	styleElement.textContent = `
+const styleElement = document.createElement( 'style' );
+styleElement.textContent = `
 ${ additionalCssTextareaSelector } {
   visibility: hidden;
 }`;
-	document.head.appendChild( styleElement );
-}
+document.head.appendChild( styleElement );
 
 const observer = new MutationObserver( () => {
 	const additionalCSSTextarea: ReactHTMLTextAreaElement | null = document.querySelector(
@@ -36,7 +34,11 @@ const observer = new MutationObserver( () => {
 		// And the editor isn't loaded or initializing
 		if ( ! editor ) {
 			// Do it
-			setupEditor( additionalCSSTextarea, isSingleBlockStyleEditor );
+			setupEditor( additionalCSSTextarea, isSingleBlockStyleEditor ).catch( () => {
+				// Clean up in case of problems.
+				observer.disconnect();
+				styleElement.remove();
+			} );
 		}
 	}
 	// If there's no textarea but the editor is loaded


### PR DESCRIPTION




## Proposed changes:

- Add fallback in case of errors loading the improved code editor.
- Improve FireFox compatibility by using Firefox-supported [`getComputedStyle`](https://developer.mozilla.org/en-US/docs/Web/API/Window/getComputedStyle) over [`computedStyleMap`](https://developer.mozilla.org/en-US/docs/Web/API/Element/computedStyleMap).

This fixes an issue where the editor would not load due to the following error:

> Uncaught (in promise) TypeError: l.computedStyleMap is not a function

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?




## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
Try out the improved Code editor in Firefox. It should load the editor and not show any errors in the console.