### PR TITLE
Holiday snow: switch to automatically detecting the hemisphere

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-holiday-snow-settings-auto-hemisphere-detection
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-holiday-snow-settings-auto-hemisphere-detection
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Holiday snow: switch to automatically detecting the hemisphere.
+
+

--- a/projects/packages/jetpack-mu-wpcom/src/features/holiday-snow/class-holiday-snow.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/holiday-snow/class-holiday-snow.php
@@ -229,8 +229,9 @@ class Holiday_Snow {
 	public static function holiday_snow_markup() {
 		// Get the snow speed option, fallback to default if not set.
 		// Use hardcoded default (9) if config is not initialized yet.
-		$speed_config = self::get_config( self::OPTION_SPEED );
-		$snow_speed   = get_option( self::OPTION_SPEED, $speed_config['default'] ?? 9 );
+		$speed_config  = self::get_config( self::OPTION_SPEED );
+		$default_speed = $speed_config ? $speed_config['default'] : 9;
+		$snow_speed    = get_option( self::OPTION_SPEED, $default_speed );
 
 		// Sanitize the value, using config if available, otherwise use hardcoded defaults.
 		if ( $speed_config ) {

--- a/projects/packages/jetpack-mu-wpcom/src/features/holiday-snow/class-holiday-snow.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/holiday-snow/class-holiday-snow.php
@@ -15,20 +15,12 @@ namespace Automattic\Jetpack\Jetpack_Mu_Wpcom;
  */
 class Holiday_Snow {
 	/**
-	 * Slug where one can find the Holiday Snow settings.
-	 *
-	 * @var string
-	 */
-	private const SETTINGS_PAGE_SLUG = 'jetpack-holiday-snow';
-
-	/**
 	 * Option names.
 	 */
 	private const OPTION_ENABLED    = 'jetpack_holiday_snow_enabled';
 	private const OPTION_GRID_WIDTH = 'jetpack_holiday_snow_grid_width';
 	private const OPTION_DENSITY    = 'jetpack_holiday_snow_density';
 	private const OPTION_SPEED      = 'jetpack_holiday_snow_speed';
-	private const OPTION_SOUTH      = 'jetpack_holiday_snow_south';
 
 	/**
 	 * Settings config; defined in init().
@@ -45,24 +37,81 @@ class Holiday_Snow {
 	private static $is_snow_enabled_cache = null;
 
 	/**
-	 * Whether to show the holiday snow settings.
-	 * Shows from 1 December through 6 January and from 1 June through 6 July.
+	 * Get a config array safely, ensuring config is initialized.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param string $option_name The option name.
+	 * @return array|null The config array or null if not initialized.
 	 */
-	public static function show_settings() {
-		$today = time();
-		return (
-			// southern hemisphere
-			$today >= mktime( 0, 0, 0, 6, 1 ) && $today < mktime( 0, 0, 0, 7, 7 )
-			||
-			// northern hemisphere
-			$today >= mktime( 0, 0, 0, 12, 1 ) || $today < mktime( 0, 0, 0, 1, 7 )
-		);
+	private static function get_config( $option_name ) {
+		// Ensure config is initialized.
+		if ( empty( self::$holiday_snow_config ) ) {
+			return null;
+		}
+
+		if ( ! isset( self::$holiday_snow_config[ $option_name ] ) ) {
+			return null;
+		}
+
+		return self::$holiday_snow_config[ $option_name ];
 	}
 
 	/**
-	 * Check if it is the holiday snow season.
-	 * If set to northern hemisphere (default), it shows from 1 December through 6 January.
-	 * Otherwise it shows from 1 June through 6 July.
+	 * Get the hemisphere setting, automatically detected from timezone.
+	 * Attempts to detect hemisphere from the site's timezone location data.
+	 * Falls back to Northern hemisphere if detection is not possible
+	 * e.g., UTC or offset-based timezones).
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @return string 'south' or 'north'.
+	 */
+	private static function get_hemisphere_setting() {
+		$hemisphere = 'north';
+		$timezone   = wp_timezone();
+
+		/*
+		 * Get location data from the timezone object.
+		 * This only works for named timezones (e.g., "Europe/Budapest"), not offsets.
+		 */
+		$location = $timezone->getLocation();
+
+		if ( $location && isset( $location['latitude'] ) ) {
+			$latitude = (float) $location['latitude'];
+
+			/*
+			 * Latitude > 0 = Northern hemisphere, < 0 = Southern hemisphere.
+			 */
+			if ( $latitude < 0 ) {
+				$hemisphere = 'south';
+			}
+		}
+
+		/**
+		 * Filter the detected hemisphere setting.
+		 * Allows overriding the automatic hemisphere detection from timezone.
+		 *
+		 * @since $$next-version$$
+		 *
+		 * @param string $hemisphere The detected hemisphere. Either 'north' or 'south'.
+		 */
+		$hemisphere = apply_filters( 'jetpack_holiday_snow_hemisphere', $hemisphere );
+
+		if ( ! in_array( $hemisphere, array( 'north', 'south' ), true ) ) {
+			$hemisphere = 'north';
+		}
+
+		return $hemisphere;
+	}
+
+	/**
+	 * Check if it is the holiday snow season, based on hemisphere and date.
+	 *
+	 * The hemisphere is automatically detected from the site's timezone.
+	 * If detection is not possible, fallback to Northern hemisphere.
+	 * Northern hemisphere: shows from 1 December through 6 January.
+	 * Southern hemisphere: shows from 1 June through 6 July.
 	 *
 	 * @return bool
 	 */
@@ -70,8 +119,8 @@ class Holiday_Snow {
 		$is_snow_season = false;
 		$today          = time();
 
-		$do_southern_hemisphere = get_option( self::OPTION_SOUTH, self::$holiday_snow_config[ self::OPTION_SOUTH ]['default'] );
-		if ( $do_southern_hemisphere ) {
+		$hemisphere = self::get_hemisphere_setting();
+		if ( 'south' === $hemisphere ) {
 			$first_snow_day = mktime( 0, 0, 0, 6, 1 );
 			$last_snow_day  = mktime( 0, 0, 0, 7, 7 );
 			// Southern hemisphere: June 1 - July 7 (doesn't span year boundary, use AND)
@@ -97,20 +146,6 @@ class Holiday_Snow {
 		 * @param bool $is_holiday_snow_season Is it the snow season?
 		 */
 		return apply_filters( 'jetpack_is_holiday_snow_season', $is_snow_season );
-	}
-
-	/**
-	 * Check if the site uses p2.
-	 * p2 is currently not compatible with Holiday Snow.
-	 * This covers both P2 and P2020 themes.
-	 *
-	 * @deprecated 6.1.0
-	 *
-	 * @return bool
-	 */
-	private static function is_p2() {
-		return str_contains( get_stylesheet(), 'pub/p2' )
-			|| function_exists( '\WPForTeams\is_wpforteams_site' ) && is_wpforteams_site( get_current_blog_id() );
 	}
 
 	/**
@@ -167,20 +202,10 @@ class Holiday_Snow {
 				'description' => __( 'How long it takes for a snowflake to get to the bottom of the screen. The lower the number, the faster it goes.', 'jetpack-mu-wpcom' ),
 				'label'       => __( 'Snow Speed', 'jetpack-mu-wpcom' ),
 			),
-			self::OPTION_SOUTH      => array(
-				'default'     => false,
-				'type'        => 'boolean',
-				'description' => __( 'If snow is enabled and this is ticked, it will show from 1 June through 6 July. Otherwise it will fall from 1 December through 6 January.', 'jetpack-mu-wpcom' ),
-				'label'       => __( 'Southern Hemisphere', 'jetpack-mu-wpcom' ),
-			),
 		);
 
-		/**
-		 * We should show settings if:
-		 * 1. It's in one of the seasons.
-		 * 2. It's snow season, which can be configured with a filter.
-		 */
-		if ( ! self::show_settings() && ! self::is_snow_season() ) {
+		// Only show settings if it's snow season.
+		if ( ! self::is_snow_season() ) {
 			return;
 		}
 
@@ -188,12 +213,6 @@ class Holiday_Snow {
 		add_filter( 'rest_api_update_site_settings', array( __CLASS__, 'update_option_api' ), 10, 2 );
 		add_action( 'update_option_' . self::OPTION_ENABLED, array( __CLASS__, 'holiday_snow_option_updated' ) );
 		add_action( 'admin_init', array( __CLASS__, 'register_settings' ) );
-		add_action( 'admin_menu', array( __CLASS__, 'add_settings_page' ) );
-
-		// If we're in the wrong hemisphere, we'll see the settings but not the snow.
-		if ( ! self::is_snow_season() ) {
-			return;
-		}
 
 		if ( self::is_snow_enabled() ) {
 			add_action( 'wp_footer', array( __CLASS__, 'holiday_snow_markup' ) );
@@ -209,8 +228,21 @@ class Holiday_Snow {
 	 */
 	public static function holiday_snow_markup() {
 		// Get the snow speed option, fallback to default if not set.
-		$snow_speed = get_option( self::OPTION_SPEED, self::$holiday_snow_config[ self::OPTION_SPEED ]['default'] );
-		$snow_speed = self::sanitize_option( $snow_speed, self::$holiday_snow_config[ self::OPTION_SPEED ] );
+		// Use hardcoded default (9) if config is not initialized yet.
+		$speed_config = self::get_config( self::OPTION_SPEED );
+		$snow_speed   = get_option( self::OPTION_SPEED, $speed_config['default'] ?? 9 );
+
+		// Sanitize the value, using config if available, otherwise use hardcoded defaults.
+		if ( $speed_config ) {
+			$snow_speed = self::sanitize_option( $snow_speed, $speed_config );
+		} else {
+			// Fallback sanitization if config not initialized: ensure it's between 1-20, default to 9.
+			$snow_speed = (int) $snow_speed;
+			if ( $snow_speed < 1 || $snow_speed > 20 ) {
+				$snow_speed = 9;
+			}
+		}
+
 		echo '<div id="jetpack-holiday-snow" style="--jetpack-holiday-snow-speed: ' . (int) $snow_speed . 's;" ></div>';
 	}
 
@@ -298,7 +330,7 @@ class Holiday_Snow {
 				continue;
 			}
 			register_setting(
-				self::SETTINGS_PAGE_SLUG,
+				'general',
 				$option_name,
 				array(
 					'type'              => $option_config['type'],
@@ -346,46 +378,13 @@ class Holiday_Snow {
 						);
 					}
 				},
-				self::SETTINGS_PAGE_SLUG,
-				self::SETTINGS_PAGE_SLUG,
+				'general',
+				'default',
 				array(
 					'label_for' => $option_name,
 				)
 			);
 		}
-	}
-
-	/**
-	 * Add a new settings page for Holiday Snow.
-	 */
-	public static function add_settings_page() {
-		add_options_page(
-			esc_attr__( 'Holiday Snow Settings', 'jetpack-mu-wpcom' ),
-			esc_attr__( 'Holiday Snow', 'jetpack-mu-wpcom' ),
-			'manage_options',
-			self::SETTINGS_PAGE_SLUG,
-			array( __CLASS__, 'render_settings_page' )
-		);
-	}
-
-	/**
-	 * Render the Holiday Snow settings page.
-	 */
-	public static function render_settings_page() {
-		?>
-		<div class="wrap">
-			<h1><?php esc_html_e( 'Holiday Snow Settings', 'jetpack-mu-wpcom' ); ?></h1>
-			<form method="post" action="options.php">
-				<?php settings_fields( self::SETTINGS_PAGE_SLUG ); ?>
-				<table class="form-table">
-					<tbody>
-						<?php do_settings_fields( self::SETTINGS_PAGE_SLUG, self::SETTINGS_PAGE_SLUG ); ?>
-					</tbody>
-				</table>
-				<?php submit_button(); ?>
-			</form>
-		</div>
-		<?php
 	}
 
 	/**

--- a/projects/packages/jetpack-mu-wpcom/src/features/holiday-snow/class-holiday-snow.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/holiday-snow/class-holiday-snow.php
@@ -74,13 +74,17 @@ class Holiday_Snow {
 		if ( $do_southern_hemisphere ) {
 			$first_snow_day = mktime( 0, 0, 0, 6, 1 );
 			$last_snow_day  = mktime( 0, 0, 0, 7, 7 );
+			// Southern hemisphere: June 1 - July 7 (doesn't span year boundary, use AND)
+			if ( $today >= $first_snow_day && $today < $last_snow_day ) {
+				$is_snow_season = true;
+			}
 		} else {
 			$first_snow_day = mktime( 0, 0, 0, 12, 1 );
 			$last_snow_day  = mktime( 0, 0, 0, 1, 7 );
-		}
-
-		if ( $today >= $first_snow_day || $today < $last_snow_day ) {
-			$is_snow_season = true;
+			// Northern hemisphere: Dec 1 - Jan 7 (spans year boundary, use OR)
+			if ( $today >= $first_snow_day || $today < $last_snow_day ) {
+				$is_snow_season = true;
+			}
 		}
 
 		/**

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/holiday-snow/Holiday_Snow_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/holiday-snow/Holiday_Snow_Test.php
@@ -1,0 +1,327 @@
+<?php
+/**
+ * Holiday Snow Tests
+ *
+ * @package automattic/jetpack-mu-wpcom
+ */
+
+declare( strict_types = 1 );
+
+namespace Automattic\Jetpack\Jetpack_Mu_Wpcom;
+
+use Automattic\Jetpack\Jetpack_Mu_Wpcom;
+use PHPUnit\Framework\Attributes\DataProvider;
+use ReflectionClass;
+use ReflectionMethod;
+
+require_once Jetpack_Mu_Wpcom::PKG_DIR . 'src/features/holiday-snow/class-holiday-snow.php';
+
+/**
+ * Tests for the Holiday_Snow class.
+ */
+class Holiday_Snow_Test extends \WorDBless\BaseTestCase {
+	/**
+	 * Reflection class instance for accessing private methods.
+	 *
+	 * @var ReflectionClass
+	 */
+	private $reflection_class;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		$this->reflection_class = new ReflectionClass( Holiday_Snow::class );
+
+		// Remove any existing filters.
+		remove_all_filters( 'jetpack_holiday_snow_hemisphere' );
+	}
+
+	/**
+	 * Tear down test fixtures.
+	 */
+	public function tear_down() {
+		// Clean up any filters.
+		remove_all_filters( 'jetpack_holiday_snow_hemisphere' );
+
+		// Reset timezone to default.
+		delete_option( 'timezone_string' );
+		delete_option( 'gmt_offset' );
+
+		// Clean up holiday snow options.
+		delete_option( 'jetpack_holiday_snow_speed' );
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Get the private get_hemisphere_setting method using reflection.
+	 *
+	 * @return ReflectionMethod
+	 */
+	private function get_hemisphere_setting_method(): ReflectionMethod {
+		$method = $this->reflection_class->getMethod( 'get_hemisphere_setting' );
+		$method->setAccessible( true );
+		return $method;
+	}
+
+	/**
+	 * Data provider for test_get_hemisphere_setting.
+	 *
+	 * @return \Iterator
+	 */
+	public static function provide_hemisphere_setting_scenarios(): \Iterator {
+		// Northern hemisphere timezones.
+		yield 'Europe/London (Northern)' => array(
+			'timezone_string' => 'Europe/London',
+			'expected'        => 'north',
+		);
+
+		yield 'America/New_York (Northern)' => array(
+			'timezone_string' => 'America/New_York',
+			'expected'        => 'north',
+		);
+
+		yield 'Asia/Tokyo (Northern)' => array(
+			'timezone_string' => 'Asia/Tokyo',
+			'expected'        => 'north',
+		);
+
+		// Southern hemisphere timezones.
+		yield 'Australia/Sydney (Southern)' => array(
+			'timezone_string' => 'Australia/Sydney',
+			'expected'        => 'south',
+		);
+
+		yield 'America/Santiago (Southern)' => array(
+			'timezone_string' => 'America/Santiago',
+			'expected'        => 'south',
+		);
+
+		yield 'Africa/Johannesburg (Southern)' => array(
+			'timezone_string' => 'Africa/Johannesburg',
+			'expected'        => 'south',
+		);
+
+		// UTC and offset-based timezones (should default to north).
+		yield 'UTC (defaults to north)' => array(
+			'timezone_string' => '',
+			'expected'        => 'north',
+		);
+
+		yield 'GMT offset +5 (defaults to north)' => array(
+			'timezone_string' => '',
+			'expected'        => 'north',
+			'gmt_offset'      => '5',
+		);
+
+		yield 'GMT offset -3 (defaults to north)' => array(
+			'timezone_string' => '',
+			'expected'        => 'north',
+			'gmt_offset'      => '-3',
+		);
+
+		// Timezone near equator (latitude >= 0 defaults to north).
+		yield 'Africa/Lagos (near equator, defaults to north)' => array(
+			'timezone_string' => 'Africa/Lagos',
+			'expected'        => 'north',
+		);
+	}
+
+	/**
+	 * Test get_hemisphere_setting with various timezone scenarios.
+	 *
+	 * @dataProvider provide_hemisphere_setting_scenarios
+	 * @param string      $timezone_string The timezone string to set.
+	 * @param string      $expected The expected hemisphere result.
+	 * @param string|null $gmt_offset Optional GMT offset if timezone_string is empty.
+	 */
+	#[DataProvider( 'provide_hemisphere_setting_scenarios' )]
+	public function test_get_hemisphere_setting( string $timezone_string, string $expected, ?string $gmt_offset = null ) {
+		// Set the timezone.
+		if ( ! empty( $timezone_string ) ) {
+			update_option( 'timezone_string', $timezone_string );
+			update_option( 'gmt_offset', '0' );
+		} else {
+			update_option( 'timezone_string', '' );
+			update_option( 'gmt_offset', $gmt_offset ?? '0' );
+		}
+
+		// Get the method and invoke it.
+		$method = $this->get_hemisphere_setting_method();
+		$result = $method->invoke( null );
+
+		$this->assertSame( $expected, $result );
+	}
+
+	/**
+	 * Test that the filter can override the detected hemisphere.
+	 */
+	public function test_get_hemisphere_setting_filter_override() {
+		// Set a Northern hemisphere timezone.
+		update_option( 'timezone_string', 'Europe/London' );
+		update_option( 'gmt_offset', 0 );
+
+		// Get the method.
+		$method = $this->get_hemisphere_setting_method();
+
+		// Test without filter - should return north.
+		$result = $method->invoke( null );
+		$this->assertSame( 'north', $result, 'Should detect north for Europe/London' );
+
+		// Add filter to override to south.
+		add_filter(
+			'jetpack_holiday_snow_hemisphere',
+			function () {
+				return 'south';
+			}
+		);
+
+		$result = $method->invoke( null );
+		$this->assertSame( 'south', $result, 'Filter should override detected hemisphere to south' );
+
+		// Remove filter and test with different override.
+		remove_all_filters( 'jetpack_holiday_snow_hemisphere' );
+
+		add_filter(
+			'jetpack_holiday_snow_hemisphere',
+			function () {
+				return 'north';
+			}
+		);
+
+		// Set a Southern hemisphere timezone.
+		update_option( 'timezone_string', 'Australia/Sydney' );
+
+		$result = $method->invoke( null );
+		$this->assertSame( 'north', $result, 'Filter should override detected hemisphere to north even for Southern timezone' );
+	}
+
+	/**
+	 * Data provider for test_holiday_snow_markup.
+	 *
+	 * @return \Iterator
+	 */
+	public static function provide_holiday_snow_markup_scenarios(): \Iterator {
+		// Test with config initialized and valid speed values.
+		yield 'Default speed (9) with config initialized' => array(
+			'init_config'    => true,
+			'speed_option'   => null,
+			'expected_speed' => 9,
+			'description'    => 'Should use default speed of 9 when option is not set and config is initialized',
+		);
+
+		yield 'Custom speed (5) within range with config initialized' => array(
+			'init_config'    => true,
+			'speed_option'   => 5,
+			'expected_speed' => 5,
+			'description'    => 'Should use custom speed value within valid range',
+		);
+
+		yield 'Custom speed (15) within range with config initialized' => array(
+			'init_config'    => true,
+			'speed_option'   => 15,
+			'expected_speed' => 15,
+			'description'    => 'Should use custom speed value within valid range',
+		);
+
+		yield 'Speed below minimum (0) with config initialized' => array(
+			'init_config'    => true,
+			'speed_option'   => 0,
+			'expected_speed' => 9,
+			'description'    => 'Should default to 9 when speed is below minimum (1)',
+		);
+
+		yield 'Speed above maximum (25) with config initialized' => array(
+			'init_config'    => true,
+			'speed_option'   => 25,
+			'expected_speed' => 9,
+			'description'    => 'Should default to 9 when speed is above maximum (20)',
+		);
+
+		// Test with config not initialized (fallback behavior).
+		yield 'Default speed (9) without config initialized' => array(
+			'init_config'    => false,
+			'speed_option'   => null,
+			'expected_speed' => 9,
+			'description'    => 'Should use hardcoded default of 9 when config is not initialized',
+		);
+
+		yield 'Valid speed (10) without config initialized' => array(
+			'init_config'    => false,
+			'speed_option'   => 10,
+			'expected_speed' => 10,
+			'description'    => 'Should use option value when config is not initialized and value is valid',
+		);
+
+		yield 'Invalid speed (0) without config initialized' => array(
+			'init_config'    => false,
+			'speed_option'   => 0,
+			'expected_speed' => 9,
+			'description'    => 'Should default to 9 when speed is invalid and config is not initialized',
+		);
+
+		yield 'Invalid speed (25) without config initialized' => array(
+			'init_config'    => false,
+			'speed_option'   => 25,
+			'expected_speed' => 9,
+			'description'    => 'Should default to 9 when speed exceeds max and config is not initialized',
+		);
+	}
+
+	/**
+	 * Test holiday_snow_markup with various speed scenarios.
+	 *
+	 * @dataProvider provide_holiday_snow_markup_scenarios
+	 * @param bool     $init_config Whether to initialize the config.
+	 * @param int|null $speed_option The speed option value to set (null to not set).
+	 * @param int      $expected_speed The expected speed in the output.
+	 * @param string   $description Description of the test case.
+	 */
+	#[DataProvider( 'provide_holiday_snow_markup_scenarios' )]
+	public function test_holiday_snow_markup( bool $init_config, ?int $speed_option, int $expected_speed, string $description ) {
+		// Initialize config if needed.
+		if ( $init_config ) {
+			Holiday_Snow::init();
+		}
+
+		// Set speed option if provided.
+		if ( $speed_option !== null ) {
+			update_option( 'jetpack_holiday_snow_speed', $speed_option );
+		} else {
+			delete_option( 'jetpack_holiday_snow_speed' );
+		}
+
+		// Capture output.
+		ob_start();
+		Holiday_Snow::holiday_snow_markup();
+		$output = ob_get_clean();
+
+		// Verify output format.
+		$expected_output = '<div id="jetpack-holiday-snow" style="--jetpack-holiday-snow-speed: ' . $expected_speed . 's;" ></div>';
+		$this->assertSame( $expected_output, $output, $description );
+	}
+
+	/**
+	 * Test holiday_snow_markup output format.
+	 */
+	public function test_holiday_snow_markup_output_format() {
+		// Initialize config.
+		Holiday_Snow::init();
+
+		// Set a valid speed.
+		update_option( 'jetpack_holiday_snow_speed', 12 );
+
+		// Capture output.
+		ob_start();
+		Holiday_Snow::holiday_snow_markup();
+		$output = ob_get_clean();
+
+		// Verify output contains expected elements.
+		$this->assertStringContainsString( 'id="jetpack-holiday-snow"', $output, 'Output should contain the div with correct id' );
+		$this->assertStringContainsString( '--jetpack-holiday-snow-speed:', $output, 'Output should contain the CSS variable' );
+		$this->assertStringContainsString( '12s', $output, 'Output should contain the correct speed value' );
+	}
+}

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/holiday-snow/Holiday_Snow_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/holiday-snow/Holiday_Snow_Test.php
@@ -45,6 +45,7 @@ class Holiday_Snow_Test extends \WorDBless\BaseTestCase {
 	public function tear_down() {
 		// Clean up any filters.
 		remove_all_filters( 'jetpack_holiday_snow_hemisphere' );
+		remove_all_filters( 'jetpack_is_holiday_snow_season' );
 
 		// Reset timezone to default.
 		delete_option( 'timezone_string' );
@@ -326,5 +327,60 @@ class Holiday_Snow_Test extends \WorDBless\BaseTestCase {
 		$this->assertStringContainsString( 'id="jetpack-holiday-snow"', $output, 'Output should contain the div with correct id' );
 		$this->assertStringContainsString( '--jetpack-holiday-snow-speed:', $output, 'Output should contain the CSS variable' );
 		$this->assertStringContainsString( '12s', $output, 'Output should contain the correct speed value' );
+	}
+
+	/**
+	 * Data provider for test_is_snow_season_boolean_values.
+	 *
+	 * @return \Iterator
+	 */
+	public static function get_is_snow_season_boolean_scenarios(): \Iterator {
+		// Filter override scenarios.
+		yield 'Filter returns true' => array(
+			'filter_return' => true,
+			'expected'      => true,
+		);
+
+		yield 'Filter returns false' => array(
+			'filter_return' => false,
+			'expected'      => false,
+		);
+
+		// No filter scenarios - should return boolean based on natural behavior.
+		yield 'No filter with Northern hemisphere timezone' => array(
+			'filter_return' => null,
+			'expected'      => null,
+		);
+	}
+
+	/**
+	 * Test that is_snow_season returns the correct boolean values, including filter overrides.
+	 *
+	 * @dataProvider get_is_snow_season_boolean_scenarios
+	 * @param mixed     $filter_return The value the filter should return, or null for no filter.
+	 * @param bool|null $expected The expected boolean result from is_snow_season, or null if we just verify it's a boolean.
+	 */
+	#[DataProvider( 'get_is_snow_season_boolean_scenarios' )]
+	public function test_is_snow_season_boolean_values( $filter_return, ?bool $expected ) {
+		// Add filter if specified.
+		if ( $filter_return !== null ) {
+			add_filter(
+				'jetpack_is_holiday_snow_season',
+				function () use ( $filter_return ) {
+					return $filter_return;
+				}
+			);
+		}
+
+		$result = Holiday_Snow::is_snow_season();
+
+		// We can't predict the actual boolean,
+		// but we can verify it returns a boolean.
+		$this->assertIsBool( $result, 'is_snow_season should always return a boolean' );
+
+		// If we have an expected value, verify it matches.
+		if ( $expected !== null ) {
+			$this->assertSame( $expected, $result );
+		}
 	}
 }

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/holiday-snow/Holiday_Snow_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/holiday-snow/Holiday_Snow_Test.php
@@ -63,7 +63,10 @@ class Holiday_Snow_Test extends \WorDBless\BaseTestCase {
 	 */
 	private function get_hemisphere_setting_method(): ReflectionMethod {
 		$method = $this->reflection_class->getMethod( 'get_hemisphere_setting' );
-		$method->setAccessible( true );
+		// @todo Remove this call once we no longer need to support PHP <8.1.
+		if ( PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
 		return $method;
 	}
 


### PR DESCRIPTION
> [!NOTE]
> This is a proposal for an additional take on #46139, the PR is merged into that other branch.

## Proposed changes:

This is based on my review here: https://github.com/Automattic/jetpack/pull/46139/files#r2584263969

Instead of asking the site owner to set an option for their site, let's try to make the decision for them, based on their site settings. If we know where their site is located (i.e. if their timezone includes a specific location), we can deduce their site's latitude, and thus the hemisphere they're in.

Since this commit removes that new field, I've opted to move the settings back to Settings > General, since I don't think we need a separate setting section for just 2 fields.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* This is better tested on a WoA site
* Go to Settings > General
* Check for the holiday snow section
* Now change your site's timezone
* Check for the holiday snow section again.

