### PR TITLE
Add agents provider frontend data

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-agent-providers-frontend
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-agent-providers-frontend
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Adds a new hook to get async loaded agent providers in the frontend

--- a/projects/packages/jetpack-mu-wpcom/src/features/agents-manager/class-agents-manager.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/agents-manager/class-agents-manager.php
@@ -24,13 +24,13 @@ class Agents_Manager {
 	public function __construct() {
 		add_action( 'rest_api_init', array( $this, 'register_rest_api' ) );
 		add_filter( 'calypso_preferences_update', array( $this, 'calypso_preferences_update' ) );
-		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_wp_scripts' ), 100 );
+		add_action( 'wp_enqueue_scripts', array( $this, 'add_inline_script' ), 100 );
 	}
 
 	/**
-	 * Enqueue the scripts for the frontend.
+	 * Add inline script data for the Agents Manager.
 	 */
-	public function enqueue_wp_scripts() {
+	public function add_inline_script() {
 		/**
 		 * Filter to register agent provider modules for the Agents Manager.
 		 *
@@ -42,13 +42,14 @@ class Agents_Manager {
 		 */
 		$agent_providers = apply_filters( 'agents_manager_agent_providers', array() );
 
+		// For now, we want this added wherever the help-center script is enqueued.
 		wp_add_inline_script(
-			'agents-manager',
+			'help-center',
 			'const agentsManagerData = ' . wp_json_encode(
 				array(
 					'agentProviders' => $agent_providers,
 				)
-			),
+			) . ';',
 			'before'
 		);
 	}

--- a/projects/packages/jetpack-mu-wpcom/src/features/agents-manager/class-agents-manager.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/agents-manager/class-agents-manager.php
@@ -26,7 +26,7 @@ class Agents_Manager {
 		add_filter( 'calypso_preferences_update', array( $this, 'calypso_preferences_update' ) );
 		add_action( 'admin_enqueue_scripts', array( $this, 'add_inline_script' ), 101 );
 		add_action( 'wp_enqueue_scripts', array( $this, 'add_inline_script' ), 101 );
-		add_action( 'next_admin_init', array( $this, 'enqueue_wp_admin_scripts' ), 1001 );
+		add_action( 'next_admin_init', array( $this, 'add_inline_script' ), 1001 );
 	}
 
 	/**

--- a/projects/packages/jetpack-mu-wpcom/src/features/agents-manager/class-agents-manager.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/agents-manager/class-agents-manager.php
@@ -24,6 +24,33 @@ class Agents_Manager {
 	public function __construct() {
 		add_action( 'rest_api_init', array( $this, 'register_rest_api' ) );
 		add_filter( 'calypso_preferences_update', array( $this, 'calypso_preferences_update' ) );
+		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_wp_scripts' ), 100 );
+	}
+
+	/**
+	 * Enqueue the scripts for the frontend.
+	 */
+	public function enqueue_wp_scripts() {
+		/**
+		 * Filter to register agent provider modules for the Agents Manager.
+		 *
+		 * Plugins can hook into this filter to register script module IDs that export
+		 * toolProvider and/or contextProvider. The Agents Manager JS will dynamically
+		 * import these modules and merge their providers.
+		 *
+		 * @param array $providers Array of provider script module IDs.
+		 */
+		$agent_providers = apply_filters( 'agents_manager_agent_providers', array() );
+
+		wp_add_inline_script(
+			'agents-manager',
+			'const agentsManagerData = ' . wp_json_encode(
+				array(
+					'agentProviders' => $agent_providers,
+				)
+			),
+			'before'
+		);
 	}
 
 	/**

--- a/projects/packages/jetpack-mu-wpcom/src/features/agents-manager/class-agents-manager.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/agents-manager/class-agents-manager.php
@@ -24,7 +24,9 @@ class Agents_Manager {
 	public function __construct() {
 		add_action( 'rest_api_init', array( $this, 'register_rest_api' ) );
 		add_filter( 'calypso_preferences_update', array( $this, 'calypso_preferences_update' ) );
-		add_action( 'wp_enqueue_scripts', array( $this, 'add_inline_script' ), 100 );
+		add_action( 'admin_enqueue_scripts', array( $this, 'add_inline_script' ), 101 );
+		add_action( 'wp_enqueue_scripts', array( $this, 'add_inline_script' ), 101 );
+		add_action( 'next_admin_init', array( $this, 'enqueue_wp_admin_scripts' ), 1001 );
 	}
 
 	/**
@@ -43,6 +45,8 @@ class Agents_Manager {
 		$agent_providers = apply_filters( 'agents_manager_agent_providers', array() );
 
 		// For now, we want this added wherever the help-center script is enqueued.
+		// This allows us to be quite blunt here because the logic for whether to inject this is currently
+		// in the help-center script.
 		wp_add_inline_script(
 			'help-center',
 			'const agentsManagerData = ' . wp_json_encode(

--- a/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-help-center.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-help-center.php
@@ -298,7 +298,7 @@ class Help_Center {
 						'site'             => $this->get_current_site(),
 						'locale'           => self::determine_iso_639_locale(),
 					)
-				) . ';',
+				),
 				'before'
 			);
 		}

--- a/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-help-center.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-help-center.php
@@ -298,7 +298,7 @@ class Help_Center {
 						'site'             => $this->get_current_site(),
 						'locale'           => self::determine_iso_639_locale(),
 					)
-				),
+				) . ';',
 				'before'
 			);
 		}

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/agents-manager/Agents_Manager_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/agents-manager/Agents_Manager_Test.php
@@ -42,6 +42,7 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 		// Remove hooks added by the Agents_Manager constructor.
 		remove_action( 'rest_api_init', array( $this->agents_manager, 'register_rest_api' ) );
 		remove_filter( 'calypso_preferences_update', array( $this->agents_manager, 'calypso_preferences_update' ) );
+		remove_action( 'wp_enqueue_scripts', array( $this->agents_manager, 'add_inline_script' ), 100 );
 
 		// Reset the REST server to clear any registered routes.
 		global $wp_rest_server;
@@ -264,5 +265,59 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 
 		// Reset back to null for other tests
 		$property->setValue( $dummy, null );
+	}
+
+	/**
+	 * Tests that add_inline_script adds script with empty providers by default.
+	 */
+	public function test_add_inline_script_with_empty_providers() {
+		// Register the help-center script so we can attach inline script to it.
+		wp_register_script( 'help-center', 'https://example.com/help-center.js', array(), '1.0', true );
+
+		$this->agents_manager->add_inline_script();
+
+		global $wp_scripts;
+		$inline_scripts = $wp_scripts->registered['help-center']->extra['before'] ?? array();
+
+		// Find the inline script containing agentsManagerData (wp_add_inline_script may add at different indices).
+		$inline_script = implode( "\n", array_filter( $inline_scripts ) );
+
+		$this->assertStringContainsString( 'window.agentsManagerData =', $inline_script );
+		$this->assertStringContainsString( '"agentProviders":[]', $inline_script );
+	}
+
+	/**
+	 * Tests that add_inline_script includes providers added via the filter.
+	 */
+	public function test_add_inline_script_includes_filtered_providers() {
+		// Reset the script registry to ensure test isolation.
+		global $wp_scripts;
+		$wp_scripts = null;
+
+		// Register the help-center script so we can attach inline script to it.
+		wp_register_script( 'help-center', 'https://example.com/help-center.js', array(), '1.0', true );
+
+		// Add a filter to provide agent providers.
+		add_filter(
+			'agents_manager_agent_providers',
+			function () {
+				return array( 'my-plugin/tool-provider', 'another-plugin/context-provider' );
+			}
+		);
+
+		$this->agents_manager->add_inline_script();
+
+		$inline_scripts = $wp_scripts->registered['help-center']->extra['before'] ?? array();
+
+		// Find the inline script containing agentsManagerData (wp_add_inline_script may add at different indices).
+		$inline_script = implode( "\n", array_filter( $inline_scripts ) );
+
+		$this->assertStringContainsString( 'window.agentsManagerData =', $inline_script );
+		// JSON encodes forward slashes as \/.
+		$this->assertStringContainsString( 'my-plugin\\/tool-provider', $inline_script );
+		$this->assertStringContainsString( 'another-plugin\\/context-provider', $inline_script );
+
+		// Clean up the filter.
+		remove_all_filters( 'agents_manager_agent_providers' );
 	}
 }

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/agents-manager/Agents_Manager_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/agents-manager/Agents_Manager_Test.php
@@ -301,7 +301,7 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 		add_filter(
 			'agents_manager_agent_providers',
 			function () {
-				return array( 'my-plugin/tool-provider', 'another-plugin/context-provider' );
+				return array( 'my-plugin/tool-provider.js', 'another-plugin/context-provider.js' );
 			}
 		);
 
@@ -315,8 +315,8 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 
 		$this->assertStringContainsString( 'const agentsManagerData =', $inline_script );
 		// JSON encodes forward slashes as \/.
-		$this->assertStringContainsString( 'my-plugin\\/tool-provider', $inline_script );
-		$this->assertStringContainsString( 'another-plugin\\/context-provider', $inline_script );
+		$this->assertStringContainsString( 'my-plugin\\/tool-provider.js', $inline_script );
+		$this->assertStringContainsString( 'another-plugin\\/context-provider.js', $inline_script );
 
 		// Clean up the filter.
 		remove_all_filters( 'agents_manager_agent_providers' );

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/agents-manager/Agents_Manager_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/agents-manager/Agents_Manager_Test.php
@@ -282,7 +282,7 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 		// Find the inline script containing agentsManagerData (wp_add_inline_script may add at different indices).
 		$inline_script = implode( "\n", array_filter( $inline_scripts ) );
 
-		$this->assertStringContainsString( 'window.agentsManagerData =', $inline_script );
+		$this->assertStringContainsString( 'const agentsManagerData =', $inline_script );
 		$this->assertStringContainsString( '"agentProviders":[]', $inline_script );
 	}
 
@@ -312,7 +312,7 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 		// Find the inline script containing agentsManagerData (wp_add_inline_script may add at different indices).
 		$inline_script = implode( "\n", array_filter( $inline_scripts ) );
 
-		$this->assertStringContainsString( 'window.agentsManagerData =', $inline_script );
+		$this->assertStringContainsString( 'const agentsManagerData =', $inline_script );
 		// JSON encodes forward slashes as \/.
 		$this->assertStringContainsString( 'my-plugin\\/tool-provider', $inline_script );
 		$this->assertStringContainsString( 'another-plugin\\/context-provider', $inline_script );

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/agents-manager/Agents_Manager_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/agents-manager/Agents_Manager_Test.php
@@ -307,7 +307,8 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 
 		$this->agents_manager->add_inline_script();
 
-		$inline_scripts = $wp_scripts->registered['help-center']->extra['before'] ?? array();
+		// Re-fetch global after wp_register_script initializes it.
+		$inline_scripts = $wp_scripts->registered['help-center']->extra['before'] ?? array(); // @phan-suppress-current-line PhanTypeExpectedObjectPropAccessButGotNull
 
 		// Find the inline script containing agentsManagerData (wp_add_inline_script may add at different indices).
 		$inline_script = implode( "\n", array_filter( $inline_scripts ) );

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/agents-manager/Agents_Manager_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/agents-manager/Agents_Manager_Test.php
@@ -42,7 +42,9 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 		// Remove hooks added by the Agents_Manager constructor.
 		remove_action( 'rest_api_init', array( $this->agents_manager, 'register_rest_api' ) );
 		remove_filter( 'calypso_preferences_update', array( $this->agents_manager, 'calypso_preferences_update' ) );
-		remove_action( 'wp_enqueue_scripts', array( $this->agents_manager, 'add_inline_script' ), 100 );
+		remove_action( 'wp_enqueue_scripts', array( $this->agents_manager, 'add_inline_script' ), 101 );
+		remove_action( 'admin_enqueue_scripts', array( $this->agents_manager, 'add_inline_script' ), 101 );
+		remove_action( 'next_admin_init', array( $this->agents_manager, 'add_inline_script' ), 1001 );
 
 		// Reset the REST server to clear any registered routes.
 		global $wp_rest_server;


### PR DESCRIPTION
Paired with https://github.com/Automattic/wp-calypso/pull/107446/

## Proposed changes:
* Injects agent providers for the Calypso Agents Manager to load async.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
* Switch to this branch for _WordPress.com Site Helper_ in Jetpack Beta plugin.
* Inspect output. You should see this:
<img width="585" height="118" alt="CleanShot 2025-12-03 at 12  36 46" src="https://github.com/user-attachments/assets/3235db2b-c025-4b63-9de3-e47b52cb5744" />

