### PR TITLE
Forms: Decode HTML entities in CSV exports

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-html-entities-csv-export
+++ b/projects/packages/forms/changelog/fix-forms-html-entities-csv-export
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: Decode HTML entities in exported form names to prevent codes like &#8211; appearing in CSV exports

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -388,7 +388,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 				// create a fallback source
 				$source = array(
 					'source_id'   => $post->ID,
-					'entry_title' => $post->post_title,
+					'entry_title' => html_entity_decode( $post->post_title, ENT_QUOTES | ENT_HTML5, 'UTF-8' ),
 					'entry_page'  => 1,
 					'source_type' => 'single',
 					'request_url' => get_permalink( $post ),

--- a/projects/packages/forms/src/contact-form/class-feedback-source.php
+++ b/projects/packages/forms/src/contact-form/class-feedback-source.php
@@ -81,7 +81,7 @@ class Feedback_Source {
 			$this->page_number = 1;
 		}
 
-		$this->title       = $title;
+		$this->title       = html_entity_decode( $title, ENT_QUOTES | ENT_HTML5, 'UTF-8' );
 		$this->permalink   = empty( $request_url ) ? home_url() : $request_url;
 		$this->source_type = $source_type; // possible source types: single, widget, block_template, block_template_part
 		$this->request_url = $request_url;
@@ -90,7 +90,7 @@ class Feedback_Source {
 			$entry_post = get_post( (int) $id );
 			if ( $entry_post && $entry_post->post_status === 'publish' ) {
 				$this->permalink = get_permalink( $entry_post );
-				$this->title     = get_the_title( $entry_post );
+				$this->title     = html_entity_decode( get_the_title( $entry_post ), ENT_QUOTES | ENT_HTML5, 'UTF-8' );
 			} elseif ( $entry_post ) {
 				$this->permalink = '';
 
@@ -121,7 +121,7 @@ class Feedback_Source {
 			return new self( 0, '', $current_page_number );
 		}
 
-		$title = $current_post->post_title ?? __( '(no title)', 'jetpack-forms' );
+		$title = isset( $current_post->post_title ) ? html_entity_decode( $current_post->post_title, ENT_QUOTES | ENT_HTML5, 'UTF-8' ) : __( '(no title)', 'jetpack-forms' );
 
 		return new self( $id, $title, $current_page_number );
 	}

--- a/projects/packages/forms/src/contact-form/class-util.php
+++ b/projects/packages/forms/src/contact-form/class-util.php
@@ -456,7 +456,7 @@ class Util {
 				/* translators: 1: Site title; 2: post title. Used to craft the export filename, eg "MySite - Jetpack Form Responses - Contact" */
 				__( '%1$s - Jetpack Form Responses - %2$s', 'jetpack-forms' ),
 				sanitize_file_name( get_bloginfo( 'name' ) ),
-				sanitize_file_name( $source )
+				sanitize_file_name( html_entity_decode( $source, ENT_QUOTES | ENT_HTML5, 'UTF-8' ) )
 			);
 	}
 }


### PR DESCRIPTION
Fixes FORMS-439

When exporting form responses to CSV, form names containing HTML entities (like &#8211; for em dash) were not being decoded, appearing as-is in the exported file instead of the actual characters.

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
This fix decodes HTML entities in two places:
1. In Util::get_export_filename() - for the CSV filename
2. In Contact_Form when setting entry_title - for the CSV data

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a post with a form and a title that contains dashes, such as `Contact Form Test – Jetpack 14.4`.
* Submit a form response and then got to Jetpack > Forms and export the responses as CSV.
* Check that the dash is properly rendered in the title column.

