### PR TITLE
Forms: add filter to hide integration icons

### DIFF
--- a/projects/packages/forms/changelog/add-forms-icons-filter
+++ b/projects/packages/forms/changelog/add-forms-icons-filter
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Forms: add filter to hide integration icons.

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integration-controls.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integration-controls.js
@@ -5,6 +5,7 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { plugins } from '@wordpress/icons';
+import useConfigValue from '../../../hooks/use-config-value.ts';
 import { INTEGRATIONS_STORE } from '../../../store/integrations/index.ts';
 import ActiveIntegrations from './jetpack-integrations-modal/active-integrations/index.js';
 import IntegrationsModal from './jetpack-integrations-modal/index.tsx';
@@ -26,6 +27,7 @@ export default function IntegrationControls( { attributes, setAttributes } ) {
 	const isLoading = useSelect( select => select( INTEGRATIONS_STORE ).isIntegrationsLoading(), [] );
 	const { refreshIntegrations } = useDispatch( INTEGRATIONS_STORE );
 	const { tracks } = useAnalytics();
+	const showIntegrationIcons = useConfigValue( 'showIntegrationIcons' );
 
 	const handleOpenModal = entry_point => {
 		tracks.recordEvent( 'jetpack_forms_block_modal_view', { entry_point } );
@@ -39,11 +41,13 @@ export default function IntegrationControls( { attributes, setAttributes } ) {
 				className="jetpack-contact-form__panel jetpack-contact-form__integrations-panel"
 				initialOpen={ false }
 			>
-				<ActiveIntegrations
-					integrations={ integrations }
-					attributes={ attributes }
-					isLoading={ isLoading }
-				/>
+				{ showIntegrationIcons !== false && (
+					<ActiveIntegrations
+						integrations={ integrations }
+						attributes={ attributes }
+						isLoading={ isLoading }
+					/>
+				) }
 				<Button
 					variant="secondary"
 					onClick={ () => handleOpenModal( 'block-sidebar' ) }

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/integration-card/integration-card-header.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/integration-card/integration-card-header.tsx
@@ -18,6 +18,7 @@ import {
 import { __ } from '@wordpress/i18n';
 import { chevronDown, chevronUp } from '@wordpress/icons';
 import clsx from 'clsx';
+import useConfigValue from '../../../../../hooks/use-config-value.ts';
 import PluginActionButton from './plugin-action-button.tsx';
 /**
  * Types
@@ -97,6 +98,7 @@ const IntegrationCardHeader = ( {
 
 	const isHeaderToggleEnabledFinal = isHeaderToggleEnabled && ! __isPartial; // wait for the full data to load before allwing things to be exanded;
 	const showHeaderToggleFinal = showHeaderToggle && ! __isPartial;
+	const showIntegrationIcons = useConfigValue( 'showIntegrationIcons' );
 
 	return (
 		<CardHeader
@@ -105,15 +107,17 @@ const IntegrationCardHeader = ( {
 		>
 			<div className="integration-card__header-content">
 				<div className="integration-card__header-main">
-					<div className="integration-card__service-icon-container">
-						<Icon
-							icon={ icon }
-							className={ `integration-card__service-icon ${
-								cardData.slug ? `integration-card__service-icon--${ cardData.slug }` : ''
-							}` }
-							size={ 30 }
-						/>
-					</div>
+					{ showIntegrationIcons !== false && (
+						<div className="integration-card__service-icon-container">
+							<Icon
+								icon={ icon }
+								className={ `integration-card__service-icon ${
+									cardData.slug ? `integration-card__service-icon--${ cardData.slug }` : ''
+								}` }
+								size={ 30 }
+							/>
+						</div>
+					) }
 					<div className="integration-card__title-section">
 						<h3 className="integration-card__title">{ title }</h3>
 						{ description && (

--- a/projects/packages/forms/src/class-jetpack-forms.php
+++ b/projects/packages/forms/src/class-jetpack-forms.php
@@ -174,4 +174,25 @@ class Jetpack_Forms {
 		 */
 		return apply_filters( 'jetpack_forms_show_block_integrations', true );
 	}
+
+	/**
+	 * Returns true if integration icons should be shown (editor sidebar and integrations modal).
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @return boolean
+	 */
+	public static function show_integration_icons() {
+		/**
+		 * Whether to show integration icons in the UI.
+		 *
+		 * If set to false, the ActiveIntegrations component (editor sidebar) will be hidden
+		 * and integration icons in the integrations modal will not be rendered.
+		 *
+		 * @since $$next-version$$
+		 *
+		 * @param bool true Whether to show integration icons. Default true.
+		 */
+		return apply_filters( 'jetpack_forms_show_integration_icons', true );
+	}
 }

--- a/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
@@ -1497,6 +1497,7 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 			'isWebhooksEnabled'         => Jetpack_Forms::is_webhooks_enabled(),
 			'showDashboardIntegrations' => Jetpack_Forms::show_dashboard_integrations(),
 			'showBlockIntegrations'     => Jetpack_Forms::show_block_integrations(),
+			'showIntegrationIcons'      => Jetpack_Forms::show_integration_icons(),
 			'dashboardURL'              => Forms_Dashboard::get_forms_admin_url(),
 			// New data.
 			'canInstallPlugins'         => current_user_can( 'install_plugins' ),

--- a/projects/packages/forms/src/types/index.ts
+++ b/projects/packages/forms/src/types/index.ts
@@ -240,6 +240,8 @@ export interface FormsConfigData {
 	showDashboardIntegrations?: boolean;
 	/** Whether to show integrations in the Form block editor UI. */
 	showBlockIntegrations?: boolean;
+	/** Whether to show integration icons across UI (editor sidebar and modal). */
+	showIntegrationIcons?: boolean;
 	/** Whether the current user can install plugins (install_plugins). */
 	canInstallPlugins?: boolean;
 	/** Whether the current user can activate plugins (activate_plugins). */

--- a/projects/plugins/jetpack/changelog/add-forms-icons-filter
+++ b/projects/plugins/jetpack/changelog/add-forms-icons-filter
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Forms: add filter to hide integration icons.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Addresses [FORMS-265](https://linear.app/a8c/issue/FORMS-265/ciab-hide-jetpack-and-akismet-branding-in-forms)

## Proposed changes:

We do not want to show specific branding for Akismet, MailPoet, etc in the CIAB environment. As is, we show those icons alongside the integrations in the integrations modal, and we also show the icons as 'active integrations' in the form block sidebar when enabled. 

This PR adds a filter to hide those. 

In a subsequent PR to the ciab-next repository, I'll use this filter to hide the integrations. 

**Before**
<img width="1181" height="595" alt="icons-before" src="https://github.com/user-attachments/assets/de6a740f-2272-43f8-8e06-b4ea74c395f2" />


**After (note that in CIAB, we also update integration names and descriptions to avoid brands)**)
<img width="1196" height="640" alt="disable-form-icons" src="https://github.com/user-attachments/assets/644b0dd4-79cf-4d45-b924-d1cf3c8d1f9d" />

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
See linear issue. 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No. 

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Apply this filter on your site: 

`add_filter( 'jetpack_forms_show_integration_icons', '__return_false' );`

Confirm that icons do now show in the integrations modal in the dashboard or the block editor. 

Confirm that icons do now show for active/enabled integrations in the form block sidebar in the integrations panel. 
