### PR TITLE
Admin bar: Add a ?origin_admin_bar=wpcom param to admin bar links to Calypso

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/DOTMSD-400-origin-admin-bar-param
+++ b/projects/packages/jetpack-mu-wpcom/changelog/DOTMSD-400-origin-admin-bar-param
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Added query parameter to detect when Calypso navigation is coming from wpcom admin bar.

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.php
@@ -48,6 +48,19 @@ function maybe_add_origin_site_id_to_url( $url ) {
 }
 
 /**
+ * Adds the origin_admin_bar query parameter to a URL.
+ * Calypso can use this parameter to know that the user is coming from wp-admin
+ * and to check whether it should do custom routing based on user preferences.
+ * E.g. redirecting to my.wordpress.com depending on their preference.
+ *
+ * @param string $url The URL to add the query param to.
+ * @return string The URL with the origin_admin_bar query parameter mey be added.
+ */
+function add_origin_admin_bar_to_url( $url ) {
+	return add_query_arg( 'origin_admin_bar', 'wpcom', $url );
+}
+
+/**
  * Enqueue assets needed by the WordPress.com admin bar.
  */
 function wpcom_enqueue_admin_bar_assets() {
@@ -161,7 +174,7 @@ function wpcom_replace_wp_logo_with_wpcom_logo_menu( $wp_admin_bar ) {
 						/* translators: Hidden accessibility text. */
 						__( 'All Sites', 'jetpack-mu-wpcom' ) .
 						'</span>',
-			'href'  => maybe_add_origin_site_id_to_url( 'https://wordpress.com/sites' ),
+			'href'  => add_origin_admin_bar_to_url( maybe_add_origin_site_id_to_url( 'https://wordpress.com/sites' ) ),
 			'meta'  => array(
 				'menu_title' => __( 'All Sites', 'jetpack-mu-wpcom' ),
 			),
@@ -173,7 +186,7 @@ function wpcom_replace_wp_logo_with_wpcom_logo_menu( $wp_admin_bar ) {
 			'parent' => 'wpcom-logo',
 			'id'     => 'wpcom-sites',
 			'title'  => __( 'Sites', 'jetpack-mu-wpcom' ),
-			'href'   => maybe_add_origin_site_id_to_url( 'https://wordpress.com/sites' ),
+			'href'   => add_origin_admin_bar_to_url( maybe_add_origin_site_id_to_url( 'https://wordpress.com/sites' ) ),
 		)
 	);
 
@@ -182,7 +195,7 @@ function wpcom_replace_wp_logo_with_wpcom_logo_menu( $wp_admin_bar ) {
 			'parent' => 'wpcom-logo',
 			'id'     => 'wpcom-domains',
 			'title'  => __( 'Domains', 'jetpack-mu-wpcom' ),
-			'href'   => maybe_add_origin_site_id_to_url( 'https://wordpress.com/domains/manage' ),
+			'href'   => add_origin_admin_bar_to_url( maybe_add_origin_site_id_to_url( 'https://wordpress.com/domains/manage' ) ),
 		)
 	);
 
@@ -302,13 +315,13 @@ function wpcom_replace_edit_profile_menu_to_me( $wp_admin_bar ) {
 
 	$edit_profile_node = $wp_admin_bar->get_node( 'user-info' );
 	if ( $edit_profile_node ) {
-		$edit_profile_node->href  = maybe_add_origin_site_id_to_url( 'https://wordpress.com/me' );
+		$edit_profile_node->href  = add_origin_admin_bar_to_url( maybe_add_origin_site_id_to_url( 'https://wordpress.com/me' ) );
 		$edit_profile_node->title = preg_replace( "/(<span class='display-name edit-profile'>)(.*?)(<\/span>)/", '$1' . __( 'My Profile', 'jetpack-mu-wpcom' ) . '$3', $edit_profile_node->title );
 		$wp_admin_bar->add_node( (array) $edit_profile_node );
 	}
 	$my_account_node = $wp_admin_bar->get_node( 'my-account' );
 	if ( $my_account_node ) {
-		$my_account_node->href = maybe_add_origin_site_id_to_url( 'https://wordpress.com/me' );
+		$my_account_node->href = add_origin_admin_bar_to_url( maybe_add_origin_site_id_to_url( 'https://wordpress.com/me' ) );
 		$wp_admin_bar->add_node( (array) $my_account_node );
 	}
 }
@@ -339,7 +352,7 @@ function wpcom_add_my_wpcom_account_submenu( $wp_admin_bar ) {
 			'parent' => 'wpcom-account',
 			'id'     => 'my-wpcom-account',
 			'title'  => '<span class="button wpcom-button">' . $button_text . '</span>',
-			'href'   => maybe_add_origin_site_id_to_url( 'https://wordpress.com/me/account' ),
+			'href'   => add_origin_admin_bar_to_url( maybe_add_origin_site_id_to_url( 'https://wordpress.com/me/account' ) ),
 		)
 	);
 }

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/wpcom-admin-bar/WPCOM_Admin_Bar_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/wpcom-admin-bar/WPCOM_Admin_Bar_Test.php
@@ -1,0 +1,114 @@
+<?php
+/**
+ * Test class for admin bar changes.
+ *
+ * @package automattic/jetpack-mu-wpcom
+ */
+
+use Automattic\Jetpack\Jetpack_Mu_Wpcom;
+
+require_once Jetpack_Mu_Wpcom::PKG_DIR . 'src/features/wpcom-admin-bar/wpcom-admin-bar.php';
+require_once ABSPATH . 'wp-includes/class-wp-admin-bar.php';
+
+/**
+ * Class WPCOM_Admin_Bar_Test
+ */
+class WPCOM_Admin_Bar_Test extends \WorDBless\BaseTestCase {
+	private static function make_test_admin_bar() {
+			$admin_bar = new \WP_Admin_Bar();
+
+			$admin_bar->add_node(
+				array(
+					'id'    => 'wp-logo',
+					'title' => 'WordPress Logo',
+					'href'  => 'https://wordpress.org/',
+				)
+			);
+			$admin_bar->add_node(
+				array(
+					'id'     => 'about',
+					'parent' => 'wp-logo',
+					'title'  => 'About WordPress',
+					'href'   => 'https://wordpress.org/about/',
+				)
+			);
+			$admin_bar->add_node(
+				array(
+					'id'     => 'contribute',
+					'parent' => 'wp-logo',
+					'title'  => 'Get Involved',
+					'href'   => 'https://wordpress.org/contribute/',
+				)
+			);
+			$admin_bar->add_group(
+				array(
+					'id'    => 'top-secondary',
+					'title' => '',
+				)
+			);
+			$admin_bar->add_node(
+				array(
+					'id'     => 'my-account',
+					'title'  => 'Account',
+					'href'   => 'https://example.com/wp-admin/profile.php',
+					'parent' => 'top-secondary',
+				)
+			);
+
+			do_action( 'admin_bar_menu', $admin_bar );
+
+			return $admin_bar;
+	}
+
+	private static function get_all_admin_bar_nodes( WP_Admin_Bar $bar, $parent = null ) {
+		$result = array();
+
+		foreach ( $bar->get_nodes() as $id => $node ) {
+			if ( ( $parent === null && $node->parent === false ) || ( $node->parent === $parent ) ) {
+				$result[ $id ] = $node;
+
+				// recurse into children
+				$children = self::get_all_admin_bar_nodes( $bar, $id );
+				$result   = array_merge( $result, $children );
+			}
+		}
+
+		return $result;
+	}
+
+	public function test_wp_logo_replaced_by_wpcom_logo() {
+		$admin_bar = self::make_test_admin_bar();
+
+		$this->assertNull( $admin_bar->get_node( 'wp-logo' ) );
+		$this->assertNotNull( $admin_bar->get_node( 'wpcom-logo' ) );
+	}
+
+	public function test_origin_admin_bar_param_in_menu_links() {
+		$admin_bar = self::make_test_admin_bar();
+
+		$all_nodes = $admin_bar->get_nodes();
+
+		$links_with_origin_param = array(
+			'https://wordpress.com/sites',
+			'https://wordpress.com/domains/manage',
+			'https://wordpress.com/me',
+			'https://wordpress.com/me/account',
+		);
+
+		foreach ( $all_nodes as $node ) {
+			$should_have_param = false;
+			foreach ( $links_with_origin_param as $link ) {
+				if ( str_starts_with( $node->href, $link ) ) {
+					$should_have_param = true;
+					break;
+				}
+			}
+
+			if ( $should_have_param ) {
+				$this->assertStringContainsString( 'origin_admin_bar=wpcom', $node->href );
+			} else {
+				$this->assertStringNotContainsString( 'origin_admin_bar=wpcom', $node->href );
+			}
+		}
+	}
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Supersedes #45155
Part of DOTDASH-400

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Links from the wpcom admin bar to Calypso include a `?origin_admin-bar=wpcom` query parameter
* Only links that are related to the my.wordpress.com dashboard get the new param
  * Checkout and reader aren't in the my.wordpress.com dashboard, so I haven't a param to them

This is a different approach from #45155. In that PR I was trying to access the user's preferences on the backend, and have the admin bar link to the correct place. The issue with this is that loading the user's preference becomes a blocking part of rendering the admin bar. On an atomic site this would involve making a remote request to fetch the users preferences before we could load the front end.

The idea here is to give a hint to Calypso of where the user has navigated from, and Calypso will do the redirecting based on the user preference.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply patch to wpcom or an atomic test site using these instructions https://github.com/Automattic/jetpack/pull/46193#issuecomment-3609545430
* The site list, domain list, and account links in the admin bar should include the `?origin_admin_bar=wpcom` query param.

