### PR TITLE
Charts: Add SegmentedBar component

### DIFF
--- a/projects/js-packages/charts/changelog/add-new-chart-categorybar
+++ b/projects/js-packages/charts/changelog/add-new-chart-categorybar
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Charts: Add SegmentedBar component for horizontal segmented progress bars

--- a/projects/js-packages/charts/package.json
+++ b/projects/js-packages/charts/package.json
@@ -82,12 +82,18 @@
 			"import": "./dist/providers/index.js",
 			"require": "./dist/providers/index.cjs"
 		},
-		"./sparkline": {
-			"jetpack:src": "./src/components/sparkline/index.ts",
-			"import": "./dist/components/sparkline/index.js",
-			"require": "./dist/components/sparkline/index.cjs"
+		"./segmented-bar": {
+			"jetpack:src": "./src/charts/segmented-bar/index.ts",
+			"import": "./dist/charts/segmented-bar/index.js",
+			"require": "./dist/charts/segmented-bar/index.cjs"
 		},
-		"./sparkline/style.css": "./dist/components/sparkline/index.css",
+		"./segmented-bar/style.css": "./dist/charts/segmented-bar/index.css",
+		"./sparkline": {
+			"jetpack:src": "./src/charts/sparkline/index.ts",
+			"import": "./dist/charts/sparkline/index.js",
+			"require": "./dist/charts/sparkline/index.cjs"
+		},
+		"./sparkline/style.css": "./dist/charts/sparkline/index.css",
 		"./style.css": "./dist/index.css",
 		"./tooltip": {
 			"jetpack:src": "./src/components/tooltip/index.ts",
@@ -156,8 +162,11 @@
 			"legend": [
 				"./dist/components/legend/index.d.ts"
 			],
+			"segmented-bar": [
+				"./dist/charts/segmented-bar/index.d.ts"
+			],
 			"sparkline": [
-				"./dist/components/sparkline/index.d.ts"
+				"./dist/charts/sparkline/index.d.ts"
 			],
 			"trend-indicator": [
 				"./dist/components/trend-indicator/index.d.ts"

--- a/projects/js-packages/charts/src/charts/index.ts
+++ b/projects/js-packages/charts/src/charts/index.ts
@@ -5,4 +5,5 @@ export * from './leaderboard-chart';
 export * from './line-chart';
 export * from './pie-chart';
 export * from './pie-semi-circle-chart';
+export * from './segmented-bar';
 export * from './sparkline';

--- a/projects/js-packages/charts/src/charts/segmented-bar/index.ts
+++ b/projects/js-packages/charts/src/charts/segmented-bar/index.ts
@@ -1,0 +1,9 @@
+export { default as SegmentedBar, SegmentedBarUnresponsive } from './segmented-bar';
+
+export type {
+	SegmentedBarProps,
+	SegmentedBarSegment,
+	SegmentedBarMarker,
+	SegmentedBarMode,
+	SegmentedBarResponsiveConfig,
+} from './types';

--- a/projects/js-packages/charts/src/charts/segmented-bar/segmented-bar.module.scss
+++ b/projects/js-packages/charts/src/charts/segmented-bar/segmented-bar.module.scss
@@ -1,0 +1,105 @@
+.segmentedBar {
+	// CSS custom properties for theming
+	--segmented-bar-empty-bg: #e5e7eb;
+	--segmented-bar-label-color: #6b7280;
+	--segmented-bar-label-font-size: 12px;
+	--segmented-bar-tooltip-bg: #1f2937;
+	--segmented-bar-tooltip-color: #fff;
+	--segmented-bar-tooltip-font-size: 12px;
+	--segmented-bar-segment-hover-opacity: 0.8;
+	--segmented-bar-marker-width: 2px;
+
+	display: flex;
+	flex-direction: column;
+	position: relative;
+
+	&--empty {
+		display: block;
+		background-color: var(--segmented-bar-empty-bg);
+		border-radius: 4px;
+	}
+
+	&__bar {
+		display: flex;
+		width: 100%;
+		position: relative;
+		overflow: visible;
+	}
+
+	&__segment {
+		height: 100%;
+		flex-shrink: 0;
+		transition: opacity 0.15s ease;
+		cursor: default;
+
+		&:hover {
+			opacity: var(--segmented-bar-segment-hover-opacity);
+		}
+	}
+
+	&__marker {
+		position: absolute;
+		width: var(--segmented-bar-marker-width);
+		transform: translateX(-50%);
+		pointer-events: none;
+		z-index: 1;
+
+		&--animated {
+			transition: left 0.5s ease-out;
+		}
+
+		// Triangle indicator at top
+		&::before {
+			content: "";
+			position: absolute;
+			top: -4px;
+			left: 50%;
+			transform: translateX(-50%);
+			border-left: 4px solid transparent;
+			border-right: 4px solid transparent;
+			border-top: 4px solid currentColor;
+		}
+	}
+
+	&__labels {
+		display: flex;
+		position: relative;
+		margin-top: 4px;
+		height: 16px;
+		font-size: var(--segmented-bar-label-font-size);
+		color: var(--segmented-bar-label-color);
+	}
+
+	&__label {
+		position: absolute;
+		transform: translateX(-50%);
+		white-space: nowrap;
+
+		// First label aligned to left edge
+		&:first-child {
+			transform: translateX(0);
+		}
+
+		// Last label aligned to right edge
+		&:last-child {
+			transform: translateX(-100%);
+		}
+	}
+
+	&__tooltip {
+		background-color: var(--segmented-bar-tooltip-bg);
+		color: var(--segmented-bar-tooltip-color);
+		padding: 4px 8px;
+		border-radius: 4px;
+		font-size: var(--segmented-bar-tooltip-font-size);
+		white-space: nowrap;
+	}
+
+	&__tooltip__label {
+		font-weight: 500;
+	}
+
+	&__tooltip__value {
+		font-weight: 400;
+	}
+}

--- a/projects/js-packages/charts/src/charts/segmented-bar/segmented-bar.tsx
+++ b/projects/js-packages/charts/src/charts/segmented-bar/segmented-bar.tsx
@@ -1,0 +1,335 @@
+import { localPoint } from '@visx/event';
+import { useParentSize } from '@visx/responsive';
+import { useTooltip, useTooltipInPortal } from '@visx/tooltip';
+import clsx from 'clsx';
+import { useMemo, forwardRef, useCallback, useContext, useRef } from 'react';
+import {
+	GlobalChartsProvider,
+	GlobalChartsContext,
+	useGlobalChartsContext,
+	useChartId,
+} from '../../providers';
+import styles from './segmented-bar.module.scss';
+import type { SegmentedBarProps, SegmentedBarSegment, SegmentedBarResponsiveConfig } from './types';
+import type { MouseEvent, FC } from 'react';
+
+const DEFAULT_WIDTH = 300;
+const DEFAULT_LABEL_FORMATTER = ( value: number ) => value.toString();
+
+/**
+ * Normalizes input values to SegmentedBarSegment array without colors.
+ * Colors are applied separately using getElementStyles.
+ * @param values - Input values array (numbers or segment objects).
+ * @return Normalized array of SegmentedBarSegment objects.
+ */
+const normalizeSegments = ( values: number[] | SegmentedBarSegment[] ): SegmentedBarSegment[] => {
+	return ( values || [] ).map( value => {
+		return typeof value === 'number' ? { value } : { ...value };
+	} );
+};
+
+const SegmentedBarComponent = forwardRef< HTMLDivElement, SegmentedBarProps >(
+	(
+		{
+			values,
+			mode = 'proportional',
+			colors,
+			marker,
+			showLabels = true,
+			width = DEFAULT_WIDTH,
+			height: heightProp,
+			gap: gapProp,
+			borderRadius: borderRadiusProp,
+			className,
+			chartId: providedChartId,
+			labelFormatter = DEFAULT_LABEL_FORMATTER,
+			withTooltips = false,
+		},
+		ref
+	) => {
+		const { getElementStyles, theme } = useGlobalChartsContext();
+
+		// Get theme defaults
+		const height = heightProp ?? theme.segmentedBar.height;
+		const gap = gapProp ?? theme.segmentedBar.gap;
+		const borderRadius = borderRadiusProp ?? theme.segmentedBar.borderRadius;
+		const generatedChartId = useChartId();
+		const chartId = providedChartId || generatedChartId;
+
+		// Normalize values to segments with colors from context
+		const segments = useMemo( () => {
+			const normalizedSegments = normalizeSegments( values );
+			return normalizedSegments.map( ( segment, index ) => {
+				// Apply color priority: segment.color > colors prop > getElementStyles
+				const color = segment.color || colors?.[ index ] || getElementStyles( { index } ).color;
+				return { ...segment, color };
+			} );
+		}, [ values, colors, getElementStyles ] );
+
+		// Calculate total for proportional mode
+		const total = useMemo( () => {
+			return segments.reduce( ( sum, s ) => sum + s.value, 0 );
+		}, [ segments ] );
+
+		// Calculate segment widths as percentages
+		const segmentWidths = useMemo( () => {
+			if ( segments.length === 0 ) {
+				return [];
+			}
+			if ( mode === 'equal' ) {
+				return segments.map( () => 100 / segments.length );
+			}
+			if ( total === 0 ) {
+				return segments.map( () => 100 / segments.length );
+			}
+			return segments.map( s => ( s.value / total ) * 100 );
+		}, [ segments, mode, total ] );
+
+		// Calculate cumulative positions for labels
+		const labelPositions = useMemo( () => {
+			const positions: Array< { value: number; percent: number } > = [ { value: 0, percent: 0 } ];
+			let cumulative = 0;
+			let cumulativePercent = 0;
+
+			segments.forEach( ( s, index ) => {
+				cumulative += s.value;
+				cumulativePercent += segmentWidths[ index ];
+				positions.push( { value: cumulative, percent: cumulativePercent } );
+			} );
+
+			return positions;
+		}, [ segments, segmentWidths ] );
+
+		// Calculate marker position as percentage
+		const markerPosition = useMemo( () => {
+			if ( ! marker || total === 0 ) {
+				return null;
+			}
+			const percent = ( marker.value / total ) * 100;
+			return Math.min( 100, Math.max( 0, percent ) );
+		}, [ marker, total ] );
+
+		// Tooltip handling
+		const { tooltipOpen, tooltipLeft, tooltipTop, tooltipData, hideTooltip, showTooltip } =
+			useTooltip< { label?: string; value: number; color: string } >();
+
+		const { containerRef, TooltipInPortal } = useTooltipInPortal( {
+			detectBounds: true,
+			scroll: true,
+		} );
+
+		// Keep a local ref to the container for localPoint calculations
+		const internalRef = useRef< HTMLDivElement | null >( null );
+
+		// Merge forwarded ref with containerRef from useTooltipInPortal
+		const mergedRef = useCallback(
+			( node: HTMLDivElement | null ) => {
+				// Store internally for localPoint
+				internalRef.current = node;
+				// Call the tooltip container ref
+				containerRef( node );
+				// Forward to the external ref
+				if ( ref ) {
+					if ( typeof ref === 'function' ) {
+						ref( node );
+					} else {
+						ref.current = node;
+					}
+				}
+			},
+			[ containerRef, ref ]
+		);
+
+		const createSegmentMouseMoveHandler = useCallback(
+			( segment: SegmentedBarSegment ) => ( event: MouseEvent< HTMLDivElement > ) => {
+				if ( ! withTooltips || ! internalRef.current ) {
+					return;
+				}
+				// Get coordinates relative to the container element
+				const coords = localPoint( internalRef.current, event.nativeEvent );
+				if ( ! coords ) {
+					return;
+				}
+
+				showTooltip( {
+					tooltipData: {
+						label: segment.label,
+						value: segment.value,
+						color: segment.color || '#000',
+					},
+					tooltipLeft: coords.x,
+					tooltipTop: coords.y - 10,
+				} );
+			},
+			[ withTooltips, showTooltip ]
+		);
+
+		// Memoize handlers for each segment to avoid creating new functions on each render
+		const segmentMouseMoveHandlers = useMemo( () => {
+			return segments.map( segment => createSegmentMouseMoveHandler( segment ) );
+		}, [ segments, createSegmentMouseMoveHandler ] );
+
+		const handleMouseLeave = useCallback( () => {
+			if ( withTooltips ) {
+				hideTooltip();
+			}
+		}, [ withTooltips, hideTooltip ] );
+
+		// Handle empty data
+		if ( ! values || values.length === 0 ) {
+			return (
+				<div
+					ref={ ref }
+					className={ clsx( styles.segmentedBar, styles[ 'segmentedBar--empty' ], className ) }
+					style={ { width, height } }
+					data-testid="segmented-bar-empty"
+				/>
+			);
+		}
+
+		// Calculate total gap width
+		const totalGapWidth = gap * ( segments.length - 1 );
+		const availableWidth = width - totalGapWidth;
+
+		return (
+			<div
+				ref={ mergedRef }
+				className={ clsx( styles.segmentedBar, className ) }
+				style={ { width } }
+				data-testid="segmented-bar"
+				data-chart-id={ `segmented-bar-${ chartId }` }
+			>
+				<div
+					className={ styles.segmentedBar__bar }
+					style={ {
+						height,
+						borderRadius,
+						gap,
+					} }
+				>
+					{ segments.map( ( segment, index ) => {
+						const widthPercent = segmentWidths[ index ];
+						const isFirst = index === 0;
+						const isLast = index === segments.length - 1;
+
+						return (
+							<div
+								key={ index }
+								className={ clsx( styles.segmentedBar__segment, {
+									[ styles[ 'segmentedBar__segment--first' ] ]: isFirst,
+									[ styles[ 'segmentedBar__segment--last' ] ]: isLast,
+								} ) }
+								style={ {
+									width: `${ ( widthPercent / 100 ) * availableWidth }px`,
+									backgroundColor: segment.color,
+									borderTopLeftRadius: isFirst ? borderRadius : 0,
+									borderBottomLeftRadius: isFirst ? borderRadius : 0,
+									borderTopRightRadius: isLast ? borderRadius : 0,
+									borderBottomRightRadius: isLast ? borderRadius : 0,
+								} }
+								onMouseMove={ segmentMouseMoveHandlers[ index ] }
+								onMouseLeave={ handleMouseLeave }
+								data-testid={ `segmented-bar-segment-${ index }` }
+							/>
+						);
+					} ) }
+
+					{ marker && markerPosition !== null && (
+						<div
+							className={ clsx( styles.segmentedBar__marker, {
+								[ styles[ 'segmentedBar__marker--animated' ] ]: marker.showAnimation,
+							} ) }
+							style={ {
+								left: `${ markerPosition }%`,
+								height: height + 8,
+								top: -4,
+								backgroundColor: marker.color || theme.segmentedBar.markerColor,
+							} }
+							data-testid="segmented-bar-marker"
+							title={ marker.tooltip }
+						/>
+					) }
+				</div>
+
+				{ showLabels && (
+					<div className={ styles.segmentedBar__labels }>
+						{ labelPositions.map( ( pos, index ) => (
+							<span
+								key={ index }
+								className={ styles.segmentedBar__label }
+								style={ {
+									left: `${ pos.percent }%`,
+								} }
+								data-testid={ `segmented-bar-label-${ index }` }
+							>
+								{ labelFormatter( pos.value ) }
+							</span>
+						) ) }
+					</div>
+				) }
+
+				{ withTooltips && tooltipOpen && tooltipData && (
+					<TooltipInPortal top={ tooltipTop || 0 } left={ tooltipLeft || 0 }>
+						<div className={ styles.segmentedBar__tooltip } role="tooltip">
+							{ tooltipData.label && (
+								<span className={ styles.segmentedBar__tooltip__label }>
+									{ tooltipData.label }:{ ' ' }
+								</span>
+							) }
+							<span className={ styles.segmentedBar__tooltip__value }>{ tooltipData.value }</span>
+						</div>
+					</TooltipInPortal>
+				) }
+			</div>
+		);
+	}
+);
+
+SegmentedBarComponent.displayName = 'SegmentedBarComponent';
+
+const SegmentedBarUnresponsive: FC< SegmentedBarProps > = props => {
+	const existingContext = useContext( GlobalChartsContext );
+
+	// If we're already in a GlobalChartsProvider context, render the core component directly
+	if ( existingContext ) {
+		return <SegmentedBarComponent { ...props } />;
+	}
+
+	// Otherwise, wrap with our own GlobalChartsProvider
+	return (
+		<GlobalChartsProvider>
+			<SegmentedBarComponent { ...props } />
+		</GlobalChartsProvider>
+	);
+};
+
+SegmentedBarUnresponsive.displayName = 'SegmentedBarUnresponsive';
+
+const SegmentedBar: FC<
+	Omit< SegmentedBarProps, 'width' > & SegmentedBarResponsiveConfig & { width?: number }
+> = ( { resizeDebounceTime = 300, maxWidth = 1200, ...chartProps } ) => {
+	const { parentRef, width: parentWidth } = useParentSize( {
+		debounceTime: resizeDebounceTime,
+		enableDebounceLeadingCall: true,
+	} );
+
+	const containerWidth = parentWidth > 0 ? Math.min( parentWidth, maxWidth ) : 0;
+
+	return (
+		<div
+			ref={ parentRef }
+			style={ {
+				width: chartProps.width ?? '100%',
+			} }
+		>
+			<SegmentedBarUnresponsive
+				{ ...chartProps }
+				width={ containerWidth || chartProps.width || DEFAULT_WIDTH }
+			/>
+		</div>
+	);
+};
+
+SegmentedBar.displayName = 'SegmentedBar';
+
+export { SegmentedBar as default, SegmentedBarUnresponsive };

--- a/projects/js-packages/charts/src/charts/segmented-bar/stories/index.api.mdx
+++ b/projects/js-packages/charts/src/charts/segmented-bar/stories/index.api.mdx
@@ -1,0 +1,223 @@
+import { Meta, Source } from '@storybook/addon-docs/blocks';
+
+<Meta title="JS Packages/Charts Library/Charts/Segmented Bar/API Reference" />
+
+# Segmented Bar API Reference
+
+Complete API documentation for the Segmented Bar component.
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `values` | `number[] \| SegmentedBarSegment[]` | **Required** | Array of segment values or segment objects |
+| `mode` | `'proportional' \| 'equal'` | `'proportional'` | How segment widths are calculated |
+| `colors` | `string[]` | Theme colors | Custom colors for segments |
+| `marker` | `SegmentedBarMarker` | - | Optional position indicator |
+| `showLabels` | `boolean` | `true` | Whether to show cumulative value labels |
+| `width` | `number` | `300` | Width of the bar in pixels |
+| `height` | `number` | Theme default (`8`) | Height of the bar in pixels |
+| `gap` | `number` | Theme default (`0`) | Gap between segments in pixels |
+| `borderRadius` | `number` | Theme default (`4`) | Corner radius for bar ends |
+| `className` | `string` | - | Additional CSS class name |
+| `chartId` | `string` | Auto-generated | Unique ID for the chart |
+| `labelFormatter` | `(value: number) => string` | `value.toString()` | Formatter for label values |
+| `withTooltips` | `boolean` | `false` | Whether to show tooltips on hover |
+
+## Responsive Variant Props
+
+The responsive `SegmentedBar` variant accepts additional props:
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `resizeDebounceTime` | `number` | `300` | Debounce time for resize events in ms |
+| `maxWidth` | `number` | `1200` | Maximum width for the responsive chart |
+
+## Type Definitions
+
+### SegmentedBarSegment
+
+<Source
+	language="typescript"
+	code={`interface SegmentedBarSegment {
+	/** Numeric value for this segment */
+	value: number;
+	/** Optional label for the segment (used in tooltips) */
+	label?: string;
+	/** Optional color override for this segment */
+	color?: string;
+}`}
+/>
+
+### SegmentedBarMarker
+
+<Source
+	language="typescript"
+	code={`interface SegmentedBarMarker {
+	/** Position value where the marker should appear (0 to total) */
+	value: number;
+	/** Optional tooltip text for the marker */
+	tooltip?: string;
+	/** Whether to animate the marker position */
+	showAnimation?: boolean;
+	/** Marker color (defaults to theme segmentedBar.markerColor) */
+	color?: string;
+}`}
+/>
+
+### SegmentedBarMode
+
+<Source
+	language="typescript"
+	code={`type SegmentedBarMode = 'proportional' | 'equal';`}
+/>
+
+### SegmentedBarProps
+
+<Source
+	language="typescript"
+	code={`interface SegmentedBarProps {
+	values: number[] | SegmentedBarSegment[];
+	mode?: SegmentedBarMode;
+	colors?: string[];
+	marker?: SegmentedBarMarker;
+	showLabels?: boolean;
+	width?: number;
+	height?: number;
+	gap?: number;
+	borderRadius?: number;
+	className?: string;
+	chartId?: string;
+	labelFormatter?: (value: number) => string;
+	withTooltips?: boolean;
+}`}
+/>
+
+### SegmentedBarResponsiveConfig
+
+<Source
+	language="typescript"
+	code={`type SegmentedBarResponsiveConfig = {
+	maxWidth?: number;
+	resizeDebounceTime?: number;
+}`}
+/>
+
+## Exports
+
+<Source
+	language="typescript"
+	code={`// Component exports
+import { SegmentedBar, SegmentedBarUnresponsive } from '@automattic/charts';
+
+// Type exports
+import type {
+	SegmentedBarProps,
+	SegmentedBarSegment,
+	SegmentedBarMarker,
+	SegmentedBarMode,
+} from '@automattic/charts';
+
+// Direct import (tree-shakeable)
+import { SegmentedBar } from '@automattic/charts/segmented-bar';`}
+/>
+
+## Component Variants
+
+| Variant | Description |
+|---------|-------------|
+| `SegmentedBar` | Responsive variant that adapts to container width |
+| `SegmentedBarUnresponsive` | Fixed-size variant requiring explicit width |
+
+## CSS Classes
+
+The component uses CSS Modules with the following class structure:
+
+| Class | Description |
+|-------|-------------|
+| `.segmentedBar` | Root container element |
+| `.segmentedBar--empty` | Applied when values array is empty |
+| `.segmentedBar__bar` | The horizontal bar container |
+| `.segmentedBar__segment` | Individual segment elements |
+| `.segmentedBar__segment--first` | First segment (has left border radius) |
+| `.segmentedBar__segment--last` | Last segment (has right border radius) |
+| `.segmentedBar__marker` | Position marker element |
+| `.segmentedBar__marker--animated` | Marker with animation enabled |
+| `.segmentedBar__labels` | Labels container |
+| `.segmentedBar__label` | Individual label elements |
+| `.segmentedBar__tooltip` | Tooltip container |
+| `.segmentedBar__tooltip__label` | Tooltip label text |
+| `.segmentedBar__tooltip__value` | Tooltip value text |
+
+## CSS Custom Properties
+
+The component exposes CSS custom properties for theming:
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| `--segmented-bar-empty-bg` | `#e5e7eb` | Empty state background color |
+| `--segmented-bar-label-color` | `#6b7280` | Label text color |
+| `--segmented-bar-label-font-size` | `12px` | Label font size |
+| `--segmented-bar-tooltip-bg` | `#1f2937` | Tooltip background color |
+| `--segmented-bar-tooltip-color` | `#fff` | Tooltip text color |
+| `--segmented-bar-tooltip-font-size` | `12px` | Tooltip font size |
+| `--segmented-bar-segment-hover-opacity` | `0.8` | Segment hover opacity |
+| `--segmented-bar-marker-width` | `2px` | Marker line width |
+
+## Theme Configuration
+
+The component reads from the theme's `segmentedBar` configuration:
+
+<Source
+	language="typescript"
+	code={`interface ChartTheme {
+	segmentedBar?: {
+		height?: number;        // Default bar height
+		gap?: number;           // Default gap between segments
+		borderRadius?: number;  // Default corner radius
+		markerColor?: string;   // Default marker color
+	};
+}`}
+/>
+
+## Data Test IDs
+
+For testing, the component provides these test IDs:
+
+| Test ID | Description |
+|---------|-------------|
+| `segmented-bar` | Main component container |
+| `segmented-bar-empty` | Empty state container |
+| `segmented-bar-segment-{index}` | Individual segments (0-indexed) |
+| `segmented-bar-marker` | Position marker |
+| `segmented-bar-label-{index}` | Cumulative labels (0-indexed) |
+
+## Display Mode Calculations
+
+### Proportional Mode
+
+```
+Segment width = (segment.value / total) * 100%
+```
+
+### Equal Mode
+
+```
+Segment width = 100% / number of segments
+```
+
+### Marker Positioning
+
+```
+Marker position = (marker.value / total) * 100%
+```
+
+Values outside the valid range (0 to total) are clamped.
+
+## Color Priority
+
+Colors are resolved in this order:
+
+1. `segment.color` (from segment object)
+2. `colors[index]` (from colors prop)
+3. `getElementStyles({ index })` (from theme context)

--- a/projects/js-packages/charts/src/charts/segmented-bar/stories/index.docs.mdx
+++ b/projects/js-packages/charts/src/charts/segmented-bar/stories/index.docs.mdx
@@ -1,0 +1,264 @@
+import { Meta, Canvas, Source } from '@storybook/addon-docs/blocks';
+import * as SegmentedBarStories from './index.stories';
+
+<Meta title="JS Packages/Charts Library/Charts/Segmented Bar" of={ SegmentedBarStories } />
+
+# Segmented Bar
+
+A horizontal segmented bar component for visualizing proportions, progress, or status indicators.
+
+<Canvas of={ SegmentedBarStories.Default } />
+
+## Overview
+
+The Segmented Bar displays colored segments that can show proportional data or equal-width status indicators. It supports tooltips, markers, and customizable labels.
+
+**Key features:**
+- Two display modes: proportional (widths based on values) or equal (same width segments)
+- Optional position markers with animation
+- Tooltips on hover
+- Customizable colors, gap, and border radius
+- Responsive and fixed-width variants
+
+<Source
+	language="jsx"
+	code={`import { SegmentedBar } from '@automattic/charts';
+	import '@automattic/charts/segmented-bar/style.css';
+
+	<SegmentedBar
+		values={[
+			{ value: 40, label: 'Direct' },
+			{ value: 30, label: 'Organic Search' },
+			{ value: 20, label: 'Referral' },
+			{ value: 10, label: 'Social' },
+		]}
+		height={8}
+		withTooltips
+	/>`}
+/>
+
+## API Reference
+
+For detailed information about component props and types, see the [Segmented Bar API Reference](./?path=/docs/js-packages-charts-library-charts-segmented-bar-api-reference--docs).
+
+## Basic Usage
+
+### Simple Segmented Bar
+
+The simplest segmented bar requires only a `values` prop with an array of numeric values or segment objects:
+
+<Canvas of={ SegmentedBarStories.Default } />
+
+<Source
+	language="jsx"
+	code={`<SegmentedBar
+		values={[40, 30, 20, 10]}
+		height={8}
+	/>`}
+/>
+
+### Required Props
+
+- **`values`**: Array of numeric values or segment objects (`{ value, label?, color? }`)
+
+### Optional Props
+
+- **`mode`** (default: `'proportional'`): Display mode - `'proportional'` or `'equal'`
+- **`height`** (default: `8`): Height of the bar in pixels
+- **`gap`** (default: `0`): Gap between segments in pixels
+- **`borderRadius`** (default: `4`): Corner radius for bar ends
+- **`showLabels`** (default: `true`): Whether to show cumulative value labels
+- **`withTooltips`** (default: `false`): Enable tooltips on hover
+- **`colors`**: Custom colors array (overrides theme colors)
+- **`marker`**: Position indicator configuration
+- **`labelFormatter`**: Custom function to format label values
+
+For detailed prop information and type definitions, see the [Segmented Bar API Reference](./?path=/docs/js-packages-charts-library-charts-segmented-bar-api-reference--docs).
+
+## Display Modes
+
+### Proportional Mode (Default)
+
+Segment widths are calculated based on their values relative to the total:
+
+<Canvas of={ SegmentedBarStories.Default } />
+
+### Equal Mode
+
+All segments have the same width regardless of values. Useful for status indicators:
+
+<Canvas of={ SegmentedBarStories.EqualMode } />
+
+<Source
+	language="jsx"
+	code={`<SegmentedBar
+		values={[
+			{ value: 1, label: 'Critical' },
+			{ value: 1, label: 'Warning' },
+			{ value: 1, label: 'Good' },
+		]}
+		mode="equal"
+		colors={['#ef4444', '#f59e0b', '#22c55e']}
+		gap={2}
+		showLabels={false}
+	/>`}
+/>
+
+## Marker Indicator
+
+Add a marker to indicate a specific position on the bar, useful for showing targets or thresholds:
+
+<Canvas of={ SegmentedBarStories.WithMarker } />
+
+<Source
+	language="jsx"
+	code={`<SegmentedBar
+		values={[25, 35, 25, 15]}
+		marker={{
+			value: 60,
+			tooltip: 'Target: 60%',
+			showAnimation: true,
+		}}
+		withTooltips
+	/>`}
+/>
+
+## Visual Customization
+
+### Custom Colors
+
+Override theme colors with the `colors` prop:
+
+<Source
+	language="jsx"
+	code={`<SegmentedBar
+		values={[40, 30, 20, 10]}
+		colors={['#3B82F6', '#10B981', '#F59E0B', '#EF4444']}
+	/>`}
+/>
+
+### Gaps Between Segments
+
+Add visual separation between segments:
+
+<Source
+	language="jsx"
+	code={`<SegmentedBar
+		values={[30, 40, 30]}
+		gap={2}
+		borderRadius={4}
+	/>`}
+/>
+
+### Custom Labels
+
+Use `labelFormatter` to customize how values are displayed:
+
+<Source
+	language="jsx"
+	code={`<SegmentedBar
+		values={[25, 50, 25]}
+		labelFormatter={(value) => \`\${value}%\`}
+	/>`}
+/>
+
+## Theming Integration
+
+Segmented bars integrate seamlessly with the chart theming system. The default theme has neutral colors and styling, and is automatically applied to all charts unless a custom theme is provided. A custom theme can be provided by wrapping your chart in `GlobalChartsProvider` and passing a custom theme object with the properties you want to override to the `theme` prop:
+
+<Source
+	language="tsx"
+	code={`import { GlobalChartsProvider, SegmentedBar, type ChartTheme } from '@automattic/charts';
+
+	const customTheme: ChartTheme = {
+		colors: ['#FF6B6B', '#4ECDC4', '#45B7D1', '#FFA07A'],
+		segmentedBar: {
+			height: 12,
+			gap: 2,
+			borderRadius: 6,
+			markerColor: '#1F2937',
+		},
+	};
+
+	<GlobalChartsProvider theme={customTheme}>
+		<SegmentedBar values={[30, 40, 30]} />
+	</GlobalChartsProvider>`}
+/>
+
+## Edge Cases
+
+The component handles various edge cases gracefully:
+
+### Empty Data
+
+When values is empty (`[]`), renders an empty container with the `segmentedBar--empty` class:
+
+<Source
+	language="jsx"
+	code={`<SegmentedBar values={[]} />
+	// Renders empty placeholder`}
+/>
+
+### Single Segment
+
+Renders a full-width bar:
+
+<Source
+	language="jsx"
+	code={`<SegmentedBar values={[100]} />`}
+/>
+
+### All Zero Values
+
+In proportional mode, all segments get equal width when total is zero:
+
+<Source
+	language="jsx"
+	code={`<SegmentedBar values={[0, 0, 0]} />
+	// All segments: 33.33% width each`}
+/>
+
+### Marker Out of Range
+
+Marker values are clamped to the valid range (0 to total data value):
+
+<Source
+	language="jsx"
+	code={`<SegmentedBar
+		values={[50, 50]}
+		marker={{ value: 150 }}  // Clamped to 100 (total value)
+	/>`}
+/>
+
+## Accessibility
+
+Segmented bars are decorative visualizations. For accessibility, wrap the component in a container that provides context:
+
+<Source
+	language="jsx"
+	code={`<div role="img" aria-label="Traffic sources: Direct 40%, Organic 30%, Referral 20%, Social 10%" aria-hidden="true">
+		<SegmentedBar values={[40, 30, 20, 10]} />
+	</div>`}
+/>
+
+**Best Practices:**
+- Use `role="img"` on the container
+- Provide `aria-label` describing what the segments represent
+- Add `aria-hidden="true"` to the wrapper container (not the component itself)
+- Consider showing percentage or value text alongside the visualization
+
+## Browser Compatibility
+
+Segmented bar charts are compatible with all modern browsers:
+- Chrome/Edge (latest)
+- Firefox (latest)
+- Safari (latest)
+- Mobile browsers (iOS Safari, Chrome Mobile)
+
+## Performance
+
+Segmented bars are optimized for performance with:
+- Memoized segment calculations and color resolution
+- Efficient CSS-based rendering
+- Tooltip portal only rendered when `withTooltips` is enabled
+- Responsive variant uses `ResizeObserver` for efficient resizing

--- a/projects/js-packages/charts/src/charts/segmented-bar/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/charts/segmented-bar/stories/index.stories.tsx
@@ -1,0 +1,110 @@
+import { SegmentedBar } from '../';
+import type { SegmentedBarProps } from '../types';
+import type { Meta, StoryObj } from '@storybook/react';
+
+const meta: Meta< SegmentedBarProps > = {
+	title: 'JS Packages/Charts Library/Charts/Segmented Bar',
+	component: SegmentedBar,
+	parameters: {
+		layout: 'padded',
+	},
+	argTypes: {
+		values: {
+			control: 'object',
+			description: 'Array of segment values (numbers or segment objects with value, label, color)',
+			table: { category: 'Data' },
+		},
+		mode: {
+			control: 'select',
+			options: [ 'proportional', 'equal' ],
+			description: 'Proportional: widths based on values. Equal: all segments same width.',
+			table: { category: 'Display' },
+		},
+		colors: {
+			control: 'object',
+			description: 'Custom colors for segments',
+			table: { category: 'Visual Style' },
+		},
+		showLabels: {
+			control: 'boolean',
+			description: 'Show cumulative value labels',
+			table: { category: 'Display' },
+		},
+		withTooltips: {
+			control: 'boolean',
+			description: 'Show tooltips on hover',
+			table: { category: 'Interaction' },
+		},
+		height: {
+			control: { type: 'number', min: 4, max: 32 },
+			description: 'Height of the bar in pixels',
+			table: { category: 'Dimensions' },
+		},
+		gap: {
+			control: { type: 'number', min: 0, max: 8 },
+			description: 'Gap between segments in pixels',
+			table: { category: 'Visual Style' },
+		},
+		borderRadius: {
+			control: { type: 'number', min: 0, max: 16 },
+			description: 'Corner radius for the bar',
+			table: { category: 'Visual Style' },
+		},
+	},
+};
+
+export default meta;
+type Story = StoryObj< typeof SegmentedBar >;
+
+/**
+ * Default segmented bar with proportional segments.
+ * Use the controls to explore different configurations.
+ */
+export const Default: Story = {
+	args: {
+		values: [
+			{ value: 40, label: 'Direct' },
+			{ value: 30, label: 'Organic Search' },
+			{ value: 20, label: 'Referral' },
+			{ value: 10, label: 'Social' },
+		],
+		height: 8,
+		withTooltips: true,
+	},
+};
+
+/**
+ * Equal mode where all segments have the same width regardless of values.
+ * Useful for status indicators like health checks.
+ */
+export const EqualMode: Story = {
+	args: {
+		values: [
+			{ value: 1, label: 'Critical' },
+			{ value: 1, label: 'Warning' },
+			{ value: 1, label: 'Good' },
+		],
+		mode: 'equal',
+		height: 6,
+		colors: [ '#ef4444', '#f59e0b', '#22c55e' ],
+		gap: 2,
+		borderRadius: 3,
+		showLabels: false,
+	},
+};
+
+/**
+ * Segmented bar with a marker indicating a specific position.
+ */
+export const WithMarker: Story = {
+	args: {
+		values: [ 25, 35, 25, 15 ],
+		height: 8,
+		marker: {
+			value: 60,
+			tooltip: 'Target: 60%',
+			showAnimation: true,
+		},
+		withTooltips: true,
+	},
+};

--- a/projects/js-packages/charts/src/charts/segmented-bar/test/segmented-bar.test.tsx
+++ b/projects/js-packages/charts/src/charts/segmented-bar/test/segmented-bar.test.tsx
@@ -1,0 +1,320 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { SegmentedBar, SegmentedBarUnresponsive } from '../';
+import { GlobalChartsProvider, defaultTheme } from '../../../providers';
+
+describe( 'SegmentedBar', () => {
+	const defaultData = [ 25, 50, 25 ];
+
+	const renderWithTheme = ( props = {} ) => {
+		return render(
+			<GlobalChartsProvider theme={ defaultTheme }>
+				<SegmentedBarUnresponsive values={ defaultData } { ...props } />
+			</GlobalChartsProvider>
+		);
+	};
+
+	describe( 'Basic Rendering', () => {
+		test( 'renders with array of numbers', () => {
+			renderWithTheme();
+			expect( screen.getByTestId( 'segmented-bar' ) ).toBeInTheDocument();
+		} );
+
+		test( 'renders correct number of segments', () => {
+			renderWithTheme();
+			expect( screen.getByTestId( 'segmented-bar-segment-0' ) ).toBeInTheDocument();
+			expect( screen.getByTestId( 'segmented-bar-segment-1' ) ).toBeInTheDocument();
+			expect( screen.getByTestId( 'segmented-bar-segment-2' ) ).toBeInTheDocument();
+		} );
+
+		test( 'renders with segment objects', () => {
+			renderWithTheme( {
+				values: [
+					{ value: 30, label: 'First' },
+					{ value: 70, label: 'Second' },
+				],
+			} );
+			expect( screen.getByTestId( 'segmented-bar-segment-0' ) ).toBeInTheDocument();
+			expect( screen.getByTestId( 'segmented-bar-segment-1' ) ).toBeInTheDocument();
+		} );
+
+		test( 'applies custom className', () => {
+			renderWithTheme( { className: 'custom-class' } );
+			expect( screen.getByTestId( 'segmented-bar' ) ).toHaveClass( 'custom-class' );
+		} );
+
+		test( 'renders responsive variant', () => {
+			render(
+				<GlobalChartsProvider theme={ defaultTheme }>
+					<SegmentedBar values={ defaultData } width={ 200 } height={ 10 } />
+				</GlobalChartsProvider>
+			);
+			expect( screen.getByTestId( 'segmented-bar' ) ).toBeInTheDocument();
+		} );
+	} );
+
+	describe( 'Display Modes', () => {
+		test( 'proportional mode: segment widths reflect values', () => {
+			renderWithTheme( { values: [ 25, 75 ], width: 200, gap: 0 } );
+			const segment0 = screen.getByTestId( 'segmented-bar-segment-0' );
+			const segment1 = screen.getByTestId( 'segmented-bar-segment-1' );
+
+			// First segment should be 25% width, second 75%
+			expect( segment0 ).toHaveStyle( { width: '50px' } ); // 25% of 200
+			expect( segment1 ).toHaveStyle( { width: '150px' } ); // 75% of 200
+		} );
+
+		test( 'equal mode: all segments same width', () => {
+			renderWithTheme( { values: [ 25, 75 ], mode: 'equal', width: 200, gap: 0 } );
+			const segment0 = screen.getByTestId( 'segmented-bar-segment-0' );
+			const segment1 = screen.getByTestId( 'segmented-bar-segment-1' );
+
+			// Both segments should be 50% width
+			expect( segment0 ).toHaveStyle( { width: '100px' } );
+			expect( segment1 ).toHaveStyle( { width: '100px' } );
+		} );
+	} );
+
+	describe( 'Edge Cases', () => {
+		test( 'handles empty values array', () => {
+			renderWithTheme( { values: [] } );
+			expect( screen.getByTestId( 'segmented-bar-empty' ) ).toBeInTheDocument();
+		} );
+
+		test( 'handles single segment', () => {
+			renderWithTheme( { values: [ 100 ] } );
+			expect( screen.getByTestId( 'segmented-bar-segment-0' ) ).toBeInTheDocument();
+			expect( screen.queryByTestId( 'segmented-bar-segment-1' ) ).not.toBeInTheDocument();
+		} );
+
+		test( 'handles all zero values', () => {
+			renderWithTheme( { values: [ 0, 0, 0 ], mode: 'equal', width: 300, gap: 0 } );
+			// Should render equal segments when all values are zero
+			const segment0 = screen.getByTestId( 'segmented-bar-segment-0' );
+			// Allow for floating point precision issues
+			const computedWidth = parseFloat( segment0.style.width );
+			expect( computedWidth ).toBeCloseTo( 100, 0 );
+		} );
+	} );
+
+	describe( 'Styling', () => {
+		test( 'custom colors applied correctly', () => {
+			renderWithTheme( {
+				values: [ 50, 50 ],
+				colors: [ '#ff0000', '#00ff00' ],
+			} );
+			const segment0 = screen.getByTestId( 'segmented-bar-segment-0' );
+			const segment1 = screen.getByTestId( 'segmented-bar-segment-1' );
+
+			expect( segment0 ).toHaveStyle( { backgroundColor: '#ff0000' } );
+			expect( segment1 ).toHaveStyle( { backgroundColor: '#00ff00' } );
+		} );
+
+		test( 'segment object colors override colors prop', () => {
+			renderWithTheme( {
+				values: [ { value: 50, color: '#0000ff' }, { value: 50 } ],
+				colors: [ '#ff0000', '#00ff00' ],
+			} );
+			const segment0 = screen.getByTestId( 'segmented-bar-segment-0' );
+			const segment1 = screen.getByTestId( 'segmented-bar-segment-1' );
+
+			expect( segment0 ).toHaveStyle( { backgroundColor: '#0000ff' } );
+			expect( segment1 ).toHaveStyle( { backgroundColor: '#00ff00' } );
+		} );
+
+		test( 'border radius applied to first and last segments', () => {
+			renderWithTheme( { values: [ 33, 34, 33 ], borderRadius: 8 } );
+			const segment0 = screen.getByTestId( 'segmented-bar-segment-0' );
+			const segment2 = screen.getByTestId( 'segmented-bar-segment-2' );
+
+			expect( segment0 ).toHaveStyle( { borderTopLeftRadius: '8px' } );
+			expect( segment0 ).toHaveStyle( { borderBottomLeftRadius: '8px' } );
+			expect( segment2 ).toHaveStyle( { borderTopRightRadius: '8px' } );
+			expect( segment2 ).toHaveStyle( { borderBottomRightRadius: '8px' } );
+		} );
+	} );
+
+	describe( 'Dimensions', () => {
+		test( 'applies default dimensions', () => {
+			renderWithTheme();
+			const bar = screen.getByTestId( 'segmented-bar' );
+			expect( bar ).toHaveStyle( { width: '300px' } );
+		} );
+
+		test( 'applies custom dimensions', () => {
+			renderWithTheme( { width: 400, height: 12 } );
+			const bar = screen.getByTestId( 'segmented-bar' );
+			expect( bar ).toHaveStyle( { width: '400px' } );
+		} );
+	} );
+
+	describe( 'Labels', () => {
+		test( 'shows labels when showLabels=true', () => {
+			renderWithTheme( { showLabels: true } );
+			// Should show cumulative labels: 0, 25, 75, 100
+			expect( screen.getByTestId( 'segmented-bar-label-0' ) ).toHaveTextContent( '0' );
+			expect( screen.getByTestId( 'segmented-bar-label-3' ) ).toHaveTextContent( '100' );
+		} );
+
+		test( 'hides labels when showLabels=false', () => {
+			renderWithTheme( { showLabels: false } );
+			expect( screen.queryByTestId( 'segmented-bar-label-0' ) ).not.toBeInTheDocument();
+		} );
+
+		test( 'custom labelFormatter works', () => {
+			renderWithTheme( {
+				showLabels: true,
+				labelFormatter: value => `${ value }%`,
+			} );
+			expect( screen.getByTestId( 'segmented-bar-label-0' ) ).toHaveTextContent( '0%' );
+			expect( screen.getByTestId( 'segmented-bar-label-3' ) ).toHaveTextContent( '100%' );
+		} );
+	} );
+
+	describe( 'Marker', () => {
+		test( 'renders marker at correct position', () => {
+			renderWithTheme( {
+				values: [ 50, 50 ],
+				marker: { value: 25 },
+			} );
+			const marker = screen.getByTestId( 'segmented-bar-marker' );
+			expect( marker ).toBeInTheDocument();
+			expect( marker ).toHaveStyle( { left: '25%' } );
+		} );
+
+		test( 'marker tooltip displays', () => {
+			renderWithTheme( {
+				values: [ 50, 50 ],
+				marker: { value: 50, tooltip: 'Halfway point' },
+			} );
+			const marker = screen.getByTestId( 'segmented-bar-marker' );
+			expect( marker ).toHaveAttribute( 'title', 'Halfway point' );
+		} );
+
+		test( 'marker renders with showAnimation=true', () => {
+			renderWithTheme( {
+				values: [ 50, 50 ],
+				marker: { value: 50, showAnimation: true },
+			} );
+			const marker = screen.getByTestId( 'segmented-bar-marker' );
+			// Marker should be present - animation is a CSS-only visual effect
+			expect( marker ).toBeInTheDocument();
+			expect( marker ).toHaveStyle( { left: '50%' } );
+		} );
+	} );
+
+	describe( 'Theme Integration', () => {
+		test( 'uses theme colors by default', () => {
+			renderWithTheme( { values: [ 50, 50 ] } );
+			const segment0 = screen.getByTestId( 'segmented-bar-segment-0' );
+			// Default theme first color
+			expect( segment0 ).toHaveStyle( { backgroundColor: defaultTheme.colors[ 0 ] } );
+		} );
+
+		test( 'color prop overrides theme color', () => {
+			renderWithTheme( {
+				values: [ 50, 50 ],
+				colors: [ '#custom1', '#custom2' ],
+			} );
+			const segment0 = screen.getByTestId( 'segmented-bar-segment-0' );
+			expect( segment0 ).toHaveStyle( { backgroundColor: '#custom1' } );
+		} );
+	} );
+
+	describe( 'Gap Between Segments', () => {
+		test( 'applies gap between segments', () => {
+			renderWithTheme( { values: [ 50, 50 ], gap: 4, width: 204 } );
+			// With 4px gap and 204px width, available width is 200px
+			// Each segment should be 100px (50% of 200)
+			const segment0 = screen.getByTestId( 'segmented-bar-segment-0' );
+			expect( segment0 ).toHaveStyle( { width: '100px' } );
+		} );
+	} );
+
+	describe( 'Tooltips', () => {
+		test( 'shows tooltip on segment hover when withTooltips=true', async () => {
+			const user = userEvent.setup();
+			renderWithTheme( {
+				values: [
+					{ value: 50, label: 'First' },
+					{ value: 50, label: 'Second' },
+				],
+				withTooltips: true,
+				showLabels: false,
+			} );
+			const segment0 = screen.getByTestId( 'segmented-bar-segment-0' );
+
+			await user.hover( segment0 );
+
+			await waitFor( () => {
+				expect( screen.getByRole( 'tooltip' ) ).toBeInTheDocument();
+			} );
+			const tooltip = screen.getByRole( 'tooltip' );
+			expect( tooltip ).toHaveTextContent( 'First:' );
+			expect( tooltip ).toHaveTextContent( '50' );
+		} );
+
+		test( 'does not show tooltip when withTooltips=false', async () => {
+			const user = userEvent.setup();
+			renderWithTheme( {
+				values: [
+					{ value: 50, label: 'First' },
+					{ value: 50, label: 'Second' },
+				],
+				withTooltips: false,
+			} );
+			const segment0 = screen.getByTestId( 'segmented-bar-segment-0' );
+
+			await user.hover( segment0 );
+
+			expect( screen.queryByRole( 'tooltip' ) ).not.toBeInTheDocument();
+		} );
+
+		test( 'hides tooltip on mouse leave', async () => {
+			const user = userEvent.setup();
+			renderWithTheme( {
+				values: [
+					{ value: 50, label: 'First' },
+					{ value: 50, label: 'Second' },
+				],
+				withTooltips: true,
+				showLabels: false,
+			} );
+			const segment0 = screen.getByTestId( 'segmented-bar-segment-0' );
+
+			await user.hover( segment0 );
+
+			await waitFor( () => {
+				expect( screen.getByRole( 'tooltip' ) ).toBeInTheDocument();
+			} );
+
+			await user.unhover( segment0 );
+
+			await waitFor( () => {
+				expect( screen.queryByRole( 'tooltip' ) ).not.toBeInTheDocument();
+			} );
+		} );
+
+		test( 'tooltip displays segment value without label', async () => {
+			const user = userEvent.setup();
+			renderWithTheme( {
+				values: [ 75, 25 ],
+				withTooltips: true,
+				showLabels: false,
+			} );
+			const segment0 = screen.getByTestId( 'segmented-bar-segment-0' );
+
+			await user.hover( segment0 );
+
+			await waitFor( () => {
+				expect( screen.getByRole( 'tooltip' ) ).toBeInTheDocument();
+			} );
+			const tooltip = screen.getByRole( 'tooltip' );
+			expect( tooltip ).toHaveTextContent( '75' );
+		} );
+	} );
+} );

--- a/projects/js-packages/charts/src/charts/segmented-bar/types.ts
+++ b/projects/js-packages/charts/src/charts/segmented-bar/types.ts
@@ -1,0 +1,148 @@
+/**
+ * Single segment in the segmented bar
+ */
+export interface SegmentedBarSegment {
+	/**
+	 * Numeric value for this segment.
+	 * In 'proportional' mode, determines segment width relative to total.
+	 * In 'equal' mode, used for tooltip/label display only.
+	 */
+	value: number;
+
+	/**
+	 * Optional label for the segment (used in tooltips)
+	 */
+	label?: string;
+
+	/**
+	 * Optional color override for this segment.
+	 * If not provided, uses theme colors by index.
+	 */
+	color?: string;
+}
+
+/**
+ * Marker configuration for indicating a position on the bar
+ */
+export interface SegmentedBarMarker {
+	/**
+	 * Position value where the marker should appear.
+	 * Interpreted as cumulative value from left (0 to total).
+	 */
+	value: number;
+
+	/**
+	 * Optional tooltip text for the marker
+	 */
+	tooltip?: string;
+
+	/**
+	 * Whether to animate the marker position
+	 * @default false
+	 */
+	showAnimation?: boolean;
+
+	/**
+	 * Marker color (defaults to theme segmentedBar.markerColor)
+	 */
+	color?: string;
+}
+
+/**
+ * Display mode for segment sizing
+ */
+export type SegmentedBarMode = 'proportional' | 'equal';
+
+export interface SegmentedBarProps {
+	/**
+	 * Array of segments to display.
+	 * Can be simple numbers or full segment objects.
+	 */
+	values: number[] | SegmentedBarSegment[];
+
+	/**
+	 * Display mode for segments.
+	 * - 'proportional': Segment widths based on their values (default)
+	 * - 'equal': All segments have equal width
+	 * @default 'proportional'
+	 */
+	mode?: SegmentedBarMode;
+
+	/**
+	 * Custom colors for segments (overrides theme colors)
+	 * Applied in order to segments
+	 */
+	colors?: string[];
+
+	/**
+	 * Optional marker to indicate a position on the bar
+	 */
+	marker?: SegmentedBarMarker;
+
+	/**
+	 * Whether to show cumulative value labels below the bar
+	 * @default true
+	 */
+	showLabels?: boolean;
+
+	/**
+	 * Width of the bar in pixels
+	 * @default 300
+	 */
+	width?: number;
+
+	/**
+	 * Height of the bar in pixels
+	 * @default 8
+	 */
+	height?: number;
+
+	/**
+	 * Gap between segments in pixels
+	 * @default 0
+	 */
+	gap?: number;
+
+	/**
+	 * Corner radius for the bar ends
+	 * @default 4
+	 */
+	borderRadius?: number;
+
+	/**
+	 * Additional CSS class name
+	 */
+	className?: string;
+
+	/**
+	 * Chart ID for unique element identification
+	 */
+	chartId?: string;
+
+	/**
+	 * Format function for label values
+	 * @default (value) => value.toString()
+	 */
+	labelFormatter?: ( value: number ) => string;
+
+	/**
+	 * Whether to show tooltips on hover
+	 * @default false
+	 */
+	withTooltips?: boolean;
+}
+
+/**
+ * Responsive configuration for SegmentedBar
+ */
+export type SegmentedBarResponsiveConfig = {
+	/**
+	 * The maximum width of the chart. Defaults to 1200.
+	 */
+	maxWidth?: number;
+	/**
+	 * Child render updates upon resize are delayed until debounceTime milliseconds
+	 * after the last resize event.
+	 */
+	resizeDebounceTime?: number;
+};

--- a/projects/js-packages/charts/src/index.ts
+++ b/projects/js-packages/charts/src/index.ts
@@ -8,6 +8,7 @@ export { LineChart, LineChartUnresponsive } from './charts/line-chart';
 export { PieChart, PieChartUnresponsive } from './charts/pie-chart';
 export { PieSemiCircleChart, PieSemiCircleChartUnresponsive } from './charts/pie-semi-circle-chart';
 export { Sparkline, SparklineUnresponsive } from './charts/sparkline';
+export { SegmentedBar, SegmentedBarUnresponsive } from './charts/segmented-bar';
 
 // Components
 export { BaseTooltip } from './components/tooltip';
@@ -35,6 +36,11 @@ export type { PieChartProps } from './charts/pie-chart';
 export type { GeoChartProps, GeoRegion, GeoResolution } from './charts/geo-chart';
 export type { LegendValueDisplay, BaseLegendItem } from './components/legend';
 export type { TrendIndicatorProps, TrendDirection } from './components/trend-indicator';
+export type {
+	SegmentedBarProps,
+	SegmentedBarSegment,
+	SegmentedBarMarker,
+} from './charts/segmented-bar';
 export type { LineStyles, GridStyles, EventHandlerParams } from '@visx/xychart';
 export type {
 	GoogleDataTableColumn,

--- a/projects/js-packages/charts/src/providers/chart-context/themes.ts
+++ b/projects/js-packages/charts/src/providers/chart-context/themes.ts
@@ -65,6 +65,12 @@ const defaultTheme: CompleteChartTheme = {
 		margin: { top: 2, right: 2, bottom: 2, left: 2 },
 		strokeWidth: 1.5,
 	},
+	segmentedBar: {
+		height: 8,
+		gap: 0,
+		borderRadius: 4,
+		markerColor: '#374151',
+	},
 };
 
 export { defaultTheme };

--- a/projects/js-packages/charts/src/types.ts
+++ b/projects/js-packages/charts/src/types.ts
@@ -266,6 +266,17 @@ export type ChartTheme = {
 		/** Stroke width for the sparkline line */
 		strokeWidth?: number;
 	};
+	/** SegmentedBar specific settings */
+	segmentedBar?: {
+		/** Height of the bar in pixels */
+		height?: number;
+		/** Gap between segments in pixels */
+		gap?: number;
+		/** Corner radius for the bar ends */
+		borderRadius?: number;
+		/** Default color for markers */
+		markerColor?: string;
+	};
 };
 
 /**
@@ -289,6 +300,7 @@ export type CompleteChartTheme = Required< ChartTheme > & {
 	sparkline: Required< NonNullable< ChartTheme[ 'sparkline' ] > > & {
 		margin: Required< NonNullable< ChartTheme[ 'sparkline' ] >[ 'margin' ] >;
 	};
+	segmentedBar: Required< NonNullable< ChartTheme[ 'segmentedBar' ] > >;
 };
 
 declare type AxisOptions = {


### PR DESCRIPTION
Closes CHARTS-146

## Proposed changes:
* Add new SegmentedBar component for displaying horizontal segmented progress bars
* Supports proportional and equal-width segment modes
* Includes marker indicator for showing target/threshold positions
* Tooltips, custom colors, and label formatting support

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?

No, it does not.

## Testing instructions:

### SegmentedBar Component:
1. Go to Storybook -> JS Packages -> Charts -> Types -> Segmented Bar
2. Test all three stories: Default, EqualMode, WithMarker
3. Use Storybook controls to explore different configurations:
   - Toggle between `proportional` and `equal` modes
   - Adjust height, gap, borderRadius
   - Enable/disable tooltips and labels
   - Add/configure marker indicator
4. Verify responsive behavior at different container widths