### PR TITLE
Forms: refactor to use Feedback object in webhooks

### DIFF
--- a/projects/packages/forms/changelog/refactor-use-feedback-object-in-webhooks
+++ b/projects/packages/forms/changelog/refactor-use-feedback-object-in-webhooks
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Forms: refactored how we retrieve form submission fields to send in the webhook payload.

--- a/projects/packages/forms/src/contact-form/class-feedback.php
+++ b/projects/packages/forms/src/contact-form/class-feedback.php
@@ -625,7 +625,10 @@ class Feedback {
 					$compiled_fields[ $field->get_key() ] = $field->get_render_value( $context );
 					break;
 				case 'label-value':
-						$compiled_fields[ $field->get_label( $context, $count_field_labels[ $label ] ) ] = $field->get_render_value( $context );
+					$compiled_fields[ $field->get_label( $context, $count_field_labels[ $label ] ) ] = $field->get_render_value( $context );
+					break;
+				case 'id-value':
+					$compiled_fields[ $field->get_form_field_id() ] = $field->get_render_value( $context );
 					break;
 			}
 		}

--- a/projects/packages/forms/src/service/class-form-webhooks.php
+++ b/projects/packages/forms/src/service/class-form-webhooks.php
@@ -7,6 +7,7 @@
 
 namespace Automattic\Jetpack\Forms\Service;
 
+use Automattic\Jetpack\Forms\ContactForm\Feedback;
 use WP_Error;
 
 /**
@@ -75,13 +76,25 @@ class Form_Webhooks {
 	 *
 	 * @param int   $post_id - the post_id for the CPT that is created.
 	 * @param array $fields - a collection of Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field instances.
-	 * @param bool  $is_spam - marked as spam by Akismet(?).
+	 * @param bool  $is_spam - marked as spam by Akismet.
 	 * @param array $entry_values - extra fields added to from the contact form.
 	 *
 	 * @return null|void
 	 */
 	public function send_webhooks( $post_id, $fields, $is_spam, $entry_values ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
-		// Try and get the form from any of the fields
+		// Get the Feedback object from the post_id
+		$feedback = Feedback::get( $post_id );
+
+		if ( ! $feedback ) {
+			return;
+		}
+
+		// if spam (hinted by akismet), don't process
+		if ( $is_spam ) {
+			return;
+		}
+
+		// Get the form from any of the fields to access form attributes (webhooks configuration)
 		$form = null;
 		foreach ( $fields as $field ) {
 			if ( ! empty( $field->form ) ) {
@@ -93,18 +106,13 @@ class Form_Webhooks {
 			return;
 		}
 
-		// if spam (hinted by akismet?), don't process
-		if ( $is_spam ) {
-			return;
-		}
-
 		$webhooks = $this->get_enabled_webhooks( $form->attributes );
 
 		if ( empty( $webhooks ) ) {
 			return;
 		}
 
-		$form_data = $this->get_form_data( $form );
+		$form_data = $this->get_form_data( $feedback );
 
 		// Iterate through each webhook and send the request
 		foreach ( $webhooks as $webhook ) {
@@ -244,21 +252,15 @@ class Form_Webhooks {
 	}
 
 	/**
-	 * Gather fields key/value pairs from the form
-	 * Sanitizes the hidden fields values
+	 * Gather fields key/value pairs from the Feedback object
 	 *
-	 * @param \Automattic\Jetpack\Forms\ContactForm\Contact_Form $form The form instance being processed/submitted.
+	 * @param Feedback $feedback The Feedback instance containing submitted form data.
+	 * @return array The form data key/value pairs.
 	 */
-	private function get_form_data( $form ) {
+	private function get_form_data( $feedback ) {
 		$fields = array();
-		foreach ( $form->fields as $field ) {
-			$fields[ $field->get_attribute( 'id' ) ] = $field->value;
-		}
-
-		if ( ! empty( $form->attributes['hiddenFields'] ) ) {
-			foreach ( $form->attributes['hiddenFields'] as $hidden_field ) {
-				$fields[ $hidden_field['name'] ] = sanitize_text_field( $hidden_field['value'] );
-			}
+		foreach ( $feedback->get_fields() as $field ) {
+			$fields[ $field->get_form_field_id() ] = $field->get_value();
 		}
 
 		return $fields;

--- a/projects/packages/forms/src/service/class-form-webhooks.php
+++ b/projects/packages/forms/src/service/class-form-webhooks.php
@@ -112,7 +112,7 @@ class Form_Webhooks {
 			return;
 		}
 
-		$form_data = $this->get_form_data( $feedback );
+		$form_data = $feedback->get_compiled_fields( 'webhook', 'id-value' );
 
 		// Iterate through each webhook and send the request
 		foreach ( $webhooks as $webhook ) {
@@ -249,20 +249,5 @@ class Form_Webhooks {
 		);
 
 		return wp_remote_request( $url, $args );
-	}
-
-	/**
-	 * Gather fields key/value pairs from the Feedback object
-	 *
-	 * @param Feedback $feedback The Feedback instance containing submitted form data.
-	 * @return array The form data key/value pairs.
-	 */
-	private function get_form_data( $feedback ) {
-		$fields = array();
-		foreach ( $feedback->get_fields() as $field ) {
-			$fields[ $field->get_form_field_id() ] = $field->get_value();
-		}
-
-		return $fields;
 	}
 }

--- a/projects/packages/forms/tests/php/contact-form/Feedback_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Feedback_Test.php
@@ -1867,6 +1867,11 @@ class Feedback_Test extends BaseTestCase {
 				),
 				'message'  => 'Compiled fields should return only labels as indexed array.',
 			),
+			'id-value_format'    => array(
+				'format'   => 'id-value',
+				'expected' => array(), // Rebuilt dynamically in the test with actual form_id
+				'message'  => 'Compiled fields should return field IDs mapped to values.',
+			),
 		);
 	}
 
@@ -1905,6 +1910,17 @@ class Feedback_Test extends BaseTestCase {
 
 		// Test the specified format
 		$compiled_fields = $response->get_compiled_fields( 'default', $format );
+
+		// For id-value format, rebuild expected with actual form_id, there
+		// was no way of passing the form_id to the data provider.
+		if ( 'id-value' === $format ) {
+			$expected = array(
+				'g' . $form_id . '-name'    => $test_name,
+				'g' . $form_id . '-email'   => $test_email,
+				'g' . $form_id . '-website' => $test_website,
+				'g' . $form_id . '-message' => $test_message,
+			);
+		}
 
 		$this->assertEquals( $expected, $compiled_fields, $message );
 	}

--- a/projects/packages/forms/tests/php/service/Form_Webhooks_Test.php
+++ b/projects/packages/forms/tests/php/service/Form_Webhooks_Test.php
@@ -9,6 +9,7 @@ namespace Automattic\Jetpack\Forms\Service;
 
 use Automattic\Jetpack\Forms\ContactForm\Contact_Form;
 use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field;
+use Automattic\Jetpack\Forms\ContactForm\Feedback;
 use PHPUnit\Framework\Attributes\CoversClass;
 use WorDBless\BaseTestCase;
 use WpOrg\Requests\Utility\CaseInsensitiveDictionary;
@@ -171,6 +172,8 @@ class Form_Webhooks_Test extends BaseTestCase {
 		$form->fields = array( $field1, $field2 );
 		$fields       = array( $field1, $field2 );
 
+		$post_id = $this->create_feedback_post( $form, $fields );
+
 		$captured_request = null;
 		add_filter(
 			'pre_http_request',
@@ -190,7 +193,7 @@ class Form_Webhooks_Test extends BaseTestCase {
 		);
 
 		$webhooks = Form_Webhooks::init();
-		$webhooks->send_webhooks( 123, $fields, false, array() );
+		$webhooks->send_webhooks( $post_id, $fields, false, array() );
 
 		$this->assertNotNull( $captured_request, 'HTTP request should be made' );
 		$this->assertEquals( 'https://example.com/webhook', $captured_request['url'] );
@@ -226,6 +229,8 @@ class Form_Webhooks_Test extends BaseTestCase {
 		$form->fields = array( $field1, $field2 );
 		$fields       = array( $field1, $field2 );
 
+		$post_id = $this->create_feedback_post( $form, $fields );
+
 		$captured_request = null;
 		add_filter(
 			'pre_http_request',
@@ -245,7 +250,7 @@ class Form_Webhooks_Test extends BaseTestCase {
 		);
 
 		$webhooks = Form_Webhooks::init();
-		$webhooks->send_webhooks( 123, $fields, false, array() );
+		$webhooks->send_webhooks( $post_id, $fields, false, array() );
 
 		$this->assertNotNull( $captured_request, 'HTTP request should be made' );
 		$this->assertEquals( 'application/x-www-form-urlencoded', $captured_request['args']['headers']['Content-Type'] );
@@ -347,6 +352,8 @@ class Form_Webhooks_Test extends BaseTestCase {
 		);
 		$fields = array( $this->create_mock_field( $form, 'test-field', 'test value' ) );
 
+		$post_id = $this->create_feedback_post( $form, $fields );
+
 		$captured_request = null;
 		add_filter(
 			'pre_http_request',
@@ -366,7 +373,7 @@ class Form_Webhooks_Test extends BaseTestCase {
 		);
 
 		$webhooks = Form_Webhooks::init();
-		$webhooks->send_webhooks( 123, $fields, false, array() );
+		$webhooks->send_webhooks( $post_id, $fields, false, array() );
 
 		$this->assertNotNull( $captured_request );
 		$this->assertEquals( 'GET', $captured_request['args']['method'] );
@@ -390,6 +397,8 @@ class Form_Webhooks_Test extends BaseTestCase {
 			)
 		);
 		$fields = array( $this->create_mock_field( $form, 'email', 'john@example.com' ) );
+
+		$post_id = $this->create_feedback_post( $form, $fields );
 
 		// Add filter to modify data
 		add_filter(
@@ -422,7 +431,7 @@ class Form_Webhooks_Test extends BaseTestCase {
 		);
 
 		$webhooks = Form_Webhooks::init();
-		$webhooks->send_webhooks( 123, $fields, false, array() );
+		$webhooks->send_webhooks( $post_id, $fields, false, array() );
 
 		// @phan-suppress-next-line PhanTypeArraySuspiciousNull, PhanTypeMismatchArgumentInternal
 		$body_data = json_decode( $captured_request['args']['body'], true );
@@ -434,8 +443,7 @@ class Form_Webhooks_Test extends BaseTestCase {
 	 * Test webhook logs successful response to post meta.
 	 */
 	public function test_send_webhooks_logs_successful_response() {
-		$post_id = 123;
-		$form    = $this->create_mock_form(
+		$form   = $this->create_mock_form(
 			array(
 				'webhooks' => array(
 					array(
@@ -448,7 +456,9 @@ class Form_Webhooks_Test extends BaseTestCase {
 				),
 			)
 		);
-		$fields  = array( $this->create_mock_field( $form, 'test-field', 'test value' ) );
+		$fields = array( $this->create_mock_field( $form, 'test-field', 'test value' ) );
+
+		$post_id = $this->create_feedback_post( $form, $fields );
 
 		add_filter(
 			'pre_http_request',
@@ -477,8 +487,7 @@ class Form_Webhooks_Test extends BaseTestCase {
 	 * Test webhook logs error to post meta.
 	 */
 	public function test_send_webhooks_logs_error() {
-		$post_id = 456;
-		$form    = $this->create_mock_form(
+		$form   = $this->create_mock_form(
 			array(
 				'webhooks' => array(
 					array(
@@ -491,7 +500,9 @@ class Form_Webhooks_Test extends BaseTestCase {
 				),
 			)
 		);
-		$fields  = array( $this->create_mock_field( $form, 'test-field', 'test value' ) );
+		$fields = array( $this->create_mock_field( $form, 'test-field', 'test value' ) );
+
+		$post_id = $this->create_feedback_post( $form, $fields );
 
 		add_filter(
 			'pre_http_request',
@@ -505,68 +516,6 @@ class Form_Webhooks_Test extends BaseTestCase {
 
 		$error_meta = get_post_meta( $post_id, '_jetpack_forms_webhook_error', true );
 		$this->assertEquals( 'Connection timeout', $error_meta );
-	}
-
-	/**
-	 * Test webhook includes hidden fields in data.
-	 */
-	public function test_send_webhooks_includes_hidden_fields() {
-		$form         = $this->create_mock_form(
-			array(
-				'webhooks'     => array(
-					array(
-						'webhook_id' => 'test-webhook',
-						'url'        => 'https://example.com/webhook',
-						'format'     => 'json',
-						'method'     => 'POST',
-						'enabled'    => true,
-					),
-				),
-				'hiddenFields' => array(
-					array(
-						'name'  => 'utm_source',
-						'value' => 'google',
-					),
-					array(
-						'name'  => 'utm_campaign',
-						'value' => 'summer_2025',
-					),
-				),
-			)
-		);
-		$field1       = $this->create_mock_field( $form, 'email', 'john@example.com' );
-		$form->fields = array( $field1 );
-		$fields       = array( $field1 );
-
-		$captured_request = null;
-		add_filter(
-			'pre_http_request',
-			function ( $preempt, $args, $url ) use ( &$captured_request ) {
-				$captured_request = array(
-					'url'  => $url,
-					'args' => $args,
-				);
-				return array(
-					'response' => array( 'code' => 200 ),
-					'body'     => '{"success":true}',
-					'headers'  => new CaseInsensitiveDictionary( array( 'Content-Type' => 'application/json' ) ),
-				);
-			},
-			10,
-			3
-		);
-
-		$webhooks = Form_Webhooks::init();
-		$webhooks->send_webhooks( 123, $fields, false, array() );
-
-		// @phan-suppress-next-line PhanTypeArraySuspiciousNull, PhanTypeMismatchArgumentInternal
-		$body_data = json_decode( $captured_request['args']['body'], true );
-		// @phan-suppress-next-line PhanTypeArraySuspiciousNullable
-		$this->assertEquals( 'john@example.com', $body_data['email'] );
-		// @phan-suppress-next-line PhanTypeArraySuspiciousNullable
-		$this->assertEquals( 'google', $body_data['utm_source'] );
-		// @phan-suppress-next-line PhanTypeArraySuspiciousNullable
-		$this->assertEquals( 'summer_2025', $body_data['utm_campaign'] );
 	}
 
 	/**
@@ -588,6 +537,8 @@ class Form_Webhooks_Test extends BaseTestCase {
 		);
 		$fields = array( $this->create_mock_field( $form, 'test-field', 'test value' ) );
 
+		$post_id = $this->create_feedback_post( $form, $fields );
+
 		$logged_events = array();
 		add_action(
 			'jetpack_forms_log',
@@ -603,7 +554,7 @@ class Form_Webhooks_Test extends BaseTestCase {
 		);
 
 		$webhooks = Form_Webhooks::init();
-		$webhooks->send_webhooks( 123, $fields, false, array() );
+		$webhooks->send_webhooks( $post_id, $fields, false, array() );
 
 		$this->assertCount( 1, $logged_events );
 		// @phan-suppress-next-line PhanTypeArraySuspiciousNull, PhanTypeInvalidDimOffset
@@ -631,6 +582,8 @@ class Form_Webhooks_Test extends BaseTestCase {
 		);
 		$fields = array( $this->create_mock_field( $form, 'test-field', 'test value' ) );
 
+		$post_id = $this->create_feedback_post( $form, $fields );
+
 		$logged_events = array();
 		add_action(
 			'jetpack_forms_log',
@@ -646,7 +599,7 @@ class Form_Webhooks_Test extends BaseTestCase {
 		);
 
 		$webhooks = Form_Webhooks::init();
-		$webhooks->send_webhooks( 123, $fields, false, array() );
+		$webhooks->send_webhooks( $post_id, $fields, false, array() );
 
 		$this->assertCount( 1, $logged_events );
 		// @phan-suppress-next-line PhanTypeArraySuspiciousNull, PhanTypeInvalidDimOffset
@@ -678,6 +631,8 @@ class Form_Webhooks_Test extends BaseTestCase {
 		);
 		$fields = array( $this->create_mock_field( $form, 'test-field', 'test value' ) );
 
+		$post_id = $this->create_feedback_post( $form, $fields );
+
 		$logged_events = array();
 		add_action(
 			'jetpack_forms_log',
@@ -693,7 +648,7 @@ class Form_Webhooks_Test extends BaseTestCase {
 		);
 
 		$webhooks = Form_Webhooks::init();
-		$webhooks->send_webhooks( 123, $fields, false, array() );
+		$webhooks->send_webhooks( $post_id, $fields, false, array() );
 
 		$this->assertCount( 1, $logged_events );
 		// @phan-suppress-next-line PhanTypeArraySuspiciousNull, PhanTypeInvalidDimOffset
@@ -725,6 +680,8 @@ class Form_Webhooks_Test extends BaseTestCase {
 		);
 		$fields = array( $this->create_mock_field( $form, 'test-field', 'test value' ) );
 
+		$post_id = $this->create_feedback_post( $form, $fields );
+
 		$captured_request = null;
 		add_filter(
 			'pre_http_request',
@@ -744,7 +701,7 @@ class Form_Webhooks_Test extends BaseTestCase {
 		);
 
 		$webhooks = Form_Webhooks::init();
-		$webhooks->send_webhooks( 123, $fields, false, array() );
+		$webhooks->send_webhooks( $post_id, $fields, false, array() );
 
 		$this->assertNotNull( $captured_request, 'HTTP request should be made even with lowercase method' );
 		$this->assertEquals( 'post', $captured_request['args']['method'] );
@@ -796,5 +753,36 @@ class Form_Webhooks_Test extends BaseTestCase {
 			);
 
 		return $field;
+	}
+
+	/**
+	 * Helper method to create a feedback post with fields.
+	 *
+	 * @param Contact_Form $form The mock form object with webhook configuration.
+	 * @param array        $fields Array of Contact_Form_Field mock instances.
+	 * @return int The feedback post ID.
+	 */
+	private function create_feedback_post( $form, $fields ) {
+		// Build POST data from fields
+		$post_data        = array();
+		$shortcode_fields = array();
+		foreach ( $fields as $field ) {
+			$field_id               = $field->get_attribute( 'id' );
+			$post_data[ $field_id ] = $field->value;
+			// Create shortcode for each field based on its ID (name, email, etc.)
+			$shortcode_fields[] = "[contact-field label='" . ucfirst( $field_id ) . "' type='text' id='" . $field_id . "'/]";
+		}
+
+		// Create a real Contact_Form with the webhook configuration
+		$real_form = new Contact_Form(
+			$form->attributes,
+			implode( '', $shortcode_fields )
+		);
+
+		// Create feedback from submission
+		$feedback = Feedback::from_submission( $post_data, $real_form );
+		$post_id  = $feedback->save();
+
+		return is_int( $post_id ) ? $post_id : $post_id->ID;
 	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Addresses [comment from previous PR](https://github.com/Automattic/jetpack/pull/46059#pullrequestreview-3525906098).

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Retrieve form fields from the Feedback object instead of the form attributes.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Enable webhooks via the filter flag:
```add_filter( 'jetpack_forms_webhooks_enabled', '__return_true' );```
- Create a form with webhook configuration in the block editor
- Enter a webhook URL (e.g., one from https://webhook.site/unique-url for testing)
- Publish/update the post and submit the form
- Verify the webhook endpoint receives the form data, including hidden fields, in JSON format
