### PR TITLE
Boost: cache image quality lookups per type in Image CDN

### DIFF
--- a/projects/plugins/boost/app/modules/optimizations/image-cdn/class-quality-settings.php
+++ b/projects/plugins/boost/app/modules/optimizations/image-cdn/class-quality-settings.php
@@ -91,26 +91,29 @@ class Quality_Settings implements Sub_Feature, Is_Always_On, Has_Data_Sync, Chan
 	 * Get the quality for an image based on the extension.
 	 */
 	private function get_quality_for_image( $image_url ) {
-		// Define an associative array to map extensions to image types
-		$extension_to_quality = array(
-			'jpg'  => $this->get_quality_for_type( 'jpg' ),
-			'jpeg' => $this->get_quality_for_type( 'jpg' ),
-			'webp' => $this->get_quality_for_type( 'webp' ),
-			'png'  => $this->get_quality_for_type( 'png' ),
-		);
+		static $quality_cache = array();
 
 		// Extract the file extension from the URL
-		$file_extension = pathinfo( $image_url, PATHINFO_EXTENSION );
+		$file_extension = strtolower( pathinfo( $image_url, PATHINFO_EXTENSION ) );
 
-		// Convert the extension to lowercase for case-insensitive comparison
-		$file_extension = strtolower( $file_extension );
+		static $extension_to_type = array(
+			'jpg'  => 'jpg',
+			'jpeg' => 'jpg',
+			'webp' => 'webp',
+			'png'  => 'png',
+		);
 
-		// Determine the image type based on the extension
-		if ( isset( $extension_to_quality[ $file_extension ] ) ) {
-			return $extension_to_quality[ $file_extension ];
+		if ( ! isset( $extension_to_type[ $file_extension ] ) ) {
+			return null;
 		}
 
-		return null;
+		$type = $extension_to_type[ $file_extension ];
+
+		if ( ! isset( $quality_cache[ $type ] ) ) {
+			$quality_cache[ $type ] = $this->get_quality_for_type( $type );
+		}
+
+		return $quality_cache[ $type ];
 	}
 
 	private function get_quality_for_type( $image_type ) {

--- a/projects/plugins/boost/changelog/get_quality_for_image_memo
+++ b/projects/plugins/boost/changelog/get_quality_for_image_memo
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Image CDN: cache image quality settings per format to reduce repeated processing.


### PR DESCRIPTION
* `get_quality_for_image()`: Refactor to avoid doing calls to `get_quality_for_type()` and immediately throwing away the work. For the one we do need, at a in-process cache so it can be reused for future images.

On a client site, I saw 700+ calls to this function taking up ~85ms:

```
Label                                    |    Count | Total (ms) |   Avg (ms) | Median (ms) |   Min (ms) |   Max (ms)
----------------------------------------------------------------------------------------------------
add_quality_args                         |      763 |      85.06 |       0.11 |       0.12 |       0.07 |       0.19
----------------------------------------------------------------------------------------------------
```

Of note is that is calculates 4 things and only uses 1:
<img width="758" height="495" alt="Screenshot 2025-12-04 at 2 51 25 PM" src="https://github.com/user-attachments/assets/45c6f7af-0b82-4124-86b8-fa9002fed0c0" />

It's getting the same setting over and over which won't change from image to image in a particular request:
```php
	private function get_quality_for_type( $image_type ) {
		$quality_settings = jetpack_boost_ds_get( 'image_cdn_quality' );

		if ( ! isset( $quality_settings[ $image_type ] ) ) {
			return null;
		}

		// Passing 100 to photon will result in a lossless image
		return $quality_settings[ $image_type ]['lossless'] ? 100 : $quality_settings[ $image_type ]['quality'];
	}
```

So in order to speed things up:
* Only call to get the one that we need
* Memoize it so future images can reuse the work we just did.

In the new version, the same 700+ calls only take 2ms:
```
Count | Total (ms) |   Avg (ms) | Median (ms) |   Min (ms) |   Max (ms)
----------------------------------------------------------------------------------------------------
add_quality_args                         |      763 |       1.80 |       0.00 |       0.00 |       0.00 |       0.08
----------------------------------------------------------------------------------------------------
```

## Proposed changes:
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

## Does this pull request change what data or activity we track or use?

## Testing instructions:

* Go to '..'
*

