### PR TITLE
Try: Add reusable form block

### DIFF
--- a/projects/packages/forms/changelog/add-jetpack-forms-custom-post-type
+++ b/projects/packages/forms/changelog/add-jetpack-forms-custom-post-type
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add jetpack-forms custom post type

--- a/projects/packages/forms/src/blocks/contact-form/components/convert-to-reusable-button.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/components/convert-to-reusable-button.tsx
@@ -1,0 +1,50 @@
+import { hasFeatureFlag } from '@automattic/jetpack-shared-extension-utils';
+import { ToolbarButton } from '@wordpress/components';
+import { store as coreStore } from '@wordpress/core-data';
+import { useSelect } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
+import { backup } from '@wordpress/icons';
+import { useConvertToReusableForm } from '../hooks/use-convert-to-reusable-form';
+
+interface ConvertToReusableButtonProps {
+	clientId: string;
+}
+
+/**
+ * Toolbar button to convert a contact form to a reusable form.
+ *
+ * @param {ConvertToReusableButtonProps} props          - Component props
+ * @param {string}                       props.clientId - The client ID of the block to convert
+ * @return {JSX.Element | null} The toolbar button or null if feature is disabled
+ */
+export default function ConvertToReusableButton( {
+	clientId,
+}: ConvertToReusableButtonProps ): JSX.Element | null {
+	// Check if the reusable-forms feature flag is enabled
+	const isFeatureEnabled = hasFeatureFlag( 'reusable-forms' );
+
+	// Check if the user has permission to create jetpack-form posts
+	const canCreate = useSelect( select => {
+		return select( coreStore ).canUser( 'create', {
+			kind: 'postType',
+			name: 'jetpack-form',
+		} );
+	}, [] );
+
+	const { convertToReusableForm, isConverting } = useConvertToReusableForm( { clientId } );
+
+	// Don't render the button if feature is disabled or user lacks permissions
+	if ( ! isFeatureEnabled || ! canCreate ) {
+		return null;
+	}
+
+	return (
+		<ToolbarButton
+			icon={ backup }
+			label={ __( 'Convert to Reusable', 'jetpack-forms' ) }
+			onClick={ convertToReusableForm }
+			disabled={ isConverting }
+			isBusy={ isConverting }
+		/>
+	);
+}

--- a/projects/packages/forms/src/blocks/contact-form/edit.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/edit.tsx
@@ -22,6 +22,7 @@ import {
 	TextControl,
 	ToggleControl,
 	RadioControl,
+	ToolbarGroup,
 } from '@wordpress/components';
 import { useInstanceId } from '@wordpress/compose';
 import { store as coreStore } from '@wordpress/core-data';
@@ -47,6 +48,7 @@ import useFormSteps from '../shared/hooks/use-form-steps.js';
 import { SyncedAttributeProvider } from '../shared/hooks/use-synced-attributes.js';
 import { CORE_BLOCKS } from '../shared/util/constants.js';
 import { childBlocks } from './child-blocks.js';
+import ConvertToReusableButton from './components/convert-to-reusable-button';
 import { ContactFormPlaceholder } from './components/jetpack-contact-form-placeholder.js';
 import ContactFormSkeletonLoader from './components/jetpack-contact-form-skeleton-loader.js';
 import NotificationsSettings from './components/notifications-settings.js';
@@ -830,6 +832,9 @@ function JetpackContactFormEdit( {
 			<>
 				<BlockControls>
 					{ variationName === 'multistep' && <StepControls formClientId={ clientId } /> }
+					<ToolbarGroup>
+						<ConvertToReusableButton clientId={ clientId } />
+					</ToolbarGroup>
 				</BlockControls>
 				<InspectorControls>
 					<PanelBody

--- a/projects/packages/forms/src/blocks/contact-form/hooks/use-convert-to-reusable-form.ts
+++ b/projects/packages/forms/src/blocks/contact-form/hooks/use-convert-to-reusable-form.ts
@@ -1,0 +1,89 @@
+import apiFetch from '@wordpress/api-fetch';
+import { store as blockEditorStore } from '@wordpress/block-editor';
+import { createBlock, serialize } from '@wordpress/blocks';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { useState, useCallback } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { store as noticesStore } from '@wordpress/notices';
+
+interface UseConvertToReusableFormOptions {
+	clientId: string;
+}
+
+interface UseConvertToReusableFormReturn {
+	convertToReusableForm: () => Promise< void >;
+	isConverting: boolean;
+}
+
+/**
+ * Hook to convert a contact form block to a reusable form.
+ *
+ * @param {UseConvertToReusableFormOptions} options          - Hook options
+ * @param {string}                          options.clientId - The client ID of the block to convert
+ * @return {UseConvertToReusableFormReturn} An object containing the conversion function and loading state
+ */
+export function useConvertToReusableForm( {
+	clientId,
+}: UseConvertToReusableFormOptions ): UseConvertToReusableFormReturn {
+	const [ isConverting, setIsConverting ] = useState( false );
+
+	const block = useSelect(
+		select => {
+			return select( blockEditorStore ).getBlock( clientId );
+		},
+		[ clientId ]
+	);
+
+	const { replaceBlock } = useDispatch( blockEditorStore );
+	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
+
+	const convertToReusableForm = useCallback( async () => {
+		if ( ! block || isConverting ) {
+			return;
+		}
+
+		setIsConverting( true );
+
+		try {
+			// Serialize the current block to HTML
+			const content = serialize( block );
+
+			// Create a new jetpack-form post
+			const response = await apiFetch< { id: number } >( {
+				path: '/wp/v2/jetpack-forms',
+				method: 'POST',
+				data: {
+					title: __( 'Reusable Form', 'jetpack-forms' ),
+					content,
+					status: 'publish',
+				},
+			} );
+
+			// Create a new jetpack/form block with a reference to the created post
+			const newBlock = createBlock( 'jetpack/form', {
+				ref: response.id,
+			} );
+
+			// Replace the current block with the new reusable form block
+			replaceBlock( clientId, newBlock );
+
+			// Show success notice
+			createSuccessNotice( __( 'Form converted to reusable form', 'jetpack-forms' ), {
+				type: 'snackbar',
+			} );
+			// eslint-disable-next-line @typescript-eslint/no-unused-vars
+		} catch ( error ) {
+			// Show error notice
+			createErrorNotice( __( 'Failed to convert form. Please try again.', 'jetpack-forms' ), {
+				type: 'snackbar',
+			} );
+			setIsConverting( false );
+		}
+		// Note: We don't reset isConverting on success because the block will be replaced
+	}, [ block, clientId, isConverting, replaceBlock, createSuccessNotice, createErrorNotice ] );
+
+	return {
+		convertToReusableForm,
+		isConverting,
+	};
+}

--- a/projects/packages/forms/src/blocks/form/block.json
+++ b/projects/packages/forms/src/blocks/form/block.json
@@ -1,0 +1,21 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "jetpack/form",
+	"title": "Form",
+	"description": "Insert a reusable form from your forms library.",
+	"keywords": [ "form", "reusable", "reference" ],
+	"version": "1.0.0",
+	"textdomain": "jetpack-forms",
+	"category": "contact-form",
+	"icon": "<svg viewBox='0 0 24 24' width='24' height='24' xmlns='http://www.w3.org/2000/svg'><path d='m13 7.5 h 5 v 1.5 h -5 v -1.5z'/><path d='m13 15 h 5 v 1.5 h -5 v -1.5z'/><path d='m19.01,3H4.99c-1.1,0-1.99.89-1.99,1.99v14.02c0,1.1.89,1.99,1.99,1.99h14.02c1.1,0,1.99-.89,1.99-1.99V4.99c0-1.1-.89-1.99-1.99-1.99Zm.49,15.99c0,.28-.23.51-.51.51H5.01c-.28,0-.51-.23-.51-.51V5.01c0-.28.23-.51.51-.51h13.98c.28,0,.51.23.51.51v13.98Z'/><path d='m9.46,13h-1.92c-.85,0-1.54.69-1.54,1.54v1.92c0,.85.69,1.54,1.54,1.54h1.92c.85,0,1.54-.69,1.54-1.54v-1.92c0-.85-.69-1.54-1.54-1.54Zm.04,3.5h-2v-2h2v2Z'/><path d='m9.46,6h-1.92c-.85,0-1.54.69-1.54,1.54v1.92c0,.85.69,1.54,1.54,1.54h1.92c.85,0,1.54-.69,1.54-1.54v-1.92c0-.85-.69-1.54-1.54-1.54Zm.04,3.5h-2v-2h2v2Z'/></svg>",
+	"supports": {
+		"html": false,
+		"inserter": false
+	},
+	"attributes": {
+		"ref": {
+			"type": "number"
+		}
+	}
+}

--- a/projects/packages/forms/src/blocks/form/block.json
+++ b/projects/packages/forms/src/blocks/form/block.json
@@ -2,7 +2,7 @@
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 3,
 	"name": "jetpack/form",
-	"title": "Form",
+	"title": "Reusable Form",
 	"description": "Insert a reusable form from your forms library.",
 	"keywords": [ "form", "reusable", "reference" ],
 	"version": "1.0.0",
@@ -10,12 +10,14 @@
 	"category": "contact-form",
 	"icon": "<svg viewBox='0 0 24 24' width='24' height='24' xmlns='http://www.w3.org/2000/svg'><path d='m13 7.5 h 5 v 1.5 h -5 v -1.5z'/><path d='m13 15 h 5 v 1.5 h -5 v -1.5z'/><path d='m19.01,3H4.99c-1.1,0-1.99.89-1.99,1.99v14.02c0,1.1.89,1.99,1.99,1.99h14.02c1.1,0,1.99-.89,1.99-1.99V4.99c0-1.1-.89-1.99-1.99-1.99Zm.49,15.99c0,.28-.23.51-.51.51H5.01c-.28,0-.51-.23-.51-.51V5.01c0-.28.23-.51.51-.51h13.98c.28,0,.51.23.51.51v13.98Z'/><path d='m9.46,13h-1.92c-.85,0-1.54.69-1.54,1.54v1.92c0,.85.69,1.54,1.54,1.54h1.92c.85,0,1.54-.69,1.54-1.54v-1.92c0-.85-.69-1.54-1.54-1.54Zm.04,3.5h-2v-2h2v2Z'/><path d='m9.46,6h-1.92c-.85,0-1.54.69-1.54,1.54v1.92c0,.85.69,1.54,1.54,1.54h1.92c.85,0,1.54-.69,1.54-1.54v-1.92c0-.85-.69-1.54-1.54-1.54Zm.04,3.5h-2v-2h2v2Z'/></svg>",
 	"supports": {
+		"customClassName": false,
 		"html": false,
-		"inserter": false
+		"renaming": false
 	},
 	"attributes": {
 		"ref": {
 			"type": "number"
 		}
-	}
+	},
+	"editorScript": "file:./index.js"
 }

--- a/projects/packages/forms/src/blocks/form/class-form-block.php
+++ b/projects/packages/forms/src/blocks/form/class-form-block.php
@@ -19,8 +19,11 @@ class Form_Block {
 	 * This block only registers when the reusable-forms feature flag is enabled.
 	 */
 	public static function register_block() {
+		// Point to the dist folder where the compiled block.json and assets are
+		$block_dir = dirname( __DIR__, 3 ) . '/dist/blocks/form';
+
 		Blocks::jetpack_register_block(
-			'jetpack/form',
+			$block_dir,
 			array(
 				'render_callback' => array( __CLASS__, 'render' ),
 			)

--- a/projects/packages/forms/src/blocks/form/class-form-block.php
+++ b/projects/packages/forms/src/blocks/form/class-form-block.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * Form Block.
+ *
+ * @package automattic/jetpack-forms
+ */
+
+namespace Automattic\Jetpack\Extensions\Contact_Form;
+
+use Automattic\Jetpack\Blocks;
+
+/**
+ * Form block registration and rendering.
+ * This block allows inserting reusable forms from the forms library.
+ */
+class Form_Block {
+	/**
+	 * Register the Form block.
+	 * This block only registers when the reusable-forms feature flag is enabled.
+	 */
+	public static function register_block() {
+		Blocks::jetpack_register_block(
+			'jetpack/form',
+			array(
+				'render_callback' => array( __CLASS__, 'render' ),
+			)
+		);
+	}
+
+	/**
+	 * Render the form block.
+	 *
+	 * @param array  $atts - the block attributes.
+	 * @param string $content - html content.
+	 *
+	 * @return string
+	 */
+	public static function render( $atts, $content = '' ) {
+		// Get the form reference ID
+		$ref = isset( $atts['ref'] ) ? absint( $atts['ref'] ) : 0;
+
+		if ( ! $ref ) {
+			return '';
+		}
+
+		unset( $content );
+
+		// Get the referenced form post
+		$form_post = get_post( $ref );
+
+		// Verify the post exists and is a jetpack-form post type
+		if ( ! $form_post || 'jetpack-form' !== $form_post->post_type ) {
+			return '';
+		}
+
+		// Return the form content rendered with do_blocks
+		return do_blocks( $form_post->post_content );
+	}
+}

--- a/projects/packages/forms/src/blocks/form/edit.tsx
+++ b/projects/packages/forms/src/blocks/form/edit.tsx
@@ -1,0 +1,65 @@
+/**
+ * WordPress dependencies
+ */
+import { useInnerBlocksProps, useBlockProps, Warning } from '@wordpress/block-editor';
+import { Spinner } from '@wordpress/components';
+import { useEntityBlockEditor, useEntityRecord } from '@wordpress/core-data';
+import { __ } from '@wordpress/i18n';
+
+export default function FormEdit( { attributes } ) {
+	const { ref } = attributes;
+
+	// Fetch the form post from the jetpack-form post type
+	const { record, hasResolved } = useEntityRecord( 'postType', 'jetpack-form', ref );
+
+	// Get the blocks from the form post
+	const [ blocks, onInput, onChange ] = useEntityBlockEditor( 'postType', 'jetpack-form', {
+		id: ref,
+	} );
+
+	// Check if the form is missing
+	const isMissing = hasResolved && ! record;
+
+	// Get the block props for the wrapper
+	const blockProps = useBlockProps( {
+		className: 'wp-block-jetpack-form',
+	} );
+
+	// Get inner blocks props for rendering the form blocks
+	const innerBlocksProps = useInnerBlocksProps( blockProps, {
+		value: blocks,
+		onInput,
+		onChange,
+		renderAppender: blocks?.length ? undefined : () => null,
+	} );
+
+	// Loading state
+	if ( ! hasResolved ) {
+		return (
+			<div { ...blockProps }>
+				<Spinner />
+			</div>
+		);
+	}
+
+	// Missing or invalid form
+	if ( isMissing ) {
+		return (
+			<div { ...blockProps }>
+				<Warning>{ __( 'Form not found. Please select a valid form.', 'jetpack-forms' ) }</Warning>
+			</div>
+		);
+	}
+
+	// No ref specified
+	if ( ! ref ) {
+		return (
+			<div { ...blockProps }>
+				<Warning>{ __( 'No form selected. Please select a form.', 'jetpack-forms' ) }</Warning>
+			</div>
+		);
+	}
+
+	// Render the form blocks
+	return <div { ...innerBlocksProps } />;
+}

--- a/projects/packages/forms/src/blocks/form/edit.tsx
+++ b/projects/packages/forms/src/blocks/form/edit.tsx
@@ -6,7 +6,13 @@ import { Spinner } from '@wordpress/components';
 import { useEntityBlockEditor, useEntityRecord } from '@wordpress/core-data';
 import { __ } from '@wordpress/i18n';
 
-export default function FormEdit( { attributes } ) {
+type FormEditProps = {
+	attributes: {
+		ref?: number;
+	};
+};
+
+export default function FormEdit( { attributes }: FormEditProps ) {
 	const { ref } = attributes;
 
 	// Fetch the form post from the jetpack-form post type

--- a/projects/packages/forms/src/blocks/form/index.tsx
+++ b/projects/packages/forms/src/blocks/form/index.tsx
@@ -1,0 +1,47 @@
+/**
+ * WordPress dependencies
+ */
+import { hasFeatureFlag } from '@automattic/jetpack-shared-extension-utils';
+import { registerBlockType } from '@wordpress/blocks';
+import { Path } from '@wordpress/components';
+import renderMaterialIcon from '../shared/components/render-material-icon.js';
+/**
+ * Internal dependencies
+ */
+import metadata from './block.json';
+import edit from './edit';
+
+const icon = renderMaterialIcon(
+	<>
+		<Path fillRule="evenodd" clipRule="evenodd" d="M18 9H13V7.5H18V9Z" />
+		<Path fillRule="evenodd" clipRule="evenodd" d="M18 16.5H13V15H18V16.5Z" />
+		<Path
+			fillRule="evenodd"
+			clipRule="evenodd"
+			d="M9.5 7.5H7.5V9.5H9.5V7.5ZM7.5 6H9.5C10.3284 6 11 6.67157 11 7.5V9.5C11 10.3284 10.3284 11 9.5 11H7.5C6.67157 11 6 10.3284 6 9.5V7.5C6 6.67157 6.67157 6 7.5 6Z"
+		/>
+		<Path
+			fillRule="evenodd"
+			clipRule="evenodd"
+			d="M9.5 14.5H7.5V16.5H9.5V14.5ZM7.5 13H9.5C10.3284 13 11 13.6716 11 14.5V16.5C11 17.3284 10.3284 18 9.5 18H7.5C6.67157 18 6 17.3284 6 16.5V14.5C6 13.6716 6.67157 13 7.5 13Z"
+		/>
+		<Path
+			fillRule="evenodd"
+			clipRule="evenodd"
+			d="M19 4.5H5C4.72386 4.5 4.5 4.72386 4.5 5V19C4.5 19.2761 4.72386 19.5 5 19.5H19C19.2761 19.5 19.5 19.2761 19.5 19V5C19.5 4.72386 19.2761 4.5 19 4.5ZM5 3C3.89543 3 3 3.89543 3 5V19C3 20.1046 3.89543 21 5 21H19C20.1046 21 21 20.1046 21 19V5C21 3.89543 20.1046 3 19 3H5Z"
+		/>
+	</>
+);
+
+/**
+ * Register the jetpack/form block.
+ * This block displays reusable forms from the jetpack-form post type.
+ */
+if ( hasFeatureFlag( 'reusable-forms' ) ) {
+	const settings = {
+		...metadata,
+		icon: { src: icon },
+		edit,
+	};
+	registerBlockType( 'jetpack/form', settings );
+}

--- a/projects/packages/forms/src/class-reusable-forms.php
+++ b/projects/packages/forms/src/class-reusable-forms.php
@@ -7,6 +7,8 @@
 
 namespace Automattic\Jetpack\Forms;
 
+use Automattic\Jetpack\Extensions\Contact_Form\Form_Block;
+
 /**
  * Handles Reusable Forms functionality.
  */
@@ -17,6 +19,15 @@ class Reusable_Forms {
 	 */
 	public static function init() {
 		self::register_post_type();
+		self::register_block();
+	}
+
+	/**
+	 * Register the jetpack/form block.
+	 */
+	private static function register_block() {
+		// Register the block
+		Form_Block::register_block();
 	}
 
 	/**

--- a/projects/packages/forms/src/class-reusable-forms.php
+++ b/projects/packages/forms/src/class-reusable-forms.php
@@ -56,7 +56,7 @@ class Reusable_Forms {
 				'show_in_rest'          => true,
 				'rest_base'             => 'jetpack-forms',
 				'rest_controller_class' => 'Automattic\Jetpack\Forms\ContactForm\REST_Jetpack_Form_Controller',
-				'capability_type'       => 'jetpack-form',
+				'capability_type'       => 'post',
 				'capabilities'          => array(
 					// You need to be able to edit posts, in order to read blocks in their raw form.
 					'read'                   => 'edit_posts',
@@ -70,6 +70,7 @@ class Reusable_Forms {
 					'edit_others_posts'      => 'edit_others_posts',
 					'delete_others_posts'    => 'delete_others_posts',
 				),
+				'map_meta_cap'          => true,
 				'supports'              => array(
 					'title',
 					'excerpt',

--- a/projects/packages/forms/src/class-reusable-forms.php
+++ b/projects/packages/forms/src/class-reusable-forms.php
@@ -26,16 +26,57 @@ class Reusable_Forms {
 		register_post_type(
 			'jetpack-form',
 			array(
-				'labels'       => array(
-					'name'          => __( 'Jetpack Forms', 'jetpack-forms' ),
-					'singular_name' => __( 'Jetpack Form', 'jetpack-forms' ),
+				'labels'                => array(
+					'name'                     => __( 'Forms', 'jetpack-forms' ),
+					'singular_name'            => __( 'Form', 'jetpack-forms' ),
+					'add_new'                  => __( 'Add Form', 'jetpack-forms' ),
+					'add_new_item'             => __( 'Add Form', 'jetpack-forms' ),
+					'new_item'                 => __( 'New Form', 'jetpack-forms' ),
+					'edit_item'                => __( 'Edit Block Form', 'jetpack-forms' ),
+					'view_item'                => __( 'View Form', 'jetpack-forms' ),
+					'view_items'               => __( 'View Forms', 'jetpack-forms' ),
+					'all_items'                => __( 'All Forms', 'jetpack-forms' ),
+					'search_items'             => __( 'Search Forms', 'jetpack-forms' ),
+					'not_found'                => __( 'No forms found.', 'jetpack-forms' ),
+					'not_found_in_trash'       => __( 'No forms found in Trash.', 'jetpack-forms' ),
+					'filter_items_list'        => __( 'Filter forms list', 'jetpack-forms' ),
+					'items_list_navigation'    => __( 'Forms list navigation', 'jetpack-forms' ),
+					'items_list'               => __( 'Forms list', 'jetpack-forms' ),
+					'item_published'           => __( 'Form published.', 'jetpack-forms' ),
+					'item_published_privately' => __( 'Form published privately.', 'jetpack-forms' ),
+					'item_reverted_to_draft'   => __( 'Form reverted to draft.', 'jetpack-forms' ),
+					'item_scheduled'           => __( 'Form scheduled.', 'jetpack-forms' ),
+					'item_updated'             => __( 'Form updated.', 'jetpack-forms' ),
 				),
-				'public'       => false,
-				'show_ui'      => false,
-				'show_in_menu' => false,
-				'rewrite'      => false,
-				'query_var'    => false,
-				'show_in_rest' => false,
+				'public'                => false,
+				'show_ui'               => true, // not sure we need this.
+				'show_in_menu'          => false,
+				'rewrite'               => false,
+				'query_var'             => false,
+				'show_in_rest'          => true,
+				'rest_base'             => 'jetpack-forms',
+				'rest_controller_class' => 'Automattic\Jetpack\Forms\ContactForm\REST_Jetpack_Form_Controller',
+				'capability_type'       => 'jetpack-form',
+				'capabilities'          => array(
+					// You need to be able to edit posts, in order to read blocks in their raw form.
+					'read'                   => 'edit_posts',
+					// You need to be able to publish posts, in order to create blocks.
+					'create_posts'           => 'publish_posts',
+					'edit_posts'             => 'edit_posts',
+					'edit_published_posts'   => 'edit_published_posts',
+					'delete_published_posts' => 'delete_published_posts',
+					// Enables trashing draft posts as well.
+					'delete_posts'           => 'delete_posts',
+					'edit_others_posts'      => 'edit_others_posts',
+					'delete_others_posts'    => 'delete_others_posts',
+				),
+				'supports'              => array(
+					'title',
+					'excerpt',
+					'editor',
+					'revisions',
+					'custom-fields',
+				),
 			)
 		);
 	}

--- a/projects/packages/forms/src/class-reusable-forms.php
+++ b/projects/packages/forms/src/class-reusable-forms.php
@@ -82,6 +82,7 @@ class Reusable_Forms {
 					'delete_others_posts'    => 'delete_others_posts',
 				),
 				'map_meta_cap'          => true,
+				'template'              => array( array( 'jetpack/contact-form' ) ),
 				'supports'              => array(
 					'title',
 					'excerpt',

--- a/projects/packages/forms/src/class-reusable-forms.php
+++ b/projects/packages/forms/src/class-reusable-forms.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Reusable Forms class.
+ *
+ * @package automattic/jetpack-forms
+ */
+
+namespace Automattic\Jetpack\Forms;
+
+/**
+ * Handles Reusable Forms functionality.
+ */
+class Reusable_Forms {
+
+	/**
+	 * Initialize the Reusable Forms feature.
+	 */
+	public static function init() {
+		self::register_post_type();
+	}
+
+	/**
+	 * Register the jetpack-form custom post type.
+	 */
+	private static function register_post_type() {
+		register_post_type(
+			'jetpack-form',
+			array(
+				'labels'       => array(
+					'name'          => __( 'Jetpack Forms', 'jetpack-forms' ),
+					'singular_name' => __( 'Jetpack Form', 'jetpack-forms' ),
+				),
+				'public'       => false,
+				'show_ui'      => false,
+				'show_in_menu' => false,
+				'rewrite'      => false,
+				'query_var'    => false,
+				'show_in_rest' => false,
+			)
+		);
+	}
+}

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -11,6 +11,7 @@ use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Constants;
 use Automattic\Jetpack\Extensions\Contact_Form\Contact_Form_Block;
 use Automattic\Jetpack\Forms\Jetpack_Forms;
+use Automattic\Jetpack\Forms\Reusable_Forms;
 use Automattic\Jetpack\Forms\Service\Form_Webhooks;
 use Automattic\Jetpack\Forms\Service\Hostinger_Reach_Integration;
 use Automattic\Jetpack\Forms\Service\MailPoet_Integration;
@@ -265,6 +266,13 @@ class Contact_Form_Plugin {
 				'map_meta_cap'          => true,
 			)
 		);
+
+		// Initialize Reusable Forms feature if enabled
+		$feature_flags = apply_filters( 'jetpack_block_editor_feature_flags', array() );
+		if ( ! empty( $feature_flags['reusable-forms'] ) ) {
+			Reusable_Forms::init();
+		}
+
 		add_filter( 'wp_untrash_post_status', array( $this, 'untrash_feedback_status_handler' ), 10, 3 );
 
 		// Add to REST API post type allowed list.

--- a/projects/packages/forms/src/contact-form/class-rest-jetpack-form-controller.php
+++ b/projects/packages/forms/src/contact-form/class-rest-jetpack-form-controller.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * Contact_Form_Endpoint class.
+ *
+ * @package automattic/jetpack-forms
+ */
+
+namespace Automattic\Jetpack\Forms\ContactForm;
+
+/**
+ * REST_Jetpack_Form_Controller class.
+ *
+ * Responsible for handling REST API requests for Jetpack forms custom post type.
+ */
+class REST_Jetpack_Form_Controller extends WP_REST_Posts_Controller {
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		parent::__construct( 'jetpack-form' );
+	}
+}

--- a/projects/packages/forms/src/contact-form/class-rest-jetpack-form-controller.php
+++ b/projects/packages/forms/src/contact-form/class-rest-jetpack-form-controller.php
@@ -12,11 +12,66 @@ namespace Automattic\Jetpack\Forms\ContactForm;
  *
  * Responsible for handling REST API requests for Jetpack forms custom post type.
  */
-class REST_Jetpack_Form_Controller extends WP_REST_Posts_Controller {
+class REST_Jetpack_Form_Controller extends \WP_REST_Posts_Controller {
 	/**
 	 * Constructor.
 	 */
 	public function __construct() {
 		parent::__construct( 'jetpack-form' );
+	}
+
+	/**
+	 * Checks if a given request has access to get items.
+	 *
+	 * @param \WP_REST_Request $request Full details about the request.
+	 * @return true|\WP_Error True if the request has read access, WP_Error object otherwise.
+	 */
+	public function get_items_permissions_check( $request ) {
+		$post_type = get_post_type_object( $this->post_type );
+
+		if ( ! current_user_can( $post_type->cap->edit_posts ) ) {
+			return new \WP_Error(
+				'rest_cannot_read',
+				__( 'Sorry, you are not allowed to view forms.', 'jetpack-forms' ),
+				array( 'status' => rest_authorization_required_code() )
+			);
+		}
+
+		return parent::get_items_permissions_check( $request );
+	}
+
+	/**
+	 * Checks if a given request has access to create items.
+	 *
+	 * @param \WP_REST_Request $request Full details about the request.
+	 * @return true|\WP_Error True if the request has access to create items, WP_Error object otherwise.
+	 */
+	public function create_item_permissions_check( $request ) {
+		$post_type = get_post_type_object( $this->post_type );
+
+		if ( ! current_user_can( $post_type->cap->create_posts ) ) {
+			return new \WP_Error(
+				'rest_cannot_create',
+				__( 'Sorry, you are not allowed to create forms.', 'jetpack-forms' ),
+				array( 'status' => rest_authorization_required_code() )
+			);
+		}
+
+		return parent::create_item_permissions_check( $request );
+	}
+
+	/**
+	 * Checks if a jetpack-form can be read.
+	 *
+	 * @param WP_Post $post Post object that backs the block.
+	 * @return bool Whether the pattern can be read.
+	 */
+	public function check_read_permission( $post ) {
+		// By default the read_post capability is mapped to edit_posts.
+		if ( ! current_user_can( 'read_post', $post->ID ) ) {
+			return false;
+		}
+
+		return parent::check_read_permission( $post );
 	}
 }

--- a/projects/packages/forms/tests/php/contact-form/Reusable_Forms_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Reusable_Forms_Test.php
@@ -1,0 +1,317 @@
+<?php
+/**
+ * Unit Tests for Reusable_Forms.
+ *
+ * @package automattic/jetpack-forms
+ */
+
+namespace Automattic\Jetpack\Forms\ContactForm;
+
+use Automattic\Jetpack\Forms\Reusable_Forms;
+use PHPUnit\Framework\TestCase;
+use WorDBless\Options as WorDBless_Options;
+use WorDBless\Users as WorDBless_Users;
+use WP_REST_Request;
+use WP_REST_Server;
+
+/**
+ * Unit tests for the Reusable Forms feature.
+ *
+ * To run this test, you can use the following command: (from the projects/packages/forms directory)
+ *
+ * composer test-php tests/php/contact-form/Reusable_Forms_Test.php
+ */
+class Reusable_Forms_Test extends TestCase {
+
+	/**
+	 * REST Server object.
+	 *
+	 * @var WP_REST_Server
+	 */
+	private $server;
+
+	/**
+	 * The current user id.
+	 *
+	 * @var int
+	 */
+	private static $user_id;
+
+	/**
+	 * Setting up the test.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		global $wp_rest_server;
+
+		$wp_rest_server = new WP_REST_Server();
+		$this->server   = $wp_rest_server;
+
+		do_action( 'rest_api_init' );
+
+		self::$user_id = wp_insert_user(
+			array(
+				'user_login' => 'test_admin',
+				'user_pass'  => '123',
+				'role'       => 'administrator',
+			)
+		);
+		wp_set_current_user( self::$user_id );
+	}
+
+	/**
+	 * Returning the environment into its initial state.
+	 */
+	public function tearDown(): void {
+		parent::tearDown();
+		WorDBless_Options::init()->clear_options();
+		WorDBless_Users::init()->clear_all_users();
+
+		unset( $_SERVER['REQUEST_METHOD'] );
+		$_GET = array();
+
+		// Unregister the post type if it was registered
+		unregister_post_type( 'jetpack-form' );
+	}
+
+	/**
+	 * Test that the post type is registered when init is called.
+	 */
+	public function test_init_registers_post_type() {
+		Reusable_Forms::init();
+
+		$this->assertTrue( post_type_exists( 'jetpack-form' ), 'jetpack-form post type should be registered' );
+	}
+
+	/**
+	 * Test that the post type has the correct configuration.
+	 */
+	public function test_post_type_configuration() {
+		Reusable_Forms::init();
+
+		$post_type_object = get_post_type_object( 'jetpack-form' );
+
+		$this->assertNotNull( $post_type_object, 'Post type object should exist' );
+		$this->assertEquals( 'jetpack-form', $post_type_object->name );
+		$this->assertFalse( $post_type_object->public, 'Post type should not be public' );
+		$this->assertTrue( $post_type_object->show_ui, 'Post type should show UI' );
+		$this->assertFalse( $post_type_object->show_in_menu, 'Post type should not show in menu' );
+		$this->assertTrue( $post_type_object->show_in_rest, 'Post type should be available in REST' );
+		$this->assertEquals( 'jetpack-forms', $post_type_object->rest_base, 'REST base should be jetpack-forms' );
+	}
+
+	/**
+	 * Test that the post type supports the correct features.
+	 */
+	public function test_post_type_supports() {
+		Reusable_Forms::init();
+
+		$this->assertTrue( post_type_supports( 'jetpack-form', 'title' ), 'Should support title' );
+		$this->assertTrue( post_type_supports( 'jetpack-form', 'excerpt' ), 'Should support excerpt' );
+		$this->assertTrue( post_type_supports( 'jetpack-form', 'editor' ), 'Should support editor' );
+		$this->assertTrue( post_type_supports( 'jetpack-form', 'revisions' ), 'Should support revisions' );
+		$this->assertTrue( post_type_supports( 'jetpack-form', 'custom-fields' ), 'Should support custom-fields' );
+	}
+
+	/**
+	 * Test that the REST endpoints are registered.
+	 */
+	public function test_rest_endpoints_are_registered() {
+		Reusable_Forms::init();
+
+		// Re-initialize REST server to pick up new routes
+		do_action( 'rest_api_init' );
+
+		$routes = $this->server->get_routes();
+
+		$this->assertArrayHasKey( '/wp/v2/jetpack-forms', $routes, 'Main endpoint should be registered' );
+		$this->assertArrayHasKey( '/wp/v2/jetpack-forms/(?P<id>[\d]+)', $routes, 'Single item endpoint should be registered' );
+	}
+
+	/**
+	 * Test that GET request to jetpack-forms endpoint works.
+	 */
+	public function test_get_jetpack_forms_returns_200() {
+		Reusable_Forms::init();
+		do_action( 'rest_api_init' );
+
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/jetpack-forms' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 200, $response->get_status(), 'GET request should return 200' );
+		$this->assertIsArray( $response->get_data(), 'Response should be an array' );
+	}
+
+	/**
+	 * Test that users without edit_posts capability cannot access jetpack-forms endpoint.
+	 */
+	public function test_get_jetpack_forms_unauthorized_returns_401() {
+		Reusable_Forms::init();
+		do_action( 'rest_api_init' );
+
+		// Create a subscriber user (no edit_posts capability)
+		$subscriber_id = wp_insert_user(
+			array(
+				'user_login' => 'test_subscriber',
+				'user_pass'  => '123',
+				'role'       => 'subscriber',
+			)
+		);
+		wp_set_current_user( $subscriber_id );
+
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/jetpack-forms' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertContains( $response->get_status(), array( 401, 403 ), 'Unauthorized request should return 401 or 403' );
+	}
+
+	/**
+	 * Test creating a jetpack-form via REST API.
+	 */
+	public function test_create_jetpack_form_via_rest() {
+		Reusable_Forms::init();
+		do_action( 'rest_api_init' );
+
+		// Ensure user has proper capabilities
+		$user = wp_get_current_user();
+		$user->add_cap( 'edit_posts' );
+		$user->add_cap( 'publish_posts' );
+
+		$request = new WP_REST_Request( 'POST', '/wp/v2/jetpack-forms' );
+		$request->set_param( 'title', 'Test Reusable Form' );
+		$request->set_param( 'status', 'publish' );
+		$request->set_param( 'content', '<!-- wp:jetpack/contact-form --><div class="wp-block-jetpack-contact-form">Test Form</div><!-- /wp:jetpack/contact-form -->' );
+
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 201, $response->get_status(), 'POST request should return 201' );
+
+		$data  = $response->get_data();
+		$title = isset( $data['title']['raw'] ) ? $data['title']['raw'] : $data['title']['rendered'];
+		$this->assertEquals( 'Test Reusable Form', $title, 'Title should match' );
+		$this->assertEquals( 'publish', $data['status'], 'Status should be publish' );
+	}
+
+	/**
+	 * Test retrieving a specific jetpack-form via REST API.
+	 */
+	public function test_get_single_jetpack_form_via_rest() {
+		Reusable_Forms::init();
+		do_action( 'rest_api_init' );
+
+		// Create a form first
+		$post_id = wp_insert_post(
+			array(
+				'post_type'    => 'jetpack-form',
+				'post_title'   => 'Single Test Form',
+				'post_content' => 'Form content',
+				'post_status'  => 'publish',
+			)
+		);
+
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/jetpack-forms/' . $post_id );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 200, $response->get_status(), 'GET single item should return 200' );
+
+		$data = $response->get_data();
+		// Title might be in different formats depending on context
+		$title = isset( $data['title']['raw'] ) ? $data['title']['raw'] : $data['title']['rendered'];
+		$this->assertEquals( 'Single Test Form', $title, 'Title should match' );
+		$this->assertEquals( $post_id, $data['id'], 'ID should match' );
+	}
+
+	/**
+	 * Test updating a jetpack-form via REST API.
+	 */
+	public function test_update_jetpack_form_via_rest() {
+		Reusable_Forms::init();
+		do_action( 'rest_api_init' );
+
+		// Ensure user has proper capabilities
+		$user = wp_get_current_user();
+		$user->add_cap( 'edit_posts' );
+		$user->add_cap( 'edit_published_posts' );
+
+		// Create a form first
+		$post_id = wp_insert_post(
+			array(
+				'post_type'    => 'jetpack-form',
+				'post_title'   => 'Original Title',
+				'post_content' => 'Original content',
+				'post_status'  => 'publish',
+			)
+		);
+
+		$request = new WP_REST_Request( 'PUT', '/wp/v2/jetpack-forms/' . $post_id );
+		$request->set_param( 'title', 'Updated Title' );
+
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 200, $response->get_status(), 'PUT request should return 200' );
+
+		$data  = $response->get_data();
+		$title = isset( $data['title']['raw'] ) ? $data['title']['raw'] : $data['title']['rendered'];
+		$this->assertEquals( 'Updated Title', $title, 'Title should be updated' );
+	}
+
+	/**
+	 * Test deleting a jetpack-form via REST API.
+	 */
+	public function test_delete_jetpack_form_via_rest() {
+		Reusable_Forms::init();
+		do_action( 'rest_api_init' );
+
+		// Ensure user has proper capabilities
+		$user = wp_get_current_user();
+		$user->add_cap( 'delete_posts' );
+		$user->add_cap( 'delete_published_posts' );
+
+		// Create a form first
+		$post_id = wp_insert_post(
+			array(
+				'post_type'    => 'jetpack-form',
+				'post_title'   => 'Form to Delete',
+				'post_content' => 'Form content',
+				'post_status'  => 'publish',
+			)
+		);
+
+		$request  = new WP_REST_Request( 'DELETE', '/wp/v2/jetpack-forms/' . $post_id );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 200, $response->get_status(), 'DELETE request should return 200' );
+
+		// Verify the post is trashed
+		$post = get_post( $post_id );
+		$this->assertEquals( 'trash', $post->post_status, 'Post should be in trash' );
+	}
+
+	/**
+	 * Test that the REST controller class is correctly assigned.
+	 */
+	public function test_rest_controller_class() {
+		Reusable_Forms::init();
+
+		$post_type_object = get_post_type_object( 'jetpack-form' );
+
+		$this->assertEquals(
+			'Automattic\Jetpack\Forms\ContactForm\REST_Jetpack_Form_Controller',
+			$post_type_object->rest_controller_class,
+			'REST controller class should be correctly set'
+		);
+	}
+
+	/**
+	 * Test that the post type has correct capability mappings.
+	 */
+	public function test_post_type_capabilities() {
+		Reusable_Forms::init();
+
+		$post_type_object = get_post_type_object( 'jetpack-form' );
+
+		$this->assertEquals( 'edit_posts', $post_type_object->cap->read, 'Read capability should be edit_posts' );
+		$this->assertEquals( 'publish_posts', $post_type_object->cap->create_posts, 'Create capability should be publish_posts' );
+		$this->assertEquals( 'edit_posts', $post_type_object->cap->edit_posts, 'Edit posts capability should be edit_posts' );
+	}
+}

--- a/projects/packages/forms/tools/webpack.config.blocks.js
+++ b/projects/packages/forms/tools/webpack.config.blocks.js
@@ -20,6 +20,7 @@ const sharedWebpackConfig = {
 	entry: {
 		editor: './src/blocks/contact-form/editor.ts',
 		view: './src/blocks/contact-form/view.ts',
+		'form/index': './src/blocks/form/index.tsx',
 		'form-progress-indicator/style': './src/blocks/form-progress-indicator/style.scss',
 		'form-step-navigation/style': './src/blocks/form-step-navigation/style.scss',
 		'field-rating/style': './src/blocks/field-rating/style.scss',
@@ -105,7 +106,13 @@ export default [
 				patterns: [
 					{
 						from: 'src/blocks/**/block.json',
-						to: '[name][ext]',
+						to: ( { absoluteFilename } ) => {
+							const relativePath = path.relative(
+								path.join( __dirname, '../src/blocks' ),
+								absoluteFilename
+							);
+							return relativePath;
+						},
 						noErrorOnMissing: true,
 					},
 				],


### PR DESCRIPTION
### !!! Do not merge 

https://github.com/user-attachments/assets/666cffe4-f6ec-468a-a31e-e04898fd5cc7


## Proposed changes:
* This PR adds a "reusable form" block that lets us insert a reusable form from anywhere. 


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion


## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
You need to feature enable with a filter somoething like this. 
```
add_filter( 'jetpack_block_editor_feature_flags', 'eb_register_feature' );
function eb_register_feature( $flags ) {
    $flags['reusable-forms'] = true;
    return $flags;
}
```

In this version you should be able to create a new jetpack-form
custom post type by going to /wp-admin/post-new.php?post_type=jetpack-form

insert a form block there. (currently there is no restriction in what kind of block you can insert but the idea is to only be able to insert a form block via the block inserter. 



