### PR TITLE
add id-value shape for compiled fields, use it on webhooks

### DIFF
--- a/projects/packages/forms/src/contact-form/class-feedback.php
+++ b/projects/packages/forms/src/contact-form/class-feedback.php
@@ -625,7 +625,10 @@ class Feedback {
 					$compiled_fields[ $field->get_key() ] = $field->get_render_value( $context );
 					break;
 				case 'label-value':
-						$compiled_fields[ $field->get_label( $context, $count_field_labels[ $label ] ) ] = $field->get_render_value( $context );
+					$compiled_fields[ $field->get_label( $context, $count_field_labels[ $label ] ) ] = $field->get_render_value( $context );
+					break;
+				case 'id-value':
+					$compiled_fields[ $field->get_form_field_id() ] = $field->get_render_value( $context );
 					break;
 			}
 		}

--- a/projects/packages/forms/src/service/class-form-webhooks.php
+++ b/projects/packages/forms/src/service/class-form-webhooks.php
@@ -258,11 +258,6 @@ class Form_Webhooks {
 	 * @return array The form data key/value pairs.
 	 */
 	private function get_form_data( $feedback ) {
-		$fields = array();
-		foreach ( $feedback->get_fields() as $field ) {
-			$fields[ $field->get_form_field_id() ] = $field->get_value();
-		}
-
-		return $fields;
+		return $feedback->get_compiled_fields( 'webhook', 'id-value' );
 	}
 }

--- a/projects/packages/forms/src/service/class-form-webhooks.php
+++ b/projects/packages/forms/src/service/class-form-webhooks.php
@@ -112,7 +112,7 @@ class Form_Webhooks {
 			return;
 		}
 
-		$form_data = $this->get_form_data( $feedback );
+		$form_data = $feedback->get_compiled_fields( 'webhook', 'id-value' );
 
 		// Iterate through each webhook and send the request
 		foreach ( $webhooks as $webhook ) {
@@ -249,15 +249,5 @@ class Form_Webhooks {
 		);
 
 		return wp_remote_request( $url, $args );
-	}
-
-	/**
-	 * Gather fields key/value pairs from the Feedback object
-	 *
-	 * @param Feedback $feedback The Feedback instance containing submitted form data.
-	 * @return array The form data key/value pairs.
-	 */
-	private function get_form_data( $feedback ) {
-		return $feedback->get_compiled_fields( 'webhook', 'id-value' );
 	}
 }

--- a/projects/packages/forms/tests/php/contact-form/Feedback_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Feedback_Test.php
@@ -1867,6 +1867,11 @@ class Feedback_Test extends BaseTestCase {
 				),
 				'message'  => 'Compiled fields should return only labels as indexed array.',
 			),
+			'id-value_format'    => array(
+				'format'   => 'id-value',
+				'expected' => array(), // Rebuilt dynamically in the test with actual form_id
+				'message'  => 'Compiled fields should return field IDs mapped to values.',
+			),
 		);
 	}
 
@@ -1905,6 +1910,17 @@ class Feedback_Test extends BaseTestCase {
 
 		// Test the specified format
 		$compiled_fields = $response->get_compiled_fields( 'default', $format );
+
+		// For id-value format, rebuild expected with actual form_id, there
+		// was no way of passing the form_id to the data provider.
+		if ( 'id-value' === $format ) {
+			$expected = array(
+				'g' . $form_id . '-name'    => $test_name,
+				'g' . $form_id . '-email'   => $test_email,
+				'g' . $form_id . '-website' => $test_website,
+				'g' . $form_id . '-message' => $test_message,
+			);
+		}
 
 		$this->assertEquals( $expected, $compiled_fields, $message );
 	}


### PR DESCRIPTION
See: p1764958359382309/1764949794.021509-slack-C052XEUUBL4

## Proposed changes:
This PR adds a new data shape for compiled fields, returning as:
```
Array
(
    [fieldIdName] => 'field value'
)
```

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1764958359382309/1764949794.021509-slack-C052XEUUBL4

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Follow instructions on the original PR #46201 

You should get the same results.