### PR TITLE
Charts: Add TrendIndicator component

### DIFF
--- a/projects/js-packages/charts/changelog/add-charts-new-trend-indicator
+++ b/projects/js-packages/charts/changelog/add-charts-new-trend-indicator
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add TrendIndicator component for displaying directional trends with values

--- a/projects/js-packages/charts/package.json
+++ b/projects/js-packages/charts/package.json
@@ -95,6 +95,12 @@
 			"require": "./dist/components/tooltip/index.cjs"
 		},
 		"./tooltip/style.css": "./dist/components/tooltip/index.css",
+		"./trend-indicator": {
+			"jetpack:src": "./src/components/trend-indicator/index.ts",
+			"import": "./dist/components/trend-indicator/index.js",
+			"require": "./dist/components/trend-indicator/index.cjs"
+		},
+		"./trend-indicator/style.css": "./dist/components/trend-indicator/index.css",
 		"./utils": {
 			"jetpack:src": "./src/utils/index.ts",
 			"import": "./dist/utils/index.js",
@@ -152,6 +158,9 @@
 			],
 			"sparkline": [
 				"./dist/components/sparkline/index.d.ts"
+			],
+			"trend-indicator": [
+				"./dist/components/trend-indicator/index.d.ts"
 			],
 			"hooks": [
 				"./dist/hooks/index.d.ts"

--- a/projects/js-packages/charts/src/components/index.ts
+++ b/projects/js-packages/charts/src/components/index.ts
@@ -1,2 +1,3 @@
 export * from './legend';
 export * from './tooltip';
+export * from './trend-indicator';

--- a/projects/js-packages/charts/src/components/trend-indicator/index.ts
+++ b/projects/js-packages/charts/src/components/trend-indicator/index.ts
@@ -1,0 +1,2 @@
+export { TrendIndicator } from './trend-indicator';
+export type { TrendIndicatorProps, TrendDirection } from './types';

--- a/projects/js-packages/charts/src/components/trend-indicator/stories/index.api.mdx
+++ b/projects/js-packages/charts/src/components/trend-indicator/stories/index.api.mdx
@@ -1,0 +1,107 @@
+import { Meta, Source } from '@storybook/addon-docs/blocks';
+
+<Meta title="JS Packages/Charts Library/Components/Trend Indicator/API Reference" />
+
+# Trend Indicator API Reference
+
+Complete API documentation for the TrendIndicator component.
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `direction` | `'up' \| 'down' \| 'neutral'` | **Required** | The direction of the trend |
+| `value` | `string \| number` | **Required** | The value to display |
+| `showIcon` | `boolean` | `true` | Whether to show the directional arrow icon |
+| `className` | `string` | - | Additional CSS class name |
+| `style` | `CSSProperties` | - | Inline CSS styles |
+
+## Type Definitions
+
+### TrendDirection
+
+<Source
+	language="typescript"
+	code={`type TrendDirection = 'up' | 'down' | 'neutral';`}
+/>
+
+### TrendIndicatorProps
+
+<Source
+	language="typescript"
+	code={`interface TrendIndicatorProps {
+	/** The direction of the trend (up, down, or neutral) */
+	direction: TrendDirection;
+
+	/** The value to display (e.g., "14%", "+$500", "2.5k") */
+	value: string | number;
+
+	/** Whether to show the directional icon */
+	showIcon?: boolean;
+
+	/** Additional CSS class name */
+	className?: string;
+
+	/** Inline styles */
+	style?: CSSProperties;
+}`}
+/>
+
+## Exports
+
+<Source
+	language="typescript"
+	code={`// Component export
+import { TrendIndicator } from '@automattic/charts';
+
+// Type exports
+import type { TrendIndicatorProps, TrendDirection } from '@automattic/charts';`}
+/>
+
+## CSS Classes
+
+The component uses CSS Modules with the following class structure:
+
+| Class | Description |
+|-------|-------------|
+| `.trend-indicator` | Root container element |
+| `.trend-indicator--up` | Applied when direction is `'up'` |
+| `.trend-indicator--down` | Applied when direction is `'down'` |
+| `.trend-indicator--neutral` | Applied when direction is `'neutral'` |
+| `.trend-indicator__icon` | The directional arrow SVG |
+| `.trend-indicator__value` | The value text container |
+
+## CSS Custom Properties
+
+The component exposes CSS custom properties for theming:
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| `--charts-trend-up-color` | `#1a8917` | Color for upward trends (green) |
+| `--charts-trend-down-color` | `#d63638` | Color for downward trends (red) |
+| `--charts-trend-neutral-color` | `#646970` | Color for neutral trends (gray) |
+
+## Accessibility Attributes
+
+| Attribute | Value | Description |
+|-----------|-------|-------------|
+| `aria-label` | `"{Direction}: {value}"` | Describes the trend for screen readers |
+| `aria-hidden` | `true` (on icon) | Hides decorative icon from screen readers |
+
+### Generated aria-label Values
+
+| Direction | Example Value | aria-label |
+|-----------|---------------|------------|
+| `up` | `+14%` | `"Increase: +14%"` |
+| `down` | `-5%` | `"Decrease: -5%"` |
+| `neutral` | `0%` | `"No change: 0%"` |
+
+## Icon Behavior
+
+| Direction | Icon Displayed |
+|-----------|----------------|
+| `up` | Upward arrow (↑) |
+| `down` | Downward arrow (↓) |
+| `neutral` | No icon |
+
+When `showIcon={false}`, no icon is displayed regardless of direction.

--- a/projects/js-packages/charts/src/components/trend-indicator/stories/index.docs.mdx
+++ b/projects/js-packages/charts/src/components/trend-indicator/stories/index.docs.mdx
@@ -1,0 +1,214 @@
+import { Meta, Canvas, Source } from '@storybook/addon-docs/blocks';
+import * as TrendIndicatorStories from './index.stories';
+
+<Meta title="JS Packages/Charts Library/Components/Trend Indicator" of={ TrendIndicatorStories } />
+
+# Trend Indicator
+
+A compact component for displaying directional trends with values, perfect for showing percentage changes, growth metrics, or status indicators.
+
+<Canvas of={ TrendIndicatorStories.Up } />
+
+## Overview
+
+The TrendIndicator component displays a value with an optional directional icon and color-coded styling to indicate positive, negative, or neutral trends. It's designed to be used inline with text or alongside metrics in dashboards.
+
+<Source
+	language="tsx"
+	code={`import { TrendIndicator } from '@automattic/charts';
+
+<TrendIndicator direction="up" value="+14%" />
+<TrendIndicator direction="down" value="-5%" />
+<TrendIndicator direction="neutral" value="0%" />`}
+/>
+
+## API Reference
+
+For detailed information about component props and types, see the [Trend Indicator API Reference](./?path=/docs/js-packages-charts-library-components-trend-indicator-api-reference--docs).
+
+## Basic Usage
+
+### Upward Trend
+
+Use `direction="up"` for positive changes. The indicator displays in green with an upward arrow:
+
+<Canvas of={ TrendIndicatorStories.Up } />
+
+<Source
+	language="tsx"
+	code={`<TrendIndicator direction="up" value="+14%" />`}
+/>
+
+### Downward Trend
+
+Use `direction="down"` for negative changes. The indicator displays in red with a downward arrow:
+
+<Canvas of={ TrendIndicatorStories.Down } />
+
+<Source
+	language="tsx"
+	code={`<TrendIndicator direction="down" value="-5%" />`}
+/>
+
+### Neutral Trend
+
+Use `direction="neutral"` for unchanged values. The indicator displays in gray without an arrow:
+
+<Canvas of={ TrendIndicatorStories.Neutral } />
+
+<Source
+	language="tsx"
+	code={`<TrendIndicator direction="neutral" value="0%" />`}
+/>
+
+### Required Props
+
+- **`direction`**: The trend direction (`'up'`, `'down'`, or `'neutral'`)
+- **`value`**: The value to display (string or number)
+
+### Optional Props
+
+- **`showIcon`** (default: `true`): Whether to show the directional arrow icon
+- **`className`**: Additional CSS class name
+- **`style`**: Inline CSS styles
+
+## Visual Customization
+
+### Without Icon
+
+Hide the directional icon when you only need color-coded text:
+
+<Canvas of={ TrendIndicatorStories.WithoutIcon } />
+
+<Source
+	language="tsx"
+	code={`<TrendIndicator direction="up" value="+14%" showIcon={false} />`}
+/>
+
+### Custom Styling
+
+Apply custom styles using the `className` or `style` props:
+
+<Source
+	language="tsx"
+	code={`<TrendIndicator
+	direction="up"
+	value="+25%"
+	style={{ fontSize: '1.5rem', fontWeight: 700 }}
+/>
+
+<TrendIndicator
+	direction="down"
+	value="-10%"
+	className="my-custom-trend"
+/>`}
+/>
+
+### Value Formats
+
+The `value` prop accepts any string or number format:
+
+<Source
+	language="tsx"
+	code={`// Percentages
+<TrendIndicator direction="up" value="+14%" />
+<TrendIndicator direction="down" value="-5.2%" />
+
+// Currency
+<TrendIndicator direction="up" value="+$500" />
+<TrendIndicator direction="down" value="-$1,234" />
+
+// Numbers
+<TrendIndicator direction="up" value={42} />
+<TrendIndicator direction="up" value="2.5k" />`}
+/>
+
+## Theming
+
+The component uses CSS custom properties for colors, making it easy to customize:
+
+<Source
+	language="css"
+	code={`:root {
+	--charts-trend-up-color: #1a8917;    /* Green for positive */
+	--charts-trend-down-color: #d63638;  /* Red for negative */
+	--charts-trend-neutral-color: #646970; /* Gray for neutral */
+}`}
+/>
+
+Override these variables in your stylesheet to match your design system.
+
+## Common Use Cases
+
+### Dashboard Metrics
+
+Display trend indicators alongside key metrics:
+
+<Source
+	language="tsx"
+	code={`<div className="metric-card">
+	<span className="metric-label">Monthly Revenue</span>
+	<div className="metric-value">
+		<span>$45,231</span>
+		<TrendIndicator direction="up" value="+12%" />
+	</div>
+</div>`}
+/>
+
+### Data Tables
+
+Show trends in table cells:
+
+<Source
+	language="tsx"
+	code={`<table>
+	<tbody>
+		<tr>
+			<td>Product A</td>
+			<td>1,234 sales</td>
+			<td><TrendIndicator direction="up" value="+8%" /></td>
+		</tr>
+		<tr>
+			<td>Product B</td>
+			<td>567 sales</td>
+			<td><TrendIndicator direction="down" value="-3%" /></td>
+		</tr>
+	</tbody>
+</table>`}
+/>
+
+### Inline with Text
+
+Use inline with descriptive text:
+
+<Source
+	language="tsx"
+	code={`<p>
+	Sales increased this quarter <TrendIndicator direction="up" value="+14%" />
+</p>`}
+/>
+
+## Accessibility
+
+The TrendIndicator component includes built-in accessibility features:
+
+- **aria-label**: Automatically generated label describing the trend (e.g., "Increase: +14%")
+- **aria-hidden**: The decorative icon is hidden from screen readers
+- **Color independence**: Trends are distinguishable by icon direction, not just color
+
+<Source
+	language="tsx"
+	code={`// Rendered output includes:
+<span aria-label="Increase: +14%">
+	<svg aria-hidden="true">...</svg>
+	<span>+14%</span>
+</span>`}
+/>
+
+## Browser Compatibility
+
+TrendIndicator is compatible with all modern browsers:
+- Chrome/Edge (latest)
+- Firefox (latest)
+- Safari (latest)
+- Mobile browsers (iOS Safari, Chrome Mobile)

--- a/projects/js-packages/charts/src/components/trend-indicator/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/components/trend-indicator/stories/index.stories.tsx
@@ -3,10 +3,19 @@ import { TrendIndicator } from '../trend-indicator';
 import type { TrendIndicatorProps } from '../types';
 
 const meta: Meta< TrendIndicatorProps > = {
-	title: 'JS Packages/Charts/Components/Trend Indicator',
+	title: 'JS Packages/Charts Library/Components/Trend Indicator',
 	component: TrendIndicator,
 	parameters: {
 		layout: 'centered',
+	},
+	argTypes: {
+		direction: {
+			control: { type: 'radio' },
+			options: [ 'up', 'down', 'neutral' ],
+		},
+		value: {
+			control: 'text',
+		},
 	},
 };
 

--- a/projects/js-packages/charts/src/components/trend-indicator/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/components/trend-indicator/stories/index.stories.tsx
@@ -16,6 +16,9 @@ const meta: Meta< TrendIndicatorProps > = {
 		value: {
 			control: 'text',
 		},
+		showIcon: {
+			control: 'boolean',
+		},
 	},
 };
 
@@ -40,5 +43,13 @@ export const Neutral: Story = {
 	args: {
 		direction: 'neutral',
 		value: '0%',
+	},
+};
+
+export const WithoutIcon: Story = {
+	args: {
+		direction: 'up',
+		value: '+14%',
+		showIcon: false,
 	},
 };

--- a/projects/js-packages/charts/src/components/trend-indicator/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/components/trend-indicator/stories/index.stories.tsx
@@ -1,0 +1,35 @@
+import { Meta, StoryObj } from '@storybook/react';
+import { TrendIndicator } from '../trend-indicator';
+import type { TrendIndicatorProps } from '../types';
+
+const meta: Meta< TrendIndicatorProps > = {
+	title: 'JS Packages/Charts/Components/Trend Indicator',
+	component: TrendIndicator,
+	parameters: {
+		layout: 'centered',
+	},
+};
+
+export default meta;
+type Story = StoryObj< TrendIndicatorProps >;
+
+export const Up: Story = {
+	args: {
+		direction: 'up',
+		value: '+14%',
+	},
+};
+
+export const Down: Story = {
+	args: {
+		direction: 'down',
+		value: '-5%',
+	},
+};
+
+export const Neutral: Story = {
+	args: {
+		direction: 'neutral',
+		value: '0%',
+	},
+};

--- a/projects/js-packages/charts/src/components/trend-indicator/test/trend-indicator.test.tsx
+++ b/projects/js-packages/charts/src/components/trend-indicator/test/trend-indicator.test.tsx
@@ -53,4 +53,19 @@ describe( 'TrendIndicator', () => {
 		// eslint-disable-next-line testing-library/no-node-access
 		expect( container.firstChild ).toHaveClass( 'custom-class' );
 	} );
+
+	it( 'renders numeric value', () => {
+		render( <TrendIndicator direction="up" value={ 42 } /> );
+
+		expect( screen.getByText( '42' ) ).toBeInTheDocument();
+	} );
+
+	it( 'applies custom style', () => {
+		const { container } = render(
+			<TrendIndicator direction="up" value="+10%" style={ { fontSize: '2rem' } } />
+		);
+
+		// eslint-disable-next-line testing-library/no-node-access
+		expect( container.firstChild ).toHaveStyle( { fontSize: '2rem' } );
+	} );
 } );

--- a/projects/js-packages/charts/src/components/trend-indicator/test/trend-indicator.test.tsx
+++ b/projects/js-packages/charts/src/components/trend-indicator/test/trend-indicator.test.tsx
@@ -68,4 +68,27 @@ describe( 'TrendIndicator', () => {
 		// eslint-disable-next-line testing-library/no-node-access
 		expect( container.firstChild ).toHaveStyle( { fontSize: '2rem' } );
 	} );
+
+	describe( 'accessibility', () => {
+		it( 'provides aria-label for up trend', () => {
+			const { container } = render( <TrendIndicator direction="up" value="+14%" /> );
+
+			// eslint-disable-next-line testing-library/no-node-access
+			expect( container.firstChild ).toHaveAttribute( 'aria-label', 'Increase: +14%' );
+		} );
+
+		it( 'provides aria-label for down trend', () => {
+			const { container } = render( <TrendIndicator direction="down" value="-5%" /> );
+
+			// eslint-disable-next-line testing-library/no-node-access
+			expect( container.firstChild ).toHaveAttribute( 'aria-label', 'Decrease: -5%' );
+		} );
+
+		it( 'provides aria-label for neutral trend', () => {
+			const { container } = render( <TrendIndicator direction="neutral" value="0%" /> );
+
+			// eslint-disable-next-line testing-library/no-node-access
+			expect( container.firstChild ).toHaveAttribute( 'aria-label', 'No change: 0%' );
+		} );
+	} );
 } );

--- a/projects/js-packages/charts/src/components/trend-indicator/test/trend-indicator.test.tsx
+++ b/projects/js-packages/charts/src/components/trend-indicator/test/trend-indicator.test.tsx
@@ -21,21 +21,28 @@ describe( 'TrendIndicator', () => {
 	} );
 
 	it( 'renders icon for up direction', () => {
-		render( <TrendIndicator direction="up" value="+10%" /> );
+		const { container } = render( <TrendIndicator direction="up" value="+10%" /> );
 
-		expect( screen.getByRole( 'img', { hidden: true } ) ).toBeInTheDocument();
+		// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+		const svg = container.querySelector( 'svg' );
+		expect( svg ).toBeInTheDocument();
+		expect( svg ).toHaveAttribute( 'aria-hidden', 'true' );
 	} );
 
 	it( 'renders icon for down direction', () => {
-		render( <TrendIndicator direction="down" value="-10%" /> );
+		const { container } = render( <TrendIndicator direction="down" value="-10%" /> );
 
-		expect( screen.getByRole( 'img', { hidden: true } ) ).toBeInTheDocument();
+		// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+		const svg = container.querySelector( 'svg' );
+		expect( svg ).toBeInTheDocument();
+		expect( svg ).toHaveAttribute( 'aria-hidden', 'true' );
 	} );
 
 	it( 'does not render icon for neutral direction', () => {
-		render( <TrendIndicator direction="neutral" value="0%" /> );
+		const { container } = render( <TrendIndicator direction="neutral" value="0%" /> );
 
-		expect( screen.queryByRole( 'img', { hidden: true } ) ).not.toBeInTheDocument();
+		// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+		expect( container.querySelector( 'svg' ) ).not.toBeInTheDocument();
 	} );
 
 	it( 'applies custom className', () => {

--- a/projects/js-packages/charts/src/components/trend-indicator/test/trend-indicator.test.tsx
+++ b/projects/js-packages/charts/src/components/trend-indicator/test/trend-indicator.test.tsx
@@ -1,0 +1,49 @@
+import { render, screen } from '@testing-library/react';
+import { TrendIndicator } from '../trend-indicator';
+
+describe( 'TrendIndicator', () => {
+	it( 'renders up trend with value', () => {
+		render( <TrendIndicator direction="up" value="+14%" /> );
+
+		expect( screen.getByText( '+14%' ) ).toBeInTheDocument();
+	} );
+
+	it( 'renders down trend with value', () => {
+		render( <TrendIndicator direction="down" value="-5%" /> );
+
+		expect( screen.getByText( '-5%' ) ).toBeInTheDocument();
+	} );
+
+	it( 'renders neutral trend with value', () => {
+		render( <TrendIndicator direction="neutral" value="0%" /> );
+
+		expect( screen.getByText( '0%' ) ).toBeInTheDocument();
+	} );
+
+	it( 'renders icon for up direction', () => {
+		render( <TrendIndicator direction="up" value="+10%" /> );
+
+		expect( screen.getByRole( 'img', { hidden: true } ) ).toBeInTheDocument();
+	} );
+
+	it( 'renders icon for down direction', () => {
+		render( <TrendIndicator direction="down" value="-10%" /> );
+
+		expect( screen.getByRole( 'img', { hidden: true } ) ).toBeInTheDocument();
+	} );
+
+	it( 'does not render icon for neutral direction', () => {
+		render( <TrendIndicator direction="neutral" value="0%" /> );
+
+		expect( screen.queryByRole( 'img', { hidden: true } ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'applies custom className', () => {
+		const { container } = render(
+			<TrendIndicator direction="up" value="+10%" className="custom-class" />
+		);
+
+		// eslint-disable-next-line testing-library/no-node-access
+		expect( container.firstChild ).toHaveClass( 'custom-class' );
+	} );
+} );

--- a/projects/js-packages/charts/src/components/trend-indicator/test/trend-indicator.test.tsx
+++ b/projects/js-packages/charts/src/components/trend-indicator/test/trend-indicator.test.tsx
@@ -45,6 +45,15 @@ describe( 'TrendIndicator', () => {
 		expect( container.querySelector( 'svg' ) ).not.toBeInTheDocument();
 	} );
 
+	it( 'does not render icon when showIcon is false', () => {
+		const { container } = render(
+			<TrendIndicator direction="up" value="+10%" showIcon={ false } />
+		);
+
+		// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+		expect( container.querySelector( 'svg' ) ).not.toBeInTheDocument();
+	} );
+
 	it( 'applies custom className', () => {
 		const { container } = render(
 			<TrendIndicator direction="up" value="+10%" className="custom-class" />

--- a/projects/js-packages/charts/src/components/trend-indicator/trend-indicator.module.scss
+++ b/projects/js-packages/charts/src/components/trend-indicator/trend-indicator.module.scss
@@ -1,0 +1,18 @@
+.trend-indicator {
+	display: inline-flex;
+	align-items: center;
+	gap: 0.125em;
+	font-size: 0.875rem;
+	font-weight: 500;
+	line-height: 1;
+
+	&__icon {
+		width: 1em;
+		height: 1em;
+		flex-shrink: 0;
+	}
+
+	&__value {
+		white-space: nowrap;
+	}
+}

--- a/projects/js-packages/charts/src/components/trend-indicator/trend-indicator.module.scss
+++ b/projects/js-packages/charts/src/components/trend-indicator/trend-indicator.module.scss
@@ -6,6 +6,18 @@
 	font-weight: 500;
 	line-height: 1;
 
+	&--up {
+		color: var(--charts-trend-up-color, #1a8917);
+	}
+
+	&--down {
+		color: var(--charts-trend-down-color, #d63638);
+	}
+
+	&--neutral {
+		color: var(--charts-trend-neutral-color, #646970);
+	}
+
 	&__icon {
 		width: 1em;
 		height: 1em;

--- a/projects/js-packages/charts/src/components/trend-indicator/trend-indicator.tsx
+++ b/projects/js-packages/charts/src/components/trend-indicator/trend-indicator.tsx
@@ -2,6 +2,12 @@ import clsx from 'clsx';
 import styles from './trend-indicator.module.scss';
 import type { TrendIndicatorProps, TrendDirection } from './types';
 
+const DIRECTION_LABELS: Record< TrendDirection, string > = {
+	up: 'Increase',
+	down: 'Decrease',
+	neutral: 'No change',
+};
+
 const Icon = ( { direction }: { direction: TrendDirection } ) => {
 	if ( direction === 'neutral' ) {
 		return null;
@@ -34,6 +40,8 @@ const Icon = ( { direction }: { direction: TrendDirection } ) => {
  * @return {JSX.Element} The rendered trend indicator
  */
 export function TrendIndicator( { direction, value, className, style }: TrendIndicatorProps ) {
+	const ariaLabel = `${ DIRECTION_LABELS[ direction ] }: ${ value }`;
+
 	return (
 		<span
 			className={ clsx(
@@ -42,6 +50,7 @@ export function TrendIndicator( { direction, value, className, style }: TrendInd
 				className
 			) }
 			style={ style }
+			aria-label={ ariaLabel }
 		>
 			<Icon direction={ direction } />
 			<span className={ styles[ 'trend-indicator__value' ] }>{ value }</span>

--- a/projects/js-packages/charts/src/components/trend-indicator/trend-indicator.tsx
+++ b/projects/js-packages/charts/src/components/trend-indicator/trend-indicator.tsx
@@ -39,7 +39,13 @@ const Icon = ( { direction }: { direction: TrendDirection } ) => {
  * @param {TrendIndicatorProps} props - Component props
  * @return {JSX.Element} The rendered trend indicator
  */
-export function TrendIndicator( { direction, value, className, style }: TrendIndicatorProps ) {
+export function TrendIndicator( {
+	direction,
+	value,
+	className,
+	style,
+	showIcon = true,
+}: TrendIndicatorProps ) {
 	const ariaLabel = `${ DIRECTION_LABELS[ direction ] }: ${ value }`;
 
 	return (
@@ -52,7 +58,7 @@ export function TrendIndicator( { direction, value, className, style }: TrendInd
 			style={ style }
 			aria-label={ ariaLabel }
 		>
-			<Icon direction={ direction } />
+			{ showIcon && <Icon direction={ direction } /> }
 			<span className={ styles[ 'trend-indicator__value' ] }>{ value }</span>
 		</span>
 	);

--- a/projects/js-packages/charts/src/components/trend-indicator/trend-indicator.tsx
+++ b/projects/js-packages/charts/src/components/trend-indicator/trend-indicator.tsx
@@ -13,7 +13,6 @@ const Icon = ( { direction }: { direction: TrendDirection } ) => {
 			className={ styles[ 'trend-indicator__icon' ] }
 			viewBox="0 0 16 16"
 			fill="none"
-			role="img"
 			aria-hidden="true"
 		>
 			<path

--- a/projects/js-packages/charts/src/components/trend-indicator/trend-indicator.tsx
+++ b/projects/js-packages/charts/src/components/trend-indicator/trend-indicator.tsx
@@ -1,0 +1,53 @@
+import clsx from 'clsx';
+import styles from './trend-indicator.module.scss';
+import type { TrendIndicatorProps, TrendDirection } from './types';
+
+const COLORS: Record< TrendDirection, string > = {
+	up: '#1a8917',
+	down: '#d63638',
+	neutral: '#646970',
+};
+
+const Icon = ( { direction }: { direction: TrendDirection } ) => {
+	if ( direction === 'neutral' ) {
+		return null;
+	}
+
+	const isUp = direction === 'up';
+	return (
+		<svg
+			className={ styles[ 'trend-indicator__icon' ] }
+			viewBox="0 0 16 16"
+			fill="none"
+			role="img"
+			aria-hidden="true"
+		>
+			<path
+				d={ isUp ? 'M8 13V3M4 7l4-4 4 4' : 'M8 3v10M4 9l4 4 4-4' }
+				stroke="currentColor"
+				strokeWidth="1.5"
+				strokeLinecap="round"
+				strokeLinejoin="round"
+			/>
+		</svg>
+	);
+};
+
+/**
+ * TrendIndicator displays a directional trend with a value.
+ * Used to show percentage changes or growth metrics.
+ *
+ * @param {TrendIndicatorProps} props - Component props
+ * @return {JSX.Element} The rendered trend indicator
+ */
+export function TrendIndicator( { direction, value, className, style }: TrendIndicatorProps ) {
+	return (
+		<span
+			className={ clsx( styles[ 'trend-indicator' ], className ) }
+			style={ { ...style, color: COLORS[ direction ] } }
+		>
+			<Icon direction={ direction } />
+			<span className={ styles[ 'trend-indicator__value' ] }>{ value }</span>
+		</span>
+	);
+}

--- a/projects/js-packages/charts/src/components/trend-indicator/trend-indicator.tsx
+++ b/projects/js-packages/charts/src/components/trend-indicator/trend-indicator.tsx
@@ -2,12 +2,6 @@ import clsx from 'clsx';
 import styles from './trend-indicator.module.scss';
 import type { TrendIndicatorProps, TrendDirection } from './types';
 
-const COLORS: Record< TrendDirection, string > = {
-	up: '#1a8917',
-	down: '#d63638',
-	neutral: '#646970',
-};
-
 const Icon = ( { direction }: { direction: TrendDirection } ) => {
 	if ( direction === 'neutral' ) {
 		return null;
@@ -43,8 +37,12 @@ const Icon = ( { direction }: { direction: TrendDirection } ) => {
 export function TrendIndicator( { direction, value, className, style }: TrendIndicatorProps ) {
 	return (
 		<span
-			className={ clsx( styles[ 'trend-indicator' ], className ) }
-			style={ { ...style, color: COLORS[ direction ] } }
+			className={ clsx(
+				styles[ 'trend-indicator' ],
+				styles[ `trend-indicator--${ direction }` ],
+				className
+			) }
+			style={ style }
 		>
 			<Icon direction={ direction } />
 			<span className={ styles[ 'trend-indicator__value' ] }>{ value }</span>

--- a/projects/js-packages/charts/src/components/trend-indicator/types.ts
+++ b/projects/js-packages/charts/src/components/trend-indicator/types.ts
@@ -1,0 +1,31 @@
+import type { CSSProperties } from 'react';
+
+/**
+ * The direction of the trend
+ */
+export type TrendDirection = 'up' | 'down' | 'neutral';
+
+/**
+ * Props for the TrendIndicator component
+ */
+export type TrendIndicatorProps = {
+	/**
+	 * The direction of the trend (up, down, or neutral)
+	 */
+	direction: TrendDirection;
+
+	/**
+	 * The value to display (e.g., "14%", "+$500", "2.5k")
+	 */
+	value: string | number;
+
+	/**
+	 * Additional CSS class name
+	 */
+	className?: string;
+
+	/**
+	 * Inline styles
+	 */
+	style?: CSSProperties;
+};

--- a/projects/js-packages/charts/src/components/trend-indicator/types.ts
+++ b/projects/js-packages/charts/src/components/trend-indicator/types.ts
@@ -28,4 +28,10 @@ export type TrendIndicatorProps = {
 	 * Inline styles
 	 */
 	style?: CSSProperties;
+
+	/**
+	 * Whether to show the directional icon
+	 * @default true
+	 */
+	showIcon?: boolean;
 };

--- a/projects/js-packages/charts/src/index.ts
+++ b/projects/js-packages/charts/src/index.ts
@@ -12,6 +12,8 @@ export { Sparkline, SparklineUnresponsive } from './charts/sparkline';
 export { BaseTooltip } from './components/tooltip';
 export { Legend, useChartLegendItems } from './components/legend';
 export type { LegendValueDisplay, BaseLegendItem } from './components/legend';
+export { TrendIndicator } from './components/trend-indicator';
+export type { TrendIndicatorProps, TrendDirection } from './components/trend-indicator';
 
 // Compositions
 


### PR DESCRIPTION
Closes CHARTS-144

## Proposed changes:
* Add new `TrendIndicator` component for displaying directional trends with values
* Support three directions: `up` (green), `down` (red), `neutral` (gray)
* Include arrow icon for up/down directions, no icon for neutral
* Export component and types from main package entry
* Add package.json export paths for tree-shaking support

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?

No, it does not.

## Testing instructions:

* Go to Storybook -> Charts -> Components -> Trend Indicator
* Test the three stories:
  - `Up`: Should display green arrow pointing up with "+14%"
  - `Down`: Should display red arrow pointing down with "-5%"
  - `Neutral`: Should display gray text "0%" with no icon
* Verify the component accepts `className` and `style` props for customization
* Run tests: `pnpm test -- src/components/trend-indicator`
* Build package: `pnpm build` and verify trend-indicator outputs are generated