### PR TITLE
Sync: Stop syncing 'woocommerce_update_order_item' WooCommerce action

### DIFF
--- a/projects/packages/sync/changelog/update-sync-remove-woocommerce_update_order_item
+++ b/projects/packages/sync/changelog/update-sync-remove-woocommerce_update_order_item
@@ -1,0 +1,4 @@
+Significance: minor
+Type: removed
+
+Jetpack Sync: Stop syncing 'woocommerce_update_order_item' WooCommerce action

--- a/projects/packages/sync/src/modules/class-woocommerce.php
+++ b/projects/packages/sync/src/modules/class-woocommerce.php
@@ -129,7 +129,6 @@ class WooCommerce extends Module {
 		add_filter( 'jetpack_sync_comment_meta_whitelist', array( $this, 'add_woocommerce_comment_meta_whitelist' ), 10 );
 
 		add_filter( 'jetpack_sync_before_enqueue_woocommerce_new_order_item', array( $this, 'filter_order_item' ) );
-		add_filter( 'jetpack_sync_before_enqueue_woocommerce_update_order_item', array( $this, 'filter_order_item' ) );
 		add_filter( 'jetpack_sync_whitelisted_comment_types', array( $this, 'add_review_comment_types' ) );
 
 		// Blacklist Action Scheduler comment types.
@@ -170,7 +169,6 @@ class WooCommerce extends Module {
 
 		// Order items.
 		add_action( 'woocommerce_new_order_item', $callable, 10, 4 );
-		add_action( 'woocommerce_update_order_item', $callable, 10, 4 );
 		add_action( 'woocommerce_delete_order_item', $callable, 10, 1 );
 		add_action( 'woocommerce_remove_order_item_ids', $callable, 10, 1 );
 		$this->init_listeners_for_meta_type( 'order_item', $callable );

--- a/projects/plugins/jetpack/changelog/update-sync-remove-woocommerce_update_order_item
+++ b/projects/plugins/jetpack/changelog/update-sync-remove-woocommerce_update_order_item
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Unit tests: Update Sync related unit test for WooCommerce
+
+

--- a/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_WooCommerce_Test.php
+++ b/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_WooCommerce_Test.php
@@ -102,25 +102,6 @@ class Jetpack_Sync_WooCommerce_Test extends Jetpack_Sync_TestBase {
 		$this->assertEquals( $order->get_id(), $create_order_item_event->args[2] );
 	}
 
-	public function test_updated_order_items_are_synced() {
-		$order       = $this->createOrderWithItem();
-		$order_items = $order->get_items();
-		$order_item  = reset( $order_items ); // first item
-
-		// trigger an update
-		$order_item->set_name( 'A new name' );
-		$order_item->save();
-
-		$this->sender->do_sync();
-
-		$update_order_item_event = $this->server_event_storage->get_most_recent_event( 'woocommerce_update_order_item' );
-
-		$this->assertTrue( (bool) $update_order_item_event );
-		$this->assertEquals( $order_item->get_id(), $update_order_item_event->args[0] );
-		$this->assertHasOrderItemProperties( $update_order_item_event->args[1], $order_item );
-		$this->assertEquals( $order->get_id(), $update_order_item_event->args[2] );
-	}
-
 	public function test_updated_order_item_meta_is_synced() {
 		$order       = $this->createOrderWithItem();
 		$order_items = $order->get_items();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Closes SYNC-179

Due to the volume of `woocommerce_update_order_item` actions we receive via Sync combined with the fact that we don't actually use this action on WPCOM we decided to remove this WooCommerce action from Sync.
The only potential update we'd care about to ensure Cache site consistency would be updating the order item name which we can still periodically do via checksums.
Real time updates for order item names are not currently needed by any Sync consumer plugin.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* `Automattic\Jetpack\Sync\Modules\WooCommerce`: Remove `woocommerce_update_order_item` from Sync, aka stop sending `woocommerce_update_order_item` actions to WordPress.com

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
SYNC-179

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Pre-requisites: A JP connected Woo store with WooCommerce and Jetpack plugins active.

* Create/update an order and try adding, removing order items or updating order item meta via wp-admin and confirm we no longer receive any `woocommerce_update_order_item` actions on WordPress.com
* Change the name of an order item and trigger a Fix Checksum on WPCOM: Confirm the change is reflected in the Cache site DB

