### PR TITLE
Social: Update connections list in sidebar

### DIFF
--- a/projects/js-packages/publicize-components/changelog/update-social-connections-list-in-sidebar
+++ b/projects/js-packages/publicize-components/changelog/update-social-connections-list-in-sidebar
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update connections list in the editor sidebar to flip the toggle position.

--- a/projects/js-packages/publicize-components/src/components/connection-icon/styles.module.scss
+++ b/projects/js-packages/publicize-components/src/components/connection-icon/styles.module.scss
@@ -1,5 +1,10 @@
 .wrapper {
 	display: grid;
+	width: 28px;
+	height: 28px;
+	justify-content: start;
+	align-items: center;
+	overflow: hidden;
 
 	&.disabled {
 		opacity: 0.4;
@@ -15,12 +20,11 @@
 		}
 
 		.social-icon {
-			width: 15px;
-			height: 15px;
+			width: 14px;
+			height: 14px;
 			grid-area: 1 / 1 / 2 / 2;
 			margin-top: 14px;
 			margin-inline-start: 14px;
-			margin-inline-end: 5px;
 			border-radius: 2px;
 			background-color: #fff;
 		}

--- a/projects/js-packages/publicize-components/src/components/connections-toggle-list/index.tsx
+++ b/projects/js-packages/publicize-components/src/components/connections-toggle-list/index.tsx
@@ -1,4 +1,4 @@
-import { FormToggle, MenuGroup, MenuItem } from '@wordpress/components';
+import { Flex, FormToggle, MenuGroup, MenuItem } from '@wordpress/components';
 import { _x, sprintf } from '@wordpress/i18n';
 import clsx from 'clsx';
 import { useCallback } from 'react';
@@ -62,9 +62,24 @@ export function ConnectionsToggleList( {
 				return (
 					<MenuItem
 						key={ connection.connection_id }
-						role="menuitemcheckbox"
+						role="switch"
 						disabled={ isDisabled }
 						icon={
+							<ConnectionIcon
+								serviceName={ connection.service_name }
+								label={ connection.display_name }
+								profilePicture={ connection.profile_picture }
+								disabled={ isDisabled }
+							/>
+						}
+						iconPosition="right"
+						isSelected={ isSelected }
+						onClick={ onClickConnection( connection ) }
+						aria-label={ ariaLabel }
+						aria-checked={ isSelected }
+						className={ clsx( styles.item, getItemClassName?.( connection ) ) }
+					>
+						<Flex justify="start">
 							<FormToggle
 								tabIndex={ ! onClickToggle ? -1 : 0 }
 								checked={ isSelected }
@@ -72,23 +87,10 @@ export function ConnectionsToggleList( {
 								onClick={ onClickToggle ? onClickToggleConnection( connection ) : undefined }
 								aria-label={ ariaLabel }
 							/>
-						}
-						isSelected={ isSelected }
-						onClick={ onClickConnection( connection ) }
-						aria-label={ ariaLabel }
-						className={ clsx( styles.item, getItemClassName?.( connection ) ) }
-					>
-						<div className={ styles[ 'item-content' ] }>
-							<ConnectionIcon
-								serviceName={ connection.service_name }
-								label={ connection.display_name }
-								profilePicture={ connection.profile_picture }
-								disabled={ isDisabled }
-							/>
 							<div className={ styles[ 'display-name' ] } title={ connection.display_name }>
 								{ connection.display_name }
 							</div>
-						</div>
+						</Flex>
 					</MenuItem>
 				);
 			} ) }

--- a/projects/js-packages/publicize-components/src/components/connections-toggle-list/styles.module.scss
+++ b/projects/js-packages/publicize-components/src/components/connections-toggle-list/styles.module.scss
@@ -11,12 +11,6 @@
 		}
 	}
 
-	.item-content {
-		display: flex;
-		align-items: center;
-		gap: 4px;
-	}
-
 	.display-name {
 		max-width: 8rem;
 		overflow: hidden;

--- a/projects/js-packages/publicize-components/src/components/panel/auto-share-toggle.tsx
+++ b/projects/js-packages/publicize-components/src/components/panel/auto-share-toggle.tsx
@@ -1,4 +1,4 @@
-import { CheckboxControl, PanelRow } from '@wordpress/components';
+import { PanelRow, ToggleControl } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
 import { __ } from '@wordpress/i18n';
@@ -20,7 +20,7 @@ export function AutoShareToggle() {
 
 	return (
 		<PanelRow>
-			<CheckboxControl
+			<ToggleControl
 				label={ __( 'Auto-share post', 'jetpack-publicize-components' ) }
 				onChange={ togglePublicizeFeature }
 				checked={ isPublicizeEnabled }


### PR DESCRIPTION
Completes SOCIAL-256

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Update the connections list in the editor sidebar to flip the toggle position as per the design - DDjUX6bySvzZ302nXgNPfo-fi-5197_54728
* Update the connection icon to match the design

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to Jetpack sidebar in the editor
* Confirm that you see the toggle/switch for the "Auto-share post" instead of a checkbox
* Confirm that the connections list has now toggle before the connection name and the icon towards the end

| BEFORE | AFTER |
|--------|--------|
| <img width="276" height="438" alt="image" src="https://github.com/user-attachments/assets/a3ce9af1-8198-4ff5-81ce-9410b3030392" /> | <img width="266" height="435" alt="image" src="https://github.com/user-attachments/assets/ee3ab1e6-da9a-4235-ae65-a4f9d389ad7f" /> |