### PR TITLE
Jetpack Sync: Deprecate WooCommerce_Products module

### DIFF
--- a/projects/packages/sync/changelog/update-deprecate-sync-products-module
+++ b/projects/packages/sync/changelog/update-deprecate-sync-products-module
@@ -1,0 +1,4 @@
+Significance: minor
+Type: deprecated
+
+Jetpack Sync: Deprecate WooCommerce_Products module

--- a/projects/packages/sync/src/modules/class-woocommerce-products.php
+++ b/projects/packages/sync/src/modules/class-woocommerce-products.php
@@ -24,6 +24,7 @@ class WooCommerce_Products extends Module {
 	 * Constructor.
 	 */
 	public function __construct() {
+		_deprecated_class( 'WooCommerce_Products', '$$next-version$$', 'Automattic\Jetpack\Sync\Modules\Posts' );
 		// Preprocess action to be sent by Jetpack sync for wp_delete_post.
 		add_action( 'delete_post', array( $this, 'action_wp_delete_post' ), 10, 1 );
 		add_action( 'trashed_post', array( $this, 'action_wp_trash_post' ), 10, 1 );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Closes SYNC-180

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* `Automattic\Jetpack\Sync\Modules\WooCommerce_Products`: Add a deprecated class warning so that we can safely remove this module in a next Sync release. This module was initially introduced for WC Analytics purposes to sync WooCommerce products, however it's rather redundant since those are synced via the `Posts` module instead.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

```
wp shell
$woo_products = new Automattic\Jetpack\Sync\Modules\WooCommerce_Products()
```

Confirm you see the corresponding deprecation warning.

