### PR TITLE
Try: Extend form block with innerChild ref

### DIFF
--- a/projects/packages/forms/changelog/add-jetpack-forms-custom-post-type
+++ b/projects/packages/forms/changelog/add-jetpack-forms-custom-post-type
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add jetpack-forms custom post type

--- a/projects/packages/forms/src/blocks/contact-form/attributes.ts
+++ b/projects/packages/forms/src/blocks/contact-form/attributes.ts
@@ -4,6 +4,10 @@
 import { __ } from '@wordpress/i18n';
 
 export default {
+	ref: {
+		type: 'number',
+		default: null,
+	},
 	subject: {
 		type: 'string',
 		default: window.jpFormsBlocks?.defaults?.subject || '',

--- a/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
+++ b/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
@@ -728,7 +728,58 @@ class Contact_Form_Block {
 
 		self::load_view_scripts();
 
+		if ( isset( $atts['ref'] ) && is_numeric( $atts['ref'] ) ) {
+			return Contact_Form::parse( $atts, self::render_reusable_form( intval( $atts['ref'] ) ) );
+		}
+
 		return Contact_Form::parse( $atts, do_blocks( $content ) );
+	}
+
+	/**
+	 * Render a reusable form by reference ID.
+	 *
+	 * @param int $ref_id The jetpack-form post ID.
+	 * @return string Rendered form HTML.
+	 */
+	private static function render_reusable_form( $ref_id ) {
+		// Circular reference prevention.
+		static $seen_refs = array();
+
+		if ( isset( $seen_refs[ $ref_id ] ) ) {
+			return sprintf(
+				'<div class="wp-block-jetpack-contact-form">%s</div>',
+				esc_html__( 'Circular reference detected in form.', 'jetpack-forms' )
+			);
+		}
+
+		// Load the jetpack-form post.
+		$reusable_form = get_post( $ref_id );
+
+		// Validate post.
+		if ( ! $reusable_form || 'jetpack-form' !== $reusable_form->post_type ) {
+			return '';
+		}
+
+		// Only render published forms.
+		if ( ! in_array( $reusable_form->post_status, array( 'publish', 'private', 'draft' ), true ) ) {
+			return '';
+		}
+
+		// Mark as seen for circular reference prevention.
+		$seen_refs[ $ref_id ] = true;
+
+		// Parse and render blocks from post_content.
+		$blocks = parse_blocks( $reusable_form->post_content );
+		$output = '';
+
+		foreach ( $blocks as $block ) {
+			$output .= render_block( $block );
+		}
+
+		// Clean up.
+		unset( $seen_refs[ $ref_id ] );
+
+		return $output;
 	}
 
 	/**

--- a/projects/packages/forms/src/blocks/contact-form/components/form-title-modal.scss
+++ b/projects/packages/forms/src/blocks/contact-form/components/form-title-modal.scss
@@ -1,0 +1,14 @@
+.jetpack-form-title-modal {
+
+	.components-modal__content {
+		padding-bottom: 0;
+	}
+
+	.jetpack-form-title-modal__actions {
+		display: flex;
+		justify-content: flex-end;
+		gap: 12px;
+		margin-top: 24px;
+		padding: 16px 0;
+	}
+}

--- a/projects/packages/forms/src/blocks/contact-form/components/form-title-modal.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/components/form-title-modal.tsx
@@ -1,0 +1,67 @@
+/**
+ * External dependencies
+ */
+import { Modal, TextControl, Button } from '@wordpress/components';
+import { useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import './form-title-modal.scss';
+
+type FormTitleModalProps = {
+	onClose: () => void;
+	onSubmit: ( title: string ) => void;
+	defaultTitle: string;
+	isCreating: boolean;
+};
+
+const FormTitleModal = ( { onClose, onSubmit, defaultTitle, isCreating }: FormTitleModalProps ) => {
+	const [ title, setTitle ] = useState( defaultTitle );
+
+	const handleSubmit = () => {
+		if ( title.trim() ) {
+			onSubmit( title.trim() );
+		}
+	};
+
+	const handleKeyDown = ( event: React.KeyboardEvent ) => {
+		if ( event.key === 'Enter' && title.trim() && ! isCreating ) {
+			handleSubmit();
+		}
+	};
+
+	return (
+		<Modal
+			title={ __( 'Create Reusable Form', 'jetpack-forms' ) }
+			onRequestClose={ onClose }
+			size="medium"
+			className="jetpack-form-title-modal"
+		>
+			<TextControl
+				label={ __( 'Title', 'jetpack-forms' ) }
+				value={ title }
+				onChange={ setTitle }
+				placeholder={ __( 'Enter form title…', 'jetpack-forms' ) }
+				help={ __( 'This title will help you identify the form.', 'jetpack-forms' ) }
+				onKeyDown={ handleKeyDown }
+			/>
+			<div className="jetpack-form-title-modal__actions">
+				<Button variant="tertiary" onClick={ onClose } disabled={ isCreating }>
+					{ __( 'Cancel', 'jetpack-forms' ) }
+				</Button>
+				<Button
+					variant="primary"
+					onClick={ handleSubmit }
+					disabled={ ! title.trim() || isCreating }
+					isBusy={ isCreating }
+				>
+					{ isCreating ? __( 'Creating…', 'jetpack-forms' ) : __( 'Create Form', 'jetpack-forms' ) }
+				</Button>
+			</div>
+		</Modal>
+	);
+};
+
+export default FormTitleModal;

--- a/projects/packages/forms/src/blocks/contact-form/edit.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/edit.tsx
@@ -3,6 +3,7 @@
  */
 import { ThemeProvider } from '@automattic/jetpack-components';
 import { useModuleStatus, hasFeatureFlag } from '@automattic/jetpack-shared-extension-utils';
+import apiFetch from '@wordpress/api-fetch';
 import {
 	URLInput,
 	InspectorAdvancedControls,
@@ -14,20 +15,28 @@ import {
 	BlockControls,
 	BlockContextProvider,
 } from '@wordpress/block-editor';
-import { createBlock } from '@wordpress/blocks';
+import { createBlock, serialize } from '@wordpress/blocks';
 import {
+	Button,
 	ExternalLink,
 	PanelBody,
 	TextareaControl,
 	TextControl,
 	ToggleControl,
 	RadioControl,
+	ToolbarGroup,
+	ToolbarButton,
 } from '@wordpress/components';
 import { useInstanceId } from '@wordpress/compose';
-import { store as coreStore } from '@wordpress/core-data';
+import {
+	store as coreStore,
+	useEntityRecord,
+	useEntityBlockEditor,
+	EntityProvider,
+} from '@wordpress/core-data';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
-import { useRef, useEffect, useCallback, lazy, Suspense } from '@wordpress/element';
+import { useRef, useEffect, useCallback, useState, lazy, Suspense } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
 /*
@@ -47,6 +56,7 @@ import useFormSteps from '../shared/hooks/use-form-steps.js';
 import { SyncedAttributeProvider } from '../shared/hooks/use-synced-attributes.js';
 import { CORE_BLOCKS } from '../shared/util/constants.js';
 import { childBlocks } from './child-blocks.js';
+import FormTitleModal from './components/form-title-modal.tsx';
 import { ContactFormPlaceholder } from './components/jetpack-contact-form-placeholder.js';
 import ContactFormSkeletonLoader from './components/jetpack-contact-form-skeleton-loader.js';
 import NotificationsSettings from './components/notifications-settings.js';
@@ -56,6 +66,42 @@ import VariationPicker from './variation-picker.js';
 import './util/form-styles.js';
 
 const IntegrationControls = lazy( () => import( './components/jetpack-integration-controls.js' ) );
+
+/**
+ * Inner component for reusable forms that uses useEntityBlockEditor.
+ * This must be rendered inside EntityProvider to work correctly.
+ *
+ * @param {object} root0                   - Component props.
+ * @param {object} root0.innerBlocksConfig - Configuration for inner blocks.
+ * @param {object} root0.innerRef          - Ref for the inner blocks container.
+ * @param {string} root0.formClassnames    - CSS classes for the form.
+ * @return {Element} The inner blocks component.
+ */
+function ReusableFormInnerBlocks( { innerBlocksConfig, innerRef, formClassnames } ) {
+	const [ entityBlocks, onEntityInput, onEntityChange ] = useEntityBlockEditor(
+		'postType',
+		'jetpack-form'
+	);
+
+	// Apply entity block editor values
+	const configWithEntity = {
+		...innerBlocksConfig,
+		value: entityBlocks,
+		onInput: onEntityInput,
+		onChange: onEntityChange,
+	};
+
+	const innerBlocksProps = useInnerBlocksProps(
+		{
+			ref: innerRef,
+			className: formClassnames,
+			style: window.jetpackForms.generateStyleVariables( innerRef.current ),
+		},
+		configWithEntity
+	);
+
+	return <div { ...innerBlocksProps } />;
+}
 
 // Transforms
 const FormTransitionState = {
@@ -143,6 +189,7 @@ type JetpackContactFormAttributes = {
 	disableSummary: boolean;
 	notificationRecipients: string[];
 	webhooks: Webhook[];
+	ref: number | null;
 };
 
 type JetpackContactFormEditProps = {
@@ -178,11 +225,27 @@ function JetpackContactFormEdit( {
 		disableSummary,
 		notificationRecipients,
 		webhooks,
+		ref,
 	} = attributes;
 	const isIntegrationsEnabled = useConfigValue( 'isIntegrationsEnabled' );
 	const showWebhooks = useConfigValue( 'isWebhooksEnabled' ) && hasFeatureFlag( 'form-webhooks' );
 	const showBlockIntegrations = useConfigValue( 'showBlockIntegrations' );
 	const instanceId = useInstanceId( JetpackContactFormEdit );
+
+	// Modal state for creating reusable forms
+	const [ titleModalState, setTitleModalState ] = useState< {
+		isOpen: boolean;
+		variation: null | {
+			title?: string;
+			innerBlocks?: Array< unknown >;
+			attributes?: Record< string, unknown >;
+		};
+		isCreating: boolean;
+	} >( {
+		isOpen: false,
+		variation: null,
+		isCreating: false,
+	} );
 
 	// Backward compatibility for the deprecated customThankyou attribute.
 	// Older forms will have a customThankyou attribute set, but not a confirmationType attribute
@@ -285,28 +348,43 @@ function JetpackContactFormEdit( {
 		isLastStep && 'is-last-step',
 		variationName === 'multistep' && isSingleStep && 'is-previewing-step'
 	);
+
+	// Configure inner blocks
+	const innerBlocksConfig = {
+		allowedBlocks: variationName === 'multistep' ? ALLOWED_MULTI_STEP_BLOCKS : ALLOWED_FORM_BLOCKS,
+		prioritizedInserterBlocks: PRIORITIZED_INSERTER_BLOCKS,
+		templateInsertUpdatesSelection: false,
+	};
+
+	// For inline forms (not reusable), use regular inner blocks
 	const innerBlocksProps = useInnerBlocksProps(
 		{
 			ref: innerRef,
 			className: formClassnames,
 			style: window.jetpackForms.generateStyleVariables( innerRef.current ),
 		},
-		{
-			allowedBlocks:
-				variationName === 'multistep' ? ALLOWED_MULTI_STEP_BLOCKS : ALLOWED_FORM_BLOCKS,
-			prioritizedInserterBlocks: PRIORITIZED_INSERTER_BLOCKS,
-			templateInsertUpdatesSelection: false,
-		}
+		innerBlocksConfig
 	);
 	const { isLoadingModules, isChangingStatus, isModuleActive, changeStatus } =
 		useModuleStatus( 'contact-form' );
 
-	const { replaceInnerBlocks, __unstableMarkNextChangeAsNotPersistent, updateBlockAttributes } =
-		useDispatch( blockEditorStore );
+	const {
+		replaceInnerBlocks,
+		__unstableMarkNextChangeAsNotPersistent,
+		updateBlockAttributes,
+		selectBlock,
+	} = useDispatch( blockEditorStore );
 
 	const currentInnerBlocks = useSelect(
 		select => select( blockEditorStore ).getBlocks( clientId ),
 		[ clientId ]
+	);
+
+	// Load form post if ref is set
+	const { record: formPost, isResolving: isLoadingPost } = useEntityRecord(
+		'postType',
+		'jetpack-form',
+		ref || undefined
 	);
 
 	// Track previous block count to detect insertions
@@ -395,6 +473,121 @@ function JetpackContactFormEdit( {
 				b.name === 'jetpack/form-step-divider' ||
 				( b.innerBlocks?.length && hasMultistep( b.innerBlocks ) )
 		);
+	}, [] );
+
+	// Helper to create blocks from inner blocks template (same as variation-picker.js)
+	const createBlocksFromInnerBlocksTemplate = useCallback( innerBlocksTemplate => {
+		const blocks = innerBlocksTemplate.map( ( [ blockName, attr, innerBlocks = [] ] ) =>
+			createBlock( blockName, attr, createBlocksFromInnerBlocksTemplate( innerBlocks ) )
+		);
+		return blocks;
+	}, [] );
+
+	// Helper to create draft form post
+	const createDraftFormPost = useCallback(
+		async ( title, innerBlocks ) => {
+			// Create blocks from template
+			const blocks = createBlocksFromInnerBlocksTemplate( innerBlocks );
+			const content = serialize( blocks );
+
+			const response = await apiFetch( {
+				path: '/wp/v2/jetpack-forms',
+				method: 'POST',
+				data: {
+					title,
+					content,
+					status: 'draft',
+				},
+			} );
+
+			return response;
+		},
+		[ createBlocksFromInnerBlocksTemplate ]
+	);
+
+	// Handle variation selection
+	const handleVariationSelect = useCallback(
+		variation => {
+			const TEMPLATE_VARIATIONS = [
+				'contact-form',
+				'rsvp-form',
+				'registration-form',
+				'appointment-form',
+				'feedback-form',
+				'lead-capture-form',
+			];
+
+			if ( hasFeatureFlag( 'multistep-form' ) ) {
+				TEMPLATE_VARIATIONS.push( 'multistep-form' );
+			}
+
+			if ( TEMPLATE_VARIATIONS.includes( variation.name ) ) {
+				// Show title modal for template variations
+				setTitleModalState( {
+					isOpen: true,
+					variation,
+					isCreating: false,
+				} );
+			} else {
+				// Regular inline mode - existing behavior
+				if ( variation.attributes ) {
+					setAttributes( variation.attributes );
+				}
+				if ( variation.innerBlocks ) {
+					replaceInnerBlocks(
+						clientId,
+						createBlocksFromInnerBlocksTemplate( variation.innerBlocks )
+					);
+				}
+				selectBlock( clientId );
+			}
+		},
+		[
+			replaceInnerBlocks,
+			clientId,
+			setAttributes,
+			selectBlock,
+			createBlocksFromInnerBlocksTemplate,
+		]
+	);
+
+	// Handle modal title submit
+	const handleTitleSubmit = useCallback(
+		async title => {
+			const { variation } = titleModalState;
+
+			setTitleModalState( prev => ( { ...prev, isCreating: true } ) );
+
+			try {
+				const post = await createDraftFormPost( title, variation.innerBlocks );
+
+				setAttributes( {
+					ref: post.id,
+					...variation.attributes,
+				} );
+
+				selectBlock( clientId );
+
+				setTitleModalState( {
+					isOpen: false,
+					variation: null,
+					isCreating: false,
+				} );
+			} catch {
+				// Error creating form - reset modal state
+				setTitleModalState( prev => ( { ...prev, isCreating: false } ) );
+			}
+		},
+		[ titleModalState, createDraftFormPost, setAttributes, selectBlock, clientId ]
+	);
+
+	// Handle modal cancel
+	const handleTitleCancel = useCallback( () => {
+		setTitleModalState( {
+			isOpen: false,
+			variation: null,
+			isCreating: false,
+		} );
 	}, [] );
 
 	// Detect a conversion to a multistep form and structure inner blocks only once.
@@ -807,14 +1000,40 @@ function JetpackContactFormEdit( {
 				/>
 			);
 		}
-	} else if ( ! hasAnyInnerBlocks ) {
+	} else if ( ! hasAnyInnerBlocks && ! ref ) {
 		elt = (
-			<VariationPicker
-				blockName={ name }
-				setAttributes={ setAttributes }
-				clientId={ clientId }
-				classNames={ formClassnames }
-			/>
+			<>
+				<VariationPicker
+					blockName={ name }
+					setAttributes={ setAttributes }
+					clientId={ clientId }
+					classNames={ formClassnames }
+					onVariationSelect={ handleVariationSelect }
+				/>
+				{ titleModalState.isOpen && (
+					<FormTitleModal
+						onClose={ handleTitleCancel }
+						onSubmit={ handleTitleSubmit }
+						defaultTitle={ titleModalState.variation?.title || '' }
+						isCreating={ titleModalState.isCreating }
+					/>
+				) }
+			</>
+		);
+	} else if ( ref && isLoadingPost ) {
+		// Loading state for reusable forms
+		elt = <ContactFormSkeletonLoader />;
+	} else if ( ref && ! isLoadingPost && ! formPost ) {
+		// Error state - post not found (only show if done loading)
+		elt = (
+			<div className="jetpack-form-error">
+				<p>
+					{ __( 'Form not found. The referenced form may have been deleted.', 'jetpack-forms' ) }
+				</p>
+				<Button variant="secondary" onClick={ () => setAttributes( { ref: null } ) }>
+					{ __( 'Convert to inline form', 'jetpack-forms' ) }
+				</Button>
+			</div>
 		);
 	} else if ( onlySubmitBlock ) {
 		elt = (
@@ -822,7 +1041,15 @@ function JetpackContactFormEdit( {
 				<div className="is-form-empty">
 					<InnerBlocks.ButtonBlockAppender />
 				</div>
-				<div { ...innerBlocksProps } />
+				{ ref ? (
+					<ReusableFormInnerBlocks
+						innerBlocksConfig={ innerBlocksConfig }
+						innerRef={ innerRef }
+						formClassnames={ formClassnames }
+					/>
+				) : (
+					<div { ...innerBlocksProps } />
+				) }
 			</>
 		);
 	} else {
@@ -830,6 +1057,17 @@ function JetpackContactFormEdit( {
 			<>
 				<BlockControls>
 					{ variationName === 'multistep' && <StepControls formClientId={ clientId } /> }
+					{ ref && (
+						<ToolbarGroup>
+							<ToolbarButton
+								icon="edit"
+								label={ __( 'Edit Form', 'jetpack-forms' ) }
+								onClick={ () => {
+									window.open( `/wp-admin/post.php?post=${ ref }&action=edit`, '_blank' );
+								} }
+							/>
+						</ToolbarGroup>
+					) }
 				</BlockControls>
 				<InspectorControls>
 					<PanelBody
@@ -972,19 +1210,38 @@ function JetpackContactFormEdit( {
 						'jetpack/form-current-step': currentStepInfo,
 					} }
 				>
-					<div { ...innerBlocksProps } />
+					{ ref ? (
+						<ReusableFormInnerBlocks
+							innerBlocksConfig={ innerBlocksConfig }
+							innerRef={ innerRef }
+							formClassnames={ formClassnames }
+						/>
+					) : (
+						<div { ...innerBlocksProps } />
+					) }
 				</BlockContextProvider>
 			</>
 		);
 	}
 
-	return (
+	const content = (
 		<SyncedAttributeProvider>
 			<ThemeProvider targetDom={ wrapperRef.current }>
 				<div { ...blockProps }>{ elt }</div>
 			</ThemeProvider>
 		</SyncedAttributeProvider>
 	);
+
+	// Wrap in EntityProvider if this is a reusable form
+	if ( ref ) {
+		return (
+			<EntityProvider kind="postType" type="jetpack-form" id={ ref }>
+				{ content }
+			</EntityProvider>
+		);
+	}
+
+	return content;
 }
 
 export default JetpackContactFormEdit;

--- a/projects/packages/forms/src/blocks/contact-form/edit.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/edit.tsx
@@ -485,7 +485,7 @@ function JetpackContactFormEdit( {
 
 	// Helper to create draft form post
 	const createDraftFormPost = useCallback(
-		async ( title, innerBlocks ) => {
+		async ( title, innerBlocks, blockAttributes = {} ) => {
 			// Create blocks from template
 			const blocks = createBlocksFromInnerBlocksTemplate( innerBlocks );
 			const content = serialize( blocks );
@@ -497,6 +497,9 @@ function JetpackContactFormEdit( {
 					title,
 					content,
 					status: 'draft',
+					meta: {
+						'block-attributes': JSON.stringify( blockAttributes ),
+					},
 				},
 			} );
 
@@ -559,7 +562,11 @@ function JetpackContactFormEdit( {
 			setTitleModalState( prev => ( { ...prev, isCreating: true } ) );
 
 			try {
-				const post = await createDraftFormPost( title, variation.innerBlocks );
+				const post = await createDraftFormPost(
+					title,
+					variation.innerBlocks,
+					variation.attributes
+				);
 
 				setAttributes( {
 					ref: post.id,

--- a/projects/packages/forms/src/blocks/contact-form/index.js
+++ b/projects/packages/forms/src/blocks/contact-form/index.js
@@ -63,8 +63,16 @@ export const settings = {
 		'jetpack/form-class-name': 'className',
 	},
 	edit,
-	save: () => {
+	save: ( { attributes } ) => {
 		const blockProps = useBlockProps.save();
+
+		// If this is a reusable form, don't save inner blocks
+		// They're stored in the jetpack-form post instead
+		if ( attributes.ref ) {
+			return <div { ...blockProps } />;
+		}
+
+		// For inline forms, save inner blocks as usual
 		return (
 			<div { ...blockProps }>
 				<InnerBlocks.Content />

--- a/projects/packages/forms/src/blocks/contact-form/variation-picker.js
+++ b/projects/packages/forms/src/blocks/contact-form/variation-picker.js
@@ -19,7 +19,13 @@ const createBlocksFromInnerBlocksTemplate = innerBlocksTemplate => {
 	return blocks;
 };
 
-export default function VariationPicker( { blockName, setAttributes, clientId, classNames } ) {
+export default function VariationPicker( {
+	blockName,
+	setAttributes,
+	clientId,
+	classNames,
+	onVariationSelect,
+} ) {
 	const registry = useRegistry();
 	const [ isPatternsModalOpen, setIsPatternsModalOpen ] = useState( false );
 	const { replaceInnerBlocks, selectBlock } = useDispatch( blockEditorStore );
@@ -57,20 +63,26 @@ export default function VariationPicker( { blockName, setAttributes, clientId, c
 				) }
 				variations={ variations.filter( v => ! v.hiddenFromPicker ) }
 				onSelect={ ( nextVariation = defaultVariation ) => {
-					registry.batch( () => {
-						if ( nextVariation.attributes ) {
-							setAttributes( nextVariation.attributes );
-						}
+					if ( onVariationSelect ) {
+						// Delegate to parent component
+						onVariationSelect( nextVariation );
+					} else {
+						// Default behavior
+						registry.batch( () => {
+							if ( nextVariation.attributes ) {
+								setAttributes( nextVariation.attributes );
+							}
 
-						if ( nextVariation.innerBlocks ) {
-							replaceInnerBlocks(
-								clientId,
-								createBlocksFromInnerBlocksTemplate( nextVariation.innerBlocks )
-							);
-						}
+							if ( nextVariation.innerBlocks ) {
+								replaceInnerBlocks(
+									clientId,
+									createBlocksFromInnerBlocksTemplate( nextVariation.innerBlocks )
+								);
+							}
 
-						selectBlock( clientId );
-					} );
+							selectBlock( clientId );
+						} );
+					}
 				} }
 			/>
 			<div className="form-placeholder__footer">

--- a/projects/packages/forms/src/class-reusable-forms.php
+++ b/projects/packages/forms/src/class-reusable-forms.php
@@ -17,6 +17,9 @@ class Reusable_Forms {
 	 */
 	public static function init() {
 		self::register_post_type();
+		add_filter( 'allowed_block_types_all', array( __CLASS__, 'allowed_blocks_for_jetpack_form' ), 10, 2 );
+		add_filter( 'wp_insert_post_data', array( __CLASS__, 'unwrap_contact_form_blocks' ), 10, 2 );
+		add_action( 'enqueue_block_editor_assets', array( __CLASS__, 'enqueue_editor_assets' ) );
 	}
 
 	/**
@@ -80,5 +83,178 @@ class Reusable_Forms {
 				),
 			)
 		);
+	}
+
+	/**
+	 * Restrict allowed blocks when editing jetpack-form posts.
+	 *
+	 * Only allows field blocks and supporting blocks. The contact-form block is excluded
+	 * because visual wrapping is handled via DOM manipulation in the editor script.
+	 *
+	 * @param bool|array $allowed_block_types Array of block type slugs, or boolean to enable/disable all.
+	 * @param object     $editor_context       The current editor context.
+	 * @return bool|array Array of allowed block types for jetpack-form posts.
+	 */
+	public static function allowed_blocks_for_jetpack_form( $allowed_block_types, $editor_context ) {
+		// Only apply to jetpack-form post type.
+		if ( ! isset( $editor_context->post ) || 'jetpack-form' !== $editor_context->post->post_type ) {
+			return $allowed_block_types;
+		}
+
+		// Allow only field blocks, button, and core blocks.
+		// Visual wrapping is handled by JavaScript DOM manipulation.
+		return array(
+			// Field blocks.
+			'jetpack/field-name',
+			'jetpack/field-email',
+			'jetpack/field-url',
+			'jetpack/field-telephone',
+			'jetpack/field-textarea',
+			'jetpack/field-checkbox',
+			'jetpack/field-checkbox-multiple',
+			'jetpack/field-radio',
+			'jetpack/field-select',
+			'jetpack/field-date',
+			'jetpack/field-consent',
+			'jetpack/field-rating',
+			'jetpack/field-text',
+			'jetpack/field-number',
+			'jetpack/field-file-upload',
+
+			// Supporting blocks.
+			'jetpack/button',
+			'jetpack/label',
+			'jetpack/input',
+			'jetpack/options',
+			'jetpack/option',
+			'jetpack/phone-input',
+
+			// Multistep blocks.
+			'jetpack/form-step',
+			'jetpack/form-step-container',
+			'jetpack/form-step-divider',
+			'jetpack/form-step-navigation',
+			'jetpack/form-progress-indicator',
+
+			// Core blocks for rich content.
+			'core/paragraph',
+			'core/heading',
+			'core/list',
+			'core/list-item',
+			'core/separator',
+			'core/spacer',
+			'core/columns',
+			'core/column',
+			'core/group',
+			'core/image',
+			'core/html',
+		);
+	}
+
+	/**
+	 * Unwrap contact-form blocks from jetpack-form post content.
+	 *
+	 * Run this on save to clean up any wrapped content. This ensures that jetpack-form
+	 * posts always store raw field blocks without any contact-form wrapper.
+	 *
+	 * @param array $data    An array of slashed, sanitized, and processed post data.
+	 * @param array $postarr An array of sanitized (and slashed) but otherwise unmodified post data.
+	 * @return array Modified post data.
+	 */
+	public static function unwrap_contact_form_blocks( $data, $postarr ) {
+		// Only process jetpack-form posts.
+		if ( 'jetpack-form' !== $data['post_type'] ) {
+			return $data;
+		}
+
+		// Skip autosaves and revisions to prevent infinite loop with editor wrapping.
+		if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
+			return $data;
+		}
+
+		// Skip revisions (autosaves are stored as revisions).
+		if ( ! empty( $postarr['ID'] ) && wp_is_post_revision( $postarr['ID'] ) ) {
+			return $data;
+		}
+
+		// Skip if content is empty.
+		if ( empty( $data['post_content'] ) ) {
+			return $data;
+		}
+
+		// Parse blocks from content.
+		$blocks = parse_blocks( $data['post_content'] );
+
+		// Unwrap any contact-form blocks.
+		$unwrapped_blocks = array();
+		$has_changes      = false;
+
+		foreach ( $blocks as $block ) {
+			if ( 'jetpack/contact-form' === $block['blockName'] ) {
+				// Extract inner blocks from contact-form wrapper.
+				if ( ! empty( $block['innerBlocks'] ) ) {
+					$unwrapped_blocks = array_merge( $unwrapped_blocks, $block['innerBlocks'] );
+					$has_changes      = true;
+				}
+			} else {
+				$unwrapped_blocks[] = $block;
+			}
+		}
+
+		// Re-serialize if changes were made.
+		if ( $has_changes ) {
+			$data['post_content'] = serialize_blocks( $unwrapped_blocks );
+		}
+
+		return $data;
+	}
+
+	/**
+	 * Enqueue editor assets for jetpack-form post type.
+	 *
+	 * Loads JavaScript that wraps field blocks in a contact-form block when editing
+	 * jetpack-form posts directly (for proper styling and context).
+	 */
+	public static function enqueue_editor_assets() {
+		$screen = get_current_screen();
+
+		// Only enqueue for jetpack-form post type editor.
+		if ( ! $screen || 'jetpack-form' !== $screen->post_type ) {
+			return;
+		}
+
+		$script_path = plugin_dir_path( __FILE__ ) . '../dist/blocks/jetpack-form-editor.js';
+		$script_url  = plugin_dir_url( __FILE__ ) . '../dist/blocks/jetpack-form-editor.js';
+		$style_path  = plugin_dir_path( __FILE__ ) . '../dist/blocks/jetpack-form-editor.css';
+		$style_url   = plugin_dir_url( __FILE__ ) . '../dist/blocks/jetpack-form-editor.css';
+
+		// Only enqueue if the file exists.
+		if ( ! file_exists( $script_path ) ) {
+			return;
+		}
+
+		$asset_file = plugin_dir_path( __FILE__ ) . '../dist/blocks/jetpack-form-editor.asset.php';
+		$asset_data = file_exists( $asset_file ) ? require $asset_file : array(
+			'dependencies' => array(),
+			'version'      => filemtime( $script_path ),
+		);
+
+		wp_enqueue_script(
+			'jetpack-form-editor',
+			$script_url,
+			$asset_data['dependencies'],
+			$asset_data['version'],
+			true
+		);
+
+		// Enqueue the editor styles for proper layout.
+		if ( file_exists( $style_path ) ) {
+			wp_enqueue_style(
+				'jetpack-form-editor',
+				$style_url,
+				array(),
+				$asset_data['version']
+			);
+		}
 	}
 }

--- a/projects/packages/forms/src/class-reusable-forms.php
+++ b/projects/packages/forms/src/class-reusable-forms.php
@@ -56,7 +56,7 @@ class Reusable_Forms {
 				'show_in_rest'          => true,
 				'rest_base'             => 'jetpack-forms',
 				'rest_controller_class' => 'Automattic\Jetpack\Forms\ContactForm\REST_Jetpack_Form_Controller',
-				'capability_type'       => 'jetpack-form',
+				'capability_type'       => 'post',
 				'capabilities'          => array(
 					// You need to be able to edit posts, in order to read blocks in their raw form.
 					'read'                   => 'edit_posts',
@@ -70,6 +70,7 @@ class Reusable_Forms {
 					'edit_others_posts'      => 'edit_others_posts',
 					'delete_others_posts'    => 'delete_others_posts',
 				),
+				'map_meta_cap'          => true,
 				'supports'              => array(
 					'title',
 					'excerpt',

--- a/projects/packages/forms/src/class-reusable-forms.php
+++ b/projects/packages/forms/src/class-reusable-forms.php
@@ -26,16 +26,57 @@ class Reusable_Forms {
 		register_post_type(
 			'jetpack-form',
 			array(
-				'labels'       => array(
-					'name'          => __( 'Jetpack Forms', 'jetpack-forms' ),
-					'singular_name' => __( 'Jetpack Form', 'jetpack-forms' ),
+				'labels'                => array(
+					'name'                     => __( 'Forms', 'jetpack-forms' ),
+					'singular_name'            => __( 'Form', 'jetpack-forms' ),
+					'add_new'                  => __( 'Add Form', 'jetpack-forms' ),
+					'add_new_item'             => __( 'Add Form', 'jetpack-forms' ),
+					'new_item'                 => __( 'New Form', 'jetpack-forms' ),
+					'edit_item'                => __( 'Edit Block Form', 'jetpack-forms' ),
+					'view_item'                => __( 'View Form', 'jetpack-forms' ),
+					'view_items'               => __( 'View Forms', 'jetpack-forms' ),
+					'all_items'                => __( 'All Forms', 'jetpack-forms' ),
+					'search_items'             => __( 'Search Forms', 'jetpack-forms' ),
+					'not_found'                => __( 'No forms found.', 'jetpack-forms' ),
+					'not_found_in_trash'       => __( 'No forms found in Trash.', 'jetpack-forms' ),
+					'filter_items_list'        => __( 'Filter forms list', 'jetpack-forms' ),
+					'items_list_navigation'    => __( 'Forms list navigation', 'jetpack-forms' ),
+					'items_list'               => __( 'Forms list', 'jetpack-forms' ),
+					'item_published'           => __( 'Form published.', 'jetpack-forms' ),
+					'item_published_privately' => __( 'Form published privately.', 'jetpack-forms' ),
+					'item_reverted_to_draft'   => __( 'Form reverted to draft.', 'jetpack-forms' ),
+					'item_scheduled'           => __( 'Form scheduled.', 'jetpack-forms' ),
+					'item_updated'             => __( 'Form updated.', 'jetpack-forms' ),
 				),
-				'public'       => false,
-				'show_ui'      => false,
-				'show_in_menu' => false,
-				'rewrite'      => false,
-				'query_var'    => false,
-				'show_in_rest' => false,
+				'public'                => false,
+				'show_ui'               => true, // not sure we need this.
+				'show_in_menu'          => false,
+				'rewrite'               => false,
+				'query_var'             => false,
+				'show_in_rest'          => true,
+				'rest_base'             => 'jetpack-forms',
+				'rest_controller_class' => 'Automattic\Jetpack\Forms\ContactForm\REST_Jetpack_Form_Controller',
+				'capability_type'       => 'jetpack-form',
+				'capabilities'          => array(
+					// You need to be able to edit posts, in order to read blocks in their raw form.
+					'read'                   => 'edit_posts',
+					// You need to be able to publish posts, in order to create blocks.
+					'create_posts'           => 'publish_posts',
+					'edit_posts'             => 'edit_posts',
+					'edit_published_posts'   => 'edit_published_posts',
+					'delete_published_posts' => 'delete_published_posts',
+					// Enables trashing draft posts as well.
+					'delete_posts'           => 'delete_posts',
+					'edit_others_posts'      => 'edit_others_posts',
+					'delete_others_posts'    => 'delete_others_posts',
+				),
+				'supports'              => array(
+					'title',
+					'excerpt',
+					'editor',
+					'revisions',
+					'custom-fields',
+				),
 			)
 		);
 	}

--- a/projects/packages/forms/src/class-reusable-forms.php
+++ b/projects/packages/forms/src/class-reusable-forms.php
@@ -17,6 +17,7 @@ class Reusable_Forms {
 	 */
 	public static function init() {
 		self::register_post_type();
+		self::register_post_meta();
 		add_filter( 'allowed_block_types_all', array( __CLASS__, 'allowed_blocks_for_jetpack_form' ), 10, 2 );
 		add_filter( 'wp_insert_post_data', array( __CLASS__, 'unwrap_contact_form_blocks' ), 10, 2 );
 		add_action( 'enqueue_block_editor_assets', array( __CLASS__, 'enqueue_editor_assets' ) );
@@ -81,6 +82,27 @@ class Reusable_Forms {
 					'revisions',
 					'custom-fields',
 				),
+			)
+		);
+	}
+
+	/**
+	 * Register post meta field for storing block attributes.
+	 */
+	private static function register_post_meta() {
+		register_post_meta(
+			'jetpack-form',
+			'block-attributes',
+			array(
+				'type'              => 'string',
+				'description'       => 'JSON-encoded attributes from the jetpack/contact-form block',
+				'single'            => true,
+				'show_in_rest'      => true,
+				'default'           => '',
+				'sanitize_callback' => 'sanitize_text_field',
+				'auth_callback'     => function () {
+					return current_user_can( 'edit_posts' );
+				},
 			)
 		);
 	}

--- a/projects/packages/forms/src/class-reusable-forms.php
+++ b/projects/packages/forms/src/class-reusable-forms.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Reusable Forms class.
+ *
+ * @package automattic/jetpack-forms
+ */
+
+namespace Automattic\Jetpack\Forms;
+
+/**
+ * Handles Reusable Forms functionality.
+ */
+class Reusable_Forms {
+
+	/**
+	 * Initialize the Reusable Forms feature.
+	 */
+	public static function init() {
+		self::register_post_type();
+	}
+
+	/**
+	 * Register the jetpack-form custom post type.
+	 */
+	private static function register_post_type() {
+		register_post_type(
+			'jetpack-form',
+			array(
+				'labels'       => array(
+					'name'          => __( 'Jetpack Forms', 'jetpack-forms' ),
+					'singular_name' => __( 'Jetpack Form', 'jetpack-forms' ),
+				),
+				'public'       => false,
+				'show_ui'      => false,
+				'show_in_menu' => false,
+				'rewrite'      => false,
+				'query_var'    => false,
+				'show_in_rest' => false,
+			)
+		);
+	}
+}

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -11,6 +11,7 @@ use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Constants;
 use Automattic\Jetpack\Extensions\Contact_Form\Contact_Form_Block;
 use Automattic\Jetpack\Forms\Jetpack_Forms;
+use Automattic\Jetpack\Forms\Reusable_Forms;
 use Automattic\Jetpack\Forms\Service\Form_Webhooks;
 use Automattic\Jetpack\Forms\Service\Hostinger_Reach_Integration;
 use Automattic\Jetpack\Forms\Service\MailPoet_Integration;
@@ -265,6 +266,13 @@ class Contact_Form_Plugin {
 				'map_meta_cap'          => true,
 			)
 		);
+
+		// Initialize Reusable Forms feature if enabled
+		$feature_flags = apply_filters( 'jetpack_block_editor_feature_flags', array() );
+		if ( ! empty( $feature_flags['reusable-forms'] ) ) {
+			Reusable_Forms::init();
+		}
+
 		add_filter( 'wp_untrash_post_status', array( $this, 'untrash_feedback_status_handler' ), 10, 3 );
 
 		// Add to REST API post type allowed list.

--- a/projects/packages/forms/src/contact-form/class-rest-jetpack-form-controller.php
+++ b/projects/packages/forms/src/contact-form/class-rest-jetpack-form-controller.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * Contact_Form_Endpoint class.
+ *
+ * @package automattic/jetpack-forms
+ */
+
+namespace Automattic\Jetpack\Forms\ContactForm;
+
+/**
+ * REST_Jetpack_Form_Controller class.
+ *
+ * Responsible for handling REST API requests for Jetpack forms custom post type.
+ */
+class REST_Jetpack_Form_Controller extends WP_REST_Posts_Controller {
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		parent::__construct( 'jetpack-form' );
+	}
+}

--- a/projects/packages/forms/src/contact-form/class-rest-jetpack-form-controller.php
+++ b/projects/packages/forms/src/contact-form/class-rest-jetpack-form-controller.php
@@ -12,11 +12,66 @@ namespace Automattic\Jetpack\Forms\ContactForm;
  *
  * Responsible for handling REST API requests for Jetpack forms custom post type.
  */
-class REST_Jetpack_Form_Controller extends WP_REST_Posts_Controller {
+class REST_Jetpack_Form_Controller extends \WP_REST_Posts_Controller {
 	/**
 	 * Constructor.
 	 */
 	public function __construct() {
 		parent::__construct( 'jetpack-form' );
+	}
+
+	/**
+	 * Checks if a given request has access to get items.
+	 *
+	 * @param \WP_REST_Request $request Full details about the request.
+	 * @return true|\WP_Error True if the request has read access, WP_Error object otherwise.
+	 */
+	public function get_items_permissions_check( $request ) {
+		$post_type = get_post_type_object( $this->post_type );
+
+		if ( ! current_user_can( $post_type->cap->edit_posts ) ) {
+			return new \WP_Error(
+				'rest_cannot_read',
+				__( 'Sorry, you are not allowed to view forms.', 'jetpack-forms' ),
+				array( 'status' => rest_authorization_required_code() )
+			);
+		}
+
+		return parent::get_items_permissions_check( $request );
+	}
+
+	/**
+	 * Checks if a given request has access to create items.
+	 *
+	 * @param \WP_REST_Request $request Full details about the request.
+	 * @return true|\WP_Error True if the request has access to create items, WP_Error object otherwise.
+	 */
+	public function create_item_permissions_check( $request ) {
+		$post_type = get_post_type_object( $this->post_type );
+
+		if ( ! current_user_can( $post_type->cap->create_posts ) ) {
+			return new \WP_Error(
+				'rest_cannot_create',
+				__( 'Sorry, you are not allowed to create forms.', 'jetpack-forms' ),
+				array( 'status' => rest_authorization_required_code() )
+			);
+		}
+
+		return parent::create_item_permissions_check( $request );
+	}
+
+	/**
+	 * Checks if a jetpack-form can be read.
+	 *
+	 * @param WP_Post $post Post object that backs the block.
+	 * @return bool Whether the pattern can be read.
+	 */
+	public function check_read_permission( $post ) {
+		// By default the read_post capability is mapped to edit_posts.
+		if ( ! current_user_can( 'read_post', $post->ID ) ) {
+			return false;
+		}
+
+		return parent::check_read_permission( $post );
 	}
 }

--- a/projects/packages/forms/src/modules/jetpack-form-editor/editor.scss
+++ b/projects/packages/forms/src/modules/jetpack-form-editor/editor.scss
@@ -1,0 +1,84 @@
+/**
+ * Jetpack Form Editor Styles
+ *
+ * When editing jetpack-form posts, the visual wrapper needs the same CSS styling
+ * as the contact-form block when used in pages/posts.
+ */
+
+// Apply form layout styles to the jetpack-form editor
+body.post-type-jetpack-form .editor-styles-wrapper,
+.editor-styles-wrapper {
+	// Target our DOM wrapper structure
+	.jetpack-form-visual-wrapper {
+
+		.jetpack-contact-form {
+			// The block list inside needs flex layout
+			.block-editor-block-list__layout {
+				display: flex;
+				flex-wrap: wrap;
+				justify-content: flex-start;
+				flex-direction: row;
+				gap: var(--wp--style--block-gap, 1.5rem);
+			}
+
+			// Style the blocks inside
+			.wp-block {
+				flex: 1 1 100%;
+				margin-top: 0;
+				margin-bottom: 0;
+				max-width: 100%;
+
+				// Button styling
+				&.wp-block-jetpack-button {
+					flex: 0 0 auto;
+					min-height: var(--jetpack--contact-form--input-height, auto);
+					align-self: flex-end;
+					line-height: 1;
+
+					.wp-block-button__link {
+						min-height: var(--jetpack--contact-form--input-height, auto);
+					}
+				}
+
+				// Field width classes
+				&.jetpack-field__width-25 {
+					flex: 1 1 calc(25% - var(--wp--style--block-gap, 1.5rem));
+					max-width: 25%;
+				}
+
+				&.jetpack-field__width-33 {
+					flex: 1 1 calc(33.33% - var(--wp--style--block-gap, 1.5rem));
+					max-width: 33.33%;
+				}
+
+				&.jetpack-field__width-50 {
+					flex: 1 1 calc(50% - var(--wp--style--block-gap, 1.5rem));
+					max-width: 50%;
+				}
+
+				&.jetpack-field__width-75 {
+					flex: 1 1 calc(75% - var(--wp--style--block-gap, 1.5rem));
+					max-width: 75%;
+				}
+
+				&.jetpack-field__width-auto {
+					flex: 1 1 0;
+				}
+			}
+
+			// Radio and checkbox options need tighter gap
+			.wp-block-jetpack-field-option-radio,
+			.wp-block-jetpack-field-option-checkbox {
+				gap: 0;
+
+				> .wp-block {
+					flex: initial;
+				}
+			}
+
+			.wp-block-jetpack-field-option-checkbox {
+				align-items: center;
+			}
+		}
+	}
+}

--- a/projects/packages/forms/src/modules/jetpack-form-editor/index.js
+++ b/projects/packages/forms/src/modules/jetpack-form-editor/index.js
@@ -1,0 +1,98 @@
+/**
+ * Jetpack Form Editor - Adds visual wrapper for proper form display.
+ *
+ * This script adds a DOM wrapper around the block list to provide the
+ * contact-form styling without actually inserting a contact-form block.
+ * This keeps the block structure clean while providing proper visual context.
+ */
+
+import { select, subscribe } from '@wordpress/data';
+import './editor.scss';
+
+let hasWrapped = false;
+
+/**
+ * Add a DOM wrapper around the block list for form styling.
+ */
+const addVisualWrapper = () => {
+	// Only run once.
+	if ( hasWrapped ) {
+		return;
+	}
+
+	const editor = select( 'core/editor' );
+
+	// Check if editor is available and post type is jetpack-form.
+	if ( ! editor ) {
+		return;
+	}
+
+	const postType = editor.getCurrentPostType();
+
+	// If post type is not loaded yet, wait for next iteration
+	if ( ! postType ) {
+		return;
+	}
+
+	// If this is not a jetpack-form post, stop trying
+	if ( postType !== 'jetpack-form' ) {
+		hasWrapped = true; // Don't keep trying on non-form posts
+		return;
+	}
+
+	// Try to find the editor canvas - check both regular and iframe editor
+	let editorCanvas = document.querySelector( '.editor-styles-wrapper' );
+
+	// If not found, try looking in iframe (block editor might be in iframe)
+	if ( ! editorCanvas ) {
+		const iframe = document.querySelector( 'iframe[name="editor-canvas"]' );
+		if ( iframe && iframe.contentDocument ) {
+			editorCanvas = iframe.contentDocument.querySelector( '.editor-styles-wrapper' );
+		}
+	}
+
+	if ( ! editorCanvas ) {
+		return;
+	}
+
+	// Find the block list container
+	const blockList = editorCanvas.querySelector( '.block-editor-block-list__layout' );
+
+	if ( ! blockList || blockList.children.length === 0 ) {
+		return;
+	}
+
+	// Check if we already added a wrapper
+	if ( blockList.classList.contains( 'jetpack-form-editor-wrapped' ) ) {
+		hasWrapped = true;
+		return;
+	}
+
+	// Add a wrapper div with the contact-form classes
+	const wrapper = document.createElement( 'div' );
+	wrapper.className = 'jetpack-form-visual-wrapper wp-block-jetpack-contact-form';
+
+	// Create inner wrapper with the form styling class
+	const innerWrapper = document.createElement( 'div' );
+	innerWrapper.className = 'jetpack-contact-form';
+
+	// Mark the block list as wrapped
+	blockList.classList.add( 'jetpack-form-editor-wrapped' );
+
+	// Insert the wrapper structure
+	blockList.parentNode.insertBefore( wrapper, blockList );
+	wrapper.appendChild( innerWrapper );
+	innerWrapper.appendChild( blockList );
+
+	hasWrapped = true;
+};
+
+// Subscribe to editor changes to add wrapper when ready.
+const unsubscribe = subscribe( () => {
+	addVisualWrapper();
+
+	// Unsubscribe once we've wrapped.
+	if ( hasWrapped ) {
+		unsubscribe();
+	}
+} );

--- a/projects/packages/forms/tests/php/contact-form/Reusable_Forms_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Reusable_Forms_Test.php
@@ -190,6 +190,10 @@ class Reusable_Forms_Test extends TestCase {
 		$title = isset( $data['title']['raw'] ) ? $data['title']['raw'] : $data['title']['rendered'];
 		$this->assertEquals( 'Test Reusable Form', $title, 'Title should match' );
 		$this->assertEquals( 'publish', $data['status'], 'Status should be publish' );
+
+		// Verify block attributes are stored in meta
+		$this->assertArrayHasKey( 'meta', $data, 'Response should have meta field' );
+		$this->assertArrayHasKey( 'block-attributes', $data['meta'], 'Meta should contain block-attributes' );
 	}
 
 	/**
@@ -219,6 +223,10 @@ class Reusable_Forms_Test extends TestCase {
 		$title = isset( $data['title']['raw'] ) ? $data['title']['raw'] : $data['title']['rendered'];
 		$this->assertEquals( 'Single Test Form', $title, 'Title should match' );
 		$this->assertEquals( $post_id, $data['id'], 'ID should match' );
+
+		// Verify meta field is included in response
+		$this->assertArrayHasKey( 'meta', $data, 'Response should have meta field' );
+		$this->assertArrayHasKey( 'block-attributes', $data['meta'], 'Meta should contain block-attributes' );
 	}
 
 	/**

--- a/projects/packages/forms/tests/php/contact-form/Reusable_Forms_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Reusable_Forms_Test.php
@@ -1,0 +1,317 @@
+<?php
+/**
+ * Unit Tests for Reusable_Forms.
+ *
+ * @package automattic/jetpack-forms
+ */
+
+namespace Automattic\Jetpack\Forms\ContactForm;
+
+use Automattic\Jetpack\Forms\Reusable_Forms;
+use PHPUnit\Framework\TestCase;
+use WorDBless\Options as WorDBless_Options;
+use WorDBless\Users as WorDBless_Users;
+use WP_REST_Request;
+use WP_REST_Server;
+
+/**
+ * Unit tests for the Reusable Forms feature.
+ *
+ * To run this test, you can use the following command: (from the projects/packages/forms directory)
+ *
+ * composer test-php tests/php/contact-form/Reusable_Forms_Test.php
+ */
+class Reusable_Forms_Test extends TestCase {
+
+	/**
+	 * REST Server object.
+	 *
+	 * @var WP_REST_Server
+	 */
+	private $server;
+
+	/**
+	 * The current user id.
+	 *
+	 * @var int
+	 */
+	private static $user_id;
+
+	/**
+	 * Setting up the test.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		global $wp_rest_server;
+
+		$wp_rest_server = new WP_REST_Server();
+		$this->server   = $wp_rest_server;
+
+		do_action( 'rest_api_init' );
+
+		self::$user_id = wp_insert_user(
+			array(
+				'user_login' => 'test_admin',
+				'user_pass'  => '123',
+				'role'       => 'administrator',
+			)
+		);
+		wp_set_current_user( self::$user_id );
+	}
+
+	/**
+	 * Returning the environment into its initial state.
+	 */
+	public function tearDown(): void {
+		parent::tearDown();
+		WorDBless_Options::init()->clear_options();
+		WorDBless_Users::init()->clear_all_users();
+
+		unset( $_SERVER['REQUEST_METHOD'] );
+		$_GET = array();
+
+		// Unregister the post type if it was registered
+		unregister_post_type( 'jetpack-form' );
+	}
+
+	/**
+	 * Test that the post type is registered when init is called.
+	 */
+	public function test_init_registers_post_type() {
+		Reusable_Forms::init();
+
+		$this->assertTrue( post_type_exists( 'jetpack-form' ), 'jetpack-form post type should be registered' );
+	}
+
+	/**
+	 * Test that the post type has the correct configuration.
+	 */
+	public function test_post_type_configuration() {
+		Reusable_Forms::init();
+
+		$post_type_object = get_post_type_object( 'jetpack-form' );
+
+		$this->assertNotNull( $post_type_object, 'Post type object should exist' );
+		$this->assertEquals( 'jetpack-form', $post_type_object->name );
+		$this->assertFalse( $post_type_object->public, 'Post type should not be public' );
+		$this->assertTrue( $post_type_object->show_ui, 'Post type should show UI' );
+		$this->assertFalse( $post_type_object->show_in_menu, 'Post type should not show in menu' );
+		$this->assertTrue( $post_type_object->show_in_rest, 'Post type should be available in REST' );
+		$this->assertEquals( 'jetpack-forms', $post_type_object->rest_base, 'REST base should be jetpack-forms' );
+	}
+
+	/**
+	 * Test that the post type supports the correct features.
+	 */
+	public function test_post_type_supports() {
+		Reusable_Forms::init();
+
+		$this->assertTrue( post_type_supports( 'jetpack-form', 'title' ), 'Should support title' );
+		$this->assertTrue( post_type_supports( 'jetpack-form', 'excerpt' ), 'Should support excerpt' );
+		$this->assertTrue( post_type_supports( 'jetpack-form', 'editor' ), 'Should support editor' );
+		$this->assertTrue( post_type_supports( 'jetpack-form', 'revisions' ), 'Should support revisions' );
+		$this->assertTrue( post_type_supports( 'jetpack-form', 'custom-fields' ), 'Should support custom-fields' );
+	}
+
+	/**
+	 * Test that the REST endpoints are registered.
+	 */
+	public function test_rest_endpoints_are_registered() {
+		Reusable_Forms::init();
+
+		// Re-initialize REST server to pick up new routes
+		do_action( 'rest_api_init' );
+
+		$routes = $this->server->get_routes();
+
+		$this->assertArrayHasKey( '/wp/v2/jetpack-forms', $routes, 'Main endpoint should be registered' );
+		$this->assertArrayHasKey( '/wp/v2/jetpack-forms/(?P<id>[\d]+)', $routes, 'Single item endpoint should be registered' );
+	}
+
+	/**
+	 * Test that GET request to jetpack-forms endpoint works.
+	 */
+	public function test_get_jetpack_forms_returns_200() {
+		Reusable_Forms::init();
+		do_action( 'rest_api_init' );
+
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/jetpack-forms' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 200, $response->get_status(), 'GET request should return 200' );
+		$this->assertIsArray( $response->get_data(), 'Response should be an array' );
+	}
+
+	/**
+	 * Test that users without edit_posts capability cannot access jetpack-forms endpoint.
+	 */
+	public function test_get_jetpack_forms_unauthorized_returns_401() {
+		Reusable_Forms::init();
+		do_action( 'rest_api_init' );
+
+		// Create a subscriber user (no edit_posts capability)
+		$subscriber_id = wp_insert_user(
+			array(
+				'user_login' => 'test_subscriber',
+				'user_pass'  => '123',
+				'role'       => 'subscriber',
+			)
+		);
+		wp_set_current_user( $subscriber_id );
+
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/jetpack-forms' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertContains( $response->get_status(), array( 401, 403 ), 'Unauthorized request should return 401 or 403' );
+	}
+
+	/**
+	 * Test creating a jetpack-form via REST API.
+	 */
+	public function test_create_jetpack_form_via_rest() {
+		Reusable_Forms::init();
+		do_action( 'rest_api_init' );
+
+		// Ensure user has proper capabilities
+		$user = wp_get_current_user();
+		$user->add_cap( 'edit_posts' );
+		$user->add_cap( 'publish_posts' );
+
+		$request = new WP_REST_Request( 'POST', '/wp/v2/jetpack-forms' );
+		$request->set_param( 'title', 'Test Reusable Form' );
+		$request->set_param( 'status', 'publish' );
+		$request->set_param( 'content', '<!-- wp:jetpack/contact-form --><div class="wp-block-jetpack-contact-form">Test Form</div><!-- /wp:jetpack/contact-form -->' );
+
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 201, $response->get_status(), 'POST request should return 201' );
+
+		$data  = $response->get_data();
+		$title = isset( $data['title']['raw'] ) ? $data['title']['raw'] : $data['title']['rendered'];
+		$this->assertEquals( 'Test Reusable Form', $title, 'Title should match' );
+		$this->assertEquals( 'publish', $data['status'], 'Status should be publish' );
+	}
+
+	/**
+	 * Test retrieving a specific jetpack-form via REST API.
+	 */
+	public function test_get_single_jetpack_form_via_rest() {
+		Reusable_Forms::init();
+		do_action( 'rest_api_init' );
+
+		// Create a form first
+		$post_id = wp_insert_post(
+			array(
+				'post_type'    => 'jetpack-form',
+				'post_title'   => 'Single Test Form',
+				'post_content' => 'Form content',
+				'post_status'  => 'publish',
+			)
+		);
+
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/jetpack-forms/' . $post_id );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 200, $response->get_status(), 'GET single item should return 200' );
+
+		$data = $response->get_data();
+		// Title might be in different formats depending on context
+		$title = isset( $data['title']['raw'] ) ? $data['title']['raw'] : $data['title']['rendered'];
+		$this->assertEquals( 'Single Test Form', $title, 'Title should match' );
+		$this->assertEquals( $post_id, $data['id'], 'ID should match' );
+	}
+
+	/**
+	 * Test updating a jetpack-form via REST API.
+	 */
+	public function test_update_jetpack_form_via_rest() {
+		Reusable_Forms::init();
+		do_action( 'rest_api_init' );
+
+		// Ensure user has proper capabilities
+		$user = wp_get_current_user();
+		$user->add_cap( 'edit_posts' );
+		$user->add_cap( 'edit_published_posts' );
+
+		// Create a form first
+		$post_id = wp_insert_post(
+			array(
+				'post_type'    => 'jetpack-form',
+				'post_title'   => 'Original Title',
+				'post_content' => 'Original content',
+				'post_status'  => 'publish',
+			)
+		);
+
+		$request = new WP_REST_Request( 'PUT', '/wp/v2/jetpack-forms/' . $post_id );
+		$request->set_param( 'title', 'Updated Title' );
+
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 200, $response->get_status(), 'PUT request should return 200' );
+
+		$data  = $response->get_data();
+		$title = isset( $data['title']['raw'] ) ? $data['title']['raw'] : $data['title']['rendered'];
+		$this->assertEquals( 'Updated Title', $title, 'Title should be updated' );
+	}
+
+	/**
+	 * Test deleting a jetpack-form via REST API.
+	 */
+	public function test_delete_jetpack_form_via_rest() {
+		Reusable_Forms::init();
+		do_action( 'rest_api_init' );
+
+		// Ensure user has proper capabilities
+		$user = wp_get_current_user();
+		$user->add_cap( 'delete_posts' );
+		$user->add_cap( 'delete_published_posts' );
+
+		// Create a form first
+		$post_id = wp_insert_post(
+			array(
+				'post_type'    => 'jetpack-form',
+				'post_title'   => 'Form to Delete',
+				'post_content' => 'Form content',
+				'post_status'  => 'publish',
+			)
+		);
+
+		$request  = new WP_REST_Request( 'DELETE', '/wp/v2/jetpack-forms/' . $post_id );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 200, $response->get_status(), 'DELETE request should return 200' );
+
+		// Verify the post is trashed
+		$post = get_post( $post_id );
+		$this->assertEquals( 'trash', $post->post_status, 'Post should be in trash' );
+	}
+
+	/**
+	 * Test that the REST controller class is correctly assigned.
+	 */
+	public function test_rest_controller_class() {
+		Reusable_Forms::init();
+
+		$post_type_object = get_post_type_object( 'jetpack-form' );
+
+		$this->assertEquals(
+			'Automattic\Jetpack\Forms\ContactForm\REST_Jetpack_Form_Controller',
+			$post_type_object->rest_controller_class,
+			'REST controller class should be correctly set'
+		);
+	}
+
+	/**
+	 * Test that the post type has correct capability mappings.
+	 */
+	public function test_post_type_capabilities() {
+		Reusable_Forms::init();
+
+		$post_type_object = get_post_type_object( 'jetpack-form' );
+
+		$this->assertEquals( 'edit_posts', $post_type_object->cap->read, 'Read capability should be edit_posts' );
+		$this->assertEquals( 'publish_posts', $post_type_object->cap->create_posts, 'Create capability should be publish_posts' );
+		$this->assertEquals( 'edit_posts', $post_type_object->cap->edit_posts, 'Edit posts capability should be edit_posts' );
+	}
+}

--- a/projects/packages/forms/tools/webpack.config.blocks.js
+++ b/projects/packages/forms/tools/webpack.config.blocks.js
@@ -20,6 +20,7 @@ const sharedWebpackConfig = {
 	entry: {
 		editor: './src/blocks/contact-form/editor.ts',
 		view: './src/blocks/contact-form/view.ts',
+		'jetpack-form-editor': './src/modules/jetpack-form-editor/index.js',
 		'form-progress-indicator/style': './src/blocks/form-progress-indicator/style.scss',
 		'form-step-navigation/style': './src/blocks/form-step-navigation/style.scss',
 		'field-rating/style': './src/blocks/field-rating/style.scss',

--- a/projects/packages/forms/tools/webpack.config.modules.js
+++ b/projects/packages/forms/tools/webpack.config.modules.js
@@ -26,6 +26,11 @@ if ( ! fs.existsSync( moduleSrcDir ) ) {
 
 	// Create entry points
 	const entry = moduleFiles.reduce( ( acc, filepath ) => {
+		// Skip jetpack-form-editor - it's built by the blocks webpack config
+		if ( filepath.includes( 'jetpack-form-editor' ) ) {
+			return acc;
+		}
+
 		// Maintain the directory structure relative to src/modules
 		const relativePath = path.relative( moduleSrcDir, filepath );
 		const outputPath = path.join( path.dirname( relativePath ), path.parse( filepath ).name );


### PR DESCRIPTION
### !!! Do not merge

https://github.com/user-attachments/assets/d0bc9aa5-999b-4b9f-bbbe-721ad69125de

This PR explores the extends the form block with a new ref attribute.

## Proposed changes:
* Extends the form block and stores the ref id of a block when it is created via the variation picker. 
* Extends the Jetpack-form editor with scripts so that we are able to edit the inner blocks. 


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
On a new page or post. 
Add form.
Use the variation picker select a form. 

See the form editor 
