### PR TITLE
Forms: Add filter for programmatic webhook configuration

### DIFF
--- a/projects/packages/forms/changelog/add-forms-add-webhook-filter
+++ b/projects/packages/forms/changelog/add-forms-add-webhook-filter
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Add jetpack_forms_extra_webhooks filter and include feedback ID in jetpack_forms_before_webhook_request filter

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -1593,6 +1593,15 @@ class Contact_Form_Plugin {
 				);
 			}
 
+			// filter to add webhooks via code
+			$extra_webhooks = apply_filters( 'jetpack_forms_extra_webhooks', array(), $form );
+			if ( ! empty( $extra_webhooks ) ) {
+				$form->attributes['webhooks'] = array_merge(
+					$form->attributes['webhooks'] ?? array(),
+					$extra_webhooks
+				);
+			}
+
 			if ( Jetpack_Forms::is_webhooks_enabled() && ! empty( $form->attributes['webhooks'] ) ) {
 				Form_Webhooks::init();
 			}

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -1593,7 +1593,44 @@ class Contact_Form_Plugin {
 				);
 			}
 
-			// filter to add webhooks via code
+			/**
+			 * Filters the list of extra webhooks to be called when a form is submitted.
+			 *
+			 * This filter allows developers to programmatically add webhook configurations that will
+			 * receive form submission data. The webhooks added through this filter are merged
+			 * with any webhooks already configured in the form's attributes.
+			 *
+			 * Each webhook configuration array supports the following keys:
+			 * - `webhook_id` (string, required): Unique identifier for the webhook.
+			 * - `url` (string, required): The webhook URL to POST data to.
+			 * - `method` (string, optional): HTTP method. Default 'POST'.
+			 * - `verified` (bool, optional): Whether the webhook is verified. Default false.
+			 * - `format` (string, optional): Data format ('json'). Default 'json'.
+			 * - `enabled` (bool, optional): Whether the webhook is enabled. Default false.
+			 *
+			 * Example usage:
+			 * ```
+			 * add_filter( 'jetpack_forms_extra_webhooks', function( $webhooks, $form ) {
+			 *     if ( $form->get_attribute( 'id' ) === '123' ) {
+			 *         $webhooks[] = array(
+			 *            'webhook_id' => 'test-webhook-1',
+			 *            'url'        => '[your webhook URL]',
+			 *            'method'     => 'POST',
+			 *            'verified'   => false,
+			 *            'format'     => 'json',
+			 *            'enabled'    => true,
+			 *         );
+			 *     }
+			 *     return $webhooks;
+			 * }, 10, 2 );
+			 * ```
+			 *
+			 * @since $$next-version$$
+			 *
+			 * @param array        $extra_webhooks Array of webhook configuration arrays. Default empty array.
+			 * @param Contact_Form $form           The form instance being processed.
+			 * @return array                       The modified array of webhook configurations.
+			 */
 			$extra_webhooks = apply_filters( 'jetpack_forms_extra_webhooks', array(), $form );
 			if ( ! empty( $extra_webhooks ) ) {
 				$form->attributes['webhooks'] = array_merge(

--- a/projects/packages/forms/src/service/class-form-webhooks.php
+++ b/projects/packages/forms/src/service/class-form-webhooks.php
@@ -116,7 +116,7 @@ class Form_Webhooks {
 
 		// Iterate through each webhook and send the request
 		foreach ( $webhooks as $webhook ) {
-			$response = $this->send_webhook( $form_data, $webhook );
+			$response = $this->send_webhook( $form_data, $webhook, $post_id );
 			$this->log_response_to_post_meta( $post_id, $response );
 		}
 	}
@@ -211,10 +211,11 @@ class Form_Webhooks {
 	 *
 	 * @param array $data The data key/value pairs to send.
 	 * @param array $webhook Webhook configuration.
+	 * @param int   $feedback_id The unique identifier for the feedback post.
 	 *
 	 * @return array|WP_Error The result value from wp_remote_request
 	 */
-	private function send_webhook( $data, $webhook ) {
+	private function send_webhook( $data, $webhook, $feedback_id ) {
 		global $wp_version;
 
 		/**
@@ -227,10 +228,11 @@ class Form_Webhooks {
 		 *
 		 * @param array  $form_data  The form data to be sent (field IDs as keys, values as values).
 		 * @param string $webhook_id The unique identifier for this webhook.
+		 * @param int    $feedback_id The unique identifier for the feedback post.
 		 *
 		 * @return array The form data to be sent (field IDs as keys, values as values).
 		 */
-		$data = apply_filters( 'jetpack_forms_before_webhook_request', $data, $webhook['webhook_id'] );
+		$data = apply_filters( 'jetpack_forms_before_webhook_request', $data, $webhook['webhook_id'], $feedback_id );
 
 		$user_agent = "WordPress/{$wp_version} | Jetpack/" . constant( 'JETPACK__VERSION' ) . '; ' . get_bloginfo( 'url' );
 		$url        = $webhook['url'];


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/FORMS-434/allow-collecting-webhooks-from-filter

## Proposed changes:
* Add `jetpack_forms_extra_webhooks` filter to allow programmatically adding webhooks via code before webhook processing
* Enhance `jetpack_forms_before_webhook_request` filter to include feedback ID as a third parameter, enabling better tracking and conditional webhook processing
* Pass feedback post ID through the webhook sending pipeline to provide context for filter implementations

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

## Does this pull request change what data or activity we track or use?
No, this PR only adds filter hooks for extensibility. No data tracking changes.

## Testing instructions:

### Testing the `jetpack_forms_extra_webhooks` filter:

Add the following code to your theme's `functions.php`:
```php
add_filter( 'jetpack_forms_extra_webhooks', function( $webhooks, $form ) {
    // Add a test webhook programmatically
    $webhooks[] = array(
        'url' => 'https://webhook.site/your-unique-url',
        'webhook_id' => 'test-webhook-1',
        'enabled' => true,
    );
    return $webhooks;
}, 10, 2 );
```
Create a form, visit the frontend and submit it.

Verify that the webhook request is sent to your test webhook URL (or use the code below to just print to error log).

### Testing the enhanced `jetpack_forms_before_webhook_request` filter:

Add the following code to your theme's `functions.php`:
```php
add_filter( 'jetpack_forms_before_webhook_request', function( $data, $webhook_id, $feedback_id ) {
    // Log the feedback ID for verification
    error_log( 'Processing webhook ' . $webhook_id . ' for feedback ' . $feedback_id );
    
    // Optionally modify data based on feedback ID
    if ( $webhook_id === 'test-webhook-1' ) {
      $data['feedback_post_id'] = $feedback_id;
    }
    
    return $data;
}, 10, 3 );
```

- Check the debug log to verify the feedback ID is being passed.
- Verify that webhook payloads include the `feedback_post_id` field.