### PR TITLE
Clean up most uses of `esc_js()`

### DIFF
--- a/projects/packages/forms/changelog/fix-clean-up-uses-of-esc_js
+++ b/projects/packages/forms/changelog/fix-clean-up-uses-of-esc_js
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Replace use of confusing `esc_js` with `wp_json_encode`.

--- a/projects/packages/forms/src/contact-form/class-editor-view.php
+++ b/projects/packages/forms/src/contact-form/class-editor-view.php
@@ -258,7 +258,7 @@ class Editor_View {
 				<?php esc_html_e( 'Field Type', 'jetpack-forms' ); ?>
 				<select name="type">
 					<?php foreach ( $grunion_field_types as $type => $label ) : ?>
-					<option <# if ( '<?php echo esc_js( $type ); ?>' === data.type ) print( "selected='selected'" ) #> value="<?php echo esc_attr( $type ); ?>">
+					<option <# if ( <?php echo wp_json_encode( $type, JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP ); ?> === data.type ) print( "selected='selected'" ) #> value="<?php echo esc_attr( $type ); ?>">
 						<?php echo esc_html( $label ); ?>
 					</option>
 					<?php endforeach; ?>

--- a/projects/packages/google-analytics/changelog/fix-clean-up-uses-of-esc_js
+++ b/projects/packages/google-analytics/changelog/fix-clean-up-uses-of-esc_js
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Replace use of confusing `esc_js` with `wp_json_encode`.

--- a/projects/packages/google-analytics/src/class-universal.php
+++ b/projects/packages/google-analytics/src/class-universal.php
@@ -289,7 +289,7 @@ class Universal {
 
 		// @phan-suppress-next-line PhanUndeclaredFunction
 		\wc_enqueue_js(
-			"$( '" . esc_js( $selector ) . "' ).click( function() {
+			'$( ' . wp_json_encode( $selector, JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP ) . " ).click( function() {
 				var productDetails = {
 					'id': '" . esc_js( $product_sku_or_id ) . "',
 					'name' : '" . esc_js( $product->get_title() ) . "',
@@ -324,7 +324,7 @@ class Universal {
 
 		// @phan-suppress-next-line PhanUndeclaredFunction
 		\wc_enqueue_js(
-			"$( '" . esc_js( $selector ) . "' ).click( function() {
+			'$( ' . wp_json_encode( $selector, JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP ) . " ).click( function() {
 				var productSku = $( this ).data( 'product_sku' );
 				var productID = $( this ).data( 'product_id' );
 				var productDetails = {
@@ -448,7 +448,7 @@ class Universal {
 		global $product, $woocommerce_loop;
 		$product_sku_or_id = Utils::get_product_sku_or_id( $product );
 
-		$selector = '.products .post-' . esc_js( $product->get_id() ) . ' a';
+		$selector = '.products .post-' . $product->get_id() . ' a';
 
 		$item_details = array(
 			'id'       => $product_sku_or_id,
@@ -459,7 +459,7 @@ class Universal {
 
 		// @phan-suppress-next-line PhanUndeclaredFunction
 		\wc_enqueue_js(
-			"$( '" . esc_js( $selector ) . "' ).click( function() {
+			'$( ' . wp_json_encode( $selector, JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP ) . " ).click( function() {
 				if ( true === $( this ).hasClass( 'add_to_cart_button' ) ) {
 					return;
 				}

--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-clean-up-uses-of-esc_js
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-clean-up-uses-of-esc_js
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Replace use of confusing `esc_js` with `wp_json_encode`, or with nothing where it had no effect.

--- a/projects/packages/jetpack-mu-wpcom/src/features/jetpack-global-styles/class-global-styles.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/jetpack-global-styles/class-global-styles.php
@@ -304,7 +304,7 @@ class Global_Styles {
 		$tracks_events_data = array();
 		if ( $current_user->exists() ) {
 			$tracks_events_data['user_id']    = (int) $current_user->ID;
-			$tracks_events_data['user_login'] = esc_js( $current_user->user_login );
+			$tracks_events_data['user_login'] = $current_user->user_login;
 		}
 
 		wp_localize_script(

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-block-editor/class-jetpack-wpcom-block-editor.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-block-editor/class-jetpack-wpcom-block-editor.php
@@ -197,7 +197,7 @@ class Jetpack_WPCOM_Block_Editor {
 		<script type="application/javascript">
 			document.getElementById( 'loginform' ).addEventListener( 'submit' , function() {
 				document.getElementById( 'wp-submit' ).setAttribute( 'disabled', 'disabled' );
-				document.getElementById( 'wp-submit' ).value = '<?php echo esc_js( __( 'Logging In...', 'jetpack-mu-wpcom' ) ); ?>';
+				document.getElementById( 'wp-submit' ).value = <?php echo wp_json_encode( __( 'Logging In...', 'jetpack-mu-wpcom' ), JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP ); ?>;
 			} );
 		</script>
 		<?php

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-profile-settings/profile-settings-notices.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-profile-settings/profile-settings-notices.php
@@ -25,7 +25,7 @@ function maybe_show_wpcom_toolbar_proxy_notice() {
 					// Create a new paragraph for the notice.
 					var notice = document.createElement('p');
 					notice.className = 'description';
-					notice.textContent = '<?php echo esc_js( __( 'The Toolbar is always visible on Atomic sites while connected to the Automattic proxy.', 'jetpack-mu-wpcom' ) ); ?>'
+					notice.textContent = <?php echo wp_json_encode( __( 'The Toolbar is always visible on Atomic sites while connected to the Automattic proxy.', 'jetpack-mu-wpcom' ), JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP ); ?>;
 
 					// Insert the new div after the checkbox and label.
 					toolbarCell.appendChild(notice);

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-wpadmin-page-view/wpcom-wpadmin-page-view.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-wpadmin-page-view/wpcom-wpadmin-page-view.php
@@ -52,7 +52,7 @@ function wpcom_nosara_track_admin_page_views() {
 	<script type="text/javascript">
 		var _admin_pv_props = {
 			from_page: '<?php echo esc_js( $current_screen->id ); ?>',
-			is_block_editor: '<?php echo esc_js( $current_screen->is_block_editor ? 'true' : 'false' ); ?>',
+			is_block_editor: '<?php echo $current_screen->is_block_editor ? 'true' : 'false'; ?>',
 			source: 'wp-admin',
 			blog_id: '<?php echo esc_js( (string) $blog_id ); ?>',
 			user_type: '<?php echo esc_js( implode( ',', $user_types ) ); ?>'

--- a/projects/packages/paypal-payments/changelog/fix-clean-up-uses-of-esc_js
+++ b/projects/packages/paypal-payments/changelog/fix-clean-up-uses-of-esc_js
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Replace use of confusing `esc_js` with `wp_json_encode`, or `intval` where appropriate.

--- a/projects/packages/paypal-payments/src/legacy/class-simple-payments.php
+++ b/projects/packages/paypal-payments/src/legacy/class-simple-payments.php
@@ -177,11 +177,11 @@ class Simple_Payments {
 		wp_add_inline_script(
 			'jetpack-paypal-express-checkout',
 			sprintf(
-				"try{PaypalExpressCheckout.renderButton( '%d', '%d', '%s', '%d' );}catch(e){}",
-				esc_js( (string) $this->get_blog_id() ),
-				esc_js( $id ),
-				esc_js( $dom_id ),
-				esc_js( $is_multiple ) /* @phan-suppress-current-line PhanTypeMismatchArgument */
+				"try{PaypalExpressCheckout.renderButton( '%d', '%d', %s, '%d' );}catch(e){}",
+				intval( $this->get_blog_id() ),
+				intval( $id ),
+				wp_json_encode( $dom_id, JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP ),
+				intval( $is_multiple )
 			)
 		);
 	}

--- a/projects/packages/paypal-payments/src/paypal-payment-buttons/class-paypal-payment-buttons.php
+++ b/projects/packages/paypal-payments/src/paypal-payment-buttons/class-paypal-payment-buttons.php
@@ -144,15 +144,15 @@ class PayPal_Payment_Buttons {
 			);
 
 			// Generate the button HTML and inline script
-			$container_id = 'paypal-container-' . esc_attr( $hosted_button_id );
-			$button_html  = '<div id="' . $container_id . '"></div>';
+			$container_id = 'paypal-container-' . $hosted_button_id;
+			$button_html  = '<div id="' . esc_attr( $container_id ) . '"></div>';
 
 			$inline_script = sprintf(
 				'(window.paypal_payment_buttons || window.paypal).HostedButtons({
-					hostedButtonId: "%s",
-				}).render("#%s");',
-				esc_js( $hosted_button_id ),
-				esc_js( $container_id )
+					hostedButtonId: %s,
+				}).render(%s);',
+				wp_json_encode( $hosted_button_id, JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP ),
+				wp_json_encode( $container_id, JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP )
 			);
 
 			wp_add_inline_script( 'paypal-payment-buttons-block-head', $inline_script );

--- a/projects/packages/publicize/changelog/fix-clean-up-uses-of-esc_js
+++ b/projects/packages/publicize/changelog/fix-clean-up-uses-of-esc_js
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Replace use of confusing `esc_js` with `wp_json_encode`.

--- a/projects/packages/publicize/src/class-publicize-ui.php
+++ b/projects/packages/publicize/src/class-publicize-ui.php
@@ -196,13 +196,13 @@ class Publicize_UI {
 		);
 
 		$default_prefix = $this->publicize->default_prefix;
-		$default_prefix = preg_replace( '/%([0-9])\$s/', "' + %\\1\$s + '", esc_js( $default_prefix ) );
+		$default_prefix = preg_replace( '/%([0-9])\$s/', '" + %\\1$s + "', wp_json_encode( (string) $default_prefix, JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP ) );
 
 		$default_message = $this->publicize->default_message;
-		$default_message = preg_replace( '/%([0-9])\$s/', "' + %\\1\$s + '", esc_js( $default_message ) );
+		$default_message = preg_replace( '/%([0-9])\$s/', '" + %\\1$s + "', wp_json_encode( (string) $default_message, JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP ) );
 
 		$default_suffix = $this->publicize->default_suffix;
-		$default_suffix = preg_replace( '/%([0-9])\$s/', "' + %\\1\$s + '", esc_js( $default_suffix ) );
+		$default_suffix = preg_replace( '/%([0-9])\$s/', '" + %\\1$s + "', wp_json_encode( (string) $default_suffix, JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP ) );
 
 		$max_length = defined( 'JETPACK_PUBLICIZE_TWITTER_LENGTH' ) ? JETPACK_PUBLICIZE_TWITTER_LENGTH : 280;
 		$max_length = $max_length - 24; // t.co link, space.
@@ -238,7 +238,7 @@ jQuery( function($) {
 	postTitle.on( 'keyup', function( e ) {
 		var url = $( '#sample-permalink' ).text();
 		<?php // phpcs:ignore ?>
-		var defaultMessage = $.trim( '<?php printf( $default_prefix, 'url' ); printf( $default_message, 'e.currentTarget.value', 'url' ); printf( $default_suffix, 'url' ); ?>' )
+		var defaultMessage = $.trim( <?php printf( $default_prefix, 'url' ); ?> + <?php printf( $default_message, 'e.currentTarget.value', 'url' ); ?> + <?php printf( $default_suffix, 'url' ); ?> )
 			.replace( /<[^>]+>/g,'');
 
 		wpasTitle.attr( 'placeholder', defaultMessage );

--- a/projects/packages/videopress/changelog/fix-clean-up-uses-of-esc_js
+++ b/projects/packages/videopress/changelog/fix-clean-up-uses-of-esc_js
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Replace use of confusing `esc_js` with `wp_json_encode`.

--- a/projects/packages/videopress/src/class-initializer.php
+++ b/projects/packages/videopress/src/class-initializer.php
@@ -320,8 +320,8 @@ class Initializer {
 		$maybe_premium_script     = '';
 		if ( $is_premium_content_child ) {
 			Access_Control::instance()->set_guid_subscription( $guid, $premium_block_plan_id );
-			$escaped_guid         = esc_js( $guid );
-			$script_content       = "if ( ! window.__guidsToPlanIds ) { window.__guidsToPlanIds = {}; }; window.__guidsToPlanIds['$escaped_guid'] = $premium_block_plan_id;";
+			$escaped_guid         = wp_json_encode( $guid, JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP );
+			$script_content       = "if ( ! window.__guidsToPlanIds ) { window.__guidsToPlanIds = {}; }; window.__guidsToPlanIds[$escaped_guid] = $premium_block_plan_id;";
 			$maybe_premium_script = '<script>' . $script_content . '</script>';
 		}
 

--- a/projects/plugins/crm/changelog/fix-clean-up-uses-of-esc_js
+++ b/projects/plugins/crm/changelog/fix-clean-up-uses-of-esc_js
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Replace use of confusing `esc_js` with `wp_json_encode`.

--- a/projects/plugins/crm/includes/ZeroBSCRM.Core.License.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.Core.License.php
@@ -112,7 +112,7 @@ function jpcrm_show_admin_nag_modal( $message = '' ) {
 	if ( ! get_transient( 'jpcrm-license-modal' ) ) {
 
 		?>
-		<script type="text/javascript">var jpcrm_modal_message_licensing_nonce = '<?php echo esc_js( wp_create_nonce( 'jpcrm-set-transient-nonce' ) ); ?>';</script>
+		<script type="text/javascript">var jpcrm_modal_message_licensing_nonce = <?php echo wp_json_encode( wp_create_nonce( 'jpcrm-set-transient-nonce' ), JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP ); ?>;</script>
 		<div class="zbs_overlay" id="jpcrm-modal-message-licensing">
 			<div class='close_nag_modal'>
 				<span id="jpcrm-close-licensing-modal">x</span>

--- a/projects/plugins/debug-helper/changelog/fix-clean-up-uses-of-esc_js
+++ b/projects/plugins/debug-helper/changelog/fix-clean-up-uses-of-esc_js
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Replace use of confusing `esc_js` on an integer value with `intval`.

--- a/projects/plugins/debug-helper/modules/class-wpcom-api-request-tracker-module.php
+++ b/projects/plugins/debug-helper/modules/class-wpcom-api-request-tracker-module.php
@@ -69,7 +69,7 @@ class WPCOM_API_Request_Tracker_Module {
 		$requests = WPCOM_API_Request_Tracker::init()->get_requests();
 
 		?>
-		<script>var wpcom_api_request_tracker_count = <?php echo esc_js( array_sum( $requests ) ); ?>;</script>
+		<script>var wpcom_api_request_tracker_count = <?php echo intval( array_sum( $requests ) ); ?>;</script>
 		<div id='wpcom-api-request-tracker'>
 
 			<div id="wpcom-api-request-tracker-actions">

--- a/projects/plugins/jetpack/changelog/fix-clean-up-uses-of-esc_js
+++ b/projects/plugins/jetpack/changelog/fix-clean-up-uses-of-esc_js
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+General: Replace uses of confusing `esc_js()` function with clearer code.

--- a/projects/plugins/jetpack/extensions/blocks/calendly/calendly.php
+++ b/projects/plugins/jetpack/extensions/blocks/calendly/calendly.php
@@ -98,7 +98,7 @@ function load_assets( $attr, $content ) {
 		if ( ! $is_amp_request ) {
 			wp_add_inline_script(
 				'jetpack-calendly-external-js',
-				sprintf( "calendly_attach_link_events( '%s' )", esc_js( $block_id ) )
+				sprintf( 'calendly_attach_link_events( %s )', wp_json_encode( $block_id, JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP ) )
 			);
 		}
 	} elseif ( $is_amp_request ) { // Inline style.
@@ -106,7 +106,7 @@ function load_assets( $attr, $content ) {
 			'<div class="%1$s" id="%2$s"><a href="%3$s" role="button" target="_blank">%4$s</a></div>',
 			esc_attr( Blocks::classes( Blocks::get_block_feature( __DIR__ ), $attr ) ),
 			esc_attr( $block_id ),
-			esc_js( $url ),
+			esc_attr( $url ),
 			wp_kses_post( get_attribute( $attr, 'submitButtonText' ) )
 		);
 	} else {
@@ -262,7 +262,7 @@ function deprecated_render_button_v1( $attributes, $block_id, $classes, $url ) {
 		esc_attr( $classes ),
 		esc_attr( $block_id ),
 		! empty( $submit_button_classes ) ? esc_attr( $submit_button_classes ) : 'wp-block-button__link',
-		esc_js( $url ),
+		esc_attr( $url ),
 		wp_kses_post( $submit_button_text )
 	);
 }

--- a/projects/plugins/jetpack/extensions/blocks/eventbrite/eventbrite.php
+++ b/projects/plugins/jetpack/extensions/blocks/eventbrite/eventbrite.php
@@ -127,9 +127,9 @@ function render_embed_block( $widget_id, $is_amp, $attr ) {
 			'eventbrite-widget',
 			"window.EBWidgets.createWidget( {
 				widgetType: 'checkout',
-				eventId: " . absint( $attr['eventId'] ) . ",
-				iframeContainerId: '" . esc_js( $widget_id ) . "',
-			} );"
+				eventId: " . absint( $attr['eventId'] ) . ',
+				iframeContainerId: ' . wp_json_encode( $widget_id, JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP ) . ',
+			} );'
 		);
 	}
 
@@ -214,10 +214,10 @@ function render_modal_block( $widget_id, $is_amp, $attr, $content ) {
 		'eventbrite-widget',
 		"window.EBWidgets.createWidget( {
 			widgetType: 'checkout',
-			eventId: " . absint( $attr['eventId'] ) . ",
+			eventId: " . absint( $attr['eventId'] ) . ',
 			modal: true,
-			modalTriggerElementId: '" . esc_js( $widget_id ) . "',
-		} );"
+			modalTriggerElementId: ' . wp_json_encode( $widget_id, JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP ) . ',
+		} );'
 	);
 
 	// Modal button is saved as an `<a>` element with `role="button"` because `<button>` is not allowed
@@ -225,8 +225,8 @@ function render_modal_block( $widget_id, $is_amp, $attr, $content ) {
 	// @link https://www.w3.org/TR/wai-aria-practices/examples/button/button.html.
 	wp_add_inline_script(
 		'eventbrite-widget',
-		"( function() {
-			var widget = document.getElementById( '" . esc_js( $widget_id ) . "' );
+		'( function() {
+			var widget = document.getElementById( ' . wp_json_encode( $widget_id, JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP ) . " );
 			if ( widget ) {
 				widget.addEventListener( 'click', function( event ) {
 					event.preventDefault();

--- a/projects/plugins/jetpack/extensions/blocks/tock/tock.php
+++ b/projects/plugins/jetpack/extensions/blocks/tock/tock.php
@@ -58,7 +58,7 @@ function render_block( $attr ) {
 		"!function(t,o){if(!t.tock){var e=t.tock=function(){e.callMethod?
 		  e.callMethod.apply(e,arguments):e.queue.push(arguments)};t._tock||(t._tock=e),
 		  e.push=e,e.loaded=!0,e.version='1.0',e.queue=[];}}(window,document);
-			tock('init', '" . esc_js( $attr['url'] ) . "');",
+			tock('init', " . wp_json_encode( $attr['url'], JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP ) . ');',
 		'before'
 	);
 	return sprintf(

--- a/projects/plugins/jetpack/modules/infinite-scroll/infinity.php
+++ b/projects/plugins/jetpack/modules/infinite-scroll/infinity.php
@@ -934,7 +934,7 @@ class The_Neverending_Home_Page {
 			'footer'           => is_string( $settings->footer ) ? esc_js( $settings->footer ) : $settings->footer,
 			'click_handle'     => esc_js( $settings->click_handle ),
 			'text'             => esc_js( $click_handle_text ),
-			'totop'            => esc_js( __( 'Scroll back to top', 'jetpack' ) ),
+			'totop'            => __( 'Scroll back to top', 'jetpack' ),
 			'currentday'       => $currentday,
 			'order'            => 'DESC',
 			'scripts'          => array(),
@@ -951,7 +951,7 @@ class The_Neverending_Home_Page {
 			'query_before'     => current_time( 'mysql' ),
 			'last_post_date'   => self::get_last_post_date(),
 			'body_class'       => self::body_class(),
-			'loading_text'     => esc_js( __( 'Loading new page', 'jetpack' ) ),
+			'loading_text'     => __( 'Loading new page', 'jetpack' ),
 		);
 
 		// Optional order param

--- a/projects/plugins/jetpack/modules/sharedaddy/sharing.php
+++ b/projects/plugins/jetpack/modules/sharedaddy/sharing.php
@@ -375,7 +375,7 @@ class Sharing_Admin {
 	</div>
 
 	<script type="text/javascript">
-		var sharing_loading_icon = '<?php echo esc_js( admin_url( '/images/loading.gif' ) ); ?>';
+		var sharing_loading_icon = <?php echo wp_json_encode( admin_url( '/images/loading.gif' ), JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP ); ?>;
 		<?php
 		// phpcs:disable WordPress.Security.NonceVerification.Recommended -- we handle the nonce on the PHP side.
 		if (
@@ -385,9 +385,9 @@ class Sharing_Admin {
 			?>
 		jQuery(document).ready(function() {
 			// Prefill new service box and then open it
-			jQuery( '#new_sharing_name' ).val( '<?php echo esc_js( sanitize_text_field( wp_unslash( $_GET['name'] ) ) ); ?>' );
-			jQuery( '#new_sharing_url' ).val( '<?php echo esc_js( sanitize_text_field( wp_unslash( $_GET['url'] ) ) ); ?>' );
-			jQuery( '#new_sharing_icon' ).val( '<?php echo esc_js( sanitize_text_field( wp_unslash( $_GET['icon'] ) ) ); ?>' );
+			jQuery( '#new_sharing_name' ).val( <?php echo wp_json_encode( sanitize_text_field( wp_unslash( $_GET['name'] ) ), JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP ); ?> );
+			jQuery( '#new_sharing_url' ).val( <?php echo wp_json_encode( sanitize_text_field( wp_unslash( $_GET['url'] ) ), JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP ); ?> );
+			jQuery( '#new_sharing_icon' ).val( <?php echo wp_json_encode( sanitize_text_field( wp_unslash( $_GET['icon'] ) ), JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP ); ?> );
 			jQuery( '#add-a-new-service' ).click();
 		});
 		<?php endif; ?>

--- a/projects/plugins/jetpack/modules/shortcodes/brightcove.php
+++ b/projects/plugins/jetpack/modules/shortcodes/brightcove.php
@@ -266,7 +266,7 @@ class Jetpack_Brightcove_Shortcode {
 				'brightcove-loader',
 				'brightcoveData',
 				array(
-					'tld' => esc_js( $js_tld ),
+					'tld' => $js_tld,
 				)
 			);
 

--- a/projects/plugins/jetpack/modules/shortcodes/crowdsignal.php
+++ b/projects/plugins/jetpack/modules/shortcodes/crowdsignal.php
@@ -285,8 +285,6 @@ if (
 					JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP
 				);
 
-				$item_id = esc_js( $item_id );
-
 				if (
 					class_exists( 'Jetpack_AMP_Support' )
 					&& Jetpack_AMP_Support::is_amp_request()

--- a/projects/plugins/jetpack/modules/stats.php
+++ b/projects/plugins/jetpack/modules/stats.php
@@ -360,7 +360,7 @@ function stats_js_remove_stnojs_cookie() {
 	?>
 <script type="text/javascript">
 /* <![CDATA[ */
-document.cookie = 'stnojs=0; expires=Wed, 9 Mar 2011 16:55:50 UTC; path=<?php echo esc_js( $parsed['path'] ); ?>';
+document.cookie = <?php echo wp_json_encode( 'stnojs=0; expires=Wed, 9 Mar 2011 16:55:50 UTC; path=' . $parsed['path'], JSON_UNESCAPED_SLASHES | JSON_HEX_TAG ); ?>;
 /* ]]> */
 </script>
 	<?php

--- a/projects/plugins/jetpack/modules/stats/class-jetpack-stats-upgrade-nudges.php
+++ b/projects/plugins/jetpack/modules/stats/class-jetpack-stats-upgrade-nudges.php
@@ -296,7 +296,7 @@ class Jetpack_Stats_Upgrade_Nudges {
 							method: 'post',
 							body: JSON.stringify( { collapse_nudges: collapseValue } ),
 							headers: {
-								'X-WP-Nonce': "<?php echo esc_js( wp_create_nonce( 'wp_rest' ) ); ?>",
+								'X-WP-Nonce': <?php echo wp_json_encode( wp_create_nonce( 'wp_rest' ), JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP ); ?>,
 								'Content-type': 'application/json' }
 						} );
 					};

--- a/projects/plugins/jetpack/modules/widgets/class-jetpack-instagram-widget.php
+++ b/projects/plugins/jetpack/modules/widgets/class-jetpack-instagram-widget.php
@@ -411,7 +411,7 @@ class Jetpack_Instagram_Widget extends WP_Widget {
 
 		// If coming back to the widgets page from an action, expand this widget.
 		if ( isset( $_GET['instagram_widget_id'] ) && (int) $_GET['instagram_widget_id'] === (int) $this->number ) {
-			echo '<script type="text/javascript">jQuery(document).ready(function($){ $(\'.widget[id$="wpcom_instagram_widget-' . esc_js( $this->number ) . '"] .widget-inside\').slideDown(\'fast\'); });</script>';
+			echo '<script type="text/javascript">jQuery(document).ready(function($){ $(\'.widget[id$="wpcom_instagram_widget-' . intval( $this->number ) . '"] .widget-inside\').slideDown(\'fast\'); });</script>';
 		}
 
 		$status = $this->get_token_status( $instance['token_id'] );
@@ -476,20 +476,20 @@ class Jetpack_Instagram_Widget extends WP_Widget {
 						'_blank',
 						'toolbar=0,location=0,menubar=0,' + getScreenCenterSpecs( 700, 700 )
 					);
-					button.innerText = '<?php echo esc_js( __( 'Connecting…', 'jetpack' ) ); ?>';
+					button.innerText = <?php echo wp_json_encode( __( 'Connecting…', 'jetpack' ), JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP ); ?>;
 					button.disabled = true;
 					window.onmessage = function( { data } ) {
 						if ( !! data.keyring_id ) {
 							var payload = {
 								action: 'wpcom_instagram_widget_update_widget_token_id',
-								savetoken: '<?php echo esc_js( wp_create_nonce( 'instagram-widget-save-token' ) ); ?>',
+								savetoken: <?php echo wp_json_encode( wp_create_nonce( 'instagram-widget-save-token' ), JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP ); ?>,
 								keyring_id: data.keyring_id,
 								instagram_widget_id: button.dataset.widgetid,
 							};
 							jQuery.post( ajaxurl, payload, function( response ) {
 								var widget = jQuery(button).closest('div.widget');
 								if ( ! window.wpWidgets ) {
-									window.location = '<?php echo esc_js( add_query_arg( array( 'autofocus[panel]' => 'widgets' ), admin_url( 'customize.php' ) ) ); ?>';
+									window.location = <?php echo wp_json_encode( add_query_arg( array( 'autofocus[panel]' => 'widgets' ), admin_url( 'customize.php' ) ), JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP ); ?>;
 								} else {
 									wpWidgets.save( widget, 0, 1, 1 );
 								}

--- a/projects/plugins/jetpack/modules/widgets/rsslinks-widget.php
+++ b/projects/plugins/jetpack/modules/widgets/rsslinks-widget.php
@@ -165,7 +165,7 @@ class Jetpack_RSS_Links_Widget extends WP_Widget {
 			'text-image' => __( 'Text & Image Links', 'jetpack' ),
 		);
 		echo '<p><label for="' . esc_attr( $this->get_field_id( 'format' ) ) . '">' . esc_html_x( 'Format:', 'Noun', 'jetpack' ) . '
-		<select class="widefat" id="' . esc_attr( $this->get_field_id( 'format' ) ) . '" name="' . esc_attr( $this->get_field_name( 'format' ) ) . '" onchange="if ( this.value == \'text\' ) jQuery( \'#' . esc_js( $this->get_field_id( 'image-settings' ) ) . '\' ).fadeOut(); else jQuery( \'#' . esc_js( $this->get_field_id( 'image-settings' ) ) . '\' ).fadeIn();">';
+		<select class="widefat" id="' . esc_attr( $this->get_field_id( 'format' ) ) . '" name="' . esc_attr( $this->get_field_name( 'format' ) ) . '" onchange="if ( this.value == \'text\' ) jQuery( ' . esc_attr( wp_json_encode( '#' . $this->get_field_id( 'image-settings' ), JSON_UNESCAPED_SLASHES | JSON_HEX_AMP ) ) . ' ).fadeOut(); else jQuery( ' . esc_attr( wp_json_encode( '#' . $this->get_field_id( 'image-settings' ), JSON_UNESCAPED_SLASHES | JSON_HEX_AMP ) ) . ' ).fadeIn();">';
 		foreach ( $formats as $format_option => $label ) {
 			echo '<option value="' . esc_attr( $format_option ) . '"';
 			if ( $format_option === $format ) {

--- a/projects/plugins/jetpack/modules/woocommerce-analytics/classes/class-jetpack-woocommerce-analytics-my-account.php
+++ b/projects/plugins/jetpack/modules/woocommerce-analytics/classes/class-jetpack-woocommerce-analytics-my-account.php
@@ -223,8 +223,15 @@ class Jetpack_WooCommerce_Analytics_My_Account {
 	 * @deprecated 13.3
 	 */
 	public function track_logouts() {
-		$common_props = $this->render_properties_as_js(
-			$this->get_common_properties()
+		$common_props = wp_json_encode(
+			array_merge(
+				array(
+					'_en' => 'woocommerceanalytics_my_account_tab_click',
+					'tab' => 'logout',
+				),
+				$this->get_common_properties()
+			),
+			JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP
 		);
 
 		wc_enqueue_js(
@@ -232,14 +239,10 @@ class Jetpack_WooCommerce_Analytics_My_Account {
 			jQuery(document).ready(function($) {
 					// Attach event listener to the logout link
 				jQuery('.woocommerce-MyAccount-navigation-link--customer-logout').on('click', function() {
-					_wca.push({
-							'_en': 'woocommerceanalytics_my_account_tab_click',
-							'tab': 'logout'," .
-							$common_props . '
-					});
+					_wca.push($common_props);
 				});
 			});
-			'
+			"
 		);
 	}
 

--- a/projects/plugins/jetpack/modules/woocommerce-analytics/classes/class-jetpack-woocommerce-analytics-trait.php
+++ b/projects/plugins/jetpack/modules/woocommerce-analytics/classes/class-jetpack-woocommerce-analytics-trait.php
@@ -278,22 +278,6 @@ trait Jetpack_WooCommerce_Analytics_Trait {
 		return array_merge( $site_info, $cart_checkout_info );
 	}
 
-	/**
-	 * Render tracks event properties as string of JavaScript object props.
-	 *
-	 * @deprecated 13.3
-	 *
-	 * @param  array $properties Array of key/value pairs.
-	 * @return string String of the form "key1: value1, key2: value2, " (etc).
-	 */
-	private function render_properties_as_js( $properties ) {
-		$js_args_string = '';
-		foreach ( $properties as $key => $value ) {
-			$js_args_string = $js_args_string . "'$key': " . wp_json_encode( $value, JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP ) . ',';
-		}
-		return $js_args_string;
-	}
-
 		/**
 		 * Record an event with optional product and custom properties.
 		 *
@@ -397,15 +381,17 @@ trait Jetpack_WooCommerce_Analytics_Trait {
 			)
 		);
 
-		$js = "{'_en': '" . esc_js( $event_name ) . "'";
-
 		if ( isset( $product_details ) ) {
 				$all_props = array_merge( $all_props, $product_details );
 		}
 
-		$js .= ',' . $this->render_properties_as_js( $all_props ) . '}';
-
-		return $js;
+		return wp_json_encode(
+			array_merge(
+				array( '_en' => $event_name ),
+				$all_props
+			),
+			JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP
+		);
 	}
 
 	/**

--- a/projects/plugins/jetpack/modules/woocommerce-analytics/classes/class-jetpack-woocommerce-analytics-universal.php
+++ b/projects/plugins/jetpack/modules/woocommerce-analytics/classes/class-jetpack-woocommerce-analytics-universal.php
@@ -95,8 +95,14 @@ class Jetpack_WooCommerce_Analytics_Universal {
 	 * @deprecated 13.3
 	 */
 	public function remove_from_cart() {
-		$common_props = $this->render_properties_as_js(
-			$this->get_common_properties()
+		$common_props = wp_json_encode(
+			array_merge(
+				array(
+					'_en' => 'woocommerceanalytics_remove_from_cart',
+				),
+				$this->get_common_properties()
+			),
+			JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP
 		);
 
 		// We listen at div.woocommerce because the cart 'form' contents get forcibly
@@ -106,17 +112,11 @@ class Jetpack_WooCommerce_Analytics_Universal {
 			"jQuery( 'div.woocommerce' ).on( 'click', 'a.remove', function() {
 				var productID = jQuery( this ).data( 'product_id' );
 				var quantity = jQuery( this ).parent().parent().find( '.qty' ).val()
-				var productDetails = {
-					'id': productID,
-					'quantity': quantity ? quantity : '1',
-				};
-				_wca.push( {
-					'_en': 'woocommerceanalytics_remove_from_cart',
-					'pi': productDetails.id,
-					'pq': productDetails.quantity, " .
-					$common_props . '
-				} );
-			} );'
+				var common_props = $common_props;
+				common_props.pi = productID;
+				common_props.pq = quantity ? quantity : '1';
+				_wca.push( common_props );
+			} );"
 		);
 	}
 
@@ -402,8 +402,14 @@ class Jetpack_WooCommerce_Analytics_Universal {
 	 * @deprecated 13.3
 	 */
 	public function remove_from_cart_via_quantity() {
-		$common_props = $this->render_properties_as_js(
-			$this->get_common_properties()
+		$common_props = wp_json_encode(
+			array_merge(
+				array(
+					'_en' => 'woocommerceanalytics_remove_from_cart',
+				),
+				$this->get_common_properties()
+			),
+			JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP
 		);
 
 		wc_enqueue_js(
@@ -414,14 +420,12 @@ class Jetpack_WooCommerce_Analytics_Universal {
 					var qty = jQuery( this ).find( 'input.qty' );
 					if ( qty && qty.val() === '0' ) {
 						var productID = jQuery( this ).find( '.product-remove a' ).data( 'product_id' );
-						_wca.push( {
-							'_en': 'woocommerceanalytics_remove_from_cart',
-							'pi': productID, " .
-							$common_props . '
-						} );
+						var common_props = $common_props;
+						common_props.pi = productID;
+						_wca.push( common_props );
 					}
 				} );
-			} );'
+			} );"
 		);
 	}
 

--- a/projects/plugins/wpcomsh/changelog/fix-clean-up-uses-of-esc_js
+++ b/projects/plugins/wpcomsh/changelog/fix-clean-up-uses-of-esc_js
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Replace use of confusing `esc_js` with `wp_json_encode`, or with nothing where it had no effect.

--- a/projects/plugins/wpcomsh/custom-colors/colors.php
+++ b/projects/plugins/wpcomsh/custom-colors/colors.php
@@ -355,11 +355,11 @@ class Colors_Manager_Common {
 			'themeSupport'      => array( 'customBackground' => current_theme_supports( 'custom-background' ) ),
 			'defaultImage'      => get_theme_support( 'custom-background', 'default-image' ),
 			'topPatterns'       => self::get_patterns( array( 'limit' => 30 ) ),
-			'genPalette'        => esc_js( __( 'Generating...', 'wpcomsh' ) ),
-			'backgroundTitle'   => esc_js( __( 'Background', 'wpcomsh' ) ),
-			'colorsTitle'       => esc_js( __( 'Colors', 'wpcomsh' ) ),
-			'mediaTitle'        => esc_js( __( 'Select background image', 'wpcomsh' ) ),
-			'mediaSelectButton' => esc_js( __( 'Select', 'wpcomsh' ) ),
+			'genPalette'        => __( 'Generating...', 'wpcomsh' ),
+			'backgroundTitle'   => __( 'Background', 'wpcomsh' ),
+			'colorsTitle'       => __( 'Colors', 'wpcomsh' ),
+			'mediaTitle'        => __( 'Select background image', 'wpcomsh' ),
+			'mediaSelectButton' => __( 'Select', 'wpcomsh' ),
 		);
 
 		wp_localize_script( 'colors-tool', 'ColorsTool', $settings );

--- a/projects/plugins/wpcomsh/notices/feature-moved-to-jetpack-notices.php
+++ b/projects/plugins/wpcomsh/notices/feature-moved-to-jetpack-notices.php
@@ -40,7 +40,7 @@ function add_wpcom_writing_features_moved_script() {
 			document.addEventListener('click', function(event) {
 				if (event.target.closest('.notice[data-notice="options_writing"] .notice-dismiss')) {
 					wp.ajax.post('dismiss_wpcom_writing_features_moved_notice', {
-						nonce: '<?php echo esc_js( $ajax_nonce ); ?>'
+						nonce: <?php echo wp_json_encode( $ajax_nonce, JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP ); ?>
 					});
 				}
 			});


### PR DESCRIPTION
Closes MONOREP-283

 <!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
`esc_js()` is a legacy of the pre-PHP-5.2 days, when PHP didn't have `json_encode()`. It's basically a version of `esc_attr()` that handles `'` differently to work right for code like
```html
<span onclick="doSomething( '<?php eccho esc_js( $string )?>' )">
```
(and it also randomly strips backslashes, yay).

Unfortunately its name tends to fool people into thinking it's appropriate for "escaping JS" in other contexts; uses inside `<script>` tags, for example, probably don't really intend for HTML entities to be encoded inside the JS strings.

In modern WordPress, it's generally better to use `wp_json_encode()` to produce a properly encoded string (or other object), and to use `esc_attr()` when HTML entity encoding is needed. Before we can introduce a phpcs sniff to push for that, though, we need to clean up various existing uses.

General cleanups:

* Removed when passed into `wp_localize_script`'s `$l10n` parameter. That, for presumably hysterical raisins, does `html_entity_decode` on the `$l10n` parameter values, making it a no-op beyond screwing up `'`, backslash, and a few other characters.
* Replaced with `json_encode` when used as a jQuery selector. HTML entities are clearly wrong there, and other characters messed with are unlikely.
* Replaced with `json_encode` when wrapping a `__()` where the text doesn't have any HTML in it, as it's unlikely that it's expected that translations would introduce HTML that would need encoding (or that backslashes will be stripped).
* Replaced with `json_encode` when apparently passed a nonce or url, as those shouldn't need HTML entity encoding (or backslash stripping) either.
* Replaced with `intval` in a few places where it seems an integer is expected (e.g. `sprintf` with `%d`).

Specific cleanups:

* One place in woocommerce-analytics was weirdly manually building a JSON object, with one field getting `esc_js`-ed. Decided that field was probably safe and turned the whole thing into a single `json_encode` call.
* Calendly block had a few that should have been `esc_attr` (or maybe `esc_url`) in the first place. Apparently at some point in the past they were sprintf-ed into an event handler, then later changed to normal hrefs.
* Publicize had some weird thing turning printf format strings into JS concatenation. Rewrote that to do the same but with `json_encode`. 🤷
* Sharedaddy had some code copying GET values into form fields via JS, that seemed like they probably shouldn't be getting HTML entity encoded either.
* Videopress had a guid that seems unlikely to need HTML entity encoding either, particularly since various places seem to dump it into a URL without even percent-encoding it. 🙄

That leaves some infinite-scroll settings, a bunch of wordads stuff, a bunch of tracking stuff (Google Analytics and wpcom), and some CRM files already in `tools/phpcs-excludelist.json`. When introducing the phpcs sniff to check for future use of `esc_js()`, these will be excluded.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Make sure stuff still works as it did before.
