### PR TITLE
Try: update form block - store the whole block

### DIFF
--- a/projects/packages/forms/changelog/add-jetpack-forms-custom-post-type
+++ b/projects/packages/forms/changelog/add-jetpack-forms-custom-post-type
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add jetpack-forms custom post type

--- a/projects/packages/forms/src/blocks/contact-form/attributes.ts
+++ b/projects/packages/forms/src/blocks/contact-form/attributes.ts
@@ -4,6 +4,9 @@
 import { __ } from '@wordpress/i18n';
 
 export default {
+	ref: {
+		type: 'number' as const,
+	},
 	subject: {
 		type: 'string',
 		default: window.jpFormsBlocks?.defaults?.subject || '',

--- a/projects/packages/forms/src/blocks/contact-form/block.json
+++ b/projects/packages/forms/src/blocks/contact-form/block.json
@@ -21,6 +21,10 @@
 		},
 		"align": [ "wide", "full" ]
 	},
-	"attributes": {},
+	"attributes": {
+		"ref": {
+			"type": "number"
+		}
+	},
 	"editorScript": "file:./editor.js"
 }

--- a/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
+++ b/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
@@ -716,6 +716,12 @@ class Contact_Form_Block {
 		if ( class_exists( 'Jetpack' ) && ! ( new Modules() )->is_active( 'contact-form' ) ) {
 			return '';
 		}
+
+		// Handle ref attribute - load form from jetpack-form post
+		if ( isset( $atts['ref'] ) && is_numeric( $atts['ref'] ) ) {
+			return self::render_reusable_form( $atts['ref'] );
+		}
+
 		// Render fallback in other contexts than frontend (i.e. feed, emails, API, etc.), unless the form is being submitted.
 		if ( ! Request::is_frontend() && ! isset( $_POST['contact-form-id'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing
 			return sprintf(
@@ -729,6 +735,53 @@ class Contact_Form_Block {
 		self::load_view_scripts();
 
 		return Contact_Form::parse( $atts, do_blocks( $content ) );
+	}
+
+	/**
+	 * Render a reusable form by reference ID.
+	 *
+	 * @param int $ref_id The jetpack-form post ID.
+	 * @return string Rendered form HTML.
+	 */
+	private static function render_reusable_form( $ref_id ) {
+		// Circular reference prevention.
+		static $seen_refs = array();
+
+		if ( isset( $seen_refs[ $ref_id ] ) ) {
+			return sprintf(
+				'<div class="wp-block-jetpack-contact-form">%s</div>',
+				esc_html__( 'Circular reference detected in form.', 'jetpack-forms' )
+			);
+		}
+
+		// Load the jetpack-form post.
+		$reusable_form = get_post( $ref_id );
+
+		// Validate post.
+		if ( ! $reusable_form || 'jetpack-form' !== $reusable_form->post_type ) {
+			return '';
+		}
+
+		// Only render published forms.
+		if ( 'publish' !== $reusable_form->post_status ) {
+			return '';
+		}
+
+		// Mark as seen for circular reference prevention.
+		$seen_refs[ $ref_id ] = true;
+
+		// Parse and render blocks from post_content.
+		$blocks = parse_blocks( $reusable_form->post_content );
+		$output = '';
+
+		foreach ( $blocks as $block ) {
+			$output .= render_block( $block );
+		}
+
+		// Clean up.
+		unset( $seen_refs[ $ref_id ] );
+
+		return $output;
 	}
 
 	/**

--- a/projects/packages/forms/src/blocks/contact-form/edit.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/edit.tsx
@@ -34,7 +34,7 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
 import { useRef, useEffect, useCallback, useMemo, lazy, Suspense } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
-import { edit } from '@wordpress/icons';
+import { pencil } from '@wordpress/icons';
 import clsx from 'clsx';
 /*
  * Internal dependencies
@@ -987,7 +987,7 @@ function JetpackContactFormEdit( {
 					{ ref && reusableForm && (
 						<ToolbarGroup>
 							<ToolbarButton
-								icon={ edit }
+								icon={ pencil }
 								label={ sprintf(
 									/* translators: %s: Form title */
 									__( 'Edit "%s" in new tab', 'jetpack-forms' ),

--- a/projects/packages/forms/src/blocks/contact-form/edit.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/edit.tsx
@@ -14,21 +14,27 @@ import {
 	BlockControls,
 	BlockContextProvider,
 } from '@wordpress/block-editor';
-import { createBlock } from '@wordpress/blocks';
+import { createBlock, parse, serialize } from '@wordpress/blocks';
 import {
 	ExternalLink,
+	Notice,
 	PanelBody,
+	Placeholder,
+	Spinner,
 	TextareaControl,
 	TextControl,
 	ToggleControl,
 	RadioControl,
+	ToolbarButton,
+	ToolbarGroup,
 } from '@wordpress/components';
 import { useInstanceId } from '@wordpress/compose';
 import { store as coreStore } from '@wordpress/core-data';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
-import { useRef, useEffect, useCallback, lazy, Suspense } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { useRef, useEffect, useCallback, useMemo, lazy, Suspense } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
+import { edit } from '@wordpress/icons';
 import clsx from 'clsx';
 /*
  * Internal dependencies
@@ -128,6 +134,7 @@ type Webhook = {
 };
 
 type JetpackContactFormAttributes = {
+	ref?: number;
 	to: string;
 	subject: string;
 	// Legacy support for the customThankyou attribute
@@ -164,6 +171,7 @@ function JetpackContactFormEdit( {
 	useFormBlockDefaults( { attributes, setAttributes } );
 
 	const {
+		ref,
 		to,
 		subject,
 		customThankyou,
@@ -183,6 +191,49 @@ function JetpackContactFormEdit( {
 	const showWebhooks = useConfigValue( 'isWebhooksEnabled' ) && hasFeatureFlag( 'form-webhooks' );
 	const showBlockIntegrations = useConfigValue( 'showBlockIntegrations' );
 	const instanceId = useInstanceId( JetpackContactFormEdit );
+
+	// Load reusable form content when ref is set
+	const { reusableForm, isResolvingReusableForm } = useSelect(
+		select => {
+			if ( ! ref ) {
+				return { reusableForm: null, isResolvingReusableForm: false };
+			}
+
+			const { getEntityRecord, isResolving } = select( coreStore );
+
+			return {
+				reusableForm: getEntityRecord( 'postType', 'jetpack-form', ref ),
+				isResolvingReusableForm: isResolving( 'getEntityRecord', [
+					'postType',
+					'jetpack-form',
+					ref,
+				] ),
+			};
+		},
+		[ ref ]
+	);
+
+	// Parse blocks from reusable form and extract form attributes and inner blocks
+	const { reusableFormBlocks, reusableFormAttributes } = useMemo( () => {
+		if ( ! reusableForm?.content?.raw ) {
+			return { reusableFormBlocks: null, reusableFormAttributes: null };
+		}
+
+		const parsedBlocks = parse( reusableForm.content.raw );
+
+		// The content should be a single jetpack/contact-form block
+		// Extract its inner blocks and attributes
+		if ( parsedBlocks.length > 0 && parsedBlocks[ 0 ].name === 'jetpack/contact-form' ) {
+			const formBlock = parsedBlocks[ 0 ];
+			return {
+				reusableFormBlocks: formBlock.innerBlocks || [],
+				reusableFormAttributes: formBlock.attributes || {},
+			};
+		}
+
+		// Fallback: if it's just inner blocks (backward compatibility)
+		return { reusableFormBlocks: parsedBlocks, reusableFormAttributes: null };
+	}, [ reusableForm ] );
 
 	// Backward compatibility for the deprecated customThankyou attribute.
 	// Older forms will have a customThankyou attribute set, but not a confirmationType attribute
@@ -304,10 +355,93 @@ function JetpackContactFormEdit( {
 	const { replaceInnerBlocks, __unstableMarkNextChangeAsNotPersistent, updateBlockAttributes } =
 		useDispatch( blockEditorStore );
 
+	const { editEntityRecord } = useDispatch( coreStore );
+
 	const currentInnerBlocks = useSelect(
 		select => select( blockEditorStore ).getBlocks( clientId ),
 		[ clientId ]
 	);
+
+	// Track if we're currently syncing to prevent save-back loops
+	const isSyncingRef = useRef( false );
+	const lastLoadedRefId = useRef( null );
+
+	// Sync inner blocks and attributes when reusable form loads (ONLY ONCE per ref)
+	useEffect( () => {
+		if ( ! ref || ! reusableFormBlocks ) {
+			return;
+		}
+
+		// Only sync when ref changes or loads for the first time
+		// Don't re-sync when reusableFormBlocks changes due to our own edits
+		if ( lastLoadedRefId.current === ref ) {
+			return; // Already loaded this ref
+		}
+
+		// Mark this ref as loaded
+		lastLoadedRefId.current = ref;
+
+		// Sync on initial load
+		// Once loaded, the user can edit freely and changes will save back to the source
+		isSyncingRef.current = true;
+
+		// Apply form attributes from the reusable form (except ref and layout attrs)
+		// Mark as non-persistent so they're not saved locally - only ref is saved
+		if ( reusableFormAttributes ) {
+			const attrsToApply = { ...reusableFormAttributes };
+			// Don't override layout attributes or ref
+			delete attrsToApply.className;
+			delete attrsToApply.align;
+			delete attrsToApply.style;
+			delete attrsToApply.ref;
+
+			__unstableMarkNextChangeAsNotPersistent();
+			setAttributes( attrsToApply );
+		}
+
+		// Load inner blocks from source
+		__unstableMarkNextChangeAsNotPersistent();
+		replaceInnerBlocks( clientId, reusableFormBlocks, false );
+
+		// Reset syncing flag after a short delay
+		setTimeout( () => {
+			isSyncingRef.current = false;
+		}, 100 );
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [ ref, reusableFormBlocks, reusableFormAttributes, clientId ] );
+
+	// Save changes back to reusable form post (inline editing)
+	useEffect( () => {
+		if ( ! ref || ! reusableForm || isSyncingRef.current ) {
+			return; // Not a reusable form or currently syncing
+		}
+
+		// Create the full jetpack/contact-form block with current attributes and inner blocks
+		// Exclude ref from saved attributes since it's not part of the form definition
+		const attributesToSave = { ...attributes };
+		delete attributesToSave.ref;
+
+		const formBlock = createBlock( 'jetpack/contact-form', attributesToSave, currentInnerBlocks );
+
+		// Serialize the entire form block
+		const serialized = serialize( formBlock );
+
+		// Only update if content has changed
+		if ( serialized !== reusableForm.content?.raw ) {
+			// Debounce to avoid excessive saves
+			const timeoutId = setTimeout( () => {
+				editEntityRecord( 'postType', 'jetpack-form', ref, {
+					content: serialized,
+				} );
+			}, 1000 ); // 1 second debounce
+
+			return () => clearTimeout( timeoutId );
+		}
+	}, [ currentInnerBlocks, ref, reusableForm, editEntityRecord, attributes ] );
+
+	// Note: We don't clear attributes in memory when ref is set, as they're needed
+	// for the form to work properly in the editor. The save() method ensures that
+	// only the ref attribute is persisted to the database.
 
 	// Track previous block count to detect insertions
 	const previousBlockCountRef = useRef( currentInnerBlocks.length );
@@ -795,7 +929,27 @@ function JetpackContactFormEdit( {
 
 	let elt;
 
-	if ( ! isModuleActive ) {
+	// Show loading state when resolving reusable form
+	if ( ref && isResolvingReusableForm ) {
+		elt = (
+			<div { ...blockProps }>
+				<Placeholder>
+					<Spinner />
+					{ __( 'Loading form...', 'jetpack-forms' ) }
+				</Placeholder>
+			</div>
+		);
+	}
+	// Show error if referenced form not found
+	else if ( ref && ! reusableForm && ! isResolvingReusableForm ) {
+		elt = (
+			<div { ...blockProps }>
+				<Notice status="warning" isDismissible={ false }>
+					{ __( 'The referenced form could not be found.', 'jetpack-forms' ) }
+				</Notice>
+			</div>
+		);
+	} else if ( ! isModuleActive ) {
 		if ( isLoadingModules ) {
 			elt = <ContactFormSkeletonLoader />;
 		} else {
@@ -830,6 +984,24 @@ function JetpackContactFormEdit( {
 			<>
 				<BlockControls>
 					{ variationName === 'multistep' && <StepControls formClientId={ clientId } /> }
+					{ ref && reusableForm && (
+						<ToolbarGroup>
+							<ToolbarButton
+								icon={ edit }
+								label={ sprintf(
+									/* translators: %s: Form title */
+									__( 'Edit "%s" in new tab', 'jetpack-forms' ),
+									reusableForm.title?.rendered || __( 'Reusable Form', 'jetpack-forms' )
+								) }
+								onClick={ () => {
+									// Construct the edit URL for the jetpack-form post
+									const adminUrl = window?.location?.origin || '';
+									const editUrl = `${ adminUrl }/wp-admin/post.php?post=${ ref }&action=edit`;
+									window.open( editUrl, '_blank', 'noopener,noreferrer' );
+								} }
+							/>
+						</ToolbarGroup>
+					) }
 				</BlockControls>
 				<InspectorControls>
 					<PanelBody

--- a/projects/packages/forms/src/blocks/contact-form/index.js
+++ b/projects/packages/forms/src/blocks/contact-form/index.js
@@ -63,8 +63,15 @@ export const settings = {
 		'jetpack/form-class-name': 'className',
 	},
 	edit,
-	save: () => {
+	save: ( { attributes } ) => {
 		const blockProps = useBlockProps.save();
+
+		// When ref is present, don't save inner blocks - they're stored in the referenced post
+		if ( attributes.ref ) {
+			return <div { ...blockProps } />;
+		}
+
+		// Normal save for non-reusable forms
 		return (
 			<div { ...blockProps }>
 				<InnerBlocks.Content />

--- a/projects/packages/forms/src/blocks/contact-form/variation-picker.js
+++ b/projects/packages/forms/src/blocks/contact-form/variation-picker.js
@@ -3,9 +3,11 @@ import {
 	__experimentalBlockPatternSetup as BlockPatternSetup, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
-import { createBlock, store as blocksStore } from '@wordpress/blocks';
+import { createBlock, serialize, store as blocksStore } from '@wordpress/blocks';
 import { Button, Modal } from '@wordpress/components';
+import { store as coreStore } from '@wordpress/core-data';
 import { useDispatch, useRegistry, useSelect } from '@wordpress/data';
+import { store as editorStore } from '@wordpress/editor';
 import { useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
@@ -23,18 +25,24 @@ export default function VariationPicker( { blockName, setAttributes, clientId, c
 	const registry = useRegistry();
 	const [ isPatternsModalOpen, setIsPatternsModalOpen ] = useState( false );
 	const { replaceInnerBlocks, selectBlock } = useDispatch( blockEditorStore );
-	const { blockType, defaultVariation, variations } = useSelect(
+	const { saveEntityRecord } = useDispatch( coreStore );
+	const { blockType, defaultVariation, variations, currentPostType } = useSelect(
 		select => {
 			const { getBlockType, getBlockVariations, getDefaultBlockVariation } = select( blocksStore );
+			const { getCurrentPostType } = select( editorStore );
 
 			return {
 				blockType: getBlockType( blockName ),
 				defaultVariation: getDefaultBlockVariation( blockName, 'block' ),
 				variations: getBlockVariations( blockName, 'block' ),
+				currentPostType: getCurrentPostType(),
 			};
 		},
 		[ blockName ]
 	);
+
+	// Check if we're editing a jetpack-form post directly
+	const isEditingJetpackFormPost = currentPostType === 'jetpack-form';
 
 	useEffect( () => {
 		if (
@@ -56,21 +64,70 @@ export default function VariationPicker( { blockName, setAttributes, clientId, c
 					'jetpack-forms'
 				) }
 				variations={ variations.filter( v => ! v.hiddenFromPicker ) }
-				onSelect={ ( nextVariation = defaultVariation ) => {
-					registry.batch( () => {
-						if ( nextVariation.attributes ) {
-							setAttributes( nextVariation.attributes );
-						}
-
-						if ( nextVariation.innerBlocks ) {
-							replaceInnerBlocks(
-								clientId,
-								createBlocksFromInnerBlocksTemplate( nextVariation.innerBlocks )
+				onSelect={ async ( nextVariation = defaultVariation ) => {
+					// If we're editing a jetpack-form post directly, use the old behavior
+					// (just set attributes and inner blocks, don't create another ref)
+					if ( isEditingJetpackFormPost || nextVariation.name === 'regular-form' ) {
+						registry.batch( () => {
+							if ( nextVariation.attributes ) {
+								setAttributes( nextVariation.attributes );
+							}
+							if ( nextVariation.innerBlocks ) {
+								replaceInnerBlocks(
+									clientId,
+									createBlocksFromInnerBlocksTemplate( nextVariation.innerBlocks )
+								);
+							}
+							selectBlock( clientId );
+						} );
+					} else {
+						// We're editing a regular post/page - create a reusable form with ref
+						try {
+							// Create inner blocks from template
+							const innerBlocks = createBlocksFromInnerBlocksTemplate(
+								nextVariation.innerBlocks
 							);
-						}
 
-						selectBlock( clientId );
-					} );
+							// Create the full jetpack/contact-form block with attributes and inner blocks
+							const formBlock = createBlock(
+								'jetpack/contact-form',
+								nextVariation.attributes || {},
+								innerBlocks
+							);
+
+							// Serialize the entire form block to block markup
+							const serialized = serialize( formBlock );
+
+							// Create jetpack-form post
+							const post = await saveEntityRecord( 'postType', 'jetpack-form', {
+								title: nextVariation.title || 'Form',
+								content: serialized,
+								status: 'publish',
+							} );
+
+							// Set ONLY ref attribute
+							registry.batch( () => {
+								setAttributes( { ref: post.id } );
+								selectBlock( clientId );
+							} );
+						} catch ( error ) {
+							// eslint-disable-next-line no-console
+							console.error( 'Failed to create reusable form:', error );
+							// Fallback to old behavior
+							registry.batch( () => {
+								if ( nextVariation.attributes ) {
+									setAttributes( nextVariation.attributes );
+								}
+								if ( nextVariation.innerBlocks ) {
+									replaceInnerBlocks(
+										clientId,
+										createBlocksFromInnerBlocksTemplate( nextVariation.innerBlocks )
+									);
+								}
+								selectBlock( clientId );
+							} );
+						}
+					}
 				} }
 			/>
 			<div className="form-placeholder__footer">

--- a/projects/packages/forms/src/blocks/form/admin.js
+++ b/projects/packages/forms/src/blocks/form/admin.js
@@ -1,0 +1,135 @@
+/**
+ * Jetpack Form Editor - Makes the form block unselectable and enforces block nesting.
+ *
+ * This script prevents the jetpack/contact-form block from being selected
+ * in the jetpack-form custom post type editor, and ensures that blocks can
+ * only be added inside the form block, not as siblings to it.
+ */
+
+import { subscribe, select, dispatch } from '@wordpress/data';
+
+let hasLocked = false;
+let formBlockClientId = null;
+
+/**
+ * Lock the contact-form block to prevent selection.
+ */
+const lockFormBlock = () => {
+	const { getBlocks, getSelectedBlockClientId } = select( 'core/block-editor' );
+
+	const { updateBlockAttributes, clearSelectedBlock } = dispatch( 'core/block-editor' );
+
+	const blocks = getBlocks();
+
+	// Find the jetpack/contact-form block (should be the first and only root block).
+	const formBlock = blocks.find( block => block.name === 'jetpack/contact-form' );
+
+	if ( ! formBlock ) {
+		return;
+	}
+
+	// Store the form block client ID for later use.
+	formBlockClientId = formBlock.clientId;
+
+	// Set the flag BEFORE making any changes to prevent recursion.
+	hasLocked = true;
+
+	// Lock the block to prevent removal, moving, and selection.
+	updateBlockAttributes( formBlock.clientId, {
+		lock: {
+			remove: true,
+			move: true,
+		},
+	} );
+
+	// If the form block is currently selected, clear the selection.
+	const selectedBlockId = getSelectedBlockClientId();
+	if ( selectedBlockId === formBlock.clientId ) {
+		clearSelectedBlock();
+	}
+
+	// Add CSS to hide the form block's selection outline and controls.
+	if ( ! document.getElementById( 'jetpack-form-block-lock-styles' ) ) {
+		const style = document.createElement( 'style' );
+		style.id = 'jetpack-form-block-lock-styles';
+		style.textContent = `
+			/* Hide selection outline and controls for the form block */
+			.wp-block[data-type="jetpack/contact-form"] > .block-editor-block-list__block-edit::before {
+				display: none !important;
+			}
+			.wp-block[data-type="jetpack/contact-form"] > .block-editor-block-contextual-toolbar,
+			.wp-block[data-type="jetpack/contact-form"] > .block-list-appender {
+				display: none !important;
+			}
+			/* Prevent pointer events on the form block wrapper */
+			.wp-block[data-type="jetpack/contact-form"] {
+				pointer-events: none;
+			}
+			/* Re-enable pointer events for inner blocks */
+			.wp-block[data-type="jetpack/contact-form"] .block-editor-block-list__layout {
+				pointer-events: auto;
+			}
+			/* Hide the root-level block appender to prevent adding blocks outside the form */
+			.editor-styles-wrapper > .block-editor-block-list__layout > .block-list-appender,
+			.editor-styles-wrapper > .block-editor-block-list__layout > .wp-block > .block-list-appender {
+				display: none !important;
+			}
+		`;
+		document.head.appendChild( style );
+	}
+};
+
+/**
+ * Monitor for blocks added at the root level and move them inside the form.
+ */
+const enforceBlockNesting = () => {
+	if ( ! formBlockClientId ) {
+		return;
+	}
+
+	const { getBlocks } = select( 'core/block-editor' );
+
+	const rootBlocks = getBlocks();
+
+	// Find any blocks that aren't the form block.
+	const blocksToMove = rootBlocks.filter( block => block.clientId !== formBlockClientId );
+
+	if ( blocksToMove.length === 0 ) {
+		return;
+	}
+
+	const { moveBlocksToPosition } = dispatch( 'core/block-editor' );
+	// Move each block inside the form block.
+	blocksToMove.forEach( block => {
+		// Get the current number of inner blocks to append at the end.
+		const formBlock = rootBlocks.find( b => b.clientId === formBlockClientId );
+		const targetIndex = formBlock ? formBlock.innerBlocks.length : 0;
+
+		// Move the block from root to inside the form.
+		moveBlocksToPosition(
+			[ block.clientId ],
+			'', // From root
+			formBlockClientId, // To form block
+			targetIndex
+		);
+	} );
+};
+
+// Subscribe to editor changes to lock the form block when ready.
+const unsubscribe = subscribe( () => {
+	if ( hasLocked ) {
+		unsubscribe();
+		return;
+	}
+
+	lockFormBlock();
+} );
+
+// Subscribe to monitor block additions and enforce nesting.
+subscribe( () => {
+	if ( ! hasLocked ) {
+		return;
+	}
+
+	enforceBlockNesting();
+} );

--- a/projects/packages/forms/src/class-reusable-forms.php
+++ b/projects/packages/forms/src/class-reusable-forms.php
@@ -18,6 +18,8 @@ class Reusable_Forms {
 	public static function init() {
 		self::register_post_type();
 		add_filter( 'allowed_block_types_all', array( __CLASS__, 'allowed_blocks_for_jetpack_form' ), 10, 2 );
+		add_filter( 'block_editor_settings_all', array( __CLASS__, 'block_editor_settings_all' ), 10, 2 );
+		add_action( 'admin_enqueue_scripts', array( __CLASS__, 'enqueue_admin_scripts' ) );
 	}
 
 	/**
@@ -146,6 +148,47 @@ class Reusable_Forms {
 			'core/group',
 			'core/image',
 			'core/html',
+		);
+	}
+
+	/**
+	 * Modify block editor settings for jetpack-form posts.
+	 *
+	 * Disables the inserter in the top toolbar.
+	 *
+	 * @param array  $settings       Block editor settings.
+	 * @param object $editor_context The current editor context.
+	 * @return array Modified block editor settings for jetpack-form posts.
+	 */
+	public static function block_editor_settings_all( $settings, $editor_context ) {
+		// Only apply to jetpack-form post type.
+		if ( ! isset( $editor_context->post ) || 'jetpack-form' !== $editor_context->post->post_type ) {
+			return $settings;
+		}
+
+		// Disable the inserter in the top toolbar.
+		$settings['canLockBlocks'] = false;
+
+		return $settings;
+	}
+
+	/**
+	 * Enqueue admin scripts for jetpack-form post type.
+	 */
+	public static function enqueue_admin_scripts() {
+		$current_screen = get_current_screen();
+
+		// Only enqueue on the jetpack-form post type edit screen
+		if ( empty( $current_screen ) || 'jetpack-form' !== $current_screen->post_type ) {
+			return;
+		}
+
+		wp_enqueue_script(
+			'jetpack-form-admin',
+			plugin_dir_url( __FILE__ ) . '../dist/blocks/form/admin.js',
+			array(),
+			\JETPACK__VERSION,
+			true
 		);
 	}
 }

--- a/projects/packages/forms/src/class-reusable-forms.php
+++ b/projects/packages/forms/src/class-reusable-forms.php
@@ -56,7 +56,7 @@ class Reusable_Forms {
 				'show_in_rest'          => true,
 				'rest_base'             => 'jetpack-forms',
 				'rest_controller_class' => 'Automattic\Jetpack\Forms\ContactForm\REST_Jetpack_Form_Controller',
-				'capability_type'       => 'jetpack-form',
+				'capability_type'       => 'post',
 				'capabilities'          => array(
 					// You need to be able to edit posts, in order to read blocks in their raw form.
 					'read'                   => 'edit_posts',
@@ -70,6 +70,7 @@ class Reusable_Forms {
 					'edit_others_posts'      => 'edit_others_posts',
 					'delete_others_posts'    => 'delete_others_posts',
 				),
+				'map_meta_cap'          => true,
 				'supports'              => array(
 					'title',
 					'excerpt',

--- a/projects/packages/forms/src/class-reusable-forms.php
+++ b/projects/packages/forms/src/class-reusable-forms.php
@@ -26,16 +26,57 @@ class Reusable_Forms {
 		register_post_type(
 			'jetpack-form',
 			array(
-				'labels'       => array(
-					'name'          => __( 'Jetpack Forms', 'jetpack-forms' ),
-					'singular_name' => __( 'Jetpack Form', 'jetpack-forms' ),
+				'labels'                => array(
+					'name'                     => __( 'Forms', 'jetpack-forms' ),
+					'singular_name'            => __( 'Form', 'jetpack-forms' ),
+					'add_new'                  => __( 'Add Form', 'jetpack-forms' ),
+					'add_new_item'             => __( 'Add Form', 'jetpack-forms' ),
+					'new_item'                 => __( 'New Form', 'jetpack-forms' ),
+					'edit_item'                => __( 'Edit Block Form', 'jetpack-forms' ),
+					'view_item'                => __( 'View Form', 'jetpack-forms' ),
+					'view_items'               => __( 'View Forms', 'jetpack-forms' ),
+					'all_items'                => __( 'All Forms', 'jetpack-forms' ),
+					'search_items'             => __( 'Search Forms', 'jetpack-forms' ),
+					'not_found'                => __( 'No forms found.', 'jetpack-forms' ),
+					'not_found_in_trash'       => __( 'No forms found in Trash.', 'jetpack-forms' ),
+					'filter_items_list'        => __( 'Filter forms list', 'jetpack-forms' ),
+					'items_list_navigation'    => __( 'Forms list navigation', 'jetpack-forms' ),
+					'items_list'               => __( 'Forms list', 'jetpack-forms' ),
+					'item_published'           => __( 'Form published.', 'jetpack-forms' ),
+					'item_published_privately' => __( 'Form published privately.', 'jetpack-forms' ),
+					'item_reverted_to_draft'   => __( 'Form reverted to draft.', 'jetpack-forms' ),
+					'item_scheduled'           => __( 'Form scheduled.', 'jetpack-forms' ),
+					'item_updated'             => __( 'Form updated.', 'jetpack-forms' ),
 				),
-				'public'       => false,
-				'show_ui'      => false,
-				'show_in_menu' => false,
-				'rewrite'      => false,
-				'query_var'    => false,
-				'show_in_rest' => false,
+				'public'                => false,
+				'show_ui'               => true, // not sure we need this.
+				'show_in_menu'          => false,
+				'rewrite'               => false,
+				'query_var'             => false,
+				'show_in_rest'          => true,
+				'rest_base'             => 'jetpack-forms',
+				'rest_controller_class' => 'Automattic\Jetpack\Forms\ContactForm\REST_Jetpack_Form_Controller',
+				'capability_type'       => 'jetpack-form',
+				'capabilities'          => array(
+					// You need to be able to edit posts, in order to read blocks in their raw form.
+					'read'                   => 'edit_posts',
+					// You need to be able to publish posts, in order to create blocks.
+					'create_posts'           => 'publish_posts',
+					'edit_posts'             => 'edit_posts',
+					'edit_published_posts'   => 'edit_published_posts',
+					'delete_published_posts' => 'delete_published_posts',
+					// Enables trashing draft posts as well.
+					'delete_posts'           => 'delete_posts',
+					'edit_others_posts'      => 'edit_others_posts',
+					'delete_others_posts'    => 'delete_others_posts',
+				),
+				'supports'              => array(
+					'title',
+					'excerpt',
+					'editor',
+					'revisions',
+					'custom-fields',
+				),
 			)
 		);
 	}

--- a/projects/packages/forms/src/class-reusable-forms.php
+++ b/projects/packages/forms/src/class-reusable-forms.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Reusable Forms class.
+ *
+ * @package automattic/jetpack-forms
+ */
+
+namespace Automattic\Jetpack\Forms;
+
+/**
+ * Handles Reusable Forms functionality.
+ */
+class Reusable_Forms {
+
+	/**
+	 * Initialize the Reusable Forms feature.
+	 */
+	public static function init() {
+		self::register_post_type();
+	}
+
+	/**
+	 * Register the jetpack-form custom post type.
+	 */
+	private static function register_post_type() {
+		register_post_type(
+			'jetpack-form',
+			array(
+				'labels'       => array(
+					'name'          => __( 'Jetpack Forms', 'jetpack-forms' ),
+					'singular_name' => __( 'Jetpack Form', 'jetpack-forms' ),
+				),
+				'public'       => false,
+				'show_ui'      => false,
+				'show_in_menu' => false,
+				'rewrite'      => false,
+				'query_var'    => false,
+				'show_in_rest' => false,
+			)
+		);
+	}
+}

--- a/projects/packages/forms/src/class-reusable-forms.php
+++ b/projects/packages/forms/src/class-reusable-forms.php
@@ -17,6 +17,7 @@ class Reusable_Forms {
 	 */
 	public static function init() {
 		self::register_post_type();
+		add_filter( 'allowed_block_types_all', array( __CLASS__, 'allowed_blocks_for_jetpack_form' ), 10, 2 );
 	}
 
 	/**
@@ -71,14 +72,80 @@ class Reusable_Forms {
 					'delete_others_posts'    => 'delete_others_posts',
 				),
 				'map_meta_cap'          => true,
+				'template'              => array( array( 'jetpack/contact-form' ) ),
 				'supports'              => array(
 					'title',
-					'excerpt',
 					'editor',
 					'revisions',
-					'custom-fields',
 				),
 			)
+		);
+	}
+
+	/**
+	 * Restrict allowed blocks when editing jetpack-form posts.
+	 *
+	 * Only allows field blocks and supporting blocks. The contact-form block is excluded
+	 * because visual wrapping is handled via DOM manipulation in the editor script.
+	 *
+	 * @param bool|array $allowed_block_types Array of block type slugs, or boolean to enable/disable all.
+	 * @param object     $editor_context       The current editor context.
+	 * @return bool|array Array of allowed block types for jetpack-form posts.
+	 */
+	public static function allowed_blocks_for_jetpack_form( $allowed_block_types, $editor_context ) {
+		// Only apply to jetpack-form post type.
+		if ( ! isset( $editor_context->post ) || 'jetpack-form' !== $editor_context->post->post_type ) {
+			return $allowed_block_types;
+		}
+
+		// Allow only field blocks, button, and core blocks.
+		// Visual wrapping is handled by JavaScript DOM manipulation.
+		return array(
+			// 'jetpack/contact-form',
+			// Field blocks.
+			'jetpack/field-name',
+			'jetpack/field-email',
+			'jetpack/field-url',
+			'jetpack/field-telephone',
+			'jetpack/field-textarea',
+			'jetpack/field-checkbox',
+			'jetpack/field-checkbox-multiple',
+			'jetpack/field-radio',
+			'jetpack/field-select',
+			'jetpack/field-date',
+			'jetpack/field-consent',
+			'jetpack/field-rating',
+			'jetpack/field-text',
+			'jetpack/field-number',
+			'jetpack/field-file-upload',
+
+			// Supporting blocks.
+			'jetpack/button',
+			'jetpack/label',
+			'jetpack/input',
+			'jetpack/options',
+			'jetpack/option',
+			'jetpack/phone-input',
+
+			// Multistep blocks.
+			'jetpack/form-step',
+			'jetpack/form-step-container',
+			'jetpack/form-step-divider',
+			'jetpack/form-step-navigation',
+			'jetpack/form-progress-indicator',
+
+			// Core blocks for rich content.
+			'core/paragraph',
+			'core/heading',
+			'core/list',
+			'core/list-item',
+			'core/separator',
+			'core/spacer',
+			'core/columns',
+			'core/column',
+			'core/group',
+			'core/image',
+			'core/html',
 		);
 	}
 }

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -11,6 +11,7 @@ use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Constants;
 use Automattic\Jetpack\Extensions\Contact_Form\Contact_Form_Block;
 use Automattic\Jetpack\Forms\Jetpack_Forms;
+use Automattic\Jetpack\Forms\Reusable_Forms;
 use Automattic\Jetpack\Forms\Service\Form_Webhooks;
 use Automattic\Jetpack\Forms\Service\Hostinger_Reach_Integration;
 use Automattic\Jetpack\Forms\Service\MailPoet_Integration;
@@ -265,6 +266,13 @@ class Contact_Form_Plugin {
 				'map_meta_cap'          => true,
 			)
 		);
+
+		// Initialize Reusable Forms feature if enabled
+		$feature_flags = apply_filters( 'jetpack_block_editor_feature_flags', array() );
+		if ( ! empty( $feature_flags['reusable-forms'] ) ) {
+			Reusable_Forms::init();
+		}
+
 		add_filter( 'wp_untrash_post_status', array( $this, 'untrash_feedback_status_handler' ), 10, 3 );
 
 		// Add to REST API post type allowed list.

--- a/projects/packages/forms/src/contact-form/class-rest-jetpack-form-controller.php
+++ b/projects/packages/forms/src/contact-form/class-rest-jetpack-form-controller.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * Contact_Form_Endpoint class.
+ *
+ * @package automattic/jetpack-forms
+ */
+
+namespace Automattic\Jetpack\Forms\ContactForm;
+
+/**
+ * REST_Jetpack_Form_Controller class.
+ *
+ * Responsible for handling REST API requests for Jetpack forms custom post type.
+ */
+class REST_Jetpack_Form_Controller extends WP_REST_Posts_Controller {
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		parent::__construct( 'jetpack-form' );
+	}
+}

--- a/projects/packages/forms/src/contact-form/class-rest-jetpack-form-controller.php
+++ b/projects/packages/forms/src/contact-form/class-rest-jetpack-form-controller.php
@@ -12,11 +12,66 @@ namespace Automattic\Jetpack\Forms\ContactForm;
  *
  * Responsible for handling REST API requests for Jetpack forms custom post type.
  */
-class REST_Jetpack_Form_Controller extends WP_REST_Posts_Controller {
+class REST_Jetpack_Form_Controller extends \WP_REST_Posts_Controller {
 	/**
 	 * Constructor.
 	 */
 	public function __construct() {
 		parent::__construct( 'jetpack-form' );
+	}
+
+	/**
+	 * Checks if a given request has access to get items.
+	 *
+	 * @param \WP_REST_Request $request Full details about the request.
+	 * @return true|\WP_Error True if the request has read access, WP_Error object otherwise.
+	 */
+	public function get_items_permissions_check( $request ) {
+		$post_type = get_post_type_object( $this->post_type );
+
+		if ( ! current_user_can( $post_type->cap->edit_posts ) ) {
+			return new \WP_Error(
+				'rest_cannot_read',
+				__( 'Sorry, you are not allowed to view forms.', 'jetpack-forms' ),
+				array( 'status' => rest_authorization_required_code() )
+			);
+		}
+
+		return parent::get_items_permissions_check( $request );
+	}
+
+	/**
+	 * Checks if a given request has access to create items.
+	 *
+	 * @param \WP_REST_Request $request Full details about the request.
+	 * @return true|\WP_Error True if the request has access to create items, WP_Error object otherwise.
+	 */
+	public function create_item_permissions_check( $request ) {
+		$post_type = get_post_type_object( $this->post_type );
+
+		if ( ! current_user_can( $post_type->cap->create_posts ) ) {
+			return new \WP_Error(
+				'rest_cannot_create',
+				__( 'Sorry, you are not allowed to create forms.', 'jetpack-forms' ),
+				array( 'status' => rest_authorization_required_code() )
+			);
+		}
+
+		return parent::create_item_permissions_check( $request );
+	}
+
+	/**
+	 * Checks if a jetpack-form can be read.
+	 *
+	 * @param WP_Post $post Post object that backs the block.
+	 * @return bool Whether the pattern can be read.
+	 */
+	public function check_read_permission( $post ) {
+		// By default the read_post capability is mapped to edit_posts.
+		if ( ! current_user_can( 'read_post', $post->ID ) ) {
+			return false;
+		}
+
+		return parent::check_read_permission( $post );
 	}
 }

--- a/projects/packages/forms/tests/php/contact-form/Reusable_Forms_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Reusable_Forms_Test.php
@@ -1,0 +1,317 @@
+<?php
+/**
+ * Unit Tests for Reusable_Forms.
+ *
+ * @package automattic/jetpack-forms
+ */
+
+namespace Automattic\Jetpack\Forms\ContactForm;
+
+use Automattic\Jetpack\Forms\Reusable_Forms;
+use PHPUnit\Framework\TestCase;
+use WorDBless\Options as WorDBless_Options;
+use WorDBless\Users as WorDBless_Users;
+use WP_REST_Request;
+use WP_REST_Server;
+
+/**
+ * Unit tests for the Reusable Forms feature.
+ *
+ * To run this test, you can use the following command: (from the projects/packages/forms directory)
+ *
+ * composer test-php tests/php/contact-form/Reusable_Forms_Test.php
+ */
+class Reusable_Forms_Test extends TestCase {
+
+	/**
+	 * REST Server object.
+	 *
+	 * @var WP_REST_Server
+	 */
+	private $server;
+
+	/**
+	 * The current user id.
+	 *
+	 * @var int
+	 */
+	private static $user_id;
+
+	/**
+	 * Setting up the test.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		global $wp_rest_server;
+
+		$wp_rest_server = new WP_REST_Server();
+		$this->server   = $wp_rest_server;
+
+		do_action( 'rest_api_init' );
+
+		self::$user_id = wp_insert_user(
+			array(
+				'user_login' => 'test_admin',
+				'user_pass'  => '123',
+				'role'       => 'administrator',
+			)
+		);
+		wp_set_current_user( self::$user_id );
+	}
+
+	/**
+	 * Returning the environment into its initial state.
+	 */
+	public function tearDown(): void {
+		parent::tearDown();
+		WorDBless_Options::init()->clear_options();
+		WorDBless_Users::init()->clear_all_users();
+
+		unset( $_SERVER['REQUEST_METHOD'] );
+		$_GET = array();
+
+		// Unregister the post type if it was registered
+		unregister_post_type( 'jetpack-form' );
+	}
+
+	/**
+	 * Test that the post type is registered when init is called.
+	 */
+	public function test_init_registers_post_type() {
+		Reusable_Forms::init();
+
+		$this->assertTrue( post_type_exists( 'jetpack-form' ), 'jetpack-form post type should be registered' );
+	}
+
+	/**
+	 * Test that the post type has the correct configuration.
+	 */
+	public function test_post_type_configuration() {
+		Reusable_Forms::init();
+
+		$post_type_object = get_post_type_object( 'jetpack-form' );
+
+		$this->assertNotNull( $post_type_object, 'Post type object should exist' );
+		$this->assertEquals( 'jetpack-form', $post_type_object->name );
+		$this->assertFalse( $post_type_object->public, 'Post type should not be public' );
+		$this->assertTrue( $post_type_object->show_ui, 'Post type should show UI' );
+		$this->assertFalse( $post_type_object->show_in_menu, 'Post type should not show in menu' );
+		$this->assertTrue( $post_type_object->show_in_rest, 'Post type should be available in REST' );
+		$this->assertEquals( 'jetpack-forms', $post_type_object->rest_base, 'REST base should be jetpack-forms' );
+	}
+
+	/**
+	 * Test that the post type supports the correct features.
+	 */
+	public function test_post_type_supports() {
+		Reusable_Forms::init();
+
+		$this->assertTrue( post_type_supports( 'jetpack-form', 'title' ), 'Should support title' );
+		$this->assertTrue( post_type_supports( 'jetpack-form', 'excerpt' ), 'Should support excerpt' );
+		$this->assertTrue( post_type_supports( 'jetpack-form', 'editor' ), 'Should support editor' );
+		$this->assertTrue( post_type_supports( 'jetpack-form', 'revisions' ), 'Should support revisions' );
+		$this->assertTrue( post_type_supports( 'jetpack-form', 'custom-fields' ), 'Should support custom-fields' );
+	}
+
+	/**
+	 * Test that the REST endpoints are registered.
+	 */
+	public function test_rest_endpoints_are_registered() {
+		Reusable_Forms::init();
+
+		// Re-initialize REST server to pick up new routes
+		do_action( 'rest_api_init' );
+
+		$routes = $this->server->get_routes();
+
+		$this->assertArrayHasKey( '/wp/v2/jetpack-forms', $routes, 'Main endpoint should be registered' );
+		$this->assertArrayHasKey( '/wp/v2/jetpack-forms/(?P<id>[\d]+)', $routes, 'Single item endpoint should be registered' );
+	}
+
+	/**
+	 * Test that GET request to jetpack-forms endpoint works.
+	 */
+	public function test_get_jetpack_forms_returns_200() {
+		Reusable_Forms::init();
+		do_action( 'rest_api_init' );
+
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/jetpack-forms' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 200, $response->get_status(), 'GET request should return 200' );
+		$this->assertIsArray( $response->get_data(), 'Response should be an array' );
+	}
+
+	/**
+	 * Test that users without edit_posts capability cannot access jetpack-forms endpoint.
+	 */
+	public function test_get_jetpack_forms_unauthorized_returns_401() {
+		Reusable_Forms::init();
+		do_action( 'rest_api_init' );
+
+		// Create a subscriber user (no edit_posts capability)
+		$subscriber_id = wp_insert_user(
+			array(
+				'user_login' => 'test_subscriber',
+				'user_pass'  => '123',
+				'role'       => 'subscriber',
+			)
+		);
+		wp_set_current_user( $subscriber_id );
+
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/jetpack-forms' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertContains( $response->get_status(), array( 401, 403 ), 'Unauthorized request should return 401 or 403' );
+	}
+
+	/**
+	 * Test creating a jetpack-form via REST API.
+	 */
+	public function test_create_jetpack_form_via_rest() {
+		Reusable_Forms::init();
+		do_action( 'rest_api_init' );
+
+		// Ensure user has proper capabilities
+		$user = wp_get_current_user();
+		$user->add_cap( 'edit_posts' );
+		$user->add_cap( 'publish_posts' );
+
+		$request = new WP_REST_Request( 'POST', '/wp/v2/jetpack-forms' );
+		$request->set_param( 'title', 'Test Reusable Form' );
+		$request->set_param( 'status', 'publish' );
+		$request->set_param( 'content', '<!-- wp:jetpack/contact-form --><div class="wp-block-jetpack-contact-form">Test Form</div><!-- /wp:jetpack/contact-form -->' );
+
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 201, $response->get_status(), 'POST request should return 201' );
+
+		$data  = $response->get_data();
+		$title = isset( $data['title']['raw'] ) ? $data['title']['raw'] : $data['title']['rendered'];
+		$this->assertEquals( 'Test Reusable Form', $title, 'Title should match' );
+		$this->assertEquals( 'publish', $data['status'], 'Status should be publish' );
+	}
+
+	/**
+	 * Test retrieving a specific jetpack-form via REST API.
+	 */
+	public function test_get_single_jetpack_form_via_rest() {
+		Reusable_Forms::init();
+		do_action( 'rest_api_init' );
+
+		// Create a form first
+		$post_id = wp_insert_post(
+			array(
+				'post_type'    => 'jetpack-form',
+				'post_title'   => 'Single Test Form',
+				'post_content' => 'Form content',
+				'post_status'  => 'publish',
+			)
+		);
+
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/jetpack-forms/' . $post_id );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 200, $response->get_status(), 'GET single item should return 200' );
+
+		$data = $response->get_data();
+		// Title might be in different formats depending on context
+		$title = isset( $data['title']['raw'] ) ? $data['title']['raw'] : $data['title']['rendered'];
+		$this->assertEquals( 'Single Test Form', $title, 'Title should match' );
+		$this->assertEquals( $post_id, $data['id'], 'ID should match' );
+	}
+
+	/**
+	 * Test updating a jetpack-form via REST API.
+	 */
+	public function test_update_jetpack_form_via_rest() {
+		Reusable_Forms::init();
+		do_action( 'rest_api_init' );
+
+		// Ensure user has proper capabilities
+		$user = wp_get_current_user();
+		$user->add_cap( 'edit_posts' );
+		$user->add_cap( 'edit_published_posts' );
+
+		// Create a form first
+		$post_id = wp_insert_post(
+			array(
+				'post_type'    => 'jetpack-form',
+				'post_title'   => 'Original Title',
+				'post_content' => 'Original content',
+				'post_status'  => 'publish',
+			)
+		);
+
+		$request = new WP_REST_Request( 'PUT', '/wp/v2/jetpack-forms/' . $post_id );
+		$request->set_param( 'title', 'Updated Title' );
+
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 200, $response->get_status(), 'PUT request should return 200' );
+
+		$data  = $response->get_data();
+		$title = isset( $data['title']['raw'] ) ? $data['title']['raw'] : $data['title']['rendered'];
+		$this->assertEquals( 'Updated Title', $title, 'Title should be updated' );
+	}
+
+	/**
+	 * Test deleting a jetpack-form via REST API.
+	 */
+	public function test_delete_jetpack_form_via_rest() {
+		Reusable_Forms::init();
+		do_action( 'rest_api_init' );
+
+		// Ensure user has proper capabilities
+		$user = wp_get_current_user();
+		$user->add_cap( 'delete_posts' );
+		$user->add_cap( 'delete_published_posts' );
+
+		// Create a form first
+		$post_id = wp_insert_post(
+			array(
+				'post_type'    => 'jetpack-form',
+				'post_title'   => 'Form to Delete',
+				'post_content' => 'Form content',
+				'post_status'  => 'publish',
+			)
+		);
+
+		$request  = new WP_REST_Request( 'DELETE', '/wp/v2/jetpack-forms/' . $post_id );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 200, $response->get_status(), 'DELETE request should return 200' );
+
+		// Verify the post is trashed
+		$post = get_post( $post_id );
+		$this->assertEquals( 'trash', $post->post_status, 'Post should be in trash' );
+	}
+
+	/**
+	 * Test that the REST controller class is correctly assigned.
+	 */
+	public function test_rest_controller_class() {
+		Reusable_Forms::init();
+
+		$post_type_object = get_post_type_object( 'jetpack-form' );
+
+		$this->assertEquals(
+			'Automattic\Jetpack\Forms\ContactForm\REST_Jetpack_Form_Controller',
+			$post_type_object->rest_controller_class,
+			'REST controller class should be correctly set'
+		);
+	}
+
+	/**
+	 * Test that the post type has correct capability mappings.
+	 */
+	public function test_post_type_capabilities() {
+		Reusable_Forms::init();
+
+		$post_type_object = get_post_type_object( 'jetpack-form' );
+
+		$this->assertEquals( 'edit_posts', $post_type_object->cap->read, 'Read capability should be edit_posts' );
+		$this->assertEquals( 'publish_posts', $post_type_object->cap->create_posts, 'Create capability should be publish_posts' );
+		$this->assertEquals( 'edit_posts', $post_type_object->cap->edit_posts, 'Edit posts capability should be edit_posts' );
+	}
+}

--- a/projects/packages/forms/tools/webpack.config.blocks.js
+++ b/projects/packages/forms/tools/webpack.config.blocks.js
@@ -20,6 +20,7 @@ const sharedWebpackConfig = {
 	entry: {
 		editor: './src/blocks/contact-form/editor.ts',
 		view: './src/blocks/contact-form/view.ts',
+		'form/admin': './src/blocks/form/admin.js',
 		'form-progress-indicator/style': './src/blocks/form-progress-indicator/style.scss',
 		'form-step-navigation/style': './src/blocks/form-step-navigation/style.scss',
 		'field-rating/style': './src/blocks/field-rating/style.scss',


### PR DESCRIPTION
### Do not merge!

https://github.com/user-attachments/assets/fedf2107-4eaf-4103-b58d-193d306482b7


## Proposed changes:
* Update the variation picker to create a new jetpack-form custom post type and add the ref attribute. 
* Store the whole form block on the custom post type. 
* Form innerblock as well as attributes get inherited from the custom post type. 
* Limit the number 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
- Enable feature flag:
  ```php
  add_filter( 'jetpack_block_editor_feature_flags', function ( $features ) {
  	$features['reusable-forms'] = true;
  	return $features;
  } );
  ```
- Add a new form on a page 
- Edit the form from within the form editor. 

