### PR TITLE
Hook into new filter to allow toggling unified ai experience.

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-agents-manager-unified-experience-toggle-logic
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-agents-manager-unified-experience-toggle-logic
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Agents Manager: implement logic to toggle unified chat experience.

--- a/projects/packages/jetpack-mu-wpcom/src/features/agents-manager/class-agents-manager.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/agents-manager/class-agents-manager.php
@@ -148,15 +148,21 @@ class Agents_Manager {
 		$user_id = get_current_user_id();
 
 		if ( ! $user_id ) {
+			error_log( '[Agents Manager Debug] should_use_unified_experience: no user_id, returning false' );
 			return false;
 		}
 
 		$is_simple_site = ( new \Automattic\Jetpack\Status\Host() )->is_wpcom_simple();
+		error_log( '[Agents Manager Debug] should_use_unified_experience: is_simple_site = ' . ( $is_simple_site ? 'true' : 'false' ) );
+
 		if ( $is_simple_site ) {
 			// On Simple sites, evaluate locally.
 			// Check Automattician and opt-in setting.
 			$is_automattician = function_exists( '\is_automattician' ) && \is_automattician( $user_id );
-			if ( $is_automattician && $this->has_unified_chat_opt_in_enabled( $user_id ) ) {
+			$has_opt_in       = $this->has_unified_chat_opt_in_enabled( $user_id );
+			error_log( '[Agents Manager Debug] Simple site: is_automattician = ' . ( $is_automattician ? 'true' : 'false' ) . ', has_opt_in = ' . ( $has_opt_in ? 'true' : 'false' ) );
+			if ( $is_automattician && $has_opt_in ) {
+				error_log( '[Agents Manager Debug] should_use_unified_experience: returning true (Simple + automattician + opt-in)' );
 				return true;
 			}
 		}
@@ -164,12 +170,15 @@ class Agents_Manager {
 		// On WoA and Garden sites, delegate to wpcom via the /me/preferences endpoint.
 		// This avoids duplicating rollout logic and handles cases where
 		// wpcom-specific functions (like get_user_attribute) aren't available.
-		if ( $this->get_unified_experience_from_wpcom() ) {
+		$wpcom_result = $this->get_unified_experience_from_wpcom();
+		error_log( '[Agents Manager Debug] should_use_unified_experience: get_unified_experience_from_wpcom() = ' . ( $wpcom_result ? 'true' : 'false' ) );
+		if ( $wpcom_result ) {
 			return true;
 		}
 
 		// False, for now.
 		// In the future: users with a big sky site (similar to https://github.a8c.com/Automattic/wpcom/pull/196449/files), a big-sky free trial or a paid plan.
+		error_log( '[Agents Manager Debug] should_use_unified_experience: returning false (no conditions met)' );
 		return false;
 	}
 
@@ -207,6 +216,7 @@ class Agents_Manager {
 		static $cached_value = null;
 
 		if ( $cached_value !== null ) {
+			error_log( '[Agents Manager Debug] get_unified_experience_from_wpcom: returning cached value = ' . ( $cached_value ? 'true' : 'false' ) );
 			return $cached_value;
 		}
 
@@ -218,12 +228,14 @@ class Agents_Manager {
 		);
 
 		if ( is_wp_error( $wpcom_request ) ) {
+			error_log( '[Agents Manager Debug] get_unified_experience_from_wpcom: WP_Error = ' . $wpcom_request->get_error_message() );
 			$cached_value = false;
 			return false;
 		}
 
 		$response_code = wp_remote_retrieve_response_code( $wpcom_request );
 		if ( 200 !== $response_code ) {
+			error_log( '[Agents Manager Debug] get_unified_experience_from_wpcom: HTTP ' . $response_code );
 			$cached_value = false;
 			return false;
 		}
@@ -231,8 +243,11 @@ class Agents_Manager {
 		$body         = wp_remote_retrieve_body( $wpcom_request );
 		$decoded_body = json_decode( $body, true );
 
+		error_log( '[Agents Manager Debug] get_unified_experience_from_wpcom: response body = ' . $body );
+
 		// The response is the value of the preference directly when using preference_key.
 		$cached_value = ! empty( $decoded_body );
+		error_log( '[Agents Manager Debug] get_unified_experience_from_wpcom: final value = ' . ( $cached_value ? 'true' : 'false' ) );
 		return $cached_value;
 	}
 }

--- a/projects/packages/jetpack-mu-wpcom/src/features/agents-manager/class-agents-manager.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/agents-manager/class-agents-manager.php
@@ -151,18 +151,20 @@ class Agents_Manager {
 			return false;
 		}
 
-		// On Atomic sites, delegate to wpcom via the /me endpoint.
-		// This avoids duplicating rollout logic and handles cases where
-		// wpcom-specific functions (like get_user_attribute) aren't available.
-		$is_atomic_site = ( new \Automattic\Jetpack\Status\Host() )->is_woa_site();
-		if ( $is_atomic_site ) {
-			return $this->get_unified_experience_from_wpcom();
+		$is_simple_site = ( new \Automattic\Jetpack\Status\Host() )->is_wpcom_simple();
+		if ( $is_simple_site ) {
+			// On Simple sites, evaluate locally.
+			// Check Automattician and opt-in setting.
+			$is_automattician = function_exists( '\is_automattician' ) && \is_automattician( $user_id );
+			if ( $is_automattician && $this->has_unified_chat_opt_in_enabled( $user_id ) ) {
+				return true;
+			}
 		}
 
-		// On Simple sites, evaluate locally.
-		// Check Automattician and opt-in setting.
-		$is_automattician = function_exists( '\is_automattician' ) && \is_automattician( $user_id );
-		if ( $is_automattician && $this->has_unified_chat_opt_in_enabled( $user_id ) ) {
+		// On WoA and Garden sites, delegate to wpcom via the /me/preferences endpoint.
+		// This avoids duplicating rollout logic and handles cases where
+		// wpcom-specific functions (like get_user_attribute) aren't available.
+		if ( $this->get_unified_experience_from_wpcom() ) {
 			return true;
 		}
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/agents-manager/class-agents-manager.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/agents-manager/class-agents-manager.php
@@ -148,21 +148,15 @@ class Agents_Manager {
 		$user_id = get_current_user_id();
 
 		if ( ! $user_id ) {
-			error_log( '[Agents Manager Debug] should_use_unified_experience: no user_id, returning false' );
 			return false;
 		}
 
 		$is_simple_site = ( new \Automattic\Jetpack\Status\Host() )->is_wpcom_simple();
-		error_log( '[Agents Manager Debug] should_use_unified_experience: is_simple_site = ' . ( $is_simple_site ? 'true' : 'false' ) );
-
 		if ( $is_simple_site ) {
 			// On Simple sites, evaluate locally.
 			// Check Automattician and opt-in setting.
 			$is_automattician = function_exists( '\is_automattician' ) && \is_automattician( $user_id );
-			$has_opt_in       = $this->has_unified_chat_opt_in_enabled( $user_id );
-			error_log( '[Agents Manager Debug] Simple site: is_automattician = ' . ( $is_automattician ? 'true' : 'false' ) . ', has_opt_in = ' . ( $has_opt_in ? 'true' : 'false' ) );
-			if ( $is_automattician && $has_opt_in ) {
-				error_log( '[Agents Manager Debug] should_use_unified_experience: returning true (Simple + automattician + opt-in)' );
+			if ( $is_automattician && $this->has_unified_chat_opt_in_enabled( $user_id ) ) {
 				return true;
 			}
 		}
@@ -170,15 +164,12 @@ class Agents_Manager {
 		// On WoA and Garden sites, delegate to wpcom via the /me/preferences endpoint.
 		// This avoids duplicating rollout logic and handles cases where
 		// wpcom-specific functions (like get_user_attribute) aren't available.
-		$wpcom_result = $this->get_unified_experience_from_wpcom();
-		error_log( '[Agents Manager Debug] should_use_unified_experience: get_unified_experience_from_wpcom() = ' . ( $wpcom_result ? 'true' : 'false' ) );
-		if ( $wpcom_result ) {
+		if ( $this->get_unified_experience_from_wpcom() ) {
 			return true;
 		}
 
 		// False, for now.
 		// In the future: users with a big sky site (similar to https://github.a8c.com/Automattic/wpcom/pull/196449/files), a big-sky free trial or a paid plan.
-		error_log( '[Agents Manager Debug] should_use_unified_experience: returning false (no conditions met)' );
 		return false;
 	}
 
@@ -216,7 +207,6 @@ class Agents_Manager {
 		static $cached_value = null;
 
 		if ( $cached_value !== null ) {
-			error_log( '[Agents Manager Debug] get_unified_experience_from_wpcom: returning cached value = ' . ( $cached_value ? 'true' : 'false' ) );
 			return $cached_value;
 		}
 
@@ -228,14 +218,12 @@ class Agents_Manager {
 		);
 
 		if ( is_wp_error( $wpcom_request ) ) {
-			error_log( '[Agents Manager Debug] get_unified_experience_from_wpcom: WP_Error = ' . $wpcom_request->get_error_message() );
 			$cached_value = false;
 			return false;
 		}
 
 		$response_code = wp_remote_retrieve_response_code( $wpcom_request );
 		if ( 200 !== $response_code ) {
-			error_log( '[Agents Manager Debug] get_unified_experience_from_wpcom: HTTP ' . $response_code );
 			$cached_value = false;
 			return false;
 		}
@@ -243,11 +231,8 @@ class Agents_Manager {
 		$body         = wp_remote_retrieve_body( $wpcom_request );
 		$decoded_body = json_decode( $body, true );
 
-		error_log( '[Agents Manager Debug] get_unified_experience_from_wpcom: response body = ' . $body );
-
 		// The response is the value of the preference directly when using preference_key.
 		$cached_value = ! empty( $decoded_body );
-		error_log( '[Agents Manager Debug] get_unified_experience_from_wpcom: final value = ' . ( $cached_value ? 'true' : 'false' ) );
 		return $cached_value;
 	}
 }

--- a/projects/packages/jetpack-mu-wpcom/src/features/agents-manager/class-agents-manager.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/agents-manager/class-agents-manager.php
@@ -200,6 +200,8 @@ class Agents_Manager {
 	 *
 	 * Calls /me/preferences endpoint which is accessible via Jetpack user tokens.
 	 *
+	 * @codeCoverageIgnore Cannot test without mocking Jetpack Connection Client.
+	 *
 	 * @return bool Whether user should see unified experience.
 	 */
 	private function get_unified_experience_from_wpcom() {

--- a/projects/packages/jetpack-mu-wpcom/src/features/agents-manager/class-agents-manager.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/agents-manager/class-agents-manager.php
@@ -27,6 +27,7 @@ class Agents_Manager {
 		add_action( 'admin_enqueue_scripts', array( $this, 'add_inline_script' ), 101 );
 		add_action( 'wp_enqueue_scripts', array( $this, 'add_inline_script' ), 101 );
 		add_action( 'next_admin_init', array( $this, 'add_inline_script' ), 1001 );
+		add_filter( 'agents_manager_use_unified_experience', array( $this, 'should_use_unified_experience' ) );
 	}
 
 	/**
@@ -124,6 +125,65 @@ class Agents_Manager {
 		require_once __DIR__ . '/class-wp-rest-agents-manager-persisted-open-state.php';
 		$controller = new WP_REST_Agents_Manager_Persisted_Open_State();
 		$controller->register_rest_route();
+	}
+
+	/**
+	 * Determine if user should see unified experience.
+	 *
+	 * @param bool $default Default value (false).
+	 * @return bool
+	 */
+	public function should_use_unified_experience( $default ) {
+		$user_id = get_current_user_id();
+
+		if ( ! $user_id ) {
+			return $default;
+		}
+
+		// Check hardcoded allowlist
+		if ( $this->is_user_in_unified_experience_allowlist( $user_id ) ) {
+			return true;
+		}
+
+		// Check Automattician opt-in setting (wpcom only)
+		if ( $this->has_unified_chat_enabled( $user_id ) ) {
+			return true;
+		}
+
+		return $default;
+	}
+
+	/**
+	 * Check if user has enabled unified chat in their Automattician options.
+	 *
+	 * This checks the a11n_unified_chat attribute set via the wpcom profile settings.
+	 * Only available on wpcom where get_user_attribute() exists.
+	 *
+	 * @param int $user_id User ID.
+	 * @return bool
+	 */
+	private function has_unified_chat_enabled( $user_id ) {
+		if ( ! function_exists( 'get_user_attribute' ) ) {
+			return false;
+		}
+
+		return (bool) get_user_attribute( $user_id, 'a11n_unified_chat' );
+	}
+
+	/**
+	 * Check if user is in the unified experience allowlist.
+	 *
+	 * Hardcoded list of user IDs for initial rollout.
+	 *
+	 * @param int $user_id User ID.
+	 * @return bool
+	 */
+	private function is_user_in_unified_experience_allowlist( $user_id ) {
+		$allowlist = array(
+			// Add user IDs here for rollout
+		);
+
+		return in_array( $user_id, $allowlist, true );
 	}
 }
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/agents-manager/class-agents-manager.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/agents-manager/class-agents-manager.php
@@ -131,36 +131,35 @@ class Agents_Manager {
 	/**
 	 * Determine if user should see unified experience.
 	 *
-	 * @param bool $default Default value (false).
-	 *
 	 * @return bool
 	 */
-	public function should_use_unified_experience( $default ) {
+	public function should_use_unified_experience() {
 		$user_id = get_current_user_id();
 
 		if ( ! $user_id ) {
-			return $default;
+			return false;
 		}
 
-		// Check Automattician opt-in setting (wpcom only)
-		if ( $this->has_unified_chat_enabled( $user_id ) ) {
+		// Check Automattician and opt-in setting
+		if ( is_automattician( $user_id ) && $this->has_unified_chat_opt_in_enabled( $user_id ) ) {
 			return true;
 		}
 
-		return $default;
+		// False, for now.
+		// In the future: users with a big sky site (similar to https://github.a8c.com/Automattic/wpcom/pull/196449/files), a big-sky free trial or a paid plan.
+		return false;
 	}
 
 	/**
-	 * Check if user has enabled unified chat in their Automattician options.
+	 * Check if user has enabled unified chat opt-in in their Automattician options.
 	 *
 	 * This checks the a11n_unified_chat attribute set via the wpcom profile settings.
-	 * Only available on wpcom where get_user_attribute() exists.
 	 *
 	 * @param int $user_id User ID.
 	 *
 	 * @return bool
 	 */
-	private function has_unified_chat_enabled( $user_id ) {
+	private function has_unified_chat_opt_in_enabled( $user_id ) {
 		if ( ! function_exists( 'get_user_attribute' ) ) {
 			return false;
 		}

--- a/projects/packages/jetpack-mu-wpcom/src/features/agents-manager/class-agents-manager.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/agents-manager/class-agents-manager.php
@@ -151,11 +151,18 @@ class Agents_Manager {
 			return false;
 		}
 
-		// Check Automattician and opt-in setting
-		$is_proxied              = defined( 'AT_PROXIED_REQUEST' ) && AT_PROXIED_REQUEST;
-		$is_automattician        = function_exists( '\is_automattician' ) && \is_automattician( $user_id );
-		$is_likely_automattician = $is_automattician || $is_proxied;
-		if ( $is_likely_automattician && $this->has_unified_chat_opt_in_enabled( $user_id ) ) {
+		// On Atomic sites, delegate to wpcom via the /me endpoint.
+		// This avoids duplicating rollout logic and handles cases where
+		// wpcom-specific functions (like get_user_attribute) aren't available.
+		$is_atomic_site = ( new \Automattic\Jetpack\Status\Host() )->is_woa_site();
+		if ( $is_atomic_site ) {
+			return $this->get_unified_experience_from_wpcom();
+		}
+
+		// On Simple sites, evaluate locally.
+		// Check Automattician and opt-in setting.
+		$is_automattician = function_exists( '\is_automattician' ) && \is_automattician( $user_id );
+		if ( $is_automattician && $this->has_unified_chat_opt_in_enabled( $user_id ) ) {
 			return true;
 		}
 
@@ -168,91 +175,58 @@ class Agents_Manager {
 	 * Check if user has enabled unified chat opt-in in their Automattician options.
 	 *
 	 * This checks the a11n_unified_chat attribute set via the wpcom profile settings.
+	 * Only used on Simple sites where get_user_attribute is available.
 	 *
 	 * @param int $user_id User ID.
 	 *
 	 * @return bool
 	 */
 	private function has_unified_chat_opt_in_enabled( $user_id ) {
-		return (bool) $this->get_user_attribute( $user_id, 'a11n_unified_chat' );
+		if ( ! function_exists( '\get_user_attribute' ) ) {
+			return false;
+		}
+
+		return (bool) \get_user_attribute( $user_id, 'a11n_unified_chat' );
 	}
 
 	/**
-	 * Get a user attribute, handling both Simple and Atomic (WoA) sites.
+	 * Get unified experience flag from wpcom via Jetpack Connection.
 	 *
-	 * On Simple sites, uses the native get_user_attribute function.
-	 * On Atomic sites, requests the attribute via Jetpack Connection API.
+	 * Used on Atomic sites to delegate the decision to wpcom, which has
+	 * access to user attributes and can evaluate the rollout logic.
 	 *
-	 * @param int    $user_id   User ID.
-	 * @param string $attribute The attribute name to retrieve.
-	 *
-	 * @return mixed The attribute value, or null if not found.
+	 * @return bool Whether user should see unified experience.
 	 */
-	private function get_user_attribute( $user_id, $attribute ) {
-		$is_atomic_site = ( new \Automattic\Jetpack\Status\Host() )->is_woa_site();
-
-		if ( $is_atomic_site ) {
-			return $this->get_user_attribute_via_api( $attribute );
-		}
-
-		// Simple site - use native function
-		if ( function_exists( '\get_user_attribute' ) ) {
-			return \get_user_attribute( $user_id, $attribute );
-		}
-
-		return null;
-	}
-
-	/**
-	 * Request user attributes via Jetpack Connection API.
-	 *
-	 * Used on Atomic sites where get_user_attribute is not available.
-	 * Pattern based on wpcom_launchpad_request_user_attributes.
-	 *
-	 * @param string      $attribute      The attribute name to retrieve.
-	 * @param object|null $client_wrapper Optional client wrapper for testing.
-	 *
-	 * @return mixed The attribute value, or null if not found or on error.
-	 */
-	private function get_user_attribute_via_api( $attribute, $client_wrapper = null ) {
+	private function get_unified_experience_from_wpcom() {
 		// Use static cache to avoid multiple HTTP requests in same request.
-		static $cached_attributes = array();
+		static $cached_value = null;
 
-		if ( isset( $cached_attributes[ $attribute ] ) ) {
-			return $cached_attributes[ $attribute ];
+		if ( $cached_value !== null ) {
+			return $cached_value;
 		}
 
-		$query_params  = build_query( array( 'attributes' => array( $attribute ) ) );
-		$client        = $client_wrapper ? $client_wrapper : new \Automattic\Jetpack\Connection\Client();
-		$wpcom_request = $client->wpcom_json_api_request_as_user(
-			'/jetpack-user-attributes?' . $query_params,
-			'v2',
-			array(
-				'method'  => 'GET',
-				'headers' => array(
-					'X-Forwarded-For' => ( new \Automattic\Jetpack\Status\Visitor() )->get_ip( true ),
-				),
-			)
+		$wpcom_request = \Automattic\Jetpack\Connection\Client::wpcom_json_api_request_as_user(
+			'/me?fields=unified_ai_chat',
+			'1.1',
+			array( 'method' => 'GET' )
 		);
+
+		if ( is_wp_error( $wpcom_request ) ) {
+			$cached_value = false;
+			return false;
+		}
 
 		$response_code = wp_remote_retrieve_response_code( $wpcom_request );
 		if ( 200 !== $response_code ) {
-			return null;
+			$cached_value = false;
+			return false;
 		}
 
 		$body         = wp_remote_retrieve_body( $wpcom_request );
 		$decoded_body = json_decode( $body );
 
-		if ( ! isset( $decoded_body->user_attributes ) ) {
-			return null;
-		}
-
-		$user_attributes = get_object_vars( $decoded_body->user_attributes );
-
-		// Cache all returned attributes
-		$cached_attributes = array_merge( $cached_attributes, $user_attributes );
-
-		return $cached_attributes[ $attribute ] ?? null;
+		$cached_value = ! empty( $decoded_body->unified_ai_chat );
+		return $cached_value;
 	}
 }
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/agents-manager/class-agents-manager.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/agents-manager/class-agents-manager.php
@@ -174,7 +174,7 @@ class Agents_Manager {
 	/**
 	 * Check if user has enabled unified chat opt-in in their Automattician options.
 	 *
-	 * This checks the a11n_unified_chat attribute set via the wpcom profile settings.
+	 * This checks the unified_ai_chat calypso preference set via the wpcom profile settings.
 	 * Only used on Simple sites where get_user_attribute is available.
 	 *
 	 * @param int $user_id User ID.
@@ -186,7 +186,8 @@ class Agents_Manager {
 			return false;
 		}
 
-		return (bool) \get_user_attribute( $user_id, 'a11n_unified_chat' );
+		$calypso_prefs = \get_user_attribute( $user_id, 'calypso_preferences' );
+		return ! empty( $calypso_prefs['unified_ai_chat'] );
 	}
 
 	/**
@@ -194,6 +195,8 @@ class Agents_Manager {
 	 *
 	 * Used on Atomic sites to delegate the decision to wpcom, which has
 	 * access to user attributes and can evaluate the rollout logic.
+	 *
+	 * Calls /me/preferences endpoint which is accessible via Jetpack user tokens.
 	 *
 	 * @return bool Whether user should see unified experience.
 	 */
@@ -205,9 +208,10 @@ class Agents_Manager {
 			return $cached_value;
 		}
 
+		// Call /me/preferences via wpcom/v2 namespace (works with Jetpack user tokens).
 		$wpcom_request = \Automattic\Jetpack\Connection\Client::wpcom_json_api_request_as_user(
-			'/me?fields=unified_ai_chat',
-			'1.1',
+			'/me/preferences?preference_key=unified_ai_chat',
+			'2',
 			array( 'method' => 'GET' )
 		);
 
@@ -223,9 +227,10 @@ class Agents_Manager {
 		}
 
 		$body         = wp_remote_retrieve_body( $wpcom_request );
-		$decoded_body = json_decode( $body );
+		$decoded_body = json_decode( $body, true );
 
-		$cached_value = ! empty( $decoded_body->unified_ai_chat );
+		// The response is the value of the preference directly when using preference_key.
+		$cached_value = ! empty( $decoded_body );
 		return $cached_value;
 	}
 }

--- a/projects/packages/jetpack-mu-wpcom/src/features/agents-manager/class-agents-manager.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/agents-manager/class-agents-manager.php
@@ -152,7 +152,10 @@ class Agents_Manager {
 		}
 
 		// Check Automattician and opt-in setting
-		if ( is_automattician( $user_id ) && $this->has_unified_chat_opt_in_enabled( $user_id ) ) {
+		$is_proxied              = defined( 'AT_PROXIED_REQUEST' ) && AT_PROXIED_REQUEST;
+		$is_automattician        = function_exists( '\is_automattician' ) && \is_automattician( $user_id );
+		$is_likely_automattician = $is_automattician || $is_proxied;
+		if ( $is_likely_automattician && $this->has_unified_chat_opt_in_enabled( $user_id ) ) {
 			return true;
 		}
 
@@ -171,11 +174,85 @@ class Agents_Manager {
 	 * @return bool
 	 */
 	private function has_unified_chat_opt_in_enabled( $user_id ) {
-		if ( ! function_exists( 'get_user_attribute' ) ) {
-			return false;
+		return (bool) $this->get_user_attribute( $user_id, 'a11n_unified_chat' );
+	}
+
+	/**
+	 * Get a user attribute, handling both Simple and Atomic (WoA) sites.
+	 *
+	 * On Simple sites, uses the native get_user_attribute function.
+	 * On Atomic sites, requests the attribute via Jetpack Connection API.
+	 *
+	 * @param int    $user_id   User ID.
+	 * @param string $attribute The attribute name to retrieve.
+	 *
+	 * @return mixed The attribute value, or null if not found.
+	 */
+	private function get_user_attribute( $user_id, $attribute ) {
+		$is_atomic_site = ( new \Automattic\Jetpack\Status\Host() )->is_woa_site();
+
+		if ( $is_atomic_site ) {
+			return $this->get_user_attribute_via_api( $attribute );
 		}
 
-		return (bool) get_user_attribute( $user_id, 'a11n_unified_chat' );
+		// Simple site - use native function
+		if ( function_exists( '\get_user_attribute' ) ) {
+			return \get_user_attribute( $user_id, $attribute );
+		}
+
+		return null;
+	}
+
+	/**
+	 * Request user attributes via Jetpack Connection API.
+	 *
+	 * Used on Atomic sites where get_user_attribute is not available.
+	 * Pattern based on wpcom_launchpad_request_user_attributes.
+	 *
+	 * @param string      $attribute      The attribute name to retrieve.
+	 * @param object|null $client_wrapper Optional client wrapper for testing.
+	 *
+	 * @return mixed The attribute value, or null if not found or on error.
+	 */
+	private function get_user_attribute_via_api( $attribute, $client_wrapper = null ) {
+		// Use static cache to avoid multiple HTTP requests in same request.
+		static $cached_attributes = array();
+
+		if ( isset( $cached_attributes[ $attribute ] ) ) {
+			return $cached_attributes[ $attribute ];
+		}
+
+		$query_params  = build_query( array( 'attributes' => array( $attribute ) ) );
+		$client        = $client_wrapper ? $client_wrapper : new \Automattic\Jetpack\Connection\Client();
+		$wpcom_request = $client->wpcom_json_api_request_as_user(
+			'/jetpack-user-attributes?' . $query_params,
+			'v2',
+			array(
+				'method'  => 'GET',
+				'headers' => array(
+					'X-Forwarded-For' => ( new \Automattic\Jetpack\Status\Visitor() )->get_ip( true ),
+				),
+			)
+		);
+
+		$response_code = wp_remote_retrieve_response_code( $wpcom_request );
+		if ( 200 !== $response_code ) {
+			return null;
+		}
+
+		$body         = wp_remote_retrieve_body( $wpcom_request );
+		$decoded_body = json_decode( $body );
+
+		if ( ! isset( $decoded_body->user_attributes ) ) {
+			return null;
+		}
+
+		$user_attributes = get_object_vars( $decoded_body->user_attributes );
+
+		// Cache all returned attributes
+		$cached_attributes = array_merge( $cached_attributes, $user_attributes );
+
+		return $cached_attributes[ $attribute ] ?? null;
 	}
 }
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/agents-manager/class-agents-manager.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/agents-manager/class-agents-manager.php
@@ -45,6 +45,16 @@ class Agents_Manager {
 		 */
 		$agent_providers = apply_filters( 'agents_manager_agent_providers', array() );
 
+		/**
+		 * Filter to determine if user should see the unified chat experience.
+		 *
+		 * When true, Help Center will render UnifiedAIAgent instead of traditional UI.
+		 * The filter is hooked by should_use_unified_experience() in this class.
+		 *
+		 * @param bool $use_unified_experience Whether to use unified experience. Default false.
+		 */
+		$use_unified_experience = apply_filters( 'agents_manager_use_unified_experience', false );
+
 		// For now, we want this added wherever the help-center script is enqueued.
 		// This allows us to be quite blunt here because the logic for whether to inject this is currently
 		// in the help-center script.
@@ -52,7 +62,8 @@ class Agents_Manager {
 			'help-center',
 			'const agentsManagerData = ' . wp_json_encode(
 				array(
-					'agentProviders' => $agent_providers,
+					'agentProviders'       => $agent_providers,
+					'useUnifiedExperience' => $use_unified_experience,
 				),
 				JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP
 			) . ';',

--- a/projects/packages/jetpack-mu-wpcom/src/features/agents-manager/class-agents-manager.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/agents-manager/class-agents-manager.php
@@ -64,6 +64,7 @@ class Agents_Manager {
 	 * Update the calypso preferences.
 	 *
 	 * @param \stdClass $preferences The preferences.
+	 *
 	 * @return \stdClass The preferences.
 	 */
 	public function calypso_preferences_update( $preferences ) {
@@ -131,6 +132,7 @@ class Agents_Manager {
 	 * Determine if user should see unified experience.
 	 *
 	 * @param bool $default Default value (false).
+	 *
 	 * @return bool
 	 */
 	public function should_use_unified_experience( $default ) {
@@ -138,11 +140,6 @@ class Agents_Manager {
 
 		if ( ! $user_id ) {
 			return $default;
-		}
-
-		// Check hardcoded allowlist
-		if ( $this->is_user_in_unified_experience_allowlist( $user_id ) ) {
-			return true;
 		}
 
 		// Check Automattician opt-in setting (wpcom only)
@@ -160,6 +157,7 @@ class Agents_Manager {
 	 * Only available on wpcom where get_user_attribute() exists.
 	 *
 	 * @param int $user_id User ID.
+	 *
 	 * @return bool
 	 */
 	private function has_unified_chat_enabled( $user_id ) {
@@ -168,22 +166,6 @@ class Agents_Manager {
 		}
 
 		return (bool) get_user_attribute( $user_id, 'a11n_unified_chat' );
-	}
-
-	/**
-	 * Check if user is in the unified experience allowlist.
-	 *
-	 * Hardcoded list of user IDs for initial rollout.
-	 *
-	 * @param int $user_id User ID.
-	 * @return bool
-	 */
-	private function is_user_in_unified_experience_allowlist( $user_id ) {
-		$allowlist = array(
-			// Add user IDs here for rollout
-		);
-
-		return in_array( $user_id, $allowlist, true );
 	}
 }
 

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/agents-manager/Agents_Manager_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/agents-manager/Agents_Manager_Test.php
@@ -7,6 +7,7 @@
 
 namespace A8C\FSE;
 
+use Automattic\Jetpack\Constants;
 use Automattic\Jetpack\Jetpack_Mu_Wpcom;
 use Automattic\Jetpack\Status\Cache;
 use Brain\Monkey\Functions;
@@ -58,8 +59,9 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 		// Log out any logged-in user.
 		wp_set_current_user( 0 );
 
-		// Clear the status cache.
+		// Clear the status cache and constants.
 		Cache::clear();
+		Constants::clear_constants();
 
 		parent::tear_down();
 	}
@@ -281,7 +283,7 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
-	 * Tests that add_inline_script adds script with empty providers by default.
+	 * Tests that add_inline_script adds script with empty providers and useUnifiedExperience false by default.
 	 */
 	public function test_add_inline_script_with_empty_providers() {
 		// Register the help-center script so we can attach inline script to it.
@@ -297,6 +299,7 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 
 		$this->assertStringContainsString( 'const agentsManagerData =', $inline_script );
 		$this->assertStringContainsString( '"agentProviders":[]', $inline_script );
+		$this->assertStringContainsString( '"useUnifiedExperience":false', $inline_script );
 	}
 
 	/**
@@ -335,6 +338,40 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
+	 * Tests that add_inline_script includes useUnifiedExperience true when filter returns true.
+	 */
+	public function test_add_inline_script_includes_use_unified_experience_when_enabled() {
+		// Reset the script registry to ensure test isolation.
+		global $wp_scripts;
+		$wp_scripts = null;
+
+		// Register the help-center script so we can attach inline script to it.
+		wp_register_script( 'help-center', 'https://example.com/help-center.js', array(), '1.0', true );
+
+		// Add a filter to enable unified experience.
+		add_filter(
+			'agents_manager_use_unified_experience',
+			'__return_true',
+			// Use a higher priority to ensure it runs after the class's own filter.
+			20
+		);
+
+		$this->agents_manager->add_inline_script();
+
+		// Re-fetch global after wp_register_script initializes it.
+		$inline_scripts = $wp_scripts->registered['help-center']->extra['before'] ?? array(); // @phan-suppress-current-line PhanTypeExpectedObjectPropAccessButGotNull
+
+		// Find the inline script containing agentsManagerData.
+		$inline_script = implode( "\n", array_filter( $inline_scripts ) );
+
+		$this->assertStringContainsString( 'const agentsManagerData =', $inline_script );
+		$this->assertStringContainsString( '"useUnifiedExperience":true', $inline_script );
+
+		// Clean up the filter.
+		remove_filter( 'agents_manager_use_unified_experience', '__return_true', 20 );
+	}
+
+	/**
 	 * Tests that the agents_manager_use_unified_experience filter is registered.
 	 */
 	public function test_unified_experience_filter_is_registered() {
@@ -355,7 +392,7 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
-	 * Tests that should_use_unified_experience returns false for non-Automattician users.
+	 * Tests that should_use_unified_experience returns false for non-Automattician users on Simple sites.
 	 *
 	 * @runInSeparateProcess
 	 * @preserveGlobalState disabled
@@ -363,6 +400,9 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 	#[RunInSeparateProcess]
 	#[PreserveGlobalState( false )]
 	public function test_should_use_unified_experience_returns_false_for_non_automattician() {
+		// Simulate being on a Simple site.
+		Constants::set_constant( 'IS_WPCOM', true );
+
 		Functions\stubs(
 			array(
 				'is_automattician' => false,
@@ -384,7 +424,7 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
-	 * Tests that should_use_unified_experience returns true for Automattician with opt-in enabled.
+	 * Tests that should_use_unified_experience returns true for Automattician with opt-in enabled on Simple sites.
 	 *
 	 * @runInSeparateProcess
 	 * @preserveGlobalState disabled
@@ -392,10 +432,14 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 	#[RunInSeparateProcess]
 	#[PreserveGlobalState( false )]
 	public function test_should_use_unified_experience_returns_true_for_automattician_with_opt_in() {
+		// Simulate being on a Simple site.
+		Constants::set_constant( 'IS_WPCOM', true );
+
 		Functions\stubs(
 			array(
 				'is_automattician'   => true,
-				'get_user_attribute' => true,
+				// Return calypso_preferences with unified_ai_chat enabled.
+				'get_user_attribute' => array( 'unified_ai_chat' => true ),
 			)
 		);
 
@@ -414,7 +458,7 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
-	 * Tests that should_use_unified_experience returns false for Automattician without opt-in.
+	 * Tests that should_use_unified_experience returns false for Automattician without opt-in on Simple sites.
 	 *
 	 * @runInSeparateProcess
 	 * @preserveGlobalState disabled
@@ -422,10 +466,14 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 	#[RunInSeparateProcess]
 	#[PreserveGlobalState( false )]
 	public function test_should_use_unified_experience_returns_false_for_automattician_without_opt_in() {
+		// Simulate being on a Simple site.
+		Constants::set_constant( 'IS_WPCOM', true );
+
 		Functions\stubs(
 			array(
 				'is_automattician'   => true,
-				'get_user_attribute' => false,
+				// Return calypso_preferences without unified_ai_chat (or with it set to false).
+				'get_user_attribute' => array( 'unified_ai_chat' => false ),
 			)
 		);
 

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/agents-manager/Agents_Manager_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/agents-manager/Agents_Manager_Test.php
@@ -8,6 +8,7 @@
 namespace A8C\FSE;
 
 use Automattic\Jetpack\Jetpack_Mu_Wpcom;
+use Automattic\Jetpack\Status\Cache;
 use Brain\Monkey\Functions;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\PreserveGlobalState;
@@ -56,6 +57,9 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 
 		// Log out any logged-in user.
 		wp_set_current_user( 0 );
+
+		// Clear the status cache.
+		Cache::clear();
 
 		parent::tear_down();
 	}
@@ -446,6 +450,43 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 		wp_set_current_user( 0 );
 
 		$result = apply_filters( 'agents_manager_use_unified_experience', null );
+
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * Tests that should_use_unified_experience returns false on Atomic site when API call fails.
+	 *
+	 * On Atomic sites, the get_user_attribute function is not available, so the code
+	 * falls back to the Jetpack Connection API. If that fails, it should return false.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	#[RunInSeparateProcess]
+	#[PreserveGlobalState( false )]
+	public function test_should_use_unified_experience_returns_false_on_atomic_when_api_fails() {
+		// Simulate being on an Atomic (WoA) site.
+		Cache::set( 'is_woa_site', true );
+
+		Functions\stubs(
+			array(
+				'is_automattician' => true,
+			)
+		);
+
+		$user_id = wp_insert_user(
+			array(
+				'user_login' => 'test_atomic_user',
+				'user_pass'  => 'password',
+				'role'       => 'subscriber',
+			)
+		);
+		wp_set_current_user( $user_id );
+
+		// Since we can't mock the API call, it will fail and return null,
+		// which means has_unified_chat_opt_in_enabled returns false.
+		$result = $this->agents_manager->should_use_unified_experience();
 
 		$this->assertFalse( $result );
 	}

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/agents-manager/Agents_Manager_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/agents-manager/Agents_Manager_Test.php
@@ -457,23 +457,12 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 	/**
 	 * Tests that should_use_unified_experience returns false on Atomic site when API call fails.
 	 *
-	 * On Atomic sites, the get_user_attribute function is not available, so the code
-	 * falls back to the Jetpack Connection API. If that fails, it should return false.
-	 *
-	 * @runInSeparateProcess
-	 * @preserveGlobalState disabled
+	 * On Atomic sites, the decision is delegated to wpcom via the /me endpoint.
+	 * If the API call fails, it should return false.
 	 */
-	#[RunInSeparateProcess]
-	#[PreserveGlobalState( false )]
 	public function test_should_use_unified_experience_returns_false_on_atomic_when_api_fails() {
 		// Simulate being on an Atomic (WoA) site.
 		Cache::set( 'is_woa_site', true );
-
-		Functions\stubs(
-			array(
-				'is_automattician' => true,
-			)
-		);
 
 		$user_id = wp_insert_user(
 			array(
@@ -484,8 +473,8 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 		);
 		wp_set_current_user( $user_id );
 
-		// Since we can't mock the API call, it will fail and return null,
-		// which means has_unified_chat_opt_in_enabled returns false.
+		// Since we can't mock the API call in this test environment,
+		// the call to /me?fields=unified_ai_chat will fail and return false.
 		$result = $this->agents_manager->should_use_unified_experience();
 
 		$this->assertFalse( $result );

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/agents-manager/Agents_Manager_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/agents-manager/Agents_Manager_Test.php
@@ -8,7 +8,10 @@
 namespace A8C\FSE;
 
 use Automattic\Jetpack\Jetpack_Mu_Wpcom;
+use Brain\Monkey\Functions;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 
 require_once Jetpack_Mu_Wpcom::PKG_DIR . 'src/features/agents-manager/class-agents-manager.php';
 
@@ -45,10 +48,14 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 		remove_action( 'wp_enqueue_scripts', array( $this->agents_manager, 'add_inline_script' ), 101 );
 		remove_action( 'admin_enqueue_scripts', array( $this->agents_manager, 'add_inline_script' ), 101 );
 		remove_action( 'next_admin_init', array( $this->agents_manager, 'add_inline_script' ), 1001 );
+		remove_filter( 'agents_manager_use_unified_experience', array( $this->agents_manager, 'should_use_unified_experience' ) );
 
 		// Reset the REST server to clear any registered routes.
 		global $wp_rest_server;
 		$wp_rest_server = null;
+
+		// Log out any logged-in user.
+		wp_set_current_user( 0 );
 
 		parent::tear_down();
 	}
@@ -321,5 +328,125 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 
 		// Clean up the filter.
 		remove_all_filters( 'agents_manager_agent_providers' );
+	}
+
+	/**
+	 * Tests that the agents_manager_use_unified_experience filter is registered.
+	 */
+	public function test_unified_experience_filter_is_registered() {
+		$this->assertNotFalse(
+			has_filter( 'agents_manager_use_unified_experience', array( $this->agents_manager, 'should_use_unified_experience' ) )
+		);
+	}
+
+	/**
+	 * Tests that should_use_unified_experience returns false when no user is logged in.
+	 */
+	public function test_should_use_unified_experience_returns_false_when_no_user() {
+		wp_set_current_user( 0 );
+
+		$result = $this->agents_manager->should_use_unified_experience();
+
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * Tests that should_use_unified_experience returns false for non-Automattician users.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	#[RunInSeparateProcess]
+	#[PreserveGlobalState( false )]
+	public function test_should_use_unified_experience_returns_false_for_non_automattician() {
+		Functions\stubs(
+			array(
+				'is_automattician' => false,
+			)
+		);
+
+		$user_id = wp_insert_user(
+			array(
+				'user_login' => 'test_non_automattician',
+				'user_pass'  => 'password',
+				'role'       => 'subscriber',
+			)
+		);
+		wp_set_current_user( $user_id );
+
+		$result = $this->agents_manager->should_use_unified_experience();
+
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * Tests that should_use_unified_experience returns true for Automattician with opt-in enabled.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	#[RunInSeparateProcess]
+	#[PreserveGlobalState( false )]
+	public function test_should_use_unified_experience_returns_true_for_automattician_with_opt_in() {
+		Functions\stubs(
+			array(
+				'is_automattician'   => true,
+				'get_user_attribute' => true,
+			)
+		);
+
+		$user_id = wp_insert_user(
+			array(
+				'user_login' => 'test_automattician_with_opt_in',
+				'user_pass'  => 'password',
+				'role'       => 'subscriber',
+			)
+		);
+		wp_set_current_user( $user_id );
+
+		$result = $this->agents_manager->should_use_unified_experience();
+
+		$this->assertTrue( $result );
+	}
+
+	/**
+	 * Tests that should_use_unified_experience returns false for Automattician without opt-in.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	#[RunInSeparateProcess]
+	#[PreserveGlobalState( false )]
+	public function test_should_use_unified_experience_returns_false_for_automattician_without_opt_in() {
+		Functions\stubs(
+			array(
+				'is_automattician'   => true,
+				'get_user_attribute' => false,
+			)
+		);
+
+		$user_id = wp_insert_user(
+			array(
+				'user_login' => 'test_automattician_no_opt_in',
+				'user_pass'  => 'password',
+				'role'       => 'subscriber',
+			)
+		);
+		wp_set_current_user( $user_id );
+
+		$result = $this->agents_manager->should_use_unified_experience();
+
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * Tests that the filter can be used to get the unified experience value.
+	 */
+	public function test_unified_experience_filter_returns_expected_value() {
+		wp_set_current_user( 0 );
+
+		$result = apply_filters( 'agents_manager_use_unified_experience', null );
+
+		$this->assertFalse( $result );
 	}
 }


### PR DESCRIPTION
Related to DOTCOM-15279

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Hooking into new filter to centralize the logic for Unified AI Experience behind Agents_Manager feature (in jetpack-mu-wpcom).
* The corresponding user attribute is being introduced in 197669-ghe-Automattic/wpcom
* This is safe to be released as it is

## Does this pull request change what data or activity we track or use?

No

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

This is a small (but independent) part in a bigger set of changes. To test the full feature see https://github.com/Automattic/wp-calypso/pull/107601.


## Release

This can be independently released. Since nothing is yet consuming the `agents_manager_use_unified_experience` hook until https://github.com/Automattic/wp-calypso/pull/107601 and https://github.com/Automattic/big-sky-plugin/pull/5210 are deployed.