### PR TITLE
cli: Use `os.availableParallelism()` instead of `os.cpus().length`

### DIFF
--- a/tools/cli/commands/phan.js
+++ b/tools/cli/commands/phan.js
@@ -67,7 +67,7 @@ export async function builder( yargs ) {
 		.option( 'concurrency', {
 			type: 'number',
 			description: 'Maximum number of phan tasks to run at once.',
-			default: os.cpus().length,
+			default: os.availableParallelism(),
 			coerce: coerceConcurrency,
 		} )
 		.option( 'format', {

--- a/tools/cli/commands/test.js
+++ b/tools/cli/commands/test.js
@@ -48,7 +48,7 @@ export async function builder( yargs ) {
 		.option( 'concurrency', {
 			type: 'number',
 			description: 'Maximum number of test tasks to run at once. Ignored with `--verbose`.',
-			default: os.cpus().length,
+			default: os.availableParallelism(),
 			coerce: coerceConcurrency,
 		} )
 		.option( 'no-html', {


### PR DESCRIPTION
Closes MONOREP-286

 <!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Node has this function (and has since v18.14, apparently) that's specifically intended to give us the number we want. We should use it.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Stuff still work?
