### PR TITLE
Forms: Fix export functionality to handle null values

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-google-export-fix
+++ b/projects/packages/forms/changelog/fix-forms-google-export-fix
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix export functionality to handle null values properly for IP Address, Country code, and Browser fields

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -2809,9 +2809,9 @@ class Contact_Form_Plugin {
 			}
 
 			$results[ $prefix_meta_fields . __( 'Consent', 'jetpack-forms' ) ][]      = $feedback->has_consent() ? __( 'Yes', 'jetpack-forms' ) : __( 'No', 'jetpack-forms' );
-			$results[ $prefix_meta_fields . __( 'IP Address', 'jetpack-forms' ) ][]   = $feedback->get_ip_address();
-			$results[ $prefix_meta_fields . __( 'Country code', 'jetpack-forms' ) ][] = $feedback->get_country_code();
-			$results[ $prefix_meta_fields . __( 'Browser', 'jetpack-forms' ) ][]      = $feedback->get_browser();
+			$results[ $prefix_meta_fields . __( 'IP Address', 'jetpack-forms' ) ][]   = $feedback->get_ip_address() ?? '';
+			$results[ $prefix_meta_fields . __( 'Country code', 'jetpack-forms' ) ][] = $feedback->get_country_code() ?? '';
+			$results[ $prefix_meta_fields . __( 'Browser', 'jetpack-forms' ) ][]      = $feedback->get_browser() ?? '';
 
 		}
 		return $results;

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -2808,7 +2808,8 @@ class Contact_Form_Plugin {
 				$results[ $trimmed_field_name ][] = isset( $compiled_fields[ $trimmed_field_name ] ) ? $compiled_fields[ $trimmed_field_name ] : '';
 			}
 
-			$results[ $prefix_meta_fields . __( 'Consent', 'jetpack-forms' ) ][]      = $feedback->has_consent() ? __( 'Yes', 'jetpack-forms' ) : __( 'No', 'jetpack-forms' );
+			$results[ $prefix_meta_fields . __( 'Consent', 'jetpack-forms' ) ][] = $feedback->has_consent() ? __( 'Yes', 'jetpack-forms' ) : __( 'No', 'jetpack-forms' );
+
 			// Convert null values to empty strings for proper CSV/export formatting.
 			$results[ $prefix_meta_fields . __( 'IP Address', 'jetpack-forms' ) ][]   = $feedback->get_ip_address() ?? '';
 			$results[ $prefix_meta_fields . __( 'Country code', 'jetpack-forms' ) ][] = $feedback->get_country_code() ?? '';

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -2809,6 +2809,7 @@ class Contact_Form_Plugin {
 			}
 
 			$results[ $prefix_meta_fields . __( 'Consent', 'jetpack-forms' ) ][]      = $feedback->has_consent() ? __( 'Yes', 'jetpack-forms' ) : __( 'No', 'jetpack-forms' );
+			// Convert null values to empty strings for proper CSV/export formatting.
 			$results[ $prefix_meta_fields . __( 'IP Address', 'jetpack-forms' ) ][]   = $feedback->get_ip_address() ?? '';
 			$results[ $prefix_meta_fields . __( 'Country code', 'jetpack-forms' ) ][] = $feedback->get_country_code() ?? '';
 			$results[ $prefix_meta_fields . __( 'Browser', 'jetpack-forms' ) ][]      = $feedback->get_browser() ?? '';

--- a/projects/packages/forms/src/contact-form/class-feedback-field.php
+++ b/projects/packages/forms/src/contact-form/class-feedback-field.php
@@ -180,6 +180,10 @@ class Feedback_Field {
 			);
 		}
 
+		if ( $this->value === null ) {
+			return '';
+		}
+
 		return $this->get_render_default_value();
 	}
 

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
@@ -885,6 +885,7 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 		$this->assertTrue( isset( $result[ $prefix_meta . 'Consent' ] ) );
 		$this->assertTrue( isset( $result[ $prefix_meta . 'IP Address' ] ) );
 		$this->assertTrue( isset( $result[ $prefix_meta . 'Browser' ] ) );
+		$this->assertTrue( isset( $result[ $prefix_meta . 'Country code' ] ) );
 
 		// check that none of the fields are null
 		$fields = array_keys( $result );

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
@@ -890,7 +890,9 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 		$fields = array_keys( $result );
 
 		foreach ( $fields as $field ) {
-			$this->assertNotNull( $result[ $field ][0], "Field {$field} should not be null." );
+			foreach ( $result[ $field ] as $index => $value ) {
+				$this->assertNotNull( $value, "Field {$field}[{$index}] should not be null." );
+			}
 		}
 		$equals = array(
 			'Name'    => array( 'Test "Quotes" User' ),

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
@@ -886,6 +886,12 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 		$this->assertTrue( isset( $result[ $prefix_meta . 'IP Address' ] ) );
 		$this->assertTrue( isset( $result[ $prefix_meta . 'Browser' ] ) );
 
+		// check that non of the fields are null
+		$fields = array_keys( $result );
+
+		foreach ( $fields as $field ) {
+			$this->assertNotNull( $result[ $field ][0], "Field {$field} should not be null." );
+		}
 		$equals = array(
 			'Name'    => array( 'Test "Quotes" User' ),
 			'Text'    => array( 'test@example.com' ),

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
@@ -886,7 +886,7 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 		$this->assertTrue( isset( $result[ $prefix_meta . 'IP Address' ] ) );
 		$this->assertTrue( isset( $result[ $prefix_meta . 'Browser' ] ) );
 
-		// check that non of the fields are null
+		// check that none of the fields are null
 		$fields = array_keys( $result );
 
 		foreach ( $fields as $field ) {


### PR DESCRIPTION
Fixes FORMS-456

## Proposed changes:
  * Fix export functionality to properly handle null values for IP Address, Country code, and Browser metadata fields
  * Add null coalescing operators in the export method to prevent null values from being exported
  * Handle null values in the Feedback_Field class by returning empty string
  * Add test coverage to verify no fields contain null values in export results

  ### Other information:

  - [x] Have you written new tests for your changes, if applicable?
  - [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
  - [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

  ## Jetpack product discussion
See p1765324268015949/1765317985.302089-slack-C052XEUUBL 4

  ## Does this pull request change what data or activity we track or use?
  No

  ## Testing instructions:

  * Set up a WordPress site with Jetpack Forms installed
  * Create a contact form and submit several entries
  * For some submissions, ensure certain metadata fields (IP address, country code, browser) might be null (this can happen in certain server configurations or when data collection is limited)
  * Go to the Forms dashboard and attempt to export the form responses to Google Sheets or CSV
  * Verify that the export completes successfully without errors
  * Verify that null values are exported as empty strings instead of causing export failures
  * Run the test suite: `vendor/bin/phpunit --filter Contact_Form_Plugin_Test`
  * Verify all tests pass, including the new null value assertion