### PR TITLE
My Jetpack: Add benefit-driven success messages for module activation

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/module-toggle/index.tsx
+++ b/projects/packages/my-jetpack/_inc/components/module-toggle/index.tsx
@@ -5,6 +5,7 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { __, sprintf } from '@wordpress/i18n';
 import { useCallback } from 'react';
 import { MyJetpackModule } from '../../types';
+import { getModuleActivationMessage } from '../../utils/module-benefit-messages';
 import { useProductFiltersContext } from '../my-jetpack-tab-panel/products/products-tracking-context';
 import type { ChangeEvent } from 'react';
 
@@ -40,11 +41,7 @@ export function ModuleToggle( { module: $module }: ModuleToggleProps ) {
 			if ( noticeType === 'success' ) {
 				const message =
 					action === 'activation'
-						? sprintf(
-								/* translators: %s is the module name */
-								__( '%s has been activated.', 'jetpack-my-jetpack' ),
-								$module.name
-						  )
+						? getModuleActivationMessage( $module.module, $module.name )
 						: sprintf(
 								/* translators: %s is the module name */
 								__( '%s has been deactivated.', 'jetpack-my-jetpack' ),
@@ -68,7 +65,7 @@ export function ModuleToggle( { module: $module }: ModuleToggleProps ) {
 				createErrorNotice( message );
 			}
 		},
-		[ $module.name, createErrorNotice, createSuccessNotice ]
+		[ $module.module, $module.name, createErrorNotice, createSuccessNotice ]
 	);
 
 	const onChange = useCallback(

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/products/mappings.ts
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/products/mappings.ts
@@ -67,6 +67,7 @@ export const CATEGORY_CARDS_AND_MODULES: {
 		modules: [
 			'blocks',
 			'carousel',
+			'custom-content-types',
 			'google-fonts',
 			'gravatar-hovercards',
 			'infinite-scroll',

--- a/projects/packages/my-jetpack/_inc/constants.ts
+++ b/projects/packages/my-jetpack/_inc/constants.ts
@@ -96,6 +96,7 @@ export const JETPACK_NON_PAID_MODULES = [
 	'comments',
 	'contact-form',
 	'copy-post',
+	'custom-content-types',
 	'google-fonts',
 	'gravatar-hovercards',
 	'infinite-scroll',

--- a/projects/packages/my-jetpack/_inc/utils/module-benefit-messages.ts
+++ b/projects/packages/my-jetpack/_inc/utils/module-benefit-messages.ts
@@ -1,12 +1,14 @@
-import { __ } from '@wordpress/i18n';
+import { __, sprintf, _x } from '@wordpress/i18n';
 
 /**
  * Benefit-driven success messages for module activation.
  *
- * Format: "[Feature Name] activated! [Present-tense benefit describing what the user NOW has]"
- *
  * These messages are shown when a module is successfully activated,
  * emphasizing the immediate value to the user.
+ *
+ * The benefit messages use present-tense descriptions of what the user NOW has.
+ * Messages are interpolated as: "%1$s activated! %2$s" where %1$s is the module
+ * name and %2$s is the benefit message.
  *
  * @return {Record<string, string>} Module benefit messages.
  */
@@ -184,10 +186,22 @@ export function getModuleActivationMessage( moduleSlug: string, moduleName: stri
 	const benefit = benefits[ moduleSlug ];
 
 	if ( benefit ) {
-		// The benefit string is already translated
-		return `${ moduleName } ${ __( 'activated!', 'jetpack-my-jetpack' ) } ${ benefit }`;
+		return sprintf(
+			/* translators: 1: Module name, 2: The benefit of the module */
+			_x(
+				'%1$s activated! %2$s',
+				'Message shown when a module is activated. 1: Module name, 2: The benefit of the module',
+				'jetpack-my-jetpack'
+			),
+			moduleName,
+			benefit
+		);
 	}
 
 	// Fallback to generic message if no benefit message is defined
-	return `${ moduleName } ${ __( 'has been activated.', 'jetpack-my-jetpack' ) }`;
+	return sprintf(
+		/* translators: %s: Jetpack module name */
+		_x( '%s has been activated.', '1: Jetpack module name', 'jetpack-my-jetpack' ),
+		moduleName
+	);
 }

--- a/projects/packages/my-jetpack/_inc/utils/module-benefit-messages.ts
+++ b/projects/packages/my-jetpack/_inc/utils/module-benefit-messages.ts
@@ -1,0 +1,193 @@
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Benefit-driven success messages for module activation.
+ *
+ * Format: "[Feature Name] activated! [Present-tense benefit describing what the user NOW has]"
+ *
+ * These messages are shown when a module is successfully activated,
+ * emphasizing the immediate value to the user.
+ *
+ * @return {Record<string, string>} Module benefit messages.
+ */
+function getModuleBenefitMessages(): Record< string, string > {
+	return {
+		'account-protection': __(
+			'Your login page now has rate-limiting and secure authentication safeguards.',
+			'jetpack-my-jetpack'
+		),
+		blaze: __(
+			'You can now promote your posts across millions of sites in the WordPress.com and Tumblr ad network.',
+			'jetpack-my-jetpack'
+		),
+		blocks: __(
+			'Your editor now has custom Jetpack blocks for rich content and layout options.',
+			'jetpack-my-jetpack'
+		),
+		carousel: __(
+			'Your image galleries now display as immersive, full-screen slideshows.',
+			'jetpack-my-jetpack'
+		),
+		'comment-likes': __(
+			'Visitors can now like individual comments and boost engagement.',
+			'jetpack-my-jetpack'
+		),
+		comments: __( 'Your site now has a modern, feature-rich comment form.', 'jetpack-my-jetpack' ),
+		'contact-form': __(
+			'You can now add contact, registration, and feedback forms directly from the block editor.',
+			'jetpack-my-jetpack'
+		),
+		'copy-post': __( 'You can now duplicate any post or page in one click.', 'jetpack-my-jetpack' ),
+		'custom-content-types': __(
+			'Your site can now display different types of custom content.',
+			'jetpack-my-jetpack'
+		),
+		'google-fonts': __(
+			"You can now customize your site's typography with Google Fonts.",
+			'jetpack-my-jetpack'
+		),
+		'gravatar-hovercards': __(
+			"Visitors now see a user's Gravatar profile when they hover over names or images.",
+			'jetpack-my-jetpack'
+		),
+		'infinite-scroll': __(
+			'New posts now load automatically as visitors scroll down your site.',
+			'jetpack-my-jetpack'
+		),
+		'json-api': __(
+			"Your site's data is now accessible remotely through the WordPress.com REST API.",
+			'jetpack-my-jetpack'
+		),
+		latex: __(
+			'You can now add beautifully formatted math equations using LaTeX.',
+			'jetpack-my-jetpack'
+		),
+		likes: __( 'Readers can now like your posts to show appreciation.', 'jetpack-my-jetpack' ),
+		markdown: __(
+			'You can now write and format posts using Markdown syntax.',
+			'jetpack-my-jetpack'
+		),
+		monitor: __( "You'll now get instant alerts if your site goes down.", 'jetpack-my-jetpack' ),
+		notes: __(
+			'You now receive real-time notifications about site activity across your devices.',
+			'jetpack-my-jetpack'
+		),
+		'photon-cdn': __(
+			"Your site now serves static files from Jetpack's global CDN for faster load times.",
+			'jetpack-my-jetpack'
+		),
+		photon: __(
+			'Your site now loads images faster with automatic resizing from our global CDN.',
+			'jetpack-my-jetpack'
+		),
+		'post-by-email': __(
+			'You can now publish blog posts by sending an email.',
+			'jetpack-my-jetpack'
+		),
+		'post-list': __(
+			'You can now display a customizable list of your latest posts anywhere on your site.',
+			'jetpack-my-jetpack'
+		),
+		protect: __(
+			'Your site now blocks malicious login attempts automatically.',
+			'jetpack-my-jetpack'
+		),
+		publicize: __(
+			'Your posts now auto-share to social networks and track engagement in one place.',
+			'jetpack-my-jetpack'
+		),
+		'related-posts': __(
+			'Your site now displays related articles to keep visitors reading longer.',
+			'jetpack-my-jetpack'
+		),
+		search: __(
+			'Your visitors now get the most relevant search results instantly.',
+			'jetpack-my-jetpack'
+		),
+		'seo-tools': __(
+			'You can now optimize titles, meta descriptions, and social previews for better search results.',
+			'jetpack-my-jetpack'
+		),
+		sharedaddy: __(
+			'Visitors can now easily share your content with customizable share buttons.',
+			'jetpack-my-jetpack'
+		),
+		shortcodes: __(
+			'You can now easily embed rich media like YouTube videos and tweets.',
+			'jetpack-my-jetpack'
+		),
+		shortlinks: __(
+			'You can now share short, easy-to-remember links to your posts and pages.',
+			'jetpack-my-jetpack'
+		),
+		sitemaps: __(
+			'Search engines can now index your site more efficiently with XML sitemaps.',
+			'jetpack-my-jetpack'
+		),
+		sso: __(
+			'Users can now log in with their WordPress.com account for quick, secure access.',
+			'jetpack-my-jetpack'
+		),
+		stats: __(
+			'You now have clear, concise traffic insights right in your WordPress dashboard.',
+			'jetpack-my-jetpack'
+		),
+		subscriptions: __(
+			'You can now grow your subscriber list and deliver content to email inboxes.',
+			'jetpack-my-jetpack'
+		),
+		'tiled-gallery': __(
+			'You can now create visually engaging tiled image galleries with multiple layout options.',
+			'jetpack-my-jetpack'
+		),
+		vaultpress: __(
+			'Your site now has real-time backups with one-click restores.',
+			'jetpack-my-jetpack'
+		),
+		'verification-tools': __(
+			'You can now verify your site with search engines and social platforms easily.',
+			'jetpack-my-jetpack'
+		),
+		videopress: __( 'You now have powerful and flexible video hosting.', 'jetpack-my-jetpack' ),
+		waf: __(
+			"Your site now filters malicious traffic in real time with Jetpack's firewall.",
+			'jetpack-my-jetpack'
+		),
+		'widget-visibility': __(
+			'You can now choose which widgets appear on specific pages with advanced controls.',
+			'jetpack-my-jetpack'
+		),
+		widgets: __(
+			'Your site now has more widget options like social feeds and subscriptions.',
+			'jetpack-my-jetpack'
+		),
+		'woocommerce-analytics': __(
+			"You now have actionable insights on your store's orders, revenue, and customers.",
+			'jetpack-my-jetpack'
+		),
+		wordads: __(
+			'Your site can now earn revenue by displaying high-quality ads.',
+			'jetpack-my-jetpack'
+		),
+	};
+}
+
+/**
+ * Get the benefit message for a module activation.
+ *
+ * @param {string} moduleSlug - The module slug.
+ * @param {string} moduleName - The module display name.
+ * @return {string} The benefit message.
+ */
+export function getModuleActivationMessage( moduleSlug: string, moduleName: string ): string {
+	const benefits = getModuleBenefitMessages();
+	const benefit = benefits[ moduleSlug ];
+
+	if ( benefit ) {
+		// The benefit string is already translated
+		return `${ moduleName } ${ __( 'activated!', 'jetpack-my-jetpack' ) } ${ benefit }`;
+	}
+
+	// Fallback to generic message if no benefit message is defined
+	return `${ moduleName } ${ __( 'has been activated.', 'jetpack-my-jetpack' ) }`;
+}

--- a/projects/packages/my-jetpack/_inc/utils/module-benefit-messages.ts
+++ b/projects/packages/my-jetpack/_inc/utils/module-benefit-messages.ts
@@ -202,7 +202,7 @@ export function getModuleActivationMessage( moduleSlug: string, moduleName: stri
 	// Fallback to generic message if no benefit message is defined
 	return sprintf(
 		/* translators: %s: Jetpack module name */
-		_x( '%s has been activated.', '1: Jetpack module name', 'jetpack-my-jetpack' ),
+		_x( '%s has been activated.', '%s: Jetpack module name', 'jetpack-my-jetpack' ),
 		moduleName
 	);
 }

--- a/projects/packages/my-jetpack/_inc/utils/module-benefit-messages.ts
+++ b/projects/packages/my-jetpack/_inc/utils/module-benefit-messages.ts
@@ -1,4 +1,5 @@
 import { __, sprintf, _x } from '@wordpress/i18n';
+import { JetpackModuleSlug } from '../types';
 
 /**
  * Benefit-driven success messages for module activation.
@@ -10,9 +11,9 @@ import { __, sprintf, _x } from '@wordpress/i18n';
  * Messages are interpolated as: "%1$s activated! %2$s" where %1$s is the module
  * name and %2$s is the benefit message.
  *
- * @return {Record<string, string>} Module benefit messages.
+ * @return {Record<JetpackModuleSlug, string>} Module benefit messages.
  */
-function getModuleBenefitMessages(): Record< string, string > {
+function getModuleBenefitMessages(): Record< JetpackModuleSlug, string > {
 	return {
 		'account-protection': __(
 			'Your login page now has rate-limiting and secure authentication safeguards.',

--- a/projects/packages/my-jetpack/changelog/add-myjp-products-benefit-driven-activation-messages
+++ b/projects/packages/my-jetpack/changelog/add-myjp-products-benefit-driven-activation-messages
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Add benefit-driven success messages for module activation


### PR DESCRIPTION
## Proposed changes:
  * Replace generic module activation success messages with benefit-driven messages that emphasize immediate value.
  * Create a new utility module with custom benefit messages for all 41 Jetpack modules.
  * Update the ModuleToggle component to display contextual benefits when features are activated (e.g., "Image CDN activated! Your site now loads images faster with automatic resizing from our global CDN.")
  * All benefit messages are fully translatable using WordPress i18n functions.

Before | After
--|--
<img width="333" height="83" alt="image" src="https://github.com/user-attachments/assets/e83094e7-3ba6-408c-8ef2-8872d52b005a" /> | <img width="648" height="112" alt="image" src="https://github.com/user-attachments/assets/1285dee8-203a-4120-add9-65c38479f69a" />


  ### Other information:

  - [ ] Have you written new tests for your changes, if applicable?
  - [ ] Have you checked the E2E test CI results, and verified that your changes
  do not break them?
  - [ ] Have you tested your changes on WordPress.com, if applicable (if so,
  you'll see a generated comment below with a script to run)?

  ## Jetpack product discussion

p1765329939935419-slack-C0D96691V

  ## Does this pull request change what data or activity we track or use?

  No

  ## Testing instructions:

  1. Go to **My Jetpack** → **Products** tab.
  2. Find any inactive module in the list (e.g., Image CDN, Downtime Monitor, Related Posts, etc.)
  3. Toggle the module **ON**.
  4. Confirm the success message emphasizes the value of that module.

  **Expected behavior:**
  - Success message should follow the format: `[Module name] activated! [Benefit]`.
  - Example for Image CDN: "Image CDN activated! Your site now loads images faster with automatic resizing from our global CDN."
  - The message should clearly communicate the immediate value/benefit of activating the feature.

  **Before:**
  Generic message: "Image CDN has been activated."

  **After:**
  Benefit-driven message: "Image CDN activated! Your site now loads images faster
  with automatic resizing from our global CDN."

  5. Test with multiple different modules to verify each has a custom benefit message.
  6. Toggle a module **OFF** to verify deactivation messages still work correctly. Should show: "[Module name] has been deactivated.")