### PR TITLE
Forms: Remove classic Admin initialization and migrate functionality

### DIFF
--- a/projects/packages/forms/.phan/baseline.php
+++ b/projects/packages/forms/.phan/baseline.php
@@ -11,9 +11,10 @@ return [
     // # Issue statistics:
     // PhanTypeMismatchArgument : 50+ occurrences
     // PhanPluginDuplicateConditionalNullCoalescing : 30+ occurrences
-    // PhanDeprecatedFunction : 8 occurrences
+    // PhanDeprecatedFunction : 9 occurrences
     // PhanTypeMismatchReturnProbablyReal : 8 occurrences
     // PhanTypeMismatchArgumentProbablyReal : 6 occurrences
+    // PhanUndeclaredFunction : 4 occurrences
     // PhanPluginDuplicateAdjacentStatement : 3 occurrences
     // PhanTypeConversionFromArray : 2 occurrences
     // PhanTypeMismatchReturn : 2 occurrences
@@ -34,8 +35,8 @@ return [
         'src/dashboard/class-dashboard-view-switch.php' => ['PhanDeprecatedFunction', 'PhanUnreferencedUseNormal'],
         'src/service/class-google-drive.php' => ['PhanTypeMismatchReturnProbablyReal'],
         'tests/php/contact-form/Contact_Form_Plugin_Test.php' => ['PhanPluginMixedKeyNoKey'],
-        'tests/php/dashboard/Dashboard_View_Switch_Test.php' => ['PhanDeprecatedClass', 'PhanDeprecatedFunction'],
         'tests/php/contact-form/Util_Test.php' => ['PhanDeprecatedFunction'],
+        'tests/php/dashboard/Dashboard_View_Switch_Test.php' => ['PhanDeprecatedClass', 'PhanDeprecatedFunction'],
     ],
     // 'directory_suppressions' => ['src/directory_name' => ['PhanIssueName1', 'PhanIssueName2']] can be manually added if needed.
     // (directory_suppressions will currently be ignored by subsequent calls to --save-baseline, but may be preserved in future Phan releases)

--- a/projects/packages/forms/.phan/baseline.php
+++ b/projects/packages/forms/.phan/baseline.php
@@ -20,14 +20,13 @@ return [
     // PhanDeprecatedClass : 1 occurrence
     // PhanPluginMixedKeyNoKey : 1 occurrence
     // PhanPossiblyNullTypeMismatchProperty : 1 occurrence
-    // PhanTypeArraySuspiciousNullable : 1 occurrence
     // PhanTypeMismatchReturnNullable : 1 occurrence
     // PhanUnreferencedUseNormal : 1 occurrence
 
     // Currently, file_suppressions and directory_suppressions are the only supported suppressions
     'file_suppressions' => [
         'src/abilities/class-forms-abilities.php' => ['PhanUndeclaredFunction'],
-        'src/contact-form/class-admin.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeArraySuspiciousNullable', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchReturn'],
+        'src/contact-form/class-admin.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchReturn'],
         'src/contact-form/class-contact-form-field.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanPossiblyNullTypeMismatchProperty', 'PhanTypeConversionFromArray', 'PhanTypeMismatchArgument', 'PhanTypeMismatchReturnProbablyReal'],
         'src/contact-form/class-contact-form-plugin.php' => ['PhanPluginDuplicateAdjacentStatement', 'PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchReturnProbablyReal'],
         'src/contact-form/class-contact-form-shortcode.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchReturnProbablyReal'],

--- a/projects/packages/forms/.phan/baseline.php
+++ b/projects/packages/forms/.phan/baseline.php
@@ -35,6 +35,7 @@ return [
         'src/service/class-google-drive.php' => ['PhanTypeMismatchReturnProbablyReal'],
         'tests/php/contact-form/Contact_Form_Plugin_Test.php' => ['PhanPluginMixedKeyNoKey'],
         'tests/php/dashboard/Dashboard_View_Switch_Test.php' => ['PhanDeprecatedClass', 'PhanDeprecatedFunction'],
+        'tests/php/contact-form/Util_Test.php' => ['PhanDeprecatedFunction'],
     ],
     // 'directory_suppressions' => ['src/directory_name' => ['PhanIssueName1', 'PhanIssueName2']] can be manually added if needed.
     // (directory_suppressions will currently be ignored by subsequent calls to --save-baseline, but may be preserved in future Phan releases)

--- a/projects/packages/forms/changelog/remove-forms-old-admin
+++ b/projects/packages/forms/changelog/remove-forms-old-admin
@@ -1,0 +1,4 @@
+Significance: major
+Type: removed
+
+Forms: Removes classic Admin initialization code

--- a/projects/packages/forms/src/contact-form/class-admin.php
+++ b/projects/packages/forms/src/contact-form/class-admin.php
@@ -17,6 +17,8 @@ use Jetpack_Tracks_Client;
 /**
  * Class Admin
  *
+ * @deprecated $$next-version$$
+ *
  * Singleton for Grunion admin area support.
  */
 class Admin {

--- a/projects/packages/forms/src/contact-form/class-admin.php
+++ b/projects/packages/forms/src/contact-form/class-admin.php
@@ -150,70 +150,14 @@ class Admin {
 	 * Ajax handler for wp_ajax_grunion_export_to_gdrive.
 	 * Exports data to Google Drive, based on POST data.
 	 *
+	 * @deprecated $$next-version$$
+	 *
 	 * @see Contact_Form_Plugin::get_feedback_entries_from_post
 	 */
 	public function export_to_gdrive() {
-		$post_data = wp_unslash( $_POST );
-		if (
-			! current_user_can( 'export' )
-			|| empty( sanitize_text_field( $post_data[ $this->export_nonce_field_gdrive ] ) )
-			|| ! wp_verify_nonce( sanitize_text_field( $post_data[ $this->export_nonce_field_gdrive ] ), 'feedback_export' )
-		) {
-			wp_send_json_error(
-				__( 'You aren\'t authorized to do that.', 'jetpack-forms' ),
-				403,
-				JSON_UNESCAPED_SLASHES
-			);
+		_deprecated_function( __METHOD__, 'package-$$next-version$$', 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::init()->export_to_gdrive()' );
 
-			return;
-		}
-
-		$grunion     = Contact_Form_Plugin::init();
-		$export_data = $grunion->get_feedback_entries_from_post();
-
-		$fields    = is_array( $export_data ) ? array_keys( $export_data ) : array();
-		$row_count = ! is_array( $export_data ) || empty( $export_data ) ? 0 : count( reset( $export_data ) );
-
-		$sheet_data = array( $fields );
-
-		for ( $i = 0; $i < $row_count; $i++ ) {
-
-			$current_row = array();
-
-			/**
-			 * Put all the fields in `$current_row` array.
-			 */
-			foreach ( $fields as $single_field_name ) {
-				$current_row[] = $export_data[ $single_field_name ][ $i ];
-			}
-
-			$sheet_data[] = $current_row;
-		}
-
-		$user_id = (int) get_current_user_id();
-
-		if ( ! empty( $post_data['post'] ) && $post_data['post'] !== 'all' ) {
-			$spreadsheet_title = sprintf(
-				'%1$s - %2$s',
-				$this->get_export_filename( get_the_title( (int) $post_data['post'] ) ),
-				gmdate( 'Y-m-d H:i' )
-			);
-		} else {
-			$spreadsheet_title = sprintf( '%s - %s', $this->get_export_filename(), gmdate( 'Y-m-d H:i' ) );
-		}
-
-		$sheet = Google_Drive::create_sheet( $user_id, $spreadsheet_title, $sheet_data );
-
-		$grunion->record_tracks_event( 'forms_export_responses', array( 'format' => 'gsheets' ) );
-
-		wp_send_json(
-			array(
-				'success' => ! is_wp_error( $sheet ),
-				'data'    => $sheet,
-			),
-			200,
-			JSON_UNESCAPED_SLASHES
-		);
+		return Contact_Form_Plugin::init()->export_to_gdrive();
 	}
 
 	/**

--- a/projects/packages/forms/src/contact-form/class-admin.php
+++ b/projects/packages/forms/src/contact-form/class-admin.php
@@ -17,9 +17,9 @@ use Jetpack_Tracks_Client;
 /**
  * Class Admin
  *
- * @deprecated $$next-version$$
- *
  * Singleton for Grunion admin area support.
+ *
+ * This class will be removed in a future version.
  */
 class Admin {
 	/**
@@ -39,9 +39,12 @@ class Admin {
 	/**
 	 * Instantiates this singleton class
 	 *
+	 * @deprecated $$next-version$$
+	 *
 	 * @return Admin The Admin class instance.
 	 */
 	public static function init() {
+		_deprecated_function( __METHOD__, 'package-$$next-version$$' );
 		static $instance = false;
 
 		if ( ! $instance ) {

--- a/projects/packages/forms/src/contact-form/class-admin.php
+++ b/projects/packages/forms/src/contact-form/class-admin.php
@@ -83,9 +83,6 @@ class Admin {
 
 		add_action( 'admin_enqueue_scripts', array( $this, 'admin_enqueue_scripts' ) );
 		add_action( 'admin_footer-edit.php', array( $this, 'print_export_modal' ) );
-
-		add_action( 'wp_ajax_grunion_export_to_gdrive', array( $this, 'export_to_gdrive' ) );
-		add_action( 'wp_ajax_grunion_gdrive_connection', array( $this, 'test_gdrive_connection' ) );
 	}
 
 	/**

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -3664,19 +3664,39 @@ class Contact_Form_Plugin {
 	}
 
 	/**
+	 * Validates the export to Google Drive request.
+	 *
+	 * @param array $post_data The POST data to validate.
+	 * @return bool True if the request is valid, false otherwise.
+	 */
+	public function validate_export_to_gdrive_request( $post_data ) {
+		if ( ! current_user_can( 'export' ) ) {
+			return false;
+		}
+
+		if ( empty( $post_data[ $this->export_nonce_field_gdrive ] ) ) {
+			return false;
+		}
+
+		$nonce = sanitize_text_field( $post_data[ $this->export_nonce_field_gdrive ] );
+		if ( ! wp_verify_nonce( $nonce, 'feedback_export' ) ) {
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
 	 * Ajax handler for wp_ajax_grunion_export_to_gdrive.
 	 * Exports data to Google Drive, based on POST data.
 	 *
 	 * @see Contact_Form_Plugin::get_feedback_entries_from_post
 	 */
 	public function export_to_gdrive() {
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- verification is done on validate_export_to_gdrive_request function
 		$post_data = wp_unslash( $_POST );
 
-		if (
-			! current_user_can( 'export' )
-			|| empty( sanitize_text_field( $post_data[ $this->export_nonce_field_gdrive ] ) )
-			|| ! wp_verify_nonce( sanitize_text_field( $post_data[ $this->export_nonce_field_gdrive ] ), 'feedback_export' )
-		) {
+		if ( ! $this->validate_export_to_gdrive_request( $post_data ) ) {
 			wp_send_json_error(
 				__( 'You aren\'t authorized to do that.', 'jetpack-forms' ),
 				403,

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -3701,7 +3701,11 @@ class Contact_Form_Plugin {
 			 * Put all the fields in `$current_row` array.
 			 */
 			foreach ( $fields as $single_field_name ) {
-				$current_row[] = $export_data[ $single_field_name ][ $i ];
+				if ( isset( $export_data[ $single_field_name ][ $i ] ) ) {
+					$current_row[] = $export_data[ $single_field_name ][ $i ];
+				} else {
+					$current_row[] = '';
+				}
 			}
 
 			$sheet_data[] = $current_row;

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -3679,7 +3679,8 @@ class Contact_Form_Plugin {
 		) {
 			wp_send_json_error(
 				__( 'You aren\'t authorized to do that.', 'jetpack-forms' ),
-				403
+				403,
+				JSON_UNESCAPED_SLASHES
 			);
 			return;
 		}
@@ -3701,7 +3702,7 @@ class Contact_Form_Plugin {
 			 */
 			foreach ( $fields as $single_field_name ) {
 				if ( isset( $export_data[ $single_field_name ][ $i ] ) ) {
-					$current_row[] = $export_data[ $single_field_name ][ $i ];
+					$current_row[] = $this->esc_csv( $export_data[ $single_field_name ][ $i ] );
 				} else {
 					$current_row[] = '';
 				}
@@ -3730,7 +3731,9 @@ class Contact_Form_Plugin {
 			array(
 				'success' => ! is_wp_error( $sheet ),
 				'data'    => $sheet,
-			)
+			),
+			is_wp_error( $sheet ) ? 500 : 200,
+			JSON_UNESCAPED_SLASHES
 		);
 	}
 }

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -12,6 +12,7 @@ use Automattic\Jetpack\Constants;
 use Automattic\Jetpack\Extensions\Contact_Form\Contact_Form_Block;
 use Automattic\Jetpack\Forms\Jetpack_Forms;
 use Automattic\Jetpack\Forms\Service\Form_Webhooks;
+use Automattic\Jetpack\Forms\Service\Google_Drive;
 use Automattic\Jetpack\Forms\Service\Hostinger_Reach_Integration;
 use Automattic\Jetpack\Forms\Service\MailPoet_Integration;
 use Automattic\Jetpack\Forms\Service\Post_To_Url;
@@ -96,6 +97,13 @@ class Contact_Form_Plugin {
 		'entry_page'              => '',
 		'feedback_id'             => '',
 	);
+
+	/**
+	 * GDrive export nonce field name
+	 *
+	 * @var string The nonce field name for GDrive export.
+	 */
+	private $export_nonce_field_gdrive = 'feedback_export_nonce_gdrive';
 
 	/**
 	 * Initializing function.
@@ -221,6 +229,8 @@ class Contact_Form_Plugin {
 		if ( is_admin() ) {
 			add_action( 'wp_ajax_feedback_export', array( $this, 'download_feedback_as_csv' ) );
 			add_action( 'wp_ajax_create_new_form', array( $this, 'create_new_form' ) );
+			add_action( 'wp_ajax_grunion_export_to_gdrive', array( $this, 'export_to_gdrive' ) );
+			add_action( 'wp_ajax_grunion_gdrive_connection', array( $this, 'test_gdrive_connection' ) );
 		}
 		add_action( 'admin_menu', array( $this, 'admin_menu' ) );
 		add_action( 'current_screen', array( $this, 'unread_count' ) );
@@ -3652,5 +3662,109 @@ class Contact_Form_Plugin {
 		// Use wp_safe_redirect to ensure we're redirecting to a safe location
 		wp_safe_redirect( $redirect_url );
 		exit;
+	}
+
+	/**
+	 * Ajax handler for wp_ajax_grunion_export_to_gdrive.
+	 * Exports data to Google Drive, based on POST data.
+	 *
+	 * @see Contact_Form_Plugin::get_feedback_entries_from_post
+	 */
+	public function export_to_gdrive() {
+		$post_data = wp_unslash( $_POST );
+
+		if (
+			! current_user_can( 'export' )
+			|| empty( sanitize_text_field( $post_data[ $this->export_nonce_field_gdrive ] ) )
+			|| ! wp_verify_nonce( sanitize_text_field( $post_data[ $this->export_nonce_field_gdrive ] ), 'feedback_export' )
+		) {
+			wp_send_json_error(
+				__( 'You aren\'t authorized to do that.', 'jetpack-forms' ),
+				403
+			);
+
+			return;
+		}
+
+		$grunion     = self::init();
+		$export_data = $grunion->get_feedback_entries_from_post();
+
+		$fields    = is_array( $export_data ) ? array_keys( $export_data ) : array();
+		$row_count = ! is_array( $export_data ) || empty( $export_data ) ? 0 : count( reset( $export_data ) );
+
+		$sheet_data = array( $fields );
+
+		for ( $i = 0; $i < $row_count; $i++ ) {
+
+			$current_row = array();
+
+			/**
+			 * Put all the fields in `$current_row` array.
+			 */
+			foreach ( $fields as $single_field_name ) {
+				$current_row[] = $export_data[ $single_field_name ][ $i ];
+			}
+
+			$sheet_data[] = $current_row;
+		}
+
+		$user_id = (int) get_current_user_id();
+
+		if ( ! empty( $post_data['post'] ) && $post_data['post'] !== 'all' ) {
+			$spreadsheet_title = sprintf(
+				'%1$s - %2$s',
+				Util::get_export_filename( get_the_title( (int) $post_data['post'] ) ),
+				gmdate( 'Y-m-d H:i' )
+			);
+		} else {
+			$spreadsheet_title = sprintf( '%s - %s', Util::get_export_filename(), gmdate( 'Y-m-d H:i' ) );
+		}
+
+		$sheet = Google_Drive::create_sheet( $user_id, $spreadsheet_title, $sheet_data );
+
+		$grunion->record_tracks_event( 'forms_export_responses', array( 'format' => 'gsheets' ) );
+
+		wp_send_json(
+			array(
+				'success' => ! is_wp_error( $sheet ),
+				'data'    => $sheet,
+			)
+		);
+	}
+
+	/**
+	 * Ajax handler. Sends a payload with connection status and html to replace
+	 * the Connect button with the Export button using get_gdrive_export_button
+	 */
+	public function test_gdrive_connection() {
+		$post_data = wp_unslash( $_POST );
+		$user_id   = (int) get_current_user_id();
+
+		if (
+			! $user_id ||
+			! current_user_can( 'export' ) ||
+			empty( sanitize_text_field( $post_data[ $this->export_nonce_field_gdrive ] ) ) ||
+			! wp_verify_nonce( sanitize_text_field( $post_data[ $this->export_nonce_field_gdrive ] ), 'feedback_export' )
+		) {
+			wp_send_json_error(
+				__( 'You aren\'t authorized to do that.', 'jetpack-forms' ),
+				403
+			);
+
+			return;
+		}
+
+		$has_valid_connection = Google_Drive::has_valid_connection();
+
+		$replacement_html = $has_valid_connection
+			? $this->get_gdrive_export_button_markup()
+			: '';
+
+		wp_send_json(
+			array(
+				'connection' => $has_valid_connection,
+				'html'       => $replacement_html,
+			)
+		);
 	}
 }

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -3681,7 +3681,6 @@ class Contact_Form_Plugin {
 				__( 'You aren\'t authorized to do that.', 'jetpack-forms' ),
 				403
 			);
-
 			return;
 		}
 
@@ -3703,8 +3702,6 @@ class Contact_Form_Plugin {
 			foreach ( $fields as $single_field_name ) {
 				if ( isset( $export_data[ $single_field_name ][ $i ] ) ) {
 					$current_row[] = $export_data[ $single_field_name ][ $i ];
-				} else {
-					$current_row[] = '';
 				}
 			}
 

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -3702,6 +3702,8 @@ class Contact_Form_Plugin {
 			foreach ( $fields as $single_field_name ) {
 				if ( isset( $export_data[ $single_field_name ][ $i ] ) ) {
 					$current_row[] = $export_data[ $single_field_name ][ $i ];
+				} else {
+					$current_row[] = '';
 				}
 			}
 

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -230,7 +230,6 @@ class Contact_Form_Plugin {
 			add_action( 'wp_ajax_feedback_export', array( $this, 'download_feedback_as_csv' ) );
 			add_action( 'wp_ajax_create_new_form', array( $this, 'create_new_form' ) );
 			add_action( 'wp_ajax_grunion_export_to_gdrive', array( $this, 'export_to_gdrive' ) );
-			add_action( 'wp_ajax_grunion_gdrive_connection', array( $this, 'test_gdrive_connection' ) );
 		}
 		add_action( 'admin_menu', array( $this, 'admin_menu' ) );
 		add_action( 'current_screen', array( $this, 'unread_count' ) );
@@ -3728,42 +3727,6 @@ class Contact_Form_Plugin {
 			array(
 				'success' => ! is_wp_error( $sheet ),
 				'data'    => $sheet,
-			)
-		);
-	}
-
-	/**
-	 * Ajax handler. Sends a payload with connection status and html to replace
-	 * the Connect button with the Export button using get_gdrive_export_button
-	 */
-	public function test_gdrive_connection() {
-		$post_data = wp_unslash( $_POST );
-		$user_id   = (int) get_current_user_id();
-
-		if (
-			! $user_id ||
-			! current_user_can( 'export' ) ||
-			empty( sanitize_text_field( $post_data[ $this->export_nonce_field_gdrive ] ) ) ||
-			! wp_verify_nonce( sanitize_text_field( $post_data[ $this->export_nonce_field_gdrive ] ), 'feedback_export' )
-		) {
-			wp_send_json_error(
-				__( 'You aren\'t authorized to do that.', 'jetpack-forms' ),
-				403
-			);
-
-			return;
-		}
-
-		$has_valid_connection = Google_Drive::has_valid_connection();
-
-		$replacement_html = $has_valid_connection
-			? $this->get_gdrive_export_button_markup()
-			: '';
-
-		wp_send_json(
-			array(
-				'connection' => $has_valid_connection,
-				'html'       => $replacement_html,
 			)
 		);
 	}

--- a/projects/packages/forms/src/contact-form/class-editor-view.php
+++ b/projects/packages/forms/src/contact-form/class-editor-view.php
@@ -32,7 +32,6 @@ class Editor_View {
 	 * Admin header.
 	 */
 	public static function admin_head() {
-		remove_action( 'media_buttons', array( Admin::init(), 'grunion_media_button' ), 999 );
 		add_action( 'media_buttons', array( __CLASS__, 'grunion_media_button' ), 999 );
 	}
 

--- a/projects/packages/forms/src/contact-form/class-util.php
+++ b/projects/packages/forms/src/contact-form/class-util.php
@@ -17,9 +17,6 @@ class Util {
 	 * Registers all relevant actions and filters for this class.
 	 */
 	public static function init() {
-		if ( is_admin() ) {
-			Admin::init();
-		}
 
 		add_filter( 'template_include', '\Automattic\Jetpack\Forms\ContactForm\Util::grunion_contact_form_set_block_template_attribute' );
 

--- a/projects/packages/forms/tests/php/contact-form/Util_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Util_Test.php
@@ -735,4 +735,98 @@ EOT
 			'grunion_pre_message_sent action should be registered'
 		);
 	}
+
+	/**
+	 * Test that export_to_gdrive functionality has been moved from Admin to Contact_Form_Plugin.
+	 *
+	 * This test verifies that the export_to_gdrive method is available in Contact_Form_Plugin
+	 * and that the deprecated Admin method properly delegates to it.
+	 */
+	public function test_export_to_gdrive_moved_from_admin_to_plugin() {
+		// Verify that Contact_Form_Plugin has the export_to_gdrive method
+		$plugin_reflection = new \ReflectionClass( Contact_Form_Plugin::class );
+		$this->assertTrue(
+			$plugin_reflection->hasMethod( 'export_to_gdrive' ),
+			'Contact_Form_Plugin should have export_to_gdrive method'
+		);
+
+		// Verify that Admin still has the deprecated method
+		$admin_reflection = new \ReflectionClass( Admin::class );
+		$this->assertTrue(
+			$admin_reflection->hasMethod( 'export_to_gdrive' ),
+			'Admin should still have deprecated export_to_gdrive method for backward compatibility'
+		);
+
+		// Verify that Admin method is marked as deprecated
+		$admin_method = $admin_reflection->getMethod( 'export_to_gdrive' );
+		$doc_comment  = $admin_method->getDocComment();
+		$this->assertStringContainsString( '@deprecated', $doc_comment, 'Admin::export_to_gdrive() should be marked as deprecated' );
+	}
+
+	/**
+	 * Test export_to_gdrive method security and validation.
+	 *
+	 * This test verifies that the export_to_gdrive method properly validates
+	 * permissions and nonces before processing the export request.
+	 */
+	public function test_export_to_gdrive_security_validation() {
+		// Create a Contact_Form_Plugin instance
+		$plugin = Contact_Form_Plugin::init();
+
+		// Test without proper capabilities
+		$original_user = wp_get_current_user();
+		wp_set_current_user( 0 ); // Set to no user
+
+		// Mock $_POST data without proper nonce
+		$_POST = array(
+			'feedback_export_nonce_gdrive' => 'invalid_nonce',
+		);
+
+		// Capture output to check for JSON error response
+		ob_start();
+		$plugin->export_to_gdrive();
+		$output = ob_get_clean();
+
+		// Verify that an error response was sent
+		$this->assertStringContainsString( 'You aren\'t authorized to do that.', $output );
+
+		// Restore original user
+		wp_set_current_user( $original_user->ID );
+
+		// Clean up $_POST
+		unset( $_POST['feedback_export_nonce_gdrive'] );
+	}
+
+	/**
+	 * Test that deprecated Admin::export_to_gdrive properly delegates to Contact_Form_Plugin.
+	 *
+	 * This test ensures that calling the deprecated Admin method still works
+	 * by delegating to the new implementation in Contact_Form_Plugin.
+	 */
+	public function test_deprecated_admin_export_delegates_to_plugin() {
+		// Verify that the Admin method contains the proper delegation code
+		$reflection = new \ReflectionMethod( Admin::class, 'export_to_gdrive' );
+
+		// Get the method source code to verify it delegates to Contact_Form_Plugin
+		$filename   = $reflection->getFileName();
+		$start_line = $reflection->getStartLine();
+		$end_line   = $reflection->getEndLine();
+
+		$file_contents = file( $filename );
+		$method_source = implode( '', array_slice( $file_contents, $start_line - 1, $end_line - $start_line + 1 ) );
+
+		// Verify the method calls _deprecated_function with the correct replacement
+		$this->assertStringContainsString(
+			'Contact_Form_Plugin::init()->export_to_gdrive()',
+			$method_source,
+			'Admin::export_to_gdrive should reference Contact_Form_Plugin::init()->export_to_gdrive() in deprecation notice'
+		);
+
+		// Verify the method actually delegates to Contact_Form_Plugin
+		$this->assertStringContainsString(
+			'return Contact_Form_Plugin::init()->export_to_gdrive()',
+			$method_source,
+			'Admin::export_to_gdrive should delegate to Contact_Form_Plugin::init()->export_to_gdrive()'
+		);
+	}
 }

--- a/projects/packages/forms/tests/php/contact-form/Util_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Util_Test.php
@@ -51,7 +51,6 @@ class Util_Test extends BaseTestCase {
 	 * @dataProvider provider_apply_block_attribute_scenarios
 	 */
 	#[DataProvider( 'provider_apply_block_attribute_scenarios' )]
-	#[DataProvider( 'provider_apply_block_attribute_scenarios' )]
 	public function test_apply_block_attribute( $content, $new_attr, $expected_attrs ) {
 		$result = Util::grunion_contact_form_apply_block_attribute( $content, $new_attr );
 

--- a/projects/packages/forms/tests/php/contact-form/Util_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Util_Test.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Unit Tests for Util.
+ * Unit Tests for Util class.
  *
  * @package automattic/jetpack-forms
  */
@@ -50,6 +50,7 @@ class Util_Test extends BaseTestCase {
 	 *
 	 * @dataProvider provider_apply_block_attribute_scenarios
 	 */
+	#[DataProvider( 'provider_apply_block_attribute_scenarios' )]
 	#[DataProvider( 'provider_apply_block_attribute_scenarios' )]
 	public function test_apply_block_attribute( $content, $new_attr, $expected_attrs ) {
 		$result = Util::grunion_contact_form_apply_block_attribute( $content, $new_attr );
@@ -621,6 +622,117 @@ EOT
 EOT
 				,
 			),
+		);
+	}
+
+	/**
+	 * Test that Admin::init() is not called when Util::init() is called.
+	 *
+	 * This test verifies that the deprecated Admin class is not being initialized
+	 * when the Util class is initialized, confirming the deprecation of the
+	 * classic admin functionality.
+	 */
+	public function test_admin_init_not_called_on_util_init() {
+		// Initialize Util
+		Util::init();
+
+		$actions_after = $GLOBALS['wp_filter'];
+
+		// Verify that no admin-specific hooks were added
+		// We check for hooks that would be added by Admin::init()
+		$admin_hooks = array(
+			'media_buttons',
+			'wp_ajax_grunion_form_builder',
+			'admin_print_styles',
+			'admin_print_scripts',
+			'admin_head',
+			'admin_init',
+			'admin_enqueue_scripts',
+			'admin_footer-edit.php',
+		);
+
+		$unexpected_hooks_found = array();
+		foreach ( $admin_hooks as $hook ) {
+			if ( isset( $actions_after[ $hook ] ) ) {
+				// Check if any of the callbacks are from the Admin class
+				foreach ( $actions_after[ $hook ]->callbacks as $callbacks ) {
+					foreach ( $callbacks as $callback ) {
+						if ( is_array( $callback['function'] ) &&
+							is_object( $callback['function'][0] ) &&
+							$callback['function'][0] instanceof Admin ) {
+							$unexpected_hooks_found[] = $hook;
+						}
+					}
+				}
+			}
+		}
+
+		$this->assertEmpty(
+			$unexpected_hooks_found,
+			'No Admin class hooks should be registered after Util::init(). Found: ' . implode( ', ', $unexpected_hooks_found )
+		);
+	}
+
+	/**
+	 * Test that Admin::init() method is properly deprecated.
+	 *
+	 * This test verifies that calling Admin::init() directly triggers
+	 * a deprecation notice as expected.
+	 */
+	public function test_admin_init_is_deprecated() {
+		// Test that the Admin::init method has the @deprecated annotation
+		$reflection  = new \ReflectionMethod( Admin::class, 'init' );
+		$doc_comment = $reflection->getDocComment();
+
+		$this->assertStringContainsString( '@deprecated', $doc_comment, 'Admin::init() method should have @deprecated annotation' );
+
+		// Call the deprecated method and verify it still works (for backward compatibility)
+		$admin_instance = Admin::init();
+		$this->assertInstanceOf( Admin::class, $admin_instance, 'Admin::init() should still return an Admin instance for backward compatibility' );
+	}
+
+	/**
+	 * Test that Util::init() sets up the expected hooks and filters.
+	 *
+	 * This test verifies that the Util::init() method properly registers
+	 * the expected WordPress hooks and filters without initializing the
+	 * deprecated Admin class.
+	 */
+	public function test_util_init_registers_expected_hooks() {
+		// Remove any existing hooks first to get a clean state
+		remove_all_filters( 'template_include' );
+		remove_all_actions( 'render_block_core_template_part_post' );
+		remove_all_actions( 'init' );
+		remove_all_actions( 'grunion_scheduled_delete' );
+		remove_all_actions( 'grunion_pre_message_sent' );
+
+		// Initialize Util
+		Util::init();
+
+		// Verify that the expected hooks are registered (has_filter/has_action return priority or false)
+		$this->assertNotFalse(
+			has_filter( 'template_include', '\Automattic\Jetpack\Forms\ContactForm\Util::grunion_contact_form_set_block_template_attribute' ),
+			'template_include filter should be registered'
+		);
+
+		$this->assertNotFalse(
+			has_action( 'render_block_core_template_part_post', '\Automattic\Jetpack\Forms\ContactForm\Util::grunion_contact_form_set_block_template_part_id_global' ),
+			'render_block_core_template_part_post action should be registered'
+		);
+
+		$this->assertNotFalse(
+			has_action( 'init', '\Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::init' ),
+			'Contact_Form_Plugin::init should be registered on init action'
+		);
+
+		$this->assertNotFalse(
+			has_action( 'grunion_scheduled_delete', '\Automattic\Jetpack\Forms\ContactForm\Util::grunion_delete_old_spam' ),
+			'grunion_scheduled_delete action should be registered'
+		);
+
+		$this->assertNotFalse(
+			has_action( 'grunion_pre_message_sent', '\Automattic\Jetpack\Forms\ContactForm\Util::jetpack_tracks_record_grunion_pre_message_sent' ),
+			'grunion_pre_message_sent action should be registered'
 		);
 	}
 }

--- a/projects/packages/forms/tests/php/contact-form/Util_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Util_Test.php
@@ -763,37 +763,60 @@ EOT
 	}
 
 	/**
-	 * Test export_to_gdrive method security and validation.
+	 * Test export_to_gdrive validation method with various security scenarios.
 	 *
-	 * This test verifies that the export_to_gdrive method properly validates
-	 * permissions and nonces before processing the export request.
+	 * This test verifies that the validate_export_to_gdrive_request method properly
+	 * validates permissions and nonces.
 	 */
 	public function test_export_to_gdrive_security_validation() {
-		// Create a Contact_Form_Plugin instance
-		$plugin = Contact_Form_Plugin::init();
-
-		// Test without proper capabilities
+		$plugin        = Contact_Form_Plugin::init();
 		$original_user = wp_get_current_user();
-		wp_set_current_user( 0 ); // Set to no user
 
-		// Mock $_POST data without proper nonce
-		$_POST = array(
-			'feedback_export_nonce_gdrive' => 'invalid_nonce',
+		// Test 1: User without 'export' capability should fail
+		wp_set_current_user( 0 );
+		$post_data = array(
+			'feedback_export_nonce_gdrive' => wp_create_nonce( 'feedback_export' ),
+		);
+		$this->assertFalse(
+			$plugin->validate_export_to_gdrive_request( $post_data ),
+			'Validation should fail for user without export capability'
 		);
 
-		// Capture output to check for JSON error response
-		ob_start();
-		$plugin->export_to_gdrive();
-		$output = ob_get_clean();
+		// Test 2: Missing nonce field should fail
+		$admin_user = wp_insert_user(
+			array(
+				'user_login' => 'testadmin',
+				'user_pass'  => 'password',
+				'role'       => 'administrator',
+			)
+		);
+		wp_set_current_user( $admin_user );
+		$post_data = array(); // No nonce field
+		$this->assertFalse(
+			$plugin->validate_export_to_gdrive_request( $post_data ),
+			'Validation should fail when nonce field is missing'
+		);
 
-		// Verify that an error response was sent
-		$this->assertStringContainsString( 'You aren\'t authorized to do that.', $output );
+		// Test 3: Invalid nonce should fail
+		$post_data = array(
+			'feedback_export_nonce_gdrive' => 'invalid_nonce',
+		);
+		$this->assertFalse(
+			$plugin->validate_export_to_gdrive_request( $post_data ),
+			'Validation should fail with invalid nonce'
+		);
 
-		// Restore original user
+		// Test 4: Valid user with valid nonce should pass
+		$post_data = array(
+			'feedback_export_nonce_gdrive' => wp_create_nonce( 'feedback_export' ),
+		);
+		$this->assertTrue(
+			$plugin->validate_export_to_gdrive_request( $post_data ),
+			'Validation should pass with valid user and nonce'
+		);
+
+		// Cleanup
 		wp_set_current_user( $original_user->ID );
-
-		// Clean up $_POST
-		unset( $_POST['feedback_export_nonce_gdrive'] );
 	}
 
 	/**

--- a/projects/plugins/jetpack/changelog/remove-forms-old-admin
+++ b/projects/plugins/jetpack/changelog/remove-forms-old-admin
@@ -1,0 +1,4 @@
+Significance: major
+Type: bugfix
+
+Forms: Removes the classis Admin initliazation call

--- a/projects/plugins/jetpack/changelog/remove-forms-old-admin
+++ b/projects/plugins/jetpack/changelog/remove-forms-old-admin
@@ -1,4 +1,4 @@
 Significance: major
 Type: bugfix
 
-Forms: Removes the classis Admin initliazation call
+Forms: Removes the classic Admin initialization call


### PR DESCRIPTION
This is a rebase of #44538 but decided to open a new PR so to not mess with the original changes.

## Proposed changes:

* Deprecates the `Admin::init()` method in the Forms package as part of migrating away from the classic admin interface
* Removes the call to `Admin::init()` from `Util::init()` to stop initializing the deprecated classic admin functionality
* Migrates Google Drive export functionality from the deprecated `Admin` class to `Contact_Form_Plugin` class where it belongs
* Adds comprehensive test coverage for:
  - Verifying `Admin::init()` is no longer called during initialization
  - Testing deprecation warnings are properly implemented
  - Validating export functionality delegation works correctly
  - Ensuring security validation in export methods
* Updates Phan baseline to reflect code changes

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

### Test that Forms functionality still works:

1. In your Docker environment, go to Jetpack > Forms
2. Verify that you can still view form responses
3. Verify that CSV export still works by clicking the "Export" button and choosing "CSV"
4. If you have Google Drive connected, verify that Google Drive export still works

### Test that deprecated code triggers warnings (optional):

1. In your test environment with `WP_DEBUG` enabled, add this code to call the deprecated method:
   ```php
   add_action('init', function() {
       \Automattic\Jetpack\Forms\ContactForm\Admin::init();
   });
   ```
2. Check debug.log for deprecation warnings
3. Remove the test code when done

### Test that classic admin is no longer initialized:

1. Run the new unit tests: `jetpack test projects/packages/forms -- --filter=Util_Test`
2. Verify all tests pass, especially the new tests that check Admin::init() is not called