### PR TITLE
Forms: Fix PHPUnit 12 test strictness warnings

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-phpunit-nuances
+++ b/projects/packages/forms/changelog/fix-forms-phpunit-nuances
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Tests: Replace PHPUnit mocks with anonymous classes to eliminate PHPUnit 12 strictness warnings

--- a/projects/packages/forms/tests/php/contact-form/Feedback_Author_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Feedback_Author_Test.php
@@ -139,7 +139,7 @@ class Feedback_Author_Test extends BaseTestCase {
 	 * Test from_submission method.
 	 */
 	public function test_from_submission() {
-		$form = $this->createMock( Contact_Form::class );
+		$form = $this->createStub( Contact_Form::class );
 		$form->method( 'get_field_ids' )
 			->willReturn(
 				array(
@@ -191,7 +191,7 @@ class Feedback_Author_Test extends BaseTestCase {
 	 * Test from_submission with missing fields.
 	 */
 	public function test_from_submission_missing_fields() {
-		$form = $this->createMock( Contact_Form::class );
+		$form = $this->createStub( Contact_Form::class );
 		$form->method( 'get_field_ids' )
 			->willReturn(
 				array(

--- a/projects/packages/forms/tests/php/service/Form_Webhooks_Test.php
+++ b/projects/packages/forms/tests/php/service/Form_Webhooks_Test.php
@@ -708,51 +708,70 @@ class Form_Webhooks_Test extends BaseTestCase {
 	}
 
 	/**
-	 * Helper method to create a mock form.
+	 * Helper method to create a test form object.
 	 *
 	 * @param array $attributes Form attributes.
-	 * @return Contact_Form Mock form instance.
+	 * @return Contact_Form Test form instance with required properties.
 	 */
 	private function create_mock_form( $attributes ) {
-		$form = $this->getMockBuilder( Contact_Form::class )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$form->attributes = $attributes;
-		$form->fields     = array();
-
-		return $form;
+		return new class( $attributes ) extends Contact_Form {
+			/**
+			 * Constructor.
+			 *
+			 * @param array $attributes Form attributes.
+			 */
+			public function __construct( $attributes ) {
+				// Don't call parent constructor - just set properties directly
+				$this->attributes = $attributes;
+				$this->fields     = array();
+			}
+		};
 	}
 
 	/**
-	 * Helper method to create a mock field.
+	 * Helper method to create a test field object.
 	 *
 	 * @param Contact_Form $form Parent form.
 	 * @param string       $id Field ID.
 	 * @param mixed        $value Field value.
-	 * @return Contact_Form_Field Mock field instance.
+	 * @return Contact_Form_Field Test field instance with required properties and methods.
 	 */
 	private function create_mock_field( $form, $id, $value ) {
-		$field = $this->getMockBuilder( Contact_Form_Field::class )
-			->disableOriginalConstructor()
-			->onlyMethods( array( 'get_attribute' ) )
-			->getMock();
+		return new class( $form, $id, $value ) extends Contact_Form_Field {
+			/**
+			 * Field ID.
+			 *
+			 * @var string
+			 */
+			private $id;
 
-		$field->form  = $form;
-		$field->value = $value;
+			/**
+			 * Constructor.
+			 *
+			 * @param Contact_Form $form Parent form.
+			 * @param string       $id Field ID.
+			 * @param mixed        $value Field value.
+			 */
+			public function __construct( $form, $id, $value ) {
+				// Don't call parent constructor - just set properties directly
+				$this->form  = $form;
+				$this->id    = $id;
+				$this->value = $value;
+			}
 
-		$field->expects( $this->any() )
-			->method( 'get_attribute' )
-			->willReturnCallback(
-				function ( $attr ) use ( $id ) {
-					if ( $attr === 'id' ) {
-						return $id;
-					}
-					return null;
+			/**
+			 * Get field attribute.
+			 *
+			 * @param string $attr Attribute name.
+			 * @return mixed Attribute value or null.
+			 */
+			public function get_attribute( $attr ) {
+				if ( $attr === 'id' ) {
+					return $this->id;
 				}
-			);
-
-		return $field;
+				return null;
+			}
+		};
 	}
 
 	/**


### PR DESCRIPTION
## Proposed changes:
* Replaced PHPUnit mocks with anonymous classes extending actual classes to eliminate PHPUnit 12 strictness warnings
* Changed `createMock()` to `createStub()` in Feedback_Author_Test for simple stub behavior
* Refactored Form_Webhooks_Test helpers to use anonymous classes instead of PHPUnit's mock framework
* All 440 tests now pass with zero PHPUnit notices (previously had 36 notices from 18 tests)

### Other information:

- [x] Have you written new tests for your changes, if applicable?
  - N/A - This refactors existing tests only
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
N/A - Test-only changes

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
1. Check out this branch
2. Navigate to `projects/packages/forms`
3. Run `composer phpunit -- --display-all-issues`
4. Verify all 440 tests pass with zero PHPUnit notices
5. Confirm the output shows: `Tests: 440, Assertions: 1890, Skipped: 4` with no warnings