### PR TITLE
Limited Global Styles: Improve reset flows

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/dotthem-134-allow-users-to-remove-premium-styles-from-all-three-banners
+++ b/projects/packages/jetpack-mu-wpcom/changelog/dotthem-134-allow-users-to-remove-premium-styles-from-all-three-banners
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Update limited Global Styles notices with easier style resetting options.

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/index.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/index.php
@@ -586,16 +586,8 @@ function wpcom_display_global_styles_notice_admin_bar( $wp_admin_bar ) {
 		array(
 			'parent' => 'wpcom-global-styles',
 			'id'     => 'wpcom-global-styles-reset',
-			'title'  =>
-				'<svg class="wpcom-global-styles-reset-help-icon" width="15" height="14" viewBox="0 0 15 14" fill="none" xmlns="http://www.w3.org/2000/svg">
-					<path d="M5.8125 5.6875C5.8125 4.75552 6.56802 4 7.5 4C8.43198 4 9.1875 4.75552 9.1875 5.6875C9.1875 6.55621 8.53108 7.2716 7.6872 7.36473C7.58427 7.37609 7.5 7.45895 7.5 7.5625V8.5M7.5 9.25V10.375M13.5 7C13.5 10.3137 10.8137 13 7.5 13C4.18629 13 1.5 10.3137 1.5 7C1.5 3.68629 4.18629 1 7.5 1C10.8137 1 13.5 3.68629 13.5 7Z" stroke-width="1.5"/>
-				</svg>' .
-				esc_html__( 'Remove premium styles', 'jetpack-mu-wpcom' ) .
-				'<svg class="wpcom-global-styles-reset-external-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="15" height="15" aria-hidden="true" focusable="false"><path d="M18.2 17c0 .7-.6 1.2-1.2 1.2H7c-.7 0-1.2-.6-1.2-1.2V7c0-.7.6-1.2 1.2-1.2h3.2V4.2H7C5.5 4.2 4.2 5.5 4.2 7v10c0 1.5 1.2 2.8 2.8 2.8h10c1.5 0 2.8-1.2 2.8-2.8v-3.6h-1.5V17zM14.9 3v1.5h3.7l-6.4 6.4 1.1 1.1 6.4-6.4v3.7h1.5V3h-6.3z"></path></svg>',
-			'href'   => 'https://wordpress.com/support/using-styles/#remove-premium-styles',
-			'meta'   => array(
-				'target' => '_blank',
-			),
+			'title'  => esc_html__( 'Remove premium styles', 'jetpack-mu-wpcom' ),
+			'href'   => admin_url( 'site-editor.php?p=/styles' ),
 		)
 	);
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/notice.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/notice.scss
@@ -15,6 +15,15 @@
 	.components-notice__content {
 		margin-right: 0;
 	}
+
+	.components-notice__action.components-button {
+		margin-left: 0;
+		margin-top: 12px;
+
+		// Protect the button against long strings overflowing the sidebar
+		text-align: left;
+		white-space: normal;
+	}
 }
 
 // Inline the action buttons when there is another pinned notice,
@@ -46,7 +55,7 @@
 	}
 }
 
-.components-notice-list .components-notice__action.components-button.wpcom-global-styles-action-has-icon {
+.components-notice__action.components-button.wpcom-global-styles-action-has-icon {
 	display: flex;
 
 	&::after,

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/notices.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/notices.js
@@ -1,20 +1,14 @@
 /* global wpcomGlobalStyles */
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { store as blockEditorStore } from '@wordpress/block-editor';
-import { ExternalLink, Notice } from '@wordpress/components';
+import { Notice } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
-import {
-	createInterpolateElement,
-	render,
-	useCallback,
-	useEffect,
-	useState,
-} from '@wordpress/element';
+import { render, useCallback, useEffect, useState } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
-import clsx from 'clsx';
 import { wpcomTrackEvent } from '../../common/tracks';
 import { useCanvas } from './use-canvas';
 import { useGlobalStylesConfig } from './use-global-styles-config';
+import useGlobalStyleNoticeActions from './use-global-styles-notice-actions';
 import { usePreview } from './use-preview';
 
 import './notice.scss';
@@ -33,33 +27,32 @@ const trackEvent = ( eventName, isSiteEditor = true ) =>
  * @return {import('react').JSX.Element} The component to render.
  */
 function GlobalStylesWarningNotice() {
+	const { upgrade, reset, learnMore } = useGlobalStyleNoticeActions( {
+		isSiteEditor: true,
+		context: 'view_canvas',
+	} );
+
 	useEffect( () => {
 		trackEvent( 'calypso_global_styles_gating_notice_view_canvas_show' );
 	}, [] );
 
 	const planName = wpcomGlobalStyles.planName;
 
-	const upgradeTranslation = sprintf(
-		/* translators: %s is the short-form Premium plan name */
-		__(
-			'Your site includes premium styles that are only visible to visitors after <a>upgrading to the %s plan or higher</a>.',
-			'jetpack-mu-wpcom'
-		),
-		planName
-	);
 	return (
-		<Notice status="warning" isDismissible={ false } className="wpcom-global-styles-notice">
-			{ createInterpolateElement( upgradeTranslation, {
-				a: (
-					<ExternalLink
-						href={ wpcomGlobalStyles.upgradeUrl }
-						target="_blank"
-						onClick={ () =>
-							trackEvent( 'calypso_global_styles_gating_notice_view_canvas_upgrade_click' )
-						}
-					/>
+		<Notice
+			actions={ [ upgrade, reset, learnMore ] }
+			status="warning"
+			isDismissible={ false }
+			className="wpcom-global-styles-notice"
+		>
+			{ sprintf(
+				/* translators: %s is the short-form Premium plan name */
+				__(
+					'Your site includes premium styles that are only visible to visitors after upgrading to the %s plan or higher.',
+					'jetpack-mu-wpcom'
 				),
-			} ) }
+				planName
+			) }
 		</Notice>
 	);
 }
@@ -115,7 +108,7 @@ function GlobalStylesViewNotice() {
  */
 function GlobalStylesEditNotice() {
 	const NOTICE_ID = 'wpcom-global-styles/gating-notice';
-	const { globalStylesInUse, globalStylesId } = useGlobalStylesConfig();
+	const { globalStylesInUse } = useGlobalStylesConfig();
 	const { canvas } = useCanvas();
 	const { isSiteEditor, isPostEditor } = useSelect(
 		select => ( {
@@ -126,63 +119,20 @@ function GlobalStylesEditNotice() {
 	);
 	const { previewPostWithoutCustomStyles, canPreviewPost } = usePreview();
 
-	const { createWarningNotice, removeNotice } = useDispatch( 'core/notices' );
-	const { editEntityRecord } = useDispatch( 'core' );
-	const helpCenterDispatch = useDispatch( 'automattic/help-center' );
-	const setShowHelpCenter = helpCenterDispatch?.setShowHelpCenter;
-	const setShowSupportDoc = helpCenterDispatch?.setShowSupportDoc;
+	const { upgrade, reset, learnMore } = useGlobalStyleNoticeActions( {
+		isSiteEditor: true,
+		context: 'view_canvas',
+	} );
 
-	const upgradePlan = useCallback( () => {
-		window.open( wpcomGlobalStyles.upgradeUrl, '_blank' ).focus();
-		trackEvent( 'calypso_global_styles_gating_notice_upgrade_click', isSiteEditor );
-	}, [ isSiteEditor ] );
+	const { createWarningNotice, removeNotice } = useDispatch( 'core/notices' );
 
 	const previewPost = useCallback( () => {
 		previewPostWithoutCustomStyles();
 		trackEvent( 'calypso_global_styles_gating_notice_preview_click', isSiteEditor );
 	}, [ isSiteEditor, previewPostWithoutCustomStyles ] );
 
-	const resetGlobalStyles = useCallback( () => {
-		if ( ! globalStylesId ) {
-			return;
-		}
-
-		editEntityRecord( 'root', 'globalStyles', globalStylesId, {
-			styles: {},
-			settings: {},
-		} );
-
-		trackEvent( 'calypso_global_styles_gating_notice_reset_click', isSiteEditor );
-	}, [ editEntityRecord, globalStylesId, isSiteEditor ] );
-
-	const openLearnMoreAboutStylesDialog = useCallback( () => {
-		if ( setShowHelpCenter && setShowSupportDoc ) {
-			setShowHelpCenter( true );
-			setShowSupportDoc(
-				wpcomGlobalStyles.learnMoreAboutStylesUrl,
-				wpcomGlobalStyles.learnMoreAboutStylesPostId
-			);
-		} else {
-			window.open( wpcomGlobalStyles.learnMoreAboutStylesUrl, '_blank' ).focus();
-		}
-
-		trackEvent( 'calypso_global_styles_gating_learn_more_click', isSiteEditor );
-	}, [ isSiteEditor, setShowHelpCenter, setShowSupportDoc ] );
-
 	const showNotice = useCallback( () => {
-		const actions = [
-			{
-				label: __( 'Upgrade now', 'jetpack-mu-wpcom' ),
-				onClick: upgradePlan,
-				variant: 'primary',
-				noDefaultClasses: true,
-				className: clsx(
-					'wpcom-global-styles-action-is-upgrade',
-					'wpcom-global-styles-action-has-icon',
-					'wpcom-global-styles-action-is-external'
-				),
-			},
-		];
+		const actions = [ upgrade ];
 
 		if ( isPostEditor && canPreviewPost ) {
 			actions.push( {
@@ -195,20 +145,10 @@ function GlobalStylesEditNotice() {
 		}
 
 		if ( isSiteEditor ) {
-			actions.push( {
-				label: __( 'Remove premium styles', 'jetpack-mu-wpcom' ),
-				onClick: resetGlobalStyles,
-				variant: 'secondary',
-				noDefaultClasses: true,
-			} );
+			actions.push( reset );
 		}
 
-		actions.push( {
-			label: __( 'Learn more', 'jetpack-mu-wpcom' ),
-			onClick: openLearnMoreAboutStylesDialog,
-			variant: 'link',
-			noDefaultClasses: true,
-		} );
+		actions.push( learnMore );
 
 		const planName = wpcomGlobalStyles.planName;
 		createWarningNotice(
@@ -233,10 +173,10 @@ function GlobalStylesEditNotice() {
 		createWarningNotice,
 		isPostEditor,
 		isSiteEditor,
-		openLearnMoreAboutStylesDialog,
+		learnMore,
 		previewPost,
-		resetGlobalStyles,
-		upgradePlan,
+		reset,
+		upgrade,
 	] );
 
 	const isDistractionFree = useSelect(

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/use-global-styles-notice-actions.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/use-global-styles-notice-actions.js
@@ -1,0 +1,100 @@
+/* global wpcomGlobalStyles */
+import { useDispatch } from '@wordpress/data';
+import { useCallback } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import clsx from 'clsx';
+import { wpcomTrackEvent } from '../../common/tracks';
+import { useGlobalStylesConfig } from './use-global-styles-config';
+
+const trackEvent = ( eventName, isSiteEditor = true ) =>
+	wpcomTrackEvent( eventName, {
+		context: isSiteEditor ? 'site-editor' : 'post-editor',
+		blog_id: wpcomGlobalStyles.wpcomBlogId,
+	} );
+
+/**
+ * Hook for actions used by different notices.
+ *
+ * @param {object}  options              - Options object.
+ * @param {boolean} options.isSiteEditor - Whether the notice is displayed in the site editor.
+ * @param {string}  options.context      - The context where the notice is displayed, for tracking purposes.
+ * @return {object} The shared notice actions.
+ */
+export default function useGlobalStyleNoticeActions( { isSiteEditor, context = 'edit_canvas' } ) {
+	const { editEntityRecord } = useDispatch( 'core' );
+	const { globalStylesId } = useGlobalStylesConfig();
+	const helpCenterDispatch = useDispatch( 'automattic/help-center' );
+	const setShowHelpCenter = helpCenterDispatch?.setShowHelpCenter;
+	const setShowSupportDoc = helpCenterDispatch?.setShowSupportDoc;
+
+	const upgradePlan = useCallback( () => {
+		window.open( wpcomGlobalStyles.upgradeUrl, '_blank' ).focus();
+
+		if ( context === 'view_canvas' ) {
+			trackEvent( 'calypso_global_styles_notice_view_canvas_upgrade_click', isSiteEditor );
+		} else {
+			trackEvent( 'calypso_global_styles_gating_notice_upgrade_click', isSiteEditor );
+		}
+	}, [ context, isSiteEditor ] );
+
+	const resetGlobalStyles = useCallback( () => {
+		if ( ! globalStylesId ) {
+			return;
+		}
+
+		editEntityRecord( 'root', 'globalStyles', globalStylesId, {
+			styles: {},
+			settings: {},
+		} );
+
+		if ( context === 'view_canvas' ) {
+			trackEvent( 'calypso_global_styles_notice_view_canvas_reset_click', isSiteEditor );
+		} else {
+			trackEvent( 'calypso_global_styles_gating_notice_reset_click', isSiteEditor );
+		}
+	}, [ context, editEntityRecord, globalStylesId, isSiteEditor ] );
+
+	const openLearnMoreAboutStylesDialog = useCallback( () => {
+		if ( setShowHelpCenter && setShowSupportDoc ) {
+			setShowHelpCenter( true );
+			setShowSupportDoc(
+				wpcomGlobalStyles.learnMoreAboutStylesUrl,
+				wpcomGlobalStyles.learnMoreAboutStylesPostId
+			);
+		} else {
+			window.open( wpcomGlobalStyles.learnMoreAboutStylesUrl, '_blank' ).focus();
+		}
+
+		if ( context === 'view_canvas' ) {
+			trackEvent( 'calypso_global_styles_notice_view_canvas_learn_more_click', isSiteEditor );
+		} else {
+			trackEvent( 'calypso_global_styles_gating_notice_learn_more_click', isSiteEditor );
+		}
+	}, [ context, isSiteEditor, setShowHelpCenter, setShowSupportDoc ] );
+
+	return {
+		learnMore: {
+			label: __( 'Learn more', 'jetpack-mu-wpcom' ),
+			onClick: openLearnMoreAboutStylesDialog,
+			variant: 'link',
+			noDefaultClasses: true,
+		},
+		reset: {
+			label: __( 'Remove premium styles', 'jetpack-mu-wpcom' ),
+			onClick: resetGlobalStyles,
+			variant: 'secondary',
+			noDefaultClasses: true,
+		},
+		upgrade: {
+			label: __( 'Upgrade now', 'jetpack-mu-wpcom' ),
+			onClick: upgradePlan,
+			variant: 'primary',
+			noDefaultClasses: true,
+			className: clsx(
+				'wpcom-global-styles-action-is-upgrade',
+				'wpcom-global-styles-action-has-icon',
+				'wpcom-global-styles-action-is-external'
+			),
+		},
+	};
+}

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/wpcom-global-styles-view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/wpcom-global-styles-view.js
@@ -96,7 +96,7 @@ document.addEventListener( 'DOMContentLoaded', () => {
 	} );
 
 	resetButton.addEventListener( 'click', () => {
-		recordEvent( 'wpcom_global_styles_gating_notice_reset_support' );
+		recordEvent( 'wpcom_global_styles_gating_notice_reset_link' );
 	} );
 
 	popoverToggle.addEventListener( 'click', () => {

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/wpcom-global-styles-view.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/wpcom-global-styles-view.scss
@@ -94,25 +94,6 @@
 		display: flex;
 		gap: 4px;
 		justify-content: center;
-
-		.wpcom-global-styles-reset-help-icon path {
-			stroke: #c3c4c7;
-		}
-
-		.wpcom-global-styles-reset-external-icon path {
-			fill: #c3c4c7;
-		}
-
-		&:hover {
-
-			.wpcom-global-styles-reset-help-icon path {
-				stroke: #72aee6;
-			}
-
-			.wpcom-global-styles-reset-external-icon path {
-				fill: #72aee6;
-			}
-		}
 	}
 
 	#wp-admin-bar-wpcom-global-styles-preview {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes DOTTHEM-134

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

* Refactor the editor-side Limited Global Styles notices to share actions across different notices.
* Show upgrade, reset, and learn more actions in the "view canvas" notice (site editor black frame).
* Replace the support link with a site editor link for resetting premium styles in the front end notice.

| Before | After |
|--------|--------|
| <img width="899" height="924" alt="Screenshot 2025-12-10 at 17 51 41" src="https://github.com/user-attachments/assets/bacf590b-fd87-4f57-bc4d-4c6a54ca03db" /> | <img width="899" height="924" alt="Screenshot 2025-12-10 at 17 50 57" src="https://github.com/user-attachments/assets/fa42d964-d7c7-46b2-987c-7422a20c1438" /> |
| <img width="899" height="924" alt="Screenshot 2025-12-10 at 17 51 31" src="https://github.com/user-attachments/assets/fd5180f9-07c4-4e03-b6d1-1b374f2d31ff" /> | <img width="899" height="924" alt="Screenshot 2025-12-10 at 17 50 31" src="https://github.com/user-attachments/assets/06db80bd-c047-4fe1-90d3-ba954f6a3385" /> | 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## ~Jetpack~ Dotcom product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

p58i-oLo-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

> [!IMPORTANT]
> **Automatticians only!**

> [!WARNING]
> There's a bug in the "view canvas" that doesn't correctly persist global styles when switching to the "edit canvas". It seems to be a Dotcom-only bug, and it's unrelated to this change. We are investigating.

* Sync these changes to the sandbox.
* Sandbox a free site.
* Enter the site editor and add some styles.
* In the "view canvas" (black frame), ensure the Limited Global Styles notice shows these three actions: upgrade, reset, learn more.
* Confirm they all do what they are supposed to do (open the Plans page in a new tab, reset any global styles, open the Help Center.
* Check for regression: enter the "edit canvas" and try the three actions in the big Limited Global Styles notice, and confirm they work in the same way.
* Move on to the front end.
* In the admin bar's Limited Global Styles popover, click on the "Remove" link.
* Confirm you are redirected to the site editor, in "view canvas" mode (black frame), with the Design panel opened.