### PR TITLE
jetpack: Fix WooCommerce tests

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-woocommerce-tests
+++ b/projects/plugins/jetpack/changelog/fix-woocommerce-tests
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Fix WooCommerce tests by loading Action Schedule earlier.
+
+

--- a/projects/plugins/jetpack/tests/php/bootstrap.php
+++ b/projects/plugins/jetpack/tests/php/bootstrap.php
@@ -134,6 +134,11 @@ if ( ! function_exists( '_manually_load_plugin' ) ) {
 	function _manually_load_plugin() {
 		if ( '1' === getenv( 'JETPACK_TEST_WOOCOMMERCE' ) ) {
 			require JETPACK_WOOCOMMERCE_INSTALL_DIR . '/woocommerce.php';
+
+			// Action Scheduler is needed early on since 10.4.0.
+			$as_file = JETPACK_WOOCOMMERCE_INSTALL_DIR . '/packages/action-scheduler/action-scheduler.php';
+			require_once JETPACK_WOOCOMMERCE_INSTALL_DIR . '/packages/action-scheduler/classes/abstracts/ActionScheduler.php';
+			ActionScheduler::init( $as_file );
 		}
 
 		require __DIR__ . '/../../jetpack.php';

--- a/projects/plugins/jetpack/tests/php/trait-woo-tests.php
+++ b/projects/plugins/jetpack/tests/php/trait-woo-tests.php
@@ -68,10 +68,5 @@ trait WooCommerceTestTrait {
 		// Traits.
 		require_once $woo_tests_dir . '/legacy/framework/traits/trait-wc-rest-api-complex-meta.php';
 		require_once $woo_tests_dir . '/php/helpers/HPOSToggleTrait.php';
-
-		// Action Scheduler.
-		$as_file = dirname( $woo_tests_dir ) . '/packages/action-scheduler/action-scheduler.php';
-		require_once dirname( $woo_tests_dir ) . '/packages/action-scheduler/classes/abstracts/ActionScheduler.php';
-		ActionScheduler::init( $as_file );
 	}
 }


### PR DESCRIPTION
Closes MONOREP-287

 <!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
WooCommerce 10.4.0 has added some code run during 'init' that depends on its Action Scheduler, which somehow or other doesn't get loaded with how we load WC.

Move the loading of that earlier so it's available during 'init'.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1765388570532119-slack-C034JEXD1RD

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* CI happy?