### PR TITLE
PayPal Payment Buttons: Address an issue where not adding # broke container

### DIFF
--- a/projects/packages/paypal-payments/changelog/update-paypal-payment-buttons-fix
+++ b/projects/packages/paypal-payments/changelog/update-paypal-payment-buttons-fix
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Adds back a # selector to fix a broken selector for the container

--- a/projects/packages/paypal-payments/src/paypal-payment-buttons/class-paypal-payment-buttons.php
+++ b/projects/packages/paypal-payments/src/paypal-payment-buttons/class-paypal-payment-buttons.php
@@ -152,7 +152,7 @@ class PayPal_Payment_Buttons {
 					hostedButtonId: %s,
 				}).render(%s);',
 				wp_json_encode( $hosted_button_id, JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP ),
-				wp_json_encode( $container_id, JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP )
+				wp_json_encode( '#' . $container_id, JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP )
 			);
 
 			wp_add_inline_script( 'paypal-payment-buttons-block-head', $inline_script );

--- a/projects/packages/paypal-payments/tests/php/Paypal_Payment_Buttons_Test.php
+++ b/projects/packages/paypal-payments/tests/php/Paypal_Payment_Buttons_Test.php
@@ -21,6 +21,16 @@ use PHPUnit\Framework\TestCase;
 class Paypal_Payment_Buttons_Test extends TestCase {
 
 	/**
+	 * Clean up after each test.
+	 */
+	protected function tearDown(): void {
+		parent::tearDown();
+		// Clean up any registered scripts.
+		global $wp_scripts;
+		$wp_scripts = null;
+	}
+
+	/**
 	 * Test that valid PayPal URLs pass through unchanged.
 	 *
 	 * @dataProvider valid_paypal_urls_provider
@@ -186,5 +196,54 @@ class Paypal_Payment_Buttons_Test extends TestCase {
 
 		$result_parsed = wp_parse_url( $result );
 		$this->assertEquals( 'sandbox.paypal.com', $result_parsed['host'], 'Trailing dot should be stripped from sandbox' );
+	}
+
+	/**
+	 * Test that render_block uses CSS selector with # prefix for stacked buttons.
+	 *
+	 * This test ensures that the render() call uses a proper CSS ID selector (with #)
+	 * rather than just the container ID. The PayPal SDK expects a CSS selector.
+	 *
+	 * @see https://github.com/Automattic/jetpack/pull/46259
+	 */
+	public function test_render_block_uses_css_selector_with_hash_prefix() {
+		$attributes = array(
+			'buttonType'     => 'stacked',
+			'scriptSrc'      => 'https://www.paypal.com/sdk/js?client-id=test',
+			'hostedButtonId' => 'TESTBUTTONID123',
+		);
+
+		// Call render_block
+		$result = PayPal_Payment_Buttons::render_block( $attributes, '' );
+
+		// Verify the container div is created
+		$this->assertStringContainsString(
+			'id="paypal-container-TESTBUTTONID123"',
+			$result,
+			'Container div should have the correct ID'
+		);
+
+		// Get the inline script that was added
+		global $wp_scripts;
+		$inline_script = $wp_scripts->get_data( 'paypal-payment-buttons-block-head', 'after' );
+
+		$this->assertNotEmpty( $inline_script, 'Inline script should be registered' );
+
+		// The inline script is an array, join it to search
+		$script_content = implode( '', $inline_script );
+
+		// Verify the render call uses CSS selector with # prefix
+		$this->assertStringContainsString(
+			'.render("#paypal-container-TESTBUTTONID123")',
+			$script_content,
+			'The render() call must use a CSS ID selector with # prefix'
+		);
+
+		// Verify it does NOT use the container ID without #
+		$this->assertStringNotContainsString(
+			'.render("paypal-container-TESTBUTTONID123")',
+			$script_content,
+			'The render() call must NOT use container ID without # prefix'
+		);
 	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes EDI-163

This was broken in https://github.com/Automattic/jetpack/pull/46229/files#diff-847c93cb60eafe86e67de3dadf1c49e164a3a1cb33e38b22e14084f088819faf

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Fixes selector for PayPal Payment Buttons selector after the `#` previously removed.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

NA

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Checkout branch
- `jetpack build packages/paypal-payments && jetpack build plugins/paypal-payment-buttons`
- Add the PayPal Payment Buttons block in a post
- Configure the block by visiting PayPal and copying code into the block
- Publish post
- Verify block loads
