### PR TITLE
tests: Fix PHPUnit 12.5 whining about mocks versus stubs

### DIFF
--- a/.phan/stubs/phpunit-stubs.php
+++ b/.phan/stubs/phpunit-stubs.php
@@ -14721,7 +14721,7 @@ abstract class TestDoubleBuilder
     }
 }
 /**
- * @template StubbedType
+ * @template MockedType
  *
  * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
  */
@@ -14739,7 +14739,7 @@ final class TestStubBuilder extends \PHPUnit\Framework\MockObject\TestDoubleBuil
      * @throws Generator\RuntimeException
      * @throws Generator\UnknownTypeException
      *
-     * @return Stub&StubbedType
+     * @return Stub&MockedType
      */
     public function getStub(): \PHPUnit\Framework\MockObject\Stub
     {

--- a/projects/packages/account-protection/changelog/fix-phpunit-12-whining-about-mocks-vs-stubs
+++ b/projects/packages/account-protection/changelog/fix-phpunit-12-whining-about-mocks-vs-stubs
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix PHPUnit 12.5 whining about mocks versus stubs.
+
+

--- a/projects/packages/account-protection/tests/php/Password_Manager_Test.php
+++ b/projects/packages/account-protection/tests/php/Password_Manager_Test.php
@@ -39,7 +39,7 @@ class Password_Manager_Test extends BaseTestCase {
 		$errors = new \WP_Error();
 		$user   = new \WP_Error( 'invalid_user', 'Invalid user.' );
 
-		$validation_service_mock = $this->createMock( Validation_Service::class );
+		$validation_service_mock = $this->createStub( Validation_Service::class );
 		$password_manager_mock   = new Password_Manager( $validation_service_mock );
 
 		$password_manager_mock->validate_password_reset( $errors, $user );
@@ -66,7 +66,7 @@ class Password_Manager_Test extends BaseTestCase {
 	}
 
 	private function create_password_manager_mocks() {
-		$validation_service_mock = $this->createMock( Validation_Service::class );
+		$validation_service_mock = $this->createStub( Validation_Service::class );
 		$password_manager_mock   = $this->getMockBuilder( Password_Manager::class )
 			->setConstructorArgs( array( $validation_service_mock ) )
 			->onlyMethods( array( 'save_recent_password_hash' ) )
@@ -230,7 +230,7 @@ class Password_Manager_Test extends BaseTestCase {
 
 		update_user_meta( $user_id, Config::RECENT_PASSWORD_HASHES_USER_META_KEY, $password_hashes );
 
-		$validation_service_mock = $this->createMock( Validation_Service::class );
+		$validation_service_mock = $this->createStub( Validation_Service::class );
 		$password_manager_mock   = new Password_Manager( $validation_service_mock );
 		$password_manager_mock->save_recent_password_hash( $user_id, 'new_hash' );
 

--- a/projects/packages/account-protection/tests/php/Password_Strength_Meter_Test.php
+++ b/projects/packages/account-protection/tests/php/Password_Strength_Meter_Test.php
@@ -2,11 +2,13 @@
 
 namespace Automattic\Jetpack\Account_Protection;
 
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use WorDBless\BaseTestCase;
 
 /**
  * Tests for the Password_Strength_Meter class.
  */
+#[AllowMockObjectsWithoutExpectations /* Mocks created in setUp, some tests add expectations and others don't. Plus getStubBuilder() (for partial stubs) doesn't exist until PHPUnit 12.5. */ ]
 class Password_Strength_Meter_Test extends BaseTestCase {
 
 	private $validation_service;

--- a/projects/packages/account-protection/tests/php/Validation_Service_Test.php
+++ b/projects/packages/account-protection/tests/php/Validation_Service_Test.php
@@ -23,16 +23,12 @@ class Validation_Service_Test extends BaseTestCase {
 	}
 
 	private function get_connection_manager() {
-		$connection = $this->getMockBuilder( 'Automattic\Jetpack\Connection\Manager' )
-			->disableOriginalConstructor()
-			->getMock();
-
+		$connection = $this->createStub( 'Automattic\Jetpack\Connection\Manager' );
 		return $connection;
 	}
 
 	private function get_connected_connection_manager() {
-		$connection = $this->get_connection_manager();
-
+		$connection = $this->createMock( 'Automattic\Jetpack\Connection\Manager' );
 		$connection->expects( $this->once() )
 			->method( 'is_connected' )
 			->willReturn( true );

--- a/projects/packages/assets/changelog/fix-phpunit-12-whining-about-mocks-vs-stubs
+++ b/projects/packages/assets/changelog/fix-phpunit-12-whining-about-mocks-vs-stubs
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix PHPUnit 12.5 whining about mocks versus stubs.
+
+

--- a/projects/packages/assets/tests/php/AssetsTest.php
+++ b/projects/packages/assets/tests/php/AssetsTest.php
@@ -363,7 +363,7 @@ class AssetsTest extends TestCase {
 			$this->expectExceptionMessage( $extra['exception']->getMessage() );
 		}
 		if ( isset( $extra['enqueue'] ) ) {
-			$obj = $this->getMockBuilder( AssetsTest_test_wp_default_scripts_hook::class )->getMock();
+			$obj = $this->createStub( AssetsTest_test_wp_default_scripts_hook::class );
 			$obj->method( 'get_data' )->with( ...$extra['enqueue'][0] )->willReturn( $extra['enqueue'][1] );
 			Functions\expect( 'wp_scripts' )->andReturn( $obj );
 		}

--- a/projects/packages/autoloader/changelog/fix-phpunit-12-whining-about-mocks-vs-stubs
+++ b/projects/packages/autoloader/changelog/fix-phpunit-12-whining-about-mocks-vs-stubs
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix PHPUnit 12.5 whining about mocks versus stubs.
+
+

--- a/projects/packages/autoloader/tests/php/tests/unit/AutoloaderHandlerTest.php
+++ b/projects/packages/autoloader/tests/php/tests/unit/AutoloaderHandlerTest.php
@@ -23,66 +23,18 @@ use PHPUnit\Framework\TestCase;
 class AutoloaderHandlerTest extends TestCase {
 
 	/**
-	 * The php autoloader mock;
-	 *
-	 * @var PHP_Autoloader&\PHPUnit\Framework\MockObject\MockObject
-	 */
-	private $php_autoloader;
-
-	/**
-	 * The hook manager mock;
-	 *
-	 * @var Hook_Manager&\PHPUnit\Framework\MockObject\MockObject
-	 */
-	private $hook_manager;
-
-	/**
-	 * The manifest reader mock.
-	 *
-	 * @var Manifest_Reader&\PHPUnit\Framework\MockObject\MockObject
-	 */
-	private $manifest_reader;
-
-	/**
-	 * The autoloader handler we're testing.
-	 *
-	 * @var Autoloader_Handler
-	 */
-	private $autoloader_handler;
-
-	/**
-	 * Setup runs before each test.
-	 */
-	public function setUp(): void {
-		parent::setUp();
-
-		$this->php_autoloader     = $this->getMockBuilder( PHP_Autoloader::class )
-			->disableOriginalConstructor()
-			->getMock();
-		$this->hook_manager       = $this->getMockBuilder( Hook_Manager::class )
-			->disableOriginalConstructor()
-			->getMock();
-		$this->manifest_reader    = $this->getMockBuilder( Manifest_Reader::class )
-			->disableOriginalConstructor()
-			->getMock();
-		$version_selector         = $this->getMockBuilder( Version_Selector::class )
-			->disableOriginalConstructor()
-			->getMock();
-		$this->autoloader_handler = new Autoloader_Handler(
-			$this->php_autoloader,
-			$this->hook_manager,
-			$this->manifest_reader,
-			$version_selector
-		);
-	}
-
-	/**
 	 * Tests that the handler is able to activate the autoloader successfully.
 	 */
 	public function test_activates_autoloader() {
 		$plugins = array( TEST_PLUGIN_DIR );
 
-		$this->manifest_reader->expects( $this->exactly( 3 ) )
+		$php_autoloader     = $this->createMock( PHP_Autoloader::class );
+		$hook_manager       = $this->createStub( Hook_Manager::class );
+		$manifest_reader    = $this->createMock( Manifest_Reader::class );
+		$version_selector   = $this->createStub( Version_Selector::class );
+		$autoloader_handler = new Autoloader_Handler( $php_autoloader, $hook_manager, $manifest_reader, $version_selector );
+
+		$manifest_reader->expects( $this->exactly( 3 ) )
 			->method( 'read_manifests' )
 			->with(
 				...with_consecutive(
@@ -91,10 +43,10 @@ class AutoloaderHandlerTest extends TestCase {
 					array( $plugins, 'vendor/composer/jetpack_autoload_filemap.php' )
 				)
 			);
-		$this->php_autoloader->expects( $this->once() )
+		$php_autoloader->expects( $this->once() )
 			->method( 'register_autoloader' );
 
-		$this->autoloader_handler->activate_autoloader( $plugins );
+		$autoloader_handler->activate_autoloader( $plugins );
 	}
 
 	/**
@@ -104,13 +56,19 @@ class AutoloaderHandlerTest extends TestCase {
 		global $jetpack_autoloader_loader;
 		global $jetpack_autoloader_latest_version;
 
+		$php_autoloader     = $this->createMock( PHP_Autoloader::class );
+		$hook_manager       = $this->createMock( Hook_Manager::class );
+		$manifest_reader    = $this->createStub( Manifest_Reader::class );
+		$version_selector   = $this->createStub( Version_Selector::class );
+		$autoloader_handler = new Autoloader_Handler( $php_autoloader, $hook_manager, $manifest_reader, $version_selector );
+
 		$jetpack_autoloader_loader         = 'test';
 		$jetpack_autoloader_latest_version = 'test';
-		$this->php_autoloader->expects( $this->once() )
+		$php_autoloader->expects( $this->once() )
 			->method( 'unregister_autoloader' );
-		$this->hook_manager->expects( $this->once() )
+		$hook_manager->expects( $this->once() )
 			->method( 'reset' );
 
-		$this->autoloader_handler->reset_autoloader();
+		$autoloader_handler->reset_autoloader();
 	}
 }

--- a/projects/packages/autoloader/tests/php/tests/unit/LatestAutoloaderGuardTest.php
+++ b/projects/packages/autoloader/tests/php/tests/unit/LatestAutoloaderGuardTest.php
@@ -51,17 +51,10 @@ class LatestAutoloaderGuardTest extends TestCase {
 	 */
 	public function setUp(): void {
 		parent::setUp();
-		$this->plugins_handler    = $this->getMockBuilder( Plugins_Handler::class )
-			->disableOriginalConstructor()
-			->getMock();
-		$this->autoloader_handler = $this->getMockBuilder( Autoloader_Handler::class )
-			->disableOriginalConstructor()
-			->getMock();
-		$this->autoloader_locator = $this->getMockBuilder( Autoloader_Locator::class )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$this->guard = new Latest_Autoloader_Guard(
+		$this->plugins_handler    = $this->createStub( Plugins_Handler::class );
+		$this->autoloader_handler = $this->createMock( Autoloader_Handler::class );
+		$this->autoloader_locator = $this->createStub( Autoloader_Locator::class );
+		$this->guard              = new Latest_Autoloader_Guard(
 			$this->plugins_handler,
 			$this->autoloader_handler,
 			$this->autoloader_locator
@@ -79,6 +72,8 @@ class LatestAutoloaderGuardTest extends TestCase {
 	public function test_should_stop_init_when_autoloader_already_initialized() {
 		global $jetpack_autoloader_latest_version;
 		$jetpack_autoloader_latest_version = Test_Plugin_Factory::VERSION_CURRENT;
+
+		$this->autoloader_handler->expects( $this->never() )->method( 'reset_autoloader' );
 
 		$this->assertTrue(
 			$this->guard->should_stop_init(
@@ -100,6 +95,8 @@ class LatestAutoloaderGuardTest extends TestCase {
 		global $jetpack_autoloader_latest_version;
 		$jetpack_autoloader_latest_version = Test_Plugin_Factory::VERSION_CURRENT;
 
+		$this->autoloader_handler->expects( $this->never() )->method( 'reset_autoloader' );
+
 		$this->assertFalse(
 			$this->guard->should_stop_init(
 				TEST_PLUGIN_DIR,
@@ -119,6 +116,7 @@ class LatestAutoloaderGuardTest extends TestCase {
 		$this->plugins_handler->method( 'have_plugins_changed' )
 			->with( array() )
 			->willReturn( true );
+		$this->autoloader_handler->expects( $this->once() )->method( 'reset_autoloader' );
 		$this->autoloader_locator->method( 'find_latest_autoloader' )
 			->willReturn( 'new-latest' );
 		$this->autoloader_locator->method( 'get_autoloader_path' )
@@ -145,6 +143,7 @@ class LatestAutoloaderGuardTest extends TestCase {
 		$this->plugins_handler->method( 'have_plugins_changed' )
 			->with( array() )
 			->willReturn( true );
+		$this->autoloader_handler->expects( $this->once() )->method( 'reset_autoloader' );
 		$this->autoloader_locator->method( 'find_latest_autoloader' )
 			->willReturn( null );
 

--- a/projects/packages/autoloader/tests/php/tests/unit/PHPAutoloaderTest.php
+++ b/projects/packages/autoloader/tests/php/tests/unit/PHPAutoloaderTest.php
@@ -32,9 +32,7 @@ class PHPAutoloaderTest extends TestCase {
 
 		global $jetpack_autoloader_loader;
 
-		$loader = $this->getMockBuilder( Version_Loader::class )
-			->disableOriginalConstructor()
-			->getMock();
+		$loader = $this->createStub( Version_Loader::class );
 
 		( new PHP_Autoloader() )->register_autoloader( $loader );
 

--- a/projects/packages/autoloader/tests/php/tests/unit/PluginLocatorTest.php
+++ b/projects/packages/autoloader/tests/php/tests/unit/PluginLocatorTest.php
@@ -208,6 +208,8 @@ class PluginLocatorTest extends TestCase {
 	 * Tests that plugins in request parameters are not discovered if a nonce is not set.
 	 */
 	public function test_using_request_action_returns_nothing_without_nonce() {
+		$this->path_processor->expects( $this->never() )->method( 'find_directory_with_autoloader' );
+
 		$_REQUEST['action'] = 'activate';
 		$_REQUEST['plugin'] = 'dummy_current/dummy_current.php';
 
@@ -237,6 +239,8 @@ class PluginLocatorTest extends TestCase {
 	 * Tests that plugins in the request action are not found if the action is not found.
 	 */
 	public function test_using_request_action_returns_nothing_without_action() {
+		$this->path_processor->expects( $this->never() )->method( 'find_directory_with_autoloader' );
+
 		$_REQUEST['_wpnonce'] = '123abc';
 		$_REQUEST['action']   = '';
 

--- a/projects/packages/autoloader/tests/php/tests/unit/PluginsHandlerTest.php
+++ b/projects/packages/autoloader/tests/php/tests/unit/PluginsHandlerTest.php
@@ -8,6 +8,7 @@
 // We live in the namespace of the test autoloader to avoid many use statements.
 namespace Automattic\Jetpack\Autoloader\jpCurrent;
 
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\PreserveGlobalState;
 use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 use PHPUnit\Framework\TestCase;
@@ -18,6 +19,7 @@ use PHPUnit\Framework\TestCase;
  * @runTestsInSeparateProcesses Ensure that each test has no previously autoloaded files.
  * @preserveGlobalState disabled
  */
+#[AllowMockObjectsWithoutExpectations /* Mocks created in setUp, some tests add expectations and others don't. */ ]
 #[RunTestsInSeparateProcesses]
 #[PreserveGlobalState( false )]
 class PluginsHandlerTest extends TestCase {
@@ -48,12 +50,8 @@ class PluginsHandlerTest extends TestCase {
 	 */
 	public function setUp(): void {
 		parent::setUp();
-		$this->plugin_locator  = $this->getMockBuilder( Plugin_Locator::class )
-			->disableOriginalConstructor()
-			->getMock();
-		$this->path_processor  = $this->getMockBuilder( Path_Processor::class )
-			->disableOriginalConstructor()
-			->getMock();
+		$this->plugin_locator  = $this->createMock( Plugin_Locator::class );
+		$this->path_processor  = $this->createMock( Path_Processor::class );
 		$this->plugins_handler = new Plugins_Handler( $this->plugin_locator, $this->path_processor );
 	}
 

--- a/projects/packages/changelogger/changelog/fix-phpunit-12-whining-about-mocks-vs-stubs
+++ b/projects/packages/changelogger/changelog/fix-phpunit-12-whining-about-mocks-vs-stubs
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix PHPUnit 12.5 whining about mocks versus stubs.
+
+

--- a/projects/packages/changelogger/tests/php/tests/lib/ParserTest.php
+++ b/projects/packages/changelogger/tests/php/tests/lib/ParserTest.php
@@ -25,7 +25,7 @@ class ParserTest extends TestCase {
 	/**
 	 * Get a mock Parser.
 	 *
-	 * @return Parser&\PHPUnit\Framework\StubObject\StubObject
+	 * @return Parser&\PHPUnit\Framework\MockObject\Stub
 	 */
 	private function getStubParser() {
 		if ( is_callable( array( $this, 'getStubBuilder' ) ) ) {

--- a/projects/packages/changelogger/tests/php/tests/lib/ParserTest.php
+++ b/projects/packages/changelogger/tests/php/tests/lib/ParserTest.php
@@ -25,19 +25,25 @@ class ParserTest extends TestCase {
 	/**
 	 * Get a mock Parser.
 	 *
-	 * @return Parser&\PHPUnit\Framework\MockObject\MockObject
+	 * @return Parser&\PHPUnit\Framework\StubObject\StubObject
 	 */
-	private function getMockParser() {
-		return $this->getMockBuilder( Parser::class )
-			->onlyMethods( array( 'parse', 'format' ) )
-			->getMock();
+	private function getStubParser() {
+		if ( is_callable( array( $this, 'getStubBuilder' ) ) ) {
+			return $this->getStubBuilder( Parser::class )
+				->onlyMethods( array( 'parse', 'format' ) )
+				->getStub();
+		} else {
+			return $this->getMockBuilder( Parser::class )
+				->onlyMethods( array( 'parse', 'format' ) )
+				->getMock();
+		}
 	}
 
 	/**
 	 * Test parseFromFile.
 	 */
 	public function testParseFromFile() {
-		$mock = $this->getMockParser();
+		$mock = $this->getStubParser();
 		$mock->method( 'parse' )->willReturnArgument( 0 );
 
 		$temp = tempnam( sys_get_temp_dir(), 'phpunit-testParseFromFile-' );
@@ -58,7 +64,7 @@ class ParserTest extends TestCase {
 	 * Test formatToFile.
 	 */
 	public function testFormatToFile() {
-		$mock      = $this->getMockParser();
+		$mock      = $this->getStubParser();
 		$changelog = new Changelog();
 		$mock->method( 'format' )
 			->with( $this->identicalTo( $changelog ) )
@@ -88,7 +94,7 @@ class ParserTest extends TestCase {
 	 * Test newChangelogEntry.
 	 */
 	public function testNewChangelogEntry() {
-		$mock = $this->getMockParser();
+		$mock = $this->getStubParser();
 		$this->assertInstanceOf( ChangelogEntry::class, $mock->newChangelogEntry( '1.0' ) );
 	}
 
@@ -96,7 +102,7 @@ class ParserTest extends TestCase {
 	 * Test newChangeEntry.
 	 */
 	public function testNewChangeEntry() {
-		$mock = $this->getMockParser();
+		$mock = $this->getStubParser();
 		$this->assertInstanceOf( ChangeEntry::class, $mock->newChangeEntry() );
 	}
 }

--- a/projects/packages/connection/.phan/baseline.php
+++ b/projects/packages/connection/.phan/baseline.php
@@ -15,13 +15,13 @@ return [
     // PhanTypeMismatchPropertyProbablyReal : 9 occurrences
     // PhanTypeMismatchReturnProbablyReal : 8 occurrences
     // PhanTypeArraySuspiciousNullable : 5 occurrences
+    // PhanTypeMismatchArgumentProbablyReal : 4 occurrences
     // PhanTypeMismatchDefault : 4 occurrences
-    // PhanTypeMismatchArgumentProbablyReal : 3 occurrences
-    // PhanTypeObjectUnsetDeclaredProperty : 3 occurrences
     // PhanDeprecatedFunction : 2 occurrences
     // PhanNonClassMethodCall : 2 occurrences
     // PhanPluginUnreachableCode : 2 occurrences
     // PhanTypeMismatchPropertyDefault : 2 occurrences
+    // PhanTypeObjectUnsetDeclaredProperty : 2 occurrences
     // PhanTypePossiblyInvalidDimOffset : 2 occurrences
     // PhanPluginDuplicateAdjacentStatement : 1 occurrence
     // PhanPluginSimplifyExpressionBool : 1 occurrence
@@ -57,7 +57,6 @@ return [
         'tests/php/REST_Authentication_Test.php' => ['PhanTypeMismatchArgument'],
         'tests/php/REST_Endpoints_Test.php' => ['PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchReturn', 'PhanTypeMismatchReturnProbablyReal'],
         'tests/php/Server_Sandbox_Test.php' => ['PhanTypeArraySuspiciousNullable'],
-        'tests/php/TokensTest.php' => ['PhanTypeObjectUnsetDeclaredProperty'],
     ],
     // 'directory_suppressions' => ['src/directory_name' => ['PhanIssueName1', 'PhanIssueName2']] can be manually added if needed.
     // (directory_suppressions will currently be ignored by subsequent calls to --save-baseline, but may be preserved in future Phan releases)

--- a/projects/packages/connection/changelog/fix-phpunit-12-whining-about-mocks-vs-stubs
+++ b/projects/packages/connection/changelog/fix-phpunit-12-whining-about-mocks-vs-stubs
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix PHPUnit 12.5 whining about mocks versus stubs.
+
+

--- a/projects/packages/connection/tests/php/Error_Handler_Test.php
+++ b/projects/packages/connection/tests/php/Error_Handler_Test.php
@@ -608,13 +608,15 @@ class Error_Handler_Test extends BaseTestCase {
 	 */
 	public function test_send_error_to_wpcom_encryption_failure() {
 		// Mock encryption to fail
-		$error_handler_mock = $this->getMockBuilder( Error_Handler::class )
-			->disableOriginalConstructor()
-			->onlyMethods( array( 'encrypt_data_to_wpcom' ) )
-			->getMock();
-
-		$error_handler_mock->method( 'encrypt_data_to_wpcom' )
-			->willReturn( false );
+		// Anonymous class to disable constructor and replace one method.
+		// PHPUnit 12.5 whines about mocks without expectations, while getStubBuilder() doesn't exist until 12.5.
+		$error_handler_mock = new class() extends Error_Handler {
+			public function __construct() {
+			}
+			public function encrypt_data_to_wpcom( $data ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+				return false;
+			}
+		};
 
 		$error_array = array(
 			'error_code' => 'test_error',

--- a/projects/packages/connection/tests/php/ManagerTest.php
+++ b/projects/packages/connection/tests/php/ManagerTest.php
@@ -10,6 +10,7 @@ namespace Automattic\Jetpack\Connection;
 use Automattic\Jetpack\Constants;
 use Automattic\Jetpack\Status\Cache as StatusCache;
 use Jetpack_Options;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use WorDBless\Options as WorDBless_Options;
@@ -19,6 +20,7 @@ use WP_Error;
 /**
  * Connection Manager functionality testing.
  */
+#[AllowMockObjectsWithoutExpectations /* Mocks created in setUp, some tests add expectations and others don't. Plus getStubBuilder() (for partial stubs) doesn't exist until PHPUnit 12.5. */ ]
 class ManagerTest extends TestCase {
 
 	/**
@@ -288,7 +290,7 @@ class ManagerTest extends TestCase {
 
 		( new Plugin( 'plugin-slug-2' ) )->add( 'Plugin Name 2' );
 
-		$stub = $this->createMock( Plugin::class );
+		$stub = $this->createStub( Plugin::class );
 		$stub->method( 'is_only' )
 			->willReturn( false );
 		$manager = ( new Manager() )->set_plugin_instance( $stub );
@@ -304,7 +306,7 @@ class ManagerTest extends TestCase {
 
 		( new Plugin( 'plugin-slug-2' ) )->add( 'Plugin Name 2' );
 
-		$stub = $this->createMock( Plugin::class );
+		$stub = $this->createStub( Plugin::class );
 		$stub->method( 'is_only' )
 			->willReturn( false );
 		$manager = ( new Manager() )->set_plugin_instance( $stub );

--- a/projects/packages/connection/tests/php/REST_Authentication_Test.php
+++ b/projects/packages/connection/tests/php/REST_Authentication_Test.php
@@ -7,6 +7,7 @@
 
 namespace Automattic\Jetpack\Connection;
 
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
@@ -16,6 +17,7 @@ use PHPUnit\Framework\TestCase;
  *
  * @covers \Automattic\Jetpack\Connection\REST_Authentication
  */
+#[AllowMockObjectsWithoutExpectations /* Mocks created in setUp, some tests add expectations and others don't. Plus getStubBuilder() (for partial stubs) doesn't exist until PHPUnit 12.5. */ ]
 #[CoversClass( REST_Authentication::class )]
 class REST_Authentication_Test extends TestCase {
 

--- a/projects/packages/connection/tests/php/TokensTest.php
+++ b/projects/packages/connection/tests/php/TokensTest.php
@@ -31,29 +31,11 @@ class TokensTest extends TestCase {
 	private $site_url;
 
 	/**
-	 * Tokens mock object.
-	 *
-	 * @var Tokens
-	 */
-	private $tokens;
-
-	/**
-	 * Initialize the object before running the test method.
-	 */
-	public function setUp(): void {
-		parent::setUp();
-		$this->tokens = $this->getMockBuilder( 'Automattic\Jetpack\Connection\Tokens' )
-			->onlyMethods( array( 'get_access_token' ) )
-			->getMock();
-	}
-
-	/**
 	 * Clean up the testing environment.
 	 */
 	public function tearDown(): void {
 		parent::tearDown();
 		remove_all_filters( 'jetpack_options' );
-		unset( $this->tokens );
 		Constants::clear_constants();
 	}
 
@@ -62,7 +44,7 @@ class TokensTest extends TestCase {
 	 */
 	public function test_validate_when_site_is_not_registered() {
 		$expected = new WP_Error( 'site_not_registered', 'Site not registered.' );
-		$this->assertEquals( $expected, $this->tokens->validate() );
+		$this->assertEquals( $expected, ( new Tokens() )->validate() );
 	}
 
 	/**
@@ -84,10 +66,13 @@ class TokensTest extends TestCase {
 
 		$user_token = false;
 
-		$this->tokens->expects( $this->exactly( 2 ) )
+		$tokens = $this->getMockBuilder( 'Automattic\Jetpack\Connection\Tokens' )
+			->onlyMethods( array( 'get_access_token' ) )
+			->getMock();
+		$tokens->expects( $this->exactly( 2 ) )
 			->method( 'get_access_token' )
 			->willReturnOnConsecutiveCalls( $blog_token, $user_token );
-		$this->assertFalse( $this->tokens->validate() );
+		$this->assertFalse( $tokens->validate() );
 	}
 
 	/**
@@ -113,11 +98,14 @@ class TokensTest extends TestCase {
 			'external_user_id' => 1,
 		);
 
-		$this->tokens->expects( $this->exactly( 2 ) )
+		$tokens = $this->getMockBuilder( 'Automattic\Jetpack\Connection\Tokens' )
+			->onlyMethods( array( 'get_access_token' ) )
+			->getMock();
+		$tokens->expects( $this->exactly( 2 ) )
 			->method( 'get_access_token' )
 			->willReturnOnConsecutiveCalls( $blog_token, $user_token );
 
-		$this->assertFalse( $this->tokens->validate() );
+		$this->assertFalse( $tokens->validate() );
 
 		remove_filter( 'pre_http_request', array( $this, 'intercept_jetpack_token_health_request_failed' ), 10 );
 	}
@@ -145,7 +133,10 @@ class TokensTest extends TestCase {
 			'external_user_id' => 1,
 		);
 
-		$this->tokens->expects( $this->exactly( 2 ) )
+		$tokens = $this->getMockBuilder( 'Automattic\Jetpack\Connection\Tokens' )
+			->onlyMethods( array( 'get_access_token' ) )
+			->getMock();
+		$tokens->expects( $this->exactly( 2 ) )
 			->method( 'get_access_token' )
 			->willReturnOnConsecutiveCalls( $blog_token, $user_token );
 
@@ -158,7 +149,7 @@ class TokensTest extends TestCase {
 				'is_master_user' => true,
 			),
 		);
-		$this->assertSame( $expected, $this->tokens->validate() );
+		$this->assertSame( $expected, $tokens->validate() );
 
 		remove_filter( 'pre_http_request', array( $this, 'intercept_jetpack_token_health_request_success' ), 10 );
 	}

--- a/projects/packages/connection/tests/php/Tracking_Test.php
+++ b/projects/packages/connection/tests/php/Tracking_Test.php
@@ -8,6 +8,7 @@
 namespace Automattic\Jetpack;
 
 use Brain\Monkey;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
@@ -17,6 +18,7 @@ use PHPUnit\Framework\TestCase;
  *
  * @covers \Automattic\Jetpack\Tracking
  */
+#[AllowMockObjectsWithoutExpectations /* getStubBuilder() (for partial stubs) doesn't exist until PHPUnit 12.5. */ ]
 #[CoversClass( Tracking::class )]
 class Tracking_Test extends TestCase {
 

--- a/projects/packages/connection/tests/php/Webhooks_Test.php
+++ b/projects/packages/connection/tests/php/Webhooks_Test.php
@@ -90,7 +90,7 @@ class Webhooks_Test extends TestCase {
 	 * Testing the successful authorization.
 	 */
 	public function test_handle_authorize_success() {
-		$manager = $this->createMock( Manager::class );
+		$manager = $this->createStub( Manager::class );
 		$manager->method( 'authorize' )
 				->willReturn( 'authorized' );
 
@@ -155,6 +155,7 @@ class Webhooks_Test extends TestCase {
 			->setConstructorArgs( array( new Manager() ) )
 			->onlyMethods( array( 'do_exit' ) )
 			->getMock();
+		$webhooks->expects( $this->once() )->method( 'do_exit' );
 
 		Constants::set_constant( 'JETPACK__API_BASE', 'https://example.com/api/base.' );
 		Constants::set_constant( 'JETPACK__API_VERSION', '1' );

--- a/projects/packages/google-analytics/changelog/fix-phpunit-12-whining-about-mocks-vs-stubs
+++ b/projects/packages/google-analytics/changelog/fix-phpunit-12-whining-about-mocks-vs-stubs
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix PHPUnit 12.5 whining about mocks versus stubs.
+
+

--- a/projects/packages/google-analytics/tests/php/Jetpack_Google_Analytics_Test.php
+++ b/projects/packages/google-analytics/tests/php/Jetpack_Google_Analytics_Test.php
@@ -151,11 +151,12 @@ class Jetpack_Google_Analytics_Test extends TestCase {
 		// GA code is only inserted in non-admin screens.
 		set_current_screen( 'front' );
 
-		// Mock `Jetpack_Google_Analytics_Legacy` instance to disable the constructor class.
-		$instance = $this->getMockBuilder( Legacy::class )
-			->onlyMethods( array() )
-			->disableOriginalConstructor()
-			->getMock();
+		// Subclass `Jetpack_Google_Analytics_Legacy` instance to disable the constructor class.
+		// PHPUnit 12.5 whines about mocks without expectations, while getStubBuilder() (for partial stubs) doesn't exist until 12.5.
+		$instance = new class() extends Legacy {
+			public function __construct() {
+			}
+		};
 
 		ob_start();
 		$instance->insert_code();

--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-phpunit-12-whining-about-mocks-vs-stubs
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-phpunit-12-whining-about-mocks-vs-stubs
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix PHPUnit 12.5 whining about mocks versus stubs.
+
+

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/block-patterns/Wpcom_Block_Patterns_From_Api_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/block-patterns/Wpcom_Block_Patterns_From_Api_Test.php
@@ -157,7 +157,7 @@ class Wpcom_Block_Patterns_From_Api_Test extends TestCase {
 	 */
 	public function multiple_route_pattern_registration( $patterns_from_api_mock, $test_routes ) {
 		foreach ( $test_routes as $route ) {
-			$request_mock = $this->createMock( \WP_REST_Request::class );
+			$request_mock = $this->createStub( \WP_REST_Request::class );
 			$request_mock->method( 'get_route' )->willReturn( $route );
 
 			$function = register_patterns_on_api_request(

--- a/projects/packages/licensing/changelog/fix-phpunit-12-whining-about-mocks-vs-stubs
+++ b/projects/packages/licensing/changelog/fix-phpunit-12-whining-about-mocks-vs-stubs
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix PHPUnit 12.5 whining about mocks versus stubs.
+
+

--- a/projects/packages/licensing/tests/php/Licensing_Test.php
+++ b/projects/packages/licensing/tests/php/Licensing_Test.php
@@ -115,16 +115,17 @@ class Licensing_Test extends BaseTestCase {
 	 * Test attach_licenses() without an active Jetpack connection.
 	 */
 	public function test_attach_licenses__without_connection() {
-		$connection = $this->createMock( Connection_Manager::class );
+		$connection = $this->createStub( Connection_Manager::class );
 
 		$connection->method( 'has_connected_owner' )->willReturn( false );
 
 		$licensing = $this->createPartialMock(
 			Licensing::class,
-			array( 'connection' )
+			array( 'connection', 'attach_licenses_request' )
 		);
 
 		$licensing->method( 'connection' )->willReturn( $connection );
+		$licensing->expects( $this->never() )->method( 'attach_licenses_request' );
 
 		$result = $licensing->attach_licenses( array() );
 
@@ -136,16 +137,17 @@ class Licensing_Test extends BaseTestCase {
 	 * Test attach_licenses() with an empty input.
 	 */
 	public function test_attach_licenses__empty_input() {
-		$connection = $this->createMock( Connection_Manager::class );
+		$connection = $this->createStub( Connection_Manager::class );
 
 		$connection->method( 'has_connected_owner' )->willReturn( true );
 
 		$licensing = $this->createPartialMock(
 			Licensing::class,
-			array( 'connection' )
+			array( 'connection', 'attach_licenses_request' )
 		);
 
 		$licensing->method( 'connection' )->willReturn( $connection );
+		$licensing->expects( $this->never() )->method( 'attach_licenses_request' );
 
 		$this->assertSame( array(), $licensing->attach_licenses( array() ) );
 	}
@@ -156,7 +158,7 @@ class Licensing_Test extends BaseTestCase {
 	public function test_attach_licenses__request_failure() {
 		$licenses = array( 'foo', 'bar' );
 
-		$connection = $this->createMock( Connection_Manager::class );
+		$connection = $this->createStub( Connection_Manager::class );
 
 		$connection->method( 'has_connected_owner' )->willReturn( true );
 
@@ -169,7 +171,7 @@ class Licensing_Test extends BaseTestCase {
 			->method( 'connection' )
 			->willReturn( $connection );
 
-		$ixr_client = $this->createMock( Jetpack_IXR_ClientMulticall::class );
+		$ixr_client = $this->createStub( Jetpack_IXR_ClientMulticall::class );
 		$ixr_client->method( 'isError' )->willReturn( true );
 		$ixr_client->method( 'getErrorCode' )->willReturn( 1 );
 		$ixr_client->method( 'getErrorMessage' )->willReturn( 'Expected error message' );
@@ -192,7 +194,7 @@ class Licensing_Test extends BaseTestCase {
 	public function test_attach_licenses__multiple_licenses() {
 		$licenses = array( 'foo', 'bar' );
 
-		$connection = $this->createMock( Connection_Manager::class );
+		$connection = $this->createStub( Connection_Manager::class );
 
 		$connection->method( 'has_connected_owner' )->willReturn( true );
 
@@ -205,7 +207,7 @@ class Licensing_Test extends BaseTestCase {
 			->method( 'connection' )
 			->willReturn( $connection );
 
-		$ixr_client = $this->createMock( Jetpack_IXR_ClientMulticall::class );
+		$ixr_client = $this->createStub( Jetpack_IXR_ClientMulticall::class );
 		$ixr_client->method( 'isError' )
 			->willReturn( false );
 		$ixr_client->method( 'getResponse' )
@@ -239,7 +241,7 @@ class Licensing_Test extends BaseTestCase {
 	public function test_attach_licenses__returns_product_ids_on_success() {
 		$licenses = array( 'foo' );
 
-		$connection = $this->createMock( Connection_Manager::class );
+		$connection = $this->createStub( Connection_Manager::class );
 
 		$connection->method( 'has_connected_owner' )->willReturn( true );
 
@@ -252,7 +254,7 @@ class Licensing_Test extends BaseTestCase {
 			->method( 'connection' )
 			->willReturn( $connection );
 
-		$ixr_client = $this->createMock( Jetpack_IXR_ClientMulticall::class );
+		$ixr_client = $this->createStub( Jetpack_IXR_ClientMulticall::class );
 		$ixr_client->method( 'isError' )->willReturn( false );
 		$ixr_client->method( 'query' )->willReturn( null );
 		$ixr_client->method( 'getResponse' )->willReturn( array( array( 'activatedProductId' => 1 ) ) );
@@ -381,7 +383,7 @@ class Licensing_Test extends BaseTestCase {
 	 * Test attach_stored_licenses_on_connection() for the master user.
 	 */
 	public function test_attach_stored_licenses_on_connection__master_user() {
-		$connection = $this->createMock( Connection_Manager::class );
+		$connection = $this->createStub( Connection_Manager::class );
 
 		$connection->method( 'is_connection_owner' )->willReturn( true );
 
@@ -402,7 +404,7 @@ class Licensing_Test extends BaseTestCase {
 	 * Test attach_stored_licenses_on_connection() for a secondary user.
 	 */
 	public function test_attach_stored_licenses_on_connection__secondary_user() {
-		$connection = $this->createMock( Connection_Manager::class );
+		$connection = $this->createStub( Connection_Manager::class );
 
 		$connection->method( 'is_connection_owner' )->willReturn( false );
 

--- a/projects/packages/masterbar/changelog/fix-phpunit-12-whining-about-mocks-vs-stubs
+++ b/projects/packages/masterbar/changelog/fix-phpunit-12-whining-about-mocks-vs-stubs
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix PHPUnit 12.5 whining about mocks versus stubs.
+
+

--- a/projects/packages/masterbar/tests/php/Atomic_Additional_CSS_Manager_Test.php
+++ b/projects/packages/masterbar/tests/php/Atomic_Additional_CSS_Manager_Test.php
@@ -7,6 +7,7 @@
 
 namespace Automattic\Jetpack\Masterbar;
 
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use WorDBless\Options as WorDBless_Options;
@@ -19,6 +20,7 @@ require_once ABSPATH . WPINC . '/class-wp-customize-section.php';
 /**
  * @covers Automattic\Jetpack\Masterbar\Atomic_Additional_CSS_Manager
  */
+#[AllowMockObjectsWithoutExpectations /* getStubBuilder() (for partial stubs) doesn't exist until PHPUnit 12.5. */ ]
 #[CoversClass( Atomic_Additional_CSS_Manager::class )]
 class Atomic_Additional_CSS_Manager_Test extends TestCase {
 	/**

--- a/projects/packages/masterbar/tests/php/Domain_Only_Admin_Menu_Test.php
+++ b/projects/packages/masterbar/tests/php/Domain_Only_Admin_Menu_Test.php
@@ -8,6 +8,7 @@
 namespace Automattic\Jetpack\Masterbar;
 
 use Automattic\Jetpack\Status;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use WorDBless\Options as WorDBless_Options;
@@ -20,6 +21,7 @@ require_once __DIR__ . '/data/admin-menu.php';
  *
  * @covers Automattic\Jetpack\Masterbar\Domain_Only_Admin_Menu
  */
+#[AllowMockObjectsWithoutExpectations /* getStubBuilder() (for partial stubs) doesn't exist until PHPUnit 12.5. */ ]
 #[CoversClass( Domain_Only_Admin_Menu::class )]
 class Domain_Only_Admin_Menu_Test extends TestCase {
 

--- a/projects/packages/masterbar/tests/php/WPCOM_Additional_Css_Manager_Test.php
+++ b/projects/packages/masterbar/tests/php/WPCOM_Additional_Css_Manager_Test.php
@@ -7,6 +7,7 @@
 
 namespace Automattic\Jetpack\Masterbar;
 
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
@@ -19,6 +20,7 @@ require_once ABSPATH . WPINC . '/class-wp-customize-section.php';
  *
  * @covers Automattic\Jetpack\Masterbar\WPCOM_Additional_CSS_Manager
  */
+#[AllowMockObjectsWithoutExpectations /* getStubBuilder() (for partial stubs) doesn't exist until PHPUnit 12.5. */ ]
 #[CoversClass( WPCOM_Additional_CSS_Manager::class )]
 class WPCOM_Additional_Css_Manager_Test extends TestCase {
 

--- a/projects/packages/masterbar/tests/php/WPCOM_User_Profile_Fields_Revert_Test.php
+++ b/projects/packages/masterbar/tests/php/WPCOM_User_Profile_Fields_Revert_Test.php
@@ -75,7 +75,7 @@ class WPCOM_User_Profile_Fields_Revert_Test extends TestCase {
 	 * Check if the revert ignores not connected users.
 	 */
 	public function test_if_it_skips_not_connected_users() {
-		$connection_manager = $this->createMock( Connection_Manager::class );
+		$connection_manager = $this->createStub( Connection_Manager::class );
 		$connection_manager->method( 'is_user_connected' )->willReturn( false );
 		$service = new WPCOM_User_Profile_Fields_Revert( $connection_manager );
 
@@ -89,7 +89,7 @@ class WPCOM_User_Profile_Fields_Revert_Test extends TestCase {
 	 * Check if the implementation prevents updating the display_name.
 	 */
 	public function test_revert_display_name() {
-		$connection_manager = $this->createMock( Connection_Manager::class );
+		$connection_manager = $this->createStub( Connection_Manager::class );
 		$connection_manager->method( 'is_user_connected' )->willReturn( true );
 		$service = new WPCOM_User_Profile_Fields_Revert( $connection_manager );
 
@@ -103,7 +103,7 @@ class WPCOM_User_Profile_Fields_Revert_Test extends TestCase {
 	 * Check if the revert works for first_name, last_name and description fields.
 	 */
 	public function test_revert_user_fields() {
-		$connection_manager = $this->createMock( Connection_Manager::class );
+		$connection_manager = $this->createStub( Connection_Manager::class );
 		$connection_manager->method( 'is_user_connected' )->willReturn( true );
 		$service = new WPCOM_User_Profile_Fields_Revert( $connection_manager );
 

--- a/projects/packages/publicize/changelog/fix-phpunit-12-whining-about-mocks-vs-stubs
+++ b/projects/packages/publicize/changelog/fix-phpunit-12-whining-about-mocks-vs-stubs
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix PHPUnit 12.5 whining about mocks versus stubs.
+
+

--- a/projects/packages/publicize/tests/php/Connections_Post_Field_Test.php
+++ b/projects/packages/publicize/tests/php/Connections_Post_Field_Test.php
@@ -2,6 +2,7 @@
 
 namespace Automattic\Jetpack\Publicize;
 
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\TestCase;
 use WorDBless\Options as WorDBless_Options;
 use WorDBless\Posts as WorDBless_Posts;
@@ -14,6 +15,7 @@ use WP_REST_Server;
  *
  * @package automattic/jetpack-publicize
  */
+#[AllowMockObjectsWithoutExpectations /* getStubBuilder() (for partial stubs) doesn't exist until PHPUnit 12.5. */ ]
 class Connections_Post_Field_Test extends TestCase {
 
 	/**

--- a/projects/packages/publicize/tests/php/Scheduled_Actions_Controller_Test.php
+++ b/projects/packages/publicize/tests/php/Scheduled_Actions_Controller_Test.php
@@ -7,6 +7,7 @@ namespace Automattic\Jetpack\Publicize;
 
 use Automattic\Jetpack\Constants;
 use Automattic\Jetpack\Publicize\REST_API\Scheduled_Actions_Controller;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\TestCase;
 use WorDBless\Options as WorDBless_Options;
 use WorDBless\Posts as WorDBless_Posts;
@@ -18,6 +19,7 @@ use WpOrg\Requests\Requests;
 /**
  * Class Scheduled_Actions_Controller_Test
  */
+#[AllowMockObjectsWithoutExpectations /* getStubBuilder() (for partial stubs) doesn't exist until PHPUnit 12.5. */ ]
 class Scheduled_Actions_Controller_Test extends TestCase {
 
 	/**

--- a/projects/packages/publicize/tests/php/jetpack-social-settings/Jetpack_Social_Settings_Test.php
+++ b/projects/packages/publicize/tests/php/jetpack-social-settings/Jetpack_Social_Settings_Test.php
@@ -9,6 +9,7 @@ namespace Automattic\Jetpack\Publicize;
 
 use Automattic\Jetpack\Publicize\Jetpack_Social_Settings\Settings as SocialSettings;
 use Automattic\Jetpack\Publicize\Social_Image_Generator\Templates;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use WorDBless\BaseTestCase;
 use WorDBless\Options as WorDBless_Options;
 use WorDBless\Posts as WorDBless_Posts;
@@ -17,6 +18,7 @@ use WorDBless\Users as WorDBless_Users;
 /**
  * Testing the Settings class.
  */
+#[AllowMockObjectsWithoutExpectations /* getStubBuilder() (for partial stubs) doesn't exist until PHPUnit 12.5. */ ]
 class Jetpack_Social_Settings_Test extends BaseTestCase {
 	/**
 	 * Instance of the Settings class.

--- a/projects/packages/publicize/tests/php/test-social-image-generator/Post_Settings_Test.php
+++ b/projects/packages/publicize/tests/php/test-social-image-generator/Post_Settings_Test.php
@@ -33,7 +33,12 @@ class Post_Settings_Test extends BaseTestCase {
 	 * Initialize tests
 	 */
 	public function set_up() {
-		$publicize = $this->getMockBuilder( Publicize::class )->disableOriginalConstructor()->onlyMethods( array() )->getMock();
+		// Anonymous class to disable constructor.
+		// PHPUnit 12.5 whines about mocks without expectations, while getStubBuilder() (for partial mocks) doesn't exist until 12.5.
+		$publicize = new class() extends Publicize {
+			public function __construct() {
+			}
+		};
 		$publicize->register_post_meta();
 
 		$this->post_id       = wp_insert_post(

--- a/projects/packages/search/changelog/fix-phpunit-12-whining-about-mocks-vs-stubs
+++ b/projects/packages/search/changelog/fix-phpunit-12-whining-about-mocks-vs-stubs
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix PHPUnit 12.5 whining about mocks versus stubs.
+
+

--- a/projects/packages/search/tests/php/Module_Control_Test.php
+++ b/projects/packages/search/tests/php/Module_Control_Test.php
@@ -31,13 +31,13 @@ class Module_Control_Test extends Search_TestCase {
 	public function setUp(): void {
 		parent::setUp();
 
-		$plan = $this->createMock( Plan::class );
+		$plan = $this->createStub( Plan::class );
 		$plan->method( 'supports_search' )->willReturn( true );
 		$plan->method( 'supports_instant_search' )->willReturn( true );
 
 		static::$search_module = new Module_Control( $plan );
 
-		$plan = $this->createMock( Plan::class );
+		$plan = $this->createStub( Plan::class );
 		$plan->method( 'supports_search' )->willReturn( true );
 		$plan->method( 'supports_instant_search' )->willReturn( false );
 
@@ -75,7 +75,7 @@ class Module_Control_Test extends Search_TestCase {
 	 * Test static::$search_module->activate() when search is not supported
 	 */
 	public function test_activate_module_failed_not_supported() {
-		$plan = $this->createMock( Plan::class );
+		$plan = $this->createStub( Plan::class );
 		$plan->method( 'supports_search' )->willReturn( false );
 
 		$search_module = new Module_Control( $plan );
@@ -89,7 +89,7 @@ class Module_Control_Test extends Search_TestCase {
 	 * Test static::$search_module->activate() when site is not connected
 	 */
 	public function test_activate_module_failed_connection_required() {
-		$connection_manager = $this->createMock( Connection_Manager::class );
+		$connection_manager = $this->createStub( Connection_Manager::class );
 		$connection_manager->method( 'is_connected' )->willReturn( false );
 		$search_module = new Module_Control( null, $connection_manager );
 		$err           = $search_module->activate();

--- a/projects/packages/search/tests/php/REST_Controller_Test.php
+++ b/projects/packages/search/tests/php/REST_Controller_Test.php
@@ -41,7 +41,7 @@ class REST_Controller_Test extends Search_TestCase {
 
 		wp_set_current_user( 0 );
 
-		$plan = $this->createMock( Plan::class );
+		$plan = $this->createStub( Plan::class );
 		$plan->method( 'supports_search' )->willReturn( true );
 		$plan->method( 'supports_instant_search' )->willReturn( true );
 

--- a/projects/packages/stats-admin/changelog/fix-phpunit-12-whining-about-mocks-vs-stubs
+++ b/projects/packages/stats-admin/changelog/fix-phpunit-12-whining-about-mocks-vs-stubs
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix PHPUnit 12.5 whining about mocks versus stubs.
+
+

--- a/projects/packages/stats-admin/tests/php/Admin_Post_List_Test.php
+++ b/projects/packages/stats-admin/tests/php/Admin_Post_List_Test.php
@@ -1,8 +1,10 @@
 <?php
 use Automattic\Jetpack\Stats_Admin\Admin_Post_List_Column;
 use Automattic\Jetpack\Stats_Admin\TestCase as BaseTestCase;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\DataProvider;
 
+#[AllowMockObjectsWithoutExpectations /* getStubBuilder() (for partial stubs) doesn't exist until PHPUnit 12.5. */ ]
 class Admin_Post_List_Test extends BaseTestCase {
 	/**
 	 * Get a mock for the WP_Query class.
@@ -12,7 +14,7 @@ class Admin_Post_List_Test extends BaseTestCase {
 	 * @return WP_Query The mocked WP_Query object.
 	 */
 	private function get_wp_query_mock( int $post_id ) {
-		$wp_query = $this->createMock( WP_Query::class );
+		$wp_query = $this->createStub( WP_Query::class );
 
 		$wp_query->query_vars = array();
 		$wp_query->posts      = array( (object) array( 'ID' => $post_id ) );
@@ -246,7 +248,7 @@ class Admin_Post_List_Test extends BaseTestCase {
 		);
 
 		// Mock get_stats() method to return fake views
-		$mock_stats = $this->createMock( Automattic\Jetpack\Stats\WPCOM_Stats::class );
+		$mock_stats = $this->createStub( Automattic\Jetpack\Stats\WPCOM_Stats::class );
 		$mock_stats->method( 'get_total_post_views' )->willReturn(
 			array(
 				'posts' => array(

--- a/projects/packages/status/changelog/fix-phpunit-12-whining-about-mocks-vs-stubs
+++ b/projects/packages/status/changelog/fix-phpunit-12-whining-about-mocks-vs-stubs
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix PHPUnit 12.5 whining about mocks versus stubs.
+
+

--- a/projects/packages/status/tests/php/Host_Test.php
+++ b/projects/packages/status/tests/php/Host_Test.php
@@ -199,10 +199,13 @@ class Host_Test extends TestCase {
 	 */
 	public function test_is_p2_site_true_if_wpforteams_function_exists_and_true() {
 		// Mock get_wpcom_site_id to ensure we are testing all existing functions within is_p2_site().
-		$host = $this->getMockBuilder( Host::class )
-		->onlyMethods( array( 'get_wpcom_site_id' ) )
-		->getMock();
-		$host->method( 'get_wpcom_site_id' )->willReturn( 123 );
+		// Anonymous class to replace method.
+		// PHPUnit 12.5 whines about mocks without expectations, while getStubBuilder() (for partial mocks) doesn't exist until 12.5.
+		$host = new class() extends Host {
+			public function get_wpcom_site_id() {
+				return 123;
+			}
+		};
 
 		Functions\when( 'get_stylesheet' )->justReturn( 'not-p2-theme' );
 		Functions\when( 'function_exists' )->alias(

--- a/projects/packages/sync/changelog/fix-phpunit-12-whining-about-mocks-vs-stubs
+++ b/projects/packages/sync/changelog/fix-phpunit-12-whining-about-mocks-vs-stubs
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix PHPUnit 12.5 whining about mocks versus stubs.
+
+

--- a/projects/packages/sync/tests/php/Dedicated_Sender_Test.php
+++ b/projects/packages/sync/tests/php/Dedicated_Sender_Test.php
@@ -2,6 +2,7 @@
 
 namespace Automattic\Jetpack\Sync;
 
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\CoversClass;
 use WorDBless\BaseTestCase;
 use WorDBless\Options as WorDBless_Options;
@@ -13,6 +14,7 @@ use WorDBless\Options as WorDBless_Options;
  *
  * @package automattic/jetpack-sync
  */
+#[AllowMockObjectsWithoutExpectations /* getStubBuilder() (for partial stubs) doesn't exist until PHPUnit 12.5. */ ]
 #[CoversClass( Dedicated_Sender::class )]
 class Dedicated_Sender_Test extends BaseTestCase {
 	/**

--- a/projects/packages/sync/tests/php/modules/Module_Test.php
+++ b/projects/packages/sync/tests/php/modules/Module_Test.php
@@ -7,6 +7,7 @@
 
 namespace Automattic\Jetpack\Sync;
 
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\CoversClass;
 use WorDBless\BaseTestCase;
 
@@ -15,6 +16,7 @@ use WorDBless\BaseTestCase;
  *
  * @covers Automattic\Jetpack\Sync\Modules\Module
  */
+#[AllowMockObjectsWithoutExpectations /* getStubBuilder() (for partial stubs) doesn't exist until PHPUnit 12.5. */ ]
 #[CoversClass( Modules\Module::class )]
 class Module_Test extends BaseTestCase {
 

--- a/projects/packages/waf/changelog/fix-phpunit-12-whining-about-mocks-vs-stubs
+++ b/projects/packages/waf/changelog/fix-phpunit-12-whining-about-mocks-vs-stubs
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix PHPUnit 12.5 whining about mocks versus stubs.
+
+

--- a/projects/packages/waf/tests/php/integration/BruteForceProtectionTest.php
+++ b/projects/packages/waf/tests/php/integration/BruteForceProtectionTest.php
@@ -6,12 +6,14 @@
  */
 
 use Automattic\Jetpack\Waf\Brute_Force_Protection\Brute_Force_Protection;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\BackupGlobals;
 use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * Brute Force Protection test case.
  */
+#[AllowMockObjectsWithoutExpectations /* getStubBuilder() (for partial stubs) doesn't exist until PHPUnit 12.5. */ ]
 class BruteForceProtectionTest extends WorDBless\BaseTestCase {
 
 	/**

--- a/projects/packages/waf/tests/php/integration/WafUpdateTest.php
+++ b/projects/packages/waf/tests/php/integration/WafUpdateTest.php
@@ -25,7 +25,7 @@ final class WafUpdateTest extends WorDBless\BaseTestCase {
 		$broken_value = 'something-broken';
 		update_option( Waf_Initializer::NEEDS_UPDATE_OPTION_NAME, $broken_value );
 
-		Waf_Initializer::update_waf_after_plugin_upgrade( $this->createMock( 'WP_Upgrader' ), array() );
+		Waf_Initializer::update_waf_after_plugin_upgrade( $this->createStub( 'WP_Upgrader' ), array() );
 		$this->assertSame( $broken_value, get_option( Waf_Initializer::NEEDS_UPDATE_OPTION_NAME, null ), 'The update need option should still be the broken value.' );
 	}
 }

--- a/projects/packages/waf/tests/php/unit/WafRequestTest.php
+++ b/projects/packages/waf/tests/php/unit/WafRequestTest.php
@@ -6,11 +6,13 @@
  */
 
 use Automattic\Jetpack\Waf\Waf_Request;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\TestWith;
 
 /**
  * Request test suite.
  */
+#[AllowMockObjectsWithoutExpectations /* Mocks created in setUp, some tests add expectations and others don't. */ ]
 class WafRequestTest extends PHPUnit\Framework\TestCase {
 
 	/**

--- a/projects/packages/waf/tests/php/unit/WafRuntimeTargetsTest.php
+++ b/projects/packages/waf/tests/php/unit/WafRuntimeTargetsTest.php
@@ -9,11 +9,13 @@ use Automattic\Jetpack\Waf\Waf_Operators;
 use Automattic\Jetpack\Waf\Waf_Request;
 use Automattic\Jetpack\Waf\Waf_Runtime;
 use Automattic\Jetpack\Waf\Waf_Transforms;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * Runtime test suite.
  */
+#[AllowMockObjectsWithoutExpectations /* getStubBuilder() (for partial stubs) doesn't exist until PHPUnit 12.5. */ ]
 final class WafRuntimeTargetsTest extends PHPUnit\Framework\TestCase {
 
 	/**

--- a/projects/packages/waf/tests/php/unit/WafStandaloneBootstrapTest.php
+++ b/projects/packages/waf/tests/php/unit/WafStandaloneBootstrapTest.php
@@ -6,6 +6,7 @@
  */
 
 use Automattic\Jetpack\Waf\Waf_Standalone_Bootstrap;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 
 // phpcs:disable Generic.Files.OneObjectStructurePerFile.MultipleFound
@@ -21,6 +22,7 @@ interface WafStandaloneBootstrapTest_filesystem_mock {
 /**
  * Runtime test suite.
  */
+#[AllowMockObjectsWithoutExpectations /* getStubBuilder() (for partial stubs) doesn't exist until PHPUnit 12.5. */ ]
 final class WafStandaloneBootstrapTest extends PHPUnit\Framework\TestCase {
 
 	/**

--- a/projects/plugins/crm/changelog/fix-phpunit-12-whining-about-mocks-vs-stubs
+++ b/projects/plugins/crm/changelog/fix-phpunit-12-whining-about-mocks-vs-stubs
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix PHPUnit 12.5 whining about mocks versus stubs.
+
+

--- a/projects/plugins/crm/composer.lock
+++ b/projects/plugins/crm/composer.lock
@@ -1936,16 +1936,16 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v5.6.2",
+            "version": "v5.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "3a454ca033b9e06b63282ce19562e892747449bb"
+                "reference": "dca41cd15c2ac9d055ad70dbfd011130757d1f82"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/3a454ca033b9e06b63282ce19562e892747449bb",
-                "reference": "3a454ca033b9e06b63282ce19562e892747449bb",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/dca41cd15c2ac9d055ad70dbfd011130757d1f82",
+                "reference": "dca41cd15c2ac9d055ad70dbfd011130757d1f82",
                 "shasum": ""
             },
             "require": {
@@ -1988,9 +1988,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v5.6.2"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.7.0"
             },
-            "time": "2025-10-21T19:32:17+00:00"
+            "time": "2025-12-06T11:56:16+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -2178,23 +2178,23 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "12.4.0",
+            "version": "12.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "67e8aed88f93d0e6e1cb7effe1a2dfc2fee6022c"
+                "reference": "c467c59a4f6e04b942be422844e7a6352fa01b57"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/67e8aed88f93d0e6e1cb7effe1a2dfc2fee6022c",
-                "reference": "67e8aed88f93d0e6e1cb7effe1a2dfc2fee6022c",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/c467c59a4f6e04b942be422844e7a6352fa01b57",
+                "reference": "c467c59a4f6e04b942be422844e7a6352fa01b57",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-libxml": "*",
                 "ext-xmlwriter": "*",
-                "nikic/php-parser": "^5.6.1",
+                "nikic/php-parser": "^5.7.0",
                 "php": ">=8.3",
                 "phpunit/php-file-iterator": "^6.0",
                 "phpunit/php-text-template": "^5.0",
@@ -2202,10 +2202,10 @@
                 "sebastian/environment": "^8.0.3",
                 "sebastian/lines-of-code": "^4.0",
                 "sebastian/version": "^6.0",
-                "theseer/tokenizer": "^1.2.3"
+                "theseer/tokenizer": "^2.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^12.3.7"
+                "phpunit/phpunit": "^12.5.1"
             },
             "suggest": {
                 "ext-pcov": "PHP extension that provides line coverage",
@@ -2214,7 +2214,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "12.4.x-dev"
+                    "dev-main": "12.5.x-dev"
                 }
             },
             "autoload": {
@@ -2243,7 +2243,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
                 "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/12.4.0"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/12.5.1"
             },
             "funding": [
                 {
@@ -2263,7 +2263,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-09-24T13:44:41+00:00"
+            "time": "2025-12-08T07:17:58+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -2512,16 +2512,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "12.4.2",
+            "version": "12.5.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "a94ea4d26d865875803b23aaf78c3c2c670ea2ea"
+                "reference": "06713c2633d6d832f2fe98a70511ecaa7cb92c1a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/a94ea4d26d865875803b23aaf78c3c2c670ea2ea",
-                "reference": "a94ea4d26d865875803b23aaf78c3c2c670ea2ea",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/06713c2633d6d832f2fe98a70511ecaa7cb92c1a",
+                "reference": "06713c2633d6d832f2fe98a70511ecaa7cb92c1a",
                 "shasum": ""
             },
             "require": {
@@ -2535,7 +2535,7 @@
                 "phar-io/manifest": "^2.0.4",
                 "phar-io/version": "^3.2.1",
                 "php": ">=8.3",
-                "phpunit/php-code-coverage": "^12.4.0",
+                "phpunit/php-code-coverage": "^12.5.1",
                 "phpunit/php-file-iterator": "^6.0.0",
                 "phpunit/php-invoker": "^6.0.0",
                 "phpunit/php-text-template": "^5.0.0",
@@ -2557,7 +2557,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "12.4-dev"
+                    "dev-main": "12.5-dev"
                 }
             },
             "autoload": {
@@ -2589,7 +2589,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/12.4.2"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/12.5.2"
             },
             "funding": [
                 {
@@ -2613,7 +2613,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-10-30T08:41:39+00:00"
+            "time": "2025-12-08T07:22:32+00:00"
         },
         {
             "name": "psr/container",
@@ -5221,28 +5221,28 @@
         },
         {
             "name": "symfony/yaml",
-            "version": "v7.3.5",
+            "version": "v7.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "90208e2fc6f68f613eae7ca25a2458a931b1bacc"
+                "reference": "24dd4de28d2e3988b311751ac49e684d783e2345"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/90208e2fc6f68f613eae7ca25a2458a931b1bacc",
-                "reference": "90208e2fc6f68f613eae7ca25a2458a931b1bacc",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/24dd4de28d2e3988b311751ac49e684d783e2345",
+                "reference": "24dd4de28d2e3988b311751ac49e684d783e2345",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.2",
-                "symfony/deprecation-contracts": "^2.5|^3.0",
+                "symfony/deprecation-contracts": "^2.5|^3",
                 "symfony/polyfill-ctype": "^1.8"
             },
             "conflict": {
                 "symfony/console": "<6.4"
             },
             "require-dev": {
-                "symfony/console": "^6.4|^7.0"
+                "symfony/console": "^6.4|^7.0|^8.0"
             },
             "bin": [
                 "Resources/bin/yaml-lint"
@@ -5273,7 +5273,7 @@
             "description": "Loads and dumps YAML files",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/yaml/tree/v7.3.5"
+                "source": "https://github.com/symfony/yaml/tree/v7.4.1"
             },
             "funding": [
                 {
@@ -5293,27 +5293,27 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-09-27T09:00:46+00:00"
+            "time": "2025-12-04T18:11:45+00:00"
         },
         {
             "name": "theseer/tokenizer",
-            "version": "1.2.3",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/theseer/tokenizer.git",
-                "reference": "737eda637ed5e28c3413cb1ebe8bb52cbf1ca7a2"
+                "reference": "7989e43bf381af0eac72e4f0ca5bcbfa81658be4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/737eda637ed5e28c3413cb1ebe8bb52cbf1ca7a2",
-                "reference": "737eda637ed5e28c3413cb1ebe8bb52cbf1ca7a2",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/7989e43bf381af0eac72e4f0ca5bcbfa81658be4",
+                "reference": "7989e43bf381af0eac72e4f0ca5bcbfa81658be4",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-tokenizer": "*",
                 "ext-xmlwriter": "*",
-                "php": "^7.2 || ^8.0"
+                "php": "^8.1"
             },
             "type": "library",
             "autoload": {
@@ -5335,7 +5335,7 @@
             "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
             "support": {
                 "issues": "https://github.com/theseer/tokenizer/issues",
-                "source": "https://github.com/theseer/tokenizer/tree/1.2.3"
+                "source": "https://github.com/theseer/tokenizer/tree/2.0.1"
             },
             "funding": [
                 {
@@ -5343,7 +5343,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-03-03T12:36:25+00:00"
+            "time": "2025-12-08T11:19:18+00:00"
         },
         {
             "name": "yoast/phpunit-polyfills",

--- a/projects/plugins/crm/tests/php/rest-api/v4/REST_Contacts_Controller_Test.php
+++ b/projects/plugins/crm/tests/php/rest-api/v4/REST_Contacts_Controller_Test.php
@@ -84,7 +84,7 @@ class REST_Contacts_Controller_Test extends REST_Base_TestCase {
 		};
 
 		// Mock contacts DAL service.
-		$dal_mock = $this->createMock( zbsDAL_contacts::class );
+		$dal_mock = $this->createStub( zbsDAL_contacts::class );
 		$dal_mock->method( 'getContact' )->willReturnCallback( $func );
 
 		$GLOBALS['zbs']->DAL           = new \stdClass();

--- a/projects/plugins/jetpack/changelog/fix-phpunit-12-whining-about-mocks-vs-stubs
+++ b/projects/plugins/jetpack/changelog/fix-phpunit-12-whining-about-mocks-vs-stubs
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Fix PHPUnit 12.5 whining about mocks versus stubs.
+
+

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -3930,16 +3930,16 @@
 		},
 		{
 			"name": "nikic/php-parser",
-			"version": "v5.6.2",
+			"version": "v5.7.0",
 			"source": {
 				"type": "git",
 				"url": "https://github.com/nikic/PHP-Parser.git",
-				"reference": "3a454ca033b9e06b63282ce19562e892747449bb"
+				"reference": "dca41cd15c2ac9d055ad70dbfd011130757d1f82"
 			},
 			"dist": {
 				"type": "zip",
-				"url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/3a454ca033b9e06b63282ce19562e892747449bb",
-				"reference": "3a454ca033b9e06b63282ce19562e892747449bb",
+				"url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/dca41cd15c2ac9d055ad70dbfd011130757d1f82",
+				"reference": "dca41cd15c2ac9d055ad70dbfd011130757d1f82",
 				"shasum": ""
 			},
 			"require": {
@@ -3982,9 +3982,9 @@
 			],
 			"support": {
 				"issues": "https://github.com/nikic/PHP-Parser/issues",
-				"source": "https://github.com/nikic/PHP-Parser/tree/v5.6.2"
+				"source": "https://github.com/nikic/PHP-Parser/tree/v5.7.0"
 			},
-			"time": "2025-10-21T19:32:17+00:00"
+			"time": "2025-12-06T11:56:16+00:00"
 		},
 		{
 			"name": "phar-io/manifest",
@@ -4106,23 +4106,23 @@
 		},
 		{
 			"name": "phpunit/php-code-coverage",
-			"version": "12.4.0",
+			"version": "12.5.1",
 			"source": {
 				"type": "git",
 				"url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-				"reference": "67e8aed88f93d0e6e1cb7effe1a2dfc2fee6022c"
+				"reference": "c467c59a4f6e04b942be422844e7a6352fa01b57"
 			},
 			"dist": {
 				"type": "zip",
-				"url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/67e8aed88f93d0e6e1cb7effe1a2dfc2fee6022c",
-				"reference": "67e8aed88f93d0e6e1cb7effe1a2dfc2fee6022c",
+				"url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/c467c59a4f6e04b942be422844e7a6352fa01b57",
+				"reference": "c467c59a4f6e04b942be422844e7a6352fa01b57",
 				"shasum": ""
 			},
 			"require": {
 				"ext-dom": "*",
 				"ext-libxml": "*",
 				"ext-xmlwriter": "*",
-				"nikic/php-parser": "^5.6.1",
+				"nikic/php-parser": "^5.7.0",
 				"php": ">=8.3",
 				"phpunit/php-file-iterator": "^6.0",
 				"phpunit/php-text-template": "^5.0",
@@ -4130,10 +4130,10 @@
 				"sebastian/environment": "^8.0.3",
 				"sebastian/lines-of-code": "^4.0",
 				"sebastian/version": "^6.0",
-				"theseer/tokenizer": "^1.2.3"
+				"theseer/tokenizer": "^2.0"
 			},
 			"require-dev": {
-				"phpunit/phpunit": "^12.3.7"
+				"phpunit/phpunit": "^12.5.1"
 			},
 			"suggest": {
 				"ext-pcov": "PHP extension that provides line coverage",
@@ -4142,7 +4142,7 @@
 			"type": "library",
 			"extra": {
 				"branch-alias": {
-					"dev-main": "12.4.x-dev"
+					"dev-main": "12.5.x-dev"
 				}
 			},
 			"autoload": {
@@ -4171,7 +4171,7 @@
 			"support": {
 				"issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
 				"security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
-				"source": "https://github.com/sebastianbergmann/php-code-coverage/tree/12.4.0"
+				"source": "https://github.com/sebastianbergmann/php-code-coverage/tree/12.5.1"
 			},
 			"funding": [
 				{
@@ -4191,7 +4191,7 @@
 					"type": "tidelift"
 				}
 			],
-			"time": "2025-09-24T13:44:41+00:00"
+			"time": "2025-12-08T07:17:58+00:00"
 		},
 		{
 			"name": "phpunit/php-file-iterator",
@@ -4440,16 +4440,16 @@
 		},
 		{
 			"name": "phpunit/phpunit",
-			"version": "12.4.2",
+			"version": "12.5.2",
 			"source": {
 				"type": "git",
 				"url": "https://github.com/sebastianbergmann/phpunit.git",
-				"reference": "a94ea4d26d865875803b23aaf78c3c2c670ea2ea"
+				"reference": "06713c2633d6d832f2fe98a70511ecaa7cb92c1a"
 			},
 			"dist": {
 				"type": "zip",
-				"url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/a94ea4d26d865875803b23aaf78c3c2c670ea2ea",
-				"reference": "a94ea4d26d865875803b23aaf78c3c2c670ea2ea",
+				"url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/06713c2633d6d832f2fe98a70511ecaa7cb92c1a",
+				"reference": "06713c2633d6d832f2fe98a70511ecaa7cb92c1a",
 				"shasum": ""
 			},
 			"require": {
@@ -4463,7 +4463,7 @@
 				"phar-io/manifest": "^2.0.4",
 				"phar-io/version": "^3.2.1",
 				"php": ">=8.3",
-				"phpunit/php-code-coverage": "^12.4.0",
+				"phpunit/php-code-coverage": "^12.5.1",
 				"phpunit/php-file-iterator": "^6.0.0",
 				"phpunit/php-invoker": "^6.0.0",
 				"phpunit/php-text-template": "^5.0.0",
@@ -4485,7 +4485,7 @@
 			"type": "library",
 			"extra": {
 				"branch-alias": {
-					"dev-main": "12.4-dev"
+					"dev-main": "12.5-dev"
 				}
 			},
 			"autoload": {
@@ -4517,7 +4517,7 @@
 			"support": {
 				"issues": "https://github.com/sebastianbergmann/phpunit/issues",
 				"security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-				"source": "https://github.com/sebastianbergmann/phpunit/tree/12.4.2"
+				"source": "https://github.com/sebastianbergmann/phpunit/tree/12.5.2"
 			},
 			"funding": [
 				{
@@ -4541,7 +4541,7 @@
 					"type": "tidelift"
 				}
 			],
-			"time": "2025-10-30T08:41:39+00:00"
+			"time": "2025-12-08T07:22:32+00:00"
 		},
 		{
 			"name": "psr/container",
@@ -6289,23 +6289,23 @@
 		},
 		{
 			"name": "theseer/tokenizer",
-			"version": "1.2.3",
+			"version": "2.0.1",
 			"source": {
 				"type": "git",
 				"url": "https://github.com/theseer/tokenizer.git",
-				"reference": "737eda637ed5e28c3413cb1ebe8bb52cbf1ca7a2"
+				"reference": "7989e43bf381af0eac72e4f0ca5bcbfa81658be4"
 			},
 			"dist": {
 				"type": "zip",
-				"url": "https://api.github.com/repos/theseer/tokenizer/zipball/737eda637ed5e28c3413cb1ebe8bb52cbf1ca7a2",
-				"reference": "737eda637ed5e28c3413cb1ebe8bb52cbf1ca7a2",
+				"url": "https://api.github.com/repos/theseer/tokenizer/zipball/7989e43bf381af0eac72e4f0ca5bcbfa81658be4",
+				"reference": "7989e43bf381af0eac72e4f0ca5bcbfa81658be4",
 				"shasum": ""
 			},
 			"require": {
 				"ext-dom": "*",
 				"ext-tokenizer": "*",
 				"ext-xmlwriter": "*",
-				"php": "^7.2 || ^8.0"
+				"php": "^8.1"
 			},
 			"type": "library",
 			"autoload": {
@@ -6327,7 +6327,7 @@
 			"description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
 			"support": {
 				"issues": "https://github.com/theseer/tokenizer/issues",
-				"source": "https://github.com/theseer/tokenizer/tree/1.2.3"
+				"source": "https://github.com/theseer/tokenizer/tree/2.0.1"
 			},
 			"funding": [
 				{
@@ -6335,7 +6335,7 @@
 					"type": "github"
 				}
 			],
-			"time": "2024-03-03T12:36:25+00:00"
+			"time": "2025-12-08T11:19:18+00:00"
 		},
 		{
 			"name": "yoast/phpunit-polyfills",

--- a/projects/plugins/jetpack/tests/php/modules/publicize/Publicize_Test.php
+++ b/projects/plugins/jetpack/tests/php/modules/publicize/Publicize_Test.php
@@ -3,6 +3,7 @@
 // phpcs:disable Universal.Files.SeparateFunctionsFromOO.Mixed
 
 use Automattic\Jetpack\Publicize\Publicize;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\Group;
 
 if ( ! function_exists( 'publicize_init' ) ) {
@@ -23,6 +24,7 @@ if ( ! function_exists( 'publicize_init' ) ) {
 /**
  * @group publicize
  */
+#[AllowMockObjectsWithoutExpectations /* getStubBuilder() (for partial stubs) doesn't exist until PHPUnit 12.5. */ ]
 #[Group( 'publicize' )]
 class Publicize_Test extends WP_UnitTestCase {
 	use \Automattic\Jetpack\PHPUnit\WP_UnitTestCase_Fix;

--- a/projects/plugins/jetpack/tests/php/modules/widgets/Jetpack_Display_Posts_Widget_Test.php
+++ b/projects/plugins/jetpack/tests/php/modules/widgets/Jetpack_Display_Posts_Widget_Test.php
@@ -1,9 +1,11 @@
 <?php
 
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Constraint\Constraint;
 
 require __DIR__ . '/../../../../modules/widgets/wordpress-post-widget.php';
 
+#[AllowMockObjectsWithoutExpectations /* getStubBuilder() (for partial stubs) doesn't exist until PHPUnit 12.5. */ ]
 class Jetpack_Display_Posts_Widget_Test extends WP_UnitTestCase {
 	use \Automattic\Jetpack\PHPUnit\WP_UnitTestCase_Fix;
 

--- a/projects/plugins/social/changelog/fix-phpunit-12-whining-about-mocks-vs-stubs
+++ b/projects/plugins/social/changelog/fix-phpunit-12-whining-about-mocks-vs-stubs
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix PHPUnit 12.5 whining about mocks versus stubs.
+
+

--- a/projects/plugins/social/composer.lock
+++ b/projects/plugins/social/composer.lock
@@ -2351,16 +2351,16 @@
 		},
 		{
 			"name": "nikic/php-parser",
-			"version": "v5.6.2",
+			"version": "v5.7.0",
 			"source": {
 				"type": "git",
 				"url": "https://github.com/nikic/PHP-Parser.git",
-				"reference": "3a454ca033b9e06b63282ce19562e892747449bb"
+				"reference": "dca41cd15c2ac9d055ad70dbfd011130757d1f82"
 			},
 			"dist": {
 				"type": "zip",
-				"url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/3a454ca033b9e06b63282ce19562e892747449bb",
-				"reference": "3a454ca033b9e06b63282ce19562e892747449bb",
+				"url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/dca41cd15c2ac9d055ad70dbfd011130757d1f82",
+				"reference": "dca41cd15c2ac9d055ad70dbfd011130757d1f82",
 				"shasum": ""
 			},
 			"require": {
@@ -2403,9 +2403,9 @@
 			],
 			"support": {
 				"issues": "https://github.com/nikic/PHP-Parser/issues",
-				"source": "https://github.com/nikic/PHP-Parser/tree/v5.6.2"
+				"source": "https://github.com/nikic/PHP-Parser/tree/v5.7.0"
 			},
-			"time": "2025-10-21T19:32:17+00:00"
+			"time": "2025-12-06T11:56:16+00:00"
 		},
 		{
 			"name": "phar-io/manifest",
@@ -2527,23 +2527,23 @@
 		},
 		{
 			"name": "phpunit/php-code-coverage",
-			"version": "12.4.0",
+			"version": "12.5.1",
 			"source": {
 				"type": "git",
 				"url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-				"reference": "67e8aed88f93d0e6e1cb7effe1a2dfc2fee6022c"
+				"reference": "c467c59a4f6e04b942be422844e7a6352fa01b57"
 			},
 			"dist": {
 				"type": "zip",
-				"url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/67e8aed88f93d0e6e1cb7effe1a2dfc2fee6022c",
-				"reference": "67e8aed88f93d0e6e1cb7effe1a2dfc2fee6022c",
+				"url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/c467c59a4f6e04b942be422844e7a6352fa01b57",
+				"reference": "c467c59a4f6e04b942be422844e7a6352fa01b57",
 				"shasum": ""
 			},
 			"require": {
 				"ext-dom": "*",
 				"ext-libxml": "*",
 				"ext-xmlwriter": "*",
-				"nikic/php-parser": "^5.6.1",
+				"nikic/php-parser": "^5.7.0",
 				"php": ">=8.3",
 				"phpunit/php-file-iterator": "^6.0",
 				"phpunit/php-text-template": "^5.0",
@@ -2551,10 +2551,10 @@
 				"sebastian/environment": "^8.0.3",
 				"sebastian/lines-of-code": "^4.0",
 				"sebastian/version": "^6.0",
-				"theseer/tokenizer": "^1.2.3"
+				"theseer/tokenizer": "^2.0"
 			},
 			"require-dev": {
-				"phpunit/phpunit": "^12.3.7"
+				"phpunit/phpunit": "^12.5.1"
 			},
 			"suggest": {
 				"ext-pcov": "PHP extension that provides line coverage",
@@ -2563,7 +2563,7 @@
 			"type": "library",
 			"extra": {
 				"branch-alias": {
-					"dev-main": "12.4.x-dev"
+					"dev-main": "12.5.x-dev"
 				}
 			},
 			"autoload": {
@@ -2592,7 +2592,7 @@
 			"support": {
 				"issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
 				"security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
-				"source": "https://github.com/sebastianbergmann/php-code-coverage/tree/12.4.0"
+				"source": "https://github.com/sebastianbergmann/php-code-coverage/tree/12.5.1"
 			},
 			"funding": [
 				{
@@ -2612,7 +2612,7 @@
 					"type": "tidelift"
 				}
 			],
-			"time": "2025-09-24T13:44:41+00:00"
+			"time": "2025-12-08T07:17:58+00:00"
 		},
 		{
 			"name": "phpunit/php-file-iterator",
@@ -2861,16 +2861,16 @@
 		},
 		{
 			"name": "phpunit/phpunit",
-			"version": "12.4.2",
+			"version": "12.5.2",
 			"source": {
 				"type": "git",
 				"url": "https://github.com/sebastianbergmann/phpunit.git",
-				"reference": "a94ea4d26d865875803b23aaf78c3c2c670ea2ea"
+				"reference": "06713c2633d6d832f2fe98a70511ecaa7cb92c1a"
 			},
 			"dist": {
 				"type": "zip",
-				"url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/a94ea4d26d865875803b23aaf78c3c2c670ea2ea",
-				"reference": "a94ea4d26d865875803b23aaf78c3c2c670ea2ea",
+				"url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/06713c2633d6d832f2fe98a70511ecaa7cb92c1a",
+				"reference": "06713c2633d6d832f2fe98a70511ecaa7cb92c1a",
 				"shasum": ""
 			},
 			"require": {
@@ -2884,7 +2884,7 @@
 				"phar-io/manifest": "^2.0.4",
 				"phar-io/version": "^3.2.1",
 				"php": ">=8.3",
-				"phpunit/php-code-coverage": "^12.4.0",
+				"phpunit/php-code-coverage": "^12.5.1",
 				"phpunit/php-file-iterator": "^6.0.0",
 				"phpunit/php-invoker": "^6.0.0",
 				"phpunit/php-text-template": "^5.0.0",
@@ -2906,7 +2906,7 @@
 			"type": "library",
 			"extra": {
 				"branch-alias": {
-					"dev-main": "12.4-dev"
+					"dev-main": "12.5-dev"
 				}
 			},
 			"autoload": {
@@ -2938,7 +2938,7 @@
 			"support": {
 				"issues": "https://github.com/sebastianbergmann/phpunit/issues",
 				"security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-				"source": "https://github.com/sebastianbergmann/phpunit/tree/12.4.2"
+				"source": "https://github.com/sebastianbergmann/phpunit/tree/12.5.2"
 			},
 			"funding": [
 				{
@@ -2962,7 +2962,7 @@
 					"type": "tidelift"
 				}
 			],
-			"time": "2025-10-30T08:41:39+00:00"
+			"time": "2025-12-08T07:22:32+00:00"
 		},
 		{
 			"name": "psr/container",
@@ -4710,23 +4710,23 @@
 		},
 		{
 			"name": "theseer/tokenizer",
-			"version": "1.2.3",
+			"version": "2.0.1",
 			"source": {
 				"type": "git",
 				"url": "https://github.com/theseer/tokenizer.git",
-				"reference": "737eda637ed5e28c3413cb1ebe8bb52cbf1ca7a2"
+				"reference": "7989e43bf381af0eac72e4f0ca5bcbfa81658be4"
 			},
 			"dist": {
 				"type": "zip",
-				"url": "https://api.github.com/repos/theseer/tokenizer/zipball/737eda637ed5e28c3413cb1ebe8bb52cbf1ca7a2",
-				"reference": "737eda637ed5e28c3413cb1ebe8bb52cbf1ca7a2",
+				"url": "https://api.github.com/repos/theseer/tokenizer/zipball/7989e43bf381af0eac72e4f0ca5bcbfa81658be4",
+				"reference": "7989e43bf381af0eac72e4f0ca5bcbfa81658be4",
 				"shasum": ""
 			},
 			"require": {
 				"ext-dom": "*",
 				"ext-tokenizer": "*",
 				"ext-xmlwriter": "*",
-				"php": "^7.2 || ^8.0"
+				"php": "^8.1"
 			},
 			"type": "library",
 			"autoload": {
@@ -4748,7 +4748,7 @@
 			"description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
 			"support": {
 				"issues": "https://github.com/theseer/tokenizer/issues",
-				"source": "https://github.com/theseer/tokenizer/tree/1.2.3"
+				"source": "https://github.com/theseer/tokenizer/tree/2.0.1"
 			},
 			"funding": [
 				{
@@ -4756,7 +4756,7 @@
 					"type": "github"
 				}
 			],
-			"time": "2024-03-03T12:36:25+00:00"
+			"time": "2025-12-08T11:19:18+00:00"
 		},
 		{
 			"name": "yoast/phpunit-polyfills",

--- a/projects/plugins/social/tests/php/Jetpack_Social_Test.php
+++ b/projects/plugins/social/tests/php/Jetpack_Social_Test.php
@@ -47,7 +47,7 @@ class Jetpack_Social_Test extends BaseTestCase {
 		$this->activate_plugin( JETPACK_SOCIAL_PLUGIN_ROOT_FILE_RELATIVE_PATH );
 		$this->assertFalse( ( Jetpack_Social::is_publicize_active() ) );
 
-		$connection_manager = $this->createMock( Connection_Manager::class );
+		$connection_manager = $this->createStub( Connection_Manager::class );
 		$connection_manager->method( 'is_connected' )->willReturn( true );
 		$connection_manager->method( 'has_connected_user' )->willReturn( true );
 
@@ -66,13 +66,14 @@ class Jetpack_Social_Test extends BaseTestCase {
 	 * Test that the Publicize package isn't ensured without a user connection
 	 */
 	public function test_publicize_not_configured() {
-		$connection_manager = $this->createMock( Connection_Manager::class );
+		$connection_manager = $this->createStub( Connection_Manager::class );
 		$connection_manager->method( 'is_connected' )->willReturn( true );
 		$connection_manager->method( 'has_connected_user' )->willReturn( false );
 
 		$this->social = $this->getMockBuilder( Jetpack_Social::class )
 			->setConstructorArgs( array( $connection_manager ) )
 			->getMock();
+		$this->social->expects( $this->never() )->method( 'calculate_scheduled_shares' );
 
 		do_action( 'plugins_loaded' );
 

--- a/tools/stubs/munge-phpunit-stubs.php
+++ b/tools/stubs/munge-phpunit-stubs.php
@@ -35,6 +35,12 @@ if ( $stubs === null ) {
 	throw new RuntimeException( preg_last_error_msg() );
 }
 
+// Also it seems to get confused by TestStubBuilder using "StubbedType" rather than "MockedType". `@inherits` doesn't seem to help.
+$stubs = preg_replace( '/\bStubbedType\b/', 'MockedType', $stubs );
+if ( $stubs === null ) {
+	throw new RuntimeException( preg_last_error_msg() );
+}
+
 // Phan doesn't track generics across `@return $this` properly. Rewrite them.
 // Possibly fixed in Phan v6? https://github.com/phan/phan/issues/4849
 $stubs = preg_replace_callback(


### PR DESCRIPTION
Closes MONOREP-288

 <!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
PHPUnit 12.5 has started complaining about the use of mocks when stubs would be sufficient. Unfortunately the ability to create partial stubs was only added in 12.5.1, so in many cases we have to just set the attribute to ignore the complaints.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1765375284769239-slack-CDLH4C1UZ

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* CI happy?
* Check the logs for the PHP 8.5 run, see if it reports any tests having notices.