### PR TITLE
forms: Fix `Contact_Form_Endpoint_Test::test_resend_email` trying to actually send mail

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-test-sending-mail
+++ b/projects/packages/forms/changelog/fix-forms-test-sending-mail
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix `Contact_Form_Endpoint_Test::test_resend_email` attempting to actually send email.

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Endpoint_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Endpoint_Test.php
@@ -39,6 +39,13 @@ class Contact_Form_Endpoint_Test extends TestCase {
 	 */
 	private $plugin;
 
+	public static function setUpBeforeClass(): void {
+		parent::setUpBeforeClass();
+
+		// Avoid actually trying to send any mail.
+		add_filter( 'pre_wp_mail', '__return_true', PHP_INT_MAX );
+	}
+
 	/**
 	 * Setting up the test.
 	 */


### PR DESCRIPTION
Closes MONOREP-289

 <!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
WorDBless doesn't block attempts to send mail, and this test wasn't blocking it either.

In CI this was producing a message `sh: 1: /usr/sbin/sendmail: not found` while on individual machines it might actually send email if that binary exists.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* CI happy?
* Check the CI logs for the `sh: 1: /usr/sbin/sendmail: not found` message.
