### PR TITLE
Forms: fix submission summary not contained within form area

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-contain-within-100-percent
+++ b/projects/packages/forms/changelog/fix-forms-contain-within-100-percent
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fixed
+
+Forms: ensure submission summary is contained within 100% width

--- a/projects/packages/forms/src/contact-form/css/grunion.scss
+++ b/projects/packages/forms/src/contact-form/css/grunion.scss
@@ -214,6 +214,7 @@ that needs to mimic the input element styles */
 }
 
 .contact-form-submission {
+	box-sizing: border-box;
 	margin-bottom: 4em;
 	padding: 1.5em 1em;
 	width: 100%;

--- a/projects/plugins/jetpack/changelog/fix-forms-contain-within-100-percent
+++ b/projects/plugins/jetpack/changelog/fix-forms-contain-within-100-percent
@@ -1,0 +1,4 @@
+Significance: minor
+Type: bugfix
+
+Forms: ensure submission summary is contained within 100% width


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes FORMS-458

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Fixes issue of submission confirmation not being contained within the space the form takes, in some themes producing unwanted visual "leakage".

Before
<img width="1227" height="681" alt="Screenshot 2025-12-11 at 11 25 53" src="https://github.com/user-attachments/assets/d6108ab3-37bf-4070-a476-005dc3b59a78" />


After
<img width="1228" height="680" alt="Screenshot 2025-12-11 at 11 26 03" src="https://github.com/user-attachments/assets/c896407c-287e-491d-a409-409708d7acfa" />



### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Submit form, and observe the submisson area size compared to area size