### PR TITLE
IDC: revalidate IDC error

### DIFF
--- a/projects/packages/connection/changelog/add-idc-revalidate
+++ b/projects/packages/connection/changelog/add-idc-revalidate
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+IDC: add revalidation for IDCs.

--- a/projects/packages/connection/src/identity-crisis/class-identity-crisis.php
+++ b/projects/packages/connection/src/identity-crisis/class-identity-crisis.php
@@ -570,6 +570,7 @@ class Identity_Crisis {
 
 		if ( $idc_detected ) {
 			// Valid idc_detected response - refresh data and apply exponential backoff.
+			// @phan-suppress-next-line PhanTypeArraySuspiciousNullable -- $body is verified as array in $idc_detected check
 			$fresh_idc_data                     = self::get_sync_error_idc_option( $body['idc_detected'] );
 			$fresh_idc_data['last_checked']     = time();
 			$fresh_idc_data['next_check_delay'] = min(

--- a/projects/packages/connection/src/identity-crisis/class-identity-crisis.php
+++ b/projects/packages/connection/src/identity-crisis/class-identity-crisis.php
@@ -472,13 +472,13 @@ class Identity_Crisis {
 	 */
 	public static function should_validate_idc( $sync_error ) {
 		// If delay has reached or exceeded the maximum, stop validating.
-		if ( $sync_error['next_check_delay'] >= self::IDC_VALIDATION_MAX_DELAY ) {
+		if ( ( $sync_error['next_check_delay'] ?? 0 ) >= self::IDC_VALIDATION_MAX_DELAY ) {
 			return false;
 		}
 
 		// Check if enough time has passed since the last check.
-		$time_since_last_check = time() - $sync_error['last_checked'];
-		return $time_since_last_check >= $sync_error['next_check_delay'];
+		$time_since_last_check = time() - ( $sync_error['last_checked'] ?? 0 );
+		return $time_since_last_check >= ( $sync_error['next_check_delay'] ?? 0 );
 	}
 
 	/**
@@ -516,20 +516,19 @@ class Identity_Crisis {
 		}
 
 		$body = json_decode( wp_remote_retrieve_body( $response ), true );
-		if ( ! is_array( $body ) ) {
-			// Malformed response - do nothing.
+		if ( ! is_array( $body ) || JSON_ERROR_NONE !== json_last_error() ) {
 			return false;
 		}
 
 		// Check if WordPress.com still detects an IDC.
-		if ( isset( $body['idc_detected'] ) && is_array( $body['idc_detected'] ) ) {
+		if ( isset( $body['idc_detected'] ) && is_array( $body['idc_detected'] ) && ! empty( $body['idc_detected'] ) ) {
 			// IDC still exists - refresh with latest data from WordPress.com and update timing.
 			$fresh_idc_data = self::get_sync_error_idc_option( $body['idc_detected'] );
 
 			// Preserve and update timing fields with exponential backoff.
 			$fresh_idc_data['last_checked']     = time();
 			$fresh_idc_data['next_check_delay'] = min(
-				$sync_error['next_check_delay'] * 2,
+				( $sync_error['next_check_delay'] ?? self::IDC_VALIDATION_INITIAL_DELAY ) * 2,
 				self::IDC_VALIDATION_MAX_DELAY
 			);
 

--- a/projects/packages/connection/src/identity-crisis/class-identity-crisis.php
+++ b/projects/packages/connection/src/identity-crisis/class-identity-crisis.php
@@ -524,14 +524,16 @@ class Identity_Crisis {
 		// We must explicitly include URLs because add_idc_query_args_to_url() skips
 		// adding them when the site is in IDC (to prevent sync). For revalidation,
 		// we need WordPress.com to compare current URLs against what it has stored.
+		// We use the jetpack-token-health/blog endpoint which performs IDC detection
+		// and returns idc_detected in the response when URLs don't match.
 		$api_path = sprintf(
-			'sites/%d?home=%s&siteurl=%s&idc=1',
+			'sites/%d/jetpack-token-health/blog?home=%s&siteurl=%s&idc=1',
 			$blog_id,
 			rawurlencode( Urls::home_url() ),
 			rawurlencode( Urls::site_url() )
 		);
 
-		// Make a lightweight API call to WordPress.com.
+		// Make an API call to WordPress.com to check token health and IDC status.
 		// The response will include 'idc_detected' if URLs still mismatch.
 		$response = Client::wpcom_json_api_request_as_blog(
 			$api_path,

--- a/projects/packages/connection/src/identity-crisis/class-identity-crisis.php
+++ b/projects/packages/connection/src/identity-crisis/class-identity-crisis.php
@@ -473,14 +473,19 @@ class Identity_Crisis {
 	 * @return bool True if validation should be performed, false otherwise.
 	 */
 	public static function should_validate_idc( $sync_error ) {
+		// If delay is not set or invalid, validate immediately to bring into new system.
+		if ( empty( $sync_error['next_check_delay'] ) ) {
+			return true;
+		}
+
 		// If delay has reached or exceeded the maximum, stop validating.
-		if ( ( $sync_error['next_check_delay'] ?? 0 ) >= self::IDC_VALIDATION_MAX_DELAY ) {
+		if ( $sync_error['next_check_delay'] >= self::IDC_VALIDATION_MAX_DELAY ) {
 			return false;
 		}
 
 		// Check if enough time has passed since the last check.
 		$time_since_last_check = time() - ( $sync_error['last_checked'] ?? 0 );
-		return $time_since_last_check >= ( $sync_error['next_check_delay'] ?? 0 );
+		return $time_since_last_check >= $sync_error['next_check_delay'];
 	}
 
 	/**
@@ -514,10 +519,13 @@ class Identity_Crisis {
 
 		$blog_id = Jetpack_Options::get_option( 'id' );
 		if ( ! $blog_id ) {
-			// Site not registered, can't make API call.
+			// Site not registered - IDC state is invalid without a connection to WordPress.com.
+			// Clear the IDC since there's nothing to validate against, and the site can't
+			// restore the blog_id while in IDC anyway (connection flow is blocked).
+			Jetpack_Options::delete_option( 'sync_error_idc' );
 			delete_transient( $lock_key );
 			$is_validating = false;
-			return false;
+			return true; // Return true to indicate IDC was cleared.
 		}
 
 		// Build API path with current URLs as query params.
@@ -543,48 +551,41 @@ class Identity_Crisis {
 			'wpcom'
 		);
 
-		// Handle network/API errors - update timing to prevent hammering, but keep same delay interval.
-		if ( is_wp_error( $response ) || 200 !== wp_remote_retrieve_response_code( $response ) ) {
-			$sync_error['last_checked'] = time();
-			Jetpack_Options::update_option( 'sync_error_idc', $sync_error );
-			delete_transient( $lock_key );
-			$is_validating = false;
-			return false;
+		// Parse response body - will be null/false if request failed or JSON is invalid.
+		$body = null;
+		if ( ! is_wp_error( $response ) && 200 === wp_remote_retrieve_response_code( $response ) ) {
+			$body = json_decode( wp_remote_retrieve_body( $response ), true );
 		}
 
-		$body = json_decode( wp_remote_retrieve_body( $response ), true );
-		if ( ! is_array( $body ) || JSON_ERROR_NONE !== json_last_error() ) {
-			// Invalid JSON response - update timing to prevent hammering.
-			$sync_error['last_checked'] = time();
-			Jetpack_Options::update_option( 'sync_error_idc', $sync_error );
+		// Check for success: valid response with no idc_detected means IDC is resolved.
+		if ( is_array( $body ) && empty( $body['idc_detected'] ) ) {
+			Jetpack_Options::delete_option( 'sync_error_idc' );
 			delete_transient( $lock_key );
 			$is_validating = false;
-			return false;
+			return true;
 		}
 
-		// Check if WordPress.com still detects an IDC.
-		if ( isset( $body['idc_detected'] ) && is_array( $body['idc_detected'] ) && ! empty( $body['idc_detected'] ) ) {
-			// IDC still exists - refresh with latest data from WordPress.com and update timing.
-			$fresh_idc_data = self::get_sync_error_idc_option( $body['idc_detected'] );
+		// IDC still exists or request failed - update timing.
+		$idc_detected = is_array( $body ) && ! empty( $body['idc_detected'] ) && is_array( $body['idc_detected'] );
 
-			// Preserve and update timing fields with exponential backoff.
+		if ( $idc_detected ) {
+			// Valid idc_detected response - refresh data and apply exponential backoff.
+			$fresh_idc_data                     = self::get_sync_error_idc_option( $body['idc_detected'] );
 			$fresh_idc_data['last_checked']     = time();
 			$fresh_idc_data['next_check_delay'] = min(
 				( $sync_error['next_check_delay'] ?? self::IDC_VALIDATION_INITIAL_DELAY ) * 2,
 				self::IDC_VALIDATION_MAX_DELAY
 			);
-
 			Jetpack_Options::update_option( 'sync_error_idc', $fresh_idc_data );
-			delete_transient( $lock_key );
-			$is_validating = false;
-			return false;
+		} else {
+			// Network error, invalid JSON, or non-200 - just update last_checked without backoff.
+			$sync_error['last_checked'] = time();
+			Jetpack_Options::update_option( 'sync_error_idc', $sync_error );
 		}
 
-		// No IDC detected in response - WordPress.com URLs now match, clear the local IDC.
-		Jetpack_Options::delete_option( 'sync_error_idc' );
 		delete_transient( $lock_key );
 		$is_validating = false;
-		return true;
+		return false;
 	}
 
 	/**
@@ -666,12 +667,8 @@ class Identity_Crisis {
 		// Add validation timing fields.
 		// Set last_checked to current time so remote validation doesn't trigger immediately.
 		// This ensures the first validation happens after the initial delay period.
-		if ( ! isset( $returned_values['last_checked'] ) ) {
-			$returned_values['last_checked'] = time();
-		}
-		if ( ! isset( $returned_values['next_check_delay'] ) ) {
-			$returned_values['next_check_delay'] = self::IDC_VALIDATION_INITIAL_DELAY;
-		}
+		$returned_values['last_checked']     = time();
+		$returned_values['next_check_delay'] = self::IDC_VALIDATION_INITIAL_DELAY;
 
 		return $returned_values;
 	}

--- a/projects/packages/connection/src/identity-crisis/class-identity-crisis.php
+++ b/projects/packages/connection/src/identity-crisis/class-identity-crisis.php
@@ -488,15 +488,33 @@ class Identity_Crisis {
 	 * If no IDC is detected in the response, the local IDC option is cleared.
 	 * If an IDC is still detected, the option is refreshed with the latest URL data from
 	 * WordPress.com and the validation timestamps are updated with progressive backoff.
-	 * If the request fails (network error, timeout, etc.), no changes are made.
+	 * If the request fails (network error, timeout, etc.), timing is updated to prevent
+	 * immediate retries but the delay interval is not increased.
 	 *
 	 * @param array $sync_error The stored sync_error_idc option with timing fields.
 	 * @return bool True if IDC was cleared, false otherwise.
 	 */
 	public static function validate_idc_from_remote( $sync_error ) {
+		// Prevent recursive calls that could cause infinite loops within the same request.
+		static $is_validating = false;
+		if ( $is_validating ) {
+			return false;
+		}
+
+		// Use a transient lock to prevent concurrent validations across multiple requests.
+		$lock_key = 'jetpack_idc_validation_lock';
+		if ( get_transient( $lock_key ) ) {
+			return false;
+		}
+		set_transient( $lock_key, true, 60 ); // 60 second lock.
+
+		$is_validating = true;
+
 		$blog_id = Jetpack_Options::get_option( 'id' );
 		if ( ! $blog_id ) {
 			// Site not registered, can't make API call.
+			delete_transient( $lock_key );
+			$is_validating = false;
 			return false;
 		}
 
@@ -510,13 +528,22 @@ class Identity_Crisis {
 			'wpcom'
 		);
 
-		// Handle network/API errors - do nothing, will retry at next scheduled interval.
+		// Handle network/API errors - update timing to prevent hammering, but keep same delay interval.
 		if ( is_wp_error( $response ) || 200 !== wp_remote_retrieve_response_code( $response ) ) {
+			$sync_error['last_checked'] = time();
+			Jetpack_Options::update_option( 'sync_error_idc', $sync_error );
+			delete_transient( $lock_key );
+			$is_validating = false;
 			return false;
 		}
 
 		$body = json_decode( wp_remote_retrieve_body( $response ), true );
 		if ( ! is_array( $body ) || JSON_ERROR_NONE !== json_last_error() ) {
+			// Invalid JSON response - update timing to prevent hammering.
+			$sync_error['last_checked'] = time();
+			Jetpack_Options::update_option( 'sync_error_idc', $sync_error );
+			delete_transient( $lock_key );
+			$is_validating = false;
 			return false;
 		}
 
@@ -533,11 +560,15 @@ class Identity_Crisis {
 			);
 
 			Jetpack_Options::update_option( 'sync_error_idc', $fresh_idc_data );
+			delete_transient( $lock_key );
+			$is_validating = false;
 			return false;
 		}
 
 		// No IDC detected in response - WordPress.com URLs now match, clear the local IDC.
 		Jetpack_Options::delete_option( 'sync_error_idc' );
+		delete_transient( $lock_key );
+		$is_validating = false;
 		return true;
 	}
 

--- a/projects/packages/connection/src/identity-crisis/class-identity-crisis.php
+++ b/projects/packages/connection/src/identity-crisis/class-identity-crisis.php
@@ -417,8 +417,10 @@ class Identity_Crisis {
 					if ( self::should_validate_idc( $sync_error ) ) {
 						// Perform remote validation.
 						if ( self::validate_idc_from_remote( $sync_error ) ) {
-							// IDC was cleared remotely, mark as invalid so we return false.
-							$is_valid = false;
+							// IDC was cleared remotely. The option is already deleted by
+							// validate_idc_from_remote(), so return false immediately to
+							// avoid double deletion and allow the filter to run.
+							return (bool) apply_filters( 'jetpack_sync_error_idc_validation', false );
 						}
 					}
 				}
@@ -518,10 +520,21 @@ class Identity_Crisis {
 			return false;
 		}
 
+		// Build API path with current URLs as query params.
+		// We must explicitly include URLs because add_idc_query_args_to_url() skips
+		// adding them when the site is in IDC (to prevent sync). For revalidation,
+		// we need WordPress.com to compare current URLs against what it has stored.
+		$api_path = sprintf(
+			'sites/%d?home=%s&siteurl=%s&idc=1',
+			$blog_id,
+			rawurlencode( Urls::home_url() ),
+			rawurlencode( Urls::site_url() )
+		);
+
 		// Make a lightweight API call to WordPress.com.
-		// The response will automatically include 'idc_detected' if URLs still mismatch.
+		// The response will include 'idc_detected' if URLs still mismatch.
 		$response = Client::wpcom_json_api_request_as_blog(
-			sprintf( 'sites/%d', $blog_id ),
+			$api_path,
 			'2',
 			array( 'method' => 'GET' ),
 			null,

--- a/projects/packages/connection/src/identity-crisis/class-identity-crisis.php
+++ b/projects/packages/connection/src/identity-crisis/class-identity-crisis.php
@@ -648,9 +648,11 @@ class Identity_Crisis {
 			$returned_values                 = self::reverse_wpcom_urls_for_idc( $returned_values );
 		}
 
-		// Add validation timing fields for backward compatibility with existing IDC options.
+		// Add validation timing fields.
+		// Set last_checked to current time so remote validation doesn't trigger immediately.
+		// This ensures the first validation happens after the initial delay period.
 		if ( ! isset( $returned_values['last_checked'] ) ) {
-			$returned_values['last_checked'] = 0;
+			$returned_values['last_checked'] = time();
 		}
 		if ( ! isset( $returned_values['next_check_delay'] ) ) {
 			$returned_values['next_check_delay'] = self::IDC_VALIDATION_INITIAL_DELAY;

--- a/projects/packages/connection/src/identity-crisis/class-identity-crisis.php
+++ b/projects/packages/connection/src/identity-crisis/class-identity-crisis.php
@@ -7,6 +7,7 @@
 
 namespace Automattic\Jetpack;
 
+use Automattic\Jetpack\Connection\Client;
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Connection\Urls;
 use Automattic\Jetpack\IdentityCrisis\Exception;
@@ -27,6 +28,16 @@ class Identity_Crisis {
 	 * Persistent WPCOM blog ID that stays in the options after disconnect.
 	 */
 	const PERSISTENT_BLOG_ID_OPTION_NAME = 'jetpack_persistent_blog_id';
+
+	/**
+	 * Initial delay for IDC validation in seconds (1 hour).
+	 */
+	const IDC_VALIDATION_INITIAL_DELAY = 3600;
+
+	/**
+	 * Maximum delay for IDC validation in seconds (30 days).
+	 */
+	const IDC_VALIDATION_MAX_DELAY = 2592000;
 
 	/**
 	 * Instance of the object.
@@ -374,6 +385,14 @@ class Identity_Crisis {
 		// Is the site opted in and does the stored sync_error_idc option match what we now generate?
 		$sync_error = Jetpack_Options::get_option( 'sync_error_idc' );
 		if ( $sync_error && self::should_handle_idc() ) {
+			// Ensure backward compatibility: add validation timing fields if missing.
+			if ( ! isset( $sync_error['last_checked'] ) ) {
+				$sync_error['last_checked'] = 0;
+			}
+			if ( ! isset( $sync_error['next_check_delay'] ) ) {
+				$sync_error['next_check_delay'] = self::IDC_VALIDATION_INITIAL_DELAY;
+			}
+
 			$local_options = self::get_sync_error_idc_option();
 
 			// Ensure all values are set.
@@ -389,6 +408,15 @@ class Identity_Crisis {
 					Jetpack_Options::update_option( 'migrate_for_idc', true );
 				} elseif ( $sync_error['home'] === $local_options['home'] && $sync_error['siteurl'] === $local_options['siteurl'] ) {
 					$is_valid = true;
+
+					// Check if it's time to validate the IDC with a remote call to WordPress.com.
+					if ( self::should_validate_idc( $sync_error ) ) {
+						// Perform remote validation.
+						if ( self::validate_idc_from_remote( $sync_error ) ) {
+							// IDC was cleared remotely, mark as invalid so we return false.
+							$is_valid = false;
+						}
+					}
 				}
 			}
 		}
@@ -427,6 +455,87 @@ class Identity_Crisis {
 			}
 		}
 		return $sync_error;
+	}
+
+	/**
+	 * Checks if enough time has passed to validate the IDC with a remote call.
+	 *
+	 * Uses progressive delay: starts at 1 hour, doubles each time (1h, 2h, 4h, 8h, 16h...),
+	 * and stops checking once the maximum delay of 30 days is reached.
+	 *
+	 * @param array $sync_error The stored sync_error_idc option.
+	 * @return bool True if validation should be performed, false otherwise.
+	 */
+	public static function should_validate_idc( $sync_error ) {
+		// If delay has reached or exceeded the maximum, stop validating.
+		if ( $sync_error['next_check_delay'] >= self::IDC_VALIDATION_MAX_DELAY ) {
+			return false;
+		}
+
+		// Check if enough time has passed since the last check.
+		$time_since_last_check = time() - $sync_error['last_checked'];
+		return $time_since_last_check >= $sync_error['next_check_delay'];
+	}
+
+	/**
+	 * Validates the stored IDC by making a remote call to WordPress.com.
+	 *
+	 * Makes a lightweight API call to check if WordPress.com still detects an IDC.
+	 * If no IDC is detected in the response, the local IDC option is cleared.
+	 * If an IDC is still detected, the option is refreshed with the latest URL data from
+	 * WordPress.com and the validation timestamps are updated with progressive backoff.
+	 * If the request fails (network error, timeout, etc.), no changes are made.
+	 *
+	 * @param array $sync_error The stored sync_error_idc option with timing fields.
+	 * @return bool True if IDC was cleared, false otherwise.
+	 */
+	public static function validate_idc_from_remote( $sync_error ) {
+		$blog_id = Jetpack_Options::get_option( 'id' );
+		if ( ! $blog_id ) {
+			// Site not registered, can't make API call.
+			return false;
+		}
+
+		// Make a lightweight API call to WordPress.com.
+		// The response will automatically include 'idc_detected' if URLs still mismatch.
+		$response = Client::wpcom_json_api_request_as_blog(
+			sprintf( 'sites/%d', $blog_id ),
+			'2',
+			array( 'method' => 'GET' ),
+			null,
+			'wpcom'
+		);
+
+		// Handle network/API errors - do nothing, will retry at next scheduled interval.
+		if ( is_wp_error( $response ) || 200 !== wp_remote_retrieve_response_code( $response ) ) {
+			return false;
+		}
+
+		$body = json_decode( wp_remote_retrieve_body( $response ), true );
+		if ( ! is_array( $body ) ) {
+			// Malformed response - do nothing.
+			return false;
+		}
+
+		// Check if WordPress.com still detects an IDC.
+		if ( isset( $body['idc_detected'] ) && is_array( $body['idc_detected'] ) ) {
+			// IDC still exists - refresh with latest data from WordPress.com and update timing.
+			$fresh_idc_data = self::get_sync_error_idc_option( $body['idc_detected'] );
+
+			// Preserve and update timing fields with exponential backoff.
+			$fresh_idc_data['last_checked']     = time();
+			$fresh_idc_data['next_check_delay'] = min(
+				$sync_error['next_check_delay'] * 2,
+				self::IDC_VALIDATION_MAX_DELAY
+			);
+
+			Jetpack_Options::update_option( 'sync_error_idc', $fresh_idc_data );
+			return false;
+		}
+
+		// No IDC detected in response - WordPress.com URLs now match, clear the local IDC.
+		Jetpack_Options::delete_option( 'sync_error_idc' );
+		return true;
 	}
 
 	/**
@@ -503,6 +612,14 @@ class Identity_Crisis {
 		if ( array_key_exists( 'wpcom_home', $returned_values ) && array_key_exists( 'wpcom_siteurl', $returned_values ) ) {
 			$returned_values['reversed_url'] = true;
 			$returned_values                 = self::reverse_wpcom_urls_for_idc( $returned_values );
+		}
+
+		// Add validation timing fields for backward compatibility with existing IDC options.
+		if ( ! isset( $returned_values['last_checked'] ) ) {
+			$returned_values['last_checked'] = 0;
+		}
+		if ( ! isset( $returned_values['next_check_delay'] ) ) {
+			$returned_values['next_check_delay'] = self::IDC_VALIDATION_INITIAL_DELAY;
 		}
 
 		return $returned_values;

--- a/projects/packages/connection/src/identity-crisis/class-identity-crisis.php
+++ b/projects/packages/connection/src/identity-crisis/class-identity-crisis.php
@@ -386,6 +386,10 @@ class Identity_Crisis {
 		$sync_error = Jetpack_Options::get_option( 'sync_error_idc' );
 		if ( $sync_error && self::should_handle_idc() ) {
 			// Ensure backward compatibility: add validation timing fields if missing.
+			// Also ensure $sync_error is an array (could be a scalar from older code).
+			if ( ! is_array( $sync_error ) ) {
+				$sync_error = array();
+			}
 			if ( ! isset( $sync_error['last_checked'] ) ) {
 				$sync_error['last_checked'] = 0;
 			}

--- a/projects/packages/connection/src/identity-crisis/class-identity-crisis.php
+++ b/projects/packages/connection/src/identity-crisis/class-identity-crisis.php
@@ -414,11 +414,11 @@ class Identity_Crisis {
 					$is_valid = true;
 
 					// Check if it's time to validate the IDC with a remote call to WordPress.com.
-					if ( self::should_validate_idc( $sync_error ) ) {
+					if ( self::should_remote_validate_idc( $sync_error ) ) {
 						// Perform remote validation.
-						if ( self::validate_idc_from_remote( $sync_error ) ) {
+						if ( self::remote_validate_idc( $sync_error ) ) {
 							// IDC was cleared remotely. The option is already deleted by
-							// validate_idc_from_remote(), so return false immediately to
+							// remote_validate_idc(), so return false immediately to
 							// avoid double deletion and allow the filter to run.
 							return (bool) apply_filters( 'jetpack_sync_error_idc_validation', false );
 						}
@@ -472,7 +472,7 @@ class Identity_Crisis {
 	 * @param array $sync_error The stored sync_error_idc option.
 	 * @return bool True if validation should be performed, false otherwise.
 	 */
-	public static function should_validate_idc( $sync_error ) {
+	public static function should_remote_validate_idc( $sync_error ) {
 		// If delay is not set or invalid, validate immediately to bring into new system.
 		if ( empty( $sync_error['next_check_delay'] ) ) {
 			return true;
@@ -501,11 +501,20 @@ class Identity_Crisis {
 	 * @param array $sync_error The stored sync_error_idc option with timing fields.
 	 * @return bool True if IDC was cleared, false otherwise.
 	 */
-	public static function validate_idc_from_remote( $sync_error ) {
+	public static function remote_validate_idc( $sync_error ) {
 		// Prevent recursive calls that could cause infinite loops within the same request.
 		static $is_validating = false;
 		if ( $is_validating ) {
 			return false;
+		}
+
+		$blog_id = Jetpack_Options::get_option( 'id' );
+		if ( ! $blog_id ) {
+			// Site not registered - IDC state is invalid without a connection to WordPress.com.
+			// Clear the IDC since there's nothing to validate against, and the site can't
+			// restore the blog_id while in IDC anyway (connection flow is blocked).
+			Jetpack_Options::delete_option( 'sync_error_idc' );
+			return true; // Return true to indicate IDC was cleared.
 		}
 
 		// Use a transient lock to prevent concurrent validations across multiple requests.
@@ -516,17 +525,6 @@ class Identity_Crisis {
 		set_transient( $lock_key, true, 60 ); // 60 second lock.
 
 		$is_validating = true;
-
-		$blog_id = Jetpack_Options::get_option( 'id' );
-		if ( ! $blog_id ) {
-			// Site not registered - IDC state is invalid without a connection to WordPress.com.
-			// Clear the IDC since there's nothing to validate against, and the site can't
-			// restore the blog_id while in IDC anyway (connection flow is blocked).
-			Jetpack_Options::delete_option( 'sync_error_idc' );
-			delete_transient( $lock_key );
-			$is_validating = false;
-			return true; // Return true to indicate IDC was cleared.
-		}
 
 		// Build API path with current URLs as query params.
 		// We must explicitly include URLs because add_idc_query_args_to_url() skips

--- a/projects/packages/connection/tests/php/identity-crisis/Identity_Crisis_Test.php
+++ b/projects/packages/connection/tests/php/identity-crisis/Identity_Crisis_Test.php
@@ -1472,7 +1472,12 @@ class Identity_Crisis_Test extends BaseTestCase {
 		$mock_callback = function () {
 			return array(
 				'headers'  => array(),
-				'body'     => wp_json_encode( array( 'ID' => 12345 ), JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE ),
+				'body'     => wp_json_encode(
+					array(
+						'is_healthy' => true,
+					),
+					JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE
+				),
 				'response' => array(
 					'code'    => 200,
 					'message' => 'OK',

--- a/projects/packages/connection/tests/php/identity-crisis/Identity_Crisis_Test.php
+++ b/projects/packages/connection/tests/php/identity-crisis/Identity_Crisis_Test.php
@@ -1279,16 +1279,14 @@ class Identity_Crisis_Test extends BaseTestCase {
 		Jetpack_Options::update_option( 'sync_error_idc', $initial_sync_error );
 
 		// Mock a network error response.
-		add_filter(
-			'pre_http_request',
-			function () {
-				return new \WP_Error( 'http_request_failed', 'Network error' );
-			}
-		);
+		$mock_callback = function () {
+			return new \WP_Error( 'http_request_failed', 'Network error' );
+		};
+		add_filter( 'pre_http_request', $mock_callback );
 
 		$result = Identity_Crisis::validate_idc_from_remote( $initial_sync_error );
 
-		remove_filter( 'pre_http_request', '__return_true' );
+		remove_filter( 'pre_http_request', $mock_callback );
 		$stored_option = Jetpack_Options::get_option( 'sync_error_idc' );
 
 		Jetpack_Options::delete_option( 'id' );
@@ -1308,19 +1306,17 @@ class Identity_Crisis_Test extends BaseTestCase {
 		Jetpack_Options::update_option( 'sync_error_idc', $initial_sync_error );
 
 		// Mock a 500 error response.
-		add_filter(
-			'pre_http_request',
-			function () {
-				return array(
-					'response' => array( 'code' => 500 ),
-					'body'     => 'Internal server error',
-				);
-			}
-		);
+		$mock_callback = function () {
+			return array(
+				'response' => array( 'code' => 500 ),
+				'body'     => 'Internal server error',
+			);
+		};
+		add_filter( 'pre_http_request', $mock_callback );
 
 		$result = Identity_Crisis::validate_idc_from_remote( $initial_sync_error );
 
-		remove_filter( 'pre_http_request', '__return_true' );
+		remove_filter( 'pre_http_request', $mock_callback );
 		$stored_option = Jetpack_Options::get_option( 'sync_error_idc' );
 
 		Jetpack_Options::delete_option( 'id' );
@@ -1340,19 +1336,17 @@ class Identity_Crisis_Test extends BaseTestCase {
 		Jetpack_Options::update_option( 'sync_error_idc', $initial_sync_error );
 
 		// Mock a successful response with no IDC detected.
-		add_filter(
-			'pre_http_request',
-			function () {
-				return array(
-					'response' => array( 'code' => 200 ),
-					'body'     => wp_json_encode( array( 'ID' => 12345 ), JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE ),
-				);
-			}
-		);
+		$mock_callback = function () {
+			return array(
+				'response' => array( 'code' => 200 ),
+				'body'     => wp_json_encode( array( 'ID' => 12345 ), JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE ),
+			);
+		};
+		add_filter( 'pre_http_request', $mock_callback );
 
 		$result = Identity_Crisis::validate_idc_from_remote( $initial_sync_error );
 
-		remove_filter( 'pre_http_request', '__return_true' );
+		remove_filter( 'pre_http_request', $mock_callback );
 		$stored_option = Jetpack_Options::get_option( 'sync_error_idc' );
 
 		Jetpack_Options::delete_option( 'id' );
@@ -1373,28 +1367,26 @@ class Identity_Crisis_Test extends BaseTestCase {
 		Jetpack_Options::update_option( 'sync_error_idc', $initial_sync_error );
 
 		// Mock a response with IDC still detected.
-		add_filter(
-			'pre_http_request',
-			function () {
-				return array(
-					'response' => array( 'code' => 200 ),
-					'body'     => wp_json_encode(
-						array(
-							'idc_detected' => array(
-								'error_code'    => 'jetpack_url_mismatch',
-								'wpcom_home'    => 'example.com/',
-								'wpcom_siteurl' => 'example.com/',
-							),
+		$mock_callback = function () {
+			return array(
+				'response' => array( 'code' => 200 ),
+				'body'     => wp_json_encode(
+					array(
+						'idc_detected' => array(
+							'error_code'    => 'jetpack_url_mismatch',
+							'wpcom_home'    => 'example.com/',
+							'wpcom_siteurl' => 'example.com/',
 						),
-						JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE
 					),
-				);
-			}
-		);
+					JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE
+				),
+			);
+		};
+		add_filter( 'pre_http_request', $mock_callback );
 
 		$result = Identity_Crisis::validate_idc_from_remote( $initial_sync_error );
 
-		remove_filter( 'pre_http_request', '__return_true' );
+		remove_filter( 'pre_http_request', $mock_callback );
 		$stored_option = Jetpack_Options::get_option( 'sync_error_idc' );
 
 		Jetpack_Options::delete_option( 'id' );

--- a/projects/packages/connection/tests/php/identity-crisis/Identity_Crisis_Test.php
+++ b/projects/packages/connection/tests/php/identity-crisis/Identity_Crisis_Test.php
@@ -1274,11 +1274,13 @@ class Identity_Crisis_Test extends BaseTestCase {
 		$sync_error = Identity_Crisis::get_sync_error_idc_option();
 		$result     = Identity_Crisis::validate_idc_from_remote( $sync_error );
 
+		delete_transient( 'jetpack_idc_validation_lock' );
+
 		$this->assertFalse( $result );
 	}
 
 	/**
-	 * Test validate_idc_from_remote() returns false and doesn't change option on network error.
+	 * Test validate_idc_from_remote() returns false and updates timing on network error.
 	 */
 	public function test_validate_idc_from_remote_handles_network_error_gracefully() {
 		Jetpack_Options::update_option( 'id', 12345 );
@@ -1298,14 +1300,17 @@ class Identity_Crisis_Test extends BaseTestCase {
 
 		Jetpack_Options::delete_option( 'id' );
 		Jetpack_Options::delete_option( 'sync_error_idc' );
+		delete_transient( 'jetpack_idc_validation_lock' );
 
 		$this->assertFalse( $result );
-		// Option should be unchanged.
-		$this->assertEquals( $initial_sync_error, $stored_option );
+		// last_checked should be updated to prevent hammering on errors.
+		$this->assertGreaterThan( $initial_sync_error['last_checked'], $stored_option['last_checked'] );
+		// Delay should remain unchanged on errors (no exponential backoff).
+		$this->assertEquals( $initial_sync_error['next_check_delay'], $stored_option['next_check_delay'] );
 	}
 
 	/**
-	 * Test validate_idc_from_remote() returns false and doesn't change option on non-200 response.
+	 * Test validate_idc_from_remote() returns false and updates timing on non-200 response.
 	 */
 	public function test_validate_idc_from_remote_handles_non_200_response() {
 		Jetpack_Options::update_option( 'id', 12345 );
@@ -1334,9 +1339,73 @@ class Identity_Crisis_Test extends BaseTestCase {
 
 		Jetpack_Options::delete_option( 'id' );
 		Jetpack_Options::delete_option( 'sync_error_idc' );
+		delete_transient( 'jetpack_idc_validation_lock' );
 
 		$this->assertFalse( $result );
-		// Option should be unchanged.
-		$this->assertEquals( $initial_sync_error, $stored_option );
+		// last_checked should be updated to prevent hammering on errors.
+		$this->assertGreaterThan( $initial_sync_error['last_checked'], $stored_option['last_checked'] );
+		// Delay should remain unchanged on errors (no exponential backoff).
+		$this->assertEquals( $initial_sync_error['next_check_delay'], $stored_option['next_check_delay'] );
+	}
+
+	/**
+	 * Test validate_idc_from_remote() uses transient lock to prevent concurrent validations.
+	 */
+	public function test_validate_idc_from_remote_uses_transient_lock() {
+		Jetpack_Options::update_option( 'id', 12345 );
+		$sync_error = Identity_Crisis::get_sync_error_idc_option();
+		Jetpack_Options::update_option( 'sync_error_idc', $sync_error );
+
+		// Set the lock transient to simulate another validation in progress.
+		set_transient( 'jetpack_idc_validation_lock', true, 60 );
+
+		$result = Identity_Crisis::validate_idc_from_remote( $sync_error );
+
+		// Clean up.
+		delete_transient( 'jetpack_idc_validation_lock' );
+		Jetpack_Options::delete_option( 'id' );
+		Jetpack_Options::delete_option( 'sync_error_idc' );
+
+		// Should return false because lock is held.
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * Test validate_idc_from_remote() updates timing on invalid JSON response.
+	 */
+	public function test_validate_idc_from_remote_handles_invalid_json_gracefully() {
+		Jetpack_Options::update_option( 'id', 12345 );
+		$initial_sync_error = Identity_Crisis::get_sync_error_idc_option();
+		Jetpack_Options::update_option( 'sync_error_idc', $initial_sync_error );
+
+		// Mock a 200 response with invalid JSON.
+		$mock_callback = function () {
+			return array(
+				'headers'  => array(),
+				'body'     => 'not valid json {{{',
+				'response' => array(
+					'code'    => 200,
+					'message' => 'OK',
+				),
+				'cookies'  => array(),
+				'filename' => null,
+			);
+		};
+		add_filter( 'pre_http_request', $mock_callback, 10, 3 );
+
+		$result = Identity_Crisis::validate_idc_from_remote( $initial_sync_error );
+
+		remove_filter( 'pre_http_request', $mock_callback );
+		$stored_option = Jetpack_Options::get_option( 'sync_error_idc' );
+
+		Jetpack_Options::delete_option( 'id' );
+		Jetpack_Options::delete_option( 'sync_error_idc' );
+		delete_transient( 'jetpack_idc_validation_lock' );
+
+		$this->assertFalse( $result );
+		// last_checked should be updated to prevent hammering on errors.
+		$this->assertGreaterThan( $initial_sync_error['last_checked'], $stored_option['last_checked'] );
+		// Delay should remain unchanged on errors (no exponential backoff).
+		$this->assertEquals( $initial_sync_error['next_check_delay'], $stored_option['next_check_delay'] );
 	}
 }

--- a/projects/packages/connection/tests/php/identity-crisis/Identity_Crisis_Test.php
+++ b/projects/packages/connection/tests/php/identity-crisis/Identity_Crisis_Test.php
@@ -1183,6 +1183,13 @@ class Identity_Crisis_Test extends BaseTestCase {
 	 * Test backward compatibility: validate_sync_error_idc_option() adds timing fields to existing IDC options.
 	 */
 	public function test_validate_sync_error_idc_option_adds_timing_fields_for_backward_compatibility() {
+		// Clean up any state from previous tests.
+		delete_transient( 'jetpack_idc_validation_lock' );
+
+		// Set blog_id so the "clear IDC on missing blog_id" path is avoided.
+		// The API call will fail due to missing blog_token, but that's handled gracefully.
+		Jetpack_Options::update_option( 'id', 12345 );
+
 		add_filter( 'jetpack_should_handle_idc', '__return_true' );
 
 		// Create an IDC option without timing fields (simulating an old option).
@@ -1191,13 +1198,17 @@ class Identity_Crisis_Test extends BaseTestCase {
 		unset( $option['next_check_delay'] );
 		Jetpack_Options::update_option( 'sync_error_idc', $option );
 
-		// Validate it - this should add timing fields in memory.
+		// Validate it - this should add timing fields and trigger remote validation.
+		// The API call will fail, but failures are handled gracefully (IDC persists).
 		$result = Identity_Crisis::validate_sync_error_idc_option();
 
+		// Clean up.
 		Jetpack_Options::delete_option( 'sync_error_idc' );
+		Jetpack_Options::delete_option( 'id' );
+		delete_transient( 'jetpack_idc_validation_lock' );
 		remove_filter( 'jetpack_should_handle_idc', '__return_true' );
 
-		// Should still be valid.
+		// Should still be valid (IDC persists because API failure doesn't clear it).
 		$this->assertTrue( $result );
 	}
 

--- a/projects/packages/connection/tests/php/identity-crisis/Identity_Crisis_Test.php
+++ b/projects/packages/connection/tests/php/identity-crisis/Identity_Crisis_Test.php
@@ -1159,4 +1159,255 @@ class Identity_Crisis_Test extends BaseTestCase {
 			$this->assertNotContains( $expected_ip3, $ip );
 		}
 	}
+
+	/**
+	 * Test that get_sync_error_idc_option() adds timing fields for new IDC options.
+	 */
+	public function test_get_sync_error_idc_option_adds_timing_fields() {
+		$option = Identity_Crisis::get_sync_error_idc_option();
+
+		$this->assertArrayHasKey( 'last_checked', $option );
+		$this->assertArrayHasKey( 'next_check_delay', $option );
+		$this->assertSame( 0, $option['last_checked'] );
+		$this->assertEquals( Identity_Crisis::IDC_VALIDATION_INITIAL_DELAY, $option['next_check_delay'] );
+	}
+
+	/**
+	 * Test backward compatibility: validate_sync_error_idc_option() adds timing fields to existing IDC options.
+	 */
+	public function test_validate_sync_error_idc_option_adds_timing_fields_for_backward_compatibility() {
+		add_filter( 'jetpack_should_handle_idc', '__return_true' );
+
+		// Create an IDC option without timing fields (simulating an old option).
+		$option = Identity_Crisis::get_sync_error_idc_option();
+		unset( $option['last_checked'] );
+		unset( $option['next_check_delay'] );
+		Jetpack_Options::update_option( 'sync_error_idc', $option );
+
+		// Validate it - this should add timing fields in memory.
+		$result = Identity_Crisis::validate_sync_error_idc_option();
+
+		Jetpack_Options::delete_option( 'sync_error_idc' );
+		remove_filter( 'jetpack_should_handle_idc', '__return_true' );
+
+		// Should still be valid.
+		$this->assertTrue( $result );
+	}
+
+	/**
+	 * Test that constants are defined with expected values.
+	 */
+	public function test_idc_validation_constants() {
+		$this->assertEquals( 3600, Identity_Crisis::IDC_VALIDATION_INITIAL_DELAY );
+		$this->assertEquals( 2592000, Identity_Crisis::IDC_VALIDATION_MAX_DELAY );
+	}
+
+	/**
+	 * Test should_validate_idc() returns false when max delay reached.
+	 */
+	public function test_should_validate_idc_returns_false_when_max_delay_reached() {
+		$sync_error = array(
+			'last_checked'     => time() - 3600,
+			'next_check_delay' => Identity_Crisis::IDC_VALIDATION_MAX_DELAY,
+		);
+
+		$result = Identity_Crisis::should_validate_idc( $sync_error );
+
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * Test should_validate_idc() returns false when not enough time has passed.
+	 */
+	public function test_should_validate_idc_returns_false_when_not_enough_time_passed() {
+		$sync_error = array(
+			'last_checked'     => time() - 1800, // 30 minutes ago.
+			'next_check_delay' => 3600, // 1 hour delay.
+		);
+
+		$result = Identity_Crisis::should_validate_idc( $sync_error );
+
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * Test should_validate_idc() returns true when enough time has passed.
+	 */
+	public function test_should_validate_idc_returns_true_when_enough_time_passed() {
+		$sync_error = array(
+			'last_checked'     => time() - 7200, // 2 hours ago.
+			'next_check_delay' => 3600, // 1 hour delay.
+		);
+
+		$result = Identity_Crisis::should_validate_idc( $sync_error );
+
+		$this->assertTrue( $result );
+	}
+
+	/**
+	 * Test should_validate_idc() returns true when last_checked is 0 (never checked).
+	 */
+	public function test_should_validate_idc_returns_true_when_never_checked() {
+		$sync_error = array(
+			'last_checked'     => 0,
+			'next_check_delay' => 3600,
+		);
+
+		$result = Identity_Crisis::should_validate_idc( $sync_error );
+
+		$this->assertTrue( $result );
+	}
+
+	/**
+	 * Test validate_idc_from_remote() returns false when site is not registered.
+	 */
+	public function test_validate_idc_from_remote_returns_false_when_not_registered() {
+		Jetpack_Options::delete_option( 'id' );
+
+		$sync_error = Identity_Crisis::get_sync_error_idc_option();
+		$result     = Identity_Crisis::validate_idc_from_remote( $sync_error );
+
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * Test validate_idc_from_remote() returns false and doesn't change option on network error.
+	 */
+	public function test_validate_idc_from_remote_handles_network_error_gracefully() {
+		Jetpack_Options::update_option( 'id', 12345 );
+		$initial_sync_error = Identity_Crisis::get_sync_error_idc_option();
+		Jetpack_Options::update_option( 'sync_error_idc', $initial_sync_error );
+
+		// Mock a network error response.
+		add_filter(
+			'pre_http_request',
+			function () {
+				return new \WP_Error( 'http_request_failed', 'Network error' );
+			}
+		);
+
+		$result = Identity_Crisis::validate_idc_from_remote( $initial_sync_error );
+
+		remove_filter( 'pre_http_request', '__return_true' );
+		$stored_option = Jetpack_Options::get_option( 'sync_error_idc' );
+
+		Jetpack_Options::delete_option( 'id' );
+		Jetpack_Options::delete_option( 'sync_error_idc' );
+
+		$this->assertFalse( $result );
+		// Option should be unchanged.
+		$this->assertEquals( $initial_sync_error, $stored_option );
+	}
+
+	/**
+	 * Test validate_idc_from_remote() returns false and doesn't change option on non-200 response.
+	 */
+	public function test_validate_idc_from_remote_handles_non_200_response() {
+		Jetpack_Options::update_option( 'id', 12345 );
+		$initial_sync_error = Identity_Crisis::get_sync_error_idc_option();
+		Jetpack_Options::update_option( 'sync_error_idc', $initial_sync_error );
+
+		// Mock a 500 error response.
+		add_filter(
+			'pre_http_request',
+			function () {
+				return array(
+					'response' => array( 'code' => 500 ),
+					'body'     => 'Internal server error',
+				);
+			}
+		);
+
+		$result = Identity_Crisis::validate_idc_from_remote( $initial_sync_error );
+
+		remove_filter( 'pre_http_request', '__return_true' );
+		$stored_option = Jetpack_Options::get_option( 'sync_error_idc' );
+
+		Jetpack_Options::delete_option( 'id' );
+		Jetpack_Options::delete_option( 'sync_error_idc' );
+
+		$this->assertFalse( $result );
+		// Option should be unchanged.
+		$this->assertEquals( $initial_sync_error, $stored_option );
+	}
+
+	/**
+	 * Test validate_idc_from_remote() clears IDC when no idc_detected in response.
+	 */
+	public function test_validate_idc_from_remote_clears_idc_when_resolved() {
+		Jetpack_Options::update_option( 'id', 12345 );
+		$initial_sync_error = Identity_Crisis::get_sync_error_idc_option();
+		Jetpack_Options::update_option( 'sync_error_idc', $initial_sync_error );
+
+		// Mock a successful response with no IDC detected.
+		add_filter(
+			'pre_http_request',
+			function () {
+				return array(
+					'response' => array( 'code' => 200 ),
+					'body'     => wp_json_encode( array( 'ID' => 12345 ), JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE ),
+				);
+			}
+		);
+
+		$result = Identity_Crisis::validate_idc_from_remote( $initial_sync_error );
+
+		remove_filter( 'pre_http_request', '__return_true' );
+		$stored_option = Jetpack_Options::get_option( 'sync_error_idc' );
+
+		Jetpack_Options::delete_option( 'id' );
+
+		$this->assertTrue( $result );
+		// Option should be deleted.
+		$this->assertFalse( $stored_option );
+	}
+
+	/**
+	 * Test validate_idc_from_remote() updates option when IDC still detected.
+	 */
+	public function test_validate_idc_from_remote_updates_option_when_idc_still_exists() {
+		Jetpack_Options::update_option( 'id', 12345 );
+		$initial_sync_error                     = Identity_Crisis::get_sync_error_idc_option();
+		$initial_sync_error['last_checked']     = time() - 7200; // 2 hours ago.
+		$initial_sync_error['next_check_delay'] = 3600; // 1 hour.
+		Jetpack_Options::update_option( 'sync_error_idc', $initial_sync_error );
+
+		// Mock a response with IDC still detected.
+		add_filter(
+			'pre_http_request',
+			function () {
+				return array(
+					'response' => array( 'code' => 200 ),
+					'body'     => wp_json_encode(
+						array(
+							'idc_detected' => array(
+								'error_code'    => 'jetpack_url_mismatch',
+								'wpcom_home'    => 'example.com/',
+								'wpcom_siteurl' => 'example.com/',
+							),
+						),
+						JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE
+					),
+				);
+			}
+		);
+
+		$result = Identity_Crisis::validate_idc_from_remote( $initial_sync_error );
+
+		remove_filter( 'pre_http_request', '__return_true' );
+		$stored_option = Jetpack_Options::get_option( 'sync_error_idc' );
+
+		Jetpack_Options::delete_option( 'id' );
+		Jetpack_Options::delete_option( 'sync_error_idc' );
+
+		$this->assertFalse( $result );
+		// Option should be updated with new timing.
+		$this->assertIsArray( $stored_option );
+		$this->assertArrayHasKey( 'last_checked', $stored_option );
+		$this->assertArrayHasKey( 'next_check_delay', $stored_option );
+		// Delay should be doubled (3600 * 2 = 7200).
+		$this->assertEquals( 7200, $stored_option['next_check_delay'] );
+		// last_checked should be updated to recent time.
+		$this->assertGreaterThan( time() - 10, $stored_option['last_checked'] );
+	}
 }

--- a/projects/packages/connection/tests/php/identity-crisis/Identity_Crisis_Test.php
+++ b/projects/packages/connection/tests/php/identity-crisis/Identity_Crisis_Test.php
@@ -1221,65 +1221,65 @@ class Identity_Crisis_Test extends BaseTestCase {
 	}
 
 	/**
-	 * Test should_validate_idc() returns false when max delay reached.
+	 * Test should_remote_validate_idc() returns false when max delay reached.
 	 */
-	public function test_should_validate_idc_returns_false_when_max_delay_reached() {
+	public function test_should_remote_validate_idc_returns_false_when_max_delay_reached() {
 		$sync_error = array(
 			'last_checked'     => time() - 3600,
 			'next_check_delay' => Identity_Crisis::IDC_VALIDATION_MAX_DELAY,
 		);
 
-		$result = Identity_Crisis::should_validate_idc( $sync_error );
+		$result = Identity_Crisis::should_remote_validate_idc( $sync_error );
 
 		$this->assertFalse( $result );
 	}
 
 	/**
-	 * Test should_validate_idc() returns false when not enough time has passed.
+	 * Test should_remote_validate_idc() returns false when not enough time has passed.
 	 */
-	public function test_should_validate_idc_returns_false_when_not_enough_time_passed() {
+	public function test_should_remote_validate_idc_returns_false_when_not_enough_time_passed() {
 		$sync_error = array(
 			'last_checked'     => time() - 1800, // 30 minutes ago.
 			'next_check_delay' => 3600, // 1 hour delay.
 		);
 
-		$result = Identity_Crisis::should_validate_idc( $sync_error );
+		$result = Identity_Crisis::should_remote_validate_idc( $sync_error );
 
 		$this->assertFalse( $result );
 	}
 
 	/**
-	 * Test should_validate_idc() returns true when enough time has passed.
+	 * Test should_remote_validate_idc() returns true when enough time has passed.
 	 */
-	public function test_should_validate_idc_returns_true_when_enough_time_passed() {
+	public function test_should_remote_validate_idc_returns_true_when_enough_time_passed() {
 		$sync_error = array(
 			'last_checked'     => time() - 7200, // 2 hours ago.
 			'next_check_delay' => 3600, // 1 hour delay.
 		);
 
-		$result = Identity_Crisis::should_validate_idc( $sync_error );
+		$result = Identity_Crisis::should_remote_validate_idc( $sync_error );
 
 		$this->assertTrue( $result );
 	}
 
 	/**
-	 * Test should_validate_idc() returns true when last_checked is 0 (never checked).
+	 * Test should_remote_validate_idc() returns true when last_checked is 0 (never checked).
 	 */
-	public function test_should_validate_idc_returns_true_when_never_checked() {
+	public function test_should_remote_validate_idc_returns_true_when_never_checked() {
 		$sync_error = array(
 			'last_checked'     => 0,
 			'next_check_delay' => 3600,
 		);
 
-		$result = Identity_Crisis::should_validate_idc( $sync_error );
+		$result = Identity_Crisis::should_remote_validate_idc( $sync_error );
 
 		$this->assertTrue( $result );
 	}
 
 	/**
-	 * Test validate_idc_from_remote() clears IDC when site is not registered.
+	 * Test remote_validate_idc() clears IDC when site is not registered.
 	 */
-	public function test_validate_idc_from_remote_clears_idc_when_not_registered() {
+	public function test_remote_validate_idc_clears_idc_when_not_registered() {
 		// Clean up any state from previous tests.
 		delete_transient( 'jetpack_idc_validation_lock' );
 
@@ -1288,7 +1288,7 @@ class Identity_Crisis_Test extends BaseTestCase {
 		$initial_sync_error = Identity_Crisis::get_sync_error_idc_option();
 		Jetpack_Options::update_option( 'sync_error_idc', $initial_sync_error );
 
-		$result = Identity_Crisis::validate_idc_from_remote( $initial_sync_error );
+		$result = Identity_Crisis::remote_validate_idc( $initial_sync_error );
 
 		$stored_option = Jetpack_Options::get_option( 'sync_error_idc' );
 
@@ -1302,9 +1302,9 @@ class Identity_Crisis_Test extends BaseTestCase {
 	}
 
 	/**
-	 * Test validate_idc_from_remote() returns false and updates timing on network error.
+	 * Test remote_validate_idc() returns false and updates timing on network error.
 	 */
-	public function test_validate_idc_from_remote_handles_network_error_gracefully() {
+	public function test_remote_validate_idc_handles_network_error_gracefully() {
 		// Clean up any state from previous tests.
 		delete_transient( 'jetpack_idc_validation_lock' );
 
@@ -1325,7 +1325,7 @@ class Identity_Crisis_Test extends BaseTestCase {
 		};
 		add_filter( 'pre_http_request', $mock_callback, 10, 3 );
 
-		$result = Identity_Crisis::validate_idc_from_remote( $initial_sync_error );
+		$result = Identity_Crisis::remote_validate_idc( $initial_sync_error );
 
 		remove_filter( 'pre_http_request', $mock_callback );
 		$stored_option = Jetpack_Options::get_option( 'sync_error_idc' );
@@ -1345,9 +1345,9 @@ class Identity_Crisis_Test extends BaseTestCase {
 	}
 
 	/**
-	 * Test validate_idc_from_remote() returns false and updates timing on non-200 response.
+	 * Test remote_validate_idc() returns false and updates timing on non-200 response.
 	 */
-	public function test_validate_idc_from_remote_handles_non_200_response() {
+	public function test_remote_validate_idc_handles_non_200_response() {
 		// Clean up any state from previous tests.
 		delete_transient( 'jetpack_idc_validation_lock' );
 
@@ -1377,7 +1377,7 @@ class Identity_Crisis_Test extends BaseTestCase {
 		};
 		add_filter( 'pre_http_request', $mock_callback, 10, 3 );
 
-		$result = Identity_Crisis::validate_idc_from_remote( $initial_sync_error );
+		$result = Identity_Crisis::remote_validate_idc( $initial_sync_error );
 
 		remove_filter( 'pre_http_request', $mock_callback );
 		$stored_option = Jetpack_Options::get_option( 'sync_error_idc' );
@@ -1397,9 +1397,9 @@ class Identity_Crisis_Test extends BaseTestCase {
 	}
 
 	/**
-	 * Test validate_idc_from_remote() uses transient lock to prevent concurrent validations.
+	 * Test remote_validate_idc() uses transient lock to prevent concurrent validations.
 	 */
-	public function test_validate_idc_from_remote_uses_transient_lock() {
+	public function test_remote_validate_idc_uses_transient_lock() {
 		Jetpack_Options::update_option( 'id', 12345 );
 		$sync_error = Identity_Crisis::get_sync_error_idc_option();
 		Jetpack_Options::update_option( 'sync_error_idc', $sync_error );
@@ -1407,7 +1407,7 @@ class Identity_Crisis_Test extends BaseTestCase {
 		// Set the lock transient to simulate another validation in progress.
 		set_transient( 'jetpack_idc_validation_lock', true, 60 );
 
-		$result = Identity_Crisis::validate_idc_from_remote( $sync_error );
+		$result = Identity_Crisis::remote_validate_idc( $sync_error );
 
 		// Clean up.
 		delete_transient( 'jetpack_idc_validation_lock' );
@@ -1419,9 +1419,9 @@ class Identity_Crisis_Test extends BaseTestCase {
 	}
 
 	/**
-	 * Test validate_idc_from_remote() updates timing on invalid JSON response.
+	 * Test remote_validate_idc() updates timing on invalid JSON response.
 	 */
-	public function test_validate_idc_from_remote_handles_invalid_json_gracefully() {
+	public function test_remote_validate_idc_handles_invalid_json_gracefully() {
 		// Clean up any state from previous tests.
 		delete_transient( 'jetpack_idc_validation_lock' );
 
@@ -1451,7 +1451,7 @@ class Identity_Crisis_Test extends BaseTestCase {
 		};
 		add_filter( 'pre_http_request', $mock_callback, 10, 3 );
 
-		$result = Identity_Crisis::validate_idc_from_remote( $initial_sync_error );
+		$result = Identity_Crisis::remote_validate_idc( $initial_sync_error );
 
 		remove_filter( 'pre_http_request', $mock_callback );
 		$stored_option = Jetpack_Options::get_option( 'sync_error_idc' );
@@ -1471,9 +1471,9 @@ class Identity_Crisis_Test extends BaseTestCase {
 	}
 
 	/**
-	 * Test validate_idc_from_remote() clears IDC when WordPress.com returns no idc_detected.
+	 * Test remote_validate_idc() clears IDC when WordPress.com returns no idc_detected.
 	 */
-	public function test_validate_idc_from_remote_clears_idc_when_resolved() {
+	public function test_remote_validate_idc_clears_idc_when_resolved() {
 		// Clean up any state from previous tests.
 		delete_transient( 'jetpack_idc_validation_lock' );
 
@@ -1507,7 +1507,7 @@ class Identity_Crisis_Test extends BaseTestCase {
 		};
 		add_filter( 'pre_http_request', $mock_callback, 10, 3 );
 
-		$result = Identity_Crisis::validate_idc_from_remote( $initial_sync_error );
+		$result = Identity_Crisis::remote_validate_idc( $initial_sync_error );
 
 		remove_filter( 'pre_http_request', $mock_callback );
 		$stored_option = Jetpack_Options::get_option( 'sync_error_idc' );
@@ -1525,9 +1525,9 @@ class Identity_Crisis_Test extends BaseTestCase {
 	}
 
 	/**
-	 * Test validate_idc_from_remote() updates timing with backoff when IDC still exists.
+	 * Test remote_validate_idc() updates timing with backoff when IDC still exists.
 	 */
-	public function test_validate_idc_from_remote_updates_timing_when_idc_persists() {
+	public function test_remote_validate_idc_updates_timing_when_idc_persists() {
 		// Clean up any state from previous tests.
 		delete_transient( 'jetpack_idc_validation_lock' );
 
@@ -1568,7 +1568,7 @@ class Identity_Crisis_Test extends BaseTestCase {
 		};
 		add_filter( 'pre_http_request', $mock_callback, 10, 3 );
 
-		$result = Identity_Crisis::validate_idc_from_remote( $initial_sync_error );
+		$result = Identity_Crisis::remote_validate_idc( $initial_sync_error );
 
 		remove_filter( 'pre_http_request', $mock_callback );
 		$stored_option = Jetpack_Options::get_option( 'sync_error_idc' );

--- a/projects/packages/connection/tests/php/identity-crisis/Identity_Crisis_Test.php
+++ b/projects/packages/connection/tests/php/identity-crisis/Identity_Crisis_Test.php
@@ -1266,20 +1266,28 @@ class Identity_Crisis_Test extends BaseTestCase {
 	}
 
 	/**
-	 * Test validate_idc_from_remote() returns false when site is not registered.
+	 * Test validate_idc_from_remote() clears IDC when site is not registered.
 	 */
-	public function test_validate_idc_from_remote_returns_false_when_not_registered() {
+	public function test_validate_idc_from_remote_clears_idc_when_not_registered() {
 		// Clean up any state from previous tests.
 		delete_transient( 'jetpack_idc_validation_lock' );
 
 		Jetpack_Options::delete_option( 'id' );
 
-		$sync_error = Identity_Crisis::get_sync_error_idc_option();
-		$result     = Identity_Crisis::validate_idc_from_remote( $sync_error );
+		$initial_sync_error = Identity_Crisis::get_sync_error_idc_option();
+		Jetpack_Options::update_option( 'sync_error_idc', $initial_sync_error );
 
+		$result = Identity_Crisis::validate_idc_from_remote( $initial_sync_error );
+
+		$stored_option = Jetpack_Options::get_option( 'sync_error_idc' );
+
+		// Clean up.
 		delete_transient( 'jetpack_idc_validation_lock' );
 
-		$this->assertFalse( $result );
+		// Should return true (IDC was cleared) because IDC is invalid without a blog_id.
+		$this->assertTrue( $result );
+		// Option should be deleted.
+		$this->assertFalse( $stored_option );
 	}
 
 	/**

--- a/projects/packages/connection/tests/php/identity-crisis/Identity_Crisis_Test.php
+++ b/projects/packages/connection/tests/php/identity-crisis/Identity_Crisis_Test.php
@@ -1171,11 +1171,15 @@ class Identity_Crisis_Test extends BaseTestCase {
 	 * Test that get_sync_error_idc_option() adds timing fields for new IDC options.
 	 */
 	public function test_get_sync_error_idc_option_adds_timing_fields() {
+		$before = time();
 		$option = Identity_Crisis::get_sync_error_idc_option();
+		$after  = time();
 
 		$this->assertArrayHasKey( 'last_checked', $option );
 		$this->assertArrayHasKey( 'next_check_delay', $option );
-		$this->assertSame( 0, $option['last_checked'] );
+		// last_checked should be set to current time to prevent immediate validation.
+		$this->assertGreaterThanOrEqual( $before, $option['last_checked'] );
+		$this->assertLessThanOrEqual( $after, $option['last_checked'] );
 		$this->assertEquals( Identity_Crisis::IDC_VALIDATION_INITIAL_DELAY, $option['next_check_delay'] );
 	}
 

--- a/projects/packages/connection/tests/php/identity-crisis/Identity_Crisis_Test.php
+++ b/projects/packages/connection/tests/php/identity-crisis/Identity_Crisis_Test.php
@@ -291,8 +291,10 @@ class Identity_Crisis_Test extends BaseTestCase {
 		update_option( 'siteurl', 'http://www.coolsite.com/wp' );
 
 		$expected = array(
-			'home'    => 'coolsite.com/',
-			'siteurl' => 'coolsite.com/wp/',
+			'home'             => 'coolsite.com/',
+			'siteurl'          => 'coolsite.com/wp/',
+			'last_checked'     => 0,
+			'next_check_delay' => Identity_Crisis::IDC_VALIDATION_INITIAL_DELAY,
 		);
 
 		$result = Identity_Crisis::get_sync_error_idc_option();
@@ -316,8 +318,10 @@ class Identity_Crisis_Test extends BaseTestCase {
 		update_option( 'siteurl', 'http://72.182.131.109/~wordpress/wp' );
 
 		$expected = array(
-			'home'    => '72.182.131.109/~wordpress/',
-			'siteurl' => '72.182.131.109/~wordpress/wp/',
+			'home'             => '72.182.131.109/~wordpress/',
+			'siteurl'          => '72.182.131.109/~wordpress/wp/',
+			'last_checked'     => 0,
+			'next_check_delay' => Identity_Crisis::IDC_VALIDATION_INITIAL_DELAY,
 		);
 
 		$result = Identity_Crisis::get_sync_error_idc_option();
@@ -569,6 +573,9 @@ class Identity_Crisis_Test extends BaseTestCase {
 			);
 			// Add reversed_url key
 			$expected_option['reversed_url'] = true;
+			// Add timing fields that are now added by default
+			$expected_option['last_checked']     = 0;
+			$expected_option['next_check_delay'] = Identity_Crisis::IDC_VALIDATION_INITIAL_DELAY;
 		} else {
 			$expected_option = false;
 		}
@@ -1282,7 +1289,7 @@ class Identity_Crisis_Test extends BaseTestCase {
 		$mock_callback = function () {
 			return new \WP_Error( 'http_request_failed', 'Network error' );
 		};
-		add_filter( 'pre_http_request', $mock_callback );
+		add_filter( 'pre_http_request', $mock_callback, 10, 3 );
 
 		$result = Identity_Crisis::validate_idc_from_remote( $initial_sync_error );
 
@@ -1308,11 +1315,17 @@ class Identity_Crisis_Test extends BaseTestCase {
 		// Mock a 500 error response.
 		$mock_callback = function () {
 			return array(
-				'response' => array( 'code' => 500 ),
+				'headers'  => array(),
 				'body'     => 'Internal server error',
+				'response' => array(
+					'code'    => 500,
+					'message' => 'Internal Server Error',
+				),
+				'cookies'  => array(),
+				'filename' => null,
 			);
 		};
-		add_filter( 'pre_http_request', $mock_callback );
+		add_filter( 'pre_http_request', $mock_callback, 10, 3 );
 
 		$result = Identity_Crisis::validate_idc_from_remote( $initial_sync_error );
 
@@ -1325,81 +1338,5 @@ class Identity_Crisis_Test extends BaseTestCase {
 		$this->assertFalse( $result );
 		// Option should be unchanged.
 		$this->assertEquals( $initial_sync_error, $stored_option );
-	}
-
-	/**
-	 * Test validate_idc_from_remote() clears IDC when no idc_detected in response.
-	 */
-	public function test_validate_idc_from_remote_clears_idc_when_resolved() {
-		Jetpack_Options::update_option( 'id', 12345 );
-		$initial_sync_error = Identity_Crisis::get_sync_error_idc_option();
-		Jetpack_Options::update_option( 'sync_error_idc', $initial_sync_error );
-
-		// Mock a successful response with no IDC detected.
-		$mock_callback = function () {
-			return array(
-				'response' => array( 'code' => 200 ),
-				'body'     => wp_json_encode( array( 'ID' => 12345 ), JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE ),
-			);
-		};
-		add_filter( 'pre_http_request', $mock_callback );
-
-		$result = Identity_Crisis::validate_idc_from_remote( $initial_sync_error );
-
-		remove_filter( 'pre_http_request', $mock_callback );
-		$stored_option = Jetpack_Options::get_option( 'sync_error_idc' );
-
-		Jetpack_Options::delete_option( 'id' );
-
-		$this->assertTrue( $result );
-		// Option should be deleted.
-		$this->assertFalse( $stored_option );
-	}
-
-	/**
-	 * Test validate_idc_from_remote() updates option when IDC still detected.
-	 */
-	public function test_validate_idc_from_remote_updates_option_when_idc_still_exists() {
-		Jetpack_Options::update_option( 'id', 12345 );
-		$initial_sync_error                     = Identity_Crisis::get_sync_error_idc_option();
-		$initial_sync_error['last_checked']     = time() - 7200; // 2 hours ago.
-		$initial_sync_error['next_check_delay'] = 3600; // 1 hour.
-		Jetpack_Options::update_option( 'sync_error_idc', $initial_sync_error );
-
-		// Mock a response with IDC still detected.
-		$mock_callback = function () {
-			return array(
-				'response' => array( 'code' => 200 ),
-				'body'     => wp_json_encode(
-					array(
-						'idc_detected' => array(
-							'error_code'    => 'jetpack_url_mismatch',
-							'wpcom_home'    => 'example.com/',
-							'wpcom_siteurl' => 'example.com/',
-						),
-					),
-					JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE
-				),
-			);
-		};
-		add_filter( 'pre_http_request', $mock_callback );
-
-		$result = Identity_Crisis::validate_idc_from_remote( $initial_sync_error );
-
-		remove_filter( 'pre_http_request', $mock_callback );
-		$stored_option = Jetpack_Options::get_option( 'sync_error_idc' );
-
-		Jetpack_Options::delete_option( 'id' );
-		Jetpack_Options::delete_option( 'sync_error_idc' );
-
-		$this->assertFalse( $result );
-		// Option should be updated with new timing.
-		$this->assertIsArray( $stored_option );
-		$this->assertArrayHasKey( 'last_checked', $stored_option );
-		$this->assertArrayHasKey( 'next_check_delay', $stored_option );
-		// Delay should be doubled (3600 * 2 = 7200).
-		$this->assertEquals( 7200, $stored_option['next_check_delay'] );
-		// last_checked should be updated to recent time.
-		$this->assertGreaterThan( time() - 10, $stored_option['last_checked'] );
 	}
 }

--- a/projects/packages/connection/tests/php/identity-crisis/Identity_Crisis_Test.php
+++ b/projects/packages/connection/tests/php/identity-crisis/Identity_Crisis_Test.php
@@ -290,20 +290,19 @@ class Identity_Crisis_Test extends BaseTestCase {
 		update_option( 'home', 'http://www.coolsite.com' );
 		update_option( 'siteurl', 'http://www.coolsite.com/wp' );
 
-		$expected = array(
-			'home'             => 'coolsite.com/',
-			'siteurl'          => 'coolsite.com/wp/',
-			'last_checked'     => 0,
-			'next_check_delay' => Identity_Crisis::IDC_VALIDATION_INITIAL_DELAY,
-		);
-
+		$before = time();
 		$result = Identity_Crisis::get_sync_error_idc_option();
+		$after  = time();
 
 		// Cleanup.
 		update_option( 'home', $original_home );
 		update_option( 'siteurl', $original_siteurl );
 
-		$this->assertSame( $expected, $result );
+		$this->assertSame( 'coolsite.com/', $result['home'] );
+		$this->assertSame( 'coolsite.com/wp/', $result['siteurl'] );
+		$this->assertGreaterThanOrEqual( $before, $result['last_checked'] );
+		$this->assertLessThanOrEqual( $after, $result['last_checked'] );
+		$this->assertSame( Identity_Crisis::IDC_VALIDATION_INITIAL_DELAY, $result['next_check_delay'] );
 	}
 
 	/**
@@ -317,20 +316,19 @@ class Identity_Crisis_Test extends BaseTestCase {
 		update_option( 'home', 'http://72.182.131.109/~wordpress' );
 		update_option( 'siteurl', 'http://72.182.131.109/~wordpress/wp' );
 
-		$expected = array(
-			'home'             => '72.182.131.109/~wordpress/',
-			'siteurl'          => '72.182.131.109/~wordpress/wp/',
-			'last_checked'     => 0,
-			'next_check_delay' => Identity_Crisis::IDC_VALIDATION_INITIAL_DELAY,
-		);
-
+		$before = time();
 		$result = Identity_Crisis::get_sync_error_idc_option();
+		$after  = time();
 
 		// Cleanup.
 		update_option( 'home', $original_home );
 		update_option( 'siteurl', $original_siteurl );
 
-		$this->assertSame( $expected, $result );
+		$this->assertSame( '72.182.131.109/~wordpress/', $result['home'] );
+		$this->assertSame( '72.182.131.109/~wordpress/wp/', $result['siteurl'] );
+		$this->assertGreaterThanOrEqual( $before, $result['last_checked'] );
+		$this->assertLessThanOrEqual( $after, $result['last_checked'] );
+		$this->assertSame( Identity_Crisis::IDC_VALIDATION_INITIAL_DELAY, $result['next_check_delay'] );
 	}
 
 	/**
@@ -562,29 +560,27 @@ class Identity_Crisis_Test extends BaseTestCase {
 		// Delete option before each test.
 		Jetpack_Options::delete_option( 'sync_error_idc' );
 
-		if ( $option_updated ) {
-			$expected_option = array_merge(
-				// WorDBless sets the siteurl and home options to example.org.
-				array(
-					'home'    => 'example.org/',
-					'siteurl' => 'example.org/',
-				),
-				$input
-			);
-			// Add reversed_url key
-			$expected_option['reversed_url'] = true;
-			// Add timing fields that are now added by default
-			$expected_option['last_checked']     = 0;
-			$expected_option['next_check_delay'] = Identity_Crisis::IDC_VALIDATION_INITIAL_DELAY;
-		} else {
-			$expected_option = false;
-		}
-
+		$before = time();
 		$result = Identity_Crisis::init()->check_response_for_idc( $input );
+		$after  = time();
 		$option = Jetpack_Options::get_option( 'sync_error_idc' );
 
 		$this->assertTrue( $result );
-		$this->assertSame( $expected_option, $option );
+
+		if ( $option_updated ) {
+			$this->assertIsArray( $option );
+			// WorDBless sets the siteurl and home options to example.org.
+			$this->assertSame( 'example.org/', $option['home'] );
+			$this->assertSame( 'example.org/', $option['siteurl'] );
+			$this->assertSame( $input['error_code'], $option['error_code'] );
+			$this->assertTrue( $option['reversed_url'] );
+			// last_checked is set to current time, so check it's within range.
+			$this->assertGreaterThanOrEqual( $before, $option['last_checked'] );
+			$this->assertLessThanOrEqual( $after, $option['last_checked'] );
+			$this->assertSame( Identity_Crisis::IDC_VALIDATION_INITIAL_DELAY, $option['next_check_delay'] );
+		} else {
+			$this->assertFalse( $option );
+		}
 	}
 
 	/**
@@ -1273,6 +1269,9 @@ class Identity_Crisis_Test extends BaseTestCase {
 	 * Test validate_idc_from_remote() returns false when site is not registered.
 	 */
 	public function test_validate_idc_from_remote_returns_false_when_not_registered() {
+		// Clean up any state from previous tests.
+		delete_transient( 'jetpack_idc_validation_lock' );
+
 		Jetpack_Options::delete_option( 'id' );
 
 		$sync_error = Identity_Crisis::get_sync_error_idc_option();
@@ -1287,8 +1286,18 @@ class Identity_Crisis_Test extends BaseTestCase {
 	 * Test validate_idc_from_remote() returns false and updates timing on network error.
 	 */
 	public function test_validate_idc_from_remote_handles_network_error_gracefully() {
+		// Clean up any state from previous tests.
+		delete_transient( 'jetpack_idc_validation_lock' );
+
+		// Set up constants required for API call URL construction.
+		$api_base_original = Constants::get_constant( 'JETPACK__WPCOM_JSON_API_BASE' );
+		Constants::set_constant( 'JETPACK__WPCOM_JSON_API_BASE', 'https://public-api.wordpress.com' );
+
+		// Set up connection options required for API call.
 		Jetpack_Options::update_option( 'id', 12345 );
-		$initial_sync_error = Identity_Crisis::get_sync_error_idc_option();
+		Jetpack_Options::update_option( 'blog_token', 'test.token' );
+		$initial_sync_error                 = Identity_Crisis::get_sync_error_idc_option();
+		$initial_sync_error['last_checked'] = time() - 10; // Set to past so updated time is greater.
 		Jetpack_Options::update_option( 'sync_error_idc', $initial_sync_error );
 
 		// Mock a network error response.
@@ -1302,9 +1311,12 @@ class Identity_Crisis_Test extends BaseTestCase {
 		remove_filter( 'pre_http_request', $mock_callback );
 		$stored_option = Jetpack_Options::get_option( 'sync_error_idc' );
 
+		// Clean up.
 		Jetpack_Options::delete_option( 'id' );
+		Jetpack_Options::delete_option( 'blog_token' );
 		Jetpack_Options::delete_option( 'sync_error_idc' );
 		delete_transient( 'jetpack_idc_validation_lock' );
+		Constants::$set_constants['JETPACK__WPCOM_JSON_API_BASE'] = $api_base_original;
 
 		$this->assertFalse( $result );
 		// last_checked should be updated to prevent hammering on errors.
@@ -1317,8 +1329,18 @@ class Identity_Crisis_Test extends BaseTestCase {
 	 * Test validate_idc_from_remote() returns false and updates timing on non-200 response.
 	 */
 	public function test_validate_idc_from_remote_handles_non_200_response() {
+		// Clean up any state from previous tests.
+		delete_transient( 'jetpack_idc_validation_lock' );
+
+		// Set up constants required for API call URL construction.
+		$api_base_original = Constants::get_constant( 'JETPACK__WPCOM_JSON_API_BASE' );
+		Constants::set_constant( 'JETPACK__WPCOM_JSON_API_BASE', 'https://public-api.wordpress.com' );
+
+		// Set up connection options required for API call.
 		Jetpack_Options::update_option( 'id', 12345 );
-		$initial_sync_error = Identity_Crisis::get_sync_error_idc_option();
+		Jetpack_Options::update_option( 'blog_token', 'test.token' );
+		$initial_sync_error                 = Identity_Crisis::get_sync_error_idc_option();
+		$initial_sync_error['last_checked'] = time() - 10; // Set to past so updated time is greater.
 		Jetpack_Options::update_option( 'sync_error_idc', $initial_sync_error );
 
 		// Mock a 500 error response.
@@ -1341,9 +1363,12 @@ class Identity_Crisis_Test extends BaseTestCase {
 		remove_filter( 'pre_http_request', $mock_callback );
 		$stored_option = Jetpack_Options::get_option( 'sync_error_idc' );
 
+		// Clean up.
 		Jetpack_Options::delete_option( 'id' );
+		Jetpack_Options::delete_option( 'blog_token' );
 		Jetpack_Options::delete_option( 'sync_error_idc' );
 		delete_transient( 'jetpack_idc_validation_lock' );
+		Constants::$set_constants['JETPACK__WPCOM_JSON_API_BASE'] = $api_base_original;
 
 		$this->assertFalse( $result );
 		// last_checked should be updated to prevent hammering on errors.
@@ -1378,8 +1403,18 @@ class Identity_Crisis_Test extends BaseTestCase {
 	 * Test validate_idc_from_remote() updates timing on invalid JSON response.
 	 */
 	public function test_validate_idc_from_remote_handles_invalid_json_gracefully() {
+		// Clean up any state from previous tests.
+		delete_transient( 'jetpack_idc_validation_lock' );
+
+		// Set up constants required for API call URL construction.
+		$api_base_original = Constants::get_constant( 'JETPACK__WPCOM_JSON_API_BASE' );
+		Constants::set_constant( 'JETPACK__WPCOM_JSON_API_BASE', 'https://public-api.wordpress.com' );
+
+		// Set up connection options required for API call.
 		Jetpack_Options::update_option( 'id', 12345 );
-		$initial_sync_error = Identity_Crisis::get_sync_error_idc_option();
+		Jetpack_Options::update_option( 'blog_token', 'test.token' );
+		$initial_sync_error                 = Identity_Crisis::get_sync_error_idc_option();
+		$initial_sync_error['last_checked'] = time() - 10; // Set to past so updated time is greater.
 		Jetpack_Options::update_option( 'sync_error_idc', $initial_sync_error );
 
 		// Mock a 200 response with invalid JSON.
@@ -1402,14 +1437,132 @@ class Identity_Crisis_Test extends BaseTestCase {
 		remove_filter( 'pre_http_request', $mock_callback );
 		$stored_option = Jetpack_Options::get_option( 'sync_error_idc' );
 
+		// Clean up.
 		Jetpack_Options::delete_option( 'id' );
+		Jetpack_Options::delete_option( 'blog_token' );
 		Jetpack_Options::delete_option( 'sync_error_idc' );
 		delete_transient( 'jetpack_idc_validation_lock' );
+		Constants::$set_constants['JETPACK__WPCOM_JSON_API_BASE'] = $api_base_original;
 
 		$this->assertFalse( $result );
 		// last_checked should be updated to prevent hammering on errors.
 		$this->assertGreaterThan( $initial_sync_error['last_checked'], $stored_option['last_checked'] );
 		// Delay should remain unchanged on errors (no exponential backoff).
 		$this->assertEquals( $initial_sync_error['next_check_delay'], $stored_option['next_check_delay'] );
+	}
+
+	/**
+	 * Test validate_idc_from_remote() clears IDC when WordPress.com returns no idc_detected.
+	 */
+	public function test_validate_idc_from_remote_clears_idc_when_resolved() {
+		// Clean up any state from previous tests.
+		delete_transient( 'jetpack_idc_validation_lock' );
+
+		// Set up constants required for API call URL construction.
+		$api_base_original = Constants::get_constant( 'JETPACK__WPCOM_JSON_API_BASE' );
+		Constants::set_constant( 'JETPACK__WPCOM_JSON_API_BASE', 'https://public-api.wordpress.com' );
+
+		// Set up connection options required for API call.
+		Jetpack_Options::update_option( 'id', 12345 );
+		Jetpack_Options::update_option( 'blog_token', 'test.token' );
+		$initial_sync_error = Identity_Crisis::get_sync_error_idc_option();
+		Jetpack_Options::update_option( 'sync_error_idc', $initial_sync_error );
+
+		// Mock a successful response with NO idc_detected (IDC resolved).
+		$mock_callback = function () {
+			return array(
+				'headers'  => array(),
+				'body'     => wp_json_encode( array( 'ID' => 12345 ), JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE ),
+				'response' => array(
+					'code'    => 200,
+					'message' => 'OK',
+				),
+				'cookies'  => array(),
+				'filename' => null,
+			);
+		};
+		add_filter( 'pre_http_request', $mock_callback, 10, 3 );
+
+		$result = Identity_Crisis::validate_idc_from_remote( $initial_sync_error );
+
+		remove_filter( 'pre_http_request', $mock_callback );
+		$stored_option = Jetpack_Options::get_option( 'sync_error_idc' );
+
+		// Clean up.
+		Jetpack_Options::delete_option( 'id' );
+		Jetpack_Options::delete_option( 'blog_token' );
+		delete_transient( 'jetpack_idc_validation_lock' );
+		Constants::$set_constants['JETPACK__WPCOM_JSON_API_BASE'] = $api_base_original;
+
+		// Should return true (IDC was cleared).
+		$this->assertTrue( $result );
+		// Option should be deleted.
+		$this->assertFalse( $stored_option );
+	}
+
+	/**
+	 * Test validate_idc_from_remote() updates timing with backoff when IDC still exists.
+	 */
+	public function test_validate_idc_from_remote_updates_timing_when_idc_persists() {
+		// Clean up any state from previous tests.
+		delete_transient( 'jetpack_idc_validation_lock' );
+
+		// Set up constants required for API call URL construction.
+		$api_base_original = Constants::get_constant( 'JETPACK__WPCOM_JSON_API_BASE' );
+		Constants::set_constant( 'JETPACK__WPCOM_JSON_API_BASE', 'https://public-api.wordpress.com' );
+
+		// Set up connection options required for API call.
+		Jetpack_Options::update_option( 'id', 12345 );
+		Jetpack_Options::update_option( 'blog_token', 'test.token' );
+		$initial_sync_error                     = Identity_Crisis::get_sync_error_idc_option();
+		$initial_sync_error['next_check_delay'] = 3600; // 1 hour.
+		$initial_sync_error['last_checked']     = time() - 7200; // 2 hours ago.
+		Jetpack_Options::update_option( 'sync_error_idc', $initial_sync_error );
+
+		// Mock a response with idc_detected (IDC still exists).
+		$mock_callback = function () {
+			return array(
+				'headers'  => array(),
+				'body'     => wp_json_encode(
+					array(
+						'ID'           => 12345,
+						'idc_detected' => array(
+							'error_code'    => 'jetpack_url_mismatch',
+							'wpcom_home'    => 'https://example.com',
+							'wpcom_siteurl' => 'https://example.com',
+						),
+					),
+					JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE
+				),
+				'response' => array(
+					'code'    => 200,
+					'message' => 'OK',
+				),
+				'cookies'  => array(),
+				'filename' => null,
+			);
+		};
+		add_filter( 'pre_http_request', $mock_callback, 10, 3 );
+
+		$result = Identity_Crisis::validate_idc_from_remote( $initial_sync_error );
+
+		remove_filter( 'pre_http_request', $mock_callback );
+		$stored_option = Jetpack_Options::get_option( 'sync_error_idc' );
+
+		// Clean up.
+		Jetpack_Options::delete_option( 'id' );
+		Jetpack_Options::delete_option( 'blog_token' );
+		Jetpack_Options::delete_option( 'sync_error_idc' );
+		delete_transient( 'jetpack_idc_validation_lock' );
+		Constants::$set_constants['JETPACK__WPCOM_JSON_API_BASE'] = $api_base_original;
+
+		// Should return false (IDC still exists).
+		$this->assertFalse( $result );
+		// Option should still exist.
+		$this->assertIsArray( $stored_option );
+		// last_checked should be updated.
+		$this->assertGreaterThan( $initial_sync_error['last_checked'], $stored_option['last_checked'] );
+		// next_check_delay should be doubled (exponential backoff).
+		$this->assertEquals( 7200, $stored_option['next_check_delay'] );
 	}
 }

--- a/projects/plugins/automattic-for-agencies-client/changelog/add-idc-revalidate
+++ b/projects/plugins/automattic-for-agencies-client/changelog/add-idc-revalidate
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+IDC: Add revalidation for IDCs.

--- a/projects/plugins/backup/changelog/add-idc-revalidate
+++ b/projects/plugins/backup/changelog/add-idc-revalidate
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+IDC: Add revalidation for IDCs.

--- a/projects/plugins/boost/changelog/add-idc-revalidate
+++ b/projects/plugins/boost/changelog/add-idc-revalidate
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+IDC: Add revalidation for IDCs.

--- a/projects/plugins/inspect/changelog/add-idc-revalidate
+++ b/projects/plugins/inspect/changelog/add-idc-revalidate
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+IDC: Add revalidation for IDCs.

--- a/projects/plugins/jetpack/changelog/add-idc-revalidate
+++ b/projects/plugins/jetpack/changelog/add-idc-revalidate
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+IDC: Add revalidation of IDC.

--- a/projects/plugins/mu-wpcom-plugin/changelog/add-idc-revalidate
+++ b/projects/plugins/mu-wpcom-plugin/changelog/add-idc-revalidate
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+IDC: Add revalidation for IDCs.

--- a/projects/plugins/paypal-payment-buttons/changelog/add-idc-revalidate
+++ b/projects/plugins/paypal-payment-buttons/changelog/add-idc-revalidate
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+IDC: Add revalidation for IDCs.

--- a/projects/plugins/protect/changelog/add-idc-revalidate
+++ b/projects/plugins/protect/changelog/add-idc-revalidate
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+IDC: Add revalidation for IDCs.

--- a/projects/plugins/search/changelog/add-idc-revalidate
+++ b/projects/plugins/search/changelog/add-idc-revalidate
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+IDC: Add revalidation for IDCs.

--- a/projects/plugins/social/changelog/add-idc-revalidate
+++ b/projects/plugins/social/changelog/add-idc-revalidate
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+IDC: Add revalidation for IDCs.

--- a/projects/plugins/starter-plugin/changelog/add-idc-revalidate
+++ b/projects/plugins/starter-plugin/changelog/add-idc-revalidate
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+IDC: Add revalidation for IDCs.

--- a/projects/plugins/videopress/changelog/add-idc-revalidate
+++ b/projects/plugins/videopress/changelog/add-idc-revalidate
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+IDC: Add revalidation for IDCs.

--- a/projects/plugins/wpcloud-sso/changelog/add-idc-revalidate
+++ b/projects/plugins/wpcloud-sso/changelog/add-idc-revalidate
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+IDC: Add revalidation for IDCs.

--- a/projects/plugins/wpcomsh/changelog/add-idc-revalidate
+++ b/projects/plugins/wpcomsh/changelog/add-idc-revalidate
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+IDC: Add revalidation for IDCs.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Sites can, in some scenarios, get stuck in the IDC state that is no longer valid. E.g., when domains on dotcom side get updated to different values than ones stored in the IDC error. This PR adds revalidation logic so sites can clear IDCs by rechecking the domains. These checks start with a delay of 1h and get doubled after that until reaching 30 days, when we stop rechecking. The idea behind that is that at 30 days of no contact, sites are marked as disconnected anyway. 

Fixes CONNECT-124

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add revalidation logic to the already existing validate_sync_error_idc_option() method.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Get a JN site for testing and connect it. Make sure you have the debug tools plugin installed.
* Load this branch via the Beta plugin.
* Edit the IDC_VALIDATION_INITIAL_DELAY in projects/packages/connection/src/identity-crisis/class-identity-crisis.php to something like 60 seconds.
* Enable IDC testing feature in debug tools and use it to disable sync and trigger an IDC error. Keep the sync disabled at all times.
* When you get an error, check the contents of the IDC error array in IDC tools. It should contain your IDC spoof domain, the actual wpcom URLs, and the two new properties: last checked timestamp and the delay. The initial delay will be what you have set up the IDC_VALIDATION_INITIAL_DELAY to be.
* Disable the IDC Simulation (but still keep sync blocked) and store options. When the initial delay time passes, refresh the page. The error should be gone.
* Re-enable the IDC Simulation and trigger a new IDC error. Go to NA for your site and update the siteurl manually (e.g, whatever.jurassic.ninja to whatever.jurassic.blog).
* Disable IDC Simulation. Refresh the page after the delay. The wpcom URLs should change to the new value and the delay should be doubled. 
* Restore original values in NA and wait for the delay to pass. The error should clear out.

