### PR TITLE
cli: Improve import error output

### DIFF
--- a/tools/cli/bin/jetpack.js
+++ b/tools/cli/bin/jetpack.js
@@ -14,14 +14,14 @@ async function guardedImport( path ) {
 	try {
 		return await import( path );
 	} catch ( error ) {
-		const bold =
+		let { bold, dim } =
 			( await import( 'chalk' ).then(
-				m => m.default?.stderr?.bold,
+				m => ( { bold: m.chalkStderr?.bold, dim: m.chalkStderr?.dim } ),
 				() => null
-			) ) || ( v => v );
+			) ) || {};
+		bold ||= v => v;
+		dim ||= v => `\n${ v.replace( /^/m, '  ' ) }`;
 
-		console.error( error );
-		console.error( '' );
 		if ( error.code === 'ERR_MODULE_NOT_FOUND' ) {
 			// if pnpm install hasn't been run, the import() will fail here.
 			console.error(
@@ -29,6 +29,7 @@ async function guardedImport( path ) {
 					'*** Something is missing from your install. Please run `pnpm install` and try again. ***'
 				)
 			);
+			console.error( dim( error.message ) );
 		} else if (
 			error.name === 'SyntaxError' &&
 			( error.stack.match(
@@ -41,7 +42,10 @@ async function guardedImport( path ) {
 					'*** Perhaps you have outdated dependencies. Please run `pnpm install` and try again. ***'
 				)
 			);
+			console.error( dim( error.message ) );
 		} else {
+			console.error( error );
+			console.error( '' );
 			console.error( bold( '*** Something unexpected happened. See error above. ***' ) );
 		}
 		process.exit( 1 );


### PR DESCRIPTION
Closes MONOREP-290

 <!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
To be more user-friendly, we catch some errors that may indicate "you have to run `pnpm install`" and display helpful information to the user. But we're still dumping the whole error object, which is generally not terribly useful because all the stack trace refers to "files" like `node:internal/modules/esm/loader`.

Instead, when it's one of the errors we recognize, print only the message without the trace, and do that in a dimmer color if possible.

And also fix the bolding of our message, which was probably broken by #40786.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1765465591396439/1765438448.876579-slack-CDLH4C1UZ

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Edit one of the CLI files (e.g. `tools/cli/commands/rsync.js`) to include `import x from 'does-not-exist';`. Then try running `jetpack`. Check the display of the error message.
* Same but with `import { doesNotExist } from 'fs';`.
* Same but with `throw new Error( "Some exception" );`. This should include the stack trace and such.