### PR TITLE
Form: auto-generated webhook id

### DIFF
--- a/projects/packages/forms/changelog/add-form-generated-webhook-id
+++ b/projects/packages/forms/changelog/add-form-generated-webhook-id
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Forms: auto-generate webhook id so users don't have to fill it.

--- a/projects/packages/forms/src/blocks/contact-form/components/webhooks-settings.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/webhooks-settings.js
@@ -1,12 +1,24 @@
 import { TextControl, ToggleControl, ExternalLink } from '@wordpress/components';
-import { useState, useEffect, createInterpolateElement } from '@wordpress/element';
+import { useState, useEffect, useCallback, createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
-const WebhooksSettings = ( { setAttributes, webhooks } ) => {
+const WebhooksSettings = ( { setAttributes, webhooks, clientId } ) => {
 	// For now, we only support one webhook, but the data structure supports multiple
 	const firstWebhook = webhooks?.[ 0 ] || null;
 
-	const [ localWebhookId, setLocalWebhookId ] = useState( firstWebhook?.webhook_id || '' );
+	// Generate a unique webhook ID based on clientId
+	const generateWebhookId = useCallback(
+		( index = 1 ) => {
+			// Use a shortened version of clientId (first 8 chars) for readability
+			const shortId = clientId?.substring( 0, 8 ) || 'unknown';
+			return `webhook-${ shortId }-${ index }`;
+		},
+		[ clientId ]
+	);
+
+	const [ localWebhookId, setLocalWebhookId ] = useState(
+		firstWebhook?.webhook_id || generateWebhookId( 1 )
+	);
 	const [ localWebhookUrl, setLocalWebhookUrl ] = useState( firstWebhook?.url || '' );
 	const [ localWebhookEnabled, setLocalWebhookEnabled ] = useState(
 		firstWebhook?.enabled || false
@@ -15,11 +27,11 @@ const WebhooksSettings = ( { setAttributes, webhooks } ) => {
 	// Sync local state with attributes when webhook changes
 	useEffect( () => {
 		if ( firstWebhook ) {
-			setLocalWebhookId( firstWebhook.webhook_id || '' );
+			setLocalWebhookId( firstWebhook.webhook_id || generateWebhookId( 1 ) );
 			setLocalWebhookUrl( firstWebhook.url || '' );
 			setLocalWebhookEnabled( firstWebhook.enabled || false );
 		}
-	}, [ firstWebhook ] );
+	}, [ firstWebhook, generateWebhookId ] );
 
 	const updateWebhook = ( id, url, enabled ) => {
 		if ( ! url && ! enabled ) {
@@ -57,24 +69,15 @@ const WebhooksSettings = ( { setAttributes, webhooks } ) => {
 				checked={ localWebhookEnabled }
 				onChange={ value => {
 					setLocalWebhookEnabled( value );
-					updateWebhook( localWebhookId, localWebhookUrl, value );
+					// Auto-generate webhook ID when enabling if it doesn't exist
+					const webhookId = localWebhookId || generateWebhookId( webhooks?.length + 1 || 1 );
+					setLocalWebhookId( webhookId );
+					updateWebhook( webhookId, localWebhookUrl, value );
 				} }
 				__nextHasNoMarginBottom={ true }
 			/>
 			{ localWebhookEnabled && (
 				<>
-					<TextControl
-						label={ __( 'Webhook ID', 'jetpack-forms' ) }
-						value={ localWebhookId }
-						onChange={ value => {
-							setLocalWebhookId( value );
-							updateWebhook( value, localWebhookUrl, localWebhookEnabled );
-						} }
-						placeholder="webhook-1"
-						help={ __( 'A unique identifier for this webhook.', 'jetpack-forms' ) }
-						__nextHasNoMarginBottom={ true }
-						__next40pxDefaultSize={ true }
-					/>
 					<TextControl
 						label={ __( 'Webhook URL', 'jetpack-forms' ) }
 						value={ localWebhookUrl }
@@ -88,6 +91,20 @@ const WebhooksSettings = ( { setAttributes, webhooks } ) => {
 							'jetpack-forms'
 						) }
 						type="url"
+						__nextHasNoMarginBottom={ true }
+						__next40pxDefaultSize={ true }
+					/>
+					<TextControl
+						label={ __( 'Webhook ID', 'jetpack-forms' ) }
+						value={ localWebhookId }
+						onChange={ value => {
+							setLocalWebhookId( value );
+							updateWebhook( value, localWebhookUrl, localWebhookEnabled );
+						} }
+						help={ __(
+							'Auto-generated unique identifier. You can customize it if needed.',
+							'jetpack-forms'
+						) }
 						__nextHasNoMarginBottom={ true }
 						__next40pxDefaultSize={ true }
 					/>

--- a/projects/packages/forms/src/blocks/contact-form/edit.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/edit.tsx
@@ -933,7 +933,11 @@ function JetpackContactFormEdit( {
 							className="jetpack-contact-form__panel"
 							initialOpen={ false }
 						>
-							<WebhooksSettings webhooks={ webhooks } setAttributes={ setAttributes } />
+							<WebhooksSettings
+								webhooks={ webhooks }
+								setAttributes={ setAttributes }
+								clientId={ clientId }
+							/>
 						</PanelBody>
 					) }
 					<PanelBody


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes FORMS-462

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Auto-generate webhook id using the first 8 characters of the block clientId UUID and an auto-increment number (e.g., `webhook-a1b2c3dr-1`)
* Move the webhook id text input to the bottom of the panel setting.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
Before:
<img width="289" height="381" alt="Screenshot 2025-12-01 at 15 13 55" src="https://github.com/user-attachments/assets/996a2113-42bf-48ce-9a95-b06af959b4ee" />

After:
<img width="280" height="398" alt="Screenshot 2025-12-11 at 00 18 41" src="https://github.com/user-attachments/assets/d2f1ec1a-9e16-4921-b878-fa3e60986ea8" />

* Enable webhooks via the filter flag:
```add_filter( 'jetpack_forms_webhooks_enabled', '__return_true' );```
* Create a form and go to Webhook settings. 
* Enable webhooks and check that the webhook id text input already has a string in it.

