### PR TITLE
phan: Further hack PHPUnit stubs

### DIFF
--- a/tools/stubs/munge-phpunit-stubs.php
+++ b/tools/stubs/munge-phpunit-stubs.php
@@ -35,6 +35,12 @@ if ( $stubs === null ) {
 	throw new RuntimeException( preg_last_error_msg() );
 }
 
+// Also it seems to get confused by TestStubBuilder using "StubbedType" rather than "MockedType". `@inherits` doesn't seem to help.
+$stubs = preg_replace( '/\bStubbedType\b/', 'MockedType', $stubs );
+if ( $stubs === null ) {
+	throw new RuntimeException( preg_last_error_msg() );
+}
+
 // Phan doesn't track generics across `@return $this` properly. Rewrite them.
 // Possibly fixed in Phan v6? https://github.com/phan/phan/issues/4849
 $stubs = preg_replace_callback(


### PR DESCRIPTION
Closes MONOREP-292

 <!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
It gets confused by TestStubBuilder using "StubbedType" rather than "MockedType". `@inherits` doesn't seem to help.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
#46260

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* See that it worked as part of #46260 🤷

