### PR TITLE
Forms: track webhook requests in wpcom infra

### DIFF
--- a/projects/packages/forms/changelog/add-form-track-webhook-requests
+++ b/projects/packages/forms/changelog/add-form-track-webhook-requests
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Forms: track webhook requests done in wpcom infrastructure.

--- a/projects/packages/forms/src/service/class-form-webhooks.php
+++ b/projects/packages/forms/src/service/class-form-webhooks.php
@@ -130,20 +130,43 @@ class Form_Webhooks {
 	private function log_response_to_post_meta( $post_id, $response ) {
 		if ( is_wp_error( $response ) ) {
 			update_post_meta( $post_id, '_jetpack_forms_webhook_error', sanitize_text_field( $response->get_error_message() ) );
+			$this->track_webhook_request( 'error' );
 			return $response;
 		}
 
+		$response_code = wp_remote_retrieve_response_code( $response );
 		$response_body = wp_remote_retrieve_body( $response );
 		$response_data = json_decode( $response_body, true );
 
 		$response_data = array(
 			'timestamp' => gmdate( 'Y-m-d H:i:s', time() ),
-			'http_code' => wp_remote_retrieve_response_code( $response ),
+			'http_code' => $response_code,
 			'headers'   => wp_remote_retrieve_headers( $response )->getAll(),
 			'body'      => $response_data ?? $response_body, // If the response is not JSON, return the body as is.
 		);
 
 		update_post_meta( $post_id, '_jetpack_forms_webhook_response', sanitize_text_field( wp_json_encode( $response_data, JSON_UNESCAPED_SLASHES ) ) );
+
+		// Track success (2xx) or failure based on HTTP response code
+		$status = ( $response_code >= 200 && $response_code < 300 ) ? 'success' : 'failed';
+		$this->track_webhook_request( $status );
+	}
+
+	/**
+	 * Track webhook request stats.
+	 *
+	 * @param string $status The status of the webhook request ('success', 'failed', or 'error').
+	 */
+	private function track_webhook_request( $status ) {
+		/**
+		 * Fires when a webhook request is made, allowing stats tracking.
+		 *
+		 * @since $$next-version$$
+		 *
+		 * @param string $stat_group The stat group name.
+		 * @param string $status The status of the request: 'success', 'failed', or 'error'.
+		 */
+		do_action( 'jetpack_bump_stats_extras', 'jetpack_forms_webhook_request', $status );
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes FORMS-461

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Bump mc stats on each webhook request, including the requests status (success, failed, error)

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Enable webhooks via the filter flag:
```add_filter( 'jetpack_forms_webhooks_enabled', '__return_true' );```
* Create a form and enable webhooks in the form settings.
* Publish the post and submit a form response.
* Check that the submission works correctly.

