### PR TITLE
Forms: fix validation error accessibility

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-validation-accessibility-issue
+++ b/projects/packages/forms/changelog/fix-forms-validation-accessibility-issue
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: fix validation accessibility.

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -949,7 +949,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 					</svg>
 					<span class="visually-hidden">' . __( 'Warning', 'jetpack-forms' ) . '</span>
 				</span>
-				<span data-wp-text="state.errorMessage" id="' . esc_attr( $id ) . '-' . esc_attr( $type ) . '-error-message"></span>
+				<span data-wp-text="state.errorMessage" id="' . esc_attr( $id ) . '-' . esc_attr( $type ) . '-error-message" role="alert" aria-live="assertive"></span>
 			</div>';
 	}
 

--- a/projects/plugins/jetpack/changelog/fix-forms-validation-accessibility-issue
+++ b/projects/plugins/jetpack/changelog/fix-forms-validation-accessibility-issue
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Forms: fix validation accessibility.


### PR DESCRIPTION

Fixes [FORMS-457](https://linear.app/a8c/issue/FORMS-457/form-fields-accessibility)
Fixes [FORMS-313](https://linear.app/a8c/issue/FORMS-313/forms-text-fields-must-use-an-aria-technique-to-announce-the-message)

## Proposed changes:

The error divs that we show when there is a validation error do not have proper accessibility and aria attributes. This PR adds them.

**Screenshot with fix**
<img width="1069" height="667" alt="forms-accessibility-fix" src="https://github.com/user-attachments/assets/7c32d932-bd44-49f1-8ba0-aebbb35dc47b" />

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
See both linear issues.

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Confirm the error divs no have proper accessibility attributes. 

I also tested using Axe dev tools. 
* First, I confirm the issue. I triggered a validation error and then scanned the page with that error div, and Axe flagged it as an issue. 
* Second, I re-did that test with this fix and Axe detected no issues related to the error. 