### PR TITLE
Forms: Fix dashboard height

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-dashboard-wp-notices
+++ b/projects/packages/forms/changelog/fix-forms-dashboard-wp-notices
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: Fix dashboard height

--- a/projects/packages/forms/src/dashboard/index.tsx
+++ b/projects/packages/forms/src/dashboard/index.tsx
@@ -8,6 +8,7 @@ import { RouterProvider } from 'react-router/dom';
 /**
  * Internal dependencies
  */
+import { adjustDashboardHeight } from '../util/adjust-dashboard-height.ts';
 import Layout from './components/layout/index.tsx';
 import Inbox from './inbox/index.js';
 import DashboardNotices from './notices-list.tsx';
@@ -60,6 +61,8 @@ function initFormsDashboard() {
 			<DashboardNotices />
 		</SlotFillProvider>
 	);
+
+	adjustDashboardHeight( container );
 }
 
 window.jetpackFormsInit = initFormsDashboard;

--- a/projects/packages/forms/src/util/adjust-dashboard-height.ts
+++ b/projects/packages/forms/src/util/adjust-dashboard-height.ts
@@ -1,0 +1,30 @@
+/**
+ * Adjusts the height of the dashboard container to the available height, including WP notices.
+ *
+ * @param container - The container element to adjust the height of.
+ */
+export const adjustDashboardHeight = ( container: HTMLElement ) => {
+	const applyDynamicHeight = () => {
+		const rect = container.getBoundingClientRect();
+		const availableHeight = Math.max( window.innerHeight - rect.top, 0 );
+
+		container.style.height = `${ availableHeight }px`;
+	};
+
+	requestAnimationFrame( () => {
+		applyDynamicHeight();
+	} );
+
+	const resizeHandler = () => applyDynamicHeight();
+	window.addEventListener( 'resize', resizeHandler );
+
+	const wpBody = document.getElementById( 'wpbody-content' ) ?? document.body;
+
+	const observer = new MutationObserver( mutations => {
+		if ( mutations.some( mutation => mutation.type === 'childList' ) ) {
+			applyDynamicHeight();
+		}
+	} );
+
+	observer.observe( wpBody, { childList: true } );
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Sets the height of the dashboard dynamically so that it does not push the footer down when there is a WP notice above the dashboard

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* In a site with a WP notice (like a prompt to update WordPress), go to the forms dashboard
* Check that the footer is immediately visible, without needing to scroll down

| Before | After |
| - | - |
| <img width="1110" height="543" alt="Screenshot from 2025-12-11 20-26-17" src="https://github.com/user-attachments/assets/85917e31-65c9-4645-b8cf-d62aa7f6ba9c" /> | <img width="1110" height="543" alt="Screenshot from 2025-12-11 20-26-22" src="https://github.com/user-attachments/assets/e707be13-c78b-4fd0-b8eb-e30bc2dc0a47" /> |
