### PR TITLE
Forms: add webhook toggle tracking

### DIFF
--- a/projects/packages/forms/changelog/add-form-webhook-toggle-tracking
+++ b/projects/packages/forms/changelog/add-form-webhook-toggle-tracking
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Forms: track when users enable and disable webhooks.

--- a/projects/packages/forms/src/blocks/contact-form/components/webhooks-settings.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/webhooks-settings.js
@@ -1,6 +1,6 @@
 import jetpackAnalytics from '@automattic/jetpack-analytics';
-import { TextControl, ToggleControl, ExternalLink } from '@wordpress/components';
-import { useState, useEffect, useCallback, createInterpolateElement } from '@wordpress/element';
+import { TextControl, ToggleControl } from '@wordpress/components';
+import { useState, useEffect, useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 const WebhooksSettings = ( { setAttributes, webhooks, clientId } ) => {
@@ -56,17 +56,7 @@ const WebhooksSettings = ( { setAttributes, webhooks, clientId } ) => {
 		<>
 			<ToggleControl
 				label={ __( 'Enable webhook', 'jetpack-forms' ) }
-				help={ createInterpolateElement(
-					__(
-						'Send form submission data to an external URL. <webhookDocsLink>Learn more about webhooks.</webhookDocsLink>',
-						'jetpack-forms'
-					),
-					{
-						webhookDocsLink: (
-							<ExternalLink href="https://jetpack.com/support/jetpack-forms/webhooks/" />
-						),
-					}
-				) }
+				help={ __( 'Send form submission data to an external URL.', 'jetpack-forms' ) }
 				checked={ localWebhookEnabled }
 				onChange={ value => {
 					jetpackAnalytics.tracks.recordEvent( 'jetpack_forms_webhook_toggle', {

--- a/projects/packages/forms/src/blocks/contact-form/components/webhooks-settings.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/webhooks-settings.js
@@ -1,3 +1,4 @@
+import jetpackAnalytics from '@automattic/jetpack-analytics';
 import { TextControl, ToggleControl, ExternalLink } from '@wordpress/components';
 import { useState, useEffect, useCallback, createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -68,6 +69,10 @@ const WebhooksSettings = ( { setAttributes, webhooks, clientId } ) => {
 				) }
 				checked={ localWebhookEnabled }
 				onChange={ value => {
+					jetpackAnalytics.tracks.recordEvent( 'jetpack_forms_webhook_toggle', {
+						origin: 'block-editor',
+						enabled: value,
+					} );
 					setLocalWebhookEnabled( value );
 					// Auto-generate webhook ID when enabling if it doesn't exist
 					const webhookId = localWebhookId || generateWebhookId( webhooks?.length + 1 || 1 );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes FORMS-463

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Added new tracking event `jetpack_forms_webhook_toggle` to track the webhook toggle.
* Removed the webhook documentation link until we have the documentation page ready.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* TBD
*

