### PR TITLE
Social: Remove the usage of useAdminUiV1 feature flag

### DIFF
--- a/projects/js-packages/publicize-components/changelog/remove-socail-feature-flag-use-admin-ui-v1
+++ b/projects/js-packages/publicize-components/changelog/remove-socail-feature-flag-use-admin-ui-v1
@@ -1,0 +1,4 @@
+Significance: patch
+Type: removed
+
+Social: Remove the usage of useAdminUiV1 feature flag.

--- a/projects/js-packages/publicize-components/src/components/admin-page/header/index.js
+++ b/projects/js-packages/publicize-components/src/components/admin-page/header/index.js
@@ -12,7 +12,6 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { Icon, postList } from '@wordpress/icons';
 import { store as socialStore } from '../../../social-store';
-import { getSocialScriptData } from '../../../utils';
 import StatCards from './stat-cards';
 import styles from './styles.module.scss';
 
@@ -33,10 +32,6 @@ const Header = () => {
 			isShareLimitEnabled: store.isShareLimitEnabled(),
 		};
 	} );
-
-	const { urls, feature_flags } = getSocialScriptData();
-
-	const useAdminUiV1 = feature_flags.useAdminUiV1;
 
 	const { hasConnectionError } = useConnectionErrorNotice();
 
@@ -64,17 +59,9 @@ const Header = () => {
 					<H3 mt={ 2 }>{ __( 'Write once, post everywhere', 'jetpack-publicize-components' ) }</H3>
 					<div className={ styles.actions }>
 						{ isModuleEnabled && ! hasConnections && (
-							<>
-								{ useAdminUiV1 ? (
-									<Button onClick={ openConnectionsModal }>
-										{ __( 'Connect accounts', 'jetpack-publicize-components' ) }
-									</Button>
-								) : (
-									<Button href={ urls.connectionsManagementPage } isExternalLink={ true }>
-										{ __( 'Connect accounts', 'jetpack-publicize-components' ) }
-									</Button>
-								) }
-							</>
+							<Button onClick={ openConnectionsModal }>
+								{ __( 'Connect accounts', 'jetpack-publicize-components' ) }
+							</Button>
 						) }
 						<Button
 							href={ getAdminUrl( 'post-new.php' ) }

--- a/projects/js-packages/publicize-components/src/components/admin-page/test/social-module-toggle.test.jsx
+++ b/projects/js-packages/publicize-components/src/components/admin-page/test/social-module-toggle.test.jsx
@@ -7,7 +7,6 @@ describe( 'SocialModuleToggle', () => {
 		mockScriptData( {
 			social: {
 				urls: { connectionsManagementPage: 'https://example.com/connections' },
-				feature_flags: { useAdminUiV1: true },
 				is_publicize_enabled: true,
 			},
 		} );
@@ -21,20 +20,6 @@ describe( 'SocialModuleToggle', () => {
 		render( <SocialModuleToggle /> );
 
 		expect( screen.queryByText( /Manage social media connections/i ) ).not.toBeInTheDocument();
-	} );
-
-	it( 'should render legacy UI when useAdminUiV1 is false', () => {
-		mockScriptData( {
-			social: {
-				urls: { connectionsManagementPage: 'https://example.com/connections' },
-				feature_flags: { useAdminUiV1: false },
-			},
-		} );
-
-		render( <SocialModuleToggle /> );
-
-		expect( screen.getByText( /Manage social media connections/i ) ).toBeInTheDocument();
-		expect( screen.getByText( /Manage social media connections/i ) ).toBeEnabled();
 	} );
 
 	it( 'should show upgrade trigger when no paid features', () => {

--- a/projects/js-packages/publicize-components/src/components/admin-page/toggles/social-module-toggle/index.tsx
+++ b/projects/js-packages/publicize-components/src/components/admin-page/toggles/social-module-toggle/index.tsx
@@ -1,5 +1,4 @@
 import {
-	Button,
 	ContextualUpgradeTrigger,
 	Text,
 	getRedirectUrl,
@@ -34,10 +33,6 @@ const SocialModuleToggle: FC = () => {
 	const { wpcom, host, suffix: siteSuffix } = getScriptData().site;
 	const is_wpcom = host === 'wpcom';
 
-	const { urls, feature_flags } = getSocialScriptData();
-
-	const useAdminUiV1 = feature_flags.useAdminUiV1;
-
 	const { updateSocialModuleSettings } = useDispatch( socialStore );
 
 	const toggleModule = useCallback( async () => {
@@ -55,27 +50,11 @@ const SocialModuleToggle: FC = () => {
 	const [ isSmall ] = useBreakpointMatch( 'sm' );
 
 	const renderConnectionManagement = () => {
-		if ( useAdminUiV1 ) {
-			return isModuleEnabled ? (
-				<ConnectionManagement
-					className={ styles[ 'connection-management' ] }
-					disabled={ isUpdating }
-				/>
-			) : null;
-		}
-
-		return urls.connectionsManagementPage ? (
-			<Button
-				fullWidth={ isSmall }
-				className={ styles.button }
-				variant="secondary"
-				isExternalLink={ true }
-				href={ urls.connectionsManagementPage }
-				disabled={ isUpdating || ! isModuleEnabled }
-				target="_blank"
-			>
-				{ __( 'Manage social media connections', 'jetpack-publicize-components' ) }
-			</Button>
+		return isModuleEnabled ? (
+			<ConnectionManagement
+				className={ styles[ 'connection-management' ] }
+				disabled={ isUpdating }
+			/>
 		) : null;
 	};
 

--- a/projects/js-packages/publicize-components/src/components/form/broken-connections-notice.tsx
+++ b/projects/js-packages/publicize-components/src/components/form/broken-connections-notice.tsx
@@ -1,11 +1,9 @@
 import { Button } from '@automattic/jetpack-components';
-import { ExternalLink, Notice } from '@wordpress/components';
+import { Notice } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { createInterpolateElement } from '@wordpress/element';
 import { _n } from '@wordpress/i18n';
-import usePublicizeConfig from '../../hooks/use-publicize-config';
 import { store as socialStore } from '../../social-store';
-import { getSocialScriptData } from '../../utils/script-data';
 import styles from './styles.module.scss';
 import type { FC } from 'react';
 
@@ -18,20 +16,14 @@ export const BrokenConnectionsNotice: FC = () => {
 		};
 	}, [] );
 
-	const { connectionsPageUrl } = usePublicizeConfig();
-
-	const { useAdminUiV1 } = getSocialScriptData().feature_flags;
-
 	const { openConnectionsModal } = useDispatch( socialStore );
 
-	const fixLink = useAdminUiV1 ? (
+	const fixLink = (
 		<Button
 			variant="link"
 			onClick={ openConnectionsModal }
 			className={ styles[ 'broken-connection-btn' ] }
 		/>
-	) : (
-		<ExternalLink href={ connectionsPageUrl } />
 	);
 
 	const problemConnections = [ ...brokenConnections, ...reauthConnections ];

--- a/projects/js-packages/publicize-components/src/components/form/settings-button.tsx
+++ b/projects/js-packages/publicize-components/src/components/form/settings-button.tsx
@@ -4,12 +4,10 @@
  * Component which allows user to click to open settings
  * in a new window/tab.
  */
-import { ExternalLink, Button } from '@wordpress/components';
+import { Button } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
-import usePublicizeConfig from '../../hooks/use-publicize-config';
 import { store } from '../../social-store';
-import { getSocialScriptData } from '../../utils/script-data';
 import styles from './styles.module.scss';
 import type { ComponentProps } from 'react';
 
@@ -26,20 +24,17 @@ type SettingsButtonProps = {
  * @return {import('react').ReactNode} The button/link component.
  */
 export function SettingsButton( { label, variant = 'secondary' }: SettingsButtonProps ) {
-	const { useAdminUiV1 } = getSocialScriptData().feature_flags;
-
 	const { connections } = useSelect( select => {
 		return {
 			connections: select( store ).getConnections(),
 		};
 	}, [] );
 	const { openConnectionsModal } = useDispatch( store );
-	const { connectionsPageUrl } = usePublicizeConfig();
 
 	const text = label || __( 'Add a new account', 'jetpack-publicize-components' );
 	const hasConnections = connections.length > 0;
 
-	return useAdminUiV1 ? (
+	return (
 		<Button
 			onClick={ openConnectionsModal }
 			variant={ hasConnections ? 'link' : variant }
@@ -47,9 +42,5 @@ export function SettingsButton( { label, variant = 'secondary' }: SettingsButton
 		>
 			{ text }
 		</Button>
-	) : (
-		<ExternalLink className={ styles[ 'settings-button' ] } href={ connectionsPageUrl }>
-			{ text }
-		</ExternalLink>
 	);
 }

--- a/projects/js-packages/publicize-components/src/hooks/use-publicize-config/index.js
+++ b/projects/js-packages/publicize-components/src/hooks/use-publicize-config/index.js
@@ -7,7 +7,6 @@ import {
 } from '@automattic/jetpack-shared-extension-utils';
 import { useSelect } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
-import { getSocialScriptData } from '../../utils';
 import { usePostMeta } from '../use-post-meta';
 
 const republicizeFeatureName = 'republicize';
@@ -25,7 +24,6 @@ export default function usePublicizeConfig() {
 		isJetpackSite || getJetpackExtensionAvailability( republicizeFeatureName )?.available;
 	const isPostPublished = useSelect( select => select( editorStore ).isCurrentPostPublished(), [] );
 	const { isUserConnected } = useConnection();
-	const { urls } = getSocialScriptData();
 
 	/*
 	 * isPublicizeEnabledMeta:
@@ -90,7 +88,6 @@ export default function usePublicizeConfig() {
 		hidePublicizeFeature,
 		isPostAlreadyShared,
 		isSocialImageGeneratorEnabled: !! getJetpackData()?.social?.isSocialImageGeneratorEnabled,
-		connectionsPageUrl: urls.connectionsManagementPage,
 		needsUserConnection,
 	};
 }

--- a/projects/js-packages/publicize-components/src/types.ts
+++ b/projects/js-packages/publicize-components/src/types.ts
@@ -16,10 +16,6 @@ export type SharesData = {
 	is_share_limit_enabled: boolean;
 };
 
-export interface FeatureFlags {
-	useEditorPreview: boolean;
-}
-
 export type ConnectionService = {
 	id: string;
 	label: string;
@@ -50,7 +46,6 @@ export type PluginInfo = Record< 'social' | 'jetpack', { version: string | null 
 export interface SocialScriptData {
 	api_paths: ApiPaths;
 	assets_url: string;
-	feature_flags: FeatureFlags;
 	is_publicize_enabled: boolean;
 	plugin_info: PluginInfo;
 	review?: {

--- a/projects/js-packages/publicize-components/src/types.ts
+++ b/projects/js-packages/publicize-components/src/types.ts
@@ -17,7 +17,6 @@ export type SharesData = {
 };
 
 export interface FeatureFlags {
-	useAdminUiV1: boolean;
 	useEditorPreview: boolean;
 }
 

--- a/projects/js-packages/publicize-components/src/utils/test-utils.js
+++ b/projects/js-packages/publicize-components/src/utils/test-utils.js
@@ -190,7 +190,6 @@ export function mockScriptData( data = {} ) {
 			social: {
 				is_publicize_enabled: true,
 				api_paths: {},
-				feature_flags: {},
 				settings: {
 					utmSettings: {},
 					socialNotes: {

--- a/projects/packages/publicize/changelog/remove-socail-feature-flag-use-admin-ui-v1
+++ b/projects/packages/publicize/changelog/remove-socail-feature-flag-use-admin-ui-v1
@@ -1,0 +1,4 @@
+Significance: patch
+Type: removed
+
+Social: Remove the usage of useAdminUiV1 feature flag.

--- a/projects/packages/publicize/src/class-publicize-script-data.php
+++ b/projects/packages/publicize/src/class-publicize-script-data.php
@@ -229,7 +229,6 @@ class Publicize_Script_Data {
 	 */
 	public static function get_feature_flags() {
 		$variable_to_feature_map = array(
-			'useAdminUiV1'     => 'connections-management',
 			'useEditorPreview' => 'editor-preview',
 			'useShareStatus'   => 'share-status',
 		);

--- a/projects/packages/publicize/src/class-publicize-script-data.php
+++ b/projects/packages/publicize/src/class-publicize-script-data.php
@@ -115,7 +115,6 @@ class Publicize_Script_Data {
 			'api_paths'            => self::get_api_paths(),
 			'assets_url'           => plugins_url( '/build/', __DIR__ ),
 			'is_publicize_enabled' => Utils::is_publicize_active(),
-			'feature_flags'        => self::get_feature_flags(),
 			'supported_services'   => array(),
 			'shares_data'          => array(),
 			'urls'                 => array(),
@@ -220,26 +219,6 @@ class Publicize_Script_Data {
 			),
 			'shareStatus'    => $share_status,
 		);
-	}
-
-	/**
-	 * Get the feature flags.
-	 *
-	 * @return array
-	 */
-	public static function get_feature_flags() {
-		$variable_to_feature_map = array(
-			'useEditorPreview' => 'editor-preview',
-			'useShareStatus'   => 'share-status',
-		);
-
-		$feature_flags = array();
-
-		foreach ( $variable_to_feature_map as $variable => $feature ) {
-			$feature_flags[ $variable ] = self::has_feature_flag( $feature );
-		}
-
-		return $feature_flags;
 	}
 
 	/**

--- a/projects/packages/publicize/src/jetpack-social-settings/class-settings.php
+++ b/projects/packages/publicize/src/jetpack-social-settings/class-settings.php
@@ -51,27 +51,6 @@ class Settings {
 	const NOTES_FLUSH_REWRITE_RULES_FLUSHED = 'jetpack_social_rewrite_rules_flushed';
 
 	/**
-	 * Feature flags. Each item has 3 keys because of the naming conventions:
-	 * - flag_name: The name of the feature flag for the option check.
-	 * - feature_name: The name of the feature that enables the feature. Will be checked with Current_Plan.
-	 * - variable_name: The name of the variable that will be used in the front-end.
-	 *
-	 * @var array
-	 */
-	const FEATURE_FLAGS = array(
-		array(
-			'flag_name'     => 'editor_preview',
-			'feature_name'  => 'editor-preview',
-			'variable_name' => 'useEditorPreview',
-		),
-		array(
-			'flag_name'     => 'share_status',
-			'feature_name'  => 'share-status',
-			'variable_name' => 'useShareStatus',
-		),
-	);
-
-	/**
 	 * Whether the actions have been hooked into.
 	 *
 	 * @var bool


### PR DESCRIPTION
Closes SOCIAL-264

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Remove the usage of useAdminUiV1 feature flag which is not relevant anymore.
* Clean up the unused feature flags code

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the editor
* Open Jetpack sidebar
* Confirm that you can see the connections management UI
* Go to Jetpack > Social
* Confirm that you can see the connections management UI

