### PR TITLE
Social: Fix the submit button label and alignment for custom input form

### DIFF
--- a/projects/js-packages/publicize-components/changelog/fix-social-connect-button-
+++ b/projects/js-packages/publicize-components/changelog/fix-social-connect-button-
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Social: Fix the submit button label and alignment for custom input form.

--- a/projects/js-packages/publicize-components/src/components/services/service-item.tsx
+++ b/projects/js-packages/publicize-components/src/components/services/service-item.tsx
@@ -127,7 +127,7 @@ export function ServiceItem( {
 									service={ service }
 									displayInputs
 									isSmall={ false }
-									buttonLabel={ __( 'Connect', 'jetpack-publicize-components' ) }
+									buttonLabel={ __( 'Submit', 'jetpack-publicize-components' ) }
 								/>
 							</div>
 						) : null

--- a/projects/js-packages/publicize-components/src/components/services/style.module.scss
+++ b/projects/js-packages/publicize-components/src/components/services/style.module.scss
@@ -197,7 +197,6 @@
 	.fields-wrapper {
 		display: flex;
 		flex-direction: column;
-		justify-content: flex-end;
 		width: 100%;
 		gap: 1rem;
 
@@ -223,7 +222,7 @@
 		@include gb.break-small {
 
 			button {
-				align-self: flex-end;
+				align-self: start;
 			}
 		}
 	}


### PR DESCRIPTION
Closes SOCIAL-246

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* In the social connections management modal, update the label for the submit button of the custom input form (for Bluesky and Mastodon) from "Connect" to "Submit"
* Make that Submit button aligned to start (Left for LTR and right for RTL)

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to Jetpack > Social or the editor
* Oen connections management modal
* Expand Bluesky and Mastodon
* Confirm that the submit button now has the label "Submit"
* Confirm that the button is aligned to start

| Before | After |
|--------|--------|
| <img width="594" height="758" alt="Screenshot 2025-12-12 at 4 55 33 PM" src="https://github.com/user-attachments/assets/5ded9aa8-15af-4b56-9fdc-874ec4349b82" /> | <img width="600" height="763" alt="Screenshot 2025-12-12 at 4 57 41 PM" src="https://github.com/user-attachments/assets/27966d36-84c5-4ff2-94d8-c84c2860ce6f" /> | 

