### PR TITLE
Remove Duplicator Pro from incompatible plugins list

### DIFF
--- a/projects/plugins/wpcomsh/changelog/update-incompatible-plugins-list-remove-duplicator-pro
+++ b/projects/plugins/wpcomsh/changelog/update-incompatible-plugins-list-remove-duplicator-pro
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Remove Duplicator Pro from incompatible plugins list.

--- a/projects/plugins/wpcomsh/class-jetpack-plugin-compatibility.php
+++ b/projects/plugins/wpcomsh/class-jetpack-plugin-compatibility.php
@@ -61,7 +61,6 @@ class Jetpack_Plugin_Compatibility {
 		'backwpup/backwpup.php'                           => '"backwpup" has been deactivated, WordPress.com handles managing your site backups for you.',
 		'backwpup-pro/backwpup.php'                       => '"backwpup-pro" has been deactivated, WordPress.com handles managing your site backups for you.',
 		'duplicator/duplicator.php'                       => '"duplicator" has been deactivated, it deletes data necessary to manage your site and is not supported on WordPress.com.',
-		'duplicator-pro/duplicator-pro.php'               => '"duplicator-pro" has been deactivated, it deletes data necessary to manage your site and is not supported on WordPress.com.',
 		'jetpack-backup/jetpack-backup.php'               => '"jetpack-backup" has been deactivated, WordPress.com handles managing your site backups for you.',
 		'siteground-migrator/siteground-migrator.php'     => '"siteground-migrator" has been deactivated, WordPress.com handles managing your site backups for you.',
 		'wp-backitup/wp-backitup.php'                     => '"wp-backitup" has been deactivated, WordPress.com handles managing your site backups for you.',


### PR DESCRIPTION

- update `class-jetpack-plugin-compatibility.php`
- added changelog

From this comment: https://github.com/Automattic/jetpack/pull/46225#issuecomment-3642524877

We've tested Duplicator Pro v4.5.24.2 on WordPress.com and it seems work fine without errors.


## Jetpack product discussion
N/A

## Does this pull request change what data or activity we track or use?
No, I don't believe this would apply to the update.

## Testing instructions:

1. Create a new Business Plan site, mark it as a WoA Dev site, and take it Atomic.
2. Build wpcomsh plugin and synchronize to the WoA Dev site

```
git checkout BRANCH
composer install
WPCOMSH_DEVMODE=1 make clean build
rsync -avze ssh --delete build/wpcomsh USERNAME@sftp.wp.com:htdocs/wp-content/mu-plugins
```

3. SSH into the WoA dev site, and run: wp plugin install wp-staging --activate
4. Navigate to the WoA dev site's /wp-admin/plugins.php page and confirm that WP STAGING can be activated and is not disabled.
