### PR TITLE
WP Super Cache: Fix fatal error when getmypid() is unavailable in deb…

### DIFF
--- a/projects/plugins/super-cache/changelog/fix-getmypid-fatal-error
+++ b/projects/plugins/super-cache/changelog/fix-getmypid-fatal-error
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+WP Super Cache: Fix fatal error when getmypid() is unavailable in debug logging

--- a/projects/plugins/super-cache/wp-cache-phase2.php
+++ b/projects/plugins/super-cache/wp-cache-phase2.php
@@ -754,7 +754,11 @@ function wp_cache_debug( $message, $level = 1 ) {
 	}
 
 	// Log message: Date URI Message
-	$log_message = date( 'H:i:s' ) . ' ' . getmypid() . " {$_SERVER['REQUEST_URI']} {$message}" . PHP_EOL;
+	if ( function_exists( 'getmypid' ) ) {
+		$log_message = date( 'H:i:s' ) . ' ' . getmypid() . " {$_SERVER['REQUEST_URI']} {$message}" . PHP_EOL;
+	} else {
+		$log_message = date( 'H:i:s' ) . " {$_SERVER['REQUEST_URI']} {$message}" . PHP_EOL;
+	}
 	// path to the log file in the cache folder
 	$log_file = $cache_path . str_replace( '/', '', str_replace( '..', '', $wp_cache_debug_log ) );
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->


## Proposed changes:
<!--- Explain what functional changes your PR includes -->

Add function_exists check before calling getmypid() to prevent fatal errors in environments where the function is disabled (via disable_functions in php.ini by some hosting providers, e.g. [[1]](https://wordpress.org/support/topic/php-fatal-error-uncaught-error-call-to-undefined-function-w3tcgetmypid/) [[2]](https://wpmudev.com/docs/hosting/allowed-disabled-functions-commands/#disabled-functions-php-ini) [[3]](https://process.qservers.net/index.php?rp=/knowledgebase/79/List-of-PHP-functions-disabled-on-shared-hosting-platform.html) [[4]](https://developer.aliyun.com/ask/96344)).

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

Not applicable.

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Disable getmypid() in php.ini disabled_functions.
2. Go to **WP Super Cache -> Debug**. Click **Enable Logging**.
3. Before this PR: fatal error. After this PR: no error.

