### PR TITLE
Webpack config: Add local name for css module classes for development for easier debugging

### DIFF
--- a/projects/js-packages/webpack-config/changelog/add-local-name-for-css-module-classes-for-dev
+++ b/projects/js-packages/webpack-config/changelog/add-local-name-for-css-module-classes-for-dev
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add local name for css module classes for development for easier debugging.

--- a/projects/js-packages/webpack-config/src/webpack/css-rule.js
+++ b/projects/js-packages/webpack-config/src/webpack/css-rule.js
@@ -1,3 +1,5 @@
+const isDevelopment = process.env.NODE_ENV !== 'production';
+
 const MiniCssExtractLoader = options => ( {
 	loader: require( 'mini-css-extract-plugin' ).loader,
 	options: options,
@@ -8,6 +10,10 @@ const CssLoader = options => ( {
 	options: {
 		// By default we do not want css-loader to try to handle absolute paths.
 		url: { filter: path => ! path.startsWith( '/' ) },
+		modules: {
+			auto: true,
+			localIdentName: isDevelopment ? '[local]--[hash:base64:5]' : '[hash:base64]',
+		},
 		...options,
 	},
 } );


### PR DESCRIPTION
Currently, when working with CSS modules, the generated class names are base64 hash which are unreadable while debugging. So, it is helpful to have the classnames retained during development.

Slack: p1764235570543949-slack-C05Q5HSS013

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Update the global webpack config to update `localIdentName` for CSS modules for development.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Run `jetpack watch plugins/jetpack`
* Review some of the pages to ensure they work fine
* Confirm that CSS modules have class name in them
* Run `jetpack build plugins/jetpack`
* Confirm that the UIs work fine