### PR TITLE
Add documentation link to media section

### DIFF
--- a/projects/js-packages/publicize-components/changelog/SOCIAL-265
+++ b/projects/js-packages/publicize-components/changelog/SOCIAL-265
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Added documentation link for media best practices in the media section

--- a/projects/js-packages/publicize-components/src/components/media-section-v2/index.tsx
+++ b/projects/js-packages/publicize-components/src/components/media-section-v2/index.tsx
@@ -4,10 +4,10 @@
  */
 
 import { GeneralPurposeImage } from '@automattic/jetpack-ai-client';
-import { ThemeProvider } from '@automattic/jetpack-components';
+import { getRedirectUrl, ThemeProvider } from '@automattic/jetpack-components';
 import { useAnalytics } from '@automattic/jetpack-shared-extension-utils';
 import { MediaUpload } from '@wordpress/block-editor';
-import { BaseControl, Button, Notice } from '@wordpress/components';
+import { BaseControl, Button, ExternalLink, Notice } from '@wordpress/components';
 import { useCallback, useMemo, useReducer, useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import useFeaturedImage from '../../hooks/use-featured-image';
@@ -312,6 +312,14 @@ export default function MediaSectionV2( {
 								</Notice>
 							) }
 						</>
+					) }
+					{ ( currentSource === 'media-library' || currentSource === 'upload-video' ) && (
+						<ExternalLink
+							href={ getRedirectUrl( 'jetpack-social-media-support-information' ) }
+							className={ styles[ 'learn-more' ] }
+						>
+							{ __( 'Learn photo and video best practices', 'jetpack-publicize-components' ) }
+						</ExternalLink>
 					) }
 				</BaseControl>
 			</div>

--- a/projects/js-packages/publicize-components/src/components/media-section-v2/styles.module.scss
+++ b/projects/js-packages/publicize-components/src/components/media-section-v2/styles.module.scss
@@ -84,3 +84,8 @@
 .notice {
 	margin-top: 12px;
 }
+
+.learn-more {
+	display: block;
+	margin-top: 1rem;
+}


### PR DESCRIPTION
Fixes SOCIAL-265

## Proposed changes:

* Added "Learn photo and video best practices" documentation link to the new media section (MediaSectionV2)
* Link only appears when custom media is selected (media library or uploaded video)

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

* Open a post in the editor
* Enable Jetpack Social and connect a social account
* Select "Media Library" from the media source dropdown and choose an image
* Verify the "Learn photo and video best practices" link appears below the media controls
* Select "Featured Image" or "Social Image" and verify the link does NOT appear

<img width="556" height="458" alt="CleanShot 2025-12-15 at 11 37 34@2x" src="https://github.com/user-attachments/assets/2156a91c-42cf-4ea2-827c-ce1f2098bf2c" />
