### PR TITLE
Jetpack Sync: Remove the woocommerce_onboarding_profile action from options whitelist

### DIFF
--- a/projects/packages/sync/changelog/remove-sync-woocommerce_onboarding_profile-options
+++ b/projects/packages/sync/changelog/remove-sync-woocommerce_onboarding_profile-options
@@ -1,0 +1,4 @@
+Significance: patch
+Type: removed
+
+Sync: Removed an option from the sync whitelist as it is not in use.

--- a/projects/packages/sync/src/modules/class-woocommerce.php
+++ b/projects/packages/sync/src/modules/class-woocommerce.php
@@ -502,7 +502,6 @@ class WooCommerce extends Module {
 		'woocommerce_api_enabled',
 		'woocommerce_allow_tracking',
 		'woocommerce_task_list_hidden',
-		'woocommerce_onboarding_profile',
 		'woocommerce_cod_settings',
 	);
 


### PR DESCRIPTION
Fixes SYNC-49

## Proposed changes:

* This PR removes the `woocommerce_onboarding_profile` action from the Sync default Woo options whitelist.
* This was added in this PR - https://github.com/Automattic/jetpack/pull/17075 - but is not synced on the WPcom side. Comments in D49062-code indicate that it was intentional not added in WPcom as it wasn't needed just yet. Given the amount of time as well, it seems best to remove this entirely until it is actually needed.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

n/a

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

* Proof-read