### PR TITLE
Forms: Add CSV file upload support

### DIFF
--- a/projects/packages/forms/changelog/add-csv-upload-support
+++ b/projects/packages/forms/changelog/add-csv-upload-support
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Allow CSV files to be uploaded via contact forms

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -1473,6 +1473,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 				'odt'             => 'application/vnd.oasis.opendocument.text',
 				'ppsx'            => 'application/vnd.openxmlformats-officedocument.presentationml.slideshow',
 				'ppsm'            => 'application/vnd.ms-powerpoint.slideshow.macroEnabled.12',
+				'csv'             => 'text/csv',
 				'xla|xls|xlt|xlw' => 'application/vnd.ms-excel',
 				'xlsx'            => 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
 				'xlsm'            => 'application/vnd.ms-excel.sheet.macroEnabled.12',


### PR DESCRIPTION
Resolves FORMS-465

## Proposed changes:
   * Add support for CSV file uploads in Jetpack Forms by adding the `text/csv` MIME type to the list of allowed file types

Works with 198080-ghe-Automattic/wpcom backend change.

### Other information:

   - [x] Have you written new tests for your changes, if applicable?
   - [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
   - [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
See pMz3w-n6q-p2

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

   * Set up a WordPress site with Jetpack Forms installed
   * Create a contact form with a file upload field
   * On the frontend, submit the form and attempt to upload a CSV file
   * Verify that the CSV file is accepted and uploaded successfully
   * Verify that the file appears in the form responses in the dashboard
   * Optionally, verify that other file types continue to work as expected"--base trunk
   
Note: Make sure the .com side is eather merged or you will need to apply the patch on your sandbox and sandbox public-api.wordpress.com