### PR TITLE
Forms: Fix textarea placeholders to match input placeholder styling

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-placeholders-style
+++ b/projects/packages/forms/changelog/fix-forms-placeholders-style
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed textarea placeholders to match input placeholder styling

--- a/projects/packages/forms/src/contact-form/css/grunion.scss
+++ b/projects/packages/forms/src/contact-form/css/grunion.scss
@@ -18,14 +18,18 @@
 	clear: both;
 }
 
+.contact-form textarea::placeholder,
 .contact-form input::placeholder {
+	color: inherit;
 	transition: opacity 0.3s ease-out;
 }
 
+.contact-form textarea:hover::placeholder,
 .contact-form input:hover::placeholder {
 	opacity: 0.5;
 }
 
+.contact-form textarea:focus::placeholder,
 .contact-form input:focus::placeholder {
 	opacity: 0.3;
 }


### PR DESCRIPTION
## Proposed changes:
* Fixed textarea placeholders to inherit color and match input placeholder animations
* Added hover and focus state transitions for textarea placeholders to match input fields

The issue is mostly noticeable with dark backgrounds.

Before:
<img width="657" height="550" alt="image" src="https://github.com/user-attachments/assets/193c6796-aaaf-4052-a076-f38123a512b6" />


After:
<img width="670" height="559" alt="image" src="https://github.com/user-attachments/assets/65c185be-3fe2-45bd-b134-2b5ab0b7d899" />


### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion


## Does this pull request change what data or activity we track or use?

No, this is a CSS styling fix only.

## Testing instructions:

1. Create a contact form with both input fields and a textarea field
2. Verify that placeholder text in both inputs and textarea has the same color and styling
3. Hover over the textarea - placeholder should fade to 50% opacity
4. Focus on the textarea - placeholder should fade to 30% opacity
5. Verify the same behavior works for input fields (they should all behave consistently)

Before this fix, textarea placeholders did not have the same styling and transitions as input placeholders.
