### PR TITLE
Social: Remove the use of share status feature flag

### DIFF
--- a/projects/js-packages/publicize-components/changelog/remove-social-use-of-share-status-feature-flag
+++ b/projects/js-packages/publicize-components/changelog/remove-social-use-of-share-status-feature-flag
@@ -1,0 +1,4 @@
+Significance: patch
+Type: removed
+
+Social: Remove the use of share status feature flag.

--- a/projects/js-packages/publicize-components/src/components/global-modals/index.tsx
+++ b/projects/js-packages/publicize-components/src/components/global-modals/index.tsx
@@ -6,7 +6,7 @@ import { UnifiedModal } from '../unified-modal';
 export const GlobalModals = () => {
 	return (
 		<>
-			{ siteHasFeature( features.SHARE_STATUS ) ? <ShareStatusModal /> : null }
+			<ShareStatusModal />
 			{ siteHasFeature( features.UNIFIED_UI_V1 ) ? <UnifiedModal /> : null }
 		</>
 	);

--- a/projects/js-packages/publicize-components/src/components/panel/index.tsx
+++ b/projects/js-packages/publicize-components/src/components/panel/index.tsx
@@ -2,7 +2,6 @@
  * Publicize sharing panel based on the
  * Jetpack plugin implementation.
  */
-import { siteHasFeature } from '@automattic/jetpack-script-data';
 import { PanelBody } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
@@ -12,7 +11,6 @@ import usePublicizeConfig from '../../hooks/use-publicize-config';
 import useRefreshConnections from '../../hooks/use-refresh-connections';
 import { usePostJustPublished } from '../../hooks/use-saving-post';
 import useSelectSocialMediaConnections from '../../hooks/use-social-media-connections';
-import { features } from '../../utils/constants';
 import PublicizeForm from '../form';
 import { ManualSharing } from '../manual-sharing';
 import { ReSharingPanel } from '../resharing-panel';
@@ -73,7 +71,7 @@ const PublicizePanel = ( { prePublish }: PublicizePanelProps ) => {
 			) }
 			{ isPostPublished && (
 				<>
-					{ siteHasFeature( features.SHARE_STATUS ) ? <ReSharingPanel /> : null }
+					<ReSharingPanel />
 					<ManualSharing />
 				</>
 			) }

--- a/projects/js-packages/publicize-components/src/components/post-publish-share-status/index.tsx
+++ b/projects/js-packages/publicize-components/src/components/post-publish-share-status/index.tsx
@@ -1,4 +1,3 @@
-import { siteHasFeature } from '@automattic/jetpack-script-data';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { store as editorStore, PluginPostPublishPanel } from '@wordpress/editor';
 import { useIsSharingPossible } from '../../hooks/use-is-sharing-possible';
@@ -6,7 +5,6 @@ import { usePostMeta } from '../../hooks/use-post-meta';
 import { usePostPrePublishValue } from '../../hooks/use-post-pre-publish-value';
 import { usePostJustPublished } from '../../hooks/use-saving-post';
 import { store as socialStore } from '../../social-store';
-import { features } from '../../utils/constants';
 import { ShareStatus } from './share-status';
 
 /**
@@ -34,7 +32,7 @@ export function PostPublishShareStatus() {
 
 	const willPostBeShared = isPublicizeEnabled && enabledConnections.length > 0 && isSharingPossible;
 
-	const showStatus = siteHasFeature( features.SHARE_STATUS ) && willPostBeShared && isPostPublished;
+	const showStatus = willPostBeShared && isPostPublished;
 
 	usePostJustPublished( () => {
 		if ( showStatus ) {

--- a/projects/js-packages/publicize-components/src/components/share-post/index.jsx
+++ b/projects/js-packages/publicize-components/src/components/share-post/index.jsx
@@ -134,9 +134,7 @@ export function SharePostButton( { onShareCompleted } ) {
 
 		await doPublicize();
 
-		if ( siteHasFeature( features.SHARE_STATUS ) ) {
-			pollForPostShareStatus();
-		}
+		pollForPostShareStatus();
 	}, [
 		isPostPublished,
 		recordEvent,

--- a/projects/js-packages/publicize-components/src/components/share-status/modal-trigger.tsx
+++ b/projects/js-packages/publicize-components/src/components/share-status/modal-trigger.tsx
@@ -1,4 +1,3 @@
-import { siteHasFeature } from '@automattic/jetpack-script-data';
 import { useAnalytics } from '@automattic/jetpack-shared-extension-utils';
 import { Button } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
@@ -6,7 +5,6 @@ import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
 import { forwardRef, useCallback } from 'react';
 import { store as socialStore } from '../../social-store';
-import { features } from '../../utils/constants';
 import styles from './styles.module.scss';
 import type { ComponentPropsWithoutRef } from 'react';
 
@@ -35,10 +33,6 @@ export const ModalTrigger = forwardRef(
 
 		// If the post is not shared anywhere, thus there is no share status or no shares, we don't need to show the trigger.
 		if ( ! shareStatus || ! shareStatus.shares || shareStatus.shares.length === 0 ) {
-			return null;
-		}
-
-		if ( ! siteHasFeature( features.SHARE_STATUS ) ) {
 			return null;
 		}
 

--- a/projects/js-packages/publicize-components/src/social-store/resolvers.ts
+++ b/projects/js-packages/publicize-components/src/social-store/resolvers.ts
@@ -1,7 +1,5 @@
-import { siteHasFeature } from '@automattic/jetpack-script-data';
 import apiFetch from '@wordpress/api-fetch';
 import { store as editorStore } from '@wordpress/editor';
-import { features } from '../utils/constants';
 import { normalizeShareStatus } from '../utils/share-status';
 import { setConnections } from './actions/connection-data';
 import { fetchPostShareStatus, receivePostShareStaus } from './actions/share-status';
@@ -55,10 +53,6 @@ export function getPostShareStatus( _postId ) {
 	return async ( { dispatch, registry } ) => {
 		// Default to the current post ID if none is provided.
 		const postId = _postId || registry.select( editorStore ).getCurrentPostId();
-
-		if ( ! siteHasFeature( features.SHARE_STATUS ) ) {
-			return;
-		}
 
 		try {
 			dispatch( fetchPostShareStatus( postId ) );

--- a/projects/js-packages/publicize-components/src/utils/constants.ts
+++ b/projects/js-packages/publicize-components/src/utils/constants.ts
@@ -1,6 +1,5 @@
 export const features = {
 	ENHANCED_PUBLISHING: 'social-enhanced-publishing',
 	IMAGE_GENERATOR: 'social-image-generator',
-	SHARE_STATUS: 'social-share-status',
 	UNIFIED_UI_V1: 'social-unified-ui-v1',
 };


### PR DESCRIPTION
The [share status](https://github.com/Automattic/jetpack/blob/8dd21e5af0b61038a34f208b3b3705f35d18273a/projects/js-packages/publicize-components/src/utils/constants.ts#L4) feature is now obsolete as it's now available on all sites.

Completes SOCIAL-271

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Social: Remove the use of share status feature flag

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Publish a post
* Confirm that you see share status in the post publish sidebar
* Reshare a post, confirm that you see the resharing (loading...) and the share status in the sidebar.

