### PR TITLE
Social: Fix connections management modal not opening from pre-publish panel

### DIFF
--- a/projects/js-packages/publicize-components/changelog/fix-social-connections-modal-in-pre-publish-panel
+++ b/projects/js-packages/publicize-components/changelog/fix-social-connections-modal-in-pre-publish-panel
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix connections management modal not opening from pre-publish panel.

--- a/projects/js-packages/publicize-components/src/components/form/index.tsx
+++ b/projects/js-packages/publicize-components/src/components/form/index.tsx
@@ -16,7 +16,6 @@ import useMediaRestrictions from '../../hooks/use-media-restrictions';
 import usePublicizeConfig from '../../hooks/use-publicize-config';
 import useSocialMediaConnections from '../../hooks/use-social-media-connections';
 import { features } from '../../utils';
-import { ThemedConnectionsModal as ManageConnectionsModal } from '../manage-connections-modal';
 import { SocialPostModal } from '../social-post-modal/modal';
 import { ConnectionsList } from './connections-list';
 import { EmptyState } from './empty-state';
@@ -53,7 +52,6 @@ export default function PublicizeForm() {
 
 	return (
 		<Wrapper>
-			<ManageConnectionsModal />
 			{ hasConnections ? (
 				<PanelRow>
 					<ConnectionsList />

--- a/projects/js-packages/publicize-components/src/components/global-modals/index.tsx
+++ b/projects/js-packages/publicize-components/src/components/global-modals/index.tsx
@@ -1,5 +1,6 @@
 import { siteHasFeature } from '@automattic/jetpack-script-data';
 import { features } from '../../utils/constants';
+import { ThemedConnectionsModal as ManageConnectionsModal } from '../manage-connections-modal';
 import { ThemedShareStatusModal as ShareStatusModal } from '../share-status';
 import { UnifiedModal } from '../unified-modal';
 
@@ -8,6 +9,7 @@ export const GlobalModals = () => {
 		<>
 			{ siteHasFeature( features.SHARE_STATUS ) ? <ShareStatusModal /> : null }
 			{ siteHasFeature( features.UNIFIED_UI_V1 ) ? <UnifiedModal /> : null }
+			<ManageConnectionsModal />
 		</>
 	);
 };

--- a/projects/plugins/jetpack/changelog/fix-social-connections-modal-in-pre-publish-panel
+++ b/projects/plugins/jetpack/changelog/fix-social-connections-modal-in-pre-publish-panel
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Social: Fix connections management modal not opening from pre-publish panel.

--- a/projects/plugins/social/changelog/fix-social-connections-modal-in-pre-publish-panel
+++ b/projects/plugins/social/changelog/fix-social-connections-modal-in-pre-publish-panel
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix connections management modal not opening from pre-publish panel.


### PR DESCRIPTION
Fixes SOCIAL-263

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Move the manage connections modal rendering to the global modals component

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a new post in the block editor
* Click on the Publish button
* Find the "Add a new account" button/link under the social media connections
* Click on it
* Confirm that it opens the modal

<table>
    <tbody>
        <tr>
            <th>BEFORE</th>
            <th>AFTER</th>
        </tr>
        <tr>
            <td>

https://github.com/user-attachments/assets/4ace7271-e3fd-4f2a-88bf-f323326344ee

</td>
            <td>

https://github.com/user-attachments/assets/5ec2d56e-88f4-47b0-b335-5ac8bc807c33

</td>
        </tr>
    </tbody>
</table>
