### PR TITLE
Jetpack Sync: Assorted cleanup in two sync module files

### DIFF
--- a/projects/packages/sync/changelog/update-sync-module-file-cleanup
+++ b/projects/packages/sync/changelog/update-sync-module-file-cleanup
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Sync: General cleanup and clarity added in a couple of module files.

--- a/projects/packages/sync/src/modules/class-comments.php
+++ b/projects/packages/sync/src/modules/class-comments.php
@@ -508,6 +508,9 @@ class Comments extends Module {
 	 * @return array|boolean False if not whitelisted, the original hook args otherwise.
 	 */
 	public function filter_meta( $args ) {
+		if ( ! is_array( $args ) || count( $args ) < 3 ) {
+			return false;
+		}
 		if ( $this->is_comment_type_allowed( $args[1] ) && $this->is_whitelisted_comment_meta( $args[2] ) ) {
 			return $args;
 		}

--- a/projects/packages/sync/src/modules/class-woocommerce.php
+++ b/projects/packages/sync/src/modules/class-woocommerce.php
@@ -327,15 +327,13 @@ class WooCommerce extends Module {
 	 *
 	 * @access public
 	 *
-	 * @todo Refactor table name to use a $wpdb->prepare placeholder.
-	 *
 	 * @param int $order_item_id Order item ID.
 	 * @return object Order item.
 	 */
 	public function build_order_item( $order_item_id ) {
 		global $wpdb;
-		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-		return $wpdb->get_row( $wpdb->prepare( "SELECT * FROM $this->order_item_table_name WHERE order_item_id = %d", $order_item_id ) );
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Direct database access is intentional; caching is not required for this query.
+		return $wpdb->get_row( $wpdb->prepare( 'SELECT * FROM %i WHERE order_item_id = %d', $this->order_item_table_name, $order_item_id ) );
 	}
 
 	/**

--- a/projects/packages/sync/src/modules/class-woocommerce.php
+++ b/projects/packages/sync/src/modules/class-woocommerce.php
@@ -185,6 +185,7 @@ class WooCommerce extends Module {
 		add_action( 'woocommerce_grant_product_download_access', $callable, 10, 1 );
 
 		// Tax rates.
+		// These are ignored on WP.com: tax items are derived from order data via wc_order_tax_lookup, which isn’t present there.
 		add_action( 'woocommerce_tax_rate_added', $callable, 10, 2 );
 		add_action( 'woocommerce_tax_rate_updated', $callable, 10, 2 );
 		add_action( 'woocommerce_tax_rate_deleted', $callable, 10, 1 );


### PR DESCRIPTION


## Proposed changes:

* This PR includes three small 'cleanup' related additions, to two different Sync module files:
  * A check in `class_comments.php` `filter_meta` function to ensure `$args` is in the correct format. This is a follow up from [this comment](https://github.com/Automattic/jetpack/pull/45684#discussion_r2480822948), following the same approach as with `class-posts.php` [here](https://github.com/Automattic/jetpack/blob/8dd21e5af0b61038a34f208b3b3705f35d18273a/projects/packages/sync/src/modules/class-posts.php#L461).
  * In `class-woocommerce.php`: Removing a 'todo' - we're now using the `%i` placeholder for the table names within the `wpdb:prepare` statement as placeholders in `build_order_items` (leaving `estimate_full_sync_actions` changes for now as this also applies across multiple files).
  * Also in `class-woocommere.php`, added a comment to clarify why the tax rate actions aren't processed on WPcom ( a follow-up from SYNC-192).

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

n/a

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

* Proof-read.
* For the `build_order_items` changes, you can test adding an order item to an order and ensuring there are no issues with the incremental sync (eg. `gpr select * from wp_YOURBLOGID_woocommerce_order_items` )

