### PR TITLE
Forms: strip HTML from styled labels in error summary

### DIFF
--- a/projects/packages/forms/changelog/update-forms-error-styling
+++ b/projects/packages/forms/changelog/update-forms-error-styling
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fixed
+
+Forms: strip HTML from styled labels in error summary

--- a/projects/packages/forms/src/modules/form/view.js
+++ b/projects/packages/forms/src/modules/form/view.js
@@ -170,6 +170,11 @@ const toggleImageOptionInput = ( input, optionElement ) => {
 	}
 };
 
+const stripHtml = html => {
+	const doc = new DOMParser().parseFromString( html, 'text/html' );
+	return doc.body.textContent || '';
+};
+
 const { state, actions } = store( NAMESPACE, {
 	state: {
 		validators: {},
@@ -301,7 +306,7 @@ const { state, actions } = store( NAMESPACE, {
 					if ( field.error && field.error !== 'yes' ) {
 						errors.push( {
 							anchor: '#' + field.id,
-							label: field.label + ' : ' + getError( field ),
+							label: stripHtml( field.label ) + ': ' + getError( field ),
 							id: field.id,
 						} );
 					}

--- a/projects/plugins/jetpack/changelog/update-forms-error-styling
+++ b/projects/plugins/jetpack/changelog/update-forms-error-styling
@@ -1,0 +1,4 @@
+Significance: minor
+Type: bugfix
+
+Forms: strip HTML from styled labels in error summary


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes FORMS-466

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Strip out HTML from styled labels shown in error summary
* Remove extra space before `:`


### Before

<img width="672" height="970" alt="image" src="https://github.com/user-attachments/assets/1dfc031b-e156-41dc-baf3-ca69f63f287c" />

<img width="669" height="101" alt="Screenshot 2025-12-16 at 11 53 06" src="https://github.com/user-attachments/assets/29822b20-900a-43df-b075-877ef815b0fb" />



### After

<img width="769" height="983" alt="Screenshot 2025-12-16 at 13 18 48" src="https://github.com/user-attachments/assets/a9b144c6-f2dd-484b-965c-ea4008239c2a" />

<img width="668" height="103" alt="Screenshot 2025-12-16 at 11 53 12" src="https://github.com/user-attachments/assets/39c0f63c-a637-41ab-814a-d199ed2a1bb4" />


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* In editor, add bold/italic styles to field label
    <img width="708" height="187" alt="Screenshot 2025-12-16 at 12 25 16" src="https://github.com/user-attachments/assets/14acaf81-6b9d-474a-b362-921a96c585f7" />
* You can even copy-paste two lines to label to hack two liner with `<br />` (separate concern if that should be possible...)
* Save post and submit invalid fields
* See error with/without PR

