### PR TITLE
Social: Move Share post action from post-list to Publicize

### DIFF
--- a/projects/packages/post-list/changelog/remove-share-action
+++ b/projects/packages/post-list/changelog/remove-share-action
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Moved Share post action to the Publicize package for better discoverability. The `jetpack_post_list_display_share_action` filter is now handled by Publicize.

--- a/projects/packages/post-list/src/class-post-list.php
+++ b/projects/packages/post-list/src/class-post-list.php
@@ -125,34 +125,6 @@ class Post_List {
 	}
 
 	/**
-	 * Checks the current post type and adds the Share post
-	 * action if it is appropriate to do so.
-	 *
-	 * @param string $post_type The post type associated with the current request.
-	 */
-	public function maybe_add_share_action( $post_type ) {
-		// Add Share action if post type supports 'publicize', uses the 'block editor', and the feature flag is true.
-		if (
-			post_type_supports( $post_type, 'publicize' ) &&
-			use_block_editor_for_post_type( $post_type ) &&
-			/**
-			 * Determine whether we should show the share action for this post type.
-			 * The default is false.
-			 *
-			 * @since 0.2.0
-			 *
-			 * @param boolean Whether we should show the share action for this post type.
-			 * @param string  The current post type.
-			 */
-			apply_filters( 'jetpack_post_list_display_share_action', false, $post_type )
-		) {
-			// Add Share post action.
-			add_filter( 'post_row_actions', array( $this, 'add_share_action' ), 20, 2 );
-			add_filter( 'page_row_actions', array( $this, 'add_share_action' ), 20, 2 );
-		}
-	}
-
-	/**
 	 * If the current_screen has 'edit' as the base, add filters and actions to change the post list tables.
 	 *
 	 * @param object $current_screen The current screen.
@@ -163,7 +135,6 @@ class Post_List {
 		}
 
 		$this->maybe_customize_columns( $current_screen->post_type );
-		$this->maybe_add_share_action( $current_screen->post_type );
 		$this->maybe_add_copy_link_action( $current_screen->post_type );
 	}
 
@@ -215,33 +186,8 @@ class Post_List {
 		if ( ! empty( $_POST['screen'] ) && str_starts_with( sanitize_key( $_POST['screen'] ), 'edit-' ) && ! empty( $_POST['post_type'] ) ) {
 			$type = sanitize_key( $_POST['post_type'] );
 			$this->maybe_customize_columns( $type );
-			$this->maybe_add_share_action( $type );
 		}
 		// phpcs:enable WordPress.Security.NonceVerification.Missing
-	}
-
-	/**
-	 * Adds the Share post action which links to the editor with the sidebar open.
-	 *
-	 * @param array   $post_actions The current array of post actions.
-	 * @param WP_Post $post The current post in the post list table.
-	 *
-	 * @return array The modified post actions array.
-	 */
-	public function add_share_action( $post_actions, $post ) {
-		$edit_url = get_edit_post_link( $post->ID, 'raw' );
-		if ( ! $edit_url || 'publish' !== $post->post_status ) {
-			// Do nothing since we do not have an edit URL to work with.
-			return $post_actions;
-		}
-
-		$url   = add_query_arg( 'jetpack-editor-action', 'share_post', $edit_url );
-		$text  = _x( 'Share', 'Share the post on social networks', 'jetpack-post-list' );
-		$title = _draft_or_post_title( $post );
-		/* translators: post title */
-		$label                 = sprintf( __( 'Share &#8220;%s&#8221; via Jetpack Social', 'jetpack-post-list' ), $title );
-		$post_actions['share'] = sprintf( '<a href="%s" aria-label="%s">%s</a>', esc_url( $url ), esc_attr( $label ), esc_html( $text ) );
-		return $post_actions;
 	}
 
 	/**

--- a/projects/packages/post-list/tests/php/Post_List_Test.php
+++ b/projects/packages/post-list/tests/php/Post_List_Test.php
@@ -82,7 +82,7 @@ class Post_List_Test extends BaseTestCase {
 
 	/**
 	 * Test add_filters_and_actions_for_screen() with "Pages".
-	 * Thumbnail should show up on "Pages", but Share should not, because 'publicize' is not supported on "Pages".
+	 * Thumbnail and Copy link should show up on "Pages".
 	 */
 	public function test_add_filters_and_actions_for_screen_thumbnail() {
 		$this->confirm_add_filters_and_actions_for_screen_starts_clean();
@@ -94,28 +94,22 @@ class Post_List_Test extends BaseTestCase {
 			'post_type' => 'page',
 		);
 
-		// Turn on the flag that allows the Share action if applicable.
-		add_filter( 'jetpack_post_list_display_share_action', '__return_true' );
-
 		$post_list->add_filters_and_actions_for_screen( $current_screen );
 
-		// Assert that our style, filter, and action has been added.
+		// Assert that thumbnail columns and copy link actions have been added.
 		$this->assertTrue( has_filter( 'manage_posts_columns' ) );
 		$this->assertTrue( has_action( 'manage_posts_custom_column' ) );
 		$this->assertTrue( has_filter( 'manage_pages_columns' ) );
 		$this->assertTrue( has_action( 'manage_pages_custom_column' ) );
-		$this->assertFalse( has_action( 'post_row_actions', array( $post_list, 'add_share_action' ) ) );
-		$this->assertFalse( has_action( 'page_row_actions', array( $post_list, 'add_share_action' ) ) );
 		$this->assertNotFalse( has_action( 'post_row_actions', array( $post_list, 'add_copy_link_action' ) ) );
 		$this->assertNotFalse( has_action( 'page_row_actions', array( $post_list, 'add_copy_link_action' ) ) );
 	}
 
 	/**
 	 * Test add_filters_and_actions_for_screen() with a custom post type.
-	 * Thumbnail should ONLY show up on "Posts" and "Pages". However, the Share action should show up on custom post
-	 * types that support publicize and the block editor.
+	 * Thumbnail should ONLY show up on "Posts" and "Pages", but copy link should show up.
 	 */
-	public function test_add_filters_and_actions_for_screen_share() {
+	public function test_add_filters_and_actions_for_screen_custom_post_type() {
 		$this->confirm_add_filters_and_actions_for_screen_starts_clean();
 		$post_list = Post_List::configure();
 
@@ -124,7 +118,8 @@ class Post_List_Test extends BaseTestCase {
 			'post_type_we_made_up',
 			array(
 				'show_in_rest' => true,
-				'supports'     => array( 'editor', 'publicize' ),
+				'public'       => true,
+				'supports'     => array( 'editor' ),
 			)
 		);
 
@@ -134,12 +129,9 @@ class Post_List_Test extends BaseTestCase {
 			'post_type' => 'post_type_we_made_up',
 		);
 
-		// Turn on the flag that allows the Share action if applicable.
-		add_filter( 'jetpack_post_list_display_share_action', '__return_true' );
-
 		$post_list->add_filters_and_actions_for_screen( $current_screen );
 
-		// Assert that only the Share action was enabled.
+		// Assert that only copy link action was enabled (no thumbnail columns for custom post types).
 		$this->assertFalse( has_filter( 'manage_posts_columns' ) );
 		$this->assertFalse( has_action( 'manage_posts_custom_column' ) );
 		$this->assertFalse( has_filter( 'manage_pages_columns' ) );
@@ -150,9 +142,9 @@ class Post_List_Test extends BaseTestCase {
 
 	/**
 	 * Test the add_filters_and_actions_for_screen() with "Posts".
-	 * The thumbnail and Share action should be available on "Posts".
+	 * Thumbnail and copy link should be available on "Posts".
 	 */
-	public function test_add_filters_and_actions_for_screen_thumbnail_and_share() {
+	public function test_add_filters_and_actions_for_screen_posts() {
 		$this->confirm_add_filters_and_actions_for_screen_starts_clean();
 		$post_list = Post_List::configure();
 
@@ -160,53 +152,20 @@ class Post_List_Test extends BaseTestCase {
 			'base'      => 'edit',
 			'post_type' => 'post',
 		);
-		add_post_type_support( 'post', 'publicize' );
-
-		// Turn on the flag that allows the Share action if applicable.
-		add_filter( 'jetpack_post_list_display_share_action', '__return_true' );
 
 		$post_list->add_filters_and_actions_for_screen( $current_screen );
 
-		// Assert that our style, filter, and action has been added.
+		// Assert that thumbnail columns and copy link actions have been added.
 		$this->assertTrue( has_filter( 'manage_posts_columns' ) );
 		$this->assertTrue( has_action( 'manage_posts_custom_column' ) );
 		$this->assertTrue( has_filter( 'manage_pages_columns' ) );
 		$this->assertTrue( has_action( 'manage_pages_custom_column' ) );
-		$this->assertTrue( has_action( 'post_row_actions' ) );
-		$this->assertTrue( has_action( 'page_row_actions' ) );
-	}
-
-	/**
-	 * Test the add_filters_and_actions_for_screen() with "Posts".
-	 * The thumbnail and Share action should be available on "Posts", but we don't set the share flag to true, so only
-	 * thumbnails show up.
-	 */
-	public function test_add_filters_and_actions_for_screen_share_flag_disabled() {
-
-		$this->confirm_add_filters_and_actions_for_screen_starts_clean();
-		$post_list = Post_List::configure();
-
-		$current_screen = (object) array(
-			'base'      => 'edit',
-			'post_type' => 'post',
-		);
-		add_post_type_support( 'post', 'publicize' );
-
-		$post_list->add_filters_and_actions_for_screen( $current_screen );
-
-		// Assert that our style, filter, and action has been added.
-		$this->assertTrue( has_filter( 'manage_posts_columns' ) );
-		$this->assertTrue( has_action( 'manage_posts_custom_column' ) );
-		$this->assertTrue( has_filter( 'manage_pages_columns' ) );
-		$this->assertTrue( has_action( 'manage_pages_custom_column' ) );
-		$this->assertFalse( has_action( 'post_row_actions', array( $post_list, 'add_share_action' ) ) );
-		$this->assertFalse( has_action( 'page_row_actions', array( $post_list, 'add_share_action' ) ) );
 		$this->assertNotFalse( has_action( 'post_row_actions', array( $post_list, 'add_copy_link_action' ) ) );
 		$this->assertNotFalse( has_action( 'page_row_actions', array( $post_list, 'add_copy_link_action' ) ) );
 	}
 
 	/**
-	 * Test the add_filters_and_actions_for_screen() method doesn't add thumbnails or Share if screen not 'edit' base.
+	 * Test the add_filters_and_actions_for_screen() method doesn't add thumbnails or copy link if screen not 'edit' base.
 	 */
 	public function test_add_filters_and_actions_for_screen_wrong_screen() {
 		$post_list      = Post_List::configure();

--- a/projects/packages/publicize/changelog/add-share-post-action
+++ b/projects/packages/publicize/changelog/add-share-post-action
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Added Share post action to the post list screen. Shows automatically for plans with republicize support, and supports the `jetpack_post_list_display_share_action` filter for custom overrides.

--- a/projects/packages/publicize/src/class-publicize-setup.php
+++ b/projects/packages/publicize/src/class-publicize-setup.php
@@ -188,16 +188,16 @@ class Publicize_Setup {
 		 *
 		 * The Share action allows users to reshare published posts via Jetpack Social.
 		 * It is automatically enabled for plans that support the 'republicize' feature,
-		 * but can also be enabled/disabled via this filter.
+		 * but can be disabled via this filter.
 		 *
 		 * @since 0.2.0 Originally in jetpack-post-list package.
 		 * @since $$NEXT_VERSION$$ Moved to jetpack-publicize package.
 		 *
-		 * @param bool   $show_share Whether to show the share action. Default false.
+		 * @param bool   $show_share Whether to show the share action. Default true.
 		 * @param string $post_type  The current post type.
 		 */
 		$show_share_action = Current_Plan::supports( 'republicize' )
-			|| apply_filters( 'jetpack_post_list_display_share_action', false, $current_screen->post_type );
+			&& apply_filters( 'jetpack_post_list_display_share_action', true, $current_screen->post_type );
 
 		if ( $show_share_action ) {
 			self::maybe_add_share_action( $current_screen->post_type );
@@ -214,8 +214,8 @@ class Publicize_Setup {
 			post_type_supports( $post_type, 'publicize' ) &&
 			use_block_editor_for_post_type( $post_type )
 		) {
-			add_filter( 'post_row_actions', array( self::class, 'add_share_action' ), 15, 2 );
-			add_filter( 'page_row_actions', array( self::class, 'add_share_action' ), 15, 2 );
+			add_filter( 'post_row_actions', array( self::class, 'add_share_action' ), 20, 2 );
+			add_filter( 'page_row_actions', array( self::class, 'add_share_action' ), 20, 2 );
 		}
 	}
 

--- a/projects/packages/publicize/src/class-publicize-setup.php
+++ b/projects/packages/publicize/src/class-publicize-setup.php
@@ -183,9 +183,63 @@ class Publicize_Setup {
 			return;
 		}
 
-		if ( Current_Plan::supports( 'republicize' ) ) {
-			add_filter( 'jetpack_post_list_display_share_action', '__return_true' );
+		/**
+		 * Filter to enable/disable the Share action on the post list screen.
+		 *
+		 * The Share action allows users to reshare published posts via Jetpack Social.
+		 * It is automatically enabled for plans that support the 'republicize' feature,
+		 * but can also be enabled/disabled via this filter.
+		 *
+		 * @since 0.2.0 Originally in jetpack-post-list package.
+		 * @since $$NEXT_VERSION$$ Moved to jetpack-publicize package.
+		 *
+		 * @param bool   $show_share Whether to show the share action. Default false.
+		 * @param string $post_type  The current post type.
+		 */
+		$show_share_action = Current_Plan::supports( 'republicize' )
+			|| apply_filters( 'jetpack_post_list_display_share_action', false, $current_screen->post_type );
+
+		if ( $show_share_action ) {
+			self::maybe_add_share_action( $current_screen->post_type );
 		}
+	}
+
+	/**
+	 * Add the Share action for post types that support publicize.
+	 *
+	 * @param string $post_type The post type.
+	 */
+	public static function maybe_add_share_action( $post_type ) {
+		if (
+			post_type_supports( $post_type, 'publicize' ) &&
+			use_block_editor_for_post_type( $post_type )
+		) {
+			add_filter( 'post_row_actions', array( self::class, 'add_share_action' ), 15, 2 );
+			add_filter( 'page_row_actions', array( self::class, 'add_share_action' ), 15, 2 );
+		}
+	}
+
+	/**
+	 * Add the Share action link to the post row actions.
+	 *
+	 * @param array    $post_actions The current post actions.
+	 * @param \WP_Post $post The post object.
+	 * @return array Modified post actions.
+	 */
+	public static function add_share_action( $post_actions, $post ) {
+		$edit_url = get_edit_post_link( $post->ID, 'raw' );
+		if ( ! $edit_url || 'publish' !== $post->post_status ) {
+			return $post_actions;
+		}
+
+		$url   = add_query_arg( 'jetpack-editor-action', 'share_post', $edit_url );
+		$text  = _x( 'Share', 'Share the post on social networks', 'jetpack-publicize-pkg' );
+		$title = _draft_or_post_title( $post );
+		/* translators: post title */
+		$label                 = sprintf( __( 'Share "%s" via Jetpack Social', 'jetpack-publicize-pkg' ), $title );
+		$post_actions['share'] = sprintf( '<a href="%s" aria-label="%s">%s</a>', esc_url( $url ), esc_attr( $label ), esc_html( $text ) );
+
+		return $post_actions;
 	}
 
 	/**

--- a/projects/packages/publicize/tests/php/Share_Action_Test.php
+++ b/projects/packages/publicize/tests/php/Share_Action_Test.php
@@ -50,9 +50,14 @@ class Share_Action_Test extends BaseTestCase {
 	}
 
 	/**
-	 * Test Share action filter is added for post types supporting publicize when filter is enabled.
+	 * Test Share action is added when plan supports republicize.
 	 */
-	public function test_add_share_action_for_publicize_post_type() {
+	public function test_add_share_action_when_plan_supports_republicize() {
+		// Set up a plan that supports republicize.
+		$plan                       = Current_Plan::PLAN_DATA['free'];
+		$plan['features']['active'] = array( 'republicize' );
+		update_option( Current_Plan::PLAN_OPTION, $plan, true );
+
 		// Register CPT with publicize support.
 		register_post_type(
 			'test_pub_cpt',
@@ -67,9 +72,6 @@ class Share_Action_Test extends BaseTestCase {
 			'post_type' => 'test_pub_cpt',
 		);
 
-		// Enable via filter.
-		add_filter( 'jetpack_post_list_display_share_action', '__return_true' );
-
 		Publicize_Setup::add_filters_and_actions_for_screen( $current_screen );
 
 		$this->assertNotFalse( has_action( 'post_row_actions', array( Publicize_Setup::class, 'add_share_action' ) ) );
@@ -77,15 +79,37 @@ class Share_Action_Test extends BaseTestCase {
 	}
 
 	/**
-	 * Test Share action filter is NOT added when filter returns false and no plan support.
+	 * Test Share action can be disabled via filter even when plan supports it.
 	 */
-	public function test_no_share_action_when_disabled() {
+	public function test_share_action_can_be_disabled_via_filter() {
+		// Set up a plan that supports republicize.
+		$plan                       = Current_Plan::PLAN_DATA['free'];
+		$plan['features']['active'] = array( 'republicize' );
+		update_option( Current_Plan::PLAN_OPTION, $plan, true );
+
 		$current_screen = (object) array(
 			'base'      => 'edit',
 			'post_type' => 'post',
 		);
 
-		// Filter defaults to false, no plan support.
+		// Disable via filter.
+		add_filter( 'jetpack_post_list_display_share_action', '__return_false' );
+
+		Publicize_Setup::add_filters_and_actions_for_screen( $current_screen );
+
+		$this->assertFalse( has_action( 'post_row_actions', array( Publicize_Setup::class, 'add_share_action' ) ) );
+	}
+
+	/**
+	 * Test Share action filter is NOT added when plan does not support republicize.
+	 */
+	public function test_no_share_action_without_plan_support() {
+		$current_screen = (object) array(
+			'base'      => 'edit',
+			'post_type' => 'post',
+		);
+
+		// No plan support, filter won't help.
 		Publicize_Setup::add_filters_and_actions_for_screen( $current_screen );
 
 		$this->assertFalse( has_action( 'post_row_actions', array( Publicize_Setup::class, 'add_share_action' ) ) );
@@ -114,13 +138,15 @@ class Share_Action_Test extends BaseTestCase {
 	 * Test Share action filter is NOT added on non-edit screens.
 	 */
 	public function test_no_share_action_on_non_edit_screen() {
+		// Set up a plan that supports republicize.
+		$plan                       = Current_Plan::PLAN_DATA['free'];
+		$plan['features']['active'] = array( 'republicize' );
+		update_option( Current_Plan::PLAN_OPTION, $plan, true );
+
 		$current_screen = (object) array(
 			'base'      => 'edit-tags',
 			'post_type' => 'post',
 		);
-
-		// Enable via filter.
-		add_filter( 'jetpack_post_list_display_share_action', '__return_true' );
 
 		Publicize_Setup::add_filters_and_actions_for_screen( $current_screen );
 
@@ -131,6 +157,11 @@ class Share_Action_Test extends BaseTestCase {
 	 * Test Share action filter is NOT added for post types that don't support publicize.
 	 */
 	public function test_no_share_action_for_non_publicize_post_type() {
+		// Set up a plan that supports republicize.
+		$plan                       = Current_Plan::PLAN_DATA['free'];
+		$plan['features']['active'] = array( 'republicize' );
+		update_option( Current_Plan::PLAN_OPTION, $plan, true );
+
 		// Register CPT without publicize support (max 20 chars for post type name).
 		register_post_type(
 			'test_no_pub_cpt',
@@ -144,9 +175,6 @@ class Share_Action_Test extends BaseTestCase {
 			'base'      => 'edit',
 			'post_type' => 'test_no_pub_cpt',
 		);
-
-		// Enable via filter.
-		add_filter( 'jetpack_post_list_display_share_action', '__return_true' );
 
 		Publicize_Setup::add_filters_and_actions_for_screen( $current_screen );
 

--- a/projects/packages/publicize/tests/php/Share_Action_Test.php
+++ b/projects/packages/publicize/tests/php/Share_Action_Test.php
@@ -1,0 +1,132 @@
+<?php
+/**
+ * Share action testing.
+ *
+ * @package automattic/jetpack-publicize
+ */
+
+namespace Automattic\Jetpack\Publicize;
+
+use WorDBless\BaseTestCase;
+
+/**
+ * Share action testing.
+ */
+class Share_Action_Test extends BaseTestCase {
+
+	/**
+	 * Set up before each test.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		// Reset filters before each test.
+		remove_all_filters( 'post_row_actions' );
+		remove_all_filters( 'page_row_actions' );
+		remove_all_filters( 'jetpack_post_list_display_share_action' );
+	}
+
+	/**
+	 * Test Share action filter is added for post types supporting publicize when filter is enabled.
+	 */
+	public function test_add_share_action_for_publicize_post_type() {
+		// Register CPT with publicize support.
+		register_post_type(
+			'test_pub_cpt',
+			array(
+				'show_in_rest' => true,
+				'supports'     => array( 'editor', 'publicize' ),
+			)
+		);
+
+		$current_screen = (object) array(
+			'base'      => 'edit',
+			'post_type' => 'test_pub_cpt',
+		);
+
+		// Enable via filter.
+		add_filter( 'jetpack_post_list_display_share_action', '__return_true' );
+
+		Publicize_Setup::add_filters_and_actions_for_screen( $current_screen );
+
+		$this->assertNotFalse( has_action( 'post_row_actions', array( Publicize_Setup::class, 'add_share_action' ) ) );
+		$this->assertNotFalse( has_action( 'page_row_actions', array( Publicize_Setup::class, 'add_share_action' ) ) );
+	}
+
+	/**
+	 * Test Share action filter is NOT added when filter returns false and no plan support.
+	 */
+	public function test_no_share_action_when_disabled() {
+		$current_screen = (object) array(
+			'base'      => 'edit',
+			'post_type' => 'post',
+		);
+
+		// Filter defaults to false, no plan support.
+		Publicize_Setup::add_filters_and_actions_for_screen( $current_screen );
+
+		$this->assertFalse( has_action( 'post_row_actions', array( Publicize_Setup::class, 'add_share_action' ) ) );
+	}
+
+	/**
+	 * Test Share action is not added for draft posts.
+	 */
+	public function test_share_action_not_added_for_draft_posts() {
+		$draft_post_id = wp_insert_post(
+			array(
+				'post_title'  => 'Test Draft Post',
+				'post_status' => 'draft',
+				'post_type'   => 'post',
+			)
+		);
+		$draft_post    = get_post( $draft_post_id );
+		$post_actions  = array();
+
+		$result = Publicize_Setup::add_share_action( $post_actions, $draft_post );
+
+		$this->assertArrayNotHasKey( 'share', $result );
+	}
+
+	/**
+	 * Test Share action filter is NOT added on non-edit screens.
+	 */
+	public function test_no_share_action_on_non_edit_screen() {
+		$current_screen = (object) array(
+			'base'      => 'edit-tags',
+			'post_type' => 'post',
+		);
+
+		// Enable via filter.
+		add_filter( 'jetpack_post_list_display_share_action', '__return_true' );
+
+		Publicize_Setup::add_filters_and_actions_for_screen( $current_screen );
+
+		$this->assertFalse( has_action( 'post_row_actions', array( Publicize_Setup::class, 'add_share_action' ) ) );
+	}
+
+	/**
+	 * Test Share action filter is NOT added for post types that don't support publicize.
+	 */
+	public function test_no_share_action_for_non_publicize_post_type() {
+		// Register CPT without publicize support (max 20 chars for post type name).
+		register_post_type(
+			'test_no_pub_cpt',
+			array(
+				'show_in_rest' => true,
+				'supports'     => array( 'editor' ),
+			)
+		);
+
+		$current_screen = (object) array(
+			'base'      => 'edit',
+			'post_type' => 'test_no_pub_cpt',
+		);
+
+		// Enable via filter.
+		add_filter( 'jetpack_post_list_display_share_action', '__return_true' );
+
+		Publicize_Setup::add_filters_and_actions_for_screen( $current_screen );
+
+		$this->assertFalse( has_action( 'post_row_actions', array( Publicize_Setup::class, 'add_share_action' ) ) );
+	}
+}

--- a/projects/packages/publicize/tests/php/Share_Action_Test.php
+++ b/projects/packages/publicize/tests/php/Share_Action_Test.php
@@ -7,6 +7,7 @@
 
 namespace Automattic\Jetpack\Publicize;
 
+use Automattic\Jetpack\Current_Plan;
 use WorDBless\BaseTestCase;
 
 /**
@@ -24,6 +25,28 @@ class Share_Action_Test extends BaseTestCase {
 		remove_all_filters( 'post_row_actions' );
 		remove_all_filters( 'page_row_actions' );
 		remove_all_filters( 'jetpack_post_list_display_share_action' );
+	}
+
+	/**
+	 * Tear down after each test.
+	 */
+	public function tear_down() {
+		// Unregister test post types.
+		unregister_post_type( 'test_pub_cpt' );
+		unregister_post_type( 'test_no_pub_cpt' );
+
+		// Clean up filters.
+		remove_all_filters( 'post_row_actions' );
+		remove_all_filters( 'page_row_actions' );
+		remove_all_filters( 'jetpack_post_list_display_share_action' );
+
+		// Clear the Current_Plan cache to avoid affecting other tests.
+		$reflection = new \ReflectionClass( Current_Plan::class );
+		$property   = $reflection->getProperty( 'active_plan_cache' );
+		$property->setAccessible( true );
+		$property->setValue( null, null );
+
+		parent::tear_down();
 	}
 
 	/**

--- a/projects/packages/publicize/tests/php/Share_Action_Test.php
+++ b/projects/packages/publicize/tests/php/Share_Action_Test.php
@@ -43,7 +43,6 @@ class Share_Action_Test extends BaseTestCase {
 		// Clear the Current_Plan cache to avoid affecting other tests.
 		$reflection = new \ReflectionClass( Current_Plan::class );
 		$property   = $reflection->getProperty( 'active_plan_cache' );
-		$property->setAccessible( true );
 		$property->setValue( null, null );
 
 		parent::tear_down();

--- a/projects/packages/publicize/tests/php/Share_Action_Test.php
+++ b/projects/packages/publicize/tests/php/Share_Action_Test.php
@@ -43,6 +43,10 @@ class Share_Action_Test extends BaseTestCase {
 		// Clear the Current_Plan cache to avoid affecting other tests.
 		$reflection = new \ReflectionClass( Current_Plan::class );
 		$property   = $reflection->getProperty( 'active_plan_cache' );
+		// @todo Remove this call once we no longer need to support PHP <8.1.
+		if ( PHP_VERSION_ID < 80100 ) {
+			$property->setAccessible( true );
+		}
 		$property->setValue( null, null );
 
 		parent::tear_down();

--- a/projects/plugins/social/changelog/remove-redundant-share-action-filter
+++ b/projects/plugins/social/changelog/remove-redundant-share-action-filter
@@ -1,0 +1,3 @@
+Significance: patch
+Type: removed
+Comment: Remove redundant jetpack_post_list_display_share_action filter hook from Social Notes.

--- a/projects/plugins/social/src/class-note.php
+++ b/projects/plugins/social/src/class-note.php
@@ -83,18 +83,6 @@ class Note {
 		}
 
 		add_filter( 'the_title', array( $this, 'override_empty_title' ), 10, 2 );
-		add_filter( 'jetpack_post_list_display_share_action', array( $this, 'show_share_action' ), 10, 2 );
-	}
-
-	/**
-	 * Used as a filter to determine if we should show the share action on the post list screen.
-	 *
-	 * @param bool   $show_share The current filter value.
-	 * @param string $post_type The current post type on the post list screen.
-	 * @return bool Whether to show the share action.
-	 */
-	public function show_share_action( $show_share, $post_type ) {
-		return self::JETPACK_SOCIAL_NOTE_CPT === $post_type || $show_share;
 	}
 
 	/**

--- a/projects/plugins/wpcomsh/changelog/remove-redundant-share-action-filter
+++ b/projects/plugins/wpcomsh/changelog/remove-redundant-share-action-filter
@@ -1,0 +1,3 @@
+Significance: patch
+Type: removed
+Comment: Remove redundant jetpack_post_list_display_share_action filter hook.

--- a/projects/plugins/wpcomsh/feature-plugins/post-list.php
+++ b/projects/plugins/wpcomsh/feature-plugins/post-list.php
@@ -16,7 +16,6 @@ use Automattic\Jetpack\Config;
  */
 function wpcomsh_post_list_init() {
 	add_filter( 'jetpack_block_editor_republicize_feature', '__return_true' );
-	wpcomsh_maybe_enable_share_action();
 
 	$config = new Config();
 	$config->ensure( 'post_list' );
@@ -24,26 +23,3 @@ function wpcomsh_post_list_init() {
 }
 
 add_action( 'admin_init', 'wpcomsh_post_list_init', 1 );
-
-/**
- * Checks if Republicize is available and that the classic editor plugin
- * in not active. If so, then it enables the Share post action in the
- * post list.
- */
-function wpcomsh_maybe_enable_share_action() {
-	// Jetpack isn't available. Unlikely if we got here, but worth checking.
-	if ( ! class_exists( 'Jetpack' ) || ! class_exists( 'Jetpack_Gutenberg' ) ) {
-		return;
-	}
-
-	if ( Jetpack::is_plugin_active( 'classic-editor/classic-editor.php' ) ||
-		array_key_exists( 'classic-editor.php', get_mu_plugins() ) ) {
-		return;
-	}
-
-	// Needed to ensure that the jetpack_register_gutenberg_extensions action has fired.
-	Jetpack_Gutenberg::get_cached_availability();
-	if ( Jetpack_Gutenberg::is_available( 'republicize' ) ) {
-		add_filter( 'jetpack_post_list_display_share_action', '__return_true' );
-	}
-}


### PR DESCRIPTION
Fixes SOCIAL-16

## Proposed changes:

* Move the Share post action from the `post-list` package to the `Publicize` package for better discoverability
* The Share action now appears automatically for users with plans that support the `republicize` feature
* Maintain backward compatibility with the existing `jetpack_post_list_display_share_action` filter

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

1. On a site with a plan that supports `republicize` (Jetpack Social or higher):
   - Go to Posts > All Posts
   - Hover over a published post
   - Verify the "Share" action appears in the row actions
   - Click Share and verify it opens the editor with the share panel

2. On a site without `republicize` support:
   - Verify the Share action does NOT appear by default
   - Add `add_filter( 'jetpack_post_list_display_share_action', '__return_true' );` to enable it
   - Verify the Share action now appears (backward compatibility)

3. Verify the Share action only appears for:
   - Published posts (not drafts)
   - Post types that support `publicize`
   - Post types that use the block editor
   - Social Notes