### PR TITLE
 Forms: Fix button padding

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-button-padding
+++ b/projects/packages/forms/changelog/fix-forms-button-padding
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: Fix button padding

--- a/projects/packages/forms/src/blocks/contact-form/util/form-styles.js
+++ b/projects/packages/forms/src/blocks/contact-form/util/form-styles.js
@@ -100,6 +100,7 @@ window.jetpackForms.generateStyleVariables = function ( formNode ) {
 		borderColor: buttonPrimaryBorderColor,
 		backgroundColor: buttonPrimaryBackgroundColor,
 		color: buttonPrimaryColor,
+		padding: buttonPrimaryPadding,
 	} = window.getComputedStyle( buttonPrimaryNode );
 
 	const {
@@ -165,6 +166,7 @@ window.jetpackForms.generateStyleVariables = function ( formNode ) {
 		'--jetpack--contact-form--button-primary--background-color': buttonPrimaryBackgroundColor,
 		'--jetpack--contact-form--button-primary--border': buttonPrimaryBorder,
 		'--jetpack--contact-form--button-primary--border-color': buttonPrimaryBorderColor,
+		'--jetpack--contact-form--button-primary--padding': buttonPrimaryPadding,
 		'--jetpack--contact-form--button-outline--padding': buttonOutlinePadding,
 		'--jetpack--contact-form--button-outline--border': buttonOutlineBorder,
 		'--jetpack--contact-form--button-outline--background-color': buttonOutlineBackgroundColor,

--- a/projects/packages/forms/src/contact-form/css/grunion.scss
+++ b/projects/packages/forms/src/contact-form/css/grunion.scss
@@ -400,9 +400,8 @@ that needs to mimic the input element styles */
 
 	.wp-block-button__link {
 		min-height: var(--jetpack--contact-form--input-height, auto);
-		padding: var(--jetpack--contact-form--input-padding);
+		padding: var(--jetpack--contact-form--button-primary--padding);
 	}
-
 }
 
 .wp-block-jetpack-contact-form .wp-block-jetpack-button.aligncenter {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes FORMS-468

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Compute the padding values from a button to set the style variable for form button padding instead of using computed input padding values

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Use a theme that sets different padding values for left and right on input elements of type "text", or set a custom CSS to force this
* Add a form and publish it

Before the PR:
- The Submit button would have weird padding values

After the PR:
- The Submit button should have the same padding as other buttons, usually centered


| Before | After |
| - | - |
| <img width="674" height="555" alt="Screenshot from 2025-12-16 20-36-37" src="https://github.com/user-attachments/assets/682a252f-2233-4f3d-987a-be838259c672" /> | <img width="674" height="555" alt="Screenshot from 2025-12-16 20-44-17" src="https://github.com/user-attachments/assets/edde99b9-9882-4b1f-8de9-38b2c90273f4" /> |


