### PR TITLE
Components: NavigatorModal | Remove extra padding for screen component following recent Gutenberg changes

### DIFF
--- a/projects/js-packages/components/changelog/fix-components-navigator-modal-screen-padding
+++ b/projects/js-packages/components/changelog/fix-components-navigator-modal-screen-padding
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+NavigatorModal: Remove extra padding for screen component following recent Gutenberg changes.

--- a/projects/js-packages/components/components/navigator-modal/styles.module.scss
+++ b/projects/js-packages/components/components/navigator-modal/styles.module.scss
@@ -26,6 +26,7 @@
 
 .screen {
 	height: 100%;
+	padding: 0;
 
 	.header {
 		display: flex;


### PR DESCRIPTION
On Jetpack sites with the Gutenberg plugin active and on Simple sites, the unified Navigator modal shows an extra 12px padding due to recent Gutenberg changes.

Fixes SOCIAL-276

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Remove the padding for NavigatorModal screen

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Activate the Gutenberg plugin
* Add the blog sticker to your site - `add_blog_sticker( 'jetpack-social-unified-ui-v1', null, null, <your-blog-id> );`
* On trunk, go to the post editor
* Open Jetpack sidebar
* Open preview or resharing modal
* Confirm that you see the extra padding in the modal
* Now check out this branch
* Confirm that there is no unnecessary padding

| Before | After |
|--------|--------|
| <img width="228" height="731" alt="Screenshot 2025-12-17 at 2 03 01 PM" src="https://github.com/user-attachments/assets/0b713e8a-735c-4423-94f5-2789e60fb26d" /> | <img width="227" height="725" alt="Screenshot 2025-12-17 at 2 09 50 PM" src="https://github.com/user-attachments/assets/359744c5-f0a8-4cd8-93d6-ca4d00ab45a2" /> | 
