### PR TITLE
Social: Replace the resharing upgrade nudge with the core Notice component with action

### DIFF
--- a/projects/js-packages/publicize-components/changelog/fix-social-resharing-upgrade-notice
+++ b/projects/js-packages/publicize-components/changelog/fix-social-resharing-upgrade-notice
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Replace resharing upgrade nudge with Notice component with action.

--- a/projects/js-packages/publicize-components/src/components/panel/upsell.tsx
+++ b/projects/js-packages/publicize-components/src/components/panel/upsell.tsx
@@ -1,6 +1,5 @@
-import { isWpcomPlatformSite } from '@automattic/jetpack-script-data';
 import { getRequiredPlan, useUpgradeFlow } from '@automattic/jetpack-shared-extension-utils';
-import { ExternalLink, Notice } from '@wordpress/components';
+import { Notice } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
 import { __, _x, sprintf } from '@wordpress/i18n';
@@ -12,7 +11,7 @@ import usePublicizeConfig from '../../hooks/use-publicize-config';
  * @return The upsell notice.
  */
 export function UpsellNotice() {
-	const { isRePublicizeUpgradableViaUpsell, isRePublicizeFeatureAvailable } = usePublicizeConfig();
+	const { isRePublicizeFeatureAvailable } = usePublicizeConfig();
 	const requiredPlan = getRequiredPlan( 'republicize' );
 	const [ , goToCheckoutPage, isRedirecting, planData ] = useUpgradeFlow( `${ requiredPlan }` );
 	const isPostPublished = useSelect( select => select( editorStore ).isCurrentPostPublished(), [] );
@@ -29,43 +28,6 @@ export function UpsellNotice() {
 
 	// Define plan name, with a fallback value.
 	const planName = planData?.product_name || __( 'paid', 'jetpack-publicize-components' );
-
-	const isPureJetpackSite = ! isWpcomPlatformSite();
-	const upgradeFeatureTitle = isPureJetpackSite
-		? __( 'Re-sharing your content', 'jetpack-publicize-components' )
-		: _x( 'Share Your Content Again', '', 'jetpack-publicize-components' );
-
-	// Doc page URL.
-	const docPageUrl = isPureJetpackSite
-		? 'https://jetpack.com/support/jetpack-social/#re-sharing-your-content'
-		: 'https://wordpress.com/support/jetpack-social/#share-your-content-again';
-
-	/*
-	 * Render an info message when the feature is not available
-	 * and when it shouldn't show upgrade notices.
-	 * (pure Jetpack sites, for instance).
-	 */
-	if ( ! isRePublicizeFeatureAvailable && ! isRePublicizeUpgradableViaUpsell ) {
-		return (
-			<div className="jetpack-publicize__upsell">
-				<strong>{ upgradeFeatureTitle }</strong>
-
-				<br />
-
-				{ sprintf(
-					/* translators: %s: the product name of the plan. */
-					__( 'This feature is for sites with a %s plan.', 'jetpack-publicize-components' ),
-					planName
-				) }
-
-				<br />
-
-				<ExternalLink href={ docPageUrl }>
-					{ __( 'More information.', 'jetpack-publicize-components' ) }
-				</ExternalLink>
-			</div>
-		);
-	}
 
 	return (
 		<Notice

--- a/projects/js-packages/publicize-components/src/components/panel/upsell.tsx
+++ b/projects/js-packages/publicize-components/src/components/panel/upsell.tsx
@@ -27,7 +27,9 @@ export function UpsellNotice() {
 	}
 
 	// Define plan name, with a fallback value.
-	const planName = planData?.product_name || __( 'paid', 'jetpack-publicize-components' );
+	const planName =
+		planData?.product_name ||
+		_x( 'paid', 'The plan type - paid vs free', 'jetpack-publicize-components' );
 
 	return (
 		<Notice

--- a/projects/js-packages/publicize-components/src/components/panel/upsell.tsx
+++ b/projects/js-packages/publicize-components/src/components/panel/upsell.tsx
@@ -1,11 +1,9 @@
 import { isWpcomPlatformSite } from '@automattic/jetpack-script-data';
 import { getRequiredPlan, useUpgradeFlow } from '@automattic/jetpack-shared-extension-utils';
-import { Button, ExternalLink } from '@wordpress/components';
+import { ExternalLink, Notice } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
 import { __, _x, sprintf } from '@wordpress/i18n';
-import { external } from '@wordpress/icons';
-import clsx from 'clsx';
 import usePublicizeConfig from '../../hooks/use-publicize-config';
 
 /**
@@ -16,9 +14,7 @@ import usePublicizeConfig from '../../hooks/use-publicize-config';
 export function UpsellNotice() {
 	const { isRePublicizeUpgradableViaUpsell, isRePublicizeFeatureAvailable } = usePublicizeConfig();
 	const requiredPlan = getRequiredPlan( 'republicize' );
-	const [ checkoutUrl, goToCheckoutPage, isRedirecting, planData ] = useUpgradeFlow(
-		`${ requiredPlan }`
-	);
+	const [ , goToCheckoutPage, isRedirecting, planData ] = useUpgradeFlow( `${ requiredPlan }` );
 	const isPostPublished = useSelect( select => select( editorStore ).isCurrentPostPublished(), [] );
 
 	/*
@@ -43,8 +39,6 @@ export function UpsellNotice() {
 	const docPageUrl = isPureJetpackSite
 		? 'https://jetpack.com/support/jetpack-social/#re-sharing-your-content'
 		: 'https://wordpress.com/support/jetpack-social/#share-your-content-again';
-
-	const buttonText = __( 'Upgrade now', 'jetpack-publicize-components' );
 
 	/*
 	 * Render an info message when the feature is not available
@@ -74,30 +68,27 @@ export function UpsellNotice() {
 	}
 
 	return (
-		<div className="jetpack-publicize__upsell">
-			<div className="jetpack-publicize__upsell-description">
-				{ sprintf(
-					/* translators: %s: the product name of the plan. */
-					__(
-						'To re-share a post, you need to upgrade to the %s plan',
-						'jetpack-publicize-components'
-					),
-					planName
-				) }
-			</div>
-
-			<Button
-				href={ isRedirecting ? null : checkoutUrl } // Only for server-side rendering, since onClick doesn't work there.
-				onClick={ goToCheckoutPage }
-				target="_top"
-				icon={ external }
-				className={ clsx( 'jetpack-publicize__upsell-button is-primary', {
-					'jetpack-upgrade-plan__hidden': ! checkoutUrl,
-				} ) }
-				isBusy={ isRedirecting }
-			>
-				{ isRedirecting ? __( 'Redirecting…', 'jetpack-publicize-components' ) : buttonText }
-			</Button>
-		</div>
+		<Notice
+			status="info"
+			isDismissible={ false }
+			actions={ [
+				{
+					label: isRedirecting
+						? __( 'Redirecting…', 'jetpack-publicize-components' )
+						: _x( 'Upgrade now', 'Upgrade CTA', 'jetpack-publicize-components' ),
+					variant: 'primary',
+					onClick: goToCheckoutPage,
+				},
+			] }
+		>
+			{ sprintf(
+				/* translators: %s: the product name of the plan. */
+				__(
+					'To re-share a post, you need to upgrade to the %s plan',
+					'jetpack-publicize-components'
+				),
+				planName
+			) }
+		</Notice>
 	);
 }

--- a/projects/js-packages/publicize-components/src/components/panel/upsell.tsx
+++ b/projects/js-packages/publicize-components/src/components/panel/upsell.tsx
@@ -31,15 +31,16 @@ export function UpsellNotice() {
 		planData?.product_name ||
 		_x( 'paid', 'The plan type - paid vs free', 'jetpack-publicize-components' );
 
+	// This is here to avoid the build minification error
+	const buttonText = __( 'Upgrade now', 'jetpack-publicize-components' );
+
 	return (
 		<Notice
 			status="info"
 			isDismissible={ false }
 			actions={ [
 				{
-					label: isRedirecting
-						? __( 'Redirecting…', 'jetpack-publicize-components' )
-						: _x( 'Upgrade now', 'Upgrade CTA', 'jetpack-publicize-components' ),
+					label: isRedirecting ? __( 'Redirecting…', 'jetpack-publicize-components' ) : buttonText,
 					variant: 'primary',
 					onClick: goToCheckoutPage,
 				},


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

On Simple sites with a free plan, resharing is not available and an upgrade notice is shown. This notice does not use the Core Notice component. It rather uses some custom component.

Completes SOCIAL-275

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Replace the resharing upgrade nudge with the core Notice component with action
* Remove the unnecessary condition of resharing not being upgradable. Resharing has been made available to all sites except Simple free sites, and thus, this condition is no longer used.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this PR to your sandbox
* Point your Simple site with a free plan to your sandbox along with the public API
* Edit an exisitng post on the site
* Open Jetpack sidebar
* Confirm that the resharing upgrade now shows the Notice instead of our own implementation.

| Before | After |
|--------|--------|
| <img width="276" height="220" alt="Screenshot 2025-12-17 at 3 02 10 PM" src="https://github.com/user-attachments/assets/10e26301-8553-47f7-b0d5-779c6cb2e8a8" /> | <img width="274" height="266" alt="Screenshot 2025-12-17 at 3 01 19 PM" src="https://github.com/user-attachments/assets/31e4d17b-6801-41fa-b01b-12be324de79f" /> | 

**Note:** The spacing for the core Notice has already been fixed in [#69430](https://github.com/WordPress/gutenberg/pull/69430) and should be automatically be available in the next Gutenber/Core release.
<img width="737" height="538" alt="Image" src="https://github.com/user-attachments/assets/9196168c-d5a1-44f4-a231-65f4e9cc18db" />
