### PR TITLE
Social: Integrate post list share action with the unified modal

### DIFF
--- a/projects/js-packages/publicize-components/changelog/update-social-integrate-post-list-share-action-n-unified-modal
+++ b/projects/js-packages/publicize-components/changelog/update-social-integrate-post-list-share-action-n-unified-modal
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Integrate post list share action with the unified modal.

--- a/projects/js-packages/publicize-components/src/components/block-editor/shared-utils.ts
+++ b/projects/js-packages/publicize-components/src/components/block-editor/shared-utils.ts
@@ -1,6 +1,8 @@
+import { siteHasFeature } from '@automattic/jetpack-script-data';
 import { dispatch } from '@wordpress/data';
 import { store as interfaceStore } from '@wordpress/interface';
 import { store as socialStore } from '../../social-store';
+import { features } from '../../utils';
 
 /**
  * Handle a particular Jetpack Editor action.
@@ -21,8 +23,13 @@ export function handleSharePostAction(
 	// First open the sidebar
 	enableComplementaryArea( 'core', sidebarToOpen );
 
+	const { openSharePostModal, openUnifiedModal } = dispatch( socialStore );
 	// Then open the share post modal
-	dispatch( socialStore ).openSharePostModal();
+	if ( siteHasFeature( features.UNIFIED_UI_V1 ) ) {
+		openUnifiedModal();
+	} else {
+		openSharePostModal();
+	}
 
 	return removeQueryArg;
 }


### PR DESCRIPTION
We allow users to click on the "Share" link from the post list screen which redirects to the editor with resharing modal open.

We need to update that logic to make it work with the unified modal via the feature flag.

Related to #46323

Closes SOCIAL-277

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Update `handleSharePostAction` to open the unified modal when the `UNIFIED_UI_V1` feature is enabled, otherwise fallback to the original share post modal.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Activate Social plugin or add this snipped somewhere
```php
add_filter('jetpack_post_list_display_share_action', '__return_true', 20 );
```
* Go to post list page
* Hover over a published post
* Click on "Share" action
* Confirm that it opens the editor with unified share post modal open