### PR TITLE
Beta Tester: Make searching branch name case-insensitive

### DIFF
--- a/projects/plugins/beta/changelog/fix-beta-uppercase-search
+++ b/projects/plugins/beta/changelog/fix-beta-uppercase-search
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix branch search not working for uppercase branch names.

--- a/projects/plugins/beta/src/admin/admin.js
+++ b/projects/plugins/beta/src/admin/admin.js
@@ -221,8 +221,14 @@
 	 * @return {string} Search result with span wrapping matching word (search input) for styling.
 	 */
 	function highlight_word( word, phrase ) {
-		const replace = '<span class="highlight">' + word + '</span>';
-		return phrase.replace( word, replace );
+		// Escape special regex characters in the search word
+		const escapedWord = word.replace( /[.*+?^${}()|[\]\\]/g, '\\$&' );
+		// Create a case-insensitive regex to find all occurrences in the phrase
+		const regex = new RegExp( escapedWord, 'gi' );
+		// Replace with the matched text (preserving original case) wrapped in a span
+		return phrase.replace( regex, function ( match ) {
+			return '<span class="highlight">' + match + '</span>';
+		} );
 	}
 
 	/**

--- a/projects/plugins/beta/src/admin/admin.js
+++ b/projects/plugins/beta/src/admin/admin.js
@@ -95,7 +95,7 @@
 		const header_text = /^ *[0-9]+ *$/.test( search_for ) ? `${ found.key }` : found.header;
 		const class_selector = '.branch-card-header';
 
-		const found_position = header_text.indexOf( search_for );
+		const found_position = header_text.toLowerCase().indexOf( search_for.toLowerCase() );
 		if ( -1 === found_position ) {
 			hide( element );
 			return;


### PR DESCRIPTION
Jetpack Beta Tester plugin can’t find the branch name when the name is uppercase. 

Slack: p1765970484988619-slack-CDLH4C1UZ

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Make searching branch name case-insensitive in the Beta Tester plugin

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to Jetpack > Beta Tester
* Select Jetpack
* Search for both `"SOCIAL-16"` and `"social-16"`
* Confirm that the branch shows up for both cases.
* Confirm that the word highlight works fine.