### PR TITLE
Scan: Replace inline onclick with `target="_blank"` for CSP compliance

### DIFF
--- a/projects/plugins/jetpack/changelog/JETPACK-1146
+++ b/projects/plugins/jetpack/changelog/JETPACK-1146
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Scan: Replace inline onclick handler with target="_blank" for CSP compliance in admin bar notice.

--- a/projects/plugins/jetpack/modules/scan/class-admin-bar-notice.php
+++ b/projects/plugins/jetpack/modules/scan/class-admin-bar-notice.php
@@ -177,6 +177,7 @@ class Admin_Bar_Notice {
 		if ( $has_threats ) {
 			$node['href']           = esc_url( Redirect::get_url( 'calypso-scanner' ) );
 			$node['meta']['target'] = '_blank';
+			$node['meta']['rel']    = 'noopener noreferrer';
 			$node['meta']['class']  = 'error';
 			$node['title']          = sprintf(
 				esc_html(

--- a/projects/plugins/jetpack/modules/scan/class-admin-bar-notice.php
+++ b/projects/plugins/jetpack/modules/scan/class-admin-bar-notice.php
@@ -175,10 +175,10 @@ class Admin_Bar_Notice {
 		);
 
 		if ( $has_threats ) {
-			$node['href']            = esc_url( Redirect::get_url( 'calypso-scanner' ) );
-			$node['meta']['onclick'] = 'window.open( this.href ); return false;';
-			$node['meta']['class']   = 'error';
-			$node['title']           = sprintf(
+			$node['href']           = esc_url( Redirect::get_url( 'calypso-scanner' ) );
+			$node['meta']['target'] = '_blank';
+			$node['meta']['class']  = 'error';
+			$node['title']          = sprintf(
 				esc_html(
 				/* translators: %s is the alert icon */
 					_n( '%s Threat found', '%s Threats found', $this->get_threat_count(), 'jetpack' )


### PR DESCRIPTION
Fixes JETPACK-1146
Fixes  #46304

## Proposed changes:

* Replace inline `onclick="window.open( this.href ); return false;"` with `target="_blank"` in the Scan admin bar notice.

### Why this works:

The original inline `onclick` handler was used to open the external Calypso scanner URL in a new tab. However, inline event handlers violate Content Security Policy (CSP) because they require `unsafe-inline` in the script-src directive.

The HTML `target="_blank"` attribute achieves the same behavior natively, both result in: user clicks → link opens in new tab. The HTML approach is CSP-compliant and works without JavaScript.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

N/A - Security/CSP compliance fix

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

1. **Deactivate the Protect plugin** if active (it has its own admin bar notice and will prevent Scan's notice from showing)

2. Add this snippet to `tools/docker/mu-plugins/0-snippets.php` to simulate threat detection:
   ```php
   // Test JETPACK-1146: Fake scan threats for admin bar notice testing.
   add_action(
       'init',
       function () {
           $fake_scan_state = (object) array(
               'threats' => array( (object) array( 'id' => 1, 'name' => 'Test threat' ) ),
           );
           set_transient( 'jetpack_scan_state', $fake_scan_state );
       }
   );
   ```

3. Visit any wp-admin page

4. Look for the red shield icon with "Threat found" in the admin bar (top right)

<img width="702" height="152" alt="CleanShot 2025-12-17 at 14 17 47@2x" src="https://github.com/user-attachments/assets/6177023a-9d7c-47a0-a45c-987ceec7eef8" />


6. Inspect the HTML element and verify:
   - ✅ `target="_blank"` is present on the link
   - ✅ No `onclick` attribute exists

7. Click the link and verify it opens in a new tab

8. **Remove the test snippet** after testing