### PR TITLE
Social: Fix empty state mix up when all connections are removed after attaching an image.

### DIFF
--- a/projects/js-packages/publicize-components/changelog/fix-social-empty-state-mix-up
+++ b/projects/js-packages/publicize-components/changelog/fix-social-empty-state-mix-up
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix empty state mix up when all connections are removed after attaching an image.

--- a/projects/js-packages/publicize-components/src/components/form/empty-state.tsx
+++ b/projects/js-packages/publicize-components/src/components/form/empty-state.tsx
@@ -2,11 +2,8 @@
 import { Flex, FlexBlock, PanelRow, __experimentalText as Text } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import illustration from '../../assets/networks-illustration.png';
-import usePublicizeConfig from '../../hooks/use-publicize-config';
-import useSocialMediaConnections from '../../hooks/use-social-media-connections';
 import { SettingsButton } from './settings-button';
 import styles from './styles.module.scss';
-import { UserConnectionNotice } from './user-connection-notice';
 
 /**
  * Empty state component for Publicize form.
@@ -14,37 +11,19 @@ import { UserConnectionNotice } from './user-connection-notice';
  * @return React element or null
  */
 export function EmptyState() {
-	const { hasConnections } = useSocialMediaConnections();
-	const { needsUserConnection } = usePublicizeConfig();
-
-	if ( hasConnections && ! needsUserConnection ) {
-		return null;
-	}
-
 	return (
 		<PanelRow className={ styles[ 'empty-state' ] }>
 			<Flex justify="center" direction="column" align="center" gap={ 4 }>
-				{
-					// Do not show illustration if there are connections
-					! hasConnections && <img className={ styles.illustration } src={ illustration } alt="" />
-				}
-				{ needsUserConnection ? (
-					<UserConnectionNotice />
-				) : (
-					<>
-						<Text className={ styles[ 'connect-account-text' ] }>
-							{ __(
-								'Automatically share your website content to your favorite social media platforms, from one place.',
-								'jetpack-publicize-components'
-							) }
-						</Text>
-						<FlexBlock className={ styles[ 'connect-account-button' ] }>
-							<SettingsButton
-								label={ __( 'Connect your accounts', 'jetpack-publicize-components' ) }
-							/>
-						</FlexBlock>
-					</>
-				) }
+				<img className={ styles.illustration } src={ illustration } alt="" />
+				<Text className={ styles[ 'connect-account-text' ] }>
+					{ __(
+						'Automatically share your website content to your favorite social media platforms, from one place.',
+						'jetpack-publicize-components'
+					) }
+				</Text>
+				<FlexBlock className={ styles[ 'connect-account-button' ] }>
+					<SettingsButton label={ __( 'Connect your accounts', 'jetpack-publicize-components' ) } />
+				</FlexBlock>
 			</Flex>
 		</PanelRow>
 	);

--- a/projects/js-packages/publicize-components/src/components/form/index.tsx
+++ b/projects/js-packages/publicize-components/src/components/form/index.tsx
@@ -42,6 +42,7 @@ export default function PublicizeForm() {
 
 	const showSharePostForm =
 		isPublicizeEnabled &&
+		! isPublicizeDisabledBySitePlan &&
 		( hasEnabledConnections ||
 			// We show the form if there is any attached media or validation errors to let the user
 			// fix the issues with uploading an image.
@@ -66,14 +67,9 @@ export default function PublicizeForm() {
 						<SocialPostModal />
 					) }
 					<EnhancedFeaturesNudge />
+					{ showSharePostForm && <SharePostForm analyticsData={ { location: 'editor' } } /> }
 				</>
 			) : null }
-
-			{ ! isPublicizeDisabledBySitePlan && (
-				<Fragment>
-					{ showSharePostForm && <SharePostForm analyticsData={ { location: 'editor' } } /> }
-				</Fragment>
-			) }
 		</Wrapper>
 	);
 }

--- a/projects/js-packages/publicize-components/src/components/form/index.tsx
+++ b/projects/js-packages/publicize-components/src/components/form/index.tsx
@@ -21,6 +21,7 @@ import { EmptyState } from './empty-state';
 import { EnhancedFeaturesNudge } from './enhanced-features-nudge';
 import { PreviewPostsTrigger } from './preview-posts-trigger';
 import { SharePostForm } from './share-post-form';
+import { UserConnectionNotice } from './user-connection-notice';
 
 /**
  * The Publicize form component. It contains the connection list, and the message box.
@@ -29,7 +30,8 @@ import { SharePostForm } from './share-post-form';
  */
 export default function PublicizeForm() {
 	const { hasConnections, hasEnabledConnections, connections } = useSocialMediaConnections();
-	const { isPublicizeEnabled, isPublicizeDisabledBySitePlan } = usePublicizeConfig();
+	const { isPublicizeEnabled, isPublicizeDisabledBySitePlan, needsUserConnection } =
+		usePublicizeConfig();
 	const { attachedMedia } = useAttachedMedia();
 	const featuredImageId = useFeaturedImage();
 
@@ -48,25 +50,21 @@ export default function PublicizeForm() {
 			attachedMedia.length > 0 ||
 			( Object.keys( validationErrors ).length !== 0 && ! isConvertible ) );
 
+	// If there are no connections, show the empty state or user connection notice.
+	if ( ! hasConnections ) {
+		// User connection has priority over empty state.
+		return needsUserConnection ? <UserConnectionNotice /> : <EmptyState />;
+	}
+
 	return (
 		<>
-			{ hasConnections ? (
-				<PanelRow>
-					<ConnectionsList />
-				</PanelRow>
-			) : null }
-			<EmptyState />
-			{ hasConnections ? (
-				<>
-					{ siteHasFeature( features.UNIFIED_UI_V1 ) ? (
-						<PreviewPostsTrigger />
-					) : (
-						<SocialPostModal />
-					) }
-					<EnhancedFeaturesNudge />
-					{ showSharePostForm && <SharePostForm analyticsData={ { location: 'editor' } } /> }
-				</>
-			) : null }
+			<PanelRow>
+				<ConnectionsList />
+			</PanelRow>
+			{ needsUserConnection ? <UserConnectionNotice /> : null }
+			{ siteHasFeature( features.UNIFIED_UI_V1 ) ? <PreviewPostsTrigger /> : <SocialPostModal /> }
+			<EnhancedFeaturesNudge />
+			{ showSharePostForm && <SharePostForm analyticsData={ { location: 'editor' } } /> }
 		</>
 	);
 }

--- a/projects/js-packages/publicize-components/src/components/form/index.tsx
+++ b/projects/js-packages/publicize-components/src/components/form/index.tsx
@@ -7,8 +7,7 @@
  */
 
 import { siteHasFeature } from '@automattic/jetpack-script-data';
-import { Disabled, PanelRow } from '@wordpress/components';
-import { Fragment } from '@wordpress/element';
+import { PanelRow } from '@wordpress/components';
 import useAttachedMedia from '../../hooks/use-attached-media';
 import useFeaturedImage from '../../hooks/use-featured-image';
 import useMediaDetails from '../../hooks/use-media-details';
@@ -49,10 +48,8 @@ export default function PublicizeForm() {
 			attachedMedia.length > 0 ||
 			( Object.keys( validationErrors ).length !== 0 && ! isConvertible ) );
 
-	const Wrapper = isPublicizeDisabledBySitePlan ? Disabled : Fragment;
-
 	return (
-		<Wrapper>
+		<>
 			{ hasConnections ? (
 				<PanelRow>
 					<ConnectionsList />
@@ -70,6 +67,6 @@ export default function PublicizeForm() {
 					{ showSharePostForm && <SharePostForm analyticsData={ { location: 'editor' } } /> }
 				</>
 			) : null }
-		</Wrapper>
+		</>
 	);
 }


### PR DESCRIPTION
After saving a post with a custom social image and then removing all social media connections, the UI ends up in an incorrect state instead of showing the expected empty state.

Closes SOCIAL-278

This PR fixes a bug where the **empty state was being incorrectly displayed** when users removed all connections after attaching an image to a post. I simplified the logic for determining when to show the empty state, user connection notice, and the main Publicize form.

## Proposed changes:

### 1. Simplified `EmptyState` Component
- Removed all conditional logic from the component itself
- The component is now a pure presentational component that always renders the same content when used
- Removed dependency on `needsUserConnection` and `hasConnections` checks
- Parent components now control when to render it

### 2. Refactored `PublicizeForm` Component
I took this opportunity to clean up and simplify the `PublicizeForm` component
- Moved all display logic to a single, clear conditional flow at the top level
- Removed the unnecessary `Wrapper` component (was conditionally `Disabled` or `Fragment`)
- Implemented clear priority order:
  1. **If no connections exist**: Show either `UserConnectionNotice` (if user needs to connect WordPress.com) OR `EmptyState` (default)
  2. **If connections exist**: Show the full form with connections list, preview trigger, and share form
- Consolidated `SharePostForm` visibility logic to prevent showing the form when plan restrictions apply
- Cleaned up the structure to avoid nested fragments and conditional wrappers

### 3. Key Logic Changes
- **User connection notice has priority** over empty state (when there are no connections)
- The form is only shown when there are connections
- Removed redundant null checks and wrapper components

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

### Test Case 1: Empty state shows when no connections exist
1. Remove all social media connections from Jetpack Social settings (if any exist)
2. Create a new post or open an existing draft
3. Open the Jetpack Social panel in the sidebar
4. **Expected**:
   - An illustration should be visible
   - Text: "Automatically share your website content to your favorite social media platforms, from one place."
   - A "Connect your accounts" button should appear
   - No connections list should be visible

### Test Case 2: User connection notice takes priority over empty state
1. Disconnect your WordPress.com account (if connected)
2. Ensure you have no social media connections
3. Create a new post
4. Open the Jetpack Social panel
5. **Expected**:
   - A warning notice should appear with text: "You must connect your WordPress.com account to be able to connect social media accounts."
   - A "Connect now" link should be visible in the notice
   - The empty state illustration and "Connect your accounts" button should NOT appear

### Test Case 3: Form shows when connections exist
1. Ensure you're connected to WordPress.com
2. Connect at least one social media account
3. Create a new post
4. Open the Jetpack Social panel
5. **Expected**:
   - The connections list should be visible showing your connected account(s)
   - The empty state should NOT appear

### Test Case 4: Bug fix - Removing all connections after attaching image

1. Create a new post
2. Connect at least one social media account
3. Open the Jetpack Social panel
4. Add an image to the post (either as featured image or from media library)
5. Verify the connections list and form are visible
6. Now, remove ALL social media connections via Jetpack Social settings
7. Return to the post editor and check the Jetpack Social panel
8. **Expected**:
   - The empty state should appear with the illustration and "Connect your accounts" button
   - OR if WordPress.com account is not connected, the user connection notice should appear
   - The form should NOT be in a confused state

| Before | After |
|--------|--------|
| <img width="546" height="1252" alt="image" src="https://github.com/user-attachments/assets/d02cd382-1422-4e0d-92fa-76ac3a4aa6e9" /> | <img width="275" height="337" alt="Screenshot 2025-12-18 at 11 06 26 AM" src="https://github.com/user-attachments/assets/f88d7d4e-1c22-4e0c-b988-46a8b7758854" /> | 

