### PR TITLE
Social: Show upgrade notice when media feature is not available

### DIFF
--- a/projects/js-packages/publicize-components/changelog/update-social-handle-media-feature-upgrade
+++ b/projects/js-packages/publicize-components/changelog/update-social-handle-media-feature-upgrade
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Social: Show upgrade notice when media feature is not available.

--- a/projects/js-packages/publicize-components/src/components/form/index.tsx
+++ b/projects/js-packages/publicize-components/src/components/form/index.tsx
@@ -63,7 +63,7 @@ export default function PublicizeForm() {
 			</PanelRow>
 			{ needsUserConnection ? <UserConnectionNotice /> : null }
 			{ siteHasFeature( features.UNIFIED_UI_V1 ) ? <PreviewPostsTrigger /> : <SocialPostModal /> }
-			<EnhancedFeaturesNudge />
+			{ ! siteHasFeature( features.UNIFIED_UI_V1 ) ? <EnhancedFeaturesNudge /> : null }
 			{ showSharePostForm && <SharePostForm analyticsData={ { location: 'editor' } } /> }
 		</>
 	);

--- a/projects/js-packages/publicize-components/src/components/form/share-post-form.tsx
+++ b/projects/js-packages/publicize-components/src/components/form/share-post-form.tsx
@@ -6,6 +6,7 @@ import { useCallback, type FC } from 'react';
 import { usePostCanUseSig } from '../../hooks/use-post-can-use-sig';
 import useSocialMediaMessage from '../../hooks/use-social-media-message';
 import { store as socialStore } from '../../social-store';
+import { hasSocialPaidFeatures } from '../../utils';
 import { features } from '../../utils/constants';
 import { useIsSocialNote } from '../../utils/use-is-social-note';
 import MediaSection from '../media-section';
@@ -13,6 +14,7 @@ import MediaSectionV2 from '../media-section-v2';
 import MessageBoxControl from '../message-box-control';
 import SocialImageGeneratorPanel from '../social-image-generator/panel';
 import styles from './styles.module.scss';
+import { UpgradeNotice } from './upgrade-notice';
 
 type SharePostFormProps = {
 	/** Data for tracking analytics */
@@ -68,7 +70,11 @@ export const SharePostForm: FC< SharePostFormProps > = ( {
 			) }
 			{ siteHasFeature( features.UNIFIED_UI_V1 ) ? (
 				<div className={ styles[ 'share-post-form__media-section' ] }>
-					<MediaSectionV2 analyticsData={ analyticsData } onEditTemplate={ onEditTemplate } />
+					{ ! hasSocialPaidFeatures() ? (
+						<UpgradeNotice />
+					) : (
+						<MediaSectionV2 analyticsData={ analyticsData } onEditTemplate={ onEditTemplate } />
+					) }
 				</div>
 			) : (
 				<>

--- a/projects/js-packages/publicize-components/src/components/form/upgrade-notice.tsx
+++ b/projects/js-packages/publicize-components/src/components/form/upgrade-notice.tsx
@@ -1,0 +1,60 @@
+import { getRedirectUrl } from '@automattic/jetpack-components';
+import { isSimpleSite } from '@automattic/jetpack-script-data';
+import {
+	getSiteFragment,
+	useAutosaveAndRedirect,
+} from '@automattic/jetpack-shared-extension-utils';
+import { Notice } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import clsx from 'clsx';
+
+/**
+ * A notice for upgrading to a plan that supports the Enhanced Publishing feature.
+ *
+ * @return The UpgradeNotice component.
+ */
+export function UpgradeNotice() {
+	const redirectUrl = getRedirectUrl( 'jetpack-social-basic-plan-block-editor', {
+		site: getSiteFragment() || '',
+		query: 'redirect_to=' + encodeURIComponent( window.location.href ),
+	} );
+
+	const { autosaveAndRedirect, isRedirecting } = useAutosaveAndRedirect( redirectUrl );
+
+	if ( isSimpleSite() ) {
+		// We don't have any upgrade options on Simple sites, yet.
+		return null;
+	}
+
+	return (
+		<Notice
+			isDismissible={ false }
+			status="info"
+			actions={ [
+				{
+					variant: 'primary',
+					label: __( 'Upgrade now', 'jetpack-publicize-components' ),
+					/**
+					 * At the time of writing, Notice action does not support disabled or busy state,
+					 * @see https://github.com/WordPress/gutenberg/issues/74090
+					 */
+					// So we prevent onClick when redirecting.
+					onClick: isRedirecting ? undefined : autosaveAndRedirect,
+					className: clsx( 'is-compact', {
+						// Because of the above, we add a busy class for styling purposes.
+						'is-busy': isRedirecting,
+					} ),
+				},
+				{
+					variant: 'secondary',
+					label: __( 'View demo', 'jetpack-publicize-components' ),
+					noDefaultClasses: true,
+					className: 'is-compact',
+					url: getRedirectUrl( 'jetpack-social-landing-page' ),
+				},
+			] }
+		>
+			{ __( 'Choose your social media image or video to share.', 'jetpack-publicize-components' ) }
+		</Notice>
+	);
+}

--- a/projects/js-packages/publicize-components/src/components/panel/upsell.tsx
+++ b/projects/js-packages/publicize-components/src/components/panel/upsell.tsx
@@ -42,6 +42,7 @@ export function UpsellNotice() {
 				{
 					label: isRedirecting ? __( 'Redirecting…', 'jetpack-publicize-components' ) : buttonText,
 					variant: 'primary',
+					className: 'is-compact',
 					onClick: goToCheckoutPage,
 				},
 			] }

--- a/projects/js-packages/publicize-components/src/utils/script-data.ts
+++ b/projects/js-packages/publicize-components/src/utils/script-data.ts
@@ -1,5 +1,6 @@
 import { getAdminUrl, getScriptData, siteHasFeature } from '@automattic/jetpack-script-data';
 import { SocialScriptData } from '../types';
+import { features } from './constants';
 
 /**
  * Get the social script data from the window object.
@@ -13,10 +14,10 @@ export function getSocialScriptData(): SocialScriptData {
 /**
  * Check if the site has social paid features.
  *
- * @return {boolean} Whether the site has social paid features.
+ * @return Whether the site has social paid features.
  */
 export function hasSocialPaidFeatures() {
-	return siteHasFeature( 'social-enhanced-publishing' );
+	return siteHasFeature( features.ENHANCED_PUBLISHING );
 }
 
 /**


### PR DESCRIPTION
Closes SOCIAL-273, SOCIAL-274

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Hide the new media UI if Social paid features are not available
* Show a notice with upgrade and demo for that case
* Hide the existing upgrade nudge

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* On a Jetpack site with free plan, create a post
* Open Jetpack sidebar
* In the sharing panel, confirm that you don't see the media selection UI
* Confirm that you see the notice with an upgrade button and the demo link
* Click on both the buttons to confirm that they work as expected
* Now check on a site with paid social features
* Confirm that the upgrade notice is not shown
* Confirm that media UI is shown
* Apply the patch to your sandbox
* Point your free Simple site and the public API to your sandbox
* Confirm that the above upgrade notice is not shown on the site.

<img width="276" height="226" alt="Screenshot 2025-12-18 at 3 50 24 PM" src="https://github.com/user-attachments/assets/e4319380-8c97-4aa7-add0-e6490ba5dd6b" />

