### PR TITLE
AI Assistant: Fix product page URL for Simple sites

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-jetpack-ai-learn-more-link
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-ai-learn-more-link
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+AI Assistant: Fix product page URL for Simple sites to use jetpack.com instead of My Jetpack

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-ai-product-page/index.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-ai-product-page/index.ts
@@ -19,10 +19,10 @@ export default function useAiProductPage(): {
 	productPageUrl: string;
 	isMyJetpackAvailable: boolean;
 } {
-	const productPageUrl =
-		isMyJetpackAvailable() && ! isSimpleSite()
-			? `${ getJetpackData()?.adminUrl || '' }admin.php?page=my-jetpack#/jetpack-ai`
-			: getRedirectUrl( 'org-ai' );
+	const isMyJetpackReallyAvailable = isMyJetpackAvailable() && ! isSimpleSite();
+	const productPageUrl = isMyJetpackReallyAvailable
+		? `${ getJetpackData()?.adminUrl || '' }admin.php?page=my-jetpack#/jetpack-ai`
+		: getRedirectUrl( 'org-ai' );
 
 	const { autosaveAndRedirect, isRedirecting } = useAutosaveAndRedirect( productPageUrl );
 
@@ -30,6 +30,6 @@ export default function useAiProductPage(): {
 		productPageUrl,
 		autosaveAndRedirect,
 		isRedirecting,
-		isMyJetpackAvailable: isMyJetpackAvailable(),
+		isMyJetpackAvailable: isMyJetpackReallyAvailable,
 	};
 }

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-ai-product-page/index.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-ai-product-page/index.ts
@@ -2,7 +2,12 @@
  * External dependencies
  */
 import { getRedirectUrl } from '@automattic/jetpack-components';
-import { getJetpackData, useAutosaveAndRedirect } from '@automattic/jetpack-shared-extension-utils';
+import { isSimpleSite } from '@automattic/jetpack-script-data';
+import {
+	getJetpackData,
+	isMyJetpackAvailable,
+	useAutosaveAndRedirect,
+} from '@automattic/jetpack-shared-extension-utils';
 /*
  * Types
  */
@@ -14,12 +19,10 @@ export default function useAiProductPage(): {
 	productPageUrl: string;
 	isMyJetpackAvailable: boolean;
 } {
-	// TODO: use isMyJetpackAvailable from shared-extension-utils once PR is merged and package published:
-	// https://github.com/Automattic/jetpack/pull/38529
-	const isMyJetpackAvailable = getJetpackData()?.jetpack?.is_my_jetpack_available;
-	const productPageUrl = isMyJetpackAvailable
-		? `${ getJetpackData()?.adminUrl || '' }admin.php?page=my-jetpack#/jetpack-ai`
-		: getRedirectUrl( 'org-ai' );
+	const productPageUrl =
+		isMyJetpackAvailable() && ! isSimpleSite()
+			? `${ getJetpackData()?.adminUrl || '' }admin.php?page=my-jetpack#/jetpack-ai`
+			: getRedirectUrl( 'org-ai' );
 
 	const { autosaveAndRedirect, isRedirecting } = useAutosaveAndRedirect( productPageUrl );
 
@@ -27,6 +30,6 @@ export default function useAiProductPage(): {
 		productPageUrl,
 		autosaveAndRedirect,
 		isRedirecting,
-		isMyJetpackAvailable,
+		isMyJetpackAvailable: isMyJetpackAvailable(),
 	};
 }


### PR DESCRIPTION
Part of JPAI-76

## Proposed changes:
* Fix AI Assistant product page URL to redirect Simple sites to jetpack.com instead of My Jetpack
* Use the proper `isMyJetpackAvailable()` function from shared-extension-utils (removes TODO)
* Add `isSimpleSite()` check to exclude Simple sites from My Jetpack links

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion


## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

### On a Simple site:
1. Install Jetpack plugin with AI Assistant block
2. Add an AI Assistant block to a post
3. Click the "Learn more" or upgrade link in the AI Assistant block
4. Verify you are redirected to jetpack.com/ai instead of My Jetpack

### On a regular site with My Jetpack:
1. Install Jetpack plugin with AI Assistant block
2. Add an AI Assistant block to a post  
3. Click the "Learn more" or upgrade link in the AI Assistant block
4. Verify you are redirected to My Jetpack AI page (admin.php?page=my-jetpack#/jetpack-ai)