### PR TITLE
jetpack: Add an error check in taxonomy update endpoint

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-wpcom-json-api-update-taxonomy-endpoint-error-check
+++ b/projects/plugins/jetpack/changelog/fix-wpcom-json-api-update-taxonomy-endpoint-error-check
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+JSON API: Add an error check in taxonomy update endpoint.

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-update-taxonomy-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-update-taxonomy-endpoint.php
@@ -332,7 +332,10 @@ class WPCOM_JSON_API_Update_Taxonomy_Endpoint extends WPCOM_JSON_API_Taxonomy_En
 			$update['name'] = addslashes( $input['name'] );
 		}
 
-		$data     = wp_update_term( $taxonomy->term_id, $taxonomy_type, $update );
+		$data = wp_update_term( $taxonomy->term_id, $taxonomy_type, $update );
+		if ( is_wp_error( $data ) ) {
+			return $data;
+		}
 		$taxonomy = get_term_by( 'id', $data['term_id'], $taxonomy_type );
 
 		$return = $this->get_taxonomy( $taxonomy->slug, $taxonomy_type, $args['context'] );


### PR DESCRIPTION
Closes MONOREP-299

 <!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Wpcom reported the following fatal error:
```
Fatal error: Uncaught Error: Cannot use object of type WP_Error as array in /home/wpcom/public_html/wp-content/mu-plugins/jetpack-plugin/moon/json-endpoints/class.wpcom-json-api-update-taxonomy-endpoint.php:336
Stack trace:
#0 /home/wpcom/public_html/wp-content/mu-plugins/jetpack-plugin/moon/json-endpoints/class.wpcom-json-api-update-taxonomy-endpoint.php(225): WPCOM_JSON_API_Update_Taxonomy_Endpoint->update_taxonomy(...)
#1 /home/wpcom/public_html/wp-content/mu-plugins/jetpack-plugin/moon/class.json-api.php(616): WPCOM_JSON_API_Update_Taxonomy_Endpoint->callback(...)
#2 /home/wpcom/public_html/public.api/rest/class.wpcom-json-api.php(1868): WPCOM_JSON_API->process_request(...)
#3 /home/wpcom/public_html/public.api/rest/class.wpcom-json-api.php(2879): Public_API_WPCOM_JSON_API->process_wpcom_request(...)
#4 /home/wpcom/public_html/wp-content/mu-plugins/jetpack-plugin/moon/class.json-api.php(592): Public_API_WPCOM_JSON_API->process_request(...)
#5 /home/wpcom/public_html/public.api/rest/class.wpcom-json-api.php(1242): WPCOM_JSON_API->serve(...)
#6 /home/wpcom/public_html/wp-includes/class-wp-hook.php(341): Public_API_WPCOM_JSON_API->serve(...)
#7 /home/wpcom/public_html/wp-includes/class-wp-hook.php(365): WP_Hook->apply_filters(...)
#8 /home/wpcom/public_html/wp-includes/plugin.php(522): WP_Hook->do_action(...)
#9 /home/wpcom/public_html/public.api/rest/load.php(97): do_action(...)
#10 /home/wpcom/public_html/public.api/rest/index.php(84): wpcom_rest_api_run()
#11 {main}
  thrown in /home/wpcom/public_html/wp-content/mu-plugins/jetpack-plugin/moon/json-endpoints/class.wpcom-json-api-update-taxonomy-endpoint.php on line 336
```
Additional details in p1766075453454049-slack-C08PN0LHCCT

Other branches in the function return a WP_Error, seems like this can too.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1766075453454049-slack-C08PN0LHCCT

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* No idea. 🤷 I only got pinged on this by accident, as far as I can tell.
