### PR TITLE
Forms: Add ID support for hidden field blocks

### DIFF
--- a/projects/packages/forms/changelog/add-forms-hidden-field-id-support
+++ b/projects/packages/forms/changelog/add-forms-hidden-field-id-support
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add support for setting custom ID on hidden field blocks from block settings

--- a/projects/packages/forms/src/blocks/field-hidden/edit.js
+++ b/projects/packages/forms/src/blocks/field-hidden/edit.js
@@ -2,6 +2,7 @@ import { useBlockProps } from '@wordpress/block-editor';
 import { Placeholder, TextControl, __experimentalHStack as HStack } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
 import { __ } from '@wordpress/i18n';
 import { unseen } from '@wordpress/icons';
+import JetpackFieldControls from '../shared/components/jetpack-field-controls.js';
 import useFormWrapper from '../shared/hooks/use-form-wrapper.js';
 import useInsertAfterOnEnterKeyDown from '../shared/hooks/use-insert-after-on-enter-key-down.js';
 import './editor.scss';
@@ -22,32 +23,40 @@ export default function HiddenFieldEdit( props ) {
 	const onKeyDown = useInsertAfterOnEnterKeyDown( clientId, true );
 
 	return (
-		<div { ...blockProps }>
-			<Placeholder icon={ unseen } label={ __( 'Hidden field', 'jetpack-forms' ) }>
-				<HStack alignment="top" className="jetpack-form-hidden-field-inputs">
-					<TextControl
-						__next40pxDefaultSize
-						__nextHasNoMarginBottom
-						onChange={ handleLabelChange }
-						label={ __( 'Name', 'jetpack-forms' ) }
-						value={ attributes.label }
-						help={ __(
-							'Internal name used to identify this field in form responses.',
-							'jetpack-forms'
-						) }
-						onKeyDown={ onKeyDown }
-					/>
-					<TextControl
-						__next40pxDefaultSize
-						__nextHasNoMarginBottom
-						onChange={ handleValueChange }
-						label={ __( 'Value', 'jetpack-forms' ) }
-						value={ attributes.default }
-						help={ __( 'The value that will be submitted with the form.', 'jetpack-forms' ) }
-						onKeyDown={ onKeyDown }
-					/>
-				</HStack>
-			</Placeholder>
-		</div>
+		<>
+			<div { ...blockProps }>
+				<Placeholder icon={ unseen } label={ __( 'Hidden field', 'jetpack-forms' ) }>
+					<HStack alignment="top" className="jetpack-form-hidden-field-inputs">
+						<TextControl
+							__next40pxDefaultSize
+							__nextHasNoMarginBottom
+							onChange={ handleLabelChange }
+							label={ __( 'Name', 'jetpack-forms' ) }
+							value={ attributes.label }
+							help={ __(
+								'Internal name used to identify this field in form responses.',
+								'jetpack-forms'
+							) }
+							onKeyDown={ onKeyDown }
+						/>
+						<TextControl
+							__next40pxDefaultSize
+							__nextHasNoMarginBottom
+							onChange={ handleValueChange }
+							label={ __( 'Value', 'jetpack-forms' ) }
+							value={ attributes.default }
+							help={ __( 'The value that will be submitted with the form.', 'jetpack-forms' ) }
+							onKeyDown={ onKeyDown }
+						/>
+					</HStack>
+				</Placeholder>
+			</div>
+			<JetpackFieldControls
+				id={ attributes.id }
+				setAttributes={ setAttributes }
+				attributes={ attributes }
+				extraFieldSettings={ [] }
+			/>
+		</>
 	);
 }

--- a/projects/packages/forms/src/blocks/field-hidden/edit.js
+++ b/projects/packages/forms/src/blocks/field-hidden/edit.js
@@ -2,7 +2,7 @@ import { useBlockProps } from '@wordpress/block-editor';
 import { Placeholder, TextControl, __experimentalHStack as HStack } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
 import { __ } from '@wordpress/i18n';
 import { unseen } from '@wordpress/icons';
-import JetpackFieldControls from '../shared/components/jetpack-field-controls.js';
+import JetpackFieldId from '../shared/components/jetpack-field-id-control.js';
 import useFormWrapper from '../shared/hooks/use-form-wrapper.js';
 import useInsertAfterOnEnterKeyDown from '../shared/hooks/use-insert-after-on-enter-key-down.js';
 import './editor.scss';
@@ -51,12 +51,7 @@ export default function HiddenFieldEdit( props ) {
 					</HStack>
 				</Placeholder>
 			</div>
-			<JetpackFieldControls
-				id={ attributes.id }
-				setAttributes={ setAttributes }
-				attributes={ attributes }
-				extraFieldSettings={ [] }
-			/>
+			<JetpackFieldId id={ attributes.id } setAttributes={ setAttributes } />
 		</>
 	);
 }

--- a/projects/packages/forms/src/blocks/field-hidden/index.js
+++ b/projects/packages/forms/src/blocks/field-hidden/index.js
@@ -18,6 +18,7 @@ const settings = {
 	edit,
 	save,
 	attributes: {
+		id: { type: 'string' },
 		label: { type: 'string', default: '' },
 		default: { type: 'string', default: '' },
 	},

--- a/projects/packages/forms/src/blocks/field-hidden/index.js
+++ b/projects/packages/forms/src/blocks/field-hidden/index.js
@@ -18,7 +18,7 @@ const settings = {
 	edit,
 	save,
 	attributes: {
-		id: { type: 'string' },
+		id: { type: 'string', default: '' },
 		label: { type: 'string', default: '' },
 		default: { type: 'string', default: '' },
 	},

--- a/projects/packages/forms/src/blocks/shared/components/jetpack-field-controls.js
+++ b/projects/packages/forms/src/blocks/shared/components/jetpack-field-controls.js
@@ -1,27 +1,10 @@
-import {
-	InspectorAdvancedControls,
-	InspectorControls,
-	BlockControls,
-} from '@wordpress/block-editor';
-import { PanelBody, TextControl, ToggleControl } from '@wordpress/components';
-import { isValidElement, useState } from '@wordpress/element';
-import { __, sprintf } from '@wordpress/i18n';
+import { InspectorControls, BlockControls } from '@wordpress/block-editor';
+import { PanelBody, ToggleControl } from '@wordpress/components';
+import { isValidElement } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import JetpackFieldId from './jetpack-field-id-control.js';
 import JetpackFieldWidth from './jetpack-field-width.js';
 import ToolbarRequiredGroup from './toolbar-required-group.js';
-
-// List of reserved HTML form element attribute names
-const reservedAttributes = [
-	'accept',
-	'action',
-	'autocomplete',
-	'enctype',
-	'method',
-	'name',
-	'novalidate',
-	'target',
-	'type',
-	'value',
-];
 
 const JetpackFieldControls = ( {
 	attributes,
@@ -31,41 +14,6 @@ const JetpackFieldControls = ( {
 	width,
 	extraFieldSettings = [],
 } ) => {
-	const helpMessage = __(
-		"Customize the input's name/ID. Only alphanumeric, dash and underscore characters are allowed",
-		'jetpack-forms'
-	);
-
-	const [ errorState, setErrorState ] = useState( {
-		error: false,
-		message: '',
-	} );
-
-	const setId = value => {
-		const newValue = value.replace( /[^a-zA-Z0-9_-]/g, '' );
-		const reservedWordError = word => {
-			return sprintf(
-				/* translators: %s is the reserved attribute name causing an error */
-				__( 'The name/ID "%s" is a reserved word. Please use a different name.', 'jetpack-forms' ),
-				word
-			);
-		};
-
-		// Only set ID if it's not a reserved attribute name (case insensitive)
-		if ( ! reservedAttributes.some( attr => attr.toLowerCase() === newValue.toLowerCase() ) ) {
-			setErrorState( {
-				error: false,
-				message: '',
-			} );
-			setAttributes( { id: newValue } );
-		} else {
-			setErrorState( {
-				error: true,
-				message: reservedWordError( newValue ),
-			} );
-		}
-	};
-
 	let fieldSettings = [
 		<ToggleControl
 			key="required"
@@ -132,17 +80,7 @@ const JetpackFieldControls = ( {
 					<>{ fieldSettings }</>
 				</PanelBody>
 			</InspectorControls>
-			<InspectorAdvancedControls>
-				<TextControl
-					className={ errorState.error ? 'jetpack-forms-field-controls__input-error' : '' }
-					label={ __( 'Name/ID', 'jetpack-forms' ) }
-					value={ id || '' }
-					onChange={ setId }
-					help={ errorState.error ? errorState.message : helpMessage }
-					__nextHasNoMarginBottom={ true }
-					__next40pxDefaultSize={ true }
-				/>
-			</InspectorAdvancedControls>
+			<JetpackFieldId id={ id } setAttributes={ setAttributes } />
 		</>
 	);
 };

--- a/projects/packages/forms/src/blocks/shared/components/jetpack-field-id-control.js
+++ b/projects/packages/forms/src/blocks/shared/components/jetpack-field-id-control.js
@@ -1,0 +1,71 @@
+import { InspectorAdvancedControls } from '@wordpress/block-editor';
+import { TextControl } from '@wordpress/components';
+import { useState } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
+
+// List of reserved HTML form element attribute names
+const reservedAttributes = [
+	'accept',
+	'action',
+	'autocomplete',
+	'enctype',
+	'method',
+	'name',
+	'novalidate',
+	'target',
+	'type',
+	'value',
+];
+
+const JetpackFieldId = ( { id, setAttributes } ) => {
+	const helpMessage = __(
+		"Customize the input's name/ID. Only alphanumeric, dash and underscore characters are allowed",
+		'jetpack-forms'
+	);
+
+	const [ errorState, setErrorState ] = useState( {
+		error: false,
+		message: '',
+	} );
+
+	const setId = value => {
+		const newValue = value.replace( /[^a-zA-Z0-9_-]/g, '' );
+		const reservedWordError = word => {
+			return sprintf(
+				/* translators: %s is the reserved attribute name causing an error */
+				__( 'The name/ID "%s" is a reserved word. Please use a different name.', 'jetpack-forms' ),
+				word
+			);
+		};
+
+		// Only set ID if it's not a reserved attribute name (case insensitive)
+		if ( ! reservedAttributes.some( attr => attr.toLowerCase() === newValue.toLowerCase() ) ) {
+			setErrorState( {
+				error: false,
+				message: '',
+			} );
+			setAttributes( { id: newValue } );
+		} else {
+			setErrorState( {
+				error: true,
+				message: reservedWordError( newValue ),
+			} );
+		}
+	};
+
+	return (
+		<InspectorAdvancedControls>
+			<TextControl
+				className={ errorState.error ? 'jetpack-forms-field-controls__input-error' : '' }
+				label={ __( 'Name/ID', 'jetpack-forms' ) }
+				value={ id || '' }
+				onChange={ setId }
+				help={ errorState.error ? errorState.message : helpMessage }
+				__nextHasNoMarginBottom={ true }
+				__next40pxDefaultSize={ true }
+			/>
+		</InspectorAdvancedControls>
+	);
+};
+
+export default JetpackFieldId;


### PR DESCRIPTION
Resolves FORMS-473

Part of FORMS-476

## Proposed changes:
* Add `id` attribute to the field-hidden block definition
* Add `JetpackFieldControls` component to provide UI for setting custom IDs from block settings
* Hidden fields now support custom Name/ID configuration matching other field types

<img width="1000" height="353" alt="Screenshot 2025-12-19 at 11 16 00" src="https://github.com/user-attachments/assets/cef3b6b5-a580-418e-9f7c-4d686fd6862f" />


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
* Add a hidden field block to the form
* Select the hidden field block
* Open the block settings sidebar (click the gear icon if not visible)
* Navigate to the "Advanced" section at the bottom of the sidebar
* Verify you can see a "Name/ID" field
* Enter a custom ID (e.g., "my_custom_field")
* Verify the ID accepts only alphanumeric characters, dashes, and underscores
* Try entering a reserved HTML attribute name (e.g., "action", "method", "type") and verify it shows an error
* Save the form and verify the hidden field uses your custom ID in the HTML output
