### PR TITLE
Social: Make connection list in sidebar full width for single connection

### DIFF
--- a/projects/js-packages/publicize-components/changelog/fix-social-single-connection-width
+++ b/projects/js-packages/publicize-components/changelog/fix-social-single-connection-width
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Social: Make connection list in sidebar full width for single connection

--- a/projects/js-packages/publicize-components/src/components/form/connections-list.tsx
+++ b/projects/js-packages/publicize-components/src/components/form/connections-list.tsx
@@ -39,7 +39,7 @@ export const ConnectionsList: React.FC = () => {
 	);
 
 	return (
-		<div>
+		<div className={ styles[ 'connections-list-wrapper' ] }>
 			<Disabled isDisabled={ disableConnectionsList }>
 				<div className={ styles[ 'connections-list' ] }>
 					<ConnectionsToggleList onClickItem={ onClickConnection } />

--- a/projects/js-packages/publicize-components/src/components/form/styles.module.scss
+++ b/projects/js-packages/publicize-components/src/components/form/styles.module.scss
@@ -61,6 +61,10 @@
 	list-style-type: disc;
 }
 
+.connections-list-wrapper {
+	width: 100%;
+}
+
 .connections-list {
 	border-radius: 2px;
 	border: 1px solid gb.$gray-200;


### PR DESCRIPTION
Fixes SOCIAL-282

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Social: Make connection list in sidebar full width for single connection

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Ensure that your site has only one social connection, preferably the one with a short name
<details><summary>You can simulate it by applying this diff</summary>

```diff
diff --git a/projects/js-packages/publicize-components/src/components/connections-toggle-list/index.tsx b/projects/js-packages/publicize-components/src/components/connections-toggle-list/index.tsx
index 935ebfb2836..6a0f17b103f 100644
--- a/projects/js-packages/publicize-components/src/components/connections-toggle-list/index.tsx
+++ b/projects/js-packages/publicize-components/src/components/connections-toggle-list/index.tsx
@@ -40,7 +40,7 @@ export function ConnectionsToggleList( {
                        className={ styles.wrapper }
                        aria-label={ __( 'Connection toggles', 'jetpack-publicize-components' ) }
                >
-                       { connections.map( connection => {
+                       { [ connections[ 0 ] ].map( connection => {
                                const isSelected = canBeTurnedOn( connection ) && connection.enabled;
                                const isDisabled = shouldBeDisabled( connection );
```

</details>

* Go to editor sidebar Jetpack panel
* Confirm that the connection list is full width

| Before | After |
|--------|--------|
| <img width="279" height="122" alt="Screenshot 2025-12-19 at 12 17 55 PM" src="https://github.com/user-attachments/assets/d9f2e2ed-f6e8-4b56-8362-1e67ccbfb915" /> | <img width="277" height="121" alt="Screenshot 2025-12-19 at 12 16 04 PM" src="https://github.com/user-attachments/assets/be54a616-dfb9-47d3-9b2b-b7b61016606c" /> | 
