### PR TITLE
Social: Fix template image not shown as attached when send as attachment is enabled.

### DIFF
--- a/projects/js-packages/publicize-components/changelog/fix-social-sig-image-as-attached
+++ b/projects/js-packages/publicize-components/changelog/fix-social-sig-image-as-attached
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Social: Fix template image not shown as attached when send as attachment is enabled.

--- a/projects/js-packages/publicize-components/src/components/social-previews/use-post-data.js
+++ b/projects/js-packages/publicize-components/src/components/social-previews/use-post-data.js
@@ -47,22 +47,25 @@ export function usePostData() {
 
 			const media = [];
 
-			const getMediaDetails = id => {
-				const mediaItem = getEntityRecord( 'postType', 'attachment', id );
-				if ( ! mediaItem ) {
-					return null;
-				}
-				return {
-					type: mediaItem.mime_type,
-					url: getMediaSourceUrl( mediaItem ),
-					alt: mediaItem.alt_text,
-				};
-			};
+			for ( const item of attachedMedia ) {
+				// It can be a SIG (Social Image Generator) image allowed to be attached without an ID.
+				if ( ! item.id && item.url ) {
+					media.push( {
+						type: item.type || 'image/jpeg',
+						url: item.url,
+						alt: item.alt || '',
+					} );
+				} else {
+					// Otherwise, fetch the media details from the store.
+					const mediaItem = getEntityRecord( 'postType', 'attachment', item.id );
 
-			for ( const { id } of attachedMedia ) {
-				const mediaDetails = getMediaDetails( id );
-				if ( mediaDetails ) {
-					media.push( mediaDetails );
+					if ( mediaItem ) {
+						media.push( {
+							type: mediaItem.mime_type,
+							url: getMediaSourceUrl( mediaItem ),
+							alt: mediaItem.alt_text,
+						} );
+					}
 				}
 			}
 


### PR DESCRIPTION
Fixes SOCIAL-286

> When I select a template and indicate to use it as attachment, it's not working.

The reason for the bug was that we tried to get the media details from the store, which does not exist in case of SIG. So, we need to handle that case separately.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Social: Fix template image not shown as attached when send as attachment is enabled.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to social sharing panel in the sidebar
* Use template as the media
* Turn ON "Send as attachment"
* Open the preview modal
* Confirm that the image is shown as an attachment

| Before | After |
|--------|--------|
| <img width="926" height="508" alt="Screenshot 2025-12-19 at 1 11 45 PM" src="https://github.com/user-attachments/assets/bb224b6f-34b7-4a3e-9df9-b7f381f566ce" /> | <img width="923" height="508" alt="Screenshot 2025-12-19 at 1 11 07 PM" src="https://github.com/user-attachments/assets/ffa0deb9-67e0-40e7-861b-8c7832e58484" /> | 