### PR TITLE
Agents Manager: Add caching and proxy protection for unified experience check

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-unified-experience-uncached-request
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-unified-experience-uncached-request
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Agents Manager: Add caching and proxy protection for unified experience preference check to avoid remote API calls on every page load.

--- a/projects/packages/jetpack-mu-wpcom/src/features/agents-manager/class-agents-manager.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/agents-manager/class-agents-manager.php
@@ -7,6 +7,8 @@
 
 namespace A8C\FSE;
 
+use Automattic\Jetpack\Connection\Manager as Connection_Manager;
+
 /**
  * Class Agents_Manager
  */
@@ -131,6 +133,23 @@ class Agents_Manager {
 	}
 
 	/**
+	 * Returns whether the current request is coming from the A8C proxy.
+	 *
+	 * @return bool
+	 */
+	private static function is_proxied() {
+		// On Simple sites, use the wpcom function if available.
+		if ( function_exists( 'wpcom_is_proxied_request' ) ) {
+			return wpcom_is_proxied_request();
+		}
+
+		// On WoA/Garden sites, check server variable or constant.
+		return isset( $_SERVER['A8C_PROXIED_REQUEST'] )
+			? sanitize_text_field( wp_unslash( $_SERVER['A8C_PROXIED_REQUEST'] ) )
+			: defined( 'A8C_PROXIED_REQUEST' ) && A8C_PROXIED_REQUEST;
+	}
+
+	/**
 	 * Register the Agents Manager endpoints.
 	 */
 	public function register_rest_api() {
@@ -145,6 +164,12 @@ class Agents_Manager {
 	 * @return bool
 	 */
 	public function should_use_unified_experience() {
+		// Early return for non-proxied requests.
+		// This feature is currently only available to Automattic employees testing via proxy.
+		if ( ! self::is_proxied() ) {
+			return false;
+		}
+
 		$user_id = get_current_user_id();
 
 		if ( ! $user_id ) {
@@ -164,7 +189,7 @@ class Agents_Manager {
 		// On WoA and Garden sites, delegate to wpcom via the /me/preferences endpoint.
 		// This avoids duplicating rollout logic and handles cases where
 		// wpcom-specific functions (like get_user_attribute) aren't available.
-		if ( $this->get_unified_experience_from_wpcom() ) {
+		if ( $this->fetch_unified_experience_preference() ) {
 			return true;
 		}
 
@@ -193,23 +218,31 @@ class Agents_Manager {
 	}
 
 	/**
-	 * Get unified experience flag from wpcom via Jetpack Connection.
+	 * Fetch unified experience preference from wpcom via Jetpack Connection.
 	 *
 	 * Used on Atomic sites to delegate the decision to wpcom, which has
 	 * access to user attributes and can evaluate the rollout logic.
 	 *
 	 * Calls /me/preferences endpoint which is accessible via Jetpack user tokens.
 	 *
-	 * @codeCoverageIgnore Cannot test without mocking Jetpack Connection Client.
-	 *
 	 * @return bool Whether user should see unified experience.
 	 */
-	private function get_unified_experience_from_wpcom() {
-		// Use static cache to avoid multiple HTTP requests in same request.
-		static $cached_value = null;
+	private function fetch_unified_experience_preference() {
+		$user_id = get_current_user_id();
+		if ( ! $user_id ) {
+			return false;
+		}
 
-		if ( $cached_value !== null ) {
-			return $cached_value;
+		// Check transient cache first (per-user cache).
+		$cache_key     = 'unified-experience-' . $user_id;
+		$cached_result = get_transient( $cache_key );
+		if ( false !== $cached_result ) {
+			return (bool) $cached_result;
+		}
+
+		// Check if user is connected before making API call.
+		if ( ! ( new Connection_Manager() )->is_user_connected( $user_id ) ) {
+			return false;
 		}
 
 		// Call /me/preferences via wpcom/v2 namespace (works with Jetpack user tokens).
@@ -220,13 +253,14 @@ class Agents_Manager {
 		);
 
 		if ( is_wp_error( $wpcom_request ) ) {
-			$cached_value = false;
+			// Cache failures too to avoid hammering the API.
+			set_transient( $cache_key, 0, MINUTE_IN_SECONDS );
 			return false;
 		}
 
 		$response_code = wp_remote_retrieve_response_code( $wpcom_request );
 		if ( 200 !== $response_code ) {
-			$cached_value = false;
+			set_transient( $cache_key, 0, MINUTE_IN_SECONDS );
 			return false;
 		}
 
@@ -234,8 +268,12 @@ class Agents_Manager {
 		$decoded_body = json_decode( $body, true );
 
 		// The response is the value of the preference directly when using preference_key.
-		$cached_value = ! empty( $decoded_body );
-		return $cached_value;
+		$result = ! empty( $decoded_body );
+
+		// Cache for 1 minute.
+		set_transient( $cache_key, $result ? 1 : 0, MINUTE_IN_SECONDS );
+
+		return $result;
 	}
 }
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/agents-manager/class-agents-manager.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/agents-manager/class-agents-manager.php
@@ -145,7 +145,7 @@ class Agents_Manager {
 
 		// On WoA/Garden sites, check server variable or constant.
 		return isset( $_SERVER['A8C_PROXIED_REQUEST'] )
-			? sanitize_text_field( wp_unslash( $_SERVER['A8C_PROXIED_REQUEST'] ) )
+			? (bool) sanitize_text_field( wp_unslash( $_SERVER['A8C_PROXIED_REQUEST'] ) )
 			: defined( 'A8C_PROXIED_REQUEST' ) && A8C_PROXIED_REQUEST;
 	}
 

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/agents-manager/Agents_Manager_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/agents-manager/Agents_Manager_Test.php
@@ -658,4 +658,241 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 		// Result is false because API call fails, but we verified the proxy check passed.
 		$this->assertFalse( $result );
 	}
+
+	/**
+	 * Tests that fetch_unified_experience_preference returns true when API returns unified_ai_chat enabled.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	#[RunInSeparateProcess]
+	#[PreserveGlobalState( false )]
+	public function test_fetch_unified_experience_preference_returns_true_when_api_returns_enabled() {
+		// Simulate being on an Atomic (WoA) site with proxy.
+		Cache::set( 'is_woa_site', true );
+		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
+
+		// Set up Jetpack connection mocking.
+		Constants::set_constant( 'JETPACK__WPCOM_JSON_API_BASE', 'https://public-api.wordpress.com' );
+
+		$user_id = wp_insert_user(
+			array(
+				'user_login' => 'test_api_enabled',
+				'user_pass'  => 'password',
+				'role'       => 'subscriber',
+			)
+		);
+		wp_set_current_user( $user_id );
+
+		// Mock user connection by setting user tokens.
+		\Jetpack_Options::update_option( 'user_tokens', array( $user_id => 'test.token.' . $user_id ) );
+		\Jetpack_Options::update_option( 'id', 12345 );
+
+		// Mock the API response.
+		add_filter( 'pre_http_request', array( $this, 'mock_preferences_api_enabled' ), 10, 3 );
+
+		$result = $this->agents_manager->should_use_unified_experience();
+
+		remove_filter( 'pre_http_request', array( $this, 'mock_preferences_api_enabled' ), 10 );
+
+		$this->assertTrue( $result );
+	}
+
+	/**
+	 * Tests that fetch_unified_experience_preference returns false when API returns unified_ai_chat disabled.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	#[RunInSeparateProcess]
+	#[PreserveGlobalState( false )]
+	public function test_fetch_unified_experience_preference_returns_false_when_api_returns_disabled() {
+		// Simulate being on an Atomic (WoA) site with proxy.
+		Cache::set( 'is_woa_site', true );
+		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
+
+		// Set up Jetpack connection mocking.
+		Constants::set_constant( 'JETPACK__WPCOM_JSON_API_BASE', 'https://public-api.wordpress.com' );
+
+		$user_id = wp_insert_user(
+			array(
+				'user_login' => 'test_api_disabled',
+				'user_pass'  => 'password',
+				'role'       => 'subscriber',
+			)
+		);
+		wp_set_current_user( $user_id );
+
+		// Mock user connection by setting user tokens.
+		\Jetpack_Options::update_option( 'user_tokens', array( $user_id => 'test.token.' . $user_id ) );
+		\Jetpack_Options::update_option( 'id', 12345 );
+
+		// Mock the API response.
+		add_filter( 'pre_http_request', array( $this, 'mock_preferences_api_disabled' ), 10, 3 );
+
+		$result = $this->agents_manager->should_use_unified_experience();
+
+		remove_filter( 'pre_http_request', array( $this, 'mock_preferences_api_disabled' ), 10 );
+
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * Tests that fetch_unified_experience_preference uses cached value on subsequent calls.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	#[RunInSeparateProcess]
+	#[PreserveGlobalState( false )]
+	public function test_fetch_unified_experience_preference_uses_cache() {
+		// Simulate being on an Atomic (WoA) site with proxy.
+		Cache::set( 'is_woa_site', true );
+		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
+
+		// Set up Jetpack connection mocking.
+		Constants::set_constant( 'JETPACK__WPCOM_JSON_API_BASE', 'https://public-api.wordpress.com' );
+
+		$user_id = wp_insert_user(
+			array(
+				'user_login' => 'test_cache',
+				'user_pass'  => 'password',
+				'role'       => 'subscriber',
+			)
+		);
+		wp_set_current_user( $user_id );
+
+		// Mock user connection by setting user tokens.
+		\Jetpack_Options::update_option( 'user_tokens', array( $user_id => 'test.token.' . $user_id ) );
+		\Jetpack_Options::update_option( 'id', 12345 );
+
+		// Set transient cache directly.
+		set_transient( 'unified-experience-' . $user_id, 1, MINUTE_IN_SECONDS );
+
+		// Track API calls - should not be called if cache is used.
+		$api_call_count = 0;
+		$count_callback = function () use ( &$api_call_count ) {
+			++$api_call_count;
+			return array(
+				'body'     => wp_json_encode( true, JSON_UNESCAPED_SLASHES ),
+				'response' => array(
+					'code'    => 200,
+					'message' => 'OK',
+				),
+			);
+		};
+		add_filter( 'pre_http_request', $count_callback, 10, 3 );
+
+		$result = $this->agents_manager->should_use_unified_experience();
+
+		remove_filter( 'pre_http_request', $count_callback, 10 );
+
+		// Should return true from cache and not make any API calls.
+		$this->assertTrue( $result );
+		$this->assertSame( 0, $api_call_count );
+	}
+
+	/**
+	 * Tests that fetch_unified_experience_preference caches API failures.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	#[RunInSeparateProcess]
+	#[PreserveGlobalState( false )]
+	public function test_fetch_unified_experience_preference_caches_failures() {
+		// Simulate being on an Atomic (WoA) site with proxy.
+		Cache::set( 'is_woa_site', true );
+		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
+
+		// Set up Jetpack connection mocking.
+		Constants::set_constant( 'JETPACK__WPCOM_JSON_API_BASE', 'https://public-api.wordpress.com' );
+
+		$user_id = wp_insert_user(
+			array(
+				'user_login' => 'test_cache_failure',
+				'user_pass'  => 'password',
+				'role'       => 'subscriber',
+			)
+		);
+		wp_set_current_user( $user_id );
+
+		// Mock user connection by setting user tokens.
+		\Jetpack_Options::update_option( 'user_tokens', array( $user_id => 'test.token.' . $user_id ) );
+		\Jetpack_Options::update_option( 'id', 12345 );
+
+		// Mock API failure.
+		add_filter( 'pre_http_request', array( $this, 'mock_preferences_api_error' ), 10, 3 );
+
+		// First call - should fail and cache the failure.
+		$result1 = $this->agents_manager->should_use_unified_experience();
+
+		remove_filter( 'pre_http_request', array( $this, 'mock_preferences_api_error' ), 10 );
+
+		$this->assertFalse( $result1 );
+
+		// Verify failure is cached.
+		$cached = get_transient( 'unified-experience-' . $user_id );
+		$this->assertSame( 0, $cached );
+	}
+
+	/**
+	 * Mock the preferences API to return enabled.
+	 *
+	 * @param mixed  $response The response.
+	 * @param array  $args The request args.
+	 * @param string $url The URL.
+	 * @return array The mocked response.
+	 */
+	public function mock_preferences_api_enabled( $response, $args, $url ) {
+		if ( strpos( $url, '/me/preferences' ) === false ) {
+			return $response;
+		}
+
+		return array(
+			'body'     => wp_json_encode( true, JSON_UNESCAPED_SLASHES ),
+			'response' => array(
+				'code'    => 200,
+				'message' => 'OK',
+			),
+		);
+	}
+
+	/**
+	 * Mock the preferences API to return disabled.
+	 *
+	 * @param mixed  $response The response.
+	 * @param array  $args The request args.
+	 * @param string $url The URL.
+	 * @return array The mocked response.
+	 */
+	public function mock_preferences_api_disabled( $response, $args, $url ) {
+		if ( strpos( $url, '/me/preferences' ) === false ) {
+			return $response;
+		}
+
+		return array(
+			'body'     => wp_json_encode( false, JSON_UNESCAPED_SLASHES ),
+			'response' => array(
+				'code'    => 200,
+				'message' => 'OK',
+			),
+		);
+	}
+
+	/**
+	 * Mock the preferences API to return an error.
+	 *
+	 * @param mixed  $response The response.
+	 * @param array  $args The request args.
+	 * @param string $url The URL.
+	 * @return \WP_Error The mocked error response.
+	 */
+	public function mock_preferences_api_error( $response, $args, $url ) {
+		if ( strpos( $url, '/me/preferences' ) === false ) {
+			return $response;
+		}
+
+		return new \WP_Error( 'http_request_failed', 'Connection failed' );
+	}
 }

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/agents-manager/Agents_Manager_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/agents-manager/Agents_Manager_Test.php
@@ -437,9 +437,11 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 
 		Functions\stubs(
 			array(
-				'is_automattician'   => true,
+				'is_automattician'         => true,
 				// Return calypso_preferences with unified_ai_chat enabled.
-				'get_user_attribute' => array( 'unified_ai_chat' => true ),
+				'get_user_attribute'       => array( 'unified_ai_chat' => true ),
+				// Simulate proxied request (required for unified experience).
+				'wpcom_is_proxied_request' => true,
 			)
 		);
 
@@ -525,6 +527,135 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 		// the call to /me?fields=unified_ai_chat will fail and return false.
 		$result = $this->agents_manager->should_use_unified_experience();
 
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * Tests that should_use_unified_experience returns false when wpcom_is_proxied_request returns false.
+	 *
+	 * On Simple sites, proxy detection uses the wpcom_is_proxied_request function.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	#[RunInSeparateProcess]
+	#[PreserveGlobalState( false )]
+	public function test_should_use_unified_experience_returns_false_when_wpcom_proxy_function_returns_false() {
+		// Simulate being on a Simple site.
+		Constants::set_constant( 'IS_WPCOM', true );
+
+		Functions\stubs(
+			array(
+				// Simulate non-proxied request via wpcom function.
+				'wpcom_is_proxied_request' => false,
+			)
+		);
+
+		$user_id = wp_insert_user(
+			array(
+				'user_login' => 'test_not_proxied_simple',
+				'user_pass'  => 'password',
+				'role'       => 'subscriber',
+			)
+		);
+		wp_set_current_user( $user_id );
+
+		$result = $this->agents_manager->should_use_unified_experience();
+
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * Tests that should_use_unified_experience returns false on WoA when not proxied (no constant/server var).
+	 *
+	 * On WoA/Garden sites, proxy detection falls back to A8C_PROXIED_REQUEST constant or server variable.
+	 */
+	public function test_should_use_unified_experience_returns_false_on_woa_when_not_proxied() {
+		// Simulate being on an Atomic (WoA) site without proxy.
+		Cache::set( 'is_woa_site', true );
+		// Do NOT set A8C_PROXIED_REQUEST constant or $_SERVER variable.
+
+		$user_id = wp_insert_user(
+			array(
+				'user_login' => 'test_not_proxied_woa',
+				'user_pass'  => 'password',
+				'role'       => 'subscriber',
+			)
+		);
+		wp_set_current_user( $user_id );
+
+		$result = $this->agents_manager->should_use_unified_experience();
+
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * Tests that should_use_unified_experience checks proxy via A8C_PROXIED_REQUEST constant on WoA.
+	 *
+	 * On WoA/Garden sites where wpcom_is_proxied_request doesn't exist,
+	 * proxy detection uses the A8C_PROXIED_REQUEST constant.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	#[RunInSeparateProcess]
+	#[PreserveGlobalState( false )]
+	public function test_should_use_unified_experience_uses_constant_for_proxy_on_woa() {
+		// Simulate being on an Atomic (WoA) site with proxy via constant.
+		Cache::set( 'is_woa_site', true );
+		Constants::set_constant( 'A8C_PROXIED_REQUEST', true );
+
+		$user_id = wp_insert_user(
+			array(
+				'user_login' => 'test_proxied_woa_constant',
+				'user_pass'  => 'password',
+				'role'       => 'subscriber',
+			)
+		);
+		wp_set_current_user( $user_id );
+
+		// The proxy check passes, but the API call will fail in test environment,
+		// so the result will still be false. This test verifies the proxy check
+		// doesn't block execution when the constant is set.
+		$result = $this->agents_manager->should_use_unified_experience();
+
+		// Result is false because API call fails, but importantly we got past the proxy check.
+		// If proxy check failed, we would have returned false before any API call attempt.
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * Tests that should_use_unified_experience checks proxy via $_SERVER on WoA.
+	 *
+	 * On WoA/Garden sites where wpcom_is_proxied_request doesn't exist,
+	 * proxy detection can also use the A8C_PROXIED_REQUEST server variable.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	#[RunInSeparateProcess]
+	#[PreserveGlobalState( false )]
+	public function test_should_use_unified_experience_uses_server_var_for_proxy_on_woa() {
+		// Simulate being on an Atomic (WoA) site with proxy via server variable.
+		Cache::set( 'is_woa_site', true );
+		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
+
+		$user_id = wp_insert_user(
+			array(
+				'user_login' => 'test_proxied_woa_server',
+				'user_pass'  => 'password',
+				'role'       => 'subscriber',
+			)
+		);
+		wp_set_current_user( $user_id );
+
+		// The proxy check passes, but the API call will fail in test environment.
+		$result = $this->agents_manager->should_use_unified_experience();
+
+		// Clean up server variable.
+		unset( $_SERVER['A8C_PROXIED_REQUEST'] );
+
+		// Result is false because API call fails, but we verified the proxy check passed.
 		$this->assertFalse( $result );
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/Automattic/jetpack/pull/46237#discussion_r1891656541

## Proposed changes:

* Add transient caching (1 minute TTL) for the unified experience preference check to avoid remote API calls on every page load
* Add proxy detection to limit the feature to proxied requests during internal testing phase
* Support both Simple sites (via `wpcom_is_proxied_request()`) and WoA/Garden sites (via `A8C_PROXIED_REQUEST` constant/server variable)
* Add connection state check before making API call to avoid unnecessary requests
* Rename method from `get_unified_experience_from_wpcom()` to `fetch_unified_experience_preference()` for clarity

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

N/A - Internal tooling improvement

## Does this pull request change what data or activity we track or use?

No changes to tracking.

## Testing instructions:

1. On a WoA or Garden site, access the site **without** the A8C proxy
2. Verify that `should_use_unified_experience()` returns `false` (the unified experience is disabled)
3. Access the site **with** the A8C proxy enabled
4. Verify that the unified experience check now proceeds (will still return false if the user hasn't opted in, but the proxy check passes)
5. Enable the unified experience preference for a user and verify it's cached:
   - First page load should make the API call
   - Subsequent page loads within 1 minute should use the cached value (no additional API calls)
6. Run the unit tests: `cd projects/packages/jetpack-mu-wpcom && composer test-php -- --filter=Agents_Manager_Test`

## My testing
I have  made the following manual tests:
- Simple site:
  - [x] Disabled when non-proxied.
  - [x] Enabled when opt-in enabled + proxied.
- Atomic site:
  - [x] Disabled when non-proxied (no requests).
  - [x] Enabled when opt-in enabled + proxied.
  - [x] Refresh did not make a new request until cache expired.
