### PR TITLE
Social: Fix social previews post data reactivity for attached media.

### DIFF
--- a/projects/js-packages/publicize-components/changelog/fix-social-preview-post-data-reactivity
+++ b/projects/js-packages/publicize-components/changelog/fix-social-preview-post-data-reactivity
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix social previews post data reactivity for attached media.

--- a/projects/js-packages/publicize-components/src/components/social-post-modal/post-preview.tsx
+++ b/projects/js-packages/publicize-components/src/components/social-post-modal/post-preview.tsx
@@ -15,9 +15,9 @@ import { useMemo } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
 import { __ } from '@wordpress/i18n';
 import useSocialMediaMessage from '../../hooks/use-social-media-message';
+import { useSocialPreviewPostData } from '../../hooks/use-social-preview-post-data';
 import { Connection } from '../../social-store/types';
 import { InstagramNoMediaNotice } from '../form/instagram-no-media-notice';
-import { usePostData } from '../social-previews/use-post-data';
 
 export type PostPreviewProps = {
 	connection: Connection;
@@ -54,7 +54,7 @@ export function PostPreview( { connection }: PostPreviewProps ) {
 		[ connection ]
 	);
 
-	const { image, media, title, description, url, excerpt } = usePostData();
+	const { image, media, title, description, url, excerpt } = useSocialPreviewPostData();
 	const message = ( useSocialMediaMessage().message || '' ).trim();
 
 	const commonProps = useMemo(

--- a/projects/js-packages/publicize-components/src/components/social-previews/modal.js
+++ b/projects/js-packages/publicize-components/src/components/social-previews/modal.js
@@ -8,13 +8,13 @@ import { Button, Modal, TabPanel } from '@wordpress/components';
 import { decodeEntities } from '@wordpress/html-entities';
 import { __ } from '@wordpress/i18n';
 import { close } from '@wordpress/icons';
+import { useSocialPreviewPostData } from '../../hooks/use-social-preview-post-data';
 import { useAvailableSerivces } from './use-available-services';
-import { usePostData } from './use-post-data';
 import './modal.scss';
 
 const SocialPreviewsModal = function SocialPreviewsModal( { onClose, initialTabName = null } ) {
 	const availableServices = useAvailableSerivces();
-	const { image, media, title, description, url, excerpt } = usePostData();
+	const { image, media, title, description, url, excerpt } = useSocialPreviewPostData();
 
 	return (
 		<Modal

--- a/projects/js-packages/publicize-components/src/hooks/use-social-preview-post-data/index.js
+++ b/projects/js-packages/publicize-components/src/hooks/use-social-preview-post-data/index.js
@@ -12,7 +12,7 @@ import { getMediaSourceUrl, getPostImageUrl } from './utils';
  *
  * @return {object} The post data.
  */
-export function usePostData() {
+export function useSocialPreviewPostData() {
 	const { attachedMedia, imageGeneratorSettings } = usePostMeta();
 
 	const { getEntityRecord } = useSelect( coreStore, [] );

--- a/projects/js-packages/publicize-components/src/hooks/use-social-preview-post-data/index.ts
+++ b/projects/js-packages/publicize-components/src/hooks/use-social-preview-post-data/index.ts
@@ -19,7 +19,6 @@ export function useSocialPreviewPostData() {
 	const { getEditedPostAttribute, getEditedPostContent } = useSelect( editorStore, [] );
 
 	return useMemo(
-		// eslint-disable-next-line no-unused-vars -- This is here temporarily to avoid prettier making the diff unreadable.
 		_ => {
 			const featuredImageId = getEditedPostAttribute( 'featured_media' );
 

--- a/projects/js-packages/publicize-components/src/hooks/use-social-preview-post-data/index.ts
+++ b/projects/js-packages/publicize-components/src/hooks/use-social-preview-post-data/index.ts
@@ -5,61 +5,39 @@ import { __ } from '@wordpress/i18n';
 import { useMemo } from 'react';
 import { usePostMeta } from '../../hooks/use-post-meta';
 import { getSigImageUrl } from '../../hooks/use-sig-preview/utils';
+import { PostData } from './types';
 import { getMediaSourceUrl, getPostImageUrl } from './utils';
 
 /**
- * Returns the post data.
+ * Returns the post data needed for social preview.
  *
- * @return {object} The post data.
+ * @return The post data.
  */
-export function useSocialPreviewPostData() {
+export function useSocialPreviewPostData(): PostData {
 	const { attachedMedia, imageGeneratorSettings } = usePostMeta();
 
-	const { getEntityRecord } = useSelect( coreStore, [] );
-	const { getEditedPostAttribute, getEditedPostContent } = useSelect( editorStore, [] );
+	const { getEditedPostAttribute } = useSelect( editorStore, [] );
 
-	return useMemo(
-		_ => {
-			const featuredImageId = getEditedPostAttribute( 'featured_media' );
+	const media = useSelect(
+		select => {
+			const { getEntityRecord } = select( coreStore );
 
-			// Use the featured image by default, if it's available.
-			let image = featuredImageId
-				? getMediaSourceUrl( getEntityRecord( 'postType', 'attachment', featuredImageId ) )
-				: '';
-
-			const sigImageUrl = imageGeneratorSettings.enabled
-				? getSigImageUrl( imageGeneratorSettings.token )
-				: '';
-			// If we have a SIG token, use it to generate the image URL.
-			if ( sigImageUrl ) {
-				image = sigImageUrl;
-			}
-
-			// If we still don't have an image, try to get it from the post content.
-			if ( ! image ) {
-				const postImageUrl = getPostImageUrl( getEditedPostContent() );
-
-				if ( postImageUrl ) {
-					image = postImageUrl;
-				}
-			}
-
-			const media = [];
+			const items = [];
 
 			for ( const item of attachedMedia ) {
 				// It can be a SIG (Social Image Generator) image allowed to be attached without an ID.
 				if ( ! item.id && item.url ) {
-					media.push( {
+					items.push( {
 						type: item.type || 'image/jpeg',
 						url: item.url,
-						alt: item.alt || '',
+						alt: '',
 					} );
 				} else {
 					// Otherwise, fetch the media details from the store.
 					const mediaItem = getEntityRecord( 'postType', 'attachment', item.id );
 
 					if ( mediaItem ) {
-						media.push( {
+						items.push( {
 							type: mediaItem.mime_type,
 							url: getMediaSourceUrl( mediaItem ),
 							alt: mediaItem.alt_text,
@@ -68,37 +46,66 @@ export function useSocialPreviewPostData() {
 				}
 			}
 
-			return {
-				title: (
-					getEditedPostAttribute( 'meta' )?.jetpack_seo_html_title ||
-					getEditedPostAttribute( 'title' ) ||
-					''
-				).trim(),
-				description: (
-					getEditedPostAttribute( 'meta' )?.advanced_seo_description ||
-					getEditedPostAttribute( 'excerpt' ) ||
-					getEditedPostAttribute( 'content' ).split( '<!--more' )[ 0 ] ||
-					__( 'Visit the post for more.', 'jetpack-publicize-components' ) ||
-					''
-				).trim(),
-				url: getEditedPostAttribute( 'link' ),
-				excerpt: (
-					getEditedPostAttribute( 'excerpt' ) ||
-					getEditedPostAttribute( 'content' ).split( '<!--more' )[ 0 ] ||
-					''
-				).trim(),
-				image,
-				media,
-				initialTabName: null,
-			};
+			return items;
 		},
-		[
-			attachedMedia,
-			getEditedPostAttribute,
-			getEditedPostContent,
-			getEntityRecord,
-			imageGeneratorSettings.enabled,
-			imageGeneratorSettings.token,
-		]
+		[ attachedMedia ]
 	);
+
+	const image = useSelect(
+		select => {
+			const { getEntityRecord } = select( coreStore );
+
+			const featuredImageId = select( editorStore ).getEditedPostAttribute( 'featured_media' );
+
+			// Use the featured image by default, if it's available.
+			let _image = featuredImageId
+				? getMediaSourceUrl( getEntityRecord( 'postType', 'attachment', featuredImageId ) )
+				: '';
+
+			const sigImageUrl = imageGeneratorSettings.enabled
+				? getSigImageUrl( imageGeneratorSettings.token )
+				: '';
+			// If we have a SIG token, use it to generate the image URL.
+			if ( sigImageUrl ) {
+				_image = sigImageUrl;
+			}
+
+			// If we still don't have an image, try to get it from the post content.
+			if ( ! _image ) {
+				const postImageUrl = getPostImageUrl( select( editorStore ).getEditedPostContent() );
+
+				if ( postImageUrl ) {
+					_image = postImageUrl;
+				}
+			}
+
+			return _image;
+		},
+		[ imageGeneratorSettings.enabled, imageGeneratorSettings.token ]
+	);
+
+	return useMemo( () => {
+		return {
+			title: (
+				getEditedPostAttribute( 'meta' )?.jetpack_seo_html_title ||
+				getEditedPostAttribute( 'title' ) ||
+				''
+			).trim(),
+			description: (
+				getEditedPostAttribute( 'meta' )?.advanced_seo_description ||
+				getEditedPostAttribute( 'excerpt' ) ||
+				getEditedPostAttribute( 'content' ).split( '<!--more' )[ 0 ] ||
+				__( 'Visit the post for more.', 'jetpack-publicize-components' ) ||
+				''
+			).trim(),
+			url: getEditedPostAttribute( 'link' ),
+			excerpt: (
+				getEditedPostAttribute( 'excerpt' ) ||
+				getEditedPostAttribute( 'content' ).split( '<!--more' )[ 0 ] ||
+				''
+			).trim(),
+			image,
+			media,
+		};
+	}, [ getEditedPostAttribute, media, image ] );
 }

--- a/projects/js-packages/publicize-components/src/hooks/use-social-preview-post-data/types.ts
+++ b/projects/js-packages/publicize-components/src/hooks/use-social-preview-post-data/types.ts
@@ -1,0 +1,12 @@
+export type PostData = {
+	title: string;
+	description: string;
+	url: string;
+	excerpt: string;
+	image: string;
+	media: Array< {
+		type: string;
+		url: string;
+		alt?: string;
+	} >;
+};

--- a/projects/js-packages/publicize-components/src/hooks/use-social-preview-post-data/utils.ts
+++ b/projects/js-packages/publicize-components/src/hooks/use-social-preview-post-data/utils.ts
@@ -8,7 +8,7 @@ import type { Attachment } from '@wordpress/core-data';
  */
 export function getMediaSourceUrl( media: Attachment | null ): string {
 	if ( ! media ) {
-		return null;
+		return '';
 	}
 
 	// Try getting the large size (1024px width) and fallback to the full size.

--- a/projects/js-packages/publicize-components/src/hooks/use-social-preview-post-data/utils.ts
+++ b/projects/js-packages/publicize-components/src/hooks/use-social-preview-post-data/utils.ts
@@ -1,10 +1,12 @@
+import type { Attachment } from '@wordpress/core-data';
+
 /**
  * Gets the URL of the media. Tries loading a smaller size (1024px width) if available and falls back to the full size.
  *
- * @param {object} media - Media object
- * @return {?string} URL address
+ * @param {Attachment} media - Media object
+ * @return URL address
  */
-export function getMediaSourceUrl( media ) {
+export function getMediaSourceUrl( media: Attachment | null ): string {
 	if ( ! media ) {
 		return null;
 	}
@@ -17,9 +19,9 @@ export function getMediaSourceUrl( media ) {
  * Gets the URL of an image from the post body
  *
  * @param {string} editedPostContent - The post content coming from core/editor
- * @return {?string} URL address
+ * @return URL address
  */
-export function getPostImageUrl( editedPostContent ) {
+export function getPostImageUrl( editedPostContent: string ): string | null {
 	const parser = new DOMParser();
 	const doc = parser.parseFromString( editedPostContent, 'text/html' );
 	const imgElements = Array.from( doc.querySelectorAll( 'img' ) );


### PR DESCRIPTION
Closes SOCIAL-287

Currently, when a custom image is attached to the post for Social, the image is not reflected in the social previews. The reason is that the `usePostData` hook is not reactive to changes for attached media in the data store.
So, if you open the previews modal before the media item details are fetched, the change in the media item after it's fetched is not reflected. This PR aims to fix it.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* This PR, after moving and converting `usePostData` to TypeScipt, extracts the logic for media and image computation out of the `useMemo` and uses `useSelect` for both to ensure they reflect the changes to the data store.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* To reproduce the issue on trunk, attach a custom image for Social for a post and save
* Add this snippet somewhere, e.g. `tools/docker/mu-plugins/0-snippets.php` for JT to instantly open the modal on page load

<details><summary>SNIPPET (Click to expand)</summary>

```php
/**
 * When block editor is loaded, open the Jetpack sidebar by default, along with unified modal
 */
add_action(
	'enqueue_block_editor_assets',
	function () {
		$open_jetpack_sidebar = 'wp.data.dispatch( "core/interface" ).enableComplementaryArea( "core", "jetpack-sidebar/jetpack" );';
		$open_unified_modal   = 'wp.data.dispatch( "jetpack-social-plugin" ).openUnifiedModal();';

		$actions = implode(
			'',
			array(
				$open_jetpack_sidebar,
				$open_unified_modal,
			)
		);

		wp_add_inline_script(
			'jetpack-social-editor',
			sprintf( 'wp.domReady( function() {%s} );', $actions )
		);
	},
	20
);
```

</details>

* Reload the editor page where you saved the custom image
* The preview modal should load instantly
* Confirm that the custom image is NOT shown by the social preview. It shows up on after closing and re-opening the modal
* Generate an image using AI
* Confirm that the image is NOT reflected in the preview
* Now checkout this branch
* Reload the page
* Confirm that the attached image is reflected in the preview. There may be a slight delay while the API call for media finishes
* Generate an image using AI
* Confirm that the image is immediately reflected in the preview

<table>
    <tbody>
        <tr>
            <th>BEFORE</th>
            <th>AFTER</th>
        </tr>
        <tr>
            <td>

https://github.com/user-attachments/assets/c476538f-4ba9-407e-9939-70df6783eeff

</td>
            <td>

https://github.com/user-attachments/assets/868cc5db-660e-4784-9a3e-d3f22bf8ebc3

</td>
        </tr>
    </tbody>
</table>