### PR TITLE
Social: Adjust media selection for Replace action

### DIFF
--- a/projects/js-packages/publicize-components/changelog/update-social-media-selection
+++ b/projects/js-packages/publicize-components/changelog/update-social-media-selection
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Adjust media selection for Replace action.

--- a/projects/js-packages/publicize-components/src/components/media-section-v2/media-source-menu.tsx
+++ b/projects/js-packages/publicize-components/src/components/media-section-v2/media-source-menu.tsx
@@ -5,7 +5,7 @@
 
 import { Button, Dropdown, MenuGroup } from '@wordpress/components';
 import { useCallback, useMemo } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import MediaSourceMenuItem from './media-source-menu-item';
 import styles from './styles.module.scss';
 import { MediaSourceMenuProps } from './types';
@@ -61,7 +61,13 @@ export default function MediaSourceMenu( {
 	const renderContent = useCallback(
 		( { onClose }: { onClose: () => void } ) => (
 			<>
-				<MenuGroup label={ __( 'Link Preview', 'jetpack-publicize-components' ) }>
+				<MenuGroup
+					label={ _x(
+						'For link preview',
+						'The image source to use for post link preview on social media.',
+						'jetpack-publicize-components'
+					) }
+				>
 					{ linkPreviewOptions.map( option => (
 						<MediaSourceMenuItem
 							key={ option.id }
@@ -72,7 +78,13 @@ export default function MediaSourceMenu( {
 						/>
 					) ) }
 				</MenuGroup>
-				<MenuGroup label={ __( 'Attachment', 'jetpack-publicize-components' ) }>
+				<MenuGroup
+					label={ _x(
+						'For attachment',
+						'The media source to use for post attachment on social media.',
+						'jetpack-publicize-components'
+					) }
+				>
 					{ attachmentOptions.map( option => (
 						<MediaSourceMenuItem
 							key={ option.id }

--- a/projects/js-packages/publicize-components/src/components/media-section-v2/test/index.test.tsx
+++ b/projects/js-packages/publicize-components/src/components/media-section-v2/test/index.test.tsx
@@ -247,7 +247,7 @@ describe( 'MediaSectionV2', () => {
 			await user.click( screen.getByRole( 'button', { name: 'Replace' } ) );
 
 			// Select SIG
-			await user.click( screen.getByRole( 'menuitem', { name: 'Social Image Template' } ) );
+			await user.click( screen.getByRole( 'menuitem', { name: 'Use template' } ) );
 
 			expect( mockUpdateJetpackSocialOptions ).toHaveBeenCalledWith( {
 				media_source: 'sig',
@@ -256,7 +256,7 @@ describe( 'MediaSectionV2', () => {
 			} );
 		} );
 
-		it( 'should call updateJetpackSocialOptions when selecting Featured Image', async () => {
+		it( 'should call updateJetpackSocialOptions when selecting Use featured image', async () => {
 			const user = userEvent.setup();
 
 			// Start with SIG enabled
@@ -270,8 +270,8 @@ describe( 'MediaSectionV2', () => {
 			// Open dropdown
 			await user.click( screen.getByRole( 'button', { name: 'Replace' } ) );
 
-			// Select Featured Image
-			await user.click( screen.getByRole( 'menuitem', { name: 'Featured Image' } ) );
+			// Select Use featured image
+			await user.click( screen.getByRole( 'menuitem', { name: 'Use featured image' } ) );
 
 			expect( mockUpdateJetpackSocialOptions ).toHaveBeenCalledWith( {
 				media_source: 'featured-image',
@@ -295,7 +295,7 @@ describe( 'MediaSectionV2', () => {
 			await user.click( screen.getByRole( 'button', { name: 'Replace' } ) );
 
 			// Select SIG
-			await user.click( screen.getByRole( 'menuitem', { name: 'Social Image Template' } ) );
+			await user.click( screen.getByRole( 'menuitem', { name: 'Use template' } ) );
 
 			expect( mockRecordEvent ).toHaveBeenCalledWith( 'jetpack_social_media_source_changed', {
 				test: 'data',

--- a/projects/js-packages/publicize-components/src/components/media-section-v2/test/media-source-menu.test.tsx
+++ b/projects/js-packages/publicize-components/src/components/media-section-v2/test/media-source-menu.test.tsx
@@ -70,16 +70,16 @@ describe( 'MediaSourceMenu', () => {
 		await user.click( screen.getByRole( 'button', { name: 'Select' } ) );
 
 		// Check that menu groups are rendered
-		expect( screen.getByText( 'Link Preview' ) ).toBeInTheDocument();
-		expect( screen.getByText( 'Attachment' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'For link preview' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'For attachment' ) ).toBeInTheDocument();
 
 		// Check that menu items are rendered
-		expect( screen.getByRole( 'menuitem', { name: 'Featured Image' } ) ).toBeInTheDocument();
-		expect( screen.getByRole( 'menuitem', { name: 'Social Image Template' } ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'menuitem', { name: 'Use featured image' } ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'menuitem', { name: 'Use template' } ) ).toBeInTheDocument();
 		expect( screen.getByRole( 'menuitem', { name: 'From Media Library' } ) ).toBeInTheDocument();
 	} );
 
-	it( 'should call onSelect when Featured Image is clicked', async () => {
+	it( 'should call onSelect when Use featured image is clicked', async () => {
 		const user = userEvent.setup();
 
 		render(
@@ -91,12 +91,12 @@ describe( 'MediaSourceMenu', () => {
 		);
 
 		await user.click( screen.getByRole( 'button', { name: 'Select' } ) );
-		await user.click( screen.getByRole( 'menuitem', { name: 'Featured Image' } ) );
+		await user.click( screen.getByRole( 'menuitem', { name: 'Use featured image' } ) );
 
 		expect( mockOnSelect ).toHaveBeenCalledWith( 'featured-image' );
 	} );
 
-	it( 'should call onSelect when Social Image Template is clicked', async () => {
+	it( 'should call onSelect when Use template is clicked', async () => {
 		const user = userEvent.setup();
 
 		render(
@@ -108,7 +108,7 @@ describe( 'MediaSourceMenu', () => {
 		);
 
 		await user.click( screen.getByRole( 'button', { name: 'Select' } ) );
-		await user.click( screen.getByRole( 'menuitem', { name: 'Social Image Template' } ) );
+		await user.click( screen.getByRole( 'menuitem', { name: 'Use template' } ) );
 
 		expect( mockOnSelect ).toHaveBeenCalledWith( 'sig' );
 	} );
@@ -160,7 +160,7 @@ describe( 'MediaSourceMenu', () => {
 
 		// Clicking custom trigger should open dropdown
 		await user.click( screen.getByRole( 'button', { name: 'Custom Trigger' } ) );
-		expect( screen.getByText( 'Link Preview' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'For link preview' ) ).toBeInTheDocument();
 	} );
 
 	it( 'should render menu with current source item', async () => {
@@ -177,7 +177,7 @@ describe( 'MediaSourceMenu', () => {
 		await user.click( screen.getByRole( 'button', { name: 'Select' } ) );
 
 		// Verify the menu renders with all options including the current source
-		const featuredImageItem = screen.getByRole( 'menuitem', { name: 'Featured Image' } );
+		const featuredImageItem = screen.getByRole( 'menuitem', { name: 'Use featured image' } );
 		expect( featuredImageItem ).toBeInTheDocument();
 
 		// Verify clicking the current source still triggers onSelect

--- a/projects/js-packages/publicize-components/src/components/media-section-v2/utils/media-source-options.ts
+++ b/projects/js-packages/publicize-components/src/components/media-section-v2/utils/media-source-options.ts
@@ -16,19 +16,8 @@ import { MediaSourceOption, MediaSourceType } from '../types';
 export function getMediaSourceOptions(): MediaSourceOption[] {
 	return [
 		{
-			id: 'featured-image',
-			label: __( 'Featured Image', 'jetpack-publicize-components' ),
-			description: __( 'You are using your post featured image.', 'jetpack-publicize-components' ),
-			icon: image,
-			group: 'link-preview',
-			attachmentDescription: __(
-				'Shares your image as a regular post, without a link preview card, for higher engagement.',
-				'jetpack-publicize-components'
-			),
-		},
-		{
 			id: 'sig',
-			label: __( 'Social Image Template', 'jetpack-publicize-components' ),
+			label: __( 'Use template', 'jetpack-publicize-components' ),
 			description: __( 'You are using the template.', 'jetpack-publicize-components' ),
 			icon: starEmpty,
 			group: 'link-preview',
@@ -38,11 +27,15 @@ export function getMediaSourceOptions(): MediaSourceOption[] {
 			),
 		},
 		{
-			id: 'media-library',
-			label: __( 'From Media Library', 'jetpack-publicize-components' ),
-			description: __( 'You are using a custom image.', 'jetpack-publicize-components' ),
-			icon: mediaIcon,
-			group: 'attachment',
+			id: 'featured-image',
+			label: __( 'Use featured image', 'jetpack-publicize-components' ),
+			description: __( 'You are using your post featured image.', 'jetpack-publicize-components' ),
+			icon: image,
+			group: 'link-preview',
+			attachmentDescription: __(
+				'Shares your image as a regular post, without a link preview card, for higher engagement.',
+				'jetpack-publicize-components'
+			),
 		},
 		{
 			id: 'ai-image',
@@ -54,6 +47,13 @@ export function getMediaSourceOptions(): MediaSourceOption[] {
 				'Shares your AI-generated image as an attachment for higher engagement.',
 				'jetpack-publicize-components'
 			),
+		},
+		{
+			id: 'media-library',
+			label: __( 'From Media Library', 'jetpack-publicize-components' ),
+			description: __( 'You are using a custom image.', 'jetpack-publicize-components' ),
+			icon: mediaIcon,
+			group: 'attachment',
 		},
 	];
 }


### PR DESCRIPTION
Closes SOCIAL-285

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Update the copy and order for media selection dropdown

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to social panel for a post
* Click on Set image or Replace button in the media UI
* Confirm that the order and copy is as per the design - DDjUX6bySvzZ302nXgNPfo-fi-5519_5454

| Before | After |
|--------|--------|
| <img width="277" height="326" alt="Screenshot 2025-12-19 at 4 29 46 PM" src="https://github.com/user-attachments/assets/1d26c439-40a1-44ff-885c-a4d4359f7b4d" /> | <img width="277" height="316" alt="Screenshot 2025-12-19 at 4 29 23 PM" src="https://github.com/user-attachments/assets/098e6952-7a81-4b62-a618-e308cfa2a843" /> | 