### PR TITLE
Social: Show inactive message when connection is disabled in preview modal

### DIFF
--- a/projects/js-packages/publicize-components/changelog/SOCIAL-288
+++ b/projects/js-packages/publicize-components/changelog/SOCIAL-288
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Show inactive message when connection is disabled in preview modal

--- a/projects/js-packages/publicize-components/src/components/unified-modal/social-post-preview/content.tsx
+++ b/projects/js-packages/publicize-components/src/components/unified-modal/social-post-preview/content.tsx
@@ -61,9 +61,7 @@ export function Content( { baseId, selectedConnection, forSmallScreen }: Content
 				</Flex>
 			) : (
 				<Flex className={ styles[ 'inactive-preview' ] } align="center" justify="center">
-					<p>
-						{ __( 'No post will be shared for this account.', 'jetpack-publicize-components' ) }
-					</p>
+					<p>{ __( 'Enable this account to see the preview.', 'jetpack-publicize-components' ) }</p>
 				</Flex>
 			) }
 		</div>

--- a/projects/js-packages/publicize-components/src/components/unified-modal/social-post-preview/content.tsx
+++ b/projects/js-packages/publicize-components/src/components/unified-modal/social-post-preview/content.tsx
@@ -1,5 +1,6 @@
 import { Flex } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
 import { useEffect } from 'react';
 import { store as socialStore } from '../../../social-store';
 import { Connection } from '../../../social-store/types';
@@ -54,9 +55,17 @@ export function Content( { baseId, selectedConnection, forSmallScreen }: Content
 			id={ `${ baseId }-preview-content-${ selectedConnection.connection_id }` }
 			aria-labelledby={ `${ baseId }-preview-tab-${ selectedConnection.connection_id }` }
 		>
-			<Flex className={ styles.preview } align="center" justify="center">
-				<PostPreview connection={ selectedConnection } />
-			</Flex>
+			{ selectedConnection.enabled ? (
+				<Flex className={ styles.preview } align="center" justify="center">
+					<PostPreview connection={ selectedConnection } />
+				</Flex>
+			) : (
+				<Flex className={ styles[ 'inactive-preview' ] } align="center" justify="center">
+					<p>
+						{ __( 'No post will be shared for this account.', 'jetpack-publicize-components' ) }
+					</p>
+				</Flex>
+			) }
 		</div>
 	);
 }

--- a/projects/js-packages/publicize-components/src/components/unified-modal/social-post-preview/styles.module.scss
+++ b/projects/js-packages/publicize-components/src/components/unified-modal/social-post-preview/styles.module.scss
@@ -88,12 +88,18 @@
 	&[role="tabpanel"] {
 		background-color: gb.$gray-100;
 		padding: 1.5rem;
+		display: grid;
+		place-items: center;
 	}
 
 	.preview {
 		height: 100%;
 		max-width: max-content;
 		margin: 0 auto;
+	}
+
+	.inactive-preview {
+		color: gb.$gray-600;
 	}
 
 	.toggle-wrapper {

--- a/projects/js-packages/publicize-components/src/components/unified-modal/social-post-preview/use-modal-screen.tsx
+++ b/projects/js-packages/publicize-components/src/components/unified-modal/social-post-preview/use-modal-screen.tsx
@@ -3,7 +3,7 @@ import { useBreakpoint } from '@automattic/viewport-react';
 import { useSelect } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
 import { __, _x } from '@wordpress/i18n';
-import { useId, useMemo, useState } from 'react';
+import { useCallback, useId, useMemo, useState } from 'react';
 import useSocialMediaConnections from '../../../hooks/use-social-media-connections';
 import { Connection } from '../../../social-store/types';
 import { ScreenDetails } from '../types';
@@ -20,7 +20,16 @@ import { useFooterActions } from './use-footer-actions';
 export function useModalScreen(): ScreenDetails {
 	const { connections } = useSocialMediaConnections();
 
-	const [ selectedConnection, setSelectedConnection ] = useState< Connection >( connections[ 0 ] );
+	const [ selectedId, setSelectedId ] = useState( connections[ 0 ]?.connection_id );
+
+	// Get fresh connection data from the array to react to enabled/disabled changes
+	const selectedConnection =
+		connections.find( c => c.connection_id === selectedId ) ?? connections[ 0 ];
+
+	const onSelectConnection = useCallback(
+		( c: Connection ) => setSelectedId( c.connection_id ),
+		[]
+	);
 
 	const baseId = useId();
 	const isSmallScreen = useBreakpoint( '<660px' );
@@ -48,7 +57,7 @@ export function useModalScreen(): ScreenDetails {
 			sidebar: isSmallScreen ? null : (
 				<Sidebar
 					baseId={ baseId }
-					onSelectConnection={ setSelectedConnection }
+					onSelectConnection={ onSelectConnection }
 					selectedConnection={ selectedConnection }
 				/>
 			),
@@ -67,6 +76,7 @@ export function useModalScreen(): ScreenDetails {
 			isPrePublishScreen,
 			isSmallScreen,
 			baseId,
+			onSelectConnection,
 			selectedConnection,
 			footerActions,
 		]

--- a/projects/js-packages/publicize-components/src/components/unified-modal/social-post-preview/use-modal-screen.tsx
+++ b/projects/js-packages/publicize-components/src/components/unified-modal/social-post-preview/use-modal-screen.tsx
@@ -5,6 +5,7 @@ import { store as editorStore } from '@wordpress/editor';
 import { __, _x } from '@wordpress/i18n';
 import { useCallback, useId, useMemo, useState } from 'react';
 import useSocialMediaConnections from '../../../hooks/use-social-media-connections';
+import { store as socialStore } from '../../../social-store';
 import { Connection } from '../../../social-store/types';
 import { ScreenDetails } from '../types';
 import { Content } from './content';
@@ -22,9 +23,9 @@ export function useModalScreen(): ScreenDetails {
 
 	const [ selectedId, setSelectedId ] = useState( connections[ 0 ]?.connection_id );
 
-	// Get fresh connection data from the array to react to enabled/disabled changes
 	const selectedConnection =
-		connections.find( c => c.connection_id === selectedId ) ?? connections[ 0 ];
+		useSelect( select => select( socialStore ).getConnectionById( selectedId ), [ selectedId ] ) ??
+		connections[ 0 ];
 
 	const onSelectConnection = useCallback(
 		( c: Connection ) => setSelectedId( c.connection_id ),


### PR DESCRIPTION
Fixes SOCIAL-288

## Proposed changes:
* When a social connection is disabled (toggled off) in the preview modal, show "No post will be shared for this account." instead of the regular preview
* Store only the connection ID in state and derive the fresh connection from the connections array to properly react to enabled/disabled changes

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Testing instructions:

1. Go to a post editor with Jetpack Social connected accounts
2. Open the Social preview modal
3. Toggle a connection ON, observe the preview shows
4. Toggle the same connection OFF
5. Verify the preview area now shows "No post will be shared for this account." centered in the panel
6. Toggle it back ON, verify the preview returns


https://github.com/user-attachments/assets/7ef37403-1a15-4f59-8770-fafe433e2315