### PR TITLE
Social: Update unified modal footer button labels

### DIFF
--- a/projects/js-packages/publicize-components/changelog/update-social-unified-modal-button-labels
+++ b/projects/js-packages/publicize-components/changelog/update-social-unified-modal-button-labels
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update unified modal footer button labels.

--- a/projects/js-packages/publicize-components/src/components/unified-modal/edit-template/use-modal-screen.tsx
+++ b/projects/js-packages/publicize-components/src/components/unified-modal/edit-template/use-modal-screen.tsx
@@ -1,5 +1,5 @@
 import { useSelect } from '@wordpress/data';
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import { useCallback, useMemo, useState } from 'react';
 import useFeaturedImage from '../../../hooks/use-featured-image';
 import useImageGeneratorConfig from '../../../hooks/use-image-generator-config';
@@ -58,7 +58,9 @@ export function useModalScreen(): ScreenDetails {
 			content: <Content localState={ localState } />,
 			footerActions: [
 				{
-					text: __( 'Save Changes', 'jetpack-publicize-components' ),
+					text: isScreenLocked
+						? _x( 'Close', 'Button text to close the modal.', 'jetpack-publicize-components' )
+						: _x( 'Done', 'Button text to save changes.', 'jetpack-publicize-components' ),
 					variant: 'primary',
 					onClick: handleSave,
 				},

--- a/projects/js-packages/publicize-components/src/components/unified-modal/social-post-preview/use-footer-actions.tsx
+++ b/projects/js-packages/publicize-components/src/components/unified-modal/social-post-preview/use-footer-actions.tsx
@@ -1,7 +1,7 @@
 import { Button } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
-import { __ } from '@wordpress/i18n';
+import { _x } from '@wordpress/i18n';
 import { useMemo } from 'react';
 import usePublicizeConfig from '../../../hooks/use-publicize-config';
 import ScheduleButton from '../../schedule-button';
@@ -28,7 +28,7 @@ export function useFooterActions(): ScreenDetails[ 'footerActions' ] {
 		return [
 			( { navigate } ) => (
 				<Button key="save" variant="primary" onClick={ navigate }>
-					{ __( 'Save Changes', 'jetpack-publicize-components' ) }
+					{ _x( 'Close', 'Button text to close the modal.', 'jetpack-publicize-components' ) }
 				</Button>
 			),
 		];


### PR DESCRIPTION
Completes SOCIAL-289

The current “Save changes” button in the footer of the preview modal does not actually save changes; it just closes the modal. This can mislead users into thinking changes might be reverted if they cancel, or that they need to explicitly save.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Update the modal footer buttons from "Save changes" to "Close" or "Done"

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* For a new post open the social preview modal
* Confirm that the footer button now says "Close"
* From the sidebar set the media option to use template
* Click on Edit template
* Confirm that the footer button says, "Close"
* Open the preview modal again
* Click on Edit template from the modal
* Confirm that the button now says "Done" instead of "Close" because we just want to navigate back


https://github.com/user-attachments/assets/1fd1ab1d-952b-4fd2-8e9d-e15cb781349e



