### PR TITLE
Feature gating for Donations payment block

### DIFF
--- a/projects/plugins/jetpack/changelog/update-feature-gating-for-payments
+++ b/projects/plugins/jetpack/changelog/update-feature-gating-for-payments
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Feature gating for two blocks

--- a/projects/plugins/jetpack/class.jetpack-gutenberg.php
+++ b/projects/plugins/jetpack/class.jetpack-gutenberg.php
@@ -1234,6 +1234,23 @@ class Jetpack_Gutenberg {
 	}
 
 	/**
+	 * Get default required plan for blocks that need a fallback when no plan is found in features data.
+	 * This ensures upgrade banners appear for blocks that are available via WPCOM_ALL_SITES/JETPACK_ALL_SITES
+	 * but should still show upgrade prompts.
+	 *
+	 * @param string $slug Block slug.
+	 * @return string|false Plan slug if a default should be used, false otherwise.
+	 */
+	private static function get_default_plan_for_block( $slug ) {
+		$default_plans = array(
+			'donations'       => 'value_bundle', // Premium plan slug for WordPress.com.
+			'payment-buttons' => 'value_bundle', // Premium plan slug for WordPress.com.
+		);
+
+		return isset( $default_plans[ $slug ] ) ? $default_plans[ $slug ] : false;
+	}
+
+	/**
 	 * Set the availability of the block as the editor
 	 * is loaded.
 	 *
@@ -1267,6 +1284,13 @@ class Jetpack_Gutenberg {
 
 			if ( ! empty( $features_data['available'][ $slug ] ) ) {
 				$plan = $features_data['available'][ $slug ][0];
+			}
+
+			if ( empty( $plan ) ) {
+				$default_plan = self::get_default_plan_for_block( $slug );
+				if ( $default_plan ) {
+					$plan = $default_plan;
+				}
 			}
 		} else {
 			// Jetpack sites.

--- a/projects/plugins/jetpack/extensions/blocks/donations/donations.php
+++ b/projects/plugins/jetpack/extensions/blocks/donations/donations.php
@@ -31,6 +31,7 @@ function register_block() {
 			__DIR__,
 			array(
 				'render_callback' => __NAMESPACE__ . '\render_block',
+				'plan_check'      => true,
 			)
 		);
 	}

--- a/projects/plugins/wpcomsh/changelog/update-feature-gating-for-payments
+++ b/projects/plugins/wpcomsh/changelog/update-feature-gating-for-payments
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Feature gating for two blocks

--- a/projects/plugins/wpcomsh/wpcom-features/class-wpcom-features.php
+++ b/projects/plugins/wpcomsh/wpcom-features/class-wpcom-features.php
@@ -735,6 +735,10 @@ class WPCOM_Features {
 				'sticker_not_present' => 'gating-business-q1',
 				self::WPCOM_ALL_SITES,
 			),
+			array(
+				'sticker_not_present' => 'gating-business-q1',
+				self::WPCOM_PERSONAL_AND_HIGHER_PLANS,
+			),
 			self::WPCOM_PREMIUM_AND_HIGHER_PLANS,
 			self::JETPACK_ALL_SITES,
 		),

--- a/projects/plugins/wpcomsh/wpcom-features/class-wpcom-features.php
+++ b/projects/plugins/wpcomsh/wpcom-features/class-wpcom-features.php
@@ -731,7 +731,11 @@ class WPCOM_Features {
 			self::WOO_HOSTED_PLANS,
 		),
 		self::DONATIONS                         => array(
-			self::WPCOM_ALL_SITES,
+			array(
+				'sticker_not_present' => 'gating-business-q1',
+				self::WPCOM_ALL_SITES,
+			),
+			self::WPCOM_PREMIUM_AND_HIGHER_PLANS,
 			self::JETPACK_ALL_SITES,
 		),
 		// ECOMMERCE_MANAGED_PLUGINS - Can install the plugin bundle that comes with eCommerce plans.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes DOTCOM-15586

## Proposed changes:

* Add feature gating for Donations

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:

```
jetpack build --production plugins/jetpack
jetpack rsync wpcomsh yourdevblog.wordpress.com@sftp.wp.com:/srv/htdocs/wp-content/mu-plugins/wpcomsh
jetpack rsync jetpack yourdevblog.wordpress.com@sftp.wp.com:/srv/htdocs/wp-content/plugins/jetpack
```

Now check the /donations Gutenberg block with a Personal site.

```
add_blog_sticker( 'gating-business-q1', null, null, 123 );
```

Adding the sticker should make the block go behind a flag.

Notes:
- It's easier to test with two separate dev blogs, one with, and one without the sticker
- The donations sticker_not_present definition looks a bit funny. That's because WPCOM_ALL_SITES wouldn't work on Atomic sites - nobody expected Free Atomic sites, and fixing it is out of scope. The issue is that $blog->registered is checked, which exists in WPCOM context.