### PR TITLE
Forms: fix 'Learn more' link in notification settings

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-learn-more-notification-settings
+++ b/projects/packages/forms/changelog/fix-forms-learn-more-notification-settings
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: update 'Learn more' link in form notification settings.

--- a/projects/packages/forms/src/blocks/contact-form/components/notifications-settings.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/notifications-settings.js
@@ -1,4 +1,5 @@
 import { isWpcomPlatformSite } from '@automattic/jetpack-script-data';
+import { WpcomSupportLink } from '@automattic/jetpack-shared-extension-utils/components';
 import { FormTokenField, ToggleControl, ExternalLink } from '@wordpress/components';
 import { store as coreStore } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
@@ -56,9 +57,10 @@ const NotificationsSettings = ( {
 	// All available user names for suggestions
 	const allUserNames = eligibleUsers.map( user => user.name || user.slug );
 
-	const supportNotificationsLink = isWpcomPlatformSite()
-		? 'https://jetpack.com/support/notifications/'
-		: 'https://wordpress.com/support/notifications/';
+	const isWpcom = isWpcomPlatformSite();
+	const wpcomSupportLink =
+		'https://wordpress.com/support/wordpress-editor/blocks/form-block/view-contact-form-messages/#receive-push-notifications';
+	const jetpackSupportLink = 'https://jetpack.com/support/notifications/';
 
 	return (
 		<>
@@ -79,7 +81,11 @@ const NotificationsSettings = ( {
 							'jetpack-forms'
 						),
 						{
-							pushNotificationsLink: <ExternalLink href={ supportNotificationsLink } />,
+							pushNotificationsLink: isWpcom ? (
+								<WpcomSupportLink supportLink={ wpcomSupportLink } />
+							) : (
+								<ExternalLink href={ jetpackSupportLink } />
+							),
 						}
 					) }
 					checked={ localFormNotifications }

--- a/projects/packages/forms/tests/js/contact-form/components/notifications-settings.test.js
+++ b/projects/packages/forms/tests/js/contact-form/components/notifications-settings.test.js
@@ -177,6 +177,15 @@ await jest.unstable_mockModule( '@automattic/jetpack-shared-extension-utils', ()
 	hasFeatureFlag: jest.fn( () => true ),
 } ) );
 
+// Mock Jetpack shared extension utils components
+await jest.unstable_mockModule( '@automattic/jetpack-shared-extension-utils/components', () => ( {
+	WpcomSupportLink: ( { supportLink, children } ) => (
+		<a href={ supportLink } data-testid="wpcom-support-link">
+			{ children }
+		</a>
+	),
+} ) );
+
 // Mock Jetpack script data
 await jest.unstable_mockModule( '@automattic/jetpack-script-data', () => ( {
 	isWpcomPlatformSite: jest.fn( () => false ),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes FORMS-475

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Use WpcomSupportLink component to open the link in the Help center

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Insert a form block
2. In the Form block settings, open the Form notifications section.
3. Under "Enable notifications for responses", there's a "Learn more" link.
4. Click on the "Learn more" link and check that in WPCOM it opens the help center like in the image below:
<img width="1409" height="985" alt="Screenshot 2025-12-22 at 13 22 00" src="https://github.com/user-attachments/assets/57736cd1-ce03-4aa3-aeee-f2694788c890" />
5. In Jetpack it should open https://jetpack.com/support/notifications in a new tab 

