### PR TITLE
Publicize: Remove unused feature flag logic

### DIFF
--- a/projects/packages/publicize/.phan/baseline.php
+++ b/projects/packages/publicize/.phan/baseline.php
@@ -9,7 +9,6 @@
  */
 return [
     // # Issue statistics:
-    // PhanDeprecatedFunction : 1 occurrences
     // PhanPluginMixedKeyNoKey : 8 occurrences
     // PhanPluginDuplicateConditionalNullCoalescing : 7 occurrences
     // PhanPluginUnreachableCode : 4 occurrences
@@ -18,6 +17,7 @@ return [
     // PhanTypeMismatchArgumentNullable : 2 occurrences
     // PhanTypeMismatchReturnProbablyReal : 2 occurrences
     // PhanTypeMissingReturn : 2 occurrences
+    // PhanDeprecatedFunction : 1 occurrence
     // PhanParamSignatureMismatch : 1 occurrence
     // PhanPluginDuplicateExpressionAssignmentOperation : 1 occurrence
     // PhanPluginSimplifyExpressionBool : 1 occurrence
@@ -33,7 +33,7 @@ return [
     'file_suppressions' => [
         'src/class-connections.php' => ['PhanUndeclaredClassMethod', 'PhanUndeclaredMethod'],
         'src/class-keyring-helper.php' => ['PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchDefault'],
-        'src/class-publicize-base.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanPluginSimplifyExpressionBool', 'PhanSuspiciousMagicConstant', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentNullable', 'PhanTypeMismatchArgumentNullableInternal', 'PhanTypeMismatchDimFetch'],
+        'src/class-publicize-base.php' => ['PhanDeprecatedFunction', 'PhanPluginDuplicateConditionalNullCoalescing', 'PhanPluginSimplifyExpressionBool', 'PhanSuspiciousMagicConstant', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentNullable', 'PhanTypeMismatchArgumentNullableInternal', 'PhanTypeMismatchDimFetch'],
         'src/class-publicize-ui.php' => ['PhanPluginDuplicateExpressionAssignmentOperation', 'PhanTypeMismatchReturnProbablyReal'],
         'src/class-publicize.php' => ['PhanParamSignatureMismatch', 'PhanTypeMismatchArgument', 'PhanTypeMissingReturn'],
         'src/class-rest-controller.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchReturnProbablyReal'],

--- a/projects/packages/publicize/.phan/baseline.php
+++ b/projects/packages/publicize/.phan/baseline.php
@@ -9,6 +9,7 @@
  */
 return [
     // # Issue statistics:
+    // PhanDeprecatedFunction : 1 occurrences
     // PhanPluginMixedKeyNoKey : 8 occurrences
     // PhanPluginDuplicateConditionalNullCoalescing : 7 occurrences
     // PhanPluginUnreachableCode : 4 occurrences

--- a/projects/packages/publicize/changelog/remove-publicize-unused-feature-flag-logic
+++ b/projects/packages/publicize/changelog/remove-publicize-unused-feature-flag-logic
@@ -1,0 +1,4 @@
+Significance: patch
+Type: removed
+
+Remove unused feature flag logic.

--- a/projects/packages/publicize/src/class-publicize-base.php
+++ b/projects/packages/publicize/src/class-publicize-base.php
@@ -275,6 +275,10 @@ abstract class Publicize_Base {
 	/**
 	 * Whether the site has the feature flag enabled.
 	 *
+	 * @deprecated $$next-version$$ Use Current_Plan::supports() directly instead.
+	 *
+	 * @todo Remove this method After March 2026.
+	 *
 	 * @param string $flag_name The feature flag to check. Will be prefixed with 'jetpack_social_has_' for the option.
 	 * @param string $feature_name The feature name to check for for the Current_Plan check, without the social- prefix.
 	 * @return bool
@@ -1809,7 +1813,7 @@ abstract class Publicize_Base {
 	 * @return string
 	 */
 	public function publicize_connections_url() {
-		$has_social_admin_page = defined( 'JETPACK_SOCIAL_PLUGIN_DIR' ) || Publicize_Script_Data::has_feature_flag( 'admin-page' );
+		$has_social_admin_page = defined( 'JETPACK_SOCIAL_PLUGIN_DIR' );
 
 		$page = $has_social_admin_page ? 'jetpack-social' : 'jetpack#/sharing';
 

--- a/projects/packages/publicize/src/class-publicize-script-data.php
+++ b/projects/packages/publicize/src/class-publicize-script-data.php
@@ -207,15 +207,13 @@ class Publicize_Script_Data {
 		$share_status = array();
 
 		// get_post_share_status is not available on WPCOM yet.
-		if ( Utils::should_block_editor_have_social() && $post && self::has_feature_flag( 'share-status' ) ) {
+		if ( Utils::should_block_editor_have_social() && $post ) {
 			$share_status[ $post->ID ] = Share_Status::get_post_share_status( $post->ID );
 		}
 
-		$should_have_connections = self::has_feature_flag( 'connections-management' ) || self::has_feature_flag( 'editor-preview' );
-
 		return array(
 			'connectionData' => array(
-				'connections' => $should_have_connections ? Connections::get_all_for_user() : array(),
+				'connections' => Connections::get_all_for_user(),
 			),
 			'shareStatus'    => $share_status,
 		);
@@ -224,23 +222,14 @@ class Publicize_Script_Data {
 	/**
 	 * Whether the site has the feature flag enabled.
 	 *
+	 * @deprecated $$next-version$$ Use Current_Plan::supports() directly instead.
+	 *
+	 * @todo Remove this method After March 2026.
+	 *
 	 * @param string $feature The feature name to check for, without the "social-" prefix.
 	 * @return bool
 	 */
 	public static function has_feature_flag( $feature ): bool {
-		$flag_name = str_replace( '-', '_', $feature );
-
-		// If the option is set, use it.
-		if ( get_option( 'jetpack_social_has_' . $flag_name, false ) ) {
-			return true;
-		}
-
-		$constant_name = 'JETPACK_SOCIAL_HAS_' . strtoupper( $flag_name );
-		// If the constant is set, use it.
-		if ( defined( $constant_name ) && constant( $constant_name ) ) {
-			return true;
-		}
-
 		return Current_Plan::supports( 'social-' . $feature );
 	}
 

--- a/projects/packages/publicize/src/class-social-admin-page.php
+++ b/projects/packages/publicize/src/class-social-admin-page.php
@@ -50,10 +50,6 @@ class Social_Admin_Page {
 	 */
 	public function add_menu() {
 
-		if ( ! Publicize_Script_Data::has_feature_flag( 'admin-page' ) ) {
-			return;
-		}
-
 		// Remove the old Social menu item, if it exists.
 		Admin_Menu::remove_menu( 'jetpack-social' );
 

--- a/projects/plugins/jetpack/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/projects/plugins/jetpack/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -4,7 +4,6 @@ use Automattic\Jetpack\Admin_UI\Admin_Menu;
 use Automattic\Jetpack\Assets\Logo;
 use Automattic\Jetpack\Connection\Initial_State as Connection_Initial_State;
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
-use Automattic\Jetpack\Publicize\Publicize_Script_Data;
 use Automattic\Jetpack\Status;
 
 require_once __DIR__ . '/class.jetpack-admin-page.php';
@@ -156,7 +155,6 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 			if (
 				! Jetpack::is_module_active( 'post-by-email' )
 					&& (
-						Publicize_Script_Data::has_feature_flag( 'admin-page' ) ||
 						! Jetpack::is_module_active( 'publicize' ) ||
 						! current_user_can( 'publish_posts' )
 					)

--- a/projects/plugins/jetpack/changelog/remove-publicize-unused-feature-flag-logic
+++ b/projects/plugins/jetpack/changelog/remove-publicize-unused-feature-flag-logic
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Clean up the logic for admin page access for Social as the settings page is now widely available.


### PR DESCRIPTION
There is still some feature flag logic that is no longer used. It's better to clean that up

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Publicize: Remove unused feature flag logic

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* On Jetpack, Simple and Atomic, do a sanity check in the editor
* Confirm that the connections in the editor load fine
* Share a post, confirm that it works fine and the share status shows up fine
* Do a sanity check for the Jetpack settings page.
