### PR TITLE
Fix HC open state persistence in Atomic

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-open-state-in-atomic
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-open-state-in-atomic
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Help Center: fix accessing stored preferences of open state'

--- a/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-wp-rest-help-center-persisted-open-state.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-wp-rest-help-center-persisted-open-state.php
@@ -63,9 +63,9 @@ class WP_REST_Help_Center_Persisted_Open_State extends \WP_REST_Controller {
 
 		$response = json_decode( wp_remote_retrieve_body( $body ) );
 
-		$is_open        = $response->help_center_open ?? false;
-		$is_minimized   = $response->help_center_minimized ?? false;
-		$router_history = $response->help_center_router_history ?? null;
+		$is_open        = $response->calypso_preferences->help_center_open ?? false;
+		$is_minimized   = $response->calypso_preferences->help_center_minimized ?? false;
+		$router_history = $response->calypso_preferences->help_center_router_history ?? null;
 
 		$projected_response = array(
 			'help_center_open'           => (bool) $is_open,


### PR DESCRIPTION
Fixes DOTCOM-15580

## Proposed changes:
Access the persisted values of open state correctly. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

