### PR TITLE
AI Assistant: disable Write Brief for non-English sites

### DIFF
--- a/projects/plugins/jetpack/changelog/update-disable-write-brief-for-non-english-sites
+++ b/projects/plugins/jetpack/changelog/update-disable-write-brief-for-non-english-sites
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+AI Assistant: disabled Write Brief functionality for non-English sites.

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-assistant.php
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-assistant.php
@@ -78,7 +78,9 @@ add_action(
 			Jetpack_Gutenberg::set_extension_available( 'ai-title-optimization-keywords-support' );
 			Jetpack_Gutenberg::set_extension_available( 'ai-assistant-image-extension' );
 
-			if ( apply_filters( 'breve_enabled', true ) ) {
+			$site_locale = get_option( 'WPLANG' );
+			// Only enable Write Brief for sites with an English locale
+			if ( str_starts_with( $site_locale, 'en' ) && apply_filters( 'breve_enabled', true ) ) {
 				Jetpack_Gutenberg::set_extension_available( 'ai-proofread-breve' );
 			}
 

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-assistant.php
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-assistant.php
@@ -78,7 +78,7 @@ add_action(
 			Jetpack_Gutenberg::set_extension_available( 'ai-title-optimization-keywords-support' );
 			Jetpack_Gutenberg::set_extension_available( 'ai-assistant-image-extension' );
 
-			$site_locale = get_option( 'WPLANG' );
+			$site_locale = get_locale();
 			// Only enable Write Brief for sites with an English locale
 			if ( str_starts_with( $site_locale, 'en' ) && apply_filters( 'breve_enabled', true ) ) {
 				Jetpack_Gutenberg::set_extension_available( 'ai-proofread-breve' );

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/utils/get-availability.ts
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/utils/get-availability.ts
@@ -26,13 +26,6 @@ export function getBreveAvailability() {
 		return false;
 	}
 
-	// Only available for English sites.
-	const siteLocale = window?.Jetpack_Editor_Initial_State?.siteLocale || '';
-	const siteLanguage = siteLocale.split( '-' )[ 0 ] || '';
-	if ( siteLanguage !== 'en' ) {
-		return false;
-	}
-
 	// Free plan users have access to Breve while it's in beta.
 	// const isFreePlan = currentTier?.value === 0;
 	// TODO: Review this logic when Breve is out of beta.

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/utils/get-availability.ts
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/utils/get-availability.ts
@@ -27,9 +27,10 @@ export function getBreveAvailability() {
 	}
 
 	// Only available for English sites.
-	const siteLocale = window?.Jetpack_Editor_Initial_State?.siteLocale || '';
-	const siteLanguage = siteLocale.split( '-' )[ 0 ] || '';
-	if ( siteLanguage !== 'en' ) {
+	const siteLanguage = (
+		select( 'core' ).getEntityRecord( 'root', 'site' ) as { language?: string }
+	 )?.language;
+	if ( ! siteLanguage?.startsWith( 'en' ) ) {
 		return false;
 	}
 

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/utils/get-availability.ts
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/utils/get-availability.ts
@@ -27,10 +27,9 @@ export function getBreveAvailability() {
 	}
 
 	// Only available for English sites.
-	const siteLanguage = (
-		select( 'core' ).getEntityRecord( 'root', 'site' ) as { language?: string }
-	 )?.language;
-	if ( ! siteLanguage?.startsWith( 'en' ) ) {
+	const siteLocale = window?.Jetpack_Editor_Initial_State?.siteLocale || '';
+	const siteLanguage = siteLocale.split( '-' )[ 0 ] || '';
+	if ( siteLanguage !== 'en' ) {
 		return false;
 	}
 

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/utils/get-availability.ts
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/utils/get-availability.ts
@@ -26,6 +26,13 @@ export function getBreveAvailability() {
 		return false;
 	}
 
+	// Only available for English sites.
+	const siteLocale = window?.Jetpack_Editor_Initial_State?.siteLocale || '';
+	const siteLanguage = siteLocale.split( '-' )[ 0 ] || '';
+	if ( siteLanguage !== 'en' ) {
+		return false;
+	}
+
 	// Free plan users have access to Breve while it's in beta.
 	// const isFreePlan = currentTier?.value === 0;
 	// TODO: Review this logic when Breve is out of beta.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes JPAI-18

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
1. Gets the site locale from window?.Jetpack_Editor_Initial_State?.siteLocale
2. Extracts the language code (e.g., en from en-US)
3. Returns false if it's not en, disabling Write Brief for non-English sites

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Confirm that Write Brief section appears under the "Improve with AI" in the Jetpack sidebar when your site locale is set to English.
* Set your site locale to a non-English language (for WPCOM sites you have to change it in your Account profile settings).
* Check that the Write Brief section doesn't appear under the "Improve with AI" in the Jetpack sidebar.

