### PR TITLE
Forms: add radio styles to mimic checkbox

### DIFF
--- a/projects/packages/forms/changelog/add-forms-radio-style-as-checkbox
+++ b/projects/packages/forms/changelog/add-forms-radio-style-as-checkbox
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update radio button styling to use ::before pseudo-element approach for consistency with checkboxes

--- a/projects/packages/forms/src/contact-form/css/grunion.scss
+++ b/projects/packages/forms/src/contact-form/css/grunion.scss
@@ -1051,6 +1051,33 @@ on production builds, the attributes are being reordered, causing side-effects
 
 .contact-form .grunion-field-wrap:not(.is-style-plain) input.radio {
 	border-radius: 50%;
+
+	&::before {
+		border-radius: 50%;
+		content: "";
+		opacity: 0;
+		scale: 0.5;
+
+		/* Inherit the font size from the parent element.
+		 * This allows the input to scale with the font size
+		 * set from global styles or from block styles */
+		font-size: inherit;
+		height: 40%;
+		width: 40%;
+		margin-left: 50%;
+		margin-top: 50%;
+		position: absolute;
+		transform: translate(-100%, -100%);
+		top: 0;
+		left: 0;
+		border-width: 6px;
+		border-style: solid;
+		border-color: currentColor;
+		transition:
+			opacity 0.1s ease-in-out,
+			scale 0.1s ease-in-out,
+			transform 0.1s ease-in-out;
+	}
 }
 
 .contact-form .is-style-list input.consent:checked,
@@ -1090,22 +1117,9 @@ on production builds, the attributes are being reordered, causing side-effects
 }
 
 .contact-form .grunion-field-wrap:not(.is-style-plain) input.radio:checked::before {
-	background: currentColor;
-	border-radius: 50%;
-	content: "";
-
-	/* Inherit the font size from the parent element.
-	 * This allows the input to scale with the font size
-	 * set from global styles or from block styles */
-	font-size: inherit;
-	height: calc(1em / 2);
-	width: calc(1em / 2);
-	margin-left: 50%;
-	margin-top: 50%;
-	position: absolute;
+	opacity: 1;
+	scale: 1;
 	transform: translate(-50%, -50%);
-	top: 0;
-	left: 0;
 }
 
 .contact-form .grunion-field-wrap.grunion-field-checkbox-multiple-wrap.is-style-button-wrap .contact-form-field,

--- a/projects/packages/forms/src/contact-form/css/grunion.scss
+++ b/projects/packages/forms/src/contact-form/css/grunion.scss
@@ -1055,28 +1055,18 @@ on production builds, the attributes are being reordered, causing side-effects
 	&::before {
 		border-radius: 50%;
 		content: "";
-		opacity: 0;
-		scale: 0.5;
 
-		/* Inherit the font size from the parent element.
-		 * This allows the input to scale with the font size
-		 * set from global styles or from block styles */
-		font-size: inherit;
-		height: 40%;
-		width: 40%;
-		margin-left: 50%;
-		margin-top: 50%;
-		position: absolute;
-		transform: translate(-100%, -100%);
-		top: 0;
-		left: 0;
-		border-width: 6px;
+		border-width: 1px;
 		border-style: solid;
-		border-color: currentColor;
-		transition:
-			opacity 0.1s ease-in-out,
-			scale 0.1s ease-in-out,
-			transform 0.1s ease-in-out;
+
+		width: 1em;
+		height: 1em;
+		display: block;
+		position: absolute;
+		top: -1px;
+		left: -1px;
+		box-sizing: border-box;
+		transition: all 0.1s ease-in-out;
 	}
 }
 
@@ -1117,9 +1107,7 @@ on production builds, the attributes are being reordered, causing side-effects
 }
 
 .contact-form .grunion-field-wrap:not(.is-style-plain) input.radio:checked::before {
-	opacity: 1;
-	scale: 1;
-	transform: translate(-50%, -50%);
+	border-width: 0.3em;
 }
 
 .contact-form .grunion-field-wrap.grunion-field-checkbox-multiple-wrap.is-style-button-wrap .contact-form-field,


### PR DESCRIPTION


Part of FORMS-114

## Proposed changes:
The PR uses the same approach for standard radio inputs as the one we use on checkboxes, where the selected option will have a more prominent dark color.

It also adds animation as the radio fills from the border inwards.

The PR only adds the styles to normalize the approach, achieving a consistent look on most themes. However, it doesn't deal with the extreme cases that glitch the inputs (dark themes, button style radio/checkboxes). Those will be addressed on a separate PR.


Sample on 2010 theme:

| Before | After |
|--------|--------|
| <img width="264" height="446" alt="image" src="https://github.com/user-attachments/assets/645d7a7a-61a4-4ea5-b3f6-9896309ce5be" /> | <img width="270" height="437" alt="image" src="https://github.com/user-attachments/assets/2decb231-aa8e-47b7-9233-94fae79da087" /> |

2016:
<img width="247" height="427" alt="image" src="https://github.com/user-attachments/assets/6b6402d1-6002-4123-aff3-e3cb2ac1c3a6" />

2017:
<img width="231" height="419" alt="image" src="https://github.com/user-attachments/assets/df982ec3-02e5-4de3-ad6b-d50d9013c845" />

2020:
<img width="268" height="524" alt="image" src="https://github.com/user-attachments/assets/e103209b-6367-4b41-8073-8c6a811ce2dd" />

2021:
| w/glitch | Fixed on https://github.com/Automattic/jetpack/pull/46393 |
|--------|--------|
| <img width="308" height="564" alt="image" src="https://github.com/user-attachments/assets/32188330-722b-432b-99b7-f4b3e3404d08" /> | <img width="312" height="570" alt="image" src="https://github.com/user-attachments/assets/bf7ba61c-36ce-4541-81aa-d0d661f50819" /> |

2022:
<img width="275" height="463" alt="image" src="https://github.com/user-attachments/assets/807fbdbc-0075-4f95-b0ca-0792b4ba1e80" />

Assembler:
<img width="236" height="464" alt="image" src="https://github.com/user-attachments/assets/40e9dc06-3e53-4c49-bfaa-30523bea5a19" />

2025:
<img width="292" height="457" alt="image" src="https://github.com/user-attachments/assets/fd17b6c4-01ed-4cee-b9d5-4bdc4222086c" />

Astra:
<img width="215" height="389" alt="image" src="https://github.com/user-attachments/assets/6f08e64b-8a26-4980-bfc5-c3cde7c53b1f" />

Livro:
<img width="241" height="217" alt="image" src="https://github.com/user-attachments/assets/1583ccab-2df5-4ccc-8b24-581106356e6f" />




### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1765471459173609/1765446723.887619-slack-C052XEUUBL4

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Insert a form with Single choice input, test several themes. Confirm consistency and style. 