### PR TITLE
Forms: hide after pseudo element

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-hide-after-pseudo-element
+++ b/projects/packages/forms/changelog/fix-forms-hide-after-pseudo-element
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: don't allow ::after pseudo element manipulation on Jetpack Forms radio and checkbox input elements

--- a/projects/packages/forms/src/contact-form/css/grunion.scss
+++ b/projects/packages/forms/src/contact-form/css/grunion.scss
@@ -1060,6 +1060,12 @@ on production builds, the attributes are being reordered, causing side-effects
 
 }
 
+// don't allow ::after pseudo-element to be displayed for checkboxes and radios
+.contact-form input[type="checkbox"]::after,
+.contact-form input[type="radio"]::after {
+	display: none;
+}
+
 .contact-form .is-style-list input.consent::before,
 .contact-form .is-style-list input.checkbox::before,
 .contact-form .grunion-field-wrap:not(.is-style-plain) input.checkbox-multiple::before {


### PR DESCRIPTION
## Proposed changes:
This PR attempts to hide ::after pseudo element on Jetpack Forms radio and checkbox input elements to avoid issues with theme's customizing checkboxes using `::after` instead of `::before`, causing conflicts.

Before:
<img width="314" height="210" alt="image" src="https://github.com/user-attachments/assets/905403d9-5e04-4f3a-b7a0-9c5f5f2a33b7" />

After:
<img width="313" height="220" alt="image" src="https://github.com/user-attachments/assets/a7c2f0f1-3576-4857-ab3a-6c0c042d7f52" />



### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1765471459173609/1765446723.887619-slack-C052XEUUBL4

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Insert checkbox input on a Jetpack Form, both single and multiple selection. Add some options.
Publish and visit the frontend. See that they look like usual and without glitches.

Install theme 2021, visit the frontend and verify they still look fine. You can try 2021 without this PR to see the issue