### PR TITLE
Social: Fix React warnings for unknown prop and uncontrolled input

### DIFF
--- a/projects/js-packages/publicize-components/changelog/fix-social-react-warnings
+++ b/projects/js-packages/publicize-components/changelog/fix-social-react-warnings
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix React warnings for unknown prop and a component changing an uncontrolled input to be controlled.

--- a/projects/js-packages/publicize-components/src/components/connections-toggle-list/index.tsx
+++ b/projects/js-packages/publicize-components/src/components/connections-toggle-list/index.tsx
@@ -41,7 +41,8 @@ export function ConnectionsToggleList( {
 			aria-label={ __( 'Connection toggles', 'jetpack-publicize-components' ) }
 		>
 			{ connections.map( connection => {
-				const isSelected = canBeTurnedOn( connection ) && connection.enabled;
+				const isSelected = Boolean( canBeTurnedOn( connection ) && connection.enabled );
+
 				const isDisabled = shouldBeDisabled( connection );
 
 				const ariaLabel = getA11yLabelForConnectionToggle( connection );
@@ -60,7 +61,6 @@ export function ConnectionsToggleList( {
 							/>
 						}
 						iconPosition="right"
-						isSelected={ isSelected }
 						onClick={ onClickConnection( connection ) }
 						aria-label={ ariaLabel }
 						aria-checked={ isSelected }

--- a/projects/js-packages/publicize-components/src/components/unified-modal/social-post-preview/connection-toggles.tsx
+++ b/projects/js-packages/publicize-components/src/components/unified-modal/social-post-preview/connection-toggles.tsx
@@ -40,7 +40,7 @@ export function ConnectionToggles( { selectedConnection }: ConnectionTogglesProp
 	return (
 		<div role="group" aria-label={ __( 'Connection toggles', 'jetpack-publicize-components' ) }>
 			{ connections.map( connection => {
-				const isEnabled = canBeTurnedOn( connection ) && connection.enabled;
+				const isEnabled = Boolean( canBeTurnedOn( connection ) && connection.enabled );
 				const isDisabled = shouldBeDisabled( connection );
 				const isSelected = selectedConnection?.connection_id === connection.connection_id;
 


### PR DESCRIPTION
<details>

<summary>The social panel in the sidebar shows some React warnings</summary>

<img width="681" height="439" alt="Screenshot 2025-12-23 at 3 59 11 PM" src="https://github.com/user-attachments/assets/20f97337-d2c0-45e9-90ec-da8b8a7da626" />
<img width="683" height="351" alt="Screenshot 2025-12-23 at 3 59 19 PM" src="https://github.com/user-attachments/assets/ea04566d-78ed-4b3d-b893-42f54d65369b" />

</details>

```log
Warning: React does not recognize the `isSelected` prop on a DOM element.
```

```log
Warning: A component is changing an uncontrolled input to be controlled.
```

Fixes SOCIAL-296

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Ensure that `checked` prop passed to FormToggle is always boolean instead of undefined
* Remove the unnecessary `isSelected` prop from button which was left there from the previous implementation

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Do a sanity check for the Social panel in the editor.
* Confirm that there are no React warnings like above.

