### PR TITLE
Social: Set a maximum width for unified modal

### DIFF
--- a/projects/js-packages/publicize-components/changelog/fix-social-preview-model-width
+++ b/projects/js-packages/publicize-components/changelog/fix-social-preview-model-width
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+UI: Prevent the modals in editor from stretching too wide on large screens.

--- a/projects/js-packages/publicize-components/src/components/unified-modal/index.tsx
+++ b/projects/js-packages/publicize-components/src/components/unified-modal/index.tsx
@@ -4,6 +4,7 @@ import { useCallback } from 'react';
 import { store as socialStore } from '../../social-store';
 import { useModalScreen as useEditTemplateModalScreen } from './edit-template/use-modal-screen';
 import { useModalScreen as useSocialPostPreviewModalScreen } from './social-post-preview/use-modal-screen';
+import styles from './styles.module.scss';
 
 /**
  * Themed Unified Modal component.
@@ -24,7 +25,11 @@ function ThemedUnifiedModal() {
 
 	return (
 		<ThemeProvider targetDom={ document.body }>
-			<NavigatorModal initialPath={ initialPath || '/' } onClose={ onClose }>
+			<NavigatorModal
+				className={ styles[ 'unified-modal' ] }
+				initialPath={ initialPath || '/' }
+				onClose={ onClose }
+			>
 				<NavigatorModal.Screen { ...socialPostPreviewModalScreen } />
 				<NavigatorModal.Screen { ...editTemplateModalScreen } />
 				{ /* Generate with AI screen goes here */ }

--- a/projects/js-packages/publicize-components/src/components/unified-modal/styles.module.scss
+++ b/projects/js-packages/publicize-components/src/components/unified-modal/styles.module.scss
@@ -1,0 +1,10 @@
+@use "@automattic/jetpack-base-styles/gutenberg-base-styles" as gb;
+
+.unified-modal {
+	max-width: gb.$wide-content-width;
+	width: 100%;
+
+	@include gb.break-small {
+		width: calc(100vw - 40px);
+	}
+}

--- a/projects/plugins/jetpack/changelog/fix-social-preview-model-width
+++ b/projects/plugins/jetpack/changelog/fix-social-preview-model-width
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+UI: Prevent social modals in editor from stretching too wide on large screens.

--- a/projects/plugins/social/changelog/fix-social-preview-model-width
+++ b/projects/plugins/social/changelog/fix-social-preview-model-width
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+UI: Prevent the modals in editor from stretching too wide on large screens.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes SOCIAL-293

## Proposed changes:
* Set a maximum width for social unified modals to prevent them from being too wide.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
None

## Does this pull request change what data or activity we track or use?
None

## Testing instructions:
* Open social share preview modal and edit template modal under unified modal design.
* Confirm they do not expand beyond 1100px.

| Before | After |
|--------|--------|
|![qRV4T36lnh.png](https://github.com/user-attachments/assets/c437e157-8337-46c0-842e-419560a2fe89)"|![](https://github.com/user-attachments/assets/019c1e32-b6a7-47d0-a5ad-ee4eddb9b0f3)|
|![NzrD1fCpCY.png](https://github.com/user-attachments/assets/853fab75-52f8-468a-bb6d-04ef73ea9beb)|![](https://github.com/user-attachments/assets/4e807ce5-2cc1-4746-94e2-655eb7fe991a)|