### PR TITLE
Forms: Fix combobox dropdown occlusion with z-index

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-combobox-oclusion
+++ b/projects/packages/forms/changelog/fix-forms-combobox-oclusion
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed combobox dropdown occlusion by adding z-index when open

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -1081,7 +1081,6 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 					<div class="jetpack-custom-combobox">
 
 						<button
-							tabindex="0"
 							class="jetpack-combobox-trigger"
 							type="button"
 							data-wp-on--click="actions.phoneComboboxToggle"

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -1081,6 +1081,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 					<div class="jetpack-custom-combobox">
 
 						<button
+							tabindex="0"
 							class="jetpack-combobox-trigger"
 							type="button"
 							data-wp-on--click="actions.phoneComboboxToggle"

--- a/projects/packages/forms/src/contact-form/css/combobox.scss
+++ b/projects/packages/forms/src/contact-form/css/combobox.scss
@@ -166,6 +166,14 @@
 	color: currentColor;
 }
 
+// input wrappers with combobox open should raise to avoid oclusion
+.contact-form .wp-block-jetpack-input-wrap {
+
+	&:has(.is-combobox-open) {
+		z-index: 2;
+	}
+}
+
 // Editor styles
 .wp-block .jetpack-custom-combobox {
 

--- a/projects/packages/forms/src/contact-form/css/combobox.scss
+++ b/projects/packages/forms/src/contact-form/css/combobox.scss
@@ -166,7 +166,7 @@
 	color: currentColor;
 }
 
-// input wrappers with combobox open should raise to avoid oclusion
+// input wrappers with combobox open should raise to avoid occlusion
 .contact-form .wp-block-jetpack-input-wrap {
 
 	&:has(.is-combobox-open) {

--- a/projects/packages/forms/src/contact-form/css/grunion.scss
+++ b/projects/packages/forms/src/contact-form/css/grunion.scss
@@ -914,7 +914,7 @@ on production builds, the attributes are being reordered, causing side-effects
 	margin: 0;
 	transform: translateY(-50%);
 	transition: translatey 150ms cubic-bezier(0.4, 0, 0.2, 1);
-	z-index: 2;
+	z-index: 1;
 }
 
 .contact-form .is-style-animated .grunion-field-wrap .grunion-label-text {


### PR DESCRIPTION
Part of FORMS-477

## Proposed changes:
* Fix combobox dropdown being occluded by other form elements by adding z-index when open
* Add tabindex to combobox trigger button for improved accessibility

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you will see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
No, this is a CSS/HTML fix only with no changes to data tracking.

## Testing instructions:
* Go to a page with a Jetpack contact form that includes a phone field with country code dropdown
* Add another form field directly below the phone field
* Open the country code dropdown combobox
* Verify the dropdown is not hidden behind the field below it (z-index fix)
* Verify the combobox trigger button is keyboard accessible (tabindex fix)
* Change the form style to Outlined, verify it works as expected