### PR TITLE
Improve jetpack-changelog Claude command: add step to return to root directory

### DIFF
--- a/.claude/commands/jetpack-changelog.md
+++ b/.claude/commands/jetpack-changelog.md
@@ -20,7 +20,8 @@ Instructions:
      --type={type} \
      --entry="{description}"
    ```
-5. Stage the generated changelog file with `git add`
+5. Navigate back to root repo directory
+6. Stage the generated changelog file with `git add`
 
 Project types reference:
 - Jetpack Plugin (projects/plugins/jetpack): major, enhancement, compat, bugfix, other


### PR DESCRIPTION
## Proposed changes:
* Add instruction to navigate back to root repo directory after running the changelogger command
* This fixes an issue where subsequent commands would fail because the working directory was still in the project subdirectory

### Other information:

- [x] Have you written new tests for your changes, if applicable? N/A - documentation only
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them? N/A
- [x] Have you tested your changes on WordPress.com, if applicable? N/A

## Jetpack product discussion
N/A - Developer tooling improvement

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
* Run `/jetpack-changelog` in Claude Code on a branch with project changes
* Verify the command now includes step 5 to navigate back to root repo directory
* Confirm that after running the command, you are back in the repo root (not stuck in a project subdirectory)
