### PR TITLE
Forms: Add list view sidebar for easier field management

### DIFF
--- a/projects/packages/forms/changelog/update-forms-list-view
+++ b/projects/packages/forms/changelog/update-forms-list-view
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Forms: add list view sidebar for easier field management

--- a/projects/packages/forms/src/blocks/contact-form/index.js
+++ b/projects/packages/forms/src/blocks/contact-form/index.js
@@ -57,6 +57,7 @@ export const settings = {
 			margin: true,
 		},
 		align: [ 'wide', 'full' ],
+		listView: true,
 	},
 	attributes: defaultAttributes,
 	providesContext: {

--- a/projects/plugins/jetpack/changelog/update-forms-list-view
+++ b/projects/plugins/jetpack/changelog/update-forms-list-view
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Forms: add list view sidebar for easier field management


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

As of https://github.com/WordPress/gutenberg/pull/74120 it's possible to just declare "list view" support in blocks. List view sidebar can be easier way to manage inner fields — something that is particularly hard with Forms.

While existing full page "list view" exists, it has a lot of complexity as well since all the blocks of the page are visible there simultaneously. Dedicated forms list view is much simpler:

<img width="1478" height="1107" alt="Screenshot 2025-12-23 at 22 30 45" src="https://github.com/user-attachments/assets/cfe1dfec-9161-423c-b861-d422ab82d053" />

Negative aspect is that "settings" are now by default slightly more hidden. It's not too worrying since defaults for those settings are pretty good (including notification email), and integrations are still available via block toolbar. 3-tabs pattern in sidebar isn't super hidden either, and now becoming more common pattern in other complex blocks in Gutenberg.

The problem of "managing inner fields of form" is really significant tho, so anything we can do to potentially make it easier seems like worth trying out.

It also helps to better visualize the multi-step forms while working on them:

<img width="1271" height="964" alt="Screenshot 2025-12-23 at 22 36 55" src="https://github.com/user-attachments/assets/f3ec0f1f-c8e1-4185-8a63-b86eb515a055" />



Video:

https://github.com/user-attachments/assets/5c803f20-6778-4067-b5a1-0e5b4916c69e





### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Run latest Gutenberg `trunk`
* Test forms sidebar

