### PR TITLE
Fix Forms combobox dropdown styling overrides for phone input field

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-combobox-styling-overrides
+++ b/projects/packages/forms/changelog/fix-forms-combobox-styling-overrides
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix combobox dropdown styling overrides for phone input field

--- a/projects/packages/forms/src/blocks/form-progress-indicator/style.scss
+++ b/projects/packages/forms/src/blocks/form-progress-indicator/style.scss
@@ -10,6 +10,7 @@
 	position: relative;
 	overflow: visible;
 	box-sizing: border-box;
+	z-index: 1;
 
 	.jetpack-form-progress-indicator-steps {
 		display: flex;

--- a/projects/packages/forms/src/blocks/input-phone/editor.scss
+++ b/projects/packages/forms/src/blocks/input-phone/editor.scss
@@ -127,6 +127,10 @@
 .is-style-outlined .jetpack-contact-form .jetpack-field.jetpack-field-phone,
 .is-style-outlined .jetpack-contact-form .jetpack-field.jetpack-field-telephone {
 
+	&:has(.jetpack-combobox-open) {
+		z-index: 2;
+	}
+
 	.jetpack-field__input {
 
 		&.is-selected {

--- a/projects/packages/forms/src/blocks/input-phone/editor.scss
+++ b/projects/packages/forms/src/blocks/input-phone/editor.scss
@@ -97,6 +97,10 @@
 				}
 			}
 		}
+
+		.jetpack-field__input-element {
+			backdrop-filter: none;
+		}
 	}
 }
 

--- a/projects/packages/forms/src/blocks/input-phone/editor.scss
+++ b/projects/packages/forms/src/blocks/input-phone/editor.scss
@@ -1,6 +1,13 @@
 .jetpack-contact-form .jetpack-field.jetpack-field-phone,
 .jetpack-contact-form .jetpack-field.jetpack-field-telephone {
 
+	&:has(.jetpack-combobox-open) {
+		// GB re-sets z-index every time the block is moved
+		// so we need to force it to 3 to stay on top of other
+		// blocks so the dropdown overlay stays on top of them.
+		z-index: 3 !important;
+	}
+
 	.jetpack-field__input,
 	.jetpack-field__textarea {
 		box-sizing: border-box;
@@ -126,10 +133,6 @@
 
 .is-style-outlined .jetpack-contact-form .jetpack-field.jetpack-field-phone,
 .is-style-outlined .jetpack-contact-form .jetpack-field.jetpack-field-telephone {
-
-	&:has(.jetpack-combobox-open) {
-		z-index: 2;
-	}
 
 	.jetpack-field__input {
 

--- a/projects/packages/forms/src/contact-form/css/combobox.scss
+++ b/projects/packages/forms/src/contact-form/css/combobox.scss
@@ -10,8 +10,11 @@
 	}
 
 	// special override for aggressive themes (2021) that set background-color
-	.has-background & button.jetpack-combobox-trigger:not(:active):not(:hover):not(.has-background) {
+	button.jetpack-combobox-trigger:not(:active):not(:hover),
+	button.jetpack-combobox-trigger:not(:active):hover,
+	button.jetpack-combobox-trigger:focus {
 		background-color: transparent;
+		color: inherit;
 	}
 
 	.jetpack-combobox-trigger {

--- a/projects/packages/forms/src/contact-form/css/combobox.scss
+++ b/projects/packages/forms/src/contact-form/css/combobox.scss
@@ -92,9 +92,14 @@
 		.jetpack-combobox-search {
 			width: 100%;
 			padding: 8px 12px;
+
+			// Using !important to keep tight control over the
+			// search input looks.
 			border-top: none !important;
 			border-left: none !important;
 			border-right: none !important;
+			border-bottom-left-radius: 0 !important;
+			border-bottom-right-radius: 0 !important;
 			border-bottom: 1px solid #eee;
 			outline: none;
 			font-size: 14px;
@@ -103,8 +108,6 @@
 			color: inherit;
 			background-color: inherit;
 			z-index: 1;
-			border-bottom-left-radius: 0 !important;
-			border-bottom-right-radius: 0 !important;
 
 			&:focus {
 				outline: none;

--- a/projects/packages/forms/src/contact-form/css/combobox.scss
+++ b/projects/packages/forms/src/contact-form/css/combobox.scss
@@ -65,8 +65,8 @@
 
 	.jetpack-combobox-dropdown {
 		position: absolute;
-		left: calc(var(--jetpack--contact-form--border-left-size) * -1);
-		right: calc(var(--jetpack--contact-form--border-left-size) * -1);
+		left: calc(var(--jetpack--contact-form--border-left-size, 1px) * -1);
+		right: calc(var(--jetpack--contact-form--border-left-size, 1px) * -1);
 		top: 100%;
 		width: -webkit-fill-available;
 		min-width: 60%;

--- a/projects/packages/forms/src/contact-form/css/combobox.scss
+++ b/projects/packages/forms/src/contact-form/css/combobox.scss
@@ -65,7 +65,8 @@
 
 	.jetpack-combobox-dropdown {
 		position: absolute;
-		left: -1px;
+		left: calc(var(--jetpack--contact-form--border-right-size) * -1);
+		right: calc(var(--jetpack--contact-form--border-left-size) * -1);
 		top: 100%;
 		width: -webkit-fill-available;
 		min-width: 60%;
@@ -88,7 +89,9 @@
 		.jetpack-combobox-search {
 			width: 100%;
 			padding: 8px 12px;
-			border: none;
+			border-top: none !important;
+			border-left: none !important;
+			border-right: none !important;
 			border-bottom: 1px solid #eee;
 			outline: none;
 			font-size: 14px;
@@ -97,8 +100,8 @@
 			color: inherit;
 			background-color: inherit;
 			z-index: 1;
-			border-bottom-left-radius: 0;
-			border-bottom-right-radius: 0;
+			border-bottom-left-radius: 0 !important;
+			border-bottom-right-radius: 0 !important;
 
 			&:focus {
 				outline: none;

--- a/projects/packages/forms/src/contact-form/css/combobox.scss
+++ b/projects/packages/forms/src/contact-form/css/combobox.scss
@@ -65,7 +65,7 @@
 
 	.jetpack-combobox-dropdown {
 		position: absolute;
-		left: calc(var(--jetpack--contact-form--border-right-size) * -1);
+		left: calc(var(--jetpack--contact-form--border-left-size) * -1);
 		right: calc(var(--jetpack--contact-form--border-left-size) * -1);
 		top: 100%;
 		width: -webkit-fill-available;

--- a/projects/packages/forms/src/contact-form/css/grunion.scss
+++ b/projects/packages/forms/src/contact-form/css/grunion.scss
@@ -34,6 +34,10 @@
 	opacity: 0.3;
 }
 
+.jetpack-form-steps-wrapper {
+	z-index: 2;
+}
+
 .jetpack-form-step {
 	display: none;
 }

--- a/projects/packages/forms/src/contact-form/css/phone-field.scss
+++ b/projects/packages/forms/src/contact-form/css/phone-field.scss
@@ -44,7 +44,6 @@
 			}
 		}
 
-
 		.jetpack-field__input-element {
 			border: 0;
 			font: inherit;

--- a/projects/packages/forms/src/contact-form/css/phone-field.scss
+++ b/projects/packages/forms/src/contact-form/css/phone-field.scss
@@ -31,6 +31,7 @@
 
 		.jetpack-field__input-prefix:not([hidden]) {
 			background-color: inherit;
+			z-index: 1;
 
 			.jetpack-field__input-element {
 				width: 100%;
@@ -58,6 +59,7 @@
 			min-width: unset;
 			min-height: unset;
 			backdrop-filter: none;
+			z-index: 1;
 
 			&:not(.jetpack-field__input-prefix .jetpack-field__input-element) {
 				letter-spacing: inherit;

--- a/projects/packages/forms/src/contact-form/css/phone-field.scss
+++ b/projects/packages/forms/src/contact-form/css/phone-field.scss
@@ -30,7 +30,7 @@
 		}
 
 		.jetpack-field__input-prefix:not([hidden]) {
-			background-color: inherit;
+			background-color: transparent;
 			z-index: 1;
 
 			.jetpack-field__input-element {

--- a/projects/packages/forms/src/contact-form/css/phone-field.scss
+++ b/projects/packages/forms/src/contact-form/css/phone-field.scss
@@ -157,12 +157,15 @@
 					font-size: 0.8em;
 				}
 			}
+
+			&:has(~.jetpack-field__input-phone-wrapper.is-combobox-open) .notched-label__notch,
+			&:has(~.jetpack-field__input-phone-wrapper:focus-within) .notched-label__notch,
+			&:has(~* .jetpack-field__input-element:focus) .notched-label__notch,
+			&:has(~* .jetpack-field__input-element.has-value) .notched-label__notch,
+			&:has(~* .jetpack-field__input-element.has-placeholder) .notched-label__notch {
+				border-top-color: transparent !important;
+			}
 		}
 
-		.notched-label:has(~* .jetpack-field__input-element:focus) .notched-label__notch,
-		.notched-label:has(~* .jetpack-field__input-element.has-value) .notched-label__notch,
-		.notched-label:has(~* .jetpack-field__input-element.has-placeholder) .notched-label__notch {
-			border-top-color: transparent !important;
-		}
 	}
 }


### PR DESCRIPTION
## Proposed changes:
- Fix combobox dropdown positioning to properly align with form field borders using CSS variables
- Add z-index handling for outlined style phone fields when combobox is open to prevent occlusion
- Remove backdrop-filter from phone input element in editor (handled by wrapper)
- Override conflicting border and border-radius styles on combobox search input


| Header | Header |
|--------|--------|
| <img width="565" height="166" alt="image" src="https://github.com/user-attachments/assets/6989b698-45e0-416f-b843-a0ca304ab3f4" /> | <img width="562" height="288" alt="image" src="https://github.com/user-attachments/assets/c205a1aa-64ca-4565-b393-e4d8d7e9cacb" /> |
| <img width="287" height="241" alt="image" src="https://github.com/user-attachments/assets/09166cc4-1ad0-4f63-b2f6-8398cb9532af" /> | See above |
| <img width="556" height="115" alt="image" src="https://github.com/user-attachments/assets/1a641a8e-9153-456a-9741-a754da519fa9" /> | See above | 
| <img width="602" height="189" alt="image" src="https://github.com/user-attachments/assets/0787aa4c-8153-4f8a-b49c-752c0e76776f" /> | <img width="589" height="205" alt="image" src="https://github.com/user-attachments/assets/4d510cef-726a-44b5-a65d-0899d61e5a65" /> |






### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?

No, this is a CSS-only fix with no changes to data tracking or privacy.

## Testing instructions:

* Add a Jetpack Form block to a page
* Add a Phone field to the form
* Apply the "outlined" style to the form
* Open the page on the frontend
* Click on the phone field's country selector dropdown
* Verify the dropdown aligns properly with the field borders
* Verify the dropdown appears above other form elements (no z-index issues)
* Verify the search input in the dropdown has no visible borders on the sides/top
