### PR TITLE
AI Assistant: Add site language code to AI request

### DIFF
--- a/projects/js-packages/ai-client/changelog/update-jetpack-ai-language
+++ b/projects/js-packages/ai-client/changelog/update-jetpack-ai-language
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+AI Assistant: Add site language code to AI request

--- a/projects/js-packages/ai-client/src/ask-question/index.ts
+++ b/projects/js-packages/ai-client/src/ask-question/index.ts
@@ -1,9 +1,13 @@
 /**
  * External dependencies
  */
+import { select } from '@wordpress/data';
 import debugFactory from 'debug';
+/**
+ * Internal dependencies
+ */
 import SuggestionsEventSource from '../suggestions-event-source/index.ts';
-/*
+/**
  * Types & constants
  */
 import type { AiModelTypeProp, PromptProp } from '../types.ts';
@@ -38,6 +42,11 @@ export type AskQuestionOptionsArgProps = {
 		// eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
 		implementation?: Function;
 	} >;
+
+	/*
+	 * The language configured in the WordPress site settings.
+	 */
+	languageCode?: string;
 };
 
 const debug = debugFactory( 'jetpack-ai-client:ask-question' );
@@ -62,18 +71,36 @@ const debug = debugFactory( 'jetpack-ai-client:ask-question' );
  */
 export default async function askQuestion(
 	question: PromptProp,
-	{ postId = null, fromCache = false, feature, functions, model }: AskQuestionOptionsArgProps = {}
+	{
+		postId = null,
+		fromCache = false,
+		feature,
+		functions,
+		model,
+		languageCode,
+	}: AskQuestionOptionsArgProps = {}
 ): Promise< SuggestionsEventSource > {
+	const code =
+		languageCode || select( 'core' ).getEntityRecord( 'root', 'site' )?.language || 'en_US';
+
 	debug( 'Asking question: %o. options: %o', question, {
 		postId,
 		fromCache,
 		feature,
 		functions,
 		model,
+		languageCode: code,
 	} );
 
 	return new SuggestionsEventSource( {
 		question,
-		options: { postId, feature, fromCache, functions, model },
+		options: {
+			postId,
+			feature,
+			fromCache,
+			functions,
+			model,
+			languageCode: code,
+		},
 	} );
 }

--- a/projects/js-packages/ai-client/src/ask-question/sync.ts
+++ b/projects/js-packages/ai-client/src/ask-question/sync.ts
@@ -1,12 +1,16 @@
 /**
  * External dependencies
  */
+import { select } from '@wordpress/data';
 import debugFactory from 'debug';
-/*
- * Types & constants
+/**
+ * Internal dependencies
  */
 import requestJwt from '../jwt/index.ts';
-import { AskQuestionOptionsArgProps } from './index.ts';
+/**
+ * Types & constants
+ */
+import type { AskQuestionOptionsArgProps } from './index.ts';
 import type { PromptProp } from '../types.ts';
 
 /**
@@ -37,6 +41,9 @@ export default async function askQuestionSync(
 	question: PromptProp,
 	options: AskQuestionOptionsArgProps = {}
 ): Promise< ResponseData > {
+	options.languageCode =
+		options.languageCode || select( 'core' ).getEntityRecord( 'root', 'site' )?.language || 'en_US';
+
 	debug( 'Asking question with no streaming: %o. options: %o', question, options );
 
 	/**

--- a/projects/js-packages/ai-client/src/suggestions-event-source/index.ts
+++ b/projects/js-packages/ai-client/src/suggestions-event-source/index.ts
@@ -37,6 +37,7 @@ type SuggestionsEventSourceConstructorArgs = {
 		fromCache?: boolean;
 		functions?: Array< object >;
 		model?: AiModelTypeProp;
+		languageCode?: string;
 	};
 };
 
@@ -115,6 +116,7 @@ export default class SuggestionsEventSource extends EventTarget {
 			feature?: string;
 			functions?: Array< object >;
 			model?: AiModelTypeProp;
+			languageCode?: string;
 		} = {};
 
 		// Populate body data with post id only if it is an integer
@@ -158,6 +160,11 @@ export default class SuggestionsEventSource extends EventTarget {
 		if ( options?.model?.length ) {
 			debug( 'Model: %o', options.model );
 			bodyData.model = options.model;
+		}
+
+		if ( options?.languageCode?.length ) {
+			debug( 'Language: %o', options.languageCode );
+			bodyData.languageCode = options.languageCode;
 		}
 
 		// Clean the unclear prompt trigger flag


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Part of JPAI-78

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* What the title says

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Add an AI Assistant block and make a request
* In the network tab, filter for `jetpack-ai-query`
* Check that the payload has the site's language code like `en_US` or `pt_BR`
* Check other features, like image alt text generation

This PR only adds the information. It will be used in a follow-up.