### PR TITLE
Forms: Fix checkbox and radio styles for dark background themes

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-check-radio-dark-styles
+++ b/projects/packages/forms/changelog/fix-forms-check-radio-dark-styles
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: fixing form checkboxes and radio styles for dark background themes

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -427,7 +427,7 @@
 	}
 
 	.jetpack-field-option__checkbox.jetpack-field-option__checkbox,
-	.jetpack-option__type.jetpack-option__type {
+	.jetpack-option__type {
 		align-items: center;
 		display: flex;
 		justify-content: center;

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -588,6 +588,7 @@
 
 	.jetpack-field-option .jetpack-option__type {
 		color: inherit;
+		transform: translateY(0.15em);
 
 		&::before {
 

--- a/projects/packages/forms/src/blocks/contact-form/util/form-styles.js
+++ b/projects/packages/forms/src/blocks/contact-form/util/form-styles.js
@@ -54,16 +54,22 @@ window.jetpackForms.getInverseReadableColor = function ( color ) {
 };
 
 window.jetpackForms.generateStyleVariables = function ( formNode ) {
-	const STYLE_PROBE_CLASS = 'contact-form__style-probe';
+	// the probe is creating a sibling of the form node, we need to assign the same class as
+	// the main node selector (.wp-block-jetpack-contact-form-container, see view.ts)
+	const STYLE_PROBE_CLASS = 'contact-form__style-probe .wp-block-jetpack-contact-form-container';
 	const STYLE_PROBE_STYLE =
 		'position: absolute; z-index: -1; width: 1px; height: 1px; visibility: hidden';
 	const HTML = `
 			<div class="contact-form">
-				<div class="wp-block-button">
-					<div class="wp-block-button__link btn-primary">Test</div>
+				<div class="wp-block-buttons">
+					<div class="wp-block-button">
+						<div class="wp-block-button__link wp-element-button btn-primary">Test</div>
+					</div>
 				</div>
-				<div class="wp-block-button is-style-outline">
-					<div class="wp-block-button__link btn-outline">Test</div>
+				<div class="wp-block-buttons">
+					<div class="wp-block-button is-style-outline">
+						<div class="wp-block-button__link wp-element-button btn-outline">Test</div>
+					</div>
 				</div>
 				<div class="jetpack-field">
 					<input class="jetpack-field__input" type="text">

--- a/projects/packages/forms/src/blocks/contact-form/util/form-styles.js
+++ b/projects/packages/forms/src/blocks/contact-form/util/form-styles.js
@@ -53,6 +53,16 @@ window.jetpackForms.getInverseReadableColor = function ( color ) {
 	return luminance > 186 ? '#000000' : '#FFFFFF';
 };
 
+function isTransparent( color ) {
+	return (
+		color === 'rgba(0, 0, 0, 0)' ||
+		color === 'transparent' ||
+		color === '#00000000' ||
+		color === 'none' ||
+		color === 'transparent none'
+	);
+}
+
 window.jetpackForms.generateStyleVariables = function ( formNode ) {
 	// the probe is creating a sibling of the form node, we need to assign the same class as
 	// the main node selector (.wp-block-jetpack-contact-form-container, see view.ts)
@@ -122,6 +132,12 @@ window.jetpackForms.generateStyleVariables = function ( formNode ) {
 	const buttonOutlineBackgroundColorFallback =
 		window.jetpackForms.getBackgroundColor( buttonOutlineNode );
 
+	// Fallbacks don't cut it, we need to evaluate bg/fg/border color
+	const buttonOutlineSafeBackgroundColor =
+		buttonOutlineBackgroundColor === buttonOutlineTextColor
+			? 'transparent'
+			: buttonOutlineBackgroundColor;
+
 	const {
 		color: textColor,
 		padding: inputPadding,
@@ -139,10 +155,6 @@ window.jetpackForms.generateStyleVariables = function ( formNode ) {
 		backdropFilter: inputBackdropFilter,
 		backgroundColor: inputBackground,
 	} = window.getComputedStyle( inputNode );
-	const inputBackgroundIsTransparent =
-		inputBackground === 'rgba(0, 0, 0, 0)' ||
-		inputBackground === 'transparent' ||
-		inputBackground === '#00000000';
 
 	styleProbe.remove();
 
@@ -157,9 +169,10 @@ window.jetpackForms.generateStyleVariables = function ( formNode ) {
 		'--jetpack--contact-form--border-size': borderWidth,
 		'--jetpack--contact-form--border-style': borderStyle,
 		'--jetpack--contact-form--border-radius': borderRadius,
-		...( inputBackgroundIsTransparent
+		...( isTransparent( inputBackground )
 			? {}
 			: { '--jetpack--contact-form--input-background': inputBackground } ),
+		'--jetpack--contact-form--input-backdrop-filter': inputBackdropFilter,
 		'--jetpack--contact-form--input-background-fallback': inputBackgroundFallback,
 		'--jetpack--contact-form--input-padding': inputPadding,
 		'--jetpack--contact-form--input-padding-top': inputPaddingTop,
@@ -168,20 +181,26 @@ window.jetpackForms.generateStyleVariables = function ( formNode ) {
 		'--jetpack--contact-form--font-size': fontSize,
 		'--jetpack--contact-form--font-family': fontFamily,
 		'--jetpack--contact-form--line-height': lineHeight === 'normal' ? '1.2em' : lineHeight,
+		// Primary button styles
 		'--jetpack--contact-form--button-primary--color': buttonPrimaryColor,
 		'--jetpack--contact-form--button-primary--background-color': buttonPrimaryBackgroundColor,
 		'--jetpack--contact-form--button-primary--border': buttonPrimaryBorder,
 		'--jetpack--contact-form--button-primary--border-color': buttonPrimaryBorderColor,
 		'--jetpack--contact-form--button-primary--padding': buttonPrimaryPadding,
+		// Outline button styles
 		'--jetpack--contact-form--button-outline--padding': buttonOutlinePadding,
 		'--jetpack--contact-form--button-outline--border': buttonOutlineBorder,
-		'--jetpack--contact-form--button-outline--background-color': buttonOutlineBackgroundColor,
+		...( isTransparent( buttonOutlineBackgroundColor )
+			? {}
+			: {
+					'--jetpack--contact-form--button-outline--background-color':
+						buttonOutlineSafeBackgroundColor,
+			  } ),
 		'--jetpack--contact-form--button-outline--background-color-fallback':
 			buttonOutlineBackgroundColorFallback,
 		'--jetpack--contact-form--button-outline--border-size': buttonOutlineBorderSize,
 		'--jetpack--contact-form--button-outline--border-radius': buttonOutlineBorderRadius,
 		'--jetpack--contact-form--button-outline--text-color': buttonOutlineTextColor,
 		'--jetpack--contact-form--button-outline--line-height': buttonOutlineLineHeight,
-		'--jetpack--contact-form--input-backdrop-filter': inputBackdropFilter,
 	};
 };

--- a/projects/packages/forms/src/blocks/contact-form/util/form-styles.js
+++ b/projects/packages/forms/src/blocks/contact-form/util/form-styles.js
@@ -64,9 +64,7 @@ function isTransparent( color ) {
 }
 
 window.jetpackForms.generateStyleVariables = function ( formNode ) {
-	// the probe is creating a sibling of the form node, we need to assign the same class as
-	// the main node selector (.wp-block-jetpack-contact-form-container, see view.ts)
-	const STYLE_PROBE_CLASS = 'contact-form__style-probe .wp-block-jetpack-contact-form-container';
+	const STYLE_PROBE_CLASS = 'contact-form__style-probe';
 	const STYLE_PROBE_STYLE =
 		'position: absolute; z-index: -1; width: 1px; height: 1px; visibility: hidden';
 	const HTML = `

--- a/projects/packages/forms/src/contact-form/css/grunion.scss
+++ b/projects/packages/forms/src/contact-form/css/grunion.scss
@@ -1127,8 +1127,13 @@ on production builds, the attributes are being reordered, causing side-effects
 	opacity: 1;
 }
 
-.contact-form .grunion-field-wrap:not(.is-style-plain) input.radio:checked::before {
-	border-width: 0.3em;
+// button style uses the primary button face color and white checkboxes
+.contact-form .is-style-button input.consent:checked::before,
+.contact-form .is-style-button input.checkbox:checked::before,
+.contact-form .grunion-field-wrap:not(.is-style-plain,.is-style-list) input.checkbox-multiple:checked::before {
+	$button-bg: var(--jetpack--contact-form--button-outline--background-color);
+	$button-bg-fallback: var(--jetpack--contact-form--button-outline--background-color-fallback, fieldText);
+	border-color: #{$button-bg}, #{$button-bg-fallback};
 }
 
 .contact-form .grunion-field-wrap.grunion-field-checkbox-multiple-wrap.is-style-button-wrap .contact-form-field,
@@ -1166,12 +1171,6 @@ on production builds, the attributes are being reordered, causing side-effects
 
 .contact-form .grunion-field-wrap.is-style-button-wrap .grunion-field.radio:checked + .grunion-radio-label::before {
 	content: "\2713";
-}
-
-.contact-form .grunion-field-wrap.grunion-field-checkbox-multiple-wrap.is-style-button-wrap .contact-form-field:focus-within,
-.contact-form .grunion-field-wrap.is-style-button-wrap .grunion-field.radio:focus + .grunion-radio-label {
-	outline: var(--jetpack--contact-form--button-outline--border);
-	outline-offset: 2px;
 }
 
 .contact-form :where(.grunion-field-wrap.is-style-button-wrap .grunion-field.checkbox-multiple) {

--- a/projects/packages/forms/src/contact-form/css/grunion.scss
+++ b/projects/packages/forms/src/contact-form/css/grunion.scss
@@ -1112,7 +1112,8 @@ on production builds, the attributes are being reordered, causing side-effects
 	transition: opacity 0.1s ease-in-out, scale 0.15s ease-in-out;
 
 	font-size: inherit;
-	border: solid var(--jetpack--contact-form--inverted-text-color, var(--jetpack--contact-form--input-background));
+	border-style: solid;
+	border-color: var(--jetpack--contact-form--inverted-body-text-color, var(--jetpack--contact-form--input-background));
 	border-width: 0 2px 2px 0;
 	transform: translate(-50%, -60%) rotate(40deg);
 	top: 0;

--- a/projects/packages/forms/src/contact-form/css/grunion.scss
+++ b/projects/packages/forms/src/contact-form/css/grunion.scss
@@ -1080,10 +1080,14 @@ on production builds, the attributes are being reordered, causing side-effects
 	}
 }
 
-.contact-form .is-style-list input.consent:checked,
-.contact-form .is-style-list input.checkbox:checked,
-.contact-form .grunion-field-wrap:not(.is-style-plain) input.checkbox-multiple:checked {
-	background-color: currentColor;
+
+.contact-form .is-style-list input.consent,
+.contact-form .is-style-list input.checkbox,
+.contact-form .grunion-field-wrap:not(.is-style-plain) input.checkbox-multiple {
+
+	&:not(.is-style-button):checked {
+		background-color: currentColor;
+	}
 
 }
 

--- a/projects/packages/forms/src/contact-form/css/grunion.scss
+++ b/projects/packages/forms/src/contact-form/css/grunion.scss
@@ -1187,31 +1187,10 @@ on production builds, the attributes are being reordered, causing side-effects
 	* This is not needed for the button style.
 	*/
 	transform: unset !important;
-}
 
-.contact-form .grunion-field-wrap.is-style-button-wrap .grunion-field.checkbox-multiple:focus {
-	outline-width: 0; /* focus style defined on parent */
-}
-
-.contact-form .grunion-field-wrap.is-style-button-wrap input.checkbox-multiple::before {
-	border-color: var(--jetpack--contact-form--button-outline--background-color, fieldText);
-}
-
-/* TODO - is this style used anywhere? if not, remove it */
-.contact-form :where(.is-style-button-wrap input.grunion-field + .grunion-field-text::before) {
-	background: var(--jetpack--contact-form--button-outline--background-color);
-	border: var(--jetpack--contact-form--button-outline--border);
-	border-color: currentColor;
-	border-radius: var(--jetpack--contact-form--button-outline--border-radius);
-	box-sizing: initial;
-	content: "";
-	display: block;
-	height: 100%;
-	left: calc(var(--jetpack--contact-form--button-outline--border-size) * -1);
-	position: absolute;
-	top: calc(var(--jetpack--contact-form--button-outline--border-size) * -1);
-	width: 100%;
-	z-index: -1;
+	&:focus {
+		outline-width: 0; /* focus style defined on parent */
+	}
 }
 
 .contact-form :where(.is-style-button-wrap input.grunion-field) {

--- a/projects/packages/forms/src/contact-form/css/grunion.scss
+++ b/projects/packages/forms/src/contact-form/css/grunion.scss
@@ -1072,6 +1072,12 @@ on production builds, the attributes are being reordered, causing side-effects
 		box-sizing: border-box;
 		transition: all 0.1s ease-in-out;
 	}
+
+	&:checked::before {
+		border-width: 0.3em;
+		border-color: currentColor;
+		background-color: var(--jetpack--contact-form--inverted-body-text-color, var(--jetpack--contact-form--input-background));
+	}
 }
 
 .contact-form .is-style-list input.consent:checked,
@@ -1208,10 +1214,6 @@ on production builds, the attributes are being reordered, causing side-effects
 	color: var(--jetpack--contact-form--button-outline--color);
 }
 
-.contact-form :where(.is-style-button-wrap input.grunion-field:checked),
-.contact-form :where(.is-style-button-wrap input.grunion-field:checked + .grunion-field-text) {
-	color: var(--jetpack--contact-form--button-outline--background-color-fallback);
-}
 
 .contact-form :where(.is-style-button-wrap input.grunion-field:checked + .grunion-field-text::before) {
 	background: var(--jetpack--contact-form--button-outline--text-color);

--- a/projects/packages/forms/src/contact-form/css/grunion.scss
+++ b/projects/packages/forms/src/contact-form/css/grunion.scss
@@ -1131,9 +1131,9 @@ on production builds, the attributes are being reordered, causing side-effects
 .contact-form .is-style-button input.consent:checked::before,
 .contact-form .is-style-button input.checkbox:checked::before,
 .contact-form .grunion-field-wrap:not(.is-style-plain,.is-style-list) input.checkbox-multiple:checked::before {
-	$button-bg: var(--jetpack--contact-form--button-outline--background-color);
 	$button-bg-fallback: var(--jetpack--contact-form--button-outline--background-color-fallback, fieldText);
-	border-color: #{$button-bg}, #{$button-bg-fallback};
+	$button-bg: var(--jetpack--contact-form--button-outline--background-color, #{$button-bg-fallback});
+	border-color: #{$button-bg};
 }
 
 .contact-form .grunion-field-wrap.grunion-field-checkbox-multiple-wrap.is-style-button-wrap .contact-form-field,


### PR DESCRIPTION
Part of FORMS-437

## Proposed changes:
- Fix checkbox and radio input styles when displayed on dark background themes
- Improve the style probe to correctly detect button styles by using proper WordPress block markup
- Add `isTransparent()` helper function to consistently check for transparent colors and avoid setting CSS variables when not needed
- Fix border color and background color for checked states to properly use fallback values
- Clean up unused and redundant CSS styles

Showcase:

Assembler
<img width="541" height="567" alt="image" src="https://github.com/user-attachments/assets/73ea1b24-bbd2-4019-9021-3acd7332cb0d" />

Astra
<img width="555" height="404" alt="image" src="https://github.com/user-attachments/assets/733f6318-88b4-4768-851b-be65b633cb35" />

Dravix
<img width="625" height="493" alt="image" src="https://github.com/user-attachments/assets/ec653915-417b-42be-8201-08ef3088dcbe" />

Livro
<img width="570" height="584" alt="image" src="https://github.com/user-attachments/assets/45e40987-1b2a-406d-b958-5658986d2f4c" />

Rivington
<img width="613" height="525" alt="image" src="https://github.com/user-attachments/assets/f6edf3b7-c5c9-428e-a841-d35f7a10f5e0" />

2021
<img width="604" height="574" alt="image" src="https://github.com/user-attachments/assets/e3b6f257-9f9b-4134-b4e5-1c03074a155c" />


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

* Go to the block editor and add a Form block
* Add checkbox and radio fields to the form
* Test with a theme that has a dark background (or add a dark cover block behind the form)
* Verify that:
  - Unchecked checkboxes and radios have visible borders
  - Checked checkboxes show a proper checkmark with correct colors
  - Checked radios show a proper filled circle
  - The button style variant for checkboxes works correctly
* Also test with light background themes to ensure no regressions
