### PR TITLE
Forms: Fix checkbox-multiple styling by removing incorrect button style selector

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-assembler-checkbox-issue
+++ b/projects/packages/forms/changelog/fix-forms-assembler-checkbox-issue
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed checkbox-multiple styling by removing incorrect button style selector

--- a/projects/packages/forms/src/contact-form/css/grunion.scss
+++ b/projects/packages/forms/src/contact-form/css/grunion.scss
@@ -1129,8 +1129,7 @@ on production builds, the attributes are being reordered, causing side-effects
 
 // button style uses the primary button face color and white checkboxes
 .contact-form .is-style-button input.consent:checked::before,
-.contact-form .is-style-button input.checkbox:checked::before,
-.contact-form .grunion-field-wrap:not(.is-style-plain,.is-style-list) input.checkbox-multiple:checked::before {
+.contact-form .is-style-button input.checkbox:checked::before {
 	$button-bg-fallback: var(--jetpack--contact-form--button-outline--background-color-fallback, fieldText);
 	$button-bg: var(--jetpack--contact-form--button-outline--background-color, #{$button-bg-fallback});
 	border-color: #{$button-bg};

--- a/projects/packages/forms/src/contact-form/css/grunion.scss
+++ b/projects/packages/forms/src/contact-form/css/grunion.scss
@@ -1129,7 +1129,8 @@ on production builds, the attributes are being reordered, causing side-effects
 
 // button style uses the primary button face color and white checkboxes
 .contact-form .is-style-button input.consent:checked::before,
-.contact-form .is-style-button input.checkbox:checked::before {
+.contact-form .is-style-button input.checkbox:checked::before,
+.contact-form .is-style-button input.checkbox-multiple:checked::before {
 	$button-bg-fallback: var(--jetpack--contact-form--button-outline--background-color-fallback, fieldText);
 	$button-bg: var(--jetpack--contact-form--button-outline--background-color, #{$button-bg-fallback});
 	border-color: #{$button-bg};


### PR DESCRIPTION
## Proposed changes:
* Remove incorrect CSS selector for `.checkbox-multiple` inputs that was causing styling conflicts
* The selector `.contact-form .grunion-field-wrap:not(.is-style-plain,.is-style-list) input.checkbox-multiple:checked::before` was incorrectly applying button-style border colors to checkbox-multiple elements

Before:
<img width="613" height="491" alt="image" src="https://github.com/user-attachments/assets/89f1f17a-579b-4c23-9ae2-0684e30f2f7e" />

After:
<img width="692" height="495" alt="image" src="https://github.com/user-attachments/assets/1859aa55-4501-4951-ae3a-e547c228cfe0" />


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?

No, this is a CSS-only fix that does not affect data tracking or user activity.

## Testing instructions:

1. Create a new page or post with the Form block
2. Add a Multiple Choice (Checkbox) field to the form
3. Save and preview the page
4. Verify that the checkbox styling displays correctly when checked
5. Test with different form styles (default, outlined, etc.) to ensure consistent behavior
