### PR TITLE
Add Copilot instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,5 +1,5 @@
 When performing a code review, ensure that the code adheres to the project's coding standards and guidelines as outlined in `/docs/coding-guidelines.md` file.
 
-When performing a code review, look for issues such as inconsistent naming conventions, typos, lack of comments, and inefficient algorithms. Provide constructive feedback and suggest improvements where necessary.
+When performing a code review, look for issues such as inconsistent naming conventions, typos, missing documentation for public APIs, missing explanations for complex or non-obvious logic, and inefficient algorithms. Provide constructive feedback and suggest improvements where necessary.
 
 When performing a code review of style (CSS/SCSS) files, suggest using logical properties instead of physical direction and dimension mappings to make CSS RTL-aware by default. When commenting, you can link to this resource: https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Logical_Properties

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,5 @@
+When performing a code review, ensure that the code adheres to the project's coding standards and guidelines as outlined in `/docs/coding-guidelines.md` file.
+
+When performing a code review, look for issues such as inconsistent naming conventions, typos, lack of comments, and inefficient algorithms. Provide constructive feedback and suggest improvements where necessary.
+
+When performing a code review of style (CSS/SCSS) files, suggest using logical properties instead of physical direction and dimension mappings to make CSS RTL-aware by default. When commenting, you can link to this resource: https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Logical_Properties


### PR DESCRIPTION
We often request review from Copilot for our PRs which is often useful. To make its code review better, we can [provide custom instructions to customize its code review](https://docs.github.com/en/copilot/how-tos/use-copilot-agents/request-a-code-review/use-code-review#customizing-copilots-reviews-with-custom-instructions).

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
- Create `.github/copilot-instructions.md` file to add the basic instructions. This is just an initial version, we can improve it in the future.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Try creating a test PR and update a style file by using `margin-left` in the style file.
* Copilot should suggest using `margin-inline-start` instead.
* But, that is expected to work only when the instructions are in the main branch.