### PR TITLE
Social: Fix `useSelect` warning in `useSocialPreviewPostData`

### DIFF
--- a/projects/js-packages/publicize-components/changelog/fix-social-use-select-warning
+++ b/projects/js-packages/publicize-components/changelog/fix-social-use-select-warning
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix `useSelect` warning in `useSocialPreviewPostData`.

--- a/projects/js-packages/publicize-components/src/hooks/use-social-preview-post-data/index.ts
+++ b/projects/js-packages/publicize-components/src/hooks/use-social-preview-post-data/index.ts
@@ -1,4 +1,4 @@
-import { store as coreStore } from '@wordpress/core-data';
+import { Attachment, store as coreStore } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
 import { __ } from '@wordpress/i18n';
@@ -18,11 +18,24 @@ export function useSocialPreviewPostData(): PostData {
 
 	const { getEditedPostAttribute } = useSelect( editorStore, [] );
 
-	const media = useSelect(
+	// pre-fetch media items from the store.
+	const mediaItems = useSelect(
 		select => {
-			const { getEntityRecord } = select( coreStore );
+			return select( coreStore ).getEntityRecords< Attachment >( 'postType', 'attachment', {
+				// A comma-separated list of media IDs to fetch.
+				include: attachedMedia
+					.map( item => item.id )
+					.filter( Boolean )
+					.join( ',' ),
+			} );
+		},
+		[ attachedMedia ]
+	);
 
-			const items = [];
+	const media = useMemo(
+		// This is here to avoid mangled diff.
+		() => {
+			const items: PostData[ 'media' ] = [];
 
 			for ( const item of attachedMedia ) {
 				// It can be a SIG (Social Image Generator) image allowed to be attached without an ID.
@@ -34,7 +47,7 @@ export function useSocialPreviewPostData(): PostData {
 					} );
 				} else {
 					// Otherwise, fetch the media details from the store.
-					const mediaItem = getEntityRecord( 'postType', 'attachment', item.id );
+					const mediaItem = mediaItems?.find( $item => $item.id === item.id );
 
 					if ( mediaItem ) {
 						items.push( {
@@ -48,7 +61,7 @@ export function useSocialPreviewPostData(): PostData {
 
 			return items;
 		},
-		[ attachedMedia ]
+		[ attachedMedia, mediaItems ]
 	);
 
 	const image = useSelect(

--- a/projects/js-packages/publicize-components/src/hooks/use-social-preview-post-data/index.ts
+++ b/projects/js-packages/publicize-components/src/hooks/use-social-preview-post-data/index.ts
@@ -18,18 +18,27 @@ export function useSocialPreviewPostData(): PostData {
 
 	const { getEditedPostAttribute } = useSelect( editorStore, [] );
 
-	// pre-fetch media items from the store.
+	// Prepare a comma-separated list of media IDs to fetch.
+	const mediaIdsStr = attachedMedia
+		.map( item => item.id )
+		.filter( Boolean )
+		.join( ',' );
+
+	// Pre-fetch media items from the store.
 	const mediaItems = useSelect(
 		select => {
-			return select( coreStore ).getEntityRecords< Attachment >( 'postType', 'attachment', {
-				// A comma-separated list of media IDs to fetch.
-				include: attachedMedia
-					.map( item => item.id )
-					.filter( Boolean )
-					.join( ',' ),
-			} );
+			let items: Array< Attachment >;
+
+			// Avoid fetching if there are no media IDs.
+			if ( mediaIdsStr.length ) {
+				items = select( coreStore ).getEntityRecords( 'postType', 'attachment', {
+					include: mediaIdsStr,
+				} );
+			}
+
+			return items || [];
 		},
-		[ attachedMedia ]
+		[ mediaIdsStr ]
 	);
 
 	const media = useMemo(
@@ -47,7 +56,7 @@ export function useSocialPreviewPostData(): PostData {
 					} );
 				} else {
 					// Otherwise, fetch the media details from the store.
-					const mediaItem = mediaItems?.find( $item => $item.id === item.id );
+					const mediaItem = mediaItems.find( $item => $item.id === item.id );
 
 					if ( mediaItem ) {
 						items.push( {

--- a/projects/js-packages/publicize-components/src/hooks/use-social-preview-post-data/test/index.test.ts
+++ b/projects/js-packages/publicize-components/src/hooks/use-social-preview-post-data/test/index.test.ts
@@ -1,0 +1,420 @@
+import { renderHook } from '@testing-library/react';
+import { useSelect } from '@wordpress/data';
+import { useSocialPreviewPostData } from '../';
+import { usePostMeta } from '../../use-post-meta';
+import { getSigImageUrl } from '../../use-sig-preview/utils';
+import { getMediaSourceUrl, getPostImageUrl } from '../utils';
+
+jest.mock( '@wordpress/data', () => {
+	const actual = jest.requireActual( '@wordpress/data' );
+	const mocks = {
+		useSelect: jest.fn(),
+	};
+	return new Proxy( actual, {
+		get( target, property ) {
+			return mocks[ property as keyof typeof mocks ] ?? target[ property as keyof typeof target ];
+		},
+	} );
+} );
+
+jest.mock( '../../use-post-meta', () => ( {
+	usePostMeta: jest.fn(),
+} ) );
+
+jest.mock( '../../use-sig-preview/utils', () => ( {
+	getSigImageUrl: jest.fn(),
+} ) );
+
+jest.mock( '../utils', () => ( {
+	getMediaSourceUrl: jest.fn(),
+	getPostImageUrl: jest.fn(),
+} ) );
+
+const mockUsePostMeta = usePostMeta as jest.MockedFunction< typeof usePostMeta >;
+const mockUseSelect = useSelect as jest.MockedFunction< typeof useSelect >;
+const mockGetSigImageUrl = getSigImageUrl as jest.MockedFunction< typeof getSigImageUrl >;
+const mockGetMediaSourceUrl = getMediaSourceUrl as jest.MockedFunction< typeof getMediaSourceUrl >;
+const mockGetPostImageUrl = getPostImageUrl as jest.MockedFunction< typeof getPostImageUrl >;
+
+const mockGetEditedPostAttribute = jest.fn();
+
+const getDefaultMockPostMeta = () => ( {
+	attachedMedia: [] as Array< { id: number; type: string; url: string } >,
+	imageGeneratorSettings: {
+		enabled: false,
+		token: '',
+	},
+	isPostAlreadyShared: false,
+	isPublicizeEnabled: true,
+	jetpackSocialOptions: {},
+	mediaSource: undefined,
+	shareMessage: '',
+	togglePublicizeFeature: jest.fn(),
+	updateMeta: jest.fn(),
+	updateJetpackSocialOptions: jest.fn(),
+} );
+
+describe( 'useSocialPreviewPostData', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+
+		mockUsePostMeta.mockReturnValue( getDefaultMockPostMeta() );
+
+		mockGetSigImageUrl.mockReturnValue( '' );
+		mockGetMediaSourceUrl.mockReturnValue( '' );
+		mockGetPostImageUrl.mockReturnValue( null );
+
+		// Default mock for useSelect
+		mockUseSelect.mockImplementation( ( selectorOrMapper: unknown ) => {
+			// Handle callback-style useSelect
+			if ( typeof selectorOrMapper === 'function' ) {
+				const mockSelect = () => ( {
+					getEntityRecords: jest.fn().mockReturnValue( [] ),
+					getEntityRecord: jest.fn().mockReturnValue( null ),
+					getEditedPostAttribute: mockGetEditedPostAttribute,
+					getEditedPostContent: jest.fn().mockReturnValue( '' ),
+				} );
+				return selectorOrMapper( mockSelect );
+			}
+
+			return { getEditedPostAttribute: mockGetEditedPostAttribute };
+		} );
+
+		mockGetEditedPostAttribute.mockImplementation( ( attr: string ) => {
+			const attributes: Record< string, unknown > = {
+				title: 'Test Post Title',
+				excerpt: 'Test excerpt',
+				content: 'Test content',
+				link: 'https://example.com/test-post',
+				featured_media: 0,
+				meta: {},
+			};
+			return attributes[ attr ];
+		} );
+	} );
+
+	it( 'should return basic post data', () => {
+		const { result } = renderHook( () => useSocialPreviewPostData() );
+
+		expect( result.current.title ).toBe( 'Test Post Title' );
+		expect( result.current.excerpt ).toBe( 'Test excerpt' );
+		expect( result.current.url ).toBe( 'https://example.com/test-post' );
+		expect( result.current.media ).toEqual( [] );
+	} );
+
+	it( 'should use SEO title when available', () => {
+		mockGetEditedPostAttribute.mockImplementation( ( attr: string ) => {
+			const attributes: Record< string, unknown > = {
+				title: 'Regular Title',
+				excerpt: '',
+				content: '',
+				link: 'https://example.com/test-post',
+				featured_media: 0,
+				meta: {
+					jetpack_seo_html_title: 'SEO Title',
+				},
+			};
+			return attributes[ attr ];
+		} );
+
+		const { result } = renderHook( () => useSocialPreviewPostData() );
+
+		expect( result.current.title ).toBe( 'SEO Title' );
+	} );
+
+	it( 'should use advanced SEO description when available', () => {
+		mockGetEditedPostAttribute.mockImplementation( ( attr: string ) => {
+			const attributes: Record< string, unknown > = {
+				title: 'Test Title',
+				excerpt: 'Regular excerpt',
+				content: 'Test content',
+				link: 'https://example.com/test-post',
+				featured_media: 0,
+				meta: {
+					advanced_seo_description: 'SEO Description',
+				},
+			};
+			return attributes[ attr ];
+		} );
+
+		const { result } = renderHook( () => useSocialPreviewPostData() );
+
+		expect( result.current.description ).toBe( 'SEO Description' );
+	} );
+
+	it( 'should fall back to excerpt for description', () => {
+		mockGetEditedPostAttribute.mockImplementation( ( attr: string ) => {
+			const attributes: Record< string, unknown > = {
+				title: 'Test Title',
+				excerpt: 'Post excerpt',
+				content: 'Test content',
+				link: 'https://example.com/test-post',
+				featured_media: 0,
+				meta: {},
+			};
+			return attributes[ attr ];
+		} );
+
+		const { result } = renderHook( () => useSocialPreviewPostData() );
+
+		expect( result.current.description ).toBe( 'Post excerpt' );
+	} );
+
+	it( 'should use content before more tag when no excerpt', () => {
+		mockGetEditedPostAttribute.mockImplementation( ( attr: string ) => {
+			const attributes: Record< string, unknown > = {
+				title: 'Test Title',
+				excerpt: '',
+				content: 'Content before more<!--more-->Content after more',
+				link: 'https://example.com/test-post',
+				featured_media: 0,
+				meta: {},
+			};
+			return attributes[ attr ];
+		} );
+
+		const { result } = renderHook( () => useSocialPreviewPostData() );
+
+		expect( result.current.description ).toBe( 'Content before more' );
+		expect( result.current.excerpt ).toBe( 'Content before more' );
+	} );
+
+	it( 'should trim whitespace from title and description', () => {
+		mockGetEditedPostAttribute.mockImplementation( ( attr: string ) => {
+			const attributes: Record< string, unknown > = {
+				title: '  Title with spaces  ',
+				excerpt: '  Excerpt with spaces  ',
+				content: '',
+				link: 'https://example.com/test-post',
+				featured_media: 0,
+				meta: {},
+			};
+			return attributes[ attr ];
+		} );
+
+		const { result } = renderHook( () => useSocialPreviewPostData() );
+
+		expect( result.current.title ).toBe( 'Title with spaces' );
+		expect( result.current.description ).toBe( 'Excerpt with spaces' );
+	} );
+
+	it( 'should return attached media with URLs from SIG images', () => {
+		mockUsePostMeta.mockReturnValue( {
+			...getDefaultMockPostMeta(),
+			attachedMedia: [
+				{
+					id: 0,
+					url: 'https://example.com/sig-image.jpg',
+					type: 'image/png',
+				},
+			],
+		} );
+
+		const { result } = renderHook( () => useSocialPreviewPostData() );
+
+		expect( result.current.media ).toEqual( [
+			{
+				type: 'image/png',
+				url: 'https://example.com/sig-image.jpg',
+				alt: '',
+			},
+		] );
+	} );
+
+	it( 'should default to image/jpeg for SIG images without type', () => {
+		mockUsePostMeta.mockReturnValue( {
+			...getDefaultMockPostMeta(),
+			attachedMedia: [
+				{
+					id: 0,
+					url: 'https://example.com/sig-image.jpg',
+					type: '',
+				},
+			],
+		} );
+
+		const { result } = renderHook( () => useSocialPreviewPostData() );
+
+		expect( result.current.media ).toEqual( [
+			{
+				type: 'image/jpeg',
+				url: 'https://example.com/sig-image.jpg',
+				alt: '',
+			},
+		] );
+	} );
+
+	it( 'should fetch media details from store for attached media with IDs', () => {
+		const mockMediaItem = {
+			id: 123,
+			mime_type: 'image/png',
+			alt_text: 'Alt text',
+			source_url: 'https://example.com/image.png',
+		};
+
+		mockUsePostMeta.mockReturnValue( {
+			...getDefaultMockPostMeta(),
+			attachedMedia: [ { id: 123, type: 'image/png', url: 'https://example.com/image.png' } ],
+		} );
+
+		mockGetMediaSourceUrl.mockReturnValue( 'https://example.com/image.png' );
+
+		mockUseSelect.mockImplementation( ( selectorOrMapper: unknown ) => {
+			if ( typeof selectorOrMapper === 'function' ) {
+				const mockSelect = () => ( {
+					getEntityRecords: jest.fn().mockReturnValue( [ mockMediaItem ] ),
+					getEntityRecord: jest.fn().mockReturnValue( null ),
+					getEditedPostAttribute: mockGetEditedPostAttribute,
+					getEditedPostContent: jest.fn().mockReturnValue( '' ),
+				} );
+				return selectorOrMapper( mockSelect );
+			}
+			return { getEditedPostAttribute: mockGetEditedPostAttribute };
+		} );
+
+		const { result } = renderHook( () => useSocialPreviewPostData() );
+
+		expect( result.current.media ).toEqual( [
+			{
+				type: 'image/png',
+				url: 'https://example.com/image.png',
+				alt: 'Alt text',
+			},
+		] );
+	} );
+
+	it( 'should use SIG image URL when enabled', () => {
+		mockUsePostMeta.mockReturnValue( {
+			...getDefaultMockPostMeta(),
+			imageGeneratorSettings: {
+				enabled: true,
+				token: 'test-token',
+			},
+		} );
+
+		mockGetSigImageUrl.mockReturnValue( 'https://example.com/sig-generated.jpg' );
+
+		mockUseSelect.mockImplementation( ( selectorOrMapper: unknown ) => {
+			if ( typeof selectorOrMapper === 'function' ) {
+				const mockSelect = () => ( {
+					getEntityRecords: jest.fn().mockReturnValue( [] ),
+					getEntityRecord: jest.fn().mockReturnValue( null ),
+					getEditedPostAttribute: mockGetEditedPostAttribute,
+					getEditedPostContent: jest.fn().mockReturnValue( '' ),
+				} );
+				return selectorOrMapper( mockSelect );
+			}
+			return { getEditedPostAttribute: mockGetEditedPostAttribute };
+		} );
+
+		const { result } = renderHook( () => useSocialPreviewPostData() );
+
+		expect( result.current.image ).toBe( 'https://example.com/sig-generated.jpg' );
+	} );
+
+	it( 'should use featured image when no SIG', () => {
+		const mockFeaturedMedia = {
+			id: 456,
+			source_url: 'https://example.com/featured.jpg',
+		};
+
+		mockGetEditedPostAttribute.mockImplementation( ( attr: string ) => {
+			const attributes: Record< string, unknown > = {
+				title: 'Test Title',
+				excerpt: '',
+				content: '',
+				link: 'https://example.com/test-post',
+				featured_media: 456,
+				meta: {},
+			};
+			return attributes[ attr ];
+		} );
+
+		mockGetMediaSourceUrl.mockReturnValue( 'https://example.com/featured.jpg' );
+
+		mockUseSelect.mockImplementation( ( selectorOrMapper: unknown ) => {
+			if ( typeof selectorOrMapper === 'function' ) {
+				const mockSelect = () => ( {
+					getEntityRecords: jest.fn().mockReturnValue( [] ),
+					getEntityRecord: jest.fn().mockReturnValue( mockFeaturedMedia ),
+					getEditedPostAttribute: mockGetEditedPostAttribute,
+					getEditedPostContent: jest.fn().mockReturnValue( '' ),
+				} );
+				return selectorOrMapper( mockSelect );
+			}
+			return { getEditedPostAttribute: mockGetEditedPostAttribute };
+		} );
+
+		const { result } = renderHook( () => useSocialPreviewPostData() );
+
+		expect( result.current.image ).toBe( 'https://example.com/featured.jpg' );
+	} );
+
+	it( 'should extract image from post content when no featured image', () => {
+		mockGetPostImageUrl.mockReturnValue( 'https://example.com/content-image.jpg' );
+
+		mockUseSelect.mockImplementation( ( selectorOrMapper: unknown ) => {
+			if ( typeof selectorOrMapper === 'function' ) {
+				const mockSelect = () => ( {
+					getEntityRecords: jest.fn().mockReturnValue( [] ),
+					getEntityRecord: jest.fn().mockReturnValue( null ),
+					getEditedPostAttribute: mockGetEditedPostAttribute,
+					getEditedPostContent: jest
+						.fn()
+						.mockReturnValue( '<img src="https://example.com/content-image.jpg">' ),
+				} );
+				return selectorOrMapper( mockSelect );
+			}
+			return { getEditedPostAttribute: mockGetEditedPostAttribute };
+		} );
+
+		const { result } = renderHook( () => useSocialPreviewPostData() );
+
+		expect( result.current.image ).toBe( 'https://example.com/content-image.jpg' );
+	} );
+
+	it( 'should return empty string for image when none available', () => {
+		mockUseSelect.mockImplementation( ( selectorOrMapper: unknown ) => {
+			if ( typeof selectorOrMapper === 'function' ) {
+				const mockSelect = () => ( {
+					getEntityRecords: jest.fn().mockReturnValue( [] ),
+					getEntityRecord: jest.fn().mockReturnValue( null ),
+					getEditedPostAttribute: mockGetEditedPostAttribute,
+					getEditedPostContent: jest.fn().mockReturnValue( '' ),
+				} );
+				return selectorOrMapper( mockSelect );
+			}
+			return { getEditedPostAttribute: mockGetEditedPostAttribute };
+		} );
+
+		mockGetPostImageUrl.mockReturnValue( null );
+
+		const { result } = renderHook( () => useSocialPreviewPostData() );
+
+		expect( result.current.image ).toBe( '' );
+	} );
+
+	it( 'should not fetch media when there are no attached media IDs', () => {
+		mockUsePostMeta.mockReturnValue( getDefaultMockPostMeta() );
+
+		const mockGetEntityRecords = jest.fn().mockReturnValue( [] );
+
+		mockUseSelect.mockImplementation( ( selectorOrMapper: unknown ) => {
+			if ( typeof selectorOrMapper === 'function' ) {
+				const mockSelect = () => ( {
+					getEntityRecords: mockGetEntityRecords,
+					getEntityRecord: jest.fn().mockReturnValue( null ),
+					getEditedPostAttribute: mockGetEditedPostAttribute,
+					getEditedPostContent: jest.fn().mockReturnValue( '' ),
+				} );
+				return selectorOrMapper( mockSelect );
+			}
+			return { getEditedPostAttribute: mockGetEditedPostAttribute };
+		} );
+
+		renderHook( () => useSocialPreviewPostData() );
+
+		// getEntityRecords should not be called when there are no media IDs
+		expect( mockGetEntityRecords ).not.toHaveBeenCalled();
+	} );
+} );

--- a/projects/js-packages/publicize-components/src/hooks/use-social-preview-post-data/test/utils.test.ts
+++ b/projects/js-packages/publicize-components/src/hooks/use-social-preview-post-data/test/utils.test.ts
@@ -1,0 +1,54 @@
+import { getMediaSourceUrl, getPostImageUrl } from '../utils';
+import type { Attachment } from '@wordpress/core-data';
+
+describe( 'getMediaSourceUrl', () => {
+	it( 'should return empty string for null media', () => {
+		expect( getMediaSourceUrl( null ) ).toBe( '' );
+	} );
+
+	it( 'should return large size URL when available', () => {
+		const media = {
+			source_url: 'https://example.com/full.jpg',
+			media_details: {
+				sizes: {
+					large: {
+						source_url: 'https://example.com/large.jpg',
+					},
+				},
+			},
+		} as unknown as Attachment;
+
+		expect( getMediaSourceUrl( media ) ).toBe( 'https://example.com/large.jpg' );
+	} );
+
+	it( 'should fall back to source_url when large size is not available', () => {
+		const media = {
+			source_url: 'https://example.com/full.jpg',
+		} as unknown as Attachment;
+
+		expect( getMediaSourceUrl( media ) ).toBe( 'https://example.com/full.jpg' );
+	} );
+} );
+
+describe( 'getPostImageUrl', () => {
+	it( 'should return null for empty content', () => {
+		expect( getPostImageUrl( '' ) ).toBeNull();
+	} );
+
+	it( 'should return null when no images in content', () => {
+		expect( getPostImageUrl( '<p>Some text without images</p>' ) ).toBeNull();
+	} );
+
+	it( 'should extract image URL from content', () => {
+		const content = '<p>Some text</p><img src="https://example.com/image.jpg" /><p>More text</p>';
+		expect( getPostImageUrl( content ) ).toBe( 'https://example.com/image.jpg' );
+	} );
+
+	it( 'should return first image when multiple images exist', () => {
+		const content = `
+			<img src="https://example.com/first.jpg" />
+			<img src="https://example.com/second.jpg" />
+		`;
+		expect( getPostImageUrl( content ) ).toBe( 'https://example.com/first.jpg' );
+	} );
+} );


### PR DESCRIPTION


#46369 fixed the reactivity issue in post data, but there seems to be a minor issue with the solution.

`useSelect` inside `useSocialPreviewPostData` now results in a warning in the console.

```
The `useSelect` hook returns different values when called with the same state and parameters.
This can lead to unnecessary re-renders and performance issues if not fixed.
```

<img width="687" height="236" alt="Screenshot 2025-12-29 at 3 33 56 PM" src="https://github.com/user-attachments/assets/3ea30e9a-195a-4f44-a142-9f8f4e51b92b" />


<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes SOCIAL-298

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Update `useSocialPreviewPostData` hook to extract the `useSelect` usage outside of the computation part. This way, we don't perform any computation inside `useSelect` and the result remains consistent. We instead do the computation inside `useMemo` which is better.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a post
* Open Jetpack sidebar
* Add a custom image from Media Library to the post in the "Share to social media" panel
* Open the preview modal
* Confirm that there is no warning in the console related to `useSelect`
* Follow the instructions in #46369 to ensure that reactivity is still good.

