### PR TITLE
jetpack-mu-wpcom: Code block fixes and improvements

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/code-block-fixes-polish
+++ b/projects/packages/jetpack-mu-wpcom/changelog/code-block-fixes-polish
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Code block: Fixes and improvements to the unreleased code block.

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/block-definition/block-definition.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/block-definition/block-definition.tsx
@@ -351,13 +351,22 @@ const BlockHeader = ( props: Props ) => {
 			: 'wp-element-button';
 
 	const showRight = props.attributes.showCopyButton || showLanguage;
+
+	const onClick = () => {
+		navigator.clipboard.writeText( props.attributes.content.toPlainText() ).catch();
+	};
+
 	return (
 		<div className="a8c/code__header">
 			<Filename { ...props } />
 			{ showRight && (
 				<div className="a8c/code__header-right">
 					{ props.attributes.showCopyButton && (
-						<button className={ `${ wpElementButtonClass } a8c/code__btn-copy` } type="button">
+						<button
+							className={ `${ wpElementButtonClass } a8c/code__btn-copy` }
+							type="button"
+							onClick={ onClick }
+						>
 							{ __( 'Copy', 'jetpack-mu-wpcom' ) }
 						</button>
 					) }

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/block-definition/block-definition.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/block-definition/block-definition.tsx
@@ -257,7 +257,7 @@ const blockEdit = withColors(
 						label={ __( 'Filename', 'jetpack-mu-wpcom' ) }
 						value={ attributes.filename }
 						onChange={ ( nextValue: string ) => {
-							setAttributes!( { filename: nextValue } );
+							setAttributes( { filename: nextValue } );
 						} }
 						placeholder={ sprintf(
 							/* translators: Placeholder for a filename input. %s is a file extension, like "txt". */

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/block-definition/block-definition.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/block-definition/block-definition.tsx
@@ -44,14 +44,15 @@ const LINE_NUMBER_START_MAX = 10_000;
 type Props = EditBlockProps | SaveBlockProps;
 const plainLanguageName = __( 'Plain text', 'jetpack-mu-wpcom' ) as string;
 
-const emptyLanguageOption = {
-	value: '',
-	label: plainLanguageName as string,
-};
-const selectLanguageOptions: {
+interface LanguageOption {
 	readonly value: string;
 	readonly label: string;
-}[] = [ emptyLanguageOption ];
+}
+const emptyLanguageOption: LanguageOption = {
+	value: '',
+	label: plainLanguageName,
+};
+const selectLanguageOptions: ReadonlyArray< LanguageOption > = [ emptyLanguageOption ];
 {
 	const langNames = new Set< string >();
 	extensionToLang.forEach( ( [ , lang ] ) => {
@@ -60,11 +61,32 @@ const selectLanguageOptions: {
 	const sortedLangNames = Array.of( ...langNames );
 	sortedLangNames.sort( ( a, b ) => a.localeCompare( b ) );
 	sortedLangNames.forEach( lang =>
-		selectLanguageOptions.push( {
+		( selectLanguageOptions as LanguageOption[] ).push( {
 			value: lang,
 			label: lang,
 		} )
 	);
+}
+
+const selectPopularLanguageOptions: ReadonlyArray< LanguageOption > = [];
+{
+	const popularLanguages = new Set< string >( [
+		'JavaScript',
+		'HTML',
+		'CSS',
+		'SQL',
+		'Python',
+		'Java',
+		'C++',
+		'PHP',
+		'TypeScript',
+		'Bash',
+	] );
+	for ( const opt of selectLanguageOptions ) {
+		if ( popularLanguages.has( opt.value ) ) {
+			( selectPopularLanguageOptions as LanguageOption[] ).push( opt );
+		}
+	}
 }
 
 /**
@@ -192,7 +214,6 @@ const blockEdit = withColors(
 					<SelectControl
 						label={ __( 'Language', 'jetpack-mu-wpcom' ) }
 						value={ attributes.language }
-						options={ selectLanguageOptions }
 						onChange={ ( newLanguage: string ) => {
 							setAttributes( {
 								language: newLanguage,
@@ -201,7 +222,23 @@ const blockEdit = withColors(
 						} }
 						__next40pxDefaultSize
 						__nextHasNoMarginBottom
-					/>
+					>
+						<option value="">{ plainLanguageName }</option>
+						<optgroup label={ __( 'Popular Languages', 'jetpack-mu-wpcom' ) }>
+							{ selectPopularLanguageOptions.map( option => (
+								<option key={ option.value } value={ option.value }>
+									{ option.label }
+								</option>
+							) ) }
+						</optgroup>
+						<optgroup label={ __( 'All Languages', 'jetpack-mu-wpcom' ) }>
+							{ selectLanguageOptions.map( option => (
+								<option key={ option.value } value={ option.value }>
+									{ option.label }
+								</option>
+							) ) }
+						</optgroup>
+					</SelectControl>
 					<TextControl
 						label={ __( 'Filename', 'jetpack-mu-wpcom' ) }
 						value={ attributes.filename }

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/block-definition/block-definition.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/block-definition/block-definition.tsx
@@ -255,9 +255,9 @@ const blockEdit = withColors(
 					</SelectControl>
 					<TextControl
 						label={ __( 'Filename', 'jetpack-mu-wpcom' ) }
-						value={ attributes.filename }
+						defaultValue={ attributes.filename }
 						onChange={ ( nextValue: string ) => {
-							setAttributes( { filename: nextValue } );
+							setAttributes( { filename: nextValue.trim() } );
 						} }
 						placeholder={ sprintf(
 							/* translators: Placeholder for a filename input. %s is a file extension, like "txt". */

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/block-definition/block-definition.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/block-definition/block-definition.tsx
@@ -52,7 +52,7 @@ const emptyLanguageOption: LanguageOption = {
 	value: '',
 	label: plainLanguageName,
 };
-const selectLanguageOptions: ReadonlyArray< LanguageOption > = [ emptyLanguageOption ];
+const selectLanguageOptions: ReadonlyArray< LanguageOption > = [];
 {
 	const langNames = new Set< string >();
 	extensionToLang.forEach( ( [ , lang ] ) => {
@@ -184,6 +184,20 @@ const blockEdit = withColors(
 						renderContent={ ( { onClose }: { onClose: () => void } ) => (
 							<NavigableMenu role="menu" stopNavigationEvents>
 								<MenuGroup>
+									<MenuItem
+										key={ emptyLanguageOption.value }
+										role="menuitemradio"
+										isSelected={ emptyLanguageOption.value === props.attributes.language }
+										onClick={ () => {
+											props.setAttributes( {
+												language: emptyLanguageOption.value,
+												languageConfidence: 'certain',
+											} );
+											onClose();
+										} }
+									>
+										{ emptyLanguageOption.label }
+									</MenuItem>
 									{ selectLanguageOptions.map( option => (
 										<MenuItem
 											key={ option.value }

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/block-definition/block-definition.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/block-definition/block-definition.tsx
@@ -42,10 +42,11 @@ const LINE_NUMBER_START_MIN = 0;
 const LINE_NUMBER_START_MAX = 10_000;
 
 type Props = EditBlockProps | SaveBlockProps;
+const plainLanguageName = __( 'Plain text', 'jetpack-mu-wpcom' ) as string;
 
 const emptyLanguageOption = {
 	value: '',
-	label: __( 'Plain text', 'jetpack-mu-wpcom' ) as string,
+	label: plainLanguageName as string,
 };
 const selectLanguageOptions: {
 	readonly value: string;
@@ -349,9 +350,8 @@ const Chrome = ( { isLoading = false, ...props }: ChromeProps ) => {
 };
 
 const BlockHeader = ( props: Props ) => {
-	const showLanguage = props.attributes.showLanguageName && props.attributes.language;
-
-	if ( ! props.attributes.filename && ! props.attributes.showCopyButton && ! showLanguage ) {
+	const showRightSection = props.attributes.showCopyButton || props.attributes.showLanguageName;
+	if ( ! props.attributes.filename && ! showRightSection ) {
 		return null;
 	}
 
@@ -360,8 +360,6 @@ const BlockHeader = ( props: Props ) => {
 			? __experimentalGetElementClassName( 'button' )
 			: 'wp-element-button';
 
-	const showRight = props.attributes.showCopyButton || showLanguage;
-
 	const onClick = () => {
 		navigator.clipboard.writeText( props.attributes.content.toPlainText() ).catch();
 	};
@@ -369,7 +367,7 @@ const BlockHeader = ( props: Props ) => {
 	return (
 		<div className="a8c/code__header">
 			<Filename { ...props } />
-			{ showRight && (
+			{ showRightSection && (
 				<div className="a8c/code__header-right">
 					{ props.attributes.showCopyButton && (
 						<button
@@ -380,7 +378,9 @@ const BlockHeader = ( props: Props ) => {
 							{ __( 'Copy', 'jetpack-mu-wpcom' ) }
 						</button>
 					) }
-					{ showLanguage ? <span>{ props.attributes.language }</span> : null }
+					{ props.attributes.showLanguageName ? (
+						<span>{ props.attributes.language || plainLanguageName }</span>
+					) : null }
 				</div>
 			) }
 		</div>

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/block-definition/block-definition.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/block-definition/block-definition.tsx
@@ -32,7 +32,6 @@ const {
 	__experimentalGetElementClassName,
 	BlockControls,
 	InspectorControls,
-	PlainText,
 	useBlockProps,
 	withColors,
 }: Window[ 'wp' ][ 'blockEditor' ] = wpBlockEditor;
@@ -139,6 +138,11 @@ const blockEdit = withColors(
 )( ( props: EditBlockProps ) => {
 	const { setAttributes, attributes } = props;
 
+	const placeholderExtension =
+		extensionToLang.find(
+			( [ , languageName ] ) => props.attributes.language === languageName
+		)?.[ 0 ] ?? 'txt';
+
 	return (
 		<>
 			<BlockControls>
@@ -197,19 +201,25 @@ const blockEdit = withColors(
 						__next40pxDefaultSize
 						__nextHasNoMarginBottom
 					/>
+					<TextControl
+						label={ __( 'Filename', 'jetpack-mu-wpcom' ) }
+						value={ attributes.filename }
+						onChange={ ( nextValue: string ) => {
+							setAttributes!( { filename: nextValue } );
+						} }
+						placeholder={ sprintf(
+							/* translators: Placeholder for a filename input. %s is a file extension, like "txt". */
+							__( 'filename.%s', 'jetpack-mu-wpcom' ),
+							placeholderExtension
+						) }
+						__next40pxDefaultSize
+						__nextHasNoMarginBottom
+					/>
 					<ToggleControl
 						label={ __( 'Show language name', 'jetpack-mu-wpcom' ) }
 						checked={ attributes.showLanguageName }
 						onChange={ ( next: boolean ) => {
 							setAttributes( { showLanguageName: next } );
-						} }
-						__nextHasNoMarginBottom
-					/>
-					<ToggleControl
-						label={ __( 'Show filename', 'jetpack-mu-wpcom' ) }
-						checked={ attributes.showFileName }
-						onChange={ ( next: boolean ) => {
-							setAttributes( { showFileName: next } );
 						} }
 						__nextHasNoMarginBottom
 					/>
@@ -341,7 +351,7 @@ const Chrome = ( { isLoading = false, ...props }: ChromeProps ) => {
 const BlockHeader = ( props: Props ) => {
 	const showLanguage = props.attributes.showLanguageName && props.attributes.language;
 
-	if ( ! props.attributes.showFileName && ! props.attributes.showCopyButton && ! showLanguage ) {
+	if ( ! props.attributes.filename && ! props.attributes.showCopyButton && ! showLanguage ) {
 		return null;
 	}
 
@@ -378,40 +388,10 @@ const BlockHeader = ( props: Props ) => {
 };
 
 const Filename = ( props: Props ) => {
-	if ( ! props.attributes.showFileName ) {
+	if ( ! props.attributes.filename ) {
 		return null;
 	}
-	const { setAttributes, isSelected = false } = props;
-	const { filename } = props.attributes;
-
-	if ( isSelected ) {
-		const placeholderExtension =
-			extensionToLang.find(
-				( [ , languageName ] ) => props.attributes.language === languageName
-			)?.[ 0 ] ?? 'txt';
-
-		return (
-			<PlainText
-				__experimentalVersion={ 2 }
-				value={ filename }
-				onChange={ ( nextValue: string ) => {
-					setAttributes!( { filename: nextValue } );
-				} }
-				disableLineBreaks
-				className="a8c/code__filename"
-				placeholder={ sprintf(
-					/* translators: Placeholder for a filename input. %s is a file extension, like "txt". */
-					__( 'filename.%s', 'jetpack-mu-wpcom' ),
-					placeholderExtension
-				) }
-			/>
-		);
-	}
-
-	if ( filename ) {
-		return <span className="a8c/code__filename">{ filename }</span>;
-	}
-	return null;
+	return <span className="a8c/code__filename">{ props.attributes.filename }</span>;
 };
 
 /**

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/class-code-block.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/class-code-block.php
@@ -432,9 +432,16 @@ abstract class Code_Block {
 			)
 			: '';
 
-		$language_html = ( ( $attributes['showLanguageName'] ?? false ) && ! empty( $attributes['language'] ) )
-			? \sprintf( '<span>%s</span>', esc_html( $attributes['language'] ) )
-			: '';
+		$language_html = '';
+		if ( $attributes['showLanguageName'] ) {
+			$language_text = empty( $attributes['language'] )
+				? __( 'Plain text', 'jetpack-mu-wpcom' )
+				: $attributes['language'];
+			$language_html = \sprintf(
+				'<span>%s</span>',
+				esc_html( $language_text )
+			);
+		}
 
 		$header_right_html = ( $copy_html || $language_html )
 			? "<div class=\"a8c/code__header-right\">{$copy_html}{$language_html}</div>"

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/class-code-block.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/class-code-block.php
@@ -261,10 +261,6 @@ abstract class Code_Block {
 				'type'    => 'boolean',
 				'default' => false,
 			),
-			'showFileName'            => array(
-				'type'    => 'boolean',
-				'default' => false,
-			),
 			'showCopyButton'          => array(
 				'type'    => 'boolean',
 				'default' => false,
@@ -423,7 +419,7 @@ abstract class Code_Block {
 
 		$attrs = get_block_wrapper_attributes( $extra_attrs );
 
-		$filename_html = ( ( $attributes['showFileName'] ?? false ) && ! empty( $attributes['filename'] ) )
+		$filename_html = ( ! empty( $attributes['filename'] ) )
 			? \sprintf( '<span class="a8c/code__filename">%s</span>', esc_html( $attributes['filename'] ) )
 			: '';
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/class-code-block.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/class-code-block.php
@@ -433,7 +433,7 @@ abstract class Code_Block {
 			: '';
 
 		$language_html = '';
-		if ( $attributes['showLanguageName'] ) {
+		if ( $attributes['showLanguageName'] ?? false ) {
 			$language_text = empty( $attributes['language'] )
 				? __( 'Plain text', 'jetpack-mu-wpcom' )
 				: $attributes['language'];

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/common/block.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/common/block.ts
@@ -24,7 +24,6 @@ export interface Attributes {
 	 */
 	triggerCodeUpdate: boolean;
 
-	showFileName: boolean;
 	showCopyButton: boolean;
 
 	showLanguageName: boolean;

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/editor.css
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/editor.css
@@ -32,6 +32,10 @@
 			backdrop-filter: blur(1em);
 		}
 
+		.cm-activeLine {
+			background-color: oklch(from currentColor l c h / 0.06);
+		}
+
 		/* Disable active line highlight on inactive blocks. */
 		&:not(.is-selected) .cm-activeLine {
 			background-color: transparent !important;


### PR DESCRIPTION
## Proposed changes:


A list of popular languages are sorted at the top of the language dropdown (closes ARC-1306):

| Before | After |
| --- | --- |
| <img width="550" height="514" alt="Screenshot 2026-01-02 at 17 40 04" src="https://github.com/user-attachments/assets/6ec721c6-2f8c-44b4-a24c-df36a176311e" /> | <img width="550" height="783" alt="Screenshot 2026-01-02 at 17 44 48" src="https://github.com/user-attachments/assets/d1606f34-0074-4017-90a4-870c18bedb00" /> |


Ensure that the "show language name" option displays "Plain text" language name when selected (fixes ARC-1305):

| Before | After |
| --- | --- |
| (no language displayed) | <img width="404" height="266" alt="Screenshot 2026-01-02 at 17 45 23" src="https://github.com/user-attachments/assets/a2866cec-7a3e-4bf0-b9ca-d2190837ae90" /> |

Replace show filename toggle with filename input field (closes ARC-1307):


| Before | After |
| --- | --- |
| <img width="550" height="514" alt="Screenshot 2026-01-02 at 17 39 37" src="https://github.com/user-attachments/assets/00fc05fb-031b-402b-b50b-4a12a9a1aa4a" /> | <img width="550" height="600" alt="Screenshot 2026-01-02 at 17 45 03" src="https://github.com/user-attachments/assets/f5ae247c-b164-425f-bf11-63aa15f8acf4" /> |

Improve line highlight color based on text color (closes ARC-1308):

| Before | After |
| --- | --- |
| <img width="1338" height="328" alt="Screenshot 2026-01-02 at 17 47 00" src="https://github.com/user-attachments/assets/520896fe-e7ad-415b-906f-5c1f9130c2ab" /> | <img width="1338" height="328" alt="Screenshot 2026-01-02 at 17 45 39" src="https://github.com/user-attachments/assets/d5083d54-79df-412f-8105-50890fb241fb" /> |

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

pdtkmj-42c-p2#comment-8195
pdtkmj-42c-p2#comment-8230

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

Test out the modified functionality in the Code block and confirm it works as expected.