### PR TITLE
AI Assistant: Fix site language parameter on AI request

### DIFF
--- a/projects/js-packages/ai-client/changelog/fix-jetpack-ai-language
+++ b/projects/js-packages/ai-client/changelog/fix-jetpack-ai-language
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Casing fix on yet-unused value
+
+

--- a/projects/js-packages/ai-client/src/suggestions-event-source/index.ts
+++ b/projects/js-packages/ai-client/src/suggestions-event-source/index.ts
@@ -116,7 +116,7 @@ export default class SuggestionsEventSource extends EventTarget {
 			feature?: string;
 			functions?: Array< object >;
 			model?: AiModelTypeProp;
-			languageCode?: string;
+			language_code?: string;
 		} = {};
 
 		// Populate body data with post id only if it is an integer
@@ -164,7 +164,7 @@ export default class SuggestionsEventSource extends EventTarget {
 
 		if ( options?.languageCode?.length ) {
 			debug( 'Language: %o', options.languageCode );
-			bodyData.languageCode = options.languageCode;
+			bodyData.language_code = options.languageCode;
 		}
 
 		// Clean the unclear prompt trigger flag


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Follow-up to #46410
Part of JPAI-78

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Fixes the casing of the expected `language_code` body value

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Send an AI request
* Check that the request body now has a `language_code` value instead of `languageCode`
