### PR TITLE
Forms: support Math and Code blocks inside forms

### DIFF
--- a/projects/packages/forms/changelog/update-forms-support-math-code
+++ b/projects/packages/forms/changelog/update-forms-support-math-code
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Forms: support Math and Code blocks inside forms.

--- a/projects/packages/forms/src/blocks/shared/util/constants.js
+++ b/projects/packages/forms/src/blocks/shared/util/constants.js
@@ -5,12 +5,14 @@ export const ALLOWED_INNER_BLOCKS = [ 'jetpack/label', 'jetpack/input' ];
 
 export const CORE_BLOCKS = [
 	'core/audio',
+	'core/code',
 	'core/columns',
 	'core/group',
 	'core/heading',
 	'core/html',
 	'core/image',
 	'core/list',
+	'core/math',
 	'core/paragraph',
 	'core/row',
 	'core/separator',

--- a/projects/plugins/jetpack/changelog/update-forms-support-math-code
+++ b/projects/plugins/jetpack/changelog/update-forms-support-math-code
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Forms: support Math and Code blocks inside forms.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Adds support for adding Math and Code blocks inside forms.

Math block [shipped in WP 6.9](https://wordpress.org/download/releases/6-9/).

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

<img width="1113" height="793" alt="Screenshot 2025-12-30 at 11 38 44" src="https://github.com/user-attachments/assets/3c94cead-0d03-4d6b-969b-2bc7e622ea67" />


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- You can now add the blocks and they show up well in frontend.
