### PR TITLE
Forms: Add SSRF protection for webhook URLs

### DIFF
--- a/projects/packages/forms/changelog/add-forms-webhook-url-validation
+++ b/projects/packages/forms/changelog/add-forms-webhook-url-validation
@@ -1,0 +1,5 @@
+Significance: patch
+Type: security
+Comment: Addresses potential SSRF vulnerability in webhooks feature by validating URLs using wp_http_validate_url() and blocking link-local addresses.
+
+Add SSRF protection for webhook URLs to prevent requests to internal networks and cloud metadata endpoints.

--- a/projects/packages/forms/changelog/add-forms-webhook-url-validation
+++ b/projects/packages/forms/changelog/add-forms-webhook-url-validation
@@ -1,5 +1,4 @@
 Significance: patch
 Type: security
-Comment: Addresses potential SSRF vulnerability in webhooks feature by validating URLs using wp_http_validate_url() and blocking link-local addresses.
 
-Add SSRF protection for webhook URLs to prevent requests to internal networks and cloud metadata endpoints.
+Forms: add SSRF protection for webhook URLs to prevent requests to internal networks and cloud metadata endpoints.

--- a/projects/packages/forms/src/service/class-form-webhooks.php
+++ b/projects/packages/forms/src/service/class-form-webhooks.php
@@ -389,12 +389,13 @@ class Form_Webhooks {
 		// Add filter for request-time SSRF protection (blocks link-local IPs like AWS metadata endpoint)
 		add_filter( 'http_request_host_is_external', array( $this, 'block_link_local_requests' ), 10, 3 );
 
-		// Use wp_safe_remote_request for built-in SSRF protection and redirect validation
-		$response = wp_safe_remote_request( $url, $args );
-
-		// Remove filter after request
-		remove_filter( 'http_request_host_is_external', array( $this, 'block_link_local_requests' ), 10 );
-
+		try {
+			// Use wp_safe_remote_request for built-in SSRF protection and redirect validation
+			$response = wp_safe_remote_request( $url, $args );
+		} finally {
+			// Always remove filter after request to avoid affecting subsequent HTTP requests.
+			remove_filter( 'http_request_host_is_external', array( $this, 'block_link_local_requests' ), 10 );
+		}
 		return $response;
 	}
 }

--- a/projects/packages/forms/src/service/class-form-webhooks.php
+++ b/projects/packages/forms/src/service/class-form-webhooks.php
@@ -170,17 +170,50 @@ class Form_Webhooks {
 	}
 
 	/**
-	 * Validate a webhook URL for security (SSRF protection).
+	 * Block requests to link-local IP addresses (169.254.x.x) at request time.
 	 *
-	 * Ensures the URL uses HTTPS and doesn't point to internal/private networks.
-	 * Uses WordPress's wp_http_validate_url() for SSRF protection, plus additional
-	 * checks for link-local addresses (169.254.x.x) which includes AWS metadata endpoints.
+	 * This filter runs when WordPress resolves DNS during an HTTP request,
+	 * preventing TOCTOU (Time-of-Check Time-of-Use) attacks via DNS rebinding.
+	 * The link-local range includes AWS/cloud metadata endpoints (169.254.169.254).
+	 *
+	 * This filter is added/removed around webhook requests in send_webhook().
+	 *
+	 * @param bool|null $is_external Whether the host is considered external. Default null.
+	 * @param string    $host        The host being checked.
+	 * @param string    $url         The full URL being requested.
+	 * @return bool|null False to block the request, original value otherwise.
+	 */
+	public function block_link_local_requests( $is_external, $host, $url ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		// Resolve hostname to IP (WordPress has resolved it by this point in the request)
+		$ip = gethostbyname( $host );
+
+		// Check if the resolved IP is in the link-local range (169.254.0.0/16)
+		if ( filter_var( $ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4 ) ) {
+			$ip_long = ip2long( $ip );
+			// 169.254.0.0/16 = 2851995648 to 2852061183
+			if ( $ip_long !== false && $ip_long >= 2851995648 && $ip_long <= 2852061183 ) {
+				return false; // Block the request
+			}
+		}
+
+		return $is_external;
+	}
+
+	/**
+	 * Validate a webhook URL format and scheme.
+	 *
+	 * Performs basic validation:
+	 * - Valid URL format
+	 * - HTTPS scheme requirement (policy decision)
+	 *
+	 * SSRF protection (private IPs, link-local addresses) is handled at request time
+	 * by wp_safe_remote_request() and our http_request_host_is_external filter.
+	 * This avoids TOCTOU vulnerabilities from DNS resolution during validation.
 	 *
 	 * @param string $url The webhook URL to validate.
 	 * @return bool|WP_Error True if valid, WP_Error with reason if invalid.
 	 */
 	private function validate_webhook_url( $url ) {
-		// Parse the URL to check scheme
 		$parsed = wp_parse_url( $url );
 
 		if ( ! $parsed || empty( $parsed['host'] ) ) {
@@ -190,24 +223,6 @@ class Form_Webhooks {
 		// Require HTTPS scheme
 		if ( empty( $parsed['scheme'] ) || strtolower( $parsed['scheme'] ) !== 'https' ) {
 			return new WP_Error( 'https_required', __( 'Webhook URL must use HTTPS.', 'jetpack-forms' ) );
-		}
-
-		// Use WordPress's built-in SSRF protection
-		// wp_http_validate_url() blocks private/internal IP ranges (127.x, 10.x, 172.16-31.x, 192.168.x)
-		if ( ! wp_http_validate_url( $url ) ) {
-			return new WP_Error( 'private_ip', __( 'Webhook URL cannot point to private or internal networks.', 'jetpack-forms' ) );
-		}
-
-		// Additional check for link-local addresses (169.254.x.x) which wp_http_validate_url() doesn't block
-		// This range includes the AWS/cloud metadata endpoint (169.254.169.254)
-		$host = $parsed['host'];
-		$ip   = filter_var( $host, FILTER_VALIDATE_IP ) ? $host : gethostbyname( $host );
-		if ( filter_var( $ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4 ) ) {
-			$ip_long = ip2long( $ip );
-			// 169.254.0.0/16 = 2851995648 to 2852061183
-			if ( $ip_long >= 2851995648 && $ip_long <= 2852061183 ) {
-				return new WP_Error( 'private_ip', __( 'Webhook URL cannot point to private or internal networks.', 'jetpack-forms' ) );
-			}
 		}
 
 		return true;
@@ -283,11 +298,14 @@ class Form_Webhooks {
 	/**
 	 * Send webhook request
 	 *
+	 * Uses wp_safe_remote_request() for built-in SSRF protection including redirect validation.
+	 * The http_request_host_is_external filter provides additional protection for link-local IPs.
+	 *
 	 * @param array $data The data key/value pairs to send.
 	 * @param array $webhook Webhook configuration.
 	 * @param int   $feedback_id The unique identifier for the feedback post.
 	 *
-	 * @return array|WP_Error The result value from wp_remote_request
+	 * @return array|WP_Error The result value from wp_safe_remote_request
 	 */
 	private function send_webhook( $data, $webhook, $feedback_id ) {
 		global $wp_version;
@@ -324,6 +342,15 @@ class Form_Webhooks {
 			'sslverify' => true,
 		);
 
-		return wp_remote_request( $url, $args );
+		// Add filter for request-time SSRF protection (blocks link-local IPs like AWS metadata endpoint)
+		add_filter( 'http_request_host_is_external', array( $this, 'block_link_local_requests' ), 10, 3 );
+
+		// Use wp_safe_remote_request for built-in SSRF protection and redirect validation
+		$response = wp_safe_remote_request( $url, $args );
+
+		// Remove filter after request
+		remove_filter( 'http_request_host_is_external', array( $this, 'block_link_local_requests' ), 10 );
+
+		return $response;
 	}
 }

--- a/projects/packages/forms/src/service/class-form-webhooks.php
+++ b/projects/packages/forms/src/service/class-form-webhooks.php
@@ -170,11 +170,17 @@ class Form_Webhooks {
 	}
 
 	/**
-	 * Block requests to link-local IP addresses (169.254.x.x) at request time.
+	 * Block requests to link-local and private IP addresses at request time.
 	 *
 	 * This filter runs when WordPress resolves DNS during an HTTP request,
 	 * preventing TOCTOU (Time-of-Check Time-of-Use) attacks via DNS rebinding.
-	 * The link-local range includes AWS/cloud metadata endpoints (169.254.169.254).
+	 *
+	 * Blocks:
+	 * - IPv4 link-local (169.254.0.0/16) - includes AWS metadata endpoint (169.254.169.254)
+	 * - IPv6 loopback (::1)
+	 * - IPv6 link-local (fe80::/10)
+	 * - IPv6 unique local addresses (fc00::/7, includes fd00::/8)
+	 * - IPv6 site-local addresses (fec0::/10) - deprecated but still blocked
 	 *
 	 * This filter is added/removed around webhook requests in send_webhook().
 	 *
@@ -184,15 +190,53 @@ class Form_Webhooks {
 	 * @return bool|null False to block the request, original value otherwise.
 	 */
 	public function block_link_local_requests( $is_external, $host, $url ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
-		// Resolve hostname to IP (WordPress has resolved it by this point in the request)
-		$ip = gethostbyname( $host );
+		// Strip brackets from IPv6 addresses if present (e.g., [::1] -> ::1)
+		$host = trim( $host, '[]' );
 
-		// Check if the resolved IP is in the link-local range (169.254.0.0/16)
+		// Get IP address - either directly if host is an IP, or resolve via DNS
+		$ip = filter_var( $host, FILTER_VALIDATE_IP ) ? $host : gethostbyname( $host );
+
+		// Check IPv4 link-local addresses (169.254.0.0/16)
+		// This range includes the AWS/cloud metadata endpoint (169.254.169.254)
 		if ( filter_var( $ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4 ) ) {
 			$ip_long = ip2long( $ip );
 			// 169.254.0.0/16 = 2851995648 to 2852061183
 			if ( $ip_long !== false && $ip_long >= 2851995648 && $ip_long <= 2852061183 ) {
-				return false; // Block the request
+				return false;
+			}
+		}
+
+		// Check IPv6 addresses for private/internal ranges
+		if ( filter_var( $ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6 ) ) {
+			$ip_binary = inet_pton( $ip );
+			if ( $ip_binary === false ) {
+				return false; // Invalid IPv6, let other filters handle it
+			}
+
+			// Check for IPv6 loopback (::1)
+			if ( $ip === '::1' ) {
+				return false;
+			}
+
+			$first_byte  = ord( $ip_binary[0] );
+			$second_byte = ord( $ip_binary[1] );
+
+			// Check for IPv6 link-local addresses (fe80::/10)
+			// First byte is 0xfe (254), second byte's top 2 bits are 10 (0x80-0xbf)
+			if ( $first_byte === 0xfe && ( $second_byte & 0xc0 ) === 0x80 ) {
+				return false;
+			}
+
+			// Check for IPv6 unique local addresses (fc00::/7)
+			// Covers fc00::/8 and fd00::/8 (used for private networks, cloud metadata)
+			if ( ( $first_byte & 0xfe ) === 0xfc ) {
+				return false;
+			}
+
+			// Check for IPv6 site-local addresses (fec0::/10) - deprecated but still blocked
+			// First byte is 0xfe (254), second byte's top 2 bits are 11 (0xc0-0xff)
+			if ( $first_byte === 0xfe && ( $second_byte & 0xc0 ) === 0xc0 ) {
+				return false;
 			}
 		}
 

--- a/projects/packages/forms/src/service/class-form-webhooks.php
+++ b/projects/packages/forms/src/service/class-form-webhooks.php
@@ -187,6 +187,13 @@ class Form_Webhooks {
 			if ( $ip_long !== false && $ip_long >= 2851995648 && $ip_long <= 2852061183 ) {
 				return true;
 			}
+
+			// Block Azure Wire Server (168.63.129.16)
+			// Used for Azure internal services including Instance Metadata Service
+			if ( $ip === '168.63.129.16' ) {
+				return true;
+			}
+
 			return false;
 		}
 

--- a/projects/packages/forms/src/service/class-form-webhooks.php
+++ b/projects/packages/forms/src/service/class-form-webhooks.php
@@ -216,11 +216,8 @@ class Form_Webhooks {
 			if ( strlen( $ip_binary ) === 16 &&
 				substr( $ip_binary, 0, 10 ) === "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00" &&
 				substr( $ip_binary, 10, 2 ) === "\xff\xff" ) {
-				// Extract the embedded IPv4 address and check it
-				$ipv4_bytes = substr( $ip_binary, 12, 4 );
-				$ipv4       = inet_ntop( "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00" . $ipv4_bytes );
-				// Convert to proper IPv4 format
-				$ipv4 = long2ip( ip2long( substr( $ip, strrpos( $ip, ':' ) + 1 ) ) );
+				// Extract the embedded IPv4 address (last 4 bytes) and check it
+				$ipv4 = inet_ntop( substr( $ip_binary, 12, 4 ) );
 				if ( $ipv4 && $this->is_blocked_ip( $ipv4 ) ) {
 					return true;
 				}

--- a/projects/packages/forms/src/service/class-form-webhooks.php
+++ b/projects/packages/forms/src/service/class-form-webhooks.php
@@ -200,7 +200,7 @@ class Form_Webhooks {
 		// Check IPv6 addresses for private/internal ranges
 		if ( filter_var( $ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6 ) ) {
 			$ip_binary = inet_pton( $ip );
-			if ( $ip_binary === false ) {
+			if ( $ip_binary === false || strlen( $ip_binary ) < 2 ) {
 				return false;
 			}
 

--- a/projects/packages/forms/src/service/class-form-webhooks.php
+++ b/projects/packages/forms/src/service/class-form-webhooks.php
@@ -260,6 +260,12 @@ class Form_Webhooks {
 	 * @return bool|WP_Error True if valid, WP_Error with reason if invalid.
 	 */
 	private function validate_webhook_url( $url ) {
+		// Validate URL format before parsing to catch malformed URLs
+		// e.g., "https:///example.com" or URLs with unusual syntax
+		if ( ! filter_var( $url, FILTER_VALIDATE_URL ) ) {
+			return new WP_Error( 'invalid_url', __( 'Invalid webhook URL format.', 'jetpack-forms' ) );
+		}
+
 		$parsed = wp_parse_url( $url );
 
 		if ( ! $parsed || empty( $parsed['host'] ) ) {

--- a/projects/packages/forms/src/service/class-form-webhooks.php
+++ b/projects/packages/forms/src/service/class-form-webhooks.php
@@ -176,6 +176,9 @@ class Form_Webhooks {
 	 * @return bool True if the IP should be blocked.
 	 */
 	private function is_blocked_ip( $ip ) {
+		// Strip IPv6 zone identifier if present (e.g., fe80::1%eth0 -> fe80::1)
+		$ip = preg_replace( '/%.*$/', '', $ip );
+
 		// Check IPv4 link-local addresses (169.254.0.0/16)
 		// This range includes the AWS/cloud metadata endpoint (169.254.169.254)
 		if ( filter_var( $ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4 ) ) {
@@ -197,6 +200,22 @@ class Form_Webhooks {
 			// Check for IPv6 loopback (::1)
 			if ( $ip === '::1' ) {
 				return true;
+			}
+
+			// Check for IPv4-mapped IPv6 addresses (::ffff:x.x.x.x)
+			// These are 16 bytes where first 10 are zeros, next 2 are 0xff, last 4 are IPv4
+			// phpcs:ignore Generic.Strings.UnnecessaryStringConcat.Found -- string concat for readability
+			if ( strlen( $ip_binary ) === 16 &&
+				substr( $ip_binary, 0, 10 ) === "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00" &&
+				substr( $ip_binary, 10, 2 ) === "\xff\xff" ) {
+				// Extract the embedded IPv4 address and check it
+				$ipv4_bytes = substr( $ip_binary, 12, 4 );
+				$ipv4       = inet_ntop( "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00" . $ipv4_bytes );
+				// Convert to proper IPv4 format
+				$ipv4 = long2ip( ip2long( substr( $ip, strrpos( $ip, ':' ) + 1 ) ) );
+				if ( $ipv4 && $this->is_blocked_ip( $ipv4 ) ) {
+					return true;
+				}
 			}
 
 			$first_byte  = ord( $ip_binary[0] );
@@ -251,6 +270,18 @@ class Form_Webhooks {
 		$host = $parsed['host'];
 		// Strip brackets from IPv6 addresses if present (e.g., [::1] -> ::1)
 		$host = trim( $host, '[]' );
+
+		// URL-decode the host to prevent bypass attempts using encoded characters
+		// e.g., 169%2e254%2e169%2e254 -> 169.254.169.254
+		// e.g., fe80::1%25eth0 -> fe80::1%eth0 (zone identifier becomes visible)
+		$host = rawurldecode( $host );
+
+		// Strip IPv6 zone identifier if present (e.g., fe80::1%eth0 -> fe80::1)
+		// Zone identifiers are used for link-local addresses and should be blocked
+		// Must happen AFTER URL decoding since %25 decodes to %
+		if ( strpos( $host, '%' ) !== false ) {
+			$host = preg_replace( '/%.*$/', '', $host );
+		}
 
 		// If host is already an IP, check it directly
 		if ( filter_var( $host, FILTER_VALIDATE_IP ) ) {

--- a/projects/packages/forms/src/service/class-form-webhooks.php
+++ b/projects/packages/forms/src/service/class-form-webhooks.php
@@ -170,58 +170,6 @@ class Form_Webhooks {
 	}
 
 	/**
-	 * Block requests to link-local and private IP addresses at request time.
-	 *
-	 * This filter runs when WordPress resolves DNS during an HTTP request,
-	 * preventing TOCTOU (Time-of-Check Time-of-Use) attacks via DNS rebinding.
-	 *
-	 * Blocks:
-	 * - IPv4 link-local (169.254.0.0/16) - includes AWS metadata endpoint (169.254.169.254)
-	 * - IPv6 loopback (::1)
-	 * - IPv6 link-local (fe80::/10)
-	 * - IPv6 unique local addresses (fc00::/7, includes fd00::/8)
-	 * - IPv6 site-local addresses (fec0::/10) - deprecated but still blocked
-	 *
-	 * This filter is added/removed around webhook requests in send_webhook().
-	 *
-	 * @param bool|null $is_external Whether the host is considered external. Default null.
-	 * @param string    $host        The host being checked.
-	 * @param string    $url         The full URL being requested.
-	 * @return bool|null False to block the request, original value otherwise.
-	 */
-	public function block_link_local_requests( $is_external, $host, $url ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
-		// Strip brackets from IPv6 addresses if present (e.g., [::1] -> ::1)
-		$host = trim( $host, '[]' );
-
-		// If host is already an IP, check it directly
-		if ( filter_var( $host, FILTER_VALIDATE_IP ) ) {
-			return $this->is_blocked_ip( $host ) ? false : $is_external;
-		}
-
-		// For hostnames, check IPv4 via gethostbyname
-		$ipv4 = gethostbyname( $host );
-		if ( $ipv4 !== $host && $this->is_blocked_ip( $ipv4 ) ) {
-			return false;
-		}
-
-		// Check IPv6 via DNS AAAA records (gethostbyname only resolves IPv4)
-		// This catches hostnames that resolve to blocked IPv6 addresses
-		if ( function_exists( 'dns_get_record' ) ) {
-			// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- dns_get_record may fail on some systems
-			$aaaa_records = @dns_get_record( $host, DNS_AAAA );
-			if ( $aaaa_records ) {
-				foreach ( $aaaa_records as $record ) {
-					if ( isset( $record['ipv6'] ) && $this->is_blocked_ip( $record['ipv6'] ) ) {
-						return false;
-					}
-				}
-			}
-		}
-
-		return $is_external;
-	}
-
-	/**
 	 * Check if an IP address is in a blocked range.
 	 *
 	 * @param string $ip The IP address to check.
@@ -277,15 +225,12 @@ class Form_Webhooks {
 	}
 
 	/**
-	 * Validate a webhook URL format and scheme.
+	 * Validate a webhook URL format, scheme, and check for blocked IP ranges.
 	 *
-	 * Performs basic validation:
+	 * Performs validation:
 	 * - Valid URL format
-	 * - HTTPS scheme requirement (policy decision)
-	 *
-	 * SSRF protection (private IPs, link-local addresses) is handled at request time
-	 * by wp_safe_remote_request() and our http_request_host_is_external filter.
-	 * This avoids TOCTOU vulnerabilities from DNS resolution during validation.
+	 * - HTTPS scheme requirement
+	 * - Blocks link-local and private IP ranges not covered by wp_safe_remote_request()
 	 *
 	 * @param string $url The webhook URL to validate.
 	 * @return bool|WP_Error True if valid, WP_Error with reason if invalid.
@@ -300,6 +245,39 @@ class Form_Webhooks {
 		// Require HTTPS scheme
 		if ( empty( $parsed['scheme'] ) || strtolower( $parsed['scheme'] ) !== 'https' ) {
 			return new WP_Error( 'https_required', __( 'Webhook URL must use HTTPS.', 'jetpack-forms' ) );
+		}
+
+		// Check for blocked IP ranges (link-local, private IPv6)
+		$host = $parsed['host'];
+		// Strip brackets from IPv6 addresses if present (e.g., [::1] -> ::1)
+		$host = trim( $host, '[]' );
+
+		// If host is already an IP, check it directly
+		if ( filter_var( $host, FILTER_VALIDATE_IP ) ) {
+			if ( $this->is_blocked_ip( $host ) ) {
+				return new WP_Error( 'blocked_ip', __( 'Webhook URL cannot point to private or internal networks.', 'jetpack-forms' ) );
+			}
+			return true;
+		}
+
+		// For hostnames, check IPv4 via gethostbyname
+		$ipv4 = gethostbyname( $host );
+		if ( $ipv4 !== $host && $this->is_blocked_ip( $ipv4 ) ) {
+			return new WP_Error( 'blocked_ip', __( 'Webhook URL cannot point to private or internal networks.', 'jetpack-forms' ) );
+		}
+
+		// Check IPv6 via DNS AAAA records (gethostbyname only resolves IPv4)
+		// This catches hostnames that resolve to blocked IPv6 addresses
+		if ( function_exists( 'dns_get_record' ) ) {
+			// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- dns_get_record may fail on some systems
+			$aaaa_records = @dns_get_record( $host, DNS_AAAA );
+			if ( $aaaa_records ) {
+				foreach ( $aaaa_records as $record ) {
+					if ( isset( $record['ipv6'] ) && $this->is_blocked_ip( $record['ipv6'] ) ) {
+						return new WP_Error( 'blocked_ip', __( 'Webhook URL cannot point to private or internal networks.', 'jetpack-forms' ) );
+					}
+				}
+			}
 		}
 
 		return true;
@@ -376,7 +354,6 @@ class Form_Webhooks {
 	 * Send webhook request
 	 *
 	 * Uses wp_safe_remote_request() for built-in SSRF protection including redirect validation.
-	 * The http_request_host_is_external filter provides additional protection for link-local IPs.
 	 *
 	 * @param array $data The data key/value pairs to send.
 	 * @param array $webhook Webhook configuration.
@@ -419,16 +396,7 @@ class Form_Webhooks {
 			'sslverify' => true,
 		);
 
-		// Add filter for request-time SSRF protection (blocks link-local IPs like AWS metadata endpoint)
-		add_filter( 'http_request_host_is_external', array( $this, 'block_link_local_requests' ), 10, 3 );
-
-		try {
-			// Use wp_safe_remote_request for built-in SSRF protection and redirect validation
-			$response = wp_safe_remote_request( $url, $args );
-		} finally {
-			// Always remove filter after request to avoid affecting subsequent HTTP requests.
-			remove_filter( 'http_request_host_is_external', array( $this, 'block_link_local_requests' ), 10 );
-		}
-		return $response;
+		// Use wp_safe_remote_request for built-in SSRF protection and redirect validation
+		return wp_safe_remote_request( $url, $args );
 	}
 }

--- a/projects/packages/forms/src/service/class-form-webhooks.php
+++ b/projects/packages/forms/src/service/class-form-webhooks.php
@@ -204,8 +204,9 @@ class Form_Webhooks {
 				return false;
 			}
 
-			// Check for IPv6 loopback (::1)
-			if ( $ip === '::1' ) {
+			// Check for IPv6 loopback (::1) using binary comparison
+			// This handles all valid representations (e.g., 0:0:0:0:0:0:0:1, ::0:1)
+			if ( $ip_binary === inet_pton( '::1' ) ) {
 				return true;
 			}
 

--- a/projects/packages/forms/src/service/class-form-webhooks.php
+++ b/projects/packages/forms/src/service/class-form-webhooks.php
@@ -170,6 +170,50 @@ class Form_Webhooks {
 	}
 
 	/**
+	 * Validate a webhook URL for security (SSRF protection).
+	 *
+	 * Ensures the URL uses HTTPS and doesn't point to internal/private networks.
+	 * Uses WordPress's wp_http_validate_url() for SSRF protection, plus additional
+	 * checks for link-local addresses (169.254.x.x) which includes AWS metadata endpoints.
+	 *
+	 * @param string $url The webhook URL to validate.
+	 * @return bool|WP_Error True if valid, WP_Error with reason if invalid.
+	 */
+	private function validate_webhook_url( $url ) {
+		// Parse the URL to check scheme
+		$parsed = wp_parse_url( $url );
+
+		if ( ! $parsed || empty( $parsed['host'] ) ) {
+			return new WP_Error( 'invalid_url', __( 'Invalid webhook URL format.', 'jetpack-forms' ) );
+		}
+
+		// Require HTTPS scheme
+		if ( empty( $parsed['scheme'] ) || strtolower( $parsed['scheme'] ) !== 'https' ) {
+			return new WP_Error( 'https_required', __( 'Webhook URL must use HTTPS.', 'jetpack-forms' ) );
+		}
+
+		// Use WordPress's built-in SSRF protection
+		// wp_http_validate_url() blocks private/internal IP ranges (127.x, 10.x, 172.16-31.x, 192.168.x)
+		if ( ! wp_http_validate_url( $url ) ) {
+			return new WP_Error( 'private_ip', __( 'Webhook URL cannot point to private or internal networks.', 'jetpack-forms' ) );
+		}
+
+		// Additional check for link-local addresses (169.254.x.x) which wp_http_validate_url() doesn't block
+		// This range includes the AWS/cloud metadata endpoint (169.254.169.254)
+		$host = $parsed['host'];
+		$ip   = filter_var( $host, FILTER_VALIDATE_IP ) ? $host : gethostbyname( $host );
+		if ( filter_var( $ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4 ) ) {
+			$ip_long = ip2long( $ip );
+			// 169.254.0.0/16 = 2851995648 to 2852061183
+			if ( $ip_long >= 2851995648 && $ip_long <= 2852061183 ) {
+				return new WP_Error( 'private_ip', __( 'Webhook URL cannot point to private or internal networks.', 'jetpack-forms' ) );
+			}
+		}
+
+		return true;
+	}
+
+	/**
 	 * Get the enabled webhooks from the form attributes.
 	 *
 	 * @param array $attributes - the attributes of the contact form.
@@ -203,6 +247,13 @@ class Form_Webhooks {
 			// Validate webhook configuration
 			if ( empty( $setup['url'] ) ) {
 				do_action( 'jetpack_forms_log', 'webhook_skipped', 'url_empty' );
+				continue;
+			}
+
+			// Validate URL for security (SSRF protection)
+			$url_validation = $this->validate_webhook_url( $setup['url'] );
+			if ( is_wp_error( $url_validation ) ) {
+				do_action( 'jetpack_forms_log', 'webhook_skipped', $url_validation->get_error_code(), $setup );
 				continue;
 			}
 

--- a/projects/packages/forms/src/service/class-form-webhooks.php
+++ b/projects/packages/forms/src/service/class-form-webhooks.php
@@ -193,29 +193,62 @@ class Form_Webhooks {
 		// Strip brackets from IPv6 addresses if present (e.g., [::1] -> ::1)
 		$host = trim( $host, '[]' );
 
-		// Get IP address - either directly if host is an IP, or resolve via DNS
-		$ip = filter_var( $host, FILTER_VALIDATE_IP ) ? $host : gethostbyname( $host );
+		// If host is already an IP, check it directly
+		if ( filter_var( $host, FILTER_VALIDATE_IP ) ) {
+			return $this->is_blocked_ip( $host ) ? false : $is_external;
+		}
 
+		// For hostnames, check IPv4 via gethostbyname
+		$ipv4 = gethostbyname( $host );
+		if ( $ipv4 !== $host && $this->is_blocked_ip( $ipv4 ) ) {
+			return false;
+		}
+
+		// Check IPv6 via DNS AAAA records (gethostbyname only resolves IPv4)
+		// This catches hostnames that resolve to blocked IPv6 addresses
+		if ( function_exists( 'dns_get_record' ) ) {
+			// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- dns_get_record may fail on some systems
+			$aaaa_records = @dns_get_record( $host, DNS_AAAA );
+			if ( $aaaa_records ) {
+				foreach ( $aaaa_records as $record ) {
+					if ( isset( $record['ipv6'] ) && $this->is_blocked_ip( $record['ipv6'] ) ) {
+						return false;
+					}
+				}
+			}
+		}
+
+		return $is_external;
+	}
+
+	/**
+	 * Check if an IP address is in a blocked range.
+	 *
+	 * @param string $ip The IP address to check.
+	 * @return bool True if the IP should be blocked.
+	 */
+	private function is_blocked_ip( $ip ) {
 		// Check IPv4 link-local addresses (169.254.0.0/16)
 		// This range includes the AWS/cloud metadata endpoint (169.254.169.254)
 		if ( filter_var( $ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4 ) ) {
 			$ip_long = ip2long( $ip );
 			// 169.254.0.0/16 = 2851995648 to 2852061183
 			if ( $ip_long !== false && $ip_long >= 2851995648 && $ip_long <= 2852061183 ) {
-				return false;
+				return true;
 			}
+			return false;
 		}
 
 		// Check IPv6 addresses for private/internal ranges
 		if ( filter_var( $ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6 ) ) {
 			$ip_binary = inet_pton( $ip );
 			if ( $ip_binary === false ) {
-				return false; // Invalid IPv6, let other filters handle it
+				return false;
 			}
 
 			// Check for IPv6 loopback (::1)
 			if ( $ip === '::1' ) {
-				return false;
+				return true;
 			}
 
 			$first_byte  = ord( $ip_binary[0] );
@@ -224,23 +257,23 @@ class Form_Webhooks {
 			// Check for IPv6 link-local addresses (fe80::/10)
 			// First byte is 0xfe (254), second byte's top 2 bits are 10 (0x80-0xbf)
 			if ( $first_byte === 0xfe && ( $second_byte & 0xc0 ) === 0x80 ) {
-				return false;
+				return true;
 			}
 
 			// Check for IPv6 unique local addresses (fc00::/7)
 			// Covers fc00::/8 and fd00::/8 (used for private networks, cloud metadata)
 			if ( ( $first_byte & 0xfe ) === 0xfc ) {
-				return false;
+				return true;
 			}
 
 			// Check for IPv6 site-local addresses (fec0::/10) - deprecated but still blocked
 			// First byte is 0xfe (254), second byte's top 2 bits are 11 (0xc0-0xff)
 			if ( $first_byte === 0xfe && ( $second_byte & 0xc0 ) === 0xc0 ) {
-				return false;
+				return true;
 			}
 		}
 
-		return $is_external;
+		return false;
 	}
 
 	/**

--- a/projects/packages/forms/tests/php/service/Form_Webhooks_Test.php
+++ b/projects/packages/forms/tests/php/service/Form_Webhooks_Test.php
@@ -1314,11 +1314,11 @@ class Form_Webhooks_Test extends BaseTestCase {
 		$webhooks = Form_Webhooks::init();
 		$webhooks->send_webhooks( $post_id, $fields, false, array() );
 
-		// URL-encoded IPs should be decoded and blocked at validation time
+		// URL-encoded IPs are rejected as invalid URLs by filter_var()
 		$this->assertFalse( $http_request_made, 'HTTP request should not be made for URL-encoded IP URLs' );
-		$this->assertNotEmpty( $logged_events, 'Blocked IP should be logged' );
+		$this->assertNotEmpty( $logged_events, 'Invalid URL should be logged' );
 		// @phan-suppress-next-line PhanTypeArraySuspiciousNull, PhanTypeInvalidDimOffset
-		$this->assertEquals( 'blocked_ip', $logged_events[0]['reason'] );
+		$this->assertEquals( 'invalid_url', $logged_events[0]['reason'] );
 	}
 
 	/**
@@ -1629,12 +1629,11 @@ class Form_Webhooks_Test extends BaseTestCase {
 		$webhooks = Form_Webhooks::init();
 		$webhooks->send_webhooks( $post_id, $fields, false, array() );
 
-		// IPv6 with zone identifier should be blocked at validation time
-		// The zone ID is stripped, revealing the fe80:: link-local address
+		// IPv6 with zone identifier is rejected as invalid URL by filter_var()
 		$this->assertFalse( $http_request_made, 'HTTP request should not be made for IPv6 with zone identifier' );
-		$this->assertNotEmpty( $logged_events, 'Blocked IP should be logged' );
+		$this->assertNotEmpty( $logged_events, 'Invalid URL should be logged' );
 		// @phan-suppress-next-line PhanTypeArraySuspiciousNull, PhanTypeInvalidDimOffset
-		$this->assertEquals( 'blocked_ip', $logged_events[0]['reason'] );
+		$this->assertEquals( 'invalid_url', $logged_events[0]['reason'] );
 	}
 
 	/**

--- a/projects/packages/forms/tests/php/service/Form_Webhooks_Test.php
+++ b/projects/packages/forms/tests/php/service/Form_Webhooks_Test.php
@@ -1000,17 +1000,28 @@ class Form_Webhooks_Test extends BaseTestCase {
 
 		$post_id = $this->create_feedback_post( $form, $fields );
 
-		// Track if HTTP request was made
+		// Prevent actual network requests - return WP_Error if filter is reached
 		$http_request_made = false;
 		add_filter(
 			'pre_http_request',
 			function () use ( &$http_request_made ) {
 				$http_request_made = true;
-				return array(
-					'response' => array( 'code' => 200 ),
-					'body'     => '{}',
-				);
+				return new \WP_Error( 'http_request_not_executed', 'Request should have been blocked.' );
 			}
+		);
+
+		$logged_events = array();
+		add_action(
+			'jetpack_forms_log',
+			function ( $event, $reason, $data = null ) use ( &$logged_events ) {
+				$logged_events[] = array(
+					'event'  => $event,
+					'reason' => $reason,
+					'data'   => $data,
+				);
+			},
+			10,
+			3
 		);
 
 		$webhooks = Form_Webhooks::init();
@@ -1018,6 +1029,11 @@ class Form_Webhooks_Test extends BaseTestCase {
 
 		// IPv6 loopback should be blocked at validation time
 		$this->assertFalse( $http_request_made, 'HTTP request should not be made for IPv6 loopback URLs' );
+		$this->assertCount( 1, $logged_events );
+		// @phan-suppress-next-line PhanTypeArraySuspiciousNull, PhanTypeInvalidDimOffset
+		$this->assertEquals( 'webhook_skipped', $logged_events[0]['event'] );
+		// @phan-suppress-next-line PhanTypeArraySuspiciousNull, PhanTypeInvalidDimOffset
+		$this->assertEquals( 'blocked_ip', $logged_events[0]['reason'] );
 	}
 
 	/**
@@ -1042,17 +1058,28 @@ class Form_Webhooks_Test extends BaseTestCase {
 
 		$post_id = $this->create_feedback_post( $form, $fields );
 
-		// Track if HTTP request was made
+		// Prevent actual network requests - return WP_Error if filter is reached
 		$http_request_made = false;
 		add_filter(
 			'pre_http_request',
 			function () use ( &$http_request_made ) {
 				$http_request_made = true;
-				return array(
-					'response' => array( 'code' => 200 ),
-					'body'     => '{}',
-				);
+				return new \WP_Error( 'http_request_not_executed', 'Request should have been blocked.' );
 			}
+		);
+
+		$logged_events = array();
+		add_action(
+			'jetpack_forms_log',
+			function ( $event, $reason, $data = null ) use ( &$logged_events ) {
+				$logged_events[] = array(
+					'event'  => $event,
+					'reason' => $reason,
+					'data'   => $data,
+				);
+			},
+			10,
+			3
 		);
 
 		$webhooks = Form_Webhooks::init();
@@ -1060,6 +1087,11 @@ class Form_Webhooks_Test extends BaseTestCase {
 
 		// IPv6 link-local should be blocked at validation time
 		$this->assertFalse( $http_request_made, 'HTTP request should not be made for IPv6 link-local URLs' );
+		$this->assertCount( 1, $logged_events );
+		// @phan-suppress-next-line PhanTypeArraySuspiciousNull, PhanTypeInvalidDimOffset
+		$this->assertEquals( 'webhook_skipped', $logged_events[0]['event'] );
+		// @phan-suppress-next-line PhanTypeArraySuspiciousNull, PhanTypeInvalidDimOffset
+		$this->assertEquals( 'blocked_ip', $logged_events[0]['reason'] );
 	}
 
 	/**
@@ -1085,17 +1117,28 @@ class Form_Webhooks_Test extends BaseTestCase {
 
 		$post_id = $this->create_feedback_post( $form, $fields );
 
-		// Track if HTTP request was made
+		// Prevent actual network requests - return WP_Error if filter is reached
 		$http_request_made = false;
 		add_filter(
 			'pre_http_request',
 			function () use ( &$http_request_made ) {
 				$http_request_made = true;
-				return array(
-					'response' => array( 'code' => 200 ),
-					'body'     => '{}',
-				);
+				return new \WP_Error( 'http_request_not_executed', 'Request should have been blocked.' );
 			}
+		);
+
+		$logged_events = array();
+		add_action(
+			'jetpack_forms_log',
+			function ( $event, $reason, $data = null ) use ( &$logged_events ) {
+				$logged_events[] = array(
+					'event'  => $event,
+					'reason' => $reason,
+					'data'   => $data,
+				);
+			},
+			10,
+			3
 		);
 
 		$webhooks = Form_Webhooks::init();
@@ -1103,6 +1146,11 @@ class Form_Webhooks_Test extends BaseTestCase {
 
 		// IPv6 unique local addresses should be blocked at validation time
 		$this->assertFalse( $http_request_made, 'HTTP request should not be made for IPv6 unique local URLs' );
+		$this->assertCount( 1, $logged_events );
+		// @phan-suppress-next-line PhanTypeArraySuspiciousNull, PhanTypeInvalidDimOffset
+		$this->assertEquals( 'webhook_skipped', $logged_events[0]['event'] );
+		// @phan-suppress-next-line PhanTypeArraySuspiciousNull, PhanTypeInvalidDimOffset
+		$this->assertEquals( 'blocked_ip', $logged_events[0]['reason'] );
 	}
 
 	/**
@@ -1127,17 +1175,28 @@ class Form_Webhooks_Test extends BaseTestCase {
 
 		$post_id = $this->create_feedback_post( $form, $fields );
 
-		// Track if HTTP request was made
+		// Prevent actual network requests - return WP_Error if filter is reached
 		$http_request_made = false;
 		add_filter(
 			'pre_http_request',
 			function () use ( &$http_request_made ) {
 				$http_request_made = true;
-				return array(
-					'response' => array( 'code' => 200 ),
-					'body'     => '{}',
-				);
+				return new \WP_Error( 'http_request_not_executed', 'Request should have been blocked.' );
 			}
+		);
+
+		$logged_events = array();
+		add_action(
+			'jetpack_forms_log',
+			function ( $event, $reason, $data = null ) use ( &$logged_events ) {
+				$logged_events[] = array(
+					'event'  => $event,
+					'reason' => $reason,
+					'data'   => $data,
+				);
+			},
+			10,
+			3
 		);
 
 		$webhooks = Form_Webhooks::init();
@@ -1145,6 +1204,11 @@ class Form_Webhooks_Test extends BaseTestCase {
 
 		// IPv6 site-local addresses (deprecated) should be blocked at validation time
 		$this->assertFalse( $http_request_made, 'HTTP request should not be made for IPv6 site-local URLs' );
+		$this->assertCount( 1, $logged_events );
+		// @phan-suppress-next-line PhanTypeArraySuspiciousNull, PhanTypeInvalidDimOffset
+		$this->assertEquals( 'webhook_skipped', $logged_events[0]['event'] );
+		// @phan-suppress-next-line PhanTypeArraySuspiciousNull, PhanTypeInvalidDimOffset
+		$this->assertEquals( 'blocked_ip', $logged_events[0]['reason'] );
 	}
 
 	/**

--- a/projects/packages/forms/tests/php/service/Form_Webhooks_Test.php
+++ b/projects/packages/forms/tests/php/service/Form_Webhooks_Test.php
@@ -1097,6 +1097,601 @@ class Form_Webhooks_Test extends BaseTestCase {
 	}
 
 	/**
+	 * Test that webhook blocks IPv4-mapped IPv6 addresses.
+	 * SSRF protection should block ::ffff:169.254.169.254 which maps to the AWS metadata endpoint.
+	 */
+	public function test_send_webhooks_blocks_ipv4_mapped_ipv6() {
+		$form   = $this->create_mock_form(
+			array(
+				'webhooks' => array(
+					array(
+						'webhook_id' => 'test-webhook',
+						'url'        => 'https://[::ffff:169.254.169.254]/latest/meta-data/',
+						'format'     => 'json',
+						'method'     => 'POST',
+						'enabled'    => true,
+					),
+				),
+			)
+		);
+		$fields = array( $this->create_mock_field( $form, 'test-field', 'test value' ) );
+
+		$post_id = $this->create_feedback_post( $form, $fields );
+
+		// Track if HTTP request was made
+		$http_request_made = false;
+		add_filter(
+			'pre_http_request',
+			function () use ( &$http_request_made ) {
+				$http_request_made = true;
+				return array(
+					'response' => array( 'code' => 200 ),
+					'body'     => '{}',
+					'headers'  => new CaseInsensitiveDictionary( array( 'Content-Type' => 'application/json' ) ),
+				);
+			}
+		);
+
+		$logged_events = array();
+		add_action(
+			'jetpack_forms_log',
+			function ( $event, $reason, $data = null ) use ( &$logged_events ) {
+				$logged_events[] = array(
+					'event'  => $event,
+					'reason' => $reason,
+					'data'   => $data,
+				);
+			},
+			10,
+			3
+		);
+
+		$webhooks = Form_Webhooks::init();
+		$webhooks->send_webhooks( $post_id, $fields, false, array() );
+
+		// IPv4-mapped IPv6 addresses should be blocked at validation time
+		$this->assertFalse( $http_request_made, 'HTTP request should not be made for IPv4-mapped IPv6 URLs' );
+		$this->assertNotEmpty( $logged_events, 'Blocked IP should be logged' );
+		// @phan-suppress-next-line PhanTypeArraySuspiciousNull, PhanTypeInvalidDimOffset
+		$this->assertEquals( 'blocked_ip', $logged_events[0]['reason'] );
+	}
+
+	/**
+	 * Test that webhook blocks fc00:: addresses (part of fc00::/7 unique local range).
+	 * SSRF protection should block fc00::/8 in addition to fd00::/8.
+	 */
+	public function test_send_webhooks_blocks_ipv6_fc00_range() {
+		$form   = $this->create_mock_form(
+			array(
+				'webhooks' => array(
+					array(
+						'webhook_id' => 'test-webhook',
+						'url'        => 'https://[fc00::1]/webhook',
+						'format'     => 'json',
+						'method'     => 'POST',
+						'enabled'    => true,
+					),
+				),
+			)
+		);
+		$fields = array( $this->create_mock_field( $form, 'test-field', 'test value' ) );
+
+		$post_id = $this->create_feedback_post( $form, $fields );
+
+		// Track if HTTP request was made
+		$http_request_made = false;
+		add_filter(
+			'pre_http_request',
+			function () use ( &$http_request_made ) {
+				$http_request_made = true;
+				return array(
+					'response' => array( 'code' => 200 ),
+					'body'     => '{}',
+				);
+			}
+		);
+
+		$webhooks = Form_Webhooks::init();
+		$webhooks->send_webhooks( $post_id, $fields, false, array() );
+
+		// fc00:: addresses should be blocked at validation time
+		$this->assertFalse( $http_request_made, 'HTTP request should not be made for fc00:: URLs' );
+	}
+
+	/**
+	 * Test webhook is blocked when URL uses localhost hostname.
+	 * SSRF protection should block localhost - either at validation (if resolves to 127.0.0.1)
+	 * or at request time via wp_safe_remote_request().
+	 */
+	public function test_send_webhooks_blocks_localhost_hostname() {
+		$form   = $this->create_mock_form(
+			array(
+				'webhooks' => array(
+					array(
+						'webhook_id' => 'test-webhook',
+						'url'        => 'https://localhost/webhook',
+						'format'     => 'json',
+						'method'     => 'POST',
+						'enabled'    => true,
+					),
+				),
+			)
+		);
+		$fields = array( $this->create_mock_field( $form, 'test-field', 'test value' ) );
+
+		$post_id = $this->create_feedback_post( $form, $fields );
+
+		// Track if HTTP request was made
+		$http_request_made = false;
+		add_filter(
+			'pre_http_request',
+			function () use ( &$http_request_made ) {
+				$http_request_made = true;
+				return array(
+					'response' => array( 'code' => 200 ),
+					'body'     => '{}',
+					'headers'  => new CaseInsensitiveDictionary( array( 'Content-Type' => 'application/json' ) ),
+				);
+			}
+		);
+
+		$logged_events = array();
+		add_action(
+			'jetpack_forms_log',
+			function ( $event, $reason, $data = null ) use ( &$logged_events ) {
+				$logged_events[] = array(
+					'event'  => $event,
+					'reason' => $reason,
+					'data'   => $data,
+				);
+			},
+			10,
+			3
+		);
+
+		$webhooks = Form_Webhooks::init();
+		$webhooks->send_webhooks( $post_id, $fields, false, array() );
+
+		// localhost should be blocked - either at validation or by wp_safe_remote_request
+		$error_meta = get_post_meta( $post_id, '_jetpack_forms_webhook_error', true );
+		$this->assertTrue(
+			! $http_request_made || ! empty( $error_meta ) || ! empty( $logged_events ),
+			'localhost hostname should be blocked or fail'
+		);
+	}
+
+	/**
+	 * Test webhook is blocked when URL contains URL-encoded IP address.
+	 * This tests for URL encoding bypass attempts like 169%2e254%2e169%2e254.
+	 */
+	public function test_send_webhooks_blocks_url_encoded_ip() {
+		$form   = $this->create_mock_form(
+			array(
+				'webhooks' => array(
+					array(
+						'webhook_id' => 'test-webhook',
+						// URL-encoded dots: 169.254.169.254 -> 169%2e254%2e169%2e254
+						'url'        => 'https://169%2e254%2e169%2e254/latest/meta-data/',
+						'format'     => 'json',
+						'method'     => 'POST',
+						'enabled'    => true,
+					),
+				),
+			)
+		);
+		$fields = array( $this->create_mock_field( $form, 'test-field', 'test value' ) );
+
+		$post_id = $this->create_feedback_post( $form, $fields );
+
+		// Track if HTTP request was made
+		$http_request_made = false;
+		add_filter(
+			'pre_http_request',
+			function () use ( &$http_request_made ) {
+				$http_request_made = true;
+				return array(
+					'response' => array( 'code' => 200 ),
+					'body'     => '{}',
+					'headers'  => new CaseInsensitiveDictionary( array( 'Content-Type' => 'application/json' ) ),
+				);
+			}
+		);
+
+		$logged_events = array();
+		add_action(
+			'jetpack_forms_log',
+			function ( $event, $reason, $data = null ) use ( &$logged_events ) {
+				$logged_events[] = array(
+					'event'  => $event,
+					'reason' => $reason,
+					'data'   => $data,
+				);
+			},
+			10,
+			3
+		);
+
+		$webhooks = Form_Webhooks::init();
+		$webhooks->send_webhooks( $post_id, $fields, false, array() );
+
+		// URL-encoded IPs should be decoded and blocked at validation time
+		$this->assertFalse( $http_request_made, 'HTTP request should not be made for URL-encoded IP URLs' );
+		$this->assertNotEmpty( $logged_events, 'Blocked IP should be logged' );
+		// @phan-suppress-next-line PhanTypeArraySuspiciousNull, PhanTypeInvalidDimOffset
+		$this->assertEquals( 'blocked_ip', $logged_events[0]['reason'] );
+	}
+
+	/**
+	 * Test webhook is blocked for other link-local addresses (not just AWS metadata).
+	 * The entire 169.254.0.0/16 range should be blocked.
+	 */
+	public function test_send_webhooks_blocks_other_link_local_addresses() {
+		$form   = $this->create_mock_form(
+			array(
+				'webhooks' => array(
+					array(
+						'webhook_id' => 'test-webhook',
+						'url'        => 'https://169.254.1.1/webhook',
+						'format'     => 'json',
+						'method'     => 'POST',
+						'enabled'    => true,
+					),
+				),
+			)
+		);
+		$fields = array( $this->create_mock_field( $form, 'test-field', 'test value' ) );
+
+		$post_id = $this->create_feedback_post( $form, $fields );
+
+		// Track if HTTP request was made
+		$http_request_made = false;
+		add_filter(
+			'pre_http_request',
+			function () use ( &$http_request_made ) {
+				$http_request_made = true;
+				return array(
+					'response' => array( 'code' => 200 ),
+					'body'     => '{}',
+				);
+			}
+		);
+
+		$webhooks = Form_Webhooks::init();
+		$webhooks->send_webhooks( $post_id, $fields, false, array() );
+
+		// All link-local addresses (169.254.x.x) should be blocked at validation time
+		$this->assertFalse( $http_request_made, 'HTTP request should not be made for link-local URLs' );
+	}
+
+	/**
+	 * Test webhook is blocked for Azure Wire Server endpoint.
+	 * Azure uses 168.63.129.16 for internal services which should be blocked.
+	 */
+	public function test_send_webhooks_blocks_azure_wire_server() {
+		$form   = $this->create_mock_form(
+			array(
+				'webhooks' => array(
+					array(
+						'webhook_id' => 'test-webhook',
+						'url'        => 'https://168.63.129.16/metadata/instance',
+						'format'     => 'json',
+						'method'     => 'POST',
+						'enabled'    => true,
+					),
+				),
+			)
+		);
+		$fields = array( $this->create_mock_field( $form, 'test-field', 'test value' ) );
+
+		$post_id = $this->create_feedback_post( $form, $fields );
+
+		// Track if HTTP request was made and to what URL
+		$request_url = null;
+		add_filter(
+			'pre_http_request',
+			function ( $preempt, $args, $url ) use ( &$request_url ) {
+				$request_url = $url;
+				return array(
+					'response' => array( 'code' => 200 ),
+					'body'     => '{}',
+					'headers'  => new CaseInsensitiveDictionary( array( 'Content-Type' => 'application/json' ) ),
+				);
+			},
+			10,
+			3
+		);
+
+		$webhooks = Form_Webhooks::init();
+		$webhooks->send_webhooks( $post_id, $fields, false, array() );
+
+		// Azure Wire Server IP - note: this may pass validation but should be considered
+		// This test documents the current behavior; wp_safe_remote_request may block it
+		if ( $request_url !== null ) {
+			// If request was made, check if wp_safe_remote_request blocked it
+			$error_meta = get_post_meta( $post_id, '_jetpack_forms_webhook_error', true );
+			// Either no error (allowed) or error (blocked) - document the behavior
+			$this->assertTrue( true, 'Azure Wire Server IP behavior documented' );
+		} else {
+			$this->assertNull( $request_url, 'Azure Wire Server should be blocked' );
+		}
+	}
+
+	/**
+	 * Test webhook is blocked when URL uses decimal IP notation.
+	 * Decimal notation like 2852039166 converts to 169.254.169.254.
+	 */
+	public function test_send_webhooks_blocks_decimal_ip_notation() {
+		$form   = $this->create_mock_form(
+			array(
+				'webhooks' => array(
+					array(
+						'webhook_id' => 'test-webhook',
+						// 2852039166 = 169.254.169.254 in decimal
+						'url'        => 'https://2852039166/latest/meta-data/',
+						'format'     => 'json',
+						'method'     => 'POST',
+						'enabled'    => true,
+					),
+				),
+			)
+		);
+		$fields = array( $this->create_mock_field( $form, 'test-field', 'test value' ) );
+
+		$post_id = $this->create_feedback_post( $form, $fields );
+
+		// Track if HTTP request was made
+		$http_request_made = false;
+		add_filter(
+			'pre_http_request',
+			function () use ( &$http_request_made ) {
+				$http_request_made = true;
+				return array(
+					'response' => array( 'code' => 200 ),
+					'body'     => '{}',
+				);
+			}
+		);
+
+		$logged_events = array();
+		add_action(
+			'jetpack_forms_log',
+			function ( $event, $reason, $data = null ) use ( &$logged_events ) {
+				$logged_events[] = array(
+					'event'  => $event,
+					'reason' => $reason,
+					'data'   => $data,
+				);
+			},
+			10,
+			3
+		);
+
+		$webhooks = Form_Webhooks::init();
+		$webhooks->send_webhooks( $post_id, $fields, false, array() );
+
+		// Decimal IP notation should be blocked - either by validation or wp_safe_remote_request
+		$error_meta = get_post_meta( $post_id, '_jetpack_forms_webhook_error', true );
+		$this->assertTrue(
+			! $http_request_made || ! empty( $error_meta ) || ! empty( $logged_events ),
+			'Decimal IP notation should be blocked or fail'
+		);
+	}
+
+	/**
+	 * Test webhook is blocked when URL uses octal IP notation.
+	 * Octal notation like 0251.0376.0251.0376 converts to 169.254.169.254.
+	 */
+	public function test_send_webhooks_blocks_octal_ip_notation() {
+		$form   = $this->create_mock_form(
+			array(
+				'webhooks' => array(
+					array(
+						'webhook_id' => 'test-webhook',
+						// 0251.0376.0251.0376 = 169.254.169.254 in octal
+						'url'        => 'https://0251.0376.0251.0376/latest/meta-data/',
+						'format'     => 'json',
+						'method'     => 'POST',
+						'enabled'    => true,
+					),
+				),
+			)
+		);
+		$fields = array( $this->create_mock_field( $form, 'test-field', 'test value' ) );
+
+		$post_id = $this->create_feedback_post( $form, $fields );
+
+		// Track if HTTP request was made
+		$http_request_made = false;
+		add_filter(
+			'pre_http_request',
+			function () use ( &$http_request_made ) {
+				$http_request_made = true;
+				return array(
+					'response' => array( 'code' => 200 ),
+					'body'     => '{}',
+				);
+			}
+		);
+
+		$logged_events = array();
+		add_action(
+			'jetpack_forms_log',
+			function ( $event, $reason, $data = null ) use ( &$logged_events ) {
+				$logged_events[] = array(
+					'event'  => $event,
+					'reason' => $reason,
+					'data'   => $data,
+				);
+			},
+			10,
+			3
+		);
+
+		$webhooks = Form_Webhooks::init();
+		$webhooks->send_webhooks( $post_id, $fields, false, array() );
+
+		// Octal IP notation should be blocked - either by validation or wp_safe_remote_request
+		$error_meta = get_post_meta( $post_id, '_jetpack_forms_webhook_error', true );
+		$this->assertTrue(
+			! $http_request_made || ! empty( $error_meta ) || ! empty( $logged_events ),
+			'Octal IP notation should be blocked or fail'
+		);
+	}
+
+	/**
+	 * Test webhook is blocked when URL uses zero-padded IP notation.
+	 * Zero-padded IPs like 127.000.000.001 should resolve to 127.0.0.1.
+	 */
+	public function test_send_webhooks_blocks_zero_padded_ip() {
+		$form   = $this->create_mock_form(
+			array(
+				'webhooks' => array(
+					array(
+						'webhook_id' => 'test-webhook',
+						'url'        => 'https://127.000.000.001/webhook',
+						'format'     => 'json',
+						'method'     => 'POST',
+						'enabled'    => true,
+					),
+				),
+			)
+		);
+		$fields = array( $this->create_mock_field( $form, 'test-field', 'test value' ) );
+
+		$post_id = $this->create_feedback_post( $form, $fields );
+
+		$webhooks = Form_Webhooks::init();
+		$webhooks->send_webhooks( $post_id, $fields, false, array() );
+
+		// Zero-padded localhost should be blocked by wp_safe_remote_request
+		$error_meta = get_post_meta( $post_id, '_jetpack_forms_webhook_error', true );
+		$this->assertNotEmpty( $error_meta, 'Error should be logged for zero-padded localhost URLs' );
+	}
+
+	/**
+	 * Test webhook is blocked for IPv6 addresses with zone identifiers.
+	 * Zone identifiers like fe80::1%eth0 are used for link-local addresses.
+	 */
+	public function test_send_webhooks_blocks_ipv6_with_zone_id() {
+		$form   = $this->create_mock_form(
+			array(
+				'webhooks' => array(
+					array(
+						'webhook_id' => 'test-webhook',
+						// %25 is URL-encoded % for zone identifier
+						'url'        => 'https://[fe80::1%25eth0]/webhook',
+						'format'     => 'json',
+						'method'     => 'POST',
+						'enabled'    => true,
+					),
+				),
+			)
+		);
+		$fields = array( $this->create_mock_field( $form, 'test-field', 'test value' ) );
+
+		$post_id = $this->create_feedback_post( $form, $fields );
+
+		// Track if HTTP request was made
+		$http_request_made = false;
+		add_filter(
+			'pre_http_request',
+			function () use ( &$http_request_made ) {
+				$http_request_made = true;
+				return array(
+					'response' => array( 'code' => 200 ),
+					'body'     => '{}',
+					'headers'  => new CaseInsensitiveDictionary( array( 'Content-Type' => 'application/json' ) ),
+				);
+			}
+		);
+
+		$logged_events = array();
+		add_action(
+			'jetpack_forms_log',
+			function ( $event, $reason, $data = null ) use ( &$logged_events ) {
+				$logged_events[] = array(
+					'event'  => $event,
+					'reason' => $reason,
+					'data'   => $data,
+				);
+			},
+			10,
+			3
+		);
+
+		$webhooks = Form_Webhooks::init();
+		$webhooks->send_webhooks( $post_id, $fields, false, array() );
+
+		// IPv6 with zone identifier should be blocked at validation time
+		// The zone ID is stripped, revealing the fe80:: link-local address
+		$this->assertFalse( $http_request_made, 'HTTP request should not be made for IPv6 with zone identifier' );
+		$this->assertNotEmpty( $logged_events, 'Blocked IP should be logged' );
+		// @phan-suppress-next-line PhanTypeArraySuspiciousNull, PhanTypeInvalidDimOffset
+		$this->assertEquals( 'blocked_ip', $logged_events[0]['reason'] );
+	}
+
+	/**
+	 * Test webhook handles hostname with trailing dot.
+	 * Trailing dots are valid in DNS but could be used in bypass attempts.
+	 */
+	public function test_send_webhooks_handles_trailing_dot_hostname() {
+		$form   = $this->create_mock_form(
+			array(
+				'webhooks' => array(
+					array(
+						'webhook_id' => 'test-webhook',
+						'url'        => 'https://localhost./webhook',
+						'format'     => 'json',
+						'method'     => 'POST',
+						'enabled'    => true,
+					),
+				),
+			)
+		);
+		$fields = array( $this->create_mock_field( $form, 'test-field', 'test value' ) );
+
+		$post_id = $this->create_feedback_post( $form, $fields );
+
+		// Track if HTTP request was made
+		$http_request_made = false;
+		add_filter(
+			'pre_http_request',
+			function () use ( &$http_request_made ) {
+				$http_request_made = true;
+				return array(
+					'response' => array( 'code' => 200 ),
+					'body'     => '{}',
+					'headers'  => new CaseInsensitiveDictionary( array( 'Content-Type' => 'application/json' ) ),
+				);
+			}
+		);
+
+		$logged_events = array();
+		add_action(
+			'jetpack_forms_log',
+			function ( $event, $reason, $data = null ) use ( &$logged_events ) {
+				$logged_events[] = array(
+					'event'  => $event,
+					'reason' => $reason,
+					'data'   => $data,
+				);
+			},
+			10,
+			3
+		);
+
+		$webhooks = Form_Webhooks::init();
+		$webhooks->send_webhooks( $post_id, $fields, false, array() );
+
+		// localhost with trailing dot should be blocked - either at validation or by wp_safe_remote_request
+		$error_meta = get_post_meta( $post_id, '_jetpack_forms_webhook_error', true );
+		$this->assertTrue(
+			! $http_request_made || ! empty( $error_meta ) || ! empty( $logged_events ),
+			'Trailing dot localhost hostname should be blocked or fail'
+		);
+	}
+
+	/**
 	 * Test webhook allows valid public HTTPS URLs.
 	 */
 	public function test_send_webhooks_allows_valid_public_https_urls() {

--- a/projects/packages/forms/tests/php/service/Form_Webhooks_Test.php
+++ b/projects/packages/forms/tests/php/service/Form_Webhooks_Test.php
@@ -916,6 +916,127 @@ class Form_Webhooks_Test extends BaseTestCase {
 	}
 
 	/**
+	 * Test that webhook blocks IPv6 loopback addresses.
+	 * SSRF protection should block ::1 (IPv6 loopback).
+	 */
+	public function test_send_webhooks_blocks_ipv6_loopback() {
+		$form   = $this->create_mock_form(
+			array(
+				'webhooks' => array(
+					array(
+						'webhook_id' => 'test-webhook',
+						'url'        => 'https://[::1]/webhook',
+						'format'     => 'json',
+						'method'     => 'POST',
+						'enabled'    => true,
+					),
+				),
+			)
+		);
+		$fields = array( $this->create_mock_field( $form, 'test-field', 'test value' ) );
+
+		$post_id = $this->create_feedback_post( $form, $fields );
+
+		$webhooks = Form_Webhooks::init();
+		$webhooks->send_webhooks( $post_id, $fields, false, array() );
+
+		// IPv6 loopback should be blocked
+		$error_meta = get_post_meta( $post_id, '_jetpack_forms_webhook_error', true );
+		$this->assertNotEmpty( $error_meta, 'Error should be logged for IPv6 loopback URLs' );
+	}
+
+	/**
+	 * Test that webhook blocks IPv6 link-local addresses.
+	 * SSRF protection should block fe80::/10 range.
+	 */
+	public function test_send_webhooks_blocks_ipv6_link_local() {
+		$form   = $this->create_mock_form(
+			array(
+				'webhooks' => array(
+					array(
+						'webhook_id' => 'test-webhook',
+						'url'        => 'https://[fe80::1]/webhook',
+						'format'     => 'json',
+						'method'     => 'POST',
+						'enabled'    => true,
+					),
+				),
+			)
+		);
+		$fields = array( $this->create_mock_field( $form, 'test-field', 'test value' ) );
+
+		$post_id = $this->create_feedback_post( $form, $fields );
+
+		$webhooks = Form_Webhooks::init();
+		$webhooks->send_webhooks( $post_id, $fields, false, array() );
+
+		// IPv6 link-local should be blocked
+		$error_meta = get_post_meta( $post_id, '_jetpack_forms_webhook_error', true );
+		$this->assertNotEmpty( $error_meta, 'Error should be logged for IPv6 link-local URLs' );
+	}
+
+	/**
+	 * Test that webhook blocks IPv6 unique local addresses (fd00::/8).
+	 * SSRF protection should block fc00::/7 range which includes fd00::/8 used for private networks
+	 * and cloud metadata endpoints like fd00::a9fe:a9fe.
+	 */
+	public function test_send_webhooks_blocks_ipv6_unique_local() {
+		$form   = $this->create_mock_form(
+			array(
+				'webhooks' => array(
+					array(
+						'webhook_id' => 'test-webhook',
+						'url'        => 'https://[fd00::1]/webhook',
+						'format'     => 'json',
+						'method'     => 'POST',
+						'enabled'    => true,
+					),
+				),
+			)
+		);
+		$fields = array( $this->create_mock_field( $form, 'test-field', 'test value' ) );
+
+		$post_id = $this->create_feedback_post( $form, $fields );
+
+		$webhooks = Form_Webhooks::init();
+		$webhooks->send_webhooks( $post_id, $fields, false, array() );
+
+		// IPv6 unique local addresses should be blocked
+		$error_meta = get_post_meta( $post_id, '_jetpack_forms_webhook_error', true );
+		$this->assertNotEmpty( $error_meta, 'Error should be logged for IPv6 unique local URLs' );
+	}
+
+	/**
+	 * Test that webhook blocks IPv6 site-local addresses (fec0::/10).
+	 * These are deprecated but still blocked for security.
+	 */
+	public function test_send_webhooks_blocks_ipv6_site_local() {
+		$form   = $this->create_mock_form(
+			array(
+				'webhooks' => array(
+					array(
+						'webhook_id' => 'test-webhook',
+						'url'        => 'https://[fec0::1]/webhook',
+						'format'     => 'json',
+						'method'     => 'POST',
+						'enabled'    => true,
+					),
+				),
+			)
+		);
+		$fields = array( $this->create_mock_field( $form, 'test-field', 'test value' ) );
+
+		$post_id = $this->create_feedback_post( $form, $fields );
+
+		$webhooks = Form_Webhooks::init();
+		$webhooks->send_webhooks( $post_id, $fields, false, array() );
+
+		// IPv6 site-local addresses (deprecated) should be blocked
+		$error_meta = get_post_meta( $post_id, '_jetpack_forms_webhook_error', true );
+		$this->assertNotEmpty( $error_meta, 'Error should be logged for IPv6 site-local URLs' );
+	}
+
+	/**
 	 * Test webhook allows valid public HTTPS URLs.
 	 */
 	public function test_send_webhooks_allows_valid_public_https_urls() {

--- a/projects/packages/forms/tests/php/service/Form_Webhooks_Test.php
+++ b/projects/packages/forms/tests/php/service/Form_Webhooks_Test.php
@@ -787,6 +787,14 @@ class Form_Webhooks_Test extends BaseTestCase {
 
 		$post_id = $this->create_feedback_post( $form, $fields );
 
+		// Prevent actual network requests - return WP_Error simulating blocked private IP
+		add_filter(
+			'pre_http_request',
+			function () {
+				return new \WP_Error( 'http_request_not_executed', 'A valid URL was not provided.' );
+			}
+		);
+
 		$webhooks = Form_Webhooks::init();
 		$webhooks->send_webhooks( $post_id, $fields, false, array() );
 
@@ -816,6 +824,14 @@ class Form_Webhooks_Test extends BaseTestCase {
 		$fields = array( $this->create_mock_field( $form, 'test-field', 'test value' ) );
 
 		$post_id = $this->create_feedback_post( $form, $fields );
+
+		// Prevent actual network requests - return WP_Error simulating blocked private IP
+		add_filter(
+			'pre_http_request',
+			function () {
+				return new \WP_Error( 'http_request_not_executed', 'A valid URL was not provided.' );
+			}
+		);
 
 		$webhooks = Form_Webhooks::init();
 		$webhooks->send_webhooks( $post_id, $fields, false, array() );
@@ -847,6 +863,14 @@ class Form_Webhooks_Test extends BaseTestCase {
 
 		$post_id = $this->create_feedback_post( $form, $fields );
 
+		// Prevent actual network requests - return WP_Error simulating blocked private IP
+		add_filter(
+			'pre_http_request',
+			function () {
+				return new \WP_Error( 'http_request_not_executed', 'A valid URL was not provided.' );
+			}
+		);
+
 		$webhooks = Form_Webhooks::init();
 		$webhooks->send_webhooks( $post_id, $fields, false, array() );
 
@@ -876,6 +900,14 @@ class Form_Webhooks_Test extends BaseTestCase {
 		$fields = array( $this->create_mock_field( $form, 'test-field', 'test value' ) );
 
 		$post_id = $this->create_feedback_post( $form, $fields );
+
+		// Prevent actual network requests - return WP_Error simulating blocked private IP
+		add_filter(
+			'pre_http_request',
+			function () {
+				return new \WP_Error( 'http_request_not_executed', 'A valid URL was not provided.' );
+			}
+		);
 
 		$webhooks = Form_Webhooks::init();
 		$webhooks->send_webhooks( $post_id, $fields, false, array() );

--- a/projects/packages/forms/tests/php/service/Form_Webhooks_Test.php
+++ b/projects/packages/forms/tests/php/service/Form_Webhooks_Test.php
@@ -887,7 +887,7 @@ class Form_Webhooks_Test extends BaseTestCase {
 
 	/**
 	 * Test webhook is blocked when URL points to link-local network (169.254.x.x - includes AWS metadata).
-	 * SSRF protection for link-local is handled at request time by our http_request_host_is_external filter.
+	 * SSRF protection blocks link-local IPs at validation time.
 	 */
 	public function test_send_webhooks_blocks_link_local_urls() {
 		$form   = $this->create_mock_form(
@@ -907,17 +907,29 @@ class Form_Webhooks_Test extends BaseTestCase {
 
 		$post_id = $this->create_feedback_post( $form, $fields );
 
+		// Track if HTTP request was made
+		$http_request_made = false;
+		add_filter(
+			'pre_http_request',
+			function () use ( &$http_request_made ) {
+				$http_request_made = true;
+				return array(
+					'response' => array( 'code' => 200 ),
+					'body'     => '{}',
+				);
+			}
+		);
+
 		$webhooks = Form_Webhooks::init();
 		$webhooks->send_webhooks( $post_id, $fields, false, array() );
 
-		// Our http_request_host_is_external filter blocks link-local IPs, causing a WP_Error
-		$error_meta = get_post_meta( $post_id, '_jetpack_forms_webhook_error', true );
-		$this->assertNotEmpty( $error_meta, 'Error should be logged for link-local/AWS metadata URLs' );
+		// Link-local IPs should be blocked at validation time, no HTTP request made
+		$this->assertFalse( $http_request_made, 'HTTP request should not be made for link-local/AWS metadata URLs' );
 	}
 
 	/**
 	 * Test that webhook blocks IPv6 loopback addresses.
-	 * SSRF protection should block ::1 (IPv6 loopback).
+	 * SSRF protection should block ::1 (IPv6 loopback) at validation time.
 	 */
 	public function test_send_webhooks_blocks_ipv6_loopback() {
 		$form   = $this->create_mock_form(
@@ -937,17 +949,29 @@ class Form_Webhooks_Test extends BaseTestCase {
 
 		$post_id = $this->create_feedback_post( $form, $fields );
 
+		// Track if HTTP request was made
+		$http_request_made = false;
+		add_filter(
+			'pre_http_request',
+			function () use ( &$http_request_made ) {
+				$http_request_made = true;
+				return array(
+					'response' => array( 'code' => 200 ),
+					'body'     => '{}',
+				);
+			}
+		);
+
 		$webhooks = Form_Webhooks::init();
 		$webhooks->send_webhooks( $post_id, $fields, false, array() );
 
-		// IPv6 loopback should be blocked
-		$error_meta = get_post_meta( $post_id, '_jetpack_forms_webhook_error', true );
-		$this->assertNotEmpty( $error_meta, 'Error should be logged for IPv6 loopback URLs' );
+		// IPv6 loopback should be blocked at validation time
+		$this->assertFalse( $http_request_made, 'HTTP request should not be made for IPv6 loopback URLs' );
 	}
 
 	/**
 	 * Test that webhook blocks IPv6 link-local addresses.
-	 * SSRF protection should block fe80::/10 range.
+	 * SSRF protection should block fe80::/10 range at validation time.
 	 */
 	public function test_send_webhooks_blocks_ipv6_link_local() {
 		$form   = $this->create_mock_form(
@@ -967,12 +991,24 @@ class Form_Webhooks_Test extends BaseTestCase {
 
 		$post_id = $this->create_feedback_post( $form, $fields );
 
+		// Track if HTTP request was made
+		$http_request_made = false;
+		add_filter(
+			'pre_http_request',
+			function () use ( &$http_request_made ) {
+				$http_request_made = true;
+				return array(
+					'response' => array( 'code' => 200 ),
+					'body'     => '{}',
+				);
+			}
+		);
+
 		$webhooks = Form_Webhooks::init();
 		$webhooks->send_webhooks( $post_id, $fields, false, array() );
 
-		// IPv6 link-local should be blocked
-		$error_meta = get_post_meta( $post_id, '_jetpack_forms_webhook_error', true );
-		$this->assertNotEmpty( $error_meta, 'Error should be logged for IPv6 link-local URLs' );
+		// IPv6 link-local should be blocked at validation time
+		$this->assertFalse( $http_request_made, 'HTTP request should not be made for IPv6 link-local URLs' );
 	}
 
 	/**
@@ -998,17 +1034,29 @@ class Form_Webhooks_Test extends BaseTestCase {
 
 		$post_id = $this->create_feedback_post( $form, $fields );
 
+		// Track if HTTP request was made
+		$http_request_made = false;
+		add_filter(
+			'pre_http_request',
+			function () use ( &$http_request_made ) {
+				$http_request_made = true;
+				return array(
+					'response' => array( 'code' => 200 ),
+					'body'     => '{}',
+				);
+			}
+		);
+
 		$webhooks = Form_Webhooks::init();
 		$webhooks->send_webhooks( $post_id, $fields, false, array() );
 
-		// IPv6 unique local addresses should be blocked
-		$error_meta = get_post_meta( $post_id, '_jetpack_forms_webhook_error', true );
-		$this->assertNotEmpty( $error_meta, 'Error should be logged for IPv6 unique local URLs' );
+		// IPv6 unique local addresses should be blocked at validation time
+		$this->assertFalse( $http_request_made, 'HTTP request should not be made for IPv6 unique local URLs' );
 	}
 
 	/**
 	 * Test that webhook blocks IPv6 site-local addresses (fec0::/10).
-	 * These are deprecated but still blocked for security.
+	 * These are deprecated but still blocked for security at validation time.
 	 */
 	public function test_send_webhooks_blocks_ipv6_site_local() {
 		$form   = $this->create_mock_form(
@@ -1028,12 +1076,24 @@ class Form_Webhooks_Test extends BaseTestCase {
 
 		$post_id = $this->create_feedback_post( $form, $fields );
 
+		// Track if HTTP request was made
+		$http_request_made = false;
+		add_filter(
+			'pre_http_request',
+			function () use ( &$http_request_made ) {
+				$http_request_made = true;
+				return array(
+					'response' => array( 'code' => 200 ),
+					'body'     => '{}',
+				);
+			}
+		);
+
 		$webhooks = Form_Webhooks::init();
 		$webhooks->send_webhooks( $post_id, $fields, false, array() );
 
-		// IPv6 site-local addresses (deprecated) should be blocked
-		$error_meta = get_post_meta( $post_id, '_jetpack_forms_webhook_error', true );
-		$this->assertNotEmpty( $error_meta, 'Error should be logged for IPv6 site-local URLs' );
+		// IPv6 site-local addresses (deprecated) should be blocked at validation time
+		$this->assertFalse( $http_request_made, 'HTTP request should not be made for IPv6 site-local URLs' );
 	}
 
 	/**

--- a/projects/packages/forms/tests/php/service/Form_Webhooks_Test.php
+++ b/projects/packages/forms/tests/php/service/Form_Webhooks_Test.php
@@ -708,6 +708,318 @@ class Form_Webhooks_Test extends BaseTestCase {
 	}
 
 	/**
+	 * Test webhook is blocked when URL uses HTTP instead of HTTPS.
+	 */
+	public function test_send_webhooks_blocks_http_urls() {
+		$form   = $this->create_mock_form(
+			array(
+				'webhooks' => array(
+					array(
+						'webhook_id' => 'test-webhook',
+						'url'        => 'http://example.com/webhook', // HTTP instead of HTTPS
+						'format'     => 'json',
+						'method'     => 'POST',
+						'enabled'    => true,
+					),
+				),
+			)
+		);
+		$fields = array( $this->create_mock_field( $form, 'test-field', 'test value' ) );
+
+		$post_id = $this->create_feedback_post( $form, $fields );
+
+		$http_request_made = false;
+		add_filter(
+			'pre_http_request',
+			function () use ( &$http_request_made ) {
+				$http_request_made = true;
+				return array(
+					'response' => array( 'code' => 200 ),
+					'body'     => '{"success":true}',
+				);
+			}
+		);
+
+		$logged_events = array();
+		add_action(
+			'jetpack_forms_log',
+			function ( $event, $reason, $data = null ) use ( &$logged_events ) {
+				$logged_events[] = array(
+					'event'  => $event,
+					'reason' => $reason,
+					'data'   => $data,
+				);
+			},
+			10,
+			3
+		);
+
+		$webhooks = Form_Webhooks::init();
+		$webhooks->send_webhooks( $post_id, $fields, false, array() );
+
+		$this->assertFalse( $http_request_made, 'HTTP request should not be made for non-HTTPS URLs' );
+		$this->assertCount( 1, $logged_events );
+		// @phan-suppress-next-line PhanTypeArraySuspiciousNull, PhanTypeInvalidDimOffset
+		$this->assertEquals( 'webhook_skipped', $logged_events[0]['event'] );
+		// @phan-suppress-next-line PhanTypeArraySuspiciousNull, PhanTypeInvalidDimOffset
+		$this->assertEquals( 'https_required', $logged_events[0]['reason'] );
+	}
+
+	/**
+	 * Test webhook is blocked when URL points to localhost.
+	 */
+	public function test_send_webhooks_blocks_localhost_urls() {
+		$form   = $this->create_mock_form(
+			array(
+				'webhooks' => array(
+					array(
+						'webhook_id' => 'test-webhook',
+						'url'        => 'https://127.0.0.1/webhook',
+						'format'     => 'json',
+						'method'     => 'POST',
+						'enabled'    => true,
+					),
+				),
+			)
+		);
+		$fields = array( $this->create_mock_field( $form, 'test-field', 'test value' ) );
+
+		$post_id = $this->create_feedback_post( $form, $fields );
+
+		$http_request_made = false;
+		add_filter(
+			'pre_http_request',
+			function () use ( &$http_request_made ) {
+				$http_request_made = true;
+				return array(
+					'response' => array( 'code' => 200 ),
+					'body'     => '{"success":true}',
+				);
+			}
+		);
+
+		$logged_events = array();
+		add_action(
+			'jetpack_forms_log',
+			function ( $event, $reason, $data = null ) use ( &$logged_events ) {
+				$logged_events[] = array(
+					'event'  => $event,
+					'reason' => $reason,
+					'data'   => $data,
+				);
+			},
+			10,
+			3
+		);
+
+		$webhooks = Form_Webhooks::init();
+		$webhooks->send_webhooks( $post_id, $fields, false, array() );
+
+		$this->assertFalse( $http_request_made, 'HTTP request should not be made for localhost URLs' );
+		$this->assertCount( 1, $logged_events );
+		// @phan-suppress-next-line PhanTypeArraySuspiciousNull, PhanTypeInvalidDimOffset
+		$this->assertEquals( 'webhook_skipped', $logged_events[0]['event'] );
+		// @phan-suppress-next-line PhanTypeArraySuspiciousNull, PhanTypeInvalidDimOffset
+		$this->assertEquals( 'private_ip', $logged_events[0]['reason'] );
+	}
+
+	/**
+	 * Test webhook is blocked when URL points to private Class A network (10.x.x.x).
+	 */
+	public function test_send_webhooks_blocks_private_class_a_urls() {
+		$form   = $this->create_mock_form(
+			array(
+				'webhooks' => array(
+					array(
+						'webhook_id' => 'test-webhook',
+						'url'        => 'https://10.0.0.1/webhook',
+						'format'     => 'json',
+						'method'     => 'POST',
+						'enabled'    => true,
+					),
+				),
+			)
+		);
+		$fields = array( $this->create_mock_field( $form, 'test-field', 'test value' ) );
+
+		$post_id = $this->create_feedback_post( $form, $fields );
+
+		$http_request_made = false;
+		add_filter(
+			'pre_http_request',
+			function () use ( &$http_request_made ) {
+				$http_request_made = true;
+				return array(
+					'response' => array( 'code' => 200 ),
+					'body'     => '{"success":true}',
+				);
+			}
+		);
+
+		$webhooks = Form_Webhooks::init();
+		$webhooks->send_webhooks( $post_id, $fields, false, array() );
+
+		$this->assertFalse( $http_request_made, 'HTTP request should not be made for private Class A URLs' );
+	}
+
+	/**
+	 * Test webhook is blocked when URL points to private Class B network (172.16-31.x.x).
+	 */
+	public function test_send_webhooks_blocks_private_class_b_urls() {
+		$form   = $this->create_mock_form(
+			array(
+				'webhooks' => array(
+					array(
+						'webhook_id' => 'test-webhook',
+						'url'        => 'https://172.16.0.1/webhook',
+						'format'     => 'json',
+						'method'     => 'POST',
+						'enabled'    => true,
+					),
+				),
+			)
+		);
+		$fields = array( $this->create_mock_field( $form, 'test-field', 'test value' ) );
+
+		$post_id = $this->create_feedback_post( $form, $fields );
+
+		$http_request_made = false;
+		add_filter(
+			'pre_http_request',
+			function () use ( &$http_request_made ) {
+				$http_request_made = true;
+				return array(
+					'response' => array( 'code' => 200 ),
+					'body'     => '{"success":true}',
+				);
+			}
+		);
+
+		$webhooks = Form_Webhooks::init();
+		$webhooks->send_webhooks( $post_id, $fields, false, array() );
+
+		$this->assertFalse( $http_request_made, 'HTTP request should not be made for private Class B URLs' );
+	}
+
+	/**
+	 * Test webhook is blocked when URL points to private Class C network (192.168.x.x).
+	 */
+	public function test_send_webhooks_blocks_private_class_c_urls() {
+		$form   = $this->create_mock_form(
+			array(
+				'webhooks' => array(
+					array(
+						'webhook_id' => 'test-webhook',
+						'url'        => 'https://192.168.1.1/webhook',
+						'format'     => 'json',
+						'method'     => 'POST',
+						'enabled'    => true,
+					),
+				),
+			)
+		);
+		$fields = array( $this->create_mock_field( $form, 'test-field', 'test value' ) );
+
+		$post_id = $this->create_feedback_post( $form, $fields );
+
+		$http_request_made = false;
+		add_filter(
+			'pre_http_request',
+			function () use ( &$http_request_made ) {
+				$http_request_made = true;
+				return array(
+					'response' => array( 'code' => 200 ),
+					'body'     => '{"success":true}',
+				);
+			}
+		);
+
+		$webhooks = Form_Webhooks::init();
+		$webhooks->send_webhooks( $post_id, $fields, false, array() );
+
+		$this->assertFalse( $http_request_made, 'HTTP request should not be made for private Class C URLs' );
+	}
+
+	/**
+	 * Test webhook is blocked when URL points to link-local network (169.254.x.x - includes AWS metadata).
+	 */
+	public function test_send_webhooks_blocks_link_local_urls() {
+		$form   = $this->create_mock_form(
+			array(
+				'webhooks' => array(
+					array(
+						'webhook_id' => 'test-webhook',
+						'url'        => 'https://169.254.169.254/latest/meta-data/',
+						'format'     => 'json',
+						'method'     => 'POST',
+						'enabled'    => true,
+					),
+				),
+			)
+		);
+		$fields = array( $this->create_mock_field( $form, 'test-field', 'test value' ) );
+
+		$post_id = $this->create_feedback_post( $form, $fields );
+
+		$http_request_made = false;
+		add_filter(
+			'pre_http_request',
+			function () use ( &$http_request_made ) {
+				$http_request_made = true;
+				return array(
+					'response' => array( 'code' => 200 ),
+					'body'     => '{"success":true}',
+				);
+			}
+		);
+
+		$webhooks = Form_Webhooks::init();
+		$webhooks->send_webhooks( $post_id, $fields, false, array() );
+
+		$this->assertFalse( $http_request_made, 'HTTP request should not be made for link-local/AWS metadata URLs' );
+	}
+
+	/**
+	 * Test webhook allows valid public HTTPS URLs.
+	 */
+	public function test_send_webhooks_allows_valid_public_https_urls() {
+		$form   = $this->create_mock_form(
+			array(
+				'webhooks' => array(
+					array(
+						'webhook_id' => 'test-webhook',
+						'url'        => 'https://hooks.zapier.com/webhook/123',
+						'format'     => 'json',
+						'method'     => 'POST',
+						'enabled'    => true,
+					),
+				),
+			)
+		);
+		$fields = array( $this->create_mock_field( $form, 'test-field', 'test value' ) );
+
+		$post_id = $this->create_feedback_post( $form, $fields );
+
+		$http_request_made = false;
+		add_filter(
+			'pre_http_request',
+			function () use ( &$http_request_made ) {
+				$http_request_made = true;
+				return array(
+					'response' => array( 'code' => 200 ),
+					'body'     => '{"success":true}',
+					'headers'  => new CaseInsensitiveDictionary( array( 'Content-Type' => 'application/json' ) ),
+				);
+			}
+		);
+
+		$webhooks = Form_Webhooks::init();
+		$webhooks->send_webhooks( $post_id, $fields, false, array() );
+
+		$this->assertTrue( $http_request_made, 'HTTP request should be made for valid public HTTPS URLs' );
+	}
+
+	/**
 	 * Helper method to create a test form object.
 	 *
 	 * @param array $attributes Form attributes.

--- a/projects/packages/forms/tests/php/service/Form_Webhooks_Test.php
+++ b/projects/packages/forms/tests/php/service/Form_Webhooks_Test.php
@@ -1365,7 +1365,7 @@ class Form_Webhooks_Test extends BaseTestCase {
 
 	/**
 	 * Test webhook is blocked for Azure Wire Server endpoint.
-	 * Azure uses 168.63.129.16 for internal services which should be blocked.
+	 * Azure uses 168.63.129.16 for internal services including Instance Metadata Service.
 	 */
 	public function test_send_webhooks_blocks_azure_wire_server() {
 		$form   = $this->create_mock_form(
@@ -1385,16 +1385,28 @@ class Form_Webhooks_Test extends BaseTestCase {
 
 		$post_id = $this->create_feedback_post( $form, $fields );
 
-		// Track if HTTP request was made and to what URL
-		$request_url = null;
+		// Track if HTTP request was made
+		$http_request_made = false;
 		add_filter(
 			'pre_http_request',
-			function ( $preempt, $args, $url ) use ( &$request_url ) {
-				$request_url = $url;
+			function () use ( &$http_request_made ) {
+				$http_request_made = true;
 				return array(
 					'response' => array( 'code' => 200 ),
 					'body'     => '{}',
 					'headers'  => new CaseInsensitiveDictionary( array( 'Content-Type' => 'application/json' ) ),
+				);
+			}
+		);
+
+		$logged_events = array();
+		add_action(
+			'jetpack_forms_log',
+			function ( $event, $reason, $data = null ) use ( &$logged_events ) {
+				$logged_events[] = array(
+					'event'  => $event,
+					'reason' => $reason,
+					'data'   => $data,
 				);
 			},
 			10,
@@ -1404,16 +1416,11 @@ class Form_Webhooks_Test extends BaseTestCase {
 		$webhooks = Form_Webhooks::init();
 		$webhooks->send_webhooks( $post_id, $fields, false, array() );
 
-		// Azure Wire Server IP - note: this may pass validation but should be considered
-		// This test documents the current behavior; wp_safe_remote_request may block it
-		if ( $request_url !== null ) {
-			// If request was made, check if wp_safe_remote_request blocked it
-			$error_meta = get_post_meta( $post_id, '_jetpack_forms_webhook_error', true );
-			// Either no error (allowed) or error (blocked) - document the behavior
-			$this->assertTrue( true, 'Azure Wire Server IP behavior documented' );
-		} else {
-			$this->assertNull( $request_url, 'Azure Wire Server should be blocked' );
-		}
+		// Azure Wire Server IP should be blocked at validation time
+		$this->assertFalse( $http_request_made, 'HTTP request should not be made for Azure Wire Server URLs' );
+		$this->assertNotEmpty( $logged_events, 'Blocked IP should be logged' );
+		// @phan-suppress-next-line PhanTypeArraySuspiciousNull, PhanTypeInvalidDimOffset
+		$this->assertEquals( 'blocked_ip', $logged_events[0]['reason'] );
 	}
 
 	/**

--- a/projects/packages/forms/tests/php/service/Form_Webhooks_Test.php
+++ b/projects/packages/forms/tests/php/service/Form_Webhooks_Test.php
@@ -952,11 +952,30 @@ class Form_Webhooks_Test extends BaseTestCase {
 			}
 		);
 
+		$logged_events = array();
+		add_action(
+			'jetpack_forms_log',
+			function ( $event, $reason, $data = null ) use ( &$logged_events ) {
+				$logged_events[] = array(
+					'event'  => $event,
+					'reason' => $reason,
+					'data'   => $data,
+				);
+			},
+			10,
+			3
+		);
+
 		$webhooks = Form_Webhooks::init();
 		$webhooks->send_webhooks( $post_id, $fields, false, array() );
 
 		// Link-local IPs should be blocked at validation time, no HTTP request made
 		$this->assertFalse( $http_request_made, 'HTTP request should not be made for link-local/AWS metadata URLs' );
+		$this->assertCount( 1, $logged_events );
+		// @phan-suppress-next-line PhanTypeArraySuspiciousNull, PhanTypeInvalidDimOffset
+		$this->assertEquals( 'webhook_skipped', $logged_events[0]['event'] );
+		// @phan-suppress-next-line PhanTypeArraySuspiciousNull, PhanTypeInvalidDimOffset
+		$this->assertEquals( 'blocked_ip', $logged_events[0]['reason'] );
 	}
 
 	/**

--- a/projects/packages/forms/tests/php/service/Form_Webhooks_Test.php
+++ b/projects/packages/forms/tests/php/service/Form_Webhooks_Test.php
@@ -767,6 +767,7 @@ class Form_Webhooks_Test extends BaseTestCase {
 
 	/**
 	 * Test webhook is blocked when URL points to localhost.
+	 * SSRF protection is handled at request time by wp_safe_remote_request().
 	 */
 	public function test_send_webhooks_blocks_localhost_urls() {
 		$form   = $this->create_mock_form(
@@ -786,45 +787,17 @@ class Form_Webhooks_Test extends BaseTestCase {
 
 		$post_id = $this->create_feedback_post( $form, $fields );
 
-		$http_request_made = false;
-		add_filter(
-			'pre_http_request',
-			function () use ( &$http_request_made ) {
-				$http_request_made = true;
-				return array(
-					'response' => array( 'code' => 200 ),
-					'body'     => '{"success":true}',
-				);
-			}
-		);
-
-		$logged_events = array();
-		add_action(
-			'jetpack_forms_log',
-			function ( $event, $reason, $data = null ) use ( &$logged_events ) {
-				$logged_events[] = array(
-					'event'  => $event,
-					'reason' => $reason,
-					'data'   => $data,
-				);
-			},
-			10,
-			3
-		);
-
 		$webhooks = Form_Webhooks::init();
 		$webhooks->send_webhooks( $post_id, $fields, false, array() );
 
-		$this->assertFalse( $http_request_made, 'HTTP request should not be made for localhost URLs' );
-		$this->assertCount( 1, $logged_events );
-		// @phan-suppress-next-line PhanTypeArraySuspiciousNull, PhanTypeInvalidDimOffset
-		$this->assertEquals( 'webhook_skipped', $logged_events[0]['event'] );
-		// @phan-suppress-next-line PhanTypeArraySuspiciousNull, PhanTypeInvalidDimOffset
-		$this->assertEquals( 'private_ip', $logged_events[0]['reason'] );
+		// wp_safe_remote_request() blocks private IPs and returns WP_Error, which gets logged
+		$error_meta = get_post_meta( $post_id, '_jetpack_forms_webhook_error', true );
+		$this->assertNotEmpty( $error_meta, 'Error should be logged for localhost URLs' );
 	}
 
 	/**
 	 * Test webhook is blocked when URL points to private Class A network (10.x.x.x).
+	 * SSRF protection is handled at request time by wp_safe_remote_request().
 	 */
 	public function test_send_webhooks_blocks_private_class_a_urls() {
 		$form   = $this->create_mock_form(
@@ -844,26 +817,17 @@ class Form_Webhooks_Test extends BaseTestCase {
 
 		$post_id = $this->create_feedback_post( $form, $fields );
 
-		$http_request_made = false;
-		add_filter(
-			'pre_http_request',
-			function () use ( &$http_request_made ) {
-				$http_request_made = true;
-				return array(
-					'response' => array( 'code' => 200 ),
-					'body'     => '{"success":true}',
-				);
-			}
-		);
-
 		$webhooks = Form_Webhooks::init();
 		$webhooks->send_webhooks( $post_id, $fields, false, array() );
 
-		$this->assertFalse( $http_request_made, 'HTTP request should not be made for private Class A URLs' );
+		// wp_safe_remote_request() blocks private IPs and returns WP_Error, which gets logged
+		$error_meta = get_post_meta( $post_id, '_jetpack_forms_webhook_error', true );
+		$this->assertNotEmpty( $error_meta, 'Error should be logged for private Class A URLs' );
 	}
 
 	/**
 	 * Test webhook is blocked when URL points to private Class B network (172.16-31.x.x).
+	 * SSRF protection is handled at request time by wp_safe_remote_request().
 	 */
 	public function test_send_webhooks_blocks_private_class_b_urls() {
 		$form   = $this->create_mock_form(
@@ -883,26 +847,17 @@ class Form_Webhooks_Test extends BaseTestCase {
 
 		$post_id = $this->create_feedback_post( $form, $fields );
 
-		$http_request_made = false;
-		add_filter(
-			'pre_http_request',
-			function () use ( &$http_request_made ) {
-				$http_request_made = true;
-				return array(
-					'response' => array( 'code' => 200 ),
-					'body'     => '{"success":true}',
-				);
-			}
-		);
-
 		$webhooks = Form_Webhooks::init();
 		$webhooks->send_webhooks( $post_id, $fields, false, array() );
 
-		$this->assertFalse( $http_request_made, 'HTTP request should not be made for private Class B URLs' );
+		// wp_safe_remote_request() blocks private IPs and returns WP_Error, which gets logged
+		$error_meta = get_post_meta( $post_id, '_jetpack_forms_webhook_error', true );
+		$this->assertNotEmpty( $error_meta, 'Error should be logged for private Class B URLs' );
 	}
 
 	/**
 	 * Test webhook is blocked when URL points to private Class C network (192.168.x.x).
+	 * SSRF protection is handled at request time by wp_safe_remote_request().
 	 */
 	public function test_send_webhooks_blocks_private_class_c_urls() {
 		$form   = $this->create_mock_form(
@@ -922,26 +877,17 @@ class Form_Webhooks_Test extends BaseTestCase {
 
 		$post_id = $this->create_feedback_post( $form, $fields );
 
-		$http_request_made = false;
-		add_filter(
-			'pre_http_request',
-			function () use ( &$http_request_made ) {
-				$http_request_made = true;
-				return array(
-					'response' => array( 'code' => 200 ),
-					'body'     => '{"success":true}',
-				);
-			}
-		);
-
 		$webhooks = Form_Webhooks::init();
 		$webhooks->send_webhooks( $post_id, $fields, false, array() );
 
-		$this->assertFalse( $http_request_made, 'HTTP request should not be made for private Class C URLs' );
+		// wp_safe_remote_request() blocks private IPs and returns WP_Error, which gets logged
+		$error_meta = get_post_meta( $post_id, '_jetpack_forms_webhook_error', true );
+		$this->assertNotEmpty( $error_meta, 'Error should be logged for private Class C URLs' );
 	}
 
 	/**
 	 * Test webhook is blocked when URL points to link-local network (169.254.x.x - includes AWS metadata).
+	 * SSRF protection for link-local is handled at request time by our http_request_host_is_external filter.
 	 */
 	public function test_send_webhooks_blocks_link_local_urls() {
 		$form   = $this->create_mock_form(
@@ -961,22 +907,12 @@ class Form_Webhooks_Test extends BaseTestCase {
 
 		$post_id = $this->create_feedback_post( $form, $fields );
 
-		$http_request_made = false;
-		add_filter(
-			'pre_http_request',
-			function () use ( &$http_request_made ) {
-				$http_request_made = true;
-				return array(
-					'response' => array( 'code' => 200 ),
-					'body'     => '{"success":true}',
-				);
-			}
-		);
-
 		$webhooks = Form_Webhooks::init();
 		$webhooks->send_webhooks( $post_id, $fields, false, array() );
 
-		$this->assertFalse( $http_request_made, 'HTTP request should not be made for link-local/AWS metadata URLs' );
+		// Our http_request_host_is_external filter blocks link-local IPs, causing a WP_Error
+		$error_meta = get_post_meta( $post_id, '_jetpack_forms_webhook_error', true );
+		$this->assertNotEmpty( $error_meta, 'Error should be logged for link-local/AWS metadata URLs' );
 	}
 
 	/**


### PR DESCRIPTION
## Proposed changes:
* Add URL validation to the Forms webhooks feature to prevent Server-Side Request Forgery (SSRF) attacks
* Require HTTPS scheme for all webhook URLs
* Use WordPress's `wp_http_validate_url()` to block private IP ranges (127.x, 10.x, 172.16-31.x, 192.168.x)
* Add explicit check for link-local addresses (169.254.x.x) which includes AWS/cloud metadata endpoints

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
N/A - Security fix

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

### Automated tests
* Run `jetpack test -v php packages/forms -- --filter="Form_Webhooks"` to verify all tests pass

### Manual testing
* Enable form webhooks with the filter: ```add_filter( ''jetpack_forms_webhooks_enabled', '__return_true' );```
* Create a form with a webhook configured
* Try setting the webhook URL to various blocked addresses and verify they are rejected:
  * `http://example.com/webhook` (HTTP - should be blocked, HTTPS required)
  * `https://127.0.0.1/webhook` (localhost - should be blocked)
  * `https://10.0.0.1/webhook` (private Class A - should be blocked)
  * `https://172.16.0.1/webhook` (private Class B - should be blocked)
  * `https://192.168.1.1/webhook` (private Class C - should be blocked)
  * `https://169.254.169.254/latest/meta-data/` (AWS metadata - should be blocked)
* Verify that valid public HTTPS URLs still work:
  * `https://hooks.zapier.com/webhook/123` (should work)
  * `https://webhook.site/abc123` (should work)