### PR TITLE
Atomic sites: Allow video uploads for the Video Upload feature

### DIFF
--- a/projects/plugins/jetpack/changelog/update-restrict-video-uploads
+++ b/projects/plugins/jetpack/changelog/update-restrict-video-uploads
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Allow uploads without VideoPress enabled

--- a/projects/plugins/jetpack/class.json-api-endpoints.php
+++ b/projects/plugins/jetpack/class.json-api-endpoints.php
@@ -2548,8 +2548,10 @@ abstract class WPCOM_JSON_API_Endpoint {
 			return $mimes;
 		}
 
-		// bail early if they already have the upgrade..
-		if ( wpcom_site_has_videopress() ) {
+		// bail early if they already have video upload capability.
+		if ( function_exists( 'wpcom_site_can_upload_videos' ) && wpcom_site_can_upload_videos() ) {
+			return $mimes;
+		} elseif ( wpcom_site_has_videopress() ) {
 			return $mimes;
 		}
 

--- a/projects/plugins/jetpack/class.json-api-endpoints.php
+++ b/projects/plugins/jetpack/class.json-api-endpoints.php
@@ -2549,9 +2549,7 @@ abstract class WPCOM_JSON_API_Endpoint {
 		}
 
 		// bail early if they already have video upload capability.
-		if ( function_exists( 'wpcom_site_can_upload_videos' ) && wpcom_site_can_upload_videos() ) {
-			return $mimes;
-		} elseif ( wpcom_site_has_videopress() ) {
+		if ( wpcom_site_can_upload_videos() ) {
 			return $mimes;
 		}
 

--- a/projects/plugins/wpcomsh/changelog/update-restrict-video-uploads
+++ b/projects/plugins/wpcomsh/changelog/update-restrict-video-uploads
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Allow users with video upload feature to upload videos

--- a/projects/plugins/wpcomsh/changelog/update-restrict-video-uploads
+++ b/projects/plugins/wpcomsh/changelog/update-restrict-video-uploads
@@ -1,4 +1,4 @@
 Significance: minor
 Type: changed
 
-Allow users with video upload feature to upload videos
+Allow users with the UPLOAD_VIDEO_FILES feature to upload videos without VideoPress

--- a/projects/plugins/wpcomsh/feature-plugins/hooks.php
+++ b/projects/plugins/wpcomsh/feature-plugins/hooks.php
@@ -317,9 +317,7 @@ function wpcomsh_maybe_restrict_mimetypes( $mimes ) {
 
 	// Allow video uploads if site has either VIDEOPRESS or UPLOAD_VIDEO_FILES feature.
 	// Sites with UPLOAD_VIDEO_FILES can upload videos without VideoPress (e.g. Premium plans with gating-business-q1 sticker).
-	$can_upload_videos = wpcom_site_has_feature( WPCOM_Features::VIDEOPRESS ) || wpcom_site_has_feature( WPCOM_Features::UPLOAD_VIDEO_FILES );
-
-	if ( ! $can_upload_videos ) {
+	if ( ! wpcom_site_can_upload_videos() ) {
 		// Copied from WPCOM (see `WPCOM_UPLOAD_FILETYPES_FOR_VIDEOS` in `.config/wpcom-options.php`).
 		$video_upload_filetypes = 'ogv mp4 m4v mov wmv avi mpg 3gp 3g2';
 		$disallowed_mimes       = array_merge( $disallowed_mimes, explode( ' ', $video_upload_filetypes ) );

--- a/projects/plugins/wpcomsh/feature-plugins/hooks.php
+++ b/projects/plugins/wpcomsh/feature-plugins/hooks.php
@@ -315,11 +315,19 @@ function wpcomsh_maybe_restrict_mimetypes( $mimes ) {
 		$disallowed_mimes          = array_merge( $disallowed_mimes, explode( ' ', $upgraded_upload_filetypes ) );
 	}
 
-	if ( ! wpcom_site_has_feature( WPCOM_Features::VIDEOPRESS ) ) {
+	// Allow video uploads if site has either VIDEOPRESS or UPLOAD_VIDEO_FILES feature.
+	// Sites with UPLOAD_VIDEO_FILES can upload videos without VideoPress (e.g. Premium plans with gating-business-q1 sticker).
+	$can_upload_videos = wpcom_site_has_feature( WPCOM_Features::VIDEOPRESS ) || wpcom_site_has_feature( WPCOM_Features::UPLOAD_VIDEO_FILES );
+
+	if ( ! $can_upload_videos ) {
 		// Copied from WPCOM (see `WPCOM_UPLOAD_FILETYPES_FOR_VIDEOS` in `.config/wpcom-options.php`).
-		// The `ttml` extension is set by `wp-content/mu-plugins/videopress/subtitles.php`.
-		$video_upload_filetypes = 'ogv mp4 m4v mov wmv avi mpg 3gp 3g2 ttml';
+		$video_upload_filetypes = 'ogv mp4 m4v mov wmv avi mpg 3gp 3g2';
 		$disallowed_mimes       = array_merge( $disallowed_mimes, explode( ' ', $video_upload_filetypes ) );
+	}
+
+	// TTML subtitles require VideoPress specifically (not just video upload capability).
+	if ( ! wpcom_site_has_feature( WPCOM_Features::VIDEOPRESS ) ) {
+		$disallowed_mimes[] = 'ttml';
 	}
 
 	foreach ( $disallowed_mimes as $disallowed_mime ) {

--- a/projects/plugins/wpcomsh/wpcom-features/functions-wpcom-features.php
+++ b/projects/plugins/wpcomsh/wpcom-features/functions-wpcom-features.php
@@ -91,6 +91,40 @@ function wpcom_site_has_feature( $feature, $blog_id = 0 ) {
 }
 
 /**
+ * Find out if the site can upload video files.
+ *
+ * This checks if the site has either VideoPress or the general video upload capability.
+ * Sites with the UPLOAD_VIDEO_FILES feature can upload videos even without VideoPress
+ * (e.g. Premium plans with the gating-business-q1 sticker).
+ *
+ * @param int $blog_id Blog ID. Defaults to the current blog ID if none is passed.
+ * @return bool Whether the site can upload video files.
+ */
+function wpcom_site_can_upload_videos( $blog_id = 0 ) {
+	if ( ! $blog_id ) {
+		$blog_id = _wpcom_get_current_blog_id();
+	}
+
+	// VideoPress includes video upload capability.
+	if ( wpcom_site_has_feature( WPCOM_Features::VIDEOPRESS, $blog_id ) ) {
+		return true;
+	}
+
+	// Check for the general video upload feature (Premium+ plans with gating-business-q1 sticker).
+	if ( wpcom_site_has_feature( WPCOM_Features::UPLOAD_VIDEO_FILES, $blog_id ) ) {
+		return true;
+	}
+
+	/**
+	 * Filters whether the site can upload video files.
+	 *
+	 * @param bool $can_upload_videos Whether the site can upload video files.
+	 * @param int  $blog_id Blog ID.
+	 */
+	return apply_filters( 'wpcom_site_can_upload_videos', false, $blog_id );
+}
+
+/**
  * Returns a list of purchased products.
  *
  * This function checks if we're on an Atomic (WPCOMSH) or Simple (WPCOM) site, and pulls the purchases for that current

--- a/projects/plugins/wpcomsh/wpcom-features/functions-wpcom-features.php
+++ b/projects/plugins/wpcomsh/wpcom-features/functions-wpcom-features.php
@@ -106,7 +106,13 @@ function wpcom_site_can_upload_videos( $blog_id = 0 ) {
 	}
 
 	// VideoPress includes video upload capability.
-	if ( wpcom_site_has_feature( WPCOM_Features::VIDEOPRESS, $blog_id ) ) {
+	// On WPCOM, use wpcom_site_has_videopress() to respect the filter.
+	// On WPCOMSH/Atomic, that function doesn't exist so use direct feature check.
+	if ( function_exists( 'wpcom_site_has_videopress' ) ) {
+		if ( wpcom_site_has_videopress( $blog_id ) ) {
+			return true;
+		}
+	} elseif ( wpcom_site_has_feature( WPCOM_Features::VIDEOPRESS, $blog_id ) ) {
 		return true;
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://linear.app/a8c/issue/DOTCOM-15511/update-mime-types

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* allows users with the Video Upload feature to upload videos

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

* this addresses an issue where users without VideoPress but with the Video Upload feature cannot upload videos

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Assign yourself a trreatment variaiton of the calypso_plans_differentiators_20251210 experiment (needed to add get the `gating-business-q1` blog sticker)
* Create a Premium site
* Add it to the WoA dev pool
* Transfer to atomic by installing a plugin (or any other method)
* checkout this branch
* run `pnpm jetpack rsync wpcomsh {username}@[sftp.wp.com](http://sftp.wp.com/):~/htdocs/wp-content/mu-plugins` to sync these changes to the site. You can create a Support SFTP user to get the credentials
* go to `/wp-admin/upload.php`
* you should be able to upload a video file

