### PR TITLE
Include gating-business-q1 sticker in wpcom_get_product_features cache key

### DIFF
--- a/projects/plugins/wpcomsh/changelog/fix-gating-business-q1-cache-key
+++ b/projects/plugins/wpcomsh/changelog/fix-gating-business-q1-cache-key
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+
+Fix product features cache key to include gating-business-q1 sticker status for the calypso_plans_differentiators_20251210 experiment.
+

--- a/projects/plugins/wpcomsh/wpcom-features/functions-wpcom-features.php
+++ b/projects/plugins/wpcomsh/wpcom-features/functions-wpcom-features.php
@@ -461,8 +461,8 @@ function wpcom_get_product_features( $product ) {
 	$cache_group = 'site_purchases';
 	$cache_found = false;
 
-	// Include sticker status in cache key only for Personal and Premium plans since they're affected by summer-special-2025
-	$has_summer_sticker = '';
+	// Include sticker status in cache key only for Personal and Premium plans since they're affected by feature gating experiments.
+	$sticker_cache_suffix = '';
 	// @phan-suppress-next-line PhanRedundantCondition
 	if ( function_exists( 'has_blog_sticker' ) && $purchase ) {
 		// Use existing WPCOM_Store helper methods to check plan types
@@ -472,12 +472,17 @@ function wpcom_get_product_features( $product ) {
 		}
 
 		if ( $is_personal_or_premium_plan ) {
-			$current_blog_id    = get_current_blog_id();
-			$has_summer_sticker = has_blog_sticker( 'summer-special-2025', $current_blog_id ) ? '_summer2025_' : '';
+			$current_blog_id = get_current_blog_id();
+			if ( has_blog_sticker( 'summer-special-2025', $current_blog_id ) ) {
+				$sticker_cache_suffix .= '_summer2025';
+			}
+			if ( has_blog_sticker( 'gating-business-q1', $current_blog_id ) ) {
+				$sticker_cache_suffix .= '_gatingbq1';
+			}
 		}
 	}
 
-	$cache_key = $purchase->product_slug . $has_summer_sticker . filemtime( __DIR__ . '/class-wpcom-features.php' );
+	$cache_key = $purchase->product_slug . $sticker_cache_suffix . filemtime( __DIR__ . '/class-wpcom-features.php' );
 	$features  = wp_cache_get( $cache_key, $cache_group, false, $cache_found );
 
 	if ( false === $cache_found ) {


### PR DESCRIPTION
## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

This is a wpcomsh-only change that mirrors the wpcom change for cache key handling.

Related to https://linear.app/a8c/issue/DOTCOM-15429/gutenberg-block-changes

## Does this pull request change what data or activity we track or use?
<!-- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!-- Check existing Jetpack support documents for a preview of the information we need. -->

No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Create a Simple site with Premium plan and the `gating-business-q1` sticker
2. Add a VideoPress block in the editor
3. Verify it shows "Upgrade to Business" (not "Upgrade to Premium")
4. Add a File Upload field in a Form block
5. Verify it shows "Upgrade to Business" (not "Upgrade to Personal")
6. Transfer the site to Atomic and verify the same behavior
7. Verify sites without the sticker continue to work as expected