### PR TITLE
Forms: Fix personal data export search for all responses format

### DIFF
--- a/projects/packages/forms/changelog/fix-FORMS-479
+++ b/projects/packages/forms/changelog/fix-FORMS-479
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix personal data export search to handle email addresses in all storage formats (legacy, V2, V3) including unicode/emoji characters

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -2816,7 +2816,7 @@ class Contact_Form_Plugin {
 			// - wp_json_encode( '🎉' ) produces the JSON string "\"\ud83c\udf89\"" (note the backslashes).
 			// - trim( ..., '"' ) removes the surrounding JSON quotes, giving "\ud83c\udf89".
 			// - stripslashes() then removes the backslashes from the escape sequence, yielding "ud83cudf89",
-			//   which is exactly how V2 stored the corrupted value in post_content.
+			// which is exactly how V2 stored the corrupted value in post_content.
 			// If the email contains unicode, also search for the V2 corrupted version generated this way.
 			$v2_corrupted_email = stripslashes( trim( wp_json_encode( $this->pde_email_address, JSON_UNESCAPED_SLASHES ), '"' ) );
 			if ( $v2_corrupted_email !== $this->pde_email_address ) {

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -2805,8 +2805,10 @@ class Contact_Form_Plugin {
 				'%' . $wpdb->esc_like( chr( 10 ) . 'AUTHOR EMAIL: ' . $this->pde_email_address . chr( 10 ) ) . '%',
 				'%' . $wpdb->esc_like( chr( 13 ) . 'AUTHOR EMAIL: ' . $this->pde_email_address . chr( 13 ) ) . '%',
 
-				// Pattern 3: V2/V3 format - JSON field value with escaped quotes
-				// Both V2 and V3 store with escaped quotes. Searches for: \"value\":\"user@example.com
+				// Pattern 3 & 4: V2/V3 format - JSON field value with escaped quotes
+				// Handles both storage variants:
+				// - Pattern 3: double-escaped quotes (e.g. stored as \"value\":\" in JSON-encoded content).
+				// - Pattern 4: single-escaped quotes (e.g. stored as "value":" after one level of unescaping).
 				'%\\"value\\":\\"' . $wpdb->esc_like( $this->pde_email_address ) . '%',
 				'%\"value\":\"' . $wpdb->esc_like( $this->pde_email_address ) . '%',
 			);

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -1761,7 +1761,7 @@ class Contact_Form_Plugin {
 				'slug'    => $block_template_part_slug,
 				'tagName' => 'div',
 			);
-			do_blocks( '<!-- wp:template-part ' . wp_json_encode( $attributes, JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP ) . ' /-->' );
+			do_blocks( '<!-- wp:template-part ' . wp_wp_json_encode( $attributes, JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP ) . ' /-->' );
 		} else {
 			// It's a form embedded in a post
 
@@ -2612,12 +2612,12 @@ class Contact_Form_Plugin {
 
 			$post_export_data[] = array(
 				'name'  => __( 'IP Address', 'jetpack-forms' ),
-				'value' => $feedback->get_ip_address(),
+				'value' => $feedback->get_ip_address() ?? '',
 			);
 
 			$post_export_data[] = array(
 				'name'  => __( 'Country code', 'jetpack-forms' ),
-				'value' => $feedback->get_country_code(),
+				'value' => $feedback->get_country_code() ?? '',
 			);
 
 			$export_data[] = array(
@@ -2742,7 +2742,7 @@ class Contact_Form_Plugin {
 		add_filter( 'posts_search', array( $this, 'personal_data_search_filter' ) );
 
 		$this->pde_last_post_id_erased = $last_post_id;
-		$this->pde_email_address       = $email;
+		$this->set_pde_email_address( $email );
 
 		$post_ids = get_posts(
 			array(
@@ -2769,6 +2769,18 @@ class Contact_Form_Plugin {
 	}
 
 	/**
+	 * Sets the email address to filter searches by.
+	 * Helper for tests.
+	 *
+	 * @since 6.1.1
+	 *
+	 * @param  string $email Email address.
+	 */
+	public function set_pde_email_address( $email ) {
+		$this->pde_email_address = $email;
+	}
+
+	/**
 	 * Filters searches by email address.
 	 *
 	 * @since 6.1.1
@@ -2781,18 +2793,38 @@ class Contact_Form_Plugin {
 		global $wpdb;
 
 		/*
-		 * Limits search to `post_content` only, and we only match the
-		 * author's email address whenever it's on a line by itself.
+		 * Searches for email addresses in feedback post_content across all storage formats:
+		 * - Legacy format: AUTHOR EMAIL on its own line
+		 * - V2/V3 format: JSON with email in field values
 		 */
 		if ( $this->pde_email_address && str_contains( $search, '..PDE..AUTHOR EMAIL:..PDE..' ) ) {
-			$search = (string) $wpdb->prepare(
-				" AND (
-					{$wpdb->posts}.post_content LIKE %s
-					OR {$wpdb->posts}.post_content LIKE %s
-				)",
-				// `chr( 10 )` = `\n`, `chr( 13 )` = `\r` - Keeping this in case someone needs it for reference.
+			// Build search patterns for all formats
+			$patterns = array(
+				// Pattern 1 & 2: Legacy format - AUTHOR EMAIL on its own line
+				// `chr( 10 )` = `\n`, `chr( 13 )` = `\r`
 				'%' . $wpdb->esc_like( chr( 10 ) . 'AUTHOR EMAIL: ' . $this->pde_email_address . chr( 10 ) ) . '%',
-				'%' . $wpdb->esc_like( chr( 13 ) . 'AUTHOR EMAIL: ' . $this->pde_email_address . chr( 13 ) ) . '%'
+				'%' . $wpdb->esc_like( chr( 13 ) . 'AUTHOR EMAIL: ' . $this->pde_email_address . chr( 13 ) ) . '%',
+
+				// Pattern 3: V2/V3 format - JSON field value with escaped quotes
+				// Both V2 and V3 store with escaped quotes. Searches for: \"value\":\"user@example.com
+				'%\\"value\\":\\"' . $wpdb->esc_like( $this->pde_email_address ) . '%',
+				'%\"value\":\"' . $wpdb->esc_like( $this->pde_email_address ) . '%',
+			);
+
+			// V2 has a bug where emojis become malformed: 🎉 becomes ud83cudf89 instead of \ud83c\udf89
+			// If the email contains unicode, also search for the V2 corrupted version
+			$v2_corrupted_email = stripslashes( trim( wp_json_encode( $this->pde_email_address, JSON_UNESCAPED_SLASHES ), '"' ) );
+			if ( $v2_corrupted_email !== $this->pde_email_address ) {
+				// Email contains unicode - add pattern for V2's corrupted format
+				$patterns[] = '%\"value\":\"' . $wpdb->esc_like( $v2_corrupted_email ) . '%';
+			}
+
+			// Build SQL with all patterns
+			$placeholders = implode( ' OR ', array_fill( 0, count( $patterns ), "{$wpdb->posts}.post_content LIKE %s" ) );
+
+			$search = (string) $wpdb->prepare(
+				' AND ( ' . $placeholders . ' )', // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare
+				...$patterns
 			);
 
 			if ( $this->pde_last_post_id_erased ) {

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -2829,6 +2829,12 @@ class Contact_Form_Plugin {
 			// Build SQL with all patterns
 			$placeholders = implode( ' OR ', array_fill( 0, count( $patterns ), "{$wpdb->posts}.post_content LIKE %s" ) );
 
+			// Validate that the number of placeholders matches the number of pattern values
+			$placeholder_count = substr_count( $placeholders, '%s' );
+			if ( $placeholder_count !== count( $patterns ) ) {
+				return $search;
+			}
+
 			$search = (string) $wpdb->prepare(
 				' AND ( ' . $placeholders . ' )', // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare
 				...$patterns

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -1761,7 +1761,7 @@ class Contact_Form_Plugin {
 				'slug'    => $block_template_part_slug,
 				'tagName' => 'div',
 			);
-			do_blocks( '<!-- wp:template-part ' . wp_wp_json_encode( $attributes, JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP ) . ' /-->' );
+			do_blocks( '<!-- wp:template-part ' . wp_json_encode( $attributes, JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP ) . ' /-->' );
 		} else {
 			// It's a form embedded in a post
 

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -2811,11 +2811,16 @@ class Contact_Form_Plugin {
 				'%\"value\":\"' . $wpdb->esc_like( $this->pde_email_address ) . '%',
 			);
 
-			// V2 has a bug where emojis become malformed: 🎉 becomes ud83cudf89 instead of \ud83c\udf89
-			// If the email contains unicode, also search for the V2 corrupted version
+			// V2 has a bug where emojis become malformed: 🎉 becomes ud83cudf89 instead of \ud83c\udf89.
+			// Here we deliberately reproduce that corruption so we can still match feedback saved by V2:
+			// - wp_json_encode( '🎉' ) produces the JSON string "\"\ud83c\udf89\"" (note the backslashes).
+			// - trim( ..., '"' ) removes the surrounding JSON quotes, giving "\ud83c\udf89".
+			// - stripslashes() then removes the backslashes from the escape sequence, yielding "ud83cudf89",
+			//   which is exactly how V2 stored the corrupted value in post_content.
+			// If the email contains unicode, also search for the V2 corrupted version generated this way.
 			$v2_corrupted_email = stripslashes( trim( wp_json_encode( $this->pde_email_address, JSON_UNESCAPED_SLASHES ), '"' ) );
 			if ( $v2_corrupted_email !== $this->pde_email_address ) {
-				// Email contains unicode - add pattern for V2's corrupted format
+				// Email contains unicode - add pattern for V2's corrupted format.
 				$patterns[] = '%\"value\":\"' . $wpdb->esc_like( $v2_corrupted_email ) . '%';
 			}
 

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
@@ -994,7 +994,7 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 		// Should search for both original AND V2 corrupted version
 		$this->assertStringContainsString( $email_with_emoji, $result, 'Should search for original email' );
 		$this->assertStringContainsString( 'testud83cudf89@example.com', $result, 'Should ALSO search for V2 corrupted version' );
-		$this->assertStringContainsString( $email_with_emoji, $result, 'Should ALSO search for regular email' );
+
 	}
 
 	public function test_personal_data_search_filter_includes_json_pattern() {
@@ -1013,7 +1013,7 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 
 		// Verify it contains multiple OR conditions (for legacy + JSON patterns)
 		$or_count = substr_count( $result, ' OR ' );
-		$this->assertGreaterThanOrEqual( 3, $or_count, 'Should have at least 2 OR clauses (legacy LF, legacy CR, JSON)' );
+		$this->assertGreaterThanOrEqual( 3, $or_count, 'Should have at least 3 OR clauses (legacy LF, legacy CR, JSON escaped, JSON unescaped)' );
 		$this->assertStringContainsString( 'AND (', $result, 'Should start with AND (' );
 		$this->assertStringContainsString( 'post_content LIKE', $result, 'Should include LIKE clause' );
 		$this->assertStringContainsString( '\"value\":\"' . $test_email, $result, 'Should include JSON value pattern v2' );

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
@@ -980,6 +980,46 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 		$this->assertIsArray( $exporter, 'Expected the exporter to return an array.' );
 	}
 
+	public function test_personal_data_search_filter_v2_unicode_search() {
+
+		$email_with_emoji = 'test🎉@example.com';
+
+		// Test the conversion function
+		$plugin = Contact_Form_Plugin::init();
+		$plugin->set_pde_email_address( $email_with_emoji );
+
+		$search = '..PDE..AUTHOR EMAIL:..PDE..';
+		$result = $plugin->personal_data_search_filter( $search );
+
+		// Should search for both original AND V2 corrupted version
+		$this->assertStringContainsString( $email_with_emoji, $result, 'Should search for original email' );
+		$this->assertStringContainsString( 'testud83cudf89@example.com', $result, 'Should ALSO search for V2 corrupted version' );
+		$this->assertStringContainsString( $email_with_emoji, $result, 'Should ALSO search for regular email' );
+	}
+
+	public function test_personal_data_search_filter_includes_json_pattern() {
+		// Test that the filter generates the correct SQL pattern for V2/V3 JSON formats
+		$test_email = 'user+test@example.com'; // Email with + sign
+		$plugin     = Contact_Form_Plugin::init();
+		$plugin->set_pde_email_address( $test_email );
+
+		// Call the filter with a mock search string
+		$search = '..PDE..AUTHOR EMAIL:..PDE..';
+		$result = $plugin->personal_data_search_filter( $search );
+
+		// Verify JSON format pattern: \"value\":\"email
+		// The pattern should contain the escaped quotes and the email
+		$this->assertStringContainsString( $test_email, $result, 'Should include email address in pattern' );
+
+		// Verify it contains multiple OR conditions (for legacy + JSON patterns)
+		$or_count = substr_count( $result, ' OR ' );
+		$this->assertGreaterThanOrEqual( 3, $or_count, 'Should have at least 2 OR clauses (legacy LF, legacy CR, JSON)' );
+		$this->assertStringContainsString( 'AND (', $result, 'Should start with AND (' );
+		$this->assertStringContainsString( 'post_content LIKE', $result, 'Should include LIKE clause' );
+		$this->assertStringContainsString( '\"value\":\"' . $test_email, $result, 'Should include JSON value pattern' );
+		$this->assertStringContainsString( '\\"value\\":\\"' . $test_email, $result, 'Should include JSON value pattern v2' );
+	}
+
 	public function test_get_unread_count_zero() {
 		delete_option( 'jetpack_feedback_unread_count' );
 		$this->assertIsInt( Contact_Form_Plugin::get_unread_count() );
@@ -1006,12 +1046,12 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 		add_filter(
 			'jetpack_block_editor_feature_flags',
 			function ( $flags ) {
-				$flags['central-form-management'] = true;
+				$flags['central - form - management'] = true;
 				return $flags;
 			}
 		);
 
-		$this->assertTrue( Contact_Form_Plugin::has_editor_feature_flag( 'central-form-management' ) );
+		$this->assertTrue( Contact_Form_Plugin::has_editor_feature_flag( 'central - form - management' ) );
 
 		remove_all_filters( 'jetpack_block_editor_feature_flags' );
 	}
@@ -1023,12 +1063,12 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 		add_filter(
 			'jetpack_block_editor_feature_flags',
 			function ( $flags ) {
-				$flags['central-form-management'] = false;
+				$flags['central - form - management'] = false;
 				return $flags;
 			}
 		);
 
-		$this->assertFalse( Contact_Form_Plugin::has_editor_feature_flag( 'central-form-management' ) );
+		$this->assertFalse( Contact_Form_Plugin::has_editor_feature_flag( 'central - form - management' ) );
 
 		remove_all_filters( 'jetpack_block_editor_feature_flags' );
 	}
@@ -1044,7 +1084,7 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 			}
 		);
 
-		$this->assertFalse( Contact_Form_Plugin::has_editor_feature_flag( 'non-existent-flag' ) );
+		$this->assertFalse( Contact_Form_Plugin::has_editor_feature_flag( 'non - existent - flag' ) );
 
 		remove_all_filters( 'jetpack_block_editor_feature_flags' );
 	}
@@ -1053,7 +1093,7 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 	 * Test has_editor_feature_flag returns false when no filter is applied
 	 */
 	public function test_has_editor_feature_flag_no_filter() {
-		$this->assertFalse( Contact_Form_Plugin::has_editor_feature_flag( 'any-flag' ) );
+		$this->assertFalse( Contact_Form_Plugin::has_editor_feature_flag( 'any - flag' ) );
 	}
 
 	/**
@@ -1073,7 +1113,7 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 		// Create fields with duplicates and empty labels
 		$fields_1 = array(
 			( new Feedback_Field( '1_question', 'Question', 'Answer 1', 'text', array(), 'question' ) )->serialize(),
-			( new Feedback_Field( '2_email', 'Email', 'user1@example.com', 'email', array(), 'email' ) )->serialize(),
+			( new Feedback_Field( '2_email', 'Email', 'user1@example . com', 'email', array(), 'email' ) )->serialize(),
 			( new Feedback_Field( '3_question', 'Question', 'Answer 2', 'text', array(), 'question' ) )->serialize(), // Duplicate label
 			( new Feedback_Field( '4_empty', '', 'Hidden value 1', 'text', array(), 'empty' ) )->serialize(), // Empty label
 			( new Feedback_Field( '5_question', 'Question', 'Answer 3', 'text', array(), 'question' ) )->serialize(), // Another duplicate
@@ -1082,7 +1122,7 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 
 		$content_1 = array(
 			'subject'     => 'Test Subject',
-			'ip'          => 'https://127.0.0.1',
+			'ip'          => 'https:// 127.0.0.1',
 			'entry_title' => 'Cool Post Title',
 			'entry_page'  => 1,
 			'fields'      => $fields_1,

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
@@ -994,7 +994,6 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 		// Should search for both original AND V2 corrupted version
 		$this->assertStringContainsString( $email_with_emoji, $result, 'Should search for original email' );
 		$this->assertStringContainsString( 'testud83cudf89@example.com', $result, 'Should ALSO search for V2 corrupted version' );
-
 	}
 
 	public function test_personal_data_search_filter_includes_json_pattern() {
@@ -1084,7 +1083,7 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 			}
 		);
 
-		$this->assertFalse( Contact_Form_Plugin::has_editor_feature_flag( 'non - existent - flag' ) );
+		$this->assertFalse( Contact_Form_Plugin::has_editor_feature_flag( 'non-existent-flag' ) );
 
 		remove_all_filters( 'jetpack_block_editor_feature_flags' );
 	}

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
@@ -996,7 +996,7 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 		$this->assertStringContainsString( 'testud83cudf89@example.com', $result, 'Should ALSO search for V2 corrupted version' );
 	}
 
-	public function test_personal_data_search_filter_includes_json_pattern() {
+	public function test_personal_data_search_filter_includes_v2_v3_json_patterns() {
 		// Test that the filter generates the correct SQL pattern for V2/V3 JSON formats
 		$test_email = 'user+test@example.com'; // Email with + sign
 		$plugin     = Contact_Form_Plugin::init();
@@ -1015,7 +1015,7 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 		$this->assertGreaterThanOrEqual( 3, $or_count, 'Should have at least 3 OR clauses (legacy LF, legacy CR, JSON escaped, JSON unescaped)' );
 		$this->assertStringContainsString( 'AND (', $result, 'Should start with AND (' );
 		$this->assertStringContainsString( 'post_content LIKE', $result, 'Should include LIKE clause' );
-		$this->assertStringContainsString( '\"value\":\"' . $test_email, $result, 'Should include JSON value pattern v2' );
+		$this->assertStringContainsString( '\"value\":\"' . $test_email, $result, 'Should include JSON value pattern with single-escaped quotes' );
 		$this->assertStringContainsString( '\\"value\\":\\"' . $test_email, $result, 'Should include JSON value pattern' );
 	}
 

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
@@ -1016,8 +1016,8 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 		$this->assertGreaterThanOrEqual( 3, $or_count, 'Should have at least 2 OR clauses (legacy LF, legacy CR, JSON)' );
 		$this->assertStringContainsString( 'AND (', $result, 'Should start with AND (' );
 		$this->assertStringContainsString( 'post_content LIKE', $result, 'Should include LIKE clause' );
-		$this->assertStringContainsString( '\"value\":\"' . $test_email, $result, 'Should include JSON value pattern' );
-		$this->assertStringContainsString( '\\"value\\":\\"' . $test_email, $result, 'Should include JSON value pattern v2' );
+		$this->assertStringContainsString( '\"value\":\"' . $test_email, $result, 'Should include JSON value pattern v2' );
+		$this->assertStringContainsString( '\\"value\\":\\"' . $test_email, $result, 'Should include JSON value pattern' );
 	}
 
 	public function test_get_unread_count_zero() {

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
@@ -1046,12 +1046,12 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 		add_filter(
 			'jetpack_block_editor_feature_flags',
 			function ( $flags ) {
-				$flags['central - form - management'] = true;
+				$flags['central-form-management'] = true;
 				return $flags;
 			}
 		);
 
-		$this->assertTrue( Contact_Form_Plugin::has_editor_feature_flag( 'central - form - management' ) );
+		$this->assertTrue( Contact_Form_Plugin::has_editor_feature_flag( 'central-form-management' ) );
 
 		remove_all_filters( 'jetpack_block_editor_feature_flags' );
 	}
@@ -1063,12 +1063,12 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 		add_filter(
 			'jetpack_block_editor_feature_flags',
 			function ( $flags ) {
-				$flags['central - form - management'] = false;
+				$flags['central-form-management'] = false;
 				return $flags;
 			}
 		);
 
-		$this->assertFalse( Contact_Form_Plugin::has_editor_feature_flag( 'central - form - management' ) );
+		$this->assertFalse( Contact_Form_Plugin::has_editor_feature_flag( 'central-form-management' ) );
 
 		remove_all_filters( 'jetpack_block_editor_feature_flags' );
 	}
@@ -1093,7 +1093,7 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 	 * Test has_editor_feature_flag returns false when no filter is applied
 	 */
 	public function test_has_editor_feature_flag_no_filter() {
-		$this->assertFalse( Contact_Form_Plugin::has_editor_feature_flag( 'any - flag' ) );
+		$this->assertFalse( Contact_Form_Plugin::has_editor_feature_flag( 'any-flag' ) );
 	}
 
 	/**
@@ -1113,7 +1113,7 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 		// Create fields with duplicates and empty labels
 		$fields_1 = array(
 			( new Feedback_Field( '1_question', 'Question', 'Answer 1', 'text', array(), 'question' ) )->serialize(),
-			( new Feedback_Field( '2_email', 'Email', 'user1@example . com', 'email', array(), 'email' ) )->serialize(),
+			( new Feedback_Field( '2_email', 'Email', 'user1@example.com', 'email', array(), 'email' ) )->serialize(),
 			( new Feedback_Field( '3_question', 'Question', 'Answer 2', 'text', array(), 'question' ) )->serialize(), // Duplicate label
 			( new Feedback_Field( '4_empty', '', 'Hidden value 1', 'text', array(), 'empty' ) )->serialize(), // Empty label
 			( new Feedback_Field( '5_question', 'Question', 'Answer 3', 'text', array(), 'question' ) )->serialize(), // Another duplicate
@@ -1122,7 +1122,7 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 
 		$content_1 = array(
 			'subject'     => 'Test Subject',
-			'ip'          => 'https:// 127.0.0.1',
+			'ip'          => 'https://127.0.0.1',
 			'entry_title' => 'Cool Post Title',
 			'entry_page'  => 1,
 			'fields'      => $fields_1,


### PR DESCRIPTION
Improves the personal data export search to correctly handle email addresses in all storage formats (legacy, V2, V3), including those with unicode or emoji characters. Updates the search filter to match emails in both legacy and JSON formats, and adds handling for V2's corrupted unicode storage. Includes new tests to verify correct search behavior for unicode and JSON email patterns.

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes FORMS-479

## Proposed changes:

   * Fixes personal data export search to properly find email addresses stored in V2 and V3 JSON formats, not just the legacy format
   * Adds support for searching email addresses containing unicode/emoji characters, including handling V2's corrupted unicode encoding
   * Improves search pattern to handle both escaped and unescaped quotes in JSON field values

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

 ## Testing instructions:

   This fix addresses a bug in the personal data export feature (GDPR compliance) where email addresses stored in newer formats (V2/V3) were not being found during export searches.

   ### Prerequisites:
   1. Install and activate the Jetpack Forms plugin
   2. Ensure you have some form submissions with email addresses stored in different formats

   ### Testing steps:

   **Test 1: Basic email search (V2/V3 format)**
   1. Go to Tools > Export Personal Data in WordPress admin
   2. Enter an email address that has submitted a form (stored in V2 or V3 format with JSON field values)
   3. Click "Send Request"
   4. Verify that the feedback submissions are found and included in the export
   5. Expected: Email addresses in JSON format like `\"value\":\"user@example.com\"` should be found

   **Test 3: Legacy format (regression test)**
   1. Go to Tools > Export Personal Data
   2. Enter an email that was stored in the legacy format (AUTHOR EMAIL on its own line)
   3. Click "Send Request"
   4. Verify that legacy format submissions are still found correctly
   5. Expected: No regression - legacy emails should still be found


