### PR TITLE
[DO NOT MERGE] Social: Per network customization

### DIFF
--- a/projects/js-packages/publicize-components/src/components/form/share-post-form.tsx
+++ b/projects/js-packages/publicize-components/src/components/form/share-post-form.tsx
@@ -1,5 +1,5 @@
 import { siteHasFeature } from '@automattic/jetpack-script-data';
-import { useNavigator } from '@wordpress/components';
+import { ToggleControl, useNavigator } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { useCallback, type FC } from 'react';
@@ -15,8 +15,9 @@ import MessageBoxControl from '../message-box-control';
 import SocialImageGeneratorPanel from '../social-image-generator/panel';
 import styles from './styles.module.scss';
 import { UpgradeNotice } from './upgrade-notice';
+import type { AttachedMedia, JetpackSocialOptions, SIGSettings } from '../../utils/types';
 
-type SharePostFormProps = {
+export type SharePostFormProps = {
 	/** Data for tracking analytics */
 	analyticsData?: {
 		/** The location of the analytics event */
@@ -27,6 +28,57 @@ type SharePostFormProps = {
 	 * This enables navigation for certain components within the form.
 	 */
 	isInsideNavigatorModal?: boolean;
+
+	/**
+	 * Optional message value. When provided, the component uses this value
+	 * instead of fetching from the store.
+	 */
+	message?: string;
+
+	/**
+	 * Optional callback to update the message. Required when `message` prop is provided.
+	 */
+	onMessageChange?: ( message: string ) => void;
+
+	/**
+	 * Optional attached media array. When provided along with `onMediaChange`,
+	 * the component uses these values instead of fetching from the store.
+	 */
+	attachedMedia?: Array< AttachedMedia >;
+
+	/**
+	 * Optional image generator settings. Used with per-connection customization.
+	 */
+	imageGeneratorSettings?: SIGSettings;
+
+	/**
+	 * Optional media source value.
+	 */
+	mediaSource?: JetpackSocialOptions[ 'media_source' ];
+
+	/**
+	 * Optional callback to update media-related options. Required when media props are provided.
+	 * Accepts partial JetpackSocialOptions to update.
+	 */
+	onMediaChange?: ( updates: Partial< JetpackSocialOptions > ) => void;
+
+	/**
+	 * Whether to show the "Customize for this connection" toggle.
+	 * When true, displays a toggle that allows users to override global settings.
+	 */
+	showCustomizeToggle?: boolean;
+
+	/**
+	 * Whether the customize toggle is currently enabled.
+	 * Only used when showCustomizeToggle is true.
+	 */
+	isCustomizeEnabled?: boolean;
+
+	/**
+	 * Callback when the customize toggle is changed.
+	 * Only used when showCustomizeToggle is true.
+	 */
+	onCustomizeToggle?: ( enabled: boolean ) => void;
 };
 
 /**
@@ -38,10 +90,30 @@ type SharePostFormProps = {
 export const SharePostForm: FC< SharePostFormProps > = ( {
 	analyticsData = null,
 	isInsideNavigatorModal,
+	message: messageProp,
+	onMessageChange,
+	attachedMedia,
+	imageGeneratorSettings,
+	mediaSource,
+	onMediaChange,
+	showCustomizeToggle = false,
+	isCustomizeEnabled = false,
+	onCustomizeToggle,
 } ) => {
-	const { message, updateMessage, maxLength } = useSocialMediaMessage();
+	const {
+		message: storeMessage,
+		updateMessage: storeUpdateMessage,
+		maxLength,
+	} = useSocialMediaMessage();
 	const isSocialNote = useIsSocialNote();
 	const postCanUseSig = usePostCanUseSig();
+
+	// Use props if provided, otherwise fall back to store values
+	const message = messageProp !== undefined ? messageProp : storeMessage;
+	const updateMessage = onMessageChange ?? storeUpdateMessage;
+
+	// Check if we're in "controlled" mode for media (props provided)
+	const isMediaControlled = onMediaChange !== undefined;
 
 	const { openUnifiedModal } = useDispatch( socialStore );
 
@@ -57,8 +129,30 @@ export const SharePostForm: FC< SharePostFormProps > = ( {
 		}
 	}, [ openUnifiedModal, isInsideNavigatorModal, navigator ] );
 
+	// When customize is disabled, the form fields should be disabled
+	const isFormDisabled = showCustomizeToggle && ! isCustomizeEnabled;
+
 	return (
 		<>
+			{ showCustomizeToggle && (
+				<ToggleControl
+					__nextHasNoMarginBottom
+					label={ __( 'Customize for this connection', 'jetpack-publicize-components' ) }
+					checked={ isCustomizeEnabled }
+					onChange={ onCustomizeToggle }
+					help={
+						isCustomizeEnabled
+							? __(
+									'Using custom message and media for this connection.',
+									'jetpack-publicize-components'
+							  )
+							: __(
+									'Using the same message and media for all connections.',
+									'jetpack-publicize-components'
+							  )
+					}
+				/>
+			) }
 			{ ! isSocialNote && (
 				<MessageBoxControl
 					label={ __( 'Message', 'jetpack-publicize-components' ) }
@@ -66,6 +160,7 @@ export const SharePostForm: FC< SharePostFormProps > = ( {
 					onChange={ updateMessage }
 					message={ message }
 					analyticsData={ analyticsData }
+					disabled={ isFormDisabled }
 				/>
 			) }
 			{ siteHasFeature( features.UNIFIED_UI_V1 ) ? (
@@ -73,14 +168,31 @@ export const SharePostForm: FC< SharePostFormProps > = ( {
 					{ ! hasSocialPaidFeatures() ? (
 						<UpgradeNotice />
 					) : (
-						<MediaSectionV2 analyticsData={ analyticsData } onEditTemplate={ onEditTemplate } />
+						<MediaSectionV2
+							analyticsData={ analyticsData }
+							onEditTemplate={ onEditTemplate }
+							disabled={ isFormDisabled }
+							{ ...( isMediaControlled && {
+								attachedMedia,
+								imageGeneratorSettings,
+								mediaSource,
+								onMediaChange,
+							} ) }
+						/>
 					) }
 				</div>
 			) : (
 				<>
 					{ siteHasFeature( features.ENHANCED_PUBLISHING ) && (
 						<div className={ styles[ 'share-post-form__media-section' ] }>
-							<MediaSection analyticsData={ analyticsData } />
+							<MediaSection
+								analyticsData={ analyticsData }
+								disabled={ isFormDisabled }
+								{ ...( isMediaControlled && {
+									attachedMedia,
+									onMediaChange,
+								} ) }
+							/>
 						</div>
 					) }
 					{ /* Social Image Generator panel - only shown when not using unified UI */ }

--- a/projects/js-packages/publicize-components/src/components/media-section-v2/index.tsx
+++ b/projects/js-packages/publicize-components/src/components/media-section-v2/index.tsx
@@ -34,12 +34,33 @@ export default function MediaSectionV2( {
 	analyticsData = {},
 	disabled = false,
 	onEditTemplate,
+	attachedMedia: attachedMediaProp,
+	imageGeneratorSettings: imageGeneratorSettingsProp,
+	mediaSource: mediaSourceProp,
+	onMediaChange,
 }: MediaSectionV2Props ) {
 	const { recordEvent } = useAnalytics();
 	const featuredImageId = useFeaturedImage();
 	const { isEnabled: sigEnabled } = useImageGeneratorConfig();
-	const { attachedMedia, imageGeneratorSettings, mediaSource, updateJetpackSocialOptions } =
-		usePostMeta();
+	const {
+		attachedMedia: storeAttachedMedia,
+		imageGeneratorSettings: storeImageGeneratorSettings,
+		mediaSource: storeMediaSource,
+		updateJetpackSocialOptions,
+	} = usePostMeta();
+
+	// Check if we're in "controlled" mode (props provided)
+	const isControlled = onMediaChange !== undefined;
+
+	// Use props if in controlled mode, otherwise fall back to store values
+	const attachedMedia = isControlled ? attachedMediaProp ?? [] : storeAttachedMedia;
+	const imageGeneratorSettings = isControlled
+		? imageGeneratorSettingsProp ?? { enabled: false }
+		: storeImageGeneratorSettings;
+	const mediaSource = isControlled ? mediaSourceProp : storeMediaSource;
+
+	// Unified update function that uses props callback or store
+	const updateMediaOptions = isControlled ? onMediaChange : updateJetpackSocialOptions;
 
 	// Get SIG preview URL when SIG is enabled
 	const { url: sigPreviewUrl, isLoading: sigIsLoading } = useSigPreview( sigEnabled );
@@ -110,7 +131,7 @@ export default function MediaSectionV2( {
 			} );
 
 			// Single batch update with explicit media_source and all related fields
-			updateJetpackSocialOptions( {
+			updateMediaOptions( {
 				media_source: source || 'none',
 				attached_media: [], // Reset attachment when changing source
 				image_generator_settings: {
@@ -119,7 +140,7 @@ export default function MediaSectionV2( {
 				},
 			} );
 		},
-		[ recordEvent, analyticsData, updateJetpackSocialOptions, imageGeneratorSettings ]
+		[ recordEvent, analyticsData, updateMediaOptions, imageGeneratorSettings ]
 	);
 
 	// Handle media selection from Media Library
@@ -128,7 +149,7 @@ export default function MediaSectionV2( {
 			const { id, url, mime } = media;
 
 			// Single batch update with explicit media_source
-			updateJetpackSocialOptions( {
+			updateMediaOptions( {
 				media_source: 'media-library',
 				attached_media: [ { id, url, type: mime } ],
 				image_generator_settings: { ...imageGeneratorSettings, enabled: false },
@@ -139,7 +160,7 @@ export default function MediaSectionV2( {
 				source: 'media-library',
 			} );
 		},
-		[ updateJetpackSocialOptions, imageGeneratorSettings, recordEvent, analyticsData ]
+		[ updateMediaOptions, imageGeneratorSettings, recordEvent, analyticsData ]
 	);
 
 	const handleMediaLibraryClick = useCallback( () => {
@@ -152,7 +173,7 @@ export default function MediaSectionV2( {
 	const handleAiImageSelect = useCallback(
 		( { id, url, mime }: WPMediaObject ) => {
 			// Use 'media-library' as the source since the AI image is uploaded to the media library
-			updateJetpackSocialOptions( {
+			updateMediaOptions( {
 				media_source: 'media-library',
 				attached_media: [ { id, url, type: mime || 'image/png' } ],
 				image_generator_settings: { ...imageGeneratorSettings, enabled: false },
@@ -166,7 +187,7 @@ export default function MediaSectionV2( {
 
 			toggleShowAiImageModal();
 		},
-		[ updateJetpackSocialOptions, imageGeneratorSettings, recordEvent, analyticsData ]
+		[ updateMediaOptions, imageGeneratorSettings, recordEvent, analyticsData ]
 	);
 
 	const renderMediaUpload = useCallback( ( { open }: { open: () => void } ) => {
@@ -177,7 +198,7 @@ export default function MediaSectionV2( {
 	// Handle remove - go to "no image" state
 	const handleRemove = useCallback( () => {
 		// Single batch update with explicit 'none' source
-		updateJetpackSocialOptions( {
+		updateMediaOptions( {
 			media_source: 'none',
 			attached_media: [],
 			image_generator_settings: { ...imageGeneratorSettings, enabled: false },
@@ -187,20 +208,14 @@ export default function MediaSectionV2( {
 			...analyticsData,
 			source: currentSource,
 		} );
-	}, [
-		updateJetpackSocialOptions,
-		imageGeneratorSettings,
-		recordEvent,
-		analyticsData,
-		currentSource,
-	] );
+	}, [ updateMediaOptions, imageGeneratorSettings, recordEvent, analyticsData, currentSource ] );
 
 	// Handle attachment toggle change
 	const handleAttachmentToggle = useCallback(
 		( checked: boolean ) => {
 			if ( currentSource === 'featured-image' && previewData ) {
 				// Featured image: toggle attachment mode
-				updateJetpackSocialOptions( {
+				updateMediaOptions( {
 					media_source: 'featured-image',
 					attached_media: checked
 						? [ { id: previewData.id, url: previewData.url, type: 'image/jpeg' } ]
@@ -208,7 +223,7 @@ export default function MediaSectionV2( {
 				} );
 			} else if ( currentSource === 'sig' && sigPreviewUrl ) {
 				// SIG: toggle attachment mode (add SIG URL to attached_media)
-				updateJetpackSocialOptions( {
+				updateMediaOptions( {
 					media_source: 'sig',
 					attached_media: checked ? [ { id: 0, url: sigPreviewUrl, type: 'image/jpeg' } ] : [],
 					// Keep SIG enabled regardless
@@ -230,7 +245,7 @@ export default function MediaSectionV2( {
 			currentSource,
 			previewData,
 			sigPreviewUrl,
-			updateJetpackSocialOptions,
+			updateMediaOptions,
 			imageGeneratorSettings,
 			recordEvent,
 			analyticsData,

--- a/projects/js-packages/publicize-components/src/components/media-section-v2/types.ts
+++ b/projects/js-packages/publicize-components/src/components/media-section-v2/types.ts
@@ -50,6 +50,42 @@ export interface MediaPreviewData {
 }
 
 /**
+ * Attached media item structure (matches AttachedMedia from utils/types)
+ */
+export interface AttachedMediaItem {
+	id: number;
+	url: string;
+	type: string;
+}
+
+/**
+ * Image generator settings structure
+ */
+export interface ImageGeneratorSettings {
+	enabled: boolean;
+	custom_text?: string;
+	image_type?: string;
+	image_id?: number;
+	template?: string;
+	token?: string;
+	default_image_id?: number;
+}
+
+/**
+ * Media source value type
+ */
+export type MediaSourceValue = 'featured-image' | 'sig' | 'media-library' | 'upload-video' | 'none';
+
+/**
+ * Jetpack social options for media updates
+ */
+export interface MediaOptions {
+	attached_media?: Array< AttachedMediaItem >;
+	image_generator_settings?: ImageGeneratorSettings;
+	media_source?: MediaSourceValue;
+}
+
+/**
  * Props for MediaSectionV2 component
  */
 export interface MediaSectionV2Props {
@@ -67,6 +103,28 @@ export interface MediaSectionV2Props {
 	 * Callback when the edit template action is triggered
 	 */
 	onEditTemplate?: VoidFunction;
+
+	/**
+	 * Optional attached media array. When provided along with `onMediaChange`,
+	 * the component uses these values instead of fetching from the store.
+	 */
+	attachedMedia?: Array< AttachedMediaItem >;
+
+	/**
+	 * Optional image generator settings. Used with per-connection customization.
+	 */
+	imageGeneratorSettings?: ImageGeneratorSettings;
+
+	/**
+	 * Optional media source value.
+	 */
+	mediaSource?: MediaSourceValue;
+
+	/**
+	 * Optional callback to update media-related options.
+	 * When provided, the component operates in "controlled" mode.
+	 */
+	onMediaChange?: ( updates: Partial< MediaOptions > ) => void;
 }
 
 /**

--- a/projects/js-packages/publicize-components/src/components/media-section/index.js
+++ b/projects/js-packages/publicize-components/src/components/media-section/index.js
@@ -18,6 +18,8 @@ const ADD_MEDIA_LABEL = __( 'Choose Media', 'jetpack-publicize-components' );
  * @param {string}                    [props.disabledNoticeMessage=''] - An optional notice that's displayed when the section is disabled.
  * @param {import('react').ReactNode} [props.CustomNotice=null]        - An optional custom notice that's displayed.
  * @param {object}                    [props.analyticsData]            - Data for tracking analytics.
+ * @param {Array}                     [props.attachedMedia]            - Optional attached media array for controlled mode.
+ * @param {Function}                  [props.onMediaChange]            - Optional callback to update media options in controlled mode.
  * @return {object} The media section.
  */
 export default function MediaSection( {
@@ -25,9 +27,23 @@ export default function MediaSection( {
 	disabledNoticeMessage = '',
 	CustomNotice = null,
 	analyticsData,
+	attachedMedia: attachedMediaProp,
+	onMediaChange,
 } ) {
-	const { attachedMedia, updateAttachedMedia } = useAttachedMedia();
+	const { attachedMedia: storeAttachedMedia, updateAttachedMedia: storeUpdateAttachedMedia } =
+		useAttachedMedia();
 	const { recordEvent } = useAnalytics();
+
+	// Check if we're in "controlled" mode (props provided)
+	const isControlled = onMediaChange !== undefined;
+
+	// Use props if in controlled mode, otherwise fall back to store values
+	const attachedMedia = isControlled ? attachedMediaProp ?? [] : storeAttachedMedia;
+
+	// Unified update function that uses props callback or store
+	const updateAttachedMedia = isControlled
+		? media => onMediaChange( { attached_media: media } )
+		: storeUpdateAttachedMedia;
 
 	const [ mediaDetails ] = useMediaDetails( attachedMedia[ 0 ]?.id );
 

--- a/projects/js-packages/publicize-components/src/components/unified-modal/social-post-preview/content.tsx
+++ b/projects/js-packages/publicize-components/src/components/unified-modal/social-post-preview/content.tsx
@@ -1,7 +1,9 @@
 import { Flex } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
-import { useEffect } from 'react';
+import { useCallback, useEffect } from 'react';
+import { useConnectionOverrides } from '../../../hooks/use-connection-overrides';
+import { usePostMeta } from '../../../hooks/use-post-meta';
 import { store as socialStore } from '../../../social-store';
 import { Connection } from '../../../social-store/types';
 import { MediaValidationNotices } from '../../form/media-validation-notices';
@@ -10,6 +12,7 @@ import { PostPreview } from '../../social-post-modal/post-preview';
 import { ConnectionPanels } from './connection-panels';
 import { ScheduledPosts } from './scheduled-posts';
 import styles from './styles.module.scss';
+import type { AttachedMedia } from '../../../utils/types';
 
 type ContentProps = {
 	baseId: string;
@@ -25,6 +28,45 @@ type ContentProps = {
  */
 export function Content( { baseId, selectedConnection, forSmallScreen }: ContentProps ) {
 	const { incrementRenderCountFor } = useDispatch( socialStore );
+	const { shareMessage, attachedMedia } = usePostMeta();
+	const { getConnectionOverride, hasOverride, updateConnectionOverride, toggleOverride } =
+		useConnectionOverrides();
+
+	const connectionId = selectedConnection.connection_id;
+	const isCustomizeEnabled = hasOverride( connectionId );
+	const override = getConnectionOverride( connectionId );
+
+	// Get the effective message and media values (override or global)
+	const effectiveMessage = isCustomizeEnabled ? override?.message ?? '' : shareMessage;
+	const effectiveAttachedMedia = isCustomizeEnabled
+		? override?.attached_media ?? []
+		: attachedMedia;
+
+	// Handler for message changes
+	const handleMessageChange = useCallback(
+		( message: string ) => {
+			updateConnectionOverride( connectionId, { message } );
+		},
+		[ connectionId, updateConnectionOverride ]
+	);
+
+	// Handler for media changes - only stores attached_media in the override
+	const handleMediaChange = useCallback(
+		( updates: { attached_media?: Array< AttachedMedia > } ) => {
+			updateConnectionOverride( connectionId, {
+				attached_media: updates.attached_media,
+			} );
+		},
+		[ connectionId, updateConnectionOverride ]
+	);
+
+	// Handler for customize toggle
+	const handleCustomizeToggle = useCallback( () => {
+		toggleOverride( connectionId, {
+			message: shareMessage,
+			attached_media: attachedMedia,
+		} );
+	}, [ connectionId, toggleOverride, shareMessage, attachedMedia ] );
 
 	useEffect( () => {
 		incrementRenderCountFor( 'social-preview' );
@@ -39,7 +81,17 @@ export function Content( { baseId, selectedConnection, forSmallScreen }: Content
 						<MediaValidationNotices />
 					</div>
 					<div className={ styles[ 'customization-form' ] }>
-						<SharePostForm analyticsData={ { location: 'preview-modal' } } isInsideNavigatorModal />
+						<SharePostForm
+							analyticsData={ { location: 'preview-modal' } }
+							isInsideNavigatorModal
+							showCustomizeToggle
+							isCustomizeEnabled={ isCustomizeEnabled }
+							onCustomizeToggle={ handleCustomizeToggle }
+							message={ effectiveMessage }
+							onMessageChange={ isCustomizeEnabled ? handleMessageChange : undefined }
+							attachedMedia={ effectiveAttachedMedia }
+							onMediaChange={ isCustomizeEnabled ? handleMediaChange : undefined }
+						/>
 					</div>
 					<ScheduledPosts />
 				</Flex>
@@ -57,6 +109,19 @@ export function Content( { baseId, selectedConnection, forSmallScreen }: Content
 		>
 			{ selectedConnection.enabled ? (
 				<Flex className={ styles.preview } align="center" justify="center">
+					<div className={ styles[ 'customization-form' ] }>
+						<SharePostForm
+							analyticsData={ { location: 'preview-modal' } }
+							isInsideNavigatorModal
+							showCustomizeToggle
+							isCustomizeEnabled={ isCustomizeEnabled }
+							onCustomizeToggle={ handleCustomizeToggle }
+							message={ effectiveMessage }
+							onMessageChange={ isCustomizeEnabled ? handleMessageChange : undefined }
+							attachedMedia={ effectiveAttachedMedia }
+							onMediaChange={ isCustomizeEnabled ? handleMediaChange : undefined }
+						/>
+					</div>
 					<PostPreview connection={ selectedConnection } />
 				</Flex>
 			) : (

--- a/projects/js-packages/publicize-components/src/hooks/use-connection-overrides/index.ts
+++ b/projects/js-packages/publicize-components/src/hooks/use-connection-overrides/index.ts
@@ -1,0 +1,157 @@
+import { useDispatch, useSelect } from '@wordpress/data';
+import { store as editorStore } from '@wordpress/editor';
+import { useCallback, useMemo } from '@wordpress/element';
+import type { AttachedMedia } from '../../utils/types';
+
+/**
+ * Per-connection override settings.
+ * Only includes the fields that can be customized per-connection.
+ */
+export interface ConnectionOverride {
+	override_settings: boolean;
+	message?: string;
+	attached_media?: Array< AttachedMedia >;
+}
+
+/**
+ * Map of connection ID to override settings.
+ */
+export type ConnectionOverrides = Record< string, ConnectionOverride >;
+
+const EMPTY_OBJECT: ConnectionOverrides = {};
+
+/**
+ * The REST API name for the connection overrides meta.
+ * This is defined in class-publicize-base.php via show_in_rest.name
+ */
+const META_KEY = 'jetpack_publicize_connection_overrides';
+
+/**
+ * Hook to manage per-connection customization overrides.
+ *
+ * This hook provides access to the `_wpas_connection_overrides` post meta
+ * (exposed as `jetpack_publicize_connection_overrides` in REST),
+ * which stores per-connection message and media customizations.
+ *
+ * @return Object with overrides data and update functions.
+ */
+export function useConnectionOverrides() {
+	const { editPost } = useDispatch( editorStore );
+
+	const connectionOverrides = useSelect( select => {
+		const meta = select( editorStore ).getEditedPostAttribute( 'meta' ) || {};
+		return ( meta[ META_KEY ] as ConnectionOverrides ) || EMPTY_OBJECT;
+	}, [] );
+
+	/**
+	 * Get override settings for a specific connection.
+	 */
+	const getConnectionOverride = useCallback(
+		( connectionId: string ): ConnectionOverride | undefined => {
+			return connectionOverrides[ connectionId ];
+		},
+		[ connectionOverrides ]
+	);
+
+	/**
+	 * Check if a connection has override settings enabled.
+	 */
+	const hasOverride = useCallback(
+		( connectionId: string ): boolean => {
+			return connectionOverrides[ connectionId ]?.override_settings === true;
+		},
+		[ connectionOverrides ]
+	);
+
+	/**
+	 * Update override settings for a specific connection.
+	 * Pass null to remove the override for that connection.
+	 */
+	const updateConnectionOverride = useCallback(
+		( connectionId: string, override: Partial< ConnectionOverride > | null ) => {
+			const newOverrides = { ...connectionOverrides };
+
+			if ( override === null ) {
+				// Remove the override for this connection
+				delete newOverrides[ connectionId ];
+			} else {
+				// Merge with existing override or create new one
+				newOverrides[ connectionId ] = {
+					...( newOverrides[ connectionId ] || {} ),
+					...override,
+					override_settings: override.override_settings ?? true,
+				};
+			}
+
+			// If all overrides are removed, delete the meta entirely
+			const hasAnyOverrides = Object.keys( newOverrides ).length > 0;
+
+			editPost( {
+				meta: {
+					[ META_KEY ]: hasAnyOverrides ? newOverrides : undefined,
+				},
+			} );
+		},
+		[ connectionOverrides, editPost ]
+	);
+
+	/**
+	 * Toggle override settings for a connection.
+	 * When enabling, copies current global message and attached_media as initial values.
+	 */
+	const toggleOverride = useCallback(
+		(
+			connectionId: string,
+			globalSettings?: {
+				message?: string;
+				attached_media?: Array< AttachedMedia >;
+			}
+		) => {
+			const currentOverride = connectionOverrides[ connectionId ];
+			const isCurrentlyEnabled = currentOverride?.override_settings === true;
+
+			if ( isCurrentlyEnabled ) {
+				// Disable override - remove it
+				updateConnectionOverride( connectionId, null );
+			} else {
+				// Enable override - copy global message and media as initial values
+				updateConnectionOverride( connectionId, {
+					override_settings: true,
+					message: globalSettings?.message ?? '',
+					attached_media: globalSettings?.attached_media ?? [],
+				} );
+			}
+		},
+		[ connectionOverrides, updateConnectionOverride ]
+	);
+
+	/**
+	 * Clear all connection overrides.
+	 */
+	const clearAllOverrides = useCallback( () => {
+		editPost( {
+			meta: {
+				[ META_KEY ]: undefined,
+			},
+		} );
+	}, [ editPost ] );
+
+	return useMemo(
+		() => ( {
+			connectionOverrides,
+			getConnectionOverride,
+			hasOverride,
+			updateConnectionOverride,
+			toggleOverride,
+			clearAllOverrides,
+		} ),
+		[
+			connectionOverrides,
+			getConnectionOverride,
+			hasOverride,
+			updateConnectionOverride,
+			toggleOverride,
+			clearAllOverrides,
+		]
+	);
+}

--- a/projects/packages/publicize/src/class-publicize-base.php
+++ b/projects/packages/publicize/src/class-publicize-base.php
@@ -1139,6 +1139,24 @@ abstract class Publicize_Base {
 			'auth_callback' => array( $this, 'message_meta_auth_callback' ),
 		);
 
+		$attached_media = array(
+			'type'  => 'array',
+			'items' => array(
+				'type'       => 'object',
+				'properties' => array(
+					'id'   => array(
+						'type' => 'number',
+					),
+					'url'  => array(
+						'type' => 'string',
+					),
+					'type' => array(
+						'type' => 'string',
+					),
+				),
+			),
+		);
+
 		$jetpack_social_options_args = array(
 			'type'          => 'object',
 			'description'   => __( 'Post options related to Jetpack Social.', 'jetpack-publicize-pkg' ),
@@ -1160,23 +1178,7 @@ abstract class Publicize_Base {
 						'version'                  => array(
 							'type' => 'number',
 						),
-						'attached_media'           => array(
-							'type'  => 'array',
-							'items' => array(
-								'type'       => 'object',
-								'properties' => array(
-									'id'   => array(
-										'type' => 'number',
-									),
-									'url'  => array(
-										'type' => 'string',
-									),
-									'type' => array(
-										'type' => 'string',
-									),
-								),
-							),
-						),
+						'attached_media'           => $attached_media,
 						'image_generator_settings' => array(
 							'type'       => 'object',
 							'properties' => array(
@@ -1216,6 +1218,34 @@ abstract class Publicize_Base {
 			'auth_callback' => array( $this, 'message_meta_auth_callback' ),
 		);
 
+		// Per-connection overrides for message and attached media.
+		// This allows users to customize what gets shared to each social network connection.
+		$connection_overrides_args = array(
+			'type'          => 'object',
+			'description'   => __( 'Per-connection customizations for message and media.', 'jetpack-publicize-pkg' ),
+			'single'        => true,
+			'default'       => array(),
+			'show_in_rest'  => array(
+				'name'   => 'jetpack_publicize_connection_overrides',
+				'schema' => array(
+					'type'                 => 'object',
+					'additionalProperties' => array(
+						'type'       => 'object',
+						'properties' => array(
+							'override_settings' => array(
+								'type' => 'boolean',
+							),
+							'message'           => array(
+								'type' => 'string',
+							),
+							'attached_media'    => $attached_media,
+						),
+					),
+				),
+			),
+			'auth_callback' => array( $this, 'message_meta_auth_callback' ),
+		);
+
 		foreach ( get_post_types() as $post_type ) {
 			if ( ! $this->post_type_is_publicizeable( $post_type ) ) {
 				continue;
@@ -1225,11 +1255,13 @@ abstract class Publicize_Base {
 			$publicize_feature_enable_args['object_subtype'] = $post_type;
 			$already_shared_flag_args['object_subtype']      = $post_type;
 			$jetpack_social_options_args['object_subtype']   = $post_type;
+			$connection_overrides_args['object_subtype']     = $post_type;
 
 			register_meta( 'post', $this->POST_MESS, $message_args );
 			register_meta( 'post', self::POST_PUBLICIZE_FEATURE_ENABLED, $publicize_feature_enable_args );
 			register_meta( 'post', $this->POST_DONE . 'all', $already_shared_flag_args );
 			register_meta( 'post', self::POST_JETPACK_SOCIAL_OPTIONS, $jetpack_social_options_args );
+			register_meta( 'post', '_wpas_connection_overrides', $connection_overrides_args );
 		}
 	}
 

--- a/projects/packages/publicize/src/rest-api/class-connections-post-field.php
+++ b/projects/packages/publicize/src/rest-api/class-connections-post-field.php
@@ -123,10 +123,44 @@ class Connections_Post_Field {
 				$deprecated_fields,
 				$connection_fields,
 				array(
-					'enabled' => array(
+					'enabled'           => array(
 						'description' => __( 'Whether to share to this connection.', 'jetpack-publicize-pkg' ),
 						'type'        => 'boolean',
 						'context'     => array( 'edit' ),
+					),
+					'override_settings' => array(
+						'description' => __( 'Whether to use per-connection settings instead of global settings. When true, message and attached_media values will be used even if empty.', 'jetpack-publicize-pkg' ),
+						'type'        => 'boolean',
+						'context'     => array( 'edit' ),
+						'default'     => false,
+					),
+					'message'           => array(
+						'description' => __( 'Custom message to use for this connection instead of the global message. Only used when override_settings is true.', 'jetpack-publicize-pkg' ),
+						'type'        => 'string',
+						'context'     => array( 'edit' ),
+					),
+					'attached_media'    => array(
+						'description' => __( 'Custom media to attach for this connection instead of the global media. Only used when override_settings is true.', 'jetpack-publicize-pkg' ),
+						'type'        => 'array',
+						'context'     => array( 'edit' ),
+						'items'       => array(
+							'type'       => 'object',
+							'properties' => array(
+								'id'   => array(
+									'description' => __( 'Media attachment ID.', 'jetpack-publicize-pkg' ),
+									'type'        => 'integer',
+								),
+								'url'  => array(
+									'description' => __( 'Media URL.', 'jetpack-publicize-pkg' ),
+									'type'        => 'string',
+									'format'      => 'uri',
+								),
+								'type' => array(
+									'description' => __( 'Media type (e.g., image, video).', 'jetpack-publicize-pkg' ),
+									'type'        => 'string',
+								),
+							),
+						),
 					),
 				)
 			),
@@ -372,13 +406,67 @@ class Connections_Post_Field {
 			return;
 		}
 		foreach ( $this->get_meta_to_update( $requested_connections, $post->ID ) as $meta_key => $meta_value ) {
-			if ( $meta_value === null ) {
+			if ( null === $meta_value ) {
 				delete_post_meta( $post->ID, $meta_key );
 			} else {
 				update_post_meta( $post->ID, $meta_key, $meta_value );
 			}
 		}
+
+		// Save per-connection overrides (message and attached_media).
+		$this->save_connection_overrides( $requested_connections, $post->ID );
+
 		$this->meta_saved[ $post->ID ] = true;
+	}
+
+	/**
+	 * Save per-connection message and media overrides to post meta.
+	 *
+	 * Extracts 'message' and 'attached_media' from each connection and saves
+	 * them to the '_wpas_connection_overrides' post meta. This allows users
+	 * to customize what gets shared to each social network connection.
+	 *
+	 * @param array $requested_connections Array of connection objects with optional message/attached_media.
+	 * @param int   $post_id               Post ID to save overrides for.
+	 */
+	private function save_connection_overrides( $requested_connections, $post_id ) {
+		$overrides = array();
+
+		foreach ( $requested_connections as $connection ) {
+			// We need a connection_id to store overrides.
+			if ( empty( $connection['connection_id'] ) ) {
+				continue;
+			}
+
+			// Only save overrides if override_settings is explicitly true.
+			if ( empty( $connection['override_settings'] ) ) {
+				continue;
+			}
+
+			$connection_id = $connection['connection_id'];
+
+			$overrides[ $connection_id ] = array(
+				'override_settings' => true,
+			);
+
+			// Save message (can be empty string to explicitly clear global message).
+			if ( isset( $connection['message'] ) ) {
+				$overrides[ $connection_id ]['message'] = sanitize_textarea_field( $connection['message'] );
+			}
+
+			// Save attached_media (can be empty array to explicitly clear global media).
+			// REST API schema validates the structure, so we save as-is.
+			if ( isset( $connection['attached_media'] ) && is_array( $connection['attached_media'] ) ) {
+				$overrides[ $connection_id ]['attached_media'] = $connection['attached_media'];
+			}
+		}
+
+		// Only save if there are overrides, otherwise delete any existing meta.
+		if ( ! empty( $overrides ) ) {
+			update_post_meta( $post_id, '_wpas_connection_overrides', $overrides );
+		} else {
+			delete_post_meta( $post_id, '_wpas_connection_overrides' );
+		}
 	}
 
 	/**

--- a/projects/packages/sync/src/class-defaults.php
+++ b/projects/packages/sync/src/class-defaults.php
@@ -774,6 +774,7 @@ class Defaults {
 		'_wp_old_date',
 		'_wp_page_template',
 		'_wp_trash_meta_comments_status',
+		'_wpas_connection_overrides',
 		'_wpas_feature_enabled',
 		'_wpas_mess',
 		'_wpas_options',


### PR DESCRIPTION
⚠️  Created with the help of Clause Code but reviewed and tested the code before pushing.

WPCOM changes 198964-ghe-Automattic/wpcom

## Proposed changes:

This PR adds the ability for users to customize the message and attached media per social network connection when sharing a post. Previously, users could only set a single message and media that would be shared to all enabled connections. Now they can override these settings for individual connections.

### Backend (PHP):
* Register new `_wpas_connection_overrides` post meta to store per-connection customizations
* Expose the meta via REST API as `jetpack_publicize_connection_overrides`
* Add `override_settings`, `message`, and `attached_media` fields to the connection schema in `jetpack_publicize_connections`
* Implement `save_connection_overrides()` to persist per-connection overrides when updating connections
* Add the new meta key to the sync whitelist for WPCOM sync

### Frontend (JS/TS):
* Create `useConnectionOverrides` hook to read/write per-connection customizations from post meta
* Decouple `SharePostForm`, `MediaSectionV2`, and `MediaSection` components from the store to support both global and per-connection modes via props
* Add "Customize for this connection" toggle to `SharePostForm`
* Update `Content` component in the social preview modal to wire up per-connection customization

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

## Does this pull request change what data or activity we track or use?

No. This stores user-provided content (custom messages and media selections) in post meta, similar to existing `jetpack_publicize_message` functionality.

## Testing instructions:

### Setup
1. Ensure you have Jetpack Social enabled with at least 2 social connections configured
2. Create or edit a post

### Test per-connection customization
1. Open the Social preview modal (click on the Social connections in the sidebar, then "Preview")
2. Select a connection tab
3. You should see a "Customize for this connection" toggle at the top of the form
4. Toggle it ON - the message and media fields should become editable
5. Enter a custom message for this connection
6. Select different media for this connection (if applicable)
7. Switch to another connection tab - it should show the global message/media
8. Toggle customization ON for this second connection and enter different content
9. Save/publish the post

### Verify data persistence
1. After saving, reopen the post editor
2. Open the Social preview modal
3. The connections you customized should still show the toggle ON with your custom content
4. Other connections should show the global content

### Verify override structure
Using WP-CLI, verify the stored data is minimal:
```bash
wp post meta get <post_id> _wpas_connection_overrides
```
Should only contain `override_settings`, `message`, and `attached_media` (no `image_generator_settings` or `media_source`).