### PR TITLE
Forms: Improve phone field styling to better mimic theme input styles

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-add-phone-input-mimicry
+++ b/projects/packages/forms/changelog/fix-forms-add-phone-input-mimicry
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Improved phone field styling to better mimic theme input styles, including focus outline and filter CSS properties

--- a/projects/packages/forms/src/blocks/contact-form/util/form-styles.js
+++ b/projects/packages/forms/src/blocks/contact-form/util/form-styles.js
@@ -152,6 +152,7 @@ window.jetpackForms.generateStyleVariables = function ( formNode ) {
 		height: inputHeight,
 		backdropFilter: inputBackdropFilter,
 		backgroundColor: inputBackground,
+		filter: inputFilter,
 	} = window.getComputedStyle( inputNode );
 
 	styleProbe.remove();
@@ -176,6 +177,7 @@ window.jetpackForms.generateStyleVariables = function ( formNode ) {
 		'--jetpack--contact-form--input-padding-top': inputPaddingTop,
 		'--jetpack--contact-form--input-padding-left': inputPaddingLeft,
 		'--jetpack--contact-form--input-height': inputHeight,
+		'--jetpack--contact-form--input-filter': inputFilter,
 		'--jetpack--contact-form--font-size': fontSize,
 		'--jetpack--contact-form--font-family': fontFamily,
 		'--jetpack--contact-form--line-height': lineHeight === 'normal' ? '1.2em' : lineHeight,

--- a/projects/packages/forms/src/blocks/input-phone/editor.scss
+++ b/projects/packages/forms/src/blocks/input-phone/editor.scss
@@ -20,9 +20,10 @@
 		background-color: var(--jetpack--contact-form--input-background);
 
 		// TODO: Doesn't work well with next version of Gutenberg, should be removed
-		&.is-selected {
+		&.is-selected,
+		&:focus-within {
 			border-color: #2271b1;
-			box-shadow: 0 0 0 1px #2271b1;
+			box-shadow: revert;
 			z-index: 1;
 		}
 
@@ -136,7 +137,8 @@
 
 	.jetpack-field__input {
 
-		&.is-selected {
+		&.is-selected,
+		&:focus-within {
 			box-shadow: unset;
 		}
 	}

--- a/projects/packages/forms/src/blocks/input-phone/editor.scss
+++ b/projects/packages/forms/src/blocks/input-phone/editor.scss
@@ -17,7 +17,7 @@
 		font-size: var(--jetpack--contact-form--font-size);
 		line-height: var(--jetpack--contact-form--line-height);
 		// defaulting to white, it's gutenberg's default background for inputs
-		background-color: var(--jetpack--contact-form--input-background, #fff);
+		background-color: var(--jetpack--contact-form--input-background);
 
 		// TODO: Doesn't work well with next version of Gutenberg, should be removed
 		&.is-selected {

--- a/projects/packages/forms/src/contact-form/css/combobox.scss
+++ b/projects/packages/forms/src/contact-form/css/combobox.scss
@@ -64,6 +64,10 @@
 				transform: scaleY(-1);
 			}
 		}
+
+		.jetpack-combobox-selected {
+			white-space: nowrap;
+		}
 	}
 
 	.jetpack-combobox-dropdown {

--- a/projects/packages/forms/src/contact-form/css/phone-field.scss
+++ b/projects/packages/forms/src/contact-form/css/phone-field.scss
@@ -20,6 +20,7 @@
 		line-height: var(--jetpack--contact-form--line-height);
 		align-items: center;
 		backdrop-filter: var(--jetpack--contact-form--input-backdrop-filter, none);
+		filter: var(--jetpack--contact-form--input-filter, none);
 
 		&:has(.jetpack-field__input-element:focus) {
 			outline-width: 2px;

--- a/projects/packages/forms/src/contact-form/css/phone-field.scss
+++ b/projects/packages/forms/src/contact-form/css/phone-field.scss
@@ -23,11 +23,8 @@
 		filter: var(--jetpack--contact-form--input-filter, none);
 
 		&:has(.jetpack-field__input-element:focus) {
-			outline-width: 2px;
+			outline-width: 1px;
 			outline-style: solid;
-			// mimics default focus outline color, this is something we cannot
-			// fully control as the probe would fail to capture :focus styles
-			outline-color: rgb(0, 95, 204);
 		}
 
 		.jetpack-field__input-prefix:not([hidden]) {


### PR DESCRIPTION
Fixes FORMS-481

## Proposed changes:

* Add `filter` CSS property to the style probe variables for better theme mimicry
* Fix phone field focus outline to use native outline styles instead of hardcoded values
* Allow transparent input backgrounds by removing the white fallback
* Add `:focus-within` selector alongside `.is-selected` for proper focus state handling in editor
* Add `white-space: nowrap` to combobox selected text to prevent wrapping

The enhancements were noticed while checking on a theme where inputs had a `filter` CSS rule by default.

### Before

Editor:
<img width="653" height="362" alt="image" src="https://github.com/user-attachments/assets/4d877db1-5ae2-49a6-81f9-4604d1e6f0c1" />


Frontend:
<img width="758" height="307" alt="image" src="https://github.com/user-attachments/assets/c80ef649-af97-4a95-9ab2-45889e314843" />


### After

Editor:
<img width="642" height="341" alt="image" src="https://github.com/user-attachments/assets/3b97b4d5-7cac-41d5-ab35-008dc8e1f4b2" />

Frontend:
<img width="769" height="308" alt="image" src="https://github.com/user-attachments/assets/286834a4-3764-49a4-8b4d-8a7b0afa305f" />


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1767032753503959-slack-C086RGTJT1D

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

1. Create a new post/page and add a Jetpack Form block
2. Add a Phone field to the form
3. In the frontend, verify that:
   - The phone field properly mimics the theme's input styles (background, borders, focus states)
   - When focusing on the phone input, the outline style matches native inputs
   - If the theme uses transparent backgrounds, the phone field should also be transparent
4. In the editor, verify that:
   - Clicking on the phone field shows proper focus/selected styling
   - The country code dropdown text doesn't wrap unexpectedly