### PR TITLE
Charts: Add Geo Chart exports to package

### DIFF
--- a/projects/js-packages/charts/changelog/charts-152-add-geo-chart-exports-to-package
+++ b/projects/js-packages/charts/changelog/charts-152-add-geo-chart-exports-to-package
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add Geo Chart exports to package

--- a/projects/js-packages/charts/package.json
+++ b/projects/js-packages/charts/package.json
@@ -42,6 +42,12 @@
 			"require": "./dist/charts/conversion-funnel-chart/index.cjs"
 		},
 		"./conversion-funnel-chart/style.css": "./dist/charts/conversion-funnel-chart/index.css",
+		"./geo-chart": {
+			"jetpack:src": "./src/charts/geo-chart/index.ts",
+			"import": "./dist/charts/geo-chart/index.js",
+			"require": "./dist/charts/geo-chart/index.cjs"
+		},
+		"./geo-chart/style.css": "./dist/charts/geo-chart/index.css",
 		"./hooks": {
 			"jetpack:src": "./src/hooks/index.ts",
 			"import": "./dist/hooks/index.js",
@@ -129,11 +135,29 @@
 			".": [
 				"./dist/index.d.ts"
 			],
-			"line-chart": [
-				"./dist/charts/line-chart/index.d.ts"
-			],
 			"bar-chart": [
 				"./dist/charts/bar-chart/index.d.ts"
+			],
+			"bar-list-chart": [
+				"./dist/charts/bar-list-chart/index.d.ts"
+			],
+			"conversion-funnel-chart": [
+				"./dist/charts/conversion-funnel-chart/index.d.ts"
+			],
+			"geo-chart": [
+				"./dist/charts/geo-chart/index.d.ts"
+			],
+			"hooks": [
+				"./dist/hooks/index.d.ts"
+			],
+			"leaderboard-chart": [
+				"./dist/charts/leaderboard-chart/index.d.ts"
+			],
+			"legend": [
+				"./dist/components/legend/index.d.ts"
+			],
+			"line-chart": [
+				"./dist/charts/line-chart/index.d.ts"
 			],
 			"pie-chart": [
 				"./dist/charts/pie-chart/index.d.ts"
@@ -141,32 +165,17 @@
 			"pie-semi-circle-chart": [
 				"./dist/charts/pie-semi-circle-chart/index.d.ts"
 			],
-			"bar-list-chart": [
-				"./dist/charts/bar-list-chart/index.d.ts"
-			],
-			"leaderboard-chart": [
-				"./dist/charts/leaderboard-chart/index.d.ts"
-			],
-			"conversion-funnel-chart": [
-				"./dist/charts/conversion-funnel-chart/index.d.ts"
-			],
-			"tooltip": [
-				"./dist/components/tooltip/index.d.ts"
-			],
-			"legend": [
-				"./dist/components/legend/index.d.ts"
+			"providers": [
+				"./dist/providers/index.d.ts"
 			],
 			"sparkline": [
 				"./dist/components/sparkline/index.d.ts"
 			],
+			"tooltip": [
+				"./dist/components/tooltip/index.d.ts"
+			],
 			"trend-indicator": [
 				"./dist/components/trend-indicator/index.d.ts"
-			],
-			"hooks": [
-				"./dist/hooks/index.d.ts"
-			],
-			"providers": [
-				"./dist/providers/index.d.ts"
 			],
 			"utils": [
 				"./dist/utils/index.d.ts"

--- a/projects/js-packages/charts/src/charts/conversion-funnel-chart/conversion-funnel-chart.tsx
+++ b/projects/js-packages/charts/src/charts/conversion-funnel-chart/conversion-funnel-chart.tsx
@@ -1,6 +1,5 @@
 import { localPoint } from '@visx/event';
 import { useTooltip, useTooltipInPortal } from '@visx/tooltip';
-import { color as d3Color } from '@visx/vendor/d3-color';
 import clsx from 'clsx';
 import { type FC, useRef, useMemo, useEffect, useCallback, useContext } from 'react';
 import { usePrefersReducedMotion } from '../../hooks';
@@ -12,7 +11,7 @@ import {
 	useGlobalChartsTheme,
 	useGlobalChartsContext,
 } from '../../providers';
-import { formatPercentage } from '../../utils';
+import { formatPercentage, hexToRgba } from '../../utils';
 import styles from './conversion-funnel-chart.module.scss';
 import { useFunnelSelection } from './private';
 import type { FunnelStep, ConversionFunnelChartProps } from './types';
@@ -226,9 +225,7 @@ const ConversionFunnelChartInternal: FC< ConversionFunnelChartProps > = ( {
 
 	// Create light background version of primary color if not set
 	const barBackgroundColor =
-		backgroundColor ||
-		d3Color( barColor )?.copy( { opacity: 0.08 } ).formatRgb() ||
-		'rgba(0, 0, 0, 0.08)';
+		backgroundColor || hexToRgba( barColor, 0.08 ) || 'rgba(0, 0, 0, 0.08)';
 
 	// Default main metric rendering function
 	const renderDefaultMainMetric = () => (

--- a/projects/js-packages/charts/src/charts/leaderboard-chart/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/charts/leaderboard-chart/stories/index.stories.tsx
@@ -1,4 +1,3 @@
-import { color as d3Color } from '@visx/vendor/d3-color';
 import { defaultTheme, useGlobalChartsContext } from '../../../providers';
 import {
 	chartDecorator,
@@ -13,7 +12,7 @@ import {
 	themeArgTypes,
 } from '../../../stories';
 import { legendArgTypes } from '../../../stories/legend-config';
-import { formatMetricValue } from '../../../utils';
+import { formatMetricValue, hexToRgba } from '../../../utils';
 import LeaderboardChart from '../leaderboard-chart';
 import type { Meta, StoryObj } from '@storybook/react';
 
@@ -335,7 +334,7 @@ const LeaderboardChartWithOverlayLabelImage = ( args: StoryArgs ) => {
 		overrideColor: args.primaryColor,
 	} );
 
-	const primaryColorWithAlpha = d3Color( primaryColor )?.copy( { opacity: 0.08 } ).formatRgb();
+	const primaryColorWithAlpha = hexToRgba( primaryColor, 0.08 );
 
 	return <LeaderboardChart { ...args } primaryColor={ primaryColorWithAlpha } />;
 };

--- a/projects/js-packages/charts/src/utils/color-utils.ts
+++ b/projects/js-packages/charts/src/utils/color-utils.ts
@@ -33,6 +33,25 @@ export const validateHexColor = ( hex: unknown ): void => {
 };
 
 /**
+ * Convert hex color to rgba with specified opacity
+ * This is genuinely reusable across chart components
+ * @param  hex   - The hex color string (e.g., '#ff0000')
+ * @param  alpha - The opacity value between 0 and 1
+ * @return The rgba color string (e.g., 'rgba(255, 0, 0, 0.5)')
+ * @throws {Error} if hex string is malformed or alpha is not a valid number
+ */
+export const hexToRgba = ( hex: string, alpha: number ): string => {
+	validateHexColor( hex );
+
+	if ( typeof alpha !== 'number' || isNaN( alpha ) ) {
+		throw new Error( 'Alpha must be a number' );
+	}
+
+	// Safe to use non-null assertion since validateHexColor ensures valid hex
+	return d3Color( hex )!.copy( { opacity: alpha } ).formatRgb();
+};
+
+/**
  * Calculate the perceptual distance between two HSL colors
  * @param hsl1 - first color in HSL format [h, s, l]
  * @param hsl2 - second color in HSL format [h, s, l]

--- a/projects/js-packages/charts/src/utils/color-utils.ts
+++ b/projects/js-packages/charts/src/utils/color-utils.ts
@@ -33,10 +33,10 @@ export const validateHexColor = ( hex: unknown ): void => {
 };
 
 /**
- * Convert hex color to rgba with specified opacity
- * This is genuinely reusable across chart components
+ * Convert hex color to rgba with specified opacity.
+ * This is genuinely reusable across chart components.
  * @param  hex   - The hex color string (e.g., '#ff0000')
- * @param  alpha - The opacity value between 0 and 1
+ * @param  alpha - The opacity value. Values outside the [0, 1] range will be clamped by the underlying d3 color library.
  * @return The rgba color string (e.g., 'rgba(255, 0, 0, 0.5)')
  * @throws {Error} if hex string is malformed or alpha is not a valid number
  */

--- a/projects/js-packages/charts/src/utils/test/color-utils.test.ts
+++ b/projects/js-packages/charts/src/utils/test/color-utils.test.ts
@@ -429,7 +429,7 @@ describe( 'hexToRgba', () => {
 				expect( () => hexToRgba( '#ff0000', NaN ) ).toThrow( 'Alpha must be a number' );
 			} );
 
-			it( 'accepts negative and greater than 1 alpha values without throwing (d3 color formatRgb() clamps them))', () => {
+			it( 'accepts negative and greater than 1 alpha values without throwing (d3 color formatRgb() clamps them)', () => {
 				// These should not throw - CSS allows alpha values outside 0-1 range
 				expect( () => hexToRgba( '#ff0000', -0.5 ) ).not.toThrow();
 				expect( () => hexToRgba( '#ff0000', 1.5 ) ).not.toThrow();

--- a/projects/js-packages/charts/src/utils/test/color-utils.test.ts
+++ b/projects/js-packages/charts/src/utils/test/color-utils.test.ts
@@ -429,7 +429,7 @@ describe( 'hexToRgba', () => {
 				expect( () => hexToRgba( '#ff0000', NaN ) ).toThrow( 'Alpha must be a number' );
 			} );
 
-			it( 'accepts negative and greater than 1 alpha values (CSS allows this)', () => {
+			it( 'accepts negative and greater than 1 alpha values without throwing (d3 color formatRgb() clamps them))', () => {
 				// These should not throw - CSS allows alpha values outside 0-1 range
 				expect( () => hexToRgba( '#ff0000', -0.5 ) ).not.toThrow();
 				expect( () => hexToRgba( '#ff0000', 1.5 ) ).not.toThrow();

--- a/projects/js-packages/charts/src/utils/test/color-utils.test.ts
+++ b/projects/js-packages/charts/src/utils/test/color-utils.test.ts
@@ -3,6 +3,7 @@ import {
 	getColorDistance,
 	lightenHexColor,
 	isValidHexColor,
+	hexToRgba,
 	validateHexColor,
 	parseHslString,
 	parseRgbString,
@@ -286,6 +287,237 @@ describe( 'getColorDistance', () => {
 			const color2: [ number, number, number ] = [ 200, 20, 70 ];
 			const distance = getColorDistance( color1, color2 );
 			expect( distance ).toBeGreaterThan( 0 );
+		} );
+	} );
+} );
+
+describe( 'hexToRgba', () => {
+	describe( 'Valid hex colors', () => {
+		it( 'converts 6-digit hex to rgb with full opacity', () => {
+			const result = hexToRgba( '#ff0000', 1 );
+			expect( result ).toBe( 'rgb(255, 0, 0)' );
+		} );
+
+		it( 'converts 6-digit hex to rgba with partial opacity', () => {
+			const result = hexToRgba( '#00ff00', 0.5 );
+			expect( result ).toBe( 'rgba(0, 255, 0, 0.5)' );
+		} );
+
+		it( 'converts 6-digit hex to rgba with zero opacity', () => {
+			const result = hexToRgba( '#0000ff', 0 );
+			expect( result ).toBe( 'rgba(0, 0, 255, 0)' );
+		} );
+
+		it( 'handles lowercase hex colors', () => {
+			const result = hexToRgba( '#abcdef', 0.8 );
+			expect( result ).toBe( 'rgba(171, 205, 239, 0.8)' );
+		} );
+
+		it( 'handles uppercase hex colors', () => {
+			const result = hexToRgba( '#ABCDEF', 0.8 );
+			expect( result ).toBe( 'rgba(171, 205, 239, 0.8)' );
+		} );
+
+		it( 'handles mixed case hex colors', () => {
+			const result = hexToRgba( '#AbCdEf', 0.3 );
+			expect( result ).toBe( 'rgba(171, 205, 239, 0.3)' );
+		} );
+	} );
+
+	describe( 'Edge cases', () => {
+		it( 'handles black color', () => {
+			const result = hexToRgba( '#000000', 1 );
+			expect( result ).toBe( 'rgb(0, 0, 0)' );
+		} );
+
+		it( 'handles white color', () => {
+			const result = hexToRgba( '#ffffff', 1 );
+			expect( result ).toBe( 'rgb(255, 255, 255)' );
+		} );
+
+		it( 'handles high precision alpha values', () => {
+			const result = hexToRgba( '#ff0000', 0.123456 );
+			expect( result ).toBe( 'rgba(255, 0, 0, 0.123456)' );
+		} );
+
+		// Function now validates hex input format
+		it( 'throws error for hex without # prefix', () => {
+			expect( () => hexToRgba( 'ff0000', 1 ) ).toThrow( 'Hex color must start with #' );
+		} );
+	} );
+
+	describe( 'Input validation', () => {
+		describe( 'Invalid hex format', () => {
+			it( 'throws error for non-string input', () => {
+				expect( () => hexToRgba( 123 as unknown as string, 1 ) ).toThrow(
+					'Hex color must be a string'
+				);
+				expect( () => hexToRgba( null as unknown as string, 1 ) ).toThrow(
+					'Hex color must be a string'
+				);
+				expect( () => hexToRgba( undefined as unknown as string, 1 ) ).toThrow(
+					'Hex color must be a string'
+				);
+			} );
+
+			it( 'throws error for hex without # prefix', () => {
+				expect( () => hexToRgba( 'ff0000', 1 ) ).toThrow( 'Hex color must start with #' );
+				expect( () => hexToRgba( '000000', 1 ) ).toThrow( 'Hex color must start with #' );
+			} );
+
+			it( 'throws error for wrong length hex strings', () => {
+				expect( () => hexToRgba( '#ff', 1 ) ).toThrow(
+					'Hex color must be 7 characters long (e.g., #ff0000)'
+				);
+				expect( () => hexToRgba( '#fff', 1 ) ).toThrow(
+					'Hex color must be 7 characters long (e.g., #ff0000)'
+				);
+				expect( () => hexToRgba( '#ffff', 1 ) ).toThrow(
+					'Hex color must be 7 characters long (e.g., #ff0000)'
+				);
+				expect( () => hexToRgba( '#fffff', 1 ) ).toThrow(
+					'Hex color must be 7 characters long (e.g., #ff0000)'
+				);
+				expect( () => hexToRgba( '#ff00000', 1 ) ).toThrow(
+					'Hex color must be 7 characters long (e.g., #ff0000)'
+				);
+				expect( () => hexToRgba( '#', 1 ) ).toThrow(
+					'Hex color must be 7 characters long (e.g., #ff0000)'
+				);
+			} );
+
+			it( 'throws error for invalid hex characters', () => {
+				expect( () => hexToRgba( '#gggggg', 1 ) ).toThrow(
+					'Hex color contains invalid characters. Only 0-9, a-f, A-F are allowed'
+				);
+				expect( () => hexToRgba( '#ff00gg', 1 ) ).toThrow(
+					'Hex color contains invalid characters. Only 0-9, a-f, A-F are allowed'
+				);
+				expect( () => hexToRgba( '#zz0000', 1 ) ).toThrow(
+					'Hex color contains invalid characters. Only 0-9, a-f, A-F are allowed'
+				);
+				expect( () => hexToRgba( '#ff@000', 1 ) ).toThrow(
+					'Hex color contains invalid characters. Only 0-9, a-f, A-F are allowed'
+				);
+				expect( () => hexToRgba( '#ff 000', 1 ) ).toThrow(
+					'Hex color contains invalid characters. Only 0-9, a-f, A-F are allowed'
+				);
+			} );
+
+			it( 'throws error for empty string', () => {
+				expect( () => hexToRgba( '', 1 ) ).toThrow( 'Hex color must start with #' );
+			} );
+		} );
+
+		describe( 'Invalid alpha values', () => {
+			it( 'throws error for non-number alpha', () => {
+				expect( () => hexToRgba( '#ff0000', 'invalid' as unknown as number ) ).toThrow(
+					'Alpha must be a number'
+				);
+				expect( () => hexToRgba( '#ff0000', null as unknown as number ) ).toThrow(
+					'Alpha must be a number'
+				);
+				expect( () => hexToRgba( '#ff0000', undefined as unknown as number ) ).toThrow(
+					'Alpha must be a number'
+				);
+				expect( () => hexToRgba( '#ff0000', {} as unknown as number ) ).toThrow(
+					'Alpha must be a number'
+				);
+			} );
+
+			it( 'throws error for NaN alpha', () => {
+				expect( () => hexToRgba( '#ff0000', NaN ) ).toThrow( 'Alpha must be a number' );
+			} );
+
+			it( 'accepts negative and greater than 1 alpha values (CSS allows this)', () => {
+				// These should not throw - CSS allows alpha values outside 0-1 range
+				expect( () => hexToRgba( '#ff0000', -0.5 ) ).not.toThrow();
+				expect( () => hexToRgba( '#ff0000', 1.5 ) ).not.toThrow();
+				expect( () => hexToRgba( '#ff0000', 2 ) ).not.toThrow();
+			} );
+		} );
+	} );
+
+	describe( 'Real-world color examples', () => {
+		it( 'converts primary blue color', () => {
+			const result = hexToRgba( '#4f46e5', 0.08 );
+			expect( result ).toBe( 'rgba(79, 70, 229, 0.08)' );
+		} );
+
+		it( 'converts success green color', () => {
+			const result = hexToRgba( '#10b981', 0.15 );
+			expect( result ).toBe( 'rgba(16, 185, 129, 0.15)' );
+		} );
+
+		it( 'converts error red color', () => {
+			const result = hexToRgba( '#ef4444', 0.2 );
+			expect( result ).toBe( 'rgba(239, 68, 68, 0.2)' );
+		} );
+
+		it( 'converts gray color', () => {
+			const result = hexToRgba( '#6b7280', 0.6 );
+			expect( result ).toBe( 'rgba(107, 114, 128, 0.6)' );
+		} );
+	} );
+
+	describe( 'Boundary alpha values', () => {
+		it( 'handles alpha value of 0', () => {
+			const result = hexToRgba( '#ff0000', 0 );
+			expect( result ).toBe( 'rgba(255, 0, 0, 0)' );
+		} );
+
+		it( 'handles alpha value of 1 (returns rgb format)', () => {
+			const result = hexToRgba( '#ff0000', 1 );
+			expect( result ).toBe( 'rgb(255, 0, 0)' );
+		} );
+
+		it( 'clamps negative alpha values to 0', () => {
+			const result = hexToRgba( '#ff0000', -0.5 );
+			expect( result ).toBe( 'rgba(255, 0, 0, 0)' );
+		} );
+
+		it( 'clamps alpha values greater than 1 (returns rgb format)', () => {
+			const result = hexToRgba( '#ff0000', 1.5 );
+			expect( result ).toBe( 'rgb(255, 0, 0)' );
+		} );
+	} );
+
+	describe( 'Color component extraction', () => {
+		it( 'correctly extracts red component', () => {
+			const result = hexToRgba( '#ff0000', 1 );
+			expect( result ).toContain( '255, 0, 0' );
+		} );
+
+		it( 'correctly extracts green component', () => {
+			const result = hexToRgba( '#00ff00', 1 );
+			expect( result ).toContain( '0, 255, 0' );
+		} );
+
+		it( 'correctly extracts blue component', () => {
+			const result = hexToRgba( '#0000ff', 1 );
+			expect( result ).toContain( '0, 0, 255' );
+		} );
+
+		it( 'correctly extracts all components for mixed color', () => {
+			const result = hexToRgba( '#8a2be2', 1 ); // BlueViolet
+			expect( result ).toBe( 'rgb(138, 43, 226)' );
+		} );
+	} );
+
+	describe( 'Typical usage patterns', () => {
+		it( 'works with common CSS background opacity', () => {
+			const result = hexToRgba( '#4f46e5', 0.08 );
+			expect( result ).toBe( 'rgba(79, 70, 229, 0.08)' );
+		} );
+
+		it( 'works with hover state opacity', () => {
+			const result = hexToRgba( '#4f46e5', 0.15 );
+			expect( result ).toBe( 'rgba(79, 70, 229, 0.15)' );
+		} );
+
+		it( 'works with disabled state opacity', () => {
+			const result = hexToRgba( '#4f46e5', 0.3 );
+			expect( result ).toBe( 'rgba(79, 70, 229, 0.3)' );
 		} );
 	} );
 } );


### PR DESCRIPTION
Fixes [CHARTS-152: Add Geo Chart exports to package](https://linear.app/a8c/issue/CHARTS-152/add-geo-chart-exports-to-package)

## Proposed changes:
* Add Geo Chart exports (`./geo-chart` and `./geo-chart/style.css`) to the charts package.json
* Add TypeScript definitions path for geo-chart in `typesVersions`
* Alphabetize the `typesVersions` entries for better maintainability

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

* Verify the `@automattic/charts` package builds successfully
* Import the geo-chart component using the new export path:
  ```js
  import { GeoChart } from '@automattic/charts';
  ```
* Confirm TypeScript types resolve correctly for the geo-chart import