### PR TITLE
Forms: Fix React console error on checkbox/radio option inputs

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-consent-checkbox-error
+++ b/projects/packages/forms/changelog/fix-forms-consent-checkbox-error
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed React console error on checkbox/radio option inputs by providing an onChange handler

--- a/projects/packages/forms/src/blocks/option/edit.js
+++ b/projects/packages/forms/src/blocks/option/edit.js
@@ -7,6 +7,8 @@ import useEnter from './use-enter.js';
 
 const SYNCED_ATTRIBUTE_KEYS = [ 'textColor', 'fontFamily', 'fontSize', 'style' ];
 
+const noop = () => {};
+
 const getLabelOrFallback = ( label, placeholder ) => {
 	if ( label === '' ) {
 		return placeholder;
@@ -68,6 +70,7 @@ const OptionEdit = ( { attributes, clientId, context, name, setAttributes } ) =>
 					<input
 						className="jetpack-field-option__checkbox"
 						checked={ !! defaultValue }
+						onChange={ noop }
 						type={ type }
 					/>
 				) }

--- a/projects/packages/forms/src/blocks/option/edit.js
+++ b/projects/packages/forms/src/blocks/option/edit.js
@@ -7,7 +7,7 @@ import useEnter from './use-enter.js';
 
 const SYNCED_ATTRIBUTE_KEYS = [ 'textColor', 'fontFamily', 'fontSize', 'style' ];
 
-const noop = () => {};
+const noop = () => undefined;
 
 const getLabelOrFallback = ( label, placeholder ) => {
 	if ( label === '' ) {


### PR DESCRIPTION
## Proposed changes:

- Fix React console error on Terms and Consent field in the block editor by providing a no-op `onChange` handler for the checkbox input


Error when changing to "checkboxed" Terms and Consent field:


https://github.com/user-attachments/assets/0c8b2831-974b-4cbf-ab98-32855e09e7b5


### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

N/A - Minor bug fix for console warning.

## Does this pull request change what data or activity we track or use?

No changes to data tracking or privacy.

## Testing instructions:

1. Go to the block editor and add a Jetpack Form block
2. Add a Terms and Consent field option to the form
3. Open the browser developer console
4. Change the field's option to "Add privacy checkbox"
5. Observe that there is no React error
6. Before this fix, that warning would appear in the console
