### PR TITLE
jetpack-mu-wpcom: Add language display names

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/code-block-add-language-renames
+++ b/projects/packages/jetpack-mu-wpcom/changelog/code-block-add-language-renames
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Add language display names

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/block-definition/block-definition.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/block-definition/block-definition.tsx
@@ -52,6 +52,29 @@ const emptyLanguageOption: LanguageOption = {
 	value: '',
 	label: plainLanguageName,
 };
+
+interface LanguageNameRewrite {
+	rewrites?: Map< string, string >;
+	( lang: string ): string;
+}
+const languageNameDisplay: LanguageNameRewrite = ( language: string ): string => {
+	if ( typeof languageNameDisplay.rewrites === 'undefined' ) {
+		try {
+			languageNameDisplay.rewrites = new Map(
+				Object.entries(
+					JSON.parse(
+						document.getElementById( 'wp-script-module-data-@a8cCodeBlock/dummy' )?.textContent
+					)?.languageNameRewrites
+				)
+			);
+		} catch {
+			languageNameDisplay.rewrites = new Map();
+		}
+	}
+
+	return languageNameDisplay.rewrites.get( language ) ?? language;
+};
+
 const selectLanguageOptions: ReadonlyArray< LanguageOption > = [];
 {
 	const langNames = new Set< string >();
@@ -63,7 +86,7 @@ const selectLanguageOptions: ReadonlyArray< LanguageOption > = [];
 	sortedLangNames.forEach( lang =>
 		( selectLanguageOptions as LanguageOption[] ).push( {
 			value: lang,
-			label: lang,
+			label: languageNameDisplay( lang ),
 		} )
 	);
 }
@@ -237,7 +260,7 @@ const blockEdit = withColors(
 						__next40pxDefaultSize
 						__nextHasNoMarginBottom
 					>
-						<option value="">{ plainLanguageName }</option>
+						<option value="">{ languageNameDisplay( plainLanguageName ) }</option>
 						<optgroup label={ __( 'Popular Languages', 'jetpack-mu-wpcom' ) }>
 							{ selectPopularLanguageOptions.map( option => (
 								<option key={ option.value } value={ option.value }>
@@ -430,7 +453,7 @@ const BlockHeader = ( props: Props ) => {
 						</button>
 					) }
 					{ props.attributes.showLanguageName ? (
-						<span>{ props.attributes.language || plainLanguageName }</span>
+						<span>{ languageNameDisplay( props.attributes.language || plainLanguageName ) }</span>
 					) : null }
 				</div>
 			) }

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/block-definition/block-definition.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/block-definition/block-definition.tsx
@@ -53,31 +53,20 @@ const emptyLanguageOption: LanguageOption = {
 	label: plainLanguageName,
 };
 
-interface LanguageNameRewrite {
-	/**
-	 * Language names for display.
-	 */
-	rewrites?: Map< string, string >;
-	( lang: string ): string;
-}
-const languageNameDisplay: LanguageNameRewrite = ( language: string ): string => {
-	if ( typeof languageNameDisplay.rewrites === 'undefined' ) {
-		try {
-			languageNameDisplay.rewrites = new Map(
-				Object.entries(
-					JSON.parse(
-						// @ts-expect-error -- This is OK in this try/catch block.
-						document.getElementById( 'wp-script-module-data-@a8cCodeBlock/dummy' )?.textContent
-					)?.languageNameRewrites
-				)
-			);
-		} catch {
-			languageNameDisplay.rewrites = new Map();
-		}
+/**
+ * Modify language names for display.
+ *
+ * @param language - Original language name.
+ * @return Display language name.
+ */
+function languageNameDisplay( language: string ): string {
+	switch ( language ) {
+		case 'Brainfuck':
+			return 'Brain****';
 	}
 
-	return languageNameDisplay.rewrites.get( language ) ?? language;
-};
+	return language;
+}
 
 const selectLanguageOptions: ReadonlyArray< LanguageOption > = [];
 {

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/block-definition/block-definition.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/block-definition/block-definition.tsx
@@ -54,6 +54,9 @@ const emptyLanguageOption: LanguageOption = {
 };
 
 interface LanguageNameRewrite {
+	/**
+	 * Language names for display.
+	 */
 	rewrites?: Map< string, string >;
 	( lang: string ): string;
 }
@@ -63,6 +66,7 @@ const languageNameDisplay: LanguageNameRewrite = ( language: string ): string =>
 			languageNameDisplay.rewrites = new Map(
 				Object.entries(
 					JSON.parse(
+						// @ts-expect-error -- This is OK in this try/catch block.
 						document.getElementById( 'wp-script-module-data-@a8cCodeBlock/dummy' )?.textContent
 					)?.languageNameRewrites
 				)

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/block-definition/block-definition.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/block-definition/block-definition.tsx
@@ -62,7 +62,7 @@ const emptyLanguageOption: LanguageOption = {
 function languageNameDisplay( language: string ): string {
 	switch ( language ) {
 		case 'Brainfuck':
-			return 'Brain****';
+			return 'Brainf***';
 	}
 
 	return language;

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/block-definition/block-definition.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/block-definition/block-definition.tsx
@@ -205,7 +205,7 @@ const blockEdit = withColors(
 						} }
 						renderToggle={ ( { isOpen, onToggle }: { isOpen: boolean; onToggle: () => void } ) => (
 							<Button onClick={ onToggle } aria-expanded={ isOpen } aria-haspopup="true">
-								{ props.attributes.language || emptyLanguageOption.label }
+								{ languageNameDisplay( props.attributes.language || emptyLanguageOption.label ) }
 							</Button>
 						) }
 						renderContent={ ( { onClose }: { onClose: () => void } ) => (

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/class-code-block.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/class-code-block.php
@@ -26,7 +26,9 @@ abstract class Code_Block {
 	 *
 	 * @var array<string, string>
 	 */
-	public static $language_name_rewrites = array();
+	public static $language_name_rewrites = array(
+		'Brainfuck' => 'Brainf***',
+	);
 
 	/**
 	 * Filterable check for whether the block should be available.
@@ -45,10 +47,6 @@ abstract class Code_Block {
 		if ( ! self::should_load_block() ) {
 			return;
 		}
-
-		self::$language_name_rewrites = array(
-			'Brainfuck' => 'Brainf***',
-		);
 
 		self::init();
 		add_action( 'init', array( __CLASS__, 'override_block_style' ) );

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/class-code-block.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/class-code-block.php
@@ -22,7 +22,7 @@ abstract class Code_Block {
 	const MODULE_PREFIX = '@a8cCodeBlock/';
 
 	/**
-	 * Language name rewrites for display.
+	 * Language names for display.
 	 *
 	 * @var array<string, string>
 	 */

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/class-code-block.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/class-code-block.php
@@ -22,6 +22,13 @@ abstract class Code_Block {
 	const MODULE_PREFIX = '@a8cCodeBlock/';
 
 	/**
+	 * Language name rewrites for display.
+	 *
+	 * @var array<string, string>
+	 */
+	public static $language_name_rewrites = array();
+
+	/**
 	 * Filterable check for whether the block should be available.
 	 *
 	 * @return bool
@@ -39,9 +46,20 @@ abstract class Code_Block {
 			return;
 		}
 
+		self::$language_name_rewrites = array(
+			'Brainfuck' => 'Brainf***',
+		);
+
 		self::init();
 		add_action( 'init', array( __CLASS__, 'override_block_style' ) );
 		add_filter( 'register_block_type_args', array( __CLASS__, 'register_block_type_args' ), 150, 2 );
+		add_filter(
+			'script_module_data_' . self::MODULE_PREFIX . 'dummy',
+			function ( array $data ): array {
+				$data['languageNameRewrites'] = Code_Block::$language_name_rewrites;
+				return $data;
+			}
+		);
 		add_action( 'enqueue_block_editor_assets', array( __CLASS__, 'enqueue_editor_assets' ) );
 		add_action(
 			'wp_enqueue_scripts',
@@ -437,6 +455,7 @@ abstract class Code_Block {
 			$language_text = empty( $attributes['language'] )
 				? __( 'Plain text', 'jetpack-mu-wpcom' )
 				: $attributes['language'];
+			$language_text = self::$language_name_rewrites[ $language_text ] ?? $language_text;
 			$language_html = \sprintf(
 				'<span>%s</span>',
 				esc_html( $language_text )

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/class-code-block.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/class-code-block.php
@@ -51,13 +51,6 @@ abstract class Code_Block {
 		self::init();
 		add_action( 'init', array( __CLASS__, 'override_block_style' ) );
 		add_filter( 'register_block_type_args', array( __CLASS__, 'register_block_type_args' ), 150, 2 );
-		add_filter(
-			'script_module_data_' . self::MODULE_PREFIX . 'dummy',
-			function ( array $data ): array {
-				$data['languageNameRewrites'] = Code_Block::$language_name_rewrites;
-				return $data;
-			}
-		);
 		add_action( 'enqueue_block_editor_assets', array( __CLASS__, 'enqueue_editor_assets' ) );
 		add_action(
 			'wp_enqueue_scripts',


### PR DESCRIPTION
## Proposed changes:

Address some feedback by adding language name display rewrites.

This allows for language names to be rewritten for display, for example a language like "Brainfuck" may be considered offensive and is rewritten for display in this PR as "Brainf***". This is one of the [listed variants on esolangs.org](https://esolangs.org/wiki/Brainfuck).

pdtkmj-42c-p2#comment-8141

### Editor

| Before | After |
|--------|--------|
| <img width="2336" height="1606" alt="Screenshot 2026-01-05 at 15 51 06" src="https://github.com/user-attachments/assets/a7fd5aeb-a5ea-473a-b7d4-bd2934b8a52e" /> | <img width="2336" height="1606" alt="Screenshot 2026-01-05 at 15 56 01" src="https://github.com/user-attachments/assets/70c60220-e736-4189-af8f-7e437b01af36" /> |

### Frontend

| Before | After |
|--------|--------|
| <img width="1338" height="1550" alt="Screenshot 2026-01-05 at 15 50 33" src="https://github.com/user-attachments/assets/e4f18eb5-70cb-4bda-82fa-be462604275c" /> | <img width="1338" height="1550" alt="Screenshot 2026-01-05 at 15 49 44" src="https://github.com/user-attachments/assets/7f36b5fa-7fcb-4f0b-ac81-99ddac08c8d4" /> | 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
pdtkmj-42c-p2#comment-8141

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
See screenshots.