### PR TITLE
Forms: Set consent block to not required when using implicit mode

### DIFF
--- a/projects/packages/forms/changelog/change-forms-terms-consent-implicit-not-required
+++ b/projects/packages/forms/changelog/change-forms-terms-consent-implicit-not-required
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Consent block: automatically set required to false when consent type is implicit

--- a/projects/packages/forms/src/blocks/contact-form/edit.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/edit.tsx
@@ -114,7 +114,7 @@ const isInputWithRequiredField = ( fullName?: string ): boolean => {
 		field?.name === 'field-consent' &&
 		// @ts-expect-error: childBlocks are defined in JS without explicit types.
 		// TS is inferring the type wrong. Fix is to update childBlocks to TS with types.
-		field?.attributes?.consentType === 'implicit';
+		field?.settings?.attributes?.consentType !== 'explicit';
 	return hasRequired && ! isHidden && ! isImplicitConsent;
 };
 

--- a/projects/packages/forms/src/blocks/contact-form/edit.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/edit.tsx
@@ -110,7 +110,12 @@ const isInputWithRequiredField = ( fullName?: string ): boolean => {
 	// TS is inferring the type wrong. Fix is to update childBlocks to TS with types.
 	const hasRequired = field && field?.settings?.attributes?.required !== undefined;
 	const isHidden = field?.name === 'field-hidden';
-	return hasRequired && ! isHidden;
+	const isImplicitConsent =
+		field?.name === 'field-consent' &&
+		// @ts-expect-error: childBlocks are defined in JS without explicit types.
+		// TS is inferring the type wrong. Fix is to update childBlocks to TS with types.
+		field?.attributes?.consentType === 'implicit';
+	return hasRequired && ! isHidden && ! isImplicitConsent;
 };
 
 type CustomThankyouType =

--- a/projects/packages/forms/src/blocks/field-consent/edit.js
+++ b/projects/packages/forms/src/blocks/field-consent/edit.js
@@ -163,7 +163,10 @@ export default function ConsentFieldEdit( props ) {
 
 	const onConsentTypeChange = useCallback(
 		value => {
-			setAttributes( { consentType: value } );
+			setAttributes( {
+				consentType: value,
+				...( value === 'implicit' ? { required: false } : {} ),
+			} );
 		},
 		[ setAttributes ]
 	);

--- a/projects/packages/forms/src/blocks/field-consent/edit.js
+++ b/projects/packages/forms/src/blocks/field-consent/edit.js
@@ -192,6 +192,17 @@ export default function ConsentFieldEdit( props ) {
 	return (
 		<>
 			<div { ...innerBlocksProps } />
+			<BlockControls __experimentalShareWithChildBlocks>
+				<ToolbarRequiredGroup
+					required={ required }
+					onClick={ () => setAttributes( { required: ! required } ) }
+					disabled={ consentType !== 'explicit' }
+					disabledTooltip={ __(
+						'Implicit consent cannot be required. Please add a privacy checkbox from the block settings to make it required.',
+						'jetpack-forms'
+					) }
+				/>
+			</BlockControls>
 			<InspectorControls>
 				<PanelBody
 					title={ __( 'Field settings', 'jetpack-forms' ) }

--- a/projects/packages/forms/src/blocks/field-consent/edit.js
+++ b/projects/packages/forms/src/blocks/field-consent/edit.js
@@ -3,6 +3,7 @@ import {
 	store as blockEditorStore,
 	useBlockProps,
 	useInnerBlocksProps,
+	BlockControls,
 } from '@wordpress/block-editor';
 import { getBlockType } from '@wordpress/blocks';
 import { BaseControl, PanelBody, SelectControl, ToggleControl } from '@wordpress/components';
@@ -11,7 +12,9 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import { useCallback, useEffect, useMemo, useRef } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import JetpackFieldWidth from '../shared/components/jetpack-field-width.js';
+import ToolbarRequiredGroup from '../shared/components/toolbar-required-group.js';
 import useFormWrapper from '../shared/hooks/use-form-wrapper.js';
+import useSyncRequiredIndicator from '../shared/hooks/use-sync-required-indicator.js';
 
 // Returns a translated placeholder based on the consent type.
 function getConsentPlaceholder( consentType ) {
@@ -24,8 +27,14 @@ function getConsentPlaceholder( consentType ) {
 
 export default function ConsentFieldEdit( props ) {
 	const { attributes, clientId, setAttributes } = props;
-	const { consentType, width, implicitConsentMessage, explicitConsentMessage, className } =
-		attributes;
+	const {
+		consentType,
+		width,
+		implicitConsentMessage,
+		explicitConsentMessage,
+		className,
+		required,
+	} = attributes;
 
 	useFormWrapper( props );
 
@@ -54,10 +63,11 @@ export default function ConsentFieldEdit( props ) {
 					placeholder: getConsentPlaceholder( 'implicit' ),
 					isStandalone: true,
 					hideInput: true,
+					required: consentType === 'explicit' ? required : false,
 				},
 			],
 		],
-		[ implicitConsentMessage ]
+		[ implicitConsentMessage, required, consentType ]
 	);
 
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {
@@ -170,6 +180,14 @@ export default function ConsentFieldEdit( props ) {
 		},
 		[ setAttributes ]
 	);
+
+	useSyncRequiredIndicator( {
+		clientId,
+		blockName: 'jetpack/field-sync',
+		isSynced: attributes?.shareFieldAttributes,
+		attributes,
+		setAttributes,
+	} );
 
 	return (
 		<>

--- a/projects/packages/forms/src/blocks/shared/components/toolbar-required-group.js
+++ b/projects/packages/forms/src/blocks/shared/components/toolbar-required-group.js
@@ -2,11 +2,12 @@ import { ToolbarGroup, ToolbarButton, Path } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import renderMaterialIcon from './render-material-icon.js';
 
-const ToolbarRequiredGroup = ( { required, onClick } ) => {
+const ToolbarRequiredGroup = ( { required, onClick, disabled = false, disabledTooltip = '' } ) => {
+	const title = disabled && disabledTooltip ? disabledTooltip : __( 'Required', 'jetpack-forms' );
 	return (
 		<ToolbarGroup>
 			<ToolbarButton
-				title={ __( 'Required', 'jetpack-forms' ) }
+				title={ title }
 				icon={ renderMaterialIcon(
 					<Path
 						d="M8.23118 8L16 16M8 16L15.7688 8 M6.5054 11.893L17.6567 11.9415M12.0585 17.6563L12 6.5"
@@ -15,6 +16,7 @@ const ToolbarRequiredGroup = ( { required, onClick } ) => {
 				) }
 				onClick={ onClick }
 				className={ required ? 'is-pressed' : undefined }
+				disabled={ disabled }
 			/>
 		</ToolbarGroup>
 	);

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -1412,6 +1412,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 		$consent_message               = 'explicit' === $consent_type ? $this->get_attribute( 'explicitconsentmessage' ) : $this->get_attribute( 'implicitconsentmessage' );
 		$label_class                   = 'grunion-field-label consent consent-' . esc_attr( $consent_type );
 		$label_class                  .= $this->option_classes ? ' ' . $this->option_classes : '';
+		$label_class                  .= $this->is_error() ? ' form-error' : '';
 		$has_inner_block_option_styles = ! empty( $this->get_attribute( 'optionstyles' ) );
 
 		$field = "<label class='" . esc_attr( $label_class ) . "' style='" . esc_attr( $this->label_styles ) . ( $has_inner_block_option_styles ? esc_attr( $this->option_styles ) : '' ) . "'>";
@@ -1419,12 +1420,12 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 		if ( 'implicit' === $consent_type ) {
 			$field .= "\t\t<input type='hidden' name='" . esc_attr( $id ) . "' value='" . esc_attr__( 'Yes', 'jetpack-forms' ) . "' /> \n";
 		} else {
-			$field .= "\t\t<input type='checkbox' name='" . esc_attr( $id ) . "' value='" . esc_attr__( 'Yes', 'jetpack-forms' ) . "' " . $class . "/> \n";
+			$field .= "\t\t<input type='checkbox' data-wp-on--change='actions.onFieldChange' name='" . esc_attr( $id ) . "' value='" . esc_attr__( 'Yes', 'jetpack-forms' ) . "' " . $class . "/> \n";
 		}
 		$field .= "\t\t" . wp_kses_post( $consent_message );
 		$field .= "</label>\n";
 		$field .= "<div class='clear-form'></div>\n";
-		return $field;
+		return $field . $this->get_error_div( $id, 'checkbox' );
 	}
 
 	/**


### PR DESCRIPTION
## Proposed changes:

- Automatically set the consent block's `required` attribute to `false` when consent type is changed to "implicit"
- Exclude implicit consent blocks from the required fields watcher in the contact form editor

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

N/A

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

* Go to the block editor and add a Form block
* Add a Consent block inside the form
* Switch the consent type to "Implicit"
* Verify the "Required" toggle is automatically set to off
* Verify the form doesn't show a validation warning about required fields for the implicit consent block
