### PR TITLE
Forms: fix response exports by date

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-responses-date-exports
+++ b/projects/packages/forms/changelog/fix-forms-responses-date-exports
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: fix date exports.

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -2980,9 +2980,10 @@ class Contact_Form_Plugin {
 		if ( ! empty( $_POST['after'] ) && ! empty( $_POST['before'] ) ) {
 			$before = strtotime( sanitize_text_field( wp_unslash( $_POST['before'] ) ) );
 			$after  = strtotime( sanitize_text_field( wp_unslash( $_POST['after'] ) ) );
-			if ( $before && $after && $before < $after ) {
-				$args['date_query']['after']  = $after;
-				$args['date_query']['before'] = $before;
+			if ( $before && $after && $after < $before ) {
+				// date_query expects date strings/arrays, not timestamps.
+				$args['date_query']['after']  = gmdate( 'Y-m-d H:i:s', $after );
+				$args['date_query']['before'] = gmdate( 'Y-m-d H:i:s', $before );
 			}
 		}
 

--- a/projects/plugins/jetpack/changelog/fix-forms-responses-date-exports
+++ b/projects/plugins/jetpack/changelog/fix-forms-responses-date-exports
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Forms: fix date exports.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes [FORMS-307](https://linear.app/a8c/issue/FORMS-307/contact-form-date-filter-is-not-applied-to-exports)

## Proposed changes:

Ensures that when responses are filtered by date, and a user exports the responses, we only export the date-filtered responses rather than all responses. We were doing the wrong before/after comparison, and using the wrong date format for the date query. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None.

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No. 

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to Jetpack > Forms
* Filter your responses by date
* Click the export button, and confirm that the exported responses match the date-filtered responses in your responses view