### PR TITLE
Boost: Fix malformed `link` tag when media attribute is missing

### DIFF
--- a/projects/plugins/boost/changelog/fix-critical-css-rel-tags-regex
+++ b/projects/plugins/boost/changelog/fix-critical-css-rel-tags-regex
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Critical CSS: Fix breaking stylesheets without media attributes.

--- a/projects/plugins/boost/tests/php/lib/critical-css/Display_Critical_CSS_Test.php
+++ b/projects/plugins/boost/tests/php/lib/critical-css/Display_Critical_CSS_Test.php
@@ -96,6 +96,9 @@ class Display_Critical_CSS_Test extends BaseTestCase {
 		$this->assertStringContainsString( 'data-media="all"', $output );
 		$this->assertStringContainsString( 'onload=', $output );
 		$this->assertStringContainsString( '<noscript>', $output );
+		// Verify HTML structure is preserved.
+		$this->assertStringContainsString( 'rel="stylesheet"', $output );
+		$this->assertStringContainsString( 'href="style.css"', $output );
 	}
 
 	/**
@@ -140,6 +143,51 @@ class Display_Critical_CSS_Test extends BaseTestCase {
 		$output = $instance->asynchronize_stylesheets( $html, 'handle', 'style.css', 'all' );
 
 		$this->assertSame( $html, $output );
+	}
+
+	/**
+	 * Test asynchronize_stylesheets() without media attribute.
+	 */
+	public function test_asynchronize_stylesheets_without_media_attribute() {
+		$html   = '<link rel="stylesheet" href="https://example.com/style.css">';
+		$output = $this->instance->asynchronize_stylesheets( $html, 'handle', 'https://example.com/style.css', 'all' );
+
+		$this->assertStringContainsString( 'media="not all"', $output );
+		$this->assertStringContainsString( 'data-media="all"', $output );
+		$this->assertStringContainsString( 'onload=', $output );
+		$this->assertStringContainsString( '<noscript>', $output );
+		// Verify HTML structure is preserved.
+		$this->assertStringContainsString( 'rel="stylesheet"', $output );
+		$this->assertStringContainsString( 'href="https://example.com/style.css"', $output );
+	}
+
+	/**
+	 * Test asynchronize_stylesheets() with full URL preserves href.
+	 */
+	public function test_asynchronize_stylesheets_preserves_full_url() {
+		$url    = 'https://example.com/wp-content/plugins/test/style.css?ver=1.0';
+		$html   = '<link rel="stylesheet" id="test-css" href="' . $url . '" type="text/css" media="all">';
+		$output = $this->instance->asynchronize_stylesheets( $html, 'test', $url, 'all' );
+
+		$this->assertStringContainsString( 'media="not all"', $output );
+		$this->assertStringContainsString( 'data-media="all"', $output );
+		// Verify all original attributes are preserved.
+		$this->assertStringContainsString( 'rel="stylesheet"', $output );
+		$this->assertStringContainsString( 'id="test-css"', $output );
+		$this->assertStringContainsString( 'href="' . $url . '"', $output );
+		$this->assertStringContainsString( 'type="text/css"', $output );
+	}
+
+	/**
+	 * Test asynchronize_stylesheets() with single-quoted attributes.
+	 */
+	public function test_asynchronize_stylesheets_single_quoted_attributes() {
+		$html   = "<link rel='stylesheet' href='style.css' media='all' />";
+		$output = $this->instance->asynchronize_stylesheets( $html, 'handle', 'style.css', 'all' );
+
+		$this->assertStringContainsString( 'media="not all"', $output );
+		$this->assertStringContainsString( 'data-media="all"', $output );
+		$this->assertStringContainsString( '<noscript>', $output );
 	}
 
 	/**


### PR DESCRIPTION
By specification, a `media` attribute defaults to `all` if it's not present in a `link` tag - https://html.spec.whatwg.org/multipage/semantics.html#processing-the-media-attribute

> The default, if the [media](https://html.spec.whatwg.org/multipage/semantics.html#attr-link-media) attribute is omitted, is "all", meaning that by default links apply to all media.

Boost didn't handle this properly and pages that didn't have a `media` attribute, ended up with an invalid `link` tag for stylesheets.

Fixes HOG-462
Related to HOG-455

## Proposed changes:

- Add support for `link` tags that don't have a `media` attribute. Code now uses the [WP HTML API](https://make.wordpress.org/core/2023/03/07/introducing-the-html-api-in-wordpress-6-2/) instead of a regex;
- Add test cases for updated code.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

n/a

## Does this pull request change what data or activity we track or use?

no

## Testing instructions:

### Automated tests

- Make sure tests pass;

### Manual tests

- Setup Boost free;
- Enable Critical CSS;
- Make sure the page loads and looks okay;
- You can also check if `link` tags are valid.

Page source:

```html

<noscript><link rel='stylesheet' id='woocommerce-smallscreen-css' href='http://jetpack-boost.test/wp-content/plugins/woocommerce/assets/css/woocommerce-smallscreen.css?ver=10.2.3' type='text/css' media='only screen and (max-width: 768px)' />
</noscript><link data-media="only screen and (max-width: 768px)" onload="this.media=this.dataset.media; delete this.dataset.media; this.removeAttribute( &apos;onload&apos; );" rel='stylesheet' id='woocommerce-smallscreen-css' href='http://jetpack-boost.test/wp-content/plugins/woocommerce/assets/css/woocommerce-smallscreen.css?ver=10.2.3' type='text/css' media="not all" />

```

DOM (after JS runs):
```html
<noscript><link rel='stylesheet' id='woocommerce-smallscreen-css' href='http://jetpack-boost.test/wp-content/plugins/woocommerce/assets/css/woocommerce-smallscreen.css?ver=10.2.3' type='text/css' media='only screen and (max-width: 768px)' />
</noscript>
<link rel="stylesheet" id="woocommerce-smallscreen-css" href="http://jetpack-boost.test/wp-content/plugins/woocommerce/assets/css/woocommerce-smallscreen.css?ver=10.2.3" type="text/css" media="only screen and (max-width: 768px)">
```