### PR TITLE
pnpm/renovate: Update configs

### DIFF
--- a/.github/files/renovate-post-upgrade.sh
+++ b/.github/files/renovate-post-upgrade.sh
@@ -44,10 +44,11 @@ fi
 
 # Do the pnpm install. Turn off some strictness settings to make it more likely this will work.
 cd "$BASE"
-echo 'strict-peer-dependencies = false' >> .npmrc
-echo 'strict-dep-builds = false' >> .npmrc
+TMP=$(< pnpm-workspace.yaml )
+pnpm config set --location project strict-peer-dependencies false
+pnpm config set --location project strict-dep-builds false
 pnpm install
-git restore .npmrc
+echo "$TMP" > pnpm-workspace.yaml
 
 # Install changelogger too.
 cd "$BASE/projects/packages/changelogger"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -30,8 +30,6 @@ minimumReleaseAgeExclude:
   - '@automattic/*'
   - '@woocommerce/*'
   - '@wordpress/*'
-  # CVE-2024-51999
-  - 'express@4.22.0'
 trustPolicy: no-downgrade
 trustPolicyExclude:
   # https://github.com/paulmillr/chokidar/issues/1440
@@ -62,6 +60,7 @@ trustPolicyExclude:
 # Package compromise avoidance: require dep build script approval.
 strictDepBuilds: true
 verifyDepsBeforeRun: install
+# TODO: When pnpm 10.26+ is the minimum, consider changing this to `allowBuilds`.
 ignoredBuiltDependencies:
   # Tries to download/install stuff if optional deps weren't installed.
   - '@swc/core'
@@ -72,6 +71,9 @@ ignoredBuiltDependencies:
   # Attempt to show "support me" spam.
   - core-js
   - print-this
+
+# Package compromise avoidance: Block odd protocols in subdeps
+blockExoticSubdeps: true
 
 # Dependencies needing patching.
 patchedDependencies:


### PR DESCRIPTION
Closes MONOREP-305

 <!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
For Renovate, we were turning off some strictness settings to make it more likely to work. Now they're in `pnpm-workspace.yaml` rather than `.npmrc`, so account for that.

For pnpm, we can also set `blockExoticSubdeps` even though CI won't use it yet, and clean up some other things.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
https://github.com/Automattic/jetpack/pull/46456#issuecomment-3715232666

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* We can try running renovate off those branch to update the other PR, see if that works.
