### PR TITLE
Update @wordpress/build for pnpm compatibility and fix Forms2 page registration

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2920,8 +2920,8 @@ importers:
         specifier: 6.36.0
         version: 6.36.0
       '@wordpress/build':
-        specifier: 0.4.1-next.6deb34194.0
-        version: 0.4.1-next.6deb34194.0(@babel/core@7.28.4)(@wordpress/boot@0.3.1-next.6deb34194.0(@types/react-dom@18.3.7(@types/react@18.3.26))(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@wordpress/route@0.2.1-next.6deb34194.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@wordpress/theme@0.3.1-next.6deb34194.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(browserslist@4.24.5)(sass-embedded@1.87.0)
+        specifier: 0.4.1-next.8fd3f8831.0
+        version: 0.4.1-next.8fd3f8831.0(@babel/core@7.28.4)(@wordpress/boot@0.3.1-next.6deb34194.0(@types/react-dom@18.3.7(@types/react@18.3.26))(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@wordpress/route@0.2.1-next.6deb34194.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@wordpress/theme@0.3.1-next.6deb34194.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(browserslist@4.24.5)(sass-embedded@1.87.0)
       '@wordpress/date':
         specifier: 5.36.0
         version: 5.36.0(patch_hash=0c63a888feb97f2f1d416ca013ad85c31b6360b41cc0b6e2b0ae28f778fbdc5b)
@@ -9817,9 +9817,6 @@ packages:
   '@types/tedious@4.0.14':
     resolution: {integrity: sha512-KHPsfX/FoVbUGbyYvk1q9MMQHLPeRZhRJZdO45Q4YjvFkv4hMNghCWTvy7rdKessBsmtz4euWCWAB6/tVpI1Iw==}
 
-  '@types/toposort@2.0.7':
-    resolution: {integrity: sha512-sQNk65vbC36+UixCkcky+dCr7MlflHcVILg1FVGqlUntsLFv9xd9ToWIVko/gTuin+cVe16t+2YubEFkhnSuPQ==}
-
   '@types/tough-cookie@4.0.5':
     resolution: {integrity: sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==}
 
@@ -10385,8 +10382,8 @@ packages:
     resolution: {integrity: sha512-EovRSDgVb8c5U+srAHK4FsU4Rt7dtYylgNxcLhbV4dmHFuHpipAvYBUkNP9DdlBYd2lMCiCNhtsnSyJXHbdvlg==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
-  '@wordpress/build@0.4.1-next.6deb34194.0':
-    resolution: {integrity: sha512-5qECpafR0nH1z3c2jZz+pMt6H7LJFG9XNxOgrfdd7z3cWdhQI/txe1P2Nitb8CVZwCkO7U191fgTMrRItCWKsw==}
+  '@wordpress/build@0.4.1-next.8fd3f8831.0':
+    resolution: {integrity: sha512-oK/dyLwCOxzG87BlkhDJEmkBVsvH4ADapejEocPxSNjzkzv1Jond5X2Jwh25NViYcUv9Y789YukUBPk6Ro+rLg==}
     engines: {node: '>=20.10.0', npm: '>=10.2.3'}
     hasBin: true
     peerDependencies:
@@ -17322,9 +17319,6 @@ packages:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
 
-  toposort@2.0.2:
-    resolution: {integrity: sha512-0a5EOkAUp8D4moMi2W8ZF8jcga7BgZd91O/yabJCFY8az+XSzeGyTKs0Aoo897iV1Nj6guFq8orWDS96z91oGg==}
-
   tough-cookie@5.1.2:
     resolution: {integrity: sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==}
     engines: {node: '>=16'}
@@ -22575,8 +22569,6 @@ snapshots:
     dependencies:
       '@types/node': 20.19.25
 
-  '@types/toposort@2.0.7': {}
-
   '@types/tough-cookie@4.0.5': {}
 
   '@types/triple-beam@1.3.5': {}
@@ -23809,10 +23801,9 @@ snapshots:
 
   '@wordpress/browserslist-config@6.36.0': {}
 
-  '@wordpress/build@0.4.1-next.6deb34194.0(@babel/core@7.28.4)(@wordpress/boot@0.3.1-next.6deb34194.0(@types/react-dom@18.3.7(@types/react@18.3.26))(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@wordpress/route@0.2.1-next.6deb34194.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@wordpress/theme@0.3.1-next.6deb34194.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(browserslist@4.24.5)(sass-embedded@1.87.0)':
+  '@wordpress/build@0.4.1-next.8fd3f8831.0(@babel/core@7.28.4)(@wordpress/boot@0.3.1-next.6deb34194.0(@types/react-dom@18.3.7(@types/react@18.3.26))(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@wordpress/route@0.2.1-next.6deb34194.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@wordpress/theme@0.3.1-next.6deb34194.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(browserslist@4.24.5)(sass-embedded@1.87.0)':
     dependencies:
       '@emotion/babel-plugin': 11.13.5
-      '@types/toposort': 2.0.7
       autoprefixer: 10.4.21(postcss@8.5.6)
       browserslist-to-esbuild: 2.1.1(browserslist@4.24.5)
       change-case: 4.1.2
@@ -23825,7 +23816,6 @@ snapshots:
       postcss: 8.5.6
       postcss-modules: 6.0.1(postcss@8.5.6)
       rtlcss: 4.3.0
-      toposort: 2.0.2
     optionalDependencies:
       '@wordpress/boot': 0.3.1-next.6deb34194.0(@types/react-dom@18.3.7(@types/react@18.3.26))(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/route': 0.2.1-next.6deb34194.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -33767,8 +33757,6 @@ snapshots:
       reserved-identifiers: 1.2.0
 
   toidentifier@1.0.1: {}
-
-  toposort@2.0.2: {}
 
   tough-cookie@5.1.2:
     dependencies:

--- a/projects/packages/forms/changelog/fix-forms2-admin-page-registration
+++ b/projects/packages/forms/changelog/fix-forms2-admin-page-registration
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed Forms2 admin page registration to use proper callback

--- a/projects/packages/forms/package.json
+++ b/projects/packages/forms/package.json
@@ -105,7 +105,7 @@
 		"@types/react-dom": "18.3.7",
 		"@wordpress/api-fetch": "7.36.0",
 		"@wordpress/browserslist-config": "6.36.0",
-		"@wordpress/build": "0.4.1-next.6deb34194.0",
+		"@wordpress/build": "0.4.1-next.8fd3f8831.0",
 		"@wordpress/date": "5.36.0",
 		"autoprefixer": "10.4.20",
 		"browserslist": "^4.24.0",

--- a/projects/packages/forms/src/dashboard/class-dashboard.php
+++ b/projects/packages/forms/src/dashboard/class-dashboard.php
@@ -170,14 +170,12 @@ class Dashboard {
 	 * Register Forms2 submenu under Jetpack menu using wp-build page.
 	 */
 	public function add_forms2_submenu() {
-		$url = admin_url( 'admin.php?page=jetpack-forms-responses-wp-admin&p=' . rawurlencode( '/responses/inbox' ) );
-
 		Admin_Menu::add_menu(
 			'Forms2',
 			'Forms2',
 			'edit_pages',
-			$url,
-			null,
+			'jetpack-forms-responses-wp-admin',
+			'jetpack_forms_responses_wp_admin_render_page',
 			11
 		);
 	}


### PR DESCRIPTION
## Summary
- Updates `@wordpress/build` to `0.4.1-next.8fd3f8831.0` which includes Riad's fix for pnpm strict hoisting compatibility
- Fixes the Forms2 admin page registration to use a proper callback instead of just a URL link

The `@wordpress/build` fix resolves an issue where externalized WordPress dependencies (like `wp-data`, `wp-notices`) were not being detected when using pnpm with strict hoisting (`hoist-pattern=[]`). See: https://github.com/WordPress/gutenberg/pull/74194

## Test plan
- [x] Verified build succeeds with `pnpm run build:wp-build`
- [x] Confirmed asset file correctly lists externalized dependencies
- [x] Tested Forms2 page loads correctly with `jetpack_forms_alpha` filter enabled