### PR TITLE
Jetpack CLI: check and update monorepo docker image automatically once a day

### DIFF
--- a/tools/docker/bin/monorepo
+++ b/tools/docker/bin/monorepo
@@ -13,7 +13,7 @@ MONOREPO_ROOT="$( cd "$SCRIPT_DIR/../../.." && pwd )"
 FORCE_PULL=0
 ARGS=()
 for arg in "$@"; do
-    if [ "$arg" = "--latest-image" ]; then
+    if [[ "$arg" = "--latest-image" ]]; then
         FORCE_PULL=1
     else
         ARGS+=("$arg")
@@ -36,15 +36,15 @@ SHOULD_PULL=0
 if ! docker image inspect jetpack-monorepo:latest >/dev/null 2>&1; then
     SHOULD_PULL=1
 # Force pull if --latest-image flag is passed
-elif [ "$FORCE_PULL" = "1" ]; then
+elif [[ "$FORCE_PULL" = "1" ]]; then
     SHOULD_PULL=1
     echo "Forcing image update due to --latest-image flag..."
 # Pull if cache file doesn't exist or is older than 24 hours (86400 seconds)
-elif [ ! -f "$CACHE_FILE" ]; then
+elif [[ ! -f "$CACHE_FILE" ]]; then
     SHOULD_PULL=1
 else
     # Check if file is older than 24 hours
-    if [ "$(uname)" = "Darwin" ]; then
+    if [[ "$(uname)" = "Darwin" ]]; then
         # macOS date command
         FILE_TIME=$(stat -f %m "$CACHE_FILE" 2>/dev/null || echo 0)
     else
@@ -54,14 +54,14 @@ else
     CURRENT_TIME=$(date +%s)
     TIME_DIFF=$((CURRENT_TIME - FILE_TIME))
 
-    if [ "$TIME_DIFF" -gt 86400 ]; then
+    if [[ "$TIME_DIFF" -gt 86400 ]]; then
         SHOULD_PULL=1
     fi
 fi
 
 # Pull or build the image if needed
-if [ "$SHOULD_PULL" = "1" ]; then
-    if [ "${BUILD_LOCAL:-}" = "1" ]; then
+if [[ "$SHOULD_PULL" = "1" ]]; then
+    if [[ "${BUILD_LOCAL:-}" = "1" ]]; then
         echo "Building monorepo image locally..."
         docker build \
             --build-arg PHP_VERSION="$PHP_VERSION" \

--- a/tools/docker/bin/monorepo
+++ b/tools/docker/bin/monorepo
@@ -9,7 +9,18 @@ fi
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 MONOREPO_ROOT="$( cd "$SCRIPT_DIR/../../.." && pwd )"
 
-echo "Running command in monorepo container: $*"
+# Parse --latest-image flag
+FORCE_PULL=0
+ARGS=()
+for arg in "$@"; do
+    if [ "$arg" = "--latest-image" ]; then
+        FORCE_PULL=1
+    else
+        ARGS+=("$arg")
+    fi
+done
+
+echo "Running command in monorepo container: ${ARGS[*]}"
 
 # Source the versions file
 source "$MONOREPO_ROOT/.github/versions.sh"
@@ -17,8 +28,39 @@ source "$MONOREPO_ROOT/.github/versions.sh"
 # Export variables needed by docker-compose
 export HOST_CWD="$MONOREPO_ROOT"
 
-# Build the image if it doesn't exist
+# Check if we should pull the latest image
+CACHE_FILE="$MONOREPO_ROOT/tools/docker/data/.monorepo-image-check"
+SHOULD_PULL=0
+
+# Always pull if image doesn't exist
 if ! docker image inspect jetpack-monorepo:latest >/dev/null 2>&1; then
+    SHOULD_PULL=1
+# Force pull if --latest-image flag is passed
+elif [ "$FORCE_PULL" = "1" ]; then
+    SHOULD_PULL=1
+    echo "Forcing image update due to --latest-image flag..."
+# Pull if cache file doesn't exist or is older than 24 hours (86400 seconds)
+elif [ ! -f "$CACHE_FILE" ]; then
+    SHOULD_PULL=1
+else
+    # Check if file is older than 24 hours
+    if [ "$(uname)" = "Darwin" ]; then
+        # macOS date command
+        FILE_TIME=$(stat -f %m "$CACHE_FILE" 2>/dev/null || echo 0)
+    else
+        # Linux date command
+        FILE_TIME=$(stat -c %Y "$CACHE_FILE" 2>/dev/null || echo 0)
+    fi
+    CURRENT_TIME=$(date +%s)
+    TIME_DIFF=$((CURRENT_TIME - FILE_TIME))
+
+    if [ "$TIME_DIFF" -gt 86400 ]; then
+        SHOULD_PULL=1
+    fi
+fi
+
+# Pull or build the image if needed
+if [ "$SHOULD_PULL" = "1" ]; then
     if [ "${BUILD_LOCAL:-}" = "1" ]; then
         echo "Building monorepo image locally..."
         docker build \
@@ -30,10 +72,14 @@ if ! docker image inspect jetpack-monorepo:latest >/dev/null 2>&1; then
             -f "$MONOREPO_ROOT/tools/docker/Dockerfile.monorepo" \
             "$MONOREPO_ROOT/tools/docker"
     else
-        echo "Pulling monorepo image..."
+        echo "Checking for latest monorepo image..."
         docker pull automattic/jetpack-monorepo:latest
         docker tag automattic/jetpack-monorepo:latest jetpack-monorepo:latest
     fi
+
+    # Update the timestamp file
+    mkdir -p "$(dirname "$CACHE_FILE")"
+    touch "$CACHE_FILE"
 fi
 
 # Run the command in the container
@@ -52,4 +98,4 @@ docker run --rm -it \
     -e PNPM_HOME=/root/.local/share/pnpm \
     -e PNPM_STORE_DIR=/root/.pnpm-store \
     jetpack-monorepo:latest \
-    "$@"
+    "${ARGS[@]}"

--- a/tools/docker/bin/monorepo
+++ b/tools/docker/bin/monorepo
@@ -9,18 +9,7 @@ fi
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 MONOREPO_ROOT="$( cd "$SCRIPT_DIR/../../.." && pwd )"
 
-# Parse --latest-image flag
-FORCE_PULL=0
-ARGS=()
-for arg in "$@"; do
-    if [[ "$arg" = "--latest-image" ]]; then
-        FORCE_PULL=1
-    else
-        ARGS+=("$arg")
-    fi
-done
-
-echo "Running command in monorepo container: ${ARGS[*]}"
+echo "Running command in monorepo container: $*"
 
 # Source the versions file
 source "$MONOREPO_ROOT/.github/versions.sh"
@@ -35,10 +24,10 @@ SHOULD_PULL=0
 # Always pull if image doesn't exist
 if ! docker image inspect jetpack-monorepo:latest >/dev/null 2>&1; then
     SHOULD_PULL=1
-# Force pull if --latest-image flag is passed
-elif [[ "$FORCE_PULL" = "1" ]]; then
+# Force pull if FORCE_PULL environment variable is set
+elif [[ "${FORCE_PULL:-}" = "1" ]]; then
     SHOULD_PULL=1
-    echo "Forcing image update due to --latest-image flag..."
+    echo "Forcing image update due to FORCE_PULL environment variable..."
 # Pull if cache file doesn't exist or is older than 24 hours (86400 seconds)
 elif [[ ! -f "$CACHE_FILE" ]]; then
     SHOULD_PULL=1
@@ -98,4 +87,4 @@ docker run --rm -it \
     -e PNPM_HOME=/root/.local/share/pnpm \
     -e PNPM_STORE_DIR=/root/.pnpm-store \
     jetpack-monorepo:latest \
-    "${ARGS[@]}"
+    "$@"


### PR DESCRIPTION
## Proposed changes:
* Add automatic daily check for updated `automattic/jetpack-monorepo:latest` Docker image
* Support `FORCE_PULL=1` environment variable to force an immediate image update check
* Cache the last check timestamp in `tools/docker/data/.monorepo-image-check` to avoid checking more than once per 24 hours

### Other information:

- [x] Have you written new tests for your changes, if applicable? (N/A - shell script change)
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)? (N/A)

## Jetpack product discussion
N/A - Internal tooling improvement

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

### Test automatic daily check:
1. Delete the cache file if it exists: `rm tools/docker/data/.monorepo-image-check`
2. Run any `jp` command: `jp --help`
3. Verify you see "Checking for latest monorepo image..." and it runs `docker pull`
4. Run `jp --help` again immediately
5. Verify it does NOT check for the image again (no pull message)
6. Check the cache file was created: `ls -la tools/docker/data/.monorepo-image-check`

### Test FORCE_PULL environment variable:
1. Run: `FORCE_PULL=1 jp install`
2. Verify you see "Forcing image update due to FORCE_PULL environment variable..." and it checks for updates
3. Verify the command still executes properly after the check

### Test 24-hour expiry:
1. Create an old cache file: `touch -t 202501010000 tools/docker/data/.monorepo-image-check`
2. Run: `jp --version`
3. Verify it checks for the latest image again (cache is > 24 hours old)