### PR TITLE
WooCommerce Analytics: Move product_purchase event to JS-side for funnel consistency

### DIFF
--- a/projects/packages/woocommerce-analytics/README.md
+++ b/projects/packages/woocommerce-analytics/README.md
@@ -99,7 +99,7 @@ When WP Consent API is not available, the package defaults to allowing all track
 | `remove_from_cart`        | Remove from cart    | ✓          | PHP (Immediate)  | When products are removed from cart                |
 | `checkout_view`           | Checkout page       | ✓          | PHP → JS Queue   | When checkout page is viewed                       |
 | `product_checkout`        | Checkout page       | ✓          | PHP → JS Queue   | When checkout page is viewed and cart is not empty |
-| `product_purchase`        | Order placed        | ✓          | PHP (Immediate)  | When purchase is completed                         |
+| `product_purchase`        | Thank you page      | ✓          | PHP → JS Queue   | When purchase is completed (fires once per order)  |
 | `order_confirmation_view` | Thank you page      | ✓          | PHP → JS Queue   | When order confirmation page is viewed             |
 | `post_account_creation`   | Account creation    | -          | PHP → JS Queue   | When new account is created during checkout        |
 

--- a/projects/packages/woocommerce-analytics/changelog/fix-product-purchase-tracking-consistency
+++ b/projects/packages/woocommerce-analytics/changelog/fix-product-purchase-tracking-consistency
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fixed
+
+Move product_purchase event to fire on thank you page (JS-side) to align with product_checkout event, ensuring consistent funnel analysis. Added duplicate prevention via order meta.

--- a/projects/packages/woocommerce-analytics/src/class-universal.php
+++ b/projects/packages/woocommerce-analytics/src/class-universal.php
@@ -393,7 +393,7 @@ class Universal {
 		}
 
 		// Mark order as tracked to prevent duplicates on page refresh.
-		$order->add_meta_data( self::PURCHASE_TRACKED_META_KEY, true );
+		$order->update_meta_data( self::PURCHASE_TRACKED_META_KEY, '1' );
 		$order->save();
 	}
 	/**

--- a/projects/packages/woocommerce-analytics/src/class-universal.php
+++ b/projects/packages/woocommerce-analytics/src/class-universal.php
@@ -21,6 +21,12 @@ class Universal {
 	use Woo_Analytics_Trait;
 
 	/**
+	 * Meta key used to track if purchase event was already recorded.
+	 * Used to prevent duplicate tracking when the thank you page is refreshed.
+	 */
+	const PURCHASE_TRACKED_META_KEY = '_woocommerce_analytics_purchase_tracked';
+
+	/**
 	 * Constructor.
 	 */
 	public function init_hooks() {
@@ -43,9 +49,9 @@ class Universal {
 		// Send events after checkout block.
 		add_action( 'woocommerce_blocks_enqueue_checkout_block_scripts_after', array( $this, 'checkout_process' ) );
 
-		// order processed.
-		add_action( 'woocommerce_checkout_order_processed', array( $this, 'order_process' ), 10, 1 );
-		add_action( 'woocommerce_store_api_checkout_order_processed', array( $this, 'order_process' ), 10, 1 );
+		// Fire purchase event on thank you page (JS side) for both shortcode and block checkout.
+		// Using order meta to prevent duplicate tracking on page refresh.
+		add_action( 'woocommerce_thankyou', array( $this, 'order_process' ), 10, 1 );
 
 		add_filter( 'woocommerce_checkout_posted_data', array( $this, 'save_checkout_post_data' ), 10, 1 );
 
@@ -287,12 +293,13 @@ class Universal {
 	}
 
 	/**
-	 * After the order processed, fire an event for each item in the order
+	 * On the thank you page, fire an event for each item in the order.
+	 * Uses order meta to prevent duplicate tracking on page refresh.
 	 *
-	 * @param string|WC_Order $order_id_or_order Order Id or Order object.
+	 * @param string|int|WC_Order $order_id_or_order Order ID or Order object.
 	 */
 	public function order_process( $order_id_or_order ) {
-		if ( is_string( $order_id_or_order ) ) {
+		if ( is_string( $order_id_or_order ) || is_int( $order_id_or_order ) ) {
 			$order = wc_get_order( $order_id_or_order );
 		} else {
 			$order = $order_id_or_order;
@@ -302,6 +309,11 @@ class Universal {
 			! $order
 			|| ! $order instanceof WC_Order
 		) {
+			return;
+		}
+
+		// Prevent duplicate tracking (e.g., when user refreshes the thank you page).
+		if ( $order->get_meta( self::PURCHASE_TRACKED_META_KEY ) ) {
 			return;
 		}
 
@@ -342,28 +354,22 @@ class Universal {
 			$checkout_page_contains_checkout_shortcode = '1';
 		}
 
-		// loop through products in the order and queue a purchase event.
-		foreach ( $order->get_items() as $order_item ) {
+		$order_items       = $order->get_items();
+		$order_items_count = is_array( $order_items ) ? count( $order_items ) : 0;
+
+		$order_coupons       = $order->get_coupons();
+		$order_coupons_count = is_array( $order_coupons ) ? count( $order_coupons ) : 0;
+
+		// Loop through products in the order and enqueue a purchase event for client-side tracking.
+		foreach ( $order_items as $order_item ) {
 			// @phan-suppress-next-line PhanUndeclaredMethod -- Checked before being called. See also https://github.com/phan/phan/issues/1204.
 			$product_id = is_callable( array( $order_item, 'get_product_id' ) ) ? $order_item->get_product_id() : -1;
 
-			$order_items       = $order->get_items();
-			$order_items_count = 0;
-			if ( is_array( $order_items ) ) {
-				$order_items_count = count( $order_items );
-			}
-			$order_coupons       = $order->get_coupons();
-			$order_coupons_count = 0;
-			if ( is_array( $order_coupons ) ) {
-				$order_coupons_count = count( $order_coupons );
-			}
-
-			WC_Analytics_Tracking::record_event(
+			$this->enqueue_event(
 				'product_purchase',
 				$this->get_cart_checkout_event_properties(
 					array(
 						'oi'                       => $order->get_order_number(),
-						'pi'                       => $product_id,
 						'pq'                       => $order_item->get_quantity(),
 						'payment_option'           => $payment_option,
 						'create_account'           => $create_account,
@@ -381,9 +387,14 @@ class Universal {
 						'checkout_page_contains_checkout_block' => $checkout_page_contains_checkout_block,
 						'checkout_page_contains_checkout_shortcode' => $checkout_page_contains_checkout_shortcode,
 					)
-				)
+				),
+				$product_id
 			);
 		}
+
+		// Mark order as tracked to prevent duplicates on page refresh.
+		$order->add_meta_data( self::PURCHASE_TRACKED_META_KEY, true );
+		$order->save();
 	}
 	/**
 	 * Gets the inner blocks of a block.


### PR DESCRIPTION
Related to WOOA7S-929

## Proposed changes:

Move the `product_purchase` event from server-side (PHP) to client-side (JS) to align with the `product_checkout` event, ensuring consistent funnel analysis.`

### Problem

The checkout funnel analysis was inaccurate because `product_checkout` and `product_purchase` events were triggered in different environments:

| Event            | Previous Location                       | Bot/Consent Check |
|------------------|----------------------------------------|-------------------|
| checkout_view.     | Client (JS) via `enqueue_event()`      | JS-side           |
| product_checkout | Client (JS) via `enqueue_event()`      | JS-side           |
| product_purchase | Server (PHP) via `record_event()`      | PHP-side          |
| order_confirmation_view | Client (JS) via `enqueue_event()` | JS-side           |

This inconsistency was introduced after PR #44973 changed `product_purchase` to fire server-side to fix duplicate event issues, causing misaligned event counts in funnel analysis.

Additionally, we currently use `woocommerce_checkout_order_processed` and `woocommerce_store_api_checkout_order_processed` hooks to fire `product_purchase` events. However, it seems that for classic checkout, it doesn't work as expected for some reason.

### Solution

Following the [Plausible WooCommerce integration approach](https://github.com/plausible/wordpress/blob/092b97b247f45bf347ae32f9614f20a81d9e10c0/src/Integrations/WooCommerce.php#L348-L367):

- Changed hook from `woocommerce_checkout_order_processed` to back `woocommerce_thankyou`
- Changed from `record_event()` to `enqueue_event()` for JS-side tracking
- Added order meta (`_woocommerce_analytics_purchase_tracked`) to prevent duplicate tracking on page refresh
- Optimized by moving `order_items_count` and `order_coupons_count` outside the loop

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

N/A

## Does this pull request change what data or activity we track or use?

No changes to what data is tracked. This PR only changes **how** the `product_purchase` event is delivered:
- Previously: Fired server-side immediately via `record_event()`
- Now: Queued server-side and fired client-side via `enqueue_event()` (same as `product_checkout`)

This ensures consistent bot detection, consent handling, and accurate funnel analysis between `product_checkout` and `product_purchase` events.

## Testing instructions:


### Pre-requisites:

1. Enable debug logging `window.localStorage.setItem('debug', '*')` in the browser console

### Test block checkout:
1. Go to a WooCommerce store with block checkout (default)
2. Add a product to the cart
3. Go to checkout and complete a purchase
4. On the thank you page, open browser console and check console logs for `wc-analytics` events
5. Verify `product_purchase` event is present with correct order data
6. Refresh the thank you page
7. Verify `product_purchase` event does NOT fire again (duplicate prevention)

### Test shortcode checkout:
1. Edit checkout page to use shortcode `[woocommerce_checkout]`
2. Add a product to cart
3. Go to checkout and complete a purchase (use Cash on Delivery for easy testing)
4. On the thank you page, open browser console and check console logs for `wc-analytics` events
5. Verify `product_purchase` event is present with correct order data
6. Refresh the thank you page
7. Verify `product_purchase` event does NOT fire again (duplicate prevention)

<img width="938" height="264" alt="Screenshot 2026-01-07 at 15 56 38" src="https://github.com/user-attachments/assets/017df44a-dbe4-48e3-8f4d-389c264a84a6" />


<img width="1131" height="448" alt="Screenshot 2026-01-07 at 16 27 34" src="https://github.com/user-attachments/assets/7a4be102-377c-4568-b64c-20b5ce826de6" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)