### PR TITLE
Newsletter Settings (1/3): Add further infra for settings page

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3268,6 +3268,18 @@ importers:
 
   projects/packages/newsletter:
     dependencies:
+      '@automattic/jetpack-api':
+        specifier: workspace:*
+        version: link:../../js-packages/api
+      '@automattic/jetpack-components':
+        specifier: workspace:*
+        version: link:../../js-packages/components
+      '@automattic/jetpack-shared-extension-utils':
+        specifier: workspace:*
+        version: link:../../js-packages/shared-extension-utils
+      '@wordpress/components':
+        specifier: 30.9.0
+        version: 30.9.0(patch_hash=2659f08edd4c0250f15fb428f013852a17e84da9c745e6dae6307de837e4d30b)(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/dataviews':
         specifier: 11.0.0
         version: 11.0.0(patch_hash=2659f08edd4c0250f15fb428f013852a17e84da9c745e6dae6307de837e4d30b)(@types/react@18.3.26)(react@18.3.1)
@@ -3277,6 +3289,12 @@ importers:
       '@wordpress/i18n':
         specifier: 6.10.0
         version: 6.10.0(patch_hash=0c63a888feb97f2f1d416ca013ad85c31b6360b41cc0b6e2b0ae28f778fbdc5b)
+      '@wordpress/notices':
+        specifier: 5.37.0
+        version: 5.37.0(patch_hash=0c63a888feb97f2f1d416ca013ad85c31b6360b41cc0b6e2b0ae28f778fbdc5b)(react@18.3.1)
+      '@wordpress/url':
+        specifier: 4.37.0
+        version: 4.37.0(patch_hash=2659f08edd4c0250f15fb428f013852a17e84da9c745e6dae6307de837e4d30b)
       debug:
         specifier: 4.4.3
         version: 4.4.3

--- a/projects/packages/newsletter/changelog/newsletter-settings-infra
+++ b/projects/packages/newsletter/changelog/newsletter-settings-infra
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Implement bits of infrastructure for newsletter settings UI.

--- a/projects/packages/newsletter/package.json
+++ b/projects/packages/newsletter/package.json
@@ -32,9 +32,15 @@
 		"extends @wordpress/browserslist-config"
 	],
 	"dependencies": {
+		"@automattic/jetpack-api": "workspace:*",
+		"@automattic/jetpack-components": "workspace:*",
+		"@automattic/jetpack-shared-extension-utils": "workspace:*",
+		"@wordpress/components": "30.9.0",
 		"@wordpress/dataviews": "11.0.0",
 		"@wordpress/element": "6.37.0",
 		"@wordpress/i18n": "6.10.0",
+		"@wordpress/notices": "5.37.0",
+		"@wordpress/url": "4.37.0",
 		"debug": "4.4.3"
 	},
 	"devDependencies": {

--- a/projects/packages/newsletter/src/class-settings.php
+++ b/projects/packages/newsletter/src/class-settings.php
@@ -9,6 +9,7 @@ namespace Automattic\Jetpack\Newsletter;
 
 use Automattic\Jetpack\Admin_UI\Admin_Menu;
 use Automattic\Jetpack\Assets;
+use Automattic\Jetpack\Modules;
 use Automattic\Jetpack\Paths;
 use Automattic\Jetpack\Status\Host;
 
@@ -52,6 +53,15 @@ class Settings {
 	}
 
 	/**
+	 * Check if the subscriptions module is active.
+	 *
+	 * @return bool
+	 */
+	private function is_subscriptions_active() {
+		return ( new Modules() )->is_active( 'subscriptions' );
+	}
+
+	/**
 	 * Subscribe to necessary hooks.
 	 */
 	public function init_hooks() {
@@ -75,17 +85,23 @@ class Settings {
 	 * Add the newsletter settings menu to the Jetpack menu.
 	 */
 	public function add_wp_admin_menu() {
-		if ( ( new Host() )->is_wpcom_platform() ) {
-			$page_suffix = add_submenu_page(
-				'jetpack',
-				/** "Newsletter" is a product name, do not translate. */
-				'Newsletter',
-				'Newsletter',
-				'manage_options',
-				'jetpack-newsletter',
-				array( $this, 'render' )
-			);
+		$is_module_active = $this->is_subscriptions_active();
+		$host             = new Host();
+
+		// Determine parent slug and menu registration method.
+		// - wpcom simple: Always show in Jetpack menu (module always active).
+		// - wpcom atomic: Show in Jetpack menu if active, hidden page if inactive.
+		// - Jetpack: Show in Jetpack menu if active, hidden page if inactive.
+		if ( $host->is_wpcom_platform() ) {
+			$parent_slug      = ( $host->is_wpcom_simple() || $is_module_active ) ? 'jetpack' : '';
+			$use_jetpack_menu = false; // Use add_submenu_page for all wpcom sites.
 		} else {
+			$parent_slug      = $is_module_active ? 'jetpack' : '';
+			$use_jetpack_menu = $is_module_active;
+		}
+
+		// Register menu item.
+		if ( $use_jetpack_menu ) {
 			$page_suffix = Admin_Menu::add_menu(
 				/** "Newsletter" is a product name, do not translate. */
 				'Newsletter',
@@ -94,6 +110,16 @@ class Settings {
 				'jetpack-newsletter',
 				array( $this, 'render' ),
 				10
+			);
+		} else {
+			$page_suffix = add_submenu_page(
+				$parent_slug,
+				/** "Newsletter" is a product name, do not translate. */
+				'Newsletter',
+				'Newsletter',
+				'manage_options',
+				'jetpack-newsletter',
+				array( $this, 'render' )
 			);
 		}
 
@@ -122,6 +148,53 @@ class Settings {
 				'textdomain' => 'jetpack-newsletter',
 				'enqueue'    => true,
 			)
+		);
+
+		wp_add_inline_script(
+			'jetpack-newsletter',
+			'window.jetpackNewsletterSettings = ' . wp_json_encode( $this->get_settings_data(), JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP ) . ';',
+			'before'
+		);
+	}
+
+	/**
+	 * Get the data to be passed to the newsletter settings page.
+	 *
+	 * @return array
+	 */
+	private function get_settings_data() {
+		$current_user = wp_get_current_user();
+		$theme        = wp_get_theme();
+
+		$site_url     = get_site_url();
+		$site_raw_url = preg_replace( '(^https?://)', '', $site_url );
+
+		$host                   = new Host();
+		$blog_id                = (int) $host->get_wpcom_site_id();
+		$is_wpcom               = $host->is_wpcom_platform();
+		$is_wpcom_simple        = $host->is_wpcom_simple();
+		$base_url               = $is_wpcom ? 'https://wordpress.com/earn/payments/' : 'https://cloud.jetpack.com/monetize/payments/';
+		$setup_payment_plan_url = $base_url . rawurlencode( $site_raw_url );
+
+		return array(
+			'isBlockTheme'                       => wp_is_block_theme(),
+			'siteAdminUrl'                       => admin_url(),
+			'themeStylesheet'                    => $theme->get_stylesheet(),
+			'blogID'                             => $blog_id,
+			'siteRawUrl'                         => $site_raw_url,
+			'email'                              => $current_user->user_email,
+			'gravatar'                           => get_avatar_url( $current_user->ID ),
+			'displayName'                        => $current_user->display_name,
+			'dateExample'                        => gmdate( get_option( 'date_format' ), time() ),
+			'wpAdminSubscriberManagementEnabled' => apply_filters( 'jetpack_wpcom_subscriber_management_enabled', false ),
+			'isSubscriptionSiteEditSupported'    => wp_is_block_theme(),
+			'setupPaymentPlansUrl'               => $setup_payment_plan_url,
+			'isSitePublic'                       => (int) get_option( 'blog_public' ) === 1,
+			'isWpcomPlatform'                    => $is_wpcom,
+			'isWpcomSimple'                      => $is_wpcom_simple,
+			'isSubscriptionsActive'              => $this->is_subscriptions_active(),
+			'restApiRoot'                        => esc_url_raw( rest_url() ),
+			'restApiNonce'                       => wp_create_nonce( 'wp_rest' ),
 		);
 	}
 

--- a/projects/packages/newsletter/src/settings/components/byline-preview.scss
+++ b/projects/packages/newsletter/src/settings/components/byline-preview.scss
@@ -1,0 +1,36 @@
+// Byline preview component
+.byline-preview {
+	display: inline-flex;
+	align-items: center;
+	flex-flow: row;
+	margin: 16px 0;
+	padding: 16px;
+	background-color: #f0f0f1;
+	border-radius: 4px;
+
+	&__label {
+		height: 24px;
+		line-height: 24px;
+		margin-right: 8px;
+		color: #1e1e1e;
+	}
+
+	&__gravatar {
+		border-radius: 50%;
+		width: 24px;
+		height: 24px;
+		margin: 0 8px 0 0;
+	}
+
+	&__author {
+		color: #1e1e1e;
+	}
+
+	&__date {
+		color: #1e1e1e;
+	}
+
+	em {
+		color: #646970;
+	}
+}

--- a/projects/packages/newsletter/src/settings/components/byline-preview.scss
+++ b/projects/packages/newsletter/src/settings/components/byline-preview.scss
@@ -11,7 +11,7 @@
 	&__label {
 		height: 24px;
 		line-height: 24px;
-		margin-right: 8px;
+		margin-inline-end: 8px;
 		color: #1e1e1e;
 	}
 
@@ -19,7 +19,7 @@
 		border-radius: 50%;
 		width: 24px;
 		height: 24px;
-		margin: 0 8px 0 0;
+		margin-inline-end: 8px;
 	}
 
 	&__author {

--- a/projects/packages/newsletter/src/settings/components/byline-preview.tsx
+++ b/projects/packages/newsletter/src/settings/components/byline-preview.tsx
@@ -88,8 +88,10 @@ export function BylinePreview( {
 				<img
 					className="byline-preview__gravatar"
 					src={ gravatar }
-					/* translators: %s is the display name of the author */
-					alt={ sprintf( __( 'Avatar for %s', 'jetpack-newsletter' ), displayName ) }
+					alt={
+						/* translators: %s is the display name of the author */
+						sprintf( __( 'Avatar for %s', 'jetpack-newsletter' ), displayName )
+					}
 				/>
 			) }
 			<span>{ byline }</span>

--- a/projects/packages/newsletter/src/settings/components/byline-preview.tsx
+++ b/projects/packages/newsletter/src/settings/components/byline-preview.tsx
@@ -65,8 +65,8 @@ export function BylinePreview( {
 				dateExample
 			),
 			{
-				Author: <strong className="byline-preview__author">{ displayName }</strong>,
-				Date: <span className="byline-preview__date">{ dateExample }</span>,
+				Author: <strong className="byline-preview__author" />,
+				Date: <span className="byline-preview__date" />,
 			}
 		);
 	} else if ( isAuthorEnabled && ! isPostDateEnabled ) {
@@ -88,7 +88,8 @@ export function BylinePreview( {
 				<img
 					className="byline-preview__gravatar"
 					src={ gravatar }
-					alt={ __( 'User’s Avatar', 'jetpack-newsletter' ) }
+					/* translators: %s is the display name of the author */
+					alt={ sprintf( __( 'Avatar for %s', 'jetpack-newsletter' ), displayName ) }
 				/>
 			) }
 			<span>{ byline }</span>

--- a/projects/packages/newsletter/src/settings/components/byline-preview.tsx
+++ b/projects/packages/newsletter/src/settings/components/byline-preview.tsx
@@ -1,0 +1,97 @@
+/**
+ * External dependencies
+ */
+import { createInterpolateElement } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import './byline-preview.scss';
+
+interface BylinePreviewProps {
+	isGravatarEnabled: boolean;
+	isAuthorEnabled: boolean;
+	isPostDateEnabled: boolean;
+	gravatar?: string;
+	displayName: string;
+	dateExample: string;
+}
+
+/**
+ * Byline Preview Component
+ *
+ * Shows a preview of how the email byline will appear based on the enabled settings.
+ *
+ * @param {BylinePreviewProps} props - Component props
+ * @return {JSX.Element} The byline preview
+ */
+export function BylinePreview( {
+	isGravatarEnabled,
+	isAuthorEnabled,
+	isPostDateEnabled,
+	gravatar,
+	displayName,
+	dateExample,
+}: BylinePreviewProps ): JSX.Element {
+	if ( ! isGravatarEnabled && ! isAuthorEnabled && ! isPostDateEnabled ) {
+		return (
+			<div className="byline-preview">
+				<span>
+					{ createInterpolateElement(
+						/* translators: <Empty /> placeholder is set to "Byline will be empty" */
+						__(
+							'<Preview>Preview:</Preview> <Empty>Byline will be empty</Empty>',
+							'jetpack-newsletter'
+						),
+						{
+							Preview: <span className="byline-preview__label" />,
+							Empty: <em />,
+						}
+					) }
+				</span>
+			</div>
+		);
+	}
+
+	let byline: JSX.Element | string = '';
+
+	if ( isAuthorEnabled && isPostDateEnabled ) {
+		byline = createInterpolateElement(
+			sprintf(
+				/* translators: %1$s placeholder is the user display name, %2$s is example date */
+				__( 'By <Author>%1$s</Author> on <Date>%2$s</Date>', 'jetpack-newsletter' ),
+				displayName,
+				dateExample
+			),
+			{
+				Author: <strong className="byline-preview__author">{ displayName }</strong>,
+				Date: <span className="byline-preview__date">{ dateExample }</span>,
+			}
+		);
+	} else if ( isAuthorEnabled && ! isPostDateEnabled ) {
+		byline = createInterpolateElement(
+			/* translators: %1$s placeholder is the user display name */
+			sprintf( __( 'By <Author>%1$s</Author>', 'jetpack-newsletter' ), displayName ),
+			{
+				Author: <strong className="byline-preview__author" />,
+			}
+		);
+	} else if ( ! isAuthorEnabled && isPostDateEnabled ) {
+		byline = <span className="byline-preview__date">{ dateExample }</span>;
+	}
+
+	return (
+		<div className="byline-preview">
+			<span className="byline-preview__label">{ __( 'Preview:', 'jetpack-newsletter' ) }</span>
+			{ isGravatarEnabled && gravatar && (
+				<img
+					className="byline-preview__gravatar"
+					src={ gravatar }
+					alt={ __( 'User’s Avatar', 'jetpack-newsletter' ) }
+				/>
+			) }
+			<span>{ byline }</span>
+		</div>
+	);
+}

--- a/projects/packages/newsletter/src/settings/components/header.scss
+++ b/projects/packages/newsletter/src/settings/components/header.scss
@@ -1,0 +1,17 @@
+.newsletter-settings__header {
+	margin-bottom: 2em;
+
+	&-top {
+		display: flex;
+		align-items: center;
+		gap: 1em;
+	}
+}
+
+.newsletter-settings__title {
+	margin: 0;
+}
+
+.newsletter-settings__tagline {
+	margin: 8px 0 0;
+}

--- a/projects/packages/newsletter/src/settings/components/header.tsx
+++ b/projects/packages/newsletter/src/settings/components/header.tsx
@@ -1,0 +1,34 @@
+/**
+ * External dependencies
+ */
+import { JetpackLogo } from '@automattic/jetpack-components';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import './header.scss';
+
+/**
+ * Newsletter Settings Header Component
+ *
+ * @return {JSX.Element} The header component.
+ */
+export function Header(): JSX.Element {
+	return (
+		<header className="newsletter-settings__header">
+			<div className="newsletter-settings__header-top">
+				<JetpackLogo showText={ false } width={ 20 } />
+				<h1 className="newsletter-settings__title">
+					{ __( 'Newsletter Settings', 'jetpack-newsletter' ) }
+				</h1>
+			</div>
+			<p className="newsletter-settings__tagline">
+				{ __(
+					'Transform your blog posts into newsletters to easily reach your subscribers.',
+					'jetpack-newsletter'
+				) }
+			</p>
+		</header>
+	);
+}

--- a/projects/packages/newsletter/src/settings/components/toggle-with-link.scss
+++ b/projects/packages/newsletter/src/settings/components/toggle-with-link.scss
@@ -1,0 +1,5 @@
+.toggle-with-link__label {
+	display: inline-flex;
+	align-items: center;
+	gap: 0.5em;
+}

--- a/projects/packages/newsletter/src/settings/components/toggle-with-link.tsx
+++ b/projects/packages/newsletter/src/settings/components/toggle-with-link.tsx
@@ -110,6 +110,7 @@ export function ToggleWithEditorLink( {
 			onChange={ onChange }
 			url={ url }
 			linkText={ __( 'Preview and edit', 'jetpack-newsletter' ) }
+			isExternal={ false }
 		/>
 	);
 }

--- a/projects/packages/newsletter/src/settings/components/toggle-with-link.tsx
+++ b/projects/packages/newsletter/src/settings/components/toggle-with-link.tsx
@@ -1,0 +1,115 @@
+/**
+ * External dependencies
+ */
+import { ExternalLink, ToggleControl } from '@wordpress/components';
+import { type Field } from '@wordpress/dataviews/wp';
+import { useCallback } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { addQueryArgs } from '@wordpress/url';
+
+/**
+ * Internal dependencies
+ */
+import './toggle-with-link.scss';
+
+interface ToggleWithLinkProps {
+	data: Record< string, unknown >;
+	field: Field< Record< string, unknown > >;
+	onChange: ( updates: Record< string, unknown > ) => void;
+	url: string;
+	linkText: string;
+	isExternal?: boolean;
+}
+
+/**
+ * Generic toggle control with a link in the label
+ *
+ * @param {object}   props            - Component props
+ * @param {object}   props.data       - The data object
+ * @param {object}   props.field      - The field definition
+ * @param {Function} props.onChange   - Change handler
+ * @param {string}   props.url        - URL for the link
+ * @param {string}   props.linkText   - Text for the link
+ * @param {boolean}  props.isExternal - Whether the link is external (default: true)
+ * @return {JSX.Element} The toggle control with link
+ */
+export function ToggleWithLink( {
+	data,
+	field,
+	onChange,
+	url,
+	linkText,
+	isExternal = true,
+}: ToggleWithLinkProps ): JSX.Element {
+	const handleChange = useCallback( () => {
+		onChange( { [ field.id ]: ! data[ field.id ] } );
+	}, [ data, field.id, onChange ] );
+
+	return (
+		<ToggleControl
+			__nextHasNoMarginBottom
+			checked={ !! data[ field.id ] }
+			onChange={ handleChange }
+			label={
+				<span className="toggle-with-link__label">
+					{ field.label }
+					{ isExternal ? (
+						<ExternalLink href={ url }>{ linkText }</ExternalLink>
+					) : (
+						<a href={ url }>{ linkText }</a>
+					) }
+				</span>
+			}
+			help={ field.description }
+		/>
+	);
+}
+
+interface ToggleWithEditorLinkProps {
+	data: Record< string, unknown >;
+	field: Field< Record< string, unknown > >;
+	onChange: ( updates: Record< string, unknown > ) => void;
+	siteAdminUrl: string;
+	themeStylesheet: string;
+	postType: 'wp_template' | 'wp_template_part';
+	templateId: string;
+}
+
+/**
+ * Toggle control with a "Preview and edit" link to the site editor
+ *
+ * @param {object}   props                 - Component props
+ * @param {object}   props.data            - The data object
+ * @param {object}   props.field           - The field definition
+ * @param {Function} props.onChange        - Change handler
+ * @param {string}   props.siteAdminUrl    - Site admin URL
+ * @param {string}   props.themeStylesheet - Theme stylesheet name
+ * @param {string}   props.postType        - Post type (wp_template or wp_template_part)
+ * @param {string}   props.templateId      - Template ID
+ * @return {JSX.Element} The toggle control with editor link
+ */
+export function ToggleWithEditorLink( {
+	data,
+	field,
+	onChange,
+	siteAdminUrl,
+	themeStylesheet,
+	postType,
+	templateId,
+}: ToggleWithEditorLinkProps ): JSX.Element {
+	const url = addQueryArgs( `${ siteAdminUrl }site-editor.php`, {
+		postType,
+		postId: `${ themeStylesheet }//${ templateId }`,
+		canvas: 'edit',
+	} );
+
+	return (
+		<ToggleWithLink
+			data={ data }
+			field={ field }
+			onChange={ onChange }
+			url={ url }
+			linkText={ __( 'Preview and edit', 'jetpack-newsletter' ) }
+		/>
+	);
+}

--- a/projects/packages/newsletter/src/settings/index.tsx
+++ b/projects/packages/newsletter/src/settings/index.tsx
@@ -45,7 +45,7 @@ function NewsletterSettingsApp(): JSX.Element | null {
 				setError( err.message || 'Failed to load settings' );
 				setIsLoading( false );
 			} );
-	}, [ jetpackSettings ] );
+	}, [ jetpackSettings?.restApiRoot, jetpackSettings?.restApiNonce ] );
 
 	if ( isLoading ) {
 		return (

--- a/projects/packages/newsletter/src/settings/index.tsx
+++ b/projects/packages/newsletter/src/settings/index.tsx
@@ -42,7 +42,7 @@ function NewsletterSettingsApp(): JSX.Element | null {
 				setIsLoading( false );
 			} )
 			.catch( ( err: Error ) => {
-				setError( err.message || 'Failed to load settings' );
+				setError( err.message || __( 'Failed to load settings', 'jetpack-newsletter' ) );
 				setIsLoading( false );
 			} );
 	}, [ jetpackSettings?.restApiRoot, jetpackSettings?.restApiNonce ] );

--- a/projects/packages/newsletter/src/settings/index.tsx
+++ b/projects/packages/newsletter/src/settings/index.tsx
@@ -1,28 +1,82 @@
 /**
  * External dependencies
  */
-import { createRoot } from '@wordpress/element';
-
+import restApi from '@automattic/jetpack-api';
+import { Notice } from '@wordpress/components';
+import { createRoot, useEffect, useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
+import { Header } from './components/header';
+import type { NewsletterSettings, JetpackNewsletterSettings } from './types';
 import './style.scss';
 
 /**
  * Newsletter Settings App
  *
- * @return {Element} The newsletter settings component.
+ * @return {JSX.Element | null} The newsletter settings component or null.
  */
-function NewsletterSettingsApp() {
+function NewsletterSettingsApp(): JSX.Element | null {
+	const [ data, setData ] = useState< NewsletterSettings | null >( null );
+	const [ isLoading, setIsLoading ] = useState( true );
+	const [ error, setError ] = useState< string | null >( null );
+
+	// Get settings from PHP
+	const jetpackSettings = (
+		window as Window & { jetpackNewsletterSettings?: JetpackNewsletterSettings }
+	 ).jetpackNewsletterSettings;
+
+	// Load settings on mount
+	useEffect( () => {
+		// Initialize the REST API with settings from PHP
+		if ( jetpackSettings?.restApiRoot && jetpackSettings?.restApiNonce ) {
+			restApi.setApiRoot( jetpackSettings.restApiRoot );
+			restApi.setApiNonce( jetpackSettings.restApiNonce );
+		}
+
+		restApi
+			.fetchSettings()
+			.then( ( settings: Record< string, unknown > ) => {
+				setData( settings as NewsletterSettings );
+				setIsLoading( false );
+			} )
+			.catch( ( err: Error ) => {
+				setError( err.message || 'Failed to load settings' );
+				setIsLoading( false );
+			} );
+	}, [ jetpackSettings ] );
+
+	if ( isLoading ) {
+		return (
+			<div className="newsletter-settings">
+				<p>{ __( 'Loading newsletter settings…', 'jetpack-newsletter' ) }</p>
+			</div>
+		);
+	}
+
+	if ( error ) {
+		return (
+			<div className="newsletter-settings newsletter-settings--error">
+				<Notice status="error" isDismissible={ false }>
+					{ error }
+				</Notice>
+			</div>
+		);
+	}
+
+	if ( ! data ) {
+		return null;
+	}
+
 	return (
 		<div className="newsletter-settings">
-			<h1>Newsletter Settings</h1>
-			<p>This is a proof of concept, I am rendered via React.</p>
+			<Header />
+			{ /* Settings sections will be added in subsequent PRs */ }
 		</div>
 	);
 }
 
-// Initialize the app when DOM is ready
 const container = document.getElementById( 'newsletter-settings-root' );
 if ( container ) {
 	const root = createRoot( container );

--- a/projects/packages/newsletter/src/settings/style.scss
+++ b/projects/packages/newsletter/src/settings/style.scss
@@ -36,8 +36,8 @@
 				content: "";
 				position: absolute;
 				top: 0;
-				left: 0;
-				right: 0;
+				inset-inline-start: 0;
+				inset-inline-end: 0;
 				bottom: 0;
 				background: rgba(255, 255, 255, 0.6);
 				pointer-events: none;
@@ -75,7 +75,6 @@
 			color: #646970;
 		}
 	}
-
 
 	// Notice component styling
 	.components-notice {

--- a/projects/packages/newsletter/src/settings/style.scss
+++ b/projects/packages/newsletter/src/settings/style.scss
@@ -1,8 +1,84 @@
 .newsletter-settings {
-	padding: 20px;
+	max-width: 1200px;
+	margin: 0 auto;
+	padding: 0;
 
-	h1 {
-		font-size: 24px;
-		margin-bottom: 16px;
+	// Card-based sections
+	&__section {
+		background: #fff;
+		border: 1px solid #c3c4c7;
+		box-shadow: 0 1px 1px rgba(0, 0, 0, 0.04);
+		margin-bottom: 20px;
+		padding: 1.5em;
+	}
+
+	&__section-title {
+		margin: 0;
+		padding: 0;
+	}
+
+	&__section-description {
+		margin: 0;
+		padding: 0;
+		text-wrap: pretty;
+	}
+
+	&__section-content {
+		padding-top: 1em;
+
+		// Disabled state styling
+		&:disabled {
+			opacity: 0.5;
+			pointer-events: none;
+			position: relative;
+
+			&::after {
+				content: "";
+				position: absolute;
+				top: 0;
+				left: 0;
+				right: 0;
+				bottom: 0;
+				background: rgba(255, 255, 255, 0.6);
+				pointer-events: none;
+			}
+		}
+	}
+
+	&__section-actions {
+		margin-top: 2em;
+		display: flex;
+		justify-content: flex-start;
+	}
+
+	// Links styling
+	&__link {
+		margin-top: 2em;
+	}
+
+	// Help text with links
+	&__help-text {
+		margin-top: 12px;
+		font-size: 13px;
+	}
+
+	&--error {
+		padding: 20px;
+
+		h2 {
+			color: #d63638;
+			font-size: 18px;
+			margin-bottom: 12px;
+		}
+
+		p {
+			color: #646970;
+		}
+	}
+
+
+	// Notice component styling
+	.components-notice {
+		margin: 0 0 20px;
 	}
 }

--- a/projects/packages/newsletter/src/settings/types.ts
+++ b/projects/packages/newsletter/src/settings/types.ts
@@ -1,0 +1,65 @@
+/**
+ * Type definitions for newsletter settings
+ */
+
+/**
+ * Type definitions for newsletter settings data
+ */
+export interface NewsletterSettings {
+	subscriptions: boolean;
+	stb_enabled: boolean;
+	stc_enabled: boolean;
+	sm_enabled: boolean;
+	jetpack_subscribe_overlay_enabled: boolean;
+	jetpack_subscribe_floating_button_enabled: boolean;
+	jetpack_subscriptions_subscribe_post_end_enabled: boolean;
+	jetpack_subscriptions_login_navigation_enabled: boolean;
+	jetpack_subscriptions_subscribe_navigation_enabled: boolean;
+	wpcom_featured_image_in_email: boolean;
+	wpcom_subscription_emails_use_excerpt: boolean;
+	jetpack_gravatar_in_email: boolean;
+	jetpack_author_in_email: boolean;
+	jetpack_post_date_in_email: boolean;
+	jetpack_subscriptions_reply_to: 'comment' | 'author' | 'no-reply';
+	jetpack_subscriptions_from_name: string;
+	wpcom_newsletter_categories_enabled: boolean;
+	wpcom_newsletter_categories: string[];
+	subscription_options?: {
+		invitation: string;
+		welcome: string;
+		comment_follow: string;
+	};
+	[ key: string ]: unknown;
+}
+
+/**
+ * Type definitions for Jetpack Newsletter settings passed from PHP
+ */
+export interface JetpackNewsletterSettings {
+	isBlockTheme: boolean;
+	siteAdminUrl: string;
+	themeStylesheet: string;
+	blogID: number;
+	siteRawUrl: string;
+	email: string;
+	gravatar: string;
+	displayName: string;
+	dateExample: string;
+	wpAdminSubscriberManagementEnabled: boolean;
+	isSubscriptionSiteEditSupported: boolean;
+	setupPaymentPlansUrl: string;
+	isSitePublic: boolean;
+	isWpcomPlatform: boolean;
+	isWpcomSimple: boolean;
+	isSubscriptionsActive: boolean;
+	restApiRoot: string;
+	restApiNonce: string;
+}
+
+/**
+ * Type definition for WordPress category
+ */
+export interface WordPressCategory {
+	id: string;
+	name: string;
+}

--- a/projects/packages/newsletter/src/settings/utils.ts
+++ b/projects/packages/newsletter/src/settings/utils.ts
@@ -1,0 +1,26 @@
+/**
+ * Utility functions for newsletter settings
+ */
+import type { JetpackNewsletterSettings } from './types';
+
+/**
+ * Helper function to get "Manage all subscribers" URL
+ *
+ * @param {JetpackNewsletterSettings | undefined} jetpackSettings - Settings passed from PHP
+ * @return {string} URL to manage subscribers
+ */
+export function getManageSubscribersUrl(
+	jetpackSettings: JetpackNewsletterSettings | undefined
+): string {
+	if ( ! jetpackSettings ) {
+		return '#';
+	}
+
+	if ( jetpackSettings.wpAdminSubscriberManagementEnabled ) {
+		return `${ jetpackSettings.siteAdminUrl }admin.php?page=subscribers`;
+	}
+
+	// Fallback to WordPress.com URL (prefer siteRawUrl, fallback to blogID)
+	const site = jetpackSettings.siteRawUrl || jetpackSettings.blogID;
+	return `https://wordpress.com/subscribers/${ site }`;
+}

--- a/projects/packages/newsletter/webpack.config.js
+++ b/projects/packages/newsletter/webpack.config.js
@@ -68,6 +68,17 @@ export default {
 			// Transpile JavaScript and TypeScript
 			jetpackWebpackConfig.TranspileRule( {
 				exclude: /node_modules\//,
+				babelOpts: {
+					configFile: false,
+					plugins: [
+						[
+							require.resolve( '@automattic/babel-plugin-replace-textdomain' ),
+							{
+								textdomain: 'jetpack-newsletter',
+							},
+						],
+					],
+				},
 			} ),
 
 			// Transpile @automattic/* in node_modules too.

--- a/projects/plugins/jetpack/changelog/jetpack-newsletter-wip
+++ b/projects/plugins/jetpack/changelog/jetpack-newsletter-wip
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Newsletter: Work on new UI, not available yet.

--- a/projects/plugins/jetpack/load-jetpack.php
+++ b/projects/plugins/jetpack/load-jetpack.php
@@ -61,6 +61,9 @@ require_once JETPACK__PLUGIN_DIR . '_inc/lib/class-jetpack-recommendations.php';
 if ( is_admin() ) {
 	require_once JETPACK__PLUGIN_DIR . 'class.jetpack-admin.php';
 	require_once JETPACK__PLUGIN_DIR . '_inc/lib/debugger.php';
+
+	// Initialize Newsletter Settings (always-loaded so the settings page URL works even when module is inactive).
+	\Automattic\Jetpack\Newsletter\Settings::init();
 }
 
 // Play nice with https://wp-cli.org/.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This is part of solving DOTCOM-15286 and has been split out from the original PR (#46136) in the hope it makes the changes easier to review. It is the first of three PRs.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

Adds further components and infrastructure that will be used on the new newsletter settings screen. It has no user-visible changes yet.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

 1. Make add_filter( 'jetpack_wp_admin_newsletter_settings_enabled', '__return_true' ); run early, e.g. by adding it to a new mu-plugin or just by pasting it into the top of jetpack-dev/jetpack.php using the plugin file editor on a jurassic ninja site.
 2. Enable the newsletter module if it isn't already
 3. Navigate to Jetpack → Newsletter in WordPress admin
 4. Note that there are no errors, and nothing really in-place on the screen except a holding message.

  #### Platform-Specific Behavior

  **wpcom Simple Sites:**
  - Verify Newsletter menu item is always visible in Jetpack menu (cannot be hidden)
  - Verify nothing else has changed (will be a separate PR)

  **wpcom Atomic (WoA) Sites:**
  - With module **active**: Verify Newsletter menu item appears in Jetpack menu
  - With module **inactive**: Verify Newsletter menu item is hidden, but direct URL (`/wp-admin/admin.php?page=jetpack-newsletter`)
  still works

  **Jetpack Sites:**
  - With module **active**: Verify Newsletter menu item appears in Jetpack menu
  - With module **inactive**: Verify Newsletter menu item is hidden, but direct URL still works
