### PR TITLE
Update/feature gating for donations v2

### DIFF
--- a/projects/plugins/wpcomsh/changelog/update-feature-gating-for-donations-v2
+++ b/projects/plugins/wpcomsh/changelog/update-feature-gating-for-donations-v2
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Update the feature gating for Donations, allowing conditional hiding based on a sticker

--- a/projects/plugins/wpcomsh/wpcom-features/class-wpcom-features.php
+++ b/projects/plugins/wpcomsh/wpcom-features/class-wpcom-features.php
@@ -731,7 +731,15 @@ class WPCOM_Features {
 			self::WOO_HOSTED_PLANS,
 		),
 		self::DONATIONS                         => array(
-			self::WPCOM_ALL_SITES,
+			array(
+				'sticker_not_present' => 'gating-business-q1',
+				self::WPCOM_ALL_SITES,
+			),
+			array(
+				'sticker_not_present' => 'gating-business-q1',
+				self::WPCOM_PERSONAL_AND_HIGHER_PLANS,
+			),
+			self::WPCOM_PREMIUM_AND_HIGHER_PLANS,
 			self::JETPACK_ALL_SITES,
 		),
 		// ECOMMERCE_MANAGED_PLUGINS - Can install the plugin bundle that comes with eCommerce plans.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Part of DOTCOM-15586

## Proposed changes:

* Add feature gating for Donations

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:

Copy to a sandbox and use wpsh with a Free site

```
echo wpcom_site_has_feature( WPCOM_Features::DONATIONS, 247144906 ); // 1
add_blog_sticker( 'gating-business-q1', null, null, 247144906 );  
echo wpcom_site_has_feature( WPCOM_Features::DONATIONS, 247144906 ); // 0
```

The blog won't change because it doesn't do a feature check.

Notes:
- It's easier to test with two separate dev blogs, one with, and one without the sticker
- The donations sticker_not_present definition looks a bit funny. That's because WPCOM_ALL_SITES wouldn't work on Atomic sites - nobody expected Free Atomic sites, and fixing it is out of scope. The issue is that $blog->registered is checked, which exists in WPCOM context.