### PR TITLE
Newsletters Settings (3/4): Add more settings

### DIFF
--- a/projects/packages/newsletter/changelog/more-newsletter-settings
+++ b/projects/packages/newsletter/changelog/more-newsletter-settings
@@ -1,4 +1,4 @@
 Significance: patch
 Type: added
 
-Added settings sections: subscribe, paid newsletter, and welcome message.
+Add settings sections: subscriptions, paid newsletter, and welcome message.

--- a/projects/packages/newsletter/changelog/more-newsletter-settings
+++ b/projects/packages/newsletter/changelog/more-newsletter-settings
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Added settings sections: subscribe, paid newsletter, and welcome message.

--- a/projects/packages/newsletter/src/class-settings.php
+++ b/projects/packages/newsletter/src/class-settings.php
@@ -207,8 +207,7 @@ class Settings {
 		$blog_id                = (int) $host->get_wpcom_site_id();
 		$is_wpcom               = $host->is_wpcom_platform();
 		$is_wpcom_simple        = $host->is_wpcom_simple();
-		$base_url               = $is_wpcom ? 'https://wordpress.com/earn/payments/' : 'https://cloud.jetpack.com/monetize/payments/';
-		$setup_payment_plan_url = $base_url . rawurlencode( $site_raw_url );
+		$setup_payment_plan_url = ( $is_wpcom_simple ? 'https://wordpress.com/earn/payments/' : 'https://cloud.jetpack.com/monetize/payments/' ) . rawurlencode( $site_raw_url );
 
 		$wp_admin_subscriber_management_enabled = apply_filters( 'jetpack_wp_admin_subscriber_management_enabled', false );
 
@@ -217,7 +216,6 @@ class Settings {
 			'siteAdminUrl'                    => admin_url(),
 			'themeStylesheet'                 => $theme->get_stylesheet(),
 			'blogID'                          => $blog_id,
-			'siteRawUrl'                      => $site_raw_url,
 			'email'                           => $current_user->user_email,
 			'gravatar'                        => get_avatar_url( $current_user->ID ),
 			'displayName'                     => $current_user->display_name,
@@ -228,7 +226,6 @@ class Settings {
 			'isSitePublic'                    => (int) get_option( 'blog_public' ) === 1,
 			'isWpcomPlatform'                 => $is_wpcom,
 			'isWpcomSimple'                   => $is_wpcom_simple,
-			'isSubscriptionsActive'           => $this->is_subscriptions_active(),
 			'restApiRoot'                     => esc_url_raw( rest_url() ),
 			'restApiNonce'                    => wp_create_nonce( 'wp_rest' ),
 			'siteName'                        => get_bloginfo( 'name' ),

--- a/projects/packages/newsletter/src/settings/index.tsx
+++ b/projects/packages/newsletter/src/settings/index.tsx
@@ -10,14 +10,33 @@ import { __ } from '@wordpress/i18n';
  */
 import { Header } from './components/header';
 import {
-	EmailBylineSection,
 	EmailContentSection,
-	EmailReplyToSettingsSection,
+	EmailBylineSection,
 	EmailSenderSettingsSection,
+	EmailReplyToSettingsSection,
 	NewsletterSection,
+	PaidNewsletterSection,
+	SubscriptionsSection,
+	WelcomeEmailSection,
 } from './sections';
 import type { NewsletterSettings, JetpackNewsletterSettings } from './types';
 import './style.scss';
+
+/**
+ * Normalize settings from API response
+ *
+ * @param {Record<string, unknown>} settings - Raw settings from API
+ * @return {NewsletterSettings} Normalized settings
+ */
+function normalizeSettings( settings: Record< string, unknown > ): NewsletterSettings {
+	return {
+		...( settings as NewsletterSettings ),
+		// Ensure wpcom_subscription_emails_use_excerpt is a string ('0' or '1')
+		wpcom_subscription_emails_use_excerpt: String(
+			Number( settings.wpcom_subscription_emails_use_excerpt ) || 0
+		),
+	};
+}
 
 /**
  * Newsletter Settings App
@@ -29,6 +48,12 @@ function NewsletterSettingsApp(): JSX.Element | null {
 	const [ isLoading, setIsLoading ] = useState( true );
 	const [ error, setError ] = useState< string | null >( null );
 
+	// Subscription settings state (for manual save)
+	const [ subscriptionChanges, setSubscriptionChanges ] = useState< Partial< NewsletterSettings > >(
+		{}
+	);
+	const [ isSavingSubscriptions, setIsSavingSubscriptions ] = useState( false );
+
 	// Sender name state (for manual save)
 	const [ senderNameChanges, setSenderNameChanges ] = useState< Partial< NewsletterSettings > >(
 		{}
@@ -37,6 +62,12 @@ function NewsletterSettingsApp(): JSX.Element | null {
 
 	// Snackbar notification state
 	const [ snackbarMessage, setSnackbarMessage ] = useState< string | null >( null );
+
+	// Welcome email state (for manual save)
+	const [ welcomeEmailChanges, setWelcomeEmailChanges ] = useState< Partial< NewsletterSettings > >(
+		{}
+	);
+	const [ isSavingWelcomeEmail, setIsSavingWelcomeEmail ] = useState( false );
 
 	// Get settings from PHP
 	const jetpackSettings = (
@@ -57,15 +88,7 @@ function NewsletterSettingsApp(): JSX.Element | null {
 		restApi
 			.fetchSettings()
 			.then( ( settings: Record< string, unknown > ) => {
-				// Normalize settings types for frontend use
-				const normalizedSettings: NewsletterSettings = {
-					...( settings as NewsletterSettings ),
-					// Ensure wpcom_subscription_emails_use_excerpt is a string ('0' or '1')
-					wpcom_subscription_emails_use_excerpt: String(
-						Number( settings.wpcom_subscription_emails_use_excerpt ) || 0
-					),
-				};
-				setData( normalizedSettings );
+				setData( normalizeSettings( settings ) );
 				setIsLoading( false );
 			} )
 			.catch( ( err: Error ) => {
@@ -84,7 +107,7 @@ function NewsletterSettingsApp(): JSX.Element | null {
 			}
 
 			// Update local state optimistically
-			setData( { ...data, ...updates } );
+			setData( prev => ( { ...prev, ...updates } ) );
 
 			// Save to backend
 			restApi
@@ -137,6 +160,78 @@ function NewsletterSettingsApp(): JSX.Element | null {
 			} );
 	}, [ senderNameChanges, data ] );
 
+	// Handle subscription settings changes (staged, not auto-saved)
+	const handleSubscriptionChange = useCallback( ( updates: Partial< NewsletterSettings > ) => {
+		// Update local state immediately (like auto-save)
+		setData( prev => ( { ...prev, ...updates } ) );
+		// Track changes for save button state
+		setSubscriptionChanges( prev => ( { ...prev, ...updates } ) );
+	}, [] );
+
+	// Save subscription settings
+	const saveSubscriptionSettings = useCallback( () => {
+		if ( ! data ) {
+			return;
+		}
+
+		setIsSavingSubscriptions( true );
+		setError( null );
+
+		restApi
+			.updateSettings( subscriptionChanges )
+			.then( () => {
+				setError( null );
+				setSubscriptionChanges( {} );
+				setSnackbarMessage( __( 'Settings saved', 'jetpack-newsletter' ) );
+			} )
+			.catch( ( err: Error ) => {
+				// eslint-disable-next-line no-console
+				console.error( 'Newsletter subscription settings save error:', err );
+				setError(
+					err.message || __( 'Failed to save subscription settings', 'jetpack-newsletter' )
+				);
+			} )
+			.finally( () => {
+				setIsSavingSubscriptions( false );
+			} );
+	}, [ subscriptionChanges, data ] );
+
+	// Handle welcome email changes (staged, not auto-saved)
+	const handleWelcomeEmailChange = useCallback( ( updates: Partial< NewsletterSettings > ) => {
+		// Update local state immediately (like auto-save)
+		setData( prev => ( { ...prev, ...updates } ) );
+		// Track changes for save button state
+		setWelcomeEmailChanges( prev => ( { ...prev, ...updates } ) );
+	}, [] );
+
+	// Save welcome email settings
+	const saveWelcomeEmail = useCallback( () => {
+		if ( ! data ) {
+			return;
+		}
+
+		setIsSavingWelcomeEmail( true );
+		setError( null );
+
+		restApi
+			.updateSettings( welcomeEmailChanges )
+			.then( () => {
+				setError( null );
+				setWelcomeEmailChanges( {} );
+				setSnackbarMessage( __( 'Welcome email message saved', 'jetpack-newsletter' ) );
+			} )
+			.catch( ( err: Error ) => {
+				// eslint-disable-next-line no-console
+				console.error( 'Newsletter welcome email save error:', err );
+				setError(
+					err.message || __( 'Failed to save welcome email message', 'jetpack-newsletter' )
+				);
+			} )
+			.finally( () => {
+				setIsSavingWelcomeEmail( false );
+			} );
+	}, [ welcomeEmailChanges, data ] );
+
 	if ( isLoading ) {
 		return (
 			<div className="newsletter-settings">
@@ -159,7 +254,9 @@ function NewsletterSettingsApp(): JSX.Element | null {
 		return null;
 	}
 
+	const hasSubscriptionChanges = Object.keys( subscriptionChanges ).length > 0;
 	const hasSenderNameChanges = Object.keys( senderNameChanges ).length > 0;
+	const hasWelcomeEmailChanges = Object.keys( welcomeEmailChanges ).length > 0;
 
 	return (
 		<div className="newsletter-settings">
@@ -172,6 +269,21 @@ function NewsletterSettingsApp(): JSX.Element | null {
 					onChange={ handleAutoSave }
 				/>
 			) }
+
+			<SubscriptionsSection
+				data={ data }
+				jetpackSettings={ jetpackSettings }
+				onChange={ handleSubscriptionChange }
+				onSave={ saveSubscriptionSettings }
+				isSaving={ isSavingSubscriptions }
+				hasChanges={ hasSubscriptionChanges }
+				isNewsletterEnabled={ data.subscriptions }
+			/>
+
+			<PaidNewsletterSection
+				jetpackSettings={ jetpackSettings }
+				isNewsletterEnabled={ data.subscriptions }
+			/>
 
 			<EmailContentSection
 				data={ data }
@@ -200,6 +312,15 @@ function NewsletterSettingsApp(): JSX.Element | null {
 			<EmailReplyToSettingsSection
 				data={ data }
 				onChange={ handleAutoSave }
+				isNewsletterEnabled={ data.subscriptions }
+			/>
+
+			<WelcomeEmailSection
+				data={ data }
+				onChange={ handleWelcomeEmailChange }
+				onSave={ saveWelcomeEmail }
+				isSaving={ isSavingWelcomeEmail }
+				hasChanges={ hasWelcomeEmailChanges }
 				isNewsletterEnabled={ data.subscriptions }
 			/>
 

--- a/projects/packages/newsletter/src/settings/sections/index.ts
+++ b/projects/packages/newsletter/src/settings/sections/index.ts
@@ -1,5 +1,11 @@
-export { EmailBylineSection } from './email-byline-section';
+/**
+ * Export all section components
+ */
 export { EmailContentSection } from './email-content-section';
-export { EmailReplyToSettingsSection } from './email-reply-to-settings-section';
+export { EmailBylineSection } from './email-byline-section';
 export { EmailSenderSettingsSection } from './email-sender-settings-section';
+export { EmailReplyToSettingsSection } from './email-reply-to-settings-section';
 export { NewsletterSection } from './newsletter-section';
+export { PaidNewsletterSection } from './paid-newsletter-section';
+export { SubscriptionsSection } from './subscriptions-section';
+export { WelcomeEmailSection } from './welcome-email-section';

--- a/projects/packages/newsletter/src/settings/sections/paid-newsletter-section.tsx
+++ b/projects/packages/newsletter/src/settings/sections/paid-newsletter-section.tsx
@@ -1,0 +1,54 @@
+/**
+ * External dependencies
+ */
+import { Button } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+/**
+ * Internal dependencies
+ */
+import type { JetpackNewsletterSettings } from '../types';
+
+interface PaidNewsletterSectionProps {
+	jetpackSettings: JetpackNewsletterSettings | undefined;
+	isNewsletterEnabled: boolean;
+}
+
+/**
+ * Paid Newsletter Section Component
+ *
+ * @param {PaidNewsletterSectionProps} props - Component props
+ * @return {JSX.Element | null} The paid newsletter section or null if URL not available
+ */
+export function PaidNewsletterSection( {
+	jetpackSettings,
+	isNewsletterEnabled,
+}: PaidNewsletterSectionProps ): JSX.Element | null {
+	if ( ! jetpackSettings?.setupPaymentPlansUrl ) {
+		return null;
+	}
+
+	return (
+		<div className="newsletter-settings__section">
+			<h3 className="newsletter-settings__section-title">
+				{ __( 'Paid newsletter', 'jetpack-newsletter' ) }
+			</h3>
+			<p className="newsletter-settings__section-description">
+				{ __(
+					'Earn money through your Newsletter. Reward your most loyal subscribers with exclusive content or add a paywall to monetize content.',
+					'jetpack-newsletter'
+				) }
+			</p>
+			<fieldset className="newsletter-settings__section-content" disabled={ ! isNewsletterEnabled }>
+				<Button
+					variant="primary"
+					href={ jetpackSettings.setupPaymentPlansUrl }
+					target="_blank"
+					rel="noopener noreferrer"
+					disabled={ ! isNewsletterEnabled }
+				>
+					{ __( 'Add Plans', 'jetpack-newsletter' ) }
+				</Button>
+			</fieldset>
+		</div>
+	);
+}

--- a/projects/packages/newsletter/src/settings/sections/subscriptions-section.tsx
+++ b/projects/packages/newsletter/src/settings/sections/subscriptions-section.tsx
@@ -1,0 +1,293 @@
+/**
+ * External dependencies
+ */
+import { Button } from '@wordpress/components';
+import { DataForm, type Field } from '@wordpress/dataviews/wp';
+import { __ } from '@wordpress/i18n';
+/**
+ * Internal dependencies
+ */
+import { ToggleWithEditorLink } from '../components/toggle-with-link';
+import type { NewsletterSettings, JetpackNewsletterSettings } from '../types';
+
+interface SubscriptionsSectionProps {
+	data: NewsletterSettings;
+	jetpackSettings: JetpackNewsletterSettings | undefined;
+	onChange: ( updates: Partial< NewsletterSettings > ) => void;
+	onSave: () => void;
+	isSaving: boolean;
+	hasChanges: boolean;
+	isNewsletterEnabled: boolean;
+}
+
+/**
+ * Subscriptions Section Component
+ *
+ * @param {SubscriptionsSectionProps} props - Component props
+ * @return {JSX.Element} The subscriptions section
+ */
+export function SubscriptionsSection( {
+	data,
+	jetpackSettings,
+	onChange,
+	onSave,
+	isSaving,
+	hasChanges,
+	isNewsletterEnabled,
+}: SubscriptionsSectionProps ): JSX.Element {
+	// Translation strings for save button
+	const savingText = __( 'Saving…', 'jetpack-newsletter' );
+	const saveText = __( 'Save', 'jetpack-newsletter' );
+
+	// Helper to check if we can show editor links for block theme features
+	const canShowBlockThemeEditorLinks =
+		jetpackSettings?.isBlockTheme &&
+		jetpackSettings?.siteAdminUrl &&
+		jetpackSettings?.themeStylesheet;
+
+	// Helper to check if we can show editor links for subscription site edit features
+	const canShowSubscriptionEditorLinks =
+		jetpackSettings?.isSubscriptionSiteEditSupported &&
+		jetpackSettings?.siteAdminUrl &&
+		jetpackSettings?.themeStylesheet;
+
+	const fields: Field< NewsletterSettings >[] = [
+		{
+			id: 'jetpack_subscriptions_subscribe_post_end_enabled',
+			label: __( 'Add the Subscribe Block at the end of each post.', 'jetpack-newsletter' ),
+			type: 'boolean' as const,
+			Edit: canShowSubscriptionEditorLinks
+				? ( {
+						data: formData,
+						field,
+						onChange: fieldOnChange,
+				  }: {
+						data: NewsletterSettings;
+						field: Field< Record< string, unknown > >;
+						onChange: ( updates: Partial< NewsletterSettings > ) => void;
+				  } ) => (
+						<ToggleWithEditorLink
+							data={ formData }
+							field={ field }
+							onChange={ fieldOnChange }
+							siteAdminUrl={ jetpackSettings.siteAdminUrl }
+							themeStylesheet={ jetpackSettings.themeStylesheet }
+							postType="wp_template"
+							templateId="single"
+						/>
+				  )
+				: ( 'toggle' as const ),
+		},
+		{
+			id: 'sm_enabled',
+			label: __( 'Show subscription pop-up when scrolling a post.', 'jetpack-newsletter' ),
+			type: 'boolean' as const,
+			Edit: canShowBlockThemeEditorLinks
+				? ( {
+						data: formData,
+						field,
+						onChange: fieldOnChange,
+				  }: {
+						data: NewsletterSettings;
+						field: Field< Record< string, unknown > >;
+						onChange: ( updates: Partial< NewsletterSettings > ) => void;
+				  } ) => (
+						<ToggleWithEditorLink
+							data={ formData }
+							field={ field }
+							onChange={ fieldOnChange }
+							siteAdminUrl={ jetpackSettings.siteAdminUrl }
+							themeStylesheet={ jetpackSettings.themeStylesheet }
+							postType="wp_template_part"
+							templateId="jetpack-subscribe-modal"
+						/>
+				  )
+				: ( 'toggle' as const ),
+		},
+		{
+			id: 'jetpack_subscribe_overlay_enabled',
+			label: __( 'Subscription overlay on homepage', 'jetpack-newsletter' ),
+			type: 'boolean' as const,
+			Edit: canShowBlockThemeEditorLinks
+				? ( {
+						data: formData,
+						field,
+						onChange: fieldOnChange,
+				  }: {
+						data: NewsletterSettings;
+						field: Field< Record< string, unknown > >;
+						onChange: ( updates: Partial< NewsletterSettings > ) => void;
+				  } ) => (
+						<ToggleWithEditorLink
+							data={ formData }
+							field={ field }
+							onChange={ fieldOnChange }
+							siteAdminUrl={ jetpackSettings.siteAdminUrl }
+							themeStylesheet={ jetpackSettings.themeStylesheet }
+							postType="wp_template_part"
+							templateId="jetpack-subscribe-overlay"
+						/>
+				  )
+				: ( 'toggle' as const ),
+		},
+		{
+			id: 'jetpack_subscribe_floating_button_enabled',
+			label: __( "Floating subscribe button on site's bottom corner", 'jetpack-newsletter' ),
+			type: 'boolean' as const,
+			Edit: canShowBlockThemeEditorLinks
+				? ( {
+						data: formData,
+						field,
+						onChange: fieldOnChange,
+				  }: {
+						data: NewsletterSettings;
+						field: Field< Record< string, unknown > >;
+						onChange: ( updates: Partial< NewsletterSettings > ) => void;
+				  } ) => (
+						<ToggleWithEditorLink
+							data={ formData }
+							field={ field }
+							onChange={ fieldOnChange }
+							siteAdminUrl={ jetpackSettings.siteAdminUrl }
+							themeStylesheet={ jetpackSettings.themeStylesheet }
+							postType="wp_template_part"
+							templateId="jetpack-subscribe-floating-button"
+						/>
+				  )
+				: ( 'toggle' as const ),
+		},
+		{
+			id: 'jetpack_subscriptions_subscribe_navigation_enabled',
+			label: __( 'Add the Subscribe Block to the navigation', 'jetpack-newsletter' ),
+			type: 'boolean' as const,
+			Edit: canShowSubscriptionEditorLinks
+				? ( {
+						data: formData,
+						field,
+						onChange: fieldOnChange,
+				  }: {
+						data: NewsletterSettings;
+						field: Field< Record< string, unknown > >;
+						onChange: ( updates: Partial< NewsletterSettings > ) => void;
+				  } ) => (
+						<ToggleWithEditorLink
+							data={ formData }
+							field={ field }
+							onChange={ fieldOnChange }
+							siteAdminUrl={ jetpackSettings.siteAdminUrl }
+							themeStylesheet={ jetpackSettings.themeStylesheet }
+							postType="wp_template"
+							templateId="index"
+						/>
+				  )
+				: ( 'toggle' as const ),
+		},
+		{
+			id: 'jetpack_subscriptions_login_navigation_enabled',
+			label: __( 'Add the Subscriber Login Block to the navigation', 'jetpack-newsletter' ),
+			type: 'boolean' as const,
+			Edit: canShowSubscriptionEditorLinks
+				? ( {
+						data: formData,
+						field,
+						onChange: fieldOnChange,
+				  }: {
+						data: NewsletterSettings;
+						field: Field< Record< string, unknown > >;
+						onChange: ( updates: Partial< NewsletterSettings > ) => void;
+				  } ) => (
+						<ToggleWithEditorLink
+							data={ formData }
+							field={ field }
+							onChange={ fieldOnChange }
+							siteAdminUrl={ jetpackSettings.siteAdminUrl }
+							themeStylesheet={ jetpackSettings.themeStylesheet }
+							postType="wp_template"
+							templateId="index"
+						/>
+				  )
+				: ( 'toggle' as const ),
+		},
+		{
+			id: 'stb_enabled',
+			label: __(
+				'Enable the "Subscribe to site" option on your comment form',
+				'jetpack-newsletter'
+			),
+			type: 'boolean' as const,
+			Edit: 'toggle' as const,
+		},
+		{
+			id: 'stc_enabled',
+			label: __(
+				'Enable the "Subscribe to comments" option on your comment form',
+				'jetpack-newsletter'
+			),
+			type: 'boolean' as const,
+			Edit: 'toggle' as const,
+		},
+	];
+
+	return (
+		<div className="newsletter-settings__section">
+			<h3 className="newsletter-settings__section-title">
+				{ __( 'Subscriptions', 'jetpack-newsletter' ) }
+			</h3>
+			<p className="newsletter-settings__section-description">
+				{ __(
+					'Automatically add subscription forms to your site and turn visitors into subscribers.',
+					'jetpack-newsletter'
+				) }
+			</p>
+			<fieldset className="newsletter-settings__section-content" disabled={ ! isNewsletterEnabled }>
+				<DataForm
+					data={ data }
+					fields={ fields }
+					form={ {
+						layout: {
+							type: 'regular',
+							labelPosition: 'top',
+						},
+						fields: [
+							{
+								id: 'homepage_and_posts',
+								label: __( 'Homepage and posts', 'jetpack-newsletter' ),
+								children: [
+									'jetpack_subscriptions_subscribe_post_end_enabled',
+									'sm_enabled',
+									'jetpack_subscribe_overlay_enabled',
+									'jetpack_subscribe_floating_button_enabled',
+								],
+							},
+							{
+								id: 'navigation',
+								label: __( 'Navigation', 'jetpack-newsletter' ),
+								children: [
+									'jetpack_subscriptions_subscribe_navigation_enabled',
+									'jetpack_subscriptions_login_navigation_enabled',
+								],
+							},
+							{
+								id: 'comments',
+								label: __( 'Comments', 'jetpack-newsletter' ),
+								children: [ 'stb_enabled', 'stc_enabled' ],
+							},
+						],
+					} }
+					onChange={ onChange }
+				/>
+
+				<div className="newsletter-settings__section-actions">
+					<Button
+						variant="primary"
+						onClick={ onSave }
+						disabled={ ! isNewsletterEnabled || isSaving || ! hasChanges }
+						isBusy={ isSaving }
+					>
+						{ isSaving ? savingText : saveText }
+					</Button>
+				</div>
+			</fieldset>
+		</div>
+	);
+}

--- a/projects/packages/newsletter/src/settings/sections/subscriptions-section.tsx
+++ b/projects/packages/newsletter/src/settings/sections/subscriptions-section.tsx
@@ -10,6 +10,12 @@ import { __ } from '@wordpress/i18n';
 import { ToggleWithEditorLink } from '../components/toggle-with-link';
 import type { NewsletterSettings, JetpackNewsletterSettings } from '../types';
 
+interface FieldRenderProps {
+	data: NewsletterSettings;
+	field: Field< Record< string, unknown > >;
+	onChange: ( updates: Partial< NewsletterSettings > ) => void;
+}
+
 interface SubscriptionsSectionProps {
 	data: NewsletterSettings;
 	jetpackSettings: JetpackNewsletterSettings | undefined;
@@ -57,15 +63,7 @@ export function SubscriptionsSection( {
 			label: __( 'Add the Subscribe Block at the end of each post.', 'jetpack-newsletter' ),
 			type: 'boolean' as const,
 			Edit: canShowSubscriptionEditorLinks
-				? ( {
-						data: formData,
-						field,
-						onChange: fieldOnChange,
-				  }: {
-						data: NewsletterSettings;
-						field: Field< Record< string, unknown > >;
-						onChange: ( updates: Partial< NewsletterSettings > ) => void;
-				  } ) => (
+				? ( { data: formData, field, onChange: fieldOnChange }: FieldRenderProps ) => (
 						<ToggleWithEditorLink
 							data={ formData }
 							field={ field }
@@ -83,15 +81,7 @@ export function SubscriptionsSection( {
 			label: __( 'Show subscription pop-up when scrolling a post.', 'jetpack-newsletter' ),
 			type: 'boolean' as const,
 			Edit: canShowBlockThemeEditorLinks
-				? ( {
-						data: formData,
-						field,
-						onChange: fieldOnChange,
-				  }: {
-						data: NewsletterSettings;
-						field: Field< Record< string, unknown > >;
-						onChange: ( updates: Partial< NewsletterSettings > ) => void;
-				  } ) => (
+				? ( { data: formData, field, onChange: fieldOnChange }: FieldRenderProps ) => (
 						<ToggleWithEditorLink
 							data={ formData }
 							field={ field }
@@ -109,15 +99,7 @@ export function SubscriptionsSection( {
 			label: __( 'Subscription overlay on homepage', 'jetpack-newsletter' ),
 			type: 'boolean' as const,
 			Edit: canShowBlockThemeEditorLinks
-				? ( {
-						data: formData,
-						field,
-						onChange: fieldOnChange,
-				  }: {
-						data: NewsletterSettings;
-						field: Field< Record< string, unknown > >;
-						onChange: ( updates: Partial< NewsletterSettings > ) => void;
-				  } ) => (
+				? ( { data: formData, field, onChange: fieldOnChange }: FieldRenderProps ) => (
 						<ToggleWithEditorLink
 							data={ formData }
 							field={ field }
@@ -135,15 +117,7 @@ export function SubscriptionsSection( {
 			label: __( "Floating subscribe button on site's bottom corner", 'jetpack-newsletter' ),
 			type: 'boolean' as const,
 			Edit: canShowBlockThemeEditorLinks
-				? ( {
-						data: formData,
-						field,
-						onChange: fieldOnChange,
-				  }: {
-						data: NewsletterSettings;
-						field: Field< Record< string, unknown > >;
-						onChange: ( updates: Partial< NewsletterSettings > ) => void;
-				  } ) => (
+				? ( { data: formData, field, onChange: fieldOnChange }: FieldRenderProps ) => (
 						<ToggleWithEditorLink
 							data={ formData }
 							field={ field }
@@ -161,15 +135,7 @@ export function SubscriptionsSection( {
 			label: __( 'Add the Subscribe Block to the navigation', 'jetpack-newsletter' ),
 			type: 'boolean' as const,
 			Edit: canShowSubscriptionEditorLinks
-				? ( {
-						data: formData,
-						field,
-						onChange: fieldOnChange,
-				  }: {
-						data: NewsletterSettings;
-						field: Field< Record< string, unknown > >;
-						onChange: ( updates: Partial< NewsletterSettings > ) => void;
-				  } ) => (
+				? ( { data: formData, field, onChange: fieldOnChange }: FieldRenderProps ) => (
 						<ToggleWithEditorLink
 							data={ formData }
 							field={ field }
@@ -187,15 +153,7 @@ export function SubscriptionsSection( {
 			label: __( 'Add the Subscriber Login Block to the navigation', 'jetpack-newsletter' ),
 			type: 'boolean' as const,
 			Edit: canShowSubscriptionEditorLinks
-				? ( {
-						data: formData,
-						field,
-						onChange: fieldOnChange,
-				  }: {
-						data: NewsletterSettings;
-						field: Field< Record< string, unknown > >;
-						onChange: ( updates: Partial< NewsletterSettings > ) => void;
-				  } ) => (
+				? ( { data: formData, field, onChange: fieldOnChange }: FieldRenderProps ) => (
 						<ToggleWithEditorLink
 							data={ formData }
 							field={ field }

--- a/projects/packages/newsletter/src/settings/sections/welcome-email-section.tsx
+++ b/projects/packages/newsletter/src/settings/sections/welcome-email-section.tsx
@@ -1,0 +1,122 @@
+/**
+ * External dependencies
+ */
+import { Button } from '@wordpress/components';
+import { DataForm, type Field } from '@wordpress/dataviews/wp';
+import { useCallback, useMemo } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+/**
+ * Internal dependencies
+ */
+import type { NewsletterSettings } from '../types';
+
+interface WelcomeEmailSectionProps {
+	data: NewsletterSettings;
+	onChange: ( updates: Partial< NewsletterSettings > ) => void;
+	onSave: () => void;
+	isSaving: boolean;
+	hasChanges: boolean;
+	isNewsletterEnabled: boolean;
+}
+
+// Flattened data structure for DataForm
+interface WelcomeEmailFormData {
+	welcome_message: string;
+}
+
+/**
+ * Welcome Email Section Component
+ *
+ * Handles the welcome email message configuration for new subscribers.
+ *
+ * @param {WelcomeEmailSectionProps} props - Component props
+ * @return {JSX.Element} The welcome email section
+ */
+export function WelcomeEmailSection( {
+	data,
+	onChange,
+	onSave,
+	isSaving,
+	hasChanges,
+	isNewsletterEnabled,
+}: WelcomeEmailSectionProps ): JSX.Element {
+	// Flatten data for DataForm
+	const formData: WelcomeEmailFormData = useMemo(
+		() => ( {
+			welcome_message: data.subscription_options?.welcome || '',
+		} ),
+		[ data.subscription_options?.welcome ]
+	);
+
+	// Translation strings for save button
+	const savingText = __( 'Saving…', 'jetpack-newsletter' );
+	const saveText = __( 'Save', 'jetpack-newsletter' );
+
+	const fields: Field< WelcomeEmailFormData >[] = [
+		{
+			id: 'welcome_message',
+			label: __( 'Welcome message', 'jetpack-newsletter' ),
+			type: 'text' as const,
+			Edit: 'textarea' as const,
+			description: __(
+				'You can use plain text or HTML tags in this textarea for formatting.',
+				'jetpack-newsletter'
+			),
+		},
+	];
+
+	const handleDataFormChange = useCallback(
+		( updates: Partial< WelcomeEmailFormData > ) => {
+			if ( updates.welcome_message !== undefined ) {
+				// Preserve all properties of subscription_options when updating
+				onChange( {
+					subscription_options: {
+						invitation: data.subscription_options?.invitation || '',
+						welcome: updates.welcome_message,
+						comment_follow: data.subscription_options?.comment_follow || '',
+					},
+				} );
+			}
+		},
+		[ onChange, data.subscription_options ]
+	);
+
+	return (
+		<div className="newsletter-settings__section">
+			<h3 className="newsletter-settings__section-title">
+				{ __( 'Welcome email message', 'jetpack-newsletter' ) }
+			</h3>
+			<p className="newsletter-settings__section-description">
+				{ __(
+					'Sent to your email subscribers when they subscribe to your newsletter.',
+					'jetpack-newsletter'
+				) }
+			</p>
+			<fieldset className="newsletter-settings__section-content" disabled={ ! isNewsletterEnabled }>
+				<DataForm
+					data={ formData }
+					fields={ fields }
+					form={ {
+						layout: {
+							type: 'regular',
+							labelPosition: 'top',
+						},
+						fields: [ 'welcome_message' ],
+					} }
+					onChange={ handleDataFormChange }
+				/>
+
+				<div className="newsletter-settings__section-actions">
+					<Button
+						variant="primary"
+						onClick={ onSave }
+						disabled={ ! isNewsletterEnabled || isSaving || ! hasChanges }
+						isBusy={ isSaving }
+					>
+						{ isSaving ? savingText : saveText }
+					</Button>
+				</div>
+			</fieldset>
+		</div>
+	);
+}

--- a/projects/packages/newsletter/src/settings/types.ts
+++ b/projects/packages/newsletter/src/settings/types.ts
@@ -40,7 +40,6 @@ export interface JetpackNewsletterSettings {
 	siteAdminUrl: string;
 	themeStylesheet: string;
 	blogID: number;
-	siteRawUrl: string;
 	email: string;
 	gravatar: string;
 	displayName: string;
@@ -51,7 +50,6 @@ export interface JetpackNewsletterSettings {
 	isSitePublic: boolean;
 	isWpcomPlatform: boolean;
 	isWpcomSimple: boolean;
-	isSubscriptionsActive: boolean;
 	restApiRoot: string;
 	restApiNonce: string;
 	siteName: string;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This is part of solving [DOTCOM-15286](https://linear.app/a8c/issue/DOTCOM-15286) and has been split out from the original PR (https://github.com/Automattic/jetpack/pull/46136) in the hope it makes the changes easier to review. It is the third of four PRs (previously #46470, #46471).


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
- Add new settings sections to the Newsletter package:                                                                                         
    - Subscriptions Section: Configure subscription placement options (post end, social menu, overlay, floating button, navigation)              
    - Paid Newsletter Section: Link to payment plan setup on appropriate platform                                                                
    - Welcome Email Section: Customize the welcome email message for new subscribers 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->


Before | After
-------|------
<img width="2918" height="2802" alt="image" src="https://github.com/user-attachments/assets/af5a6100-ce61-49d1-9fa0-71ac3c24686d" /> | <img width="2614" height="4864" alt="Screen Shot 2026-01-21 at 16 00 28-fullpage" src="https://github.com/user-attachments/assets/2448c627-21b3-43dd-914e-2b3f446fdc99" />


  - Make add_filter( 'jetpack_wp_admin_newsletter_settings_enabled', '__return_true' ); run early, e.g. by adding it to a new mu-plugin or just by pasting it into the top of jetpack-dev/jetpack.php using the plugin file editor on a jurassic ninja site.
  - Enable the newsletter module if it isn't already
  - Navigate to Jetpack → Newsletter Settings                                                                                                    
  - Verify the following sections appear and function correctly:                                                                                 
    - Subscriptions: Toggle options for subscription placement, verify save button works                                                         
    - Paid Newsletter: "Add plans" link should go to cloud.jetpack.com/monetize/payments/ for Jetpack/atomic sites, wordpress.com/earn/payments/ 
  for simple sites                                                                                                                               
    - Welcome Email: Edit welcome message, verify save works          