### PR TITLE
Forms: hide table headers if no responses

### DIFF
--- a/projects/packages/forms/changelog/update-forms-remove-headers-if-no-responses
+++ b/projects/packages/forms/changelog/update-forms-remove-headers-if-no-responses
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Forms: hide table headers if no responses.

--- a/projects/packages/forms/src/dashboard/inbox/stage/index.js
+++ b/projects/packages/forms/src/dashboard/inbox/stage/index.js
@@ -5,7 +5,7 @@ import jetpackAnalytics from '@automattic/jetpack-analytics';
 import { JetpackLogo } from '@automattic/jetpack-components';
 import { isSimpleSite } from '@automattic/jetpack-script-data';
 import { Badge } from '@automattic/ui';
-import { ExternalLink, Modal } from '@wordpress/components';
+import { ExternalLink, Modal, Spinner } from '@wordpress/components';
 import { useResizeObserver, useViewportMatch } from '@wordpress/compose';
 import { useSelect } from '@wordpress/data';
 import { DataViews } from '@wordpress/dataviews/wp';
@@ -478,6 +478,14 @@ export default function InboxView() {
 	// Check if read_status filter is applied
 	const readStatusFilter = view.filters?.find( filter => filter.field === 'read_status' )?.value;
 
+	// Consider both "true empty" tabs and "filtered empty" views as empty states for layout purposes.
+	// We still keep tabs/search/filters visible so users can change/clear them.
+	const isFilteredView = !! view.search || !! readStatusFilter || ( view.filters?.length ?? 0 ) > 0;
+	const hasData = ( records?.length ?? 0 ) > 0;
+	const showLoading = isInboxLoading && ! hasData;
+	const showEmptyResponses = ! isInboxLoading && ! hasData;
+	const showLayout = hasData;
+
 	// Conditional header actions based on status filter
 	const headerActions = useMemo( () => {
 		const exportIsPrimary = statusFilter !== 'trash' && statusFilter !== 'spam';
@@ -524,13 +532,6 @@ export default function InboxView() {
 				onChangeSelection={ onChangeSelection }
 				getItemId={ getItemId }
 				defaultLayouts={ defaultLayouts }
-				empty={
-					<EmptyResponses
-						status={ statusFilter }
-						isSearch={ !! view.search }
-						readStatusFilter={ readStatusFilter }
-					/>
-				}
 			>
 				<div className="jp-forms-view-actions">
 					<div>
@@ -550,8 +551,30 @@ export default function InboxView() {
 				</div>
 				<DataViews.FiltersToggled className="jp-forms-filters-container" />
 				<div className="jp-forms-dataviews-layout-container">
-					<DataViews.Layout />
-					<DataViews.Footer />
+					{ showLoading && (
+						<div className="jp-forms-dataviews-layout-container__placeholder">
+							<div className="dataviews-loading">
+								<p>
+									<Spinner />
+								</p>
+							</div>
+						</div>
+					) }
+					{ showEmptyResponses && (
+						<div className="jp-forms-dataviews-layout-container__placeholder">
+							<EmptyResponses
+								status={ statusFilter }
+								isSearch={ isFilteredView }
+								readStatusFilter={ readStatusFilter }
+							/>
+						</div>
+					) }
+					{ showLayout && (
+						<>
+							<DataViews.Layout />
+							<DataViews.Footer />
+						</>
+					) }
 				</div>
 			</DataViews>
 		</Page>

--- a/projects/packages/forms/src/dashboard/inbox/style.scss
+++ b/projects/packages/forms/src/dashboard/inbox/style.scss
@@ -64,6 +64,15 @@
 	display: flex;
 	flex-direction: column;
 	background-color: var(--wpds-color-bg-surface-neutral-strong, #fff);
+
+	&__placeholder {
+		flex: 1 1 auto;
+		min-height: 0;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		padding: variables.$grid-unit * 2.5;
+	}
 }
 
 .jp-forms-filters-container:not(:empty) {

--- a/projects/plugins/jetpack/changelog/update-forms-remove-headers-if-no-responses
+++ b/projects/plugins/jetpack/changelog/update-forms-remove-headers-if-no-responses
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Forms: hide table headers if no responses.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes [FORMS-454](https://linear.app/a8c/issue/FORMS-454/hide-table-headers-when-table-is-empty)

## Proposed changes:

This PR hides table column headers/titles in the responses table when it is empty.
* If responses are loading: we replace Layout (table) with a spinner
* If responses are empty: we load EmptyResponses component in place of Layout (table) rather than inside it
* If there are responses: we load Layout (table) like usual

**Before**
<img width="1343" height="666" alt="form-responses-empty-before" src="https://github.com/user-attachments/assets/c9edb939-9f7b-4f59-81ec-71d4578e01ae" />

**After**
<img width="1345" height="666" alt="form-responses-empty-after" src="https://github.com/user-attachments/assets/a6672507-a746-47ea-bd5d-dc9921dd3fd0" />

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
See linear issue.

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to Jetpack > Forms
* Ensure either inbox or spam or trash tab is empty and go to it
* Confirm we still show the EmptyResponses component/notice, but without table headers
* Navigate around between empty and non-empty response tabs and confirm everything loads smoothly and nicely when there are responses. 

