### PR TITLE
CLI README: Add missing commands to Available Commands list

### DIFF
--- a/tools/cli/README.md
+++ b/tools/cli/README.md
@@ -29,15 +29,20 @@ The CLI commands can be run from anywhere, and the changes will be made in which
 ## Available Commands
 
 * `build` - Build a project in the monorepo.
-* `changelog` -  Manage changelog files for a project.
+* `changelog` - Manage changelog files for a project.
 * `clean` - Clean unwanted files in the monorepo.
 * `cli` - Manage global symlink for the CLI.
-* `completion` - Generate bash/zsh completions
+* `completion` - Generate bash/zsh completions.
+* `dependencies` - Analyze and display project dependencies.
 * `docker` - Manage docker containers.
+* `draft` - Enable or disable draft mode for relaxed pre-commit/pre-push checks.
 * `generate` - Create a new project in the monorepo.
 * `install` - Install project dependencies.
-* `watch` - Watch a specific project.
-* `rsync` - rsync projects/plugins to external destinations.
+* `phan` - Run PHP static analysis using Phan.
+* `release` - Manage releases and versioning.
+* `rsync` - Rsync projects/plugins to external destinations.
+* `test` - Run PHP, JavaScript, or E2E tests for a project.
+* `watch` - Watch a specific project and rebuild on changes.
 
 ## Examples
 

--- a/tools/cli/README.md
+++ b/tools/cli/README.md
@@ -35,12 +35,13 @@ The CLI commands can be run from anywhere, and the changes will be made in which
 * `completion` - Generate bash/zsh completions.
 * `dependencies` - Analyze and display project dependencies.
 * `docker` - Manage docker containers.
+* `docs` - Parse PHPDoc documentation from a project and output it into a JSON file.
 * `draft` - Enable or disable draft mode for relaxed pre-commit/pre-push checks.
 * `generate` - Create a new project in the monorepo.
 * `install` - Install project dependencies.
 * `phan` - Run PHP static analysis using Phan.
 * `release` - Manage releases and versioning.
-* `rsync` - Rsync projects/plugins to external destinations.
+* `rsync` - rsync projects/plugins to external destinations.
 * `test` - Run PHP, JavaScript, or E2E tests for a project.
 * `watch` - Watch a specific project and rebuild on changes.
 


### PR DESCRIPTION
Fixes #

## Proposed changes:
- Add missing CLI commands to the "Available Commands" section in tools/cli/README.md
- Commands added: `dependencies`, `draft`, `phan`, `release`, `test`
- Minor formatting fixes (consistent punctuation)

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable?

## Jetpack product discussion
N/A - Documentation fix

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
* Review the updated Available Commands list in tools/cli/README.md
* Verify the listed commands match the actual available commands (run `jetpack help`)
