### PR TITLE
Docs: Update version references with canonical source

### DIFF
--- a/docs/development-environment.md
+++ b/docs/development-environment.md
@@ -123,7 +123,7 @@ You'll need all the tools below to work in the Jetpack monorepo.
 
 	Composer is a PHP package manager and it's used to install packages that are required to run development tools and build projects.
 
-	The monorepo requires version 2.3.x.
+	The monorepo requires Composer 2.9.x. The canonical source for required versions is [`.github/versions.sh`](../.github/versions.sh).
 
 	 * ##### Installing Composer on macOS
 

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -27,7 +27,7 @@ Once the installation is complete, continue onto the section [Running Jetpack lo
 Prior to installation, we recommend using [`Homebrew`](https://brew.sh/) to manage installations and [`nvm`](https://github.com/nvm-sh/nvm/) to manage Node.js versions. If you don't already have those installed, you can do so by copy/pasting each of the following commands and running them in your terminal:
 
 - Homebrew: `bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"`
-- nvm: `curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.0/install.sh | bash`
+- nvm: `curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.3/install.sh | bash` (see [nvm releases](https://github.com/nvm-sh/nvm/releases) for the latest version)
 
 The Jetpack Monorepo requires various software to be installed on your machine.
 


### PR DESCRIPTION
Fixes #

## Proposed changes:
- Update Composer version requirement from 2.3.x to 2.9.x in development-environment.md
- Add reference to `.github/versions.sh` as the canonical source for required versions
- Update nvm version from v0.39.0 to v0.40.3 in quick-start.md with link to releases page

This makes version references more maintainable by pointing to the canonical source.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable?

## Jetpack product discussion
N/A - Documentation fix

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
* Review the updated version references in docs/development-environment.md and docs/quick-start.md
* Verify the versions match current CI requirements in .github/versions.sh
