### PR TITLE
Forms: change phone dropdown flags handling

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-phone-dropdown-flags-handling
+++ b/projects/packages/forms/changelog/fix-forms-phone-dropdown-flags-handling
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Forms: change how phone combobox handles flag changes, bypassing wpemoji MutationObserver

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -1086,8 +1086,8 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 							data-wp-on--click="actions.phoneComboboxToggle"
 							data-wp-bind--aria-expanded="context.comboboxOpen">
 							<span
-								class="jetpack-combobox-selected"
-								data-wp-text="context.selectedCountry.flag"></span>
+								class="jetpack-combobox-selected wp-exclude-emoji"
+								data-wp-watch="callbacks.updateSelectedFlag">&#8203;</span>
 							<span
 								class="jetpack-combobox-trigger-arrow"
 								data-wp-class--is-open="context.comboboxOpen">
@@ -1119,7 +1119,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 										data-wp-key="context.filtered.code"
 										data-wp-class--jetpack-combobox-option-selected="context.filtered.selected"
 										data-wp-on--click="actions.phoneCountryChangeHandler">
-										<span class="jetpack-combobox-option-icon" data-wp-text="context.filtered.flag"></span>
+										<span class="jetpack-combobox-option-icon wp-exclude-emoji" data-wp-watch="callbacks.updateOptionFlag">&#8203;</span>
 										<span class="jetpack-combobox-option-value" data-wp-text="context.filtered.value"></span>
 										<span class="jetpack-combobox-option-description" data-wp-text="context.filtered.country"></span>
 									</div>

--- a/projects/packages/forms/src/modules/field-phone/view.js
+++ b/projects/packages/forms/src/modules/field-phone/view.js
@@ -21,6 +21,23 @@ const asYouTypes = {};
 const phoneInputRefs = {};
 const searchInputRefs = {};
 const optionsListRefs = {};
+
+/**
+ * Sets flag text on an element by modifying existing text node data instead of
+ * replacing textContent. This avoids triggering wp-emoji's MutationObserver
+ * (which only watches childList, not characterData) that converts emoji to SVG.
+ *
+ * @param {HTMLElement} element - The element to set flag text on.
+ * @param {string}      flag    - The flag emoji to display.
+ */
+const setFlagText = ( element, flag ) => {
+	const text = flag || '';
+	if ( element.firstChild?.nodeType === 3 ) {
+		element.firstChild.data = text;
+	} else {
+		element.textContent = text;
+	}
+};
 const updateSelection = selectedCountry => {
 	const context = getContext();
 	context.phoneCountryCode = selectedCountry.code;
@@ -217,35 +234,19 @@ const { actions, callbacks } = store( NAMESPACE, {
 	},
 	callbacks: {
 		/**
-		 * Updates the flag display by modifying existing text node data
-		 * instead of replacing textContent, to avoid triggering wp-emoji
-		 * MutationObserver which only watches childList, not characterData.
+		 * Sets flag text by modifying existing text node data (nodeType 3 = TEXT_NODE)
+		 * instead of replacing textContent, to avoid triggering wp-emoji's MutationObserver
+		 * which only watches childList (not characterData) and converts emoji to SVG images.
 		 */
 		updateSelectedFlag() {
 			const { ref } = getElement();
 			const context = getContext();
-			const flag = context.selectedCountry?.flag || '';
-			// Modify existing text node's data (nodeType 3 = TEXT_NODE) instead of
-			// replacing textContent to avoid triggering wp-emoji's MutationObserver,
-			// which converts emoji characters to SVG images.
-			if ( ref.firstChild?.nodeType === 3 ) {
-				ref.firstChild.data = flag;
-			} else {
-				ref.textContent = flag;
-			}
+			setFlagText( ref, context.selectedCountry?.flag );
 		},
 		updateOptionFlag() {
 			const { ref } = getElement();
 			const context = getContext();
-			const flag = context.filtered?.flag || '';
-			// Modify existing text node's data (nodeType 3 = TEXT_NODE) instead of
-			// replacing textContent to avoid triggering wp-emoji's MutationObserver,
-			// which converts emoji characters to SVG images.
-			if ( ref.firstChild?.nodeType === 3 ) {
-				ref.firstChild.data = flag;
-			} else {
-				ref.textContent = flag;
-			}
+			setFlagText( ref, context.filtered?.flag );
 		},
 		registerPhoneInput() {
 			const element = getElement().ref;

--- a/projects/packages/forms/src/modules/field-phone/view.js
+++ b/projects/packages/forms/src/modules/field-phone/view.js
@@ -216,6 +216,37 @@ const { actions, callbacks } = store( NAMESPACE, {
 		},
 	},
 	callbacks: {
+		/**
+		 * Updates the flag display by modifying existing text node data
+		 * instead of replacing textContent, to avoid triggering wp-emoji
+		 * MutationObserver which only watches childList, not characterData.
+		 */
+		updateSelectedFlag() {
+			const { ref } = getElement();
+			const context = getContext();
+			const flag = context.selectedCountry?.flag || '';
+			// Modify existing text node's data (nodeType 3 = TEXT_NODE) instead of
+			// replacing textContent to avoid triggering wp-emoji's MutationObserver,
+			// which converts emoji characters to SVG images.
+			if ( ref.firstChild?.nodeType === 3 ) {
+				ref.firstChild.data = flag;
+			} else {
+				ref.textContent = flag;
+			}
+		},
+		updateOptionFlag() {
+			const { ref } = getElement();
+			const context = getContext();
+			const flag = context.filtered?.flag || '';
+			// Modify existing text node's data (nodeType 3 = TEXT_NODE) instead of
+			// replacing textContent to avoid triggering wp-emoji's MutationObserver,
+			// which converts emoji characters to SVG images.
+			if ( ref.firstChild?.nodeType === 3 ) {
+				ref.firstChild.data = flag;
+			} else {
+				ref.textContent = flag;
+			}
+		},
 		registerPhoneInput() {
 			const element = getElement().ref;
 			const context = getContext();

--- a/projects/packages/forms/tests/js/modules/field-phone/view.test.js
+++ b/projects/packages/forms/tests/js/modules/field-phone/view.test.js
@@ -385,6 +385,77 @@ describe( 'Phone Field View', () => {
 	} );
 
 	describe( 'Callbacks', () => {
+		describe( 'Flag text updates', () => {
+			test( 'updateSelectedFlag sets flag by modifying existing text node data', () => {
+				// Create element with existing text node
+				const flagElement = document.createElement( 'span' );
+				flagElement.textContent = '\u200B'; // Zero-width space placeholder
+				mockGetElement.mockReturnValue( { ref: flagElement } );
+				mockContext.selectedCountry = { flag: '🇬🇧' };
+
+				storeConfig.callbacks.updateSelectedFlag();
+
+				// Should modify existing text node's data, not replace textContent
+				expect( flagElement.firstChild.nodeType ).toBe( 3 ); // TEXT_NODE
+				expect( flagElement.firstChild.data ).toBe( '🇬🇧' );
+			} );
+
+			test( 'updateSelectedFlag uses textContent when no text node exists', () => {
+				// Create element without children
+				const flagElement = document.createElement( 'span' );
+				mockGetElement.mockReturnValue( { ref: flagElement } );
+				mockContext.selectedCountry = { flag: '🇫🇷' };
+
+				storeConfig.callbacks.updateSelectedFlag();
+
+				expect( flagElement ).toHaveTextContent( '🇫🇷' );
+			} );
+
+			test( 'updateSelectedFlag handles missing flag gracefully', () => {
+				const flagElement = document.createElement( 'span' );
+				flagElement.textContent = '🇺🇸';
+				mockGetElement.mockReturnValue( { ref: flagElement } );
+				mockContext.selectedCountry = {};
+
+				storeConfig.callbacks.updateSelectedFlag();
+
+				expect( flagElement.firstChild.data ).toBe( '' );
+			} );
+
+			test( 'updateOptionFlag sets flag by modifying existing text node data', () => {
+				const flagElement = document.createElement( 'span' );
+				flagElement.textContent = '\u200B';
+				mockGetElement.mockReturnValue( { ref: flagElement } );
+				mockContext.filtered = { flag: '🇩🇪' };
+
+				storeConfig.callbacks.updateOptionFlag();
+
+				expect( flagElement.firstChild.nodeType ).toBe( 3 );
+				expect( flagElement.firstChild.data ).toBe( '🇩🇪' );
+			} );
+
+			test( 'updateOptionFlag uses textContent when no text node exists', () => {
+				const flagElement = document.createElement( 'span' );
+				mockGetElement.mockReturnValue( { ref: flagElement } );
+				mockContext.filtered = { flag: '🇯🇵' };
+
+				storeConfig.callbacks.updateOptionFlag();
+
+				expect( flagElement ).toHaveTextContent( '🇯🇵' );
+			} );
+
+			test( 'updateOptionFlag handles missing flag gracefully', () => {
+				const flagElement = document.createElement( 'span' );
+				flagElement.textContent = '🇺🇸';
+				mockGetElement.mockReturnValue( { ref: flagElement } );
+				mockContext.filtered = {};
+
+				storeConfig.callbacks.updateOptionFlag();
+
+				expect( flagElement.firstChild.data ).toBe( '' );
+			} );
+		} );
+
 		test( 'registers phone input element', () => {
 			const mockInputElement = document.querySelector( '.jetpack-field__input-element' );
 			mockGetElement.mockReturnValue( { ref: mockInputElement } );


### PR DESCRIPTION


Part of FORMS-478

## Proposed changes:
When WP emoji replacement scripts swaps our flag characters the interactivity API fails to bind with `data-wp-text` and the flags don't update.

###  Summary of the change:

  1. PHP changes (class-contact-form-field.php):
    - Replaced data-wp-text with data-wp-watch="callbacks.updateSelectedFlag/updateOptionFlag"
    - Added &#8203; (zero-width space) placeholder to ensure a text node exists
    - Kept wp-exclude-emoji class as fallback for initial page parse
  2. JS changes (view.js):
    - Added updateSelectedFlag and updateOptionFlag callbacks
    - These callbacks modify firstChild.data instead of textContent
    - Since wp-emoji's MutationObserver only watches childList (not characterData), modifying .data doesn't trigger emoji conversion

The key insight: wp-emoji's MutationObserver uses:  .observe(document.body, { childList: true, subtree: true })

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion


## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

### Before the fix:
  - Emoji characters → converted to SVG <img> tags by wp-emoji
  - This broke the dropdown because data-wp-text would keep resetting to text, causing a conflict

### After the fix:
  - Emoji characters stay as emoji characters (no SVG conversion)
  - The MutationObserver doesn't trigger because we modify .data instead of replacing textContent
  - The dropdown works correctly

NOTE: in order to see the swap on local envs, you can use this on startup:

```php

  add_action( 'wp_head', function() {
	// Inject script BEFORE the emoji detection (priority 7)
	// This sets fake "no support" values in sessionStorage
	?>
	<script>
	try {
	  sessionStorage.setItem('wpEmojiSettingsSupports', JSON.stringify({
		timestamp: Date.now(),
		supportTests: { flag: false, emoji: false }
	  }));
	} catch(e) {}
	</script>
	<?php
  }, 6 );
 
  // Force load the emoji scripts even if browser supports emojis
  add_action( 'wp_enqueue_scripts', function() {
	// Enqueue twemoji and wp-emoji scripts
	wp_enqueue_script(
	  'twemoji',
	  includes_url( 'js/twemoji.js' ),
	  array(),
	  false,
	  array( 'in_footer' => false )
	);
	wp_enqueue_script(
	  'wp-emoji',
	  includes_url( 'js/wp-emoji.js' ),
	  array( 'twemoji' ),
	  false,
	  array( 'in_footer' => false )
	);
  }, 100 );
```