### PR TITLE
Jetpack Sync: Introduce Sync actions blacklist

### DIFF
--- a/projects/packages/sync/changelog/add-sync-actions-blacklist
+++ b/projects/packages/sync/changelog/add-sync-actions-blacklist
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+ Jetpack Sync: Introduce Sync actions blacklist

--- a/projects/packages/sync/src/class-defaults.php
+++ b/projects/packages/sync/src/class-defaults.php
@@ -1188,6 +1188,13 @@ class Defaults {
 	public static $default_comment_meta_whitelist = array();
 
 	/**
+	 * Default for sync actions blacklist.
+	 *
+	 * @var array Empty array.
+	 */
+	public static $default_sync_actions_blacklist = array();
+
+	/**
 	 * Default for disabling sync across the site.
 	 *
 	 * @var int Bool-ish. Default to 0.

--- a/projects/packages/sync/src/class-listener.php
+++ b/projects/packages/sync/src/class-listener.php
@@ -289,6 +289,12 @@ class Listener {
 			return;
 		}
 
+		// Skip enqueueing if current action is blacklisted.
+		$sync_actions_blacklist = Settings::get_setting( 'sync_actions_blacklist' );
+		if ( is_array( $sync_actions_blacklist ) && in_array( $current_filter, $sync_actions_blacklist, true ) ) {
+			return;
+		}
+
 		/**
 		 * Add an action hook to execute when anything on the whitelist gets sent to the queue to sync.
 		 *

--- a/projects/packages/sync/src/class-settings.php
+++ b/projects/packages/sync/src/class-settings.php
@@ -62,6 +62,7 @@ class Settings {
 		'dedicated_sync_enabled'                 => true,
 		'custom_queue_table_enabled'             => true,
 		'wpcom_rest_api_enabled'                 => true,
+		'sync_actions_blacklist'                 => true,
 	);
 
 	/**

--- a/projects/plugins/jetpack/changelog/add-sync-actions-blacklist
+++ b/projects/plugins/jetpack/changelog/add-sync-actions-blacklist
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Updated Sync related unit test
+
+

--- a/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Listener_Test.php
+++ b/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Listener_Test.php
@@ -35,6 +35,19 @@ class Jetpack_Sync_Listener_Test extends Jetpack_Sync_TestBase {
 		$this->assertSame( 0, $queue->size() );
 	}
 
+	public function test_never_queues_if_current_action_is_blacklisted() {
+		Settings::update_settings( array( 'sync_actions_blacklist' => array( 'jetpack_sync_save_post' ) ) );
+
+		$queue = $this->listener->get_sync_queue();
+		$queue->reset(); // remove any actions that already got queued
+
+		self::factory()->post->create();
+
+		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_sync_save_post' );
+
+		$this->assertFalse( $event );
+	}
+
 	public function test_detects_if_exceeded_queue_size_limit_and_oldest_item_gt_15_mins() {
 		// This is trickier than you would expect because we only check against
 		// maximum queue size periodically (to avoid a counts on every request), and then

--- a/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Listener_Test.php
+++ b/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Listener_Test.php
@@ -36,16 +36,21 @@ class Jetpack_Sync_Listener_Test extends Jetpack_Sync_TestBase {
 	}
 
 	public function test_never_queues_if_current_action_is_blacklisted() {
-		Settings::update_settings( array( 'sync_actions_blacklist' => array( 'jetpack_sync_save_post' ) ) );
-
-		$queue = $this->listener->get_sync_queue();
-		$queue->reset(); // remove any actions that already got queued
-
-		self::factory()->post->create();
-
-		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_sync_save_post' );
-
-		$this->assertFalse( $event );
+		$original_sync_actions_blacklist = Settings::get_setting( 'sync_actions_blacklist' );
+		try {
+			Settings::update_settings( array( 'sync_actions_blacklist' => array( 'jetpack_sync_save_post' ) ) );
+			$queue = $this->listener->get_sync_queue();
+			$queue->reset(); // remove any actions that already got queued
+			self::factory()->post->create();
+			$event = $this->server_event_storage->get_most_recent_event( 'jetpack_sync_save_post' );
+			$this->assertFalse( $event );
+		} finally {
+			Settings::update_settings(
+				array(
+					'sync_actions_blacklist' => $original_sync_actions_blacklist,
+				)
+			);
+		}
 	}
 
 	public function test_detects_if_exceeded_queue_size_limit_and_oldest_item_gt_15_mins() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Closes SYNC-195



## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* `Jetpack\Sync\Settings`: Add a new Sync setting, `sync_actions_blacklist` that will hold the list of actions we want to blacklist for a certain blog.
* `Jetpack\Sync\Defaults`: Ensure `sync_actions_blacklist` setting will default to an empty array if not set.
* `Jetpack\Sync\Listener`: Check if the current action is blacklisted and return early instead of adding it to Sync's queue.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
SYNC-195

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* SYNC-195

