### PR TITLE
WooCommerce Analytics: Deduplicate product_checkout events

### DIFF
--- a/projects/packages/woocommerce-analytics/README.md
+++ b/projects/packages/woocommerce-analytics/README.md
@@ -98,7 +98,7 @@ When WP Consent API is not available, the package defaults to allowing all track
 | `add_to_cart`             | Add to cart action  | ✓          | PHP (Immediate)  | When products are added to cart                    |
 | `remove_from_cart`        | Remove from cart    | ✓          | PHP (Immediate)  | When products are removed from cart                |
 | `checkout_view`           | Checkout page       | ✓          | PHP → JS Queue   | When checkout page is viewed                       |
-| `product_checkout`        | Checkout page       | ✓          | PHP → JS Queue   | When checkout page is viewed and cart is not empty |
+| `product_checkout`        | Checkout page       | ✓          | PHP (Immediate)  | When checkout page is viewed and cart is not empty (deduplicated per cart state) |
 | `product_purchase`        | Order placed        | ✓          | PHP (Immediate)  | When purchase is completed                         |
 | `order_confirmation_view` | Thank you page      | ✓          | PHP → JS Queue   | When order confirmation page is viewed             |
 | `post_account_creation`   | Account creation    | -          | PHP → JS Queue   | When new account is created during checkout        |

--- a/projects/packages/woocommerce-analytics/changelog/fix-deduplicate-product-checkout-event
+++ b/projects/packages/woocommerce-analytics/changelog/fix-deduplicate-product-checkout-event
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Deduplicate product_checkout events to fire once per cart state instead of on every page load.

--- a/projects/packages/woocommerce-analytics/src/class-universal.php
+++ b/projects/packages/woocommerce-analytics/src/class-universal.php
@@ -340,12 +340,11 @@ class Universal {
 		}
 
 		// Check if JS session changed (if sessionTracking is enabled).
-		// Only re-track if we have both a current and previous session ID to compare,
 		// and they differ - indicating a new session started.
 		$current_session_id = $this->get_js_session_id();
 		$last_session_id    = $session->get( self::CHECKOUT_SESSION_ID_KEY );
 
-		if ( $current_session_id && $last_session_id && $current_session_id !== $last_session_id ) {
+		if ( $current_session_id !== $last_session_id ) {
 			return true; // Session changed.
 		}
 

--- a/projects/packages/woocommerce-analytics/src/class-universal.php
+++ b/projects/packages/woocommerce-analytics/src/class-universal.php
@@ -21,6 +21,16 @@ class Universal {
 	use Woo_Analytics_Trait;
 
 	/**
+	 * Session key for tracking if checkout has been tracked for current cart state.
+	 */
+	const CHECKOUT_TRACKED_KEY = 'wca_checkout_tracked';
+
+	/**
+	 * Session key for storing the last tracked JS session ID.
+	 */
+	const CHECKOUT_SESSION_ID_KEY = 'wca_checkout_session_id';
+
+	/**
 	 * Constructor.
 	 */
 	public function init_hooks() {
@@ -36,6 +46,12 @@ class Universal {
 		add_action( 'woocommerce_after_cart_item_quantity_update', array( $this, 'capture_cart_quantity_update' ), 10, 4 );
 		add_action( 'woocommerce_cart_item_removed', array( $this, 'capture_remove_from_cart' ), 10, 2 );
 		add_filter( 'woocommerce_cart_item_remove_link', array( $this, 'remove_from_cart_attributes' ), 10, 2 );
+
+		// Reset checkout tracking state when cart changes.
+		add_action( 'woocommerce_add_to_cart', array( $this, 'reset_checkout_tracking_state' ) );
+		add_action( 'woocommerce_cart_item_removed', array( $this, 'reset_checkout_tracking_state' ) );
+		add_action( 'woocommerce_after_cart_item_quantity_update', array( $this, 'reset_checkout_tracking_state' ) );
+		add_action( 'woocommerce_cart_emptied', array( $this, 'reset_checkout_tracking_state' ) );
 
 		// Checkout.
 		// Send events after checkout template (shortcode).
@@ -246,7 +262,9 @@ class Universal {
 	}
 
 	/**
-	 * On the Checkout page, trigger an event for each product in the cart
+	 * On the Checkout page, trigger an event for each product in the cart.
+	 * Events are deduplicated based on cart state and session ID.
+	 * Fires PHP-side via record_event() for consistency with product_purchase.
 	 */
 	public function checkout_process() {
 		global $post;
@@ -257,6 +275,16 @@ class Universal {
 		if ( is_object( $session ) ) {
 			$session->set( 'checkout_page_used', 'Yes' === $is_in_checkout_page );
 			$session->save_data();
+		}
+
+		// Skip if cart is empty.
+		if ( empty( $cart ) ) {
+			return;
+		}
+
+		// Deduplicate: check if we should track this checkout.
+		if ( ! $this->should_track_checkout( $session ) ) {
+			return;
 		}
 
 		foreach ( $cart as $cart_item_key => $cart_item ) {
@@ -282,7 +310,80 @@ class Universal {
 			}
 
 			$data['pq'] = $cart_item['quantity'];
-			$this->enqueue_event( 'product_checkout', $this->get_cart_checkout_event_properties( $data ), $product->get_id() );
+			$data['pi'] = $product->get_id();
+
+			// Fire PHP-side for consistency with product_purchase event.
+			WC_Analytics_Tracking::record_event(
+				'product_checkout',
+				$this->get_cart_checkout_event_properties( $data )
+			);
+		}
+
+		// Mark checkout as tracked for this cart state.
+		$this->mark_checkout_tracked( $session );
+	}
+
+	/**
+	 * Check if checkout should be tracked.
+	 * Returns true if cart changed or JS session changed.
+	 *
+	 * @param \WC_Session|null $session WooCommerce session.
+	 * @return bool True if checkout should be tracked.
+	 */
+	private function should_track_checkout( $session ) {
+		if ( ! is_object( $session ) ) {
+			return true; // No session, track to be safe.
+		}
+
+		// Check if already tracked for this cart state.
+		$has_tracked = $session->get( self::CHECKOUT_TRACKED_KEY );
+		if ( ! $has_tracked ) {
+			return true; // Not tracked yet.
+		}
+
+		// Check if JS session changed (if sessionTracking is enabled).
+		// Only re-track if we have both a current and previous session ID to compare,
+		// and they differ - indicating a new session started.
+		$current_session_id = $this->get_js_session_id();
+		$last_session_id    = $session->get( self::CHECKOUT_SESSION_ID_KEY );
+
+		if ( $current_session_id && $last_session_id && $current_session_id !== $last_session_id ) {
+			return true; // Session changed.
+		}
+
+		return false; // Already tracked, no changes.
+	}
+
+	/**
+	 * Mark checkout as tracked and store current session ID.
+	 *
+	 * @param \WC_Session|null $session WooCommerce session.
+	 */
+	private function mark_checkout_tracked( $session ) {
+		if ( ! is_object( $session ) ) {
+			return;
+		}
+
+		$session->set( self::CHECKOUT_TRACKED_KEY, true );
+
+		// Store current JS session ID (if sessionTracking is enabled).
+		$current_session_id = $this->get_js_session_id();
+		if ( $current_session_id ) {
+			$session->set( self::CHECKOUT_SESSION_ID_KEY, $current_session_id );
+		}
+
+		$session->save_data();
+	}
+
+	/**
+	 * Reset checkout tracking state when cart changes.
+	 * This ensures product_checkout fires again after cart modifications.
+	 */
+	public function reset_checkout_tracking_state() {
+		$session = WC()->session;
+		if ( is_object( $session ) ) {
+			$session->set( self::CHECKOUT_TRACKED_KEY, false );
+			$session->save_data();
 		}
 	}
 

--- a/projects/packages/woocommerce-analytics/src/class-universal.php
+++ b/projects/packages/woocommerce-analytics/src/class-universal.php
@@ -369,8 +369,6 @@ class Universal {
 		if ( $current_session_id ) {
 			$session->set( self::CHECKOUT_SESSION_ID_KEY, $current_session_id );
 		}
-
-		$session->save_data();
 	}
 
 	/**
@@ -381,7 +379,6 @@ class Universal {
 		$session = WC()->session;
 		if ( is_object( $session ) ) {
 			$session->set( self::CHECKOUT_TRACKED_KEY, false );
-			$session->save_data();
 		}
 	}
 

--- a/projects/packages/woocommerce-analytics/src/class-universal.php
+++ b/projects/packages/woocommerce-analytics/src/class-universal.php
@@ -277,7 +277,6 @@ class Universal {
 			$session->save_data();
 		}
 
-		// Skip if cart is empty.
 		if ( empty( $cart ) ) {
 			return;
 		}
@@ -319,7 +318,6 @@ class Universal {
 			);
 		}
 
-		// Mark checkout as tracked for this cart state.
 		$this->mark_checkout_tracked( $session );
 	}
 

--- a/projects/packages/woocommerce-analytics/src/class-woo-analytics-trait.php
+++ b/projects/packages/woocommerce-analytics/src/class-woo-analytics-trait.php
@@ -316,6 +316,25 @@ trait Woo_Analytics_Trait {
 	}
 
 	/**
+	 * Get JS session ID from cookie (if sessionTracking is enabled).
+	 * Cookie format: {"session_id":"uuid","landing_page":"...","expires":"..."}
+	 *
+	 * @return string|null Session ID or null if not available.
+	 */
+	protected function get_js_session_id() {
+		$cookie_name = 'woocommerceanalytics_session';
+
+		if ( ! isset( $_COOKIE[ $cookie_name ] ) ) {
+			return null;
+		}
+
+		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- We're just reading and JSON-decoding the cookie.
+		$cookie_value = wp_unslash( $_COOKIE[ $cookie_name ] );
+		$cookie_data  = json_decode( urldecode( $cookie_value ), true );
+		return $cookie_data['session_id'] ?? null;
+	}
+
+	/**
 	 * Gather relevant product information
 	 *
 	 * @param \WC_Product $product product.

--- a/projects/packages/woocommerce-analytics/src/class-woo-analytics-trait.php
+++ b/projects/packages/woocommerce-analytics/src/class-woo-analytics-trait.php
@@ -332,7 +332,7 @@ trait Woo_Analytics_Trait {
 		$cookie_value = wp_unslash( $_COOKIE[ $cookie_name ] );
 		$cookie_data  = json_decode( urldecode( $cookie_value ), true );
 
-		if ( ! is_array( $cookie_data ) ) {
+		if ( JSON_ERROR_NONE !== json_last_error() || ! is_array( $cookie_data ) ) {
 			return null;
 		}
 		return $cookie_data['session_id'] ?? null;

--- a/projects/packages/woocommerce-analytics/src/class-woo-analytics-trait.php
+++ b/projects/packages/woocommerce-analytics/src/class-woo-analytics-trait.php
@@ -331,6 +331,10 @@ trait Woo_Analytics_Trait {
 		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- We're just reading and JSON-decoding the cookie.
 		$cookie_value = wp_unslash( $_COOKIE[ $cookie_name ] );
 		$cookie_data  = json_decode( urldecode( $cookie_value ), true );
+
+		if ( ! is_array( $cookie_data ) ) {
+			return null;
+		}
 		return $cookie_data['session_id'] ?? null;
 	}
 

--- a/projects/packages/woocommerce-analytics/tests/php/Universal_Test.php
+++ b/projects/packages/woocommerce-analytics/tests/php/Universal_Test.php
@@ -26,6 +26,29 @@ class Universal_Test extends BaseTestCase {
 	}
 
 	/**
+	 * Helper method to set up a mock session cookie with a session ID.
+	 * The cookie name matches the one used in get_js_session_id() method.
+	 *
+	 * @param string $session_id The session ID to set in the cookie.
+	 */
+	private function set_session_cookie( $session_id ) {
+		$_COOKIE['woocommerceanalytics_session'] = rawurlencode(
+			wp_json_encode(
+				array(
+					'session_id' => $session_id,
+				)
+			)
+		);
+	}
+
+	/**
+	 * Helper method to clear the session cookie.
+	 */
+	private function clear_session_cookie() {
+		unset( $_COOKIE['woocommerceanalytics_session'] );
+	}
+
+	/**
 	 * Test that order_process calls wc_get_order with an integer order ID.
 	 */
 	public function test_order_process_handles_integer_order_id(): void {
@@ -148,5 +171,227 @@ class Universal_Test extends BaseTestCase {
 			Universal::CHECKOUT_SESSION_ID_KEY,
 			'CHECKOUT_SESSION_ID_KEY should be defined correctly.'
 		);
+	}
+
+	/**
+	 * Test that first checkout should be tracked.
+	 */
+	public function test_first_checkout_should_track(): void {
+		$session = new \WC_Session();
+
+		// Create a mock WC instance with the session.
+		$wc_mock          = new \stdClass();
+		$wc_mock->session = $session;
+		set_wc_mock_instance( $wc_mock );
+
+		$universal = new Universal();
+
+		// Use reflection to test the private should_track_checkout method.
+		$reflection = new \ReflectionClass( $universal );
+		$method     = $reflection->getMethod( 'should_track_checkout' );
+		$method->setAccessible( true );
+
+		// First checkout - should return true.
+		$result = $method->invoke( $universal, $session );
+		$this->assertTrue( $result, 'First checkout should be tracked.' );
+
+		// Clean up.
+		reset_wc_mock_instance();
+	}
+
+	/**
+	 * Test that duplicate checkout with same cart state should not track.
+	 */
+	public function test_duplicate_checkout_same_cart_should_not_track(): void {
+		$session = new \WC_Session();
+		$session->set( Universal::CHECKOUT_TRACKED_KEY, true );
+
+		// Create a mock WC instance with the session.
+		$wc_mock          = new \stdClass();
+		$wc_mock->session = $session;
+		set_wc_mock_instance( $wc_mock );
+
+		$universal = new Universal();
+
+		// Use reflection to test the private should_track_checkout method.
+		$reflection = new \ReflectionClass( $universal );
+		$method     = $reflection->getMethod( 'should_track_checkout' );
+		$method->setAccessible( true );
+
+		// Duplicate checkout - should return false.
+		$result = $method->invoke( $universal, $session );
+		$this->assertFalse( $result, 'Duplicate checkout with same cart state should not be tracked.' );
+
+		// Clean up.
+		reset_wc_mock_instance();
+	}
+
+	/**
+	 * Test that checkout after cart modification should track.
+	 */
+	public function test_checkout_after_cart_modification_should_track(): void {
+		$session = new \WC_Session();
+		$session->set( Universal::CHECKOUT_TRACKED_KEY, true );
+
+		// Create a mock WC instance with the session.
+		$wc_mock          = new \stdClass();
+		$wc_mock->session = $session;
+		set_wc_mock_instance( $wc_mock );
+
+		$universal = new Universal();
+
+		// Simulate cart modification by resetting the tracking state.
+		$universal->reset_checkout_tracking_state();
+
+		// Use reflection to test the private should_track_checkout method.
+		$reflection = new \ReflectionClass( $universal );
+		$method     = $reflection->getMethod( 'should_track_checkout' );
+		$method->setAccessible( true );
+
+		// After cart modification - should return true.
+		$result = $method->invoke( $universal, $session );
+		$this->assertTrue( $result, 'Checkout after cart modification should be tracked.' );
+
+		// Clean up.
+		reset_wc_mock_instance();
+	}
+
+	/**
+	 * Test that checkout with different JS session ID should track.
+	 */
+	public function test_checkout_with_different_session_id_should_track(): void {
+		$session = new \WC_Session();
+		$session->set( Universal::CHECKOUT_TRACKED_KEY, true );
+		$session->set( Universal::CHECKOUT_SESSION_ID_KEY, 'old-session-id' );
+
+		// Create a mock WC instance with the session.
+		$wc_mock          = new \stdClass();
+		$wc_mock->session = $session;
+		set_wc_mock_instance( $wc_mock );
+
+		// Mock the cookie with a new session ID.
+		$this->set_session_cookie( 'new-session-id' );
+
+		$universal = new Universal();
+
+		// Use reflection to test the private should_track_checkout method.
+		$reflection = new \ReflectionClass( $universal );
+		$method     = $reflection->getMethod( 'should_track_checkout' );
+		$method->setAccessible( true );
+
+		// With different session ID - should return true.
+		$result = $method->invoke( $universal, $session );
+		$this->assertTrue( $result, 'Checkout with different JS session ID should be tracked.' );
+
+		// Clean up.
+		$this->clear_session_cookie();
+		reset_wc_mock_instance();
+	}
+
+	/**
+	 * Test that checkout with same JS session ID should not track.
+	 */
+	public function test_checkout_with_same_session_id_should_not_track(): void {
+		$session = new \WC_Session();
+		$session->set( Universal::CHECKOUT_TRACKED_KEY, true );
+		$session->set( Universal::CHECKOUT_SESSION_ID_KEY, 'same-session-id' );
+
+		// Create a mock WC instance with the session.
+		$wc_mock          = new \stdClass();
+		$wc_mock->session = $session;
+		set_wc_mock_instance( $wc_mock );
+
+		// Mock the cookie with the same session ID.
+		$this->set_session_cookie( 'same-session-id' );
+
+		$universal = new Universal();
+
+		// Use reflection to test the private should_track_checkout method.
+		$reflection = new \ReflectionClass( $universal );
+		$method     = $reflection->getMethod( 'should_track_checkout' );
+		$method->setAccessible( true );
+
+		// With same session ID - should return false.
+		$result = $method->invoke( $universal, $session );
+		$this->assertFalse( $result, 'Checkout with same JS session ID should not be tracked.' );
+
+		// Clean up.
+		$this->clear_session_cookie();
+		reset_wc_mock_instance();
+	}
+
+	/**
+	 * Test that mark_checkout_tracked stores the session ID.
+	 */
+	public function test_mark_checkout_tracked_stores_session_id(): void {
+		$session = new \WC_Session();
+
+		// Create a mock WC instance with the session.
+		$wc_mock          = new \stdClass();
+		$wc_mock->session = $session;
+		set_wc_mock_instance( $wc_mock );
+
+		// Mock the cookie with a session ID.
+		$this->set_session_cookie( 'test-session-id' );
+
+		$universal = new Universal();
+
+		// Use reflection to test the private mark_checkout_tracked method.
+		$reflection = new \ReflectionClass( $universal );
+		$method     = $reflection->getMethod( 'mark_checkout_tracked' );
+		$method->setAccessible( true );
+
+		// Mark checkout as tracked.
+		$method->invoke( $universal, $session );
+
+		// Verify the session was marked as tracked.
+		$this->assertTrue(
+			$session->get( Universal::CHECKOUT_TRACKED_KEY ),
+			'Session should be marked as tracked.'
+		);
+
+		// Verify the session ID was stored.
+		$this->assertSame(
+			'test-session-id',
+			$session->get( Universal::CHECKOUT_SESSION_ID_KEY ),
+			'Session ID should be stored.'
+		);
+
+		// Clean up.
+		$this->clear_session_cookie();
+		reset_wc_mock_instance();
+	}
+
+	/**
+	 * Test that mark_checkout_tracked handles null session gracefully.
+	 */
+	public function test_mark_checkout_tracked_handles_null_session(): void {
+		$this->expectNotToPerformAssertions();
+
+		$universal = new Universal();
+
+		// Use reflection to test the private mark_checkout_tracked method.
+		$reflection = new \ReflectionClass( $universal );
+		$method     = $reflection->getMethod( 'mark_checkout_tracked' );
+		$method->setAccessible( true );
+
+		// Should not throw an exception with null session.
+		$method->invoke( $universal, null );
+	}
+
+	/**
+	 * Test that should_track_checkout handles null session.
+	 */
+	public function test_should_track_checkout_handles_null_session(): void {
+		$universal = new Universal();
+
+		// Use reflection to test the private should_track_checkout method.
+		$reflection = new \ReflectionClass( $universal );
+		$method     = $reflection->getMethod( 'should_track_checkout' );
+		$method->setAccessible( true );
+
+		// With null session - should return true (safe to track).
+		$result = $method->invoke( $universal, null );
+		$this->assertTrue( $result, 'should_track_checkout should return true with null session.' );
 	}
 }

--- a/projects/packages/woocommerce-analytics/tests/php/Universal_Test.php
+++ b/projects/packages/woocommerce-analytics/tests/php/Universal_Test.php
@@ -50,6 +50,20 @@ class Universal_Test extends BaseTestCase {
 	}
 
 	/**
+	 * Helper method to make a reflection method accessible.
+	 * Only calls setAccessible() on PHP < 8.1 where it's required.
+	 * PHP 8.1+ makes private/protected methods accessible by default via reflection.
+	 * PHP 8.5+ deprecates setAccessible() since it's a no-op.
+	 *
+	 * @param \ReflectionMethod $method The reflection method to make accessible.
+	 */
+	private function make_method_accessible( \ReflectionMethod $method ) {
+		if ( PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
+	}
+
+	/**
 	 * Test that order_process calls wc_get_order with an integer order ID.
 	 */
 	public function test_order_process_handles_integer_order_id(): void {
@@ -190,7 +204,7 @@ class Universal_Test extends BaseTestCase {
 		// Use reflection to test the private should_track_checkout method.
 		$reflection = new \ReflectionClass( $universal );
 		$method     = $reflection->getMethod( 'should_track_checkout' );
-		$method->setAccessible( true );
+		$this->make_method_accessible( $method );
 
 		// First checkout - should return true.
 		$result = $method->invoke( $universal, $session );
@@ -217,7 +231,7 @@ class Universal_Test extends BaseTestCase {
 		// Use reflection to test the private should_track_checkout method.
 		$reflection = new \ReflectionClass( $universal );
 		$method     = $reflection->getMethod( 'should_track_checkout' );
-		$method->setAccessible( true );
+		$this->make_method_accessible( $method );
 
 		// Duplicate checkout - should return false.
 		$result = $method->invoke( $universal, $session );
@@ -247,7 +261,7 @@ class Universal_Test extends BaseTestCase {
 		// Use reflection to test the private should_track_checkout method.
 		$reflection = new \ReflectionClass( $universal );
 		$method     = $reflection->getMethod( 'should_track_checkout' );
-		$method->setAccessible( true );
+		$this->make_method_accessible( $method );
 
 		// After cart modification - should return true.
 		$result = $method->invoke( $universal, $session );
@@ -278,7 +292,7 @@ class Universal_Test extends BaseTestCase {
 		// Use reflection to test the private should_track_checkout method.
 		$reflection = new \ReflectionClass( $universal );
 		$method     = $reflection->getMethod( 'should_track_checkout' );
-		$method->setAccessible( true );
+		$this->make_method_accessible( $method );
 
 		// With different session ID - should return true.
 		$result = $method->invoke( $universal, $session );
@@ -310,7 +324,7 @@ class Universal_Test extends BaseTestCase {
 		// Use reflection to test the private should_track_checkout method.
 		$reflection = new \ReflectionClass( $universal );
 		$method     = $reflection->getMethod( 'should_track_checkout' );
-		$method->setAccessible( true );
+		$this->make_method_accessible( $method );
 
 		// With same session ID - should return false.
 		$result = $method->invoke( $universal, $session );
@@ -340,7 +354,7 @@ class Universal_Test extends BaseTestCase {
 		// Use reflection to test the private mark_checkout_tracked method.
 		$reflection = new \ReflectionClass( $universal );
 		$method     = $reflection->getMethod( 'mark_checkout_tracked' );
-		$method->setAccessible( true );
+		$this->make_method_accessible( $method );
 
 		// Mark checkout as tracked.
 		$method->invoke( $universal, $session );
@@ -374,7 +388,7 @@ class Universal_Test extends BaseTestCase {
 		// Use reflection to test the private mark_checkout_tracked method.
 		$reflection = new \ReflectionClass( $universal );
 		$method     = $reflection->getMethod( 'mark_checkout_tracked' );
-		$method->setAccessible( true );
+		$this->make_method_accessible( $method );
 
 		// Should not throw an exception with null session.
 		$method->invoke( $universal, null );
@@ -389,7 +403,7 @@ class Universal_Test extends BaseTestCase {
 		// Use reflection to test the private should_track_checkout method.
 		$reflection = new \ReflectionClass( $universal );
 		$method     = $reflection->getMethod( 'should_track_checkout' );
-		$method->setAccessible( true );
+		$this->make_method_accessible( $method );
 
 		// With null session - should return true (safe to track).
 		$result = $method->invoke( $universal, null );

--- a/projects/packages/woocommerce-analytics/tests/php/Universal_Test.php
+++ b/projects/packages/woocommerce-analytics/tests/php/Universal_Test.php
@@ -90,4 +90,63 @@ class Universal_Test extends BaseTestCase {
 		// If we get here without errors, the method completed without processing a non-existent order.
 		$this->assertTrue( true, 'order_process should handle a missing order without throwing an exception.' );
 	}
+
+	/**
+	 * Test that reset_checkout_tracking_state clears the session flag.
+	 */
+	public function test_reset_checkout_tracking_state_clears_session(): void {
+		$session = new \WC_Session();
+		$session->set( Universal::CHECKOUT_TRACKED_KEY, true );
+
+		// Create a mock WC instance with the session.
+		$wc_mock          = new \stdClass();
+		$wc_mock->session = $session;
+		set_wc_mock_instance( $wc_mock );
+
+		$universal = new Universal();
+		$universal->reset_checkout_tracking_state();
+
+		$this->assertFalse(
+			$session->get( Universal::CHECKOUT_TRACKED_KEY ),
+			'reset_checkout_tracking_state should set the tracked key to false.'
+		);
+
+		// Clean up.
+		reset_wc_mock_instance();
+	}
+
+	/**
+	 * Test that reset_checkout_tracking_state works when session is not available.
+	 */
+	public function test_reset_checkout_tracking_state_handles_null_session(): void {
+		// Create a mock WC instance with null session.
+		$wc_mock          = new \stdClass();
+		$wc_mock->session = null;
+		set_wc_mock_instance( $wc_mock );
+
+		$universal = new Universal();
+
+		// Should not throw an exception.
+		$universal->reset_checkout_tracking_state();
+		$this->assertTrue( true, 'reset_checkout_tracking_state should handle null session without throwing an exception.' );
+
+		// Clean up.
+		reset_wc_mock_instance();
+	}
+
+	/**
+	 * Test that checkout tracking session keys are defined correctly.
+	 */
+	public function test_checkout_session_keys_are_defined(): void {
+		$this->assertSame(
+			'wca_checkout_tracked',
+			Universal::CHECKOUT_TRACKED_KEY,
+			'CHECKOUT_TRACKED_KEY should be defined correctly.'
+		);
+		$this->assertSame(
+			'wca_checkout_session_id',
+			Universal::CHECKOUT_SESSION_ID_KEY,
+			'CHECKOUT_SESSION_ID_KEY should be defined correctly.'
+		);
+	}
 }

--- a/projects/packages/woocommerce-analytics/tests/php/Universal_Test.php
+++ b/projects/packages/woocommerce-analytics/tests/php/Universal_Test.php
@@ -36,7 +36,8 @@ class Universal_Test extends BaseTestCase {
 			wp_json_encode(
 				array(
 					'session_id' => $session_id,
-				)
+				),
+				JSON_UNESCAPED_SLASHES
 			)
 		);
 	}

--- a/projects/packages/woocommerce-analytics/tests/php/bootstrap.php
+++ b/projects/packages/woocommerce-analytics/tests/php/bootstrap.php
@@ -13,6 +13,7 @@ require_once __DIR__ . '/../../vendor/autoload.php';
 // Include WooCommerce mocks before initializing test environment.
 require_once __DIR__ . '/mocks/woocommerce-functions.php';
 require_once __DIR__ . '/mocks/class-wc-order.php';
+require_once __DIR__ . '/mocks/class-wc-session.php';
 require_once __DIR__ . '/mocks/class-wc-tracks.php';
 
 // Initialize WordPress test environment.

--- a/projects/packages/woocommerce-analytics/tests/php/mocks/class-wc-session.php
+++ b/projects/packages/woocommerce-analytics/tests/php/mocks/class-wc-session.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * Mock WC_Session class for testing.
+ *
+ * @package automattic/woocommerce-analytics
+ */
+
+if ( ! class_exists( 'WC_Session' ) ) {
+	/**
+	 * Mock WC_Session class for testing.
+	 */
+	class WC_Session {
+		/**
+		 * Session data storage.
+		 *
+		 * @var array
+		 */
+		private $data = array();
+
+		/**
+		 * Get a session variable.
+		 *
+		 * @param string $key Key to get.
+		 * @param mixed  $default Default value if key doesn't exist.
+		 * @return mixed
+		 */
+		public function get( $key, $default = null ) {
+			return $this->data[ $key ] ?? $default;
+		}
+
+		/**
+		 * Set a session variable.
+		 *
+		 * @param string $key Key to set.
+		 * @param mixed  $value Value to set.
+		 */
+		public function set( $key, $value ) {
+			$this->data[ $key ] = $value;
+		}
+
+		/**
+		 * Save session data (no-op in mock).
+		 */
+		public function save_data() {
+			// No-op in tests.
+		}
+
+		/**
+		 * Get all session data (for testing).
+		 *
+		 * @return array
+		 */
+		public function get_all_data() {
+			return $this->data;
+		}
+
+		/**
+		 * Clear all session data (for testing).
+		 */
+		public function clear_data() {
+			$this->data = array();
+		}
+	}
+}

--- a/projects/packages/woocommerce-analytics/tests/php/mocks/class-wc-session.php
+++ b/projects/packages/woocommerce-analytics/tests/php/mocks/class-wc-session.php
@@ -39,13 +39,6 @@ if ( ! class_exists( 'WC_Session' ) ) {
 		}
 
 		/**
-		 * Save session data (no-op in mock).
-		 */
-		public function save_data() {
-			// No-op in tests.
-		}
-
-		/**
 		 * Get all session data (for testing).
 		 *
 		 * @return array

--- a/projects/packages/woocommerce-analytics/tests/php/mocks/woocommerce-functions.php
+++ b/projects/packages/woocommerce-analytics/tests/php/mocks/woocommerce-functions.php
@@ -23,6 +23,14 @@ $wc_get_order_mock_return = false;
 global $wc_get_order_calls;
 $wc_get_order_calls = array();
 
+/**
+ * Global variable to store mock WC instance for testing.
+ *
+ * @var object|null
+ */
+global $wc_mock_instance;
+$wc_mock_instance = null;
+
 if ( ! function_exists( 'wc_get_order' ) ) {
 	/**
 	 * Mock wc_get_order function.
@@ -44,6 +52,10 @@ if ( ! function_exists( 'WC' ) ) {
 	 * @return object Mock WooCommerce object.
 	 */
 	function WC() {
+		global $wc_mock_instance;
+		if ( $wc_mock_instance !== null ) {
+			return $wc_mock_instance;
+		}
 		return new class() {
 			/**
 			 * Session property.
@@ -53,4 +65,22 @@ if ( ! function_exists( 'WC' ) ) {
 			public $session = null;
 		};
 	}
+}
+
+/**
+ * Helper function to set the mock WC instance for testing.
+ *
+ * @param object|null $instance The mock WC instance.
+ */
+function set_wc_mock_instance( $instance ) {
+	global $wc_mock_instance;
+	$wc_mock_instance = $instance;
+}
+
+/**
+ * Helper function to reset the mock WC instance.
+ */
+function reset_wc_mock_instance() {
+	global $wc_mock_instance;
+	$wc_mock_instance = null;
 }


### PR DESCRIPTION
Related to [WOOA7S-929](https://linear.app/a8c/issue/WOOA7S-929)

## Problem

The `product_checkout` event currently fires every time the checkout page loads, causing duplicate events on page refresh. This is inconsistent with the `product_purchase` event, which only fires on the final purchase. Since two events are often analyzed together, this inconsistency can lead to misleading insights.

**Current behavior:**
- User visits checkout → event fires ✓
- User refreshes page → event fires again ✗ (duplicate)
- User refreshes again → event fires again ✗ (duplicate)

**Expected behavior:**
- User visits checkout → event fires ✓
- User refreshes page → no event (same cart, same session)
- User modifies cart → event fires again ✓ (cart changed)

## Proposed changes:

* **Deduplicate `product_checkout` events** using WC Session storage to track if checkout has already been recorded for the current cart state
* **Fire `product_checkout` PHP-side** via `record_event()` for consistency with `product_purchase` event (both now fire server-side)
* **Reset tracking state automatically** when cart changes (add/remove items, quantity updates) via WooCommerce hooks
* **Include JS session ID tracking** for sessionTracking feature support - when a new JS session starts, events fire again to capture the new session

### Technical approach

1. Store a `wca_checkout_tracked` flag in WC Session when `product_checkout` fires
2. On subsequent checkout page loads, check if flag is set - if so, skip firing events
3. Hook into cart modification actions to reset the flag when cart changes
4. Optionally track JS session ID to detect session changes (when ClickHouse/sessionTracking is enabled)

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?

No, this PR does not change what data we track. It reduces duplicate events while preserving meaningful tracking:
- Events still fire on first checkout page visit
- Events still fire when cart changes (add/remove/quantity update)
- Events still fire when JS session changes (if sessionTracking is enabled)

## Testing instructions:



1. Set up a WooCommerce store with Jetpack connected and WooCommerce Analytics enabled
2. Add the following code snippet to your theme's functions.php or use a code snippet plugin:

```php
add_filter( 'jetpack_woocommerce_analytics_event_props', function( $event_properties, $event_name ) {
    error_log( 'Tracks event: ' . $event_name );
    return $event_properties;
}, 10, 2 );
```

3. Add a product to cart
4. Go to checkout page - `product_checkout` event should fire (check debug.log)
5. Refresh checkout page - event should **NOT** fire again
6. Go back to cart, change quantity, return to checkout - event **SHOULD** fire again
7. Go back to cart, add another product, return to checkout - event **SHOULD** fire again
8. Change `woocommerceanalytics_session`  cookie session id value (simulate new session)
10. Go to checkout page - event **SHOULD** fire again

| Scenario | Expected |
|----------|----------|
| First checkout page load | Events fire for each item |
| Page refresh (same cart, same session) | No events fire |
| Add/remove item, return to checkout | Events fire again |
| Change quantity, return to checkout | Events fire again |
| JS session expires (if sessionTracking enabled) | Events fire again |