### PR TITLE
Gate donations behind a conditional feature, v3

### DIFF
--- a/projects/packages/blocks/changelog/update-gate-donations-behind-conditional-features-v3
+++ b/projects/packages/blocks/changelog/update-gate-donations-behind-conditional-features-v3
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Gating for the donations block

--- a/projects/packages/blocks/src/class-blocks.php
+++ b/projects/packages/blocks/src/class-blocks.php
@@ -75,11 +75,18 @@ class Blocks {
 		if ( ! self::is_standalone_block() ) {
 			// If the block is dynamic, and a Jetpack block, wrap the render_callback to check availability.
 			if ( ! empty( $args['plan_check'] ) ) {
+				$existing_attributes = array();
+				if ( 'jetpack/donations' === $slug && is_string( $block_type ) && file_exists( $block_type ) ) {
+					$metadata            = self::get_block_metadata( $block_type );
+					$existing_attributes = isset( $metadata['attributes'] ) ? $metadata['attributes'] : array();
+				}
+
 				// Set up attributes.
 				if ( ! isset( $args['attributes'] ) ) {
 					$args['attributes'] = array();
 				}
 				$args['attributes'] = array_merge(
+					$existing_attributes,
 					$args['attributes'],
 					array(
 						// Indicates that this block should display an upgrade nudge on the frontend when applicable.

--- a/projects/plugins/jetpack/changelog/update-gate-donations-behind-conditional-features-v3
+++ b/projects/plugins/jetpack/changelog/update-gate-donations-behind-conditional-features-v3
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Gating for the donations block

--- a/projects/plugins/jetpack/class.jetpack-gutenberg.php
+++ b/projects/plugins/jetpack/class.jetpack-gutenberg.php
@@ -69,6 +69,20 @@ class Jetpack_Gutenberg {
 	);
 
 	/**
+	 * Fallback minimum plan requirements for WordPress.com/Atomic sites.
+	 *
+	 * Used when features have conditional availability (e.g., sticker-based gating)
+	 * and don't appear in features_data['available']. This only affects the upsell
+	 * message shown to users.
+	 *
+	 * @since $$next-version$$
+	 * @var array Feature slug => minimum WordPress.com plan slug.
+	 */
+	private static $wpcom_minimum_plan_fallbacks = array(
+		'donations' => 'value_bundle',
+	);
+
+	/**
 	 * Storing the contents of the preset file.
 	 *
 	 * Already been json_decode.
@@ -1267,6 +1281,10 @@ class Jetpack_Gutenberg {
 
 			if ( ! empty( $features_data['available'][ $slug ] ) ) {
 				$plan = $features_data['available'][ $slug ][0];
+			} elseif ( isset( self::$wpcom_minimum_plan_fallbacks[ $slug ] ) ) {
+				// Fallback for features with conditional availability (e.g., sticker-based gating)
+				// that don't appear in features_data['available'].
+				$plan = self::$wpcom_minimum_plan_fallbacks[ $slug ];
 			}
 		} else {
 			// Jetpack sites.

--- a/projects/plugins/jetpack/extensions/blocks/donations/donations.php
+++ b/projects/plugins/jetpack/extensions/blocks/donations/donations.php
@@ -31,6 +31,7 @@ function register_block() {
 			__DIR__,
 			array(
 				'render_callback' => __NAMESPACE__ . '\render_block',
+				'plan_check'      => true,
 			)
 		);
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Part of DOTCOM-15586

## Proposed changes:

* Feature gates Donations based on a sticker
* This change broke a Calypso e2e test. As it turns out, once the block is gated, the attributes aren't preserved for reasons I couldn't understand, perhaps due to a bug. So, in this change, we bundle the gating with a conditional bugfix for this particular block only

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:

* Two dev blogs, one with the sticker, and one without
```
add_blog_sticker( 'gating-business-q1', null, null, 247144906 );
```
* Confirm that on the site with the sticker, the Donations block requires Premium (you'll need to be on Personal)

<img width="1106" height="308" alt="Screenshot 2026-01-07 at 17 25 04" src="https://github.com/user-attachments/assets/cf0f0e7e-7d4c-4695-aac0-f0e95e0378b8" />

* Confirm that on the site without the sticker, the Donations block doesn't require Premium

Here's a screenshot of the e2e test that used to fail, ran locally.

```yarn workspace wp-e2e-tests test --group=jetpack-wpcom-integration```
<img width="774" height="464" alt="Screenshot 2026-01-08 at 13 02 12" src="https://github.com/user-attachments/assets/ef67af23-ded1-4c3d-bb8e-d57a37792cea" />