### PR TITLE
Forms: add dashboard tabs with feature flag

### DIFF
--- a/projects/packages/forms/changelog/add-central-form-dashboard-tabs
+++ b/projects/packages/forms/changelog/add-central-form-dashboard-tabs
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Forms: add centralized dashboard tabs.

--- a/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
@@ -1493,29 +1493,31 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 	 */
 	public function get_forms_config( WP_REST_Request $request ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 		$config = array(
+			// Feature flags.
+			'isCentralFormManagementEnabled' => Contact_Form_Plugin::has_editor_feature_flag( 'central-form-management' ),
 			// From jpFormsBlocks in class-contact-form-block.php.
-			'formsResponsesUrl'         => Forms_Dashboard::get_forms_admin_url(),
-			'isMailPoetEnabled'         => Jetpack_Forms::is_mailpoet_enabled(),
-			'isHostingerReachEnabled'   => Jetpack_Forms::is_hostinger_reach_enabled(),
+			'formsResponsesUrl'              => Forms_Dashboard::get_forms_admin_url(),
+			'isMailPoetEnabled'              => Jetpack_Forms::is_mailpoet_enabled(),
+			'isHostingerReachEnabled'        => Jetpack_Forms::is_hostinger_reach_enabled(),
 			// From config in class-dashboard.php.
-			'blogId'                    => get_current_blog_id(),
-			'gdriveConnectSupportURL'   => esc_url( Redirect::get_url( 'jetpack-support-contact-form-export' ) ),
-			'pluginAssetsURL'           => Jetpack_Forms::assets_url(),
-			'siteURL'                   => ( new Status() )->get_site_suffix(),
-			'hasFeedback'               => ( new Forms_Dashboard() )->has_feedback(),
-			'isNotesEnabled'            => Forms_Dashboard::is_notes_enabled(),
-			'isIntegrationsEnabled'     => Jetpack_Forms::is_integrations_enabled(),
-			'isWebhooksEnabled'         => Jetpack_Forms::is_webhooks_enabled(),
-			'showDashboardIntegrations' => Jetpack_Forms::show_dashboard_integrations(),
-			'showBlockIntegrations'     => Jetpack_Forms::show_block_integrations(),
-			'showIntegrationIcons'      => Jetpack_Forms::show_integration_icons(),
-			'dashboardURL'              => Forms_Dashboard::get_forms_admin_url(),
+			'blogId'                         => get_current_blog_id(),
+			'gdriveConnectSupportURL'        => esc_url( Redirect::get_url( 'jetpack-support-contact-form-export' ) ),
+			'pluginAssetsURL'                => Jetpack_Forms::assets_url(),
+			'siteURL'                        => ( new Status() )->get_site_suffix(),
+			'hasFeedback'                    => ( new Forms_Dashboard() )->has_feedback(),
+			'isNotesEnabled'                 => Forms_Dashboard::is_notes_enabled(),
+			'isIntegrationsEnabled'          => Jetpack_Forms::is_integrations_enabled(),
+			'isWebhooksEnabled'              => Jetpack_Forms::is_webhooks_enabled(),
+			'showDashboardIntegrations'      => Jetpack_Forms::show_dashboard_integrations(),
+			'showBlockIntegrations'          => Jetpack_Forms::show_block_integrations(),
+			'showIntegrationIcons'           => Jetpack_Forms::show_integration_icons(),
+			'dashboardURL'                   => Forms_Dashboard::get_forms_admin_url(),
 			// New data.
-			'canInstallPlugins'         => current_user_can( 'install_plugins' ),
-			'canActivatePlugins'        => current_user_can( 'activate_plugins' ),
-			'exportNonce'               => wp_create_nonce( 'feedback_export' ),
-			'newFormNonce'              => wp_create_nonce( 'create_new_form' ),
-			'emptyTrashDays'            => defined( 'EMPTY_TRASH_DAYS' ) ? EMPTY_TRASH_DAYS : 0,
+			'canInstallPlugins'              => current_user_can( 'install_plugins' ),
+			'canActivatePlugins'             => current_user_can( 'activate_plugins' ),
+			'exportNonce'                    => wp_create_nonce( 'feedback_export' ),
+			'newFormNonce'                   => wp_create_nonce( 'create_new_form' ),
+			'emptyTrashDays'                 => defined( 'EMPTY_TRASH_DAYS' ) ? EMPTY_TRASH_DAYS : 0,
 		);
 
 		return rest_ensure_response( $config );

--- a/projects/packages/forms/src/dashboard/components/forms-responses-tabs/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/forms-responses-tabs/index.tsx
@@ -1,0 +1,41 @@
+/**
+ * External dependencies
+ */
+import { useCallback } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { useLocation, useNavigate } from 'react-router';
+/**
+ * Internal dependencies
+ */
+import * as Tabs from '../tabs/index.ts';
+
+type TabValue = 'forms' | 'responses';
+
+/**
+ * Route-aware top tabs for the Forms dashboard (Forms / All Responses).
+ * This component controls routing; it does not manage filters.
+ *
+ * @return {JSX.Element} The tabs component.
+ */
+export default function FormsResponsesTabs(): JSX.Element {
+	const location = useLocation();
+	const navigate = useNavigate();
+
+	const value: TabValue = location.pathname === '/forms' ? 'forms' : 'responses';
+
+	const onValueChange = useCallback(
+		( nextValue: TabValue ) => {
+			navigate( nextValue === 'forms' ? '/forms' : '/responses' );
+		},
+		[ navigate ]
+	);
+
+	return (
+		<Tabs.Root value={ value } onValueChange={ onValueChange }>
+			<Tabs.List density="compact">
+				<Tabs.Tab value="forms">{ __( 'Forms', 'jetpack-forms' ) }</Tabs.Tab>
+				<Tabs.Tab value="responses">{ __( 'All Responses', 'jetpack-forms' ) }</Tabs.Tab>
+			</Tabs.List>
+		</Tabs.Root>
+	);
+}

--- a/projects/packages/forms/src/dashboard/forms/index.tsx
+++ b/projects/packages/forms/src/dashboard/forms/index.tsx
@@ -1,0 +1,57 @@
+/**
+ * External dependencies
+ */
+import { JetpackLogo } from '@automattic/jetpack-components';
+import { useEffect } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { useNavigate } from 'react-router';
+/**
+ * Internal dependencies
+ */
+import useConfigValue from '../../hooks/use-config-value.ts';
+import FormsResponsesTabs from '../components/forms-responses-tabs/index.tsx';
+import Page from '../components/page/index.tsx';
+
+/**
+ * Forms dashboard "Forms" route placeholder.
+ *
+ * @return {JSX.Element|null} The placeholder page, or null when redirecting.
+ */
+export default function FormsDashboardForms(): JSX.Element | null {
+	const navigate = useNavigate();
+	const isCentralFormManagementEnabled = useConfigValue( 'isCentralFormManagementEnabled' );
+
+	useEffect( () => {
+		if ( isCentralFormManagementEnabled === false ) {
+			navigate( '/responses', { replace: true } );
+		}
+	}, [ isCentralFormManagementEnabled, navigate ] );
+
+	// Avoid rendering the placeholder if the flag is off (we'll redirect).
+	if ( isCentralFormManagementEnabled === false ) {
+		return null;
+	}
+
+	return (
+		<div className="jp-forms-layout__surface is-stage">
+			<Page
+				title={
+					<div className="jp-forms-page-header-title">
+						<JetpackLogo showText={ false } width={ 20 } />
+						{ __( 'Forms', 'jetpack-forms' ) }
+					</div>
+				}
+				subTitle={ __(
+					'View and manage all your form submissions in one place.',
+					'jetpack-forms'
+				) }
+				tabs={ <FormsResponsesTabs /> }
+				hasPadding={ false }
+			>
+				<p style={ { fontWeight: 'bold', margin: '20px' } }>
+					{ __( 'Forms will appear here', 'jetpack-forms' ) }
+				</p>
+			</Page>
+		</div>
+	);
+}

--- a/projects/packages/forms/src/dashboard/forms/index.tsx
+++ b/projects/packages/forms/src/dashboard/forms/index.tsx
@@ -41,10 +41,7 @@ export default function FormsDashboardForms(): JSX.Element | null {
 						{ __( 'Forms', 'jetpack-forms' ) }
 					</div>
 				}
-				subTitle={ __(
-					'View and manage all your forms in one place.',
-					'jetpack-forms'
-				) }
+				subTitle={ __( 'View and manage all your forms in one place.', 'jetpack-forms' ) }
 				tabs={ <FormsResponsesTabs /> }
 				hasPadding={ false }
 			>

--- a/projects/packages/forms/src/dashboard/forms/index.tsx
+++ b/projects/packages/forms/src/dashboard/forms/index.tsx
@@ -42,7 +42,7 @@ export default function FormsDashboardForms(): JSX.Element | null {
 					</div>
 				}
 				subTitle={ __(
-					'View and manage all your form submissions in one place.',
+					'View and manage all your forms in one place.',
 					'jetpack-forms'
 				) }
 				tabs={ <FormsResponsesTabs /> }

--- a/projects/packages/forms/src/dashboard/inbox/stage/index.js
+++ b/projects/packages/forms/src/dashboard/inbox/stage/index.js
@@ -5,7 +5,7 @@ import jetpackAnalytics from '@automattic/jetpack-analytics';
 import { JetpackLogo } from '@automattic/jetpack-components';
 import { isSimpleSite } from '@automattic/jetpack-script-data';
 import { Badge } from '@automattic/ui';
-import { ExternalLink, Modal } from '@wordpress/components';
+import { ExternalLink, Modal, Button, Composite } from '@wordpress/components';
 import { useResizeObserver, useViewportMatch } from '@wordpress/compose';
 import { useSelect } from '@wordpress/data';
 import { DataViews } from '@wordpress/dataviews/wp';
@@ -141,6 +141,9 @@ export default function InboxView() {
 		isLoadingData,
 		totalItems,
 		totalPages,
+		totalItemsInbox,
+		totalItemsSpam,
+		totalItemsTrash,
 	} = useInboxData();
 
 	const urlStatus = searchParams.get( 'status' ) || 'inbox';
@@ -197,10 +200,26 @@ export default function InboxView() {
 					setSelectedResponses( [] );
 				}
 			}
-
 			setView( newView );
 		},
 		[ isCentralFormManagementEnabled, setSearchParams, setSelectedResponses, setView, view.filters ]
+	);
+
+	// A function that changes the status filter such as index, spam, trash
+	const onChangeStatus = useCallback(
+		newStatus => {
+			const newView = { ...view };
+
+			newView.filters = ( newView.filters || [] ).filter( f => f.field !== 'folder' );
+			newView.filters.push( {
+				field: 'folder',
+				operator: 'is',
+				value: newStatus,
+			} );
+
+			onChangeView( newView );
+		},
+		[ onChangeView, view ]
 	);
 	const isAkismetStatusPending = useSelect(
 		select => {
@@ -328,22 +347,6 @@ export default function InboxView() {
 
 	const fields = useMemo(
 		() => [
-			...( isCentralFormManagementEnabled
-				? [
-						{
-							id: 'folder',
-							label: __( 'Folder', 'jetpack-forms' ),
-							elements: [
-								{ label: __( 'Inbox', 'jetpack-forms' ), value: 'inbox' },
-								{ label: __( 'Spam', 'jetpack-forms' ), value: 'spam' },
-								{ label: __( 'Trash', 'jetpack-forms' ), value: 'trash' },
-							],
-							filterBy: { operators: [ 'is' ], isPrimary: true },
-							enableSorting: false,
-							enableHiding: false,
-						},
-				  ]
-				: [] ),
 			{
 				id: 'from',
 				label: __( 'From', 'jetpack-forms' ),
@@ -615,6 +618,33 @@ export default function InboxView() {
 				{ isCentralFormManagementEnabled ? (
 					<div className="jp-forms-filters-bar">
 						<div className="jp-forms-filters-bar__chips">
+							<Composite className="jp-forms-filters-bar__status-chips">
+								<Button
+									size="compact"
+									variant={ 'tertiary' }
+									className={ statusFilter === 'draft,publish' ? 'is-active' : '' }
+									onClick={ () => onChangeStatus( 'inbox' ) }
+								>
+									{ __( 'Status is Inbox', 'jetpack-forms' ) } ({ totalItemsInbox })
+								</Button>
+
+								<Button
+									size="compact"
+									variant={ 'tertiary' }
+									className={ statusFilter === 'spam' ? 'is-active' : '' }
+									onClick={ () => onChangeStatus( 'spam' ) }
+								>
+									{ __( 'Status is Spam', 'jetpack-forms' ) } ({ totalItemsSpam })
+								</Button>
+								<Button
+									size="compact"
+									variant={ 'tertiary' }
+									className={ statusFilter === 'trash' ? 'is-active' : '' }
+									onClick={ () => onChangeStatus( 'trash' ) }
+								>
+									{ __( 'Status is Trash', 'jetpack-forms' ) } ({ totalItemsTrash })
+								</Button>
+							</Composite>
 							<DataViews.FiltersToggled className="jp-forms-filters-container" />
 						</div>
 						<div

--- a/projects/packages/forms/src/dashboard/inbox/stage/index.js
+++ b/projects/packages/forms/src/dashboard/inbox/stage/index.js
@@ -28,6 +28,7 @@ import EmptySpamButton from '../../components/empty-spam-button/index.tsx';
 import EmptyTrashButton from '../../components/empty-trash-button/index.tsx';
 import ExportResponsesButton from '../../components/export-responses/button.tsx';
 import Flag from '../../components/flag/index.tsx';
+import FormsResponsesTabs from '../../components/forms-responses-tabs/index.tsx';
 import Gravatar from '../../components/gravatar/index.tsx';
 import InboxStatusToggle from '../../components/inbox-status-toggle/index.tsx';
 import { ResponseMobileView, SingleResponseView } from '../../components/inspector/index.tsx';
@@ -129,6 +130,7 @@ export default function InboxView() {
 
 	const isIntegrationsEnabled = useConfigValue( 'isIntegrationsEnabled' );
 	const showDashboardIntegrations = useConfigValue( 'showDashboardIntegrations' );
+	const isCentralFormManagementEnabled = useConfigValue( 'isCentralFormManagementEnabled' );
 
 	const {
 		setCurrentQuery,
@@ -140,6 +142,66 @@ export default function InboxView() {
 		totalItems,
 		totalPages,
 	} = useInboxData();
+
+	const urlStatus = searchParams.get( 'status' ) || 'inbox';
+	const normalizedUrlFolder = [ 'inbox', 'spam', 'trash' ].includes( urlStatus )
+		? urlStatus
+		: 'inbox';
+	const currentFolderValue = view.filters?.find( filter => filter.field === 'folder' )?.value;
+
+	// When central form management is enabled, ensure the Folder filter has a value
+	// so it renders as "Folder: Inbox/Spam/Trash" in the DataViews filters UI.
+	// We only seed it when missing to avoid fighting user edits.
+	useEffect( () => {
+		if ( ! isCentralFormManagementEnabled ) {
+			return;
+		}
+
+		if ( currentFolderValue !== undefined ) {
+			return;
+		}
+
+		setView( {
+			...view,
+			page: 1,
+			filters: [
+				...( view.filters || [] ).filter( f => f.field !== 'folder' ),
+				{
+					field: 'folder',
+					operator: 'is',
+					value: normalizedUrlFolder,
+				},
+			],
+		} );
+	}, [ isCentralFormManagementEnabled, currentFolderValue, normalizedUrlFolder, setView, view ] );
+
+	const onChangeView = useCallback(
+		newView => {
+			if ( isCentralFormManagementEnabled ) {
+				const getFolder = filters => {
+					const raw = filters?.find( f => f.field === 'folder' )?.value;
+					const value = Array.isArray( raw ) ? raw[ 0 ] : raw;
+					return [ 'inbox', 'spam', 'trash' ].includes( value ) ? value : 'inbox';
+				};
+
+				const prevFolder = getFolder( view.filters );
+				const nextFolder = getFolder( newView.filters );
+
+				if ( prevFolder !== nextFolder ) {
+					setSearchParams( previousSearchParams => {
+						const params = new URLSearchParams( previousSearchParams );
+						params.set( 'status', nextFolder );
+						params.delete( 'r' ); // Clear selection when changing folder.
+						return params;
+					} );
+					setSelectedResponses( [] );
+				}
+			}
+
+			setView( newView );
+		},
+		[ isCentralFormManagementEnabled, setSearchParams, setSelectedResponses, setView, view.filters ]
+	);
 	const isAkismetStatusPending = useSelect(
 		select => {
 			const store = select( INTEGRATIONS_STORE );
@@ -266,6 +328,22 @@ export default function InboxView() {
 
 	const fields = useMemo(
 		() => [
+			...( isCentralFormManagementEnabled
+				? [
+						{
+							id: 'folder',
+							label: __( 'Folder', 'jetpack-forms' ),
+							elements: [
+								{ label: __( 'Inbox', 'jetpack-forms' ), value: 'inbox' },
+								{ label: __( 'Spam', 'jetpack-forms' ), value: 'spam' },
+								{ label: __( 'Trash', 'jetpack-forms' ), value: 'trash' },
+							],
+							filterBy: { operators: [ 'is' ], isPrimary: true },
+							enableSorting: false,
+							enableHiding: false,
+						},
+				  ]
+				: [] ),
 			{
 				id: 'from',
 				label: __( 'From', 'jetpack-forms' ),
@@ -412,6 +490,7 @@ export default function InboxView() {
 		[
 			filterOptions?.date,
 			filterOptions?.source,
+			isCentralFormManagementEnabled,
 			isMobileViewport,
 			openResponseModal,
 			dateSettings.formats.date,
@@ -510,6 +589,7 @@ export default function InboxView() {
 			}
 			subTitle={ __( 'View and manage all your form submissions in one place.', 'jetpack-forms' ) }
 			actions={ headerActions }
+			tabs={ isCentralFormManagementEnabled ? <FormsResponsesTabs /> : undefined }
 			hasPadding={ false }
 		>
 			<DataViews
@@ -519,7 +599,7 @@ export default function InboxView() {
 				data={ records || EMPTY_ARRAY }
 				isLoading={ isInboxLoading }
 				view={ view }
-				onChangeView={ setView }
+				onChangeView={ isCentralFormManagementEnabled ? onChangeView : setView }
 				selection={ selection }
 				onChangeSelection={ onChangeSelection }
 				getItemId={ getItemId }
@@ -532,23 +612,45 @@ export default function InboxView() {
 					/>
 				}
 			>
-				<div className="jp-forms-view-actions">
-					<div>
-						<InboxStatusToggle onChange={ resetPage } />
+				{ isCentralFormManagementEnabled ? (
+					<div className="jp-forms-filters-bar">
+						<div className="jp-forms-filters-bar__chips">
+							<DataViews.FiltersToggled className="jp-forms-filters-container" />
+						</div>
+						<div
+							className="jp-forms-filters-bar__controls"
+							style={ {
+								display: 'flex',
+								gap: '8px',
+								justifyContent: containerWidth < 600 ? 'unset' : 'flex-end',
+							} }
+						>
+							<DataViews.Search />
+							<DataViews.FiltersToggle />
+							<DataViews.ViewConfig />
+						</div>
 					</div>
-					<div
-						style={ {
-							display: 'flex',
-							gap: '8px',
-							justifyContent: containerWidth < 600 ? 'unset' : 'flex-end',
-						} }
-					>
-						<DataViews.Search />
-						<DataViews.FiltersToggle />
-						<DataViews.ViewConfig />
-					</div>
-				</div>
-				<DataViews.FiltersToggled className="jp-forms-filters-container" />
+				) : (
+					<>
+						<div className="jp-forms-view-actions">
+							<div>
+								<InboxStatusToggle onChange={ resetPage } />
+							</div>
+							<div
+								style={ {
+									display: 'flex',
+									gap: '8px',
+									justifyContent: containerWidth < 600 ? 'unset' : 'flex-end',
+								} }
+							>
+								<DataViews.Search />
+								<DataViews.FiltersToggle />
+								<DataViews.ViewConfig />
+							</div>
+						</div>
+						<DataViews.FiltersToggled className="jp-forms-filters-container" />
+					</>
+				) }
 				<div className="jp-forms-dataviews-layout-container">
 					<DataViews.Layout />
 					<DataViews.Footer />

--- a/projects/packages/forms/src/dashboard/inbox/stage/index.js
+++ b/projects/packages/forms/src/dashboard/inbox/stage/index.js
@@ -145,81 +145,26 @@ export default function InboxView() {
 		totalItemsSpam,
 		totalItemsTrash,
 	} = useInboxData();
-
-	const urlStatus = searchParams.get( 'status' ) || 'inbox';
-	const normalizedUrlFolder = [ 'inbox', 'spam', 'trash' ].includes( urlStatus )
-		? urlStatus
-		: 'inbox';
-	const currentFolderValue = view.filters?.find( filter => filter.field === 'folder' )?.value;
-
-	// When central form management is enabled, ensure the Folder filter has a value
-	// so it renders as "Folder: Inbox/Spam/Trash" in the DataViews filters UI.
-	// We only seed it when missing to avoid fighting user edits.
-	useEffect( () => {
-		if ( ! isCentralFormManagementEnabled ) {
-			return;
-		}
-
-		if ( currentFolderValue !== undefined ) {
-			return;
-		}
-
-		setView( {
-			...view,
-			page: 1,
-			filters: [
-				...( view.filters || [] ).filter( f => f.field !== 'folder' ),
-				{
-					field: 'folder',
-					operator: 'is',
-					value: normalizedUrlFolder,
-				},
-			],
-		} );
-	}, [ isCentralFormManagementEnabled, currentFolderValue, normalizedUrlFolder, setView, view ] );
-
-	const onChangeView = useCallback(
-		newView => {
-			if ( isCentralFormManagementEnabled ) {
-				const getFolder = filters => {
-					const raw = filters?.find( f => f.field === 'folder' )?.value;
-					const value = Array.isArray( raw ) ? raw[ 0 ] : raw;
-					return [ 'inbox', 'spam', 'trash' ].includes( value ) ? value : 'inbox';
-				};
-
-				const prevFolder = getFolder( view.filters );
-				const nextFolder = getFolder( newView.filters );
-
-				if ( prevFolder !== nextFolder ) {
-					setSearchParams( previousSearchParams => {
-						const params = new URLSearchParams( previousSearchParams );
-						params.set( 'status', nextFolder );
-						params.delete( 'r' ); // Clear selection when changing folder.
-						return params;
-					} );
-					setSelectedResponses( [] );
-				}
-			}
-			setView( newView );
-		},
-		[ isCentralFormManagementEnabled, setSearchParams, setSelectedResponses, setView, view.filters ]
-	);
-
-	// A function that changes the status filter such as index, spam, trash
 	const onChangeStatus = useCallback(
 		newStatus => {
-			const newView = { ...view };
+			if ( ! isCentralFormManagementEnabled ) {
+				return;
+			}
 
-			newView.filters = ( newView.filters || [] ).filter( f => f.field !== 'folder' );
-			newView.filters.push( {
-				field: 'folder',
-				operator: 'is',
-				value: newStatus,
+			setSearchParams( previousSearchParams => {
+				const params = new URLSearchParams( previousSearchParams );
+				params.set( 'status', newStatus );
+				params.delete( 'r' ); // Clear selected responses when changing status.
+				return params;
 			} );
 
-			onChangeView( newView );
+			// Reset page to 1 when switching status (matches previous tab behavior).
+			setView( { ...view, page: 1 } );
+
+			// Clear selection in store.
+			setSelectedResponses( [] );
 		},
-		[ onChangeView, view ]
+		[ isCentralFormManagementEnabled, setSearchParams, setSelectedResponses, setView, view ]
 	);
 
 	const onInboxClick = useCallback( () => onChangeStatus( 'inbox' ), [ onChangeStatus ] );
@@ -605,7 +550,7 @@ export default function InboxView() {
 				data={ records || EMPTY_ARRAY }
 				isLoading={ isInboxLoading }
 				view={ view }
-				onChangeView={ isCentralFormManagementEnabled ? onChangeView : setView }
+				onChangeView={ setView }
 				selection={ selection }
 				onChangeSelection={ onChangeSelection }
 				getItemId={ getItemId }

--- a/projects/packages/forms/src/dashboard/inbox/stage/index.js
+++ b/projects/packages/forms/src/dashboard/inbox/stage/index.js
@@ -221,6 +221,10 @@ export default function InboxView() {
 		},
 		[ onChangeView, view ]
 	);
+
+	const onInboxClick = useCallback( () => onChangeStatus( 'inbox' ), [ onChangeStatus ] );
+	const onSpamClick = useCallback( () => onChangeStatus( 'spam' ), [ onChangeStatus ] );
+	const onTrashClick = useCallback( () => onChangeStatus( 'trash' ), [ onChangeStatus ] );
 	const isAkismetStatusPending = useSelect(
 		select => {
 			const store = select( INTEGRATIONS_STORE );
@@ -493,7 +497,6 @@ export default function InboxView() {
 		[
 			filterOptions?.date,
 			filterOptions?.source,
-			isCentralFormManagementEnabled,
 			isMobileViewport,
 			openResponseModal,
 			dateSettings.formats.date,
@@ -623,7 +626,7 @@ export default function InboxView() {
 									size="compact"
 									variant={ 'tertiary' }
 									className={ statusFilter === 'draft,publish' ? 'is-active' : '' }
-									onClick={ () => onChangeStatus( 'inbox' ) }
+									onClick={ onInboxClick }
 								>
 									{ __( 'Status is Inbox', 'jetpack-forms' ) } ({ totalItemsInbox })
 								</Button>
@@ -632,7 +635,7 @@ export default function InboxView() {
 									size="compact"
 									variant={ 'tertiary' }
 									className={ statusFilter === 'spam' ? 'is-active' : '' }
-									onClick={ () => onChangeStatus( 'spam' ) }
+									onClick={ onSpamClick }
 								>
 									{ __( 'Status is Spam', 'jetpack-forms' ) } ({ totalItemsSpam })
 								</Button>
@@ -640,7 +643,7 @@ export default function InboxView() {
 									size="compact"
 									variant={ 'tertiary' }
 									className={ statusFilter === 'trash' ? 'is-active' : '' }
-									onClick={ () => onChangeStatus( 'trash' ) }
+									onClick={ onTrashClick }
 								>
 									{ __( 'Status is Trash', 'jetpack-forms' ) } ({ totalItemsTrash })
 								</Button>

--- a/projects/packages/forms/src/dashboard/inbox/stage/views.js
+++ b/projects/packages/forms/src/dashboard/inbox/stage/views.js
@@ -31,10 +31,12 @@ export const defaultLayouts = {
  */
 export function useView() {
 	const [ searchParams, setSearchParams ] = useSearchParams();
-	const urlSearch = searchParams.get( 'search' );
+	// Normalize missing query param to empty string so we don't treat
+	// `null` (missing) and `''` (empty) as different values.
+	const urlSearch = searchParams.get( 'search' ) ?? '';
 	const [ view, setView ] = useState( () => ( {
 		...defaultView,
-		search: urlSearch ?? '',
+		search: urlSearch,
 	} ) );
 	// When view changes, update the URL params if needed.
 	const setViewWithUrlUpdate = useEvent( newView => {
@@ -55,7 +57,7 @@ export function useView() {
 	// without affecting any other config.
 	const onUrlSearchChange = useEvent( () => {
 		setView( previousView => {
-			const newValue = urlSearch ?? '';
+			const newValue = urlSearch;
 			if ( newValue === previousView.search ) {
 				return previousView;
 			}

--- a/projects/packages/forms/src/dashboard/inbox/stage/views.js
+++ b/projects/packages/forms/src/dashboard/inbox/stage/views.js
@@ -31,12 +31,10 @@ export const defaultLayouts = {
  */
 export function useView() {
 	const [ searchParams, setSearchParams ] = useSearchParams();
-	// Normalize missing query param to empty string so we don't treat
-	// `null` (missing) and `''` (empty) as different values.
-	const urlSearch = searchParams.get( 'search' ) ?? '';
+	const urlSearch = searchParams.get( 'search' );
 	const [ view, setView ] = useState( () => ( {
 		...defaultView,
-		search: urlSearch,
+		search: urlSearch ?? '',
 	} ) );
 	// When view changes, update the URL params if needed.
 	const setViewWithUrlUpdate = useEvent( newView => {
@@ -57,7 +55,7 @@ export function useView() {
 	// without affecting any other config.
 	const onUrlSearchChange = useEvent( () => {
 		setView( previousView => {
-			const newValue = urlSearch;
+			const newValue = urlSearch ?? '';
 			if ( newValue === previousView.search ) {
 				return previousView;
 			}

--- a/projects/packages/forms/src/dashboard/inbox/style.scss
+++ b/projects/packages/forms/src/dashboard/inbox/style.scss
@@ -90,11 +90,6 @@
 	background-color: var(--wpds-color-bg-surface-neutral-strong, #fff);
 }
 
-.jp-forms-filters-container:not(:empty) {
-	padding-inline: variables.$grid-unit * 2.5;
-	padding-block: variables.$grid-unit * 1.5;
-}
-
 /*
  * DataViews custom spacing adjustments
 */
@@ -199,3 +194,24 @@
 	font-weight: 600;
 }
 
+.jp-forms-filters-bar__chips {
+	display: flex;
+	align-items: center;
+	padding: variables.$grid-unit * 1.5 0;
+	gap: 8px;
+}
+
+.jp-forms-filters-bar__status-chips {
+	gap: 8px;
+	display: flex;
+
+	.components-button {
+		border-radius: 16px;
+		background-color: #e0e0e0;
+		color: #1e1e1e;
+	}
+	.components-button.is-active {
+		color: var(--wp-admin-theme-color);
+  		background: rgba(var(--wp-admin-theme-color--rgb), 0.04);
+	}
+}

--- a/projects/packages/forms/src/dashboard/inbox/style.scss
+++ b/projects/packages/forms/src/dashboard/inbox/style.scss
@@ -68,15 +68,36 @@
 	background: var(--wpds-color-bg-surface-neutral-strong, #fff);
 
 	&__chips {
+		display: flex;
 		flex: 1 1 auto;
 		min-width: 0;
+		align-items: center;
+		padding: variables.$grid-unit * 1.5 0;
+		gap: 8px;
+	}
+
+	&__status-chips {
+		gap: 8px;
+		display: flex;
+
+		.components-button {
+			border-radius: 16px;
+			background-color: #e0e0e0;
+			color: #1e1e1e;
+		}
+
+		.components-button.is-active {
+			color: var(--wp-admin-theme-color);
+			background: rgba(var(--wp-admin-theme-color--rgb), 0.04);
+		}
 	}
 
 	&__controls {
 		flex: 0 0 auto;
 	}
 
-	.jp-forms-filters-container {
+	.jp-forms-filters-container,
+	.jp-forms-filters-container:not(:empty) {
 		padding: 0;
 	}
 }
@@ -88,6 +109,11 @@
 	display: flex;
 	flex-direction: column;
 	background-color: var(--wpds-color-bg-surface-neutral-strong, #fff);
+}
+
+.jp-forms-filters-container:not(:empty) {
+	padding-inline: variables.$grid-unit * 2.5;
+	padding-block: variables.$grid-unit * 1.5;
 }
 
 /*
@@ -192,26 +218,4 @@
 
 .jp-forms__inbox__unread {
 	font-weight: 600;
-}
-
-.jp-forms-filters-bar__chips {
-	display: flex;
-	align-items: center;
-	padding: variables.$grid-unit * 1.5 0;
-	gap: 8px;
-}
-
-.jp-forms-filters-bar__status-chips {
-	gap: 8px;
-	display: flex;
-
-	.components-button {
-		border-radius: 16px;
-		background-color: #e0e0e0;
-		color: #1e1e1e;
-	}
-	.components-button.is-active {
-		color: var(--wp-admin-theme-color);
-  		background: rgba(var(--wp-admin-theme-color--rgb), 0.04);
-	}
 }

--- a/projects/packages/forms/src/dashboard/inbox/style.scss
+++ b/projects/packages/forms/src/dashboard/inbox/style.scss
@@ -57,6 +57,30 @@
 	}
 }
 
+.jp-forms-filters-bar {
+	border-bottom: 1px solid var(--wpds-color-stroke-surface-neutral-weak);
+	padding-inline: variables.$grid-unit * 2.5;
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	flex-wrap: wrap;
+	gap: variables.$grid-unit * 1.25;
+	background: var(--wpds-color-bg-surface-neutral-strong, #fff);
+
+	&__chips {
+		flex: 1 1 auto;
+		min-width: 0;
+	}
+
+	&__controls {
+		flex: 0 0 auto;
+	}
+
+	.jp-forms-filters-container {
+		padding: 0;
+	}
+}
+
 .jp-forms-dataviews-layout-container {
 	overflow-x: auto;
 	width: 100%;

--- a/projects/packages/forms/src/dashboard/inbox/style.scss
+++ b/projects/packages/forms/src/dashboard/inbox/style.scss
@@ -82,8 +82,8 @@
 
 		.components-button {
 			border-radius: 16px;
-			background-color: #e0e0e0;
-			color: #1e1e1e;
+			background-color: var(--jp-gray-5);
+			color: var(--jp-gray-40);
 		}
 
 		.components-button.is-active {

--- a/projects/packages/forms/src/dashboard/index.tsx
+++ b/projects/packages/forms/src/dashboard/index.tsx
@@ -2,13 +2,15 @@
  * External dependencies
  */
 import { SlotFillProvider } from '@wordpress/components';
-import { createRoot } from '@wordpress/element';
-import { createHashRouter } from 'react-router';
+import { createRoot, useEffect } from '@wordpress/element';
+import { createHashRouter, useNavigate } from 'react-router';
 import { RouterProvider } from 'react-router/dom';
 /**
  * Internal dependencies
  */
+import useConfigValue from '../hooks/use-config-value.ts';
 import Layout from './components/layout/index.tsx';
+import FormsDashboardForms from './forms/index.tsx';
 import Inbox from './inbox/index.js';
 import DashboardNotices from './notices-list.tsx';
 import './style.scss';
@@ -31,6 +33,22 @@ function initFormsDashboard() {
 
 	container.dataset.formsInitialized = 'true';
 
+	const DashboardIndexRedirect = () => {
+		const navigate = useNavigate();
+		const isCentralFormManagementEnabled = useConfigValue( 'isCentralFormManagementEnabled' );
+
+		useEffect( () => {
+			if ( isCentralFormManagementEnabled === undefined ) {
+				return;
+			}
+
+			// Default landing when no hash/route is set.
+			navigate( isCentralFormManagementEnabled ? '/forms' : '/responses', { replace: true } );
+		}, [ isCentralFormManagementEnabled, navigate ] );
+
+		return null;
+	};
+
 	const router = createHashRouter( [
 		{
 			path: '/',
@@ -38,7 +56,11 @@ function initFormsDashboard() {
 			children: [
 				{
 					index: true,
-					element: <Inbox />,
+					element: <DashboardIndexRedirect />,
+				},
+				{
+					path: 'forms',
+					element: <FormsDashboardForms />,
 				},
 				{
 					path: 'responses',

--- a/projects/packages/forms/src/dashboard/style.scss
+++ b/projects/packages/forms/src/dashboard/style.scss
@@ -1,3 +1,5 @@
+@use "@automattic/jetpack-base-styles/root-variables";
+
 :root {
 	// Forms-specific variables
 	--jp-forms-font-size-regular: 14px;

--- a/projects/packages/forms/src/types/index.ts
+++ b/projects/packages/forms/src/types/index.ts
@@ -270,6 +270,8 @@ export type BlockEditorStoreSelect = {
  * Forms script data exposed via JetpackScriptData.forms
  */
 export interface FormsConfigData {
+	/** Whether the central form management feature is enabled (feature-flagged). */
+	isCentralFormManagementEnabled?: boolean;
 	/** Whether MailPoet integration is enabled across contexts. */
 	isMailPoetEnabled?: boolean;
 	/** Whether Hostinger Reach integration is enabled across contexts. */


### PR DESCRIPTION
Addresses [FORMS-367](https://linear.app/a8c/issue/FORMS-367/central-form-management-spike-custom-post-type)

## Proposed changes:

This PR should be considered a spike or trial for the centralized form management dashboard. The goal is to move toward the Figma designs here: 8TmDfrB54NU4Rzj19Qs9Tg-fi-5374_18492

Changes: 
* All changes are behind the centralized-form-management feature flag
* Add new tabs at top of screen for `Forms` and `All Responses`
* The `Forms` tab just shows a placeholder screen, but this is where our forms list would go in future PRs. 
* The `All Responses` tab shows our long-standings responses list. 
* Add new button chips for Inbox/Spam/Trash, below the tabs. 
   - These may be temporary until we can introduce something more native to DataViews.
* Adjust container / alignment / styles of filter interface when showing the new filters

**Before**
<img width="1343" height="298" alt="forms-screen-before" src="https://github.com/user-attachments/assets/e86d9c58-8768-4316-b3c4-e8a4577098a3" />

**With Feature Flag: Responses**
<img width="1344" height="336" alt="forms-responses-tab-2" src="https://github.com/user-attachments/assets/6b18ad43-7455-4302-a30c-8d156150e95c" />

**With Feature Flag: Forms Placeholder Screen**
<img width="1346" height="183" alt="forms-tab" src="https://github.com/user-attachments/assets/5222921c-5856-42cc-ada9-35b32f320bb1" />

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Add this feature flag to your test site. 

```
add_filter( 'jetpack_block_editor_feature_flags', 'eb_register_feature' );
function eb_register_feature( $flags ) {
    $flags['central-form-management'] = true;
    return $flags;
}
```

Test new tabs: 
* Go to Jetpack > Forms
* Confirm new tabs are there and work
* Confirm Forms screen has a placeholder
* Confirm Responses screen shows responses list, and that you can filter by Inbox, Spam or Trash

Test for now regression:
* Remove feature flag and confirm everything works as before