### PR TITLE
Forms: allow merging two options together with backspace

### DIFF
--- a/projects/packages/forms/changelog/update-forms-merge-option
+++ b/projects/packages/forms/changelog/update-forms-merge-option
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Forms: allow merging two options together with backspace

--- a/projects/packages/forms/src/blocks/option/edit.js
+++ b/projects/packages/forms/src/blocks/option/edit.js
@@ -17,7 +17,7 @@ const getLabelOrFallback = ( label, placeholder ) => {
 	return label ?? placeholder;
 };
 
-const OptionEdit = ( { attributes, clientId, context, name, setAttributes } ) => {
+const OptionEdit = ( { attributes, clientId, context, name, setAttributes, mergeBlocks } ) => {
 	const {
 		'jetpack/field-default-value': defaultValue,
 		'jetpack/field-options-type': type = 'checkbox',
@@ -110,6 +110,7 @@ const OptionEdit = ( { attributes, clientId, context, name, setAttributes } ) =>
 				identifier="label"
 				tagName="div"
 				className="wp-block"
+				onMerge={ mergeBlocks }
 				value={ labelValue }
 				placeholder={ __( 'Add option…', 'jetpack-forms' ) }
 				__unstableDisableFormats

--- a/projects/packages/forms/src/blocks/option/index.js
+++ b/projects/packages/forms/src/blocks/option/index.js
@@ -37,6 +37,10 @@ const settings = {
 			},
 		},
 	},
+	merge: ( attributes, { label = '' } ) => ( {
+		...attributes,
+		label: ( attributes.label || '' ) + label,
+	} ),
 	attributes: {
 		placeholder: {
 			type: 'string',

--- a/projects/plugins/jetpack/changelog/update-forms-merge-option
+++ b/projects/plugins/jetpack/changelog/update-forms-merge-option
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Forms: allow merging two options together with backspace


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->



## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Small enhancement to options allowing to merge multiple options using backspace

We already allowed splitting by hitting enter, so allowing merging is natural.


https://github.com/user-attachments/assets/353415ca-da55-4384-bae7-0cf2e5615d21



### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Add single choice field
* Add options
* Split option by hitting enter in the middle
* Join options by using backspace at the beginning of option text

