### PR TITLE
Forms: Fix wp-build dashboard with updated @wordpress/build package

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2926,8 +2926,8 @@ importers:
         specifier: 6.37.0
         version: 6.37.0
       '@wordpress/build':
-        specifier: 0.5.0
-        version: 0.5.0(@babel/core@7.28.4)(@wordpress/boot@0.3.0(@types/react-dom@18.3.7(@types/react@18.3.26))(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@wordpress/route@0.2.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@wordpress/theme@0.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(browserslist@4.24.5)(sass-embedded@1.87.0)
+        specifier: 0.5.1-next.79a2f3cdd.0
+        version: 0.5.1-next.79a2f3cdd.0(@babel/core@7.28.4)(@wordpress/boot@0.3.0(@types/react-dom@18.3.7(@types/react@18.3.26))(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@wordpress/route@0.2.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@wordpress/theme@0.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(browserslist@4.24.5)(sass-embedded@1.87.0)
       '@wordpress/date':
         specifier: 5.37.0
         version: 5.37.0(patch_hash=0c63a888feb97f2f1d416ca013ad85c31b6360b41cc0b6e2b0ae28f778fbdc5b)
@@ -9832,9 +9832,6 @@ packages:
   '@types/tedious@4.0.14':
     resolution: {integrity: sha512-KHPsfX/FoVbUGbyYvk1q9MMQHLPeRZhRJZdO45Q4YjvFkv4hMNghCWTvy7rdKessBsmtz4euWCWAB6/tVpI1Iw==}
 
-  '@types/toposort@2.0.7':
-    resolution: {integrity: sha512-sQNk65vbC36+UixCkcky+dCr7MlflHcVILg1FVGqlUntsLFv9xd9ToWIVko/gTuin+cVe16t+2YubEFkhnSuPQ==}
-
   '@types/tough-cookie@4.0.5':
     resolution: {integrity: sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==}
 
@@ -10357,8 +10354,8 @@ packages:
     resolution: {integrity: sha512-L//FRak9bo+sDLAignC4QkhITHgeFVlL0C4lWI/AM+AIHKGrHT4LOdwwNpYWMkkztW9rxHRptGkF/JDxuCakxQ==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
-  '@wordpress/build@0.5.0':
-    resolution: {integrity: sha512-6dg+yWSQJxuiPhZI91p1tVxochBaRDW07Gnzlshx2YjV2yZ3Z/ZBJcFu0zGe4ADtc+Q+ud4m7blYhIhvaACydg==}
+  '@wordpress/build@0.5.1-next.79a2f3cdd.0':
+    resolution: {integrity: sha512-ZFYeILbNvIOo+55gzRUViD6vRpb9fPp62y0ju7dA6mfLgFD8Fq8uLoPjDSxIeQQbkBOWLsSOA5ZoP+jCqxr9MQ==}
     engines: {node: '>=20.10.0', npm: '>=10.2.3'}
     hasBin: true
     peerDependencies:
@@ -17044,9 +17041,6 @@ packages:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
 
-  toposort@2.0.2:
-    resolution: {integrity: sha512-0a5EOkAUp8D4moMi2W8ZF8jcga7BgZd91O/yabJCFY8az+XSzeGyTKs0Aoo897iV1Nj6guFq8orWDS96z91oGg==}
-
   tough-cookie@5.1.2:
     resolution: {integrity: sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==}
     engines: {node: '>=16'}
@@ -22298,8 +22292,6 @@ snapshots:
     dependencies:
       '@types/node': 20.19.25
 
-  '@types/toposort@2.0.7': {}
-
   '@types/tough-cookie@4.0.5': {}
 
   '@types/triple-beam@1.3.5': {}
@@ -23403,10 +23395,9 @@ snapshots:
 
   '@wordpress/browserslist-config@6.37.0': {}
 
-  '@wordpress/build@0.5.0(@babel/core@7.28.4)(@wordpress/boot@0.3.0(@types/react-dom@18.3.7(@types/react@18.3.26))(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@wordpress/route@0.2.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@wordpress/theme@0.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(browserslist@4.24.5)(sass-embedded@1.87.0)':
+  '@wordpress/build@0.5.1-next.79a2f3cdd.0(@babel/core@7.28.4)(@wordpress/boot@0.3.0(@types/react-dom@18.3.7(@types/react@18.3.26))(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@wordpress/route@0.2.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@wordpress/theme@0.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(browserslist@4.24.5)(sass-embedded@1.87.0)':
     dependencies:
       '@emotion/babel-plugin': 11.13.5
-      '@types/toposort': 2.0.7
       autoprefixer: 10.4.21(postcss@8.5.6)
       browserslist-to-esbuild: 2.1.1(browserslist@4.24.5)
       change-case: 4.1.2
@@ -23419,7 +23410,6 @@ snapshots:
       postcss: 8.5.6
       postcss-modules: 6.0.1(postcss@8.5.6)
       rtlcss: 4.3.0
-      toposort: 2.0.2
     optionalDependencies:
       '@wordpress/boot': 0.3.0(@types/react-dom@18.3.7(@types/react@18.3.26))(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/route': 0.2.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -32912,8 +32902,6 @@ snapshots:
       reserved-identifiers: 1.2.0
 
   toidentifier@1.0.1: {}
-
-  toposort@2.0.2: {}
 
   tough-cookie@5.1.2:
     dependencies:

--- a/projects/packages/forms/changelog/update-forms-wp-build
+++ b/projects/packages/forms/changelog/update-forms-wp-build
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: Fix wp-build dashboard with updated @wordpress/build package

--- a/projects/packages/forms/package.json
+++ b/projects/packages/forms/package.json
@@ -108,7 +108,7 @@
 		"@types/react-dom": "18.3.7",
 		"@wordpress/api-fetch": "7.37.0",
 		"@wordpress/browserslist-config": "6.37.0",
-		"@wordpress/build": "0.5.0",
+		"@wordpress/build": "0.5.1-next.79a2f3cdd.0",
 		"@wordpress/date": "5.37.0",
 		"autoprefixer": "10.4.20",
 		"browserslist": "^4.24.0",

--- a/projects/packages/forms/routes/responses/package.json
+++ b/projects/packages/forms/routes/responses/package.json
@@ -23,7 +23,7 @@
 		"@wordpress/i18n": "6.10.0",
 		"@wordpress/icons": "11.4.0",
 		"@wordpress/notices": "5.37.0",
-		"@wordpress/route": "0.3.0"
+		"@wordpress/route": "0.2.0"
 	},
 	"route": {
 		"path": "/responses/$view",

--- a/projects/packages/forms/routes/root/package.json
+++ b/projects/packages/forms/routes/root/package.json
@@ -1,0 +1,12 @@
+{
+	"name": "_@jetpack-forms/root-route",
+	"version": "1.0.0",
+	"private": true,
+	"dependencies": {
+		"@wordpress/route": "0.2.0"
+	},
+	"route": {
+		"path": "/",
+		"page": "jetpack-forms-responses"
+	}
+}

--- a/projects/packages/forms/routes/root/route.ts
+++ b/projects/packages/forms/routes/root/route.ts
@@ -1,0 +1,16 @@
+/**
+ * WordPress dependencies
+ */
+import { redirect } from '@wordpress/route';
+
+export const route = {
+	/**
+	 * Redirect `/` to the default inbox view.
+	 *
+	 * In wp-admin integrated mode, the boot router uses the `p` query arg and defaults to `/`
+	 * when missing. Adding this route lets us redirect to the default inbox view.
+	 */
+	beforeLoad: () => {
+		throw redirect( { href: '/responses/inbox' } );
+	},
+};

--- a/projects/packages/forms/src/dashboard/class-dashboard.php
+++ b/projects/packages/forms/src/dashboard/class-dashboard.php
@@ -42,6 +42,15 @@ class Dashboard {
 	const ADMIN_SLUG = 'jetpack-forms-admin';
 
 	/**
+	 * Slug for the wp-admin integrated Responses UI (wp-build page).
+	 *
+	 * Note: This must be a valid submenu slug (sanitize_key compatible), not a full URL.
+	 *
+	 * @var string
+	 */
+	const FORMS_WPBUILD_ADMIN_SLUG = 'jetpack-forms-responses-wp-admin';
+
+	/**
 	 * Priority for the dashboard menu.
 	 * Needs to be high enough for us to be able to unregister the default edit.php menu item.
 	 *
@@ -63,7 +72,7 @@ class Dashboard {
 		add_action( 'admin_menu', array( $this, 'add_new_admin_submenu' ), self::MENU_PRIORITY );
 
 		if ( $is_wp_build_enabled ) {
-			add_action( 'admin_menu', array( $this, 'add_forms2_submenu' ), self::MENU_PRIORITY );
+			add_action( 'admin_menu', array( $this, 'add_forms_wpbuild_submenu' ), self::MENU_PRIORITY );
 		}
 
 		add_action( 'admin_enqueue_scripts', array( $this, 'load_admin_scripts' ) );
@@ -167,17 +176,19 @@ class Dashboard {
 	}
 
 	/**
-	 * Register Forms2 submenu under Jetpack menu using wp-build page.
+	 * Register Forms (WP-Build) submenu under Jetpack menu using wp-build page.
 	 */
-	public function add_forms2_submenu() {
-		$url = admin_url( 'admin.php?page=jetpack-forms-responses-wp-admin&p=' . rawurlencode( '/responses/inbox' ) );
+	public function add_forms_wpbuild_submenu() {
+		$callback = function_exists( 'jetpack_forms_responses_wp_admin_render_page' )
+			? 'jetpack_forms_responses_wp_admin_render_page'
+			: array( $this, 'render_dashboard' );
 
 		Admin_Menu::add_menu(
-			'Forms2',
-			'Forms2',
+			'Jetpack Forms',
+			'Forms (WP-Build)',
 			'edit_pages',
-			$url,
-			null,
+			self::FORMS_WPBUILD_ADMIN_SLUG,
+			$callback,
 			11
 		);
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Follow-up to #46206 and #46377

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Updates the `@wordpress/build` to a version with a fix for pnpm projects
* Fixes a 403 issue when registering the URL directly instead of a slug by adding a root redirect

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Enable the `jetpack_forms_alpha` flag
* `(cd projects/packages/forms && pnpm run build:wp-build)`
* Open WP Admin
* Check that there is a `Forms (WP-Build)` entry under the `Jetpack` menu
* Click on it
* The dashboard should be displayed (has some issues and needs updating, but that is outside of the scope of this PR)
