### PR TITLE
My Jetpack: Show module descriptions beneath titles instead of tooltips

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/module-toggle/index.tsx
+++ b/projects/packages/my-jetpack/_inc/components/module-toggle/index.tsx
@@ -11,6 +11,7 @@ import type { ChangeEvent } from 'react';
 
 export type ModuleToggleProps = {
 	module: MyJetpackModule;
+	describedby?: string;
 };
 
 /**
@@ -20,7 +21,7 @@ export type ModuleToggleProps = {
  *
  * @return The rendered component.
  */
-export function ModuleToggle( { module: $module }: ModuleToggleProps ) {
+export function ModuleToggle( { module: $module, describedby }: ModuleToggleProps ) {
 	const { updateJetpackModuleStatus: toggleModule } = useDispatch( modulesStore );
 	const { createSuccessNotice, createErrorNotice } = useGlobalNotices();
 	const { trackProductAction } = useProductFiltersContext() || {};
@@ -106,6 +107,7 @@ export function ModuleToggle( { module: $module }: ModuleToggleProps ) {
 				__( 'Toggle %s module', 'jetpack-my-jetpack' ),
 				$module.name
 			) }
+			aria-describedby={ describedby }
 		/>
 	);
 }

--- a/projects/packages/my-jetpack/_inc/components/modules-list/index.tsx
+++ b/projects/packages/my-jetpack/_inc/components/modules-list/index.tsx
@@ -2,7 +2,7 @@ import { Badge } from '@automattic/ui';
 import { Flex } from '@wordpress/components';
 import { DataViews, Field } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
-import { useMemo } from 'react';
+import { useId, useMemo } from 'react';
 import { MyJetpackModule } from '../../types';
 import { ModuleStatus } from '../module-status';
 import { ModuleToggle } from '../module-toggle';
@@ -27,6 +27,8 @@ const getItemId = ( item: MyJetpackModule ) => item.module;
  * @return The rendered component.
  */
 export function ModulesList( { modules }: ModulesListProps ) {
+	const baseId = useId();
+
 	const fields = useMemo< Array< Field< MyJetpackModule > > >( () => {
 		return [
 			{
@@ -39,7 +41,12 @@ export function ModulesList( { modules }: ModulesListProps ) {
 					return (
 						<div className={ styles[ 'module-title-wrapper' ] }>
 							<span className={ styles[ 'module-name' ] }>{ item.name }</span>
-							<span className={ styles[ 'module-description' ] }>{ item.description }</span>
+							<span
+								id={ `${ baseId }-description-${ item.module }` }
+								className={ styles[ 'module-description' ] }
+							>
+								{ item.description }
+							</span>
 						</div>
 					);
 				},
@@ -55,13 +62,16 @@ export function ModulesList( { modules }: ModulesListProps ) {
 					) : (
 						<Flex gap={ 4 } className={ styles[ 'toggle-wrap' ] }>
 							<ModuleStatus module={ item } />
-							<ModuleToggle module={ item } />
+							<ModuleToggle
+								module={ item }
+								describedby={ `${ baseId }-description-${ item.module }` }
+							/>
 						</Flex>
 					);
 				},
 			},
 		];
-	}, [] );
+	}, [ baseId ] );
 
 	return (
 		<div className={ styles.wrapper }>

--- a/projects/packages/my-jetpack/_inc/components/modules-list/index.tsx
+++ b/projects/packages/my-jetpack/_inc/components/modules-list/index.tsx
@@ -1,5 +1,5 @@
 import { Badge } from '@automattic/ui';
-import { Flex, Tooltip } from '@wordpress/components';
+import { Flex } from '@wordpress/components';
 import { DataViews, Field } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
 import { useMemo } from 'react';
@@ -37,9 +37,10 @@ export function ModulesList( { modules }: ModulesListProps ) {
 				},
 				render( { item } ) {
 					return (
-						<Tooltip text={ item.description } className={ styles[ 'module-tooltip' ] }>
-							<span>{ item.name }</span>
-						</Tooltip>
+						<div className={ styles[ 'module-title-wrapper' ] }>
+							<span className={ styles[ 'module-name' ] }>{ item.name }</span>
+							<span className={ styles[ 'module-description' ] }>{ item.description }</span>
+						</div>
 					);
 				},
 			},

--- a/projects/packages/my-jetpack/_inc/components/modules-list/styles.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/modules-list/styles.module.scss
@@ -29,10 +29,16 @@
 
 	:global(.dataviews-view-table td:last-child) {
 		padding-inline-end: 1.5rem;
+		width: auto;
+		white-space: nowrap;
 	}
 
 	:global(.dataviews-view-table td:first-child) {
 		padding-inline-start: 1.5rem;
+
+		:global(.dataviews-view-table__cell-content-wrapper) {
+			white-space: normal;
+		}
 	}
 
 	.toggle-wrap {
@@ -40,10 +46,19 @@
 	}
 }
 
-.module-tooltip {
+.module-title-wrapper {
+	display: flex;
+	flex-direction: column;
+	gap: 0.25rem;
+	min-width: 0; // Allow flex item to shrink below content size
+}
 
-	&:global(.components-tooltip) {
-		max-width: 90vw;
-		text-align: start;
-	}
+.module-name {
+	font-weight: 500;
+}
+
+.module-description {
+
+	@include gb.body-small;
+	color: #{gb.$gray-700};
 }

--- a/projects/packages/my-jetpack/changelog/MYJP-288
+++ b/projects/packages/my-jetpack/changelog/MYJP-288
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Show module descriptions beneath titles instead of in tooltips for improved discoverability.


### PR DESCRIPTION
Fixes MYJP-288

## Proposed changes:
* Move module descriptions from hover tooltips to visible text beneath each module title
* This improves discoverability - users can now see what each module does at a glance without needing to hover

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p6TEKc-8p8-p2#comment-12037

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
* Go to WP Admin → Jetpack → My Jetpack → Products tab
* Scroll down to the modules list (table view showing free modules like "Likes", "Markdown", etc.)
* Verify each module now shows:
  - Module name on the first line
  - Description text on a second line beneath the name in smaller, muted text
* Verify the toggle on the right side stays properly positioned
* Verify long descriptions wrap properly and don't push the toggle off-screen
* Test on mobile viewport to ensure proper text wrapping

<img width="1512" height="806" alt="CleanShot 2026-01-09 at 12 52 17@2x" src="https://github.com/user-attachments/assets/f37769e6-2457-42bf-b46f-a1be1ccc073c" />

<img width="674" height="984" alt="CleanShot 2026-01-09 at 12 52 36@2x" src="https://github.com/user-attachments/assets/eaf1b9b6-61d2-4676-94e9-f0b96a61b5cc" />