### PR TITLE
Forms: Update form submission confirmation page template

### DIFF
--- a/projects/packages/forms/changelog/update-forms-response-submission-template
+++ b/projects/packages/forms/changelog/update-forms-response-submission-template
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Forms: update form submission confirmation page with new design including '← Back' link, 'Thank you for your response.' heading with sparkle decoration, and improved field display styling.

--- a/projects/packages/forms/changelog/update-forms-response-submission-template
+++ b/projects/packages/forms/changelog/update-forms-response-submission-template
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Forms: update form submission confirmation page with new design including '← Back' link, 'Thank you for your response.' heading with sparkle decoration, and improved field display styling.
+Forms: update form submission confirmation page with new design.

--- a/projects/packages/forms/src/blocks/contact-form/attributes.ts
+++ b/projects/packages/forms/src/blocks/contact-form/attributes.ts
@@ -18,7 +18,7 @@ export default {
 	},
 	customThankyouHeading: {
 		type: 'string',
-		default: __( 'Your message has been sent', 'jetpack-forms' ),
+		default: __( 'Thank you for your response.', 'jetpack-forms' ),
 	},
 	customThankyouMessage: {
 		type: 'string',

--- a/projects/packages/forms/src/blocks/contact-form/edit.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/edit.tsx
@@ -863,7 +863,7 @@ function JetpackContactFormEdit( {
 								<TextControl
 									label={ __( 'Message heading', 'jetpack-forms' ) }
 									value={ customThankyouHeading }
-									placeholder={ __( 'Your message has been sent', 'jetpack-forms' ) }
+									placeholder={ __( 'Thank you for your response.', 'jetpack-forms' ) }
 									onChange={ ( newHeading: string ) =>
 										setAttributes( { customThankyouHeading: newHeading } )
 									}

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -205,7 +205,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 			'submit_button_text'     => __( 'Submit', 'jetpack-forms' ),
 			// These attributes come from the block editor, so use camel case instead of snake case.
 			'customThankyou'         => '', // Whether to show a custom thankyou response after submitting a form. '' for no, 'noSummary' to disable the summary, 'message' for a custom message, 'redirect' to redirect to a new URL. Deprecated.
-			'customThankyouHeading'  => self::get_translated_with_fallback( 'Thank you for your response.', 'Your message has been sent', 'jetpack-forms' ) . ' ✨', // The text to show above customThankyouMessage. Sparkle is appended outside i18n so translators don't need to handle it.
+			'customThankyouHeading'  => self::get_default_thank_you_heading(), // The text to show above customThankyouMessage.
 			'customThankyouMessage'  => '', // The message to show when customThankyou is set to 'message'.
 			'customThankyouRedirect' => '', // The URL to redirect to when confirmationType is set to 'redirect'.
 			'confirmationType'       => null, // The type of confirmation to show after submitting a form. 'text' for a text message, 'redirect' for a redirect link.
@@ -601,33 +601,32 @@ class Contact_Form extends Contact_Form_Shortcode {
 	}
 
 	/**
-	 * Get a translated string with fallback to a previous translation.
+	 * Get the default thank you heading with conditional sparkle.
 	 *
-	 * When copy is updated, translations may not be immediately available.
-	 * This helper falls back to the old (translated) string if the new one
-	 * hasn't been translated yet.
+	 * Returns the new copy with sparkle emoji if translated, otherwise
+	 * falls back to the old copy without sparkle.
 	 *
-	 * @param string $new_string The new string to translate.
-	 * @param string $old_string The previous string to fall back to.
-	 * @param string $domain     Text domain.
-	 * @return string The translated string.
+	 * TEMPORARY: This method can be removed once the new copy has been translated.
+	 * Replace the call with: __( 'Thank you for your response.', 'jetpack-forms' ) . ' ✨'
+	 *
+	 * @return string The translated heading.
 	 */
-	private static function get_translated_with_fallback( $new_string, $old_string, $domain ) {
-		// English locales don't need fallback.
+	private static function get_default_thank_you_heading() {
+		// English locales always get the new copy with sparkle.
 		if ( str_starts_with( get_locale(), 'en' ) ) {
-			return __( $new_string, $domain ); // phpcs:ignore WordPress.WP.I18n.NonSingularStringLiteralText,WordPress.WP.I18n.NonSingularStringLiteralDomain
+			return __( 'Thank you for your response.', 'jetpack-forms' ) . ' ✨';
 		}
 
 		// Check if new string has a translation.
-		$translations = get_translations_for_domain( $domain );
-		$entry        = $translations->translate_entry( $new_string );
+		$translations = get_translations_for_domain( 'jetpack-forms' );
+		$entry        = $translations->translate_entry( 'Thank you for your response.' );
 
 		if ( $entry && ! empty( $entry->translations ) ) {
-			return __( $new_string, $domain ); // phpcs:ignore WordPress.WP.I18n.NonSingularStringLiteralText,WordPress.WP.I18n.NonSingularStringLiteralDomain
+			return __( 'Thank you for your response.', 'jetpack-forms' ) . ' ✨';
 		}
 
-		// Fall back to old string.
-		return __( $old_string, $domain ); // phpcs:ignore WordPress.WP.I18n.NonSingularStringLiteralText,WordPress.WP.I18n.NonSingularStringLiteralDomain
+		// Fall back to old string without sparkle.
+		return __( 'Your message has been sent', 'jetpack-forms' );
 	}
 
 	/**

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -205,7 +205,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 			'submit_button_text'     => __( 'Submit', 'jetpack-forms' ),
 			// These attributes come from the block editor, so use camel case instead of snake case.
 			'customThankyou'         => '', // Whether to show a custom thankyou response after submitting a form. '' for no, 'noSummary' to disable the summary, 'message' for a custom message, 'redirect' to redirect to a new URL. Deprecated.
-			'customThankyouHeading'  => __( 'Thank you for your response.', 'jetpack-forms' ), // The text to show above customThankyouMessage.
+			'customThankyouHeading'  => self::get_translated_with_fallback( 'Thank you for your response.', 'Your message has been sent', 'jetpack-forms' ) . ' ✨', // The text to show above customThankyouMessage. Sparkle is appended outside i18n so translators don't need to handle it.
 			'customThankyouMessage'  => '', // The message to show when customThankyou is set to 'message'.
 			'customThankyouRedirect' => '', // The URL to redirect to when confirmationType is set to 'redirect'.
 			'confirmationType'       => null, // The type of confirmation to show after submitting a form. 'text' for a text message, 'redirect' for a redirect link.
@@ -598,6 +598,36 @@ class Contact_Form extends Contact_Form_Shortcode {
 		}
 
 		return $secret;
+	}
+
+	/**
+	 * Get a translated string with fallback to a previous translation.
+	 *
+	 * When copy is updated, translations may not be immediately available.
+	 * This helper falls back to the old (translated) string if the new one
+	 * hasn't been translated yet.
+	 *
+	 * @param string $new_string The new string to translate.
+	 * @param string $old_string The previous string to fall back to.
+	 * @param string $domain     Text domain.
+	 * @return string The translated string.
+	 */
+	private static function get_translated_with_fallback( $new_string, $old_string, $domain ) {
+		// English locales don't need fallback.
+		if ( str_starts_with( get_locale(), 'en' ) ) {
+			return __( $new_string, $domain ); // phpcs:ignore WordPress.WP.I18n.NonSingularStringLiteralText,WordPress.WP.I18n.NonSingularStringLiteralDomain
+		}
+
+		// Check if new string has a translation.
+		$translations = get_translations_for_domain( $domain );
+		$entry        = $translations->translate_entry( $new_string );
+
+		if ( $entry && ! empty( $entry->translations ) ) {
+			return __( $new_string, $domain ); // phpcs:ignore WordPress.WP.I18n.NonSingularStringLiteralText,WordPress.WP.I18n.NonSingularStringLiteralDomain
+		}
+
+		// Fall back to old string.
+		return __( $old_string, $domain ); // phpcs:ignore WordPress.WP.I18n.NonSingularStringLiteralText,WordPress.WP.I18n.NonSingularStringLiteralDomain
 	}
 
 	/**
@@ -1345,7 +1375,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 			$success_message = '<p class="go-back-message"> <a class="link" href="' . esc_url( $back_url ) . '">' . esc_html__( '← Back', 'jetpack-forms' ) . '</a> </p>';
 		}
 
-		$success_message .= '<h4 id="contact-form-success-header">' . esc_html( $form->get_attribute( 'customThankyouHeading' ) ) . ' <span class="sparkle-decoration" aria-hidden="true">✨</span>' . "</h4>\n\n";
+		$success_message .= '<h4 id="contact-form-success-header">' . esc_html( $form->get_attribute( 'customThankyouHeading' ) ) . "</h4>\n\n";
 
 		// Don't show the feedback details unless the nonce matches
 		if ( $is_reload_nonce_valid ) {
@@ -1443,7 +1473,6 @@ class Contact_Form extends Contact_Form_Shortcode {
 
 		$html .=
 			'<h4 id="contact-form-success-header">' . esc_html( $form->get_attribute( 'customThankyouHeading' ) ) .
-			' <span class="sparkle-decoration" aria-hidden="true">✨</span>' .
 			"</h4>\n\n";
 
 		if ( 'text' === $confirmation_type ) {

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -617,12 +617,12 @@ class Contact_Form extends Contact_Form_Shortcode {
 			return __( 'Thank you for your response.', 'jetpack-forms' ) . ' ✨';
 		}
 
-		// Check if new string has a translation.
-		$translations = get_translations_for_domain( 'jetpack-forms' );
-		$entry        = $translations->translate_entry( 'Thank you for your response.' );
+		// Check if new string has a translation by comparing with the original.
+		$original   = 'Thank you for your response.';
+		$translated = __( 'Thank you for your response.', 'jetpack-forms' );
 
-		if ( $entry && ! empty( $entry->translations ) ) {
-			return __( 'Thank you for your response.', 'jetpack-forms' ) . ' ✨';
+		if ( $translated !== $original ) {
+			return $translated . ' ✨';
 		}
 
 		// Fall back to old string without sparkle.

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -205,7 +205,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 			'submit_button_text'     => __( 'Submit', 'jetpack-forms' ),
 			// These attributes come from the block editor, so use camel case instead of snake case.
 			'customThankyou'         => '', // Whether to show a custom thankyou response after submitting a form. '' for no, 'noSummary' to disable the summary, 'message' for a custom message, 'redirect' to redirect to a new URL. Deprecated.
-			'customThankyouHeading'  => __( 'Your message has been sent', 'jetpack-forms' ), // The text to show above customThankyouMessage.
+			'customThankyouHeading'  => __( 'Thank you for your response.', 'jetpack-forms' ), // The text to show above customThankyouMessage.
 			'customThankyouMessage'  => '', // The message to show when customThankyou is set to 'message'.
 			'customThankyouRedirect' => '', // The URL to redirect to when confirmationType is set to 'redirect'.
 			'confirmationType'       => null, // The type of confirmation to show after submitting a form. 'text' for a text message, 'redirect' for a redirect link.
@@ -1342,10 +1342,10 @@ class Contact_Form extends Contact_Form_Shortcode {
 		$success_message = '';
 
 		if ( ! $disable_go_back ) {
-			$success_message = '<p class="go-back-message"> <a class="link" href="' . esc_url( $back_url ) . '">' . esc_html__( 'Go back', 'jetpack-forms' ) . '</a> </p>';
+			$success_message = '<p class="go-back-message"> <a class="link" href="' . esc_url( $back_url ) . '">' . esc_html__( '← Back', 'jetpack-forms' ) . '</a> </p>';
 		}
 
-		$success_message .= '<h4 id="contact-form-success-header">' . esc_html( $form->get_attribute( 'customThankyouHeading' ) ) . "</h4>\n\n";
+		$success_message .= '<h4 id="contact-form-success-header">' . esc_html( $form->get_attribute( 'customThankyouHeading' ) ) . ' <span class="sparkle-decoration" aria-hidden="true">✨</span>' . "</h4>\n\n";
 
 		// Don't show the feedback details unless the nonce matches
 		if ( $is_reload_nonce_valid ) {
@@ -1437,12 +1437,13 @@ class Contact_Form extends Contact_Form_Shortcode {
 
 		if ( ! $disable_go_back ) {
 			$html .= '<p class="go-back-message">';
-			$html .= '<a class="link" role="button" tabindex="0" data-wp-on--click="actions.goBack" href="' . esc_url( $back_url ) . '">' . esc_html__( 'Go back', 'jetpack-forms' ) . '</a>';
+			$html .= '<a class="link" role="button" tabindex="0" data-wp-on--click="actions.goBack" href="' . esc_url( $back_url ) . '">' . esc_html__( '← Back', 'jetpack-forms' ) . '</a>';
 			$html .= '</p>';
 		}
 
 		$html .=
 			'<h4 id="contact-form-success-header">' . esc_html( $form->get_attribute( 'customThankyouHeading' ) ) .
+			' <span class="sparkle-decoration" aria-hidden="true">✨</span>' .
 			"</h4>\n\n";
 
 		if ( 'text' === $confirmation_type ) {

--- a/projects/packages/forms/src/contact-form/css/grunion.scss
+++ b/projects/packages/forms/src/contact-form/css/grunion.scss
@@ -257,14 +257,14 @@ that needs to mimic the input element styles */
 
 	.sparkle-decoration {
 		display: inline;
-		margin-left: 4px;
+		margin-inline-start: 4px;
 	}
 }
 
 .contact-form-submission .go-back-message {
 	margin-top: 0;
 	margin-bottom: 0;
-	text-align: left;
+	text-align: start;
 }
 
 .contact-form-submission .go-back-message .link {

--- a/projects/packages/forms/src/contact-form/css/grunion.scss
+++ b/projects/packages/forms/src/contact-form/css/grunion.scss
@@ -254,11 +254,6 @@ that needs to mimic the input element styles */
 	font-size: 1.75rem;
 	font-weight: 500;
 	line-height: 1.3;
-
-	.sparkle-decoration {
-		display: inline;
-		margin-inline-start: 4px;
-	}
 }
 
 .contact-form-submission .go-back-message {

--- a/projects/packages/forms/src/contact-form/css/grunion.scss
+++ b/projects/packages/forms/src/contact-form/css/grunion.scss
@@ -281,17 +281,20 @@ that needs to mimic the input element styles */
 
 .contact-form-submission .jetpack_forms_contact-form-success-summary {
 	padding: 24px 0;
-	border-bottom: 1px solid #e0e0e0;
+	border-bottom: 1px solid currentColor;
+	border-bottom-color: color-mix(in sRGB, currentColor 20%, transparent);
 
 	&:first-of-type {
-		border-top: 1px solid #e0e0e0;
+		border-top: 1px solid currentColor;
+		border-top-color: color-mix(in sRGB, currentColor 20%, transparent);
 	}
 }
 
 .contact-form-submission .field-name {
 	font-size: 0.875rem;
 	font-weight: 400;
-	color: #6b6b6b;
+	color: inherit;
+	opacity: 0.6;
 	margin-bottom: 8px;
 }
 

--- a/projects/packages/forms/src/contact-form/css/grunion.scss
+++ b/projects/packages/forms/src/contact-form/css/grunion.scss
@@ -224,11 +224,10 @@ that needs to mimic the input element styles */
 
 .contact-form-submission {
 	box-sizing: border-box;
-	margin-bottom: 4em;
-	padding: 1.5em 1em;
+	margin: 0 auto 4em;
+	padding: 0;
 	width: 100%;
-	border-top: 1px solid #000;
-	border-bottom: 1px solid #000;
+	max-width: 600px;
 }
 
 .contact-form-submission p {
@@ -250,32 +249,57 @@ that needs to mimic the input element styles */
 }
 
 .contact-form-submission h4 {
-	margin-top: 32px;
-	margin-bottom: 32px;
-	font-weight: 200;
+	margin-top: 16px;
+	margin-bottom: 40px;
+	font-size: 1.75rem;
+	font-weight: 500;
+	line-height: 1.3;
+
+	.sparkle-decoration {
+		display: inline;
+		margin-left: 4px;
+	}
 }
 
 .contact-form-submission .go-back-message {
-	margin-top: 20px;
-	margin-bottom: 32px;
+	margin-top: 0;
+	margin-bottom: 0;
 	text-align: left;
 }
 
 .contact-form-submission .go-back-message .link {
-	font-weight: 200;
+	font-size: 0.875rem;
+	font-weight: 400;
 	color: inherit;
+	text-decoration: none;
 	cursor: pointer;
+
+	&:hover {
+		text-decoration: underline;
+	}
+}
+
+.contact-form-submission .jetpack_forms_contact-form-success-summary {
+	padding: 24px 0;
+	border-bottom: 1px solid #e0e0e0;
+
+	&:first-of-type {
+		border-top: 1px solid #e0e0e0;
+	}
 }
 
 .contact-form-submission .field-name {
-	font-weight: 200;
+	font-size: 0.875rem;
+	font-weight: 400;
+	color: #6b6b6b;
+	margin-bottom: 8px;
 }
 
 .contact-form-submission .field-images {
 	display: flex;
 	flex-wrap: wrap;
 	gap: 16px;
-	margin-bottom: 20px;
+	margin-top: 8px;
 
 	&[hidden] {
 		display: none;
@@ -308,7 +332,8 @@ that needs to mimic the input element styles */
 }
 
 .contact-form-submission .field-value {
-	margin-bottom: 20px;
+	margin-bottom: 0;
+	font-size: 1rem;
 	font-weight: 600;
 	white-space: pre-wrap;
 }

--- a/projects/plugins/jetpack/changelog/update-forms-response-submission-template
+++ b/projects/plugins/jetpack/changelog/update-forms-response-submission-template
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Forms: update E2E test to match new form submission confirmation heading.

--- a/projects/plugins/jetpack/tests/e2e/specs/forms/submission.test.ts
+++ b/projects/plugins/jetpack/tests/e2e/specs/forms/submission.test.ts
@@ -73,7 +73,7 @@ test.describe( 'Forms: Submission', () => {
 			await submissionPromise;
 
 			await expect(
-				previewPage.getByRole( 'heading', { name: 'Your message has been sent' } )
+				previewPage.getByRole( 'heading', { name: 'Thank you for your response.' } )
 			).toBeVisible();
 
 			// The form should disappear after submission.
@@ -155,7 +155,7 @@ test.describe( 'Forms: Submission', () => {
 			// Check the correct form was submitted.
 			const submittedFormWrapper = previewPage.locator( `#${ formId }` );
 			await expect(
-				submittedFormWrapper.getByRole( 'heading', { name: 'Your message has been sent' } )
+				submittedFormWrapper.getByRole( 'heading', { name: 'Thank you for your response.' } )
 			).toBeVisible();
 
 			const submittedForm = submittedFormWrapper.getByRole( 'form', { name: 'Submit this form' } );


### PR DESCRIPTION
## Proposed changes:

Updates the form submission confirmation page (shown after a user submits a form) with a new design:

* Change back link text from "Go back" to "← Back"
* Update default heading from "Your message has been sent" to "Thank you for your response."
* Add sparkle emoji (✨) decoration after the heading
* Redesign CSS for the confirmation page:
  - Centered layout with max-width 600px
  - Remove top/bottom borders
  - Fields displayed with label above value
  - Horizontal dividers between fields
  - Labels smaller (0.875rem) and muted color (#6b6b6b)
  - Values bold (font-weight 600)

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

Part of the Forms: Improve Form Response Display project.

## Does this pull request change what data or activity we track or use?

No changes to tracking or data usage.

## Testing instructions:

1. Go to any WordPress post/page with a Jetpack Form
2. Submit the form with some test data
3. Verify the confirmation page shows:
   - "← Back" link at the top
   - "Thank you for your response. ✨" heading
   - Fields displayed with labels above values
   - Horizontal dividers between each field
   - Centered, clean layout

**Before:**
- "Go back" link
- "Your message has been sent" heading
- Bordered container with different styling
<img width="691" height="602" alt="Screenshot 2026-01-09 at 14 40 20" src="https://github.com/user-attachments/assets/0a807ce7-58a9-43d3-86f0-3c9ea01485dd" />


**After:**
- "← Back" link
- "Thank you for your response. ✨" heading
- Clean centered layout with subtle dividers between fields
<img width="667" height="643" alt="Screenshot 2026-01-09 at 14 42 11" src="https://github.com/user-attachments/assets/1fa2e822-4699-4570-8bde-569625ce5a4e" />


🤖 Generated with [Claude Code](https://claude.ai/code)