### PR TITLE
Forms: Fix responses endpoint PHP Warning

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-responses-warning
+++ b/projects/packages/forms/changelog/fix-forms-responses-warning
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: prevent get_render_api_value from mutating internal state when called multiple times on cached feedback objects.

--- a/projects/packages/forms/src/contact-form/class-feedback-field.php
+++ b/projects/packages/forms/src/contact-form/class-feedback-field.php
@@ -266,7 +266,8 @@ class Feedback_Field {
 	private function get_render_api_value() {
 		if ( $this->is_of_type( 'file' ) ) {
 			$files = array();
-			foreach ( $this->value['files'] as &$file ) {
+			$value = $this->value;
+			foreach ( $value['files'] as $file ) {
 				if ( ! isset( $file['size'] ) || ! isset( $file['file_id'] ) ) {
 					// this shouldn't happen, todo: log this
 					continue;
@@ -278,8 +279,8 @@ class Feedback_Field {
 				$file['is_previewable'] = $this->is_previewable_file( $file );
 				$files[]                = $file;
 			}
-			$this->value['files'] = $files;
-			return $this->value;
+			$value['files'] = $files;
+			return $value;
 		}
 
 		if ( $this->is_of_type( 'image-select' ) ) {


### PR DESCRIPTION
This PR Removes a PHP Warning that happens in when viewing the form responses that contain a file upload. 

## Proposed changes:
   * Fix PHP warning in Forms package when `get_render_api_value()` is called multiple times on cached feedback objects
   * Prevent mutation of internal state in `Feedback_Field::get_render_api_value()` by working on a copy of the value instead of mutating `$this->value` directly
   * Ensure `size_format()` only receives numeric values even when called repeatedly on the same cached object

### Other information:

   - [x] Have you written new tests for your changes, if applicable?
   - [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
   - [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
No

## Does this pull request change what data or activity we track or use?
   No

## Testing instructions:

### Background
The Forms package uses a static cache to store `Feedback` objects. When `get_render_api_value()` was called multiple times on the same cached object (e.g., through REST API
   endpoints), it would mutate the internal `$this->value['files']` array, converting numeric file sizes to formatted strings. On subsequent calls, `size_format()` would receive a
   string like "1 KB" instead of a numeric value, causing a PHP warning.

You can see the PHP warning when visiting the Forms Responses page and looking at the debug log. 
It goes away when this PR is applied. 
```
PHP Warning:  A non-numeric value encountered in /var/www/html/wp-includes/functions.php on line 496
```

### Steps to reproduce the original issue:
   1. Create a form with a file upload field
   2. Submit the form with a file attachment
   3. Call the feedback REST API endpoint multiple times for the same feedback entry (e.g., `GET /wp-json/jetpack/v4/forms/responses/{id}`)
   4. Observe PHP warnings in the error log about `size_format()` expecting numeric values

### Testing the fix:
   1. Create a form with a file upload field
   2. Submit the form with a file attachment
   3. Call the feedback REST API endpoint multiple times: `GET /wp-json/jetpack/v4/forms/responses/{id}`
   4. Verify no PHP warnings appear in the error log
   5. Verify the file size is correctly formatted in the API response (e.g., "1 KB", "500 bytes")
   6. Call the endpoint again and verify the response remains consistent
