### PR TITLE
VideoPress: Fix wide width alignment for core video blocks (VIDP-12)

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-videopress-wide-width-alignment
+++ b/projects/plugins/jetpack/changelog/fix-videopress-wide-width-alignment
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+VideoPress: Fix wide width alignment for core video blocks in the editor.

--- a/projects/plugins/jetpack/extensions/blocks/videopress/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/edit.js
@@ -934,6 +934,12 @@ const VideoPressEdit = CoreVideoEdit =>
 				</Fragment>
 			);
 
+			// For regular videos when VideoPress is not being used, render without wrappers
+			// If there's no GUID and we're not uploading, it's a regular video that doesn't need wrappers
+			if ( renderCoreVideoAndLoadingBlocks && ! guid && ! isUploading ) {
+				return <CoreVideoEdit { ...this.props } />;
+			}
+
 			if ( renderCoreVideoAndLoadingBlocks ) {
 				return resumableUploadEnabled ? (
 					<VideoPressBlockProvider


### PR DESCRIPTION
## Summary

Fixes a bug where core video blocks with "Wide width" alignment were not displaying correctly in the editor when Jetpack is active.

**Root Cause**: VideoPress was wrapping ALL core video blocks (not just VideoPress videos) with extra div elements, breaking the CSS direct child selector `.is-root-container > .alignwide` required for wide width styling.

## Changes

**File Modified**: `projects/plugins/jetpack/extensions/blocks/videopress/edit.js` (lines 937-941)

Added early return for regular videos to bypass VideoPress wrappers:

```javascript
// For regular videos when VideoPress is not being used, render without wrappers
// If there's no GUID and we're not uploading, it's a regular video that doesn't need wrappers
if ( renderCoreVideoAndLoadingBlocks && ! guid && ! isUploading ) {
    return <CoreVideoEdit { ...this.props } />;
}
```

**Logic**: Only videos with a VideoPress GUID (indicating they're hosted on VideoPress) or videos currently being uploaded need the wrapper divs. Regular videos should render directly using the core video block component.

## DOM Structure Impact

### Before Fix (Broken)
```html
<div class="is-root-container">
  <div class="videopress-block-hide">  <!-- ❌ Unwanted wrapper -->
    <Loading text="Generating preview…" />
  </div>
  <div class="">  <!-- ❌ Empty class wrapper breaks CSS -->
    <figure class="alignwide">
      <video>...</video>
    </figure>
  </div>
</div>
```

**Issues**:
- VideoPress wrapper divs present for ALL videos
- CSS selector `.is-root-container > .alignwide` fails (figure not direct child)
- "Generating preview…" message shown for regular videos
- Wide width alignment not applied

### After Fix (Working)
```html
<div class="is-root-container">
  <figure class="alignwide">  <!-- ✅ Direct child -->
    <video>...</video>
  </figure>
</div>
```

**Results**:
- No VideoPress wrappers for regular videos
- CSS selector matches correctly
- Figure is direct child of container
- Wide width alignment properly applied (1280px)

## Validation Results

### Editor (Before Fix)
- `hasVideoPressHide`: `true` ❌
- `hasGeneratingPreview`: `true` ❌  
- `hasEmptyClassDiv`: `true` ❌
- `cssSelectorWorks`: `false` ❌

### Editor (After Fix)
- `hasVideoPressHide`: `false` ✅
- `hasGeneratingPreview`: `false` ✅
- `figureParentTag`: `DIV` with class `is-root-container` ✅
- `cssSelectorWorks`: `true` ✅

### Frontend (After Fix)
- `hasVideoPressHide`: `false` ✅
- `figureWidth`: `1280px` ✅ (wide width applied)
- `parentWidth`: `1520px` ✅
- No JavaScript errors ✅

## Does this pull request change what data or activity we track or use?
No

## Testing

### Automated Tests
- ✅ **532 tests passed** (102 test suites)
- ✅ All VideoPress block tests passing
- ✅ No test failures or regressions

## Testing Instructions:
- **Site**: WordPress 6.9 with Jetpack 15.4-a.5 + VideoPress v2.7
- **Theme**: Twenty Twenty-Four
- **Test Video**: External MP4 (Big Buck Bunny)
- ✅ Created video block with "Wide width" alignment
- ✅ Verified DOM structure in editor
- ✅ Published and verified on frontend
- ✅ No console errors

### Impact Analysis
| Scenario | Before Fix | After Fix |
|----------|------------|-----------|
| Regular video (no GUID) | Wrapped with VideoPress divs ❌ | Direct core video render ✅ |
| VideoPress video (has GUID) | Wrapped (correct) ✅ | Wrapped (preserved) ✅ |
| Video uploading | Wrapped (correct) ✅ | Wrapped (preserved) ✅ |
| Wide width alignment CSS | Broken ❌ | Working ✅ |

## Screenshots

I have three screenshots ready to be uploaded:

1. **Before Fix** - Editor view showing bug with VideoPress wrappers
<img width="3456" height="1888" alt="vidp-12-before-fix-fullscreen" src="https://github.com/user-attachments/assets/49c90fda-18df-49fa-9109-128ef9dcf415" />

   - File: `vidp-12-before-fix-fullscreen.png` (225KB)
   - Shows: VideoPress wrapper divs, "Generating preview" message, broken CSS selector

2. **After Fix** - Editor view showing fix working
<img width="3456" height="1888" alt="vidp-12-after-fix-fullscreen" src="https://github.com/user-attachments/assets/1f76b4b7-ef09-4175-98da-adef045705f8" />

   - File: `vidp-12-after-fix-fullscreen.png` (233KB)  
   - Shows: No wrappers, clean DOM structure, CSS selector working

4. **Frontend** - Published post with wide width video
<img width="3456" height="1888" alt="vidp-12-frontend-wide-width" src="https://github.com/user-attachments/assets/77321682-e243-4b6a-90a1-d346e47a5b89" />

   - File: `vidp-12-frontend-wide-width.png` (153KB)
   - Shows: Video rendering correctly at 1280px width on frontend

Screenshot files are located at: `/Users/derrick/Developer/ai-enablement/day1/`

I'll upload these shortly by dragging them into a comment.

## Related

Fixes: https://linear.app/a8c/issue/VIDP-12/videopress-video-block-with-wide-width-not-styled-as-wide-in-the
Fixes VIDP-12

🤖 Generated with [Claude Code](https://claude.com/claude-code)