### PR TITLE
Optimize CI: Make code coverage non-blocking

### DIFF
--- a/.github/files/generate-ci-matrix.php
+++ b/.github/files/generate-ci-matrix.php
@@ -118,11 +118,14 @@ $matrix[] = array(
 );
 
 // Add Coverage tests.
+// Coverage is experimental (non-blocking) to reduce CI wait time on PRs.
+// Coverage data is still collected and published, but failures won't block merging.
 $matrix[] = array(
-	'name'    => 'Code coverage',
-	'script'  => 'test-coverage',
-	'wp'      => 'latest',
-	'timeout' => 40, // 2025-11-06: Successful runs seem to take ~15 minutes.
+	'name'         => 'Code coverage',
+	'script'       => 'test-coverage',
+	'wp'           => 'latest',
+	'timeout'      => 40, // 2025-11-06: Successful runs seem to take ~15 minutes.
+	'experimental' => true,
 );
 
 // END matrix definitions.


### PR DESCRIPTION
## Summary

Makes the code coverage job non-blocking (`experimental: true`) to reduce CI wait time on PRs.

## Changes

- Added `'experimental' => true` to the code coverage matrix entry in `generate-ci-matrix.php`

## Impact

- **Before:** PRs wait for the 40-minute coverage job to complete before merging
- **After:** Coverage still runs and publishes data, but failures won't block PR merges

Coverage data is still collected and published to Codecov - this only changes whether coverage failures block the workflow.

## Does this pull request change what data or activity we track or use?

No.