### PR TITLE
Gate PayPal payment buttons block behind conditional features

### DIFF
--- a/projects/packages/blocks/changelog/update-gate-paypal-payment-buttons-conditional-features
+++ b/projects/packages/blocks/changelog/update-gate-paypal-payment-buttons-conditional-features
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Gating for the PayPal payment buttons block

--- a/projects/packages/blocks/src/class-blocks.php
+++ b/projects/packages/blocks/src/class-blocks.php
@@ -79,6 +79,7 @@ class Blocks {
 				$gated_blocks        = array(
 					'jetpack/donations',
 					'jetpack/payment-buttons',
+					'jetpack/paypal-payment-buttons',
 				);
 				if ( in_array( $slug, $gated_blocks, true ) &&
 					is_string( $block_type ) &&

--- a/projects/packages/paypal-payments/changelog/update-gate-paypal-payment-buttons-conditional-features
+++ b/projects/packages/paypal-payments/changelog/update-gate-paypal-payment-buttons-conditional-features
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Gating for the PayPal payment buttons block

--- a/projects/packages/paypal-payments/src/paypal-payment-buttons/class-paypal-payment-buttons.php
+++ b/projects/packages/paypal-payments/src/paypal-payment-buttons/class-paypal-payment-buttons.php
@@ -83,7 +83,10 @@ class PayPal_Payment_Buttons {
 	public static function register_block() {
 		Blocks::jetpack_register_block(
 			__DIR__,
-			array( 'render_callback' => array( __CLASS__, 'render_block' ) )
+			array(
+				'render_callback' => array( __CLASS__, 'render_block' ),
+				'plan_check'      => true,
+			)
 		);
 	}
 

--- a/projects/plugins/jetpack/changelog/update-gate-paypal-payment-buttons-conditional-features
+++ b/projects/plugins/jetpack/changelog/update-gate-paypal-payment-buttons-conditional-features
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Gating for the PayPal payment buttons block

--- a/projects/plugins/jetpack/class.jetpack-gutenberg.php
+++ b/projects/plugins/jetpack/class.jetpack-gutenberg.php
@@ -79,8 +79,9 @@ class Jetpack_Gutenberg {
 	 * @var array Feature slug => minimum WordPress.com plan slug.
 	 */
 	private static $wpcom_minimum_plan_fallbacks = array(
-		'donations'       => 'value_bundle',
-		'payment-buttons' => 'value_bundle',
+		'donations'              => 'value_bundle',
+		'payment-buttons'        => 'value_bundle',
+		'paypal-payment-buttons' => 'value_bundle',
 	);
 
 	/**

--- a/projects/plugins/wpcomsh/changelog/update-gate-paypal-payment-buttons-conditional-features
+++ b/projects/plugins/wpcomsh/changelog/update-gate-paypal-payment-buttons-conditional-features
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Feature gating for payment-buttons and paypal-payment-buttons blocks

--- a/projects/plugins/wpcomsh/wpcom-features/class-wpcom-features.php
+++ b/projects/plugins/wpcomsh/wpcom-features/class-wpcom-features.php
@@ -450,6 +450,8 @@ class WPCOM_Features {
 	public const OPENTABLE                         = 'opentable';
 	public const OPTIONS_PERMALINK                 = 'options-permalink';
 	public const PAYMENTS                          = 'payments';
+	public const PAYMENT_BUTTONS                   = 'payment-buttons';
+	public const PAYPAL_PAYMENT_BUTTONS            = 'paypal-payment-buttons';
 	public const PERFORMANCE                       = 'performance';
 	public const PERFORMANCE_HISTORY               = 'performance-history';
 	public const POLLDADDY                         = 'polldaddy';
@@ -1031,6 +1033,22 @@ class WPCOM_Features {
 			),
 			self::WPCOM_STARTER_PLANS,
 			self::WPCOM_PREMIUM_AND_HIGHER_PLANS,
+		),
+		self::PAYMENT_BUTTONS                   => array(
+			array(
+				'sticker_not_present' => 'gating-business-q1',
+				self::WPCOM_ALL_SITES,
+			),
+			self::WPCOM_PREMIUM_AND_HIGHER_PLANS,
+			self::JETPACK_ALL_SITES,
+		),
+		self::PAYPAL_PAYMENT_BUTTONS            => array(
+			array(
+				'sticker_not_present' => 'gating-business-q1',
+				self::WPCOM_ALL_SITES,
+			),
+			self::WPCOM_PREMIUM_AND_HIGHER_PLANS,
+			self::JETPACK_ALL_SITES,
 		),
 		self::PERFORMANCE                       => array(
 			self::WPCOM_BUSINESS_AND_HIGHER_PLANS,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes DOTCOM-15588

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add gating for the PayPal Payment Buttons block

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Add a test sticker to a site - `add_blog_sticker( 'gating-business-q1', null, null, site_id );`
* Sandbox two test sites with Personal plan (with/without the sticker) and checkout the PR with `bin/jetpack-downloader test jetpack update/gate-paypal-payment-buttons-conditional-features`
* Confirm that on a site with a sticker the PayPal Payment Buttons block shows a banner:
<img width="1264" height="449" alt="Screenshot 2026-01-09 at 23 38 01" src="https://github.com/user-attachments/assets/abc6d171-ae30-4dbb-a204-92d6033dd4bb" />

* Confirm that on a site without a sticker the PayPal Payment Buttons block doesn't show a banner:
<img width="655" height="449" alt="Screenshot 2026-01-09 at 23 38 35" src="https://github.com/user-attachments/assets/cfcd82d4-fb75-401a-81a8-9a882aa6db5a" />

