### PR TITLE
wpcomsh: Remove artificial 50GB storage limit for Pro plan

### DIFF
--- a/projects/plugins/wpcomsh/changelog/fix-pro-plan-storage-limit
+++ b/projects/plugins/wpcomsh/changelog/fix-pro-plan-storage-limit
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Legacy Pro plan: Remove artificial media storage limit
+Legacy Pro plan: Remove artificial media storage limit.

--- a/projects/plugins/wpcomsh/changelog/fix-pro-plan-storage-limit
+++ b/projects/plugins/wpcomsh/changelog/fix-pro-plan-storage-limit
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Legacy Pro plan: Remove artificial media storage limit

--- a/projects/plugins/wpcomsh/notices/storage-notices.php
+++ b/projects/plugins/wpcomsh/notices/storage-notices.php
@@ -17,7 +17,7 @@ function wpcomsh_storage_notices() {
 	}
 
 	$space_used  = intval( $site_info['space_used'] );
-	$space_quota = intval( wpcomsh_pro_plan_storage_override( $site_info['space_quota'] ) );
+	$space_quota = intval( $site_info['space_quota'] );
 
 	// Info (0-95% usage)
 	$notice_class = 'info';
@@ -75,7 +75,7 @@ function wpcomsh_display_disk_space_usage() {
 	}
 
 	$space_used  = intval( $site_info['space_used'] );
-	$space_quota = intval( wpcomsh_pro_plan_storage_override( $site_info['space_quota'] ) );
+	$space_quota = intval( $site_info['space_quota'] );
 
 	$message = sprintf(
 		/* translators: 1: Upload space used; 2: Upload space allowed; 3: percentage of allowed space used */
@@ -126,18 +126,3 @@ function wpcomsh_debug_information_disk_usage( $args ) {
 	return $args;
 }
 add_filter( 'debug_information', 'wpcomsh_debug_information_disk_usage' );
-
-/**
- * Override the storage limit for Pro plans.
- *
- * @param string $space_allowed The storage limit.
- *
- * @return string The potentially updated storage limit.
- */
-function wpcomsh_pro_plan_storage_override( $space_allowed ) {
-	if ( wpcom_site_has_feature( WPCOM_Features::ARTIFICIAL_50GB_STORAGE_LIMIT ) ) {
-		$space_allowed = strval( 50 * GB_IN_BYTES );
-	}
-
-	return $space_allowed;
-}

--- a/projects/plugins/wpcomsh/wpcom-features/class-wpcom-features.php
+++ b/projects/plugins/wpcomsh/wpcom-features/class-wpcom-features.php
@@ -382,7 +382,6 @@ class WPCOM_Features {
 	public const AKISMET                           = 'akismet';
 	public const ANTISPAM                          = 'antispam';
 	public const ARCHIVE_CONTENT                   = 'archive-content';
-	public const ARTIFICIAL_50GB_STORAGE_LIMIT     = 'artificial-50gb-storage-limit';
 	public const ATOMIC                            = 'atomic';
 	public const BACKUPS                           = 'backups';
 	public const BACKUPS_DAILY                     = 'backups-daily';
@@ -588,13 +587,6 @@ class WPCOM_Features {
 			self::WPCOM_HUNDRED_YEAR_BUNDLE,
 		),
 
-		/*
-		 * Temporary limit until the Pro plan storage is ready to be fully
-		 * implemented.
-		 */
-		self::ARTIFICIAL_50GB_STORAGE_LIMIT     => array(
-			self::WPCOM_PRO_PLANS,
-		),
 		self::ATOMIC                            => array(
 			self::WPCOM_PRO_PLANS,
 			self::WPCOM_BUSINESS_AND_HIGHER_PLANS,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to DOTDEV-253
Related PR: 199616-ghe-Automattic/wpcom

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* remove artificial hardcoded 50 GB storage limit from the legacy Pro plan

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

DOTDEV-253

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No, it does not.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

ℹ️ There's quite a number of steps. Please let me know if something isn't clear or you would like to pair.

1. Create a test WoA site with a free plan (3a167-pb).
2. Add a legacy Pro plan to it through SA (similarly as it is outlined in the testing instructions in 199616-ghe-Automattic/wpcom).
3. If you don't have any free credits on your account, you can add it now (at least 600 USD is needed for one 50 GB add-on).
4. Go to the _Upgrades → Add-Ons_ in your test site dashboard and purchase one 50 GB storage add-on.
5. Follow these steps provided in the [comment below](https://github.com/Automattic/jetpack/pull/46543#issuecomment-3738122551) to apply the changes from this PR to your WoA test site:

> - To test on WoA, go to the Plugins menu on a WoA dev site. Click on the "Upload" button and follow the upgrade flow to be able to upload, install, and activate [the Jetpack Beta plugin](https://jetpack.com/download-jetpack-beta/). Once the plugin is active, go to Jetpack > Jetpack Beta, select your plugin (WordPress.com Site Helper), and enable the `fix/pro-plan-storage-limit` branch.
6. Connect to the site through SFTP and create the `.at-site-info` file in `tmp/` with this content: 3a16a-pb. This is how it should look like: 3a16d-pb.

ℹ️ This step is needed because the `.at-site-info` file gets written within 12 hours of the site creation (related discussion: p1768230851586439-slack-C7YPW6K40). Without the file we cannot test the changes as the logic relies on it.

7. Go to WP Admin of the WoA test site and navigate to _Media → Library_.
8. Review the reported storage in the notice. It should include the 50 GB storage add-on:

| Before | After |
|--------|--------|
| <img width="1248" height="500" alt="CleanShot 2026-01-13 at 09 48 41@2x" src="https://github.com/user-attachments/assets/15d8fbbe-0e5d-4438-84a0-708deaf76e7d" /> | <img width="1248" height="500" alt="CleanShot 2026-01-13 at 09 50 15@2x" src="https://github.com/user-attachments/assets/73cf40af-a42b-44bb-bf72-9ac7415c76a7" /> |