### PR TITLE
jetpack-mu-wpcom: Fix code block enhancement warning

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/code-block-conditional-block-enhancement
+++ b/projects/packages/jetpack-mu-wpcom/changelog/code-block-conditional-block-enhancement
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+jetpack-mu-wpcom: Only enhance code block when content attribute is registered.

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/class-code-block.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/class-code-block.php
@@ -179,7 +179,12 @@ abstract class Code_Block {
 	 * @return array The modified block type arguments.
 	 */
 	public static function register_block_type_args( array $args, string $block_type ): array {
-		if ( 'core/code' !== $block_type ) {
+		if (
+			'core/code' !== $block_type
+			// In some cases the block may not include the content attribute.
+			// Only perform enhancement on the _full_, expected block.
+			|| ! isset( $args['attributes']['content'] )
+		) {
 			return $args;
 		}
 


### PR DESCRIPTION
## Proposed changes:

Prevent warning and incorrect code block enhancement.

Occasional warnings appear when the code block enhancement filter runs:

```
Undefined array key "content"
```

Pointing to this:

https://github.com/Automattic/jetpack/blob/24b1d605a683ee48d57da7527e9c2880b73cf557/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/class-code-block.php#L255

If the `content` attribute is not set on an `attributes` array, the block is not in its expected form for enhancement and nothing should occur.

This issue appears to be common on certain URLs, for example `/comments/feed`.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?



## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:

Ensure the enhanced code block appears in the editor and frontend as expected.
No warnings should be issued, for example on `/comments/feed` URLs.
