### PR TITLE
Social: Decouple SharePostForm component from the store

### DIFF
--- a/projects/packages/publicize/_inc/components/form/share-post-form.tsx
+++ b/projects/packages/publicize/_inc/components/form/share-post-form.tsx
@@ -42,18 +42,20 @@ export type SharePostFormProps = {
 	onMessageChange?: ( message: string ) => void;
 
 	/**
-	 * Optional attached media array. When provided along with `onMediaChange`,
-	 * the component uses these values instead of fetching from the store.
+	 * Optional attached media array. In controlled mode (when `onMediaChange` is provided),
+	 * this value is passed to child components instead of fetching from the store.
 	 */
 	attachedMedia?: Array< AttachedMedia >;
 
 	/**
-	 * Optional image generator settings. Used with per-connection customization.
+	 * Optional image generator settings. In controlled mode, this value is passed to
+	 * child components instead of fetching from the store.
 	 */
 	imageGeneratorSettings?: SIGSettings;
 
 	/**
-	 * Optional media source value.
+	 * Optional media source value. In controlled mode, this value is passed to
+	 * child components instead of fetching from the store.
 	 */
 	mediaSource?: JetpackSocialOptions[ 'media_source' ];
 

--- a/projects/packages/publicize/_inc/components/form/share-post-form.tsx
+++ b/projects/packages/publicize/_inc/components/form/share-post-form.tsx
@@ -15,8 +15,9 @@ import MessageBoxControl from '../message-box-control';
 import SocialImageGeneratorPanel from '../social-image-generator/panel';
 import styles from './styles.module.scss';
 import { UpgradeNotice } from './upgrade-notice';
+import type { AttachedMedia, JetpackSocialOptions, SIGSettings } from '../../utils/types';
 
-type SharePostFormProps = {
+export type SharePostFormProps = {
 	/** Data for tracking analytics */
 	analyticsData?: {
 		/** The location of the analytics event */
@@ -27,6 +28,39 @@ type SharePostFormProps = {
 	 * This enables navigation for certain components within the form.
 	 */
 	isInsideNavigatorModal?: boolean;
+
+	/**
+	 * Optional message value. When provided, the component uses this value
+	 * instead of fetching from the store.
+	 */
+	message?: string;
+
+	/**
+	 * Optional callback to update the message. Required when `message` prop is provided.
+	 */
+	onMessageChange?: ( message: string ) => void;
+
+	/**
+	 * Optional attached media array. When provided along with `onMediaChange`,
+	 * the component uses these values instead of fetching from the store.
+	 */
+	attachedMedia?: Array< AttachedMedia >;
+
+	/**
+	 * Optional image generator settings. Used with per-connection customization.
+	 */
+	imageGeneratorSettings?: SIGSettings;
+
+	/**
+	 * Optional media source value.
+	 */
+	mediaSource?: JetpackSocialOptions[ 'media_source' ];
+
+	/**
+	 * Optional callback to update media-related options. Required when media props are provided.
+	 * Accepts partial JetpackSocialOptions to update.
+	 */
+	onMediaChange?: ( updates: Partial< JetpackSocialOptions > ) => void;
 };
 
 /**
@@ -38,10 +72,27 @@ type SharePostFormProps = {
 export const SharePostForm: FC< SharePostFormProps > = ( {
 	analyticsData = null,
 	isInsideNavigatorModal,
+	message: messageProp,
+	onMessageChange,
+	attachedMedia,
+	imageGeneratorSettings,
+	mediaSource,
+	onMediaChange,
 } ) => {
-	const { message, updateMessage, maxLength } = useSocialMediaMessage();
+	const {
+		message: storeMessage,
+		updateMessage: storeUpdateMessage,
+		maxLength,
+	} = useSocialMediaMessage();
 	const isSocialNote = useIsSocialNote();
 	const postCanUseSig = usePostCanUseSig();
+
+	// Use props if provided, otherwise fall back to store values
+	const message = messageProp !== undefined ? messageProp : storeMessage;
+	const updateMessage = onMessageChange ?? storeUpdateMessage;
+
+	// Check if we're in "controlled" mode for media (props provided)
+	const isMediaControlled = onMediaChange !== undefined;
 
 	const { openUnifiedModal } = useDispatch( socialStore );
 
@@ -73,14 +124,29 @@ export const SharePostForm: FC< SharePostFormProps > = ( {
 					{ ! hasSocialPaidFeatures() ? (
 						<UpgradeNotice />
 					) : (
-						<MediaSectionV2 analyticsData={ analyticsData } onEditTemplate={ onEditTemplate } />
+						<MediaSectionV2
+							analyticsData={ analyticsData }
+							onEditTemplate={ onEditTemplate }
+							{ ...( isMediaControlled && {
+								attachedMedia,
+								imageGeneratorSettings,
+								mediaSource,
+								onMediaChange,
+							} ) }
+						/>
 					) }
 				</div>
 			) : (
 				<>
 					{ siteHasFeature( features.ENHANCED_PUBLISHING ) && (
 						<div className={ styles[ 'share-post-form__media-section' ] }>
-							<MediaSection analyticsData={ analyticsData } />
+							<MediaSection
+								analyticsData={ analyticsData }
+								{ ...( isMediaControlled && {
+									attachedMedia,
+									onMediaChange,
+								} ) }
+							/>
 						</div>
 					) }
 					{ /* Social Image Generator panel - only shown when not using unified UI */ }

--- a/projects/packages/publicize/_inc/components/form/share-post-form.tsx
+++ b/projects/packages/publicize/_inc/components/form/share-post-form.tsx
@@ -36,7 +36,8 @@ export type SharePostFormProps = {
 	message?: string;
 
 	/**
-	 * Optional callback to update the message. Required when `message` prop is provided.
+	 * Optional callback to update the message. When omitted, falls back to
+	 * updating via the internal store.
 	 */
 	onMessageChange?: ( message: string ) => void;
 
@@ -57,8 +58,8 @@ export type SharePostFormProps = {
 	mediaSource?: JetpackSocialOptions[ 'media_source' ];
 
 	/**
-	 * Optional callback to update media-related options. Required when media props are provided.
-	 * Accepts partial JetpackSocialOptions to update.
+	 * Optional callback to update media-related options. When provided, the component
+	 * operates in controlled mode and uses the media props instead of fetching from the store.
 	 */
 	onMediaChange?: ( updates: Partial< JetpackSocialOptions > ) => void;
 };

--- a/projects/packages/publicize/_inc/components/media-section-v2/index.tsx
+++ b/projects/packages/publicize/_inc/components/media-section-v2/index.tsx
@@ -62,7 +62,10 @@ export default function MediaSectionV2( {
 			isControlled ? imageGeneratorSettingsProp ?? { enabled: false } : storeImageGeneratorSettings,
 		[ isControlled, imageGeneratorSettingsProp, storeImageGeneratorSettings ]
 	);
-	const mediaSource = isControlled ? mediaSourceProp : storeMediaSource;
+	const mediaSource = useMemo(
+		() => ( isControlled ? mediaSourceProp ?? storeMediaSource : storeMediaSource ),
+		[ isControlled, mediaSourceProp, storeMediaSource ]
+	);
 
 	// Unified update function that uses props callback or store
 	const updateMediaOptions = useMemo(

--- a/projects/packages/publicize/_inc/components/media-section-v2/index.tsx
+++ b/projects/packages/publicize/_inc/components/media-section-v2/index.tsx
@@ -34,12 +34,41 @@ export default function MediaSectionV2( {
 	analyticsData = {},
 	disabled = false,
 	onEditTemplate,
+	attachedMedia: attachedMediaProp,
+	imageGeneratorSettings: imageGeneratorSettingsProp,
+	mediaSource: mediaSourceProp,
+	onMediaChange,
 }: MediaSectionV2Props ) {
 	const { recordEvent } = useAnalytics();
 	const featuredImageId = useFeaturedImage();
 	const { isEnabled: sigEnabled } = useImageGeneratorConfig();
-	const { attachedMedia, imageGeneratorSettings, mediaSource, updateJetpackSocialOptions } =
-		usePostMeta();
+	const {
+		attachedMedia: storeAttachedMedia,
+		imageGeneratorSettings: storeImageGeneratorSettings,
+		mediaSource: storeMediaSource,
+		updateJetpackSocialOptions,
+	} = usePostMeta();
+
+	// Check if we're in "controlled" mode (props provided)
+	const isControlled = onMediaChange !== undefined;
+
+	// Use props if in controlled mode, otherwise fall back to store values
+	const attachedMedia = useMemo(
+		() => ( isControlled ? attachedMediaProp ?? [] : storeAttachedMedia ),
+		[ isControlled, attachedMediaProp, storeAttachedMedia ]
+	);
+	const imageGeneratorSettings = useMemo(
+		() =>
+			isControlled ? imageGeneratorSettingsProp ?? { enabled: false } : storeImageGeneratorSettings,
+		[ isControlled, imageGeneratorSettingsProp, storeImageGeneratorSettings ]
+	);
+	const mediaSource = isControlled ? mediaSourceProp : storeMediaSource;
+
+	// Unified update function that uses props callback or store
+	const updateMediaOptions = useMemo(
+		() => ( isControlled ? onMediaChange : updateJetpackSocialOptions ),
+		[ isControlled, onMediaChange, updateJetpackSocialOptions ]
+	);
 
 	// Get SIG preview URL when SIG is enabled
 	const { url: sigPreviewUrl, isLoading: sigIsLoading } = useSigPreview( sigEnabled );
@@ -110,7 +139,7 @@ export default function MediaSectionV2( {
 			} );
 
 			// Single batch update with explicit media_source and all related fields
-			updateJetpackSocialOptions( {
+			updateMediaOptions( {
 				media_source: source || 'none',
 				attached_media: [], // Reset attachment when changing source
 				image_generator_settings: {
@@ -119,7 +148,7 @@ export default function MediaSectionV2( {
 				},
 			} );
 		},
-		[ recordEvent, analyticsData, updateJetpackSocialOptions, imageGeneratorSettings ]
+		[ recordEvent, analyticsData, updateMediaOptions, imageGeneratorSettings ]
 	);
 
 	// Handle media selection from Media Library
@@ -128,7 +157,7 @@ export default function MediaSectionV2( {
 			const { id, url, mime } = media;
 
 			// Single batch update with explicit media_source
-			updateJetpackSocialOptions( {
+			updateMediaOptions( {
 				media_source: 'media-library',
 				attached_media: [ { id, url, type: mime } ],
 				image_generator_settings: { ...imageGeneratorSettings, enabled: false },
@@ -139,7 +168,7 @@ export default function MediaSectionV2( {
 				source: 'media-library',
 			} );
 		},
-		[ updateJetpackSocialOptions, imageGeneratorSettings, recordEvent, analyticsData ]
+		[ updateMediaOptions, imageGeneratorSettings, recordEvent, analyticsData ]
 	);
 
 	const handleMediaLibraryClick = useCallback( () => {
@@ -152,7 +181,7 @@ export default function MediaSectionV2( {
 	const handleAiImageSelect = useCallback(
 		( { id, url, mime }: WPMediaObject ) => {
 			// Use 'media-library' as the source since the AI image is uploaded to the media library
-			updateJetpackSocialOptions( {
+			updateMediaOptions( {
 				media_source: 'media-library',
 				attached_media: [ { id, url, type: mime || 'image/png' } ],
 				image_generator_settings: { ...imageGeneratorSettings, enabled: false },
@@ -166,7 +195,7 @@ export default function MediaSectionV2( {
 
 			toggleShowAiImageModal();
 		},
-		[ updateJetpackSocialOptions, imageGeneratorSettings, recordEvent, analyticsData ]
+		[ updateMediaOptions, imageGeneratorSettings, recordEvent, analyticsData ]
 	);
 
 	const renderMediaUpload = useCallback( ( { open }: { open: () => void } ) => {
@@ -177,7 +206,7 @@ export default function MediaSectionV2( {
 	// Handle remove - go to "no image" state
 	const handleRemove = useCallback( () => {
 		// Single batch update with explicit 'none' source
-		updateJetpackSocialOptions( {
+		updateMediaOptions( {
 			media_source: 'none',
 			attached_media: [],
 			image_generator_settings: { ...imageGeneratorSettings, enabled: false },
@@ -187,20 +216,14 @@ export default function MediaSectionV2( {
 			...analyticsData,
 			source: currentSource,
 		} );
-	}, [
-		updateJetpackSocialOptions,
-		imageGeneratorSettings,
-		recordEvent,
-		analyticsData,
-		currentSource,
-	] );
+	}, [ updateMediaOptions, imageGeneratorSettings, recordEvent, analyticsData, currentSource ] );
 
 	// Handle attachment toggle change
 	const handleAttachmentToggle = useCallback(
 		( checked: boolean ) => {
 			if ( currentSource === 'featured-image' && previewData ) {
 				// Featured image: toggle attachment mode
-				updateJetpackSocialOptions( {
+				updateMediaOptions( {
 					media_source: 'featured-image',
 					attached_media: checked
 						? [ { id: previewData.id, url: previewData.url, type: 'image/jpeg' } ]
@@ -208,7 +231,7 @@ export default function MediaSectionV2( {
 				} );
 			} else if ( currentSource === 'sig' && sigPreviewUrl ) {
 				// SIG: toggle attachment mode (add SIG URL to attached_media)
-				updateJetpackSocialOptions( {
+				updateMediaOptions( {
 					media_source: 'sig',
 					attached_media: checked ? [ { id: 0, url: sigPreviewUrl, type: 'image/jpeg' } ] : [],
 					// Keep SIG enabled regardless
@@ -230,7 +253,7 @@ export default function MediaSectionV2( {
 			currentSource,
 			previewData,
 			sigPreviewUrl,
-			updateJetpackSocialOptions,
+			updateMediaOptions,
 			imageGeneratorSettings,
 			recordEvent,
 			analyticsData,

--- a/projects/packages/publicize/_inc/components/media-section-v2/types.ts
+++ b/projects/packages/publicize/_inc/components/media-section-v2/types.ts
@@ -50,6 +50,42 @@ export interface MediaPreviewData {
 }
 
 /**
+ * Attached media item structure
+ */
+export interface AttachedMediaItem {
+	id: number;
+	url: string;
+	type: string;
+}
+
+/**
+ * Image generator settings structure
+ */
+export interface ImageGeneratorSettings {
+	enabled: boolean;
+	custom_text?: string;
+	image_type?: string;
+	image_id?: number;
+	template?: string;
+	token?: string;
+	default_image_id?: number;
+}
+
+/**
+ * Media source value type (including 'none' for explicit no-media state)
+ */
+export type MediaSourceValue = 'featured-image' | 'sig' | 'media-library' | 'upload-video' | 'none';
+
+/**
+ * Jetpack social options for media updates
+ */
+export interface MediaOptions {
+	attached_media?: Array< AttachedMediaItem >;
+	image_generator_settings?: ImageGeneratorSettings;
+	media_source?: MediaSourceValue;
+}
+
+/**
  * Props for MediaSectionV2 component
  */
 export interface MediaSectionV2Props {
@@ -67,6 +103,28 @@ export interface MediaSectionV2Props {
 	 * Callback when the edit template action is triggered
 	 */
 	onEditTemplate?: VoidFunction;
+
+	/**
+	 * Optional attached media array. When provided along with `onMediaChange`,
+	 * the component uses these values instead of fetching from the store.
+	 */
+	attachedMedia?: Array< AttachedMediaItem >;
+
+	/**
+	 * Optional image generator settings. Used with per-connection customization.
+	 */
+	imageGeneratorSettings?: ImageGeneratorSettings;
+
+	/**
+	 * Optional media source value.
+	 */
+	mediaSource?: MediaSourceValue;
+
+	/**
+	 * Optional callback to update media-related options.
+	 * When provided, the component operates in "controlled" mode.
+	 */
+	onMediaChange?: ( updates: Partial< MediaOptions > ) => void;
 }
 
 /**

--- a/projects/packages/publicize/_inc/components/media-section-v2/types.ts
+++ b/projects/packages/publicize/_inc/components/media-section-v2/types.ts
@@ -2,6 +2,8 @@
  * Types for the unified media section component
  */
 
+import type { AttachedMedia, JetpackSocialOptions, SIGSettings } from '../../utils/types';
+
 /**
  * Media source types
  */
@@ -50,42 +52,6 @@ export interface MediaPreviewData {
 }
 
 /**
- * Attached media item structure
- */
-export interface AttachedMediaItem {
-	id: number;
-	url: string;
-	type: string;
-}
-
-/**
- * Image generator settings structure
- */
-export interface ImageGeneratorSettings {
-	enabled: boolean;
-	custom_text?: string;
-	image_type?: string;
-	image_id?: number;
-	template?: string;
-	token?: string;
-	default_image_id?: number;
-}
-
-/**
- * Media source value type (including 'none' for explicit no-media state)
- */
-export type MediaSourceValue = 'featured-image' | 'sig' | 'media-library' | 'upload-video' | 'none';
-
-/**
- * Jetpack social options for media updates
- */
-export interface MediaOptions {
-	attached_media?: Array< AttachedMediaItem >;
-	image_generator_settings?: ImageGeneratorSettings;
-	media_source?: MediaSourceValue;
-}
-
-/**
  * Props for MediaSectionV2 component
  */
 export interface MediaSectionV2Props {
@@ -108,23 +74,23 @@ export interface MediaSectionV2Props {
 	 * Optional attached media array. When provided along with `onMediaChange`,
 	 * the component uses these values instead of fetching from the store.
 	 */
-	attachedMedia?: Array< AttachedMediaItem >;
+	attachedMedia?: Array< AttachedMedia >;
 
 	/**
 	 * Optional image generator settings. Used with per-connection customization.
 	 */
-	imageGeneratorSettings?: ImageGeneratorSettings;
+	imageGeneratorSettings?: SIGSettings;
 
 	/**
 	 * Optional media source value.
 	 */
-	mediaSource?: MediaSourceValue;
+	mediaSource?: JetpackSocialOptions[ 'media_source' ];
 
 	/**
 	 * Optional callback to update media-related options.
 	 * When provided, the component operates in "controlled" mode.
 	 */
-	onMediaChange?: ( updates: Partial< MediaOptions > ) => void;
+	onMediaChange?: ( updates: Partial< JetpackSocialOptions > ) => void;
 }
 
 /**

--- a/projects/packages/publicize/_inc/components/media-section-v2/types.ts
+++ b/projects/packages/publicize/_inc/components/media-section-v2/types.ts
@@ -71,24 +71,26 @@ export interface MediaSectionV2Props {
 	onEditTemplate?: VoidFunction;
 
 	/**
-	 * Optional attached media array. When provided along with `onMediaChange`,
-	 * the component uses these values instead of fetching from the store.
+	 * Optional attached media array. In controlled mode (when `onMediaChange` is provided),
+	 * this value is used instead of fetching from the store. Falls back to empty array if not provided.
 	 */
 	attachedMedia?: Array< AttachedMedia >;
 
 	/**
-	 * Optional image generator settings. Used with per-connection customization.
+	 * Optional image generator settings. In controlled mode, this value is used instead of
+	 * fetching from the store. Falls back to `{ enabled: false }` if not provided.
 	 */
 	imageGeneratorSettings?: SIGSettings;
 
 	/**
-	 * Optional media source value.
+	 * Optional media source value. In controlled mode, this value is used instead of
+	 * fetching from the store. Falls back to store value if not provided.
 	 */
 	mediaSource?: JetpackSocialOptions[ 'media_source' ];
 
 	/**
-	 * Optional callback to update media-related options.
-	 * When provided, the component operates in "controlled" mode.
+	 * Optional callback to update media-related options. When provided, the component
+	 * operates in "controlled" mode and uses the media props above instead of fetching from the store.
 	 */
 	onMediaChange?: ( updates: Partial< JetpackSocialOptions > ) => void;
 }

--- a/projects/packages/publicize/_inc/components/media-section/index.js
+++ b/projects/packages/publicize/_inc/components/media-section/index.js
@@ -1,7 +1,7 @@
 import { ThemeProvider, getRedirectUrl } from '@automattic/jetpack-components';
 import { useAnalytics } from '@automattic/jetpack-shared-extension-utils';
 import { Disabled, ExternalLink, Notice, BaseControl } from '@wordpress/components';
-import { useCallback } from '@wordpress/element';
+import { useCallback, useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Fragment } from 'react';
 import useAttachedMedia from '../../hooks/use-attached-media';
@@ -18,6 +18,8 @@ const ADD_MEDIA_LABEL = __( 'Choose Media', 'jetpack-publicize-pkg' );
  * @param {string}                    [props.disabledNoticeMessage=''] - An optional notice that's displayed when the section is disabled.
  * @param {import('react').ReactNode} [props.CustomNotice=null]        - An optional custom notice that's displayed.
  * @param {object}                    [props.analyticsData]            - Data for tracking analytics.
+ * @param {Array}                     [props.attachedMedia]            - Optional attached media array for controlled mode.
+ * @param {Function}                  [props.onMediaChange]            - Optional callback to update media options in controlled mode.
  * @return {object} The media section.
  */
 export default function MediaSection( {
@@ -25,9 +27,25 @@ export default function MediaSection( {
 	disabledNoticeMessage = '',
 	CustomNotice = null,
 	analyticsData,
+	attachedMedia: attachedMediaProp,
+	onMediaChange,
 } ) {
-	const { attachedMedia, updateAttachedMedia } = useAttachedMedia();
+	const { attachedMedia: storeAttachedMedia, updateAttachedMedia: storeUpdateAttachedMedia } =
+		useAttachedMedia();
 	const { recordEvent } = useAnalytics();
+
+	// Check if we're in "controlled" mode (props provided)
+	const isControlled = onMediaChange !== undefined;
+
+	// Use props if in controlled mode, otherwise fall back to store values
+	const attachedMedia = isControlled ? attachedMediaProp ?? [] : storeAttachedMedia;
+
+	// Unified update function that uses props callback or store
+	const updateAttachedMedia = useMemo(
+		() =>
+			isControlled ? media => onMediaChange( { attached_media: media } ) : storeUpdateAttachedMedia,
+		[ isControlled, onMediaChange, storeUpdateAttachedMedia ]
+	);
 
 	const [ mediaDetails ] = useMediaDetails( attachedMedia[ 0 ]?.id );
 

--- a/projects/packages/publicize/changelog/SOCIAL-312
+++ b/projects/packages/publicize/changelog/SOCIAL-312
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Decouple SharePostForm component from the store by adding optional props for controlled mode.


### PR DESCRIPTION
Fixes SOCIAL-312

## Proposed changes:
* Add optional props to `SharePostForm` component (`message`, `onMessageChange`, `attachedMedia`, `imageGeneratorSettings`, `mediaSource`, `onMediaChange`)
* Update `MediaSection` and `MediaSectionV2` to accept optional props for controlled mode
* When props are provided, components use them instead of reading from the store
* When props are not provided, components fall back to store values (backward compatible)
* Export `SharePostFormProps` type for consumers

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
N/A - This is a refactoring task to enable future per-connection customization.

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

* Open WordPress editor with Jetpack Social enabled
* Verify the SharePostForm works in the editor sidebar (message editing, media selection)
* Verify the SharePostForm works in the social post modal
* Existing functionality should work exactly as before (no regressions)