### PR TITLE
Launchpad: Remove 'Give your site a name' step and reorder tasks (DOTOBRD-385)

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/dotobrd-385-hide-most-info-on-my-home-if-launch-pad-not-complete
+++ b/projects/packages/jetpack-mu-wpcom/changelog/dotobrd-385-hide-most-info-on-my-home-if-launch-pad-not-complete
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Launchpad: Remove "Give your site a name" step and reorder tasks. The "Edit your design" step now appears before "Write your first post" in the Launchpad task list.

--- a/projects/packages/jetpack-mu-wpcom/changelog/dotobrd-385-hide-most-info-on-my-home-if-launch-pad-not-complete
+++ b/projects/packages/jetpack-mu-wpcom/changelog/dotobrd-385-hide-most-info-on-my-home-if-launch-pad-not-complete
@@ -1,4 +1,4 @@
 Significance: minor
 Type: changed
 
-Launchpad: Remove "Give your site a name" step and reorder tasks. The "Edit your design" step now appears before "Write your first post" in the Launchpad task list.
+Launchpad: Reorder build checklist tasks

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -37,9 +37,8 @@ function wpcom_launchpad_get_task_list_definitions() {
 			},
 			'task_ids'            => array(
 				'plan_selected',
-				'setup_general',
-				'first_post_published',
 				'design_edited',
+				'first_post_published',
 				'site_launched',
 			),
 			'is_enabled_callback' => 'wpcom_launchpad_get_fullscreen_enabled',

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -37,8 +37,9 @@ function wpcom_launchpad_get_task_list_definitions() {
 			},
 			'task_ids'            => array(
 				'plan_selected',
+				'domain_upsell',
 				'design_edited',
-				'first_post_published',
+				'mobile_app_installed',
 				'site_launched',
 			),
 			'is_enabled_callback' => 'wpcom_launchpad_get_fullscreen_enabled',


### PR DESCRIPTION
## Summary

This PR implements part of the changes for DOTOBRD-385.

## Changes

- Removed the 'setup_general' task ("Give your site a name" step) from the Launchpad task list
- Reordered tasks: 'design_edited' now appears before 'first_post_published'

This reduces the Launchpad from 5 steps to 4 steps and simplifies the onboarding flow by removing the confusing Settings screen step.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

- [ ] Verify Launchpad shows 4 tasks in the correct order
- [ ] Verify 'setup_general' task is no longer present
- [ ] Verify 'design_edited' appears before 'first_post_published'