### PR TITLE
Harden request input handling for user deletion in connection notice

### DIFF
--- a/projects/packages/connection/changelog/harden-request-input-validation
+++ b/projects/packages/connection/changelog/harden-request-input-validation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Harden request input handling to prevent PHP warnings when malformed input is received during user deletion flows.

--- a/projects/packages/connection/src/class-connection-notice.php
+++ b/projects/packages/connection/src/class-connection-notice.php
@@ -81,12 +81,19 @@ class Connection_Notice {
 		$connection_owner_userdata = get_userdata( $connection_owner_id );
 
 		// Bail if we're not trying to delete connection owner.
-		$user_ids_to_delete = array();
-		if ( isset( $_REQUEST['users'] ) ) {
-			$user_ids_to_delete = array_map( 'sanitize_text_field', wp_unslash( $_REQUEST['users'] ) );
-		} elseif ( isset( $_REQUEST['user'] ) ) {
-			$user_ids_to_delete[] = sanitize_text_field( wp_unslash( $_REQUEST['user'] ) );
-		}
+		// Bail if we're not trying to delete connection owner.
+$user_ids_to_delete = array();
+
+if ( isset( $_REQUEST['users'] ) ) {
+    $raw_users = wp_unslash( $_REQUEST['users'] );
+
+    if ( is_array( $raw_users ) ) {
+        $user_ids_to_delete = array_map( 'sanitize_text_field', $raw_users );
+    }
+} elseif ( isset( $_REQUEST['user'] ) ) {
+    $user_ids_to_delete[] = sanitize_text_field( wp_unslash( $_REQUEST['user'] ) );
+}
+
 
 		// phpcs:enable
 		$user_ids_to_delete        = array_map( 'absint', $user_ids_to_delete );

--- a/projects/packages/connection/src/class-connection-notice.php
+++ b/projects/packages/connection/src/class-connection-notice.php
@@ -84,7 +84,8 @@ class Connection_Notice {
 		// Bail if we're not trying to delete connection owner.
 $user_ids_to_delete = array();
 
-if ( isset( $_REQUEST['users'] ) ) {
+if ( isset( $_REQUEST['users'] ) && is_array( $_REQUEST['users'] ) ) {
+
     $raw_users = wp_unslash( $_REQUEST['users'] );
 
     if ( is_array( $raw_users ) ) {


### PR DESCRIPTION
## Description
This change hardens request input handling for user deletion actions in the Jetpack Connection package by validating incoming request data before processing.
## Does this pull request change what data or activity we track or use?
No. This PR does not add, remove, or modify any data collection, tracking, or privacy-related behavior.


This helps prevent PHP warnings/notices when malformed or unexpected input is received.

## Testing instructions
1. Set up a local Jetpack development environment.
2. Trigger the connection notice flow for user deletion.
3. Pass malformed or non-scalar values to the request parameters.
4. Confirm no PHP warnings/notices occur and valid behavior remains unchanged.

## Does this PR change data or privacy?
No. This PR does not modify stored data or affect user privacy.

## Screenshots
N/A
