### PR TITLE
Jetpack CLI: Release v1.1.0

### DIFF
--- a/projects/js-packages/jetpack-cli/CHANGELOG.md
+++ b/projects/js-packages/jetpack-cli/CHANGELOG.md
@@ -5,9 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 1.0.3 - 2026-01-12
+## 1.1.0 - 2026-01-12
+### Added
+- Add jp init-hooks and jp git-hook commands to run git hooks in Docker container.
+
 ### Changed
-- Internal updates.
+- Display alpha version number when running from monorepo source to indicate development build.
 
 ## 1.0.2 - 2025-09-08
 ### Changed

--- a/projects/js-packages/jetpack-cli/CHANGELOG.md
+++ b/projects/js-packages/jetpack-cli/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Display alpha version number when running from monorepo source to indicate development build.
 
+## 1.0.3 - 2026-01-12
+### Changed
+- Internal updates.
+
 ## 1.0.2 - 2025-09-08
 ### Changed
 - Internal updates.

--- a/projects/js-packages/jetpack-cli/changelog/add-dev-version-display
+++ b/projects/js-packages/jetpack-cli/changelog/add-dev-version-display
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Display alpha version number when running from monorepo source to indicate development build.

--- a/projects/js-packages/jetpack-cli/changelog/update-jetpack-cli-git-hooks
+++ b/projects/js-packages/jetpack-cli/changelog/update-jetpack-cli-git-hooks
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Add jp init-hooks and jp git-hook commands to run git hooks in Docker container.

--- a/projects/js-packages/jetpack-cli/package.json
+++ b/projects/js-packages/jetpack-cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-cli",
-	"version": "1.0.3",
+	"version": "1.1.0",
 	"description": "Docker-based CLI for Jetpack development",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/jetpack-cli/#readme",
 	"bugs": {


### PR DESCRIPTION
## Proposed changes:

Release version 1.1.0 of the Jetpack CLI (`@automattic/jetpack-cli`) npm package.

### Changes in this release:
- **Added**: `jp init-hooks` and `jp git-hook` commands to run git hooks in Docker container
- **Changed**: Display alpha version number when running from monorepo source to indicate development build

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- N/A - Have you tested your changes on WordPress.com, if applicable?

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

This is a release PR that compiles the changelog and bumps the version. The functionality was already merged in #46462.

1. Verify the version in `package.json` is `1.1.0`
2. Verify the CHANGELOG.md includes the 1.1.0 release notes
3. Once merged, the automation will publish to npm