### PR TITLE
Forms: fix dashboard routing on wpcom

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-routing-on-wpcom
+++ b/projects/packages/forms/changelog/fix-forms-routing-on-wpcom
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: fix dashboard routing on wpcom.

--- a/projects/packages/forms/src/dashboard/index.tsx
+++ b/projects/packages/forms/src/dashboard/index.tsx
@@ -38,12 +38,11 @@ function initFormsDashboard() {
 		const isCentralFormManagementEnabled = useConfigValue( 'isCentralFormManagementEnabled' );
 
 		useEffect( () => {
-			if ( isCentralFormManagementEnabled === undefined ) {
-				return;
-			}
-
 			// Default landing when no hash/route is set.
-			navigate( isCentralFormManagementEnabled ? '/forms' : '/responses', { replace: true } );
+			// Treat undefined (not yet loaded / not provided) as false so we never render a blank page.
+			navigate( isCentralFormManagementEnabled === true ? '/forms' : '/responses', {
+				replace: true,
+			} );
 		}, [ isCentralFormManagementEnabled, navigate ] );
 
 		return null;


### PR DESCRIPTION
## Proposed changes:

We just pushed a PR that adds tabs to the forms dashboard behind a feature flag. But I found in testing that the feature flag is sometimes undefined on WordPress.com. This adds a fix that defaults to our longstanding responses path if the feature flag is undefined. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Add this feature flag to your test site. 

```
add_filter( 'jetpack_block_editor_feature_flags', 'eb_register_feature' );
function eb_register_feature( $flags ) {
    $flags['central-form-management'] = true;
    return $flags;
}
```

Test new tabs: 
* Go to Jetpack > Forms
* Confirm new tabs are there and work
* Confirm Forms screen has a placeholder
* Confirm Responses screen shows responses list, and that you can filter by Inbox, Spam or Trash

Test for now regression:
* Remove feature flag and confirm everything works as before

