### PR TITLE
Admin: Add experimental modern sidebar navigation

### DIFF
--- a/projects/plugins/jetpack/_inc/client/components/sidebar-navigation/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/sidebar-navigation/index.jsx
@@ -1,0 +1,95 @@
+import { __ } from '@wordpress/i18n';
+import { useState, useMemo, useCallback } from 'react';
+import { getNavigationScreen, getParentScreenId } from './navigation-config';
+import SidebarNavigationItem from './navigation-item';
+import SidebarNavigationScreen from './navigation-screen';
+import './style.scss';
+
+/**
+ * SidebarNavigation component - modern app-like navigation for Jetpack.
+ *
+ * This component implements the navigation pattern proposed in the P2 post
+ * "Reimagining Jetpack Navigation", adopting patterns from modern WordPress
+ * admin experiences like the Site Editor.
+ *
+ * @param {object} props              - Component props.
+ * @param {string} props.currentRoute - The current hash route (e.g., '/dashboard').
+ * @return {Element|null} The sidebar navigation component.
+ */
+export default function SidebarNavigation( { currentRoute } ) {
+	const [ currentScreenId, setCurrentScreenId ] = useState( 'root' );
+
+	const currentScreen = useMemo(
+		() => getNavigationScreen( currentScreenId ),
+		[ currentScreenId ]
+	);
+
+	const handleDrilldown = useCallback( screenId => {
+		setCurrentScreenId( screenId );
+	}, [] );
+
+	const handleBack = useCallback( () => {
+		const parentId = getParentScreenId( currentScreenId );
+		if ( parentId ) {
+			setCurrentScreenId( parentId );
+		}
+	}, [ currentScreenId ] );
+
+	const isItemActive = useCallback(
+		item => {
+			if ( ! item.to ) {
+				return false;
+			}
+			return currentRoute === item.to || currentRoute.startsWith( item.to + '/' );
+		},
+		[ currentRoute ]
+	);
+
+	if ( ! currentScreen ) {
+		return null;
+	}
+
+	const isRoot = currentScreenId === 'root';
+
+	return (
+		<nav className="jp-sidebar-navigation" aria-label={ __( 'Jetpack Navigation', 'jetpack' ) }>
+			<div className="jp-sidebar-navigation__header">
+				<div className="jp-sidebar-navigation__logo">
+					<svg
+						width="32"
+						height="32"
+						viewBox="0 0 32 32"
+						fill="none"
+						xmlns="http://www.w3.org/2000/svg"
+					>
+						<path
+							d="M16 0C7.163 0 0 7.163 0 16s7.163 16 16 16 16-7.163 16-16S24.837 0 16 0zm0 2.133c7.659 0 13.867 6.208 13.867 13.867S23.659 29.867 16 29.867 2.133 23.659 2.133 16 8.341 2.133 16 2.133z"
+							fill="#069e08"
+						/>
+						<path d="M15.5 17.5v8.5l-8-12h8v-9l8 12.5h-8z" fill="#069e08" />
+					</svg>
+					<span className="jp-sidebar-navigation__title">{ __( 'Jetpack', 'jetpack' ) }</span>
+				</div>
+			</div>
+
+			<SidebarNavigationScreen
+				isRoot={ isRoot }
+				title={ currentScreen.title }
+				onBack={ handleBack }
+			>
+				{ currentScreen.items.map( item => (
+					<SidebarNavigationItem
+						key={ item.id }
+						id={ item.id }
+						icon={ item.icon }
+						label={ item.label }
+						to={ item.to }
+						isDrilldown={ item.isDrilldown }
+						onClick={ item.isDrilldown ? handleDrilldown : undefined }
+						isActive={ isItemActive( item ) }
+					/>
+				) ) }
+			</SidebarNavigationScreen>
+		</nav>
+	);
+}

--- a/projects/plugins/jetpack/_inc/client/components/sidebar-navigation/navigation-config.js
+++ b/projects/plugins/jetpack/_inc/client/components/sidebar-navigation/navigation-config.js
@@ -1,0 +1,200 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	backup,
+	shield,
+	search,
+	commentContent,
+	video,
+	trendingUp,
+	share,
+	postContent,
+	cog,
+	home,
+} from '@wordpress/icons';
+
+/**
+ * Navigation configuration for the modern Jetpack sidebar.
+ * Defines the product hierarchy as outlined in the P2 proposal.
+ */
+export const navigationConfig = {
+	root: {
+		id: 'root',
+		items: [
+			{
+				id: 'dashboard',
+				label: 'Dashboard',
+				icon: home,
+				to: '/dashboard',
+			},
+			{
+				id: 'security',
+				label: 'Security',
+				icon: shield,
+				isDrilldown: true,
+			},
+			{
+				id: 'performance',
+				label: 'Performance',
+				icon: trendingUp,
+				isDrilldown: true,
+			},
+			{
+				id: 'growth',
+				label: 'Growth',
+				icon: share,
+				isDrilldown: true,
+			},
+			{
+				id: 'content',
+				label: 'Content',
+				icon: postContent,
+				isDrilldown: true,
+			},
+			{
+				id: 'settings',
+				label: 'Settings',
+				icon: cog,
+				to: '/settings',
+			},
+		],
+	},
+	security: {
+		id: 'security',
+		title: 'Security',
+		parentId: 'root',
+		items: [
+			{
+				id: 'backup',
+				label: 'Backup',
+				icon: backup,
+				to: '/security', // Would link to backup-specific page
+			},
+			{
+				id: 'scan',
+				label: 'Scan',
+				icon: shield,
+				to: '/security',
+			},
+			{
+				id: 'protect',
+				label: 'Protect',
+				icon: shield,
+				to: '/security',
+			},
+		],
+	},
+	performance: {
+		id: 'performance',
+		title: 'Performance',
+		parentId: 'root',
+		items: [
+			{
+				id: 'boost',
+				label: 'Boost',
+				icon: trendingUp,
+				to: '/performance',
+			},
+			{
+				id: 'search',
+				label: 'Search',
+				icon: search,
+				to: '/performance',
+			},
+			{
+				id: 'videopress',
+				label: 'VideoPress',
+				icon: video,
+				to: '/performance',
+			},
+		],
+	},
+	growth: {
+		id: 'growth',
+		title: 'Growth',
+		parentId: 'root',
+		items: [
+			{
+				id: 'social',
+				label: 'Social',
+				icon: share,
+				to: '/sharing',
+			},
+			{
+				id: 'crm',
+				label: 'CRM',
+				icon: commentContent,
+				to: '/traffic',
+			},
+			{
+				id: 'stats',
+				label: 'Stats',
+				icon: trendingUp,
+				to: '/traffic',
+			},
+		],
+	},
+	content: {
+		id: 'content',
+		title: 'Content',
+		parentId: 'root',
+		items: [
+			{
+				id: 'forms',
+				label: 'Forms',
+				icon: postContent,
+				isDrilldown: true,
+			},
+			{
+				id: 'newsletter',
+				label: 'Newsletter',
+				icon: commentContent,
+				to: '/newsletter',
+			},
+		],
+	},
+	forms: {
+		id: 'forms',
+		title: 'Forms',
+		parentId: 'content',
+		items: [
+			{
+				id: 'forms-all',
+				label: 'All Forms',
+				to: '/writing', // Placeholder route
+			},
+			{
+				id: 'forms-responses',
+				label: 'Responses',
+				to: '/writing',
+			},
+			{
+				id: 'forms-integrations',
+				label: 'Integrations',
+				to: '/writing',
+			},
+		],
+	},
+};
+
+/**
+ * Get navigation items for a given screen.
+ *
+ * @param {string} screenId - The screen ID to get items for.
+ * @return {object|null} The screen configuration or null if not found.
+ */
+export function getNavigationScreen( screenId ) {
+	return navigationConfig[ screenId ] || null;
+}
+
+/**
+ * Get the parent screen ID for a given screen.
+ *
+ * @param {string} screenId - The screen ID.
+ * @return {string|null} The parent screen ID or null if root.
+ */
+export function getParentScreenId( screenId ) {
+	const screen = navigationConfig[ screenId ];
+	return screen?.parentId || null;
+}

--- a/projects/plugins/jetpack/_inc/client/components/sidebar-navigation/navigation-item.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/sidebar-navigation/navigation-item.jsx
@@ -1,0 +1,66 @@
+import { Icon, chevronRight } from '@wordpress/icons';
+import clsx from 'clsx';
+import { useCallback } from 'react';
+import './style.scss';
+
+/**
+ * SidebarNavigationItem component - a single navigation link or drilldown trigger.
+ *
+ * @param {object}   props             - Component props.
+ * @param {string}   props.id          - Unique identifier.
+ * @param {Element}  props.icon        - Icon to display.
+ * @param {string}   props.label       - Text label.
+ * @param {string}   props.to          - Hash route to navigate to.
+ * @param {boolean}  props.isDrilldown - Whether this triggers a drilldown.
+ * @param {Function} props.onClick     - Click handler.
+ * @param {boolean}  props.isActive    - Whether this item is currently active.
+ * @param {string}   props.className   - Additional CSS classes.
+ * @return {Element} The navigation item component.
+ */
+export default function SidebarNavigationItem( {
+	id,
+	icon,
+	label,
+	to,
+	isDrilldown = false,
+	onClick,
+	isActive = false,
+	className,
+} ) {
+	const handleClick = useCallback(
+		e => {
+			if ( isDrilldown && onClick ) {
+				e.preventDefault();
+				onClick( id );
+			} else if ( to ) {
+				window.location.hash = to;
+			}
+		},
+		[ id, isDrilldown, onClick, to ]
+	);
+
+	return (
+		<button
+			type="button"
+			className={ clsx( 'jp-sidebar-navigation-item', className, {
+				'is-active': isActive,
+				'is-drilldown': isDrilldown,
+			} ) }
+			onClick={ handleClick }
+		>
+			<span className="jp-sidebar-navigation-item__content">
+				{ icon && (
+					<span className="jp-sidebar-navigation-item__icon">
+						<Icon icon={ icon } size={ 24 } />
+					</span>
+				) }
+				<span className="jp-sidebar-navigation-item__label">{ label }</span>
+				{ isDrilldown && (
+					<span className="jp-sidebar-navigation-item__chevron">
+						<Icon icon={ chevronRight } size={ 24 } />
+					</span>
+				) }
+			</span>
+		</button>
+	);
+}

--- a/projects/plugins/jetpack/_inc/client/components/sidebar-navigation/navigation-screen.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/sidebar-navigation/navigation-screen.jsx
@@ -1,0 +1,33 @@
+import { Button } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { Icon, chevronLeft } from '@wordpress/icons';
+import './style.scss';
+
+/**
+ * SidebarNavigationScreen component - a screen within the sidebar with optional back navigation.
+ *
+ * @param {object}   props          - Component props.
+ * @param {boolean}  props.isRoot   - Whether this is the root screen (no back button).
+ * @param {string}   props.title    - Screen title.
+ * @param {Element}  props.children - Screen content (navigation items).
+ * @param {Function} props.onBack   - Callback when back button is clicked.
+ * @return {Element} The navigation screen component.
+ */
+export default function SidebarNavigationScreen( { isRoot = true, title, children, onBack } ) {
+	return (
+		<div className="jp-sidebar-navigation-screen">
+			{ ! isRoot && (
+				<div className="jp-sidebar-navigation-screen__header">
+					<Button
+						className="jp-sidebar-navigation-screen__back"
+						onClick={ onBack }
+						icon={ <Icon icon={ chevronLeft } size={ 24 } /> }
+						label={ __( 'Back', 'jetpack' ) }
+					/>
+					{ title && <h2 className="jp-sidebar-navigation-screen__title">{ title }</h2> }
+				</div>
+			) }
+			<div className="jp-sidebar-navigation-screen__content">{ children }</div>
+		</div>
+	);
+}

--- a/projects/plugins/jetpack/_inc/client/components/sidebar-navigation/style.scss
+++ b/projects/plugins/jetpack/_inc/client/components/sidebar-navigation/style.scss
@@ -1,0 +1,220 @@
+/**
+ * Sidebar Navigation Styles
+ *
+ * Modern app-like navigation for Jetpack, inspired by
+ * Gutenberg Site Editor patterns.
+ */
+
+.jp-sidebar-navigation {
+	display: flex;
+	flex-direction: column;
+	width: 280px;
+	min-width: 280px;
+	height: 100vh;
+	background: #1e1e1e;
+	color: #fff;
+	overflow-y: auto;
+	position: fixed;
+	left: 0;
+	top: 0;
+	z-index: 100000;
+
+	@media (max-width: 782px) {
+		width: 100%;
+		min-width: 100%;
+		height: auto;
+		position: relative;
+	}
+}
+
+.jp-sidebar-navigation__header {
+	padding: 16px;
+	border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.jp-sidebar-navigation__logo {
+	display: flex;
+	align-items: center;
+	gap: 12px;
+
+	svg {
+		width: 32px;
+		height: 32px;
+	}
+}
+
+.jp-sidebar-navigation__title {
+	font-size: 16px;
+	font-weight: 600;
+	color: #fff;
+}
+
+// Navigation Screen
+.jp-sidebar-navigation-screen {
+	flex: 1;
+	display: flex;
+	flex-direction: column;
+}
+
+.jp-sidebar-navigation-screen__header {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	padding: 12px 16px;
+	border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.jp-sidebar-navigation-screen__back {
+	color: #fff !important;
+	padding: 4px !important;
+	min-width: auto !important;
+
+	&:hover {
+		color: rgba(255, 255, 255, 0.8) !important;
+	}
+
+	svg {
+		fill: currentColor;
+	}
+}
+
+.jp-sidebar-navigation-screen__title {
+	font-size: 14px;
+	font-weight: 600;
+	color: #fff;
+	margin: 0;
+}
+
+.jp-sidebar-navigation-screen__content {
+	padding: 8px;
+	display: flex;
+	flex-direction: column;
+	gap: 2px;
+}
+
+// Navigation Item
+.jp-sidebar-navigation-item {
+	display: flex;
+	align-items: center;
+	padding: 10px 12px !important;
+	border-radius: 4px;
+	color: rgba(255, 255, 255, 0.85);
+	cursor: pointer;
+	transition: background-color 0.15s ease, color 0.15s ease;
+	background: transparent;
+	border: none;
+	width: 100%;
+	text-align: left;
+
+	&:hover {
+		background: rgba(255, 255, 255, 0.1);
+		color: #fff;
+	}
+
+	&:focus {
+		outline: 2px solid #007cba;
+		outline-offset: -2px;
+	}
+
+	&.is-active {
+		background: rgba(255, 255, 255, 0.15);
+		color: #fff;
+
+		&::before {
+			content: "";
+			position: absolute;
+			left: 0;
+			top: 50%;
+			transform: translateY(-50%);
+			width: 3px;
+			height: 24px;
+			background: #069e08;
+			border-radius: 0 2px 2px 0;
+		}
+	}
+
+	&.is-drilldown {
+
+		.jp-sidebar-navigation-item__chevron {
+			margin-left: auto;
+			opacity: 0.6;
+		}
+	}
+}
+
+.jp-sidebar-navigation-item__content {
+	display: flex;
+	align-items: center;
+	gap: 12px;
+	width: 100%;
+}
+
+.jp-sidebar-navigation-item__icon {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 24px;
+	height: 24px;
+	opacity: 0.8;
+
+	svg {
+		fill: currentColor;
+	}
+}
+
+.jp-sidebar-navigation-item__label {
+	font-size: 14px;
+	font-weight: 400;
+	flex: 1;
+}
+
+.jp-sidebar-navigation-item__chevron {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+
+	svg {
+		fill: currentColor;
+	}
+}
+
+// Layout wrapper when sidebar is enabled
+.jp-admin-layout {
+	display: flex;
+	min-height: 100vh;
+
+	@media (max-width: 782px) {
+		flex-direction: column;
+	}
+}
+
+.jp-admin-layout__content {
+	flex: 1;
+	margin-left: 280px;
+	padding: 0;
+
+	@media (max-width: 782px) {
+		margin-left: 0;
+	}
+}
+
+// Hide the WordPress admin menu when sidebar is active
+body.jp-sidebar-navigation-active {
+
+	#adminmenumain {
+		display: none;
+	}
+
+	#wpcontent {
+		margin-left: 0;
+		padding-left: 0;
+	}
+
+	.jp-admin-layout__content {
+		margin-left: 280px;
+
+		@media (max-width: 782px) {
+			margin-left: 0;
+		}
+	}
+}

--- a/projects/plugins/jetpack/_inc/client/main.jsx
+++ b/projects/plugins/jetpack/_inc/client/main.jsx
@@ -88,6 +88,18 @@ import {
 	fetchSitePurchases as fetchSitePurchasesAction,
 } from 'state/site';
 import JetpackManageBanner from './components/jetpack-manage-banner';
+import SidebarNavigation from './components/sidebar-navigation';
+
+/**
+ * Feature flag for the modern sidebar navigation.
+ * Enable by adding ?sidebar=1 to the URL.
+ *
+ * @return {boolean} Whether the modern sidebar is enabled.
+ */
+const isModernSidebarEnabled = () => {
+	const urlParams = new URLSearchParams( window.location.search );
+	return urlParams.get( 'sidebar' ) === '1';
+};
 
 const recommendationsRoutes = [
 	'/recommendations',
@@ -818,6 +830,7 @@ class Main extends Component {
 
 	render() {
 		const jpClasses = [ 'jp-lower' ];
+		const useModernSidebar = isModernSidebarEnabled();
 
 		if ( this.isMainConnectScreen() ) {
 			jpClasses.push( 'jp-main-connect-screen' );
@@ -833,6 +846,46 @@ class Main extends Component {
 
 		const mainNav = this.renderMainNav( this.props.location.pathname );
 		const showHeader = mainNav || this.shouldShowMasthead() || this.shouldShowRewindStatus();
+
+		// Modern sidebar layout
+		if ( useModernSidebar ) {
+			// Add class to body for CSS adjustments
+			document.body.classList.add( 'jp-sidebar-navigation-active' );
+
+			return (
+				<div className="jp-admin-layout">
+					<SidebarNavigation currentRoute={ this.props.location.pathname } />
+					<div className="jp-admin-layout__content">
+						{ this.shouldShowReconnectModal() && (
+							<ReconnectModal show={ true } onHide={ this.closeReconnectModal } />
+						) }
+
+						<div className={ jpClasses.join( ' ' ) }>
+							<AdminNotices />
+							<JetpackNotices />
+							{ this.shouldConnectUser() && this.connectUser() }
+
+							{ this.renderMainContent( this.props.location.pathname ) }
+							{ this.shouldShowJetpackManageBanner() && (
+								<JetpackManageBanner
+									path={ this.props.location.pathname }
+									isAgencyAccount={ this.props.jetpackManage.isAgencyAccount }
+								/>
+							) }
+							{ this.shouldShowSupportCard() && (
+								<SupportCard path={ this.props.location.pathname } />
+							) }
+							{ this.shouldShowAppsCard() && <AppsCard /> }
+						</div>
+						{ this.shouldShowFooter() && <Footer siteAdminUrl={ this.props.siteAdminUrl } /> }
+						<Tracker analytics={ analytics } />
+					</div>
+				</div>
+			);
+		}
+
+		// Remove class if switching back to classic layout
+		document.body.classList.remove( 'jp-sidebar-navigation-active' );
 
 		return (
 			<div>

--- a/projects/plugins/jetpack/changelog/add-modern-sidebar-navigation
+++ b/projects/plugins/jetpack/changelog/add-modern-sidebar-navigation
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Admin: Add experimental modern sidebar navigation (enable with ?sidebar=1 URL parameter).


### PR DESCRIPTION
## Summary

Implements a new app-like sidebar navigation for Jetpack, inspired by Gutenberg Site Editor patterns. This is an initial prototype to explore the navigation concepts discussed in the "Reimagining Jetpack Navigation" proposal.

**Features:**
- Drilldown navigation for product sections (Security, Performance, Growth, Content)
- Nested navigation for Forms (All Forms, Responses, Integrations)
- Dark theme matching modern admin patterns
- Feature flagged via `?sidebar=1` URL parameter

## Test Instructions

1. Create a test site or use Jurassic Ninja: https://jurassic.ninja/create?jetpack-beta&branch=add/modern-sidebar-navigation
2. Navigate to: `wp-admin/admin.php?page=jetpack&sidebar=1`
3. Verify the new sidebar appears on the left
4. Click "Security", "Performance", "Growth", or "Content" to drill into sections
5. Navigate to Content → Forms to see nested drilldown
6. Click the back button to return to parent screens
7. Verify navigation links work (Dashboard, Settings)

## Screenshots

<!-- Add screenshots after testing -->

## Checklist

- [x] Feature flagged (disabled by default)
- [x] No new dependencies added
- [x] Uses existing `@wordpress/components` and `@wordpress/icons`
- [x] Follows existing Jetpack code patterns

---

🤖 Generated with [Claude Code](https://claude.ai/code)