### PR TITLE
MU WPCOM: Update Help Center menu panel experiment name

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/DOTCOM-15670-new-experiment
+++ b/projects/packages/jetpack-mu-wpcom/changelog/DOTCOM-15670-new-experiment
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update Help Center menu panel experiment name

--- a/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-help-center.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-help-center.php
@@ -332,7 +332,7 @@ class Help_Center {
 	 * @return boolean True if the menu panel experiment variation is enabled, false otherwise.
 	 */
 	private function is_menu_panel_enabled() {
-		$experiment_name      = 'calypso_help_center_menu_popover_v2';
+		$experiment_name      = 'calypso_help_center_menu_popover_increase_exposure';
 		$experiment_variation = 'menu_popover';
 		$user_id              = get_current_user_id();
 		$cache_key            = 'help-center-menu-panel-enabled-' . $user_id . '-' . $experiment_name;


### PR DESCRIPTION
## Summary
- Updates the experiment name for the Help Center menu popover from `calypso_help_center_menu_popover_v2` to `calypso_help_center_menu_popover_increase_exposure`

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Verify the new experiment name is used when checking if the menu panel is enabled

