### PR TITLE
Forms: Update read/unread status column style to match old dashboard

### DIFF
--- a/projects/packages/forms/changelog/update-forms-wp-build-status-badge
+++ b/projects/packages/forms/changelog/update-forms-wp-build-status-badge
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Update read/unread status column style to match old dashboard.

--- a/projects/packages/forms/routes/responses/stage.tsx
+++ b/projects/packages/forms/routes/responses/stage.tsx
@@ -374,8 +374,13 @@ function Stage() {
 				],
 				filterBy: { operators: [ 'is' ] },
 				enableSorting: false,
-				render: ( { item } ) =>
-					item.is_unread ? __( 'Unread', 'jetpack-forms' ) : __( 'Read', 'jetpack-forms' ),
+				render: ( { item } ) => {
+					return (
+						<Badge intent="default">
+							{ item.is_unread ? __( 'Unread', 'jetpack-forms' ) : __( 'Read', 'jetpack-forms' ) }
+						</Badge>
+					);
+				},
 			},
 			{
 				id: 'ip',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Part of FORMS-442

Originally done in https://github.com/Automattic/jetpack/pull/45931 for old dash.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Match status with old dashboard styles by using Badge component.
* Here we use `@automattic/ui` Badge with idea to switch later to [`Badge`](https://github.com/WordPress/gutenberg/tree/b7969eca697b328abfa6de2b1aa37f3841d21404/packages/ui/src/badge) from `@wordpress/ui`.

Old dash (active/hover/resting row):

<img width="379" height="246" alt="Screenshot 2026-01-13 at 15 30 23" src="https://github.com/user-attachments/assets/a6efa4f5-a8c8-4db1-bbc6-b603f60614c9" />

New dash before:

<img width="167" height="138" alt="Screenshot 2026-01-13 at 15 15 03" src="https://github.com/user-attachments/assets/98f9976e-8b6f-4a72-9d13-e18d506dd59a" />

New dash now:

<img width="161" height="162" alt="image" src="https://github.com/user-attachments/assets/6d1618f6-4738-4419-a7e9-ecb0269bac58" />

Note that visually there's no much difference yet but switching to WP component later should help.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Enable new dash `add_filter('jetpack_forms_alpha', '__return_true');`
* Build dash with `cd projects/packages/forms && pnpm run build:wp-build`
* Enable column via cog
    <img width="397" height="524" alt="Screenshot 2026-01-13 at 15 15 35" src="https://github.com/user-attachments/assets/71ac2012-1751-4982-8257-79e933a3b4b2" />
* See badge