### PR TITLE
IDC: revalidation respects safe mode

### DIFF
--- a/projects/packages/connection/changelog/update-idc-revalidate-safe-mode
+++ b/projects/packages/connection/changelog/update-idc-revalidate-safe-mode
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Minor update
+
+

--- a/projects/packages/connection/src/identity-crisis/class-identity-crisis.php
+++ b/projects/packages/connection/src/identity-crisis/class-identity-crisis.php
@@ -473,6 +473,12 @@ class Identity_Crisis {
 	 * @return bool True if validation should be performed, false otherwise.
 	 */
 	public static function should_remote_validate_idc( $sync_error ) {
+		// Respect the user's decision to stay in safe mode.
+		// If safe mode is confirmed, don't attempt validation.
+		if ( self::safe_mode_is_confirmed() ) {
+			return false;
+		}
+
 		// If a validation is already in progress or recently completed, don't trigger another.
 		if ( get_transient( 'jetpack_idc_validation_lock' ) ) {
 			return false;

--- a/projects/packages/connection/tests/php/identity-crisis/Identity_Crisis_Test.php
+++ b/projects/packages/connection/tests/php/identity-crisis/Identity_Crisis_Test.php
@@ -1279,6 +1279,27 @@ class Identity_Crisis_Test extends BaseTestCase {
 	}
 
 	/**
+	 * Test should_remote_validate_idc() returns false when safe mode is confirmed.
+	 */
+	public function test_should_remote_validate_idc_returns_false_when_safe_mode_confirmed() {
+		// Set up safe mode as confirmed.
+		Jetpack_Options::update_option( 'safe_mode_confirmed', true );
+
+		$sync_error = array(
+			'last_checked'     => time() - 7200, // 2 hours ago.
+			'next_check_delay' => 3600, // 1 hour delay - validation would normally occur.
+		);
+
+		$result = Identity_Crisis::should_remote_validate_idc( $sync_error );
+
+		// Clean up.
+		Jetpack_Options::delete_option( 'safe_mode_confirmed' );
+
+		// Should return false because safe mode is confirmed, even though enough time has passed.
+		$this->assertFalse( $result );
+	}
+
+	/**
 	 * Test remote_validate_idc() clears IDC when site is not registered.
 	 */
 	public function test_remote_validate_idc_clears_idc_when_not_registered() {


### PR DESCRIPTION
The re-validation of IDC code should respect the confirmed Safe Mode state and not send out any requests if the user decided to stay in Safe Mode.

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related CONNECT-139

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add check for confirmed safe mode.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

