### PR TITLE
Docker: mark /workspace as git safe directory

### DIFF
--- a/tools/docker/Dockerfile.monorepo
+++ b/tools/docker/Dockerfile.monorepo
@@ -89,6 +89,6 @@ RUN locale-gen en_US.UTF-8 \
 
 # Mark /workspace as a safe directory for git to avoid "dubious ownership" warnings
 # when the monorepo is mounted from the host with different ownership.
-RUN git config --global --add safe.directory /workspace
+RUN git config --system --add safe.directory /workspace
 
 CMD ["bash"]

--- a/tools/docker/Dockerfile.monorepo
+++ b/tools/docker/Dockerfile.monorepo
@@ -87,4 +87,8 @@ RUN locale-gen en_US.UTF-8 \
     && find /var/ -name '*-old' -delete \
     && rm -rf /var/log/dpkg.log /var/log/alternatives.log /var/log/apt/ ~/.launchpadlib
 
+# Mark /workspace as a safe directory for git to avoid "dubious ownership" warnings
+# when the monorepo is mounted from the host with different ownership.
+RUN git config --global --add safe.directory /workspace
+
 CMD ["bash"]


### PR DESCRIPTION
Fixes MONOREP-314

## Proposed changes:
* Add git config to treat `/workspace` as a safe directory in the monorepo container, preventing "dubious ownership" warnings when git commands run inside the container with mounted host directories.
* Uses system-level config (`/etc/gitconfig`) instead of global user config to avoid being shadowed by the `/root` volume mount.

### Other information:

- [x] Have you written new tests for your changes, if applicable? N/A - Dockerfile change
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them? N/A
- [x] Have you tested your changes on WordPress.com, if applicable? N/A

## Jetpack product discussion
N/A - Infrastructure/tooling change

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

* On a Linux host (where this issue is most likely to occur), rebuild the monorepo Docker image
* Run a git command inside the container (e.g., `jp docker sh` then `git status`)
* Verify that no "dubious ownership" warning appears