### PR TITLE
Docs: improve Claude Code instructions for changelogs and PR labels

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -38,6 +38,8 @@ For plugins, you can choose the "Starter plugin" template which includes a worki
 
 Every PR touching `/projects` needs a changelog file in the project's `changelog/` directory.
 
+**Note:** Changes outside `/projects` (e.g., `tools/`, `docs/`, `.github/`, `.claude/`) do NOT need changelog entries.
+
 ### Interactive Mode
 Run `jp changelog add` and follow the prompts.
 

--- a/.claude/commands/jetpack-pr.md
+++ b/.claude/commands/jetpack-pr.md
@@ -17,5 +17,11 @@ Instructions:
    - Proposed changes: Bullet points of functional changes
    - Testing instructions: Step-by-step how to test the changes
 5. Create the PR using `gh pr create`, providing the prepared content for the title and body (e.g., with `--title` and `--body` flags)
+6. Add required labels:
+   - `[Status] *` - use `[Status] In Progress` by default, or `[Status] Needs Review` if ready for review
+   - `[Type] *` - choose the appropriate type label:
+     - `[Type] Bug` - for bug fixes
+     - `[Type] Enhancement` - for new features or improvements
+     - `[Type] Janitorial` - for documentation, refactoring, or maintenance
 
 When using `--title` and `--body` with `gh pr create`, the template is not auto-filled; you must format the PR body to match the template structure yourself. Alternatively, omit `--body` to open an editor with the template pre-filled. Deduce all information from git history and code changes - do not ask the user for input.


### PR DESCRIPTION
## Proposed changes:
* Add explicit note to CLAUDE.md clarifying that changes outside `/projects` directory (e.g., `tools/`, `docs/`, `.github/`, `.claude/`) do NOT need changelog entries.
* Add required label documentation to jetpack-pr command:
  - `[Status] In Progress` (default) or `[Status] Needs Review`
  - `[Type] Bug`, `[Type] Enhancement`, or `[Type] Janitorial`

This helps avoid confusion when AI assistants or developers modify non-project files and ensures PRs are properly labeled.

### Other information:

- [x] Have you written new tests for your changes, if applicable? N/A - Documentation only
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them? N/A
- [x] Have you tested your changes on WordPress.com, if applicable? N/A

## Jetpack product discussion

N/A - Internal tooling documentation only.

## Does this pull request change what data or activity we track or use?

No, this PR only updates internal documentation for AI assistants.

## Testing instructions:

* Review the updated documentation in `.claude/CLAUDE.md` and `.claude/commands/jetpack-pr.md`