### PR TITLE
Form block: Fix email rendering

### DIFF
--- a/projects/packages/forms/changelog/fix-form-block-email-rendering
+++ b/projects/packages/forms/changelog/fix-form-block-email-rendering
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Form block: Use fallback in all email rendering contexts.
+Use fallback in all email rendering contexts.

--- a/projects/packages/forms/changelog/fix-form-block-email-rendering
+++ b/projects/packages/forms/changelog/fix-form-block-email-rendering
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Form block: Use fallback in all email rendering contexts.

--- a/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
+++ b/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
@@ -41,7 +41,8 @@ class Contact_Form_Block {
 		Blocks::jetpack_register_block(
 			'jetpack/contact-form',
 			array(
-				'render_callback' => array( __CLASS__, 'gutenblock_render_form' ),
+				'render_callback'       => array( __CLASS__, 'gutenblock_render_form' ),
+				'render_email_callback' => array( __CLASS__, 'render_email' ),
 			)
 		);
 
@@ -704,6 +705,37 @@ class Contact_Form_Block {
 	}
 
 	/**
+	 * Render fallback for non-interactive contexts (email, feed, API, etc.).
+	 *
+	 * @param array $atts - the block attributes.
+	 *
+	 * @return string
+	 */
+	private static function render_fallback( $atts ) {
+		return sprintf(
+			'<div class="%1$s"><a href="%2$s" target="_blank" rel="noopener noreferrer">%3$s</a></div>',
+			esc_attr( Blocks::classes( 'contact-form', $atts ) ),
+			esc_url( get_the_permalink() ),
+			esc_html__( 'Submit a form.', 'jetpack-forms' )
+		);
+	}
+
+	/**
+	 * Render the contact form block for email contexts.
+	 *
+	 * @param string $block_content     The original block HTML content.
+	 * @param array  $parsed_block      The parsed block data including attributes.
+	 * @param object $rendering_context Email rendering context.
+	 *
+	 * @return string
+	 */
+	public static function render_email( $block_content, array $parsed_block, $rendering_context ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		$atts = isset( $parsed_block['attrs'] ) ? $parsed_block['attrs'] : array();
+
+		return self::render_fallback( $atts );
+	}
+
+	/**
 	 * Render the gutenblock form.
 	 *
 	 * @param array  $atts - the block attributes.
@@ -718,12 +750,7 @@ class Contact_Form_Block {
 		}
 		// Render fallback in other contexts than frontend (i.e. feed, emails, API, etc.), unless the form is being submitted.
 		if ( ! Request::is_frontend() && ! isset( $_POST['contact-form-id'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing
-			return sprintf(
-				'<div class="%1$s"><a href="%2$s" target="_blank" rel="noopener noreferrer">%3$s</a></div>',
-				esc_attr( Blocks::classes( 'contact-form', $atts ) ),
-				esc_url( get_the_permalink() ),
-				esc_html__( 'Submit a form.', 'jetpack-forms' )
-			);
+			return self::render_fallback( $atts );
 		}
 
 		self::load_view_scripts();

--- a/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
+++ b/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
@@ -730,7 +730,7 @@ class Contact_Form_Block {
 	 * @return string
 	 */
 	public static function render_email( $block_content, array $parsed_block, $rendering_context ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
-		$atts = isset( $parsed_block['attrs'] ) ? $parsed_block['attrs'] : array();
+		$atts = $parsed_block['attrs'] ?? array();
 
 		return self::render_fallback( $atts );
 	}

--- a/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
+++ b/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
@@ -723,11 +723,21 @@ class Contact_Form_Block {
 	/**
 	 * Render the contact form block for email contexts.
 	 *
-	 * @param string $block_content     The original block HTML content.
-	 * @param array  $parsed_block      The parsed block data including attributes.
-	 * @param object $rendering_context Email rendering context.
+	 * This method is called by WordPress/WooCommerce email rendering system when a form block
+	 * appears in email content. Forms are not interactive in email contexts, so we always return
+	 * a fallback link that directs recipients to the form on the website.
 	 *
-	 * @return string
+	 * Note: The $block_content and $rendering_context parameters are required by the
+	 * render_email_callback signature but are intentionally unused here. We only need the
+	 * block attributes from $parsed_block to generate the fallback HTML, and we don't need
+	 * to process the block content or use email-specific rendering context since we're
+	 * always returning a simple fallback.
+	 *
+	 * @param string $block_content     The original block HTML content. Unused - we always return a fallback.
+	 * @param array  $parsed_block      The parsed block data including attributes.
+	 * @param object $rendering_context Email rendering context. Unused - not needed for fallback rendering.
+	 *
+	 * @return string HTML fallback with link to submit the form on the website.
 	 */
 	public static function render_email( $block_content, array $parsed_block, $rendering_context ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 		$atts = $parsed_block['attrs'] ?? array();

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Block_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Block_Test.php
@@ -373,4 +373,107 @@ class Contact_Form_Block_Test extends BaseTestCase {
 
 		remove_filter( 'jetpack_contact_form_can_manage_block', '__return_false' );
 	}
+
+	/**
+	 * Test render_email with valid attributes.
+	 */
+	public function test_render_email_with_valid_attributes() {
+		// Create a test post to get a valid permalink
+		$post_id = wp_insert_post(
+			array(
+				'post_title'   => 'Test Post',
+				'post_content' => 'Test content',
+				'post_status'  => 'publish',
+			)
+		);
+		global $post;
+		$post = get_post( $post_id );
+
+		$parsed_block = array(
+			'attrs' => array(
+				'className' => 'test-class',
+			),
+		);
+
+		$mock_context = (object) array();
+
+		$result = Contact_Form_Block::render_email( '', $parsed_block, $mock_context );
+
+		// Should return HTML content
+		$this->assertNotEmpty( $result );
+		$this->assertStringContainsString( '<div', $result );
+		$this->assertStringContainsString( '<a', $result );
+		$this->assertStringContainsString( 'target="_blank"', $result );
+		$this->assertStringContainsString( 'rel="noopener noreferrer"', $result );
+
+		// Should contain the fallback text
+		$this->assertStringContainsString( 'Submit a form.', $result );
+
+		// Should contain the permalink
+		$this->assertStringContainsString( get_permalink( $post_id ), $result );
+
+		// Cleanup
+		wp_delete_post( $post_id, true );
+	}
+
+	/**
+	 * Test render_email with missing attrs.
+	 */
+	public function test_render_email_with_missing_attrs() {
+		// Create a test post to get a valid permalink
+		$post_id = wp_insert_post(
+			array(
+				'post_title'   => 'Test Post',
+				'post_content' => 'Test content',
+				'post_status'  => 'publish',
+			)
+		);
+		global $post;
+		$post = get_post( $post_id );
+
+		$mock_context = (object) array();
+
+		// Test with missing attrs key
+		$parsed_block = array();
+		$result       = Contact_Form_Block::render_email( '', $parsed_block, $mock_context );
+
+		// Should still return HTML (uses empty array as default)
+		$this->assertNotEmpty( $result );
+		$this->assertStringContainsString( 'Submit a form.', $result );
+
+		// Cleanup
+		wp_delete_post( $post_id, true );
+	}
+
+	/**
+	 * Test render_email with empty attrs.
+	 */
+	public function test_render_email_with_empty_attrs() {
+		// Create a test post to get a valid permalink
+		$post_id = wp_insert_post(
+			array(
+				'post_title'   => 'Test Post',
+				'post_content' => 'Test content',
+				'post_status'  => 'publish',
+			)
+		);
+		global $post;
+		$post = get_post( $post_id );
+
+		$parsed_block = array(
+			'attrs' => array(),
+		);
+
+		$mock_context = (object) array();
+
+		$result = Contact_Form_Block::render_email( '', $parsed_block, $mock_context );
+
+		// Should return HTML content even with empty attrs
+		$this->assertNotEmpty( $result );
+		$this->assertStringContainsString( 'Submit a form.', $result );
+		$this->assertStringContainsString( get_permalink( $post_id ), $result );
+
+		// Cleanup
+		wp_delete_post( $post_id, true );
+	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://linear.app/a8c/issue/NL-352/newsletter-email-shows-form-success-message-and-full-form

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds a `render_email_callback` for email rendering, similar to how we've handled email rendering in other Jetpack blocks. This is the callback that the WooCommerce Email Editor rendering expects.
* Moves the existing email fallback into a reusable function so that it can be used in multiple contexts.
* Adds related tests.

Without this change | With this change
---- | ----
<img width="759" height="676" alt="Screenshot 2026-01-14 at 11 48 28 AM" src="https://github.com/user-attachments/assets/6519c906-f3c9-4b68-ac6b-f670c6dd0867" /> | <img width="696" height="510" alt="Screenshot 2026-01-14 at 11 48 47 AM" src="https://github.com/user-attachments/assets/b3fea030-fbb3-4583-b311-34dbdffd61ae" />


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

https://linear.app/a8c/issue/NL-352/newsletter-email-shows-form-success-message-and-full-form

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

N/A

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this change to your sandbox: `bin/jetpack-downloader test jetpack fix/form-block-email-rendering`
* Sandbox the API.
* Sandbox all jobs: `add_filter( 'sandbox_async_job', '__return_true', 10, 2 );`
* Run the jobs watcher: `php /home/wpcom/public_html/async-jobs/watcher.php`
* Turn on write access: `allow-sandbox-production-writes "10 minutes"`
* Create a post with a form block in it. Choose any of the form presets, like contact form.
* In the Jetpack newsletter panel, preview the email. Verify that the form becomes a link to the form.
* Publish the post and send it to at least one subscriber. Verify that the form becomes a link to the form.

