### PR TITLE
Jetpack Sync: Suppress unserialize warnings

### DIFF
--- a/projects/packages/sync/changelog/fix-sync-suppress-unserialize-warnings
+++ b/projects/packages/sync/changelog/fix-sync-suppress-unserialize-warnings
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Jetpack Sync: Suppress unserialize warnings
+
+

--- a/projects/packages/sync/src/class-queue.php
+++ b/projects/packages/sync/src/class-queue.php
@@ -329,9 +329,8 @@ class Queue {
 			// phpcs:ignore Generic.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition
 			while ( ( $current_item = array_shift( $current_items ) ) !== null ) {
 				// @codingStandardsIgnoreStart
-				$current_item->value = unserialize( $current_item->value );
+				$current_item->value = @unserialize( $current_item->value );
 				// @codingStandardsIgnoreEnd
-
 				$items[] = $current_item;
 			}
 		}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes SYNC-46

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* `Automattic\Jetpack\Sync\Queue::checkout_with_memory_limit`: Suppress unserialize related warnings same way we do in `unserialize_values`

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Code review should suffice in this case

