### PR TITLE
jetpack-mu-wpcom: Improve Code block load performance

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/code-block-improve-load-perf
+++ b/projects/packages/jetpack-mu-wpcom/changelog/code-block-improve-load-perf
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+jetpack-mu-wpcom: Improve Code block loading performance.

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/class-code-block.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/class-code-block.php
@@ -58,11 +58,11 @@ abstract class Code_Block {
 	 * Called lazily when editor assets are needed, not on every request.
 	 */
 	private static function register_editor_assets() {
-		static $registered = false;
-		if ( $registered ) {
+		static $done = false;
+		if ( $done ) {
 			return;
 		}
-		$registered = true;
+		$done = true;
 
 		$block_definition_asset_file  = include Jetpack_Mu_Wpcom::BASE_DIR . 'build/wpcom-blocks-code-block-definition/wpcom-blocks-code-block-definition.asset.php';
 		$jetpack_wpcom_modules_assets = self::get_module_assets();
@@ -122,6 +122,12 @@ abstract class Code_Block {
 	 * Enqueue view script module.
 	 */
 	private static function enqueue_view_assets() {
+		static $done = false;
+		if ( $done ) {
+			return;
+		}
+		$done = true;
+
 		$jetpack_wpcom_modules_assets = self::get_module_assets();
 		wp_enqueue_script_module(
 			self::MODULE_PREFIX . 'block-front',

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/class-code-block.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/class-code-block.php
@@ -141,7 +141,10 @@ abstract class Code_Block {
 	 * Get module assets file.
 	 */
 	private static function get_module_assets() {
-		static $jetpack_wpcom_modules_assets = include Jetpack_Mu_Wpcom::BASE_DIR . 'build-module/assets.php';
+		static $jetpack_wpcom_modules_assets = null;
+		if ( null === $jetpack_wpcom_modules_assets ) {
+			$jetpack_wpcom_modules_assets = include Jetpack_Mu_Wpcom::BASE_DIR . 'build-module/assets.php';
+		}
 		return $jetpack_wpcom_modules_assets;
 	}
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/class-code-block.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/class-code-block.php
@@ -65,7 +65,7 @@ abstract class Code_Block {
 		$done = true;
 
 		$block_definition_asset_file  = include Jetpack_Mu_Wpcom::BASE_DIR . 'build/wpcom-blocks-code-block-definition/wpcom-blocks-code-block-definition.asset.php';
-		$jetpack_wpcom_modules_assets = self::get_module_assets();
+		$jetpack_wpcom_modules_assets = self::get_module_asset_data();
 
 		// The block definition must contain the script dependencies that the edit function script module requires.
 		// Append static dependency list here. Some duplicates may appear, that should be harmless.
@@ -128,7 +128,7 @@ abstract class Code_Block {
 		}
 		$done = true;
 
-		$jetpack_wpcom_modules_assets = self::get_module_assets();
+		$jetpack_wpcom_modules_assets = self::get_module_asset_data();
 		wp_enqueue_script_module(
 			self::MODULE_PREFIX . 'block-front',
 			plugins_url( 'build-module/wpcom-blocks-code-block-front/wpcom-blocks-code-block-front.js', Jetpack_Mu_Wpcom::BASE_FILE ),
@@ -138,9 +138,9 @@ abstract class Code_Block {
 	}
 
 	/**
-	 * Get module assets file.
+	 * Get the module asset data.
 	 */
-	private static function get_module_assets() {
+	private static function get_module_asset_data() {
 		static $jetpack_wpcom_modules_assets = null;
 		if ( null === $jetpack_wpcom_modules_assets ) {
 			$jetpack_wpcom_modules_assets = include Jetpack_Mu_Wpcom::BASE_DIR . 'build-module/assets.php';

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/class-code-block.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/class-code-block.php
@@ -119,9 +119,7 @@ abstract class Code_Block {
 	}
 
 	/**
-	 * Enqueue view/frontend script module.
-	 *
-	 * Uses wp_enqueue_script_module() which registers and enqueues in one call.
+	 * Enqueue view script module.
 	 */
 	private static function enqueue_view_assets() {
 		$jetpack_wpcom_modules_asset_file = include Jetpack_Mu_Wpcom::BASE_DIR . 'build-module/assets.php';

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/class-code-block.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/class-code-block.php
@@ -202,7 +202,7 @@ abstract class Code_Block {
 			// Only perform enhancement on the _full_, expected block.
 			|| ! isset( $args['attributes']['content'] )
 
-			// Skip if the block is correctly processed.
+			// Skip if the block is already processed.
 			|| $args['render_callback'] === array( __CLASS__, 'render_block' )
 		) {
 			return $args;
@@ -212,29 +212,33 @@ abstract class Code_Block {
 		self::register_editor_assets();
 		self::override_block_style();
 
-		add_action( 'enqueue_block_editor_assets', array( __CLASS__, 'enqueue_editor_assets' ) );
-		add_action(
-			'wp_enqueue_scripts',
-			function () {
-				if ( wp_should_load_block_editor_scripts_and_styles() ) {
-					self::enqueue_editor_assets();
-				}
+		static $hooks_registered = false;
+		if ( ! $hooks_registered ) {
+			$hooks_registered = true;
+			add_action( 'enqueue_block_editor_assets', array( __CLASS__, 'enqueue_editor_assets' ) );
+			add_action(
+				'wp_enqueue_scripts',
+				function () {
+					if ( wp_should_load_block_editor_scripts_and_styles() ) {
+						self::enqueue_editor_assets();
+					}
 
-				/*
-				 * Core should handle this, but Script Module assets are not currently handled.
-				 *
-				 * `wp_should_load_block_assets_on_demand()` was added in WordPress 6.8. The
-				 * `function_exists()` can be removed when 6.8+ is required.
-				 */
-				if (
-					function_exists( 'wp_should_load_block_assets_on_demand' )
-					&& ! wp_should_load_block_assets_on_demand() // @phan-suppress-current-line PhanUndeclaredFunction, UnusedPluginSuppression
-					&& has_block( 'core/code' )
-				) {
-					self::enqueue_view_assets();
+					/*
+					 * Core should handle this, but Script Module assets are not currently handled.
+					 *
+					 * `wp_should_load_block_assets_on_demand()` was added in WordPress 6.8. The
+					 * `function_exists()` can be removed when 6.8+ is required.
+					 */
+					if (
+						function_exists( 'wp_should_load_block_assets_on_demand' )
+						&& ! wp_should_load_block_assets_on_demand() // @phan-suppress-current-line PhanUndeclaredFunction, UnusedPluginSuppression
+						&& has_block( 'core/code' )
+					) {
+						self::enqueue_view_assets();
+					}
 				}
-			}
-		);
+			);
+		}
 
 		$args['render_callback']       = array( __CLASS__, 'render_block' );
 		$args['editor_script_handles'] = array_merge( array( self::MODULE_PREFIX . 'block-definition' ), $args['editor_script_handles'] ?? array() );

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/class-code-block.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/class-code-block.php
@@ -19,8 +19,7 @@ use WP_Theme_JSON;
  * Contains necessary functionality for the Code Block.
  */
 abstract class Code_Block {
-	const MODULE_PREFIX                     = '@a8cCodeBlock/';
-	const REGISTER_BLOCK_TYPE_ARGS_PRIORITY = 150;
+	const MODULE_PREFIX = '@a8cCodeBlock/';
 
 	/**
 	 * Language names for display.
@@ -50,7 +49,7 @@ abstract class Code_Block {
 		}
 
 		add_action( 'after_setup_theme', array( __CLASS__, 'after_setup_theme' ), 100 );
-		add_filter( 'register_block_type_args', array( __CLASS__, 'register_block_type_args' ), self::REGISTER_BLOCK_TYPE_ARGS_PRIORITY, 2 );
+		add_filter( 'register_block_type_args', array( __CLASS__, 'register_block_type_args' ), 150, 2 );
 	}
 
 	/**
@@ -189,13 +188,16 @@ abstract class Code_Block {
 	public static function register_block_type_args( array $args, string $block_type ): array {
 		if (
 			'core/code' !== $block_type
+
 			// In some cases the block may not include the content attribute.
 			// Only perform enhancement on the _full_, expected block.
 			|| ! isset( $args['attributes']['content'] )
+
+			// Skip if the block is correctly processed.
+			|| $args['render_callback'] === array( __CLASS__, 'render_block' )
 		) {
 			return $args;
 		}
-		remove_filter( 'register_block_type_args', array( __CLASS__, 'register_block_type_args' ), self::REGISTER_BLOCK_TYPE_ARGS_PRIORITY );
 
 		// Register assets and hooks only when overriding the block.
 		self::register_editor_assets();

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/class-code-block.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/class-code-block.php
@@ -373,6 +373,12 @@ abstract class Code_Block {
 	 * Enqueue plugin assets necessary for the block editor.
 	 */
 	public static function enqueue_editor_assets() {
+		static $done = false;
+		if ( $done ) {
+			return;
+		}
+		$done = true;
+
 		/*
 		 * The code block registration script depends on some script modules.
 		 * This "dummy" module ensures those dependencies are available.

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/class-code-block.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/class-code-block.php
@@ -121,20 +121,14 @@ abstract class Code_Block {
 	}
 
 	/**
-	 * Registration of view/frontend script modules.
+	 * Enqueue view/frontend script module.
 	 *
-	 * Called lazily when view assets are needed (when rendering or on-demand loading is disabled).
+	 * Uses wp_enqueue_script_module() which registers and enqueues in one call.
 	 */
-	private static function register_view_assets() {
-		static $registered = false;
-		if ( $registered ) {
-			return;
-		}
-		$registered = true;
-
+	private static function enqueue_view_assets() {
 		$jetpack_wpcom_modules_asset_file = include Jetpack_Mu_Wpcom::BASE_DIR . 'build-module/assets.php';
 
-		wp_register_script_module(
+		wp_enqueue_script_module(
 			self::MODULE_PREFIX . 'block-front',
 			plugins_url( 'build-module/wpcom-blocks-code-block-front/wpcom-blocks-code-block-front.js', Jetpack_Mu_Wpcom::BASE_FILE ),
 			$jetpack_wpcom_modules_asset_file['wpcom-blocks-code-block-front/wpcom-blocks-code-block-front.js']['dependencies'],
@@ -212,8 +206,7 @@ abstract class Code_Block {
 					&& ! wp_should_load_block_assets_on_demand() // @phan-suppress-current-line PhanUndeclaredFunction, UnusedPluginSuppression
 					&& has_block( 'core/code' )
 				) {
-					self::register_view_assets();
-					wp_enqueue_script_module( self::MODULE_PREFIX . 'block-front' );
+					self::enqueue_view_assets();
 				}
 			}
 		);
@@ -406,8 +399,7 @@ abstract class Code_Block {
 		$style_properties = array();
 
 		if ( isset( $attributes['showCopyButton'] ) ) {
-			self::register_view_assets();
-			wp_enqueue_script_module( self::MODULE_PREFIX . 'block-front' );
+			self::enqueue_view_assets();
 		}
 
 		$show_line_numbers = $attributes['showLineNumbers'] ?? false;

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/class-code-block.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/class-code-block.php
@@ -157,13 +157,22 @@ abstract class Code_Block {
 	 * Instead of using a different style handle, replace the registered style for `wp-block-code`.
 	 *
 	 * @see https://core.trac.wordpress.org/browser/tags/6.8.3/src/wp-includes/global-styles-and-settings.php#L322
+	 *
+	 * @global \WP_Styles $wp_styles
 	 */
 	public static function override_block_style() {
+		global $wp_styles;
+
+		$src = plugins_url( 'build/wpcom-blocks-code-style/wpcom-blocks-code-style.css', Jetpack_Mu_Wpcom::BASE_FILE );
+		// Skip work if style is registered as desired.
+		if ( isset( $wp_styles->registered['wp-block-code'] ) && $wp_styles->registered['wp-block-code']->src === $src ) {
+			return;
+		}
+
 		$was_enqueued = wp_style_is( 'wp-block-code', 'enqueued' );
 		wp_deregister_style( 'wp-block-code' );
 
 		$style_asset_file = include Jetpack_Mu_Wpcom::BASE_DIR . 'build/wpcom-blocks-code-style/wpcom-blocks-code-style.asset.php';
-		$src              = plugins_url( 'build/wpcom-blocks-code-style/wpcom-blocks-code-style.css', Jetpack_Mu_Wpcom::BASE_FILE );
 		$version          = $style_asset_file['version'];
 
 		wp_register_style(

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/class-code-block.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/class-code-block.php
@@ -48,10 +48,8 @@ abstract class Code_Block {
 			return;
 		}
 
-		// Entry point filter - other hooks are registered conditionally when the block is overridden.
-		add_filter( 'register_block_type_args', array( __CLASS__, 'register_block_type_args' ), 150, 2 );
-		// Optimization hook - runs before init, can't be conditional.
 		add_action( 'after_setup_theme', array( __CLASS__, 'after_setup_theme' ), 100 );
+		add_filter( 'register_block_type_args', array( __CLASS__, 'register_block_type_args' ), 150, 2 );
 	}
 
 	/**
@@ -203,7 +201,7 @@ abstract class Code_Block {
 				 */
 				if (
 					function_exists( 'wp_should_load_block_assets_on_demand' )
-					&& ! wp_should_load_block_assets_on_demand() // @phan-suppress-current-line PhanUndeclaredFunction, UnusedPluginSuppression
+					&& ! wp_should_load_block_assets_on_demand()
 					&& has_block( 'core/code' )
 				) {
 					self::enqueue_view_assets();

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/class-code-block.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/class-code-block.php
@@ -394,7 +394,7 @@ abstract class Code_Block {
 		$extra_attrs      = array();
 		$style_properties = array();
 
-		if ( isset( $attributes['showCopyButton'] ) ) {
+		if ( $attributes['showCopyButton'] ?? false ) {
 			self::enqueue_view_assets();
 		}
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/class-code-block.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/class-code-block.php
@@ -64,8 +64,8 @@ abstract class Code_Block {
 		}
 		$registered = true;
 
-		$block_definition_asset_file      = include Jetpack_Mu_Wpcom::BASE_DIR . 'build/wpcom-blocks-code-block-definition/wpcom-blocks-code-block-definition.asset.php';
-		$jetpack_wpcom_modules_asset_file = include Jetpack_Mu_Wpcom::BASE_DIR . 'build-module/assets.php';
+		$block_definition_asset_file  = include Jetpack_Mu_Wpcom::BASE_DIR . 'build/wpcom-blocks-code-block-definition/wpcom-blocks-code-block-definition.asset.php';
+		$jetpack_wpcom_modules_assets = self::get_module_assets();
 
 		// The block definition must contain the script dependencies that the edit function script module requires.
 		// Append static dependency list here. Some duplicates may appear, that should be harmless.
@@ -94,8 +94,8 @@ abstract class Code_Block {
 		wp_register_script_module(
 			self::MODULE_PREFIX . 'block-edit-function',
 			plugins_url( 'build-module/wpcom-blocks-code-edit-function/wpcom-blocks-code-edit-function.js', Jetpack_Mu_Wpcom::BASE_FILE ),
-			$jetpack_wpcom_modules_asset_file['wpcom-blocks-code-edit-function/wpcom-blocks-code-edit-function.js']['dependencies'],
-			$jetpack_wpcom_modules_asset_file['wpcom-blocks-code-edit-function/wpcom-blocks-code-edit-function.js']['version']
+			$jetpack_wpcom_modules_assets['wpcom-blocks-code-edit-function/wpcom-blocks-code-edit-function.js']['dependencies'],
+			$jetpack_wpcom_modules_assets['wpcom-blocks-code-edit-function/wpcom-blocks-code-edit-function.js']['version']
 		);
 
 		$editor_style_asset_file = include Jetpack_Mu_Wpcom::BASE_DIR . 'build/wpcom-blocks-code-editor-style/wpcom-blocks-code-editor-style.asset.php';
@@ -107,7 +107,7 @@ abstract class Code_Block {
 		);
 
 		$block_worker_url     = plugins_url( 'build-module/wpcom-blocks-code-worker/wpcom-blocks-code-worker.js', Jetpack_Mu_Wpcom::BASE_FILE );
-		$block_worker_version = $jetpack_wpcom_modules_asset_file['wpcom-blocks-code-worker/wpcom-blocks-code-worker.js']['version'];
+		$block_worker_version = $jetpack_wpcom_modules_assets['wpcom-blocks-code-worker/wpcom-blocks-code-worker.js']['version'];
 		add_filter(
 			'script_module_data_' . self::MODULE_PREFIX . 'block-edit-function',
 			function ( array $data ) use ( $block_worker_url, $block_worker_version ): array {
@@ -122,14 +122,21 @@ abstract class Code_Block {
 	 * Enqueue view script module.
 	 */
 	private static function enqueue_view_assets() {
-		$jetpack_wpcom_modules_asset_file = include Jetpack_Mu_Wpcom::BASE_DIR . 'build-module/assets.php';
-
+		$jetpack_wpcom_modules_assets = self::get_module_assets();
 		wp_enqueue_script_module(
 			self::MODULE_PREFIX . 'block-front',
 			plugins_url( 'build-module/wpcom-blocks-code-block-front/wpcom-blocks-code-block-front.js', Jetpack_Mu_Wpcom::BASE_FILE ),
-			$jetpack_wpcom_modules_asset_file['wpcom-blocks-code-block-front/wpcom-blocks-code-block-front.js']['dependencies'],
-			$jetpack_wpcom_modules_asset_file['wpcom-blocks-code-block-front/wpcom-blocks-code-block-front.js']['version']
+			$jetpack_wpcom_modules_assets['wpcom-blocks-code-block-front/wpcom-blocks-code-block-front.js']['dependencies'],
+			$jetpack_wpcom_modules_assets['wpcom-blocks-code-block-front/wpcom-blocks-code-block-front.js']['version']
 		);
+	}
+
+	/**
+	 * Get module assets file.
+	 */
+	private static function get_module_assets() {
+		static $jetpack_wpcom_modules_assets = include Jetpack_Mu_Wpcom::BASE_DIR . 'build-module/assets.php';
+		return $jetpack_wpcom_modules_assets;
 	}
 
 	/**

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/class-code-block.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/class-code-block.php
@@ -212,6 +212,9 @@ abstract class Code_Block {
 			return $args;
 		}
 
+		// Register editor assets when the block is being overridden.
+		self::register_editor_assets();
+
 		$args['render_callback']       = array( __CLASS__, 'render_block' );
 		$args['editor_script_handles'] = array_merge( array( self::MODULE_PREFIX . 'block-definition' ), $args['editor_script_handles'] ?? array() );
 
@@ -362,9 +365,6 @@ abstract class Code_Block {
 	 * Enqueue plugin assets necessary for the block editor.
 	 */
 	public static function enqueue_editor_assets() {
-		// Register editor assets lazily when needed.
-		self::register_editor_assets();
-
 		/*
 		 * The code block registration script depends on some script modules.
 		 * This "dummy" module ensures those dependencies are available.

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/class-code-block.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/class-code-block.php
@@ -199,7 +199,7 @@ abstract class Code_Block {
 				 */
 				if (
 					function_exists( 'wp_should_load_block_assets_on_demand' )
-					&& ! wp_should_load_block_assets_on_demand()
+					&& ! wp_should_load_block_assets_on_demand() // @phan-suppress-current-line PhanUndeclaredFunction, UnusedPluginSuppression
 					&& has_block( 'core/code' )
 				) {
 					self::enqueue_view_assets();

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/class-code-block.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/class-code-block.php
@@ -139,6 +139,8 @@ abstract class Code_Block {
 
 	/**
 	 * Get the module asset data.
+	 *
+	 * @return array
 	 */
 	private static function get_module_asset_data() {
 		static $jetpack_wpcom_modules_assets = null;

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/class-code-block.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/class-code-block.php
@@ -48,32 +48,9 @@ abstract class Code_Block {
 			return;
 		}
 
-		add_action( 'init', array( __CLASS__, 'override_block_style' ) );
+		// Entry point filter - other hooks are registered conditionally when the block is overridden.
 		add_filter( 'register_block_type_args', array( __CLASS__, 'register_block_type_args' ), 150, 2 );
-		add_action( 'enqueue_block_editor_assets', array( __CLASS__, 'enqueue_editor_assets' ) );
-		add_action(
-			'wp_enqueue_scripts',
-			function () {
-				if ( wp_should_load_block_editor_scripts_and_styles() ) {
-					self::enqueue_editor_assets();
-				}
-
-				/*
-				 * Core should handle this, but Script Module assets are not currently handled.
-				 *
-				 * `wp_should_load_block_assets_on_demand()` was added in WordPress 6.8. The
-				 * `function_exists()` can be removed when 6.8+ is required.
-				 */
-				if (
-					function_exists( 'wp_should_load_block_assets_on_demand' )
-					&& ! wp_should_load_block_assets_on_demand() // @phan-suppress-current-line PhanUndeclaredFunction, UnusedPluginSuppression
-					&& has_block( 'core/code' )
-				) {
-					self::register_view_assets();
-					wp_enqueue_script_module( self::MODULE_PREFIX . 'block-front' );
-				}
-			}
-		);
+		// Optimization hook - runs before init, can't be conditional.
 		add_action( 'after_setup_theme', array( __CLASS__, 'after_setup_theme' ), 100 );
 	}
 
@@ -212,8 +189,34 @@ abstract class Code_Block {
 			return $args;
 		}
 
-		// Register editor assets when the block is being overridden.
+		// Register assets and hooks only when overriding the block.
 		self::register_editor_assets();
+		self::override_block_style();
+
+		add_action( 'enqueue_block_editor_assets', array( __CLASS__, 'enqueue_editor_assets' ) );
+		add_action(
+			'wp_enqueue_scripts',
+			function () {
+				if ( wp_should_load_block_editor_scripts_and_styles() ) {
+					self::enqueue_editor_assets();
+				}
+
+				/*
+				 * Core should handle this, but Script Module assets are not currently handled.
+				 *
+				 * `wp_should_load_block_assets_on_demand()` was added in WordPress 6.8. The
+				 * `function_exists()` can be removed when 6.8+ is required.
+				 */
+				if (
+					function_exists( 'wp_should_load_block_assets_on_demand' )
+					&& ! wp_should_load_block_assets_on_demand() // @phan-suppress-current-line PhanUndeclaredFunction, UnusedPluginSuppression
+					&& has_block( 'core/code' )
+				) {
+					self::register_view_assets();
+					wp_enqueue_script_module( self::MODULE_PREFIX . 'block-front' );
+				}
+			}
+		);
 
 		$args['render_callback']       = array( __CLASS__, 'render_block' );
 		$args['editor_script_handles'] = array_merge( array( self::MODULE_PREFIX . 'block-definition' ), $args['editor_script_handles'] ?? array() );

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/class-code-block.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/class-code-block.php
@@ -48,7 +48,6 @@ abstract class Code_Block {
 			return;
 		}
 
-		self::init();
 		add_action( 'init', array( __CLASS__, 'override_block_style' ) );
 		add_filter( 'register_block_type_args', array( __CLASS__, 'register_block_type_args' ), 150, 2 );
 		add_action( 'enqueue_block_editor_assets', array( __CLASS__, 'enqueue_editor_assets' ) );
@@ -68,8 +67,10 @@ abstract class Code_Block {
 				if (
 					function_exists( 'wp_should_load_block_assets_on_demand' )
 					&& ! wp_should_load_block_assets_on_demand() // @phan-suppress-current-line PhanUndeclaredFunction, UnusedPluginSuppression
+					&& has_block( 'core/code' )
 				) {
-						wp_enqueue_script_module( self::MODULE_PREFIX . 'block-front' );
+					self::register_view_assets();
+					wp_enqueue_script_module( self::MODULE_PREFIX . 'block-front' );
 				}
 			}
 		);
@@ -77,9 +78,17 @@ abstract class Code_Block {
 	}
 
 	/**
-	 * Registration of scripts and styles.
+	 * Registration of editor scripts, styles, and modules.
+	 *
+	 * Called lazily when editor assets are needed, not on every request.
 	 */
-	private static function init() {
+	private static function register_editor_assets() {
+		static $registered = false;
+		if ( $registered ) {
+			return;
+		}
+		$registered = true;
+
 		$block_definition_asset_file      = include Jetpack_Mu_Wpcom::BASE_DIR . 'build/wpcom-blocks-code-block-definition/wpcom-blocks-code-block-definition.asset.php';
 		$jetpack_wpcom_modules_asset_file = include Jetpack_Mu_Wpcom::BASE_DIR . 'build-module/assets.php';
 
@@ -122,13 +131,6 @@ abstract class Code_Block {
 			$editor_style_asset_file['version']
 		);
 
-		wp_register_script_module(
-			self::MODULE_PREFIX . 'block-front',
-			plugins_url( 'build-module/wpcom-blocks-code-block-front/wpcom-blocks-code-block-front.js', Jetpack_Mu_Wpcom::BASE_FILE ),
-			$jetpack_wpcom_modules_asset_file['wpcom-blocks-code-block-front/wpcom-blocks-code-block-front.js']['dependencies'],
-			$jetpack_wpcom_modules_asset_file['wpcom-blocks-code-block-front/wpcom-blocks-code-block-front.js']['version']
-		);
-
 		$block_worker_url     = plugins_url( 'build-module/wpcom-blocks-code-worker/wpcom-blocks-code-worker.js', Jetpack_Mu_Wpcom::BASE_FILE );
 		$block_worker_version = $jetpack_wpcom_modules_asset_file['wpcom-blocks-code-worker/wpcom-blocks-code-worker.js']['version'];
 		add_filter(
@@ -138,6 +140,28 @@ abstract class Code_Block {
 				$data['workerVersion'] = $block_worker_version;
 				return $data;
 			}
+		);
+	}
+
+	/**
+	 * Registration of view/frontend script modules.
+	 *
+	 * Called lazily when view assets are needed (when rendering or on-demand loading is disabled).
+	 */
+	private static function register_view_assets() {
+		static $registered = false;
+		if ( $registered ) {
+			return;
+		}
+		$registered = true;
+
+		$jetpack_wpcom_modules_asset_file = include Jetpack_Mu_Wpcom::BASE_DIR . 'build-module/assets.php';
+
+		wp_register_script_module(
+			self::MODULE_PREFIX . 'block-front',
+			plugins_url( 'build-module/wpcom-blocks-code-block-front/wpcom-blocks-code-block-front.js', Jetpack_Mu_Wpcom::BASE_FILE ),
+			$jetpack_wpcom_modules_asset_file['wpcom-blocks-code-block-front/wpcom-blocks-code-block-front.js']['dependencies'],
+			$jetpack_wpcom_modules_asset_file['wpcom-blocks-code-block-front/wpcom-blocks-code-block-front.js']['version']
 		);
 	}
 
@@ -338,6 +362,9 @@ abstract class Code_Block {
 	 * Enqueue plugin assets necessary for the block editor.
 	 */
 	public static function enqueue_editor_assets() {
+		// Register editor assets lazily when needed.
+		self::register_editor_assets();
+
 		/*
 		 * The code block registration script depends on some script modules.
 		 * This "dummy" module ensures those dependencies are available.
@@ -376,6 +403,7 @@ abstract class Code_Block {
 		$style_properties = array();
 
 		if ( isset( $attributes['showCopyButton'] ) ) {
+			self::register_view_assets();
 			wp_enqueue_script_module( self::MODULE_PREFIX . 'block-front' );
 		}
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/class-code-block.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/class-code-block.php
@@ -19,7 +19,8 @@ use WP_Theme_JSON;
  * Contains necessary functionality for the Code Block.
  */
 abstract class Code_Block {
-	const MODULE_PREFIX = '@a8cCodeBlock/';
+	const MODULE_PREFIX                     = '@a8cCodeBlock/';
+	const REGISTER_BLOCK_TYPE_ARGS_PRIORITY = 150;
 
 	/**
 	 * Language names for display.
@@ -49,7 +50,7 @@ abstract class Code_Block {
 		}
 
 		add_action( 'after_setup_theme', array( __CLASS__, 'after_setup_theme' ), 100 );
-		add_filter( 'register_block_type_args', array( __CLASS__, 'register_block_type_args' ), 150, 2 );
+		add_filter( 'register_block_type_args', array( __CLASS__, 'register_block_type_args' ), self::REGISTER_BLOCK_TYPE_ARGS_PRIORITY, 2 );
 	}
 
 	/**
@@ -194,6 +195,7 @@ abstract class Code_Block {
 		) {
 			return $args;
 		}
+		remove_filter( 'register_block_type_args', array( __CLASS__, 'register_block_type_args' ), self::REGISTER_BLOCK_TYPE_ARGS_PRIORITY );
 
 		// Register assets and hooks only when overriding the block.
 		self::register_editor_assets();


### PR DESCRIPTION
## Proposed changes:

Enabling the code block caused performance regressions when loading WordPress. Eager script or module registration is expected to be the culprit.

Defer or conditionally register scripts and modules as much as possible.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1768342065723929-slack-C4GAQ900P

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:

- The block should continue to work correctly in the block editor and the site frontend.
- For performance testing instructions, see the linked slack thread.