### PR TITLE
Forms: use wrapper function to mark unread rows in new dashboard

### DIFF
--- a/projects/packages/forms/changelog/update-forms-wp-build-unread
+++ b/projects/packages/forms/changelog/update-forms-wp-build-unread
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Use wrapper function to mark unread rows in new dashboard.

--- a/projects/packages/forms/routes/responses/stage.tsx
+++ b/projects/packages/forms/routes/responses/stage.tsx
@@ -417,7 +417,7 @@ function Stage() {
 				label: __( 'IP Address', 'jetpack-forms' ),
 				render: ( { item } ) => {
 					if ( ! item.ip ) {
-						return '-';
+						return styleUnreadValue( '-', item.is_unread );
 					}
 					return (
 						<>
@@ -425,7 +425,7 @@ function Stage() {
 								{ ! item.country_code && <Icon icon={ globe } size={ 20 } /> }
 								{ item.country_code && <Flag countryCode={ item.country_code } /> }
 							</span>
-							{ item.ip || '' }
+							{ styleUnreadValue( item.ip, item.is_unread ) }
 						</>
 					);
 				},

--- a/projects/packages/forms/routes/responses/stage.tsx
+++ b/projects/packages/forms/routes/responses/stage.tsx
@@ -140,6 +140,35 @@ function getItemId( item ) {
 }
 
 /**
+ * Styles an element with bold font weight when it represents an unread item.
+ * If the element is a string, it will be wrapped in a span tag with the appropriate styling.
+ *
+ * @param {React.ReactNode} element  - The element to style. Can be a string, React element, or other React node.
+ * @param {boolean}         isUnread - Whether the item is unread. If true, applies fontWeight: 600 styling.
+ * @return {React.ReactNode} The styled element. Returns the element as-is if not unread, or wraps/clones it with fontWeight: 600 if unread.
+ */
+function styleUnreadValue( element: React.ReactNode, isUnread: boolean ): React.ReactNode {
+	if ( ! isUnread ) {
+		return element;
+	}
+
+	// If element is a string, wrap it in a span tag with fontWeight style
+	if ( typeof element === 'string' ) {
+		return <span style={ { fontWeight: 600 } }>{ element }</span>;
+	}
+
+	// If element is already a React element, clone it and add the fontWeight style
+	if ( React.isValidElement( element ) ) {
+		return React.cloneElement( element, {
+			style: { ...( element.props.style || {} ), fontWeight: 600 },
+		} as React.HTMLAttributes< HTMLElement > );
+	}
+
+	// Fallback: wrap in span for other types
+	return <span style={ { fontWeight: 600 } }>{ element }</span>;
+}
+
+/**
  * Stage component for the form responses DataViews.
  *
  * @return The stage component.
@@ -288,14 +317,17 @@ function Stage() {
 								size={ 40 }
 								useHovercard={ false }
 							/>
-							<span style={ { display: 'flex', flexDirection: 'column', gap: '2px' } }>
-								<span style={ { fontWeight: item.is_unread ? 600 : 400 } }>{ displayName }</span>
-								{ showEmail && (
-									<span style={ { fontSize: '12px', color: '#757575' } }>
-										{ item.author_email }
-									</span>
-								) }
-							</span>
+							{ styleUnreadValue(
+								<span style={ { display: 'flex', flexDirection: 'column', gap: '2px' } }>
+									{ displayName }
+									{ showEmail && (
+										<span style={ { fontSize: '12px', color: '#757575' } }>
+											{ item.author_email }
+										</span>
+									) }
+								</span>,
+								item.is_unread
+							) }
 						</span>
 					);
 				},
@@ -313,7 +345,7 @@ function Stage() {
 						month: 'long',
 						day: 'numeric',
 					} );
-					return <span style={ { fontWeight: item.is_unread ? 600 : 400 } }>{ dateStr }</span>;
+					return styleUnreadValue( dateStr, item.is_unread );
 				},
 				elements: ( filterOptions?.date || [] ).map( filter => {
 					const date = new Date();
@@ -334,13 +366,12 @@ function Stage() {
 				render: ( { item } ) => {
 					const source = item.entry_title || __( 'Unknown', 'jetpack-forms' );
 					if ( item.entry_permalink ) {
-						return (
+						const link = (
 							<a
 								href={ item.entry_permalink }
 								target="_blank"
 								rel="noopener noreferrer"
 								style={ {
-									fontWeight: item.is_unread ? 600 : 400,
 									color: 'var(--wp-admin-theme-color, #3858e9)',
 									textDecoration: 'none',
 									display: 'inline-flex',
@@ -352,8 +383,10 @@ function Stage() {
 								<span aria-hidden="true">↗</span>
 							</a>
 						);
+
+						return styleUnreadValue( link, item.is_unread );
 					}
-					return <span style={ { fontWeight: item.is_unread ? 600 : 400 } }>{ source }</span>;
+					return styleUnreadValue( source, item.is_unread );
 				},
 				elements: ( filterOptions?.source || [] ).map( source => ( {
 					value: source.id.toString(),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Follow-up to FORMS-442

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds wrapper function similar to what we had in old dashboard to mark unread rows, without needing to manually add styles everywhere.

<img width="1485" height="443" alt="Screenshot 2026-01-14 at 15 19 43" src="https://github.com/user-attachments/assets/5d6c501c-4015-4221-abd9-f66862b53668" />


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->


* Enable new dash `add_filter('jetpack_forms_alpha', '__return_true');`
* Build dash with `cd projects/packages/forms && pnpm run build:wp-build`
* Mark rows as unread and see difference to read rows
* Doesn't style "read/unread" value (which is hidden by default) as can't style Badge component anyway for now.