### PR TITLE
Forms: Display URL field values as clickable links in submission page

### DIFF
--- a/projects/packages/forms/changelog/add-forms-response-url-link
+++ b/projects/packages/forms/changelog/add-forms-response-url-link
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Forms: Display URL field values as clickable links in form submission confirmation page.

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -1556,7 +1556,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 					<div class="jetpack_forms_contact-form-success-summary">
 						<div class="field-name" data-wp-text="context.submission.label" data-wp-bind--hidden="!context.submission.label"></div>
 						<div class="field-value" data-wp-text="context.submission.value" data-wp-bind--hidden="context.submission.url"></div>
-						<a class="field-url" data-wp-bind--href="context.submission.url" data-wp-text="context.submission.value" data-wp-bind--hidden="!context.submission.url" target="_blank" rel="noopener noreferrer"></a>
+						<a class="field-url" data-wp-bind--href="context.submission.url" data-wp-text="context.submission.url && context.submission.value" data-wp-bind--hidden="!context.submission.url" target="_blank" rel="noopener noreferrer"></a>
 						<div class="field-images" data-wp-bind--hidden="!context.submission.images">
 							<template data-wp-each--image="context.submission.images">
 								<figure class="field-image" data-wp-class--is-empty="!context.image">

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -2222,6 +2222,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 	 * Stores feedback.  Sends email.
 	 */
 	public function process_submission() {
+
 		$response = Feedback::from_submission( $_POST, $this ); // phpcs:Ignore WordPress.Security.NonceVerification.Missing
 		$response->set_source( $this->get_source() );
 		$plugin = Contact_Form_Plugin::init();

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -3180,9 +3180,10 @@ class Contact_Form extends Contact_Form_Shortcode {
 			);
 		}
 
-		// For URL fields, extract the URL text value.
+		// For URL fields, extract the display text value (original user input without auto-added protocol).
 		if ( is_array( $value ) && isset( $value['type'] ) && $value['type'] === 'url' ) {
-			return isset( $value['url'] ) ? $value['url'] : '';
+			// Prefer displayValue (raw input) over url (which may have https:// prepended).
+			return isset( $value['displayValue'] ) ? $value['displayValue'] : ( isset( $value['url'] ) ? $value['url'] : '' );
 		}
 
 		// For file upload fields, we want to show the file name and size

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -1556,7 +1556,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 					<div class="jetpack_forms_contact-form-success-summary">
 						<div class="field-name" data-wp-text="context.submission.label" data-wp-bind--hidden="!context.submission.label"></div>
 						<div class="field-value" data-wp-text="context.submission.value" data-wp-bind--hidden="context.submission.url"></div>
-						<a class="field-url" data-wp-bind--href="context.submission.url" data-wp-text="context.submission.url && context.submission.value" data-wp-bind--hidden="!context.submission.url" target="_blank" rel="noopener noreferrer"></a>
+						<a class="field-url" data-wp-bind--href="context.submission.url" data-wp-text="context.submission.value" data-wp-bind--hidden="!context.submission.url" target="_blank" rel="noopener noreferrer"></a>
 						<div class="field-images" data-wp-bind--hidden="!context.submission.images">
 							<template data-wp-each--image="context.submission.images">
 								<figure class="field-image" data-wp-class--is-empty="!context.image">

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -1439,10 +1439,34 @@ class Contact_Form extends Contact_Form_Shortcode {
 				'label'  => self::maybe_add_colon_to_label( $field_data['label'] ),
 				'value'  => self::maybe_transform_value( $field_data['value'] ),
 				'images' => self::get_images( $field_data['value'] ),
+				'url'    => self::get_url( $field_data['value'] ),
 			);
 		}
 
 		return $formatted_submission_data;
+	}
+
+	/**
+	 * Get the URL from a URL field value if present.
+	 *
+	 * @param mixed $value The field value.
+	 *
+	 * @return string|null The URL if this is a URL field, null otherwise.
+	 */
+	private static function get_url( $value ) {
+		if ( is_array( $value ) && isset( $value['type'] ) && $value['type'] === 'url' && ! empty( $value['url'] ) ) {
+			$url = $value['url'];
+
+			// Prepend https:// if no protocol is specified.
+			if ( ! preg_match( '#^https?://#i', $url ) ) {
+				$url = 'https://' . $url;
+			}
+
+			// Validate URL - only http and https protocols are allowed for safety.
+			$url = esc_url( $url, array( 'http', 'https' ) );
+			return ! empty( $url ) ? $url : null;
+		}
+		return null;
 	}
 
 	/**
@@ -1531,7 +1555,8 @@ class Contact_Form extends Contact_Form_Shortcode {
 				$html .= '<template data-wp-each--submission="context.formattedSubmissionData">
 					<div class="jetpack_forms_contact-form-success-summary">
 						<div class="field-name" data-wp-text="context.submission.label" data-wp-bind--hidden="!context.submission.label"></div>
-						<div class="field-value" data-wp-text="context.submission.value"></div>
+						<div class="field-value" data-wp-text="context.submission.value" data-wp-bind--hidden="context.submission.url"></div>
+						<a class="field-url" data-wp-bind--href="context.submission.url" data-wp-text="context.submission.value" data-wp-bind--hidden="!context.submission.url" target="_blank" rel="noopener noreferrer"></a>
 						<div class="field-images" data-wp-bind--hidden="!context.submission.images">
 							<template data-wp-each--image="context.submission.images">
 								<figure class="field-image" data-wp-class--is-empty="!context.image">
@@ -1545,10 +1570,17 @@ class Contact_Form extends Contact_Form_Shortcode {
 
 				// For each entry in the submission data array, render a div with the label and value.
 				foreach ( $formatted_submission_data as $submission ) {
-					$html .= '<div data-wp-each-child class="jetpack_forms_contact-form-success-summary">
-						<div class="field-name" data-wp-text="context.submission.label" data-wp-bind--hidden="!context.submission.label">' . $submission['label'] . '</div>
-						<div class="field-value" data-wp-text="context.submission.value">' . $submission['value'] . '</div>
-						<div class="field-images" data-wp-bind--hidden="!context.submission.images">';
+					$has_url = ! empty( $submission['url'] );
+					$html   .= '<div data-wp-each-child class="jetpack_forms_contact-form-success-summary">
+						<div class="field-name" data-wp-text="context.submission.label" data-wp-bind--hidden="!context.submission.label">' . esc_html( $submission['label'] ) . '</div>';
+
+					if ( $has_url ) {
+						$html .= '<a class="field-url" href="' . esc_attr( $submission['url'] ) . '" data-wp-bind--href="context.submission.url" data-wp-text="context.submission.value" target="_blank" rel="noopener noreferrer">' . esc_html( $submission['value'] ) . '</a>';
+					} else {
+						$html .= '<div class="field-value" data-wp-text="context.submission.value" data-wp-bind--hidden="context.submission.url">' . esc_html( $submission['value'] ) . '</div>';
+					}
+
+					$html .= '<div class="field-images" data-wp-bind--hidden="!context.submission.images">';
 
 					if ( ! empty( $submission['images'] ) ) {
 						foreach ( $submission['images'] as $image ) {
@@ -2190,7 +2222,6 @@ class Contact_Form extends Contact_Form_Shortcode {
 	 * Stores feedback.  Sends email.
 	 */
 	public function process_submission() {
-
 		$response = Feedback::from_submission( $_POST, $this ); // phpcs:Ignore WordPress.Security.NonceVerification.Missing
 		$response->set_source( $this->get_source() );
 		$plugin = Contact_Form_Plugin::init();
@@ -3146,6 +3177,11 @@ class Contact_Form extends Contact_Form_Shortcode {
 					$value['choices']
 				)
 			);
+		}
+
+		// For URL fields, extract the URL text value.
+		if ( is_array( $value ) && isset( $value['type'] ) && $value['type'] === 'url' ) {
+			return isset( $value['url'] ) ? $value['url'] : '';
 		}
 
 		// For file upload fields, we want to show the file name and size

--- a/projects/packages/forms/src/contact-form/class-feedback-field.php
+++ b/projects/packages/forms/src/contact-form/class-feedback-field.php
@@ -191,7 +191,7 @@ class Feedback_Field {
 	/**
 	 * Get the value of the field for rendering the post-submission page.
 	 *
-	 * @return string
+	 * @return string|array
 	 */
 	private function get_render_web_value() {
 		if ( $this->is_of_type( 'image-select' ) ) {

--- a/projects/packages/forms/src/contact-form/class-feedback-field.php
+++ b/projects/packages/forms/src/contact-form/class-feedback-field.php
@@ -204,11 +204,14 @@ class Feedback_Field {
 		}
 
 		// For URL fields, return a structured array with the URL for proper link rendering.
+		// 'displayValue' preserves the original user input for display text.
+		// 'url' is used for the href and may have https:// prepended.
 		if ( $this->is_of_type( 'url' ) ) {
 			if ( ! empty( $this->value ) ) {
 				return array(
-					'type' => 'url',
-					'url'  => $this->value,
+					'type'         => 'url',
+					'url'          => $this->value,
+					'displayValue' => $this->value,
 				);
 			}
 		}

--- a/projects/packages/forms/src/contact-form/class-feedback-field.php
+++ b/projects/packages/forms/src/contact-form/class-feedback-field.php
@@ -203,6 +203,16 @@ class Feedback_Field {
 			return $this->get_phone_value_with_flag();
 		}
 
+		// For URL fields, return a structured array with the URL for proper link rendering.
+		if ( $this->is_of_type( 'url' ) ) {
+			if ( ! empty( $this->value ) ) {
+				return array(
+					'type' => 'url',
+					'url'  => $this->value,
+				);
+			}
+		}
+
 		return $this->get_render_default_value();
 	}
 

--- a/projects/packages/forms/src/modules/form/view.js
+++ b/projects/packages/forms/src/modules/form/view.js
@@ -53,6 +53,7 @@ const setSubmissionData = ( data = [] ) => {
 		label: maybeAddColonToLabel( item.label ),
 		value: maybeTransformValue( item.value ),
 		images: getImages( item.value ),
+		url: getUrl( item.value ),
 	} ) );
 };
 
@@ -126,6 +127,11 @@ const maybeTransformValue = value => {
 			.join( ', ' );
 	}
 
+	// For URL fields, extract the URL text value.
+	if ( value?.type === 'url' && value?.url ) {
+		return value.url;
+	}
+
 	// For file upload fields, we want to show the file name and size
 	if ( value?.name && value?.size ) {
 		return value.name + ' (' + value.size + ')';
@@ -137,6 +143,21 @@ const maybeTransformValue = value => {
 const getImages = value => {
 	if ( value?.type === 'image-select' ) {
 		return value.choices.map( choice => choice.image?.src );
+	}
+
+	return null;
+};
+
+const getUrl = value => {
+	if ( value?.type === 'url' && value?.url ) {
+		let url = value.url;
+
+		// Prepend https:// if no protocol is specified.
+		if ( ! /^https?:\/\//i.test( url ) ) {
+			url = 'https://' + url;
+		}
+
+		return url;
 	}
 
 	return null;

--- a/projects/plugins/jetpack/changelog/add-forms-response-url-link
+++ b/projects/plugins/jetpack/changelog/add-forms-response-url-link
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Update E2E test selectors for forms submission, no user-facing changes
+
+

--- a/projects/plugins/jetpack/tests/e2e/specs/forms/submission.test.ts
+++ b/projects/plugins/jetpack/tests/e2e/specs/forms/submission.test.ts
@@ -84,9 +84,21 @@ test.describe( 'Forms: Submission', () => {
 			await expect( successWrapper ).toBeVisible();
 
 			// The form contents should be visible in the success wrapper.
-			await expect( successWrapper.getByText( 'John Doe' ) ).toBeVisible();
-			await expect( successWrapper.getByText( 'john@doe.com' ) ).toBeVisible();
-			await expect( successWrapper.getByText( 'Hello, world!' ) ).toBeVisible();
+			// Use locator with :visible to avoid matching both hidden and visible elements
+			// (the template has both .field-value and .field-url with the same text content).
+			await expect(
+				successWrapper.locator( '.field-value:visible, .field-url:visible' ).getByText( 'John Doe' )
+			).toBeVisible();
+			await expect(
+				successWrapper
+					.locator( '.field-value:visible, .field-url:visible' )
+					.getByText( 'john@doe.com' )
+			).toBeVisible();
+			await expect(
+				successWrapper
+					.locator( '.field-value:visible, .field-url:visible' )
+					.getByText( 'Hello, world!' )
+			).toBeVisible();
 		} );
 	} );
 
@@ -167,9 +179,19 @@ test.describe( 'Forms: Submission', () => {
 			const successWrapper = submittedFormWrapper.locator( '.contact-form-submission' );
 			await expect( successWrapper ).toBeVisible();
 
-			await expect( successWrapper.getByText( 'John Doe' ) ).toBeVisible();
-			await expect( successWrapper.getByText( 'john@doe.com' ) ).toBeVisible();
-			await expect( successWrapper.getByText( 'Hello, world!' ) ).toBeVisible();
+			await expect(
+				successWrapper.locator( '.field-value:visible, .field-url:visible' ).getByText( 'John Doe' )
+			).toBeVisible();
+			await expect(
+				successWrapper
+					.locator( '.field-value:visible, .field-url:visible' )
+					.getByText( 'john@doe.com' )
+			).toBeVisible();
+			await expect(
+				successWrapper
+					.locator( '.field-value:visible, .field-url:visible' )
+					.getByText( 'Hello, world!' )
+			).toBeVisible();
 
 			// Check the other forms were not submitted.
 			const firstForm = previewPage.getByRole( 'form', { name: 'First form' } );


### PR DESCRIPTION
Fixes FORMS-509

## Proposed changes:
* Display URL field values as clickable hyperlinks in the form submission confirmation page
* Automatically prepend `https://` when users enter URLs without a protocol (e.g., `google.com` → `https://google.com`)
* Support both server-rendered pages and AJAX form submissions

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- N/A -->

## Does this pull request change what data or activity we track or use?
No changes to tracking or data usage.

## Testing instructions:

1. Create a new post with a Jetpack Form block
2. Add a URL field to the form (Website field)
3. Publish the post and view it on the frontend
4. Submit the form with different URL formats:
   - With protocol: `https://jetpack.com`
   - Without protocol: `google.com`
5. Verify that in the confirmation page:
   - The URL is displayed as a clickable link
   - URLs without protocol are rendered with `https://` (hover over the link to verify)
   - Clicking the link opens the URL in a new tab
