### PR TITLE
Forms: simplify wp build dashboard styling with components

### DIFF
--- a/projects/packages/forms/changelog/update-forms-wp-build-dashboard-flex-elements
+++ b/projects/packages/forms/changelog/update-forms-wp-build-dashboard-flex-elements
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Simplify wp build dashboard styling with components.

--- a/projects/packages/forms/routes/responses/stage.tsx
+++ b/projects/packages/forms/routes/responses/stage.tsx
@@ -8,7 +8,13 @@ import '@automattic/ui/style.css';
  * WordPress dependencies
  */
 import apiFetch from '@wordpress/api-fetch';
-import { Button } from '@wordpress/components';
+import {
+	Button,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalHStack as HStack,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
 import { store as coreStore, useEntityRecords } from '@wordpress/core-data';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { DataViews } from '@wordpress/dataviews';
@@ -87,12 +93,12 @@ function useFilterOptions() {
  */
 function getTabLabel( label: string, count: number ): JSX.Element {
 	return (
-		<span style={ { display: 'flex', gap: '4px', alignItems: 'center' } }>
+		<HStack as="span" spacing={ 1 } alignment="center">
 			{ label }
 			<Badge intent="default" style={ { backgroundColor: '#f0f0f0' } }>
 				{ count.toString() }
 			</Badge>
-		</span>
+		</HStack>
 	);
 }
 
@@ -267,7 +273,7 @@ function Stage() {
 					const showEmail = item.author_email && item.author_name !== item.author_email;
 					const defaultImage = item.author_name || item.author_email ? 'initials' : 'mp';
 					return (
-						<span style={ { display: 'flex', alignItems: 'center', gap: '12px' } }>
+						<HStack spacing={ 3 } alignment="center">
 							{ item.is_unread && (
 								<span
 									style={ {
@@ -287,15 +293,15 @@ function Stage() {
 								size={ 40 }
 								useHovercard={ false }
 							/>
-							<span style={ { display: 'flex', flexDirection: 'column', gap: '2px' } }>
+							<VStack spacing={ 0.5 }>
 								<span style={ { fontWeight: item.is_unread ? 600 : 400 } }>{ displayName }</span>
 								{ showEmail && (
 									<span style={ { fontSize: '12px', color: '#757575' } }>
 										{ item.author_email }
 									</span>
 								) }
-							</span>
-						</span>
+							</VStack>
+						</HStack>
 					);
 				},
 				getValue: ( { item } ) =>
@@ -386,10 +392,10 @@ function Stage() {
 						return '-';
 					}
 					return (
-						<span style={ { display: 'inline-flex', alignItems: 'center', gap: '4px' } }>
+						<HStack spacing={ 1 } alignment="center">
 							<span aria-hidden="true">🌐</span>
 							{ item.ip }
-						</span>
+						</HStack>
 					);
 				},
 				enableSorting: false,
@@ -1025,10 +1031,10 @@ function Stage() {
 		<Page
 			showSidebarToggle={ false }
 			title={
-				<span style={ { display: 'flex', alignItems: 'center', gap: '8px' } }>
+				<HStack as="span" spacing={ 2 } alignment="center">
 					<JetpackLogo showText={ false } width={ 20 } />
 					{ __( 'Forms', 'jetpack-forms' ) }
-				</span>
+				</HStack>
 			}
 			subTitle={ __( 'View and manage all your form submissions in one place.', 'jetpack-forms' ) }
 			actions={ headerActions }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Follow-up to FORMS-442
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Use HStack/VStack components instead of inline styles in various places in the new dashboard.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Enable new dash `add_filter('jetpack_forms_alpha', '__return_true');`
* Build dash with `cd projects/packages/forms && pnpm run build:wp-build`
* No visual differences in dashboard