### PR TITLE
Public Abilities: prototype for exposing WordPress capabilities to AI agents

### DIFF
--- a/projects/packages/device-detection/changelog/add-public-abilities-api
+++ b/projects/packages/device-detection/changelog/add-public-abilities-api
@@ -1,4 +1,4 @@
 Significance: patch
 Type: added
 
-User_Agent_Info: Add is_automated_client() method for detecting bots, AI assistants, and HTTP libraries.
+Add is_automated_client() method for detecting bots, AI assistants, and HTTP libraries.

--- a/projects/packages/device-detection/changelog/add-public-abilities-api
+++ b/projects/packages/device-detection/changelog/add-public-abilities-api
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+User_Agent_Info: add is_automated_client() method for detecting bots, AI assistants, and HTTP libraries.

--- a/projects/packages/device-detection/changelog/add-public-abilities-api
+++ b/projects/packages/device-detection/changelog/add-public-abilities-api
@@ -1,4 +1,4 @@
 Significance: patch
 Type: added
 
-User_Agent_Info: add is_automated_client() method for detecting bots, AI assistants, and HTTP libraries.
+User_Agent_Info: Add is_automated_client() method for detecting bots, AI assistants, and HTTP libraries.

--- a/projects/packages/device-detection/src/class-user-agent-info.php
+++ b/projects/packages/device-detection/src/class-user-agent-info.php
@@ -2287,4 +2287,61 @@ class User_Agent_Info {
 
 		return false;
 	}
+
+	/**
+	 * Is the current request from an automated client?
+	 *
+	 * Detects bots, crawlers, AI assistants, and HTTP libraries.
+	 * Useful for showing machine-readable hints or alternative content to non-browser clients.
+	 *
+	 * @param string|null $user_agent Optional. User agent string to check. If not provided, uses $_SERVER['HTTP_USER_AGENT'].
+	 *
+	 * @return bool True if the request appears to be automated.
+	 */
+	public static function is_automated_client( $user_agent = null ) {
+		// Check for bots (AI agents, crawlers, etc.)
+		if ( self::is_bot( $user_agent ) ) {
+			return true;
+		}
+
+		// Get user agent for HTTP library check.
+		if ( null === $user_agent ) {
+			if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
+				return false;
+			}
+			$user_agent = wp_unslash( $_SERVER['HTTP_USER_AGENT'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
+		}
+
+		$ua = strtolower( $user_agent );
+
+		// HTTP libraries and tools (not bots, but programmatic clients).
+		$http_clients = array(
+			'axios',
+			'node-fetch',
+			'python-requests',
+			'httpie',
+			'postman',
+			'insomnia',
+			'curl/',        // curl/X.X.X format
+			'wget/',        // wget/X.X.X format
+			'libwww-perl',
+			'java/',        // Java HTTP clients
+			'okhttp',
+			'go-http-client',
+		);
+
+		foreach ( $http_clients as $client ) {
+			if ( false !== strpos( $ua, $client ) ) {
+				return true;
+			}
+		}
+
+		/**
+		 * Filter to customize automated client detection.
+		 *
+		 * @param bool   $is_automated Whether the request is automated.
+		 * @param string $user_agent   The user agent string.
+		 */
+		return apply_filters( 'jetpack_is_automated_client', false, $user_agent );
+	}
 }

--- a/projects/packages/forms/changelog/add-public-abilities-api
+++ b/projects/packages/forms/changelog/add-public-abilities-api
@@ -1,4 +1,4 @@
 Significance: patch
 Type: added
 
-Forms: Add experimental API endpoints for programmatic form discovery and submission.
+Add experimental API endpoints for programmatic form discovery and submission.

--- a/projects/packages/forms/changelog/add-public-abilities-api
+++ b/projects/packages/forms/changelog/add-public-abilities-api
@@ -1,4 +1,4 @@
 Significance: patch
 Type: added
 
-Forms: add experimental API endpoints for programmatic form discovery and submission.
+Forms: Add experimental API endpoints for programmatic form discovery and submission.

--- a/projects/packages/forms/changelog/add-public-abilities-api
+++ b/projects/packages/forms/changelog/add-public-abilities-api
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Forms: add experimental API endpoints for programmatic form discovery and submission.

--- a/projects/packages/forms/src/class-jetpack-forms.php
+++ b/projects/packages/forms/src/class-jetpack-forms.php
@@ -140,6 +140,23 @@ class Jetpack_Forms {
 	}
 
 	/**
+	 * Returns true if AI Forms API submission is enabled.
+	 *
+	 * When enabled, forms will include a data attribute signaling API availability,
+	 * and a REST endpoint will be registered for programmatic form submissions.
+	 *
+	 * @return boolean
+	 */
+	public static function is_ai_forms_enabled() {
+		/**
+		 * Whether to enable AI Forms API submission.
+		 *
+		 * @param bool false Whether AI Forms API should be enabled. Default false.
+		 */
+		return apply_filters( 'jetpack_ai_forms_enabled', false );
+	}
+
+	/**
 	 * Returns true if the Integrations UI should be shown in the Forms dashboard.
 	 *
 	 * @since 6.22.0

--- a/projects/packages/forms/src/class-jetpack-forms.php
+++ b/projects/packages/forms/src/class-jetpack-forms.php
@@ -143,7 +143,8 @@ class Jetpack_Forms {
 	 * Returns true if AI Forms API submission is enabled.
 	 *
 	 * When enabled, forms will include a data attribute signaling API availability,
-	 * and a REST endpoint will be registered for programmatic form submissions.
+	 * a REST endpoint will be registered for programmatic form submissions,
+	 * and automated clients will see a hint about the available API endpoints.
 	 *
 	 * @return boolean
 	 */
@@ -151,7 +152,7 @@ class Jetpack_Forms {
 		/**
 		 * Whether to enable AI Forms API submission.
 		 *
-		 * @param bool false Whether AI Forms API should be enabled. Default false.
+		 * @param bool $enabled Whether AI Forms API should be enabled. Default false.
 		 */
 		return apply_filters( 'jetpack_ai_forms_enabled', false );
 	}

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -30,6 +30,9 @@ use WP_Post;
 // Load the Form_Submission_Error class.
 require_once __DIR__ . '/class-form-submission-error.php';
 
+// Load the Forms_API_Submission class.
+require_once __DIR__ . '/class-forms-api-submission.php';
+
 /**
  * Sets up various actions, filters, post types, post statuses, shortcodes.
  */
@@ -371,6 +374,11 @@ class Contact_Form_Plugin {
 				16,
 				4
 			);
+		}
+
+		// Register AI Forms API submission endpoint.
+		if ( Jetpack_Forms::is_ai_forms_enabled() ) {
+			Forms_API_Submission::init();
 		}
 
 		if ( self::has_editor_feature_flag( 'central-form-management' ) ) {

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -8,7 +8,9 @@
 namespace Automattic\Jetpack\Forms\ContactForm;
 
 use Automattic\Jetpack\Connection\Tokens;
+use Automattic\Jetpack\Device_Detection\User_Agent_Info;
 use Automattic\Jetpack\Forms\Dashboard\Dashboard as Forms_Dashboard;
+use Automattic\Jetpack\Forms\Jetpack_Forms;
 use Automattic\Jetpack\JWT;
 use Automattic\Jetpack\Sync\Settings;
 use Jetpack_Tracks_Event;
@@ -675,8 +677,11 @@ class Contact_Form extends Contact_Form_Shortcode {
 		$jwt_signing_key = hash_hkdf( 'sha256', $secret, 32, 'jetpack-forms-jwt-hmac-v2' );
 		$encryption_key  = hash_hkdf( 'sha256', $secret, 32, 'jetpack-forms-aes-gcm-v2' );
 
-		$attributes   = $this->attributes;
-		$this->source = Feedback_Source::get_current( $attributes );
+		$attributes = $this->attributes;
+		// Only get current source if not already set (allows discovery endpoint to provide source).
+		if ( ! $this->source ) {
+			$this->source = Feedback_Source::get_current( $attributes );
+		}
 
 		// Only encrypt the attributes field as it contains sensitive information
 		// Content, hash, and source are not sensitive and can remain unencrypted
@@ -1208,10 +1213,24 @@ class Contact_Form extends Contact_Form_Shortcode {
 			}
 			$post_title           = $post->post_title ?? '';
 			$form_accessible_name = ! empty( $attributes['formTitle'] ) ? $attributes['formTitle'] : $post_title;
-			$form_aria_label      = isset( $form_accessible_name ) && ! empty( $form_accessible_name ) ? 'aria-label="' . esc_attr( $form_accessible_name ) . '"' : '';
+			$form_aria_label      = ! empty( $form_accessible_name ) ? 'aria-label="' . esc_attr( $form_accessible_name ) . '"' : '';
 
 			if ( $has_submit_button_block ) {
 				$form_classes .= ' wp-block-jetpack-contact-form';
+			}
+
+			$api_forms_attr = '';
+			if ( Jetpack_Forms::is_ai_forms_enabled() && User_Agent_Info::is_automated_client() ) {
+				$api_info       = array(
+					'discover' => '/wp-json/jetpack/v1/forms/discover',
+					'submit'   => '/wp-json/jetpack/v1/forms/submit',
+				);
+				$api_forms_attr = "data-jetpack-form-api='" . esc_attr( wp_json_encode( $api_info, JSON_HEX_TAG | JSON_HEX_AMP ) ) . "'";
+				$discover_url   = home_url( '/wp-json/jetpack/v1/forms/discover?url=' . rawurlencode( $url ) );
+				$r             .= sprintf(
+					'<p class="jetpack-form-api-hint">This form supports programmatic submission. GET %s for the submission token and field details, then POST to /wp-json/jetpack/v1/forms/submit with {"token":"...","fields":{"field-id":"value"}}.</p>',
+					esc_url( $discover_url )
+				);
 			}
 
 			$r .= "<form action='" . esc_url( $url ) . "'
@@ -1224,6 +1243,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 				data-wp-class--is-first-step=\"state.isFirstStep\"
 				data-wp-class--is-last-step=\"state.isLastStep\"
 				data-wp-class--is-ajax-form=\"context.useAjax\"
+				$api_forms_attr
 				novalidate >\n";
 
 			if ( $is_multistep ) { // This makes the "enter" key work in multi-step forms as expected.
@@ -3035,6 +3055,8 @@ class Contact_Form extends Contact_Form_Shortcode {
 				$value->{$key} = $this->addslashes_deep( $data );
 			}
 			return (array) $value;
+		} elseif ( $value === null ) {
+			return '';
 		}
 
 		return addslashes( $value );

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -1222,14 +1222,15 @@ class Contact_Form extends Contact_Form_Shortcode {
 			$api_forms_attr = '';
 			if ( Jetpack_Forms::is_ai_forms_enabled() && User_Agent_Info::is_automated_client() ) {
 				$api_info       = array(
-					'discover' => '/wp-json/jetpack/v1/forms/discover',
-					'submit'   => '/wp-json/jetpack/v1/forms/submit',
+					'discover' => rest_url( 'jetpack/v1/forms/discover' ),
+					'submit'   => rest_url( 'jetpack/v1/forms/submit' ),
 				);
 				$api_forms_attr = "data-jetpack-form-api='" . esc_attr( wp_json_encode( $api_info, JSON_HEX_TAG | JSON_HEX_AMP ) ) . "'";
-				$discover_url   = home_url( '/wp-json/jetpack/v1/forms/discover?url=' . rawurlencode( $url ) );
+				$discover_url   = rest_url( 'jetpack/v1/forms/discover' ) . '?url=' . rawurlencode( $url );
 				$r             .= sprintf(
-					'<p class="jetpack-form-api-hint">This form supports programmatic submission. GET %s for the submission token and field details, then POST to /wp-json/jetpack/v1/forms/submit with {"token":"...","fields":{"field-id":"value"}}.</p>',
-					esc_url( $discover_url )
+					'<p class="jetpack-form-api-hint">This form supports programmatic submission. GET %s for the submission token and field details, then POST to %s with {"token":"...","fields":{"field-id":"value"}}.</p>',
+					esc_url( $discover_url ),
+					esc_url( rest_url( 'jetpack/v1/forms/submit' ) )
 				);
 			}
 

--- a/projects/packages/forms/src/contact-form/class-feedback.php
+++ b/projects/packages/forms/src/contact-form/class-feedback.php
@@ -1257,7 +1257,7 @@ class Feedback {
 	/**
 	 * Save the feedback entry to the database.
 	 *
-	 * @return int
+	 * @return \WP_Post|int The saved post object, or 0 on failure.
 	 */
 	public function save() {
 		$post_id = wp_insert_post(

--- a/projects/packages/forms/src/contact-form/class-forms-api-submission.php
+++ b/projects/packages/forms/src/contact-form/class-forms-api-submission.php
@@ -1,0 +1,321 @@
+<?php
+/**
+ * Forms API Submission class.
+ *
+ * Handles REST API submissions for AI agents and programmatic form submissions.
+ *
+ * @package automattic/jetpack-forms
+ */
+
+namespace Automattic\Jetpack\Forms\ContactForm;
+
+use WP_Error;
+use WP_REST_Request;
+use WP_REST_Response;
+
+/**
+ * REST API endpoint for programmatic form submissions.
+ *
+ * This allows AI agents and other programmatic clients to submit forms
+ * using the JWT token embedded in the form HTML.
+ */
+class Forms_API_Submission {
+
+	/**
+	 * Initialize the API submission handler.
+	 */
+	public static function init() {
+		add_action( 'rest_api_init', array( self::class, 'register_routes' ) );
+	}
+
+	/**
+	 * Register REST API routes.
+	 */
+	public static function register_routes() {
+		register_rest_route(
+			'jetpack/v1',
+			'/forms/submit',
+			array(
+				'methods'             => 'POST',
+				'callback'            => array( self::class, 'handle_submission' ),
+				'permission_callback' => '__return_true',
+				'args'                => array(
+					'token'  => array(
+						'required'          => true,
+						'type'              => 'string',
+						'description'       => __( 'JWT token from form', 'jetpack-forms' ),
+						'sanitize_callback' => 'sanitize_text_field',
+					),
+					'fields' => array(
+						'required'    => true,
+						'type'        => 'object',
+						'description' => __( 'Form field values', 'jetpack-forms' ),
+					),
+				),
+			)
+		);
+
+		register_rest_route(
+			'jetpack/v1',
+			'/forms/discover',
+			array(
+				'methods'             => 'GET',
+				'callback'            => array( self::class, 'handle_discover' ),
+				'permission_callback' => '__return_true',
+				'args'                => array(
+					'url'     => array(
+						'required'          => false,
+						'type'              => 'string',
+						'description'       => __( 'Page URL containing the form', 'jetpack-forms' ),
+						'sanitize_callback' => 'sanitize_text_field',
+					),
+					'post_id' => array(
+						'required'          => false,
+						'type'              => 'integer',
+						'description'       => __( 'Post ID containing the form', 'jetpack-forms' ),
+						'sanitize_callback' => 'absint',
+					),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Handle form discovery request.
+	 *
+	 * Returns form metadata including JWT token and field information.
+	 *
+	 * @param WP_REST_Request $request The REST request.
+	 * @return WP_REST_Response|WP_Error Response with form info, or error.
+	 */
+	public static function handle_discover( WP_REST_Request $request ) {
+		$url     = $request->get_param( 'url' );
+		$post_id = $request->get_param( 'post_id' );
+
+		// Validate URL belongs to this site.
+		if ( $url && ! $post_id ) {
+			$site_host   = wp_parse_url( home_url(), PHP_URL_HOST );
+			$target_host = wp_parse_url( $url, PHP_URL_HOST );
+
+			if ( ! $target_host || strcasecmp( $target_host, $site_host ) !== 0 ) {
+				return new WP_Error(
+					'invalid_url',
+					__( 'URL must belong to this site', 'jetpack-forms' ),
+					array( 'status' => 400 )
+				);
+			}
+
+			$post_id = url_to_postid( $url );
+		}
+
+		if ( ! $post_id ) {
+			return new WP_Error(
+				'invalid_request',
+				__( 'Please provide a valid url or post_id parameter', 'jetpack-forms' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		$post = get_post( $post_id );
+		if ( ! $post ) {
+			return new WP_Error(
+				'not_found',
+				__( 'Post not found', 'jetpack-forms' ),
+				array( 'status' => 404 )
+			);
+		}
+
+		// Parse the post content for contact form blocks.
+		$blocks = parse_blocks( $post->post_content );
+		$forms  = self::find_forms_in_blocks( $blocks, $post );
+
+		if ( empty( $forms ) ) {
+			return new WP_Error(
+				'no_forms',
+				__( 'No forms found on this page', 'jetpack-forms' ),
+				array( 'status' => 404 )
+			);
+		}
+
+		return new WP_REST_Response(
+			array(
+				'submit_endpoint' => '/wp-json/jetpack/v1/forms/submit',
+				'forms'           => $forms,
+			),
+			200
+		);
+	}
+
+	/**
+	 * Recursively find forms in blocks.
+	 *
+	 * @param array   $blocks The blocks to search.
+	 * @param WP_Post $post   The post object.
+	 * @return array Array of form data.
+	 */
+	private static function find_forms_in_blocks( $blocks, $post ) {
+		$forms = array();
+
+		foreach ( $blocks as $block ) {
+			if ( 'jetpack/contact-form' === $block['blockName'] ) {
+				$form_data = self::extract_form_data( $block, $post );
+				if ( $form_data ) {
+					$forms[] = $form_data;
+				}
+			}
+
+			// Check inner blocks recursively.
+			if ( ! empty( $block['innerBlocks'] ) ) {
+				array_push( $forms, ...self::find_forms_in_blocks( $block['innerBlocks'], $post ) );
+			}
+		}
+
+		return $forms;
+	}
+
+	/**
+	 * Extract form data from a contact form block.
+	 *
+	 * @param array   $block The block data.
+	 * @param WP_Post $post  The post object.
+	 * @return array|null Form data or null if extraction fails.
+	 */
+	private static function extract_form_data( $block, $post ) {
+		$attrs = $block['attrs'] ?? array();
+
+		// Generate form instance - this parses content and populates $form->fields with correct IDs.
+		$form = new Contact_Form( $attrs, $block['innerHTML'] ?? '' );
+		// Use post permalink as request_url so JWT matches what the form page generates.
+		$source = new Feedback_Source( $post->ID, $post->post_title, 1, 'single', get_permalink( $post ) );
+		$form->set_source( $source );
+
+		// Extract field info from the form's actual field objects.
+		$fields = array();
+		if ( ! empty( $form->fields ) ) {
+			foreach ( $form->fields as $field_id => $field ) {
+				$fields[] = array(
+					'id'       => $field_id,
+					'type'     => $field->get_attribute( 'type' ),
+					'label'    => $field->get_attribute( 'label' ),
+					'required' => (bool) $field->get_attribute( 'required' ),
+				);
+			}
+		}
+
+		return array(
+			'title'  => $attrs['formTitle'] ?? $post->post_title ?? 'Contact Form',
+			'token'  => $form->get_jwt(),
+			'fields' => $fields,
+		);
+	}
+
+	/**
+	 * Handle a form submission via REST API.
+	 *
+	 * @param WP_REST_Request $request The REST request.
+	 * @return WP_REST_Response|WP_Error Response on success, error on failure.
+	 */
+	public static function handle_submission( WP_REST_Request $request ) {
+		$token  = $request->get_param( 'token' );
+		$fields = $request->get_param( 'fields' );
+
+		// Validate JWT and reconstruct form.
+		try {
+			$form = Contact_Form::get_instance_from_jwt( $token, true );
+		} catch ( \Exception $e ) {
+			return new WP_Error(
+				'invalid_token',
+				$e->getMessage(),
+				array( 'status' => 400 )
+			);
+		}
+
+		if ( ! $form || ! $form->has_verified_jwt ) {
+			return new WP_Error(
+				'invalid_token',
+				__( 'Invalid or expired form token', 'jetpack-forms' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		// Build POST data array matching existing submission format.
+		$post_data = self::build_post_data( $form, $fields );
+
+		// Create Feedback object.
+		$feedback = Feedback::from_submission( $post_data, $form );
+		$feedback->set_source( $form->get_source() );
+
+		// Run Akismet check.
+		$plugin         = Contact_Form_Plugin::init();
+		$akismet_values = $plugin->prepare_for_akismet( $feedback->get_akismet_vars() );
+
+		/**
+		 * Filter to determine if a form submission is spam.
+		 *
+		 * @param bool  $is_spam       Whether the submission is spam.
+		 * @param array $akismet_values Values to check against Akismet.
+		 */
+		$is_spam = apply_filters( 'jetpack_contact_form_is_spam', false, $akismet_values );
+
+		if ( is_wp_error( $is_spam ) ) {
+			return new WP_Error(
+				'spam_rejected',
+				__( 'Submission rejected as spam', 'jetpack-forms' ),
+				array( 'status' => 403 )
+			);
+		}
+
+		// Set status based on spam check.
+		$feedback->set_status( $is_spam ? 'spam' : 'publish' );
+
+		// Save feedback.
+		$feedback_post = $feedback->save();
+
+		if ( ! $feedback_post || is_wp_error( $feedback_post ) ) {
+			return new WP_Error(
+				'save_failed',
+				__( 'Failed to save submission', 'jetpack-forms' ),
+				array( 'status' => 500 )
+			);
+		}
+
+		$post_id = $feedback_post->ID;
+
+		// Store Akismet values for potential later reporting.
+		if ( ! empty( $akismet_values ) ) {
+			update_post_meta( $post_id, '_feedback_akismet_values', $form->addslashes_deep( $akismet_values ) );
+		}
+
+		return new WP_REST_Response(
+			array(
+				'success'     => true,
+				'feedback_id' => $post_id,
+				'message'     => __( 'Your message has been sent', 'jetpack-forms' ),
+			),
+			200
+		);
+	}
+
+	/**
+	 * Build POST data array from REST fields.
+	 *
+	 * Converts REST API field format to the POST format expected by Feedback::from_submission().
+	 *
+	 * @param Contact_Form $form   The form instance.
+	 * @param array        $fields The submitted field values.
+	 * @return array POST data array.
+	 */
+	private static function build_post_data( $form, $fields ) {
+		$post_data = array(
+			'action'            => 'grunion-contact-form',
+			'contact-form-id'   => $form->get_attribute( 'id' ),
+			'contact-form-hash' => $form->hash,
+		);
+
+		foreach ( $fields as $key => $value ) {
+			$post_data[ $key ] = is_array( $value ) ? $value : sanitize_textarea_field( $value );
+		}
+
+		return $post_data;
+	}
+}

--- a/projects/packages/forms/src/contact-form/class-forms-api-submission.php
+++ b/projects/packages/forms/src/contact-form/class-forms-api-submission.php
@@ -158,8 +158,10 @@ class Forms_API_Submission {
 	/**
 	 * Recursively find forms in blocks.
 	 *
-	 * @param array   $blocks The blocks to search.
-	 * @param WP_Post $post   The post object.
+	 * TODO: Replace with centralized forms management API once available.
+	 *
+	 * @param array    $blocks The blocks to search.
+	 * @param \WP_Post $post   The post object.
 	 * @return array Array of form data.
 	 */
 	private static function find_forms_in_blocks( $blocks, $post ) {
@@ -185,8 +187,8 @@ class Forms_API_Submission {
 	/**
 	 * Extract form data from a contact form block.
 	 *
-	 * @param array   $block The block data.
-	 * @param WP_Post $post  The post object.
+	 * @param array    $block The block data.
+	 * @param \WP_Post $post  The post object.
 	 * @return array|null Form data or null if extraction fails.
 	 */
 	private static function extract_form_data( $block, $post ) {

--- a/projects/packages/forms/src/contact-form/class-forms-api-submission.php
+++ b/projects/packages/forms/src/contact-form/class-forms-api-submission.php
@@ -175,7 +175,7 @@ class Forms_API_Submission {
 
 			// Check inner blocks recursively.
 			if ( ! empty( $block['innerBlocks'] ) ) {
-				array_push( $forms, ...self::find_forms_in_blocks( $block['innerBlocks'], $post ) );
+				$forms = array_merge( $forms, self::find_forms_in_blocks( $block['innerBlocks'], $post ) );
 			}
 		}
 
@@ -322,7 +322,7 @@ class Forms_API_Submission {
 		);
 
 		foreach ( $fields as $key => $value ) {
-			$post_data[ $key ] = is_array( $value ) ? $value : sanitize_textarea_field( $value );
+			$post_data[ $key ] = is_array( $value ) ? map_deep( $value, 'sanitize_textarea_field' ) : sanitize_textarea_field( $value );
 		}
 
 		return $post_data;

--- a/projects/packages/forms/src/contact-form/class-forms-api-submission.php
+++ b/projects/packages/forms/src/contact-form/class-forms-api-submission.php
@@ -67,7 +67,7 @@ class Forms_API_Submission {
 						'required'          => false,
 						'type'              => 'string',
 						'description'       => __( 'Page URL containing the form', 'jetpack-forms' ),
-						'sanitize_callback' => 'sanitize_text_field',
+						'sanitize_callback' => 'esc_url_raw',
 					),
 					'post_id' => array(
 						'required'          => false,
@@ -122,6 +122,15 @@ class Forms_API_Submission {
 				'not_found',
 				__( 'Post not found', 'jetpack-forms' ),
 				array( 'status' => 404 )
+			);
+		}
+
+		// Only expose forms from published, publicly accessible posts.
+		if ( $post->post_status !== 'publish' || ! empty( $post->post_password ) ) {
+			return new WP_Error(
+				'not_accessible',
+				__( 'This content is not publicly accessible', 'jetpack-forms' ),
+				array( 'status' => 403 )
 			);
 		}
 

--- a/projects/packages/public-abilities/.gitattributes
+++ b/projects/packages/public-abilities/.gitattributes
@@ -1,0 +1,10 @@
+# Files not needed to be distributed in the package.
+.gitattributes    export-ignore
+.github/          export-ignore
+
+# Files to exclude from the mirror repo, but included in the monorepo.
+.gitignore        production-exclude
+.phpcs.dir.xml    production-exclude
+.phpcsignore      production-exclude
+changelog/**      production-exclude
+tests/**          production-exclude

--- a/projects/packages/public-abilities/.phan/baseline.php
+++ b/projects/packages/public-abilities/.phan/baseline.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * This is an automatically generated baseline for Phan issues.
+ *
+ * Use `jetpack phan --update-baseline` to update this file.
+ */
+return [
+	// Currently, file_suppressions and directory_suppressions are the only supported suppressions
+	'file_suppressions' => [],
+	// 'directory_suppressions' => ['src/directory_name' => ['PhanIssueName1', 'PhanIssueName2']] can be manually added if needed.
+	// (directory_suppressions will currently be ignored by subsequent calls to --save-baseline, but may be preserved in future Phan releases)
+];

--- a/projects/packages/public-abilities/.phan/config.php
+++ b/projects/packages/public-abilities/.phan/config.php
@@ -17,5 +17,9 @@ return make_phan_config(
 			// Reference file for optional device-detection dependency (used via class_exists check).
 			__DIR__ . '/../../device-detection/src/class-user-agent-info.php',
 		),
+		'file_list'       => array(
+			// Stubs for WordPress Ability API functions (proposed feature).
+			__DIR__ . '/stubs.php',
+		),
 	)
 );

--- a/projects/packages/public-abilities/.phan/config.php
+++ b/projects/packages/public-abilities/.phan/config.php
@@ -10,4 +10,12 @@
 // Require base config.
 require __DIR__ . '/../../../../.phan/config.base.php';
 
-return make_phan_config( dirname( __DIR__ ) );
+return make_phan_config(
+	dirname( __DIR__ ),
+	array(
+		'parse_file_list' => array(
+			// Reference file for optional device-detection dependency (used via class_exists check).
+			__DIR__ . '/../../device-detection/src/class-user-agent-info.php',
+		),
+	)
+);

--- a/projects/packages/public-abilities/.phan/config.php
+++ b/projects/packages/public-abilities/.phan/config.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * This configuration will be read and overlaid on top of the
+ * default configuration. Command-line arguments will be applied
+ * after this file is read.
+ *
+ * @package automattic/jetpack-public-abilities
+ */
+
+// Require base config.
+require __DIR__ . '/../../../../.phan/config.base.php';
+
+return make_phan_config( dirname( __DIR__ ) );

--- a/projects/packages/public-abilities/.phan/stubs.php
+++ b/projects/packages/public-abilities/.phan/stubs.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Stubs for WordPress Ability API functions.
+ *
+ * These functions are part of a proposed WordPress Feature API that may be added to core.
+ * This stub file allows Phan to analyze code that depends on these functions.
+ *
+ * @package automattic/jetpack-public-abilities
+ */
+
+// phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- Stub functions don't use parameters.
+
+/**
+ * Check if an ability is registered.
+ *
+ * @param string $name The ability name.
+ * @return bool True if the ability exists, false otherwise.
+ */
+function wp_has_ability( $name ) {
+	return false;
+}
+
+/**
+ * Get a registered ability by name.
+ *
+ * @param string $name The ability name.
+ * @return object|null The ability object or null if not found.
+ */
+function wp_get_ability( $name ) {
+	return null;
+}
+
+/**
+ * Get all registered abilities.
+ *
+ * @return array Array of ability objects.
+ */
+function wp_get_abilities() {
+	return array();
+}

--- a/projects/packages/public-abilities/.phpcs.dir.xml
+++ b/projects/packages/public-abilities/.phpcs.dir.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<ruleset>
+
+	<rule ref="WordPress.WP.I18n">
+		<properties>
+			<property name="text_domain" type="array">
+				<element value="jetpack-public-abilities" />
+			</property>
+		</properties>
+	</rule>
+	<rule ref="Jetpack.Functions.I18n">
+		<properties>
+			<property name="text_domain" value="jetpack-public-abilities" />
+		</properties>
+	</rule>
+
+	<rule ref="WordPress.Utils.I18nTextDomainFixer">
+		<properties>
+			<property name="old_text_domain" type="array" />
+			<property name="new_text_domain" value="jetpack-public-abilities" />
+		</properties>
+	</rule>
+
+</ruleset>

--- a/projects/packages/public-abilities/CHANGELOG.md
+++ b/projects/packages/public-abilities/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## 0.1.0 - unreleased
+
+- Initial release.

--- a/projects/packages/public-abilities/changelog/add-public-abilities-api
+++ b/projects/packages/public-abilities/changelog/add-public-abilities-api
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add new package for exposing WordPress abilities to automated clients.

--- a/projects/packages/public-abilities/changelog/add-public-abilities-api#2
+++ b/projects/packages/public-abilities/changelog/add-public-abilities-api#2
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update package dependencies.

--- a/projects/packages/public-abilities/composer.json
+++ b/projects/packages/public-abilities/composer.json
@@ -8,7 +8,12 @@
 	},
 	"require-dev": {
 		"automattic/jetpack-changelogger": "@dev",
+		"automattic/phpunit-select-config": "@dev",
 		"yoast/phpunit-polyfills": "^1.1.1"
+	},
+	"suggest": {
+		"automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package.",
+		"automattic/jetpack-device-detection": "Enable automated client detection for targeted API hints."
 	},
 	"autoload": {
 		"classmap": [
@@ -20,6 +25,17 @@
 			"phpunit-select-config phpunit.#.xml.dist --colors=always"
 		]
 	},
+	"repositories": [
+		{
+			"type": "path",
+			"url": "../*",
+			"options": {
+				"monorepo": true
+			}
+		}
+	],
+	"minimum-stability": "dev",
+	"prefer-stable": true,
 	"extra": {
 		"autotagger": true,
 		"branch-alias": {

--- a/projects/packages/public-abilities/composer.json
+++ b/projects/packages/public-abilities/composer.json
@@ -4,7 +4,7 @@
 	"type": "jetpack-library",
 	"license": "GPL-2.0-or-later",
 	"require": {
-		"php": ">=7.4"
+		"php": ">=7.2"
 	},
 	"require-dev": {
 		"automattic/jetpack-changelogger": "@dev",

--- a/projects/packages/public-abilities/composer.json
+++ b/projects/packages/public-abilities/composer.json
@@ -7,7 +7,7 @@
 		"php": ">=7.4"
 	},
 	"require-dev": {
-		"automattic/jetpack-changelogger": "^4.2.7",
+		"automattic/jetpack-changelogger": "@dev",
 		"yoast/phpunit-polyfills": "^1.1.1"
 	},
 	"autoload": {

--- a/projects/packages/public-abilities/composer.json
+++ b/projects/packages/public-abilities/composer.json
@@ -1,0 +1,38 @@
+{
+	"name": "automattic/jetpack-public-abilities",
+	"description": "Expose WordPress abilities publicly without authentication",
+	"type": "jetpack-library",
+	"license": "GPL-2.0-or-later",
+	"require": {
+		"php": ">=7.4"
+	},
+	"require-dev": {
+		"automattic/jetpack-changelogger": "^4.2.7",
+		"yoast/phpunit-polyfills": "^1.1.1"
+	},
+	"autoload": {
+		"classmap": [
+			"src/"
+		]
+	},
+	"scripts": {
+		"phpunit": [
+			"phpunit-select-config phpunit.#.xml.dist --colors=always"
+		]
+	},
+	"extra": {
+		"autotagger": true,
+		"branch-alias": {
+			"dev-trunk": "0.1.x-dev"
+		},
+		"changelogger": {
+			"link-template": "https://github.com/Automattic/jetpack-public-abilities/compare/v${old}...v${new}"
+		},
+		"textdomain": "jetpack-public-abilities"
+	},
+	"config": {
+		"allow-plugins": {
+			"automattic/jetpack-autoloader": true
+		}
+	}
+}

--- a/projects/packages/public-abilities/phpunit.11.xml.dist
+++ b/projects/packages/public-abilities/phpunit.11.xml.dist
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+	bootstrap="tests/php/bootstrap.php"
+	cacheDirectory=".phpunit.cache"
+	colors="true"
+	executionOrder="depends"
+	beStrictAboutOutputDuringTests="true"
+	displayDetailsOnPhpunitDeprecations="true"
+	displayDetailsOnTestsThatTriggerDeprecations="true"
+	displayDetailsOnTestsThatTriggerErrors="true"
+	displayDetailsOnTestsThatTriggerNotices="true"
+	displayDetailsOnTestsThatTriggerWarnings="true"
+	failOnDeprecation="true"
+	failOnEmptyTestSuite="true"
+	failOnPhpunitDeprecation="true"
+	failOnNotice="true"
+	failOnRisky="true"
+	failOnWarning="true"
+>
+	<testsuites>
+		<testsuite name="main">
+			<directory suffix="Test.php">tests/php</directory>
+		</testsuite>
+	</testsuites>
+
+	<source>
+		<include>
+			<!-- Better to only include "src" than to add "." and then exclude "tests", "vendor", and so on, as PHPUnit still scans the excluded directories. -->
+			<!-- Add additional lines for any files or directories outside of src/ that need coverage. -->
+			<directory suffix=".php">src</directory>
+		</include>
+	</source>
+	<coverage ignoreDeprecatedCodeUnits="true">
+	</coverage>
+</phpunit>

--- a/projects/packages/public-abilities/phpunit.12.xml.dist
+++ b/projects/packages/public-abilities/phpunit.12.xml.dist
@@ -1,0 +1,1 @@
+phpunit.11.xml.dist

--- a/projects/packages/public-abilities/phpunit.8.xml.dist
+++ b/projects/packages/public-abilities/phpunit.8.xml.dist
@@ -1,0 +1,1 @@
+phpunit.9.xml.dist

--- a/projects/packages/public-abilities/phpunit.9.xml.dist
+++ b/projects/packages/public-abilities/phpunit.9.xml.dist
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.6/phpunit.xsd"
+	bootstrap="tests/php/bootstrap.php"
+	cacheResultFile=".phpunit.cache/test-results"
+	colors="true"
+	executionOrder="depends"
+	beStrictAboutOutputDuringTests="true"
+	failOnRisky="true"
+	failOnWarning="true"
+>
+	<testsuites>
+		<testsuite name="main">
+			<directory suffix="Test.php">tests/php</directory>
+		</testsuite>
+	</testsuites>
+</phpunit>

--- a/projects/packages/public-abilities/src/class-public-abilities.php
+++ b/projects/packages/public-abilities/src/class-public-abilities.php
@@ -40,7 +40,7 @@ class Public_Abilities {
 	 * @param string $name The ability name.
 	 * @return array Modified arguments.
 	 */
-	public static function maybe_open_permissions( $args, $name ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+	public static function maybe_open_permissions( $args, $name ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- $name required by wp_register_ability_args filter signature
 		if ( self::has_public_flag( $args['meta'] ?? array() ) ) {
 			$args['permission_callback'] = '__return_true';
 		}
@@ -180,6 +180,9 @@ class Public_Abilities {
 
 	/**
 	 * Register .well-known/abilities.json rewrite.
+	 *
+	 * Note: After enabling this feature, users may need to visit Settings > Permalinks
+	 * to flush rewrite rules for the .well-known route to work.
 	 */
 	public static function register_well_known_route() {
 		if ( ! self::is_enabled() ) {
@@ -236,7 +239,7 @@ class Public_Abilities {
 	 * @param WP_REST_Request $request The request.
 	 * @return WP_REST_Response
 	 */
-	public static function list_abilities( WP_REST_Request $request ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+	public static function list_abilities( WP_REST_Request $request ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- $request required by REST API callback signature
 		$data = array(
 			'site'      => array(
 				'name'        => get_bloginfo( 'name' ),

--- a/projects/packages/public-abilities/src/class-public-abilities.php
+++ b/projects/packages/public-abilities/src/class-public-abilities.php
@@ -157,7 +157,7 @@ class Public_Abilities {
 					'name'  => array(
 						'required'          => true,
 						'type'              => 'string',
-						'description'       => __( 'The ability name/slug', 'jetpack-public-abilities' ),
+						'description'       => __( 'The ability name in the format "namespace/ability-name".', 'jetpack-public-abilities' ),
 						'sanitize_callback' => 'sanitize_text_field',
 					),
 					'input' => array(

--- a/projects/packages/public-abilities/src/class-public-abilities.php
+++ b/projects/packages/public-abilities/src/class-public-abilities.php
@@ -1,0 +1,372 @@
+<?php
+/**
+ * Public Abilities API.
+ *
+ * Exposes WordPress abilities marked as public without authentication.
+ *
+ * @package automattic/jetpack-public-abilities
+ */
+
+namespace Automattic\Jetpack\PublicAbilities;
+
+use WP_Error;
+use WP_REST_Request;
+use WP_REST_Response;
+
+/**
+ * Provides public discovery and execution of WordPress abilities.
+ */
+class Public_Abilities {
+
+	/**
+	 * Initialize the public abilities feature.
+	 */
+	public static function init() {
+		// Open permissions for abilities marked as public - must run before abilities are registered.
+		add_filter( 'wp_register_ability_args', array( self::class, 'maybe_open_permissions' ), 10, 2 );
+
+		add_action( 'rest_api_init', array( self::class, 'register_routes' ) );
+		add_action( 'init', array( self::class, 'register_well_known_route' ) );
+
+		// Add discovery hints for automated clients.
+		add_action( 'send_headers', array( self::class, 'add_abilities_header' ) );
+		add_action( 'wp_footer', array( self::class, 'add_abilities_footer_hint' ) );
+	}
+
+	/**
+	 * Open permissions for abilities marked as public.
+	 *
+	 * @param array  $args The ability arguments.
+	 * @param string $name The ability name.
+	 * @return array Modified arguments.
+	 */
+	public static function maybe_open_permissions( $args, $name ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		if ( self::has_public_flag( $args['meta'] ?? array() ) ) {
+			$args['permission_callback'] = '__return_true';
+		}
+
+		return $args;
+	}
+
+	/**
+	 * Add HTTP header advertising abilities endpoint.
+	 */
+	public static function add_abilities_header() {
+		if ( ! self::is_enabled() ) {
+			return;
+		}
+
+		// Only add if there are public abilities.
+		if ( empty( self::get_public_abilities() ) ) {
+			return;
+		}
+
+		header( 'X-Abilities-Endpoint: ' . rest_url( 'jetpack/v1/abilities' ) );
+	}
+
+	/**
+	 * Add footer hint for automated clients.
+	 */
+	public static function add_abilities_footer_hint() {
+		if ( ! self::is_enabled() ) {
+			return;
+		}
+
+		// Only show to automated clients.
+		if ( ! self::is_automated_request() ) {
+			return;
+		}
+
+		// Only add if there are public abilities.
+		$abilities = self::get_public_abilities();
+		if ( empty( $abilities ) ) {
+			return;
+		}
+
+		$endpoint = rest_url( 'jetpack/v1/abilities' );
+		$count    = count( $abilities );
+
+		printf(
+			'<p class="jetpack-abilities-hint">This site exposes %d public %s. GET %s for available actions and their endpoints.</p>',
+			(int) $count,
+			$count === 1 ? 'ability' : 'abilities',
+			esc_url( $endpoint )
+		);
+	}
+
+	/**
+	 * Check if current request is from an automated client.
+	 *
+	 * @return bool
+	 */
+	private static function is_automated_request() {
+		if ( class_exists( '\Automattic\Jetpack\Device_Detection\User_Agent_Info' ) ) {
+			return \Automattic\Jetpack\Device_Detection\User_Agent_Info::is_automated_client();
+		}
+
+		// Fallback if device-detection package not available.
+		if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
+			return false;
+		}
+
+		$user_agent = strtolower( sanitize_text_field( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ) ) );
+		$patterns   = array( 'curl', 'wget', 'python', 'axios', 'node-fetch', 'chatgpt', 'claude', 'gptbot' );
+
+		foreach ( $patterns as $pattern ) {
+			if ( str_contains( $user_agent, $pattern ) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Check if the public abilities feature is enabled.
+	 *
+	 * @return bool
+	 */
+	public static function is_enabled() {
+		/**
+		 * Filter to enable/disable the public abilities feature.
+		 *
+		 * @param bool $enabled Whether the feature is enabled. Default false.
+		 */
+		return apply_filters( 'jetpack_public_abilities_enabled', false );
+	}
+
+	/**
+	 * Register REST API routes.
+	 */
+	public static function register_routes() {
+		if ( ! self::is_enabled() ) {
+			return;
+		}
+
+		// List public abilities.
+		register_rest_route(
+			'jetpack/v1',
+			'/abilities',
+			array(
+				'methods'             => 'GET',
+				'callback'            => array( self::class, 'list_abilities' ),
+				'permission_callback' => '__return_true',
+			)
+		);
+
+		// Execute a public ability.
+		register_rest_route(
+			'jetpack/v1',
+			'/abilities/(?P<name>[a-zA-Z0-9_\-\/]+)/run',
+			array(
+				'methods'             => 'POST',
+				'callback'            => array( self::class, 'run_ability' ),
+				'permission_callback' => '__return_true',
+				'args'                => array(
+					'name'  => array(
+						'required'          => true,
+						'type'              => 'string',
+						'description'       => __( 'The ability name/slug', 'jetpack-public-abilities' ),
+						'sanitize_callback' => 'sanitize_text_field',
+					),
+					'input' => array(
+						'required'    => false,
+						'description' => __( 'Input data for the ability', 'jetpack-public-abilities' ),
+					),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Register .well-known/abilities.json rewrite.
+	 */
+	public static function register_well_known_route() {
+		if ( ! self::is_enabled() ) {
+			return;
+		}
+
+		add_rewrite_rule(
+			'^\.well-known/abilities\.json$',
+			'index.php?jetpack_abilities_discovery=1',
+			'top'
+		);
+
+		add_filter( 'query_vars', array( self::class, 'add_query_vars' ) );
+		add_action( 'template_redirect', array( self::class, 'handle_well_known' ) );
+	}
+
+	/**
+	 * Add query vars for .well-known route.
+	 *
+	 * @param array $vars Query vars.
+	 * @return array
+	 */
+	public static function add_query_vars( $vars ) {
+		$vars[] = 'jetpack_abilities_discovery';
+		return $vars;
+	}
+
+	/**
+	 * Handle .well-known/abilities.json request.
+	 */
+	public static function handle_well_known() {
+		if ( ! get_query_var( 'jetpack_abilities_discovery' ) ) {
+			return;
+		}
+
+		// Allow cross-origin requests for discovery.
+		header( 'Access-Control-Allow-Origin: *' );
+
+		$response = array(
+			'schema_version' => '1.0',
+			'name'           => get_bloginfo( 'name' ),
+			'description'    => get_bloginfo( 'description' ),
+			'url'            => home_url(),
+			'api_base'       => rest_url( 'jetpack/v1/abilities' ),
+			'abilities'      => array_map( array( self::class, 'format_ability_data' ), self::get_public_abilities() ),
+		);
+
+		wp_send_json( $response, null, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES );
+	}
+
+	/**
+	 * List public abilities.
+	 *
+	 * @param WP_REST_Request $request The request.
+	 * @return WP_REST_Response
+	 */
+	public static function list_abilities( WP_REST_Request $request ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		$data = array(
+			'site'      => array(
+				'name'        => get_bloginfo( 'name' ),
+				'description' => get_bloginfo( 'description' ),
+				'url'         => home_url(),
+			),
+			'abilities' => array_map( array( self::class, 'format_ability_data' ), self::get_public_abilities() ),
+		);
+
+		return new WP_REST_Response( $data, 200 );
+	}
+
+	/**
+	 * Run a public ability.
+	 *
+	 * @param WP_REST_Request $request The request.
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public static function run_ability( WP_REST_Request $request ) {
+		$name  = $request->get_param( 'name' );
+		$input = $request->get_param( 'input' );
+
+		// Check if ability exists.
+		if ( ! function_exists( 'wp_has_ability' ) || ! wp_has_ability( $name ) ) {
+			return new WP_Error(
+				'ability_not_found',
+				__( 'Ability not found', 'jetpack-public-abilities' ),
+				array( 'status' => 404 )
+			);
+		}
+
+		$ability = wp_get_ability( $name );
+
+		// Check if ability is public.
+		if ( ! self::is_ability_public( $ability ) ) {
+			return new WP_Error(
+				'ability_not_public',
+				__( 'This ability is not available for public access', 'jetpack-public-abilities' ),
+				array( 'status' => 403 )
+			);
+		}
+
+		// Execute the ability.
+		$result = $ability->execute( $input );
+
+		if ( is_wp_error( $result ) ) {
+			return new WP_Error(
+				'ability_execution_failed',
+				$result->get_error_message(),
+				array( 'status' => 500 )
+			);
+		}
+
+		return new WP_REST_Response(
+			array(
+				'success' => true,
+				'ability' => $name,
+				'result'  => $result,
+			),
+			200
+		);
+	}
+
+	/**
+	 * Get all public abilities.
+	 *
+	 * @return array Array of WP_Ability objects marked as public.
+	 */
+	private static function get_public_abilities() {
+		if ( ! function_exists( 'wp_get_abilities' ) ) {
+			return array();
+		}
+
+		$all_abilities = wp_get_abilities();
+		$public        = array();
+
+		foreach ( $all_abilities as $ability ) {
+			if ( self::is_ability_public( $ability ) ) {
+				$public[] = $ability;
+			}
+		}
+
+		return $public;
+	}
+
+	/**
+	 * Check if an ability is marked as public.
+	 *
+	 * @param object $ability The ability object.
+	 * @return bool
+	 */
+	private static function is_ability_public( $ability ) {
+		if ( self::has_public_flag( $ability->get_meta() ) ) {
+			return true;
+		}
+
+		/**
+		 * Filter to determine if a specific ability should be public.
+		 *
+		 * @param bool   $is_public Whether the ability is public.
+		 * @param object $ability   The ability object.
+		 */
+		return apply_filters( 'jetpack_is_ability_public', false, $ability );
+	}
+
+	/**
+	 * Check if meta array has a public flag set.
+	 *
+	 * @param array $meta The meta array to check.
+	 * @return bool
+	 */
+	private static function has_public_flag( $meta ) {
+		return ! empty( $meta['mcp']['public'] ) || ! empty( $meta['public'] );
+	}
+
+	/**
+	 * Format ability object into array for API response.
+	 *
+	 * @param object $ability The ability object.
+	 * @return array Formatted ability data.
+	 */
+	private static function format_ability_data( $ability ) {
+		return array(
+			'name'        => $ability->get_name(),
+			'label'       => $ability->get_label(),
+			'description' => $ability->get_description(),
+			'category'    => $ability->get_category(),
+			'endpoint'    => rest_url( 'jetpack/v1/abilities/' . $ability->get_name() . '/run' ),
+			'input'       => $ability->get_input_schema(),
+			'annotations' => $ability->get_meta()['annotations'] ?? array(),
+		);
+	}
+}

--- a/projects/packages/public-abilities/src/class-public-abilities.php
+++ b/projects/packages/public-abilities/src/class-public-abilities.php
@@ -29,7 +29,7 @@ class Public_Abilities {
 		add_action( 'init', array( self::class, 'register_well_known_route' ) );
 
 		// Add discovery hints for automated clients.
-		add_action( 'send_headers', array( self::class, 'add_abilities_header' ) );
+		add_filter( 'wp_headers', array( self::class, 'add_abilities_header' ) );
 		add_action( 'wp_footer', array( self::class, 'add_abilities_footer_hint' ) );
 	}
 
@@ -50,18 +50,22 @@ class Public_Abilities {
 
 	/**
 	 * Add HTTP header advertising abilities endpoint.
+	 *
+	 * @param array $headers The HTTP headers array.
+	 * @return array Modified headers array.
 	 */
-	public static function add_abilities_header() {
+	public static function add_abilities_header( $headers ) {
 		if ( ! self::is_enabled() ) {
-			return;
+			return $headers;
 		}
 
 		// Only add if there are public abilities.
 		if ( empty( self::get_public_abilities() ) ) {
-			return;
+			return $headers;
 		}
 
-		header( 'X-Abilities-Endpoint: ' . rest_url( 'jetpack/v1/abilities' ) );
+		$headers['X-Abilities-Endpoint'] = rest_url( 'jetpack/v1/abilities' );
+		return $headers;
 	}
 
 	/**

--- a/projects/packages/public-abilities/src/class-public-abilities.php
+++ b/projects/packages/public-abilities/src/class-public-abilities.php
@@ -104,20 +104,7 @@ class Public_Abilities {
 			return \Automattic\Jetpack\Device_Detection\User_Agent_Info::is_automated_client();
 		}
 
-		// Fallback if device-detection package not available.
-		if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
-			return false;
-		}
-
-		$user_agent = strtolower( sanitize_text_field( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ) ) );
-		$patterns   = array( 'curl', 'wget', 'python', 'axios', 'node-fetch', 'chatgpt', 'claude', 'gptbot' );
-
-		foreach ( $patterns as $pattern ) {
-			if ( str_contains( $user_agent, $pattern ) ) {
-				return true;
-			}
-		}
-
+		// Fallback: return false if device-detection package not available.
 		return false;
 	}
 

--- a/projects/packages/public-abilities/src/class-public-abilities.php
+++ b/projects/packages/public-abilities/src/class-public-abilities.php
@@ -230,7 +230,7 @@ class Public_Abilities {
 			'abilities'      => array_map( array( self::class, 'format_ability_data' ), self::get_public_abilities() ),
 		);
 
-		wp_send_json( $response, null, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES );
+		wp_send_json( $response, 200, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES );
 	}
 
 	/**

--- a/projects/packages/public-abilities/src/class-public-abilities.php
+++ b/projects/packages/public-abilities/src/class-public-abilities.php
@@ -92,7 +92,7 @@ class Public_Abilities {
 
 		printf(
 			'<p class="jetpack-abilities-hint">This site exposes %d public %s. GET %s for available actions and their endpoints.</p>',
-			(int) $count,
+			absint( $count ),
 			$count === 1 ? 'ability' : 'abilities',
 			esc_url( $endpoint )
 		);

--- a/projects/packages/public-abilities/tests/.phpcs.dir.xml
+++ b/projects/packages/public-abilities/tests/.phpcs.dir.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<ruleset>
+	<rule ref="Jetpack-Tests" />
+</ruleset>

--- a/projects/packages/public-abilities/tests/php/bootstrap.php
+++ b/projects/packages/public-abilities/tests/php/bootstrap.php
@@ -1,0 +1,11 @@
+<?php
+/**
+ * Bootstrap.
+ *
+ * @package automattic/jetpack-public-abilities
+ */
+
+/**
+ * Include the composer autoloader.
+ */
+require_once __DIR__ . '/../../vendor/autoload.php';


### PR DESCRIPTION
## Summary

Prototype exploring how WordPress sites can expose capabilities to AI agents and automated clients.

**The idea:** When an AI assistant visits a WordPress site on behalf of a user, it should be able to discover what actions are available and execute them programmatically - like submitting a contact form or searching products.

```mermaid
sequenceDiagram
    participant User
    participant AI as AI Assistant
    participant WP as WordPress Site

    User->>AI: "Contact this business for me"
    AI->>WP: GET /contact-page/
    WP-->>AI: Page + hint: "This form supports API submission"
    AI->>WP: GET /wp-json/jetpack/v1/forms/discover?url=...
    WP-->>AI: {token, fields: [{id, label, type}]}
    AI->>User: "I found a contact form. What message?"
    User->>AI: "Ask about catering for 50 people"
    AI->>WP: POST /wp-json/jetpack/v1/forms/submit {token, fields}
    WP-->>AI: {success: true}
    AI->>User: "Done! Message sent."
```

## What's included

| Component | Purpose |
|-----------|---------|
| `public-abilities` package | Expose WordPress abilities via REST API |
| `User_Agent_Info::is_automated_client()` | Detect AI/bot/HTTP client requests |
| Forms API endpoints | `/forms/discover` and `/forms/submit` |
| Discovery hints | HTTP header + footer text for agents |

## Use cases to explore

- **Contact forms** - AI submits inquiries on behalf of users
- **Product search** - "Find me a blue widget under $50"
- **Reservations** - "Book a table for 4 on Saturday"
- **Support** - "Check my order status"

## How it works

1. Site owner enables feature and marks specific abilities as public
2. Automated clients see discovery hints (header/footer)
3. Clients call `/wp-json/jetpack/v1/abilities` to list available actions
4. Each ability has an execution endpoint with defined input schema

## Open questions

- Per-form opt-in vs site-wide setting?
- Rate limiting strategy beyond Akismet?
- Should this align with MCP (Model Context Protocol)?
- WordPress core proposal for `is_automated_client()`?

## Test plan

Add to `tools/docker/mu-plugins/0-sandbox.php`:

```php
// Enable feature flags
add_filter( 'jetpack_ai_forms_enabled', '__return_true' );
add_filter( 'jetpack_public_abilities_enabled', '__return_true' );

// Load public-abilities package (not autoloaded yet)
$monorepo_path = apply_filters( 'jetpack_monorepo_path', '/usr/local/src/jetpack-monorepo/' );
require_once $monorepo_path . 'projects/packages/public-abilities/src/class-public-abilities.php';
add_action( 'plugins_loaded', array( \Automattic\Jetpack\PublicAbilities\Public_Abilities::class, 'init' ) );

// Optional: mark specific abilities as public (for /abilities endpoint)
add_filter( 'wp_register_ability_args', function( $args, $name ) {
    if ( $name === 'core/get-site-info' ) {
        $args['meta']['mcp']['public'] = true;
    }
    return $args;
}, 10, 2 );
```

Create a page with a Jetpack Form block (or use an existing contact page), then test:

```bash
# Check abilities header
curl -I http://localhost/ | grep X-Abilities

# List public abilities
curl http://localhost/wp-json/jetpack/v1/abilities

# Discover form (on a page with a contact form)
curl "http://localhost/wp-json/jetpack/v1/forms/discover?url=http://localhost/contact/"

# Submit form
curl -X POST http://localhost/wp-json/jetpack/v1/forms/submit \
  -H "Content-Type: application/json" \
  -d '{"token":"<from-discover>", "fields":{"field-id":"value"}}'
```

- [ ] Hints appear for curl/bot user agents
- [ ] Regular browsers don't see hints
- [ ] Form discovery returns token and field schema
- [ ] Form submission creates feedback entry

### Real-world test: AI discovers and uses capabilities

Ask Claude (or another AI assistant with web access) to simply read a page:

> "Check out https://example.com/contact/ - I might want to work with them"

Without any prompting about forms or APIs, Claude should:

1. Fetch the page and notice the hint about available capabilities
2. Report back: *"This site has a contact form I can submit on your behalf. Want me to reach out?"*
3. If you say yes, Claude discovers the form schema and submits programmatically

The surprise: **Claude autonomously discovers what actions are possible** - no instructions needed about the API. The site advertises its capabilities, and AI assistants naturally find and use them.
