### PR TITLE
Forms: update Create Form if CFM flag is on

### DIFF
--- a/projects/packages/forms/changelog/add-dashboard-link-to-form-post
+++ b/projects/packages/forms/changelog/add-dashboard-link-to-form-post
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Forms: update Create Form if CFM flag is on.

--- a/projects/packages/forms/src/dashboard/hooks/use-create-form.ts
+++ b/projects/packages/forms/src/dashboard/hooks/use-create-form.ts
@@ -7,6 +7,22 @@ import { useCallback } from '@wordpress/element';
  */
 import useConfigValue from '../../hooks/use-config-value.ts';
 
+const openFormLinkInNewTab = ( url: string ) => {
+	/*
+	 * We are using a temporary link click to open the page. Using window.open() does not work reliably
+	 * due to Safari's popup blocker, especially after async work.
+	 */
+	const link = document.createElement( 'a' );
+	link.setAttribute( 'href', url );
+	link.setAttribute( 'target', '_blank' );
+	link.setAttribute( 'rel', 'noopener noreferrer' );
+	link.style.display = 'none';
+
+	document.body.appendChild( link );
+	link.click();
+	document.body.removeChild( link );
+};
+
 type ClickHandlerProps = {
 	formPattern?: string;
 	showPatterns?: boolean;
@@ -25,6 +41,7 @@ type CreateFormReturn = {
  */
 export default function useCreateForm(): CreateFormReturn {
 	const newFormNonce = useConfigValue( 'newFormNonce' );
+	const isCentralFormManagementEnabled = useConfigValue( 'isCentralFormManagementEnabled' );
 	const createForm = useCallback(
 		async ( formPattern: string ) => {
 			const data = new FormData();
@@ -56,35 +73,30 @@ export default function useCreateForm(): CreateFormReturn {
 	const openNewForm = useCallback(
 		async ( { formPattern, showPatterns, analyticsEvent }: ClickHandlerProps ) => {
 			try {
+				// When centralized form management is enabled, create a jetpack_form post via wp-admin.
+				// Keep existing behavior when disabled (or not yet loaded).
+				if ( isCentralFormManagementEnabled === true ) {
+					analyticsEvent?.( { formPattern: formPattern ?? '' } );
+					const url = 'post-new.php?post_type=jetpack_form';
+					openFormLinkInNewTab( url );
+					return;
+				}
+
 				const postUrl = await createForm( formPattern );
 
 				if ( postUrl ) {
 					analyticsEvent?.( { formPattern } );
 
-					/*
-					 * We are using a temporary link click to open the new form page, as it is created in the backend and we need
-					 * to wait for it before we have the post URL. Using window.open() does not work due to Safari's popup blocker.
-					 */
 					const url = `${ postUrl }${
 						showPatterns && ! formPattern ? '&showJetpackFormsPatterns' : ''
 					}`;
-
-					const link = document.createElement( 'a' );
-
-					link.setAttribute( 'href', url );
-					link.setAttribute( 'target', '_blank' );
-					link.setAttribute( 'rel', 'noopener noreferrer' );
-					link.style.display = 'none';
-
-					document.body.appendChild( link );
-					link.click();
-					document.body.removeChild( link );
+					openFormLinkInNewTab( url );
 				}
 			} catch ( error ) {
 				console.error( error.message ); // eslint-disable-line no-console
 			}
 		},
-		[ createForm ]
+		[ createForm, isCentralFormManagementEnabled ]
 	);
 
 	return { createForm, openNewForm };


### PR DESCRIPTION
## Proposed changes:

When the 'centralized-form-management' flag is on, we update the Create Form button to create a new jetpack_form post type rather than create a normal page and add a form block. Since we already have a useCreateForm hook, I made the change there to keep it centralized. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None. 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No. 

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Add this feature flag to your test site. 

```
add_filter( 'jetpack_block_editor_feature_flags', 'eb_register_feature' );
function eb_register_feature( $flags ) {
    $flags['central-form-management'] = true;
    return $flags;
}
```

Test form creation:
* Go to Jetpack > Forms
* Click the Create Form button and confirm it creates a new jetpack_form post type

Test for now regression:
* Remove feature flag, click the Create Form button, and confirm it continues to create a normal page with a form block

