### PR TITLE
Subscriptions Block: fix excerpt filter

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-subscriptions-block-excerpt
+++ b/projects/plugins/jetpack/changelog/fix-subscriptions-block-excerpt
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Subscriptions Block: make excerpt filter more broad

--- a/projects/plugins/jetpack/changelog/fix-subscriptions-block-excerpt
+++ b/projects/plugins/jetpack/changelog/fix-subscriptions-block-excerpt
@@ -1,4 +1,4 @@
 Significance: patch
 Type: other
 
-Subscriptions Block: make excerpt filter more broad
+Subscriptions Block: make excerpt filter more broad.

--- a/projects/plugins/jetpack/changelog/fix-subscriptions-block-excerpt
+++ b/projects/plugins/jetpack/changelog/fix-subscriptions-block-excerpt
@@ -1,4 +1,4 @@
 Significance: patch
-Type: other
+Type: bugfix
 
 Subscriptions Block: make excerpt filter more broad.

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -993,10 +993,10 @@ function render_email( $block_content, array $parsed_block, $rendering_context )
 function jetpack_filter_excerpt_for_newsletter( $excerpt, $post = null ) {
 	// The blogmagazine theme is overriding WP core `get_the_excerpt` filter and only passing the excerpt
 	// TODO: Until this is fixed, return the excerpt without gating. See https://github.com/Automattic/jetpack/pull/28102#issuecomment-1369161116
-	if ( $post instanceof \WP_Post && str_contains( $post->post_content, '<!-- wp:jetpack/subscriptions -->' ) ) {
+	if ( $post instanceof \WP_Post && str_contains( $post->post_content, '<!-- wp:jetpack/subscriptions ' ) ) {
 		$excerpt .= sprintf(
 			// translators: %s is the permalink url to the current post.
-			__( "<p><a href='%s'>View post</a> to subscribe to site newsletter.</p>", 'jetpack' ),
+			__( "<br/><br/><p><a href='%s'>View post</a> to subscribe to site newsletter.</p>", 'jetpack' ),
 			get_post_permalink()
 		);
 	}

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -993,7 +993,7 @@ function render_email( $block_content, array $parsed_block, $rendering_context )
 function jetpack_filter_excerpt_for_newsletter( $excerpt, $post = null ) {
 	// The blogmagazine theme is overriding WP core `get_the_excerpt` filter and only passing the excerpt
 	// TODO: Until this is fixed, return the excerpt without gating. See https://github.com/Automattic/jetpack/pull/28102#issuecomment-1369161116
-	if ( $post instanceof \WP_Post && str_contains( $post->post_content, '<!-- wp:jetpack/subscriptions ' ) ) {
+	if ( $post instanceof \WP_Post && has_block( 'jetpack/subscriptions', $post ) ) {
 		$excerpt .= '<br/><br/>';
 		$excerpt .= sprintf(
 			// translators: %s is the permalink url to the current post.

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -994,9 +994,10 @@ function jetpack_filter_excerpt_for_newsletter( $excerpt, $post = null ) {
 	// The blogmagazine theme is overriding WP core `get_the_excerpt` filter and only passing the excerpt
 	// TODO: Until this is fixed, return the excerpt without gating. See https://github.com/Automattic/jetpack/pull/28102#issuecomment-1369161116
 	if ( $post instanceof \WP_Post && str_contains( $post->post_content, '<!-- wp:jetpack/subscriptions ' ) ) {
+		$excerpt .= '<br/><br/>';
 		$excerpt .= sprintf(
 			// translators: %s is the permalink url to the current post.
-			__( "<br/><br/><p><a href='%s'>View post</a> to subscribe to site newsletter.</p>", 'jetpack' ),
+			__( "<p><a href='%s'>View post</a> to subscribe to the site's newsletter.</p>", 'jetpack' ),
 			get_post_permalink()
 		);
 	}


### PR DESCRIPTION
Related to 200046-ghe-Automattic/wpcom

## Proposed changes:

* Update `str_contains()` check for the subscriptions block more vague.
* Prepend a couple line breaks

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [X] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
The current check for the Subscriptions block is sometimes failing since it can be a self-closing tag when added from Gutenberg. This means the code in the content is `<!-- wp:jetpack/subscriptions /-->` instead of `<!-- wp:jetpack/subscriptions -->`. Both are valid blocks and render the same, but the former is not triggering the excerpt appending.

As for the additional line breaks, these are irrelevant when the excerpt is run through `wpautop` (which the excerpt is by default). This addresses the formatting when `wpautop` is _not_ enabled. The extra line break that is typically added gets left out and the text is very close to the excerpt.

<table>
<tr>
 <td><strong>With wpautop
 <td><strong>Without wpautop
<tr>
 <td><img height="506" alt="Screen Shot 2026-01-14 at 19 21 36" src="https://github.com/user-attachments/assets/371926f2-3b06-4a95-b239-a2f04fbc3864" />
 <td><img height="538" alt="Screen Shot 2026-01-14 at 19 24 05" src="https://github.com/user-attachments/assets/c8d36a24-c736-46db-8270-ba357d8c2599" />
</table>

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Go to your Newsletter settings and set it to show `Excerpt`.
2. Create a post with and add a subscriptions block from the block inserter.
3. Set an excerpt or add some extra content to the post
4. Preview email for the post and look for `View post to subscribe to site newsletter.`
5. You can also add the non-closed tag `<!-- wp:jetpack/subscriptions -->` instead of the originally added block and check again.