### PR TITLE
Make Help Center enqueueing filterable

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/make-help-center-filterable
+++ b/projects/packages/jetpack-mu-wpcom/changelog/make-help-center-filterable
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Help Center: allow filtering whether the Help Center should be enqueued.

--- a/projects/packages/jetpack-mu-wpcom/changelog/make-help-center-filterable
+++ b/projects/packages/jetpack-mu-wpcom/changelog/make-help-center-filterable
@@ -1,4 +1,4 @@
 Significance: patch
 Type: added
 
-Help Center: allow filtering whether the Help Center should be enqueued.
+Help Center: Allow filtering whether the Help Center should be enqueued.

--- a/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-help-center.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-help-center.php
@@ -577,6 +577,15 @@ class Help_Center {
 	 * Enqueue Help Center assets for the customizer.
 	 */
 	public function enqueue_customizer_scripts() {
+		/**
+		 * Allow filtering whether the help center should be enqueued.
+		 */
+		$should_show_help_center = apply_filters( 'jetpack_should_enqueue_help_center', true );
+
+		if ( ! $should_show_help_center ) {
+			return;
+		}
+
 		if ( $this->is_jetpack_disconnected() ) {
 			$variant = 'wp-admin-disconnected';
 		} else {
@@ -613,6 +622,15 @@ class Help_Center {
 	 * Add icon to WP-ADMIN admin bar.
 	 */
 	public function enqueue_wp_admin_scripts() {
+		/**
+		 * Allow filtering whether the help center should be enqueued.
+		 */
+		$should_show_help_center = apply_filters( 'jetpack_should_enqueue_help_center', true );
+
+		if ( ! $should_show_help_center ) {
+			return;
+		}
+
 		if ( $this->is_wc_admin_home_page() ) {
 			return;
 		}
@@ -622,15 +640,6 @@ class Help_Center {
 
 		$can_edit_posts = current_user_can( 'edit_posts' ) && is_user_member_of_blog();
 		$is_p2          = str_contains( get_stylesheet(), 'pub/p2' ) || function_exists( '\WPForTeams\is_wpforteams_site' ) && is_wpforteams_site( get_current_blog_id() );
-
-		/**
-		 * Allow filtering whether the help center should be enqueued.
-		 */
-		$should_show_help_center = apply_filters( 'jetpack_should_enqueue_help_center', true );
-
-		if ( ! $should_show_help_center ) {
-			return;
-		}
 
 		// We will show the help center icon in the admin bar when;
 		// 1. On wp-admin

--- a/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-help-center.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-help-center.php
@@ -623,6 +623,15 @@ class Help_Center {
 		$can_edit_posts = current_user_can( 'edit_posts' ) && is_user_member_of_blog();
 		$is_p2          = str_contains( get_stylesheet(), 'pub/p2' ) || function_exists( '\WPForTeams\is_wpforteams_site' ) && is_wpforteams_site( get_current_blog_id() );
 
+		/**
+		 * Allow filtering whether the help center should be enqueued.
+		 */
+		$should_show_help_center = apply_filters( 'jetpack_should_enqueue_help_center', true );
+
+		if ( ! $should_show_help_center ) {
+			return;
+		}
+
 		// We will show the help center icon in the admin bar when;
 		// 1. On wp-admin
 		// 2. On the front end of the site if the current user can edit posts


### PR DESCRIPTION
## Summary:

This PR adds a hook that allows sites to completely opt out of enqueueing the Help Center UI and assets.
By default, behavior is unchanged; consumers can now use a filter to disable the Help Center when needed.

## Proposed Changes:

- **Help Center enqueueing** (`Help_Center::enqueue_wp_admin_scripts`):
  - Introduces a new filter `jetpack_should_enqueue_help_center` (default `true`).
  - Short-circuits Help Center setup early if the filter returns `false`, preventing scripts/styles and the admin bar item from being added.

## Usage

To disable the Help Center entirely:

```php
add_filter( 'jetpack_should_enqueue_help_center', '__return_false' );
```

Or conditionally:

```php
add_filter( 'jetpack_should_enqueue_help_center', function ( $enabled ) {
    // Example: disable on certain sites or environments.
    if ( defined( 'WP_ENVIRONMENT_TYPE' ) && WP_ENVIRONMENT_TYPE === 'staging' ) {
        return false;
    }
    return $enabled;
} );
```

### Does this pull request change what data or activity we track or use?

No

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Testing instructions:

- **Baseline (no filter)**
  - On a site where the Help Center normally appears, load `wp-admin` as a user who can edit posts.
  - **Expected**: Help Center icon appears in the admin bar; assets are enqueued as before.

- **Filter disables Help Center**
  - Add:
    ```php
    add_filter( 'jetpack_should_enqueue_help_center', '__return_false' );
    ```
  - Reload `wp-admin`.
  - **Expected**: Help Center icon is not shown; related assets are not enqueued.

- **Conditional behavior sanity check**
  - Add a filter that returns `false` only on specific screens.
  - **Expected**: Help Center appears only where the filter returns `true`, and remains off elsewhere.