### PR TITLE
Clean up plugin release automation settings

### DIFF
--- a/.github/files/lint-project-structure.sh
+++ b/.github/files/lint-project-structure.sh
@@ -473,6 +473,13 @@ for PROJECT in projects/*/*; do
 		done < <( jq --stream -r 'if length == 2 and ( .[0] == ["require","automattic/wordbless"] or .[0] == ["require-dev","automattic/wordbless"] ) then [input_line_number] | @tsv else empty end' "$PROJECT/composer.json" )
 	fi
 
+	# - Plugins shouldn't have redundant wp-plugin-slug and beta-plugin-slug.
+	if [[ "$TYPE" == "plugins" ]] && jq -e '.extra["wp-plugin-slug"] and .extra["beta-plugin-slug"] and .extra["wp-plugin-slug"] == .extra["beta-plugin-slug"]' "$PROJECT/composer.json" > /dev/null; then
+		EXIT=1
+		LINE=$(jq --stream 'if length == 1 then .[0][:-1] else .[0] end | if . == ["extra","beta-plugin-slug"] then input_line_number else empty end' "$PROJECT/composer.json" | head -n 1)
+		echo "::error file=$PROJECT/composer.json,line=$LINE::There is no need to set both \`wp-plugin-slug\` and \`beta-plugin-slug\` to the same value. Delete \`beta-plugin-slug\` if the plugin is on wporg (or will be soon), or \`wp-plugin-slug\` otherwise."
+	fi
+
 done
 
 # - Monorepo root composer.json must also use dev deps appropriately.
@@ -510,7 +517,7 @@ fi
 
 # - Text domains from plugins should not be used in packages.
 debug "Checking package textdomain usage vs plugin slugs"
-PLUGDOMAINS="$(jq -n 'reduce inputs as $i ({}; .[$i.extra["wp-plugin-slug"] // $i.extra["wp-theme-slug"] // ""] = ( input_filename | sub("^projects/(?<slug>.*)/composer\\.json$";"\(.slug)"))) | .[""] |= empty' projects/plugins/*/composer.json)"
+PLUGDOMAINS="$(jq -n 'reduce inputs as $i ({}; .[$i.extra["wp-plugin-slug"] // $i.extra["beta-plugin-slug"] // ""] = ( input_filename | sub("^projects/(?<slug>.*)/composer\\.json$";"\(.slug)"))) | .[""] |= empty' projects/plugins/*/composer.json)"
 for FILE in projects/packages/*/composer.json; do
 	DIR="${FILE%/composer.json}"
 	SLUG="${DIR#projects/}"

--- a/docs/monorepo.md
+++ b/docs/monorepo.md
@@ -404,10 +404,10 @@ If `.extra.autorelease` is set to a truthy value in the project's `composer.json
 
 The body of the created release will be the entry from CHANGELOG.md for the tagged version. A zip file will be added to the release as an artifact. The zip file contains a single directory, which holds the output from `git archive`.
 
-If `.extra.autotagger` is set to an object, the following are recognized:
+If `.extra.autorelease` is set to an object, the following are recognized:
 
-* `.extra.autotagger.slug`: Base name for the zip file, and the name of the base directory inside. If this is omitted, `.extra.wp-plugin-slug` will be used. If that is also not set, the portion of `.name` after the `/` will be used.
-* `.extra.autotagger.titlefmt`: Format for the release title. Must contain a single `%s`, which will be replaced with the version tagged. If omitted, the release title will simply be the version number.
+* `.extra.autorelease.slug`: Base name for the zip file, and the name of the base directory inside. If this is omitted, `.extra.wp-plugin-slug` or `.extra.beta-plugin-slug` will be used. If that is also not set, the portion of `.name` after the `/` will be used.
+* `.extra.autorelease.titlefmt`: Format for the release title. Must contain a single `%s`, which will be replaced with the version tagged. If omitted, the release title will simply be the version number.
 
 Note the following will also be done by the build process:
 

--- a/projects/js-packages/webpack-config/changelog/fix-plugin-release-automation
+++ b/projects/js-packages/webpack-config/changelog/fix-plugin-release-automation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Use `beta-plugin-slug` as a fallback for plugin textdomains if `wp-plugin-slug` isn't set.

--- a/projects/js-packages/webpack-config/changelog/fix-plugin-release-automation#2
+++ b/projects/js-packages/webpack-config/changelog/fix-plugin-release-automation#2
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Remove unused `wp-theme-slug` fallback. It can be added back (everywhere in monorepo tooling) if we ever do have themes in the monorepo.

--- a/projects/js-packages/webpack-config/src/webpack.js
+++ b/projects/js-packages/webpack-config/src/webpack.js
@@ -34,8 +34,8 @@ let loadTextDomainFromComposerJson = () => {
 					ret = cfg.extra.textdomain;
 				} else if ( cfg.extra[ 'wp-plugin-slug' ] ) {
 					ret = cfg.extra[ 'wp-plugin-slug' ];
-				} else if ( cfg.extra[ 'wp-theme-slug' ] ) {
-					ret = cfg.extra[ 'wp-theme-slug' ];
+				} else if ( cfg.extra[ 'beta-plugin-slug' ] ) {
+					ret = cfg.extra[ 'beta-plugin-slug' ];
 				}
 			}
 			break;

--- a/projects/plugins/automattic-for-agencies-client/changelog/fix-plugin-release-automation
+++ b/projects/plugins/automattic-for-agencies-client/changelog/fix-plugin-release-automation
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Remove redundant `beta-plugin-slug` setting, plugin already has `wp-plugin-slug` set.
+
+

--- a/projects/plugins/automattic-for-agencies-client/composer.json
+++ b/projects/plugins/automattic-for-agencies-client/composer.json
@@ -62,7 +62,6 @@
 		"autorelease": true,
 		"mirror-repo": "Automattic/automattic-for-agencies-client",
 		"release-branch-prefix": "automattic-for-agencies-client",
-		"beta-plugin-slug": "automattic-for-agencies-client",
 		"wp-plugin-slug": "automattic-for-agencies-client",
 		"wp-svn-autopublish": true,
 		"changelogger": {

--- a/projects/plugins/automattic-for-agencies-client/composer.lock
+++ b/projects/plugins/automattic-for-agencies-client/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d9d3dc949263965e9c503e1823c6942c",
+    "content-hash": "79eafece3b08f5d822504d13389f6f1b",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",

--- a/projects/plugins/classic-theme-helper-plugin/changelog/fix-plugin-release-automation
+++ b/projects/plugins/classic-theme-helper-plugin/changelog/fix-plugin-release-automation
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Remove `wp-plugin-slug` in favor of `beta-plugin-slug`, as the plugin isn't on wporg. If it gets added there someday, we can always change that.
+
+

--- a/projects/plugins/classic-theme-helper-plugin/composer.json
+++ b/projects/plugins/classic-theme-helper-plugin/composer.json
@@ -50,7 +50,6 @@
 		"mirror-repo": "Automattic/classic-theme-plugin",
 		"release-branch-prefix": "classic-theme-plugin",
 		"beta-plugin-slug": "classic-theme-helper-plugin",
-		"wp-plugin-slug": "classic-theme-helper-plugin",
 		"changelogger": {
 			"versioning": "semver"
 		}

--- a/projects/plugins/classic-theme-helper-plugin/composer.lock
+++ b/projects/plugins/classic-theme-helper-plugin/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2061c0b4785c464691d7518f1ad4313f",
+    "content-hash": "20f23ff09f1376cb789e40a16632ec1d",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",

--- a/projects/plugins/debug-helper/changelog/fix-plugin-release-automation
+++ b/projects/plugins/debug-helper/changelog/fix-plugin-release-automation
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Enable autotagger and autorelease workflows, instead of making people do it manually.
+
+

--- a/projects/plugins/debug-helper/composer.json
+++ b/projects/plugins/debug-helper/composer.json
@@ -19,6 +19,10 @@
 	"minimum-stability": "dev",
 	"prefer-stable": true,
 	"extra": {
+		"autotagger": {
+			"v": false
+		},
+		"autorelease": true,
 		"mirror-repo": "Automattic/jetpack-debug-helper",
 		"version-constants": {
 			"JETPACK_DEBUG_HELPER_VERSION": "plugin.php"

--- a/projects/plugins/debug-helper/composer.lock
+++ b/projects/plugins/debug-helper/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "90508ab73efdc01ec5346540c36554d7",
+    "content-hash": "7b588125f4282bd2c7e158eaf4673507",
     "packages": [],
     "packages-dev": [
         {

--- a/projects/plugins/paypal-payment-buttons/changelog/fix-plugin-release-automation
+++ b/projects/plugins/paypal-payment-buttons/changelog/fix-plugin-release-automation
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Remove redundant `beta-plugin-slug` setting, plugin already has `wp-plugin-slug` set.
+
+

--- a/projects/plugins/paypal-payment-buttons/composer.json
+++ b/projects/plugins/paypal-payment-buttons/composer.json
@@ -57,7 +57,6 @@
 	"extra": {
 		"mirror-repo": "Automattic/paypal-payment-buttons",
 		"release-branch-prefix": "paypal-payment-buttons",
-		"beta-plugin-slug": "paypal-payment-buttons",
 		"autorelease": true,
 		"autotagger": true,
 		"wp-plugin-slug": "paypal-payment-buttons"

--- a/projects/plugins/paypal-payment-buttons/composer.lock
+++ b/projects/plugins/paypal-payment-buttons/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4b57524a5506e19a5ad73b709fc0e5a6",
+    "content-hash": "fcb1803a3c7e1a1831c2c1de3845cf90",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",

--- a/projects/plugins/starter-plugin/changelog/fix-plugin-release-automation
+++ b/projects/plugins/starter-plugin/changelog/fix-plugin-release-automation
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Enable autotagger and autorelease workflows, instead of making people do it manually.
+
+

--- a/projects/plugins/starter-plugin/composer.json
+++ b/projects/plugins/starter-plugin/composer.json
@@ -59,6 +59,8 @@
 	"minimum-stability": "dev",
 	"prefer-stable": true,
 	"extra": {
+		"autotagger": true,
+		"autorelease": true,
 		"mirror-repo": "Automattic/jetpack-starter-plugin",
 		"release-branch-prefix": "starter-plugin",
 		"beta-plugin-slug": "jetpack-starter-plugin"

--- a/projects/plugins/starter-plugin/composer.lock
+++ b/projects/plugins/starter-plugin/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "85723ba4bb858bcfcd6330adc83db808",
+    "content-hash": "ed554c21ee63d2059cafc9e50b3ae890",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",

--- a/projects/plugins/videopress/changelog/fix-plugin-release-automation
+++ b/projects/plugins/videopress/changelog/fix-plugin-release-automation
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Remove redundant `beta-plugin-slug` setting, plugin already has `wp-plugin-slug` set.
+
+

--- a/projects/plugins/videopress/composer.json
+++ b/projects/plugins/videopress/composer.json
@@ -44,7 +44,6 @@
 			"versioning": "wordpress"
 		},
 		"release-branch-prefix": "videopress",
-		"beta-plugin-slug": "jetpack-videopress",
 		"wp-plugin-slug": "jetpack-videopress",
 		"wp-svn-autopublish": true
 	},

--- a/projects/plugins/videopress/composer.lock
+++ b/projects/plugins/videopress/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c137d3d2f7ef6ae28a72fcc687226553",
+    "content-hash": "56900eee4d2fe6aaa2df617640154a17",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",

--- a/tools/cli/commands/generate.js
+++ b/tools/cli/commands/generate.js
@@ -278,6 +278,17 @@ export function getQuestions( type ) {
 				},
 			],
 		},
+		{
+			type: 'confirm',
+			name: 'pluginOnWporg',
+			message: 'Will this plugin be published to WordPress.org?',
+			initial() {
+				return this.state.answers.mirrorrepo;
+			},
+			skip() {
+				return ! this.state.answers.mirrorrepo;
+			},
+		},
 	];
 	const extensionQuestions = [];
 	const githubQuestions = [];
@@ -454,11 +465,13 @@ async function generatePluginFromStarter( projDir, answers ) {
 	composerJson.extra ||= {};
 	composerJson.extra.changelogger ||= {};
 	composerJson.extra.changelogger.versioning = answers.versioningMethod;
-	// Add proposed WP.org slug and remove alternative beta slug if we've indicated this is a public plugin.
-	if ( answers.mirrorrepo ) {
+	// Add proposed WP.org slug and remove alternative beta slug if we've indicated this will be on wporg.
+	if ( answers.pluginOnWporg ) {
 		composerJson.extra[ 'wp-plugin-slug' ] = normalizeSlug( answers.name );
+		composerJson.extra[ 'wp-svn-autopublish' ] = true;
 		delete composerJson.extra[ 'beta-plugin-slug' ];
 	}
+	composerJson.extra = Object.fromEntries( Object.entries( composerJson.extra ).sort() );
 	writeComposerJson( answers.project, composerJson, answers.projDir );
 }
 
@@ -480,6 +493,19 @@ function generatePlugin( answers, pluginDir ) {
 	);
 	const readmeTxtData = fs.readFileSync( readmeTxtPath, 'utf8' );
 	writeToFile( pluginDir + '/README.txt', readmeTxtContent + readmeTxtData );
+
+	// Update composer.json
+	const composerJson = readComposerJson( answers.project );
+	composerJson.extra.autotagger ??= true;
+	composerJson.extra.autorelease ??= true;
+	if ( answers.pluginOnWporg ) {
+		composerJson.extra[ 'wp-plugin-slug' ] = normalizeSlug( answers.name );
+		composerJson.extra[ 'wp-svn-autopublish' ] = true;
+	} else {
+		composerJson.extra[ 'beta-plugin-slug' ] = normalizeSlug( answers.name );
+	}
+	composerJson.extra = Object.fromEntries( Object.entries( composerJson.extra ).sort() );
+	writeComposerJson( answers.project, composerJson, answers.projDir );
 }
 
 /**

--- a/tools/release-plugin.sh
+++ b/tools/release-plugin.sh
@@ -358,7 +358,7 @@ function do_final_instructions {
 			continue
 		fi
 
-		if ! jq -e '.extra["wp-plugin-slug"] // .extra["wp-theme-slug"] // false' "$F" &>/dev/null; then
+		if ! jq -e '.extra["wp-plugin-slug"] // false' "$F" &>/dev/null; then
 			if ! jq -e '.extra["autotagger"]' "$F" &>/dev/null; then
 				MANUALTAGONLY+=( "$PLUGIN" )
 			fi


### PR DESCRIPTION
Closes MONOREP-316

 <!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Clean up duplicate `wp-plugin-slug` / `beta-plugin-slug`.
* Have project structure lint check for that.
* Use `beta-plugin-slug` as a fallback for plugin textdomains.
* Remove `wp-theme-slug` from tooling. We've never used it, and it's not in half the places it would need to be to actually work.
  * Left it in packages/composer-plugin though, that could be being used externally.
* Fix doc about the auto-release action that incorrectly referred to `.extra.autotagger` instead of `.extra.autorelease`.
* Enable `autotagger` and `autorelease` for `debug-helper` and `starter-plugin`, since they have been getting tags and releases.
* Have `jetpack generate` do a better job of setting all of these settings in new plugins.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
Started with p1767990098571859/1767830247.074719-slack-C08PN0LHCCT, then found a bunch more stuff to do.

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Try out `jetpack generate plugin` with various options.
* Try reverting some of the `beta-plugin-slug` deletions, see if the new check catches them.