### PR TITLE
Fix incorrect Docker admin credentials in README

### DIFF
--- a/tools/docker/README.md
+++ b/tools/docker/README.md
@@ -103,7 +103,7 @@ You can just quickly install WordPress and activate Jetpack via command line. En
 jetpack docker install
 ```
 
-This will give you a single site with user `jp_docker_acct` and password `jp_docker_pass` (unless you changed these in `./tools/docker/.env`). You will still have to connect Jetpack to WordPress.com manually.
+This will give you a single site with user `jp_docker_acct` and password `jp_docker_pass` (unless you changed these in `tools/docker/.env`). You will still have to connect Jetpack to WordPress.com manually.
 
 To convert installed single site into a multisite, run:
 

--- a/tools/docker/README.md
+++ b/tools/docker/README.md
@@ -103,7 +103,7 @@ You can just quickly install WordPress and activate Jetpack via command line. En
 jetpack docker install
 ```
 
-This will give you a single site with user/pass `wordpress` (unless you changed these from `./tools/docker/.env` file). You will still have to connect Jetpack to WordPress.com manually.
+This will give you a single site with user `jp_docker_acct` and password `jp_docker_pass` (unless you changed these in `./tools/docker/.env`). You will still have to connect Jetpack to WordPress.com manually.
 
 To convert installed single site into a multisite, run:
 


### PR DESCRIPTION
Fixes #

## Proposed changes:

* Update the Docker README to show the correct default WordPress admin credentials (`jp_docker_acct`/`jp_docker_pass` instead of `wordpress`/`wordpress`)

### Other information:

The default credentials were changed in PR #43541, but the README documentation was not updated at that time.

- [x] Have you written new tests for your changes, if applicable? N/A - documentation only
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them? N/A
- [x] Have you tested your changes on WordPress.com, if applicable? N/A

## Jetpack product discussion

N/A

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

* Open `tools/docker/README.md` and verify line 106 shows the correct credentials matching `tools/docker/default.env`
* Optionally run `jetpack docker install` on a fresh setup and confirm the credentials `jp_docker_acct`/`jp_docker_pass` work