### PR TITLE
About: Page Fix plugin icons 

### DIFF
--- a/projects/plugins/jetpack/_inc/client/components/about-page/style.scss
+++ b/projects/plugins/jetpack/_inc/client/components/about-page/style.scss
@@ -239,8 +239,11 @@ $color__back-link: #787c82;
 		}
 
 		.plugin-icon {
+			position: absolute;
 			top: 24px;
 			left: 24px;
+			width: 128px;
+			height: 128px;
 		}
 	}
 

--- a/projects/plugins/jetpack/_inc/client/components/about-page/style.scss
+++ b/projects/plugins/jetpack/_inc/client/components/about-page/style.scss
@@ -244,7 +244,7 @@ $color__back-link: #787c82;
 			inset-inline-start: 24px;
 			width: 128px;
 			height: 128px;
-			border-radius: 24px; /* This is done so that the icons end up with the same border radius across the plugins even thought they are not there by default. */
+			border-radius: 24px; /* This is done so that the icons end up with the same border radius across the plugins even though they are not there by default. */
 		}
 	}
 

--- a/projects/plugins/jetpack/_inc/client/components/about-page/style.scss
+++ b/projects/plugins/jetpack/_inc/client/components/about-page/style.scss
@@ -244,7 +244,7 @@ $color__back-link: #787c82;
 			inset-inline-start: 24px;
 			width: 128px;
 			height: 128px;
-			border-radius: 24px;
+			border-radius: 24px; /* This is done so that the icons end up with the same border radius across the plugins even thought they are not there by default. */
 		}
 	}
 

--- a/projects/plugins/jetpack/_inc/client/components/about-page/style.scss
+++ b/projects/plugins/jetpack/_inc/client/components/about-page/style.scss
@@ -241,9 +241,10 @@ $color__back-link: #787c82;
 		.plugin-icon {
 			position: absolute;
 			top: 24px;
-			left: 24px;
+			inset-inline-start: 24px;
 			width: 128px;
 			height: 128px;
+			border-radius: 24px;
 		}
 	}
 

--- a/projects/plugins/jetpack/changelog/fix-icons-about-page
+++ b/projects/plugins/jetpack/changelog/fix-icons-about-page
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+About Page: Plugin Icons fixes

--- a/projects/plugins/jetpack/changelog/fix-icons-about-page
+++ b/projects/plugins/jetpack/changelog/fix-icons-about-page
@@ -1,4 +1,4 @@
 Significance: patch
 Type: bugfix
 
-About Page: Plugin Icons fixes
+About Page: Fix plugin icon positioning and sizing.


### PR DESCRIPTION
Currenly the icons on the about page look broken. 

This PR fixes them by making sure that they are located in the correct place as well as the right size. 

Before:
<img width="819" height="832" alt="Screenshot 2026-01-14 at 4 25 07 PM" src="https://github.com/user-attachments/assets/f40aafea-047b-4bad-a71e-9a85fd124fa3" />

After:

<img width="961" height="713" alt="Screenshot 2026-01-14 at 4 22 39 PM" src="https://github.com/user-attachments/assets/8c3f07d9-3024-4225-949a-73bdd84f7d62" />


## Proposed changes:
Place the icons at the correct place. 
The icon sizes match what core shipped when you visit the add plugins page. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
No

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Visit the about page in the dashbaord do the plugins look less broken. 


