### PR TITLE
IDC: preserve re-validation parameters

### DIFF
--- a/projects/packages/connection/changelog/update-idc-preserve-revalidation-params
+++ b/projects/packages/connection/changelog/update-idc-preserve-revalidation-params
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+IDC: preserve re-validation parameters when new idc error is created.

--- a/projects/packages/connection/changelog/update-idc-preserve-revalidation-params
+++ b/projects/packages/connection/changelog/update-idc-preserve-revalidation-params
@@ -1,4 +1,4 @@
 Significance: patch
 Type: added
 
-IDC: preserve re-validation parameters when new idc error is created.
+IDC: Preserve re-validation parameters when new idc error is created.

--- a/projects/packages/connection/src/identity-crisis/class-identity-crisis.php
+++ b/projects/packages/connection/src/identity-crisis/class-identity-crisis.php
@@ -333,23 +333,8 @@ class Identity_Crisis {
 			);
 
 			if ( in_array( $error_code, $allowed_idc_error_codes, true ) ) {
-				// Get existing IDC option to check if this is the same error.
-				$existing_idc = Jetpack_Options::get_option( 'sync_error_idc' );
-
-				// Get the new error data with fresh timing values.
-				$new_idc_data = self::get_sync_error_idc_option( $response );
-
-				// If an existing IDC exists, check if the wpcom URLs are the same.
-				if ( is_array( $existing_idc ) && self::has_same_wpcom_urls( $existing_idc, $new_idc_data ) ) {
-					// Same wpcom URLs - preserve the backoff delay.
-					// Note: last_checked is already set to time() by get_sync_error_idc_option(),
-					// which is correct - we want to record that we just saw this error again.
-					if ( isset( $existing_idc['next_check_delay'] ) ) {
-						$new_idc_data['next_check_delay'] = $existing_idc['next_check_delay'];
-					}
-				}
-				// else: Different wpcom URLs or first time - use fresh timing from get_sync_error_idc_option().
-
+				// This is a defensive fallback.
+				$new_idc_data = self::get_idc_option_with_preserved_timing( $response );
 				Jetpack_Options::update_option( 'sync_error_idc', $new_idc_data );
 			}
 
@@ -357,6 +342,67 @@ class Identity_Crisis {
 		}
 
 		return false;
+	}
+
+	/**
+	 * Gets IDC option data with timing preserved from existing option if appropriate.
+	 *
+	 * This is a defensive fallback for edge cases where IDC errors are repeatedly detected
+	 * even though the site should be in IDC mode. However, edge cases can cause the option
+	 * to be deleted, triggering new IDC detections. For example, dynamic URLs, race conditions,
+	 * or external storage synchronization issues can cause the option to be deleted, triggering
+	 * new IDC detections.
+	 *
+	 * @param array $response The IDC error response from WordPress.com.
+	 *
+	 * @return array The IDC option data, with timing preserved if the wpcom URLs match.
+	 */
+	private static function get_idc_option_with_preserved_timing( $response ) {
+		// Get existing IDC option to check if this is the same error.
+		$existing_idc = Jetpack_Options::get_option( 'sync_error_idc' );
+
+		// Get the new error data with fresh timing values.
+		$new_idc_data = self::get_sync_error_idc_option( $response );
+
+		// If an existing IDC exists and the wpcom URLs match, preserve the backoff delay.
+		if ( is_array( $existing_idc ) && self::has_same_wpcom_urls( $existing_idc, $new_idc_data ) ) {
+			// Same wpcom URLs - preserve the backoff delay.
+			// Note: last_checked is already set to time() by get_sync_error_idc_option(),
+			// which is correct - we want to record that we just saw this error again.
+			$preserved_delay = self::get_valid_delay_from_existing_idc( $existing_idc );
+			if ( $preserved_delay !== null ) {
+				$new_idc_data['next_check_delay'] = $preserved_delay;
+			}
+		}
+		// else: Different wpcom URLs or first time - use fresh timing from get_sync_error_idc_option().
+
+		return $new_idc_data;
+	}
+
+	/**
+	 * Extracts and validates the next_check_delay from an existing IDC option.
+	 *
+	 * @param array $existing_idc The existing IDC option data.
+	 *
+	 * @return int|null The validated delay in seconds, or null if invalid.
+	 */
+	private static function get_valid_delay_from_existing_idc( $existing_idc ) {
+		if ( ! isset( $existing_idc['next_check_delay'] ) ) {
+			return null;
+		}
+
+		$delay = $existing_idc['next_check_delay'];
+
+		// Validate the delay is numeric and within acceptable bounds.
+		if (
+			! is_numeric( $delay ) ||
+			$delay < self::IDC_VALIDATION_INITIAL_DELAY ||
+			$delay > self::IDC_VALIDATION_MAX_DELAY
+		) {
+			return null;
+		}
+
+		return (int) $delay;
 	}
 
 	/**

--- a/projects/packages/connection/src/identity-crisis/class-identity-crisis.php
+++ b/projects/packages/connection/src/identity-crisis/class-identity-crisis.php
@@ -349,9 +349,7 @@ class Identity_Crisis {
 	 *
 	 * This is a defensive fallback for edge cases where IDC errors are repeatedly detected
 	 * even though the site should be in IDC mode. However, edge cases can cause the option
-	 * to be deleted, triggering new IDC detections. For example, dynamic URLs, race conditions,
-	 * or external storage synchronization issues can cause the option to be deleted, triggering
-	 * new IDC detections.
+	 * to be deleted, triggering new IDC detections.
 	 *
 	 * @param array $response The IDC error response from WordPress.com.
 	 *
@@ -419,7 +417,14 @@ class Identity_Crisis {
 	 */
 	private static function has_same_wpcom_urls( $idc1, $idc2 ) {
 		// Both must have wpcom_home and wpcom_siteurl to be comparable.
-		if ( ! isset( $idc1['wpcom_home'] ) || ! isset( $idc1['wpcom_siteurl'] ) || ! isset( $idc2['wpcom_home'] ) || ! isset( $idc2['wpcom_siteurl'] ) ) {
+		if (
+			! isset( $idc1['wpcom_home'] ) ||
+			! isset( $idc1['wpcom_siteurl'] ) ||
+			! isset( $idc2['wpcom_home'] ) ||
+			! isset( $idc2['wpcom_siteurl'] ) ||
+			! isset( $idc1['reversed_url'] ) ||
+			! isset( $idc2['reversed_url'] )
+		) {
 			return false;
 		}
 

--- a/projects/packages/connection/src/identity-crisis/class-identity-crisis.php
+++ b/projects/packages/connection/src/identity-crisis/class-identity-crisis.php
@@ -341,8 +341,9 @@ class Identity_Crisis {
 
 				// If an existing IDC exists, check if the wpcom URLs are the same.
 				if ( is_array( $existing_idc ) && self::has_same_wpcom_urls( $existing_idc, $new_idc_data ) ) {
-					// Same wpcom URLs - update last_checked but preserve the backoff delay.
-					$new_idc_data['last_checked'] = time();
+					// Same wpcom URLs - preserve the backoff delay.
+					// Note: last_checked is already set to time() by get_sync_error_idc_option(),
+					// which is correct - we want to record that we just saw this error again.
 					if ( isset( $existing_idc['next_check_delay'] ) ) {
 						$new_idc_data['next_check_delay'] = $existing_idc['next_check_delay'];
 					}

--- a/projects/packages/connection/src/identity-crisis/class-identity-crisis.php
+++ b/projects/packages/connection/src/identity-crisis/class-identity-crisis.php
@@ -333,16 +333,59 @@ class Identity_Crisis {
 			);
 
 			if ( in_array( $error_code, $allowed_idc_error_codes, true ) ) {
-				Jetpack_Options::update_option(
-					'sync_error_idc',
-					self::get_sync_error_idc_option( $response )
-				);
+				// Get existing IDC option to check if this is the same error.
+				$existing_idc = Jetpack_Options::get_option( 'sync_error_idc' );
+
+				// Get the new error data with fresh timing values.
+				$new_idc_data = self::get_sync_error_idc_option( $response );
+
+				// If an existing IDC exists, check if the wpcom URLs are the same.
+				if ( is_array( $existing_idc ) && self::has_same_wpcom_urls( $existing_idc, $new_idc_data ) ) {
+					// Same wpcom URLs - update last_checked but preserve the backoff delay.
+					$new_idc_data['last_checked'] = time();
+					if ( isset( $existing_idc['next_check_delay'] ) ) {
+						$new_idc_data['next_check_delay'] = $existing_idc['next_check_delay'];
+					}
+				}
+				// else: Different wpcom URLs or first time - use fresh timing from get_sync_error_idc_option().
+
+				Jetpack_Options::update_option( 'sync_error_idc', $new_idc_data );
 			}
 
 			return true;
 		}
 
 		return false;
+	}
+
+	/**
+	 * Determines if two IDC error arrays have the same wpcom URLs.
+	 *
+	 * The wpcom URLs are stored in reversed form in the database, but the jetpack_options
+	 * filter un-reverses them when retrieved. This method normalizes both sets of URLs
+	 * to reversed form before comparing.
+	 *
+	 * @param array $idc1 First IDC error data (from get_option, may be un-reversed).
+	 * @param array $idc2 Second IDC error data (from get_sync_error_idc_option, reversed).
+	 *
+	 * @return bool True if they have the same wpcom URLs.
+	 */
+	private static function has_same_wpcom_urls( $idc1, $idc2 ) {
+		// Both must have wpcom_home and wpcom_siteurl to be comparable.
+		if ( ! isset( $idc1['wpcom_home'] ) || ! isset( $idc1['wpcom_siteurl'] ) || ! isset( $idc2['wpcom_home'] ) || ! isset( $idc2['wpcom_siteurl'] ) ) {
+			return false;
+		}
+
+		// The existing IDC data has been un-reversed by the jetpack_options filter when
+		// retrieved via Jetpack_Options::get_option(), so the wpcom URLs are in normal format.
+		// The new data from get_sync_error_idc_option() has reversed URLs.
+		// Reverse the existing URLs to match the format of the new data for comparison.
+		$existing_wpcom_home    = strrev( $idc1['wpcom_home'] );
+		$existing_wpcom_siteurl = strrev( $idc1['wpcom_siteurl'] );
+
+		// Compare the reversed URLs.
+		return $existing_wpcom_home === $idc2['wpcom_home']
+			&& $existing_wpcom_siteurl === $idc2['wpcom_siteurl'];
 	}
 
 	/**

--- a/projects/packages/connection/tests/php/identity-crisis/Identity_Crisis_Test.php
+++ b/projects/packages/connection/tests/php/identity-crisis/Identity_Crisis_Test.php
@@ -743,7 +743,7 @@ class Identity_Crisis_Test extends BaseTestCase {
 	}
 
 	/**
-	 * Test that check_response_for_idc preserves delay when wpcom_siteurl differs but wpcom_home is same.
+	 * Test that check_response_for_idc resets timing when wpcom_siteurl differs but wpcom_home is same.
 	 */
 	public function test_check_response_for_idc_resets_when_only_wpcom_siteurl_differs() {
 		// Set up initial IDC.

--- a/projects/packages/connection/tests/php/identity-crisis/Identity_Crisis_Test.php
+++ b/projects/packages/connection/tests/php/identity-crisis/Identity_Crisis_Test.php
@@ -775,6 +775,50 @@ class Identity_Crisis_Test extends BaseTestCase {
 	}
 
 	/**
+	 * Test that check_response_for_idc resets delay when corrupted (invalid values).
+	 */
+	public function test_check_response_for_idc_resets_corrupted_delay() {
+		$test_cases = array(
+			'too_small'   => 100,       // Below minimum.
+			'too_large'   => 99999999,  // Above maximum.
+			'not_numeric' => 'invalid', // String.
+			'negative'    => -1000,     // Negative number.
+		);
+
+		foreach ( $test_cases as $case_name => $invalid_delay ) {
+			// Set up IDC with corrupted delay value.
+			$existing_idc = array(
+				'home'             => 'example.org/',
+				'siteurl'          => 'example.org/',
+				'error_code'       => 'jetpack_url_mismatch',
+				'wpcom_siteurl'    => '/moc.elpmaxe',
+				'wpcom_home'       => '/moc.elpmaxe',
+				'reversed_url'     => true,
+				'last_checked'     => time() - 7200,
+				'next_check_delay' => $invalid_delay,
+			);
+			Jetpack_Options::update_option( 'sync_error_idc', $existing_idc );
+
+			// Simulate a new response with the same wpcom URLs.
+			$response = array(
+				'error_code'    => 'jetpack_url_mismatch',
+				'wpcom_siteurl' => 'example.com/',
+				'wpcom_home'    => 'example.com/',
+			);
+
+			Identity_Crisis::init()->check_response_for_idc( $response );
+			$updated_idc = Jetpack_Options::get_option( 'sync_error_idc' );
+
+			// Should reset to initial delay when corrupted value is detected.
+			$this->assertSame(
+				Identity_Crisis::IDC_VALIDATION_INITIAL_DELAY,
+				$updated_idc['next_check_delay'],
+				"Failed for case: {$case_name}"
+			);
+		}
+	}
+
+	/**
 	 * Test the check_http_response_for_idc_detected method with invalid inputs. These inputs should
 	 * cause the method to return false.
 	 *

--- a/projects/packages/connection/tests/php/identity-crisis/Identity_Crisis_Test.php
+++ b/projects/packages/connection/tests/php/identity-crisis/Identity_Crisis_Test.php
@@ -639,6 +639,142 @@ class Identity_Crisis_Test extends BaseTestCase {
 	}
 
 	/**
+	 * Test that check_response_for_idc preserves next_check_delay when same wpcom URLs are detected.
+	 */
+	public function test_check_response_for_idc_preserves_delay_on_same_wpcom_urls() {
+		// Set up initial IDC with custom timing values.
+		$initial_last_checked     = time() - 7200; // 2 hours ago.
+		$initial_next_check_delay = 7200; // 2 hours (doubled from initial 3600).
+		$existing_idc             = array(
+			'home'             => 'example.org/',
+			'siteurl'          => 'example.org/',
+			'error_code'       => 'jetpack_url_mismatch',
+			'wpcom_siteurl'    => '/moc.elpmaxe', // example.com reversed.
+			'wpcom_home'       => '/moc.elpmaxe', // example.com reversed.
+			'reversed_url'     => true,
+			'last_checked'     => $initial_last_checked,
+			'next_check_delay' => $initial_next_check_delay,
+		);
+		Jetpack_Options::update_option( 'sync_error_idc', $existing_idc );
+
+		// Simulate a new response with the same wpcom URLs.
+		$response = array(
+			'error_code'    => 'jetpack_url_mismatch',
+			'wpcom_siteurl' => 'example.com/',
+			'wpcom_home'    => 'example.com/',
+		);
+
+		$before = time();
+		Identity_Crisis::init()->check_response_for_idc( $response );
+		$after = time();
+
+		$updated_idc = Jetpack_Options::get_option( 'sync_error_idc' );
+
+		// last_checked should be updated to current time.
+		$this->assertGreaterThanOrEqual( $before, $updated_idc['last_checked'] );
+		$this->assertLessThanOrEqual( $after, $updated_idc['last_checked'] );
+
+		// next_check_delay should be preserved from existing IDC.
+		$this->assertSame( $initial_next_check_delay, $updated_idc['next_check_delay'] );
+	}
+
+	/**
+	 * Test that check_response_for_idc resets timing when different wpcom URLs are detected.
+	 */
+	public function test_check_response_for_idc_resets_timing_on_different_wpcom_urls() {
+		// Set up initial IDC with custom timing values.
+		$initial_last_checked     = time() - 7200; // 2 hours ago.
+		$initial_next_check_delay = 7200; // 2 hours (doubled from initial 3600).
+		$existing_idc             = array(
+			'home'             => 'example.org/',
+			'siteurl'          => 'example.org/',
+			'error_code'       => 'jetpack_url_mismatch',
+			'wpcom_siteurl'    => '/moc.elpmaxe', // example.com reversed.
+			'wpcom_home'       => '/moc.elpmaxe', // example.com reversed.
+			'reversed_url'     => true,
+			'last_checked'     => $initial_last_checked,
+			'next_check_delay' => $initial_next_check_delay,
+		);
+		Jetpack_Options::update_option( 'sync_error_idc', $existing_idc );
+
+		// Simulate a new response with different wpcom URLs.
+		$response = array(
+			'error_code'    => 'jetpack_url_mismatch',
+			'wpcom_siteurl' => 'different.com/',
+			'wpcom_home'    => 'different.com/',
+		);
+
+		$before = time();
+		Identity_Crisis::init()->check_response_for_idc( $response );
+		$after = time();
+
+		$updated_idc = Jetpack_Options::get_option( 'sync_error_idc' );
+
+		// Both timing parameters should be reset to initial values.
+		$this->assertGreaterThanOrEqual( $before, $updated_idc['last_checked'] );
+		$this->assertLessThanOrEqual( $after, $updated_idc['last_checked'] );
+		$this->assertSame( Identity_Crisis::IDC_VALIDATION_INITIAL_DELAY, $updated_idc['next_check_delay'] );
+	}
+
+	/**
+	 * Test that check_response_for_idc sets initial timing on first IDC detection.
+	 */
+	public function test_check_response_for_idc_sets_initial_timing_on_first_detection() {
+		// Ensure no existing IDC.
+		Jetpack_Options::delete_option( 'sync_error_idc' );
+
+		// Simulate first IDC detection.
+		$response = array(
+			'error_code'    => 'jetpack_url_mismatch',
+			'wpcom_siteurl' => 'example.com/',
+			'wpcom_home'    => 'example.com/',
+		);
+
+		$before = time();
+		Identity_Crisis::init()->check_response_for_idc( $response );
+		$after = time();
+
+		$updated_idc = Jetpack_Options::get_option( 'sync_error_idc' );
+
+		// Timing parameters should be set to initial values.
+		$this->assertGreaterThanOrEqual( $before, $updated_idc['last_checked'] );
+		$this->assertLessThanOrEqual( $after, $updated_idc['last_checked'] );
+		$this->assertSame( Identity_Crisis::IDC_VALIDATION_INITIAL_DELAY, $updated_idc['next_check_delay'] );
+	}
+
+	/**
+	 * Test that check_response_for_idc preserves delay when wpcom_siteurl differs but wpcom_home is same.
+	 */
+	public function test_check_response_for_idc_resets_when_only_wpcom_siteurl_differs() {
+		// Set up initial IDC.
+		$initial_next_check_delay = 7200;
+		$existing_idc             = array(
+			'home'             => 'example.org/',
+			'siteurl'          => 'example.org/',
+			'error_code'       => 'jetpack_url_mismatch',
+			'wpcom_siteurl'    => '/moc.elpmaxe', // example.com reversed.
+			'wpcom_home'       => '/moc.elpmaxe', // example.com reversed.
+			'reversed_url'     => true,
+			'last_checked'     => time() - 7200,
+			'next_check_delay' => $initial_next_check_delay,
+		);
+		Jetpack_Options::update_option( 'sync_error_idc', $existing_idc );
+
+		// Simulate response with different wpcom_siteurl but same wpcom_home.
+		$response = array(
+			'error_code'    => 'jetpack_url_mismatch',
+			'wpcom_siteurl' => 'different.com/', // Different.
+			'wpcom_home'    => 'example.com/', // Same.
+		);
+
+		Identity_Crisis::init()->check_response_for_idc( $response );
+		$updated_idc = Jetpack_Options::get_option( 'sync_error_idc' );
+
+		// Timing should be reset because wpcom URLs are different.
+		$this->assertSame( Identity_Crisis::IDC_VALIDATION_INITIAL_DELAY, $updated_idc['next_check_delay'] );
+	}
+
+	/**
 	 * Test the check_http_response_for_idc_detected method with invalid inputs. These inputs should
 	 * cause the method to return false.
 	 *


### PR DESCRIPTION
The [new re-validation logic for IDC ](https://github.com/Automattic/jetpack/pull/46268)introduced two new parameters in the IDC error array that define the last checked timestamp and the progressive delay for the next validation attempt. This PR adds logic that makes sure these two parameters are inherited when a new IDC error is generated (by a new remote request).

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Closes CONNECT-139

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* If the core reason for IDC is still valid (wpcom URLs don't match, we rewrite the existing error but keep the delay and timing parameters.
* The timing gets updated if the wpcom URLs are the same in the new error as they are in the existing one but the delay stays the same.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* This can be tough to test, so code review should do.