### PR TITLE
Adds dev mode to Agents Manager

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-agents-manager-dev-mode
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-agents-manager-dev-mode
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Add dev mode to Agents Manager

--- a/projects/packages/jetpack-mu-wpcom/src/features/agents-manager/class-agents-manager.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/agents-manager/class-agents-manager.php
@@ -215,6 +215,7 @@ class Agents_Manager {
 				array(
 					'agentProviders'       => $agent_providers,
 					'useUnifiedExperience' => $use_unified_experience,
+					'isDevMode'            => self::is_dev_mode(),
 				),
 				JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP
 			) . ';',
@@ -254,8 +255,8 @@ class Agents_Manager {
 			set_transient( $cache_key, $asset_file, HOUR_IN_SECONDS );
 		}
 
-		// When the request is proxied, use a random cache buster as the version for easier debugging.
-		$version = self::is_proxied() ? wp_rand() : $asset_file['version'];
+		// When the request is dev mode, use a random cache buster as the version for easier debugging.
+		$version = self::is_dev_mode() ? wp_rand() : $asset_file['version'];
 
 		$script_dependencies = $asset_file['dependencies'] ?? array();
 
@@ -400,6 +401,39 @@ class Agents_Manager {
 	}
 
 	/**
+	 * Enables "Development" features that should be accessible only for admins.
+	 */
+	private static function is_dev_mode() {
+		// Known local environments.
+		$domain = wp_parse_url( get_site_url(), PHP_URL_HOST );
+		if (
+			$domain === 'localhost' ||
+			'.jurassic.tube' === stristr( $domain, '.jurassic.tube' ) ||
+			'.jurassic.ninja' === stristr( $domain, '.jurassic.ninja' )
+		) {
+			return true;
+		}
+
+		// A8C development.
+		if ( self::is_proxied() ) {
+			return true;
+		}
+
+		if ( defined( 'AT_PROXIED_REQUEST' ) && AT_PROXIED_REQUEST && defined( 'ATOMIC_CLIENT_ID' ) ) {
+			switch ( ATOMIC_CLIENT_ID ) {
+				case 1:
+				case 2:
+				case 3: // Pressable
+				case 32:
+				case 118: // Commerce garden client (ciab)
+					return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
 	 * Register the Agents Manager endpoints.
 	 */
 	public function register_rest_api() {
@@ -414,9 +448,9 @@ class Agents_Manager {
 	 * @return bool
 	 */
 	public function should_use_unified_experience() {
-		// Early return for non-proxied requests.
+		// Early return for non-proxied/dev mode requests.
 		// This feature is currently only available to Automattic employees testing via proxy.
-		if ( ! self::is_proxied() ) {
+		if ( ! self::is_dev_mode() ) {
 			return false;
 		}
 

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/agents-manager/Agents_Manager_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/agents-manager/Agents_Manager_Test.php
@@ -913,4 +913,169 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 
 		return new \WP_Error( 'http_request_failed', 'Connection failed' );
 	}
+
+	/**
+	 * Helper to call the private is_dev_mode method via reflection.
+	 *
+	 * @return bool The result of is_dev_mode.
+	 */
+	private function call_is_dev_mode() {
+		$reflection = new \ReflectionClass( Agents_Manager::class );
+		$method     = $reflection->getMethod( 'is_dev_mode' );
+		if ( PHP_VERSION_ID < 80500 ) {
+			$method->setAccessible( true );
+		}
+		return $method->invoke( null );
+	}
+
+	/**
+	 * Tests that is_dev_mode returns true for localhost.
+	 */
+	public function test_is_dev_mode_returns_true_for_localhost() {
+		update_option( 'siteurl', 'http://localhost' );
+
+		$result = $this->call_is_dev_mode();
+
+		$this->assertTrue( $result );
+	}
+
+	/**
+	 * Tests that is_dev_mode returns true for jurassic.tube domains.
+	 */
+	public function test_is_dev_mode_returns_true_for_jurassic_tube() {
+		update_option( 'siteurl', 'https://mysite.jurassic.tube' );
+
+		$result = $this->call_is_dev_mode();
+
+		$this->assertTrue( $result );
+	}
+
+	/**
+	 * Tests that is_dev_mode returns true for jurassic.ninja domains.
+	 */
+	public function test_is_dev_mode_returns_true_for_jurassic_ninja() {
+		update_option( 'siteurl', 'https://mysite.jurassic.ninja' );
+
+		$result = $this->call_is_dev_mode();
+
+		$this->assertTrue( $result );
+	}
+
+	/**
+	 * Tests that is_dev_mode returns true when request is proxied via constant.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	#[RunInSeparateProcess]
+	#[PreserveGlobalState( false )]
+	public function test_is_dev_mode_returns_true_when_proxied_via_constant() {
+		update_option( 'siteurl', 'https://example.com' );
+		define( 'A8C_PROXIED_REQUEST', true );
+
+		$result = $this->call_is_dev_mode();
+
+		$this->assertTrue( $result );
+	}
+
+	/**
+	 * Tests that is_dev_mode returns true when request is proxied via server variable.
+	 */
+	public function test_is_dev_mode_returns_true_when_proxied_via_server_var() {
+		update_option( 'siteurl', 'https://example.com' );
+		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
+
+		$result = $this->call_is_dev_mode();
+
+		unset( $_SERVER['A8C_PROXIED_REQUEST'] );
+
+		$this->assertTrue( $result );
+	}
+
+	/**
+	 * Tests that is_dev_mode returns true for Atomic client ID 1.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	#[RunInSeparateProcess]
+	#[PreserveGlobalState( false )]
+	public function test_is_dev_mode_returns_true_for_atomic_client_id_1() {
+		update_option( 'siteurl', 'https://example.com' );
+		define( 'AT_PROXIED_REQUEST', true );
+		define( 'ATOMIC_CLIENT_ID', 1 );
+
+		$result = $this->call_is_dev_mode();
+
+		$this->assertTrue( $result );
+	}
+
+	/**
+	 * Tests that is_dev_mode returns false for non-allowed Atomic client IDs.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	#[RunInSeparateProcess]
+	#[PreserveGlobalState( false )]
+	public function test_is_dev_mode_returns_false_for_non_allowed_atomic_client_id() {
+		update_option( 'siteurl', 'https://example.com' );
+		define( 'AT_PROXIED_REQUEST', true );
+		define( 'ATOMIC_CLIENT_ID', 999 );
+
+		$result = $this->call_is_dev_mode();
+
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * Tests that is_dev_mode returns false when AT_PROXIED_REQUEST is false.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	#[RunInSeparateProcess]
+	#[PreserveGlobalState( false )]
+	public function test_is_dev_mode_returns_false_when_at_proxied_request_is_false() {
+		update_option( 'siteurl', 'https://example.com' );
+		define( 'AT_PROXIED_REQUEST', false );
+		define( 'ATOMIC_CLIENT_ID', 1 );
+
+		$result = $this->call_is_dev_mode();
+
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * Tests that is_dev_mode returns false for regular production sites.
+	 */
+	public function test_is_dev_mode_returns_false_for_production_sites() {
+		update_option( 'siteurl', 'https://myproductionsite.com' );
+
+		$result = $this->call_is_dev_mode();
+
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * Tests that is_dev_mode returns true when wpcom_is_proxied_request function exists and returns true.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	#[RunInSeparateProcess]
+	#[PreserveGlobalState( false )]
+	public function test_is_dev_mode_returns_true_when_wpcom_proxy_function_returns_true() {
+		update_option( 'siteurl', 'https://example.com' );
+
+		Functions\stubs(
+			array(
+				'wpcom_is_proxied_request' => true,
+			)
+		);
+
+		$result = $this->call_is_dev_mode();
+
+		$this->assertTrue( $result );
+	}
 }


### PR DESCRIPTION
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Brings over the dev mode concept from Big Sky

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ x Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Testing instructions:
- Enable the unified experience on `https://wordpress.com/wp-admin/profile.php`. 
- `bin/jetpack-downloader test jetpack-mu-wpcom-plugin add/agents-manager-dev-mode` on your sandbox
- Visit a sandboxed site `/wp-admin` and view source. Confirm `agentsManagerData `:
  - Exists when proxied
  - Doesn't exist when not proxied
- Visit local development. Confirm `agentsManagerData` always present (when unified setting enabled on WPCOM).
