### PR TITLE
Update/incompatible plugins list remove jetbackup

### DIFF
--- a/projects/plugins/wpcomsh/changelog/update-incompatible-plugins-list-remove-jetbackup
+++ b/projects/plugins/wpcomsh/changelog/update-incompatible-plugins-list-remove-jetbackup
@@ -1,0 +1,4 @@
+Significance: minor
+Type: removed
+
+Removed JetBackup from incompatible plugins list. Developer provided new version which works on WordPress.com when tested.

--- a/projects/plugins/wpcomsh/class-jetpack-plugin-compatibility.php
+++ b/projects/plugins/wpcomsh/class-jetpack-plugin-compatibility.php
@@ -24,7 +24,6 @@ class Jetpack_Plugin_Compatibility {
 		'advanced-database-cleaner/advanced-db-cleaner.php' => '"advanced-database-cleaner" has been deactivated, it deletes data necessary to manage your site and is not supported on WordPress.com.',
 		'advanced-reset-wp/advanced-reset-wp.php'         => '"advanced-reset-wp" has been deactivated, it deletes data necessary to manage your site and is not supported on WordPress.com.',
 		'advanced-wp-reset/advanced-wp-reset.php'         => '"advanced-wp-reset" has been deactivated, it deletes data necessary to manage your site and is not supported on WordPress.com.',
-		'backup/backup.php'                               => '"backup" has been deactivated, it deletes data necessary to manage your site and is not supported on WordPress.com.',
 		'better-wp-security/better-wp-security.php'       => '"better-wp-security" has been deactivated, it deletes data necessary to manage your site and is not supported on WordPress.com.',
 		'database-browser/database-browser.php'           => '"database-browser" has been deactivated, it deletes data necessary to manage your site and is not supported on WordPress.com.',
 		'extended-wp-reset/extended-wp-reset.php'         => '"extended-wp-reset" has been deactivated, it interferes with site operation and is not supported on WordPress.com.',
@@ -59,7 +58,6 @@ class Jetpack_Plugin_Compatibility {
 		'wp-downgrade/wp-downgrade.php'                   => '"wp-downgrade" has been deactivated, it deletes data necessary to manage your site and is not supported on WordPress.com.',
 
 		// Backup.
-		'backup-wd/backup-wd.php'                         => '"backup-wd" has been deactivated, WordPress.com handles managing your site backups for you.',
 		'backwpup/backwpup.php'                           => '"backwpup" has been deactivated, WordPress.com handles managing your site backups for you.',
 		'backwpup-pro/backwpup.php'                       => '"backwpup-pro" has been deactivated, WordPress.com handles managing your site backups for you.',
 		'duplicator/duplicator.php'                       => '"duplicator" has been deactivated, it deletes data necessary to manage your site and is not supported on WordPress.com.',


### PR DESCRIPTION
Remove JetBackups from incompatible plugins list known by slugs `backup` and `backup-wd` (previously). The new version provided by the developer as of 2026-01-15 works fine on WordPress.com.

Corresponding PR: https://github.com/Automattic/wp-calypso/pull/108146

## Jetpack product discussion

N/A

## Does this pull request change what data or activity we track or use?

No, I don't believe this would apply to the update.

## Testing instructions:

1. Create a new Business Plan site, mark it as a WoA Dev site, and take it Atomic.
2. Build wpcomsh plugin and synchronize to the WoA Dev site

```
git checkout BRANCH
composer install
WPCOMSH_DEVMODE=1 make clean build
rsync -avze ssh --delete build/wpcomsh USERNAME@sftp.wp.com:htdocs/wp-content/mu-plugins
```

3. SSH into the WoA dev site, and run: wp plugin install wp-staging --activate
4. Navigate to the WoA dev site's /wp-admin/plugins.php page and confirm that WP STAGING can be activated and is not disabled.