### PR TITLE
Pnpmfile hack for GHSA-73rr-hh4g-fpgx

### DIFF
--- a/.pnpmfile.cjs
+++ b/.pnpmfile.cjs
@@ -256,6 +256,12 @@ async function fixDeps( pkg ) {
 		pkg.dependencies.undici = '^6.23.0';
 	}
 
+	// GHSA-73rr-hh4g-fpgx
+	// https://github.com/WordPress/gutenberg/issues/74669
+	if ( pkg.name === '@wordpress/block-editor' && pkg.dependencies?.diff?.startsWith( '^4.' ) ) {
+		pkg.dependencies.diff = '^8.0.3';
+	}
+
 	return pkg;
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,7 +4,7 @@ settings:
   autoInstallPeers: false
   excludeLinksFromLockfile: false
 
-pnpmfileChecksum: sha256-ks4bdg8gITupem/gRF7PYabyzCI56FKF8ElJIeOOn78=
+pnpmfileChecksum: sha256-AGez7xzLHdU0SPhGiKpqXP9vdrqt49SjVU5wB/67wsk=
 
 patchedDependencies:
   '@wordpress/a11y':
@@ -12022,8 +12022,8 @@ packages:
     resolution: {integrity: sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
-  diff@4.0.2:
-    resolution: {integrity: sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==}
+  diff@8.0.3:
+    resolution: {integrity: sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ==}
     engines: {node: '>=0.3.1'}
 
   diffable-html@4.1.0:
@@ -22898,7 +22898,7 @@ snapshots:
       clsx: 2.1.1
       colord: 2.9.3
       deepmerge: 4.3.1
-      diff: 4.0.2
+      diff: 8.0.3
       fast-deep-equal: 3.1.3
       memize: 2.1.1
       parsel-js: 1.2.2
@@ -22960,7 +22960,7 @@ snapshots:
       clsx: 2.1.1
       colord: 2.9.3
       deepmerge: 4.3.1
-      diff: 4.0.2
+      diff: 8.0.3
       fast-deep-equal: 3.1.3
       memize: 2.1.1
       parsel-js: 1.2.2
@@ -23022,7 +23022,7 @@ snapshots:
       clsx: 2.1.1
       colord: 2.9.3
       deepmerge: 4.3.1
-      diff: 4.0.2
+      diff: 8.0.3
       fast-deep-equal: 3.1.3
       memize: 2.1.1
       parsel-js: 1.2.2
@@ -26791,7 +26791,7 @@ snapshots:
 
   diff-sequences@29.6.3: {}
 
-  diff@4.0.2: {}
+  diff@8.0.3: {}
 
   diffable-html@4.1.0:
     dependencies:


### PR DESCRIPTION
Closes MONOREP-317

 <!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
The dependency comes from `@wordpress/block-editor`, which in all our builds is extracted by dependency-extraction-webpack-plugin so this results in no changes to the build artifacts.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* CI happy?
* Should be no changes to the build artifacts.
