### PR TITLE
Slideshow block: Render as core gallery block in email

### DIFF
--- a/projects/plugins/jetpack/changelog/update-slideshow-email-block-rendering
+++ b/projects/plugins/jetpack/changelog/update-slideshow-email-block-rendering
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Render slideshow block as core gallery block in emails.

--- a/projects/plugins/jetpack/extensions/blocks/slideshow/slideshow.php
+++ b/projects/plugins/jetpack/extensions/blocks/slideshow/slideshow.php
@@ -129,12 +129,12 @@ function render_email( $block_content, array $parsed_block, $rendering_context )
 	}
 
 	// Build block content HTML for gallery caption extraction (if needed)
+	// The renderer uses $block_content parameter to extract gallery-level captions
 	$block_content_html = '<figure class="wp-block-gallery has-nested-images columns-default is-cropped"><ul class="blocks-gallery-grid"></ul></figure>';
 
 	// Create a mock parsed block that WooCommerce's gallery renderer can handle
 	// The renderer uses columns from attrs (defaults to 3, but 2 works better for email)
 	$mock_parsed_block = array(
-		'innerHTML'   => $block_content_html,
 		'innerBlocks' => $inner_blocks,
 		'attrs'       => array(
 			'columns' => 2,

--- a/projects/plugins/jetpack/extensions/blocks/slideshow/slideshow.php
+++ b/projects/plugins/jetpack/extensions/blocks/slideshow/slideshow.php
@@ -81,86 +81,75 @@ function load_assets( $attr, $content ) {
 function render_email( $block_content, array $parsed_block, $rendering_context ) {
 	// Validate input parameters and required dependencies
 	if ( ! isset( $parsed_block['attrs'] ) || ! is_array( $parsed_block['attrs'] ) ||
-		! class_exists( '\Automattic\WooCommerce\EmailEditor\Integrations\Utils\Styles_Helper' ) ||
-		! class_exists( '\Automattic\WooCommerce\EmailEditor\Integrations\Utils\Table_Wrapper_Helper' ) ) {
+		! class_exists( '\Automattic\WooCommerce\EmailEditor\Integrations\Core\Renderer\Blocks\Gallery' ) ) {
 		return '';
 	}
 
-	// Email rendering configuration - only extract values used multiple times
-	$email_grid_padding_margin = 20; // Total padding/margin space for grid layout
-	$email_common_margin       = 16; // Common margin/padding value used multiple times
-	$email_cell_padding        = 8; // Cell padding used in multiple places
-
-	$attr = $parsed_block['attrs'];
+	$attributes = $parsed_block['attrs'];
 
 	// Process images for email rendering
-	$images = process_slideshow_images_for_email( $attr );
+	$images = process_slideshow_images_for_email( $attributes );
 
 	if ( empty( $images ) ) {
 		return '';
 	}
 
-	// Determine target width from the email layout if available
-	$target_width = get_email_target_width( $rendering_context );
+	// Build innerBlocks that WooCommerce's gallery renderer expects
+	// The renderer looks for innerBlocks with blockName 'core/image' and innerHTML
+	$inner_blocks = array();
+	foreach ( $images as $image ) {
+		// Build image HTML in the format that extract_image_from_html() can parse
+		$img_html = sprintf(
+			'<img src="%s" alt="%s"',
+			esc_url( $image['url'] ),
+			esc_attr( $image['alt'] )
+		);
 
-	// Build grid content
-	$grid_content   = '';
-	$images_per_row = 2; // Two images per row for better email compatibility
-	$image_width    = floor( ( $target_width - $email_grid_padding_margin ) / $images_per_row ); // Account for padding/margins
+		if ( ! empty( $image['id'] ) ) {
+			$img_html .= sprintf( ' class="wp-image-%d"', absint( $image['id'] ) );
+		}
 
-	// Create rows
-	$image_chunks = array_chunk( $images, $images_per_row );
+		$img_html .= ' />';
 
-	foreach ( $image_chunks as $row_images ) {
-		$grid_content .= '<table role="presentation" style="width: 100%; border-collapse: collapse; margin: 0 0 ' . $email_common_margin . 'px 0; table-layout: fixed;"><tr>';
-
-		foreach ( $row_images as $image ) {
-					$grid_content .= sprintf(
-						'<td style="width: %dpx; padding: %dpx; vertical-align: top; text-align: center; font-family: Arial, sans-serif;">',
-						$image_width,
-						$email_cell_padding
-					);
-
-			// Build individual image content
-			$grid_content .= sprintf(
-				'<img src="%s" alt="%s" style="width: 100%%; max-width: %dpx; height: auto; display: block; border: 0; margin: 0 auto; border-radius: 4px;" />',
-				esc_url( $image['url'] ),
-				esc_attr( $image['alt'] ),
-				$image_width - $email_common_margin // Account for padding
+		// Add caption if available (extract_image_from_html looks for figcaption)
+		// Preserve HTML in captions - the gallery renderer will sanitize it
+		if ( ! empty( $image['caption'] ) ) {
+			$img_html .= sprintf(
+				'<figcaption>%s</figcaption>',
+				wp_kses_post( $image['caption'] )
 			);
-
-			// Add caption if available
-			if ( ! empty( $image['caption'] ) ) {
-				$grid_content .= sprintf(
-					'<p style="margin: 12px 0 0 0; padding: 0; font-size: 14px; color: #666666; line-height: 1.4; text-align: center; font-family: Arial, sans-serif;">%s</p>',
-					esc_html( wp_strip_all_tags( $image['caption'] ) )
-				);
-			}
-
-			$grid_content .= '</td>';
 		}
 
-		// Fill remaining cells if odd number of images in last row
-		$remaining_cells = $images_per_row - count( $row_images );
-		for ( $i = 0; $i < $remaining_cells; $i++ ) {
-			$grid_content .= sprintf( '<td style="width: %dpx; padding: %dpx;"></td>', $image_width, $email_cell_padding );
-		}
-
-		$grid_content .= '</tr></table>';
+		// Create inner block structure that the gallery renderer expects
+		// The renderer only uses innerHTML, not attrs
+		$inner_blocks[] = array(
+			'blockName' => 'core/image',
+			'innerHTML' => $img_html,
+		);
 	}
 
-	// Use Table_Wrapper_Helper for consistent email rendering
-	$image_table_attrs = array(
-		'style' => 'margin: ' . $email_common_margin . 'px 0; padding: 0; border-collapse: collapse;',
-		'width' => $target_width,
+	// Build block content HTML for gallery caption extraction (if needed)
+	$block_content_html = '<figure class="wp-block-gallery has-nested-images columns-default is-cropped"><ul class="blocks-gallery-grid"></ul></figure>';
+
+	// Create a mock parsed block that WooCommerce's gallery renderer can handle
+	// The renderer uses columns from attrs (defaults to 3, but 2 works better for email)
+	$mock_parsed_block = array(
+		'innerHTML'   => $block_content_html,
+		'innerBlocks' => $inner_blocks,
+		'attrs'       => array(
+			'columns' => 2,
+		),
 	);
 
-	$html = \Automattic\WooCommerce\EmailEditor\Integrations\Utils\Table_Wrapper_Helper::render_table_wrapper( $grid_content, $image_table_attrs );
+	// Preserve email_attrs if present (used for width calculation)
+	if ( ! empty( $parsed_block['email_attrs'] ) ) {
+		$mock_parsed_block['email_attrs'] = $parsed_block['email_attrs'];
+	}
 
-	// Add margin below the block
-	$html .= '<div style="margin-bottom: 2em;"></div>';
+	// Use WooCommerce's core gallery renderer
+	$woo_gallery_renderer = new \Automattic\WooCommerce\EmailEditor\Integrations\Core\Renderer\Blocks\Gallery();
 
-	return $html;
+	return $woo_gallery_renderer->render( $block_content_html, $mock_parsed_block, $rendering_context );
 }
 
 /**
@@ -376,28 +365,6 @@ function enqueue_swiper_library() {
 }
 
 /**
- * Get target width for email rendering.
- *
- * @param object $rendering_context Email rendering context.
- * @return int Target width in pixels.
- */
-function get_email_target_width( $rendering_context ) {
-	$target_width = 600; // Default
-
-	if ( ! empty( $rendering_context ) && is_object( $rendering_context ) && method_exists( $rendering_context, 'get_layout_width_without_padding' ) ) {
-		$layout_width_px = $rendering_context->get_layout_width_without_padding();
-		if ( is_string( $layout_width_px ) ) {
-			$parsed_width = \Automattic\WooCommerce\EmailEditor\Integrations\Utils\Styles_Helper::parse_value( $layout_width_px );
-			if ( $parsed_width > 0 ) {
-				$target_width = $parsed_width;
-			}
-		}
-	}
-
-	return $target_width;
-}
-
-/**
  * Process slideshow images for email rendering.
  *
  * @param array $attr Block attributes containing image data.
@@ -426,13 +393,14 @@ function process_slideshow_images_for_email( $attr ) {
 			$caption         = '';
 
 			// First try to get caption from images array if available (with validation)
+			// Preserve HTML in captions - the gallery renderer will sanitize it
 			if ( ! empty( $attr['images'] ) && is_array( $attr['images'] ) && isset( $attr['images'][ $index ]['caption'] ) ) {
-				$caption = wp_strip_all_tags( $attr['images'][ $index ]['caption'] );
+				$caption = wp_kses_post( $attr['images'][ $index ]['caption'] );
 			}
 
 			// If no caption in images array, get it from attachment post
 			if ( empty( $caption ) && $attachment_post && ! empty( $attachment_post->post_excerpt ) ) {
-				$caption = wp_strip_all_tags( $attachment_post->post_excerpt );
+				$caption = wp_kses_post( $attachment_post->post_excerpt );
 			}
 
 			if ( $image_url ) {
@@ -445,20 +413,20 @@ function process_slideshow_images_for_email( $attr ) {
 			}
 		}
 	} elseif ( ! empty( $attr['images'] ) && is_array( $attr['images'] ) ) {
-		// Fall back to images array if IDs aren't available (for testing)
+		// Fall back to images array if IDs aren't available (for edge cases/testing)
 		foreach ( $attr['images'] as $image_data ) {
 			if ( ! empty( $image_data['url'] ) ) {
-				// Validate and sanitize URL
+				// Sanitize URL - esc_url_raw returns empty string for invalid URLs
 				$url = esc_url_raw( $image_data['url'] );
-				if ( ! $url || ! wp_http_validate_url( $url ) ) {
+				if ( ! $url ) {
 					continue;
 				}
 
 				// Sanitize alt text
 				$alt_text = ! empty( $image_data['alt'] ) ? sanitize_text_field( $image_data['alt'] ) : '';
 
-				// Sanitize caption
-				$caption = ! empty( $image_data['caption'] ) ? wp_strip_all_tags( $image_data['caption'] ) : '';
+				// Preserve HTML in captions - the gallery renderer will sanitize it
+				$caption = ! empty( $image_data['caption'] ) ? wp_kses_post( $image_data['caption'] ) : '';
 
 				// Validate ID if present
 				$id = ! empty( $image_data['id'] ) ? absint( $image_data['id'] ) : 0;

--- a/projects/plugins/jetpack/tests/php/extensions/blocks/Slideshow_Block_Email_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/blocks/Slideshow_Block_Email_Test.php
@@ -5,16 +5,16 @@
  * @package automattic/jetpack
  */
 
+// Include mock classes for WooCommerce Email Editor helpers FIRST
+// This ensures the mock class is available when slideshow.php checks for it
+require_once __DIR__ . '/mocks/class-mock-woocommerce-gallery-renderer.php';
+
 require_once JETPACK__PLUGIN_DIR . 'extensions/blocks/slideshow/slideshow.php';
 
 // Ensure the function is available
 if ( ! function_exists( 'Automattic\Jetpack\Extensions\Slideshow\render_email' ) ) {
 	require_once JETPACK__PLUGIN_DIR . 'extensions/blocks/slideshow/slideshow.php';
 }
-
-// Include mock classes for WooCommerce Email Editor helpers
-require_once __DIR__ . '/mocks/class-mock-styles-helper.php';
-require_once __DIR__ . '/mocks/class-mock-table-wrapper-helper.php';
 
 use PHPUnit\Framework\Attributes\CoversFunction;
 
@@ -43,8 +43,28 @@ class Slideshow_Block_Email_Test extends WP_UnitTestCase {
 	public function set_up() {
 		parent::set_up();
 
-		// Create test attachments
+		// Create test attachments first
 		$this->create_test_attachments();
+
+		// Filter wp_get_attachment_image_url to return test URLs for our test attachments
+		$test_ids = $this->test_attachment_ids;
+		add_filter(
+			'wp_get_attachment_image_url',
+			function ( $url, $attachment_id ) use ( $test_ids ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+				if ( ! empty( $test_ids ) && in_array( $attachment_id, $test_ids, true ) ) {
+					$test_urls = array(
+						$test_ids[0] => 'http://example.com/wp-content/uploads/test-image-1.jpg',
+						$test_ids[1] => 'http://example.com/wp-content/uploads/test-image-2.jpg',
+					);
+					if ( isset( $test_urls[ $attachment_id ] ) ) {
+						return $test_urls[ $attachment_id ];
+					}
+				}
+				return $url;
+			},
+			10,
+			2
+		);
 	}
 
 	/**
@@ -63,17 +83,26 @@ class Slideshow_Block_Email_Test extends WP_UnitTestCase {
 	 * Helper to create a parsed block with test images.
 	 *
 	 * @param array $images_data Optional custom images data.
+	 * @param array $ids Optional attachment IDs. If not provided, only images array is used.
 	 * @return array Parsed block structure.
 	 */
-	private function create_parsed_block_with_images( $images_data = null ) {
+	private function create_parsed_block_with_images( $images_data = null, $ids = null ) {
 		if ( null === $images_data ) {
 			$images_data = $this->get_default_test_images();
 		}
 
+		$attrs = array(
+			'images' => $images_data,
+		);
+
+		// Only set ids if explicitly provided (for testing the ids path)
+		// Otherwise, rely on images array fallback which is more reliable for testing
+		if ( null !== $ids ) {
+			$attrs['ids'] = $ids;
+		}
+
 		return array(
-			'attrs' => array(
-				'images' => $images_data,
-			),
+			'attrs' => $attrs,
 		);
 	}
 
@@ -140,6 +169,7 @@ class Slideshow_Block_Email_Test extends WP_UnitTestCase {
 				'post_parent'  => $post_id,
 				'post_excerpt' => 'Photo by Test User on <a href="https://example.com">Example.com</a>',
 				'post_status'  => 'inherit',
+				'guid'         => 'http://example.com/wp-content/uploads/test-image-1.jpg',
 			)
 		);
 
@@ -151,6 +181,7 @@ class Slideshow_Block_Email_Test extends WP_UnitTestCase {
 				'post_parent'  => $post_id,
 				'post_excerpt' => 'Another test caption',
 				'post_status'  => 'inherit',
+				'guid'         => 'http://example.com/wp-content/uploads/test-image-2.jpg',
 			)
 		);
 
@@ -194,6 +225,7 @@ class Slideshow_Block_Email_Test extends WP_UnitTestCase {
 	 * Test render_email with valid IDs.
 	 */
 	public function test_render_email_with_valid_ids() {
+		// Test with images array (more reliable for testing)
 		$parsed_block = $this->create_parsed_block_with_images();
 		$mock_context = $this->create_rendering_context_mock();
 		$result       = \Automattic\Jetpack\Extensions\Slideshow\render_email( '', $parsed_block, $mock_context );
@@ -286,13 +318,13 @@ class Slideshow_Block_Email_Test extends WP_UnitTestCase {
 				'url'     => 'http://example.com/test-image-1.jpg',
 				'alt'     => 'Test Alt Text 1',
 				'caption' => 'Photo by Test User on <a href="https://example.com">Example.com</a>',
-				'id'      => 1,
+				'id'      => $this->test_attachment_ids[0],
 			),
 			array(
 				'url'     => 'http://example.com/test-image-2.jpg',
 				'alt'     => 'Test Alt Text 2',
 				'caption' => 'Another test caption',
-				'id'      => 2,
+				'id'      => $this->test_attachment_ids[1],
 			),
 		);
 
@@ -300,13 +332,13 @@ class Slideshow_Block_Email_Test extends WP_UnitTestCase {
 		$mock_context = $this->create_rendering_context_mock();
 		$result       = \Automattic\Jetpack\Extensions\Slideshow\render_email( '', $parsed_block, $mock_context );
 
-		// Should contain sanitized captions (HTML stripped)
-		$this->assertStringContainsString( 'Photo by Test User on Example.com', $result );
+		// Should contain captions (HTML preserved and sanitized by gallery renderer)
+		$this->assertStringContainsString( 'Photo by Test User on', $result );
 		$this->assertStringContainsString( 'Another test caption', $result );
 
-		// Should not contain raw HTML
-		$this->assertStringNotContainsString( '<a href="https://example.com">', $result );
-		$this->assertStringNotContainsString( '</a>', $result );
+		// Links in captions should be sanitized but may still appear
+		// The gallery renderer sanitizes HTML, so script tags should be removed
+		$this->assertStringNotContainsString( '<script>', $result );
 	}
 
 	/**
@@ -345,7 +377,7 @@ class Slideshow_Block_Email_Test extends WP_UnitTestCase {
 		$mock_context = $this->create_rendering_context_mock();
 		$result       = \Automattic\Jetpack\Extensions\Slideshow\render_email( '', $parsed_block, $mock_context );
 
-		// Should have table-based grid structure
+		// Should have table-based grid structure (from core gallery renderer)
 		$this->assertStringContainsString( 'role="presentation"', $result );
 		$this->assertStringContainsString( 'table-layout: fixed', $result );
 		$this->assertStringContainsString( 'border-collapse: collapse', $result );
@@ -356,7 +388,7 @@ class Slideshow_Block_Email_Test extends WP_UnitTestCase {
 
 		// Should have inline styles for email compatibility
 		$this->assertStringContainsString( 'style="', $result );
-		$this->assertStringContainsString( 'font-family: Arial, sans-serif', $result );
+		$this->assertStringContainsString( 'email-block-gallery', $result );
 	}
 
 	/**
@@ -367,14 +399,16 @@ class Slideshow_Block_Email_Test extends WP_UnitTestCase {
 		$parsed_block = $this->create_parsed_block_with_images();
 		$result       = \Automattic\Jetpack\Extensions\Slideshow\render_email( '', $parsed_block, $mock_context );
 
-		// Should use the provided width
-		$this->assertStringContainsString( 'max-width: 800px', $result );
+		// Should return HTML (width is handled by the gallery renderer)
+		$this->assertNotEmpty( $result );
+		$this->assertStringContainsString( '<table', $result );
 	}
 
 	/**
 	 * Test render_email with odd number of images.
 	 */
 	public function test_render_email_with_odd_number_of_images() {
+		// Use images array for reliable testing
 		$images_data = array(
 			array(
 				'url'     => 'http://example.com/test-image-1.jpg',
@@ -400,13 +434,12 @@ class Slideshow_Block_Email_Test extends WP_UnitTestCase {
 		$mock_context = $this->create_rendering_context_mock();
 		$result       = \Automattic\Jetpack\Extensions\Slideshow\render_email( '', $parsed_block, $mock_context );
 
-		// Should have 3 images (2 in first row, 1 in second row)
-		$this->assertStringContainsString( 'test-image-1.jpg', $result );
-		$this->assertStringContainsString( 'test-image-2.jpg', $result );
-		$this->assertStringContainsString( 'test-image-3.jpg', $result );
-
-		// Should have empty cell for the last row
-		$this->assertStringContainsString( '<td style="width:', $result );
+		// Should have 3 images (gallery renderer handles layout)
+		$this->assertNotEmpty( $result );
+		$this->assertStringContainsString( '<img', $result );
+		$this->assertStringContainsString( 'Test Alt Text 1', $result );
+		$this->assertStringContainsString( 'Test Alt Text 2', $result );
+		$this->assertStringContainsString( 'Test Alt Text 3', $result );
 	}
 
 	/**
@@ -426,31 +459,31 @@ class Slideshow_Block_Email_Test extends WP_UnitTestCase {
 		$mock_context = $this->create_rendering_context_mock();
 		$result       = \Automattic\Jetpack\Extensions\Slideshow\render_email( '', $parsed_block, $mock_context );
 
-		// Should contain the caption text but not the script
+		// Should contain the caption text but not the script tag
+		// The text "alert("XSS")" may appear but it's safe as long as script tags are removed
 		$this->assertStringContainsString( 'Malicious caption', $result );
 		$this->assertStringNotContainsString( '<script>', $result );
-		$this->assertStringNotContainsString( 'alert("XSS")', $result );
+		$this->assertStringNotContainsString( '</script>', $result );
+		// The gallery renderer sanitizes HTML, so script tags are removed but text may remain
 	}
 
 	/**
-	 * Test render_email returns empty when WooCommerce Email Editor helper classes are missing.
+	 * Test render_email returns empty when WooCommerce Email Editor gallery renderer class is missing.
 	 */
-	public function test_render_email_returns_empty_when_helpers_missing() {
-		// Test that the function returns empty when helper classes don't exist
+	public function test_render_email_returns_empty_when_gallery_renderer_missing() {
+		// Test that the function returns empty when gallery renderer class doesn't exist
 		// This test verifies the upfront class checking behavior
 		$parsed_block = $this->create_parsed_block_with_images();
 		$mock_context = $this->create_rendering_context_mock();
 
-		// Verify that with mocked classes, the function works
+		// Verify that with mocked class, the function works
 		$result_with_mocks = \Automattic\Jetpack\Extensions\Slideshow\render_email( '', $parsed_block, $mock_context );
 		$this->assertNotEmpty( $result_with_mocks );
 
 		// Test the class existence check logic directly
-		$styles_helper_exists = class_exists( '\Automattic\WooCommerce\EmailEditor\Integrations\Utils\Styles_Helper' );
-		$table_helper_exists  = class_exists( '\Automattic\WooCommerce\EmailEditor\Integrations\Utils\Table_Wrapper_Helper' );
+		$gallery_renderer_exists = class_exists( '\Automattic\WooCommerce\EmailEditor\Integrations\Core\Renderer\Blocks\Gallery' );
 
-		// Both classes should exist due to our mocks
-		$this->assertTrue( $styles_helper_exists, 'Styles_Helper class should be mocked and available' );
-		$this->assertTrue( $table_helper_exists, 'Table_Wrapper_Helper class should be mocked and available' );
+		// Gallery renderer class should exist due to our mock
+		$this->assertTrue( $gallery_renderer_exists, 'Gallery renderer class should be mocked and available' );
 	}
 }

--- a/projects/plugins/jetpack/tests/php/extensions/blocks/mocks/class-mock-woocommerce-gallery-renderer.php
+++ b/projects/plugins/jetpack/tests/php/extensions/blocks/mocks/class-mock-woocommerce-gallery-renderer.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * Mock class for WooCommerce Email Editor Gallery Renderer
+ *
+ * @package automattic/jetpack
+ */
+
+// Mock WooCommerce Gallery Renderer class for testing
+if ( ! class_exists( '\Automattic\WooCommerce\EmailEditor\Integrations\Core\Renderer\Blocks\Gallery' ) ) {
+	/**
+	 * Mock implementation of WooCommerce Gallery Renderer for testing
+	 */
+	class Mock_WooCommerce_Gallery_Renderer {
+		/**
+		 * Mock render method
+		 *
+		 * @param string $block_content The block content.
+		 * @param array  $parsed_block  The parsed block data.
+		 * @param object $rendering_context The email rendering context.
+		 * @return string
+		 */
+		public function render( $block_content, $parsed_block, $rendering_context ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+			$inner_blocks = $parsed_block['innerBlocks'] ?? array();
+			$attributes   = $parsed_block['attrs'] ?? array();
+			$columns      = $attributes['columns'] ?? 3;
+
+			if ( empty( $inner_blocks ) ) {
+				return '';
+			}
+
+			// Extract images from innerBlocks
+			$gallery_images = array();
+			foreach ( $inner_blocks as $block ) {
+				if ( 'core/image' === $block['blockName'] && isset( $block['innerHTML'] ) ) {
+					// Extract image HTML from innerHTML
+					if ( preg_match( '/<img[^>]*>/', $block['innerHTML'], $img_matches ) ) {
+						$img_html = $img_matches[0];
+
+						// Extract caption if present
+						if ( preg_match( '/<figcaption[^>]*>(.*?)<\/figcaption>/s', $block['innerHTML'], $caption_matches ) ) {
+							$caption   = wp_kses_post( trim( $caption_matches[1] ) );
+							$img_html .= '<br><div class="wp-element-caption" style="font-size: 13px; line-height: 1.0;">' . $caption . '</div>';
+						}
+
+						$gallery_images[] = $img_html;
+					}
+				}
+			}
+
+			if ( empty( $gallery_images ) ) {
+				return '';
+			}
+
+			// Build table-based layout
+			$content_parts = array();
+			$image_count   = count( $gallery_images );
+			$cell_padding  = 8;
+
+			// Process images in chunks based on columns
+			for ( $i = 0; $i < $image_count; $i += $columns ) {
+				$row_images = array_slice( $gallery_images, $i, $columns );
+				$row_cells  = '';
+
+				foreach ( $row_images as $image_html ) {
+					$cell_width_percent = 100 / count( $row_images );
+					$row_cells         .= sprintf(
+						'<td style="width: %.2f%%; padding: %dpx; vertical-align: top; text-align: center;" valign="top">%s</td>',
+						$cell_width_percent,
+						$cell_padding,
+						$image_html
+					);
+				}
+
+				$content_parts[] = sprintf(
+					'<table role="presentation" style="width: 100%%; border-collapse: collapse; table-layout: fixed;"><tr>%s</tr></table>',
+					$row_cells
+				);
+			}
+
+			// Wrap in main table
+			return sprintf(
+				'<table role="presentation" class="email-block-gallery" style="width: 100%%; border-collapse: collapse; text-align: left;" align="left" width="100%%"><tr><td>%s</td></tr></table>',
+				implode( '', $content_parts )
+			);
+		}
+	}
+
+	// Use class_alias to create the namespaced class
+	if ( ! class_exists( '\Automattic\WooCommerce\EmailEditor\Integrations\Core\Renderer\Blocks\Gallery' ) ) {
+		class_alias( 'Mock_WooCommerce_Gallery_Renderer', '\Automattic\WooCommerce\EmailEditor\Integrations\Core\Renderer\Blocks\Gallery' );
+	}
+}

--- a/projects/plugins/jetpack/tests/php/extensions/blocks/mocks/class-mock-woocommerce-gallery-renderer.php
+++ b/projects/plugins/jetpack/tests/php/extensions/blocks/mocks/class-mock-woocommerce-gallery-renderer.php
@@ -84,9 +84,5 @@ if ( ! class_exists( '\Automattic\WooCommerce\EmailEditor\Integrations\Core\Rend
 			);
 		}
 	}
-
-	// Use class_alias to create the namespaced class
-	if ( ! class_exists( '\Automattic\WooCommerce\EmailEditor\Integrations\Core\Renderer\Blocks\Gallery' ) ) {
-		class_alias( 'Mock_WooCommerce_Gallery_Renderer', '\Automattic\WooCommerce\EmailEditor\Integrations\Core\Renderer\Blocks\Gallery' );
-	}
+	class_alias( 'Mock_WooCommerce_Gallery_Renderer', '\Automattic\WooCommerce\EmailEditor\Integrations\Core\Renderer\Blocks\Gallery' );
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://linear.app/a8c/issue/NL-153/slideshow-block-re-use-core-gallery-block-rendering

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* I previously added gallery block rendering specifically for the slideshow block, then later realized we could re-purpose the gallery block rendering in the WooCommerce Email Editor package. I'm implementing that here to reduce the logic and code needed, and align the gallery rendering with the package gallery rendering. We'll get links in captions (sanitized in the package) and better email client compatibility.

Before | After
---- | ----
<img width="480" height="746" alt="Screenshot 2026-01-15 at 3 58 10 PM" src="https://github.com/user-attachments/assets/b68e6f6f-d8a5-4fbf-a504-d2bef2e1ff35" /> | <img width="446" height="738" alt="Screenshot 2026-01-15 at 3 57 36 PM" src="https://github.com/user-attachments/assets/a8083819-c357-4c3b-be32-63d61f621ce6" />


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

https://linear.app/a8c/issue/NL-153/slideshow-block-re-use-core-gallery-block-rendering

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

N/A

## Testing instructions:

* Apply this change to your sandbox: `bin/jetpack-downloader test jetpack update/slideshow-email-block-rendering`
* Sandbox the API.
* Sandbox all jobs: `add_filter( 'sandbox_async_job', '__return_true', 10, 2 );`
* Run the jobs watcher: `php /home/wpcom/public_html/async-jobs/watcher.php`
* Turn on write access: `allow-sandbox-production-writes "10 minutes"`
* Create a post with a slideshow in it. Add images with captions and links (e.g. Pexel images).
* In the Jetpack newsletter panel, preview the email. Verify that the slideshow becomes a gallery.
* Send a test email. Verify that the links work.
* Publish the post and send it to at least one subscriber. Verify that the gallery looks the same as in the preview.

