### PR TITLE
Revert "Update Jetpack dashboard links to My Jetpack (MYJP-286)"

### DIFF
--- a/projects/js-packages/components/changelog/update-dashboard-links-myjp-286
+++ b/projects/js-packages/components/changelog/update-dashboard-links-myjp-286
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-General: Update dashboard links to point to new locations.

--- a/projects/js-packages/components/components/jetpack-footer/index.tsx
+++ b/projects/js-packages/components/components/jetpack-footer/index.tsx
@@ -2,6 +2,7 @@ import { __, _x } from '@wordpress/i18n';
 import { Icon, external } from '@wordpress/icons';
 import clsx from 'clsx';
 import { getRedirectUrl } from '../../index.ts';
+import getSiteAdminUrl from '../../tools/get-site-admin-url/index.ts';
 import AutomatticBylineLogo from '../automattic-byline-logo/index.tsx';
 import './style.scss';
 import JetpackLogo from '../jetpack-logo/index.tsx';
@@ -36,7 +37,6 @@ const JetpackFooter: FC< JetpackFooterProps > = ( {
 	className,
 	moduleNameHref = 'https://jetpack.com',
 	menu,
-	// eslint-disable-next-line @typescript-eslint/no-unused-vars -- Prop kept for backwards compatibility. Remove after consumers of this component have updated.
 	useInternalLinks,
 	onAboutClick,
 	onPrivacyClick,
@@ -47,19 +47,25 @@ const JetpackFooter: FC< JetpackFooterProps > = ( {
 	const [ isMd ] = useBreakpointMatch( 'md', '<=' );
 	const [ isLg ] = useBreakpointMatch( 'lg', '>' );
 
+	const siteAdminUrl = getSiteAdminUrl();
+
 	let items: JetpackFooterMenuItem[] = [
 		{
 			label: _x( 'About', 'Link to learn more about Jetpack.', 'jetpack-components' ),
 			title: __( 'About Jetpack', 'jetpack-components' ),
-			href: getRedirectUrl( 'jetpack-about' ),
-			target: '_blank',
+			href: useInternalLinks
+				? new URL( 'admin.php?page=jetpack_about', siteAdminUrl ).href
+				: getRedirectUrl( 'jetpack-about' ),
+			target: useInternalLinks ? '_self' : '_blank',
 			onClick: onAboutClick,
 		},
 		{
 			label: _x( 'Privacy', 'Shorthand for Privacy Policy.', 'jetpack-components' ),
 			title: __( "Automattic's Privacy Policy", 'jetpack-components' ),
-			href: getRedirectUrl( 'a8c-privacy' ),
-			target: '_blank',
+			href: useInternalLinks
+				? new URL( 'admin.php?page=jetpack#/privacy', siteAdminUrl ).href
+				: getRedirectUrl( 'a8c-privacy' ),
+			target: useInternalLinks ? '_self' : '_blank',
 			onClick: onPrivacyClick,
 		},
 		{
@@ -132,10 +138,12 @@ const JetpackFooter: FC< JetpackFooterProps > = ( {
 				} ) }
 				<li className="jp-dashboard-footer__a8c-item">
 					<a
-						href={ getRedirectUrl( 'a8c-about' ) }
-						target="_blank"
+						href={
+							useInternalLinks
+								? new URL( 'admin.php?page=jetpack_about', siteAdminUrl ).href
+								: getRedirectUrl( 'a8c-about' )
+						}
 						aria-label={ __( 'An Automattic Airline', 'jetpack-components' ) }
-						rel="noreferrer"
 					>
 						<AutomatticBylineLogo aria-hidden="true" />
 					</a>

--- a/projects/js-packages/components/components/jetpack-footer/test/__snapshots__/component.tsx.snap
+++ b/projects/js-packages/components/components/jetpack-footer/test/__snapshots__/component.tsx.snap
@@ -173,8 +173,6 @@ exports[`JetpackFooter Render the component should match the snapshot: all props
         <a
           aria-label="An Automattic Airline"
           href="https://jetpack.com/redirect/?source=a8c-about"
-          rel="noreferrer"
-          target="_blank"
         >
           <svg
             aria-hidden="true"

--- a/projects/plugins/jetpack/_inc/client/components/masthead/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/masthead/index.jsx
@@ -8,7 +8,6 @@ import {
 	getSandboxDomain,
 	fetchSiteConnectionTest,
 } from 'state/connection';
-import { getSiteAdminUrl } from 'state/initial-state';
 import { HeaderNav } from './header-nav';
 
 export class Masthead extends Component {
@@ -24,7 +23,7 @@ export class Masthead extends Component {
 	};
 
 	render() {
-		const { sandboxDomain, siteAdminUrl, siteConnectionStatus } = this.props;
+		const { sandboxDomain, siteConnectionStatus } = this.props;
 
 		const offlineNotice = siteConnectionStatus === 'offline' ? <code>Offline Mode</code> : '',
 			sandboxedBadge = sandboxDomain ? (
@@ -47,11 +46,7 @@ export class Masthead extends Component {
 			<div className="jp-masthead">
 				<div className="jp-masthead__inside-container">
 					<div className="jp-masthead__logo-container">
-						<a
-							onClick={ this.trackLogoClick }
-							className="jp-masthead__logo-link"
-							href={ siteAdminUrl + 'admin.php?page=my-jetpack' }
-						>
+						<a onClick={ this.trackLogoClick } className="jp-masthead__logo-link" href="#dashboard">
 							<JetpackLogo className="jetpack-logo__masthead" height={ 40 } />
 						</a>
 						{ offlineNotice }
@@ -68,7 +63,6 @@ export default connect(
 	state => {
 		return {
 			sandboxDomain: getSandboxDomain( state ),
-			siteAdminUrl: getSiteAdminUrl( state ),
 			siteConnectionStatus: getSiteConnectionStatus( state ),
 		};
 	},

--- a/projects/plugins/jetpack/_inc/lib/admin-pages/class.jetpack-admin-page.php
+++ b/projects/plugins/jetpack/_inc/lib/admin-pages/class.jetpack-admin-page.php
@@ -248,11 +248,19 @@ abstract class Jetpack_Admin_Page {
 		);
 		$args     = wp_parse_args( $args, $defaults );
 
-		$jetpack_admin_url    = admin_url( 'admin.php?page=my-jetpack' );
-		$jetpack_settings_url = admin_url( 'admin.php?page=jetpack#/settings' );
-		$jetpack_about_url    = Redirect::get_url( 'jetpack-about' );
+		// Is Jetpack not connected and not offline?
+		// True means that Jetpack is NOT connected and NOT in offline mode.
+		// If Jetpack is connected OR in offline mode, this will be false.
+		$connectable = ! Jetpack::is_connection_ready() && ! ( new Status() )->is_offline_mode();
 
-		$jetpack_privacy_url = Redirect::get_url( 'a8c-privacy' );
+		$jetpack_admin_url = admin_url( 'admin.php?page=jetpack' );
+		$jetpack_about_url = ! $connectable
+			? admin_url( 'admin.php?page=jetpack_about' )
+			: Redirect::get_url( 'jetpack' );
+
+		$jetpack_privacy_url = ! $connectable
+			? $jetpack_admin_url . '#/privacy'
+			: Redirect::get_url( 'a8c-privacy' );
 
 		$external_link_icon = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" class="jp-footer__menu-item__icon" aria-hidden="true" focusable="false"><path d="M18.2 17c0 .7-.6 1.2-1.2 1.2H7c-.7 0-1.2-.6-1.2-1.2V7c0-.7.6-1.2 1.2-1.2h3.2V4.2H7C5.5 4.2 4.2 5.5 4.2 7v10c0 1.5 1.2 2.8 2.8 2.8h10c1.5 0 2.8-1.2 2.8-2.8v-3.6h-1.5V17zM14.9 3v1.5h3.7l-6.4 6.4 1.1 1.1 6.4-6.4v3.7h1.5V3h-6.3z"></path></svg>';
 
@@ -301,7 +309,7 @@ abstract class Jetpack_Admin_Page {
 														<?php
 														if ( current_user_can( 'jetpack_manage_modules' ) ) {
 															?>
-										<a href="<?php echo esc_url( $jetpack_settings_url ); ?>" type="button" class="dops-button is-compact"><?php esc_html_e( 'Settings', 'jetpack' ); ?></a>
+										<a href="<?php echo esc_url( $jetpack_admin_url . '#/settings' ); ?>" type="button" class="dops-button is-compact"><?php esc_html_e( 'Settings', 'jetpack' ); ?></a>
 															<?php
 														}
 														?>
@@ -354,13 +362,12 @@ abstract class Jetpack_Admin_Page {
 						</span>
 					</div>
 					<div class="jp-footer__menu">
-						<a href="<?php echo esc_url( $jetpack_about_url ); ?>" target="_blank" rel="noopener noreferrer" title="<?php esc_attr__( 'About Jetpack', 'jetpack' ); ?>" class="jp-footer__menu-item is-external">
+						<a href="<?php echo esc_url( $jetpack_about_url ); ?>" title="<?php esc_attr__( 'About Jetpack', 'jetpack' ); ?>" class="jp-footer__menu-item">
 							<?php echo esc_html__( 'About', 'jetpack' ); ?>
-							<?php echo $external_link_icon; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 						</a>
-						<a href="<?php echo esc_url( $jetpack_privacy_url ); ?>" target="_blank" rel="noopener noreferrer" title="<?php esc_html_e( "Automattic's Privacy Policy", 'jetpack' ); ?>" class="jp-footer__menu-item is-external">
+						<a href="<?php echo esc_url( $jetpack_privacy_url ); ?>" rel="noopener noreferrer" title="<?php esc_html_e( "Automattic's Privacy Policy", 'jetpack' ); ?>" class="jp-footer__menu-item <?php echo ! $connectable ? 'is-external' : ''; ?> ?>" target="<?php echo ! $connectable ? '_blank' : '_self'; ?>">
 							<?php echo esc_html_x( 'Privacy', 'Navigation item', 'jetpack' ); ?>
-							<?php echo $external_link_icon; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+							<?php echo ! $connectable ? $external_link_icon : ''; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 						</a>
 						<a href="<?php echo esc_url( Redirect::get_url( 'wpcom-tos' ) ); ?>" target="_blank" rel="noopener noreferrer" title="<?php esc_html__( 'WordPress.com Terms of Service', 'jetpack' ); ?>" class="jp-footer__menu-item is-external">
 							<?php echo esc_html_x( 'Terms', 'Navigation item', 'jetpack' ); ?>
@@ -381,7 +388,7 @@ abstract class Jetpack_Admin_Page {
 							<a href="<?php echo esc_url( admin_url( 'admin.php?page=jetpack-debugger' ) ); ?>" title="<?php esc_html_e( "Test your site's compatibility with Jetpack.", 'jetpack' ); ?>" class="jp-footer__menu-item"><?php echo esc_html_x( 'Debug', 'Navigation item', 'jetpack' ); ?></a>
 						<?php } ?>
 					</div>
-					<a class="jp-footer__a8c-logo" href="<?php echo esc_url( Redirect::get_url( 'a8c-about' ) ); ?>" target="_blank" aria-label="<?php echo esc_attr__( 'An Automattic Airline', 'jetpack' ); ?>">
+					<a class="jp-footer__a8c-logo" href="<?php echo esc_url( $jetpack_about_url ); ?>" aria-label="<?php echo esc_attr__( 'An Automattic Airline', 'jetpack' ); ?>">
 						<svg role="img" x="0" y="0" viewBox="0 0 935 38.2" enable-background="new 0 0 935 38.2" aria-labelledby="jp-automattic-byline-logo-title" height="7" class="jp-automattic-byline-logo">
 							<desc id="jp-automattic-byline-logo-title">
 								<?php echo esc_attr__( 'An Automattic Airline', 'jetpack' ); ?>

--- a/projects/plugins/jetpack/changelog/copilot-update-dashboard-links-myjp-286
+++ b/projects/plugins/jetpack/changelog/copilot-update-dashboard-links-myjp-286
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-Dashboard: update navigation links across settings, modules, and debugger pages to redirect to My Jetpack.


### PR DESCRIPTION
## Proposed changes:
Reverts Automattic/jetpack#46508
Because MY Jetpack is not available on .com.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1768503418524029-slack-C08PN0LHCCT

## Does this pull request change what data or activity we track or use?
None

## Testing instructions:
None