### PR TITLE
Add tablet device detection to WooCommerce Analytics events

### DIFF
--- a/projects/packages/woocommerce-analytics/changelog/add-tablet-device-detection
+++ b/projects/packages/woocommerce-analytics/changelog/add-tablet-device-detection
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Analytics: add tablet device detection to the 'device' event property, distinguishing between mobile, tablet, and desktop devices.

--- a/projects/packages/woocommerce-analytics/changelog/add-tablet-device-detection
+++ b/projects/packages/woocommerce-analytics/changelog/add-tablet-device-detection
@@ -1,4 +1,4 @@
 Significance: minor
 Type: added
 
-Analytics: add tablet device detection to the 'device' event property, distinguishing between mobile, tablet, and desktop devices.
+Add tablet device detection to the 'device' event property, distinguishing between mobile, tablet, and desktop devices

--- a/projects/packages/woocommerce-analytics/src/class-woo-analytics-trait.php
+++ b/projects/packages/woocommerce-analytics/src/class-woo-analytics-trait.php
@@ -9,6 +9,7 @@ namespace Automattic\Woocommerce_Analytics;
 
 use Automattic\Block_Scanner;
 use Automattic\Jetpack\Connection\Manager as Jetpack_Connection;
+use Automattic\Jetpack\Device_Detection;
 use WC_Order_Item;
 use WC_Order_Item_Product;
 use WC_Payment_Gateway;
@@ -268,7 +269,7 @@ trait Woo_Analytics_Trait {
 			'woo_version'    => WC()->version,
 			'wp_version'     => get_bloginfo( 'version' ),
 			'store_admin'    => in_array( array( 'administrator', 'shop_manager' ), wp_get_current_user()->roles, true ) ? 1 : 0,
-			'device'         => wp_is_mobile() ? 'mobile' : 'desktop',
+			'device'         => $this->get_device_type(),
 			'store_currency' => get_woocommerce_currency(),
 			'timezone'       => wp_timezone_string(),
 			'is_guest'       => ( $this->get_user_id() === null ) ? 1 : 0,
@@ -371,6 +372,25 @@ trait Woo_Analytics_Trait {
 			return $blogid . ':' . $userid;
 		}
 		return null;
+	}
+
+	/**
+	 * Get the device type for the current request.
+	 *
+	 * Uses Jetpack Device Detection to distinguish between mobile phones, tablets, and desktop devices.
+	 *
+	 * @return string 'mobile' for phones, 'tablet' for tablets, 'desktop' otherwise.
+	 */
+	protected function get_device_type() {
+		if ( Device_Detection::is_phone() ) {
+			return 'mobile';
+		}
+
+		if ( Device_Detection::is_tablet() ) {
+			return 'tablet';
+		}
+
+		return 'desktop';
 	}
 
 	/**


### PR DESCRIPTION
Fixes WOOA7S-977

## Proposed changes:
* Add tablet device detection to the `device` event property in WooCommerce Analytics
* Replace `wp_is_mobile()` with Jetpack Device Detection package for more granular device categorization
* The `device` property now reports three distinct values: `mobile`, `tablet`, and `desktop`

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
N/A

## Does this pull request change what data or activity we track or use?
Yes - this PR enhances the existing `device` tracking property to distinguish tablets from mobile phones. Previously, tablets were grouped with mobile phones under the `mobile` value. Now:
- `mobile` - phones only
- `tablet` - tablets only
- `desktop` - desktop/laptop browsers

This provides more granular analytics data without changing the fundamental tracking behavior.

## Testing instructions:

1. Set up a WooCommerce store with Jetpack connected
2. Deactivate `WooCommerce Analytics` plugin if it's activated
3. Go to site frontend
4. Open browser DevTools
5. Inspect the `window.wcAnalytics.commonProps.device` and verify:
   - From a phone browser/user agent: should be `mobile`
   - From a tablet browser/user agent: should be `tablet`
   - From a desktop browser: should be `desktop`

**To test with different user agents:**
- Use browser DevTools to emulate different devices

**Known issues:** The device detection is based on user agent strings, which may not always accurately reflect the device type. For example, since **iPadOS 13+ intentionally reports itself as “Macintosh” to receive desktop websites**, it's impossible to detect it as a tablet using the user agent string alone when it’s running on an iPad. We can iterate on this in the future if needed.

<img width="2512" height="1306" alt="Screenshot 2026-01-16 at 15 25 44" src="https://github.com/user-attachments/assets/8b654943-1a44-441c-a14e-57a8ab73d7ee" />
<img width="2554" height="1333" alt="Screenshot 2026-01-16 at 15 25 03" src="https://github.com/user-attachments/assets/fb1edddc-464e-4ed9-ab47-6b8ccd7179ca" />
<img width="2560" height="1336" alt="Screenshot 2026-01-16 at 15 25 34" src="https://github.com/user-attachments/assets/10a5c993-6082-4356-91d7-f6fb085ebad6" />


