### PR TITLE
Enabled Custom CSS on Atomic sites when GS on personal

### DIFF
--- a/projects/plugins/wpcomsh/changelog/dotcom-15735-custom-css-should-be-enabled-on-plans-with-global-styles
+++ b/projects/plugins/wpcomsh/changelog/dotcom-15735-custom-css-should-be-enabled-on-plans-with-global-styles
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Atomic sites that have access to Global Styles can use Custom CSS

--- a/projects/plugins/wpcomsh/feature-plugins/additional-css.php
+++ b/projects/plugins/wpcomsh/feature-plugins/additional-css.php
@@ -18,6 +18,11 @@ function wpcomsh_maybe_disable_custom_css() {
 		return;
 	}
 
+	// If global styles are enabled on personal plan, all atomic sites have custom css enabled.
+	if ( function_exists( 'is_global_styles_on_personal_plan' ) && is_global_styles_on_personal_plan() && defined( 'IS_ATOMIC' ) && IS_ATOMIC ) {
+		return;
+	}
+
 	add_action( 'admin_menu', 'wpcomsh_custom_css_admin_menu' );
 	add_filter( 'jetpack_get_available_modules', 'wpcomsh_custom_css_remove_available_module' );
 	add_filter( 'jetpack_active_modules', 'wpcomsh_custom_css_remove_active_module' );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes:
- https://linear.app/a8c/issue/DOTCOM-15735/custom-css-should-be-enabled-on-plans-with-global-styles-enabled

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* On Atomic sites, if we have GS on Personal, we show the Custom CSS panel for consistency with Simple sites.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply to an Atomic site on the Personal plan
* Use a non-block theme
* Go to the customizer's Custom CSS section
* You should be abe to use the feature without being prompted to upgrade.

