### PR TITLE
Forms: fix z-index stacking order for animated labels and combobox

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-elevate-surfaces-by-1
+++ b/projects/packages/forms/changelog/fix-forms-elevate-surfaces-by-1
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Contact Form: fix z-index stacking order for animated labels and combobox dropdown.

--- a/projects/packages/forms/src/contact-form/css/combobox.scss
+++ b/projects/packages/forms/src/contact-form/css/combobox.scss
@@ -183,7 +183,7 @@
 .contact-form .wp-block-jetpack-input-wrap {
 
 	&:has(.is-combobox-open) {
-		z-index: 2;
+		z-index: 3;
 	}
 }
 

--- a/projects/packages/forms/src/contact-form/css/grunion.scss
+++ b/projects/packages/forms/src/contact-form/css/grunion.scss
@@ -948,7 +948,7 @@ on production builds, the attributes are being reordered, causing side-effects
 	margin: 0;
 	transform: translateY(-50%);
 	transition: translatey 150ms cubic-bezier(0.4, 0, 0.2, 1);
-	z-index: 1;
+	z-index: 2;
 }
 
 .contact-form .is-style-animated .grunion-field-wrap .grunion-label-text {


### PR DESCRIPTION
Part of FORMS-532

## Proposed changes:
* Increase z-index values by 1 for animated labels and combobox dropdown to fix stacking order issues
* Animated labels now use z-index: 2 (was 1)
* Combobox open state now uses z-index: 3 (was 2)

Before (notice the lack of label visibility on the dropdown):
<img width="671" height="416" alt="image" src="https://github.com/user-attachments/assets/9c13a3a1-1e7d-4fa5-995f-da608cf842a3" />

After:
<img width="719" height="418" alt="image" src="https://github.com/user-attachments/assets/0792c991-4fd7-49cd-8b18-4fa9b4f37d82" />

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

N/A

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

1. Create a Jetpack Form block with multiple fields, including a combobox/dropdown field
2. Use the "Animated" style for the form
3. Open the combobox dropdown
4. Verify the dropdown appears above the animated label elements and is not cut off or hidden behind other form elements
