### PR TITLE
Forms: use empty state component for new wp-build dashboard

### DIFF
--- a/projects/packages/forms/changelog/update-forms-wp-build-dashboard-empty
+++ b/projects/packages/forms/changelog/update-forms-wp-build-dashboard-empty
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Use empty state component for new dashboard.

--- a/projects/packages/forms/routes/responses/stage.tsx
+++ b/projects/packages/forms/routes/responses/stage.tsx
@@ -24,6 +24,7 @@ import * as React from 'react';
  * Internal dependencies
  */
 import IntegrationsModal from '../../src/blocks/contact-form/components/jetpack-integrations-modal';
+import EmptyResponses from '../../src/dashboard/components/empty-responses';
 import Flag from '../../src/dashboard/components/flag';
 import Gravatar from '../../src/dashboard/components/gravatar';
 import Page, { Stack } from '../../src/dashboard/components/page';
@@ -1044,6 +1045,9 @@ function Stage() {
 		showDashboardIntegrations,
 	] );
 
+	// Check if read_status filter is applied
+	const readStatusFilter = view.filters?.find( filter => filter.field === 'read_status' )?.value;
+
 	return (
 		<Page
 			showSidebarToggle={ false }
@@ -1058,6 +1062,13 @@ function Stage() {
 			hasPadding={ false }
 		>
 			<DataViews
+				empty={
+					<EmptyResponses
+						status={ params.view }
+						isSearch={ !! view.search }
+						readStatusFilter={ readStatusFilter }
+					/>
+				}
 				data={ records || EMPTY_ARRAY }
 				fields={ fields as Field< unknown >[] }
 				view={ view }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Follow-up to FORMS-442

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

* Match old dashboard behaviour for empty states

Before

<img width="1264" height="1134" alt="image" src="https://github.com/user-attachments/assets/d86b376f-062c-4619-bed7-1b673f7f21cc" />

<img width="1280" height="1137" alt="image" src="https://github.com/user-attachments/assets/e98228c7-9820-4c75-9ed9-8f1aef6b8362" />

After

<img width="1272" height="1131" alt="Screenshot 2026-01-16 at 16 42 23" src="https://github.com/user-attachments/assets/c841a0f8-533a-4694-b928-2c5fd7725246" />
<img width="1283" height="1141" alt="Screenshot 2026-01-16 at 16 42 48" src="https://github.com/user-attachments/assets/a93015df-12ea-4d4c-9a23-67e924d9d141" />


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Build new dash with `cd projects/packages/forms && pnpm run watch:wp-build`
* See empty states in new dash
