### PR TITLE
Jetpack: Fix test after changed behavior in wpcomsh

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-jetpack-wpcomsh-test
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-wpcomsh-test
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Fix test after #46632 changed behavior.
+
+

--- a/projects/plugins/jetpack/tests/php/src/Jetpack_Modules_Overrides_Test.php
+++ b/projects/plugins/jetpack/tests/php/src/Jetpack_Modules_Overrides_Test.php
@@ -116,9 +116,9 @@ class Jetpack_Modules_Overrides_Test extends WP_UnitTestCase {
 			'photon-cdn' => 'active',
 		);
 
-		if ( defined( 'IS_ATOMIC' ) && IS_ATOMIC ) {
-
-			// Atomic does not override either.
+		if ( defined( 'IS_ATOMIC' ) && IS_ATOMIC && ! ( function_exists( 'is_global_styles_on_personal_plan' ) && is_global_styles_on_personal_plan() ) ) {
+			// Atomic only registers an override if is_global_styles_on_personal_plan() is missing or returns false.
+			// See `projects/plugins/wpcomsh/feature-plugins/additional-css.php`.
 			$expected = array();
 		}
 		$this->assertSame( $expected, $this->instance->get_overrides() );

--- a/projects/plugins/jetpack/tests/php/src/Jetpack_Modules_Overrides_Test.php
+++ b/projects/plugins/jetpack/tests/php/src/Jetpack_Modules_Overrides_Test.php
@@ -116,6 +116,7 @@ class Jetpack_Modules_Overrides_Test extends WP_UnitTestCase {
 			'photon-cdn' => 'active',
 		);
 
+		// @phan-suppress-next-line PhanUndeclaredFunction -- Checked before being called.
 		if ( defined( 'IS_ATOMIC' ) && IS_ATOMIC && ! ( function_exists( 'is_global_styles_on_personal_plan' ) && is_global_styles_on_personal_plan() ) ) {
 			// Atomic only registers an override if is_global_styles_on_personal_plan() is missing or returns false.
 			// See `projects/plugins/wpcomsh/feature-plugins/additional-css.php`.


### PR DESCRIPTION
Closes MONOREP-318

 <!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
PR #46632 caused wpcomsh to stop registering a filter for 'jetpack_active_modules', which caused `Jetpack_Modules_Overrides` to short-circuit where it didn't before, breaking the test that expected the first call to not be short-circuited and therefore to have populated the cache.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1768571121231469-slack-CDLH4C1UZ

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* CI happy?