### PR TITLE
Connection: Replace Error_Handler use in External_Storage

### DIFF
--- a/projects/packages/connection/changelog/remove-remove-deprecate-error-handling-external-storage
+++ b/projects/packages/connection/changelog/remove-remove-deprecate-error-handling-external-storage
@@ -1,4 +1,4 @@
 Significance: major
-Type: updated
+Type: changed
 
 Remove error handling methods for external storage and add host agnostic error reporting.

--- a/projects/packages/connection/changelog/remove-remove-deprecate-error-handling-external-storage
+++ b/projects/packages/connection/changelog/remove-remove-deprecate-error-handling-external-storage
@@ -1,0 +1,4 @@
+Significance: major
+Type: deprecated
+
+Removing and deprecationg error handling methods for external storage.

--- a/projects/packages/connection/changelog/remove-remove-deprecate-error-handling-external-storage
+++ b/projects/packages/connection/changelog/remove-remove-deprecate-error-handling-external-storage
@@ -1,4 +1,4 @@
 Significance: major
 Type: deprecated
 
-Removing and deprecationg error handling methods for external storage.
+Remove and deprecate error handling methods for external storage.

--- a/projects/packages/connection/changelog/remove-remove-deprecate-error-handling-external-storage
+++ b/projects/packages/connection/changelog/remove-remove-deprecate-error-handling-external-storage
@@ -1,4 +1,4 @@
 Significance: major
-Type: deprecated
+Type: updated
 
-Remove and deprecate error handling methods for external storage.
+Remove error handling methods for external storage and add host agnostic error reporting.

--- a/projects/packages/connection/src/class-error-handler.php
+++ b/projects/packages/connection/src/class-error-handler.php
@@ -125,6 +125,8 @@ class Error_Handler {
 		'invalid_nonce',
 		'signature_mismatch',
 		'invalid_connection_owner',
+		// @deprecated $$next-version$$ External storage error reporting moved to provider classes.
+		// These error codes will be removed in a future release.
 		'external_storage_empty',
 		'external_storage_error',
 	);

--- a/projects/packages/connection/src/class-external-storage.php
+++ b/projects/packages/connection/src/class-external-storage.php
@@ -172,8 +172,10 @@ class External_Storage {
 		$should_report_remote = false;
 
 		if ( 'error' === $event_type ) {
+			// @phan-suppress-next-line PhanDeprecatedFunction -- Intentionally calling deprecated method during deprecation period.
 			$should_report_remote = self::should_report_for_environment( $key );
 		} elseif ( 'empty' === $event_type ) {
+			// @phan-suppress-next-line PhanDeprecatedFunction -- Intentionally calling deprecated methods during deprecation period.
 			$should_report_remote = self::should_report_for_environment( $key ) && self::should_report_empty_state( $key );
 		}
 

--- a/projects/packages/connection/src/class-external-storage.php
+++ b/projects/packages/connection/src/class-external-storage.php
@@ -50,6 +50,15 @@ class External_Storage {
 	private static $provider = null;
 
 	/**
+	 * Static cache to prevent logging same event multiple times in single request.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @var array
+	 */
+	private static $logged_events = array();
+
+	/**
 	 * Register a storage provider for external storage.
 	 *
 	 * @since 6.18.0
@@ -80,8 +89,7 @@ class External_Storage {
 			return null; // No provider registered, use database
 		}
 
-		// Get environment ID from provider
-		$environment = method_exists( $provider, 'get_environment_id' ) ? $provider->get_environment_id() : 'unknown';
+		$environment = $provider->get_environment_id();
 
 		// Check if provider is available in current environment
 		if ( ! $provider->is_available() ) {
@@ -117,8 +125,10 @@ class External_Storage {
 
 	/**
 	 * Log events if WP_DEBUG is enabled.
-	 * Report external storage events through Jetpack Connection Error_Handler.
 	 * Includes rate limiting to prevent log spam from noisy events.
+	 *
+	 * Note: Error_Handler integration has been deprecated. Storage providers should
+	 * implement their own error reporting via the optional handle_error_event() method.
 	 *
 	 * @since 6.18.0
 	 *
@@ -127,7 +137,7 @@ class External_Storage {
 	 * @param string $details     Additional details about the event.
 	 * @param string $environment The environment identifier (atomic, vip, etc.).
 	 */
-	public static function log_event( $event_type, $key, $details = '', $environment = 'unknown' ) {
+	public static function log_event( $event_type, $key, $details, $environment ) {
 		// Apply rate limiting to prevent log spam
 		if ( ! self::should_log_event( $key ) ) {
 			return;
@@ -145,57 +155,52 @@ class External_Storage {
 			);
 		}
 
-		// Only report 'error' and 'empty' events to WordPress.com
+		// Only process 'error' and 'empty' events for remote reporting
 		if ( 'error' !== $event_type && 'empty' !== $event_type ) {
 			return;
 		}
 
+		/*
+		 * Error_Handler integration for External_Storage has been deprecated.
+		 * Storage providers should implement handle_error_event() method for error reporting.
+		 *
+		 * The Error_Handler integration is disabled. The deprecated methods below are kept for
+		 * backwards compatibility but no longer report to WordPress.com through Error_Handler.
+		 *
+		 * @deprecated $$next-version$$
+		 */
 		$should_report_remote = false;
 
 		if ( 'error' === $event_type ) {
-			// Report external storage errors for supported environments
 			$should_report_remote = self::should_report_for_environment( $key );
 		} elseif ( 'empty' === $event_type ) {
-			// Use delay mechanism to distinguish disconnection from a delay
 			$should_report_remote = self::should_report_for_environment( $key ) && self::should_report_empty_state( $key );
 		}
 
-		if ( ! $should_report_remote || ! class_exists( 'Automattic\Jetpack\Connection\Error_Handler' ) ) {
-			return;
+		// Trigger deprecation notice if any code is still trying to use Error_Handler integration
+		if ( $should_report_remote ) {
+			_deprecated_function(
+				'External_Storage Error_Handler integration',
+				'jetpack-connection-$$next-version$$',
+				'Implement handle_error_event() method in your Storage Provider instead'
+			);
+			// Error_Handler reporting is now disabled - providers should implement handle_error_event()
 		}
-
-		// Create and report error
-		$error_code    = 'external_storage_' . $event_type;
-		$error_message = sprintf(
-			'External storage %s for key "%s"%s',
-			str_replace( '_', ' ', $event_type ),
-			$key,
-			$details ? ': ' . $details : ''
-		);
-
-		$error_data = array(
-			'key'         => $key,
-			'event_type'  => $event_type,
-			'details'     => $details,
-			'environment' => $environment,
-			'timestamp'   => time(),
-			'site_url'    => home_url(),
-		);
-
-		$error = new \WP_Error( $error_code, $error_message, $error_data );
-		Error_Handler::get_instance()->report_error( $error, false, true );
 	}
 
 	/**
 	 * Determine if the current environment should report external storage errors to WordPress.com.
-	 * Allows providers to control remote error reporting per-option via optional should_report_errors_for() method.
 	 *
 	 * @since 6.18.0
+	 * @deprecated $$next-version$$ Error_Handler integration has been deprecated.
+	 *             Implement handle_error_event() method in your Storage Provider instead.
 	 *
 	 * @param string $key The option key being accessed.
 	 * @return bool True if this environment should report external storage errors to WordPress.com.
 	 */
 	private static function should_report_for_environment( $key = '' ) {
+		_deprecated_function( __METHOD__, 'jetpack-connection-$$next-version$$', 'Implement handle_error_event() method in your Storage Provider instead' );
+
 		$provider = self::$provider;
 
 		// Check if provider implements per-option reporting (optional method not defined in interface).
@@ -203,19 +208,6 @@ class External_Storage {
 		if ( null !== $provider && method_exists( $provider, 'should_report_errors_for' ) && ! empty( $key ) ) {
 			// @phan-suppress-next-line PhanUndeclaredMethodInCallable - Optional method, checked via method_exists()
 			return call_user_func( array( $provider, 'should_report_errors_for' ), $key );
-		}
-
-		// Deprecated: JETPACK_EXTERNAL_STORAGE_REPORTING_ENABLED constant
-		// @deprecated 6.18.13 Use should_report_errors_for() method in your Storage Provider instead.
-		if ( defined( 'JETPACK_EXTERNAL_STORAGE_REPORTING_ENABLED' ) ) {
-			if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
-				// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
-				trigger_error(
-					'JETPACK_EXTERNAL_STORAGE_REPORTING_ENABLED constant is deprecated. Implement should_report_errors_for() method in your Storage Provider instead.',
-					E_USER_DEPRECATED
-				);
-			}
-			return (bool) constant( 'JETPACK_EXTERNAL_STORAGE_REPORTING_ENABLED' );
 		}
 
 		return false;
@@ -228,11 +220,15 @@ class External_Storage {
 	 * after 10 minutes, allows reporting (indicating likely disconnection, not sync delay).
 	 *
 	 * @since 6.18.0
+	 * @deprecated $$next-version$$ Error_Handler integration has been deprecated.
+	 *             This method will be repurposed to support provider-based error reporting.
 	 *
 	 * @param string $key The key that was empty.
 	 * @return bool True if we should report this empty state, false otherwise.
 	 */
 	private static function should_report_empty_state( $key ) {
+		_deprecated_function( __METHOD__, 'jetpack-connection-$$next-version$$', 'Provider-based error reporting via handle_error_event()' );
+
 		$delay_key        = 'jetpack_external_storage_empty_delay_' . $key;
 		$first_empty_time = get_transient( $delay_key );
 
@@ -257,14 +253,20 @@ class External_Storage {
 	 * Determine if an event should be logged based on rate limiting rules.
 	 *
 	 * This prevents log spam from noisy events by applying a simple one-hour
-	 * rate limit per key, regardless of event type.
+	 * rate limit per key, regardless of event type. Also uses a static cache
+	 * to prevent duplicate logs within the same request.
 	 *
 	 * @since 6.18.0
 	 *
-	 * @param string $key        The key that triggered the event.
+	 * @param string $key The key that triggered the event.
 	 * @return bool True if the event should be logged, false if rate limited.
 	 */
 	private static function should_log_event( $key ) {
+		// Check static cache first (prevents multiple logs in same request)
+		if ( isset( self::$logged_events[ $key ] ) ) {
+			return false;
+		}
+
 		$rate_limit_key = 'jetpack_ext_storage_rate_limit_' . $key;
 
 		// Check if we're still within the rate limit period
@@ -272,6 +274,8 @@ class External_Storage {
 			return false;
 		}
 
+		// Mark as logged in both caches
+		self::$logged_events[ $key ] = true;
 		set_transient( $rate_limit_key, true, HOUR_IN_SECONDS );
 
 		return true;

--- a/projects/packages/connection/src/class-external-storage.php
+++ b/projects/packages/connection/src/class-external-storage.php
@@ -138,10 +138,35 @@ class External_Storage {
 	 * @param string $environment The environment identifier (atomic, vip, etc.).
 	 */
 	public static function log_event( $event_type, $key, $details = '', $environment = 'unknown' ) {
-		// Apply rate limiting to prevent log spam
+		// Only process 'error' and 'empty' events for provider error reporting
+		if ( 'error' !== $event_type && 'empty' !== $event_type ) {
+			// For non-reportable events, just do debug logging with rate limiting
+			if ( self::should_log_event( $key ) && defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+				error_log( // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+					sprintf(
+						'Jetpack External Storage %s: %s in %s%s',
+						$event_type,
+						$key,
+						$environment,
+						$details ? ' - ' . $details : ''
+					)
+				);
+			}
+			return;
+		}
+
+		// For 'empty' events, check delay mechanism first to avoid false positives
+		// during sync between external storage and the database.
+		// This is checked BEFORE rate limiting so we don't block legitimate reports.
+		if ( 'empty' === $event_type && ! self::should_report_empty_state( $key ) ) {
+			return;
+		}
+
+		// Apply rate limiting only for events that will trigger provider notification
 		if ( ! self::should_log_event( $key ) ) {
 			return;
 		}
+
 		// Local debug logging (only when WP_DEBUG is enabled)
 		if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
 			error_log( // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
@@ -153,16 +178,6 @@ class External_Storage {
 					$details ? ' - ' . $details : ''
 				)
 			);
-		}
-
-		// Only process 'error' and 'empty' events for provider error reporting
-		if ( 'error' !== $event_type && 'empty' !== $event_type ) {
-			return;
-		}
-
-		// For 'empty' events, check delay mechanism to avoid false positives during sync between external storage and the database.
-		if ( 'empty' === $event_type && ! self::should_report_empty_state( $key ) ) {
-			return;
 		}
 
 		// Delegate to provider if it implements error handling

--- a/projects/packages/connection/src/class-external-storage.php
+++ b/projects/packages/connection/src/class-external-storage.php
@@ -59,6 +59,15 @@ class External_Storage {
 	private static $logged_events = array();
 
 	/**
+	 * Maximum delay threshold for empty state reporting (in seconds).
+	 * This also determines the transient expiry for tracking first empty state.
+	 * Provider custom thresholds must not exceed this value.
+	 *
+	 * @since $$next-version$$
+	 */
+	private const EMPTY_STATE_TRANSIENT_EXPIRY = 15 * MINUTE_IN_SECONDS;
+
+	/**
 	 * Register a storage provider for external storage.
 	 *
 	 * @since 6.18.0
@@ -207,7 +216,7 @@ class External_Storage {
 
 		if ( false === $first_empty_time ) {
 			// First time encountering empty state - set delay transient and don't report yet
-			set_transient( $delay_key, time(), 15 * MINUTE_IN_SECONDS ); // Keep for 15 minutes
+			set_transient( $delay_key, time(), self::EMPTY_STATE_TRANSIENT_EXPIRY );
 			return false;
 		}
 
@@ -219,7 +228,7 @@ class External_Storage {
 		if ( null !== self::$provider && method_exists( self::$provider, 'get_empty_state_delay_threshold' ) ) {
 			// @phan-suppress-next-line PhanUndeclaredMethod -- Optional method, checked via method_exists()
 			$custom_threshold = self::$provider->get_empty_state_delay_threshold();
-			if ( is_int( $custom_threshold ) && $custom_threshold >= 0 ) {
+			if ( is_int( $custom_threshold ) && $custom_threshold >= 0 && $custom_threshold <= self::EMPTY_STATE_TRANSIENT_EXPIRY ) {
 				$delay_threshold = $custom_threshold;
 			}
 		}

--- a/projects/packages/connection/src/class-external-storage.php
+++ b/projects/packages/connection/src/class-external-storage.php
@@ -124,11 +124,11 @@ class External_Storage {
 	}
 
 	/**
-	 * Log events if WP_DEBUG is enabled.
+	 * Log events if WP_DEBUG is enabled and delegate to provider for error reporting.
 	 * Includes rate limiting to prevent log spam from noisy events.
 	 *
-	 * Note: Error_Handler integration has been deprecated. Storage providers should
-	 * implement their own error reporting via the optional handle_error_event() method.
+	 * Storage providers can optionally implement handle_error_event() method to receive
+	 * notifications about storage errors and empty states for their own error reporting.
 	 *
 	 * @since 6.18.0
 	 *
@@ -155,78 +155,38 @@ class External_Storage {
 			);
 		}
 
-		// Only process 'error' and 'empty' events for remote reporting
+		// Only process 'error' and 'empty' events for provider error reporting
 		if ( 'error' !== $event_type && 'empty' !== $event_type ) {
 			return;
 		}
 
-		/*
-		 * Error_Handler integration for External_Storage has been deprecated.
-		 * Storage providers should implement handle_error_event() method for error reporting.
-		 *
-		 * The Error_Handler integration is disabled. The deprecated methods below are kept for
-		 * backwards compatibility but no longer report to WordPress.com through Error_Handler.
-		 *
-		 * @deprecated $$next-version$$
-		 */
-		$should_report_remote = false;
-
-		if ( 'error' === $event_type ) {
-			// @phan-suppress-next-line PhanDeprecatedFunction -- Intentionally calling deprecated method during deprecation period.
-			$should_report_remote = self::should_report_for_environment( $key );
-		} elseif ( 'empty' === $event_type ) {
-			// @phan-suppress-next-line PhanDeprecatedFunction -- Intentionally calling deprecated methods during deprecation period.
-			$should_report_remote = self::should_report_for_environment( $key ) && self::should_report_empty_state( $key );
+		// For 'empty' events, check delay mechanism to avoid false positives during sync between external storage and the database.
+		if ( 'empty' === $event_type && ! self::should_report_empty_state( $key ) ) {
+			return;
 		}
 
-		// Trigger deprecation notice if any code is still trying to use Error_Handler integration
-		if ( $should_report_remote ) {
-			_deprecated_function( 'External_Storage Error_Handler integration', 'jetpack-connection-$$next-version$$', 'Implement handle_error_event() method in your Storage Provider instead' );
-			// Error_Handler reporting is now disabled - providers should implement handle_error_event()
+		// Delegate to provider if it implements error handling
+		if ( null !== self::$provider && method_exists( self::$provider, 'handle_error_event' ) ) {
+			// @phan-suppress-next-line PhanUndeclaredMethod -- Optional method, checked via method_exists()
+			self::$provider->handle_error_event( $event_type, $key, $details, $environment );
 		}
-	}
-
-	/**
-	 * Determine if the current environment should report external storage errors to WordPress.com.
-	 *
-	 * @since 6.18.0
-	 * @deprecated $$next-version$$ Error_Handler integration has been deprecated.
-	 *             Implement handle_error_event() method in your Storage Provider instead.
-	 *
-	 * @param string $key The option key being accessed.
-	 * @return bool True if this environment should report external storage errors to WordPress.com.
-	 */
-	private static function should_report_for_environment( $key = '' ) {
-		_deprecated_function( __METHOD__, 'jetpack-connection-$$next-version$$', 'Implement handle_error_event() method in your Storage Provider instead' );
-
-		$provider = self::$provider;
-
-		// Check if provider implements per-option reporting (optional method not defined in interface).
-		// Providers can optionally implement: public function should_report_errors_for( $option_name )
-		if ( null !== $provider && method_exists( $provider, 'should_report_errors_for' ) && ! empty( $key ) ) {
-			// @phan-suppress-next-line PhanUndeclaredMethodInCallable - Optional method, checked via method_exists()
-			return call_user_func( array( $provider, 'should_report_errors_for' ), $key );
-		}
-
-		return false;
 	}
 
 	/**
 	 * Determine if we should report an empty state based on delay mechanism.
-	 * We need this due to delays in writing in external storage vs writing into the database.
-	 * On first encounter of empty state, sets a transient. On subsequent encounters
-	 * after 10 minutes, allows reporting (indicating likely disconnection, not sync delay).
+	 *
+	 * This prevents false positives during storage sync delays. On first encounter
+	 * of empty state, sets a transient. On subsequent encounters after the delay
+	 * threshold, allows reporting (indicating likely disconnection, not sync delay).
+	 *
+	 * Providers can customize the delay threshold by implementing get_empty_state_delay_threshold().
 	 *
 	 * @since 6.18.0
-	 * @deprecated $$next-version$$ Error_Handler integration has been deprecated.
-	 *             This method will be repurposed to support provider-based error reporting.
 	 *
 	 * @param string $key The key that was empty.
 	 * @return bool True if we should report this empty state, false otherwise.
 	 */
 	private static function should_report_empty_state( $key ) {
-		_deprecated_function( __METHOD__, 'jetpack-connection-$$next-version$$', 'Provider-based error reporting via handle_error_event()' );
-
 		$delay_key        = 'jetpack_external_storage_empty_delay_' . $key;
 		$first_empty_time = get_transient( $delay_key );
 
@@ -236,10 +196,21 @@ class External_Storage {
 			return false;
 		}
 
-		// Check if 10 minutes have passed since first empty encounter
-		$delay_threshold = 10 * MINUTE_IN_SECONDS;
+		// Default delay threshold (5 minutes)
+		$delay_threshold = 5 * MINUTE_IN_SECONDS;
+
+		// Allow provider to customize delay threshold
+		// A threshold of 0 is valid for providers where external storage is written first
+		if ( null !== self::$provider && method_exists( self::$provider, 'get_empty_state_delay_threshold' ) ) {
+			// @phan-suppress-next-line PhanUndeclaredMethod -- Optional method, checked via method_exists()
+			$custom_threshold = self::$provider->get_empty_state_delay_threshold();
+			if ( is_int( $custom_threshold ) && $custom_threshold >= 0 ) {
+				$delay_threshold = $custom_threshold;
+			}
+		}
+
 		if ( ( time() - $first_empty_time ) >= $delay_threshold ) {
-			// 10+ minutes of empty state - likely disconnection, report it
+			// Delay threshold passed - likely disconnection, report it
 			delete_transient( $delay_key );
 			return true;
 		}

--- a/projects/packages/connection/src/class-external-storage.php
+++ b/projects/packages/connection/src/class-external-storage.php
@@ -137,7 +137,7 @@ class External_Storage {
 	 * @param string $details     Additional details about the event.
 	 * @param string $environment The environment identifier (atomic, vip, etc.).
 	 */
-	public static function log_event( $event_type, $key, $details, $environment ) {
+	public static function log_event( $event_type, $key, $details = '', $environment = 'unknown' ) {
 		// Apply rate limiting to prevent log spam
 		if ( ! self::should_log_event( $key ) ) {
 			return;

--- a/projects/packages/connection/src/class-external-storage.php
+++ b/projects/packages/connection/src/class-external-storage.php
@@ -141,7 +141,7 @@ class External_Storage {
 		// Only process 'error' and 'empty' events for provider error reporting
 		if ( 'error' !== $event_type && 'empty' !== $event_type ) {
 			// For non-reportable events, just do debug logging with rate limiting
-			if ( self::should_log_event( $key ) && defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+			if ( self::should_log_event( $key, $event_type ) && defined( 'WP_DEBUG' ) && WP_DEBUG ) {
 				error_log( // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
 					sprintf(
 						'Jetpack External Storage %s: %s in %s%s',
@@ -163,7 +163,7 @@ class External_Storage {
 		}
 
 		// Apply rate limiting only for events that will trigger provider notification
-		if ( ! self::should_log_event( $key ) ) {
+		if ( ! self::should_log_event( $key, $event_type ) ) {
 			return;
 		}
 
@@ -237,21 +237,25 @@ class External_Storage {
 	 * Determine if an event should be logged based on rate limiting rules.
 	 *
 	 * This prevents log spam from noisy events by applying a simple one-hour
-	 * rate limit per key, regardless of event type. Also uses a static cache
+	 * rate limit per key and event type combination. Also uses a static cache
 	 * to prevent duplicate logs within the same request.
 	 *
 	 * @since 6.18.0
 	 *
-	 * @param string $key The key that triggered the event.
+	 * @param string $key        The key that triggered the event.
+	 * @param string $event_type The event type (error, empty, unavailable).
 	 * @return bool True if the event should be logged, false if rate limited.
 	 */
-	private static function should_log_event( $key ) {
+	private static function should_log_event( $key, $event_type = '' ) {
+		// Combine event type and key for unique tracking
+		$cache_key = $event_type . '_' . $key;
+
 		// Check static cache first (prevents multiple logs in same request)
-		if ( isset( self::$logged_events[ $key ] ) ) {
+		if ( isset( self::$logged_events[ $cache_key ] ) ) {
 			return false;
 		}
 
-		$rate_limit_key = 'jetpack_ext_storage_rate_limit_' . $key;
+		$rate_limit_key = 'jetpack_ext_storage_rate_limit_' . $cache_key;
 
 		// Check if we're still within the rate limit period
 		if ( get_transient( $rate_limit_key ) ) {
@@ -259,7 +263,7 @@ class External_Storage {
 		}
 
 		// Mark as logged in both caches
-		self::$logged_events[ $key ] = true;
+		self::$logged_events[ $cache_key ] = true;
 		set_transient( $rate_limit_key, true, HOUR_IN_SECONDS );
 
 		return true;

--- a/projects/packages/connection/src/class-external-storage.php
+++ b/projects/packages/connection/src/class-external-storage.php
@@ -257,14 +257,14 @@ class External_Storage {
 	 */
 	private static function should_log_event( $key, $event_type = '' ) {
 		// Combine event type and key for unique tracking
-		$cache_key = $event_type . '_' . $key;
+		$event_cache_key = $event_type . '_' . $key;
 
 		// Check static cache first (prevents multiple logs in same request)
-		if ( isset( self::$logged_events[ $cache_key ] ) ) {
+		if ( isset( self::$logged_events[ $event_cache_key ] ) ) {
 			return false;
 		}
 
-		$rate_limit_key = 'jetpack_ext_storage_rate_limit_' . $cache_key;
+		$rate_limit_key = 'jetpack_ext_storage_rate_limit_' . $event_cache_key;
 
 		// Check if we're still within the rate limit period
 		if ( get_transient( $rate_limit_key ) ) {
@@ -272,7 +272,7 @@ class External_Storage {
 		}
 
 		// Mark as logged in both caches
-		self::$logged_events[ $cache_key ] = true;
+		self::$logged_events[ $event_cache_key ] = true;
 		set_transient( $rate_limit_key, true, HOUR_IN_SECONDS );
 
 		return true;

--- a/projects/packages/connection/src/class-external-storage.php
+++ b/projects/packages/connection/src/class-external-storage.php
@@ -181,11 +181,7 @@ class External_Storage {
 
 		// Trigger deprecation notice if any code is still trying to use Error_Handler integration
 		if ( $should_report_remote ) {
-			_deprecated_function(
-				'External_Storage Error_Handler integration',
-				'jetpack-connection-$$next-version$$',
-				'Implement handle_error_event() method in your Storage Provider instead'
-			);
+			_deprecated_function( 'External_Storage Error_Handler integration', 'jetpack-connection-$$next-version$$', 'Implement handle_error_event() method in your Storage Provider instead' );
 			// Error_Handler reporting is now disabled - providers should implement handle_error_event()
 		}
 	}

--- a/projects/packages/connection/src/interface-storage-provider.php
+++ b/projects/packages/connection/src/interface-storage-provider.php
@@ -62,6 +62,7 @@ namespace Automattic\Jetpack\Connection;
  *
  * - Return `0` if external storage is the source of truth (written first)
  * - Return higher values for slower sync systems
+ * - Maximum allowed value is 15 minutes (900 seconds); values above this are ignored
  *
  * Example:
  *

--- a/projects/packages/connection/src/interface-storage-provider.php
+++ b/projects/packages/connection/src/interface-storage-provider.php
@@ -41,13 +41,24 @@ namespace Automattic\Jetpack\Connection;
  *
  *     public function handle_error_event( $event_type, $key, $details, $environment ) {
  *         // Report to your monitoring system
- *         wp_remote_post( 'https://your-api/errors', array( 'body' => compact( 'event_type', 'key' ) ) );
+ *         wp_remote_post(
+ *             'https://your-api/errors',
+ *             array(
+ *                 'body' => array(
+ *                     'event_type'  => $event_type,
+ *                     'key'         => $key,
+ *                     'details'     => $details,
+ *                     'environment' => $environment,
+ *                 ),
+ *             )
+ *         );
  *     }
  *
  * ### get_empty_state_delay_threshold()
  *
  * Customize the delay before reporting empty states. Returns delay in seconds.
- * Default is 5 minutes. Use this if your storage system has different sync times.
+ * Default (when not implemented) is 5 minutes (300 seconds). Use this if your
+ * storage system has different sync times.
  *
  * - Return `0` if external storage is the source of truth (written first)
  * - Return higher values for slower sync systems

--- a/projects/packages/connection/src/interface-storage-provider.php
+++ b/projects/packages/connection/src/interface-storage-provider.php
@@ -16,6 +16,49 @@ namespace Automattic\Jetpack\Connection;
  * All storage providers must implement this interface to ensure
  * compatibility with the External_Storage system.
  *
+ * ## Required Methods
+ *
+ * - `is_available()` - Check if storage backend is accessible
+ * - `should_handle( $option_name )` - Determine if provider handles the option
+ * - `get( $option_name )` - Retrieve value from external storage
+ * - `get_environment_id()` - Return environment identifier for logging
+ *
+ * ## Optional Methods
+ *
+ * Providers may implement these additional methods for enhanced functionality:
+ *
+ * ### handle_error_event( string $event_type, string $key, string $details, string $environment )
+ *
+ * Called when External_Storage detects an error or empty state. Implement this
+ * to report errors to your host's monitoring system.
+ *
+ * - `$event_type` - 'error' or 'empty'
+ * - `$key` - The option key that triggered the event
+ * - `$details` - Additional error details (error message, etc.)
+ * - `$environment` - Environment identifier from get_environment_id()
+ *
+ * Example:
+ *
+ *     public function handle_error_event( $event_type, $key, $details, $environment ) {
+ *         // Report to your monitoring system
+ *         wp_remote_post( 'https://your-api/errors', array( 'body' => compact( 'event_type', 'key' ) ) );
+ *     }
+ *
+ * ### get_empty_state_delay_threshold()
+ *
+ * Customize the delay before reporting empty states. Returns delay in seconds.
+ * Default is 5 minutes. Use this if your storage system has different sync times.
+ *
+ * - Return `0` if external storage is the source of truth (written first)
+ * - Return higher values for slower sync systems
+ *
+ * Example:
+ *
+ *     public function get_empty_state_delay_threshold() {
+ *         return 90; // 90 seconds for fast-syncing storage
+ *         // return 0; // No delay - external storage is written first
+ *     }
+ *
  * @since 6.18.0
  */
 interface Storage_Provider_Interface {

--- a/projects/packages/connection/tests/php/External_Storage_Test.php
+++ b/projects/packages/connection/tests/php/External_Storage_Test.php
@@ -199,8 +199,8 @@ class External_Storage_Test extends TestCase {
 			$method->setAccessible( true );
 		}
 
-		// First call sets transient
-		$method->invoke( null, 'immediate_test' );
+		// First call sets transient and should return false
+		$this->assertFalse( $method->invoke( null, 'immediate_test' ) );
 
 		// Second call returns true immediately (threshold is 0)
 		$this->assertTrue( $method->invoke( null, 'immediate_test' ) );

--- a/projects/packages/connection/tests/php/External_Storage_Test.php
+++ b/projects/packages/connection/tests/php/External_Storage_Test.php
@@ -45,19 +45,28 @@ class External_Storage_Test extends TestCase {
 	}
 
 	/**
-	 * Reset provider after each test.
+	 * Reset provider and static caches after each test.
 	 */
 	public function tearDown(): void {
 		parent::tearDown();
 
-		// Reset the provider using reflection
 		$reflection = new \ReflectionClass( External_Storage::class );
-		$property   = $reflection->getProperty( 'provider' );
+
+		// Reset the provider
+		$provider_property = $reflection->getProperty( 'provider' );
 		// @todo Remove this call once we no longer need to support PHP <8.1.
 		if ( PHP_VERSION_ID < 80100 ) {
-			$property->setAccessible( true );
+			$provider_property->setAccessible( true );
 		}
-		$property->setValue( null, null );
+		$provider_property->setValue( null, null );
+
+		// Reset the static logged_events cache
+		$logged_events_property = $reflection->getProperty( 'logged_events' );
+		// @todo Remove this call once we no longer need to support PHP <8.1.
+		if ( PHP_VERSION_ID < 80100 ) {
+			$logged_events_property->setAccessible( true );
+		}
+		$logged_events_property->setValue( null, array() );
 	}
 
 	/**
@@ -168,12 +177,21 @@ class External_Storage_Test extends TestCase {
 	 * Note: We use reflection to test the rate limiting logic without triggering debug logging.
 	 */
 	public function test_rate_limiting_logic() {
-		// Clear any existing transients
+		// Clear any existing transients and static cache
 		delete_transient( 'jetpack_ext_storage_rate_limit_test_key' );
 
-		// Use reflection to access the private should_log_event method
 		$reflection = new \ReflectionClass( External_Storage::class );
-		$method     = $reflection->getMethod( 'should_log_event' );
+
+		// Reset static cache before test
+		$logged_events_property = $reflection->getProperty( 'logged_events' );
+		// @todo Remove this call once we no longer need to support PHP <8.1.
+		if ( PHP_VERSION_ID < 80100 ) {
+			$logged_events_property->setAccessible( true );
+		}
+		$logged_events_property->setValue( null, array() );
+
+		// Use reflection to access the private should_log_event method
+		$method = $reflection->getMethod( 'should_log_event' );
 		// @todo Remove this call once we no longer need to support PHP <8.1.
 		if ( PHP_VERSION_ID < 80100 ) {
 			$method->setAccessible( true );
@@ -186,7 +204,7 @@ class External_Storage_Test extends TestCase {
 		// Verify rate limit transient was set
 		$this->assertNotFalse( get_transient( 'jetpack_ext_storage_rate_limit_test_key' ) );
 
-		// Second immediate call should return false (rate limited)
+		// Second immediate call should return false (rate limited by static cache)
 		$result2 = $method->invoke( null, 'test_key' );
 		$this->assertFalse( $result2 );
 
@@ -195,34 +213,46 @@ class External_Storage_Test extends TestCase {
 	}
 
 	/**
-	 * Test empty state delay logic by directly testing the private method.
-	 *
-	 * Note: We use reflection to test the delay logic without triggering debug logging.
+	 * Test static cache prevents duplicate logs in same request.
 	 */
-	public function test_empty_state_delay_logic() {
-		// Clear any existing transients
-		delete_transient( 'jetpack_external_storage_empty_delay_test_key' );
+	public function test_static_cache_prevents_duplicate_logs() {
+		// Clear any existing transients and static cache
+		delete_transient( 'jetpack_ext_storage_rate_limit_static_test' );
 
-		// Use reflection to access the private should_report_empty_state method
 		$reflection = new \ReflectionClass( External_Storage::class );
-		$method     = $reflection->getMethod( 'should_report_empty_state' );
+
+		// Reset static cache before test
+		$logged_events_property = $reflection->getProperty( 'logged_events' );
+		// @todo Remove this call once we no longer need to support PHP <8.1.
+		if ( PHP_VERSION_ID < 80100 ) {
+			$logged_events_property->setAccessible( true );
+		}
+		$logged_events_property->setValue( null, array() );
+
+		$method = $reflection->getMethod( 'should_log_event' );
 		// @todo Remove this call once we no longer need to support PHP <8.1.
 		if ( PHP_VERSION_ID < 80100 ) {
 			$method->setAccessible( true );
 		}
 
-		// First call should return false (sets delay, doesn't report yet)
-		$result1 = $method->invoke( null, 'test_key' );
-		$this->assertFalse( $result1 );
+		// First call should return true
+		$result1 = $method->invoke( null, 'static_test' );
+		$this->assertTrue( $result1 );
 
-		// Verify delay transient was set
-		$this->assertNotFalse( get_transient( 'jetpack_external_storage_empty_delay_test_key' ) );
+		// Verify static cache was set
+		$logged_events = $logged_events_property->getValue( null );
+		$this->assertArrayHasKey( 'static_test', $logged_events );
 
-		// Second immediate call should still return false (within delay period)
-		$result2 = $method->invoke( null, 'test_key' );
+		// Second call should return false (blocked by static cache, not transient)
+		$result2 = $method->invoke( null, 'static_test' );
 		$this->assertFalse( $result2 );
 
+		// Different key should still work
+		$result3 = $method->invoke( null, 'different_key' );
+		$this->assertTrue( $result3 );
+
 		// Clean up
-		delete_transient( 'jetpack_external_storage_empty_delay_test_key' );
+		delete_transient( 'jetpack_ext_storage_rate_limit_static_test' );
+		delete_transient( 'jetpack_ext_storage_rate_limit_different_key' );
 	}
 }

--- a/projects/packages/connection/tests/php/External_Storage_Test.php
+++ b/projects/packages/connection/tests/php/External_Storage_Test.php
@@ -240,7 +240,7 @@ class External_Storage_Test extends TestCase {
 		$this->assertTrue( $result1 );
 
 		// Verify static cache was set
-		$logged_events = $logged_events_property->getValue( null );
+		$logged_events = $logged_events_property->getValue();
 		$this->assertArrayHasKey( 'static_test', $logged_events );
 
 		// Second call should return false (blocked by static cache, not transient)

--- a/projects/packages/connection/tests/php/External_Storage_Test.php
+++ b/projects/packages/connection/tests/php/External_Storage_Test.php
@@ -19,32 +19,6 @@ use PHPUnit\Framework\TestCase;
 class External_Storage_Test extends TestCase {
 
 	/**
-	 * Set up a test provider before each test.
-	 */
-	public function setUp(): void {
-		parent::setUp();
-
-		// Register a simple test provider for more realistic testing
-		$test_provider = new class() implements \Automattic\Jetpack\Connection\Storage_Provider_Interface {
-			public function is_available() {
-				return true;
-			}
-			public function should_handle( $option_name ) {
-				return in_array( $option_name, array( 'blog_token', 'id', 'test_key' ), true );
-			}
-			public function get( $option_name ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
-				// Return null to simulate empty state for testing
-				return null;
-			}
-			public function get_environment_id() {
-				return 'test';
-			}
-		};
-
-		External_Storage::register_provider( $test_provider );
-	}
-
-	/**
 	 * Reset provider and static caches after each test.
 	 */
 	public function tearDown(): void {
@@ -70,34 +44,9 @@ class External_Storage_Test extends TestCase {
 	}
 
 	/**
-	 * Test get_value with provider that returns null (empty state).
-	 *
-	 * Note: This test avoids calling get_value() which would trigger logging.
-	 * Instead we test the provider registration and basic functionality.
+	 * Test provider registration and get_value functionality.
 	 */
-	public function test_provider_returns_null() {
-		// Test that we can register a provider and it behaves as expected
-		$reflection        = new \ReflectionClass( External_Storage::class );
-		$provider_property = $reflection->getProperty( 'provider' );
-		// @todo Remove this call once we no longer need to support PHP <8.1.
-		if ( PHP_VERSION_ID < 80100 ) {
-			$provider_property->setAccessible( true );
-		}
-		$provider = $provider_property->getValue();
-
-		// Verify provider is registered and behaves correctly
-		$this->assertNotNull( $provider );
-		$this->assertTrue( $provider->is_available() );
-		$this->assertTrue( $provider->should_handle( 'blog_token' ) );
-		$this->assertNull( $provider->get( 'blog_token' ) );
-		$this->assertEquals( 'test', $provider->get_environment_id() );
-	}
-
-	/**
-	 * Test provider registration and usage.
-	 */
-	public function test_provider_registration_and_usage() {
-		// Create a simple mock provider implementing the interface
+	public function test_provider_registration_and_get_value() {
 		$provider = new class() implements \Automattic\Jetpack\Connection\Storage_Provider_Interface {
 			public function is_available() {
 				return true;
@@ -106,122 +55,62 @@ class External_Storage_Test extends TestCase {
 				return 'blog_token' === $option_name;
 			}
 			public function get( $option_name ) {
-				if ( 'blog_token' === $option_name ) {
-					return 'test-token-value';
-				}
-				return null;
+				return 'blog_token' === $option_name ? 'test-token-value' : null;
 			}
 			public function get_environment_id() {
 				return 'test';
 			}
 		};
 
-		// Register provider
-		$result = External_Storage::register_provider( $provider );
-		$this->assertTrue( $result );
+		// Test registration
+		$this->assertTrue( External_Storage::register_provider( $provider ) );
 
-		// Test that it returns the expected value
-		$this->assertEquals( 'test-token-value', External_Storage::get_value( 'blog_token' ) );
+		// Test get_value returns provider value
+		$this->assertSame( 'test-token-value', External_Storage::get_value( 'blog_token' ) );
 
-		// Test that it returns null for unhandled options
-		$this->assertNull( External_Storage::get_value( 'id' ) );
+		// Test get_value returns null for unhandled options
+		$this->assertNull( External_Storage::get_value( 'unhandled_option' ) );
 	}
 
 	/**
-	 * Test that interface ensures all required methods are implemented.
+	 * Test provider with only required methods (no optional methods).
 	 */
-	public function test_interface_enforces_required_methods() {
-		// Create a provider that implements the interface
+	public function test_provider_without_optional_methods() {
 		$provider = new class() implements \Automattic\Jetpack\Connection\Storage_Provider_Interface {
 			public function is_available() {
-				return false;
+				return true;
 			}
-			public function should_handle( $option_name ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
-				return false;
+			public function should_handle( $option_name ) {
+				return 'blog_token' === $option_name;
 			}
-			public function get( $option_name ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
-				return null;
+			public function get( $option_name ) {
+				return 'blog_token' === $option_name ? 'test-value' : null;
 			}
 			public function get_environment_id() {
 				return 'test-minimal';
 			}
 		};
 
-		// Registration should succeed because all required methods are present
-		$result = External_Storage::register_provider( $provider );
-		$this->assertTrue( $result );
+		External_Storage::register_provider( $provider );
 
-		// Test that the provider works as expected
-		$this->assertFalse( $provider->is_available() );
-		$this->assertFalse( $provider->should_handle( 'blog_token' ) );
-		$this->assertNull( $provider->get( 'blog_token' ) );
-		$this->assertEquals( 'test-minimal', $provider->get_environment_id() );
+		// Verify optional methods don't exist
+		$this->assertFalse( method_exists( $provider, 'handle_error_event' ) );
+		$this->assertFalse( method_exists( $provider, 'get_empty_state_delay_threshold' ) );
+
+		// Verify provider still works
+		$this->assertSame( 'test-value', External_Storage::get_value( 'blog_token' ) );
 	}
 
 	/**
-	 * Test log_event method exists and is callable.
-	 *
-	 * Note: We only test method existence to avoid triggering debug logging.
+	 * Test rate limiting with static cache prevents duplicate logs.
 	 */
-	public function test_log_event_method_exists() {
-		// Test that the method exists and is callable
-		$this->assertTrue( method_exists( 'Automattic\Jetpack\Connection\External_Storage', 'log_event' ) );
-		$this->assertTrue( is_callable( array( 'Automattic\Jetpack\Connection\External_Storage', 'log_event' ) ) );
-
-		// Don't call the method to avoid debug logging output
-	}
-
-	/**
-	 * Test rate limiting logic by directly testing the private method.
-	 *
-	 * Note: We use reflection to test the rate limiting logic without triggering debug logging.
-	 */
-	public function test_rate_limiting_logic() {
-		// Clear any existing transients and static cache
-		delete_transient( 'jetpack_ext_storage_rate_limit_test_key' );
+	public function test_rate_limiting_with_static_cache() {
+		delete_transient( 'jetpack_ext_storage_rate_limit_rate_test' );
+		delete_transient( 'jetpack_ext_storage_rate_limit_other_key' );
 
 		$reflection = new \ReflectionClass( External_Storage::class );
 
-		// Reset static cache before test
-		$logged_events_property = $reflection->getProperty( 'logged_events' );
-		// @todo Remove this call once we no longer need to support PHP <8.1.
-		if ( PHP_VERSION_ID < 80100 ) {
-			$logged_events_property->setAccessible( true );
-		}
-		$logged_events_property->setValue( null, array() );
-
-		// Use reflection to access the private should_log_event method
-		$method = $reflection->getMethod( 'should_log_event' );
-		// @todo Remove this call once we no longer need to support PHP <8.1.
-		if ( PHP_VERSION_ID < 80100 ) {
-			$method->setAccessible( true );
-		}
-
-		// First call should return true (no rate limiting yet)
-		$result1 = $method->invoke( null, 'test_key' );
-		$this->assertTrue( $result1 );
-
-		// Verify rate limit transient was set
-		$this->assertNotFalse( get_transient( 'jetpack_ext_storage_rate_limit_test_key' ) );
-
-		// Second immediate call should return false (rate limited by static cache)
-		$result2 = $method->invoke( null, 'test_key' );
-		$this->assertFalse( $result2 );
-
-		// Clean up
-		delete_transient( 'jetpack_ext_storage_rate_limit_test_key' );
-	}
-
-	/**
-	 * Test static cache prevents duplicate logs in same request.
-	 */
-	public function test_static_cache_prevents_duplicate_logs() {
-		// Clear any existing transients and static cache
-		delete_transient( 'jetpack_ext_storage_rate_limit_static_test' );
-
-		$reflection = new \ReflectionClass( External_Storage::class );
-
-		// Reset static cache before test
+		// Reset static cache
 		$logged_events_property = $reflection->getProperty( 'logged_events' );
 		// @todo Remove this call once we no longer need to support PHP <8.1.
 		if ( PHP_VERSION_ID < 80100 ) {
@@ -236,23 +125,121 @@ class External_Storage_Test extends TestCase {
 		}
 
 		// First call should return true
-		$result1 = $method->invoke( null, 'static_test' );
-		$this->assertTrue( $result1 );
+		$this->assertTrue( $method->invoke( null, 'rate_test' ) );
 
-		// Verify static cache was set
-		$logged_events = $logged_events_property->getValue();
-		$this->assertArrayHasKey( 'static_test', $logged_events );
+		// Verify both caches are set
+		$this->assertNotFalse( get_transient( 'jetpack_ext_storage_rate_limit_rate_test' ) );
+		$this->assertArrayHasKey( 'rate_test', $logged_events_property->getValue() );
 
-		// Second call should return false (blocked by static cache, not transient)
-		$result2 = $method->invoke( null, 'static_test' );
-		$this->assertFalse( $result2 );
+		// Second call should return false (blocked by static cache)
+		$this->assertFalse( $method->invoke( null, 'rate_test' ) );
 
 		// Different key should still work
-		$result3 = $method->invoke( null, 'different_key' );
-		$this->assertTrue( $result3 );
+		$this->assertTrue( $method->invoke( null, 'other_key' ) );
 
 		// Clean up
-		delete_transient( 'jetpack_ext_storage_rate_limit_static_test' );
-		delete_transient( 'jetpack_ext_storage_rate_limit_different_key' );
+		delete_transient( 'jetpack_ext_storage_rate_limit_rate_test' );
+		delete_transient( 'jetpack_ext_storage_rate_limit_other_key' );
+	}
+
+	/**
+	 * Test empty state delay mechanism with default threshold.
+	 */
+	public function test_empty_state_delay_mechanism() {
+		delete_transient( 'jetpack_external_storage_empty_delay_delay_test' );
+
+		$reflection = new \ReflectionClass( External_Storage::class );
+		$method     = $reflection->getMethod( 'should_report_empty_state' );
+		// @todo Remove this call once we no longer need to support PHP <8.1.
+		if ( PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
+
+		// First call sets transient and returns false
+		$this->assertFalse( $method->invoke( null, 'delay_test' ) );
+		$this->assertNotFalse( get_transient( 'jetpack_external_storage_empty_delay_delay_test' ) );
+
+		// Second call within delay period still returns false
+		$this->assertFalse( $method->invoke( null, 'delay_test' ) );
+
+		// Clean up
+		delete_transient( 'jetpack_external_storage_empty_delay_delay_test' );
+	}
+
+	/**
+	 * Test provider with custom delay threshold of 0 (immediate reporting).
+	 */
+	public function test_provider_custom_delay_threshold_zero() {
+		delete_transient( 'jetpack_external_storage_empty_delay_immediate_test' );
+
+		$provider = new class() implements \Automattic\Jetpack\Connection\Storage_Provider_Interface {
+			public function is_available() {
+				return true;
+			}
+			public function should_handle( $option_name ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+				return true;
+			}
+			public function get( $option_name ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+				return null;
+			}
+			public function get_environment_id() {
+				return 'test';
+			}
+			public function get_empty_state_delay_threshold() {
+				return 0; // No delay - external storage is source of truth
+			}
+		};
+
+		External_Storage::register_provider( $provider );
+
+		$reflection = new \ReflectionClass( External_Storage::class );
+		$method     = $reflection->getMethod( 'should_report_empty_state' );
+		// @todo Remove this call once we no longer need to support PHP <8.1.
+		if ( PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
+
+		// First call sets transient
+		$method->invoke( null, 'immediate_test' );
+
+		// Second call returns true immediately (threshold is 0)
+		$this->assertTrue( $method->invoke( null, 'immediate_test' ) );
+
+		// Clean up
+		delete_transient( 'jetpack_external_storage_empty_delay_immediate_test' );
+	}
+
+	/**
+	 * Test provider with optional methods implemented.
+	 */
+	public function test_provider_with_optional_methods() {
+		$provider = new class() implements \Automattic\Jetpack\Connection\Storage_Provider_Interface {
+			public function is_available() {
+				return true;
+			}
+			public function should_handle( $option_name ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+				return true;
+			}
+			public function get( $option_name ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+				return null;
+			}
+			public function get_environment_id() {
+				return 'test';
+			}
+			public function get_empty_state_delay_threshold() {
+				return 90;
+			}
+			public function handle_error_event( $event_type, $key, $details, $environment ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+				// Custom error handling
+			}
+		};
+
+		// Verify optional methods exist
+		$this->assertTrue( method_exists( $provider, 'handle_error_event' ) );
+		$this->assertTrue( method_exists( $provider, 'get_empty_state_delay_threshold' ) );
+
+		// Verify custom threshold value
+		$reflection = new \ReflectionMethod( $provider, 'get_empty_state_delay_threshold' );
+		$this->assertSame( 90, $reflection->invoke( $provider ) );
 	}
 }

--- a/projects/packages/connection/tests/php/External_Storage_Test.php
+++ b/projects/packages/connection/tests/php/External_Storage_Test.php
@@ -105,8 +105,9 @@ class External_Storage_Test extends TestCase {
 	 * Test rate limiting with static cache prevents duplicate logs.
 	 */
 	public function test_rate_limiting_with_static_cache() {
-		delete_transient( 'jetpack_ext_storage_rate_limit_rate_test' );
-		delete_transient( 'jetpack_ext_storage_rate_limit_other_key' );
+		delete_transient( 'jetpack_ext_storage_rate_limit_error_rate_test' );
+		delete_transient( 'jetpack_ext_storage_rate_limit_error_other_key' );
+		delete_transient( 'jetpack_ext_storage_rate_limit_empty_rate_test' );
 
 		$reflection = new \ReflectionClass( External_Storage::class );
 
@@ -125,21 +126,26 @@ class External_Storage_Test extends TestCase {
 		}
 
 		// First call should return true
-		$this->assertTrue( $method->invoke( null, 'rate_test' ) );
+		$this->assertTrue( $method->invoke( null, 'rate_test', 'error' ) );
 
-		// Verify both caches are set
-		$this->assertNotFalse( get_transient( 'jetpack_ext_storage_rate_limit_rate_test' ) );
-		$this->assertArrayHasKey( 'rate_test', $logged_events_property->getValue() );
+		// Verify both caches are set (key includes event type)
+		$this->assertNotFalse( get_transient( 'jetpack_ext_storage_rate_limit_error_rate_test' ) );
+		$this->assertArrayHasKey( 'error_rate_test', $logged_events_property->getValue() );
 
-		// Second call should return false (blocked by static cache)
-		$this->assertFalse( $method->invoke( null, 'rate_test' ) );
+		// Second call with same key and event type should return false (blocked by static cache)
+		$this->assertFalse( $method->invoke( null, 'rate_test', 'error' ) );
 
 		// Different key should still work
-		$this->assertTrue( $method->invoke( null, 'other_key' ) );
+		$this->assertTrue( $method->invoke( null, 'other_key', 'error' ) );
+
+		// Same key with different event type should also work
+		$this->assertTrue( $method->invoke( null, 'rate_test', 'empty' ) );
+		$this->assertArrayHasKey( 'empty_rate_test', $logged_events_property->getValue() );
 
 		// Clean up
-		delete_transient( 'jetpack_ext_storage_rate_limit_rate_test' );
-		delete_transient( 'jetpack_ext_storage_rate_limit_other_key' );
+		delete_transient( 'jetpack_ext_storage_rate_limit_error_rate_test' );
+		delete_transient( 'jetpack_ext_storage_rate_limit_error_other_key' );
+		delete_transient( 'jetpack_ext_storage_rate_limit_empty_rate_test' );
 	}
 
 	/**


### PR DESCRIPTION
Refactors External_Storage to remove the unused Error_Handler integration and introduces a host-agnostic provider-based error reporting system. Storage providers can now optionally implement error handling methods to report errors to their own monitoring systems.


<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related CONNECT-81

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
External_Storage (class-external-storage.php)

- Added static cache ($logged_events) to prevent duplicate logging within the same request
- Removed Error_Handler integration (was never used in production)
- Removed should_report_for_environment() method
- Updated should_report_empty_state() to support provider customization
- Added provider delegation via optional handle_error_event() method
- Added support for optional get_empty_state_delay_threshold() provider method
- Changed default empty state delay from 10 minutes to 5 minutes

Storage Provider Interface (interface-storage-provider.php)

- Added comprehensive documentation for required and optional methods
- Documented handle_error_event($event_type, $key, $details, $environment) optional method
- Documented get_empty_state_delay_threshold() optional method with support for 0 (immediate reporting)

Error_Handler (class-error-handler.php)

- Marked external_storage_empty and external_storage_error codes as deprecated

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Code review
* Make sure the connection is still working when this branch is loaded on WoA test site.

