### PR TITLE
Forms: add form delete action

### DIFF
--- a/projects/packages/forms/changelog/add-delete-form-post
+++ b/projects/packages/forms/changelog/add-delete-form-post
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Forms: add form delete action.

--- a/projects/packages/forms/src/dashboard/forms/index.tsx
+++ b/projects/packages/forms/src/dashboard/forms/index.tsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { JetpackLogo } from '@automattic/jetpack-components';
-import { __experimentalConfirmDialog as ConfirmDialog } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
 import { DataViews } from '@wordpress/dataviews/wp';
 import { dateI18n, getSettings as getDateSettings } from '@wordpress/date';
 import { useCallback, useEffect, useMemo } from '@wordpress/element';
@@ -39,13 +38,7 @@ export default function FormsDashboardForms(): JSX.Element | null {
 		view.perPage,
 		view.search
 	);
-	const {
-		isDeleteConfirmDialogOpen,
-		isDeleting,
-		openDeleteConfirmDialog,
-		closeDeleteConfirmDialog,
-		onConfirmDelete,
-	} = useDeleteForm( {
+	const { isDeleting, trashForm } = useDeleteForm( {
 		view,
 		setView,
 		recordsLength: records?.length ?? 0,
@@ -142,11 +135,11 @@ export default function FormsDashboardForms(): JSX.Element | null {
 					if ( ! item ) {
 						return;
 					}
-					openDeleteConfirmDialog( item );
+					trashForm( item );
 				},
 			},
 		],
-		[ isDeleting, openDeleteConfirmDialog ]
+		[ isDeleting, trashForm ]
 	);
 
 	const paginationInfo = useMemo(
@@ -207,20 +200,6 @@ export default function FormsDashboardForms(): JSX.Element | null {
 					getItemId={ getItemId }
 					defaultLayouts={ defaultLayouts }
 				>
-					<ConfirmDialog
-						onCancel={ closeDeleteConfirmDialog }
-						onConfirm={ onConfirmDelete }
-						isOpen={ isDeleteConfirmDialogOpen }
-						confirmButtonText={ __( 'Move to Trash', 'jetpack-forms' ) }
-					>
-						<h3>{ __( 'Move to Trash', 'jetpack-forms' ) }</h3>
-						<p>
-							{ __(
-								'This will move the form to Trash. It will no longer appear in your forms list.',
-								'jetpack-forms'
-							) }
-						</p>
-					</ConfirmDialog>
 					<div className="jp-forms-filters-bar">
 						<div className="jp-forms-filters-bar__chips">
 							<DataViews.FiltersToggled className="jp-forms-filters-container" />

--- a/projects/packages/forms/src/dashboard/forms/index.tsx
+++ b/projects/packages/forms/src/dashboard/forms/index.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { JetpackLogo } from '@automattic/jetpack-components';
+import { __experimentalConfirmDialog as ConfirmDialog } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
 import { DataViews } from '@wordpress/dataviews/wp';
 import { dateI18n, getSettings as getDateSettings } from '@wordpress/date';
 import { useCallback, useEffect, useMemo } from '@wordpress/element';
@@ -15,6 +16,7 @@ import CreateFormButton from '../components/create-form-button/index.tsx';
 import { EmptyWrapper } from '../components/empty-responses/index.tsx';
 import FormsResponsesTabs from '../components/forms-responses-tabs/index.tsx';
 import Page from '../components/page/index.tsx';
+import useDeleteForm from '../hooks/use-delete-form.ts';
 import useFormsData from '../hooks/use-forms-data.ts';
 import { defaultLayouts, useView } from './views.ts';
 import './style.scss';
@@ -37,6 +39,17 @@ export default function FormsDashboardForms(): JSX.Element | null {
 		view.perPage,
 		view.search
 	);
+	const {
+		isDeleteConfirmDialogOpen,
+		isDeleting,
+		openDeleteConfirmDialog,
+		closeDeleteConfirmDialog,
+		onConfirmDelete,
+	} = useDeleteForm( {
+		view,
+		setView,
+		recordsLength: records?.length ?? 0,
+	} );
 
 	useEffect( () => {
 		if ( isCentralFormManagementDisabled ) {
@@ -116,8 +129,24 @@ export default function FormsDashboardForms(): JSX.Element | null {
 					window.location.href = url.toString();
 				},
 			},
+			{
+				id: 'delete-form',
+				isPrimary: false,
+				label: __( 'Trash', 'jetpack-forms' ),
+				supportsBulk: false,
+				callback( items: FormListItem[] ) {
+					if ( isDeleting ) {
+						return;
+					}
+					const [ item ] = items;
+					if ( ! item ) {
+						return;
+					}
+					openDeleteConfirmDialog( item );
+				},
+			},
 		],
-		[]
+		[ isDeleting, openDeleteConfirmDialog ]
 	);
 
 	const paginationInfo = useMemo(
@@ -178,6 +207,20 @@ export default function FormsDashboardForms(): JSX.Element | null {
 					getItemId={ getItemId }
 					defaultLayouts={ defaultLayouts }
 				>
+					<ConfirmDialog
+						onCancel={ closeDeleteConfirmDialog }
+						onConfirm={ onConfirmDelete }
+						isOpen={ isDeleteConfirmDialogOpen }
+						confirmButtonText={ __( 'Move to Trash', 'jetpack-forms' ) }
+					>
+						<h3>{ __( 'Move to Trash', 'jetpack-forms' ) }</h3>
+						<p>
+							{ __(
+								'This will move the form to Trash. It will no longer appear in your forms list.',
+								'jetpack-forms'
+							) }
+						</p>
+					</ConfirmDialog>
 					<div className="jp-forms-filters-bar">
 						<div className="jp-forms-filters-bar__chips">
 							<DataViews.FiltersToggled className="jp-forms-filters-container" />

--- a/projects/packages/forms/src/dashboard/hooks/use-delete-form.ts
+++ b/projects/packages/forms/src/dashboard/hooks/use-delete-form.ts
@@ -1,0 +1,143 @@
+import { useDispatch } from '@wordpress/data';
+import { useCallback, useMemo, useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { store as noticesStore } from '@wordpress/notices';
+/**
+ * Internal dependencies
+ */
+import { getFormsListQuery } from './use-forms-data.ts';
+import type { FormListItem } from './use-forms-data.ts';
+import type { View } from '@wordpress/dataviews/wp';
+
+type CoreDispatch = {
+	deleteEntityRecord: (
+		kind: string,
+		name: string,
+		recordId: number,
+		query?: Record< string, unknown >,
+		options?: { throwOnError?: boolean }
+	) => Promise< unknown >;
+	invalidateResolution: ( selector: string, args: unknown[] ) => void;
+};
+
+type UseDeleteFormArgs = {
+	view: View;
+	setView: ( newView: View ) => void;
+	recordsLength: number;
+};
+
+type UseDeleteFormReturn = {
+	isDeleteConfirmDialogOpen: boolean;
+	isDeleting: boolean;
+	openDeleteConfirmDialog: ( item: FormListItem ) => void;
+	closeDeleteConfirmDialog: () => void;
+	onConfirmDelete: () => Promise< void >;
+};
+
+/**
+ * Manage the "move form to trash" flow for the Forms list (confirmation state, REST delete, notices, cache invalidation).
+ *
+ * @param args               - Hook arguments.
+ * @param args.view          - Current DataViews view (for page/perPage/search).
+ * @param args.setView       - View setter (used to navigate to previous page when needed).
+ * @param args.recordsLength - Number of records currently displayed (used for pagination edge case).
+ *
+ * @return State + handlers for opening/closing the confirm dialog and executing the trash operation.
+ */
+export default function useDeleteForm( {
+	view,
+	setView,
+	recordsLength,
+}: UseDeleteFormArgs ): UseDeleteFormReturn {
+	const [ formPendingDelete, setFormPendingDelete ] = useState< FormListItem | null >( null );
+	const [ isDeleteConfirmDialogOpen, setIsDeleteConfirmDialogOpen ] = useState( false );
+	const [ isDeleting, setIsDeleting ] = useState( false );
+
+	const { deleteEntityRecord, invalidateResolution } = useDispatch( 'core' ) as CoreDispatch;
+	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
+
+	const page = view.page ?? 1;
+	const perPage = view.perPage ?? 20;
+	const search = view.search ?? '';
+
+	const currentQuery = useMemo(
+		() => getFormsListQuery( page, perPage, search ),
+		[ page, perPage, search ]
+	);
+
+	const openDeleteConfirmDialog = useCallback( ( item: FormListItem ) => {
+		setFormPendingDelete( item );
+		setIsDeleteConfirmDialogOpen( true );
+	}, [] );
+
+	const closeDeleteConfirmDialog = useCallback( () => {
+		setIsDeleteConfirmDialogOpen( false );
+		setFormPendingDelete( null );
+	}, [] );
+
+	const onConfirmDelete = useCallback( async () => {
+		if ( ! formPendingDelete || isDeleting ) {
+			return;
+		}
+
+		setIsDeleteConfirmDialogOpen( false );
+		setIsDeleting( true );
+
+		const shouldNavigateToPreviousPage = page > 1 && recordsLength === 1;
+
+		try {
+			await deleteEntityRecord(
+				'postType',
+				'jetpack_form',
+				formPendingDelete.id,
+				{ force: false },
+				{ throwOnError: true }
+			);
+
+			createSuccessNotice( __( 'Form moved to trash.', 'jetpack-forms' ), {
+				type: 'snackbar',
+				id: 'delete-form',
+			} );
+
+			if ( shouldNavigateToPreviousPage ) {
+				setView( { ...view, page: page - 1 } );
+			}
+		} catch {
+			createErrorNotice( __( 'Could not move form to trash.', 'jetpack-forms' ), {
+				type: 'snackbar',
+				id: 'delete-form-error',
+			} );
+		} finally {
+			setIsDeleting( false );
+			setFormPendingDelete( null );
+
+			// Invalidate the list query so the trashed form disappears from the table and totals refresh.
+			invalidateResolution( 'getEntityRecords', [ 'postType', 'jetpack_form', currentQuery ] );
+			invalidateResolution( 'getEntityRecords', [
+				'postType',
+				'jetpack_form',
+				{ ...currentQuery, per_page: 1, _fields: 'id' },
+			] );
+		}
+	}, [
+		createErrorNotice,
+		createSuccessNotice,
+		currentQuery,
+		deleteEntityRecord,
+		formPendingDelete,
+		invalidateResolution,
+		isDeleting,
+		page,
+		recordsLength,
+		setView,
+		view,
+	] );
+
+	return {
+		isDeleteConfirmDialogOpen,
+		isDeleting,
+		openDeleteConfirmDialog,
+		closeDeleteConfirmDialog,
+		onConfirmDelete,
+	};
+}

--- a/projects/packages/forms/src/dashboard/hooks/use-delete-form.ts
+++ b/projects/packages/forms/src/dashboard/hooks/use-delete-form.ts
@@ -10,6 +10,12 @@ import type { FormListItem } from './use-forms-data.ts';
 import type { View } from '@wordpress/dataviews/wp';
 
 type CoreDispatch = {
+	saveEntityRecord: (
+		kind: string,
+		name: string,
+		record: Record< string, unknown >,
+		options?: { throwOnError?: boolean }
+	) => Promise< unknown >;
 	deleteEntityRecord: (
 		kind: string,
 		name: string,
@@ -27,33 +33,30 @@ type UseDeleteFormArgs = {
 };
 
 type UseDeleteFormReturn = {
-	isDeleteConfirmDialogOpen: boolean;
 	isDeleting: boolean;
-	openDeleteConfirmDialog: ( item: FormListItem ) => void;
-	closeDeleteConfirmDialog: () => void;
-	onConfirmDelete: () => Promise< void >;
+	trashForm: ( item: FormListItem ) => Promise< void >;
 };
 
 /**
- * Manage the "move form to trash" flow for the Forms list (confirmation state, REST delete, notices, cache invalidation).
+ * Manage the "move form to trash" flow for the Forms list (REST delete, notices, cache invalidation).
  *
  * @param args               - Hook arguments.
  * @param args.view          - Current DataViews view (for page/perPage/search).
  * @param args.setView       - View setter (used to navigate to previous page when needed).
  * @param args.recordsLength - Number of records currently displayed (used for pagination edge case).
  *
- * @return State + handlers for opening/closing the confirm dialog and executing the trash operation.
+ * @return State + handler for executing the trash operation.
  */
 export default function useDeleteForm( {
 	view,
 	setView,
 	recordsLength,
 }: UseDeleteFormArgs ): UseDeleteFormReturn {
-	const [ formPendingDelete, setFormPendingDelete ] = useState< FormListItem | null >( null );
-	const [ isDeleteConfirmDialogOpen, setIsDeleteConfirmDialogOpen ] = useState( false );
 	const [ isDeleting, setIsDeleting ] = useState( false );
 
-	const { deleteEntityRecord, invalidateResolution } = useDispatch( 'core' ) as CoreDispatch;
+	const { saveEntityRecord, deleteEntityRecord, invalidateResolution } = useDispatch(
+		'core'
+	) as CoreDispatch;
 	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
 
 	const page = view.page ?? 1;
@@ -65,79 +68,104 @@ export default function useDeleteForm( {
 		[ page, perPage, search ]
 	);
 
-	const openDeleteConfirmDialog = useCallback( ( item: FormListItem ) => {
-		setFormPendingDelete( item );
-		setIsDeleteConfirmDialogOpen( true );
-	}, [] );
-
-	const closeDeleteConfirmDialog = useCallback( () => {
-		setIsDeleteConfirmDialogOpen( false );
-		setFormPendingDelete( null );
-	}, [] );
-
-	const onConfirmDelete = useCallback( async () => {
-		if ( ! formPendingDelete || isDeleting ) {
-			return;
-		}
-
-		setIsDeleteConfirmDialogOpen( false );
-		setIsDeleting( true );
-
-		const shouldNavigateToPreviousPage = page > 1 && recordsLength === 1;
-
-		try {
-			await deleteEntityRecord(
-				'postType',
-				'jetpack_form',
-				formPendingDelete.id,
-				{ force: false },
-				{ throwOnError: true }
-			);
-
-			createSuccessNotice( __( 'Form moved to trash.', 'jetpack-forms' ), {
-				type: 'snackbar',
-				id: 'delete-form',
-			} );
-
-			if ( shouldNavigateToPreviousPage ) {
-				setView( { ...view, page: page - 1 } );
+	const undoTrashForm = useCallback(
+		async ( id: number, previousStatus: string ) => {
+			try {
+				await saveEntityRecord(
+					'postType',
+					'jetpack_form',
+					{ id, status: previousStatus },
+					{ throwOnError: true }
+				);
+				createSuccessNotice( __( 'Form restored.', 'jetpack-forms' ), {
+					type: 'snackbar',
+					id: `restore-form-${ id }`,
+				} );
+			} catch {
+				createErrorNotice( __( 'Could not restore form.', 'jetpack-forms' ), {
+					type: 'snackbar',
+					id: `restore-form-error-${ id }`,
+				} );
+			} finally {
+				invalidateResolution( 'getEntityRecords', [ 'postType', 'jetpack_form', currentQuery ] );
+				invalidateResolution( 'getEntityRecords', [
+					'postType',
+					'jetpack_form',
+					{ ...currentQuery, per_page: 1, _fields: 'id' },
+				] );
 			}
-		} catch {
-			createErrorNotice( __( 'Could not move form to trash.', 'jetpack-forms' ), {
-				type: 'snackbar',
-				id: 'delete-form-error',
-			} );
-		} finally {
-			setIsDeleting( false );
-			setFormPendingDelete( null );
+		},
+		[ createErrorNotice, createSuccessNotice, currentQuery, invalidateResolution, saveEntityRecord ]
+	);
 
-			// Invalidate the list query so the trashed form disappears from the table and totals refresh.
-			invalidateResolution( 'getEntityRecords', [ 'postType', 'jetpack_form', currentQuery ] );
-			invalidateResolution( 'getEntityRecords', [
-				'postType',
-				'jetpack_form',
-				{ ...currentQuery, per_page: 1, _fields: 'id' },
-			] );
-		}
-	}, [
-		createErrorNotice,
-		createSuccessNotice,
-		currentQuery,
-		deleteEntityRecord,
-		formPendingDelete,
-		invalidateResolution,
-		isDeleting,
-		page,
-		recordsLength,
-		setView,
-		view,
-	] );
+	const trashForm = useCallback(
+		async ( item: FormListItem ) => {
+			if ( ! item || isDeleting ) {
+				return;
+			}
+
+			const previousStatus = item.status;
+			setIsDeleting( true );
+
+			const shouldNavigateToPreviousPage = page > 1 && recordsLength === 1;
+
+			try {
+				await deleteEntityRecord(
+					'postType',
+					'jetpack_form',
+					item.id,
+					{ force: false },
+					{ throwOnError: true }
+				);
+
+				createSuccessNotice( __( 'Form moved to trash.', 'jetpack-forms' ), {
+					type: 'snackbar',
+					id: `trash-form-${ item.id }`,
+					actions: [
+						{
+							label: __( 'Undo', 'jetpack-forms' ),
+							onClick: () => void undoTrashForm( item.id, previousStatus ),
+						},
+					],
+				} );
+
+				if ( shouldNavigateToPreviousPage ) {
+					setView( { ...view, page: page - 1 } );
+				}
+			} catch {
+				createErrorNotice( __( 'Could not move form to trash.', 'jetpack-forms' ), {
+					type: 'snackbar',
+					id: 'delete-form-error',
+				} );
+			} finally {
+				setIsDeleting( false );
+
+				// Invalidate the list query so the trashed form disappears from the table and totals refresh.
+				invalidateResolution( 'getEntityRecords', [ 'postType', 'jetpack_form', currentQuery ] );
+				invalidateResolution( 'getEntityRecords', [
+					'postType',
+					'jetpack_form',
+					{ ...currentQuery, per_page: 1, _fields: 'id' },
+				] );
+			}
+		},
+		[
+			createErrorNotice,
+			createSuccessNotice,
+			currentQuery,
+			deleteEntityRecord,
+			invalidateResolution,
+			isDeleting,
+			undoTrashForm,
+			page,
+			recordsLength,
+			setView,
+			view,
+		]
+	);
 
 	return {
-		isDeleteConfirmDialogOpen,
 		isDeleting,
-		openDeleteConfirmDialog,
-		closeDeleteConfirmDialog,
-		onConfirmDelete,
+		trashForm,
 	};
 }

--- a/projects/packages/forms/src/dashboard/hooks/use-forms-data.ts
+++ b/projects/packages/forms/src/dashboard/hooks/use-forms-data.ts
@@ -11,6 +11,33 @@ export type FormListItem = {
 	editUrl?: string;
 };
 
+/**
+ * Build the query object for fetching Forms list records from core-data.
+ *
+ * @param page    - Current page number.
+ * @param perPage - Items per page.
+ * @param search  - Search term.
+ *
+ * @return Query params for useEntityRecords / core-data.
+ */
+export function getFormsListQuery( page: number, perPage: number, search: string ) {
+	const queryParams: Record< string, unknown > = {
+		context: 'edit',
+		jetpack_forms_context: 'dashboard',
+		order: 'desc',
+		orderby: 'modified',
+		page,
+		per_page: perPage,
+		status: 'publish,draft,pending,future,private',
+	};
+
+	if ( search ) {
+		queryParams.search = search;
+	}
+
+	return queryParams;
+}
+
 type JetpackFormRestItem = {
 	id: number;
 	title?: { rendered?: string };
@@ -42,21 +69,7 @@ export default function useFormsData(
 	search: string
 ): UseFormsDataReturn {
 	const query = useMemo( () => {
-		const queryParams: Record< string, unknown > = {
-			context: 'edit',
-			jetpack_forms_context: 'dashboard',
-			order: 'desc',
-			orderby: 'modified',
-			page,
-			per_page: perPage,
-			status: 'publish,draft,pending,future,private',
-		};
-
-		if ( search ) {
-			queryParams.search = search;
-		}
-
-		return queryParams;
+		return getFormsListQuery( page, perPage, search );
 	}, [ page, perPage, search ] );
 
 	const {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:

We recently added a new forms tab and forms list to the dashboard behind our central form management flag. 

This PR adds a Trash action that allows us to move Forms to trash. Specifically: 
* adds a Trash action to the actions dropdown
* adds a custom hook to hold the delete form logic, and which calls deleteEntityRecord
* adds a success notification in the lower corner 
* adds 'undo' link on success notification to quickly undo the trash action

**Screenshot: Trash Action**

<img width="1347" height="477" alt="forms-trash-action" src="https://github.com/user-attachments/assets/a55f5756-a8b6-4ce3-9c7a-1d83915f9680" />

**Screenshot: Confirmation with undo**
<img width="1301" height="501" alt="undo-trash" src="https://github.com/user-attachments/assets/a08b0c74-6346-4220-a341-a45e8d01b14b" />

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
See [Central Forms Management ](https://linear.app/a8c/project/forms-central-form-management-a472909af5ec/overview)project on Linear. 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No. 

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Add this feature flag to your test site. 

```
add_filter( 'jetpack_block_editor_feature_flags', 'eb_register_feature' );
function eb_register_feature( $flags ) {
    $flags['central-form-management'] = true;
    return $flags;
}
```

* Create a new form. You can go to Jetpack > Form and click the Create Button which will create a new form post. Add your form, save, return to Jetpack > Forms and confirm your form shows in the list 
* Test deletion. Click the three dots in the Actions column and then Trash. 
* Confirm form is removed from list. 
* Confirm success notice appears in lower right. 
* Confirm if you click 'Undo' in the notification, the form is restored to the list

Test for no regressions:
* Remove feature flag and confirm everything works as before