### PR TITLE
Forms: Fix the new build pr

### DIFF
--- a/projects/packages/forms/changelog/fix-new-build-pr
+++ b/projects/packages/forms/changelog/fix-new-build-pr
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Fix a bug where we were overwritting the default wp modules
+Fix a bug where we were overwriting the default wp modules.

--- a/projects/packages/forms/changelog/fix-new-build-pr
+++ b/projects/packages/forms/changelog/fix-new-build-pr
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix a bug where we were overwritting the default wp modules

--- a/projects/packages/forms/src/dashboard/class-dashboard.php
+++ b/projects/packages/forms/src/dashboard/class-dashboard.php
@@ -27,9 +27,11 @@ class Dashboard {
 	 * This is for the new DataViews-based responses list.
 	 */
 	public static function load_wp_build() {
-		$wp_build_index = dirname( __DIR__, 2 ) . '/build/index.php';
-		if ( file_exists( $wp_build_index ) ) {
-			require_once $wp_build_index;
+		if ( isset( $_GET['page'] ) && $_GET['page'] === self::FORMS_WPBUILD_ADMIN_SLUG ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			$wp_build_index = dirname( __DIR__, 2 ) . '/build/index.php';
+			if ( file_exists( $wp_build_index ) ) {
+				require_once $wp_build_index;
+			}
 		}
 	}
 	/**

--- a/projects/packages/forms/src/dashboard/class-dashboard.php
+++ b/projects/packages/forms/src/dashboard/class-dashboard.php
@@ -27,7 +27,7 @@ class Dashboard {
 	 * This is for the new DataViews-based responses list.
 	 */
 	public static function load_wp_build() {
-		if ( isset( $_GET['page'] ) && $_GET['page'] === self::FORMS_WPBUILD_ADMIN_SLUG ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		if ( self::get_admin_query_page() === self::FORMS_WPBUILD_ADMIN_SLUG ) {
 			$wp_build_index = dirname( __DIR__, 2 ) . '/build/index.php';
 			if ( file_exists( $wp_build_index ) ) {
 				require_once $wp_build_index;
@@ -80,9 +80,18 @@ class Dashboard {
 		add_action( 'admin_enqueue_scripts', array( $this, 'load_admin_scripts' ) );
 
 		// Removed all admin notices on the Jetpack Forms admin page.
-		if ( isset( $_GET['page'] ) && $_GET['page'] === self::ADMIN_SLUG ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		if ( self::get_admin_query_page() === self::ADMIN_SLUG ) {
 			remove_all_actions( 'admin_notices' );
 		}
+	}
+	/**
+	 * Get the current query 'page' parameter.
+	 *
+	 * @return string
+	 */
+	private static function get_admin_query_page() {
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		return isset( $_GET['page'] ) ? sanitize_text_field( wp_unslash( $_GET['page'] ) ) : '';
 	}
 
 	/**


### PR DESCRIPTION
Currently when we load the new build we also remove the default core modules. via 
`remove_action( 'wp_default_scripts', 'wp_default_script_modules' );`

In forms/build/modules.php ( an autogenerated file ) 

This was happening on all the pages. Which caused the forms to stop workingman's we were never loading properly enqueing the interactivity api module any more. (since this is something that is not needed, but this was also the case for other modules. 

This PR make it so that the build system only does this on the specific page that we show the new dashboard UI. 

## Proposed changes:
* Limits where we include the new form wp build system. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
See p1768520569988519-slack-C086RGTJT1D 

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Add the following to your 0-sandbox.php file `add_filter('jetpack_forms_alpha', '__return_true');` 

build the forms with in the forms package.  pnpm forms 

Notice that you are able to submit a form and it works as expected. 
