### PR TITLE
Forms: Fix wp-build dashboard rendering after dependency update

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-wp-build-dashboard-build-update
+++ b/projects/packages/forms/changelog/fix-forms-wp-build-dashboard-build-update
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: Fix wp-build dashboard rendering after dependency update

--- a/projects/packages/forms/changelog/fix-forms-wp-build-dashboard-build-update
+++ b/projects/packages/forms/changelog/fix-forms-wp-build-dashboard-build-update
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Forms: Fix wp-build dashboard rendering after dependency update
+Fix wp-build dashboard rendering after wp-build dependency update and prefix functions to avoid conflicts with Gutenberg.

--- a/projects/packages/forms/package.json
+++ b/projects/packages/forms/package.json
@@ -128,6 +128,7 @@
 		"react-dom": "18.3.1"
 	},
 	"wpPlugin": {
+		"name": "jetpack_forms",
 		"scriptGlobal": "jetpackForms",
 		"packageNamespace": "jetpack-forms",
 		"handlePrefix": "jetpack-forms",

--- a/projects/packages/forms/src/dashboard/class-dashboard.php
+++ b/projects/packages/forms/src/dashboard/class-dashboard.php
@@ -211,8 +211,8 @@ class Dashboard {
 	 * Register Forms (WP-Build) submenu under Jetpack menu using wp-build page.
 	 */
 	public function add_forms_wpbuild_submenu() {
-		$callback = function_exists( 'gutenberg_jetpack_forms_responses_wp_admin_render_page' )
-			? 'gutenberg_jetpack_forms_responses_wp_admin_render_page'
+		$callback = function_exists( 'jetpack_forms_jetpack_forms_responses_wp_admin_render_page' )
+			? 'jetpack_forms_jetpack_forms_responses_wp_admin_render_page'
 			: array( $this, 'render_dashboard' );
 
 		Admin_Menu::add_menu(

--- a/projects/packages/forms/src/dashboard/class-dashboard.php
+++ b/projects/packages/forms/src/dashboard/class-dashboard.php
@@ -28,7 +28,7 @@ class Dashboard {
 	 */
 	public static function load_wp_build() {
 		if ( self::get_admin_query_page() === self::FORMS_WPBUILD_ADMIN_SLUG ) {
-			$wp_build_index = dirname( __DIR__, 2 ) . '/build/index.php';
+			$wp_build_index = dirname( __DIR__, 2 ) . '/build/build.php';
 			if ( file_exists( $wp_build_index ) ) {
 				require_once $wp_build_index;
 			}
@@ -211,8 +211,8 @@ class Dashboard {
 	 * Register Forms (WP-Build) submenu under Jetpack menu using wp-build page.
 	 */
 	public function add_forms_wpbuild_submenu() {
-		$callback = function_exists( 'jetpack_forms_responses_wp_admin_render_page' )
-			? 'jetpack_forms_responses_wp_admin_render_page'
+		$callback = function_exists( 'gutenberg_jetpack_forms_responses_wp_admin_render_page' )
+			? 'gutenberg_jetpack_forms_responses_wp_admin_render_page'
 			: array( $this, 'render_dashboard' );
 
 		Admin_Menu::add_menu(

--- a/projects/packages/forms/src/dashboard/class-dashboard.php
+++ b/projects/packages/forms/src/dashboard/class-dashboard.php
@@ -34,6 +34,7 @@ class Dashboard {
 			}
 		}
 	}
+
 	/**
 	 * Script handle for the JS file we enqueue in the Feedback admin page.
 	 *
@@ -84,6 +85,7 @@ class Dashboard {
 			remove_all_actions( 'admin_notices' );
 		}
 	}
+
 	/**
 	 * Get the current query 'page' parameter.
 	 *


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes an issue introduced in https://github.com/Automattic/jetpack/pull/46647 due to dependency update

See [changelog](https://github.com/WordPress/gutenberg/blob/3fd3bc7e7cec7555c63e1a964e19f6c53838a129/packages/wp-build/CHANGELOG.md#060-2026-01-16)

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Updates the built file name and function name to render the dashboard

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Enable the forms alpha flag
* Go to Jetpack > Forms (WP-Build)
* Check that the dashboard is rendered
