### PR TITLE
Social: Update the customization toggle and save the flag to post meta.

### DIFF
--- a/projects/packages/publicize/_inc/components/customize-and-preview/customization-toggle/index.tsx
+++ b/projects/packages/publicize/_inc/components/customize-and-preview/customization-toggle/index.tsx
@@ -22,6 +22,7 @@ export function CustomizationToggle() {
 			label={ _x( 'Customize', 'Verb: Customize the social preview', 'jetpack-publicize-pkg' ) }
 			onChange={ toggle }
 			value={ isEnabled ? 'each' : 'all' }
+			hideLabelFromVision
 		>
 			<ToggleGroupControlOption
 				label={ _x(

--- a/projects/packages/publicize/_inc/components/customize-and-preview/customization-toggle/index.tsx
+++ b/projects/packages/publicize/_inc/components/customize-and-preview/customization-toggle/index.tsx
@@ -4,7 +4,7 @@ import {
 	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
 } from '@wordpress/components';
 import { _x } from '@wordpress/i18n';
-import { usePerNetworkCustomization } from './use-per-network-customization';
+import { usePerNetworkCustomization } from '../../../hooks/use-per-network-customization';
 
 /**
  * Customization Toggle component for the social preview modal.

--- a/projects/packages/publicize/_inc/components/customize-and-preview/customization-toggle/use-per-network-customization.ts
+++ b/projects/packages/publicize/_inc/components/customize-and-preview/customization-toggle/use-per-network-customization.ts
@@ -1,27 +1,31 @@
 import { useDispatch, useSelect } from '@wordpress/data';
+import { store as editorStore } from '@wordpress/editor';
 import { useCallback, useMemo } from '@wordpress/element';
-import { store as preferencesStore } from '@wordpress/preferences';
 
-const NAMESPACE = 'jetpack/social';
-
-const KEY = 'temp_social_per_network_customization';
+const KEY = '_wpas_customize_per_network';
 
 /**
- * TEMPORARY hook to manage per network customization toggle state.
+ * Hook to manage per network customization toggle state.
  *
- * TODO: Replace this with a persistent solution once available.
- *
- * @return User preferences.
+ * @return - An object containing isEnabled boolean and toggle function.
  */
 export function usePerNetworkCustomization() {
-	const preferences = useDispatch( preferencesStore );
+	const { editPost } = useDispatch( editorStore );
 
-	const isEnabled = useSelect(
-		select => Boolean( select( preferencesStore ).get( NAMESPACE, KEY ) ),
-		[]
-	);
+	const isEnabled = useSelect( select => {
+		const postMeta = select( editorStore ).getEditedPostAttribute( 'meta' );
 
-	const toggle = useCallback( () => preferences.toggle( NAMESPACE, KEY ), [ preferences ] );
+		return Boolean( postMeta?.[ KEY ] );
+	}, [] );
+
+	const toggle = useCallback( () => {
+		// Update post metadata.
+		editPost( {
+			meta: {
+				[ KEY ]: ! isEnabled,
+			},
+		} );
+	}, [ editPost, isEnabled ] );
 
 	return useMemo(
 		() => ( {

--- a/projects/packages/publicize/_inc/components/customize-and-preview/index.tsx
+++ b/projects/packages/publicize/_inc/components/customize-and-preview/index.tsx
@@ -1,4 +1,6 @@
 import { useBreakpoint } from '@automattic/viewport-react';
+import { CustomizationToggle } from './customization-toggle';
+import styles from './styles.module.scss';
 import { TabPanelDesktop } from './tab-panels/desktop';
 import { TabPanelMobile } from './tab-panels/mobile';
 
@@ -10,5 +12,12 @@ import { TabPanelMobile } from './tab-panels/mobile';
 export function CustomizeAndPreview() {
 	const isSmallScreen = useBreakpoint( '<782px' );
 
-	return isSmallScreen ? <TabPanelMobile /> : <TabPanelDesktop />;
+	return (
+		<div className={ styles[ 'customize-and-preview' ] }>
+			<div className={ styles[ 'customization-toggle-wrapper' ] }>
+				<CustomizationToggle />
+			</div>
+			<div>{ isSmallScreen ? <TabPanelMobile /> : <TabPanelDesktop /> }</div>
+		</div>
+	);
 }

--- a/projects/packages/publicize/_inc/components/customize-and-preview/styles.module.scss
+++ b/projects/packages/publicize/_inc/components/customize-and-preview/styles.module.scss
@@ -1,0 +1,17 @@
+@use "@automattic/jetpack-base-styles/gutenberg-base-styles" as gb;
+
+.customize-and-preview {
+
+	.customization-toggle-wrapper {
+		padding: 1rem;
+
+		@include gb.break-medium() {
+			border-bottom: 1px solid #ddd;
+		}
+
+		:global(.components-base-control) {
+			max-width: 400px;
+			margin: 0 auto;
+		}
+	}
+}

--- a/projects/packages/publicize/_inc/components/customize-and-preview/tab-panels/desktop/customization-section.tsx
+++ b/projects/packages/publicize/_inc/components/customize-and-preview/tab-panels/desktop/customization-section.tsx
@@ -2,7 +2,6 @@ import { __ } from '@wordpress/i18n';
 import { Connection } from '../../../../social-store/types';
 import { SharePostForm } from '../../../form/share-post-form';
 import { ConnectionToggle } from '../../connection-toggle';
-import { CustomizationToggle } from '../../customization-toggle';
 import styles from './styles.module.scss';
 
 type CustomizationSectionProps = {
@@ -25,7 +24,6 @@ export function CustomizationSection( {
 			aria-label={ __( 'Customization form', 'jetpack-publicize-pkg' ) }
 			className={ styles[ 'customization-section' ] }
 		>
-			<CustomizationToggle />
 			<ConnectionToggle connection={ connection } />
 			<SharePostForm
 				// TODO Wire up per-network customization state to the form.

--- a/projects/packages/publicize/_inc/components/customize-and-preview/tab-panels/desktop/index.tsx
+++ b/projects/packages/publicize/_inc/components/customize-and-preview/tab-panels/desktop/index.tsx
@@ -1,6 +1,6 @@
 import { TabPanel } from '@wordpress/components';
 import { useCallback } from 'react';
-import { usePerNetworkCustomization } from '../../customization-toggle/use-per-network-customization';
+import { usePerNetworkCustomization } from '../../../../hooks/use-per-network-customization';
 import { ConnectionTab } from '../types';
 import { useConnectionTabs } from '../use-connection-tabs';
 import styles from './styles.module.scss';

--- a/projects/packages/publicize/_inc/components/customize-and-preview/tab-panels/mobile/index.tsx
+++ b/projects/packages/publicize/_inc/components/customize-and-preview/tab-panels/mobile/index.tsx
@@ -1,7 +1,6 @@
 import { TabPanel } from '@wordpress/components';
 import clsx from 'clsx';
 import { useCallback } from 'react';
-import { CustomizationToggle } from '../../customization-toggle';
 import { usePerNetworkCustomization } from '../../customization-toggle/use-per-network-customization';
 import { ConnectionTab } from '../types';
 import { useConnectionTabs } from '../use-connection-tabs';
@@ -32,22 +31,13 @@ export function TabPanelMobile() {
 	);
 
 	return (
-		<div>
-			<div className={ styles[ 'customization-toggle-wrapper' ] }>
-				<CustomizationToggle />
-			</div>
-			<div
-				className={ clsx( {
-					[ styles[ 'tab-panel-mobile-wrapper-border' ] ]: ! usingPerNetworkCustomization,
-				} ) }
-			>
-				{ ! usingPerNetworkCustomization && <CustomizationSection /> }
-				<TabPanel
-					className={ styles[ 'tab-panel-mobile' ] }
-					tabs={ tabs }
-					children={ tabRenderer }
-				/>
-			</div>
+		<div
+			className={ clsx( {
+				[ styles[ 'tab-panel-mobile-wrapper-border' ] ]: ! usingPerNetworkCustomization,
+			} ) }
+		>
+			{ ! usingPerNetworkCustomization && <CustomizationSection /> }
+			<TabPanel className={ styles[ 'tab-panel-mobile' ] } tabs={ tabs } children={ tabRenderer } />
 		</div>
 	);
 }

--- a/projects/packages/publicize/_inc/components/customize-and-preview/tab-panels/mobile/index.tsx
+++ b/projects/packages/publicize/_inc/components/customize-and-preview/tab-panels/mobile/index.tsx
@@ -1,7 +1,7 @@
 import { TabPanel } from '@wordpress/components';
 import clsx from 'clsx';
 import { useCallback } from 'react';
-import { usePerNetworkCustomization } from '../../customization-toggle/use-per-network-customization';
+import { usePerNetworkCustomization } from '../../../../hooks/use-per-network-customization';
 import { ConnectionTab } from '../types';
 import { useConnectionTabs } from '../use-connection-tabs';
 import { CustomizationSection } from './customization-section';

--- a/projects/packages/publicize/_inc/hooks/use-per-network-customization/index.ts
+++ b/projects/packages/publicize/_inc/hooks/use-per-network-customization/index.ts
@@ -2,7 +2,7 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
 import { useCallback, useMemo } from '@wordpress/element';
 
-const KEY = '_wpas_customize_per_network';
+const TOGGLE_KEY = '_wpas_customize_per_network';
 
 /**
  * Hook to manage per network customization toggle state.
@@ -15,14 +15,14 @@ export function usePerNetworkCustomization() {
 	const isEnabled = useSelect( select => {
 		const postMeta = select( editorStore ).getEditedPostAttribute( 'meta' );
 
-		return Boolean( postMeta?.[ KEY ] );
+		return Boolean( postMeta?.[ TOGGLE_KEY ] );
 	}, [] );
 
 	const toggle = useCallback( () => {
 		// Update post metadata.
 		editPost( {
 			meta: {
-				[ KEY ]: ! isEnabled,
+				[ TOGGLE_KEY ]: ! isEnabled,
 			},
 		} );
 	}, [ editPost, isEnabled ] );

--- a/projects/packages/publicize/_inc/hooks/use-per-network-customization/test/index.test.ts
+++ b/projects/packages/publicize/_inc/hooks/use-per-network-customization/test/index.test.ts
@@ -1,0 +1,82 @@
+import { act, renderHook } from '@testing-library/react';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { usePerNetworkCustomization } from '../';
+
+jest.mock( '@wordpress/data', () => {
+	const actual = jest.requireActual( '@wordpress/data' );
+	const mocks = {
+		useDispatch: jest.fn(),
+		useSelect: jest.fn(),
+	};
+	return new Proxy( actual, {
+		get( target, property ) {
+			return mocks[ property as keyof typeof mocks ] ?? target[ property as keyof typeof target ];
+		},
+	} );
+} );
+
+const mockUseDispatch = useDispatch as jest.MockedFunction< typeof useDispatch >;
+const mockUseSelect = useSelect as jest.MockedFunction< typeof useSelect >;
+
+describe( 'usePerNetworkCustomization', () => {
+	const mockEditPost = jest.fn();
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+
+		mockUseDispatch.mockReturnValue( {
+			editPost: mockEditPost,
+		} );
+	} );
+
+	it( 'should return isEnabled as false when meta key is not set', () => {
+		mockUseSelect.mockImplementation( ( selector: ( select: unknown ) => unknown ) => {
+			const mockSelect = () => ( {
+				getEditedPostAttribute: jest.fn().mockReturnValue( {} ),
+			} );
+			return selector( mockSelect );
+		} );
+
+		const { result } = renderHook( () => usePerNetworkCustomization() );
+
+		expect( result.current.isEnabled ).toBe( false );
+	} );
+
+	it( 'should return isEnabled as true when meta key is true', () => {
+		mockUseSelect.mockImplementation( ( selector: ( select: unknown ) => unknown ) => {
+			const mockSelect = () => ( {
+				getEditedPostAttribute: jest.fn().mockReturnValue( {
+					_wpas_customize_per_network: true,
+				} ),
+			} );
+			return selector( mockSelect );
+		} );
+
+		const { result } = renderHook( () => usePerNetworkCustomization() );
+
+		expect( result.current.isEnabled ).toBe( true );
+	} );
+
+	it( 'should toggle the meta value when toggle is called', () => {
+		mockUseSelect.mockImplementation( ( selector: ( select: unknown ) => unknown ) => {
+			const mockSelect = () => ( {
+				getEditedPostAttribute: jest.fn().mockReturnValue( {
+					_wpas_customize_per_network: false,
+				} ),
+			} );
+			return selector( mockSelect );
+		} );
+
+		const { result } = renderHook( () => usePerNetworkCustomization() );
+
+		act( () => {
+			result.current.toggle();
+		} );
+
+		expect( mockEditPost ).toHaveBeenCalledWith( {
+			meta: {
+				_wpas_customize_per_network: true,
+			},
+		} );
+	} );
+} );

--- a/projects/packages/publicize/changelog/update-social-wire-up-customization-toggle
+++ b/projects/packages/publicize/changelog/update-social-wire-up-customization-toggle
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update the customization toggle and save the flag to post meta.

--- a/projects/packages/publicize/src/rest-api/class-connections-post-field.php
+++ b/projects/packages/publicize/src/rest-api/class-connections-post-field.php
@@ -193,7 +193,7 @@ class Connections_Post_Field {
 	 *
 	 * @return mixed
 	 */
-	public function get( $post_array, $field_name, $request, $object_type ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+	public function get( $post_array, $field_name, $request, $object_type ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable, Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
 		global $publicize;
 
 		$post_id          = $post_array['id'] ?? 0;
@@ -413,7 +413,7 @@ class Connections_Post_Field {
 			return;
 		}
 		foreach ( $this->get_meta_to_update( $requested_connections, $post->ID ) as $meta_key => $meta_value ) {
-			if ( $meta_value === null ) {
+			if ( null === $meta_value ) {
 				delete_post_meta( $post->ID, $meta_key );
 			} else {
 				update_post_meta( $post->ID, $meta_key, $meta_value );
@@ -442,7 +442,7 @@ class Connections_Post_Field {
 		if ( $request && isset( $request['meta'][ Publicize_Base::POST_CUSTOMIZE_PER_NETWORK ] ) ) {
 			$customize_per_network = $request['meta'][ Publicize_Base::POST_CUSTOMIZE_PER_NETWORK ];
 		}
-		if ( $customize_per_network === null ) {
+		if ( null === $customize_per_network ) {
 			$customize_per_network = get_post_meta( $post_id, Publicize_Base::POST_CUSTOMIZE_PER_NETWORK, true );
 		}
 		if ( ! $customize_per_network ) {


### PR DESCRIPTION
Completes SOCIAL-317

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Move the customization toggle out of the sidebar on desktop to the top of the modal, making it consistent with mobile, following the discussion in p1768573662725229/1767164097.436849-slack-C09QJF0GKJB
* Wire up the post meta for the toggle

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Add the blog sticker to your site - `add_blog_sticker( 'jetpack-social-unified-ui-v1', null, null, <your-blog-id> );`
* Go to the post editor
* Open Jetpack sidebar
* Open preview or resharing modal
* Confirm that you see the customization toggle is at the top on desktop as well as on small screens
* Change the state of the toggle
* Save the post
* Confirm that the state is preserved on page reload

<img width="1057" height="248" alt="Screenshot 2026-01-19 at 11 47 20 AM" src="https://github.com/user-attachments/assets/2820692f-fba4-4997-8eaf-027eb69759d3" />
