### PR TITLE
Update VS Code settings to add explicit code actions

### DIFF
--- a/.vscode/settings.dist.jsonc
+++ b/.vscode/settings.dist.jsonc
@@ -43,9 +43,15 @@
 		"editor.formatOnSave": true,
 		"editor.defaultFormatter": "obliviousharmony.vscode-php-codesniffer"
 	},
+	// Custom settings for JavaScript and TypeScript files.
+	"[javascript][javascriptreact][typescript][typescriptreact]": {
+		"editor.formatOnSave": false,
+		"editor.defaultFormatter": "esbenp.prettier-vscode"
+	},
 	// Run Code Actions for the editor.
 	"editor.codeActionsOnSave": {
-		"source.fixAll": "explicit"
+		"source.fixAll.eslint": "explicit",
+		"source.fixAll.stylelint": "explicit"
 	},
 	// Use this wp-prettier from this path.
 	"prettier.prettierPath": "tools/js-tools/node_modules/prettier/index.cjs",


### PR DESCRIPTION
I have observed that if I have similar settings in the global VS Code settings, then `"source.fixAll": "explicit"` results in double formatting, often resulting in mangled code.

## Proposed changes:

Prevents double formatting for JS/TS files when users have similar format-on-save settings in their VS Code user preferences.

- Disables `editor.formatOnSave` for JS/TS files to prevent Prettier from running alongside ESLint/Stylelint auto-fix.
- Replaces generic `source.fixAll` with explicit `source.fixAll.eslint` and `source.fixAll.stylelint` for more predictable behavior.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

N/A - Developer tooling change.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

1. Close VS Code completely and reopen it with this branch checked out.
2. Open a JS/TS file and save - verify that formatting on save works as expected.
3. Run "ESLint: Fix all auto-fixable Problems" - verify ESLint fixes apply.
