### PR TITLE
Charts: Add labelOverflow ellipsis option for bar chart axis labels

### DIFF
--- a/projects/js-packages/charts/changelog/add-bar-chart-label-overflow-ellipsis
+++ b/projects/js-packages/charts/changelog/add-bar-chart-label-overflow-ellipsis
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+BarChart: add labelOverflow ellipsis option to truncate long axis labels.

--- a/projects/js-packages/charts/changelog/add-bar-chart-label-overflow-ellipsis
+++ b/projects/js-packages/charts/changelog/add-bar-chart-label-overflow-ellipsis
@@ -1,4 +1,4 @@
 Significance: minor
 Type: added
 
-Add labelOverflow ellipsis option to truncate long axis labels for bar chart
+Add labelOverflow ellipsis option to truncate long axis labels for bar chart.

--- a/projects/js-packages/charts/changelog/add-bar-chart-label-overflow-ellipsis
+++ b/projects/js-packages/charts/changelog/add-bar-chart-label-overflow-ellipsis
@@ -1,4 +1,4 @@
 Significance: minor
 Type: added
 
-BarChart: add labelOverflow ellipsis option to truncate long axis labels.
+Add labelOverflow ellipsis option to truncate long axis labels for bar chart

--- a/projects/js-packages/charts/src/charts/bar-chart/private/index.ts
+++ b/projects/js-packages/charts/src/charts/bar-chart/private/index.ts
@@ -1,2 +1,2 @@
 export { useBarChartOptions } from './use-bar-chart-options';
-export { createTruncatedTickComponent, TruncatedTickComponent } from './truncated-tick-component';
+export { createTruncatedTickComponent } from './truncated-tick-component';

--- a/projects/js-packages/charts/src/charts/bar-chart/private/index.ts
+++ b/projects/js-packages/charts/src/charts/bar-chart/private/index.ts
@@ -1,1 +1,2 @@
 export { useBarChartOptions } from './use-bar-chart-options';
+export { createTruncatedTickComponent, TruncatedTickComponent } from './truncated-tick-component';

--- a/projects/js-packages/charts/src/charts/bar-chart/private/index.ts
+++ b/projects/js-packages/charts/src/charts/bar-chart/private/index.ts
@@ -1,2 +1,2 @@
 export { useBarChartOptions } from './use-bar-chart-options';
-export { createTruncatedTickComponent } from './truncated-tick-component';
+export { TruncatedXTickComponent, TruncatedYTickComponent } from './truncated-tick-component';

--- a/projects/js-packages/charts/src/charts/bar-chart/private/truncated-tick-component.tsx
+++ b/projects/js-packages/charts/src/charts/bar-chart/private/truncated-tick-component.tsx
@@ -101,8 +101,14 @@ export const TruncatedTickComponent: FC< TruncatedTickComponentProps > = ( {
 	};
 
 	const textStyles: CSSProperties = {
+		/**
+		 * SVG <text> elements are vertically aligned to the baseline by default, but HTML <div> elements inside <foreignObject>
+		 * are positioned relative to the top-left corner. To visually align the tick label like SVG text,
+		 * we shift the div up by 100% of its height and adjust by twice the SVG dy value (from visx) to approximate original placement.
+		 */
+		transform: `translateY(calc(-100% + ${ dy ?? '0' } * 2))`,
+		position: 'fixed',
 		// Offset y to convert from baseline to top-left positioning because svg text is positioned by baseline, but html div is positioned by top-left.
-		transform: 'translateY(-100%)',
 		// Apply compatible SVG text styles
 		fontSize,
 		fontFamily,
@@ -124,15 +130,7 @@ export const TruncatedTickComponent: FC< TruncatedTickComponentProps > = ( {
 	};
 
 	return (
-		<foreignObject
-			x={ x + xOffset }
-			y={ y }
-			width={ maxWidth }
-			overflow="visible"
-			// dy * 2: The div's translateY(-100%) and visx's pre-calculated y offset
-			// create a compound effect that requires doubling dy to match original text position.
-			style={ { transform: `translateY(calc(${ dy ?? '0' } * 2))` } }
-		>
+		<foreignObject x={ x + xOffset } y={ y } width={ maxWidth } overflow="visible">
 			<div
 				style={ textStyles }
 				title={ formattedValue || undefined }

--- a/projects/js-packages/charts/src/charts/bar-chart/private/truncated-tick-component.tsx
+++ b/projects/js-packages/charts/src/charts/bar-chart/private/truncated-tick-component.tsx
@@ -109,8 +109,7 @@ export const TruncatedTickComponent: FC< TruncatedTickComponentProps > = ( {
 		transform: `translateY(calc(-100% + ${ dy ?? '0' } * 2))`,
 		// Safari doesn't work well with foreignObject, this is a workaround to position the div correctly.
 		position: 'fixed',
-		// Offset y to convert from baseline to top-left positioning because svg text is positioned by baseline, but html div is positioned by top-left.
-		// Apply compatible SVG text styles
+		// Apply SVG-like font properties from visx text props to the HTML div.
 		fontSize,
 		fontFamily,
 		fontWeight,

--- a/projects/js-packages/charts/src/charts/bar-chart/private/truncated-tick-component.tsx
+++ b/projects/js-packages/charts/src/charts/bar-chart/private/truncated-tick-component.tsx
@@ -22,6 +22,15 @@ interface TruncatedTickComponentProps extends TickRendererProps {
 /**
  * Minimum width in pixels for tick labels when scale bandwidth is very small.
  * Prevents labels from collapsing to unreadable widths on dense charts.
+ *
+ * Trade-off: When bandwidth is less than this minimum (e.g., many bars in a narrow chart),
+ * adjacent labels may overlap since each label uses this minimum width regardless of
+ * available space. This prioritizes label readability over preventing overlap.
+ *
+ * For very dense charts where overlap occurs, consider:
+ * - Using `numTicks` option to reduce the number of displayed labels
+ * - Using `tickFormat` to abbreviate label text
+ * - Increasing chart width or reducing data points
  */
 const MIN_TICK_LABEL_WIDTH = 20;
 
@@ -31,6 +40,10 @@ const MIN_TICK_LABEL_WIDTH = 20;
  *
  * Uses foreignObject to embed HTML within SVG, enabling CSS text-overflow: ellipsis.
  * Inherits text styles from tickLabelProps passed by visx Axis component.
+ *
+ * Note: A minimum label width (MIN_TICK_LABEL_WIDTH) is enforced to keep labels readable.
+ * On very dense charts where bandwidth < 20px, this may cause label overlap.
+ * See MIN_TICK_LABEL_WIDTH documentation for mitigation strategies.
  *
  * @param props                - The props for the truncated tick component
  * @param props.x              - The x position of the tick

--- a/projects/js-packages/charts/src/charts/bar-chart/private/truncated-tick-component.tsx
+++ b/projects/js-packages/charts/src/charts/bar-chart/private/truncated-tick-component.tsx
@@ -23,7 +23,7 @@ interface TruncatedTickComponentProps extends TickRendererProps {
  * Minimum width in pixels for tick labels when scale bandwidth is very small.
  * Prevents labels from collapsing to unreadable widths on dense charts.
  */
-const MINI_TICK_LABEL_LENGTH = 20;
+const MIN_TICK_LABEL_WIDTH = 20;
 
 /**
  * A tick component that renders labels with text truncation (ellipsis) when they exceed
@@ -57,7 +57,7 @@ export const TruncatedTickComponent: FC< TruncatedTickComponentProps > = ( {
 	const { xScale, yScale } = useContext( DataContext ) || {};
 	const scale = axis === 'x' ? xScale : yScale;
 	const bandwidth = getScaleBandwidth( scale );
-	const maxWidth = Math.max( bandwidth, MINI_TICK_LABEL_LENGTH );
+	const maxWidth = Math.max( bandwidth, MIN_TICK_LABEL_WIDTH );
 
 	// Map SVG textAnchor to CSS textAlign
 	let textAlign: 'left' | 'right' | 'center' = 'center';

--- a/projects/js-packages/charts/src/charts/bar-chart/private/truncated-tick-component.tsx
+++ b/projects/js-packages/charts/src/charts/bar-chart/private/truncated-tick-component.tsx
@@ -107,6 +107,7 @@ export const TruncatedTickComponent: FC< TruncatedTickComponentProps > = ( {
 		 * we shift the div up by 100% of its height and adjust by twice the SVG dy value (from visx) to approximate original placement.
 		 */
 		transform: `translateY(calc(-100% + ${ dy ?? '0' } * 2))`,
+		// Safari doesn't work well with foreignObject, this is a workaround to position the div correctly.
 		position: 'fixed',
 		// Offset y to convert from baseline to top-left positioning because svg text is positioned by baseline, but html div is positioned by top-left.
 		// Apply compatible SVG text styles

--- a/projects/js-packages/charts/src/charts/bar-chart/private/truncated-tick-component.tsx
+++ b/projects/js-packages/charts/src/charts/bar-chart/private/truncated-tick-component.tsx
@@ -1,0 +1,105 @@
+import { DataContext } from '@visx/xychart';
+import { useContext } from 'react';
+import type { AxisScale, TickRendererProps } from '@visx/axis';
+import type { FC, CSSProperties } from 'react';
+
+/**
+ * Get the bandwidth of a scale
+ *
+ * @param scale - The scale to get the bandwidth of
+ * @return The bandwidth of the scale
+ */
+const getScaleBandwidth = < Scale extends AxisScale >( scale?: Scale ) => {
+	const s = scale as AxisScale;
+	return s && 'bandwidth' in s ? s?.bandwidth() ?? 0 : 0;
+};
+
+interface TruncatedTickComponentProps extends TickRendererProps {
+	/** Which axis this tick belongs to */
+	axis: 'x' | 'y';
+}
+
+const MINI_TICK_LABEL_LENGTH = 20;
+
+/**
+ * A tick component that renders labels with text truncation (ellipsis) when they exceed
+ * the available bandwidth. Shows the full text on hover via native title attribute.
+ *
+ * Uses foreignObject to embed HTML within SVG, enabling CSS text-overflow: ellipsis.
+ * Inherits text styles from tickLabelProps passed by visx Axis component.
+ *
+ * @param props                - The props for the truncated tick component
+ * @param props.x              - The x position of the tick
+ * @param props.y              - The y position of the tick
+ * @param props.formattedValue - The formatted value of the tick
+ * @param props.axis           - The axis this tick belongs to
+ * @param props.textAnchor     - The text anchor of the tick
+ * @param props.fill           - The fill color of the tick
+ * @param props.dy             - The dy offset of the tick
+ *
+ * @return The truncated tick component
+ */
+export const TruncatedTickComponent: FC< TruncatedTickComponentProps > = ( {
+	x,
+	y,
+	formattedValue,
+	axis,
+	textAnchor,
+	fill,
+	dy,
+	...textProps
+} ) => {
+	// Get max width of the tick label
+	const { xScale, yScale } = useContext( DataContext ) || {};
+	const scale = axis === 'x' ? xScale : yScale;
+	const bandwidth = getScaleBandwidth( scale );
+	const maxWidth = Math.max( bandwidth, MINI_TICK_LABEL_LENGTH );
+
+	// Offset to center the text on the tick position
+	const xOffset = -maxWidth / 2;
+
+	// Map textAnchor to CSS textAlign
+	let textAlign: 'left' | 'right' | 'center' = 'left';
+	if ( textAnchor === 'start' ) {
+		textAlign = 'left';
+	} else if ( textAnchor === 'end' ) {
+		textAlign = 'right';
+	}
+
+	const textStyles: CSSProperties = {
+		// Offset y to convert from baseline to top-left positioning because svg text is positioned by baseline, but html div is positioned by top-left.
+		transform: 'translateY(-100%)',
+		...( textProps as unknown as CSSProperties ),
+		// Convert svg text styles to CSS styles for the div
+		color: fill ?? 'inherit',
+		textAlign,
+		// Ensure text is truncated with ellipsis, remains on one line, and shows the full value in a tooltip on hover.
+		// The surrounding div uses CSS to handle overflow, and the 'title' attribute is set for accessibility.
+		width: maxWidth,
+		overflow: 'hidden',
+		textOverflow: 'ellipsis',
+		whiteSpace: 'nowrap',
+		cursor: 'default',
+		pointerEvents: 'auto',
+	};
+
+	return (
+		<foreignObject
+			x={ x + xOffset }
+			y={ y }
+			width={ maxWidth }
+			overflow="visible"
+			// dy * 2: The div's translateY(-100%) and visx's pre-calculated y offset
+			// create a compound effect that requires doubling dy to match original text position.
+			style={ { transform: `translateY(calc(${ dy ?? '0' } * 2))` } }
+		>
+			<div style={ textStyles } title={ formattedValue || '' }>
+				{ formattedValue }
+			</div>
+		</foreignObject>
+	);
+};
+
+export const createTruncatedTickComponent = ( axis: 'x' | 'y' ) => ( props: TickRendererProps ) => {
+	return <TruncatedTickComponent { ...props } axis={ axis } />;
+};

--- a/projects/js-packages/charts/src/charts/bar-chart/private/truncated-tick-component.tsx
+++ b/projects/js-packages/charts/src/charts/bar-chart/private/truncated-tick-component.tsx
@@ -135,7 +135,6 @@ export const TruncatedTickComponent: FC< TruncatedTickComponentProps > = ( {
 			<div
 				style={ textStyles }
 				title={ formattedValue || undefined }
-				aria-label={ formattedValue || undefined }
 			>
 				{ formattedValue }
 			</div>

--- a/projects/js-packages/charts/src/charts/bar-chart/private/truncated-tick-component.tsx
+++ b/projects/js-packages/charts/src/charts/bar-chart/private/truncated-tick-component.tsx
@@ -19,6 +19,10 @@ interface TruncatedTickComponentProps extends TickRendererProps {
 	axis: 'x' | 'y';
 }
 
+/**
+ * Minimum width in pixels for tick labels when scale bandwidth is very small.
+ * Prevents labels from collapsing to unreadable widths on dense charts.
+ */
 const MINI_TICK_LABEL_LENGTH = 20;
 
 /**
@@ -55,21 +59,44 @@ export const TruncatedTickComponent: FC< TruncatedTickComponentProps > = ( {
 	const bandwidth = getScaleBandwidth( scale );
 	const maxWidth = Math.max( bandwidth, MINI_TICK_LABEL_LENGTH );
 
-	// Offset to center the text on the tick position
-	const xOffset = -maxWidth / 2;
-
-	// Map textAnchor to CSS textAlign
-	let textAlign: 'left' | 'right' | 'center' = 'left';
+	// Map SVG textAnchor to CSS textAlign
+	let textAlign: 'left' | 'right' | 'center' = 'center';
 	if ( textAnchor === 'start' ) {
 		textAlign = 'left';
 	} else if ( textAnchor === 'end' ) {
 		textAlign = 'right';
+	} else if ( textAnchor === 'middle' ) {
+		textAlign = 'center';
 	}
+
+	// Calculate x offset based on text alignment
+	let xOffset = 0;
+	if ( textAlign === 'center' ) {
+		xOffset = -maxWidth / 2;
+	} else if ( textAlign === 'right' ) {
+		xOffset = -maxWidth;
+	}
+
+	// Extract compatible style properties from SVG text props
+	const { fontSize, fontFamily, fontWeight, fontStyle, letterSpacing, opacity } = textProps as {
+		fontSize?: CSSProperties[ 'fontSize' ];
+		fontFamily?: CSSProperties[ 'fontFamily' ];
+		fontWeight?: CSSProperties[ 'fontWeight' ];
+		fontStyle?: CSSProperties[ 'fontStyle' ];
+		letterSpacing?: CSSProperties[ 'letterSpacing' ];
+		opacity?: CSSProperties[ 'opacity' ];
+	};
 
 	const textStyles: CSSProperties = {
 		// Offset y to convert from baseline to top-left positioning because svg text is positioned by baseline, but html div is positioned by top-left.
 		transform: 'translateY(-100%)',
-		...( textProps as unknown as CSSProperties ),
+		// Apply compatible SVG text styles
+		fontSize,
+		fontFamily,
+		fontWeight,
+		fontStyle,
+		letterSpacing,
+		opacity,
 		// Convert svg text styles to CSS styles for the div
 		color: fill ?? 'inherit',
 		textAlign,
@@ -93,7 +120,11 @@ export const TruncatedTickComponent: FC< TruncatedTickComponentProps > = ( {
 			// create a compound effect that requires doubling dy to match original text position.
 			style={ { transform: `translateY(calc(${ dy ?? '0' } * 2))` } }
 		>
-			<div style={ textStyles } title={ formattedValue || '' }>
+			<div
+				style={ textStyles }
+				title={ formattedValue || undefined }
+				aria-label={ formattedValue || undefined }
+			>
 				{ formattedValue }
 			</div>
 		</foreignObject>

--- a/projects/js-packages/charts/src/charts/bar-chart/private/truncated-tick-component.tsx
+++ b/projects/js-packages/charts/src/charts/bar-chart/private/truncated-tick-component.tsx
@@ -1,5 +1,6 @@
 import { DataContext } from '@visx/xychart';
 import { useContext } from 'react';
+import { isSafari } from '../../../utils';
 import type { AxisScale, TickRendererProps } from '@visx/axis';
 import type { FC, CSSProperties } from 'react';
 
@@ -105,9 +106,9 @@ export const TruncatedTickComponent: FC< TruncatedTickComponentProps > = ( {
 		 * we shift the div up by 100% of its height and adjust by twice the SVG dy value (from visx) to approximate original placement.
 		 */
 		transform: `translateY(calc(-100% + ${ dy ?? '0' } * 2))`,
-		// Safari doesn't work well with foreignObject, this is a workaround to position the div correctly.
-		position: 'fixed',
-		// Apply SVG-like font properties from visx text props to the HTML div.
+		// Safari doesn't work well with foreignObject positioning. Use position: fixed as a workaround.
+		...( isSafari() ? { position: 'fixed' as const } : {} ),
+		// Apply compatible SVG text styles
 		fontSize,
 		fontFamily,
 		fontWeight,
@@ -128,17 +129,29 @@ export const TruncatedTickComponent: FC< TruncatedTickComponentProps > = ( {
 	};
 
 	return (
-		<foreignObject x={ x + xOffset } y={ y } width={ maxWidth } overflow="visible">
-			<div
-				style={ textStyles }
-				title={ formattedValue || undefined }
-			>
+		<foreignObject x={ x + xOffset } y={ y } width={ maxWidth } height={ 0 } overflow="visible">
+			<div style={ textStyles } title={ formattedValue || undefined }>
 				{ formattedValue }
 			</div>
 		</foreignObject>
 	);
 };
 
-export const createTruncatedTickComponent = ( axis: 'x' | 'y' ) => ( props: TickRendererProps ) => {
+/**
+ * Factory function to create a truncated tick component for a specific axis.
+ * Returns a component that can be passed to visx's tickComponent prop.
+ *
+ * @param axis - The axis this tick component is for ('x' or 'y')
+ * @return A tick component function compatible with visx's TickRendererProps
+ */
+const createTruncatedTickComponent = ( axis: 'x' | 'y' ) => ( props: TickRendererProps ) => {
 	return <TruncatedTickComponent { ...props } axis={ axis } />;
 };
+
+/**
+ * Pre-created tick components for x and y axes.
+ * These are memoized at module level to prevent component recreation on every render,
+ * which would cause unnecessary DOM operations and potential state loss.
+ */
+export const TruncatedXTickComponent = createTruncatedTickComponent( 'x' );
+export const TruncatedYTickComponent = createTruncatedTickComponent( 'y' );

--- a/projects/js-packages/charts/src/charts/bar-chart/private/truncated-tick-component.tsx
+++ b/projects/js-packages/charts/src/charts/bar-chart/private/truncated-tick-component.tsx
@@ -130,7 +130,7 @@ export const TruncatedTickComponent: FC< TruncatedTickComponentProps > = ( {
 
 	return (
 		<foreignObject x={ x + xOffset } y={ y } width={ maxWidth } height={ 0 } overflow="visible">
-			<div style={ textStyles } title={ formattedValue || undefined }>
+			<div style={ textStyles } title={ formattedValue }>
 				{ formattedValue }
 			</div>
 		</foreignObject>

--- a/projects/js-packages/charts/src/charts/bar-chart/private/truncated-tick-component.tsx
+++ b/projects/js-packages/charts/src/charts/bar-chart/private/truncated-tick-component.tsx
@@ -10,10 +10,8 @@ import type { FC, CSSProperties } from 'react';
  * @return The bandwidth of the scale
  */
 const getScaleBandwidth = < Scale extends AxisScale >( scale?: Scale ) => {
-	const s = scale as AxisScale;
-	return s && 'bandwidth' in s ? s?.bandwidth() ?? 0 : 0;
+	return scale && 'bandwidth' in scale ? scale.bandwidth() ?? 0 : 0;
 };
-
 interface TruncatedTickComponentProps extends TickRendererProps {
 	/** Which axis this tick belongs to */
 	axis: 'x' | 'y';

--- a/projects/js-packages/charts/src/charts/bar-chart/private/truncated-tick-component.tsx
+++ b/projects/js-packages/charts/src/charts/bar-chart/private/truncated-tick-component.tsx
@@ -150,8 +150,8 @@ const createTruncatedTickComponent = ( axis: 'x' | 'y' ) => ( props: TickRendere
 
 /**
  * Pre-created tick components for x and y axes.
- * These are memoized at module level to prevent component recreation on every render,
- * which would cause unnecessary DOM operations and potential state loss.
+ * These functions are created once at module initialization and reused,
+ * avoiding repeated factory calls when configuring axes.
  */
 export const TruncatedXTickComponent = createTruncatedTickComponent( 'x' );
 export const TruncatedYTickComponent = createTruncatedTickComponent( 'y' );

--- a/projects/js-packages/charts/src/charts/bar-chart/private/use-bar-chart-options.ts
+++ b/projects/js-packages/charts/src/charts/bar-chart/private/use-bar-chart-options.ts
@@ -1,6 +1,6 @@
 import { formatNumberCompact } from '@automattic/number-formatters';
 import { useMemo } from 'react';
-import { createTruncatedTickComponent } from './truncated-tick-component';
+import { TruncatedXTickComponent, TruncatedYTickComponent } from './truncated-tick-component';
 import type { EnhancedDataPoint } from '../../../hooks/use-zero-value-display';
 import type { DataPointDate, BaseChartProps, SeriesData } from '../../../types';
 import type { TickFormatter } from '@visx/axis';
@@ -119,18 +119,14 @@ export function useBarChartOptions(
 					orientation: 'bottom' as const,
 					numTicks: 4,
 					tickFormat: xTickFormat,
-					...( xLabelOverflow === 'ellipsis'
-						? { tickComponent: createTruncatedTickComponent( 'x' ) }
-						: {} ),
+					...( xLabelOverflow === 'ellipsis' ? { tickComponent: TruncatedXTickComponent } : {} ),
 					...xAxisOptions,
 				},
 				y: {
 					orientation: 'left' as const,
 					numTicks: 4,
 					tickFormat: yTickFormat,
-					...( yLabelOverflow === 'ellipsis'
-						? { tickComponent: createTruncatedTickComponent( 'y' ) }
-						: {} ),
+					...( yLabelOverflow === 'ellipsis' ? { tickComponent: TruncatedYTickComponent } : {} ),
 					...yAxisOptions,
 				},
 			},

--- a/projects/js-packages/charts/src/charts/bar-chart/private/use-bar-chart-options.ts
+++ b/projects/js-packages/charts/src/charts/bar-chart/private/use-bar-chart-options.ts
@@ -1,5 +1,6 @@
 import { formatNumberCompact } from '@automattic/number-formatters';
 import { useMemo } from 'react';
+import { createTruncatedTickComponent } from './truncated-tick-component';
 import type { EnhancedDataPoint } from '../../../hooks/use-zero-value-display';
 import type { DataPointDate, BaseChartProps, SeriesData } from '../../../types';
 import type { TickFormatter } from '@visx/axis';
@@ -116,12 +117,18 @@ export function useBarChartOptions(
 					numTicks: 4,
 					tickFormat: xTickFormat,
 					...( options.axis?.x || {} ),
+					...( options.axis?.x?.labelOverflow === 'ellipsis'
+						? { tickComponent: createTruncatedTickComponent( 'x' ) }
+						: {} ),
 				},
 				y: {
 					orientation: 'left' as const,
 					numTicks: 4,
 					tickFormat: yTickFormat,
 					...( options.axis?.y || {} ),
+					...( options.axis?.y?.labelOverflow === 'ellipsis'
+						? { tickComponent: createTruncatedTickComponent( 'y' ) }
+						: {} ),
 				},
 			},
 			barGroup: {

--- a/projects/js-packages/charts/src/charts/bar-chart/private/use-bar-chart-options.ts
+++ b/projects/js-packages/charts/src/charts/bar-chart/private/use-bar-chart-options.ts
@@ -103,6 +103,9 @@ export function useBarChartOptions(
 			? options.axis?.y?.tickFormat
 			: options.axis?.x?.tickFormat;
 
+		const { labelOverflow: xLabelOverflow, ...xAxisOptions } = options.axis?.x || {};
+		const { labelOverflow: yLabelOverflow, ...yAxisOptions } = options.axis?.y || {};
+
 		return {
 			gridVisibility,
 			xScale,
@@ -116,19 +119,19 @@ export function useBarChartOptions(
 					orientation: 'bottom' as const,
 					numTicks: 4,
 					tickFormat: xTickFormat,
-					...( options.axis?.x || {} ),
-					...( options.axis?.x?.labelOverflow === 'ellipsis'
+					...( xLabelOverflow === 'ellipsis'
 						? { tickComponent: createTruncatedTickComponent( 'x' ) }
 						: {} ),
+					...xAxisOptions,
 				},
 				y: {
 					orientation: 'left' as const,
 					numTicks: 4,
 					tickFormat: yTickFormat,
-					...( options.axis?.y || {} ),
-					...( options.axis?.y?.labelOverflow === 'ellipsis'
+					...( yLabelOverflow === 'ellipsis'
 						? { tickComponent: createTruncatedTickComponent( 'y' ) }
 						: {} ),
+					...yAxisOptions,
 				},
 			},
 			barGroup: {

--- a/projects/js-packages/charts/src/charts/bar-chart/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/charts/bar-chart/stories/index.stories.tsx
@@ -448,11 +448,10 @@ export const LabelOverflowEllipsis: StoryObj< typeof BarChart > = {
 					<BarChart data={ longLabelData } withTooltips={ true } gridVisibility="x" />
 				</div>
 			</div>
-
 			<div>
-				<h3>With labelOverflow: 'ellipsis' (Labels Truncated)</h3>
+				<h3>With labelOverflow: &apos;ellipsis&apos; (Labels Truncated)</h3>
 				<p style={ { marginBottom: '20px', color: '#666' } }>
-					With <code>labelOverflow: 'ellipsis'</code>, labels are truncated to fit the
+					With <code>labelOverflow: &apos;ellipsis&apos;</code>, labels are truncated to fit the
 					available bandwidth. <strong>Hover over a label to see the full text.</strong>
 				</p>
 				<div style={ { width: '350px', height: '250px', border: '1px solid #e0e0e0' } }>

--- a/projects/js-packages/charts/src/charts/bar-chart/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/charts/bar-chart/stories/index.stories.tsx
@@ -450,9 +450,9 @@ export const LabelOverflowEllipsis: StoryObj< typeof BarChart > = {
 			</div>
 
 			<div>
-				<h3>With labelOverflow: &apos;ellipsis&apos; (Labels Truncated)</h3>
+				<h3>With labelOverflow: 'ellipsis' (Labels Truncated)</h3>
 				<p style={ { marginBottom: '20px', color: '#666' } }>
-					With <code>labelOverflow: &apos;ellipsis&apos;</code>, labels are truncated to fit the
+					With <code>labelOverflow: 'ellipsis'</code>, labels are truncated to fit the
 					available bandwidth. <strong>Hover over a label to see the full text.</strong>
 				</p>
 				<div style={ { width: '350px', height: '250px', border: '1px solid #e0e0e0' } }>

--- a/projects/js-packages/charts/src/charts/bar-chart/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/charts/bar-chart/stories/index.stories.tsx
@@ -419,3 +419,65 @@ export const ZeroValueComparison: StoryObj< typeof BarChart > = {
 		},
 	},
 };
+
+// Data with long categorical labels to demonstrate overlapping issue
+const longLabelData = [
+	{
+		group: 'sales',
+		label: 'Sales by Channel',
+		data: [
+			{ label: 'Organic Search Traffic', value: 12500 },
+			{ label: 'Paid Advertising Campaign', value: 8750 },
+			{ label: 'Social Media Marketing', value: 6250 },
+			{ label: 'Email Newsletter Subscribers', value: 4375 },
+			{ label: 'Direct Website Visitors', value: 3125 },
+			{ label: 'Affiliate Partner Referrals', value: 2500 },
+		],
+	},
+];
+
+export const LabelOverflowEllipsis: StoryObj< typeof BarChart > = {
+	render: () => (
+		<div style={ { display: 'grid', gap: '40px' } }>
+			<div>
+				<h3>Without labelOverflow (Default - Labels Overlap)</h3>
+				<p style={ { marginBottom: '20px', color: '#666' } }>
+					Default behavior: long labels overlap and become unreadable at narrow widths.
+				</p>
+				<div style={ { width: '350px', height: '250px', border: '1px solid #e0e0e0' } }>
+					<BarChart data={ longLabelData } withTooltips={ true } gridVisibility="x" />
+				</div>
+			</div>
+
+			<div>
+				<h3>With labelOverflow: &apos;ellipsis&apos; (Labels Truncated)</h3>
+				<p style={ { marginBottom: '20px', color: '#666' } }>
+					With <code>labelOverflow: &apos;ellipsis&apos;</code>, labels are truncated to fit the
+					available bandwidth. <strong>Hover over a label to see the full text.</strong>
+				</p>
+				<div style={ { width: '350px', height: '250px', border: '1px solid #e0e0e0' } }>
+					<BarChart
+						data={ longLabelData }
+						withTooltips={ true }
+						gridVisibility="x"
+						options={ {
+							axis: {
+								x: {
+									labelOverflow: 'ellipsis',
+								},
+							},
+						} }
+					/>
+				</div>
+			</div>
+		</div>
+	),
+	parameters: {
+		docs: {
+			description: {
+				story:
+					'Demonstrates the `labelOverflow: "ellipsis"` option that truncates long axis labels to fit the available bandwidth. The full label text is shown on hover via a native tooltip. This is useful for narrow widget contexts where space is limited.',
+			},
+		},
+	},
+};

--- a/projects/js-packages/charts/src/charts/bar-chart/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/charts/bar-chart/stories/index.stories.tsx
@@ -476,7 +476,7 @@ export const LabelOverflowEllipsis: StoryObj< typeof BarChart > = {
 		docs: {
 			description: {
 				story:
-					'Demonstrates the `labelOverflow: "ellipsis"` option that truncates long axis labels to fit the available bandwidth. The full label text is shown on hover via a native tooltip. This is useful for narrow widget contexts where space is limited.',
+					"Demonstrates the `labelOverflow: 'ellipsis'` option that truncates long axis labels to fit the available bandwidth. The full label text is shown on hover via a native tooltip. This is useful for narrow widget contexts where space is limited.",
 			},
 		},
 	},

--- a/projects/js-packages/charts/src/charts/bar-chart/test/bar-chart.test.tsx
+++ b/projects/js-packages/charts/src/charts/bar-chart/test/bar-chart.test.tsx
@@ -626,23 +626,6 @@ describe( 'BarChart', () => {
 			expect( label ).toHaveAttribute( 'title', 'Very Long Category Label One' );
 		} );
 
-		test( 'sets aria-label for screen reader accessibility', () => {
-			renderWithTheme( {
-				width: 300,
-				data: longLabelData,
-				options: {
-					axis: {
-						x: {
-							labelOverflow: 'ellipsis',
-						},
-					},
-				},
-			} );
-
-			const label = screen.getByText( /Very Long Category Label One/i );
-			expect( label ).toHaveAttribute( 'aria-label', 'Very Long Category Label One' );
-		} );
-
 		test( 'applies truncation to x-axis for vertical bar charts', () => {
 			renderWithTheme( {
 				width: 300,

--- a/projects/js-packages/charts/src/charts/bar-chart/test/bar-chart.test.tsx
+++ b/projects/js-packages/charts/src/charts/bar-chart/test/bar-chart.test.tsx
@@ -560,6 +560,164 @@ describe( 'BarChart', () => {
 
 	/* eslint-enable testing-library/no-node-access */
 
+	describe( 'Label Overflow Ellipsis', () => {
+		const longLabelData = [
+			{
+				label: 'Series A',
+				data: [
+					{ label: 'Very Long Category Label One', value: 100 },
+					{ label: 'Very Long Category Label Two', value: 200 },
+					{ label: 'Very Long Category Label Three', value: 150 },
+				],
+				options: {},
+			},
+		];
+
+		test( 'renders chart with labelOverflow ellipsis option', () => {
+			renderWithTheme( {
+				data: longLabelData,
+				options: {
+					axis: {
+						x: {
+							labelOverflow: 'ellipsis',
+						},
+					},
+				},
+			} );
+
+			expect( screen.getByRole( 'grid', { name: /bar chart/i } ) ).toBeInTheDocument();
+		} );
+
+		test( 'truncates labels with CSS text-overflow ellipsis', () => {
+			renderWithTheme( {
+				width: 300, // Narrow width to force truncation
+				data: longLabelData,
+				options: {
+					axis: {
+						x: {
+							labelOverflow: 'ellipsis',
+						},
+					},
+				},
+			} );
+
+			// Labels should be rendered with truncation styles
+			const label = screen.getByText( /Very Long Category Label One/i );
+			expect( label ).toHaveStyle( { textOverflow: 'ellipsis' } );
+			expect( label ).toHaveStyle( { overflow: 'hidden' } );
+			expect( label ).toHaveStyle( { whiteSpace: 'nowrap' } );
+		} );
+
+		test( 'sets title attribute for hover tooltips on truncated labels', () => {
+			renderWithTheme( {
+				width: 300,
+				data: longLabelData,
+				options: {
+					axis: {
+						x: {
+							labelOverflow: 'ellipsis',
+						},
+					},
+				},
+			} );
+
+			// Title attribute should show full text on hover
+			const label = screen.getByText( /Very Long Category Label One/i );
+			expect( label ).toHaveAttribute( 'title', 'Very Long Category Label One' );
+		} );
+
+		test( 'sets aria-label for screen reader accessibility', () => {
+			renderWithTheme( {
+				width: 300,
+				data: longLabelData,
+				options: {
+					axis: {
+						x: {
+							labelOverflow: 'ellipsis',
+						},
+					},
+				},
+			} );
+
+			const label = screen.getByText( /Very Long Category Label One/i );
+			expect( label ).toHaveAttribute( 'aria-label', 'Very Long Category Label One' );
+		} );
+
+		test( 'applies truncation to x-axis for vertical bar charts', () => {
+			renderWithTheme( {
+				width: 300,
+				data: longLabelData,
+				orientation: 'vertical',
+				options: {
+					axis: {
+						x: {
+							labelOverflow: 'ellipsis',
+						},
+					},
+				},
+			} );
+
+			// X-axis labels should have truncation
+			const label = screen.getByText( /Very Long Category Label One/i );
+			expect( label ).toHaveStyle( { textOverflow: 'ellipsis' } );
+		} );
+
+		test( 'applies truncation to y-axis for horizontal bar charts', () => {
+			renderWithTheme( {
+				width: 300,
+				data: longLabelData,
+				orientation: 'horizontal',
+				options: {
+					axis: {
+						y: {
+							labelOverflow: 'ellipsis',
+						},
+					},
+				},
+			} );
+
+			// Y-axis labels should have truncation in horizontal mode
+			const label = screen.getByText( /Very Long Category Label One/i );
+			expect( label ).toHaveStyle( { textOverflow: 'ellipsis' } );
+		} );
+
+		test( 'handles very small chart widths gracefully', () => {
+			renderWithTheme( {
+				width: 100, // Very small width
+				data: longLabelData,
+				options: {
+					axis: {
+						x: {
+							labelOverflow: 'ellipsis',
+						},
+					},
+				},
+			} );
+
+			// Chart should still render without errors
+			expect( screen.getByRole( 'grid', { name: /bar chart/i } ) ).toBeInTheDocument();
+
+			// Labels should still be present and have minimum width applied
+			const label = screen.getByText( /Very Long Category Label One/i );
+			expect( label ).toBeInTheDocument();
+		} );
+
+		test( 'does not apply truncation styles when labelOverflow is not set', () => {
+			renderWithTheme( {
+				width: 300,
+				data: longLabelData,
+			} );
+
+			// Without labelOverflow, labels should use default SVG text rendering
+			// which doesn't have CSS text-overflow
+			const labels = screen.getAllByText( /Very Long Category Label/i );
+			labels.forEach( label => {
+				// SVG text elements don't have textOverflow style
+				expect( label.tagName.toLowerCase() ).not.toBe( 'div' );
+			} );
+		} );
+	} );
+
 	describe( 'Interactive Legend', () => {
 		it( 'filters series when interactive legend is enabled and series is toggled', async () => {
 			const user = userEvent.setup();

--- a/projects/js-packages/charts/src/types.ts
+++ b/projects/js-packages/charts/src/types.ts
@@ -310,7 +310,10 @@ declare type AxisOptions = {
 	/**
 	 * Controls tick label overflow (bar charts only):
 	 *
-	 * - 'ellipsis': Truncate with ellipsis and fit to available space.
+	 * - 'ellipsis': Truncate with ellipsis and fit to available space. Labels show full text
+	 * on hover via native tooltip. Note: A minimum width (20px) is enforced for readability.
+	 * On very dense charts (bandwidth < 20px), labels may overlap. To mitigate, use `numTicks`
+	 * to reduce labels or `tickFormat` to abbreviate text.
 	 * - undefined: No truncation; labels may overlap.
 	 *
 	 * Default: No truncation; labels may overlap.

--- a/projects/js-packages/charts/src/types.ts
+++ b/projects/js-packages/charts/src/types.ts
@@ -312,7 +312,7 @@ declare type AxisOptions = {
 	 *
 	 * - 'ellipsis': Truncate with ellipsis and fit to available space. Labels show full text
 	 * on hover via native tooltip. Note: A minimum width (20px) is enforced for readability.
-	 * On very dense charts (bandwidth < 20px), labels may overlap. To mitigate, use `numTicks`
+	 * On very dense charts (bandwidth < 20px), adjacent labels may overlap. To mitigate, use `numTicks`
 	 * to reduce labels or `tickFormat` to abbreviate text.
 	 * - undefined: No truncation; labels may overlap.
 	 *

--- a/projects/js-packages/charts/src/types.ts
+++ b/projects/js-packages/charts/src/types.ts
@@ -307,6 +307,15 @@ declare type AxisOptions = {
 	 * For more control over rendering or to add event handlers to datum, pass a function as children.
 	 */
 	children?: ( renderProps: AxisRendererProps< AxisScale > ) => ReactNode;
+	/**
+	 * Controls tick label overflow (bar charts only):
+	 *
+	 * - 'ellipsis': Truncate with ellipsis and fit to available space.
+	 * - undefined: No truncation; labels may overlap.
+	 *
+	 * Default: No truncation; labels may overlap.
+	 */
+	labelOverflow?: 'ellipsis';
 };
 
 export type ScaleOptions = {


### PR DESCRIPTION
Fixes WOOA7S-973

## Proposed changes:
* Add `labelOverflow: 'ellipsis'` option to `AxisOptions` type for bar charts
* Create `TruncatedTickComponent` that uses SVG `foreignObject` to render HTML-based labels with CSS text-overflow ellipsis
* Labels are automatically truncated to fit the available bandwidth from the scale
* Full label text is shown on hover via native `title` attribute tooltip
* Add Storybook story demonstrating the feature with before/after comparison

### Why a custom `TruncatedTickComponent`?

SVG `<text>` elements (used by visx for axis labels) don't support CSS `text-overflow: ellipsis`. There's no pure CSS solution for truncating SVG text with ellipsis.

**Approaches considered:**

1. **`tickLabelProps` with `scaleToFit`**: visx's `<Text>` component supports `scaleToFit: 'shrink-only'` which scales text to fit a width. However,  it could cause labels to be too small to be readable.

2. **Custom `tickComponent`**: This approach gives us access to `DataContext` from `@visx/xychart`, which provides `xScale` and `yScale`. From the scale, we can call `bandwidth()` to get the exact pixel width available for each category label.

**Solution:**
We use `tickComponent` with SVG `<foreignObject>` to embed an HTML `<div>` inside SVG. This allows us to use CSS `text-overflow: ellipsis` for proper text truncation, while accessing the scale's bandwidth for dynamic width calculation.

```tsx
// Usage
<BarChart
  data={data}
  options={{
    axis: {
      x: { labelOverflow: 'ellipsis' }
    }
  }}
/>
```

### Screenshots:

<img width="1372" height="1218" alt="Screenshot 2026-01-19 at 15 20 20" src="https://github.com/user-attachments/assets/62436783-1107-415b-a620-842ce635f479" />


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
N/A - This is a charts library enhancement.

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:

1. Run Storybook: `pnpm --filter @automattic/charts run storybook`
2. Navigate to **JS Packages / Charts Library / Charts / Bar Chart / LabelOverflowEllipsis**
3. Verify:
   - The first chart shows overlapping labels (default behavior)
   - The second chart shows truncated labels with ellipsis
   - Hovering over truncated labels shows the full text in a tooltip
   - Test in safari

