### PR TITLE
Renovate: separate wp-build

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -106,6 +106,17 @@
 			],
 		},
 
+		// Separate Build from 'monorepo:wordpress' as build is still heavily developed, to manually test changes.
+		{
+			groupName: '@wordpress/build',
+			matchPackageNames: [ '@wordpress/build' ],
+			separateMajorMinor: false,
+			// Teams using Build in their projects
+			additionalReviewers: [
+				'team:zap', // Forms
+			],
+		},
+
 		// 🤷
 		{
 			groupName: 'Instant Search Dependency Updates',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

To avoid issues where changes in Build affect build-pipeline unnoticed (e.g. https://github.com/Automattic/jetpack/pull/46652), let's review these changes separately for now. Build is still under heavy development and not used much in Jetpack (yet).

It'll appear on its own line at https://github.com/Automattic/jetpack/issues/23363 similar to DataViews.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Separate wp-build to its own update from main wordpress-monorepo update.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Just if it makes sense?

