### PR TITLE
jetpack-mu-wpcom: Disable contrast checker (take 2)

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/code-block-disable-contrast-checker-2
+++ b/projects/packages/jetpack-mu-wpcom/changelog/code-block-disable-contrast-checker-2
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fixes a previously documented change.
+
+

--- a/projects/packages/jetpack-mu-wpcom/changelog/code-block-disable-contrast-checker-2
+++ b/projects/packages/jetpack-mu-wpcom/changelog/code-block-disable-contrast-checker-2
@@ -1,5 +1,5 @@
 Significance: patch
 Type: fixed
-Comment: Fixes a previously documented change.
+Comment: Correctly disable the contrast checker warning for the enhanced Code block using the proper property name.
 
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/block-definition/block-definition.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/block-definition/block-definition.tsx
@@ -162,7 +162,7 @@ function filterBlockRegistration( settings: any ) {
 	if ( ! settings.supports.color ) {
 		settings.supports.color = {};
 	}
-	settings.supports.color.contrastChecker = false;
+	settings.supports.color.enableContrastChecker = false;
 
 	return settings;
 }


### PR DESCRIPTION

## Proposed changes:

#46614 attempted to disable the contrast checker, but used the [incorrect block supports property name.](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-supports/#color).

One issue with the contrast checker and this block is that it works irregularly and intermittently. This hid the problem in #46614.

This PR corrects the property name.

Fixes [ARC-1371](https://linear.app/a8c/issue/ARC-1371)

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?



## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
- Ensure the contrast checker does not display in the block editor for the code block.