### PR TITLE
Forms: use generated asset dependecy file for dashboard

### DIFF
--- a/projects/packages/forms/changelog/update-forms-dash-use-generated-deps
+++ b/projects/packages/forms/changelog/update-forms-dash-use-generated-deps
@@ -1,4 +1,4 @@
 Significance: minor
 Type: changed
 
-Use generated asset dependecy file for dashboard.
+Use the generated asset dependency file for the dashboard.

--- a/projects/packages/forms/changelog/update-forms-dash-use-generated-deps
+++ b/projects/packages/forms/changelog/update-forms-dash-use-generated-deps
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Use generated asset dependecy file for dashboard.

--- a/projects/packages/forms/src/dashboard/class-dashboard.php
+++ b/projects/packages/forms/src/dashboard/class-dashboard.php
@@ -96,10 +96,9 @@ class Dashboard {
 			'../../dist/dashboard/jetpack-forms-dashboard.js',
 			__FILE__,
 			array(
-				'in_footer'    => true,
-				'textdomain'   => 'jetpack-forms',
-				'enqueue'      => true,
-				'dependencies' => array( 'wp-api-fetch', 'wp-data', 'wp-core-data', 'wp-dom-ready', 'wp-dom' ),
+				'in_footer'  => true,
+				'textdomain' => 'jetpack-forms',
+				'enqueue'    => true,
 			)
 		);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Simplify dashboard JS loading; we were defining depencies that were loaded anyway, so this just removes manual deps.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to `/wp-admin/admin.php?page=jetpack-forms-admin#/responses` and confirm it loads normally
* You can see the same deps in generated PHP file `projects/packages/forms/dist/dashboard/jetpack-forms-dashboard.asset.php` and see how the [asset registration file loads](https://github.com/Automattic/jetpack/blob/b9da39518401441e1525699756ae06e75298ea0c/projects/packages/assets/src/class-assets.php#L368-L370) those deps and merges with manually defined deps.
