### PR TITLE
Forms Dashboard: Fix race conditions in spam/not-spam actions

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-async-actions-flow
+++ b/projects/packages/forms/changelog/fix-forms-async-actions-flow
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms Dashboard: Fix race conditions in spam/not-spam actions when triggered in quick succession.

--- a/projects/packages/forms/src/dashboard/inbox/stage/actions.tsx
+++ b/projects/packages/forms/src/dashboard/inbox/stage/actions.tsx
@@ -315,7 +315,6 @@ export const markAsSpamAction: Action = {
 	isEligible: item => item.status !== 'spam',
 	supportsBulk: true,
 	async callback( items, { registry }, { isUndo = false } = {} ) {
-		let undoTriggered = false;
 		jetpackAnalytics.tracks.recordEvent( 'jetpack_forms_inbox_action_click', {
 			action: 'mark-as-spam',
 			multiple: items.length > 1,
@@ -367,28 +366,12 @@ export const markAsSpamAction: Action = {
 
 			// If there is at least one successful update, invalidate the cache and navigate if needed
 			if ( itemsUpdated.length ) {
-				waitForRecordsPromise = new Promise( resolve => {
-					setTimeout( () => {
-						if ( undoTriggered ) {
-							resolve();
-							return;
-						}
-
-						let status = 'inbox';
-						if ( items[ 0 ]?.status === 'trash' ) {
-							status = 'trash';
-						}
-
-						invalidateCacheAndNavigate( registry, getCurrentQuery(), queryParams, status );
-
-						if ( undoTriggered ) {
-							resolve();
-							return;
-						}
-
-						waitForEntityRecordsResolution( registry, getCurrentQuery() ).finally( resolve );
-					}, 0 );
-				} );
+				let status = 'inbox';
+				if ( items[ 0 ]?.status === 'trash' ) {
+					status = 'trash';
+				}
+				invalidateCacheAndNavigate( registry, getCurrentQuery(), queryParams, status );
+				waitForRecordsPromise = waitForEntityRecordsResolution( registry, getCurrentQuery() );
 				// Store promise so undo can wait for it
 				pendingRefetches.set( actionId, waitForRecordsPromise );
 			}
@@ -417,8 +400,6 @@ export const markAsSpamAction: Action = {
 							{
 								label: __( 'Undo', 'jetpack-forms' ),
 								onClick: async () => {
-									undoTriggered = true;
-
 									// Wait for the original action's refetch to complete before undoing
 									const originalRefetch = pendingRefetches.get( actionId );
 									if ( originalRefetch ) {
@@ -448,7 +429,7 @@ export const markAsSpamAction: Action = {
 
 			// Make the REST request which performs the `contact_form_akismet` `spam` action.
 			if ( itemsUpdated.length ) {
-				registry.dispatch( dashboardStore ).doBulkAction(
+				await registry.dispatch( dashboardStore ).doBulkAction(
 					itemsUpdated.map( item => item.id.toString() ),
 					BULK_ACTIONS.markAsSpam
 				);
@@ -473,7 +454,6 @@ export const markAsNotSpamAction: Action = {
 	isEligible: item => item.status === 'spam',
 	supportsBulk: true,
 	async callback( items, { registry }, { isUndo = false } = {} ) {
-		let undoTriggered = false;
 		jetpackAnalytics.tracks.recordEvent( 'jetpack_forms_inbox_action_click', {
 			action: 'mark-as-not-spam',
 			multiple: items.length > 1,
@@ -525,23 +505,8 @@ export const markAsNotSpamAction: Action = {
 
 			// If there is at least one successful update, invalidate the cache and navigate if needed
 			if ( itemsUpdated.length ) {
-				waitForRecordsPromise = new Promise( resolve => {
-					setTimeout( () => {
-						if ( undoTriggered ) {
-							resolve();
-							return;
-						}
-
-						invalidateCacheAndNavigate( registry, getCurrentQuery(), queryParams, 'spam' );
-
-						if ( undoTriggered ) {
-							resolve();
-							return;
-						}
-
-						waitForEntityRecordsResolution( registry, getCurrentQuery() ).finally( resolve );
-					}, 0 );
-				} );
+				invalidateCacheAndNavigate( registry, getCurrentQuery(), queryParams, 'spam' );
+				waitForRecordsPromise = waitForEntityRecordsResolution( registry, getCurrentQuery() );
 				// Store promise so undo can wait for it
 				pendingRefetches.set( actionId, waitForRecordsPromise );
 			}
@@ -570,8 +535,6 @@ export const markAsNotSpamAction: Action = {
 							{
 								label: __( 'Undo', 'jetpack-forms' ),
 								onClick: async () => {
-									undoTriggered = true;
-
 									// Wait for the original action's refetch to complete before undoing
 									const originalRefetch = pendingRefetches.get( actionId );
 									if ( originalRefetch ) {
@@ -598,7 +561,7 @@ export const markAsNotSpamAction: Action = {
 			}
 			// Make the REST request which performs the `contact_form_akismet` `ham` action.
 			if ( itemsUpdated.length ) {
-				registry.dispatch( dashboardStore ).doBulkAction(
+				await registry.dispatch( dashboardStore ).doBulkAction(
 					itemsUpdated.map( item => item.id.toString() ),
 					BULK_ACTIONS.markAsNotSpam
 				);

--- a/projects/packages/forms/src/dashboard/inbox/stage/types.tsx
+++ b/projects/packages/forms/src/dashboard/inbox/stage/types.tsx
@@ -70,7 +70,7 @@ export type DispatchActions = {
 		count: number,
 		queryParams?: QueryParams
 	) => void;
-	doBulkAction: ( ids: string[], action: string ) => void;
+	doBulkAction: ( ids: string[], action: string ) => Promise< void >;
 	invalidateFilters: () => void;
 	invalidateCounts: () => void;
 	markRecordsAsInvalid: ( ids: number[] ) => void;


### PR DESCRIPTION
## Proposed changes:

* Fix race conditions in Forms Dashboard spam/not-spam actions when triggered in quick succession
* Remove `setTimeout(..., 0)` wrapper around cache invalidation that was causing deferred execution
* Await `doBulkAction()` calls for Akismet spam/ham reporting instead of fire-and-forget
* Remove now-unnecessary `undoTriggered` variable that was only used to short-circuit the setTimeout callback

### Changes Made

  **markAsSpamAction**

  1. Removed let undoTriggered = false; variable declaration
  2. Replaced the setTimeout(..., 0) wrapper with synchronous execution:
    - Cache invalidation and navigation now happen immediately
    - waitForRecordsPromise is now assigned directly from waitForEntityRecordsResolution()
  3. Removed undoTriggered = true; from the undo onClick handler
  4. Added await before the doBulkAction() call for Akismet spam reporting

  **markAsNotSpamAction**

  1. Removed let undoTriggered = false; variable declaration
  2. Replaced the setTimeout(..., 0) wrapper with synchronous execution:
    - Cache invalidation and navigation now happen immediately
    - waitForRecordsPromise is now assigned directly from waitForEntityRecordsResolution()
  3. Removed undoTriggered = true; from the undo onClick handler
  4. Added await before the doBulkAction() call for Akismet ham reporting

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

N/A

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

1. Go to Jetpack Forms Dashboard (wp-admin → Jetpack → Forms)
2. View an unread form response (should auto-mark as read)
3. Click "Mark as unread" 
4. Immediately click "Mark as spam"
5. Verify the actions execute in the correct order without race conditions
6. Test the undo functionality still works correctly
7. Verify UI responsiveness is not degraded
