### PR TITLE
CRM customer email identification

### DIFF
--- a/projects/plugins/crm/changelog/fix-woosync-contact-identification-by-wp-user
+++ b/projects/plugins/crm/changelog/fix-woosync-contact-identification-by-wp-user
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-WooSync: Fix CRM contact identification on orders where customer used a different billing email. Now prioritizes the WordPress customer account over billing email, with billing email as fallback for guest orders.
+WooSync: Fix CRM contact identification on orders where customer used a different billing email.

--- a/projects/plugins/crm/changelog/fix-woosync-contact-identification-by-wp-user
+++ b/projects/plugins/crm/changelog/fix-woosync-contact-identification-by-wp-user
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+WooSync: Fix CRM contact identification on orders where customer used a different email address while logged in. Now correctly falls back to WordPress user ID lookup.

--- a/projects/plugins/crm/changelog/fix-woosync-contact-identification-by-wp-user
+++ b/projects/plugins/crm/changelog/fix-woosync-contact-identification-by-wp-user
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-WooSync: Fix CRM contact identification on orders where customer used a different email address while logged in. Now correctly falls back to WordPress user ID lookup.
+WooSync: Fix CRM contact identification on orders where customer used a different billing email. Now prioritizes the WordPress customer account over billing email, with billing email as fallback for guest orders.

--- a/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync-woo-admin-integration.php
+++ b/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync-woo-admin-integration.php
@@ -261,31 +261,42 @@ class Woo_Sync_Woo_Admin_Integration {
 	 * Get CRM contact ID from WooCommerce order.
 	 *
 	 * This method attempts to identify the CRM contact associated with a WooCommerce order.
-	 * It first checks by billing email, and if not found, it falls back to checking
-	 * if the order belongs to a WordPress user who is linked to a CRM contact.
 	 *
-	 * This addresses the issue where a logged-in customer uses a different email
-	 * for their order than their main CRM contact email.
+	 * Priority order:
+	 * 1. If order has a customer (WordPress user), use that to find CRM contact
+	 * 2. If order is from a guest (no WordPress user), use billing email
+	 *
+	 * This ensures that logged-in customers are always identified by their account,
+	 * even if they use a different billing email on the order.
 	 *
 	 * @param \WC_Order $order WooCommerce order object.
 	 * @return int CRM contact ID, or 0 if not found.
 	 */
 	public function get_contact_id_from_order( $order ) {
-		// First, try to find contact by billing email.
-		$email = $order->get_billing_email();
-		if ( ! empty( $email ) ) {
-			$contact_id = zeroBS_getCustomerIDWithEmail( $email );
+		// First, check if the order has a customer (WordPress user).
+		// If so, use their account to find the CRM contact.
+		$customer_id = $order->get_customer_id();
+		if ( $customer_id > 0 ) {
+			// Try to find CRM contact linked to this WordPress user.
+			$contact_id = zeroBS_getCustomerIDFromWPID( $customer_id );
 			if ( $contact_id > 0 ) {
 				return $contact_id;
 			}
+
+			// If no CRM contact is linked to WP user, try the WP user's email.
+			$wp_user = get_user_by( 'id', $customer_id );
+			if ( $wp_user && ! empty( $wp_user->user_email ) ) {
+				$contact_id = zeroBS_getCustomerIDWithEmail( $wp_user->user_email );
+				if ( $contact_id > 0 ) {
+					return $contact_id;
+				}
+			}
 		}
 
-		// Fallback: Check if the order has a customer ID (WordPress user ID).
-		// This handles cases where the customer used a different email for their order
-		// but was logged in to their WordPress account.
-		$customer_id = $order->get_customer_id();
-		if ( $customer_id > 0 ) {
-			$contact_id = zeroBS_getCustomerIDFromWPID( $customer_id );
+		// Fallback for guest orders: use billing email.
+		$billing_email = $order->get_billing_email();
+		if ( ! empty( $billing_email ) ) {
+			$contact_id = zeroBS_getCustomerIDWithEmail( $billing_email );
 			if ( $contact_id > 0 ) {
 				return $contact_id;
 			}

--- a/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync-woo-admin-integration.php
+++ b/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync-woo-admin-integration.php
@@ -113,13 +113,8 @@ class Woo_Sync_Woo_Admin_Integration {
 					$order = wc_get_order( $order_or_post_id );
 				}
 
-				$email = $order->get_billing_email();
-
-				if ( empty( $email ) ) {
-					return;
-				}
-
-				$contact_id = zeroBS_getCustomerIDWithEmail( $email );
+				// Use the helper method to find contact by email or WordPress user ID.
+				$contact_id = $this->get_contact_id_from_order( $order );
 
 				if ( $contact_id > 0 ) {
 					$url   = jpcrm_esc_link( 'view', $contact_id, 'zerobs_customer' );
@@ -185,10 +180,10 @@ class Woo_Sync_Woo_Admin_Integration {
 		$this->render_metabox_styles();
 
 		// the customer information pane
-		$email = $order->get_billing_email();
+		$billing_email = $order->get_billing_email();
 
 		// No billing email found, so render message and return.
-		if ( empty( $email ) ) {
+		if ( empty( $billing_email ) ) {
 			?>
 			<div class="jpcrm-contact-metabox">
 				<div class="no-crm-contact">
@@ -201,11 +196,23 @@ class Woo_Sync_Woo_Admin_Integration {
 			return;
 		}
 
-		// retrieve contact id
-		$contact_id = zeroBS_getCustomerIDWithEmail( $email );
+		// Use the helper method to find contact by email or WordPress user ID.
+		$contact_id = $this->get_contact_id_from_order( $order );
 
-		// Can't find a contact under that email, so return.
+		// Can't find a contact, show "Add Contact" button.
 		if ( $contact_id <= 0 ) {
+			?>
+			<div class="jpcrm-contact-metabox">
+				<div class="no-crm-contact">
+					<p style="margin-top:20px;">
+					<?php esc_html_e( 'No CRM contact found for this order.', 'zero-bs-crm' ); ?>
+					</p>
+					<div class="panel-edit-contact">
+						<a class="view-contact-link button button-secondary" href="<?php echo esc_url( admin_url( 'admin.php?page=' . $zbs->modules->woosync->slugs['hub'] ) ); ?>"><?php echo esc_html__( 'Add Contact', 'zero-bs-crm' ); ?></a>
+					</div>
+				</div>
+			</div>
+			<?php
 			return;
 		}
 
@@ -213,6 +220,9 @@ class Woo_Sync_Woo_Admin_Integration {
 		$crm_contact               = $zbs->DAL->contacts->getContact( $contact_id );
 		$contact_name              = $zbs->DAL->contacts->getContactFullNameEtc( $contact_id, $crm_contact, array( false, false ) );
 		$contact_transaction_count = $zbs->DAL->specific_obj_type_count_for_assignee( $contact_id, ZBS_TYPE_TRANSACTION, ZBS_TYPE_CONTACT ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+
+		// Use contact email from CRM if available, otherwise fallback to billing email.
+		$display_email = ! empty( $crm_contact['email'] ) ? $crm_contact['email'] : $billing_email;
 
 		// check avatar mode
 		$avatar      = '';
@@ -236,7 +246,7 @@ class Woo_Sync_Woo_Admin_Integration {
 			</div>
 
 			<div class="panel-left-info cust-email">
-				<i class="ui icon envelope outline"></i> <span class="panel-customer-email"><?php echo esc_html( $email ); ?></span>
+				<i class="ui icon envelope outline"></i> <span class="panel-customer-email"><?php echo esc_html( $display_email ); ?></span>
 			</div>
 
 			<div class="panel-edit-contact">
@@ -245,6 +255,43 @@ class Woo_Sync_Woo_Admin_Integration {
 		</div>
 		<?php
 		// phpcs:enable WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+	}
+
+	/**
+	 * Get CRM contact ID from WooCommerce order.
+	 *
+	 * This method attempts to identify the CRM contact associated with a WooCommerce order.
+	 * It first checks by billing email, and if not found, it falls back to checking
+	 * if the order belongs to a WordPress user who is linked to a CRM contact.
+	 *
+	 * This addresses the issue where a logged-in customer uses a different email
+	 * for their order than their main CRM contact email.
+	 *
+	 * @param \WC_Order $order WooCommerce order object.
+	 * @return int CRM contact ID, or 0 if not found.
+	 */
+	public function get_contact_id_from_order( $order ) {
+		// First, try to find contact by billing email.
+		$email = $order->get_billing_email();
+		if ( ! empty( $email ) ) {
+			$contact_id = zeroBS_getCustomerIDWithEmail( $email );
+			if ( $contact_id > 0 ) {
+				return $contact_id;
+			}
+		}
+
+		// Fallback: Check if the order has a customer ID (WordPress user ID).
+		// This handles cases where the customer used a different email for their order
+		// but was logged in to their WordPress account.
+		$customer_id = $order->get_customer_id();
+		if ( $customer_id > 0 ) {
+			$contact_id = zeroBS_getCustomerIDFromWPID( $customer_id );
+			if ( $contact_id > 0 ) {
+				return $contact_id;
+			}
+		}
+
+		return 0;
 	}
 
 	/**


### PR DESCRIPTION
Fixes JETCRM-62

## Proposed changes:

Fix: WooSync contact identification for orders with alternative emails

To identify a lead
*  Always use the logged-in customer email as opposed to the billing email.
* If customer is a guest, use the billing email

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
None

## Does this pull request change what data or activity we track or use?
None

## Testing instructions:

1.  Ensure Jetpack CRM and WooCommerce are active.
2.  Create a WordPress user and a corresponding Jetpack CRM contact.
3.  Log in as the WordPress user on the frontend of your site.
4.  Place a WooCommerce order, but in the billing details, use a *different* email address than the one associated with the logged-in WordPress user.
5.  Go to the WordPress admin and navigate to the newly created order (WooCommerce > Orders > [Your Order]).
6.  **Verify**: The "Jetpack CRM Contact" metabox on the order edit page should now correctly display the existing CRM contact associated with the logged-in WordPress user and show "View Contact". Previously, it would show no contact or no "Add Contact" option.
7.  **Optional (to test "Add Contact" button)**: Log out, place an order as a guest using a completely new email address that does not correspond to any existing CRM contact or WordPress user.
8.  **Verify**: On this new guest order, the "Jetpack CRM Contact" metabox should display "No CRM contact found for this order." and offer an "Add Contact" button.

