### PR TITLE
VideoPress: Improve upload error handling and messages

### DIFF
--- a/projects/packages/videopress/changelog/vidp-204-clarify-media-library-errors-when-videopress-blocks-uploads
+++ b/projects/packages/videopress/changelog/vidp-204-clarify-media-library-errors-when-videopress-blocks-uploads
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Only retry upload on transient HTTP errors to show plan limit errors immediately.
+Retry uploads only on transient HTTP errors to show plan limit errors immediately.

--- a/projects/packages/videopress/changelog/vidp-204-clarify-media-library-errors-when-videopress-blocks-uploads
+++ b/projects/packages/videopress/changelog/vidp-204-clarify-media-library-errors-when-videopress-blocks-uploads
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Only retry upload on transient HTTP errors to show plan limit errors immediately.

--- a/projects/packages/videopress/changelog/vidp-204-clarify-media-library-errors-when-videopress-blocks-uploads
+++ b/projects/packages/videopress/changelog/vidp-204-clarify-media-library-errors-when-videopress-blocks-uploads
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Retry uploads only on transient HTTP errors to show plan limit errors immediately.
+Clarify error messages when video uploads fail due to plan limitations.

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/videopress-uploader/uploader-error.js
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/videopress-uploader/uploader-error.js
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
+import { getRequiredPlan, getSiteFragment } from '@automattic/jetpack-shared-extension-utils';
 import { Button, ExternalLink } from '@wordpress/components';
+import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { PlaceholderWrapper } from '../../edit';
 
@@ -10,24 +12,38 @@ const getErrorMessage = uploadErrorData => {
 		return '';
 	}
 
-	let errorMessage =
+	const errorMessage =
 		uploadErrorData?.data?.message ||
 		__( 'Failed to upload your video. Please try again.', 'jetpack-videopress-pkg' );
 
-	// Let's give this error a better message.
+	// Check if site needs upgrade for VideoPress (same check as paid block banner)
+	const needsUpgrade = !! getRequiredPlan( 'videopress/video' );
+
+	// "Invalid Mime" on sites without VideoPress = plan doesn't include video uploads
+	if ( errorMessage === 'Invalid Mime' && needsUpgrade ) {
+		return createInterpolateElement(
+			__(
+				'Your plan does not include video uploads. <upgradeLink>Upgrade to upload videos</upgradeLink>.',
+				'jetpack-videopress-pkg'
+			),
+			{
+				upgradeLink: <ExternalLink href={ `https://wordpress.com/plans/${ getSiteFragment() }` } />,
+			}
+		);
+	}
+
+	// "Invalid Mime" on sites WITH VideoPress = actual format issue
 	if ( errorMessage === 'Invalid Mime' ) {
-		errorMessage = (
-			<>
-				{ __( 'The format of the video you uploaded is not supported.', 'jetpack-videopress-pkg' ) }
-				&nbsp;
-				<ExternalLink
-					href="https://wordpress.com/support/videopress/recommended-video-settings/"
-					target="_blank"
-					rel="noreferrer"
-				>
-					{ __( 'Check the recommended video settings.', 'jetpack-videopress-pkg' ) }
-				</ExternalLink>
-			</>
+		return createInterpolateElement(
+			__(
+				'The format of the video you uploaded is not supported. <settingsLink>Check the recommended video settings.</settingsLink>',
+				'jetpack-videopress-pkg'
+			),
+			{
+				settingsLink: (
+					<ExternalLink href="https://wordpress.com/support/videopress/recommended-video-settings/" />
+				),
+			}
 		);
 	}
 

--- a/projects/packages/videopress/src/client/lib/resumable-file-uploader/index.ts
+++ b/projects/packages/videopress/src/client/lib/resumable-file-uploader/index.ts
@@ -13,6 +13,13 @@ import type { MediaTokenProps } from '../../lib/get-media-token/types';
 
 const debug = debugFactory( 'videopress:resumable-file-uploader' );
 
+/**
+ * HTTP status codes that are safe to retry.
+ *
+ * @see https://github.com/tfredrich/RestApiTutorial.com/blob/master/content/advanced/responses/retries.md
+ */
+const RETRIABLE_STATUS_CODES = [ 408, 429, 500, 502, 503, 504 ];
+
 const jwtsForKeys = {};
 
 declare module 'tus-js-client' {
@@ -69,14 +76,14 @@ const resumableFileUploader = ( {
 		retryDelays: [ 0, 1000, 3000, 5000, 10000 ],
 		onShouldRetry: function ( err: tus.DetailedError ) {
 			const status = err.originalResponse ? err.originalResponse.getStatus() : 0;
-			// Do not retry if the status is a 400.
-			if ( status === 400 ) {
-				debug( 'cleanup retry due to 400 error' );
+
+			// Only retry on transient errors (timeouts, rate limits, server errors).
+			if ( status && ! RETRIABLE_STATUS_CODES.includes( status ) ) {
+				debug( 'not retrying due to %d error', status );
 				localStorage.removeItem( upload._urlStorageKey );
 				return false;
 			}
 
-			// For any other status code, we retry.
 			return true;
 		},
 		onBeforeRequest: async function ( req: VPUploadHttpRequest ) {


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/VIDP-204

## Proposed changes:

### Retry logic improvements
* Changed the TUS upload retry logic to only retry on transient HTTP errors (408, 429, 500, 502, 503, 504)
* Previously, the uploader would retry on all non-400 errors, causing 403 errors (like plan quota limits) to be retried 5 times before showing the error message

### Clearer error messages for plan limitations
* On Simple sites without a VideoPress-supporting plan, "Invalid Mime" errors now show a clear upgrade message with a link to the plans page
* Previously, the error incorrectly suggested the video format was unsupported when the real issue was plan limitations
* Sites with VideoPress that encounter actual format issues still see the appropriate "format not supported" message

Before | After
--- | ---
<img width="770" height="334" alt="Screenshot 2026-02-03 at 4 40 14 PM" src="https://github.com/user-attachments/assets/7d46cf35-3c89-4204-8857-86a6ef95eb2f" /> | <img width="769" height="335" alt="Screenshot 2026-02-03 at 4 39 05 PM" src="https://github.com/user-attachments/assets/00fc82bd-22d2-4921-93e5-d507bf338c76" />


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

### Retry logic
* Set up a site with a free VideoPress plan (or one that has hit its quota)
* Add a VideoPress block in the block editor
* Attempt to upload a video
* **Before:** The upload would retry 5 times (with delays of 0, 1, 3, 5, 10 seconds) before showing the error
* **After:** The error message should appear immediately without retries

### Upgrade CTA (Simple sites)
* On a Simple site without a VideoPress-supporting plan (e.g., free or Personal plan)
* Add a VideoPress block and attempt to upload a video
* **Before:** Generic "Invalid Mime" error suggesting format issue
* **After:** "Your plan does not include video uploads. Upgrade to upload videos." with link to plans page