### PR TITLE
Forms: add form post type admin redirect

### DIFF
--- a/projects/packages/forms/changelog/add-forms-admin-redirect
+++ b/projects/packages/forms/changelog/add-forms-admin-redirect
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add redirect for jetpack_forms post type to the new dashboard. 

--- a/projects/packages/forms/changelog/add-forms-admin-redirect
+++ b/projects/packages/forms/changelog/add-forms-admin-redirect
@@ -1,4 +1,4 @@
 Significance: minor
 Type: added
 
-Add redirect for jetpack_forms post type to the new dashboard. 
+Add redirect for jetpack_forms post type to the new dashboard.

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -10,6 +10,7 @@ namespace Automattic\Jetpack\Forms\ContactForm;
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Constants;
 use Automattic\Jetpack\Extensions\Contact_Form\Contact_Form_Block;
+use Automattic\Jetpack\Forms\Dashboard\Dashboard;
 use Automattic\Jetpack\Forms\Editor\Form_Editor;
 use Automattic\Jetpack\Forms\Jetpack_Forms;
 use Automattic\Jetpack\Forms\Service\Form_Webhooks;
@@ -3765,17 +3766,15 @@ class Contact_Form_Plugin {
 
 		$screen = get_current_screen();
 
-		// Check if this is the edit-feedback screen
-		if ( ! $screen || $screen->id !== 'edit-feedback' ) {
+		if ( ! $screen || ! isset( $screen->id ) ) {
 			return;
 		}
 
-		// Perform the redirect to the Jetpack Forms admin page
-		$redirect_url = admin_url( 'admin.php?page=jetpack-forms-admin' );
-
-		// Use wp_safe_redirect to ensure we're redirecting to a safe location
-		wp_safe_redirect( $redirect_url );
-		exit;
+		$redirect = Dashboard::get_admin_url( $screen->id );
+		if ( $redirect ) {
+			wp_safe_redirect( $redirect );
+			exit;
+		}
 	}
 
 	/**

--- a/projects/packages/forms/src/dashboard/class-dashboard.php
+++ b/projects/packages/forms/src/dashboard/class-dashboard.php
@@ -315,4 +315,20 @@ class Dashboard {
 		*/
 		return apply_filters( 'jetpack_forms_notes_enable', false );
 	}
+
+	/**
+	 * Get admin URL for given screen ID.
+	 *
+	 * @param string $screen_id Screen ID.
+	 * @return string|null Admin URL or null if not found.
+	 */
+	public static function get_admin_url( $screen_id ) {
+		switch ( $screen_id ) {
+			case 'edit-jetpack_form':
+				return admin_url( 'admin.php?page=' . self::ADMIN_SLUG . '#/forms' );
+			case 'edit-feedback':
+				return admin_url( 'admin.php?page=' . self::ADMIN_SLUG . '#/responses' );
+		}
+		return null;
+	}
 }

--- a/projects/packages/forms/tests/php/dashboard/Dashboard_Test.php
+++ b/projects/packages/forms/tests/php/dashboard/Dashboard_Test.php
@@ -73,13 +73,12 @@ class Dashboard_Test extends BaseTestCase {
 	}
 
 	/**
-	 * Test get_admin_url with valid 'edit-jetpack_form' screen ID.
+	 * Test get_admin_url with valid screen IDS
 	 */
-	public function test_get_admin_url_with_jetpack_form_screen() {
-		$url = Dashboard::get_admin_url( 'edit-jetpack_form' );
-		$this->assertStringContainsString( 'admin.php?page=' . Dashboard::ADMIN_SLUG, $url );
-		$this->assertStringContainsString( '#/forms', $url );
-		$this->assertStringContainsString( admin_url( 'admin.php' ), $url );
+	public function test_get_admin_url_with_valid_screen_ids() {
+		$url_form = Dashboard::get_admin_url( 'edit-jetpack_form' );
+		$this->assertStringContainsString( 'admin.php?page=' . Dashboard::ADMIN_SLUG, $url_form );
+		$this->assertStringContainsString( '#/forms', $url_form );
 
 		$url_feedback = Dashboard::get_admin_url( 'edit-feedback' );
 		$this->assertStringContainsString( 'admin.php?page=' . Dashboard::ADMIN_SLUG, $url_feedback );

--- a/projects/packages/forms/tests/php/dashboard/Dashboard_Test.php
+++ b/projects/packages/forms/tests/php/dashboard/Dashboard_Test.php
@@ -87,12 +87,6 @@ class Dashboard_Test extends BaseTestCase {
 	}
 
 	/**
-	 * Test get_admin_url with valid 'edit-feedback' screen ID.
-	 */
-	public function test_get_admin_url_with_feedback_screen() {
-	}
-
-	/**
 	 * Test get_admin_url with invalid screen ID returns null.
 	 */
 	public function test_get_admin_url_with_invalid_screen() {

--- a/projects/packages/forms/tests/php/dashboard/Dashboard_Test.php
+++ b/projects/packages/forms/tests/php/dashboard/Dashboard_Test.php
@@ -71,4 +71,34 @@ class Dashboard_Test extends BaseTestCase {
 		$this->assertTrue( Dashboard::is_notes_enabled() );
 		remove_filter( 'jetpack_forms_notes_enable', '__return_true' );
 	}
+
+	/**
+	 * Test get_admin_url with valid 'edit-jetpack_form' screen ID.
+	 */
+	public function test_get_admin_url_with_jetpack_form_screen() {
+		$url = Dashboard::get_admin_url( 'edit-jetpack_form' );
+		$this->assertStringContainsString( 'admin.php?page=' . Dashboard::ADMIN_SLUG, $url );
+		$this->assertStringContainsString( '#/forms', $url );
+		$this->assertStringContainsString( admin_url( 'admin.php' ), $url );
+
+		$url_feedback = Dashboard::get_admin_url( 'edit-feedback' );
+		$this->assertStringContainsString( 'admin.php?page=' . Dashboard::ADMIN_SLUG, $url_feedback );
+		$this->assertStringContainsString( '#/responses', $url_feedback );
+	}
+
+	/**
+	 * Test get_admin_url with valid 'edit-feedback' screen ID.
+	 */
+	public function test_get_admin_url_with_feedback_screen() {
+	}
+
+	/**
+	 * Test get_admin_url with invalid screen ID returns null.
+	 */
+	public function test_get_admin_url_with_invalid_screen() {
+		$url = Dashboard::get_admin_url( 'invalid-screen' );
+		$this->assertNull( $url );
+		$url = Dashboard::get_admin_url( '' );
+		$this->assertNull( $url );
+	}
 }


### PR DESCRIPTION
This PR adds a forms post type redirect. 

Currently when you visit the form post type you end up in the classic forms post type. 

This PR makes sure that we redirect the user to the new admin UI. 

## Proposed changes:
* Creates a new function that lets us navigate the user to the new forms dashboard. 
* Adds tests. 

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion


## Does this pull request change what data or activity we track or use?
no
## Testing instructions:

// Note this only works if you have post type active. with the feature flag. 
```

add_filter( 'jetpack_block_editor_feature_flags', 'eb_register_feature' );

function eb_register_feature( $flags ) {
    $flags['central-form-management'] = true;
    return $flags;
}
```
Visit the following URLS. 
http://localhost/wp-admin/edit.php?post_type=jetpack_form you see the new forms dashboard. 
http://localhost/wp-admin/edit.php?post_type=feedback you see the new dashboard but for responses. 

you visit http://localhost/wp-admin/edit.php?post_type=page you end up as expected on the list of pages. 





