### PR TITLE
Social: Show a snackbar while sharing is in progress

### DIFF
--- a/projects/packages/publicize/_inc/social-store/actions/share-post.ts
+++ b/projects/packages/publicize/_inc/social-store/actions/share-post.ts
@@ -75,8 +75,7 @@ export function shareCurrentPost(
 	{ apiPath, savePost = true }: ShareCurrentPostConfig
 ) {
 	return async function ( { dispatch, registry } ): Promise< boolean > {
-		const { createErrorNotice, createSuccessNotice, removeNotice } =
-			registry.dispatch( noticesStore );
+		const { createErrorNotice, removeNotice } = registry.dispatch( noticesStore );
 		const { isCurrentPostPublished, isEditedPostDirty, isEditedPostAutosaveable } =
 			registry.select( editorStore );
 
@@ -132,11 +131,6 @@ export function shareCurrentPost(
 			} );
 		} else {
 			dispatch( pollForPostShareStatus() );
-
-			createSuccessNotice( __( 'Request submitted successfully.', 'jetpack-publicize-pkg' ), {
-				type: 'snackbar',
-				id: SHARE_POST_NOTICE_ID,
-			} );
 		}
 
 		dispatch( setIsSharingCurrentPost( false ) );

--- a/projects/packages/publicize/_inc/social-store/actions/share-status.ts
+++ b/projects/packages/publicize/_inc/social-store/actions/share-status.ts
@@ -1,4 +1,6 @@
 import { store as editorStore } from '@wordpress/editor';
+import { __ } from '@wordpress/i18n';
+import { store as noticesStore } from '@wordpress/notices';
 import { PostShareStatus, SocialStoreState } from '../types';
 import {
 	FETCH_POST_SHARE_STATUS,
@@ -123,6 +125,8 @@ export function pollingForPostShareStatus( postId: number, polling = true ) {
 	};
 }
 
+const SHARING_IN_PROGRESS_NOTICE_ID = 'publicize_sharing_in_progress_notice';
+
 /**
  * Poll for share status.
  *
@@ -140,6 +144,7 @@ export function pollForPostShareStatus( {
 		const startedAt = Date.now();
 
 		const postId = _postId || registry.select( editorStore ).getCurrentPostId();
+		const { createInfoNotice, removeNotice } = registry.dispatch( noticesStore );
 
 		const lastTimestamp = select.getPostShareStatus( postId ).shares[ 0 ]?.timestamp || 0;
 
@@ -147,6 +152,12 @@ export function pollForPostShareStatus( {
 		let hasTimeoutPassed = false;
 
 		dispatch( pollingForPostShareStatus( postId ) );
+
+		createInfoNotice( __( 'Sharing to your social media…', 'jetpack-publicize-pkg' ), {
+			type: 'snackbar',
+			id: SHARING_IN_PROGRESS_NOTICE_ID,
+			explicitDismiss: true,
+		} );
 
 		do {
 			// Do not invalidate the resolution if the request is still loading.
@@ -165,6 +176,8 @@ export function pollForPostShareStatus( {
 
 			hasTimeoutPassed = Date.now() - startedAt > timeout;
 		} while ( ! isTheRequestComplete && ! hasTimeoutPassed );
+
+		removeNotice( SHARING_IN_PROGRESS_NOTICE_ID );
 
 		dispatch( pollingForPostShareStatus( postId, false ) );
 	};

--- a/projects/packages/publicize/changelog/update-social-show-a-snackbar-while-sharing-is-in-progress
+++ b/projects/packages/publicize/changelog/update-social-show-a-snackbar-while-sharing-is-in-progress
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Show a snackbar while sharing is in progress.

--- a/projects/plugins/jetpack/changelog/update-social-show-a-snackbar-while-sharing-is-in-progress
+++ b/projects/plugins/jetpack/changelog/update-social-show-a-snackbar-while-sharing-is-in-progress
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Social: Show a snackbar while sharing is in progress.

--- a/projects/plugins/social/changelog/update-social-show-a-snackbar-while-sharing-is-in-progress
+++ b/projects/plugins/social/changelog/update-social-show-a-snackbar-while-sharing-is-in-progress
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Show a snackbar while sharing is in progress.


### PR DESCRIPTION
Completes SOCIAL-318

## Proposed changes:

Shows a persistent "Sharing to your social media…" snackbar while social sharing is in progress, replacing the previous "Request submitted successfully" message that appeared immediately after submission.

- Moved the snackbar from `shareCurrentPost` (fires on submit) to `pollForPostShareStatus` (fires during polling)
- Changed from success notice to info notice with `explicitDismiss: true`
- Snackbar is automatically removed when polling completes

This gives users better feedback that sharing is actively happening rather than just confirming the request was sent.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

N/A

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

1. Open a post in the editor
2. Connect a social account and enable sharing
3. Click "Share now" or publish the post
4. Verify a "Sharing to your social media…" snackbar appears and stays visible
5. Verify the snackbar disappears once sharing completes


https://github.com/user-attachments/assets/28d6bf43-2a38-4830-bf76-90a676bd4aee


