### PR TITLE
Social: Refactor share status to use Notice component

### DIFF
--- a/projects/packages/publicize/_inc/components/post-publish-share-status/share-status.tsx
+++ b/projects/packages/publicize/_inc/components/post-publish-share-status/share-status.tsx
@@ -13,7 +13,7 @@ type ShareStatusProps = {
  * Share status component.
  *
  * @param {ShareStatusProps} props - component props
- * @return {import('react').ReactNode} - React element
+ * @return React element
  */
 export function ShareStatus( { reShareTimestamp }: ShareStatusProps ) {
 	const shareStatus = useSelect( select => select( socialStore ).getPostShareStatus(), [] );
@@ -23,6 +23,8 @@ export function ShareStatus( { reShareTimestamp }: ShareStatusProps ) {
 		: shareStatus.shares;
 
 	if ( shareStatus.polling ) {
+		// Not using the `Notice` component here because we show a snackbar,
+		// that announces that sharing is in progress to screen readers.
 		return (
 			<div className={ styles[ 'loading-block' ] }>
 				<Spinner />
@@ -64,22 +66,27 @@ export function ShareStatus( { reShareTimestamp }: ShareStatusProps ) {
 		// If we are here, it means that polling has finished/timedout
 		// but we don't know the share status yet.
 		return (
-			<span>
+			<Notice isDismissible={ false }>
 				{ __( 'The request to share your post is still in progress.', 'jetpack-publicize-pkg' ) }
-				&nbsp;
+				<br />
 				{ __( 'Please refresh and check again in a few minutes.', 'jetpack-publicize-pkg' ) }
-			</span>
+			</Notice>
 		);
 	}
 
 	if ( ! currentShares.length ) {
 		// We should ideally never reach here but just in case.
-		return <span>{ __( 'Your post was not shared.', 'jetpack-publicize-pkg' ) }</span>;
+		return (
+			<Notice isDismissible={ false } status="warning">
+				{ __( 'Your post was not shared.', 'jetpack-publicize-pkg' ) }
+			</Notice>
+		);
 	}
 
 	return (
-		<>
-			<b>{ __( 'Your post was shared.', 'jetpack-publicize-pkg' ) }</b>&nbsp;{ '🎉' }
+		<Notice status="success" isDismissible={ false }>
+			<b>{ __( 'Your post was shared.', 'jetpack-publicize-pkg' ) }</b>&nbsp;
+			<span aria-hidden="true">{ '🎉' }</span>
 			<p>
 				{ sprintf(
 					/* translators: %d: number of connections to which a post was shared */
@@ -97,6 +104,6 @@ export function ShareStatus( { reShareTimestamp }: ShareStatusProps ) {
 					location: reShareTimestamp ? 'resharing-section' : 'post-publish-panel',
 				} }
 			/>
-		</>
+		</Notice>
 	);
 }

--- a/projects/packages/publicize/_inc/components/resharing-panel/styles.module.scss
+++ b/projects/packages/publicize/_inc/components/resharing-panel/styles.module.scss
@@ -1,4 +1,3 @@
 .wrapper {
-	margin-top: 1rem;
 	padding-block: 1rem;
 }

--- a/projects/packages/publicize/changelog/update-social-sharestatus-use-core-notice
+++ b/projects/packages/publicize/changelog/update-social-sharestatus-use-core-notice
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Refactor share status UI to use Notice component.

--- a/projects/plugins/jetpack/changelog/update-social-sharestatus-use-core-notice
+++ b/projects/plugins/jetpack/changelog/update-social-sharestatus-use-core-notice
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Social: Refactor share status UI to use Notice component.

--- a/projects/plugins/social/changelog/update-social-sharestatus-use-core-notice
+++ b/projects/plugins/social/changelog/update-social-sharestatus-use-core-notice
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Refactor share status UI to use Notice component.


### PR DESCRIPTION
Completes SOCIAL-321

## Proposed changes:

Refactors the share status component to use WordPress core `Notice` component for better accessibility and consistent styling.

- Wraps status messages (success, warning, in-progress) in `Notice` component with appropriate `status` prop
- Adds `aria-hidden="true"` to the celebration emoji to prevent screen readers from announcing it
- Removes redundant `margin-top` from resharing panel styles
- Keeps the loading state unchanged since a snackbar already announces sharing progress to screen readers

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

N/A

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

1. Open a post in the editor and share it to social media
2. Verify the share status messages display with proper Notice styling
3. Test with a screen reader to confirm the notices are announced
4. Check both the post-publish panel and the resharing panel for correct styling

<table>
    <tbody>
        <tr>
            <th>BEFORE</th>
            <th>AFTER</th>
        </tr>
        <tr>
            <td>
                <img width="276" height="164" alt="Screenshot 2026-01-20 at 2 05 46 PM" src="https://github.com/user-attachments/assets/d3dd2329-782d-4045-b427-7ca0fa283d14" />
            </td>
            <td>
                <img width="279" height="173" alt="Screenshot 2026-01-20 at 2 01 44 PM" src="https://github.com/user-attachments/assets/ce7ae74c-1422-4fa6-93cc-0938a3aff716" />
            </td>
        </tr>
        <tr>
            <td>
                <img width="279" height="83" alt="Screenshot 2026-01-20 at 2 06 57 PM" src="https://github.com/user-attachments/assets/07b82746-3633-4c9b-a9ed-76cf1ec0aa93" />
            </td>
            <td>
                <img width="272" height="99" alt="Screenshot 2026-01-20 at 2 02 04 PM" src="https://github.com/user-attachments/assets/f32ca6b4-c25c-4adc-9e18-3aab70788716" />
            </td>
        </tr>
        <tr>
            <td>
                <img width="285" height="122" alt="Screenshot 2026-01-20 at 2 06 12 PM" src="https://github.com/user-attachments/assets/c6e90e46-247f-41a6-9eea-8116a0664956" />
            </td>
            <td>
                <img width="278" height="158" alt="Screenshot 2026-01-20 at 2 08 27 PM" src="https://github.com/user-attachments/assets/66f9be71-4120-4158-a551-7c1a9fbbc6bf" />
            </td>
        </tr>
        <tr>
            <th colspan="2">No difference</th>
        </tr>
        <tr>
            <td>
                <img width="277" height="160" alt="Screenshot 2026-01-20 at 2 05 15 PM" src="https://github.com/user-attachments/assets/1d34eb37-36b6-4427-bfc4-d59942b2ce6d" />
            </td>
            <td>
                <img width="281" height="158" alt="Screenshot 2026-01-20 at 1 53 51 PM" src="https://github.com/user-attachments/assets/67e086b1-34f9-47df-aebb-1ff265a866af" />
            </td>
        </tr>
        <tr>
            <td>
<img width="275" height="150" alt="Screenshot 2026-01-20 at 1 53 16 PM" src="https://github.com/user-attachments/assets/99af8942-13a2-4c24-85a7-3bc75e21fe72" />
            </td>
            <td>
<img width="275" height="150" alt="Screenshot 2026-01-20 at 1 53 16 PM" src="https://github.com/user-attachments/assets/99af8942-13a2-4c24-85a7-3bc75e21fe72" />
            </td>
        </tr>
    </tbody>
</table>


