### PR TITLE
Load wpcom-global-styles on the customizer page

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/dotthem-157-additional-css-field-hidden-after-atomic-upgrade-on-hybrid
+++ b/projects/packages/jetpack-mu-wpcom/changelog/dotthem-157-additional-css-field-hidden-after-atomic-upgrade-on-hybrid
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Global Styles: Load the feature on the customizer to fix access checks for additional CSS.

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -434,6 +434,9 @@ class Jetpack_Mu_Wpcom {
 			require_once __DIR__ . '/features/wpcom-documentation-links/wpcom-documentation-links.php';
 			require_once __DIR__ . '/features/wpcom-global-styles/index.php';
 			require_once __DIR__ . '/features/wpcom-legacy-fse/wpcom-legacy-fse.php';
+		} elseif ( isset( $pagenow ) && 'customize.php' === $pagenow ) {
+			// Load wpcom-global-styles on the customizer so access to additional css can be checked there.
+			require_once __DIR__ . '/features/wpcom-global-styles/index.php';
 		}
 	}
 


### PR DESCRIPTION
Fixes DOTTHEM-157

## Proposed changes:
* Load the `wpcom-global-styles` feature on `customize.php` so that `is_global_styles_on_personal_plan()` is available when `wpcomsh_maybe_disable_custom_css` calls it

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
N/A - Bug fix for missing function on customizer page.

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:

1. Have a WordPress.com site on a Personal plan with a classic theme (non-block theme)
2. Go Atomic
3. Enable this branch via Jetpack Beta
4. Go to the Customizer (Appearance → Customize / Appearance → Additional CSS)
5. Verify the "Additional CSS" section is visible and functional - there is a textarea you can enter some CSS into

Before | After
-------|------
<img width="686" height="918" alt="Screenshot 2026-01-20 at 11 08 16" src="https://github.com/user-attachments/assets/7dbb110f-7223-456a-a465-cf66c88b44bf" /> | <img width="686" height="918" alt="Screenshot 2026-01-20 at 11 06 59" src="https://github.com/user-attachments/assets/3b19defd-de6e-4bf6-8326-f80fc325964c" />

