### PR TITLE
Forms: use 'Stack' component from wp-ui in wp-build dashboard

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2416,6 +2416,9 @@ importers:
       '@wordpress/theme':
         specifier: 0.5.0
         version: 0.5.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@16.26.1)
+      '@wordpress/ui':
+        specifier: 0.5.0
+        version: 0.5.0(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/url':
         specifier: 4.38.0
         version: 4.38.0

--- a/projects/packages/forms/changelog/update-forms-stack
+++ b/projects/packages/forms/changelog/update-forms-stack
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Use Stack component from WP-UI package in new wp-build dashboard.

--- a/projects/packages/forms/package.json
+++ b/projects/packages/forms/package.json
@@ -73,6 +73,7 @@
 		"@wordpress/primitives": "4.38.0",
 		"@wordpress/route": "0.4.0",
 		"@wordpress/theme": "0.5.0",
+		"@wordpress/ui": "0.5.0",
 		"@wordpress/url": "4.38.0",
 		"clsx": "2.1.1",
 		"copy-webpack-plugin": "13.0.1",

--- a/projects/packages/forms/routes/responses/package.json
+++ b/projects/packages/forms/routes/responses/package.json
@@ -23,7 +23,8 @@
 		"@wordpress/i18n": "6.11.0",
 		"@wordpress/icons": "11.5.0",
 		"@wordpress/notices": "5.38.0",
-		"@wordpress/route": "0.4.0"
+		"@wordpress/route": "0.4.0",
+		"@wordpress/ui": "0.5.0"
 	},
 	"route": {
 		"path": "/responses/$view",

--- a/projects/packages/forms/routes/responses/stage.tsx
+++ b/projects/packages/forms/routes/responses/stage.tsx
@@ -19,6 +19,7 @@ import { __, _n, sprintf } from '@wordpress/i18n';
 import { download, plus, Icon, globe } from '@wordpress/icons';
 import { store as noticesStore } from '@wordpress/notices';
 import { useParams, useSearch, useNavigate } from '@wordpress/route';
+import { Stack } from '@wordpress/ui';
 import * as React from 'react';
 /**
  * Internal dependencies
@@ -27,7 +28,7 @@ import IntegrationsModal from '../../src/blocks/contact-form/components/jetpack-
 import EmptyResponses from '../../src/dashboard/components/empty-responses';
 import Flag from '../../src/dashboard/components/flag';
 import Gravatar from '../../src/dashboard/components/gravatar';
-import Page, { Stack } from '../../src/dashboard/components/page';
+import Page from '../../src/dashboard/components/page';
 import './style.scss';
 import * as Tabs from '../../src/dashboard/components/tabs';
 import useCreateForm from '../../src/dashboard/hooks/use-create-form';
@@ -1086,8 +1087,9 @@ function Stage() {
 					direction="row"
 					justify="space-between"
 					align="center"
+					gap="sm"
 				>
-					<Stack direction="row" align="center" gap={ 2 }>
+					<Stack direction="row" align="center" gap="sm">
 						<Tabs.Root value={ params.view || 'inbox' } onValueChange={ handleTabChange }>
 							<Tabs.List density="compact">
 								{ statusTabs.map( tab => (
@@ -1098,7 +1100,7 @@ function Stage() {
 							</Tabs.List>
 						</Tabs.Root>
 					</Stack>
-					<Stack direction="row" align="center" gap={ 2 }>
+					<Stack direction="row" align="center" gap="sm">
 						<DataViews.Search />
 						<DataViews.FiltersToggle />
 						<DataViews.ViewConfig />

--- a/projects/packages/forms/routes/responses/stage.tsx
+++ b/projects/packages/forms/routes/responses/stage.tsx
@@ -91,7 +91,7 @@ function useFilterOptions() {
  */
 function getTabLabel( label: string, count: number ): JSX.Element {
 	return (
-		<Stack align="center" gap="xs">
+		<Stack align="center" gap="2xs">
 			{ label }
 			<Badge intent="default" style={ { backgroundColor: '#f0f0f0' } }>
 				{ count.toString() }
@@ -300,7 +300,7 @@ function Stage() {
 					const showEmail = item.author_email && item.author_name !== item.author_email;
 					const defaultImage = item.author_name || item.author_email ? 'initials' : 'mp';
 					return (
-						<span style={ { display: 'flex', alignItems: 'center', gap: '12px' } }>
+						<Stack align="center" gap="sm">
 							{ item.is_unread && (
 								<span
 									style={ {
@@ -321,17 +321,17 @@ function Stage() {
 								useHovercard={ false }
 							/>
 							{ styleUnreadValue(
-								<span style={ { display: 'flex', flexDirection: 'column', gap: '2px' } }>
+								<Stack direction="column" gap="2xs">
 									{ displayName }
 									{ showEmail && (
 										<span style={ { fontSize: '12px', color: '#757575' } }>
 											{ item.author_email }
 										</span>
 									) }
-								</span>,
+								</Stack>,
 								item.is_unread
 							) }
-						</span>
+						</Stack>
 					);
 				},
 				getValue: ( { item } ) =>

--- a/projects/packages/forms/routes/responses/stage.tsx
+++ b/projects/packages/forms/routes/responses/stage.tsx
@@ -91,12 +91,12 @@ function useFilterOptions() {
  */
 function getTabLabel( label: string, count: number ): JSX.Element {
 	return (
-		<span style={ { display: 'flex', gap: '4px', alignItems: 'center' } }>
+		<Stack align="center" gap="xs">
 			{ label }
 			<Badge intent="default" style={ { backgroundColor: '#f0f0f0' } }>
 				{ count.toString() }
 			</Badge>
-		</span>
+		</Stack>
 	);
 }
 
@@ -1053,10 +1053,10 @@ function Stage() {
 		<Page
 			showSidebarToggle={ false }
 			title={
-				<span style={ { display: 'flex', alignItems: 'center', gap: '8px' } }>
+				<Stack align="center" gap="xs">
 					<JetpackLogo showText={ false } width={ 20 } />
 					{ __( 'Forms', 'jetpack-forms' ) }
-				</span>
+				</Stack>
 			}
 			subTitle={ __( 'View and manage all your form submissions in one place.', 'jetpack-forms' ) }
 			actions={ headerActions }

--- a/projects/packages/forms/routes/responses/stage.tsx
+++ b/projects/packages/forms/routes/responses/stage.tsx
@@ -1082,7 +1082,12 @@ function Stage() {
 				onChangeSelection={ onChangeSelection }
 				actions={ actions }
 			>
-				<Stack justify="space-between" align="center" gap="sm">
+				<Stack
+					align="center"
+					className="jp-forms-dataviews__view-actions"
+					gap="sm"
+					justify="space-between"
+				>
 					<Stack align="center" gap="sm">
 						<Tabs.Root value={ params.view || 'inbox' } onValueChange={ handleTabChange }>
 							<Tabs.List density="compact">

--- a/projects/packages/forms/routes/responses/stage.tsx
+++ b/projects/packages/forms/routes/responses/stage.tsx
@@ -1082,14 +1082,8 @@ function Stage() {
 				onChangeSelection={ onChangeSelection }
 				actions={ actions }
 			>
-				<Stack
-					className="jp-forms-dataviews__view-actions"
-					direction="row"
-					justify="space-between"
-					align="center"
-					gap="sm"
-				>
-					<Stack direction="row" align="center" gap="sm">
+				<Stack justify="space-between" align="center" gap="sm">
+					<Stack align="center" gap="sm">
 						<Tabs.Root value={ params.view || 'inbox' } onValueChange={ handleTabChange }>
 							<Tabs.List density="compact">
 								{ statusTabs.map( tab => (
@@ -1100,7 +1094,7 @@ function Stage() {
 							</Tabs.List>
 						</Tabs.Root>
 					</Stack>
-					<Stack direction="row" align="center" gap="sm">
+					<Stack align="center" gap="sm">
 						<DataViews.Search />
 						<DataViews.FiltersToggle />
 						<DataViews.ViewConfig />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Use `Stack` component in new wp-build dashboard, instead of internally bundled one.

This is first component we're using from `@wordpress/ui` so I'm mostly interested to see build work fine, the package get bundled instead of externalized etc.

Internally bundled one is still used at old dashboard; `gap` didn't seem to work well there so I'm focusing on updating just the new dashboard now.

There will be more components that will follow in separate PRs (Badge, Tabs, Icon, Button, etc)

Docs: https://wordpress.github.io/gutenberg/?path=/docs/design-system-components-stack--docs

Before

<img width="1248" height="674" alt="Screenshot 2026-01-20 at 15 35 49" src="https://github.com/user-attachments/assets/b659d828-64a2-4c3a-ad39-eccb06fe7dfc" />

After

<img width="1249" height="658" alt="image" src="https://github.com/user-attachments/assets/bbf184c0-a0c5-4b4a-9112-013af5b4ac57" />

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Build forms
* Dashboard continues to work `/wp-admin/admin.php?page=jetpack-forms-responses-wp-admin&p=%2Fresponses%2Finbox`
* Note that we have a separate issue loading styles now, so don't pay too much attention to the dataviews styles working. Surrounding styles still work.
