### PR TITLE
Forms: Use safe photon URLs for image select response previews

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-image-select-response-preview
+++ b/projects/packages/forms/changelog/fix-forms-image-select-response-preview
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Image Select Response: use native img attributes instead of photon for image previews.

--- a/projects/packages/forms/changelog/fix-forms-image-select-response-preview
+++ b/projects/packages/forms/changelog/fix-forms-image-select-response-preview
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Image Select Response: use native img attributes instead of photon for image previews.
+Image Select Response: fix image previews by handling edge cases where Photon should not be used (localhost, blob URLs, local domains, private atomic sites).

--- a/projects/packages/forms/src/dashboard/components/response-view/field-image-select/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/response-view/field-image-select/index.tsx
@@ -9,9 +9,9 @@ import photon from 'photon';
 import './style.scss';
 
 /**
- * Clean the query string from the URL.
- * @param url - The URL to clean.
- * @return The URL with the query string removed.
+ * Returns a Photon-optimized image URL or the original URL if Photon should not be used.
+ * @param url - The image URL to process.
+ * @return A Photon-optimized image URL, the original URL if Photon is skipped, or null if the input is empty.
  */
 function photonSafeUrl( url: string = '' ): string | null {
 	if ( ! url ) {

--- a/projects/packages/forms/src/dashboard/components/response-view/field-image-select/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/response-view/field-image-select/index.tsx
@@ -1,3 +1,5 @@
+import { isWoASite } from '@automattic/jetpack-script-data';
+import { isPrivateSite } from '@automattic/jetpack-shared-extension-utils';
 import {
 	Button,
 	__experimentalVStack as VStack, // eslint-disable-line @wordpress/no-unsafe-wp-apis
@@ -5,6 +7,28 @@ import {
 import { image as imageIcon } from '@wordpress/icons';
 import photon from 'photon';
 import './style.scss';
+
+/**
+ * Clean the query string from the URL.
+ * @param url - The URL to clean.
+ * @return The URL with the query string removed.
+ */
+function photonSafeUrl( url: string = '' ): string | null {
+	if ( ! url ) {
+		return null;
+	}
+	// Do not Photonize images that are still uploading, are from localhost, or are private + atomic
+	if (
+		url.startsWith( 'blob:' ) ||
+		/^https?:\/\/localhost/.test( url ) ||
+		/^https?:\/\/.*\.local\//.test( url ) ||
+		( isWoASite() && isPrivateSite() )
+	) {
+		return url;
+	}
+
+	return photon( url.split( '?', 1 )[ 0 ], { width: 120, height: 120 } );
+}
 
 const FieldImageSelect = ( { choices, handleFilePreview } ) => {
 	return (
@@ -37,7 +61,8 @@ const FieldImageSelect = ( { choices, handleFilePreview } ) => {
 										<img
 											alt={ choice.selected }
 											loading="lazy"
-											src={ photon( choice.image.src, { width: 120, height: 120 } ) }
+											src={ photonSafeUrl( choice.image.src ) }
+											style={ { objectFit: 'cover' } }
 										/>
 									) : (
 										imageIcon


### PR DESCRIPTION
Part of FORMS-537

When images carry a query string, photon will return `null` as URL, hence the image tag not holding a `src` attribute at all. This PR adds a tiny function to remove the query string from image URLs and also deal with some exceptions to the image URLs being passed to photon or not. By design, photon deals with publicly available images, so private sites shouldn't use it. Local envs (local/localhost) also shouldn't use photon for the same public availability reasons. Blobs should not happen, but in case one comes along, it's also accepted straight into the image tag's `src`.

## Proposed changes:
  - Fix image previews in the Forms Image Select Response view by adding proper handling for edge cases where Photon should not be used
  - Add a photonSafeUrl helper function that bypasses Photon for:
    - Blob URLs (images still uploading)
    - Localhost URLs
    - Local domain URLs (.local)
    - Private atomic sites (WoA + private)
  - Add objectFit: 'cover' style to ensure consistent image display

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1768909155099309-slack-C052XEUUBL4

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

  - Set up a form with an Image Select field that has images
  - Submit the form with image selections
  - Go to the Jetpack Forms responses dashboard
  - View a response that includes image selections
  - Verify that the image previews display correctly
  - (Optional) Test on a local development environment to verify localhost images display without Photon errors
