### PR TITLE
CRM: CSV import path separator

### DIFF
--- a/projects/plugins/crm/changelog/fix-csv-import-path-separator-windows
+++ b/projects/plugins/crm/changelog/fix-csv-import-path-separator-windows
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+CSV Importer: fix path separator issue causing import failures on Windows servers.

--- a/projects/plugins/crm/changelog/fix-csv-import-path-separator-windows
+++ b/projects/plugins/crm/changelog/fix-csv-import-path-separator-windows
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-CSV Importer: fix path separator issue causing import failures on Windows servers.
+CSV Importer: Fix path separator issue causing import failures on Windows servers.

--- a/projects/plugins/crm/includes/ZeroBSCRM.CSVImporter.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.CSVImporter.php
@@ -152,7 +152,7 @@ function jpcrm_csvimporter_lite_preflight_checks( $stage ) {
 	// eventually update this to use the zbscrm-store/_wip replacement
 	// apparently sys_get_temp_dir() isn't consistent on whether it has a trailing slash
 	$tmp_dir = untrailingslashit( sys_get_temp_dir() );
-	$tmp_dir = realpath( $tmp_dir ) . '/';
+	$tmp_dir = realpath( $tmp_dir ) . DIRECTORY_SEPARATOR;
 
 	$field_map = array();
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
CSV Importer: Fix path separator issue causing import failures on Windows servers

Fixes JETCRM-64

## Proposed changes:
* Replaced a hardcoded forward slash (`/`) with `DIRECTORY_SEPARATOR` when constructing the temporary directory path in `ZeroBSCRM.CSVImporter.php`. This resolves an issue where `realpath()` on Windows returns backslashes, causing a path mismatch and failure in a security check (`str_starts_with()`).

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
None

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
* Set up a WordPress environment on a Windows server.
* Install and activate Jetpack CRM.
* Go to Jetpack CRM → Contacts -> Import.
* Upload a valid CSV file.
* Attempt to import the CSV using either Importer Pro or the core importer.
* **Expected Result:** The import process should start, and the dashboard should load the import progress.
* **Actual Result (before fix):** The import fails immediately with the message: “There was an error processing your CSV file. Please try again.”

