### PR TITLE
Forms: Use components for empty actions in trash/spam for new wp-build dashboard

### DIFF
--- a/projects/packages/forms/changelog/update-forms-wp-build-dash-ctas
+++ b/projects/packages/forms/changelog/update-forms-wp-build-dash-ctas
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Use components for empty actions in trash/spam for new wp-build dashboard.

--- a/projects/packages/forms/routes/responses/stage.tsx
+++ b/projects/packages/forms/routes/responses/stage.tsx
@@ -16,7 +16,7 @@ import { dateI18n } from '@wordpress/date';
 import { useMemo, useState, useCallback, useEffect } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
 import { __, _n, sprintf } from '@wordpress/i18n';
-import { download, plus, Icon, globe } from '@wordpress/icons';
+import { plus, Icon, globe } from '@wordpress/icons';
 import { store as noticesStore } from '@wordpress/notices';
 import { useParams, useSearch, useNavigate } from '@wordpress/route';
 import * as React from 'react';
@@ -25,6 +25,9 @@ import * as React from 'react';
  */
 import IntegrationsModal from '../../src/blocks/contact-form/components/jetpack-integrations-modal';
 import EmptyResponses from '../../src/dashboard/components/empty-responses';
+import EmptySpamButton from '../../src/dashboard/components/empty-spam-button';
+import EmptyTrashButton from '../../src/dashboard/components/empty-trash-button';
+import ExportResponsesButton from '../../src/dashboard/components/export-responses/button';
 import Flag from '../../src/dashboard/components/flag';
 import Gravatar from '../../src/dashboard/components/gravatar';
 import Page, { Stack } from '../../src/dashboard/components/page';
@@ -1015,25 +1018,15 @@ function Stage() {
 		}
 
 		actionsArray.push(
-			<Button key="export" variant="primary" size="compact" icon={ download }>
-				{ __( 'Export', 'jetpack-forms' ) }
-			</Button>
+			<ExportResponsesButton key="export" isPrimary={ params.view === 'inbox' } />
 		);
 
 		if ( params.view === 'trash' ) {
-			actionsArray.push(
-				<Button key="empty-trash" variant="secondary" isDestructive size="compact">
-					{ __( 'Empty Trash', 'jetpack-forms' ) }
-				</Button>
-			);
+			actionsArray.push( <EmptyTrashButton key="empty-trash" /> );
 		}
 
 		if ( params.view === 'spam' ) {
-			actionsArray.push(
-				<Button key="empty-spam" variant="secondary" isDestructive size="compact">
-					{ __( 'Empty Spam', 'jetpack-forms' ) }
-				</Button>
-			);
+			actionsArray.push( <EmptySpamButton key="empty-spam" /> );
 		}
 
 		return actionsArray;

--- a/projects/packages/forms/routes/responses/stage.tsx
+++ b/projects/packages/forms/routes/responses/stage.tsx
@@ -16,7 +16,7 @@ import { dateI18n } from '@wordpress/date';
 import { useMemo, useState, useCallback, useEffect } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
 import { __, _n, sprintf } from '@wordpress/i18n';
-import { plus, Icon, globe } from '@wordpress/icons';
+import { download, plus, Icon, globe } from '@wordpress/icons';
 import { store as noticesStore } from '@wordpress/notices';
 import { useParams, useSearch, useNavigate } from '@wordpress/route';
 import * as React from 'react';
@@ -27,7 +27,6 @@ import IntegrationsModal from '../../src/blocks/contact-form/components/jetpack-
 import EmptyResponses from '../../src/dashboard/components/empty-responses';
 import EmptySpamButton from '../../src/dashboard/components/empty-spam-button';
 import EmptyTrashButton from '../../src/dashboard/components/empty-trash-button';
-import ExportResponsesButton from '../../src/dashboard/components/export-responses/button';
 import Flag from '../../src/dashboard/components/flag';
 import Gravatar from '../../src/dashboard/components/gravatar';
 import Page, { Stack } from '../../src/dashboard/components/page';
@@ -1018,7 +1017,14 @@ function Stage() {
 		}
 
 		actionsArray.push(
-			<ExportResponsesButton key="export" isPrimary={ params.view === 'inbox' } />
+			<Button
+				key="export"
+				variant={ params.view === 'inbox' ? 'primary' : 'secondary' }
+				size="compact"
+				icon={ download }
+			>
+				{ __( 'Export', 'jetpack-forms' ) }
+			</Button>
 		);
 
 		if ( params.view === 'trash' ) {

--- a/projects/packages/forms/src/dashboard/inbox/stage/index.js
+++ b/projects/packages/forms/src/dashboard/inbox/stage/index.js
@@ -13,7 +13,7 @@ import { dateI18n, getSettings as getDateSettings } from '@wordpress/date';
 import { useCallback, useMemo, useState } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
 import { __ } from '@wordpress/i18n';
-import { Icon, globe } from '@wordpress/icons';
+import { download, Icon, globe } from '@wordpress/icons';
 import clsx from 'clsx';
 import { useEffect } from 'react';
 import { useSearchParams } from 'react-router';
@@ -26,7 +26,6 @@ import CreateFormButton from '../../components/create-form-button/index.tsx';
 import EmptyResponses from '../../components/empty-responses/index.tsx';
 import EmptySpamButton from '../../components/empty-spam-button/index.tsx';
 import EmptyTrashButton from '../../components/empty-trash-button/index.tsx';
-import ExportResponsesButton from '../../components/export-responses/button.tsx';
 import Flag from '../../components/flag/index.tsx';
 import FormsResponsesTabs from '../../components/forms-responses-tabs/index.tsx';
 import Gravatar from '../../components/gravatar/index.tsx';
@@ -512,7 +511,14 @@ export default function InboxView() {
 	const headerActions = useMemo( () => {
 		const exportIsPrimary = statusFilter !== 'trash' && statusFilter !== 'spam';
 		const headerActionsArray = [
-			<ExportResponsesButton key="export" isPrimary={ exportIsPrimary } />,
+			<Button
+				key="export"
+				variant={ exportIsPrimary ? 'primary' : 'secondary' }
+				size="compact"
+				icon={ download }
+			>
+				{ __( 'Export', 'jetpack-forms' ) }
+			</Button>,
 		];
 
 		if ( statusFilter === 'trash' ) {

--- a/projects/packages/forms/src/dashboard/inbox/stage/index.js
+++ b/projects/packages/forms/src/dashboard/inbox/stage/index.js
@@ -13,7 +13,7 @@ import { dateI18n, getSettings as getDateSettings } from '@wordpress/date';
 import { useCallback, useMemo, useState } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
 import { __ } from '@wordpress/i18n';
-import { download, Icon, globe } from '@wordpress/icons';
+import { Icon, globe } from '@wordpress/icons';
 import clsx from 'clsx';
 import { useEffect } from 'react';
 import { useSearchParams } from 'react-router';
@@ -26,6 +26,7 @@ import CreateFormButton from '../../components/create-form-button/index.tsx';
 import EmptyResponses from '../../components/empty-responses/index.tsx';
 import EmptySpamButton from '../../components/empty-spam-button/index.tsx';
 import EmptyTrashButton from '../../components/empty-trash-button/index.tsx';
+import ExportResponsesButton from '../../components/export-responses/button.tsx';
 import Flag from '../../components/flag/index.tsx';
 import FormsResponsesTabs from '../../components/forms-responses-tabs/index.tsx';
 import Gravatar from '../../components/gravatar/index.tsx';
@@ -511,14 +512,7 @@ export default function InboxView() {
 	const headerActions = useMemo( () => {
 		const exportIsPrimary = statusFilter !== 'trash' && statusFilter !== 'spam';
 		const headerActionsArray = [
-			<Button
-				key="export"
-				variant={ exportIsPrimary ? 'primary' : 'secondary' }
-				size="compact"
-				icon={ download }
-			>
-				{ __( 'Export', 'jetpack-forms' ) }
-			</Button>,
+			<ExportResponsesButton key="export" isPrimary={ exportIsPrimary } />,
 		];
 
 		if ( statusFilter === 'trash' ) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Use components for empty actions in trash/spam for new wp-build dashboard.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Build forms
* Test Empty trash / Empty spam CTAs
* They should stay disabled with tooltip if view is empty

