### PR TITLE
Forms: Use components for trash/spam header CTAs in wp-build dashboard

### DIFF
--- a/projects/packages/forms/changelog/update-forms-wp-build-dash-ctas
+++ b/projects/packages/forms/changelog/update-forms-wp-build-dash-ctas
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Use components for empty actions in trash/spam for new wp-build dashboard.

--- a/projects/packages/forms/routes/responses/stage.tsx
+++ b/projects/packages/forms/routes/responses/stage.tsx
@@ -35,6 +35,7 @@ import './style.scss';
 import * as Tabs from '../../src/dashboard/components/tabs';
 import useCreateForm from '../../src/dashboard/hooks/use-create-form';
 import { getPath } from '../../src/dashboard/inbox/utils';
+import WpRouteDashboardSearchParamsProvider from '../../src/dashboard/router/wp-route-dashboard-search-params-provider.tsx';
 import { store as dashboardStore } from '../../src/dashboard/store';
 import useConfigValue from '../../src/hooks/use-config-value';
 import { INTEGRATIONS_STORE, IntegrationsSelectors } from '../../src/store/integrations';
@@ -187,7 +188,7 @@ function Stage() {
 		[]
 	);
 	const { updateCountsOptimistically, invalidateCounts } = useDispatch(
-		dashboardStore
+		( dashboardStore as unknown as { name: string } ).name
 	) as DispatchActions;
 	const filterOptions = useFilterOptions();
 	let status = 'publish';
@@ -1049,75 +1050,80 @@ function Stage() {
 	const readStatusFilter = view.filters?.find( filter => filter.field === 'read_status' )?.value;
 
 	return (
-		<Page
-			showSidebarToggle={ false }
-			title={
-				<Stack align="center" gap="xs">
-					<JetpackLogo showText={ false } width={ 20 } />
-					{ __( 'Forms', 'jetpack-forms' ) }
-				</Stack>
-			}
-			subTitle={ __( 'View and manage all your form submissions in one place.', 'jetpack-forms' ) }
-			actions={ headerActions }
-			hasPadding={ false }
-		>
-			<DataViews
-				empty={
-					<EmptyResponses
-						status={ params.view }
-						isSearch={ !! view.search }
-						readStatusFilter={ readStatusFilter }
-					/>
+		<WpRouteDashboardSearchParamsProvider from="/responses/$view">
+			<Page
+				showSidebarToggle={ false }
+				title={
+					<Stack align="center" gap="xs">
+						<JetpackLogo showText={ false } width={ 20 } />
+						{ __( 'Forms', 'jetpack-forms' ) }
+					</Stack>
 				}
-				data={ records || EMPTY_ARRAY }
-				fields={ fields as Field< unknown >[] }
-				view={ view }
-				onChangeView={ onChangeView }
-				paginationInfo={ paginationInfo }
-				isLoading={ isResolving }
-				getItemId={ getItemId }
-				defaultLayouts={ defaultLayouts }
-				selection={ selection }
-				onChangeSelection={ onChangeSelection }
-				actions={ actions }
+				subTitle={ __(
+					'View and manage all your form submissions in one place.',
+					'jetpack-forms'
+				) }
+				actions={ headerActions }
+				hasPadding={ false }
 			>
-				<Stack
-					align="center"
-					className="jp-forms-dataviews__view-actions"
-					gap="sm"
-					justify="space-between"
+				<DataViews
+					empty={
+						<EmptyResponses
+							status={ params.view }
+							isSearch={ !! view.search }
+							readStatusFilter={ readStatusFilter }
+						/>
+					}
+					data={ records || EMPTY_ARRAY }
+					fields={ fields as Field< unknown >[] }
+					view={ view }
+					onChangeView={ onChangeView }
+					paginationInfo={ paginationInfo }
+					isLoading={ isResolving }
+					getItemId={ getItemId }
+					defaultLayouts={ defaultLayouts }
+					selection={ selection }
+					onChangeSelection={ onChangeSelection }
+					actions={ actions }
 				>
-					<Stack align="center" gap="sm">
-						<Tabs.Root value={ params.view || 'inbox' } onValueChange={ handleTabChange }>
-							<Tabs.List density="compact">
-								{ statusTabs.map( tab => (
-									<Tabs.Tab value={ tab.slug } key={ tab.slug }>
-										{ tab.label }
-									</Tabs.Tab>
-								) ) }
-							</Tabs.List>
-						</Tabs.Root>
+					<Stack
+						align="center"
+						className="jp-forms-dataviews__view-actions"
+						gap="sm"
+						justify="space-between"
+					>
+						<Stack align="center" gap="sm">
+							<Tabs.Root value={ params.view || 'inbox' } onValueChange={ handleTabChange }>
+								<Tabs.List density="compact">
+									{ statusTabs.map( tab => (
+										<Tabs.Tab value={ tab.slug } key={ tab.slug }>
+											{ tab.label }
+										</Tabs.Tab>
+									) ) }
+								</Tabs.List>
+							</Tabs.Root>
+						</Stack>
+						<Stack align="center" gap="sm">
+							<DataViews.Search />
+							<DataViews.FiltersToggle />
+							<DataViews.ViewConfig />
+						</Stack>
 					</Stack>
-					<Stack align="center" gap="sm">
-						<DataViews.Search />
-						<DataViews.FiltersToggle />
-						<DataViews.ViewConfig />
-					</Stack>
-				</Stack>
-				<DataViews.Filters className="dataviews-filters__container" />
-				<DataViews.Layout />
-				<DataViews.Footer />
-			</DataViews>
-			<IntegrationsModal
-				isOpen={ isIntegrationsModalOpen }
-				onClose={ closeIntegrationsModal }
-				attributes={ undefined }
-				setAttributes={ undefined }
-				integrationsData={ integrations }
-				refreshIntegrations={ refreshIntegrations }
-				context="dashboard"
-			/>
-		</Page>
+					<DataViews.Filters className="dataviews-filters__container" />
+					<DataViews.Layout />
+					<DataViews.Footer />
+				</DataViews>
+				<IntegrationsModal
+					isOpen={ isIntegrationsModalOpen }
+					onClose={ closeIntegrationsModal }
+					attributes={ undefined }
+					setAttributes={ undefined }
+					integrationsData={ integrations }
+					refreshIntegrations={ refreshIntegrations }
+					context="dashboard"
+				/>
+			</Page>
+		</WpRouteDashboardSearchParamsProvider>
 	);
 }
 

--- a/projects/packages/forms/routes/responses/stage.tsx
+++ b/projects/packages/forms/routes/responses/stage.tsx
@@ -16,7 +16,7 @@ import { dateI18n } from '@wordpress/date';
 import { useMemo, useState, useCallback, useEffect } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
 import { __, _n, sprintf } from '@wordpress/i18n';
-import { plus, Icon, globe } from '@wordpress/icons';
+import { download, plus, Icon, globe } from '@wordpress/icons';
 import { store as noticesStore } from '@wordpress/notices';
 import { useParams, useSearch, useNavigate } from '@wordpress/route';
 import { Stack } from '@wordpress/ui';
@@ -28,7 +28,6 @@ import IntegrationsModal from '../../src/blocks/contact-form/components/jetpack-
 import EmptyResponses from '../../src/dashboard/components/empty-responses';
 import EmptySpamButton from '../../src/dashboard/components/empty-spam-button';
 import EmptyTrashButton from '../../src/dashboard/components/empty-trash-button';
-import ExportResponsesButton from '../../src/dashboard/components/export-responses/button';
 import Flag from '../../src/dashboard/components/flag';
 import Gravatar from '../../src/dashboard/components/gravatar';
 import Page from '../../src/dashboard/components/page';
@@ -1019,7 +1018,14 @@ function Stage() {
 		}
 
 		actionsArray.push(
-			<ExportResponsesButton key="export" isPrimary={ params.view === 'inbox' } />
+			<Button
+				key="export"
+				variant={ params.view === 'inbox' ? 'primary' : 'secondary' }
+				size="compact"
+				icon={ download }
+			>
+				{ __( 'Export', 'jetpack-forms' ) }
+			</Button>
 		);
 
 		if ( params.view === 'trash' ) {

--- a/projects/packages/forms/routes/responses/stage.tsx
+++ b/projects/packages/forms/routes/responses/stage.tsx
@@ -44,6 +44,7 @@ import { INTEGRATIONS_STORE, IntegrationsSelectors } from '../../src/store/integ
  */
 import type { SelectActions, DispatchActions } from '../../src/dashboard/inbox/stage/types.tsx';
 import type { FormResponse } from '../../src/types/index.ts';
+import type { StoreDescriptor } from '@wordpress/data';
 import type { View, Field } from '@wordpress/dataviews';
 
 type FeedbackFilterDate = {
@@ -141,8 +142,8 @@ const DEFAULT_VIEW: View = {
  * @param {object} item - The item object.
  * @return {string} The item ID as a string.
  */
-function getItemId( item ) {
-	return item.id.toString();
+function getItemId( item: unknown ): string {
+	return ( item as { id: number | string } )?.id?.toString() ?? '';
 }
 
 /**
@@ -187,9 +188,11 @@ function Stage() {
 		select => ( select( dashboardStore ) as SelectActions ).getCounts(),
 		[]
 	);
+
+	const dashboardStoreDescriptor = dashboardStore as StoreDescriptor;
 	const { updateCountsOptimistically, invalidateCounts } = useDispatch(
-		( dashboardStore as unknown as { name: string } ).name
-	) as DispatchActions;
+		dashboardStoreDescriptor
+	) as unknown as DispatchActions;
 	const filterOptions = useFilterOptions();
 	let status = 'publish';
 	if ( params.view === 'spam' ) {

--- a/projects/packages/forms/routes/responses/stage.tsx
+++ b/projects/packages/forms/routes/responses/stage.tsx
@@ -16,7 +16,7 @@ import { dateI18n } from '@wordpress/date';
 import { useMemo, useState, useCallback, useEffect } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
 import { __, _n, sprintf } from '@wordpress/i18n';
-import { download, plus, Icon, globe } from '@wordpress/icons';
+import { plus, Icon, globe } from '@wordpress/icons';
 import { store as noticesStore } from '@wordpress/notices';
 import { useParams, useSearch, useNavigate } from '@wordpress/route';
 import { Stack } from '@wordpress/ui';
@@ -26,6 +26,9 @@ import * as React from 'react';
  */
 import IntegrationsModal from '../../src/blocks/contact-form/components/jetpack-integrations-modal';
 import EmptyResponses from '../../src/dashboard/components/empty-responses';
+import EmptySpamButton from '../../src/dashboard/components/empty-spam-button';
+import EmptyTrashButton from '../../src/dashboard/components/empty-trash-button';
+import ExportResponsesButton from '../../src/dashboard/components/export-responses/button';
 import Flag from '../../src/dashboard/components/flag';
 import Gravatar from '../../src/dashboard/components/gravatar';
 import Page from '../../src/dashboard/components/page';
@@ -1016,25 +1019,15 @@ function Stage() {
 		}
 
 		actionsArray.push(
-			<Button key="export" variant="primary" size="compact" icon={ download }>
-				{ __( 'Export', 'jetpack-forms' ) }
-			</Button>
+			<ExportResponsesButton key="export" isPrimary={ params.view === 'inbox' } />
 		);
 
 		if ( params.view === 'trash' ) {
-			actionsArray.push(
-				<Button key="empty-trash" variant="secondary" isDestructive size="compact">
-					{ __( 'Empty Trash', 'jetpack-forms' ) }
-				</Button>
-			);
+			actionsArray.push( <EmptyTrashButton key="empty-trash" /> );
 		}
 
 		if ( params.view === 'spam' ) {
-			actionsArray.push(
-				<Button key="empty-spam" variant="secondary" isDestructive size="compact">
-					{ __( 'Empty Spam', 'jetpack-forms' ) }
-				</Button>
-			);
+			actionsArray.push( <EmptySpamButton key="empty-spam" /> );
 		}
 
 		return actionsArray;

--- a/projects/packages/forms/src/dashboard/components/inbox-status-toggle/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/inbox-status-toggle/index.tsx
@@ -7,11 +7,11 @@ import { formatNumberCompact } from '@automattic/number-formatters';
 import { Badge } from '@automattic/ui';
 import { __, _x } from '@wordpress/i18n';
 import { useCallback } from 'react';
-import { useSearchParams } from 'react-router';
 /**
  * Internal dependencies
  */
 import useInboxData from '../../hooks/use-inbox-data.ts';
+import { useDashboardSearchParams } from '../../router/dashboard-search-params-context.tsx';
 import * as Tabs from '../tabs/index.ts';
 
 /**
@@ -41,7 +41,7 @@ type InboxStatusToggleProps = {
  * @return {JSX.Element} The status toggle component.
  */
 export default function InboxStatusToggle( { onChange }: InboxStatusToggleProps ): JSX.Element {
-	const [ searchParams, setSearchParams ] = useSearchParams();
+	const [ searchParams, setSearchParams ] = useDashboardSearchParams();
 	const status = searchParams.get( 'status' ) || 'inbox';
 	const [ isSm ] = useBreakpointMatch( 'sm' );
 

--- a/projects/packages/forms/src/dashboard/forms/views.ts
+++ b/projects/packages/forms/src/dashboard/forms/views.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from '@wordpress/element';
-import { useSearchParams } from 'react-router';
+import { useDashboardSearchParams } from '../router/dashboard-search-params-context.tsx';
 import type { View } from '@wordpress/dataviews/wp';
 
 const LAYOUT_TABLE = 'table';
@@ -23,7 +23,7 @@ export const defaultLayouts = {
  * @return {[typeof defaultView, (newView: typeof defaultView) => void]} The current DataViews view and a setter that updates the URL.
  */
 export function useView() {
-	const [ searchParams, setSearchParams ] = useSearchParams();
+	const [ searchParams, setSearchParams ] = useDashboardSearchParams();
 	const urlSearch = searchParams.get( 'search' );
 
 	const [ view, setView ] = useState( () => ( {

--- a/projects/packages/forms/src/dashboard/hooks/use-inbox-data.ts
+++ b/projects/packages/forms/src/dashboard/hooks/use-inbox-data.ts
@@ -44,7 +44,8 @@ const isEmpty = obj =>
 const formatFieldValue = fieldValue => {
 	if ( ! fieldValue || isEmpty( fieldValue ) ) {
 		return '-';
-	} else if ( Array.isArray( fieldValue ) ) {
+	}
+	if ( Array.isArray( fieldValue ) ) {
 		return fieldValue.join( ', ' );
 	}
 	return fieldValue;

--- a/projects/packages/forms/src/dashboard/hooks/use-inbox-data.ts
+++ b/projects/packages/forms/src/dashboard/hooks/use-inbox-data.ts
@@ -5,7 +5,6 @@ import { useEntityRecords, store as coreDataStore } from '@wordpress/core-data';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useMemo, useRef, useEffect, useState } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
-import { isEmpty } from 'lodash';
 /**
  * Internal dependencies
  */
@@ -37,6 +36,10 @@ const formatFieldName = fieldName => {
 	}
 	return fieldName;
 };
+
+// https://github.com/you-dont-need/You-Dont-Need-Lodash-Underscore?tab=readme-ov-file#_isempty
+const isEmpty = obj =>
+	[ Object, Array ].includes( ( obj || {} ).constructor ) && ! Object.entries( obj || {} ).length;
 
 const formatFieldValue = fieldValue => {
 	if ( isEmpty( fieldValue ) ) {

--- a/projects/packages/forms/src/dashboard/hooks/use-inbox-data.ts
+++ b/projects/packages/forms/src/dashboard/hooks/use-inbox-data.ts
@@ -42,7 +42,7 @@ const isEmpty = obj =>
 	[ Object, Array ].includes( ( obj || {} ).constructor ) && ! Object.entries( obj || {} ).length;
 
 const formatFieldValue = fieldValue => {
-	if ( isEmpty( fieldValue ) ) {
+	if ( ! fieldValue || isEmpty( fieldValue ) ) {
 		return '-';
 	} else if ( Array.isArray( fieldValue ) ) {
 		return fieldValue.join( ', ' );

--- a/projects/packages/forms/src/dashboard/hooks/use-inbox-data.ts
+++ b/projects/packages/forms/src/dashboard/hooks/use-inbox-data.ts
@@ -6,10 +6,10 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { useMemo, useRef, useEffect, useState } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
 import { isEmpty } from 'lodash';
-import { useSearchParams } from 'react-router';
 /**
  * Internal dependencies
  */
+import { useDashboardSearchParams } from '../router/dashboard-search-params-context.tsx';
 import { store as dashboardStore } from '../store/index.js';
 /**
  * Types
@@ -73,7 +73,7 @@ interface UseInboxDataReturn {
  * @return {UseInboxDataReturn} The inbox related data.
  */
 export default function useInboxData(): UseInboxDataReturn {
-	const [ searchParams ] = useSearchParams();
+	const [ searchParams ] = useDashboardSearchParams();
 	const { setCurrentQuery, setSelectedResponses } = useDispatch( dashboardStore );
 	const urlStatus = searchParams.get( 'status' );
 	const statusFilter = getStatusFilter( urlStatus );

--- a/projects/packages/forms/src/dashboard/inbox/stage/index.js
+++ b/projects/packages/forms/src/dashboard/inbox/stage/index.js
@@ -13,7 +13,7 @@ import { dateI18n, getSettings as getDateSettings } from '@wordpress/date';
 import { useCallback, useMemo, useState } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
 import { __ } from '@wordpress/i18n';
-import { Icon, globe } from '@wordpress/icons';
+import { download, Icon, globe } from '@wordpress/icons';
 import clsx from 'clsx';
 import { useEffect } from 'react';
 import { useSearchParams } from 'react-router';
@@ -26,7 +26,6 @@ import CreateFormButton from '../../components/create-form-button/index.tsx';
 import EmptyResponses from '../../components/empty-responses/index.tsx';
 import EmptySpamButton from '../../components/empty-spam-button/index.tsx';
 import EmptyTrashButton from '../../components/empty-trash-button/index.tsx';
-import ExportResponsesButton from '../../components/export-responses/button.tsx';
 import Flag from '../../components/flag/index.tsx';
 import FormsResponsesTabs from '../../components/forms-responses-tabs/index.tsx';
 import Gravatar from '../../components/gravatar/index.tsx';
@@ -512,7 +511,14 @@ export default function InboxView() {
 	const headerActions = useMemo( () => {
 		const exportIsPrimary = statusFilter !== 'trash' && statusFilter !== 'spam';
 		const headerActionsArray = [
-			<ExportResponsesButton key="export" isPrimary={ exportIsPrimary } />,
+			<Button
+				key="export"
+				variant={ exportIsPrimary ? 'primary' : 'secondary' }
+				size="compact"
+				icon={ download }
+			>
+				{ __( 'Export', 'jetpack-forms' ) }
+			</Button>,
 		];
 
 		if ( statusFilter === 'trash' ) {

--- a/projects/packages/forms/src/dashboard/inbox/stage/index.js
+++ b/projects/packages/forms/src/dashboard/inbox/stage/index.js
@@ -16,7 +16,6 @@ import { __ } from '@wordpress/i18n';
 import { Icon, globe } from '@wordpress/icons';
 import clsx from 'clsx';
 import { useEffect } from 'react';
-import { useSearchParams } from 'react-router';
 /**
  * Internal dependencies
  */
@@ -35,6 +34,7 @@ import { ResponseMobileView, SingleResponseView } from '../../components/inspect
 import IntegrationsButton from '../../components/integrations-button/index.tsx';
 import Page from '../../components/page/index.tsx';
 import useInboxData from '../../hooks/use-inbox-data.ts';
+import { useDashboardSearchParams } from '../../router/dashboard-search-params-context.tsx';
 import { getPath, getItemId } from '../utils.js';
 import {
 	viewAction,
@@ -87,7 +87,7 @@ const setupSidebarWidthObserver = () => {
  */
 export default function InboxView() {
 	const [ view, setView ] = useView();
-	const [ searchParams, setSearchParams ] = useSearchParams();
+	const [ searchParams, setSearchParams ] = useDashboardSearchParams();
 	const [ containerWidth, setContainerWidth ] = useState( 0 );
 
 	const dateSettings = getDateSettings();

--- a/projects/packages/forms/src/dashboard/inbox/stage/index.js
+++ b/projects/packages/forms/src/dashboard/inbox/stage/index.js
@@ -13,7 +13,7 @@ import { dateI18n, getSettings as getDateSettings } from '@wordpress/date';
 import { useCallback, useMemo, useState } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
 import { __ } from '@wordpress/i18n';
-import { download, Icon, globe } from '@wordpress/icons';
+import { Icon, globe } from '@wordpress/icons';
 import clsx from 'clsx';
 import { useEffect } from 'react';
 import { useSearchParams } from 'react-router';
@@ -26,6 +26,7 @@ import CreateFormButton from '../../components/create-form-button/index.tsx';
 import EmptyResponses from '../../components/empty-responses/index.tsx';
 import EmptySpamButton from '../../components/empty-spam-button/index.tsx';
 import EmptyTrashButton from '../../components/empty-trash-button/index.tsx';
+import ExportResponsesButton from '../../components/export-responses/button.tsx';
 import Flag from '../../components/flag/index.tsx';
 import FormsResponsesTabs from '../../components/forms-responses-tabs/index.tsx';
 import Gravatar from '../../components/gravatar/index.tsx';
@@ -511,14 +512,7 @@ export default function InboxView() {
 	const headerActions = useMemo( () => {
 		const exportIsPrimary = statusFilter !== 'trash' && statusFilter !== 'spam';
 		const headerActionsArray = [
-			<Button
-				key="export"
-				variant={ exportIsPrimary ? 'primary' : 'secondary' }
-				size="compact"
-				icon={ download }
-			>
-				{ __( 'Export', 'jetpack-forms' ) }
-			</Button>,
+			<ExportResponsesButton key="export" isPrimary={ exportIsPrimary } />,
 		];
 
 		if ( statusFilter === 'trash' ) {

--- a/projects/packages/forms/src/dashboard/inbox/stage/views.js
+++ b/projects/packages/forms/src/dashboard/inbox/stage/views.js
@@ -3,7 +3,7 @@
  */
 import { useEvent } from '@wordpress/compose';
 import { useEffect, useState } from '@wordpress/element';
-import { useSearchParams } from 'react-router';
+import { useDashboardSearchParams } from '../../router/dashboard-search-params-context.tsx';
 
 const LAYOUT_TABLE = 'table';
 
@@ -30,7 +30,7 @@ export const defaultLayouts = {
  * @return {Array} The [ state, setState ] tuple.
  */
 export function useView() {
-	const [ searchParams, setSearchParams ] = useSearchParams();
+	const [ searchParams, setSearchParams ] = useDashboardSearchParams();
 	// Normalize missing query param to empty string so we don't treat
 	// `null` (missing) and `''` (empty) as different values.
 	const urlSearch = searchParams.get( 'search' ) ?? '';

--- a/projects/packages/forms/src/dashboard/index.tsx
+++ b/projects/packages/forms/src/dashboard/index.tsx
@@ -13,6 +13,7 @@ import Layout from './components/layout/index.tsx';
 import FormsDashboardForms from './forms/index.tsx';
 import Inbox from './inbox/index.js';
 import DashboardNotices from './notices-list.tsx';
+import ReactRouterDashboardSearchParamsProvider from './router/react-router-dashboard-search-params-provider.tsx';
 import './style.scss';
 
 declare global {
@@ -48,10 +49,16 @@ function initFormsDashboard() {
 		return null;
 	};
 
+	const DashboardRoot = () => (
+		<ReactRouterDashboardSearchParamsProvider>
+			<Layout />
+		</ReactRouterDashboardSearchParamsProvider>
+	);
+
 	const router = createHashRouter( [
 		{
 			path: '/',
-			element: <Layout />,
+			element: <DashboardRoot />,
 			children: [
 				{
 					index: true,

--- a/projects/packages/forms/src/dashboard/router/dashboard-search-params-context.tsx
+++ b/projects/packages/forms/src/dashboard/router/dashboard-search-params-context.tsx
@@ -1,0 +1,53 @@
+/**
+ * External dependencies
+ */
+import { createContext, useContext } from '@wordpress/element';
+/**
+ * Types
+ */
+import type { PropsWithChildren } from 'react';
+
+export type SetDashboardSearchParams = (
+	next: URLSearchParams | ( ( prev: URLSearchParams ) => URLSearchParams )
+) => void;
+
+export type DashboardSearchParamsTuple = readonly [ URLSearchParams, SetDashboardSearchParams ];
+
+const DashboardSearchParamsContext = createContext< DashboardSearchParamsTuple | null >( null );
+
+/**
+ * Dashboard search params provider.
+ *
+ * @param props          - Props.
+ * @param props.value    - Dashboard search params tuple.
+ * @param props.children - React children.
+ * @return               - JSX element.
+ */
+export function DashboardSearchParamsProvider( {
+	value,
+	children,
+}: PropsWithChildren< { value: DashboardSearchParamsTuple } > ): JSX.Element {
+	return (
+		<DashboardSearchParamsContext.Provider value={ value }>
+			{ children }
+		</DashboardSearchParamsContext.Provider>
+	);
+}
+
+/**
+ * Hook to get the dashboard search params.
+ *
+ * @return - Dashboard search params tuple.
+ * @throws {Error} If the hook is used outside of a DashboardSearchParamsProvider.
+ */
+export function useDashboardSearchParams(): DashboardSearchParamsTuple {
+	const ctx = useContext( DashboardSearchParamsContext );
+
+	if ( ! ctx ) {
+		throw new Error(
+			'useDashboardSearchParams must be used within a DashboardSearchParamsProvider.'
+		);
+	}
+
+	return ctx;
+}

--- a/projects/packages/forms/src/dashboard/router/react-router-dashboard-search-params-provider.tsx
+++ b/projects/packages/forms/src/dashboard/router/react-router-dashboard-search-params-provider.tsx
@@ -1,0 +1,41 @@
+/**
+ * External dependencies
+ */
+import { useMemo } from '@wordpress/element';
+import { useSearchParams as useReactRouterSearchParams } from 'react-router';
+/**
+ * Internal dependencies
+ */
+import {
+	DashboardSearchParamsProvider,
+	type DashboardSearchParamsTuple,
+	type SetDashboardSearchParams,
+} from './dashboard-search-params-context';
+/**
+ * Types
+ */
+import type { PropsWithChildren } from 'react';
+
+/**
+ * React Router implementation of the dashboard search params provider.
+ *
+ * @param props          - Props.
+ * @param props.children - Children.
+ * @return               - JSX element.
+ */
+export default function ReactRouterDashboardSearchParamsProvider( {
+	children,
+}: PropsWithChildren ): JSX.Element {
+	const [ searchParams, setReactRouterSearchParams ] = useReactRouterSearchParams();
+
+	const setSearchParams = setReactRouterSearchParams as unknown as SetDashboardSearchParams;
+
+	const value = useMemo(
+		() => [ searchParams, setSearchParams ] as DashboardSearchParamsTuple,
+		[ searchParams, setSearchParams ]
+	);
+
+	return (
+		<DashboardSearchParamsProvider value={ value }>{ children }</DashboardSearchParamsProvider>
+	);
+}

--- a/projects/packages/forms/src/dashboard/router/wp-route-dashboard-search-params-provider.tsx
+++ b/projects/packages/forms/src/dashboard/router/wp-route-dashboard-search-params-provider.tsx
@@ -1,0 +1,155 @@
+/**
+ * External dependencies
+ */
+import { useCallback, useMemo } from '@wordpress/element';
+import { useSearch, useNavigate } from '@wordpress/route';
+/**
+ * Internal dependencies
+ */
+import {
+	DashboardSearchParamsProvider,
+	type DashboardSearchParamsTuple,
+	type SetDashboardSearchParams,
+} from './dashboard-search-params-context';
+/**
+ * Types
+ */
+import type { PropsWithChildren } from 'react';
+
+type Props = PropsWithChildren< {
+	/**
+	 * Route id to bind `useSearch` / `useNavigate` to.
+	 *
+	 * Required because ciab-admin doesn't provide a
+	 * "nearest match" for `useSearch()` to infer.
+	 */
+	from: string;
+} >;
+
+/**
+ * Convert `@wordpress/route` `search` record shape into `URLSearchParams`.
+ *
+ * @param search - Search record to convert.
+ * @return       - URL search params.
+ */
+function searchRecordToUrlSearchParams( search: Record< string, unknown > ): URLSearchParams {
+	const params = new URLSearchParams();
+
+	for ( const [ key, value ] of Object.entries( search || {} ) ) {
+		if ( value === undefined || value === null ) {
+			continue;
+		}
+
+		if ( Array.isArray( value ) ) {
+			for ( const v of value ) {
+				if ( v === undefined || v === null ) {
+					continue;
+				}
+
+				params.append( key, String( v ) );
+			}
+
+			continue;
+		}
+
+		params.set( key, String( value ) );
+	}
+
+	return params;
+}
+
+/**
+ * Convert `URLSearchParams` into the router `search` record shape.
+ *
+ * Note: some keys (e.g. `responseIds`) are treated as arrays even when only one value is present.
+ *
+ * @param params            - URL search params to convert.
+ * @param options           - Options.
+ * @param options.arrayKeys - Keys that should always be represented as arrays.
+ * @return                  - Record suitable for `@wordpress/route` `search`.
+ */
+function urlSearchParamsToSearchRecord(
+	params: URLSearchParams,
+	options: {
+		/**
+		 * Keys that should always be represented as arrays.
+		 * For example: `responseIds` is treated as `string[]` by routes that use selection.
+		 */
+		arrayKeys?: ReadonlySet< string >;
+	} = {}
+): Record< string, string | string[] > {
+	const { arrayKeys = new Set< string >() } = options;
+	const out: Record< string, string | string[] > = {};
+
+	for ( const key of params.keys() ) {
+		const values = params.getAll( key );
+
+		if ( values.length < 1 ) {
+			continue;
+		}
+
+		if ( arrayKeys.has( key ) ) {
+			out[ key ] = values;
+			continue;
+		}
+
+		// For non-array keys, always coerce to a scalar string.
+		// If multiple values exist for a key, preserve the last one.
+		out[ key ] = values[ values.length - 1 ];
+	}
+
+	return out;
+}
+
+/**
+ * Provider for the dashboard search params.
+ *
+ * @param props          - Props.
+ * @param props.from     - Route id to bind `useSearch` / `useNavigate` to.
+ * @param props.children - Children.
+ * @return               - JSX element.
+ */
+export default function WpRouteDashboardSearchParamsProvider( {
+	from,
+	children,
+}: Props ): JSX.Element {
+	// `useSearch()` re-renders when the router search changes. We'll adapt it to URLSearchParams
+	// so shared dashboard code can keep using the URLSearchParams API.
+	const search = useSearch( {
+		// In this build, the router type isn't registered, so `@wordpress/route` models `from` as `never`.
+		// We still want to pass the runtime route id through.
+		from: from as unknown as never,
+		strict: false,
+	} );
+	const navigate = useNavigate();
+	const searchParams = useMemo( () => searchRecordToUrlSearchParams( search ), [ search ] );
+
+	const setSearchParams: SetDashboardSearchParams = useCallback(
+		next => {
+			const resolved = typeof next === 'function' ? next( searchParams ) : next;
+			const nextSearch = urlSearchParamsToSearchRecord( resolved, {
+				arrayKeys: new Set( [ 'responseIds' ] ),
+			} );
+
+			type NavigateArg = Parameters< typeof navigate >[ 0 ];
+			type SearchOption = NavigateArg extends { search?: infer S } ? S : never;
+			type SearchReducer = Exclude< SearchOption, true | undefined >;
+
+			// In `@wordpress/route`, `search` is modeled as a reducer function, but without a registered
+			// router type it ends up as a very "loose" signature. We still pass a fully-formed object.
+			const replaceSearch = ( () => nextSearch ) as unknown as SearchReducer;
+
+			navigate( { search: replaceSearch } );
+		},
+		[ navigate, searchParams ]
+	);
+
+	const value = useMemo(
+		() => [ searchParams, setSearchParams ] as DashboardSearchParamsTuple,
+		[ searchParams, setSearchParams ]
+	);
+
+	return (
+		<DashboardSearchParamsProvider value={ value }>{ children }</DashboardSearchParamsProvider>
+	);
+}

--- a/projects/packages/forms/tests/js/dashboard/components/empty-spam-button/index.test.jsx
+++ b/projects/packages/forms/tests/js/dashboard/components/empty-spam-button/index.test.jsx
@@ -150,10 +150,19 @@ const EmptySpamButtonModule = await import(
 );
 const EmptySpamButton = EmptySpamButtonModule.default;
 
+const DashboardSearchParamsModule = await import(
+	'../../../../../src/dashboard/router/dashboard-search-params-context'
+);
+const { DashboardSearchParamsProvider } = DashboardSearchParamsModule;
+
 describe( 'EmptySpamButton', () => {
+	const mockSetSearchParams = jest.fn();
+	const mockSearchParams = new URLSearchParams( 'status=spam' );
+
 	beforeEach( async () => {
 		// Reset all mocks before each test
 		jest.clearAllMocks();
+		mockSetSearchParams.mockClear();
 		const coreDataModule = await import( '@wordpress/core-data' );
 		coreDataModule.useEntityRecords.mockReturnValue( {
 			totalItems: 1,
@@ -161,8 +170,16 @@ describe( 'EmptySpamButton', () => {
 		} );
 	} );
 
+	const renderWithProvider = ( component ) => {
+		return render(
+			<DashboardSearchParamsProvider value={ [ mockSearchParams, mockSetSearchParams ] }>
+				{ component }
+			</DashboardSearchParamsProvider>
+		);
+	};
+
 	it( 'renders correctly', () => {
-		render( <EmptySpamButton totalItemsSpam={ 1 } isLoadingCounts={ false } /> );
+		renderWithProvider( <EmptySpamButton totalItemsSpam={ 1 } isLoadingCounts={ false } /> );
 
 		const button = screen.getByText( 'Delete spam' );
 		expect( button ).toBeInTheDocument();
@@ -171,7 +188,7 @@ describe( 'EmptySpamButton', () => {
 	} );
 
 	it( 'shows disabled state when trash is empty', () => {
-		render( <EmptySpamButton totalItemsSpam={ 0 } isLoadingCounts={ false } /> );
+		renderWithProvider( <EmptySpamButton totalItemsSpam={ 0 } isLoadingCounts={ false } /> );
 
 		const button = screen.getByText( 'Delete spam' );
 		expect( button ).toBeDisabled();
@@ -179,7 +196,7 @@ describe( 'EmptySpamButton', () => {
 	} );
 
 	it( 'shows confirmation dialog when clicked', async () => {
-		render( <EmptySpamButton totalItemsSpam={ 1 } isLoadingCounts={ false } /> );
+		renderWithProvider( <EmptySpamButton totalItemsSpam={ 1 } isLoadingCounts={ false } /> );
 
 		const button = screen.getByText( 'Delete spam' );
 		await userEvent.click( button );
@@ -194,7 +211,7 @@ describe( 'EmptySpamButton', () => {
 		const { useDispatch } = await import( '@wordpress/data' );
 		const mockDispatch = useDispatch( 'notices' );
 
-		render( <EmptySpamButton totalItemsSpam={ 1 } isLoadingCounts={ false } /> );
+		renderWithProvider( <EmptySpamButton totalItemsSpam={ 1 } isLoadingCounts={ false } /> );
 
 		// Click empty trash button
 		const button = screen.getByText( 'Delete spam' );

--- a/projects/packages/forms/tests/js/dashboard/components/empty-spam-button/index.test.jsx
+++ b/projects/packages/forms/tests/js/dashboard/components/empty-spam-button/index.test.jsx
@@ -170,7 +170,7 @@ describe( 'EmptySpamButton', () => {
 		} );
 	} );
 
-	const renderWithProvider = ( component ) => {
+	const renderWithProvider = component => {
 		return render(
 			<DashboardSearchParamsProvider value={ [ mockSearchParams, mockSetSearchParams ] }>
 				{ component }

--- a/projects/packages/forms/tests/js/dashboard/components/empty-trash-button/index.test.jsx
+++ b/projects/packages/forms/tests/js/dashboard/components/empty-trash-button/index.test.jsx
@@ -150,10 +150,19 @@ const EmptyTrashButtonModule = await import(
 );
 const EmptyTrashButton = EmptyTrashButtonModule.default;
 
+const DashboardSearchParamsModule = await import(
+	'../../../../../src/dashboard/router/dashboard-search-params-context'
+);
+const { DashboardSearchParamsProvider } = DashboardSearchParamsModule;
+
 describe( 'EmptyTrashButton', () => {
+	const mockSetSearchParams = jest.fn();
+	const mockSearchParams = new URLSearchParams();
+
 	beforeEach( async () => {
 		// Reset all mocks before each test
 		jest.clearAllMocks();
+		mockSetSearchParams.mockClear();
 		const coreDataModule = await import( '@wordpress/core-data' );
 		coreDataModule.useEntityRecords.mockReturnValue( {
 			totalItems: 1,
@@ -161,8 +170,16 @@ describe( 'EmptyTrashButton', () => {
 		} );
 	} );
 
+	const renderWithProvider = ( component ) => {
+		return render(
+			<DashboardSearchParamsProvider value={ [ mockSearchParams, mockSetSearchParams ] }>
+				{ component }
+			</DashboardSearchParamsProvider>
+		);
+	};
+
 	it( 'renders correctly', () => {
-		render( <EmptyTrashButton totalItemsTrash={ 1 } isLoadingCounts={ false } /> );
+		renderWithProvider( <EmptyTrashButton totalItemsTrash={ 1 } isLoadingCounts={ false } /> );
 
 		const button = screen.getByText( 'Empty trash' );
 		expect( button ).toBeInTheDocument();
@@ -171,7 +188,7 @@ describe( 'EmptyTrashButton', () => {
 	} );
 
 	it( 'shows disabled state when trash is empty', () => {
-		render( <EmptyTrashButton totalItemsTrash={ 0 } isLoadingCounts={ false } /> );
+		renderWithProvider( <EmptyTrashButton totalItemsTrash={ 0 } isLoadingCounts={ false } /> );
 
 		const button = screen.getByText( 'Empty trash' );
 		expect( button ).toBeDisabled();
@@ -179,7 +196,7 @@ describe( 'EmptyTrashButton', () => {
 	} );
 
 	it( 'shows confirmation dialog when clicked', async () => {
-		render( <EmptyTrashButton totalItemsTrash={ 1 } isLoadingCounts={ false } /> );
+		renderWithProvider( <EmptyTrashButton totalItemsTrash={ 1 } isLoadingCounts={ false } /> );
 
 		const button = screen.getByText( 'Empty trash' );
 		await userEvent.click( button );
@@ -194,7 +211,7 @@ describe( 'EmptyTrashButton', () => {
 		const { useDispatch } = await import( '@wordpress/data' );
 		const mockDispatch = useDispatch( 'notices' );
 
-		render( <EmptyTrashButton totalItemsTrash={ 1 } isLoadingCounts={ false } /> );
+		renderWithProvider( <EmptyTrashButton totalItemsTrash={ 1 } isLoadingCounts={ false } /> );
 
 		// Click empty trash button
 		const button = screen.getByText( 'Empty trash' );

--- a/projects/packages/forms/tests/js/dashboard/components/empty-trash-button/index.test.jsx
+++ b/projects/packages/forms/tests/js/dashboard/components/empty-trash-button/index.test.jsx
@@ -170,7 +170,7 @@ describe( 'EmptyTrashButton', () => {
 		} );
 	} );
 
-	const renderWithProvider = ( component ) => {
+	const renderWithProvider = component => {
 		return render(
 			<DashboardSearchParamsProvider value={ [ mockSearchParams, mockSetSearchParams ] }>
 				{ component }

--- a/projects/packages/forms/tests/js/dashboard/components/empty-trash-button/index.test.jsx
+++ b/projects/packages/forms/tests/js/dashboard/components/empty-trash-button/index.test.jsx
@@ -157,7 +157,7 @@ const { DashboardSearchParamsProvider } = DashboardSearchParamsModule;
 
 describe( 'EmptyTrashButton', () => {
 	const mockSetSearchParams = jest.fn();
-	const mockSearchParams = new URLSearchParams();
+	const mockSearchParams = new URLSearchParams( 'status=trash' );
 
 	beforeEach( async () => {
 		// Reset all mocks before each test


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Follow-up to FORMS-442

Alternative to https://github.com/Automattic/jetpack/pull/46687

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Use actual components for WP build dash
* Issue with just using components is that EmptySpamButton uses useInboxData, that in turn uses useSearchParams, that is a hook from React Router, which wp-build does not use. Fix is to use contexts to determine which router functions should be used.
* There was issue with `import_lodash.isEmpty is not a function` showing up on tab switching, and that we're fixing simply by not using lodash, which is anyway good change for loading performance.

Slack convo about fix p1768928713328179-slack-C052XEUUBL4



### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Test new and old dashboards, as well as CIAB. Check that there are no regressions.