### PR TITLE
Social: Wire up media customization per network.

### DIFF
--- a/projects/packages/publicize/_inc/components/customize-and-preview/customization-forms/per-network.tsx
+++ b/projects/packages/publicize/_inc/components/customize-and-preview/customization-forms/per-network.tsx
@@ -4,8 +4,7 @@ import { useCallback } from 'react';
 import { usePostMeta } from '../../../hooks/use-post-meta';
 import { store as socialStore } from '../../../social-store';
 import { Connection } from '../../../social-store/types';
-import { AttachedMedia } from '../../../utils';
-import { SharePostForm } from '../../form/share-post-form';
+import { SharePostForm, SharePostFormProps } from '../../form/share-post-form';
 import { ConnectionToggle } from '../connection-toggle';
 
 type PerNetworkCustomizationFormProps = {
@@ -20,10 +19,15 @@ type PerNetworkCustomizationFormProps = {
  */
 export function PerNetworkCustomizationForm( { connection }: PerNetworkCustomizationFormProps ) {
 	const { customizeConnectionById } = useDispatch( socialStore );
-	const { attachedMedia: globalAttachedMedia, shareMessage: globalMessage } = usePostMeta();
+	const {
+		attachedMedia: globalAttachedMedia,
+		shareMessage: globalMessage,
+		mediaSource: globalMediaSource,
+	} = usePostMeta();
 
 	const message = connection.message ?? globalMessage ?? '';
 	const attachedMedia = connection.attached_media ?? globalAttachedMedia ?? [];
+	const mediaSource = connection.media_source ?? globalMediaSource ?? 'none';
 
 	// Handler for message changes
 	const handleMessageChange = useCallback(
@@ -34,10 +38,11 @@ export function PerNetworkCustomizationForm( { connection }: PerNetworkCustomiza
 	);
 
 	// Handler for media changes - only stores attached_media in the override
-	const handleMediaChange = useCallback(
-		( updates: { attached_media?: Array< AttachedMedia > } ) => {
+	const handleMediaChange = useCallback< SharePostFormProps[ 'onMediaChange' ] >(
+		updates => {
 			customizeConnectionById( connection.connection_id, {
 				attached_media: updates.attached_media,
+				media_source: updates.media_source,
 			} );
 		},
 		[ connection.connection_id, customizeConnectionById ]
@@ -54,6 +59,8 @@ export function PerNetworkCustomizationForm( { connection }: PerNetworkCustomiza
 				onMessageChange={ handleMessageChange }
 				attachedMedia={ attachedMedia }
 				onMediaChange={ handleMediaChange }
+				mediaSource={ mediaSource }
+				forceMediaAsAttachment
 			/>
 		</Flex>
 	);

--- a/projects/packages/publicize/_inc/components/form/share-post-form.tsx
+++ b/projects/packages/publicize/_inc/components/form/share-post-form.tsx
@@ -70,6 +70,11 @@ export type SharePostFormProps = {
 	 * Whether the form is disabled.
 	 */
 	disabled?: boolean;
+
+	/**
+	 * Whether to force media as attachment.
+	 */
+	forceMediaAsAttachment?: boolean;
 };
 
 /**
@@ -88,6 +93,7 @@ export const SharePostForm: FC< SharePostFormProps > = ( {
 	mediaSource,
 	onMediaChange,
 	disabled = false,
+	forceMediaAsAttachment,
 } ) => {
 	const {
 		message: storeMessage,
@@ -148,6 +154,7 @@ export const SharePostForm: FC< SharePostFormProps > = ( {
 									imageGeneratorSettings,
 									mediaSource,
 									onMediaChange,
+									forceAsAttachment: forceMediaAsAttachment,
 								} ) }
 							/>
 						) }

--- a/projects/packages/publicize/_inc/components/media-section-v2/index.tsx
+++ b/projects/packages/publicize/_inc/components/media-section-v2/index.tsx
@@ -317,7 +317,7 @@ export default function MediaSectionV2( {
 								source={ currentSource }
 								checked={ isShareAsAttachment }
 								onChange={ handleAttachmentToggle }
-								disabled={ forceAsAttachment ?? disabled }
+								disabled={ forceAsAttachment || disabled }
 							/>
 						</>
 					) }

--- a/projects/packages/publicize/_inc/components/media-section-v2/index.tsx
+++ b/projects/packages/publicize/_inc/components/media-section-v2/index.tsx
@@ -28,7 +28,7 @@ import { getMediaSourceDescription } from './utils/media-source-options';
  * MediaSectionV2 component
  *
  * @param {MediaSectionV2Props} props - Component props
- * @return {JSX.Element} MediaSectionV2 component
+ * @return MediaSectionV2 component
  */
 export default function MediaSectionV2( {
 	analyticsData = {},
@@ -38,6 +38,7 @@ export default function MediaSectionV2( {
 	imageGeneratorSettings: imageGeneratorSettingsProp,
 	mediaSource: mediaSourceProp,
 	onMediaChange,
+	forceAsAttachment,
 }: MediaSectionV2Props ) {
 	const { recordEvent } = useAnalytics();
 	const featuredImageId = useFeaturedImage();
@@ -74,7 +75,9 @@ export default function MediaSectionV2( {
 	);
 
 	// Get SIG preview URL when SIG is enabled
-	const { url: sigPreviewUrl, isLoading: sigIsLoading } = useSigPreview( sigEnabled );
+	const { url: sigPreviewUrl, isLoading: sigIsLoading } = useSigPreview(
+		sigEnabled || mediaSource === 'sig'
+	);
 
 	// Ref to store the MediaUpload open function
 	const openMediaLibraryRef = useRef< () => void >( () => {} );
@@ -93,7 +96,7 @@ export default function MediaSectionV2( {
 	}, [ mediaSource, attachedMedia, featuredImageId, sigEnabled ] );
 
 	// Attachment mode: check if attached_media has items (matches backend is_social_post())
-	const isShareAsAttachment = attachedMedia?.length > 0;
+	const isShareAsAttachment = forceAsAttachment || attachedMedia?.length > 0;
 
 	// Get media ID for preview
 	const mediaId = useMemo( () => {
@@ -314,7 +317,7 @@ export default function MediaSectionV2( {
 								source={ currentSource }
 								checked={ isShareAsAttachment }
 								onChange={ handleAttachmentToggle }
-								disabled={ disabled }
+								disabled={ forceAsAttachment ?? disabled }
 							/>
 						</>
 					) }

--- a/projects/packages/publicize/_inc/components/media-section-v2/index.tsx
+++ b/projects/packages/publicize/_inc/components/media-section-v2/index.tsx
@@ -95,7 +95,9 @@ export default function MediaSectionV2( {
 		return detectMediaSource( attachedMedia, featuredImageId, sigEnabled );
 	}, [ mediaSource, attachedMedia, featuredImageId, sigEnabled ] );
 
-	// Attachment mode: check if attached_media has items (matches backend is_social_post())
+	// Attachment mode:
+	// - When attachedMedia has items, this reflects the backend behavior (attached_media is set).
+	// - When forceAsAttachment is true, attachment mode is forced on at the UI level, even if attachedMedia is empty.
 	const isShareAsAttachment = forceAsAttachment || attachedMedia?.length > 0;
 
 	// Get media ID for preview

--- a/projects/packages/publicize/_inc/components/media-section-v2/types.ts
+++ b/projects/packages/publicize/_inc/components/media-section-v2/types.ts
@@ -93,6 +93,11 @@ export interface MediaSectionV2Props {
 	 * operates in "controlled" mode and uses the media props above instead of fetching from the store.
 	 */
 	onMediaChange?: ( updates: Partial< JetpackSocialOptions > ) => void;
+
+	/**
+	 * Whether to force media as attachment.
+	 */
+	forceAsAttachment?: boolean;
 }
 
 /**

--- a/projects/packages/publicize/_inc/components/social-post-modal/post-preview.tsx
+++ b/projects/packages/publicize/_inc/components/social-post-modal/post-preview.tsx
@@ -14,8 +14,7 @@ import { useSelect } from '@wordpress/data';
 import { useMemo } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
 import { __ } from '@wordpress/i18n';
-import useSocialMediaMessage from '../../hooks/use-social-media-message';
-import { useSocialPreviewPostData } from '../../hooks/use-social-preview-post-data';
+import { useConnectionPreviewData } from '../../hooks/use-connection-preview-data';
 import { Connection } from '../../social-store/types';
 import { InstagramNoMediaNotice } from '../form/instagram-no-media-notice';
 
@@ -42,7 +41,7 @@ function getCombinedText( title: string, excerpt: string ): string {
  *
  * @param {PostPreviewProps} props - PostPreview component props.
  *
- * @return {import('react').ReactNode} - Post preview component.
+ * @return - Post preview component.
  */
 export function PostPreview( { connection }: PostPreviewProps ) {
 	const user = useMemo(
@@ -54,8 +53,8 @@ export function PostPreview( { connection }: PostPreviewProps ) {
 		[ connection ]
 	);
 
-	const { image, media, title, description, url, excerpt } = useSocialPreviewPostData();
-	const message = ( useSocialMediaMessage().message || '' ).trim();
+	const { image, media, title, description, url, excerpt, message } =
+		useConnectionPreviewData( connection );
 
 	const commonProps = useMemo(
 		() => ( {

--- a/projects/packages/publicize/_inc/hooks/use-connection-preview-data/index.ts
+++ b/projects/packages/publicize/_inc/hooks/use-connection-preview-data/index.ts
@@ -72,7 +72,7 @@ export function useConnectionPreviewData( connection: Connection ) {
 
 		return {
 			...postData,
-			message: connection.message?.trim(),
+			message: ( connection.message ?? globalMessage ).trim(),
 			media,
 		};
 	}, [

--- a/projects/packages/publicize/_inc/hooks/use-connection-preview-data/index.ts
+++ b/projects/packages/publicize/_inc/hooks/use-connection-preview-data/index.ts
@@ -45,11 +45,11 @@ export function useConnectionPreviewData( connection: Connection ) {
 
 		switch ( connection.media_source ) {
 			case 'featured-image':
-				media = featuredImageDetails
+				media = featuredImageDetails?.mediaData?.sourceUrl
 					? [
 							{
-								url: featuredImageDetails.mediaData?.sourceUrl,
-								type: featuredImageDetails.metaData?.mime ?? 'image/jpeg',
+								url: featuredImageDetails.mediaData.sourceUrl,
+								type: featuredImageDetails.metaData.mime ?? 'image/jpeg',
 							},
 					  ]
 					: [];

--- a/projects/packages/publicize/_inc/hooks/use-connection-preview-data/index.ts
+++ b/projects/packages/publicize/_inc/hooks/use-connection-preview-data/index.ts
@@ -1,0 +1,86 @@
+import { siteHasFeature } from '@automattic/jetpack-script-data';
+import { useSelect } from '@wordpress/data';
+import { store as editorStore } from '@wordpress/editor';
+import { useMemo } from 'react';
+import { Connection } from '../../social-store/types';
+import { features } from '../../utils';
+import useMediaDetails from '../use-media-details';
+import { usePerNetworkCustomization } from '../use-per-network-customization';
+import useSigPreview from '../use-sig-preview';
+import useSocialMediaMessage from '../use-social-media-message';
+import { useSocialPreviewPostData } from '../use-social-preview-post-data';
+import { PostData } from '../use-social-preview-post-data/types';
+
+/**
+ * Returns the post data needed for the preview of a specific connection.
+ *
+ * @param {Connection} connection - The connection.
+ * @return The post data.
+ */
+export function useConnectionPreviewData( connection: Connection ) {
+	const { isEnabled: usingPerNetworkCustomization } = usePerNetworkCustomization();
+
+	const postData = useSocialPreviewPostData();
+	const { message: globalMessage } = useSocialMediaMessage();
+	const featuredImageId = useSelect( select =>
+		select( editorStore ).getEditedPostAttribute( 'featured_media' )
+	);
+	const [ featuredImageDetails ] = useMediaDetails( featuredImageId );
+
+	// Generate SIG preview only if site has the feature and connection is set to use SIG.
+	const generateSigPreview =
+		siteHasFeature( features.IMAGE_GENERATOR ) && connection.media_source === 'sig';
+
+	const sig = useSigPreview( generateSigPreview );
+
+	return useMemo( () => {
+		if ( ! siteHasFeature( features.ENHANCED_PUBLISHING ) || ! usingPerNetworkCustomization ) {
+			return {
+				...postData,
+				message: globalMessage.trim(),
+			};
+		}
+
+		let media: PostData[ 'media' ] = connection.attached_media || [];
+
+		switch ( connection.media_source ) {
+			case 'featured-image':
+				media = featuredImageDetails
+					? [
+							{
+								url: featuredImageDetails.mediaData?.sourceUrl,
+								type: featuredImageDetails.metaData?.mime ?? 'image/jpeg',
+							},
+					  ]
+					: [];
+				break;
+			case 'sig':
+				media = sig.url
+					? [
+							{
+								url: sig.url,
+								type: 'image/png',
+							},
+					  ]
+					: [];
+				break;
+
+			case 'none':
+				media = [];
+				break;
+		}
+
+		return {
+			...postData,
+			message: globalMessage.trim(),
+			media,
+		};
+	}, [
+		connection,
+		featuredImageDetails,
+		globalMessage,
+		postData,
+		sig.url,
+		usingPerNetworkCustomization,
+	] );
+}

--- a/projects/packages/publicize/_inc/hooks/use-connection-preview-data/index.ts
+++ b/projects/packages/publicize/_inc/hooks/use-connection-preview-data/index.ts
@@ -72,7 +72,7 @@ export function useConnectionPreviewData( connection: Connection ) {
 
 		return {
 			...postData,
-			message: globalMessage.trim(),
+			message: connection.message?.trim(),
 			media,
 		};
 	}, [

--- a/projects/packages/publicize/_inc/hooks/use-connection-preview-data/test/index.test.ts
+++ b/projects/packages/publicize/_inc/hooks/use-connection-preview-data/test/index.test.ts
@@ -1,0 +1,243 @@
+/* eslint-disable import/order */
+// Setup mock script data BEFORE any other imports that might use it
+import { clearMockedScriptData, mockScriptData } from '../../../utils/test-utils';
+
+mockScriptData();
+
+jest.mock( '@automattic/jetpack-script-data', () => {
+	const actual = jest.requireActual( '@automattic/jetpack-script-data' );
+	return {
+		...actual,
+		siteHasFeature: jest.fn(),
+	};
+} );
+
+jest.mock( '@wordpress/data', () => {
+	const actual = jest.requireActual( '@wordpress/data' );
+	const mocks = {
+		useSelect: jest.fn(),
+	};
+	return new Proxy( actual, {
+		get( target, property ) {
+			return mocks[ property as keyof typeof mocks ] ?? target[ property as keyof typeof target ];
+		},
+	} );
+} );
+
+jest.mock( '../../use-per-network-customization', () => ( {
+	usePerNetworkCustomization: jest.fn(),
+} ) );
+
+jest.mock( '../../use-social-media-message', () => ( {
+	__esModule: true,
+	default: jest.fn(),
+} ) );
+
+jest.mock( '../../use-social-preview-post-data', () => ( {
+	useSocialPreviewPostData: jest.fn(),
+} ) );
+
+jest.mock( '../../use-media-details', () => ( {
+	__esModule: true,
+	default: jest.fn(),
+} ) );
+
+jest.mock( '../../use-sig-preview', () => ( {
+	__esModule: true,
+	default: jest.fn(),
+} ) );
+
+import { renderHook } from '@testing-library/react';
+import { useSelect } from '@wordpress/data';
+import { useConnectionPreviewData } from '../';
+import useMediaDetails from '../../use-media-details';
+import { usePerNetworkCustomization } from '../../use-per-network-customization';
+import useSigPreview from '../../use-sig-preview';
+import useSocialMediaMessage from '../../use-social-media-message';
+import { useSocialPreviewPostData } from '../../use-social-preview-post-data';
+import type { Connection } from '../../../social-store/types';
+
+const mockSiteHasFeature = jest.requireMock( '@automattic/jetpack-script-data' )
+	.siteHasFeature as jest.Mock;
+const mockUseSelect = useSelect as jest.MockedFunction< typeof useSelect >;
+const mockUsePerNetworkCustomization = usePerNetworkCustomization as jest.MockedFunction<
+	typeof usePerNetworkCustomization
+>;
+const mockUseSocialMediaMessage = useSocialMediaMessage as jest.MockedFunction<
+	typeof useSocialMediaMessage
+>;
+const mockUseSocialPreviewPostData = useSocialPreviewPostData as jest.MockedFunction<
+	typeof useSocialPreviewPostData
+>;
+const mockUseMediaDetails = useMediaDetails as jest.MockedFunction< typeof useMediaDetails >;
+const mockUseSigPreview = useSigPreview as jest.MockedFunction< typeof useSigPreview >;
+
+const createMockConnection = ( overrides: Partial< Connection > = {} ): Connection => ( {
+	connection_id: '123',
+	display_name: 'Test User',
+	external_handle: '@test',
+	external_id: 'ext123',
+	profile_link: 'https://example.com/test',
+	profile_picture: 'https://example.com/pic.jpg',
+	service_label: 'Test Service',
+	service_name: 'test',
+	shared: false,
+	status: 'ok',
+	wpcom_user_id: 1,
+	enabled: true,
+	...overrides,
+} );
+
+const defaultPostData = {
+	title: 'Test Post',
+	description: 'Test description',
+	url: 'https://example.com/post',
+	image: 'https://example.com/image.jpg',
+	excerpt: 'Test excerpt',
+	media: [],
+	message: '',
+};
+
+describe( 'useConnectionPreviewData', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+
+		mockSiteHasFeature.mockReturnValue( false );
+		mockUseSelect.mockReturnValue( 0 );
+		mockUsePerNetworkCustomization.mockReturnValue( { isEnabled: false, toggle: jest.fn() } );
+		mockUseSocialMediaMessage.mockReturnValue( {
+			message: 'Global message',
+			updateMessage: jest.fn(),
+			maxLength: 280,
+		} );
+		mockUseSocialPreviewPostData.mockReturnValue( defaultPostData );
+		mockUseMediaDetails.mockReturnValue( [ null ] );
+		mockUseSigPreview.mockReturnValue( { url: null, isLoading: false } );
+	} );
+
+	afterAll( () => {
+		clearMockedScriptData();
+	} );
+
+	it( 'should return post data with global message when per-network customization is disabled', () => {
+		const connection = createMockConnection();
+
+		const { result } = renderHook( () => useConnectionPreviewData( connection ) );
+
+		expect( result.current ).toEqual( {
+			...defaultPostData,
+			message: 'Global message',
+		} );
+	} );
+
+	it( 'should return post data with global message when ENHANCED_PUBLISHING feature is not available', () => {
+		mockUsePerNetworkCustomization.mockReturnValue( { isEnabled: true, toggle: jest.fn() } );
+		mockSiteHasFeature.mockReturnValue( false );
+
+		const connection = createMockConnection();
+
+		const { result } = renderHook( () => useConnectionPreviewData( connection ) );
+
+		expect( result.current.message ).toBe( 'Global message' );
+	} );
+
+	it( 'should trim the global message', () => {
+		mockUseSocialMediaMessage.mockReturnValue( {
+			message: '  Message with spaces  ',
+			updateMessage: jest.fn(),
+			maxLength: 280,
+		} );
+
+		const connection = createMockConnection();
+
+		const { result } = renderHook( () => useConnectionPreviewData( connection ) );
+
+		expect( result.current.message ).toBe( 'Message with spaces' );
+	} );
+
+	it( 'should use connection attached_media when per-network customization is enabled', () => {
+		mockSiteHasFeature.mockReturnValue( true );
+		mockUsePerNetworkCustomization.mockReturnValue( { isEnabled: true, toggle: jest.fn() } );
+
+		const attachedMedia = [ { id: 1, url: 'https://example.com/media.jpg', type: 'image/jpeg' } ];
+		const connection = createMockConnection( {
+			attached_media: attachedMedia,
+		} );
+
+		const { result } = renderHook( () => useConnectionPreviewData( connection ) );
+
+		expect( result.current.media ).toEqual( attachedMedia );
+	} );
+
+	it( 'should return featured image when media_source is featured-image', () => {
+		mockSiteHasFeature.mockReturnValue( true );
+		mockUsePerNetworkCustomization.mockReturnValue( { isEnabled: true, toggle: jest.fn() } );
+		mockUseMediaDetails.mockReturnValue( [
+			{
+				mediaData: { width: 800, height: 600, sourceUrl: 'https://example.com/featured.jpg' },
+				metaData: { mime: 'image/jpeg', fileSize: 1024, length: 0 },
+			},
+		] );
+
+		const connection = createMockConnection( { media_source: 'featured-image' } );
+
+		const { result } = renderHook( () => useConnectionPreviewData( connection ) );
+
+		expect( result.current.media ).toEqual( [
+			{ url: 'https://example.com/featured.jpg', type: 'image/jpeg' },
+		] );
+	} );
+
+	it( 'should return empty media when media_source is featured-image but no featured image exists', () => {
+		mockSiteHasFeature.mockReturnValue( true );
+		mockUsePerNetworkCustomization.mockReturnValue( { isEnabled: true, toggle: jest.fn() } );
+		// When no featured image is set, useMediaDetails returns [ null ] or a falsy first element
+		mockUseMediaDetails.mockReturnValue( [ null ] );
+
+		const connection = createMockConnection( { media_source: 'featured-image' } );
+
+		const { result } = renderHook( () => useConnectionPreviewData( connection ) );
+
+		expect( result.current.media ).toEqual( [] );
+	} );
+
+	it( 'should return SIG image when media_source is sig', () => {
+		mockSiteHasFeature.mockReturnValue( true );
+		mockUsePerNetworkCustomization.mockReturnValue( { isEnabled: true, toggle: jest.fn() } );
+		mockUseSigPreview.mockReturnValue( {
+			url: 'https://example.com/sig.png',
+			isLoading: false,
+		} );
+
+		const connection = createMockConnection( { media_source: 'sig' } );
+
+		const { result } = renderHook( () => useConnectionPreviewData( connection ) );
+
+		expect( result.current.media ).toEqual( [
+			{ url: 'https://example.com/sig.png', type: 'image/png' },
+		] );
+	} );
+
+	it( 'should return empty media when media_source is sig but no SIG URL exists', () => {
+		mockSiteHasFeature.mockReturnValue( true );
+		mockUsePerNetworkCustomization.mockReturnValue( { isEnabled: true, toggle: jest.fn() } );
+		mockUseSigPreview.mockReturnValue( { url: null, isLoading: false } );
+
+		const connection = createMockConnection( { media_source: 'sig' } );
+
+		const { result } = renderHook( () => useConnectionPreviewData( connection ) );
+
+		expect( result.current.media ).toEqual( [] );
+	} );
+
+	it( 'should return empty media when media_source is none', () => {
+		mockSiteHasFeature.mockReturnValue( true );
+		mockUsePerNetworkCustomization.mockReturnValue( { isEnabled: true, toggle: jest.fn() } );
+
+		const connection = createMockConnection( { media_source: 'none' } );
+
+		const { result } = renderHook( () => useConnectionPreviewData( connection ) );
+
+		expect( result.current.media ).toEqual( [] );
+	} );
+} );

--- a/projects/packages/publicize/_inc/hooks/use-connection-preview-data/test/index.test.ts
+++ b/projects/packages/publicize/_inc/hooks/use-connection-preview-data/test/index.test.ts
@@ -191,8 +191,9 @@ describe( 'useConnectionPreviewData', () => {
 	it( 'should return empty media when media_source is featured-image but no featured image exists', () => {
 		mockSiteHasFeature.mockReturnValue( true );
 		mockUsePerNetworkCustomization.mockReturnValue( { isEnabled: true, toggle: jest.fn() } );
-		// When no featured image is set, useMediaDetails returns [ null ] or a falsy first element
-		mockUseMediaDetails.mockReturnValue( [ null ] );
+		// When no featured image is set, useMediaDetails returns [ {} ] with no mediaData.sourceUrl
+		// The hook checks featuredImageDetails?.mediaData?.sourceUrl to handle this edge case
+		mockUseMediaDetails.mockReturnValue( [ {} ] as ReturnType< typeof useMediaDetails > );
 
 		const connection = createMockConnection( { media_source: 'featured-image' } );
 

--- a/projects/packages/publicize/_inc/hooks/use-per-network-customization/index.ts
+++ b/projects/packages/publicize/_inc/hooks/use-per-network-customization/index.ts
@@ -1,6 +1,8 @@
 import { useDispatch, useSelect } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
 import { useCallback, useMemo } from '@wordpress/element';
+import { store as socialStore } from '../../social-store';
+import { usePostMeta } from '../use-post-meta';
 
 const TOGGLE_KEY = '_wpas_customize_per_network';
 
@@ -10,22 +12,52 @@ const TOGGLE_KEY = '_wpas_customize_per_network';
  * @return - An object containing isEnabled boolean and toggle function.
  */
 export function usePerNetworkCustomization() {
+	const postMeta = usePostMeta();
+
 	const { editPost } = useDispatch( editorStore );
+	const { customizeConnectionById } = useDispatch( socialStore );
+	const connections = useSelect( select => select( socialStore ).getConnections(), [] );
 
 	const isEnabled = useSelect( select => {
-		const postMeta = select( editorStore ).getEditedPostAttribute( 'meta' );
+		const meta = select( editorStore ).getEditedPostAttribute( 'meta' );
 
-		return Boolean( postMeta?.[ TOGGLE_KEY ] );
+		return Boolean( meta?.[ TOGGLE_KEY ] );
 	}, [] );
 
+	const syncConnections = useCallback( () => {
+		// Copy global settings to each connection.
+		connections.forEach( connection => {
+			// Only copy if no existing customization.
+			if ( connection.message === undefined ) {
+				customizeConnectionById( connection.connection_id, {
+					message: postMeta.shareMessage || '',
+					// We want to copy the attached media only if the media source is from media library or upload video.
+					// For other media sources (like featured image, sig), we don't copy the attached media
+					// Because those are resolved from the source directly.
+					attached_media:
+						postMeta.mediaSource === 'media-library' || postMeta.mediaSource === 'upload-video'
+							? postMeta.attachedMedia
+							: undefined,
+					media_source: postMeta.mediaSource,
+				} );
+			}
+		} );
+	}, [ connections, customizeConnectionById, postMeta ] );
+
 	const toggle = useCallback( () => {
+		const isNowEnabled = ! isEnabled;
+
 		// Update post metadata.
 		editPost( {
 			meta: {
-				[ TOGGLE_KEY ]: ! isEnabled,
+				[ TOGGLE_KEY ]: isNowEnabled,
 			},
 		} );
-	}, [ editPost, isEnabled ] );
+
+		if ( isNowEnabled ) {
+			syncConnections();
+		}
+	}, [ isEnabled, editPost, syncConnections ] );
 
 	return useMemo(
 		() => ( {

--- a/projects/packages/publicize/_inc/hooks/use-per-network-customization/test/index.test.ts
+++ b/projects/packages/publicize/_inc/hooks/use-per-network-customization/test/index.test.ts
@@ -18,23 +18,31 @@ jest.mock( '@wordpress/data', () => {
 const mockUseDispatch = useDispatch as jest.MockedFunction< typeof useDispatch >;
 const mockUseSelect = useSelect as jest.MockedFunction< typeof useSelect >;
 
+const createMockSelect = ( meta: Record< string, unknown > = {} ) => {
+	return () => ( {
+		getEditedPostAttribute: jest.fn().mockReturnValue( meta ),
+		getConnections: jest.fn().mockReturnValue( [] ),
+		getEnabledConnections: jest.fn().mockReturnValue( [] ),
+		getDisabledConnections: jest.fn().mockReturnValue( [] ),
+	} );
+};
+
 describe( 'usePerNetworkCustomization', () => {
 	const mockEditPost = jest.fn();
+	const mockCustomizeConnectionById = jest.fn();
 
 	beforeEach( () => {
 		jest.clearAllMocks();
 
 		mockUseDispatch.mockReturnValue( {
 			editPost: mockEditPost,
+			customizeConnectionById: mockCustomizeConnectionById,
 		} );
 	} );
 
 	it( 'should return isEnabled as false when meta key is not set', () => {
 		mockUseSelect.mockImplementation( ( selector: ( select: unknown ) => unknown ) => {
-			const mockSelect = () => ( {
-				getEditedPostAttribute: jest.fn().mockReturnValue( {} ),
-			} );
-			return selector( mockSelect );
+			return selector( createMockSelect( {} ) );
 		} );
 
 		const { result } = renderHook( () => usePerNetworkCustomization() );
@@ -44,12 +52,11 @@ describe( 'usePerNetworkCustomization', () => {
 
 	it( 'should return isEnabled as true when meta key is true', () => {
 		mockUseSelect.mockImplementation( ( selector: ( select: unknown ) => unknown ) => {
-			const mockSelect = () => ( {
-				getEditedPostAttribute: jest.fn().mockReturnValue( {
+			return selector(
+				createMockSelect( {
 					_wpas_customize_per_network: true,
-				} ),
-			} );
-			return selector( mockSelect );
+				} )
+			);
 		} );
 
 		const { result } = renderHook( () => usePerNetworkCustomization() );
@@ -59,12 +66,11 @@ describe( 'usePerNetworkCustomization', () => {
 
 	it( 'should toggle the meta value when toggle is called', () => {
 		mockUseSelect.mockImplementation( ( selector: ( select: unknown ) => unknown ) => {
-			const mockSelect = () => ( {
-				getEditedPostAttribute: jest.fn().mockReturnValue( {
+			return selector(
+				createMockSelect( {
 					_wpas_customize_per_network: false,
-				} ),
-			} );
-			return selector( mockSelect );
+				} )
+			);
 		} );
 
 		const { result } = renderHook( () => usePerNetworkCustomization() );

--- a/projects/packages/publicize/_inc/social-store/types.ts
+++ b/projects/packages/publicize/_inc/social-store/types.ts
@@ -1,4 +1,4 @@
-import { AttachedMedia } from '../utils';
+import { AttachedMedia, MediaSourceValue } from '../utils';
 
 export type ConnectionStatus = 'ok' | 'broken' | 'must_reauth';
 
@@ -10,6 +10,7 @@ export interface EditorConnection {
 	// Customization fields
 	message?: string;
 	attached_media?: Array< AttachedMedia >;
+	media_source?: MediaSourceValue;
 }
 
 export type Connection = Partial< EditorConnection > & {

--- a/projects/packages/publicize/changelog/update-social-wire-up-media-customization
+++ b/projects/packages/publicize/changelog/update-social-wire-up-media-customization
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Wire up media customization per network.

--- a/projects/packages/publicize/src/class-publicize-base.php
+++ b/projects/packages/publicize/src/class-publicize-base.php
@@ -1230,45 +1230,11 @@ abstract class Publicize_Base {
 			'auth_callback' => array( $this, 'message_meta_auth_callback' ),
 		);
 
-		// Schema for attached media, shared between jetpack_social_options and connection_overrides.
-		$attached_media_schema = array(
-			'type'  => 'array',
-			'items' => array(
-				'type'       => 'object',
-				'properties' => array(
-					'id'   => array(
-						'type' => 'number',
-					),
-					'url'  => array(
-						'type' => 'string',
-					),
-					'type' => array(
-						'type' => 'string',
-					),
-				),
-			),
-		);
-
 		$connection_overrides_args = array(
 			'type'          => 'object',
 			'description'   => __( 'Per-connection customizations for message and media.', 'jetpack-publicize-pkg' ),
 			'single'        => true,
 			'default'       => array(),
-			'show_in_rest'  => array(
-				'name'   => 'jetpack_publicize_connection_overrides',
-				'schema' => array(
-					'type'                 => 'object',
-					'additionalProperties' => array(
-						'type'       => 'object',
-						'properties' => array(
-							'message'        => array(
-								'type' => 'string',
-							),
-							'attached_media' => $attached_media_schema,
-						),
-					),
-				),
-			),
 			'auth_callback' => array( $this, 'message_meta_auth_callback' ),
 		);
 

--- a/projects/packages/publicize/src/rest-api/class-connections-post-field.php
+++ b/projects/packages/publicize/src/rest-api/class-connections-post-field.php
@@ -147,6 +147,16 @@ class Connections_Post_Field {
 							),
 						),
 					),
+					'media_source'   => array(
+						'type' => 'string',
+						'enum' => array(
+							'featured-image',
+							'sig',
+							'media-library',
+							'upload-video',
+							'none',
+						),
+					),
 				)
 			),
 		);
@@ -234,6 +244,9 @@ class Connections_Post_Field {
 				}
 				if ( isset( $override['attached_media'] ) ) {
 					$output_connection['attached_media'] = $override['attached_media'];
+				}
+				if ( isset( $override['media_source'] ) ) {
+					$output_connection['media_source'] = $override['media_source'];
 				}
 			}
 
@@ -450,6 +463,11 @@ class Connections_Post_Field {
 			return;
 		}
 
+		// If the request does not have connections, skip.
+		if ( ! isset( $request[ self::FIELD_NAME ] ) ) {
+			return;
+		}
+
 		$overrides = array();
 
 		foreach ( $requested_connections as $connection ) {
@@ -459,7 +477,7 @@ class Connections_Post_Field {
 			}
 
 			// Only save if connection has custom message or attached_media.
-			if ( ! isset( $connection['message'] ) && ! isset( $connection['attached_media'] ) ) {
+			if ( ! isset( $connection['message'] ) && ! isset( $connection['attached_media'] ) && ! isset( $connection['media_source'] ) ) {
 				continue;
 			}
 
@@ -474,6 +492,11 @@ class Connections_Post_Field {
 			// Save attached_media (can be empty array to clear media).
 			if ( isset( $connection['attached_media'] ) ) {
 				$overrides[ $connection_id ]['attached_media'] = $this->sanitize_attached_media( $connection['attached_media'] );
+			}
+
+			// Save media_source (can be empty to use default).
+			if ( isset( $connection['media_source'] ) ) {
+				$overrides[ $connection_id ]['media_source'] = sanitize_text_field( $connection['media_source'] );
 			}
 		}
 


### PR DESCRIPTION
Closes SOCIAL-315

## Proposed changes:

* Wire up the media customization per network connection

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

N/A

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

* Go to a post in the editor with Social connections enabled
* Open the Social preview modal (customize and preview)
* Set customization to "For all"
* Add a message and attach some media
* Confirm that it's saved when the post is saved. Reload the page to confirm
* Change the customization toggle to "For each"
* Edit the share message for a particular connection - verify it saves separately from the global message
* Change the attached media for that connection - verify it saves separately
* Toggle the connection off - verify the form becomes disabled
* Switch between connections and verify each maintains its own customization
* Publish/save the post and verify the customizations persist in post meta


https://github.com/user-attachments/assets/f4dd3c53-e68a-454b-b91a-9a67215b19cb



