### PR TITLE
Sync: Stop sending redundant actions when Dedicated Sync fails to enable

### DIFF
--- a/projects/packages/sync/changelog/update-stop-sending-redundant-dedicated_sync_enabled-actions
+++ b/projects/packages/sync/changelog/update-stop-sending-redundant-dedicated_sync_enabled-actions
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Sync: Stop sending redundant actions when Dedicated Sync fails to enable
+Sync: Stop sending redundant actions when Dedicated Sync fails to enable.

--- a/projects/packages/sync/changelog/update-stop-sending-redundant-dedicated_sync_enabled-actions
+++ b/projects/packages/sync/changelog/update-stop-sending-redundant-dedicated_sync_enabled-actions
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Sync: Stop sending redundant actions when Dedicated Sync fails to enable

--- a/projects/packages/sync/src/class-queue.php
+++ b/projects/packages/sync/src/class-queue.php
@@ -121,7 +121,7 @@ class Queue {
 	}
 
 	/**
-	 * Get the front-most item on the queue without checking it out.
+	 * Get the front-most items on the queue without checking them out.
 	 *
 	 * @param int $count Number of items to return when looking at the items.
 	 *
@@ -137,7 +137,7 @@ class Queue {
 	}
 
 	/**
-	 * Get the last-added item on the queue without checking it out.
+	 * Get the last-added items on the queue without checking them out.
 	 *
 	 * @param int $count Number of items to return when looking at the items.
 	 *

--- a/projects/packages/sync/src/class-queue.php
+++ b/projects/packages/sync/src/class-queue.php
@@ -245,14 +245,31 @@ class Queue {
 	}
 
 	/**
-	 * Pop elements from the queue.
+	 * Remove the oldest items from the queue.
 	 *
-	 * @param int $limit Number of items to pop from the queue.
+	 * @param int $limit Number of items to remove from the queue.
 	 *
 	 * @return array|object|null
 	 */
 	public function pop( $limit ) {
 		$items = $this->fetch_items( $limit );
+
+		$ids = $this->get_ids( $items );
+
+		$this->delete( $ids );
+
+		return $items;
+	}
+
+	/**
+	 * Remove the newest items from the queue.
+	 *
+	 * @param int $limit Number of items to remove from the queue.
+	 *
+	 * @return array|object|null
+	 */
+	public function pop_newest( $limit ) {
+		$items = $this->fetch_items( $limit, 'DESC' );
 
 		$ids = $this->get_ids( $items );
 
@@ -609,11 +626,15 @@ class Queue {
 	 * Return the items in the queue.
 	 *
 	 * @param null|int $limit Limit to the number of items we fetch at once.
+	 * @param string   $order      Sort direction for the items. Accepts 'ASC' or 'DESC'.
+	 *                             Any other value will be treated as 'ASC'.
 	 *
 	 * @return array|object|null
 	 */
-	private function fetch_items( $limit = null ) {
-		$items = $this->queue_storage->fetch_items( $limit );
+	private function fetch_items( $limit = null, $order = 'ASC' ) {
+		$order = 'DESC' === $order ? 'DESC' : 'ASC';
+
+		$items = $this->queue_storage->fetch_items( $limit, $order );
 
 		return $this->unserialize_values( $items );
 	}

--- a/projects/packages/sync/src/class-queue.php
+++ b/projects/packages/sync/src/class-queue.php
@@ -271,7 +271,7 @@ class Queue {
 		$items = $this->fetch_items( $limit );
 
 		if ( ! $items ) {
-			return;
+			return array();
 		}
 
 		$ids = $this->get_ids( $items );
@@ -292,7 +292,7 @@ class Queue {
 		$items = $this->fetch_items( $limit, 'DESC' );
 
 		if ( ! $items ) {
-			return;
+			return array();
 		}
 
 		$ids = $this->get_ids( $items );

--- a/projects/packages/sync/src/class-queue.php
+++ b/projects/packages/sync/src/class-queue.php
@@ -254,6 +254,10 @@ class Queue {
 	public function pop( $limit ) {
 		$items = $this->fetch_items( $limit );
 
+		if ( ! $items ) {
+			return;
+		}
+
 		$ids = $this->get_ids( $items );
 
 		$this->delete( $ids );
@@ -270,6 +274,10 @@ class Queue {
 	 */
 	public function pop_newest( $limit ) {
 		$items = $this->fetch_items( $limit, 'DESC' );
+
+		if ( ! $items ) {
+			return;
+		}
 
 		$ids = $this->get_ids( $items );
 

--- a/projects/packages/sync/src/class-queue.php
+++ b/projects/packages/sync/src/class-queue.php
@@ -137,6 +137,22 @@ class Queue {
 	}
 
 	/**
+	 * Get the last-added item on the queue without checking it out.
+	 *
+	 * @param int $count Number of items to return when looking at the items.
+	 *
+	 * @return array
+	 */
+	public function peek_newest( $count = 1 ) {
+		$items = $this->fetch_items( $count, 'DESC' );
+		if ( $items ) {
+			return Utils::get_item_values( $items );
+		}
+
+		return array();
+	}
+
+	/**
 	 * Gets items with particular IDs.
 	 *
 	 * @param array $item_ids Array of item IDs to retrieve.

--- a/projects/packages/sync/src/class-settings.php
+++ b/projects/packages/sync/src/class-settings.php
@@ -304,6 +304,10 @@ class Settings {
 			if ( 'dedicated_sync_enabled' === $setting && $updated && (bool) $value ) {
 				if ( ! Dedicated_Sender::can_spawn_dedicated_sync_request() ) {
 					update_option( self::SETTINGS_OPTION_PREFIX . $setting, 0, true );
+					$listener = Listener::get_instance();
+					// Remove the last two actions from the queue since we failed to enable Dedicated Sync.
+					// Those would be `updated_option` with dedicated_sync_enabled set to 1 and then 0 again.
+					$listener->get_sync_queue()->pop_newest( 2 );
 				}
 			}
 		}

--- a/projects/packages/sync/src/class-settings.php
+++ b/projects/packages/sync/src/class-settings.php
@@ -306,8 +306,19 @@ class Settings {
 					update_option( self::SETTINGS_OPTION_PREFIX . $setting, 0, true );
 					$listener = Listener::get_instance();
 					// Remove the last two actions from the queue since we failed to enable Dedicated Sync.
-					// Those would be `updated_option` with dedicated_sync_enabled set to 1 and then 0 again.
-					$listener->get_sync_queue()->pop_newest( 2 );
+					// Those would be `updated_option` with `jetpack_sync_settings_dedicated_sync_enabled` set to 1 and then 0 again.
+					$queue = $listener->get_sync_queue();
+					$items = $queue->peek_newest( 2 );
+					$key   = 'jetpack_sync_settings_dedicated_sync_enabled';
+
+					if (
+						isset( $items[0][1][0] )
+						&& isset( $items[1][1][0] )
+						&& $items[0][1][0] === $key
+						&& $items[1][1][0] === $key
+					) {
+						$queue->pop_newest( 2 );
+					}
 				}
 			}
 		}

--- a/projects/packages/sync/src/sync-queue/class-queue-storage-options.php
+++ b/projects/packages/sync/src/sync-queue/class-queue-storage-options.php
@@ -71,7 +71,7 @@ class Queue_Storage_Options {
 	 * @param string   $order      Sort direction for the items. Accepts 'ASC' or 'DESC'.
 	 *                             Any other value will be treated as 'ASC'.
 	 *
-	 * @return object[]|null Array of result objects on success, or null on failure.
+	 * @return array|object|null Array of result objects on success, or null on failure.
 	 */
 	public function fetch_items( $item_count, $order = 'ASC' ) {
 		global $wpdb;

--- a/projects/packages/sync/src/sync-queue/class-queue-storage-options.php
+++ b/projects/packages/sync/src/sync-queue/class-queue-storage-options.php
@@ -67,34 +67,36 @@ class Queue_Storage_Options {
 	 * Fetch items from the queue.
 	 *
 	 * @param int|null $item_count How many items to fetch from the queue.
-	 *                             The parameter is null-able, if no limit on the amount of items.
+	 *                             Null for no limit.
+	 * @param string   $order      Sort direction for the items. Accepts 'ASC' or 'DESC'.
+	 *                             Any other value will be treated as 'ASC'.
 	 *
-	 * @return array|object|\stdClass[]|null
+	 * @return object[]|null Array of result objects on success, or null on failure.
 	 */
-	public function fetch_items( $item_count ) {
+	public function fetch_items( $item_count, $order = 'ASC' ) {
 		global $wpdb;
 
-		// TODO make it more simple for the $item_count
+		$order = 'DESC' === $order ? 'DESC' : 'ASC';
+
+		$sql_order = "ORDER BY option_name {$order}";
+
+		$sql = "SELECT option_name AS id, option_value AS value
+				FROM $wpdb->options
+				WHERE option_name LIKE %s
+				{$sql_order}";
+
+		$params = array( "jpsq_{$this->queue_id}-%" );
+
 		if ( $item_count ) {
-			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.DirectDatabaseQuery.DirectQuery
-			$items = $wpdb->get_results(
-				$wpdb->prepare(
-					"SELECT option_name AS id, option_value AS value FROM $wpdb->options WHERE option_name LIKE %s ORDER BY option_name ASC LIMIT %d",
-					"jpsq_{$this->queue_id}-%",
-					$item_count
-				),
-				OBJECT
-			);
-		} else {
-			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.DirectDatabaseQuery.DirectQuery
-			$items = $wpdb->get_results(
-				$wpdb->prepare(
-					"SELECT option_name AS id, option_value AS value FROM $wpdb->options WHERE option_name LIKE %s ORDER BY option_name ASC",
-					"jpsq_{$this->queue_id}-%"
-				),
-				OBJECT
-			);
+			$sql     .= ' LIMIT %d';
+			$params[] = $item_count;
 		}
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		$items = $wpdb->get_results(
+			$wpdb->prepare( $sql, $params ), // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+			OBJECT
+		);
 
 		return $items;
 	}

--- a/projects/packages/sync/src/sync-queue/class-queue-storage-table.php
+++ b/projects/packages/sync/src/sync-queue/class-queue-storage-table.php
@@ -228,7 +228,7 @@ class Queue_Storage_Table {
 	 * Fetch items from the queue.
 	 *
 	 * @param int|null $item_count How many items to fetch from the queue.
-	 *                             Null/0 for no limit.
+	 *                             Null for no limit.
 	 * @param string   $order      Sort direction for the items. Accepts 'ASC' or 'DESC'.
 	 *                             Any other value will be treated as 'ASC'.
 	 *

--- a/projects/packages/sync/src/sync-queue/class-queue-storage-table.php
+++ b/projects/packages/sync/src/sync-queue/class-queue-storage-table.php
@@ -228,55 +228,38 @@ class Queue_Storage_Table {
 	 * Fetch items from the queue.
 	 *
 	 * @param int|null $item_count How many items to fetch from the queue.
-	 *                             The parameter is null-able, if no limit on the amount of items.
+	 *                             Null/0 for no limit.
+	 * @param string   $order      Sort direction for the items. Accepts 'ASC' or 'DESC'.
+	 *                             Any other value will be treated as 'ASC'.
 	 *
-	 * @return object[]|null
+	 * @return object[]|null Array of result objects on success, or null on failure.
 	 */
-	public function fetch_items( $item_count ) {
+	public function fetch_items( $item_count, $order = 'ASC' ) {
 		global $wpdb;
 
-		/**
-		 * Ignoring the linting warning, as there's still no placeholder replacement for DB field name,
-		 * in this case this is `$this->table_name`
-		 */
-		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$order     = ( 'DESC' === $order ) ? 'DESC' : 'ASC';
+		$sql_order = "ORDER BY event_id {$order}";
 
-		// TODO make it more simple for the $item_count
+		$sql = "
+			SELECT
+				event_id AS id,
+				event_payload AS value
+			FROM {$this->table_name}
+			WHERE queue_id LIKE %s
+			{$sql_order}
+		";
+
+		$params = array( $this->queue_id );
+
 		if ( $item_count ) {
-			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-			$items = $wpdb->get_results(
-				$wpdb->prepare(
-					"
-						SELECT
-	                        event_id AS id,
-	                        event_payload AS value
-						FROM {$this->table_name}
-							WHERE queue_id LIKE %s
-						ORDER BY event_id ASC
-						LIMIT %d
-					",
-					$this->queue_id,
-					$item_count
-				)
-			);
-		} else {
-			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-			$items = $wpdb->get_results(
-				$wpdb->prepare(
-					"
-						SELECT
-	                        event_id AS id,
-	                        event_payload AS value
-						FROM {$this->table_name}
-							WHERE queue_id LIKE %s
-						ORDER BY event_id ASC
-					",
-					$this->queue_id
-				)
-			);
+			$sql     .= ' LIMIT %d';
+			$params[] = $item_count;
 		}
 
-		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		$items = $wpdb->get_results(
+			$wpdb->prepare( $sql, $params ) // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+		);
 
 		return $items;
 	}

--- a/projects/packages/sync/src/sync-queue/class-queue-storage-table.php
+++ b/projects/packages/sync/src/sync-queue/class-queue-storage-table.php
@@ -232,7 +232,7 @@ class Queue_Storage_Table {
 	 * @param string   $order      Sort direction for the items. Accepts 'ASC' or 'DESC'.
 	 *                             Any other value will be treated as 'ASC'.
 	 *
-	 * @return object[]|null Array of result objects on success, or null on failure.
+	 * @return array|object|null Array of result objects on success, or null on failure.
 	 */
 	public function fetch_items( $item_count, $order = 'ASC' ) {
 		global $wpdb;

--- a/projects/plugins/jetpack/changelog/update-stop-sending-redundant-dedicated_sync_enabled-actions
+++ b/projects/plugins/jetpack/changelog/update-stop-sending-redundant-dedicated_sync_enabled-actions
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Update Sync related unit tests
+
+

--- a/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Queue_Test.php
+++ b/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Queue_Test.php
@@ -47,6 +47,15 @@ class Jetpack_Sync_Queue_Test extends WP_UnitTestCase {
 		$this->assertEquals( array( 'foo', 'bar' ), $this->queue->peek( 2 ) );
 	}
 
+	public function test_peek_newest_items() {
+		$this->queue->add( 'foo' );
+		$this->queue->add( 'bar' );
+		$this->queue->add( 'baz' );
+
+		$this->assertEquals( array( 'baz' ), $this->queue->peek_newest( 1 ) );
+		$this->assertEquals( array( 'baz', 'bar' ), $this->queue->peek_newest( 2 ) );
+	}
+
 	public function test_items_exist() {
 		$this->assertFalse( $this->queue->has_any_items() );
 

--- a/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Queue_Test.php
+++ b/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Queue_Test.php
@@ -2,6 +2,7 @@
 
 use Automattic\Jetpack\Sync\Queue;
 use Automattic\Jetpack\Sync\Queue_Buffer;
+use Automattic\Jetpack\Sync\Utils;
 
 class Jetpack_Sync_Queue_Test extends WP_UnitTestCase {
 	use \Automattic\Jetpack\PHPUnit\WP_UnitTestCase_Fix;
@@ -52,6 +53,28 @@ class Jetpack_Sync_Queue_Test extends WP_UnitTestCase {
 		$this->queue->add( 'foo' );
 
 		$this->assertTrue( $this->queue->has_any_items() );
+	}
+
+	public function test_pop_items() {
+		$this->queue->add( 'foo' );
+		$this->queue->add( 'bar' );
+		$this->queue->add( 'baz' );
+
+		$popped = $this->queue->pop( 1 );
+
+		$this->assertEquals( array( 'foo' ), Utils::get_item_values( $popped ) );
+		$this->assertSame( 2, $this->queue->size() );
+	}
+
+	public function test_pop_latest_items() {
+		$this->queue->add( 'foo' );
+		$this->queue->add( 'bar' );
+		$this->queue->add( 'baz' );
+
+		$popped = $this->queue->pop_newest( 1 );
+
+		$this->assertEquals( array( 'baz' ), Utils::get_item_values( $popped ) );
+		$this->assertSame( 2, $this->queue->size() );
 	}
 
 	public function test_queue_lag() {

--- a/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Queue_Test.php
+++ b/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Queue_Test.php
@@ -66,7 +66,7 @@ class Jetpack_Sync_Queue_Test extends WP_UnitTestCase {
 		$this->assertSame( 2, $this->queue->size() );
 	}
 
-	public function test_pop_latest_items() {
+	public function test_pop_newest_items() {
 		$this->queue->add( 'foo' );
 		$this->queue->add( 'bar' );
 		$this->queue->add( 'baz' );

--- a/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Settings_Test.php
+++ b/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Settings_Test.php
@@ -126,9 +126,18 @@ class Jetpack_Sync_Settings_Test extends Jetpack_Sync_TestBase {
 		$this->assertTrue( $this->dedicated_sync_test_request_spawned );
 		$this->assertFalse( Settings::is_dedicated_sync_enabled() );
 
-		// syncing sends no data
+		// Ensure 'updated_option' events related to 'jetpack_sync_settings_dedicated_sync_enabled' have been removed from
+		// the queue.
 		$this->sender->do_sync();
-		$this->assertFalse( $this->server_event_storage->get_most_recent_event( 'updated_option' ) );
+		$event = $this->server_event_storage->get_most_recent_event(
+			'updated_option',
+			null,
+			function ( $event ) {
+				return isset( $event->args[0] ) && 'jetpack_sync_settings_dedicated_sync_enabled' === $event->args[0];
+			}
+		);
+
+		$this->assertFalse( $event );
 	}
 
 	public function test_enabling_dedicated_sync_setting_with_successful_sync_spawn_test_request() {

--- a/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Settings_Test.php
+++ b/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Settings_Test.php
@@ -125,6 +125,10 @@ class Jetpack_Sync_Settings_Test extends Jetpack_Sync_TestBase {
 
 		$this->assertTrue( $this->dedicated_sync_test_request_spawned );
 		$this->assertFalse( Settings::is_dedicated_sync_enabled() );
+
+		// syncing sends no data
+		$this->sender->do_sync();
+		$this->assertFalse( $this->server_event_storage->get_most_recent_event( 'updated_option' ) );
 	}
 
 	public function test_enabling_dedicated_sync_setting_with_successful_sync_spawn_test_request() {
@@ -135,6 +139,7 @@ class Jetpack_Sync_Settings_Test extends Jetpack_Sync_TestBase {
 		$this->assertTrue( $this->dedicated_sync_test_request_spawned );
 		$this->assertTrue( Settings::is_dedicated_sync_enabled() );
 	}
+
 	/**
 	 * Intercept HTTP request to run Sync and mock the response.
 	 * Should be hooked on the `pre_http_request` filter.

--- a/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Settings_Test.php
+++ b/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Settings_Test.php
@@ -131,7 +131,7 @@ class Jetpack_Sync_Settings_Test extends Jetpack_Sync_TestBase {
 		$this->sender->do_sync();
 		$event = $this->server_event_storage->get_most_recent_event(
 			'updated_option',
-			null,
+			get_current_blog_id(),
 			function ( $event ) {
 				return isset( $event->args[0] ) && 'jetpack_sync_settings_dedicated_sync_enabled' === $event->args[0];
 			}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Closes SYNC-218

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
- Added a pop_newest() method to remove items from the end of the queue (newest items first)
- Modified queue storage implementations to support sorting items in descending order
- Updated the `Settings` class to remove the two redundant `updated_option` actions when Dedicated Sync fails to enable
- Added tests to verify the queue methods and the fix behaviour

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
SYNC-218

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Disable Dedicated sync via the JP Debugger - Sync settings section
* Sabotage the Dedicated Sync flow by modifying [this line](https://github.com/Automattic/jetpack/blob/trunk/projects/packages/sync/src/class-sender.php#L398) to echo anything but `Dedicated_Sender::DEDICATED_SYNC_VALIDATION_STRING`
* Enable Dedicated sync via the JP Debugger - Sync settings section
* Note that on trunk we sync the `update_option` action for `jetpack_sync_settings_dedicated_sync_enabled` option
* Confirm this is not the case on current branch

**Important**: When testing multiple times you'll probably need to remove [this transient](https://github.com/Automattic/jetpack/blob/trunk/projects/packages/sync/src/class-dedicated-sender.php#L25C8-L25C38) after each test. In `cli` run: `wp transient delete jetpack_sync_dedicated_sync_spawn_check`

