### PR TITLE
Forms: Hide non-allowed blocks when switching to form editor

### DIFF
--- a/projects/packages/forms/changelog/update-form-editor-unregister-blocks
+++ b/projects/packages/forms/changelog/update-form-editor-unregister-blocks
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fixed
+
+Remove blocks from the form editor that are not supposed to be there when switching to it.

--- a/projects/packages/forms/src/form-editor/index.tsx
+++ b/projects/packages/forms/src/form-editor/index.tsx
@@ -27,6 +27,7 @@ import {
 	registerFormCategories,
 	unregisterFormCategories,
 } from './utils/category-utils';
+import { filterFormEditorBlocks, restoreAllBlocks } from './utils/form-editor-blocks';
 
 import './style.scss';
 
@@ -206,6 +207,7 @@ const enforceBlockNesting = () => {
 
 let isJetpackFormEditor: boolean | null = null;
 let categoriesFiltered: boolean = false;
+let blocksFiltered: boolean = false;
 
 let lastRootBlockIds: string = '';
 let lastSelectedBlockId: string | null | undefined = null;
@@ -224,6 +226,7 @@ const setupFormEditorSubscription = () => {
 	unsubscribe = subscribe( () => {
 		const { getCurrentPostType } = select( 'core/editor' );
 		const isCurrentPostTypeJetpackForm = getCurrentPostType() === FORM_POST_TYPE;
+
 		if ( isCurrentPostTypeJetpackForm ) {
 			// Check if root blocks changed by comparing their IDs
 			// This detects when blocks are added, removed, or reordered at the root level
@@ -269,9 +272,23 @@ const setupFormEditorSubscription = () => {
 					// Plugin may not be registered, ignore.
 				}
 			}
-		} else if ( categoriesFiltered ) {
-			categoriesFiltered = false;
-			restoreOriginalCategories( previousCategories || [] );
+
+			if ( ! blocksFiltered ) {
+				blocksFiltered = true;
+				filterFormEditorBlocks();
+			}
+		} else {
+			console.log( 'Not in jetpack_form editor' );
+			// We are not in the form editor anymore.
+			if ( categoriesFiltered ) {
+				categoriesFiltered = false;
+				restoreOriginalCategories( previousCategories || [] );
+			}
+
+			if ( blocksFiltered ) {
+				blocksFiltered = false;
+				restoreAllBlocks();
+			}
 		}
 
 		if ( isCurrentPostTypeJetpackForm === isJetpackFormEditor ) {

--- a/projects/packages/forms/src/form-editor/index.tsx
+++ b/projects/packages/forms/src/form-editor/index.tsx
@@ -278,7 +278,6 @@ const setupFormEditorSubscription = () => {
 				filterFormEditorBlocks();
 			}
 		} else {
-			console.log( 'Not in jetpack_form editor' );
 			// We are not in the form editor anymore.
 			if ( categoriesFiltered ) {
 				categoriesFiltered = false;

--- a/projects/packages/forms/src/form-editor/utils/block-filter-utils.ts
+++ b/projects/packages/forms/src/form-editor/utils/block-filter-utils.ts
@@ -1,0 +1,49 @@
+/**
+ * Pure utility functions for block filtering.
+ *
+ * These functions have no external dependencies and can be easily tested.
+ *
+ * @package
+ */
+
+/**
+ * Child block type definition for filtering.
+ */
+export interface ChildBlock {
+	name: string;
+	settings: {
+		parent?: string | string[];
+	};
+}
+
+/**
+ * Filters child blocks to get only those that can be used in a parent block.
+ * A block is valid if it has no parent restriction, or if its parent includes the specified parent block name.
+ *
+ * @param blocks          - Array of child block definitions
+ * @param parentBlockName - The parent block name to filter by (e.g., 'jetpack/contact-form')
+ * @return Array of valid field block names (with jetpack/ prefix)
+ */
+export function getValidFormFieldBlocks( blocks: ChildBlock[], parentBlockName: string ): string[] {
+	return blocks
+		.filter( childBlock => {
+			const { parent } = childBlock.settings;
+			return (
+				! parent ||
+				parent === parentBlockName ||
+				( Array.isArray( parent ) && parent.includes( parentBlockName ) )
+			);
+		} )
+		.map( block => `jetpack/${ block.name }` );
+}
+
+/**
+ * Determines which blocks should be hidden based on the allowed blocks list.
+ *
+ * @param allBlockNames - Array of all registered block names
+ * @param allowedBlocks - Set of allowed block names
+ * @return Array of block names to hide
+ */
+export function getBlocksToHide( allBlockNames: string[], allowedBlocks: Set< string > ): string[] {
+	return allBlockNames.filter( blockName => ! allowedBlocks.has( blockName ) );
+}

--- a/projects/packages/forms/src/form-editor/utils/form-editor-blocks.ts
+++ b/projects/packages/forms/src/form-editor/utils/form-editor-blocks.ts
@@ -10,7 +10,11 @@
 import { getBlockTypes } from '@wordpress/blocks';
 import { select, dispatch } from '@wordpress/data';
 import { childBlocks } from '../../blocks/contact-form/child-blocks.js';
-import { CORE_BLOCKS } from '../../blocks/shared/util/constants.js';
+import { CORE_BLOCKS, FORM_BLOCK_NAME } from '../../blocks/shared/util/constants.js';
+import { getValidFormFieldBlocks, getBlocksToHide, type ChildBlock } from './block-filter-utils';
+
+// Re-export pure functions for testing
+export { getValidFormFieldBlocks, getBlocksToHide } from './block-filter-utils';
 
 /**
  * Storage for hidden block names to restore them later.
@@ -24,19 +28,8 @@ let shownBlockTypes: string[] = [];
  * @return Array of allowed block names
  */
 function getAllowedFormEditorBlocks(): string[] {
-	const validFields = childBlocks.filter( childBlock => {
-		const settings = childBlock.settings as typeof childBlock.settings & {
-			parent?: string | string[];
-		};
-
-		return (
-			! settings.parent ||
-			settings.parent === 'jetpack/contact-form' ||
-			( Array.isArray( settings.parent ) && settings.parent.includes( 'jetpack/contact-form' ) )
-		);
-	} );
-
-	return [ ...validFields.map( block => `jetpack/${ block.name }` ) ].concat( CORE_BLOCKS );
+	const validFields = getValidFormFieldBlocks( childBlocks as ChildBlock[], FORM_BLOCK_NAME );
+	return validFields.concat( CORE_BLOCKS );
 }
 
 /**
@@ -48,18 +41,16 @@ function getAllowedFormEditorBlocks(): string[] {
 export function filterFormEditorBlocks(): void {
 	const allowedBlocks = new Set( getAllowedFormEditorBlocks() );
 	const allBlockTypes = getBlockTypes();
+	const allBlockNames = allBlockTypes.map( block => block.name );
 
 	// Find blocks that need to be hidden (not in allowed list)
-	const blocksToHide = allBlockTypes
-		.map( block => block.name )
-		.filter( blockName => ! allowedBlocks.has( blockName ) );
+	const blocksToHide = getBlocksToHide( allBlockNames, allowedBlocks );
 
-	// Verify the change
+	// Store the current hidden blocks preference for later restoration
 	const { getPreference } = select( 'core/edit-post' ) as {
 		getPreference: ( preference: string ) => unknown;
 	};
-	// Store for later restoration
-	hiddenBlockTypes = getPreference( 'hiddenBlockTypes' ) as string[];
+	hiddenBlockTypes = ( getPreference( 'hiddenBlockTypes' ) as string[] ) || [];
 	shownBlockTypes = blocksToHide;
 
 	const { hideBlockTypes } = dispatch( 'core/edit-post' ) as {

--- a/projects/packages/forms/src/form-editor/utils/form-editor-blocks.ts
+++ b/projects/packages/forms/src/form-editor/utils/form-editor-blocks.ts
@@ -1,0 +1,93 @@
+/**
+ * Form editor block filtering utilities
+ *
+ * Functions to filter the block inserter when entering the form editor
+ * using the `hideBlockTypes` and `showBlockTypes` actions from `core/edit-post`.
+ *
+ * @package
+ */
+
+import { getBlockTypes } from '@wordpress/blocks';
+import { select, dispatch } from '@wordpress/data';
+import { childBlocks } from '../../blocks/contact-form/child-blocks.js';
+import { CORE_BLOCKS } from '../../blocks/shared/util/constants.js';
+
+/**
+ * Storage for hidden block names to restore them later.
+ */
+let hiddenBlockTypes: string[] = [];
+let shownBlockTypes: string[] = [];
+
+/**
+ * Get the list of allowed blocks for the form editor.
+ *
+ * @return Array of allowed block names
+ */
+function getAllowedFormEditorBlocks(): string[] {
+	const validFields = childBlocks.filter( childBlock => {
+		const settings = childBlock.settings as typeof childBlock.settings & {
+			parent?: string | string[];
+		};
+
+		return (
+			! settings.parent ||
+			settings.parent === 'jetpack/contact-form' ||
+			( Array.isArray( settings.parent ) && settings.parent.includes( 'jetpack/contact-form' ) )
+		);
+	} );
+
+	return [ ...validFields.map( block => `jetpack/${ block.name }` ) ].concat( CORE_BLOCKS );
+}
+
+/**
+ * Filters the block inserter to only show allowed blocks for the form editor.
+ *
+ * Uses `hideBlockTypes` action from `core/edit-post` store to hide
+ * blocks that are not allowed in the form editor.
+ */
+export function filterFormEditorBlocks(): void {
+	const allowedBlocks = new Set( getAllowedFormEditorBlocks() );
+	const allBlockTypes = getBlockTypes();
+
+	// Find blocks that need to be hidden (not in allowed list)
+	const blocksToHide = allBlockTypes
+		.map( block => block.name )
+		.filter( blockName => ! allowedBlocks.has( blockName ) );
+
+	// Verify the change
+	const { getPreference } = select( 'core/edit-post' ) as {
+		getPreference: ( preference: string ) => unknown;
+	};
+	// Store for later restoration
+	hiddenBlockTypes = getPreference( 'hiddenBlockTypes' ) as string[];
+	shownBlockTypes = blocksToHide;
+
+	const { hideBlockTypes } = dispatch( 'core/edit-post' ) as {
+		hideBlockTypes: ( blockNames: string[] ) => void;
+	};
+
+	hideBlockTypes( blocksToHide );
+}
+
+/**
+ * Restores the block inserter to show all previously hidden blocks.
+ *
+ * Uses `showBlockTypes` action from `core/edit-post` store.
+ */
+export function restoreAllBlocks(): void {
+	if ( shownBlockTypes.length === 0 ) {
+		return;
+	}
+
+	const { showBlockTypes, hideBlockTypes } = dispatch( 'core/edit-post' ) as {
+		showBlockTypes: ( blockNames: string[] ) => void;
+		hideBlockTypes: ( blockNames: string[] ) => void;
+	};
+
+	showBlockTypes( shownBlockTypes );
+	hideBlockTypes( hiddenBlockTypes );
+
+	// Clear the stored list
+	hiddenBlockTypes = [];
+	shownBlockTypes = [];
+}

--- a/projects/packages/forms/tests/js/form-editor/utils/form-editor-blocks.test.js
+++ b/projects/packages/forms/tests/js/form-editor/utils/form-editor-blocks.test.js
@@ -1,0 +1,47 @@
+/**
+ * Tests for block-filter-utils
+ */
+
+import {
+	getValidFormFieldBlocks,
+	getBlocksToHide,
+} from '../../../../src/form-editor/utils/block-filter-utils';
+
+describe( 'getValidFormFieldBlocks', () => {
+	const PARENT = 'jetpack/contact-form';
+
+	test( 'filters blocks based on parent restriction', () => {
+		const blocks = [
+			{ name: 'field-a', settings: { parent: PARENT } },
+			{ name: 'field-b', settings: { parent: [ PARENT, 'other/block' ] } },
+			{ name: 'field-c', settings: {} },
+			{ name: 'excluded', settings: { parent: 'other/block' } },
+		];
+
+		expect( getValidFormFieldBlocks( blocks, PARENT ) ).toEqual( [
+			'jetpack/field-a',
+			'jetpack/field-b',
+			'jetpack/field-c',
+		] );
+	} );
+
+	test( 'returns empty array for empty input', () => {
+		expect( getValidFormFieldBlocks( [], PARENT ) ).toEqual( [] );
+	} );
+} );
+
+describe( 'getBlocksToHide', () => {
+	test( 'returns blocks not in allowed set', () => {
+		const all = [ 'a', 'b', 'c' ];
+		const allowed = new Set( [ 'a' ] );
+
+		expect( getBlocksToHide( all, allowed ) ).toEqual( [ 'b', 'c' ] );
+	} );
+
+	test( 'returns empty array when all allowed', () => {
+		const all = [ 'a', 'b' ];
+		const allowed = new Set( [ 'a', 'b' ] );
+
+		expect( getBlocksToHide( all, allowed ) ).toEqual( [] );
+	} );
+} );


### PR DESCRIPTION
## Proposed changes:
   * Add block filtering when entering the Jetpack Form editor to hide blocks that are not allowed
   * Implement `filterFormEditorBlocks()` to hide blocks that don't belong in the form context
   * Implement `restoreAllBlocks()` to restore the original block visibility when leaving the form editor
   * Add pure utility functions in `block-filter-utils.ts` for testability
   * Add unit tests for the block filtering logic

### Other information:
- [x] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
no


## Testing instructions:

Add the feature flag via the filter. 
```
add_filter( 'jetpack_block_editor_feature_flags', 'eb_register_feature' );

function eb_register_feature( $flags ) {
    $flags['central-form-management'] = true;
    return $flags;
}
```
via direct the form editor
   1. Create or edit a Jetpack Form post (go to Jetpack > Feedback > Add New, or edit an existing form response to access the form editor)
   2. Open the block inserter (click the + button or use /)
   3. Verify that only form-related blocks are visible (form fields, core blocks like paragraphs, headings, etc.)
   4. Non-form blocks like embeds, widgets, or other Jetpack blocks should be hidden
   5. Navigate away from the form editor to a regular post/page
   6. Verify that all blocks are restored and visible in the inserter

via the page. 

1. Create a new page. 
2. insert the form block. 
3. click the edit form. 
4. Notice now then you go and insert the block only the form blocks appear. 
