### PR TITLE
Newsletter Settings (4/4): Add categories section

### DIFF
--- a/projects/packages/newsletter/changelog/newsletter-category-settings
+++ b/projects/packages/newsletter/changelog/newsletter-category-settings
@@ -1,4 +1,4 @@
 Significance: patch
 Type: added
 
-Added categories settings sections.
+Add a newsletter categories section to the settings screen.

--- a/projects/packages/newsletter/changelog/newsletter-category-settings
+++ b/projects/packages/newsletter/changelog/newsletter-category-settings
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Added categories settings sections.

--- a/projects/packages/newsletter/src/settings/index.tsx
+++ b/projects/packages/newsletter/src/settings/index.tsx
@@ -15,6 +15,7 @@ import {
 	EmailSenderSettingsSection,
 	EmailReplyToSettingsSection,
 	NewsletterSection,
+	NewsletterCategoriesSection,
 	PaidNewsletterSection,
 	SubscriptionsSection,
 	WelcomeEmailSection,
@@ -31,6 +32,9 @@ import './style.scss';
 function normalizeSettings( settings: Record< string, unknown > ): NewsletterSettings {
 	return {
 		...( settings as NewsletterSettings ),
+		wpcom_newsletter_categories: ( ( settings.wpcom_newsletter_categories as number[] ) || [] ).map(
+			String
+		),
 		// Ensure wpcom_subscription_emails_use_excerpt is a string ('0' or '1')
 		wpcom_subscription_emails_use_excerpt: String(
 			Number( settings.wpcom_subscription_emails_use_excerpt ) || 0
@@ -62,6 +66,12 @@ function NewsletterSettingsApp(): JSX.Element | null {
 
 	// Snackbar notification state
 	const [ snackbarMessage, setSnackbarMessage ] = useState< string | null >( null );
+
+	// Newsletter categories state (for manual save)
+	const [ newsletterCategoriesChanges, setNewsletterCategoriesChanges ] = useState<
+		Partial< NewsletterSettings >
+	>( {} );
+	const [ isSavingNewsletterCategories, setIsSavingNewsletterCategories ] = useState( false );
 
 	// Welcome email state (for manual save)
 	const [ welcomeEmailChanges, setWelcomeEmailChanges ] = useState< Partial< NewsletterSettings > >(
@@ -196,6 +206,83 @@ function NewsletterSettingsApp(): JSX.Element | null {
 			} );
 	}, [ subscriptionChanges, data ] );
 
+	// Handle newsletter categories changes (staged, not auto-saved)
+	const handleNewsletterCategoriesChange = useCallback(
+		( updates: Partial< NewsletterSettings > ) => {
+			// Update local state immediately (like auto-save)
+			setData( prev => ( { ...prev, ...updates } ) );
+			// Track changes for save button state
+			setNewsletterCategoriesChanges( prev => ( { ...prev, ...updates } ) );
+		},
+		[]
+	);
+
+	// Save newsletter categories settings
+	const saveNewsletterCategories = useCallback( () => {
+		if ( ! data ) {
+			return;
+		}
+
+		setIsSavingNewsletterCategories( true );
+		setError( null );
+
+		// Convert categories from strings to numbers for API
+		const apiUpdates: Record< string, unknown > = { ...newsletterCategoriesChanges };
+
+		// Only include categories if they exist AND are not empty
+		if (
+			apiUpdates.wpcom_newsletter_categories &&
+			Array.isArray( apiUpdates.wpcom_newsletter_categories )
+		) {
+			if ( ( apiUpdates.wpcom_newsletter_categories as string[] ).length > 0 ) {
+				apiUpdates.wpcom_newsletter_categories = (
+					apiUpdates.wpcom_newsletter_categories as string[]
+				 ).map( Number );
+			} else {
+				// Remove empty categories from the update payload to avoid API error
+				delete apiUpdates.wpcom_newsletter_categories;
+			}
+		}
+
+		restApi
+			.updateSettings( apiUpdates )
+			.then( () => {
+				setError( null );
+				setNewsletterCategoriesChanges( {} );
+				setSnackbarMessage( __( 'Newsletter categories saved', 'jetpack-newsletter' ) );
+
+				// Re-fetch settings to sync client with server
+				// (backend may not update empty categories)
+				return restApi.fetchSettings();
+			} )
+			.then( ( settings: Record< string, unknown > ) => {
+				// Update client state with server values, preserving unsaved changes in other sections
+				const serverData = normalizeSettings( settings );
+				setData( {
+					...serverData,
+					...subscriptionChanges,
+					...senderNameChanges,
+					...welcomeEmailChanges,
+				} );
+			} )
+			.catch( ( err: Error ) => {
+				// eslint-disable-next-line no-console
+				console.error( 'Newsletter categories save error:', err );
+				setError(
+					err.message || __( 'Failed to save newsletter categories', 'jetpack-newsletter' )
+				);
+			} )
+			.finally( () => {
+				setIsSavingNewsletterCategories( false );
+			} );
+	}, [
+		newsletterCategoriesChanges,
+		data,
+		subscriptionChanges,
+		senderNameChanges,
+		welcomeEmailChanges,
+	] );
+
 	// Handle welcome email changes (staged, not auto-saved)
 	const handleWelcomeEmailChange = useCallback( ( updates: Partial< NewsletterSettings > ) => {
 		// Update local state immediately (like auto-save)
@@ -256,6 +343,7 @@ function NewsletterSettingsApp(): JSX.Element | null {
 
 	const hasSubscriptionChanges = Object.keys( subscriptionChanges ).length > 0;
 	const hasSenderNameChanges = Object.keys( senderNameChanges ).length > 0;
+	const hasNewsletterCategoriesChanges = Object.keys( newsletterCategoriesChanges ).length > 0;
 	const hasWelcomeEmailChanges = Object.keys( welcomeEmailChanges ).length > 0;
 
 	return (
@@ -282,6 +370,17 @@ function NewsletterSettingsApp(): JSX.Element | null {
 
 			<PaidNewsletterSection
 				jetpackSettings={ jetpackSettings }
+				isNewsletterEnabled={ data.subscriptions }
+			/>
+
+			<NewsletterCategoriesSection
+				data={ data }
+				onChange={ handleNewsletterCategoriesChange }
+				onSave={ saveNewsletterCategories }
+				isSaving={ isSavingNewsletterCategories }
+				hasChanges={ hasNewsletterCategoriesChanges }
+				jetpackSettings={ jetpackSettings }
+				onError={ setError }
 				isNewsletterEnabled={ data.subscriptions }
 			/>
 

--- a/projects/packages/newsletter/src/settings/index.tsx
+++ b/projects/packages/newsletter/src/settings/index.tsx
@@ -250,20 +250,6 @@ function NewsletterSettingsApp(): JSX.Element | null {
 				setError( null );
 				setNewsletterCategoriesChanges( {} );
 				setSnackbarMessage( __( 'Newsletter categories saved', 'jetpack-newsletter' ) );
-
-				// Re-fetch settings to sync client with server
-				// (backend may not update empty categories)
-				return restApi.fetchSettings();
-			} )
-			.then( ( settings: Record< string, unknown > ) => {
-				// Update client state with server values, preserving unsaved changes in other sections
-				const serverData = normalizeSettings( settings );
-				setData( {
-					...serverData,
-					...subscriptionChanges,
-					...senderNameChanges,
-					...welcomeEmailChanges,
-				} );
 			} )
 			.catch( ( err: Error ) => {
 				// eslint-disable-next-line no-console
@@ -275,13 +261,7 @@ function NewsletterSettingsApp(): JSX.Element | null {
 			.finally( () => {
 				setIsSavingNewsletterCategories( false );
 			} );
-	}, [
-		newsletterCategoriesChanges,
-		data,
-		subscriptionChanges,
-		senderNameChanges,
-		welcomeEmailChanges,
-	] );
+	}, [ newsletterCategoriesChanges, data ] );
 
 	// Handle welcome email changes (staged, not auto-saved)
 	const handleWelcomeEmailChange = useCallback( ( updates: Partial< NewsletterSettings > ) => {

--- a/projects/packages/newsletter/src/settings/sections/index.ts
+++ b/projects/packages/newsletter/src/settings/sections/index.ts
@@ -6,6 +6,7 @@ export { EmailBylineSection } from './email-byline-section';
 export { EmailSenderSettingsSection } from './email-sender-settings-section';
 export { EmailReplyToSettingsSection } from './email-reply-to-settings-section';
 export { NewsletterSection } from './newsletter-section';
+export { NewsletterCategoriesSection } from './newsletter-categories-section';
 export { PaidNewsletterSection } from './paid-newsletter-section';
 export { SubscriptionsSection } from './subscriptions-section';
 export { WelcomeEmailSection } from './welcome-email-section';

--- a/projects/packages/newsletter/src/settings/sections/newsletter-categories-section.tsx
+++ b/projects/packages/newsletter/src/settings/sections/newsletter-categories-section.tsx
@@ -1,0 +1,235 @@
+/**
+ * External dependencies
+ */
+import { WpcomSupportLink } from '@automattic/jetpack-shared-extension-utils/components';
+import { Button, ExternalLink } from '@wordpress/components';
+import { DataForm, type Field, useFormValidity } from '@wordpress/dataviews/wp';
+import { createInterpolateElement, useEffect, useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+/**
+ * Internal dependencies
+ */
+import type { NewsletterSettings, JetpackNewsletterSettings, WordPressCategory } from '../types';
+
+interface NewsletterCategoriesSectionProps {
+	data: NewsletterSettings;
+	onChange: ( updates: Partial< NewsletterSettings > ) => void;
+	onSave: () => void;
+	isSaving: boolean;
+	hasChanges: boolean;
+	jetpackSettings: JetpackNewsletterSettings | undefined;
+	onError: ( error: string ) => void;
+	isNewsletterEnabled: boolean;
+}
+
+/**
+ * Newsletter Categories Section Component
+ *
+ * @param {NewsletterCategoriesSectionProps} props - Component props
+ * @return {JSX.Element} The newsletter categories section
+ */
+export function NewsletterCategoriesSection( {
+	data,
+	onChange,
+	onSave,
+	isSaving,
+	hasChanges,
+	jetpackSettings,
+	onError,
+	isNewsletterEnabled,
+}: NewsletterCategoriesSectionProps ): JSX.Element {
+	const [ categories, setCategories ] = useState< WordPressCategory[] >( [] );
+	const [ isFetchingCategories, setIsFetchingCategories ] = useState( true );
+
+	// Fetch WordPress categories on mount
+	useEffect( () => {
+		const wpApiSettings = ( window as Window & { wpApiSettings?: { root: string; nonce: string } } )
+			.wpApiSettings;
+
+		if ( ! wpApiSettings?.root ) {
+			setIsFetchingCategories( false );
+			return;
+		}
+
+		// Recursive function to fetch all pages of categories
+		const fetchAllCategories = async (
+			page = 1,
+			allCategories: { id: number; name: string }[] = []
+		): Promise< { id: number; name: string }[] > => {
+			const response = await fetch(
+				`${ wpApiSettings.root }wp/v2/categories?per_page=100&page=${ page }`,
+				{
+					credentials: 'same-origin',
+					headers: {
+						'X-WP-Nonce': wpApiSettings.nonce,
+					},
+				}
+			);
+
+			if ( ! response.ok ) {
+				throw new Error(
+					`Failed to load categories: ${ response.status } ${ response.statusText }`
+				);
+			}
+
+			const pageCategories = await response.json();
+			const totalPages = parseInt( response.headers.get( 'X-WP-TotalPages' ) || '1', 10 );
+			const combined = [ ...allCategories, ...pageCategories ];
+
+			// If there are more pages, fetch them recursively
+			if ( page < totalPages ) {
+				return fetchAllCategories( page + 1, combined );
+			}
+
+			return combined;
+		};
+
+		// Fetch all categories from WordPress REST API
+		fetchAllCategories()
+			.then( ( fetchedCategories: { id: number; name: string }[] ) => {
+				// Convert category IDs to strings
+				setCategories(
+					fetchedCategories.map( cat => ( {
+						id: String( cat.id ),
+						name: cat.name,
+					} ) )
+				);
+				setIsFetchingCategories( false );
+			} )
+			.catch( ( err: Error ) => {
+				onError( err.message || __( 'Failed to load categories', 'jetpack-newsletter' ) );
+				setIsFetchingCategories( false );
+			} );
+	}, [ onError ] );
+
+	// Define fields
+	const fields: Field< NewsletterSettings >[] = [
+		{
+			id: 'wpcom_newsletter_categories_enabled',
+			label: __( 'Enable newsletter categories', 'jetpack-newsletter' ),
+			type: 'boolean' as const,
+			Edit: 'toggle' as const,
+		},
+		{
+			id: 'wpcom_newsletter_categories',
+			label: __(
+				'Which categories will you use for newsletter subscribers? Select all that apply:',
+				'jetpack-newsletter'
+			),
+			type: 'array' as const,
+			elements: categories.map( cat => ( {
+				value: cat.id,
+				label: cat.name,
+			} ) ),
+			isValid: {
+				elements: true,
+				custom: ( item: NewsletterSettings ) => {
+					if (
+						item.wpcom_newsletter_categories_enabled &&
+						! item.wpcom_newsletter_categories?.length
+					) {
+						return __(
+							'Please select at least one category when newsletter categories are enabled.',
+							'jetpack-newsletter'
+						);
+					}
+					return null;
+				},
+			},
+		},
+	];
+
+	// Field list for newsletter categories section
+	const newsletterCategoriesFieldIds = data.wpcom_newsletter_categories_enabled
+		? [ 'wpcom_newsletter_categories_enabled', 'wpcom_newsletter_categories' ]
+		: [ 'wpcom_newsletter_categories_enabled' ];
+
+	const newsletterCategoriesFields = fields.filter( f =>
+		newsletterCategoriesFieldIds.includes( f.id )
+	);
+
+	// Form configuration for newsletter categories
+	const newsletterCategoriesForm = {
+		layout: {
+			type: 'regular' as const,
+			labelPosition: 'top' as const,
+		},
+		fields: newsletterCategoriesFieldIds,
+	};
+
+	// Get form validity state for newsletter categories
+	const { validity = {}, isValid = true } =
+		useFormValidity( data, newsletterCategoriesFields, newsletterCategoriesForm ) || {};
+
+	// Translation strings for save button
+	const savingText = __( 'Saving…', 'jetpack-newsletter' );
+	const saveText = __( 'Save', 'jetpack-newsletter' );
+
+	// Build subscribe block documentation URL and component
+	const subscribeBlockUrl = jetpackSettings?.isWpcomPlatform
+		? 'https://wordpress.com/support/wordpress-editor/blocks/subscribe-block/'
+		: `https://jetpack.com/redirect/?source=jetpack-support-subscribe-block&site=${
+				jetpackSettings?.blogID || ''
+		  }`;
+
+	const SubscribeBlockLink = jetpackSettings?.isWpcomPlatform ? (
+		<WpcomSupportLink supportLink={ subscribeBlockUrl } supportPostId={ 170164 } />
+	) : (
+		<ExternalLink href={ subscribeBlockUrl } />
+	);
+
+	return (
+		<div className="newsletter-settings__section">
+			<h3 className="newsletter-settings__section-title">
+				{ __( 'Newsletter categories', 'jetpack-newsletter' ) }
+			</h3>
+			<p className="newsletter-settings__section-description">
+				{ createInterpolateElement(
+					__(
+						"Newsletter categories let you select the content that's emailed to subscribers. When enabled, only posts in the selected categories will be sent as newsletters. By default, subscribers can choose from your selected categories, or you can pre-select categories using the <link>subscribe block</link>. When you add a new category, your existing subscribers will be automatically subscribed to it.",
+						'jetpack-newsletter'
+					),
+					{
+						link: SubscribeBlockLink,
+					}
+				) }
+			</p>
+			<fieldset className="newsletter-settings__section-content" disabled={ ! isNewsletterEnabled }>
+				<DataForm
+					data={ data }
+					fields={ newsletterCategoriesFields }
+					form={ newsletterCategoriesForm }
+					onChange={ onChange }
+					validity={ validity }
+				/>
+
+				{ data.wpcom_newsletter_categories_enabled && jetpackSettings?.siteAdminUrl && (
+					<div className="newsletter-settings__link">
+						<ExternalLink
+							href={ `${ jetpackSettings.siteAdminUrl }edit-tags.php?taxonomy=category&referer=newsletter-categories` }
+						>
+							{ __( 'Add New Category', 'jetpack-newsletter' ) }
+						</ExternalLink>
+					</div>
+				) }
+
+				<div className="newsletter-settings__section-actions">
+					<Button
+						variant="primary"
+						onClick={ onSave }
+						disabled={
+							! isNewsletterEnabled ||
+							isSaving ||
+							! hasChanges ||
+							isFetchingCategories ||
+							( data.wpcom_newsletter_categories_enabled && ! isValid )
+						}
+						isBusy={ isSaving }
+					>
+						{ isSaving ? savingText : saveText }
+					</Button>
+				</div>
+			</fieldset>
+		</div>
+	);
+}

--- a/projects/packages/newsletter/src/settings/sections/newsletter-categories-section.tsx
+++ b/projects/packages/newsletter/src/settings/sections/newsletter-categories-section.tsx
@@ -56,15 +56,16 @@ export function NewsletterCategoriesSection( {
 			page = 1,
 			allCategories: { id: number; name: string }[] = []
 		): Promise< { id: number; name: string }[] > => {
-			const response = await fetch(
-				`${ wpApiSettings.root }wp/v2/categories?per_page=100&page=${ page }`,
-				{
-					credentials: 'same-origin',
-					headers: {
-						'X-WP-Nonce': wpApiSettings.nonce,
-					},
-				}
-			);
+			const url = new URL( 'wp/v2/categories', wpApiSettings.root );
+			url.searchParams.set( 'per_page', '100' );
+			url.searchParams.set( 'page', String( page ) );
+
+			const response = await fetch( url.toString(), {
+				credentials: 'same-origin',
+				headers: {
+					'X-WP-Nonce': wpApiSettings.nonce,
+				},
+			} );
 
 			if ( ! response.ok ) {
 				throw new Error(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This is part of solving [DOTCOM-15286](https://linear.app/a8c/issue/DOTCOM-15286) and has been split out from the original PR (https://github.com/Automattic/jetpack/pull/46136) in the hope it makes the changes easier to review. It is the fourth of four PRs (previously https://github.com/Automattic/jetpack/pull/46470, https://github.com/Automattic/jetpack/pull/46471, https://github.com/Automattic/jetpack/pull/46473).

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Add newsletter categories section to the newsletter settings page

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->


  * Make add_filter( 'jetpack_wp_admin_newsletter_settings_enabled', '__return_true' ); run early, e.g. by adding it to a new mu-plugin or just by pasting it into the top of jetpack-dev/jetpack.php using the plugin file editor on a jurassic ninja site.
  * Enable the newsletter module if it isn't already (it is on WoA)
  * Go to Jetpack → Newsletter in wp-admin                                                                                            
  * Scroll to the "Newsletter categories" section                                                                                                
  * Toggle "Enable newsletter categories" on                                                                                                     
  * Verify the category selection checkboxes appear                                                                                              
  * Select one or more categories and click Save                                                                                                 
  * Verify the settings persist after page reload                                                                                                
  * Try saving with no categories selected - should show validation error                                                                        
  * If you have 100+ categories, verify all categories load (pagination)     

