### PR TITLE
Forms: add status filter for form posts

### DIFF
--- a/projects/packages/forms/changelog/add-forms-status-filter
+++ b/projects/packages/forms/changelog/add-forms-status-filter
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Forms: add status filter for form posts.

--- a/projects/packages/forms/src/dashboard/forms/index.tsx
+++ b/projects/packages/forms/src/dashboard/forms/index.tsx
@@ -20,7 +20,7 @@ import useFormsData from '../hooks/use-forms-data.ts';
 import { defaultLayouts, useView } from './views.ts';
 import './style.scss';
 import type { FormListItem } from '../hooks/use-forms-data.ts';
-import type { Operator } from '@wordpress/dataviews/wp';
+import type { Action, Operator } from '@wordpress/dataviews/wp';
 
 /**
  * Forms dashboard "Forms" route.
@@ -52,13 +52,18 @@ export default function FormsDashboardForms(): JSX.Element | null {
 		return statusFilterValue;
 	}, [ view.filters ] );
 
+	const isViewingTrash = useMemo( () => {
+		const statusFilterValue = view.filters?.find( filter => filter.field === 'status' )?.value;
+		return statusFilterValue === 'trash';
+	}, [ view.filters ] );
+
 	const { records, isLoading, totalItems, totalPages } = useFormsData(
 		view.page,
 		view.perPage,
 		view.search,
 		statusQuery
 	);
-	const { isDeleting, trashForm } = useDeleteForm( {
+	const { isDeleting, trashForm, restoreForm } = useDeleteForm( {
 		view,
 		setView,
 		recordsLength: records?.length ?? 0,
@@ -137,8 +142,8 @@ export default function FormsDashboardForms(): JSX.Element | null {
 		[ dateSettings.formats.datetime, statusLabel ]
 	);
 
-	const actions = useMemo(
-		() => [
+	const actions = useMemo( () => {
+		const actionsList: Action< FormListItem >[] = [
 			{
 				id: 'edit-form',
 				isPrimary: false,
@@ -155,12 +160,15 @@ export default function FormsDashboardForms(): JSX.Element | null {
 					window.location.href = url.toString();
 				},
 			},
-			{
-				id: 'delete-form',
+		];
+
+		if ( isViewingTrash ) {
+			actionsList.push( {
+				id: 'restore-form',
 				isPrimary: false,
-				label: __( 'Trash', 'jetpack-forms' ),
+				label: __( 'Restore', 'jetpack-forms' ),
 				supportsBulk: false,
-				callback( items: FormListItem[] ) {
+				async callback( items: FormListItem[] ) {
 					if ( isDeleting ) {
 						return;
 					}
@@ -168,12 +176,31 @@ export default function FormsDashboardForms(): JSX.Element | null {
 					if ( ! item ) {
 						return;
 					}
-					trashForm( item );
+					await restoreForm( item );
 				},
+			} );
+			return actionsList;
+		}
+
+		actionsList.push( {
+			id: 'trash-form',
+			isPrimary: false,
+			label: __( 'Trash', 'jetpack-forms' ),
+			supportsBulk: false,
+			async callback( items: FormListItem[] ) {
+				if ( isDeleting ) {
+					return;
+				}
+				const [ item ] = items;
+				if ( ! item ) {
+					return;
+				}
+				await trashForm( item );
 			},
-		],
-		[ isDeleting, trashForm ]
-	);
+		} );
+
+		return actionsList;
+	}, [ isDeleting, isViewingTrash, restoreForm, trashForm ] );
 
 	const paginationInfo = useMemo(
 		() => ( {

--- a/projects/packages/forms/src/dashboard/forms/index.tsx
+++ b/projects/packages/forms/src/dashboard/forms/index.tsx
@@ -38,15 +38,15 @@ export default function FormsDashboardForms(): JSX.Element | null {
 	const statusQuery = useMemo( () => {
 		const statusFilterValue = view.filters?.find( filter => filter.field === 'status' )?.value;
 
-		// Default: show Published forms and keep Trash out unless explicitly requested.
+		// Default: show all non-trash forms (matches WP core list behavior).
 		const nonTrashStatuses = 'publish,draft,pending,future,private';
 
 		if ( ! statusFilterValue ) {
-			return 'publish';
+			return nonTrashStatuses;
 		}
 
 		if ( statusFilterValue === 'all' ) {
-			return `${ nonTrashStatuses },trash`;
+			return nonTrashStatuses;
 		}
 
 		return statusFilterValue;

--- a/projects/packages/forms/src/dashboard/forms/index.tsx
+++ b/projects/packages/forms/src/dashboard/forms/index.tsx
@@ -20,6 +20,7 @@ import useFormsData from '../hooks/use-forms-data.ts';
 import { defaultLayouts, useView } from './views.ts';
 import './style.scss';
 import type { FormListItem } from '../hooks/use-forms-data.ts';
+import type { Operator } from '@wordpress/dataviews/wp';
 
 /**
  * Forms dashboard "Forms" route.
@@ -33,15 +34,35 @@ export default function FormsDashboardForms(): JSX.Element | null {
 
 	const dateSettings = getDateSettings();
 	const [ view, setView ] = useView();
+
+	const statusQuery = useMemo( () => {
+		const statusFilterValue = view.filters?.find( filter => filter.field === 'status' )?.value;
+
+		// Default: show Published forms and keep Trash out unless explicitly requested.
+		const nonTrashStatuses = 'publish,draft,pending,future,private';
+
+		if ( ! statusFilterValue ) {
+			return 'publish';
+		}
+
+		if ( statusFilterValue === 'all' ) {
+			return `${ nonTrashStatuses },trash`;
+		}
+
+		return statusFilterValue;
+	}, [ view.filters ] );
+
 	const { records, isLoading, totalItems, totalPages } = useFormsData(
 		view.page,
 		view.perPage,
-		view.search
+		view.search,
+		statusQuery
 	);
 	const { isDeleting, trashForm } = useDeleteForm( {
 		view,
 		setView,
 		recordsLength: records?.length ?? 0,
+		statusQuery,
 	} );
 
 	useEffect( () => {
@@ -90,6 +111,18 @@ export default function FormsDashboardForms(): JSX.Element | null {
 				label: __( 'Status', 'jetpack-forms' ),
 				getValue: ( { item }: { item: FormListItem } ) => item.status,
 				render: ( { item }: { item: FormListItem } ) => statusLabel( item.status ),
+				elements: [
+					{ label: __( 'All', 'jetpack-forms' ), value: 'all' },
+					{ label: __( 'Published', 'jetpack-forms' ), value: 'publish' },
+					{ label: __( 'Draft', 'jetpack-forms' ), value: 'draft' },
+					{ label: __( 'Pending review', 'jetpack-forms' ), value: 'pending' },
+					{ label: __( 'Scheduled', 'jetpack-forms' ), value: 'future' },
+					{ label: __( 'Private', 'jetpack-forms' ), value: 'private' },
+					{ label: __( 'Trash', 'jetpack-forms' ), value: 'trash' },
+				],
+				// Mark as primary so the filter UI (and its pill) is visible by default on load.
+				// DataViews expects `operators` to be typed as a known operator union; keep this narrowly typed.
+				filterBy: { operators: [ 'is' ] as Operator[], isPrimary: true },
 				enableSorting: false,
 			},
 			{

--- a/projects/packages/forms/src/dashboard/forms/views.ts
+++ b/projects/packages/forms/src/dashboard/forms/views.ts
@@ -7,7 +7,8 @@ const LAYOUT_TABLE = 'table';
 export const defaultView: View = {
 	type: LAYOUT_TABLE,
 	search: '',
-	filters: [],
+	// Default to showing Published forms.
+	filters: [ { field: 'status', operator: 'is', value: 'publish' } ],
 	page: 1,
 	perPage: 20,
 	fields: [ 'title', 'entries', 'status', 'modified' ],

--- a/projects/packages/forms/src/dashboard/forms/views.ts
+++ b/projects/packages/forms/src/dashboard/forms/views.ts
@@ -7,8 +7,7 @@ const LAYOUT_TABLE = 'table';
 export const defaultView: View = {
 	type: LAYOUT_TABLE,
 	search: '',
-	// Default to showing Published forms.
-	filters: [ { field: 'status', operator: 'is', value: 'publish' } ],
+	filters: [ { field: 'status', operator: 'is', value: 'all' } ],
 	page: 1,
 	perPage: 20,
 	fields: [ 'title', 'entries', 'status', 'modified' ],

--- a/projects/packages/forms/src/dashboard/hooks/use-delete-form.ts
+++ b/projects/packages/forms/src/dashboard/hooks/use-delete-form.ts
@@ -46,7 +46,6 @@ type UseDeleteFormReturn = {
  * @param args.view          - Current DataViews view (for page/perPage/search).
  * @param args.setView       - View setter (used to navigate to previous page when needed).
  * @param args.recordsLength - Number of records currently displayed (used for pagination edge case).
- *
  * @param args.statusQuery   - REST `status` query param for the current list view (used for cache invalidation).
  * @return State + handler for executing the trash operation.
  */

--- a/projects/packages/forms/src/dashboard/hooks/use-delete-form.ts
+++ b/projects/packages/forms/src/dashboard/hooks/use-delete-form.ts
@@ -36,6 +36,7 @@ type UseDeleteFormArgs = {
 type UseDeleteFormReturn = {
 	isDeleting: boolean;
 	trashForm: ( item: FormListItem ) => Promise< void >;
+	restoreForm: ( item: FormListItem ) => Promise< void >;
 };
 
 /**
@@ -99,6 +100,50 @@ export default function useDeleteForm( {
 			}
 		},
 		[ createErrorNotice, createSuccessNotice, currentQuery, invalidateResolution, saveEntityRecord ]
+	);
+
+	const restoreForm = useCallback(
+		async ( item: FormListItem ) => {
+			if ( ! item || isDeleting ) {
+				return;
+			}
+
+			setIsDeleting( true );
+
+			try {
+				await saveEntityRecord(
+					'postType',
+					'jetpack_form',
+					{ id: item.id, status: 'publish' },
+					{ throwOnError: true }
+				);
+				createSuccessNotice( __( 'Form restored.', 'jetpack-forms' ), {
+					type: 'snackbar',
+					id: `restore-form-${ item.id }`,
+				} );
+			} catch {
+				createErrorNotice( __( 'Could not restore form.', 'jetpack-forms' ), {
+					type: 'snackbar',
+					id: `restore-form-error-${ item.id }`,
+				} );
+			} finally {
+				setIsDeleting( false );
+				invalidateResolution( 'getEntityRecords', [ 'postType', 'jetpack_form', currentQuery ] );
+				invalidateResolution( 'getEntityRecords', [
+					'postType',
+					'jetpack_form',
+					{ ...currentQuery, per_page: 1, _fields: 'id' },
+				] );
+			}
+		},
+		[
+			createErrorNotice,
+			createSuccessNotice,
+			currentQuery,
+			invalidateResolution,
+			isDeleting,
+			saveEntityRecord,
+		]
 	);
 
 	const trashForm = useCallback(
@@ -170,5 +215,6 @@ export default function useDeleteForm( {
 	return {
 		isDeleting,
 		trashForm,
+		restoreForm,
 	};
 }

--- a/projects/packages/forms/src/dashboard/hooks/use-delete-form.ts
+++ b/projects/packages/forms/src/dashboard/hooks/use-delete-form.ts
@@ -30,6 +30,7 @@ type UseDeleteFormArgs = {
 	view: View;
 	setView: ( newView: View ) => void;
 	recordsLength: number;
+	statusQuery: string;
 };
 
 type UseDeleteFormReturn = {
@@ -45,12 +46,14 @@ type UseDeleteFormReturn = {
  * @param args.setView       - View setter (used to navigate to previous page when needed).
  * @param args.recordsLength - Number of records currently displayed (used for pagination edge case).
  *
+ * @param args.statusQuery   - REST `status` query param for the current list view (used for cache invalidation).
  * @return State + handler for executing the trash operation.
  */
 export default function useDeleteForm( {
 	view,
 	setView,
 	recordsLength,
+	statusQuery,
 }: UseDeleteFormArgs ): UseDeleteFormReturn {
 	const [ isDeleting, setIsDeleting ] = useState( false );
 
@@ -64,8 +67,8 @@ export default function useDeleteForm( {
 	const search = view.search ?? '';
 
 	const currentQuery = useMemo(
-		() => getFormsListQuery( page, perPage, search ),
-		[ page, perPage, search ]
+		() => getFormsListQuery( page, perPage, search, statusQuery ),
+		[ page, perPage, search, statusQuery ]
 	);
 
 	const undoTrashForm = useCallback(

--- a/projects/packages/forms/src/dashboard/hooks/use-forms-data.ts
+++ b/projects/packages/forms/src/dashboard/hooks/use-forms-data.ts
@@ -17,10 +17,11 @@ export type FormListItem = {
  * @param page    - Current page number.
  * @param perPage - Items per page.
  * @param search  - Search term.
+ * @param status  - REST `status` query param (comma-separated list or single status).
  *
  * @return Query params for useEntityRecords / core-data.
  */
-export function getFormsListQuery( page: number, perPage: number, search: string ) {
+export function getFormsListQuery( page: number, perPage: number, search: string, status: string ) {
 	const queryParams: Record< string, unknown > = {
 		context: 'edit',
 		jetpack_forms_context: 'dashboard',
@@ -28,7 +29,7 @@ export function getFormsListQuery( page: number, perPage: number, search: string
 		orderby: 'modified',
 		page,
 		per_page: perPage,
-		status: 'publish,draft,pending,future,private',
+		status,
 	};
 
 	if ( search ) {
@@ -60,17 +61,19 @@ type UseFormsDataReturn = {
  * @param page    - Current page number.
  * @param perPage - Items per page.
  * @param search  - Search term.
+ * @param status  - REST `status` query param (comma-separated list or single status).
  *
  * @return Forms list data for the current query.
  */
 export default function useFormsData(
 	page: number,
 	perPage: number,
-	search: string
+	search: string,
+	status: string
 ): UseFormsDataReturn {
 	const query = useMemo( () => {
-		return getFormsListQuery( page, perPage, search );
-	}, [ page, perPage, search ] );
+		return getFormsListQuery( page, perPage, search, status );
+	}, [ page, perPage, search, status ] );
 
 	const {
 		records: rawRecords,


### PR DESCRIPTION
## Proposed changes:

Changes:
* Adds 'status' filter (published, draft, trash, etc) to DataViews table for form posts. 
* On initial page load, filter for for 'all' status (all but trash) and show the filter pill
* When filtering for trash, hide the 'Trash' action and show a 'Restore' action

**Screenshot: status filter**
<img width="1346" height="670" alt="form-status-filter-2" src="https://github.com/user-attachments/assets/dc282c47-beeb-4705-a2fa-3cebf38b2cef" />

**Screenshot: restore action**
<img width="1347" height="380" alt="restore-action" src="https://github.com/user-attachments/assets/93579bef-14ec-4d9e-a1f9-9929e1601ca6" />


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
See Figma designs: 8TmDfrB54NU4Rzj19Qs9Tg-fi-5374_18492

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Add this feature flag to your test site. 

```
add_filter( 'jetpack_block_editor_feature_flags', 'eb_register_feature' );
function eb_register_feature( $flags ) {
    $flags['central-form-management'] = true;
    return $flags;
}
```

Test new filter: 
* Go to Jetpack > Forms
* Confirm Forms tab loads with 'all' status applied. 
* Use actions to move some forms to trash. 
* Update filter status to 'trash' and confirm you can see those loaded. 
* Click actions icon, Restore a trashed post, and confirm it is returned to Published status

Test for now regression:
* Remove feature flag and confirm everything works as before (no centralized form management).