### PR TITLE
Forms: add permanent delete for form posts

### DIFF
--- a/projects/packages/forms/changelog/add-forms-delete-permanently
+++ b/projects/packages/forms/changelog/add-forms-delete-permanently
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Forms: add permanent delete for form posts.

--- a/projects/packages/forms/src/dashboard/forms/index.tsx
+++ b/projects/packages/forms/src/dashboard/forms/index.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { JetpackLogo } from '@automattic/jetpack-components';
+import { __experimentalConfirmDialog as ConfirmDialog } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
 import { DataViews } from '@wordpress/dataviews/wp';
 import { dateI18n, getSettings as getDateSettings } from '@wordpress/date';
 import { useCallback, useEffect, useMemo } from '@wordpress/element';
@@ -63,7 +64,15 @@ export default function FormsDashboardForms(): JSX.Element | null {
 		view.search,
 		statusQuery
 	);
-	const { isDeleting, trashForm, restoreForm } = useDeleteForm( {
+	const {
+		isDeleting,
+		trashForm,
+		restoreForm,
+		isPermanentDeleteConfirmOpen,
+		openPermanentDeleteConfirm,
+		closePermanentDeleteConfirm,
+		confirmPermanentDelete,
+	} = useDeleteForm( {
 		view,
 		setView,
 		recordsLength: records?.length ?? 0,
@@ -179,6 +188,22 @@ export default function FormsDashboardForms(): JSX.Element | null {
 					await restoreForm( item );
 				},
 			} );
+			actionsList.push( {
+				id: 'delete-form-permanently',
+				isPrimary: false,
+				label: __( 'Delete permanently', 'jetpack-forms' ),
+				supportsBulk: false,
+				async callback( items: FormListItem[] ) {
+					if ( isDeleting ) {
+						return;
+					}
+					const [ item ] = items;
+					if ( ! item ) {
+						return;
+					}
+					openPermanentDeleteConfirm( item );
+				},
+			} );
 			return actionsList;
 		}
 
@@ -200,7 +225,7 @@ export default function FormsDashboardForms(): JSX.Element | null {
 		} );
 
 		return actionsList;
-	}, [ isDeleting, isViewingTrash, restoreForm, trashForm ] );
+	}, [ isDeleting, isViewingTrash, openPermanentDeleteConfirm, restoreForm, trashForm ] );
 
 	const paginationInfo = useMemo(
 		() => ( {
@@ -260,6 +285,20 @@ export default function FormsDashboardForms(): JSX.Element | null {
 					getItemId={ getItemId }
 					defaultLayouts={ defaultLayouts }
 				>
+					<ConfirmDialog
+						onCancel={ closePermanentDeleteConfirm }
+						onConfirm={ confirmPermanentDelete }
+						isOpen={ isPermanentDeleteConfirmOpen }
+						confirmButtonText={ __( 'Delete permanently', 'jetpack-forms' ) }
+					>
+						<h3>{ __( 'Delete permanently', 'jetpack-forms' ) }</h3>
+						<p>
+							{ __(
+								'This will permanently delete the form. This action cannot be undone.',
+								'jetpack-forms'
+							) }
+						</p>
+					</ConfirmDialog>
 					<div className="jp-forms-filters-bar">
 						<div className="jp-forms-filters-bar__chips">
 							<DataViews.FiltersToggled className="jp-forms-filters-container" />

--- a/projects/packages/forms/src/dashboard/hooks/use-delete-form.ts
+++ b/projects/packages/forms/src/dashboard/hooks/use-delete-form.ts
@@ -37,6 +37,10 @@ type UseDeleteFormReturn = {
 	isDeleting: boolean;
 	trashForm: ( item: FormListItem ) => Promise< void >;
 	restoreForm: ( item: FormListItem ) => Promise< void >;
+	isPermanentDeleteConfirmOpen: boolean;
+	openPermanentDeleteConfirm: ( item: FormListItem ) => void;
+	closePermanentDeleteConfirm: () => void;
+	confirmPermanentDelete: () => Promise< void >;
 };
 
 /**
@@ -56,6 +60,8 @@ export default function useDeleteForm( {
 	statusQuery,
 }: UseDeleteFormArgs ): UseDeleteFormReturn {
 	const [ isDeleting, setIsDeleting ] = useState( false );
+	const [ isPermanentDeleteConfirmOpen, setIsPermanentDeleteConfirmOpen ] = useState( false );
+	const [ permanentDeleteItem, setPermanentDeleteItem ] = useState< FormListItem | null >( null );
 
 	const { saveEntityRecord, deleteEntityRecord, invalidateResolution } = useDispatch(
 		'core'
@@ -211,9 +217,71 @@ export default function useDeleteForm( {
 		]
 	);
 
+	const openPermanentDeleteConfirm = useCallback( ( item: FormListItem ) => {
+		setPermanentDeleteItem( item );
+		setIsPermanentDeleteConfirmOpen( true );
+	}, [] );
+
+	const closePermanentDeleteConfirm = useCallback( () => {
+		setIsPermanentDeleteConfirmOpen( false );
+		setPermanentDeleteItem( null );
+	}, [] );
+
+	const confirmPermanentDelete = useCallback( async () => {
+		if ( ! permanentDeleteItem || isDeleting ) {
+			return;
+		}
+
+		setIsPermanentDeleteConfirmOpen( false );
+		setIsDeleting( true );
+
+		try {
+			await deleteEntityRecord(
+				'postType',
+				'jetpack_form',
+				permanentDeleteItem.id,
+				{ force: true },
+				{ throwOnError: true }
+			);
+
+			createSuccessNotice( __( 'Form deleted permanently.', 'jetpack-forms' ), {
+				type: 'snackbar',
+				id: `delete-form-permanently-${ permanentDeleteItem.id }`,
+			} );
+		} catch {
+			createErrorNotice( __( 'Could not delete form permanently.', 'jetpack-forms' ), {
+				type: 'snackbar',
+				id: `delete-form-permanently-error-${ permanentDeleteItem.id }`,
+			} );
+		} finally {
+			setIsDeleting( false );
+			setPermanentDeleteItem( null );
+
+			// Invalidate the list query so the deleted form disappears from the table and totals refresh.
+			invalidateResolution( 'getEntityRecords', [ 'postType', 'jetpack_form', currentQuery ] );
+			invalidateResolution( 'getEntityRecords', [
+				'postType',
+				'jetpack_form',
+				{ ...currentQuery, per_page: 1, _fields: 'id' },
+			] );
+		}
+	}, [
+		createErrorNotice,
+		createSuccessNotice,
+		currentQuery,
+		deleteEntityRecord,
+		invalidateResolution,
+		isDeleting,
+		permanentDeleteItem,
+	] );
+
 	return {
 		isDeleting,
 		trashForm,
 		restoreForm,
+		isPermanentDeleteConfirmOpen,
+		openPermanentDeleteConfirm,
+		closePermanentDeleteConfirm,
+		confirmPermanentDelete,
 	};
 }


### PR DESCRIPTION
## Proposed changes:

Changes:
* Adds 'status' filter (published, draft, trash, etc) to DataViews table for form posts. 
* On initial page load, filter for for 'published' status and show the filter pill
* When filtering for trash, hide the 'Trash' action and show a 'Restore' action

**Screenshot: delete action**
<img width="1345" height="583" alt="delete-action-2" src="https://github.com/user-attachments/assets/24ed554c-6efa-4e69-9bfe-3c80972eed79" />

**Screenshot: confirmation**
<img width="1343" height="677" alt="delete-permanent-modal" src="https://github.com/user-attachments/assets/25343339-dcc9-45f8-8554-acc795be28fe" />


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
See Figma designs: 8TmDfrB54NU4Rzj19Qs9Tg-fi-5374_18492

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Add this feature flag to your test site. 

```
add_filter( 'jetpack_block_editor_feature_flags', 'eb_register_feature' );
function eb_register_feature( $flags ) {
    $flags['central-form-management'] = true;
    return $flags;
}
```

Test new filter: 
* Go to Jetpack > Forms
* Use actions to move some forms to trash. 
* Update filter status to 'trash', find you trash forms, and click the Delete Permanently action
* Confirm a popup modal asks for confirmation
* Confirm that the form is fully delete and that a notification shows in the lower left corner

Test for now regression:
* Remove feature flag and confirm everything works as before (no centralized form management).