### PR TITLE
Forms: fix useSelect warning in Image Select field by memoizing derived data

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-image-select-hook
+++ b/projects/packages/forms/changelog/fix-forms-image-select-hook
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Image Select Field: fix useSelect returning different values warning by memoizing derived data.

--- a/projects/packages/forms/src/blocks/field-image-select/edit.tsx
+++ b/projects/packages/forms/src/blocks/field-image-select/edit.tsx
@@ -34,7 +34,7 @@ export default function ImageSelectFieldEdit( props ) {
 	const { updateBlockAttributes } = useDispatch( blockEditorStore );
 	const { blockStyle } = useJetpackFieldStyles( attributes );
 
-	const { optionsBlock, imagesData } = useSelect(
+	const { optionsBlock, imageOptionsInnerBlocks } = useSelect(
 		select => {
 			const { getBlock } = select( blockEditorStore ) as BlockEditorStoreSelect;
 
@@ -42,23 +42,28 @@ export default function ImageSelectFieldEdit( props ) {
 				( innerBlock: Block ) => innerBlock.name === 'jetpack/fieldset-image-options'
 			);
 
-			const images =
-				block?.innerBlocks?.[ 0 ]?.innerBlocks
-					// Filter out inner blocks that don't have a media id, i.e. external images.
-					?.filter( innerBlock => innerBlock.attributes?.id !== undefined )
-					// Map the inner blocks to an array of objects with the media id and client id.
-					?.map( innerBlock => ( {
-						clientId: innerBlock.clientId,
-						mediaId: innerBlock.attributes.id as number,
-					} ) ) ?? [];
-
 			return {
 				optionsBlock: block,
-				imagesData: images,
+				imageOptionsInnerBlocks: block?.innerBlocks?.[ 0 ]?.innerBlocks,
 			};
 		},
 		[ clientId ]
 	);
+
+	// Memoize the derived imagesData to avoid creating new array/object references on every render.
+	// This prevents the "useSelect returns different values" warning.
+	const imagesData = useMemo( () => {
+		return (
+			imageOptionsInnerBlocks
+				// Filter out inner blocks that don't have a media id, i.e. external images.
+				?.filter( innerBlock => innerBlock.attributes?.id !== undefined )
+				// Map the inner blocks to an array of objects with the media id and client id.
+				?.map( innerBlock => ( {
+					clientId: innerBlock.clientId,
+					mediaId: innerBlock.attributes.id as number,
+				} ) ) ?? []
+		);
+	}, [ imageOptionsInnerBlocks ] );
 
 	// Preload the image entity records reactively, as they are not available on first load.
 	// This is necessary to ensure the image URLs can be updated correctly when the supersized attribute is changed.


### PR DESCRIPTION
Fixes FORMS-538

## Proposed changes:

- Fix the "useSelect returns different values" React warning in the Image Select field block
- Move the `imagesData` derivation from inside `useSelect` to a separate `useMemo` hook
- This prevents creating new array/object references on every render, which was causing the warning

## Other information:

This change addresses a React hook best practice where derived data from `useSelect` should be memoized separately rather than computed inside the selector to avoid reference instability.

## Jetpack product discussion
p1768987199857639-slack-C052XEUUBL4

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

1. Go to the Jetpack Forms block editor
2. Add an Image Select field to a form
3. Add some image options to the field
4. Open the browser console and interact with the block (select images, change settings)
5. Verify there are no "useSelect returns different values" warnings in the console