### PR TITLE
Forms: fix React key warning in Slider field inspector controls

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-slider-controls-key
+++ b/projects/packages/forms/changelog/fix-forms-slider-controls-key
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Slider Field: fix React iteration render error by adding key prop to control wrapper.

--- a/projects/packages/forms/src/blocks/field-slider/edit.js
+++ b/projects/packages/forms/src/blocks/field-slider/edit.js
@@ -3,6 +3,7 @@ import {
 	__experimentalHStack as HStack, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 	__experimentalNumberControl as NumberControl, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 	TextControl,
+	BaseControl,
 } from '@wordpress/components';
 import { useCallback, useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -166,7 +167,7 @@ export default function SliderFieldEdit( props ) {
 					{
 						index: 1,
 						element: (
-							<>
+							<BaseControl __nextHasNoMarginBottom={ true } key="sliderFieldControls">
 								<HStack alignment="top" className="jp-field-slider-inspector-row">
 									<NumberControl
 										__next40pxDefaultSize
@@ -234,7 +235,7 @@ export default function SliderFieldEdit( props ) {
 										spinControls="custom"
 									/>
 								</HStack>
-							</>
+							</BaseControl>
 						),
 					},
 				] }

--- a/projects/packages/forms/src/blocks/field-slider/edit.js
+++ b/projects/packages/forms/src/blocks/field-slider/edit.js
@@ -165,7 +165,7 @@ export default function SliderFieldEdit( props ) {
 				width={ width }
 				extraFieldSettings={ [
 					{
-						index: 1,
+						index: 2,
 						element: (
 							<BaseControl __nextHasNoMarginBottom={ true } key="sliderFieldControls">
 								<HStack alignment="top" className="jp-field-slider-inspector-row">


### PR DESCRIPTION
Part of FORMS-539

## Proposed changes:

- Fix React iteration render error in the Slider field block by adding a `key` prop
- Replace React fragment (`<>`) with `BaseControl` component that includes a proper `key` prop
- This resolves the React warning about missing keys when rendering elements in an array/iteration context

## Other information:

The slider field inspector controls were wrapped in a React fragment inside an array, which caused React to warn about missing keys during iteration rendering. Using `BaseControl` with a `key` prop properly identifies the element for React's reconciliation.

## Jetpack product discussion

N/A - Internal code improvement with no user-facing changes.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

1. Go to the Jetpack Forms block editor
2. Add a Slider field to a form
3. Open the browser console
4. Select the slider field and interact with its inspector controls (change min, max, step values)
5. Verify there are no React warnings about missing keys in the console
