### PR TITLE
Copy Post: fix Gutenberg Footnotes block content not being copied when duplicating posts

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-footnotes-copy
+++ b/projects/plugins/jetpack/changelog/fix-footnotes-copy
@@ -1,4 +1,4 @@
 Significance: patch
 Type: bugfix
 
-Copy Post: copy Gutenberg Footnotes block content when duplicating posts.
+Copy Post: Copy Gutenberg Footnotes block content when duplicating posts.

--- a/projects/plugins/jetpack/changelog/fix-footnotes-copy
+++ b/projects/plugins/jetpack/changelog/fix-footnotes-copy
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Copy Post: copy Gutenberg Footnotes block content when duplicating posts.

--- a/projects/plugins/jetpack/modules/copy-post.php
+++ b/projects/plugins/jetpack/modules/copy-post.php
@@ -94,6 +94,8 @@ class Jetpack_Copy_Post {
 			return;
 		}
 
+		add_filter( 'jetpack_copy_post_data', array( $this, 'copy_footnotes' ), 10, 3 );
+
 		$update_results = array(
 			'update_content'         => $this->update_content( $source_post, $target_post_id ),
 			'update_featured_image'  => $this->update_featured_image( $source_post, $target_post_id ),
@@ -257,6 +259,61 @@ class Jetpack_Copy_Post {
 			'likes'   => $likes_result,
 			'sharing' => $sharing_result,
 		);
+	}
+
+	/**
+	 * Copy footnotes from source post, regenerating IDs for uniqueness.
+	 *
+	 * Gutenberg's Footnotes block stores content in post meta rather than
+	 * in the block markup itself. The IDs must be regenerated to ensure uniqueness,
+	 * otherwise multiple posts on the same page (e.g., archive views) would
+	 * have conflicting footnote anchor links.
+	 *
+	 * @param array   $data Post data with which to update the target (new) post.
+	 * @param WP_Post $source_post Post object being copied.
+	 * @param int     $target_post_id Target post ID.
+	 * @return array Modified post data.
+	 */
+	public function copy_footnotes( $data, $source_post, $target_post_id ) {
+		$footnotes_json = get_post_meta( $source_post->ID, 'footnotes', true );
+
+		if ( '' === $footnotes_json ) {
+			return $data;
+		}
+
+		$footnotes = json_decode( $footnotes_json, true );
+
+		if ( ! is_array( $footnotes ) || empty( $footnotes ) ) {
+			return $data;
+		}
+
+		// Build a mapping of old IDs to new IDs and update the footnotes array.
+		$id_mapping = array();
+		foreach ( $footnotes as &$footnote ) {
+			if ( isset( $footnote['id'] ) ) {
+				$old_id                = $footnote['id'];
+				$new_id                = wp_generate_uuid4();
+				$id_mapping[ $old_id ] = $new_id;
+				$footnote['id']        = $new_id;
+			}
+		}
+		unset( $footnote );
+
+		// Update the post content to use the new footnote IDs.
+		foreach ( $id_mapping as $old_id => $new_id ) {
+			// Replace data-fn attribute values.
+			$data['post_content'] = str_replace( 'data-fn="' . $old_id . '"', 'data-fn="' . $new_id . '"', $data['post_content'] );
+			// Replace href anchor links.
+			$data['post_content'] = str_replace( 'href="#' . $old_id . '"', 'href="#' . $new_id . '"', $data['post_content'] );
+			// Replace id attributes (e.g., id="uuid-link").
+			$data['post_content'] = str_replace( 'id="' . $old_id . '-link"', 'id="' . $new_id . '-link"', $data['post_content'] );
+			$data['post_content'] = str_replace( 'id="' . $old_id . '"', 'id="' . $new_id . '"', $data['post_content'] );
+		}
+
+		// Save the footnotes meta with new IDs.
+		update_post_meta( $target_post_id, 'footnotes', wp_json_encode( $footnotes, JSON_UNESCAPED_SLASHES ) );
+
+		return $data;
 	}
 
 	/**

--- a/projects/plugins/jetpack/modules/copy-post.php
+++ b/projects/plugins/jetpack/modules/copy-post.php
@@ -94,8 +94,6 @@ class Jetpack_Copy_Post {
 			return;
 		}
 
-		add_filter( 'jetpack_copy_post_data', array( $this, 'copy_footnotes' ), 10, 3 );
-
 		$update_results = array(
 			'update_content'         => $this->update_content( $source_post, $target_post_id ),
 			'update_featured_image'  => $this->update_featured_image( $source_post, $target_post_id ),
@@ -156,6 +154,9 @@ class Jetpack_Copy_Post {
 			'post_password'  => $source_post->post_password,
 			'tags_input'     => $source_post->tags_input,
 		);
+
+		// Copy footnotes with regenerated IDs.
+		$data = $this->copy_footnotes( $data, $source_post, $target_post_id );
 
 		/**
 		 * Fires just before the target post is updated with its new data.

--- a/projects/plugins/jetpack/phpunit.11.xml.dist
+++ b/projects/plugins/jetpack/phpunit.11.xml.dist
@@ -114,6 +114,9 @@
 		<testsuite name="carousel">
 			<directory suffix="Test.php">tests/php/modules/carousel</directory>
 		</testsuite>
+		<testsuite name="copy-post">
+			<directory suffix="Test.php">tests/php/modules/copy-post</directory>
+		</testsuite>
 		<testsuite name="deprecation">
 			<file>tests/php/Jetpack_Deprecation_Test.php</file>
 		</testsuite>

--- a/projects/plugins/jetpack/phpunit.9.xml.dist
+++ b/projects/plugins/jetpack/phpunit.9.xml.dist
@@ -105,6 +105,9 @@
 		<testsuite name="carousel">
 			<directory suffix="Test.php">tests/php/modules/carousel</directory>
 		</testsuite>
+		<testsuite name="copy-post">
+			<directory suffix="Test.php">tests/php/modules/copy-post</directory>
+		</testsuite>
 		<testsuite name="deprecation">
 			<file>tests/php/Jetpack_Deprecation_Test.php</file>
 		</testsuite>

--- a/projects/plugins/jetpack/tests/php/modules/copy-post/Copy_Post_Test.php
+++ b/projects/plugins/jetpack/tests/php/modules/copy-post/Copy_Post_Test.php
@@ -1,0 +1,257 @@
+<?php
+/**
+ * Tests for Copy Post module.
+ *
+ * @package automattic/jetpack
+ */
+
+use PHPUnit\Framework\Attributes\CoversMethod;
+use PHPUnit\Framework\Attributes\Group;
+
+require_once JETPACK__PLUGIN_DIR . 'modules/copy-post.php';
+
+/**
+ * Test class for Jetpack_Copy_Post.
+ *
+ * @group copy-post
+ * @covers Jetpack_Copy_Post::copy_footnotes
+ */
+#[Group( 'copy-post' )]
+#[CoversMethod( Jetpack_Copy_Post::class, 'copy_footnotes' )]
+class Copy_Post_Test extends WP_UnitTestCase {
+	use \Automattic\Jetpack\PHPUnit\WP_UnitTestCase_Fix;
+
+	/**
+	 * Test that copy_footnotes copies and regenerates footnote IDs.
+	 */
+	public function test_copy_footnotes_regenerates_ids() {
+		$copy_post = new Jetpack_Copy_Post();
+
+		// Create source post with footnotes.
+		$old_id         = 'abc12345-1234-1234-1234-123456789abc';
+		$source_post_id = self::factory()->post->create();
+		$source_post    = get_post( $source_post_id );
+
+		$footnotes_meta = wp_json_encode(
+			array(
+				array(
+					'id'      => $old_id,
+					'content' => 'Test footnote',
+				),
+			),
+			JSON_UNESCAPED_SLASHES
+		);
+		update_post_meta( $source_post_id, 'footnotes', $footnotes_meta );
+
+		// Create target post.
+		$target_post_id = self::factory()->post->create();
+
+		// Prepare data array as the filter would receive it.
+		$data = array(
+			'ID'           => $target_post_id,
+			'post_content' => '<p>Text with footnote<sup data-fn="' . $old_id . '" class="fn"><a href="#' . $old_id . '" id="' . $old_id . '-link">1</a></sup></p>',
+		);
+
+		// Call the method.
+		$result = $copy_post->copy_footnotes( $data, $source_post, $target_post_id );
+
+		// Assert old ID is not in content.
+		$this->assertStringNotContainsString( $old_id, $result['post_content'] );
+
+		// Assert footnotes meta was saved to target.
+		$target_footnotes = get_post_meta( $target_post_id, 'footnotes', true );
+		$this->assertNotEmpty( $target_footnotes );
+
+		// Assert new ID is a valid UUID and different from old.
+		$decoded = json_decode( $target_footnotes, true );
+		$new_id  = $decoded[0]['id'];
+		$this->assertNotEquals( $old_id, $new_id );
+		$this->assertMatchesRegularExpression(
+			'/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i',
+			$new_id
+		);
+
+		// Assert new ID is in content.
+		$this->assertStringContainsString( 'data-fn="' . $new_id . '"', $result['post_content'] );
+		$this->assertStringContainsString( 'href="#' . $new_id . '"', $result['post_content'] );
+		$this->assertStringContainsString( 'id="' . $new_id . '-link"', $result['post_content'] );
+	}
+
+	/**
+	 * Test that copy_footnotes returns unmodified data when no footnotes exist.
+	 */
+	public function test_copy_footnotes_no_footnotes() {
+		$copy_post = new Jetpack_Copy_Post();
+
+		$source_post_id = self::factory()->post->create();
+		$source_post    = get_post( $source_post_id );
+		$target_post_id = self::factory()->post->create();
+
+		$data = array(
+			'ID'           => $target_post_id,
+			'post_content' => '<p>No footnotes here</p>',
+		);
+
+		$result = $copy_post->copy_footnotes( $data, $source_post, $target_post_id );
+
+		$this->assertEquals( $data, $result );
+	}
+
+	/**
+	 * Test that copy_footnotes handles empty footnotes meta.
+	 */
+	public function test_copy_footnotes_empty_meta() {
+		$copy_post = new Jetpack_Copy_Post();
+
+		$source_post_id = self::factory()->post->create();
+		$source_post    = get_post( $source_post_id );
+		update_post_meta( $source_post_id, 'footnotes', '' );
+
+		$target_post_id = self::factory()->post->create();
+
+		$data = array(
+			'ID'           => $target_post_id,
+			'post_content' => '<p>Content</p>',
+		);
+
+		$result = $copy_post->copy_footnotes( $data, $source_post, $target_post_id );
+
+		$this->assertEquals( $data, $result );
+	}
+
+	/**
+	 * Test that copy_footnotes handles invalid JSON gracefully.
+	 */
+	public function test_copy_footnotes_invalid_json() {
+		$copy_post = new Jetpack_Copy_Post();
+
+		$source_post_id = self::factory()->post->create();
+		$source_post    = get_post( $source_post_id );
+		update_post_meta( $source_post_id, 'footnotes', 'not valid json' );
+
+		$target_post_id = self::factory()->post->create();
+
+		$data = array(
+			'ID'           => $target_post_id,
+			'post_content' => '<p>Content</p>',
+		);
+
+		$result = $copy_post->copy_footnotes( $data, $source_post, $target_post_id );
+
+		$this->assertEquals( $data, $result );
+	}
+
+	/**
+	 * Test that copy_footnotes handles empty array gracefully.
+	 */
+	public function test_copy_footnotes_empty_array() {
+		$copy_post = new Jetpack_Copy_Post();
+
+		$source_post_id = self::factory()->post->create();
+		$source_post    = get_post( $source_post_id );
+		update_post_meta( $source_post_id, 'footnotes', '[]' );
+
+		$target_post_id = self::factory()->post->create();
+
+		$data = array(
+			'ID'           => $target_post_id,
+			'post_content' => '<p>Content</p>',
+		);
+
+		$result = $copy_post->copy_footnotes( $data, $source_post, $target_post_id );
+
+		$this->assertEquals( $data, $result );
+	}
+
+	/**
+	 * Test that multiple footnotes each get unique IDs.
+	 */
+	public function test_copy_footnotes_multiple_footnotes() {
+		$copy_post = new Jetpack_Copy_Post();
+
+		$old_id_1 = 'id111111-1111-1111-1111-111111111111';
+		$old_id_2 = 'id222222-2222-2222-2222-222222222222';
+
+		$source_post_id = self::factory()->post->create();
+		$source_post    = get_post( $source_post_id );
+
+		$footnotes_meta = wp_json_encode(
+			array(
+				array(
+					'id'      => $old_id_1,
+					'content' => 'First footnote',
+				),
+				array(
+					'id'      => $old_id_2,
+					'content' => 'Second footnote',
+				),
+			),
+			JSON_UNESCAPED_SLASHES
+		);
+		update_post_meta( $source_post_id, 'footnotes', $footnotes_meta );
+
+		$target_post_id = self::factory()->post->create();
+
+		$data = array(
+			'ID'           => $target_post_id,
+			'post_content' => '<p>First<sup data-fn="' . $old_id_1 . '" class="fn"><a href="#' . $old_id_1 . '" id="' . $old_id_1 . '-link">1</a></sup> Second<sup data-fn="' . $old_id_2 . '" class="fn"><a href="#' . $old_id_2 . '" id="' . $old_id_2 . '-link">2</a></sup></p>',
+		);
+
+		$result = $copy_post->copy_footnotes( $data, $source_post, $target_post_id );
+
+		// Get the new IDs from meta.
+		$target_footnotes = json_decode( get_post_meta( $target_post_id, 'footnotes', true ), true );
+		$new_id_1         = $target_footnotes[0]['id'];
+		$new_id_2         = $target_footnotes[1]['id'];
+
+		// Assert both IDs are unique and different from originals.
+		$this->assertNotEquals( $old_id_1, $new_id_1 );
+		$this->assertNotEquals( $old_id_2, $new_id_2 );
+		$this->assertNotEquals( $new_id_1, $new_id_2 );
+
+		// Assert old IDs are not in content.
+		$this->assertStringNotContainsString( $old_id_1, $result['post_content'] );
+		$this->assertStringNotContainsString( $old_id_2, $result['post_content'] );
+
+		// Assert content has new IDs.
+		$this->assertStringContainsString( 'data-fn="' . $new_id_1 . '"', $result['post_content'] );
+		$this->assertStringContainsString( 'data-fn="' . $new_id_2 . '"', $result['post_content'] );
+	}
+
+	/**
+	 * Test that footnote content is preserved.
+	 */
+	public function test_copy_footnotes_preserves_content() {
+		$copy_post = new Jetpack_Copy_Post();
+
+		$old_id           = 'abc12345-1234-1234-1234-123456789abc';
+		$footnote_content = 'This is <em>important</em> footnote content.';
+
+		$source_post_id = self::factory()->post->create();
+		$source_post    = get_post( $source_post_id );
+
+		$footnotes_meta = wp_json_encode(
+			array(
+				array(
+					'id'      => $old_id,
+					'content' => $footnote_content,
+				),
+			),
+			JSON_UNESCAPED_SLASHES
+		);
+		update_post_meta( $source_post_id, 'footnotes', $footnotes_meta );
+
+		$target_post_id = self::factory()->post->create();
+
+		$data = array(
+			'ID'           => $target_post_id,
+			'post_content' => '<p>Text<sup data-fn="' . $old_id . '"></sup></p>',
+		);
+
+		$copy_post->copy_footnotes( $data, $source_post, $target_post_id );
+
+		// Assert footnote content is preserved.
+		$target_footnotes = json_decode( get_post_meta( $target_post_id, 'footnotes', true ), true );
+		$this->assertEquals( $footnote_content, $target_footnotes[0]['content'] );
+	}
+}

--- a/projects/plugins/jetpack/tests/php/modules/copy-post/Copy_Post_Test.php
+++ b/projects/plugins/jetpack/tests/php/modules/copy-post/Copy_Post_Test.php
@@ -64,7 +64,8 @@ class Copy_Post_Test extends WP_UnitTestCase {
 
 		// Assert new ID is a valid UUID and different from old.
 		$decoded = json_decode( $target_footnotes, true );
-		$new_id  = $decoded[0]['id'];
+		$this->assertIsArray( $decoded );
+		$new_id = $decoded[0]['id'];
 		$this->assertNotEquals( $old_id, $new_id );
 		$this->assertMatchesRegularExpression(
 			'/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i',
@@ -201,8 +202,9 @@ class Copy_Post_Test extends WP_UnitTestCase {
 
 		// Get the new IDs from meta.
 		$target_footnotes = json_decode( get_post_meta( $target_post_id, 'footnotes', true ), true );
-		$new_id_1         = $target_footnotes[0]['id'];
-		$new_id_2         = $target_footnotes[1]['id'];
+		$this->assertIsArray( $target_footnotes );
+		$new_id_1 = $target_footnotes[0]['id'];
+		$new_id_2 = $target_footnotes[1]['id'];
 
 		// Assert both IDs are unique and different from originals.
 		$this->assertNotEquals( $old_id_1, $new_id_1 );
@@ -252,6 +254,7 @@ class Copy_Post_Test extends WP_UnitTestCase {
 
 		// Assert footnote content is preserved.
 		$target_footnotes = json_decode( get_post_meta( $target_post_id, 'footnotes', true ), true );
+		$this->assertIsArray( $target_footnotes );
 		$this->assertEquals( $footnote_content, $target_footnotes[0]['content'] );
 	}
 }


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/EDI-228

## Proposed changes:

* Fix Gutenberg Footnotes block content not being copied when posts are duplicated using Jetpack's Copy Post feature
* Regenerate unique IDs for footnotes to prevent anchor link conflicts when multiple posts are displayed on the same page (e.g., archive views)

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

N/A - Bug fix for existing feature

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

* Ensure the Copy Post module is enabled in Jetpack settings (Settings > Writing > Copy Post)
* Create a new post with some content
* Add a footnote by selecting some text, clicking the dropdown arrow in the formatting toolbar, and selecting "Footnote"
* Add the footnote content in the Footnotes block that appears at the bottom
* Publish the post
* From the Posts list, click "Duplicate" on the post you just created
* Verify the duplicated post contains the footnote content (both the superscript link in the content and the footnote text in the Footnotes block)
* Publish the duplicated post
* View an archive page (e.g., the blog homepage) that shows both posts
* Verify that clicking footnote links on each post jumps to the correct footnote (they should not conflict)