### PR TITLE
AI Assistant: fix markdown rendering in feedback sidebar

### DIFF
--- a/projects/plugins/jetpack/changelog/jpai-87-fix-markdown-bold-rendering-in-ai-feedback-sidebar
+++ b/projects/plugins/jetpack/changelog/jpai-87-fix-markdown-bold-rendering-in-ai-feedback-sidebar
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+AI Assistant: fix markdown rendering in feedback sidebar to properly display bold text, lists, and other formatting.

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/feedback/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/feedback/index.tsx
@@ -1,12 +1,16 @@
-import { useAiSuggestions, usePostContent, AiAssistantModal } from '@automattic/jetpack-ai-client';
+import {
+	useAiSuggestions,
+	usePostContent,
+	AiAssistantModal,
+	renderHTMLFromMarkdown,
+} from '@automattic/jetpack-ai-client';
 import { useAnalytics } from '@automattic/jetpack-shared-extension-utils';
 import { Button } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
-import { useCallback, useState } from '@wordpress/element';
+import { RawHTML, useCallback, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import './style.scss';
-import type { JSX } from 'react';
 
 export default function Feedback( {
 	disabled = false,
@@ -18,7 +22,7 @@ export default function Feedback( {
 	busy?: boolean;
 } ) {
 	const [ isFeedbackModalVisible, setIsFeedbackModalVisible ] = useState( false );
-	const [ suggestion, setSuggestion ] = useState< Array< JSX.Element | null > >( [ null ] );
+	const [ suggestion, setSuggestion ] = useState< string >( '' );
 	const { tracks } = useAnalytics();
 
 	const postId = useSelect( select => select( editorStore ).getCurrentPostId(), [] );
@@ -32,11 +36,8 @@ export default function Feedback( {
 		useDispatch( 'wordpress-com/plans' );
 
 	const handleSuggestion = ( content: string ) => {
-		const text = content.split( '\n' ).map( ( line, idx ) => {
-			return line?.length ? <p key={ `line-${ idx }` }>{ line }</p> : null;
-		} );
-
-		setSuggestion( text );
+		const html = renderHTMLFromMarkdown( { content } );
+		setSuggestion( html );
 	};
 
 	const handleSuggestionError = () => {
@@ -87,7 +88,7 @@ export default function Feedback( {
 		<div>
 			{ isFeedbackModalVisible && (
 				<AiAssistantModal requestingState={ requestingState } handleClose={ toggleFeedbackModal }>
-					<div className="ai-assistant-post-feedback__suggestion">{ suggestion }</div>
+					<RawHTML className="ai-assistant-post-feedback__suggestion">{ suggestion }</RawHTML>
 				</AiAssistantModal>
 			) }
 			<p className="jetpack-ai-assistant__help-text">

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/feedback/style.scss
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/feedback/style.scss
@@ -3,5 +3,18 @@
 	&__suggestion {
 		padding: 18px 0;
 		margin-bottom: -32px;
+
+		ul,
+		ol {
+			margin-inline-start: 1.5em;
+		}
+
+		ul {
+			list-style-type: disc;
+		}
+
+		ol {
+			list-style-type: decimal;
+		}
 	}
 }


### PR DESCRIPTION
## Summary

Fixes markdown rendering in the AI feedback sidebar to properly display formatted content (bold text, lists, etc.).

- Use `renderHTMLFromMarkdown` from `@automattic/jetpack-ai-client` to properly parse markdown content instead of manually splitting by newlines
- Use `RawHTML` component to render the HTML output, consistent with other AI components
- Add CSS styles for proper list rendering (ul/ol bullet points)

## Testing instructions

1. Open a post in the editor
2. Add a title: `Test`
3. Add a paragraph block with content: `This is a test post to verify that the AI feedback component correctly renders markdown content as HTML.`
4. Open "Improve with AI" in the sidebar
5. Click "Generate feedback"
6. Verify that the feedback displays properly with:
   - Bold text rendered correctly
   - Bullet points/lists displayed with proper styling
   - Paragraphs separated correctly

**Note:** You may need to request feedback multiple times to get a response where markdown formatting (bold, lists, etc.) is actually present in the AI response.

## Does this pull request change what data or activity we track or use?

No, this PR does not change any data tracking or privacy-related functionality. It only changes how the AI feedback response is rendered in the UI.

## Screenshots

### Before

<img width="1450" height="832" alt="image" src="https://github.com/user-attachments/assets/a214e8f8-27a0-4050-aae5-eff32a59d4a7" />


### After

<img width="2316" height="974" alt="CleanShot 2026-01-22 at 12 37 54@2x" src="https://github.com/user-attachments/assets/1ca0db8b-fc21-432d-8bd0-3d0725ad2497" />

🤖 Generated with [Claude Code](https://claude.ai/code)