### PR TITLE
Add filter to control proxy speed module auto-installation

### DIFF
--- a/projects/packages/woocommerce-analytics/changelog/add-woocommerce-analytics-proxy-speed-module-filter
+++ b/projects/packages/woocommerce-analytics/changelog/add-woocommerce-analytics-proxy-speed-module-filter
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add woocommerce_analytics_auto_install_proxy_speed_module filter to control auto-installation of proxy speed module mu-plugin.

--- a/projects/packages/woocommerce-analytics/src/class-woocommerce-analytics.php
+++ b/projects/packages/woocommerce-analytics/src/class-woocommerce-analytics.php
@@ -174,6 +174,17 @@ class Woocommerce_Analytics {
 	 * Maybe add proxy speed module.
 	 */
 	public static function maybe_add_proxy_speed_module() {
+		/**
+		 * Filter to control auto-installation of the proxy speed module mu-plugin.
+		 *
+		 * When this filter returns false, the mu-plugin file can't be added automatically.
+		 *
+		 * @param bool $auto_install Whether to auto-install the mu-plugin. Default true.
+		 */
+		if ( ! apply_filters( 'woocommerce_analytics_auto_install_proxy_speed_module', true ) ) {
+			return;
+		}
+
 		if ( ! self::init_filesystem() ) {
 			return;
 		}

--- a/projects/packages/woocommerce-analytics/src/class-woocommerce-analytics.php
+++ b/projects/packages/woocommerce-analytics/src/class-woocommerce-analytics.php
@@ -179,6 +179,8 @@ class Woocommerce_Analytics {
 		 *
 		 * When this filter returns false, the mu-plugin file can't be added automatically.
 		 *
+		 * @since 0.15.0
+		 *
 		 * @param bool $auto_install Whether to auto-install the mu-plugin. Default true.
 		 */
 		if ( ! apply_filters( 'woocommerce_analytics_auto_install_proxy_speed_module', true ) ) {


### PR DESCRIPTION
## Summary

Adds a `woocommerce_analytics_auto_install_proxy_speed_module` filter that allows environments to opt out of automatic mu-plugin file creation.

This is the first step toward addressing WOOA7S-982. The proxy speed module mu-plugin has been causing issues on certain environments due to partial plugin context initialization. This filter provides a way to disable the auto-creation behavior.

### Usage

To disable auto-installation of the proxy speed module mu-plugin:

```php
add_filter( 'woocommerce_analytics_auto_install_proxy_speed_module', '__return_false' );
```

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

n/a

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

nope

## Testing instructions

1. **Add the filter to disable the module installation:**  
   Insert the following into your theme's `functions.php` or a custom mu-plugin:  
   ```php
   add_filter( 'woocommerce_analytics_auto_install_proxy_speed_module', '__return_false' );
   ```

2. **Ensure a clean test state:**  
   - Deactivate the `WooCommerce Analytics` plugin if it’s currently active.
   - Delete the file at `wp-content/mu-plugins/woocommerce-analytics-proxy-speed-module.php` if it exists.

3. **Validate module is NOT auto-installed with filter:**  
   - Activate Jetpack using this branch
   - Confirm that **`wp-content/mu-plugins/woocommerce-analytics-proxy-speed-module.php` is NOT created**.

4. **Remove the disabling filter:**  
   - Delete or comment out the above `add_filter` line from your theme or mu-plugin.

5. **Trigger automatic module installation:**  
   - Deactivate Jetpack, then activate it again.

6. **Confirm module installation occurs as expected:**  
   - Check that **`wp-content/mu-plugins/woocommerce-analytics-proxy-speed-module.php` now exists**.

