### PR TITLE
Agents Manager: Avoid loading JS files on all screens

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-agents-manager-js-loading
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-agents-manager-js-loading
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Agents Manager: Fix JavaScript conflicts with WooCommerce checkout and other plugins by preventing unnecessary script loading on irrelevant screens.

--- a/projects/packages/jetpack-mu-wpcom/src/features/agents-manager/class-agents-manager.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/agents-manager/class-agents-manager.php
@@ -176,6 +176,10 @@ class Agents_Manager {
 			add_action( 'admin_bar_menu', array( $this, 'add_menu_panel' ), 100 );
 		}
 
+		if ( ! $this->should_enqueue_script() ) {
+			return;
+		}
+
 		/**
 		 * Filter to register agent provider modules for the Agents Manager.
 		 *
@@ -196,10 +200,6 @@ class Agents_Manager {
 		 * @param bool $use_unified_experience Whether to use unified experience. Default false.
 		 */
 		$use_unified_experience = apply_filters( 'agents_manager_use_unified_experience', false );
-
-		if ( ! $this->should_enqueue_script() ) {
-			return;
-		}
 
 		if ( $this->is_block_editor() ) {
 			$variant = 'gutenberg';


### PR DESCRIPTION
## Summary
Testing revealed that the Big Sky plugin (`Automattic/big-sky-plugin`) causes 
unexpected payment gateways to appear at checkout. The issue stems from loading 
60+ unnecessary JS scripts during `agents_manager_agent_providers`, which conflicts 
with checkout initialization.

- Moves the `should_enqueue_script()` check earlier in the Agents Manager initialization
- Prevents unnecessary loading of JavaScript files on screens where they are not needed
- Resolves conflicts with plugins like WooCommerce checkout that can be affected by the injected scripts

Reported in C09224W4HAA-1768983185.436849-slack

## Does this pull request change what data or activity we track or use?

My PR doesn't change anything related to data or privacy (theoretically, by loading JS on fewer pages, it might improve privacy if any of the loaded scripts sends any tracking or data back to wpcom).

## Testing plan

- [ ] Verify Agents Manager still works correctly on admin pages where it should appear
- [ ] Verify WooCommerce checkout page loads without JavaScript conflicts
- [ ] Verify no scripts are loaded on frontend pages where they shouldn't appear