### PR TITLE
Social: Unify shared and scheduled sharing activity in Dataviews table.

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3453,6 +3453,9 @@ importers:
         specifier: 7.0.0
         version: 7.0.0(react@18.3.1)
     devDependencies:
+      '@automattic/babel-plugin-replace-textdomain':
+        specifier: workspace:*
+        version: link:../../js-packages/babel-plugin-replace-textdomain
       '@automattic/calypso-color-schemes':
         specifier: 4.0.0
         version: 4.0.0

--- a/projects/packages/publicize/_inc/components/customize-and-preview/styles.module.scss
+++ b/projects/packages/publicize/_inc/components/customize-and-preview/styles.module.scss
@@ -1,6 +1,9 @@
 @use "@automattic/jetpack-base-styles/gutenberg-base-styles" as gb;
 
 .customize-and-preview {
+	height: 100%;
+	display: grid;
+	grid-template-rows: auto 1fr;
 
 	.customization-toggle-wrapper {
 		padding: 1rem;

--- a/projects/packages/publicize/_inc/components/customize-and-preview/tab-panels/desktop/styles.module.scss
+++ b/projects/packages/publicize/_inc/components/customize-and-preview/tab-panels/desktop/styles.module.scss
@@ -5,6 +5,7 @@
 
 	display: flex;
 	flex-direction: row;
+	height: 100%;
 
 	[role="tablist"] {
 
@@ -22,4 +23,5 @@
 .tab-content {
 	display: grid;
 	grid-template-columns: clamp(200px, 33.33%, 350px) minmax(0, 1fr);
+	height: 100%;
 }

--- a/projects/packages/publicize/_inc/components/unified-modal/edit-template/styles.module.scss
+++ b/projects/packages/publicize/_inc/components/unified-modal/edit-template/styles.module.scss
@@ -30,6 +30,7 @@
 	justify-content: center;
 	padding: 24px;
 	overflow: auto;
+	height: 100%;
 }
 
 // Preview container for the generated image

--- a/projects/packages/publicize/_inc/components/unified-modal/sharing-activity/activity-action.tsx
+++ b/projects/packages/publicize/_inc/components/unified-modal/sharing-activity/activity-action.tsx
@@ -1,0 +1,89 @@
+import { useAnalytics } from '@automattic/jetpack-shared-extension-utils';
+import {
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalConfirmDialog as ConfirmDialog,
+	Button,
+	ExternalLink,
+} from '@wordpress/components';
+import { useDispatch } from '@wordpress/data';
+import { useCallback, useReducer } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { store as socialStore } from '../../../social-store';
+import { Retry } from '../../share-status/retry';
+import { ScheduledActivityItem, SharedActivityItem, SharingActivityItem } from './types';
+
+interface ActivityActionProps {
+	item: SharingActivityItem;
+}
+
+/**
+ * Action component for sharing activity items.
+ * Renders different actions based on item type and status.
+ *
+ * @param {ActivityActionProps} props - Component props
+ *
+ * @return React element
+ */
+export function ActivityAction( { item }: ActivityActionProps ) {
+	const { recordEvent } = useAnalytics();
+	const { deleteScheduledShare } = useDispatch( socialStore );
+	const [ showConfirmation, toggleConfirmation ] = useReducer( state => ! state, false );
+
+	const handleViewClick = useCallback( () => {
+		if ( item.activityType === 'shared' ) {
+			recordEvent( 'jetpack_social_share_status_view', {
+				service: item.serviceName,
+				location: 'modal',
+			} );
+		}
+	}, [ recordEvent, item ] );
+
+	const handleDelete = useCallback( () => {
+		if ( item.activityType === 'scheduled' ) {
+			const scheduledItem = item as ScheduledActivityItem;
+			recordEvent( 'jetpack_social_scheduled_share_delete', {
+				service: item.serviceName,
+				location: 'modal',
+			} );
+			deleteScheduledShare( scheduledItem.scheduleId );
+			toggleConfirmation();
+		}
+	}, [ recordEvent, item, deleteScheduledShare ] );
+
+	// Shared items - success shows View link
+	if ( item.activityType === 'shared' && item.status === 'success' ) {
+		const sharedItem = item as SharedActivityItem;
+		return (
+			<ExternalLink href={ sharedItem.message } onClick={ handleViewClick }>
+				{ __( 'View', 'jetpack-publicize-pkg' ) }
+			</ExternalLink>
+		);
+	}
+
+	// Shared items - failure shows Retry button
+	if ( item.activityType === 'shared' && item.status === 'failure' ) {
+		const sharedItem = item as SharedActivityItem;
+		return <Retry shareItem={ sharedItem.originalItem } />;
+	}
+
+	// Scheduled items - show Delete button
+	if ( item.activityType === 'scheduled' ) {
+		return (
+			<div>
+				<Button variant="link" isDestructive onClick={ toggleConfirmation }>
+					{ __( 'Delete', 'jetpack-publicize-pkg' ) }
+				</Button>
+				<ConfirmDialog
+					isOpen={ showConfirmation }
+					onConfirm={ handleDelete }
+					onCancel={ toggleConfirmation }
+					confirmButtonText={ __( 'Delete', 'jetpack-publicize-pkg' ) }
+				>
+					{ __( 'Are you sure you want to delete this scheduled share?', 'jetpack-publicize-pkg' ) }
+				</ConfirmDialog>
+			</div>
+		);
+	}
+
+	return null;
+}

--- a/projects/packages/publicize/_inc/components/unified-modal/sharing-activity/activity-status.tsx
+++ b/projects/packages/publicize/_inc/components/unified-modal/sharing-activity/activity-status.tsx
@@ -31,6 +31,7 @@ export function ActivityStatus( { item }: ActivityStatusProps ) {
 				icon={ info }
 				label={ __( 'Details', 'jetpack-publicize-pkg' ) }
 				showTooltip={ false }
+				// the button is not destructive, this is just to match the red color of the error badge
 				isDestructive
 				variant="tertiary"
 			/>

--- a/projects/packages/publicize/_inc/components/unified-modal/sharing-activity/activity-status.tsx
+++ b/projects/packages/publicize/_inc/components/unified-modal/sharing-activity/activity-status.tsx
@@ -1,0 +1,69 @@
+import { Badge } from '@automattic/ui';
+import { Button, Dropdown, Flex } from '@wordpress/components';
+import { useCallback } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { info } from '@wordpress/icons';
+import styles from './styles.module.scss';
+import { SharingActivityItem } from './types';
+
+type DropdownRenderToggleProps = {
+	onToggle: VoidFunction;
+	isOpen: boolean;
+};
+
+interface ActivityStatusProps {
+	item: SharingActivityItem;
+}
+
+/**
+ * Status badge component for sharing activity items.
+ *
+ * @param {ActivityStatusProps} props - Component props
+ * @return React element
+ */
+export function ActivityStatus( { item }: ActivityStatusProps ) {
+	const renderToggle = useCallback(
+		( { onToggle, isOpen }: DropdownRenderToggleProps ) => (
+			<Button
+				size="small"
+				onClick={ onToggle }
+				aria-expanded={ isOpen }
+				icon={ info }
+				label={ __( 'Details', 'jetpack-publicize-pkg' ) }
+				showTooltip={ false }
+				variant="tertiary"
+			/>
+		),
+		[]
+	);
+
+	const renderContent = useCallback( () => {
+		if ( item.activityType === 'shared' ) {
+			return <div>{ item.message }</div>;
+		}
+		return null;
+	}, [ item ] );
+
+	if ( item.status === 'scheduled' ) {
+		return <Badge intent="info">{ __( 'Scheduled', 'jetpack-publicize-pkg' ) }</Badge>;
+	}
+
+	if ( item.status === 'success' ) {
+		return <Badge intent="success">{ __( 'Shared', 'jetpack-publicize-pkg' ) }</Badge>;
+	}
+
+	// Failure status - show badge with error details dropdown
+	return (
+		<Flex justify="start" gap={ 1 }>
+			<Badge intent="error">{ __( 'Failed', 'jetpack-publicize-pkg' ) }</Badge>
+			<Dropdown
+				focusOnMount
+				popoverProps={ { placement: 'top-start' } }
+				renderToggle={ renderToggle }
+				renderContent={ renderContent }
+				className={ styles.dropdown }
+				contentClassName={ styles[ 'dropdown-content' ] }
+			/>
+		</Flex>
+	);
+}

--- a/projects/packages/publicize/_inc/components/unified-modal/sharing-activity/activity-status.tsx
+++ b/projects/packages/publicize/_inc/components/unified-modal/sharing-activity/activity-status.tsx
@@ -31,6 +31,7 @@ export function ActivityStatus( { item }: ActivityStatusProps ) {
 				icon={ info }
 				label={ __( 'Details', 'jetpack-publicize-pkg' ) }
 				showTooltip={ false }
+				isDestructive
 				variant="tertiary"
 			/>
 		),

--- a/projects/packages/publicize/_inc/components/unified-modal/sharing-activity/activity-view.tsx
+++ b/projects/packages/publicize/_inc/components/unified-modal/sharing-activity/activity-view.tsx
@@ -1,0 +1,185 @@
+import { Flex } from '@wordpress/components';
+import {
+	type Field,
+	type Filter,
+	type SortDirection,
+	type View,
+	DataViews,
+	filterSortAndPaginate,
+} from '@wordpress/dataviews';
+import { useCallback, useEffect, useMemo, useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import ConnectionIcon from '../../connection-icon';
+import { ActivityAction } from './activity-action';
+import { ActivityStatus } from './activity-status';
+import { ReadableTime } from './readable-time';
+import styles from './styles.module.scss';
+import { SharingActivityFilter, SharingActivityItem } from './types';
+import { useSharingActivity } from './use-sharing-activity';
+
+// Field IDs as constants
+const FIELD_CONNECTION = 'connection';
+const FIELD_TIME = 'time';
+const FIELD_STATUS = 'status';
+const FIELD_ACTIONS = 'actions';
+const FIELD_ACTIVITY_TYPE = 'activityType';
+
+/**
+ * Get unique ID for a sharing activity item.
+ *
+ * @param item - The sharing activity item.
+ * @return The unique ID for the item.
+ */
+const getItemId = ( item: SharingActivityItem ): string => item.id;
+
+/**
+ * Convert filter name to DataViews filters array.
+ *
+ * @param filter - The filter name.
+ * @return The filters array for DataViews.
+ */
+function getFiltersForTab( filter: SharingActivityFilter ): Filter[] {
+	if ( filter === 'shared' ) {
+		return [
+			{
+				field: FIELD_ACTIVITY_TYPE,
+				operator: 'isAny',
+				value: [ 'shared' ],
+			},
+		];
+	}
+	if ( filter === 'scheduled' ) {
+		return [
+			{
+				field: FIELD_ACTIVITY_TYPE,
+				operator: 'isAny',
+				value: [ 'scheduled' ],
+			},
+		];
+	}
+	return [];
+}
+
+interface ActivityViewProps {
+	/**
+	 * The current filter to apply.
+	 */
+	filter?: SharingActivityFilter;
+}
+
+/**
+ * DataViews component for unified sharing activity.
+ *
+ * @param {ActivityViewProps} props - Component props.
+ * @return React element.
+ */
+export function ActivityView( { filter = 'all' }: ActivityViewProps ) {
+	const { items, isLoading } = useSharingActivity();
+
+	// DataView state
+	const [ view, setView ] = useState< View >( {
+		type: 'table',
+		fields: [ FIELD_CONNECTION, FIELD_TIME, FIELD_STATUS, FIELD_ACTIONS ],
+		sort: {
+			field: FIELD_TIME,
+			direction: 'desc' as SortDirection,
+		},
+		filters: getFiltersForTab( filter ),
+		page: 1,
+		perPage: 10,
+	} );
+
+	// Update filters when the tab changes
+	useEffect( () => {
+		setView( prevView => ( {
+			...prevView,
+			filters: getFiltersForTab( filter ),
+			page: 1,
+		} ) );
+	}, [ filter ] );
+
+	// Define fields
+	const fields = useMemo(
+		(): Field< SharingActivityItem >[] => [
+			{
+				id: FIELD_CONNECTION,
+				label: __( 'Account', 'jetpack-publicize-pkg' ),
+				enableGlobalSearch: true,
+				enableHiding: false,
+				getValue: ( { item } ) => item.displayName,
+				render: ( { item } ) => (
+					<Flex gap={ 4 } justify="start">
+						<ConnectionIcon
+							serviceName={ item.serviceName }
+							label={ item.displayName }
+							profilePicture={ item.profilePicture }
+						/>
+						<div>{ item.displayName }</div>
+					</Flex>
+				),
+			},
+			{
+				id: FIELD_TIME,
+				label: __( 'Time', 'jetpack-publicize-pkg' ),
+				type: 'datetime',
+				enableHiding: false,
+				getValue: ( { item } ) => new Date( item.timestamp * 1000 ),
+				render: ( { item } ) => <ReadableTime timestamp={ item.timestamp } />,
+			},
+			{
+				id: FIELD_STATUS,
+				label: __( 'Status', 'jetpack-publicize-pkg' ),
+				elements: [
+					{ value: 'success', label: __( 'Shared', 'jetpack-publicize-pkg' ) },
+					{ value: 'failure', label: __( 'Failed', 'jetpack-publicize-pkg' ) },
+					{ value: 'scheduled', label: __( 'Scheduled', 'jetpack-publicize-pkg' ) },
+				],
+				getValue: ( { item } ) => item.status,
+				render: ( { item } ) => <ActivityStatus item={ item } />,
+			},
+			{
+				id: FIELD_ACTIONS,
+				label: __( 'Actions', 'jetpack-publicize-pkg' ),
+				enableHiding: false,
+				render: ( { item } ) => <ActivityAction item={ item } />,
+			},
+			// Hidden field for filtering by activity type
+			{
+				id: FIELD_ACTIVITY_TYPE,
+				label: __( 'Type', 'jetpack-publicize-pkg' ),
+				enableHiding: false,
+				elements: [
+					{ value: 'shared', label: __( 'Shared', 'jetpack-publicize-pkg' ) },
+					{ value: 'scheduled', label: __( 'Scheduled', 'jetpack-publicize-pkg' ) },
+				],
+				getValue: ( { item } ) => item.activityType,
+			},
+		],
+		[]
+	);
+
+	// Apply filtering, sorting, and pagination
+	const { data: processedData, paginationInfo } = useMemo( () => {
+		return filterSortAndPaginate( items, view, fields );
+	}, [ items, view, fields ] );
+
+	// Handle view changes
+	const onChangeView = useCallback( ( newView: View ) => {
+		setView( newView );
+	}, [] );
+
+	return (
+		<div className={ styles[ 'dataview-wrapper' ] }>
+			<DataViews
+				isLoading={ isLoading }
+				getItemId={ getItemId }
+				fields={ fields }
+				data={ processedData }
+				view={ view }
+				defaultLayouts={ { table: {} } }
+				onChangeView={ onChangeView }
+				paginationInfo={ paginationInfo }
+			/>
+		</div>
+	);
+}

--- a/projects/packages/publicize/_inc/components/unified-modal/sharing-activity/activity-view.tsx
+++ b/projects/packages/publicize/_inc/components/unified-modal/sharing-activity/activity-view.tsx
@@ -24,6 +24,13 @@ const FIELD_STATUS = 'status';
 const FIELD_ACTIONS = 'actions';
 const FIELD_ACTIVITY_TYPE = 'activityType';
 
+interface ActivityViewProps {
+	/**
+	 * The current filter to apply.
+	 */
+	filter?: SharingActivityFilter;
+}
+
 /**
  * Get unique ID for a sharing activity item.
  *

--- a/projects/packages/publicize/_inc/components/unified-modal/sharing-activity/activity-view.tsx
+++ b/projects/packages/publicize/_inc/components/unified-modal/sharing-activity/activity-view.tsx
@@ -67,13 +67,6 @@ function getFiltersForTab( filter: SharingActivityFilter ): Filter[] {
 	return [];
 }
 
-interface ActivityViewProps {
-	/**
-	 * The current filter to apply.
-	 */
-	filter?: SharingActivityFilter;
-}
-
 /**
  * DataViews component for unified sharing activity.
  *

--- a/projects/packages/publicize/_inc/components/unified-modal/sharing-activity/content.tsx
+++ b/projects/packages/publicize/_inc/components/unified-modal/sharing-activity/content.tsx
@@ -1,8 +1,8 @@
 import { TabPanel } from '@wordpress/components';
 import { useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { ShareList } from '../../share-status/share-list';
-import styles from '../../share-status/styles.module.scss';
+import { ActivityView } from './activity-view';
+import styles from './styles.module.scss';
 
 type Tab = React.ComponentProps< typeof TabPanel >[ 'tabs' ][ number ];
 
@@ -32,19 +32,8 @@ export function Content() {
 
 	return (
 		<div className={ styles[ 'tab-panel-wrapper' ] }>
-			<TabPanel tabs={ tabs } initialTabName="shared">
-				{ ( tab: Tab ) => {
-					// For now, just show the existing share list under the "Shared" tab
-					// Other tabs will be implemented later
-					if ( tab.name === 'shared' ) {
-						return <ShareList />;
-					}
-					return (
-						<div style={ { padding: '20px', textAlign: 'center' } }>
-							{ __( 'Coming soon', 'jetpack-publicize-pkg' ) }
-						</div>
-					);
-				} }
+			<TabPanel tabs={ tabs } initialTabName="all">
+				{ ( tab: Tab ) => <ActivityView filter={ tab.name } /> }
 			</TabPanel>
 		</div>
 	);

--- a/projects/packages/publicize/_inc/components/unified-modal/sharing-activity/readable-time.tsx
+++ b/projects/packages/publicize/_inc/components/unified-modal/sharing-activity/readable-time.tsx
@@ -1,0 +1,31 @@
+import { Tooltip } from '@wordpress/components';
+import { format, getDate, getSettings, humanTimeDiff } from '@wordpress/date';
+
+interface ReadableTimeProps {
+	/**
+	 * Unix timestamp in seconds.
+	 */
+	timestamp: number;
+}
+
+/**
+ * Displays a human-readable time difference with a tooltip showing the full date.
+ *
+ * @param {ReadableTimeProps} props - Component props.
+ * @return React element.
+ */
+export function ReadableTime( { timestamp }: ReadableTimeProps ) {
+	return (
+		<Tooltip
+			// E.g. "January 20, 2026 1:44 pm"
+			text={ format( getSettings().formats.datetime, timestamp * 1000 ) }
+		>
+			<span>
+				{
+					// "7 days from now" or "3 hours ago"
+					humanTimeDiff( timestamp * 1000, getDate( null ) )
+				}
+			</span>
+		</Tooltip>
+	);
+}

--- a/projects/packages/publicize/_inc/components/unified-modal/sharing-activity/styles.module.scss
+++ b/projects/packages/publicize/_inc/components/unified-modal/sharing-activity/styles.module.scss
@@ -1,0 +1,50 @@
+@use "sass:meta";
+
+.tab-panel-wrapper {
+
+	:global(.components-tab-panel__tabs) {
+		height: 48px;
+		border-bottom: 1px solid var(--jp-gray-10);
+	}
+}
+
+.dataview-wrapper {
+
+	/**
+	 * Import DataViews styles scoped to this component
+	 * @see https://github.com/Automattic/jetpack/issues/39981
+	 */
+	:global {
+
+		@include meta.load-css( "@wordpress/dataviews/build-style/style" );
+	}
+
+	// Hide the default DataViews view actions (we use custom header)
+	:global(.dataviews__view-actions) {
+		display: none;
+	}
+
+	table {
+		overflow: hidden;
+	}
+
+	// Make table header buttons unclickable
+	:global(.dataviews-view-table-header-button) {
+		pointer-events: none;
+	}
+}
+
+.dropdown {
+
+	&:global(.components-dropdown) {
+		display: flex;
+	}
+}
+
+.dropdown-content {
+
+	:global(.components-popover__content) {
+		min-width: 18rem;
+		padding: 1rem;
+	}
+}

--- a/projects/packages/publicize/_inc/components/unified-modal/sharing-activity/test/use-sharing-activity.test.ts
+++ b/projects/packages/publicize/_inc/components/unified-modal/sharing-activity/test/use-sharing-activity.test.ts
@@ -1,0 +1,360 @@
+jest.mock( '@wordpress/data', () => {
+	const actual = jest.requireActual( '@wordpress/data' );
+	const mocks = {
+		useSelect: jest.fn(),
+	};
+	return new Proxy( actual, {
+		get( target, property ) {
+			return mocks[ property as keyof typeof mocks ] ?? target[ property as keyof typeof target ];
+		},
+	} );
+} );
+
+import { renderHook } from '@testing-library/react';
+import { useSelect } from '@wordpress/data';
+import { SharedActivityItem } from '../types';
+import { useSharingActivity } from '../use-sharing-activity';
+import type { Connection, ScheduledShare, ShareStatusItem } from '../../../../social-store/types';
+
+const mockUseSelect = useSelect as jest.MockedFunction< typeof useSelect >;
+
+const createMockConnection = ( overrides: Partial< Connection > = {} ): Connection => ( {
+	connection_id: '123',
+	display_name: 'Test User',
+	external_handle: '@test',
+	external_id: 'ext123',
+	profile_link: 'https://example.com/test',
+	profile_picture: 'https://example.com/pic.jpg',
+	service_label: 'Test Service',
+	service_name: 'tumblr',
+	shared: false,
+	status: 'ok',
+	wpcom_user_id: 1,
+	enabled: true,
+	...overrides,
+} );
+
+const createMockShareStatusItem = (
+	overrides: Partial< ShareStatusItem > = {}
+): ShareStatusItem => ( {
+	connection_id: 123,
+	status: 'success',
+	message: 'https://tumblr.com/test/status/123',
+	timestamp: 1700000000,
+	service: 'tumblr',
+	external_name: 'Test User',
+	external_id: 'ext123',
+	profile_link: 'https://tumblr.com/test',
+	profile_picture: 'https://example.com/pic.jpg',
+	...overrides,
+} );
+
+const createMockScheduledShare = (
+	overrides: Partial< ScheduledShare > = {}
+): ScheduledShare => ( {
+	id: 1,
+	blog_id: 1,
+	connection_id: 123,
+	message: 'Scheduled post message',
+	post_id: 100,
+	timestamp: 1700100000,
+	wpcom_user_id: 1,
+	...overrides,
+} );
+
+type MockSelectorData = {
+	postId?: number;
+	postShareStatus?: {
+		shares: ShareStatusItem[];
+		loading?: boolean;
+		polling?: boolean;
+	};
+	scheduledShares?: ScheduledShare[];
+	isFetchingScheduled?: boolean;
+	connections?: Map< string, Connection >;
+	deletingIds?: number[];
+};
+
+const setupMockUseSelect = ( data: MockSelectorData ) => {
+	const {
+		postId = 100,
+		postShareStatus = { shares: [], loading: false, polling: false },
+		scheduledShares = [],
+		isFetchingScheduled = false,
+		connections = new Map(),
+		deletingIds = [],
+	} = data;
+
+	mockUseSelect.mockImplementation( ( selector: unknown ) => {
+		if ( typeof selector === 'function' ) {
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			const mockSelect = ( store: any ) => {
+				// Handle both store objects and store name strings
+				const storeName = typeof store === 'string' ? store : store?.name;
+
+				if ( storeName === 'core/editor' ) {
+					return {
+						getCurrentPostId: () => postId,
+					};
+				}
+				// socialStore or any other store
+				return {
+					getPostShareStatus: () => postShareStatus,
+					getScheduledSharesForPost: () => scheduledShares,
+					isFetchingScheduledSharesForPost: () => isFetchingScheduled,
+					getConnectionById: ( id: string ) => connections.get( id ),
+					isDeletingScheduledShare: ( id: number ) => deletingIds.includes( id ),
+				};
+			};
+			return selector( mockSelect );
+		}
+		// For direct store access (useSelect(store, []))
+		return {
+			getConnectionById: ( id: string ) => connections.get( id ),
+		};
+	} );
+};
+
+describe( 'useSharingActivity', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'should return empty items when no shares exist', () => {
+		setupMockUseSelect( {} );
+
+		const { result } = renderHook( () => useSharingActivity() );
+
+		expect( result.current.items ).toHaveLength( 0 );
+		expect( result.current.sharedCount ).toBe( 0 );
+		expect( result.current.scheduledCount ).toBe( 0 );
+		expect( result.current.isLoading ).toBe( false );
+	} );
+
+	it( 'should transform shared items correctly', () => {
+		const share = createMockShareStatusItem( {
+			connection_id: 456,
+			status: 'success',
+			message: 'https://tumblr.com/post/123',
+			timestamp: 1700000000,
+			service: 'tumblr',
+			external_name: 'Tumblr User',
+			external_id: 'tb123',
+		} );
+
+		setupMockUseSelect( {
+			postShareStatus: { shares: [ share ], loading: false },
+		} );
+
+		const { result } = renderHook( () => useSharingActivity() );
+
+		expect( result.current.items ).toHaveLength( 1 );
+		expect( result.current.sharedCount ).toBe( 1 );
+
+		const item = result.current.items[ 0 ];
+		expect( item.activityType ).toBe( 'shared' );
+		expect( item.status ).toBe( 'success' );
+		expect( item.timestamp ).toBe( 1700000000 );
+		expect( item.serviceName ).toBe( 'tumblr' );
+		expect( item.displayName ).toBe( 'Tumblr User' );
+
+		// Type assertion since we verified activityType above
+		const sharedItem = item as SharedActivityItem;
+		expect( sharedItem.connectionId ).toBe( 456 );
+		expect( sharedItem.message ).toBe( 'https://tumblr.com/post/123' );
+		expect( sharedItem.originalItem ).toBe( share );
+	} );
+
+	it( 'should transform scheduled items correctly when connection exists', () => {
+		const connection = createMockConnection( {
+			connection_id: '789',
+			service_name: 'linkedin',
+			display_name: 'LinkedIn User',
+			profile_picture: 'https://example.com/linkedin.jpg',
+			profile_link: 'https://linkedin.com/user',
+		} );
+
+		const scheduledShare = createMockScheduledShare( {
+			id: 10,
+			connection_id: 789,
+			timestamp: 1700200000,
+		} );
+
+		setupMockUseSelect( {
+			scheduledShares: [ scheduledShare ],
+			connections: new Map( [ [ '789', connection ] ] ),
+		} );
+
+		const { result } = renderHook( () => useSharingActivity() );
+
+		expect( result.current.items ).toHaveLength( 1 );
+		expect( result.current.scheduledCount ).toBe( 1 );
+
+		const item = result.current.items[ 0 ];
+		expect( item.activityType ).toBe( 'scheduled' );
+		expect( item.status ).toBe( 'scheduled' );
+		expect( item.timestamp ).toBe( 1700200000 );
+		expect( item.serviceName ).toBe( 'linkedin' );
+		expect( item.displayName ).toBe( 'LinkedIn User' );
+
+		// Type assertion since we verified activityType above
+		const scheduledItem = item as import('../types').ScheduledActivityItem;
+		expect( scheduledItem.scheduleId ).toBe( 10 );
+		expect( scheduledItem.connectionId ).toBe( 789 );
+		expect( scheduledItem.connection ).toBe( connection );
+	} );
+
+	it( 'should skip scheduled items when connection does not exist', () => {
+		const scheduledShare = createMockScheduledShare( {
+			connection_id: 999, // No matching connection
+		} );
+
+		setupMockUseSelect( {
+			scheduledShares: [ scheduledShare ],
+			connections: new Map(), // Empty - no connections
+		} );
+
+		const { result } = renderHook( () => useSharingActivity() );
+
+		expect( result.current.items ).toHaveLength( 0 );
+		expect( result.current.scheduledCount ).toBe( 0 );
+	} );
+
+	it( 'should skip scheduled items being deleted', () => {
+		const connection = createMockConnection( { connection_id: '123' } );
+		const scheduledShare = createMockScheduledShare( {
+			id: 5,
+			connection_id: 123,
+		} );
+
+		setupMockUseSelect( {
+			scheduledShares: [ scheduledShare ],
+			connections: new Map( [ [ '123', connection ] ] ),
+			deletingIds: [ 5 ], // This item is being deleted
+		} );
+
+		const { result } = renderHook( () => useSharingActivity() );
+
+		expect( result.current.items ).toHaveLength( 0 );
+		expect( result.current.scheduledCount ).toBe( 0 );
+	} );
+
+	it( 'should combine and sort items by timestamp descending', () => {
+		const connection = createMockConnection( { connection_id: '100' } );
+
+		const oldShare = createMockShareStatusItem( {
+			timestamp: 1700000000,
+			external_name: 'Old Share',
+		} );
+		const newShare = createMockShareStatusItem( {
+			timestamp: 1700300000,
+			external_name: 'New Share',
+		} );
+		const scheduledShare = createMockScheduledShare( {
+			connection_id: 100,
+			timestamp: 1700200000, // In between
+		} );
+
+		setupMockUseSelect( {
+			postShareStatus: { shares: [ oldShare, newShare ], loading: false },
+			scheduledShares: [ scheduledShare ],
+			connections: new Map( [ [ '100', connection ] ] ),
+		} );
+
+		const { result } = renderHook( () => useSharingActivity() );
+
+		expect( result.current.items ).toHaveLength( 3 );
+		expect( result.current.items[ 0 ].timestamp ).toBe( 1700300000 ); // newest first
+		expect( result.current.items[ 1 ].timestamp ).toBe( 1700200000 );
+		expect( result.current.items[ 2 ].timestamp ).toBe( 1700000000 ); // oldest last
+	} );
+
+	it( 'should return correct counts for mixed items', () => {
+		const connection = createMockConnection( { connection_id: '100' } );
+
+		const shares = [
+			createMockShareStatusItem( { status: 'success' } ),
+			createMockShareStatusItem( { status: 'failure' } ),
+		];
+		const scheduledShares = [
+			createMockScheduledShare( { id: 1, connection_id: 100 } ),
+			createMockScheduledShare( { id: 2, connection_id: 100 } ),
+		];
+
+		setupMockUseSelect( {
+			postShareStatus: { shares, loading: false },
+			scheduledShares,
+			connections: new Map( [ [ '100', connection ] ] ),
+		} );
+
+		const { result } = renderHook( () => useSharingActivity() );
+
+		expect( result.current.items ).toHaveLength( 4 );
+		expect( result.current.sharedCount ).toBe( 2 );
+		expect( result.current.scheduledCount ).toBe( 2 );
+	} );
+
+	it( 'should return isLoading true when shares are loading', () => {
+		setupMockUseSelect( {
+			postShareStatus: { shares: [], loading: true },
+		} );
+
+		const { result } = renderHook( () => useSharingActivity() );
+
+		expect( result.current.isLoading ).toBe( true );
+	} );
+
+	it( 'should return isLoading true when scheduled shares are fetching', () => {
+		setupMockUseSelect( {
+			isFetchingScheduled: true,
+		} );
+
+		const { result } = renderHook( () => useSharingActivity() );
+
+		expect( result.current.isLoading ).toBe( true );
+	} );
+
+	it( 'should return isPolling from postShareStatus', () => {
+		setupMockUseSelect( {
+			postShareStatus: { shares: [], loading: false, polling: true },
+		} );
+
+		const { result } = renderHook( () => useSharingActivity() );
+
+		expect( result.current.isPolling ).toBe( true );
+	} );
+
+	it( 'should generate unique IDs for items', () => {
+		const connection = createMockConnection( { connection_id: '100' } );
+
+		const share1 = createMockShareStatusItem( {
+			external_id: 'ext1',
+			connection_id: 100,
+			timestamp: 1700000000,
+		} );
+		const share2 = createMockShareStatusItem( {
+			external_id: 'ext2',
+			connection_id: 100,
+			timestamp: 1700000001,
+		} );
+		const scheduledShare = createMockScheduledShare( {
+			id: 42,
+			connection_id: 100,
+		} );
+
+		setupMockUseSelect( {
+			postShareStatus: { shares: [ share1, share2 ], loading: false },
+			scheduledShares: [ scheduledShare ],
+			connections: new Map( [ [ '100', connection ] ] ),
+		} );
+
+		const { result } = renderHook( () => useSharingActivity() );
+
+		const ids = result.current.items.map( item => item.id );
+		const uniqueIds = new Set( ids );
+
+		expect( uniqueIds.size ).toBe( ids.length );
+		expect( ids.some( id => id.startsWith( 'shared-' ) ) ).toBe( true );
+		expect( ids.some( id => id.startsWith( 'scheduled-' ) ) ).toBe( true );
+	} );
+} );

--- a/projects/packages/publicize/_inc/components/unified-modal/sharing-activity/test/use-sharing-activity.test.ts
+++ b/projects/packages/publicize/_inc/components/unified-modal/sharing-activity/test/use-sharing-activity.test.ts
@@ -160,7 +160,6 @@ describe( 'useSharingActivity', () => {
 
 		// Type assertion since we verified activityType above
 		const sharedItem = item as SharedActivityItem;
-		expect( sharedItem.connectionId ).toBe( 456 );
 		expect( sharedItem.message ).toBe( 'https://tumblr.com/post/123' );
 		expect( sharedItem.originalItem ).toBe( share );
 	} );
@@ -200,8 +199,6 @@ describe( 'useSharingActivity', () => {
 		// Type assertion since we verified activityType above
 		const scheduledItem = item as import('../types').ScheduledActivityItem;
 		expect( scheduledItem.scheduleId ).toBe( 10 );
-		expect( scheduledItem.connectionId ).toBe( 789 );
-		expect( scheduledItem.connection ).toBe( connection );
 	} );
 
 	it( 'should skip scheduled items when connection does not exist', () => {

--- a/projects/packages/publicize/_inc/components/unified-modal/sharing-activity/test/use-sharing-activity.test.ts
+++ b/projects/packages/publicize/_inc/components/unified-modal/sharing-activity/test/use-sharing-activity.test.ts
@@ -102,6 +102,7 @@ const setupMockUseSelect = ( data: MockSelectorData ) => {
 					getPostShareStatus: () => postShareStatus,
 					getScheduledSharesForPost: () => scheduledShares,
 					isFetchingScheduledSharesForPost: () => isFetchingScheduled,
+					getConnections: () => Array.from( connections.values() ),
 					getConnectionById: ( id: string ) => connections.get( id ),
 					isDeletingScheduledShare: ( id: number ) => deletingIds.includes( id ),
 				};

--- a/projects/packages/publicize/_inc/components/unified-modal/sharing-activity/types.ts
+++ b/projects/packages/publicize/_inc/components/unified-modal/sharing-activity/types.ts
@@ -1,4 +1,4 @@
-import { Connection, ShareStatusItem } from '../../../social-store/types';
+import { ShareStatusItem } from '../../../social-store/types';
 
 /**
  * The activity type discriminator.
@@ -48,11 +48,6 @@ interface BaseSharingActivityItem {
 	 * Profile picture URL.
 	 */
 	profilePicture: string;
-
-	/**
-	 * Profile link URL (optional).
-	 */
-	profileLink?: string;
 }
 
 /**
@@ -68,16 +63,6 @@ export interface SharedActivityItem extends BaseSharingActivityItem {
 	 * Status of the share - success or failure.
 	 */
 	status: 'success' | 'failure';
-
-	/**
-	 * Connection ID from the original share.
-	 */
-	connectionId: number;
-
-	/**
-	 * External ID from the social network.
-	 */
-	externalId?: string;
 
 	/**
 	 * Message - URL for success, error message for failure.
@@ -108,16 +93,6 @@ export interface ScheduledActivityItem extends BaseSharingActivityItem {
 	 * Scheduled share ID.
 	 */
 	scheduleId: number;
-
-	/**
-	 * Connection ID.
-	 */
-	connectionId: number;
-
-	/**
-	 * The connection object for action handling.
-	 */
-	connection: Connection;
 }
 
 /**

--- a/projects/packages/publicize/_inc/components/unified-modal/sharing-activity/types.ts
+++ b/projects/packages/publicize/_inc/components/unified-modal/sharing-activity/types.ts
@@ -1,0 +1,131 @@
+import { Connection, ShareStatusItem } from '../../../social-store/types';
+
+/**
+ * The activity type discriminator.
+ */
+export type SharingActivityType = 'shared' | 'scheduled';
+
+/**
+ * Status for sharing activity items.
+ */
+export type SharingActivityStatus = 'success' | 'failure' | 'scheduled';
+
+/**
+ * Base interface for sharing activity items.
+ */
+interface BaseSharingActivityItem {
+	/**
+	 * Unique identifier for the item.
+	 */
+	id: string;
+
+	/**
+	 * The activity type.
+	 */
+	activityType: SharingActivityType;
+
+	/**
+	 * The status of the activity.
+	 */
+	status: SharingActivityStatus;
+
+	/**
+	 * Unix timestamp (seconds).
+	 */
+	timestamp: number;
+
+	/**
+	 * Service name (e.g., 'facebook', 'linkedin').
+	 */
+	serviceName: string;
+
+	/**
+	 * Display name for the account.
+	 */
+	displayName: string;
+
+	/**
+	 * Profile picture URL.
+	 */
+	profilePicture: string;
+
+	/**
+	 * Profile link URL (optional).
+	 */
+	profileLink?: string;
+}
+
+/**
+ * Shared activity item (already shared to social).
+ */
+export interface SharedActivityItem extends BaseSharingActivityItem {
+	/**
+	 * Discriminator for shared items.
+	 */
+	activityType: 'shared';
+
+	/**
+	 * Status of the share - success or failure.
+	 */
+	status: 'success' | 'failure';
+
+	/**
+	 * Connection ID from the original share.
+	 */
+	connectionId: number;
+
+	/**
+	 * External ID from the social network.
+	 */
+	externalId?: string;
+
+	/**
+	 * Message - URL for success, error message for failure.
+	 */
+	message: string;
+
+	/**
+	 * Original ShareStatusItem for action handling.
+	 */
+	originalItem: ShareStatusItem;
+}
+
+/**
+ * Scheduled activity item (pending share).
+ */
+export interface ScheduledActivityItem extends BaseSharingActivityItem {
+	/**
+	 * Discriminator for scheduled items.
+	 */
+	activityType: 'scheduled';
+
+	/**
+	 * Status is always 'scheduled' for pending shares.
+	 */
+	status: 'scheduled';
+
+	/**
+	 * Scheduled share ID.
+	 */
+	scheduleId: number;
+
+	/**
+	 * Connection ID.
+	 */
+	connectionId: number;
+
+	/**
+	 * The connection object for action handling.
+	 */
+	connection: Connection;
+}
+
+/**
+ * Union type for all sharing activity items.
+ */
+export type SharingActivityItem = SharedActivityItem | ScheduledActivityItem;
+
+/**
+ * Filter values for the DataViews.
+ */
+export type SharingActivityFilter = 'all' | 'shared' | 'scheduled';

--- a/projects/packages/publicize/_inc/components/unified-modal/sharing-activity/use-sharing-activity.ts
+++ b/projects/packages/publicize/_inc/components/unified-modal/sharing-activity/use-sharing-activity.ts
@@ -1,0 +1,160 @@
+import { useSelect } from '@wordpress/data';
+import { store as editorStore } from '@wordpress/editor';
+import { useMemo } from '@wordpress/element';
+import { store as socialStore } from '../../../social-store';
+import { ScheduledActivityItem, SharedActivityItem, SharingActivityItem } from './types';
+
+interface UseSharingActivityReturn {
+	/**
+	 * Combined and normalized activity items.
+	 */
+	items: SharingActivityItem[];
+
+	/**
+	 * Whether data is loading.
+	 */
+	isLoading: boolean;
+
+	/**
+	 * Whether shared data is polling.
+	 */
+	isPolling: boolean;
+
+	/**
+	 * Count of shared items.
+	 */
+	sharedCount: number;
+
+	/**
+	 * Count of scheduled items.
+	 */
+	scheduledCount: number;
+}
+
+/**
+ * Hook to fetch and combine shared and scheduled activity data.
+ *
+ * @return Combined sharing activity data with loading states
+ */
+export function useSharingActivity(): UseSharingActivityReturn {
+	const postId = useSelect( select => Number( select( editorStore ).getCurrentPostId() ), [] );
+
+	// Fetch shared posts data
+	const postShareStatus = useSelect(
+		select => select( socialStore ).getPostShareStatus( postId ),
+		[ postId ]
+	);
+
+	// Fetch scheduled shares data
+	const scheduledShares = useSelect(
+		select => select( socialStore ).getScheduledSharesForPost( postId ),
+		[ postId ]
+	);
+
+	const isFetchingScheduled = useSelect(
+		select => select( socialStore ).isFetchingScheduledSharesForPost( postId ),
+		[ postId ]
+	);
+
+	// Get connection lookup function
+	const getConnectionById = useSelect( select => select( socialStore ).getConnectionById, [] );
+
+	// Get IDs of scheduled shares being deleted (reactive)
+	const deletingIdsArray = useSelect(
+		select => {
+			const { isDeletingScheduledShare } = select( socialStore );
+			return scheduledShares
+				.filter( share => isDeletingScheduledShare( share.id ) )
+				.map( share => share.id );
+		},
+		[ scheduledShares ]
+	);
+
+	// Create Set outside useSelect to avoid "data changing" warnings
+	const deletingIds = useMemo( () => new Set( deletingIdsArray ), [ deletingIdsArray ] );
+
+	// Transform and combine the data
+	const { items, sharedCount, scheduledCount } = useMemo( () => {
+		const result: SharingActivityItem[] = [];
+		let shared = 0;
+		let scheduled = 0;
+
+		// Transform shared items
+		for ( const share of postShareStatus.shares ) {
+			const item: SharedActivityItem = {
+				id: `shared-${ share.external_id || share.connection_id }-${ share.timestamp }`,
+				activityType: 'shared',
+				status: share.status,
+				timestamp: share.timestamp,
+				serviceName: share.service,
+				displayName: share.external_name,
+				profilePicture: share.profile_picture,
+				profileLink: share.profile_link,
+				connectionId: share.connection_id,
+				externalId: share.external_id,
+				message: share.message,
+				originalItem: share,
+			};
+			result.push( item );
+			shared++;
+		}
+
+		// Transform scheduled items
+		for ( const scheduledShare of scheduledShares ) {
+			// Skip items being deleted
+			if ( deletingIds.has( scheduledShare.id ) ) {
+				continue;
+			}
+
+			const connection = getConnectionById( scheduledShare.connection_id.toString() );
+
+			// Skip if connection no longer exists
+			if ( ! connection ) {
+				continue;
+			}
+
+			const item: ScheduledActivityItem = {
+				id: `scheduled-${ scheduledShare.id }`,
+				activityType: 'scheduled',
+				status: 'scheduled',
+				timestamp: scheduledShare.timestamp,
+				serviceName: connection.service_name,
+				displayName: connection.display_name,
+				profilePicture: connection.profile_picture,
+				profileLink: connection.profile_link,
+				scheduleId: scheduledShare.id,
+				connectionId: scheduledShare.connection_id,
+				connection,
+			};
+			result.push( item );
+			scheduled++;
+		}
+
+		// Sort by timestamp descending (most recent first)
+		result.sort( ( a, b ) => b.timestamp - a.timestamp );
+
+		return {
+			items: result,
+			sharedCount: shared,
+			scheduledCount: scheduled,
+		};
+	}, [ postShareStatus.shares, scheduledShares, getConnectionById, deletingIds ] );
+
+	return useMemo(
+		() => ( {
+			items,
+			isLoading: postShareStatus.loading || isFetchingScheduled,
+			isPolling: postShareStatus.polling ?? false,
+			sharedCount,
+			scheduledCount,
+		} ),
+		[
+			items,
+			postShareStatus.loading,
+			isFetchingScheduled,
+			postShareStatus.polling,
+			sharedCount,
+			scheduledCount,
+		]
+	);
+}

--- a/projects/packages/publicize/_inc/components/unified-modal/sharing-activity/use-sharing-activity.ts
+++ b/projects/packages/publicize/_inc/components/unified-modal/sharing-activity/use-sharing-activity.ts
@@ -56,29 +56,8 @@ export function useSharingActivity(): UseSharingActivityReturn {
 		[ postId ]
 	);
 
-	// Get connections for all activity items (reactive)
-	const connectionsArray = useSelect(
-		select => {
-			const { getConnectionById } = select( socialStore );
-
-			// Collect unique connection IDs from both shared and scheduled items
-			const connectionIds = new Set< string >();
-			for ( const share of postShareStatus.shares ) {
-				connectionIds.add( share.connection_id.toString() );
-			}
-			for ( const share of scheduledShares ) {
-				connectionIds.add( share.connection_id.toString() );
-			}
-
-			return Array.from( connectionIds )
-				.map( connectionId => ( {
-					connectionId,
-					connection: getConnectionById( connectionId ),
-				} ) )
-				.filter( item => item.connection );
-		},
-		[ postShareStatus.shares, scheduledShares ]
-	);
+	// Get all connections (stable reference from store)
+	const allConnections = useSelect( select => select( socialStore ).getConnections(), [] );
 
 	// Get IDs of scheduled shares being deleted (reactive)
 	const deletingIdsArray = useSelect(
@@ -93,8 +72,8 @@ export function useSharingActivity(): UseSharingActivityReturn {
 
 	// Create lookup structures outside useSelect to avoid "data changing" warnings
 	const connectionsMap = useMemo(
-		() => new Map( connectionsArray.map( item => [ item.connectionId, item.connection ] ) ),
-		[ connectionsArray ]
+		() => new Map( allConnections.map( connection => [ connection.connection_id, connection ] ) ),
+		[ allConnections ]
 	);
 	const deletingIds = useMemo( () => new Set( deletingIdsArray ), [ deletingIdsArray ] );
 

--- a/projects/packages/publicize/_inc/components/unified-modal/sharing-activity/use-sharing-activity.ts
+++ b/projects/packages/publicize/_inc/components/unified-modal/sharing-activity/use-sharing-activity.ts
@@ -56,8 +56,29 @@ export function useSharingActivity(): UseSharingActivityReturn {
 		[ postId ]
 	);
 
-	// Get connection lookup function
-	const getConnectionById = useSelect( select => select( socialStore ).getConnectionById, [] );
+	// Get connections for all activity items (reactive)
+	const connectionsArray = useSelect(
+		select => {
+			const { getConnectionById } = select( socialStore );
+
+			// Collect unique connection IDs from both shared and scheduled items
+			const connectionIds = new Set< string >();
+			for ( const share of postShareStatus.shares ) {
+				connectionIds.add( share.connection_id.toString() );
+			}
+			for ( const share of scheduledShares ) {
+				connectionIds.add( share.connection_id.toString() );
+			}
+
+			return Array.from( connectionIds )
+				.map( connectionId => ( {
+					connectionId,
+					connection: getConnectionById( connectionId ),
+				} ) )
+				.filter( item => item.connection );
+		},
+		[ postShareStatus.shares, scheduledShares ]
+	);
 
 	// Get IDs of scheduled shares being deleted (reactive)
 	const deletingIdsArray = useSelect(
@@ -70,7 +91,11 @@ export function useSharingActivity(): UseSharingActivityReturn {
 		[ scheduledShares ]
 	);
 
-	// Create Set outside useSelect to avoid "data changing" warnings
+	// Create lookup structures outside useSelect to avoid "data changing" warnings
+	const connectionsMap = useMemo(
+		() => new Map( connectionsArray.map( item => [ item.connectionId, item.connection ] ) ),
+		[ connectionsArray ]
+	);
 	const deletingIds = useMemo( () => new Set( deletingIdsArray ), [ deletingIdsArray ] );
 
 	// Transform and combine the data
@@ -81,17 +106,17 @@ export function useSharingActivity(): UseSharingActivityReturn {
 
 		// Transform shared items
 		for ( const share of postShareStatus.shares ) {
+			const connection = connectionsMap.get( share.connection_id.toString() );
+
 			const item: SharedActivityItem = {
 				id: `shared-${ share.external_id || share.connection_id }-${ share.timestamp }`,
 				activityType: 'shared',
 				status: share.status,
 				timestamp: share.timestamp,
-				serviceName: share.service,
-				displayName: share.external_name,
-				profilePicture: share.profile_picture,
-				profileLink: share.profile_link,
-				connectionId: share.connection_id,
-				externalId: share.external_id,
+				// Use connection as source of truth, fall back to share data
+				serviceName: connection?.service_name ?? share.service,
+				displayName: connection?.display_name ?? share.external_name,
+				profilePicture: connection?.profile_picture ?? share.profile_picture,
 				message: share.message,
 				originalItem: share,
 			};
@@ -106,7 +131,7 @@ export function useSharingActivity(): UseSharingActivityReturn {
 				continue;
 			}
 
-			const connection = getConnectionById( scheduledShare.connection_id.toString() );
+			const connection = connectionsMap.get( scheduledShare.connection_id.toString() );
 
 			// Skip if connection no longer exists
 			if ( ! connection ) {
@@ -121,10 +146,7 @@ export function useSharingActivity(): UseSharingActivityReturn {
 				serviceName: connection.service_name,
 				displayName: connection.display_name,
 				profilePicture: connection.profile_picture,
-				profileLink: connection.profile_link,
 				scheduleId: scheduledShare.id,
-				connectionId: scheduledShare.connection_id,
-				connection,
 			};
 			result.push( item );
 			scheduled++;
@@ -138,7 +160,7 @@ export function useSharingActivity(): UseSharingActivityReturn {
 			sharedCount: shared,
 			scheduledCount: scheduled,
 		};
-	}, [ postShareStatus.shares, scheduledShares, getConnectionById, deletingIds ] );
+	}, [ postShareStatus.shares, scheduledShares, connectionsMap, deletingIds ] );
 
 	return useMemo(
 		() => ( {

--- a/projects/packages/publicize/_inc/components/unified-modal/styles.module.scss
+++ b/projects/packages/publicize/_inc/components/unified-modal/styles.module.scss
@@ -3,6 +3,8 @@
 .unified-modal {
 	max-width: gb.$wide-content-width;
 	width: 100%;
+	height: calc(100vh - 4rem);
+	max-height: 48rem;
 
 	@include gb.break-small {
 		width: calc(100vw - 40px);

--- a/projects/packages/publicize/changelog/update-social-unify-sharing-activity
+++ b/projects/packages/publicize/changelog/update-social-unify-sharing-activity
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Unify shared and scheduled sharing activity in Dataviews table.

--- a/projects/packages/publicize/package.json
+++ b/projects/packages/publicize/package.json
@@ -69,6 +69,7 @@
 		"react-page-visibility": "7.0.0"
 	},
 	"devDependencies": {
+		"@automattic/babel-plugin-replace-textdomain": "workspace:*",
 		"@automattic/calypso-color-schemes": "4.0.0",
 		"@automattic/color-studio": "4.1.0",
 		"@automattic/jetpack-base-styles": "workspace:*",

--- a/projects/packages/publicize/webpack.config.js
+++ b/projects/packages/publicize/webpack.config.js
@@ -19,15 +19,38 @@ const socialWebpackConfig = {
 	module: {
 		strictExportPresence: true,
 		rules: [
+			// Old Gutenberg packages' ESM builds don't fully specify their imports. Sigh.
+			// @todo Remove this when we upgrade @wordpress/dataviews to 11.2.0+.
+			// https://github.com/WordPress/gutenberg/issues/73362
+			{
+				test: /\/node_modules\/@wordpress\/.*\/build-module\/.*\.js$/,
+				resolve: { fullySpecified: false },
+			},
+
 			// Transpile JavaScript
 			jetpackWebpackConfig.TranspileRule( {
 				exclude: /node_modules\//,
 			} ),
 
-			// Transpile @automattic/* in node_modules too.
+			// Transpile @automattic/jetpack-* in node_modules too.
 			jetpackWebpackConfig.TranspileRule( {
-				includeNodeModules: [ '@automattic/' ],
+				includeNodeModules: [ '@automattic/jetpack-' ],
 			} ),
+
+			// Add textdomains (but no other optimizations) for @wordpress/dataviews and its dependencies.
+			jetpackWebpackConfig.TranspileRule( {
+				includeNodeModules: [ '@wordpress/dataviews/' ],
+				babelOpts: {
+					configFile: false,
+					plugins: [
+						[
+							require.resolve( '@automattic/babel-plugin-replace-textdomain' ),
+							{ textdomain: 'jetpack-publicize-pkg' },
+						],
+					],
+				},
+			} ),
+
 			// Handle CSS.
 			jetpackWebpackConfig.CssRule( {
 				extensions: [ 'css', 'sass', 'scss' ],


### PR DESCRIPTION
Completes SOCIAL-320

## Proposed changes:

This PR unifies the sharing activity view in the Social modal to display both **shared** and **scheduled** posts in a single DataViews table with tab-based filtering.

### Changes:
- **Unified DataViews component**: Replaced the placeholder tabs with a working `ActivityView` component that uses `@wordpress/dataviews` to display both shared and scheduled items in a single table
- **Custom data hook**: Added `useSharingActivity()` hook that fetches both shared and scheduled data, enriches scheduled items with connection info, and returns a combined sorted list

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->

## Does this pull request change what data or activity we track or use?

No changes to data tracking.

## Testing instructions:

- Add the blog sticker to your site - `add_blog_sticker( 'jetpack-social-unified-ui-v1', null, null, <your-blog-id> );`

1. Connect at least one social account if not already connected
2. Create a new post in the block editor and publish it, sharing to some connections.
3. Open the Jetpack Social panel in the sidebar
4. Open preview posts modal and schedule a share
5. Click "View sharing history" or equivalent to open the sharing activity modal
6. **Test "All shares" tab**: Should display both shared and scheduled items sorted by time (most recent first)
7. **Test "Shared" tab**: Should only show items that have been shared (success or failure)
8. **Test "Scheduled" tab**: Should only show pending scheduled shares
9. **Test View action**: For successfully shared items, click "View" to open the social post in a new tab
10. **Test Retry action**: For failed shares, click "Retry" to attempt sharing again
11. **Test Delete action**: For scheduled shares, click "Delete" and confirm - the item should be removed immediately from the list
12. **Test error details**: For failed shares, click the info icon next to the "Failed" badge to see the error message



https://github.com/user-attachments/assets/04ac0d49-470f-4854-a428-df67c1eecac2


