### PR TITLE
Jetpack Sync: Send Heartbeat data immediately

### DIFF
--- a/projects/packages/sync/changelog/update-sync-send-heartbeat-immediately
+++ b/projects/packages/sync/changelog/update-sync-send-heartbeat-immediately
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Jetpack Sync: Send Heartbeat data immediately

--- a/projects/packages/sync/changelog/update-sync-send-heartbeat-immediately
+++ b/projects/packages/sync/changelog/update-sync-send-heartbeat-immediately
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Jetpack Sync: Send Heartbeat data immediately
+Jetpack Sync: Send Heartbeat data immediately.

--- a/projects/packages/sync/changelog/update-sync-send-heartbeat-immediately
+++ b/projects/packages/sync/changelog/update-sync-send-heartbeat-immediately
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Jetpack Sync: Send Heartbeat data immediately.
+Stats Module: Send Heartbeat data immediately.

--- a/projects/packages/sync/src/modules/class-stats.php
+++ b/projects/packages/sync/src/modules/class-stats.php
@@ -8,7 +8,6 @@
 namespace Automattic\Jetpack\Sync\Modules;
 
 use Automattic\Jetpack\Heartbeat;
-use Automattic\Jetpack\Sync\Sender;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit( 0 );
@@ -47,9 +46,7 @@ class Stats extends Module {
 	 */
 	public function sync_site_stats() {
 
-		$sender = Sender::get_instance();
-
-		$sender->send_action( 'jetpack_sync_heartbeat_stats', $this->add_stats() );
+		$this->send_action( 'jetpack_sync_heartbeat_stats', $this->add_stats() );
 	}
 
 	/**

--- a/projects/packages/sync/src/modules/class-stats.php
+++ b/projects/packages/sync/src/modules/class-stats.php
@@ -8,6 +8,7 @@
 namespace Automattic\Jetpack\Sync\Modules;
 
 use Automattic\Jetpack\Heartbeat;
+use Automattic\Jetpack\Sync\Sender;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit( 0 );
@@ -33,30 +34,22 @@ class Stats extends Module {
 	 *
 	 * @access public
 	 *
-	 * @param callable $callback Action handler callable.
+	 * @param callable $callback Unused - required for parent class compatibility.
 	 */
-	public function init_listeners( $callback ) {
+	public function init_listeners( $callback ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 		add_action( 'jetpack_heartbeat', array( $this, 'sync_site_stats' ), 20 );
-		add_action( 'jetpack_sync_heartbeat_stats', $callback );
 	}
 
 	/**
-	 * This namespaces the action that we sync.
-	 * So that we can differentiate it from future actions.
+	 * Send Heartbeat stats immediately.
 	 *
 	 * @access public
 	 */
 	public function sync_site_stats() {
-		do_action( 'jetpack_sync_heartbeat_stats' );
-	}
 
-	/**
-	 * Initialize the module in the sender.
-	 *
-	 * @access public
-	 */
-	public function init_before_send() {
-		add_filter( 'jetpack_sync_before_send_jetpack_sync_heartbeat_stats', array( $this, 'add_stats' ) );
+		$sender = Sender::get_instance();
+
+		$sender->send_action( 'jetpack_sync_heartbeat_stats', $this->add_stats() );
 	}
 
 	/**

--- a/projects/plugins/jetpack/changelog/update-sync-send-heartbeat-immediately
+++ b/projects/plugins/jetpack/changelog/update-sync-send-heartbeat-immediately
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Update Sync related unit tests
+
+

--- a/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Module_Stats_Test.php
+++ b/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Module_Stats_Test.php
@@ -14,6 +14,21 @@ class Jetpack_Sync_Module_Stats_Test extends Jetpack_Sync_TestBase {
 	const TEST_STAT_VALUE = 'test_stat_value';
 
 	/**
+	 * Tests that heartbeat is sent immediately.
+	 */
+	public function test_sends_data_on_heartbeat_immediately() {
+		$heartbeat = Heartbeat::init();
+
+		add_filter( 'pre_http_request', array( $this, 'pre_http_request_success' ) );
+		$heartbeat->cron_exec();
+		remove_filter( 'pre_http_request', array( $this, 'pre_http_request_success' ) );
+
+		$action = $this->server_event_storage->get_most_recent_event( 'jetpack_sync_heartbeat_stats' );
+
+		$this->assertEquals( 'immediate-send', $action->queue );
+	}
+
+	/**
 	 * Tests that stats data is sent on heartbeat.
 	 */
 	public function test_sends_data_on_heartbeat() {
@@ -26,7 +41,6 @@ class Jetpack_Sync_Module_Stats_Test extends Jetpack_Sync_TestBase {
 		$heartbeat->cron_exec();
 		remove_filter( 'pre_http_request', array( $this, 'pre_http_request_success' ) );
 
-		$this->sender->do_sync();
 		remove_filter( 'jetpack_heartbeat_stats_array', array( $this, 'add_test_stat' ) );
 
 		$action = $this->server_event_storage->get_most_recent_event( 'jetpack_sync_heartbeat_stats' );
@@ -43,8 +57,6 @@ class Jetpack_Sync_Module_Stats_Test extends Jetpack_Sync_TestBase {
 		add_filter( 'pre_http_request', array( $this, 'pre_http_request_success' ) );
 		$heartbeat->cron_exec();
 		remove_filter( 'pre_http_request', array( $this, 'pre_http_request_success' ) );
-
-		$this->sender->do_sync();
 
 		$action = $this->server_event_storage->get_most_recent_event( 'jetpack_sync_heartbeat_stats' );
 
@@ -68,7 +80,6 @@ class Jetpack_Sync_Module_Stats_Test extends Jetpack_Sync_TestBase {
 		$heartbeat->cron_exec();
 		remove_filter( 'pre_http_request', array( $this, 'pre_http_request_success' ) );
 
-		$this->sender->do_sync();
 		remove_filter( 'jetpack_heartbeat_stats_array', array( $this, 'add_test_stat' ) );
 
 		$action = $this->server_event_storage->get_most_recent_event( 'jetpack_sync_heartbeat_stats' );
@@ -114,7 +125,6 @@ class Jetpack_Sync_Module_Stats_Test extends Jetpack_Sync_TestBase {
 		$heartbeat->cron_exec();
 		remove_filter( 'pre_http_request', array( $this, 'pre_http_request_success' ) );
 
-		$this->sender->do_sync();
 		add_filter( 'jetpack_heartbeat_stats_array', array( $this, 'add_test_stat' ) );
 
 		$action = $this->server_event_storage->get_most_recent_event( 'jetpack_sync_heartbeat_stats' );

--- a/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Module_Stats_Test.php
+++ b/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Module_Stats_Test.php
@@ -125,7 +125,7 @@ class Jetpack_Sync_Module_Stats_Test extends Jetpack_Sync_TestBase {
 		$heartbeat->cron_exec();
 		remove_filter( 'pre_http_request', array( $this, 'pre_http_request_success' ) );
 
-		add_filter( 'jetpack_heartbeat_stats_array', array( $this, 'add_test_stat' ) );
+		remove_filter( 'jetpack_heartbeat_stats_array', array( $this, 'add_test_stat' ) );
 
 		$action = $this->server_event_storage->get_most_recent_event( 'jetpack_sync_heartbeat_stats' );
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Closes SYNC-219

We modified the Stats module to send heartbeat data synchronously instead of queuing it partially to avoid the high lag frequently associated with these Sync actions but mainly because the Heartbeat is something we expect to receive from every site on a daily basis.
With this approach we ensure that even sites with very large Sync queues will still send us their Heartbeat timely.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
- Modified the Stats module to send heartbeat data synchronously instead of queuing it
- Removed the init_before_send() method and associated filter registration
- Updated the sync_site_stats() method to directly invoke Sender::send_action()

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
SYNC-219

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* In your local env comment out [these lines](https://github.com/Automattic/jetpack/blob/trunk/projects/packages/connection/src/class-heartbeat.php#L102-L104) so that the heartbeat is sent every time the cron job runs
* Using a plugin like WP Crontrol run the `jetpack_v2_heartbeat` cron job
* Confirm the same payload on WPCOM on trunk vs brunch using your sandbox
* Confirm `jetpack_sync_heartbeat_stats` is logged in ES with `immediate-send` queue

