### PR TITLE
Forms: Fix dashboard URL parameter extraction for external admin contexts

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-external-admin-url-params
+++ b/projects/packages/forms/changelog/fix-forms-external-admin-url-params
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+Comment: Fix Forms dashboard URL parameter extraction to work in external admin contexts
+

--- a/projects/packages/forms/routes/responses/inspector/index.tsx
+++ b/projects/packages/forms/routes/responses/inspector/index.tsx
@@ -25,7 +25,7 @@ import { dateI18n, getSettings as getDateSettings } from '@wordpress/date';
 import { useCallback, useEffect, useState } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
 import { __, _n, sprintf } from '@wordpress/i18n';
-import { useParams, useSearch, useNavigate } from '@wordpress/route';
+import { useNavigate } from '@wordpress/route';
 import * as React from 'react';
 /**
  * Internal dependencies
@@ -33,6 +33,7 @@ import * as React from 'react';
 import CopyClipboardButton from '../../../src/dashboard/components/copy-clipboard-button';
 import Flag from '../../../src/dashboard/components/flag';
 import Gravatar from '../../../src/dashboard/components/gravatar';
+import { useSearchParams, useViewParam, viewToStatus } from '../url-params';
 import { ResponseActions } from './actions';
 import { ResponseNavigation } from './navigation';
 import type { DispatchActions, SelectActions } from '../../../src/dashboard/inbox/stage/types.tsx';
@@ -669,18 +670,11 @@ function SingleResponseView( {
  * @return - Element containing the inspector for responses.
  */
 export default function Inspector() {
-	const params = useParams( { from: '/responses/$view' } );
-	const searchParams = useSearch( { from: '/responses/$view' } );
+	const currentView = useViewParam();
+	const searchParams = useSearchParams();
 	const navigate = useNavigate();
 	const responseIds = searchParams?.responseIds || [];
-
-	// Determine the status based on the current view
-	let status = 'publish';
-	if ( params.view === 'spam' ) {
-		status = 'spam';
-	} else if ( params.view === 'trash' ) {
-		status = 'trash';
-	}
+	const status = viewToStatus( currentView );
 
 	// Fetch all visible records using the same query as the stage
 	// This leverages core-data's cache, so records loaded by stage are reused

--- a/projects/packages/forms/routes/responses/stage.tsx
+++ b/projects/packages/forms/routes/responses/stage.tsx
@@ -18,7 +18,7 @@ import { decodeEntities } from '@wordpress/html-entities';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { download, plus, Icon, globe } from '@wordpress/icons';
 import { store as noticesStore } from '@wordpress/notices';
-import { useParams, useSearch, useNavigate } from '@wordpress/route';
+import { useNavigate } from '@wordpress/route';
 import { Stack } from '@wordpress/ui';
 import * as React from 'react';
 /**
@@ -36,6 +36,7 @@ import { getPath } from '../../src/dashboard/inbox/utils';
 import { store as dashboardStore } from '../../src/dashboard/store';
 import useConfigValue from '../../src/hooks/use-config-value';
 import { INTEGRATIONS_STORE, IntegrationsSelectors } from '../../src/store/integrations';
+import { useSearchParams, useViewParam, viewToStatus } from './url-params';
 /**
  * Types
  */
@@ -177,9 +178,11 @@ function styleUnreadValue( element: React.ReactNode, isUnread: boolean ): React.
  * @return The stage component.
  */
 function Stage() {
-	const params = useParams( { from: '/responses/$view' } );
-	const searchParams = useSearch( { from: '/responses/$view' } );
+	const currentView = useViewParam();
+	const searchParams = useSearchParams();
 	const navigate = useNavigate();
+	// Create a params-like object for backward compatibility
+	const params = useMemo( () => ( { view: currentView } ), [ currentView ] );
 	const counts = useSelect(
 		select => ( select( dashboardStore ) as SelectActions ).getCounts(),
 		[]
@@ -188,12 +191,7 @@ function Stage() {
 		dashboardStore
 	) as DispatchActions;
 	const filterOptions = useFilterOptions();
-	let status = 'publish';
-	if ( params.view === 'spam' ) {
-		status = 'spam';
-	} else if ( params.view === 'trash' ) {
-		status = 'trash';
-	}
+	const status = viewToStatus( currentView );
 
 	const { saveEntityRecord, deleteEntityRecord, invalidateResolution, editEntityRecord } =
 		useDispatch( coreStore ) as unknown as DispatchActions;

--- a/projects/packages/forms/routes/responses/url-params.ts
+++ b/projects/packages/forms/routes/responses/url-params.ts
@@ -1,0 +1,166 @@
+/**
+ * URL parameter utilities for the responses routes.
+ * These utilities handle URL parsing in both standard Jetpack and external admin contexts.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { useEffect, useState } from '@wordpress/element';
+
+/**
+ * View parameter extracted from URL pathname.
+ */
+const VIEW_PATTERN = /(?:\/responses\/|\/marketing\/forms\/|\/forms\/)([^/?#]+)/;
+
+/**
+ * Parse URL to get the effective pathname.
+ * In external admin contexts, the pathname may be embedded in the ?p= parameter.
+ *
+ * @return The effective pathname.
+ */
+function getEffectivePathname(): string {
+	const url = new URL( window.location.href );
+	return url.searchParams.get( 'p' ) || url.pathname;
+}
+
+/**
+ * Extract the view parameter from a pathname.
+ *
+ * @param pathname - The pathname to extract from.
+ * @return The view parameter or 'inbox' as default.
+ */
+function extractViewFromPathname( pathname: string ): string {
+	const match = pathname.match( VIEW_PATTERN );
+	return match?.[ 1 ] || 'inbox';
+}
+
+/**
+ * Extract the view parameter from the current URL.
+ * Works in both standard Jetpack and external admin contexts.
+ *
+ * @return The current view parameter.
+ */
+export function useViewParam(): string {
+	const [ view, setView ] = useState( () => extractViewFromPathname( getEffectivePathname() ) );
+
+	useEffect( () => {
+		/**
+		 * Updates view state when URL changes via browser navigation.
+		 */
+		function handleUrlChange() {
+			setView( extractViewFromPathname( getEffectivePathname() ) );
+		}
+
+		window.addEventListener( 'popstate', handleUrlChange );
+		return () => window.removeEventListener( 'popstate', handleUrlChange );
+	}, [] );
+
+	return view;
+}
+
+export type SearchParamsResult = {
+	responseIds?: string[];
+	search?: string;
+};
+
+/**
+ * Convert a view parameter to the corresponding post status.
+ *
+ * @param view - The view parameter (inbox, spam, or trash).
+ * @return The corresponding post status.
+ */
+export function viewToStatus( view: string ): string {
+	if ( view === 'spam' ) {
+		return 'spam';
+	}
+	if ( view === 'trash' ) {
+		return 'trash';
+	}
+	return 'publish';
+}
+
+/**
+ * Parse responseIds from raw values, handling JSON-encoded arrays.
+ * TanStack Router may encode array values as JSON strings like '["61416"]'.
+ *
+ * @param rawIds - Raw responseIds values from URL.
+ * @return Parsed array of ID strings.
+ */
+function parseResponseIds( rawIds: string[] ): string[] {
+	const result: string[] = [];
+
+	for ( const raw of rawIds ) {
+		if ( raw.startsWith( '[' ) ) {
+			try {
+				const parsed = JSON.parse( raw );
+				if ( Array.isArray( parsed ) ) {
+					result.push( ...parsed.map( String ) );
+					continue;
+				}
+			} catch {
+				// Not valid JSON, treat as regular value
+			}
+		}
+		result.push( raw );
+	}
+
+	return result;
+}
+
+/**
+ * Parse search parameters from the URL.
+ * In external admin contexts, params may be embedded inside the ?p= value.
+ *
+ * @return Object with responseIds and search parameters.
+ */
+function parseSearchParams(): SearchParamsResult {
+	const url = new URL( window.location.href );
+
+	let rawResponseIds = url.searchParams.getAll( 'responseIds' );
+	let search = url.searchParams.get( 'search' ) || undefined;
+
+	// If not found in direct params, check inside the p parameter (external admin context)
+	if ( rawResponseIds.length === 0 ) {
+		const pValue = url.searchParams.get( 'p' );
+		if ( pValue && pValue.includes( '?' ) ) {
+			const pUrl = new URL( pValue, window.location.origin );
+			rawResponseIds = pUrl.searchParams.getAll( 'responseIds' );
+			if ( ! search ) {
+				search = pUrl.searchParams.get( 'search' ) || undefined;
+			}
+		}
+	}
+
+	const responseIds = parseResponseIds( rawResponseIds );
+
+	return {
+		responseIds: responseIds.length > 0 ? responseIds : undefined,
+		search,
+	};
+}
+
+/**
+ * Extract search parameters from the URL.
+ * Works in both standard Jetpack and external admin contexts.
+ * Updates automatically on browser navigation.
+ *
+ * @return Object with responseIds and search parameters.
+ */
+export function useSearchParams(): SearchParamsResult {
+	const [ searchState, setSearchState ] = useState( parseSearchParams );
+
+	useEffect( () => {
+		/**
+		 * Updates search params state when URL changes via browser navigation.
+		 */
+		function handleUrlChange() {
+			setSearchState( parseSearchParams() );
+		}
+
+		window.addEventListener( 'popstate', handleUrlChange );
+		return () => window.removeEventListener( 'popstate', handleUrlChange );
+	}, [] );
+
+	return searchState;
+}


### PR DESCRIPTION
## Summary
- Fix TanStack Router hook errors (`useParams`/`useSearch`) when Forms dashboard loads as a content module in external admin contexts
- Use URL-based parameter extraction that works in both standard Jetpack and external admin environments
- Handle JSON-encoded `responseIds` arrays in URL parameters
- Parse params embedded inside the `?p=` parameter used by external admin routing

## Test plan
- [ ] Load Forms dashboard in standard Jetpack wp-admin context
- [ ] Load Forms dashboard in external admin context via `?page=next-admin&p=/marketing/forms/inbox`
- [ ] Click "View" on a response - Inspector panel should show response details
- [ ] Verify no console errors related to TanStack Router

🤖 Generated with [Claude Code](https://claude.com/claude-code)