### PR TITLE
Forms: Add external admin context support to search params provider

### DIFF
--- a/projects/packages/forms/changelog/fix-create-form-external-admin
+++ b/projects/packages/forms/changelog/fix-create-form-external-admin
@@ -1,0 +1,3 @@
+Significance: patch
+Type: fixed
+Comment: Fix "Create a form" button in external admin contexts by using config-provided URLs instead of relying on window.ajaxurl and relative paths.

--- a/projects/packages/forms/changelog/fix-forms-external-admin-search-params
+++ b/projects/packages/forms/changelog/fix-forms-external-admin-search-params
@@ -1,0 +1,3 @@
+Significance: patch
+Type: fixed
+Comment: Add external admin context support to search params provider for compatibility with custom admin shells

--- a/projects/packages/forms/routes/responses/inspector/index.tsx
+++ b/projects/packages/forms/routes/responses/inspector/index.tsx
@@ -33,37 +33,16 @@ import CopyClipboardButton from '../../../src/dashboard/components/copy-clipboar
 import Flag from '../../../src/dashboard/components/flag';
 import Gravatar from '../../../src/dashboard/components/gravatar';
 import { useDashboardSearchParams } from '../../../src/dashboard/router/dashboard-search-params-context';
+import {
+	getViewFromUrl,
+	isExternalAdminContext,
+	DASHBOARD_URL_CHANGE_EVENT,
+} from '../../../src/dashboard/router/utils';
 import WpRouteDashboardSearchParamsProvider from '../../../src/dashboard/router/wp-route-dashboard-search-params-provider';
 import { ResponseActions } from './actions';
 import { ResponseNavigation } from './navigation';
 import type { DispatchActions, SelectActions } from '../../../src/dashboard/inbox/stage/types.tsx';
 import type { FormResponse } from '../../../src/types/index.ts';
-
-/**
- * Pattern to extract view from URL pathname.
- */
-const VIEW_PATTERN = /(?:\/responses\/|\/marketing\/forms\/|\/forms\/)([^/?#]+)/;
-
-/**
- * Get effective pathname, checking for external admin ?p= parameter.
- *
- * @return The effective pathname.
- */
-function getEffectivePathname(): string {
-	const url = new URL( window.location.href );
-	return url.searchParams.get( 'p' ) || url.pathname;
-}
-
-/**
- * Extract view parameter from URL pathname.
- *
- * @return The view parameter (inbox, spam, or trash).
- */
-function getViewFromUrl(): string {
-	const pathname = getEffectivePathname();
-	const match = pathname.match( VIEW_PATTERN );
-	return match?.[ 1 ] || 'inbox';
-}
 
 const getDisplayName = ( response: FormResponse ) => {
 	const { author_name, author_email, author_url, ip } = response;
@@ -697,16 +676,33 @@ function SingleResponseView( {
  */
 function InspectorContent() {
 	const [ searchParams, setSearchParams ] = useDashboardSearchParams();
-	const view = getViewFromUrl();
+	const [ view, setView ] = useState( getViewFromUrl );
+	const isExternal = isExternalAdminContext();
 	const responseIds = searchParams.getAll( 'responseIds' );
 
+	// Listen for URL changes in external admin context to update view
+	useEffect( () => {
+		if ( ! isExternal ) {
+			return;
+		}
+
+		/**
+		 * Updates view state when URL changes via browser navigation or custom event.
+		 */
+		function handleUrlChange() {
+			setView( getViewFromUrl() );
+		}
+
+		window.addEventListener( 'popstate', handleUrlChange );
+		window.addEventListener( DASHBOARD_URL_CHANGE_EVENT, handleUrlChange );
+		return () => {
+			window.removeEventListener( 'popstate', handleUrlChange );
+			window.removeEventListener( DASHBOARD_URL_CHANGE_EVENT, handleUrlChange );
+		};
+	}, [ isExternal ] );
+
 	// Determine the status based on the current view
-	let status = 'publish';
-	if ( view === 'spam' ) {
-		status = 'spam';
-	} else if ( view === 'trash' ) {
-		status = 'trash';
-	}
+	const status = view === 'spam' || view === 'trash' ? view : 'publish';
 
 	// Fetch all visible records using the same query as the stage
 	// This leverages core-data's cache, so records loaded by stage are reused

--- a/projects/packages/forms/routes/responses/inspector/index.tsx
+++ b/projects/packages/forms/routes/responses/inspector/index.tsx
@@ -25,7 +25,6 @@ import { dateI18n, getSettings as getDateSettings } from '@wordpress/date';
 import { useCallback, useEffect, useState } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
 import { __, _n, sprintf } from '@wordpress/i18n';
-import { useParams, useSearch, useNavigate } from '@wordpress/route';
 import * as React from 'react';
 /**
  * Internal dependencies
@@ -33,10 +32,38 @@ import * as React from 'react';
 import CopyClipboardButton from '../../../src/dashboard/components/copy-clipboard-button';
 import Flag from '../../../src/dashboard/components/flag';
 import Gravatar from '../../../src/dashboard/components/gravatar';
+import { useDashboardSearchParams } from '../../../src/dashboard/router/dashboard-search-params-context';
+import WpRouteDashboardSearchParamsProvider from '../../../src/dashboard/router/wp-route-dashboard-search-params-provider';
 import { ResponseActions } from './actions';
 import { ResponseNavigation } from './navigation';
 import type { DispatchActions, SelectActions } from '../../../src/dashboard/inbox/stage/types.tsx';
 import type { FormResponse } from '../../../src/types/index.ts';
+
+/**
+ * Pattern to extract view from URL pathname.
+ */
+const VIEW_PATTERN = /(?:\/responses\/|\/marketing\/forms\/|\/forms\/)([^/?#]+)/;
+
+/**
+ * Get effective pathname, checking for external admin ?p= parameter.
+ *
+ * @return The effective pathname.
+ */
+function getEffectivePathname(): string {
+	const url = new URL( window.location.href );
+	return url.searchParams.get( 'p' ) || url.pathname;
+}
+
+/**
+ * Extract view parameter from URL pathname.
+ *
+ * @return The view parameter (inbox, spam, or trash).
+ */
+function getViewFromUrl(): string {
+	const pathname = getEffectivePathname();
+	const match = pathname.match( VIEW_PATTERN );
+	return match?.[ 1 ] || 'inbox';
+}
 
 const getDisplayName = ( response: FormResponse ) => {
 	const { author_name, author_email, author_url, ip } = response;
@@ -664,21 +691,20 @@ function SingleResponseView( {
 }
 
 /**
- * Renders the inspector for responses.
+ * Inner inspector component that uses the search params context.
  *
  * @return - Element containing the inspector for responses.
  */
-export default function Inspector() {
-	const params = useParams( { from: '/responses/$view' } );
-	const searchParams = useSearch( { from: '/responses/$view' } );
-	const navigate = useNavigate();
-	const responseIds = searchParams?.responseIds || [];
+function InspectorContent() {
+	const [ searchParams, setSearchParams ] = useDashboardSearchParams();
+	const view = getViewFromUrl();
+	const responseIds = searchParams.getAll( 'responseIds' );
 
 	// Determine the status based on the current view
 	let status = 'publish';
-	if ( params.view === 'spam' ) {
+	if ( view === 'spam' ) {
 		status = 'spam';
-	} else if ( params.view === 'trash' ) {
+	} else if ( view === 'trash' ) {
 		status = 'trash';
 	}
 
@@ -696,24 +722,19 @@ export default function Inspector() {
 	const allRecordIds = records?.map( record => record.id ) ?? [];
 
 	const handleClose = useCallback( () => {
-		navigate( {
-			search: {
-				...searchParams,
-				responseIds: undefined,
-			},
-		} );
-	}, [ navigate, searchParams ] );
+		const nextParams = new URLSearchParams( searchParams );
+		nextParams.delete( 'responseIds' );
+		setSearchParams( nextParams );
+	}, [ searchParams, setSearchParams ] );
 
 	const handleNavigate = useCallback(
 		( id: number ) => {
-			navigate( {
-				search: {
-					...searchParams,
-					responseIds: [ String( id ) ],
-				},
-			} );
+			const nextParams = new URLSearchParams( searchParams );
+			nextParams.delete( 'responseIds' );
+			nextParams.append( 'responseIds', String( id ) );
+			setSearchParams( nextParams );
 		},
-		[ navigate, searchParams ]
+		[ searchParams, setSearchParams ]
 	);
 
 	if ( responseIds.length !== 1 ) {
@@ -731,5 +752,19 @@ export default function Inspector() {
 				onClose={ handleClose }
 			/>
 		</Page>
+	);
+}
+
+/**
+ * Renders the inspector for responses.
+ * Wraps content with the search params provider for router compatibility.
+ *
+ * @return - Element containing the inspector for responses.
+ */
+export default function Inspector() {
+	return (
+		<WpRouteDashboardSearchParamsProvider from="/responses/$view">
+			<InspectorContent />
+		</WpRouteDashboardSearchParamsProvider>
 	);
 }

--- a/projects/packages/forms/routes/responses/stage.tsx
+++ b/projects/packages/forms/routes/responses/stage.tsx
@@ -16,7 +16,7 @@ import { dateI18n } from '@wordpress/date';
 import { useMemo, useState, useCallback, useEffect } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
 import { __, _n, sprintf } from '@wordpress/i18n';
-import { plus, Icon, globe } from '@wordpress/icons';
+import { download, plus, Icon, globe } from '@wordpress/icons';
 import { store as noticesStore } from '@wordpress/notices';
 import { useParams, useSearch, useNavigate } from '@wordpress/route';
 import { Stack } from '@wordpress/ui';
@@ -28,7 +28,6 @@ import IntegrationsModal from '../../src/blocks/contact-form/components/jetpack-
 import EmptyResponses from '../../src/dashboard/components/empty-responses';
 import EmptySpamButton from '../../src/dashboard/components/empty-spam-button';
 import EmptyTrashButton from '../../src/dashboard/components/empty-trash-button';
-import ExportResponsesButton from '../../src/dashboard/components/export-responses/button';
 import Flag from '../../src/dashboard/components/flag';
 import Gravatar from '../../src/dashboard/components/gravatar';
 import Page from '../../src/dashboard/components/page';
@@ -1023,7 +1022,14 @@ function Stage() {
 		}
 
 		actionsArray.push(
-			<ExportResponsesButton key="export" isPrimary={ params.view === 'inbox' } />
+			<Button
+				key="export"
+				variant={ params.view === 'inbox' ? 'primary' : 'secondary' }
+				size="compact"
+				icon={ download }
+			>
+				{ __( 'Export', 'jetpack-forms' ) }
+			</Button>
 		);
 
 		if ( params.view === 'trash' ) {

--- a/projects/packages/forms/routes/responses/stage.tsx
+++ b/projects/packages/forms/routes/responses/stage.tsx
@@ -18,7 +18,6 @@ import { decodeEntities } from '@wordpress/html-entities';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { download, plus, Icon, globe } from '@wordpress/icons';
 import { store as noticesStore } from '@wordpress/notices';
-import { useParams, useSearch, useNavigate } from '@wordpress/route';
 import { Stack } from '@wordpress/ui';
 import * as React from 'react';
 /**
@@ -35,7 +34,8 @@ import './style.scss';
 import * as Tabs from '../../src/dashboard/components/tabs';
 import useCreateForm from '../../src/dashboard/hooks/use-create-form';
 import { getPath } from '../../src/dashboard/inbox/utils';
-import WpRouteDashboardSearchParamsProvider from '../../src/dashboard/router/wp-route-dashboard-search-params-provider.tsx';
+import { useDashboardSearchParams } from '../../src/dashboard/router/dashboard-search-params-context';
+import WpRouteDashboardSearchParamsProvider from '../../src/dashboard/router/wp-route-dashboard-search-params-provider';
 import { store as dashboardStore } from '../../src/dashboard/store';
 import useConfigValue from '../../src/hooks/use-config-value';
 import { INTEGRATIONS_STORE, IntegrationsSelectors } from '../../src/store/integrations';
@@ -46,6 +46,42 @@ import type { SelectActions, DispatchActions } from '../../src/dashboard/inbox/s
 import type { FormResponse } from '../../src/types/index.ts';
 import type { StoreDescriptor } from '@wordpress/data';
 import type { View, Field } from '@wordpress/dataviews';
+
+/**
+ * Pattern to extract view from URL pathname.
+ */
+const VIEW_PATTERN = /(?:\/responses\/|\/marketing\/forms\/|\/forms\/)([^/?#]+)/;
+
+/**
+ * Get effective pathname, checking for external admin ?p= parameter.
+ *
+ * @return The effective pathname.
+ */
+function getEffectivePathname(): string {
+	const url = new URL( window.location.href );
+	return url.searchParams.get( 'p' ) || url.pathname;
+}
+
+/**
+ * Extract view parameter from URL pathname.
+ *
+ * @return The view parameter (inbox, spam, or trash).
+ */
+function getViewFromUrl(): string {
+	const pathname = getEffectivePathname();
+	const match = pathname.match( VIEW_PATTERN );
+	return match?.[ 1 ] || 'inbox';
+}
+
+/**
+ * Check if we're in an external admin context.
+ *
+ * @return True if in external admin context.
+ */
+function isExternalAdminContext(): boolean {
+	const url = new URL( window.location.href );
+	return url.searchParams.has( 'p' );
+}
 
 type FeedbackFilterDate = {
 	month: number;
@@ -176,14 +212,15 @@ function styleUnreadValue( element: React.ReactNode, isUnread: boolean ): React.
 }
 
 /**
- * Stage component for the form responses DataViews.
+ * Inner stage component that uses the search params context.
  *
- * @return The stage component.
+ * @return The stage content.
  */
-function Stage() {
-	const params = useParams( { from: '/responses/$view' } );
-	const searchParams = useSearch( { from: '/responses/$view' } );
-	const navigate = useNavigate();
+function StageContent() {
+	const [ searchParams, setSearchParams ] = useDashboardSearchParams();
+	const currentView = getViewFromUrl();
+	const isExternal = isExternalAdminContext();
+
 	const counts = useSelect(
 		select => ( select( dashboardStore ) as SelectActions ).getCounts(),
 		[]
@@ -195,9 +232,9 @@ function Stage() {
 	) as unknown as DispatchActions;
 	const filterOptions = useFilterOptions();
 	let status = 'publish';
-	if ( params.view === 'spam' ) {
+	if ( currentView === 'spam' ) {
 		status = 'spam';
-	} else if ( params.view === 'trash' ) {
+	} else if ( currentView === 'trash' ) {
 		status = 'trash';
 	}
 
@@ -216,44 +253,47 @@ function Stage() {
 
 	const [ view, setView ] = useState< View >( () => ( {
 		...DEFAULT_VIEW,
-		search: searchParams?.search || '',
+		search: searchParams.get( 'search' ) || '',
 	} ) );
 
-	const selection = searchParams?.responseIds ?? [];
+	const selection = searchParams.getAll( 'responseIds' );
 
 	useEffect( () => {
-		const urlSearch = searchParams?.search || '';
+		const urlSearch = searchParams.get( 'search' ) || '';
 		if ( urlSearch !== view.search ) {
 			setView( prev => ( { ...prev, search: urlSearch } ) );
 		}
-	}, [ searchParams?.search ] ); // eslint-disable-line react-hooks/exhaustive-deps
+	}, [ searchParams ] ); // eslint-disable-line react-hooks/exhaustive-deps
 
 	const onChangeView = useCallback(
 		( newView: View ) => {
 			setView( newView );
 
 			if ( newView.search !== view.search ) {
-				navigate( {
-					search: {
-						...searchParams,
-						search: newView.search || undefined,
-					},
-				} );
+				const nextParams = new URLSearchParams( searchParams );
+				if ( newView.search ) {
+					nextParams.set( 'search', newView.search );
+				} else {
+					nextParams.delete( 'search' );
+				}
+				setSearchParams( nextParams );
 			}
 		},
-		[ navigate, searchParams, view.search ]
+		[ searchParams, setSearchParams, view.search ]
 	);
 
 	const onChangeSelection = useCallback(
 		items => {
-			navigate( {
-				search: {
-					...searchParams,
-					responseIds: items.length > 0 ? items : undefined,
-				},
-			} );
+			const nextParams = new URLSearchParams( searchParams );
+			nextParams.delete( 'responseIds' );
+			if ( items.length > 0 ) {
+				for ( const item of items ) {
+					nextParams.append( 'responseIds', String( item ) );
+				}
+			}
+			setSearchParams( nextParams );
 		},
-		[ searchParams, navigate ]
+		[ searchParams, setSearchParams ]
 	);
 
 	const queryParams = useMemo( () => {
@@ -434,13 +474,10 @@ function Stage() {
 	}, [ invalidateResolution, queryParams ] );
 
 	const clearSelection = useCallback( () => {
-		navigate( {
-			search: {
-				...searchParams,
-				responseIds: undefined,
-			},
-		} );
-	}, [ navigate, searchParams ] );
+		const nextParams = new URLSearchParams( searchParams );
+		nextParams.delete( 'responseIds' );
+		setSearchParams( nextParams );
+	}, [ searchParams, setSearchParams ] );
 
 	const handleMarkAsSpam = useCallback(
 		async items => {
@@ -846,17 +883,17 @@ function Stage() {
 				isPrimary: true,
 				callback: items => {
 					const ids = items.map( item => getItemId( item ) );
-					navigate( {
-						search: {
-							...searchParams,
-							responseIds: ids,
-						},
-					} );
+					const nextParams = new URLSearchParams( searchParams );
+					nextParams.delete( 'responseIds' );
+					for ( const id of ids ) {
+						nextParams.append( 'responseIds', String( id ) );
+					}
+					setSearchParams( nextParams );
 				},
 			},
 		];
 
-		if ( params.view === 'inbox' || ! params.view ) {
+		if ( currentView === 'inbox' || ! currentView ) {
 			return [
 				...baseActions,
 				{
@@ -892,7 +929,7 @@ function Stage() {
 			];
 		}
 
-		if ( params.view === 'spam' ) {
+		if ( currentView === 'spam' ) {
 			return [
 				...baseActions,
 				{
@@ -913,7 +950,7 @@ function Stage() {
 			];
 		}
 
-		if ( params.view === 'trash' ) {
+		if ( currentView === 'trash' ) {
 			return [
 				...baseActions,
 				{
@@ -936,9 +973,9 @@ function Stage() {
 
 		return baseActions;
 	}, [
-		navigate,
 		searchParams,
-		params.view,
+		setSearchParams,
+		currentView,
 		handleMarkAsRead,
 		handleMarkAsUnread,
 		handleMarkAsSpam,
@@ -964,12 +1001,26 @@ function Stage() {
 
 	const handleTabChange = useCallback(
 		newView => {
-			navigate( {
-				to: '/responses/$view',
-				params: { view: newView },
-			} );
+			if ( isExternal ) {
+				// In external admin, update URL via history API
+				const url = new URL( window.location.href );
+				const pValue = url.searchParams.get( 'p' );
+				if ( pValue ) {
+					// Update path inside the p parameter
+					const pUrl = new URL( pValue, window.location.origin );
+					const newPath = pUrl.pathname.replace( /\/[^/?#]+$/, `/${ newView }` );
+					url.searchParams.set( 'p', newPath + pUrl.search );
+					window.history.pushState( {}, '', url.toString() );
+					window.location.reload();
+				}
+			} else {
+				// Standard wp-route navigation - need to use window.location for now
+				// since we don't have access to the navigate function in external context
+				const basePath = getPath();
+				window.location.href = `${ basePath }/${ newView }`;
+			}
 		},
-		[ navigate ]
+		[ isExternal ]
 	);
 
 	const { openNewForm } = useCreateForm();
@@ -991,7 +1042,7 @@ function Stage() {
 
 		// Show integrations button on inbox when feature flags are enabled
 		if (
-			( params.view === 'inbox' || ! params.view ) &&
+			( currentView === 'inbox' || ! currentView ) &&
 			isIntegrationsEnabled &&
 			showDashboardIntegrations
 		) {
@@ -1007,7 +1058,7 @@ function Stage() {
 			);
 		}
 
-		if ( params.view === 'inbox' || ! params.view ) {
+		if ( currentView === 'inbox' || ! currentView ) {
 			actionsArray.push(
 				<Button
 					key="create"
@@ -1024,7 +1075,7 @@ function Stage() {
 		actionsArray.push(
 			<Button
 				key="export"
-				variant={ params.view === 'inbox' ? 'primary' : 'secondary' }
+				variant={ currentView === 'inbox' ? 'primary' : 'secondary' }
 				size="compact"
 				icon={ download }
 			>
@@ -1032,17 +1083,17 @@ function Stage() {
 			</Button>
 		);
 
-		if ( params.view === 'trash' ) {
+		if ( currentView === 'trash' ) {
 			actionsArray.push( <EmptyTrashButton key="empty-trash" /> );
 		}
 
-		if ( params.view === 'spam' ) {
+		if ( currentView === 'spam' ) {
 			actionsArray.push( <EmptySpamButton key="empty-spam" /> );
 		}
 
 		return actionsArray;
 	}, [
-		params.view,
+		currentView,
 		handleIntegrations,
 		handleCreateForm,
 		isIntegrationsEnabled,
@@ -1053,79 +1104,88 @@ function Stage() {
 	const readStatusFilter = view.filters?.find( filter => filter.field === 'read_status' )?.value;
 
 	return (
-		<WpRouteDashboardSearchParamsProvider from="/responses/$view">
-			<Page
-				showSidebarToggle={ false }
-				title={
-					<Stack align="center" gap="xs">
-						<JetpackLogo showText={ false } width={ 20 } />
-						{ __( 'Forms', 'jetpack-forms' ) }
-					</Stack>
+		<Page
+			showSidebarToggle={ false }
+			title={
+				<Stack align="center" gap="xs">
+					<JetpackLogo showText={ false } width={ 20 } />
+					{ __( 'Forms', 'jetpack-forms' ) }
+				</Stack>
+			}
+			subTitle={ __( 'View and manage all your form submissions in one place.', 'jetpack-forms' ) }
+			actions={ headerActions }
+			hasPadding={ false }
+		>
+			<DataViews
+				empty={
+					<EmptyResponses
+						status={ currentView }
+						isSearch={ !! view.search }
+						readStatusFilter={ readStatusFilter }
+					/>
 				}
-				subTitle={ __(
-					'View and manage all your form submissions in one place.',
-					'jetpack-forms'
-				) }
-				actions={ headerActions }
-				hasPadding={ false }
+				data={ records || EMPTY_ARRAY }
+				fields={ fields as Field< unknown >[] }
+				view={ view }
+				onChangeView={ onChangeView }
+				paginationInfo={ paginationInfo }
+				isLoading={ isResolving }
+				getItemId={ getItemId }
+				defaultLayouts={ defaultLayouts }
+				selection={ selection }
+				onChangeSelection={ onChangeSelection }
+				actions={ actions }
 			>
-				<DataViews
-					empty={
-						<EmptyResponses
-							status={ params.view }
-							isSearch={ !! view.search }
-							readStatusFilter={ readStatusFilter }
-						/>
-					}
-					data={ records || EMPTY_ARRAY }
-					fields={ fields as Field< unknown >[] }
-					view={ view }
-					onChangeView={ onChangeView }
-					paginationInfo={ paginationInfo }
-					isLoading={ isResolving }
-					getItemId={ getItemId }
-					defaultLayouts={ defaultLayouts }
-					selection={ selection }
-					onChangeSelection={ onChangeSelection }
-					actions={ actions }
+				<Stack
+					align="center"
+					className="jp-forms-dataviews__view-actions"
+					gap="sm"
+					justify="space-between"
 				>
-					<Stack
-						align="center"
-						className="jp-forms-dataviews__view-actions"
-						gap="sm"
-						justify="space-between"
-					>
-						<Stack align="center" gap="sm">
-							<Tabs.Root value={ params.view || 'inbox' } onValueChange={ handleTabChange }>
-								<Tabs.List density="compact">
-									{ statusTabs.map( tab => (
-										<Tabs.Tab value={ tab.slug } key={ tab.slug }>
-											{ tab.label }
-										</Tabs.Tab>
-									) ) }
-								</Tabs.List>
-							</Tabs.Root>
-						</Stack>
-						<Stack align="center" gap="sm">
-							<DataViews.Search />
-							<DataViews.FiltersToggle />
-							<DataViews.ViewConfig />
-						</Stack>
+					<Stack align="center" gap="sm">
+						<Tabs.Root value={ currentView || 'inbox' } onValueChange={ handleTabChange }>
+							<Tabs.List density="compact">
+								{ statusTabs.map( tab => (
+									<Tabs.Tab value={ tab.slug } key={ tab.slug }>
+										{ tab.label }
+									</Tabs.Tab>
+								) ) }
+							</Tabs.List>
+						</Tabs.Root>
 					</Stack>
-					<DataViews.Filters className="dataviews-filters__container" />
-					<DataViews.Layout />
-					<DataViews.Footer />
-				</DataViews>
-				<IntegrationsModal
-					isOpen={ isIntegrationsModalOpen }
-					onClose={ closeIntegrationsModal }
-					attributes={ undefined }
-					setAttributes={ undefined }
-					integrationsData={ integrations }
-					refreshIntegrations={ refreshIntegrations }
-					context="dashboard"
-				/>
-			</Page>
+					<Stack align="center" gap="sm">
+						<DataViews.Search />
+						<DataViews.FiltersToggle />
+						<DataViews.ViewConfig />
+					</Stack>
+				</Stack>
+				<DataViews.Filters className="dataviews-filters__container" />
+				<DataViews.Layout />
+				<DataViews.Footer />
+			</DataViews>
+			<IntegrationsModal
+				isOpen={ isIntegrationsModalOpen }
+				onClose={ closeIntegrationsModal }
+				attributes={ undefined }
+				setAttributes={ undefined }
+				integrationsData={ integrations }
+				refreshIntegrations={ refreshIntegrations }
+				context="dashboard"
+			/>
+		</Page>
+	);
+}
+
+/**
+ * Stage component for the form responses DataViews.
+ * Wraps content with the search params provider for router compatibility.
+ *
+ * @return The stage component.
+ */
+function Stage() {
+	return (
+		<WpRouteDashboardSearchParamsProvider from="/responses/$view">
+			<StageContent />
 		</WpRouteDashboardSearchParamsProvider>
 	);
 }

--- a/projects/packages/forms/routes/responses/stage.tsx
+++ b/projects/packages/forms/routes/responses/stage.tsx
@@ -35,7 +35,11 @@ import * as Tabs from '../../src/dashboard/components/tabs';
 import useCreateForm from '../../src/dashboard/hooks/use-create-form';
 import { getPath } from '../../src/dashboard/inbox/utils';
 import { useDashboardSearchParams } from '../../src/dashboard/router/dashboard-search-params-context';
-import { isExternalAdminContext, getViewFromUrl } from '../../src/dashboard/router/utils';
+import {
+	isExternalAdminContext,
+	getViewFromUrl,
+	DASHBOARD_URL_CHANGE_EVENT,
+} from '../../src/dashboard/router/utils';
 import WpRouteDashboardSearchParamsProvider from '../../src/dashboard/router/wp-route-dashboard-search-params-provider';
 import { store as dashboardStore } from '../../src/dashboard/store';
 import useConfigValue from '../../src/hooks/use-config-value';
@@ -184,8 +188,29 @@ function styleUnreadValue( element: React.ReactNode, isUnread: boolean ): React.
  */
 function StageContent() {
 	const [ searchParams, setSearchParams ] = useDashboardSearchParams();
-	const currentView = getViewFromUrl();
+	const [ currentView, setCurrentView ] = useState( getViewFromUrl );
 	const isExternal = isExternalAdminContext();
+
+	// Listen for URL changes in external admin context to update view
+	useEffect( () => {
+		if ( ! isExternal ) {
+			return;
+		}
+
+		/**
+		 * Updates view state when URL changes via browser navigation or custom event.
+		 */
+		function handleUrlChange() {
+			setCurrentView( getViewFromUrl() );
+		}
+
+		window.addEventListener( 'popstate', handleUrlChange );
+		window.addEventListener( DASHBOARD_URL_CHANGE_EVENT, handleUrlChange );
+		return () => {
+			window.removeEventListener( 'popstate', handleUrlChange );
+			window.removeEventListener( DASHBOARD_URL_CHANGE_EVENT, handleUrlChange );
+		};
+	}, [ isExternal ] );
 
 	const counts = useSelect(
 		select => ( select( dashboardStore ) as SelectActions ).getCounts(),
@@ -251,9 +276,8 @@ function StageContent() {
 		items => {
 			const nextParams = new URLSearchParams( searchParams );
 			nextParams.delete( 'responseIds' );
-			if ( items.length > 0 ) {
-				// Use JSON array format to match TanStack Router expectations
-				nextParams.set( 'responseIds', JSON.stringify( items.map( String ) ) );
+			for ( const item of items ) {
+				nextParams.append( 'responseIds', String( item ) );
 			}
 			setSearchParams( nextParams );
 		},
@@ -966,20 +990,25 @@ function StageContent() {
 	const handleTabChange = useCallback(
 		newView => {
 			if ( isExternal ) {
-				// In external admin, update URL via history API
+				// In external admin, update URL via history API and dispatch custom event
 				const url = new URL( window.location.href );
 				const pValue = url.searchParams.get( 'p' );
 				if ( pValue ) {
-					// Update path inside the p parameter
-					const pUrl = new URL( pValue, window.location.origin );
-					const newPath = pUrl.pathname.replace( /\/[^/?#]+$/, `/${ newView }` );
-					url.searchParams.set( 'p', newPath + pUrl.search );
-					window.history.pushState( {}, '', url.toString() );
-					window.location.reload();
+					try {
+						// Update path inside the p parameter
+						const pUrl = new URL( pValue, window.location.origin );
+						const newPath = pUrl.pathname.replace( /\/[^/?#]+$/, `/${ newView }` );
+						url.searchParams.set( 'p', newPath + pUrl.search );
+						window.history.pushState( {}, '', url.toString() );
+						// Dispatch custom event to notify components of URL change
+						window.dispatchEvent( new CustomEvent( DASHBOARD_URL_CHANGE_EVENT ) );
+					} catch {
+						// Fallback to page reload if URL parsing fails
+						window.location.reload();
+					}
 				}
 			} else {
-				// Standard wp-route navigation - need to use window.location for now
-				// since we don't have access to the navigate function in external context
+				// Standard wp-route navigation
 				const basePath = getPath();
 				window.location.href = `${ basePath }/${ newView }`;
 			}

--- a/projects/packages/forms/routes/responses/stage.tsx
+++ b/projects/packages/forms/routes/responses/stage.tsx
@@ -287,9 +287,8 @@ function StageContent() {
 			const nextParams = new URLSearchParams( searchParams );
 			nextParams.delete( 'responseIds' );
 			if ( items.length > 0 ) {
-				for ( const item of items ) {
-					nextParams.append( 'responseIds', String( item ) );
-				}
+				// Use JSON array format to match TanStack Router expectations
+				nextParams.set( 'responseIds', JSON.stringify( items.map( String ) ) );
 			}
 			setSearchParams( nextParams );
 		},

--- a/projects/packages/forms/routes/responses/stage.tsx
+++ b/projects/packages/forms/routes/responses/stage.tsx
@@ -197,12 +197,7 @@ function StageContent() {
 		dashboardStoreDescriptor
 	) as unknown as DispatchActions;
 	const filterOptions = useFilterOptions();
-	let status = 'publish';
-	if ( currentView === 'spam' ) {
-		status = 'spam';
-	} else if ( currentView === 'trash' ) {
-		status = 'trash';
-	}
+	const status = currentView === 'spam' || currentView === 'trash' ? currentView : 'publish';
 
 	const { saveEntityRecord, deleteEntityRecord, invalidateResolution, editEntityRecord } =
 		useDispatch( coreStore ) as unknown as DispatchActions;

--- a/projects/packages/forms/routes/responses/stage.tsx
+++ b/projects/packages/forms/routes/responses/stage.tsx
@@ -144,8 +144,8 @@ const DEFAULT_VIEW: View = {
  * @param item.id - The item ID.
  * @return The item ID as a string.
  */
-function getItemId( item: { id: number | string } ): string {
-	return item.id.toString();
+function getItemId( item: unknown ): string {
+	return ( item as { id: number | string } )?.id?.toString() ?? '';
 }
 
 /**

--- a/projects/packages/forms/routes/responses/stage.tsx
+++ b/projects/packages/forms/routes/responses/stage.tsx
@@ -16,7 +16,7 @@ import { dateI18n } from '@wordpress/date';
 import { useMemo, useState, useCallback, useEffect } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
 import { __, _n, sprintf } from '@wordpress/i18n';
-import { download, plus, Icon, globe } from '@wordpress/icons';
+import { plus, Icon, globe } from '@wordpress/icons';
 import { store as noticesStore } from '@wordpress/notices';
 import { useParams, useSearch, useNavigate } from '@wordpress/route';
 import { Stack } from '@wordpress/ui';
@@ -28,6 +28,7 @@ import IntegrationsModal from '../../src/blocks/contact-form/components/jetpack-
 import EmptyResponses from '../../src/dashboard/components/empty-responses';
 import EmptySpamButton from '../../src/dashboard/components/empty-spam-button';
 import EmptyTrashButton from '../../src/dashboard/components/empty-trash-button';
+import ExportResponsesButton from '../../src/dashboard/components/export-responses/button';
 import Flag from '../../src/dashboard/components/flag';
 import Gravatar from '../../src/dashboard/components/gravatar';
 import Page from '../../src/dashboard/components/page';
@@ -1022,14 +1023,7 @@ function Stage() {
 		}
 
 		actionsArray.push(
-			<Button
-				key="export"
-				variant={ params.view === 'inbox' ? 'primary' : 'secondary' }
-				size="compact"
-				icon={ download }
-			>
-				{ __( 'Export', 'jetpack-forms' ) }
-			</Button>
+			<ExportResponsesButton key="export" isPrimary={ params.view === 'inbox' } />
 		);
 
 		if ( params.view === 'trash' ) {

--- a/projects/packages/forms/routes/responses/stage.tsx
+++ b/projects/packages/forms/routes/responses/stage.tsx
@@ -35,6 +35,7 @@ import * as Tabs from '../../src/dashboard/components/tabs';
 import useCreateForm from '../../src/dashboard/hooks/use-create-form';
 import { getPath } from '../../src/dashboard/inbox/utils';
 import { useDashboardSearchParams } from '../../src/dashboard/router/dashboard-search-params-context';
+import { isExternalAdminContext, getViewFromUrl } from '../../src/dashboard/router/utils';
 import WpRouteDashboardSearchParamsProvider from '../../src/dashboard/router/wp-route-dashboard-search-params-provider';
 import { store as dashboardStore } from '../../src/dashboard/store';
 import useConfigValue from '../../src/hooks/use-config-value';
@@ -46,42 +47,6 @@ import type { SelectActions, DispatchActions } from '../../src/dashboard/inbox/s
 import type { FormResponse } from '../../src/types/index.ts';
 import type { StoreDescriptor } from '@wordpress/data';
 import type { View, Field } from '@wordpress/dataviews';
-
-/**
- * Pattern to extract view from URL pathname.
- */
-const VIEW_PATTERN = /(?:\/responses\/|\/marketing\/forms\/|\/forms\/)([^/?#]+)/;
-
-/**
- * Get effective pathname, checking for external admin ?p= parameter.
- *
- * @return The effective pathname.
- */
-function getEffectivePathname(): string {
-	const url = new URL( window.location.href );
-	return url.searchParams.get( 'p' ) || url.pathname;
-}
-
-/**
- * Extract view parameter from URL pathname.
- *
- * @return The view parameter (inbox, spam, or trash).
- */
-function getViewFromUrl(): string {
-	const pathname = getEffectivePathname();
-	const match = pathname.match( VIEW_PATTERN );
-	return match?.[ 1 ] || 'inbox';
-}
-
-/**
- * Check if we're in an external admin context.
- *
- * @return True if in external admin context.
- */
-function isExternalAdminContext(): boolean {
-	const url = new URL( window.location.href );
-	return url.searchParams.has( 'p' );
-}
 
 type FeedbackFilterDate = {
 	month: number;
@@ -175,11 +140,12 @@ const DEFAULT_VIEW: View = {
 /**
  * Get item ID as string.
  *
- * @param {object} item - The item object.
- * @return {string} The item ID as a string.
+ * @param item    - The item object.
+ * @param item.id - The item ID.
+ * @return The item ID as a string.
  */
-function getItemId( item: unknown ): string {
-	return ( item as { id: number | string } )?.id?.toString() ?? '';
+function getItemId( item: { id: number | string } ): string {
+	return item.id.toString();
 }
 
 /**
@@ -258,12 +224,16 @@ function StageContent() {
 
 	const selection = searchParams.getAll( 'responseIds' );
 
+	// Sync search param from URL to view state when URL changes.
+	// Intentionally excludes view.search to prevent infinite loop:
+	// URL changes -> update view.search -> triggers effect -> would update URL
 	useEffect( () => {
 		const urlSearch = searchParams.get( 'search' ) || '';
 		if ( urlSearch !== view.search ) {
 			setView( prev => ( { ...prev, search: urlSearch } ) );
 		}
-	}, [ searchParams ] ); // eslint-disable-line react-hooks/exhaustive-deps
+		// eslint-disable-next-line react-hooks/exhaustive-deps -- view.search excluded to prevent sync loop
+	}, [ searchParams ] );
 
 	const onChangeView = useCallback(
 		( newView: View ) => {

--- a/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
@@ -1518,6 +1518,9 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 			'exportNonce'                    => wp_create_nonce( 'feedback_export' ),
 			'newFormNonce'                   => wp_create_nonce( 'create_new_form' ),
 			'emptyTrashDays'                 => defined( 'EMPTY_TRASH_DAYS' ) ? EMPTY_TRASH_DAYS : 0,
+			// Admin URLs for external admin contexts.
+			'adminUrl'                       => admin_url(),
+			'ajaxUrl'                        => admin_url( 'admin-ajax.php' ),
 		);
 
 		return rest_ensure_response( $config );

--- a/projects/packages/forms/src/dashboard/hooks/use-create-form.ts
+++ b/projects/packages/forms/src/dashboard/hooks/use-create-form.ts
@@ -42,6 +42,8 @@ type CreateFormReturn = {
 export default function useCreateForm(): CreateFormReturn {
 	const newFormNonce = useConfigValue( 'newFormNonce' );
 	const isCentralFormManagementEnabled = useConfigValue( 'isCentralFormManagementEnabled' );
+	const adminUrl = useConfigValue( 'adminUrl' );
+	const ajaxUrl = useConfigValue( 'ajaxUrl' );
 	const createForm = useCallback(
 		async ( formPattern: string ) => {
 			const data = new FormData();
@@ -53,7 +55,9 @@ export default function useCreateForm(): CreateFormReturn {
 				data.append( 'pattern', formPattern );
 			}
 
-			const response = await fetch( window.ajaxurl, { method: 'POST', body: data } );
+			// Fall back to window.ajaxurl for backwards compatibility.
+			const fetchUrl = ajaxUrl || window.ajaxurl;
+			const response = await fetch( fetchUrl, { method: 'POST', body: data } );
 
 			const {
 				success,
@@ -67,7 +71,7 @@ export default function useCreateForm(): CreateFormReturn {
 
 			return postUrl;
 		},
-		[ newFormNonce ]
+		[ newFormNonce, ajaxUrl ]
 	);
 
 	const openNewForm = useCallback(
@@ -77,7 +81,8 @@ export default function useCreateForm(): CreateFormReturn {
 				// Keep existing behavior when disabled (or not yet loaded).
 				if ( isCentralFormManagementEnabled === true ) {
 					analyticsEvent?.( { formPattern: formPattern ?? '' } );
-					const url = 'post-new.php?post_type=jetpack_form';
+					// Use config adminUrl to build full URL for external admin contexts.
+					const url = `${ adminUrl || '' }post-new.php?post_type=jetpack_form`;
 					openFormLinkInNewTab( url );
 					return;
 				}
@@ -96,7 +101,7 @@ export default function useCreateForm(): CreateFormReturn {
 				console.error( error.message ); // eslint-disable-line no-console
 			}
 		},
-		[ createForm, isCentralFormManagementEnabled ]
+		[ createForm, isCentralFormManagementEnabled, adminUrl ]
 	);
 
 	return { createForm, openNewForm };

--- a/projects/packages/forms/src/dashboard/hooks/use-inbox-data.ts
+++ b/projects/packages/forms/src/dashboard/hooks/use-inbox-data.ts
@@ -42,17 +42,25 @@ function formatFieldName( fieldName: string ): string {
 }
 
 /**
- * Checks if an object or array is empty.
+ * Checks if a value is empty (null, undefined, empty string, empty array, or empty object).
  *
- * @see https://github.com/you-dont-need/You-Dont-Need-Lodash-Underscore?tab=readme-ov-file#_isempty
- * @param {unknown} obj - The object to check.
+ * @param {unknown} value - The value to check.
  * @return {boolean} True if empty, false otherwise.
  */
-function isEmpty( obj: unknown ): boolean {
-	return (
-		[ Object, Array ].includes( ( obj || {} ).constructor as ObjectConstructor ) &&
-		! Object.entries( obj || {} ).length
-	);
+function isEmpty( value: unknown ): boolean {
+	if ( value == null ) {
+		return true;
+	}
+	if ( typeof value === 'string' ) {
+		return value.trim().length === 0;
+	}
+	if ( Array.isArray( value ) ) {
+		return value.length === 0;
+	}
+	if ( typeof value === 'object' ) {
+		return Object.keys( value ).length === 0;
+	}
+	return false;
 }
 
 /**

--- a/projects/packages/forms/src/dashboard/hooks/use-inbox-data.ts
+++ b/projects/packages/forms/src/dashboard/hooks/use-inbox-data.ts
@@ -23,33 +23,53 @@ import type { FormResponse } from '../../types/index.ts';
  * @param {string} urlStatus - The current status from the URL.
  * @return {string} The status filter to apply.
  */
-function getStatusFilter( urlStatus ) {
-	// Only allow specific status values.
-	const statusFilter = [ 'inbox', 'spam', 'trash' ].includes( urlStatus ) ? urlStatus : 'inbox';
+function getStatusFilter( urlStatus: string | null ): string {
+	const statusFilter = [ 'inbox', 'spam', 'trash' ].includes( urlStatus ?? '' )
+		? urlStatus
+		: 'inbox';
 	return statusFilter === 'inbox' ? 'draft,publish' : statusFilter;
 }
 
-const formatFieldName = fieldName => {
+/**
+ * Formats a field name by removing any numeric prefix.
+ *
+ * @param {string} fieldName - The field name to format.
+ * @return {string} The formatted field name.
+ */
+function formatFieldName( fieldName: string ): string {
 	const match = fieldName.match( /^(\d+_)?(.*)/i );
-	if ( match ) {
-		return match[ 2 ];
-	}
-	return fieldName;
-};
+	return match ? match[ 2 ] : fieldName;
+}
 
-// https://github.com/you-dont-need/You-Dont-Need-Lodash-Underscore?tab=readme-ov-file#_isempty
-const isEmpty = obj =>
-	[ Object, Array ].includes( ( obj || {} ).constructor ) && ! Object.entries( obj || {} ).length;
+/**
+ * Checks if an object or array is empty.
+ *
+ * @see https://github.com/you-dont-need/You-Dont-Need-Lodash-Underscore?tab=readme-ov-file#_isempty
+ * @param {unknown} obj - The object to check.
+ * @return {boolean} True if empty, false otherwise.
+ */
+function isEmpty( obj: unknown ): boolean {
+	return (
+		[ Object, Array ].includes( ( obj || {} ).constructor as ObjectConstructor ) &&
+		! Object.entries( obj || {} ).length
+	);
+}
 
-const formatFieldValue = fieldValue => {
+/**
+ * Formats a field value for display.
+ *
+ * @param {unknown} fieldValue - The field value to format.
+ * @return {string} The formatted field value.
+ */
+function formatFieldValue( fieldValue: unknown ): string {
 	if ( ! fieldValue || isEmpty( fieldValue ) ) {
 		return '-';
 	}
 	if ( Array.isArray( fieldValue ) ) {
 		return fieldValue.join( ', ' );
 	}
-	return fieldValue;
-};
+	return String( fieldValue );
+}
 
 /**
  * Interface for the return value of the useInboxData hook.

--- a/projects/packages/forms/src/dashboard/inbox/stage/index.js
+++ b/projects/packages/forms/src/dashboard/inbox/stage/index.js
@@ -13,7 +13,7 @@ import { dateI18n, getSettings as getDateSettings } from '@wordpress/date';
 import { useCallback, useMemo, useState } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
 import { __ } from '@wordpress/i18n';
-import { download, Icon, globe } from '@wordpress/icons';
+import { Icon, globe } from '@wordpress/icons';
 import clsx from 'clsx';
 import { useEffect } from 'react';
 /**
@@ -25,6 +25,7 @@ import CreateFormButton from '../../components/create-form-button/index.tsx';
 import EmptyResponses from '../../components/empty-responses/index.tsx';
 import EmptySpamButton from '../../components/empty-spam-button/index.tsx';
 import EmptyTrashButton from '../../components/empty-trash-button/index.tsx';
+import ExportResponsesButton from '../../components/export-responses/button.tsx';
 import Flag from '../../components/flag/index.tsx';
 import FormsResponsesTabs from '../../components/forms-responses-tabs/index.tsx';
 import Gravatar from '../../components/gravatar/index.tsx';
@@ -511,14 +512,7 @@ export default function InboxView() {
 	const headerActions = useMemo( () => {
 		const exportIsPrimary = statusFilter !== 'trash' && statusFilter !== 'spam';
 		const headerActionsArray = [
-			<Button
-				key="export"
-				variant={ exportIsPrimary ? 'primary' : 'secondary' }
-				size="compact"
-				icon={ download }
-			>
-				{ __( 'Export', 'jetpack-forms' ) }
-			</Button>,
+			<ExportResponsesButton key="export" isPrimary={ exportIsPrimary } />,
 		];
 
 		if ( statusFilter === 'trash' ) {

--- a/projects/packages/forms/src/dashboard/inbox/stage/index.js
+++ b/projects/packages/forms/src/dashboard/inbox/stage/index.js
@@ -13,7 +13,7 @@ import { dateI18n, getSettings as getDateSettings } from '@wordpress/date';
 import { useCallback, useMemo, useState } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
 import { __ } from '@wordpress/i18n';
-import { Icon, globe } from '@wordpress/icons';
+import { download, Icon, globe } from '@wordpress/icons';
 import clsx from 'clsx';
 import { useEffect } from 'react';
 /**
@@ -25,7 +25,6 @@ import CreateFormButton from '../../components/create-form-button/index.tsx';
 import EmptyResponses from '../../components/empty-responses/index.tsx';
 import EmptySpamButton from '../../components/empty-spam-button/index.tsx';
 import EmptyTrashButton from '../../components/empty-trash-button/index.tsx';
-import ExportResponsesButton from '../../components/export-responses/button.tsx';
 import Flag from '../../components/flag/index.tsx';
 import FormsResponsesTabs from '../../components/forms-responses-tabs/index.tsx';
 import Gravatar from '../../components/gravatar/index.tsx';
@@ -512,7 +511,14 @@ export default function InboxView() {
 	const headerActions = useMemo( () => {
 		const exportIsPrimary = statusFilter !== 'trash' && statusFilter !== 'spam';
 		const headerActionsArray = [
-			<ExportResponsesButton key="export" isPrimary={ exportIsPrimary } />,
+			<Button
+				key="export"
+				variant={ exportIsPrimary ? 'primary' : 'secondary' }
+				size="compact"
+				icon={ download }
+			>
+				{ __( 'Export', 'jetpack-forms' ) }
+			</Button>,
 		];
 
 		if ( statusFilter === 'trash' ) {

--- a/projects/packages/forms/src/dashboard/router/utils.ts
+++ b/projects/packages/forms/src/dashboard/router/utils.ts
@@ -1,0 +1,42 @@
+/**
+ * Custom event name for URL changes within the dashboard.
+ * Uses a custom event to avoid conflicts with browser navigation popstate events.
+ */
+export const DASHBOARD_URL_CHANGE_EVENT = 'jetpack-forms-url-change';
+
+/**
+ * Pattern to extract view from URL pathname.
+ * Matches paths like /responses/inbox, /marketing/forms/spam, /forms/trash
+ */
+export const VIEW_PATTERN = /(?:\/responses\/|\/marketing\/forms\/|\/forms\/)([^/?#]+)/;
+
+/**
+ * Check if we're in an external admin context (e.g., params embedded in ?p= parameter).
+ *
+ * @return True if in external admin context.
+ */
+export function isExternalAdminContext(): boolean {
+	const url = new URL( window.location.href );
+	return url.searchParams.has( 'p' );
+}
+
+/**
+ * Get effective pathname, checking for external admin ?p= parameter.
+ *
+ * @return The effective pathname.
+ */
+export function getEffectivePathname(): string {
+	const url = new URL( window.location.href );
+	return url.searchParams.get( 'p' ) || url.pathname;
+}
+
+/**
+ * Extract view parameter from URL pathname.
+ *
+ * @return The view parameter (inbox, spam, or trash).
+ */
+export function getViewFromUrl(): string {
+	const pathname = getEffectivePathname();
+	const match = pathname.match( VIEW_PATTERN );
+	return match?.[ 1 ] || 'inbox';
+}

--- a/projects/packages/forms/src/dashboard/router/wp-route-dashboard-search-params-provider.tsx
+++ b/projects/packages/forms/src/dashboard/router/wp-route-dashboard-search-params-provider.tsx
@@ -163,40 +163,85 @@ function urlSearchParamsToSearchRecord(
 }
 
 /**
- * Provider for the dashboard search params.
+ * Provider for external admin contexts (no router hooks).
+ * Uses direct URL parsing and history API for navigation.
+ *
+ * @param props          - Props.
+ * @param props.children - Children.
+ * @return               - JSX element.
+ */
+function ExternalAdminSearchParamsProvider( {
+	children,
+}: {
+	children: React.ReactNode;
+} ): JSX.Element {
+	const [ searchParams, setSearchParamsState ] = useState( parseExternalAdminSearchParams );
+
+	useEffect( () => {
+		/**
+		 * Updates params state when URL changes via browser navigation.
+		 */
+		function handleUrlChange() {
+			setSearchParamsState( parseExternalAdminSearchParams() );
+		}
+
+		window.addEventListener( 'popstate', handleUrlChange );
+		return () => window.removeEventListener( 'popstate', handleUrlChange );
+	}, [] );
+
+	const setSearchParams: SetDashboardSearchParams = useCallback(
+		next => {
+			const resolved = typeof next === 'function' ? next( searchParams ) : next;
+
+			// Update URL via history API
+			const url = new URL( window.location.href );
+			const pValue = url.searchParams.get( 'p' );
+
+			if ( pValue ) {
+				// Update params inside the p parameter
+				const pUrl = new URL( pValue, window.location.origin );
+				// Clear existing params we manage
+				pUrl.searchParams.delete( 'responseIds' );
+				pUrl.searchParams.delete( 'search' );
+				// Set new params
+				for ( const [ key, value ] of resolved.entries() ) {
+					pUrl.searchParams.append( key, value );
+				}
+				url.searchParams.set( 'p', pUrl.pathname + pUrl.search );
+			} else {
+				// Update direct URL params
+				url.searchParams.delete( 'responseIds' );
+				url.searchParams.delete( 'search' );
+				for ( const [ key, value ] of resolved.entries() ) {
+					url.searchParams.append( key, value );
+				}
+			}
+
+			window.history.pushState( {}, '', url.toString() );
+			setSearchParamsState( resolved );
+		},
+		[ searchParams ]
+	);
+
+	const value = useMemo(
+		() => [ searchParams, setSearchParams ] as DashboardSearchParamsTuple,
+		[ searchParams, setSearchParams ]
+	);
+
+	return (
+		<DashboardSearchParamsProvider value={ value }>{ children }</DashboardSearchParamsProvider>
+	);
+}
+
+/**
+ * Provider for standard wp-route contexts (uses router hooks).
  *
  * @param props          - Props.
  * @param props.from     - Route id to bind `useSearch` / `useNavigate` to.
  * @param props.children - Children.
  * @return               - JSX element.
  */
-export default function WpRouteDashboardSearchParamsProvider( {
-	from,
-	children,
-}: Props ): JSX.Element {
-	const isExternal = isExternalAdminContext();
-
-	// For external admin contexts, use URL-based parsing with popstate listener
-	const [ externalParams, setExternalParams ] = useState( () =>
-		isExternal ? parseExternalAdminSearchParams() : new URLSearchParams()
-	);
-
-	useEffect( () => {
-		if ( ! isExternal ) {
-			return;
-		}
-
-		/**
-		 * Updates params state when URL changes via browser navigation.
-		 */
-		function handleUrlChange() {
-			setExternalParams( parseExternalAdminSearchParams() );
-		}
-
-		window.addEventListener( 'popstate', handleUrlChange );
-		return () => window.removeEventListener( 'popstate', handleUrlChange );
-	}, [ isExternal ] );
-
+function WpRouteSearchParamsProvider( { from, children }: Props ): JSX.Element {
 	// `useSearch()` re-renders when the router search changes. We'll adapt it to URLSearchParams
 	// so shared dashboard code can keep using the URLSearchParams API.
 	const search = useSearch( {
@@ -206,45 +251,11 @@ export default function WpRouteDashboardSearchParamsProvider( {
 		strict: false,
 	} );
 	const navigate = useNavigate();
-	const routerParams = useMemo( () => searchRecordToUrlSearchParams( search ), [ search ] );
-
-	// Use external params if in external admin context, otherwise use router params
-	const searchParams = isExternal ? externalParams : routerParams;
+	const searchParams = useMemo( () => searchRecordToUrlSearchParams( search ), [ search ] );
 
 	const setSearchParams: SetDashboardSearchParams = useCallback(
 		next => {
 			const resolved = typeof next === 'function' ? next( searchParams ) : next;
-
-			if ( isExternal ) {
-				// In external admin context, update URL directly via history API
-				const url = new URL( window.location.href );
-				const pValue = url.searchParams.get( 'p' );
-
-				if ( pValue ) {
-					// Update params inside the p parameter
-					const pUrl = new URL( pValue, window.location.origin );
-					// Clear existing params we manage
-					pUrl.searchParams.delete( 'responseIds' );
-					pUrl.searchParams.delete( 'search' );
-					// Set new params
-					for ( const [ key, value ] of resolved.entries() ) {
-						pUrl.searchParams.append( key, value );
-					}
-					url.searchParams.set( 'p', pUrl.pathname + pUrl.search );
-				} else {
-					// Update direct URL params
-					url.searchParams.delete( 'responseIds' );
-					url.searchParams.delete( 'search' );
-					for ( const [ key, value ] of resolved.entries() ) {
-						url.searchParams.append( key, value );
-					}
-				}
-
-				window.history.pushState( {}, '', url.toString() );
-				setExternalParams( resolved );
-				return;
-			}
-
 			const nextSearch = urlSearchParamsToSearchRecord( resolved, {
 				arrayKeys: new Set( [ 'responseIds' ] ),
 			} );
@@ -259,7 +270,7 @@ export default function WpRouteDashboardSearchParamsProvider( {
 
 			navigate( { search: replaceSearch } );
 		},
-		[ isExternal, navigate, searchParams ]
+		[ navigate, searchParams ]
 	);
 
 	const value = useMemo(
@@ -270,4 +281,27 @@ export default function WpRouteDashboardSearchParamsProvider( {
 	return (
 		<DashboardSearchParamsProvider value={ value }>{ children }</DashboardSearchParamsProvider>
 	);
+}
+
+/**
+ * Provider for the dashboard search params.
+ * Automatically detects context and uses appropriate implementation.
+ *
+ * @param props          - Props.
+ * @param props.from     - Route id to bind `useSearch` / `useNavigate` to.
+ * @param props.children - Children.
+ * @return               - JSX element.
+ */
+export default function WpRouteDashboardSearchParamsProvider( {
+	from,
+	children,
+}: Props ): JSX.Element {
+	// Check context once at mount - this determines which provider to use
+	const [ isExternal ] = useState( isExternalAdminContext );
+
+	if ( isExternal ) {
+		return <ExternalAdminSearchParamsProvider>{ children }</ExternalAdminSearchParamsProvider>;
+	}
+
+	return <WpRouteSearchParamsProvider from={ from }>{ children }</WpRouteSearchParamsProvider>;
 }

--- a/projects/packages/forms/src/dashboard/router/wp-route-dashboard-search-params-provider.tsx
+++ b/projects/packages/forms/src/dashboard/router/wp-route-dashboard-search-params-provider.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { useCallback, useMemo } from '@wordpress/element';
+import { useCallback, useEffect, useMemo, useState } from '@wordpress/element';
 import { useSearch, useNavigate } from '@wordpress/route';
 /**
  * Internal dependencies
@@ -25,6 +25,67 @@ type Props = PropsWithChildren< {
 	 */
 	from: string;
 } >;
+
+/**
+ * Check if we're in an external admin context (e.g., params embedded in ?p= parameter).
+ *
+ * @return True if in external admin context.
+ */
+function isExternalAdminContext(): boolean {
+	const url = new URL( window.location.href );
+	return url.searchParams.has( 'p' );
+}
+
+/**
+ * Parse search params from the URL for external admin contexts.
+ * In these contexts, params may be embedded inside the ?p= value.
+ *
+ * @return URLSearchParams parsed from the current URL.
+ */
+function parseExternalAdminSearchParams(): URLSearchParams {
+	const url = new URL( window.location.href );
+	const result = new URLSearchParams();
+
+	// First, check direct URL params
+	let rawResponseIds = url.searchParams.getAll( 'responseIds' );
+	let search = url.searchParams.get( 'search' );
+
+	// If not found, check inside the p parameter (external admin context)
+	if ( rawResponseIds.length === 0 ) {
+		const pValue = url.searchParams.get( 'p' );
+		if ( pValue && pValue.includes( '?' ) ) {
+			const pUrl = new URL( pValue, window.location.origin );
+			rawResponseIds = pUrl.searchParams.getAll( 'responseIds' );
+			if ( ! search ) {
+				search = pUrl.searchParams.get( 'search' );
+			}
+		}
+	}
+
+	// Parse responseIds, handling JSON-encoded arrays from TanStack Router
+	for ( const raw of rawResponseIds ) {
+		if ( raw.startsWith( '[' ) ) {
+			try {
+				const parsed = JSON.parse( raw );
+				if ( Array.isArray( parsed ) ) {
+					for ( const id of parsed ) {
+						result.append( 'responseIds', String( id ) );
+					}
+					continue;
+				}
+			} catch {
+				// Not valid JSON, treat as regular value
+			}
+		}
+		result.append( 'responseIds', raw );
+	}
+
+	if ( search ) {
+		result.set( 'search', search );
+	}
+
+	return result;
+}
 
 /**
  * Convert `@wordpress/route` `search` record shape into `URLSearchParams`.
@@ -113,6 +174,29 @@ export default function WpRouteDashboardSearchParamsProvider( {
 	from,
 	children,
 }: Props ): JSX.Element {
+	const isExternal = isExternalAdminContext();
+
+	// For external admin contexts, use URL-based parsing with popstate listener
+	const [ externalParams, setExternalParams ] = useState( () =>
+		isExternal ? parseExternalAdminSearchParams() : new URLSearchParams()
+	);
+
+	useEffect( () => {
+		if ( ! isExternal ) {
+			return;
+		}
+
+		/**
+		 * Updates params state when URL changes via browser navigation.
+		 */
+		function handleUrlChange() {
+			setExternalParams( parseExternalAdminSearchParams() );
+		}
+
+		window.addEventListener( 'popstate', handleUrlChange );
+		return () => window.removeEventListener( 'popstate', handleUrlChange );
+	}, [ isExternal ] );
+
 	// `useSearch()` re-renders when the router search changes. We'll adapt it to URLSearchParams
 	// so shared dashboard code can keep using the URLSearchParams API.
 	const search = useSearch( {
@@ -122,11 +206,45 @@ export default function WpRouteDashboardSearchParamsProvider( {
 		strict: false,
 	} );
 	const navigate = useNavigate();
-	const searchParams = useMemo( () => searchRecordToUrlSearchParams( search ), [ search ] );
+	const routerParams = useMemo( () => searchRecordToUrlSearchParams( search ), [ search ] );
+
+	// Use external params if in external admin context, otherwise use router params
+	const searchParams = isExternal ? externalParams : routerParams;
 
 	const setSearchParams: SetDashboardSearchParams = useCallback(
 		next => {
 			const resolved = typeof next === 'function' ? next( searchParams ) : next;
+
+			if ( isExternal ) {
+				// In external admin context, update URL directly via history API
+				const url = new URL( window.location.href );
+				const pValue = url.searchParams.get( 'p' );
+
+				if ( pValue ) {
+					// Update params inside the p parameter
+					const pUrl = new URL( pValue, window.location.origin );
+					// Clear existing params we manage
+					pUrl.searchParams.delete( 'responseIds' );
+					pUrl.searchParams.delete( 'search' );
+					// Set new params
+					for ( const [ key, value ] of resolved.entries() ) {
+						pUrl.searchParams.append( key, value );
+					}
+					url.searchParams.set( 'p', pUrl.pathname + pUrl.search );
+				} else {
+					// Update direct URL params
+					url.searchParams.delete( 'responseIds' );
+					url.searchParams.delete( 'search' );
+					for ( const [ key, value ] of resolved.entries() ) {
+						url.searchParams.append( key, value );
+					}
+				}
+
+				window.history.pushState( {}, '', url.toString() );
+				setExternalParams( resolved );
+				return;
+			}
+
 			const nextSearch = urlSearchParamsToSearchRecord( resolved, {
 				arrayKeys: new Set( [ 'responseIds' ] ),
 			} );
@@ -141,7 +259,7 @@ export default function WpRouteDashboardSearchParamsProvider( {
 
 			navigate( { search: replaceSearch } );
 		},
-		[ navigate, searchParams ]
+		[ isExternal, navigate, searchParams ]
 	);
 
 	const value = useMemo(

--- a/projects/packages/forms/src/dashboard/router/wp-route-dashboard-search-params-provider.tsx
+++ b/projects/packages/forms/src/dashboard/router/wp-route-dashboard-search-params-provider.tsx
@@ -219,6 +219,8 @@ function ExternalAdminSearchParamsProvider( {
 
 			window.history.pushState( {}, '', url.toString() );
 			setSearchParamsState( resolved );
+			// Dispatch popstate event so other provider instances can update
+			window.dispatchEvent( new PopStateEvent( 'popstate' ) );
 		},
 		[ searchParams ]
 	);

--- a/projects/packages/forms/src/dashboard/router/wp-route-dashboard-search-params-provider.tsx
+++ b/projects/packages/forms/src/dashboard/router/wp-route-dashboard-search-params-provider.tsx
@@ -11,6 +11,7 @@ import {
 	type DashboardSearchParamsTuple,
 	type SetDashboardSearchParams,
 } from './dashboard-search-params-context';
+import { isExternalAdminContext, DASHBOARD_URL_CHANGE_EVENT } from './utils';
 /**
  * Types
  */
@@ -25,16 +26,6 @@ type Props = PropsWithChildren< {
 	 */
 	from: string;
 } >;
-
-/**
- * Check if we're in an external admin context (e.g., params embedded in ?p= parameter).
- *
- * @return True if in external admin context.
- */
-function isExternalAdminContext(): boolean {
-	const url = new URL( window.location.href );
-	return url.searchParams.has( 'p' );
-}
 
 /**
  * Parse search params from the URL for external admin contexts.
@@ -185,8 +176,13 @@ function ExternalAdminSearchParamsProvider( {
 			setSearchParamsState( parseExternalAdminSearchParams() );
 		}
 
+		// Listen for both browser navigation and custom dashboard URL changes
 		window.addEventListener( 'popstate', handleUrlChange );
-		return () => window.removeEventListener( 'popstate', handleUrlChange );
+		window.addEventListener( DASHBOARD_URL_CHANGE_EVENT, handleUrlChange );
+		return () => {
+			window.removeEventListener( 'popstate', handleUrlChange );
+			window.removeEventListener( DASHBOARD_URL_CHANGE_EVENT, handleUrlChange );
+		};
 	}, [] );
 
 	const setSearchParams: SetDashboardSearchParams = useCallback(
@@ -219,8 +215,8 @@ function ExternalAdminSearchParamsProvider( {
 
 			window.history.pushState( {}, '', url.toString() );
 			setSearchParamsState( resolved );
-			// Dispatch popstate event so other provider instances can update
-			window.dispatchEvent( new PopStateEvent( 'popstate' ) );
+			// Dispatch custom event so other provider instances can update
+			window.dispatchEvent( new CustomEvent( DASHBOARD_URL_CHANGE_EVENT ) );
 		},
 		[ searchParams ]
 	);

--- a/projects/packages/forms/src/dashboard/router/wp-route-dashboard-search-params-provider.tsx
+++ b/projects/packages/forms/src/dashboard/router/wp-route-dashboard-search-params-provider.tsx
@@ -45,10 +45,14 @@ function parseExternalAdminSearchParams(): URLSearchParams {
 	if ( rawResponseIds.length === 0 ) {
 		const pValue = url.searchParams.get( 'p' );
 		if ( pValue && pValue.includes( '?' ) ) {
-			const pUrl = new URL( pValue, window.location.origin );
-			rawResponseIds = pUrl.searchParams.getAll( 'responseIds' );
-			if ( ! search ) {
-				search = pUrl.searchParams.get( 'search' );
+			try {
+				const pUrl = new URL( pValue, window.location.origin );
+				rawResponseIds = pUrl.searchParams.getAll( 'responseIds' );
+				if ( ! search ) {
+					search = pUrl.searchParams.get( 'search' );
+				}
+			} catch {
+				// Ignore malformed p values that cannot be parsed as URLs.
 			}
 		}
 	}
@@ -194,16 +198,25 @@ function ExternalAdminSearchParamsProvider( {
 			const pValue = url.searchParams.get( 'p' );
 
 			if ( pValue ) {
-				// Update params inside the p parameter
-				const pUrl = new URL( pValue, window.location.origin );
-				// Clear existing params we manage
-				pUrl.searchParams.delete( 'responseIds' );
-				pUrl.searchParams.delete( 'search' );
-				// Set new params
-				for ( const [ key, value ] of resolved.entries() ) {
-					pUrl.searchParams.append( key, value );
+				try {
+					// Update params inside the p parameter
+					const pUrl = new URL( pValue, window.location.origin );
+					// Clear existing params we manage
+					pUrl.searchParams.delete( 'responseIds' );
+					pUrl.searchParams.delete( 'search' );
+					// Set new params
+					for ( const [ key, value ] of resolved.entries() ) {
+						pUrl.searchParams.append( key, value );
+					}
+					url.searchParams.set( 'p', pUrl.pathname + pUrl.search );
+				} catch {
+					// Fallback: Update direct URL params if pValue is malformed
+					url.searchParams.delete( 'responseIds' );
+					url.searchParams.delete( 'search' );
+					for ( const [ key, value ] of resolved.entries() ) {
+						url.searchParams.append( key, value );
+					}
 				}
-				url.searchParams.set( 'p', pUrl.pathname + pUrl.search );
 			} else {
 				// Update direct URL params
 				url.searchParams.delete( 'responseIds' );

--- a/projects/packages/forms/src/types/index.ts
+++ b/projects/packages/forms/src/types/index.ts
@@ -312,4 +312,8 @@ export interface FormsConfigData {
 	newFormNonce?: string;
 	/** Number of days before WordPress permanently deletes trash. See https://developer.wordpress.org/advanced-administration/wordpress/wp-config/#empty-trash */
 	emptyTrashDays?: number;
+	/** The base admin URL for the site. */
+	adminUrl?: string;
+	/** The admin-ajax.php URL for the site. */
+	ajaxUrl?: string;
 }


### PR DESCRIPTION
## Summary

Extends Douglas's search params provider (#46695) to work in external admin contexts (e.g., custom admin shells that embed routes via `?p=` parameter).

**Changes:**
- Detect external admin context via `?p=` parameter presence
- Parse search params embedded inside the `?p=` value
- Handle JSON-encoded arrays from TanStack Router (e.g., `["61416"]`)
- Update Inspector to use the search params context
- Support URL updates via history API for external contexts

## Context

External admin shells may embed routes like:
```
?page=next-admin&p=/marketing/forms/inbox?responseIds=["61416"]
```

The standard `@wordpress/route` hooks can't parse params from inside the `?p=` value. This PR adds fallback URL parsing that handles this pattern.

**Depends on:** #46695

## Test plan

- [ ] Test in standard Jetpack wp-admin (should work as before)
- [ ] Test in external admin context with `?p=` routing
- [ ] Verify Inspector loads response details when clicking "View"
- [ ] Verify navigation between responses works
- [ ] Verify close button returns to list view