### PR TITLE
Update wc-calypso-bridge to 2.11.4

### DIFF
--- a/projects/plugins/wpcomsh/changelog/update-wpcomsh-to-use-wc-calypso-bridge-2.11.4
+++ b/projects/plugins/wpcomsh/changelog/update-wpcomsh-to-use-wc-calypso-bridge-2.11.4
@@ -1,4 +1,4 @@
 Significance: minor
 Type: fixed
 
-Update wc-calypso-bridge from 2.11.3 to 2.11.4
+Update wc-calypso-bridge from 2.11.3 to 2.11.4.

--- a/projects/plugins/wpcomsh/changelog/update-wpcomsh-to-use-wc-calypso-bridge-2.11.4
+++ b/projects/plugins/wpcomsh/changelog/update-wpcomsh-to-use-wc-calypso-bridge-2.11.4
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fixed
+
+Update wc-calypso-bridge from 2.11.3 to 2.11.4

--- a/projects/plugins/wpcomsh/composer.json
+++ b/projects/plugins/wpcomsh/composer.json
@@ -9,7 +9,7 @@
 		"automattic/custom-fonts": "^3.0",
 		"automattic/custom-fonts-typekit": "^2.0",
 		"automattic/text-media-widget-styles": "^2.0",
-		"automattic/wc-calypso-bridge": "2.11.3",
+		"automattic/wc-calypso-bridge": "2.11.4",
 		"wordpress/classic-editor-plugin": "1.6.7",
 		"automattic/jetpack-autoloader": "@dev",
 		"automattic/jetpack-composer-plugin": "@dev",

--- a/projects/plugins/wpcomsh/composer.lock
+++ b/projects/plugins/wpcomsh/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1988d49c2dfe6aa1ff072a3bed878b0d",
+    "content-hash": "0878b12512b5c0d49e152461c5fb055c",
     "packages": [
         {
             "name": "automattic/at-pressable-podcasting",
@@ -2191,16 +2191,16 @@
         },
         {
             "name": "automattic/wc-calypso-bridge",
-            "version": "v2.11.3",
+            "version": "v2.11.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/wc-calypso-bridge.git",
-                "reference": "5b82125fbb5aed63c84bba2e7e2bebcae17a24db"
+                "reference": "ab9c07ea45633064f7bc509242c367bc40a381bd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/wc-calypso-bridge/zipball/5b82125fbb5aed63c84bba2e7e2bebcae17a24db",
-                "reference": "5b82125fbb5aed63c84bba2e7e2bebcae17a24db",
+                "url": "https://api.github.com/repos/Automattic/wc-calypso-bridge/zipball/ab9c07ea45633064f7bc509242c367bc40a381bd",
+                "reference": "ab9c07ea45633064f7bc509242c367bc40a381bd",
                 "shasum": ""
             },
             "require-dev": {
@@ -2242,7 +2242,7 @@
             "license": [
                 "GPL-2.0-or-later"
             ],
-            "time": "2025-10-08T10:52:37+00:00"
+            "time": "2026-01-22T17:44:30+00:00"
         },
         {
             "name": "league/uri",


### PR DESCRIPTION
Fixes WOOPLUG-6150

Relates to https://github.com/Automattic/wc-calypso-bridge/pull/1589

## Proposed changes:

* This PR updates wc-calypso-bridge from 2.11.3 to 2.11.4 to pick up the changes documented in https://github.com/Automattic/wc-calypso-bridge/pull/1586.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* [Apply this patch on a Jetpack Atomic Business site](https://github.com/Automattic/jetpack/pull/46731#issuecomment-3785830977)
* Install the WooCommerce plugin.
* During the activation wizard, make sure clicking `Skip guided setup` works
* Go to WooCommerce -> Settings -> Advanced -> WooCommerce.com and ensure the only checkbox there is `Display suggestions within WooCommerce`