### PR TITLE
Forms: update DataViews header and filters

### DIFF
--- a/projects/packages/forms/changelog/update-centralized-forms-header-filters
+++ b/projects/packages/forms/changelog/update-centralized-forms-header-filters
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Forms: update dataviews header and filters.

--- a/projects/packages/forms/src/dashboard/components/dataviews-header-row/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/dataviews-header-row/index.tsx
@@ -1,0 +1,57 @@
+/**
+ * External dependencies
+ */
+import { DataViews } from '@wordpress/dataviews/wp';
+import { useLocation } from 'react-router';
+/**
+ * Internal dependencies
+ */
+import useConfigValue from '../../../hooks/use-config-value.ts';
+import FormsResponsesTabs from '../forms-responses-tabs/index.tsx';
+import InboxStatusToggle from '../inbox-status-toggle/index.tsx';
+import './style.scss';
+
+/**
+ * Proposed shared header row for DataViews-based screens.
+ *
+ * Hardcoded structure for now:
+ * - Left: Forms / Responses tabs
+ * - Right: DataViews Search / Filters toggle / View config
+ * - Below (only when there are active filters): DataViews.FiltersToggled
+ *
+ * Note: This component is not wired into any screen yet.
+ *
+ * @param {object}                   props                        - Component props.
+ * @param {(status: string) => void} [props.onLegacyStatusChange] - Optional callback invoked when the legacy Inbox status changes.
+ * @return {JSX.Element} Header row markup for DataViews pages.
+ */
+export default function DataViewsHeaderRow( {
+	onLegacyStatusChange,
+}: {
+	onLegacyStatusChange?: ( status: string ) => void;
+} ): JSX.Element {
+	const location = useLocation();
+	const isCentralFormManagementEnabled = useConfigValue( 'isCentralFormManagementEnabled' );
+	const isCentralFormManagementDisabled = isCentralFormManagementEnabled === false;
+	const isResponsesScreen = location.pathname === '/responses';
+
+	return (
+		<>
+			<div className="jp-forms-view-actions">
+				<div>
+					{ isResponsesScreen && isCentralFormManagementDisabled ? (
+						<InboxStatusToggle onChange={ onLegacyStatusChange } />
+					) : (
+						<FormsResponsesTabs />
+					) }
+				</div>
+				<div className="jp-forms-view-actions__controls">
+					<DataViews.Search />
+					<DataViews.FiltersToggle />
+					<DataViews.ViewConfig />
+				</div>
+			</div>
+			<DataViews.FiltersToggled className="jp-forms-filters-container" />
+		</>
+	);
+}

--- a/projects/packages/forms/src/dashboard/components/dataviews-header-row/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/dataviews-header-row/index.tsx
@@ -12,14 +12,13 @@ import InboxStatusToggle from '../inbox-status-toggle/index.tsx';
 import './style.scss';
 
 /**
- * Proposed shared header row for DataViews-based screens.
+ * Shared header row for DataViews-based screens.
  *
- * Hardcoded structure for now:
+ * Structure:
  * - Left: Forms / Responses tabs
+ * - Special case: on the Responses screen with CFM disabled, show Inbox/Spam/Trash toggle instead
  * - Right: DataViews Search / Filters toggle / View config
  * - Below (only when there are active filters): DataViews.FiltersToggled
- *
- * Note: This component is not wired into any screen yet.
  *
  * @param {object}                   props                        - Component props.
  * @param {(status: string) => void} [props.onLegacyStatusChange] - Optional callback invoked when the legacy Inbox status changes.

--- a/projects/packages/forms/src/dashboard/components/dataviews-header-row/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/dataviews-header-row/index.tsx
@@ -47,7 +47,7 @@ export default function DataViewsHeaderRow( {
 				</div>
 				<div className="jp-forms-view-actions__controls">
 					<DataViews.Search />
-					<DataViews.FiltersToggle />
+					{ isCentralFormManagementEnabled === true ? null : <DataViews.FiltersToggle /> }
 					<DataViews.ViewConfig />
 				</div>
 			</div>

--- a/projects/packages/forms/src/dashboard/components/dataviews-header-row/style.scss
+++ b/projects/packages/forms/src/dashboard/components/dataviews-header-row/style.scss
@@ -1,0 +1,91 @@
+@use "@wordpress/base-styles/breakpoints";
+@use "@wordpress/base-styles/variables";
+
+/**
+ * DataViewsHeaderRow styles
+ *
+ * Patterned after `dashboard/inbox/style.scss` so the header row behaves
+ * the same:
+ * - sticky row
+ * - tabs on the left
+ * - DataViews controls on the right
+ * - optional filters "pills" row that only takes space when non-empty
+ */
+
+.jp-forms-view-actions {
+	border-bottom: 1px solid var(--wpds-color-stroke-surface-neutral-weak);
+	padding-inline: variables.$grid-unit * 2.5;
+	overflow-x: auto;
+	width: 100%;
+	box-sizing: border-box;
+	display: flex;
+	container-type: inline-size;
+	flex-shrink: 0;
+
+	// Jetpack Forms specific additions (match Inbox).
+	position: sticky;
+	left: 0;
+	background: var(--wpds-color-bg-surface-neutral-strong, #fff);
+	justify-content: space-between;
+	gap: 8px;
+	flex-direction: column;
+	align-items: flex-start;
+
+	> div:not(:empty) {
+		min-height: 48px;
+		width: 100%;
+	}
+
+	@media (min-width: #{ (breakpoints.$break-small + 1) }) {
+
+		& {
+			flex-direction: row;
+			align-items: center;
+		}
+
+		> div:not(:empty) {
+			min-height: 0;
+		}
+	}
+
+	// Tab styling (match Inbox).
+	button[role="tab"] {
+		margin: 0;
+		padding: 12px 0;
+		color: var(--wpds-color-fg-interactive-neutral);
+
+		&[data-active="true"] {
+			color: var(--wpds-color-fg-interactive-neutral-active);
+		}
+
+		&:hover:not([data-active="true"]) {
+			color: var(--wpds-color-fg-interactive-neutral-active);
+		}
+	}
+}
+
+.jp-forms-view-actions__controls {
+	display: flex;
+	gap: 8px;
+	justify-content: flex-end;
+}
+
+// Match the old Inbox behavior: when the header row is narrow,
+// don't force the controls to the right.
+@container (max-width: 599px) {
+
+	.jp-forms-view-actions__controls {
+		justify-content: flex-start;
+	}
+}
+
+// Filters "pills" row: collapse when empty (match Inbox behavior).
+.jp-forms-filters-container,
+.jp-forms-filters-container:not(:empty) {
+	padding: 0;
+}
+
+.jp-forms-filters-container:not(:empty) {
+	padding-inline: variables.$grid-unit * 2.5;
+	padding-block: variables.$grid-unit * 1.5;
+}

--- a/projects/packages/forms/src/dashboard/components/inbox-status-toggle/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/inbox-status-toggle/index.tsx
@@ -31,7 +31,7 @@ function getTabLabel( label: string, count: number ): JSX.Element {
 }
 
 type InboxStatusToggleProps = {
-	onChange: ( status: string ) => void;
+	onChange?: ( status: string ) => void;
 };
 
 /**
@@ -71,7 +71,7 @@ export default function InboxStatusToggle( { onChange }: InboxStatusToggleProps 
 				return params;
 			} );
 			setSelectedResponses( [] );
-			onChange( newStatus );
+			onChange?.( newStatus );
 		},
 		[ isSm, status, setSearchParams, onChange, setSelectedResponses ]
 	);

--- a/projects/packages/forms/src/dashboard/forms/index.tsx
+++ b/projects/packages/forms/src/dashboard/forms/index.tsx
@@ -13,8 +13,8 @@ import { useNavigate } from 'react-router';
  */
 import useConfigValue from '../../hooks/use-config-value.ts';
 import CreateFormButton from '../components/create-form-button/index.tsx';
+import DataViewsHeaderRow from '../components/dataviews-header-row/index.tsx';
 import { EmptyWrapper } from '../components/empty-responses/index.tsx';
-import FormsResponsesTabs from '../components/forms-responses-tabs/index.tsx';
 import Page from '../components/page/index.tsx';
 import useDeleteForm from '../hooks/use-delete-form.ts';
 import useFormsData from '../hooks/use-forms-data.ts';
@@ -255,7 +255,6 @@ export default function FormsDashboardForms(): JSX.Element | null {
 					</div>
 				}
 				subTitle={ __( 'View and manage all your forms in one place.', 'jetpack-forms' ) }
-				tabs={ <FormsResponsesTabs /> }
 				actions={ headerActions }
 				hasPadding={ false }
 			>
@@ -299,16 +298,7 @@ export default function FormsDashboardForms(): JSX.Element | null {
 							) }
 						</p>
 					</ConfirmDialog>
-					<div className="jp-forms-filters-bar">
-						<div className="jp-forms-filters-bar__chips">
-							<DataViews.FiltersToggled className="jp-forms-filters-container" />
-						</div>
-						<div className="jp-forms-filters-bar__controls">
-							<DataViews.Search />
-							<DataViews.FiltersToggle />
-							<DataViews.ViewConfig />
-						</div>
-					</div>
+					<DataViewsHeaderRow />
 					<div className="jp-forms-dataviews-layout-container">
 						<DataViews.Layout />
 						<DataViews.Footer />

--- a/projects/packages/forms/src/dashboard/forms/style.scss
+++ b/projects/packages/forms/src/dashboard/forms/style.scss
@@ -1,4 +1,3 @@
-@use "@wordpress/base-styles/breakpoints";
 @use "@wordpress/base-styles/variables";
 
 .jp-forms-filters-bar {

--- a/projects/packages/forms/src/dashboard/hooks/use-inbox-data.ts
+++ b/projects/packages/forms/src/dashboard/hooks/use-inbox-data.ts
@@ -17,8 +17,10 @@ import type { FormResponse } from '../../types/index.ts';
 
 /**
  * Helper function to get the status filter to apply from the URL.
- * This is the only way to filter the data by `status` as intentionally
- * we don't want to have a `status` filter in the UI.
+ * This is the only way to filter the data by `status`.
+ *
+ * Note: When Central Form Management (CFM) is enabled, the UI can expose a
+ * "Folder" DataViews filter that syncs its value to the URL `status` param.
  *
  * @param {string} urlStatus - The current status from the URL.
  * @return {string} The status filter to apply.

--- a/projects/packages/forms/src/dashboard/inbox/stage/index.js
+++ b/projects/packages/forms/src/dashboard/inbox/stage/index.js
@@ -317,7 +317,8 @@ export default function InboxView() {
 							// Primary so the filter UI (and its pill) is visible by default.
 							filterBy: { operators: [ 'is' ], isPrimary: true },
 							enableSorting: false,
-							enableHiding: true,
+							// Prevent this filter-only field from being offered as a configurable column.
+							enableHiding: false,
 							// Filter-only field; not shown as a column.
 							render: () => null,
 							getValue: () => null,

--- a/projects/packages/forms/src/dashboard/inbox/stage/index.js
+++ b/projects/packages/forms/src/dashboard/inbox/stage/index.js
@@ -5,7 +5,7 @@ import jetpackAnalytics from '@automattic/jetpack-analytics';
 import { JetpackLogo } from '@automattic/jetpack-components';
 import { isSimpleSite } from '@automattic/jetpack-script-data';
 import { Badge } from '@automattic/ui';
-import { ExternalLink, Modal, Button, Composite } from '@wordpress/components';
+import { ExternalLink, Modal } from '@wordpress/components';
 import { useResizeObserver, useViewportMatch } from '@wordpress/compose';
 import { useSelect } from '@wordpress/data';
 import { DataViews } from '@wordpress/dataviews/wp';
@@ -22,14 +22,13 @@ import { useEffect } from 'react';
 import useConfigValue from '../../../hooks/use-config-value.ts';
 import { INTEGRATIONS_STORE } from '../../../store/integrations/index.ts';
 import CreateFormButton from '../../components/create-form-button/index.tsx';
+import DataViewsHeaderRow from '../../components/dataviews-header-row/index.tsx';
 import EmptyResponses from '../../components/empty-responses/index.tsx';
 import EmptySpamButton from '../../components/empty-spam-button/index.tsx';
 import EmptyTrashButton from '../../components/empty-trash-button/index.tsx';
 import ExportResponsesButton from '../../components/export-responses/button.tsx';
 import Flag from '../../components/flag/index.tsx';
-import FormsResponsesTabs from '../../components/forms-responses-tabs/index.tsx';
 import Gravatar from '../../components/gravatar/index.tsx';
-import InboxStatusToggle from '../../components/inbox-status-toggle/index.tsx';
 import { ResponseMobileView, SingleResponseView } from '../../components/inspector/index.tsx';
 import IntegrationsButton from '../../components/integrations-button/index.tsx';
 import Page from '../../components/page/index.tsx';
@@ -88,15 +87,9 @@ const setupSidebarWidthObserver = () => {
 export default function InboxView() {
 	const [ view, setView ] = useView();
 	const [ searchParams, setSearchParams ] = useDashboardSearchParams();
-	const [ containerWidth, setContainerWidth ] = useState( 0 );
 
 	const dateSettings = getDateSettings();
-	const containerRef = useResizeObserver(
-		resizeObserverEntries => {
-			setContainerWidth( resizeObserverEntries[ 0 ].borderBoxSize[ 0 ].inlineSize );
-		},
-		{ box: 'border-box' }
-	);
+	const containerRef = useResizeObserver( () => {}, { box: 'border-box' } );
 
 	const selectedResponses = searchParams.get( 'r' );
 	const isMobileViewport = useViewportMatch( 'medium', '<' );
@@ -131,6 +124,10 @@ export default function InboxView() {
 	const isIntegrationsEnabled = useConfigValue( 'isIntegrationsEnabled' );
 	const showDashboardIntegrations = useConfigValue( 'showDashboardIntegrations' );
 	const isCentralFormManagementEnabled = useConfigValue( 'isCentralFormManagementEnabled' );
+	const urlFolder = useMemo( () => {
+		const urlStatus = searchParams.get( 'status' );
+		return [ 'inbox', 'spam', 'trash' ].includes( urlStatus ) ? urlStatus : 'inbox';
+	}, [ searchParams ] );
 
 	const {
 		setCurrentQuery,
@@ -141,35 +138,7 @@ export default function InboxView() {
 		isLoadingData,
 		totalItems,
 		totalPages,
-		totalItemsInbox,
-		totalItemsSpam,
-		totalItemsTrash,
 	} = useInboxData();
-	const onChangeStatus = useCallback(
-		newStatus => {
-			if ( ! isCentralFormManagementEnabled ) {
-				return;
-			}
-
-			setSearchParams( previousSearchParams => {
-				const params = new URLSearchParams( previousSearchParams );
-				params.set( 'status', newStatus );
-				params.delete( 'r' ); // Clear selected responses when changing status.
-				return params;
-			} );
-
-			// Reset page to 1 when switching status (matches previous tab behavior).
-			setView( { ...view, page: 1 } );
-
-			// Clear selection in store.
-			setSelectedResponses( [] );
-		},
-		[ isCentralFormManagementEnabled, setSearchParams, setSelectedResponses, setView, view ]
-	);
-
-	const onInboxClick = useCallback( () => onChangeStatus( 'inbox' ), [ onChangeStatus ] );
-	const onSpamClick = useCallback( () => onChangeStatus( 'spam' ), [ onChangeStatus ] );
-	const onTrashClick = useCallback( () => onChangeStatus( 'trash' ), [ onChangeStatus ] );
 	const isAkismetStatusPending = useSelect(
 		select => {
 			const store = select( INTEGRATIONS_STORE );
@@ -287,6 +256,45 @@ export default function InboxView() {
 		[ totalItems, totalPages ]
 	);
 
+	const onChangeView = useCallback(
+		newView => {
+			if ( isCentralFormManagementEnabled ) {
+				const folderValue = newView.filters?.find( filter => filter.field === 'folder' )?.value;
+				const nextFolder = [ 'inbox', 'spam', 'trash' ].includes( folderValue )
+					? folderValue
+					: 'inbox';
+
+				// Enforce that Folder is always set (cannot be removed). If the user clears it via the pill "X",
+				// re-add it as Inbox to match legacy default behavior.
+				if ( ! folderValue ) {
+					newView = {
+						...newView,
+						page: 1,
+						filters: [
+							{ field: 'folder', operator: 'is', value: 'inbox' },
+							...( newView.filters || [] ).filter( filter => filter.field !== 'folder' ),
+						],
+					};
+				}
+
+				// Sync Folder -> URL status (source of truth for querying), clear selection, and reset page.
+				if ( nextFolder !== urlFolder ) {
+					setSearchParams( previousSearchParams => {
+						const params = new URLSearchParams( previousSearchParams );
+						params.set( 'status', nextFolder );
+						params.delete( 'r' ); // Clear selected responses when changing folder.
+						return params;
+					} );
+					setSelectedResponses( [] );
+					newView = { ...newView, page: 1 };
+				}
+			}
+
+			setView( newView );
+		},
+		[ isCentralFormManagementEnabled, setSearchParams, setSelectedResponses, setView, urlFolder ]
+	);
+
 	const wrapperUnread = ( isUnread, itemValue ) => {
 		if ( isUnread ) {
 			return <span className="jp-forms__inbox__unread">{ itemValue }</span>;
@@ -296,6 +304,26 @@ export default function InboxView() {
 
 	const fields = useMemo(
 		() => [
+			...( isCentralFormManagementEnabled
+				? [
+						{
+							id: 'folder',
+							label: __( 'Folder', 'jetpack-forms' ),
+							elements: [
+								{ label: __( 'Inbox', 'jetpack-forms' ), value: 'inbox' },
+								{ label: __( 'Spam', 'jetpack-forms' ), value: 'spam' },
+								{ label: __( 'Trash', 'jetpack-forms' ), value: 'trash' },
+							],
+							// Primary so the filter UI (and its pill) is visible by default.
+							filterBy: { operators: [ 'is' ], isPrimary: true },
+							enableSorting: false,
+							enableHiding: true,
+							// Filter-only field; not shown as a column.
+							render: () => null,
+							getValue: () => null,
+						},
+				  ]
+				: [] ),
 			{
 				id: 'from',
 				label: __( 'From', 'jetpack-forms' ),
@@ -445,8 +473,32 @@ export default function InboxView() {
 			isMobileViewport,
 			openResponseModal,
 			dateSettings.formats.date,
+			isCentralFormManagementEnabled,
 		]
 	);
+
+	// When CFM is enabled, keep the DataViews "Folder" filter in sync with the URL `status` param
+	// (and default to Inbox on first load).
+	useEffect( () => {
+		if ( ! isCentralFormManagementEnabled ) {
+			return;
+		}
+		setView( previousView => {
+			const previousFilters = previousView.filters || [];
+			const existing = previousFilters.find( filter => filter.field === 'folder' );
+			if ( existing?.value === urlFolder ) {
+				return previousView;
+			}
+			const nextFilters = [
+				{ field: 'folder', operator: 'is', value: urlFolder },
+				...previousFilters.filter( filter => filter.field !== 'folder' ),
+			];
+			return {
+				...previousView,
+				filters: nextFilters,
+			};
+		} );
+	}, [ isCentralFormManagementEnabled, setView, urlFolder ] );
 
 	const actions = useMemo( () => {
 		const mobileViewAction = {
@@ -502,8 +554,9 @@ export default function InboxView() {
 	}, [ isMobileViewport, onChangeSelection, statusFilter ] );
 
 	const resetPage = useCallback( () => {
-		view.page = 1;
-	}, [ view ] );
+		// Reset to page 1 when switching legacy Inbox statuses (Inbox/Spam/Trash).
+		setView( { ...view, page: 1 } );
+	}, [ setView, view ] );
 
 	// Check if read_status filter is applied
 	const readStatusFilter = view.filters?.find( filter => filter.field === 'read_status' )?.value;
@@ -540,7 +593,6 @@ export default function InboxView() {
 			}
 			subTitle={ __( 'View and manage all your form submissions in one place.', 'jetpack-forms' ) }
 			actions={ headerActions }
-			tabs={ isCentralFormManagementEnabled ? <FormsResponsesTabs /> : undefined }
 			hasPadding={ false }
 		>
 			<DataViews
@@ -550,7 +602,7 @@ export default function InboxView() {
 				data={ records || EMPTY_ARRAY }
 				isLoading={ isInboxLoading }
 				view={ view }
-				onChangeView={ setView }
+				onChangeView={ onChangeView }
 				selection={ selection }
 				onChangeSelection={ onChangeSelection }
 				getItemId={ getItemId }
@@ -563,72 +615,7 @@ export default function InboxView() {
 					/>
 				}
 			>
-				{ isCentralFormManagementEnabled ? (
-					<div className="jp-forms-filters-bar">
-						<div className="jp-forms-filters-bar__chips">
-							<Composite className="jp-forms-filters-bar__status-chips">
-								<Button
-									size="compact"
-									variant={ 'tertiary' }
-									className={ statusFilter === 'draft,publish' ? 'is-active' : '' }
-									onClick={ onInboxClick }
-								>
-									{ __( 'Status is Inbox', 'jetpack-forms' ) } ({ totalItemsInbox })
-								</Button>
-
-								<Button
-									size="compact"
-									variant={ 'tertiary' }
-									className={ statusFilter === 'spam' ? 'is-active' : '' }
-									onClick={ onSpamClick }
-								>
-									{ __( 'Status is Spam', 'jetpack-forms' ) } ({ totalItemsSpam })
-								</Button>
-								<Button
-									size="compact"
-									variant={ 'tertiary' }
-									className={ statusFilter === 'trash' ? 'is-active' : '' }
-									onClick={ onTrashClick }
-								>
-									{ __( 'Status is Trash', 'jetpack-forms' ) } ({ totalItemsTrash })
-								</Button>
-							</Composite>
-							<DataViews.FiltersToggled className="jp-forms-filters-container" />
-						</div>
-						<div
-							className="jp-forms-filters-bar__controls"
-							style={ {
-								display: 'flex',
-								gap: '8px',
-								justifyContent: containerWidth < 600 ? 'unset' : 'flex-end',
-							} }
-						>
-							<DataViews.Search />
-							<DataViews.FiltersToggle />
-							<DataViews.ViewConfig />
-						</div>
-					</div>
-				) : (
-					<>
-						<div className="jp-forms-view-actions">
-							<div>
-								<InboxStatusToggle onChange={ resetPage } />
-							</div>
-							<div
-								style={ {
-									display: 'flex',
-									gap: '8px',
-									justifyContent: containerWidth < 600 ? 'unset' : 'flex-end',
-								} }
-							>
-								<DataViews.Search />
-								<DataViews.FiltersToggle />
-								<DataViews.ViewConfig />
-							</div>
-						</div>
-						<DataViews.FiltersToggled className="jp-forms-filters-container" />
-					</>
-				) }
+				<DataViewsHeaderRow onLegacyStatusChange={ resetPage } />
 				<div className="jp-forms-dataviews-layout-container">
 					<DataViews.Layout />
 					<DataViews.Footer />

--- a/projects/packages/forms/src/dashboard/inbox/stage/index.js
+++ b/projects/packages/forms/src/dashboard/inbox/stage/index.js
@@ -6,7 +6,7 @@ import { JetpackLogo } from '@automattic/jetpack-components';
 import { isSimpleSite } from '@automattic/jetpack-script-data';
 import { Badge } from '@automattic/ui';
 import { ExternalLink, Modal } from '@wordpress/components';
-import { useResizeObserver, useViewportMatch } from '@wordpress/compose';
+import { useViewportMatch } from '@wordpress/compose';
 import { useSelect } from '@wordpress/data';
 import { DataViews } from '@wordpress/dataviews/wp';
 import { dateI18n, getSettings as getDateSettings } from '@wordpress/date';
@@ -89,7 +89,6 @@ export default function InboxView() {
 	const [ searchParams, setSearchParams ] = useDashboardSearchParams();
 
 	const dateSettings = getDateSettings();
-	const containerRef = useResizeObserver( () => {}, { box: 'border-box' } );
 
 	const selectedResponses = searchParams.get( 'r' );
 	const isMobileViewport = useViewportMatch( 'medium', '<' );
@@ -556,8 +555,8 @@ export default function InboxView() {
 
 	const resetPage = useCallback( () => {
 		// Reset to page 1 when switching legacy Inbox statuses (Inbox/Spam/Trash).
-		setView( { ...view, page: 1 } );
-	}, [ setView, view ] );
+		setView( previousView => ( { ...previousView, page: 1 } ) );
+	}, [ setView ] );
 
 	// Check if read_status filter is applied
 	const readStatusFilter = view.filters?.find( filter => filter.field === 'read_status' )?.value;
@@ -627,9 +626,7 @@ export default function InboxView() {
 
 	return (
 		<>
-			<div ref={ containerRef } className="jp-forms-layout__surface is-stage">
-				{ pageContent }
-			</div>
+			<div className="jp-forms-layout__surface is-stage">{ pageContent }</div>
 			{ isResponseModalOpen && (
 				<Modal
 					title={ __( 'Response', 'jetpack-forms' ) }

--- a/projects/packages/forms/src/dashboard/inbox/stage/views.js
+++ b/projects/packages/forms/src/dashboard/inbox/stage/views.js
@@ -39,19 +39,26 @@ export function useView() {
 		search: urlSearch,
 	} ) );
 	// When view changes, update the URL params if needed.
-	const setViewWithUrlUpdate = useEvent( newView => {
-		setView( newView );
-		if ( newView.search !== urlSearch ) {
-			setSearchParams( previousSearchParams => {
-				const _searchParams = new URLSearchParams( previousSearchParams );
-				if ( newView.search ) {
-					_searchParams.set( 'search', newView.search );
-				} else {
-					_searchParams.delete( 'search' );
-				}
-				return _searchParams;
-			} );
-		}
+	const setViewWithUrlUpdate = useEvent( nextView => {
+		// Support both "setView(newView)" and "setView(prev => next)" call styles,
+		// since callers treat this like a normal React setState setter.
+		setView( previousView => {
+			const resolvedView = typeof nextView === 'function' ? nextView( previousView ) : nextView;
+
+			if ( resolvedView.search !== urlSearch ) {
+				setSearchParams( previousSearchParams => {
+					const _searchParams = new URLSearchParams( previousSearchParams );
+					if ( resolvedView.search ) {
+						_searchParams.set( 'search', resolvedView.search );
+					} else {
+						_searchParams.delete( 'search' );
+					}
+					return _searchParams;
+				} );
+			}
+
+			return resolvedView;
+		} );
 	} );
 	// When search URL param changes, update the view's search filter
 	// without affecting any other config.

--- a/projects/packages/forms/src/dashboard/inbox/style.scss
+++ b/projects/packages/forms/src/dashboard/inbox/style.scss
@@ -5,58 +5,6 @@
 @use "../../blocks/shared/styles/empty_image_option" as *;
 @import "@wordpress/dataviews/build-style/style.css";
 
-.jp-forms-view-actions {
-	border-bottom: 1px solid var(--wpds-color-stroke-surface-neutral-weak);
-	padding-inline: variables.$grid-unit * 2.5;
-	overflow-x: auto;
-	width: 100%;
-	box-sizing: border-box;
-	display: flex;
-	container-type: inline-size;
-	flex-shrink: 0;
-
-	// Jetpack Forms specific additions
-	position: sticky;
-	left: 0;
-	background: var(--wpds-color-bg-surface-neutral-strong, #fff);
-	justify-content: space-between;
-	gap: 8px;
-	flex-direction: column;
-	align-items: flex-start;
-
-	> div:not(:empty) {
-		min-height: 48px;
-		width: 100%;
-	}
-
-	@media (min-width: #{ (breakpoints.$break-small + 1) }) {
-
-		& {
-			flex-direction: row;
-			align-items: center;
-		}
-
-		> div:not(:empty) {
-			min-height: 0;
-		}
-	}
-
-	// Jetpack Forms specific: Tab styling
-	button[role="tab"] {
-		margin: 0;
-		padding: 12px 0;
-		color: var(--wpds-color-fg-interactive-neutral);
-
-		&[data-active="true"] {
-			color: var(--wpds-color-fg-interactive-neutral-active);
-		}
-
-		&:hover:not([data-active="true"]) {
-			color: var(--wpds-color-fg-interactive-neutral-active);
-		}
-	}
-}
-
 .jp-forms-filters-bar {
 	border-bottom: 1px solid var(--wpds-color-stroke-surface-neutral-weak);
 	display: flex;
@@ -95,10 +43,6 @@
 		flex: 0 0 auto;
 	}
 
-	.jp-forms-filters-container,
-	.jp-forms-filters-container:not(:empty) {
-		padding: 0;
-	}
 }
 
 .jp-forms-dataviews-layout-container {
@@ -108,11 +52,6 @@
 	display: flex;
 	flex-direction: column;
 	background-color: var(--wpds-color-bg-surface-neutral-strong, #fff);
-}
-
-.jp-forms-filters-container:not(:empty) {
-	padding-inline: variables.$grid-unit * 2.5;
-	padding-block: variables.$grid-unit * 1.5;
 }
 
 /*

--- a/projects/plugins/jetpack/changelog/update-centralized-forms-header-filters
+++ b/projects/plugins/jetpack/changelog/update-centralized-forms-header-filters
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Forms: update DataViews header and filters.


### PR DESCRIPTION
## Proposed changes:

This PR adjusts our DataViews header and filter to accommodate the needs of Centralized Form Management. Changes:
* Moves the Search / Filter components to be on the same level as the main page tabs. This was requested by @ilona See [this comment](https://github.com/Automattic/jetpack/pull/46580#issuecomment-3759624150) from and the Figma designs here: 8TmDfrB54NU4Rzj19Qs9Tg-fi-6116_73070
* Removes the fixed inbox/spam/trash filter pills, and replaces those with a regualr DataViews filter for 'Folder'. This is following the apparent decision in the P2 here: p1HpG7-xwg-p2#comment-77460
* When inbox/spam/trash filters are selected, update the URL status param. We've been using that param to drive the DataViews table, and for external linking, so we can't move it. But we need it to follow to the filter. 
* Creates new DataViewsHeaderRow component to hold the the header tabs and filters that live above our responses and forms tables. This is needed because we're essentially duplicating the component code and CSS and need to keep things better in sync. 

**All behavior should be the same when the 'centralzed form management' flag is off.**
<img width="1349" height="680" alt="no-cfm-flag" src="https://github.com/user-attachments/assets/5f564515-c292-4efd-9933-4a6e2cecbec5" />

**When the centralized form management flag is ON....**

**Inbox before**
<img width="1350" height="679" alt="responses-list-before" src="https://github.com/user-attachments/assets/dae95bfc-2707-40fe-874b-c68271b79c3d" />

**Inbox after**
<img width="1348" height="679" alt="inbox-after" src="https://github.com/user-attachments/assets/b3f32299-dd00-4982-87e4-ac5f58805d32" />

**Forms list before**
<img width="1347" height="679" alt="forms-list-before" src="https://github.com/user-attachments/assets/ae859402-b010-4ab2-b87f-8226e733ad29" />


**Forms list after**
<img width="1350" height="678" alt="forms-list-after" src="https://github.com/user-attachments/assets/995ab10e-fe25-4008-b7b8-263919f81b79" />


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
See https://github.com/Automattic/jetpack/pull/46580#issuecomment-3759624150 from 
See Figma designs here: [8TmDfrB54NU4Rzj19Qs9Tg-fi-6116_73070](https://href.li/?https://www.figma.com/file/8TmDfrB54NU4Rzj19Qs9Tg/?node-id=6116-73070)
See P2 here: p1HpG7-xwg-p2#comment-77460

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Add this feature flag to your test site. 

```
add_filter( 'jetpack_block_editor_feature_flags', 'eb_register_feature' );
function eb_register_feature( $flags ) {
    $flags['central-form-management'] = true;
    return $flags;
}
```

Test with Flag on:
* Go to Jetpack > Forms
* Confirm you see the Forms and Responses tab and they show the forms list and inbox
* On Forms, confirm filters work as before
* On Responses, try filtering the Folder for Inbox, Spam, and Trash and confirm that works

Test with flag off to confirm no regressions:
* Remove feature flag and confirm everything works as before