### PR TITLE
Google Fonts: Prevent Gutenberg 22.4+ from printing all registered fonts

### DIFF
--- a/projects/plugins/jetpack/changelog/gb224-print-font-faces-fix
+++ b/projects/plugins/jetpack/changelog/gb224-print-font-faces-fix
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Google Fonts: Prevent Gutenberg 22.4+ from printing all registered fonts

--- a/projects/plugins/jetpack/changelog/gb224-print-font-faces-fix
+++ b/projects/plugins/jetpack/changelog/gb224-print-font-faces-fix
@@ -1,4 +1,4 @@
 Significance: patch
 Type: bugfix
 
-Google Fonts: Prevent Gutenberg 22.4+ from printing all registered fonts
+Google Fonts: Prevent Gutenberg 22.4+ from printing all registered fonts.

--- a/projects/plugins/jetpack/modules/google-fonts/current/class-jetpack-google-font-face.php
+++ b/projects/plugins/jetpack/modules/google-fonts/current/class-jetpack-google-font-face.php
@@ -44,6 +44,9 @@ class Jetpack_Google_Font_Face {
 	public function wp_loaded() {
 		remove_action( 'wp_head', 'wp_print_fonts', 50 );
 		remove_action( 'wp_head', 'wp_print_font_faces', 50 );
+		// Gutenberg 22.4+ overrides Core's font printing with its own function
+		// for classic theme support. Remove it so we can print only fonts in use.
+		remove_action( 'wp_head', 'gutenberg_print_font_faces', 50 );
 	}
 
 	/**


### PR DESCRIPTION
Gutenberg 22.4.0 introduced `gutenberg_print_font_faces()` to enable font support for classic themes (WordPress/gutenberg#73971). This function prints all fonts registered in global settings, including all ~60 font families (with ~720 total @font-face declarations for weight/style variations) registered by this module.

The `Jetpack_Google_Font_Face` class already prevents WordPress Core's `wp_print_font_faces()` from printing all fonts, instead collecting and printing only fonts actually used in global styles and blocks. However, it doesn't account for Gutenberg's new function.

## Proposed changes:
* Add `gutenberg_print_font_faces` to the list of font-printing functions we disable, allowing our font handling to take over.

### Problem being fixed:
With Gutenberg 22.4.0+, sites using the Google Fonts module see:
- ~150KB of additional inline CSS in `<style id='wp-fonts-local'>`
- ~720 @font-face declarations for fonts that might not be used on the page

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

## Does this pull request change what data or activity we track or use?

## Testing instructions:

1. Enable Google Fonts module on a site with a classic theme
2. With Gutenberg 22.4+, verify the homepage doesn't have massive `wp-fonts-local` styles
3. Add a block with a custom font, verify that font's @font-face IS printed
4. Test with older Gutenberg versions to confirm no regression

## Related

- Gutenberg PR: WordPress/gutenberg#73971 (Classic Themes: Enable Fonts)
- Gutenberg file: `lib/compat/wordpress-7.0/global-styles.php`