### PR TITLE
Remove "Super Blank" from incompatible plugins list

### DIFF
--- a/projects/plugins/wpcomsh/changelog/update-incompatible-plugin-list-remove-super-blank
+++ b/projects/plugins/wpcomsh/changelog/update-incompatible-plugin-list-remove-super-blank
@@ -1,0 +1,4 @@
+Significance: minor
+Type: removed
+
+Removed "Super Blank" plugin (known by slug: super-blank) from list of incompatible plugins.

--- a/projects/plugins/wpcomsh/class-jetpack-plugin-compatibility.php
+++ b/projects/plugins/wpcomsh/class-jetpack-plugin-compatibility.php
@@ -35,7 +35,6 @@ class Jetpack_Plugin_Compatibility {
 		'reset-wp/reset-wp.php'                           => '"reset-wp" has been deactivated, it deletes data necessary to manage your site and is not supported on WordPress.com.',
 		'reset/data_reset.php'                            => '"reset" has been deactivated, it deletes data necessary to manage your site and is not supported on WordPress.com.',
 		'secure-file-manager/secure-file-manager.php'     => '"secure-file-manager" has been deactivated, it deletes data necessary to manage your site and is not supported on WordPress.com.',
-		'super-blank/super-blank.php'                     => '"super-blank" has been deactivated, it deletes data necessary to manage your site and is not supported on WordPress.com.',
 		'ultimate-reset/ultimate-reset.php'               => '"ultimate-reset" has been deactivated, it deletes data necessary to manage your site and is not supported on WordPress.com.',
 		'ultimate-wp-reset/ultimate-wordpress-reset.php'  => '"ultimate-wp-reset" has been deactivated, it deletes data necessary to manage your site and is not supported on WordPress.com.',
 		'username-changer/class-username-changer.php'     => '"username-changer" has been deactivated, it deletes data necessary to manage your site and is not supported on WordPress.com.',


### PR DESCRIPTION
Remove Super Blank from incompatible plugins list known by slug super-blank. The new version provided by the developer as of 2026-01-19 works fine on WordPress.com.

Corresponding PR: https://github.com/Automattic/wp-calypso/pull/108289

## Jetpack product discussion

N/A

## Does this pull request change what data or activity we track or use?

No, I don't believe this would apply to the update.

## Testing instructions:

1. Create a new Business Plan site, mark it as a WoA Dev site, and take it Atomic.
2. Build wpcomsh plugin and synchronize to the WoA Dev site

```
git checkout BRANCH
composer install
WPCOMSH_DEVMODE=1 make clean build
rsync -avze ssh --delete build/wpcomsh USERNAME@sftp.wp.com:htdocs/wp-content/mu-plugins
```

3. SSH into the WoA dev site, and run: wp plugin install super-blank --activate
4. Navigate to the WoA dev site's /wp-admin/plugins.php page and confirm that Super Blank can be activated and is not disabled.