### PR TITLE
Forms: add bulk actions for form posts

### DIFF
--- a/projects/packages/forms/changelog/add-forms-posts-bulk-actions
+++ b/projects/packages/forms/changelog/add-forms-posts-bulk-actions
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Forms: add bulk actions for form posts.

--- a/projects/packages/forms/src/dashboard/forms/index.tsx
+++ b/projects/packages/forms/src/dashboard/forms/index.tsx
@@ -108,7 +108,11 @@ export default function FormsDashboardForms(): JSX.Element | null {
 
 	const onConfirmPermanentDelete = useCallback( async () => {
 		setPendingPermanentDeleteCount( 0 );
-		await confirmPermanentDelete();
+		try {
+			await confirmPermanentDelete();
+		} finally {
+			setSelection( [] );
+		}
 	}, [ confirmPermanentDelete ] );
 
 	const statusLabel = useCallback( ( status: string ) => {

--- a/projects/packages/forms/src/dashboard/forms/index.tsx
+++ b/projects/packages/forms/src/dashboard/forms/index.tsx
@@ -5,8 +5,8 @@ import { JetpackLogo } from '@automattic/jetpack-components';
 import { __experimentalConfirmDialog as ConfirmDialog } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
 import { DataViews } from '@wordpress/dataviews/wp';
 import { dateI18n, getSettings as getDateSettings } from '@wordpress/date';
-import { useCallback, useEffect, useMemo } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { useCallback, useEffect, useMemo, useState } from '@wordpress/element';
+import { __, _n, sprintf } from '@wordpress/i18n';
 import { useNavigate } from 'react-router';
 /**
  * Internal dependencies
@@ -66,8 +66,8 @@ export default function FormsDashboardForms(): JSX.Element | null {
 	);
 	const {
 		isDeleting,
-		trashForm,
-		restoreForm,
+		trashForms,
+		restoreForms,
 		isPermanentDeleteConfirmOpen,
 		openPermanentDeleteConfirm,
 		closePermanentDeleteConfirm,
@@ -79,11 +79,37 @@ export default function FormsDashboardForms(): JSX.Element | null {
 		statusQuery,
 	} );
 
+	const [ selection, setSelection ] = useState< string[] >( [] );
+	const [ pendingPermanentDeleteCount, setPendingPermanentDeleteCount ] = useState( 0 );
+
 	useEffect( () => {
 		if ( isCentralFormManagementDisabled ) {
 			navigate( '/responses', { replace: true } );
 		}
 	}, [ isCentralFormManagementDisabled, navigate ] );
+
+	// Selection is local (non-URL) state. Clear selection whenever the view changes (page/perPage/search/filters).
+	useEffect( () => {
+		setSelection( [] );
+	}, [ view.page, view.perPage, view.search, view.filters ] );
+
+	const onOpenPermanentDeleteConfirm = useCallback(
+		( items: FormListItem[] ) => {
+			setPendingPermanentDeleteCount( items?.length ?? 0 );
+			openPermanentDeleteConfirm( items );
+		},
+		[ openPermanentDeleteConfirm ]
+	);
+
+	const onClosePermanentDeleteConfirm = useCallback( () => {
+		setPendingPermanentDeleteCount( 0 );
+		closePermanentDeleteConfirm();
+	}, [ closePermanentDeleteConfirm ] );
+
+	const onConfirmPermanentDelete = useCallback( async () => {
+		setPendingPermanentDeleteCount( 0 );
+		await confirmPermanentDelete();
+	}, [ confirmPermanentDelete ] );
 
 	const statusLabel = useCallback( ( status: string ) => {
 		switch ( status ) {
@@ -176,32 +202,31 @@ export default function FormsDashboardForms(): JSX.Element | null {
 				id: 'restore-form',
 				isPrimary: false,
 				label: __( 'Restore', 'jetpack-forms' ),
-				supportsBulk: false,
+				supportsBulk: true,
 				async callback( items: FormListItem[] ) {
 					if ( isDeleting ) {
 						return;
 					}
-					const [ item ] = items;
-					if ( ! item ) {
-						return;
+					try {
+						await restoreForms( items );
+					} finally {
+						setSelection( [] );
 					}
-					await restoreForm( item );
 				},
 			} );
 			actionsList.push( {
 				id: 'delete-form-permanently',
 				isPrimary: false,
 				label: __( 'Delete permanently', 'jetpack-forms' ),
-				supportsBulk: false,
+				supportsBulk: true,
 				async callback( items: FormListItem[] ) {
 					if ( isDeleting ) {
 						return;
 					}
-					const [ item ] = items;
-					if ( ! item ) {
+					if ( ! items?.length ) {
 						return;
 					}
-					openPermanentDeleteConfirm( item );
+					onOpenPermanentDeleteConfirm( items );
 				},
 			} );
 			return actionsList;
@@ -211,21 +236,21 @@ export default function FormsDashboardForms(): JSX.Element | null {
 			id: 'trash-form',
 			isPrimary: false,
 			label: __( 'Trash', 'jetpack-forms' ),
-			supportsBulk: false,
+			supportsBulk: true,
 			async callback( items: FormListItem[] ) {
 				if ( isDeleting ) {
 					return;
 				}
-				const [ item ] = items;
-				if ( ! item ) {
-					return;
+				try {
+					await trashForms( items );
+				} finally {
+					setSelection( [] );
 				}
-				await trashForm( item );
 			},
 		} );
 
 		return actionsList;
-	}, [ isDeleting, isViewingTrash, openPermanentDeleteConfirm, restoreForm, trashForm ] );
+	}, [ isDeleting, isViewingTrash, onOpenPermanentDeleteConfirm, restoreForms, trashForms ] );
 
 	const paginationInfo = useMemo(
 		() => ( {
@@ -282,21 +307,34 @@ export default function FormsDashboardForms(): JSX.Element | null {
 					}
 					view={ view }
 					onChangeView={ onChangeView }
+					selection={ selection }
+					onChangeSelection={ setSelection }
 					getItemId={ getItemId }
 					defaultLayouts={ defaultLayouts }
 				>
 					<ConfirmDialog
-						onCancel={ closePermanentDeleteConfirm }
-						onConfirm={ confirmPermanentDelete }
+						onCancel={ onClosePermanentDeleteConfirm }
+						onConfirm={ onConfirmPermanentDelete }
 						isOpen={ isPermanentDeleteConfirmOpen }
 						confirmButtonText={ __( 'Delete permanently', 'jetpack-forms' ) }
 					>
 						<h3>{ __( 'Delete permanently', 'jetpack-forms' ) }</h3>
 						<p>
-							{ __(
-								'This will permanently delete the form. This action cannot be undone.',
-								'jetpack-forms'
-							) }
+							{ pendingPermanentDeleteCount === 1
+								? __(
+										'This will permanently delete this form. This action cannot be undone.',
+										'jetpack-forms'
+								  )
+								: sprintf(
+										/* translators: %d: number of forms */
+										_n(
+											'This will permanently delete %d form. This action cannot be undone.',
+											'This will permanently delete %d forms. This action cannot be undone.',
+											pendingPermanentDeleteCount,
+											'jetpack-forms'
+										),
+										pendingPermanentDeleteCount
+								  ) }
 						</p>
 					</ConfirmDialog>
 					<div className="jp-forms-filters-bar">

--- a/projects/packages/forms/src/dashboard/forms/views.ts
+++ b/projects/packages/forms/src/dashboard/forms/views.ts
@@ -10,7 +10,8 @@ export const defaultView: View = {
 	filters: [ { field: 'status', operator: 'is', value: 'all' } ],
 	page: 1,
 	perPage: 20,
-	fields: [ 'title', 'entries', 'status', 'modified' ],
+	titleField: 'title',
+	fields: [ 'entries', 'status', 'modified' ],
 };
 
 export const defaultLayouts = {

--- a/projects/packages/forms/src/dashboard/hooks/use-delete-form.ts
+++ b/projects/packages/forms/src/dashboard/hooks/use-delete-form.ts
@@ -38,7 +38,6 @@ type UseDeleteFormReturn = {
 	trashForms: ( items: FormListItem[] ) => Promise< void >;
 	restoreForms: ( items: FormListItem[] ) => Promise< void >;
 	isPermanentDeleteConfirmOpen: boolean;
-	permanentDeleteItemsCount: number;
 	openPermanentDeleteConfirm: ( items: FormListItem[] ) => void;
 	closePermanentDeleteConfirm: () => void;
 	confirmPermanentDelete: () => Promise< void >;
@@ -344,6 +343,7 @@ export default function useDeleteForm( {
 		setIsPermanentDeleteConfirmOpen( false );
 		setIsDeleting( true );
 		const currentQuerySnapshot = currentQuery;
+		let shouldNavigateToPreviousPage = false;
 
 		try {
 			const promises = await Promise.allSettled(
@@ -381,7 +381,7 @@ export default function useDeleteForm( {
 					id: `delete-forms-permanently-${ Date.now() }`,
 				} );
 
-				const shouldNavigateToPreviousPage = page > 1 && deletedCount >= recordsLength;
+				shouldNavigateToPreviousPage = page > 1 && deletedCount >= recordsLength;
 				if ( shouldNavigateToPreviousPage ) {
 					setView( { ...view, page: page - 1 } );
 				}
@@ -403,6 +403,7 @@ export default function useDeleteForm( {
 				);
 			}
 		} catch {
+			// Note: Promise.allSettled captures per-item failures; this is only for unexpected exceptions.
 			createErrorNotice( __( 'Could not delete forms permanently.', 'jetpack-forms' ), {
 				type: 'snackbar',
 				id: `delete-forms-permanently-error-${ Date.now() }`,
@@ -411,8 +412,11 @@ export default function useDeleteForm( {
 			setIsDeleting( false );
 			setPermanentDeleteItems( [] );
 
-			// Invalidate the list query so the deleted form disappears from the table and totals refresh.
+			// Invalidate the list query so the deleted forms disappear from the table and totals refresh.
 			invalidateListQueries( currentQuerySnapshot );
+			if ( shouldNavigateToPreviousPage ) {
+				invalidateListQueries( { ...currentQuerySnapshot, page: page - 1 } );
+			}
 		}
 	}, [
 		createErrorNotice,
@@ -433,7 +437,6 @@ export default function useDeleteForm( {
 		trashForms,
 		restoreForms,
 		isPermanentDeleteConfirmOpen,
-		permanentDeleteItemsCount: permanentDeleteItems.length,
 		openPermanentDeleteConfirm,
 		closePermanentDeleteConfirm,
 		confirmPermanentDelete,

--- a/projects/packages/forms/src/dashboard/hooks/use-delete-form.ts
+++ b/projects/packages/forms/src/dashboard/hooks/use-delete-form.ts
@@ -156,8 +156,8 @@ export default function useDeleteForm( {
 
 			setIsDeleting( true );
 
-			const shouldNavigateToPreviousPage = page > 1 && items.length >= recordsLength;
 			const currentQuerySnapshot = currentQuery;
+			let shouldNavigateToPreviousPage = false;
 
 			try {
 				const { restoredCount } = await restoreItemsToPublish( items, {
@@ -165,10 +165,11 @@ export default function useDeleteForm( {
 					errorNoticeIdPrefix: 'restore-forms-error',
 				} );
 
+				// Only page back if we successfully restored all items on the current page.
+				// If some restores fail, the page may still have items and navigating would be incorrect.
+				shouldNavigateToPreviousPage = page > 1 && restoredCount >= recordsLength;
 				if ( restoredCount && shouldNavigateToPreviousPage ) {
-					if ( shouldNavigateToPreviousPage ) {
-						setView( { ...view, page: page - 1 } );
-					}
+					setView( { ...view, page: page - 1 } );
 				}
 			} finally {
 				setIsDeleting( false );
@@ -227,8 +228,8 @@ export default function useDeleteForm( {
 
 			setIsDeleting( true );
 
-			const shouldNavigateToPreviousPage = page > 1 && items.length >= recordsLength;
 			const currentQuerySnapshot = currentQuery;
+			let shouldNavigateToPreviousPage = false;
 
 			try {
 				const promises = await Promise.allSettled(
@@ -275,6 +276,9 @@ export default function useDeleteForm( {
 						],
 					} );
 
+					// Only page back if we successfully trashed all items on the current page.
+					// If some trash operations fail, the page may still have items and navigating would be incorrect.
+					shouldNavigateToPreviousPage = page > 1 && trashedCount >= recordsLength;
 					if ( shouldNavigateToPreviousPage ) {
 						setView( { ...view, page: page - 1 } );
 					}
@@ -415,7 +419,9 @@ export default function useDeleteForm( {
 			// Invalidate the list query so the deleted forms disappear from the table and totals refresh.
 			invalidateListQueries( currentQuerySnapshot );
 			if ( shouldNavigateToPreviousPage ) {
-				invalidateListQueries( { ...currentQuerySnapshot, page: page - 1 } );
+				invalidateListQueries(
+					getFormsListQuery( page - 1, perPage, search, statusQuery ) as Record< string, unknown >
+				);
 			}
 		}
 	}, [
@@ -426,9 +432,12 @@ export default function useDeleteForm( {
 		invalidateListQueries,
 		isDeleting,
 		page,
+		perPage,
 		permanentDeleteItems,
 		recordsLength,
+		search,
 		setView,
+		statusQuery,
 		view,
 	] );
 

--- a/projects/packages/forms/src/dashboard/hooks/use-delete-form.ts
+++ b/projects/packages/forms/src/dashboard/hooks/use-delete-form.ts
@@ -90,6 +90,65 @@ export default function useDeleteForm( {
 		[ invalidateResolution ]
 	);
 
+	const restoreItemsToPublish = useCallback(
+		async (
+			items: FormListItem[],
+			{
+				successNoticeIdPrefix,
+				errorNoticeIdPrefix,
+			}: { successNoticeIdPrefix: string; errorNoticeIdPrefix: string }
+		): Promise< { restoredCount: number; failedCount: number } > => {
+			const promises = await Promise.allSettled(
+				items.map( item =>
+					saveEntityRecord(
+						'postType',
+						'jetpack_form',
+						{ id: item.id, status: 'publish' },
+						{ throwOnError: true }
+					)
+				)
+			);
+
+			const restoredCount = promises.filter( p => p.status === 'fulfilled' ).length;
+			const failedCount = promises.length - restoredCount;
+
+			if ( restoredCount ) {
+				const successMessage =
+					restoredCount === 1
+						? __( 'Form restored.', 'jetpack-forms' )
+						: sprintf(
+								/* translators: %d: number of forms. */
+								_n( '%d form restored.', '%d forms restored.', restoredCount, 'jetpack-forms' ),
+								restoredCount
+						  );
+
+				createSuccessNotice( successMessage, {
+					type: 'snackbar',
+					id: `${ successNoticeIdPrefix }-${ Date.now() }`,
+				} );
+			}
+
+			if ( failedCount ) {
+				createErrorNotice(
+					sprintf(
+						/* translators: %d: number of forms. */
+						_n(
+							'Could not restore %d form.',
+							'Could not restore %d forms.',
+							failedCount,
+							'jetpack-forms'
+						),
+						failedCount
+					),
+					{ type: 'snackbar', id: `${ errorNoticeIdPrefix }-${ Date.now() }` }
+				);
+			}
+
+			return { restoredCount, failedCount };
+		},
+		[ createErrorNotice, createSuccessNotice, saveEntityRecord ]
+	);
+
 	const restoreForms = useCallback(
 		async ( items: FormListItem[] ) => {
 			if ( isDeleting || ! items?.length ) {
@@ -102,54 +161,15 @@ export default function useDeleteForm( {
 			const currentQuerySnapshot = currentQuery;
 
 			try {
-				const promises = await Promise.allSettled(
-					items.map( item =>
-						saveEntityRecord(
-							'postType',
-							'jetpack_form',
-							{ id: item.id, status: 'publish' },
-							{ throwOnError: true }
-						)
-					)
-				);
+				const { restoredCount } = await restoreItemsToPublish( items, {
+					successNoticeIdPrefix: 'restore-forms',
+					errorNoticeIdPrefix: 'restore-forms-error',
+				} );
 
-				const restoredCount = promises.filter( p => p.status === 'fulfilled' ).length;
-				const failedCount = promises.length - restoredCount;
-
-				if ( restoredCount ) {
-					const successMessage =
-						restoredCount === 1
-							? __( 'Form restored.', 'jetpack-forms' )
-							: sprintf(
-									/* translators: %d: number of forms. */
-									_n( '%d form restored.', '%d forms restored.', restoredCount, 'jetpack-forms' ),
-									restoredCount
-							  );
-
-					createSuccessNotice( successMessage, {
-						type: 'snackbar',
-						id: `restore-forms-${ Date.now() }`,
-					} );
-
+				if ( restoredCount && shouldNavigateToPreviousPage ) {
 					if ( shouldNavigateToPreviousPage ) {
 						setView( { ...view, page: page - 1 } );
 					}
-				}
-
-				if ( failedCount ) {
-					createErrorNotice(
-						sprintf(
-							/* translators: %d: number of forms. */
-							_n(
-								'Could not restore %d form.',
-								'Could not restore %d forms.',
-								failedCount,
-								'jetpack-forms'
-							),
-							failedCount
-						),
-						{ type: 'snackbar', id: `restore-forms-error-${ Date.now() }` }
-					);
 				}
 			} finally {
 				setIsDeleting( false );
@@ -164,15 +184,13 @@ export default function useDeleteForm( {
 			}
 		},
 		[
-			createErrorNotice,
-			createSuccessNotice,
 			currentQuery,
 			invalidateListQueries,
 			isDeleting,
 			page,
 			perPage,
 			recordsLength,
-			saveEntityRecord,
+			restoreItemsToPublish,
 			search,
 			setView,
 			statusQuery,
@@ -190,64 +208,16 @@ export default function useDeleteForm( {
 			const currentQuerySnapshot = currentQuery;
 
 			try {
-				const promises = await Promise.allSettled(
-					items.map( item =>
-						saveEntityRecord(
-							'postType',
-							'jetpack_form',
-							{ id: item.id, status: 'publish' },
-							{ throwOnError: true }
-						)
-					)
-				);
-
-				const restoredCount = promises.filter( p => p.status === 'fulfilled' ).length;
-				const failedCount = promises.length - restoredCount;
-
-				if ( restoredCount ) {
-					const successMessage =
-						restoredCount === 1
-							? __( 'Form restored.', 'jetpack-forms' )
-							: sprintf(
-									/* translators: %d: number of forms. */
-									_n( '%d form restored.', '%d forms restored.', restoredCount, 'jetpack-forms' ),
-									restoredCount
-							  );
-
-					createSuccessNotice( successMessage, {
-						type: 'snackbar',
-						id: `undo-trash-forms-${ Date.now() }`,
-					} );
-				}
-
-				if ( failedCount ) {
-					createErrorNotice(
-						sprintf(
-							/* translators: %d: number of forms. */
-							_n(
-								'Could not restore %d form.',
-								'Could not restore %d forms.',
-								failedCount,
-								'jetpack-forms'
-							),
-							failedCount
-						),
-						{ type: 'snackbar', id: `undo-trash-forms-error-${ Date.now() }` }
-					);
-				}
+				await restoreItemsToPublish( items, {
+					successNoticeIdPrefix: 'undo-trash-forms',
+					errorNoticeIdPrefix: 'undo-trash-forms-error',
+				} );
 			} finally {
 				setIsDeleting( false );
 				invalidateListQueries( currentQuerySnapshot );
 			}
 		},
-		[
-			createErrorNotice,
-			createSuccessNotice,
-			currentQuery,
-			invalidateListQueries,
-			isDeleting,
-			saveEntityRecord,
-		]
+		[ currentQuery, invalidateListQueries, isDeleting, restoreItemsToPublish ]
 	);
 
 	const trashForms = useCallback(

--- a/projects/packages/forms/src/dashboard/hooks/use-delete-form.ts
+++ b/projects/packages/forms/src/dashboard/hooks/use-delete-form.ts
@@ -1,6 +1,6 @@
 import { useDispatch } from '@wordpress/data';
 import { useCallback, useMemo, useState } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { __, _n, sprintf } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 /**
  * Internal dependencies
@@ -35,10 +35,11 @@ type UseDeleteFormArgs = {
 
 type UseDeleteFormReturn = {
 	isDeleting: boolean;
-	trashForm: ( item: FormListItem ) => Promise< void >;
-	restoreForm: ( item: FormListItem ) => Promise< void >;
+	trashForms: ( items: FormListItem[] ) => Promise< void >;
+	restoreForms: ( items: FormListItem[] ) => Promise< void >;
 	isPermanentDeleteConfirmOpen: boolean;
-	openPermanentDeleteConfirm: ( item: FormListItem ) => void;
+	permanentDeleteItemsCount: number;
+	openPermanentDeleteConfirm: ( items: FormListItem[] ) => void;
 	closePermanentDeleteConfirm: () => void;
 	confirmPermanentDelete: () => Promise< void >;
 };
@@ -61,7 +62,7 @@ export default function useDeleteForm( {
 }: UseDeleteFormArgs ): UseDeleteFormReturn {
 	const [ isDeleting, setIsDeleting ] = useState( false );
 	const [ isPermanentDeleteConfirmOpen, setIsPermanentDeleteConfirmOpen ] = useState( false );
-	const [ permanentDeleteItem, setPermanentDeleteItem ] = useState< FormListItem | null >( null );
+	const [ permanentDeleteItems, setPermanentDeleteItems ] = useState< FormListItem[] >( [] );
 
 	const { saveEntityRecord, deleteEntityRecord, invalidateResolution } = useDispatch(
 		'core'
@@ -77,129 +78,264 @@ export default function useDeleteForm( {
 		[ page, perPage, search, statusQuery ]
 	);
 
-	const undoTrashForm = useCallback(
-		async ( id: number, previousStatus: string ) => {
-			try {
-				await saveEntityRecord(
-					'postType',
-					'jetpack_form',
-					{ id, status: previousStatus },
-					{ throwOnError: true }
-				);
-				createSuccessNotice( __( 'Form restored.', 'jetpack-forms' ), {
-					type: 'snackbar',
-					id: `restore-form-${ id }`,
-				} );
-			} catch {
-				createErrorNotice( __( 'Could not restore form.', 'jetpack-forms' ), {
-					type: 'snackbar',
-					id: `restore-form-error-${ id }`,
-				} );
-			} finally {
-				invalidateResolution( 'getEntityRecords', [ 'postType', 'jetpack_form', currentQuery ] );
-				invalidateResolution( 'getEntityRecords', [
-					'postType',
-					'jetpack_form',
-					{ ...currentQuery, per_page: 1, _fields: 'id' },
-				] );
-			}
+	const invalidateListQueries = useCallback(
+		( query: Record< string, unknown > ) => {
+			invalidateResolution( 'getEntityRecords', [ 'postType', 'jetpack_form', query ] );
+			invalidateResolution( 'getEntityRecords', [
+				'postType',
+				'jetpack_form',
+				{ ...query, per_page: 1, _fields: 'id' },
+			] );
 		},
-		[ createErrorNotice, createSuccessNotice, currentQuery, invalidateResolution, saveEntityRecord ]
+		[ invalidateResolution ]
 	);
 
-	const restoreForm = useCallback(
-		async ( item: FormListItem ) => {
-			if ( ! item || isDeleting ) {
+	const restoreForms = useCallback(
+		async ( items: FormListItem[] ) => {
+			if ( isDeleting || ! items?.length ) {
 				return;
 			}
 
 			setIsDeleting( true );
 
+			const shouldNavigateToPreviousPage = page > 1 && items.length >= recordsLength;
+			const currentQuerySnapshot = currentQuery;
+
 			try {
-				await saveEntityRecord(
-					'postType',
-					'jetpack_form',
-					{ id: item.id, status: 'publish' },
-					{ throwOnError: true }
+				const promises = await Promise.allSettled(
+					items.map( item =>
+						saveEntityRecord(
+							'postType',
+							'jetpack_form',
+							{ id: item.id, status: 'publish' },
+							{ throwOnError: true }
+						)
+					)
 				);
-				createSuccessNotice( __( 'Form restored.', 'jetpack-forms' ), {
-					type: 'snackbar',
-					id: `restore-form-${ item.id }`,
-				} );
-			} catch {
-				createErrorNotice( __( 'Could not restore form.', 'jetpack-forms' ), {
-					type: 'snackbar',
-					id: `restore-form-error-${ item.id }`,
-				} );
+
+				const restoredCount = promises.filter( p => p.status === 'fulfilled' ).length;
+				const failedCount = promises.length - restoredCount;
+
+				if ( restoredCount ) {
+					const successMessage =
+						restoredCount === 1
+							? __( 'Form restored.', 'jetpack-forms' )
+							: sprintf(
+									/* translators: %d: number of forms. */
+									_n( '%d form restored.', '%d forms restored.', restoredCount, 'jetpack-forms' ),
+									restoredCount
+							  );
+
+					createSuccessNotice( successMessage, {
+						type: 'snackbar',
+						id: `restore-forms-${ Date.now() }`,
+					} );
+
+					if ( shouldNavigateToPreviousPage ) {
+						setView( { ...view, page: page - 1 } );
+					}
+				}
+
+				if ( failedCount ) {
+					createErrorNotice(
+						sprintf(
+							/* translators: %d: number of forms. */
+							_n(
+								'Could not restore %d form.',
+								'Could not restore %d forms.',
+								failedCount,
+								'jetpack-forms'
+							),
+							failedCount
+						),
+						{ type: 'snackbar', id: `restore-forms-error-${ Date.now() }` }
+					);
+				}
 			} finally {
 				setIsDeleting( false );
-				invalidateResolution( 'getEntityRecords', [ 'postType', 'jetpack_form', currentQuery ] );
-				invalidateResolution( 'getEntityRecords', [
-					'postType',
-					'jetpack_form',
-					{ ...currentQuery, per_page: 1, _fields: 'id' },
-				] );
+
+				// Invalidate the list query so restored forms disappear from the trash view and totals refresh.
+				invalidateListQueries( currentQuerySnapshot );
+				if ( shouldNavigateToPreviousPage ) {
+					invalidateListQueries(
+						getFormsListQuery( page - 1, perPage, search, statusQuery ) as Record< string, unknown >
+					);
+				}
 			}
 		},
 		[
 			createErrorNotice,
 			createSuccessNotice,
 			currentQuery,
-			invalidateResolution,
+			invalidateListQueries,
+			isDeleting,
+			page,
+			perPage,
+			recordsLength,
+			saveEntityRecord,
+			search,
+			setView,
+			statusQuery,
+			view,
+		]
+	);
+
+	const undoTrashForms = useCallback(
+		async ( items: FormListItem[] ) => {
+			if ( isDeleting || ! items?.length ) {
+				return;
+			}
+
+			setIsDeleting( true );
+			const currentQuerySnapshot = currentQuery;
+
+			try {
+				const promises = await Promise.allSettled(
+					items.map( item =>
+						saveEntityRecord(
+							'postType',
+							'jetpack_form',
+							{ id: item.id, status: 'publish' },
+							{ throwOnError: true }
+						)
+					)
+				);
+
+				const restoredCount = promises.filter( p => p.status === 'fulfilled' ).length;
+				const failedCount = promises.length - restoredCount;
+
+				if ( restoredCount ) {
+					const successMessage =
+						restoredCount === 1
+							? __( 'Form restored.', 'jetpack-forms' )
+							: sprintf(
+									/* translators: %d: number of forms. */
+									_n( '%d form restored.', '%d forms restored.', restoredCount, 'jetpack-forms' ),
+									restoredCount
+							  );
+
+					createSuccessNotice( successMessage, {
+						type: 'snackbar',
+						id: `undo-trash-forms-${ Date.now() }`,
+					} );
+				}
+
+				if ( failedCount ) {
+					createErrorNotice(
+						sprintf(
+							/* translators: %d: number of forms. */
+							_n(
+								'Could not restore %d form.',
+								'Could not restore %d forms.',
+								failedCount,
+								'jetpack-forms'
+							),
+							failedCount
+						),
+						{ type: 'snackbar', id: `undo-trash-forms-error-${ Date.now() }` }
+					);
+				}
+			} finally {
+				setIsDeleting( false );
+				invalidateListQueries( currentQuerySnapshot );
+			}
+		},
+		[
+			createErrorNotice,
+			createSuccessNotice,
+			currentQuery,
+			invalidateListQueries,
 			isDeleting,
 			saveEntityRecord,
 		]
 	);
 
-	const trashForm = useCallback(
-		async ( item: FormListItem ) => {
-			if ( ! item || isDeleting ) {
+	const trashForms = useCallback(
+		async ( items: FormListItem[] ) => {
+			if ( isDeleting || ! items?.length ) {
 				return;
 			}
 
-			const previousStatus = item.status;
 			setIsDeleting( true );
 
-			const shouldNavigateToPreviousPage = page > 1 && recordsLength === 1;
+			const shouldNavigateToPreviousPage = page > 1 && items.length >= recordsLength;
+			const currentQuerySnapshot = currentQuery;
 
 			try {
-				await deleteEntityRecord(
-					'postType',
-					'jetpack_form',
-					item.id,
-					{ force: false },
-					{ throwOnError: true }
+				const promises = await Promise.allSettled(
+					items.map( item =>
+						deleteEntityRecord(
+							'postType',
+							'jetpack_form',
+							item.id,
+							{ force: false },
+							{ throwOnError: true }
+						)
+					)
 				);
 
-				createSuccessNotice( __( 'Form moved to trash.', 'jetpack-forms' ), {
-					type: 'snackbar',
-					id: `trash-form-${ item.id }`,
-					actions: [
-						{
-							label: __( 'Undo', 'jetpack-forms' ),
-							onClick: () => void undoTrashForm( item.id, previousStatus ),
-						},
-					],
-				} );
+				const trashedItems = items.filter(
+					( _, index ) => promises[ index ]?.status === 'fulfilled'
+				);
+				const trashedCount = trashedItems.length;
+				const failedCount = items.length - trashedCount;
 
-				if ( shouldNavigateToPreviousPage ) {
-					setView( { ...view, page: page - 1 } );
+				if ( trashedCount ) {
+					const successMessage =
+						trashedCount === 1
+							? __( 'Form moved to trash.', 'jetpack-forms' )
+							: sprintf(
+									/* translators: %d: number of forms. */
+									_n(
+										'%d form moved to trash.',
+										'%d forms moved to trash.',
+										trashedCount,
+										'jetpack-forms'
+									),
+									trashedCount
+							  );
+
+					createSuccessNotice( successMessage, {
+						type: 'snackbar',
+						id: `trash-forms-${ Date.now() }`,
+						actions: [
+							{
+								label: __( 'Undo', 'jetpack-forms' ),
+								onClick: () => void undoTrashForms( trashedItems ),
+							},
+						],
+					} );
+
+					if ( shouldNavigateToPreviousPage ) {
+						setView( { ...view, page: page - 1 } );
+					}
 				}
-			} catch {
-				createErrorNotice( __( 'Could not move form to trash.', 'jetpack-forms' ), {
-					type: 'snackbar',
-					id: 'delete-form-error',
-				} );
+
+				if ( failedCount ) {
+					createErrorNotice(
+						sprintf(
+							/* translators: %d: number of forms. */
+							_n(
+								'Could not move %d form to trash.',
+								'Could not move %d forms to trash.',
+								failedCount,
+								'jetpack-forms'
+							),
+							failedCount
+						),
+						{ type: 'snackbar', id: `trash-forms-error-${ Date.now() }` }
+					);
+				}
 			} finally {
 				setIsDeleting( false );
 
-				// Invalidate the list query so the trashed form disappears from the table and totals refresh.
-				invalidateResolution( 'getEntityRecords', [ 'postType', 'jetpack_form', currentQuery ] );
-				invalidateResolution( 'getEntityRecords', [
-					'postType',
-					'jetpack_form',
-					{ ...currentQuery, per_page: 1, _fields: 'id' },
-				] );
+				// Invalidate the list query so trashed forms disappear from the table and totals refresh.
+				invalidateListQueries( currentQuerySnapshot );
+				if ( shouldNavigateToPreviousPage ) {
+					invalidateListQueries(
+						getFormsListQuery( page - 1, perPage, search, statusQuery ) as Record< string, unknown >
+					);
+				}
 			}
 		},
 		[
@@ -207,79 +343,127 @@ export default function useDeleteForm( {
 			createSuccessNotice,
 			currentQuery,
 			deleteEntityRecord,
-			invalidateResolution,
+			invalidateListQueries,
 			isDeleting,
-			undoTrashForm,
 			page,
+			perPage,
 			recordsLength,
+			search,
 			setView,
+			statusQuery,
+			undoTrashForms,
 			view,
 		]
 	);
 
-	const openPermanentDeleteConfirm = useCallback( ( item: FormListItem ) => {
-		setPermanentDeleteItem( item );
+	const openPermanentDeleteConfirm = useCallback( ( items: FormListItem[] ) => {
+		setPermanentDeleteItems( items || [] );
 		setIsPermanentDeleteConfirmOpen( true );
 	}, [] );
 
 	const closePermanentDeleteConfirm = useCallback( () => {
 		setIsPermanentDeleteConfirmOpen( false );
-		setPermanentDeleteItem( null );
+		setPermanentDeleteItems( [] );
 	}, [] );
 
 	const confirmPermanentDelete = useCallback( async () => {
-		if ( ! permanentDeleteItem || isDeleting ) {
+		if ( ! permanentDeleteItems.length || isDeleting ) {
 			return;
 		}
 
 		setIsPermanentDeleteConfirmOpen( false );
 		setIsDeleting( true );
+		const currentQuerySnapshot = currentQuery;
 
 		try {
-			await deleteEntityRecord(
-				'postType',
-				'jetpack_form',
-				permanentDeleteItem.id,
-				{ force: true },
-				{ throwOnError: true }
+			const promises = await Promise.allSettled(
+				permanentDeleteItems.map( item =>
+					deleteEntityRecord(
+						'postType',
+						'jetpack_form',
+						item.id,
+						{ force: true },
+						{ throwOnError: true }
+					)
+				)
 			);
 
-			createSuccessNotice( __( 'Form deleted permanently.', 'jetpack-forms' ), {
-				type: 'snackbar',
-				id: `delete-form-permanently-${ permanentDeleteItem.id }`,
-			} );
+			const deletedCount = promises.filter( p => p.status === 'fulfilled' ).length;
+			const failedCount = promises.length - deletedCount;
+
+			if ( deletedCount ) {
+				const successMessage =
+					deletedCount === 1
+						? __( 'Form deleted permanently.', 'jetpack-forms' )
+						: sprintf(
+								/* translators: %d: number of forms. */
+								_n(
+									'%d form deleted permanently.',
+									'%d forms deleted permanently.',
+									deletedCount,
+									'jetpack-forms'
+								),
+								deletedCount
+						  );
+
+				createSuccessNotice( successMessage, {
+					type: 'snackbar',
+					id: `delete-forms-permanently-${ Date.now() }`,
+				} );
+
+				const shouldNavigateToPreviousPage = page > 1 && deletedCount >= recordsLength;
+				if ( shouldNavigateToPreviousPage ) {
+					setView( { ...view, page: page - 1 } );
+				}
+			}
+
+			if ( failedCount ) {
+				createErrorNotice(
+					sprintf(
+						/* translators: %d: number of forms. */
+						_n(
+							'Could not permanently delete %d form.',
+							'Could not permanently delete %d forms.',
+							failedCount,
+							'jetpack-forms'
+						),
+						failedCount
+					),
+					{ type: 'snackbar', id: `delete-forms-permanently-error-${ Date.now() }` }
+				);
+			}
 		} catch {
-			createErrorNotice( __( 'Could not delete form permanently.', 'jetpack-forms' ), {
+			createErrorNotice( __( 'Could not delete forms permanently.', 'jetpack-forms' ), {
 				type: 'snackbar',
-				id: `delete-form-permanently-error-${ permanentDeleteItem.id }`,
+				id: `delete-forms-permanently-error-${ Date.now() }`,
 			} );
 		} finally {
 			setIsDeleting( false );
-			setPermanentDeleteItem( null );
+			setPermanentDeleteItems( [] );
 
 			// Invalidate the list query so the deleted form disappears from the table and totals refresh.
-			invalidateResolution( 'getEntityRecords', [ 'postType', 'jetpack_form', currentQuery ] );
-			invalidateResolution( 'getEntityRecords', [
-				'postType',
-				'jetpack_form',
-				{ ...currentQuery, per_page: 1, _fields: 'id' },
-			] );
+			invalidateListQueries( currentQuerySnapshot );
 		}
 	}, [
 		createErrorNotice,
 		createSuccessNotice,
 		currentQuery,
 		deleteEntityRecord,
-		invalidateResolution,
+		invalidateListQueries,
 		isDeleting,
-		permanentDeleteItem,
+		page,
+		permanentDeleteItems,
+		recordsLength,
+		setView,
+		view,
 	] );
 
 	return {
 		isDeleting,
-		trashForm,
-		restoreForm,
+		trashForms,
+		restoreForms,
 		isPermanentDeleteConfirmOpen,
+		permanentDeleteItemsCount: permanentDeleteItems.length,
 		openPermanentDeleteConfirm,
 		closePermanentDeleteConfirm,
 		confirmPermanentDelete,


### PR DESCRIPTION
## Proposed changes:

Enables bulk actions for the form posts DataViews table. Specifically:
* Sets supportsBulk to true for actions
* Updates our handlers to for trashing, restoring, and permanently deleting forms to handle multiple items 
* Updates permanent delete modal text to handle multiple items
* Ensures notification messages and 'undo' links can handle multiple items

The forms index file is getting large. In a future PR, I'll extract logic for the modal and actions to separate files. 

**Screenshot**
<img width="1344" height="704" alt="forms-bulk-action-support" src="https://github.com/user-attachments/assets/046058ef-6a64-490c-a70d-aa17e4da15ce" />

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Add this feature flag to your test site. 

```
add_filter( 'jetpack_block_editor_feature_flags', 'eb_register_feature' );
function eb_register_feature( $flags ) {
    $flags['central-form-management'] = true;
    return $flags;
}
```

Test bulk actions
* Go to Jetpack > Forms
* On the forms list, confirm you now see checkboxes to select multiple forms
* Select multiple and confirm you see the option to Trash all of them in the footer
* Click trash, and confirm all selected items are trashed
* Change Status filter to Trash and confirm you can select multiple and restore them all at once
* On trash screen, try deleting multiple and confirm you get the confirmation modal with plural text
* Confirm notifications fire as expected in the lower left for all bulk actions

Test with flag off to confirm no regressions:
* Remove feature flag and confirm everything works as before