### PR TITLE
External Media: add filter to allow replacing library components

### DIFF
--- a/projects/packages/external-media/changelog/add-external-media-library-filter
+++ b/projects/packages/external-media/changelog/add-external-media-library-filter
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+External Media: add filter to allow replacing library components.

--- a/projects/packages/external-media/src/shared/sources/index.js
+++ b/projects/packages/external-media/src/shared/sources/index.js
@@ -5,6 +5,7 @@ import {
 	PexelsIcon,
 	JetpackMobileAppIcon,
 } from '@automattic/jetpack-shared-extension-utils/icons';
+import { applyFilters } from '@wordpress/hooks';
 import { __ } from '@wordpress/i18n';
 import {
 	SOURCE_WORDPRESS,
@@ -122,22 +123,35 @@ export function canDisplayPlaceholder( props ) {
  * @return {import('react').Component} - The external library.
  */
 export function getExternalLibrary( type ) {
+	let component = null;
+
 	if ( type === SOURCE_PEXELS ) {
-		return PexelsMedia;
+		component = PexelsMedia;
 	} else if ( type === SOURCE_GOOGLE_PHOTOS ) {
-		return GooglePhotosMedia;
+		component = GooglePhotosMedia;
 	} else if ( type === SOURCE_OPENVERSE ) {
-		return OpenverseMedia;
+		component = OpenverseMedia;
 	} else if ( type === SOURCE_JETPACK_APP_MEDIA ) {
-		return JetpackAppMedia;
+		component = JetpackAppMedia;
 	} else if ( type === SOURCE_JETPACK_AI_FEATURED_IMAGE ) {
-		return JetpackAIFeaturedImage;
+		component = JetpackAIFeaturedImage;
 	} else if ( type === SOURCE_JETPACK_AI_GENERAL_PURPOSE_IMAGE_FOR_MEDIA_SOURCE ) {
-		return JetpackAIGeneralPurposeImageForMediaSource;
+		component = JetpackAIGeneralPurposeImageForMediaSource;
 	} else if ( type === SOURCE_JETPACK_AI_GENERAL_PURPOSE_IMAGE_FOR_BLOCK ) {
-		return JetpackAIGeneralPurposeImageForBlock;
+		component = JetpackAIGeneralPurposeImageForBlock;
 	}
-	return null;
+
+	/**
+	 * Filter the external media library component.
+	 *
+	 * Allows replacing the component rendered for a given external media source type.
+	 *
+	 * @since $$next-version$$
+	 * @module jetpack/external-media
+	 * @param {import('react').Component|null} component - The component to render.
+	 * @param {string} type - The source type identifier.
+	 */
+	return applyFilters( 'jetpack.externalMedia.libraryComponent', component, type );
 }
 
 /**


### PR DESCRIPTION
## Summary

Adds a `jetpack.externalMedia.libraryComponent` filter that allows other plugins to replace the component rendered for a given external media source type.

## Use Case

This enables plugins like Image Studio in Calypso to replace Jetpack's "Generate with AI" modal with their own implementation. The filter is applied in `getExternalLibrary()` after resolving the default component.

**Example usage:**
```js
import { addFilter } from '@wordpress/hooks';

addFilter(
  'jetpack.externalMedia.libraryComponent',
  'my-plugin/custom-ai-generator',
  ( component, type ) => {
    if ( type === 'jetpack_ai_general_purpose_image_for_block' ) {
      return MyCustomAIGenerator;
    }
    return component;
  }
);
```

## Testing

1. Enable the external media dropdown on an image block
2. Verify "Generate with AI" works as before (no regression)
3. Add a filter hook to replace the component
4. Verify your custom component renders instead

## Changelog

- `packages/external-media`: Added `jetpack.externalMedia.libraryComponent` filter

---

Does this PR have anything to do with Jetpack AI or AI Assistant?
- [x] Yes
- [ ] No

Jetpack product  (focus area) this PR is associated with:
- [ ] My Jetpack
- [ ] Backup / Restore
- [ ] Boost
- [ ] CRM
- [ ] Dashboard
- [ ] Earn (Memberships/Subscribers, AdSense, Simple Payments/Pay With PayPal)
- [ ] AI Plugin / Experimental
- [x] Extras (Connection, Identity Crisis, Debugger)
- [ ] General (plugin listing, plugin card, new user experience, banners)
- [ ] Blaze / Newsletter (Jetpack Newsletter)
- [ ] Jetpack Search / Instant Search
- [ ] Masterbar / WP Admin Bar
- [ ] Marketplace (Jetpack Marketplace and/or Plugin Marketplace)
- [ ] Monitor
- [ ] Odyssey Stats
- [ ] VideoPress
- [ ] Plugin
- [ ] Protect
- [ ] Publicize / Sharing (Social Links, Meta, Tweetstorms)
- [ ] Related Posts
- [ ] Scan
- [ ] Search
- [ ] Social
- [ ] Social Media Icons
- [ ] SSO (Secure Auth, secure sign on)
- [ ] Subscriptions
- [ ] VaultPress
- [ ] WAF
- [ ] Widgets (All widgets in Jetpack)
- [ ] Jetpack Forms
- [ ] WordPress.com Toolbar
- [x] Other