### PR TITLE
Forms: Fix "Create a form" button in external admin contexts

### DIFF
--- a/projects/packages/forms/changelog/fix-create-form-external-admin
+++ b/projects/packages/forms/changelog/fix-create-form-external-admin
@@ -1,0 +1,3 @@
+Significance: patch
+Type: fixed
+Comment: Fix "Create a form" button in external admin contexts by using config-provided URLs instead of relying on window.ajaxurl and relative paths.

--- a/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
@@ -1518,6 +1518,9 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 			'exportNonce'                    => wp_create_nonce( 'feedback_export' ),
 			'newFormNonce'                   => wp_create_nonce( 'create_new_form' ),
 			'emptyTrashDays'                 => defined( 'EMPTY_TRASH_DAYS' ) ? EMPTY_TRASH_DAYS : 0,
+			// Admin URLs for external admin contexts.
+			'adminUrl'                       => admin_url(),
+			'ajaxUrl'                        => admin_url( 'admin-ajax.php' ),
 		);
 
 		return rest_ensure_response( $config );

--- a/projects/packages/forms/src/dashboard/hooks/use-create-form.ts
+++ b/projects/packages/forms/src/dashboard/hooks/use-create-form.ts
@@ -42,6 +42,8 @@ type CreateFormReturn = {
 export default function useCreateForm(): CreateFormReturn {
 	const newFormNonce = useConfigValue( 'newFormNonce' );
 	const isCentralFormManagementEnabled = useConfigValue( 'isCentralFormManagementEnabled' );
+	const adminUrl = useConfigValue( 'adminUrl' );
+	const ajaxUrl = useConfigValue( 'ajaxUrl' );
 	const createForm = useCallback(
 		async ( formPattern: string ) => {
 			const data = new FormData();
@@ -53,7 +55,9 @@ export default function useCreateForm(): CreateFormReturn {
 				data.append( 'pattern', formPattern );
 			}
 
-			const response = await fetch( window.ajaxurl, { method: 'POST', body: data } );
+			// Fall back to window.ajaxurl for backwards compatibility.
+			const fetchUrl = ajaxUrl || window.ajaxurl;
+			const response = await fetch( fetchUrl, { method: 'POST', body: data } );
 
 			const {
 				success,
@@ -67,7 +71,7 @@ export default function useCreateForm(): CreateFormReturn {
 
 			return postUrl;
 		},
-		[ newFormNonce ]
+		[ newFormNonce, ajaxUrl ]
 	);
 
 	const openNewForm = useCallback(
@@ -77,7 +81,8 @@ export default function useCreateForm(): CreateFormReturn {
 				// Keep existing behavior when disabled (or not yet loaded).
 				if ( isCentralFormManagementEnabled === true ) {
 					analyticsEvent?.( { formPattern: formPattern ?? '' } );
-					const url = 'post-new.php?post_type=jetpack_form';
+					// Use config adminUrl to build full URL for external admin contexts.
+					const url = `${ adminUrl || '' }post-new.php?post_type=jetpack_form`;
 					openFormLinkInNewTab( url );
 					return;
 				}
@@ -96,7 +101,7 @@ export default function useCreateForm(): CreateFormReturn {
 				console.error( error.message ); // eslint-disable-line no-console
 			}
 		},
-		[ createForm, isCentralFormManagementEnabled ]
+		[ createForm, isCentralFormManagementEnabled, adminUrl ]
 	);
 
 	return { createForm, openNewForm };

--- a/projects/packages/forms/src/types/index.ts
+++ b/projects/packages/forms/src/types/index.ts
@@ -312,4 +312,8 @@ export interface FormsConfigData {
 	newFormNonce?: string;
 	/** Number of days before WordPress permanently deletes trash. See https://developer.wordpress.org/advanced-administration/wordpress/wp-config/#empty-trash */
 	emptyTrashDays?: number;
+	/** The base admin URL for the site. */
+	adminUrl?: string;
+	/** The admin-ajax.php URL for the site. */
+	ajaxUrl?: string;
 }


### PR DESCRIPTION
Fixes FORMS-535

## Summary
- Adds `adminUrl` and `ajaxUrl` to the Forms config REST endpoint
- Updates `useCreateForm` hook to use config values instead of relying on `window.ajaxurl` and relative URLs
- Maintains backwards compatibility by falling back to previous behavior when config values aren't available

## Problem
The "Create a form" button in the wp-build dashboard was not working in external admin contexts because:
1. It relied on `window.ajaxurl` which is not defined outside standard wp-admin
2. It used relative URLs like `post-new.php?post_type=jetpack_form` which don't resolve correctly in external admin routing

## Solution
Expose `adminUrl` and `ajaxUrl` through the `/wp/v2/feedback/config` endpoint so the frontend can build proper absolute URLs regardless of the admin context.

## Test plan
- [x] Verify "Create a form" button works in standard wp-admin Forms dashboard
- [ ] Verify button works in external admin context (requires separate routing fix for the dashboard to load)

🤖 Generated with [Claude Code](https://claude.com/claude-code)