### PR TITLE
Adding some more meta fields to allow list

### DIFF
--- a/projects/packages/sync/changelog/add-wccom-product-meta-fields-to-allow-list
+++ b/projects/packages/sync/changelog/add-wccom-product-meta-fields-to-allow-list
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Search Sync Settings: Add some more meta fields for WooCommerce.com products to allow list
+Search Sync Settings: Add some more meta fields for WooCommerce.com products to allow list.

--- a/projects/packages/sync/changelog/add-wccom-product-meta-fields-to-allow-list
+++ b/projects/packages/sync/changelog/add-wccom-product-meta-fields-to-allow-list
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Search Sync Settings: Add some more meta fields for WooCommerce.com products to allow list

--- a/projects/packages/sync/src/modules/class-search.php
+++ b/projects/packages/sync/src/modules/class-search.php
@@ -442,6 +442,9 @@ class Search extends Module {
 		'_wc_general_product_dependency_plugin'  => array(),
 		'wpcom_marketplace_product_extra_fields' => array(),
 		'wccom_product_search_keywords'          => array( 'searchable_in_all_content' => true ),
+		'_wccom_product_faqs'                    => array( 'searchable_in_all_content' => true ),
+		'wccom_product_features'                 => array( 'searchable_in_all_content' => true ),
+		'wccom_product_compatibility'            => array( 'searchable_in_all_content' => true ),
 
 	); // end indexed post meta.
 


### PR DESCRIPTION
Related to 201086-ghe-Automattic/wpcom

We are adding some additional meta fields to Jetpack sync in order to improve Jetpack Search.

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
Visual inspection is fine
