### PR TITLE
Fix: Prevent agents manager from loading in iframe previews.

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-agents-manager-iframe-loading
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-agents-manager-iframe-loading
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Agents Manager: Prevents loading in previews.
+Agents Manager: Prevent loading in previews.

--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-agents-manager-iframe-loading
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-agents-manager-iframe-loading
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Agents Manager: Prevents loading in previews.

--- a/projects/packages/jetpack-mu-wpcom/src/features/agents-manager/class-agents-manager.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/agents-manager/class-agents-manager.php
@@ -227,6 +227,12 @@ class Agents_Manager {
 	 * Determine if the agents manager files should be enqueued.
 	 */
 	private function should_enqueue_script() {
+		// Don't load in iframe preview contexts (dashboard preview, theme preview, etc.)
+		// IFRAME_REQUEST is defined by Jetpack_Iframe_Embed when URL contains ?iframe=true&preview=true
+		if ( defined( 'IFRAME_REQUEST' ) && IFRAME_REQUEST ) {
+			return false;
+		}
+
 		if ( apply_filters( 'agents_manager_use_unified_experience', false ) ) {
 			return true;
 		}

--- a/projects/packages/jetpack-mu-wpcom/src/features/agents-manager/class-agents-manager.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/agents-manager/class-agents-manager.php
@@ -240,10 +240,10 @@ class Agents_Manager {
 
 		// Don't load during Gutenberg asset requests or in preview contexts.
 		// This matches the logic in Help_Center::init() to prevent excessive/unnecessary loading.
-		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Only checking for substring presence.
-		$request_uri = isset( $_SERVER['REQUEST_URI'] ) ? wp_unslash( $_SERVER['REQUEST_URI'] ) : '';
+		$request_uri = isset( $_SERVER['REQUEST_URI'] ) ? sanitize_text_field( wp_unslash( $_SERVER['REQUEST_URI'] ) ) : '';
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- This is a context check, not a form submission.
-		if ( str_contains( $request_uri, 'wp-content/plugins/gutenberg-core' ) || ( isset( $_GET['preview'] ) && 'true' === $_GET['preview'] ) ) {
+		$is_preview = isset( $_GET['preview'] ) && 'true' === sanitize_text_field( wp_unslash( $_GET['preview'] ) );
+		if ( str_contains( $request_uri, 'wp-content/plugins/gutenberg-core' ) || $is_preview ) {
 			return false;
 		}
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/agents-manager/class-agents-manager.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/agents-manager/class-agents-manager.php
@@ -227,9 +227,18 @@ class Agents_Manager {
 	 * Determine if the agents manager files should be enqueued.
 	 */
 	private function should_enqueue_script() {
-		// Don't load in iframe preview contexts (dashboard preview, theme preview, etc.)
-		// IFRAME_REQUEST is defined by Jetpack_Iframe_Embed when URL contains ?iframe=true&preview=true
-		if ( defined( 'IFRAME_REQUEST' ) && IFRAME_REQUEST ) {
+		// Don't load in customizer preview iframe - Help Center handles customizer separately
+		// via customize_controls_enqueue_scripts hook (loads only in controls panel, not preview).
+		if ( is_customize_preview() ) {
+			return false;
+		}
+
+		// Don't load during Gutenberg asset requests or in preview contexts.
+		// This matches the logic in Help_Center::init() to prevent excessive/unnecessary loading.
+		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Only checking for substring presence.
+		$request_uri = isset( $_SERVER['REQUEST_URI'] ) ? wp_unslash( $_SERVER['REQUEST_URI'] ) : '';
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- This is a context check, not a form submission.
+		if ( str_contains( $request_uri, 'wp-content/plugins/gutenberg-core' ) || ( isset( $_GET['preview'] ) && 'true' === $_GET['preview'] ) ) {
 			return false;
 		}
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/agents-manager/class-agents-manager.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/agents-manager/class-agents-manager.php
@@ -227,6 +227,11 @@ class Agents_Manager {
 	 * Determine if the agents manager files should be enqueued.
 	 */
 	private function should_enqueue_script() {
+		// Don't load on site frontend - only load in wp-admin.
+		if ( ! is_admin() ) {
+			return false;
+		}
+
 		// Don't load in customizer preview iframe - Help Center handles customizer separately
 		// via customize_controls_enqueue_scripts hook (loads only in controls panel, not preview).
 		if ( is_customize_preview() ) {

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/agents-manager/Agents_Manager_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/agents-manager/Agents_Manager_Test.php
@@ -35,9 +35,41 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 	/**
 	 * Set up test fixtures.
 	 */
+	/**
+	 * Original $_GET['preview'] value to restore after tests.
+	 *
+	 * @var mixed
+	 */
+	private $original_get_preview;
+
+	/**
+	 * Original $_SERVER['REQUEST_URI'] value to restore after tests.
+	 *
+	 * @var mixed
+	 */
+	private $original_request_uri;
+
+	/**
+	 * Original $wp_customize global value to restore after tests.
+	 *
+	 * @var mixed
+	 */
+	private $original_wp_customize;
+
+	/**
+	 * Set up test fixtures.
+	 */
 	public function set_up() {
 		parent::set_up();
 		$this->agents_manager = new Agents_Manager();
+
+		// Save original superglobal values that tests may modify.
+		$this->original_get_preview = $_GET['preview'] ?? null;
+		$this->original_request_uri = $_SERVER['REQUEST_URI'] ?? null;
+
+		// Save original $wp_customize global.
+		global $wp_customize;
+		$this->original_wp_customize = $wp_customize;
 	}
 
 	/**
@@ -51,6 +83,23 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 		remove_action( 'admin_enqueue_scripts', array( $this->agents_manager, 'enqueue_scripts' ), 101 );
 		remove_action( 'next_admin_init', array( $this->agents_manager, 'enqueue_scripts' ), 1001 );
 		remove_filter( 'agents_manager_use_unified_experience', array( $this->agents_manager, 'should_use_unified_experience' ) );
+
+		// Restore original superglobal values.
+		if ( $this->original_get_preview === null ) {
+			unset( $_GET['preview'] );
+		} else {
+			$_GET['preview'] = $this->original_get_preview;
+		}
+
+		if ( $this->original_request_uri === null ) {
+			unset( $_SERVER['REQUEST_URI'] );
+		} else {
+			$_SERVER['REQUEST_URI'] = $this->original_request_uri;
+		}
+
+		// Restore original $wp_customize global.
+		global $wp_customize;
+		$wp_customize = $this->original_wp_customize;
 
 		// Reset the REST server to clear any registered routes.
 		global $wp_rest_server;
@@ -1077,5 +1126,110 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 		$result = $this->call_is_dev_mode();
 
 		$this->assertTrue( $result );
+	}
+
+	/**
+	 * Helper to call the private should_enqueue_script method via reflection.
+	 *
+	 * @return bool The result of should_enqueue_script.
+	 */
+	private function call_should_enqueue_script() {
+		$reflection = new \ReflectionClass( Agents_Manager::class );
+		$method     = $reflection->getMethod( 'should_enqueue_script' );
+		if ( PHP_VERSION_ID < 80500 ) {
+			$method->setAccessible( true );
+		}
+		return $method->invoke( $this->agents_manager );
+	}
+
+	/**
+	 * Tests that should_enqueue_script returns false in customizer preview.
+	 *
+	 * The is_customize_preview() function checks global $wp_customize, so we set it up directly
+	 * rather than trying to stub the core WordPress function.
+	 */
+	public function test_should_enqueue_script_returns_false_in_customizer_preview() {
+		global $wp_customize;
+
+		// Load WP_Customize_Manager class if not already loaded.
+		require_once ABSPATH . WPINC . '/class-wp-customize-manager.php';
+
+		// Create a real WP_Customize_Manager instance.
+		$wp_customize = new \WP_Customize_Manager();
+
+		// Use reflection to set the protected $previewing property to true.
+		$reflection = new \ReflectionClass( $wp_customize );
+		$property   = $reflection->getProperty( 'previewing' );
+		if ( PHP_VERSION_ID < 80500 ) {
+			$property->setAccessible( true );
+		}
+		$property->setValue( $wp_customize, true );
+
+		$this->assertFalse( $this->call_should_enqueue_script() );
+	}
+
+	/**
+	 * Tests that should_enqueue_script returns false when preview=true query param is set.
+	 *
+	 * This prevents loading in dashboard site preview iframes, theme preview, and Calypso iframe embeds.
+	 */
+	public function test_should_enqueue_script_returns_false_when_preview_query_param_is_true() {
+		$_GET['preview'] = 'true';
+
+		$this->assertFalse( $this->call_should_enqueue_script() );
+	}
+
+	/**
+	 * Tests that should_enqueue_script returns false when URL contains gutenberg-core path.
+	 *
+	 * This prevents loading during Gutenberg asset requests.
+	 */
+	public function test_should_enqueue_script_returns_false_for_gutenberg_core_asset_requests() {
+		$_SERVER['REQUEST_URI'] = '/wp-content/plugins/gutenberg-core/build/block-library/style.css';
+
+		$this->assertFalse( $this->call_should_enqueue_script() );
+	}
+
+	/**
+	 * Tests that should_enqueue_script returns true when unified experience is enabled and not in preview context.
+	 */
+	public function test_should_enqueue_script_returns_true_when_unified_experience_enabled() {
+		$_SERVER['REQUEST_URI'] = '/wp-admin/index.php';
+
+		// Add a filter to enable unified experience.
+		add_filter(
+			'agents_manager_use_unified_experience',
+			'__return_true',
+			20
+		);
+
+		$result = $this->call_should_enqueue_script();
+
+		remove_filter( 'agents_manager_use_unified_experience', '__return_true', 20 );
+
+		$this->assertTrue( $result );
+	}
+
+	/**
+	 * Tests that should_enqueue_script returns false when preview=true even if unified experience is enabled.
+	 *
+	 * The preview check should take precedence over the unified experience filter.
+	 */
+	public function test_should_enqueue_script_preview_check_takes_precedence_over_unified_experience() {
+		$_SERVER['REQUEST_URI'] = '/wp-admin/index.php';
+		$_GET['preview']        = 'true';
+
+		// Add a filter to enable unified experience.
+		add_filter(
+			'agents_manager_use_unified_experience',
+			'__return_true',
+			20
+		);
+
+		$result = $this->call_should_enqueue_script();
+
+		remove_filter( 'agents_manager_use_unified_experience', '__return_true', 20 );
+
+		$this->assertFalse( $result );
 	}
 }

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/agents-manager/Agents_Manager_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/agents-manager/Agents_Manager_Test.php
@@ -33,9 +33,6 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 	private $agents_manager;
 
 	/**
-	 * Set up test fixtures.
-	 */
-	/**
 	 * Original $_GET['preview'] value to restore after tests.
 	 *
 	 * @var mixed

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/agents-manager/Agents_Manager_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/agents-manager/Agents_Manager_Test.php
@@ -57,6 +57,13 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 	private $original_wp_customize;
 
 	/**
+	 * Original current_screen global value to restore after tests.
+	 *
+	 * @var mixed
+	 */
+	private $original_current_screen;
+
+	/**
 	 * Set up test fixtures.
 	 */
 	public function set_up() {
@@ -70,6 +77,9 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 		// Save original $wp_customize global.
 		global $wp_customize;
 		$this->original_wp_customize = $wp_customize;
+
+		// Save original current_screen global.
+		$this->original_current_screen = $GLOBALS['current_screen'] ?? null;
 	}
 
 	/**
@@ -100,6 +110,13 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 		// Restore original $wp_customize global.
 		global $wp_customize;
 		$wp_customize = $this->original_wp_customize;
+
+		// Restore original current_screen global.
+		if ( $this->original_current_screen === null ) {
+			unset( $GLOBALS['current_screen'] );
+		} else {
+			$GLOBALS['current_screen'] = $this->original_current_screen;
+		}
 
 		// Reset the REST server to clear any registered routes.
 		global $wp_rest_server;
@@ -335,6 +352,10 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 	 * Tests that enqueue_scripts adds script with empty providers and useUnifiedExperience false by default.
 	 */
 	public function test_enqueue_scripts_with_empty_providers() {
+		// Set admin context - scripts only enqueue in admin.
+		require_once ABSPATH . 'wp-admin/includes/screen.php';
+		set_current_screen( 'dashboard' );
+
 		// Register the agents-manager script so we can attach inline script to it.
 		wp_register_script( 'agents-manager', 'https://example.com/agents-manager.js', array(), '1.0', true );
 
@@ -364,6 +385,10 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 	 * Tests that enqueue_scripts includes providers added via the filter.
 	 */
 	public function test_enqueue_scripts_includes_filtered_providers() {
+		// Set admin context - scripts only enqueue in admin.
+		require_once ABSPATH . 'wp-admin/includes/screen.php';
+		set_current_screen( 'dashboard' );
+
 		// Reset the script registry to ensure test isolation.
 		global $wp_scripts;
 		$wp_scripts = null;
@@ -408,6 +433,10 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 	 * Tests that enqueue_scripts includes useUnifiedExperience true when filter returns true.
 	 */
 	public function test_enqueue_scripts_includes_use_unified_experience_when_enabled() {
+		// Set admin context - scripts only enqueue in admin.
+		require_once ABSPATH . 'wp-admin/includes/screen.php';
+		set_current_screen( 'dashboard' );
+
 		// Reset the script registry to ensure test isolation.
 		global $wp_scripts;
 		$wp_scripts = null;
@@ -1143,6 +1172,23 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
+	 * Helper to simulate admin context for tests.
+	 */
+	private function set_admin_context() {
+		require_once ABSPATH . 'wp-admin/includes/screen.php';
+		set_current_screen( 'dashboard' );
+	}
+
+	/**
+	 * Tests that should_enqueue_script returns false on site frontend.
+	 */
+	public function test_should_enqueue_script_returns_false_on_frontend() {
+		// Ensure we're not in admin context (default state in tests).
+		$this->assertFalse( is_admin() );
+		$this->assertFalse( $this->call_should_enqueue_script() );
+	}
+
+	/**
 	 * Tests that should_enqueue_script returns false in customizer preview.
 	 *
 	 * The is_customize_preview() function checks global $wp_customize, so we set it up directly
@@ -1150,6 +1196,8 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 	 */
 	public function test_should_enqueue_script_returns_false_in_customizer_preview() {
 		global $wp_customize;
+
+		$this->set_admin_context();
 
 		// Load WP_Customize_Manager class if not already loaded.
 		require_once ABSPATH . WPINC . '/class-wp-customize-manager.php';
@@ -1174,6 +1222,7 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 	 * This prevents loading in dashboard site preview iframes, theme preview, and Calypso iframe embeds.
 	 */
 	public function test_should_enqueue_script_returns_false_when_preview_query_param_is_true() {
+		$this->set_admin_context();
 		$_GET['preview'] = 'true';
 
 		$this->assertFalse( $this->call_should_enqueue_script() );
@@ -1185,6 +1234,7 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 	 * This prevents loading during Gutenberg asset requests.
 	 */
 	public function test_should_enqueue_script_returns_false_for_gutenberg_core_asset_requests() {
+		$this->set_admin_context();
 		$_SERVER['REQUEST_URI'] = '/wp-content/plugins/gutenberg-core/build/block-library/style.css';
 
 		$this->assertFalse( $this->call_should_enqueue_script() );
@@ -1194,6 +1244,7 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 	 * Tests that should_enqueue_script returns true when unified experience is enabled and not in preview context.
 	 */
 	public function test_should_enqueue_script_returns_true_when_unified_experience_enabled() {
+		$this->set_admin_context();
 		$_SERVER['REQUEST_URI'] = '/wp-admin/index.php';
 
 		// Add a filter to enable unified experience.
@@ -1216,6 +1267,7 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 	 * The preview check should take precedence over the unified experience filter.
 	 */
 	public function test_should_enqueue_script_preview_check_takes_precedence_over_unified_experience() {
+		$this->set_admin_context();
 		$_SERVER['REQUEST_URI'] = '/wp-admin/index.php';
 		$_GET['preview']        = 'true';
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #DOTCOM-15814

## Proposed changes:

Prevents Agents Manager from loading in contexts where it shouldn't run, fixing JavaScript errors that occur when the script executes in preview iframes or on site frontends.

### Problem

Agents Manager was being loaded inside the dashboard site preview iframe, where `helpCenterData` is not available. This caused `ReferenceError: helpCenterData is not defined` errors in the console. The script was also loading on site frontends, which is unnecessary and could cause similar issues.

## Solution

Added multiple early-return checks in `should_enqueue_script()` to prevent loading in inappropriate contexts:

| Check | Why |
|-------|-----|
| `! is_admin()` | Agents Manager is only intended for wp-admin. Loading on frontend serves no purpose. |
| `is_customize_preview()` | Customizer preview URLs don't include `preview=true`, so need separate handling. Help Center handles this by only loading in the controls panel, not the preview iframe. |
| `preview=true` query param | All preview contexts (dashboard site preview, theme preview, Calypso iframe embeds) include this param. This matches the approach used by `Help_Center::init()`. |
| `gutenberg-core` URL check | Prevents loading during Gutenberg asset requests. Also matches Help Center's approach for consistency. |

### Why these specific checks?

Initially attempted to use the `IFRAME_REQUEST` constant, but discovered it's only defined when `iframe=true` is in the URL. The dashboard site preview uses `preview_overlay=true` instead, so `IFRAME_REQUEST` wasn't set. After investigating the wpcom codebase, found that Help Center uses a simpler `preview=true` check that covers all preview scenarios. Added `is_admin()` after discussion with @jom (p1769181161971589/1769179381.002779-slack-C9UMZ71QD) to ensure we don't load outside of the admin pages.

### Unit Tests Added

6 new tests for `should_enqueue_script()`:

- `test_should_enqueue_script_returns_false_on_frontend` - Verifies `is_admin()` check
- `test_should_enqueue_script_returns_false_in_customizer_preview` - Verifies `is_customize_preview()` check
- `test_should_enqueue_script_returns_false_when_preview_query_param_is_true` - Verifies `preview=true` check
- `test_should_enqueue_script_returns_false_for_gutenberg_core_asset_requests` - Verifies URL check
- `test_should_enqueue_script_returns_true_when_unified_experience_enabled` - Verifies normal operation
- `test_should_enqueue_script_preview_check_takes_precedence_over_unified_experience` - Verifies check priority

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No changes to tracking or data usage.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

### Prerequisites
- User must have "Unified Chat" enabled in wpcom profile (see pgatNH-1CI-p2)
- Must be accessing via proxy for unified experience to be active

### Simple Site Testing

⚠️  Sandbox your simple site, and make sure you load this PR in your sandbox following the steps in PCYsg-Osp-p2.

1. Dashboard site preview (main fix)
  - Go to https://wordpress.com/home/[your-simple-site]
  - The page shows a site preview iframe on the right
  - Open browser DevTools → Console
  - Expected: Unified chat experience is shown.
  - Expected: In Network tab, `agents-manager-wp-admin.min.js` should be loaded just once.
  - Alternatively: Navigate to [your-simple-ste]/?hide_banners=true&preview_overlay=true&preview=true and confirm `agents-manager-wp-admin.min.js` is not loaded in network tab.
2. Theme preview
  - Go to https://wordpress.com/themes/[your-simple-site]
  - Click "Preview with your content" on any theme
  - Open browser DevTools → Console
  - Expected: Unified chat experience is shown.
  - Expected: In Network tab, `agents-manager-wp-admin.min.js` should be loaded just once.
  - Alternatively: Similar to the previous one, check the iframe URL and open it directly. Shouldn't load `agents-manager-wp-admin.min.js`.
3. Customizer preview
  - Go to https://[your-simple-site].wordpress.com/wp-admin/customize.php
  - Open browser DevTools → Console
  - Expected: Unified chat will **not** be rendered because there is no admin element to hook into. (This might change in the future).
  - Expected: In Network tab, `agents-manager-wp-admin.min.js` should be loaded just once.
4. Normal wp-admin operation
  - Go to https://[your-simple-site].wordpress.com/wp-admin/
  - Expected: Unified chat experience is shown.
  - Expected: In Network tab, `agents-manager-wp-admin.min.js` should be loaded just once.
5. Site frontend
  - Go to https://[your-simple-site].wordpress.com/ (the public site, not wp-admin)
  - Open browser DevTools → Network tab
  - Expected: agents-manager-wp-admin.min.js should NOT be loaded

### Local Development (Jurassic Tube) Testing

Same tests and results than above but for `/wp-admin` and public site cases.