### PR TITLE
Social: Sync media to connections for per network customizations

### DIFF
--- a/projects/packages/publicize/_inc/components/customize-and-preview/index.tsx
+++ b/projects/packages/publicize/_inc/components/customize-and-preview/index.tsx
@@ -1,4 +1,5 @@
 import { useBreakpoint } from '@automattic/viewport-react';
+import { useSyncMediaToConnections } from '../../hooks/use-sync-media-to-connections';
 import { CustomizationToggle } from './customization-toggle';
 import styles from './styles.module.scss';
 import { TabPanelDesktop } from './tab-panels/desktop';
@@ -11,6 +12,9 @@ import { TabPanelMobile } from './tab-panels/mobile';
  */
 export function CustomizeAndPreview() {
 	const isSmallScreen = useBreakpoint( '<782px' );
+
+	// Sync media URLs (SIG, featured image) to connections when they change
+	useSyncMediaToConnections();
 
 	return (
 		<div className={ styles[ 'customize-and-preview' ] }>

--- a/projects/packages/publicize/_inc/hooks/use-image-generator-config/index.js
+++ b/projects/packages/publicize/_inc/hooks/use-image-generator-config/index.js
@@ -23,6 +23,7 @@ const getCurrentSettings = ( sigSettings, isPostPublished ) => ( {
  * @property {number}   imageId        - Optional. ID of the image in the generated image.
  * @property {string}   template       - Template for the generated image.
  * @property {string}   font           - Font for the image text.
+ * @property {string}   token          - The SIG token for generating the image URL.
  * @property {number}   defaultImageId - Optional. ID of the default image.
  * @property {Function} setIsEnabled   - Callback to enable or disable the image generator for a post.
  * @property {Function} updateProperty - Callback to update various SIG settings.

--- a/projects/packages/publicize/_inc/hooks/use-sync-media-to-connections/index.ts
+++ b/projects/packages/publicize/_inc/hooks/use-sync-media-to-connections/index.ts
@@ -1,0 +1,15 @@
+import { useSyncFeaturedImageToConnections } from './use-sync-featured-image-to-connections';
+import { useSyncSigToConnections } from './use-sync-sig-to-connections';
+
+/**
+ * Hook that syncs media URLs to connections based on their media source.
+ *
+ * When per-network customization is enabled, this hook updates the attached_media
+ * field for connections based on their media_source:
+ * - 'sig': Uses the SIG URL computed from the global token
+ * - 'featured-image': Uses the featured image URL from the post
+ */
+export function useSyncMediaToConnections() {
+	useSyncSigToConnections();
+	useSyncFeaturedImageToConnections();
+}

--- a/projects/packages/publicize/_inc/hooks/use-sync-media-to-connections/test/use-sync-featured-image-to-connections.test.ts
+++ b/projects/packages/publicize/_inc/hooks/use-sync-media-to-connections/test/use-sync-featured-image-to-connections.test.ts
@@ -1,0 +1,340 @@
+import { renderHook } from '@testing-library/react';
+import { useDispatch, useSelect } from '@wordpress/data';
+import * as scriptData from '../../../utils/script-data';
+import useFeaturedImage from '../../use-featured-image';
+import useMediaDetails from '../../use-media-details';
+import { usePerNetworkCustomization } from '../../use-per-network-customization';
+import { useSyncFeaturedImageToConnections } from '../use-sync-featured-image-to-connections';
+
+jest.mock( '@wordpress/data', () => {
+	const actual = jest.requireActual( '@wordpress/data' );
+	const mocks = {
+		useDispatch: jest.fn(),
+		useSelect: jest.fn(),
+	};
+	return new Proxy( actual, {
+		get( target, property ) {
+			return mocks[ property as keyof typeof mocks ] ?? target[ property as keyof typeof target ];
+		},
+	} );
+} );
+
+jest.mock( '../../../utils/script-data', () => ( {
+	hasSocialPaidFeatures: jest.fn(),
+} ) );
+
+jest.mock( '../../use-featured-image', () => ( {
+	__esModule: true,
+	default: jest.fn(),
+} ) );
+
+jest.mock( '../../use-media-details', () => ( {
+	__esModule: true,
+	default: jest.fn(),
+} ) );
+
+jest.mock( '../../use-per-network-customization', () => ( {
+	usePerNetworkCustomization: jest.fn(),
+} ) );
+
+jest.mock( '../../../social-store', () => ( {
+	store: 'jetpack-social-store',
+} ) );
+
+const mockUseDispatch = useDispatch as jest.MockedFunction< typeof useDispatch >;
+const mockUseSelect = useSelect as jest.MockedFunction< typeof useSelect >;
+const mockHasSocialPaidFeatures = scriptData.hasSocialPaidFeatures as jest.MockedFunction<
+	typeof scriptData.hasSocialPaidFeatures
+>;
+const mockUseFeaturedImage = useFeaturedImage as jest.MockedFunction< typeof useFeaturedImage >;
+const mockUseMediaDetails = useMediaDetails as jest.MockedFunction< typeof useMediaDetails >;
+const mockUsePerNetworkCustomization = usePerNetworkCustomization as jest.MockedFunction<
+	typeof usePerNetworkCustomization
+>;
+
+describe( 'useSyncFeaturedImageToConnections', () => {
+	const mockCustomizeConnectionById = jest.fn();
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+
+		mockUseDispatch.mockReturnValue( {
+			customizeConnectionById: mockCustomizeConnectionById,
+		} );
+
+		mockUsePerNetworkCustomization.mockReturnValue( {
+			isEnabled: true,
+			toggle: jest.fn(),
+		} );
+
+		mockUseFeaturedImage.mockReturnValue( 123 );
+
+		mockUseMediaDetails.mockReturnValue( [
+			{
+				mediaData: {
+					width: 1200,
+					height: 630,
+					sourceUrl: 'https://example.com/featured-image.jpg',
+				},
+				metaData: {
+					mime: 'image/jpeg',
+					fileSize: 12345,
+					length: 0,
+				},
+			},
+		] );
+
+		mockHasSocialPaidFeatures.mockReturnValue( true );
+	} );
+
+	it( 'should not sync when hasSocialPaidFeatures returns false', () => {
+		mockHasSocialPaidFeatures.mockReturnValue( false );
+
+		mockUseSelect.mockReturnValue( [
+			{
+				connection_id: '123',
+				media_source: 'featured-image',
+				attached_media: [],
+			},
+		] );
+
+		renderHook( () => useSyncFeaturedImageToConnections() );
+
+		expect( mockCustomizeConnectionById ).not.toHaveBeenCalled();
+	} );
+
+	it( 'should not sync when per-network customization is disabled', () => {
+		mockUsePerNetworkCustomization.mockReturnValue( {
+			isEnabled: false,
+			toggle: jest.fn(),
+		} );
+
+		mockUseSelect.mockReturnValue( [
+			{
+				connection_id: '123',
+				media_source: 'featured-image',
+				attached_media: [],
+			},
+		] );
+
+		renderHook( () => useSyncFeaturedImageToConnections() );
+
+		expect( mockCustomizeConnectionById ).not.toHaveBeenCalled();
+	} );
+
+	it( 'should not sync when featured image ID is not set', () => {
+		mockUseFeaturedImage.mockReturnValue( 0 );
+
+		mockUseSelect.mockReturnValue( [
+			{
+				connection_id: '123',
+				media_source: 'featured-image',
+				attached_media: [],
+			},
+		] );
+
+		renderHook( () => useSyncFeaturedImageToConnections() );
+
+		expect( mockCustomizeConnectionById ).not.toHaveBeenCalled();
+	} );
+
+	it( 'should not sync when featured image URL is not available', () => {
+		mockUseMediaDetails.mockReturnValue( [
+			{
+				mediaData: {
+					width: 1200,
+					height: 630,
+					sourceUrl: undefined,
+				},
+				metaData: {
+					mime: 'image/jpeg',
+					fileSize: 12345,
+					length: 0,
+				},
+			},
+		] );
+
+		mockUseSelect.mockReturnValue( [
+			{
+				connection_id: '123',
+				media_source: 'featured-image',
+				attached_media: [],
+			},
+		] );
+
+		renderHook( () => useSyncFeaturedImageToConnections() );
+
+		expect( mockCustomizeConnectionById ).not.toHaveBeenCalled();
+	} );
+
+	it( 'should sync featured image URL to connections with media_source === featured-image', () => {
+		mockUseSelect.mockReturnValue( [
+			{
+				connection_id: '123',
+				media_source: 'featured-image',
+				attached_media: [],
+			},
+		] );
+
+		renderHook( () => useSyncFeaturedImageToConnections() );
+
+		expect( mockCustomizeConnectionById ).toHaveBeenCalledWith(
+			'123',
+			{
+				attached_media: [
+					{ id: 123, url: 'https://example.com/featured-image.jpg', type: 'image/jpeg' },
+				],
+			},
+			true
+		);
+	} );
+
+	it( 'should not sync connections with different media_source', () => {
+		mockUseSelect.mockReturnValue( [
+			{
+				connection_id: '123',
+				media_source: 'sig',
+				attached_media: [],
+			},
+			{
+				connection_id: '456',
+				media_source: 'custom',
+				attached_media: [],
+			},
+		] );
+
+		renderHook( () => useSyncFeaturedImageToConnections() );
+
+		expect( mockCustomizeConnectionById ).not.toHaveBeenCalled();
+	} );
+
+	it( 'should not sync if URL is already up to date', () => {
+		mockUseSelect.mockReturnValue( [
+			{
+				connection_id: '123',
+				media_source: 'featured-image',
+				attached_media: [
+					{ id: 123, url: 'https://example.com/featured-image.jpg', type: 'image/jpeg' },
+				],
+			},
+		] );
+
+		renderHook( () => useSyncFeaturedImageToConnections() );
+
+		expect( mockCustomizeConnectionById ).not.toHaveBeenCalled();
+	} );
+
+	it( 'should use default mime type when not available', () => {
+		mockUseMediaDetails.mockReturnValue( [
+			{
+				mediaData: {
+					width: 1200,
+					height: 630,
+					sourceUrl: 'https://example.com/featured-image.jpg',
+				},
+				metaData: {} as { mime: string; fileSize: number; length: number },
+			},
+		] );
+
+		mockUseSelect.mockReturnValue( [
+			{
+				connection_id: '123',
+				media_source: 'featured-image',
+				attached_media: [],
+			},
+		] );
+
+		renderHook( () => useSyncFeaturedImageToConnections() );
+
+		expect( mockCustomizeConnectionById ).toHaveBeenCalledWith(
+			'123',
+			{
+				attached_media: [
+					{ id: 123, url: 'https://example.com/featured-image.jpg', type: 'image/jpeg' },
+				],
+			},
+			true
+		);
+	} );
+
+	it( 'should sync multiple connections with featured-image media_source', () => {
+		mockUseSelect.mockReturnValue( [
+			{
+				connection_id: '123',
+				media_source: 'featured-image',
+				attached_media: [],
+			},
+			{
+				connection_id: '456',
+				media_source: 'featured-image',
+				attached_media: [
+					{ id: 100, url: 'https://example.com/old-featured-image.jpg', type: 'image/jpeg' },
+				],
+			},
+			{
+				connection_id: '789',
+				media_source: 'sig',
+				attached_media: [],
+			},
+		] );
+
+		renderHook( () => useSyncFeaturedImageToConnections() );
+
+		expect( mockCustomizeConnectionById ).toHaveBeenCalledTimes( 2 );
+		expect( mockCustomizeConnectionById ).toHaveBeenCalledWith(
+			'123',
+			{
+				attached_media: [
+					{ id: 123, url: 'https://example.com/featured-image.jpg', type: 'image/jpeg' },
+				],
+			},
+			true
+		);
+		expect( mockCustomizeConnectionById ).toHaveBeenCalledWith(
+			'456',
+			{
+				attached_media: [
+					{ id: 123, url: 'https://example.com/featured-image.jpg', type: 'image/jpeg' },
+				],
+			},
+			true
+		);
+	} );
+
+	it( 'should use the correct mime type from media details', () => {
+		mockUseMediaDetails.mockReturnValue( [
+			{
+				mediaData: {
+					width: 1200,
+					height: 630,
+					sourceUrl: 'https://example.com/featured-image.png',
+				},
+				metaData: {
+					mime: 'image/png',
+					fileSize: 12345,
+					length: 0,
+				},
+			},
+		] );
+
+		mockUseSelect.mockReturnValue( [
+			{
+				connection_id: '123',
+				media_source: 'featured-image',
+				attached_media: [],
+			},
+		] );
+
+		renderHook( () => useSyncFeaturedImageToConnections() );
+
+		expect( mockCustomizeConnectionById ).toHaveBeenCalledWith(
+			'123',
+			{
+				attached_media: [
+					{ id: 123, url: 'https://example.com/featured-image.png', type: 'image/png' },
+				],
+			},
+			true
+		);
+	} );
+} );

--- a/projects/packages/publicize/_inc/hooks/use-sync-media-to-connections/test/use-sync-sig-to-connections.test.ts
+++ b/projects/packages/publicize/_inc/hooks/use-sync-media-to-connections/test/use-sync-sig-to-connections.test.ts
@@ -1,0 +1,253 @@
+import { renderHook } from '@testing-library/react';
+import { useDispatch, useSelect } from '@wordpress/data';
+import * as scriptData from '../../../utils/script-data';
+import useImageGeneratorConfig from '../../use-image-generator-config';
+import { usePerNetworkCustomization } from '../../use-per-network-customization';
+import { useSyncSigToConnections } from '../use-sync-sig-to-connections';
+
+jest.mock( '@wordpress/data', () => {
+	const actual = jest.requireActual( '@wordpress/data' );
+	const mocks = {
+		useDispatch: jest.fn(),
+		useSelect: jest.fn(),
+	};
+	return new Proxy( actual, {
+		get( target, property ) {
+			return mocks[ property as keyof typeof mocks ] ?? target[ property as keyof typeof target ];
+		},
+	} );
+} );
+
+jest.mock( '../../../utils/script-data', () => ( {
+	hasSocialPaidFeatures: jest.fn(),
+} ) );
+
+jest.mock( '../../use-image-generator-config', () => ( {
+	__esModule: true,
+	default: jest.fn(),
+} ) );
+
+jest.mock( '../../use-per-network-customization', () => ( {
+	usePerNetworkCustomization: jest.fn(),
+} ) );
+
+jest.mock( '../../use-sig-preview/utils', () => ( {
+	getSigImageUrl: jest.fn( ( token: string ) => `https://example.com/sig?t=${ token }` ),
+} ) );
+
+jest.mock( '../../../social-store', () => ( {
+	store: 'jetpack-social-store',
+} ) );
+
+const mockUseDispatch = useDispatch as jest.MockedFunction< typeof useDispatch >;
+const mockUseSelect = useSelect as jest.MockedFunction< typeof useSelect >;
+const mockHasSocialPaidFeatures = scriptData.hasSocialPaidFeatures as jest.MockedFunction<
+	typeof scriptData.hasSocialPaidFeatures
+>;
+const mockUseImageGeneratorConfig = useImageGeneratorConfig as jest.MockedFunction<
+	typeof useImageGeneratorConfig
+>;
+const mockUsePerNetworkCustomization = usePerNetworkCustomization as jest.MockedFunction<
+	typeof usePerNetworkCustomization
+>;
+
+describe( 'useSyncSigToConnections', () => {
+	const mockCustomizeConnectionById = jest.fn();
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+
+		mockUseDispatch.mockReturnValue( {
+			customizeConnectionById: mockCustomizeConnectionById,
+		} );
+
+		mockUsePerNetworkCustomization.mockReturnValue( {
+			isEnabled: true,
+			toggle: jest.fn(),
+		} );
+
+		mockUseImageGeneratorConfig.mockReturnValue( {
+			token: 'test-token',
+			isEnabled: true,
+			customText: '',
+			imageType: 'featured',
+			imageId: null,
+			template: 'default',
+			font: '',
+			defaultImageId: 0,
+			postSettings: [],
+			setToken: jest.fn(),
+			setIsEnabled: jest.fn(),
+			updateProperty: jest.fn(),
+			updateSettings: jest.fn(),
+		} );
+
+		mockHasSocialPaidFeatures.mockReturnValue( true );
+	} );
+
+	it( 'should not sync when hasSocialPaidFeatures returns false', () => {
+		mockHasSocialPaidFeatures.mockReturnValue( false );
+
+		mockUseSelect.mockReturnValue( [
+			{
+				connection_id: '123',
+				media_source: 'sig',
+				attached_media: [],
+			},
+		] );
+
+		renderHook( () => useSyncSigToConnections() );
+
+		expect( mockCustomizeConnectionById ).not.toHaveBeenCalled();
+	} );
+
+	it( 'should not sync when per-network customization is disabled', () => {
+		mockUsePerNetworkCustomization.mockReturnValue( {
+			isEnabled: false,
+			toggle: jest.fn(),
+		} );
+
+		mockUseSelect.mockReturnValue( [
+			{
+				connection_id: '123',
+				media_source: 'sig',
+				attached_media: [],
+			},
+		] );
+
+		renderHook( () => useSyncSigToConnections() );
+
+		expect( mockCustomizeConnectionById ).not.toHaveBeenCalled();
+	} );
+
+	it( 'should not sync when token is empty', () => {
+		mockUseImageGeneratorConfig.mockReturnValue( {
+			token: '',
+			isEnabled: true,
+			customText: '',
+			imageType: 'featured',
+			imageId: null,
+			template: 'default',
+			font: '',
+			defaultImageId: 0,
+			postSettings: [],
+			setToken: jest.fn(),
+			setIsEnabled: jest.fn(),
+			updateProperty: jest.fn(),
+			updateSettings: jest.fn(),
+		} );
+
+		mockUseSelect.mockReturnValue( [
+			{
+				connection_id: '123',
+				media_source: 'sig',
+				attached_media: [],
+			},
+		] );
+
+		renderHook( () => useSyncSigToConnections() );
+
+		expect( mockCustomizeConnectionById ).not.toHaveBeenCalled();
+	} );
+
+	it( 'should sync SIG URL to connections with media_source === sig', () => {
+		mockUseSelect.mockReturnValue( [
+			{
+				connection_id: '123',
+				media_source: 'sig',
+				attached_media: [],
+			},
+		] );
+
+		renderHook( () => useSyncSigToConnections() );
+
+		expect( mockCustomizeConnectionById ).toHaveBeenCalledWith(
+			'123',
+			{
+				attached_media: [
+					{ id: 0, url: 'https://example.com/sig?t=test-token', type: 'image/png' },
+				],
+			},
+			true
+		);
+	} );
+
+	it( 'should not sync connections with different media_source', () => {
+		mockUseSelect.mockReturnValue( [
+			{
+				connection_id: '123',
+				media_source: 'featured-image',
+				attached_media: [],
+			},
+			{
+				connection_id: '456',
+				media_source: 'custom',
+				attached_media: [],
+			},
+		] );
+
+		renderHook( () => useSyncSigToConnections() );
+
+		expect( mockCustomizeConnectionById ).not.toHaveBeenCalled();
+	} );
+
+	it( 'should not sync if URL is already up to date', () => {
+		mockUseSelect.mockReturnValue( [
+			{
+				connection_id: '123',
+				media_source: 'sig',
+				attached_media: [
+					{ id: 0, url: 'https://example.com/sig?t=test-token', type: 'image/png' },
+				],
+			},
+		] );
+
+		renderHook( () => useSyncSigToConnections() );
+
+		expect( mockCustomizeConnectionById ).not.toHaveBeenCalled();
+	} );
+
+	it( 'should sync multiple connections with sig media_source', () => {
+		mockUseSelect.mockReturnValue( [
+			{
+				connection_id: '123',
+				media_source: 'sig',
+				attached_media: [],
+			},
+			{
+				connection_id: '456',
+				media_source: 'sig',
+				attached_media: [
+					{ id: 0, url: 'https://example.com/sig?t=old-token', type: 'image/png' },
+				],
+			},
+			{
+				connection_id: '789',
+				media_source: 'featured-image',
+				attached_media: [],
+			},
+		] );
+
+		renderHook( () => useSyncSigToConnections() );
+
+		expect( mockCustomizeConnectionById ).toHaveBeenCalledTimes( 2 );
+		expect( mockCustomizeConnectionById ).toHaveBeenCalledWith(
+			'123',
+			{
+				attached_media: [
+					{ id: 0, url: 'https://example.com/sig?t=test-token', type: 'image/png' },
+				],
+			},
+			true
+		);
+		expect( mockCustomizeConnectionById ).toHaveBeenCalledWith(
+			'456',
+			{
+				attached_media: [
+					{ id: 0, url: 'https://example.com/sig?t=test-token', type: 'image/png' },
+				],
+			},
+			true
+		);
+	} );
+} );

--- a/projects/packages/publicize/_inc/hooks/use-sync-media-to-connections/use-sync-featured-image-to-connections.ts
+++ b/projects/packages/publicize/_inc/hooks/use-sync-media-to-connections/use-sync-featured-image-to-connections.ts
@@ -1,0 +1,65 @@
+import { useDispatch, useSelect } from '@wordpress/data';
+import { useEffect } from '@wordpress/element';
+import { store as socialStore } from '../../social-store';
+import { hasSocialPaidFeatures } from '../../utils/script-data';
+import useFeaturedImage from '../use-featured-image';
+import useMediaDetails from '../use-media-details';
+import { usePerNetworkCustomization } from '../use-per-network-customization';
+
+/**
+ * Hook that syncs the featured image URL to connections with media_source === 'featured-image'.
+ *
+ * When per-network customization is enabled and the featured image changes,
+ * this hook updates the attached_media field for all connections using featured image.
+ * Only runs when the site has social paid features.
+ */
+export function useSyncFeaturedImageToConnections() {
+	const { isEnabled: isPerNetworkEnabled } = usePerNetworkCustomization();
+	const { customizeConnectionById } = useDispatch( socialStore );
+
+	const connections = useSelect( select => select( socialStore ).getConnections(), [] );
+
+	// Get featured image details
+	const featuredImageId = useFeaturedImage();
+	const [ featuredImageDetails ] = useMediaDetails( featuredImageId );
+	const featuredImageUrl = featuredImageDetails?.mediaData?.sourceUrl;
+	const featuredImageMime = featuredImageDetails?.metaData?.mime ?? 'image/jpeg';
+
+	useEffect( () => {
+		if (
+			! hasSocialPaidFeatures() ||
+			! isPerNetworkEnabled ||
+			! featuredImageUrl ||
+			! featuredImageId
+		) {
+			return;
+		}
+
+		connections.forEach( connection => {
+			if ( connection.media_source !== 'featured-image' ) {
+				return;
+			}
+
+			const currentUrl = connection.attached_media?.[ 0 ]?.url;
+
+			if ( currentUrl !== featuredImageUrl ) {
+				customizeConnectionById(
+					connection.connection_id,
+					{
+						attached_media: [
+							{ id: featuredImageId, url: featuredImageUrl, type: featuredImageMime },
+						],
+					},
+					true
+				);
+			}
+		} );
+	}, [
+		isPerNetworkEnabled,
+		featuredImageId,
+		featuredImageUrl,
+		featuredImageMime,
+		connections,
+		customizeConnectionById,
+	] );
+}

--- a/projects/packages/publicize/_inc/hooks/use-sync-media-to-connections/use-sync-sig-to-connections.ts
+++ b/projects/packages/publicize/_inc/hooks/use-sync-media-to-connections/use-sync-sig-to-connections.ts
@@ -1,0 +1,48 @@
+import { useDispatch, useSelect } from '@wordpress/data';
+import { useEffect } from '@wordpress/element';
+import { store as socialStore } from '../../social-store';
+import { hasSocialPaidFeatures } from '../../utils/script-data';
+import useImageGeneratorConfig from '../use-image-generator-config';
+import { usePerNetworkCustomization } from '../use-per-network-customization';
+import { getSigImageUrl } from '../use-sig-preview/utils';
+
+/**
+ * Hook that syncs the SIG URL to connections with media_source === 'sig'.
+ *
+ * When per-network customization is enabled and the global SIG token changes,
+ * this hook updates the attached_media field for all connections using SIG.
+ * Only runs when the site has social paid features.
+ */
+export function useSyncSigToConnections() {
+	const { isEnabled: isPerNetworkEnabled } = usePerNetworkCustomization();
+	const { token } = useImageGeneratorConfig();
+	const { customizeConnectionById } = useDispatch( socialStore );
+
+	const connections = useSelect( select => select( socialStore ).getConnections(), [] );
+
+	useEffect( () => {
+		if ( ! hasSocialPaidFeatures() || ! isPerNetworkEnabled || ! token ) {
+			return;
+		}
+
+		const sigUrl = getSigImageUrl( token );
+
+		connections.forEach( connection => {
+			if ( connection.media_source !== 'sig' ) {
+				return;
+			}
+
+			const currentUrl = connection.attached_media?.[ 0 ]?.url;
+
+			if ( currentUrl !== sigUrl ) {
+				customizeConnectionById(
+					connection.connection_id,
+					{
+						attached_media: [ { id: 0, url: sigUrl, type: 'image/png' } ],
+					},
+					true
+				);
+			}
+		} );
+	}, [ isPerNetworkEnabled, token, connections, customizeConnectionById ] );
+}

--- a/projects/packages/publicize/changelog/update-social-sync-media-to-connections
+++ b/projects/packages/publicize/changelog/update-social-sync-media-to-connections
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Sync media to connections for per network customizations.


### PR DESCRIPTION
Related to SOCIAL-330

## Proposed changes:

This PR adds hooks to sync media URLs to social connections when per-network customization is enabled.

* Adds `useSyncSigToConnections` hook that syncs the Social Image Generator (SIG) URL to connections with `media_source === 'sig'` whenever the SIG token changes
* Adds `useSyncFeaturedImageToConnections` hook that syncs the featured image URL to connections with `media_source === 'featured-image'` whenever the featured image changes
* Creates a combined `useSyncMediaToConnections` hook that orchestrates both sync operations
* Integrates the sync hook into the `CustomizeAndPreview` component
* Both hooks are gated behind `hasSocialPaidFeatures()` to ensure they only run for paid users

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

* Go to a post editor with Jetpack Social enabled
* Enable per-network customization
* For SIG testing:
  * Select a connection and choose "Social Image Generator" as the media source
  * Modify the SIG settings (e.g., change template or text)
  * Run `wp.data.select('core/editor').getEditedPostAttribute('jetpack_publicize_connections')` in the browser console
  * Verify the connection's `attached_media` field contains the updated SIG URL
* For featured image testing:
  * Select a connection and choose "Featured image" as the media source
  * Change the post's featured image
  * Run `wp.data.select('core/editor').getEditedPostAttribute('jetpack_publicize_connections')` in the browser console
  * Verify the connection's `attached_media` field contains the updated featured image URL with correct ID and mime type
