### PR TITLE
Likes: enable CSS inlining

### DIFF
--- a/projects/plugins/jetpack/changelog/update-inline-jetpack-likes-css
+++ b/projects/plugins/jetpack/changelog/update-inline-jetpack-likes-css
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Likes: enable CSS inlining.

--- a/projects/plugins/jetpack/extensions/blocks/like/like.php
+++ b/projects/plugins/jetpack/extensions/blocks/like/like.php
@@ -77,11 +77,16 @@ function render_block( $attr, $content, $block ) {
 		add_action( 'wp_footer', 'jetpack_likes_master_iframe', 21 );
 	}
 
+	$style_path = null;
 	if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
-		$style_url  = content_url( 'mu-plugins/likes/jetpack-likes.css' );
+		$style_url = content_url( 'mu-plugins/likes/jetpack-likes.css' );
+		if ( defined( 'WP_CONTENT_DIR' ) && WP_CONTENT_DIR ) {
+			$style_path = WP_CONTENT_DIR . '/mu-plugins/likes/jetpack-likes.css';
+		}
 		$script_url = content_url( 'mu-plugins/likes/queuehandler.js' );
 	} else {
 		$style_url  = plugins_url( 'modules/likes/style.css', dirname( __DIR__, 2 ) );
+		$style_path = dirname( __DIR__, 3 ) . '/modules/likes/style.css';
 		$script_url = Assets::get_file_url_for_environment(
 			'_inc/build/likes/queuehandler.min.js',
 			'modules/likes/queuehandler.js'
@@ -98,6 +103,10 @@ function render_block( $attr, $content, $block ) {
 		)
 	);
 	wp_enqueue_style( 'jetpack_likes', $style_url, array(), JETPACK__VERSION );
+
+	if ( $style_path ) {
+		wp_style_add_data( 'jetpack_likes', 'path', $style_path );
+	}
 
 	$show_reblog_button = $attr['showReblogButton'] ?? false;
 	$show_avatars       = $attr['showAvatars'] ?? true;

--- a/projects/plugins/jetpack/modules/likes.php
+++ b/projects/plugins/jetpack/modules/likes.php
@@ -161,6 +161,7 @@ class Jetpack_Likes {
 	 */
 	public function load_styles_register_scripts() {
 		wp_enqueue_style( 'jetpack_likes', plugins_url( 'likes/style.css', __FILE__ ), array(), JETPACK__VERSION );
+		wp_style_add_data( 'jetpack_likes', 'path', plugin_dir_path( __FILE__ ) . 'likes/style.css' );
 		wp_register_script(
 			'jetpack_likes_queuehandler',
 			Assets::get_file_url_for_environment(


### PR DESCRIPTION
The Likes feature currently always loads its enqueued styles via an external resource. This PR adds path information to the enqueued styles, so that WP can opt into inlining the styles into the document.

## Proposed changes:
* Add path data to Likes CSS

### Other information:

- N/A Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [X] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
See #46671, which mentions this enhancement among other ideas.

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:

Please follow these instructions on both a Jetpack site and a wpcom site, to test both codepaths.

Block theme:
* Pick a block theme for your site.
* Disable the `Add Like buttons to your posts and pages` option in Jetpack Sharing settings.
* Create a post with a Like block, or using a template that has a Like block.
* Open the created post and ensure the Like button renders correctly.
* Ensure that the styles were inlined into the HTML document.
  * For a Jetpack site, look for a comment along the lines of `/*# sourceURL=<your_site>/wp-content/plugins/jetpack/modules/likes/style.css */`.
  * For a wpcom site, look for a comment along the lines of `/*# sourceURL=<your_site>/wp-content/mu-plugins/likes/jetpack-likes.css */`.

Classic theme:
* Pick a classic theme for your site.
* Enable the `Add Like buttons to your posts and pages` option in Jetpack Sharing settings.
* Create a post.
* Open the created post and ensure the Like button renders correctly.
* Ensure that the styles were inlined into the HTML document.
  * For a Jetpack site, look for a comment along the lines of `/*# sourceURL=<your_site>/wp-content/plugins/jetpack/modules/likes/style.css */`.
  * For a wpcom site, look for a comment along the lines of `/*# sourceURL=<your_site>/wp-content/mu-plugins/likes/jetpack-likes.css */`.