### PR TITLE
Forms: Load RTL specific CSS for the block

### DIFF
--- a/projects/packages/forms/changelog/update-forms-editor-rtl-css
+++ b/projects/packages/forms/changelog/update-forms-editor-rtl-css
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Load RTL specific CSS for the block.

--- a/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
+++ b/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
@@ -857,7 +857,7 @@ class Contact_Form_Block {
 				'in_footer'    => true,
 				'textdomain'   => 'jetpack-forms',
 				'enqueue'      => true,
-				'css_path'     => '../../../dist/blocks/editor.css',
+				'css_path'     => is_rtl() ? '../../../dist/blocks/editor.rtl.css' : '../../../dist/blocks/editor.css',
 			)
 		);
 

--- a/projects/plugins/jetpack/changelog/update-forms-editor-rtl-css
+++ b/projects/plugins/jetpack/changelog/update-forms-editor-rtl-css
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Forms: Load RTL specific CSS for the block.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Follow-up-to https://github.com/Automattic/jetpack/pull/46643

I noticed we're already generating the RTL version of CSS, but weren't actually using it.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Loads RTL specific CSS when editor is using RTL language.

<img width="1939" height="1110" alt="Screenshot 2026-01-23 at 17 31 58" src="https://github.com/user-attachments/assets/7e25faad-17a7-4260-bcf5-3ffad5920c17" />


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Change your WP language to Arabic, Hebrew or other right-to-left language.
* Everything works as expected.


<img width="687" height="520" alt="Screenshot 2026-01-23 at 17 29 28" src="https://github.com/user-attachments/assets/ec7cbd84-75d8-4dbc-96b7-f9447aa4c75f" />
<img width="1529" height="889" alt="Screenshot 2026-01-23 at 17 30 01" src="https://github.com/user-attachments/assets/058c9bf1-2a67-4683-982d-e20ad806b100" />
<img width="1530" height="1116" alt="Screenshot 2026-01-23 at 17 30 18" src="https://github.com/user-attachments/assets/bbf3d8f3-b41c-48de-9cad-1fc48df9be38" />
