### PR TITLE
Forms: exclude emojis from UI

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-exclude-emojis-from-ui
+++ b/projects/packages/forms/changelog/fix-forms-exclude-emojis-from-ui
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fixed
+
+Forms: don't let WP convert external links to emojis.

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/helpers/akismet.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/helpers/akismet.tsx
@@ -38,7 +38,7 @@ export function buildAkismetCard( {
 					"Add one-click spam protection for your forms with <a>Akismet</a>. Simply install the plugin and you're set.",
 					'jetpack-forms'
 				),
-				{ a: <ExternalLink href={ marketingUrl } /> }
+				{ a: <ExternalLink className="wp-exclude-emoji" href={ marketingUrl } /> }
 			),
 			notActivatedMessage: __(
 				'Akismet is installed. Just activate the plugin to start blocking spam.',
@@ -55,7 +55,7 @@ export function buildAkismetCard( {
 							'Akismet is active. There is one step left. Please add your <a>Akismet key</a>.',
 							'jetpack-forms'
 						),
-						{ a: <ExternalLink href={ settingsUrl } /> }
+						{ a: <ExternalLink className="wp-exclude-emoji" href={ settingsUrl } /> }
 					) }
 				</p>
 				<Button
@@ -79,7 +79,13 @@ export function buildAkismetCard( {
 							{ __( 'View spam', 'jetpack-forms' ) }
 						</Button>
 					) : (
-						<Button variant="link" href={ spamUrl } target="_blank" rel="noopener noreferrer">
+						<Button
+							className="wp-exclude-emoji"
+							variant="link"
+							href={ spamUrl }
+							target="_blank"
+							rel="noopener noreferrer"
+						>
 							{ __( 'View spam', 'jetpack-forms' ) }
 						</Button>
 					) }
@@ -88,7 +94,10 @@ export function buildAkismetCard( {
 						{ __( 'View stats and settings', 'jetpack-forms' ) }
 					</Button>
 					<span>|</span>
-					<ExternalLink href={ getRedirectUrl( 'akismet-jetpack-forms-docs' ) }>
+					<ExternalLink
+						className="wp-exclude-emoji"
+						href={ getRedirectUrl( 'akismet-jetpack-forms-docs' ) }
+					>
 						{ __( 'Learn about Akismet', 'jetpack-forms' ) }
 					</ExternalLink>
 				</HStack>

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/helpers/hostinger-reach.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/helpers/hostinger-reach.tsx
@@ -49,7 +49,14 @@ export function buildHostingerReachCard( {
 					'Add powerful email marketing to your forms with <a>Hostinger Reach</a>. Simply install the plugin to start sending emails.',
 					'jetpack-forms'
 				),
-				{ a: <ExternalLink href={ ( integration.marketingUrl as string ) || '' } /> }
+				{
+					a: (
+						<ExternalLink
+							className="wp-exclude-emoji"
+							href={ ( integration.marketingUrl as string ) || '' }
+						/>
+					),
+				}
 			),
 			notActivatedMessage: __(
 				'Hostinger Reach is installed. Just activate the plugin to start sending emails.',
@@ -61,7 +68,7 @@ export function buildHostingerReachCard( {
 		body: ! isConnected ? (
 			<>
 				<p className="integration-card__description">
-					<ExternalLink href={ settingsUrl }>
+					<ExternalLink className="wp-exclude-emoji" href={ settingsUrl }>
 						{ __(
 							'Hostinger Reach is active. There is one step left. Please complete Hostinger Reach setup.',
 							'jetpack-forms'
@@ -108,7 +115,7 @@ export function buildHostingerReachCard( {
 				) }
 				{ context === 'block-editor' && ConsentToggle && <ConsentToggle /> }
 				<p className="integration-card__description">
-					<ExternalLink href={ settingsUrl }>
+					<ExternalLink className="wp-exclude-emoji" href={ settingsUrl }>
 						{ __( 'View Hostinger Reach dashboard', 'jetpack-forms' ) }
 					</ExternalLink>
 				</p>

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/helpers/jetpack-crm.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/helpers/jetpack-crm.tsx
@@ -98,7 +98,7 @@ export function buildJetpackCrmCard( {
 				<p className="integration-card__description">
 					{ context === 'block-editor' ? connectedMsgEditor : connectedMsgDashboard }
 				</p>
-				<ExternalLink href={ settingsUrl }>
+				<ExternalLink className="wp-exclude-emoji" href={ settingsUrl }>
 					{ __( 'Open Jetpack CRM settings', 'jetpack-forms' ) }
 				</ExternalLink>
 			</div>
@@ -128,7 +128,7 @@ export function buildJetpackCrmCard( {
 					'You can save your form contacts in <a>Jetpack CRM</a>. To get started, please install the plugin.',
 					'jetpack-forms'
 				),
-				{ a: <ExternalLink href={ marketingUrl } /> }
+				{ a: <ExternalLink className="wp-exclude-emoji" href={ marketingUrl } /> }
 			),
 			notActivatedMessage: __(
 				'Jetpack CRM is installed. To start saving contacts, simply activate the plugin.',

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/helpers/mailpoet.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/helpers/mailpoet.tsx
@@ -59,7 +59,7 @@ export function buildMailPoetCard( {
 					'Add powerful email marketing to your forms with <a>MailPoet</a>. Simply install the plugin to start sending emails.',
 					'jetpack-forms'
 				),
-				{ a: <ExternalLink href={ marketingUrl } /> }
+				{ a: <ExternalLink className="wp-exclude-emoji" href={ marketingUrl } /> }
 			),
 			notActivatedMessage: __(
 				'MailPoet is installed. Just activate the plugin to start sending emails.',
@@ -76,7 +76,7 @@ export function buildMailPoetCard( {
 							'MailPoet is active. There is one step left. Please complete <a>MailPoet setup</a>.',
 							'jetpack-forms'
 						),
-						{ a: <ExternalLink href={ settingsUrl } /> }
+						{ a: <ExternalLink className="wp-exclude-emoji" href={ settingsUrl } /> }
 					) }
 				</p>
 				<HStack spacing="3" justify="start">
@@ -123,7 +123,7 @@ export function buildMailPoetCard( {
 					) ) }
 				{ context === 'block-editor' && ConsentToggle && <ConsentToggle /> }
 				<p className="integration-card__description">
-					<ExternalLink href={ settingsUrl }>
+					<ExternalLink className="wp-exclude-emoji" href={ settingsUrl }>
 						{ __( 'View MailPoet dashboard', 'jetpack-forms' ) }
 					</ExternalLink>
 				</p>

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/helpers/salesforce.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/helpers/salesforce.tsx
@@ -83,7 +83,10 @@ export function buildSalesforceCard( {
 						</HelpMessage>
 					) }
 					<p>
-						<ExternalLink href="https://help.salesforce.com/s/articleView?id=000325251&type=1">
+						<ExternalLink
+							className="wp-exclude-emoji"
+							href="https://help.salesforce.com/s/articleView?id=000325251&type=1"
+						>
 							{ __( 'Where to find your Salesforce Organization ID', 'jetpack-forms' ) }
 						</ExternalLink>
 					</p>

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/index.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/index.tsx
@@ -46,7 +46,7 @@ const IntegrationsModal = ( {
 			title={ __( 'Manage integrations', 'jetpack-forms' ) }
 			onRequestClose={ onClose }
 			size="large"
-			className="jetpack-forms-integrations-modal"
+			className="jetpack-forms-integrations-modal wp-exclude-emoji"
 		>
 			<VStack spacing="4">
 				<IntegrationsList

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/index.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/index.tsx
@@ -46,7 +46,7 @@ const IntegrationsModal = ( {
 			title={ __( 'Manage integrations', 'jetpack-forms' ) }
 			onRequestClose={ onClose }
 			size="large"
-			className="jetpack-forms-integrations-modal wp-exclude-emoji"
+			className="jetpack-forms-integrations-modal"
 		>
 			<VStack spacing="4">
 				<IntegrationsList

--- a/projects/packages/forms/src/blocks/contact-form/components/notifications-settings.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/notifications-settings.js
@@ -84,7 +84,7 @@ const NotificationsSettings = ( {
 							pushNotificationsLink: isWpcom ? (
 								<WpcomSupportLink supportLink={ wpcomSupportLink } />
 							) : (
-								<ExternalLink href={ jetpackSupportLink } className="wp-exclude-emoji" />
+								<ExternalLink className="wp-exclude-emoji" href={ jetpackSupportLink } />
 							),
 						}
 					) }

--- a/projects/packages/forms/src/blocks/contact-form/components/notifications-settings.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/notifications-settings.js
@@ -84,7 +84,7 @@ const NotificationsSettings = ( {
 							pushNotificationsLink: isWpcom ? (
 								<WpcomSupportLink supportLink={ wpcomSupportLink } />
 							) : (
-								<ExternalLink href={ jetpackSupportLink } />
+								<ExternalLink href={ jetpackSupportLink } className="wp-exclude-emoji" />
 							),
 						}
 					) }

--- a/projects/packages/forms/src/blocks/contact-form/edit.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/edit.tsx
@@ -1049,7 +1049,10 @@ function JetpackContactFormEdit( {
 						__next40pxDefaultSize={ true }
 					/>
 					<p>
-						<ExternalLink href="https://developer.mozilla.org/docs/Glossary/Accessible_name">
+						<ExternalLink
+							className="wp-exclude-emoji"
+							href="https://developer.mozilla.org/docs/Glossary/Accessible_name"
+						>
 							{ __( 'Read more.', 'jetpack-forms' ) }
 						</ExternalLink>
 					</p>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Stops WP from converting "↗" in ExternalLink component to emoji in some editor contexts.

A proper fix will be upstream somewhere, but this helps for now.
 
In the post/page editor context, this worked fine before already, just the site editor is the issue.

Exclusion class I found from here: https://github.com/WordPress/WordPress/blob/023c37a503f3cf67882dc9d2c44443ad4e2a6dc9/wp-includes/js/wp-emoji.js#L261C32-L261C48

Before

<img width="1503" height="1151" alt="Screenshot 2026-01-23 at 16 50 28" src="https://github.com/user-attachments/assets/c53cedef-35f9-471d-b55a-09df2b9d0f3c" />


After

<img width="272" height="276" alt="image" src="https://github.com/user-attachments/assets/e053a072-fe84-4d9c-8a6c-eb616abe38f4" />


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* In template editor, insert form.
* See that UI in integrations modal or block sidebar doesn't replace external icon arrow anymore

