### PR TITLE
Forms: allow hiding settings URL for integrations programmatically

### DIFF
--- a/projects/packages/forms/changelog/update-forms-integrations-hidden-settings
+++ b/projects/packages/forms/changelog/update-forms-integrations-hidden-settings
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Allow hiding settings URL for integrations.

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/helpers/akismet.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/helpers/akismet.tsx
@@ -84,10 +84,14 @@ export function buildAkismetCard( {
 						</Button>
 					) }
 					<span>|</span>
-					<Button variant="link" href={ settingsUrl } target="_blank" rel="noopener noreferrer">
-						{ __( 'View stats and settings', 'jetpack-forms' ) }
-					</Button>
-					<span>|</span>
+					{ settingsUrl && (
+						<>
+							<Button variant="link" href={ settingsUrl } target="_blank" rel="noopener noreferrer">
+								{ __( 'View stats and settings', 'jetpack-forms' ) }
+							</Button>
+							<span>|</span>
+						</>
+					) }
 					<ExternalLink href={ getRedirectUrl( 'akismet-jetpack-forms-docs' ) }>
 						{ __( 'Learn about Akismet', 'jetpack-forms' ) }
 					</ExternalLink>

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/helpers/hostinger-reach.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/helpers/hostinger-reach.tsx
@@ -107,11 +107,13 @@ export function buildHostingerReachCard( {
 					</div>
 				) }
 				{ context === 'block-editor' && ConsentToggle && <ConsentToggle /> }
-				<p className="integration-card__description">
-					<ExternalLink href={ settingsUrl }>
-						{ __( 'View Hostinger Reach dashboard', 'jetpack-forms' ) }
-					</ExternalLink>
-				</p>
+				{ settingsUrl && (
+					<p className="integration-card__description">
+						<ExternalLink href={ settingsUrl }>
+							{ __( 'View Hostinger Reach dashboard', 'jetpack-forms' ) }
+						</ExternalLink>
+					</p>
+				) }
 			</>
 		),
 	};

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/helpers/jetpack-crm.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/helpers/jetpack-crm.tsx
@@ -98,9 +98,11 @@ export function buildJetpackCrmCard( {
 				<p className="integration-card__description">
 					{ context === 'block-editor' ? connectedMsgEditor : connectedMsgDashboard }
 				</p>
-				<ExternalLink href={ settingsUrl }>
-					{ __( 'Open Jetpack CRM settings', 'jetpack-forms' ) }
-				</ExternalLink>
+				{ settingsUrl && (
+					<ExternalLink href={ settingsUrl }>
+						{ __( 'Open Jetpack CRM settings', 'jetpack-forms' ) }
+					</ExternalLink>
+				) }
 			</div>
 		);
 	};

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/helpers/mailpoet.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/helpers/mailpoet.tsx
@@ -122,11 +122,13 @@ export function buildMailPoetCard( {
 						</p>
 					) ) }
 				{ context === 'block-editor' && ConsentToggle && <ConsentToggle /> }
-				<p className="integration-card__description">
-					<ExternalLink href={ settingsUrl }>
-						{ __( 'View dashboard', 'jetpack-forms' ) }
-					</ExternalLink>
-				</p>
+				{ settingsUrl && (
+					<p className="integration-card__description">
+						<ExternalLink href={ settingsUrl }>
+							{ __( 'View dashboard', 'jetpack-forms' ) }
+						</ExternalLink>
+					</p>
+				) }
 			</div>
 		),
 	};

--- a/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
@@ -1334,9 +1334,7 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 				$user_id               = get_current_user_id();
 				$jetpack_connected     = ( new Host() )->is_wpcom_simple() || ( new Connection_Manager( 'jetpack-forms' ) )->is_user_connected( $user_id );
 				$status['isConnected'] = $jetpack_connected && Google_Drive::has_valid_connection();
-				if ( ( $config['settings_url'] ?? null ) !== false ) {
-					$status['settingsUrl'] = External_Connections::get_connect_url( $slug );
-				}
+				$status['settingsUrl'] = External_Connections::get_connect_url( $slug );
 				break;
 			case 'salesforce':
 				// No overrides needed for now; keep defaults.

--- a/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
@@ -1334,7 +1334,9 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 				$user_id               = get_current_user_id();
 				$jetpack_connected     = ( new Host() )->is_wpcom_simple() || ( new Connection_Manager( 'jetpack-forms' ) )->is_user_connected( $user_id );
 				$status['isConnected'] = $jetpack_connected && Google_Drive::has_valid_connection();
-				$status['settingsUrl'] = External_Connections::get_connect_url( $slug );
+				if ( ( $config['settings_url'] ?? null ) !== false ) {
+					$status['settingsUrl'] = External_Connections::get_connect_url( $slug );
+				}
 				break;
 			case 'salesforce':
 				// No overrides needed for now; keep defaults.
@@ -1369,7 +1371,9 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 		$status['isInstalled'] = $is_installed;
 		$status['isActive']    = $is_active;
 		$status['version']     = $is_installed ? $installed_plugins[ $plugin_config['file'] ]['Version'] : null;
-		$status['settingsUrl'] = $is_active ? admin_url( $plugin_config['settings_url'] ) : null;
+		$status['settingsUrl'] = ( $is_active && ! empty( $plugin_config['settings_url'] ) )
+			? admin_url( $plugin_config['settings_url'] )
+			: null;
 
 		// Override base shape for specific plugins.
 		switch ( $plugin_slug ) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Part of FORMS-547

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Doesn't show settings URL in UI when it's hidden programmatically.

Allows hiding settings entirely, e.g. Akismet:

```php
/**
 * Filter the list of supported integrations for Jetpack Forms.
 *
 * @param array $integrations Supported integrations.
 * @return array Filtered integrations.
 */
function my_filter_forms_integrations( $integrations ) {
	// Customize Akismet.
	if ( isset( $integrations['akismet'] ) ) {
		$integrations['mailpoet']['settings_url'] = '';
	}

	return $integrations;
}
add_filter( 'jetpack_forms_supported_integrations', 'my_filter_forms_integrations' );
```

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* See that in UI we hide the settings link when settings URL is empty

