### PR TITLE
 Forms: Add item click handler for DataViews on dashboards

### DIFF
--- a/projects/packages/forms/changelog/update-forms-click-item
+++ b/projects/packages/forms/changelog/update-forms-click-item
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Forms: Add item click handler for DataViews on dashboards

--- a/projects/packages/forms/routes/responses/stage.tsx
+++ b/projects/packages/forms/routes/responses/stage.tsx
@@ -185,7 +185,7 @@ function Stage() {
 	const searchParams = useSearch( { from: '/responses/$view' } );
 	const navigate = useNavigate();
 	const counts = useSelect(
-		select => ( select( dashboardStore ) as SelectActions ).getCounts(),
+		select => ( select( dashboardStore ) as unknown as SelectActions ).getCounts(),
 		[]
 	);
 
@@ -1052,6 +1052,13 @@ function Stage() {
 	// Check if read_status filter is applied
 	const readStatusFilter = view.filters?.find( filter => filter.field === 'read_status' )?.value;
 
+	const onClickItem = useCallback(
+		( item: unknown ) => {
+			onChangeSelection( [ String( ( item as { id: number | string } ).id ) ] );
+		},
+		[ onChangeSelection ]
+	);
+
 	return (
 		<WpRouteDashboardSearchParamsProvider from="/responses/$view">
 			<Page
@@ -1087,6 +1094,7 @@ function Stage() {
 					defaultLayouts={ defaultLayouts }
 					selection={ selection }
 					onChangeSelection={ onChangeSelection }
+					onClickItem={ onClickItem }
 					actions={ actions }
 				>
 					<Stack

--- a/projects/packages/forms/src/dashboard/inbox/stage/index.js
+++ b/projects/packages/forms/src/dashboard/inbox/stage/index.js
@@ -553,6 +553,13 @@ export default function InboxView() {
 		}
 	}, [ isMobileViewport, onChangeSelection, statusFilter ] );
 
+	const onClickItem = useCallback(
+		item => {
+			onChangeSelection( [ item.id.toString() ] );
+		},
+		[ onChangeSelection ]
+	);
+
 	const resetPage = useCallback( () => {
 		// Reset to page 1 when switching legacy Inbox statuses (Inbox/Spam/Trash).
 		setView( previousView => ( { ...previousView, page: 1 } ) );
@@ -605,6 +612,7 @@ export default function InboxView() {
 				onChangeView={ onChangeView }
 				selection={ selection }
 				onChangeSelection={ onChangeSelection }
+				onClickItem={ onClickItem }
 				getItemId={ getItemId }
 				defaultLayouts={ defaultLayouts }
 				empty={

--- a/projects/packages/forms/src/dashboard/inbox/style.scss
+++ b/projects/packages/forms/src/dashboard/inbox/style.scss
@@ -108,10 +108,6 @@
 	@include mixins.flex-center;
 	gap: 12px;
 	max-width: 100%;
-
-	&--mobile {
-		text-decoration: underline;
-	}
 }
 
 .jp-forms__inbox__author-info-container {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes FORMS-459

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Uses the `onClickItem` prop to handle item selection, given that the current click behavior was removed on DataViews 11.2
This does not match exactly the current implementation, and that is deliberate to better match the UI. Clicking on an item will always set this item as the only selected item.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

To see this after the change in DataViews, checkout https://github.com/Automattic/jetpack/pull/46430 and apply this PR's changes on top of it, but this is optional.

* Go to the responses dashboard
* Click on an item's "From" text
* Check that the item is selected
* Also check the wp-build dashboard for the same behavior

This does not apply for the forms dashboard, as there is no "View" action there at this point.