### PR TITLE
Sync: Stop syncing 'updating_jetpack_version' actions to WPCOM

### DIFF
--- a/projects/packages/sync/changelog/update-stop-syncing-updating_jetpack_version
+++ b/projects/packages/sync/changelog/update-stop-syncing-updating_jetpack_version
@@ -1,4 +1,4 @@
 Significance: minor
 Type: removed
 
-Stop syncing 'updating_jetpack_version' actions to WordPress.com
+Stop syncing `updating_jetpack_version` actions to WordPress.com.

--- a/projects/packages/sync/changelog/update-stop-syncing-updating_jetpack_version
+++ b/projects/packages/sync/changelog/update-stop-syncing-updating_jetpack_version
@@ -1,0 +1,4 @@
+Significance: minor
+Type: removed
+
+Stop syncing 'updating_jetpack_version' actions to WordPress.com

--- a/projects/packages/sync/src/class-listener.php
+++ b/projects/packages/sync/src/class-listener.php
@@ -92,9 +92,6 @@ class Listener {
 		add_action( 'jetpack_activate_module', $handler );
 		add_action( 'jetpack_deactivate_module', $handler );
 
-		// Jetpack Upgrade.
-		add_action( 'updating_jetpack_version', $handler, 10, 2 );
-
 		// Send periodic checksum.
 		add_action( 'jetpack_sync_checksum', $handler );
 	}

--- a/projects/plugins/jetpack/changelog/update-stop-syncing-updating_jetpack_version
+++ b/projects/plugins/jetpack/changelog/update-stop-syncing-updating_jetpack_version
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Updated Sync related unit tests
+
+

--- a/projects/plugins/jetpack/changelog/update-stop-syncing-updating_jetpack_version
+++ b/projects/plugins/jetpack/changelog/update-stop-syncing-updating_jetpack_version
@@ -1,5 +1,5 @@
 Significance: patch
 Type: other
-Comment: Updated Sync related unit tests
+Comment: Note that there are no user-facing changes; update Sync-related unit tests only.
 
 

--- a/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Integration_Test.php
+++ b/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Integration_Test.php
@@ -93,6 +93,16 @@ class Jetpack_Sync_Integration_Test extends Jetpack_Sync_TestBase {
 		$this->assertTrue( $full_sync_module->is_started() );
 	}
 
+	public function test_will_not_send_updating_jetpack_version_event() {
+		/** This action is documented in class.jetpack.php */
+		do_action( 'updating_jetpack_version', '4.3', '4.2.1' );
+
+		$this->sender->do_sync();
+
+		$event = $this->server_event_storage->get_most_recent_event( 'updating_jetpack_version' );
+		$this->assertFalse( '4.3', $event );
+	}
+
 	public function test_cleanup_old_cron_job_on_update() {
 		wp_schedule_event( time() + HOUR_IN_SECONDS, 'daily', 'jetpack_sync_send_db_checksum' );
 

--- a/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Integration_Test.php
+++ b/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Integration_Test.php
@@ -93,17 +93,6 @@ class Jetpack_Sync_Integration_Test extends Jetpack_Sync_TestBase {
 		$this->assertTrue( $full_sync_module->is_started() );
 	}
 
-	public function test_sends_updating_jetpack_version_event() {
-		/** This action is documented in class.jetpack.php */
-		do_action( 'updating_jetpack_version', '4.3', '4.2.1' );
-
-		$this->sender->do_sync();
-
-		$event = $this->server_event_storage->get_most_recent_event( 'updating_jetpack_version' );
-		$this->assertSame( '4.3', $event->args[0] );
-		$this->assertEquals( '4.2.1', $event->args[1] );
-	}
-
 	public function test_cleanup_old_cron_job_on_update() {
 		wp_schedule_event( time() + HOUR_IN_SECONDS, 'daily', 'jetpack_sync_send_db_checksum' );
 

--- a/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Integration_Test.php
+++ b/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Integration_Test.php
@@ -100,7 +100,7 @@ class Jetpack_Sync_Integration_Test extends Jetpack_Sync_TestBase {
 		$this->sender->do_sync();
 
 		$event = $this->server_event_storage->get_most_recent_event( 'updating_jetpack_version' );
-		$this->assertFalse( '4.3', $event );
+		$this->assertFalse( $event );
 	}
 
 	public function test_cleanup_old_cron_job_on_update() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Closes SYNC-225

Stop syncing `updating_jetpack_version` events to WordPress.com.
We are not processing this action, plus we already have the means to track JP plugin updates via the `JETPACK_VERSION` [constant we also sync](https://github.com/Automattic/jetpack/blob/trunk/projects/packages/sync/src/class-defaults.php#L289).
It also appears that there is a pattern with lag spikes on Atomic sites after the Jetpack updates (see linked issue), so it's possible that removing this action could be useful here.

It looks like it was added for no specific reason: https://github.com/Automattic/jetpack/pull/5064 

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* `Automattic\Jetpack\Sync\Listener`: Stop syncing `updating_jetpack_version` events to WordPress.com.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
SYNC-225

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Using the Jetpack Beta plugin confirm that `updating_jetpack_version` Sync action is not present when updating from latest Stable to current branch (opposed to updating from latest Stable to any other branch or Bleeding Edge)
* Code Review

