### PR TITLE
Forms: Display uploaded files with thumbnail preview on confirmation page

### DIFF
--- a/projects/packages/forms/changelog/add-forms-response-file-upload
+++ b/projects/packages/forms/changelog/add-forms-response-file-upload
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Forms: Display uploaded files with icon, filename link, and size on confirmation page.

--- a/projects/packages/forms/changelog/add-forms-response-file-upload
+++ b/projects/packages/forms/changelog/add-forms-response-file-upload
@@ -1,4 +1,4 @@
 Significance: patch
 Type: added
 
-Forms: Display uploaded files with icon, filename link, and size on confirmation page.
+Forms: Display uploaded files with icon, filename, and size on confirmation page.

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -1460,13 +1460,15 @@ class Contact_Form extends Contact_Form_Shortcode {
 		foreach ( $data as $field_data ) {
 			$url    = self::get_url( $field_data['value'] );
 			$images = self::get_images( $field_data['value'] );
+			$files  = self::get_files( $field_data['value'] );
 
 			$formatted_submission_data[] = array(
 				'label'          => self::maybe_add_colon_to_label( $field_data['label'] ),
 				'value'          => self::maybe_transform_value( $field_data['value'] ),
 				'images'         => $images,
 				'url'            => $url,
-				'showPlainValue' => empty( $url ) && empty( $images ),
+				'files'          => $files,
+				'showPlainValue' => empty( $url ) && empty( $images ) && empty( $files ),
 			);
 		}
 
@@ -1598,6 +1600,17 @@ class Contact_Form extends Contact_Form_Shortcode {
 								</div>
 							</template>
 						</div>
+						<div class="field-files" data-wp-bind--hidden="!context.submission.files">
+							<template data-wp-each--file="context.submission.files">
+								<div class="field-file">
+									<svg class="field-file__icon" width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+										<path d="M14 2H6C4.9 2 4 2.9 4 4V20C4 21.1 4.89 22 5.99 22H18C19.1 22 20 21.1 20 20V8L14 2ZM18 20H6V4H13V9H18V20Z" fill="currentColor"/>
+									</svg>
+									<a class="field-file__name" data-wp-bind--href="context.file.url" data-wp-text="context.file.name" target="_blank" rel="noopener noreferrer"></a>
+									<span class="field-file__size" data-wp-text="context.file.size"></span>
+								</div>
+							</template>
+						</div>
 					</div>
 				</template>';
 
@@ -1606,14 +1619,15 @@ class Contact_Form extends Contact_Form_Shortcode {
 				foreach ( $formatted_submission_data as $submission ) {
 					$has_url        = ! empty( $submission['url'] );
 					$has_images     = ! empty( $submission['images'] );
-					$show_plain_val = ! $has_url && ! $has_images;
+					$has_files      = ! empty( $submission['files'] );
+					$show_plain_val = ! $has_url && ! $has_images && ! $has_files;
 
 					$html .= '<div data-wp-each-child class="jetpack_forms_contact-form-success-summary">';
 
 					// field-name: always present.
 					$html .= '<div class="field-name" data-wp-text="context.submission.label" data-wp-bind--hidden="!context.submission.label">' . esc_html( $submission['label'] ) . '</div>';
 
-					// field-value: always present, hidden when URL or images exist.
+					// field-value: always present, hidden when URL, images, or files exist.
 					$html .= '<div class="field-value" data-wp-text="context.submission.value" data-wp-bind--hidden="!context.submission.showPlainValue"';
 					$html .= $show_plain_val ? '' : ' hidden';
 					$html .= '>' . ( $show_plain_val ? esc_html( $submission['value'] ) : '' ) . '</div>';
@@ -1649,7 +1663,35 @@ class Contact_Form extends Contact_Form_Shortcode {
 						$html .= '<template data-wp-each--image="context.submission.images"></template>';
 					}
 
-					$html .= '</div></div>'; // Close field-images and summary.
+					$html .= '</div>'; // Close field-images.
+
+					// field-files: always present, hidden when no files.
+					$html .= '<div class="field-files" data-wp-bind--hidden="!context.submission.files"';
+					$html .= $has_files ? '' : ' hidden';
+					$html .= '>';
+
+					if ( $has_files ) {
+						foreach ( $submission['files'] as $file ) {
+							$file_name = $file['name'] ?? '';
+							$file_size = $file['size'] ?? '';
+							$file_url  = $file['url'] ?? '';
+
+							$html .= '<div data-wp-each-child class="field-file">';
+							$html .= '<svg class="field-file__icon" width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">';
+							$html .= '<path d="M14 2H6C4.9 2 4 2.9 4 4V20C4 21.1 4.89 22 5.99 22H18C19.1 22 20 21.1 20 20V8L14 2ZM18 20H6V4H13V9H18V20Z" fill="currentColor"/>';
+							$html .= '</svg>';
+							$html .= '<a class="field-file__name" data-wp-bind--href="context.file.url" data-wp-text="context.file.name" target="_blank" rel="noopener noreferrer"';
+							$html .= ! empty( $file_url ) ? ' href="' . esc_attr( $file_url ) . '"' : '';
+							$html .= '>' . esc_html( $file_name ) . '</a>';
+							$html .= '<span class="field-file__size" data-wp-text="context.file.size">' . esc_html( $file_size ) . '</span>';
+							$html .= '</div>';
+						}
+					} else {
+						// Empty template for hydration when no files.
+						$html .= '<template data-wp-each--file="context.submission.files"></template>';
+					}
+
+					$html .= '</div></div>'; // Close field-files and summary.
 				}
 			}
 		}
@@ -3281,6 +3323,30 @@ class Contact_Form extends Contact_Form_Shortcode {
 					);
 				},
 				$value['choices']
+			);
+		}
+
+		return null;
+	}
+
+	/**
+	 * Get files from a file field value if present.
+	 *
+	 * @param mixed $value The field value.
+	 *
+	 * @return array|null Array of file data if this is a file field, null otherwise.
+	 */
+	private static function get_files( $value ) {
+		if ( is_array( $value ) && isset( $value['type'] ) && $value['type'] === 'file' && ! empty( $value['files'] ) ) {
+			return array_map(
+				function ( $file ) {
+					return array(
+						'name' => $file['name'] ?? __( 'Attached file', 'jetpack-forms' ),
+						'size' => $file['size'] ?? '',
+						'url'  => $file['url'] ?? '',
+					);
+				},
+				$value['files']
 			);
 		}
 

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -1604,7 +1604,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 							<template data-wp-each--file="context.submission.files">
 								<div class="field-file">
 									<div class="field-file__thumbnail" data-wp-style--background-image="context.file.previewUrl" data-wp-style--mask-image="context.file.iconUrl" data-wp-bind--hidden="!context.file.hasPreview"></div>
-									<svg class="field-file__icon" data-wp-bind--hidden="context.file.hasPreview" width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+									<svg class="field-file__icon" data-wp-bind--hidden="context.file.hasPreview" width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
 										<path d="M14 2H6C4.9 2 4 2.9 4 4V20C4 21.1 4.89 22 5.99 22H18C19.1 22 20 21.1 20 20V8L14 2ZM18 20H6V4H13V9H18V20Z" fill="currentColor"/>
 									</svg>
 									<span class="field-file__name" data-wp-text="context.file.name"></span>
@@ -1683,7 +1683,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 							$html .= $has_preview ? '' : ' hidden';
 							$html .= '></div>';
 							// SVG fallback for non-AJAX submissions
-							$html .= '<svg class="field-file__icon" data-wp-bind--hidden="context.file.hasPreview" width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"';
+							$html .= '<svg class="field-file__icon" data-wp-bind--hidden="context.file.hasPreview" width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"';
 							$html .= $has_preview ? ' hidden' : '';
 							$html .= '>';
 							$html .= '<path d="M14 2H6C4.9 2 4 2.9 4 4V20C4 21.1 4.89 22 5.99 22H18C19.1 22 20 21.1 20 20V8L14 2ZM18 20H6V4H13V9H18V20Z" fill="currentColor"/>';

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -1607,7 +1607,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 									<svg class="field-file__icon" data-wp-bind--hidden="context.file.hasPreview" width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
 										<path d="M14 2H6C4.9 2 4 2.9 4 4V20C4 21.1 4.89 22 5.99 22H18C19.1 22 20 21.1 20 20V8L14 2ZM18 20H6V4H13V9H18V20Z" fill="currentColor"/>
 									</svg>
-									<a class="field-file__name" data-wp-bind--href="context.file.url" data-wp-text="context.file.name" target="_blank" rel="noopener noreferrer"></a>
+									<span class="field-file__name" data-wp-text="context.file.name"></span>
 									<span class="field-file__size" data-wp-text="context.file.size"></span>
 								</div>
 							</template>
@@ -1675,7 +1675,6 @@ class Contact_Form extends Contact_Form_Shortcode {
 						foreach ( $submission['files'] as $file ) {
 							$file_name   = $file['name'] ?? '';
 							$file_size   = $file['size'] ?? '';
-							$file_url    = $file['url'] ?? '';
 							$has_preview = $file['hasPreview'] ?? false;
 
 							$html .= '<div data-wp-each-child class="field-file">';
@@ -1689,9 +1688,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 							$html .= '>';
 							$html .= '<path d="M14 2H6C4.9 2 4 2.9 4 4V20C4 21.1 4.89 22 5.99 22H18C19.1 22 20 21.1 20 20V8L14 2ZM18 20H6V4H13V9H18V20Z" fill="currentColor"/>';
 							$html .= '</svg>';
-							$html .= '<a class="field-file__name" data-wp-bind--href="context.file.url" data-wp-text="context.file.name" target="_blank" rel="noopener noreferrer"';
-							$html .= ! empty( $file_url ) ? ' href="' . esc_attr( $file_url ) . '"' : '';
-							$html .= '>' . esc_html( $file_name ) . '</a>';
+							$html .= '<span class="field-file__name" data-wp-text="context.file.name">' . esc_html( $file_name ) . '</span>';
 							$html .= '<span class="field-file__size" data-wp-text="context.file.size">' . esc_html( $file_size ) . '</span>';
 							$html .= '</div>';
 						}

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -1603,7 +1603,8 @@ class Contact_Form extends Contact_Form_Shortcode {
 						<div class="field-files" data-wp-bind--hidden="!context.submission.files">
 							<template data-wp-each--file="context.submission.files">
 								<div class="field-file">
-									<svg class="field-file__icon" width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+									<div class="field-file__thumbnail" data-wp-style--background-image="context.file.previewUrl" data-wp-style--mask-image="context.file.iconUrl" data-wp-bind--hidden="!context.file.hasPreview"></div>
+									<svg class="field-file__icon" data-wp-bind--hidden="context.file.hasPreview" width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
 										<path d="M14 2H6C4.9 2 4 2.9 4 4V20C4 21.1 4.89 22 5.99 22H18C19.1 22 20 21.1 20 20V8L14 2ZM18 20H6V4H13V9H18V20Z" fill="currentColor"/>
 									</svg>
 									<a class="field-file__name" data-wp-bind--href="context.file.url" data-wp-text="context.file.name" target="_blank" rel="noopener noreferrer"></a>
@@ -1672,12 +1673,20 @@ class Contact_Form extends Contact_Form_Shortcode {
 
 					if ( $has_files ) {
 						foreach ( $submission['files'] as $file ) {
-							$file_name = $file['name'] ?? '';
-							$file_size = $file['size'] ?? '';
-							$file_url  = $file['url'] ?? '';
+							$file_name   = $file['name'] ?? '';
+							$file_size   = $file['size'] ?? '';
+							$file_url    = $file['url'] ?? '';
+							$has_preview = $file['hasPreview'] ?? false;
 
 							$html .= '<div data-wp-each-child class="field-file">';
-							$html .= '<svg class="field-file__icon" width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">';
+							// Thumbnail for AJAX submissions (has preview data)
+							$html .= '<div class="field-file__thumbnail" data-wp-style--background-image="context.file.previewUrl" data-wp-style--mask-image="context.file.iconUrl" data-wp-bind--hidden="!context.file.hasPreview"';
+							$html .= $has_preview ? '' : ' hidden';
+							$html .= '></div>';
+							// SVG fallback for non-AJAX submissions
+							$html .= '<svg class="field-file__icon" data-wp-bind--hidden="context.file.hasPreview" width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"';
+							$html .= $has_preview ? ' hidden' : '';
+							$html .= '>';
 							$html .= '<path d="M14 2H6C4.9 2 4 2.9 4 4V20C4 21.1 4.89 22 5.99 22H18C19.1 22 20 21.1 20 20V8L14 2ZM18 20H6V4H13V9H18V20Z" fill="currentColor"/>';
 							$html .= '</svg>';
 							$html .= '<a class="field-file__name" data-wp-bind--href="context.file.url" data-wp-text="context.file.name" target="_blank" rel="noopener noreferrer"';
@@ -3340,10 +3349,19 @@ class Contact_Form extends Contact_Form_Shortcode {
 		if ( is_array( $value ) && isset( $value['type'] ) && $value['type'] === 'file' && ! empty( $value['files'] ) ) {
 			return array_map(
 				function ( $file ) {
+					$preview_url = $file['previewUrl'] ?? null;
+					$icon_url    = $file['iconUrl'] ?? null;
+					$has_preview = ! empty( $preview_url ) || ! empty( $icon_url );
+
 					return array(
-						'name' => $file['name'] ?? __( 'Attached file', 'jetpack-forms' ),
-						'size' => $file['size'] ?? '',
-						'url'  => $file['url'] ?? '',
+						'name'       => $file['name'] ?? __( 'Attached file', 'jetpack-forms' ),
+						'size'       => $file['size'] ?? '',
+						'url'        => $file['url'] ?? '',
+						// Preview URLs are captured from the DOM for AJAX submissions
+						'previewUrl' => $preview_url,
+						'iconUrl'    => $icon_url,
+						// Boolean flag for easier binding evaluation
+						'hasPreview' => $has_preview,
 					);
 				},
 				$value['files']

--- a/projects/packages/forms/src/contact-form/class-feedback-field.php
+++ b/projects/packages/forms/src/contact-form/class-feedback-field.php
@@ -216,6 +216,29 @@ class Feedback_Field {
 			}
 		}
 
+		// For file fields, return a structured array with file metadata for proper rendering.
+		if ( $this->is_of_type( 'file' ) ) {
+			$files = array();
+			if ( isset( $this->value['files'] ) && is_array( $this->value['files'] ) ) {
+				foreach ( $this->value['files'] as $file ) {
+					if ( ! isset( $file['size'] ) || ! isset( $file['file_id'] ) ) {
+						continue;
+					}
+					$file_id = absint( $file['file_id'] );
+					$files[] = array(
+						'file_id' => $file_id,
+						'name'    => $file['name'] ?? __( 'Attached file', 'jetpack-forms' ),
+						'size'    => size_format( $file['size'] ),
+						'url'     => apply_filters( 'jetpack_unauth_file_download_url', '', $file_id ),
+					);
+				}
+			}
+			return array(
+				'type'  => 'file',
+				'files' => $files,
+			);
+		}
+
 		return $this->get_render_default_value();
 	}
 

--- a/projects/packages/forms/src/contact-form/css/grunion.scss
+++ b/projects/packages/forms/src/contact-form/css/grunion.scss
@@ -392,12 +392,16 @@ that needs to mimic the input element styles */
 }
 
 .contact-form-submission .field-file {
-	display: flex;
-	align-items: center;
-	gap: 8px;
+	display: grid;
+	grid-template-columns: auto 1fr;
+	grid-template-rows: auto auto;
+	gap: 0 8px;
+	align-items: start;
 }
 
 .contact-form-submission .field-file__icon {
+	grid-row: span 2;
+	align-self: center;
 	flex-shrink: 0;
 	color: inherit;
 	opacity: 0.6;

--- a/projects/packages/forms/src/contact-form/css/grunion.scss
+++ b/projects/packages/forms/src/contact-form/css/grunion.scss
@@ -380,6 +380,46 @@ that needs to mimic the input element styles */
 	}
 }
 
+.contact-form-submission .field-files {
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+	margin-top: 8px;
+
+	&[hidden] {
+		display: none;
+	}
+}
+
+.contact-form-submission .field-file {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+}
+
+.contact-form-submission .field-file__icon {
+	flex-shrink: 0;
+	color: inherit;
+	opacity: 0.6;
+}
+
+.contact-form-submission .field-file__name {
+	color: inherit;
+	text-decoration: underline;
+	font-weight: 600;
+	font-size: 1rem;
+
+	&:hover {
+		text-decoration: none;
+	}
+}
+
+.contact-form-submission .field-file__size {
+	color: inherit;
+	opacity: 0.6;
+	font-size: 0.875rem;
+}
+
 .contact-form-submission .field-value {
 	margin-bottom: 0;
 	font-size: 1rem;

--- a/projects/packages/forms/src/contact-form/css/grunion.scss
+++ b/projects/packages/forms/src/contact-form/css/grunion.scss
@@ -402,14 +402,16 @@ that needs to mimic the input element styles */
 .contact-form-submission .field-file__thumbnail {
 	grid-row: span 2;
 	align-self: center;
-	width: 32px;
-	height: 32px;
-	border-radius: 4px;
+	width: 46px;
+	min-width: 46px;
+	height: 46px;
+	border-radius: 50%;
+	aspect-ratio: 1 / 1;
 	background-size: cover;
 	background-position: center;
 	background-repeat: no-repeat;
 	// For non-image files, use mask-image with the icon
-	mask-size: contain;
+	mask-size: auto;
 	mask-position: center;
 	mask-repeat: no-repeat;
 	background-color: currentColor;
@@ -433,13 +435,8 @@ that needs to mimic the input element styles */
 
 .contact-form-submission .field-file__name {
 	color: inherit;
-	text-decoration: underline;
 	font-weight: 600;
 	font-size: 1rem;
-
-	&:hover {
-		text-decoration: none;
-	}
 }
 
 .contact-form-submission .field-file__size {

--- a/projects/packages/forms/src/contact-form/css/grunion.scss
+++ b/projects/packages/forms/src/contact-form/css/grunion.scss
@@ -399,12 +399,36 @@ that needs to mimic the input element styles */
 	align-items: start;
 }
 
+.contact-form-submission .field-file__thumbnail {
+	grid-row: span 2;
+	align-self: center;
+	width: 32px;
+	height: 32px;
+	border-radius: 4px;
+	background-size: cover;
+	background-position: center;
+	background-repeat: no-repeat;
+	// For non-image files, use mask-image with the icon
+	mask-size: contain;
+	mask-position: center;
+	mask-repeat: no-repeat;
+	background-color: currentColor;
+
+	&[hidden] {
+		display: none;
+	}
+}
+
 .contact-form-submission .field-file__icon {
 	grid-row: span 2;
 	align-self: center;
 	flex-shrink: 0;
 	color: inherit;
 	opacity: 0.6;
+
+	&[hidden] {
+		display: none;
+	}
 }
 
 .contact-form-submission .field-file__name {

--- a/projects/packages/forms/src/modules/form/view.js
+++ b/projects/packages/forms/src/modules/form/view.js
@@ -229,6 +229,13 @@ const captureFilePreviews = formHash => {
 // Store for file previews captured before submission
 let capturedFilePreviews = new Map();
 
+/**
+ * Extract file data from a file field value for display on the confirmation page.
+ * Merges server response data with captured preview URLs (for AJAX submissions).
+ *
+ * @param {Object|null} value - The field value object, expected to have type 'file' and files array.
+ * @return {Array<{name: string, size: string, url: string, previewUrl: string|null, iconUrl: string|null, hasPreview: boolean}>|null} Array of file objects or null if not a file field.
+ */
 const getFiles = value => {
 	if ( value?.type === 'file' && value?.files ) {
 		return value.files.map( file => {

--- a/projects/packages/forms/src/modules/form/view.js
+++ b/projects/packages/forms/src/modules/form/view.js
@@ -630,6 +630,9 @@ const { state, actions } = store( NAMESPACE, {
 				}
 
 				context.isSubmitting = false;
+
+				// Clear captured previews to avoid memory leaks on repeated submissions
+				capturedFilePreviews.clear();
 			}
 		} ),
 

--- a/projects/packages/forms/src/modules/form/view.js
+++ b/projects/packages/forms/src/modules/form/view.js
@@ -182,13 +182,71 @@ const getUrl = value => {
 	return null;
 };
 
+/**
+ * Capture file preview data (thumbnail URLs and icons) from the DOM before form submission.
+ * This allows us to preserve the client-side preview for the confirmation page.
+ *
+ * @param {string} formHash - The form hash identifier.
+ * @return {Map<string, {previewUrl: string|null, iconUrl: string|null}>} Map of filename to preview data.
+ */
+const captureFilePreviews = formHash => {
+	const previews = new Map();
+	const form = document.getElementById( 'jp-form-' + formHash );
+
+	if ( ! form ) {
+		return previews;
+	}
+
+	// Find all file preview elements in the form
+	const filePreviewElements = form.querySelectorAll( '.jetpack-form-file-field__preview' );
+
+	filePreviewElements.forEach( preview => {
+		const nameElement = preview.querySelector( '.jetpack-form-file-field__file-name' );
+		const imageElement = preview.querySelector( '.jetpack-form-file-field__image' );
+
+		if ( nameElement && imageElement ) {
+			const fileName = nameElement.textContent?.trim();
+			const computedStyle = window.getComputedStyle( imageElement );
+
+			// Get the background-image (for image files) or mask-image (for non-image files)
+			const backgroundImage = computedStyle.backgroundImage;
+			const maskImage = computedStyle.maskImage || computedStyle.webkitMaskImage;
+
+			if ( fileName ) {
+				previews.set( fileName, {
+					// For images, the background-image contains the blob URL
+					previewUrl: backgroundImage && backgroundImage !== 'none' ? backgroundImage : null,
+					// For non-images, the mask-image contains the icon SVG URL
+					iconUrl: maskImage && maskImage !== 'none' ? maskImage : null,
+				} );
+			}
+		}
+	} );
+
+	return previews;
+};
+
+// Store for file previews captured before submission
+let capturedFilePreviews = new Map();
+
 const getFiles = value => {
 	if ( value?.type === 'file' && value?.files ) {
-		return value.files.map( file => ( {
-			name: file.name ?? '',
-			size: file.size ?? '',
-			url: file.url ?? '',
-		} ) );
+		return value.files.map( file => {
+			const fileName = file.name ?? '';
+			const preview = capturedFilePreviews.get( fileName );
+			const hasPreview = !! ( preview?.previewUrl || preview?.iconUrl );
+
+			return {
+				name: fileName,
+				size: file.size ?? '',
+				url: file.url ?? '',
+				// Include preview data if available (for AJAX submissions)
+				previewUrl: preview?.previewUrl ?? null,
+				iconUrl: preview?.iconUrl ?? null,
+				// Boolean flag for easier binding evaluation
+				hasPreview,
+			};
+		} );
 	}
 
 	return null;
@@ -532,6 +590,9 @@ const { state, actions } = store( NAMESPACE, {
 				event.preventDefault();
 				event.stopPropagation();
 				context.submissionError = null;
+
+				// Capture file preview URLs before submission (blob URLs for images, icon URLs for other files)
+				capturedFilePreviews = captureFilePreviews( context.formHash );
 
 				const { success, error, data, refreshArgs } = yield submitForm( context.formHash );
 

--- a/projects/packages/forms/src/modules/form/view.js
+++ b/projects/packages/forms/src/modules/form/view.js
@@ -52,13 +52,16 @@ const setSubmissionData = ( data = [] ) => {
 	context.formattedSubmissionData = data.map( item => {
 		const images = getImages( item.value );
 		const url = getUrl( item.value );
+		const files = getFiles( item.value );
 
 		return {
 			label: maybeAddColonToLabel( item.label ),
 			value: maybeTransformValue( item.value ),
 			images,
 			url,
-			showPlainValue: ! url && ( ! images || images.length === 0 ),
+			files,
+			showPlainValue:
+				! url && ( ! images || images.length === 0 ) && ( ! files || files.length === 0 ),
 		};
 	} );
 };
@@ -174,6 +177,18 @@ const getUrl = value => {
 		}
 
 		return url;
+	}
+
+	return null;
+};
+
+const getFiles = value => {
+	if ( value?.type === 'file' && value?.files ) {
+		return value.files.map( file => ( {
+			name: file.name ?? '',
+			size: file.size ?? '',
+			url: file.url ?? '',
+		} ) );
 	}
 
 	return null;

--- a/projects/packages/forms/tests/js/modules/form/view.test.js
+++ b/projects/packages/forms/tests/js/modules/form/view.test.js
@@ -1,4 +1,4 @@
-import { describe, expect, test } from '@jest/globals';
+import { beforeEach, describe, expect, test } from '@jest/globals';
 
 /**
  * Tests for the showPlainValue logic in form submission data formatting.
@@ -307,6 +307,178 @@ describe( 'Form View - getImages helper', () => {
 		// Third choice - showLabels false
 		expect( result[ 2 ].letterCode ).toBe( 'C' );
 		expect( result[ 2 ].label ).toBe( '' );
+	} );
+} );
+
+/**
+ * Tests for the getFiles helper function.
+ */
+describe( 'Form View - getFiles helper', () => {
+	// Mock the capturedFilePreviews Map for testing
+	const mockCapturedFilePreviews = new Map();
+
+	// Local getFiles implementation that uses the mock Map
+	const getFilesWithMock = value => {
+		if ( value?.type === 'file' && value?.files ) {
+			return value.files.map( file => {
+				const fileName = file.name ?? '';
+				const preview = mockCapturedFilePreviews.get( fileName );
+				const hasPreview = !! ( preview?.previewUrl || preview?.iconUrl );
+
+				return {
+					name: fileName,
+					size: file.size ?? '',
+					url: file.url ?? '',
+					previewUrl: preview?.previewUrl ?? null,
+					iconUrl: preview?.iconUrl ?? null,
+					hasPreview,
+				};
+			} );
+		}
+
+		return null;
+	};
+
+	beforeEach( () => {
+		mockCapturedFilePreviews.clear();
+	} );
+
+	test( 'returns null for plain text value', () => {
+		const result = getFilesWithMock( 'plain text' );
+		expect( result ).toBeNull();
+	} );
+
+	test( 'returns null for URL field value', () => {
+		const result = getFilesWithMock( { type: 'url', url: 'https://example.com' } );
+		expect( result ).toBeNull();
+	} );
+
+	test( 'returns null for image-select field value', () => {
+		const result = getFilesWithMock( {
+			type: 'image-select',
+			choices: [ { perceived: 'A' } ],
+		} );
+		expect( result ).toBeNull();
+	} );
+
+	test( 'extracts file data from file field value', () => {
+		const result = getFilesWithMock( {
+			type: 'file',
+			files: [
+				{
+					name: 'document.pdf',
+					size: '1.5 MB',
+					url: 'https://example.com/download/123',
+				},
+			],
+		} );
+
+		expect( result ).toHaveLength( 1 );
+		expect( result[ 0 ].name ).toBe( 'document.pdf' );
+		expect( result[ 0 ].size ).toBe( '1.5 MB' );
+		expect( result[ 0 ].url ).toBe( 'https://example.com/download/123' );
+		expect( result[ 0 ].hasPreview ).toBe( false );
+	} );
+
+	test( 'handles multiple files', () => {
+		const result = getFilesWithMock( {
+			type: 'file',
+			files: [
+				{ name: 'file1.pdf', size: '1 MB', url: 'https://example.com/1' },
+				{ name: 'file2.jpg', size: '2 MB', url: 'https://example.com/2' },
+				{ name: 'file3.doc', size: '500 KB', url: 'https://example.com/3' },
+			],
+		} );
+
+		expect( result ).toHaveLength( 3 );
+		expect( result[ 0 ].name ).toBe( 'file1.pdf' );
+		expect( result[ 1 ].name ).toBe( 'file2.jpg' );
+		expect( result[ 2 ].name ).toBe( 'file3.doc' );
+	} );
+
+	test( 'handles missing properties gracefully', () => {
+		const result = getFilesWithMock( {
+			type: 'file',
+			files: [ {} ],
+		} );
+
+		expect( result ).toHaveLength( 1 );
+		expect( result[ 0 ].name ).toBe( '' );
+		expect( result[ 0 ].size ).toBe( '' );
+		expect( result[ 0 ].url ).toBe( '' );
+	} );
+
+	test( 'returns empty array for empty files array', () => {
+		const result = getFilesWithMock( {
+			type: 'file',
+			files: [],
+		} );
+
+		expect( result ).toHaveLength( 0 );
+	} );
+
+	test( 'merges preview data when available', () => {
+		mockCapturedFilePreviews.set( 'photo.jpg', {
+			previewUrl: 'url(blob:http://localhost/abc123)',
+			iconUrl: null,
+		} );
+
+		const result = getFilesWithMock( {
+			type: 'file',
+			files: [
+				{
+					name: 'photo.jpg',
+					size: '500 KB',
+					url: 'https://example.com/download/photo',
+				},
+			],
+		} );
+
+		expect( result ).toHaveLength( 1 );
+		expect( result[ 0 ].previewUrl ).toBe( 'url(blob:http://localhost/abc123)' );
+		expect( result[ 0 ].iconUrl ).toBeNull();
+		expect( result[ 0 ].hasPreview ).toBe( true );
+	} );
+
+	test( 'sets hasPreview true when iconUrl is available', () => {
+		mockCapturedFilePreviews.set( 'document.pdf', {
+			previewUrl: null,
+			iconUrl: 'url(http://localhost/icons/pdf.svg)',
+		} );
+
+		const result = getFilesWithMock( {
+			type: 'file',
+			files: [
+				{
+					name: 'document.pdf',
+					size: '1 MB',
+					url: 'https://example.com/download/doc',
+				},
+			],
+		} );
+
+		expect( result ).toHaveLength( 1 );
+		expect( result[ 0 ].previewUrl ).toBeNull();
+		expect( result[ 0 ].iconUrl ).toBe( 'url(http://localhost/icons/pdf.svg)' );
+		expect( result[ 0 ].hasPreview ).toBe( true );
+	} );
+
+	test( 'sets hasPreview false when no preview data captured', () => {
+		const result = getFilesWithMock( {
+			type: 'file',
+			files: [
+				{
+					name: 'uncaptured.pdf',
+					size: '1 MB',
+					url: 'https://example.com/download/uncaptured',
+				},
+			],
+		} );
+
+		expect( result ).toHaveLength( 1 );
+		expect( result[ 0 ].previewUrl ).toBeNull();
+		expect( result[ 0 ].iconUrl ).toBeNull();
+		expect( result[ 0 ].hasPreview ).toBe( false );
 	} );
 } );
 


### PR DESCRIPTION
Fixes FORMS-510

## Proposed changes:

* Display uploaded files on the form submission confirmation page with:
  * File icon (generic document icon for non-images)
  * Thumbnail preview for image files (captured client-side using FileReader API)
  * Filename
  * File size in human-readable format (KB, MB)
* Client-side image preview approach avoids server-side permission restrictions
* Memory cleanup: clears captured previews after form submission

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

pbAPVF-4R2-p2

## Does this pull request change what data or activity we track or use?

No changes to tracking or data usage.

## Testing instructions:

1. Create a new post/page with a Jetpack Form block
2. Add a "File Upload" field to the form
3. Publish the post/page
4. Visit the published page and submit the form with:
   - An image file (jpg, png, gif, webp) - should show thumbnail preview
   - A non-image file (pdf, doc, etc.) - should show generic file icon
5. After submission, verify the confirmation page displays:
   - Thumbnail preview for image files (or generic icon for other files)
   - Filename
   - File size (e.g., "19 KB", "1.2 MB")
6. Submit another form to verify memory cleanup (no console errors)

**Before:**
<img width="642" height="275" alt="Screenshot 2026-01-27 at 10 29 12" src="https://github.com/user-attachments/assets/7ea88738-b6aa-4434-9992-f5c802292e35" />
Only filename and size

**After:**
<img width="646" height="290" alt="Screenshot 2026-01-27 at 10 28 23" src="https://github.com/user-attachments/assets/d8bbb3a1-d82d-42b8-8e20-f6471e0573aa" />

Files display with icon/thumbnail, filename, and size