### PR TITLE
Forms: Display phone numbers with country flags and international formatting

### DIFF
--- a/projects/packages/forms/changelog/add-forms-response-preview-formatted-phone-numbers
+++ b/projects/packages/forms/changelog/add-forms-response-preview-formatted-phone-numbers
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Response view: display phone numbers with country flags and international formatting.

--- a/projects/packages/forms/src/dashboard/components/response-view/field-phone/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/response-view/field-phone/index.tsx
@@ -32,6 +32,9 @@ const FieldPhone = ( { phone }: FieldPhoneProps ) => {
 	useEffect( () => {
 		let cancelled = false;
 
+		// Reset to raw phone value immediately when phone changes
+		setDisplayInfo( { formattedNumber: phone, countryCode: undefined } );
+
 		const formatPhone = async () => {
 			try {
 				const { parsePhoneNumber } = await import( 'libphonenumber-js' );

--- a/projects/packages/forms/src/dashboard/components/response-view/field-phone/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/response-view/field-phone/index.tsx
@@ -1,0 +1,75 @@
+/**
+ * WordPress dependencies
+ */
+import { useEffect, useState } from '@wordpress/element';
+/**
+ * Internal dependencies
+ */
+import Flag from '../../flag/index.tsx';
+
+type PhoneDisplayInfo = {
+	formattedNumber: string;
+	countryCode?: string;
+};
+
+type FieldPhoneProps = {
+	phone: string;
+};
+
+/**
+ * Renders a phone number with country flag and international formatting.
+ * The libphonenumber-js library is loaded asynchronously to avoid bloating the main bundle.
+ *
+ * @param {FieldPhoneProps} props       - Component props.
+ * @param {string}          props.phone - The phone number string to display.
+ * @return {JSX.Element} The rendered phone field.
+ */
+const FieldPhone = ( { phone }: FieldPhoneProps ) => {
+	const [ displayInfo, setDisplayInfo ] = useState< PhoneDisplayInfo >( {
+		formattedNumber: phone,
+	} );
+
+	useEffect( () => {
+		let cancelled = false;
+
+		const formatPhone = async () => {
+			try {
+				const { parsePhoneNumber } = await import( 'libphonenumber-js' );
+				if ( cancelled ) {
+					return;
+				}
+
+				const phoneNumber = parsePhoneNumber( phone );
+				if ( phoneNumber ) {
+					setDisplayInfo( {
+						formattedNumber: phoneNumber.formatInternational(),
+						countryCode: phoneNumber.country,
+					} );
+				}
+			} catch {
+				// Parsing failed, keep the original phone number
+			}
+		};
+
+		formatPhone();
+
+		return () => {
+			cancelled = true;
+		};
+	}, [ phone ] );
+
+	const { formattedNumber, countryCode } = displayInfo;
+
+	return (
+		<>
+			{ countryCode && (
+				<>
+					<Flag countryCode={ countryCode } />{ ' ' }
+				</>
+			) }
+			<a href={ `tel:${ phone }` }>{ formattedNumber }</a>
+		</>
+	);
+};
+
+export default FieldPhone;

--- a/projects/packages/forms/src/dashboard/components/response-view/field-preview/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/response-view/field-preview/index.tsx
@@ -8,7 +8,6 @@ import {
 	__experimentalHStack as HStack, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 	__experimentalVStack as VStack, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 } from '@wordpress/components';
-import parsePhoneNumber from 'libphonenumber-js';
 /**
  * Internal dependencies
  */
@@ -27,7 +26,6 @@ import RatingFieldIcon from '../../../../blocks/field-rating/icon.js';
 import SelectFieldIcon from '../../../../blocks/field-select/icon.js';
 import SingleChoiceFieldIcon from '../../../../blocks/field-single-choice/icon.js';
 import SliderFieldIcon from '../../../../blocks/field-slider/icon.js';
-import { countries } from '../../../../blocks/field-telephone/country-list.js';
 import TelephoneFieldIcon from '../../../../blocks/field-telephone/icon.js';
 import TextFieldIcon from '../../../../blocks/field-text/icon.js';
 import TextareaFieldIcon from '../../../../blocks/field-textarea/icon.js';
@@ -36,6 +34,7 @@ import UrlFieldIcon from '../../../../blocks/field-url/icon.js';
 import FieldEmail from '../field-email/index.tsx';
 import FieldFile from '../field-file/index.tsx';
 import FieldImageSelect from '../field-image-select/index.tsx';
+import FieldPhone from '../field-phone/index.tsx';
 import { EMAIL_REGEX, getIconSource, inferFieldTypeFromLabel } from './field-preview-utils.ts';
 import type { ResponseField, FieldType, FileItem } from '../../../../types/index.ts';
 import './style.scss';
@@ -163,18 +162,7 @@ const FieldPreview = ( { field, onFilePreview }: FieldPreviewProps ) => {
 
 		// Phone numbers
 		if ( fieldType === 'phone' || fieldType === 'telephone' ) {
-			const phoneNumber = parsePhoneNumber( stringValue );
-			const formattedNumber = phoneNumber?.formatInternational() ?? stringValue;
-			const countryCode = phoneNumber?.country;
-			const countryFlag = countryCode
-				? countries.find( c => c.code === countryCode )?.flag
-				: undefined;
-			return (
-				<>
-					{ countryFlag && `${ countryFlag } ` }
-					<a href={ `tel:${ stringValue }` }>{ formattedNumber }</a>
-				</>
-			);
+			return <FieldPhone phone={ stringValue } />;
 		}
 
 		if ( fieldType === 'url' && /^https?:\/\//.test( stringValue ) ) {

--- a/projects/packages/forms/src/dashboard/components/response-view/field-preview/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/response-view/field-preview/index.tsx
@@ -8,6 +8,7 @@ import {
 	__experimentalHStack as HStack, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 	__experimentalVStack as VStack, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 } from '@wordpress/components';
+import parsePhoneNumber from 'libphonenumber-js';
 /**
  * Internal dependencies
  */
@@ -26,6 +27,7 @@ import RatingFieldIcon from '../../../../blocks/field-rating/icon.js';
 import SelectFieldIcon from '../../../../blocks/field-select/icon.js';
 import SingleChoiceFieldIcon from '../../../../blocks/field-single-choice/icon.js';
 import SliderFieldIcon from '../../../../blocks/field-slider/icon.js';
+import { countries } from '../../../../blocks/field-telephone/country-list.js';
 import TelephoneFieldIcon from '../../../../blocks/field-telephone/icon.js';
 import TextFieldIcon from '../../../../blocks/field-text/icon.js';
 import TextareaFieldIcon from '../../../../blocks/field-textarea/icon.js';
@@ -161,7 +163,18 @@ const FieldPreview = ( { field, onFilePreview }: FieldPreviewProps ) => {
 
 		// Phone numbers
 		if ( fieldType === 'phone' || fieldType === 'telephone' ) {
-			return <a href={ `tel:${ stringValue }` }>{ stringValue }</a>;
+			const phoneNumber = parsePhoneNumber( stringValue );
+			const formattedNumber = phoneNumber?.formatInternational() ?? stringValue;
+			const countryCode = phoneNumber?.country;
+			const countryFlag = countryCode
+				? countries.find( c => c.code === countryCode )?.flag
+				: undefined;
+			return (
+				<>
+					{ countryFlag && `${ countryFlag } ` }
+					<a href={ `tel:${ stringValue }` }>{ formattedNumber }</a>
+				</>
+			);
 		}
 
 		if ( fieldType === 'url' && /^https?:\/\//.test( stringValue ) ) {

--- a/projects/packages/forms/tests/js/dashboard/components/response-view/field-phone/index.test.jsx
+++ b/projects/packages/forms/tests/js/dashboard/components/response-view/field-phone/index.test.jsx
@@ -1,0 +1,254 @@
+/**
+ * External dependencies
+ */
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { act, render, screen, waitFor } from '@testing-library/react';
+
+// Mock Flag component
+const mockFlag = jest.fn( ( { countryCode } ) => (
+	<span data-testid="flag" data-country={ countryCode }>
+		Flag: { countryCode }
+	</span>
+) );
+
+await jest.unstable_mockModule(
+	'../../../../../../src/dashboard/components/flag/index.tsx',
+	() => ( {
+		__esModule: true,
+		default: mockFlag,
+	} )
+);
+
+// Mock libphonenumber-js
+const mockParsePhoneNumber = jest.fn();
+
+await jest.unstable_mockModule( 'libphonenumber-js', () => ( {
+	__esModule: true,
+	parsePhoneNumber: mockParsePhoneNumber,
+} ) );
+
+// Import component after mocks are set up
+const { default: FieldPhone } = await import(
+	'../../../../../../src/dashboard/components/response-view/field-phone/index.tsx'
+);
+
+describe( 'FieldPhone', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	describe( 'Initial render', () => {
+		it( 'renders raw phone number immediately before async load completes', () => {
+			// Make parsePhoneNumber hang (never resolve) to test initial state
+			mockParsePhoneNumber.mockReturnValue( null );
+
+			render( <FieldPhone phone="+14155551234" /> );
+
+			const link = screen.getByRole( 'link' );
+			expect( link ).toHaveAttribute( 'href', 'tel:+14155551234' );
+			expect( link ).toHaveTextContent( '+14155551234' );
+		} );
+
+		it( 'renders tel: link with correct href', () => {
+			mockParsePhoneNumber.mockReturnValue( null );
+
+			render( <FieldPhone phone="+14155551234" /> );
+
+			const link = screen.getByRole( 'link' );
+			expect( link ).toHaveAttribute( 'href', 'tel:+14155551234' );
+		} );
+	} );
+
+	describe( 'Formatted display after async load', () => {
+		it( 'displays formatted international number after parsing', async () => {
+			mockParsePhoneNumber.mockReturnValue( {
+				formatInternational: () => '+1 415 555 1234',
+				country: 'US',
+			} );
+
+			render( <FieldPhone phone="+14155551234" /> );
+
+			await waitFor( () => {
+				const link = screen.getByRole( 'link' );
+				expect( link ).toHaveTextContent( '+1 415 555 1234' );
+			} );
+		} );
+
+		it( 'displays Flag component with correct country code', async () => {
+			mockParsePhoneNumber.mockReturnValue( {
+				formatInternational: () => '+1 415 555 1234',
+				country: 'US',
+			} );
+
+			render( <FieldPhone phone="+14155551234" /> );
+
+			await waitFor( () => {
+				const flag = screen.getByTestId( 'flag' );
+				expect( flag ).toHaveAttribute( 'data-country', 'US' );
+			} );
+		} );
+
+		it( 'does not display Flag when country cannot be determined', async () => {
+			mockParsePhoneNumber.mockReturnValue( {
+				formatInternational: () => '+14155551234',
+				country: undefined,
+			} );
+
+			render( <FieldPhone phone="+14155551234" /> );
+
+			await waitFor( () => {
+				const link = screen.getByRole( 'link' );
+				expect( link ).toHaveTextContent( '+14155551234' );
+			} );
+
+			expect( screen.queryByTestId( 'flag' ) ).not.toBeInTheDocument();
+		} );
+
+		it( 'keeps tel: href as raw phone value even when formatted', async () => {
+			mockParsePhoneNumber.mockReturnValue( {
+				formatInternational: () => '+1 415 555 1234',
+				country: 'US',
+			} );
+
+			render( <FieldPhone phone="+14155551234" /> );
+
+			const link = await screen.findByRole( 'link' );
+			await waitFor( () => {
+				expect( link ).toHaveTextContent( '+1 415 555 1234' );
+			} );
+			await waitFor( () => {
+				expect( link ).toHaveAttribute( 'href', 'tel:+14155551234' );
+			} );
+		} );
+	} );
+
+	describe( 'Failed parsing', () => {
+		it( 'displays raw phone number when parsing returns null', async () => {
+			mockParsePhoneNumber.mockReturnValue( null );
+
+			render( <FieldPhone phone="invalid-phone" /> );
+
+			// Wait a tick for the effect to run
+			await act( async () => {
+				await new Promise( resolve => setTimeout( resolve, 0 ) );
+			} );
+
+			const link = screen.getByRole( 'link' );
+			expect( link ).toHaveTextContent( 'invalid-phone' );
+			expect( link ).toHaveAttribute( 'href', 'tel:invalid-phone' );
+		} );
+
+		it( 'displays raw phone number when parsing throws', async () => {
+			mockParsePhoneNumber.mockImplementation( () => {
+				throw new Error( 'Invalid phone' );
+			} );
+
+			render( <FieldPhone phone="not-a-phone" /> );
+
+			// Wait a tick for the effect to run
+			await act( async () => {
+				await new Promise( resolve => setTimeout( resolve, 0 ) );
+			} );
+
+			const link = screen.getByRole( 'link' );
+			expect( link ).toHaveTextContent( 'not-a-phone' );
+			expect( link ).toHaveAttribute( 'href', 'tel:not-a-phone' );
+		} );
+	} );
+
+	describe( 'Phone prop changes', () => {
+		it( 'resets display when phone prop changes to unparseable value', async () => {
+			// First render with valid phone
+			mockParsePhoneNumber.mockReturnValue( {
+				formatInternational: () => '+1 415 555 1234',
+				country: 'US',
+			} );
+
+			const { rerender } = render( <FieldPhone phone="+14155551234" /> );
+
+			await waitFor( () => {
+				expect( screen.getByRole( 'link' ) ).toHaveTextContent( '+1 415 555 1234' );
+				expect( screen.getByTestId( 'flag' ) ).toBeInTheDocument();
+			} );
+
+			// Change to unparseable phone
+			mockParsePhoneNumber.mockReturnValue( null );
+
+			rerender( <FieldPhone phone="12345" /> );
+
+			const link = await screen.findByRole( 'link' );
+			// Should immediately show new raw phone, not old formatted one
+			await waitFor( () => {
+				expect( link ).toHaveTextContent( '12345' );
+			} );
+			await waitFor( () => {
+				expect( link ).toHaveAttribute( 'href', 'tel:12345' );
+			} );
+
+			// Flag should be gone
+			expect( screen.queryByTestId( 'flag' ) ).not.toBeInTheDocument();
+		} );
+
+		it( 'updates display when phone prop changes to different valid number', async () => {
+			// First render with US phone
+			mockParsePhoneNumber.mockReturnValue( {
+				formatInternational: () => '+1 415 555 1234',
+				country: 'US',
+			} );
+
+			const { rerender } = render( <FieldPhone phone="+14155551234" /> );
+
+			await waitFor( () => {
+				expect( screen.getByRole( 'link' ) ).toHaveTextContent( '+1 415 555 1234' );
+				expect( screen.getByTestId( 'flag' ) ).toHaveAttribute( 'data-country', 'US' );
+			} );
+
+			// Change to UK phone
+			mockParsePhoneNumber.mockReturnValue( {
+				formatInternational: () => '+44 20 7946 0958',
+				country: 'GB',
+			} );
+
+			rerender( <FieldPhone phone="+442079460958" /> );
+
+			const link = await screen.findByRole( 'link' );
+			await waitFor( () => {
+				expect( link ).toHaveTextContent( '+44 20 7946 0958' );
+				expect( screen.getByTestId( 'flag' ) ).toHaveAttribute( 'data-country', 'GB' );
+			} );
+			await waitFor( () => {
+				expect( link ).toHaveAttribute( 'href', 'tel:+442079460958' );
+			} );
+		} );
+	} );
+
+	describe( 'Various phone formats', () => {
+		it( 'handles phone numbers with country code', async () => {
+			mockParsePhoneNumber.mockReturnValue( {
+				formatInternational: () => '+33 1 23 45 67 89',
+				country: 'FR',
+			} );
+
+			render( <FieldPhone phone="+33123456789" /> );
+
+			await waitFor( () => {
+				expect( screen.getByRole( 'link' ) ).toHaveTextContent( '+33 1 23 45 67 89' );
+				expect( screen.getByTestId( 'flag' ) ).toHaveAttribute( 'data-country', 'FR' );
+			} );
+		} );
+
+		it( 'handles local phone numbers without formatting', async () => {
+			mockParsePhoneNumber.mockReturnValue( null );
+
+			render( <FieldPhone phone="555-1234" /> );
+
+			await act( async () => {
+				await new Promise( resolve => setTimeout( resolve, 0 ) );
+			} );
+
+			const link = screen.getByRole( 'link' );
+			expect( link ).toHaveTextContent( '555-1234' );
+			expect( link ).toHaveAttribute( 'href', 'tel:555-1234' );
+		} );
+	} );
+} );


### PR DESCRIPTION
Follow up to #46706 

Part of FORMS-524

## Proposed changes

- Display phone numbers with country flags (emoji) in the Forms response view
- Format phone numbers using international format (e.g., `+1 555 123 4567` instead of raw input)
- Reuse the same `libphonenumber-js` library already used in the frontend phone field input

<img width="426" height="594" alt="image" src="https://github.com/user-attachments/assets/236857a5-f91b-480b-9b87-7a07a22ca807" />

## Jetpack product discussion
8TmDfrB54NU4Rzj19Qs9Tg-fi-4935_76204

## Does this pull request change what data or activity we track or use?
No

### Build size impact

The `libphonenumber-js` library is loaded asynchronously via dynamic import to minimize impact on the main bundle:

| Build | Main Bundle | Async Chunk | Difference vs Trunk |
|-------|-------------|-------------|---------------------|
| **Trunk** (no phone formatting) | 2,396 KB | - | - |
| **Branch** (async import) | 2,419 KB | 120 KB | +23 KB main bundle |

The main dashboard bundle only increases by ~23 KB. The ~120 KB `libphonenumber-js` library loads on-demand in a separate chunk only when viewing a response with a phone field.

## Testing instructions

1. Create a form with a phone/telephone field
2. Submit a response with an international phone number (e.g., `+14155551234`)
3. Go to the Forms dashboard and view the response
4. Verify the phone number displays with:
   - Country flag emoji (e.g., 🇺🇸)
   - International formatting (e.g., `+1 415 555 1234`)
   - Clickable `tel:` link