### PR TITLE
Site Switcher: fix partial keyword matching in command palette

### DIFF
--- a/projects/plugins/jetpack/_inc/site-switcher.js
+++ b/projects/plugins/jetpack/_inc/site-switcher.js
@@ -173,16 +173,22 @@ function useSiteSwitcherCommandLoader( { search } ) {
 		} );
 		cleanedSearch = cleanedSearch.trim().replace( /\s+/g, ' ' );
 
-		// If search is empty after stripping generic keywords, show all sites
-		const filteredSites = ! cleanedSearch
-			? sites
-			: sites.filter( site => {
-					const domain = getHostnameFromURL( site.URL );
-					return (
-						( site.name && site.name.toLowerCase().includes( cleanedSearch ) ) ||
-						domain.toLowerCase().includes( cleanedSearch )
-					);
-			  } );
+		// Check if the search is a prefix of any generic keyword (e.g., "swit" matches "switch")
+		// If so, treat it as a generic search and show all sites
+		const isGenericKeywordPrefix =
+			cleanedSearch && genericKeywords.some( keyword => keyword.startsWith( cleanedSearch ) );
+
+		// If search is empty after stripping generic keywords, or is a prefix of a generic keyword, show all sites
+		const filteredSites =
+			! cleanedSearch || isGenericKeywordPrefix
+				? sites
+				: sites.filter( site => {
+						const domain = getHostnameFromURL( site.URL );
+						return (
+							( site.name && site.name.toLowerCase().includes( cleanedSearch ) ) ||
+							domain.toLowerCase().includes( cleanedSearch )
+						);
+				  } );
 
 		// Filter out sites with invalid URLs (can't navigate to them anyway)
 		const validSites = filteredSites.filter( site => {

--- a/projects/plugins/jetpack/changelog/edi-245-typing-swit-doesnt-yield-results-from-the-site-switcher
+++ b/projects/plugins/jetpack/changelog/edi-245-typing-swit-doesnt-yield-results-from-the-site-switcher
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Site Switcher: fix partial keyword matching so typing 'swit' shows 'Switch to...' results in the command palette.


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/EDI-245/

## Proposed changes:
* Fix partial keyword matching so typing "swit" shows "Switch to..." results in the command palette

When users typed partial generic keywords like "swit" (prefix of "switch"), the site switcher returned no results because it only stripped exact keyword matches before filtering sites.

This fix adds a check for whether the search term is a prefix of any generic keyword. If so, it treats the search as generic and shows all sites, allowing the command palette to display the matching commands.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
https://linear.app/a8c/issue/EDI-245/

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

* Ensure you have multiple WordPress.com connected sites
* Go to any wp-admin page on a Jetpack-connected site running WordPress 6.9+
* Press ⌘+K (or Ctrl+K) to open the command palette
* Type "swit"
* **Expected:** "Switch to..." results should appear for your other sites
* **Before fix:** Only "Go to: Settings > Writing" appeared