### PR TITLE
Forms: add single form screen

### DIFF
--- a/projects/packages/forms/changelog/add-single-form-screen
+++ b/projects/packages/forms/changelog/add-single-form-screen
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Forms: add single form screen.

--- a/projects/packages/forms/src/dashboard/components/back-to-forms-button/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/back-to-forms-button/index.tsx
@@ -5,9 +5,6 @@ import { Button } from '@wordpress/components';
 import { useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 /**
- * External dependencies
- */
-/**
  * Internal dependencies
  */
 import useConfigValue from '../../../hooks/use-config-value.ts';

--- a/projects/packages/forms/src/dashboard/components/back-to-forms-button/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/back-to-forms-button/index.tsx
@@ -4,11 +4,11 @@
 import { Button } from '@wordpress/components';
 import { useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { useNavigate } from 'react-router';
 /**
  * Internal dependencies
  */
 import useConfigValue from '../../../hooks/use-config-value.ts';
-import { PARTIAL_RESPONSES_PATH } from '../../../util/get-preferred-responses-view.js';
 
 /**
  * Primary action to return to the Forms list.
@@ -17,17 +17,16 @@ import { PARTIAL_RESPONSES_PATH } from '../../../util/get-preferred-responses-vi
  */
 export default function BackToFormsButton(): JSX.Element {
 	const isCentralFormManagementEnabled = useConfigValue( 'isCentralFormManagementEnabled' );
+	const navigate = useNavigate();
 	// Avoid conditional translation calls: define strings unconditionally, then select.
 	const backToFormsLabel = __( 'Back to forms', 'jetpack-forms' );
 	const viewAllResponsesLabel = __( 'View all responses', 'jetpack-forms' );
 	const label = isCentralFormManagementEnabled === true ? backToFormsLabel : viewAllResponsesLabel;
 
 	const onClick = useCallback( () => {
-		// Go to the base Forms dashboard URL (no hash). This will land on:
-		// - Forms list when CFM is enabled
-		// - All Responses when CFM is disabled
-		window.location.href = PARTIAL_RESPONSES_PATH;
-	}, [] );
+		// Use the dashboard router (no full page reload).
+		navigate( isCentralFormManagementEnabled === true ? '/forms' : '/responses' );
+	}, [ isCentralFormManagementEnabled, navigate ] );
 
 	return (
 		<Button size="compact" variant="primary" onClick={ onClick }>

--- a/projects/packages/forms/src/dashboard/components/back-to-forms-button/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/back-to-forms-button/index.tsx
@@ -10,6 +10,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
+import useConfigValue from '../../../hooks/use-config-value.ts';
 import { PARTIAL_RESPONSES_PATH } from '../../../util/get-preferred-responses-view.js';
 
 /**
@@ -18,16 +19,22 @@ import { PARTIAL_RESPONSES_PATH } from '../../../util/get-preferred-responses-vi
  * @return {JSX.Element} Button component.
  */
 export default function BackToFormsButton(): JSX.Element {
+	const isCentralFormManagementEnabled = useConfigValue( 'isCentralFormManagementEnabled' );
+	const label =
+		isCentralFormManagementEnabled === true
+			? __( 'Back to Forms', 'jetpack-forms' )
+			: __( 'View all responses', 'jetpack-forms' );
+
 	const onClick = useCallback( () => {
 		// Go to the base Forms dashboard URL (no hash). This will land on:
 		// - Forms list when CFM is enabled
-		// - Responses inbox when CFM is disabled
+		// - All Responses when CFM is disabled
 		window.location.href = PARTIAL_RESPONSES_PATH;
 	}, [] );
 
 	return (
 		<Button size="compact" variant="primary" onClick={ onClick }>
-			{ __( 'Back to forms', 'jetpack-forms' ) }
+			{ label }
 		</Button>
 	);
 }

--- a/projects/packages/forms/src/dashboard/components/back-to-forms-button/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/back-to-forms-button/index.tsx
@@ -1,5 +1,5 @@
 /**
- * WordPress dependencies
+ * External dependencies
  */
 import { Button } from '@wordpress/components';
 import { useCallback } from '@wordpress/element';

--- a/projects/packages/forms/src/dashboard/components/back-to-forms-button/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/back-to-forms-button/index.tsx
@@ -1,0 +1,33 @@
+/**
+ * WordPress dependencies
+ */
+import { Button } from '@wordpress/components';
+import { useCallback } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+/**
+ * External dependencies
+ */
+/**
+ * Internal dependencies
+ */
+import { PARTIAL_RESPONSES_PATH } from '../../../util/get-preferred-responses-view.js';
+
+/**
+ * Primary action to return to the Forms list.
+ *
+ * @return {JSX.Element} Button component.
+ */
+export default function BackToFormsButton(): JSX.Element {
+	const onClick = useCallback( () => {
+		// Go to the base Forms dashboard URL (no hash). This will land on:
+		// - Forms list when CFM is enabled
+		// - Responses inbox when CFM is disabled
+		window.location.href = PARTIAL_RESPONSES_PATH;
+	}, [] );
+
+	return (
+		<Button size="compact" variant="primary" onClick={ onClick }>
+			{ __( 'Back to Forms', 'jetpack-forms' ) }
+		</Button>
+	);
+}

--- a/projects/packages/forms/src/dashboard/components/back-to-forms-button/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/back-to-forms-button/index.tsx
@@ -20,10 +20,10 @@ import { PARTIAL_RESPONSES_PATH } from '../../../util/get-preferred-responses-vi
  */
 export default function BackToFormsButton(): JSX.Element {
 	const isCentralFormManagementEnabled = useConfigValue( 'isCentralFormManagementEnabled' );
-	const label =
-		isCentralFormManagementEnabled === true
-			? __( 'Back to Forms', 'jetpack-forms' )
-			: __( 'View all responses', 'jetpack-forms' );
+	// Avoid conditional translation calls: define strings unconditionally, then select.
+	const backToFormsLabel = __( 'Back to forms', 'jetpack-forms' );
+	const viewAllResponsesLabel = __( 'View all responses', 'jetpack-forms' );
+	const label = isCentralFormManagementEnabled === true ? backToFormsLabel : viewAllResponsesLabel;
 
 	const onClick = useCallback( () => {
 		// Go to the base Forms dashboard URL (no hash). This will land on:

--- a/projects/packages/forms/src/dashboard/components/back-to-forms-button/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/back-to-forms-button/index.tsx
@@ -27,7 +27,7 @@ export default function BackToFormsButton(): JSX.Element {
 
 	return (
 		<Button size="compact" variant="primary" onClick={ onClick }>
-			{ __( 'Back to Forms', 'jetpack-forms' ) }
+			{ __( 'Back to forms', 'jetpack-forms' ) }
 		</Button>
 	);
 }

--- a/projects/packages/forms/src/dashboard/components/dataviews-header-row/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/dataviews-header-row/index.tsx
@@ -2,11 +2,9 @@
  * External dependencies
  */
 import { DataViews } from '@wordpress/dataviews/wp';
-import { useLocation } from 'react-router';
 /**
  * Internal dependencies
  */
-import useConfigValue from '../../../hooks/use-config-value.ts';
 import FormsResponsesTabs from '../forms-responses-tabs/index.tsx';
 import InboxStatusToggle from '../inbox-status-toggle/index.tsx';
 import './style.scss';
@@ -16,29 +14,32 @@ import './style.scss';
  *
  * Structure:
  * - Left: Forms / Responses tabs
- * - Special case: on the Responses screen with CFM disabled, show Inbox/Spam/Trash toggle instead
+ * - Special case: when requested by the parent, show Inbox/Spam/Trash toggle instead
  * - Right: DataViews Search / Filters toggle / View config
  * - Below (only when there are active filters): DataViews.FiltersToggled
  *
- * @param {object}                   props                        - Component props.
- * @param {(status: string) => void} [props.onLegacyStatusChange] - Optional callback invoked when the legacy Inbox status changes.
+ * @param {object}                   props                           - Component props.
+ * @param {(status: string) => void} [props.onLegacyStatusChange]    - Optional callback invoked when the legacy Inbox status changes.
+ * @param {boolean}                  [props.isInboxStatusToggleView] - Whether to show InboxStatusToggle instead of top tabs.
+ * @param {boolean}                  [props.hasLockedFilter]         - Whether a locked filter is present (e.g. single-form filter).
  * @return {JSX.Element} Header row markup for DataViews pages.
  */
 export default function DataViewsHeaderRow( {
 	onLegacyStatusChange,
+	isInboxStatusToggleView = false,
+	hasLockedFilter = false,
 }: {
 	onLegacyStatusChange?: ( status: string ) => void;
+	isInboxStatusToggleView?: boolean;
+	hasLockedFilter?: boolean;
 } ): JSX.Element {
-	const location = useLocation();
-	const isCentralFormManagementEnabled = useConfigValue( 'isCentralFormManagementEnabled' );
-	const isCentralFormManagementDisabled = isCentralFormManagementEnabled === false;
-	const isResponsesScreen = location.pathname === '/responses';
+	const showFiltersToggle = isInboxStatusToggleView && ! hasLockedFilter;
 
 	return (
 		<>
 			<div className="jp-forms-view-actions">
 				<div>
-					{ isResponsesScreen && isCentralFormManagementDisabled ? (
+					{ isInboxStatusToggleView ? (
 						<InboxStatusToggle onChange={ onLegacyStatusChange } />
 					) : (
 						<FormsResponsesTabs />
@@ -46,7 +47,7 @@ export default function DataViewsHeaderRow( {
 				</div>
 				<div className="jp-forms-view-actions__controls">
 					<DataViews.Search />
-					{ isCentralFormManagementEnabled === true ? null : <DataViews.FiltersToggle /> }
+					{ showFiltersToggle ? <DataViews.FiltersToggle /> : null }
 					<DataViews.ViewConfig />
 				</div>
 			</div>

--- a/projects/packages/forms/src/dashboard/components/dataviews-header-row/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/dataviews-header-row/index.tsx
@@ -21,20 +21,15 @@ import './style.scss';
  * @param {object}                   props                           - Component props.
  * @param {(status: string) => void} [props.onLegacyStatusChange]    - Optional callback invoked when the legacy Inbox status changes.
  * @param {boolean}                  [props.isInboxStatusToggleView] - Whether to show InboxStatusToggle instead of top tabs.
- * @param {boolean}                  [props.hasLockedFilter]         - Whether a locked filter is present (e.g. single-form filter).
  * @return {JSX.Element} Header row markup for DataViews pages.
  */
 export default function DataViewsHeaderRow( {
 	onLegacyStatusChange,
 	isInboxStatusToggleView = false,
-	hasLockedFilter = false,
 }: {
 	onLegacyStatusChange?: ( status: string ) => void;
 	isInboxStatusToggleView?: boolean;
-	hasLockedFilter?: boolean;
 } ): JSX.Element {
-	const showFiltersToggle = isInboxStatusToggleView && ! hasLockedFilter;
-
 	return (
 		<>
 			<div className="jp-forms-view-actions">
@@ -47,7 +42,7 @@ export default function DataViewsHeaderRow( {
 				</div>
 				<div className="jp-forms-view-actions__controls">
 					<DataViews.Search />
-					{ showFiltersToggle ? <DataViews.FiltersToggle /> : null }
+					{ isInboxStatusToggleView ? <DataViews.FiltersToggle /> : null }
 					<DataViews.ViewConfig />
 				</div>
 			</div>

--- a/projects/packages/forms/src/dashboard/components/edit-form-button/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/edit-form-button/index.tsx
@@ -1,0 +1,32 @@
+/**
+ * WordPress dependencies
+ */
+import { Button } from '@wordpress/components';
+import { useCallback } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+
+type EditFormButtonProps = {
+	formId: number;
+};
+
+/**
+ * Button that navigates to edit the given `jetpack_form`.
+ *
+ * @param props        - Props.
+ * @param props.formId - Form (post) ID.
+ * @return JSX element.
+ */
+export default function EditFormButton( { formId }: EditFormButtonProps ): JSX.Element {
+	const onClick = useCallback( () => {
+		// Prefer a relative URL so it works regardless of wp-admin path.
+		const fallbackEditUrl = `post.php?post=${ formId }&action=edit&post_type=jetpack_form`;
+		const url = new URL( fallbackEditUrl, window.location.href );
+		window.location.href = url.toString();
+	}, [ formId ] );
+
+	return (
+		<Button size="compact" variant="secondary" onClick={ onClick }>
+			{ __( 'Edit form', 'jetpack-forms' ) }
+		</Button>
+	);
+}

--- a/projects/packages/forms/src/dashboard/components/edit-form-button/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/edit-form-button/index.tsx
@@ -1,5 +1,5 @@
 /**
- * WordPress dependencies
+ * External dependencies
  */
 import { Button } from '@wordpress/components';
 import { useCallback } from '@wordpress/element';

--- a/projects/packages/forms/src/dashboard/components/edit-form-button/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/edit-form-button/index.tsx
@@ -4,6 +4,10 @@
 import { Button } from '@wordpress/components';
 import { useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+/**
+ * Internal dependencies
+ */
+import useConfigValue from '../../../hooks/use-config-value';
 
 type EditFormButtonProps = {
 	formId: number;
@@ -17,12 +21,12 @@ type EditFormButtonProps = {
  * @return JSX element.
  */
 export default function EditFormButton( { formId }: EditFormButtonProps ): JSX.Element {
+	const adminUrl = useConfigValue( 'adminUrl' ) || '';
+
 	const onClick = useCallback( () => {
-		// Prefer a relative URL so it works regardless of wp-admin path.
-		const fallbackEditUrl = `post.php?post=${ formId }&action=edit&post_type=jetpack_form`;
-		const url = new URL( fallbackEditUrl, window.location.href );
-		window.location.href = url.toString();
-	}, [ formId ] );
+		const editPath = `post.php?post=${ formId }&action=edit`;
+		window.location.href = adminUrl ? `${ adminUrl }${ editPath }` : editPath;
+	}, [ adminUrl, formId ] );
 
 	return (
 		<Button size="compact" variant="secondary" onClick={ onClick }>

--- a/projects/packages/forms/src/dashboard/components/forms-responses-tabs/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/forms-responses-tabs/index.tsx
@@ -11,6 +11,9 @@ import * as Tabs from '../tabs/index.ts';
 
 type TabValue = 'forms' | 'responses';
 
+const isSingleFormResponsesRoute = ( pathname: string ) =>
+	/^\/forms\/\d+\/responses$/.test( pathname );
+
 /**
  * Route-aware top tabs for the Forms dashboard (Forms / All Responses).
  * This component controls routing; it does not manage filters.
@@ -21,6 +24,7 @@ export default function FormsResponsesTabs(): JSX.Element {
 	const location = useLocation();
 	const navigate = useNavigate();
 
+	const isSingleForm = isSingleFormResponsesRoute( location.pathname );
 	const value: TabValue = location.pathname === '/forms' ? 'forms' : 'responses';
 
 	const onValueChange = useCallback(
@@ -33,8 +37,12 @@ export default function FormsResponsesTabs(): JSX.Element {
 	return (
 		<Tabs.Root value={ value } onValueChange={ onValueChange }>
 			<Tabs.List density="compact">
-				<Tabs.Tab value="forms">{ __( 'Forms', 'jetpack-forms' ) }</Tabs.Tab>
-				<Tabs.Tab value="responses">{ __( 'All Responses', 'jetpack-forms' ) }</Tabs.Tab>
+				{ ! isSingleForm && <Tabs.Tab value="forms">{ __( 'Forms', 'jetpack-forms' ) }</Tabs.Tab> }
+				<Tabs.Tab value="responses">
+					{ isSingleForm
+						? __( 'Responses', 'jetpack-forms' )
+						: __( 'All Responses', 'jetpack-forms' ) }
+				</Tabs.Tab>
 			</Tabs.List>
 		</Tabs.Root>
 	);

--- a/projects/packages/forms/src/dashboard/components/forms-responses-tabs/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/forms-responses-tabs/index.tsx
@@ -11,9 +11,6 @@ import * as Tabs from '../tabs/index.ts';
 
 type TabValue = 'forms' | 'responses';
 
-const isSingleFormResponsesRoute = ( pathname: string ) =>
-	/^\/forms\/\d+\/responses$/.test( pathname );
-
 /**
  * Route-aware top tabs for the Forms dashboard (Forms / All Responses).
  * This component controls routing; it does not manage filters.
@@ -24,7 +21,6 @@ export default function FormsResponsesTabs(): JSX.Element {
 	const location = useLocation();
 	const navigate = useNavigate();
 
-	const isSingleForm = isSingleFormResponsesRoute( location.pathname );
 	const value: TabValue = location.pathname === '/forms' ? 'forms' : 'responses';
 
 	const onValueChange = useCallback(
@@ -37,12 +33,8 @@ export default function FormsResponsesTabs(): JSX.Element {
 	return (
 		<Tabs.Root value={ value } onValueChange={ onValueChange }>
 			<Tabs.List density="compact">
-				{ ! isSingleForm && <Tabs.Tab value="forms">{ __( 'Forms', 'jetpack-forms' ) }</Tabs.Tab> }
-				<Tabs.Tab value="responses">
-					{ isSingleForm
-						? __( 'Responses', 'jetpack-forms' )
-						: __( 'All Responses', 'jetpack-forms' ) }
-				</Tabs.Tab>
+				<Tabs.Tab value="forms">{ __( 'Forms', 'jetpack-forms' ) }</Tabs.Tab>
+				<Tabs.Tab value="responses">{ __( 'All Responses', 'jetpack-forms' ) }</Tabs.Tab>
 			</Tabs.List>
 		</Tabs.Root>
 	);

--- a/projects/packages/forms/src/dashboard/components/layout/style.scss
+++ b/projects/packages/forms/src/dashboard/components/layout/style.scss
@@ -37,6 +37,19 @@ body.jetpack_page_jetpack-forms-admin {
 
 	@include mixins.flex-center;
 	gap: 8px;
+
+	&__link {
+		font: inherit;
+		color: inherit;
+
+		&:hover {
+			text-decoration: underline;
+		}
+
+		&:focus-visible {
+			text-decoration: underline;
+		}
+	}
 }
 
 .jp-forms-layout__surface {

--- a/projects/packages/forms/src/dashboard/forms/index.tsx
+++ b/projects/packages/forms/src/dashboard/forms/index.tsx
@@ -288,6 +288,12 @@ export default function FormsDashboardForms(): JSX.Element | null {
 
 	const headerActions = useMemo( () => [ <CreateFormButton key="create" /> ], [] );
 	const getItemId = useCallback( ( item: FormListItem ) => String( item.id ), [] );
+	const onClickItem = useCallback(
+		( item: FormListItem ) => {
+			navigate( `/forms/${ item.id }/responses` );
+		},
+		[ navigate ]
+	);
 
 	// Avoid rendering if the flag is off (we'll redirect).
 	if ( isCentralFormManagementDisabled ) {
@@ -332,6 +338,7 @@ export default function FormsDashboardForms(): JSX.Element | null {
 					onChangeView={ onChangeView }
 					selection={ selection }
 					onChangeSelection={ setSelection }
+					onClickItem={ onClickItem }
 					getItemId={ getItemId }
 					defaultLayouts={ defaultLayouts }
 				>

--- a/projects/packages/forms/src/dashboard/forms/index.tsx
+++ b/projects/packages/forms/src/dashboard/forms/index.tsx
@@ -184,6 +184,19 @@ export default function FormsDashboardForms(): JSX.Element | null {
 	const actions = useMemo( () => {
 		const actionsList: Action< FormListItem >[] = [
 			{
+				id: 'view-responses',
+				isPrimary: false,
+				label: __( 'View responses', 'jetpack-forms' ),
+				supportsBulk: false,
+				callback( items: FormListItem[] ) {
+					const [ item ] = items;
+					if ( ! item ) {
+						return;
+					}
+					navigate( `/forms/${ item.id }/responses` );
+				},
+			},
+			{
 				id: 'edit-form',
 				isPrimary: false,
 				label: __( 'Edit', 'jetpack-forms' ),
@@ -254,7 +267,14 @@ export default function FormsDashboardForms(): JSX.Element | null {
 		} );
 
 		return actionsList;
-	}, [ isDeleting, isViewingTrash, onOpenPermanentDeleteConfirm, restoreForms, trashForms ] );
+	}, [
+		isDeleting,
+		isViewingTrash,
+		navigate,
+		onOpenPermanentDeleteConfirm,
+		restoreForms,
+		trashForms,
+	] );
 
 	const paginationInfo = useMemo(
 		() => ( {

--- a/projects/packages/forms/src/dashboard/forms/single/index.tsx
+++ b/projects/packages/forms/src/dashboard/forms/single/index.tsx
@@ -30,17 +30,17 @@ type RouteParams = {
 export default function SingleFormResponses(): JSX.Element | null {
 	const { formId } = useParams() as RouteParams;
 
-	const lockedParentId = useMemo( () => {
+	const parentId = useMemo( () => {
 		const id = Number( formId );
 		return Number.isFinite( id ) && id > 0 ? id : null;
 	}, [ formId ] );
 
 	const formRecord = useSelect(
 		select =>
-			lockedParentId
-				? select( coreDataStore ).getEntityRecord( 'postType', 'jetpack_form', lockedParentId )
+			parentId
+				? select( coreDataStore ).getEntityRecord( 'postType', 'jetpack_form', parentId )
 				: undefined,
-		[ lockedParentId ]
+		[ parentId ]
 	) as { title?: { rendered?: string } } | undefined;
 
 	const formTitle = useMemo( () => {
@@ -51,12 +51,12 @@ export default function SingleFormResponses(): JSX.Element | null {
 
 	useEffect( () => {
 		// Invalid ID: go back to the Forms dashboard root (no hash).
-		if ( lockedParentId === null ) {
+		if ( parentId === null ) {
 			window.location.href = PARTIAL_RESPONSES_PATH;
 		}
-	}, [ lockedParentId ] );
+	}, [ parentId ] );
 
-	if ( lockedParentId === null ) {
+	if ( parentId === null ) {
 		return null;
 	}
 
@@ -72,11 +72,5 @@ export default function SingleFormResponses(): JSX.Element | null {
 		  )
 		: __( 'View responses for this form.', 'jetpack-forms' );
 
-	return (
-		<Inbox
-			lockedParentId={ lockedParentId }
-			pageTitle={ pageTitle }
-			pageSubtitle={ pageSubtitle }
-		/>
-	);
+	return <Inbox parentId={ parentId } pageTitle={ pageTitle } pageSubtitle={ pageSubtitle } />;
 }

--- a/projects/packages/forms/src/dashboard/forms/single/index.tsx
+++ b/projects/packages/forms/src/dashboard/forms/single/index.tsx
@@ -9,10 +9,11 @@ import { useEffect, useMemo } from '@wordpress/element';
  */
 import { decodeEntities } from '@wordpress/html-entities';
 import { __, sprintf } from '@wordpress/i18n';
-import { useParams } from 'react-router';
+import { Link, useParams } from 'react-router';
 /**
  * Internal dependencies
  */
+import useConfigValue from '../../../hooks/use-config-value.ts';
 import { PARTIAL_RESPONSES_PATH } from '../../../util/get-preferred-responses-view.js';
 import Inbox from '../../inbox/index.js';
 
@@ -29,6 +30,7 @@ type RouteParams = {
  */
 export default function SingleFormResponses(): JSX.Element | null {
 	const { formId } = useParams() as RouteParams;
+	const isCentralFormManagementEnabled = useConfigValue( 'isCentralFormManagementEnabled' );
 
 	const parentId = useMemo( () => {
 		const id = Number( formId );
@@ -56,14 +58,27 @@ export default function SingleFormResponses(): JSX.Element | null {
 		}
 	}, [ parentId ] );
 
-	if ( parentId === null ) {
-		return null;
-	}
-
 	// Short-term: show a stable title/subtitle while the (optional) jetpack_form title is loading,
 	// and for non-jetpack_form "source" IDs (pre-CFM) where we may not be able to resolve a title yet.
-	const baseTitle = __( 'Form', 'jetpack-forms' );
-	const pageTitle = formTitle ? `${ baseTitle } > ${ formTitle }` : baseTitle;
+	const baseTitle = __( 'Forms', 'jetpack-forms' );
+	const formsPath = useMemo(
+		() => ( isCentralFormManagementEnabled === true ? '/forms' : '/responses' ),
+		[ isCentralFormManagementEnabled ]
+	);
+	const pageTitle = useMemo( () => {
+		const formsLink = (
+			<Link className="jp-forms-page-header-title__link" to={ formsPath }>
+				{ baseTitle }
+			</Link>
+		);
+		return formTitle ? (
+			<>
+				{ formsLink } / { formTitle }
+			</>
+		) : (
+			formsLink
+		);
+	}, [ baseTitle, formTitle, formsPath ] );
 	const pageSubtitle = formTitle
 		? sprintf(
 				/* translators: %s: form name */
@@ -71,6 +86,10 @@ export default function SingleFormResponses(): JSX.Element | null {
 				formTitle
 		  )
 		: __( 'View responses for this form.', 'jetpack-forms' );
+
+	if ( parentId === null ) {
+		return null;
+	}
 
 	return <Inbox parentId={ parentId } pageTitle={ pageTitle } pageSubtitle={ pageSubtitle } />;
 }

--- a/projects/packages/forms/src/dashboard/forms/single/index.tsx
+++ b/projects/packages/forms/src/dashboard/forms/single/index.tsx
@@ -1,0 +1,74 @@
+/**
+ * WordPress dependencies
+ */
+import { store as coreDataStore } from '@wordpress/core-data';
+import { useSelect } from '@wordpress/data';
+import { useEffect, useMemo } from '@wordpress/element';
+/**
+ * External dependencies
+ */
+import { decodeEntities } from '@wordpress/html-entities';
+import { __, sprintf } from '@wordpress/i18n';
+import { useParams } from 'react-router';
+/**
+ * Internal dependencies
+ */
+import { PARTIAL_RESPONSES_PATH } from '../../../util/get-preferred-responses-view.js';
+import Inbox from '../../inbox/index.js';
+
+type RouteParams = {
+	formId?: string;
+};
+
+/**
+ * Route element for a single form's responses.
+ *
+ * Renders the existing Inbox UI, but pre-filters and locks it to a given form ID.
+ *
+ * @return JSX element.
+ */
+export default function SingleFormResponses(): JSX.Element | null {
+	const { formId } = useParams() as RouteParams;
+
+	const lockedParentId = useMemo( () => {
+		const id = Number( formId );
+		return Number.isFinite( id ) && id > 0 ? id : null;
+	}, [ formId ] );
+
+	const formRecord = useSelect(
+		select =>
+			lockedParentId
+				? select( coreDataStore ).getEntityRecord( 'postType', 'jetpack_form', lockedParentId )
+				: undefined,
+		[ lockedParentId ]
+	) as { title?: { rendered?: string } } | undefined;
+
+	const formTitle = useMemo( () => {
+		const rendered = formRecord?.title?.rendered || '';
+		const decoded = decodeEntities( rendered );
+		return decoded || __( '(no title)', 'jetpack-forms' );
+	}, [ formRecord?.title?.rendered ] );
+
+	useEffect( () => {
+		// Invalid ID: go back to the Forms dashboard root (no hash).
+		if ( lockedParentId === null ) {
+			window.location.href = PARTIAL_RESPONSES_PATH;
+		}
+	}, [ lockedParentId ] );
+
+	if ( lockedParentId === null ) {
+		return null;
+	}
+
+	return (
+		<Inbox
+			lockedParentId={ lockedParentId }
+			pageTitle={ `${ __( 'Forms', 'jetpack-forms' ) } > ${ formTitle }` }
+			pageSubtitle={ sprintf(
+				/* translators: %s: form name */
+				__( 'Viewing responses for %s.', 'jetpack-forms' ),
+				formTitle
+			) }
+		/>
+	);
+}

--- a/projects/packages/forms/src/dashboard/forms/single/index.tsx
+++ b/projects/packages/forms/src/dashboard/forms/single/index.tsx
@@ -46,7 +46,7 @@ export default function SingleFormResponses(): JSX.Element | null {
 	const formTitle = useMemo( () => {
 		const rendered = formRecord?.title?.rendered || '';
 		const decoded = decodeEntities( rendered );
-		return decoded || __( '(no title)', 'jetpack-forms' );
+		return decoded;
 	}, [ formRecord?.title?.rendered ] );
 
 	useEffect( () => {
@@ -60,15 +60,23 @@ export default function SingleFormResponses(): JSX.Element | null {
 		return null;
 	}
 
-	return (
-		<Inbox
-			lockedParentId={ lockedParentId }
-			pageTitle={ `${ __( 'Forms', 'jetpack-forms' ) } > ${ formTitle }` }
-			pageSubtitle={ sprintf(
+	// Short-term: show a stable title/subtitle while the (optional) jetpack_form title is loading,
+	// and for non-jetpack_form "source" IDs (pre-CFM) where we may not be able to resolve a title yet.
+	const baseTitle = __( 'Form', 'jetpack-forms' );
+	const pageTitle = formTitle ? `${ baseTitle } > ${ formTitle }` : baseTitle;
+	const pageSubtitle = formTitle
+		? sprintf(
 				/* translators: %s: form name */
 				__( 'Viewing responses for %s.', 'jetpack-forms' ),
 				formTitle
-			) }
+		  )
+		: __( 'View responses for this form.', 'jetpack-forms' );
+
+	return (
+		<Inbox
+			lockedParentId={ lockedParentId }
+			pageTitle={ pageTitle }
+			pageSubtitle={ pageSubtitle }
 		/>
 	);
 }

--- a/projects/packages/forms/src/dashboard/forms/single/index.tsx
+++ b/projects/packages/forms/src/dashboard/forms/single/index.tsx
@@ -9,12 +9,11 @@ import { useEffect, useMemo } from '@wordpress/element';
  */
 import { decodeEntities } from '@wordpress/html-entities';
 import { __, sprintf } from '@wordpress/i18n';
-import { Link, useParams } from 'react-router';
+import { Link, useNavigate, useParams } from 'react-router';
 /**
  * Internal dependencies
  */
 import useConfigValue from '../../../hooks/use-config-value.ts';
-import { PARTIAL_RESPONSES_PATH } from '../../../util/get-preferred-responses-view.js';
 import Inbox from '../../inbox/index.js';
 
 type RouteParams = {
@@ -30,6 +29,7 @@ type RouteParams = {
  */
 export default function SingleFormResponses(): JSX.Element | null {
 	const { formId } = useParams() as RouteParams;
+	const navigate = useNavigate();
 	const isCentralFormManagementEnabled = useConfigValue( 'isCentralFormManagementEnabled' );
 
 	const parentId = useMemo( () => {
@@ -52,11 +52,13 @@ export default function SingleFormResponses(): JSX.Element | null {
 	}, [ formRecord?.title?.rendered ] );
 
 	useEffect( () => {
-		// Invalid ID: go back to the Forms dashboard root (no hash).
+		// Invalid ID: go back to the appropriate dashboard screen without a full page reload.
 		if ( parentId === null ) {
-			window.location.href = PARTIAL_RESPONSES_PATH;
+			navigate( isCentralFormManagementEnabled === true ? '/forms' : '/responses', {
+				replace: true,
+			} );
 		}
-	}, [ parentId ] );
+	}, [ parentId, isCentralFormManagementEnabled, navigate ] );
 
 	// Short-term: show a stable title/subtitle while the (optional) jetpack_form title is loading,
 	// and for non-jetpack_form "source" IDs (pre-CFM) where we may not be able to resolve a title yet.

--- a/projects/packages/forms/src/dashboard/inbox/stage/index.js
+++ b/projects/packages/forms/src/dashboard/inbox/stage/index.js
@@ -20,8 +20,10 @@ import { useEffect } from 'react';
  */
 import useConfigValue from '../../../hooks/use-config-value.ts';
 import { INTEGRATIONS_STORE } from '../../../store/integrations/index.ts';
+import BackToFormsButton from '../../components/back-to-forms-button/index.tsx';
 import CreateFormButton from '../../components/create-form-button/index.tsx';
 import DataViewsHeaderRow from '../../components/dataviews-header-row/index.tsx';
+import EditFormButton from '../../components/edit-form-button/index.tsx';
 import EmptyResponses from '../../components/empty-responses/index.tsx';
 import EmptySpamButton from '../../components/empty-spam-button/index.tsx';
 import EmptyTrashButton from '../../components/empty-trash-button/index.tsx';
@@ -48,6 +50,38 @@ import {
 import { useView, defaultLayouts } from './views.js';
 
 const EMPTY_ARRAY = [];
+
+/**
+ * Ensure the inbox view includes a locked "source" filter that maps to the REST `parent` query arg.
+ * This matches core DataViews behavior for locked filters (visible chip, not removable, preserved on reset).
+ *
+ * @param {object}      view         - DataViews view object.
+ * @param {number|null} lockedParent - Parent (form) ID to lock to.
+ * @return {object} Next view.
+ */
+function ensureLockedParentFilter( view, lockedParent ) {
+	if ( ! lockedParent ) {
+		return view;
+	}
+	const previousFilters = view.filters || [];
+	const existing = previousFilters.find( filter => filter.field === 'source' );
+	const isAlreadyLocked =
+		existing?.value === lockedParent &&
+		( existing?.operator || 'is' ) === 'is' &&
+		existing?.isLocked;
+	if ( isAlreadyLocked ) {
+		return view;
+	}
+	const nextFilters = [
+		{ field: 'source', operator: 'is', value: lockedParent, isLocked: true },
+		...previousFilters.filter( filter => filter.field !== 'source' ),
+	];
+	return {
+		...view,
+		page: 1,
+		filters: nextFilters,
+	};
+}
 
 const updateSidebarWidth = () => {
 	const wrapper = document.querySelector( '.dataviews-wrapper' );
@@ -81,11 +115,19 @@ const setupSidebarWidthObserver = () => {
 /**
  * The DataViews implementation.
  *
+ * @param {object} [props]                - Props.
+ * @param {number} [props.lockedParentId] - Optional parent (form) ID to lock responses to.
+ * @param {string} [props.pageTitle]      - Optional page title string. Defaults to "Forms".
+ * @param {string} [props.pageSubtitle]   - Optional page subtitle string.
  * @return {import('react').JSX.Element} The DataViews component.
  */
-export default function InboxView() {
+export default function InboxView( { lockedParentId, pageTitle, pageSubtitle } = {} ) {
 	const [ view, setView ] = useView();
 	const [ searchParams, setSearchParams ] = useDashboardSearchParams();
+	const lockedParent = useMemo( () => {
+		const id = Number( lockedParentId );
+		return Number.isFinite( id ) && id > 0 ? id : null;
+	}, [ lockedParentId ] );
 
 	const dateSettings = getDateSettings();
 
@@ -119,9 +161,18 @@ export default function InboxView() {
 		return setupSidebarWidthObserver();
 	}, [] );
 
+	// When rendering a single-form inbox, enforce the locked parent filter.
+	useEffect( () => {
+		setView( previousView => ensureLockedParentFilter( previousView, lockedParent ) );
+	}, [ lockedParent, setView ] );
+
 	const isIntegrationsEnabled = useConfigValue( 'isIntegrationsEnabled' );
 	const showDashboardIntegrations = useConfigValue( 'showDashboardIntegrations' );
 	const isCentralFormManagementEnabled = useConfigValue( 'isCentralFormManagementEnabled' );
+	// Use InboxStatusToggle UI when:
+	// - we're on the single-form responses screen (lockedParent), OR
+	// - CFM is not explicitly enabled (treat `undefined` like disabled to avoid showing folder UI early).
+	const isInboxStatusToggleView = !! lockedParent || isCentralFormManagementEnabled !== true;
 	const urlFolder = useMemo( () => {
 		const urlStatus = searchParams.get( 'status' );
 		return [ 'inbox', 'spam', 'trash' ].includes( urlStatus ) ? urlStatus : 'inbox';
@@ -260,7 +311,7 @@ export default function InboxView() {
 
 	const onChangeView = useCallback(
 		newView => {
-			if ( isCentralFormManagementEnabled ) {
+			if ( ! isInboxStatusToggleView ) {
 				const folderValue = newView.filters?.find( filter => filter.field === 'folder' )?.value;
 				const nextFolder = [ 'inbox', 'spam', 'trash' ].includes( folderValue )
 					? folderValue
@@ -292,9 +343,18 @@ export default function InboxView() {
 				}
 			}
 
+			// Enforce the locked parent filter for single-form inbox routes.
+			newView = ensureLockedParentFilter( newView, lockedParent );
 			setView( newView );
 		},
-		[ isCentralFormManagementEnabled, setSearchParams, setSelectedResponses, setView, urlFolder ]
+		[
+			isInboxStatusToggleView,
+			lockedParent,
+			setSearchParams,
+			setSelectedResponses,
+			setView,
+			urlFolder,
+		]
 	);
 
 	const wrapperUnread = ( isUnread, itemValue ) => {
@@ -306,7 +366,7 @@ export default function InboxView() {
 
 	const fields = useMemo(
 		() => [
-			...( isCentralFormManagementEnabled
+			...( ! isInboxStatusToggleView
 				? [
 						{
 							id: 'folder',
@@ -472,14 +532,14 @@ export default function InboxView() {
 			isMobileViewport,
 			openResponseModal,
 			dateSettings.formats.date,
-			isCentralFormManagementEnabled,
+			isInboxStatusToggleView,
 		]
 	);
 
 	// When CFM is enabled, keep the DataViews "Folder" filter in sync with the URL `status` param
 	// (and default to Inbox on first load).
 	useEffect( () => {
-		if ( ! isCentralFormManagementEnabled ) {
+		if ( isInboxStatusToggleView ) {
 			return;
 		}
 		setView( previousView => {
@@ -497,7 +557,7 @@ export default function InboxView() {
 				filters: nextFilters,
 			};
 		} );
-	}, [ isCentralFormManagementEnabled, setView, urlFolder ] );
+	}, [ isInboxStatusToggleView, setView, urlFolder ] );
 
 	const actions = useMemo( () => {
 		const mobileViewAction = {
@@ -569,16 +629,25 @@ export default function InboxView() {
 
 	// Conditional header actions based on status filter
 	const headerActions = useMemo( () => {
-		const exportIsPrimary = statusFilter !== 'trash' && statusFilter !== 'spam';
+		const isSingleFormView = !! lockedParent;
+		const exportIsPrimary =
+			! isSingleFormView && statusFilter !== 'trash' && statusFilter !== 'spam';
 		const headerActionsArray = [
 			<ExportResponsesButton key="export" isPrimary={ exportIsPrimary } />,
 		];
+
+		// On the single form screen, always show navigation actions regardless of folder (Inbox/Spam/Trash).
+		if ( isSingleFormView ) {
+			headerActionsArray.unshift( <BackToFormsButton key="back-to-forms" /> );
+			headerActionsArray.splice( 1, 0, <EditFormButton key="edit-form" formId={ lockedParent } /> );
+		}
 
 		if ( statusFilter === 'trash' ) {
 			headerActionsArray.push( <EmptyTrashButton key="empty-trash" /> );
 		} else if ( statusFilter === 'spam' ) {
 			headerActionsArray.push( <EmptySpamButton key="empty-spam" /> );
-		} else {
+		} else if ( ! isSingleFormView ) {
+			// When not on the single form screen, show create / integrations.
 			headerActionsArray.unshift( <CreateFormButton key="create" /> );
 			// Only show Create Form and Integrations buttons on inbox (when not in trash or spam)
 			if ( isIntegrationsEnabled && showDashboardIntegrations ) {
@@ -587,17 +656,20 @@ export default function InboxView() {
 		}
 
 		return headerActionsArray;
-	}, [ statusFilter, isIntegrationsEnabled, showDashboardIntegrations ] );
+	}, [ lockedParent, statusFilter, isIntegrationsEnabled, showDashboardIntegrations ] );
 
 	const pageContent = (
 		<Page
 			title={
 				<div className="jp-forms-page-header-title">
 					<JetpackLogo showText={ false } width={ 20 } />
-					{ __( 'Forms', 'jetpack-forms' ) }
+					{ pageTitle ? pageTitle : __( 'Forms', 'jetpack-forms' ) }
 				</div>
 			}
-			subTitle={ __( 'View and manage all your form responses in one place.', 'jetpack-forms' ) }
+			subTitle={
+				pageSubtitle ??
+				__( 'View and manage all your form submissions in one place.', 'jetpack-forms' )
+			}
 			actions={ headerActions }
 			hasPadding={ false }
 		>
@@ -622,7 +694,11 @@ export default function InboxView() {
 					/>
 				}
 			>
-				<DataViewsHeaderRow onLegacyStatusChange={ resetPage } />
+				<DataViewsHeaderRow
+					onLegacyStatusChange={ resetPage }
+					isInboxStatusToggleView={ isInboxStatusToggleView }
+					hasLockedFilter={ !! lockedParent }
+				/>
 				<div className="jp-forms-dataviews-layout-container">
 					<DataViews.Layout />
 					<DataViews.Footer />

--- a/projects/packages/forms/src/dashboard/inbox/stage/index.js
+++ b/projects/packages/forms/src/dashboard/inbox/stage/index.js
@@ -83,10 +83,10 @@ const setupSidebarWidthObserver = () => {
 /**
  * The DataViews implementation.
  *
- * @param {object} [props]              - Props.
- * @param {number} [props.parentId]     - Optional parent (form/source) ID to scope responses to.
- * @param {string} [props.pageTitle]    - Optional page title string. Defaults to "Forms".
- * @param {string} [props.pageSubtitle] - Optional page subtitle string.
+ * @param {object}                    [props]              - Props.
+ * @param {number}                    [props.parentId]     - Optional parent (form/source) ID to scope responses to.
+ * @param {import('react').ReactNode} [props.pageTitle]    - Optional page title content. Defaults to "Forms".
+ * @param {string}                    [props.pageSubtitle] - Optional page subtitle string.
  * @return {import('react').JSX.Element} The DataViews component.
  */
 export default function InboxView( { parentId, pageTitle, pageSubtitle } = {} ) {

--- a/projects/packages/forms/src/dashboard/inbox/stage/index.js
+++ b/projects/packages/forms/src/dashboard/inbox/stage/index.js
@@ -629,7 +629,7 @@ export default function InboxView( { parentId, pageTitle, pageSubtitle } = {} ) 
 			}
 			subTitle={
 				pageSubtitle ??
-				__( 'View and manage all your form submissions in one place.', 'jetpack-forms' )
+				__( 'View and manage all your form responses in one place.', 'jetpack-forms' )
 			}
 			actions={ headerActions }
 			hasPadding={ false }

--- a/projects/packages/forms/src/dashboard/inbox/stage/index.js
+++ b/projects/packages/forms/src/dashboard/inbox/stage/index.js
@@ -51,38 +51,6 @@ import { useView, defaultLayouts } from './views.js';
 
 const EMPTY_ARRAY = [];
 
-/**
- * Ensure the inbox view includes a locked "source" filter that maps to the REST `parent` query arg.
- * This matches core DataViews behavior for locked filters (visible chip, not removable, preserved on reset).
- *
- * @param {object}      view         - DataViews view object.
- * @param {number|null} lockedParent - Parent (form) ID to lock to.
- * @return {object} Next view.
- */
-function ensureLockedParentFilter( view, lockedParent ) {
-	if ( ! lockedParent ) {
-		return view;
-	}
-	const previousFilters = view.filters || [];
-	const existing = previousFilters.find( filter => filter.field === 'source' );
-	const isAlreadyLocked =
-		existing?.value === lockedParent &&
-		( existing?.operator || 'is' ) === 'is' &&
-		existing?.isLocked;
-	if ( isAlreadyLocked ) {
-		return view;
-	}
-	const nextFilters = [
-		{ field: 'source', operator: 'is', value: lockedParent, isLocked: true },
-		...previousFilters.filter( filter => filter.field !== 'source' ),
-	];
-	return {
-		...view,
-		page: 1,
-		filters: nextFilters,
-	};
-}
-
 const updateSidebarWidth = () => {
 	const wrapper = document.querySelector( '.dataviews-wrapper' );
 
@@ -115,19 +83,20 @@ const setupSidebarWidthObserver = () => {
 /**
  * The DataViews implementation.
  *
- * @param {object} [props]                - Props.
- * @param {number} [props.lockedParentId] - Optional parent (form) ID to lock responses to.
- * @param {string} [props.pageTitle]      - Optional page title string. Defaults to "Forms".
- * @param {string} [props.pageSubtitle]   - Optional page subtitle string.
+ * @param {object} [props]              - Props.
+ * @param {number} [props.parentId]     - Optional parent (form/source) ID to scope responses to.
+ * @param {string} [props.pageTitle]    - Optional page title string. Defaults to "Forms".
+ * @param {string} [props.pageSubtitle] - Optional page subtitle string.
  * @return {import('react').JSX.Element} The DataViews component.
  */
-export default function InboxView( { lockedParentId, pageTitle, pageSubtitle } = {} ) {
+export default function InboxView( { parentId, pageTitle, pageSubtitle } = {} ) {
 	const [ view, setView ] = useView();
 	const [ searchParams, setSearchParams ] = useDashboardSearchParams();
-	const lockedParent = useMemo( () => {
-		const id = Number( lockedParentId );
+	const parent = useMemo( () => {
+		const id = Number( parentId );
 		return Number.isFinite( id ) && id > 0 ? id : null;
-	}, [ lockedParentId ] );
+	}, [ parentId ] );
+	const isSingleFormView = !! parent;
 
 	const dateSettings = getDateSettings();
 
@@ -161,18 +130,10 @@ export default function InboxView( { lockedParentId, pageTitle, pageSubtitle } =
 		return setupSidebarWidthObserver();
 	}, [] );
 
-	// When rendering a single-form inbox, enforce the locked parent filter.
-	useEffect( () => {
-		setView( previousView => ensureLockedParentFilter( previousView, lockedParent ) );
-	}, [ lockedParent, setView ] );
-
 	const isIntegrationsEnabled = useConfigValue( 'isIntegrationsEnabled' );
 	const showDashboardIntegrations = useConfigValue( 'showDashboardIntegrations' );
 	const isCentralFormManagementEnabled = useConfigValue( 'isCentralFormManagementEnabled' );
-	// Use InboxStatusToggle UI when:
-	// - we're on the single-form responses screen (lockedParent), OR
-	// - CFM is not explicitly enabled (treat `undefined` like disabled to avoid showing folder UI early).
-	const isInboxStatusToggleView = !! lockedParent || isCentralFormManagementEnabled !== true;
+	const isInboxStatusToggleView = isSingleFormView || isCentralFormManagementEnabled !== true;
 	const urlFolder = useMemo( () => {
 		const urlStatus = searchParams.get( 'status' );
 		return [ 'inbox', 'spam', 'trash' ].includes( urlStatus ) ? urlStatus : 'inbox';
@@ -224,6 +185,12 @@ export default function InboxView( { lockedParentId, pageTitle, pageSubtitle } =
 			}
 			return accumulator;
 		}, {} );
+
+		// Single-form view: scope the query directly (no DataViews Source filter pill).
+		if ( isSingleFormView && parent ) {
+			_filters.parent = parent;
+		}
+
 		const _queryArgs = {
 			order: 'desc',
 			orderby: 'date',
@@ -236,7 +203,7 @@ export default function InboxView( { lockedParentId, pageTitle, pageSubtitle } =
 		// We need to keep the current query args in the store to be used in `export`
 		// and for getting the total records per `status`.
 		setCurrentQuery( _queryArgs );
-	}, [ view, statusFilter, setCurrentQuery ] );
+	}, [ view, statusFilter, setCurrentQuery, isSingleFormView, parent ] );
 
 	const selection = selectedResponses?.split( ',' ) || EMPTY_ARRAY;
 
@@ -342,19 +309,9 @@ export default function InboxView( { lockedParentId, pageTitle, pageSubtitle } =
 					newView = { ...newView, page: 1 };
 				}
 			}
-
-			// Enforce the locked parent filter for single-form inbox routes.
-			newView = ensureLockedParentFilter( newView, lockedParent );
 			setView( newView );
 		},
-		[
-			isInboxStatusToggleView,
-			lockedParent,
-			setSearchParams,
-			setSelectedResponses,
-			setView,
-			urlFolder,
-		]
+		[ isInboxStatusToggleView, setSearchParams, setSelectedResponses, setView, urlFolder ]
 	);
 
 	const wrapperUnread = ( isUnread, itemValue ) => {
@@ -384,6 +341,33 @@ export default function InboxView( { lockedParentId, pageTitle, pageSubtitle } =
 							// Filter-only field; not shown as a column.
 							render: () => null,
 							getValue: () => null,
+						},
+				  ]
+				: [] ),
+			...( ! isSingleFormView
+				? [
+						{
+							id: 'source',
+							label: __( 'Source', 'jetpack-forms' ),
+							render: ( { item } ) => {
+								if ( ! item.entry_permalink ) {
+									return wrapperUnread( item.is_unread, decodeEntities( item.entry_title ) );
+								}
+								return (
+									<ExternalLink href={ item.entry_permalink }>
+										{ wrapperUnread(
+											item.is_unread,
+											decodeEntities( item.entry_title ) || getPath( item )
+										) }
+									</ExternalLink>
+								);
+							},
+							elements: ( filterOptions?.source || [] ).map( source => ( {
+								value: source.id,
+								label: decodeEntities( source.title ) || getPath( { entry_permalink: source.url } ),
+							} ) ),
+							filterBy: { operators: [ 'is' ] },
+							enableSorting: false,
 						},
 				  ]
 				: [] ),
@@ -474,29 +458,6 @@ export default function InboxView( { lockedParentId, pageTitle, pageSubtitle } =
 				enableSorting: false,
 			},
 			{
-				id: 'source',
-				label: __( 'Source', 'jetpack-forms' ),
-				render: ( { item } ) => {
-					if ( ! item.entry_permalink ) {
-						return wrapperUnread( item.is_unread, decodeEntities( item.entry_title ) );
-					}
-					return (
-						<ExternalLink href={ item.entry_permalink }>
-							{ wrapperUnread(
-								item.is_unread,
-								decodeEntities( item.entry_title ) || getPath( item )
-							) }
-						</ExternalLink>
-					);
-				},
-				elements: ( filterOptions?.source || [] ).map( source => ( {
-					value: source.id,
-					label: decodeEntities( source.title ) || getPath( { entry_permalink: source.url } ),
-				} ) ),
-				filterBy: { operators: [ 'is' ] },
-				enableSorting: false,
-			},
-			{
 				id: 'read_status',
 				label: __( 'Status', 'jetpack-forms' ),
 				elements: [
@@ -533,6 +494,7 @@ export default function InboxView( { lockedParentId, pageTitle, pageSubtitle } =
 			openResponseModal,
 			dateSettings.formats.date,
 			isInboxStatusToggleView,
+			isSingleFormView,
 		]
 	);
 
@@ -629,7 +591,6 @@ export default function InboxView( { lockedParentId, pageTitle, pageSubtitle } =
 
 	// Conditional header actions based on status filter
 	const headerActions = useMemo( () => {
-		const isSingleFormView = !! lockedParent;
 		const exportIsPrimary =
 			! isSingleFormView && statusFilter !== 'trash' && statusFilter !== 'spam';
 		const headerActionsArray = [
@@ -639,7 +600,7 @@ export default function InboxView( { lockedParentId, pageTitle, pageSubtitle } =
 		// On the single form screen, always show navigation actions regardless of folder (Inbox/Spam/Trash).
 		if ( isSingleFormView ) {
 			headerActionsArray.unshift( <BackToFormsButton key="back-to-forms" /> );
-			headerActionsArray.splice( 1, 0, <EditFormButton key="edit-form" formId={ lockedParent } /> );
+			headerActionsArray.splice( 1, 0, <EditFormButton key="edit-form" formId={ parent } /> );
 		}
 
 		if ( statusFilter === 'trash' ) {
@@ -656,7 +617,7 @@ export default function InboxView( { lockedParentId, pageTitle, pageSubtitle } =
 		}
 
 		return headerActionsArray;
-	}, [ lockedParent, statusFilter, isIntegrationsEnabled, showDashboardIntegrations ] );
+	}, [ parent, isSingleFormView, statusFilter, isIntegrationsEnabled, showDashboardIntegrations ] );
 
 	const pageContent = (
 		<Page
@@ -697,7 +658,6 @@ export default function InboxView( { lockedParentId, pageTitle, pageSubtitle } =
 				<DataViewsHeaderRow
 					onLegacyStatusChange={ resetPage }
 					isInboxStatusToggleView={ isInboxStatusToggleView }
-					hasLockedFilter={ !! lockedParent }
 				/>
 				<div className="jp-forms-dataviews-layout-container">
 					<DataViews.Layout />

--- a/projects/packages/forms/src/dashboard/index.tsx
+++ b/projects/packages/forms/src/dashboard/index.tsx
@@ -11,6 +11,7 @@ import { RouterProvider } from 'react-router/dom';
 import useConfigValue from '../hooks/use-config-value.ts';
 import Layout from './components/layout/index.tsx';
 import FormsDashboardForms from './forms/index.tsx';
+import SingleFormResponses from './forms/single/index.tsx';
 import Inbox from './inbox/index.js';
 import DashboardNotices from './notices-list.tsx';
 import ReactRouterDashboardSearchParamsProvider from './router/react-router-dashboard-search-params-provider.tsx';
@@ -67,6 +68,10 @@ function initFormsDashboard() {
 				{
 					path: 'forms',
 					element: <FormsDashboardForms />,
+				},
+				{
+					path: 'forms/:formId/responses',
+					element: <SingleFormResponses />,
 				},
 				{
 					path: 'responses',

--- a/projects/plugins/jetpack/changelog/add-single-form-screen
+++ b/projects/plugins/jetpack/changelog/add-single-form-screen
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Forms: add single forms screen.


### PR DESCRIPTION
## Proposed changes:

This adds a 'single form' screen or view to the forms dashboard. This is intended to be used with centralized form management (CFM), but can also be used with pre-existing Jetpack Forms to show all responses tied to one specific source. 
* **Single form route.** Adds new single form route using the ID of the source (or feedback post parent). In CFM environments, this will be a jetpack_form post. In non-CFM environments, this will be the source ID (of the page where the form lives). 
* **Clickable title + view responses action.** You can get to a single form screen by clicking on the form title or clicking the View Responses action added to each row. 
* On the single form screen, we do all of the following: 
   - **Title**. Update the page title to be `Forms > [Form Name]`
      - The Forms portion is a link back to the list of all forms.
   - **Subtitle**. Update the page sub-title to say: `View responses for [Form Name]`
   - **Back to Forms**. Add a `Back to Forms` header button that goes back to the forms dashboard root. 
   - **Edit Form**. Add an 'Edit Forms' header button that goes to the jetpack_form (for CFM) post or to the page/post where the form lives (for non-CFM).
   - **Show InboxStatusToggle**. For the main tabs on this screen, we show Inbox/Spam/Trash toggle (like on production Inbox). Later this may be updated when we need Responses + Summary/Stats tabs. 
   - **Reuse DataViews inbox.** Load the same DataViews table that we are using for our regular forms inbox. So there is **no new DataViews implementation for this screen**. 
      - **New inbox props.** To allow re-using the Inbox component for single as well as all responses, it is updated to take in new props for title, subtitle, and parentId (the id of the form or source). 
      - **Parent ID in query.** We pass the parent_id, if it exists, as part of the query. This allows us to not depend on the Soruce filter. 
      - **Remove Source filter.** We remove the Source filter on single form screens. 
      - **DataViews header.** Updates DataViews header, including header component and tabs, to accommodate single form view both for CFM and for live production form sources. 
    
**Screenshot: Forms list > View responses action**
<img width="1343" height="418" alt="view-responses-action" src="https://github.com/user-attachments/assets/b5ae9978-45b8-49cb-b1d3-b86d762c55c7" />

**Screenshot: Single form screen**
<img width="1347" height="677" alt="single-forms-screen-2" src="https://github.com/user-attachments/assets/6b4f2c81-8586-4b82-986c-1df02648f8f8" />


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

**Add this feature flag to your test site.** 

```
add_filter( 'jetpack_block_editor_feature_flags', 'eb_register_feature' );
function eb_register_feature( $flags ) {
    $flags['central-form-management'] = true;
    return $flags;
}
```

**Test new screen with Central Form Management:**
* Set feature flag above
* Go to Jetpack > Forms
* On the forms list, find a form with responses. (If you need forms, click Create Form to add one. If you need to add responses to a Form, embed one of your forms on a screen, publish, and submit a few responses.)
* Click the actions row for a form and then click `View Responses`. 
* Confirm you go to the single form screen for that form. 
* Confirm you can see all responses associated with that form in the list. 
* Confirm the title is "Forms > {Your Form Name}
* Confirm clicking Forms takes you back to the forms list. 
* Confirm the subtitle is "Viewing responses for {Your Form Name}"
* Confirm there's a header button for "Back to Forms" and it takes you back to the forms list. 
* Confirm there's a header button for "Edit Form" and it takes you to the FORM editor screen for that form
* Confirm the form responses table works as expected (you can send to trash or spam, restore, filter, etc). 

**Test with flag off to confirm no regressions:**
* Remove feature flag and confirm everything works as before. You should see no sign of CFM functionality. Be sure to check title, subtitle, header buttons, and filters. 

**Test the single form screen works even without CFM:** 
* With the feature flag off, go to Jetpack Forms, find a response, and get the source ID for that post. You can get it by clicking actions > Edit Form, which will take you to the page where the form lives. Then grab the post ID from the URL. 
* Go to this URL: 
   - `YOURDOMAIN.COM/wp-admin/admin.php?page=jetpack-forms-admin#/forms/YOURPOSTID/responses`
* Confirm the single form screen loads
* Confirm you can see all responses associated with that source/page in the list. 
* Confirm the title is "Forms > {Your Page Name}
* Confirm the subtitle is "Viewing responses for {Your Page Name}"
* Confirm there's a header button for "Back to Forms" and it takes you back to the forms list. 
* Confirm there's a header button for "Edit Form" and it takes you to the PAGE editor screen

