### PR TITLE
Podcast player email rendering: Update to use audio block

### DIFF
--- a/projects/plugins/jetpack/changelog/update-podcast-player-email-rendering
+++ b/projects/plugins/jetpack/changelog/update-podcast-player-email-rendering
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Podcast player email rendering: Use audio block rendering and link to post.

--- a/projects/plugins/jetpack/extensions/blocks/podcast-player/podcast-player.php
+++ b/projects/plugins/jetpack/extensions/blocks/podcast-player/podcast-player.php
@@ -332,14 +332,17 @@ function render_email( $block_content, array $parsed_block, $rendering_context )
 	}
 
 	// Build block content HTML with audio tag that the audio renderer expects
-	// Use the post URL so the link goes to the post, not a single episode
-	$post_url           = esc_url( $post_url );
-	$block_content_html = sprintf( '<audio src="%s"></audio>', $post_url );
+	// Note: The audio renderer extracts the URL from the src attribute and uses it as a link,
+	// not as an actual audio source. While semantically incorrect to use a post URL in an
+	// audio src attribute, this is the expected format for the WooCommerce audio renderer.
+	// The renderer will create a clickable link to the post, not attempt to play audio.
+	$escaped_post_url   = esc_url( $post_url );
+	$block_content_html = sprintf( '<audio src="%s"></audio>', $escaped_post_url );
 
 	// Create a mock parsed block that WooCommerce's audio renderer can handle
 	$mock_parsed_block = array(
 		'attrs' => array(
-			'src'   => $post_url,
+			'src'   => $escaped_post_url,
 			'label' => __( 'Listen to the podcast', 'jetpack' ),
 		),
 	);

--- a/projects/plugins/jetpack/extensions/blocks/podcast-player/podcast-player.php
+++ b/projects/plugins/jetpack/extensions/blocks/podcast-player/podcast-player.php
@@ -309,10 +309,10 @@ function render( $name, $template_props = array(), $print = true ) {
  *
  * @return string
  */
-function render_email( $block_content, array $parsed_block, $rendering_context ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+function render_email( $block_content, array $parsed_block, $rendering_context ) {
 	// Validate input parameters and required dependencies
 	if ( ! isset( $parsed_block['attrs'] ) || ! is_array( $parsed_block['attrs'] ) ||
-		! class_exists( '\Automattic\WooCommerce\EmailEditor\Integrations\Utils\Table_Wrapper_Helper' ) ) {
+		! class_exists( '\Automattic\WooCommerce\EmailEditor\Integrations\Core\Renderer\Blocks\Audio' ) ) {
 		return '';
 	}
 
@@ -323,87 +323,35 @@ function render_email( $block_content, array $parsed_block, $rendering_context )
 		return '';
 	}
 
-	// Get spacing from email_attrs for better consistency with core blocks
-	$email_attrs        = $parsed_block['email_attrs'] ?? array();
-	$table_margin_style = '';
+	// Link to the post containing the podcast player for better UX
+	// Users can see the full context and interact with the full player on the site
+	$post_url = get_the_permalink();
 
-	if ( ! empty( $email_attrs ) && class_exists( '\WP_Style_Engine' ) ) {
-		// Get margin for table styling
-		$table_margin_style = \WP_Style_Engine::compile_css( array_intersect_key( $email_attrs, array_flip( array( 'margin' ) ) ), '' ) ?? '';
-
-		// Validate CSS output to prevent injection
-		if ( ! empty( $table_margin_style ) && ! preg_match( '/^[a-zA-Z0-9\s:;()-]+$/', $table_margin_style ) ) {
-			$table_margin_style = '';
-		}
+	if ( empty( $post_url ) ) {
+		return '';
 	}
 
-	$icon_image = 'https://s0.wp.com/i/emails/wpcom-notifications/audio-play.png';
-	$label      = __( 'Listen to the podcast', 'jetpack' );
-	$audio_url  = esc_url( $attr['url'] );
+	// Build block content HTML with audio tag that the audio renderer expects
+	// Use the post URL so the link goes to the post, not a single episode
+	$post_url           = esc_url( $post_url );
+	$block_content_html = sprintf( '<audio src="%s"></audio>', $post_url );
 
-	// Define pill-style colors and styling
-	$background_color = '#f6f7f7';
-	$border_color     = '#AAA';
-	$icon_size        = '18px';
-	$font_size        = '14px';
-
-	// Generate the icon content
-	$icon_content = sprintf(
-		'<a href="%1$s" rel="noopener nofollow" target="_blank" style="padding: 0.25em; padding-left: 17px; display: inline-block; vertical-align: middle;"><img height="%2$s" src="%3$s" style="display:block;margin-right:0;vertical-align:middle;" width="%2$s" alt="%4$s"></a>',
-		esc_url( $audio_url ),
-		esc_attr( $icon_size ),
-		esc_url( $icon_image ),
-		// translators: %s is the podcast player icon.
-		sprintf( __( '%s icon', 'jetpack' ), __( 'Podcast', 'jetpack' ) )
-	);
-	$icon_content = \Automattic\WooCommerce\EmailEditor\Integrations\Utils\Table_Wrapper_Helper::render_table_cell( $icon_content, array( 'style' => sprintf( 'vertical-align:middle;font-size:%s;', $font_size ) ) );
-
-	// Generate the label content
-	$label_content    = sprintf(
-		'<a href="%1$s" rel="noopener nofollow" target="_blank" style="text-decoration:none; padding: 0.25em; padding-right: 17px; display: inline-block;"><span style="margin-left:.5em;margin-right:.5em;font-weight:bold"> %2$s </span></a>',
-		esc_url( $audio_url ),
-		esc_html( $label )
-	);
-	$label_cell_style = sprintf(
-		'vertical-align:middle;font-size:%s;',
-		$font_size
-	);
-	$label_content    = \Automattic\WooCommerce\EmailEditor\Integrations\Utils\Table_Wrapper_Helper::render_table_cell( $label_content, array( 'style' => $label_cell_style ) );
-
-	// Combine icon and label tables
-	$podcast_content = $icon_content . $label_content;
-
-	// Create the main pill-style table
-	$main_table_styles = sprintf(
-		'background-color: %s; border-radius: 9999px; display: inline-table; float: none; border: 1px solid %s; border-collapse: separate;',
-		$background_color,
-		$border_color
+	// Create a mock parsed block that WooCommerce's audio renderer can handle
+	$mock_parsed_block = array(
+		'attrs' => array(
+			'src'   => $post_url,
+			'label' => __( 'Listen to the podcast', 'jetpack' ),
+		),
 	);
 
-	$main_table_attrs = array(
-		'align' => 'left',
-		'style' => $main_table_styles,
-	);
-
-	$main_table = \Automattic\WooCommerce\EmailEditor\Integrations\Utils\Table_Wrapper_Helper::render_table_wrapper( $podcast_content, $main_table_attrs, array(), array(), false );
-
-	// Create the main wrapper table
-	$table_style = 'width: 100%;';
-	if ( ! empty( $table_margin_style ) ) {
-		$table_style = $table_margin_style . '; ' . $table_style;
-	} else {
-		$table_style = 'margin: 16px 0; ' . $table_style;
+	// Preserve email_attrs if present (used for spacing)
+	if ( ! empty( $parsed_block['email_attrs'] ) ) {
+		$mock_parsed_block['email_attrs'] = $parsed_block['email_attrs'];
 	}
 
-	$table_attrs = array(
-		'style' => $table_style,
-	);
+	// Use WooCommerce's core audio renderer
+	$woo_audio_renderer = new \Automattic\WooCommerce\EmailEditor\Integrations\Core\Renderer\Blocks\Audio();
 
-	$cell_attrs = array(
-		'style' => 'min-width: 100%; vertical-align: middle; word-break: break-word; text-align: left;',
-	);
-
-	$main_wrapper = \Automattic\WooCommerce\EmailEditor\Integrations\Utils\Table_Wrapper_Helper::render_table_wrapper( $main_table, $table_attrs, $cell_attrs );
-
-	return \Automattic\WooCommerce\EmailEditor\Integrations\Utils\Table_Wrapper_Helper::render_outlook_table_wrapper( $main_wrapper, array( 'align' => 'left' ) );
+	return $woo_audio_renderer->render( $block_content_html, $mock_parsed_block, $rendering_context );
 }
+

--- a/projects/plugins/jetpack/tests/php/extensions/blocks/Podcast_Player_Block_Email_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/blocks/Podcast_Player_Block_Email_Test.php
@@ -10,6 +10,7 @@ require_once JETPACK__PLUGIN_DIR . 'extensions/blocks/podcast-player/podcast-pla
 // Include mock classes for WooCommerce Email Editor helpers
 require_once __DIR__ . '/mocks/class-mock-styles-helper.php';
 require_once __DIR__ . '/mocks/class-mock-table-wrapper-helper.php';
+require_once __DIR__ . '/mocks/class-mock-woocommerce-audio-renderer.php';
 
 use PHPUnit\Framework\Attributes\CoversFunction;
 
@@ -65,6 +66,17 @@ class Podcast_Player_Block_Email_Test extends WP_UnitTestCase {
 	 * Test render_email with valid podcast URL.
 	 */
 	public function test_render_email_with_valid_podcast_url() {
+		// Create a test post so get_the_permalink() works
+		$post_id = wp_insert_post(
+			array(
+				'post_title'   => 'Test Post',
+				'post_content' => 'Test content',
+				'post_status'  => 'publish',
+			)
+		);
+		global $post;
+		$post = get_post( $post_id );
+
 		$parsed_block = $this->create_parsed_block_with_attrs();
 		$mock_context = $this->create_rendering_context_mock();
 		$result       = \Automattic\Jetpack\Extensions\Podcast_Player\render_email( '', $parsed_block, $mock_context );
@@ -75,11 +87,17 @@ class Podcast_Player_Block_Email_Test extends WP_UnitTestCase {
 		$this->assertStringContainsString( 'href=', $result );
 		$this->assertStringContainsString( 'Listen to the podcast', $result );
 
+		// Should link to the post URL, not the RSS feed URL
+		$this->assertStringContainsString( get_permalink( $post_id ), $result );
+
 		// Should contain table-based layout for email compatibility
-		$this->assertStringContainsString( 'border-collapse: collapse', $result );
+		$this->assertStringContainsString( 'border-collapse', $result );
 
 		// Should contain margin styling for email spacing
 		$this->assertStringContainsString( 'margin: 16px 0', $result );
+
+		// Cleanup
+		wp_delete_post( $post_id, true );
 	}
 
 	/**
@@ -98,9 +116,40 @@ class Podcast_Player_Block_Email_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test render_email returns empty when no post context.
+	 */
+	public function test_render_email_returns_empty_when_no_post() {
+		// Clear global post to simulate no post context
+		global $post;
+		$original_post = $post;
+		$post          = null;
+
+		$parsed_block = $this->create_parsed_block_with_attrs();
+		$mock_context = $this->create_rendering_context_mock();
+		$result       = \Automattic\Jetpack\Extensions\Podcast_Player\render_email( '', $parsed_block, $mock_context );
+
+		// Should return empty string when no post permalink available
+		$this->assertSame( '', $result );
+
+		// Restore original post
+		$post = $original_post;
+	}
+
+	/**
 	 * Test render_email with empty URL.
 	 */
 	public function test_render_email_with_empty_url() {
+		// Create a test post so get_the_permalink() works
+		$post_id = wp_insert_post(
+			array(
+				'post_title'   => 'Test Post',
+				'post_content' => 'Test content',
+				'post_status'  => 'publish',
+			)
+		);
+		global $post;
+		$post = get_post( $post_id );
+
 		$parsed_block = $this->create_parsed_block_with_attrs(
 			array(
 				'url' => '',
@@ -111,12 +160,26 @@ class Podcast_Player_Block_Email_Test extends WP_UnitTestCase {
 
 		// Should return empty string when no valid URL
 		$this->assertSame( '', $result );
+
+		// Cleanup
+		wp_delete_post( $post_id, true );
 	}
 
 	/**
 	 * Test render_email with invalid URL.
 	 */
 	public function test_render_email_with_invalid_url() {
+		// Create a test post so get_the_permalink() works
+		$post_id = wp_insert_post(
+			array(
+				'post_title'   => 'Test Post',
+				'post_content' => 'Test content',
+				'post_status'  => 'publish',
+			)
+		);
+		global $post;
+		$post = get_post( $post_id );
+
 		$parsed_block = $this->create_parsed_block_with_attrs(
 			array(
 				'url' => 'not-a-valid-url',
@@ -127,12 +190,26 @@ class Podcast_Player_Block_Email_Test extends WP_UnitTestCase {
 
 		// Should return empty string when URL is invalid
 		$this->assertSame( '', $result );
+
+		// Cleanup
+		wp_delete_post( $post_id, true );
 	}
 
 	/**
-	 * Test render_email returns empty when WooCommerce Email Editor helper classes are missing.
+	 * Test render_email returns empty when WooCommerce Email Editor audio renderer class is missing.
 	 */
-	public function test_render_email_returns_empty_when_helpers_missing() {
+	public function test_render_email_returns_empty_when_audio_renderer_missing() {
+		// Create a test post so get_the_permalink() works
+		$post_id = wp_insert_post(
+			array(
+				'post_title'   => 'Test Post',
+				'post_content' => 'Test content',
+				'post_status'  => 'publish',
+			)
+		);
+		global $post;
+		$post = get_post( $post_id );
+
 		$parsed_block = $this->create_parsed_block_with_attrs();
 		$mock_context = $this->create_rendering_context_mock();
 
@@ -141,16 +218,30 @@ class Podcast_Player_Block_Email_Test extends WP_UnitTestCase {
 		$this->assertNotEmpty( $result_with_mocks );
 
 		// Test the class existence check logic directly
-		$table_helper_exists = class_exists( '\Automattic\WooCommerce\EmailEditor\Integrations\Utils\Table_Wrapper_Helper' );
+		$audio_renderer_exists = class_exists( '\Automattic\WooCommerce\EmailEditor\Integrations\Core\Renderer\Blocks\Audio' );
 
 		// Class should exist due to our mock
-		$this->assertTrue( $table_helper_exists, 'Table_Wrapper_Helper class should be mocked and available' );
+		$this->assertTrue( $audio_renderer_exists, 'Audio renderer class should be mocked and available' );
+
+		// Cleanup
+		wp_delete_post( $post_id, true );
 	}
 
 	/**
 	 * Test render_email security - URL validation.
 	 */
 	public function test_render_email_security_url_validation() {
+		// Create a test post so get_the_permalink() works
+		$post_id = wp_insert_post(
+			array(
+				'post_title'   => 'Test Post',
+				'post_content' => 'Test content',
+				'post_status'  => 'publish',
+			)
+		);
+		global $post;
+		$post = get_post( $post_id );
+
 		$parsed_block = $this->create_parsed_block_with_attrs(
 			array(
 				'url' => 'https://feeds.acast.com/public/shows/test-podcast',
@@ -161,35 +252,67 @@ class Podcast_Player_Block_Email_Test extends WP_UnitTestCase {
 
 		// Should render with valid URL
 		$this->assertNotEmpty( $result );
-		$this->assertStringContainsString( 'href="https://feeds.acast.com/public/shows/test-podcast"', $result );
+		// Should link to the post URL, not the RSS feed URL
+		$this->assertStringContainsString( get_permalink( $post_id ), $result );
+
+		// Cleanup
+		wp_delete_post( $post_id, true );
 	}
 
 	/**
 	 * Test render_email contains proper button styling.
 	 */
 	public function test_render_email_contains_button_styling() {
+		// Create a test post so get_the_permalink() works
+		$post_id = wp_insert_post(
+			array(
+				'post_title'   => 'Test Post',
+				'post_content' => 'Test content',
+				'post_status'  => 'publish',
+			)
+		);
+		global $post;
+		$post = get_post( $post_id );
+
 		$parsed_block = $this->create_parsed_block_with_attrs();
 		$mock_context = $this->create_rendering_context_mock();
 		$result       = \Automattic\Jetpack\Extensions\Podcast_Player\render_email( '', $parsed_block, $mock_context );
 
-		// Should contain button styling
+		// Should contain button styling from audio renderer
 		$this->assertNotEmpty( $result );
 		$this->assertStringContainsString( 'background-color: #f6f7f7', $result );
 		$this->assertStringContainsString( 'border: 1px solid #AAA', $result );
 		$this->assertStringContainsString( 'border-radius: 9999px', $result );
+
+		// Cleanup
+		wp_delete_post( $post_id, true );
 	}
 
 	/**
 	 * Test render_email contains play icon.
 	 */
 	public function test_render_email_contains_play_icon() {
+		// Create a test post so get_the_permalink() works
+		$post_id = wp_insert_post(
+			array(
+				'post_title'   => 'Test Post',
+				'post_content' => 'Test content',
+				'post_status'  => 'publish',
+			)
+		);
+		global $post;
+		$post = get_post( $post_id );
+
 		$parsed_block = $this->create_parsed_block_with_attrs();
 		$mock_context = $this->create_rendering_context_mock();
 		$result       = \Automattic\Jetpack\Extensions\Podcast_Player\render_email( '', $parsed_block, $mock_context );
 
-		// Should contain play icon
+		// Should contain play icon from audio renderer
 		$this->assertNotEmpty( $result );
 		$this->assertStringContainsString( 'audio-play.png', $result );
 		$this->assertStringContainsString( '<img', $result );
+
+		// Cleanup
+		wp_delete_post( $post_id, true );
 	}
 }

--- a/projects/plugins/jetpack/tests/php/extensions/blocks/mocks/class-mock-woocommerce-audio-renderer.php
+++ b/projects/plugins/jetpack/tests/php/extensions/blocks/mocks/class-mock-woocommerce-audio-renderer.php
@@ -24,7 +24,7 @@ if ( ! class_exists( '\Automattic\WooCommerce\EmailEditor\Integrations\Core\Rend
 
 			// Get URL from attrs or extract from block_content
 			$url = $attributes['src'] ?? '';
-			if ( empty( $url ) && preg_match( '/<audio[^>]*\ssrc=["\']([^"\']*)["\'][^>]*/?>/', $block_content, $matches ) ) {
+			if ( empty( $url ) && preg_match( '#<audio[^>]*\ssrc=["\']([^"\']*)["\'][^>]*/?>#', $block_content, $matches ) ) {
 				$url = $matches[1] ?? '';
 			}
 

--- a/projects/plugins/jetpack/tests/php/extensions/blocks/mocks/class-mock-woocommerce-audio-renderer.php
+++ b/projects/plugins/jetpack/tests/php/extensions/blocks/mocks/class-mock-woocommerce-audio-renderer.php
@@ -42,7 +42,9 @@ if ( ! class_exists( '\Automattic\WooCommerce\EmailEditor\Integrations\Core\Rend
 				$table_margin_style = \WP_Style_Engine::compile_css( array_intersect_key( $email_attrs, array_flip( array( 'margin' ) ) ), '' );
 			}
 
-			$icon_image = plugins_url( '/icons/audio/audio-play.png', __FILE__ );
+			// Use CDN URL for icon in mock
+			// This ensures the mock works in tests without requiring actual icon files
+			$icon_image = 'https://s0.wp.com/i/emails/wpcom-notifications/audio-play.png';
 			$audio_url  = esc_url( $url );
 
 			// Define pill-style colors and styling

--- a/projects/plugins/jetpack/tests/php/extensions/blocks/mocks/class-mock-woocommerce-audio-renderer.php
+++ b/projects/plugins/jetpack/tests/php/extensions/blocks/mocks/class-mock-woocommerce-audio-renderer.php
@@ -1,0 +1,102 @@
+<?php
+/**
+ * Mock class for WooCommerce Email Editor Audio Renderer
+ *
+ * @package automattic/jetpack
+ */
+
+// Mock WooCommerce Audio Renderer class for testing
+if ( ! class_exists( '\Automattic\WooCommerce\EmailEditor\Integrations\Core\Renderer\Blocks\Audio' ) ) {
+	/**
+	 * Mock implementation of WooCommerce Audio Renderer for testing
+	 */
+	class Mock_WooCommerce_Audio_Renderer {
+		/**
+		 * Mock render method
+		 *
+		 * @param string $block_content The block content.
+		 * @param array  $parsed_block  The parsed block data.
+		 * @param object $rendering_context The email rendering context.
+		 * @return string
+		 */
+		public function render( $block_content, $parsed_block, $rendering_context ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+			$attributes = $parsed_block['attrs'] ?? array();
+
+			// Get URL from attrs or extract from block_content
+			$url = $attributes['src'] ?? '';
+			if ( empty( $url ) && preg_match( '/<audio[^>]*\ssrc=["\']([^"\']*)["\'][^>]*/?>/', $block_content, $matches ) ) {
+				$url = $matches[1] ?? '';
+			}
+
+			if ( empty( $url ) ) {
+				return '';
+			}
+
+			$label = $attributes['label'] ?? __( 'Listen to the audio', 'jetpack' );
+
+			// Get spacing from email_attrs
+			$email_attrs        = $parsed_block['email_attrs'] ?? array();
+			$table_margin_style = '';
+
+			if ( ! empty( $email_attrs ) && class_exists( '\WP_Style_Engine' ) ) {
+				$table_margin_style = \WP_Style_Engine::compile_css( array_intersect_key( $email_attrs, array_flip( array( 'margin' ) ) ), '' );
+			}
+
+			$icon_image = plugins_url( '/icons/audio/audio-play.png', __FILE__ );
+			$audio_url  = esc_url( $url );
+
+			// Define pill-style colors and styling
+			$background_color = '#f6f7f7';
+			$border_color     = '#AAA';
+			$icon_size        = '18px';
+
+			// Generate the icon content
+			$icon_content = sprintf(
+				'<a href="%1$s" rel="noopener nofollow" target="_blank" style="padding: 0.25em; padding-left: 17px; display: inline-block; vertical-align: middle;"><img height="%2$s" src="%3$s" style="display:block;margin-right:0;vertical-align:middle;" width="%2$s" alt="%4$s"></a>',
+				$audio_url,
+				esc_attr( $icon_size ),
+				esc_url( $icon_image ),
+				// translators: %s is the audio player icon.
+				sprintf( __( '%s icon', 'jetpack' ), __( 'Audio', 'jetpack' ) )
+			);
+
+			// Generate the label content
+			$label_content = sprintf(
+				'<a href="%1$s" rel="noopener nofollow" target="_blank" style="text-decoration:none; padding: 0.25em; padding-right: 17px; display: inline-block;"><span style="margin-left:.5em;margin-right:.5em;font-weight:bold"> %2$s </span></a>',
+				$audio_url,
+				esc_html( $label )
+			);
+
+			// Combine icon and label
+			$audio_content = $icon_content . $label_content;
+
+			// Create the main pill-style table
+			$main_table_styles = sprintf(
+				'background-color: %s; border-radius: 9999px; float: none; border: 1px solid %s; border-collapse: separate;',
+				$background_color,
+				$border_color
+			);
+
+			$main_table = sprintf(
+				'<table role="presentation" align="left" style="%s"><tr><td>%s</td></tr></table>',
+				esc_attr( $main_table_styles ),
+				$audio_content
+			);
+
+			// Create the main wrapper table
+			$table_style = 'width: 100%;';
+			if ( ! empty( $table_margin_style ) ) {
+				$table_style = $table_margin_style . '; ' . $table_style;
+			} else {
+				$table_style = 'margin: 16px 0; ' . $table_style;
+			}
+
+			return sprintf(
+				'<table role="presentation" style="%s"><tr><td style="min-width: 100%%; vertical-align: middle; word-break: break-word; text-align: left;">%s</td></tr></table>',
+				esc_attr( $table_style ),
+				$main_table
+			);
+		}
+	}
+	class_alias( 'Mock_WooCommerce_Audio_Renderer', '\Automattic\WooCommerce\EmailEditor\Integrations\Core\Renderer\Blocks\Audio' );
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://linear.app/a8c/issue/NL-152/podcast-player-block-re-use-the-core-audio-block-rendering

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Re-purposes the core audio block email rendering from the WooCommerce Email Editor package. This reduces duplication and gives us better email compatibility.
* Changes the RSS feed link to a post link. I realized "Listen to the podcast" doesn't really align with an RSS link. We could link to the first episode, but linking to the full player seemed like the better option. We link other blocks to the post from the email, like contact form blocks.
* Updates tests.

<img width="684" height="497" alt="Screenshot 2026-01-26 at 4 22 54 PM" src="https://github.com/user-attachments/assets/8c664404-acb2-45ff-b63c-c9d8918022f8" />



### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply these changes to your sandbox: `bin/jetpack-downloader test jetpack update/podcast-player-email-rendering`
* Sandbox the API.
* Turn on write access.
* Sandbox all jobs and run the jobs watcher.
* Create a post with a podcast player. You can use this feed URL: https://feed.homecooking.show/
* Preview, send a test email, and publish the post. You should see a "Listen to the podcast" button that links to the post.
* Create and test a podcast player block on Atomic / Jetpack.

