### PR TITLE
Forms: Fix dashboard inspector "mark as read/unread" action

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-dashboard-mark-read-unread
+++ b/projects/packages/forms/changelog/fix-forms-dashboard-mark-read-unread
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: Fix dashboard inspector "mark as read/unread" action

--- a/projects/packages/forms/src/dashboard/inbox/stage/index.js
+++ b/projects/packages/forms/src/dashboard/inbox/stage/index.js
@@ -244,8 +244,12 @@ export default function InboxView() {
 			return;
 		}
 
-		// Update sidebar if item changed or needs refresh
-		if ( ! sidePanelItem || getItemId( sidePanelItem ) !== getItemId( recordToShow ) ) {
+		// Update sidebar if item changed or needs refresh.
+		// Items can be updated from row actions (e.g. mark as read/unread) without changing the selected ID.
+		const isSameItem = sidePanelItem && getItemId( sidePanelItem ) === getItemId( recordToShow );
+		const needsRefresh = ! isSameItem || sidePanelItem.is_unread !== recordToShow.is_unread;
+
+		if ( needsRefresh ) {
 			setSidePanelItem( recordToShow );
 		}
 	}, [ isMobileViewport, records, selection, sidePanelItem ] );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes FORMS-560

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Fix the update logic of the sidebar header

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the responses dashboard (current one, not wp-build)
* Select a response
* Using the actions in the row by clicking on `...`, mark the response as read or unread
* Check that the button changes on the inspector sidebar header as well to match the expected action (Mark as read or unread)

| Before | After |
| - | - |
| <img width="1085" height="588" alt="2026-01-26_19-11" src="https://github.com/user-attachments/assets/6e35d0b3-f3bf-42d3-9e5c-bcf7c989b73b" /> | <img width="955" height="548" alt="2026-01-26_19-11_1" src="https://github.com/user-attachments/assets/b8e2ffe9-ada9-4ffa-bfbe-7e70f48c1c2c" /> |

