### PR TITLE
Forms: Ensure form block is selected and locked when editing forms, and restrict available blocks to form-related blocks only.

### DIFF
--- a/projects/packages/forms/changelog/fix-jetpack-form-keep-form-selected
+++ b/projects/packages/forms/changelog/fix-jetpack-form-keep-form-selected
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Bug fixes for the form editor

--- a/projects/packages/forms/changelog/fix-jetpack-form-keep-form-selected
+++ b/projects/packages/forms/changelog/fix-jetpack-form-keep-form-selected
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Bug fixes for the form editor
+Ensure form block is selected and locked when editing forms, and restrict available blocks to form-related blocks only.

--- a/projects/packages/forms/src/form-editor/class-form-editor.php
+++ b/projects/packages/forms/src/form-editor/class-form-editor.php
@@ -146,6 +146,9 @@ class Form_Editor {
 	 * @param \WP_Screen $screen The current screen object.
 	 */
 	public static function disable_block_directory( $screen ) {
+		if ( ! isset( $screen->post_type ) ) {
+			return;
+		}
 		if ( Contact_Form::POST_TYPE === $screen->post_type ) {
 			remove_action( 'enqueue_block_editor_assets', 'wp_enqueue_editor_block_directory_assets' );
 		}

--- a/projects/packages/forms/src/form-editor/class-form-editor.php
+++ b/projects/packages/forms/src/form-editor/class-form-editor.php
@@ -97,6 +97,7 @@ class Form_Editor {
 			// Core blocks for rich content.
 			'core/audio',
 			'core/button',
+			'core/code',
 			'core/columns',
 			'core/column',
 			'core/group',
@@ -105,6 +106,7 @@ class Form_Editor {
 			'core/image',
 			'core/list',
 			'core/list-item',
+			'core/math',
 			'core/paragraph',
 			'core/row',
 			'core/separator',

--- a/projects/packages/forms/src/form-editor/class-form-editor.php
+++ b/projects/packages/forms/src/form-editor/class-form-editor.php
@@ -31,6 +31,7 @@ class Form_Editor {
 		add_filter( 'allowed_block_types_all', array( __CLASS__, 'allowed_blocks_for_jetpack_form' ), 10, 2 );
 		add_filter( 'block_editor_settings_all', array( __CLASS__, 'block_editor_settings_all' ), 10, 2 );
 		add_action( 'admin_enqueue_scripts', array( __CLASS__, 'enqueue_admin_scripts' ) );
+		add_action( 'current_screen', array( __CLASS__, 'disable_block_directory' ) );
 	}
 
 	/**
@@ -131,6 +132,21 @@ class Form_Editor {
 		$settings['canLockBlocks'] = false;
 
 		return $settings;
+	}
+
+	/**
+	 * Disable the block directory in the form editor.
+	 *
+	 * Removes the block directory assets (install blocks from the inserter)
+	 * since this feature is not needed in the form editor.
+	 * Hooked to `current_screen` so it runs before scripts are enqueued.
+	 *
+	 * @param \WP_Screen $screen The current screen object.
+	 */
+	public static function disable_block_directory( $screen ) {
+		if ( Contact_Form::POST_TYPE === $screen->post_type ) {
+			remove_action( 'enqueue_block_editor_assets', 'wp_enqueue_editor_block_directory_assets' );
+		}
 	}
 
 	/**

--- a/projects/packages/forms/src/form-editor/index.tsx
+++ b/projects/packages/forms/src/form-editor/index.tsx
@@ -105,24 +105,25 @@ const state = {
 	formBlockClientId: null as string | null,
 	categoriesSetUp: false,
 	previousCategories: null as unknown[] | null,
-	blockDirectoryPlugin: null as Record< string, unknown > | null,
+	blockDirectoryPlugin: null as PluginSettings,
 	previousAllowedBlockTypes: null as string[] | boolean | null,
 	lastRootBlockIds: '',
 	lastSelectedBlockId: null as string | null | undefined,
 	isFormBlockLocked: false,
 };
 
+const BLOCK_DIRECTORY_PLUGIN_NAME = 'block-directory';
 /**
  * Disable the block directory plugin while in the form editor.
  * Stores the plugin settings so it can be re-enabled when leaving.
  */
 const disableBlockDirectory = () => {
-	const plugin = getPlugin( 'block-directory' );
+	const plugin = getPlugin( BLOCK_DIRECTORY_PLUGIN_NAME );
 	if ( ! plugin ) {
 		return;
 	}
-	state.blockDirectoryPlugin = plugin as unknown as Record< string, unknown >;
-	unregisterPlugin( 'block-directory' );
+	state.blockDirectoryPlugin = plugin as PluginSettings;
+	unregisterPlugin( BLOCK_DIRECTORY_PLUGIN_NAME );
 };
 
 /**
@@ -132,7 +133,7 @@ const restoreBlockDirectory = () => {
 	if ( ! state.blockDirectoryPlugin ) {
 		return;
 	}
-	registerPlugin( 'block-directory', state.blockDirectoryPlugin as PluginSettings | null );
+	registerPlugin( BLOCK_DIRECTORY_PLUGIN_NAME, state.blockDirectoryPlugin );
 	state.blockDirectoryPlugin = null;
 };
 

--- a/projects/packages/forms/src/form-editor/index.tsx
+++ b/projects/packages/forms/src/form-editor/index.tsx
@@ -27,6 +27,8 @@ import {
 	registerFormCategories,
 	unregisterFormCategories,
 } from './utils/category-utils';
+import { getAllowedBlocks } from './utils/get-allowed-blocks';
+import type { PluginSettings } from '@wordpress/plugins';
 
 import './style.scss';
 
@@ -102,6 +104,7 @@ const state = {
 	categoriesSetUp: false,
 	previousCategories: null as unknown[] | null,
 	blockDirectoryPlugin: null as Record< string, unknown > | null,
+	previousAllowedBlockTypes: null as string[] | boolean | null,
 	lastRootBlockIds: '',
 	lastSelectedBlockId: null as string | null | undefined,
 	isFormBlockLocked: false,
@@ -116,7 +119,7 @@ const disableBlockDirectory = () => {
 	if ( ! plugin ) {
 		return;
 	}
-	state.blockDirectoryPlugin = plugin as Record< string, unknown >;
+	state.blockDirectoryPlugin = plugin as unknown as Record< string, unknown >;
 	unregisterPlugin( 'block-directory' );
 };
 
@@ -127,8 +130,42 @@ const restoreBlockDirectory = () => {
 	if ( ! state.blockDirectoryPlugin ) {
 		return;
 	}
-	registerPlugin( 'block-directory', state.blockDirectoryPlugin );
+	registerPlugin( 'block-directory', state.blockDirectoryPlugin as unknown as PluginSettings );
 	state.blockDirectoryPlugin = null;
+};
+
+/**
+ * Restrict the editor to only allow form-related blocks.
+ * Stores the previous setting so it can be restored when leaving.
+ */
+const restrictAllowedBlocks = () => {
+	const { getSettings } = select( 'core/block-editor' );
+	const { updateSettings } = dispatch( 'core/block-editor' ) as {
+		updateSettings: ( settings: Record< string, unknown > ) => void;
+	};
+
+	const settings = getSettings() as { allowedBlockTypes?: string[] | boolean };
+	const currentAllowed = settings.allowedBlockTypes ?? true;
+	const newAllowed = getAllowedBlocks();
+
+	state.previousAllowedBlockTypes = currentAllowed;
+	updateSettings( { allowedBlockTypes: newAllowed } );
+};
+
+/**
+ * Restore the original allowed block types when leaving the form editor.
+ */
+const restoreAllowedBlocks = () => {
+	if ( state.previousAllowedBlockTypes === null ) {
+		return;
+	}
+	const { updateSettings } = dispatch( 'core/block-editor' ) as {
+		updateSettings: ( settings: Record< string, unknown > ) => void;
+	};
+
+	const restoring = state.previousAllowedBlockTypes;
+	updateSettings( { allowedBlockTypes: restoring } );
+	state.previousAllowedBlockTypes = null;
 };
 
 /**
@@ -236,87 +273,110 @@ const setupFormEditorSubscription = () => {
 	if ( unsubscribe ) {
 		return;
 	}
+
+	let isProcessing = false;
 	unsubscribe = subscribe( () => {
-		const { getCurrentPostType } = select( 'core/editor' );
-		const isFormEditor = getCurrentPostType() === FORM_POST_TYPE;
-
-		// 1. Handle form editor enter/leave transitions
-		if ( isFormEditor !== state.isFormEditor ) {
-			state.isFormEditor = isFormEditor;
-
-			if ( isFormEditor ) {
-				document.body.classList.add( 'post-type-jetpack_form' );
-			} else {
-				document.body.classList.remove( 'post-type-jetpack_form' );
-
-				if ( state.categoriesSetUp ) {
-					state.categoriesSetUp = false;
-					restoreOriginalCategories( state.previousCategories || [] );
-				}
-				restoreBlockDirectory();
-
-				state.formBlockClientId = null;
-				state.lastRootBlockIds = '';
-				state.lastSelectedBlockId = null;
-				state.isFormBlockLocked = false;
-			}
-		}
-
-		// 2. Early return if not in form editor
-		if ( ! isFormEditor ) {
+		if ( isProcessing ) {
 			return;
 		}
+		isProcessing = true;
+		try {
+			const { getCurrentPostType } = select( 'core/editor' );
+			const isFormEditor = getCurrentPostType() === FORM_POST_TYPE;
 
-		// 3. One-time category setup and block directory disable
-		if ( ! state.categoriesSetUp ) {
-			state.categoriesSetUp = true;
-			state.previousCategories = setupFormEditorCategories();
+			// 1. Handle form editor enter/leave transitions
+			if ( isFormEditor !== state.isFormEditor ) {
+				state.isFormEditor = isFormEditor;
 
-			disableBlockDirectory();
-		}
+				if ( isFormEditor ) {
+					document.body.classList.add( 'post-type-jetpack_form' );
+				} else {
+					document.body.classList.remove( 'post-type-jetpack_form' );
 
-		// 4. React to root block changes (locate, select, nest)
-		const { getBlocks } = select( 'core/block-editor' );
-		const rootBlocks = getBlocks();
-		const currentRootBlockIds = JSON.stringify( rootBlocks.map( b => b.clientId ) );
+					if ( state.categoriesSetUp ) {
+						state.categoriesSetUp = false;
+						restoreOriginalCategories( state.previousCategories || [] );
+					}
+					restoreBlockDirectory();
+					restoreAllowedBlocks();
 
-		if ( currentRootBlockIds !== state.lastRootBlockIds ) {
-			state.lastRootBlockIds = currentRootBlockIds;
-
-			// Re-locate the form block — it may have a new clientId after
-			// block replacement (e.g. when Gutenberg parses the post content).
-			const previousFormBlockClientId = state.formBlockClientId;
-			const formBlock = findFormBlock( rootBlocks );
-			state.formBlockClientId = formBlock ? formBlock.clientId : null;
-
-			if ( state.formBlockClientId && state.formBlockClientId !== previousFormBlockClientId ) {
-				state.isFormBlockLocked = false;
+					state.formBlockClientId = null;
+					state.lastRootBlockIds = '';
+					state.lastSelectedBlockId = null;
+					state.isFormBlockLocked = false;
+				}
 			}
 
-			if ( state.formBlockClientId ) {
+			// 2. Early return if not in form editor
+			if ( ! isFormEditor ) {
+				return;
+			}
+
+			// 3. One-time category setup and block directory disable
+			if ( ! state.categoriesSetUp ) {
+				state.categoriesSetUp = true;
+				state.previousCategories = setupFormEditorCategories();
+
+				disableBlockDirectory();
+			}
+
+			// 4. React to root block changes (locate, select, nest)
+			const { getBlocks } = select( 'core/block-editor' );
+			const rootBlocks = getBlocks();
+			const currentRootBlockIds = JSON.stringify( rootBlocks.map( b => b.clientId ) );
+
+			if ( currentRootBlockIds !== state.lastRootBlockIds ) {
+				state.lastRootBlockIds = currentRootBlockIds;
+
+				// Re-locate the form block — it may have a new clientId after
+				// block replacement (e.g. when Gutenberg parses the post content).
+				const previousFormBlockClientId = state.formBlockClientId;
+				const formBlock = findFormBlock( rootBlocks );
+				state.formBlockClientId = formBlock ? formBlock.clientId : null;
+
+				if ( state.formBlockClientId && state.formBlockClientId !== previousFormBlockClientId ) {
+					state.isFormBlockLocked = false;
+				}
+
+				// DEBUG: Track when form block first appears
+				if ( state.formBlockClientId && ! previousFormBlockClientId ) {
+					// Defer restrictAllowedBlocks to break out of the synchronous dispatch chain.
+					// This ensures ExperimentalBlockEditorProvider finishes its re-renders
+					// before we update settings.
+					if ( state.previousAllowedBlockTypes === null ) {
+						requestAnimationFrame( () => {
+							restrictAllowedBlocks();
+						} );
+					}
+				}
+
+				if ( state.formBlockClientId ) {
+					enforceBlockSelection();
+				}
+
+				enforceBlockNesting();
+			}
+
+			// 5. React to selection changes
+			const { getSelectedBlockClientId } = select( 'core/block-editor' );
+			const currentSelectedBlockId = getSelectedBlockClientId();
+			if ( currentSelectedBlockId !== state.lastSelectedBlockId ) {
+				state.lastSelectedBlockId = currentSelectedBlockId;
 				enforceBlockSelection();
 			}
 
-			enforceBlockNesting();
-		}
-
-		// 5. React to selection changes
-		const { getSelectedBlockClientId } = select( 'core/block-editor' );
-		const currentSelectedBlockId = getSelectedBlockClientId();
-		if ( currentSelectedBlockId !== state.lastSelectedBlockId ) {
-			state.lastSelectedBlockId = currentSelectedBlockId;
-			enforceBlockSelection();
-		}
-
-		// 6. Ensure form block is locked
-		if ( ! state.isFormBlockLocked && state.formBlockClientId ) {
-			lockFormBlock();
-			const { getBlock } = select( 'core/block-editor' );
-			const formBlock = getBlock( state.formBlockClientId );
-			const lock = formBlock?.attributes?.lock as BlockLock | undefined;
-			if ( formBlock && lock?.remove && lock?.move ) {
-				state.isFormBlockLocked = true;
+			// 6. Ensure form block is locked
+			if ( ! state.isFormBlockLocked && state.formBlockClientId ) {
+				lockFormBlock();
+				const { getBlock } = select( 'core/block-editor' );
+				const formBlock = getBlock( state.formBlockClientId );
+				const lock = formBlock?.attributes?.lock as BlockLock | undefined;
+				if ( formBlock && lock?.remove && lock?.move ) {
+					state.isFormBlockLocked = true;
+				}
 			}
+		} finally {
+			isProcessing = false;
 		}
 	} );
 

--- a/projects/packages/forms/src/form-editor/index.tsx
+++ b/projects/packages/forms/src/form-editor/index.tsx
@@ -8,7 +8,7 @@
  */
 
 import { subscribe, select, dispatch } from '@wordpress/data';
-import { unregisterPlugin } from '@wordpress/plugins';
+import { getPlugin, registerPlugin, unregisterPlugin } from '@wordpress/plugins';
 import { FORM_POST_TYPE } from '../blocks/shared/util/constants.js';
 import {
 	activateBlockCategoryOverrides,
@@ -93,26 +93,49 @@ const restoreOriginalCategories = ( previousCategories: unknown[] ) => {
 	setCategories( categories );
 };
 
-let formBlockClientId: string | null = null;
 /**
- * Locate the contact-form block in the editor and store its client ID.
+ * Subscription state — tracks editor state across ticks to detect changes.
  */
-const locateFormBlock = () => {
-	const { getBlocks } = select( 'core/block-editor' );
-	const blocks = getBlocks();
+const state = {
+	isFormEditor: null as boolean | null,
+	formBlockClientId: null as string | null,
+	categoriesSetUp: false,
+	previousCategories: null as unknown[] | null,
+	blockDirectoryPlugin: null as Record< string, unknown > | null,
+	lastRootBlockIds: '',
+	lastSelectedBlockId: null as string | null | undefined,
+	isFormBlockLocked: false,
+};
 
-	const formBlock = findFormBlock( blocks );
-
-	if ( formBlock ) {
-		formBlockClientId = formBlock.clientId;
+/**
+ * Disable the block directory plugin while in the form editor.
+ * Stores the plugin settings so it can be re-enabled when leaving.
+ */
+const disableBlockDirectory = () => {
+	const plugin = getPlugin( 'block-directory' );
+	if ( ! plugin ) {
+		return;
 	}
+	state.blockDirectoryPlugin = plugin as Record< string, unknown >;
+	unregisterPlugin( 'block-directory' );
+};
+
+/**
+ * Re-enable the block directory plugin when leaving the form editor.
+ */
+const restoreBlockDirectory = () => {
+	if ( ! state.blockDirectoryPlugin ) {
+		return;
+	}
+	registerPlugin( 'block-directory', state.blockDirectoryPlugin );
+	state.blockDirectoryPlugin = null;
 };
 
 /**
  * Lock the contact-form block to prevent moving and removing the block.
  */
 const lockFormBlock = () => {
-	if ( ! formBlockClientId ) {
+	if ( ! state.formBlockClientId ) {
 		return;
 	}
 
@@ -121,13 +144,13 @@ const lockFormBlock = () => {
 		updateBlockAttributes: ( clientId: string, attributes: Record< string, unknown > ) => void;
 	};
 
-	const formBlock = getBlock( formBlockClientId );
+	const formBlock = getBlock( state.formBlockClientId );
 	if ( ! formBlock ) {
 		return;
 	}
 
 	if ( shouldLockBlock( formBlock ) ) {
-		updateBlockAttributes( formBlockClientId, {
+		updateBlockAttributes( state.formBlockClientId, {
 			lock: {
 				remove: true,
 				move: true,
@@ -140,7 +163,7 @@ const lockFormBlock = () => {
  * Ensure the contact-form block is always selected when no other block is selected.
  */
 const enforceBlockSelection = () => {
-	if ( ! formBlockClientId ) {
+	if ( ! state.formBlockClientId ) {
 		return;
 	}
 	const { getSelectedBlockClientId, hasMultiSelection } = select( 'core/block-editor' );
@@ -153,7 +176,7 @@ const enforceBlockSelection = () => {
 		const { selectBlock } = dispatch( 'core/block-editor' ) as {
 			selectBlock: ( clientId: string ) => void;
 		};
-		selectBlock( formBlockClientId );
+		selectBlock( state.formBlockClientId );
 	}
 };
 
@@ -162,7 +185,7 @@ const enforceBlockSelection = () => {
  * Uses pure utility functions for easier testing.
  */
 const enforceBlockNesting = () => {
-	if ( ! formBlockClientId ) {
+	if ( ! state.formBlockClientId ) {
 		return;
 	}
 
@@ -174,14 +197,14 @@ const enforceBlockNesting = () => {
 	}
 
 	// Find any blocks that aren't the form block
-	const blocksToMove = getBlocksToMove( rootBlocks, formBlockClientId );
+	const blocksToMove = getBlocksToMove( rootBlocks, state.formBlockClientId );
 
 	if ( blocksToMove.length === 0 ) {
 		return;
 	}
 
 	// Get the form block to determine where to insert the blocks
-	const formBlock = rootBlocks.find( b => b.clientId === formBlockClientId );
+	const formBlock = rootBlocks.find( b => b.clientId === state.formBlockClientId );
 	const targetIndex = formBlock ? getInsertionIndex( formBlock ) : 0;
 
 	// Collect all client IDs to move
@@ -199,18 +222,10 @@ const enforceBlockNesting = () => {
 	moveBlocksToPosition(
 		clientIdsToMove,
 		'', // From root
-		formBlockClientId, // To form block
+		state.formBlockClientId, // To form block
 		targetIndex
 	);
 };
-
-let isJetpackFormEditor: boolean | null = null;
-let categoriesFiltered: boolean = false;
-
-let lastRootBlockIds: string = '';
-let lastSelectedBlockId: string | null | undefined = null;
-let isFormBlockLocked: boolean = false;
-let previousCategories: unknown[] | null = null;
 
 let unsubscribe: ( () => void ) | null = null;
 
@@ -223,97 +238,86 @@ const setupFormEditorSubscription = () => {
 	}
 	unsubscribe = subscribe( () => {
 		const { getCurrentPostType } = select( 'core/editor' );
-		const isCurrentPostTypeJetpackForm = getCurrentPostType() === FORM_POST_TYPE;
-		if ( isCurrentPostTypeJetpackForm ) {
-			// Check if root blocks changed by comparing their IDs
-			// This detects when blocks are added, removed, or reordered at the root level
-			const { getBlocks } = select( 'core/block-editor' );
-			const rootBlocks = getBlocks();
-			const currentRootBlockIds = JSON.stringify( rootBlocks.map( b => b.clientId ) );
+		const isFormEditor = getCurrentPostType() === FORM_POST_TYPE;
 
-			if ( currentRootBlockIds !== lastRootBlockIds ) {
-				lastRootBlockIds = currentRootBlockIds;
+		// 1. Handle form editor enter/leave transitions
+		if ( isFormEditor !== state.isFormEditor ) {
+			state.isFormEditor = isFormEditor;
 
-				// Re-locate the form block — it may have a new clientId after
-				// block replacement (e.g. when Gutenberg parses the post content).
-				const previousFormBlockClientId = formBlockClientId;
-				formBlockClientId = null;
-				locateFormBlock();
+			if ( isFormEditor ) {
+				document.body.classList.add( 'post-type-jetpack_form' );
+			} else {
+				document.body.classList.remove( 'post-type-jetpack_form' );
 
-				if ( formBlockClientId && formBlockClientId !== previousFormBlockClientId ) {
-					// Reset lock flag — the new block instance won't have the lock attribute
-					isFormBlockLocked = false;
+				if ( state.categoriesSetUp ) {
+					state.categoriesSetUp = false;
+					restoreOriginalCategories( state.previousCategories || [] );
 				}
+				restoreBlockDirectory();
 
-				// Ensure the form block is selected and nested correctly
-				// after any root block change (including initial load).
-				if ( formBlockClientId ) {
-					enforceBlockSelection();
-				}
-
-				enforceBlockNesting();
+				state.formBlockClientId = null;
+				state.lastRootBlockIds = '';
+				state.lastSelectedBlockId = null;
+				state.isFormBlockLocked = false;
 			}
-
-			// Only check selection when it changes
-			const { getSelectedBlockClientId } = select( 'core/block-editor' );
-			const currentSelectedBlockId = getSelectedBlockClientId();
-			if ( currentSelectedBlockId !== lastSelectedBlockId ) {
-				lastSelectedBlockId = currentSelectedBlockId;
-				enforceBlockSelection();
-			}
-
-			// Only try to lock the form block once
-			if ( ! isFormBlockLocked && formBlockClientId ) {
-				lockFormBlock();
-				// Verify the block is now locked by checking the attributes
-				const { getBlock } = select( 'core/block-editor' );
-				const formBlock = getBlock( formBlockClientId );
-				const lock = formBlock?.attributes?.lock as BlockLock | undefined;
-				if ( formBlock && lock?.remove && lock?.move ) {
-					isFormBlockLocked = true;
-				}
-			}
-
-			// Locate the form block if we haven't yet
-			if ( ! formBlockClientId ) {
-				locateFormBlock();
-
-				if ( formBlockClientId ) {
-					enforceBlockSelection();
-				}
-			}
-
-			if ( ! categoriesFiltered ) {
-				categoriesFiltered = true;
-				previousCategories = setupFormEditorCategories();
-				try {
-					unregisterPlugin( 'block-directory' );
-				} catch {
-					// Plugin may not be registered, ignore.
-				}
-			}
-		} else if ( categoriesFiltered ) {
-			categoriesFiltered = false;
-			restoreOriginalCategories( previousCategories || [] );
 		}
 
-		if ( isCurrentPostTypeJetpackForm === isJetpackFormEditor ) {
+		// 2. Early return if not in form editor
+		if ( ! isFormEditor ) {
 			return;
 		}
 
-		if ( isCurrentPostTypeJetpackForm ) {
-			document.body.classList.add( 'post-type-jetpack_form' );
-		} else {
-			document.body.classList.remove( 'post-type-jetpack_form' );
-			formBlockClientId = null; // Reset the form block client ID if we are not in the Form editor anymore.
+		// 3. One-time category setup and block directory disable
+		if ( ! state.categoriesSetUp ) {
+			state.categoriesSetUp = true;
+			state.previousCategories = setupFormEditorCategories();
 
-			// Reset performance tracking state
-			lastRootBlockIds = '';
-			lastSelectedBlockId = null;
-			isFormBlockLocked = false;
+			disableBlockDirectory();
 		}
-		// Update the flag.
-		isJetpackFormEditor = isCurrentPostTypeJetpackForm;
+
+		// 4. React to root block changes (locate, select, nest)
+		const { getBlocks } = select( 'core/block-editor' );
+		const rootBlocks = getBlocks();
+		const currentRootBlockIds = JSON.stringify( rootBlocks.map( b => b.clientId ) );
+
+		if ( currentRootBlockIds !== state.lastRootBlockIds ) {
+			state.lastRootBlockIds = currentRootBlockIds;
+
+			// Re-locate the form block — it may have a new clientId after
+			// block replacement (e.g. when Gutenberg parses the post content).
+			const previousFormBlockClientId = state.formBlockClientId;
+			const formBlock = findFormBlock( rootBlocks );
+			state.formBlockClientId = formBlock ? formBlock.clientId : null;
+
+			if ( state.formBlockClientId && state.formBlockClientId !== previousFormBlockClientId ) {
+				state.isFormBlockLocked = false;
+			}
+
+			if ( state.formBlockClientId ) {
+				enforceBlockSelection();
+			}
+
+			enforceBlockNesting();
+		}
+
+		// 5. React to selection changes
+		const { getSelectedBlockClientId } = select( 'core/block-editor' );
+		const currentSelectedBlockId = getSelectedBlockClientId();
+		if ( currentSelectedBlockId !== state.lastSelectedBlockId ) {
+			state.lastSelectedBlockId = currentSelectedBlockId;
+			enforceBlockSelection();
+		}
+
+		// 6. Ensure form block is locked
+		if ( ! state.isFormBlockLocked && state.formBlockClientId ) {
+			lockFormBlock();
+			const { getBlock } = select( 'core/block-editor' );
+			const formBlock = getBlock( state.formBlockClientId );
+			const lock = formBlock?.attributes?.lock as BlockLock | undefined;
+			if ( formBlock && lock?.remove && lock?.move ) {
+				state.isFormBlockLocked = true;
+			}
+		}
 	} );
 
 	// Ensure we clean up the subscription when the editor/page unloads to avoid leaks.

--- a/projects/packages/forms/src/form-editor/index.tsx
+++ b/projects/packages/forms/src/form-editor/index.tsx
@@ -302,6 +302,10 @@ const setupFormEditorSubscription = () => {
 					}
 					restoreBlockDirectory();
 					restoreAllowedBlocks();
+					if ( requestAnimationFrameId ) {
+						cancelAnimationFrame( requestAnimationFrameId );
+						requestAnimationFrameId = null;
+					}
 
 					state.formBlockClientId = null;
 					state.lastRootBlockIds = '';

--- a/projects/packages/forms/src/form-editor/index.tsx
+++ b/projects/packages/forms/src/form-editor/index.tsx
@@ -291,7 +291,7 @@ const setupFormEditorSubscription = () => {
 			// 1. Handle form editor enter/leave transitions
 			// Detect if we are in the form editor and detect when this state changes across ticks.
 			if ( isFormEditor !== state.isFormEditor ) {
-				state.isFormEditor = isFormEditor; // lets store the current isFormEditor in the state object for future reference.
+				state.isFormEditor = isFormEditor; // Store the current isFormEditor in the state object for future reference.
 
 				if ( isFormEditor ) {
 					// We just entered the form editor.

--- a/projects/packages/forms/src/form-editor/index.tsx
+++ b/projects/packages/forms/src/form-editor/index.tsx
@@ -346,7 +346,9 @@ const setupFormEditorSubscription = () => {
 					state.isFormBlockLocked = false;
 				}
 
-				// When the form block first appears, defer restricting allowed blocks.
+				// When the form block first appears, defer restrictAllowedBlocks to break
+				// out of the synchronous dispatch chain and ensure ExperimentalBlockEditorProvider
+				// finishes its re-renders before we update settings.
 				if ( state.formBlockClientId && ! previousFormBlockClientId ) {
 					// Defer restrictAllowedBlocks to break out of the synchronous dispatch chain.
 					// This ensures ExperimentalBlockEditorProvider finishes its re-renders

--- a/projects/packages/forms/src/form-editor/index.tsx
+++ b/projects/packages/forms/src/form-editor/index.tsx
@@ -105,7 +105,7 @@ const state = {
 	formBlockClientId: null as string | null,
 	categoriesSetUp: false,
 	previousCategories: null as unknown[] | null,
-	blockDirectoryPlugin: null as PluginSettings,
+	blockDirectoryPlugin: null as PluginSettings | null,
 	previousAllowedBlockTypes: null as string[] | boolean | null,
 	lastRootBlockIds: '',
 	lastSelectedBlockId: null as string | null | undefined,
@@ -351,10 +351,10 @@ const setupFormEditorSubscription = () => {
 				// out of the synchronous dispatch chain and ensure ExperimentalBlockEditorProvider
 				// finishes its re-renders before we update settings.
 				if ( state.formBlockClientId && ! previousFormBlockClientId ) {
-					// Defer restrictAllowedBlocks to break out of the synchronous dispatch chain.
-					// This ensures ExperimentalBlockEditorProvider finishes its re-renders
-					// before we update settings.
 					if ( state.previousAllowedBlockTypes === null ) {
+						if ( requestAnimationFrameId ) {
+							cancelAnimationFrame( requestAnimationFrameId );
+						}
 						requestAnimationFrameId = requestAnimationFrame( () => {
 							// Guard against race conditions: the editor may no longer be
 							// in form editing mode, or the allowed block types may have

--- a/projects/packages/forms/src/form-editor/index.tsx
+++ b/projects/packages/forms/src/form-editor/index.tsx
@@ -304,6 +304,7 @@ const setupFormEditorSubscription = () => {
 					state.lastRootBlockIds = '';
 					state.lastSelectedBlockId = null;
 					state.isFormBlockLocked = false;
+					state.previousCategories = null;
 				}
 			}
 
@@ -338,13 +339,19 @@ const setupFormEditorSubscription = () => {
 					state.isFormBlockLocked = false;
 				}
 
-				// DEBUG: Track when form block first appears
+				// When the form block first appears, defer restricting allowed blocks.
 				if ( state.formBlockClientId && ! previousFormBlockClientId ) {
 					// Defer restrictAllowedBlocks to break out of the synchronous dispatch chain.
 					// This ensures ExperimentalBlockEditorProvider finishes its re-renders
 					// before we update settings.
 					if ( state.previousAllowedBlockTypes === null ) {
 						requestAnimationFrame( () => {
+							// Guard against race conditions: the editor may no longer be
+							// in form editing mode, or the allowed block types may have
+							// already been initialized by the time this runs.
+							if ( ! state.isFormEditor || state.previousAllowedBlockTypes !== null ) {
+								return;
+							}
 							restrictAllowedBlocks();
 						} );
 					}

--- a/projects/packages/forms/src/form-editor/index.tsx
+++ b/projects/packages/forms/src/form-editor/index.tsx
@@ -289,12 +289,15 @@ const setupFormEditorSubscription = () => {
 			const isFormEditor = getCurrentPostType() === FORM_POST_TYPE;
 
 			// 1. Handle form editor enter/leave transitions
+			// Detect if we are in the form editor and detect when this state changes across ticks.
 			if ( isFormEditor !== state.isFormEditor ) {
-				state.isFormEditor = isFormEditor;
+				state.isFormEditor = isFormEditor; // lets store the current isFormEditor in the state object for future reference.
 
 				if ( isFormEditor ) {
+					// We just entered the form editor.
 					document.body.classList.add( 'post-type-jetpack_form' );
 				} else {
+					// We just left the form editor.
 					document.body.classList.remove( 'post-type-jetpack_form' );
 
 					if ( state.categoriesSetUp ) {
@@ -318,6 +321,7 @@ const setupFormEditorSubscription = () => {
 
 			// 2. Early return if not in form editor
 			if ( ! isFormEditor ) {
+				// We are not in the form editor, nothing more to do.
 				return;
 			}
 

--- a/projects/packages/forms/src/form-editor/index.tsx
+++ b/projects/packages/forms/src/form-editor/index.tsx
@@ -265,6 +265,7 @@ const enforceBlockNesting = () => {
 };
 
 let unsubscribe: ( () => void ) | null = null;
+let requestAnimationFrameId: number | null = null;
 
 /**
  * Sets up a subscription to monitor editor state changes and enforce form editor behavior.
@@ -345,7 +346,7 @@ const setupFormEditorSubscription = () => {
 					// This ensures ExperimentalBlockEditorProvider finishes its re-renders
 					// before we update settings.
 					if ( state.previousAllowedBlockTypes === null ) {
-						requestAnimationFrame( () => {
+						requestAnimationFrameId = requestAnimationFrame( () => {
 							// Guard against race conditions: the editor may no longer be
 							// in form editing mode, or the allowed block types may have
 							// already been initialized by the time this runs.
@@ -395,6 +396,11 @@ const setupFormEditorSubscription = () => {
 			} finally {
 				unsubscribe = null;
 			}
+		}
+
+		if ( requestAnimationFrameId ) {
+			cancelAnimationFrame( requestAnimationFrameId );
+			requestAnimationFrameId = null;
 		}
 		window.removeEventListener( 'beforeunload', handleUnload );
 	};

--- a/projects/packages/forms/src/form-editor/index.tsx
+++ b/projects/packages/forms/src/form-editor/index.tsx
@@ -233,6 +233,24 @@ const setupFormEditorSubscription = () => {
 
 			if ( currentRootBlockIds !== lastRootBlockIds ) {
 				lastRootBlockIds = currentRootBlockIds;
+
+				// Re-locate the form block — it may have a new clientId after
+				// block replacement (e.g. when Gutenberg parses the post content).
+				const previousFormBlockClientId = formBlockClientId;
+				formBlockClientId = null;
+				locateFormBlock();
+
+				if ( formBlockClientId && formBlockClientId !== previousFormBlockClientId ) {
+					// Reset lock flag — the new block instance won't have the lock attribute
+					isFormBlockLocked = false;
+				}
+
+				// Ensure the form block is selected and nested correctly
+				// after any root block change (including initial load).
+				if ( formBlockClientId ) {
+					enforceBlockSelection();
+				}
+
 				enforceBlockNesting();
 			}
 
@@ -256,8 +274,13 @@ const setupFormEditorSubscription = () => {
 				}
 			}
 
+			// Locate the form block if we haven't yet
 			if ( ! formBlockClientId ) {
 				locateFormBlock();
+
+				if ( formBlockClientId ) {
+					enforceBlockSelection();
+				}
 			}
 
 			if ( ! categoriesFiltered ) {

--- a/projects/packages/forms/src/form-editor/index.tsx
+++ b/projects/packages/forms/src/form-editor/index.tsx
@@ -28,7 +28,9 @@ import {
 	unregisterFormCategories,
 } from './utils/category-utils';
 import { getAllowedBlocks } from './utils/get-allowed-blocks';
-import type { PluginSettings } from '@wordpress/plugins';
+import type { WPPlugin } from '@wordpress/plugins';
+
+type PluginSettings = Omit< WPPlugin, 'name' >;
 
 import './style.scss';
 
@@ -130,7 +132,7 @@ const restoreBlockDirectory = () => {
 	if ( ! state.blockDirectoryPlugin ) {
 		return;
 	}
-	registerPlugin( 'block-directory', state.blockDirectoryPlugin as unknown as PluginSettings );
+	registerPlugin( 'block-directory', state.blockDirectoryPlugin as PluginSettings | null );
 	state.blockDirectoryPlugin = null;
 };
 

--- a/projects/packages/forms/src/form-editor/index.tsx
+++ b/projects/packages/forms/src/form-editor/index.tsx
@@ -86,6 +86,7 @@ const restoreOriginalCategories = ( previousCategories: unknown[] ) => {
 	// If we have stored categories, restore them directly
 	if ( previousCategories.length !== 0 ) {
 		setCategories( previousCategories );
+		state.previousCategories = null;
 		return;
 	}
 
@@ -95,6 +96,7 @@ const restoreOriginalCategories = ( previousCategories: unknown[] ) => {
 	categories = unregisterFormCategories( categories );
 	categories = moveCategoryToBack( categories );
 	setCategories( categories );
+	state.previousCategories = null;
 };
 
 /**
@@ -315,7 +317,6 @@ const setupFormEditorSubscription = () => {
 					state.lastRootBlockIds = '';
 					state.lastSelectedBlockId = null;
 					state.isFormBlockLocked = false;
-					state.previousCategories = null;
 				}
 			}
 

--- a/projects/packages/forms/src/form-editor/utils/get-allowed-blocks.ts
+++ b/projects/packages/forms/src/form-editor/utils/get-allowed-blocks.ts
@@ -1,0 +1,15 @@
+import { childBlocks } from '../../blocks/contact-form/child-blocks.js';
+import { CORE_BLOCKS } from '../../blocks/shared/util/constants.js';
+
+/**
+ * Get the list of allowed blocks in the form editor.
+ *
+ * @return {string[]} Array of allowed block names.
+ */
+export function getAllowedBlocks(): string[] {
+	const allowedBlocks: string[] = [];
+	for ( const childBlock of childBlocks ) {
+		allowedBlocks.push( `jetpack/${ childBlock.name }` );
+	}
+	return allowedBlocks.concat( CORE_BLOCKS );
+}


### PR DESCRIPTION

Fixes FORMS-NEW

## Proposed changes:
* Make sure that the form is selected when we enter the form editor
* Make sure that we lock the form. 
* Make sure that we remove the plugin directory plugin. (and add it back) 
* Refactor to use a "state" object instead of the current variables. 
* Limit the available blocks in the form editor. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion


## Does this pull request change what data or activity we track or use?
no

## Testing instructions:
Have the Central form management enabled. 

```
add_filter( 'jetpack_block_editor_feature_flags', 'eb_register_feature' );

function eb_register_feature( $flags ) {
    $flags['central-form-management'] = ! isset( $_GET[  'not-cfm' ] );
    return $flags;
}
```

Go to the page editor.
Add the form block 
click on the Edit Form button. 

Notice that the form block is selected and is locked. 
Notice that the Block Inserter only have form block and they should be nearly organized in their own categories. 
Notice when you search for a block. That you don't end up with suggestions to install a plugin. 

Now click the back button. 
Notice that things returned back to normal. 
All blocks are not accessible. 
Categories are there as before. 
You are able to search for a block and plugins are being suggested for you. 

