### PR TITLE
Fix Newsletter menu link not working on Simple sites

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/dotcom-15379-fix-issue-with-the-url-menu-not-working-on-dotcom-simple
+++ b/projects/packages/jetpack-mu-wpcom/changelog/dotcom-15379-fix-issue-with-the-url-menu-not-working-on-dotcom-simple
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Admin Menu: fix Newsletter menu link not working on Simple sites by using Newsletter_Settings when enabled.
+Fix Newsletter menu on Simple sites to open in-admin settings when enabled instead of external URL.

--- a/projects/packages/jetpack-mu-wpcom/changelog/dotcom-15379-fix-issue-with-the-url-menu-not-working-on-dotcom-simple
+++ b/projects/packages/jetpack-mu-wpcom/changelog/dotcom-15379-fix-issue-with-the-url-menu-not-working-on-dotcom-simple
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Admin Menu: fix Newsletter menu link not working on Simple sites by using Newsletter_Settings when enabled.

--- a/projects/packages/jetpack-mu-wpcom/composer.json
+++ b/projects/packages/jetpack-mu-wpcom/composer.json
@@ -16,6 +16,7 @@
 		"automattic/jetpack-connection": "@dev",
 		"automattic/jetpack-google-analytics": "@dev",
 		"automattic/jetpack-masterbar": "@dev",
+		"automattic/jetpack-newsletter": "@dev",
 		"automattic/jetpack-redirect": "@dev",
 		"automattic/jetpack-stats-admin": "@dev",
 		"automattic/jetpack-status": "@dev",

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
@@ -8,6 +8,7 @@
  */
 
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
+use Automattic\Jetpack\Newsletter\Settings as Newsletter_Settings;
 use Automattic\Jetpack\Redirect;
 use Automattic\Jetpack\Subscribers_Dashboard\Dashboard as Subscribers_Dashboard;
 
@@ -344,14 +345,19 @@ function wpcom_add_jetpack_submenu() {
 
 	if ( $is_simple_site ) {
 		// Jetpack > Newsletter.
-		add_submenu_page(
-			'jetpack',
-			__( 'Newsletter', 'jetpack-mu-wpcom' ),
-			__( 'Newsletter', 'jetpack-mu-wpcom' ),
-			'manage_options',
-			'https://wordpress.com/settings/newsletter/' . $domain,
-			null // @phan-suppress-current-line PhanTypeMismatchArgumentProbablyReal -- Core should ideally document null for no-callback arg. https://core.trac.wordpress.org/ticket/52539.
-		);
+		if ( apply_filters( 'jetpack_wp_admin_newsletter_settings_enabled', false ) ) {
+			$newsletter_settings = new Newsletter_Settings();
+			$newsletter_settings->add_wp_admin_submenu();
+		} else {
+			add_submenu_page(
+				'jetpack',
+				__( 'Newsletter', 'jetpack-mu-wpcom' ),
+				__( 'Newsletter', 'jetpack-mu-wpcom' ),
+				'manage_options',
+				'https://wordpress.com/settings/newsletter/' . $domain,
+				null // @phan-suppress-current-line PhanTypeMismatchArgumentProbablyReal -- Core should ideally document null for no-callback arg. https://core.trac.wordpress.org/ticket/52539.
+			);
+		}
 
 		// Jetpack > Traffic
 		add_submenu_page(

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
@@ -346,6 +346,9 @@ function wpcom_add_jetpack_submenu() {
 	if ( $is_simple_site ) {
 		// Jetpack > Newsletter.
 		if ( apply_filters( 'jetpack_wp_admin_newsletter_settings_enabled', false ) ) {
+			// When enabled, call Newsletter Settings to add the in-admin settings page.
+			// This must be done here (at priority 999999) because the Jetpack menu
+			// is created by this function and doesn't exist at earlier priorities.
 			$newsletter_settings = new Newsletter_Settings();
 			$newsletter_settings->add_wp_admin_submenu();
 		} else {

--- a/projects/packages/newsletter/changelog/dotcom-15379-fix-issue-with-the-url-menu-not-working-on-dotcom-simple
+++ b/projects/packages/newsletter/changelog/dotcom-15379-fix-issue-with-the-url-menu-not-working-on-dotcom-simple
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Settings: refactor add_wp_admin_submenu to be callable from wpcom-admin-menu for proper menu integration on Simple sites.

--- a/projects/packages/newsletter/changelog/dotcom-15379-fix-issue-with-the-url-menu-not-working-on-dotcom-simple
+++ b/projects/packages/newsletter/changelog/dotcom-15379-fix-issue-with-the-url-menu-not-working-on-dotcom-simple
@@ -1,4 +1,3 @@
 Significance: patch
-Type: fixed
-
-Settings: refactor add_wp_admin_submenu to be callable from wpcom-admin-menu for proper menu integration on Simple sites.
+Type: changed
+Comment: Code quality improvements with no user-facing changes.

--- a/projects/packages/newsletter/changelog/dotcom-15379-fix-issue-with-the-url-menu-not-working-on-dotcom-simple
+++ b/projects/packages/newsletter/changelog/dotcom-15379-fix-issue-with-the-url-menu-not-working-on-dotcom-simple
@@ -1,3 +1,3 @@
 Significance: patch
 Type: changed
-Comment: Code quality improvements with no user-facing changes.
+Comment: Update newsletter settings menu on WordPress.com Simple sites to open an in-dashboard screen when enabled.

--- a/projects/packages/newsletter/src/class-settings.php
+++ b/projects/packages/newsletter/src/class-settings.php
@@ -70,8 +70,18 @@ class Settings {
 		if ( ! $this->expose_to_users() ) {
 			return;
 		}
+
+		$host = new Host();
+
+		// On wpcom Simple, the Jetpack menu is created at priority 999999 by wpcom-admin-menu.php,
+		// which will call add_wp_admin_submenu() directly. Skip adding the menu here to avoid
+		// trying to add a submenu before the parent menu exists.
+		if ( $host->is_wpcom_simple() ) {
+			return;
+		}
+
 		// Add admin menu item.
-		add_action( 'admin_menu', array( $this, 'add_wp_admin_submenu' ), 1000 );
+		add_action( 'admin_menu', array( $this, 'add_wp_admin_menu' ), 1000 );
 
 		// Hijack the config URLs to point to our settings page.
 		// Customize the configuration URL to lead to the Subscriptions settings.
@@ -84,11 +94,67 @@ class Settings {
 	}
 
 	/**
-	 * Add the newsletter settings submenu.
+	 * Add the newsletter settings submenu to the Jetpack menu.
 	 *
-	 * On wpcom, this is called from wpcom-admin-menu.php at late priority (999999)
-	 * when the Jetpack menu already exists. On standalone Jetpack, this is called
-	 * via init_hooks() at priority 1000.
+	 * Note: This method is NOT called on wpcom Simple sites. Simple sites use
+	 * add_wp_admin_submenu() called from wpcom-admin-menu.php instead.
+	 *
+	 * Menu visibility rules:
+	 * - wpcom Atomic: Show under 'jetpack' if module active, hidden if inactive.
+	 * - Standalone Jetpack: Show under 'jetpack' if module active, hidden if inactive.
+	 */
+	public function add_wp_admin_menu() {
+		if ( ! $this->expose_to_users() ) {
+			return;
+		}
+
+		$host             = new Host();
+		$is_module_active = $this->is_subscriptions_active();
+
+		// Determine parent slug and menu registration method.
+		// - wpcom Atomic: Show in Jetpack menu if active, hidden page if inactive.
+		// - Standalone Jetpack: Show in Jetpack menu if active, hidden page if inactive.
+		if ( $host->is_woa_site() ) {
+			$parent_slug      = $is_module_active ? 'jetpack' : '';
+			$use_jetpack_menu = false; // Use add_submenu_page for Atomic sites.
+		} else {
+			$parent_slug      = $is_module_active ? 'jetpack' : '';
+			$use_jetpack_menu = $is_module_active;
+		}
+
+		// Register menu item.
+		if ( $use_jetpack_menu ) {
+			$page_suffix = Admin_Menu::add_menu(
+				/** "Newsletter" is a product name, do not translate. */
+				'Newsletter',
+				'Newsletter',
+				'manage_options',
+				'jetpack-newsletter',
+				array( $this, 'render' ),
+				10
+			);
+		} else {
+			$page_suffix = add_submenu_page(
+				$parent_slug,
+				/** "Newsletter" is a product name, do not translate. */
+				'Newsletter',
+				'Newsletter',
+				'manage_options',
+				'jetpack-newsletter',
+				array( $this, 'render' )
+			);
+		}
+
+		if ( $page_suffix ) {
+			add_action( 'load-' . $page_suffix, array( $this, 'admin_init' ) );
+		}
+	}
+
+	/**
+	 * Add the newsletter settings submenu directly under the Jetpack menu.
+	 *
+	 * This method is called from wpcom-admin-menu.php on Simple sites at late priority
+	 * (999999) when the Jetpack menu already exists.
 	 *
 	 * Similar to Subscribers_Dashboard::add_wp_admin_submenu().
 	 */
@@ -97,46 +163,15 @@ class Settings {
 			return;
 		}
 
-		$host = new Host();
-
-		if ( $host->is_wpcom_platform() ) {
-			// On wpcom, use add_submenu_page directly under 'jetpack'.
-			// When called from wpcom-admin-menu.php at late priority, the menu exists.
-			$page_suffix = add_submenu_page(
-				'jetpack',
-				/** "Newsletter" is a product name, do not translate. */
-				'Newsletter',
-				'Newsletter',
-				'manage_options',
-				'jetpack-newsletter',
-				array( $this, 'render' )
-			);
-		} else {
-			// For standalone Jetpack, use Admin_Menu which handles timing.
-			$is_module_active = $this->is_subscriptions_active();
-			if ( $is_module_active ) {
-				$page_suffix = Admin_Menu::add_menu(
-					/** "Newsletter" is a product name, do not translate. */
-					'Newsletter',
-					'Newsletter',
-					'manage_options',
-					'jetpack-newsletter',
-					array( $this, 'render' ),
-					10
-				);
-			} else {
-				// Hidden page when module is inactive.
-				$page_suffix = add_submenu_page(
-					'',
-					/** "Newsletter" is a product name, do not translate. */
-					'Newsletter',
-					'Newsletter',
-					'manage_options',
-					'jetpack-newsletter',
-					array( $this, 'render' )
-				);
-			}
-		}
+		$page_suffix = add_submenu_page(
+			'jetpack',
+			/** "Newsletter" is a product name, do not translate. */
+			'Newsletter',
+			'Newsletter',
+			'manage_options',
+			'jetpack-newsletter',
+			array( $this, 'render' )
+		);
 
 		if ( $page_suffix ) {
 			add_action( 'load-' . $page_suffix, array( $this, 'admin_init' ) );

--- a/projects/packages/newsletter/src/class-settings.php
+++ b/projects/packages/newsletter/src/class-settings.php
@@ -71,7 +71,7 @@ class Settings {
 			return;
 		}
 		// Add admin menu item.
-		add_action( 'admin_menu', array( $this, 'add_wp_admin_menu' ), 1000 );
+		add_action( 'admin_menu', array( $this, 'add_wp_admin_submenu' ), 1000 );
 
 		// Hijack the config URLs to point to our settings page.
 		// Customize the configuration URL to lead to the Subscriptions settings.
@@ -84,38 +84,26 @@ class Settings {
 	}
 
 	/**
-	 * Add the newsletter settings menu to the Jetpack menu.
+	 * Add the newsletter settings submenu.
+	 *
+	 * On wpcom, this is called from wpcom-admin-menu.php at late priority (999999)
+	 * when the Jetpack menu already exists. On standalone Jetpack, this is called
+	 * via init_hooks() at priority 1000.
+	 *
+	 * Similar to Subscribers_Dashboard::add_wp_admin_submenu().
 	 */
-	public function add_wp_admin_menu() {
-		$is_module_active = $this->is_subscriptions_active();
-		$host             = new Host();
-
-		// Determine parent slug and menu registration method.
-		// - wpcom simple: Always show in Jetpack menu (module always active).
-		// - wpcom atomic: Show in Jetpack menu if active, hidden page if inactive.
-		// - Jetpack: Show in Jetpack menu if active, hidden page if inactive.
-		if ( $host->is_wpcom_platform() ) {
-			$parent_slug      = ( $host->is_wpcom_simple() || $is_module_active ) ? 'jetpack' : '';
-			$use_jetpack_menu = false; // Use add_submenu_page for all wpcom sites.
-		} else {
-			$parent_slug      = $is_module_active ? 'jetpack' : '';
-			$use_jetpack_menu = $is_module_active;
+	public function add_wp_admin_submenu() {
+		if ( ! $this->expose_to_users() ) {
+			return;
 		}
 
-		// Register menu item.
-		if ( $use_jetpack_menu ) {
-			$page_suffix = Admin_Menu::add_menu(
-				/** "Newsletter" is a product name, do not translate. */
-				'Newsletter',
-				'Newsletter',
-				'manage_options',
-				'jetpack-newsletter',
-				array( $this, 'render' ),
-				10
-			);
-		} else {
+		$host = new Host();
+
+		if ( $host->is_wpcom_platform() ) {
+			// On wpcom, use add_submenu_page directly under 'jetpack'.
+			// When called from wpcom-admin-menu.php at late priority, the menu exists.
 			$page_suffix = add_submenu_page(
-				$parent_slug,
+				'jetpack',
 				/** "Newsletter" is a product name, do not translate. */
 				'Newsletter',
 				'Newsletter',
@@ -123,6 +111,31 @@ class Settings {
 				'jetpack-newsletter',
 				array( $this, 'render' )
 			);
+		} else {
+			// For standalone Jetpack, use Admin_Menu which handles timing.
+			$is_module_active = $this->is_subscriptions_active();
+			if ( $is_module_active ) {
+				$page_suffix = Admin_Menu::add_menu(
+					/** "Newsletter" is a product name, do not translate. */
+					'Newsletter',
+					'Newsletter',
+					'manage_options',
+					'jetpack-newsletter',
+					array( $this, 'render' ),
+					10
+				);
+			} else {
+				// Hidden page when module is inactive.
+				$page_suffix = add_submenu_page(
+					'',
+					/** "Newsletter" is a product name, do not translate. */
+					'Newsletter',
+					'Newsletter',
+					'manage_options',
+					'jetpack-newsletter',
+					array( $this, 'render' )
+				);
+			}
 		}
 
 		if ( $page_suffix ) {

--- a/projects/packages/newsletter/src/class-settings.php
+++ b/projects/packages/newsletter/src/class-settings.php
@@ -111,16 +111,11 @@ class Settings {
 		$host             = new Host();
 		$is_module_active = $this->is_subscriptions_active();
 
-		// Determine parent slug and menu registration method.
-		// - wpcom Atomic: Show in Jetpack menu if active, hidden page if inactive.
-		// - Standalone Jetpack: Show in Jetpack menu if active, hidden page if inactive.
-		if ( $host->is_woa_site() ) {
-			$parent_slug      = $is_module_active ? 'jetpack' : '';
-			$use_jetpack_menu = false; // Use add_submenu_page for Atomic sites.
-		} else {
-			$parent_slug      = $is_module_active ? 'jetpack' : '';
-			$use_jetpack_menu = $is_module_active;
-		}
+		// Show in Jetpack menu if module active, hidden page if inactive.
+		$parent_slug = $is_module_active ? 'jetpack' : '';
+
+		// On Atomic, use add_submenu_page. On standalone Jetpack, use Admin_Menu when active.
+		$use_jetpack_menu = ! $host->is_woa_site() && $is_module_active;
 
 		// Register menu item.
 		if ( $use_jetpack_menu ) {

--- a/projects/plugins/mu-wpcom-plugin/changelog/fix-simple-sites-newsletter-menu-for-new-settings-screen
+++ b/projects/plugins/mu-wpcom-plugin/changelog/fix-simple-sites-newsletter-menu-for-new-settings-screen
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: This feature isn't available to end-users yet
+
+

--- a/projects/plugins/mu-wpcom-plugin/composer.lock
+++ b/projects/plugins/mu-wpcom-plugin/composer.lock
@@ -1167,7 +1167,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/jetpack-mu-wpcom",
-                "reference": "3334deb2d498b927888402a6cc7b198d5ae703f3"
+                "reference": "afa473351bab3b6cbcfd5e6d688dd4fe2af04a4d"
             },
             "require": {
                 "automattic/block-delimiter": "@dev",
@@ -1179,6 +1179,7 @@
                 "automattic/jetpack-explat": "@dev",
                 "automattic/jetpack-google-analytics": "@dev",
                 "automattic/jetpack-masterbar": "@dev",
+                "automattic/jetpack-newsletter": "@dev",
                 "automattic/jetpack-redirect": "@dev",
                 "automattic/jetpack-stats-admin": "@dev",
                 "automattic/jetpack-status": "@dev",
@@ -1243,6 +1244,83 @@
                 "GPL-2.0-or-later"
             ],
             "description": "Enhances your site with features powered by WordPress.com",
+            "transport-options": {
+                "relative": true
+            }
+        },
+        {
+            "name": "automattic/jetpack-newsletter",
+            "version": "dev-trunk",
+            "dist": {
+                "type": "path",
+                "url": "../../packages/newsletter",
+                "reference": "1a93a83b9c6c9cc0eab0dcad4f8ac4ee1ddd7d36"
+            },
+            "require": {
+                "automattic/jetpack-admin-ui": "@dev",
+                "automattic/jetpack-assets": "@dev",
+                "automattic/jetpack-connection": "@dev",
+                "automattic/jetpack-redirect": "@dev",
+                "automattic/jetpack-status": "@dev",
+                "php": ">=7.2"
+            },
+            "require-dev": {
+                "automattic/jetpack-changelogger": "@dev",
+                "automattic/phpunit-select-config": "@dev",
+                "yoast/phpunit-polyfills": "^4.0.0"
+            },
+            "suggest": {
+                "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
+            },
+            "type": "jetpack-library",
+            "extra": {
+                "autorelease": true,
+                "autotagger": true,
+                "mirror-repo": "Automattic/jetpack-newsletter",
+                "branch-alias": {
+                    "dev-trunk": "0.3.x-dev"
+                },
+                "textdomain": "jetpack-newsletter",
+                "version-constants": {
+                    "::PACKAGE_VERSION": "src/class-settings.php"
+                },
+                "changelogger": {
+                    "link-template": "https://github.com/Automattic/jetpack-newsletter/compare/v${old}...v${new}"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "scripts": {
+                "build-development": [
+                    "pnpm run build"
+                ],
+                "build-production": [
+                    "pnpm run build-production"
+                ],
+                "watch": [
+                    "Composer\\Config::disableProcessTimeout",
+                    "pnpm run watch"
+                ],
+                "phpunit": [
+                    "phpunit-select-config phpunit.#.xml.dist --colors=always"
+                ],
+                "test-coverage": [
+                    "pnpm concurrently --names php,js 'php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\"' 'pnpm:test-coverage'"
+                ],
+                "test-php": [
+                    "@composer phpunit"
+                ],
+                "typecheck": [
+                    "pnpm run typecheck"
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Jetpack Newsletter functionality",
             "transport-options": {
                 "relative": true
             }

--- a/projects/plugins/wpcomsh/changelog/fix-simple-sites-newsletter-menu-for-new-settings-screen
+++ b/projects/plugins/wpcomsh/changelog/fix-simple-sites-newsletter-menu-for-new-settings-screen
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: This feature isn't available to end-users yet
+
+

--- a/projects/plugins/wpcomsh/composer.lock
+++ b/projects/plugins/wpcomsh/composer.lock
@@ -1376,7 +1376,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/jetpack-mu-wpcom",
-                "reference": "3334deb2d498b927888402a6cc7b198d5ae703f3"
+                "reference": "afa473351bab3b6cbcfd5e6d688dd4fe2af04a4d"
             },
             "require": {
                 "automattic/block-delimiter": "@dev",
@@ -1388,6 +1388,7 @@
                 "automattic/jetpack-explat": "@dev",
                 "automattic/jetpack-google-analytics": "@dev",
                 "automattic/jetpack-masterbar": "@dev",
+                "automattic/jetpack-newsletter": "@dev",
                 "automattic/jetpack-redirect": "@dev",
                 "automattic/jetpack-stats-admin": "@dev",
                 "automattic/jetpack-status": "@dev",
@@ -1452,6 +1453,83 @@
                 "GPL-2.0-or-later"
             ],
             "description": "Enhances your site with features powered by WordPress.com",
+            "transport-options": {
+                "relative": true
+            }
+        },
+        {
+            "name": "automattic/jetpack-newsletter",
+            "version": "dev-trunk",
+            "dist": {
+                "type": "path",
+                "url": "../../packages/newsletter",
+                "reference": "1a93a83b9c6c9cc0eab0dcad4f8ac4ee1ddd7d36"
+            },
+            "require": {
+                "automattic/jetpack-admin-ui": "@dev",
+                "automattic/jetpack-assets": "@dev",
+                "automattic/jetpack-connection": "@dev",
+                "automattic/jetpack-redirect": "@dev",
+                "automattic/jetpack-status": "@dev",
+                "php": ">=7.2"
+            },
+            "require-dev": {
+                "automattic/jetpack-changelogger": "@dev",
+                "automattic/phpunit-select-config": "@dev",
+                "yoast/phpunit-polyfills": "^4.0.0"
+            },
+            "suggest": {
+                "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
+            },
+            "type": "jetpack-library",
+            "extra": {
+                "autorelease": true,
+                "autotagger": true,
+                "mirror-repo": "Automattic/jetpack-newsletter",
+                "branch-alias": {
+                    "dev-trunk": "0.3.x-dev"
+                },
+                "textdomain": "jetpack-newsletter",
+                "version-constants": {
+                    "::PACKAGE_VERSION": "src/class-settings.php"
+                },
+                "changelogger": {
+                    "link-template": "https://github.com/Automattic/jetpack-newsletter/compare/v${old}...v${new}"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "scripts": {
+                "build-development": [
+                    "pnpm run build"
+                ],
+                "build-production": [
+                    "pnpm run build-production"
+                ],
+                "watch": [
+                    "Composer\\Config::disableProcessTimeout",
+                    "pnpm run watch"
+                ],
+                "phpunit": [
+                    "phpunit-select-config phpunit.#.xml.dist --colors=always"
+                ],
+                "test-coverage": [
+                    "pnpm concurrently --names php,js 'php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\"' 'pnpm:test-coverage'"
+                ],
+                "test-php": [
+                    "@composer phpunit"
+                ],
+                "typecheck": [
+                    "pnpm run typecheck"
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Jetpack Newsletter functionality",
             "transport-options": {
                 "relative": true
             }


### PR DESCRIPTION
Fixes DOTCOM-15379

## Proposed changes:

* Fix the Newsletter submenu link on Simple sites to point to either calypso or the new in-admin settings page
  - Add `Newsletter\Settings::add_wp_admin_submenu()` method callable from wpcom-admin-menu.php at the correct priority                                                                                   
  - Skip menu registration in `Newsletter\Settings::init_hooks()` on Simple sites to avoid timing issues (Jetpack menu doesn't exist at priority 1000) 


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion


## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

* On a Simple site with the `jetpack_wp_admin_newsletter_settings_enabled` filter returning `true` (e.g. by adding `add_filter( 'jetpack_wp_admin_newsletter_settings_enabled', '__return_true' );` to your 0-sandbox.php file:
  1. Go to WP Admin > Jetpack > Newsletter
  2. Verify the menu item opens the in-admin Newsletter settings page instead of redirecting to wordpress.com/settings/newsletter/
* On a Simple site without the filter enabled:
  1. Go to WP Admin > Jetpack > Newsletter
  2. Verify the menu item still links to the external wordpress.com URL (existing behavior)
* On standalone and atomic Jetpack sites:
  1. Add the code to your site via the comment below (JN) or jetpack beta
  2. Newsletter menu should show the old newsletter menu if the module is enabled
  4. You can add `add_filter( 'jetpack_wp_admin_newsletter_settings_enabled', '__return_true' );` to the top of `wp-content/mu-plugins/wpcomsh-dev/wpcomsh.php` to test the new code
  5. The Jetpack → Newsletter menu item should link to the new setting screen if the module is enabled.

> [!NOTE]  
> This just makes the menu work on simple, it doesn't resolve the API issues that means it displays "NetworkError when attempting to fetch resource.". This will be done as part of a separate issue.