### PR TITLE
Forms: Support form editing in Site Editor context

### DIFF
--- a/projects/packages/forms/changelog/fix-site-editor-edit-form-link
+++ b/projects/packages/forms/changelog/fix-site-editor-edit-form-link
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Contact Form: fix Edit Form button in the site editor by navigating directly to the form editor.

--- a/projects/packages/forms/changelog/fix-site-editor-edit-form-link
+++ b/projects/packages/forms/changelog/fix-site-editor-edit-form-link
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Contact Form: fix Edit Form button in the site editor by navigating directly to the form editor.
+Contact Form: Fix Edit Form button in the Site Editor by navigating directly to the form editor.

--- a/projects/packages/forms/src/blocks/contact-form/components/convert-form-toolbar.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/components/convert-form-toolbar.tsx
@@ -54,7 +54,7 @@ export function ConvertFormToolbar( { clientId, attributes }: ConvertFormToolbar
 	const hasRef = !! attributes.ref;
 
 	/**
-	 * Open the form editor directly in a new tab.
+	 * Open the form editor directly in a new window.
 	 * @param formId - The ID of the form to edit.
 	 */
 	const openFormEditor = ( formId: number ) => {

--- a/projects/packages/forms/src/blocks/contact-form/components/convert-form-toolbar.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/components/convert-form-toolbar.tsx
@@ -54,7 +54,7 @@ export function ConvertFormToolbar( { clientId, attributes }: ConvertFormToolbar
 	const hasRef = !! attributes.ref;
 
 	/**
-	 * Open the form editor directly in a new window.
+	 * Open the form editor by navigating directly.
 	 * @param formId - The ID of the form to edit.
 	 */
 	const openFormEditor = ( formId: number ) => {

--- a/projects/packages/forms/src/blocks/contact-form/components/convert-form-toolbar.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/components/convert-form-toolbar.tsx
@@ -9,6 +9,7 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
 import { __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
+import { addQueryArgs } from '@wordpress/url';
 import { FORM_POST_TYPE } from '../../shared/util/constants.js';
 import { createSyncedForm } from '../util/create-synced-form.ts';
 
@@ -31,10 +32,11 @@ export function ConvertFormToolbar( { clientId, attributes }: ConvertFormToolbar
 		};
 	}, [] );
 
-	const { onNavigateToEntityRecord } = useSelect( select => {
+	const { onNavigateToEntityRecord, isSiteEditor } = useSelect( select => {
 		const { getSettings } = select( blockEditorStore );
 		return {
 			onNavigateToEntityRecord: getSettings().onNavigateToEntityRecord,
+			isSiteEditor: !! select( 'core/edit-site' ),
 		};
 	}, [] );
 
@@ -50,6 +52,15 @@ export function ConvertFormToolbar( { clientId, attributes }: ConvertFormToolbar
 	const { createErrorNotice } = useDispatch( noticesStore );
 
 	const hasRef = !! attributes.ref;
+
+	/**
+	 * Open the form editor directly in a new tab.
+	 * @param formId - The ID of the form to edit.
+	 */
+	const openFormEditor = ( formId: number ) => {
+		const editUrl = addQueryArgs( 'post.php', { post: formId, action: 'edit' } );
+		window.location.href = editUrl;
+	};
 
 	/**
 	 * Convert inline form to synced form
@@ -94,7 +105,9 @@ export function ConvertFormToolbar( { clientId, attributes }: ConvertFormToolbar
 			// Update attributes using updateBlockAttributes which properly clears them
 			updateBlockAttributes( clientId, clearedAttributes );
 
-			if ( onNavigateToEntityRecord ) {
+			if ( isSiteEditor ) {
+				openFormEditor( formId );
+			} else if ( onNavigateToEntityRecord ) {
 				onNavigateToEntityRecord( {
 					postId: formId,
 					postType: FORM_POST_TYPE,
@@ -114,17 +127,24 @@ export function ConvertFormToolbar( { clientId, attributes }: ConvertFormToolbar
 	 * Navigate to edit the synced form post
 	 */
 	const handleEditOriginal = () => {
-		if ( ! attributes.ref || ! onNavigateToEntityRecord ) {
+		if ( ! attributes.ref ) {
 			return;
 		}
 
-		onNavigateToEntityRecord( {
-			postId: attributes.ref as number,
-			postType: FORM_POST_TYPE,
-		} );
+		if ( isSiteEditor ) {
+			openFormEditor( attributes.ref as number );
+			return;
+		}
+
+		if ( onNavigateToEntityRecord ) {
+			onNavigateToEntityRecord( {
+				postId: attributes.ref as number,
+				postType: FORM_POST_TYPE,
+			} );
+		}
 	};
 
-	const showEditButton = hasRef && onNavigateToEntityRecord;
+	const showEditButton = hasRef && ( isSiteEditor || onNavigateToEntityRecord );
 	const showConvertButton = ! hasRef;
 
 	return (

--- a/projects/packages/forms/tests/js/contact-form/components/convert-form-toolbar.test.js
+++ b/projects/packages/forms/tests/js/contact-form/components/convert-form-toolbar.test.js
@@ -13,8 +13,12 @@ const mockLockPostSaving = jest.fn();
 const mockUnlockPostSaving = jest.fn();
 const mockCreateErrorNotice = jest.fn();
 const mockOnNavigateToEntityRecord = jest.fn();
+const mockAddQueryArgs = jest.fn(
+	( base, args ) => `${ base }?post=${ args.post }&action=${ args.action }`
+);
 
 let mockIsLocked = false;
+let mockIsSiteEditor = false;
 
 // Mock WordPress dependencies
 await jest.unstable_mockModule( '@wordpress/components', () => ( {
@@ -32,6 +36,7 @@ await jest.unstable_mockModule( '@wordpress/block-editor', () => ( {
 } ) );
 await jest.unstable_mockModule( '@wordpress/editor', () => ( { store: 'core/editor' } ) );
 await jest.unstable_mockModule( '@wordpress/notices', () => ( { store: 'core/notices' } ) );
+await jest.unstable_mockModule( '@wordpress/url', () => ( { addQueryArgs: mockAddQueryArgs } ) );
 
 await jest.unstable_mockModule( '@wordpress/data', () => ( {
 	useSelect: jest.fn( callback =>
@@ -47,6 +52,9 @@ await jest.unstable_mockModule( '@wordpress/data', () => ( {
 					getBlock: () => ( { innerBlocks: [] } ),
 					getSettings: () => ( { onNavigateToEntityRecord: mockOnNavigateToEntityRecord } ),
 				};
+			}
+			if ( store === 'core/edit-site' ) {
+				return mockIsSiteEditor ? {} : undefined;
 			}
 			return undefined;
 		} )
@@ -75,6 +83,7 @@ describe( 'ConvertFormToolbar', () => {
 	beforeEach( () => {
 		jest.clearAllMocks();
 		mockIsLocked = false;
+		mockIsSiteEditor = false;
 	} );
 
 	it( 'renders Edit Form button', () => {
@@ -113,6 +122,42 @@ describe( 'ConvertFormToolbar', () => {
 
 		expect( mockLockPostSaving ).toHaveBeenCalled();
 		expect( mockUnlockPostSaving ).toHaveBeenCalled();
+	} );
+
+	it( 'in site editor, navigates via URL when clicking edit on synced form', async () => {
+		mockIsSiteEditor = true;
+
+		render( <ConvertFormToolbar clientId="test-id" attributes={ { ref: 456 } } /> );
+		await userEvent.click( screen.getByRole( 'button' ) );
+
+		expect( mockAddQueryArgs ).toHaveBeenCalledWith( 'post.php', {
+			post: 456,
+			action: 'edit',
+		} );
+		expect( mockOnNavigateToEntityRecord ).not.toHaveBeenCalled();
+		// jsdom logs an error for unimplemented navigation
+		expect( console ).toHaveErrored();
+	} );
+
+	it( 'in site editor, creates synced form and navigates via URL on convert', async () => {
+		mockIsSiteEditor = true;
+		mockCreateSyncedForm.mockResolvedValue( 789 );
+
+		render( <ConvertFormToolbar clientId="test-id" attributes={ { to: 'test@example.com' } } /> );
+		await userEvent.click( screen.getByRole( 'button' ) );
+
+		await waitFor( () => {
+			expect( mockAddQueryArgs ).toHaveBeenCalledWith( 'post.php', {
+				post: 789,
+				action: 'edit',
+			} );
+		} );
+
+		expect( mockOnNavigateToEntityRecord ).not.toHaveBeenCalled();
+		expect( mockLockPostSaving ).toHaveBeenCalled();
+		expect( mockUnlockPostSaving ).toHaveBeenCalled();
+		// jsdom logs an error for unimplemented navigation
+		expect( console ).toHaveErrored();
 	} );
 
 	it( 'shows error notice when conversion fails', async () => {

--- a/projects/packages/forms/tests/js/contact-form/components/convert-form-toolbar.test.js
+++ b/projects/packages/forms/tests/js/contact-form/components/convert-form-toolbar.test.js
@@ -48,7 +48,7 @@ await jest.unstable_mockModule( '@wordpress/data', () => ( {
 					getSettings: () => ( { onNavigateToEntityRecord: mockOnNavigateToEntityRecord } ),
 				};
 			}
-			return {};
+			return undefined;
 		} )
 	),
 	useDispatch: jest.fn( () => ( {


### PR DESCRIPTION
This PR fixes a bug where the "Edit Form" button doesn't work as expected in the site editor. 

It currently returns an error. 

FORMS-NEW

## Proposed changes:
* Detect if the user in the site editor. Open the Form Editor instead. 
*  * Fix the "Edit Form" button in the block toolbar when a form block is used inside the site editor. Previously, clicking "Edit Form"
   triggered `onNavigateToEntityRecord` which doesn't support the `jetpack_form` custom post type in the site editor context, resulting
   in an error state.
   * Detect the site editor by checking for the `core/edit-site` data store (only registered when the site editor is active).
   * When in the site editor, navigate directly to the form's block editor URL (`post.php?post={id}&action=edit`) instead of using
   `onNavigateToEntityRecord`.
   * The post/page editor behavior is unchanged — it continues to use `onNavigateToEntityRecord` for inline editing.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
no

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:
   * Enable the `central-form-management` feature flag for Jetpack Forms.
```
add_filter( 'jetpack_block_editor_feature_flags', 'eb_register_feature' );

function eb_register_feature( $flags ) {
    $flags['central-form-management'] = true;
    return $flags;
}
```

   * Open the **site editor** (Appearance > Editor).
   * Edit a template and insert a Jetpack Form block.
   * Click the "Edit Form" button in the block toolbar.
   * **Before:** An error state was shown because the site editor can't navigate to the `jetpack_form` CPT.
   * **After:** You are navigated to the form's dedicated block editor page (`post.php?post={id}&action=edit`).
   * Verify that the "Edit Form" button still works as before in the **post/page editor** (inline navigation via
   `onNavigateToEntityRecord`).