### PR TITLE
Forms: update response tab name and order

### DIFF
--- a/projects/packages/forms/changelog/update-forms-dashboard-default-tab-and-labels
+++ b/projects/packages/forms/changelog/update-forms-dashboard-default-tab-and-labels
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Forms: Update dashboard default view and tab labels - rename "All responses" to "Responses", set "Responses" as the default landing page instead of Forms, and reorder tabs to show Responses first.

--- a/projects/packages/forms/src/dashboard/components/forms-responses-tabs/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/forms-responses-tabs/index.tsx
@@ -33,8 +33,8 @@ export default function FormsResponsesTabs(): JSX.Element {
 	return (
 		<Tabs.Root value={ value } onValueChange={ onValueChange }>
 			<Tabs.List density="compact">
+				<Tabs.Tab value="responses">{ __( 'Responses', 'jetpack-forms' ) }</Tabs.Tab>
 				<Tabs.Tab value="forms">{ __( 'Forms', 'jetpack-forms' ) }</Tabs.Tab>
-				<Tabs.Tab value="responses">{ __( 'All Responses', 'jetpack-forms' ) }</Tabs.Tab>
 			</Tabs.List>
 		</Tabs.Root>
 	);

--- a/projects/packages/forms/src/dashboard/index.tsx
+++ b/projects/packages/forms/src/dashboard/index.tsx
@@ -8,7 +8,6 @@ import { RouterProvider } from 'react-router/dom';
 /**
  * Internal dependencies
  */
-import useConfigValue from '../hooks/use-config-value.ts';
 import Layout from './components/layout/index.tsx';
 import FormsDashboardForms from './forms/index.tsx';
 import SingleFormResponses from './forms/single/index.tsx';
@@ -37,15 +36,14 @@ function initFormsDashboard() {
 
 	const DashboardIndexRedirect = () => {
 		const navigate = useNavigate();
-		const isCentralFormManagementEnabled = useConfigValue( 'isCentralFormManagementEnabled' );
 
 		useEffect( () => {
 			// Default landing when no hash/route is set.
 			// Treat undefined (not yet loaded / not provided) as false so we never render a blank page.
-			navigate( isCentralFormManagementEnabled === true ? '/forms' : '/responses', {
+			navigate( '/responses', {
 				replace: true,
 			} );
-		}, [ isCentralFormManagementEnabled, navigate ] );
+		}, [ navigate ] );
 
 		return null;
 	};


### PR DESCRIPTION
Resolves FORMS-544

## Changes
- Rename \"All responses\" to \"Responses\".
- Make \"Responses\" the default landing view.
- Reorder the Forms/Responses tabs so Responses comes first.

**Before**
<img width="1368" height="511" alt="image" src="https://github.com/user-attachments/assets/488d7e27-b241-4d90-bef8-f485e214a322" />


**After**
<img width="1373" height="495" alt="image" src="https://github.com/user-attachments/assets/f97e9213-df93-4180-b934-b24cc26f1114" />



## Testing instructions:

Enable central form management:
```
add_filter( 'jetpack_block_editor_feature_flags', 'central_form_management_feature' );
function central_form_management_feature( $flags ) {
	$flags['reusable-forms'] = true;
	$flags['central-form-management'] = true;
	return $flags;
}
```

With central form management is enabled:
   - Open the Forms dashboard and confirm the first tab is **Responses** 
   - Default landing view is **Responses**
- Previous \"All responses\" label now reads **Responses**.



## Does this pull request change what data or activity we track or use?

No.