### PR TITLE
wpcomsh: enable error logging for external storage

### DIFF
--- a/projects/plugins/wpcomsh/changelog/add-external-storage-logging-wpcomsh
+++ b/projects/plugins/wpcomsh/changelog/add-external-storage-logging-wpcomsh
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Enable error logging for external storage.

--- a/projects/plugins/wpcomsh/connection/class-atomic-storage-provider.php
+++ b/projects/plugins/wpcomsh/connection/class-atomic-storage-provider.php
@@ -83,6 +83,44 @@ if ( interface_exists( 'Automattic\Jetpack\Connection\Storage_Provider_Interface
 		}
 
 		/**
+		 * Handle error events from External_Storage for monitoring and alerting.
+		 *
+		 * Reports storage errors and empty states to the wpcom logstash cluster
+		 * for centralized error tracking and alerting.
+		 *
+		 * @since $$next-version$$
+		 *
+		 * @param string $event_type  The event type ('error' or 'empty').
+		 * @param string $key         The option key that triggered the event.
+		 * @param string $details     Additional error details.
+		 * @param string $environment The environment identifier.
+		 */
+		public function handle_error_event( $event_type, $key, $details, $environment ) {
+			// Build log message
+			$message = sprintf(
+				'External Storage %s: %s',
+				$event_type,
+				$key
+			);
+
+			$extra = array(
+				'event_type'  => $event_type,
+				'key'         => $key,
+				'environment' => $environment,
+			);
+
+			if ( ! empty( $details ) ) {
+				$extra['details'] = $details;
+			}
+
+			// Use unsafe_direct_log to ensure storage errors are always logged
+			// regardless of at_options_logging_on setting
+			if ( class_exists( 'WPCOMSH_Log' ) ) {
+				\WPCOMSH_Log::unsafe_direct_log( $message, $extra );
+			}
+		}
+
+		/**
 		 * Get the master user id from email.
 		 *
 		 * @since $$next-version$$


### PR DESCRIPTION
This PR applies error logging handling that will get merged in https://github.com/Automattic/jetpack/pull/46646

This can be merged before the other PR is deployed, but it won't work. It shouldn't break anything either.

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Closes CONNECT-143

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add error logging

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Load this on a dev WoA site and see nothing breaks.
