### PR TITLE
VideoPress: add email rendering support for videopress/video block

### DIFF
--- a/projects/packages/videopress/changelog/add-videopress-email-rendering
+++ b/projects/packages/videopress/changelog/add-videopress-email-rendering
@@ -1,4 +1,4 @@
 Significance: minor
 Type: added
 
-VideoPress: add email rendering support for the videopress/video block.
+Add email rendering support for the videopress/video block.

--- a/projects/packages/videopress/changelog/add-videopress-email-rendering
+++ b/projects/packages/videopress/changelog/add-videopress-email-rendering
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+VideoPress: add email rendering support for the videopress/video block.

--- a/projects/packages/videopress/src/class-initializer.php
+++ b/projects/packages/videopress/src/class-initializer.php
@@ -362,10 +362,10 @@ class Initializer {
 			return '';
 		}
 
-		// For private videos, render a simple link since the thumbnail won't be accessible.
+		// For private videos, render a simple link to the post since the video isn't accessible on VideoPress.
 		// The isPrivate attribute is pre-computed by the block editor based on video and site settings.
 		if ( isset( $attributes['isPrivate'] ) && true === $attributes['isPrivate'] ) {
-			return self::render_videopress_email_link( $videopress_url, $parsed_block );
+			return self::render_videopress_email_link( $parsed_block );
 		}
 
 		// Create a mock embed block structure that WooCommerce's embed renderer can handle.
@@ -397,18 +397,24 @@ class Initializer {
 
 	/**
 	 * Render a simple link for private VideoPress videos in emails.
+	 * Links to the post containing the video since private videos aren't accessible on VideoPress.
 	 *
-	 * @param string $url          The VideoPress URL.
-	 * @param array  $parsed_block The parsed block data.
+	 * @param array $parsed_block The parsed block data.
 	 *
 	 * @return string The rendered link HTML.
 	 */
-	private static function render_videopress_email_link( $url, $parsed_block ) {
-		$link_text = __( 'Watch on VideoPress', 'jetpack-videopress-pkg' );
+	private static function render_videopress_email_link( $parsed_block ) {
+		$post_url = get_the_permalink();
+
+		if ( empty( $post_url ) ) {
+			return '';
+		}
+
+		$link_text = __( 'Watch the video', 'jetpack-videopress-pkg' );
 
 		$link_html = sprintf(
 			'<a href="%s" target="_blank" rel="noopener noreferrer">%s</a>',
-			esc_url( $url ),
+			esc_url( $post_url ),
 			esc_html( $link_text )
 		);
 

--- a/projects/packages/videopress/src/class-initializer.php
+++ b/projects/packages/videopress/src/class-initializer.php
@@ -346,7 +346,7 @@ class Initializer {
 	 *
 	 * @return string
 	 */
-	public static function render_videopress_video_block_email( $block_content, $parsed_block, $rendering_context ) {
+	public static function render_videopress_video_block_email( $block_content, $parsed_block, $rendering_context ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 		// Validate input parameters and required dependencies.
 		if ( ! isset( $parsed_block['attrs'] ) || ! is_array( $parsed_block['attrs'] ) ||
 			! class_exists( '\Automattic\WooCommerce\EmailEditor\Integrations\Core\Renderer\Blocks\Embed' ) ) {

--- a/projects/packages/videopress/src/class-initializer.php
+++ b/projects/packages/videopress/src/class-initializer.php
@@ -338,6 +338,78 @@ class Initializer {
 	}
 
 	/**
+	 * Render VideoPress video block for email.
+	 *
+	 * @param string $block_content     The original block HTML content.
+	 * @param array  $parsed_block      The parsed block data including attributes.
+	 * @param object $rendering_context Email rendering context.
+	 *
+	 * @return string
+	 */
+	public static function render_videopress_video_block_email( $block_content, $parsed_block, $rendering_context ) {
+		// Validate input parameters and required dependencies.
+		if ( ! isset( $parsed_block['attrs'] ) || ! is_array( $parsed_block['attrs'] ) ||
+			! class_exists( '\Automattic\WooCommerce\EmailEditor\Integrations\Core\Renderer\Blocks\Embed' ) ) {
+			return '';
+		}
+
+		$attributes = $parsed_block['attrs'];
+
+		// Get the VideoPress URL from the guid attribute.
+		$videopress_url = self::get_videopress_url_for_email( $attributes );
+
+		if ( empty( $videopress_url ) ) {
+			return '';
+		}
+
+		// Create a mock embed block structure that WooCommerce's embed renderer can handle.
+		// The embed renderer will detect VideoPress from the URL and render it appropriately.
+		$mock_embed_block = array(
+			'blockName' => 'core/embed',
+			'attrs'     => array(
+				'url'              => $videopress_url,
+				'providerNameSlug' => 'videopress',
+			),
+			'innerHTML' => sprintf(
+				'<figure class="wp-block-embed is-type-video is-provider-videopress"><div class="wp-block-embed__wrapper">%s</div></figure>',
+				esc_url( $videopress_url )
+			),
+		);
+
+		// Preserve email_attrs if present (used for spacing/width calculations).
+		if ( ! empty( $parsed_block['email_attrs'] ) ) {
+			$mock_embed_block['email_attrs'] = $parsed_block['email_attrs'];
+		}
+
+		// Use WooCommerce's core embed renderer.
+		$woo_embed_renderer = new \Automattic\WooCommerce\EmailEditor\Integrations\Core\Renderer\Blocks\Embed();
+
+		return $woo_embed_renderer->render( $mock_embed_block['innerHTML'], $mock_embed_block, $rendering_context );
+	}
+
+	/**
+	 * Get the VideoPress URL from block attributes for email rendering.
+	 *
+	 * @param array $attributes Block attributes.
+	 *
+	 * @return string VideoPress URL or empty string.
+	 */
+	private static function get_videopress_url_for_email( $attributes ) {
+		// Construct URL from guid attribute.
+		if ( ! empty( $attributes['guid'] ) ) {
+			$guid = $attributes['guid'];
+
+			// VideoPress guids are alphanumeric only (e.g., "nfbj0J36").
+			// Validate format to prevent any injection issues.
+			if ( preg_match( '/^[a-zA-Z0-9]+$/', $guid ) ) {
+				return 'https://videopress.com/v/' . $guid;
+			}
+		}
+
+		return '';
+	}
+
+	/**
 	 * Register the VideoPress block editor block,
 	 * AKA "VideoPress Block v6".
 	 *
@@ -382,8 +454,9 @@ class Initializer {
 		$registration = register_block_type(
 			$videopress_video_metadata_file,
 			array(
-				'render_callback' => array( __CLASS__, 'render_videopress_video_block' ),
-				'uses_context'    => array( 'premium-content/planId', 'isPremiumContentChild', 'selectedPlanId' ),
+				'render_callback'       => array( __CLASS__, 'render_videopress_video_block' ),
+				'render_email_callback' => array( __CLASS__, 'render_videopress_video_block_email' ),
+				'uses_context'          => array( 'premium-content/planId', 'isPremiumContentChild', 'selectedPlanId' ),
 			)
 		);
 

--- a/projects/packages/videopress/src/class-initializer.php
+++ b/projects/packages/videopress/src/class-initializer.php
@@ -382,8 +382,10 @@ class Initializer {
 		}
 
 		// Use WooCommerce's core embed renderer.
+		// @phan-suppress-next-line PhanUndeclaredClassMethod -- Optional WooCommerce dependency, checked with class_exists() above.
 		$woo_embed_renderer = new \Automattic\WooCommerce\EmailEditor\Integrations\Core\Renderer\Blocks\Embed();
 
+		// @phan-suppress-next-line PhanUndeclaredClassMethod -- Optional WooCommerce dependency, checked with class_exists() above.
 		return $woo_embed_renderer->render( $mock_embed_block['innerHTML'], $mock_embed_block, $rendering_context );
 	}
 

--- a/projects/packages/videopress/src/class-initializer.php
+++ b/projects/packages/videopress/src/class-initializer.php
@@ -362,6 +362,12 @@ class Initializer {
 			return '';
 		}
 
+		// For private videos, render a simple link since the thumbnail won't be accessible.
+		// The isPrivate attribute is pre-computed by the block editor based on video and site settings.
+		if ( isset( $attributes['isPrivate'] ) && true === $attributes['isPrivate'] ) {
+			return self::render_videopress_email_link( $videopress_url, $parsed_block );
+		}
+
 		// Create a mock embed block structure that WooCommerce's embed renderer can handle.
 		// The embed renderer will detect VideoPress from the URL and render it appropriately.
 		$mock_embed_block = array(
@@ -387,6 +393,35 @@ class Initializer {
 
 		// @phan-suppress-next-line PhanUndeclaredClassMethod -- Optional WooCommerce dependency, checked with class_exists() above.
 		return $woo_embed_renderer->render( $mock_embed_block['innerHTML'], $mock_embed_block, $rendering_context );
+	}
+
+	/**
+	 * Render a simple link for private VideoPress videos in emails.
+	 *
+	 * @param string $url          The VideoPress URL.
+	 * @param array  $parsed_block The parsed block data.
+	 *
+	 * @return string The rendered link HTML.
+	 */
+	private static function render_videopress_email_link( $url, $parsed_block ) {
+		$link_text = __( 'Watch on VideoPress', 'jetpack-videopress-pkg' );
+
+		$link_html = sprintf(
+			'<a href="%s" target="_blank" rel="noopener noreferrer">%s</a>',
+			esc_url( $url ),
+			esc_html( $link_text )
+		);
+
+		// Wrap with spacing if email_attrs are present.
+		if ( ! empty( $parsed_block['email_attrs']['padding'] ) ) {
+			$link_html = sprintf(
+				'<p style="padding: %s;">%s</p>',
+				esc_attr( $parsed_block['email_attrs']['padding'] ),
+				$link_html
+			);
+		}
+
+		return $link_html;
 	}
 
 	/**

--- a/projects/packages/videopress/src/class-initializer.php
+++ b/projects/packages/videopress/src/class-initializer.php
@@ -338,121 +338,6 @@ class Initializer {
 	}
 
 	/**
-	 * Render VideoPress video block for email.
-	 *
-	 * @param string $block_content     The original block HTML content.
-	 * @param array  $parsed_block      The parsed block data including attributes.
-	 * @param object $rendering_context Email rendering context.
-	 *
-	 * @return string
-	 */
-	public static function render_videopress_video_block_email( $block_content, $parsed_block, $rendering_context ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
-		// Validate input parameters and required dependencies.
-		if ( ! isset( $parsed_block['attrs'] ) || ! is_array( $parsed_block['attrs'] ) ||
-			! class_exists( '\Automattic\WooCommerce\EmailEditor\Integrations\Core\Renderer\Blocks\Embed' ) ) {
-			return '';
-		}
-
-		$attributes = $parsed_block['attrs'];
-
-		// Get the VideoPress URL from the guid attribute.
-		$videopress_url = self::get_videopress_url_for_email( $attributes );
-
-		if ( empty( $videopress_url ) ) {
-			return '';
-		}
-
-		// For private videos, render a simple link to the post since the video isn't accessible on VideoPress.
-		// The isPrivate attribute is pre-computed by the block editor based on video and site settings.
-		if ( isset( $attributes['isPrivate'] ) && true === $attributes['isPrivate'] ) {
-			return self::render_videopress_email_link( $parsed_block );
-		}
-
-		// Create a mock embed block structure that WooCommerce's embed renderer can handle.
-		// The embed renderer will detect VideoPress from the URL and render it appropriately.
-		$mock_embed_block = array(
-			'blockName' => 'core/embed',
-			'attrs'     => array(
-				'url'              => $videopress_url,
-				'providerNameSlug' => 'videopress',
-			),
-			'innerHTML' => sprintf(
-				'<figure class="wp-block-embed is-type-video is-provider-videopress"><div class="wp-block-embed__wrapper">%s</div></figure>',
-				esc_url( $videopress_url )
-			),
-		);
-
-		// Preserve email_attrs if present (used for spacing/width calculations).
-		if ( ! empty( $parsed_block['email_attrs'] ) ) {
-			$mock_embed_block['email_attrs'] = $parsed_block['email_attrs'];
-		}
-
-		// Use WooCommerce's core embed renderer.
-		// @phan-suppress-next-line PhanUndeclaredClassMethod -- Optional WooCommerce dependency, checked with class_exists() above.
-		$woo_embed_renderer = new \Automattic\WooCommerce\EmailEditor\Integrations\Core\Renderer\Blocks\Embed();
-
-		// @phan-suppress-next-line PhanUndeclaredClassMethod -- Optional WooCommerce dependency, checked with class_exists() above.
-		return $woo_embed_renderer->render( $mock_embed_block['innerHTML'], $mock_embed_block, $rendering_context );
-	}
-
-	/**
-	 * Render a simple link for private VideoPress videos in emails.
-	 * Links to the post containing the video since private videos aren't accessible on VideoPress.
-	 *
-	 * @param array $parsed_block The parsed block data.
-	 *
-	 * @return string The rendered link HTML.
-	 */
-	private static function render_videopress_email_link( $parsed_block ) {
-		$post_url = get_the_permalink();
-
-		if ( empty( $post_url ) ) {
-			return '';
-		}
-
-		$link_text = __( 'Watch the video', 'jetpack-videopress-pkg' );
-
-		$link_html = sprintf(
-			'<a href="%s" target="_blank" rel="noopener noreferrer">%s</a>',
-			esc_url( $post_url ),
-			esc_html( $link_text )
-		);
-
-		// Wrap with spacing if email_attrs are present.
-		if ( ! empty( $parsed_block['email_attrs']['padding'] ) ) {
-			$link_html = sprintf(
-				'<p style="padding: %s;">%s</p>',
-				esc_attr( $parsed_block['email_attrs']['padding'] ),
-				$link_html
-			);
-		}
-
-		return $link_html;
-	}
-
-	/**
-	 * Get the VideoPress URL from block attributes for email rendering.
-	 *
-	 * @param array $attributes Block attributes.
-	 *
-	 * @return string VideoPress URL or empty string.
-	 */
-	private static function get_videopress_url_for_email( $attributes ) {
-		// Construct URL from guid attribute.
-		if ( ! empty( $attributes['guid'] ) ) {
-			$guid = $attributes['guid'];
-
-			// VideoPress guids are alphanumeric only (e.g., "nfbj0J36").
-			// Validate format to prevent any injection issues.
-			if ( preg_match( '/^[a-zA-Z0-9]+$/', $guid ) ) {
-				return 'https://videopress.com/v/' . $guid;
-			}
-		}
-
-		return '';
-	}
-
-	/**
 	 * Register the VideoPress block editor block,
 	 * AKA "VideoPress Block v6".
 	 *
@@ -498,7 +383,7 @@ class Initializer {
 			$videopress_video_metadata_file,
 			array(
 				'render_callback'       => array( __CLASS__, 'render_videopress_video_block' ),
-				'render_email_callback' => array( __CLASS__, 'render_videopress_video_block_email' ),
+				'render_email_callback' => array( Video_Block_Email_Renderer::class, 'render' ),
 				'uses_context'          => array( 'premium-content/planId', 'isPremiumContentChild', 'selectedPlanId' ),
 			)
 		);

--- a/projects/packages/videopress/src/class-video-block-email-renderer.php
+++ b/projects/packages/videopress/src/class-video-block-email-renderer.php
@@ -1,0 +1,129 @@
+<?php
+/**
+ * VideoPress video block email renderer class.
+ *
+ * @package automattic/jetpack-videopress
+ */
+
+namespace Automattic\Jetpack\VideoPress;
+
+/**
+ * Handles rendering VideoPress video blocks for email contexts.
+ */
+class Video_Block_Email_Renderer {
+
+	/**
+	 * Render VideoPress video block for email.
+	 *
+	 * @param string $block_content     The original block HTML content.
+	 * @param array  $parsed_block      The parsed block data including attributes.
+	 * @param object $rendering_context Email rendering context.
+	 *
+	 * @return string
+	 */
+	public static function render( $block_content, $parsed_block, $rendering_context ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		// Validate input parameters and required dependencies.
+		if ( ! isset( $parsed_block['attrs'] ) || ! is_array( $parsed_block['attrs'] ) ||
+			! class_exists( '\Automattic\WooCommerce\EmailEditor\Integrations\Core\Renderer\Blocks\Embed' ) ) {
+			return '';
+		}
+
+		$attributes = $parsed_block['attrs'];
+
+		// Get the VideoPress URL from the guid attribute.
+		$videopress_url = self::get_videopress_url( $attributes );
+
+		if ( empty( $videopress_url ) ) {
+			return '';
+		}
+
+		// For private videos, render a simple link to the post since the video isn't accessible on VideoPress.
+		// The isPrivate attribute is pre-computed by the block editor based on video and site settings.
+		if ( isset( $attributes['isPrivate'] ) && true === $attributes['isPrivate'] ) {
+			return self::render_link( $parsed_block );
+		}
+
+		// Create a mock embed block structure that WooCommerce's embed renderer can handle.
+		// The embed renderer will detect VideoPress from the URL and render it appropriately.
+		$mock_embed_block = array(
+			'blockName' => 'core/embed',
+			'attrs'     => array(
+				'url'              => $videopress_url,
+				'providerNameSlug' => 'videopress',
+			),
+			'innerHTML' => sprintf(
+				'<figure class="wp-block-embed is-type-video is-provider-videopress"><div class="wp-block-embed__wrapper">%s</div></figure>',
+				esc_url( $videopress_url )
+			),
+		);
+
+		// Preserve email_attrs if present (used for spacing/width calculations).
+		if ( ! empty( $parsed_block['email_attrs'] ) ) {
+			$mock_embed_block['email_attrs'] = $parsed_block['email_attrs'];
+		}
+
+		// Use WooCommerce's core embed renderer.
+		// @phan-suppress-next-line PhanUndeclaredClassMethod -- Optional WooCommerce dependency, checked with class_exists() above.
+		$woo_embed_renderer = new \Automattic\WooCommerce\EmailEditor\Integrations\Core\Renderer\Blocks\Embed();
+
+		// @phan-suppress-next-line PhanUndeclaredClassMethod -- Optional WooCommerce dependency, checked with class_exists() above.
+		return $woo_embed_renderer->render( $mock_embed_block['innerHTML'], $mock_embed_block, $rendering_context );
+	}
+
+	/**
+	 * Render a simple link for private VideoPress videos in emails.
+	 * Links to the post containing the video since private videos aren't accessible on VideoPress.
+	 *
+	 * @param array $parsed_block The parsed block data.
+	 *
+	 * @return string The rendered link HTML.
+	 */
+	private static function render_link( $parsed_block ) {
+		$post_url = get_the_permalink();
+
+		if ( empty( $post_url ) ) {
+			return '';
+		}
+
+		$link_text = __( 'Visit the post to watch the video', 'jetpack-videopress-pkg' );
+
+		$link_html = sprintf(
+			'<a href="%s" target="_blank" rel="noopener noreferrer">%s</a>',
+			esc_url( $post_url ),
+			esc_html( $link_text )
+		);
+
+		// Wrap with spacing if email_attrs are present.
+		if ( ! empty( $parsed_block['email_attrs']['padding'] ) ) {
+			$link_html = sprintf(
+				'<p style="padding: %s;">%s</p>',
+				esc_attr( $parsed_block['email_attrs']['padding'] ),
+				$link_html
+			);
+		}
+
+		return $link_html;
+	}
+
+	/**
+	 * Get the VideoPress URL from block attributes for email rendering.
+	 *
+	 * @param array $attributes Block attributes.
+	 *
+	 * @return string VideoPress URL or empty string.
+	 */
+	private static function get_videopress_url( $attributes ) {
+		// Construct URL from guid attribute.
+		if ( ! empty( $attributes['guid'] ) ) {
+			$guid = $attributes['guid'];
+
+			// VideoPress guids are alphanumeric only (e.g., "nfbj0J36").
+			// Validate format to prevent any injection issues.
+			if ( preg_match( '/^[a-zA-Z0-9]+$/', $guid ) ) {
+				return 'https://videopress.com/v/' . $guid;
+			}
+		}
+
+		return '';
+	}
+}

--- a/projects/packages/videopress/src/class-video-block-email-renderer.php
+++ b/projects/packages/videopress/src/class-video-block-email-renderer.php
@@ -94,10 +94,11 @@ class Video_Block_Email_Renderer {
 		);
 
 		// Wrap with spacing if email_attrs are present.
-		if ( ! empty( $parsed_block['email_attrs']['padding'] ) ) {
+		$email_attrs = $parsed_block['email_attrs'] ?? array();
+		if ( ! empty( $email_attrs['padding'] ) ) {
 			$link_html = sprintf(
 				'<p style="padding: %s;">%s</p>',
-				esc_attr( $parsed_block['email_attrs']['padding'] ),
+				esc_attr( $email_attrs['padding'] ),
 				$link_html
 			);
 		}

--- a/projects/packages/videopress/tests/php/Initializer_Email_Render_Test.php
+++ b/projects/packages/videopress/tests/php/Initializer_Email_Render_Test.php
@@ -281,4 +281,67 @@ class Initializer_Email_Render_Test extends BaseTestCase {
 		$this->assertNotEmpty( $result );
 		$this->assertStringContainsString( 'https://videopress.com/v/testguid', $result );
 	}
+
+	/**
+	 * Test render_email with private video renders a link fallback.
+	 */
+	public function test_render_email_with_private_video_renders_link() {
+		$parsed_block = $this->create_parsed_block(
+			array(
+				'guid'      => 'privatevid',
+				'isPrivate' => true,
+			)
+		);
+		$mock_context = $this->create_rendering_context_mock();
+
+		$result = Initializer::render_videopress_video_block_email( '', $parsed_block, $mock_context );
+
+		// Should render a simple link instead of video embed.
+		$this->assertNotEmpty( $result );
+		$this->assertStringContainsString( 'https://videopress.com/v/privatevid', $result );
+		$this->assertStringContainsString( '<a href=', $result );
+		$this->assertStringContainsString( 'Watch on VideoPress', $result );
+		// Should NOT contain the embed wrapper that the mock renderer produces.
+		$this->assertStringNotContainsString( 'email-embed-video', $result );
+	}
+
+	/**
+	 * Test render_email with public video renders full embed.
+	 */
+	public function test_render_email_with_public_video_renders_embed() {
+		$parsed_block = $this->create_parsed_block(
+			array(
+				'guid'      => 'publicvid',
+				'isPrivate' => false,
+			)
+		);
+		$mock_context = $this->create_rendering_context_mock();
+
+		$result = Initializer::render_videopress_video_block_email( '', $parsed_block, $mock_context );
+
+		// Should render the full embed (via mock renderer).
+		$this->assertNotEmpty( $result );
+		$this->assertStringContainsString( 'https://videopress.com/v/publicvid', $result );
+		$this->assertStringContainsString( 'email-embed-video', $result );
+	}
+
+	/**
+	 * Test render_email private video link includes padding when email_attrs present.
+	 */
+	public function test_render_email_private_video_link_with_padding() {
+		$parsed_block = $this->create_parsed_block(
+			array(
+				'guid'      => 'privatevid',
+				'isPrivate' => true,
+			),
+			array( 'padding' => '20px' )
+		);
+		$mock_context = $this->create_rendering_context_mock();
+
+		$result = Initializer::render_videopress_video_block_email( '', $parsed_block, $mock_context );
+
+		$this->assertNotEmpty( $result );
+		$this->assertStringContainsString( 'padding: 20px', $result );
+		$this->assertStringContainsString( '<p style=', $result );
+	}
 }

--- a/projects/packages/videopress/tests/php/Initializer_Email_Render_Test.php
+++ b/projects/packages/videopress/tests/php/Initializer_Email_Render_Test.php
@@ -1,0 +1,284 @@
+<?php
+/**
+ * Tests for VideoPress Initializer email rendering methods.
+ *
+ * @package automattic/jetpack-videopress
+ */
+
+namespace Automattic\Jetpack\VideoPress;
+
+// Include mock classes for WooCommerce Email Editor helpers FIRST.
+// This ensures the mock class is available when Initializer checks for it.
+require_once __DIR__ . '/mocks/class-mock-woocommerce-embed-renderer.php';
+
+use PHPUnit\Framework\Attributes\CoversMethod;
+use PHPUnit\Framework\Attributes\DataProvider;
+use WorDBless\BaseTestCase;
+
+/**
+ * Tests for VideoPress Initializer email rendering methods.
+ *
+ * @covers \Automattic\Jetpack\VideoPress\Initializer::render_videopress_video_block_email
+ * @covers \Automattic\Jetpack\VideoPress\Initializer::get_videopress_url_for_email
+ */
+#[CoversMethod( Initializer::class, 'render_videopress_video_block_email' )]
+#[CoversMethod( Initializer::class, 'get_videopress_url_for_email' )]
+class Initializer_Email_Render_Test extends BaseTestCase {
+
+	/**
+	 * Helper to create a parsed block with attributes.
+	 *
+	 * @param array $attrs Block attributes.
+	 * @param array $email_attrs Optional email attributes.
+	 * @return array Parsed block structure.
+	 */
+	private function create_parsed_block( $attrs = array(), $email_attrs = null ) {
+		$block = array(
+			'attrs' => $attrs,
+		);
+
+		if ( null !== $email_attrs ) {
+			$block['email_attrs'] = $email_attrs;
+		}
+
+		return $block;
+	}
+
+	/**
+	 * Helper to create a rendering context mock.
+	 *
+	 * @return object Mock rendering context.
+	 */
+	private function create_rendering_context_mock() {
+		return new class() {
+			/**
+			 * Get layout width.
+			 *
+			 * @return string
+			 */
+			public function get_layout_width_without_padding() {
+				return '600px';
+			}
+		};
+	}
+
+	/**
+	 * Test render_videopress_video_block_email with valid guid.
+	 */
+	public function test_render_email_with_valid_guid() {
+		$parsed_block = $this->create_parsed_block( array( 'guid' => 'nfbj0J36' ) );
+		$mock_context = $this->create_rendering_context_mock();
+
+		$result = Initializer::render_videopress_video_block_email( '', $parsed_block, $mock_context );
+
+		// Should return HTML content from the mock renderer.
+		$this->assertNotEmpty( $result );
+		$this->assertStringContainsString( 'email-embed-video', $result );
+		$this->assertStringContainsString( 'https://videopress.com/v/nfbj0J36', $result );
+		$this->assertStringContainsString( 'data-provider="videopress"', $result );
+	}
+
+	/**
+	 * Test render_videopress_video_block_email with missing attrs.
+	 */
+	public function test_render_email_with_missing_attrs() {
+		$mock_context = $this->create_rendering_context_mock();
+
+		// Test with missing attrs key.
+		$result = Initializer::render_videopress_video_block_email( '', array( 'not-attrs' => array() ), $mock_context );
+		$this->assertSame( '', $result );
+
+		// Test with non-array attrs.
+		$result = Initializer::render_videopress_video_block_email( '', array( 'attrs' => 'not-an-array' ), $mock_context );
+		$this->assertSame( '', $result );
+	}
+
+	/**
+	 * Test render_videopress_video_block_email with missing guid.
+	 */
+	public function test_render_email_with_missing_guid() {
+		$parsed_block = $this->create_parsed_block( array( 'title' => 'Test Video' ) );
+		$mock_context = $this->create_rendering_context_mock();
+
+		$result = Initializer::render_videopress_video_block_email( '', $parsed_block, $mock_context );
+
+		$this->assertSame( '', $result );
+	}
+
+	/**
+	 * Test render_videopress_video_block_email with empty guid.
+	 */
+	public function test_render_email_with_empty_guid() {
+		$parsed_block = $this->create_parsed_block( array( 'guid' => '' ) );
+		$mock_context = $this->create_rendering_context_mock();
+
+		$result = Initializer::render_videopress_video_block_email( '', $parsed_block, $mock_context );
+
+		$this->assertSame( '', $result );
+	}
+
+	/**
+	 * Data provider for invalid guid test cases.
+	 *
+	 * @return array Test cases with invalid guids.
+	 */
+	public static function invalid_guid_provider() {
+		return array(
+			'contains spaces'        => array( 'abc 123' ),
+			'contains special chars' => array( 'abc<script>alert(1)</script>' ),
+			'contains slashes'       => array( 'abc/def' ),
+			'contains dots'          => array( 'abc.def' ),
+			'contains hyphens'       => array( 'abc-def' ),
+			'contains underscores'   => array( 'abc_def' ),
+			'contains url'           => array( 'https://evil.com' ),
+			'contains html entities' => array( '&lt;script&gt;' ),
+			'contains null byte'     => array( "abc\x00def" ),
+		);
+	}
+
+	/**
+	 * Test render_videopress_video_block_email rejects invalid guid characters (security).
+	 *
+	 * @dataProvider invalid_guid_provider
+	 * @param string $invalid_guid The invalid guid to test.
+	 */
+	#[DataProvider( 'invalid_guid_provider' )]
+	public function test_render_email_rejects_invalid_guid_characters( $invalid_guid ) {
+		$parsed_block = $this->create_parsed_block( array( 'guid' => $invalid_guid ) );
+		$mock_context = $this->create_rendering_context_mock();
+
+		$result = Initializer::render_videopress_video_block_email( '', $parsed_block, $mock_context );
+
+		// Should return empty string for invalid guids.
+		$this->assertSame( '', $result, "Invalid guid '$invalid_guid' should be rejected" );
+	}
+
+	/**
+	 * Data provider for valid guid test cases.
+	 *
+	 * @return array Test cases with valid guids.
+	 */
+	public static function valid_guid_provider() {
+		return array(
+			'lowercase letters'   => array( 'abcdefgh' ),
+			'uppercase letters'   => array( 'ABCDEFGH' ),
+			'numbers'             => array( '12345678' ),
+			'mixed case and nums' => array( 'nfbj0J36' ),
+			'all lowercase mixed' => array( 'abc123xy' ),
+			'single character'    => array( 'a' ),
+			'long guid'           => array( 'abcdefghijklmnop1234567890' ),
+		);
+	}
+
+	/**
+	 * Test render_videopress_video_block_email accepts valid guid formats.
+	 *
+	 * @dataProvider valid_guid_provider
+	 * @param string $valid_guid The valid guid to test.
+	 */
+	#[DataProvider( 'valid_guid_provider' )]
+	public function test_render_email_accepts_valid_guid_formats( $valid_guid ) {
+		$parsed_block = $this->create_parsed_block( array( 'guid' => $valid_guid ) );
+		$mock_context = $this->create_rendering_context_mock();
+
+		$result = Initializer::render_videopress_video_block_email( '', $parsed_block, $mock_context );
+
+		// Should return HTML content for valid guids.
+		$this->assertNotEmpty( $result, "Valid guid '$valid_guid' should be accepted" );
+		$this->assertStringContainsString( "https://videopress.com/v/$valid_guid", $result );
+	}
+
+	/**
+	 * Test render_videopress_video_block_email preserves email_attrs.
+	 */
+	public function test_render_email_preserves_email_attrs() {
+		$email_attrs = array(
+			'width'   => '500px',
+			'padding' => '10px',
+		);
+
+		$parsed_block = $this->create_parsed_block(
+			array( 'guid' => 'testguid' ),
+			$email_attrs
+		);
+		$mock_context = $this->create_rendering_context_mock();
+
+		// The mock renderer doesn't use email_attrs, but we verify the function doesn't error.
+		$result = Initializer::render_videopress_video_block_email( '', $parsed_block, $mock_context );
+
+		$this->assertNotEmpty( $result );
+		$this->assertStringContainsString( 'https://videopress.com/v/testguid', $result );
+	}
+
+	/**
+	 * Test render_videopress_video_block_email constructs correct mock block structure.
+	 */
+	public function test_render_email_constructs_correct_mock_block() {
+		$parsed_block = $this->create_parsed_block( array( 'guid' => 'abc123' ) );
+		$mock_context = $this->create_rendering_context_mock();
+
+		$result = Initializer::render_videopress_video_block_email( '', $parsed_block, $mock_context );
+
+		// Verify the mock renderer received correct provider.
+		$this->assertStringContainsString( 'data-provider="videopress"', $result );
+
+		// Verify correct URL format.
+		$this->assertStringContainsString( 'https://videopress.com/v/abc123', $result );
+	}
+
+	/**
+	 * Test URL construction produces correct format.
+	 */
+	public function test_url_construction_format() {
+		$parsed_block = $this->create_parsed_block( array( 'guid' => 'MyVideo1' ) );
+		$mock_context = $this->create_rendering_context_mock();
+
+		$result = Initializer::render_videopress_video_block_email( '', $parsed_block, $mock_context );
+
+		// URL should be exactly https://videopress.com/v/{guid}.
+		$this->assertStringContainsString( 'href="https://videopress.com/v/MyVideo1"', $result );
+	}
+
+	/**
+	 * Test render_email works with real-world block attributes.
+	 */
+	public function test_render_email_with_realistic_block_attributes() {
+		// Simulate attributes from a real VideoPress block.
+		$parsed_block = $this->create_parsed_block(
+			array(
+				'title'          => 'small-video-1-mp4',
+				'description'    => '',
+				'id'             => 175,
+				'guid'           => 'nfbj0J36',
+				'src'            => 'https://videos.files.wordpress.com/nfbj0J36/small-video-1.mp4',
+				'videoRatio'     => 57.166666666666664,
+				'privacySetting' => 2,
+				'allowDownload'  => false,
+				'rating'         => 'G',
+				'isPrivate'      => false,
+				'duration'       => 5568,
+			)
+		);
+		$mock_context = $this->create_rendering_context_mock();
+
+		$result = Initializer::render_videopress_video_block_email( '', $parsed_block, $mock_context );
+
+		$this->assertNotEmpty( $result );
+		$this->assertStringContainsString( 'https://videopress.com/v/nfbj0J36', $result );
+	}
+
+	/**
+	 * Test that block_content parameter is accepted but not required.
+	 */
+	public function test_render_email_accepts_block_content_parameter() {
+		$parsed_block  = $this->create_parsed_block( array( 'guid' => 'testguid' ) );
+		$mock_context  = $this->create_rendering_context_mock();
+		$block_content = '<div>Some original content</div>';
+
+		// Should work with non-empty block_content.
+		$result = Initializer::render_videopress_video_block_email( $block_content, $parsed_block, $mock_context );
+
+		$this->assertNotEmpty( $result );
+		$this->assertStringContainsString( 'https://videopress.com/v/testguid', $result );
+	}
+}

--- a/projects/packages/videopress/tests/php/Initializer_Email_Render_Test.php
+++ b/projects/packages/videopress/tests/php/Initializer_Email_Render_Test.php
@@ -283,9 +283,18 @@ class Initializer_Email_Render_Test extends BaseTestCase {
 	}
 
 	/**
-	 * Test render_email with private video renders a link fallback.
+	 * Test render_email with private video renders a link fallback to the post.
 	 */
 	public function test_render_email_with_private_video_renders_link() {
+		// Create a post so get_the_permalink() returns a valid URL.
+		$post_id         = wp_insert_post(
+			array(
+				'post_title'  => 'Test Post',
+				'post_status' => 'publish',
+			)
+		);
+		$GLOBALS['post'] = get_post( $post_id );
+
 		$parsed_block = $this->create_parsed_block(
 			array(
 				'guid'      => 'privatevid',
@@ -296,13 +305,18 @@ class Initializer_Email_Render_Test extends BaseTestCase {
 
 		$result = Initializer::render_videopress_video_block_email( '', $parsed_block, $mock_context );
 
-		// Should render a simple link instead of video embed.
+		// Should render a simple link to the post instead of video embed.
 		$this->assertNotEmpty( $result );
-		$this->assertStringContainsString( 'https://videopress.com/v/privatevid', $result );
 		$this->assertStringContainsString( '<a href=', $result );
-		$this->assertStringContainsString( 'Watch on VideoPress', $result );
+		$this->assertStringContainsString( 'Watch the video', $result );
 		// Should NOT contain the embed wrapper that the mock renderer produces.
 		$this->assertStringNotContainsString( 'email-embed-video', $result );
+		// Should NOT link to VideoPress since video is private.
+		$this->assertStringNotContainsString( 'videopress.com', $result );
+
+		// Clean up.
+		wp_delete_post( $post_id, true );
+		unset( $GLOBALS['post'] );
 	}
 
 	/**
@@ -329,6 +343,15 @@ class Initializer_Email_Render_Test extends BaseTestCase {
 	 * Test render_email private video link includes padding when email_attrs present.
 	 */
 	public function test_render_email_private_video_link_with_padding() {
+		// Create a post so get_the_permalink() returns a valid URL.
+		$post_id         = wp_insert_post(
+			array(
+				'post_title'  => 'Test Post',
+				'post_status' => 'publish',
+			)
+		);
+		$GLOBALS['post'] = get_post( $post_id );
+
 		$parsed_block = $this->create_parsed_block(
 			array(
 				'guid'      => 'privatevid',
@@ -343,5 +366,30 @@ class Initializer_Email_Render_Test extends BaseTestCase {
 		$this->assertNotEmpty( $result );
 		$this->assertStringContainsString( 'padding: 20px', $result );
 		$this->assertStringContainsString( '<p style=', $result );
+
+		// Clean up.
+		wp_delete_post( $post_id, true );
+		unset( $GLOBALS['post'] );
+	}
+
+	/**
+	 * Test render_email with private video returns empty when no post context.
+	 */
+	public function test_render_email_with_private_video_no_post_returns_empty() {
+		// Ensure no post context.
+		unset( $GLOBALS['post'] );
+
+		$parsed_block = $this->create_parsed_block(
+			array(
+				'guid'      => 'privatevid',
+				'isPrivate' => true,
+			)
+		);
+		$mock_context = $this->create_rendering_context_mock();
+
+		$result = Initializer::render_videopress_video_block_email( '', $parsed_block, $mock_context );
+
+		// Should return empty string when no post URL available.
+		$this->assertSame( '', $result );
 	}
 }

--- a/projects/packages/videopress/tests/php/Initializer_Email_Render_Test.php
+++ b/projects/packages/videopress/tests/php/Initializer_Email_Render_Test.php
@@ -20,9 +20,11 @@ use WorDBless\BaseTestCase;
  *
  * @covers \Automattic\Jetpack\VideoPress\Initializer::render_videopress_video_block_email
  * @covers \Automattic\Jetpack\VideoPress\Initializer::get_videopress_url_for_email
+ * @covers \Automattic\Jetpack\VideoPress\Initializer::render_videopress_email_link
  */
 #[CoversMethod( Initializer::class, 'render_videopress_video_block_email' )]
 #[CoversMethod( Initializer::class, 'get_videopress_url_for_email' )]
+#[CoversMethod( Initializer::class, 'render_videopress_email_link' )]
 class Initializer_Email_Render_Test extends BaseTestCase {
 
 	/**

--- a/projects/packages/videopress/tests/php/Video_Block_Email_Renderer_Test.php
+++ b/projects/packages/videopress/tests/php/Video_Block_Email_Renderer_Test.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Tests for VideoPress Initializer email rendering methods.
+ * Tests for VideoPress video block email renderer.
  *
  * @package automattic/jetpack-videopress
  */
@@ -8,7 +8,7 @@
 namespace Automattic\Jetpack\VideoPress;
 
 // Include mock classes for WooCommerce Email Editor helpers FIRST.
-// This ensures the mock class is available when Initializer checks for it.
+// This ensures the mock class is available when Video_Block_Email_Renderer checks for it.
 require_once __DIR__ . '/mocks/class-mock-woocommerce-embed-renderer.php';
 
 use PHPUnit\Framework\Attributes\CoversMethod;
@@ -16,16 +16,16 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use WorDBless\BaseTestCase;
 
 /**
- * Tests for VideoPress Initializer email rendering methods.
+ * Tests for VideoPress video block email renderer.
  *
- * @covers \Automattic\Jetpack\VideoPress\Initializer::render_videopress_video_block_email
- * @covers \Automattic\Jetpack\VideoPress\Initializer::get_videopress_url_for_email
- * @covers \Automattic\Jetpack\VideoPress\Initializer::render_videopress_email_link
+ * @covers \Automattic\Jetpack\VideoPress\Video_Block_Email_Renderer::render
+ * @covers \Automattic\Jetpack\VideoPress\Video_Block_Email_Renderer::get_videopress_url
+ * @covers \Automattic\Jetpack\VideoPress\Video_Block_Email_Renderer::render_link
  */
-#[CoversMethod( Initializer::class, 'render_videopress_video_block_email' )]
-#[CoversMethod( Initializer::class, 'get_videopress_url_for_email' )]
-#[CoversMethod( Initializer::class, 'render_videopress_email_link' )]
-class Initializer_Email_Render_Test extends BaseTestCase {
+#[CoversMethod( Video_Block_Email_Renderer::class, 'render' )]
+#[CoversMethod( Video_Block_Email_Renderer::class, 'get_videopress_url' )]
+#[CoversMethod( Video_Block_Email_Renderer::class, 'render_link' )]
+class Video_Block_Email_Renderer_Test extends BaseTestCase {
 
 	/**
 	 * Helper to create a parsed block with attributes.
@@ -65,13 +65,13 @@ class Initializer_Email_Render_Test extends BaseTestCase {
 	}
 
 	/**
-	 * Test render_videopress_video_block_email with valid guid.
+	 * Test render with valid guid.
 	 */
 	public function test_render_email_with_valid_guid() {
 		$parsed_block = $this->create_parsed_block( array( 'guid' => 'nfbj0J36' ) );
 		$mock_context = $this->create_rendering_context_mock();
 
-		$result = Initializer::render_videopress_video_block_email( '', $parsed_block, $mock_context );
+		$result = Video_Block_Email_Renderer::render( '', $parsed_block, $mock_context );
 
 		// Should return HTML content from the mock renderer.
 		$this->assertNotEmpty( $result );
@@ -81,40 +81,40 @@ class Initializer_Email_Render_Test extends BaseTestCase {
 	}
 
 	/**
-	 * Test render_videopress_video_block_email with missing attrs.
+	 * Test render with missing attrs.
 	 */
 	public function test_render_email_with_missing_attrs() {
 		$mock_context = $this->create_rendering_context_mock();
 
 		// Test with missing attrs key.
-		$result = Initializer::render_videopress_video_block_email( '', array( 'not-attrs' => array() ), $mock_context );
+		$result = Video_Block_Email_Renderer::render( '', array( 'not-attrs' => array() ), $mock_context );
 		$this->assertSame( '', $result );
 
 		// Test with non-array attrs.
-		$result = Initializer::render_videopress_video_block_email( '', array( 'attrs' => 'not-an-array' ), $mock_context );
+		$result = Video_Block_Email_Renderer::render( '', array( 'attrs' => 'not-an-array' ), $mock_context );
 		$this->assertSame( '', $result );
 	}
 
 	/**
-	 * Test render_videopress_video_block_email with missing guid.
+	 * Test render with missing guid.
 	 */
 	public function test_render_email_with_missing_guid() {
 		$parsed_block = $this->create_parsed_block( array( 'title' => 'Test Video' ) );
 		$mock_context = $this->create_rendering_context_mock();
 
-		$result = Initializer::render_videopress_video_block_email( '', $parsed_block, $mock_context );
+		$result = Video_Block_Email_Renderer::render( '', $parsed_block, $mock_context );
 
 		$this->assertSame( '', $result );
 	}
 
 	/**
-	 * Test render_videopress_video_block_email with empty guid.
+	 * Test render with empty guid.
 	 */
 	public function test_render_email_with_empty_guid() {
 		$parsed_block = $this->create_parsed_block( array( 'guid' => '' ) );
 		$mock_context = $this->create_rendering_context_mock();
 
-		$result = Initializer::render_videopress_video_block_email( '', $parsed_block, $mock_context );
+		$result = Video_Block_Email_Renderer::render( '', $parsed_block, $mock_context );
 
 		$this->assertSame( '', $result );
 	}
@@ -139,7 +139,7 @@ class Initializer_Email_Render_Test extends BaseTestCase {
 	}
 
 	/**
-	 * Test render_videopress_video_block_email rejects invalid guid characters (security).
+	 * Test render rejects invalid guid characters (security).
 	 *
 	 * @dataProvider invalid_guid_provider
 	 * @param string $invalid_guid The invalid guid to test.
@@ -149,7 +149,7 @@ class Initializer_Email_Render_Test extends BaseTestCase {
 		$parsed_block = $this->create_parsed_block( array( 'guid' => $invalid_guid ) );
 		$mock_context = $this->create_rendering_context_mock();
 
-		$result = Initializer::render_videopress_video_block_email( '', $parsed_block, $mock_context );
+		$result = Video_Block_Email_Renderer::render( '', $parsed_block, $mock_context );
 
 		// Should return empty string for invalid guids.
 		$this->assertSame( '', $result, "Invalid guid '$invalid_guid' should be rejected" );
@@ -173,7 +173,7 @@ class Initializer_Email_Render_Test extends BaseTestCase {
 	}
 
 	/**
-	 * Test render_videopress_video_block_email accepts valid guid formats.
+	 * Test render accepts valid guid formats.
 	 *
 	 * @dataProvider valid_guid_provider
 	 * @param string $valid_guid The valid guid to test.
@@ -183,7 +183,7 @@ class Initializer_Email_Render_Test extends BaseTestCase {
 		$parsed_block = $this->create_parsed_block( array( 'guid' => $valid_guid ) );
 		$mock_context = $this->create_rendering_context_mock();
 
-		$result = Initializer::render_videopress_video_block_email( '', $parsed_block, $mock_context );
+		$result = Video_Block_Email_Renderer::render( '', $parsed_block, $mock_context );
 
 		// Should return HTML content for valid guids.
 		$this->assertNotEmpty( $result, "Valid guid '$valid_guid' should be accepted" );
@@ -191,7 +191,7 @@ class Initializer_Email_Render_Test extends BaseTestCase {
 	}
 
 	/**
-	 * Test render_videopress_video_block_email preserves email_attrs.
+	 * Test render preserves email_attrs.
 	 */
 	public function test_render_email_preserves_email_attrs() {
 		$email_attrs = array(
@@ -206,20 +206,20 @@ class Initializer_Email_Render_Test extends BaseTestCase {
 		$mock_context = $this->create_rendering_context_mock();
 
 		// The mock renderer doesn't use email_attrs, but we verify the function doesn't error.
-		$result = Initializer::render_videopress_video_block_email( '', $parsed_block, $mock_context );
+		$result = Video_Block_Email_Renderer::render( '', $parsed_block, $mock_context );
 
 		$this->assertNotEmpty( $result );
 		$this->assertStringContainsString( 'https://videopress.com/v/testguid', $result );
 	}
 
 	/**
-	 * Test render_videopress_video_block_email constructs correct mock block structure.
+	 * Test render constructs correct mock block structure.
 	 */
 	public function test_render_email_constructs_correct_mock_block() {
 		$parsed_block = $this->create_parsed_block( array( 'guid' => 'abc123' ) );
 		$mock_context = $this->create_rendering_context_mock();
 
-		$result = Initializer::render_videopress_video_block_email( '', $parsed_block, $mock_context );
+		$result = Video_Block_Email_Renderer::render( '', $parsed_block, $mock_context );
 
 		// Verify the mock renderer received correct provider.
 		$this->assertStringContainsString( 'data-provider="videopress"', $result );
@@ -235,14 +235,14 @@ class Initializer_Email_Render_Test extends BaseTestCase {
 		$parsed_block = $this->create_parsed_block( array( 'guid' => 'MyVideo1' ) );
 		$mock_context = $this->create_rendering_context_mock();
 
-		$result = Initializer::render_videopress_video_block_email( '', $parsed_block, $mock_context );
+		$result = Video_Block_Email_Renderer::render( '', $parsed_block, $mock_context );
 
 		// URL should be exactly https://videopress.com/v/{guid}.
 		$this->assertStringContainsString( 'href="https://videopress.com/v/MyVideo1"', $result );
 	}
 
 	/**
-	 * Test render_email works with real-world block attributes.
+	 * Test render works with real-world block attributes.
 	 */
 	public function test_render_email_with_realistic_block_attributes() {
 		// Simulate attributes from a real VideoPress block.
@@ -263,7 +263,7 @@ class Initializer_Email_Render_Test extends BaseTestCase {
 		);
 		$mock_context = $this->create_rendering_context_mock();
 
-		$result = Initializer::render_videopress_video_block_email( '', $parsed_block, $mock_context );
+		$result = Video_Block_Email_Renderer::render( '', $parsed_block, $mock_context );
 
 		$this->assertNotEmpty( $result );
 		$this->assertStringContainsString( 'https://videopress.com/v/nfbj0J36', $result );
@@ -278,14 +278,14 @@ class Initializer_Email_Render_Test extends BaseTestCase {
 		$block_content = '<div>Some original content</div>';
 
 		// Should work with non-empty block_content.
-		$result = Initializer::render_videopress_video_block_email( $block_content, $parsed_block, $mock_context );
+		$result = Video_Block_Email_Renderer::render( $block_content, $parsed_block, $mock_context );
 
 		$this->assertNotEmpty( $result );
 		$this->assertStringContainsString( 'https://videopress.com/v/testguid', $result );
 	}
 
 	/**
-	 * Test render_email with private video renders a link fallback to the post.
+	 * Test render with private video renders a link fallback to the post.
 	 */
 	public function test_render_email_with_private_video_renders_link() {
 		// Create a post so get_the_permalink() returns a valid URL.
@@ -305,12 +305,12 @@ class Initializer_Email_Render_Test extends BaseTestCase {
 		);
 		$mock_context = $this->create_rendering_context_mock();
 
-		$result = Initializer::render_videopress_video_block_email( '', $parsed_block, $mock_context );
+		$result = Video_Block_Email_Renderer::render( '', $parsed_block, $mock_context );
 
 		// Should render a simple link to the post instead of video embed.
 		$this->assertNotEmpty( $result );
 		$this->assertStringContainsString( '<a href=', $result );
-		$this->assertStringContainsString( 'Watch the video', $result );
+		$this->assertStringContainsString( 'Visit the post to watch the video', $result );
 		// Should NOT contain the embed wrapper that the mock renderer produces.
 		$this->assertStringNotContainsString( 'email-embed-video', $result );
 		// Should NOT link to VideoPress since video is private.
@@ -322,7 +322,7 @@ class Initializer_Email_Render_Test extends BaseTestCase {
 	}
 
 	/**
-	 * Test render_email with public video renders full embed.
+	 * Test render with public video renders full embed.
 	 */
 	public function test_render_email_with_public_video_renders_embed() {
 		$parsed_block = $this->create_parsed_block(
@@ -333,7 +333,7 @@ class Initializer_Email_Render_Test extends BaseTestCase {
 		);
 		$mock_context = $this->create_rendering_context_mock();
 
-		$result = Initializer::render_videopress_video_block_email( '', $parsed_block, $mock_context );
+		$result = Video_Block_Email_Renderer::render( '', $parsed_block, $mock_context );
 
 		// Should render the full embed (via mock renderer).
 		$this->assertNotEmpty( $result );
@@ -342,7 +342,7 @@ class Initializer_Email_Render_Test extends BaseTestCase {
 	}
 
 	/**
-	 * Test render_email private video link includes padding when email_attrs present.
+	 * Test render private video link includes padding when email_attrs present.
 	 */
 	public function test_render_email_private_video_link_with_padding() {
 		// Create a post so get_the_permalink() returns a valid URL.
@@ -363,7 +363,7 @@ class Initializer_Email_Render_Test extends BaseTestCase {
 		);
 		$mock_context = $this->create_rendering_context_mock();
 
-		$result = Initializer::render_videopress_video_block_email( '', $parsed_block, $mock_context );
+		$result = Video_Block_Email_Renderer::render( '', $parsed_block, $mock_context );
 
 		$this->assertNotEmpty( $result );
 		$this->assertStringContainsString( 'padding: 20px', $result );
@@ -375,7 +375,7 @@ class Initializer_Email_Render_Test extends BaseTestCase {
 	}
 
 	/**
-	 * Test render_email with private video returns empty when no post context.
+	 * Test render with private video returns empty when no post context.
 	 */
 	public function test_render_email_with_private_video_no_post_returns_empty() {
 		// Ensure no post context.
@@ -389,7 +389,7 @@ class Initializer_Email_Render_Test extends BaseTestCase {
 		);
 		$mock_context = $this->create_rendering_context_mock();
 
-		$result = Initializer::render_videopress_video_block_email( '', $parsed_block, $mock_context );
+		$result = Video_Block_Email_Renderer::render( '', $parsed_block, $mock_context );
 
 		// Should return empty string when no post URL available.
 		$this->assertSame( '', $result );

--- a/projects/packages/videopress/tests/php/mocks/class-mock-woocommerce-embed-renderer.php
+++ b/projects/packages/videopress/tests/php/mocks/class-mock-woocommerce-embed-renderer.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Mock class for WooCommerce Email Editor Embed Renderer
+ *
+ * @package automattic/jetpack-videopress
+ */
+
+// Mock WooCommerce Embed Renderer class for testing.
+if ( ! class_exists( '\Automattic\WooCommerce\EmailEditor\Integrations\Core\Renderer\Blocks\Embed' ) ) {
+	/**
+	 * Mock implementation of WooCommerce Embed Renderer for testing.
+	 */
+	class Mock_WooCommerce_Embed_Renderer {
+		/**
+		 * Mock render method.
+		 *
+		 * @param string $block_content The block content.
+		 * @param array  $parsed_block  The parsed block data.
+		 * @param object $rendering_context The email rendering context.
+		 * @return string
+		 */
+		public function render( $block_content, $parsed_block, $rendering_context ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+			$attrs = $parsed_block['attrs'] ?? array();
+			$url   = $attrs['url'] ?? '';
+
+			if ( empty( $url ) ) {
+				return '';
+			}
+
+			$provider = $attrs['providerNameSlug'] ?? 'unknown';
+
+			// Return simple HTML that tests can verify.
+			return sprintf(
+				'<div class="email-embed-video" data-provider="%s"><a href="%s">Watch Video</a></div>',
+				esc_attr( $provider ),
+				esc_url( $url )
+			);
+		}
+	}
+	class_alias( 'Mock_WooCommerce_Embed_Renderer', '\Automattic\WooCommerce\EmailEditor\Integrations\Core\Renderer\Blocks\Embed' );
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://linear.app/a8c/issue/NL-156/add-email-rendering-for-videopress-blocks-and-videopress-embeds

## Proposed changes:
                                                                                                                                                 
  * Add `render_email_callback` to the `videopress/video` block registration to support rendering in WooCommerce email editor context.
  * Implement `render_videopress_video_block_email()` method that delegates to WooCommerce's core Embed renderer                                 
  * Add `get_videopress_url_for_email()` helper that constructs VideoPress URL from block's guid attribute with alphanumeric validation for security                                                                                                                                       
  * Add comprehensive test coverage.
  * Add a fallback link to the post for when videos are private.

Private | Public
---- | ----
<img width="608" height="304" alt="Screenshot 2026-01-29 at 3 22 26 PM" src="https://github.com/user-attachments/assets/c4a97eb0-72a9-4032-8cc6-6ea5ed230041" /> | <img width="593" height="688" alt="Screenshot 2026-01-29 at 3 22 12 PM" src="https://github.com/user-attachments/assets/6c777754-45e2-4d37-803e-fd6b2c5b9440" />

                                                                                                                                                 
  ### Other information:                                                                                                                         
                                                                                                                                                 
  - [x] Have you written new tests for your changes, if applicable?                                                                              
  - [x] Have you checked the E2E test CI results, and verified that your changes do not break them?                                              
  - [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?         
                                                                                                                                                 
  ## Jetpack product discussion                                                                                                                  
                                                                                                                                                 
  N/A                                                                                                                                            
                                                                                                                                                 
  ## Does this pull request change what data or activity we track or use?                                                                        
                                                                                                                                                 
  No                                                                                                                                             
                                                                                                                                                 
  ## Testing instructions:                                                                                                                       

  * On a test Simple site, add a draft post with a `videopress/video` block. Let me know if you need a video file. You may need to upgrade to Premium.                                                       
  * Apply this change to your sandbox: `bin/jetpack-downloader test jetpack add/videopress-email-rendering`
  * Turn on write access.
  * Sandbox the API.
  * Add `define( 'EMAIL_TEST', true );` to your 0-sandbox.php.
  * Sandbox all jobs and start the jobs watcher.                   
  * For the post you created earlier, preview the email to verify that the video renders as a thumbnail with play button overlay.
  * Send a test email and verify again.
  * Publish the post and verify again.
  * Make the site private in your hosting options.
  * With a duplicate post with the VideoPress block, repeat the testing steps (preview, test email, publish). The block should render as a "Watch the video" link to the post instead.
  * Re-test on a WoA site connected to your sandbox.

