### PR TITLE
Forms: Add widget editor support for form conversion and editing

### DIFF
--- a/projects/packages/forms/changelog/fix-widget-editor-cfm
+++ b/projects/packages/forms/changelog/fix-widget-editor-cfm
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Contact Form: Add support for form editing in widget editor context.

--- a/projects/packages/forms/src/blocks/contact-form/components/convert-form-toolbar.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/components/convert-form-toolbar.tsx
@@ -15,7 +15,7 @@ import { createSyncedForm } from '../util/create-synced-form.ts';
 
 const FORM_CONVERSION_LOCK = 'jetpack-form-conversion';
 const isWidgetEditor = window.location.pathname.endsWith( '/widgets.php' );
-const isSiteEditor = window.location.pathname.includes( '/site-editor.php' );
+const isSiteEditor = window.location.pathname.endsWith( '/site-editor.php' );
 
 /**
  * Navigate to edit a form post.

--- a/projects/packages/forms/src/blocks/contact-form/components/convert-form-toolbar.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/components/convert-form-toolbar.tsx
@@ -12,27 +12,26 @@ import { store as noticesStore } from '@wordpress/notices';
 import { addQueryArgs } from '@wordpress/url';
 import { FORM_POST_TYPE } from '../../shared/util/constants.js';
 import { createSyncedForm } from '../util/create-synced-form.ts';
+import { getEditorContext, type EditorContext } from '../util/get-editor-context.ts';
 
 const FORM_CONVERSION_LOCK = 'jetpack-form-conversion';
-const isWidgetEditor = window.location.pathname.endsWith( '/widgets.php' );
-const isSiteEditor = window.location.pathname.endsWith( '/site-editor.php' );
 
 /**
  * Navigate to edit a form post.
- * - Widget editor: opens in new tab (no in-editor navigation available)
- * - Site editor: redirects in same page
+ * - Widget/Site editor: redirects in same page (no in-editor navigation available)
  * - Post editor: uses in-editor navigation if available
  *
  * @param formId                   - The form post ID to edit.
+ * @param editorContext            - The current editor context.
  * @param onNavigateToEntityRecord - Optional callback for in-editor navigation.
  */
-const navigateToForm = (
+export const navigateToForm = (
 	formId: number,
+	editorContext: EditorContext,
 	onNavigateToEntityRecord?: ( params: { postId: number; postType: string } ) => void
 ) => {
-	const editUrl = addQueryArgs( 'post.php', { post: formId, action: 'edit' } );
-
-	if ( isWidgetEditor || isSiteEditor ) {
+	if ( editorContext === 'widget' || editorContext === 'site' ) {
+		const editUrl = addQueryArgs( 'post.php', { post: formId, action: 'edit' } );
 		window.location.href = editUrl;
 	} else if ( onNavigateToEntityRecord ) {
 		onNavigateToEntityRecord( { postId: formId, postType: FORM_POST_TYPE } );
@@ -53,6 +52,9 @@ interface ConvertFormToolbarProps {
  * @return Toolbar with edit/convert buttons.
  */
 export function ConvertFormToolbar( { clientId, attributes }: ConvertFormToolbarProps ) {
+	const editorContext = getEditorContext();
+	const isWidgetEditor = editorContext === 'widget';
+
 	const { block, formTitle, currentPostId, isLocked, onNavigateToEntityRecord } = useSelect(
 		select => {
 			const { getBlock, getSettings } = select( blockEditorStore );
@@ -84,7 +86,7 @@ export function ConvertFormToolbar( { clientId, attributes }: ConvertFormToolbar
 				onNavigateToEntityRecord: getSettings().onNavigateToEntityRecord,
 			};
 		},
-		[ clientId ]
+		[ clientId, isWidgetEditor ]
 	);
 
 	const { replaceInnerBlocks, updateBlockAttributes } = useDispatch( blockEditorStore );
@@ -118,7 +120,7 @@ export function ConvertFormToolbar( { clientId, attributes }: ConvertFormToolbar
 			);
 			updateBlockAttributes( clientId, clearedAttributes );
 
-			navigateToForm( formId, onNavigateToEntityRecord );
+			navigateToForm( formId, editorContext, onNavigateToEntityRecord );
 		} catch {
 			createErrorNotice( __( 'Failed to create a form. Please try again.', 'jetpack-forms' ), {
 				type: 'snackbar',
@@ -131,17 +133,21 @@ export function ConvertFormToolbar( { clientId, attributes }: ConvertFormToolbar
 
 	const handleEditOriginal = () => {
 		if ( attributes.ref ) {
-			navigateToForm( attributes.ref as number, onNavigateToEntityRecord );
+			navigateToForm( attributes.ref as number, editorContext, onNavigateToEntityRecord );
 		}
 	};
 
-	const handleOnClick = hasRef ? handleEditOriginal : convertToSynced;
-
 	return (
 		<ToolbarGroup>
-			<ToolbarButton onClick={ handleOnClick }>
-				{ __( 'Edit Form', 'jetpack-forms' ) }
-			</ToolbarButton>
+			{ hasRef ? (
+				<ToolbarButton onClick={ handleEditOriginal }>
+					{ __( 'Edit Form', 'jetpack-forms' ) }
+				</ToolbarButton>
+			) : (
+				<ToolbarButton onClick={ convertToSynced } disabled={ isLocked }>
+					{ __( 'Edit Form', 'jetpack-forms' ) }
+				</ToolbarButton>
+			) }
 		</ToolbarGroup>
 	);
 }

--- a/projects/packages/forms/src/blocks/contact-form/components/convert-form-toolbar.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/components/convert-form-toolbar.tsx
@@ -14,151 +14,134 @@ import { FORM_POST_TYPE } from '../../shared/util/constants.js';
 import { createSyncedForm } from '../util/create-synced-form.ts';
 
 const FORM_CONVERSION_LOCK = 'jetpack-form-conversion';
+const isWidgetEditor = window.location.pathname.endsWith( '/widgets.php' );
+const isSiteEditor = window.location.pathname.includes( '/site-editor.php' );
+
+/**
+ * Navigate to edit a form post.
+ * - Widget editor: opens in new tab (no in-editor navigation available)
+ * - Site editor: redirects in same page
+ * - Post editor: uses in-editor navigation if available
+ *
+ * @param formId                   - The form post ID to edit.
+ * @param onNavigateToEntityRecord - Optional callback for in-editor navigation.
+ */
+const navigateToForm = (
+	formId: number,
+	onNavigateToEntityRecord?: ( params: { postId: number; postType: string } ) => void
+) => {
+	const editUrl = addQueryArgs( 'post.php', { post: formId, action: 'edit' } );
+
+	if ( isWidgetEditor || isSiteEditor ) {
+		window.location.href = editUrl;
+	} else if ( onNavigateToEntityRecord ) {
+		onNavigateToEntityRecord( { postId: formId, postType: FORM_POST_TYPE } );
+	}
+};
 
 interface ConvertFormToolbarProps {
 	clientId: string;
 	attributes: Record< string, unknown >;
 }
 
+/**
+ * Toolbar component for converting inline forms to synced forms and editing synced forms.
+ *
+ * @param props            - Component props.
+ * @param props.clientId   - The block client ID.
+ * @param props.attributes - The block attributes.
+ * @return Toolbar with edit/convert buttons.
+ */
 export function ConvertFormToolbar( { clientId, attributes }: ConvertFormToolbarProps ) {
-	const { postTitle, currentPostId, isLocked } = useSelect( select => {
-		const editedPost = select( editorStore ).getEditedPostAttribute( 'title' );
-		const editedPostId = select( editorStore ).getEditedPostAttribute( 'id' );
-		const savingLocked = select( editorStore ).isPostSavingLocked();
-		return {
-			postTitle: editedPost || 'Untitled',
-			currentPostId: editedPostId,
-			isLocked: savingLocked,
-		};
-	}, [] );
+	const { block, formTitle, currentPostId, isLocked, onNavigateToEntityRecord } = useSelect(
+		select => {
+			const { getBlock, getSettings } = select( blockEditorStore );
 
-	const { onNavigateToEntityRecord, isSiteEditor } = useSelect( select => {
-		const { getSettings } = select( blockEditorStore );
-		return {
-			onNavigateToEntityRecord: getSettings().onNavigateToEntityRecord,
-			isSiteEditor: !! select( 'core/edit-site' ),
-		};
-	}, [] );
+			// Get widget area name in widget editor context
+			let widgetAreaName = null;
+			if ( isWidgetEditor ) {
+				try {
+					// eslint-disable-next-line @typescript-eslint/no-explicit-any
+					const widgetStore = select( 'core/edit-widgets' ) as any;
+					widgetAreaName = widgetStore?.getParentWidgetAreaBlock?.( clientId )?.attributes?.name;
+				} catch {
+					// Widget store not available
+				}
+			}
 
-	// Get block data
-	const block = useSelect(
-		select => select( blockEditorStore ).getBlock( clientId ),
+			// In widget editor, we don't have post context
+			const postTitle = isWidgetEditor
+				? null
+				: select( editorStore ).getEditedPostAttribute( 'title' );
+			const postId = isWidgetEditor ? 0 : select( editorStore ).getEditedPostAttribute( 'id' );
+			const locked = isWidgetEditor ? false : select( editorStore ).isPostSavingLocked();
+
+			return {
+				block: getBlock( clientId ),
+				formTitle: widgetAreaName || postTitle || 'Untitled',
+				currentPostId: postId,
+				isLocked: locked,
+				onNavigateToEntityRecord: getSettings().onNavigateToEntityRecord,
+			};
+		},
 		[ clientId ]
 	);
 
-	// Get functions to manipulate blocks
 	const { replaceInnerBlocks, updateBlockAttributes } = useDispatch( blockEditorStore );
 	const { lockPostSaving, unlockPostSaving } = useDispatch( editorStore );
 	const { createErrorNotice } = useDispatch( noticesStore );
 
 	const hasRef = !! attributes.ref;
 
-	/**
-	 * Open the form editor by navigating directly.
-	 * @param formId - The ID of the form to edit.
-	 */
-	const openFormEditor = ( formId: number ) => {
-		const editUrl = addQueryArgs( 'post.php', { post: formId, action: 'edit' } );
-		window.location.href = editUrl;
-	};
-
-	/**
-	 * Convert inline form to synced form
-	 */
 	const convertToSynced = async () => {
 		if ( ! block || isLocked ) {
 			return;
 		}
 
-		lockPostSaving( FORM_CONVERSION_LOCK );
+		lockPostSaving?.( FORM_CONVERSION_LOCK );
 
 		try {
-			// Remove ref from attributes if it exists (shouldn't, but safety check)
 			// eslint-disable-next-line @typescript-eslint/no-unused-vars
 			const { ref, ...cleanAttributes } = attributes;
 
-			// Create the synced form post with all attributes and innerBlocks
 			const formId = await createSyncedForm(
-				{
-					attributes: cleanAttributes,
-					innerBlocks: block.innerBlocks || [],
-				},
-				postTitle,
+				{ attributes: cleanAttributes, innerBlocks: block.innerBlocks || [] },
+				formTitle,
 				currentPostId
 			);
 
-			// Clear innerBlocks first
+			// Clear block and set ref to the new form
 			replaceInnerBlocks( clientId, [], false );
-
-			// Get all current attribute keys
-			const attributeKeys = Object.keys( attributes );
-			const clearedAttributes: Record< string, unknown > = {};
-
-			// Set all attributes to undefined to clear them
-			attributeKeys.forEach( key => {
-				clearedAttributes[ key ] = undefined;
-			} );
-
-			// Then set only the ref
-			clearedAttributes.ref = formId;
-
-			// Update attributes using updateBlockAttributes which properly clears them
+			const clearedAttributes = Object.keys( attributes ).reduce(
+				( acc, key ) => ( { ...acc, [ key ]: undefined } ),
+				{ ref: formId }
+			);
 			updateBlockAttributes( clientId, clearedAttributes );
 
-			if ( isSiteEditor ) {
-				openFormEditor( formId );
-			} else if ( onNavigateToEntityRecord ) {
-				onNavigateToEntityRecord( {
-					postId: formId,
-					postType: FORM_POST_TYPE,
-				} );
-			}
+			navigateToForm( formId, onNavigateToEntityRecord );
 		} catch {
 			createErrorNotice( __( 'Failed to create a form. Please try again.', 'jetpack-forms' ), {
 				type: 'snackbar',
 				isDismissible: true,
 			} );
 		} finally {
-			unlockPostSaving( FORM_CONVERSION_LOCK );
+			unlockPostSaving?.( FORM_CONVERSION_LOCK );
 		}
 	};
 
-	/**
-	 * Navigate to edit the synced form post
-	 */
 	const handleEditOriginal = () => {
-		if ( ! attributes.ref ) {
-			return;
-		}
-
-		if ( isSiteEditor ) {
-			openFormEditor( attributes.ref as number );
-			return;
-		}
-
-		if ( onNavigateToEntityRecord ) {
-			onNavigateToEntityRecord( {
-				postId: attributes.ref as number,
-				postType: FORM_POST_TYPE,
-			} );
+		if ( attributes.ref ) {
+			navigateToForm( attributes.ref as number, onNavigateToEntityRecord );
 		}
 	};
 
-	const showEditButton = hasRef && ( isSiteEditor || onNavigateToEntityRecord );
-	const showConvertButton = ! hasRef;
+	const handleOnClick = hasRef ? handleEditOriginal : convertToSynced;
 
 	return (
 		<ToolbarGroup>
-			{ showEditButton && (
-				<ToolbarButton onClick={ handleEditOriginal }>
-					{ __( 'Edit Form', 'jetpack-forms' ) }
-				</ToolbarButton>
-			) }
-			{ showConvertButton && (
-				<ToolbarButton onClick={ convertToSynced } disabled={ isLocked }>
-					{ __( 'Edit Form', 'jetpack-forms' ) }
-				</ToolbarButton>
-			) }
+			<ToolbarButton onClick={ handleOnClick }>
+				{ __( 'Edit Form', 'jetpack-forms' ) }
+			</ToolbarButton>
 		</ToolbarGroup>
 	);
 }

--- a/projects/packages/forms/src/blocks/contact-form/util/create-synced-form.ts
+++ b/projects/packages/forms/src/blocks/contact-form/util/create-synced-form.ts
@@ -41,13 +41,20 @@ export async function createSyncedForm(
 			innerBlocks: blockData?.innerBlocks,
 		},
 	] );
+
+	// detect if currenPostId is valid before passing it to the seveEntityRecord
+	const meta =
+		currentPostId > 0
+			? {
+					[ FORM_SOURCE_META_KEY ]: currentPostId,
+			  }
+			: {};
+
 	const response = ( await dispatch( coreStore ).saveEntityRecord( 'postType', FORM_POST_TYPE, {
 		title: pageTitle || __( 'Untitled Form', 'jetpack-forms' ),
 		content: blockMarkup,
 		status: 'publish',
-		meta: {
-			[ FORM_SOURCE_META_KEY ]: currentPostId,
-		},
+		meta,
 	} ) ) as JetpackFormPost;
 
 	return response.id;

--- a/projects/packages/forms/src/blocks/contact-form/util/create-synced-form.ts
+++ b/projects/packages/forms/src/blocks/contact-form/util/create-synced-form.ts
@@ -42,7 +42,7 @@ export async function createSyncedForm(
 		},
 	] );
 
-	// detect if currenPostId is valid before passing it to the seveEntityRecord
+	// detect if currentPostId is valid before passing it to the saveEntityRecord
 	const meta =
 		currentPostId > 0
 			? {

--- a/projects/packages/forms/src/blocks/contact-form/util/get-editor-context.ts
+++ b/projects/packages/forms/src/blocks/contact-form/util/get-editor-context.ts
@@ -1,0 +1,22 @@
+/**
+ * Editor Context Utility
+ * Detects which WordPress editor environment the block is running in.
+ */
+
+export type EditorContext = 'widget' | 'site' | 'post';
+
+/**
+ * Detects the current editor context based on the URL path.
+ *
+ * @return The editor context: 'widget', 'site', or 'post'
+ */
+export function getEditorContext(): EditorContext {
+	const path = window.location.pathname;
+	if ( path.endsWith( '/widgets.php' ) ) {
+		return 'widget';
+	}
+	if ( path.endsWith( '/site-editor.php' ) ) {
+		return 'site';
+	}
+	return 'post';
+}

--- a/projects/packages/forms/tests/js/contact-form/components/convert-form-toolbar.test.js
+++ b/projects/packages/forms/tests/js/contact-form/components/convert-form-toolbar.test.js
@@ -206,7 +206,7 @@ describe( 'ConvertFormToolbar', () => {
 		} );
 
 		it( 'creates synced form and navigates via URL on convert', async () => {
-			mockCreateSyncedForm.mockResolvedValue( 789, 'Footer Widget Area', 0 );
+			mockCreateSyncedForm.mockResolvedValue( 789 );
 
 			render( <ConvertFormToolbar clientId="test-id" attributes={ { to: 'test@example.com' } } /> );
 			await userEvent.click( screen.getByRole( 'button' ) );

--- a/projects/packages/forms/tests/js/contact-form/components/convert-form-toolbar.test.js
+++ b/projects/packages/forms/tests/js/contact-form/components/convert-form-toolbar.test.js
@@ -206,7 +206,7 @@ describe( 'ConvertFormToolbar', () => {
 		} );
 
 		it( 'creates synced form and navigates via URL on convert', async () => {
-			mockCreateSyncedForm.mockResolvedValue( 789 );
+			mockCreateSyncedForm.mockResolvedValue( 789, 'Footer Widget Area', 0 );
 
 			render( <ConvertFormToolbar clientId="test-id" attributes={ { to: 'test@example.com' } } /> );
 			await userEvent.click( screen.getByRole( 'button' ) );

--- a/projects/packages/forms/tests/js/contact-form/components/convert-form-toolbar.test.js
+++ b/projects/packages/forms/tests/js/contact-form/components/convert-form-toolbar.test.js
@@ -9,6 +9,7 @@ import userEvent from '@testing-library/user-event';
 // Mock functions
 const mockCreateSyncedForm = jest.fn();
 const mockUpdateBlockAttributes = jest.fn();
+const mockReplaceInnerBlocks = jest.fn();
 const mockLockPostSaving = jest.fn();
 const mockUnlockPostSaving = jest.fn();
 const mockCreateErrorNotice = jest.fn();
@@ -18,11 +19,11 @@ const mockAddQueryArgs = jest.fn(
 );
 
 let mockIsLocked = false;
-let mockIsSiteEditor = false;
+let mockEditorContext = 'post';
 
 // Mock WordPress dependencies
 await jest.unstable_mockModule( '@wordpress/components', () => ( {
-	ToolbarGroup: ( { children } ) => <div>{ children }</div>,
+	ToolbarGroup: ( { children } ) => <div data-testid="toolbar-group">{ children }</div>,
 	ToolbarButton: ( { children, onClick, disabled } ) => (
 		<button onClick={ onClick } disabled={ disabled }>
 			{ children }
@@ -53,14 +54,16 @@ await jest.unstable_mockModule( '@wordpress/data', () => ( {
 					getSettings: () => ( { onNavigateToEntityRecord: mockOnNavigateToEntityRecord } ),
 				};
 			}
-			if ( store === 'core/edit-site' ) {
-				return mockIsSiteEditor ? {} : undefined;
+			if ( store === 'core/edit-widgets' ) {
+				return {
+					getParentWidgetAreaBlock: () => ( { attributes: { name: 'Footer Widget Area' } } ),
+				};
 			}
 			return undefined;
 		} )
 	),
 	useDispatch: jest.fn( () => ( {
-		replaceInnerBlocks: jest.fn(),
+		replaceInnerBlocks: mockReplaceInnerBlocks,
 		updateBlockAttributes: mockUpdateBlockAttributes,
 		lockPostSaving: mockLockPostSaving,
 		unlockPostSaving: mockUnlockPostSaving,
@@ -75,7 +78,14 @@ await jest.unstable_mockModule(
 	} )
 );
 
-const { ConvertFormToolbar } = await import(
+await jest.unstable_mockModule(
+	'../../../../src/blocks/contact-form/util/get-editor-context',
+	() => ( {
+		getEditorContext: () => mockEditorContext,
+	} )
+);
+
+const { ConvertFormToolbar, navigateToForm } = await import(
 	'../../../../src/blocks/contact-form/components/convert-form-toolbar'
 );
 
@@ -83,96 +93,210 @@ describe( 'ConvertFormToolbar', () => {
 	beforeEach( () => {
 		jest.clearAllMocks();
 		mockIsLocked = false;
-		mockIsSiteEditor = false;
+		mockEditorContext = 'post';
 	} );
 
-	it( 'renders Edit Form button', () => {
-		render( <ConvertFormToolbar clientId="test-id" attributes={ {} } /> );
-		expect( screen.getByText( 'Edit Form' ) ).toBeInTheDocument();
-	} );
+	describe( 'rendering', () => {
+		it( 'renders Edit Form button', () => {
+			render( <ConvertFormToolbar clientId="test-id" attributes={ {} } /> );
+			expect( screen.getByText( 'Edit Form' ) ).toBeInTheDocument();
+		} );
 
-	it( 'disables button when editor is locked', () => {
-		mockIsLocked = true;
-		render( <ConvertFormToolbar clientId="test-id" attributes={ {} } /> );
-		expect( screen.getByRole( 'button' ) ).toBeDisabled();
-	} );
+		it( 'disables button when editor is locked and form is not synced', () => {
+			mockIsLocked = true;
+			render( <ConvertFormToolbar clientId="test-id" attributes={ {} } /> );
+			expect( screen.getByRole( 'button' ) ).toBeDisabled();
+		} );
 
-	it( 'navigates to form when clicking edit on synced form', async () => {
-		render( <ConvertFormToolbar clientId="test-id" attributes={ { ref: 456 } } /> );
-		await userEvent.click( screen.getByRole( 'button' ) );
-
-		expect( mockOnNavigateToEntityRecord ).toHaveBeenCalledWith( {
-			postId: 456,
-			postType: 'jetpack_form',
+		it( 'does not disable button when form is already synced (has ref)', () => {
+			mockIsLocked = true;
+			render( <ConvertFormToolbar clientId="test-id" attributes={ { ref: 456 } } /> );
+			expect( screen.getByRole( 'button' ) ).toBeEnabled();
 		} );
 	} );
 
-	it( 'creates synced form and navigates on convert', async () => {
-		mockCreateSyncedForm.mockResolvedValue( 789 );
+	describe( 'post editor context', () => {
+		beforeEach( () => {
+			mockEditorContext = 'post';
+		} );
 
-		render( <ConvertFormToolbar clientId="test-id" attributes={ { to: 'test@example.com' } } /> );
-		await userEvent.click( screen.getByRole( 'button' ) );
+		it( 'navigates to form using onNavigateToEntityRecord when clicking edit on synced form', async () => {
+			render( <ConvertFormToolbar clientId="test-id" attributes={ { ref: 456 } } /> );
+			await userEvent.click( screen.getByRole( 'button' ) );
 
-		await waitFor( () => {
 			expect( mockOnNavigateToEntityRecord ).toHaveBeenCalledWith( {
-				postId: 789,
+				postId: 456,
 				postType: 'jetpack_form',
 			} );
 		} );
 
-		expect( mockLockPostSaving ).toHaveBeenCalled();
-		expect( mockUnlockPostSaving ).toHaveBeenCalled();
-	} );
+		it( 'creates synced form and navigates on convert', async () => {
+			mockCreateSyncedForm.mockResolvedValue( 789 );
 
-	it( 'in site editor, navigates via URL when clicking edit on synced form', async () => {
-		mockIsSiteEditor = true;
+			render( <ConvertFormToolbar clientId="test-id" attributes={ { to: 'test@example.com' } } /> );
+			await userEvent.click( screen.getByRole( 'button' ) );
 
-		render( <ConvertFormToolbar clientId="test-id" attributes={ { ref: 456 } } /> );
-		await userEvent.click( screen.getByRole( 'button' ) );
+			await waitFor( () => {
+				expect( mockOnNavigateToEntityRecord ).toHaveBeenCalledWith( {
+					postId: 789,
+					postType: 'jetpack_form',
+				} );
+			} );
 
-		expect( mockAddQueryArgs ).toHaveBeenCalledWith( 'post.php', {
-			post: 456,
-			action: 'edit',
+			expect( mockLockPostSaving ).toHaveBeenCalled();
+			expect( mockUnlockPostSaving ).toHaveBeenCalled();
 		} );
-		expect( mockOnNavigateToEntityRecord ).not.toHaveBeenCalled();
-		// jsdom logs an error for unimplemented navigation
-		expect( console ).toHaveErrored();
 	} );
 
-	it( 'in site editor, creates synced form and navigates via URL on convert', async () => {
-		mockIsSiteEditor = true;
-		mockCreateSyncedForm.mockResolvedValue( 789 );
+	describe( 'site editor context', () => {
+		beforeEach( () => {
+			mockEditorContext = 'site';
+		} );
 
-		render( <ConvertFormToolbar clientId="test-id" attributes={ { to: 'test@example.com' } } /> );
-		await userEvent.click( screen.getByRole( 'button' ) );
+		it( 'navigates via URL when clicking edit on synced form', async () => {
+			render( <ConvertFormToolbar clientId="test-id" attributes={ { ref: 456 } } /> );
+			await userEvent.click( screen.getByRole( 'button' ) );
 
-		await waitFor( () => {
 			expect( mockAddQueryArgs ).toHaveBeenCalledWith( 'post.php', {
-				post: 789,
+				post: 456,
 				action: 'edit',
 			} );
+			expect( mockOnNavigateToEntityRecord ).not.toHaveBeenCalled();
+			// jsdom logs an error for unimplemented navigation
+			expect( console ).toHaveErrored();
 		} );
 
-		expect( mockOnNavigateToEntityRecord ).not.toHaveBeenCalled();
-		expect( mockLockPostSaving ).toHaveBeenCalled();
-		expect( mockUnlockPostSaving ).toHaveBeenCalled();
+		it( 'creates synced form and navigates via URL on convert', async () => {
+			mockCreateSyncedForm.mockResolvedValue( 789 );
+
+			render( <ConvertFormToolbar clientId="test-id" attributes={ { to: 'test@example.com' } } /> );
+			await userEvent.click( screen.getByRole( 'button' ) );
+
+			await waitFor( () => {
+				expect( mockAddQueryArgs ).toHaveBeenCalledWith( 'post.php', {
+					post: 789,
+					action: 'edit',
+				} );
+			} );
+
+			expect( mockOnNavigateToEntityRecord ).not.toHaveBeenCalled();
+			expect( mockLockPostSaving ).toHaveBeenCalled();
+			expect( mockUnlockPostSaving ).toHaveBeenCalled();
+			// jsdom logs an error for unimplemented navigation
+			expect( console ).toHaveErrored();
+		} );
+	} );
+
+	describe( 'widget editor context', () => {
+		beforeEach( () => {
+			mockEditorContext = 'widget';
+		} );
+
+		it( 'navigates via URL when clicking edit on synced form', async () => {
+			render( <ConvertFormToolbar clientId="test-id" attributes={ { ref: 456 } } /> );
+			await userEvent.click( screen.getByRole( 'button' ) );
+
+			expect( mockAddQueryArgs ).toHaveBeenCalledWith( 'post.php', {
+				post: 456,
+				action: 'edit',
+			} );
+			expect( mockOnNavigateToEntityRecord ).not.toHaveBeenCalled();
+			// jsdom logs an error for unimplemented navigation
+			expect( console ).toHaveErrored();
+		} );
+
+		it( 'creates synced form and navigates via URL on convert', async () => {
+			mockCreateSyncedForm.mockResolvedValue( 789 );
+
+			render( <ConvertFormToolbar clientId="test-id" attributes={ { to: 'test@example.com' } } /> );
+			await userEvent.click( screen.getByRole( 'button' ) );
+
+			await waitFor( () => {
+				expect( mockAddQueryArgs ).toHaveBeenCalledWith( 'post.php', {
+					post: 789,
+					action: 'edit',
+				} );
+			} );
+
+			expect( mockOnNavigateToEntityRecord ).not.toHaveBeenCalled();
+			expect( mockLockPostSaving ).toHaveBeenCalled();
+			expect( mockUnlockPostSaving ).toHaveBeenCalled();
+			// jsdom logs an error for unimplemented navigation
+			expect( console ).toHaveErrored();
+		} );
+
+		it( 'button is not disabled even when locked (widget editor has no lock)', () => {
+			mockIsLocked = true; // This should be ignored in widget context
+			render( <ConvertFormToolbar clientId="test-id" attributes={ {} } /> );
+			// In widget editor, isLocked is always false, so button should be enabled
+			expect( screen.getByRole( 'button' ) ).toBeEnabled();
+		} );
+	} );
+
+	describe( 'error handling', () => {
+		it( 'shows error notice when conversion fails', async () => {
+			mockCreateSyncedForm.mockRejectedValue( new Error( 'API Error' ) );
+
+			render( <ConvertFormToolbar clientId="test-id" attributes={ {} } /> );
+			await userEvent.click( screen.getByRole( 'button' ) );
+
+			await waitFor( () => {
+				expect( mockCreateErrorNotice ).toHaveBeenCalledWith(
+					'Failed to create a form. Please try again.',
+					expect.objectContaining( { type: 'snackbar' } )
+				);
+			} );
+
+			expect( mockUnlockPostSaving ).toHaveBeenCalled();
+		} );
+	} );
+} );
+
+describe( 'navigateToForm', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'uses onNavigateToEntityRecord in post context when available', () => {
+		const mockNavigate = jest.fn();
+		navigateToForm( 123, 'post', mockNavigate );
+
+		expect( mockNavigate ).toHaveBeenCalledWith( {
+			postId: 123,
+			postType: 'jetpack_form',
+		} );
+		expect( mockAddQueryArgs ).not.toHaveBeenCalled();
+	} );
+
+	it( 'does nothing in post context when onNavigateToEntityRecord is not available', () => {
+		navigateToForm( 123, 'post', undefined );
+
+		expect( mockAddQueryArgs ).not.toHaveBeenCalled();
+	} );
+
+	it( 'navigates via URL in site editor context', () => {
+		const mockNavigate = jest.fn();
+		navigateToForm( 123, 'site', mockNavigate );
+
+		expect( mockAddQueryArgs ).toHaveBeenCalledWith( 'post.php', {
+			post: 123,
+			action: 'edit',
+		} );
+		expect( mockNavigate ).not.toHaveBeenCalled();
 		// jsdom logs an error for unimplemented navigation
 		expect( console ).toHaveErrored();
 	} );
 
-	it( 'shows error notice when conversion fails', async () => {
-		mockCreateSyncedForm.mockRejectedValue( new Error( 'API Error' ) );
+	it( 'navigates via URL in widget editor context', () => {
+		const mockNavigate = jest.fn();
+		navigateToForm( 123, 'widget', mockNavigate );
 
-		render( <ConvertFormToolbar clientId="test-id" attributes={ {} } /> );
-		await userEvent.click( screen.getByRole( 'button' ) );
-
-		await waitFor( () => {
-			expect( mockCreateErrorNotice ).toHaveBeenCalledWith(
-				'Failed to create a form. Please try again.',
-				expect.objectContaining( { type: 'snackbar' } )
-			);
+		expect( mockAddQueryArgs ).toHaveBeenCalledWith( 'post.php', {
+			post: 123,
+			action: 'edit',
 		} );
-
-		expect( mockUnlockPostSaving ).toHaveBeenCalled();
+		expect( mockNavigate ).not.toHaveBeenCalled();
+		// jsdom logs an error for unimplemented navigation
+		expect( console ).toHaveErrored();
 	} );
 } );

--- a/projects/packages/forms/tests/js/contact-form/create-synced-form.test.js
+++ b/projects/packages/forms/tests/js/contact-form/create-synced-form.test.js
@@ -93,4 +93,26 @@ describe( 'createSyncedForm', () => {
 			},
 		] );
 	} );
+
+	it( 'should have no meta if currentPostId is invalid', async () => {
+		mockSaveEntityRecord.mockResolvedValue( { id: 42 } );
+
+		const blockData = {
+			attributes: { to: 'test@example.com' },
+			innerBlocks: [],
+		};
+
+		const result = await createSyncedForm( blockData, 'My Form', null );
+
+		expect( result ).toBe( 42 );
+		expect( mockSaveEntityRecord ).toHaveBeenCalledWith(
+			'postType',
+			'jetpack_form',
+			expect.objectContaining( {
+				title: 'My Form',
+				status: 'publish',
+				meta: {},
+			} )
+		);
+	} );
 } );

--- a/projects/packages/forms/tests/js/contact-form/create-synced-form.test.js
+++ b/projects/packages/forms/tests/js/contact-form/create-synced-form.test.js
@@ -102,7 +102,7 @@ describe( 'createSyncedForm', () => {
 			innerBlocks: [],
 		};
 
-		const result = await createSyncedForm( blockData, 'My Form', null );
+		const result = await createSyncedForm( blockData, 'My Form', 0 );
 
 		expect( result ).toBe( 42 );
 		expect( mockSaveEntityRecord ).toHaveBeenCalledWith(


### PR DESCRIPTION
## Proposed changes:
* Add support for form editing in the WordPress widget editor context
* Detect widget editor via URL path and handle navigation appropriately (opens form editor in same page since in-editor navigation is not available)
* Use the widget area name as the form title when creating synced forms from widgets
* Fix issue where invalid post IDs (0 or negative) were being set in form source meta
* Refactor navigation logic into a shared `navigateToForm` helper function for cleaner code

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:

Enable Centreal Form Managment. 
```
add_filter( 'jetpack_block_editor_feature_flags', 'eb_register_feature' );

function eb_register_feature( $flags ) {
    $flags['central-form-management'] = true;
    return $flags;
}
```

1. Go to Appearance → Widgets in the WordPress admin
2. Add a Jetpack Form block to any widget area (e.g., Footer)
3. Click the "Edit Form" button in the block toolbar
4. Verify that:
   - A new synced form is created with the widget area name as the title
   - You are redirected to the form editor page
5. Return to the widgets page and verify the form block now shows the "Edit Form" button which opens the form editor

**Also test that existing functionality still works:**
1. Test form editing in the post editor (should use in-editor navigation)
2. Test form editing in the site editor (should redirect to form editor)