### PR TITLE
Forms: Fix multi-step form submit button spinner CSS selector

### DIFF
--- a/projects/packages/forms/changelog/fix-form-step-spinner
+++ b/projects/packages/forms/changelog/fix-form-step-spinner
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Multi-step forms: fix submit button spinner CSS selector to target the correct element.

--- a/projects/packages/forms/src/contact-form/css/grunion.scss
+++ b/projects/packages/forms/src/contact-form/css/grunion.scss
@@ -1510,8 +1510,8 @@ on production builds, the attributes are being reordered, causing side-effects
 }
 
 // use new ::after approach for animated spinner inside forms
-.contact-form .wp-block-jetpack-button button[type="submit"].is-submitting:last-of-type,
-.contact-form .wp-block-button button[type="submit"].is-submitting:last-of-type {
+.contact-form .wp-block-jetpack-form-step-navigation .wp-block-jetpack-button:last-of-type button[type="submit"].is-submitting,
+.contact-form .wp-block-jetpack-form-step-navigation .wp-block-button:last-of-type button[type="submit"].is-submitting {
 
 	&::after {
 


### PR DESCRIPTION
Part of FORMS-566

## Proposed changes:

* Fix CSS selector for multi-step form submit button spinner to target the correct element
* The previous selector was targeting `button[type="submit"].is-submitting:last-of-type` which didn't correctly match the button inside the step navigation wrapper
* Updated selector to properly target `.wp-block-jetpack-form-step-navigation .wp-block-jetpack-button:last-of-type button[type="submit"].is-submitting`

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

N/A

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

1. Create a multi-step form with at least 2 steps
2. Navigate to the last step
3. Click the submit button
4. Verify the spinner animation appears on the submit button while submitting

