### PR TITLE
Forms: Update wp-build dashboard to use useInboxData

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-wp-build-dashboard-inbox-data
+++ b/projects/packages/forms/changelog/fix-forms-wp-build-dashboard-inbox-data
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Forms: Update wp-build dashboard to use useInboxData

--- a/projects/packages/forms/routes/responses/response/index.tsx
+++ b/projects/packages/forms/routes/responses/response/index.tsx
@@ -5,7 +5,7 @@ import apiFetch from '@wordpress/api-fetch';
 import { Button, ExternalLink, Modal, Spinner, Tip } from '@wordpress/components';
 import { store as coreStore } from '@wordpress/core-data';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { useCallback, useEffect, useState } from '@wordpress/element';
+import { useCallback, useEffect, useMemo, useState } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
 import { __, _n } from '@wordpress/i18n';
 import { useParams, useSearch, useNavigate } from '@wordpress/route';
@@ -450,6 +450,8 @@ function SingleResponseView( {
 		return String( value );
 	};
 
+	const displayFields = useMemo( () => getDisplayFields( response?.fields ), [ response?.fields ] );
+
 	if ( isLoading ) {
 		return (
 			<div style={ { display: 'flex', justifyContent: 'center', padding: '40px' } }>
@@ -492,9 +494,9 @@ function SingleResponseView( {
 			<div style={ { padding: '20px', overflowY: 'auto' } }>
 				<ResponseMeta response={ response } />
 
-				{ getDisplayFields( response.fields ).length > 0 && (
+				{ displayFields.length > 0 && (
 					<div>
-						{ getDisplayFields( response.fields ).map( ( { label, value, key } ) => (
+						{ displayFields.map( ( { label, value, key } ) => (
 							<div
 								key={ key }
 								style={ {

--- a/projects/packages/forms/routes/responses/response/index.tsx
+++ b/projects/packages/forms/routes/responses/response/index.tsx
@@ -16,7 +16,6 @@ import * as React from 'react';
 import CopyClipboardButton from '../../../src/dashboard/components/copy-clipboard-button';
 import ResponseMeta from '../../../src/dashboard/components/inspector/response-meta';
 import useInboxData from '../../../src/dashboard/hooks/use-inbox-data.ts';
-import WpRouteDashboardSearchParamsProvider from '../../../src/dashboard/router/wp-route-dashboard-search-params-provider.tsx';
 import { ResponseActions } from './actions';
 import { ResponseNavigation } from './navigation';
 /**
@@ -563,19 +562,6 @@ function SingleResponseView( {
  * @return - Element containing response contents.
  */
 export default function Response() {
-	return (
-		<WpRouteDashboardSearchParamsProvider from="/responses/$view">
-			<ResponseInner />
-		</WpRouteDashboardSearchParamsProvider>
-	);
-}
-
-/**
- * Inner response view, rendered inside the dashboard search params provider.
- *
- * @return Element containing response contents.
- */
-function ResponseInner() {
 	const params = useParams( { from: '/responses/$view' } );
 	const searchParams = useSearch( { from: '/responses/$view' } );
 	const navigate = useNavigate();

--- a/projects/packages/forms/routes/responses/response/index.tsx
+++ b/projects/packages/forms/routes/responses/response/index.tsx
@@ -3,7 +3,7 @@
  */
 import apiFetch from '@wordpress/api-fetch';
 import { Button, ExternalLink, Modal, Spinner, Tip } from '@wordpress/components';
-import { store as coreStore, useEntityRecords } from '@wordpress/core-data';
+import { store as coreStore } from '@wordpress/core-data';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useCallback, useEffect, useState } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
@@ -15,6 +15,8 @@ import * as React from 'react';
  */
 import CopyClipboardButton from '../../../src/dashboard/components/copy-clipboard-button';
 import ResponseMeta from '../../../src/dashboard/components/inspector/response-meta';
+import useInboxData from '../../../src/dashboard/hooks/use-inbox-data.ts';
+import WpRouteDashboardSearchParamsProvider from '../../../src/dashboard/router/wp-route-dashboard-search-params-provider.tsx';
 import { ResponseActions } from './actions';
 import { ResponseNavigation } from './navigation';
 /**
@@ -22,6 +24,36 @@ import { ResponseNavigation } from './navigation';
  */
 import type { DispatchActions, SelectActions } from '../../../src/dashboard/inbox/stage/types.tsx';
 import type { FormResponse } from '../../../src/types/index.ts';
+
+type DisplayField = {
+	label: string;
+	value: unknown;
+	key: string;
+};
+
+const getDisplayFields = (
+	fields: FormResponse[ 'fields' ] | undefined | null
+): DisplayField[] => {
+	if ( ! fields ) {
+		return [];
+	}
+
+	// New collection format: [{ label, value, key, ... }]
+	if ( Array.isArray( fields ) ) {
+		return fields.map( ( field, index ) => ( {
+			label: field.label || field.key || String( index ),
+			value: field.value,
+			key: field.key || field.id || `${ index }-${ field.label }`,
+		} ) );
+	}
+
+	// Legacy format: { [label]: value }
+	return Object.entries( fields ).map( ( [ label, value ] ) => ( {
+		label,
+		value,
+		key: label,
+	} ) );
+};
 
 const isFileUploadField = ( value: unknown ): boolean => {
 	return !! value && typeof value === 'object' && 'files' in value;
@@ -461,9 +493,9 @@ function SingleResponseView( {
 			<div style={ { padding: '20px', overflowY: 'auto' } }>
 				<ResponseMeta response={ response } />
 
-				{ response.fields && Object.keys( response.fields ).length > 0 && (
+				{ getDisplayFields( response.fields ).length > 0 && (
 					<div>
-						{ Object.entries( response.fields ).map( ( [ key, value ] ) => (
+						{ getDisplayFields( response.fields ).map( ( { label, value, key } ) => (
 							<div
 								key={ key }
 								style={ {
@@ -480,7 +512,7 @@ function SingleResponseView( {
 										fontSize: '13px',
 									} }
 								>
-									{ key.endsWith( '?' ) ? key : `${ key }:` }
+									{ label.endsWith( '?' ) ? label : `${ label }:` }
 								</div>
 								<div style={ { color: '#3c434a', fontSize: '14px' } }>
 									{ renderFieldValue( value ) }
@@ -531,30 +563,26 @@ function SingleResponseView( {
  * @return - Element containing response contents.
  */
 export default function Response() {
+	return (
+		<WpRouteDashboardSearchParamsProvider from="/responses/$view">
+			<ResponseInner />
+		</WpRouteDashboardSearchParamsProvider>
+	);
+}
+
+/**
+ * Inner response view, rendered inside the dashboard search params provider.
+ *
+ * @return Element containing response contents.
+ */
+function ResponseInner() {
 	const params = useParams( { from: '/responses/$view' } );
 	const searchParams = useSearch( { from: '/responses/$view' } );
 	const navigate = useNavigate();
 	const responseIds = searchParams?.responseIds || [];
+	const statusView = params.view === 'spam' || params.view === 'trash' ? params.view : 'inbox';
 
-	// Determine the status based on the current view
-	let status = 'publish';
-	if ( params.view === 'spam' ) {
-		status = 'spam';
-	} else if ( params.view === 'trash' ) {
-		status = 'trash';
-	}
-
-	// Fetch all visible records using the same query as the stage
-	// This leverages core-data's cache, so records loaded by stage are reused
-	const { records } = useEntityRecords< FormResponse >( 'postType', 'feedback', {
-		status,
-		per_page: 20,
-		page: 1,
-		orderby: 'date',
-		order: 'desc',
-	} );
-
-	// Get all record IDs for navigation
+	const { records } = useInboxData( { status: statusView } );
 	const allRecordIds = records?.map( record => record.id ) ?? [];
 
 	const handleClose = useCallback( () => {

--- a/projects/packages/forms/routes/responses/stage.tsx
+++ b/projects/packages/forms/routes/responses/stage.tsx
@@ -8,13 +8,11 @@ import '@automattic/ui/style.css';
  * WordPress dependencies
  */
 import { Page } from '@wordpress/admin-ui';
-import apiFetch from '@wordpress/api-fetch';
 import {
 	__experimentalText as Text, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 	Button,
 	ExternalLink,
 } from '@wordpress/components';
-import { useEntityRecords } from '@wordpress/core-data';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { DataViews } from '@wordpress/dataviews';
 import { dateI18n } from '@wordpress/date';
@@ -36,9 +34,9 @@ import Gravatar from '../../src/dashboard/components/gravatar';
 import * as Tabs from '../../src/dashboard/components/tabs';
 import TextWithFlag from '../../src/dashboard/components/text-with-flag/index.tsx';
 import useCreateForm from '../../src/dashboard/hooks/use-create-form';
+import useInboxData from '../../src/dashboard/hooks/use-inbox-data.ts';
 import { getPath } from '../../src/dashboard/inbox/utils';
 import WpRouteDashboardSearchParamsProvider from '../../src/dashboard/router/wp-route-dashboard-search-params-provider.tsx';
-import { store as dashboardStore } from '../../src/dashboard/store';
 import useConfigValue from '../../src/hooks/use-config-value';
 import { INTEGRATIONS_STORE, IntegrationsSelectors } from '../../src/store/integrations';
 import { getActions } from './actions';
@@ -46,7 +44,6 @@ import './style.scss';
 /**
  * Types
  */
-import type { SelectActions } from '../../src/dashboard/inbox/stage/types.tsx';
 import type { FormResponse } from '../../src/types/index.ts';
 import type { View, Field, Action } from '@wordpress/dataviews';
 
@@ -65,29 +62,6 @@ type FeedbackFilters = {
 	date: FeedbackFilterDate[];
 	source: FeedbackFilterSource[];
 };
-
-/**
- * Hook to fetch filter options for date and source fields.
- *
- * @return Object containing date and source filter options.
- */
-function useFilterOptions() {
-	const [ filterOptions, setFilterOptions ] = useState< FeedbackFilters >( {
-		date: [],
-		source: [],
-	} );
-
-	useEffect( () => {
-		apiFetch< FeedbackFilters >( { path: '/wp/v2/feedback/filters' } ).then( response => {
-			setFilterOptions( {
-				date: response.date || [],
-				source: response.source || [],
-			} );
-		} );
-	}, [] );
-
-	return filterOptions;
-}
 
 /**
  * Returns a formatted tab label with count badge.
@@ -183,22 +157,12 @@ function styleUnreadValue( element: React.ReactNode, isUnread: boolean ): React.
  *
  * @return The stage component.
  */
-function Stage() {
+function StageInner() {
 	const params = useParams( { from: '/responses/$view' } );
 	const searchParams = useSearch( { from: '/responses/$view' } );
 	const navigate = useNavigate();
-	const counts = useSelect(
-		select => ( select( dashboardStore ) as unknown as SelectActions ).getCounts(),
-		[]
-	);
-
-	const filterOptions = useFilterOptions();
-	let status = 'publish';
-	if ( params.view === 'spam' ) {
-		status = 'spam';
-	} else if ( params.view === 'trash' ) {
-		status = 'trash';
-	}
+	const statusView = params.view === 'spam' || params.view === 'trash' ? params.view : 'inbox';
+	const statusFilter = statusView === 'inbox' ? 'draft,publish' : statusView;
 
 	const [ isIntegrationsModalOpen, setIsIntegrationsModalOpen ] = useState( false );
 	const integrations = useSelect(
@@ -214,7 +178,20 @@ function Stage() {
 		search: searchParams?.search || '',
 	} ) );
 
-	const selection = searchParams?.responseIds ?? [];
+	const selection = useMemo( () => searchParams?.responseIds ?? [], [ searchParams?.responseIds ] );
+
+	const {
+		setCurrentQuery,
+		setSelectedResponses,
+		filterOptions,
+		records,
+		isLoadingData,
+		totalItems,
+		totalPages,
+		totalItemsInbox,
+		totalItemsSpam,
+		totalItemsTrash,
+	} = useInboxData( { status: statusView } );
 
 	useEffect( () => {
 		const urlSearch = searchParams?.search || '';
@@ -253,7 +230,7 @@ function Stage() {
 
 	const queryParams = useMemo( () => {
 		const queryArgs: QueryParams = {
-			status,
+			status: statusFilter,
 			per_page: view.perPage,
 			page: view.page || 1,
 			orderby: view.sort?.field || 'date',
@@ -282,13 +259,21 @@ function Stage() {
 		} );
 
 		return queryArgs;
-	}, [ status, view ] );
+	}, [ statusFilter, view ] );
 
-	const { records, isResolving, totalItems, totalPages } = useEntityRecords(
-		'postType',
-		'feedback',
-		queryParams
-	);
+	// Keep dashboard store query in sync so core-data fetches include fields_format=collection.
+	useEffect( () => {
+		setCurrentQuery( queryParams );
+	}, [ queryParams, setCurrentQuery ] );
+
+	// Keep selected responses in store for shared dashboard behavior (e.g., export).
+	useEffect( () => {
+		const validSelectedIds = ( selection || [] ).filter( id => {
+			return records?.some( record => getItemId( record ) === id );
+		} );
+
+		setSelectedResponses( validSelectedIds );
+	}, [ records, selection, setSelectedResponses ] );
 
 	const fields: Field< FormResponse >[] = useMemo(
 		() => [
@@ -357,7 +342,7 @@ function Stage() {
 					} );
 					return styleUnreadValue( dateStr, item.is_unread );
 				},
-				elements: ( filterOptions?.date || [] ).map( filter => {
+				elements: ( ( filterOptions as unknown as FeedbackFilters )?.date || [] ).map( filter => {
 					const date = new Date();
 					date.setDate( 1 );
 					date.setMonth( filter.month - 1 );
@@ -383,10 +368,12 @@ function Stage() {
 					}
 					return styleUnreadValue( source, item.is_unread );
 				},
-				elements: ( filterOptions?.source || [] ).map( source => ( {
-					value: source.id.toString(),
-					label: decodeEntities( source.title ) || source.url,
-				} ) ),
+				elements: ( ( filterOptions as unknown as FeedbackFilters )?.source || [] ).map(
+					source => ( {
+						value: source.id.toString(),
+						label: decodeEntities( source.title ) || source.url,
+					} )
+				),
 				filterBy: { operators: [ 'is' ] },
 				enableSorting: false,
 			},
@@ -445,9 +432,9 @@ function Stage() {
 	);
 
 	const statusTabs = [
-		{ slug: 'inbox', label: getTabLabel( __( 'Inbox', 'jetpack-forms' ), counts.inbox ) },
-		{ slug: 'spam', label: getTabLabel( __( 'Spam', 'jetpack-forms' ), counts.spam ) },
-		{ slug: 'trash', label: getTabLabel( __( 'Trash', 'jetpack-forms' ), counts.trash ) },
+		{ slug: 'inbox', label: getTabLabel( __( 'Inbox', 'jetpack-forms' ), totalItemsInbox ) },
+		{ slug: 'spam', label: getTabLabel( __( 'Spam', 'jetpack-forms' ), totalItemsSpam ) },
+		{ slug: 'trash', label: getTabLabel( __( 'Trash', 'jetpack-forms' ), totalItemsTrash ) },
 	];
 
 	const handleTabChange = useCallback(
@@ -548,82 +535,85 @@ function Stage() {
 	);
 
 	return (
-		<WpRouteDashboardSearchParamsProvider from="/responses/$view">
-			<Page
-				showSidebarToggle={ false }
-				title={
-					<Stack align="center" gap="xs">
-						<JetpackLogo showText={ false } width={ 20 } />
-						{ __( 'Forms', 'jetpack-forms' ) }
-					</Stack>
+		<Page
+			showSidebarToggle={ false }
+			title={
+				<Stack align="center" gap="xs">
+					<JetpackLogo showText={ false } width={ 20 } />
+					{ __( 'Forms', 'jetpack-forms' ) }
+				</Stack>
+			}
+			subTitle={ __( 'View and manage all your form submissions in one place.', 'jetpack-forms' ) }
+			actions={ headerActions }
+			hasPadding={ false }
+		>
+			<DataViews
+				empty={
+					<EmptyResponses
+						status={ params.view }
+						isSearch={ !! view.search }
+						readStatusFilter={ readStatusFilter }
+					/>
 				}
-				subTitle={ __(
-					'View and manage all your form submissions in one place.',
-					'jetpack-forms'
-				) }
-				actions={ headerActions }
-				hasPadding={ false }
+				data={ records || EMPTY_ARRAY }
+				fields={ fields as Field< unknown >[] }
+				view={ view }
+				onChangeView={ onChangeView }
+				paginationInfo={ paginationInfo }
+				isLoading={ isLoadingData }
+				getItemId={ getItemId }
+				defaultLayouts={ defaultLayouts }
+				selection={ selection }
+				onChangeSelection={ onChangeSelection }
+				onClickItem={ onClickItem }
+				actions={ actions as Action< unknown >[] }
 			>
-				<DataViews
-					empty={
-						<EmptyResponses
-							status={ params.view }
-							isSearch={ !! view.search }
-							readStatusFilter={ readStatusFilter }
-						/>
-					}
-					data={ records || EMPTY_ARRAY }
-					fields={ fields as Field< unknown >[] }
-					view={ view }
-					onChangeView={ onChangeView }
-					paginationInfo={ paginationInfo }
-					isLoading={ isResolving }
-					getItemId={ getItemId }
-					defaultLayouts={ defaultLayouts }
-					selection={ selection }
-					onChangeSelection={ onChangeSelection }
-					onClickItem={ onClickItem }
-					actions={ actions as Action< unknown >[] }
+				<Stack
+					align="center"
+					className="jp-forms-dataviews__view-actions"
+					gap="sm"
+					justify="space-between"
 				>
-					<Stack
-						align="center"
-						className="jp-forms-dataviews__view-actions"
-						gap="sm"
-						justify="space-between"
-					>
-						<Stack align="center" gap="sm">
-							<Tabs.Root value={ params.view || 'inbox' } onValueChange={ handleTabChange }>
-								<Tabs.List density="compact">
-									{ statusTabs.map( tab => (
-										<Tabs.Tab value={ tab.slug } key={ tab.slug }>
-											{ tab.label }
-										</Tabs.Tab>
-									) ) }
-								</Tabs.List>
-							</Tabs.Root>
-						</Stack>
-						<Stack align="center" gap="sm">
-							<DataViews.Search />
-							<DataViews.FiltersToggle />
-							<DataViews.ViewConfig />
-						</Stack>
+					<Stack align="center" gap="sm">
+						<Tabs.Root value={ params.view || 'inbox' } onValueChange={ handleTabChange }>
+							<Tabs.List density="compact">
+								{ statusTabs.map( tab => (
+									<Tabs.Tab value={ tab.slug } key={ tab.slug }>
+										{ tab.label }
+									</Tabs.Tab>
+								) ) }
+							</Tabs.List>
+						</Tabs.Root>
 					</Stack>
-					<DataViews.Filters className="dataviews-filters__container" />
-					<DataViews.Layout />
-					<DataViews.Footer />
-				</DataViews>
-				<IntegrationsModal
-					isOpen={ isIntegrationsModalOpen }
-					onClose={ closeIntegrationsModal }
-					attributes={ undefined }
-					setAttributes={ undefined }
-					integrationsData={ integrations }
-					refreshIntegrations={ refreshIntegrations }
-					context="dashboard"
-				/>
-			</Page>
-		</WpRouteDashboardSearchParamsProvider>
+					<Stack align="center" gap="sm">
+						<DataViews.Search />
+						<DataViews.FiltersToggle />
+						<DataViews.ViewConfig />
+					</Stack>
+				</Stack>
+				<DataViews.Filters className="dataviews-filters__container" />
+				<DataViews.Layout />
+				<DataViews.Footer />
+			</DataViews>
+			<IntegrationsModal
+				isOpen={ isIntegrationsModalOpen }
+				onClose={ closeIntegrationsModal }
+				attributes={ undefined }
+				setAttributes={ undefined }
+				integrationsData={ integrations }
+				refreshIntegrations={ refreshIntegrations }
+				context="dashboard"
+			/>
+		</Page>
 	);
 }
+
+const Stage = () => {
+	return (
+		<WpRouteDashboardSearchParamsProvider from="/responses/$view">
+			<StageInner />
+		</WpRouteDashboardSearchParamsProvider>
+	);
+};
 
 export { Stage as stage };

--- a/projects/packages/forms/src/dashboard/hooks/use-inbox-data.ts
+++ b/projects/packages/forms/src/dashboard/hooks/use-inbox-data.ts
@@ -13,7 +13,7 @@ import { store as dashboardStore } from '../store/index.js';
 /**
  * Types
  */
-import type { FormResponse } from '../../types/index.ts';
+import type { FormResponse, ResponseField } from '../../types/index.ts';
 
 /**
  * Helper function to get the status filter to apply from the URL.
@@ -53,6 +53,88 @@ const formatFieldValue = fieldValue => {
 	return fieldValue;
 };
 
+type UseInboxDataOptions = {
+	status?: 'inbox' | 'spam' | 'trash';
+};
+
+const isCollectionFormatField = ( item: unknown ): item is ResponseField => {
+	return (
+		item !== null && typeof item === 'object' && 'label' in item && 'value' in item && 'key' in item
+	);
+};
+
+const decodeValue = ( value: unknown ): unknown => {
+	if ( typeof value === 'string' ) {
+		return decodeEntities( value );
+	}
+
+	if ( Array.isArray( value ) ) {
+		return value.map( v => ( typeof v === 'string' ? decodeEntities( v ) : v ) );
+	}
+
+	return value;
+};
+
+const normalizeFieldsForDisplay = (
+	fields: FormResponse[ 'fields' ]
+): Record< string, unknown > => {
+	if ( ! fields ) {
+		return {};
+	}
+
+	// Collection format: array (or an object with numeric keys containing collection items).
+	let candidateValues: unknown[] = [];
+
+	if ( Array.isArray( fields ) ) {
+		candidateValues = fields;
+	} else if ( typeof fields === 'object' ) {
+		candidateValues = Object.values( fields as Record< string, unknown > );
+	}
+
+	if ( candidateValues.length > 0 && isCollectionFormatField( candidateValues[ 0 ] ) ) {
+		return ( candidateValues as ResponseField[] ).reduce(
+			( accumulator, field ) => {
+				const baseLabel = field.label || formatFieldName( field.key ) || field.key;
+				let label = baseLabel;
+				let counter = 2;
+
+				while ( accumulator[ label ] ) {
+					label = `${ baseLabel } (${ counter })`;
+					counter++;
+				}
+
+				accumulator[ label ] = formatFieldValue( decodeValue( field.value ) );
+
+				return accumulator;
+			},
+			{} as Record< string, unknown >
+		);
+	}
+
+	// Legacy format: object map of label -> value.
+	if ( typeof fields === 'object' && ! Array.isArray( fields ) ) {
+		return Object.entries( fields ).reduce(
+			( accumulator, [ key, value ] ) => {
+				const baseLabel = formatFieldName( key );
+				let label = baseLabel;
+				let counter = 2;
+
+				while ( accumulator[ label ] ) {
+					label = `${ baseLabel } (${ counter })`;
+					counter++;
+				}
+
+				accumulator[ label ] = formatFieldValue( decodeValue( value ) );
+
+				return accumulator;
+			},
+			{} as Record< string, unknown >
+		);
+	}
+
+	return {};
+};
+
 /**
  * Interface for the return value of the useInboxData hook.
  */
@@ -76,12 +158,13 @@ interface UseInboxDataReturn {
 /**
  * Hook to get all inbox related data.
  *
+ * @param {UseInboxDataOptions} options - Optional configuration.
  * @return {UseInboxDataReturn} The inbox related data.
  */
-export default function useInboxData(): UseInboxDataReturn {
+export default function useInboxData( options: UseInboxDataOptions = {} ): UseInboxDataReturn {
 	const [ searchParams ] = useDashboardSearchParams();
 	const { setCurrentQuery, setSelectedResponses } = useDispatch( dashboardStore );
-	const urlStatus = searchParams.get( 'status' );
+	const urlStatus = options.status ?? searchParams.get( 'status' );
 	const statusFilter = getStatusFilter( urlStatus );
 
 	const {
@@ -185,19 +268,7 @@ export default function useInboxData(): UseInboxDataReturn {
 			const formResponse = record as FormResponse;
 			return {
 				...formResponse,
-				fields: Object.entries( formResponse.fields || {} ).reduce(
-					( accumulator, [ key, value ] ) => {
-						let _key = formatFieldName( key );
-						let counter = 2;
-						while ( accumulator[ _key ] ) {
-							_key = `${ formatFieldName( key ) } (${ counter })`;
-							counter++;
-						}
-						accumulator[ _key ] = formatFieldValue( decodeEntities( value as string ) );
-						return accumulator;
-					},
-					{}
-				),
+				fields: normalizeFieldsForDisplay( formResponse.fields ),
 			};
 		} ) as FormResponse[];
 	}, [ editedRecords, statusFilter ] );

--- a/projects/packages/forms/src/dashboard/hooks/use-inbox-data.ts
+++ b/projects/packages/forms/src/dashboard/hooks/use-inbox-data.ts
@@ -13,7 +13,7 @@ import { store as dashboardStore } from '../store/index.js';
 /**
  * Types
  */
-import type { FormResponse } from '../../types/index.ts';
+import type { FormResponse, ResponseField } from '../../types/index.ts';
 
 /**
  * Helper function to get the status filter to apply from the URL.
@@ -69,9 +69,7 @@ const decodeValue = ( value: unknown ): unknown => {
 	return value;
 };
 
-const normalizeFieldsForDisplay = (
-	fields: FormResponse[ 'fields' ]
-): Record< string, unknown > => {
+const normalizeFieldsForDisplay = ( fields: ResponseField[] ): Record< string, unknown > => {
 	if ( ! fields || ! Array.isArray( fields ) ) {
 		return {};
 	}
@@ -226,9 +224,10 @@ export default function useInboxData( options: UseInboxDataOptions = {} ): UseIn
 
 		return filteredRecords.map( record => {
 			const formResponse = record as FormResponse;
+
 			return {
 				...formResponse,
-				fields: normalizeFieldsForDisplay( formResponse.fields ),
+				fields: normalizeFieldsForDisplay( formResponse.fields as ResponseField[] ),
 			};
 		} ) as FormResponse[];
 	}, [ editedRecords, statusFilter ] );

--- a/projects/packages/forms/src/dashboard/hooks/use-inbox-data.ts
+++ b/projects/packages/forms/src/dashboard/hooks/use-inbox-data.ts
@@ -13,7 +13,7 @@ import { store as dashboardStore } from '../store/index.js';
 /**
  * Types
  */
-import type { FormResponse, ResponseField } from '../../types/index.ts';
+import type { FormResponse } from '../../types/index.ts';
 
 /**
  * Helper function to get the status filter to apply from the URL.
@@ -57,12 +57,6 @@ type UseInboxDataOptions = {
 	status?: 'inbox' | 'spam' | 'trash';
 };
 
-const isCollectionFormatField = ( item: unknown ): item is ResponseField => {
-	return (
-		item !== null && typeof item === 'object' && 'label' in item && 'value' in item && 'key' in item
-	);
-};
-
 const decodeValue = ( value: unknown ): unknown => {
 	if ( typeof value === 'string' ) {
 		return decodeEntities( value );
@@ -78,61 +72,27 @@ const decodeValue = ( value: unknown ): unknown => {
 const normalizeFieldsForDisplay = (
 	fields: FormResponse[ 'fields' ]
 ): Record< string, unknown > => {
-	if ( ! fields ) {
+	if ( ! fields || ! Array.isArray( fields ) ) {
 		return {};
 	}
 
-	// Collection format: array (or an object with numeric keys containing collection items).
-	let candidateValues: unknown[] = [];
+	return fields.reduce(
+		( accumulator, field ) => {
+			const baseLabel = field.label || formatFieldName( field.key ) || field.key;
+			let label = baseLabel;
+			let counter = 2;
 
-	if ( Array.isArray( fields ) ) {
-		candidateValues = fields;
-	} else if ( typeof fields === 'object' ) {
-		candidateValues = Object.values( fields as Record< string, unknown > );
-	}
+			while ( accumulator[ label ] ) {
+				label = `${ baseLabel } (${ counter })`;
+				counter++;
+			}
 
-	if ( candidateValues.length > 0 && isCollectionFormatField( candidateValues[ 0 ] ) ) {
-		return ( candidateValues as ResponseField[] ).reduce(
-			( accumulator, field ) => {
-				const baseLabel = field.label || formatFieldName( field.key ) || field.key;
-				let label = baseLabel;
-				let counter = 2;
+			accumulator[ label ] = formatFieldValue( decodeValue( field.value ) );
 
-				while ( accumulator[ label ] ) {
-					label = `${ baseLabel } (${ counter })`;
-					counter++;
-				}
-
-				accumulator[ label ] = formatFieldValue( decodeValue( field.value ) );
-
-				return accumulator;
-			},
-			{} as Record< string, unknown >
-		);
-	}
-
-	// Legacy format: object map of label -> value.
-	if ( typeof fields === 'object' && ! Array.isArray( fields ) ) {
-		return Object.entries( fields ).reduce(
-			( accumulator, [ key, value ] ) => {
-				const baseLabel = formatFieldName( key );
-				let label = baseLabel;
-				let counter = 2;
-
-				while ( accumulator[ label ] ) {
-					label = `${ baseLabel } (${ counter })`;
-					counter++;
-				}
-
-				accumulator[ label ] = formatFieldValue( decodeValue( value ) );
-
-				return accumulator;
-			},
-			{} as Record< string, unknown >
-		);
-	}
-
-	return {};
+			return accumulator;
+		},
+		{} as Record< string, unknown >
+	);
 };
 
 /**

--- a/projects/packages/forms/src/dashboard/hooks/use-inbox-data.ts
+++ b/projects/packages/forms/src/dashboard/hooks/use-inbox-data.ts
@@ -69,9 +69,12 @@ const decodeValue = ( value: unknown ): unknown => {
 	return value;
 };
 
+const hasOwn = ( obj: object, key: PropertyKey ): boolean =>
+	Object.prototype.hasOwnProperty.call( obj, key );
+
 const normalizeFieldsForDisplay = ( fields: ResponseField[] ): Record< string, unknown > => {
 	if ( ! fields || ! Array.isArray( fields ) ) {
-		return {};
+		return Object.create( null ) as Record< string, unknown >;
 	}
 
 	return fields.reduce(
@@ -80,7 +83,7 @@ const normalizeFieldsForDisplay = ( fields: ResponseField[] ): Record< string, u
 			let label = baseLabel;
 			let counter = 2;
 
-			while ( accumulator[ label ] ) {
+			while ( hasOwn( accumulator, label ) ) {
 				label = `${ baseLabel } (${ counter })`;
 				counter++;
 			}
@@ -89,7 +92,7 @@ const normalizeFieldsForDisplay = ( fields: ResponseField[] ): Record< string, u
 
 			return accumulator;
 		},
-		{} as Record< string, unknown >
+		Object.create( null ) as Record< string, unknown >
 	);
 };
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Follow-up to #46635

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Uses `useInboxData` for consistency
* Fixes an issue where the data switched to a different format after updating a response

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the wp-build dashboard
* Mark a response as spam
* When the action is done, select any response
* Check that the data is displayed as expected

Before this PR, marking any response as spam, for instance, would make the data from all responses to be displayed as text

| Before | After |
| - | - |
| <img width="356" height="167" alt="Screenshot from 2026-01-28 17-29-20" src="https://github.com/user-attachments/assets/6039d0a4-9917-4567-95c7-80cb8fefe60f" /> | <img width="356" height="167" alt="Screenshot from 2026-01-28 17-29-30" src="https://github.com/user-attachments/assets/3e4bf2a2-d0fa-47f6-ab7c-b2a8221f4f0c" />

