### PR TITLE
Contact Form: add shortcode transform support for synced form references

### DIFF
--- a/projects/packages/forms/changelog/add-shortcode-support-for-ref
+++ b/projects/packages/forms/changelog/add-shortcode-support-for-ref
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Contact Form: add shortcode transform support for synced form references.

--- a/projects/packages/forms/src/blocks/contact-form/transforms.js
+++ b/projects/packages/forms/src/blocks/contact-form/transforms.js
@@ -95,7 +95,7 @@ export default {
 					type: 'number',
 					shortcode: ( { named: { ref } } ) => {
 						const parsed = parseInt( ref, 10 );
-						return Number.isNaN( parsed ) ? undefined : parsed;
+						return Number.isNaN( parsed ) || parsed <= 0 ? undefined : parsed;
 					},
 				},
 			},

--- a/projects/packages/forms/src/blocks/contact-form/transforms.js
+++ b/projects/packages/forms/src/blocks/contact-form/transforms.js
@@ -82,8 +82,8 @@ const blockData = {
 export default {
 	from: [
 		{
-			// This transform handles only the contact-form shortcode that has the ref attribute only.
-			// This will activly be used for Centralized Form Management feature.
+			// This transform handles the contact-form shortcode only when it has a ref attribute.
+			// This will actively be used for Centralized Form Management feature.
 			type: 'shortcode',
 			tag: 'contact-form',
 			isMatch: function ( attributes ) {

--- a/projects/packages/forms/src/blocks/contact-form/transforms.js
+++ b/projects/packages/forms/src/blocks/contact-form/transforms.js
@@ -82,6 +82,23 @@ const blockData = {
 export default {
 	from: [
 		{
+			type: 'shortcode',
+			tag: 'contact-form',
+			isMatch: function ( attributes ) {
+				// Only match shortcodes that have a ref attribute (synced form reference)
+				return attributes.named.ref !== undefined;
+			},
+			attributes: {
+				ref: {
+					type: 'number',
+					shortcode: ( { named: { ref } } ) => {
+						const parsed = parseInt( ref, 10 );
+						return Number.isNaN( parsed ) ? undefined : parsed;
+					},
+				},
+			},
+		},
+		{
 			type: 'raw',
 			priority: 1,
 			isMatch: node => {

--- a/projects/packages/forms/src/blocks/contact-form/transforms.js
+++ b/projects/packages/forms/src/blocks/contact-form/transforms.js
@@ -82,6 +82,8 @@ const blockData = {
 export default {
 	from: [
 		{
+			// This transform handles only the contact-form shortcode that has the ref attribute only.
+			// This will activly be used for Centralized Form Management feature.
 			type: 'shortcode',
 			tag: 'contact-form',
 			isMatch: function ( attributes ) {


### PR DESCRIPTION
## Proposed changes:
* Add block transform to convert `[contact-form ref="123"]` shortcodes to the contact-form block
* Preserve the `ref` attribute when transforming, enabling synced forms (form patterns) to be properly converted
* Only match shortcodes that have a `ref` attribute to avoid interfering with other contact-form shortcode transforms

See

https://github.com/user-attachments/assets/2498e7d8-1798-4bb3-bb77-326c493860a2


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:
Enable Central Form management via 
```
add_filter( 'jetpack_block_editor_feature_flags', 'eb_register_feature' );
function eb_register_feature( $flags ) {
    $flags['central-form-management'] = true;
    return $flags;
}
```

* Create a synced form (form pattern) and note its ID

* In a classic editor post or via direct database, add the shortcode `[contact-form ref="<form-id>"]`
* Switch to the block editor or import the content
* Verify the shortcode is converted to a contact-form block with the correct `ref` attribute in the editor. 
* Verify the synced form renders correctly on the frontend