### PR TITLE
Forms: Select first step when switching to or loading a multistep form

### DIFF
--- a/projects/packages/forms/changelog/fix-multistep-form-select-first-step
+++ b/projects/packages/forms/changelog/fix-multistep-form-select-first-step
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: ensure first step is selected when switching to or loading a multistep form.

--- a/projects/packages/forms/src/blocks/contact-form/edit.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/edit.tsx
@@ -338,6 +338,7 @@ function JetpackContactFormEdit( {
 		useDispatch( blockEditorStore );
 
 	const { editEntityRecord } = useDispatch( coreStore );
+	const { setActiveStep } = useDispatch( singleStepStore );
 
 	const currentInnerBlocks = useSelect(
 		select => select( blockEditorStore ).getBlocks( clientId ),
@@ -353,6 +354,7 @@ function JetpackContactFormEdit( {
 		setAttributes,
 		replaceInnerBlocks,
 		__unstableMarkNextChangeAsNotPersistent,
+		setActiveStep,
 	} );
 
 	// Auto-save editor changes BACK to the synced form post
@@ -707,6 +709,11 @@ function JetpackContactFormEdit( {
 		__unstableMarkNextChangeAsNotPersistent();
 		replaceInnerBlocks( clientId, [ progressIndicator, stepContainer, stepNavigation ], false );
 
+		// Select the first step so the editor shows it immediately
+		if ( stepContainer.innerBlocks.length > 0 ) {
+			setActiveStep( clientId, stepContainer.innerBlocks[ 0 ].clientId );
+		}
+
 		// Ensure we are marked as multistep – this records the undo level.
 		if ( variationName !== 'multistep' ) {
 			setAttributes( { variationName: 'multistep' } );
@@ -717,6 +724,7 @@ function JetpackContactFormEdit( {
 		currentInnerBlocks,
 		clientId,
 		replaceInnerBlocks,
+		setActiveStep,
 		setAttributes,
 		containsMultistepBlock,
 		__unstableMarkNextChangeAsNotPersistent,
@@ -809,8 +817,6 @@ function JetpackContactFormEdit( {
 		__unstableMarkNextChangeAsNotPersistent,
 		setAttributes,
 	] );
-
-	const { setActiveStep } = useDispatch( singleStepStore );
 
 	useEffect( () => {
 		if (

--- a/projects/packages/forms/src/blocks/contact-form/hooks/use-synced-form-loader.ts
+++ b/projects/packages/forms/src/blocks/contact-form/hooks/use-synced-form-loader.ts
@@ -22,14 +22,6 @@ interface UseSyncedFormLoaderResult {
 }
 
 /**
- * Hook to handle loading synced form content into the editor
- * This performs a one-time sync when the ref changes or loads for the first time
- * After loading, the user can edit freely and changes will be saved back via auto-save
- *
- * @param {UseSyncedFormLoaderParams} params - Configuration parameters
- * @return {UseSyncedFormLoaderResult} Object containing syncing state ref
- */
-/**
  * Helper to find the first step block in a multistep form structure.
  *
  * @param {Block[]} blocks - The blocks to search through.
@@ -51,6 +43,14 @@ function findFirstStepClientId( blocks: Block[] ): string | null {
 	return null;
 }
 
+/**
+ * Hook to handle loading synced form content into the editor
+ * This performs a one-time sync when the ref changes or loads for the first time
+ * After loading, the user can edit freely and changes will be saved back via auto-save
+ *
+ * @param {UseSyncedFormLoaderParams} params - Configuration parameters
+ * @return {UseSyncedFormLoaderResult} Object containing syncing state ref
+ */
 export function useSyncedFormLoader( {
 	ref,
 	syncedFormBlocks,

--- a/projects/packages/forms/src/blocks/contact-form/hooks/use-synced-form-loader.ts
+++ b/projects/packages/forms/src/blocks/contact-form/hooks/use-synced-form-loader.ts
@@ -4,15 +4,17 @@
 
 import { useEffect, useRef } from '@wordpress/element';
 import { filterSyncedAttributes } from '../util/form-sync.ts';
+import type { Block } from '@wordpress/blocks';
 
 interface UseSyncedFormLoaderParams {
 	ref?: number;
-	syncedFormBlocks: unknown[] | null;
+	syncedFormBlocks: Block[] | null;
 	syncedFormAttributes: Record< string, unknown > | null;
 	clientId: string;
 	setAttributes: ( attributes: Record< string, unknown > ) => void;
-	replaceInnerBlocks: ( clientId: string, blocks: unknown[], updateSelection: boolean ) => void;
+	replaceInnerBlocks: ( clientId: string, blocks: Block[], updateSelection: boolean ) => void;
 	__unstableMarkNextChangeAsNotPersistent: () => void;
+	setActiveStep: ( formClientId: string, stepClientId: string ) => void;
 }
 
 interface UseSyncedFormLoaderResult {
@@ -27,6 +29,28 @@ interface UseSyncedFormLoaderResult {
  * @param {UseSyncedFormLoaderParams} params - Configuration parameters
  * @return {UseSyncedFormLoaderResult} Object containing syncing state ref
  */
+/**
+ * Helper to find the first step block in a multistep form structure.
+ *
+ * @param {Block[]} blocks - The blocks to search through.
+ * @return {string|null} The clientId of the first step block, or null if not found.
+ */
+function findFirstStepClientId( blocks: Block[] ): string | null {
+	for ( const block of blocks ) {
+		if ( block.name === 'jetpack/form-step-container' && block.innerBlocks?.length ) {
+			const firstStep = block.innerBlocks.find( b => b.name === 'jetpack/form-step' );
+			return firstStep?.clientId || null;
+		}
+		if ( block.innerBlocks?.length ) {
+			const found = findFirstStepClientId( block.innerBlocks );
+			if ( found ) {
+				return found;
+			}
+		}
+	}
+	return null;
+}
+
 export function useSyncedFormLoader( {
 	ref,
 	syncedFormBlocks,
@@ -35,6 +59,7 @@ export function useSyncedFormLoader( {
 	setAttributes,
 	replaceInnerBlocks,
 	__unstableMarkNextChangeAsNotPersistent,
+	setActiveStep,
 }: UseSyncedFormLoaderParams ): UseSyncedFormLoaderResult {
 	// Track if we're currently syncing to prevent save-back loops
 	const isSyncingRef = useRef( false );
@@ -71,6 +96,12 @@ export function useSyncedFormLoader( {
 		__unstableMarkNextChangeAsNotPersistent();
 		replaceInnerBlocks( clientId, syncedFormBlocks, false );
 
+		// For multistep forms, select the first step so the editor shows it immediately
+		const firstStepClientId = findFirstStepClientId( syncedFormBlocks );
+		if ( firstStepClientId ) {
+			setActiveStep( clientId, firstStepClientId );
+		}
+
 		// Reset syncing flag after a short delay
 		const timeoutId = setTimeout( () => {
 			isSyncingRef.current = false;
@@ -87,6 +118,7 @@ export function useSyncedFormLoader( {
 		__unstableMarkNextChangeAsNotPersistent,
 		replaceInnerBlocks,
 		setAttributes,
+		setActiveStep,
 	] );
 
 	return { isSyncingRef };


### PR DESCRIPTION
## Proposed changes:

* When switching a regular form to a multistep form, the first step is now automatically selected so the editor displays it immediately
* When loading a synced multistep form (via ref), the first step is automatically selected on initial load

Before:

https://github.com/user-attachments/assets/8505eab1-b309-451a-9ef0-2f1bcb08529f

After:

https://github.com/user-attachments/assets/489740b5-454d-4cd0-b9a9-aee690464c40

FORMS-NEW

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

### Test 1: Converting to multistep form
1. Create a new page/post and add a Form block
2. Add a few form fields (name, email, etc.)
3. Switch the form to a multistep form using the block toolbar or variation picker
4. **Expected:** The first step should be automatically selected and visible in the editor

### Test 2: Loading a synced multistep form
Enable Central Form Management via 
```
add_filter( 'jetpack_block_editor_feature_flags', 'eb_register_feature' );

function eb_register_feature( $flags ) {
    $flags['central-form-management'] = true
    return $flags;
}
```


1. Create a synced multistep form (a form with a ref attribute pointing to a jetpack_form post)
2. Refresh the page or navigate away and back
3. **Expected:** The first step should be automatically selected when the form loads
