### PR TITLE
Charts: Add TimeSeriesForecastChart component

### DIFF
--- a/projects/js-packages/charts/changelog/add-area-chart-component
+++ b/projects/js-packages/charts/changelog/add-area-chart-component
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+TimeSeriesForecastChart: add compound composition pattern and full legend prop parity

--- a/projects/js-packages/charts/changelog/add-time-series-forecast-chart
+++ b/projects/js-packages/charts/changelog/add-time-series-forecast-chart
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add TimeSeriesForecastChart component for visualizing time series data with forecast periods.

--- a/projects/js-packages/charts/package.json
+++ b/projects/js-packages/charts/package.json
@@ -95,6 +95,12 @@
 		},
 		"./sparkline/style.css": "./dist/components/sparkline/index.css",
 		"./style.css": "./dist/index.css",
+		"./time-series-forecast-chart": {
+			"jetpack:src": "./src/charts/time-series-forecast-chart/index.ts",
+			"import": "./dist/charts/time-series-forecast-chart/index.js",
+			"require": "./dist/charts/time-series-forecast-chart/index.cjs"
+		},
+		"./time-series-forecast-chart/style.css": "./dist/charts/time-series-forecast-chart/index.css",
 		"./tooltip": {
 			"jetpack:src": "./src/components/tooltip/index.ts",
 			"import": "./dist/components/tooltip/index.js",
@@ -170,6 +176,9 @@
 			],
 			"sparkline": [
 				"./dist/components/sparkline/index.d.ts"
+			],
+			"time-series-forecast-chart": [
+				"./dist/charts/time-series-forecast-chart/index.d.ts"
 			],
 			"tooltip": [
 				"./dist/components/tooltip/index.d.ts"

--- a/projects/js-packages/charts/src/charts/time-series-forecast-chart/index.ts
+++ b/projects/js-packages/charts/src/charts/time-series-forecast-chart/index.ts
@@ -1,0 +1,12 @@
+export {
+	default as TimeSeriesForecastChart,
+	TimeSeriesForecastChartUnresponsive,
+} from './time-series-forecast-chart';
+
+export type {
+	TimeSeriesForecastChartProps,
+	TimeSeriesForecastAccessors,
+	SeriesKeys,
+	Accessor,
+	ForecastTooltipParams,
+} from './types';

--- a/projects/js-packages/charts/src/charts/time-series-forecast-chart/private/forecast-divider.tsx
+++ b/projects/js-packages/charts/src/charts/time-series-forecast-chart/private/forecast-divider.tsx
@@ -1,0 +1,57 @@
+import { DataContext } from '@visx/xychart';
+import { useContext } from 'react';
+import type { FC } from 'react';
+
+interface ForecastDividerProps {
+	/**
+	 * The date at which the forecast begins
+	 */
+	forecastStart: Date;
+	/**
+	 * Color of the divider line. Default: '#888888'
+	 */
+	color?: string;
+}
+
+/**
+ * Renders a vertical dashed line at the forecast start position.
+ * Uses DataContext from visx/xychart to access scales.
+ *
+ * @param root0               - Props object
+ * @param root0.forecastStart - The date at which the forecast begins
+ * @param root0.color         - Color of the divider line
+ * @return SVG line element or null if scales are not available
+ */
+export const ForecastDivider: FC< ForecastDividerProps > = ( {
+	forecastStart,
+	color = '#888888',
+} ) => {
+	const context = useContext( DataContext );
+
+	if ( ! context?.xScale || ! context?.yScale ) {
+		return null;
+	}
+
+	const { xScale, innerHeight } = context;
+
+	// Get x position from scale
+	const xScaleFn = xScale as ( value: Date ) => number | undefined;
+	const x = xScaleFn( forecastStart );
+
+	if ( x === undefined || ! Number.isFinite( x ) ) {
+		return null;
+	}
+
+	return (
+		<line
+			x1={ x }
+			x2={ x }
+			y1={ 0 }
+			y2={ innerHeight }
+			stroke={ color }
+			strokeDasharray="4 4"
+			strokeWidth={ 1 }
+			data-testid="forecast-divider"
+		/>
+	);
+};

--- a/projects/js-packages/charts/src/charts/time-series-forecast-chart/private/index.ts
+++ b/projects/js-packages/charts/src/charts/time-series-forecast-chart/private/index.ts
@@ -1,0 +1,2 @@
+export { useForecastData } from './use-forecast-data';
+export { ForecastDivider } from './forecast-divider';

--- a/projects/js-packages/charts/src/charts/time-series-forecast-chart/private/use-forecast-data.ts
+++ b/projects/js-packages/charts/src/charts/time-series-forecast-chart/private/use-forecast-data.ts
@@ -1,0 +1,108 @@
+import { useMemo } from 'react';
+import type { TimeSeriesForecastAccessors, TransformedForecastPoint, BandPoint } from '../types';
+
+interface UseForecastDataOptions< D > {
+	data: readonly D[];
+	accessors: TimeSeriesForecastAccessors< D >;
+	forecastStart: Date;
+}
+
+interface UseForecastDataResult {
+	historical: TransformedForecastPoint[];
+	forecast: TransformedForecastPoint[];
+	bandData: BandPoint[];
+	yDomain: [ number, number ];
+	xDomain: [ Date, Date ];
+}
+
+/**
+ * Safe number extraction - returns null for non-finite numbers
+ *
+ * @param n - The value to extract as a number
+ * @return The number if valid and finite, otherwise null
+ */
+const asNumber = ( n: number | null | undefined ): number | null => {
+	return typeof n === 'number' && Number.isFinite( n ) ? n : null;
+};
+
+/**
+ * Hook to transform and split forecast data for rendering
+ *
+ * Handles:
+ * - Transforming generic data via accessors
+ * - Splitting data into historical and forecast portions
+ * - Creating band data for uncertainty regions
+ * - Computing x and y domains
+ *
+ * @param root0               - Options object
+ * @param root0.data          - Array of data points
+ * @param root0.accessors     - Accessor functions to extract values from data
+ * @param root0.forecastStart - Date at which forecast begins
+ * @return Transformed data split into historical and forecast portions
+ */
+export function useForecastData< D >( {
+	data,
+	accessors,
+	forecastStart,
+}: UseForecastDataOptions< D > ): UseForecastDataResult {
+	return useMemo( () => {
+		if ( data.length === 0 ) {
+			const now = new Date();
+			return {
+				historical: [],
+				forecast: [],
+				bandData: [],
+				yDomain: [ 0, 100 ] as [ number, number ],
+				xDomain: [ now, now ] as [ Date, Date ],
+			};
+		}
+
+		// 1. Transform all points via accessors
+		const transformed: TransformedForecastPoint[] = data.map( ( d, i ) => ( {
+			date: accessors.x( d, i ),
+			value: accessors.y( d, i ),
+			lower: accessors.yLower ? asNumber( accessors.yLower( d, i ) ) : null,
+			upper: accessors.yUpper ? asNumber( accessors.yUpper( d, i ) ) : null,
+			originalIndex: i,
+		} ) );
+
+		// 2. Sort by date for rendering stability
+		transformed.sort( ( a, b ) => a.date.getTime() - b.date.getTime() );
+
+		// 3. Split by forecastStart
+		// Both series include the transition point so the lines connect seamlessly
+		const forecastStartTime = forecastStart.getTime();
+		const historical = transformed.filter( p => p.date.getTime() <= forecastStartTime );
+		const forecast = transformed.filter( p => p.date.getTime() >= forecastStartTime );
+
+		// 4. Band data: only points with BOTH valid lower AND upper
+		const bandData: BandPoint[] = forecast
+			.filter(
+				( p ): p is TransformedForecastPoint & { lower: number; upper: number } =>
+					p.lower !== null && p.upper !== null
+			)
+			.map( p => ( { date: p.date, lower: p.lower, upper: p.upper } ) );
+
+		// 5. Compute y domain including bounds
+		const allValues = transformed.map( p => p.value );
+		const allLowers = transformed.map( p => p.lower ).filter( ( v ): v is number => v !== null );
+		const allUppers = transformed.map( p => p.upper ).filter( ( v ): v is number => v !== null );
+
+		const allYValues = [ ...allValues, ...allLowers, ...allUppers ];
+		const minY = Math.min( ...allYValues );
+		const maxY = Math.max( ...allYValues );
+
+		// Add some padding to y domain
+		const yPadding = ( maxY - minY ) * 0.1;
+		const yDomain: [ number, number ] = [ Math.max( 0, minY - yPadding ), maxY + yPadding ];
+
+		// 6. Compute x domain
+		const allDates = transformed.map( p => p.date );
+		const xDomain: [ Date, Date ] = [
+			new Date( Math.min( ...allDates.map( d => d.getTime() ) ) ),
+			new Date( Math.max( ...allDates.map( d => d.getTime() ) ) ),
+		];
+
+		return { historical, forecast, bandData, yDomain, xDomain };
+	}, [ data, accessors, forecastStart ] );
+}

--- a/projects/js-packages/charts/src/charts/time-series-forecast-chart/stories/config.tsx
+++ b/projects/js-packages/charts/src/charts/time-series-forecast-chart/stories/config.tsx
@@ -1,0 +1,156 @@
+import {
+	chartDecorator,
+	sharedChartArgTypes,
+	ChartStoryArgs,
+} from '../../../stories/chart-decorator';
+import { legendArgTypes } from '../../../stories/legend-config';
+import { sharedThemeArgs, themeArgTypes } from '../../../stories/theme-config';
+import TimeSeriesForecastChart from '../time-series-forecast-chart';
+import type { TimeSeriesForecastChartProps } from '../types';
+import type { Meta } from '@storybook/react';
+
+/**
+ * Sample forecast data point type
+ */
+export type SampleForecastDatum = {
+	date: Date;
+	value: number;
+	lower?: number;
+	upper?: number;
+};
+
+/**
+ * Generate sample forecast data for storybook demonstrations.
+ *
+ * @param historicalDays - Number of historical days to generate
+ * @param forecastDays   - Number of forecast days to generate
+ * @param baseValue      - Starting value for the data
+ * @param trend          - Daily trend increment
+ * @param volatility     - Random noise amplitude
+ * @return Array of sample forecast data points
+ */
+export const generateForecastData = (
+	historicalDays: number = 30,
+	forecastDays: number = 14,
+	baseValue: number = 100,
+	trend: number = 0.5,
+	volatility: number = 10
+): SampleForecastDatum[] => {
+	const data: SampleForecastDatum[] = [];
+	const startDate = new Date();
+	startDate.setDate( startDate.getDate() - historicalDays );
+
+	// Generate historical data (no bounds)
+	for ( let i = 0; i < historicalDays; i++ ) {
+		const date = new Date( startDate );
+		date.setDate( date.getDate() + i );
+		const noise = ( Math.random() - 0.5 ) * volatility * 2;
+		const value = baseValue + trend * i + noise;
+		data.push( { date, value: Math.max( 0, value ) } );
+	}
+
+	// Generate forecast data (with bounds)
+	const lastHistoricalValue = data[ data.length - 1 ].value;
+	for ( let i = 0; i < forecastDays; i++ ) {
+		const date = new Date( startDate );
+		date.setDate( date.getDate() + historicalDays + i );
+		const projectedValue = lastHistoricalValue + trend * ( i + 1 );
+
+		// Uncertainty grows with time
+		const uncertaintySpread = volatility * ( 1 + i * 0.2 );
+		const lower = projectedValue - uncertaintySpread;
+		const upper = projectedValue + uncertaintySpread;
+
+		data.push( {
+			date,
+			value: projectedValue,
+			lower: Math.max( 0, lower ),
+			upper,
+		} );
+	}
+
+	return data;
+};
+
+/**
+ * Fixed sample data for consistent story rendering
+ * Note: The last historical point (2024-02-19) is also the first forecast point
+ * to ensure the lines connect seamlessly at the transition.
+ */
+export const sampleForecastData: SampleForecastDatum[] = [
+	// Historical data (no bounds)
+	{ date: new Date( '2024-01-01' ), value: 100 },
+	{ date: new Date( '2024-01-08' ), value: 108 },
+	{ date: new Date( '2024-01-15' ), value: 115 },
+	{ date: new Date( '2024-01-22' ), value: 112 },
+	{ date: new Date( '2024-01-29' ), value: 125 },
+	{ date: new Date( '2024-02-05' ), value: 130 },
+	{ date: new Date( '2024-02-12' ), value: 128 },
+	// Forecast data (with bounds) - starts at last historical point for seamless connection
+	{ date: new Date( '2024-02-19' ), value: 135, lower: 135, upper: 135 }, // Transition point (no spread yet)
+	{ date: new Date( '2024-02-26' ), value: 142, lower: 132, upper: 152 },
+	{ date: new Date( '2024-03-04' ), value: 148, lower: 135, upper: 161 },
+	{ date: new Date( '2024-03-11' ), value: 155, lower: 138, upper: 172 },
+	{ date: new Date( '2024-03-18' ), value: 162, lower: 140, upper: 184 },
+];
+
+/**
+ * Sample accessors for the default data type
+ */
+export const sampleAccessors = {
+	x: ( d: SampleForecastDatum ) => d.date,
+	y: ( d: SampleForecastDatum ) => d.value,
+	yLower: ( d: SampleForecastDatum ) => d.lower,
+	yUpper: ( d: SampleForecastDatum ) => d.upper,
+};
+
+/**
+ * Forecast start date - the transition point where forecast begins
+ */
+export const sampleForecastStart = new Date( '2024-02-19' );
+
+type StoryArgs = ChartStoryArgs< TimeSeriesForecastChartProps< SampleForecastDatum > >;
+
+export const timeSeriesForecastChartMetaArgs: Meta< StoryArgs > = {
+	title: 'JS Packages/Charts Library/Charts/Time Series Forecast Chart',
+	component: TimeSeriesForecastChart,
+	parameters: {
+		layout: 'centered',
+	},
+	decorators: [ chartDecorator ],
+	argTypes: {
+		...legendArgTypes,
+		...themeArgTypes,
+		...sharedChartArgTypes,
+		showTooltip: {
+			control: 'boolean',
+			description: 'Show tooltips on hover',
+			table: { category: 'Tooltip' },
+		},
+		animation: {
+			control: 'boolean',
+			description: 'Enable chart animation',
+			table: { category: 'Visual Style' },
+		},
+		gridVisibility: {
+			control: { type: 'select' },
+			options: [ 'x', 'y', 'xy', 'none' ],
+			description: 'Grid visibility',
+			table: { category: 'Visual Style' },
+		},
+	},
+};
+
+export const timeSeriesForecastChartStoryArgs = {
+	...sharedThemeArgs,
+	data: sampleForecastData,
+	accessors: sampleAccessors,
+	forecastStart: sampleForecastStart,
+	showTooltip: true,
+	showLegend: false,
+	animation: false,
+	gridVisibility: 'y' as const,
+	maxWidth: 800,
+	aspectRatio: 0.5,
+	resizeDebounceTime: 300,
+};

--- a/projects/js-packages/charts/src/charts/time-series-forecast-chart/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/charts/time-series-forecast-chart/stories/index.stories.tsx
@@ -1,0 +1,453 @@
+import { formatNumber } from '@automattic/number-formatters';
+import { ChartStoryArgs } from '../../../stories';
+import TimeSeriesForecastChart from '../time-series-forecast-chart';
+import {
+	timeSeriesForecastChartMetaArgs,
+	timeSeriesForecastChartStoryArgs,
+	sampleForecastData,
+	sampleAccessors,
+	sampleForecastStart,
+	generateForecastData,
+	type SampleForecastDatum,
+} from './config';
+import type { TimeSeriesForecastChartProps } from '../types';
+import type { Meta, StoryFn, StoryObj } from '@storybook/react';
+
+type StoryArgs = ChartStoryArgs< TimeSeriesForecastChartProps< SampleForecastDatum > >;
+
+const meta: Meta< StoryArgs > = {
+	...timeSeriesForecastChartMetaArgs,
+	title: 'JS Packages/Charts Library/Charts/Time Series Forecast Chart',
+};
+
+export default meta;
+
+const Template: StoryFn< typeof TimeSeriesForecastChart > = args => {
+	return <TimeSeriesForecastChart { ...args } />;
+};
+
+/**
+ * Default story showing historical data with forecast and uncertainty bands
+ */
+export const Default: StoryObj< StoryArgs > = Template.bind( {} );
+Default.args = {
+	...timeSeriesForecastChartStoryArgs,
+};
+
+Default.parameters = {
+	docs: {
+		description: {
+			story:
+				'The TimeSeriesForecastChart displays historical data as a solid line and forecast data as a dashed line. ' +
+				'The shaded area represents the uncertainty band between lower and upper bounds. ' +
+				'A vertical dashed line marks the forecast start date.',
+		},
+	},
+};
+
+/**
+ * With Legend enabled
+ */
+export const WithLegend: StoryObj< StoryArgs > = Template.bind( {} );
+WithLegend.args = {
+	...timeSeriesForecastChartStoryArgs,
+	showLegend: true,
+	legendPosition: 'bottom',
+};
+
+WithLegend.parameters = {
+	docs: {
+		description: {
+			story:
+				'The chart with legend showing series labels. The forecast series shows a dashed line indicator.',
+		},
+	},
+};
+
+/**
+ * With Animation
+ */
+export const WithAnimation: StoryObj< StoryArgs > = Template.bind( {} );
+WithAnimation.args = {
+	...timeSeriesForecastChartStoryArgs,
+	animation: true,
+};
+
+WithAnimation.parameters = {
+	docs: {
+		description: {
+			story:
+				'The chart with animation enabled. Animation respects the prefers-reduced-motion setting.',
+		},
+	},
+};
+
+/**
+ * Custom Series Labels
+ */
+export const CustomSeriesLabels: StoryObj< StoryArgs > = Template.bind( {} );
+CustomSeriesLabels.args = {
+	...timeSeriesForecastChartStoryArgs,
+	showLegend: true,
+	seriesKeys: {
+		historical: 'Actual Revenue',
+		forecast: 'Projected Revenue',
+		band: 'Confidence Interval',
+	},
+};
+
+CustomSeriesLabels.parameters = {
+	docs: {
+		description: {
+			story:
+				'Customize the series labels shown in the legend and tooltip using the seriesKeys prop.',
+		},
+	},
+};
+
+/**
+ * Custom Tooltip
+ */
+export const CustomTooltip: StoryObj< StoryArgs > = Template.bind( {} );
+CustomTooltip.args = {
+	...timeSeriesForecastChartStoryArgs,
+	renderTooltip: ( { x, y, yLower, yUpper, isForecast } ) => (
+		<div style={ { padding: '8px', background: '#fff', borderRadius: '4px' } }>
+			<div style={ { fontWeight: 'bold', marginBottom: '4px' } }>
+				{ x.toLocaleDateString( 'en-US', { month: 'short', day: 'numeric', year: 'numeric' } ) }
+			</div>
+			<div>Value: ${ formatNumber( y ) }</div>
+			{ isForecast && yLower !== undefined && yUpper !== undefined && (
+				<div style={ { fontSize: '0.9em', color: '#666' } }>
+					Range: ${ formatNumber( yLower ) } - ${ formatNumber( yUpper ) }
+				</div>
+			) }
+			{ isForecast && (
+				<div
+					style={ {
+						marginTop: '4px',
+						fontSize: '0.8em',
+						color: '#3858e9',
+						fontStyle: 'italic',
+					} }
+				>
+					Forecast
+				</div>
+			) }
+		</div>
+	),
+};
+
+CustomTooltip.parameters = {
+	docs: {
+		description: {
+			story:
+				'Use the renderTooltip prop to provide a custom tooltip renderer. ' +
+				'The tooltip receives the original datum, x/y values, bounds (if available), and whether the point is in the forecast region.',
+		},
+	},
+};
+
+/**
+ * Fixed Dimensions
+ */
+export const FixedDimensions: StoryObj< StoryArgs > = Template.bind( {} );
+FixedDimensions.args = {
+	...timeSeriesForecastChartStoryArgs,
+	width: 600,
+	height: 300,
+};
+
+FixedDimensions.parameters = {
+	docs: {
+		description: {
+			story:
+				'The chart with fixed dimensions instead of responsive behavior. Use width and height props directly.',
+		},
+	},
+};
+
+/**
+ * Custom Y Domain
+ */
+export const CustomYDomain: StoryObj< StoryArgs > = Template.bind( {} );
+CustomYDomain.args = {
+	...timeSeriesForecastChartStoryArgs,
+	yDomain: [ 0, 200 ],
+};
+
+CustomYDomain.parameters = {
+	docs: {
+		description: {
+			story: 'Override the auto-calculated Y domain with a fixed range using the yDomain prop.',
+		},
+	},
+};
+
+/**
+ * Custom Tick Formatters
+ */
+export const CustomTickFormatters: StoryObj< StoryArgs > = Template.bind( {} );
+CustomTickFormatters.args = {
+	...timeSeriesForecastChartStoryArgs,
+	xTickFormat: ( d: Date ) => d.toLocaleDateString( 'en-US', { month: 'short', day: 'numeric' } ),
+	yTickFormat: ( n: number ) => `$${ n }`,
+};
+
+CustomTickFormatters.parameters = {
+	docs: {
+		description: {
+			story: 'Customize axis tick labels using xTickFormat and yTickFormat props.',
+		},
+	},
+};
+
+/**
+ * Historical Only (no forecast data)
+ */
+export const HistoricalOnly: StoryObj< StoryArgs > = Template.bind( {} );
+HistoricalOnly.args = {
+	...timeSeriesForecastChartStoryArgs,
+	data: sampleForecastData.slice( 0, 7 ), // Only historical points (before transition)
+	forecastStart: new Date( '2024-12-31' ), // Far in the future
+};
+
+HistoricalOnly.parameters = {
+	docs: {
+		description: {
+			story:
+				'When forecastStart is after all data points, only the historical line is shown (no divider or band).',
+		},
+	},
+};
+
+/**
+ * Forecast Only (no historical data)
+ */
+export const ForecastOnly: StoryObj< StoryArgs > = Template.bind( {} );
+ForecastOnly.args = {
+	...timeSeriesForecastChartStoryArgs,
+	data: sampleForecastData.slice( 7 ), // Only forecast points (from transition onward)
+	forecastStart: new Date( '2024-01-01' ), // Before all data
+};
+
+ForecastOnly.parameters = {
+	docs: {
+		description: {
+			story:
+				'When forecastStart is before all data points, only the forecast line and band are shown (no divider).',
+		},
+	},
+};
+
+/**
+ * Different Grid Visibility Options
+ */
+export const GridVisibilityOptions: StoryObj< StoryArgs > = {
+	render: () => (
+		<div style={ { display: 'grid', gap: '2rem', gridTemplateColumns: 'repeat(2, 1fr)' } }>
+			<div>
+				<h3>Y Grid (default)</h3>
+				<TimeSeriesForecastChart
+					data={ sampleForecastData }
+					accessors={ sampleAccessors }
+					forecastStart={ sampleForecastStart }
+					width={ 350 }
+					height={ 200 }
+					gridVisibility="y"
+				/>
+			</div>
+			<div>
+				<h3>X Grid</h3>
+				<TimeSeriesForecastChart
+					data={ sampleForecastData }
+					accessors={ sampleAccessors }
+					forecastStart={ sampleForecastStart }
+					width={ 350 }
+					height={ 200 }
+					gridVisibility="x"
+				/>
+			</div>
+			<div>
+				<h3>Both (XY)</h3>
+				<TimeSeriesForecastChart
+					data={ sampleForecastData }
+					accessors={ sampleAccessors }
+					forecastStart={ sampleForecastStart }
+					width={ 350 }
+					height={ 200 }
+					gridVisibility="xy"
+				/>
+			</div>
+			<div>
+				<h3>No Grid</h3>
+				<TimeSeriesForecastChart
+					data={ sampleForecastData }
+					accessors={ sampleAccessors }
+					forecastStart={ sampleForecastStart }
+					width={ 350 }
+					height={ 200 }
+					gridVisibility="none"
+				/>
+			</div>
+		</div>
+	),
+	parameters: {
+		docs: {
+			description: {
+				story: 'Different grid visibility options: y (default), x, xy, or none.',
+			},
+		},
+	},
+};
+
+/**
+ * Dynamic/Generated Data
+ */
+export const DynamicData: StoryObj< StoryArgs > = {
+	render: () => {
+		const data = generateForecastData( 30, 14, 100, 1.5, 15 );
+		const forecastStart = new Date();
+
+		return (
+			<TimeSeriesForecastChart
+				data={ data }
+				accessors={ sampleAccessors }
+				forecastStart={ forecastStart }
+				showLegend={ true }
+				maxWidth={ 800 }
+				aspectRatio={ 0.5 }
+			/>
+		);
+	},
+	parameters: {
+		docs: {
+			description: {
+				story:
+					'Example with dynamically generated data. The generateForecastData helper creates realistic time series with configurable parameters for trend, volatility, and forecast length.',
+			},
+		},
+	},
+};
+
+/**
+ * Generic Data Type Example
+ */
+type CustomDatum = {
+	timestamp: number;
+	measurement: number;
+	confidenceLow?: number;
+	confidenceHigh?: number;
+};
+
+const customData: CustomDatum[] = [
+	{ timestamp: Date.parse( '2024-01-01' ), measurement: 50 },
+	{ timestamp: Date.parse( '2024-01-15' ), measurement: 55 },
+	// Transition point - shared by both series
+	{ timestamp: Date.parse( '2024-02-01' ), measurement: 60, confidenceLow: 60, confidenceHigh: 60 },
+	{ timestamp: Date.parse( '2024-02-15' ), measurement: 65, confidenceLow: 58, confidenceHigh: 72 },
+	{ timestamp: Date.parse( '2024-03-01' ), measurement: 70, confidenceLow: 60, confidenceHigh: 80 },
+];
+
+const customAccessors = {
+	x: ( d: CustomDatum ) => new Date( d.timestamp ),
+	y: ( d: CustomDatum ) => d.measurement,
+	yLower: ( d: CustomDatum ) => d.confidenceLow,
+	yUpper: ( d: CustomDatum ) => d.confidenceHigh,
+};
+
+export const GenericDataType: StoryObj< StoryArgs > = {
+	render: () => (
+		<TimeSeriesForecastChart
+			data={ customData }
+			accessors={ customAccessors }
+			forecastStart={ new Date( '2024-02-01' ) }
+			seriesKeys={ {
+				historical: 'Measurements',
+				forecast: 'Predictions',
+				band: 'Confidence',
+			} }
+			showLegend={ true }
+			width={ 600 }
+			height={ 300 }
+		/>
+	),
+	parameters: {
+		docs: {
+			description: {
+				story:
+					'The chart supports generic data types via accessor functions. ' +
+					'This example uses a custom datum shape with timestamp (number) instead of Date, ' +
+					'and differently named fields for values and bounds.',
+			},
+		},
+	},
+};
+
+/**
+ * Empty Data State
+ */
+export const EmptyData: StoryObj< StoryArgs > = Template.bind( {} );
+EmptyData.args = {
+	...timeSeriesForecastChartStoryArgs,
+	data: [],
+};
+
+EmptyData.parameters = {
+	docs: {
+		description: {
+			story: 'When no data is provided, the chart displays a "No data available" message.',
+		},
+	},
+};
+
+/**
+ * Partial Bounds (some forecast points missing bounds)
+ */
+const partialBoundsData: SampleForecastDatum[] = [
+	{ date: new Date( '2024-01-01' ), value: 100 },
+	{ date: new Date( '2024-01-15' ), value: 110 },
+	// Transition point - shared by both series (tight bounds at start)
+	{ date: new Date( '2024-02-01' ), value: 120, lower: 120, upper: 120 },
+	// Forecast with bounds
+	{ date: new Date( '2024-02-15' ), value: 130, lower: 120, upper: 140 },
+	// Forecast WITHOUT bounds (band won't include this point)
+	{ date: new Date( '2024-03-01' ), value: 140 },
+	// Forecast with bounds again
+	{ date: new Date( '2024-03-15' ), value: 150, lower: 135, upper: 165 },
+];
+
+export const PartialBounds: StoryObj< StoryArgs > = Template.bind( {} );
+PartialBounds.args = {
+	...timeSeriesForecastChartStoryArgs,
+	data: partialBoundsData,
+	forecastStart: new Date( '2024-02-01' ),
+};
+
+PartialBounds.parameters = {
+	docs: {
+		description: {
+			story:
+				'The uncertainty band only renders for forecast points that have both lower AND upper bounds. ' +
+				'Points with missing bounds are still shown on the forecast line but excluded from the band.',
+		},
+	},
+};
+
+/**
+ * Legend at Top
+ */
+export const LegendAtTop: StoryObj< StoryArgs > = Template.bind( {} );
+LegendAtTop.args = {
+	...timeSeriesForecastChartStoryArgs,
+	showLegend: true,
+	legendPosition: 'top',
+};
+
+LegendAtTop.parameters = {
+	docs: {
+		description: {
+			story: 'The legend positioned above the chart using legendPosition="top".',
+		},
+	},
+};

--- a/projects/js-packages/charts/src/charts/time-series-forecast-chart/time-series-forecast-chart.module.scss
+++ b/projects/js-packages/charts/src/charts/time-series-forecast-chart/time-series-forecast-chart.module.scss
@@ -1,0 +1,63 @@
+.time-series-forecast-chart {
+	display: flex;
+	flex-direction: column;
+	position: relative;
+
+	&--animated {
+
+		path {
+			transform-origin: 0 95%;
+			transform: scaleY(0);
+			animation: rise 1s ease-out forwards;
+		}
+	}
+
+	&--legend-top {
+		flex-direction: column-reverse;
+	}
+
+	svg {
+		overflow: visible;
+	}
+
+	&__tooltip {
+		background: #fff;
+		padding: 0.5rem;
+		border-radius: 4px;
+		box-shadow: 0 1px 4px rgba(0, 0, 0, 0.1);
+	}
+
+	&__tooltip-header {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+		font-weight: 700;
+		padding-bottom: 8px;
+	}
+
+	&__tooltip-row {
+		display: flex;
+		justify-content: space-between;
+		padding: 4px 0;
+		gap: 16px;
+	}
+
+	&__forecast-badge {
+		font-size: 0.75rem;
+		font-weight: 500;
+		padding: 2px 6px;
+		border-radius: 3px;
+		background: rgba(0, 0, 0, 0.1);
+	}
+
+	&__legend {
+		padding-top: 8px;
+	}
+}
+
+@keyframes rise {
+
+	to {
+		transform: scaleY(1);
+	}
+}

--- a/projects/js-packages/charts/src/charts/time-series-forecast-chart/time-series-forecast-chart.tsx
+++ b/projects/js-packages/charts/src/charts/time-series-forecast-chart/time-series-forecast-chart.tsx
@@ -45,25 +45,31 @@ const formatDateTick = ( d: Date ) => {
 /**
  * Internal component that renders the TimeSeriesForecastChart
  *
- * @param root0                - Component props
- * @param root0.data           - Array of data points to display
- * @param root0.accessors      - Accessor functions to extract values from data
- * @param root0.forecastStart  - Date at which forecast begins
- * @param root0.height         - Chart height in pixels
- * @param root0.width          - Chart width in pixels
- * @param root0.margin         - Chart margin configuration
- * @param root0.yDomain        - Optional fixed y-axis domain
- * @param root0.xTickFormat    - Formatter function for x-axis ticks
- * @param root0.yTickFormat    - Formatter function for y-axis ticks
- * @param root0.showTooltip    - Whether to show tooltips on hover
- * @param root0.seriesKeys     - Custom labels for series in legend/tooltip
- * @param root0.renderTooltip  - Custom tooltip renderer function
- * @param root0.className      - Additional CSS class name
- * @param root0.chartId        - Unique chart identifier
- * @param root0.showLegend     - Whether to show the legend
- * @param root0.legendPosition - Position of the legend (top or bottom)
- * @param root0.animation      - Whether to enable chart animations
- * @param root0.gridVisibility - Which grid lines to show (x, y, xy, or none)
+ * @param root0                     - Component props
+ * @param root0.data                - Array of data points to display
+ * @param root0.accessors           - Accessor functions to extract values from data
+ * @param root0.forecastStart       - Date at which forecast begins
+ * @param root0.height              - Chart height in pixels
+ * @param root0.width               - Chart width in pixels
+ * @param root0.margin              - Chart margin configuration
+ * @param root0.yDomain             - Optional fixed y-axis domain
+ * @param root0.xTickFormat         - Formatter function for x-axis ticks
+ * @param root0.yTickFormat         - Formatter function for y-axis ticks
+ * @param root0.showTooltip         - Whether to show tooltips on hover
+ * @param root0.seriesKeys          - Custom labels for series in legend/tooltip
+ * @param root0.renderTooltip       - Custom tooltip renderer function
+ * @param root0.className           - Additional CSS class name
+ * @param root0.chartId             - Unique chart identifier
+ * @param root0.showLegend          - Whether to show the legend
+ * @param root0.legendOrientation   - Legend orientation (horizontal or vertical)
+ * @param root0.legendPosition      - Position of the legend (top or bottom)
+ * @param root0.legendAlignment     - Legend alignment within its position
+ * @param root0.legendMaxWidth      - Maximum width for legend items
+ * @param root0.legendTextOverflow  - How text behaves when exceeding legendMaxWidth
+ * @param root0.legendItemClassName - Additional CSS class name for legend items
+ * @param root0.legendShape         - Shape for legend items
+ * @param root0.animation           - Whether to enable chart animations
+ * @param root0.gridVisibility      - Which grid lines to show (x, y, xy, or none)
  * @return The rendered chart component
  */
 function TimeSeriesForecastChartInternal< D >( {
@@ -82,7 +88,13 @@ function TimeSeriesForecastChartInternal< D >( {
 	className,
 	chartId: providedChartId,
 	showLegend = false,
+	legendOrientation = 'horizontal',
 	legendPosition = 'bottom',
+	legendAlignment = 'center',
+	legendMaxWidth,
+	legendTextOverflow = 'wrap',
+	legendItemClassName,
+	legendShape = 'line',
 	animation = false,
 	gridVisibility = 'y',
 }: TimeSeriesForecastChartProps< D > ) {
@@ -366,11 +378,14 @@ function TimeSeriesForecastChartInternal< D >( {
 
 			{ showLegend && (
 				<Legend
-					orientation="horizontal"
-					alignment="center"
+					orientation={ legendOrientation }
+					alignment={ legendAlignment }
 					position={ legendPosition }
+					maxWidth={ legendMaxWidth }
+					textOverflow={ legendTextOverflow }
+					legendItemClassName={ legendItemClassName }
 					className={ styles[ 'time-series-forecast-chart__legend' ] }
-					shape="line"
+					shape={ legendShape }
 					chartId={ chartId }
 					ref={ legendRef }
 					items={ legendItems }

--- a/projects/js-packages/charts/src/charts/time-series-forecast-chart/time-series-forecast-chart.tsx
+++ b/projects/js-packages/charts/src/charts/time-series-forecast-chart/time-series-forecast-chart.tsx
@@ -4,7 +4,7 @@ import { XYChart, AreaSeries, Grid, Axis, Tooltip } from '@visx/xychart';
 import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
 import { useContext, useMemo, useCallback } from 'react';
-import { Legend, useChartLegendItems } from '../../components/legend';
+import { Legend } from '../../components/legend';
 import { useXYChartTheme, useElementHeight, usePrefersReducedMotion } from '../../hooks';
 import {
 	GlobalChartsProvider,
@@ -165,9 +165,6 @@ function TimeSeriesForecastChartInternal< D >( {
 
 		return items;
 	}, [ historical.length, forecast.length, seriesKeys, primaryColor ] );
-
-	// Use legend hook for consistent styling
-	useChartLegendItems( mockSeriesData, {}, 'line' );
 
 	// Accessors for transformed points (memoized to avoid recreating on each render)
 	const xAccessor = useCallback( ( p: TransformedForecastPoint | BandPoint ) => p.date, [] );

--- a/projects/js-packages/charts/src/charts/time-series-forecast-chart/time-series-forecast-chart.tsx
+++ b/projects/js-packages/charts/src/charts/time-series-forecast-chart/time-series-forecast-chart.tsx
@@ -1,0 +1,442 @@
+import { formatNumberCompact, formatNumber } from '@automattic/number-formatters';
+import { curveMonotoneX } from '@visx/curve';
+import { XYChart, AreaSeries, Grid, Axis, Tooltip } from '@visx/xychart';
+import { __ } from '@wordpress/i18n';
+import clsx from 'clsx';
+import { useContext, useMemo, useCallback } from 'react';
+import { Legend, useChartLegendItems } from '../../components/legend';
+import { useXYChartTheme, useElementHeight, usePrefersReducedMotion } from '../../hooks';
+import {
+	GlobalChartsProvider,
+	GlobalChartsContext,
+	useChartId,
+	useGlobalChartsTheme,
+} from '../../providers';
+import { withResponsive } from '../private/with-responsive';
+import { ForecastDivider, useForecastData } from './private';
+import styles from './time-series-forecast-chart.module.scss';
+import type {
+	TimeSeriesForecastChartProps,
+	TransformedForecastPoint,
+	BandPoint,
+	SeriesKeys,
+} from './types';
+import type { BaseLegendItem } from '../../components/legend';
+import type { Optional } from '../../types';
+import type { TickFormatter } from '@visx/axis';
+import type { RenderTooltipParams } from '@visx/xychart/lib/components/Tooltip';
+import type { FC } from 'react';
+
+const DEFAULT_MARGIN = { top: 20, right: 20, bottom: 40, left: 50 };
+
+const DEFAULT_SERIES_KEYS: Required< SeriesKeys > = {
+	historical: 'Historical',
+	forecast: 'Forecast',
+	band: 'Uncertainty',
+};
+
+const formatDateTick = ( d: Date ) => {
+	return d.toLocaleDateString( undefined, {
+		month: 'short',
+		day: 'numeric',
+	} );
+};
+
+/**
+ * Internal component that renders the TimeSeriesForecastChart
+ *
+ * @param root0                - Component props
+ * @param root0.data           - Array of data points to display
+ * @param root0.accessors      - Accessor functions to extract values from data
+ * @param root0.forecastStart  - Date at which forecast begins
+ * @param root0.height         - Chart height in pixels
+ * @param root0.width          - Chart width in pixels
+ * @param root0.margin         - Chart margin configuration
+ * @param root0.yDomain        - Optional fixed y-axis domain
+ * @param root0.xTickFormat    - Formatter function for x-axis ticks
+ * @param root0.yTickFormat    - Formatter function for y-axis ticks
+ * @param root0.showTooltip    - Whether to show tooltips on hover
+ * @param root0.seriesKeys     - Custom labels for series in legend/tooltip
+ * @param root0.renderTooltip  - Custom tooltip renderer function
+ * @param root0.className      - Additional CSS class name
+ * @param root0.chartId        - Unique chart identifier
+ * @param root0.showLegend     - Whether to show the legend
+ * @param root0.legendPosition - Position of the legend (top or bottom)
+ * @param root0.animation      - Whether to enable chart animations
+ * @param root0.gridVisibility - Which grid lines to show (x, y, xy, or none)
+ * @return The rendered chart component
+ */
+function TimeSeriesForecastChartInternal< D >( {
+	data,
+	accessors,
+	forecastStart,
+	height,
+	width = 600,
+	margin,
+	yDomain: providedYDomain,
+	xTickFormat = formatDateTick,
+	yTickFormat,
+	showTooltip = true,
+	seriesKeys: providedSeriesKeys,
+	renderTooltip,
+	className,
+	chartId: providedChartId,
+	showLegend = false,
+	legendPosition = 'bottom',
+	animation = false,
+	gridVisibility = 'y',
+}: TimeSeriesForecastChartProps< D > ) {
+	const providerTheme = useGlobalChartsTheme();
+	const chartId = useChartId( providedChartId );
+	const [ legendRef, legendHeight ] = useElementHeight< HTMLDivElement >();
+	const prefersReducedMotion = usePrefersReducedMotion();
+
+	// Merge series keys with defaults
+	const seriesKeys = useMemo(
+		() => ( {
+			...DEFAULT_SERIES_KEYS,
+			...providedSeriesKeys,
+		} ),
+		[ providedSeriesKeys ]
+	);
+
+	// Transform and split data
+	const {
+		historical,
+		forecast,
+		bandData,
+		yDomain: computedYDomain,
+		xDomain,
+	} = useForecastData( {
+		data,
+		accessors,
+		forecastStart,
+	} );
+
+	// Use provided y domain or computed one
+	const yDomain = providedYDomain ?? computedYDomain;
+
+	// Get theme colors
+	const primaryColor = providerTheme.colors[ 0 ] ?? '#3858e9';
+	const bandColor = providerTheme.colors[ 1 ] ?? primaryColor;
+
+	// Create mock series data for theme hook
+	const mockSeriesData = useMemo(
+		() => [
+			{ label: seriesKeys.historical, data: [] },
+			{ label: seriesKeys.forecast, data: [] },
+		],
+		[ seriesKeys ]
+	);
+	const theme = useXYChartTheme( mockSeriesData );
+
+	// Computed margin
+	const computedMargin = useMemo(
+		() => ( {
+			...DEFAULT_MARGIN,
+			...margin,
+		} ),
+		[ margin ]
+	);
+
+	// Chart dimensions accounting for legend
+	const chartHeight = height - ( showLegend ? legendHeight : 0 );
+
+	// Create legend items
+	const legendItems = useMemo< BaseLegendItem[] >( () => {
+		const items: BaseLegendItem[] = [];
+
+		if ( historical.length > 0 ) {
+			items.push( {
+				label: seriesKeys.historical,
+				value: '',
+				color: primaryColor,
+			} );
+		}
+
+		if ( forecast.length > 0 ) {
+			items.push( {
+				label: seriesKeys.forecast,
+				value: '',
+				color: primaryColor,
+				shapeStyle: { strokeDasharray: '5 5' },
+			} );
+		}
+
+		return items;
+	}, [ historical.length, forecast.length, seriesKeys, primaryColor ] );
+
+	// Use legend hook for consistent styling
+	useChartLegendItems( mockSeriesData, {}, 'line' );
+
+	// Accessors for transformed points (memoized to avoid recreating on each render)
+	const xAccessor = useCallback( ( p: TransformedForecastPoint | BandPoint ) => p.date, [] );
+	const yAccessor = useCallback( ( p: TransformedForecastPoint ) => p.value, [] );
+	const bandUpperAccessor = useCallback( ( p: BandPoint ) => p.upper, [] );
+	const bandLowerAccessor = useCallback( ( p: BandPoint ) => p.lower, [] );
+
+	// Default tooltip renderer (memoized to avoid recreating on each render)
+	const defaultRenderTooltip = useCallback(
+		( params: RenderTooltipParams< TransformedForecastPoint > ) => {
+			const { tooltipData } = params;
+			const nearestDatum = tooltipData?.nearestDatum?.datum;
+
+			if ( ! nearestDatum ) {
+				return null;
+			}
+
+			const isForecast = nearestDatum.date.getTime() >= forecastStart.getTime();
+			const hasBounds = nearestDatum.lower !== null && nearestDatum.upper !== null;
+
+			return (
+				<div className={ styles[ 'time-series-forecast-chart__tooltip' ] }>
+					<div className={ styles[ 'time-series-forecast-chart__tooltip-header' ] }>
+						{ xTickFormat( nearestDatum.date ) }
+						{ isForecast && (
+							<span className={ styles[ 'time-series-forecast-chart__forecast-badge' ] }>
+								{ seriesKeys.forecast }
+							</span>
+						) }
+					</div>
+					<div className={ styles[ 'time-series-forecast-chart__tooltip-row' ] }>
+						<span>{ __( 'Value', 'jetpack-charts' ) }:</span>
+						<span>{ formatNumber( nearestDatum.value ) }</span>
+					</div>
+					{ isForecast && hasBounds && (
+						<div className={ styles[ 'time-series-forecast-chart__tooltip-row' ] }>
+							<span>{ __( 'Range', 'jetpack-charts' ) }:</span>
+							<span>
+								{ formatNumber( nearestDatum.lower as number ) } -{ ' ' }
+								{ formatNumber( nearestDatum.upper as number ) }
+							</span>
+						</div>
+					) }
+				</div>
+			);
+		},
+		[ forecastStart, seriesKeys.forecast, xTickFormat ]
+	);
+
+	// Custom tooltip renderer that wraps user-provided function
+	const tooltipRenderer = useMemo( () => {
+		if ( renderTooltip ) {
+			return ( params: RenderTooltipParams< TransformedForecastPoint > ) => {
+				const nearestDatum = params.tooltipData?.nearestDatum?.datum;
+				if ( ! nearestDatum ) return null;
+
+				const originalDatum = data[ nearestDatum.originalIndex ];
+				const isForecast = nearestDatum.date.getTime() >= forecastStart.getTime();
+
+				return renderTooltip( {
+					nearest: originalDatum,
+					x: nearestDatum.date,
+					y: nearestDatum.value,
+					yLower: nearestDatum.lower ?? undefined,
+					yUpper: nearestDatum.upper ?? undefined,
+					isForecast,
+				} );
+			};
+		}
+		return defaultRenderTooltip;
+	}, [ renderTooltip, data, forecastStart, defaultRenderTooltip ] );
+
+	// Y-axis tick formatter
+	const yAxisTickFormat = useMemo( () => {
+		if ( yTickFormat ) {
+			return yTickFormat as TickFormatter< number >;
+		}
+		return formatNumberCompact as TickFormatter< number >;
+	}, [ yTickFormat ] );
+
+	// X-axis tick formatter wrapper
+	const xAxisTickFormat = useMemo( () => {
+		return ( d: Date ) => xTickFormat( d );
+	}, [ xTickFormat ] );
+
+	// Handle empty data
+	if ( data.length === 0 ) {
+		return (
+			<div
+				className={ clsx(
+					'time-series-forecast-chart',
+					styles[ 'time-series-forecast-chart' ],
+					className
+				) }
+				data-testid="time-series-forecast-chart"
+			>
+				{ __( 'No data available', 'jetpack-charts' ) }
+			</div>
+		);
+	}
+
+	// Determine if we should show the divider
+	const showDivider = forecast.length > 0 && historical.length > 0;
+
+	// Determine grid settings
+	const showXGrid = gridVisibility === 'x' || gridVisibility === 'xy';
+	const showYGrid = gridVisibility === 'y' || gridVisibility === 'xy';
+
+	return (
+		<div
+			className={ clsx(
+				'time-series-forecast-chart',
+				styles[ 'time-series-forecast-chart' ],
+				{
+					[ styles[ 'time-series-forecast-chart--animated' ] ]: animation && ! prefersReducedMotion,
+					[ styles[ 'time-series-forecast-chart--legend-top' ] ]:
+						showLegend && legendPosition === 'top',
+				},
+				className
+			) }
+			data-testid="time-series-forecast-chart"
+			style={ { width, height } }
+		>
+			<XYChart
+				theme={ theme }
+				width={ width }
+				height={ chartHeight }
+				margin={ computedMargin }
+				xScale={ { type: 'time', domain: xDomain } }
+				yScale={ { type: 'linear', domain: yDomain, nice: true } }
+				pointerEventsDataKey="nearest"
+			>
+				{ gridVisibility !== 'none' && (
+					<Grid columns={ showXGrid } rows={ showYGrid } numTicks={ 4 } />
+				) }
+
+				<Axis orientation="bottom" numTicks={ 5 } tickFormat={ xAxisTickFormat } />
+				<Axis orientation="left" numTicks={ 4 } tickFormat={ yAxisTickFormat } />
+
+				{ /* Uncertainty band - rendered first (behind lines) */ }
+				{ bandData.length > 0 && (
+					<AreaSeries
+						dataKey={ seriesKeys.band }
+						data={ bandData }
+						xAccessor={ xAccessor }
+						yAccessor={ bandUpperAccessor }
+						y0Accessor={ bandLowerAccessor }
+						fill={ bandColor }
+						fillOpacity={ 0.2 }
+						renderLine={ false }
+						curve={ curveMonotoneX }
+					/>
+				) }
+
+				{ /* Historical line - solid */ }
+				{ historical.length > 0 && (
+					<AreaSeries
+						dataKey={ seriesKeys.historical }
+						data={ historical }
+						xAccessor={ xAccessor }
+						yAccessor={ yAccessor }
+						fill="transparent"
+						renderLine={ true }
+						curve={ curveMonotoneX }
+						lineProps={ { stroke: primaryColor } }
+					/>
+				) }
+
+				{ /* Forecast line - dashed */ }
+				{ forecast.length > 0 && (
+					<AreaSeries
+						dataKey={ seriesKeys.forecast }
+						data={ forecast }
+						xAccessor={ xAccessor }
+						yAccessor={ yAccessor }
+						fill="transparent"
+						renderLine={ true }
+						curve={ curveMonotoneX }
+						lineProps={ {
+							stroke: primaryColor,
+							strokeDasharray: '5 5',
+						} }
+					/>
+				) }
+
+				{ /* Vertical divider at forecast start */ }
+				{ showDivider && (
+					<ForecastDivider
+						forecastStart={ forecastStart }
+						color={ providerTheme.gridStyles?.stroke ?? '#cccccc' }
+					/>
+				) }
+
+				{ /* Tooltip */ }
+				{ showTooltip && (
+					<Tooltip
+						snapTooltipToDatumX
+						snapTooltipToDatumY
+						showSeriesGlyphs
+						renderTooltip={ tooltipRenderer }
+					/>
+				) }
+			</XYChart>
+
+			{ showLegend && (
+				<Legend
+					orientation="horizontal"
+					alignment="center"
+					position={ legendPosition }
+					className={ styles[ 'time-series-forecast-chart__legend' ] }
+					shape="line"
+					chartId={ chartId }
+					ref={ legendRef }
+					items={ legendItems }
+				/>
+			) }
+		</div>
+	);
+}
+
+/**
+ * TimeSeriesForecastChart with GlobalChartsProvider wrapper.
+ * Automatically wraps with provider if not already in one.
+ *
+ * @param props - Chart component props
+ * @return The rendered chart component with provider context
+ */
+function TimeSeriesForecastChartWithProvider< D >(
+	props: TimeSeriesForecastChartProps< D >
+): JSX.Element {
+	const existingContext = useContext( GlobalChartsContext );
+
+	if ( existingContext ) {
+		return <TimeSeriesForecastChartInternal { ...props } />;
+	}
+
+	return (
+		<GlobalChartsProvider>
+			<TimeSeriesForecastChartInternal { ...props } />
+		</GlobalChartsProvider>
+	);
+}
+
+/**
+ * TimeSeriesForecastChart - Displays historical data and forecasts with uncertainty bands
+ *
+ * Features:
+ * - Historical series rendered as a solid line
+ * - Forecast series rendered as a dashed line
+ * - Uncertainty band (shaded area) between upper/lower bounds
+ * - Vertical divider at the forecast start date
+ * - Generic data type support via accessors
+ */
+const TimeSeriesForecastChart = withResponsive(
+	TimeSeriesForecastChartWithProvider as FC< TimeSeriesForecastChartProps< unknown > >
+) as < D >(
+	props: Optional< TimeSeriesForecastChartProps< D >, 'width' | 'height' > & {
+		maxWidth?: number;
+		aspectRatio?: number;
+		resizeDebounceTime?: number;
+	}
+) => JSX.Element;
+
+/**
+ * Non-responsive version of TimeSeriesForecastChart
+ * Requires explicit width and height props
+ */
+const TimeSeriesForecastChartUnresponsive = TimeSeriesForecastChartWithProvider as < D >(
+	props: TimeSeriesForecastChartProps< D >
+) => JSX.Element;
+
+export { TimeSeriesForecastChart as default, TimeSeriesForecastChartUnresponsive };

--- a/projects/js-packages/charts/src/charts/time-series-forecast-chart/time-series-forecast-chart.tsx
+++ b/projects/js-packages/charts/src/charts/time-series-forecast-chart/time-series-forecast-chart.tsx
@@ -159,7 +159,7 @@ function TimeSeriesForecastChartInternal< D >( {
 				label: seriesKeys.forecast,
 				value: '',
 				color: primaryColor,
-				shapeStyle: { strokeDasharray: '5 5' },
+				shapeStyle: { strokeDasharray: '4 4' },
 			} );
 		}
 
@@ -340,7 +340,7 @@ function TimeSeriesForecastChartInternal< D >( {
 						curve={ curveMonotoneX }
 						lineProps={ {
 							stroke: primaryColor,
-							strokeDasharray: '5 5',
+							strokeDasharray: '4 4',
 						} }
 					/>
 				) }

--- a/projects/js-packages/charts/src/charts/time-series-forecast-chart/time-series-forecast-chart.tsx
+++ b/projects/js-packages/charts/src/charts/time-series-forecast-chart/time-series-forecast-chart.tsx
@@ -12,6 +12,9 @@ import {
 	useChartId,
 	useGlobalChartsTheme,
 } from '../../providers';
+import { attachSubComponents } from '../../utils';
+import { ChartSVG, ChartHTML, useChartChildren } from '../private/chart-composition';
+import { SingleChartContext } from '../private/single-chart-context';
 import { withResponsive } from '../private/with-responsive';
 import { ForecastDivider, useForecastData } from './private';
 import styles from './time-series-forecast-chart.module.scss';
@@ -23,6 +26,8 @@ import type {
 } from './types';
 import type { BaseLegendItem } from '../../components/legend';
 import type { Optional } from '../../types';
+import type { ChartComponentWithComposition } from '../private/chart-composition';
+import type { ResponsiveConfig } from '../private/with-responsive';
 import type { TickFormatter } from '@visx/axis';
 import type { RenderTooltipParams } from '@visx/xychart/lib/components/Tooltip';
 import type { FC } from 'react';
@@ -70,6 +75,7 @@ const formatDateTick = ( d: Date ) => {
  * @param root0.legendShape         - Shape for legend items
  * @param root0.animation           - Whether to enable chart animations
  * @param root0.gridVisibility      - Which grid lines to show (x, y, xy, or none)
+ * @param root0.children            - Children for compound composition pattern
  * @return The rendered chart component
  */
 function TimeSeriesForecastChartInternal< D >( {
@@ -97,6 +103,7 @@ function TimeSeriesForecastChartInternal< D >( {
 	legendShape = 'line',
 	animation = false,
 	gridVisibility = 'y',
+	children = null,
 }: TimeSeriesForecastChartProps< D > ) {
 	const providerTheme = useGlobalChartsTheme();
 	const chartId = useChartId( providedChartId );
@@ -177,6 +184,12 @@ function TimeSeriesForecastChartInternal< D >( {
 
 		return items;
 	}, [ historical.length, forecast.length, seriesKeys, primaryColor ] );
+
+	// Process children to extract compound components
+	const { svgChildren, htmlChildren, otherChildren } = useChartChildren(
+		children,
+		'TimeSeriesForecastChart'
+	);
 
 	// Accessors for transformed points (memoized to avoid recreating on each render)
 	const xAccessor = useCallback( ( p: TransformedForecastPoint | BandPoint ) => p.date, [] );
@@ -281,117 +294,135 @@ function TimeSeriesForecastChartInternal< D >( {
 	const showYGrid = gridVisibility === 'y' || gridVisibility === 'xy';
 
 	return (
-		<div
-			className={ clsx(
-				'time-series-forecast-chart',
-				styles[ 'time-series-forecast-chart' ],
-				{
-					[ styles[ 'time-series-forecast-chart--animated' ] ]: animation && ! prefersReducedMotion,
-					[ styles[ 'time-series-forecast-chart--legend-top' ] ]:
-						showLegend && legendPosition === 'top',
-				},
-				className
-			) }
-			data-testid="time-series-forecast-chart"
-			style={ { width, height } }
+		<SingleChartContext.Provider
+			value={ {
+				chartId,
+				chartWidth: width,
+				chartHeight,
+			} }
 		>
-			<XYChart
-				theme={ theme }
-				width={ width }
-				height={ chartHeight }
-				margin={ computedMargin }
-				xScale={ { type: 'time', domain: xDomain } }
-				yScale={ { type: 'linear', domain: yDomain, nice: true } }
-				pointerEventsDataKey="nearest"
+			<div
+				className={ clsx(
+					'time-series-forecast-chart',
+					styles[ 'time-series-forecast-chart' ],
+					{
+						[ styles[ 'time-series-forecast-chart--animated' ] ]:
+							animation && ! prefersReducedMotion,
+						[ styles[ 'time-series-forecast-chart--legend-top' ] ]:
+							showLegend && legendPosition === 'top',
+					},
+					className
+				) }
+				data-testid="time-series-forecast-chart"
+				style={ { width, height } }
 			>
-				{ gridVisibility !== 'none' && (
-					<Grid columns={ showXGrid } rows={ showYGrid } numTicks={ 4 } />
-				) }
+				<XYChart
+					theme={ theme }
+					width={ width }
+					height={ chartHeight }
+					margin={ computedMargin }
+					xScale={ { type: 'time', domain: xDomain } }
+					yScale={ { type: 'linear', domain: yDomain, nice: true } }
+					pointerEventsDataKey="nearest"
+				>
+					{ gridVisibility !== 'none' && (
+						<Grid columns={ showXGrid } rows={ showYGrid } numTicks={ 4 } />
+					) }
 
-				<Axis orientation="bottom" numTicks={ 5 } tickFormat={ xTickFormat } />
-				<Axis orientation="left" numTicks={ 4 } tickFormat={ yAxisTickFormat } />
+					<Axis orientation="bottom" numTicks={ 5 } tickFormat={ xTickFormat } />
+					<Axis orientation="left" numTicks={ 4 } tickFormat={ yAxisTickFormat } />
 
-				{ /* Uncertainty band - rendered first (behind lines) */ }
-				{ bandData.length > 0 && (
-					<AreaSeries
-						dataKey={ seriesKeys.band }
-						data={ bandData }
-						xAccessor={ xAccessor }
-						yAccessor={ bandUpperAccessor }
-						y0Accessor={ bandLowerAccessor }
-						fill={ bandColor }
-						fillOpacity={ 0.2 }
-						renderLine={ false }
-						curve={ curveMonotoneX }
+					{ /* Uncertainty band - rendered first (behind lines) */ }
+					{ bandData.length > 0 && (
+						<AreaSeries
+							dataKey={ seriesKeys.band }
+							data={ bandData }
+							xAccessor={ xAccessor }
+							yAccessor={ bandUpperAccessor }
+							y0Accessor={ bandLowerAccessor }
+							fill={ bandColor }
+							fillOpacity={ 0.2 }
+							renderLine={ false }
+							curve={ curveMonotoneX }
+						/>
+					) }
+
+					{ /* Historical line - solid */ }
+					{ historical.length > 0 && (
+						<AreaSeries
+							dataKey={ seriesKeys.historical }
+							data={ historical }
+							xAccessor={ xAccessor }
+							yAccessor={ yAccessor }
+							fill="transparent"
+							renderLine={ true }
+							curve={ curveMonotoneX }
+							lineProps={ { stroke: primaryColor } }
+						/>
+					) }
+
+					{ /* Forecast line - dashed */ }
+					{ forecast.length > 0 && (
+						<AreaSeries
+							dataKey={ seriesKeys.forecast }
+							data={ forecast }
+							xAccessor={ xAccessor }
+							yAccessor={ yAccessor }
+							fill="transparent"
+							renderLine={ true }
+							curve={ curveMonotoneX }
+							lineProps={ {
+								stroke: primaryColor,
+								strokeDasharray: '4 4',
+							} }
+						/>
+					) }
+
+					{ /* Vertical divider at forecast start */ }
+					{ showDivider && (
+						<ForecastDivider
+							forecastStart={ forecastStart }
+							color={ providerTheme.gridStyles?.stroke ?? '#cccccc' }
+						/>
+					) }
+
+					{ /* Tooltip */ }
+					{ showTooltip && (
+						<Tooltip
+							snapTooltipToDatumX
+							snapTooltipToDatumY
+							showSeriesGlyphs
+							renderTooltip={ tooltipRenderer }
+						/>
+					) }
+				</XYChart>
+
+				{ /* Render SVG children from TimeSeriesForecastChart.SVG */ }
+				{ svgChildren }
+
+				{ showLegend && (
+					<Legend
+						orientation={ legendOrientation }
+						alignment={ legendAlignment }
+						position={ legendPosition }
+						maxWidth={ legendMaxWidth }
+						textOverflow={ legendTextOverflow }
+						legendItemClassName={ legendItemClassName }
+						className={ styles[ 'time-series-forecast-chart__legend' ] }
+						shape={ legendShape }
+						chartId={ chartId }
+						ref={ legendRef }
+						items={ legendItems }
 					/>
 				) }
 
-				{ /* Historical line - solid */ }
-				{ historical.length > 0 && (
-					<AreaSeries
-						dataKey={ seriesKeys.historical }
-						data={ historical }
-						xAccessor={ xAccessor }
-						yAccessor={ yAccessor }
-						fill="transparent"
-						renderLine={ true }
-						curve={ curveMonotoneX }
-						lineProps={ { stroke: primaryColor } }
-					/>
-				) }
+				{ /* Render HTML children from TimeSeriesForecastChart.HTML */ }
+				{ htmlChildren }
 
-				{ /* Forecast line - dashed */ }
-				{ forecast.length > 0 && (
-					<AreaSeries
-						dataKey={ seriesKeys.forecast }
-						data={ forecast }
-						xAccessor={ xAccessor }
-						yAccessor={ yAccessor }
-						fill="transparent"
-						renderLine={ true }
-						curve={ curveMonotoneX }
-						lineProps={ {
-							stroke: primaryColor,
-							strokeDasharray: '4 4',
-						} }
-					/>
-				) }
-
-				{ /* Vertical divider at forecast start */ }
-				{ showDivider && (
-					<ForecastDivider
-						forecastStart={ forecastStart }
-						color={ providerTheme.gridStyles?.stroke ?? '#cccccc' }
-					/>
-				) }
-
-				{ /* Tooltip */ }
-				{ showTooltip && (
-					<Tooltip
-						snapTooltipToDatumX
-						snapTooltipToDatumY
-						showSeriesGlyphs
-						renderTooltip={ tooltipRenderer }
-					/>
-				) }
-			</XYChart>
-
-			{ showLegend && (
-				<Legend
-					orientation={ legendOrientation }
-					alignment={ legendAlignment }
-					position={ legendPosition }
-					maxWidth={ legendMaxWidth }
-					textOverflow={ legendTextOverflow }
-					legendItemClassName={ legendItemClassName }
-					className={ styles[ 'time-series-forecast-chart__legend' ] }
-					shape={ legendShape }
-					chartId={ chartId }
-					ref={ legendRef }
-					items={ legendItems }
-				/>
-			) }
-		</div>
+				{ /* Render other React children for backward compatibility */ }
+				{ otherChildren }
+			</div>
+		</SingleChartContext.Provider>
 	);
 }
 
@@ -420,6 +451,20 @@ function TimeSeriesForecastChartWithProvider< D >(
 
 TimeSeriesForecastChartWithProvider.displayName = 'TimeSeriesForecastChart';
 
+// Base props type with optional responsive properties
+type TimeSeriesForecastChartBaseProps< D > = Optional<
+	TimeSeriesForecastChartProps< D >,
+	'width' | 'height'
+>;
+
+// Composition API types
+type TimeSeriesForecastChartComponent = ChartComponentWithComposition<
+	TimeSeriesForecastChartBaseProps< unknown >
+>;
+type TimeSeriesForecastChartResponsiveComponent = ChartComponentWithComposition<
+	TimeSeriesForecastChartBaseProps< unknown > & ResponsiveConfig
+>;
+
 /**
  * TimeSeriesForecastChart - Displays historical data and forecasts with uncertainty bands
  *
@@ -430,22 +475,28 @@ TimeSeriesForecastChartWithProvider.displayName = 'TimeSeriesForecastChart';
  * - Vertical divider at the forecast start date
  * - Generic data type support via accessors
  */
-const TimeSeriesForecastChart = withResponsive(
-	TimeSeriesForecastChartWithProvider as FC< TimeSeriesForecastChartProps< unknown > >
-) as < D >(
-	props: Optional< TimeSeriesForecastChartProps< D >, 'width' | 'height' > & {
-		maxWidth?: number;
-		aspectRatio?: number;
-		resizeDebounceTime?: number;
+const TimeSeriesForecastChart = attachSubComponents(
+	withResponsive< TimeSeriesForecastChartProps< unknown > >(
+		TimeSeriesForecastChartWithProvider as FC< TimeSeriesForecastChartProps< unknown > >
+	),
+	{
+		Legend,
+		SVG: ChartSVG,
+		HTML: ChartHTML,
 	}
-) => JSX.Element;
+) as TimeSeriesForecastChartResponsiveComponent;
 
 /**
  * Non-responsive version of TimeSeriesForecastChart
  * Requires explicit width and height props
  */
-const TimeSeriesForecastChartUnresponsive = TimeSeriesForecastChartWithProvider as < D >(
-	props: TimeSeriesForecastChartProps< D >
-) => JSX.Element;
+const TimeSeriesForecastChartUnresponsive = attachSubComponents(
+	TimeSeriesForecastChartWithProvider as FC< TimeSeriesForecastChartProps< unknown > >,
+	{
+		Legend,
+		SVG: ChartSVG,
+		HTML: ChartHTML,
+	}
+) as TimeSeriesForecastChartComponent;
 
 export { TimeSeriesForecastChart as default, TimeSeriesForecastChartUnresponsive };

--- a/projects/js-packages/charts/src/charts/time-series-forecast-chart/time-series-forecast-chart.tsx
+++ b/projects/js-packages/charts/src/charts/time-series-forecast-chart/time-series-forecast-chart.tsx
@@ -245,11 +245,6 @@ function TimeSeriesForecastChartInternal< D >( {
 		return formatNumberCompact as TickFormatter< number >;
 	}, [ yTickFormat ] );
 
-	// X-axis tick formatter wrapper
-	const xAxisTickFormat = useMemo( () => {
-		return ( d: Date ) => xTickFormat( d );
-	}, [ xTickFormat ] );
-
 	// Handle empty data
 	if ( data.length === 0 ) {
 		return (
@@ -301,7 +296,7 @@ function TimeSeriesForecastChartInternal< D >( {
 					<Grid columns={ showXGrid } rows={ showYGrid } numTicks={ 4 } />
 				) }
 
-				<Axis orientation="bottom" numTicks={ 5 } tickFormat={ xAxisTickFormat } />
+				<Axis orientation="bottom" numTicks={ 5 } tickFormat={ xTickFormat } />
 				<Axis orientation="left" numTicks={ 4 } tickFormat={ yAxisTickFormat } />
 
 				{ /* Uncertainty band - rendered first (behind lines) */ }

--- a/projects/js-packages/charts/src/charts/time-series-forecast-chart/time-series-forecast-chart.tsx
+++ b/projects/js-packages/charts/src/charts/time-series-forecast-chart/time-series-forecast-chart.tsx
@@ -10,6 +10,7 @@ import {
 	GlobalChartsProvider,
 	GlobalChartsContext,
 	useChartId,
+	useChartRegistration,
 	useGlobalChartsTheme,
 } from '../../providers';
 import { attachSubComponents } from '../../utils';
@@ -190,6 +191,26 @@ function TimeSeriesForecastChartInternal< D >( {
 		children,
 		'TimeSeriesForecastChart'
 	);
+
+	// Memoize metadata to prevent unnecessary re-registration
+	const chartMetadata = useMemo(
+		() => ( {
+			forecastStart,
+			hasHistorical: historical.length > 0,
+			hasForecast: forecast.length > 0,
+			hasBand: bandData.length > 0,
+		} ),
+		[ forecastStart, historical.length, forecast.length, bandData.length ]
+	);
+
+	// Register chart with context
+	useChartRegistration( {
+		chartId,
+		legendItems,
+		chartType: 'time-series-forecast',
+		isDataValid: data.length > 0,
+		metadata: chartMetadata,
+	} );
 
 	// Accessors for transformed points (memoized to avoid recreating on each render)
 	const xAccessor = useCallback( ( p: TransformedForecastPoint | BandPoint ) => p.date, [] );

--- a/projects/js-packages/charts/src/charts/time-series-forecast-chart/time-series-forecast-chart.tsx
+++ b/projects/js-packages/charts/src/charts/time-series-forecast-chart/time-series-forecast-chart.tsx
@@ -30,9 +30,9 @@ import type { FC } from 'react';
 const DEFAULT_MARGIN = { top: 20, right: 20, bottom: 40, left: 50 };
 
 const DEFAULT_SERIES_KEYS: Required< SeriesKeys > = {
-	historical: 'Historical',
-	forecast: 'Forecast',
-	band: 'Uncertainty',
+	historical: __( 'Historical', 'jetpack-charts' ),
+	forecast: __( 'Forecast', 'jetpack-charts' ),
+	band: __( 'Uncertainty', 'jetpack-charts' ),
 };
 
 const formatDateTick = ( d: Date ) => {

--- a/projects/js-packages/charts/src/charts/time-series-forecast-chart/time-series-forecast-chart.tsx
+++ b/projects/js-packages/charts/src/charts/time-series-forecast-chart/time-series-forecast-chart.tsx
@@ -418,6 +418,8 @@ function TimeSeriesForecastChartWithProvider< D >(
 	);
 }
 
+TimeSeriesForecastChartWithProvider.displayName = 'TimeSeriesForecastChart';
+
 /**
  * TimeSeriesForecastChart - Displays historical data and forecasts with uncertainty bands
  *

--- a/projects/js-packages/charts/src/charts/time-series-forecast-chart/types.ts
+++ b/projects/js-packages/charts/src/charts/time-series-forecast-chart/types.ts
@@ -1,0 +1,174 @@
+import type { ReactNode } from 'react';
+
+/**
+ * Generic accessor type for extracting values from datum
+ */
+export type Accessor< D, R > = ( d: D, index: number ) => R;
+
+/**
+ * Accessors for extracting values from generic datum
+ */
+export type TimeSeriesForecastAccessors< D > = {
+	/**
+	 * Accessor function to extract the x-axis date value from each datum
+	 */
+	x: Accessor< D, Date >;
+	/**
+	 * Accessor function to extract the y-axis numeric value from each datum
+	 */
+	y: Accessor< D, number >;
+	/**
+	 * Optional accessor function to extract the lower bound of the forecast uncertainty
+	 */
+	yLower?: Accessor< D, number | null | undefined >;
+	/**
+	 * Optional accessor function to extract the upper bound of the forecast uncertainty
+	 */
+	yUpper?: Accessor< D, number | null | undefined >;
+};
+
+/**
+ * Series key labels for legend/tooltip
+ */
+export type SeriesKeys = {
+	/**
+	 * Label for the historical series. Default: 'Historical'
+	 */
+	historical?: string;
+	/**
+	 * Label for the forecast series. Default: 'Forecast'
+	 */
+	forecast?: string;
+	/**
+	 * Label for the uncertainty band. Default: 'Uncertainty'
+	 */
+	band?: string;
+};
+
+/**
+ * Internal transformed point (used after accessor extraction)
+ */
+export type TransformedForecastPoint = {
+	date: Date;
+	value: number;
+	lower: number | null;
+	upper: number | null;
+	originalIndex: number;
+};
+
+/**
+ * Band point with guaranteed bounds
+ */
+export type BandPoint = {
+	date: Date;
+	lower: number;
+	upper: number;
+};
+
+/**
+ * Tooltip params passed to custom tooltip renderer
+ */
+export interface ForecastTooltipParams< D > {
+	/**
+	 * The nearest datum to the cursor
+	 */
+	nearest: D;
+	/**
+	 * The x-axis date value
+	 */
+	x: Date;
+	/**
+	 * The y-axis numeric value
+	 */
+	y: number;
+	/**
+	 * The lower bound of the forecast uncertainty (if available)
+	 */
+	yLower?: number;
+	/**
+	 * The upper bound of the forecast uncertainty (if available)
+	 */
+	yUpper?: number;
+	/**
+	 * Whether this point is in the forecast region
+	 */
+	isForecast: boolean;
+}
+
+/**
+ * Main component props (generic over datum type D)
+ */
+export interface TimeSeriesForecastChartProps< D > {
+	/**
+	 * Array of data points to display in the chart
+	 */
+	data: readonly D[];
+	/**
+	 * Accessor functions to extract values from each datum
+	 */
+	accessors: TimeSeriesForecastAccessors< D >;
+	/**
+	 * The date at which the forecast begins
+	 */
+	forecastStart: Date;
+	/**
+	 * Height of the chart in pixels
+	 */
+	height: number;
+	/**
+	 * Width of the chart in pixels
+	 */
+	width?: number;
+	/**
+	 * Chart margins
+	 */
+	margin?: { top?: number; right?: number; bottom?: number; left?: number };
+	/**
+	 * Fixed y-axis domain [min, max]
+	 */
+	yDomain?: [ number, number ];
+	/**
+	 * Custom formatter for x-axis tick labels
+	 */
+	xTickFormat?: ( d: Date ) => string;
+	/**
+	 * Custom formatter for y-axis tick labels
+	 */
+	yTickFormat?: ( n: number ) => string;
+	/**
+	 * Whether to show tooltips on hover. Default: true
+	 */
+	showTooltip?: boolean;
+	/**
+	 * Custom labels for series in legend and tooltip
+	 */
+	seriesKeys?: SeriesKeys;
+	/**
+	 * Custom tooltip renderer
+	 */
+	renderTooltip?: ( params: ForecastTooltipParams< D > ) => ReactNode;
+	/**
+	 * Additional CSS class name for the chart container
+	 */
+	className?: string;
+	/**
+	 * Optional unique identifier for the chart
+	 */
+	chartId?: string;
+	/**
+	 * Whether to show the legend. Default: false
+	 */
+	showLegend?: boolean;
+	/**
+	 * Legend position. Default: 'bottom'
+	 */
+	legendPosition?: 'top' | 'bottom';
+	/**
+	 * Whether to animate the chart on initial render. Default: false
+	 */
+	animation?: boolean;
+	/**
+	 * Grid visibility. Default: 'y'
+	 */
+	gridVisibility?: 'x' | 'y' | 'xy' | 'none';
+}

--- a/projects/js-packages/charts/src/charts/time-series-forecast-chart/types.ts
+++ b/projects/js-packages/charts/src/charts/time-series-forecast-chart/types.ts
@@ -199,4 +199,9 @@ export interface TimeSeriesForecastChartProps< D > {
 	 * Grid visibility. Default: 'y'
 	 */
 	gridVisibility?: 'x' | 'y' | 'xy' | 'none';
+	/**
+	 * Children for compound composition pattern.
+	 * Use TimeSeriesForecastChart.SVG for SVG children and TimeSeriesForecastChart.HTML for HTML children.
+	 */
+	children?: ReactNode;
 }

--- a/projects/js-packages/charts/src/charts/time-series-forecast-chart/types.ts
+++ b/projects/js-packages/charts/src/charts/time-series-forecast-chart/types.ts
@@ -1,3 +1,4 @@
+import type { LegendShape } from '@visx/legend/lib/types';
 import type { ReactNode } from 'react';
 
 /**
@@ -160,9 +161,36 @@ export interface TimeSeriesForecastChartProps< D > {
 	 */
 	showLegend?: boolean;
 	/**
+	 * Legend orientation. Default: 'horizontal'
+	 */
+	legendOrientation?: 'horizontal' | 'vertical';
+	/**
 	 * Legend position. Default: 'bottom'
 	 */
 	legendPosition?: 'top' | 'bottom';
+	/**
+	 * Legend alignment within its position. Default: 'center'
+	 */
+	legendAlignment?: 'start' | 'center' | 'end';
+	/**
+	 * Maximum width for legend items. When set, text overflow behavior is controlled by legendTextOverflow.
+	 * Should be a CSS value string (e.g. '200px', '50%', '10rem')
+	 */
+	legendMaxWidth?: string;
+	/**
+	 * Controls how text behaves when it exceeds legendMaxWidth.
+	 * - 'ellipsis': Truncate with ellipsis
+	 * - 'wrap': Wrap text to multiple lines (default)
+	 */
+	legendTextOverflow?: 'ellipsis' | 'wrap';
+	/**
+	 * Additional CSS class name for legend items.
+	 */
+	legendItemClassName?: string;
+	/**
+	 * Legend shape. Default: 'line'
+	 */
+	legendShape?: LegendShape< D, number >;
 	/**
 	 * Whether to animate the chart on initial render. Default: false
 	 */

--- a/projects/js-packages/charts/src/index.ts
+++ b/projects/js-packages/charts/src/index.ts
@@ -8,6 +8,10 @@ export { LineChart, LineChartUnresponsive } from './charts/line-chart';
 export { PieChart, PieChartUnresponsive } from './charts/pie-chart';
 export { PieSemiCircleChart, PieSemiCircleChartUnresponsive } from './charts/pie-semi-circle-chart';
 export { Sparkline, SparklineUnresponsive } from './charts/sparkline';
+export {
+	TimeSeriesForecastChart,
+	TimeSeriesForecastChartUnresponsive,
+} from './charts/time-series-forecast-chart';
 
 // Components
 export { BaseTooltip } from './components/tooltip';
@@ -35,6 +39,10 @@ export type { PieChartProps } from './charts/pie-chart';
 export type { GeoChartProps, GeoRegion, GeoResolution } from './charts/geo-chart';
 export type { LegendValueDisplay, BaseLegendItem } from './components/legend';
 export type { TrendIndicatorProps, TrendDirection } from './components/trend-indicator';
+export type {
+	TimeSeriesForecastChartProps,
+	TimeSeriesForecastAccessors,
+} from './charts/time-series-forecast-chart';
 export type { LineStyles, GridStyles, EventHandlerParams } from '@visx/xychart';
 export type {
 	GoogleDataTableColumn,


### PR DESCRIPTION
## Proposed changes

This PR introduces the `TimeSeriesForecastChart` component - a specialized chart for displaying historical data alongside forecasted values with uncertainty bands.

### Key Features
- **Historical and forecast data visualization**: Displays historical data as a solid line and forecast data as a dashed line
- **Uncertainty bands**: Shaded area representing the forecast confidence interval between lower and upper bounds
- **Forecast divider**: Vertical dashed line marking the transition from historical to forecast data
- **Generic data support**: Accepts any data shape via accessor functions
- **Compound composition pattern**: Supports `TimeSeriesForecastChart.SVG` and `TimeSeriesForecastChart.HTML` for custom children
- **Full legend prop parity**: Supports all standard legend props (orientation, alignment, maxWidth, textOverflow, etc.)
- **Responsive design**: Auto-resizes with `withResponsive` HOC
- **Animation support**: Optional entrance animation respecting prefers-reduced-motion
- **Customizable tooltips**: Default tooltip with custom renderer support
- **i18n support**: Default series labels are translatable

## Other information

The component follows existing patterns in the charts library:
- Uses `useChartRegistration` for chart registry (consistent with other charts)
- Implements compound composition using `attachSubComponents` and `useChartChildren`
- Integrates with `SingleChartContext` for state sharing
- Follows BEM CSS naming conventions

## Jetpack product changes

No changes to existing Jetpack functionality. This adds a new chart component to the charts library.


<!-- IGNORE - FOR AUTOMATTIC USE ONLY -->
### Does this pull request change what data or activity we track or use?

no