### PR TITLE
Disable VideoPress buttons when VideoPress requires an upgrade

### DIFF
--- a/projects/plugins/jetpack/changelog/update-disable-videopress-when-plan-missing
+++ b/projects/plugins/jetpack/changelog/update-disable-videopress-when-plan-missing
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+VideoPress when requiring an upgrade would display working buttons. They're now disabled

--- a/projects/plugins/jetpack/changelog/update-disable-videopress-when-plan-missing
+++ b/projects/plugins/jetpack/changelog/update-disable-videopress-when-plan-missing
@@ -1,4 +1,4 @@
 Significance: minor
 Type: other
 
-VideoPress when requiring an upgrade would display working buttons. They're now disabled
+Disable buttons on VideoPress block renders that require an upgrade to function

--- a/projects/plugins/jetpack/extensions/blocks/videopress/editor.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/editor.js
@@ -11,6 +11,7 @@ import { createBlobURL } from '@wordpress/blob';
 import { useBlockEditContext, store as blockEditorStore } from '@wordpress/block-editor';
 import { parse } from '@wordpress/block-serialization-default-parser';
 import { createBlock, getBlockType } from '@wordpress/blocks';
+import { Button } from '@wordpress/components';
 import { createHigherOrderComponent } from '@wordpress/compose';
 import { useDispatch, select } from '@wordpress/data';
 import { mediaUpload, store as editorStore } from '@wordpress/editor';
@@ -41,17 +42,28 @@ const videoPressNoPlanMediaPlaceholder = createHigherOrderComponent(
 			return <OriginalPlaceholder { ...props } />;
 		}
 
-		// Disable upload functionality while preserving the rest of the UI (including upsell banners).
-		// We intercept selection handlers to prevent any action.
 		return (
 			<OriginalPlaceholder
 				{ ...props }
-				className={ `${ props.className || '' } no-videopress-media-placeholder`.trim() }
 				disableDropZone={ true }
-				handleUpload={ false }
-				onSelect={ () => {} }
-				onSelectURL={ () => {} }
-			/>
+				className="no-videopress-media-placeholder"
+			>
+				<Button
+					disabled={ true }
+					className="components-button no-videopress-disabled-button"
+					variant="secondary"
+				>
+					{ __( 'Media Library', 'jetpack' ) }
+				</Button>
+
+				<Button
+					disabled={ true }
+					className="components-button no-videopress-disabled-button"
+					variant="secondary"
+				>
+					{ __( 'Upload', 'jetpack' ) }
+				</Button>
+			</OriginalPlaceholder>
 		);
 	},
 	'videoPressNoPlanMediaPlaceholder'

--- a/projects/plugins/jetpack/extensions/blocks/videopress/editor.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/editor.js
@@ -11,7 +11,6 @@ import { createBlobURL } from '@wordpress/blob';
 import { useBlockEditContext, store as blockEditorStore } from '@wordpress/block-editor';
 import { parse } from '@wordpress/block-serialization-default-parser';
 import { createBlock, getBlockType } from '@wordpress/blocks';
-import { Button } from '@wordpress/components';
 import { createHigherOrderComponent } from '@wordpress/compose';
 import { useDispatch, select } from '@wordpress/data';
 import { mediaUpload, store as editorStore } from '@wordpress/editor';
@@ -37,32 +36,22 @@ import './editor.scss';
 const videoPressNoPlanMediaPlaceholder = createHigherOrderComponent(
 	OriginalPlaceholder => props => {
 		const { name } = useBlockEditContext();
-		if ( name !== 'core/video' ) {
+		// Apply to both core/video and videopress/video blocks
+		if ( name !== 'core/video' && name !== 'videopress/video' ) {
 			return <OriginalPlaceholder { ...props } />;
 		}
 
+		// Disable upload functionality while preserving the rest of the UI (including upsell banners).
+		// We intercept selection handlers to prevent any action.
 		return (
 			<OriginalPlaceholder
 				{ ...props }
+				className={ `${ props.className || '' } no-videopress-media-placeholder`.trim() }
 				disableDropZone={ true }
-				className="no-videopress-media-placeholder"
-			>
-				<Button
-					disabled={ true }
-					className="components-button no-videopress-disabled-button"
-					variant="secondary"
-				>
-					{ __( 'Media Library', 'jetpack' ) }
-				</Button>
-
-				<Button
-					disabled={ true }
-					className="components-button no-videopress-disabled-button"
-					variant="secondary"
-				>
-					{ __( 'Upload', 'jetpack' ) }
-				</Button>
-			</OriginalPlaceholder>
+				handleUpload={ false }
+				onSelect={ () => {} }
+				onSelectURL={ () => {} }
+			/>
 		);
 	},
 	'videoPressNoPlanMediaPlaceholder'
@@ -411,6 +400,54 @@ addFilter(
 	'blocks.registerBlockType',
 	'videopress/add-v6-transform-support',
 	addV6TransformSupport
+);
+
+/**
+ * Handle videopress/video block unavailability.
+ * When the block is unavailable due to missing plan, add a filter to disable
+ * the upload buttons in the MediaPlaceholder.
+ *
+ * @param {object} settings - Block settings.
+ * @param {string} name     - Block name.
+ * @return {object} Modified block settings.
+ */
+function handleVideoPressVideoUnavailability( settings, name ) {
+	// Only apply to videopress/video block.
+	if ( name !== 'videopress/video' ) {
+		return settings;
+	}
+
+	const { available, unavailableReason } = getJetpackExtensionAvailability( 'videopress/video' );
+
+	// If available, don't modify.
+	if ( available ) {
+		return settings;
+	}
+
+	// Check if unavailable due to missing plan on WPCOM.
+	const isUnavailableDueToMissingPlan =
+		isWpcomPlatformSite() && [ 'missing_plan', 'unknown' ].includes( unavailableReason );
+
+	if ( ! isUnavailableDueToMissingPlan ) {
+		return settings;
+	}
+
+	// Add the filter to disable upload buttons in the MediaPlaceholder for videopress/video blocks.
+	addFilter(
+		'editor.MediaPlaceholder',
+		'jetpack/videopress-video-no-plan',
+		videoPressNoPlanMediaPlaceholder
+	);
+
+	return settings;
+}
+
+addFilter(
+	'blocks.registerBlockType',
+	'videopress/handle-unavailability',
+	handleVideoPressVideoUnavailability,
+	// Use priority 20 to run after the block is registered but before other modifications.
+	20
 );
 
 /**

--- a/projects/plugins/jetpack/extensions/blocks/videopress/editor.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/editor.js
@@ -451,6 +451,13 @@ function handleVideoPressVideoUnavailability( settings, name ) {
 		videoPressNoPlanMediaPlaceholder
 	);
 
+	// Add the warning/interactive class names filter for visual consistency with core/video.
+	addFilter(
+		'editor.BlockListBlock',
+		'jetpack/videopress-video-with-has-warning-is-interactive-class-names',
+		withHasWarningIsInteractiveClassNames( 'videopress/video' )
+	);
+
 	return settings;
 }
 

--- a/projects/plugins/jetpack/extensions/blocks/videopress/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/editor.scss
@@ -3,19 +3,21 @@
 .no-videopress-media-placeholder {
 
 	.components-placeholder__fieldset {
-		// Make buttons appear disabled.
-		// They won't do anything because onSelect handlers are intercepted.
+		flex-direction: row-reverse;
+		align-items: flex-start;
+		justify-content: flex-end;
+
 		button {
-			opacity: 0.5;
-			pointer-events: none;
-			cursor: not-allowed;
+			display: none;
 		}
 
-		// But keep the URL input container buttons functional.
-		.block-editor-media-placeholder__url-input-container button {
-			opacity: 1;
-			pointer-events: auto;
-			cursor: pointer;
+		.block-editor-media-placeholder__url-input-container button,
+		.no-videopress-disabled-button {
+			display: inline-flex;
+		}
+
+		.no-videopress-disabled-button:last-child {
+			margin-right: 12px;
 		}
 	}
 }

--- a/projects/plugins/jetpack/extensions/blocks/videopress/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/editor.scss
@@ -3,21 +3,19 @@
 .no-videopress-media-placeholder {
 
 	.components-placeholder__fieldset {
-		flex-direction: row-reverse;
-		align-items: flex-start;
-		justify-content: flex-end;
-
+		// Make buttons appear disabled.
+		// They won't do anything because onSelect handlers are intercepted.
 		button {
-			display: none;
+			opacity: 0.5;
+			pointer-events: none;
+			cursor: not-allowed;
 		}
 
-		.block-editor-media-placeholder__url-input-container button,
-		.no-videopress-disabled-button {
-			display: inline-flex;
-		}
-
-		.no-videopress-disabled-button:last-child {
-			margin-right: 12px;
+		// But keep the URL input container buttons functional.
+		.block-editor-media-placeholder__url-input-container button {
+			opacity: 1;
+			pointer-events: auto;
+			cursor: pointer;
 		}
 	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes DOTCOM-15860

## Proposed changes:

* Blocks that require an upgrade display a black upgrade banner on top but overall, do not appear disabled because they normally don't work.
* However, VideoPress has a file upload button and we don't want people to attempt uploading files

As a result of this change, VideoPress with gating-business-q1 WoA sites on Premium will see this:


<img width="1019" height="539" alt="Screenshot 2026-01-29 at 16 42 12" src="https://github.com/user-attachments/assets/9e994425-9e09-47e6-857c-b0e556b5abd6" />


After this PR is merged:
<img width="1019" height="539" alt="Screenshot 2026-01-29 at 16 39 22" src="https://github.com/user-attachments/assets/73c46f3d-0a52-469e-bbf5-fa6930fe9ab9" />



### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:

* Create a WoA dev blog with Business, save the ftp password, and then switch the plan to Premium
* From the blog report card, add it the sticker (right at the bottom) `gating-business-q1`
* Attempt to use VideoPress

Note that the styles are now matching the core/video block when an upgrade is required.


