### PR TITLE
tools: update-stubs.sh should update `php-stubs/*` composer packages too

### DIFF
--- a/tools/stubs/update-stubs.sh
+++ b/tools/stubs/update-stubs.sh
@@ -144,3 +144,6 @@ echo
 info 'Extracting Gutenberg stubs'
 "$BASE/projects/packages/stub-generator/vendor/bin/jetpack-stub-generator" --output "$BASE/.phan/stubs/gutenberg-stubs.php" "$BASE/tools/stubs/gutenberg-stub-defs.php"
 
+echo
+info 'Updating composer stub packages'
+composer --working-dir="$BASE" update 'php-stubs/*'


### PR DESCRIPTION
Closes MONOREP-330

 <!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Probably better to handle these along with the rest of the stub updates, instead of waiting for the monthly Renovate lockfile update.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Revert composer.lock to the version from before 7fd92c0383f104eb454445be75a55b8ec5a303cd, then run the script and see if only the php-stubs packages get updated.
