### PR TITLE
 Forms: Fix data normalization on dashboard

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-wp-build-dashboard-inbox-data-normalize
+++ b/projects/packages/forms/changelog/fix-forms-wp-build-dashboard-inbox-data-normalize
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: Fix data normalization on dashboard

--- a/projects/packages/forms/src/dashboard/hooks/use-inbox-data.ts
+++ b/projects/packages/forms/src/dashboard/hooks/use-inbox-data.ts
@@ -8,12 +8,13 @@ import { decodeEntities } from '@wordpress/html-entities';
 /**
  * Internal dependencies
  */
+import { isCollectionFormatField } from '../components/inspector/utils.ts';
 import { useDashboardSearchParams } from '../router/dashboard-search-params-context.tsx';
 import { store as dashboardStore } from '../store/index.js';
 /**
  * Types
  */
-import type { FormResponse, ResponseField } from '../../types/index.ts';
+import type { FormResponse, ResponseField, ResponseFields } from '../../types/index.ts';
 
 /**
  * Helper function to get the status filter to apply from the URL.
@@ -72,23 +73,26 @@ const decodeValue = ( value: unknown ): unknown => {
 const hasOwn = ( obj: object, key: PropertyKey ): boolean =>
 	Object.prototype.hasOwnProperty.call( obj, key );
 
-const normalizeFieldsForDisplay = ( fields: ResponseField[] ): Record< string, unknown > => {
+const normalizeFieldsForDisplay = ( fields: ResponseField[] ): ResponseFields => {
 	if ( ! fields || ! Array.isArray( fields ) ) {
 		return Object.create( null ) as Record< string, unknown >;
 	}
 
-	return fields.reduce(
-		( accumulator, field ) => {
-			const baseLabel = field.label || formatFieldName( field.key ) || field.key;
-			let label = baseLabel;
+	if ( isCollectionFormatField( fields[ 0 ] ) ) {
+		return fields;
+	}
+
+	return Object.entries( fields || {} ).reduce(
+		( accumulator, [ key, value ] ) => {
+			let _key = formatFieldName( key );
 			let counter = 2;
 
-			while ( hasOwn( accumulator, label ) ) {
-				label = `${ baseLabel } (${ counter })`;
+			while ( hasOwn( accumulator, _key ) ) {
+				_key = `${ formatFieldName( key ) } (${ counter })`;
 				counter++;
 			}
 
-			accumulator[ label ] = formatFieldValue( decodeValue( field.value ) );
+			accumulator[ _key ] = formatFieldValue( decodeValue( value ) );
 
 			return accumulator;
 		},


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes a bug introduced in #46808

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the current dashboard and open a response
* Check that the response data is displayed with visual enhancements added recently

| Before | After |
| - | - |
| <img width="440" height="503" alt="Screenshot from 2026-01-29 13-11-39" src="https://github.com/user-attachments/assets/bd84bbbe-9d1a-40ce-a05e-f81352ba0f4c" /> | <img width="440" height="503" alt="Screenshot from 2026-01-29 13-11-25" src="https://github.com/user-attachments/assets/88c9e866-9800-47c3-a392-f7c590080dac" />

