### PR TITLE
Forms: Add gating for integrations feature

### DIFF
--- a/projects/packages/forms/changelog/add-forms-integrations-gating
+++ b/projects/packages/forms/changelog/add-forms-integrations-gating
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Gating for the Forms Integrations feature

--- a/projects/plugins/wpcomsh/changelog/add-forms-integrations-gating
+++ b/projects/plugins/wpcomsh/changelog/add-forms-integrations-gating
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Gating for the Forms Integrations feature

--- a/projects/plugins/wpcomsh/feature-plugins/hooks.php
+++ b/projects/plugins/wpcomsh/feature-plugins/hooks.php
@@ -382,6 +382,16 @@ function wpcomsh_gate_footer_credit_feature() {
 add_filter( 'wpcom_better_footer_credit_can_customize', 'wpcomsh_gate_footer_credit_feature' );
 
 /**
+ * Controls whether Jetpack Forms integrations feature is enabled based on site plan.
+ *
+ * @return bool
+ */
+function wpcomsh_gate_jetpack_forms_integrations() {
+	return wpcom_site_has_feature( WPCOM_Features::FORM_INTEGRATIONS );
+}
+add_filter( 'jetpack_forms_is_integrations_enabled', 'wpcomsh_gate_jetpack_forms_integrations' );
+
+/**
  * Remove the Jetpack > Dashboard menu if the site doesn't have the required feature.
  */
 function wpcomsh_maybe_remove_jetpack_dashboard_menu_item() {

--- a/projects/plugins/wpcomsh/wpcom-features/class-wpcom-features.php
+++ b/projects/plugins/wpcomsh/wpcom-features/class-wpcom-features.php
@@ -417,6 +417,7 @@ class WPCOM_Features {
 	public const EMAIL_SUBSCRIPTION                = 'email-subscription';
 	public const EMAIL_FORWARDS_EXTENDED_LIMIT     = 'email-forwards-extended-limit';
 	public const FIELD_FILE                        = 'field-file';
+	public const FORM_INTEGRATIONS                 = 'form-integrations';
 	public const FORM_WEBHOOKS                     = 'form-webhooks';
 	public const FREE_BLOG                         = 'free-blog';
 	public const FULL_ACTIVITY_LOG                 = 'full-activity-log';
@@ -814,6 +815,15 @@ class WPCOM_Features {
 			self::WPCOM_PRO_PLANS,
 			self::WPCOM_BUSINESS_AND_HIGHER_PLANS,
 			self::JETPACK_COMPLETE_PLANS,
+		),
+		self::FORM_INTEGRATIONS                 => array(
+			array(
+				'sticker_not_present' => 'gating-business-q1',
+				self::WPCOM_PERSONAL_AND_HIGHER_PLANS,
+			),
+			self::WPCOM_PRO_PLANS,
+			self::WPCOM_BUSINESS_AND_HIGHER_PLANS,
+			self::JETPACK_ALL_SITES,
 		),
 		self::FORM_WEBHOOKS                     => array(
 			self::WPCOM_BUSINESS_AND_HIGHER_PLANS,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes DOTCOM-15856

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Only show the Integrations feature on Business/Commerce plans when the gating sticker is present.

|Before|After|
|---|---|
|<img width="431" height="118" alt="Screenshot 2026-01-29 at 18 17 28" src="https://github.com/user-attachments/assets/73d2d68a-299f-492f-a2c1-fbf813d6ed89" />|<img width="431" height="118" alt="Screenshot 2026-01-29 at 18 18 01" src="https://github.com/user-attachments/assets/be30efe3-daa0-462e-9927-83ceee42729c" />|

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a new Personal site. Make sure hat `gating-business-q1` sticker is not set.
* On WPCOM, confirm that Jetpack->Forms->Inbox doesn't show the 'Manage Integrations' button.
* Install a plugin to switch to Atomic.
* Confirm that the button is now visible.
* Enable the sticker and confirm that the button is not present.
* Upgrade to Business and confirm that the button is present once again.

