### PR TITLE
Forms: add forms route to wp-build dashboard

### DIFF
--- a/projects/packages/forms/changelog/add-wp-build-forms-route
+++ b/projects/packages/forms/changelog/add-wp-build-forms-route
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Forms: add forms list to wp-build dashboard.

--- a/projects/packages/forms/routes/forms/package.json
+++ b/projects/packages/forms/routes/forms/package.json
@@ -1,0 +1,22 @@
+{
+	"name": "_@jetpack-forms/forms-route",
+	"version": "1.0.0",
+	"private": true,
+	"dependencies": {
+		"@automattic/jetpack-components": "workspace:*",
+		"@base-ui-components/react": "^1.0.0-beta.4",
+		"@types/react": "18.3.26",
+		"@wordpress/admin-ui": "1.6.0",
+		"@wordpress/dataviews": "11.2.0",
+		"@wordpress/element": "6.38.0",
+		"@wordpress/i18n": "6.11.0",
+		"@wordpress/icons": "11.5.0",
+		"@wordpress/route": "0.4.0",
+		"@wordpress/ui": "0.5.0",
+		"clsx": "2.1.1"
+	},
+	"route": {
+		"path": "/forms",
+		"page": "jetpack-forms-responses"
+	}
+}

--- a/projects/packages/forms/routes/forms/stage.tsx
+++ b/projects/packages/forms/routes/forms/stage.tsx
@@ -1,0 +1,42 @@
+/**
+ * External dependencies
+ */
+import JetpackLogo from '@automattic/jetpack-components/jetpack-logo';
+/**
+ * WordPress dependencies
+ */
+import { Page } from '@wordpress/admin-ui';
+import { __ } from '@wordpress/i18n';
+import { Stack } from '@wordpress/ui';
+import * as React from 'react';
+/**
+ * Internal dependencies
+ */
+import DataViewsHeaderRow from '../../src/dashboard/wp-build/components/dataviews-header-row';
+
+/**
+ * Placeholder stage for the Forms list route (wp-build).
+ *
+ * @return The stage component.
+ */
+function Stage() {
+	return (
+		<Page
+			showSidebarToggle={ false }
+			title={
+				<Stack align="center" gap="xs">
+					<JetpackLogo showText={ false } width={ 20 } />
+					{ __( 'Forms', 'jetpack-forms' ) }
+				</Stack>
+			}
+			subTitle={ __( 'View and manage all your forms in one place.', 'jetpack-forms' ) }
+		>
+			<DataViewsHeaderRow activeTab="forms" />
+			<Stack direction="column" gap="sm">
+				<h3>{ __( 'Forms list placeholder page.', 'jetpack-forms' ) }</h3>
+			</Stack>
+		</Page>
+	);
+}
+
+export { Stage as stage };

--- a/projects/packages/forms/routes/forms/stage.tsx
+++ b/projects/packages/forms/routes/forms/stage.tsx
@@ -33,7 +33,7 @@ function Stage() {
 		>
 			<DataViewsHeaderRow activeTab="forms" />
 			<Stack direction="column" gap="sm">
-				<h3>{ __( 'Forms list placeholder page.', 'jetpack-forms' ) }</h3>
+				<h3>Forms list placeholder page.</h3>
 			</Stack>
 		</Page>
 	);

--- a/projects/packages/forms/routes/responses/stage.tsx
+++ b/projects/packages/forms/routes/responses/stage.tsx
@@ -31,12 +31,12 @@ import EmptyResponses from '../../src/dashboard/components/empty-responses';
 import EmptySpamButton from '../../src/dashboard/components/empty-spam-button';
 import EmptyTrashButton from '../../src/dashboard/components/empty-trash-button';
 import Gravatar from '../../src/dashboard/components/gravatar';
-import * as Tabs from '../../src/dashboard/components/tabs';
 import TextWithFlag from '../../src/dashboard/components/text-with-flag/index.tsx';
 import useCreateForm from '../../src/dashboard/hooks/use-create-form';
 import useInboxData from '../../src/dashboard/hooks/use-inbox-data.ts';
 import { getPath } from '../../src/dashboard/inbox/utils';
 import WpRouteDashboardSearchParamsProvider from '../../src/dashboard/router/wp-route-dashboard-search-params-provider.tsx';
+import DataViewsHeaderRow from '../../src/dashboard/wp-build/components/dataviews-header-row';
 import useConfigValue from '../../src/hooks/use-config-value';
 import { INTEGRATIONS_STORE, IntegrationsSelectors } from '../../src/store/integrations';
 import { getActions } from './actions';
@@ -62,24 +62,6 @@ type FeedbackFilters = {
 	date: FeedbackFilterDate[];
 	source: FeedbackFilterSource[];
 };
-
-/**
- * Returns a formatted tab label with count badge.
- *
- * @param label - The label for the tab.
- * @param count - The count to display.
- * @return The formatted label with count badge.
- */
-function getTabLabel( label: string, count: number ): JSX.Element {
-	return (
-		<Stack align="center" gap="2xs">
-			{ label }
-			<Badge intent="default" style={ { backgroundColor: '#f0f0f0' } }>
-				{ count.toString() }
-			</Badge>
-		</Stack>
-	);
-}
 
 const EMPTY_ARRAY = [];
 
@@ -188,9 +170,6 @@ function StageInner() {
 		isLoadingData,
 		totalItems,
 		totalPages,
-		totalItemsInbox,
-		totalItemsSpam,
-		totalItemsTrash,
 	} = useInboxData( { status: statusView } );
 
 	useEffect( () => {
@@ -202,6 +181,24 @@ function StageInner() {
 
 	const onChangeView = useCallback(
 		( newView: View ) => {
+			// If the Folder filter changes (CFM-on behavior), treat it as a route param change.
+			const folderValue =
+				newView.filters?.find( filter => filter.field === 'folder' )?.value || 'inbox';
+
+			if ( folderValue !== statusView ) {
+				// Clear selection when changing folder to avoid mismatched inspector state.
+				navigate( {
+					to: '/responses/$view',
+					params: { view: folderValue },
+					search: {
+						...searchParams,
+						responseIds: undefined,
+					},
+				} );
+				setView( { ...newView, page: 1 } );
+				return;
+			}
+
 			setView( newView );
 
 			if ( newView.search !== view.search ) {
@@ -213,7 +210,7 @@ function StageInner() {
 				} );
 			}
 		},
-		[ navigate, searchParams, view.search ]
+		[ navigate, searchParams, statusView, view.search ]
 	);
 
 	const onChangeSelection = useCallback(
@@ -227,6 +224,24 @@ function StageInner() {
 		},
 		[ searchParams, navigate ]
 	);
+
+	// Keep the Folder filter in sync with the route param (CFM-on behavior).
+	useEffect( () => {
+		setView( previousView => {
+			const previousFilters = previousView.filters || [];
+			const existing = previousFilters.find( filter => filter.field === 'folder' );
+			if ( existing?.value === statusView ) {
+				return previousView;
+			}
+			return {
+				...previousView,
+				filters: [
+					{ field: 'folder', operator: 'is', value: statusView },
+					...previousFilters.filter( filter => filter.field !== 'folder' ),
+				],
+			};
+		} );
+	}, [ setView, statusView ] );
 
 	const queryParams = useMemo( () => {
 		const queryArgs: QueryParams = {
@@ -277,6 +292,22 @@ function StageInner() {
 
 	const fields: Field< FormResponse >[] = useMemo(
 		() => [
+			{
+				id: 'folder',
+				label: __( 'Folder', 'jetpack-forms' ),
+				elements: [
+					{ label: __( 'Inbox', 'jetpack-forms' ), value: 'inbox' },
+					{ label: __( 'Spam', 'jetpack-forms' ), value: 'spam' },
+					{ label: __( 'Trash', 'jetpack-forms' ), value: 'trash' },
+				],
+				// Primary so the filter UI (and its pill) is visible by default.
+				filterBy: { operators: [ 'is' ], isPrimary: true },
+				enableSorting: false,
+				enableHiding: false,
+				// Filter-only field; not shown as a column.
+				render: () => null,
+				getValue: () => null,
+			},
 			{
 				id: 'from',
 				label: __( 'From', 'jetpack-forms' ),
@@ -418,9 +449,9 @@ function StageInner() {
 			getActions( {
 				navigate,
 				searchParams,
-				view: params.view,
+				view: statusView,
 			} ),
-		[ navigate, searchParams, params.view ]
+		[ navigate, searchParams, statusView ]
 	);
 
 	const paginationInfo = useMemo(
@@ -429,22 +460,6 @@ function StageInner() {
 			totalPages: totalPages || 1,
 		} ),
 		[ totalItems, totalPages ]
-	);
-
-	const statusTabs = [
-		{ slug: 'inbox', label: getTabLabel( __( 'Inbox', 'jetpack-forms' ), totalItemsInbox ) },
-		{ slug: 'spam', label: getTabLabel( __( 'Spam', 'jetpack-forms' ), totalItemsSpam ) },
-		{ slug: 'trash', label: getTabLabel( __( 'Trash', 'jetpack-forms' ), totalItemsTrash ) },
-	];
-
-	const handleTabChange = useCallback(
-		newView => {
-			navigate( {
-				to: '/responses/$view',
-				params: { view: newView },
-			} );
-		},
-		[ navigate ]
 	);
 
 	const { openNewForm } = useCreateForm();
@@ -465,11 +480,7 @@ function StageInner() {
 		const actionsArray: React.ReactNode[] = [];
 
 		// Show integrations button on inbox when feature flags are enabled
-		if (
-			( params.view === 'inbox' || ! params.view ) &&
-			isIntegrationsEnabled &&
-			showDashboardIntegrations
-		) {
+		if ( statusView === 'inbox' && isIntegrationsEnabled && showDashboardIntegrations ) {
 			actionsArray.push(
 				<Button
 					key="integrations"
@@ -482,7 +493,7 @@ function StageInner() {
 			);
 		}
 
-		if ( params.view === 'inbox' || ! params.view ) {
+		if ( statusView === 'inbox' ) {
 			actionsArray.push(
 				<Button
 					key="create"
@@ -499,7 +510,7 @@ function StageInner() {
 		actionsArray.push(
 			<Button
 				key="export"
-				variant={ params.view === 'inbox' ? 'primary' : 'secondary' }
+				variant={ statusView === 'inbox' ? 'primary' : 'secondary' }
 				size="compact"
 				icon={ download }
 			>
@@ -507,21 +518,21 @@ function StageInner() {
 			</Button>
 		);
 
-		if ( params.view === 'trash' ) {
+		if ( statusView === 'trash' ) {
 			actionsArray.push( <EmptyTrashButton key="empty-trash" /> );
 		}
 
-		if ( params.view === 'spam' ) {
+		if ( statusView === 'spam' ) {
 			actionsArray.push( <EmptySpamButton key="empty-spam" /> );
 		}
 
 		return actionsArray;
 	}, [
-		params.view,
 		handleIntegrations,
 		handleCreateForm,
 		isIntegrationsEnabled,
 		showDashboardIntegrations,
+		statusView,
 	] );
 
 	// Check if read_status filter is applied
@@ -550,7 +561,7 @@ function StageInner() {
 			<DataViews
 				empty={
 					<EmptyResponses
-						status={ params.view }
+						status={ statusView }
 						isSearch={ !! view.search }
 						readStatusFilter={ readStatusFilter }
 					/>
@@ -568,30 +579,7 @@ function StageInner() {
 				onClickItem={ onClickItem }
 				actions={ actions as Action< unknown >[] }
 			>
-				<Stack
-					align="center"
-					className="jp-forms-dataviews__view-actions"
-					gap="sm"
-					justify="space-between"
-				>
-					<Stack align="center" gap="sm">
-						<Tabs.Root value={ params.view || 'inbox' } onValueChange={ handleTabChange }>
-							<Tabs.List density="compact">
-								{ statusTabs.map( tab => (
-									<Tabs.Tab value={ tab.slug } key={ tab.slug }>
-										{ tab.label }
-									</Tabs.Tab>
-								) ) }
-							</Tabs.List>
-						</Tabs.Root>
-					</Stack>
-					<Stack align="center" gap="sm">
-						<DataViews.Search />
-						<DataViews.FiltersToggle />
-						<DataViews.ViewConfig />
-					</Stack>
-				</Stack>
-				<DataViews.FiltersToggled className="dataviews-filters__container jp-forms-dataviews-filters__container" />
+				<DataViewsHeaderRow activeTab="responses" />
 				<DataViews.Layout />
 				<DataViews.Footer />
 			</DataViews>

--- a/projects/packages/forms/src/dashboard/wp-build/components/dataviews-header-row/index.tsx
+++ b/projects/packages/forms/src/dashboard/wp-build/components/dataviews-header-row/index.tsx
@@ -1,0 +1,66 @@
+/**
+ * WordPress dependencies
+ */
+import { DataViews } from '@wordpress/dataviews';
+import { useCallback } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { useNavigate } from '@wordpress/route';
+import { Stack } from '@wordpress/ui';
+/**
+ * Internal dependencies
+ */
+import * as Tabs from '../../../components/tabs';
+import './style.scss';
+
+type ActiveTab = 'forms' | 'responses';
+
+/**
+ * Shared wp-build DataViews header row:
+ * - Left: Forms | Responses tabs (CFM-on behavior; wp-build assumes CFM is always on)
+ * - Right: DataViews controls (Search + ViewConfig)
+ * - Below: DataViews filter pills row (collapses when empty)
+ *
+ * @param props           - Props.
+ * @param props.activeTab - Which top tab is active.
+ * @return Header row markup for wp-build DataViews screens.
+ */
+export default function DataViewsHeaderRow( { activeTab }: { activeTab: ActiveTab } ): JSX.Element {
+	const navigate = useNavigate();
+	const onTabChange = useCallback(
+		( nextValue: ActiveTab ) => {
+			if ( nextValue === 'forms' ) {
+				navigate( { to: '/forms' } );
+				return;
+			}
+
+			// In the wp-build environment we always treat Responses as `/responses/inbox`.
+			navigate( { to: '/responses/$view', params: { view: 'inbox' } } );
+		},
+		[ navigate ]
+	);
+
+	return (
+		<>
+			<Stack
+				align="center"
+				className="jp-forms-dataviews__view-actions"
+				gap="sm"
+				justify="space-between"
+			>
+				<Stack align="center" gap="sm">
+					<Tabs.Root value={ activeTab } onValueChange={ onTabChange }>
+						<Tabs.List density="compact">
+							<Tabs.Tab value="responses">{ __( 'Responses', 'jetpack-forms' ) }</Tabs.Tab>
+							<Tabs.Tab value="forms">{ __( 'Forms', 'jetpack-forms' ) }</Tabs.Tab>
+						</Tabs.List>
+					</Tabs.Root>
+				</Stack>
+				<Stack align="center" gap="sm">
+					<DataViews.Search />
+					<DataViews.ViewConfig />
+				</Stack>
+			</Stack>
+			<DataViews.FiltersToggled className="jp-forms-dataviews-filters__container" />
+		</>
+	);
+}

--- a/projects/packages/forms/src/dashboard/wp-build/components/dataviews-header-row/index.tsx
+++ b/projects/packages/forms/src/dashboard/wp-build/components/dataviews-header-row/index.tsx
@@ -25,18 +25,22 @@ type ActiveTab = 'forms' | 'responses';
  * @return Header row markup for wp-build DataViews screens.
  */
 export default function DataViewsHeaderRow( { activeTab }: { activeTab: ActiveTab } ): JSX.Element {
-	const navigate = useNavigate();
+	// Keep navigation type-safe without requiring callers to pass a `from` prop.
+	// We bind two typed navigate functions (hooks are unconditional).
+	const navigateFromForms = useNavigate( { from: '/forms' } );
+	const navigateFromResponses = useNavigate( { from: '/responses/$view' } );
+
 	const onTabChange = useCallback(
 		( nextValue: ActiveTab ) => {
 			if ( nextValue === 'forms' ) {
-				navigate( { to: '/forms' } );
+				navigateFromResponses( { to: '/forms' } );
 				return;
 			}
 
 			// In the wp-build environment we always treat Responses as `/responses/inbox`.
-			navigate( { to: '/responses/$view', params: { view: 'inbox' } } );
+			navigateFromForms( { to: '/responses/$view', params: { view: 'inbox' } } );
 		},
-		[ navigate ]
+		[ navigateFromForms, navigateFromResponses ]
 	);
 
 	return (

--- a/projects/packages/forms/src/dashboard/wp-build/components/dataviews-header-row/index.tsx
+++ b/projects/packages/forms/src/dashboard/wp-build/components/dataviews-header-row/index.tsx
@@ -25,22 +25,19 @@ type ActiveTab = 'forms' | 'responses';
  * @return Header row markup for wp-build DataViews screens.
  */
 export default function DataViewsHeaderRow( { activeTab }: { activeTab: ActiveTab } ): JSX.Element {
-	// Keep navigation type-safe without requiring callers to pass a `from` prop.
-	// We bind two typed navigate functions (hooks are unconditional).
-	const navigateFromForms = useNavigate( { from: '/forms' } );
-	const navigateFromResponses = useNavigate( { from: '/responses/$view' } );
+	const navigate = useNavigate();
 
 	const onTabChange = useCallback(
 		( nextValue: ActiveTab ) => {
 			if ( nextValue === 'forms' ) {
-				navigateFromResponses( { to: '/forms' } );
+				navigate( { href: '/forms' } );
 				return;
 			}
 
 			// In the wp-build environment we always treat Responses as `/responses/inbox`.
-			navigateFromForms( { to: '/responses/$view', params: { view: 'inbox' } } );
+			navigate( { href: '/responses/inbox' } );
 		},
-		[ navigateFromForms, navigateFromResponses ]
+		[ navigate ]
 	);
 
 	return (

--- a/projects/packages/forms/src/dashboard/wp-build/components/dataviews-header-row/style.scss
+++ b/projects/packages/forms/src/dashboard/wp-build/components/dataviews-header-row/style.scss
@@ -1,0 +1,33 @@
+@use "@wordpress/base-styles/variables";
+
+.jp-forms-dataviews__view-actions {
+	border-bottom: 1px solid var(--wpds-color-stroke-surface-neutral, #e0e0e0);
+	padding-inline: 20px;
+	overflow-x: auto;
+	width: 100%;
+	box-sizing: border-box;
+	container-type: inline-size;
+	flex-shrink: 0;
+
+	@container (width < 500px) {
+		--wp-ui-stack-justify: flex-start;
+		flex-direction: column;
+		align-items: flex-start;
+	}
+
+	> div:not(:empty) {
+		min-height: 48px;
+	}
+}
+
+// Filters "pills" row: collapse when empty.
+.jp-forms-dataviews-filters__container,
+.jp-forms-dataviews-filters__container:not(:empty) {
+	padding: 0;
+}
+
+.jp-forms-dataviews-filters__container:not(:empty) {
+	padding-inline: variables.$grid-unit * 2.5;
+	padding-block: variables.$grid-unit * 1.5;
+}
+


### PR DESCRIPTION
## Proposed changes:

We add the forms list (for centralized forms management) to the new wp-build dashboard. Specific changes:
* **New forms route**. Add new `forms` route alongside `responses`. Just placeholder screen for now.
* **New shared header**. Create new DataviewsHeaderRow component for shared tab/filter header. This holds the the new Forms and Responses tabs.
* **Updated responses screen**. Updated responses screen to use shared header. Because we are replacing inbox/spam/inbox tabs with forms/inbox, responses is also updated to use dataviews fitlers for inbox/spam/trash. 

**Responses screen**
<img width="1504" height="680" alt="respones-screen" src="https://github.com/user-attachments/assets/012d3ee1-7194-4bef-9b50-46f8af3718b8" />

**Forms screen**
<img width="1502" height="679" alt="forms-list-screen" src="https://github.com/user-attachments/assets/a75898c8-bfc0-45ab-aad2-084d9c61d9e1" />


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
Slack: p1769633730526019-slack-C052XEUUBL4
Slack: p1769704288177129-slack-C052XEUUBL4

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Enable this feature flag to wp-build dashboard: 

`add_filter( 'jetpack_forms_alpha', '__return_true', 20 );`

Test:
* Go to Jetpack > Forms (WP-Build)
* Confirm you see Forms and Responses tabs at the top
* Confirm the Forms tab loads and just shows a placeholder for now
* Confirm the Responses screen loads
   - Confirm that the mew 'Folder' filter for inbox, spam, and trash work as expected.
