### PR TITLE
Forms: Auto-create synced form when inserting field block outside a form

### DIFF
--- a/projects/packages/forms/changelog/update-create-cfm-new-form-added
+++ b/projects/packages/forms/changelog/update-create-cfm-new-form-added
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Forms: Auto-create synced form when inserting a field block outside a form (when central form management is enabled).

--- a/projects/packages/forms/src/blocks/shared/hooks/use-form-wrapper.js
+++ b/projects/packages/forms/src/blocks/shared/hooks/use-form-wrapper.js
@@ -1,37 +1,81 @@
 import { store as blockEditorStore } from '@wordpress/block-editor';
 import { createBlock } from '@wordpress/blocks';
-import { useDispatch, useSelect } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
+import { resolveSelect, useDispatch, useSelect } from '@wordpress/data';
+import { store as editorStore } from '@wordpress/editor';
 import { useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { FORM_BLOCK_NAME } from '../util/constants.js';
+import useConfigValue from '../../../hooks/use-config-value.ts';
+import { createSyncedForm } from '../../contact-form/util/create-synced-form.ts';
+import { FORM_BLOCK_NAME, FORM_POST_TYPE } from '../util/constants.js';
 
 export default function useFormWrapper( { attributes, clientId, name } ) {
-	const { replaceBlock, __unstableMarkNextChangeAsNotPersistent } = useDispatch( blockEditorStore );
+	const { replaceBlock, updateBlockAttributes, __unstableMarkNextChangeAsNotPersistent } =
+		useDispatch( blockEditorStore );
 	const { getBlocks } = useSelect( blockEditorStore );
 
-	const parentForms = useSelect(
+	// Feature flag for central form management
+	const isCentralFormManagementEnabled = useConfigValue( 'isCentralFormManagementEnabled' );
+
+	const { parentForms, postTitle, currentPostId } = useSelect(
 		select => {
-			return select( blockEditorStore ).getBlockParentsByBlockName( clientId, FORM_BLOCK_NAME );
+			return {
+				parentForms: select( blockEditorStore ).getBlockParentsByBlockName(
+					clientId,
+					FORM_BLOCK_NAME
+				),
+				postTitle: select( editorStore ).getEditedPostAttribute( 'title' ) || 'Untitled',
+				currentPostId: select( editorStore ).getEditedPostAttribute( 'id' ),
+			};
 		},
 		[ clientId ]
 	);
 
 	useEffect( () => {
 		if ( ! parentForms?.length ) {
+			// Create the form block structure
+			const fieldBlock = createBlock( name, attributes, getBlocks( clientId ) );
+			const submitButton = createBlock( 'core/button', {
+				text: __( 'Submit', 'jetpack-forms' ),
+				type: 'submit',
+				tagName: 'button',
+			} );
+			const formBlock = createBlock( FORM_BLOCK_NAME, {}, [ fieldBlock, submitButton ] );
+
+			// Phase 1: Replace field with form (immediate visual feedback)
 			// As this is an automated update, ensure it doesn't end up in the undo stack
 			// by calling `__unstableMarkNextChangeAsNotPersistent`.
 			__unstableMarkNextChangeAsNotPersistent();
-			replaceBlock(
-				clientId,
-				createBlock( FORM_BLOCK_NAME, {}, [
-					createBlock( name, attributes, getBlocks( clientId ) ),
-					createBlock( 'core/button', {
-						text: __( 'Submit', 'jetpack-forms' ),
-						type: 'submit',
-						tagName: 'button',
-					} ),
-				] )
-			);
+			replaceBlock( clientId, formBlock );
+
+			// Phase 2: Convert to synced form (async) - only if feature flag is enabled
+			if ( isCentralFormManagementEnabled ) {
+				const convertToSynced = async () => {
+					try {
+						const formId = await createSyncedForm(
+							{
+								attributes: {},
+								innerBlocks: [ fieldBlock, submitButton ],
+							},
+							postTitle,
+							currentPostId
+						);
+
+						// Preload the entity record into the cache BEFORE setting ref.
+						// This ensures the form component won't show a loading skeleton
+						// because the data will already be available in the store.
+						await resolveSelect( coreStore ).getEntityRecord( 'postType', FORM_POST_TYPE, formId );
+
+						// Now set the ref - the form data is already cached, so no loading state
+						__unstableMarkNextChangeAsNotPersistent();
+						updateBlockAttributes( formBlock.clientId, { ref: formId } );
+					} catch {
+						// If synced form creation fails, keep as inline form (graceful degradation)
+					}
+				};
+
+				convertToSynced();
+			}
 		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [] );


### PR DESCRIPTION
## Proposed changes:
* When a user inserts a form field block (e.g., email field) outside of a form, the `useFormWrapper` hook now automatically creates a synced form (stored in `jetpack_form` post type) when the central form management feature flag is enabled
* The implementation uses a two-phase approach:
  - Phase 1: Creates an inline form immediately for instant visual feedback
  - Phase 2: Asynchronously creates a synced form via API, preloads the entity record, then updates the form block with the `ref` attribute
* When the feature flag is disabled, behavior remains unchanged (inline form)
* Graceful degradation: if synced form creation fails, the form stays as inline

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1769642502633819-slack-C052XEUUBL4

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

### With feature flag enabled:
1. Ensure `isCentralFormManagementEnabled` is `true` in the Forms config
2. Open the WordPress block editor on a new post/page
3. Insert an email field block (or any form field block) directly into the content (not inside an existing form)
4. Verify: The field is immediately wrapped in a form block with a submit button
5. Verify: After a moment, the form block has a `ref` attribute pointing to a new synced form (check block inspector)
6. Verify: A new `jetpack_form` post is created (check WP Admin > Forms)
7. Verify: No loading skeleton or flash appears during the transition

### With feature flag disabled:
1. Ensure `isCentralFormManagementEnabled` is `false` in the Forms config
2. Repeat steps 2-4 above
3. Verify: The form does NOT have a `ref` attribute (it's an inline form)
4. Verify: No new `jetpack_form` post is created