### PR TITLE
Update/incompatible plugins list fixing typo really simple ssl

### DIFF
--- a/projects/plugins/wpcomsh/changelog/update-incompatible-plugins-list-fixing-typo-really-simple-ssl
+++ b/projects/plugins/wpcomsh/changelog/update-incompatible-plugins-list-fixing-typo-really-simple-ssl
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Fixed the slug and file path for Really Simple Security (formerly Really Simple SSL) in the incompatibility list.

--- a/projects/plugins/wpcomsh/class-jetpack-plugin-compatibility.php
+++ b/projects/plugins/wpcomsh/class-jetpack-plugin-compatibility.php
@@ -113,7 +113,7 @@ class Jetpack_Plugin_Compatibility {
 		'disable-xml-rpc-api/disable-xml-rpc-api.php'     => '"disable-xml-rpc-api" has been deactivated, XML-RPC is required for your Jetpack Connection on WordPress.com.',
 		'manage-xml-rpc/manage-xml-rpc.php'               => '"manage-xml-rpc" has been deactivated, XML-RPC is required for your Jetpack Connection on WordPress.com.',
 		'one-click-ssl/ssl.php'                           => '"one-click-ssl" has been deactivated, because it is not supported on WordPress.com.',
-		'really-simple-ssl/really-simple-ssl.php'         => '"really-simple-ssl" is not supported on WordPress.com.',
+		'really-simple-ssl/rlrsssl-really-simple-ssl.php' => '"really-simple-ssl" is not supported on WordPress.com.',
 		'really-simple-ssl-pro/really-simple-ssl-pro.php' => '"really-simple-ssl-pro" is not supported on WordPress.com.',
 		'sg-security/sg-security.php'                     => '"sg-security" has been deactivated, "security" related plugins may break your site or cause performance issues for your site and are not supported on WordPress.com.',
 		'stopbadbots/stopbadbots.php'                     => '"stopbadbots" has been deactivated, "security" related plugins may break your site or cause performance issues for your site and are not supported on WordPress.com.',


### PR DESCRIPTION
Fixed typo for Really Simple Security (formerly Really Simple SSL) plugin to match the slug and path of the current version of the plugin.

Corresponding PR for Calypso: N/A - the change only needs to happen in this repo.

## Jetpack product discussion

N/A

## Does this pull request change what data or activity we track or use?

No, I don't believe this would apply to the update.

## Testing instructions:

1. Create a new Business Plan site, mark it as a WoA Dev site, and take it Atomic.
2. Build wpcomsh plugin and synchronize to the WoA Dev site

```
git checkout BRANCH
composer install
WPCOMSH_DEVMODE=1 make clean build
rsync -avze ssh --delete build/wpcomsh USERNAME@sftp.wp.com:htdocs/wp-content/mu-plugins
```

3. SSH into the WoA dev site, and run: wp plugin install really-simple-ssl --activate
4. Navigate to the WoA dev site's /wp-admin/plugins.php page and confirm that Super Blank can be activated and is not disabled.