### PR TITLE
VideoPress: Use feature flag for plan detection instead of hardcoded slugs

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -3209,5 +3209,5 @@
         "ext-json": "*"
     },
     "platform-dev": {},
-    "plugin-api-version": "2.9.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -3209,5 +3209,5 @@
         "ext-json": "*"
     },
     "platform-dev": {},
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }

--- a/projects/packages/videopress/changelog/fix-a4a-plan-detection
+++ b/projects/packages/videopress/changelog/fix-a4a-plan-detection
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Fix upgrade notice incorrectly showing for A4A (Automattic for Agencies) VideoPress customers by using backend feature flag instead of hardcoded plan slugs.
+Fix upgrade notice incorrectly showing for A4A (Automattic for Agencies) VideoPress customers by using dynamic features API instead of hardcoded plan slugs.

--- a/projects/packages/videopress/changelog/fix-a4a-plan-detection
+++ b/projects/packages/videopress/changelog/fix-a4a-plan-detection
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Use feature flag from backend for VideoPress plan detection instead of hardcoded plan slugs. Fixes upgrade notice incorrectly showing for A4A (Automattic for Agencies) VideoPress customers.
+Fix upgrade notice incorrectly showing for A4A (Automattic for Agencies) VideoPress customers by using backend feature flag instead of hardcoded plan slugs.

--- a/projects/packages/videopress/changelog/fix-a4a-plan-detection
+++ b/projects/packages/videopress/changelog/fix-a4a-plan-detection
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Use feature flag from backend for VideoPress plan detection instead of hardcoded plan slugs. Fixes upgrade notice incorrectly showing for A4A (Automattic for Agencies) VideoPress customers.

--- a/projects/packages/videopress/src/class-admin-ui.php
+++ b/projects/packages/videopress/src/class-admin-ui.php
@@ -14,6 +14,7 @@ use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Current_Plan;
 use Automattic\Jetpack\My_Jetpack\Products as My_Jetpack_Products;
 use Automattic\Jetpack\Status;
+use Automattic\Jetpack\Status\Host;
 use Automattic\Jetpack\Terms_Of_Service;
 use Automattic\Jetpack\Tracking;
 
@@ -188,7 +189,7 @@ class Admin_UI {
 				'isVideoPressSupported'          => Current_Plan::supports( 'videopress' ),
 				// Check videopress-1tb-storage (Jetpack) or videopress (WordPress.com).
 				'isVideoPress1TBSupported'       => Current_Plan::supports( 'videopress-1tb-storage' )
-					|| ( function_exists( 'wpcom_site_has_feature' ) && wpcom_site_has_feature( 'videopress' ) ),
+					|| ( ( new Host() )->is_wpcom_platform() && wpcom_site_has_feature( 'videopress' ) ),
 				'isVideoPressUnlimitedSupported' => Current_Plan::supports( 'videopress-unlimited-storage' ),
 			),
 			'siteSuffix'             => ( new Status() )->get_site_suffix(),

--- a/projects/packages/videopress/src/class-admin-ui.php
+++ b/projects/packages/videopress/src/class-admin-ui.php
@@ -186,9 +186,9 @@ class Admin_UI {
 			'adminUri'               => 'admin.php?page=' . self::ADMIN_PAGE_SLUG,
 			'paidFeatures'           => array(
 				'isVideoPressSupported'          => Current_Plan::supports( 'videopress' ),
-				// Check both features - videopress-1tb-storage (Jetpack) and videopress/video (Atomic).
+				// Check videopress-1tb-storage (Jetpack) or videopress (WordPress.com).
 				'isVideoPress1TBSupported'       => Current_Plan::supports( 'videopress-1tb-storage' )
-					|| Current_Plan::supports( 'videopress/video' ),
+					|| ( function_exists( 'wpcom_site_has_feature' ) && wpcom_site_has_feature( 'videopress' ) ),
 				'isVideoPressUnlimitedSupported' => Current_Plan::supports( 'videopress-unlimited-storage' ),
 			),
 			'siteSuffix'             => ( new Status() )->get_site_suffix(),

--- a/projects/packages/videopress/src/class-admin-ui.php
+++ b/projects/packages/videopress/src/class-admin-ui.php
@@ -186,7 +186,9 @@ class Admin_UI {
 			'adminUri'               => 'admin.php?page=' . self::ADMIN_PAGE_SLUG,
 			'paidFeatures'           => array(
 				'isVideoPressSupported'          => Current_Plan::supports( 'videopress' ),
-				'isVideoPress1TBSupported'       => Current_Plan::supports( 'videopress-1tb-storage' ),
+				// Check both features - videopress-1tb-storage (Jetpack) and videopress/video (Atomic).
+				'isVideoPress1TBSupported'       => Current_Plan::supports( 'videopress-1tb-storage' )
+					|| Current_Plan::supports( 'videopress/video' ),
 				'isVideoPressUnlimitedSupported' => Current_Plan::supports( 'videopress-unlimited-storage' ),
 			),
 			'siteSuffix'             => ( new Status() )->get_site_suffix(),

--- a/projects/packages/videopress/src/class-initializer.php
+++ b/projects/packages/videopress/src/class-initializer.php
@@ -127,6 +127,7 @@ class Initializer {
 		VideoPress_Rest_Api_V1_Stats::init();
 		VideoPress_Rest_Api_V1_Site::init();
 		VideoPress_Rest_Api_V1_Settings::init();
+		VideoPress_Rest_Api_V1_Features::init();
 		XMLRPC::init();
 		Block_Editor_Content::init();
 		self::register_oembed_providers();

--- a/projects/packages/videopress/src/class-videopress-rest-api-v1-features.php
+++ b/projects/packages/videopress/src/class-videopress-rest-api-v1-features.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * VideoPress Features Endpoint
+ *
+ * @package automattic/jetpack-videopress
+ */
+
+namespace Automattic\Jetpack\VideoPress;
+
+use Automattic\Jetpack\My_Jetpack\Products\Product;
+
+/**
+ * VideoPress REST API class for fetching site features from WPCOM.
+ */
+class VideoPress_Rest_Api_V1_Features {
+	/**
+	 * Initializes the endpoints
+	 *
+	 * @return void
+	 */
+	public static function init() {
+		add_action( 'rest_api_init', array( static::class, 'register_rest_endpoints' ) );
+	}
+
+	/**
+	 * Register the REST API routes.
+	 *
+	 * @return void
+	 */
+	public static function register_rest_endpoints() {
+		register_rest_route(
+			'videopress/v1',
+			'features',
+			array(
+				'methods'             => \WP_REST_Server::READABLE,
+				'callback'            => static::class . '::get_features',
+				'permission_callback' => static::class . '::permissions_callback',
+			)
+		);
+	}
+
+	/**
+	 * Checks whether the user has permissions to see the features.
+	 *
+	 * @return boolean
+	 */
+	public static function permissions_callback() {
+		return current_user_can( 'read' );
+	}
+
+	/**
+	 * Returns VideoPress feature flags fetched fresh from WPCOM.
+	 *
+	 * Uses My Jetpack's Product::get_site_features_from_wpcom() which calls
+	 * WPCOM /sites/%d/features API with a 15-second transient cache.
+	 *
+	 * @return \WP_REST_Response The response object.
+	 */
+	public static function get_features() {
+		$features = Product::get_site_features_from_wpcom();
+
+		if ( is_wp_error( $features ) ) {
+			return rest_ensure_response( $features );
+		}
+
+		$active = $features['active'] ?? array();
+
+		return rest_ensure_response(
+			array(
+				'isVideoPressSupported'          => true, // Always true due to free tier.
+				'isVideoPress1TBSupported'       => in_array( 'videopress-1tb-storage', $active, true ),
+				'isVideoPressUnlimitedSupported' => in_array( 'videopress-unlimited-storage', $active, true ),
+			)
+		);
+	}
+}

--- a/projects/packages/videopress/src/class-videopress-rest-api-v1-features.php
+++ b/projects/packages/videopress/src/class-videopress-rest-api-v1-features.php
@@ -7,7 +7,7 @@
 
 namespace Automattic\Jetpack\VideoPress;
 
-use Automattic\Jetpack\My_Jetpack\Products\Product;
+use Automattic\Jetpack\My_Jetpack\Product;
 
 /**
  * VideoPress REST API class for fetching site features from WPCOM.

--- a/projects/packages/videopress/src/class-videopress-rest-api-v1-features.php
+++ b/projects/packages/videopress/src/class-videopress-rest-api-v1-features.php
@@ -68,9 +68,9 @@ class VideoPress_Rest_Api_V1_Features {
 		return rest_ensure_response(
 			array(
 				'isVideoPressSupported'          => true, // Always true due to free tier.
-				// Check both features - videopress-1tb-storage (Jetpack) and videopress/video (Atomic).
+				// Check videopress-1tb-storage (Jetpack) or videopress (WordPress.com).
 				'isVideoPress1TBSupported'       => in_array( 'videopress-1tb-storage', $active, true )
-					|| in_array( 'videopress/video', $active, true ),
+					|| ( function_exists( 'wpcom_site_has_feature' ) && in_array( 'videopress', $active, true ) ),
 				'isVideoPressUnlimitedSupported' => in_array( 'videopress-unlimited-storage', $active, true ),
 			)
 		);

--- a/projects/packages/videopress/src/class-videopress-rest-api-v1-features.php
+++ b/projects/packages/videopress/src/class-videopress-rest-api-v1-features.php
@@ -68,7 +68,9 @@ class VideoPress_Rest_Api_V1_Features {
 		return rest_ensure_response(
 			array(
 				'isVideoPressSupported'          => true, // Always true due to free tier.
-				'isVideoPress1TBSupported'       => in_array( 'videopress-1tb-storage', $active, true ),
+				// Check both features - videopress-1tb-storage (Jetpack) and videopress/video (Atomic).
+				'isVideoPress1TBSupported'       => in_array( 'videopress-1tb-storage', $active, true )
+					|| in_array( 'videopress/video', $active, true ),
 				'isVideoPressUnlimitedSupported' => in_array( 'videopress-unlimited-storage', $active, true ),
 			)
 		);

--- a/projects/packages/videopress/src/class-videopress-rest-api-v1-features.php
+++ b/projects/packages/videopress/src/class-videopress-rest-api-v1-features.php
@@ -8,6 +8,7 @@
 namespace Automattic\Jetpack\VideoPress;
 
 use Automattic\Jetpack\My_Jetpack\Product;
+use Automattic\Jetpack\Status\Host;
 
 /**
  * VideoPress REST API class for fetching site features from WPCOM.
@@ -70,7 +71,7 @@ class VideoPress_Rest_Api_V1_Features {
 				'isVideoPressSupported'          => true, // Always true due to free tier.
 				// Check videopress-1tb-storage (Jetpack) or videopress (WordPress.com).
 				'isVideoPress1TBSupported'       => in_array( 'videopress-1tb-storage', $active, true )
-					|| ( function_exists( 'wpcom_site_has_feature' ) && in_array( 'videopress', $active, true ) ),
+					|| ( ( new Host() )->is_wpcom_platform() && in_array( 'videopress', $active, true ) ),
 				'isVideoPressUnlimitedSupported' => in_array( 'videopress-unlimited-storage', $active, true ),
 			)
 		);

--- a/projects/packages/videopress/src/client/admin/components/admin-page/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/admin-page/index.tsx
@@ -331,20 +331,20 @@ export default Admin;
 const UpgradeTrigger = ( { hasUsedVideo = false }: { hasUsedVideo: boolean } ) => {
 	const { adminUri, siteSuffix } = window.jetpackVideoPressInitialState;
 
-	const { product, hasVideoPressPurchase, isFetchingPurchases } = usePlan();
+	const { product, hasVideoPressPurchase, isFetchingFeatures } = usePlan();
 	// eslint-disable-next-line @wordpress/no-unused-vars-before-return -- @todo Start extending jetpack-js-tools/eslintrc/react in eslintrc, then we can remove this disable comment.
 	const { run } = useProductCheckoutWorkflow( {
 		siteSuffix,
 		productSlug: product.productSlug,
 		redirectUrl: adminUri,
-		isFetchingPurchases,
 		useBlogIdSuffix: true,
+		from: 'jetpack-videopress',
 	} );
 
 	// eslint-disable-next-line @wordpress/no-unused-vars-before-return -- @todo Start extending jetpack-js-tools/eslintrc/react in eslintrc, then we can remove this disable comment.
 	const { recordEventHandler } = useAnalyticsTracks( {} );
 
-	if ( hasVideoPressPurchase || isFetchingPurchases ) {
+	if ( hasVideoPressPurchase || isFetchingFeatures ) {
 		return null;
 	}
 

--- a/projects/packages/videopress/src/client/admin/hooks/use-plan/index.ts
+++ b/projects/packages/videopress/src/client/admin/hooks/use-plan/index.ts
@@ -31,23 +31,23 @@ export const usePlan = (): usePlanProps => {
 	const introductoryOffer = mapObjectKeysToCamel( productData.introductory_offer, true );
 	const videoPressProduct = { ...mapObjectKeysToCamel( productData, true ), introductoryOffer };
 
-	const { purchases, isFetchingPurchases } = useSelect( select => {
+	const { features, isFetchingFeatures } = useSelect( select => {
 		return {
-			purchases: ( select( STORE_ID ) as VideopressSelectors ).getPurchases(),
-			isFetchingPurchases: ( select( STORE_ID ) as VideopressSelectors ).isFetchingPurchases(),
+			features: ( select( STORE_ID ) as VideopressSelectors ).getFeatures(),
+			isFetchingFeatures: ( select( STORE_ID ) as VideopressSelectors ).isFetchingFeatures(),
 		};
 	}, [] );
-	const purchasesCamelCase = purchases.map( purchase => mapObjectKeysToCamel( purchase, true ) );
+
+	// Use dynamic features from API, fall back to static paidFeatures from initial state while loading
+	const resolvedFeatures = features ?? paidFeatures;
 
 	return {
-		features: paidFeatures,
+		features: resolvedFeatures,
 		siteProduct: { ...mapObjectKeysToCamel( { ...siteProductData }, true ), pricingForUi },
 		product: videoPressProduct,
 		productPrice,
 
-		// Site purchases
-		purchases: purchasesCamelCase,
-		hasVideoPressPurchase: paidFeatures?.isVideoPress1TBSupported ?? false,
-		isFetchingPurchases,
+		hasVideoPressPurchase: resolvedFeatures?.isVideoPress1TBSupported ?? false,
+		isFetchingFeatures,
 	};
 };

--- a/projects/packages/videopress/src/client/admin/hooks/use-plan/index.ts
+++ b/projects/packages/videopress/src/client/admin/hooks/use-plan/index.ts
@@ -39,66 +39,6 @@ export const usePlan = (): usePlanProps => {
 	}, [] );
 	const purchasesCamelCase = purchases.map( purchase => mapObjectKeysToCamel( purchase, true ) );
 
-	/**
-	 * Check if the user has a plan that includes VideoPress
-	 *
-	 * @param {string} productSlug - wpcom prtoduct slug
-	 * @return {boolean}            true if the product is owned by the user
-	 */
-	function hasPurchase( productSlug ) {
-		return purchasesCamelCase.some( product => product.productSlug === productSlug );
-	}
-
-	const hasVideoPressPurchase = [
-		'jetpack_videopress_bi_yearly',
-		'jetpack_videopress',
-		'jetpack_videopress_monthly',
-		'jetpack_complete_bi_yearly',
-		'jetpack_complete',
-		'jetpack_complete_monthly',
-		'jetpack_business',
-		'jetpack_business_monthly',
-		'jetpack_personal',
-		'jetpack_personal_monthly',
-		'jetpack_premium',
-		'jetpack_premium_monthly',
-		'videopress',
-		'videopress-pro',
-		'wp_p2_plus_monthly',
-
-		// WPCOM Premium plans
-		'bundle_pro',
-		'value_bundle',
-		'value_bundle_monthly',
-		'value_bundle-2y',
-		'value_bundle-3y',
-
-		// WPCOM PRO plans
-		'pro-plan',
-		'pro-plan-monthly',
-		'pro-plan-2y',
-
-		// WPCOM Business plans
-		'business-bundle',
-		'business-bundle-monthly',
-		'business-bundle-2y',
-		'business-bundle-3y',
-		'wp_com_hundred_year_bundle_centennially',
-		'wp_bundle_migration_trial_monthly',
-		'wp_bundle_hosting_trial_monthly',
-
-		// WPCOM eCommerce plans
-		'ecommerce-bundle',
-		'ecommerce-bundle-monthly',
-		'ecommerce-bundle-2y',
-		'ecommerce-bundle-3y',
-		'ecommerce-trial-bundle-monthly',
-		'wooexpress-small-bundle-yearly',
-		'wooexpress-small-bundle-monthly',
-		'wooexpress-medium-bundle-yearly',
-		'wooexpress-medium-bundle-monthly',
-	].some( plan => hasPurchase( plan ) );
-
 	return {
 		features: paidFeatures,
 		siteProduct: { ...mapObjectKeysToCamel( { ...siteProductData }, true ), pricingForUi },
@@ -107,7 +47,7 @@ export const usePlan = (): usePlanProps => {
 
 		// Site purchases
 		purchases: purchasesCamelCase,
-		hasVideoPressPurchase,
+		hasVideoPressPurchase: paidFeatures?.isVideoPress1TBSupported ?? false,
 		isFetchingPurchases,
 	};
 };

--- a/projects/packages/videopress/src/client/admin/hooks/use-plan/test/index.test.ts
+++ b/projects/packages/videopress/src/client/admin/hooks/use-plan/test/index.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Test for usePlan hook's hasVideoPressPurchase logic.
+ *
+ * Since the hook reads from window.jetpackVideoPressInitialState at module load time,
+ * we test the logic by mocking the entire hook module for consumers.
+ */
+
+// Mock the state store
+jest.mock( '../../../../state', () => ( {
+	STORE_ID: 'jetpack-videopress',
+} ) );
+
+// Mock @wordpress/data
+jest.mock( '@wordpress/data', () => ( {
+	useSelect: jest.fn( () => ( {
+		purchases: [],
+		isFetchingPurchases: false,
+	} ) ),
+	combineReducers: jest.fn( reducers => reducers ),
+	createReduxStore: jest.fn(),
+	register: jest.fn(),
+} ) );
+
+describe( 'usePlan hasVideoPressPurchase logic', () => {
+	beforeEach( () => {
+		jest.resetModules();
+	} );
+
+	afterEach( () => {
+		delete ( window as any ).jetpackVideoPressInitialState;
+	} );
+
+	it( 'returns true when isVideoPress1TBSupported is true (paid VideoPress plan)', () => {
+		( window as any ).jetpackVideoPressInitialState = {
+			paidFeatures: {
+				isVideoPressSupported: true,
+				isVideoPress1TBSupported: true,
+				isVideoPressUnlimitedSupported: false,
+			},
+			siteProductData: {},
+			productData: {},
+			productPrice: {},
+		};
+
+		const { usePlan } = require( '..' );
+		const result = usePlan();
+
+		expect( result.hasVideoPressPurchase ).toBe( true );
+	} );
+
+	it( 'returns false when isVideoPress1TBSupported is false (free tier)', () => {
+		( window as any ).jetpackVideoPressInitialState = {
+			paidFeatures: {
+				isVideoPressSupported: true, // This is always true, even for free tier
+				isVideoPress1TBSupported: false,
+				isVideoPressUnlimitedSupported: false,
+			},
+			siteProductData: {},
+			productData: {},
+			productPrice: {},
+		};
+
+		const { usePlan } = require( '..' );
+		const result = usePlan();
+
+		expect( result.hasVideoPressPurchase ).toBe( false );
+	} );
+
+	it( 'returns false when paidFeatures is undefined', () => {
+		( window as any ).jetpackVideoPressInitialState = {
+			siteProductData: {},
+			productData: {},
+			productPrice: {},
+		};
+
+		const { usePlan } = require( '..' );
+		const result = usePlan();
+
+		expect( result.hasVideoPressPurchase ).toBe( false );
+	} );
+
+	it( 'returns false when jetpackVideoPressInitialState is undefined', () => {
+		// Don't set window.jetpackVideoPressInitialState at all
+
+		const { usePlan } = require( '..' );
+		const result = usePlan();
+
+		expect( result.hasVideoPressPurchase ).toBe( false );
+	} );
+
+	it( 'returns true when isVideoPressUnlimitedSupported is true (Complete plan has both)', () => {
+		// Complete plans have both 1TB and unlimited features
+		( window as any ).jetpackVideoPressInitialState = {
+			paidFeatures: {
+				isVideoPressSupported: true,
+				isVideoPress1TBSupported: true,
+				isVideoPressUnlimitedSupported: true,
+			},
+			siteProductData: {},
+			productData: {},
+			productPrice: {},
+		};
+
+		const { usePlan } = require( '..' );
+		const result = usePlan();
+
+		expect( result.hasVideoPressPurchase ).toBe( true );
+	} );
+} );

--- a/projects/packages/videopress/src/client/admin/hooks/use-plan/test/index.test.ts
+++ b/projects/packages/videopress/src/client/admin/hooks/use-plan/test/index.test.ts
@@ -1,31 +1,44 @@
 /**
  * Test for usePlan hook's hasVideoPressPurchase logic.
  *
- * Since the hook reads from window.jetpackVideoPressInitialState at module load time,
- * we use jest.isolateModules() to get fresh module instances with different window state.
+ * The hook now fetches features dynamically from the Redux store via useSelect.
  */
 
 declare global {
 	interface Window {
 		jetpackVideoPressInitialState?: {
+			siteProductData?: object;
+			productData?: object;
+			productPrice?: object;
 			paidFeatures?: {
 				isVideoPressSupported?: boolean;
 				isVideoPress1TBSupported?: boolean;
 				isVideoPressUnlimitedSupported?: boolean;
 			};
-			siteProductData?: object;
-			productData?: object;
-			productPrice?: object;
 		};
 	}
 }
 
+// Store the mock features data that tests will set
+let mockFeaturesData: {
+	features?: {
+		isVideoPressSupported?: boolean;
+		isVideoPress1TBSupported?: boolean;
+		isVideoPressUnlimitedSupported?: boolean;
+	};
+	isFetchingFeatures: boolean;
+} = {
+	features: undefined,
+	isFetchingFeatures: false,
+};
+
 // Mock @wordpress/data
 jest.mock( '@wordpress/data', () => ( {
-	useSelect: jest.fn( () => ( {
-		purchases: [],
-		isFetchingPurchases: false,
-	} ) ),
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
+	useSelect: jest.fn( ( _selectorCallback: ( select: () => object ) => object ) => {
+		// Return the mock data directly since we're mocking the entire flow
+		return mockFeaturesData;
+	} ),
 	combineReducers: jest.fn( reducers => reducers ),
 	createReduxStore: jest.fn(),
 	register: jest.fn(),
@@ -36,36 +49,56 @@ jest.mock( '../../../../state', () => ( {
 	STORE_ID: 'jetpack-videopress',
 } ) );
 
+// Mock mapObjectKeysToCamel
+jest.mock( '../../../../utils/map-object-keys-to-camel-case', () => ( {
+	mapObjectKeysToCamel: jest.fn( obj => obj || {} ),
+} ) );
+
 /**
  * Helper to import usePlan in an isolated module context.
  * This ensures each test gets a fresh module that reads the current window state.
  *
  * @return {object} The result of calling usePlan()
  */
-function importUsePlan(): { hasVideoPressPurchase: boolean } {
-	let result: { hasVideoPressPurchase: boolean } = { hasVideoPressPurchase: false };
+function importUsePlan(): { hasVideoPressPurchase: boolean; isFetchingFeatures: boolean } {
+	let result: { hasVideoPressPurchase: boolean; isFetchingFeatures: boolean } = {
+		hasVideoPressPurchase: false,
+		isFetchingFeatures: false,
+	};
 	jest.isolateModules( () => {
-		const { usePlan } = jest.requireActual< typeof import('..') >( '..' );
+		// eslint-disable-next-line @typescript-eslint/no-require-imports
+		const { usePlan } = require( '..' );
 		result = usePlan();
 	} );
 	return result;
 }
 
 describe( 'usePlan hasVideoPressPurchase logic', () => {
+	beforeEach( () => {
+		jest.resetModules();
+		window.jetpackVideoPressInitialState = {
+			siteProductData: {},
+			productData: {},
+			productPrice: {},
+		};
+		mockFeaturesData = {
+			features: undefined,
+			isFetchingFeatures: false,
+		};
+	} );
+
 	afterEach( () => {
 		delete window.jetpackVideoPressInitialState;
 	} );
 
 	it( 'returns true when isVideoPress1TBSupported is true (paid VideoPress plan)', () => {
-		window.jetpackVideoPressInitialState = {
-			paidFeatures: {
+		mockFeaturesData = {
+			features: {
 				isVideoPressSupported: true,
 				isVideoPress1TBSupported: true,
 				isVideoPressUnlimitedSupported: false,
 			},
-			siteProductData: {},
-			productData: {},
-			productPrice: {},
+			isFetchingFeatures: false,
 		};
 
 		const result = importUsePlan();
@@ -73,52 +106,75 @@ describe( 'usePlan hasVideoPressPurchase logic', () => {
 	} );
 
 	it( 'returns false when isVideoPress1TBSupported is false (free tier)', () => {
-		window.jetpackVideoPressInitialState = {
-			paidFeatures: {
+		mockFeaturesData = {
+			features: {
 				isVideoPressSupported: true, // This is always true, even for free tier
 				isVideoPress1TBSupported: false,
 				isVideoPressUnlimitedSupported: false,
 			},
-			siteProductData: {},
-			productData: {},
-			productPrice: {},
+			isFetchingFeatures: false,
 		};
 
 		const result = importUsePlan();
 		expect( result.hasVideoPressPurchase ).toBe( false );
 	} );
 
-	it( 'returns false when paidFeatures is undefined', () => {
-		window.jetpackVideoPressInitialState = {
-			siteProductData: {},
-			productData: {},
-			productPrice: {},
+	it( 'returns false when features is undefined', () => {
+		mockFeaturesData = {
+			features: undefined,
+			isFetchingFeatures: false,
 		};
 
-		const result = importUsePlan();
-		expect( result.hasVideoPressPurchase ).toBe( false );
-	} );
-
-	it( 'returns false when jetpackVideoPressInitialState is undefined', () => {
-		// Don't set window.jetpackVideoPressInitialState at all
 		const result = importUsePlan();
 		expect( result.hasVideoPressPurchase ).toBe( false );
 	} );
 
 	it( 'returns true when isVideoPressUnlimitedSupported is true (Complete plan has both)', () => {
 		// Complete plans have both 1TB and unlimited features
-		window.jetpackVideoPressInitialState = {
-			paidFeatures: {
+		mockFeaturesData = {
+			features: {
 				isVideoPressSupported: true,
 				isVideoPress1TBSupported: true,
 				isVideoPressUnlimitedSupported: true,
 			},
-			siteProductData: {},
-			productData: {},
-			productPrice: {},
+			isFetchingFeatures: false,
 		};
 
 		const result = importUsePlan();
+		expect( result.hasVideoPressPurchase ).toBe( true );
+	} );
+
+	it( 'returns isFetchingFeatures state from store', () => {
+		mockFeaturesData = {
+			features: undefined,
+			isFetchingFeatures: true,
+		};
+
+		const result = importUsePlan();
+		expect( result.isFetchingFeatures ).toBe( true );
+	} );
+
+	it( 'falls back to static paidFeatures when dynamic features are undefined', () => {
+		// Set static paidFeatures in initial state
+		window.jetpackVideoPressInitialState = {
+			siteProductData: {},
+			productData: {},
+			productPrice: {},
+			paidFeatures: {
+				isVideoPressSupported: true,
+				isVideoPress1TBSupported: true,
+				isVideoPressUnlimitedSupported: false,
+			},
+		};
+
+		// Dynamic features not yet loaded
+		mockFeaturesData = {
+			features: undefined,
+			isFetchingFeatures: true,
+		};
+
+		const result = importUsePlan();
+		// Should use static paidFeatures as fallback
 		expect( result.hasVideoPressPurchase ).toBe( true );
 	} );
 } );

--- a/projects/packages/videopress/src/client/admin/hooks/use-plan/test/index.test.ts
+++ b/projects/packages/videopress/src/client/admin/hooks/use-plan/test/index.test.ts
@@ -2,13 +2,23 @@
  * Test for usePlan hook's hasVideoPressPurchase logic.
  *
  * Since the hook reads from window.jetpackVideoPressInitialState at module load time,
- * we test the logic by mocking the entire hook module for consumers.
+ * we use jest.isolateModules() to get fresh module instances with different window state.
  */
 
-// Mock the state store
-jest.mock( '../../../../state', () => ( {
-	STORE_ID: 'jetpack-videopress',
-} ) );
+declare global {
+	interface Window {
+		jetpackVideoPressInitialState?: {
+			paidFeatures?: {
+				isVideoPressSupported?: boolean;
+				isVideoPress1TBSupported?: boolean;
+				isVideoPressUnlimitedSupported?: boolean;
+			};
+			siteProductData?: object;
+			productData?: object;
+			productPrice?: object;
+		};
+	}
+}
 
 // Mock @wordpress/data
 jest.mock( '@wordpress/data', () => ( {
@@ -21,17 +31,33 @@ jest.mock( '@wordpress/data', () => ( {
 	register: jest.fn(),
 } ) );
 
-describe( 'usePlan hasVideoPressPurchase logic', () => {
-	beforeEach( () => {
-		jest.resetModules();
-	} );
+// Mock the state store
+jest.mock( '../../../../state', () => ( {
+	STORE_ID: 'jetpack-videopress',
+} ) );
 
+/**
+ * Helper to import usePlan in an isolated module context.
+ * This ensures each test gets a fresh module that reads the current window state.
+ *
+ * @return {object} The result of calling usePlan()
+ */
+function importUsePlan(): { hasVideoPressPurchase: boolean } {
+	let result: { hasVideoPressPurchase: boolean } = { hasVideoPressPurchase: false };
+	jest.isolateModules( () => {
+		const { usePlan } = jest.requireActual< typeof import('..') >( '..' );
+		result = usePlan();
+	} );
+	return result;
+}
+
+describe( 'usePlan hasVideoPressPurchase logic', () => {
 	afterEach( () => {
-		delete ( window as any ).jetpackVideoPressInitialState;
+		delete window.jetpackVideoPressInitialState;
 	} );
 
 	it( 'returns true when isVideoPress1TBSupported is true (paid VideoPress plan)', () => {
-		( window as any ).jetpackVideoPressInitialState = {
+		window.jetpackVideoPressInitialState = {
 			paidFeatures: {
 				isVideoPressSupported: true,
 				isVideoPress1TBSupported: true,
@@ -42,14 +68,12 @@ describe( 'usePlan hasVideoPressPurchase logic', () => {
 			productPrice: {},
 		};
 
-		const { usePlan } = require( '..' );
-		const result = usePlan();
-
+		const result = importUsePlan();
 		expect( result.hasVideoPressPurchase ).toBe( true );
 	} );
 
 	it( 'returns false when isVideoPress1TBSupported is false (free tier)', () => {
-		( window as any ).jetpackVideoPressInitialState = {
+		window.jetpackVideoPressInitialState = {
 			paidFeatures: {
 				isVideoPressSupported: true, // This is always true, even for free tier
 				isVideoPress1TBSupported: false,
@@ -60,37 +84,30 @@ describe( 'usePlan hasVideoPressPurchase logic', () => {
 			productPrice: {},
 		};
 
-		const { usePlan } = require( '..' );
-		const result = usePlan();
-
+		const result = importUsePlan();
 		expect( result.hasVideoPressPurchase ).toBe( false );
 	} );
 
 	it( 'returns false when paidFeatures is undefined', () => {
-		( window as any ).jetpackVideoPressInitialState = {
+		window.jetpackVideoPressInitialState = {
 			siteProductData: {},
 			productData: {},
 			productPrice: {},
 		};
 
-		const { usePlan } = require( '..' );
-		const result = usePlan();
-
+		const result = importUsePlan();
 		expect( result.hasVideoPressPurchase ).toBe( false );
 	} );
 
 	it( 'returns false when jetpackVideoPressInitialState is undefined', () => {
 		// Don't set window.jetpackVideoPressInitialState at all
-
-		const { usePlan } = require( '..' );
-		const result = usePlan();
-
+		const result = importUsePlan();
 		expect( result.hasVideoPressPurchase ).toBe( false );
 	} );
 
 	it( 'returns true when isVideoPressUnlimitedSupported is true (Complete plan has both)', () => {
 		// Complete plans have both 1TB and unlimited features
-		( window as any ).jetpackVideoPressInitialState = {
+		window.jetpackVideoPressInitialState = {
 			paidFeatures: {
 				isVideoPressSupported: true,
 				isVideoPress1TBSupported: true,
@@ -101,9 +118,7 @@ describe( 'usePlan hasVideoPressPurchase logic', () => {
 			productPrice: {},
 		};
 
-		const { usePlan } = require( '..' );
-		const result = usePlan();
-
+		const result = importUsePlan();
 		expect( result.hasVideoPressPurchase ).toBe( true );
 	} );
 } );

--- a/projects/packages/videopress/src/client/admin/hooks/use-plan/types.ts
+++ b/projects/packages/videopress/src/client/admin/hooks/use-plan/types.ts
@@ -126,7 +126,6 @@ export type usePlanProps = {
 	product?: productProps;
 	productPrice?: productPriceOriginalProps;
 
-	purchases?: Array< object >;
 	hasVideoPressPurchase: boolean;
-	isFetchingPurchases: boolean;
+	isFetchingFeatures: boolean;
 };

--- a/projects/packages/videopress/src/client/admin/types/index.ts
+++ b/projects/packages/videopress/src/client/admin/types/index.ts
@@ -249,11 +249,13 @@ export type VideopressSelectors = {
 	getFirstVideoProcessed: () => boolean;
 	getDismissedFirstVideoPopover: () => boolean;
 	getIsFetching: () => boolean;
-	getFeatures: () => {
-		isVideoPressSupported: boolean;
-		isVideoPress1TBSupported: boolean;
-		isVideoPressUnlimitedSupported: boolean;
-	};
+	getFeatures: () =>
+		| {
+				isVideoPressSupported: boolean;
+				isVideoPress1TBSupported: boolean;
+				isVideoPressUnlimitedSupported: boolean;
+		  }
+		| undefined;
 
 	getPlaybackToken: ( guid: string ) => { guid: string; token: string };
 	isFetchingPlaybackToken: () => boolean;

--- a/projects/packages/videopress/src/client/admin/types/index.ts
+++ b/projects/packages/videopress/src/client/admin/types/index.ts
@@ -240,7 +240,7 @@ export type VideoPressSettings = {
 };
 
 export type VideopressSelectors = {
-	isFetchingPurchases: () => boolean;
+	isFetchingFeatures: () => boolean;
 	getVideo: ( id: number | string, addAtEnd: boolean ) => VideoPressVideo;
 	getVideoStateMetadata: ( id: number | string ) => MetadataVideo; // @todo use specific type
 	getVideos: () => VideoPressVideo[];
@@ -249,7 +249,11 @@ export type VideopressSelectors = {
 	getFirstVideoProcessed: () => boolean;
 	getDismissedFirstVideoPopover: () => boolean;
 	getIsFetching: () => boolean;
-	getPurchases: () => Array< object >;
+	getFeatures: () => {
+		isVideoPressSupported: boolean;
+		isVideoPress1TBSupported: boolean;
+		isVideoPressUnlimitedSupported: boolean;
+	};
 
 	getPlaybackToken: ( guid: string ) => { guid: string; token: string };
 	isFetchingPlaybackToken: () => boolean;

--- a/projects/packages/videopress/src/client/state/actions.js
+++ b/projects/packages/videopress/src/client/state/actions.js
@@ -38,8 +38,8 @@ import {
 	SET_VIDEO_UPLOADING_ERROR,
 	SET_VIDEO_PROCESSING,
 	SET_VIDEO_UPLOADED,
-	SET_IS_FETCHING_PURCHASES,
-	SET_PURCHASES,
+	SET_IS_FETCHING_FEATURES,
+	SET_FEATURES,
 	UPDATE_VIDEO_PRIVACY,
 	WP_REST_API_VIDEOPRESS_ENDPOINT,
 	UPDATE_VIDEO_POSTER,
@@ -323,12 +323,12 @@ const uploadVideoFromLibrary =
 		dispatch( { type: SET_VIDEO_UPLOADED, video } );
 	};
 
-const setIsFetchingPurchases = isFetching => {
-	return { type: SET_IS_FETCHING_PURCHASES, isFetching };
+const setIsFetchingFeatures = isFetching => {
+	return { type: SET_IS_FETCHING_FEATURES, isFetching };
 };
 
-const setPurchases = purchases => {
-	return { type: SET_PURCHASES, purchases };
+const setFeatures = features => {
+	return { type: SET_FEATURES, features };
 };
 
 const updateVideoPoster =
@@ -522,8 +522,8 @@ const actions = {
 	uploadVideo,
 	uploadVideoFromLibrary,
 
-	setIsFetchingPurchases,
-	setPurchases,
+	setIsFetchingFeatures,
+	setFeatures,
 
 	updateVideoPoster,
 

--- a/projects/packages/videopress/src/client/state/constants.js
+++ b/projects/packages/videopress/src/client/state/constants.js
@@ -14,6 +14,7 @@ export const WP_REST_API_VIDEOPRESS_META_ENDPOINT = 'wpcom/v2/videopress/meta';
 export const WP_REST_API_VIDEOPRESS_PLAYBACK_TOKEN_ENDPOINT = 'wpcom/v2/videopress/playback-jwt';
 export const WP_REST_API_VIDEOPRESS_SETTINGS_ENDPOINT = 'videopress/v1/settings';
 export const REST_API_SITE_INFO_ENDPOINT = 'videopress/v1/site';
+export const REST_API_FEATURES_ENDPOINT = 'videopress/v1/features';
 
 /*
  * Actions
@@ -49,8 +50,8 @@ export const SET_VIDEO_PROCESSING = 'SET_VIDEO_PROCESSING';
 export const SET_VIDEO_UPLOADED = 'SET_VIDEO_UPLOADED';
 export const SET_VIDEO_UPLOAD_PROGRESS = 'SET_VIDEO_UPLOAD_PROGRESS';
 
-export const SET_IS_FETCHING_PURCHASES = 'SET_IS_FETCHING_PURCHASES';
-export const SET_PURCHASES = 'SET_PURCHASES';
+export const SET_IS_FETCHING_FEATURES = 'SET_IS_FETCHING_FEATURES';
+export const SET_FEATURES = 'SET_FEATURES';
 
 export const SET_IS_FETCHING_PLAYBACK_TOKEN = 'SET_IS_FETCHING_PLAYBACK_TOKEN';
 export const SET_PLAYBACK_TOKEN = 'SET_PLAYBACK_TOKEN';

--- a/projects/packages/videopress/src/client/state/reducers.js
+++ b/projects/packages/videopress/src/client/state/reducers.js
@@ -23,8 +23,8 @@ import {
 	SET_VIDEO_UPLOADING_ERROR,
 	SET_VIDEO_PROCESSING,
 	SET_VIDEO_UPLOADED,
-	SET_IS_FETCHING_PURCHASES,
-	SET_PURCHASES,
+	SET_IS_FETCHING_FEATURES,
+	SET_FEATURES,
 	UPDATE_VIDEO_PRIVACY,
 	SET_LOCAL_VIDEOS,
 	SET_LOCAL_VIDEOS_QUERY,
@@ -728,19 +728,19 @@ const users = ( state, action ) => {
 	}
 };
 
-const purchases = ( state, action ) => {
+const features = ( state, action ) => {
 	switch ( action.type ) {
-		case SET_IS_FETCHING_PURCHASES: {
+		case SET_IS_FETCHING_FEATURES: {
 			return {
 				...state,
 				isFetching: action.isFetching,
 			};
 		}
 
-		case SET_PURCHASES: {
+		case SET_FEATURES: {
 			return {
 				...state,
-				items: action.purchases,
+				...action.features,
 				isFetching: false,
 			};
 		}
@@ -823,7 +823,7 @@ const siteSettings = ( state, action ) => {
 const reducers = combineReducers( {
 	videos,
 	localVideos,
-	purchases,
+	features,
 	users,
 	playbackTokens,
 	siteSettings,

--- a/projects/packages/videopress/src/client/state/resolvers.js
+++ b/projects/packages/videopress/src/client/state/resolvers.js
@@ -12,6 +12,7 @@ import {
 	WP_REST_API_MEDIA_ENDPOINT,
 	FLUSH_DELETED_VIDEOS,
 	REST_API_SITE_INFO_ENDPOINT,
+	REST_API_FEATURES_ENDPOINT,
 	SET_VIDEO_PROCESSING,
 	SET_LOCAL_VIDEOS_QUERY,
 	WP_REST_API_USERS_ENDPOINT,
@@ -440,6 +441,28 @@ const getVideoPressSettings = {
 		},
 };
 
+const getFeatures = {
+	isFulfilled: state => state?.features?.isVideoPressSupported !== undefined,
+
+	fulfill:
+		() =>
+		async ( { dispatch } ) => {
+			dispatch.setIsFetchingFeatures( true );
+
+			try {
+				const features = await apiFetch( {
+					path: REST_API_FEATURES_ENDPOINT,
+					method: 'GET',
+				} );
+
+				dispatch.setFeatures( features );
+				return features;
+			} catch ( error ) {
+				console.error( error ); // eslint-disable-line no-console
+			}
+		},
+};
+
 export default {
 	getStorageUsed,
 	getUploadedVideoCount,
@@ -453,4 +476,6 @@ export default {
 	getPlaybackToken,
 
 	getVideoPressSettings,
+
+	getFeatures,
 };

--- a/projects/packages/videopress/src/client/state/resolvers.js
+++ b/projects/packages/videopress/src/client/state/resolvers.js
@@ -459,6 +459,8 @@ const getFeatures = {
 				return features;
 			} catch ( error ) {
 				console.error( error ); // eslint-disable-line no-console
+			} finally {
+				dispatch.setIsFetchingFeatures( false );
 			}
 		},
 };

--- a/projects/packages/videopress/src/client/state/selectors.js
+++ b/projects/packages/videopress/src/client/state/selectors.js
@@ -83,11 +83,21 @@ export const isFetchingFeatures = state => {
 	return state?.features?.isFetching;
 };
 
-export const getFeatures = state => ( {
-	isVideoPressSupported: state?.features?.isVideoPressSupported ?? false,
-	isVideoPress1TBSupported: state?.features?.isVideoPress1TBSupported ?? false,
-	isVideoPressUnlimitedSupported: state?.features?.isVideoPressUnlimitedSupported ?? false,
-} );
+export const getFeatures = state => {
+	const features = state?.features;
+
+	// Return undefined when features haven't been loaded yet,
+	// so usePlan can fall back to static paidFeatures from initial state.
+	if ( features?.isVideoPressSupported === undefined ) {
+		return undefined;
+	}
+
+	return {
+		isVideoPressSupported: features.isVideoPressSupported ?? false,
+		isVideoPress1TBSupported: features.isVideoPress1TBSupported ?? false,
+		isVideoPressUnlimitedSupported: features.isVideoPressUnlimitedSupported ?? false,
+	};
+};
 
 export const getLocalVideos = state => {
 	return state?.localVideos?.items || [];

--- a/projects/packages/videopress/src/client/state/selectors.js
+++ b/projects/packages/videopress/src/client/state/selectors.js
@@ -79,13 +79,15 @@ export const getVideoStateMetadata = ( state, id ) => {
 	return _metaVideo;
 };
 
-export const isFetchingPurchases = state => {
-	return state?.purchases?.isFetching;
+export const isFetchingFeatures = state => {
+	return state?.features?.isFetching;
 };
 
-export const getPurchases = state => {
-	return state?.purchases?.items || [];
-};
+export const getFeatures = state => ( {
+	isVideoPressSupported: state?.features?.isVideoPressSupported ?? false,
+	isVideoPress1TBSupported: state?.features?.isVideoPress1TBSupported ?? false,
+	isVideoPressUnlimitedSupported: state?.features?.isVideoPressUnlimitedSupported ?? false,
+} );
 
 export const getLocalVideos = state => {
 	return state?.localVideos?.items || [];
@@ -154,8 +156,8 @@ const selectors = {
 	getUsers,
 	getUsersPagination,
 
-	getPurchases,
-	isFetchingPurchases,
+	getFeatures,
+	isFetchingFeatures,
 
 	getPlaybackToken,
 	isFetchingPlaybackToken,

--- a/projects/packages/videopress/src/client/state/test/reducers.js
+++ b/projects/packages/videopress/src/client/state/test/reducers.js
@@ -1,0 +1,76 @@
+import { SET_FEATURES, SET_IS_FETCHING_FEATURES } from '../constants';
+import reducers from '../reducers';
+
+describe( 'features reducer', () => {
+	it( 'should return initial state with undefined features', () => {
+		const state = reducers( undefined, { type: 'UNKNOWN_ACTION' } );
+		expect( state.features ).toBeUndefined();
+	} );
+
+	it( 'should handle SET_IS_FETCHING_FEATURES', () => {
+		const state = reducers( undefined, {
+			type: SET_IS_FETCHING_FEATURES,
+			isFetching: true,
+		} );
+		expect( state.features ).toEqual( {
+			isFetching: true,
+		} );
+	} );
+
+	it( 'should handle SET_IS_FETCHING_FEATURES toggling off', () => {
+		const initialState = {
+			features: { isFetching: true },
+		};
+		const state = reducers( initialState, {
+			type: SET_IS_FETCHING_FEATURES,
+			isFetching: false,
+		} );
+		expect( state.features ).toEqual( {
+			isFetching: false,
+		} );
+	} );
+
+	it( 'should handle SET_FEATURES', () => {
+		const initialState = {
+			features: { isFetching: true },
+		};
+		const state = reducers( initialState, {
+			type: SET_FEATURES,
+			features: {
+				isVideoPressSupported: true,
+				isVideoPress1TBSupported: true,
+				isVideoPressUnlimitedSupported: false,
+			},
+		} );
+		expect( state.features ).toEqual( {
+			isFetching: false, // Should be set to false when features arrive
+			isVideoPressSupported: true,
+			isVideoPress1TBSupported: true,
+			isVideoPressUnlimitedSupported: false,
+		} );
+	} );
+
+	it( 'should preserve existing features state when setting new features', () => {
+		const initialState = {
+			features: {
+				isFetching: true,
+				someOtherProp: 'value',
+			},
+		};
+		const state = reducers( initialState, {
+			type: SET_FEATURES,
+			features: {
+				isVideoPressSupported: true,
+				isVideoPress1TBSupported: false,
+				isVideoPressUnlimitedSupported: false,
+			},
+		} );
+		expect( state.features ).toEqual( {
+			isFetching: false,
+			someOtherProp: 'value',
+			isVideoPressSupported: true,
+			isVideoPress1TBSupported: false,
+			isVideoPressUnlimitedSupported: false,
+		} );
+	} );
+} );

--- a/projects/packages/videopress/src/client/state/test/resolvers.js
+++ b/projects/packages/videopress/src/client/state/test/resolvers.js
@@ -1,0 +1,99 @@
+import apiFetch from '@wordpress/api-fetch';
+import resolvers from '../resolvers';
+
+jest.mock( '@wordpress/api-fetch' );
+
+describe( 'getFeatures resolver', () => {
+	const { getFeatures } = resolvers;
+
+	describe( 'isFulfilled', () => {
+		it( 'should return false when features state does not exist', () => {
+			expect( getFeatures.isFulfilled( {} ) ).toBe( false );
+		} );
+
+		it( 'should return false when isVideoPressSupported is undefined', () => {
+			const state = {
+				features: {
+					isFetching: false,
+				},
+			};
+			expect( getFeatures.isFulfilled( state ) ).toBe( false );
+		} );
+
+		it( 'should return true when isVideoPressSupported is defined', () => {
+			const state = {
+				features: {
+					isVideoPressSupported: true,
+				},
+			};
+			expect( getFeatures.isFulfilled( state ) ).toBe( true );
+		} );
+
+		it( 'should return true when isVideoPressSupported is false', () => {
+			const state = {
+				features: {
+					isVideoPressSupported: false,
+				},
+			};
+			expect( getFeatures.isFulfilled( state ) ).toBe( true );
+		} );
+	} );
+
+	describe( 'fulfill', () => {
+		let dispatch;
+
+		beforeEach( () => {
+			dispatch = {
+				setIsFetchingFeatures: jest.fn(),
+				setFeatures: jest.fn(),
+			};
+			jest.clearAllMocks();
+		} );
+
+		it( 'should fetch features and dispatch actions on success', async () => {
+			const mockFeatures = {
+				isVideoPressSupported: true,
+				isVideoPress1TBSupported: true,
+				isVideoPressUnlimitedSupported: false,
+			};
+			apiFetch.mockResolvedValue( mockFeatures );
+
+			const result = await getFeatures.fulfill()( { dispatch } );
+
+			expect( dispatch.setIsFetchingFeatures ).toHaveBeenCalledWith( true );
+			expect( apiFetch ).toHaveBeenCalledWith( {
+				path: 'videopress/v1/features',
+				method: 'GET',
+			} );
+			expect( dispatch.setFeatures ).toHaveBeenCalledWith( mockFeatures );
+			expect( dispatch.setIsFetchingFeatures ).toHaveBeenCalledWith( false );
+			expect( result ).toEqual( mockFeatures );
+		} );
+
+		it( 'should reset isFetching on error', async () => {
+			const error = new Error( 'API error' );
+			apiFetch.mockRejectedValue( error );
+
+			const consoleSpy = jest.spyOn( console, 'error' ).mockImplementation( () => {} );
+
+			await getFeatures.fulfill()( { dispatch } );
+
+			expect( dispatch.setIsFetchingFeatures ).toHaveBeenCalledWith( true );
+			expect( dispatch.setFeatures ).not.toHaveBeenCalled();
+			expect( dispatch.setIsFetchingFeatures ).toHaveBeenCalledWith( false );
+			expect( consoleSpy ).toHaveBeenCalledWith( error );
+
+			consoleSpy.mockRestore();
+		} );
+
+		it( 'should call setIsFetchingFeatures(false) in finally block', async () => {
+			apiFetch.mockResolvedValue( {} );
+
+			await getFeatures.fulfill()( { dispatch } );
+
+			const calls = dispatch.setIsFetchingFeatures.mock.calls;
+			expect( calls[ 0 ][ 0 ] ).toBe( true );
+			expect( calls[ 1 ][ 0 ] ).toBe( false );
+		} );
+	} );
+} );

--- a/projects/packages/videopress/src/client/state/test/selectors.js
+++ b/projects/packages/videopress/src/client/state/test/selectors.js
@@ -1,4 +1,4 @@
-import { getProcessedAllVideosBeingRemoved } from '../selectors';
+import { getProcessedAllVideosBeingRemoved, getFeatures, isFetchingFeatures } from '../selectors';
 
 describe( 'getProcessedAllVideosBeingRemoved()', () => {
 	it( 'should return true when videos finished being removed', () => {
@@ -22,5 +22,75 @@ describe( 'getProcessedAllVideosBeingRemoved()', () => {
 		const output = getProcessedAllVideosBeingRemoved( state );
 		// This would return undefined, which is falsy.
 		expect( output ).toBeFalsy();
+	} );
+} );
+
+describe( 'getFeatures()', () => {
+	it( 'should return undefined when features have not been loaded', () => {
+		const state = {};
+		expect( getFeatures( state ) ).toBeUndefined();
+	} );
+
+	it( 'should return undefined when features object exists but isVideoPressSupported is undefined', () => {
+		const state = {
+			features: {
+				isFetching: false,
+			},
+		};
+		expect( getFeatures( state ) ).toBeUndefined();
+	} );
+
+	it( 'should return features object when loaded', () => {
+		const state = {
+			features: {
+				isVideoPressSupported: true,
+				isVideoPress1TBSupported: true,
+				isVideoPressUnlimitedSupported: false,
+			},
+		};
+		expect( getFeatures( state ) ).toEqual( {
+			isVideoPressSupported: true,
+			isVideoPress1TBSupported: true,
+			isVideoPressUnlimitedSupported: false,
+		} );
+	} );
+
+	it( 'should default missing feature flags to false', () => {
+		const state = {
+			features: {
+				isVideoPressSupported: true,
+				// Other flags are missing
+			},
+		};
+		expect( getFeatures( state ) ).toEqual( {
+			isVideoPressSupported: true,
+			isVideoPress1TBSupported: false,
+			isVideoPressUnlimitedSupported: false,
+		} );
+	} );
+} );
+
+describe( 'isFetchingFeatures()', () => {
+	it( 'should return undefined when features state does not exist', () => {
+		const state = {};
+		expect( isFetchingFeatures( state ) ).toBeUndefined();
+	} );
+
+	it( 'should return true when fetching', () => {
+		const state = {
+			features: {
+				isFetching: true,
+			},
+		};
+		expect( isFetchingFeatures( state ) ).toBe( true );
+	} );
+
+	it( 'should return false when not fetching', () => {
+		const state = {
+			features: {
+				isFetching: false,
+			},
+		};
+		expect( isFetchingFeatures( state ) ).toBe( false );
 	} );
 } );

--- a/projects/packages/videopress/tests/php/VideoPress_Rest_Api_V1_Features_Test.php
+++ b/projects/packages/videopress/tests/php/VideoPress_Rest_Api_V1_Features_Test.php
@@ -7,8 +7,12 @@
 
 namespace Automattic\Jetpack\VideoPress;
 
+use Automattic\Jetpack\My_Jetpack\Product;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use WorDBless\BaseTestCase;
+use WP_REST_Request;
+use WP_REST_Server;
 
 /**
  * Tests for the VideoPress features REST API endpoint.
@@ -16,34 +20,98 @@ use WorDBless\BaseTestCase;
 class VideoPress_Rest_Api_V1_Features_Test extends BaseTestCase {
 
 	/**
-	 * Test that the REST route is registered.
+	 * REST server instance.
+	 *
+	 * @var WP_REST_Server
 	 */
-	public function test_rest_route_is_registered() {
-		VideoPress_Rest_Api_V1_Features::init();
-		do_action( 'rest_api_init' );
-
-		$routes = rest_get_server()->get_routes();
-		$this->assertArrayHasKey( '/videopress/v1/features', $routes );
-	}
+	private $server;
 
 	/**
-	 * Test permissions callback requires read capability.
+	 * Test user ID.
+	 *
+	 * @var int
 	 */
-	public function test_permissions_callback_requires_read() {
-		// Non-logged in user should not have read capability.
-		wp_set_current_user( 0 );
-		$this->assertFalse( VideoPress_Rest_Api_V1_Features::permissions_callback() );
+	private $user_id;
 
-		// Create a subscriber user (has read capability).
-		$user_id = wp_insert_user(
+	/**
+	 * Set up the test environment.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		global $wp_rest_server;
+		$wp_rest_server = new WP_REST_Server();
+		$this->server   = $wp_rest_server;
+
+		// Create a user with read capability.
+		$this->user_id = wp_insert_user(
 			array(
 				'user_login' => 'test_subscriber',
 				'user_pass'  => 'password',
 				'role'       => 'subscriber',
 			)
 		);
-		wp_set_current_user( $user_id );
-		$this->assertTrue( VideoPress_Rest_Api_V1_Features::permissions_callback() );
+
+		// Register REST routes.
+		VideoPress_Rest_Api_V1_Features::init();
+		do_action( 'rest_api_init' );
+	}
+
+	/**
+	 * Clean up after tests.
+	 */
+	public function tearDown(): void {
+		parent::tearDown();
+
+		global $wp_rest_server;
+		$wp_rest_server = null;
+
+		wp_set_current_user( 0 );
+	}
+
+	/**
+	 * Test that the REST route is registered.
+	 */
+	public function test_rest_route_is_registered() {
+		$routes = rest_get_server()->get_routes();
+		$this->assertArrayHasKey( '/videopress/v1/features', $routes );
+	}
+
+	/**
+	 * Test that unauthenticated requests are rejected.
+	 */
+	public function test_unauthenticated_request_rejected() {
+		wp_set_current_user( 0 );
+
+		$request  = new WP_REST_Request( 'GET', '/videopress/v1/features' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 401, $response->get_status() );
+	}
+
+	/**
+	 * Test that authenticated requests succeed.
+	 *
+	 * @runInSeparateProcess
+	 */
+	#[RunInSeparateProcess]
+	public function test_authenticated_request_succeeds() {
+		wp_set_current_user( $this->user_id );
+
+		// Seed the transient to avoid WPCOM API call.
+		set_transient(
+			Product::MY_JETPACK_SITE_FEATURES_TRANSIENT_KEY,
+			array(
+				'active'    => array(),
+				'available' => array(),
+			),
+			15
+		);
+
+		$request  = new WP_REST_Request( 'GET', '/videopress/v1/features' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 200, $response->get_status() );
 	}
 
 	/**
@@ -97,20 +165,39 @@ class VideoPress_Rest_Api_V1_Features_Test extends BaseTestCase {
 	}
 
 	/**
-	 * Test that feature flags are correctly mapped from WPCOM features.
+	 * Test that the endpoint correctly maps WPCOM features to VideoPress feature flags.
 	 *
-	 * @param array $active_features Features returned by WPCOM API.
-	 * @param array $expected Expected feature flags.
+	 * This test seeds the My Jetpack transient cache with mock data, then dispatches
+	 * a REST request to the endpoint. Each test runs in a separate process to avoid
+	 * static cache pollution from Product::get_site_features_from_wpcom().
+	 *
+	 * @param array $active_features Features that would be returned by WPCOM API.
+	 * @param array $expected Expected feature flags from the endpoint.
+	 *
+	 * @runInSeparateProcess
 	 * @dataProvider feature_flag_mapping_provider
 	 */
+	#[RunInSeparateProcess]
 	#[DataProvider( 'feature_flag_mapping_provider' )]
 	public function test_feature_flag_mapping( array $active_features, array $expected ) {
-		$response = array(
-			'isVideoPressSupported'          => true, // isVideoPressSupported is always true (free tier).
-			'isVideoPress1TBSupported'       => in_array( 'videopress-1tb-storage', $active_features, true ),
-			'isVideoPressUnlimitedSupported' => in_array( 'videopress-unlimited-storage', $active_features, true ),
+		wp_set_current_user( $this->user_id );
+
+		// Seed the transient that Product::get_site_features_from_wpcom() checks.
+		// This bypasses the WPCOM API call since the transient is checked first.
+		set_transient(
+			Product::MY_JETPACK_SITE_FEATURES_TRANSIENT_KEY,
+			array(
+				'active'    => $active_features,
+				'available' => array(),
+			),
+			15
 		);
 
-		$this->assertSame( $expected, $response );
+		// Dispatch actual REST request.
+		$request  = new WP_REST_Request( 'GET', '/videopress/v1/features' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertSame( $expected, $response->get_data() );
 	}
 }

--- a/projects/packages/videopress/tests/php/VideoPress_Rest_Api_V1_Features_Test.php
+++ b/projects/packages/videopress/tests/php/VideoPress_Rest_Api_V1_Features_Test.php
@@ -166,10 +166,10 @@ class VideoPress_Rest_Api_V1_Features_Test extends BaseTestCase {
 			),
 
 			/*
-			 * Note: The 'videopress' feature check is guarded by function_exists('wpcom_site_has_feature').
-			 * In this test environment (non-wpcom), that function doesn't exist, so 'videopress'
+			 * Note: The 'videopress' feature check is guarded by Host::is_wpcom_platform().
+			 * In this test environment (non-wpcom), that returns false, so 'videopress'
 			 * alone won't trigger isVideoPress1TBSupported. On actual WordPress.com sites,
-			 * wpcom_site_has_feature exists and the 'videopress' feature would work.
+			 * is_wpcom_platform() returns true and the 'videopress' feature would work.
 			 */
 			'wpcom videopress feature (non-wpcom env)' => array(
 				'active_features' => array( 'videopress' ),

--- a/projects/packages/videopress/tests/php/VideoPress_Rest_Api_V1_Features_Test.php
+++ b/projects/packages/videopress/tests/php/VideoPress_Rest_Api_V1_Features_Test.php
@@ -164,6 +164,22 @@ class VideoPress_Rest_Api_V1_Features_Test extends BaseTestCase {
 					'isVideoPressUnlimitedSupported' => false,
 				),
 			),
+			'Atomic videopress/video feature' => array(
+				'active_features' => array( 'videopress/video' ),
+				'expected'        => array(
+					'isVideoPressSupported'          => true,
+					'isVideoPress1TBSupported'       => true,
+					'isVideoPressUnlimitedSupported' => false,
+				),
+			),
+			'both 1TB and videopress/video'   => array(
+				'active_features' => array( 'videopress-1tb-storage', 'videopress/video' ),
+				'expected'        => array(
+					'isVideoPressSupported'          => true,
+					'isVideoPress1TBSupported'       => true,
+					'isVideoPressUnlimitedSupported' => false,
+				),
+			),
 		);
 	}
 

--- a/projects/packages/videopress/tests/php/VideoPress_Rest_Api_V1_Features_Test.php
+++ b/projects/packages/videopress/tests/php/VideoPress_Rest_Api_V1_Features_Test.php
@@ -1,0 +1,148 @@
+<?php
+/**
+ * Tests for VideoPress_Rest_Api_V1_Features.
+ *
+ * @package automattic/jetpack-videopress
+ */
+
+namespace Automattic\Jetpack\VideoPress;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use WorDBless\BaseTestCase;
+
+/**
+ * Tests for the VideoPress features REST API endpoint.
+ */
+class VideoPress_Rest_Api_V1_Features_Test extends BaseTestCase {
+
+	/**
+	 * Test that the REST route is registered.
+	 */
+	public function test_rest_route_is_registered() {
+		VideoPress_Rest_Api_V1_Features::init();
+		do_action( 'rest_api_init' );
+
+		$routes = rest_get_server()->get_routes();
+		$this->assertArrayHasKey( '/videopress/v1/features', $routes );
+	}
+
+	/**
+	 * Test permissions callback requires read capability.
+	 */
+	public function test_permissions_callback_requires_read() {
+		// Non-logged in user should not have read capability.
+		wp_set_current_user( 0 );
+		$this->assertFalse( VideoPress_Rest_Api_V1_Features::permissions_callback() );
+
+		// Create a subscriber user (has read capability).
+		$user_id = wp_insert_user(
+			array(
+				'user_login' => 'test_subscriber',
+				'user_pass'  => 'password',
+				'role'       => 'subscriber',
+			)
+		);
+		wp_set_current_user( $user_id );
+		$this->assertTrue( VideoPress_Rest_Api_V1_Features::permissions_callback() );
+	}
+
+	/**
+	 * Data provider for feature flag mapping tests.
+	 *
+	 * @return array[] Test cases.
+	 */
+	public static function feature_flag_mapping_provider(): array {
+		return array(
+			'free tier - no paid features'    => array(
+				'active_features' => array(),
+				'expected'        => array(
+					'isVideoPressSupported'          => true,
+					'isVideoPress1TBSupported'       => false,
+					'isVideoPressUnlimitedSupported' => false,
+				),
+			),
+			'paid 1TB plan'                   => array(
+				'active_features' => array( 'videopress-1tb-storage' ),
+				'expected'        => array(
+					'isVideoPressSupported'          => true,
+					'isVideoPress1TBSupported'       => true,
+					'isVideoPressUnlimitedSupported' => false,
+				),
+			),
+			'unlimited plan (Complete)'       => array(
+				'active_features' => array( 'videopress-1tb-storage', 'videopress-unlimited-storage' ),
+				'expected'        => array(
+					'isVideoPressSupported'          => true,
+					'isVideoPress1TBSupported'       => true,
+					'isVideoPressUnlimitedSupported' => true,
+				),
+			),
+			'only unlimited (edge case)'      => array(
+				'active_features' => array( 'videopress-unlimited-storage' ),
+				'expected'        => array(
+					'isVideoPressSupported'          => true,
+					'isVideoPress1TBSupported'       => false,
+					'isVideoPressUnlimitedSupported' => true,
+				),
+			),
+			'other features do not affect VP' => array(
+				'active_features' => array( 'some-other-feature', 'another-feature' ),
+				'expected'        => array(
+					'isVideoPressSupported'          => true,
+					'isVideoPress1TBSupported'       => false,
+					'isVideoPressUnlimitedSupported' => false,
+				),
+			),
+		);
+	}
+
+	/**
+	 * Test that feature flags are correctly mapped from WPCOM features.
+	 *
+	 * @param array $active_features Features returned by WPCOM API.
+	 * @param array $expected Expected feature flags.
+	 * @dataProvider feature_flag_mapping_provider
+	 */
+	#[DataProvider( 'feature_flag_mapping_provider' )]
+	public function test_feature_flag_mapping( array $active_features, array $expected ) {
+		// Mock the Product::get_site_features_from_wpcom() method.
+		$mock_features = array( 'active' => $active_features );
+
+		// Use a filter or mock to inject the test data.
+		add_filter(
+			'pre_http_request',
+			function () use ( $mock_features ) {
+				return array(
+					'response' => array( 'code' => 200 ),
+					'body'     => wp_json_encode( $mock_features, JSON_UNESCAPED_SLASHES ),
+				);
+			}
+		);
+
+		// Since we can't easily mock the static Product class, we test the logic directly.
+		$active   = $mock_features['active'];
+		$response = array(
+			'isVideoPressSupported'          => true,
+			'isVideoPress1TBSupported'       => in_array( 'videopress-1tb-storage', $active, true ),
+			'isVideoPressUnlimitedSupported' => in_array( 'videopress-unlimited-storage', $active, true ),
+		);
+
+		$this->assertSame( $expected, $response );
+	}
+
+	/**
+	 * Test that isVideoPressSupported is always true (free tier support).
+	 */
+	public function test_videopress_supported_always_true() {
+		// The free tier always has basic VideoPress support.
+		// This is hardcoded in the endpoint response.
+		$active   = array();
+		$response = array(
+			'isVideoPressSupported'          => true, // Always true
+			'isVideoPress1TBSupported'       => in_array( 'videopress-1tb-storage', $active, true ),
+			'isVideoPressUnlimitedSupported' => in_array( 'videopress-unlimited-storage', $active, true ),
+		);
+
+		$this->assertTrue( $response['isVideoPressSupported'] );
+	}
+}

--- a/projects/packages/videopress/tests/php/VideoPress_Rest_Api_V1_Features_Test.php
+++ b/projects/packages/videopress/tests/php/VideoPress_Rest_Api_V1_Features_Test.php
@@ -105,44 +105,12 @@ class VideoPress_Rest_Api_V1_Features_Test extends BaseTestCase {
 	 */
 	#[DataProvider( 'feature_flag_mapping_provider' )]
 	public function test_feature_flag_mapping( array $active_features, array $expected ) {
-		// Mock the Product::get_site_features_from_wpcom() method.
-		$mock_features = array( 'active' => $active_features );
-
-		// Use a filter or mock to inject the test data.
-		add_filter(
-			'pre_http_request',
-			function () use ( $mock_features ) {
-				return array(
-					'response' => array( 'code' => 200 ),
-					'body'     => wp_json_encode( $mock_features, JSON_UNESCAPED_SLASHES ),
-				);
-			}
-		);
-
-		// Since we can't easily mock the static Product class, we test the logic directly.
-		$active   = $mock_features['active'];
 		$response = array(
-			'isVideoPressSupported'          => true,
-			'isVideoPress1TBSupported'       => in_array( 'videopress-1tb-storage', $active, true ),
-			'isVideoPressUnlimitedSupported' => in_array( 'videopress-unlimited-storage', $active, true ),
+			'isVideoPressSupported'          => true, // isVideoPressSupported is always true (free tier).
+			'isVideoPress1TBSupported'       => in_array( 'videopress-1tb-storage', $active_features, true ),
+			'isVideoPressUnlimitedSupported' => in_array( 'videopress-unlimited-storage', $active_features, true ),
 		);
 
 		$this->assertSame( $expected, $response );
-	}
-
-	/**
-	 * Test that isVideoPressSupported is always true (free tier support).
-	 */
-	public function test_videopress_supported_always_true() {
-		// The free tier always has basic VideoPress support.
-		// This is hardcoded in the endpoint response, not derived from features.
-		// Even with no active features, isVideoPressSupported should be true.
-		$expected = array(
-			'isVideoPressSupported'          => true,
-			'isVideoPress1TBSupported'       => false,
-			'isVideoPressUnlimitedSupported' => false,
-		);
-
-		$this->assertTrue( $expected['isVideoPressSupported'] );
 	}
 }

--- a/projects/packages/videopress/tests/php/VideoPress_Rest_Api_V1_Features_Test.php
+++ b/projects/packages/videopress/tests/php/VideoPress_Rest_Api_V1_Features_Test.php
@@ -135,14 +135,14 @@ class VideoPress_Rest_Api_V1_Features_Test extends BaseTestCase {
 	 */
 	public function test_videopress_supported_always_true() {
 		// The free tier always has basic VideoPress support.
-		// This is hardcoded in the endpoint response.
-		$active   = array();
-		$response = array(
-			'isVideoPressSupported'          => true, // Always true
-			'isVideoPress1TBSupported'       => in_array( 'videopress-1tb-storage', $active, true ),
-			'isVideoPressUnlimitedSupported' => in_array( 'videopress-unlimited-storage', $active, true ),
+		// This is hardcoded in the endpoint response, not derived from features.
+		// Even with no active features, isVideoPressSupported should be true.
+		$expected = array(
+			'isVideoPressSupported'          => true,
+			'isVideoPress1TBSupported'       => false,
+			'isVideoPressUnlimitedSupported' => false,
 		);
 
-		$this->assertTrue( $response['isVideoPressSupported'] );
+		$this->assertTrue( $expected['isVideoPressSupported'] );
 	}
 }

--- a/projects/packages/videopress/tests/php/VideoPress_Rest_Api_V1_Features_Test.php
+++ b/projects/packages/videopress/tests/php/VideoPress_Rest_Api_V1_Features_Test.php
@@ -124,7 +124,7 @@ class VideoPress_Rest_Api_V1_Features_Test extends BaseTestCase {
 	 */
 	public static function feature_flag_mapping_provider(): array {
 		return array(
-			'free tier - no paid features'    => array(
+			'free tier - no paid features'             => array(
 				'active_features' => array(),
 				'expected'        => array(
 					'isVideoPressSupported'          => true,
@@ -132,7 +132,7 @@ class VideoPress_Rest_Api_V1_Features_Test extends BaseTestCase {
 					'isVideoPressUnlimitedSupported' => false,
 				),
 			),
-			'paid 1TB plan'                   => array(
+			'paid 1TB plan'                            => array(
 				'active_features' => array( 'videopress-1tb-storage' ),
 				'expected'        => array(
 					'isVideoPressSupported'          => true,
@@ -140,7 +140,7 @@ class VideoPress_Rest_Api_V1_Features_Test extends BaseTestCase {
 					'isVideoPressUnlimitedSupported' => false,
 				),
 			),
-			'unlimited plan (Complete)'       => array(
+			'unlimited plan (Complete)'                => array(
 				'active_features' => array( 'videopress-1tb-storage', 'videopress-unlimited-storage' ),
 				'expected'        => array(
 					'isVideoPressSupported'          => true,
@@ -148,7 +148,7 @@ class VideoPress_Rest_Api_V1_Features_Test extends BaseTestCase {
 					'isVideoPressUnlimitedSupported' => true,
 				),
 			),
-			'only unlimited (edge case)'      => array(
+			'only unlimited (edge case)'               => array(
 				'active_features' => array( 'videopress-unlimited-storage' ),
 				'expected'        => array(
 					'isVideoPressSupported'          => true,
@@ -156,7 +156,7 @@ class VideoPress_Rest_Api_V1_Features_Test extends BaseTestCase {
 					'isVideoPressUnlimitedSupported' => true,
 				),
 			),
-			'other features do not affect VP' => array(
+			'other features do not affect VP'          => array(
 				'active_features' => array( 'some-other-feature', 'another-feature' ),
 				'expected'        => array(
 					'isVideoPressSupported'          => true,
@@ -164,16 +164,23 @@ class VideoPress_Rest_Api_V1_Features_Test extends BaseTestCase {
 					'isVideoPressUnlimitedSupported' => false,
 				),
 			),
-			'Atomic videopress/video feature' => array(
-				'active_features' => array( 'videopress/video' ),
+
+			/*
+			 * Note: The 'videopress' feature check is guarded by function_exists('wpcom_site_has_feature').
+			 * In this test environment (non-wpcom), that function doesn't exist, so 'videopress'
+			 * alone won't trigger isVideoPress1TBSupported. On actual WordPress.com sites,
+			 * wpcom_site_has_feature exists and the 'videopress' feature would work.
+			 */
+			'wpcom videopress feature (non-wpcom env)' => array(
+				'active_features' => array( 'videopress' ),
 				'expected'        => array(
 					'isVideoPressSupported'          => true,
-					'isVideoPress1TBSupported'       => true,
+					'isVideoPress1TBSupported'       => false,
 					'isVideoPressUnlimitedSupported' => false,
 				),
 			),
-			'both 1TB and videopress/video'   => array(
-				'active_features' => array( 'videopress-1tb-storage', 'videopress/video' ),
+			'both 1TB and wpcom videopress'            => array(
+				'active_features' => array( 'videopress-1tb-storage', 'videopress' ),
 				'expected'        => array(
 					'isVideoPressSupported'          => true,
 					'isVideoPress1TBSupported'       => true,

--- a/projects/packages/videopress/tests/php/VideoPress_Rest_Api_V1_Features_Test.php
+++ b/projects/packages/videopress/tests/php/VideoPress_Rest_Api_V1_Features_Test.php
@@ -9,6 +9,7 @@ namespace Automattic\Jetpack\VideoPress;
 
 use Automattic\Jetpack\My_Jetpack\Product;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
 use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use WorDBless\BaseTestCase;
 use WP_REST_Request;
@@ -93,8 +94,10 @@ class VideoPress_Rest_Api_V1_Features_Test extends BaseTestCase {
 	 * Test that authenticated requests succeed.
 	 *
 	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
 	 */
 	#[RunInSeparateProcess]
+	#[PreserveGlobalState( false )]
 	public function test_authenticated_request_succeeds() {
 		wp_set_current_user( $this->user_id );
 
@@ -175,9 +178,11 @@ class VideoPress_Rest_Api_V1_Features_Test extends BaseTestCase {
 	 * @param array $expected Expected feature flags from the endpoint.
 	 *
 	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
 	 * @dataProvider feature_flag_mapping_provider
 	 */
 	#[RunInSeparateProcess]
+	#[PreserveGlobalState( false )]
 	#[DataProvider( 'feature_flag_mapping_provider' )]
 	public function test_feature_flag_mapping( array $active_features, array $expected ) {
 		wp_set_current_user( $this->user_id );

--- a/projects/packages/videopress/tests/php/bootstrap.php
+++ b/projects/packages/videopress/tests/php/bootstrap.php
@@ -5,6 +5,11 @@
  * @package automattic/
  */
 
+// Work around WordPress bug when `@runInSeparateProcess` is used.
+if ( empty( $_SERVER['SCRIPT_FILENAME'] ) ) {
+	$_SERVER['SCRIPT_FILENAME'] = __DIR__ . '/vendor/phpunit/phpunit/phpunit';
+}
+
 /**
  * Include the composer autoloader.
  */


### PR DESCRIPTION
Fixes VIDP-215.

Replaces plan check with feature check for VideoPress js client.

## Proposed changes:

* Fix upgrade notice incorrectly showing for A4A (Automattic for Agencies) VideoPress customers by using backend feature flags instead of hardcoded plan slugs
* Add `videopress/v1/features` REST endpoint that fetches fresh features from WPCOM via My Jetpack's `Product::get_site_features_from_wpcom()`
* Add Redux store integration for dynamic features fetching with fallback to static `paidFeatures` while loading
* Remove dead purchases code (actions existed but were never dispatched)
* Fix missing `from` prop in `useProductCheckoutWorkflow` call

### Background

The VideoPress admin dashboard was showing "You have used your free video upload - Upgrade now" for customers with A4A VideoPress plans, even though they had a valid paid subscription.

**Root cause**: The frontend used a hardcoded list of ~50 plan slugs to determine paid status. A4A plan slugs were missing.

**Fix**: Use `paidFeatures.isVideoPress1TBSupported` from the backend, and fetch features dynamically from WPCOM API so they're fresh after purchases without requiring a page reload.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

N/A - Bug fix for existing functionality

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

* Set up a site with an A4A VideoPress plan (or any paid VideoPress plan)
* Go to wp-admin → Jetpack → VideoPress
* Verify the upgrade banner does NOT appear for paid customers
* For free tier: upload one video, verify the upgrade banner appears after

To test the API endpoint:
* Call `GET /wp-json/videopress/v1/features` (authenticated)
* Should return feature flags based on site's plan