### PR TITLE
Forms: Remove CSS that hides editor toolbar and sidebar panel tabs

### DIFF
--- a/projects/packages/forms/changelog/fix-form-editor-do-not-hide-toolbar
+++ b/projects/packages/forms/changelog/fix-form-editor-do-not-hide-toolbar
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Form Editor: stop hiding editor toolbar and sidebar panel tabs.

--- a/projects/packages/forms/src/form-editor/style.scss
+++ b/projects/packages/forms/src/form-editor/style.scss
@@ -1,11 +1,3 @@
-.post-type-jetpack_form .editor-sidebar__panel-tabs {
-	display: none;
-}
-
 .post-type-jetpack_form .block-editor-block-breadcrumb li:first-child {
 	display: none;
-}
-
-.post-type-jetpack_form .block-editor-block-list__layout .block-editor-block-list__block.is-selected {
-	box-shadow: none;
 }


### PR DESCRIPTION
Before:

<img width="327" height="514" alt="Screenshot 2026-01-29 at 1 08 11 PM" src="https://github.com/user-attachments/assets/6903bcca-b889-45af-a1c4-02023901f22e" />


After:
<img width="357" height="515" alt="Screenshot 2026-01-29 at 1 07 50 PM" src="https://github.com/user-attachments/assets/3bdeccb3-6a04-400f-942a-de118c784093" />

<img width="341" height="535" alt="Screenshot 2026-01-29 at 1 07 39 PM" src="https://github.com/user-attachments/assets/eee45141-fbed-4482-bce4-300c1fe9ffd4" />



## Proposed changes:
* Remove CSS that was hiding the editor sidebar panel tabs (`.editor-sidebar__panel-tabs`)
* Remove CSS that was removing box-shadow from selected blocks in the form editor
* These styles were unnecessarily hiding standard WordPress editor UI elements

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

* Go to Forms > Add New in wp-admin to open the form editor
* Verify the editor sidebar panel tabs are now visible (Settings/Block tabs)
* Select a block in the form and verify it has the standard WordPress selection styling
* Confirm the form editor otherwise works as expected