### PR TITLE
Charts: Allow responsive charts to fill parent container without aspect ratio

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1591,6 +1591,9 @@ importers:
       '@wordpress/postcss-plugins-preset':
         specifier: 5.39.0
         version: 5.39.0(postcss@8.5.6)
+      '@wordpress/theme':
+        specifier: 0.5.0
+        version: 0.5.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@16.26.1)
       allure-playwright:
         specifier: 2.15.1
         version: 2.15.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -368,11 +368,11 @@ importers:
         specifier: ^6.0.0
         version: 6.12.0
       '@wordpress/theme':
-        specifier: 0.5.0
-        version: 0.5.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@16.26.1)
+        specifier: 0.6.0
+        version: 0.6.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@16.26.1)
       '@wordpress/ui':
-        specifier: 0.5.0
-        version: 0.5.0(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 0.6.0
+        version: 0.6.0(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@16.26.1)
       clsx:
         specifier: 2.1.1
         version: 2.1.1
@@ -10789,13 +10789,6 @@ packages:
   '@wordpress/token-list@3.39.0':
     resolution: {integrity: sha512-p8lVv2wPJ76CqGnwRCeQcho6MPDlBdcdyCmAtgrIe5BGS19Tvp+EpsSkfvKrFa9JkAWtOSmAiKVqIHW/LqkujA==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
-
-  '@wordpress/ui@0.5.0':
-    resolution: {integrity: sha512-D/sxkPIzptHEGEWWNh9UEdz6ySAmK3LBsqGO2dhom2kJ8RCsZMYwHXNOv2zYD1M+6rjfIthYWXAXNbDzb365Rg==}
-    engines: {node: '>=20.10.0', npm: '>=10.2.3'}
-    peerDependencies:
-      react: ^18.0.0
-      react-dom: ^18.0.0
 
   '@wordpress/ui@0.6.0':
     resolution: {integrity: sha512-KV7JkQ4bvuCWZ2+82jnhzthomCIS7wO8+6cSrkhQUgeVbp0TdGCXCFHwKXfw1O/P/S6IClqpTFgInXFz/gA1DQ==}
@@ -26352,20 +26345,6 @@ snapshots:
       stylelint: 16.26.1
 
   '@wordpress/token-list@3.39.0': {}
-
-  '@wordpress/ui@0.5.0(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@base-ui/react': 1.1.0(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/a11y': 4.39.0
-      '@wordpress/element': 6.39.0
-      '@wordpress/i18n': 6.12.0
-      '@wordpress/icons': 11.6.0(react@18.3.1)
-      '@wordpress/primitives': 4.39.0(react@18.3.1)
-      clsx: 2.1.1
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-    transitivePeerDependencies:
-      - '@types/react'
 
   '@wordpress/ui@0.6.0(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@16.26.1)':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1592,8 +1592,8 @@ importers:
         specifier: 5.39.0
         version: 5.39.0(postcss@8.5.6)
       '@wordpress/theme':
-        specifier: 0.5.0
-        version: 0.5.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@16.26.1)
+        specifier: 0.6.0
+        version: 0.6.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@16.26.1)
       allure-playwright:
         specifier: 2.15.1
         version: 2.15.1
@@ -10763,17 +10763,6 @@ packages:
   '@wordpress/sync@1.39.0':
     resolution: {integrity: sha512-oYNxhMaNf2ZYOIuPmxkBgFNvqiSnnT8uTHrFgim09aN2fxA8Mu1G86EBokqHfAXBfx/NTiYOLbCy4bhGsjdbQg==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
-
-  '@wordpress/theme@0.5.0':
-    resolution: {integrity: sha512-6V14snLXUqVs3fBPmGJhWkgtWcrwEe7vUS04nTl7hyI5uyL+N7LXRldWTjnzwaQL0ywBIx4u13gJU/GZqOc8dQ==}
-    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
-    peerDependencies:
-      react: ^18.0.0
-      react-dom: ^18.0.0
-      stylelint: ^16.8.2
-    peerDependenciesMeta:
-      stylelint:
-        optional: true
 
   '@wordpress/theme@0.6.0':
     resolution: {integrity: sha512-n/O1djUn+jny46JyqCwD77nPV4zCUBIn+0ICp8fDYLXpQ7FfCfCrEfhlkQkcVB45KC1iu6IMAsLOA/9hzavHoQ==}
@@ -26310,17 +26299,6 @@ snapshots:
       lib0: 0.2.85
       y-protocols: 1.0.7(yjs@13.6.29)
       yjs: 13.6.29
-
-  '@wordpress/theme@0.5.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@16.26.1)':
-    dependencies:
-      '@wordpress/element': 6.39.0
-      '@wordpress/private-apis': 1.39.0
-      colorjs.io: 0.6.1
-      memize: 2.1.1
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-    optionalDependencies:
-      stylelint: 16.26.1
 
   '@wordpress/theme@0.6.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -367,6 +367,12 @@ importers:
       '@wordpress/i18n':
         specifier: ^6.0.0
         version: 6.12.0
+      '@wordpress/theme':
+        specifier: 0.5.0
+        version: 0.5.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@16.26.1)
+      '@wordpress/ui':
+        specifier: 0.5.0
+        version: 0.5.0(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       clsx:
         specifier: 2.1.1
         version: 2.1.1
@@ -10755,6 +10761,17 @@ packages:
     resolution: {integrity: sha512-oYNxhMaNf2ZYOIuPmxkBgFNvqiSnnT8uTHrFgim09aN2fxA8Mu1G86EBokqHfAXBfx/NTiYOLbCy4bhGsjdbQg==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
+  '@wordpress/theme@0.5.0':
+    resolution: {integrity: sha512-6V14snLXUqVs3fBPmGJhWkgtWcrwEe7vUS04nTl7hyI5uyL+N7LXRldWTjnzwaQL0ywBIx4u13gJU/GZqOc8dQ==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    peerDependencies:
+      react: ^18.0.0
+      react-dom: ^18.0.0
+      stylelint: ^16.8.2
+    peerDependenciesMeta:
+      stylelint:
+        optional: true
+
   '@wordpress/theme@0.6.0':
     resolution: {integrity: sha512-n/O1djUn+jny46JyqCwD77nPV4zCUBIn+0ICp8fDYLXpQ7FfCfCrEfhlkQkcVB45KC1iu6IMAsLOA/9hzavHoQ==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
@@ -10769,6 +10786,13 @@ packages:
   '@wordpress/token-list@3.39.0':
     resolution: {integrity: sha512-p8lVv2wPJ76CqGnwRCeQcho6MPDlBdcdyCmAtgrIe5BGS19Tvp+EpsSkfvKrFa9JkAWtOSmAiKVqIHW/LqkujA==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+
+  '@wordpress/ui@0.5.0':
+    resolution: {integrity: sha512-D/sxkPIzptHEGEWWNh9UEdz6ySAmK3LBsqGO2dhom2kJ8RCsZMYwHXNOv2zYD1M+6rjfIthYWXAXNbDzb365Rg==}
+    engines: {node: '>=20.10.0', npm: '>=10.2.3'}
+    peerDependencies:
+      react: ^18.0.0
+      react-dom: ^18.0.0
 
   '@wordpress/ui@0.6.0':
     resolution: {integrity: sha512-KV7JkQ4bvuCWZ2+82jnhzthomCIS7wO8+6cSrkhQUgeVbp0TdGCXCFHwKXfw1O/P/S6IClqpTFgInXFz/gA1DQ==}
@@ -26291,6 +26315,17 @@ snapshots:
       y-protocols: 1.0.7(yjs@13.6.29)
       yjs: 13.6.29
 
+  '@wordpress/theme@0.5.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@16.26.1)':
+    dependencies:
+      '@wordpress/element': 6.39.0
+      '@wordpress/private-apis': 1.39.0
+      colorjs.io: 0.6.1
+      memize: 2.1.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      stylelint: 16.26.1
+
   '@wordpress/theme@0.6.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))':
     dependencies:
       '@wordpress/element': 6.39.0
@@ -26314,6 +26349,20 @@ snapshots:
       stylelint: 16.26.1
 
   '@wordpress/token-list@3.39.0': {}
+
+  '@wordpress/ui@0.5.0(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@base-ui/react': 1.1.0(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/a11y': 4.39.0
+      '@wordpress/element': 6.39.0
+      '@wordpress/i18n': 6.12.0
+      '@wordpress/icons': 11.6.0(react@18.3.1)
+      '@wordpress/primitives': 4.39.0(react@18.3.1)
+      clsx: 2.1.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    transitivePeerDependencies:
+      - '@types/react'
 
   '@wordpress/ui@0.6.0(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@16.26.1)':
     dependencies:

--- a/projects/js-packages/charts/README.md
+++ b/projects/js-packages/charts/README.md
@@ -4,6 +4,11 @@ A comprehensive charting library for displaying interactive data visualizations 
 
 Explore the available charts and their documentation in [Storybook](https://automattic.github.io/jetpack-storybook/?path=/docs/js-packages-charts).
 
+## Requirements
+
+- **Node.js**: >= 20.10.0 (required by `@wordpress/ui` dependency)
+- **React**: 17.x or 18.x
+
 ## Quick Start
 
 ### Installation

--- a/projects/js-packages/charts/changelog/update-responsive-fill-container
+++ b/projects/js-packages/charts/changelog/update-responsive-fill-container
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Responsive charts now fill parent container by default instead of using a fixed aspect ratio. Pass `aspectRatio` prop to restore the previous behavior.

--- a/projects/js-packages/charts/changelog/update-responsive-fill-container
+++ b/projects/js-packages/charts/changelog/update-responsive-fill-container
@@ -1,4 +1,4 @@
 Significance: minor
 Type: changed
 
-Responsive charts now fill parent container by default instead of using a fixed aspect ratio. Pass `aspectRatio` prop to restore the previous behavior.
+Responsive charts now fill parent container by default instead of using a fixed aspect ratio. Pass `aspectRatio` prop to restore the previous behavior. Added @wordpress/ui and @wordpress/theme dependencies (requires Node.js >= 20.10.0).

--- a/projects/js-packages/charts/package.json
+++ b/projects/js-packages/charts/package.json
@@ -220,8 +220,8 @@
 		"@visx/vendor": "^3.12.0",
 		"@visx/xychart": "^3.12.0",
 		"@wordpress/i18n": "^6.0.0",
-		"@wordpress/theme": "0.5.0",
-		"@wordpress/ui": "0.5.0",
+		"@wordpress/theme": "0.6.0",
+		"@wordpress/ui": "0.6.0",
 		"clsx": "2.1.1",
 		"date-fns": "^4.1.0",
 		"deepmerge": "4.3.1",
@@ -262,5 +262,8 @@
 	"peerDependencies": {
 		"react": "^17.0.0 || ^18.0.0",
 		"react-dom": "^17.0.0 || ^18.0.0"
+	},
+	"engines": {
+		"node": ">=20.10.0"
 	}
 }

--- a/projects/js-packages/charts/package.json
+++ b/projects/js-packages/charts/package.json
@@ -220,6 +220,8 @@
 		"@visx/vendor": "^3.12.0",
 		"@visx/xychart": "^3.12.0",
 		"@wordpress/i18n": "^6.0.0",
+		"@wordpress/theme": "0.5.0",
+		"@wordpress/ui": "0.5.0",
 		"clsx": "2.1.1",
 		"date-fns": "^4.1.0",
 		"deepmerge": "4.3.1",

--- a/projects/js-packages/charts/src/charts/bar-chart/bar-chart.module.scss
+++ b/projects/js-packages/charts/src/charts/bar-chart/bar-chart.module.scss
@@ -1,17 +1,12 @@
 .bar-chart {
-	display: flex;
-	flex-direction: column;
 
-	&--legend-top {
-		flex-direction: column-reverse;
+	&__svg-wrapper {
+		flex: 1;
+		min-height: 0; // Required for flex shrinking
 	}
 
 	svg {
 		overflow: visible;
-	}
-
-	&-legend {
-		margin-top: 1rem;
 	}
 
 	&--animated rect {

--- a/projects/js-packages/charts/src/charts/bar-chart/bar-chart.tsx
+++ b/projects/js-packages/charts/src/charts/bar-chart/bar-chart.tsx
@@ -86,7 +86,7 @@ const BarChartInternal: FC< BarChartProps > = ( {
 	data,
 	chartId: providedChartId,
 	width,
-	height = 400,
+	height,
 	className,
 	margin,
 	withTooltips = false,
@@ -127,10 +127,10 @@ const BarChartInternal: FC< BarChartProps > = ( {
 	const [ svgWrapperRef, svgWrapperHeight ] = useElementHeight< HTMLDivElement >();
 	const chartRef = useRef< HTMLDivElement >( null );
 
-	// Use the measured SVG wrapper height, falling back to the passed height initially.
+	// Use the measured SVG wrapper height, falling back to the passed height if provided.
 	// We only render the chart once we have a valid height to prevent layout shift/flicker.
 	const chartHeight = svgWrapperHeight > 0 ? svgWrapperHeight : height;
-	const isWaitingForMeasurement = chartHeight === 0;
+	const isWaitingForMeasurement = ! chartHeight;
 	const [ selectedIndex, setSelectedIndex ] = useState< number | undefined >( undefined );
 	const [ isNavigating, setIsNavigating ] = useState( false );
 

--- a/projects/js-packages/charts/src/charts/bar-chart/bar-chart.tsx
+++ b/projects/js-packages/charts/src/charts/bar-chart/bar-chart.tsx
@@ -13,6 +13,7 @@ import {
 	useZeroValueDisplay,
 	useChartMargin,
 	useElementHeight,
+	useHasLegendChild,
 	usePrefersReducedMotion,
 } from '../../hooks';
 import {
@@ -127,10 +128,15 @@ const BarChartInternal: FC< BarChartProps > = ( {
 	const [ svgWrapperRef, svgWrapperHeight ] = useElementHeight< HTMLDivElement >();
 	const chartRef = useRef< HTMLDivElement >( null );
 
+	// Check if children contain a Legend component (composition pattern)
+	const hasLegendChild = useHasLegendChild( children );
+
 	// Use the measured SVG wrapper height, falling back to the passed height if provided.
-	// We only render the chart once we have a valid height to prevent layout shift/flicker.
+	// When there's a legend (via prop or composition), we must wait for measurement because
+	// the legend takes space and the svg-wrapper height will be less than the total height.
 	const chartHeight = svgWrapperHeight > 0 ? svgWrapperHeight : height;
-	const isWaitingForMeasurement = ! chartHeight;
+	const hasLegend = showLegend || hasLegendChild;
+	const isWaitingForMeasurement = hasLegend ? svgWrapperHeight === 0 : ! chartHeight;
 	const [ selectedIndex, setSelectedIndex ] = useState< number | undefined >( undefined );
 	const [ isNavigating, setIsNavigating ] = useState( false );
 
@@ -365,6 +371,7 @@ const BarChartInternal: FC< BarChartProps > = ( {
 				style={ {
 					width,
 					height,
+					visibility: isWaitingForMeasurement ? 'hidden' : 'visible',
 				} }
 				data-chart-id={ `bar-chart-${ chartId }` }
 			>

--- a/projects/js-packages/charts/src/charts/bar-chart/bar-chart.tsx
+++ b/projects/js-packages/charts/src/charts/bar-chart/bar-chart.tsx
@@ -362,115 +362,122 @@ const BarChartInternal: FC< BarChartProps > = ( {
 					className
 				) }
 				data-testid="bar-chart"
-				role="grid"
-				aria-label={ __( 'Bar chart', 'jetpack-charts' ) }
 				style={ {
 					width,
 					height,
 				} }
-				tabIndex={ 0 }
-				onKeyDown={ onChartKeyDown }
-				onFocus={ onChartFocus }
-				onBlur={ onChartBlur }
-				ref={ chartRef }
 				data-chart-id={ `bar-chart-${ chartId }` }
 			>
 				{ legendPosition === 'top' && legendElement }
 
-				<div className={ styles[ 'bar-chart__svg-wrapper' ] } ref={ svgWrapperRef }>
+				<div
+					className={ styles[ 'bar-chart__svg-wrapper' ] }
+					ref={ svgWrapperRef }
+					role="grid"
+					aria-label={ __( 'Bar chart', 'jetpack-charts' ) }
+					tabIndex={ 0 }
+					onKeyDown={ onChartKeyDown }
+					onFocus={ onChartFocus }
+					onBlur={ onChartBlur }
+				>
 					{ ! isWaitingForMeasurement && (
-						<XYChart
-							theme={ theme }
-							width={ width }
-							height={ chartHeight }
-							margin={ {
-								...defaultMargin,
-								...margin,
-							} }
-							xScale={ chartOptions.xScale }
-							yScale={ chartOptions.yScale }
-							horizontal={ horizontal }
-							pointerEventsDataKey="nearest"
-						>
-							<Grid
-								columns={ gridVisibility.includes( 'y' ) }
-								rows={ gridVisibility.includes( 'x' ) }
-								numTicks={ 4 }
-							/>
-
-							{ withPatterns && (
-								<>
-									<defs data-testid="bar-chart-patterns">
-										{ dataSorted.map( ( seriesData, index ) =>
-											renderPattern( index, getElementStyles( { data: seriesData, index } ).color )
-										) }
-									</defs>
-									<style>
-										{ dataSorted.map( ( seriesData, index ) =>
-											createPatternBorderStyle(
-												index,
-												getElementStyles( { data: seriesData, index } ).color
-											)
-										) }
-									</style>
-								</>
-							) }
-
-							{ highlightedBarStyle && <style>{ highlightedBarStyle }</style> }
-
-							{ allSeriesHidden ? (
-								<text
-									x={ width / 2 }
-									y={ chartHeight / 2 }
-									textAnchor="middle"
-									fill={ providerTheme.gridStyles?.stroke || '#ccc' }
-									fontSize="14"
-									fontFamily="-apple-system,BlinkMacSystemFont,Roboto,Helvetica Neue,sans-serif"
-								>
-									{ __(
-										'All series are hidden. Click legend items to show data.',
-										'jetpack-charts'
-									) }
-								</text>
-							) : null }
-
-							<BarGroup padding={ chartOptions.barGroup.padding }>
-								{ seriesWithVisibility.map( ( { series: seriesData, index, isVisible } ) => {
-									// Skip rendering invisible series
-									if ( ! isVisible ) {
-										return null;
-									}
-
-									return (
-										<BarSeries
-											key={ seriesData?.label }
-											dataKey={ seriesData?.label }
-											data={ seriesData.data as DataPointDate[] }
-											yAccessor={ chartOptions.accessors.yAccessor }
-											xAccessor={ chartOptions.accessors.xAccessor }
-											colorAccessor={ getBarBackground( index ) }
-										/>
-									);
-								} ) }
-							</BarGroup>
-
-							<Axis { ...chartOptions.axis.x } />
-							<Axis { ...chartOptions.axis.y } />
-
-							{ withTooltips && (
-								<AccessibleTooltip
-									detectBounds
-									snapTooltipToDatumX
-									snapTooltipToDatumY
-									renderTooltip={ renderTooltip || renderDefaultTooltip }
-									selectedIndex={ selectedIndex }
-									tooltipRef={ tooltipRef }
-									keyboardFocusedClassName={ styles[ 'bar-chart__tooltip--keyboard-focused' ] }
-									series={ data }
-									mode="individual"
+						<div ref={ chartRef }>
+							<XYChart
+								theme={ theme }
+								width={ width }
+								height={ chartHeight }
+								margin={ {
+									...defaultMargin,
+									...margin,
+								} }
+								xScale={ chartOptions.xScale }
+								yScale={ chartOptions.yScale }
+								horizontal={ horizontal }
+								pointerEventsDataKey="nearest"
+							>
+								<Grid
+									columns={ gridVisibility.includes( 'y' ) }
+									rows={ gridVisibility.includes( 'x' ) }
+									numTicks={ 4 }
 								/>
-							) }
-						</XYChart>
+
+								{ withPatterns && (
+									<>
+										<defs data-testid="bar-chart-patterns">
+											{ dataSorted.map( ( seriesData, index ) =>
+												renderPattern(
+													index,
+													getElementStyles( { data: seriesData, index } ).color
+												)
+											) }
+										</defs>
+										<style>
+											{ dataSorted.map( ( seriesData, index ) =>
+												createPatternBorderStyle(
+													index,
+													getElementStyles( { data: seriesData, index } ).color
+												)
+											) }
+										</style>
+									</>
+								) }
+
+								{ highlightedBarStyle && <style>{ highlightedBarStyle }</style> }
+
+								{ allSeriesHidden ? (
+									<text
+										x={ width / 2 }
+										y={ chartHeight / 2 }
+										textAnchor="middle"
+										fill={ providerTheme.gridStyles?.stroke || '#ccc' }
+										fontSize="14"
+										fontFamily="-apple-system,BlinkMacSystemFont,Roboto,Helvetica Neue,sans-serif"
+									>
+										{ __(
+											'All series are hidden. Click legend items to show data.',
+											'jetpack-charts'
+										) }
+									</text>
+								) : null }
+
+								<BarGroup padding={ chartOptions.barGroup.padding }>
+									{ seriesWithVisibility.map( ( { series: seriesData, index, isVisible } ) => {
+										// Skip rendering invisible series
+										if ( ! isVisible ) {
+											return null;
+										}
+
+										return (
+											<BarSeries
+												key={ seriesData?.label }
+												dataKey={ seriesData?.label }
+												data={ seriesData.data as DataPointDate[] }
+												yAccessor={ chartOptions.accessors.yAccessor }
+												xAccessor={ chartOptions.accessors.xAccessor }
+												colorAccessor={ getBarBackground( index ) }
+											/>
+										);
+									} ) }
+								</BarGroup>
+
+								<Axis { ...chartOptions.axis.x } />
+								<Axis { ...chartOptions.axis.y } />
+
+								{ withTooltips && (
+									<AccessibleTooltip
+										detectBounds
+										snapTooltipToDatumX
+										snapTooltipToDatumY
+										renderTooltip={ renderTooltip || renderDefaultTooltip }
+										selectedIndex={ selectedIndex }
+										tooltipRef={ tooltipRef }
+										keyboardFocusedClassName={ styles[ 'bar-chart__tooltip--keyboard-focused' ] }
+										series={ data }
+										mode="individual"
+									/>
+								) }
+							</XYChart>
+						</div>
 					) }
 				</div>
 

--- a/projects/js-packages/charts/src/charts/bar-chart/bar-chart.tsx
+++ b/projects/js-packages/charts/src/charts/bar-chart/bar-chart.tsx
@@ -2,6 +2,8 @@ import { formatNumber } from '@automattic/number-formatters';
 import { PatternLines, PatternCircles, PatternWaves, PatternHexagons } from '@visx/pattern';
 import { Axis, BarSeries, BarGroup, Grid, XYChart } from '@visx/xychart';
 import { __ } from '@wordpress/i18n';
+import '@wordpress/theme/design-tokens.css';
+import { Stack } from '@wordpress/ui';
 import clsx from 'clsx';
 import { useCallback, useContext, useState, useRef, useMemo } from 'react';
 import { Legend, useChartLegendItems } from '../../components/legend';
@@ -30,6 +32,7 @@ import { useBarChartOptions } from './private';
 import type { BaseChartProps, DataPointDate, SeriesData, Optional } from '../../types';
 import type { ResponsiveConfig } from '../private/with-responsive';
 import type { RenderTooltipParams } from '@visx/xychart/lib/components/Tooltip';
+import type { GapSize } from '@wordpress/theme';
 import type { FC, ReactNode, ComponentType } from 'react';
 
 export interface BarChartProps extends BaseChartProps< SeriesData[] > {
@@ -39,6 +42,12 @@ export interface BarChartProps extends BaseChartProps< SeriesData[] > {
 	showZeroValues?: boolean;
 	legendInteractive?: boolean;
 	children?: ReactNode;
+	/**
+	 * Gap between chart elements (SVG, legend, children).
+	 * Uses WordPress design system tokens.
+	 * @default 'md'
+	 */
+	gap?: GapSize;
 }
 
 // Base props type with optional responsive properties
@@ -99,6 +108,7 @@ const BarChartInternal: FC< BarChartProps > = ( {
 	legendInteractive = false,
 	animation,
 	children,
+	gap = 'md',
 } ) => {
 	const horizontal = orientation === 'horizontal';
 	const chartId = useChartId( providedChartId );
@@ -115,8 +125,11 @@ const BarChartInternal: FC< BarChartProps > = ( {
 	const legendItems = useChartLegendItems( dataSorted );
 	const chartOptions = useBarChartOptions( dataWithVisibleZeros, horizontal, options );
 	const defaultMargin = useChartMargin( height, chartOptions, dataSorted, theme, horizontal );
-	const [ legendRef, legendHeight ] = useElementHeight< HTMLDivElement >();
+	const [ svgWrapperRef, svgWrapperHeight ] = useElementHeight< HTMLDivElement >();
 	const chartRef = useRef< HTMLDivElement >( null );
+
+	// Use the measured SVG wrapper height, falling back to the passed height initially
+	const chartHeight = svgWrapperHeight > 0 ? svgWrapperHeight : height;
 	const [ selectedIndex, setSelectedIndex ] = useState< number | undefined >( undefined );
 	const [ isNavigating, setIsNavigating ] = useState( false );
 
@@ -312,22 +325,38 @@ const BarChartInternal: FC< BarChartProps > = ( {
 	const gridVisibility = gridVisibilityProp ?? chartOptions.gridVisibility;
 	const highlightedBarStyle = createKeyboardHighlightStyle();
 
+	const legendElement = showLegend && (
+		<Legend
+			orientation={ legendOrientation }
+			position={ legendPosition }
+			alignment={ legendAlignment }
+			maxWidth={ legendMaxWidth }
+			textOverflow={ legendTextOverflow }
+			legendItemClassName={ legendItemClassName }
+			className={ styles[ 'bar-chart__legend' ] }
+			shape={ legendShape }
+			chartId={ chartId }
+			interactive={ legendInteractive }
+		/>
+	);
+
 	return (
 		<SingleChartContext.Provider
 			value={ {
 				chartId,
 				chartWidth: width,
-				chartHeight: height - ( showLegend ? legendHeight : 0 ),
+				chartHeight,
 			} }
 		>
-			<div
+			<Stack
+				direction="column"
+				gap={ gap }
 				className={ clsx(
 					'bar-chart',
 					styles[ 'bar-chart' ],
 					{
 						[ styles[ `bar-chart--animated${ horizontal ? '-horizontal' : '' }` ] ]:
 							animation && ! prefersReducedMotion,
-						[ styles[ 'bar-chart--legend-top' ] ]: showLegend && legendPosition === 'top',
 					},
 					className
 				) }
@@ -343,119 +372,109 @@ const BarChartInternal: FC< BarChartProps > = ( {
 				onFocus={ onChartFocus }
 				onBlur={ onChartBlur }
 				ref={ chartRef }
-				data-chart-id={ `bar-chart-${ chartId }` } // Unique ID for the chart
+				data-chart-id={ `bar-chart-${ chartId }` }
 			>
-				<XYChart
-					theme={ theme }
-					width={ width }
-					height={ height - ( showLegend ? legendHeight : 0 ) }
-					margin={ {
-						...defaultMargin,
-						...margin,
-						...( showLegend && legendPosition === 'top'
-							? { top: ( defaultMargin.top || 0 ) + legendHeight }
-							: {} ),
-					} }
-					xScale={ chartOptions.xScale }
-					yScale={ chartOptions.yScale }
-					horizontal={ horizontal }
-					pointerEventsDataKey="nearest"
-				>
-					<Grid
-						columns={ gridVisibility.includes( 'y' ) }
-						rows={ gridVisibility.includes( 'x' ) }
-						numTicks={ 4 }
-					/>
+				{ legendPosition === 'top' && legendElement }
 
-					{ withPatterns && (
-						<>
-							<defs data-testid="bar-chart-patterns">
-								{ dataSorted.map( ( seriesData, index ) =>
-									renderPattern( index, getElementStyles( { data: seriesData, index } ).color )
-								) }
-							</defs>
-							<style>
-								{ dataSorted.map( ( seriesData, index ) =>
-									createPatternBorderStyle(
-										index,
-										getElementStyles( { data: seriesData, index } ).color
-									)
-								) }
-							</style>
-						</>
-					) }
-
-					{ highlightedBarStyle && <style>{ highlightedBarStyle }</style> }
-
-					{ allSeriesHidden ? (
-						<text
-							x={ width / 2 }
-							y={ ( height - ( showLegend ? legendHeight : 0 ) ) / 2 }
-							textAnchor="middle"
-							fill={ providerTheme.gridStyles?.stroke || '#ccc' }
-							fontSize="14"
-							fontFamily="-apple-system,BlinkMacSystemFont,Roboto,Helvetica Neue,sans-serif"
-						>
-							{ __( 'All series are hidden. Click legend items to show data.', 'jetpack-charts' ) }
-						</text>
-					) : null }
-
-					<BarGroup padding={ chartOptions.barGroup.padding }>
-						{ seriesWithVisibility.map( ( { series: seriesData, index, isVisible } ) => {
-							// Skip rendering invisible series
-							if ( ! isVisible ) {
-								return null;
-							}
-
-							return (
-								<BarSeries
-									key={ seriesData?.label }
-									dataKey={ seriesData?.label }
-									data={ seriesData.data as DataPointDate[] }
-									yAccessor={ chartOptions.accessors.yAccessor }
-									xAccessor={ chartOptions.accessors.xAccessor }
-									colorAccessor={ getBarBackground( index ) }
-								/>
-							);
-						} ) }
-					</BarGroup>
-
-					<Axis { ...chartOptions.axis.x } />
-					<Axis { ...chartOptions.axis.y } />
-
-					{ withTooltips && (
-						<AccessibleTooltip
-							detectBounds
-							snapTooltipToDatumX
-							snapTooltipToDatumY
-							renderTooltip={ renderTooltip || renderDefaultTooltip }
-							selectedIndex={ selectedIndex }
-							tooltipRef={ tooltipRef }
-							keyboardFocusedClassName={ styles[ 'bar-chart__tooltip--keyboard-focused' ] }
-							series={ data }
-							mode="individual"
+				<div className={ styles[ 'bar-chart__svg-wrapper' ] } ref={ svgWrapperRef }>
+					<XYChart
+						theme={ theme }
+						width={ width }
+						height={ chartHeight }
+						margin={ {
+							...defaultMargin,
+							...margin,
+						} }
+						xScale={ chartOptions.xScale }
+						yScale={ chartOptions.yScale }
+						horizontal={ horizontal }
+						pointerEventsDataKey="nearest"
+					>
+						<Grid
+							columns={ gridVisibility.includes( 'y' ) }
+							rows={ gridVisibility.includes( 'x' ) }
+							numTicks={ 4 }
 						/>
-					) }
-				</XYChart>
 
-				{ showLegend && (
-					<Legend
-						orientation={ legendOrientation }
-						position={ legendPosition }
-						alignment={ legendAlignment }
-						maxWidth={ legendMaxWidth }
-						textOverflow={ legendTextOverflow }
-						legendItemClassName={ legendItemClassName }
-						className={ styles[ 'bar-chart__legend' ] }
-						shape={ legendShape }
-						ref={ legendRef }
-						chartId={ chartId }
-						interactive={ legendInteractive }
-					/>
-				) }
+						{ withPatterns && (
+							<>
+								<defs data-testid="bar-chart-patterns">
+									{ dataSorted.map( ( seriesData, index ) =>
+										renderPattern( index, getElementStyles( { data: seriesData, index } ).color )
+									) }
+								</defs>
+								<style>
+									{ dataSorted.map( ( seriesData, index ) =>
+										createPatternBorderStyle(
+											index,
+											getElementStyles( { data: seriesData, index } ).color
+										)
+									) }
+								</style>
+							</>
+						) }
+
+						{ highlightedBarStyle && <style>{ highlightedBarStyle }</style> }
+
+						{ allSeriesHidden ? (
+							<text
+								x={ width / 2 }
+								y={ chartHeight / 2 }
+								textAnchor="middle"
+								fill={ providerTheme.gridStyles?.stroke || '#ccc' }
+								fontSize="14"
+								fontFamily="-apple-system,BlinkMacSystemFont,Roboto,Helvetica Neue,sans-serif"
+							>
+								{ __(
+									'All series are hidden. Click legend items to show data.',
+									'jetpack-charts'
+								) }
+							</text>
+						) : null }
+
+						<BarGroup padding={ chartOptions.barGroup.padding }>
+							{ seriesWithVisibility.map( ( { series: seriesData, index, isVisible } ) => {
+								// Skip rendering invisible series
+								if ( ! isVisible ) {
+									return null;
+								}
+
+								return (
+									<BarSeries
+										key={ seriesData?.label }
+										dataKey={ seriesData?.label }
+										data={ seriesData.data as DataPointDate[] }
+										yAccessor={ chartOptions.accessors.yAccessor }
+										xAccessor={ chartOptions.accessors.xAccessor }
+										colorAccessor={ getBarBackground( index ) }
+									/>
+								);
+							} ) }
+						</BarGroup>
+
+						<Axis { ...chartOptions.axis.x } />
+						<Axis { ...chartOptions.axis.y } />
+
+						{ withTooltips && (
+							<AccessibleTooltip
+								detectBounds
+								snapTooltipToDatumX
+								snapTooltipToDatumY
+								renderTooltip={ renderTooltip || renderDefaultTooltip }
+								selectedIndex={ selectedIndex }
+								tooltipRef={ tooltipRef }
+								keyboardFocusedClassName={ styles[ 'bar-chart__tooltip--keyboard-focused' ] }
+								series={ data }
+								mode="individual"
+							/>
+						) }
+					</XYChart>
+				</div>
+
+				{ legendPosition === 'bottom' && legendElement }
 
 				{ children }
-			</div>
+			</Stack>
 		</SingleChartContext.Provider>
 	);
 };

--- a/projects/js-packages/charts/src/charts/bar-chart/bar-chart.tsx
+++ b/projects/js-packages/charts/src/charts/bar-chart/bar-chart.tsx
@@ -127,8 +127,10 @@ const BarChartInternal: FC< BarChartProps > = ( {
 	const [ svgWrapperRef, svgWrapperHeight ] = useElementHeight< HTMLDivElement >();
 	const chartRef = useRef< HTMLDivElement >( null );
 
-	// Use the measured SVG wrapper height, falling back to the passed height initially
+	// Use the measured SVG wrapper height, falling back to the passed height initially.
+	// We only render the chart once we have a valid height to prevent layout shift/flicker.
 	const chartHeight = svgWrapperHeight > 0 ? svgWrapperHeight : height;
+	const isWaitingForMeasurement = chartHeight === 0;
 	const [ selectedIndex, setSelectedIndex ] = useState< number | undefined >( undefined );
 	const [ isNavigating, setIsNavigating ] = useState( false );
 
@@ -376,98 +378,100 @@ const BarChartInternal: FC< BarChartProps > = ( {
 				{ legendPosition === 'top' && legendElement }
 
 				<div className={ styles[ 'bar-chart__svg-wrapper' ] } ref={ svgWrapperRef }>
-					<XYChart
-						theme={ theme }
-						width={ width }
-						height={ chartHeight }
-						margin={ {
-							...defaultMargin,
-							...margin,
-						} }
-						xScale={ chartOptions.xScale }
-						yScale={ chartOptions.yScale }
-						horizontal={ horizontal }
-						pointerEventsDataKey="nearest"
-					>
-						<Grid
-							columns={ gridVisibility.includes( 'y' ) }
-							rows={ gridVisibility.includes( 'x' ) }
-							numTicks={ 4 }
-						/>
-
-						{ withPatterns && (
-							<>
-								<defs data-testid="bar-chart-patterns">
-									{ dataSorted.map( ( seriesData, index ) =>
-										renderPattern( index, getElementStyles( { data: seriesData, index } ).color )
-									) }
-								</defs>
-								<style>
-									{ dataSorted.map( ( seriesData, index ) =>
-										createPatternBorderStyle(
-											index,
-											getElementStyles( { data: seriesData, index } ).color
-										)
-									) }
-								</style>
-							</>
-						) }
-
-						{ highlightedBarStyle && <style>{ highlightedBarStyle }</style> }
-
-						{ allSeriesHidden ? (
-							<text
-								x={ width / 2 }
-								y={ chartHeight / 2 }
-								textAnchor="middle"
-								fill={ providerTheme.gridStyles?.stroke || '#ccc' }
-								fontSize="14"
-								fontFamily="-apple-system,BlinkMacSystemFont,Roboto,Helvetica Neue,sans-serif"
-							>
-								{ __(
-									'All series are hidden. Click legend items to show data.',
-									'jetpack-charts'
-								) }
-							</text>
-						) : null }
-
-						<BarGroup padding={ chartOptions.barGroup.padding }>
-							{ seriesWithVisibility.map( ( { series: seriesData, index, isVisible } ) => {
-								// Skip rendering invisible series
-								if ( ! isVisible ) {
-									return null;
-								}
-
-								return (
-									<BarSeries
-										key={ seriesData?.label }
-										dataKey={ seriesData?.label }
-										data={ seriesData.data as DataPointDate[] }
-										yAccessor={ chartOptions.accessors.yAccessor }
-										xAccessor={ chartOptions.accessors.xAccessor }
-										colorAccessor={ getBarBackground( index ) }
-									/>
-								);
-							} ) }
-						</BarGroup>
-
-						<Axis { ...chartOptions.axis.x } />
-						<Axis { ...chartOptions.axis.y } />
-
-						{ withTooltips && (
-							<AccessibleTooltip
-								detectBounds
-								snapTooltipToDatumX
-								snapTooltipToDatumY
-								renderTooltip={ renderTooltip || renderDefaultTooltip }
-								selectedIndex={ selectedIndex }
-								tooltipRef={ tooltipRef }
-								keyboardFocusedClassName={ styles[ 'bar-chart__tooltip--keyboard-focused' ] }
-								series={ data }
-								mode="individual"
+					{ ! isWaitingForMeasurement && (
+						<XYChart
+							theme={ theme }
+							width={ width }
+							height={ chartHeight }
+							margin={ {
+								...defaultMargin,
+								...margin,
+							} }
+							xScale={ chartOptions.xScale }
+							yScale={ chartOptions.yScale }
+							horizontal={ horizontal }
+							pointerEventsDataKey="nearest"
+						>
+							<Grid
+								columns={ gridVisibility.includes( 'y' ) }
+								rows={ gridVisibility.includes( 'x' ) }
+								numTicks={ 4 }
 							/>
-						) }
-					</XYChart>
+
+							{ withPatterns && (
+								<>
+									<defs data-testid="bar-chart-patterns">
+										{ dataSorted.map( ( seriesData, index ) =>
+											renderPattern( index, getElementStyles( { data: seriesData, index } ).color )
+										) }
+									</defs>
+									<style>
+										{ dataSorted.map( ( seriesData, index ) =>
+											createPatternBorderStyle(
+												index,
+												getElementStyles( { data: seriesData, index } ).color
+											)
+										) }
+									</style>
+								</>
+							) }
+
+							{ highlightedBarStyle && <style>{ highlightedBarStyle }</style> }
+
+							{ allSeriesHidden ? (
+								<text
+									x={ width / 2 }
+									y={ chartHeight / 2 }
+									textAnchor="middle"
+									fill={ providerTheme.gridStyles?.stroke || '#ccc' }
+									fontSize="14"
+									fontFamily="-apple-system,BlinkMacSystemFont,Roboto,Helvetica Neue,sans-serif"
+								>
+									{ __(
+										'All series are hidden. Click legend items to show data.',
+										'jetpack-charts'
+									) }
+								</text>
+							) : null }
+
+							<BarGroup padding={ chartOptions.barGroup.padding }>
+								{ seriesWithVisibility.map( ( { series: seriesData, index, isVisible } ) => {
+									// Skip rendering invisible series
+									if ( ! isVisible ) {
+										return null;
+									}
+
+									return (
+										<BarSeries
+											key={ seriesData?.label }
+											dataKey={ seriesData?.label }
+											data={ seriesData.data as DataPointDate[] }
+											yAccessor={ chartOptions.accessors.yAccessor }
+											xAccessor={ chartOptions.accessors.xAccessor }
+											colorAccessor={ getBarBackground( index ) }
+										/>
+									);
+								} ) }
+							</BarGroup>
+
+							<Axis { ...chartOptions.axis.x } />
+							<Axis { ...chartOptions.axis.y } />
+
+							{ withTooltips && (
+								<AccessibleTooltip
+									detectBounds
+									snapTooltipToDatumX
+									snapTooltipToDatumY
+									renderTooltip={ renderTooltip || renderDefaultTooltip }
+									selectedIndex={ selectedIndex }
+									tooltipRef={ tooltipRef }
+									keyboardFocusedClassName={ styles[ 'bar-chart__tooltip--keyboard-focused' ] }
+									series={ data }
+									mode="individual"
+								/>
+							) }
+						</XYChart>
+					) }
 				</div>
 
 				{ legendPosition === 'bottom' && legendElement }

--- a/projects/js-packages/charts/src/charts/bar-chart/bar-chart.tsx
+++ b/projects/js-packages/charts/src/charts/bar-chart/bar-chart.tsx
@@ -2,7 +2,6 @@ import { formatNumber } from '@automattic/number-formatters';
 import { PatternLines, PatternCircles, PatternWaves, PatternHexagons } from '@visx/pattern';
 import { Axis, BarSeries, BarGroup, Grid, XYChart } from '@visx/xychart';
 import { __ } from '@wordpress/i18n';
-import '@wordpress/theme/design-tokens.css';
 import { Stack } from '@wordpress/ui';
 import clsx from 'clsx';
 import { useCallback, useContext, useState, useRef, useMemo } from 'react';

--- a/projects/js-packages/charts/src/charts/bar-chart/stories/index.docs.mdx
+++ b/projects/js-packages/charts/src/charts/bar-chart/stories/index.docs.mdx
@@ -60,15 +60,27 @@ The simplest bar chart requires only a `data` prop with categorical data:
 
 ### Optional Props
 
-- **`width`**: Chart width in pixels (responsive by default)
-- **`height`**: Chart height in pixels (responsive by default, defaults to 400)
+**Layout & Dimensions:**
+- **`width`**: Chart width in pixels. When omitted, fills parent container width
+- **`height`**: Chart height in pixels (defaults to 400). When omitted, fills parent container height
+- **`margin`**: Custom chart margins
+- **`aspectRatio`**: Height as a fraction of width (e.g., `0.5` = 50% height). When omitted, fills parent container height
+- **`maxWidth`**: Maximum width constraint for responsive charts (default: `1200`)
+- **`resizeDebounceTime`**: Debounce delay for resize events in ms (default: `300`)
+
+**Visual Styling:**
 - **`orientation`**: Bar orientation (`'vertical'` or `'horizontal'`, defaults to `'vertical'`)
-- **`withTooltips`**: Enable interactive tooltips (`false` by default)
 - **`withPatterns`**: Use pattern fills instead of solid colors (`false` by default)
+- **`gridVisibility`**: Grid line visibility (`'x'`, `'y'`, `'xy'`, or `'none'`)
+
+**Interactivity:**
+- **`withTooltips`**: Enable interactive tooltips (`false` by default)
+
+**Legend:**
 - **`showLegend`**: Display chart legend (`false` by default)
 - **`legendInteractive`**: Enable interactive legend with series toggle (`false` by default, requires `chartId`)
-- **`gridVisibility`**: Grid line visibility (`'x'`, `'y'`, `'xy'`, or `'none'`)
-- **`margin`**: Custom chart margins
+
+**Advanced:**
 - **`options`**: Advanced axis and scale configuration
 
 ## Chart Orientations

--- a/projects/js-packages/charts/src/charts/bar-chart/stories/index.docs.mdx
+++ b/projects/js-packages/charts/src/charts/bar-chart/stories/index.docs.mdx
@@ -136,9 +136,7 @@ Display multiple data series with automatic color differentiation and grouped ba
 
 ### Many Data Series
 
-The component handles large numbers of series gracefully with automatic color cycling:
-
-<Canvas of={ BarChartStories.ManyDataSeries } />
+The component handles large numbers of series gracefully with automatic color cycling. Use the `seriesCount` control above to see how the chart handles many series:
 
 <Source
 	language="jsx"
@@ -411,22 +409,27 @@ Control grid line visibility and appearance:
 
 ### Responsive Behavior
 
-Charts automatically resize based on container size:
+By default, charts **fill their parent container's dimensions**. The parent must have an explicit height:
 
-<Canvas of={ BarChartStories.FixedDimensions } />
+<Canvas of={ BarChartStories.Default } />
 
 <Source
 	language="jsx"
-	code={ `// Responsive (default)
-	<BarChart data={data} />
+	code={ `// Fill parent container (default) - parent needs explicit height
+	<div style={{ width: '100%', height: '400px' }}>
+		<BarChart data={data} />
+	</div>
+
+	// Use aspect ratio - height calculated from width
+	<div style={{ width: '100%' }}>
+		<BarChart data={data} aspectRatio={0.5} />
+	</div>
 
 	// Fixed dimensions
-	<BarChart
-		data={data}
-		width={800}
-		height={400}
-	/>` }
+	<BarChart data={data} width={800} height={400} />` }
 />
+
+For more details on responsive behavior, see the [Responsive Design section](./?path=/docs/js-packages-charts-library-introduction--docs#responsive-design) in the introduction.
 
 ### Custom Margins
 

--- a/projects/js-packages/charts/src/charts/bar-chart/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/charts/bar-chart/stories/index.stories.tsx
@@ -86,8 +86,6 @@ export const Default: Story = {
 		gridVisibility: 'x',
 		maxWidth: 1200,
 		resizeDebounceTime: 300,
-		containerHeight: '400px',
-		resize: 'both' as const,
 	},
 };
 

--- a/projects/js-packages/charts/src/charts/bar-chart/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/charts/bar-chart/stories/index.stories.tsx
@@ -87,6 +87,7 @@ export const Default: Story = {
 		maxWidth: 1200,
 		resizeDebounceTime: 300,
 		containerHeight: '400px',
+		resize: 'both' as const,
 	},
 };
 
@@ -144,32 +145,30 @@ export const TimeSeries: Story = {
 	},
 };
 
-// Story without tooltip
-export const ManyDataSeries: Story = {
-	args: {
-		...Default.args,
-		data: medalCountsData,
-	},
-	parameters: {
-		docs: {
-			description: {
-				story: 'Bar chart with many data series.',
-			},
-		},
-	},
-};
-
 export const FixedDimensions: Story = {
 	args: {
 		...Default.args,
 		width: 800,
 		height: 300,
-		data: [ medalCountsData[ 0 ], medalCountsData[ 1 ], medalCountsData[ 2 ] ],
 	},
 	parameters: {
 		docs: {
 			description: {
 				story: 'Bar chart with fixed dimensions that override the responsive behavior.',
+			},
+		},
+	},
+};
+
+export const AspectRatio: Story = {
+	args: {
+		...Default.args,
+		aspectRatio: 0.3,
+	},
+	parameters: {
+		docs: {
+			description: {
+				story: 'Bar chart with an aspect ratio that overrides the responsive behavior.',
 			},
 		},
 	},

--- a/projects/js-packages/charts/src/charts/bar-chart/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/charts/bar-chart/stories/index.stories.tsx
@@ -85,8 +85,8 @@ export const Default: Story = {
 		data: [ medalCountsData[ 0 ], medalCountsData[ 1 ], medalCountsData[ 2 ] ], // limit to 3 series for better readability
 		gridVisibility: 'x',
 		maxWidth: 1200,
-		aspectRatio: 0.5,
 		resizeDebounceTime: 300,
+		containerHeight: '400px',
 	},
 };
 
@@ -163,7 +163,7 @@ export const FixedDimensions: Story = {
 	args: {
 		...Default.args,
 		width: 800,
-		height: 400,
+		height: 300,
 		data: [ medalCountsData[ 0 ], medalCountsData[ 1 ], medalCountsData[ 2 ] ],
 	},
 	parameters: {
@@ -273,13 +273,13 @@ export const WithInteractiveLegend: Story = {
 // Story demonstrating composition API
 export const WithCompositionLegend: StoryObj< typeof BarChart > = {
 	render: args => (
-		<div style={ { width: '800px' } }>
+		<div style={ { width: '800px', height: '420px' } }>
 			<BarChart
 				data={ args.data || [ medalCountsData[ 0 ], medalCountsData[ 1 ], medalCountsData[ 2 ] ] }
 				withTooltips={ true }
 				gridVisibility="x"
 				maxWidth={ 1200 }
-				aspectRatio={ 0.5 }
+				height={ 400 }
 			>
 				<BarChart.Legend
 					orientation={ args.legendOrientation || 'horizontal' }
@@ -313,8 +313,8 @@ export const CustomLegendPositioning: Story = {
 		data: medalCountsData.slice( 0, 3 ), // Use first 3 series for cleaner legend
 		gridVisibility: 'x',
 		maxWidth: 1200,
-		aspectRatio: 0.5,
 		resizeDebounceTime: 300,
+		containerHeight: '400px',
 		// showLegend defaults to false, explicitly enabling for demonstration
 		showLegend: true,
 		legendOrientation: 'vertical',

--- a/projects/js-packages/charts/src/charts/bar-chart/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/charts/bar-chart/stories/index.stories.tsx
@@ -256,23 +256,19 @@ export const WithInteractiveLegend: Story = {
 // Story demonstrating composition API
 export const WithCompositionLegend: StoryObj< typeof BarChart > = {
 	render: args => (
-		<div style={ { width: '800px', height: '420px' } }>
-			<BarChart
-				data={ args.data || [ medalCountsData[ 0 ], medalCountsData[ 1 ], medalCountsData[ 2 ] ] }
-				withTooltips={ true }
-				gridVisibility="x"
-				maxWidth={ 1200 }
-				height={ 400 }
-			>
-				<BarChart.Legend
-					orientation={ args.legendOrientation || 'horizontal' }
-					alignment={ args.legendAlignment || 'center' }
-					position={ args.legendPosition || 'bottom' }
-					maxWidth={ args.legendMaxWidth }
-					textOverflow={ args.legendTextOverflow || 'wrap' }
-				/>
-			</BarChart>
-		</div>
+		<BarChart
+			data={ args.data || [ medalCountsData[ 0 ], medalCountsData[ 1 ], medalCountsData[ 2 ] ] }
+			withTooltips={ true }
+			gridVisibility="x"
+		>
+			<BarChart.Legend
+				orientation={ args.legendOrientation || 'horizontal' }
+				alignment={ args.legendAlignment || 'center' }
+				position={ args.legendPosition || 'bottom' }
+				maxWidth={ args.legendMaxWidth }
+				textOverflow={ args.legendTextOverflow || 'wrap' }
+			/>
+		</BarChart>
 	),
 	argTypes: {
 		legendInteractive: {

--- a/projects/js-packages/charts/src/charts/bar-chart/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/charts/bar-chart/stories/index.stories.tsx
@@ -89,6 +89,21 @@ export const Default: Story = {
 	},
 };
 
+export const FixedDimensions: Story = {
+	args: {
+		...Default.args,
+		width: 600,
+		height: 300,
+	},
+};
+
+export const AspectRatio: Story = {
+	args: {
+		...Default.args,
+		aspectRatio: 0.3,
+	},
+};
+
 // Story with single data series
 export const SingleSeries: Story = {
 	args: {
@@ -138,35 +153,6 @@ export const TimeSeries: Story = {
 		docs: {
 			description: {
 				story: 'Bar chart with a time series.',
-			},
-		},
-	},
-};
-
-export const FixedDimensions: Story = {
-	args: {
-		...Default.args,
-		width: 800,
-		height: 300,
-	},
-	parameters: {
-		docs: {
-			description: {
-				story: 'Bar chart with fixed dimensions that override the responsive behavior.',
-			},
-		},
-	},
-};
-
-export const AspectRatio: Story = {
-	args: {
-		...Default.args,
-		aspectRatio: 0.3,
-	},
-	parameters: {
-		docs: {
-			description: {
-				story: 'Bar chart with an aspect ratio that overrides the responsive behavior.',
 			},
 		},
 	},

--- a/projects/js-packages/charts/src/charts/bar-chart/test/bar-chart.test.tsx
+++ b/projects/js-packages/charts/src/charts/bar-chart/test/bar-chart.test.tsx
@@ -3,6 +3,12 @@ import userEvent from '@testing-library/user-event';
 import { GlobalChartsProvider } from '../../../providers';
 import BarChart from '../bar-chart';
 
+// Mock useElementHeight to return a non-zero height in jsdom so charts render
+const mockRefCallback = jest.fn();
+jest.mock( '../../../hooks/use-element-height', () => ( {
+	useElementHeight: () => [ mockRefCallback, 300 ], // Return test height to allow chart rendering
+} ) );
+
 describe( 'BarChart', () => {
 	const defaultProps = {
 		width: 500,

--- a/projects/js-packages/charts/src/charts/bar-list-chart/bar-list-chart.tsx
+++ b/projects/js-packages/charts/src/charts/bar-list-chart/bar-list-chart.tsx
@@ -4,7 +4,7 @@ import { createScale, scaleBand } from '@visx/scale';
 import { Text, type TextProps } from '@visx/text';
 import { useContext, useMemo } from 'react';
 import { GlobalChartsContext, GlobalChartsProvider } from '../../providers';
-import { BarChart } from '../bar-chart';
+import { BarChartUnresponsive } from '../bar-chart';
 import { withResponsive } from '../private/with-responsive';
 import type { SeriesData } from '../..';
 import type { ScaleOptions } from '../../types';
@@ -257,7 +257,7 @@ const BarListChartInternal: FC< BarListChartProps > = ( {
 	}, [ options, width, data, height ] );
 
 	return (
-		<BarChart
+		<BarChartUnresponsive
 			orientation="horizontal"
 			gridVisibility={ 'none' }
 			data={ data }

--- a/projects/js-packages/charts/src/charts/bar-list-chart/stories/index.docs.mdx
+++ b/projects/js-packages/charts/src/charts/bar-list-chart/stories/index.docs.mdx
@@ -17,19 +17,19 @@ The BarListChart component extends the BarChart component to create a list-style
 	language="jsx"
 	code={ `import { BarListChart } from '@automattic/charts';
 
-const data = [
-	{
-		group: 'primary',
-		label: 'Sales By Product',
-		data: [
-			{ label: 'Product A', value: 32400 },
-			{ label: 'Product B', value: 20000 },
-			{ label: 'Product C', value: 15000 },
-		],
-	},
-];
+	const data = [
+		{
+			group: 'primary',
+			label: 'Sales By Product',
+			data: [
+				{ label: 'Product A', value: 32400 },
+				{ label: 'Product B', value: 20000 },
+				{ label: 'Product C', value: 15000 },
+			],
+		},
+	];
 
-<BarListChart data={ data } />` }
+	<BarListChart data={ data } />` }
 />
 
 Key features:
@@ -54,22 +54,22 @@ The simplest implementation displays a single series of data with automatic form
 <Source
 	language="jsx"
 	code={ `const singleSeriesData = [
-	{
-		group: 'primary',
-		label: 'Sales By Product',
-		data: [
-			{ label: 'Behemoth hat', value: 32400 },
-			{ label: 'Margarita top', value: 20000 },
-			{ label: 'Berlioz dress', value: 15000 },
-			{ label: 'Woland shirt', value: 16000 },
-		],
-	},
-];
+		{
+			group: 'primary',
+			label: 'Sales By Product',
+			data: [
+				{ label: 'Behemoth hat', value: 32400 },
+				{ label: 'Margarita top', value: 20000 },
+				{ label: 'Berlioz dress', value: 15000 },
+				{ label: 'Woland shirt', value: 16000 },
+			],
+		},
+	];
 
-<BarListChart
-	data={ singleSeriesData }
-	withTooltips={ true }
-/>` }
+	<BarListChart
+		data={ singleSeriesData }
+		withTooltips={ true }
+	/>` }
 />
 
 ### Multi-Series Data
@@ -81,27 +81,27 @@ Compare data across different time periods or categories:
 <Source
 	language="jsx"
 	code={ `const multiSeriesData = [
-	{
-		group: 'primary',
-		label: 'Jan 21-Aug 8, 2024',
-		data: [
-			{ label: 'Organic search', value: 30000 },
-			{ label: 'Affiliates', value: 19000 },
-			{ label: 'Display', value: 18000 },
-		],
-	},
-	{
-		group: 'comparison',
-		label: 'Jan 21-Aug 8, 2023',
-		data: [
-			{ label: 'Organic search', value: 20000 },
-			{ label: 'Affiliates', value: 15000 },
-			{ label: 'Display', value: 19900 },
-		],
-	},
-];
+		{
+			group: 'primary',
+			label: 'Jan 21-Aug 8, 2024',
+			data: [
+				{ label: 'Organic search', value: 30000 },
+				{ label: 'Affiliates', value: 19000 },
+				{ label: 'Display', value: 18000 },
+			],
+		},
+		{
+			group: 'comparison',
+			label: 'Jan 21-Aug 8, 2023',
+			data: [
+				{ label: 'Organic search', value: 20000 },
+				{ label: 'Affiliates', value: 15000 },
+				{ label: 'Display', value: 19900 },
+			],
+		},
+	];
 
-<BarListChart data={ multiSeriesData } />` }
+	<BarListChart data={ multiSeriesData } />` }
 />
 
 ### Required Props
@@ -147,27 +147,27 @@ Create custom label rendering with icons or enhanced styling:
 <Source
 	language="jsx"
 	code={ `import { Circle } from '@visx/shape';
-import { Text } from '@visx/text';
+	import { Text } from '@visx/text';
 
-<BarListChart
-	data={ data }
-	options={ {
-		labelComponent: ( { textProps, x, y, label, formatter } ) => (
-			<>
-				<Circle cx={ x + 6 } cy={ y } r={ 8 } />
-				<Text
-					{ ...textProps }
-					textAnchor="start"
-					x={ x + 24 }
-					y={ y }
-					fontWeight={ 500 }
-				>
-					{ formatter( label ) }
-				</Text>
-			</>
-		),
-	} }
-/>` }
+	<BarListChart
+		data={ data }
+		options={ {
+			labelComponent: ( { textProps, x, y, label, formatter } ) => (
+				<>
+					<Circle cx={ x + 6 } cy={ y } r={ 8 } />
+					<Text
+						{ ...textProps }
+						textAnchor="start"
+						x={ x + 24 }
+						y={ y }
+						fontWeight={ 500 }
+					>
+						{ formatter( label ) }
+					</Text>
+				</>
+			),
+		} }
+	/>` }
 />
 
 ### Custom Value Components
@@ -179,43 +179,43 @@ Display additional information alongside values:
 <Source
 	language="jsx"
 	code={ `<BarListChart
-	data={ data }
-	options={ {
-		valueComponent: ( { textProps, x, y, value, formatter, data, index } ) => {
-			const currentValue = data[0].data[index].value;
-			const previousValue = data[1].data[index].value;
-			const percentage = previousValue === 0 ? 0 :
-				(((currentValue - previousValue) / previousValue) * 100).toFixed(0);
+		data={ data }
+		options={ {
+			valueComponent: ( { textProps, x, y, value, formatter, data, index } ) => {
+				const currentValue = data[0].data[index].value;
+				const previousValue = data[1].data[index].value;
+				const percentage = previousValue === 0 ? 0 :
+					(((currentValue - previousValue) / previousValue) * 100).toFixed(0);
 
-			return (
-				<>
-					<Text
-						{ ...textProps }
-						textAnchor="end"
-						x={ x }
-						y={ y }
-						dx={ -50 }
-						fontWeight={ 500 }
-					>
-						{ formatter( value ) }
-					</Text>
-					<Text
-						{ ...textProps }
-						textAnchor="end"
-						x={ x }
-						y={ y }
-						dx={ -10 }
-						fill="#008A20"
-						fontWeight={ 500 }
-					>
-						{ \`\${ Number( percentage ) > 0 ? '+' : '' }\${ percentage }%\` }
-					</Text>
-				</>
-			);
-		},
-		valueFormatter: ( value ) => \`$\${ formatNumberCompact( value ) }\`,
-	} }
-/>` }
+				return (
+					<>
+						<Text
+							{ ...textProps }
+							textAnchor="end"
+							x={ x }
+							y={ y }
+							dx={ -50 }
+							fontWeight={ 500 }
+						>
+							{ formatter( value ) }
+						</Text>
+						<Text
+							{ ...textProps }
+							textAnchor="end"
+							x={ x }
+							y={ y }
+							dx={ -10 }
+							fill="#008A20"
+							fontWeight={ 500 }
+						>
+							{ \`\${ Number( percentage ) > 0 ? '+' : '' }\${ percentage }%\` }
+						</Text>
+					</>
+				);
+			},
+			valueFormatter: ( value ) => \`$\${ formatNumberCompact( value ) }\`,
+		} }
+	/>` }
 />
 
 ### Formatting Options
@@ -293,6 +293,28 @@ The Bar List Chart component supports an optional entry animation that creates a
 
 **Note**: The animation plays once when the chart initially renders and does not repeat.
 
+## Responsive Behavior
+
+By default, BarListChart **fills its parent container's dimensions**. The parent must have an explicit height:
+
+<Source
+	language="jsx"
+	code={ `// Fill parent container (default) - parent needs explicit height
+	<div style={{ width: '100%', height: '300px' }}>
+		<BarListChart data={data} />
+	</div>
+
+	// Use aspect ratio - height calculated from width
+	<div style={{ width: '100%' }}>
+		<BarListChart data={data} aspectRatio={0.4} />
+	</div>
+
+	// Fixed dimensions
+	<BarListChart data={data} width={600} height={300} />` }
+/>
+
+For more details on responsive behavior, see the [Responsive Design section](./?path=/docs/js-packages-charts-library-introduction--docs#responsive-design) in the introduction.
+
 ## Advanced Features
 
 ### Scale Configuration
@@ -302,17 +324,17 @@ Customize the chart scales for precise control over bar sizing and spacing:
 <Source
 	language="jsx"
 	code={ `<BarListChart
-	data={ data }
-	options={ {
-		yScale: {
-			paddingInner: 0.4,  // Space between bars
-			padding: 0.2,       // Outer padding
-		},
-		xScale: {
-			zero: true,         // Always start from zero
-		},
-	} }
-/>` }
+		data={ data }
+		options={ {
+			yScale: {
+				paddingInner: 0.4,  // Space between bars
+				padding: 0.2,       // Outer padding
+			},
+			xScale: {
+				zero: true,         // Always start from zero
+			},
+		} }
+	/>` }
 />
 
 ### Automatic Layout Calculation
@@ -334,13 +356,13 @@ Override automatic positioning when needed:
 <Source
 	language="jsx"
 	code={ `<BarListChart
-	data={ data }
-	options={ {
-		yOffset: -20,          // Vertical offset for text
-		labelPosition: 10,     // Fixed label position
-		valuePosition: 380,    // Fixed value position
-	} }
-/>` }
+		data={ data }
+		options={ {
+			yOffset: -20,          // Vertical offset for text
+			labelPosition: 10,     // Fixed label position
+			valuePosition: 380,    // Fixed value position
+		} }
+	/>` }
 />
 
 ## Accessibility
@@ -352,22 +374,23 @@ BarListChart inherits accessibility features from the underlying BarChart compon
 If you're currently using a horizontal BarChart for list-style data, BarListChart provides a more optimized experience:
 
 <Source language="jsx" code={`
-// Old approach with BarChart
-<BarChart
-	orientation="horizontal"
-	data={ data }
-	// Complex custom axis configuration needed
-	options={ {
-		axis: {
-			y: { /* complex custom renderer */ },
-			x: { children: () => null }
-		}
-	} }
-/>
+	// Old approach with BarChart
+	<BarChart
+		orientation="horizontal"
+		data={ data }
+		// Complex custom axis configuration needed
+		options={ {
+			axis: {
+				y: { /* complex custom renderer */ },
+				x: { children: () => null }
+			}
+		} }
+	/>
 
-// New approach with BarListChart
-<BarListChart data={ data } />
-`} />
+	// New approach with BarListChart
+	<BarListChart data={ data } />
+	`}
+/>
 
 Benefits of migration:
 - Automatic label and value positioning

--- a/projects/js-packages/charts/src/charts/bar-list-chart/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/charts/bar-list-chart/stories/index.stories.tsx
@@ -39,8 +39,21 @@ export const Default: Story = {
 		...sharedThemeArgs,
 		withTooltips: true,
 		data: salesByProduct,
-		containerWidth: '600px',
-		containerHeight: '332px',
+	},
+};
+
+export const FixedDimensions: Story = {
+	args: {
+		...Default.args,
+		width: 600,
+		height: 300,
+	},
+};
+
+export const AspectRatio: Story = {
+	args: {
+		...Default.args,
+		aspectRatio: 0.3,
 	},
 };
 

--- a/projects/js-packages/charts/src/charts/geo-chart/stories/config.tsx
+++ b/projects/js-packages/charts/src/charts/geo-chart/stories/config.tsx
@@ -26,5 +26,4 @@ export const geoChartMetaArgs: Meta< StoryArgs > = {
 export const geoChartStoryArgs = {
 	data: viewsByCountry,
 	withPadding: false,
-	height: 500,
 };

--- a/projects/js-packages/charts/src/charts/geo-chart/stories/index.docs.mdx
+++ b/projects/js-packages/charts/src/charts/geo-chart/stories/index.docs.mdx
@@ -62,11 +62,17 @@ The simplest geo chart requires data, width, and height. The `data` prop uses Go
 ### Required Props
 
 - **`data`**: Array in Google Charts format - first row is headers, subsequent rows are data. Countries can be identified by full name (e.g., 'United States', 'Canada') or ISO 3166-1 alpha-2 codes (e.g., 'US', 'CA')
-- **`width`**: Width of the chart in pixels
-- **`height`**: Height of the chart in pixels
 
 ### Optional Props
 
+**Layout & Dimensions:**
+- **`width`**: Width of the chart in pixels. When omitted, fills parent container width
+- **`height`**: Height of the chart in pixels. When omitted, fills parent container height (parent must have explicit height)
+- **`aspectRatio`**: Height as a fraction of width (e.g., `0.625` = 62.5% height). When provided, height is calculated from width
+- **`maxWidth`**: Maximum width constraint for responsive charts (default: `1200`)
+- **`resizeDebounceTime`**: Debounce delay for resize events in ms (default: `300`)
+
+**Styling & Customization:**
 - **`className`**: Additional CSS class name for custom styling
 - **`renderPlaceholder`**: Custom render function for the loading placeholder
 

--- a/projects/js-packages/charts/src/charts/geo-chart/stories/index.docs.mdx
+++ b/projects/js-packages/charts/src/charts/geo-chart/stories/index.docs.mdx
@@ -318,6 +318,28 @@ The Geo Chart uses Google Charts' default Mercator projection for world map visu
 - **Validate data**: Check that values are positive numbers
 - **Consider scale**: Large value ranges will show more dramatic color differences
 
+### Responsive Behavior
+
+Like other charts in this library, GeoChart supports responsive sizing. By default, it **fills its parent container's dimensions**:
+
+<Source
+	language="tsx"
+	code={ `// Fill parent container (default) - parent needs explicit height
+	<div style={{ width: '100%', height: '400px' }}>
+		<GeoChart data={ordersByCountry} />
+	</div>
+
+	// Use aspect ratio - height calculated from width
+	<div style={{ width: '100%' }}>
+		<GeoChart data={ordersByCountry} aspectRatio={0.625} />
+	</div>
+
+	// Fixed dimensions
+	<GeoChart data={ordersByCountry} width={800} height={500} />` }
+/>
+
+For more details on responsive behavior, see the [Responsive Design section](./?path=/docs/js-packages-charts-library-introduction--docs#responsive-design) in the introduction.
+
 ### Performance Considerations
 
 The Geo Chart renders efficiently for typical use cases, but consider these factors:
@@ -325,7 +347,6 @@ The Geo Chart renders efficiently for typical use cases, but consider these fact
 - **Network dependency**: Google Charts loads resources from Google's CDN, requiring network access
 - **Initial load**: The first render requires loading Google Charts library (~100KB)
 - **Caching**: Subsequent renders benefit from browser caching of Google Charts resources
-- **Fixed dimensions**: The chart uses fixed width and height, not responsive sizing
 
 ### Accessibility
 

--- a/projects/js-packages/charts/src/charts/geo-chart/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/charts/geo-chart/stories/index.stories.tsx
@@ -15,15 +15,21 @@ type Story = StoryObj< typeof GeoChart >;
 export const Default: Story = {
 	args: {
 		...geoChartStoryArgs,
-		containerHeight: '400px',
 	},
-	parameters: {
-		docs: {
-			description: {
-				story:
-					'Default responsive behavior. The chart fills its parent container. Resize the container to see how the chart adapts to any aspect ratio.',
-			},
-		},
+};
+
+export const FixedDimensions: Story = {
+	args: {
+		...Default.args,
+		width: 600,
+		height: 300,
+	},
+};
+
+export const AspectRatio: Story = {
+	args: {
+		...Default.args,
+		aspectRatio: 0.5,
 	},
 };
 
@@ -59,20 +65,5 @@ export const EuropeanCountries: Story = {
 		region: '150',
 		resolution: 'countries',
 		data: viewsByEuropeanCountry,
-	},
-};
-
-export const WithAspectRatio: Story = {
-	args: {
-		...Default.args,
-		aspectRatio: 0.5,
-	},
-	parameters: {
-		docs: {
-			description: {
-				story:
-					'When `aspectRatio` is provided, the chart height is calculated as `width * aspectRatio`. This maintains a consistent shape regardless of container size.',
-			},
-		},
 	},
 };

--- a/projects/js-packages/charts/src/charts/geo-chart/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/charts/geo-chart/stories/index.stories.tsx
@@ -12,12 +12,9 @@ const meta: Meta< typeof GeoChart > = {
 export default meta;
 type Story = StoryObj< typeof GeoChart >;
 
-const responsiveArgs = { ...geoChartStoryArgs };
-delete responsiveArgs.height;
-
 export const Default: Story = {
 	args: {
-		...responsiveArgs,
+		...geoChartStoryArgs,
 		containerHeight: '400px',
 		resize: 'both' as const,
 	},
@@ -33,7 +30,7 @@ export const Default: Story = {
 
 export const SingleCountry: Story = {
 	args: {
-		...geoChartStoryArgs,
+		...Default.args,
 		data: [
 			[ 'Country', 'Views' ],
 			[ 'United States', 1500 ],
@@ -43,14 +40,14 @@ export const SingleCountry: Story = {
 
 export const EmptyData: Story = {
 	args: {
-		...geoChartStoryArgs,
+		...Default.args,
 		data: [ [ 'Country', 'Views' ] ],
 	},
 };
 
 export const USStates: Story = {
 	args: {
-		...geoChartStoryArgs,
+		...Default.args,
 		region: 'US',
 		resolution: 'provinces',
 		data: viewsByUSState,
@@ -59,7 +56,7 @@ export const USStates: Story = {
 
 export const EuropeanCountries: Story = {
 	args: {
-		...geoChartStoryArgs,
+		...Default.args,
 		region: '150',
 		resolution: 'countries',
 		data: viewsByEuropeanCountry,
@@ -68,7 +65,7 @@ export const EuropeanCountries: Story = {
 
 export const WithAspectRatio: Story = {
 	args: {
-		...responsiveArgs,
+		...Default.args,
 		aspectRatio: 0.5,
 		resize: 'both' as const,
 	},

--- a/projects/js-packages/charts/src/charts/geo-chart/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/charts/geo-chart/stories/index.stories.tsx
@@ -16,7 +16,6 @@ export const Default: Story = {
 	args: {
 		...geoChartStoryArgs,
 		containerHeight: '400px',
-		resize: 'both' as const,
 	},
 	parameters: {
 		docs: {
@@ -67,7 +66,6 @@ export const WithAspectRatio: Story = {
 	args: {
 		...Default.args,
 		aspectRatio: 0.5,
-		resize: 'both' as const,
 	},
 	parameters: {
 		docs: {

--- a/projects/js-packages/charts/src/charts/geo-chart/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/charts/geo-chart/stories/index.stories.tsx
@@ -12,9 +12,22 @@ const meta: Meta< typeof GeoChart > = {
 export default meta;
 type Story = StoryObj< typeof GeoChart >;
 
+const responsiveArgs = { ...geoChartStoryArgs };
+delete responsiveArgs.height;
+
 export const Default: Story = {
 	args: {
-		...geoChartStoryArgs,
+		...responsiveArgs,
+		containerHeight: '400px',
+		resize: 'both' as const,
+	},
+	parameters: {
+		docs: {
+			description: {
+				story:
+					'Default responsive behavior. The chart fills its parent container. Resize the container to see how the chart adapts to any aspect ratio.',
+			},
+		},
 	},
 };
 
@@ -50,5 +63,21 @@ export const EuropeanCountries: Story = {
 		region: '150',
 		resolution: 'countries',
 		data: viewsByEuropeanCountry,
+	},
+};
+
+export const WithAspectRatio: Story = {
+	args: {
+		...responsiveArgs,
+		aspectRatio: 0.5,
+		resize: 'both' as const,
+	},
+	parameters: {
+		docs: {
+			description: {
+				story:
+					'When `aspectRatio` is provided, the chart height is calculated as `width * aspectRatio`. This maintains a consistent shape regardless of container size.',
+			},
+		},
 	},
 };

--- a/projects/js-packages/charts/src/charts/line-chart/line-chart.module.scss
+++ b/projects/js-packages/charts/src/charts/line-chart/line-chart.module.scss
@@ -1,7 +1,10 @@
 .line-chart {
-	display: flex;
-	flex-direction: column;
 	position: relative;
+
+	&__svg-wrapper {
+		flex: 1;
+		min-height: 0; // Required for flex shrinking
+	}
 
 	&--animated {
 
@@ -10,10 +13,6 @@
 			transform: scaleY(0);
 			animation: rise 1s ease-out forwards;
 		}
-	}
-
-	&--legend-top {
-		flex-direction: column-reverse;
 	}
 
 	svg {

--- a/projects/js-packages/charts/src/charts/line-chart/line-chart.tsx
+++ b/projects/js-packages/charts/src/charts/line-chart/line-chart.tsx
@@ -15,6 +15,7 @@ import {
 	useChartDataTransform,
 	useChartMargin,
 	useElementHeight,
+	useHasLegendChild,
 	usePrefersReducedMotion,
 } from '../../hooks';
 import {
@@ -293,10 +294,15 @@ const LineChartInternal = forwardRef< SingleChartRef, LineChartProps >(
 		const [ isNavigating, setIsNavigating ] = useState( false );
 		const internalChartRef = useRef< SingleChartRef >( null );
 
+		// Check if children contain a Legend component (composition pattern)
+		const hasLegendChild = useHasLegendChild( children );
+
 		// Use the measured SVG wrapper height, falling back to the passed height if provided.
-		// We only render the chart once we have a valid height to prevent layout shift/flicker.
+		// When there's a legend (via prop or composition), we must wait for measurement because
+		// the legend takes space and the svg-wrapper height will be less than the total height.
 		const chartHeight = svgWrapperHeight > 0 ? svgWrapperHeight : height;
-		const isWaitingForMeasurement = ! chartHeight;
+		const hasLegend = showLegend || hasLegendChild;
+		const isWaitingForMeasurement = hasLegend ? svgWrapperHeight === 0 : ! chartHeight;
 
 		// Forward the external ref to the internal ref
 		useImperativeHandle(
@@ -483,6 +489,7 @@ const LineChartInternal = forwardRef< SingleChartRef, LineChartProps >(
 					style={ {
 						width,
 						height,
+						visibility: isWaitingForMeasurement ? 'hidden' : 'visible',
 					} }
 				>
 					{ legendPosition === 'top' && legendElement }

--- a/projects/js-packages/charts/src/charts/line-chart/line-chart.tsx
+++ b/projects/js-packages/charts/src/charts/line-chart/line-chart.tsx
@@ -250,7 +250,7 @@ const LineChartInternal = forwardRef< SingleChartRef, LineChartProps >(
 			data,
 			chartId: providedChartId,
 			width,
-			height,
+			height = 400,
 			className,
 			margin,
 			withTooltips = true,

--- a/projects/js-packages/charts/src/charts/line-chart/line-chart.tsx
+++ b/projects/js-packages/charts/src/charts/line-chart/line-chart.tsx
@@ -4,7 +4,6 @@ import { LinearGradient } from '@visx/gradient';
 import { scaleTime } from '@visx/scale';
 import { XYChart, AreaSeries, Grid, Axis, DataContext } from '@visx/xychart';
 import { __ } from '@wordpress/i18n';
-import '@wordpress/theme/design-tokens.css';
 import { Stack } from '@wordpress/ui';
 import clsx from 'clsx';
 import { differenceInHours, differenceInYears } from 'date-fns';

--- a/projects/js-packages/charts/src/charts/line-chart/line-chart.tsx
+++ b/projects/js-packages/charts/src/charts/line-chart/line-chart.tsx
@@ -500,148 +500,148 @@ const LineChartInternal = forwardRef< SingleChartRef, LineChartProps >(
 						{ ! isWaitingForMeasurement && (
 							<div ref={ chartRef }>
 								<XYChart
-								theme={ theme }
-								width={ width }
-								height={ chartHeight }
-								margin={ {
-									...defaultMargin,
-									...margin,
-								} }
-								// xScale and yScale could be set in Axis as well, but they are `scale` props there.
-								xScale={ chartOptions.xScale }
-								yScale={ chartOptions.yScale }
-								onPointerDown={ onPointerDown }
-								onPointerUp={ onPointerUp }
-								onPointerMove={ onPointerMove }
-								onPointerOut={ onPointerOut }
-								pointerEventsDataKey="nearest"
-							>
-								{ gridVisibility !== 'none' && <Grid columns={ false } numTicks={ 4 } /> }
-								{ chartOptions.axis.x.display && <Axis { ...chartOptions.axis.x } /> }
-								{ chartOptions.axis.y.display && <Axis { ...chartOptions.axis.y } /> }
-
-								{ allSeriesHidden ? (
-									<text
-										x={ width / 2 }
-										y={ chartHeight / 2 }
-										textAnchor="middle"
-										fill={ providerTheme.gridStyles?.stroke || '#ccc' }
-										fontSize="14"
-										fontFamily="-apple-system,BlinkMacSystemFont,Roboto,Helvetica Neue,sans-serif"
-									>
-										{ __(
-											'All series are hidden. Click legend items to show data.',
-											'jetpack-charts'
-										) }
-									</text>
-								) : null }
-
-								{ seriesWithVisibility.map( ( { series: seriesData, index, isVisible } ) => {
-									// Skip rendering invisible series
-									if ( ! isVisible ) {
-										return null;
-									}
-
-									const { color, lineStyles, glyph } = getElementStyles( {
-										data: seriesData,
-										index,
-									} );
-
-									const lineProps = {
-										stroke: color,
-										...lineStyles,
-									};
-
-									return (
-										<g key={ seriesData?.label || index }>
-											{ withGradientFill && (
-												<LinearGradient
-													id={ `area-gradient-${ chartId }-${ index + 1 }` }
-													from={ color }
-													fromOpacity={ 0.4 }
-													toOpacity={ 0.1 }
-													to={ providerTheme.backgroundColor }
-													{ ...seriesData.options?.gradient }
-													data-testid="line-gradient"
-												>
-													{ seriesData.options?.gradient?.stops?.map( ( stop, stopIndex ) => (
-														<stop
-															key={ `${ stop.offset }-${ stop.color || color }` }
-															offset={ stop.offset }
-															stopColor={ stop.color || color }
-															stopOpacity={ stop.opacity ?? 1 }
-															data-testid={ `line-gradient-stop-${ chartId }-${ index }-${ stopIndex }` }
-														/>
-													) ) }
-												</LinearGradient>
-											) }
-											<AreaSeries
-												key={ seriesData?.label }
-												dataKey={ seriesData?.label }
-												data={ seriesData.data as DataPointDate[] }
-												{ ...accessors }
-												fill={
-													withGradientFill
-														? `url(#area-gradient-${ chartId }-${ index + 1 })`
-														: 'transparent'
-												}
-												renderLine={ true }
-												curve={ getCurveType( curveType, smoothing ) }
-												lineProps={ lineProps }
-											/>
-
-											{ withStartGlyphs && (
-												<LineChartGlyph
-													index={ index }
-													data={ seriesData }
-													color={ color }
-													renderGlyph={ glyph ?? renderGlyph }
-													accessors={ accessors }
-													glyphStyle={ glyphStyle }
-													position="start"
-												/>
-											) }
-
-											{ withEndGlyphs && (
-												<LineChartGlyph
-													index={ index }
-													data={ seriesData }
-													color={ color }
-													renderGlyph={ glyph ?? renderGlyph }
-													accessors={ accessors }
-													glyphStyle={ glyphStyle }
-													position="end"
-												/>
-											) }
-										</g>
-									);
-								} ) }
-
-								{ withTooltips && (
-									<AccessibleTooltip
-										detectBounds
-										snapTooltipToDatumX
-										snapTooltipToDatumY
-										showSeriesGlyphs
-										renderTooltip={ renderTooltip }
-										renderGlyph={ tooltipRenderGlyph }
-										glyphStyle={ glyphStyle }
-										showVerticalCrosshair={ withTooltipCrosshairs?.showVertical }
-										showHorizontalCrosshair={ withTooltipCrosshairs?.showHorizontal }
-										selectedIndex={ selectedIndex }
-										tooltipRef={ tooltipRef }
-										keyboardFocusedClassName={ styles[ 'line-chart__tooltip--keyboard-focused' ] }
-										series={ dataSorted }
-									/>
-								) }
-
-								{ /* Component to expose scale data via ref */ }
-								<LineChartScalesRef
-									chartRef={ internalChartRef }
+									theme={ theme }
 									width={ width }
-									height={ height }
-									margin={ margin }
-								/>
+									height={ chartHeight }
+									margin={ {
+										...defaultMargin,
+										...margin,
+									} }
+									// xScale and yScale could be set in Axis as well, but they are `scale` props there.
+									xScale={ chartOptions.xScale }
+									yScale={ chartOptions.yScale }
+									onPointerDown={ onPointerDown }
+									onPointerUp={ onPointerUp }
+									onPointerMove={ onPointerMove }
+									onPointerOut={ onPointerOut }
+									pointerEventsDataKey="nearest"
+								>
+									{ gridVisibility !== 'none' && <Grid columns={ false } numTicks={ 4 } /> }
+									{ chartOptions.axis.x.display && <Axis { ...chartOptions.axis.x } /> }
+									{ chartOptions.axis.y.display && <Axis { ...chartOptions.axis.y } /> }
+
+									{ allSeriesHidden ? (
+										<text
+											x={ width / 2 }
+											y={ chartHeight / 2 }
+											textAnchor="middle"
+											fill={ providerTheme.gridStyles?.stroke || '#ccc' }
+											fontSize="14"
+											fontFamily="-apple-system,BlinkMacSystemFont,Roboto,Helvetica Neue,sans-serif"
+										>
+											{ __(
+												'All series are hidden. Click legend items to show data.',
+												'jetpack-charts'
+											) }
+										</text>
+									) : null }
+
+									{ seriesWithVisibility.map( ( { series: seriesData, index, isVisible } ) => {
+										// Skip rendering invisible series
+										if ( ! isVisible ) {
+											return null;
+										}
+
+										const { color, lineStyles, glyph } = getElementStyles( {
+											data: seriesData,
+											index,
+										} );
+
+										const lineProps = {
+											stroke: color,
+											...lineStyles,
+										};
+
+										return (
+											<g key={ seriesData?.label || index }>
+												{ withGradientFill && (
+													<LinearGradient
+														id={ `area-gradient-${ chartId }-${ index + 1 }` }
+														from={ color }
+														fromOpacity={ 0.4 }
+														toOpacity={ 0.1 }
+														to={ providerTheme.backgroundColor }
+														{ ...seriesData.options?.gradient }
+														data-testid="line-gradient"
+													>
+														{ seriesData.options?.gradient?.stops?.map( ( stop, stopIndex ) => (
+															<stop
+																key={ `${ stop.offset }-${ stop.color || color }` }
+																offset={ stop.offset }
+																stopColor={ stop.color || color }
+																stopOpacity={ stop.opacity ?? 1 }
+																data-testid={ `line-gradient-stop-${ chartId }-${ index }-${ stopIndex }` }
+															/>
+														) ) }
+													</LinearGradient>
+												) }
+												<AreaSeries
+													key={ seriesData?.label }
+													dataKey={ seriesData?.label }
+													data={ seriesData.data as DataPointDate[] }
+													{ ...accessors }
+													fill={
+														withGradientFill
+															? `url(#area-gradient-${ chartId }-${ index + 1 })`
+															: 'transparent'
+													}
+													renderLine={ true }
+													curve={ getCurveType( curveType, smoothing ) }
+													lineProps={ lineProps }
+												/>
+
+												{ withStartGlyphs && (
+													<LineChartGlyph
+														index={ index }
+														data={ seriesData }
+														color={ color }
+														renderGlyph={ glyph ?? renderGlyph }
+														accessors={ accessors }
+														glyphStyle={ glyphStyle }
+														position="start"
+													/>
+												) }
+
+												{ withEndGlyphs && (
+													<LineChartGlyph
+														index={ index }
+														data={ seriesData }
+														color={ color }
+														renderGlyph={ glyph ?? renderGlyph }
+														accessors={ accessors }
+														glyphStyle={ glyphStyle }
+														position="end"
+													/>
+												) }
+											</g>
+										);
+									} ) }
+
+									{ withTooltips && (
+										<AccessibleTooltip
+											detectBounds
+											snapTooltipToDatumX
+											snapTooltipToDatumY
+											showSeriesGlyphs
+											renderTooltip={ renderTooltip }
+											renderGlyph={ tooltipRenderGlyph }
+											glyphStyle={ glyphStyle }
+											showVerticalCrosshair={ withTooltipCrosshairs?.showVertical }
+											showHorizontalCrosshair={ withTooltipCrosshairs?.showHorizontal }
+											selectedIndex={ selectedIndex }
+											tooltipRef={ tooltipRef }
+											keyboardFocusedClassName={ styles[ 'line-chart__tooltip--keyboard-focused' ] }
+											series={ dataSorted }
+										/>
+									) }
+
+									{ /* Component to expose scale data via ref */ }
+									<LineChartScalesRef
+										chartRef={ internalChartRef }
+										width={ width }
+										height={ height }
+										margin={ margin }
+									/>
 								</XYChart>
 							</div>
 						) }

--- a/projects/js-packages/charts/src/charts/line-chart/line-chart.tsx
+++ b/projects/js-packages/charts/src/charts/line-chart/line-chart.tsx
@@ -293,8 +293,10 @@ const LineChartInternal = forwardRef< SingleChartRef, LineChartProps >(
 		const [ isNavigating, setIsNavigating ] = useState( false );
 		const internalChartRef = useRef< SingleChartRef >( null );
 
-		// Use the measured SVG wrapper height, falling back to the passed height initially
+		// Use the measured SVG wrapper height, falling back to the passed height initially.
+		// We only render the chart once we have a valid height to prevent layout shift/flicker.
 		const chartHeight = svgWrapperHeight > 0 ? svgWrapperHeight : height;
+		const isWaitingForMeasurement = chartHeight === 0;
 
 		// Forward the external ref to the internal ref
 		useImperativeHandle(
@@ -495,8 +497,9 @@ const LineChartInternal = forwardRef< SingleChartRef, LineChartProps >(
 						onFocus={ onChartFocus }
 						onBlur={ onChartBlur }
 					>
-						<div ref={ chartRef }>
-							<XYChart
+						{ ! isWaitingForMeasurement && (
+							<div ref={ chartRef }>
+								<XYChart
 								theme={ theme }
 								width={ width }
 								height={ chartHeight }
@@ -639,8 +642,9 @@ const LineChartInternal = forwardRef< SingleChartRef, LineChartProps >(
 									height={ height }
 									margin={ margin }
 								/>
-							</XYChart>
-						</div>
+								</XYChart>
+							</div>
+						) }
 					</div>
 
 					{ legendPosition === 'bottom' && legendElement }

--- a/projects/js-packages/charts/src/charts/line-chart/line-chart.tsx
+++ b/projects/js-packages/charts/src/charts/line-chart/line-chart.tsx
@@ -4,6 +4,8 @@ import { LinearGradient } from '@visx/gradient';
 import { scaleTime } from '@visx/scale';
 import { XYChart, AreaSeries, Grid, Axis, DataContext } from '@visx/xychart';
 import { __ } from '@wordpress/i18n';
+import '@wordpress/theme/design-tokens.css';
+import { Stack } from '@wordpress/ui';
 import clsx from 'clsx';
 import { differenceInHours, differenceInYears } from 'date-fns';
 import { useMemo, useContext, forwardRef, useImperativeHandle, useState, useRef } from 'react';
@@ -279,17 +281,21 @@ const LineChartInternal = forwardRef< SingleChartRef, LineChartProps >(
 			onPointerOut = undefined,
 			children,
 			gridVisibility,
+			gap = 'md',
 		},
 		ref
 	) => {
 		const providerTheme = useGlobalChartsTheme();
 		const theme = useXYChartTheme( data );
 		const chartId = useChartId( providedChartId );
-		const [ legendRef, legendHeight ] = useElementHeight< HTMLDivElement >();
+		const [ svgWrapperRef, svgWrapperHeight ] = useElementHeight< HTMLDivElement >();
 		const chartRef = useRef< HTMLDivElement >( null );
 		const [ selectedIndex, setSelectedIndex ] = useState< number | undefined >( undefined );
 		const [ isNavigating, setIsNavigating ] = useState( false );
 		const internalChartRef = useRef< SingleChartRef >( null );
+
+		// Use the measured SVG wrapper height, falling back to the passed height initially
+		const chartHeight = svgWrapperHeight > 0 ? svgWrapperHeight : height;
 
 		// Forward the external ref to the internal ref
 		useImperativeHandle(
@@ -439,21 +445,37 @@ const LineChartInternal = forwardRef< SingleChartRef, LineChartProps >(
 			return <div className={ clsx( 'line-chart', styles[ 'line-chart' ] ) }>{ error }</div>;
 		}
 
+		const legendElement = showLegend && (
+			<Legend
+				orientation={ legendOrientation }
+				alignment={ legendAlignment }
+				position={ legendPosition }
+				maxWidth={ legendMaxWidth }
+				textOverflow={ legendTextOverflow }
+				legendItemClassName={ legendItemClassName }
+				className={ styles[ 'line-chart__legend' ] }
+				shape={ legendShape }
+				chartId={ chartId }
+				interactive={ legendInteractive }
+			/>
+		);
+
 		return (
 			<SingleChartContext.Provider
 				value={ {
 					chartId,
 					chartRef: internalChartRef,
 					chartWidth: width,
-					chartHeight: height - ( showLegend ? legendHeight : 0 ),
+					chartHeight,
 				} }
 			>
-				<div
+				<Stack
+					direction="column"
+					gap={ gap }
 					className={ clsx(
 						'line-chart',
 						styles[ 'line-chart' ],
 						{ [ styles[ 'line-chart--animated' ] ]: animation && ! prefersReducedMotion },
-						{ [ styles[ 'line-chart--legend-top' ] ]: showLegend && legendPosition === 'top' },
 						className
 					) }
 					data-testid="line-chart"
@@ -462,182 +484,170 @@ const LineChartInternal = forwardRef< SingleChartRef, LineChartProps >(
 						height,
 					} }
 				>
+					{ legendPosition === 'top' && legendElement }
+
 					<div
+						className={ styles[ 'line-chart__svg-wrapper' ] }
+						ref={ svgWrapperRef }
 						role="grid"
 						aria-label={ __( 'Line chart', 'jetpack-charts' ) }
 						tabIndex={ 0 }
 						onKeyDown={ onChartKeyDown }
 						onFocus={ onChartFocus }
 						onBlur={ onChartBlur }
-						ref={ chartRef }
 					>
-						<XYChart
-							theme={ theme }
-							width={ width }
-							height={ height - ( showLegend ? legendHeight : 0 ) }
-							margin={ {
-								...defaultMargin,
-								...margin,
-								...( showLegend && legendPosition === 'top'
-									? { top: ( defaultMargin.top || 0 ) + legendHeight }
-									: {} ),
-							} }
-							// xScale and yScale could be set in Axis as well, but they are `scale` props there.
-							xScale={ chartOptions.xScale }
-							yScale={ chartOptions.yScale }
-							onPointerDown={ onPointerDown }
-							onPointerUp={ onPointerUp }
-							onPointerMove={ onPointerMove }
-							onPointerOut={ onPointerOut }
-							pointerEventsDataKey="nearest"
-						>
-							{ gridVisibility !== 'none' && <Grid columns={ false } numTicks={ 4 } /> }
-							{ chartOptions.axis.x.display && <Axis { ...chartOptions.axis.x } /> }
-							{ chartOptions.axis.y.display && <Axis { ...chartOptions.axis.y } /> }
-
-							{ allSeriesHidden ? (
-								<text
-									x={ width / 2 }
-									y={ ( height - ( showLegend ? legendHeight : 0 ) ) / 2 }
-									textAnchor="middle"
-									fill={ providerTheme.gridStyles?.stroke || '#ccc' }
-									fontSize="14"
-									fontFamily="-apple-system,BlinkMacSystemFont,Roboto,Helvetica Neue,sans-serif"
-								>
-									{ __(
-										'All series are hidden. Click legend items to show data.',
-										'jetpack-charts'
-									) }
-								</text>
-							) : null }
-
-							{ seriesWithVisibility.map( ( { series: seriesData, index, isVisible } ) => {
-								// Skip rendering invisible series
-								if ( ! isVisible ) {
-									return null;
-								}
-
-								const { color, lineStyles, glyph } = getElementStyles( {
-									data: seriesData,
-									index,
-								} );
-
-								const lineProps = {
-									stroke: color,
-									...lineStyles,
-								};
-
-								return (
-									<g key={ seriesData?.label || index }>
-										{ withGradientFill && (
-											<LinearGradient
-												id={ `area-gradient-${ chartId }-${ index + 1 }` }
-												from={ color }
-												fromOpacity={ 0.4 }
-												toOpacity={ 0.1 }
-												to={ providerTheme.backgroundColor }
-												{ ...seriesData.options?.gradient }
-												data-testid="line-gradient"
-											>
-												{ seriesData.options?.gradient?.stops?.map( ( stop, stopIndex ) => (
-													<stop
-														key={ `${ stop.offset }-${ stop.color || color }` }
-														offset={ stop.offset }
-														stopColor={ stop.color || color }
-														stopOpacity={ stop.opacity ?? 1 }
-														data-testid={ `line-gradient-stop-${ chartId }-${ index }-${ stopIndex }` }
-													/>
-												) ) }
-											</LinearGradient>
-										) }
-										<AreaSeries
-											key={ seriesData?.label }
-											dataKey={ seriesData?.label }
-											data={ seriesData.data as DataPointDate[] }
-											{ ...accessors }
-											fill={
-												withGradientFill
-													? `url(#area-gradient-${ chartId }-${ index + 1 })`
-													: 'transparent'
-											}
-											renderLine={ true }
-											curve={ getCurveType( curveType, smoothing ) }
-											lineProps={ lineProps }
-										/>
-
-										{ withStartGlyphs && (
-											<LineChartGlyph
-												index={ index }
-												data={ seriesData }
-												color={ color }
-												renderGlyph={ glyph ?? renderGlyph }
-												accessors={ accessors }
-												glyphStyle={ glyphStyle }
-												position="start"
-											/>
-										) }
-
-										{ withEndGlyphs && (
-											<LineChartGlyph
-												index={ index }
-												data={ seriesData }
-												color={ color }
-												renderGlyph={ glyph ?? renderGlyph }
-												accessors={ accessors }
-												glyphStyle={ glyphStyle }
-												position="end"
-											/>
-										) }
-									</g>
-								);
-							} ) }
-
-							{ withTooltips && (
-								<AccessibleTooltip
-									detectBounds
-									snapTooltipToDatumX
-									snapTooltipToDatumY
-									showSeriesGlyphs
-									renderTooltip={ renderTooltip }
-									renderGlyph={ tooltipRenderGlyph }
-									glyphStyle={ glyphStyle }
-									showVerticalCrosshair={ withTooltipCrosshairs?.showVertical }
-									showHorizontalCrosshair={ withTooltipCrosshairs?.showHorizontal }
-									selectedIndex={ selectedIndex }
-									tooltipRef={ tooltipRef }
-									keyboardFocusedClassName={ styles[ 'line-chart__tooltip--keyboard-focused' ] }
-									series={ dataSorted }
-								/>
-							) }
-
-							{ /* Component to expose scale data via ref */ }
-							<LineChartScalesRef
-								chartRef={ internalChartRef }
+						<div ref={ chartRef }>
+							<XYChart
+								theme={ theme }
 								width={ width }
-								height={ height }
-								margin={ margin }
-							/>
-						</XYChart>
+								height={ chartHeight }
+								margin={ {
+									...defaultMargin,
+									...margin,
+								} }
+								// xScale and yScale could be set in Axis as well, but they are `scale` props there.
+								xScale={ chartOptions.xScale }
+								yScale={ chartOptions.yScale }
+								onPointerDown={ onPointerDown }
+								onPointerUp={ onPointerUp }
+								onPointerMove={ onPointerMove }
+								onPointerOut={ onPointerOut }
+								pointerEventsDataKey="nearest"
+							>
+								{ gridVisibility !== 'none' && <Grid columns={ false } numTicks={ 4 } /> }
+								{ chartOptions.axis.x.display && <Axis { ...chartOptions.axis.x } /> }
+								{ chartOptions.axis.y.display && <Axis { ...chartOptions.axis.y } /> }
+
+								{ allSeriesHidden ? (
+									<text
+										x={ width / 2 }
+										y={ chartHeight / 2 }
+										textAnchor="middle"
+										fill={ providerTheme.gridStyles?.stroke || '#ccc' }
+										fontSize="14"
+										fontFamily="-apple-system,BlinkMacSystemFont,Roboto,Helvetica Neue,sans-serif"
+									>
+										{ __(
+											'All series are hidden. Click legend items to show data.',
+											'jetpack-charts'
+										) }
+									</text>
+								) : null }
+
+								{ seriesWithVisibility.map( ( { series: seriesData, index, isVisible } ) => {
+									// Skip rendering invisible series
+									if ( ! isVisible ) {
+										return null;
+									}
+
+									const { color, lineStyles, glyph } = getElementStyles( {
+										data: seriesData,
+										index,
+									} );
+
+									const lineProps = {
+										stroke: color,
+										...lineStyles,
+									};
+
+									return (
+										<g key={ seriesData?.label || index }>
+											{ withGradientFill && (
+												<LinearGradient
+													id={ `area-gradient-${ chartId }-${ index + 1 }` }
+													from={ color }
+													fromOpacity={ 0.4 }
+													toOpacity={ 0.1 }
+													to={ providerTheme.backgroundColor }
+													{ ...seriesData.options?.gradient }
+													data-testid="line-gradient"
+												>
+													{ seriesData.options?.gradient?.stops?.map( ( stop, stopIndex ) => (
+														<stop
+															key={ `${ stop.offset }-${ stop.color || color }` }
+															offset={ stop.offset }
+															stopColor={ stop.color || color }
+															stopOpacity={ stop.opacity ?? 1 }
+															data-testid={ `line-gradient-stop-${ chartId }-${ index }-${ stopIndex }` }
+														/>
+													) ) }
+												</LinearGradient>
+											) }
+											<AreaSeries
+												key={ seriesData?.label }
+												dataKey={ seriesData?.label }
+												data={ seriesData.data as DataPointDate[] }
+												{ ...accessors }
+												fill={
+													withGradientFill
+														? `url(#area-gradient-${ chartId }-${ index + 1 })`
+														: 'transparent'
+												}
+												renderLine={ true }
+												curve={ getCurveType( curveType, smoothing ) }
+												lineProps={ lineProps }
+											/>
+
+											{ withStartGlyphs && (
+												<LineChartGlyph
+													index={ index }
+													data={ seriesData }
+													color={ color }
+													renderGlyph={ glyph ?? renderGlyph }
+													accessors={ accessors }
+													glyphStyle={ glyphStyle }
+													position="start"
+												/>
+											) }
+
+											{ withEndGlyphs && (
+												<LineChartGlyph
+													index={ index }
+													data={ seriesData }
+													color={ color }
+													renderGlyph={ glyph ?? renderGlyph }
+													accessors={ accessors }
+													glyphStyle={ glyphStyle }
+													position="end"
+												/>
+											) }
+										</g>
+									);
+								} ) }
+
+								{ withTooltips && (
+									<AccessibleTooltip
+										detectBounds
+										snapTooltipToDatumX
+										snapTooltipToDatumY
+										showSeriesGlyphs
+										renderTooltip={ renderTooltip }
+										renderGlyph={ tooltipRenderGlyph }
+										glyphStyle={ glyphStyle }
+										showVerticalCrosshair={ withTooltipCrosshairs?.showVertical }
+										showHorizontalCrosshair={ withTooltipCrosshairs?.showHorizontal }
+										selectedIndex={ selectedIndex }
+										tooltipRef={ tooltipRef }
+										keyboardFocusedClassName={ styles[ 'line-chart__tooltip--keyboard-focused' ] }
+										series={ dataSorted }
+									/>
+								) }
+
+								{ /* Component to expose scale data via ref */ }
+								<LineChartScalesRef
+									chartRef={ internalChartRef }
+									width={ width }
+									height={ height }
+									margin={ margin }
+								/>
+							</XYChart>
+						</div>
 					</div>
 
-					{ showLegend && (
-						<Legend
-							orientation={ legendOrientation }
-							alignment={ legendAlignment }
-							position={ legendPosition }
-							maxWidth={ legendMaxWidth }
-							textOverflow={ legendTextOverflow }
-							legendItemClassName={ legendItemClassName }
-							className={ styles[ 'line-chart-legend' ] }
-							shape={ legendShape }
-							chartId={ chartId }
-							interactive={ legendInteractive }
-							ref={ legendRef }
-						/>
-					) }
+					{ legendPosition === 'bottom' && legendElement }
 
 					{ children }
-				</div>
+				</Stack>
 			</SingleChartContext.Provider>
 		);
 	}

--- a/projects/js-packages/charts/src/charts/line-chart/line-chart.tsx
+++ b/projects/js-packages/charts/src/charts/line-chart/line-chart.tsx
@@ -249,7 +249,7 @@ const LineChartInternal = forwardRef< SingleChartRef, LineChartProps >(
 			data,
 			chartId: providedChartId,
 			width,
-			height = 400,
+			height,
 			className,
 			margin,
 			withTooltips = true,
@@ -293,10 +293,10 @@ const LineChartInternal = forwardRef< SingleChartRef, LineChartProps >(
 		const [ isNavigating, setIsNavigating ] = useState( false );
 		const internalChartRef = useRef< SingleChartRef >( null );
 
-		// Use the measured SVG wrapper height, falling back to the passed height initially.
+		// Use the measured SVG wrapper height, falling back to the passed height if provided.
 		// We only render the chart once we have a valid height to prevent layout shift/flicker.
 		const chartHeight = svgWrapperHeight > 0 ? svgWrapperHeight : height;
-		const isWaitingForMeasurement = chartHeight === 0;
+		const isWaitingForMeasurement = ! chartHeight;
 
 		// Forward the external ref to the internal ref
 		useImperativeHandle(

--- a/projects/js-packages/charts/src/charts/line-chart/stories/config.tsx
+++ b/projects/js-packages/charts/src/charts/line-chart/stories/config.tsx
@@ -59,6 +59,11 @@ export const lineChartMetaArgs: Meta< StoryArgs > = {
 		...themeArgTypes,
 		...sharedChartArgTypes,
 		...lineChartTooltipArgTypes,
+		data: {
+			control: { type: 'object' },
+			description: 'Array of series data to display in the chart',
+			table: { category: 'Data' },
+		},
 	},
 };
 

--- a/projects/js-packages/charts/src/charts/line-chart/stories/config.tsx
+++ b/projects/js-packages/charts/src/charts/line-chart/stories/config.tsx
@@ -69,8 +69,8 @@ export const lineChartStoryArgs = {
 	withLegendGlyph: false,
 	smoothing: true,
 	maxWidth: 1200,
-	aspectRatio: 0.5,
 	resizeDebounceTime: 300,
+	containerHeight: '400px',
 	options: {
 		axis: {
 			x: {

--- a/projects/js-packages/charts/src/charts/line-chart/stories/config.tsx
+++ b/projects/js-packages/charts/src/charts/line-chart/stories/config.tsx
@@ -75,7 +75,6 @@ export const lineChartStoryArgs = {
 	smoothing: true,
 	maxWidth: 1200,
 	resizeDebounceTime: 300,
-	containerHeight: '400px',
 	options: {
 		axis: {
 			x: {

--- a/projects/js-packages/charts/src/charts/line-chart/stories/glyph.stories.tsx
+++ b/projects/js-packages/charts/src/charts/line-chart/stories/glyph.stories.tsx
@@ -26,7 +26,8 @@ const GLYPH_THEME_MAP = {
 
 // Custom decorator for glyph stories that includes the glyph theme
 const glyphChartDecorator: Decorator = ( Story, { args } ) => {
-	const themeName = ( args as unknown as StoryArgs ).themeName;
+	const storyArgs = args as unknown as StoryArgs;
+	const themeName = storyArgs.themeName;
 	const theme = GLYPH_THEME_MAP[ themeName || 'default' ];
 
 	return (
@@ -37,6 +38,7 @@ const glyphChartDecorator: Decorator = ( Story, { args } ) => {
 					overflow: 'auto',
 					padding: '2rem',
 					width: '800px',
+					height: storyArgs.containerHeight || '400px',
 					maxWidth: '1200px',
 					border: '1px dashed #ccc',
 					display: 'inline-block',

--- a/projects/js-packages/charts/src/charts/line-chart/stories/index.docs.mdx
+++ b/projects/js-packages/charts/src/charts/line-chart/stories/index.docs.mdx
@@ -546,22 +546,25 @@ Customize axes with formatting, orientation, and tick options:
 
 ### Responsive Behavior
 
-Charts automatically resize based on container size:
-
-<Canvas of={ LineChartStories.FixedDimensions } />
+By default, charts **fill their parent container's dimensions**. The parent must have an explicit height:
 
 <Source
 	language="jsx"
-	code={ `// Responsive (default)
-	<LineChart data={data} />
+	code={ `// Fill parent container (default) - parent needs explicit height
+	<div style={{ width: '100%', height: '400px' }}>
+		<LineChart data={data} />
+	</div>
+
+	// Use aspect ratio - height calculated from width
+	<div style={{ width: '100%' }}>
+		<LineChart data={data} aspectRatio={0.5} />
+	</div>
 
 	// Fixed dimensions
-	<LineChart
-		data={data}
-		width={800}
-		height={400}
-	/>` }
+	<LineChart data={data} width={800} height={400} />` }
 />
+
+For more details on responsive behavior, see the [Responsive Design section](./?path=/docs/js-packages-charts-library-introduction--docs#responsive-design) in the introduction.
 
 ### Custom Margins
 

--- a/projects/js-packages/charts/src/charts/line-chart/stories/index.docs.mdx
+++ b/projects/js-packages/charts/src/charts/line-chart/stories/index.docs.mdx
@@ -70,6 +70,9 @@ The simplest line chart requires only a `data` prop with time-series data:
 - **`margin`**: Custom chart margins
 - **`className`**: Additional CSS class name for the chart container
 - **`chartId`**: Unique identifier for the chart (auto-generated if not provided)
+- **`aspectRatio`**: Height as a fraction of width (e.g., `0.5` = 50% height). When omitted, fills parent container height
+- **`maxWidth`**: Maximum width constraint for responsive charts (default: `1200`)
+- **`resizeDebounceTime`**: Debounce delay for resize events in ms (default: `300`)
 
 **Visual Styling:**
 - **`curveType`**: Line curve style (`'smooth'`, `'linear'`, `'monotone'`)

--- a/projects/js-packages/charts/src/charts/line-chart/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/charts/line-chart/stories/index.stories.tsx
@@ -177,21 +177,19 @@ CustomLegendPositioning.parameters = {
 // Story showing use with LineChart using composition API
 export const WithCompositionLegend: StoryObj< typeof LineChart > = {
 	render: args => (
-		<div style={ { height: '400px' } }>
-			<LineChart
-				data={ args.data || webTrafficData }
-				withGradientFill={ false }
-				withLegendGlyph={ false }
-			>
-				<LineChart.Legend
-					orientation={ args.legendOrientation || 'horizontal' }
-					alignment={ args.legendAlignment || 'center' }
-					position={ args.legendPosition || 'bottom' }
-					maxWidth={ args.legendMaxWidth }
-					textOverflow={ args.legendTextOverflow || 'wrap' }
-				/>
-			</LineChart>
-		</div>
+		<LineChart
+			data={ args.data || webTrafficData }
+			withGradientFill={ false }
+			withLegendGlyph={ false }
+		>
+			<LineChart.Legend
+				orientation={ args.legendOrientation || 'horizontal' }
+				alignment={ args.legendAlignment || 'center' }
+				position={ args.legendPosition || 'bottom' }
+				maxWidth={ args.legendMaxWidth }
+				textOverflow={ args.legendTextOverflow || 'wrap' }
+			/>
+		</LineChart>
 	),
 	argTypes: {
 		legendInteractive: {

--- a/projects/js-packages/charts/src/charts/line-chart/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/charts/line-chart/stories/index.stories.tsx
@@ -108,6 +108,7 @@ Default.args = {
 // Story with single data series
 export const SingleSeries: StoryObj< typeof LineChart > = Template.bind( {} );
 SingleSeries.args = {
+	...lineChartStoryArgs,
 	data: [ sampleData[ 0 ] ], // Only London temperature data
 };
 
@@ -145,7 +146,6 @@ export const CustomLegendPositioning: StoryObj< typeof LineChart > = Template.bi
 CustomLegendPositioning.args = {
 	...lineChartStoryArgs,
 	showLegend: true,
-	height: 400,
 	legendAlignment: 'start',
 	legendPosition: 'top',
 	legendOrientation: 'horizontal',
@@ -164,11 +164,9 @@ CustomLegendPositioning.parameters = {
 // Story showing use with LineChart using composition API
 export const WithCompositionLegend: StoryObj< typeof LineChart > = {
 	render: args => (
-		<div style={ { width: '600px', height: '400px' } }>
+		<div style={ { height: '400px' } }>
 			<LineChart
 				data={ args.data || webTrafficData }
-				width={ 600 }
-				height={ 300 }
 				withGradientFill={ false }
 				withLegendGlyph={ false }
 			>
@@ -196,27 +194,30 @@ export const WithCompositionLegend: StoryObj< typeof LineChart > = {
 	},
 };
 
-// Story with custom dimensions
-export const CustomDimensions: StoryObj< typeof LineChart > = Template.bind( {} );
-CustomDimensions.args = {
-	...lineChartStoryArgs,
-	width: 800,
-	height: 400,
-};
-
-// Add after existing stories
 export const FixedDimensions: StoryObj< typeof LineChart > = Template.bind( {} );
 FixedDimensions.args = {
 	...lineChartStoryArgs,
-	width: 800,
-	height: 400,
-	withTooltips: true,
+	width: 600,
+	height: 300,
 };
 
 FixedDimensions.parameters = {
 	docs: {
 		description: {
 			story: 'Line chart with fixed dimensions that override the responsive behavior.',
+		},
+	},
+};
+
+export const AspectRatio: StoryObj< typeof LineChart > = Template.bind( {} );
+AspectRatio.args = {
+	...lineChartStoryArgs,
+	aspectRatio: 0.3,
+};
+AspectRatio.parameters = {
+	docs: {
+		description: {
+			story: 'Line chart with an aspect ratio that overrides the responsive behavior.',
 		},
 	},
 };
@@ -471,6 +472,7 @@ export const CurveTypes: StoryObj< typeof LineChart > = {
 // Story demonstrating Smart Formatting (formatYTick) with large values
 export const SmartFormatting: StoryObj< typeof LineChart > = Template.bind( {} );
 SmartFormatting.args = {
+	...lineChartStoryArgs,
 	data: largeValuesData,
 	withGradientFill: false,
 	smoothing: true,
@@ -527,46 +529,43 @@ BrokenLine.parameters = {
 	},
 };
 
-export const DateStringFormats: StoryObj< typeof LineChart > = {
-	render: () => {
-		return (
-			<LineChart
-				data={ [
-					{
-						label: 'String Dates',
-						data: [
-							{ dateString: '2024-01-01', value: 10 },
-							{ dateString: '2024-01-02', value: 20 },
-							{ dateString: '2024-01-03 00:00:00', value: 15 },
-							{ dateString: '2024-01-04', value: 25 },
-							{ dateString: '2024-01-05 00:00', value: 30 },
-						],
-						options: {},
-					},
-				] }
-				withGradientFill={ false }
-				withLegendGlyph={ false }
-			/>
-		);
-	},
-	parameters: {
-		docs: {
-			description: {
-				story:
-					"Demonstrates the line chart's ability to handle various date string formats and mixed date types. All dates are converted to local timezone. The chart can process:\n" +
-					'- Simple date strings (YYYY-MM-DD)\n' +
-					'- Date with time (YYYY-MM-DD 00:00:00)\n' +
-					'- Date with time (YYYY-MM-DD 00:00)\n' +
-					'- ISO format (YYYY-MM-DDT00:00:00)\n' +
-					'- UTC format (YYYY-MM-DDT00:00:00Z)\n' +
-					'- Timezone offset (YYYY-MM-DDT00:00:00±HH:mm)\n',
-			},
+export const DateStringFormats: StoryObj< typeof LineChart > = Template.bind( {} );
+DateStringFormats.args = {
+	...lineChartStoryArgs,
+	withGradientFill: false,
+	withLegendGlyph: false,
+	data: [
+		{
+			label: 'String Dates',
+			data: [
+				{ dateString: '2024-01-01', value: 10 },
+				{ dateString: '2024-01-02', value: 20 },
+				{ dateString: '2024-01-03 00:00:00', value: 15 },
+				{ dateString: '2024-01-04', value: 25 },
+				{ dateString: '2024-01-05 00:00', value: 30 },
+			],
+			options: {},
+		},
+	],
+};
+DateStringFormats.parameters = {
+	docs: {
+		description: {
+			story:
+				"Demonstrates the line chart's ability to handle various date string formats and mixed date types. All dates are converted to local timezone. The chart can process:\n" +
+				'- Simple date strings (YYYY-MM-DD)\n' +
+				'- Date with time (YYYY-MM-DD 00:00:00)\n' +
+				'- Date with time (YYYY-MM-DD 00:00)\n' +
+				'- ISO format (YYYY-MM-DDT00:00:00)\n' +
+				'- UTC format (YYYY-MM-DDT00:00:00Z)\n' +
+				'- Timezone offset (YYYY-MM-DDT00:00:00±HH:mm)\n',
 		},
 	},
 };
 
 export const Comparison: StoryObj< typeof LineChart > = Template.bind( {} );
 Comparison.args = {
+	...lineChartStoryArgs,
 	showLegend: true,
 	smoothing: false,
 	data: [

--- a/projects/js-packages/charts/src/charts/line-chart/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/charts/line-chart/stories/index.stories.tsx
@@ -105,6 +105,19 @@ Default.args = {
 	...lineChartStoryArgs,
 };
 
+export const FixedDimensions: StoryObj< typeof LineChart > = Template.bind( {} );
+FixedDimensions.args = {
+	...lineChartStoryArgs,
+	width: 600,
+	height: 300,
+};
+
+export const AspectRatio: StoryObj< typeof LineChart > = Template.bind( {} );
+AspectRatio.args = {
+	...lineChartStoryArgs,
+	aspectRatio: 0.3,
+};
+
 // Story with single data series
 export const SingleSeries: StoryObj< typeof LineChart > = Template.bind( {} );
 SingleSeries.args = {
@@ -190,34 +203,6 @@ export const WithCompositionLegend: StoryObj< typeof LineChart > = {
 			description: {
 				story: 'Legend used with LineChart using the composition API, positioned below the chart.',
 			},
-		},
-	},
-};
-
-export const FixedDimensions: StoryObj< typeof LineChart > = Template.bind( {} );
-FixedDimensions.args = {
-	...lineChartStoryArgs,
-	width: 600,
-	height: 300,
-};
-
-FixedDimensions.parameters = {
-	docs: {
-		description: {
-			story: 'Line chart with fixed dimensions that override the responsive behavior.',
-		},
-	},
-};
-
-export const AspectRatio: StoryObj< typeof LineChart > = Template.bind( {} );
-AspectRatio.args = {
-	...lineChartStoryArgs,
-	aspectRatio: 0.3,
-};
-AspectRatio.parameters = {
-	docs: {
-		description: {
-			story: 'Line chart with an aspect ratio that overrides the responsive behavior.',
 		},
 	},
 };

--- a/projects/js-packages/charts/src/charts/line-chart/test/line-chart.test.tsx
+++ b/projects/js-packages/charts/src/charts/line-chart/test/line-chart.test.tsx
@@ -8,6 +8,12 @@ import { GlobalChartsProvider, defaultTheme } from '../../../providers';
 import LineChart, { LineChartUnresponsive } from '../line-chart';
 import type { SingleChartRef } from '../../private/single-chart-context';
 
+// Mock useElementHeight to return a non-zero height in jsdom so charts render
+const mockRefCallback = jest.fn();
+jest.mock( '../../../hooks/use-element-height', () => ( {
+	useElementHeight: () => [ mockRefCallback, 300 ], // Return test height to allow chart rendering
+} ) );
+
 const customTheme = {
 	...defaultTheme,
 	glyphs: [

--- a/projects/js-packages/charts/src/charts/line-chart/types.ts
+++ b/projects/js-packages/charts/src/charts/line-chart/types.ts
@@ -7,6 +7,7 @@ import type {
 } from '../../types';
 import type { GlyphProps } from '@visx/xychart';
 import type { RenderTooltipParams } from '@visx/xychart/lib/components/Tooltip';
+import type { GapSize } from '@wordpress/theme';
 import type { ReactNode, SVGProps, FC } from 'react';
 
 export type LineChartAnnotationProps = {
@@ -43,6 +44,12 @@ export interface LineChartProps extends BaseChartProps< SeriesData[] > {
 	};
 	legendInteractive?: boolean;
 	children?: ReactNode;
+	/**
+	 * Gap between chart elements (SVG, legend, children).
+	 * Uses WordPress design system tokens.
+	 * @default 'md'
+	 */
+	gap?: GapSize;
 }
 
 export type TooltipDatum = {

--- a/projects/js-packages/charts/src/charts/pie-chart/stories/donut.stories.tsx
+++ b/projects/js-packages/charts/src/charts/pie-chart/stories/donut.stories.tsx
@@ -355,6 +355,7 @@ export const CustomLegendPositioning: Story = {
 		legendOrientation: 'vertical',
 		legendAlignment: 'start',
 		legendPosition: 'top',
+		containerHeight: '450px',
 		data: [
 			{
 				label: 'Desktop',

--- a/projects/js-packages/charts/src/charts/pie-chart/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/charts/pie-chart/stories/index.stories.tsx
@@ -325,66 +325,64 @@ export const CompositionAPI: Story = {
 		];
 
 		return (
-			<div style={ { width: '600px', padding: '20px' } }>
-				<PieChartUnresponsive
-					data={ chartData }
-					size={ 400 }
-					withTooltips={ true }
-					thickness={ 0.7 }
-					legendValueDisplay={ args.legendValueDisplay || 'value' }
-				>
-					<PieChartUnresponsive.HTML>
-						<h3 style={ { textAlign: 'center', marginBottom: '20px' } }>
-							Device Usage Distribution
-						</h3>
-					</PieChartUnresponsive.HTML>
+			<PieChartUnresponsive
+				data={ chartData }
+				size={ 400 }
+				withTooltips={ true }
+				thickness={ 0.7 }
+				legendValueDisplay={ args.legendValueDisplay || 'value' }
+			>
+				<PieChartUnresponsive.HTML>
+					<h3 style={ { textAlign: 'center', marginBottom: '20px' } }>Device Usage Distribution</h3>
+				</PieChartUnresponsive.HTML>
 
-					<PieChartUnresponsive.SVG>
-						<text
-							x={ 0 }
-							y={ 0 }
-							textAnchor="middle"
-							style={ { fontSize: '24px', fontWeight: 'bold' } }
-						>
-							100%
-						</text>
-						<text x={ 0 } y={ 20 } textAnchor="middle" style={ { fontSize: '14px', fill: '#666' } }>
-							Total Users
-						</text>
-					</PieChartUnresponsive.SVG>
+				<PieChartUnresponsive.SVG>
+					<text
+						x={ 0 }
+						y={ 0 }
+						textAnchor="middle"
+						style={ { fontSize: '24px', fontWeight: 'bold' } }
+					>
+						100%
+					</text>
+					<text x={ 0 } y={ 20 } textAnchor="middle" style={ { fontSize: '14px', fill: '#666' } }>
+						Total Users
+					</text>
+				</PieChartUnresponsive.SVG>
 
-					<PieChartUnresponsive.HTML>
-						<PieChartUnresponsive.Legend
-							position="bottom"
-							orientation="horizontal"
-							alignment="center"
-						/>
-						<div
-							style={ {
-								marginTop: '20px',
-								padding: '10px',
-								backgroundColor: '#f5f5f5',
-								borderRadius: '4px',
-								fontSize: '14px',
-								color: '#666',
-							} }
-						>
-							<p style={ { margin: 0 } }>
-								This example demonstrates the composition API where you can add:
-							</p>
-							<ul style={ { margin: '5px 0 0 20px', padding: 0 } }>
-								<li>SVG elements inside the chart using PieChart.SVG</li>
-								<li>HTML elements outside the chart using PieChart.HTML</li>
-								<li>Mix regular children with compound components</li>
-							</ul>
-						</div>
-					</PieChartUnresponsive.HTML>
-				</PieChartUnresponsive>
-			</div>
+				<PieChartUnresponsive.HTML>
+					<PieChartUnresponsive.Legend
+						position="bottom"
+						orientation="horizontal"
+						alignment="center"
+					/>
+					<div
+						style={ {
+							marginTop: '20px',
+							padding: '10px',
+							backgroundColor: '#f5f5f5',
+							borderRadius: '4px',
+							fontSize: '14px',
+							color: '#666',
+						} }
+					>
+						<p style={ { margin: 0 } }>
+							This example demonstrates the composition API where you can add:
+						</p>
+						<ul style={ { margin: '5px 0 0 20px', padding: 0 } }>
+							<li>SVG elements inside the chart using PieChart.SVG</li>
+							<li>HTML elements outside the chart using PieChart.HTML</li>
+							<li>Mix regular children with compound components</li>
+						</ul>
+					</div>
+				</PieChartUnresponsive.HTML>
+			</PieChartUnresponsive>
 		);
 	},
 	args: {
 		data,
+		containerHeight: '700px',
+		containerWidth: '600px',
 	},
 	argTypes: {
 		legendInteractive: {

--- a/projects/js-packages/charts/src/charts/pie-semi-circle-chart/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/charts/pie-semi-circle-chart/stories/index.stories.tsx
@@ -52,7 +52,6 @@ export const Default: Story = {
 	args: {
 		...sharedThemeArgs,
 		containerWidth: '600px',
-		containerHeight: '325px',
 		resize: 'none',
 		thickness: 0.4,
 		data,
@@ -136,6 +135,7 @@ export const WithCompositionLegend: Story = {
 	),
 	args: {
 		data,
+		containerWidth: '900px',
 	},
 	argTypes: {
 		legendInteractive: {
@@ -178,7 +178,6 @@ export const InteractiveLegend: Story = {
 	args: {
 		data,
 		width: 400,
-		containerHeight: '500px',
 	},
 	parameters: {
 		docs: {
@@ -288,6 +287,9 @@ export const ErrorStates: Story = {
 			</div>
 		</div>
 	),
+	args: {
+		containerHeight: '600px',
+	},
 	parameters: {
 		docs: {
 			description: {
@@ -425,6 +427,8 @@ export const CompositionAPI: Story = {
 	),
 	args: {
 		data,
+		containerHeight: '1000px',
+		containerWidth: '1000px',
 	},
 	argTypes: {
 		legendInteractive: {

--- a/projects/js-packages/charts/src/charts/private/with-responsive/test/with-responsive.test.tsx
+++ b/projects/js-packages/charts/src/charts/private/with-responsive/test/with-responsive.test.tsx
@@ -12,46 +12,78 @@ jest.mock( '@visx/responsive', () => ( {
 } ) );
 
 describe( 'withResponsive', () => {
-	const MockComponent = ( { width = 0, height = 0 }: BaseChartProps ) => (
+	const MockComponent = ( { width = 0, height = 0, size = 0 }: BaseChartProps ) => (
 		<div data-testid="responsive-container">
-			<div data-testid="mock-component" style={ { width, height } } />
+			<div data-testid="mock-component" style={ { width, height } } data-size={ size } />
 		</div>
 	);
 
 	const ResponsiveComponent = withResponsive( MockComponent );
 
-	test( 'renders with default dimensions when no parent size', () => {
-		render( <ResponsiveComponent data={ [] } /> );
-		const component = screen.getByTestId( 'mock-component' );
-		expect( component ).toHaveStyle( { width: '600px' } );
+	describe( 'component dimensions', () => {
+		test( 'passes measured parent width to component', () => {
+			render( <ResponsiveComponent data={ [] } /> );
+			const component = screen.getByTestId( 'mock-component' );
+			expect( component ).toHaveStyle( { width: '600px' } );
+		} );
+
+		test( 'passes measured parent height to component when no aspectRatio', () => {
+			render( <ResponsiveComponent data={ [] } /> );
+			const component = screen.getByTestId( 'mock-component' );
+			// Without aspectRatio, height comes from parent (300px in mock)
+			expect( component ).toHaveStyle( { height: '300px' } );
+		} );
+
+		test( 'calculates height from aspectRatio when provided', () => {
+			render( <ResponsiveComponent data={ [] } aspectRatio={ 0.75 } /> );
+			const component = screen.getByTestId( 'mock-component' );
+			// With aspectRatio, height = width * aspectRatio = 600 * 0.75 = 450
+			expect( component ).toHaveStyle( { height: '450px' } );
+		} );
+
+		test( 'respects maxWidth configuration', () => {
+			render( <ResponsiveComponent data={ [] } maxWidth={ 400 } /> );
+			const component = screen.getByTestId( 'mock-component' );
+			expect( component ).toHaveStyle( { width: '400px' } );
+		} );
+
+		test( 'passes size prop equal to container width', () => {
+			render( <ResponsiveComponent data={ [] } /> );
+			const component = screen.getByTestId( 'mock-component' );
+			expect( component ).toHaveAttribute( 'data-size', '600' );
+		} );
 	} );
 
-	test( 'respects maxWidth configuration', () => {
-		const ResponsiveWithConfig = withResponsive( MockComponent );
-		render( <ResponsiveWithConfig data={ [] } maxWidth={ 400 } /> );
-		const component = screen.getByTestId( 'mock-component' );
-		expect( component ).toHaveStyle( { width: '400px' } );
+	describe( 'wrapper dimensions', () => {
+		test( 'wrapper defaults to 100% width and height when no props', () => {
+			render( <ResponsiveComponent data={ [] } /> );
+			const wrapper = screen.getByTestId( 'responsive-wrapper' );
+			expect( wrapper ).toHaveStyle( { width: '100%', height: '100%' } );
+		} );
+
+		test( 'wrapper uses size prop for dimensions when provided', () => {
+			render( <ResponsiveComponent data={ [] } size={ 200 } /> );
+			const wrapper = screen.getByTestId( 'responsive-wrapper' );
+			expect( wrapper ).toHaveStyle( { width: '200px', height: '200px' } );
+		} );
+
+		test( 'wrapper uses auto height with aspectRatio', () => {
+			render( <ResponsiveComponent data={ [] } aspectRatio={ 0.5 } /> );
+			const wrapper = screen.getByTestId( 'responsive-wrapper' );
+			expect( wrapper ).toHaveStyle( { width: '100%', height: 'auto' } );
+		} );
 	} );
 
-	test( 'applies custom aspect ratio', () => {
-		const ResponsiveWithConfig = withResponsive( MockComponent );
-		render( <ResponsiveWithConfig data={ [] } aspectRatio={ 0.75 } /> );
-		const component = screen.getByTestId( 'mock-component' );
-		const styles = window.getComputedStyle( component );
-		const height = parseFloat( styles.height );
-		const width = parseFloat( styles.width );
-		expect( height ).toBe( width * 0.75 );
-	} );
+	describe( 'configuration', () => {
+		test( 'applies custom debounce time without errors', () => {
+			render( <ResponsiveComponent data={ [] } resizeDebounceTime={ 100 } /> );
+			const component = screen.getByTestId( 'mock-component' );
+			expect( component ).toBeInTheDocument();
+		} );
 
-	test( 'applies custom debounce time', () => {
-		const ResponsiveWithConfig = withResponsive( MockComponent );
-		render( <ResponsiveWithConfig data={ [] } resizeDebounceTime={ 100 } /> );
-		const component = screen.getByTestId( 'mock-component' );
-		expect( component ).toBeInTheDocument();
-	} );
-
-	test( 'renders container element', () => {
-		render( <ResponsiveComponent data={ [] } /> );
-		expect( screen.getByTestId( 'responsive-container' ) ).toBeInTheDocument();
+		test( 'renders wrapped component container', () => {
+			render( <ResponsiveComponent data={ [] } /> );
+			expect( screen.getByTestId( 'responsive-container' ) ).toBeInTheDocument();
+		} );
 	} );
 } );

--- a/projects/js-packages/charts/src/charts/private/with-responsive/with-responsive.tsx
+++ b/projects/js-packages/charts/src/charts/private/with-responsive/with-responsive.tsx
@@ -90,13 +90,15 @@ export function withResponsive< T extends Exclude< BaseChartProps< unknown >, 'o
 		const effectiveWidth = measuredWidth || size || width || 0;
 		const effectiveHeight = measuredHeight || size || height || 0;
 
+		const defaultHeight = hasAspectRatio ? 'auto' : '100%';
+
 		return (
 			<div
 				ref={ parentRef }
 				data-testid="responsive-wrapper"
 				style={ {
 					width: size ?? width ?? '100%',
-					height: hasAspectRatio ? size ?? height ?? 'auto' : size ?? height ?? '100%',
+					height: size ?? height ?? defaultHeight,
 				} }
 			>
 				<WrappedComponent

--- a/projects/js-packages/charts/src/charts/private/with-responsive/with-responsive.tsx
+++ b/projects/js-packages/charts/src/charts/private/with-responsive/with-responsive.tsx
@@ -46,6 +46,11 @@ const useResponsiveDimensions = ( {
 		parentRef,
 		width: containerWidth,
 		height: containerHeight,
+		/**
+		 * Whether an aspectRatio was provided. Used to determine container
+		 * height styling: 'auto' when true (height derived from width),
+		 * '100%' when false (fill parent container).
+		 */
 		hasAspectRatio: aspectRatio !== undefined,
 	};
 };

--- a/projects/js-packages/charts/src/charts/private/with-responsive/with-responsive.tsx
+++ b/projects/js-packages/charts/src/charts/private/with-responsive/with-responsive.tsx
@@ -1,6 +1,12 @@
 import { useParentSize } from '@visx/responsive';
-import type { BaseChartProps, Optional } from '../../../types';
+import type { BaseChartProps } from '../../../types';
 import type { ComponentType } from 'react';
+
+type DimensionProps = {
+	width?: number;
+	height?: number;
+	size?: number;
+};
 
 export type ResponsiveConfig = {
 	/**
@@ -58,12 +64,15 @@ export function withResponsive< T extends Exclude< BaseChartProps< unknown >, 'o
 		resizeDebounceTime = 300,
 		maxWidth = 1200,
 		aspectRatio,
+		size,
+		width,
+		height,
 		...chartProps
-	}: Optional< T, 'width' | 'height' | 'size' > & ResponsiveConfig ) {
+	}: Omit< T, 'width' | 'height' | 'size' > & DimensionProps & ResponsiveConfig ) {
 		const {
 			parentRef,
-			width: containerWidth,
-			height: containerHeight,
+			width: measuredWidth,
+			height: measuredHeight,
 			hasAspectRatio,
 		} = useResponsiveDimensions( {
 			resizeDebounceTime,
@@ -76,16 +85,14 @@ export function withResponsive< T extends Exclude< BaseChartProps< unknown >, 'o
 				ref={ parentRef }
 				data-testid="responsive-wrapper"
 				style={ {
-					width: chartProps.size ?? chartProps.width ?? '100%',
-					height: hasAspectRatio
-						? chartProps.size ?? chartProps.height ?? 'auto'
-						: chartProps.size ?? chartProps.height ?? '100%',
+					width: size ?? width ?? '100%',
+					height: hasAspectRatio ? size ?? height ?? 'auto' : size ?? height ?? '100%',
 				} }
 			>
 				<WrappedComponent
-					width={ containerWidth }
-					height={ containerHeight }
-					size={ containerWidth }
+					width={ measuredWidth }
+					height={ measuredHeight }
+					size={ measuredWidth }
 					{ ...( chartProps as T ) }
 				/>
 			</div>

--- a/projects/js-packages/charts/src/charts/private/with-responsive/with-responsive.tsx
+++ b/projects/js-packages/charts/src/charts/private/with-responsive/with-responsive.tsx
@@ -85,6 +85,11 @@ export function withResponsive< T extends Exclude< BaseChartProps< unknown >, 'o
 			aspectRatio,
 		} );
 
+		// Use measured dimensions, but fall back to explicit props if measurement returns 0
+		// (e.g., during initial render or in test environments without DOM measurement)
+		const effectiveWidth = measuredWidth || size || width || 0;
+		const effectiveHeight = measuredHeight || size || height || 0;
+
 		return (
 			<div
 				ref={ parentRef }
@@ -95,9 +100,9 @@ export function withResponsive< T extends Exclude< BaseChartProps< unknown >, 'o
 				} }
 			>
 				<WrappedComponent
-					width={ measuredWidth }
-					height={ measuredHeight }
-					size={ measuredWidth }
+					width={ effectiveWidth }
+					height={ effectiveHeight }
+					size={ effectiveWidth }
 					{ ...( chartProps as T ) }
 				/>
 			</div>

--- a/projects/js-packages/charts/src/charts/private/with-responsive/with-responsive.tsx
+++ b/projects/js-packages/charts/src/charts/private/with-responsive/with-responsive.tsx
@@ -8,7 +8,9 @@ export type ResponsiveConfig = {
 	 */
 	maxWidth?: number;
 	/**
-	 * The aspect ratio of the chart.
+	 * The aspect ratio of the chart (height = width * aspectRatio).
+	 * When provided, height is calculated from width.
+	 * When omitted, the chart fills the parent container's height.
 	 */
 	aspectRatio?: number;
 	/**
@@ -20,17 +22,26 @@ export type ResponsiveConfig = {
 const useResponsiveDimensions = ( {
 	resizeDebounceTime = 300,
 	maxWidth = 1200,
-	aspectRatio = 0.5,
+	aspectRatio,
 }: ResponsiveConfig ) => {
-	const { parentRef, width: parentWidth } = useParentSize( {
+	const {
+		parentRef,
+		width: parentWidth,
+		height: parentHeight,
+	} = useParentSize( {
 		debounceTime: resizeDebounceTime,
 		enableDebounceLeadingCall: true,
 	} );
 
 	const containerWidth = parentWidth > 0 ? Math.min( parentWidth, maxWidth ) : 0;
-	const containerHeight = containerWidth * aspectRatio;
+	const containerHeight = aspectRatio !== undefined ? containerWidth * aspectRatio : parentHeight;
 
-	return { parentRef, width: containerWidth, height: containerHeight };
+	return {
+		parentRef,
+		width: containerWidth,
+		height: containerHeight,
+		hasAspectRatio: aspectRatio !== undefined,
+	};
 };
 
 /**
@@ -46,13 +57,14 @@ export function withResponsive< T extends Exclude< BaseChartProps< unknown >, 'o
 	return function ResponsiveChart( {
 		resizeDebounceTime = 300,
 		maxWidth = 1200,
-		aspectRatio = 0.5,
+		aspectRatio,
 		...chartProps
 	}: Optional< T, 'width' | 'height' | 'size' > & ResponsiveConfig ) {
 		const {
 			parentRef,
 			width: containerWidth,
 			height: containerHeight,
+			hasAspectRatio,
 		} = useResponsiveDimensions( {
 			resizeDebounceTime,
 			maxWidth,
@@ -64,7 +76,9 @@ export function withResponsive< T extends Exclude< BaseChartProps< unknown >, 'o
 				ref={ parentRef }
 				style={ {
 					width: chartProps.size ?? chartProps.width ?? '100%',
-					height: chartProps.size ?? chartProps.height ?? 'auto',
+					height: hasAspectRatio
+						? chartProps.size ?? chartProps.height ?? 'auto'
+						: chartProps.size ?? chartProps.height ?? '100%',
 				} }
 			>
 				<WrappedComponent

--- a/projects/js-packages/charts/src/charts/private/with-responsive/with-responsive.tsx
+++ b/projects/js-packages/charts/src/charts/private/with-responsive/with-responsive.tsx
@@ -74,6 +74,7 @@ export function withResponsive< T extends Exclude< BaseChartProps< unknown >, 'o
 		return (
 			<div
 				ref={ parentRef }
+				data-testid="responsive-wrapper"
 				style={ {
 					width: chartProps.size ?? chartProps.width ?? '100%',
 					height: hasAspectRatio

--- a/projects/js-packages/charts/src/charts/sparkline/stories/index.api.mdx
+++ b/projects/js-packages/charts/src/charts/sparkline/stories/index.api.mdx
@@ -28,7 +28,7 @@ Main component for rendering minimal trend visualizations.
 | `chartId` | `string` | - | Custom chart identifier for unique gradient/element identification |
 | `margin` | `object` | `{2,2,2,2}` | Margin around the chart |
 | `animation` | `boolean` | `false` | Enable entry animation on initial render. Creates a rising effect where the line scales up from the bottom. Automatically respects user's `prefers-reduced-motion` system setting |
-| `aspectRatio` | `number` | `0.5` | Aspect ratio for responsive charts (responsive variant only) |
+| `aspectRatio` | `number` | - | Aspect ratio for responsive charts. When omitted, fills parent height (responsive variant only) |
 | `maxWidth` | `number` | `1200` | Maximum width for responsive charts (responsive variant only) |
 | `resizeDebounceTime` | `number` | `300` | Debounce time for resize events in ms (responsive variant only) |
 

--- a/projects/js-packages/charts/src/charts/sparkline/stories/index.api.mdx
+++ b/projects/js-packages/charts/src/charts/sparkline/stories/index.api.mdx
@@ -135,28 +135,27 @@ The component uses BEM-style CSS classes for styling:
 
 ## Responsive Behavior
 
-The default `Sparkline` export includes responsive sizing:
+The default `Sparkline` export includes responsive sizing. By default, it **fills its parent container's dimensions**:
 
 ```typescript
-// Responsive (default export)
-<Sparkline
-	data={data}
-	aspectRatio={0.3}
-	maxWidth={400}
-/>
+// Fill parent container (default) - parent needs explicit height
+<div style={{ width: '200px', height: '60px' }}>
+	<Sparkline data={data} />
+</div>
+
+// Use aspect ratio - height calculated from width
+<div style={{ width: '100%', maxWidth: '200px' }}>
+	<Sparkline data={data} aspectRatio={0.3} />
+</div>
 
 // Fixed size (named export)
-<SparklineUnresponsive
-	data={data}
-	width={120}
-	height={48}
-/>
+<SparklineUnresponsive data={data} width={120} height={48} />
 ```
 
 **Responsive Props:**
-- `aspectRatio`: Height as a fraction of width (e.g., 0.3 = 30% height)
-- `maxWidth`: Maximum width constraint
-- `resizeDebounceTime`: Debounce delay for window resize events
+- `aspectRatio`: Height as a fraction of width (e.g., 0.3 = 30% height). When omitted, fills parent height.
+- `maxWidth`: Maximum width constraint (default: 1200)
+- `resizeDebounceTime`: Debounce delay for resize events (default: 300ms)
 
 ## Edge Case Handling
 

--- a/projects/js-packages/charts/src/charts/sparkline/stories/index.docs.mdx
+++ b/projects/js-packages/charts/src/charts/sparkline/stories/index.docs.mdx
@@ -62,14 +62,20 @@ The simplest sparkline requires only a `data` prop with an array of numeric valu
 
 ### Optional Props
 
+**Layout & Dimensions:**
 - **`width`** (default: `100`): Width of the sparkline in pixels
 - **`height`** (default: `40`): Height of the sparkline in pixels
+- **`margin`** (default: `{2,2,2,2}`): Margin around the chart
+- **`aspectRatio`**: Height as a fraction of width. When omitted, fills parent container height
+- **`maxWidth`** (default: `1200`): Maximum width constraint for responsive charts
+- **`resizeDebounceTime`** (default: `300`): Debounce delay for resize events in ms
+
+**Visual Styling:**
 - **`color`**: Color for the line stroke (defaults to theme color)
 - **`strokeWidth`** (default: `1.5`): Line stroke width in pixels
 - **`withGradientFill`** (default: `true`): Whether to render gradient fill beneath the line
 - **`gradient`**: Custom gradient configuration (from, to, fromOpacity, toOpacity)
 - **`className`**: Additional CSS class name
-- **`margin`** (default: `{2,2,2,2}`): Margin around the chart
 
 For detailed prop information and type definitions, see the [Sparkline API Reference](./?path=/docs/js-packages-charts-library-charts-sparkline-api-reference--docs).
 

--- a/projects/js-packages/charts/src/charts/sparkline/stories/index.docs.mdx
+++ b/projects/js-packages/charts/src/charts/sparkline/stories/index.docs.mdx
@@ -145,20 +145,24 @@ Disable the gradient for a cleaner line-only appearance, or customize it:
 
 ### Responsive Sparkline
 
-The default `Sparkline` export includes responsive behavior. Wrap in a container and use `aspectRatio`:
+The default `Sparkline` export includes responsive behavior. By default, it **fills its parent container's dimensions**:
 
 <Canvas of={ SparklineStories.Responsive } />
 
 <Source
 	language="jsx"
-	code={ `<div style={{ width: '100%', maxWidth: '200px' }}>
-		<Sparkline
-			data={[10, 15, 12, 18, 22, 25]}
-			color="#9C27B0"
-			aspectRatio={0.3}
-		/>
-	</div>` }
+	code={ `// Fill parent container (default) - parent needs explicit height
+<div style={{ width: '200px', height: '60px' }}>
+	<Sparkline data={[10, 15, 12, 18, 22, 25]} color="#9C27B0" />
+</div>
+
+// Use aspect ratio - height calculated from width
+<div style={{ width: '100%', maxWidth: '200px' }}>
+	<Sparkline data={[10, 15, 12, 18, 22, 25]} color="#9C27B0" aspectRatio={0.3} />
+</div>` }
 />
+
+For more details on responsive behavior, see the [Responsive Design section](./?path=/docs/js-packages-charts-library-introduction--docs#responsive-design) in the introduction.
 
 ## Dashboard Integration
 

--- a/projects/js-packages/charts/src/charts/sparkline/stories/index.docs.mdx
+++ b/projects/js-packages/charts/src/charts/sparkline/stories/index.docs.mdx
@@ -158,14 +158,14 @@ The default `Sparkline` export includes responsive behavior. By default, it **fi
 <Source
 	language="jsx"
 	code={ `// Fill parent container (default) - parent needs explicit height
-<div style={{ width: '200px', height: '60px' }}>
-	<Sparkline data={[10, 15, 12, 18, 22, 25]} color="#9C27B0" />
-</div>
+	<div style={{ width: '200px', height: '60px' }}>
+		<Sparkline data={[10, 15, 12, 18, 22, 25]} color="#9C27B0" />
+	</div>
 
-// Use aspect ratio - height calculated from width
-<div style={{ width: '100%', maxWidth: '200px' }}>
-	<Sparkline data={[10, 15, 12, 18, 22, 25]} color="#9C27B0" aspectRatio={0.3} />
-</div>` }
+	// Use aspect ratio - height calculated from width
+	<div style={{ width: '100%', maxWidth: '200px' }}>
+		<Sparkline data={[10, 15, 12, 18, 22, 25]} color="#9C27B0" aspectRatio={0.3} />
+	</div>` }
 />
 
 For more details on responsive behavior, see the [Responsive Design section](./?path=/docs/js-packages-charts-library-introduction--docs#responsive-design) in the introduction.

--- a/projects/js-packages/charts/src/charts/sparkline/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/charts/sparkline/stories/index.stories.tsx
@@ -81,6 +81,7 @@ export const Default: Story = {
 		width: 120,
 		height: 48,
 		color: '#4CAF50',
+		containerHeight: 100,
 	},
 };
 
@@ -111,9 +112,8 @@ export const AspectRatio: Story = {
  */
 export const EmptyData: Story = {
 	args: {
+		...Default.args,
 		data: [],
-		width: 120,
-		height: 48,
 	},
 };
 
@@ -122,10 +122,9 @@ export const EmptyData: Story = {
  */
 export const SinglePoint: Story = {
 	args: {
+		...Default.args,
 		data: [ 42 ],
 		color: '#9C27B0',
-		width: 120,
-		height: 48,
 	},
 };
 
@@ -134,10 +133,9 @@ export const SinglePoint: Story = {
  */
 export const TwoPoints: Story = {
 	args: {
+		...Default.args,
 		data: [ 10, 20 ],
 		color: '#3F51B5',
-		width: 120,
-		height: 48,
 	},
 };
 
@@ -195,6 +193,9 @@ export const Dashboard: Story = {
 			</div>
 		);
 	},
+	args: {
+		containerHeight: 150,
+	},
 };
 
 /**
@@ -203,10 +204,7 @@ export const Dashboard: Story = {
  */
 export const Animation: Story = {
 	args: {
-		data: defaultData,
-		width: 120,
-		height: 48,
-		color: '#4CAF50',
+		...Default.args,
 		animation: true,
 	},
 };

--- a/projects/js-packages/charts/src/charts/sparkline/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/charts/sparkline/stories/index.stories.tsx
@@ -85,6 +85,28 @@ export const Default: Story = {
 };
 
 /**
+ * Responsive sparkline that fills the container.
+ * Drag the corner of the container to resize and see the sparkline adapt.
+ */
+export const Responsive: Story = {
+	args: {
+		data: Default.args?.data,
+		color: '#9C27B0',
+	},
+};
+
+/**
+ * Sparkline with an aspect ratio.
+ */
+export const AspectRatio: Story = {
+	args: {
+		data: Default.args?.data,
+		color: '#9C27B0',
+		aspectRatio: 0.3,
+	},
+};
+
+/**
  * Empty data renders an empty container gracefully.
  */
 export const EmptyData: Story = {
@@ -117,20 +139,6 @@ export const TwoPoints: Story = {
 		width: 120,
 		height: 48,
 	},
-};
-
-/**
- * Responsive sparkline that fills the container.
- * Drag the corner of the container to resize and see the sparkline adapt.
- */
-export const Responsive: Story = {
-	render: () => <Sparkline data={ [ 10, 15, 12, 18, 22, 25 ] } color="#9C27B0" />,
-};
-
-export const AspectRatio: Story = {
-	render: () => (
-		<Sparkline data={ [ 10, 15, 12, 18, 22, 25 ] } color="#9C27B0" aspectRatio={ 0.3 } />
-	),
 };
 
 /**

--- a/projects/js-packages/charts/src/charts/sparkline/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/charts/sparkline/stories/index.stories.tsx
@@ -120,24 +120,16 @@ export const TwoPoints: Story = {
 };
 
 /**
- * Responsive sparkline that adjusts to container width using aspectRatio.
+ * Responsive sparkline that fills the container.
  * Drag the corner of the container to resize and see the sparkline adapt.
  */
 export const Responsive: Story = {
+	render: () => <Sparkline data={ [ 10, 15, 12, 18, 22, 25 ] } color="#9C27B0" />,
+};
+
+export const AspectRatio: Story = {
 	render: () => (
-		<div
-			style={ {
-				width: '200px',
-				resize: 'horizontal',
-				overflow: 'auto',
-				padding: '8px',
-				border: '1px dashed #ccc',
-				minWidth: '80px',
-				maxWidth: '400px',
-			} }
-		>
-			<Sparkline data={ [ 10, 15, 12, 18, 22, 25 ] } color="#9C27B0" aspectRatio={ 0.3 } />
-		</div>
+		<Sparkline data={ [ 10, 15, 12, 18, 22, 25 ] } color="#9C27B0" aspectRatio={ 0.3 } />
 	),
 };
 

--- a/projects/js-packages/charts/src/hooks/index.ts
+++ b/projects/js-packages/charts/src/hooks/index.ts
@@ -4,6 +4,7 @@ export { useXYChartTheme } from './use-xychart-theme';
 export { useChartDataTransform } from './use-chart-data-transform';
 export { useChartMargin } from './use-chart-margin';
 export { useElementHeight } from './use-element-height';
+export { useHasLegendChild } from './use-has-legend-child';
 export { useTextTruncation } from './use-text-truncation';
 export { useZeroValueDisplay } from './use-zero-value-display';
 export { useInteractiveLegendData } from './use-interactive-legend-data';

--- a/projects/js-packages/charts/src/hooks/use-has-legend-child.ts
+++ b/projects/js-packages/charts/src/hooks/use-has-legend-child.ts
@@ -1,0 +1,22 @@
+import { Children, isValidElement, useMemo, type ReactNode } from 'react';
+import { Legend } from '../components/legend';
+
+/**
+ * Hook to detect if children contain a Legend component (composition pattern).
+ *
+ * @param {ReactNode} children - React children to search through
+ * @return {boolean}           Whether a Legend component is present in children
+ */
+export function useHasLegendChild( children: ReactNode ): boolean {
+	return useMemo( () => {
+		let found = false;
+
+		Children.forEach( children, child => {
+			if ( isValidElement( child ) && child.type === Legend ) {
+				found = true;
+			}
+		} );
+
+		return found;
+	}, [ children ] );
+}

--- a/projects/js-packages/charts/src/stories/chart-decorator.tsx
+++ b/projects/js-packages/charts/src/stories/chart-decorator.tsx
@@ -37,7 +37,7 @@ export const chartDecorator: Decorator = ( Story, context ) => {
 				overflow: 'auto',
 				padding: withPadding ? '1rem' : undefined,
 				width: args.containerWidth || '800px',
-				height: args.containerHeight,
+				height: args.containerHeight || '400px',
 				maxWidth: '1200px',
 				border: '1px dashed #ccc',
 				display: 'inline-block',

--- a/projects/js-packages/charts/src/stories/index.docs.mdx
+++ b/projects/js-packages/charts/src/stories/index.docs.mdx
@@ -106,7 +106,66 @@ Use the `GlobalChartsProvider` component to apply consistent styling across all 
 
 ### Responsive Design
 
-All charts automatically adapt to their container size using the `withResponsive` higher-order component.
+All charts automatically adapt to their container size using the `withResponsive` higher-order component. By default, charts **fill their parent container's dimensions** rather than calculating height from a fixed aspect ratio.
+
+#### Default Behavior (Fill Container)
+
+When you omit dimension props, the chart expands to fill its parent container:
+
+<Source
+	language="jsx"
+	code={`// Chart fills parent container's width and height
+	<div style={{ width: '100%', height: '400px' }}>
+		<LineChart data={data} />
+	</div>`}
+/>
+
+**Important**: The parent container must have an explicit height. Without a defined height, the chart cannot determine how tall to render.
+
+#### Aspect Ratio Mode
+
+For layouts where you want height calculated from width, pass the `aspectRatio` prop:
+
+<Source
+	language="jsx"
+	code={`// Height = width × aspectRatio (e.g., 2:1 ratio)
+	<div style={{ width: '100%' }}>
+		<LineChart data={data} aspectRatio={0.5} />
+	</div>`}
+/>
+
+This is useful for responsive layouts where the container width varies but you want consistent proportions.
+
+#### Fixed Dimensions
+
+For complete control, specify explicit `width` and `height` props:
+
+<Source
+	language="jsx"
+	code={`<LineChart data={data} width={800} height={400} />`}
+/>
+
+#### Responsive Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `width` | `number` | - | Fixed width in pixels (omit for responsive) |
+| `height` | `number` | - | Fixed height in pixels (omit for responsive) |
+| `aspectRatio` | `number` | - | Height as ratio of width (e.g., `0.5` = half width) |
+| `maxWidth` | `number` | `1200` | Maximum width constraint |
+| `resizeDebounceTime` | `number` | `300` | Debounce delay for resize events (ms) |
+
+#### Unresponsive Variants
+
+Each chart exports an "Unresponsive" variant for cases where you need direct control without the responsive wrapper:
+
+<Source
+	language="jsx"
+	code={`import { LineChartUnresponsive } from '@automattic/charts';
+
+	// Requires explicit width and height
+	<LineChartUnresponsive data={data} width={800} height={400} />`}
+/>
 
 ### Compound Components
 

--- a/projects/js-packages/charts/src/stories/index.docs.mdx
+++ b/projects/js-packages/charts/src/stories/index.docs.mdx
@@ -56,6 +56,18 @@ yarn add @automattic/charts
 
 />
 
+### Design Tokens
+
+Some chart components use WordPress design tokens for consistent spacing and styling. If your application doesn't already include the WordPress theme package, you'll need to import the design tokens CSS:
+
+<Source
+	language="jsx"
+	code={`// Add this import to your app's entry point if tokens aren't already available
+import '@wordpress/theme/design-tokens.css';`}
+/>
+
+In WordPress environments (wp-admin, Gutenberg editor), these tokens are typically already loaded. For standalone applications or Storybook, you may need to add this import explicitly.
+
 ## Available Chart Types
 
 ### [Bar Chart](./?path=/docs/js-packages-charts-library-charts-bar-chart--docs)

--- a/projects/js-packages/charts/src/stories/theme-config.tsx
+++ b/projects/js-packages/charts/src/stories/theme-config.tsx
@@ -54,10 +54,6 @@ export const themeArgTypes = {
 	},
 };
 
-/**
- * Shared default args for theme-related controls in chart stories
- * These provide actual default values that appear in Storybook controls
- */
 export const sharedThemeArgs = {
 	themeName: 'default',
 	accentColor: DEFAULT_ACCENT_COLOR,

--- a/projects/js-packages/charts/tests/__mocks__/styleMock.js
+++ b/projects/js-packages/charts/tests/__mocks__/styleMock.js
@@ -1,0 +1,2 @@
+// Mock for CSS imports in Jest tests
+module.exports = {};

--- a/projects/js-packages/charts/tests/__mocks__/styleMock.js
+++ b/projects/js-packages/charts/tests/__mocks__/styleMock.js
@@ -1,2 +1,0 @@
-// Mock for CSS imports in Jest tests
-module.exports = {};

--- a/projects/js-packages/charts/tests/jest.config.cjs
+++ b/projects/js-packages/charts/tests/jest.config.cjs
@@ -12,4 +12,9 @@ module.exports = {
 	},
 	// Transform d3-* ESM packages (pattern accounts for pnpm .pnpm directory structure)
 	transformIgnorePatterns: [ '/node_modules/(?!(\\.pnpm/(d3-|internmap)|d3-|internmap))' ],
+	moduleNameMapper: {
+		...baseConfig.moduleNameMapper,
+		// Mock @wordpress/theme CSS import
+		'@wordpress/theme/design-tokens\\.css$': '<rootDir>/tests/__mocks__/styleMock.js',
+	},
 };

--- a/projects/js-packages/charts/tests/jest.config.cjs
+++ b/projects/js-packages/charts/tests/jest.config.cjs
@@ -14,7 +14,5 @@ module.exports = {
 	transformIgnorePatterns: [ '/node_modules/(?!(\\.pnpm/(d3-|internmap)|d3-|internmap))' ],
 	moduleNameMapper: {
 		...baseConfig.moduleNameMapper,
-		// Mock @wordpress/theme CSS import
-		'@wordpress/theme/design-tokens\\.css$': '<rootDir>/tests/__mocks__/styleMock.js',
 	},
 };

--- a/projects/js-packages/storybook/changelog/add-wordpress-theme-tokens
+++ b/projects/js-packages/storybook/changelog/add-wordpress-theme-tokens
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add @wordpress/theme design tokens for charts library Storybook previews.

--- a/projects/js-packages/storybook/changelog/add-wordpress-theme-tokens
+++ b/projects/js-packages/storybook/changelog/add-wordpress-theme-tokens
@@ -1,4 +1,4 @@
 Significance: patch
 Type: added
 
-Add @wordpress/theme design tokens for charts library Storybook previews.
+Add @wordpress/theme 0.6.0 design tokens for charts library Storybook previews.

--- a/projects/js-packages/storybook/package.json
+++ b/projects/js-packages/storybook/package.json
@@ -45,6 +45,7 @@
 		"@wordpress/element": "6.39.0",
 		"@wordpress/format-library": "5.39.0",
 		"@wordpress/postcss-plugins-preset": "5.39.0",
+		"@wordpress/theme": "0.5.0",
 		"allure-playwright": "2.15.1",
 		"babel-loader": "9.1.2",
 		"babel-plugin-inline-json-import": "0.3.2",

--- a/projects/js-packages/storybook/package.json
+++ b/projects/js-packages/storybook/package.json
@@ -45,7 +45,7 @@
 		"@wordpress/element": "6.39.0",
 		"@wordpress/format-library": "5.39.0",
 		"@wordpress/postcss-plugins-preset": "5.39.0",
-		"@wordpress/theme": "0.5.0",
+		"@wordpress/theme": "0.6.0",
 		"allure-playwright": "2.15.1",
 		"babel-loader": "9.1.2",
 		"babel-plugin-inline-json-import": "0.3.2",

--- a/projects/js-packages/storybook/storybook/preview.mjs
+++ b/projects/js-packages/storybook/storybook/preview.mjs
@@ -1,4 +1,5 @@
 import { ThemeProvider } from '@automattic/jetpack-components';
+import '@wordpress/theme/design-tokens.css';
 
 // import '@wordpress/components/build-style/style.css';
 


### PR DESCRIPTION
Fixes [Charts: Better Legend - Layout & Refactoring](https://linear.app/a8c/project/charts-better-legend-layout-and-refactoring-a4a8444cf720)
Fixes [CHARTS-160: `size` prop should not be required for GeoChart](https://linear.app/a8c/issue/CHARTS-160/size-prop-should-not-be-required-for-geochart)
Related [WOOA7S-1034: Remove vertical scrollbar from Visitors by Location widget](https://linear.app/a8c/issue/WOOA7S-1034/remove-vertical-scrollbar-from-visitors-by-location-widget)

## Summary

This PR changes responsive charts to fill their parent container by default (instead of requiring an `aspectRatio`), and refactors BarChart/LineChart to use WordPress UI `Stack` for layout so legends are properly accounted for in height calculations.

---

## 🔍 Key Files to Review (5 files, ~660 lines changed)

These contain the core logic changes:

| File | What Changed |
|------|--------------|
| `with-responsive.tsx` | **Core change**: Default to parent height instead of requiring `aspectRatio`. Falls back to explicit props when measured size is 0 |
| `bar-chart.tsx` | Refactored to use `Stack` for legend layout. SVG dimensions now account for legend height |
| `line-chart.tsx` | Same `Stack` refactor as BarChart |
| `bar-list-chart.tsx` | Uses `BarChartUnresponsive` internally (2-line fix) |
| `line-chart/types.ts` | Added `GapSize` type for new `gap` prop |

---

## 📚 Supporting Files (not critical to review)

These files update stories, tests, and docs to work with the new behavior. They add volume but contain no core logic:

- **Stories** (~15 files): Updated to use `containerHeight` arg and demonstrate new responsive modes
- **Documentation** (~8 files): Added "Responsive Design" sections explaining the new behavior
- **Tests** (~2 files): Expanded `withResponsive` tests, added CSS mock for Jest

---

## Proposed changes:

### Responsive Container Behavior
- `withResponsive` HOC now fills parent container height by default (when `aspectRatio` not provided)
- Explicit `aspectRatio` prop still works as before (backward compatible)
- Falls back to explicit `width`/`height` props when parent size can't be measured

### Stack Layout for Charts
- BarChart and LineChart use WordPress UI `Stack` component for layout
- **Legend is properly accounted for in responsive height** - no more overflow
- New `gap` prop using WordPress design system tokens

### Impact
- GeoChart in Visitors by Location widget will fill available space without overflow
- Significantly reduces layout code needed in Woo Analytics widgets ([see PR](https://github.com/woocommerce/woocommerce-analytics/pull/1607))

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable?

## Jetpack product discussion

N/A - Charts library enhancement for Woo Analytics dashboard widgets.

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

### Core Functionality (priority)
* Run Storybook: `pnpm --filter=@automattic/jetpack-charts storybook`
* Navigate to **JS Packages / Charts Library / Charts / Geo Chart**
* On the **Default** story, verify the chart fills the 400px container height
* Resize the container using the drag handle - chart should adapt to any aspect ratio
* Navigate to **JS Packages / Charts Library / Charts / Bar Chart** or **Line Chart**
* Toggle `showLegend` on and off - chart SVG should shrink to fit legend (no overflow)
* Resize container - chart + legend should always fit within bounds
* On the **WithAspectRatio** story (GeoChart), verify the chart maintains a 2:1 ratio
* Resize width - height should scale proportionally

### Documentation (optional)
* Check Introduction → "Responsive Design" section renders correctly

---

**Note:** Pie Charts and variants are also affected by these changes but are not currently in use. They will be updated in a subsequent PR.