### PR TITLE
Forms: Extract Forms logo and product name into a shared component

### DIFF
--- a/projects/packages/forms/changelog/add-forms-logo-component
+++ b/projects/packages/forms/changelog/add-forms-logo-component
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Extract Forms logo and product name into a shared FormsLogo component and use it in both the responses and forms wp-build dashboard stage headers.

--- a/projects/packages/forms/routes/forms/stage.tsx
+++ b/projects/packages/forms/routes/forms/stage.tsx
@@ -1,8 +1,4 @@
 /**
- * External dependencies
- */
-import JetpackLogo from '@automattic/jetpack-components/jetpack-logo';
-/**
  * WordPress dependencies
  */
 import { Page } from '@wordpress/admin-ui';
@@ -12,6 +8,7 @@ import * as React from 'react';
 /**
  * Internal dependencies
  */
+import FormsLogo from '../../src/dashboard/components/forms-logo';
 import DataViewsHeaderRow from '../../src/dashboard/wp-build/components/dataviews-header-row';
 
 /**
@@ -23,12 +20,7 @@ function Stage() {
 	return (
 		<Page
 			showSidebarToggle={ false }
-			title={
-				<Stack align="center" gap="xs">
-					<JetpackLogo showText={ false } width={ 20 } />
-					{ __( 'Forms', 'jetpack-forms' ) }
-				</Stack>
-			}
+			title={ <FormsLogo /> }
 			subTitle={ __( 'View and manage all your forms in one place.', 'jetpack-forms' ) }
 		>
 			<DataViewsHeaderRow activeTab="forms" />

--- a/projects/packages/forms/routes/responses/stage.tsx
+++ b/projects/packages/forms/routes/responses/stage.tsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import JetpackLogo from '@automattic/jetpack-components/jetpack-logo';
 import { Badge } from '@automattic/ui';
 import '@automattic/ui/style.css';
 /**
@@ -28,6 +27,7 @@ import * as React from 'react';
  */
 import IntegrationsModal from '../../src/blocks/contact-form/components/jetpack-integrations-modal';
 import EmptyResponses from '../../src/dashboard/components/empty-responses';
+import FormsLogo from '../../src/dashboard/components/forms-logo';
 import EmptySpamButton from '../../src/dashboard/components/empty-spam-button';
 import EmptyTrashButton from '../../src/dashboard/components/empty-trash-button';
 import Gravatar from '../../src/dashboard/components/gravatar';
@@ -548,12 +548,7 @@ function StageInner() {
 	return (
 		<Page
 			showSidebarToggle={ false }
-			title={
-				<Stack align="center" gap="xs">
-					<JetpackLogo showText={ false } width={ 20 } />
-					{ __( 'Forms', 'jetpack-forms' ) }
-				</Stack>
-			}
+			title={ <FormsLogo /> }
 			subTitle={ __( 'View and manage all your form submissions in one place.', 'jetpack-forms' ) }
 			actions={ headerActions }
 			hasPadding={ false }

--- a/projects/packages/forms/routes/responses/stage.tsx
+++ b/projects/packages/forms/routes/responses/stage.tsx
@@ -27,9 +27,9 @@ import * as React from 'react';
  */
 import IntegrationsModal from '../../src/blocks/contact-form/components/jetpack-integrations-modal';
 import EmptyResponses from '../../src/dashboard/components/empty-responses';
-import FormsLogo from '../../src/dashboard/components/forms-logo';
 import EmptySpamButton from '../../src/dashboard/components/empty-spam-button';
 import EmptyTrashButton from '../../src/dashboard/components/empty-trash-button';
+import FormsLogo from '../../src/dashboard/components/forms-logo';
 import Gravatar from '../../src/dashboard/components/gravatar';
 import TextWithFlag from '../../src/dashboard/components/text-with-flag/index.tsx';
 import useCreateForm from '../../src/dashboard/hooks/use-create-form';

--- a/projects/packages/forms/src/dashboard/components/forms-logo/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/forms-logo/index.tsx
@@ -1,0 +1,23 @@
+/**
+ * External dependencies
+ */
+import JetpackLogo from '@automattic/jetpack-components/jetpack-logo';
+/**
+ * WordPress dependencies
+ */
+import { Stack } from '@wordpress/ui';
+
+/**
+ * Forms logo with product name for dashboard headers.
+ *
+ * @return The Forms logo component.
+ */
+export default function FormsLogo() {
+	return (
+		<Stack align="center" gap="xs">
+			<JetpackLogo showText={ false } width={ 20 } />
+			{ /** "Jetpack Forms" and "Forms" are Product names, do not translate. */ }
+			Forms
+		</Stack>
+	);
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Extracts Forms logo to component, used now in two places, and in future likely more. I could imagine us componentizing this further later for other Jetpack products and just swapping out the name.

<img width="669" height="144" alt="image" src="https://github.com/user-attachments/assets/aa34bbbb-3eda-4c56-824c-6ece40db2a96" />


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* WP build dashboard didn't change visually.