### PR TITLE
Introduce Sync blacklist for `jetpack_options`

### DIFF
--- a/projects/packages/sync/changelog/add-sync-jetpack_options-blacklist
+++ b/projects/packages/sync/changelog/add-sync-jetpack_options-blacklist
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Introduce Sync blacklist for `jetpack_options`.

--- a/projects/packages/sync/src/class-defaults.php
+++ b/projects/packages/sync/src/class-defaults.php
@@ -1385,4 +1385,13 @@ class Defaults {
 	 * @var int Bool-ish. Default 1.
 	 */
 	public static $default_wpcom_rest_api_enabled = 1;
+
+	/**
+	 * A list of 'jetpack_options' specific keys we want to ignore.
+	 *
+	 * @var array
+	 */
+	public static $jetpack_options_blacklist = array(
+		'last_heartbeat',
+	);
 }

--- a/projects/packages/sync/src/modules/class-options.php
+++ b/projects/packages/sync/src/modules/class-options.php
@@ -317,7 +317,7 @@ class Options extends Module {
 			return false;
 		}
 
-		if ( 'jetpack_options' === $args[0] && ! empty( $args[1] ) & ! empty( $args[2] ) ) {
+		if ( 'jetpack_options' === $args[0] && ! empty( $args[1] ) && ! empty( $args[2] ) ) {
 			if ( ! $this->should_enqueue_jetpack_options_update( $args[1], $args[2] ) ) {
 				return false;
 			}

--- a/projects/packages/sync/src/modules/class-options.php
+++ b/projects/packages/sync/src/modules/class-options.php
@@ -317,6 +317,14 @@ class Options extends Module {
 			return false;
 		}
 
+		if ( 'jetpack_options' === $args[0] && ! empty( $args[1] ) & ! empty( $args[2] ) ) {
+			if ( ! $this->should_enqueue_jetpack_options_update( $args[1], $args[2] ) ) {
+				return false;
+			}
+
+			return $args;
+		}
+
 		// Filter our weird array( false ) value for theme_mods_*.
 		if ( str_starts_with( $args[0], 'theme_mods_' ) ) {
 			$this->filter_theme_mods( $args[1] );
@@ -486,5 +494,32 @@ class Options extends Module {
 		}
 
 		return 'OPTION-DOES-NOT-EXIST';
+	}
+
+	/**
+	 * Check if 'jetpack_options' option update should be processed based on excluded keys.
+	 *
+	 * @param mixed $old_value    The old option value.
+	 * @param mixed $value        The new option value.
+	 * @return bool False if only excluded keys changed (or no change), true otherwise.
+	 */
+	private function should_enqueue_jetpack_options_update( $old_value, $value ) {
+		// No changes at all
+		if ( $old_value === $value ) {
+			return false;
+		}
+
+		// Values are different but not both arrays - meaningful change
+		if ( ! is_array( $old_value ) || ! is_array( $value ) ) {
+			return true;
+		}
+
+		// Get changed keys in both directions (modified/added and removed)
+		$changed_keys = array_keys(
+			array_diff_assoc( $value, $old_value ) + array_diff_assoc( $old_value, $value )
+		);
+
+		// Return false if ALL changed keys are excluded, true otherwise
+		return ! empty( array_diff( $changed_keys, Defaults::$jetpack_options_blacklist ) );
 	}
 }

--- a/projects/packages/sync/src/modules/class-options.php
+++ b/projects/packages/sync/src/modules/class-options.php
@@ -317,7 +317,8 @@ class Options extends Module {
 			return false;
 		}
 
-		if ( 'jetpack_options' === $args[0] && ! empty( $args[1] ) && ! empty( $args[2] ) ) {
+		// Check if 'jetpack_options' were updated and reject if the change affected only blacklisted keys.
+		if ( 'jetpack_options' === $args[0] && 3 === count( $args ) ) {
 			if ( ! $this->should_enqueue_jetpack_options_update( $args[1], $args[2] ) ) {
 				return false;
 			}
@@ -513,27 +514,31 @@ class Options extends Module {
 			return true;
 		}
 		// Determine all top-level keys present in either the old or new value.
-		$all_keys     = array_unique(
+		$all_keys = array_unique(
 			array_merge(
 				array_keys( $old_value ),
 				array_keys( $value )
 			)
 		);
-		$changed_keys = array();
-		// Collect keys that were added, removed, or whose values changed (strict comparison).
+		// Short-circuit as soon as we find a changed key that is not blacklisted.
 		foreach ( $all_keys as $key ) {
 			$old_has_key = array_key_exists( $key, $old_value );
 			$new_has_key = array_key_exists( $key, $value );
+			// Key was added or removed.
 			if ( ! $old_has_key || ! $new_has_key ) {
-				$changed_keys[] = $key;
+				if ( ! in_array( $key, Defaults::$jetpack_options_blacklist, true ) ) {
+					return true;
+				}
 				continue;
 			}
+			// Key exists in both arrays but the value changed.
 			if ( $old_value[ $key ] !== $value[ $key ] ) {
-				$changed_keys[] = $key;
+				if ( ! in_array( $key, Defaults::$jetpack_options_blacklist, true ) ) {
+					return true;
+				}
 			}
 		}
-
-		// Return false if ALL changed keys are excluded, true otherwise
-		return ! empty( array_diff( $changed_keys, Defaults::$jetpack_options_blacklist ) );
+		// Either there were no effective changes, or all changed keys are excluded.
+		return false;
 	}
 }

--- a/projects/packages/sync/src/modules/class-options.php
+++ b/projects/packages/sync/src/modules/class-options.php
@@ -504,20 +504,34 @@ class Options extends Module {
 	 * @return bool False if only excluded keys changed (or no change), true otherwise.
 	 */
 	private function should_enqueue_jetpack_options_update( $old_value, $value ) {
-		// No changes at all
+		// No changes at all.
 		if ( $old_value === $value ) {
 			return false;
 		}
-
-		// Values are different but not both arrays - meaningful change
+		// Values are different but not both arrays - meaningful change.
 		if ( ! is_array( $old_value ) || ! is_array( $value ) ) {
 			return true;
 		}
-
-		// Get changed keys in both directions (modified/added and removed)
-		$changed_keys = array_keys(
-			array_diff_assoc( $value, $old_value ) + array_diff_assoc( $old_value, $value )
+		// Determine all top-level keys present in either the old or new value.
+		$all_keys     = array_unique(
+			array_merge(
+				array_keys( $old_value ),
+				array_keys( $value )
+			)
 		);
+		$changed_keys = array();
+		// Collect keys that were added, removed, or whose values changed (strict comparison).
+		foreach ( $all_keys as $key ) {
+			$old_has_key = array_key_exists( $key, $old_value );
+			$new_has_key = array_key_exists( $key, $value );
+			if ( ! $old_has_key || ! $new_has_key ) {
+				$changed_keys[] = $key;
+				continue;
+			}
+			if ( $old_value[ $key ] !== $value[ $key ] ) {
+				$changed_keys[] = $key;
+			}
+		}
 
 		// Return false if ALL changed keys are excluded, true otherwise
 		return ! empty( array_diff( $changed_keys, Defaults::$jetpack_options_blacklist ) );

--- a/projects/plugins/jetpack/changelog/add-sync-jetpack_options-blacklist
+++ b/projects/plugins/jetpack/changelog/add-sync-jetpack_options-blacklist
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Updated Sync related unit tests.
+
+

--- a/projects/plugins/jetpack/changelog/add-sync-jetpack_options-blacklist
+++ b/projects/plugins/jetpack/changelog/add-sync-jetpack_options-blacklist
@@ -1,5 +1,5 @@
 Significance: patch
 Type: other
-Comment: Updated Sync related unit tests.
+Comment: Note that there are no user-facing changes; update Sync-related unit tests only.
 
 

--- a/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Options_Test.php
+++ b/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Options_Test.php
@@ -343,7 +343,7 @@ class Jetpack_Sync_Options_Test extends Jetpack_Sync_TestBase {
 		);
 	}
 
-	public function test_sync_blacklisted_jetpack_options() {
+	public function test_don_t_sync_jetpack_options_if_changed_key_is_blacklisted() {
 		$this->setSyncClientDefaults();
 
 		$this->server_replica_storage->reset();

--- a/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Options_Test.php
+++ b/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Options_Test.php
@@ -343,6 +343,18 @@ class Jetpack_Sync_Options_Test extends Jetpack_Sync_TestBase {
 		);
 	}
 
+	public function test_sync_blacklisted_jetpack_options() {
+		$this->setSyncClientDefaults();
+
+		$this->server_replica_storage->reset();
+
+		Jetpack_Options::update_option( 'last_heartbeat', microtime( true ) );
+
+		$this->sender->do_sync();
+
+		$this->assertFalse( $this->server_replica_storage->get_option( 'jetpack_options' ) );
+	}
+
 	public function assertOptionIsSynced( $option_name, $value ) {
 		$this->assertEqualsObject( $value, $this->server_replica_storage->get_option( $option_name ), 'Option ' . $option_name . ' didn\'t have the expected value of ' . wp_json_encode( $value, JSON_UNESCAPED_SLASHES ) );
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Closes SYNC-230

The `jetpack_options` option is holding various keys, related mostly to the Jetpack plugin.
As the list of keys we store grows, we realize that:
1. Some of those (namely the `last_heartbeat`) are associated with a high Sync lag
2. We are not actually interested in syncing certain keys (eg `last_timestamp`, `idc_url_secret` etc) especially via Incremental Sync

Therefore in this PR we are introducing a Sync keys blacklist for `jetpack_options`. Atm we only added `last_heartbeat` in the corresponding blacklist but we plan to add more in the future.
Note that we are currently only excluding those keys from Incremental Sync actions. During Fix Checksums and Full Syncs we will still sync all the contents of `jetpack_options`. 

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
- Add jetpack_options-specific filtering to skip syncing when only blacklisted keys change.
- Add a Sync defaults list for blacklisted jetpack_options keys.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* In your local env comment out [these lines](https://github.com/Automattic/jetpack/blob/trunk/projects/packages/connection/src/class-heartbeat.php#L102-L104) so that the heartbeat is sent every time the cron job runs
* Using a plugin like WP Crontrol run the `jetpack_v2_heartbeat` cron job
* Confirm that no `updated_option` event for `jetpack_options` was synced by monitoring ES logs

