### PR TITLE
Codeowners: Add Vulcan as codeowners of Connection and Sync package files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,6 +9,9 @@
 
 # Packages
 /projects/packages/search/src/wpes @Automattic/prometheus
+/projects/packages/connection/src @Automattic/jetpack-vulcan
+/projects/packages/connection/legacy @Automattic/jetpack-vulcan
+/projects/packages/sync/src @Automattic/jetpack-vulcan
 
 # Plugins
 


### PR DESCRIPTION
Fixes SYNC-228

## Proposed changes:

* This PR adds Vulcan as codeowners of the Sync and Connection packages, ensuring we are added as reviewers (not required reviewers) when file in the respective packages are changed in a PR. This ensures we can keep up with any changes made outwith the team.
* I've used the `src` (and `legacy` as well for Connection) directories so changes to things like composer files don't trigger a review addition.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

n/a

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

* Proof-read

