### PR TITLE
Forms: Handle deleted or missing form source in responses filter

### DIFF
--- a/projects/packages/forms/changelog/fix-wp-build-source-filter
+++ b/projects/packages/forms/changelog/fix-wp-build-source-filter
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: handle deleted or missing form source in responses filter.

--- a/projects/packages/forms/changelog/fix-wp-build-source-filter
+++ b/projects/packages/forms/changelog/fix-wp-build-source-filter
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Forms: handle deleted or missing form source in responses filter.
+Handle deleted or missing form source in responses filter.

--- a/projects/packages/forms/routes/responses/stage.tsx
+++ b/projects/packages/forms/routes/responses/stage.tsx
@@ -28,7 +28,6 @@ import EmptyResponses from '../../src/dashboard/components/empty-responses';
 import Gravatar from '../../src/dashboard/components/gravatar';
 import TextWithFlag from '../../src/dashboard/components/text-with-flag/index.tsx';
 import useInboxData from '../../src/dashboard/hooks/use-inbox-data.ts';
-import { getPath } from '../../src/dashboard/inbox/utils';
 import WpRouteDashboardSearchParamsProvider from '../../src/dashboard/router/wp-route-dashboard-search-params-provider.tsx';
 import DataViewsHeaderRow from '../../src/dashboard/wp-build/components/dataviews-header-row';
 import usePageHeaderDetails from '../../src/dashboard/wp-build/hooks/use-page-header-details';
@@ -127,6 +126,21 @@ function styleUnreadValue( element: React.ReactNode, isUnread: boolean ): React.
 
 	// Fallback: wrap in span for other types
 	return <span style={ { fontWeight: 600 } }>{ element }</span>;
+}
+
+/**
+ * Get the path from a URL string.
+ *
+ * @param url - The URL string.
+ * @return The pathname from the URL, or null if the URL is invalid.
+ */
+function getPath( url: string ): string | null {
+	try {
+		const parsedUrl = new URL( url );
+		return parsedUrl.pathname;
+	} catch {
+		return null;
+	}
 }
 
 /**

--- a/projects/packages/forms/routes/responses/stage.tsx
+++ b/projects/packages/forms/routes/responses/stage.tsx
@@ -134,7 +134,7 @@ function styleUnreadValue( element: React.ReactNode, isUnread: boolean ): React.
  * @param url - The URL string.
  * @return The pathname from the URL, or null if the URL is invalid.
  */
-function getPath( url: string ): string | null {
+function getUrlPath( url: string ): string | null {
 	try {
 		const parsedUrl = new URL( url );
 		return parsedUrl.pathname;

--- a/projects/packages/forms/routes/responses/stage.tsx
+++ b/projects/packages/forms/routes/responses/stage.tsx
@@ -460,7 +460,9 @@ function StageInner() {
 							label: __( 'Source', 'jetpack-forms' ),
 							render: ( { item } ) => {
 								const source =
-									item.entry_title || getPath( item ) || __( '(no title)', 'jetpack-forms' );
+									item.entry_title ||
+									getUrlPath( item.entry_permalink ) ||
+									__( '(no title)', 'jetpack-forms' );
 								if ( item.entry_permalink ) {
 									return styleUnreadValue(
 										<ExternalLink href={ item.entry_permalink }>{ source }</ExternalLink>,
@@ -472,7 +474,10 @@ function StageInner() {
 							elements: ( ( filterOptions as unknown as FeedbackFilters )?.source || [] ).map(
 								source => ( {
 									value: source.id.toString(),
-									label: decodeEntities( source.title ) || source.url,
+									label:
+										decodeEntities( source.title ) ||
+										getUrlPath( source.url ) ||
+										__( '(no title)', 'jetpack-forms' ),
 								} )
 							),
 							filterBy: { operators: [ 'is' ] as Operator[] },

--- a/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
@@ -385,9 +385,14 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 				if ( $permalink === false ) {
 					$permalink = '';
 				}
+				$status = get_post_status( $post );
+				$title  = get_the_title( $post->ID );
+				if ( 'trash' === $status ) {
+					$title = sprintf( /* translators: %s: post title */ __( '(trashed) %s', 'jetpack-forms' ), $title );
+				}
 				return array(
 					'id'    => $post->ID,
-					'title' => get_the_title( $post->ID ),
+					'title' => $title,
 					'url'   => $permalink,
 				);
 			},

--- a/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
@@ -380,10 +380,22 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 				),
 				'source' => array_map(
 					static function ( $post_id ) {
+						if ( ! get_post_status( $post_id ) ) {
+							return array(
+								'id'    => $post_id,
+								// translators: %d is the post ID.
+								'title' => sprintf( __( '(Deleted #%d)', 'jetpack-forms' ), $post_id ),
+								'url'   => '',
+							);
+						}
+						$permalink = get_permalink( $post_id );
+						if ( $permalink === false ) {
+							$permalink  = '';
+						}
 						return array(
 							'id'    => $post_id,
 							'title' => get_the_title( $post_id ),
-							'url'   => get_permalink( $post_id ),
+							'url'   => $permalink,
 						);
 					},
 					$source_ids

--- a/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
@@ -379,7 +379,7 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 			)
 		);
 
-		$sourse_array = array_map(
+		$source_array = array_map(
 			static function ( $post ) {
 				$permalink = get_permalink( $post->ID );
 				if ( $permalink === false ) {
@@ -410,7 +410,7 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 					},
 					$months
 				),
-				'source' => $sourse_array,
+				'source' => $source_array,
 			)
 		);
 	}

--- a/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
@@ -367,6 +367,33 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 		$source_ids = Contact_Form_Plugin::get_all_parent_post_ids(
 			array_diff_key( array( 'post_status' => array( 'draft', 'publish', 'spam', 'trash' ) ), array( 'post_parent' => '' ) )
 		);
+
+		$source_query = new WP_Query(
+			array(
+				'post__in'       => $source_ids,
+				'post_status'    => array( 'publish', 'draft', 'pending', 'future', 'private', 'inherit', 'trash' ),
+				'post_type'      => 'any',
+				'orderby'        => 'post_title',
+				'order'          => 'ASC',
+				'posts_per_page' => -1,
+			)
+		);
+
+		$sourse_array = array_map(
+			static function ( $post ) {
+				$permalink = get_permalink( $post->ID );
+				if ( $permalink === false ) {
+					$permalink = '';
+				}
+				return array(
+					'id'    => $post->ID,
+					'title' => get_the_title( $post->ID ),
+					'url'   => $permalink,
+				);
+			},
+			$source_query->posts
+		);
+
 		return rest_ensure_response(
 			array(
 				'date'   => array_map(
@@ -378,28 +405,7 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 					},
 					$months
 				),
-				'source' => array_map(
-					static function ( $post_id ) {
-						if ( ! get_post_status( $post_id ) ) {
-							return array(
-								'id'    => $post_id,
-								// translators: %d is the post ID.
-								'title' => sprintf( __( '(Deleted #%d)', 'jetpack-forms' ), $post_id ),
-								'url'   => '',
-							);
-						}
-						$permalink = get_permalink( $post_id );
-						if ( $permalink === false ) {
-							$permalink  = '';
-						}
-						return array(
-							'id'    => $post_id,
-							'title' => get_the_title( $post_id ),
-							'url'   => $permalink,
-						);
-					},
-					$source_ids
-				),
+				'source' => $sourse_array,
 			)
 		);
 	}

--- a/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
@@ -345,6 +345,49 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 			)
 		);
 	}
+	/**
+	 * Get source array from post IDs
+	 *
+	 * @param array $post_ids Array of post IDs.
+	 *
+	 * @return array Array of sources.
+	 */
+	private static function get_source_array( $post_ids ) {
+		if ( empty( $post_ids ) ) {
+			return array();
+		}
+
+		$source_query = new WP_Query(
+			array(
+				'post__in'       => $post_ids,
+				'post_status'    => array( 'publish', 'draft', 'pending', 'future', 'private', 'inherit', 'trash' ),
+				'post_type'      => 'any',
+				'orderby'        => 'post_title',
+				'order'          => 'ASC',
+				'posts_per_page' => -1,
+			)
+		);
+
+		return array_map(
+			static function ( $post ) {
+				$permalink = get_permalink( $post->ID );
+				if ( $permalink === false ) {
+					$permalink = '';
+				}
+				$status = get_post_status( $post );
+				$title  = get_the_title( $post->ID );
+				if ( 'trash' === $status ) {
+					$title = sprintf( /* translators: %s: post title */ __( '(trashed) %s', 'jetpack-forms' ), $title );
+				}
+				return array(
+					'id'    => $post->ID,
+					'title' => $title,
+					'url'   => $permalink,
+				);
+			},
+			$source_query->posts
+		);
+	}
 
 	/**
 	 * Retrieves all distinct sources (posts) and all the distinct available dates that
@@ -368,37 +411,6 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 			array_diff_key( array( 'post_status' => array( 'draft', 'publish', 'spam', 'trash' ) ), array( 'post_parent' => '' ) )
 		);
 
-		$source_query = new WP_Query(
-			array(
-				'post__in'       => $source_ids,
-				'post_status'    => array( 'publish', 'draft', 'pending', 'future', 'private', 'inherit', 'trash' ),
-				'post_type'      => 'any',
-				'orderby'        => 'post_title',
-				'order'          => 'ASC',
-				'posts_per_page' => -1,
-			)
-		);
-
-		$source_array = array_map(
-			static function ( $post ) {
-				$permalink = get_permalink( $post->ID );
-				if ( $permalink === false ) {
-					$permalink = '';
-				}
-				$status = get_post_status( $post );
-				$title  = get_the_title( $post->ID );
-				if ( 'trash' === $status ) {
-					$title = sprintf( /* translators: %s: post title */ __( '(trashed) %s', 'jetpack-forms' ), $title );
-				}
-				return array(
-					'id'    => $post->ID,
-					'title' => $title,
-					'url'   => $permalink,
-				);
-			},
-			$source_query->posts
-		);
-
 		return rest_ensure_response(
 			array(
 				'date'   => array_map(
@@ -410,7 +422,7 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 					},
 					$months
 				),
-				'source' => $source_array,
+				'source' => self::get_source_array( $source_ids ),
 			)
 		);
 	}

--- a/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
@@ -364,7 +364,7 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 				'post_type'      => 'any',
 				'orderby'        => 'post_title',
 				'order'          => 'ASC',
-				'posts_per_page' => -1,
+				'posts_per_page' => count( $post_ids ), // Retrieve all in the post_ids array but no more than that.
 			)
 		);
 


### PR DESCRIPTION
## Proposed changes:

- Handle cases where a form source post has been deleted or is missing
- In the PHP endpoint, check if the post exists before calling `get_permalink()` - deleted posts now show "(Deleted #ID)" as the title
- In the frontend filter, add fallback text "(no title)" when both title and URL are empty
- Prevents JavaScript errors and provides meaningful labels for deleted form sources

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

N/A

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

1. Create a form on a page and submit a test response
2. Delete the page containing the form
3. Go to the Forms responses dashboard
4. Open the source filter dropdown
5. Verify the deleted form source are not shown any more and trashed posts show  "(trashed) post_title" instead of causing an error or showing blank