### PR TITLE
social: Set custom upload dir for tests

### DIFF
--- a/projects/plugins/social/changelog/fix-social-plugin-test-upload-fail
+++ b/projects/plugins/social/changelog/fix-social-plugin-test-upload-fail
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Tests: Set custom upload dir so concurrent tests for other plugins don't delete files mid-test.
+
+

--- a/projects/plugins/social/tests/php/bootstrap.php
+++ b/projects/plugins/social/tests/php/bootstrap.php
@@ -13,5 +13,5 @@ require_once __DIR__ . '/../../vendor/autoload.php';
 // Preloading the file to reconcile Brain\Monkey with Wordbless.
 require_once __DIR__ . '/../../vendor/antecedent/patchwork/Patchwork.php';
 
-\Automattic\Jetpack\Test_Environment::init();
+\Automattic\Jetpack\Test_Environment::init( 'plugin-social' );
 require_once __DIR__ . '/../../jetpack-social.php';


### PR DESCRIPTION
Closes MONOREP-333

 <!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Our `Test_Environment` package can be instructed to create a custom upload directory for the project, so concurrent test runs for other projects don't stomp on the test's uploads. I've seen a few Social failures lately that point to this happening, so activate that feature for its tests.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* CI happy?
