### PR TITLE
Custom Colors: Enqueue Customizer's custom colors in the block editor

### DIFF
--- a/projects/plugins/wpcomsh/changelog/dotthem-139-rockfield-secondary-color-set-in-the-customizer-does-not
+++ b/projects/plugins/wpcomsh/changelog/dotthem-139-rockfield-secondary-color-set-in-the-customizer-does-not
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Custom Colors: ensure Customizer's custom colors are enqueued in the block editor when set.

--- a/projects/plugins/wpcomsh/changelog/dotthem-139-rockfield-secondary-color-set-in-the-customizer-does-not
+++ b/projects/plugins/wpcomsh/changelog/dotthem-139-rockfield-secondary-color-set-in-the-customizer-does-not
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Custom Colors: ensure Customizer's custom colors are enqueued in the block editor when set.
+Custom Colors: Ensure Customizer's custom colors are enqueued in the block editor when set.

--- a/projects/plugins/wpcomsh/custom-colors/colors.php
+++ b/projects/plugins/wpcomsh/custom-colors/colors.php
@@ -196,6 +196,14 @@ class Colors_Manager_Common {
 
 			add_filter( 'tonesque_image_url', array( __CLASS__, 'gravatar_image_url' ) );
 		}
+
+		if ( self::is_gutenberg() ) {
+			// If colors are set, print them in the Block Editor as well.
+			if ( self::theme_has_set_colors() ) {
+				self::override_themecolors();
+				add_action( 'enqueue_block_editor_assets', array( __CLASS__, 'print_theme_css' ), 20 );
+			}
+		}
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes DOTTHEM-139

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* On Atomic, ensure Customizer's custom colors are enqueued in the block editor as well, when they are set.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

n/d

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

**Preparation**

* Pick an Atomic site and activate one of the Varia children themes (Rockfield, Hever, or many others).
* Enter the Customizer and open the "Colors & Backgrounds" section.
* Make note of the theme color palette (e.g. the foreground color is black ⚫).
* Change a color (e.g. make foreground purple 🟣); you'll see the Customizer preview update accordingly.
* Open the site's front end.
* ✅ The customized color is applied correctly (e.g. foreground is purple 🟣).
* Open the block editor.
* ❌ The customized color is not applied, and the editor shows the default color instead (e.g. foreground is black ⚫).
* Try changing that color from a block sidebar.
* ✅ The color palette shows the correct customized color (e.g. foreground is purple 🟣).

**Testing**

* Apply these changes to the Atomic site.
* Open the block editor.
* ✅ The customized color is now applied correctly (e.g. foreground is purple 🟣).