### PR TITLE
Forms: set default value for confirmationType attribute

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-default-attributes
+++ b/projects/packages/forms/changelog/fix-forms-default-attributes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: set default value for confirmationType attribute to prevent unnecessary serialization.

--- a/projects/packages/forms/src/blocks/contact-form/attributes.ts
+++ b/projects/packages/forms/src/blocks/contact-form/attributes.ts
@@ -33,6 +33,7 @@ export default {
 	},
 	confirmationType: {
 		enum: [ 'text', 'redirect' ],
+		default: 'text',
 	},
 	jetpackCRM: {
 		type: 'boolean',

--- a/projects/packages/forms/src/blocks/contact-form/edit.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/edit.tsx
@@ -209,20 +209,16 @@ function JetpackContactFormEdit( {
 	// Older forms will have a customThankyou attribute set, but not a confirmationType attribute
 	// and not a disableSummary attribute, so we need to set it here.
 	useEffect( () => {
-		if ( confirmationType ) {
-			return;
-		}
-
-		if ( customThankyou === 'redirect' ) {
+		// Migrate redirect setting from deprecated customThankyou attribute
+		if ( customThankyou === 'redirect' && confirmationType !== 'redirect' ) {
 			setAttributes( { confirmationType: 'redirect' } );
-		} else {
-			setAttributes( { confirmationType: 'text' } );
-
-			if ( [ 'noSummary', 'message' ].includes( customThankyou ) ) {
-				setAttributes( { disableSummary: true } );
-			}
 		}
-	}, [ confirmationType, customThankyou, setAttributes ] );
+
+		// Migrate disableSummary from deprecated customThankyou attribute
+		if ( [ 'noSummary', 'message' ].includes( customThankyou ) && ! disableSummary ) {
+			setAttributes( { disableSummary: true } );
+		}
+	}, [ confirmationType, customThankyou, disableSummary, setAttributes ] );
 
 	const steps = useFormSteps( clientId );
 

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -239,7 +239,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 			'customThankyouHeading'  => self::get_default_thank_you_heading(), // The text to show above customThankyouMessage.
 			'customThankyouMessage'  => '', // The message to show when customThankyou is set to 'message'.
 			'customThankyouRedirect' => '', // The URL to redirect to when confirmationType is set to 'redirect'.
-			'confirmationType'       => null, // The type of confirmation to show after submitting a form. 'text' for a text message, 'redirect' for a redirect link.
+			'confirmationType'       => 'text', // The type of confirmation to show after submitting a form. 'text' for a text message, 'redirect' for a redirect link.
 			'jetpackCRM'             => true, // Whether Jetpack CRM should store the form submission.
 			'mailpoet'               => null,
 			'hostingerReach'         => null,
@@ -3619,13 +3619,12 @@ class Contact_Form extends Contact_Form_Shortcode {
 	 * @return string The confirmation type of the contact form.
 	 */
 	public function get_confirmation_type() {
-		$confirmation_type = $this->get_attribute( 'confirmationType' );
-
-		if ( '' === $confirmation_type ) {
-			$confirmation_type = 'redirect' === $this->get_attribute( 'customThankyou' ) ? 'redirect' : 'text';
+		// Backward compat: customThankyou 'redirect' takes precedence for old forms
+		if ( 'redirect' === $this->get_attribute( 'customThankyou' ) ) {
+			return 'redirect';
 		}
 
-		return $confirmation_type;
+		return $this->get_attribute( 'confirmationType' );
 	}
 
 	/**

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
@@ -2696,7 +2696,7 @@ class Contact_Form_Test extends BaseTestCase {
 		$expected_attributes['notificationRecipients'] = array();
 		$expected_attributes['webhooks']               = array();
 		$expected_attributes['disableSummary']         = '';
-		$expected_attributes['confirmationType']       = '';
+		$expected_attributes['confirmationType']       = 'text';
 		$expected_attributes['hostingerReach']         = '';
 		$expected_attributes['ref']                    = '';
 		$expected_attributes['formTitle']              = 'Test Form';


### PR DESCRIPTION
Set a proper default value ('text') for the `confirmationType` attribute in both JS and PHP. This ensures WordPress doesn't serialize the attribute when it matches the default, keeping block markup cleaner.

## Proposed Changes

- Added `default: 'text'` to `confirmationType` in `attributes.ts`
- Updated PHP default from `null` to `'text'` in `class-contact-form.php`
- Fixed backward compatibility logic in `edit.tsx` to only set attributes when migration is actually needed
- Simplified `get_confirmation_type()` in PHP to check `customThankyou` first for old forms

## Does this pull request change what data or activity we track or use?

No

## Testing instructions

### 1. New Form (default behavior)
- Create a new post/page and add a Contact Form block
- Check "Confirmation" settings in sidebar - should show "Text" selected
- Save the post
- Switch to Code Editor - `confirmationType` should **NOT** appear in attributes

### 2. New Form with Redirect
- Create a new form
- Change confirmation type to "Redirect link"
- Enter a redirect URL and save
- Reload and verify it persists as "Redirect link"
- Check Code Editor - `confirmationType` should appear as `"redirect"`

### 3. Old Form backward compatibility
Switch to Code Editor and paste:
```html
<!-- wp:jetpack/contact-form {"customThankyou":"redirect","customThankyouRedirect":"https://example.com"} -->
<div class="wp-block-jetpack-contact-form">
<!-- wp:jetpack/field-name {"required":true} /-->
<!-- wp:jetpack/button {"element":"button","text":"Submit"} /-->
</div>
<!-- /wp:jetpack/contact-form -->
```
- Switch back to Visual Editor
- Form settings should show "Redirect link" selected with the URL populated

### 4. Frontend submission
- Test both "Text" and "Redirect" confirmation types work correctly on frontend form submission
