### PR TITLE
Forms: add filter counts to wp-build inbox

### DIFF
--- a/projects/packages/forms/changelog/add-wp-build-forms-filter-counts
+++ b/projects/packages/forms/changelog/add-wp-build-forms-filter-counts
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Forms: add filter counts to wp-build inbox.

--- a/projects/packages/forms/routes/responses/package.json
+++ b/projects/packages/forms/routes/responses/package.json
@@ -6,6 +6,7 @@
 		"@automattic/color-studio": "4.1.0",
 		"@automattic/jetpack-analytics": "workspace:*",
 		"@automattic/jetpack-components": "workspace:*",
+		"@automattic/number-formatters": "workspace:*",
 		"@automattic/ui": "1.0.2",
 		"@tanstack/react-router": ">=1.120.5 <1.121.0",
 		"@types/react": "18.3.26",

--- a/projects/packages/forms/routes/responses/stage.tsx
+++ b/projects/packages/forms/routes/responses/stage.tsx
@@ -17,7 +17,7 @@ import { DataViews } from '@wordpress/dataviews';
 import { dateI18n } from '@wordpress/date';
 import { useMemo, useState, useCallback, useEffect } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { download, plus } from '@wordpress/icons';
 import { useParams, useSearch, useNavigate } from '@wordpress/route';
 import { Stack } from '@wordpress/ui';
@@ -170,6 +170,9 @@ function StageInner() {
 		isLoadingData,
 		totalItems,
 		totalPages,
+		totalItemsInbox,
+		totalItemsSpam,
+		totalItemsTrash,
 	} = useInboxData( { status: statusView } );
 
 	useEffect( () => {
@@ -296,9 +299,30 @@ function StageInner() {
 				id: 'folder',
 				label: __( 'Folder', 'jetpack-forms' ),
 				elements: [
-					{ label: __( 'Inbox', 'jetpack-forms' ), value: 'inbox' },
-					{ label: __( 'Spam', 'jetpack-forms' ), value: 'spam' },
-					{ label: __( 'Trash', 'jetpack-forms' ), value: 'trash' },
+					{
+						label: sprintf(
+							/* translators: %d is the number of inbox responses. */
+							__( 'Inbox (%d)', 'jetpack-forms' ),
+							totalItemsInbox ?? 0
+						),
+						value: 'inbox',
+					},
+					{
+						label: sprintf(
+							/* translators: %d is the number of spam responses. */
+							__( 'Spam (%d)', 'jetpack-forms' ),
+							totalItemsSpam ?? 0
+						),
+						value: 'spam',
+					},
+					{
+						label: sprintf(
+							/* translators: %d is the number of trash responses. */
+							__( 'Trash (%d)', 'jetpack-forms' ),
+							totalItemsTrash ?? 0
+						),
+						value: 'trash',
+					},
 				],
 				// Primary so the filter UI (and its pill) is visible by default.
 				filterBy: { operators: [ 'is' ], isPrimary: true },
@@ -441,7 +465,7 @@ function StageInner() {
 				enableSorting: false,
 			},
 		],
-		[ filterOptions ]
+		[ filterOptions, totalItemsInbox, totalItemsSpam, totalItemsTrash ]
 	);
 
 	const actions = useMemo(

--- a/projects/packages/forms/routes/responses/stage.tsx
+++ b/projects/packages/forms/routes/responses/stage.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { formatNumber } from '@automattic/number-formatters';
 import { Badge } from '@automattic/ui';
 import '@automattic/ui/style.css';
 /**
@@ -301,25 +302,25 @@ function StageInner() {
 				elements: [
 					{
 						label: sprintf(
-							/* translators: %d is the number of inbox responses. */
-							__( 'Inbox (%d)', 'jetpack-forms' ),
-							totalItemsInbox ?? 0
+							/* translators: %s is the number of inbox responses. */
+							__( 'Inbox (%s)', 'jetpack-forms' ),
+							formatNumber( totalItemsInbox ?? 0 )
 						),
 						value: 'inbox',
 					},
 					{
 						label: sprintf(
-							/* translators: %d is the number of spam responses. */
-							__( 'Spam (%d)', 'jetpack-forms' ),
-							totalItemsSpam ?? 0
+							/* translators: %s is the number of spam responses. */
+							__( 'Spam (%s)', 'jetpack-forms' ),
+							formatNumber( totalItemsSpam ?? 0 )
 						),
 						value: 'spam',
 					},
 					{
 						label: sprintf(
-							/* translators: %d is the number of trash responses. */
-							__( 'Trash (%d)', 'jetpack-forms' ),
-							totalItemsTrash ?? 0
+							/* translators: %s is the number of trash responses. */
+							__( 'Trash (%s)', 'jetpack-forms' ),
+							formatNumber( totalItemsTrash ?? 0 )
 						),
 						value: 'trash',
 					},


### PR DESCRIPTION
## Proposed changes:

We recently removed Inbox/Spam/Trash tabs in favor of filters. The tabs had counts for how many responses were in each folder. The filters did not. This updates the filters to show the counts. 

**Screenshot**
<img width="1335" height="567" alt="folder-counts" src="https://github.com/user-attachments/assets/b4b511d5-9010-4e61-9b78-eca7756fa9c8" />

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
Slack: 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->


Enable these feature flags: 

```
add_filter( 'jetpack_forms_alpha', '__return_true', 20 );
add_filter( 'jetpack_block_editor_feature_flags', 'eb_register_feature' );
function eb_register_feature( $flags ) {
    $flags['central-form-management'] = true;
    return $flags;
}
```

Test:
* Go to Jetpack > Forms (WP-Build)
* Confirm the Folder filter is applied, set to Inbox, and shows the total number of items
* Click the Folder filter pill and confirm counts show for each folder
