### PR TITLE
Forms: Improve image select field preview styling in response inspector

### DIFF
--- a/projects/packages/forms/changelog/add-forms-image-select-preview-styling
+++ b/projects/packages/forms/changelog/add-forms-image-select-preview-styling
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Image select field: improve preview styling in response inspector.

--- a/projects/packages/forms/src/dashboard/components/inspector/response-fields/field-image-select/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/inspector/response-fields/field-image-select/index.tsx
@@ -31,7 +31,7 @@ function photonSafeUrl( url: string = '' ): string | null {
 		return url;
 	}
 
-	return photon( url.split( '?', 1 )[ 0 ], { width: 120, height: 120 } );
+	return photon( url.split( '?', 1 )[ 0 ], { width: 138, height: 144 } );
 }
 
 const ImageSelectButton = ( { choice, handleFilePreview } ) => {

--- a/projects/packages/forms/src/dashboard/components/inspector/response-fields/field-image-select/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/inspector/response-fields/field-image-select/index.tsx
@@ -51,15 +51,15 @@ const ImageSelectButton2 = ( { choice, handleFilePreview } ) => {
 			className={ `jp-forms__image-select-preview ${ hasImage ? 'has-image' : '' }` }
 		>
 			<CardMedia>
-				<div className="jp-forms__image-select-preview-image" style={ { padding: '8px' } }>
+				<div className="jp-forms__image-select-preview-image-wrapper">
 					{ hasImage ? (
 						<img
+							className="jp-forms__image-select-preview-image"
 							width={ 138 }
 							height={ 144 }
 							alt={ choice.selected }
 							loading="lazy"
 							src={ photonSafeUrl( choice.image.src ) }
-							style={ { objectFit: 'cover' } }
 						/>
 					) : (
 						<Icon icon={ imageIcon } size={ 144 } />

--- a/projects/packages/forms/src/dashboard/components/inspector/response-fields/field-image-select/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/inspector/response-fields/field-image-select/index.tsx
@@ -59,7 +59,7 @@ const ImageSelectButton = ( { choice, handleFilePreview } ) => {
 							height={ 144 }
 							alt={ choice.selected }
 							loading="lazy"
-							src={ photonSafeUrl( choice.image.src ) }
+							src={ photonSafeUrl( choice.image.src ) ?? undefined }
 						/>
 					) : (
 						<Icon icon={ imageIcon } size={ 144 } />

--- a/projects/packages/forms/src/dashboard/components/inspector/response-fields/field-image-select/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/inspector/response-fields/field-image-select/index.tsx
@@ -80,7 +80,9 @@ const ImageSelectButton = ( { choice, handleFilePreview } ) => {
 					alignment="topLeft"
 				>
 					<Text className="jp-forms__image-select-preview-selected">{ choice.selected }</Text>
-					<Text className="jp-forms__image-select-preview-label">{ choice.label }</Text>
+					<Text title={ choice.label } className="jp-forms__image-select-preview-label">
+						{ choice.label }
+					</Text>
 				</HStack>
 			</CardBody>
 		</Card>

--- a/projects/packages/forms/src/dashboard/components/inspector/response-fields/field-image-select/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/inspector/response-fields/field-image-select/index.tsx
@@ -1,8 +1,11 @@
 import { isWoASite } from '@automattic/jetpack-script-data';
 import { isPrivateSite } from '@automattic/jetpack-shared-extension-utils/site-type-utils';
 import {
-	Button,
 	Icon,
+	Card,
+	CardMedia,
+	CardBody,
+	__experimentalText as Text, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 	__experimentalHStack as HStack, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 } from '@wordpress/components';
 import { image as imageIcon } from '@wordpress/icons';
@@ -31,47 +34,72 @@ function photonSafeUrl( url: string = '' ): string | null {
 	return photon( url.split( '?', 1 )[ 0 ], { width: 120, height: 120 } );
 }
 
+const ImageSelectButton2 = ( { choice, handleFilePreview } ) => {
+	const label = choice.label ? `${ choice.selected }: ${ choice.label }` : choice.selected;
+	const hasImage = choice.image?.src;
+	return (
+		<Card
+			onClick={
+				hasImage
+					? handleFilePreview( {
+							file_id: choice.image.id,
+							name: label,
+							url: choice.image.src,
+					  } )
+					: undefined
+			}
+			className={ `jp-forms__image-select-preview ${ hasImage ? 'has-image' : '' }` }
+		>
+			<CardMedia>
+				<div className="jp-forms__image-select-preview-image" style={ { padding: '8px' } }>
+					{ hasImage ? (
+						<img
+							width={ 138 }
+							height={ 144 }
+							alt={ choice.selected }
+							loading="lazy"
+							src={ photonSafeUrl( choice.image.src ) }
+							style={ { objectFit: 'cover' } }
+						/>
+					) : (
+						<Icon icon={ imageIcon } size={ 144 } />
+					) }
+				</div>
+			</CardMedia>
+			<CardBody
+				size={ {
+					blockStart: 'none',
+					blockEnd: 'xSmall',
+					inlineStart: 'xSmall',
+					inlineEnd: 'xSmall',
+				} }
+			>
+				<HStack
+					className="jp-forms__image-select-preview-label-wrapper"
+					spacing="2"
+					alignment="topLeft"
+				>
+					<Text className="jp-forms__image-select-preview-selected">{ choice.selected }</Text>
+					<Text className="jp-forms__image-select-preview-label">{ choice.label }</Text>
+				</HStack>
+			</CardBody>
+		</Card>
+	);
+};
+
 const FieldImageSelect = ( { choices, handleFilePreview } ) => {
 	return (
 		<>
 			{ ( choices?.length ?? 0 ) === 0 && '-' }
 			{ ( choices?.length ?? 0 ) > 0 && (
-				<HStack spacing="1" alignment="topLeft" wrap="wrap">
+				<HStack spacing="2" alignment="topLeft" wrap={ true }>
 					{ choices.map( choice => {
-						const label = choice.label
-							? `${ choice.selected }: ${ choice.label }`
-							: choice.selected;
-						const hasImage = choice.image?.src;
 						return (
-							<Button
-								__next40pxDefaultSize
+							<ImageSelectButton2
 								key={ choice.selected }
-								variant="secondary"
-								onClick={
-									hasImage
-										? handleFilePreview( {
-												file_id: choice.image.id,
-												name: label,
-												url: choice.image.src,
-										  } )
-										: undefined
-								}
-								className="jp-forms__image-select-field-button"
-							>
-								{ hasImage ? (
-									<img
-										width={ 138 }
-										height={ 144 }
-										alt={ choice.selected }
-										loading="lazy"
-										src={ photonSafeUrl( choice.image.src ) }
-										style={ { objectFit: 'cover' } }
-									/>
-								) : (
-									<Icon icon={ imageIcon } size={ 144 } />
-								) }
-								<span className="jp-forms__image-select-field-button-label">{ label }</span>
-							</Button>
+								choice={ choice }
+								handleFilePreview={ handleFilePreview }
+							/>
 						);
 					} ) }
 				</HStack>

--- a/projects/packages/forms/src/dashboard/components/inspector/response-fields/field-image-select/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/inspector/response-fields/field-image-select/index.tsx
@@ -34,7 +34,7 @@ function photonSafeUrl( url: string = '' ): string | null {
 	return photon( url.split( '?', 1 )[ 0 ], { width: 120, height: 120 } );
 }
 
-const ImageSelectButton2 = ( { choice, handleFilePreview } ) => {
+const ImageSelectButton = ( { choice, handleFilePreview } ) => {
 	const label = choice.label ? `${ choice.selected }: ${ choice.label }` : choice.selected;
 	const hasImage = choice.image?.src;
 	return (
@@ -92,10 +92,15 @@ const FieldImageSelect = ( { choices, handleFilePreview } ) => {
 		<>
 			{ ( choices?.length ?? 0 ) === 0 && '-' }
 			{ ( choices?.length ?? 0 ) > 0 && (
-				<HStack spacing="2" alignment="topLeft" wrap={ true }>
+				<HStack
+					spacing="2"
+					alignment="topLeft"
+					wrap={ true }
+					className="jp-forms__image-select-preview-wrapper"
+				>
 					{ choices.map( choice => {
 						return (
-							<ImageSelectButton2
+							<ImageSelectButton
 								key={ choice.selected }
 								choice={ choice }
 								handleFilePreview={ handleFilePreview }

--- a/projects/packages/forms/src/dashboard/components/inspector/response-fields/field-image-select/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/inspector/response-fields/field-image-select/index.tsx
@@ -2,7 +2,8 @@ import { isWoASite } from '@automattic/jetpack-script-data';
 import { isPrivateSite } from '@automattic/jetpack-shared-extension-utils/site-type-utils';
 import {
 	Button,
-	__experimentalVStack as VStack, // eslint-disable-line @wordpress/no-unsafe-wp-apis
+	Icon,
+	__experimentalHStack as HStack, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 } from '@wordpress/components';
 import { image as imageIcon } from '@wordpress/icons';
 import photon from 'photon';
@@ -35,7 +36,7 @@ const FieldImageSelect = ( { choices, handleFilePreview } ) => {
 		<>
 			{ ( choices?.length ?? 0 ) === 0 && '-' }
 			{ ( choices?.length ?? 0 ) > 0 && (
-				<VStack spacing="1">
+				<HStack spacing="1" alignment="topLeft" wrap="wrap">
 					{ choices.map( choice => {
 						const label = choice.label
 							? `${ choice.selected }: ${ choice.label }`
@@ -45,7 +46,7 @@ const FieldImageSelect = ( { choices, handleFilePreview } ) => {
 							<Button
 								__next40pxDefaultSize
 								key={ choice.selected }
-								variant="tertiary"
+								variant="secondary"
 								onClick={
 									hasImage
 										? handleFilePreview( {
@@ -56,25 +57,24 @@ const FieldImageSelect = ( { choices, handleFilePreview } ) => {
 										: undefined
 								}
 								className="jp-forms__image-select-field-button"
-								icon={
-									hasImage ? (
-										<img
-											alt={ choice.selected }
-											loading="lazy"
-											src={ photonSafeUrl( choice.image.src ) }
-											style={ { objectFit: 'cover' } }
-										/>
-									) : (
-										imageIcon
-									)
-								}
-								iconSize={ 60 }
 							>
-								{ label }
+								{ hasImage ? (
+									<img
+										width={ 138 }
+										height={ 144 }
+										alt={ choice.selected }
+										loading="lazy"
+										src={ photonSafeUrl( choice.image.src ) }
+										style={ { objectFit: 'cover' } }
+									/>
+								) : (
+									<Icon icon={ imageIcon } size={ 144 } />
+								) }
+								<span className="jp-forms__image-select-field-button-label">{ label }</span>
 							</Button>
 						);
 					} ) }
-				</VStack>
+				</HStack>
 			) }
 		</>
 	);

--- a/projects/packages/forms/src/dashboard/components/inspector/response-fields/field-image-select/style.scss
+++ b/projects/packages/forms/src/dashboard/components/inspector/response-fields/field-image-select/style.scss
@@ -1,16 +1,32 @@
 @use "@wordpress/base-styles/variables";
 
-.jp-forms__image-select-field-button.components-button {
-	height: auto;
-	text-align: left;
-	text-wrap: auto;
+.jp-forms__image-select-preview {
+	// Without display: block, image/svg will display a blank space.
+	img,
+	svg {
+		display: block;
+	}
 
-	padding: variables.$grid-unit-10;
-	flex-direction: column;
-	align-items: flex-start;
-	gap: variables.$grid-unit-10;
+	&.has-image {
+		cursor: pointer;
 
-	.jp-forms__image-select-field-button-label {
+	}
+
+	.jp-forms__image-select-preview-label-wrapper {
 		max-width: 138px; // Same as the image width
+		align-items: baseline;
+
+		.jp-forms__image-select-preview-selected {
+			flex-shrink: 0;
+			box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.1);
+			border-radius: 2px;
+			padding: 4px;
+			min-width: 1em;
+			text-align: center;
+		}
+
+		.jp-forms__image-select-preview-label {
+			flex-grow: 1;
+		}
 	}
 }

--- a/projects/packages/forms/src/dashboard/components/inspector/response-fields/field-image-select/style.scss
+++ b/projects/packages/forms/src/dashboard/components/inspector/response-fields/field-image-select/style.scss
@@ -20,6 +20,7 @@
 			background-color: var(--jp-forms--image-select-border-color);
 		}
 	}
+
 	.jp-forms__image-select-preview-image-wrapper {
 		padding: 8px;
 

--- a/projects/packages/forms/src/dashboard/components/inspector/response-fields/field-image-select/style.scss
+++ b/projects/packages/forms/src/dashboard/components/inspector/response-fields/field-image-select/style.scss
@@ -12,6 +12,14 @@
 
 	}
 
+	.jp-forms__image-select-preview-image-wrapper {
+		padding: 8px;
+
+		.jp-forms__image-select-preview-image {
+			object-fit: cover;
+		}
+	}
+
 	.jp-forms__image-select-preview-label-wrapper {
 		max-width: 138px; // Same as the image width
 		align-items: baseline;

--- a/projects/packages/forms/src/dashboard/components/inspector/response-fields/field-image-select/style.scss
+++ b/projects/packages/forms/src/dashboard/components/inspector/response-fields/field-image-select/style.scss
@@ -5,7 +5,7 @@
 	text-align: left;
 	text-wrap: auto;
 
-	padding: 8px;
+	padding: variables.$grid-unit-10;
 	flex-direction: column;
 	align-items: flex-start;
 	gap: variables.$grid-unit-10;

--- a/projects/packages/forms/src/dashboard/components/inspector/response-fields/field-image-select/style.scss
+++ b/projects/packages/forms/src/dashboard/components/inspector/response-fields/field-image-select/style.scss
@@ -16,12 +16,10 @@
 	&.has-image {
 		cursor: pointer;
 
+		&:hover {
+			background-color: var(--jp-forms--image-select-border-color);
+		}
 	}
-
-	&:hover {
-		background-color: var(--jp-forms--image-select-border-color);
-	}
-
 	.jp-forms__image-select-preview-image-wrapper {
 		padding: 8px;
 

--- a/projects/packages/forms/src/dashboard/components/inspector/response-fields/field-image-select/style.scss
+++ b/projects/packages/forms/src/dashboard/components/inspector/response-fields/field-image-select/style.scss
@@ -5,7 +5,12 @@
 	text-align: left;
 	text-wrap: auto;
 
-	&.has-icon.has-text {
-		gap: variables.$grid-unit-10;
+	padding: 8px;
+	flex-direction: column;
+	align-items: flex-start;
+	gap: variables.$grid-unit-10;
+
+	.jp-forms__image-select-field-button-label {
+		max-width: 138px; // Same as the image width
 	}
 }

--- a/projects/packages/forms/src/dashboard/components/inspector/response-fields/field-image-select/style.scss
+++ b/projects/packages/forms/src/dashboard/components/inspector/response-fields/field-image-select/style.scss
@@ -39,6 +39,9 @@
 
 		.jp-forms__image-select-preview-label {
 			flex-grow: 1;
+			overflow: hidden;
+			text-overflow: ellipsis;
+			white-space: nowrap;
 		}
 	}
 }

--- a/projects/packages/forms/src/dashboard/components/inspector/response-fields/field-image-select/style.scss
+++ b/projects/packages/forms/src/dashboard/components/inspector/response-fields/field-image-select/style.scss
@@ -1,5 +1,9 @@
 @use "@wordpress/base-styles/variables";
 
+.jp-forms__image-select-preview-wrapper {
+	padding-block-start: 8px;
+}
+
 .jp-forms__image-select-preview {
 	// Without display: block, image/svg will display a blank space.
 	img,

--- a/projects/packages/forms/src/dashboard/components/inspector/response-fields/field-image-select/style.scss
+++ b/projects/packages/forms/src/dashboard/components/inspector/response-fields/field-image-select/style.scss
@@ -1,7 +1,9 @@
 @use "@wordpress/base-styles/colors";
+@use "@wordpress/base-styles/variables";
+
 
 .jp-forms__image-select-preview-wrapper {
-	padding-block-start: 8px;
+	padding-block-start: variables.$grid-unit-10;
 }
 
 .jp-forms__image-select-preview {

--- a/projects/packages/forms/src/dashboard/components/inspector/response-fields/field-image-select/style.scss
+++ b/projects/packages/forms/src/dashboard/components/inspector/response-fields/field-image-select/style.scss
@@ -1,10 +1,12 @@
-@use "@wordpress/base-styles/variables";
+@use "@wordpress/base-styles/colors";
 
 .jp-forms__image-select-preview-wrapper {
 	padding-block-start: 8px;
 }
 
 .jp-forms__image-select-preview {
+	--jp-forms--image-select-border-color: rgba(0, 0, 0, 0.1);
+
 	// Without display: block, image/svg will display a blank space.
 	img,
 	svg {
@@ -14,6 +16,10 @@
 	&.has-image {
 		cursor: pointer;
 
+	}
+
+	&:hover {
+		background-color: var(--jp-forms--image-select-border-color);
 	}
 
 	.jp-forms__image-select-preview-image-wrapper {
@@ -30,11 +36,13 @@
 
 		.jp-forms__image-select-preview-selected {
 			flex-shrink: 0;
-			box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.1);
+			box-shadow: 0 0 0 1px var(--jp-forms--image-select-border-color);
 			border-radius: 2px;
 			padding: 4px;
 			min-width: 1em;
 			text-align: center;
+			background-color: colors.$white;
+			color: colors.$black;
 		}
 
 		.jp-forms__image-select-preview-label {


### PR DESCRIPTION
## Proposed changes:

Improve the styling of image select field previews in the response inspector:

* Change layout from vertical (`VStack`) to horizontal wrapping (`HStack` with `wrap`)
* Update button variant from `tertiary` to `secondary` for better visibility
* Move image rendering from button `icon` prop to button children for better control
* Add fixed dimensions for images (138x144) and matching max-width for labels
* Improve button padding and flex layout for consistent alignment

| Before | After |
|--------|--------|
| <img width="436" height="329" alt="image" src="https://github.com/user-attachments/assets/29eee6af-f878-4aa5-811c-3a13cdda7340" /> | <img width="458" height="508" alt="image" src="https://github.com/user-attachments/assets/86244da1-0808-43bb-b25e-bfafb6f14db6" /> | 




### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
8TmDfrB54NU4Rzj19Qs9Tg-fi-4930_75534

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

1. Create a form with an Image Select field
2. Submit a response selecting one or more images
3. Go to Forms > Responses and click on the submission
4. Verify the image select field previews display correctly with:
   - Horizontal layout with wrapping
   - Proper image sizing
   - Labels aligned below images
   - Clickable images open preview modal