### PR TITLE
Forms: format numbers consistently in response action messages

### DIFF
--- a/projects/packages/forms/changelog/update-forms-response-actions-number-formatting
+++ b/projects/packages/forms/changelog/update-forms-response-actions-number-formatting
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Format numbers consistently in response action messages using formatNumber() for proper locale-specific formatting (e.g., thousands separators) in all sprintf calls with _n() pluralization.

--- a/projects/packages/forms/routes/responses/actions.tsx
+++ b/projects/packages/forms/routes/responses/actions.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import jetpackAnalytics from '@automattic/jetpack-analytics';
+import { formatNumber } from '@automattic/number-formatters';
 import apiFetch from '@wordpress/api-fetch';
 import { Icon, Spinner } from '@wordpress/components';
 import { store as coreStore } from '@wordpress/core-data';
@@ -129,14 +130,14 @@ const getGenericErrorMessage = ( numberOfErrors: number ): string => {
 	return numberOfErrors === 1
 		? __( 'An error occurred.', 'jetpack-forms' )
 		: sprintf(
-				/* translators: %d: the number of responses. */
+				/* translators: %s: the number of responses. */
 				_n(
-					'An error occurred for %d response.',
-					'An error occurred for %d responses.',
+					'An error occurred for %s response.',
+					'An error occurred for %s responses.',
 					numberOfErrors,
 					'jetpack-forms'
 				),
-				numberOfErrors
+				formatNumber( numberOfErrors )
 		  );
 };
 
@@ -381,14 +382,14 @@ export function getActions( {
 			const busyMessage = isUndo
 				? undoingMessage
 				: sprintf(
-						/* translators: %d: the number of responses. */
+						/* translators: %s: the number of responses. */
 						_n(
-							'Moving %d response to spam…',
-							'Moving %d responses to spam…',
+							'Moving %s response to spam…',
+							'Moving %s responses to spam…',
 							items.length,
 							'jetpack-forms'
 						),
-						items.length
+						formatNumber( items.length )
 				  );
 
 			createInfoNotice( busyMessage, {
@@ -431,14 +432,14 @@ export function getActions( {
 						items.length === 1
 							? __( 'Response marked as spam.', 'jetpack-forms' )
 							: sprintf(
-									/* translators: %d: the number of responses. */
+									/* translators: %s: the number of responses. */
 									_n(
-										'%d response marked as spam.',
-										'%d responses marked as spam.',
+										'%s response marked as spam.',
+										'%s responses marked as spam.',
 										items.length,
 										'jetpack-forms'
 									),
-									items.length
+									formatNumber( items.length )
 							  );
 
 					if ( ! isUndo ) {
@@ -521,14 +522,14 @@ export function getActions( {
 			const busyMessage = isUndo
 				? undoingMessage
 				: sprintf(
-						/* translators: %d: the number of responses. */
+						/* translators: %s: the number of responses. */
 						_n(
-							'Marking %d response as not spam…',
-							'Marking %d responses as not spam…',
+							'Marking %s response as not spam…',
+							'Marking %s responses as not spam…',
 							items.length,
 							'jetpack-forms'
 						),
-						items.length
+						formatNumber( items.length )
 				  );
 
 			createInfoNotice( busyMessage, {
@@ -566,14 +567,14 @@ export function getActions( {
 						items.length === 1
 							? __( 'Response marked as not spam.', 'jetpack-forms' )
 							: sprintf(
-									/* translators: %d: the number of responses. */
+									/* translators: %s: the number of responses. */
 									_n(
-										'%d response marked as not spam.',
-										'%d responses marked as not spam.',
+										'%s response marked as not spam.',
+										'%s responses marked as not spam.',
 										items.length,
 										'jetpack-forms'
 									),
-									items.length
+									formatNumber( items.length )
 							  );
 
 					if ( ! isUndo ) {
@@ -654,14 +655,14 @@ export function getActions( {
 			const busyMessage = isUndo
 				? undoingMessage
 				: sprintf(
-						/* translators: %d: the number of responses. */
+						/* translators: %s: the number of responses. */
 						_n(
-							'Restoring %d response…',
-							'Restoring %d responses…',
+							'Restoring %s response…',
+							'Restoring %s responses…',
 							items.length,
 							'jetpack-forms'
 						),
-						items.length
+						formatNumber( items.length )
 				  );
 
 			createInfoNotice( busyMessage, {
@@ -698,14 +699,14 @@ export function getActions( {
 						items.length === 1
 							? __( 'Response restored.', 'jetpack-forms' )
 							: sprintf(
-									/* translators: %d: the number of responses. */
+									/* translators: %s: the number of responses. */
 									_n(
-										'%d response restored.',
-										'%d responses restored.',
+										'%s response restored.',
+										'%s responses restored.',
 										items.length,
 										'jetpack-forms'
 									),
-									items.length
+									formatNumber( items.length )
 							  );
 
 					if ( ! isUndo ) {
@@ -782,14 +783,14 @@ export function getActions( {
 			const busyMessage = isUndo
 				? undoingMessage
 				: sprintf(
-						/* translators: %d: the number of responses. */
+						/* translators: %s: the number of responses. */
 						_n(
-							'Moving %d response to trash…',
-							'Moving %d responses to trash…',
+							'Moving %s response to trash…',
+							'Moving %s responses to trash…',
 							items.length,
 							'jetpack-forms'
 						),
-						items.length
+						formatNumber( items.length )
 				  );
 
 			createInfoNotice( busyMessage, {
@@ -830,14 +831,14 @@ export function getActions( {
 						items.length === 1
 							? __( 'Response moved to trash.', 'jetpack-forms' )
 							: sprintf(
-									/* translators: %d: the number of responses. */
+									/* translators: %s: the number of responses. */
 									_n(
-										'%d response moved to trash.',
-										'%d responses moved to trash.',
+										'%s response moved to trash.',
+										'%s responses moved to trash.',
 										items.length,
 										'jetpack-forms'
 									),
-									items.length
+									formatNumber( items.length )
 							  );
 
 					if ( ! isUndo ) {
@@ -939,14 +940,14 @@ export function getActions( {
 					items.length === 1
 						? __( 'Response deleted permanently.', 'jetpack-forms' )
 						: sprintf(
-								/* translators: %d: the number of responses. */
+								/* translators: %s: the number of responses. */
 								_n(
-									'%d response deleted permanently.',
-									'%d responses deleted permanently.',
+									'%s response deleted permanently.',
+									'%s responses deleted permanently.',
 									items.length,
 									'jetpack-forms'
 								),
-								items.length
+								formatNumber( items.length )
 						  );
 
 				createSuccessNotice( successMessage, { type: 'snackbar', id: 'delete-action' } );
@@ -1064,14 +1065,14 @@ export function getActions( {
 					items.length === 1
 						? __( 'Response marked as read.', 'jetpack-forms' )
 						: sprintf(
-								/* translators: %d: the number of responses. */
+								/* translators: %s: the number of responses. */
 								_n(
-									'%d response marked as read.',
-									'%d responses marked as read.',
+									'%s response marked as read.',
+									'%s responses marked as read.',
 									items.length,
 									'jetpack-forms'
 								),
-								items.length
+								formatNumber( items.length )
 						  );
 
 				createSuccessNotice( successMessage, {
@@ -1173,14 +1174,14 @@ export function getActions( {
 					items.length === 1
 						? __( 'Response marked as unread.', 'jetpack-forms' )
 						: sprintf(
-								/* translators: %d: the number of responses. */
+								/* translators: %s: the number of responses. */
 								_n(
-									'%d response marked as unread.',
-									'%d responses marked as unread.',
+									'%s response marked as unread.',
+									'%s responses marked as unread.',
 									items.length,
 									'jetpack-forms'
 								),
-								items.length
+								formatNumber( items.length )
 						  );
 
 				createSuccessNotice( successMessage, {

--- a/projects/packages/forms/routes/responses/package.json
+++ b/projects/packages/forms/routes/responses/package.json
@@ -6,6 +6,7 @@
 		"@automattic/color-studio": "4.1.0",
 		"@automattic/jetpack-analytics": "workspace:*",
 		"@automattic/jetpack-components": "workspace:*",
+		"@automattic/number-formatters": "workspace:*",
 		"@automattic/ui": "1.0.2",
 		"@tanstack/react-router": ">=1.120.5 <1.121.0",
 		"@types/react": "18.3.26",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Format numbers consistently in response action messages using formatNumber() for proper locale-specific formatting (e.g., thousands separators) in all sprintf calls with _n() pluralization.

Basically just re-applies older PR https://github.com/Automattic/jetpack/pull/45326

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Enable wp build dash with `add_filter('jetpack_forms_alpha', '__return_true');`
* Notices in wp-buld dashboard work.

