### PR TITLE
Forms: format number field

### DIFF
--- a/projects/packages/forms/changelog/update-forms-field-preview-number-formatting
+++ b/projects/packages/forms/changelog/update-forms-field-preview-number-formatting
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Format number field values in the response field preview component using formatNumber() for proper locale-specific formatting (e.g., thousands separators).

--- a/projects/packages/forms/src/dashboard/components/inspector/response-fields/field-preview/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/inspector/response-fields/field-preview/index.tsx
@@ -158,7 +158,7 @@ const FieldPreview = ( { field, onFilePreview }: FieldPreviewProps ) => {
 
 		// Numbers
 		if ( fieldType === 'number' ) {
-			return formatNumber( stringValue );
+			return formatNumber( Number( stringValue ) );
 		}
 
 		// Emails

--- a/projects/packages/forms/src/dashboard/components/inspector/response-fields/field-preview/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/inspector/response-fields/field-preview/index.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { formatNumber } from '@automattic/number-formatters';
 import { Badge } from '@automattic/ui';
 import {
 	ExternalLink,
@@ -153,6 +154,11 @@ const FieldPreview = ( { field, onFilePreview }: FieldPreviewProps ) => {
 		const badgedValueFields = [ 'consent', 'checkbox', 'radio', 'select' ];
 		if ( badgedValueFields.includes( fieldType ) ) {
 			return <Badge>{ stringValue }</Badge>;
+		}
+
+		// Numbers
+		if ( fieldType === 'number' ) {
+			return formatNumber( stringValue );
 		}
 
 		// Emails


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->



## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Before
<img width="416" height="119" alt="image" src="https://github.com/user-attachments/assets/4ba28c7d-1124-48f3-ac36-f35d5230bfba" />

After
<img width="403" height="118" alt="image" src="https://github.com/user-attachments/assets/cc77e6cd-03e6-4e6c-aaf9-e00c87a8559a" />


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->


Fill form with numbers.
Use site with locale set to US or some other locale that formats large numbers.