### PR TITLE
Forms: simplify label rendering for form responses

### DIFF
--- a/projects/packages/forms/changelog/update-forms-simplify-label-format
+++ b/projects/packages/forms/changelog/update-forms-simplify-label-format
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Simplify labels for form responses.

--- a/projects/packages/forms/src/dashboard/components/inspector/response-fields/field-preview/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/inspector/response-fields/field-preview/index.tsx
@@ -172,21 +172,6 @@ const FieldPreview = ( { field, onFilePreview }: FieldPreviewProps ) => {
 		return stringValue;
 	};
 
-	const renderLabel = () => {
-		// If the label ends with a colon or question mark,
-		// return it as is to avoid adding a colon or question mark
-		if ( label.endsWith( ':' ) || label.endsWith( '?' ) ) {
-			return label;
-		}
-
-		if ( fieldType === 'consent' && label.endsWith( '.' ) ) {
-			return `${ label.slice( 0, -1 ) }:`;
-		}
-
-		// Default to adding a colon to the label
-		return `${ label }:`;
-	};
-
 	return (
 		<HStack
 			alignment="topLeft"
@@ -195,7 +180,7 @@ const FieldPreview = ( { field, onFilePreview }: FieldPreviewProps ) => {
 		>
 			<div className="jp-forms__field-preview-icon">{ icon }</div>
 			<VStack spacing="0" className="jp-forms__field-preview-content">
-				<div className="jp-forms__field-preview-label">{ renderLabel() }</div>
+				{ label && <div className="jp-forms__field-preview-label">{ label }</div> }
 				<div className="jp-forms__field-preview-value">{ renderFieldValue() }</div>
 			</VStack>
 		</HStack>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Remove all fancy `:` adding/not-adding; just render labels as-is.

Previously, we tried to see if we could add `:` to the label, depending on whether there is `?` or `:`, and remove `. 's, etc.

Before

<img width="415" height="400" alt="image" src="https://github.com/user-attachments/assets/73c95e86-f5d9-416b-b507-ea3e9b6c7b63" />

After

<img width="327" height="409" alt="image" src="https://github.com/user-attachments/assets/e9718aa8-54fa-4744-b9ba-2117cb865912" />


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* See form responses
* Try fields without labels (not actually sure if it's possible)
* Try end labels with :, . and ?
* Try concent field