### PR TITLE
Forms: Display star rating icons in response inspector

### DIFF
--- a/projects/packages/forms/changelog/add-forms-field-rating-preview
+++ b/projects/packages/forms/changelog/add-forms-field-rating-preview
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Response inspector: display star rating icons for rating field submissions.

--- a/projects/packages/forms/src/blocks/field-rating/edit.js
+++ b/projects/packages/forms/src/blocks/field-rating/edit.js
@@ -4,9 +4,10 @@ import {
 	RangeControl,
 } from '@wordpress/components';
 import { useCallback } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import JetpackFieldControls from '../shared/components/jetpack-field-controls.js';
 import useFormWrapper from '../shared/hooks/use-form-wrapper.js';
+import { MAX_RATING_ICONS } from './rating-icons.js';
 
 /**
  * Rating Field Edit Component
@@ -25,7 +26,7 @@ export default function RatingFieldEdit( props ) {
 
 	// Direct update functions for rating attributes
 	const updateMax = newMax => {
-		const validatedMax = Math.min( Math.max( parseInt( newMax ) || 5, 2 ), 10 );
+		const validatedMax = Math.min( Math.max( parseInt( newMax ) || 5, 2 ), MAX_RATING_ICONS );
 		const validatedDefault = Math.min( defaultValue, validatedMax );
 		setAttributes( {
 			max: validatedMax,
@@ -91,9 +92,13 @@ export default function RatingFieldEdit( props ) {
 								<NumberControl
 									__next40pxDefaultSize
 									__unstableInputWidth="50%"
-									help={ __( 'Highest rating users can select (2–10).', 'jetpack-forms' ) }
+									help={ sprintf(
+										/* translators: %d: maximum rating value (e.g. 10) */
+										__( 'Highest rating users can select (2–%d).', 'jetpack-forms' ),
+										MAX_RATING_ICONS
+									) }
 									label={ __( 'Maximum rating', 'jetpack-forms' ) }
-									max={ 10 }
+									max={ MAX_RATING_ICONS }
 									min={ 2 }
 									onChange={ updateMax }
 									spinControls="custom"

--- a/projects/packages/forms/src/blocks/field-rating/rating-icon.js
+++ b/projects/packages/forms/src/blocks/field-rating/rating-icon.js
@@ -1,0 +1,26 @@
+import { SVG, Path } from '@wordpress/components';
+import { RATING_ICONS } from './rating-icons.js';
+
+/**
+ * Rating icon React component for use in the block editor and dashboard.
+ *
+ * @param {object} props             - Component props.
+ * @param {string} props.iconStyle   - The icon style ('stars' or 'hearts').
+ * @param {string} props.strokeColor - SVG stroke color.
+ * @param {string} props.fillColor   - SVG fill color.
+ * @return {import('react').JSX.Element} SVG icon element.
+ */
+export const RatingIcon = ( { iconStyle, strokeColor = 'currentColor', fillColor = 'none' } ) => {
+	const iconPath = RATING_ICONS[ iconStyle ] || RATING_ICONS.stars;
+	return (
+		<SVG className="jetpack-field-rating__icon" viewBox="0 0 24 24" aria-hidden="true">
+			<Path
+				d={ iconPath }
+				fill={ fillColor }
+				stroke={ strokeColor }
+				strokeWidth="2"
+				strokeLinejoin="round"
+			/>
+		</SVG>
+	);
+};

--- a/projects/packages/forms/src/blocks/field-rating/rating-icon.js
+++ b/projects/packages/forms/src/blocks/field-rating/rating-icon.js
@@ -8,9 +8,15 @@ import { RATING_ICONS } from './rating-icons.js';
  * @param {string} props.iconStyle   - The icon style ('stars' or 'hearts').
  * @param {string} props.strokeColor - SVG stroke color.
  * @param {string} props.fillColor   - SVG fill color.
+ * @param {number} props.strokeWidth - SVG stroke width.
  * @return {import('react').JSX.Element} SVG icon element.
  */
-export const RatingIcon = ( { iconStyle, strokeColor = 'currentColor', fillColor = 'none' } ) => {
+export const RatingIcon = ( {
+	iconStyle,
+	strokeColor = 'currentColor',
+	fillColor = 'none',
+	strokeWidth = 2,
+} ) => {
 	const iconPath = RATING_ICONS[ iconStyle ] || RATING_ICONS.stars;
 	return (
 		<SVG className="jetpack-field-rating__icon" viewBox="0 0 24 24" aria-hidden="true">
@@ -18,7 +24,7 @@ export const RatingIcon = ( { iconStyle, strokeColor = 'currentColor', fillColor
 				d={ iconPath }
 				fill={ fillColor }
 				stroke={ strokeColor }
-				strokeWidth="2"
+				strokeWidth={ strokeWidth }
 				strokeLinejoin="round"
 			/>
 		</SVG>

--- a/projects/packages/forms/src/blocks/field-rating/rating-icons.js
+++ b/projects/packages/forms/src/blocks/field-rating/rating-icons.js
@@ -1,4 +1,10 @@
 /**
+ * Maximum number of rating icons to render.
+ * Used to prevent DOM bloat from malformed or excessively large values.
+ */
+export const MAX_RATING_ICONS = 10;
+
+/**
  * Rating icon SVG paths.
  * Single source of truth for star and heart icon paths used across the forms package.
  */

--- a/projects/packages/forms/src/blocks/input-rating/edit.js
+++ b/projects/packages/forms/src/blocks/input-rating/edit.js
@@ -3,6 +3,21 @@ import { SVG, Path } from '@wordpress/components';
 import { RATING_ICONS } from '../field-rating/rating-icons.js';
 import useInsertAfterOnEnterKeyDown from '../shared/hooks/use-insert-after-on-enter-key-down.js';
 
+export const RatingIcon = ( { iconStyle, strokeColor = 'currentColor', fillColor = 'none' } ) => {
+	const iconPath = RATING_ICONS[ iconStyle ] || RATING_ICONS.stars;
+	return (
+		<SVG className="jetpack-field-rating__icon" viewBox="0 0 24 24" aria-hidden="true">
+			<Path
+				d={ iconPath }
+				fill={ fillColor }
+				stroke={ strokeColor }
+				strokeWidth="2"
+				strokeLinejoin="round"
+			/>
+		</SVG>
+	);
+};
+
 export default function RatingInputEdit( { context, clientId } ) {
 	const max = context?.[ 'jetpack/field-rating-max' ] || 5;
 	const defaultValue = context?.[ 'jetpack/field-rating-default' ] || 0;
@@ -11,21 +26,6 @@ export default function RatingInputEdit( { context, clientId } ) {
 	const onKeyDown = useInsertAfterOnEnterKeyDown( clientId );
 
 	// Color and other support classes are injected by useBlockProps
-
-	// Get icon SVG based on iconStyle (default: stars)
-	const iconPath = RATING_ICONS[ iconStyle ] || RATING_ICONS.stars;
-	const iconSvg = (
-		<SVG className="jetpack-field-rating__icon" viewBox="0 0 24 24" aria-hidden="true">
-			<Path
-				d={ iconPath }
-				fill="none"
-				stroke="currentColor"
-				strokeWidth="2"
-				strokeLinejoin="round"
-			></Path>
-		</SVG>
-	);
-
 	const blockProps = useBlockProps( {
 		className: 'jetpack-field-rating__options',
 	} );
@@ -51,7 +51,7 @@ export default function RatingInputEdit( { context, clientId } ) {
 					onKeyDown={ onKeyDown }
 				/>
 				<label htmlFor={ radioId } className="jetpack-field-rating__label">
-					{ iconSvg }
+					<RatingIcon iconStyle={ iconStyle } />
 				</label>
 			</div>
 		);

--- a/projects/packages/forms/src/blocks/input-rating/edit.js
+++ b/projects/packages/forms/src/blocks/input-rating/edit.js
@@ -1,22 +1,6 @@
 import { useBlockProps } from '@wordpress/block-editor';
-import { SVG, Path } from '@wordpress/components';
-import { RATING_ICONS } from '../field-rating/rating-icons.js';
+import { RatingIcon } from '../field-rating/rating-icon.js';
 import useInsertAfterOnEnterKeyDown from '../shared/hooks/use-insert-after-on-enter-key-down.js';
-
-export const RatingIcon = ( { iconStyle, strokeColor = 'currentColor', fillColor = 'none' } ) => {
-	const iconPath = RATING_ICONS[ iconStyle ] || RATING_ICONS.stars;
-	return (
-		<SVG className="jetpack-field-rating__icon" viewBox="0 0 24 24" aria-hidden="true">
-			<Path
-				d={ iconPath }
-				fill={ fillColor }
-				stroke={ strokeColor }
-				strokeWidth="2"
-				strokeLinejoin="round"
-			/>
-		</SVG>
-	);
-};
 
 export default function RatingInputEdit( { context, clientId } ) {
 	const max = context?.[ 'jetpack/field-rating-max' ] || 5;

--- a/projects/packages/forms/src/dashboard/components/inspector/response-fields/field-preview/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/inspector/response-fields/field-preview/index.tsx
@@ -36,6 +36,7 @@ import FieldEmail from '../field-email/index.tsx';
 import FieldFile from '../field-file/index.tsx';
 import FieldImageSelect from '../field-image-select/index.tsx';
 import FieldPhone from '../field-phone/index.tsx';
+import FieldRating from '../field-rating/index.tsx';
 import { EMAIL_REGEX, getIconSource, inferFieldTypeFromLabel } from './field-preview-utils.ts';
 import type { ResponseField, FieldType, FileItem } from '../../../../../types/index.ts';
 import './style.scss';
@@ -173,6 +174,10 @@ const FieldPreview = ( { field, onFilePreview }: FieldPreviewProps ) => {
 
 		if ( fieldType === 'url' && /^https?:\/\//.test( stringValue ) ) {
 			return <ExternalLink href={ stringValue }>{ stringValue }</ExternalLink>;
+		}
+
+		if ( fieldType === 'rating' ) {
+			return <FieldRating value={ stringValue } />;
 		}
 
 		return stringValue;

--- a/projects/packages/forms/src/dashboard/components/inspector/response-fields/field-rating/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/inspector/response-fields/field-rating/index.tsx
@@ -30,8 +30,16 @@ const FieldRating = ( { value }: FieldRatingProps ) => {
 		return <>-</>;
 	}
 
-	const parsedRating = Number.parseInt( rateValue.trim(), 10 );
-	const parsedMax = Number.parseInt( outOf.trim(), 10 );
+	const rateValueTrimmed = rateValue.trim();
+	const outOfTrimmed = outOf.trim();
+
+	// Require strictly numeric values to reject partial matches like "4abc"
+	if ( ! /^[0-9]+$/.test( rateValueTrimmed ) || ! /^[0-9]+$/.test( outOfTrimmed ) ) {
+		return <>-</>;
+	}
+
+	const parsedRating = Number.parseInt( rateValueTrimmed, 10 );
+	const parsedMax = Number.parseInt( outOfTrimmed, 10 );
 	if (
 		! Number.isFinite( parsedRating ) ||
 		parsedRating < 0 ||

--- a/projects/packages/forms/src/dashboard/components/inspector/response-fields/field-rating/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/inspector/response-fields/field-rating/index.tsx
@@ -1,0 +1,49 @@
+/**
+ * External dependencies
+ */
+import {
+	__experimentalHStack as HStack, // eslint-disable-line @wordpress/no-unsafe-wp-apis
+	SVG,
+	Path,
+} from '@wordpress/components';
+/**
+ * Internal dependencies
+ */
+import { RATING_ICONS } from '../../../../../blocks/field-rating/rating-icons.js';
+
+type FieldRatingProps = {
+	value?: string | null;
+};
+
+const FieldRating = ( { value }: FieldRatingProps ) => {
+	const stringValue = value != null ? String( value ) : '';
+	if ( stringValue.trim() === '' ) {
+		return <>-</>;
+	}
+	const [ rateValue ] = stringValue.split( '/' );
+	if ( ! rateValue || rateValue.trim() === '' ) {
+		return <>-</>;
+	}
+	const iconSvg = (
+		<SVG viewBox="0 0 24 24" aria-hidden="true">
+			<Path
+				d={ RATING_ICONS.stars }
+				fill="#F0B849"
+				stroke="#F0B849"
+				strokeWidth="0"
+				strokeLinejoin="round"
+			/>
+		</SVG>
+	);
+	return (
+		<HStack spacing="1" alignment="topLeft">
+			{ Array.from( { length: parseInt( rateValue ) }, ( _, index ) => (
+				<div style={ { flex: '0 0 24px' } } key={ index }>
+					{ iconSvg }
+				</div>
+			) ) }
+		</HStack>
+	);
+};
+
+export default FieldRating;

--- a/projects/packages/forms/src/dashboard/components/inspector/response-fields/field-rating/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/inspector/response-fields/field-rating/index.tsx
@@ -3,15 +3,13 @@
  */
 import {
 	__experimentalHStack as HStack, // eslint-disable-line @wordpress/no-unsafe-wp-apis
-	SVG,
-	Path,
 	VisuallyHidden,
 } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { RATING_ICONS } from '../../../../../blocks/field-rating/rating-icons.js';
+import { RatingIcon } from '../../../../../blocks/input-rating/edit.js';
 
 type FieldRatingProps = {
 	value?: string | null;
@@ -56,30 +54,6 @@ const FieldRating = ( { value }: FieldRatingProps ) => {
 	const clampedMax = Math.min( parsedMax, MAX_RATING_ICONS );
 	const displayRating = Math.min( Math.max( 0, parsedRating ), clampedMax );
 
-	const filledIcon = (
-		<SVG viewBox="0 0 24 24" aria-hidden="true">
-			<Path
-				d={ RATING_ICONS.stars }
-				fill="#F0B849"
-				stroke="#F0B849"
-				strokeWidth="1"
-				strokeLinejoin="round"
-			/>
-		</SVG>
-	);
-
-	const emptyIcon = (
-		<SVG viewBox="0 0 24 24" aria-hidden="true">
-			<Path
-				d={ RATING_ICONS.stars }
-				fill="none"
-				stroke="currentColor"
-				strokeWidth="1"
-				strokeLinejoin="round"
-			/>
-		</SVG>
-	);
-
 	const ratingLabel = sprintf(
 		/* translators: 1: rating value, 2: maximum rating (e.g. "4" and "5" for "4 out of 5") */
 		__( 'Rating %1$s out of %2$s', 'jetpack-forms' ),
@@ -93,7 +67,11 @@ const FieldRating = ( { value }: FieldRatingProps ) => {
 			<HStack spacing="1" alignment="topLeft">
 				{ Array.from( { length: clampedMax }, ( _, index ) => (
 					<span style={ { flex: '0 0 24px' } } key={ index }>
-						{ index < displayRating ? filledIcon : emptyIcon }
+						<RatingIcon
+							iconStyle="stars"
+							strokeColor={ index < displayRating ? '#F0B849' : 'currentColor' }
+							fillColor={ index < displayRating ? '#F0B849' : 'none' }
+						/>
 					</span>
 				) ) }
 			</HStack>

--- a/projects/packages/forms/src/dashboard/components/inspector/response-fields/field-rating/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/inspector/response-fields/field-rating/index.tsx
@@ -19,14 +19,14 @@ type FieldRatingProps = {
 const FieldRating = ( { value }: FieldRatingProps ) => {
 	const stringValue = value != null ? String( value ) : '';
 	if ( stringValue.trim() === '' ) {
-		return <>-</>;
+		return '-';
 	}
 	const [ rateValue, outOf ] = stringValue.split( '/' ) ?? [];
 	if ( ! rateValue || rateValue.trim() === '' ) {
-		return <>-</>;
+		return '-';
 	}
 	if ( ! outOf || outOf.trim() === '' ) {
-		return <>-</>;
+		return '-';
 	}
 
 	const rateValueTrimmed = rateValue.trim();
@@ -34,7 +34,7 @@ const FieldRating = ( { value }: FieldRatingProps ) => {
 
 	// Require strictly numeric values to reject partial matches like "4abc"
 	if ( ! /^[0-9]+$/.test( rateValueTrimmed ) || ! /^[0-9]+$/.test( outOfTrimmed ) ) {
-		return <>-</>;
+		return '-';
 	}
 
 	const parsedRating = Number.parseInt( rateValueTrimmed, 10 );
@@ -45,7 +45,7 @@ const FieldRating = ( { value }: FieldRatingProps ) => {
 		! Number.isFinite( parsedMax ) ||
 		parsedMax < 0
 	) {
-		return <>-</>;
+		return '-';
 	}
 
 	// Clamp max to prevent DOM bloat from large values

--- a/projects/packages/forms/src/dashboard/components/inspector/response-fields/field-rating/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/inspector/response-fields/field-rating/index.tsx
@@ -9,14 +9,12 @@ import { __, sprintf } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { RatingIcon } from '../../../../../blocks/input-rating/edit.js';
+import { RatingIcon } from '../../../../../blocks/field-rating/rating-icon.js';
+import { MAX_RATING_ICONS } from '../../../../../blocks/field-rating/rating-icons.js';
 
 type FieldRatingProps = {
 	value?: string | null;
 };
-
-// Maximum icons to render to prevent DOM bloat from malformed values
-const MAX_RATING_ICONS = 10;
 
 const FieldRating = ( { value }: FieldRatingProps ) => {
 	const stringValue = value != null ? String( value ) : '';

--- a/projects/packages/forms/src/dashboard/components/inspector/response-fields/field-rating/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/inspector/response-fields/field-rating/index.tsx
@@ -42,17 +42,30 @@ const FieldRating = ( { value }: FieldRatingProps ) => {
 	}
 	const displayRating = Math.min( Math.max( 0, parsedRating ), parsedMax );
 
-	const iconSvg = (
+	const filledIcon = (
 		<SVG viewBox="0 0 24 24" aria-hidden="true">
 			<Path
 				d={ RATING_ICONS.stars }
 				fill="#F0B849"
 				stroke="#F0B849"
-				strokeWidth="0"
+				strokeWidth="1"
 				strokeLinejoin="round"
 			/>
 		</SVG>
 	);
+
+	const emptyIcon = (
+		<SVG viewBox="0 0 24 24" aria-hidden="true">
+			<Path
+				d={ RATING_ICONS.stars }
+				fill="none"
+				stroke="currentColor"
+				strokeWidth="1"
+				strokeLinejoin="round"
+			/>
+		</SVG>
+	);
+
 	const ratingLabel = sprintf(
 		/* translators: 1: rating value, 2: maximum rating (e.g. "4" and "5" for "4 out of 5") */
 		__( 'Rating %1$s out of %2$s', 'jetpack-forms' ),
@@ -64,9 +77,9 @@ const FieldRating = ( { value }: FieldRatingProps ) => {
 		<>
 			<VisuallyHidden as="span">{ ratingLabel }</VisuallyHidden>
 			<HStack spacing="1" alignment="topLeft">
-				{ Array.from( { length: displayRating }, ( _, index ) => (
+				{ Array.from( { length: parsedMax }, ( _, index ) => (
 					<span style={ { flex: '0 0 24px' } } key={ index }>
-						{ iconSvg }
+						{ index < displayRating ? filledIcon : emptyIcon }
 					</span>
 				) ) }
 			</HStack>

--- a/projects/packages/forms/src/dashboard/components/inspector/response-fields/field-rating/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/inspector/response-fields/field-rating/index.tsx
@@ -5,7 +5,9 @@ import {
 	__experimentalHStack as HStack, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 	SVG,
 	Path,
+	VisuallyHidden,
 } from '@wordpress/components';
+import { __, sprintf } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
@@ -20,8 +22,11 @@ const FieldRating = ( { value }: FieldRatingProps ) => {
 	if ( stringValue.trim() === '' ) {
 		return <>-</>;
 	}
-	const [ rateValue ] = stringValue.split( '/' );
+	const [ rateValue, outOf ] = stringValue.split( '/' ) ?? [];
 	if ( ! rateValue || rateValue.trim() === '' ) {
+		return <>-</>;
+	}
+	if ( ! outOf || outOf.trim() === '' ) {
 		return <>-</>;
 	}
 	const iconSvg = (
@@ -35,14 +40,24 @@ const FieldRating = ( { value }: FieldRatingProps ) => {
 			/>
 		</SVG>
 	);
+	const ratingLabel = sprintf(
+		/* translators: 1: rating value, 2: maximum rating (e.g. "4" and "5" for "4 out of 5") */
+		__( 'Rating %1$s out of %2$s', 'jetpack-forms' ),
+		rateValue.trim(),
+		outOf.trim()
+	);
+
 	return (
-		<HStack spacing="1" alignment="topLeft">
-			{ Array.from( { length: parseInt( rateValue ) }, ( _, index ) => (
-				<div style={ { flex: '0 0 24px' } } key={ index }>
-					{ iconSvg }
-				</div>
-			) ) }
-		</HStack>
+		<>
+			<VisuallyHidden as="span">{ ratingLabel }</VisuallyHidden>
+			<HStack spacing="1" alignment="topLeft">
+				{ Array.from( { length: parseInt( rateValue ) }, ( _, index ) => (
+					<span style={ { flex: '0 0 24px' } } key={ index }>
+						{ iconSvg }
+					</span>
+				) ) }
+			</HStack>
+		</>
 	);
 };
 

--- a/projects/packages/forms/src/dashboard/components/inspector/response-fields/field-rating/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/inspector/response-fields/field-rating/index.tsx
@@ -29,6 +29,19 @@ const FieldRating = ( { value }: FieldRatingProps ) => {
 	if ( ! outOf || outOf.trim() === '' ) {
 		return <>-</>;
 	}
+
+	const parsedRating = Number.parseInt( rateValue.trim(), 10 );
+	const parsedMax = Number.parseInt( outOf.trim(), 10 );
+	if (
+		! Number.isFinite( parsedRating ) ||
+		parsedRating < 0 ||
+		! Number.isFinite( parsedMax ) ||
+		parsedMax < 0
+	) {
+		return <>-</>;
+	}
+	const displayRating = Math.min( Math.max( 0, parsedRating ), parsedMax );
+
 	const iconSvg = (
 		<SVG viewBox="0 0 24 24" aria-hidden="true">
 			<Path
@@ -43,15 +56,15 @@ const FieldRating = ( { value }: FieldRatingProps ) => {
 	const ratingLabel = sprintf(
 		/* translators: 1: rating value, 2: maximum rating (e.g. "4" and "5" for "4 out of 5") */
 		__( 'Rating %1$s out of %2$s', 'jetpack-forms' ),
-		rateValue.trim(),
-		outOf.trim()
+		String( displayRating ),
+		String( parsedMax )
 	);
 
 	return (
 		<>
 			<VisuallyHidden as="span">{ ratingLabel }</VisuallyHidden>
 			<HStack spacing="1" alignment="topLeft">
-				{ Array.from( { length: parseInt( rateValue ) }, ( _, index ) => (
+				{ Array.from( { length: displayRating }, ( _, index ) => (
 					<span style={ { flex: '0 0 24px' } } key={ index }>
 						{ iconSvg }
 					</span>

--- a/projects/packages/forms/src/dashboard/components/inspector/response-fields/field-rating/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/inspector/response-fields/field-rating/index.tsx
@@ -17,6 +17,9 @@ type FieldRatingProps = {
 	value?: string | null;
 };
 
+// Maximum icons to render to prevent DOM bloat from malformed values
+const MAX_RATING_ICONS = 10;
+
 const FieldRating = ( { value }: FieldRatingProps ) => {
 	const stringValue = value != null ? String( value ) : '';
 	if ( stringValue.trim() === '' ) {
@@ -48,7 +51,10 @@ const FieldRating = ( { value }: FieldRatingProps ) => {
 	) {
 		return <>-</>;
 	}
-	const displayRating = Math.min( Math.max( 0, parsedRating ), parsedMax );
+
+	// Clamp max to prevent DOM bloat from large values
+	const clampedMax = Math.min( parsedMax, MAX_RATING_ICONS );
+	const displayRating = Math.min( Math.max( 0, parsedRating ), clampedMax );
 
 	const filledIcon = (
 		<SVG viewBox="0 0 24 24" aria-hidden="true">
@@ -78,14 +84,14 @@ const FieldRating = ( { value }: FieldRatingProps ) => {
 		/* translators: 1: rating value, 2: maximum rating (e.g. "4" and "5" for "4 out of 5") */
 		__( 'Rating %1$s out of %2$s', 'jetpack-forms' ),
 		String( displayRating ),
-		String( parsedMax )
+		String( clampedMax )
 	);
 
 	return (
 		<>
 			<VisuallyHidden as="span">{ ratingLabel }</VisuallyHidden>
 			<HStack spacing="1" alignment="topLeft">
-				{ Array.from( { length: parsedMax }, ( _, index ) => (
+				{ Array.from( { length: clampedMax }, ( _, index ) => (
 					<span style={ { flex: '0 0 24px' } } key={ index }>
 						{ index < displayRating ? filledIcon : emptyIcon }
 					</span>

--- a/projects/packages/forms/src/dashboard/components/inspector/response-fields/field-rating/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/inspector/response-fields/field-rating/index.tsx
@@ -69,7 +69,7 @@ const FieldRating = ( { value }: FieldRatingProps ) => {
 							iconStyle="stars"
 							strokeColor={ index < displayRating ? '#F0B849' : '#757575' }
 							fillColor={ index < displayRating ? '#F0B849' : 'none' }
-							strokeWidth={ 2 }
+							strokeWidth={ 1.5 }
 						/>
 					</span>
 				) ) }

--- a/projects/packages/forms/src/dashboard/components/inspector/response-fields/field-rating/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/inspector/response-fields/field-rating/index.tsx
@@ -67,8 +67,9 @@ const FieldRating = ( { value }: FieldRatingProps ) => {
 					<span style={ { flex: '0 0 24px' } } key={ index }>
 						<RatingIcon
 							iconStyle="stars"
-							strokeColor={ index < displayRating ? '#F0B849' : 'currentColor' }
+							strokeColor={ index < displayRating ? '#F0B849' : '#757575' }
 							fillColor={ index < displayRating ? '#F0B849' : 'none' }
+							strokeWidth={ 2 }
 						/>
 					</span>
 				) ) }

--- a/projects/packages/forms/tests/js/dashboard/components/response-view/field-rating/index.test.jsx
+++ b/projects/packages/forms/tests/js/dashboard/components/response-view/field-rating/index.test.jsx
@@ -93,12 +93,24 @@ describe( 'FieldRating', () => {
 	} );
 
 	describe( 'Edge cases', () => {
-		it( 'renders zero icons for non-numeric rate part', () => {
-			const { container } = render( <FieldRating value="abc/5" /> );
+		it( 'falls back to "-" for non-numeric rate part', () => {
+			render( <FieldRating value="abc/5" /> );
+
+			expect( screen.getByText( '-' ) ).toBeInTheDocument();
+		} );
+
+		it( 'falls back to "-" for non-numeric max part', () => {
+			render( <FieldRating value="3/abc" /> );
+
+			expect( screen.getByText( '-' ) ).toBeInTheDocument();
+		} );
+
+		it( 'clamps rating to max (e.g. 7/5 shows 5 icons)', () => {
+			const { container } = render( <FieldRating value="7/5" /> );
 
 			// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
 			const svgs = container.querySelectorAll( 'svg' );
-			expect( svgs ).toHaveLength( 0 );
+			expect( svgs ).toHaveLength( 5 );
 		} );
 
 		it( 'parses only the first segment before slash', () => {

--- a/projects/packages/forms/tests/js/dashboard/components/response-view/field-rating/index.test.jsx
+++ b/projects/packages/forms/tests/js/dashboard/components/response-view/field-rating/index.test.jsx
@@ -13,44 +13,65 @@ const { default: FieldRating } = await import(
 
 describe( 'FieldRating', () => {
 	describe( 'Valid rating values', () => {
-		it( 'renders 4 star icons for value "4/5"', () => {
+		it( 'renders 5 icons with 4 filled for value "4/5"', () => {
 			const { container } = render( <FieldRating value="4/5" /> );
 
 			// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
 			const svgs = container.querySelectorAll( 'svg' );
-			expect( svgs ).toHaveLength( 4 );
+			// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+			const filledPaths = container.querySelectorAll( 'path[fill="#F0B849"]' );
+			// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+			const emptyPaths = container.querySelectorAll( 'path[fill="none"]' );
+			expect( svgs ).toHaveLength( 5 );
+			expect( filledPaths ).toHaveLength( 4 );
+			expect( emptyPaths ).toHaveLength( 1 );
 		} );
 
-		it( 'renders 3 star icons for value "3/5"', () => {
+		it( 'renders 5 icons with 3 filled for value "3/5"', () => {
 			const { container } = render( <FieldRating value="3/5" /> );
 
 			// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
 			const svgs = container.querySelectorAll( 'svg' );
-			expect( svgs ).toHaveLength( 3 );
+			// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+			const filledPaths = container.querySelectorAll( 'path[fill="#F0B849"]' );
+			expect( svgs ).toHaveLength( 5 );
+			expect( filledPaths ).toHaveLength( 3 );
 		} );
 
-		it( 'renders 5 star icons for value "5/5"', () => {
+		it( 'renders 5 icons all filled for value "5/5"', () => {
 			const { container } = render( <FieldRating value="5/5" /> );
 
 			// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
 			const svgs = container.querySelectorAll( 'svg' );
+			// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+			const filledPaths = container.querySelectorAll( 'path[fill="#F0B849"]' );
 			expect( svgs ).toHaveLength( 5 );
+			expect( filledPaths ).toHaveLength( 5 );
 		} );
 
-		it( 'renders 1 star icon for value "1/5"', () => {
+		it( 'renders 5 icons with 1 filled for value "1/5"', () => {
 			const { container } = render( <FieldRating value="1/5" /> );
 
 			// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
 			const svgs = container.querySelectorAll( 'svg' );
-			expect( svgs ).toHaveLength( 1 );
+			// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+			const filledPaths = container.querySelectorAll( 'path[fill="#F0B849"]' );
+			// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+			const emptyPaths = container.querySelectorAll( 'path[fill="none"]' );
+			expect( svgs ).toHaveLength( 5 );
+			expect( filledPaths ).toHaveLength( 1 );
+			expect( emptyPaths ).toHaveLength( 4 );
 		} );
 
-		it( 'coerces numeric value to string and renders correct number of icons', () => {
-			const { container } = render( <FieldRating value={ '2/5' } /> );
+		it( 'renders 5 icons with 2 filled for value "2/5"', () => {
+			const { container } = render( <FieldRating value="2/5" /> );
 
 			// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
 			const svgs = container.querySelectorAll( 'svg' );
-			expect( svgs ).toHaveLength( 2 );
+			// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+			const filledPaths = container.querySelectorAll( 'path[fill="#F0B849"]' );
+			expect( svgs ).toHaveLength( 5 );
+			expect( filledPaths ).toHaveLength( 2 );
 		} );
 	} );
 
@@ -105,20 +126,32 @@ describe( 'FieldRating', () => {
 			expect( screen.getByText( '-' ) ).toBeInTheDocument();
 		} );
 
-		it( 'clamps rating to max (e.g. 7/5 shows 5 icons)', () => {
+		it( 'clamps rating to max (e.g. 7/5 shows 5 filled icons)', () => {
 			const { container } = render( <FieldRating value="7/5" /> );
 
 			// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
 			const svgs = container.querySelectorAll( 'svg' );
+			// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+			const filledPaths = container.querySelectorAll( 'path[fill="#F0B849"]' );
+			// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+			const emptyPaths = container.querySelectorAll( 'path[fill="none"]' );
 			expect( svgs ).toHaveLength( 5 );
+			expect( filledPaths ).toHaveLength( 5 );
+			expect( emptyPaths ).toHaveLength( 0 );
 		} );
 
-		it( 'parses only the first segment before slash', () => {
+		it( 'renders correct icons for different max values (e.g. "2/10")', () => {
 			const { container } = render( <FieldRating value="2/10" /> );
 
 			// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
 			const svgs = container.querySelectorAll( 'svg' );
-			expect( svgs ).toHaveLength( 2 );
+			// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+			const filledPaths = container.querySelectorAll( 'path[fill="#F0B849"]' );
+			// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+			const emptyPaths = container.querySelectorAll( 'path[fill="none"]' );
+			expect( svgs ).toHaveLength( 10 );
+			expect( filledPaths ).toHaveLength( 2 );
+			expect( emptyPaths ).toHaveLength( 8 );
 		} );
 	} );
 } );

--- a/projects/packages/forms/tests/js/dashboard/components/response-view/field-rating/index.test.jsx
+++ b/projects/packages/forms/tests/js/dashboard/components/response-view/field-rating/index.test.jsx
@@ -165,5 +165,17 @@ describe( 'FieldRating', () => {
 			expect( filledPaths ).toHaveLength( 2 );
 			expect( emptyPaths ).toHaveLength( 8 );
 		} );
+
+		it( 'clamps max to 10 icons to prevent DOM bloat (e.g. "50/100")', () => {
+			const { container } = render( <FieldRating value="50/100" /> );
+
+			// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+			const svgs = container.querySelectorAll( 'svg' );
+			// Should render max 10 icons, all filled since 50 > 10
+			expect( svgs ).toHaveLength( 10 );
+			// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+			const filledPaths = container.querySelectorAll( 'path[fill="#F0B849"]' );
+			expect( filledPaths ).toHaveLength( 10 );
+		} );
 	} );
 } );

--- a/projects/packages/forms/tests/js/dashboard/components/response-view/field-rating/index.test.jsx
+++ b/projects/packages/forms/tests/js/dashboard/components/response-view/field-rating/index.test.jsx
@@ -126,6 +126,18 @@ describe( 'FieldRating', () => {
 			expect( screen.getByText( '-' ) ).toBeInTheDocument();
 		} );
 
+		it( 'falls back to "-" for partial numeric rate (e.g. "4abc/5")', () => {
+			render( <FieldRating value="4abc/5" /> );
+
+			expect( screen.getByText( '-' ) ).toBeInTheDocument();
+		} );
+
+		it( 'falls back to "-" for partial numeric max (e.g. "3/5abc")', () => {
+			render( <FieldRating value="3/5abc" /> );
+
+			expect( screen.getByText( '-' ) ).toBeInTheDocument();
+		} );
+
 		it( 'clamps rating to max (e.g. 7/5 shows 5 filled icons)', () => {
 			const { container } = render( <FieldRating value="7/5" /> );
 

--- a/projects/packages/forms/tests/js/dashboard/components/response-view/field-rating/index.test.jsx
+++ b/projects/packages/forms/tests/js/dashboard/components/response-view/field-rating/index.test.jsx
@@ -1,0 +1,112 @@
+/**
+ * External dependencies
+ */
+import { describe, expect, it } from '@jest/globals';
+import { render, screen } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+const { default: FieldRating } = await import(
+	'../../../../../../src/dashboard/components/inspector/response-fields/field-rating/index.tsx'
+);
+
+describe( 'FieldRating', () => {
+	describe( 'Valid rating values', () => {
+		it( 'renders 4 star icons for value "4/5"', () => {
+			const { container } = render( <FieldRating value="4/5" /> );
+
+			// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+			const svgs = container.querySelectorAll( 'svg' );
+			expect( svgs ).toHaveLength( 4 );
+		} );
+
+		it( 'renders 3 star icons for value "3/5"', () => {
+			const { container } = render( <FieldRating value="3/5" /> );
+
+			// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+			const svgs = container.querySelectorAll( 'svg' );
+			expect( svgs ).toHaveLength( 3 );
+		} );
+
+		it( 'renders 5 star icons for value "5/5"', () => {
+			const { container } = render( <FieldRating value="5/5" /> );
+
+			// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+			const svgs = container.querySelectorAll( 'svg' );
+			expect( svgs ).toHaveLength( 5 );
+		} );
+
+		it( 'renders 1 star icon for value "1/5"', () => {
+			const { container } = render( <FieldRating value="1/5" /> );
+
+			// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+			const svgs = container.querySelectorAll( 'svg' );
+			expect( svgs ).toHaveLength( 1 );
+		} );
+
+		it( 'coerces numeric value to string and renders correct number of icons', () => {
+			const { container } = render( <FieldRating value={ '2/5' } /> );
+
+			// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+			const svgs = container.querySelectorAll( 'svg' );
+			expect( svgs ).toHaveLength( 2 );
+		} );
+	} );
+
+	describe( 'Invalid and empty values fall back to "-"', () => {
+		it( 'renders "-" for null value', () => {
+			render( <FieldRating value={ null } /> );
+
+			expect( screen.getByText( '-' ) ).toBeInTheDocument();
+		} );
+
+		it( 'renders "-" for undefined value', () => {
+			render( <FieldRating /> );
+
+			expect( screen.getByText( '-' ) ).toBeInTheDocument();
+		} );
+
+		it( 'renders "-" for empty string', () => {
+			render( <FieldRating value="" /> );
+
+			expect( screen.getByText( '-' ) ).toBeInTheDocument();
+		} );
+
+		it( 'renders "-" for whitespace-only value', () => {
+			render( <FieldRating value="   " /> );
+
+			expect( screen.getByText( '-' ) ).toBeInTheDocument();
+		} );
+
+		it( 'renders "-" when value has no rate part (e.g. "/5")', () => {
+			render( <FieldRating value="/5" /> );
+
+			expect( screen.getByText( '-' ) ).toBeInTheDocument();
+		} );
+
+		it( 'renders "-" when rate part is whitespace only', () => {
+			render( <FieldRating value="  /5" /> );
+
+			expect( screen.getByText( '-' ) ).toBeInTheDocument();
+		} );
+	} );
+
+	describe( 'Edge cases', () => {
+		it( 'renders zero icons for non-numeric rate part', () => {
+			const { container } = render( <FieldRating value="abc/5" /> );
+
+			// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+			const svgs = container.querySelectorAll( 'svg' );
+			expect( svgs ).toHaveLength( 0 );
+		} );
+
+		it( 'parses only the first segment before slash', () => {
+			const { container } = render( <FieldRating value="2/10" /> );
+
+			// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+			const svgs = container.querySelectorAll( 'svg' );
+			expect( svgs ).toHaveLength( 2 );
+		} );
+	} );
+} );


### PR DESCRIPTION
## Proposed changes:

Display star rating icons in the response inspector instead of plain text for rating field submissions.

* Add new `FieldRating` component that renders star icons based on the rating value
* Integrate `FieldRating` into the field preview component for rating field types
* Parse rating values (e.g., "4/5") and display the corresponding number of star icons

**Before**
<img width="431" height="128" alt="image" src="https://github.com/user-attachments/assets/d4e4bc56-571b-419c-b29e-02e98a55096b" />

<img width="430" height="125" alt="image" src="https://github.com/user-attachments/assets/e683c492-215e-407a-8c33-8367c06b88cf" />

**After**
<img width="433" height="126" alt="image" src="https://github.com/user-attachments/assets/faf86686-3345-420c-bfc1-1f9d0a981a7f" />


<img width="429" height="120" alt="image" src="https://github.com/user-attachments/assets/760c1bcd-2fbb-444d-b055-beb386ea2fff" />


Includes also:

refactor the rating icon SVG into a reusable RatingIcon component:

1. edit.js - Extracted the inline SVG into an exported RatingIcon component that accepts:
    - iconStyle - the icon type (stars, hearts, etc.)
    - strokeColor - defaults to currentColor
    - fillColor - defaults to none

2. field-rating/index.tsx - Replaced the duplicate filledIcon and emptyIcon SVG definitions with the new RatingIcon component, passing appropriate colors for filled (#F0B849) vs empty states.

This reduces code duplication by ~22 lines while making the rating icon reusable across both the block editor and the response inspector dashboard.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

N/A

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

1. Create a form with a Rating field
2. Submit a response with a rating (e.g., 4 out of 5 stars)
3. Go to Forms > Responses and click on the submission
4. Verify the rating field displays star icons instead of plain text like "4/5"

