### PR TITLE
Forms: add wp-build single form screen

### DIFF
--- a/projects/packages/forms/changelog/add-wp-build-single-form-screen
+++ b/projects/packages/forms/changelog/add-wp-build-single-form-screen
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Forms: add single form view to wp-build dashboard.

--- a/projects/packages/forms/routes/forms/stage.tsx
+++ b/projects/packages/forms/routes/forms/stage.tsx
@@ -199,6 +199,13 @@ function StageInner() {
 		[ dateSettings.formats.datetime, statusLabel ]
 	);
 
+	const openSingleFormView = useCallback(
+		( formId: number | string ) => {
+			navigate( { href: `/responses/inbox?sourceId=${ encodeURIComponent( String( formId ) ) }` } );
+		},
+		[ navigate ]
+	);
+
 	const actions = useMemo( () => {
 		const actionsList: Action< FormListItem >[] = [
 			{
@@ -206,8 +213,12 @@ function StageInner() {
 				isPrimary: false,
 				label: __( 'View responses', 'jetpack-forms' ),
 				supportsBulk: false,
-				callback() {
-					// Intentionally no-op for now; single form screen will be added later.
+				callback( items: FormListItem[] ) {
+					const [ item ] = items;
+					if ( ! item ) {
+						return;
+					}
+					openSingleFormView( item.id );
 				},
 			},
 			{
@@ -281,7 +292,14 @@ function StageInner() {
 		} );
 
 		return actionsList;
-	}, [ isDeleting, isViewingTrash, onOpenPermanentDeleteConfirm, restoreForms, trashForms ] );
+	}, [
+		isDeleting,
+		isViewingTrash,
+		onOpenPermanentDeleteConfirm,
+		openSingleFormView,
+		restoreForms,
+		trashForms,
+	] );
 
 	const paginationInfo = useMemo(
 		() => ( {
@@ -310,6 +328,12 @@ function StageInner() {
 
 	const headerActions = useMemo( () => [ <CreateFormButton key="create" /> ], [] );
 	const getItemId = useCallback( ( item: FormListItem ) => String( item.id ), [] );
+	const onClickItem = useCallback(
+		( item: FormListItem ) => {
+			openSingleFormView( item.id );
+		},
+		[ openSingleFormView ]
+	);
 
 	return (
 		<Page
@@ -344,6 +368,7 @@ function StageInner() {
 				onChangeView={ onChangeView }
 				selection={ selection }
 				onChangeSelection={ setSelection }
+				onClickItem={ onClickItem }
 				getItemId={ getItemId }
 				defaultLayouts={ defaultLayouts }
 			>

--- a/projects/packages/forms/routes/responses/stage.tsx
+++ b/projects/packages/forms/routes/responses/stage.tsx
@@ -46,7 +46,7 @@ import './style.scss';
  * Types
  */
 import type { FormResponse } from '../../src/types/index.ts';
-import type { View, Field, Action } from '@wordpress/dataviews';
+import type { View, Field, Action, Operator } from '@wordpress/dataviews';
 
 type FeedbackFilterDate = {
 	month: number;
@@ -147,6 +147,11 @@ function StageInner() {
 	const statusView = params.view === 'spam' || params.view === 'trash' ? params.view : 'inbox';
 	const statusFilter = statusView === 'inbox' ? 'draft,publish' : statusView;
 
+	const sourceIdValue = ( searchParams as { sourceId?: string | number } )?.sourceId;
+	const sourceIdNumber =
+		typeof sourceIdValue === 'number' ? sourceIdValue : Number( sourceIdValue );
+	const isSingleFormView = Number.isFinite( sourceIdNumber ) && sourceIdNumber > 0;
+
 	const [ isIntegrationsModalOpen, setIsIntegrationsModalOpen ] = useState( false );
 	const integrations = useSelect(
 		select => ( select( INTEGRATIONS_STORE ) as IntegrationsSelectors ).getIntegrations?.() ?? [],
@@ -185,22 +190,24 @@ function StageInner() {
 
 	const onChangeView = useCallback(
 		( newView: View ) => {
-			// If the Folder filter changes (CFM-on behavior), treat it as a route param change.
-			const folderValue =
-				newView.filters?.find( filter => filter.field === 'folder' )?.value || 'inbox';
+			if ( ! isSingleFormView ) {
+				// If the Folder filter changes (CFM-on behavior), treat it as a route param change.
+				const folderValue =
+					newView.filters?.find( filter => filter.field === 'folder' )?.value || 'inbox';
 
-			if ( folderValue !== statusView ) {
-				// Clear selection when changing folder to avoid mismatched inspector state.
-				navigate( {
-					to: '/responses/$view',
-					params: { view: folderValue },
-					search: {
-						...searchParams,
-						responseIds: undefined,
-					},
-				} );
-				setView( { ...newView, page: 1 } );
-				return;
+				if ( folderValue !== statusView ) {
+					// Clear selection when changing folder to avoid mismatched inspector state.
+					navigate( {
+						to: '/responses/$view',
+						params: { view: folderValue },
+						search: {
+							...searchParams,
+							responseIds: undefined,
+						},
+					} );
+					setView( { ...newView, page: 1 } );
+					return;
+				}
 			}
 
 			setView( newView );
@@ -214,7 +221,7 @@ function StageInner() {
 				} );
 			}
 		},
-		[ navigate, searchParams, statusView, view.search ]
+		[ isSingleFormView, navigate, searchParams, statusView, view.search ]
 	);
 
 	const onChangeSelection = useCallback(
@@ -229,8 +236,26 @@ function StageInner() {
 		[ searchParams, navigate ]
 	);
 
+	const onStatusChange = useCallback(
+		( nextStatus: 'inbox' | 'spam' | 'trash' ) => {
+			navigate( {
+				to: '/responses/$view',
+				params: { view: nextStatus },
+				search: {
+					...searchParams,
+					responseIds: undefined,
+					sourceId: isSingleFormView ? String( sourceIdNumber ) : undefined,
+				},
+			} );
+		},
+		[ isSingleFormView, navigate, searchParams, sourceIdNumber ]
+	);
+
 	// Keep the Folder filter in sync with the route param (CFM-on behavior).
 	useEffect( () => {
+		if ( isSingleFormView ) {
+			return;
+		}
 		setView( previousView => {
 			const previousFilters = previousView.filters || [];
 			const existing = previousFilters.find( filter => filter.field === 'folder' );
@@ -245,7 +270,7 @@ function StageInner() {
 				],
 			};
 		} );
-	}, [ setView, statusView ] );
+	}, [ isSingleFormView, setView, statusView ] );
 
 	const queryParams = useMemo( () => {
 		const queryArgs: QueryParams = {
@@ -260,6 +285,10 @@ function StageInner() {
 			queryArgs.search = view.search;
 		}
 
+		if ( isSingleFormView ) {
+			queryArgs.parent = String( sourceIdNumber );
+		}
+
 		view.filters?.forEach( filter => {
 			if ( ! filter.value ) {
 				return;
@@ -267,7 +296,7 @@ function StageInner() {
 			if ( filter.field === 'read_status' ) {
 				queryArgs.is_unread = filter.value === 'unread';
 			}
-			if ( filter.field === 'source' ) {
+			if ( ! isSingleFormView && filter.field === 'source' ) {
 				queryArgs.parent = filter.value;
 			}
 			if ( filter.field === 'date' ) {
@@ -278,7 +307,7 @@ function StageInner() {
 		} );
 
 		return queryArgs;
-	}, [ statusFilter, view ] );
+	}, [ isSingleFormView, sourceIdNumber, statusFilter, view ] );
 
 	// Keep dashboard store query in sync so core-data fetches include fields_format=collection.
 	useEffect( () => {
@@ -296,43 +325,47 @@ function StageInner() {
 
 	const fields: Field< FormResponse >[] = useMemo(
 		() => [
-			{
-				id: 'folder',
-				label: __( 'Folder', 'jetpack-forms' ),
-				elements: [
-					{
-						label: sprintf(
-							/* translators: %s is the number of inbox responses. */
-							__( 'Inbox (%s)', 'jetpack-forms' ),
-							formatNumber( totalItemsInbox ?? 0 )
-						),
-						value: 'inbox',
-					},
-					{
-						label: sprintf(
-							/* translators: %s is the number of spam responses. */
-							__( 'Spam (%s)', 'jetpack-forms' ),
-							formatNumber( totalItemsSpam ?? 0 )
-						),
-						value: 'spam',
-					},
-					{
-						label: sprintf(
-							/* translators: %s is the number of trash responses. */
-							__( 'Trash (%s)', 'jetpack-forms' ),
-							formatNumber( totalItemsTrash ?? 0 )
-						),
-						value: 'trash',
-					},
-				],
-				// Primary so the filter UI (and its pill) is visible by default.
-				filterBy: { operators: [ 'is' ], isPrimary: true },
-				enableSorting: false,
-				enableHiding: false,
-				// Filter-only field; not shown as a column.
-				render: () => null,
-				getValue: () => null,
-			},
+			...( isSingleFormView
+				? []
+				: [
+						{
+							id: 'folder',
+							label: __( 'Folder', 'jetpack-forms' ),
+							elements: [
+								{
+									label: sprintf(
+										/* translators: %s is the number of inbox responses. */
+										__( 'Inbox (%s)', 'jetpack-forms' ),
+										formatNumber( totalItemsInbox ?? 0 )
+									),
+									value: 'inbox',
+								},
+								{
+									label: sprintf(
+										/* translators: %s is the number of spam responses. */
+										__( 'Spam (%s)', 'jetpack-forms' ),
+										formatNumber( totalItemsSpam ?? 0 )
+									),
+									value: 'spam',
+								},
+								{
+									label: sprintf(
+										/* translators: %s is the number of trash responses. */
+										__( 'Trash (%s)', 'jetpack-forms' ),
+										formatNumber( totalItemsTrash ?? 0 )
+									),
+									value: 'trash',
+								},
+							],
+							// Primary so the filter UI (and its pill) is visible by default.
+							filterBy: { operators: [ 'is' ] as Operator[], isPrimary: true },
+							enableSorting: false,
+							enableHiding: false,
+							// Filter-only field; not shown as a column.
+							render: () => null,
+							getValue: () => null,
+						},
+				  ] ),
 			{
 				id: 'from',
 				label: __( 'From', 'jetpack-forms' ),
@@ -408,31 +441,36 @@ function StageInner() {
 						value: `${ filter.year }/${ filter.month }`,
 					};
 				} ),
-				filterBy: { operators: [ 'is' ] },
+				filterBy: { operators: [ 'is' ] as Operator[] },
 				enableSorting: false,
 			},
-			{
-				id: 'source',
-				label: __( 'Source', 'jetpack-forms' ),
-				render: ( { item } ) => {
-					const source = item.entry_title || getPath( item ) || __( '(no title)', 'jetpack-forms' );
-					if ( item.entry_permalink ) {
-						return styleUnreadValue(
-							<ExternalLink href={ item.entry_permalink }>{ source }</ExternalLink>,
-							item.is_unread
-						);
-					}
-					return styleUnreadValue( source, item.is_unread );
-				},
-				elements: ( ( filterOptions as unknown as FeedbackFilters )?.source || [] ).map(
-					source => ( {
-						value: source.id.toString(),
-						label: decodeEntities( source.title ) || source.url,
-					} )
-				),
-				filterBy: { operators: [ 'is' ] },
-				enableSorting: false,
-			},
+			...( isSingleFormView
+				? []
+				: [
+						{
+							id: 'source',
+							label: __( 'Source', 'jetpack-forms' ),
+							render: ( { item } ) => {
+								const source =
+									item.entry_title || getPath( item ) || __( '(no title)', 'jetpack-forms' );
+								if ( item.entry_permalink ) {
+									return styleUnreadValue(
+										<ExternalLink href={ item.entry_permalink }>{ source }</ExternalLink>,
+										item.is_unread
+									);
+								}
+								return styleUnreadValue( source, item.is_unread );
+							},
+							elements: ( ( filterOptions as unknown as FeedbackFilters )?.source || [] ).map(
+								source => ( {
+									value: source.id.toString(),
+									label: decodeEntities( source.title ) || source.url,
+								} )
+							),
+							filterBy: { operators: [ 'is' ] as Operator[] },
+							enableSorting: false,
+						},
+				  ] ),
 			{
 				id: 'read_status',
 				label: __( 'Status', 'jetpack-forms' ),
@@ -440,7 +478,7 @@ function StageInner() {
 					{ label: __( 'Unread', 'jetpack-forms' ), value: 'unread' },
 					{ label: __( 'Read', 'jetpack-forms' ), value: 'read' },
 				],
-				filterBy: { operators: [ 'is' ] },
+				filterBy: { operators: [ 'is' ] as Operator[] },
 				enableSorting: false,
 				render: ( { item } ) => {
 					return (
@@ -466,7 +504,7 @@ function StageInner() {
 				enableSorting: false,
 			},
 		],
-		[ filterOptions, totalItemsInbox, totalItemsSpam, totalItemsTrash ]
+		[ filterOptions, isSingleFormView, totalItemsInbox, totalItemsSpam, totalItemsTrash ]
 	);
 
 	const actions = useMemo(
@@ -599,7 +637,17 @@ function StageInner() {
 				onClickItem={ onClickItem }
 				actions={ actions as Action< unknown >[] }
 			>
-				<DataViewsHeaderRow activeTab="responses" />
+				<DataViewsHeaderRow
+					activeTab="responses"
+					isSingleFormView={ isSingleFormView }
+					activeStatus={ statusView }
+					statusCounts={ {
+						inbox: totalItemsInbox ?? 0,
+						spam: totalItemsSpam ?? 0,
+						trash: totalItemsTrash ?? 0,
+					} }
+					onStatusChange={ onStatusChange }
+				/>
 				<DataViews.Layout />
 				<DataViews.Footer />
 			</DataViews>

--- a/projects/packages/forms/src/dashboard/wp-build/components/dataviews-header-row/index.tsx
+++ b/projects/packages/forms/src/dashboard/wp-build/components/dataviews-header-row/index.tsx
@@ -10,21 +10,42 @@ import { Stack } from '@wordpress/ui';
  * Internal dependencies
  */
 import * as Tabs from '../../../components/tabs';
+import InboxStatusToggle from '../inbox-status-toggle';
 import './style.scss';
 
 type ActiveTab = 'forms' | 'responses';
+type StatusTab = 'inbox' | 'spam' | 'trash';
+
+type DataViewsHeaderRowProps = {
+	activeTab: ActiveTab;
+	isSingleFormView?: boolean;
+	activeStatus?: StatusTab;
+	statusCounts?: { inbox: number; spam: number; trash: number };
+	onStatusChange?: ( nextStatus: StatusTab ) => void;
+};
 
 /**
  * Shared wp-build DataViews header row:
  * - Left: Forms | Responses tabs (CFM-on behavior; wp-build assumes CFM is always on)
+ * - Single-form special case: show Inbox/Spam/Trash tabs instead
  * - Right: DataViews controls (Search + ViewConfig)
  * - Below: DataViews filter pills row (collapses when empty)
  *
- * @param props           - Props.
- * @param props.activeTab - Which top tab is active.
+ * @param props                  - Props.
+ * @param props.activeTab        - Which top tab is active.
+ * @param props.isSingleFormView - Whether this screen is showing a single-form responses view.
+ * @param props.activeStatus     - Current status for the single-form status tabs.
+ * @param props.statusCounts     - Status counts for the single-form status tabs.
+ * @param props.onStatusChange   - Handler for single-form status tab changes.
  * @return Header row markup for wp-build DataViews screens.
  */
-export default function DataViewsHeaderRow( { activeTab }: { activeTab: ActiveTab } ): JSX.Element {
+export default function DataViewsHeaderRow( {
+	activeTab,
+	isSingleFormView = false,
+	activeStatus,
+	statusCounts,
+	onStatusChange,
+}: DataViewsHeaderRowProps ): JSX.Element {
 	const navigate = useNavigate();
 
 	const onTabChange = useCallback(
@@ -49,15 +70,24 @@ export default function DataViewsHeaderRow( { activeTab }: { activeTab: ActiveTa
 				justify="space-between"
 			>
 				<Stack align="center" gap="sm">
-					<Tabs.Root value={ activeTab } onValueChange={ onTabChange }>
-						<Tabs.List density="compact">
-							<Tabs.Tab value="responses">{ __( 'Responses', 'jetpack-forms' ) }</Tabs.Tab>
-							<Tabs.Tab value="forms">{ __( 'Forms', 'jetpack-forms' ) }</Tabs.Tab>
-						</Tabs.List>
-					</Tabs.Root>
+					{ isSingleFormView ? (
+						<InboxStatusToggle
+							activeStatus={ activeStatus ?? 'inbox' }
+							counts={ statusCounts ?? { inbox: 0, spam: 0, trash: 0 } }
+							onChange={ onStatusChange ?? ( () => {} ) }
+						/>
+					) : (
+						<Tabs.Root value={ activeTab } onValueChange={ onTabChange }>
+							<Tabs.List density="compact">
+								<Tabs.Tab value="responses">{ __( 'Responses', 'jetpack-forms' ) }</Tabs.Tab>
+								<Tabs.Tab value="forms">{ __( 'Forms', 'jetpack-forms' ) }</Tabs.Tab>
+							</Tabs.List>
+						</Tabs.Root>
+					) }
 				</Stack>
 				<Stack align="center" gap="sm">
 					<DataViews.Search />
+					{ isSingleFormView ? <DataViews.FiltersToggle /> : null }
 					<DataViews.ViewConfig />
 				</Stack>
 			</Stack>

--- a/projects/packages/forms/src/dashboard/wp-build/components/inbox-status-toggle/index.tsx
+++ b/projects/packages/forms/src/dashboard/wp-build/components/inbox-status-toggle/index.tsx
@@ -1,0 +1,89 @@
+/**
+ * WordPress dependencies
+ */
+import { useCallback } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
+/**
+ * Internal dependencies
+ */
+import * as Tabs from '../../../components/tabs';
+
+type Status = 'inbox' | 'spam' | 'trash';
+
+type Counts = {
+	inbox: number;
+	spam: number;
+	trash: number;
+};
+
+type Props = {
+	activeStatus: Status;
+	counts: Counts;
+	onChange: ( nextStatus: Status ) => void;
+};
+
+const getLabel = ( status: Status, count: number ): string => {
+	switch ( status ) {
+		case 'inbox':
+			return sprintf(
+				/* translators: %d is the number of inbox responses. */
+				__( 'Inbox (%d)', 'jetpack-forms' ),
+				count
+			);
+		case 'spam':
+			return sprintf(
+				/* translators: %d is the number of spam responses. */
+				__( 'Spam (%d)', 'jetpack-forms' ),
+				count
+			);
+		case 'trash':
+			return sprintf(
+				/* translators: %d is the number of trash responses. */
+				__( 'Trash (%d)', 'jetpack-forms' ),
+				count
+			);
+	}
+};
+
+/**
+ * wp-build single-form view status tabs (Inbox / Spam / Trash).
+ *
+ * @param props              - Props.
+ * @param props.activeStatus - Current active status.
+ * @param props.counts       - Counts for each status.
+ * @param props.onChange     - Called when the status changes.
+ * @return Tabs UI.
+ */
+export default function InboxStatusToggle( {
+	activeStatus,
+	counts,
+	onChange,
+}: Props ): JSX.Element {
+	const handleChange = useCallback(
+		( nextStatus: Status ) => {
+			if ( nextStatus === activeStatus ) {
+				return;
+			}
+			onChange( nextStatus );
+		},
+		[ activeStatus, onChange ]
+	);
+
+	const statusTabs: Array< { value: Status; label: string } > = [
+		{ value: 'inbox', label: getLabel( 'inbox', counts.inbox ) },
+		{ value: 'spam', label: getLabel( 'spam', counts.spam ) },
+		{ value: 'trash', label: getLabel( 'trash', counts.trash ) },
+	];
+
+	return (
+		<Tabs.Root value={ activeStatus } onValueChange={ handleChange }>
+			<Tabs.List density="compact">
+				{ statusTabs.map( option => (
+					<Tabs.Tab key={ option.value } value={ option.value }>
+						{ option.label }
+					</Tabs.Tab>
+				) ) }
+			</Tabs.List>
+		</Tabs.Root>
+	);
+}

--- a/projects/packages/forms/src/dashboard/wp-build/components/inbox-status-toggle/index.tsx
+++ b/projects/packages/forms/src/dashboard/wp-build/components/inbox-status-toggle/index.tsx
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useCallback } from '@wordpress/element';
+import { useCallback, useMemo } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 /**
  * Internal dependencies
@@ -69,11 +69,14 @@ export default function InboxStatusToggle( {
 		[ activeStatus, onChange ]
 	);
 
-	const statusTabs: Array< { value: Status; label: string } > = [
-		{ value: 'inbox', label: getLabel( 'inbox', counts.inbox ) },
-		{ value: 'spam', label: getLabel( 'spam', counts.spam ) },
-		{ value: 'trash', label: getLabel( 'trash', counts.trash ) },
-	];
+	const statusTabs: Array< { value: Status; label: string } > = useMemo(
+		() => [
+			{ value: 'inbox', label: getLabel( 'inbox', counts.inbox ) },
+			{ value: 'spam', label: getLabel( 'spam', counts.spam ) },
+			{ value: 'trash', label: getLabel( 'trash', counts.trash ) },
+		],
+		[ counts.inbox, counts.spam, counts.trash ]
+	);
 
 	return (
 		<Tabs.Root value={ activeStatus } onValueChange={ handleChange }>


### PR DESCRIPTION
## Proposed changes:

Adds a single form screen in the wp-build dashboard. Approach: 
* **Responses route with query param.** Reuses the /response with source_id param (vs creating new route)
* **Updates query vs filter.** Uses source_id to update the query and return only responses for that source (vs using filter).   
* **Inbox/Spam/Trash tabs.** Based on past convos (see below), loads the status tabs (vs Forms | Responses). 
* **Hide source filter**. Since source in the query, hide the 'source' filter.
* **Hide folder filter**. Since we are using status tabs, we hide the 'folder' filter. 

**Not included.** This does not include updates to the header (title with breadcrumbs, subtitle, header actions), which I'm going to do in a separate PR. 
   
**Alternative approach.** We could use forms/$formId route. and we could could keep the Responses tab at the top (vs inbox/spam/trash) and use the folder filter.

**Screenshot**
<img width="1327" height="704" alt="single-form-screen-2" src="https://github.com/user-attachments/assets/8a615759-cdba-49a6-81fd-3f6aa88103d3" />

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
Slack: p1769531569790879/1769445176.678319-slack-C052XEUUBL4

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Enable these feature flags: 

```
add_filter( 'jetpack_forms_alpha', '__return_true', 20 );
add_filter( 'jetpack_block_editor_feature_flags', 'eb_register_feature' );
function eb_register_feature( $flags ) {
    $flags['central-form-management'] = true;
    return $flags;
}
```

Test:
* Go to Jetpack > Forms (WP-Build)
* Find a form with responses and click the form title or View responses action
* Confirm you go to a screen that only shows responses for the form
* Confirm Inbox | Spam | Trash tabs show and work correctly 
* Confirm there are no 'source' or 'folder' filters
