### PR TITLE
Newsletter: bundle DataViews CSS to fix missing design tokens

### DIFF
--- a/projects/packages/newsletter/changelog/fix-some-css
+++ b/projects/packages/newsletter/changelog/fix-some-css
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+CSS: Ensure dataforms css is loaded.

--- a/projects/packages/newsletter/src/settings/sections/newsletter-section.tsx
+++ b/projects/packages/newsletter/src/settings/sections/newsletter-section.tsx
@@ -57,7 +57,7 @@ export function NewsletterSection( {
 					onChange={ onChange }
 				/>
 				{ data.subscriptions && jetpackSettings && (
-					<div className="newsletter-settings__link">
+					<div>
 						<ExternalLink href={ jetpackSettings.subscriberManagementUrl }>
 							{ __( 'Manage all subscribers', 'jetpack-newsletter' ) }
 						</ExternalLink>

--- a/projects/packages/newsletter/src/settings/style.scss
+++ b/projects/packages/newsletter/src/settings/style.scss
@@ -1,3 +1,6 @@
+// Import dataviews styles for DataForm component
+@import "@wordpress/dataviews/build-style/style.css";
+
 .newsletter-settings {
 	max-width: 1200px;
 	margin-inline: auto;


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://linear.app/a8c/issue/DOTCOM-15924/fix-missing-css

## Proposed changes:
The DataForm component from @wordpress/dataviews expects CSS variables like --wpds-dimension-gap-md to be defined. These come from the package's stylesheet which wasn't being loaded.

Import the dataviews styles via SCSS to bundle them with our assets, ensuring the CSS version matches the JS package version we're using.

This made "Manage all subscribers" look far too spaced out, so addressed that too.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Make add_filter( 'jetpack_wp_admin_newsletter_settings_enabled', '__return_true' ); run early, e.g. by adding it to a new mu-plugin or just by pasting it into the top of jetpack-dev/jetpack.php using the plugin file editor on a jurassic ninja site.
2. Enable the newsletter module if it isn't already (it is on WoA)
3. Go to Jetpack → Newsletter in wp-admin

Before | After
-------|------
<img width="1136" height="1323" alt="Screenshot 2026-01-30 at 20 23 53" src="https://github.com/user-attachments/assets/793149bf-e01e-4eb9-a3f3-40301b3d1a84" /> | <img width="1136" height="1323" alt="Screenshot 2026-01-30 at 20 24 09" src="https://github.com/user-attachments/assets/60ab49b7-1c08-486a-9b2c-f32afb7def8c" />
