### PR TITLE
Stats Admin: Add sorting capability to Stats column

### DIFF
--- a/projects/packages/stats-admin/changelog/add-stats-column-sorting
+++ b/projects/packages/stats-admin/changelog/add-stats-column-sorting
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add sorting capability to the Stats column in post and page lists.

--- a/projects/packages/stats-admin/src/class-admin-post-list-column.php
+++ b/projects/packages/stats-admin/src/class-admin-post-list-column.php
@@ -375,6 +375,7 @@ class Admin_Post_List_Column {
 	 *
 	 * @param \WP_Query $query The WordPress query object.
 	 *
+	 * @since $$next-version$$
 	 * @return void
 	 */
 	public function handle_stats_column_sorting( $query ) {

--- a/projects/packages/stats-admin/src/class-admin-post-list-column.php
+++ b/projects/packages/stats-admin/src/class-admin-post-list-column.php
@@ -398,6 +398,8 @@ class Admin_Post_List_Column {
 	 * @param array     $posts The array of post objects.
 	 * @param \WP_Query $query The WordPress query object.
 	 *
+	 * @since $$next-version$$
+	 *
 	 * @return array
 	 */
 	public function sort_posts_by_stats( $posts, $query ) {

--- a/projects/packages/stats-admin/src/class-admin-post-list-column.php
+++ b/projects/packages/stats-admin/src/class-admin-post-list-column.php
@@ -54,6 +54,14 @@ class Admin_Post_List_Column {
 
 		add_action( 'manage_posts_custom_column', array( $this, 'add_stats_post_table_cell' ), 10, 2 );
 		add_action( 'manage_pages_custom_column', array( $this, 'add_stats_post_table_cell' ), 10, 2 );
+
+		// Make the stats column sortable.
+		add_filter( 'manage_edit-post_sortable_columns', array( $this, 'make_stats_column_sortable' ) );
+		add_filter( 'manage_edit-page_sortable_columns', array( $this, 'make_stats_column_sortable' ) );
+
+		// Handle the sorting logic.
+		add_action( 'pre_get_posts', array( $this, 'handle_stats_column_sorting' ) );
+		add_filter( 'posts_results', array( $this, 'sort_posts_by_stats' ), 10, 2 );
 	}
 
 	/**
@@ -348,5 +356,94 @@ class Admin_Post_List_Column {
 		}
 
 		return (string) $views;
+	}
+
+	/**
+	 * Make the stats column sortable.
+	 *
+	 * @param array $columns An array of sortable columns.
+	 *
+	 * @return array
+	 */
+	public function make_stats_column_sortable( $columns ) {
+		$columns['stats'] = 'stats';
+		return $columns;
+	}
+
+	/**
+	 * Handle sorting by the stats column.
+	 *
+	 * @param \WP_Query $query The WordPress query object.
+	 *
+	 * @return void
+	 */
+	public function handle_stats_column_sorting( $query ) {
+		if ( ! is_admin() || ! $query->is_main_query() ) {
+			return;
+		}
+
+		$orderby = $query->get( 'orderby' );
+
+		if ( 'stats' === $orderby ) {
+			// Set a flag to indicate we need to sort by stats.
+			// The actual sorting happens in sort_posts_by_stats().
+			$query->set( 'jetpack_sort_by_stats', true );
+		}
+	}
+
+	/**
+	 * Sort posts by stats views after query execution.
+	 *
+	 * @param array     $posts The array of post objects.
+	 * @param \WP_Query $query The WordPress query object.
+	 *
+	 * @return array
+	 */
+	public function sort_posts_by_stats( $posts, $query ) {
+		if ( ! is_admin() || ! $query->is_main_query() || ! $query->get( 'jetpack_sort_by_stats' ) ) {
+			return $posts;
+		}
+
+		if ( empty( $posts ) ) {
+			return $posts;
+		}
+
+		// Get stats for all posts in the current result set.
+		$post_ids    = wp_list_pluck( $posts, 'ID' );
+		$wpcom_stats = $this->get_stats();
+		$post_views  = $wpcom_stats->get_total_post_views(
+			array(
+				'num'      => 30,
+				'post_ids' => implode( ',', $post_ids ),
+			)
+		);
+
+		if ( is_wp_error( $post_views ) || empty( $post_views['posts'] ) ) {
+			return $posts;
+		}
+
+		// Create a map of post_id => views.
+		$views_map = array();
+		foreach ( $post_views['posts'] as $post_stats ) {
+			$views_map[ $post_stats['ID'] ] = (int) $post_stats['views'];
+		}
+
+		// Sort posts by view count.
+		usort(
+			$posts,
+			function ( $a, $b ) use ( $views_map, $query ) {
+				$views_a = $views_map[ $a->ID ] ?? 0;
+				$views_b = $views_map[ $b->ID ] ?? 0;
+
+				$order = $query->get( 'order' );
+				if ( 'asc' === strtolower( $order ) ) {
+					return $views_a <=> $views_b;
+				}
+
+				return $views_b <=> $views_a;
+			}
+		);
+
+		return $posts;
 	}
 }


### PR DESCRIPTION
## Summary

Adds sorting capability to the Stats column in WordPress post and page lists. Users can click the Stats column header to sort by view count (ascending/descending).

![2026-02-01_22-01-41 (1)](https://github.com/user-attachments/assets/706d283d-bc4f-4d46-84d6-c7261277e7fc)

## Technical Implementation

Sorts posts using the `posts_results` filter after the query executes:
1. Detects when sorting by stats is requested via `pre_get_posts` hook
2. Fetches stats for the current page of posts (reuses existing API call)
3. Sorts results in PHP using `usort()` with the view count data

This approach avoids database writes and ensures always-current data with no additional API overhead.

## Testing instructions:

**Prerequisites:** Jetpack Stats plugin active with published posts/pages that have view counts.

### Test Posts and Pages
1. Navigate to **Posts > All Posts** (or **Pages > All Pages**)
2. Click the **Stats** column header
3. Verify posts sort by view count, descending (highest first)
4. Click again - verify ascending sort (lowest first)
5. Verify the sort indicator arrow changes direction
6. Test other columns still sort independently

### Additional Checks
- Verify no JavaScript errors in browser console
- Verify no PHP errors in logs
- Test with pagination (if 20+ posts) to ensure sorting works correctly
- Verify unpublished posts or posts without views appear at the end when sorting

## Does this pull request change what data or activity we track or use?

No. Uses existing stats data already fetched and displayed. No new data storage, tracking, or transmission.