### PR TITLE
FORNO-177: Pass `mediaProps` to MediaSources component during replace flow

### DIFF
--- a/projects/packages/external-media/changelog/fix-missing-media-sources-prop
+++ b/projects/packages/external-media/changelog/fix-missing-media-sources-prop
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+
+External Media: pass media props to MediaSources during replace flow.
+

--- a/projects/packages/external-media/src/features/editor/index.js
+++ b/projects/packages/external-media/src/features/editor/index.js
@@ -100,7 +100,11 @@ if ( isUserConnected() && 'function' === typeof useBlockEditContext ) {
 					<>
 						<OriginalComponent { ...props }>
 							{ ( { onClose } ) => (
-								<MediaSources onClick={ onClose } setSource={ setSelectedSource } />
+								<MediaSources
+									mediaProps={ props }
+									onClick={ onClose }
+									setSource={ setSelectedSource }
+								/>
 							) }
 						</OriginalComponent>
 

--- a/projects/packages/external-media/src/shared/media-button/media-menu.js
+++ b/projects/packages/external-media/src/shared/media-button/media-menu.js
@@ -23,6 +23,7 @@ function MediaButtonMenu( props ) {
 	if ( isReplace ) {
 		return (
 			<MediaSources
+				mediaProps={ mediaProps }
 				originalButton={ originalComponent }
 				open={ open }
 				setSource={ setSelectedSource }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Passes `mediaProps` to `<MediaSources />` component when rendered by the "replace" button in the block toolbar. This is required for the `jetpack.externalMedia.extraMediaSources` filter to work correctly in this context. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
FORNO-177

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* [Checkout this PR](https://github.com/Automattic/jetpack/pull/46881#issuecomment-3832462094) on your sandbox using the instructions in this comment
* Go to the post editor and add an image block to the post
* In your browser console run this:

```
wp.hooks.addFilter( "jetpack.externalMedia.extraMediaSources", "myplugin", ( value, args ) => {
	return [{
		id: "myplugin-extra-source",
		label: "My Source",
		icon: "admin-site",
		onClick: () => {
		        const image = { id: 123, url: "https://example.com/image.jpg" }; // update this with an actual image attachment
			args.onSelect( args.multiple ? [ image ] : image );
		}
	}];
} );
```
* Click `Replace` from the image block toolbar and choose `My Source`
* Verify the block was updated with the specified attachment
