### PR TITLE
Charts: fix GeoChart Storybook docs error

### DIFF
--- a/projects/js-packages/charts/changelog/fix-geo-chart-storybook-docs
+++ b/projects/js-packages/charts/changelog/fix-geo-chart-storybook-docs
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+GeoChart: add missing stories referenced by Storybook MDX docs.

--- a/projects/js-packages/charts/changelog/fix-geo-chart-storybook-docs
+++ b/projects/js-packages/charts/changelog/fix-geo-chart-storybook-docs
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-GeoChart: add missing stories referenced by Storybook MDX docs.
+Add missing stories referenced by Storybook MDX docs.

--- a/projects/js-packages/charts/src/charts/geo-chart/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/charts/geo-chart/stories/index.stories.tsx
@@ -6,6 +6,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 const meta: Meta< typeof GeoChart > = {
 	...geoChartMetaArgs,
 	title: 'JS Packages/Charts Library/Charts/Geo Chart',
+	component: GeoChart,
 };
 
 export default meta;
@@ -49,5 +50,59 @@ export const EuropeanCountries: Story = {
 		region: '150',
 		resolution: 'countries',
 		data: viewsByEuropeanCountry,
+	},
+};
+
+// Stories referenced by index.docs.mdx
+export const WithTextTooltips: Story = {
+	args: {
+		...geoChartStoryArgs,
+		data: [
+			[ 'Country', 'Orders', { type: 'string', role: 'tooltip' } ],
+			[ 'United States', 1000, 'United States: 1,000 orders (40% of total)' ],
+			[ 'Canada', 500, 'Canada: 500 orders (20% of total)' ],
+			[ 'United Kingdom', 450, 'United Kingdom: 450 orders (18% of total)' ],
+		],
+	},
+};
+
+export const WithCustomTooltip: Story = {
+	args: {
+		...geoChartStoryArgs,
+		data: [
+			[ 'Country', 'Orders', { type: 'string', role: 'tooltip', p: { html: true } } ],
+			[ 'United States', 1000, '<b>United States</b><br/>1,000 orders' ],
+			[ 'Canada', 500, '<b>Canada</b><br/>500 orders' ],
+		],
+	},
+};
+
+export const WithFormattedValues: Story = {
+	args: {
+		...geoChartStoryArgs,
+		data: [
+			[ 'Country', 'Revenue' ],
+			[ 'United States', { v: 1234567, f: '$1.23M' } ],
+			[ 'Canada', { v: 543210, f: '$543K' } ],
+			[ 'United Kingdom', { v: 789012, f: '$789K' } ],
+		],
+	},
+};
+
+export const WithComplexTooltips: Story = {
+	args: {
+		...geoChartStoryArgs,
+		data: [
+			[ 'Country', 'Orders', { type: 'string', role: 'tooltip', p: { html: true } } ],
+			[
+				'United States',
+				1000,
+				`<div style="padding: 12px; font-family: sans-serif;">
+					<div style="font-weight: bold; font-size: 14px; margin-bottom: 8px;">🇺🇸 United States</div>
+					<div style="color: #666;">Orders: <strong>1,000</strong></div>
+					<div style="color: #666;">Share: <strong>40%</strong></div>
+				</div>`,
+			],
+		],
 	},
 };


### PR DESCRIPTION
Fixes CHARTS-158

## Proposed changes:
* Fix the "Unexpected of={undefined}" error on GeoChart Storybook docs page (https://automattic.github.io/jetpack-storybook/?path=/docs/js-packages-charts-library-charts-geo-chart--docs)
* Add missing stories referenced by `index.docs.mdx`: `WithTextTooltips`, `WithCustomTooltip`, `WithFormattedValues`, `WithComplexTooltips`
* Add explicit `component: GeoChart` in meta for proper autodocs resolution


| Before | After |
|--------|-------|
| <img width="1146" height="628" alt="Screenshot 2026-02-02 at 14 16 27" src="https://github.com/user-attachments/assets/8ca99e16-ee78-4476-8c63-db0181c67850" /> | <img width="1142" height="636" alt="Screenshot 2026-02-02 at 14 17 37" src="https://github.com/user-attachments/assets/35869b87-8267-49ca-ac12-6d50103ec8ac" /> |


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
N/A

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

* Run Storybook in `js-packages/charts`
* Navigate to "JS Packages/Charts Library/Charts/Geo Chart" docs page
* Verify there is no "of={undefined}" error
* Verify the Canvas components render the charts correctly