### PR TITLE
Charts: add constrainToParentHeight prop to withResponsive HOC

### DIFF
--- a/projects/js-packages/charts/changelog/add-constrain-to-parent-height
+++ b/projects/js-packages/charts/changelog/add-constrain-to-parent-height
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+withResponsive: add constrainToParentHeight prop to prevent chart overflow in fixed-height containers.

--- a/projects/js-packages/charts/changelog/add-constrain-to-parent-height
+++ b/projects/js-packages/charts/changelog/add-constrain-to-parent-height
@@ -1,4 +1,4 @@
 Significance: minor
 Type: added
 
-withResponsive: add constrainToParentHeight prop to prevent chart overflow in fixed-height containers.
+Add constrainToParentHeight prop to prevent chart overflow in fixed-height containers.

--- a/projects/js-packages/charts/src/charts/geo-chart/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/charts/geo-chart/stories/index.stories.tsx
@@ -113,7 +113,8 @@ export const ConstrainedToParentHeight: Story = {
 		constrainToParentHeight: true,
 		aspectRatio: 0.6,
 		/**
-		 * Remove the height prop to allow the chart to fill the parent container.
+		 * Set height to undefined so the wrapper uses 100% height,
+		 * enabling the constrainToParentHeight logic to work correctly.
 		 */
 		height: undefined,
 		containerWidth: '500px',

--- a/projects/js-packages/charts/src/charts/geo-chart/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/charts/geo-chart/stories/index.stories.tsx
@@ -110,7 +110,13 @@ export const WithComplexTooltips: Story = {
 export const ConstrainedToParentHeight: Story = {
 	args: {
 		...geoChartStoryArgs,
-		constrainToParentHeight: true,
-		containerHeight: '300px',
+		constrainToParentHeight: false,
+		aspectRatio: 0.6,
+		/**
+		 * Remove the height prop to allow the chart to fill the parent container.
+		 */
+		height: undefined,
+		containerWidth: '500px',
+		containerHeight: '200px',
 	},
 };

--- a/projects/js-packages/charts/src/charts/geo-chart/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/charts/geo-chart/stories/index.stories.tsx
@@ -110,7 +110,7 @@ export const WithComplexTooltips: Story = {
 export const ConstrainedToParentHeight: Story = {
 	args: {
 		...geoChartStoryArgs,
-		constrainToParentHeight: false,
+		constrainToParentHeight: true,
 		aspectRatio: 0.6,
 		/**
 		 * Remove the height prop to allow the chart to fill the parent container.

--- a/projects/js-packages/charts/src/charts/geo-chart/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/charts/geo-chart/stories/index.stories.tsx
@@ -106,3 +106,11 @@ export const WithComplexTooltips: Story = {
 		],
 	},
 };
+
+export const ConstrainedToParentHeight: Story = {
+	args: {
+		...geoChartStoryArgs,
+		constrainToParentHeight: true,
+		containerHeight: '300px',
+	},
+};

--- a/projects/js-packages/charts/src/charts/geo-chart/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/charts/geo-chart/stories/index.stories.tsx
@@ -109,15 +109,18 @@ export const WithComplexTooltips: Story = {
 
 export const ConstrainedToParentHeight: Story = {
 	args: {
-		...geoChartStoryArgs,
+		data: geoChartStoryArgs.data,
+		withPadding: geoChartStoryArgs.withPadding,
 		constrainToParentHeight: true,
 		aspectRatio: 0.6,
-		/**
-		 * Set height to undefined so the wrapper uses 100% height,
-		 * enabling the constrainToParentHeight logic to work correctly.
-		 */
-		height: undefined,
 		containerWidth: '500px',
 		containerHeight: '200px',
 	},
+	decorators: [
+		Story => (
+			<div style={ { overflow: 'hidden', height: '100%' } }>
+				<Story />
+			</div>
+		),
+	],
 };

--- a/projects/js-packages/charts/src/charts/private/with-responsive/test/with-responsive.test.tsx
+++ b/projects/js-packages/charts/src/charts/private/with-responsive/test/with-responsive.test.tsx
@@ -54,4 +54,36 @@ describe( 'withResponsive', () => {
 		render( <ResponsiveComponent data={ [] } /> );
 		expect( screen.getByTestId( 'responsive-container' ) ).toBeInTheDocument();
 	} );
+
+	describe( 'constrainToParentHeight', () => {
+		test( 'caps chart height at parent height when enabled and desired height exceeds parent', () => {
+			// With width 600 and aspectRatio 0.75, desired height would be 450
+			// But parent height is 300, so it should be capped at 300
+			render( <ResponsiveComponent data={ [] } aspectRatio={ 0.75 } constrainToParentHeight /> );
+			const component = screen.getByTestId( 'mock-component' );
+			expect( component ).toHaveStyle( { height: '300px' } );
+		} );
+
+		test( 'uses aspect ratio height when disabled regardless of parent height', () => {
+			// With width 600 and aspectRatio 0.75, height should be 450 (600 * 0.75)
+			// even though parent height is only 300
+			render(
+				<ResponsiveComponent data={ [] } aspectRatio={ 0.75 } constrainToParentHeight={ false } />
+			);
+			const component = screen.getByTestId( 'mock-component' );
+			expect( component ).toHaveStyle( { height: '450px' } );
+		} );
+
+		test( 'container has height 100% when constrainToParentHeight is enabled', () => {
+			render( <ResponsiveComponent data={ [] } constrainToParentHeight /> );
+			const wrapperDiv = screen.getByTestId( 'responsive-wrapper' );
+			expect( wrapperDiv ).toHaveStyle( { height: '100%' } );
+		} );
+
+		test( 'container has height auto when constrainToParentHeight is disabled', () => {
+			render( <ResponsiveComponent data={ [] } constrainToParentHeight={ false } /> );
+			const wrapperDiv = screen.getByTestId( 'responsive-wrapper' );
+			expect( wrapperDiv ).toHaveStyle( { height: 'auto' } );
+		} );
+	} );
 } );

--- a/projects/js-packages/charts/src/charts/private/with-responsive/test/with-responsive.test.tsx
+++ b/projects/js-packages/charts/src/charts/private/with-responsive/test/with-responsive.test.tsx
@@ -64,6 +64,14 @@ describe( 'withResponsive', () => {
 			expect( component ).toHaveStyle( { height: '300px' } );
 		} );
 
+		test( 'uses desired height when enabled but desired height is less than parent height', () => {
+			// With width 600 and aspectRatio 0.25, desired height would be 150
+			// Parent height is 300, so it should use desired height (150)
+			render( <ResponsiveComponent data={ [] } aspectRatio={ 0.25 } constrainToParentHeight /> );
+			const component = screen.getByTestId( 'mock-component' );
+			expect( component ).toHaveStyle( { height: '150px' } );
+		} );
+
 		test( 'uses aspect ratio height when disabled regardless of parent height', () => {
 			// With width 600 and aspectRatio 0.75, height should be 450 (600 * 0.75)
 			// even though parent height is only 300

--- a/projects/js-packages/charts/src/charts/private/with-responsive/with-responsive.tsx
+++ b/projects/js-packages/charts/src/charts/private/with-responsive/with-responsive.tsx
@@ -84,6 +84,7 @@ export function withResponsive< T extends Exclude< BaseChartProps< unknown >, 'o
 		return (
 			<div
 				ref={ parentRef }
+				data-testid="responsive-wrapper"
 				style={ {
 					width: chartProps.size ?? chartProps.width ?? '100%',
 					height: chartProps.size ?? chartProps.height ?? defaultHeight,

--- a/projects/js-packages/charts/src/charts/private/with-responsive/with-responsive.tsx
+++ b/projects/js-packages/charts/src/charts/private/with-responsive/with-responsive.tsx
@@ -15,20 +15,37 @@ export type ResponsiveConfig = {
 	 * Child render updates upon resize are delayed until debounceTime milliseconds after the last resize event is observed.
 	 */
 	resizeDebounceTime?: number;
+	/**
+	 * When true, constrains the chart height to not exceed the parent container height.
+	 * This prevents vertical scrollbars when the chart is inside a fixed-height container.
+	 * Requires the parent container to have a defined height. Defaults to false.
+	 */
+	constrainToParentHeight?: boolean;
 };
 
 const useResponsiveDimensions = ( {
 	resizeDebounceTime = 300,
 	maxWidth = 1200,
 	aspectRatio = 0.5,
+	constrainToParentHeight = false,
 }: ResponsiveConfig ) => {
-	const { parentRef, width: parentWidth } = useParentSize( {
+	const {
+		parentRef,
+		width: parentWidth,
+		height: parentHeight,
+	} = useParentSize( {
 		debounceTime: resizeDebounceTime,
 		enableDebounceLeadingCall: true,
 	} );
 
 	const containerWidth = parentWidth > 0 ? Math.min( parentWidth, maxWidth ) : 0;
-	const containerHeight = containerWidth * aspectRatio;
+	const desiredHeight = containerWidth * aspectRatio;
+
+	// Cap at parent height to prevent overflow when constrainToParentHeight is enabled
+	const containerHeight =
+		constrainToParentHeight && parentHeight > 0
+			? Math.min( desiredHeight, parentHeight )
+			: desiredHeight;
 
 	return { parentRef, width: containerWidth, height: containerHeight };
 };
@@ -47,6 +64,7 @@ export function withResponsive< T extends Exclude< BaseChartProps< unknown >, 'o
 		resizeDebounceTime = 300,
 		maxWidth = 1200,
 		aspectRatio = 0.5,
+		constrainToParentHeight = false,
 		...chartProps
 	}: Optional< T, 'width' | 'height' | 'size' > & ResponsiveConfig ) {
 		const {
@@ -57,14 +75,18 @@ export function withResponsive< T extends Exclude< BaseChartProps< unknown >, 'o
 			resizeDebounceTime,
 			maxWidth,
 			aspectRatio,
+			constrainToParentHeight,
 		} );
+
+		// When constrainToParentHeight is enabled, use 100% height to fill the parent container
+		const defaultHeight = constrainToParentHeight ? '100%' : 'auto';
 
 		return (
 			<div
 				ref={ parentRef }
 				style={ {
 					width: chartProps.size ?? chartProps.width ?? '100%',
-					height: chartProps.size ?? chartProps.height ?? 'auto',
+					height: chartProps.size ?? chartProps.height ?? defaultHeight,
 				} }
 			>
 				<WrappedComponent

--- a/projects/js-packages/charts/src/stories/chart-decorator.tsx
+++ b/projects/js-packages/charts/src/stories/chart-decorator.tsx
@@ -167,6 +167,12 @@ export const sharedChartArgTypes = {
 		description: 'Debounce time in ms for resize events (performance)',
 		table: { category: 'Performance' },
 	},
+	constrainToParentHeight: {
+		control: { type: 'boolean' },
+		description:
+			'When true, constrains the chart height to not exceed the parent container height. Prevents vertical scrollbars in fixed-height containers.',
+		table: { category: 'Dimensions' },
+	},
 	containerWidth: {
 		control: { type: 'text' },
 		description: 'CSS width value for the chart container (e.g., "400px", "100%")',


### PR DESCRIPTION
Fixes CHARTS-159

Related to WOOA7S-1034

## Proposed changes:

* Add `constrainToParentHeight` prop to `withResponsive` HOC to prevent charts from exceeding parent container height
* When enabled, chart height is capped at parent height using `Math.min(desiredHeight, parentHeight)`
* Add `ConstrainedToParentHeight` demo story for GeoChart

### Why this change?

Some Woo analytic widgets (e.g., Visitors by Location) have fixed heights where the chart should fit within the container without causing vertical scrollbars. The existing `aspectRatio` approach calculates height based on width, which can exceed the parent container height.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
N/A

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

* Run Storybook
* Navigate to "JS Packages/Charts Library/Charts/Geo Chart"
* Find the "Constrained To Parent Height" story
* Verify the chart fits within within the container without exceeding it
* Toggle `constrainToParentHeight` in controls to see the difference

| Before | After |
|--------|-------|
| <img width="1146" height="627" alt="Screenshot 2026-02-02 at 15 33 49" src="https://github.com/user-attachments/assets/26d77f46-c28f-4589-8676-7e4817efa60f" /> | <img width="1147" height="630" alt="Screenshot 2026-02-02 at 15 33 55" src="https://github.com/user-attachments/assets/df26d62b-9a07-49b9-977c-5a90410cc0e5" /> |


https://github.com/user-attachments/assets/26e1cf54-f8ec-4bc1-8f3e-4b668faebc8c

