### PR TITLE
Social: Clarify disabled account state with icon and simple text

### DIFF
--- a/projects/packages/publicize/_inc/components/customize-and-preview/preview-section/index.tsx
+++ b/projects/packages/publicize/_inc/components/customize-and-preview/preview-section/index.tsx
@@ -1,5 +1,6 @@
-import { Flex, Notice } from '@wordpress/components';
+import { Icon } from '@wordpress/components';
 import { __, _x } from '@wordpress/i18n';
+import { info } from '@wordpress/icons';
 import { Connection } from '../../../social-store/types';
 import { PostPreview } from '../../social-post-modal/post-preview';
 import styles from './styles.module.scss';
@@ -28,11 +29,10 @@ export function PreviewSection( { connection }: PreviewSectionProps ) {
 					<PostPreview connection={ connection } />
 				</>
 			) : (
-				<Flex className={ styles[ 'inactive-preview' ] } justify="center">
-					<Notice isDismissible={ false } status="info">
-						{ __( 'Enable sharing to this account to see the preview.', 'jetpack-publicize-pkg' ) }
-					</Notice>
-				</Flex>
+				<div className={ styles[ 'inactive-preview' ] }>
+					<Icon icon={ info } size={ 48 } />
+					<div>{ __( "The post won't be shared to this account.", 'jetpack-publicize-pkg' ) }</div>
+				</div>
 			) }
 		</section>
 	);

--- a/projects/packages/publicize/_inc/components/customize-and-preview/preview-section/styles.module.scss
+++ b/projects/packages/publicize/_inc/components/customize-and-preview/preview-section/styles.module.scss
@@ -12,5 +12,15 @@
 
 	.inactive-preview {
 		height: 100%;
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		justify-content: center;
+		gap: 0.5rem;
+		color: gb.$gray-700;
+
+		svg {
+			fill: gb.$gray-700;
+		}
 	}
 }

--- a/projects/packages/publicize/changelog/update-social-disabled-account-preview
+++ b/projects/packages/publicize/changelog/update-social-disabled-account-preview
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Preview Modal: Clarify disabled account state with icon and simple text.


### PR DESCRIPTION
# Social: Clarify disabled account state with icon and simple text

Closes SOCIAL-352

## Proposed changes:

This PR improves the UX of the preview section when a social account is disabled (not selected for sharing).

### Changes:
- **Simplified messaging**: Changed from "Enable sharing to this account to see the preview." to "The post won't be shared to this account." - this is clearer and more informative about the current state
- **Visual update**: Replaced the Notice component with a centered info icon and text for a cleaner, less alarming appearance


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

SOCIAL-352

## Does this pull request change what data or activity we track or use?

No changes to data tracking.

## Testing instructions:

1. Add the blog sticker to your site - `add_blog_sticker( 'jetpack-social-unified-ui-v1', null, null, <your-blog-id> )`;
2. Create or edit a post with Jetpack Social connections configured
3. Open the Social preview modal
4. Ensure you have at least one connection that is **disabled** (unchecked) for sharing
5. Click on the disabled connection in the modal
6. Verify the preview section shows:
   - A centered info icon
   - The text "The post won't be shared to this account."
   - The content should be gray and centered vertically
7. Toggle the connection back on and verify the normal preview appears

## Screenshots

| Before | After |
|--------|-------|
| <img width="868" height="775" alt="Screenshot 2026-02-02 at 11 48 00 AM" src="https://github.com/user-attachments/assets/1758c903-8835-44af-b89b-7c8e0c6e0408" /> | <img width="868" height="779" alt="Screenshot 2026-02-02 at 11 47 53 AM" src="https://github.com/user-attachments/assets/bf1b1693-6c2f-4f89-82d0-25d5f5cb8ec2" /> |
