### PR TITLE
Social: Retain selected preview tab on modal navigation

### DIFF
--- a/projects/packages/publicize/_inc/components/customize-and-preview/tab-panels/index.tsx
+++ b/projects/packages/publicize/_inc/components/customize-and-preview/tab-panels/index.tsx
@@ -1,6 +1,8 @@
 import { TabPanel } from '@wordpress/components';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { useCallback } from 'react';
 import { usePerNetworkCustomization } from '../../../hooks/use-per-network-customization';
+import { store as socialStore } from '../../../social-store';
 import { hasSocialPaidFeatures } from '../../../utils';
 import { CustomizationSection } from '../customization-section';
 import styles from './styles.module.scss';
@@ -30,6 +32,19 @@ export function TabPanelWrapper() {
 		[ usingPerNetworkCustomization ]
 	);
 
+	const { setUnifiedModalData } = useDispatch( socialStore );
+
+	const initialTab = useSelect( select => {
+		return select( socialStore ).getUnifiedModalData()?.socialPreview?.initialTab;
+	}, [] );
+
+	const onSelect = useCallback(
+		( tabName: string ) => {
+			setUnifiedModalData( { socialPreview: { initialTab: tabName } } );
+		},
+		[ setUnifiedModalData ]
+	);
+
 	return (
 		<div
 			className={ styles[ 'tab-panel-wrapper' ] }
@@ -39,6 +54,8 @@ export function TabPanelWrapper() {
 			{ ! usingPerNetworkCustomization && <CustomizationSection /> }
 			<TabPanel
 				className={ styles[ 'tab-panel' ] }
+				initialTabName={ initialTab }
+				onSelect={ onSelect }
 				tabs={ tabs }
 				children={ tabRenderer }
 				data-variant={ usingPerNetworkCustomization ? 'per-network' : 'global' }

--- a/projects/packages/publicize/_inc/components/unified-modal/sharing-activity/activity-view.tsx
+++ b/projects/packages/publicize/_inc/components/unified-modal/sharing-activity/activity-view.tsx
@@ -9,10 +9,10 @@ import {
 } from '@wordpress/dataviews';
 import { useCallback, useEffect, useMemo, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { SHARING_ACTIVITY_TABS } from '../../../utils';
 import ConnectionIcon from '../../connection-icon';
 import { ActivityAction } from './activity-action';
 import { ActivityStatus } from './activity-status';
-import { TABS } from './constants';
 import { ReadableTime } from './readable-time';
 import styles from './styles.module.scss';
 import { SharingActivityFilter, SharingActivityItem } from './types';
@@ -74,7 +74,7 @@ function getFiltersForTab( filter: SharingActivityFilter ): Filter[] {
  * @param {ActivityViewProps} props - Component props.
  * @return React element.
  */
-export function ActivityView( { filter = TABS.ALL }: ActivityViewProps ) {
+export function ActivityView( { filter = SHARING_ACTIVITY_TABS.ALL }: ActivityViewProps ) {
 	const { items, isLoading } = useSharingActivity();
 
 	// DataView state

--- a/projects/packages/publicize/_inc/components/unified-modal/sharing-activity/constants.ts
+++ b/projects/packages/publicize/_inc/components/unified-modal/sharing-activity/constants.ts
@@ -1,5 +1,0 @@
-export const TABS = {
-	ALL: 'all',
-	SHARED: 'shared',
-	SCHEDULED: 'scheduled',
-} as const;

--- a/projects/packages/publicize/_inc/components/unified-modal/sharing-activity/content.tsx
+++ b/projects/packages/publicize/_inc/components/unified-modal/sharing-activity/content.tsx
@@ -3,8 +3,8 @@ import { useSelect } from '@wordpress/data';
 import { useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { store as socialStore } from '../../../social-store';
+import { SHARING_ACTIVITY_TABS as TABS } from '../../../utils';
 import { ActivityView } from './activity-view';
-import { TABS } from './constants';
 import styles from './styles.module.scss';
 import type { SharingActivityFilter } from './types';
 
@@ -17,7 +17,7 @@ type Tab = React.ComponentProps< typeof TabPanel >[ 'tabs' ][ number ];
  */
 export function Content() {
 	const initialTab = useSelect( select => {
-		return select( socialStore ).getUnifiedModalData()?.initialTab ?? TABS.ALL;
+		return select( socialStore ).getUnifiedModalData()?.sharingActivity?.initialTab ?? TABS.ALL;
 	}, [] );
 
 	const tabs: Tab[] = useMemo(

--- a/projects/packages/publicize/_inc/components/unified-modal/sharing-activity/types.ts
+++ b/projects/packages/publicize/_inc/components/unified-modal/sharing-activity/types.ts
@@ -1,5 +1,4 @@
-import { ShareStatusItem } from '../../../social-store/types';
-import { TABS } from './constants';
+import { ShareStatusItem, UnifiedModalData } from '../../../social-store/types';
 
 /**
  * The activity type discriminator.
@@ -104,4 +103,4 @@ export type SharingActivityItem = SharedActivityItem | ScheduledActivityItem;
 /**
  * Filter values for the DataViews.
  */
-export type SharingActivityFilter = ( typeof TABS )[ keyof typeof TABS ];
+export type SharingActivityFilter = UnifiedModalData[ 'sharingActivity' ][ 'initialTab' ];

--- a/projects/packages/publicize/_inc/components/unified-modal/sharing-activity/types.ts
+++ b/projects/packages/publicize/_inc/components/unified-modal/sharing-activity/types.ts
@@ -103,4 +103,6 @@ export type SharingActivityItem = SharedActivityItem | ScheduledActivityItem;
 /**
  * Filter values for the DataViews.
  */
-export type SharingActivityFilter = UnifiedModalData[ 'sharingActivity' ][ 'initialTab' ];
+export type SharingActivityFilter = NonNullable<
+	NonNullable< UnifiedModalData[ 'sharingActivity' ] >[ 'initialTab' ]
+>;

--- a/projects/packages/publicize/_inc/components/unified-modal/social-post-preview/footer-content.tsx
+++ b/projects/packages/publicize/_inc/components/unified-modal/social-post-preview/footer-content.tsx
@@ -5,7 +5,7 @@ import { useCallback } from '@wordpress/element';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import useSocialMediaConnections from '../../../hooks/use-social-media-connections';
 import { store as socialStore } from '../../../social-store';
-import { TABS } from '../sharing-activity/constants';
+import { SHARING_ACTIVITY_TABS } from '../../../utils';
 import { ConfirmationConfig } from './confirmation-config';
 
 /**
@@ -25,7 +25,7 @@ function ScheduledPostsNav() {
 
 	const viewScheduled = useCallback( () => {
 		setUnifiedModalScreenLock( false );
-		setUnifiedModalData( { initialTab: TABS.SCHEDULED } );
+		setUnifiedModalData( { sharingActivity: { initialTab: SHARING_ACTIVITY_TABS.SCHEDULED } } );
 		navigator.goTo( '/sharing-activity' );
 	}, [ navigator, setUnifiedModalData, setUnifiedModalScreenLock ] );
 

--- a/projects/packages/publicize/_inc/hooks/use-schedule-post/index.tsx
+++ b/projects/packages/publicize/_inc/hooks/use-schedule-post/index.tsx
@@ -4,7 +4,7 @@ import { useDispatch } from '@wordpress/data';
 import { useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { store as socialStore } from '../../social-store';
-import { features } from '../../utils';
+import { features, SHARING_ACTIVITY_TABS } from '../../utils';
 import useSocialMediaConnections from '../use-social-media-connections';
 import useSocialMediaMessage from '../use-social-media-message';
 
@@ -28,7 +28,7 @@ export function useSchedulePost() {
 		// Just in case the modal is closed, we open it first.
 		openUnifiedModal( {
 			initialPath: '/sharing-activity',
-			data: { initialTab: 'scheduled' },
+			data: { sharingActivity: { initialTab: SHARING_ACTIVITY_TABS.SCHEDULED } },
 		} );
 
 		// Now do the navigation if it's already open.

--- a/projects/packages/publicize/_inc/social-store/reducer/unified-modal.ts
+++ b/projects/packages/publicize/_inc/social-store/reducer/unified-modal.ts
@@ -59,7 +59,10 @@ export function unifiedModal(
 		case SET_UNIFIED_MODAL_DATA:
 			return {
 				...state,
-				data: action.data,
+				data: {
+					...state?.data,
+					...action.data,
+				},
 			};
 		default:
 			return state;

--- a/projects/packages/publicize/_inc/social-store/types.ts
+++ b/projects/packages/publicize/_inc/social-store/types.ts
@@ -85,6 +85,9 @@ export type UnifiedModalData = {
 	sharingActivity?: {
 		initialTab?: ( typeof SHARING_ACTIVITY_TABS )[ keyof typeof SHARING_ACTIVITY_TABS ];
 	};
+	socialPreview?: {
+		initialTab?: string;
+	};
 };
 
 export type UnifiedModalState = {

--- a/projects/packages/publicize/_inc/social-store/types.ts
+++ b/projects/packages/publicize/_inc/social-store/types.ts
@@ -1,4 +1,4 @@
-import { AttachedMedia, MediaSourceValue } from '../utils';
+import { AttachedMedia, MediaSourceValue, SHARING_ACTIVITY_TABS } from '../utils';
 
 export type ConnectionStatus = 'ok' | 'broken' | 'must_reauth';
 
@@ -82,7 +82,9 @@ export type ScheduledShares = {
 };
 
 export type UnifiedModalData = {
-	initialTab?: string;
+	sharingActivity?: {
+		initialTab?: ( typeof SHARING_ACTIVITY_TABS )[ keyof typeof SHARING_ACTIVITY_TABS ];
+	};
 };
 
 export type UnifiedModalState = {

--- a/projects/packages/publicize/_inc/utils/constants.ts
+++ b/projects/packages/publicize/_inc/utils/constants.ts
@@ -3,3 +3,9 @@ export const features = {
 	IMAGE_GENERATOR: 'social-image-generator',
 	UNIFIED_UI_V1: 'social-unified-ui-v1',
 };
+
+export const SHARING_ACTIVITY_TABS = {
+	ALL: 'all',
+	SHARED: 'shared',
+	SCHEDULED: 'scheduled',
+} as const;

--- a/projects/packages/publicize/changelog/update-social-retain-the-preview-tab-on-modal-navigation
+++ b/projects/packages/publicize/changelog/update-social-retain-the-preview-tab-on-modal-navigation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Social Preview: Retain previously selected preview tab on navigation.


### PR DESCRIPTION
Fixes SOCIAL-347

## Proposed changes:

This PR fixes the issue where navigating away from the Social Preview screen (e.g., to edit a template) and returning would reset the selected tab (Customize/Preview) to the default.

### Changes:

1. **Persist selected tab**: The preview tab selection is now stored in the unified modal data and restored when returning to the screen

2. **Screen-specific modal data**: Refactored `UnifiedModalData` to be screen-specific:

   - `sharingActivity.initialTab` - for the Sharing Activity screen tabs
   - `socialPreview.initialTab` - for the Social Preview screen tabs (Customize/Preview)

3. **Merge modal data on update**: Updated the reducer to merge data instead of replacing it, so setting data for one screen doesn't erase data for another

4. **Consolidate constants**: Moved `SHARING_ACTIVITY_TABS` from a component-specific constants file to shared utils for better reusability

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

SOCIAL-347

## Does this pull request change what data or activity we track or use?

No changes to data tracking.

## Testing instructions:

- Create or edit a post with Jetpack Social connections configured
- Open the Social preview modal
- Select a connection other than the first one
- Set the media to use template
- Click on "Edit template"
- Navigate back to the preview screen
- **Verify**: The **connection** tab should still be selected (not reset to the first connection)

<table>
    <tbody>
        <tr>
            <th>BEFORE</th>
            <th>AFTER</th>
        </tr>
        <tr>
            <td>

https://github.com/user-attachments/assets/e421d139-2aa1-4a8b-aefa-9f2434ad5db4

</td>
            <td>

https://github.com/user-attachments/assets/172e1c2d-aad1-41e9-8d82-d4e8bd0892b9

</td>
        </tr>
    </tbody>
</table>
