### PR TITLE
Social: Adjust connection toggle UI and remove redundant "Preview" heading

### DIFF
--- a/projects/packages/publicize/_inc/components/customize-and-preview/preview-section/index.tsx
+++ b/projects/packages/publicize/_inc/components/customize-and-preview/preview-section/index.tsx
@@ -26,7 +26,9 @@ export function PreviewSection( { connection }: PreviewSectionProps ) {
 					<VisuallyHidden as="h2">
 						{ _x( 'Preview', 'Noun: Post preview section heading', 'jetpack-publicize-pkg' ) }
 					</VisuallyHidden>
-					<PostPreview connection={ connection } />
+					<div className={ styles[ 'preview-wrapper' ] }>
+						<PostPreview connection={ connection } />
+					</div>
 				</>
 			) : (
 				<div className={ styles[ 'inactive-preview' ] }>

--- a/projects/packages/publicize/_inc/components/customize-and-preview/preview-section/index.tsx
+++ b/projects/packages/publicize/_inc/components/customize-and-preview/preview-section/index.tsx
@@ -1,4 +1,4 @@
-import { Icon } from '@wordpress/components';
+import { Icon, VisuallyHidden } from '@wordpress/components';
 import { __, _x } from '@wordpress/i18n';
 import { info } from '@wordpress/icons';
 import { Connection } from '../../../social-store/types';
@@ -23,9 +23,9 @@ export function PreviewSection( { connection }: PreviewSectionProps ) {
 		>
 			{ connection.enabled ? (
 				<>
-					<h2>
+					<VisuallyHidden as="h2">
 						{ _x( 'Preview', 'Noun: Post preview section heading', 'jetpack-publicize-pkg' ) }
-					</h2>
+					</VisuallyHidden>
 					<PostPreview connection={ connection } />
 				</>
 			) : (

--- a/projects/packages/publicize/_inc/components/customize-and-preview/preview-section/styles.module.scss
+++ b/projects/packages/publicize/_inc/components/customize-and-preview/preview-section/styles.module.scss
@@ -17,4 +17,11 @@
 			fill: gb.$gray-700;
 		}
 	}
+
+	.preview-wrapper {
+		height: 100%;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+	}
 }

--- a/projects/packages/publicize/_inc/components/customize-and-preview/preview-section/styles.module.scss
+++ b/projects/packages/publicize/_inc/components/customize-and-preview/preview-section/styles.module.scss
@@ -4,12 +4,6 @@
 	background: gb.$gray-100;
 	padding: 1rem;
 
-	h2 {
-
-		@include gb.body-medium();
-		margin-top: 0;
-	}
-
 	.inactive-preview {
 		height: 100%;
 		display: flex;

--- a/projects/packages/publicize/_inc/components/customize-and-preview/tab-panels/styles.module.scss
+++ b/projects/packages/publicize/_inc/components/customize-and-preview/tab-panels/styles.module.scss
@@ -104,5 +104,7 @@
 }
 
 .connection-toggle-wrapper {
+	background: gb.$gray-100;
 	padding: 1rem;
+	padding-bottom: 0;
 }

--- a/projects/packages/publicize/changelog/update-social-adjust-connection-toggle-and-preview-heading
+++ b/projects/packages/publicize/changelog/update-social-adjust-connection-toggle-and-preview-heading
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Adjust connection toggle UI and remove redundant "Preview" heading.


### PR DESCRIPTION
Fixes SOCIAL-350, SOCIAL-351

## Proposed changes:

This PR improves the visual consistency of the Social Preview modal by adjusting the connection toggle styling and removing redundant UI elements.

### Changes:

1. **Remove redundant "Preview" heading**: The "Preview" heading inside the preview section is now visually hidden (still accessible to screen readers) since it's redundant when the user has already clicked the "Preview" tab

2. **Adjust connection toggle UI**: Added background color (`gray-100`) to the connection toggle wrapper to visually connect it with the preview section below, creating a more cohesive appearance

3. **Center align preview**: Adjusted the styling for preview to make it always center-aligned - both vertically and horizontally.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

SOCIAL-350

## Does this pull request change what data or activity we track or use?

No changes to data tracking.

## Testing instructions:

- 1. Add the blog sticker to your site - `add_blog_sticker( 'jetpack-social-unified-ui-v1', null, null, <your-blog-id> )`;

- Create or edit a post with Jetpack Social connections configured
- Open the Social preview modal
- **Verify**:
   - The "Preview" text heading should NOT be visible above the preview
   - The connection toggle (enable/disable switch) area should have a gray background that matches the preview section
   - The overall appearance should look more cohesive and less cluttered
- Remove the featured image from the post and any custom media from the customizations
- Confirm that the preview is center-aligned

## Screenshots

<table>
    <tbody>
        <tr>
            <th>BEFORE</th>
            <th>AFTER</th>
        </tr>
        <tr>
            <th colspan="2">Same for all</th>
        </tr>
        <tr>
            <td>
<img width="870" height="777" alt="Screenshot 2026-02-02 at 3 47 57 PM" src="https://github.com/user-attachments/assets/fcd9afae-ec36-49a8-8d92-291430fda783" />
</td>
            <td>
<img width="866" height="776" alt="Screenshot 2026-02-02 at 3 46 57 PM" src="https://github.com/user-attachments/assets/8e9887be-772e-4138-bf91-aa26f9859119" />
</td>
        </tr>
        <tr>
            <th colspan="2">Customize each</th>
        </tr>
        <tr>
            <td>
<img width="870" height="778" alt="Screenshot 2026-02-02 at 3 48 11 PM" src="https://github.com/user-attachments/assets/878c9f00-afe9-42cb-be81-43ef4b7f8836" />
</td>
            <td>
<img width="867" height="776" alt="Screenshot 2026-02-02 at 3 47 05 PM" src="https://github.com/user-attachments/assets/cb73537f-088d-467d-a823-d328102a94d5" />
</td>
        </tr>
        <tr>
            <th colspan="2">Connection disabled</th>
        </tr>
        <tr>
            <td>
<img width="869" height="778" alt="Screenshot 2026-02-02 at 3 48 20 PM" src="https://github.com/user-attachments/assets/9c4817ce-4a22-4b89-9d1a-ff69c4303654" />
</td>
            <td>
<img width="869" height="775" alt="Screenshot 2026-02-02 at 3 47 16 PM" src="https://github.com/user-attachments/assets/195133b2-d1a4-4eaf-bd54-bc5aac486a2f" />
</td>
        </tr>
        <tr>
            <th colspan="2">Preview alignment</th>
        </tr>
        <tr>
            <td>
<img width="866" height="776" alt="Screenshot 2026-02-02 at 4 13 40 PM" src="https://github.com/user-attachments/assets/b10e7be7-c91c-4735-b2db-6baac1e3c3be" />
</td>
            <td>
<img width="869" height="776" alt="Screenshot 2026-02-02 at 4 13 19 PM" src="https://github.com/user-attachments/assets/e5babee1-3c9d-4658-9aa1-c310a1ceed92" />
</td>
        </tr>
    </tbody>
</table>