### PR TITLE
Social: Open upgrade and demo links in new tab to preserve editor context

### DIFF
--- a/projects/packages/publicize/_inc/components/form/styles.module.scss
+++ b/projects/packages/publicize/_inc/components/form/styles.module.scss
@@ -97,15 +97,3 @@
 	opacity: 0.5;
 	pointer-events: none;
 }
-
-.upgrade-notice-customization {
-
-	:global(.components-notice__actions) {
-		margin-top: 12px;
-		margin-inline-start: 0;
-
-		:global(.components-button) {
-			margin-inline-start: 0;
-		}
-	}
-}

--- a/projects/packages/publicize/_inc/components/form/upgrade-notice-customization.tsx
+++ b/projects/packages/publicize/_inc/components/form/upgrade-notice-customization.tsx
@@ -1,13 +1,8 @@
 import { getRedirectUrl } from '@automattic/jetpack-components';
 import { isSimpleSite } from '@automattic/jetpack-script-data';
-import {
-	getSiteFragment,
-	useAutosaveAndRedirect,
-} from '@automattic/jetpack-shared-extension-utils';
-import { Notice } from '@wordpress/components';
+import { getSiteFragment } from '@automattic/jetpack-shared-extension-utils';
+import { Button, Flex, FlexItem, Notice } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import clsx from 'clsx';
-import styles from './styles.module.scss';
 
 /**
  * A notice for upgrading to a plan that supports per-network customization.
@@ -15,37 +10,36 @@ import styles from './styles.module.scss';
  * @return The UpgradeNoticeCustomization component.
  */
 export function UpgradeNoticeCustomization() {
+	if ( isSimpleSite() ) {
+		return null;
+	}
+
 	const redirectUrl = getRedirectUrl( 'jetpack-social-basic-plan-block-editor', {
 		site: getSiteFragment() || '',
 		query: 'redirect_to=' + encodeURIComponent( window.location.href ),
 	} );
 
-	const { autosaveAndRedirect, isRedirecting } = useAutosaveAndRedirect( redirectUrl );
-
-	if ( isSimpleSite() ) {
-		return null;
-	}
+	const message = __(
+		'Customize images and messages for each account for better engagement.',
+		'jetpack-publicize-pkg'
+	);
 
 	return (
-		<Notice
-			isDismissible={ false }
-			status="info"
-			className={ styles[ 'upgrade-notice-customization' ] }
-			actions={ [
-				{
-					variant: 'primary',
-					label: __( 'Upgrade now', 'jetpack-publicize-pkg' ),
-					onClick: isRedirecting ? undefined : autosaveAndRedirect,
-					className: clsx( 'is-compact', {
-						'is-busy': isRedirecting,
-					} ),
-				},
-			] }
-		>
-			{ __(
-				'Customize images and messages for each account for better engagement.',
-				'jetpack-publicize-pkg'
-			) }
+		/**
+		 * Render actions manually instead of using Notice actions prop
+		 * because actions are not flexible enough for our use case. e.g., the actions do not accept all the button props.
+		 *
+		 * @see https://github.com/WordPress/gutenberg/issues/74090
+		 */
+		<Notice isDismissible={ false } status="info" spokenMessage={ message }>
+			<Flex direction="column">
+				<FlexItem>{ message }</FlexItem>
+				<Flex>
+					<Button variant="primary" href={ redirectUrl } target="_blank" rel="noopener noreferrer">
+						{ __( 'Upgrade now', 'jetpack-publicize-pkg' ) }
+					</Button>
+				</Flex>
+			</Flex>
 		</Notice>
 	);
 }

--- a/projects/packages/publicize/_inc/components/form/upgrade-notice-customization.tsx
+++ b/projects/packages/publicize/_inc/components/form/upgrade-notice-customization.tsx
@@ -35,7 +35,13 @@ export function UpgradeNoticeCustomization() {
 			<Flex direction="column">
 				<FlexItem>{ message }</FlexItem>
 				<Flex>
-					<Button variant="primary" href={ redirectUrl } target="_blank" rel="noopener noreferrer">
+					<Button
+						variant="primary"
+						href={ redirectUrl }
+						className="is-compact"
+						target="_blank"
+						rel="noopener noreferrer"
+					>
 						{ __( 'Upgrade now', 'jetpack-publicize-pkg' ) }
 					</Button>
 				</Flex>

--- a/projects/packages/publicize/_inc/components/form/upgrade-notice.tsx
+++ b/projects/packages/publicize/_inc/components/form/upgrade-notice.tsx
@@ -1,12 +1,8 @@
 import { getRedirectUrl } from '@automattic/jetpack-components';
 import { isSimpleSite } from '@automattic/jetpack-script-data';
-import {
-	getSiteFragment,
-	useAutosaveAndRedirect,
-} from '@automattic/jetpack-shared-extension-utils';
-import { Notice } from '@wordpress/components';
+import { getSiteFragment } from '@automattic/jetpack-shared-extension-utils';
+import { Button, Flex, FlexItem, Notice } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import clsx from 'clsx';
 
 /**
  * A notice for upgrading to a plan that supports the Enhanced Publishing feature.
@@ -14,47 +10,52 @@ import clsx from 'clsx';
  * @return The UpgradeNotice component.
  */
 export function UpgradeNotice() {
-	const redirectUrl = getRedirectUrl( 'jetpack-social-basic-plan-block-editor', {
-		site: getSiteFragment() || '',
-		query: 'redirect_to=' + encodeURIComponent( window.location.href ),
-	} );
-
-	const { autosaveAndRedirect, isRedirecting } = useAutosaveAndRedirect( redirectUrl );
-
 	if ( isSimpleSite() ) {
 		// We don't have any upgrade options on Simple sites, yet.
 		return null;
 	}
 
+	const redirectUrl = getRedirectUrl( 'jetpack-social-basic-plan-block-editor', {
+		site: getSiteFragment() || '',
+		query: 'redirect_to=' + encodeURIComponent( window.location.href ),
+	} );
+
+	const message = __(
+		'Choose your social media image or video to share.',
+		'jetpack-publicize-pkg'
+	);
+
 	return (
-		<Notice
-			isDismissible={ false }
-			status="info"
-			actions={ [
-				{
-					variant: 'primary',
-					label: __( 'Upgrade now', 'jetpack-publicize-pkg' ),
-					/**
-					 * At the time of writing, Notice action does not support disabled or busy state,
-					 * @see https://github.com/WordPress/gutenberg/issues/74090
-					 */
-					// So we prevent onClick when redirecting.
-					onClick: isRedirecting ? undefined : autosaveAndRedirect,
-					className: clsx( 'is-compact', {
-						// Because of the above, we add a busy class for styling purposes.
-						'is-busy': isRedirecting,
-					} ),
-				},
-				{
-					variant: 'secondary',
-					label: __( 'View demo', 'jetpack-publicize-pkg' ),
-					noDefaultClasses: true,
-					className: 'is-compact',
-					url: getRedirectUrl( 'jetpack-social-landing-page' ),
-				},
-			] }
-		>
-			{ __( 'Choose your social media image or video to share.', 'jetpack-publicize-pkg' ) }
+		/**
+		 * Render actions manually instead of using Notice actions prop
+		 * because actions are not flexible enough for our use case. e.g., the actions do not accept all the button props.
+		 *
+		 * @see https://github.com/WordPress/gutenberg/issues/74090
+		 */
+		<Notice isDismissible={ false } status="info" spokenMessage={ message }>
+			<Flex direction="column">
+				<FlexItem>{ message }</FlexItem>
+				<Flex justify="flex-start" gap={ 3 }>
+					<Button
+						variant="primary"
+						className="is-compact"
+						href={ redirectUrl }
+						target="_blank"
+						rel="noopener noreferrer"
+					>
+						{ __( 'Upgrade now', 'jetpack-publicize-pkg' ) }
+					</Button>
+					<Button
+						variant="secondary"
+						href={ getRedirectUrl( 'jetpack-social-demo' ) }
+						target="_blank"
+						className="is-compact"
+						rel="noopener noreferrer"
+					>
+						{ __( 'View demo', 'jetpack-publicize-pkg' ) }
+					</Button>
+				</Flex>
+			</Flex>
 		</Notice>
 	);
 }

--- a/projects/packages/publicize/_inc/components/form/upgrade-notice.tsx
+++ b/projects/packages/publicize/_inc/components/form/upgrade-notice.tsx
@@ -35,7 +35,7 @@ export function UpgradeNotice() {
 		<Notice isDismissible={ false } status="info" spokenMessage={ message }>
 			<Flex direction="column">
 				<FlexItem>{ message }</FlexItem>
-				<Flex justify="flex-start" gap={ 3 }>
+				<Flex justify="start" gap={ 3 }>
 					<Button
 						variant="primary"
 						className="is-compact"

--- a/projects/packages/publicize/changelog/update-social-improve-upgrade-buttons
+++ b/projects/packages/publicize/changelog/update-social-improve-upgrade-buttons
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Convert upgrade and demo buttons to links that open in new tab.


### PR DESCRIPTION
Fixes SOCIAL-343

## Proposed changes:

This PR improves the upgrade flow by opening upgrade and demo links in a new tab instead of navigating away from the editor.

### Changes:

- **Open links in new tab**: Upgrade and demo buttons now open in a new tab (`target="_blank"`), preserving the editor context so users don't lose their work
- **Convert buttons to links**: Changed from using `useAutosaveAndRedirect` (which navigates away) to standard link buttons with proper `href` attributes
- **Render buttons manually**: Replaced the Notice `actions` prop with manually rendered buttons using Flex layout, as the actions prop doesn't support all necessary button props (see [Gutenberg issue #74090](https://github.com/WordPress/gutenberg/issues/74090))
- **Simplify code**: Removed unused `useAutosaveAndRedirect` hook, `clsx` import, and custom styles

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

SOCIAL-343

## Does this pull request change what data or activity we track or use?

No changes to data tracking.

## Testing instructions:

- Create or edit a post as a user without a paid Jetpack Social plan
- Open the Jetpack Social panel in the editor sidebar
- Click the **"Upgrade now"** button in the upgrade notice
- **Verify**: The upgrade page opens in a new tab, and your editor remains open with unsaved changes preserved
- Click the **"View demo"** button
- **Verify**: The demo page opens in a new tab and scrolls to the video on the social landing page
- Test both upgrade notices:
  - The general upgrade notice (in the Social panel)
  - The customization upgrade notice in the preview modal

- Sidebar
    <img width="280" height="244" alt="Screenshot 2026-02-02 at 4 55 09 PM" src="https://github.com/user-attachments/assets/8f87611f-a627-4f89-8992-839bdae07c14" />
- Preview modal
    <img width="334" height="187" alt="image" src="https://github.com/user-attachments/assets/9760980b-00e3-4c39-95e9-810ba09e1d37" />
