### PR TITLE
Try fixing renovate scheduled runs

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -22,7 +22,7 @@ on:
         description: 'Do OSV database lookups (slow)'
         type: boolean
   schedule:
-    - cron: '0 0/2 * * *'
+    - cron: '17 0/2 * * *'
 concurrency:
   group: renovate-${{ github.ref }}
 
@@ -58,7 +58,7 @@ jobs:
           renovate-version: 42.92.1
         env:
           LOG_LEVEL: ${{ github.event.inputs.logLevel || 'debug' }}
-          RENOVATE_DRY_RUN: ${{ case( github.event.inputs.dryRun == 'no', 'null', github.event.inputs.dryRun || 'null' ) }}
+          RENOVATE_DRY_RUN: ${{ github.event.inputs.dryRun == 'no' && 'null' || github.event.inputs.dryRun || 'null' }}
       - name: Check rate limit post-run
         env:
           TOKEN: ${{ secrets.RENOVATE_TOKEN }}


### PR DESCRIPTION
Closes MONOREP-338

 <!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Renovate's scheduled runs stopped working. Their AI claims it's because GitHub drops scheduled runs on the floor when they have too much load, rather than just delaying them, and that changing the minute will help. That sounds bogus, but may as well try changing the timing.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Merge and wait.
