### PR TITLE
Forms: add notes feature to wp-build single response view

### DIFF
--- a/projects/packages/forms/changelog/add-form-notes-to-wp-build
+++ b/projects/packages/forms/changelog/add-form-notes-to-wp-build
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Single Response View: add notes feature to wp-build dashboard.

--- a/projects/packages/forms/routes/responses/response/index.tsx
+++ b/projects/packages/forms/routes/responses/response/index.tsx
@@ -14,6 +14,7 @@ import * as React from 'react';
 /**
  * Internal dependencies
  */
+import FeedbackComments from '../../../src/dashboard/components/feedback-comments';
 import PreviewFile from '../../../src/dashboard/components/inspector/preview-file';
 import ResponseFieldsIterator from '../../../src/dashboard/components/inspector/response-fields';
 import ResponseMeta from '../../../src/dashboard/components/inspector/response-meta';

--- a/projects/packages/forms/routes/responses/response/index.tsx
+++ b/projects/packages/forms/routes/responses/response/index.tsx
@@ -53,6 +53,7 @@ function SingleResponseView( {
 	const [ hasMarkedAsRead, setHasMarkedAsRead ] = useState< number | null >( null );
 
 	const emptyTrashDays = useConfigValue( 'emptyTrashDays' ) ?? 0;
+	const isNotesEnabled = useConfigValue( 'isNotesEnabled' ) ?? false;
 
 	const { editEntityRecord } = useDispatch( coreStore ) as unknown as DispatchActions;
 
@@ -201,6 +202,8 @@ function SingleResponseView( {
 			<ResponseMeta response={ response } />
 
 			<ResponseFieldsIterator fields={ response.fields } onFilePreview={ handleFilePreview } />
+
+			{ isNotesEnabled && <FeedbackComments postId={ response.id } /> }
 
 			{ response.status === 'spam' && (
 				<div className="jp-forms__inbox__tip-container">

--- a/projects/packages/forms/src/dashboard/components/feedback-comments/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/feedback-comments/index.tsx
@@ -106,12 +106,6 @@ const FeedbackComments = ( { postId }: FeedbackCommentsProps ): JSX.Element => {
 		} );
 	}, [ commentsPage ] );
 
-	useEffect( () => {
-		setLoadedComments( [] );
-		setClientAddedComments( [] );
-		setPage( 1 );
-	}, [ postId ] );
-
 	const scrollToBottom = useCallback( () => {
 		const button = document.querySelector( '.jp-forms__feedback-comments-form-button' );
 		if ( button ) {

--- a/projects/packages/forms/src/dashboard/components/feedback-comments/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/feedback-comments/index.tsx
@@ -73,6 +73,15 @@ const FeedbackComments = ( { postId }: FeedbackCommentsProps ): JSX.Element => {
 		[ postId, page ]
 	);
 	const hasMoreComments = page * perPage < ( totalComments || 0 );
+
+	// Reset state when postId changes to avoid showing stale comments from a different post.
+	useEffect( () => {
+		setPage( 1 );
+		setLoadedComments( [] );
+		setClientAddedComments( [] );
+		setError( null );
+	}, [ postId ] );
+
 	useEffect( () => {
 		// If the selector returned nothing yet, do nothing.
 		if ( ! commentsPage ) {

--- a/projects/packages/forms/src/dashboard/components/feedback-comments/style.scss
+++ b/projects/packages/forms/src/dashboard/components/feedback-comments/style.scss
@@ -18,10 +18,6 @@
 	}
 }
 
-.jp-single-response-view .jp-forms__feedback-comments {
-	padding: 0;
-}
-
 .jp-forms__feedback-comments-heading {
 	font-size: 16px;
 	font-weight: 600;
@@ -55,7 +51,7 @@
 
 // Individual comment (item)
 .jp-forms__feedback-comments-comment {
-	background-color: var(--jp-forms-white-off, var(--wpds-color-stroke-surface-neutral-weak, #e7e7e7));
+	background-color: var(--jp-forms-white-off, var(--wpds-color-bg-surface-neutral-weak, #e7e7e7));
 	border-radius: var(--jp-forms-border-radius, 4px);
 	padding: 12px;
 
@@ -172,7 +168,7 @@
 .jp-forms__feedback-comments-error {
 	background-color: #f8d7da;
 	border: 1px solid #f5c2c7;
-	border-radius: var(--jp-forms-border-radius);
+	border-radius: var(--jp-forms-border-radius, 4px);
 	color: #842029;
 	font-size: 14px;
 	padding: 12px;

--- a/projects/packages/forms/src/dashboard/components/feedback-comments/style.scss
+++ b/projects/packages/forms/src/dashboard/components/feedback-comments/style.scss
@@ -18,6 +18,10 @@
 	}
 }
 
+.jp-single-response-view .jp-forms__feedback-comments {
+	padding: 0;
+}
+
 .jp-forms__feedback-comments-heading {
 	font-size: 16px;
 	font-weight: 600;
@@ -51,8 +55,8 @@
 
 // Individual comment (item)
 .jp-forms__feedback-comments-comment {
-	background-color: var(--jp-forms-white-off);
-	border-radius: var(--jp-forms-border-radius);
+	background-color: var(--jp-forms-white-off, var(--wpds-color-stroke-surface-neutral-weak, #e7e7e7));
+	border-radius: var(--jp-forms-border-radius, 4px);
 	padding: 12px;
 
 	@include mixins.flex-column;
@@ -76,7 +80,7 @@
 	.jp-forms__feedback-comments-comment-author {
 		font-size: 14px;
 		font-weight: 600;
-		color: var(--jp-forms-color-darker-20);
+		color: var(--jp-forms-color-darker-20, var(--wpds-color-fg-content-neutral, #1e1e1e));
 	}
 
 	.jp-forms__feedback-comments-comment-date {
@@ -107,7 +111,7 @@
 	flex-direction: column;
 	gap: 12px;
 	border: 1px solid var(--jp-forms-border-color, #ddd);
-	border-radius: var(--jp-forms-border-radius);
+	border-radius: var(--jp-forms-border-radius, 4px);
 	background-color: #fff;
 }
 


### PR DESCRIPTION
## Proposed changes:
- Integrates the FeedbackComments component into the single response view for the wp-build dashboard
- Enables users to add notes to form responses when the `isNotesEnabled` config flag is enabled
- Improves style fallbacks for the feedback comments component to work correctly in both classic and wp-build dashboard contexts (adds WPDS CSS variable fallbacks)
- Removes unnecessary useEffect that was resetting comment state on postId change

After:

<img width="421" height="381" alt="Screenshot 2026-02-05 at 4 12 21 PM" src="https://github.com/user-attachments/assets/ef2095f3-9076-4182-a2e6-4adb4fed0bcf" />


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

* Build the forms package: `jp build packages/forms`
* Navigate to a WordPress site with Jetpack Forms and the wp-build dashboard enabled
* Ensure notes are enabled via the config (set `isNotesEnabled` to `true`)
via 
```
add_filter( 'jetpack_forms_notes_enable', '__return_true' );
```

* Go to **Forms > Responses** and select a single response to view
* Verify that the notes/comments section appears below the response fields
* Add a note and verify it saves correctly
* Verify the styling looks correct (background color, border radius, text colors should all render properly)