### PR TITLE
Forms: add hook for wp-build dashboard header details

### DIFF
--- a/projects/packages/forms/changelog/update-consolide-wpbuild-header-logic
+++ b/projects/packages/forms/changelog/update-consolide-wpbuild-header-logic
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Forms: add hook for shared wp-build dashboard heaader details.

--- a/projects/packages/forms/routes/forms/stage.tsx
+++ b/projects/packages/forms/routes/forms/stage.tsx
@@ -3,6 +3,7 @@
  */
 import { Page } from '@wordpress/admin-ui';
 import { __experimentalConfirmDialog as ConfirmDialog } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
+import { useDispatch, useSelect } from '@wordpress/data';
 import { DataViews } from '@wordpress/dataviews';
 import { dateI18n, getSettings as getDateSettings } from '@wordpress/date';
 import { useEffect, useMemo, useState, useCallback } from '@wordpress/element';
@@ -12,12 +13,15 @@ import * as React from 'react';
 /**
  * Internal dependencies
  */
+import IntegrationsModal from '../../src/blocks/contact-form/components/jetpack-integrations-modal';
 import CreateFormButton from '../../src/dashboard/components/create-form-button/index.tsx';
 import { EmptyWrapper } from '../../src/dashboard/components/empty-responses/index.tsx';
-import FormsLogo from '../../src/dashboard/components/forms-logo';
 import useDeleteForm from '../../src/dashboard/hooks/use-delete-form.ts';
 import useFormsData from '../../src/dashboard/hooks/use-forms-data.ts';
 import DataViewsHeaderRow from '../../src/dashboard/wp-build/components/dataviews-header-row';
+import usePageHeaderDetails from '../../src/dashboard/wp-build/hooks/use-page-header-details';
+import useConfigValue from '../../src/hooks/use-config-value';
+import { INTEGRATIONS_STORE, IntegrationsSelectors } from '../../src/store/integrations';
 import type { FormListItem } from '../../src/dashboard/hooks/use-forms-data.ts';
 import type { Action, Operator, View } from '@wordpress/dataviews';
 
@@ -51,6 +55,14 @@ function StageInner() {
 	const searchParams = useSearch( { from: '/forms' } );
 
 	const dateSettings = getDateSettings();
+	const [ isIntegrationsModalOpen, setIsIntegrationsModalOpen ] = useState( false );
+	const integrations = useSelect(
+		select => ( select( INTEGRATIONS_STORE ) as IntegrationsSelectors ).getIntegrations?.() ?? [],
+		[]
+	);
+	const { refreshIntegrations } = useDispatch( INTEGRATIONS_STORE );
+	const isIntegrationsEnabled = useConfigValue( 'isIntegrationsEnabled' );
+	const showDashboardIntegrations = useConfigValue( 'showDashboardIntegrations' );
 
 	const [ view, setView ] = useState< View >( () => ( {
 		...DEFAULT_VIEW,
@@ -326,7 +338,23 @@ function StageInner() {
 		[ navigate, searchParams, view.search ]
 	);
 
-	const headerActions = useMemo( () => [ <CreateFormButton key="create" /> ], [] );
+	const openIntegrationsModal = useCallback( () => {
+		setIsIntegrationsModalOpen( true );
+	}, [] );
+	const closeIntegrationsModal = useCallback( () => {
+		setIsIntegrationsModalOpen( false );
+	}, [] );
+
+	const {
+		breadcrumbs,
+		subtitle,
+		actions: headerActions,
+	} = usePageHeaderDetails( {
+		screen: 'forms',
+		isIntegrationsEnabled: !! isIntegrationsEnabled,
+		showDashboardIntegrations: !! showDashboardIntegrations,
+		onOpenIntegrations: openIntegrationsModal,
+	} );
 	const getItemId = useCallback( ( item: FormListItem ) => String( item.id ), [] );
 	const onClickItem = useCallback(
 		( item: FormListItem ) => {
@@ -338,8 +366,8 @@ function StageInner() {
 	return (
 		<Page
 			showSidebarToggle={ false }
-			title={ <FormsLogo /> }
-			subTitle={ __( 'View and manage all your forms in one place.', 'jetpack-forms' ) }
+			breadcrumbs={ breadcrumbs }
+			subTitle={ subtitle }
 			actions={ headerActions }
 			hasPadding={ false }
 		>
@@ -401,6 +429,15 @@ function StageInner() {
 				<DataViews.Layout />
 				<DataViews.Footer />
 			</DataViews>
+			<IntegrationsModal
+				isOpen={ isIntegrationsModalOpen }
+				onClose={ closeIntegrationsModal }
+				attributes={ undefined }
+				setAttributes={ undefined }
+				integrationsData={ integrations }
+				refreshIntegrations={ refreshIntegrations }
+				context="dashboard"
+			/>
 		</Page>
 	);
 }

--- a/projects/packages/forms/routes/responses/stage.tsx
+++ b/projects/packages/forms/routes/responses/stage.tsx
@@ -10,7 +10,6 @@ import '@automattic/ui/style.css';
 import { Page } from '@wordpress/admin-ui';
 import {
 	__experimentalText as Text, // eslint-disable-line @wordpress/no-unsafe-wp-apis
-	Button,
 	ExternalLink,
 } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
@@ -19,7 +18,6 @@ import { dateI18n } from '@wordpress/date';
 import { useMemo, useState, useCallback, useEffect } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
 import { __, sprintf } from '@wordpress/i18n';
-import { download, plus } from '@wordpress/icons';
 import { useParams, useSearch, useNavigate } from '@wordpress/route';
 import { Stack } from '@wordpress/ui';
 import * as React from 'react';
@@ -28,16 +26,13 @@ import * as React from 'react';
  */
 import IntegrationsModal from '../../src/blocks/contact-form/components/jetpack-integrations-modal';
 import EmptyResponses from '../../src/dashboard/components/empty-responses';
-import EmptySpamButton from '../../src/dashboard/components/empty-spam-button';
-import EmptyTrashButton from '../../src/dashboard/components/empty-trash-button';
-import FormsLogo from '../../src/dashboard/components/forms-logo';
 import Gravatar from '../../src/dashboard/components/gravatar';
 import TextWithFlag from '../../src/dashboard/components/text-with-flag/index.tsx';
-import useCreateForm from '../../src/dashboard/hooks/use-create-form';
 import useInboxData from '../../src/dashboard/hooks/use-inbox-data.ts';
 import { getPath } from '../../src/dashboard/inbox/utils';
 import WpRouteDashboardSearchParamsProvider from '../../src/dashboard/router/wp-route-dashboard-search-params-provider.tsx';
 import DataViewsHeaderRow from '../../src/dashboard/wp-build/components/dataviews-header-row';
+import usePageHeaderDetails from '../../src/dashboard/wp-build/hooks/use-page-header-details';
 import useConfigValue from '../../src/hooks/use-config-value';
 import { INTEGRATIONS_STORE, IntegrationsSelectors } from '../../src/store/integrations';
 import { getActions } from './actions';
@@ -525,12 +520,6 @@ function StageInner() {
 		[ totalItems, totalPages ]
 	);
 
-	const { openNewForm } = useCreateForm();
-
-	const handleCreateForm = useCallback( () => {
-		openNewForm( { showPatterns: false } );
-	}, [ openNewForm ] );
-
 	const handleIntegrations = useCallback( () => {
 		setIsIntegrationsModalOpen( true );
 	}, [] );
@@ -539,64 +528,18 @@ function StageInner() {
 		setIsIntegrationsModalOpen( false );
 	}, [] );
 
-	const headerActions = useMemo( () => {
-		const actionsArray: React.ReactNode[] = [];
-
-		// Show integrations button on inbox when feature flags are enabled
-		if ( statusView === 'inbox' && isIntegrationsEnabled && showDashboardIntegrations ) {
-			actionsArray.push(
-				<Button
-					key="integrations"
-					variant="secondary"
-					size="compact"
-					onClick={ handleIntegrations }
-				>
-					{ __( 'Manage integrations', 'jetpack-forms' ) }
-				</Button>
-			);
-		}
-
-		if ( statusView === 'inbox' ) {
-			actionsArray.push(
-				<Button
-					key="create"
-					variant="secondary"
-					size="compact"
-					icon={ plus }
-					onClick={ handleCreateForm }
-				>
-					{ __( 'Create a form', 'jetpack-forms' ) }
-				</Button>
-			);
-		}
-
-		actionsArray.push(
-			<Button
-				key="export"
-				variant={ statusView === 'inbox' ? 'primary' : 'secondary' }
-				size="compact"
-				icon={ download }
-			>
-				{ __( 'Export', 'jetpack-forms' ) }
-			</Button>
-		);
-
-		if ( statusView === 'trash' ) {
-			actionsArray.push( <EmptyTrashButton key="empty-trash" /> );
-		}
-
-		if ( statusView === 'spam' ) {
-			actionsArray.push( <EmptySpamButton key="empty-spam" /> );
-		}
-
-		return actionsArray;
-	}, [
-		handleIntegrations,
-		handleCreateForm,
-		isIntegrationsEnabled,
-		showDashboardIntegrations,
+	const {
+		breadcrumbs,
+		subtitle,
+		actions: headerActions,
+	} = usePageHeaderDetails( {
+		screen: 'responses',
 		statusView,
-	] );
+		sourceId: sourceIdValue,
+		isIntegrationsEnabled: !! isIntegrationsEnabled,
+		showDashboardIntegrations: !! showDashboardIntegrations,
+		onOpenIntegrations: handleIntegrations,
+	} );
 
 	// Check if read_status filter is applied
 	const readStatusFilter = view.filters?.find( filter => filter.field === 'read_status' )?.value;
@@ -611,8 +554,8 @@ function StageInner() {
 	return (
 		<Page
 			showSidebarToggle={ false }
-			title={ <FormsLogo /> }
-			subTitle={ __( 'View and manage all your form submissions in one place.', 'jetpack-forms' ) }
+			breadcrumbs={ breadcrumbs }
+			subTitle={ subtitle }
 			actions={ headerActions }
 			hasPadding={ false }
 		>

--- a/projects/packages/forms/src/dashboard/wp-build/components/back-to-forms-button/index.tsx
+++ b/projects/packages/forms/src/dashboard/wp-build/components/back-to-forms-button/index.tsx
@@ -1,0 +1,23 @@
+/**
+ * WordPress dependencies
+ */
+import { Button } from '@wordpress/components';
+import { useCallback } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { useNavigate } from '@wordpress/route';
+
+/**
+ * wp-build primary action to return to the Forms list.
+ *
+ * @return Button element.
+ */
+export default function BackToFormsButton(): JSX.Element {
+	const navigate = useNavigate();
+	const onClick = useCallback( () => navigate( { href: '/forms' } ), [ navigate ] );
+
+	return (
+		<Button size="compact" variant="primary" onClick={ onClick }>
+			{ __( 'Back to forms', 'jetpack-forms' ) }
+		</Button>
+	);
+}

--- a/projects/packages/forms/src/dashboard/wp-build/components/export-responses-button/index.tsx
+++ b/projects/packages/forms/src/dashboard/wp-build/components/export-responses-button/index.tsx
@@ -1,0 +1,37 @@
+/**
+ * WordPress dependencies
+ */
+import { Button } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { download } from '@wordpress/icons';
+
+type Props = {
+	isPrimary?: boolean;
+	onClick?: () => void;
+};
+
+/**
+ * wp-build dashboard export button (placeholder).
+ *
+ * Note: wp-build does not yet use the full export flow/modal from the old dashboard.
+ *
+ * @param props           - Props.
+ * @param props.isPrimary - Whether the button should be primary.
+ * @param props.onClick   - Optional click handler.
+ * @return Button element.
+ */
+export default function ExportResponsesButton( {
+	isPrimary = false,
+	onClick,
+}: Props ): JSX.Element {
+	return (
+		<Button
+			size="compact"
+			variant={ isPrimary ? 'primary' : 'secondary' }
+			icon={ download }
+			onClick={ onClick }
+		>
+			{ __( 'Export', 'jetpack-forms' ) }
+		</Button>
+	);
+}

--- a/projects/packages/forms/src/dashboard/wp-build/components/manage-integrations-button/index.tsx
+++ b/projects/packages/forms/src/dashboard/wp-build/components/manage-integrations-button/index.tsx
@@ -1,0 +1,24 @@
+/**
+ * WordPress dependencies
+ */
+import { Button } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+type Props = {
+	onClick: () => void;
+};
+
+/**
+ * wp-build dashboard button to open the integrations modal.
+ *
+ * @param props         - Props.
+ * @param props.onClick - Click handler (typically opens a modal in the parent).
+ * @return Button element.
+ */
+export default function ManageIntegrationsButton( { onClick }: Props ): JSX.Element {
+	return (
+		<Button size="compact" variant="secondary" onClick={ onClick }>
+			{ __( 'Manage integrations', 'jetpack-forms' ) }
+		</Button>
+	);
+}

--- a/projects/packages/forms/src/dashboard/wp-build/hooks/use-page-header-details.tsx
+++ b/projects/packages/forms/src/dashboard/wp-build/hooks/use-page-header-details.tsx
@@ -1,0 +1,177 @@
+/**
+ * External dependencies
+ */
+import JetpackLogo from '@automattic/jetpack-components/jetpack-logo';
+/**
+ * WordPress dependencies
+ */
+import { Breadcrumbs } from '@wordpress/admin-ui';
+import { store as coreDataStore } from '@wordpress/core-data';
+import { useSelect } from '@wordpress/data';
+import { useMemo } from '@wordpress/element';
+import { decodeEntities } from '@wordpress/html-entities';
+import { __, sprintf } from '@wordpress/i18n';
+import { Stack } from '@wordpress/ui';
+/**
+ * Internal dependencies
+ */
+import CreateFormButton from '../../components/create-form-button';
+import EditFormButton from '../../components/edit-form-button';
+import EmptySpamButton from '../../components/empty-spam-button';
+import EmptyTrashButton from '../../components/empty-trash-button';
+import ExportResponsesButton from '../../components/export-responses/button';
+import BackToFormsButton from '../components/back-to-forms-button';
+import ManageIntegrationsButton from '../components/manage-integrations-button';
+import type { ReactNode } from 'react';
+
+type ResponsesStatusView = 'inbox' | 'spam' | 'trash';
+
+type UsePageHeaderDetailsProps = {
+	screen: 'forms' | 'responses';
+	statusView?: ResponsesStatusView;
+	sourceId?: string | number;
+	isIntegrationsEnabled: boolean;
+	showDashboardIntegrations: boolean;
+	onOpenIntegrations: () => void;
+};
+
+type UsePageHeaderDetailsReturn = {
+	breadcrumbs: ReactNode;
+	subtitle: ReactNode;
+	actions?: ReactNode;
+};
+
+/**
+ * Build wp-build page header details (breadcrumbs, subtitle, actions).
+ *
+ * This hook is intentionally scoped to just what is passed into the wp-build `<Page />`
+ * component to keep route files readable.
+ *
+ * @param props - Props.
+ * @return Page header details.
+ */
+export default function usePageHeaderDetails(
+	props: UsePageHeaderDetailsProps
+): UsePageHeaderDetailsReturn {
+	const { screen, sourceId, isIntegrationsEnabled, showDashboardIntegrations, onOpenIntegrations } =
+		props;
+	const statusView: ResponsesStatusView = props.statusView ?? 'inbox';
+	const sourceIdNumber = useMemo( () => {
+		const value = sourceId;
+		const numberValue = typeof value === 'number' ? value : Number( value );
+		return Number.isFinite( numberValue ) && numberValue > 0 ? numberValue : null;
+	}, [ sourceId ] );
+
+	// Mutually-exclusive screen flags.
+	const isFormsScreen = screen === 'forms';
+	const isSingleFormScreen = screen === 'responses' && sourceIdNumber !== null;
+
+	const formRecord = useSelect(
+		select =>
+			sourceIdNumber
+				? ( select( coreDataStore ).getEntityRecord(
+						'postType',
+						'jetpack_form',
+						sourceIdNumber
+				  ) as { title?: { rendered?: string } } | undefined )
+				: undefined,
+		[ sourceIdNumber ]
+	);
+
+	const formTitle = useMemo( () => {
+		const rendered = formRecord?.title?.rendered || '';
+		return decodeEntities( rendered );
+	}, [ formRecord?.title?.rendered ] );
+
+	const breadcrumbsItems = useMemo( () => {
+		if ( isFormsScreen ) {
+			return [ { label: __( 'Forms', 'jetpack-forms' ) } ];
+		}
+
+		if ( isSingleFormScreen ) {
+			return [
+				{ label: __( 'Forms', 'jetpack-forms' ), to: '/forms' },
+				{ label: formTitle || __( 'Form responses', 'jetpack-forms' ) },
+			];
+		}
+
+		return [
+			{ label: __( 'Forms', 'jetpack-forms' ), to: '/forms' },
+			{ label: __( 'Form Responses', 'jetpack-forms' ) },
+		];
+	}, [ formTitle, isFormsScreen, isSingleFormScreen ] );
+
+	const breadcrumbs = useMemo( () => {
+		return (
+			<Stack align="center" gap="xs">
+				<JetpackLogo showText={ false } width={ 20 } />
+				<Breadcrumbs items={ breadcrumbsItems } />
+			</Stack>
+		);
+	}, [ breadcrumbsItems ] );
+
+	const subtitle = useMemo( () => {
+		if ( isFormsScreen ) {
+			return __( 'View and manage all your forms in one place.', 'jetpack-forms' );
+		}
+
+		if ( isSingleFormScreen ) {
+			if ( formTitle ) {
+				return sprintf(
+					/* translators: %s: form name */
+					__( 'View responses for %s.', 'jetpack-forms' ),
+					formTitle
+				);
+			}
+			return __( 'View responses for this form.', 'jetpack-forms' );
+		}
+
+		return __( 'View and manage all your form submissions in one place.', 'jetpack-forms' );
+	}, [ formTitle, isFormsScreen, isSingleFormScreen ] );
+
+	const actions = useMemo( () => {
+		if ( isFormsScreen ) {
+			return [
+				...( isIntegrationsEnabled && showDashboardIntegrations
+					? [ <ManageIntegrationsButton key="integrations" onClick={ onOpenIntegrations } /> ]
+					: [] ),
+				<CreateFormButton key="create" />,
+			];
+		}
+
+		if ( isSingleFormScreen ) {
+			return [
+				<BackToFormsButton key="back-to-forms" />,
+				...( sourceIdNumber
+					? [ <EditFormButton key="edit-form" formId={ sourceIdNumber } /> ]
+					: [] ),
+				<ExportResponsesButton key="export" isPrimary={ false } />,
+				...( statusView === 'trash' ? [ <EmptyTrashButton key="empty-trash" /> ] : [] ),
+				...( statusView === 'spam' ? [ <EmptySpamButton key="empty-spam" /> ] : [] ),
+			];
+		}
+
+		// Responses list screen.
+		return [
+			...( statusView === 'inbox' && isIntegrationsEnabled && showDashboardIntegrations
+				? [ <ManageIntegrationsButton key="integrations" onClick={ onOpenIntegrations } /> ]
+				: [] ),
+			...( statusView === 'inbox'
+				? [ <CreateFormButton key="create" variant="secondary" showPatterns={ false } /> ]
+				: [] ),
+			<ExportResponsesButton key="export" isPrimary={ statusView === 'inbox' } />,
+			...( statusView === 'trash' ? [ <EmptyTrashButton key="empty-trash" /> ] : [] ),
+			...( statusView === 'spam' ? [ <EmptySpamButton key="empty-spam" /> ] : [] ),
+		];
+	}, [
+		isIntegrationsEnabled,
+		onOpenIntegrations,
+		showDashboardIntegrations,
+		sourceIdNumber,
+		isFormsScreen,
+		isSingleFormScreen,
+		statusView,
+	] );
+
+	return { breadcrumbs, subtitle, actions };
+}

--- a/projects/packages/forms/src/dashboard/wp-build/hooks/use-page-header-details.tsx
+++ b/projects/packages/forms/src/dashboard/wp-build/hooks/use-page-header-details.tsx
@@ -19,8 +19,8 @@ import CreateFormButton from '../../components/create-form-button';
 import EditFormButton from '../../components/edit-form-button';
 import EmptySpamButton from '../../components/empty-spam-button';
 import EmptyTrashButton from '../../components/empty-trash-button';
-import ExportResponsesButton from '../../components/export-responses/button';
 import BackToFormsButton from '../components/back-to-forms-button';
+import ExportResponsesButton from '../components/export-responses-button';
 import ManageIntegrationsButton from '../components/manage-integrations-button';
 import type { ReactNode } from 'react';
 

--- a/projects/packages/forms/src/dashboard/wp-build/hooks/use-page-header-details.tsx
+++ b/projects/packages/forms/src/dashboard/wp-build/hooks/use-page-header-details.tsx
@@ -95,10 +95,8 @@ export default function usePageHeaderDetails(
 			];
 		}
 
-		return [
-			{ label: __( 'Forms', 'jetpack-forms' ), to: '/forms' },
-			{ label: __( 'Form Responses', 'jetpack-forms' ) },
-		];
+		// Responses list screen.
+		return [ { label: __( 'Form Responses', 'jetpack-forms' ) } ];
 	}, [ formTitle, isFormsScreen, isSingleFormScreen ] );
 
 	const breadcrumbs = useMemo( () => {


### PR DESCRIPTION
## Proposed changes:

This PR makes the following changes: 
* **usePageHeaderDetails hook**. Adds new hook to fetch details needed for the header for different screens: breadcrumbs, page title, header buttons
* **Breadcrumbs**. Updates the screen titles to use the gutenberg breadcrumb component
* **Forms screen**. Updates which header action buttons show. 
* **Single forms screen**. Updates the title (breadcrumbs), subtitle, and header action buttons. 
* **New components**. Creates new components for header action buttons. We can't use the same buttons in many cases because of routing or build issues. These likely need additional work. For example, the Export Responses button is a placeholder. 

**KNOWN ISSUES**
- The breadcrumb titles are not vertically aligned with the logo. Easy to fix with some CSS, but since we're not trying to override core elements with CSS, possibly hard to fix. 
- The first breadcrumb on single form screen ( Forms > Form Name )... Forms renders as a blue link unlike designs.
- The Export Responses button is a placeholder that does not work. Trying to import and use the old one breaks the build. 

**Responses screen**
<img width="1339" height="633" alt="wpbuild-responses-screen" src="https://github.com/user-attachments/assets/7d7be889-b541-4181-a2e2-ed6d1c0728ab" />

**Forms screen**
<img width="1336" height="637" alt="wpbuild-forms-screen" src="https://github.com/user-attachments/assets/ece6c87a-eb97-4d64-b82f-ceb5543cef40" />

**Single form screen**
<img width="1336" height="643" alt="wpbuild-single-form-screen" src="https://github.com/user-attachments/assets/8b7c5941-e3ad-42a1-a506-5fd67dcc8452" />

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Enable these feature flags: 

```
add_filter( 'jetpack_forms_alpha', '__return_true', 20 );
add_filter( 'jetpack_block_editor_feature_flags', 'eb_register_feature' );
function eb_register_feature( $flags ) {
    $flags['central-form-management'] = true;
    return $flags;
}
```

Test:
* Go to Jetpack > Forms (WP-Build)
* Responses screen: confirm title, subtitle, and header action buttons are correct.
* Forms screen: confirm title, subtitle, and header action buttons are correct.
* Single form screen: confirm title, subtitle, and header action buttons are correct.
* Test Manage Integration, Create Form, and Edit Form header buttons. 
