### PR TITLE
ci: Use artifacts, not cache, for intra-workflow communication

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -13,7 +13,7 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  # actions/checkout, actions/cache?, actions/upload-artifact, actions/download-artifact
+  # actions/checkout, actions/upload-artifact, actions/download-artifact
   contents: read
 
 env:
@@ -81,65 +81,66 @@ jobs:
       matrix:
         include: ${{ fromJson( needs.create-test-matrix.outputs.build-matrix ) }}
     steps:
-      - name: Ensure ${{ matrix.buildGroup }} build cache
-        id: jetpack-build-cache
-        uses: actions/cache/restore@v5
-        with:
-          lookup-only: true
-          path: |
-            .
-            !./.github/
-          key: ${{ matrix.buildGroup }}-${{ github.sha }}
-
       - name: Checkout code
-        if: steps.jetpack-build-cache.outputs.cache-hit != 'true'
         uses: actions/checkout@v6
 
       - name: Setup tools
-        if: steps.jetpack-build-cache.outputs.cache-hit != 'true'
         uses: ./.github/actions/tool-setup
 
       - name: Install monorepo
-        if: steps.jetpack-build-cache.outputs.cache-hit != 'true'
         run: pnpm install
 
       - name: Build projects
         id: build-step
-        if: steps.jetpack-build-cache.outputs.cache-hit != 'true'
         env:
           COMPOSER_ROOT_VERSION: "dev-trunk"
           BUILD_DIR: ./build-output
           PROJECT_PATH: ${{ matrix.path }}
         run: |
           find . -path ./.github -prune -o -type f -print | sort > /tmp/before.txt
+          find . -path ./.github -prune -o -type l -print | sort > /tmp/beforel.txt
           echo "::group::Build plugin(s)"
           cd "$PROJECT_PATH"
           pnpm run build
           cd "$GITHUB_WORKSPACE"
           echo "::endgroup::"
+          find . -path ./.github -prune -o -type f -print | sort > /tmp/after.txt
+          find . -path ./.github -prune -o -type l -print | sort > /tmp/afterl.txt
 
           # We only want to save the files that were actually created or changed.
-          # But we can't just list them for actions/cache/save, "Argument list too long".
-          # So instead we delete all the unchanged files so we can tell actions/cache/save
-          # to save everything that's left.
-          git -c core.quotepath=off diff --name-only | sort > /tmp/changed.txt
-          if [[ -s /tmp/changed.txt ]]; then
-            grep -F -x -v -f /tmp/changed.txt /tmp/before.txt > /tmp/remove.txt
-          else
-            cp /tmp/before.txt /tmp/remove.txt
-          fi
-          xargs -d '\n' rm < /tmp/remove.txt
-          find . -type d -empty -delete
+          {
+            comm -13 /tmp/before.txt /tmp/after.txt
+            git -c core.quotepath=off diff --name-only
+          } | sed 's!^./!!' | sort -u > /tmp/changed.txt
+          comm -13 /tmp/beforel.txt /tmp/afterl.txt | sed 's!^./!!' > /tmp/changedl.txt
+
+          # There will probably be a bunch of duplicate vendor files. Try to deduplicate them.
+          echo "::group::Deduplicating files"
+          xargs -d '\n' sha256sum < /tmp/changed.txt | perl -nwe '
+            BEGIN { $h = ""; $f = ""; }
+            die "WTF? $_" unless /^([0-9a-f]{64})  (\S.*)$/;
+            if ( $h ne $1 ) {
+              $h=$1; $l=$2;
+            } else {
+              print "$2 → $f\n";
+              unlink( $2 ) or die "Failed to delete $2: $!\n";
+              link( $f, $2 ) or die "Failed to link $2 → $f: $!\n";
+            }
+          '
+          echo "::endgroup::"
+
+          echo "::group::Creating artifact"
+          sed 's!^!./!' /tmp/changed.txt /tmp/changedl.txt | tar -cvvf build-cache.tar.xz
+          echo "::endgroup::"
 
       - name: Save ${{ matrix.buildGroup }} build cache
-        if: steps.jetpack-build-cache.outputs.cache-hit != 'true'
-        id: jetpack-build-cache-save
-        uses: actions/cache/save@v5
+        uses: actions/upload-artifact@v6
         with:
-          path: |
-            .
-            !./.github/
-          key: ${{ steps.jetpack-build-cache.outputs.cache-primary-key }}
+          name: ${{ matrix.buildGroup }}
+          path: build-cache.tar.xz
+          retention-days: 1
+          # Already compressed.
+          compression-level: 0
 
   e2e-tests:
     name: "${{ matrix.project }} e2e tests"
@@ -161,15 +162,14 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Restore ${{ matrix.buildGroup }} build cache
-        id: jetpack-build-cache
+        uses: actions/download-artifact@v7
         if: needs.build-projects.result == 'success' && ! startsWith( matrix.suite, 'atomic' )
-        uses: actions/cache/restore@v5
         with:
-          path: |
-            .
-            !./.github/
-          key: ${{ matrix.buildGroup }}-${{ github.sha }}
-          fail-on-cache-miss: true
+          name: ${{ matrix.buildGroup }}
+      - name: Extract ${{ matrix.buildGroup }} build cache
+        if: needs.build-projects.result == 'success' && ! startsWith( matrix.suite, 'atomic' )
+        run: |
+          tar -xvvf build-cache.tar.xz .
 
       - name: Setup tools
         uses: ./.github/actions/tool-setup

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -130,7 +130,7 @@ jobs:
           echo "::endgroup::"
 
           echo "::group::Creating artifact"
-          sed 's!^!./!' /tmp/changed.txt /tmp/changedl.txt | tar -cvvf build-cache.tar.xz
+          sed 's!^!./!' /tmp/changed.txt /tmp/changedl.txt | tar -cvvf build-cache.tar.xz --verbatim-files-from --files-from=-
           echo "::endgroup::"
 
       - name: Save ${{ matrix.buildGroup }} build cache

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -116,7 +116,7 @@ jobs:
 
           # There will probably be a bunch of duplicate vendor files. Try to deduplicate them.
           echo "::group::Deduplicating files"
-          xargs -d '\n' sha256sum < /tmp/changed.txt | perl -nwe '
+          xargs -d '\n' sha256sum < /tmp/changed.txt | sort | perl -nwe '
             BEGIN { $h = ""; $f = ""; }
             die "WTF? $_" unless /^([0-9a-f]{64})  (\S.*)$/;
             if ( $h ne $1 ) {

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -120,7 +120,7 @@ jobs:
             BEGIN { $h = ""; $f = ""; }
             die "WTF? $_" unless /^([0-9a-f]{64})  (\S.*)$/;
             if ( $h ne $1 ) {
-              $h=$1; $l=$2;
+              $h=$1; $f=$2;
             } else {
               print "$2 → $f\n";
               unlink( $2 ) or die "Failed to delete $2: $!\n";

--- a/.github/workflows/wpcloud.yml
+++ b/.github/workflows/wpcloud.yml
@@ -116,7 +116,7 @@ jobs:
           # This can give errors if the previous state was broken, so ignore them
           ssh jpwpcomsh "wp --skip-plugins --skip-themes dereferenced freshen > /dev/null 2>&1" || echo "wp dereferenced freshen has exited with code $?"
           ssh jpwpcomsh "rm -rf /tmp/old-* > /dev/null 2>&1"
-          scp -r wpcomsh jpwpcomsh:/srv/htdocs/wp-content/mu-plugins/wpcomsh
+          rsync -azKPv --prune-empty-dirs --delete --delete-after --delete-excluded --copy-links wpcomsh/. jpwpcomsh:/srv/htdocs/wp-content/mu-plugins/wpcomsh/.
           echo "::endgroup::"
 
           # Do a basic check to verify the site is loading

--- a/.github/workflows/wpcloud.yml
+++ b/.github/workflows/wpcloud.yml
@@ -10,7 +10,7 @@ concurrency:
   # Concurrency is set up to make sure we can only run one WP Cloud testing job at the same time.
 
 permissions:
-  # actions/checkout, actions/cache?
+  # actions/checkout, actions/upload-artifact, actions/download-artifact
   contents: read
 
 jobs:
@@ -35,7 +35,7 @@ jobs:
         uses: ./.github/actions/tool-setup
         with:
           # Match PHP version on WP Cloud so the right vendor packages get installed.
-          php: 8.1
+          php: 8.3
       - name: Monorepo install
         run: |
           echo "::group::Pnpm"
@@ -51,58 +51,39 @@ jobs:
       - name: Build wpcomsh
         if: steps.changed.outputs.wpcomsh == 'true'
         run: |
-          find . -path ./.github -prune -o -type f -print | sort > /tmp/before.txt
           echo "::group::Installing and building wpcomsh"
           rm projects/plugins/wpcomsh/composer.lock
           pnpm jetpack build -v --deps plugins/wpcomsh
           echo "::endgroup::"
 
-          # We only want to save the files that were actually created or changed.
-          # But we can't just list them for actions/cache/save, "Argument list too long".
-          # So instead we delete all the unchanged files so we can tell actions/cache/save
-          # to save everything that's left.
-          git -c core.quotepath=off diff --name-only | sort > /tmp/changed.txt
-          if [[ -s /tmp/changed.txt ]]; then
-            grep -F -x -v -f /tmp/changed.txt /tmp/before.txt > /tmp/remove.txt
-          else
-            cp /tmp/before.txt /tmp/remove.txt
-          fi
-          xargs -d '\n' rm < /tmp/remove.txt
-          find . -type d -empty -delete
+          echo "::group::Preparing artifact"
+          pnpm jetpack rsync -v --non-interactive wpcomsh /tmp/wpcomsh
+          cp -a projects/plugins/wpcomsh/bin /tmp/wpcomsh
+          cp -a projects/plugins/wpcomsh/tests /tmp/wpcomsh
+          # The test on WP Cloud won't use `phpunit-select-config`, so select config manually.
+          cp -aL projects/plugins/wpcomsh/phpunit.12.xml.dist /tmp/wpcomsh/phpunit.xml.dist
+          tar -cvvf wpcomsh.tar.xz -C /tmp/ wpcomsh
+          echo "::endgroup::"
 
-      - name: Save wpcomsh build cache
-        if: steps.changed.outputs.wpcomsh == 'true'
-        id: wpcomsh-build-cache-save
-        uses: actions/cache/save@v5
+      - name: Store artifact
+        uses: actions/upload-artifact@v6
         with:
-          path: |
-            .
-            !./.github/
-          key: ${{ github.sha }}
+          name: wpcomsh
+          path: wpcomsh.tar.xz
+          retention-days: 1
+          # Already compressed.
+          compression-level: 0
+
   deploy:
     name: Run PHPUnit on the WP Cloud test site
     runs-on: ubuntu-latest
     needs: build
     if: needs.build.outputs.wpcomsh == 'true'
     steps:
-      - uses: actions/checkout@v6
-
-      - name: Restore wpcomsh build cache
-        id: wpcomsh-build-cache
-        uses: actions/cache/restore@v5
+      - name: Download build artifact
+        uses: actions/download-artifact@v7
         with:
-          path: |
-            .
-            !./.github/
-          key: ${{ github.sha }}
-          fail-on-cache-miss: true
-
-      - name: Setup tools
-        uses: ./.github/actions/tool-setup
-
-      - name: Install monorepo
-        run: |
-          pnpm install
+          name: wpcomsh
 
       - name: Configure Github to be able to SSH to the WP Cloud site
         run: |
@@ -127,13 +108,15 @@ jobs:
           echo "  IdentitiesOnly yes" >> ~/.ssh/config
           echo "::endgroup::"
 
+          echo "::group::Extract wpcomsh build"
+          tar -xvvf wpcomsh.tar.xz wpcomsh
+          echo "::endgroup::"
+
           echo "::group::Transferring wpcomsh to the testing server"
           # This can give errors if the previous state was broken, so ignore them
           ssh jpwpcomsh "wp --skip-plugins --skip-themes dereferenced freshen > /dev/null 2>&1" || echo "wp dereferenced freshen has exited with code $?"
           ssh jpwpcomsh "rm -rf /tmp/old-* > /dev/null 2>&1"
-          pnpm jetpack rsync --non-interactive wpcomsh jpwpcomsh:/srv/htdocs/wp-content/mu-plugins
-          scp -r projects/plugins/wpcomsh/bin jpwpcomsh:/srv/htdocs/wp-content/mu-plugins/wpcomsh/
-          scp -r projects/plugins/wpcomsh/tests jpwpcomsh:/srv/htdocs/wp-content/mu-plugins/wpcomsh/
+          scp -r wpcomsh jpwpcomsh:/srv/htdocs/wp-content/mu-plugins/wpcomsh
           echo "::endgroup::"
 
           # Do a basic check to verify the site is loading
@@ -159,8 +142,6 @@ jobs:
           # Proceed with tests if all seems well
           if [[ $CODE -eq 0 ]]; then
             echo "::group::Run PHPUnit tests"
-            # The test on WP Cloud won't use `phpunit-select-config`, so select config manually.
-            scp projects/plugins/wpcomsh/phpunit.9.xml.dist jpwpcomsh:/srv/htdocs/wp-content/mu-plugins/wpcomsh/phpunit.xml.dist
             ssh jpwpcomsh "/srv/htdocs/wp-content/mu-plugins/wpcomsh/bin/run-phpunit-tests.sh" || CODE=$?
             echo "::endgroup::"
           fi

--- a/projects/plugins/wpcomsh/bin/run-phpunit-tests.sh
+++ b/projects/plugins/wpcomsh/bin/run-phpunit-tests.sh
@@ -42,8 +42,9 @@ function checkout_project() {
 function setup_tests() {
 	cd "$HOME/htdocs/wp-content/mu-plugins/wpcomsh"
 	chmod 700 bin/install-wp-tests.sh
-	"$HOME/composer" global require "phpunit/phpunit=^9" --ignore-platform-reqs --dev -W
-	"$HOME/composer" global require "yoast/phpunit-polyfills=^1.0.1" --ignore-platform-reqs --dev
+	"$HOME/composer" global remove "phpunit/phpunit" --dev --no-update
+	VER=$( jq -r '.["require-dev"]["yoast/phpunit-polyfills"]' composer.json )
+	"$HOME/composer" global require "yoast/phpunit-polyfills=$VER" --dev -W
 	# "$HOME/composer" install --no-dev --optimize-autoloader
 
 	bin/install-wp-tests.sh "$DB_NAME" "$DB_USER" "$DB_PASSWORD" "$DB_HOST" latest true

--- a/projects/plugins/wpcomsh/changelog/update-ci-use-artifacts-not-cache
+++ b/projects/plugins/wpcomsh/changelog/update-ci-use-artifacts-not-cache
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: No change. Just a change entry here to make CI run the WP Cloud tests.
+
+


### PR DESCRIPTION
Closes MONOREP-340

 <!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
We've started to see random failures in the E2E and WP Cloud test runs, which seem to be due to GitHub not being able to fetch the cache entry despite it having just been created.

Their support AI bot insists that actions/cache isn't intended to be used for use between jobs in the same workflow. Seems bogus to me, but regardless we can get better reliability by using artifact upload/download rather than the cache.

Since I'm poking it anyway, let's do some extra cleanup too:
* For the WP Cloud job, we can do `jetpack rsync` to a local directory and put that in the artifact instead of shoving the build of everything in there.
* Looks like the WP Cloud site is on PHP 8.3 now, so bump that version.
* For the E2E, I think actions/cache had been deduplicating duplicate files, while tar won't by itself. But we can get tar to do it by hard-linking the files.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1769703130539749-slack-C05Q5HSS013

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* E2E and WP Cloud tests ran in CI, and are happy?