### PR TITLE
Forms: remove focus outline from form success message

### DIFF
--- a/projects/packages/forms/changelog/fix-focus-form-success
+++ b/projects/packages/forms/changelog/fix-focus-form-success
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: remove focus outline from form success message.

--- a/projects/packages/forms/src/contact-form/css/grunion.scss
+++ b/projects/packages/forms/src/contact-form/css/grunion.scss
@@ -230,6 +230,11 @@ that needs to mimic the input element styles */
 	max-width: 600px;
 }
 
+.contact-form-submission:focus {
+	outline: none;
+	border: none;
+}
+
 .contact-form-submission p {
 	margin: 0 auto;
 	word-wrap: break-word;


### PR DESCRIPTION
## Proposed changes:

* Remove the focus outline/border from the `.contact-form-submission` element (form success message)
* This prevents an unwanted visual outline when the success message receives focus after form submission

Before (twenty twenty-five theme) :
<img width="699" height="580" alt="Screenshot 2026-02-02 at 1 27 10 PM" src="https://github.com/user-attachments/assets/fcacfd7a-2c23-44b7-8abf-c401c17e2766" />


After (twenty twenty-five theme):
<img width="889" height="608" alt="Screenshot 2026-02-02 at 1 26 51 PM" src="https://github.com/user-attachments/assets/ca75dd24-d44b-4154-8847-3f63ced0479e" />


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

N/A - Minor CSS fix

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

1. Create a new post with a Jetpack Form block
2. Publish the post and view it on the frontend
3. Fill out the form and submit it
4. When the success message appears, observe that it does not have a focus outline/border
5. Previously, the success message would show a visible focus outline which could look jarring to users