### PR TITLE
Forms: Fix submit button loading spinner not showing

### DIFF
--- a/projects/packages/forms/changelog/fix-submit-button-loading-state
+++ b/projects/packages/forms/changelog/fix-submit-button-loading-state
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Contact Form: Fix loading spinner not showing on submit button.

--- a/projects/packages/forms/src/contact-form/css/grunion.scss
+++ b/projects/packages/forms/src/contact-form/css/grunion.scss
@@ -1510,8 +1510,8 @@ on production builds, the attributes are being reordered, causing side-effects
 }
 
 // use new ::after approach for animated spinner inside forms
-.contact-form .wp-block-jetpack-button:last-of-type button[type="submit"].is-submitting,
-.contact-form .wp-block-button:last-of-type button[type="submit"].is-submitting {
+.contact-form .wp-block-jetpack-button .is-submitting:not(.disable-spinner),
+.contact-form .wp-block-button .is-submitting:not(.disable-spinner) {
 
 	&::after {
 

--- a/projects/packages/forms/src/contact-form/css/grunion.scss
+++ b/projects/packages/forms/src/contact-form/css/grunion.scss
@@ -1510,8 +1510,8 @@ on production builds, the attributes are being reordered, causing side-effects
 }
 
 // use new ::after approach for animated spinner inside forms
-.contact-form .wp-block-jetpack-form-step-navigation .wp-block-jetpack-button:last-of-type button[type="submit"].is-submitting,
-.contact-form .wp-block-jetpack-form-step-navigation .wp-block-button:last-of-type button[type="submit"].is-submitting {
+.contact-form .wp-block-jetpack-button:last-of-type button[type="submit"].is-submitting,
+.contact-form .wp-block-button:last-of-type button[type="submit"].is-submitting {
 
 	&::after {
 


### PR DESCRIPTION
## Proposed changes:

- Fix the CSS selector for the submit button loading spinner to apply to all submit buttons within contact forms, not just those within step navigation blocks

## Other information:

The previous selector `.contact-form .wp-block-jetpack-form-step-navigation .wp-block-jetpack-button:last-of-type button[type="submit"].is-submitting` was too specific and only applied the loading spinner styles when the submit button was inside a step navigation block. This change broadens the selector to apply to any submit button in a contact form.

## Jetpack product discussion

N/A

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

1. Create a Jetpack Form block without step navigation
2. Add a submit button
3. Submit the form
4. Verify the loading spinner appears on the submit button while the form is being submitted

🤖 Generated with [Claude Code](https://claude.ai/code)
