### PR TITLE
Forms: Show status notice and publish for synced forms

### DIFF
--- a/projects/packages/forms/changelog/fix-form-statuses-notice
+++ b/projects/packages/forms/changelog/fix-form-statuses-notice
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Contact Form: add status notice for non-published synced forms in block editor.

--- a/projects/packages/forms/changelog/fix-form-statuses-notice
+++ b/projects/packages/forms/changelog/fix-form-statuses-notice
@@ -1,4 +1,4 @@
 Significance: patch
 Type: added
 
-Show status notice for non-published synced forms in block editor.
+Show status notice for non-published synced forms in the block editor and frontend preview when attempting to publish.

--- a/projects/packages/forms/changelog/fix-form-statuses-notice
+++ b/projects/packages/forms/changelog/fix-form-statuses-notice
@@ -1,4 +1,4 @@
 Significance: patch
 Type: added
 
-Contact Form: Add status notice for non-published synced forms in block editor.
+Show status notice for non-published synced forms in block editor.

--- a/projects/packages/forms/changelog/fix-form-statuses-notice
+++ b/projects/packages/forms/changelog/fix-form-statuses-notice
@@ -1,4 +1,4 @@
 Significance: patch
 Type: added
 
-Contact Form: add status notice for non-published synced forms in block editor.
+Contact Form: Add status notice for non-published synced forms in block editor.

--- a/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
+++ b/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
@@ -839,10 +839,7 @@ class Contact_Form_Block {
 	 * @return string Rendered form HTML.
 	 */
 	private static function render_synced_form_content( $ref_id, $synced_form ) {
-		static $seen_refs = array();
-
 		// Mark as seen for circular reference prevention.
-		$seen_refs[ $ref_id ] = true;
 		Contact_Form::set_ref_id( $ref_id );
 		$output = '';
 		try {
@@ -853,7 +850,6 @@ class Contact_Form_Block {
 			}
 		} finally {
 			// Clean up.
-			unset( $seen_refs[ $ref_id ] );
 			Contact_Form::clear_ref_id();
 		}
 		return $output;

--- a/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
+++ b/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
@@ -792,7 +792,7 @@ class Contact_Form_Block {
 	 */
 	private static function render_synced_form( $ref_id ) {
 		// Circular reference prevention.
-		if ( $ref_id === Contact_Form::get_ref_id() ) {
+		if ( Contact_Form::has_seen( $ref_id ) ) {
 			return '';
 		}
 		// Load the jetpack-form post.
@@ -849,7 +849,7 @@ class Contact_Form_Block {
 			}
 		} finally {
 			// Clean up.
-			Contact_Form::clear_ref_id();
+			Contact_Form::clear_ref_id( $ref_id );
 		}
 		return $output;
 	}

--- a/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
+++ b/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
@@ -807,10 +807,39 @@ class Contact_Form_Block {
 			return '';
 		}
 
-		// Only render published forms statuses.
-		if ( ! in_array( $synced_form->post_status, array( 'publish' ), true ) ) {
+		$status = $synced_form->post_status;
+
+		// Trashed forms are always hidden.
+		if ( 'trash' === $status ) {
 			return '';
 		}
+
+		// Published forms render normally for everyone.
+		if ( 'publish' === $status ) {
+			return self::render_synced_form_content( $ref_id, $synced_form );
+		}
+
+		// For non-published statuses (draft, pending, future, private), only show preview to users who can edit the form.
+		if ( ! current_user_can( 'edit_post', $ref_id ) ) {
+			return '';
+		}
+
+		// Render the form with a status notice for editors.
+		$notice       = self::render_frontend_status_notice( $synced_form );
+		$form_content = self::render_synced_form_content( $ref_id, $synced_form );
+
+		return $notice . $form_content;
+	}
+
+	/**
+	 * Render the actual form content for a synced form.
+	 *
+	 * @param int      $ref_id The jetpack_form post ID.
+	 * @param \WP_Post $synced_form The synced form post object.
+	 * @return string Rendered form HTML.
+	 */
+	private static function render_synced_form_content( $ref_id, $synced_form ) {
+		static $seen_refs = array();
 
 		// Mark as seen for circular reference prevention.
 		$seen_refs[ $ref_id ] = true;
@@ -828,6 +857,52 @@ class Contact_Form_Block {
 			Contact_Form::clear_ref_id();
 		}
 		return $output;
+	}
+
+	/**
+	 * Render a frontend status notice for non-published forms.
+	 *
+	 * @param \WP_Post $synced_form The synced form post object.
+	 * @return string Notice HTML.
+	 */
+	private static function render_frontend_status_notice( $synced_form ) {
+		$status = $synced_form->post_status;
+
+		$status_config = array(
+			'draft'   => array(
+				'type'    => 'warning',
+				'message' => __( 'This form is a draft and is only visible to you. Publish it to make it visible to site visitors.', 'jetpack-forms' ),
+			),
+			'pending' => array(
+				'type'    => 'warning',
+				'message' => __( 'This form is pending review and is only visible to you. It will be visible to site visitors once approved and published.', 'jetpack-forms' ),
+			),
+			'future'  => array(
+				'type'    => 'info',
+				'message' => sprintf(
+					/* translators: %s: scheduled publish date */
+					__( 'This form is scheduled for %s and is only visible to you until then.', 'jetpack-forms' ),
+					wp_date( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ), strtotime( $synced_form->post_date ) )
+				),
+			),
+			'private' => array(
+				'type'    => 'warning',
+				'message' => __( 'This form is private and is only visible to you. Change its status to published to make it visible to site visitors.', 'jetpack-forms' ),
+			),
+		);
+
+		if ( ! isset( $status_config[ $status ] ) ) {
+			return '';
+		}
+
+		$config     = $status_config[ $status ];
+		$type_class = 'info' === $config['type'] ? 'jetpack-form-status-notice--info' : 'jetpack-form-status-notice--warning';
+
+		return sprintf(
+			'<div class="jetpack-form-status-notice %s" role="alert"><p>%s</p></div>',
+			esc_attr( $type_class ),
+			esc_html( $config['message'] )
+		);
 	}
 
 	/**

--- a/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
+++ b/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
@@ -882,12 +882,8 @@ class Contact_Form_Block {
 				'message' => sprintf(
 					/* translators: %s: scheduled publish date */
 					__( 'This form is scheduled for %s and is only visible to you until then.', 'jetpack-forms' ),
-					wp_date( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ), strtotime( $synced_form->post_date ) )
+					wp_date( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ), get_post_time( 'U', true, $synced_form ) )
 				),
-			),
-			'private' => array(
-				'type'    => 'warning',
-				'message' => __( 'This form is private and is only visible to you. Change its status to published to make it visible to site visitors.', 'jetpack-forms' ),
 			),
 		);
 

--- a/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
+++ b/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
@@ -885,10 +885,6 @@ class Contact_Form_Block {
 					wp_date( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ), strtotime( $synced_form->post_date ) )
 				),
 			),
-			'private' => array(
-				'type'    => 'warning',
-				'message' => __( 'This form is private and is only visible to you. Change its status to published to make it visible to site visitors.', 'jetpack-forms' ),
-			),
 		);
 
 		if ( ! isset( $status_config[ $status ] ) ) {
@@ -899,7 +895,7 @@ class Contact_Form_Block {
 		$type_class = 'info' === $config['type'] ? 'jetpack-form-status-notice--info' : 'jetpack-form-status-notice--warning';
 
 		return sprintf(
-			'<div class="jetpack-form-status-notice %s" role="alert"><p>%s</p></div>',
+			'<div class="jetpack-form-status-notice %s"><p>%s</p></div>',
 			esc_attr( $type_class ),
 			esc_html( $config['message'] )
 		);

--- a/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
+++ b/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
@@ -885,6 +885,10 @@ class Contact_Form_Block {
 					wp_date( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ), strtotime( $synced_form->post_date ) )
 				),
 			),
+			'private' => array(
+				'type'    => 'warning',
+				'message' => __( 'This form is private and is only visible to you. Change its status to published to make it visible to site visitors.', 'jetpack-forms' ),
+			),
 		);
 
 		if ( ! isset( $status_config[ $status ] ) ) {
@@ -893,11 +897,18 @@ class Contact_Form_Block {
 
 		$config     = $status_config[ $status ];
 		$type_class = 'info' === $config['type'] ? 'jetpack-form-status-notice--info' : 'jetpack-form-status-notice--warning';
+		$edit_url   = get_edit_post_link( $synced_form->ID, 'raw' );
+		$edit_link  = $edit_url ? sprintf(
+			' <a href="%s" class="jetpack-form-status-notice__edit-link">%s</a>',
+			esc_url( $edit_url ),
+			esc_html__( 'Edit form', 'jetpack-forms' )
+		) : '';
 
 		return sprintf(
-			'<div class="jetpack-form-status-notice %s"><p>%s</p></div>',
+			'<div class="jetpack-form-status-notice %s"><p>%s%s</p></div>',
 			esc_attr( $type_class ),
-			esc_html( $config['message'] )
+			esc_html( $config['message'] ),
+			$edit_link
 		);
 	}
 

--- a/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
+++ b/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
@@ -792,13 +792,9 @@ class Contact_Form_Block {
 	 */
 	private static function render_synced_form( $ref_id ) {
 		// Circular reference prevention.
-		static $seen_refs = array();
-
-		if ( isset( $seen_refs[ $ref_id ] ) ) {
-			// Return empty string to match other error cases and unit test expectations.
+		if ( $ref_id === Contact_Form::get_ref_id() ) {
 			return '';
 		}
-
 		// Load the jetpack-form post.
 		$synced_form = get_post( $ref_id );
 
@@ -839,6 +835,9 @@ class Contact_Form_Block {
 	 * @return string Rendered form HTML.
 	 */
 	private static function render_synced_form_content( $ref_id, $synced_form ) {
+		if ( $ref_id === Contact_Form::get_ref_id() ) {
+			return '';
+		}
 		// Mark as seen for circular reference prevention.
 		Contact_Form::set_ref_id( $ref_id );
 		$output = '';

--- a/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
+++ b/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
@@ -868,6 +868,10 @@ class Contact_Form_Block {
 	private static function render_frontend_status_notice( $synced_form ) {
 		$status = $synced_form->post_status;
 
+		if ( 'publish' === $status || 'private' === $status ) {
+			return '';
+		}
+
 		$status_config = array(
 			'draft'   => array(
 				'type'    => 'warning',

--- a/projects/packages/forms/src/blocks/contact-form/components/form-status-notice.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/components/form-status-notice.tsx
@@ -1,7 +1,7 @@
-import { Button, Notice } from '@wordpress/components';
+import { Notice } from '@wordpress/components';
 import { store as coreStore } from '@wordpress/core-data';
 import { useDispatch } from '@wordpress/data';
-import { dateI18n } from '@wordpress/date';
+import { dateI18n, getSettings as getDateSettings } from '@wordpress/date';
 import { useState, useCallback } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
@@ -24,52 +24,45 @@ const STATUS_CONFIG: Record<
 > = {
 	trash: {
 		status: 'error',
-		getMessage: () =>
-			__(
-				'This form has been trashed and will not be displayed on the frontend.',
-				'jetpack-forms'
-			),
+		getMessage: () => __( 'Trashed form. Currently hidden from site visitors.', 'jetpack-forms' ),
 	},
 	draft: {
 		status: 'warning',
-		getMessage: () =>
-			__(
-				'This form is a draft and will not be displayed on the frontend until published.',
-				'jetpack-forms'
-			),
+		getMessage: () => __( 'Draft form. Currently hidden from site visitors.', 'jetpack-forms' ),
 	},
 	pending: {
 		status: 'warning',
 		getMessage: () =>
 			__(
-				'This form is pending review and will not be displayed on the frontend until approved and published.',
+				'Pending review form. Currently hidden from site visitors until approved and published.',
 				'jetpack-forms'
 			),
 	},
 	future: {
 		status: 'info',
-		getMessage: form =>
-			form?.date
+		getMessage: form => {
+			const dateSettings = getDateSettings();
+			const dateFormat = dateSettings.formats.datetime || 'F j, Y g:i a';
+
+			const message = form?.date
 				? sprintf(
 						/* translators: %s: scheduled publish date */
 						__(
-							'This form is scheduled for %s and will not be displayed until then.',
+							'Scheduled form. It will be published on %s but will remain hidden from site visitors until then.',
 							'jetpack-forms'
 						),
-						dateI18n( 'F j, Y g:i a', form.date )
+						dateI18n( dateFormat, form.date )
 				  )
 				: __(
-						'This form is scheduled and will not be displayed until its publish date.',
+						'Scheduled form. It will not be displayed to site visitors until its publish date.',
 						'jetpack-forms'
-				  ),
+				  );
+			return message;
+		},
 	},
 	private: {
 		status: 'warning',
-		getMessage: () =>
-			__(
-				'This form is private and will not be displayed on the frontend. To make it visible, change its status to published.',
-				'jetpack-forms'
-			),
+		getMessage: () => __( 'Private form. Currently hidden from site visitors.', 'jetpack-forms' ),
 	},
 };
 
@@ -132,23 +125,24 @@ export default function FormStatusNotice( {
 			formStatus
 		);
 
+	const actions = [];
+	if ( formStatus !== 'trash' ) {
+		actions.push( {
+			label: __( 'Publish', 'jetpack-forms' ),
+			onClick: handlePublish,
+			variant: 'secondary',
+			disabled: isPublishing,
+		} );
+	}
+
 	return (
 		<Notice
 			status={ noticeStatus }
 			isDismissible={ false }
 			className="jetpack-contact-form__status-notice"
+			actions={ actions }
 		>
 			{ message }
-			{ formStatus !== 'trash' && (
-				<Button
-					variant="link"
-					onClick={ handlePublish }
-					isBusy={ isPublishing }
-					disabled={ isPublishing }
-				>
-					{ __( 'Publish now', 'jetpack-forms' ) }
-				</Button>
-			) }
 		</Notice>
 	);
 }

--- a/projects/packages/forms/src/blocks/contact-form/components/form-status-notice.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/components/form-status-notice.tsx
@@ -91,7 +91,7 @@ export default function FormStatusNotice( {
 	const { removeBlocks } = useDispatch( 'core/block-editor' );
 
 	const handleUndo = useCallback(
-		async ( previousStatus: string ) => {
+		async ( previousStatus: string, previousDate?: string ) => {
 			if ( ! formRef ) {
 				return;
 			}
@@ -101,6 +101,7 @@ export default function FormStatusNotice( {
 				}
 				await editEntityRecord( 'postType', FORM_POST_TYPE, formRef, {
 					status: previousStatus,
+					date: previousDate,
 				} );
 				await saveEditedEntityRecord( 'postType', FORM_POST_TYPE, formRef );
 			} catch {
@@ -118,6 +119,8 @@ export default function FormStatusNotice( {
 			return;
 		}
 		const previousStatus = syncedForm?.status;
+		const previousDate = syncedForm?.date;
+
 		setIsPublishing( true );
 		try {
 			await editEntityRecord( 'postType', FORM_POST_TYPE, formRef, { status: 'publish' } );
@@ -128,7 +131,7 @@ export default function FormStatusNotice( {
 					? [
 							{
 								label: __( 'Undo', 'jetpack-forms' ),
-								onClick: () => handleUndo( previousStatus ),
+								onClick: () => handleUndo( previousStatus, previousDate ),
 							},
 					  ]
 					: [],
@@ -144,6 +147,7 @@ export default function FormStatusNotice( {
 	}, [
 		formRef,
 		syncedForm?.status,
+		syncedForm?.date,
 		editEntityRecord,
 		saveEditedEntityRecord,
 		createSuccessNotice,

--- a/projects/packages/forms/src/blocks/contact-form/components/form-status-notice.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/components/form-status-notice.tsx
@@ -16,6 +16,7 @@ type FormStatusNoticeProps = {
 	syncedForm: SyncedForm | null;
 	formRef: number | undefined;
 	isVisible: boolean;
+	clientId: string;
 };
 
 const STATUS_CONFIG: Record<
@@ -82,11 +83,15 @@ export default function FormStatusNotice( {
 	syncedForm,
 	formRef,
 	isVisible,
+	clientId,
 }: FormStatusNoticeProps ) {
 	const [ isPublishing, setIsPublishing ] = useState( false );
+	const [ isDeleting, setIsDeleting ] = useState( false );
 
-	const { editEntityRecord, saveEditedEntityRecord } = useDispatch( coreStore );
+	const { editEntityRecord, saveEditedEntityRecord, deleteEntityRecord } = useDispatch( coreStore );
 	const { createErrorNotice, createSuccessNotice } = useDispatch( noticesStore );
+
+	const { removeBlocks } = useDispatch( 'core/block-editor' );
 
 	const handleUndo = useCallback(
 		async ( previousStatus: string ) => {
@@ -94,6 +99,9 @@ export default function FormStatusNotice( {
 				return;
 			}
 			try {
+				if ( previousStatus === 'trash' ) {
+					previousStatus = 'draft'; // Moving to trash from publish to draft can't be undone directly.
+				}
 				await editEntityRecord( 'postType', FORM_POST_TYPE, formRef, {
 					status: previousStatus,
 				} );
@@ -146,6 +154,37 @@ export default function FormStatusNotice( {
 		handleUndo,
 	] );
 
+	const handleDeletePermanently = useCallback( async () => {
+		if ( ! formRef ) {
+			return;
+		}
+		setIsDeleting( true );
+		try {
+			// delete the entry permanently
+			await deleteEntityRecord( 'postType', FORM_POST_TYPE, formRef, { force: true } );
+			createSuccessNotice( __( 'Form deleted permanently.', 'jetpack-forms' ), {
+				type: 'snackbar',
+			} );
+		} catch {
+			createErrorNotice(
+				__(
+					'Failed to delete form permanently. Refresh this page and try again.',
+					'jetpack-forms'
+				),
+				{ type: 'snackbar' }
+			);
+		} finally {
+			setIsDeleting( false );
+			removeBlocks( [ clientId ] );
+		}
+	}, [
+		formRef,
+		createSuccessNotice,
+		createErrorNotice,
+		removeBlocks,
+		deleteEntityRecord,
+		clientId,
+	] );
 	const formStatus = syncedForm?.status;
 
 	if ( ! isVisible || ! formRef || ! formStatus || formStatus === 'publish' ) {
@@ -172,6 +211,19 @@ export default function FormStatusNotice( {
 			onClick: handlePublish,
 			variant: 'secondary',
 			disabled: isPublishing,
+		} );
+	} else {
+		actions.push( {
+			label: __( 'Restore', 'jetpack-forms' ),
+			onClick: handlePublish,
+			variant: 'secondary',
+			disabled: isPublishing,
+		} );
+		actions.push( {
+			label: __( 'Delete Permanently', 'jetpack-forms' ),
+			onClick: handleDeletePermanently,
+			variant: 'secondary',
+			disabled: isDeleting,
 		} );
 	}
 

--- a/projects/packages/forms/src/blocks/contact-form/components/form-status-notice.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/components/form-status-notice.tsx
@@ -1,4 +1,4 @@
-import { Notice } from '@wordpress/components';
+import { Button, Modal, Notice } from '@wordpress/components';
 import { store as coreStore } from '@wordpress/core-data';
 import { useDispatch } from '@wordpress/data';
 import { dateI18n, getSettings as getDateSettings } from '@wordpress/date';
@@ -87,6 +87,7 @@ export default function FormStatusNotice( {
 }: FormStatusNoticeProps ) {
 	const [ isPublishing, setIsPublishing ] = useState( false );
 	const [ isDeleting, setIsDeleting ] = useState( false );
+	const [ showDeleteConfirmation, setShowDeleteConfirmation ] = useState( false );
 
 	const { editEntityRecord, saveEditedEntityRecord, deleteEntityRecord } = useDispatch( coreStore );
 	const { createErrorNotice, createSuccessNotice } = useDispatch( noticesStore );
@@ -205,36 +206,69 @@ export default function FormStatusNotice( {
 		);
 
 	const actions = [];
-	if ( formStatus !== 'trash' ) {
+
+	actions.push( {
+		label: __( 'Publish', 'jetpack-forms' ),
+		onClick: handlePublish,
+		variant: 'secondary',
+		disabled: isPublishing,
+	} );
+	if ( formStatus === 'trash' ) {
 		actions.push( {
-			label: __( 'Publish', 'jetpack-forms' ),
-			onClick: handlePublish,
-			variant: 'secondary',
-			disabled: isPublishing,
-		} );
-	} else {
-		actions.push( {
-			label: __( 'Restore', 'jetpack-forms' ),
-			onClick: handlePublish,
-			variant: 'secondary',
-			disabled: isPublishing,
-		} );
-		actions.push( {
-			label: __( 'Delete Permanently', 'jetpack-forms' ),
-			onClick: handleDeletePermanently,
+			label: __( 'Delete', 'jetpack-forms' ),
+			onClick: () => setShowDeleteConfirmation( true ),
 			variant: 'secondary',
 			disabled: isDeleting,
 		} );
 	}
 
 	return (
-		<Notice
-			status={ noticeStatus }
-			isDismissible={ false }
-			className="jetpack-contact-form__status-notice"
-			actions={ actions }
-		>
-			{ message }
-		</Notice>
+		<>
+			<Notice
+				status={ noticeStatus }
+				isDismissible={ false }
+				className="jetpack-contact-form__status-notice"
+				actions={ actions }
+			>
+				{ message }
+			</Notice>
+			{ showDeleteConfirmation && (
+				<Modal
+					title={ __( 'Delete form permanently?', 'jetpack-forms' ) }
+					onRequestClose={ () => setShowDeleteConfirmation( false ) }
+					size="small"
+				>
+					<p>
+						{ __(
+							'Are you sure you want to delete this form? This action cannot be undone.',
+							'jetpack-forms'
+						) }
+					</p>
+					<div
+						style={ {
+							display: 'flex',
+							justifyContent: 'flex-end',
+							gap: '8px',
+							marginTop: '16px',
+						} }
+					>
+						<Button variant="tertiary" onClick={ () => setShowDeleteConfirmation( false ) }>
+							{ __( 'Cancel', 'jetpack-forms' ) }
+						</Button>
+						<Button
+							variant="primary"
+							isDestructive
+							isBusy={ isDeleting }
+							onClick={ () => {
+								setShowDeleteConfirmation( false );
+								handleDeletePermanently();
+							} }
+						>
+							{ __( 'Delete Permanently', 'jetpack-forms' ) }
+						</Button>
+					</div>
+				</Modal>
+			) }
+		</>
 	);
 }

--- a/projects/packages/forms/src/blocks/contact-form/components/form-status-notice.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/components/form-status-notice.tsx
@@ -48,12 +48,8 @@ const STATUS_CONFIG: Record<
 			),
 	},
 	private: {
-		status: 'warning',
-		getMessage: () =>
-			__(
-				'Private form. Currently hidden from site visitors and not accepting any responses.',
-				'jetpack-forms'
-			),
+		status: 'info',
+		getMessage: () => __( 'Private form. Currently hidden from site visitors.', 'jetpack-forms' ),
 	},
 	future: {
 		status: 'info',
@@ -166,6 +162,7 @@ export default function FormStatusNotice( {
 			createSuccessNotice( __( 'Form deleted permanently.', 'jetpack-forms' ), {
 				type: 'snackbar',
 			} );
+			removeBlocks( [ clientId ] );
 		} catch {
 			createErrorNotice(
 				__(
@@ -176,7 +173,6 @@ export default function FormStatusNotice( {
 			);
 		} finally {
 			setIsDeleting( false );
-			removeBlocks( [ clientId ] );
 		}
 	}, [
 		formRef,

--- a/projects/packages/forms/src/blocks/contact-form/components/form-status-notice.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/components/form-status-notice.tsx
@@ -1,3 +1,4 @@
+import { store as blockEditorStore } from '@wordpress/block-editor';
 import { Button, Modal, Notice } from '@wordpress/components';
 import { store as coreStore } from '@wordpress/core-data';
 import { useDispatch } from '@wordpress/data';
@@ -88,7 +89,7 @@ export default function FormStatusNotice( {
 	const { editEntityRecord, saveEditedEntityRecord, deleteEntityRecord } = useDispatch( coreStore );
 	const { createErrorNotice, createSuccessNotice } = useDispatch( noticesStore );
 
-	const { removeBlocks } = useDispatch( 'core/block-editor' );
+	const { removeBlocks } = useDispatch( blockEditorStore );
 
 	const handleUndo = useCallback(
 		async ( previousStatus: string, previousDate?: string ) => {

--- a/projects/packages/forms/src/blocks/contact-form/components/form-status-notice.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/components/form-status-notice.tsx
@@ -123,7 +123,14 @@ export default function FormStatusNotice( {
 
 		setIsPublishing( true );
 		try {
-			await editEntityRecord( 'postType', FORM_POST_TYPE, formRef, { status: 'publish' } );
+			const formUpdate: { status: string; date?: string } = {
+				status: 'publish',
+			};
+			if ( previousStatus === 'future' ) {
+				// If the form was previously scheduled, clear the date to publish immediately.
+				formUpdate.date = new Date().toISOString();
+			}
+			await editEntityRecord( 'postType', FORM_POST_TYPE, formRef, formUpdate );
 			await saveEditedEntityRecord( 'postType', FORM_POST_TYPE, formRef );
 			createSuccessNotice( __( 'Form is live and ready to accept responses.', 'jetpack-forms' ), {
 				type: 'snackbar',

--- a/projects/packages/forms/src/blocks/contact-form/components/form-status-notice.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/components/form-status-notice.tsx
@@ -1,0 +1,154 @@
+import { Button, Notice } from '@wordpress/components';
+import { store as coreStore } from '@wordpress/core-data';
+import { useDispatch } from '@wordpress/data';
+import { dateI18n } from '@wordpress/date';
+import { useState, useCallback } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
+import { store as noticesStore } from '@wordpress/notices';
+import { FORM_POST_TYPE } from '../../shared/util/constants.js';
+
+type SyncedForm = {
+	status?: string;
+	date?: string;
+};
+
+type FormStatusNoticeProps = {
+	syncedForm: SyncedForm | null;
+	formRef: number | undefined;
+	isVisible: boolean;
+};
+
+const STATUS_CONFIG: Record<
+	string,
+	{ status: 'error' | 'warning' | 'info'; getMessage: ( form: SyncedForm | null ) => string }
+> = {
+	trash: {
+		status: 'error',
+		getMessage: () =>
+			__(
+				'This form has been trashed and will not be displayed on the frontend.',
+				'jetpack-forms'
+			),
+	},
+	draft: {
+		status: 'warning',
+		getMessage: () =>
+			__(
+				'This form is a draft and will not be displayed on the frontend until published.',
+				'jetpack-forms'
+			),
+	},
+	pending: {
+		status: 'warning',
+		getMessage: () =>
+			__(
+				'This form is pending review and will not be displayed on the frontend until approved and published.',
+				'jetpack-forms'
+			),
+	},
+	future: {
+		status: 'info',
+		getMessage: form =>
+			form?.date
+				? sprintf(
+						/* translators: %s: scheduled publish date */
+						__(
+							'This form is scheduled for %s and will not be displayed until then.',
+							'jetpack-forms'
+						),
+						dateI18n( 'F j, Y g:i a', form.date )
+				  )
+				: __(
+						'This form is scheduled and will not be displayed until its publish date.',
+						'jetpack-forms'
+				  ),
+	},
+	private: {
+		status: 'warning',
+		getMessage: () =>
+			__(
+				'This form is private and will not be displayed on the frontend. To make it visible, change its status to published.',
+				'jetpack-forms'
+			),
+	},
+};
+
+export default function FormStatusNotice( {
+	syncedForm,
+	formRef,
+	isVisible,
+}: FormStatusNoticeProps ) {
+	const [ isPublishing, setIsPublishing ] = useState( false );
+
+	const { editEntityRecord, saveEditedEntityRecord } = useDispatch( coreStore );
+	const { createErrorNotice, createSuccessNotice } = useDispatch( noticesStore );
+
+	const handlePublish = useCallback( async () => {
+		if ( ! formRef ) {
+			return;
+		}
+		setIsPublishing( true );
+		try {
+			await editEntityRecord( 'postType', FORM_POST_TYPE, formRef, { status: 'publish' } );
+			await saveEditedEntityRecord( 'postType', FORM_POST_TYPE, formRef );
+			createSuccessNotice( __( 'Form published successfully.', 'jetpack-forms' ), {
+				type: 'snackbar',
+			} );
+		} catch {
+			createErrorNotice(
+				__(
+					'Failed to publish form. Please try again or check your permissions.',
+					'jetpack-forms'
+				),
+				{ type: 'snackbar' }
+			);
+		} finally {
+			setIsPublishing( false );
+		}
+	}, [
+		formRef,
+		editEntityRecord,
+		saveEditedEntityRecord,
+		createSuccessNotice,
+		createErrorNotice,
+	] );
+
+	const formStatus = syncedForm?.status;
+
+	if ( ! isVisible || ! formRef || ! formStatus || formStatus === 'publish' ) {
+		return null;
+	}
+
+	const config = STATUS_CONFIG[ formStatus ];
+	const noticeStatus = config?.status || 'warning';
+	const message =
+		config?.getMessage( syncedForm ) ||
+		sprintf(
+			/* translators: %s: form status */
+			__(
+				'This form has status "%s" and will not be displayed on the frontend until it is published.',
+				'jetpack-forms'
+			),
+			formStatus
+		);
+
+	return (
+		<Notice
+			status={ noticeStatus }
+			isDismissible={ false }
+			className="jetpack-contact-form__status-notice"
+		>
+			{ message }
+			{ formStatus !== 'trash' && (
+				<Button
+					variant="link"
+					onClick={ handlePublish }
+					isBusy={ isPublishing }
+					disabled={ isPublishing }
+				>
+					{ __( 'Publish now', 'jetpack-forms' ) }
+				</Button>
+			) }
+		</Notice>
+	);
+}

--- a/projects/packages/forms/src/blocks/contact-form/components/form-status-notice.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/components/form-status-notice.tsx
@@ -88,16 +88,45 @@ export default function FormStatusNotice( {
 	const { editEntityRecord, saveEditedEntityRecord } = useDispatch( coreStore );
 	const { createErrorNotice, createSuccessNotice } = useDispatch( noticesStore );
 
+	const handleUndo = useCallback(
+		async ( previousStatus: string ) => {
+			if ( ! formRef ) {
+				return;
+			}
+			try {
+				await editEntityRecord( 'postType', FORM_POST_TYPE, formRef, {
+					status: previousStatus,
+				} );
+				await saveEditedEntityRecord( 'postType', FORM_POST_TYPE, formRef );
+			} catch {
+				createErrorNotice(
+					__( 'Failed to undo. Refresh this page and try again.', 'jetpack-forms' ),
+					{ type: 'snackbar' }
+				);
+			}
+		},
+		[ formRef, editEntityRecord, saveEditedEntityRecord, createErrorNotice ]
+	);
+
 	const handlePublish = useCallback( async () => {
 		if ( ! formRef ) {
 			return;
 		}
+		const previousStatus = syncedForm?.status;
 		setIsPublishing( true );
 		try {
 			await editEntityRecord( 'postType', FORM_POST_TYPE, formRef, { status: 'publish' } );
 			await saveEditedEntityRecord( 'postType', FORM_POST_TYPE, formRef );
 			createSuccessNotice( __( 'Form is live and ready to accept responses.', 'jetpack-forms' ), {
 				type: 'snackbar',
+				actions: previousStatus
+					? [
+							{
+								label: __( 'Undo', 'jetpack-forms' ),
+								onClick: () => handleUndo( previousStatus ),
+							},
+					  ]
+					: [],
 			} );
 		} catch {
 			createErrorNotice(
@@ -109,10 +138,12 @@ export default function FormStatusNotice( {
 		}
 	}, [
 		formRef,
+		syncedForm?.status,
 		editEntityRecord,
 		saveEditedEntityRecord,
 		createSuccessNotice,
 		createErrorNotice,
+		handleUndo,
 	] );
 
 	const formStatus = syncedForm?.status;

--- a/projects/packages/forms/src/blocks/contact-form/components/form-status-notice.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/components/form-status-notice.tsx
@@ -24,17 +24,33 @@ const STATUS_CONFIG: Record<
 > = {
 	trash: {
 		status: 'error',
-		getMessage: () => __( 'Trashed form. Currently hidden from site visitors.', 'jetpack-forms' ),
+		getMessage: () =>
+			__(
+				'Trashed form. Currently hidden from site visitors and not accepting any responses.',
+				'jetpack-forms'
+			),
 	},
 	draft: {
 		status: 'warning',
-		getMessage: () => __( 'Draft form. Currently hidden from site visitors.', 'jetpack-forms' ),
+		getMessage: () =>
+			__(
+				'Draft form. Currently hidden from site visitors and not accepting any responses.',
+				'jetpack-forms'
+			),
 	},
 	pending: {
 		status: 'warning',
 		getMessage: () =>
 			__(
 				'Pending review form. Currently hidden from site visitors until approved and published.',
+				'jetpack-forms'
+			),
+	},
+	private: {
+		status: 'warning',
+		getMessage: () =>
+			__(
+				'Private form. Currently hidden from site visitors and not accepting any responses.',
 				'jetpack-forms'
 			),
 	},
@@ -60,10 +76,6 @@ const STATUS_CONFIG: Record<
 			return message;
 		},
 	},
-	private: {
-		status: 'warning',
-		getMessage: () => __( 'Private form. Currently hidden from site visitors.', 'jetpack-forms' ),
-	},
 };
 
 export default function FormStatusNotice( {
@@ -84,15 +96,12 @@ export default function FormStatusNotice( {
 		try {
 			await editEntityRecord( 'postType', FORM_POST_TYPE, formRef, { status: 'publish' } );
 			await saveEditedEntityRecord( 'postType', FORM_POST_TYPE, formRef );
-			createSuccessNotice( __( 'Form published successfully.', 'jetpack-forms' ), {
+			createSuccessNotice( __( 'Form is live and ready to accept responses.', 'jetpack-forms' ), {
 				type: 'snackbar',
 			} );
 		} catch {
 			createErrorNotice(
-				__(
-					'Failed to publish form. Please try again or check your permissions.',
-					'jetpack-forms'
-				),
+				__( 'Failed to publish form. Refresh this page and try again.', 'jetpack-forms' ),
 				{ type: 'snackbar' }
 			);
 		} finally {

--- a/projects/packages/forms/src/blocks/contact-form/edit.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/edit.tsx
@@ -944,7 +944,7 @@ function JetpackContactFormEdit( {
 		private: {
 			status: 'info',
 			message: __(
-				'This form is private and only visible to site administrators.',
+				'This form is private and will not be displayed on the frontend until published.',
 				'jetpack-forms'
 			),
 		},

--- a/projects/packages/forms/src/blocks/contact-form/edit.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/edit.tsx
@@ -1120,6 +1120,7 @@ function JetpackContactFormEdit( {
 							syncedForm={ syncedForm }
 							formRef={ ref }
 							isVisible={ isFormOrChildSelected }
+							clientId={ clientId }
 						/>
 					) }
 					{ elt }

--- a/projects/packages/forms/src/blocks/contact-form/edit.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/edit.tsx
@@ -245,10 +245,16 @@ function JetpackContactFormEdit( {
 		selectedBlockClientId,
 		onlySubmitBlock,
 		isJetpackFormEditor,
+		hasChildSelected,
 	} = useSelect(
 		select => {
-			const { getBlocks, getBlock, getSelectedBlockClientId, getBlockParentsByBlockName } =
-				select( blockEditorStore );
+			const {
+				getBlocks,
+				getBlock,
+				getSelectedBlockClientId,
+				getBlockParentsByBlockName,
+				hasSelectedInnerBlock,
+			} = select( blockEditorStore );
 			const { getEditedPostAttribute, getCurrentPostType } = select( editorStore );
 			const selectedBlockId = getSelectedBlockClientId();
 			const selectedBlock = getBlock( selectedBlockId );
@@ -280,6 +286,7 @@ function JetpackContactFormEdit( {
 				selectedBlockClientId: selectedStepBlockId,
 				onlySubmitBlock: isSingleButtonBlock,
 				isJetpackFormEditor: getCurrentPostType() === FORM_POST_TYPE,
+				hasChildSelected: hasSelectedInnerBlock( clientId, true ),
 			};
 		},
 		[ clientId ]
@@ -965,9 +972,10 @@ function JetpackContactFormEdit( {
 		},
 	};
 
-	// Render status notice for synced forms with non-publish status (only when selected)
+	// Render status notice for synced forms with non-publish status (only when form or child is selected)
 	const formStatus = syncedForm?.status;
-	const statusNotice = isSelected && ref && formStatus && formStatus !== 'publish' && (
+	const isFormOrChildSelected = isSelected || hasChildSelected;
+	const statusNotice = isFormOrChildSelected && ref && formStatus && formStatus !== 'publish' && (
 		<Notice
 			status={ statusNoticeConfig[ formStatus ]?.status || 'warning' }
 			isDismissible={ false }

--- a/projects/packages/forms/src/blocks/contact-form/edit.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/edit.tsx
@@ -164,6 +164,7 @@ type JetpackContactFormEditProps = {
 	setAttributes: ( attributes: Partial< JetpackContactFormAttributes > ) => void;
 	clientId: string;
 	className: string;
+	isSelected: boolean;
 };
 
 function JetpackContactFormEdit( {
@@ -172,6 +173,7 @@ function JetpackContactFormEdit( {
 	setAttributes,
 	clientId,
 	className,
+	isSelected,
 }: JetpackContactFormEditProps ) {
 	// Initialize default form block settings as needed.
 	useFormBlockDefaults( { attributes, setAttributes } );
@@ -963,9 +965,9 @@ function JetpackContactFormEdit( {
 		},
 	};
 
-	// Render status notice for synced forms with non-publish status
+	// Render status notice for synced forms with non-publish status (only when selected)
 	const formStatus = syncedForm?.status;
-	const statusNotice = ref && formStatus && formStatus !== 'publish' && (
+	const statusNotice = isSelected && ref && formStatus && formStatus !== 'publish' && (
 		<Notice
 			status={ statusNoticeConfig[ formStatus ]?.status || 'warning' }
 			isDismissible={ false }

--- a/projects/packages/forms/src/blocks/contact-form/edit.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/edit.tsx
@@ -961,7 +961,10 @@ function JetpackContactFormEdit( {
 			{ statusNoticeConfig[ formStatus ]?.message ||
 				sprintf(
 					/* translators: %s: form status */
-					__( 'This form has status "%s" and may not display correctly.', 'jetpack-forms' ),
+					__(
+						'This form has status "%s" and will not be displayed on the frontend until it is published.',
+						'jetpack-forms'
+					),
 					formStatus
 				) }
 			{ formStatus !== 'trash' && (

--- a/projects/packages/forms/src/blocks/contact-form/edit.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/edit.tsx
@@ -938,47 +938,29 @@ function JetpackContactFormEdit( {
 	> = {
 		trash: {
 			status: 'error',
-			message: __(
-				'This form has been trashed and will not be displayed on the frontend.',
-				'jetpack-forms'
-			),
+			message: __( 'Trashed — not visible to visitors.', 'jetpack-forms' ),
 		},
 		draft: {
 			status: 'warning',
-			message: __(
-				'This form is a draft and will not be displayed on the frontend until published.',
-				'jetpack-forms'
-			),
+			message: __( 'Draft form — not visible to visitors.', 'jetpack-forms' ),
 		},
 		pending: {
 			status: 'warning',
-			message: __(
-				'This form is pending review and will not be displayed on the frontend until approved and published.',
-				'jetpack-forms'
-			),
+			message: __( 'Pending Review - not visible to visitors.', 'jetpack-forms' ),
 		},
 		future: {
 			status: 'info',
 			message: syncedForm?.date
 				? sprintf(
 						/* translators: %s: scheduled publish date */
-						__(
-							'This form is scheduled for %s and will not be displayed until then.',
-							'jetpack-forms'
-						),
+						__( 'Hidden until publication on %s.', 'jetpack-forms' ),
 						dateI18n( 'F j, Y g:i a', syncedForm.date )
 				  )
-				: __(
-						'This form is scheduled and will not be displayed until its publish date.',
-						'jetpack-forms'
-				  ),
+				: __( 'Hidden until publication date.', 'jetpack-forms' ),
 		},
 		private: {
 			status: 'warning',
-			message: __(
-				'This form is private and will not be displayed on the frontend. To make it visible, change its status to published.',
-				'jetpack-forms'
-			),
+			message: __( 'Private form — not visible to visitors.', 'jetpack-forms' ),
 		},
 	};
 

--- a/projects/packages/forms/src/blocks/contact-form/edit.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/edit.tsx
@@ -28,6 +28,7 @@ import {
 import { useInstanceId } from '@wordpress/compose';
 import { store as coreStore } from '@wordpress/core-data';
 import { useSelect, useDispatch } from '@wordpress/data';
+import { dateI18n } from '@wordpress/date';
 import { store as editorStore } from '@wordpress/editor';
 import { useRef, useEffect, useCallback, lazy, Suspense, useState } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
@@ -958,10 +959,19 @@ function JetpackContactFormEdit( {
 		},
 		future: {
 			status: 'info',
-			message: __(
-				'This form is scheduled and will not be displayed until its publish date.',
-				'jetpack-forms'
-			),
+			message: syncedForm?.date
+				? sprintf(
+						/* translators: %s: scheduled publish date */
+						__(
+							'This form is scheduled for %s and will not be displayed until then.',
+							'jetpack-forms'
+						),
+						dateI18n( 'F j, Y g:i a', syncedForm.date )
+				  )
+				: __(
+						'This form is scheduled and will not be displayed until its publish date.',
+						'jetpack-forms'
+				  ),
 		},
 		private: {
 			status: 'warning',

--- a/projects/packages/forms/src/blocks/contact-form/edit.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/edit.tsx
@@ -984,7 +984,9 @@ function JetpackContactFormEdit( {
 				) }
 			{ formStatus !== 'trash' && (
 				<Button
-					variant="link"
+					variant="secondary"
+					size="small"
+					__next40pxDefaultSize={ true }
 					onClick={ handlePublishForm }
 					isBusy={ isPublishingForm }
 					disabled={ isPublishingForm }

--- a/projects/packages/forms/src/blocks/contact-form/edit.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/edit.tsx
@@ -31,6 +31,7 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
 import { useRef, useEffect, useCallback, lazy, Suspense, useState } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
+import { store as noticesStore } from '@wordpress/notices';
 import clsx from 'clsx';
 /*
  * Internal dependencies
@@ -335,6 +336,7 @@ function JetpackContactFormEdit( {
 		useDispatch( blockEditorStore );
 
 	const { editEntityRecord, saveEditedEntityRecord } = useDispatch( coreStore );
+	const { createErrorNotice, createSuccessNotice } = useDispatch( noticesStore );
 	const { setActiveStep } = useDispatch( singleStepStore );
 
 	const currentInnerBlocks = useSelect(
@@ -376,10 +378,21 @@ function JetpackContactFormEdit( {
 		try {
 			await editEntityRecord( 'postType', FORM_POST_TYPE, ref, { status: 'publish' } );
 			await saveEditedEntityRecord( 'postType', FORM_POST_TYPE, ref );
+			createSuccessNotice( __( 'Form published successfully.', 'jetpack-forms' ), {
+				type: 'snackbar',
+			} );
+		} catch {
+			createErrorNotice(
+				__(
+					'Failed to publish form. Please try again or check your permissions.',
+					'jetpack-forms'
+				),
+				{ type: 'snackbar' }
+			);
 		} finally {
 			setIsPublishingForm( false );
 		}
-	}, [ ref, editEntityRecord, saveEditedEntityRecord ] );
+	}, [ ref, editEntityRecord, saveEditedEntityRecord, createSuccessNotice, createErrorNotice ] );
 
 	// Note: We don't clear attributes in memory when ref is set, as they're needed
 	// for the form to work properly in the editor. The save() method ensures that
@@ -930,7 +943,7 @@ function JetpackContactFormEdit( {
 		pending: {
 			status: 'warning',
 			message: __(
-				'This form is pending review and will not be displayed on the frontend.',
+				'This form is pending review and will not be displayed on the frontend until approved and published.',
 				'jetpack-forms'
 			),
 		},
@@ -942,9 +955,9 @@ function JetpackContactFormEdit( {
 			),
 		},
 		private: {
-			status: 'info',
+			status: 'warning',
 			message: __(
-				'This form is private and will not be displayed on the frontend until published.',
+				'This form is private and will not be displayed on the frontend. To make it visible, change its status to published.',
 				'jetpack-forms'
 			),
 		},

--- a/projects/packages/forms/src/blocks/contact-form/edit.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/edit.tsx
@@ -1115,11 +1115,13 @@ function JetpackContactFormEdit( {
 		<SyncedAttributeProvider>
 			<ThemeProvider targetDom={ wrapperRef.current }>
 				<div { ...blockProps }>
-					<FormStatusNotice
-						syncedForm={ syncedForm }
-						formRef={ ref }
-						isVisible={ isFormOrChildSelected }
-					/>
+					{ ref && (
+						<FormStatusNotice
+							syncedForm={ syncedForm }
+							formRef={ ref }
+							isVisible={ isFormOrChildSelected }
+						/>
+					) }
 					{ elt }
 				</div>
 			</ThemeProvider>

--- a/projects/packages/forms/src/blocks/contact-form/edit.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/edit.tsx
@@ -16,7 +16,6 @@ import {
 } from '@wordpress/block-editor';
 import { createBlock } from '@wordpress/blocks';
 import {
-	Button,
 	ExternalLink,
 	Notice,
 	PanelBody,
@@ -28,11 +27,9 @@ import {
 import { useInstanceId } from '@wordpress/compose';
 import { store as coreStore } from '@wordpress/core-data';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { dateI18n } from '@wordpress/date';
 import { store as editorStore } from '@wordpress/editor';
-import { useRef, useEffect, useCallback, lazy, Suspense, useState } from '@wordpress/element';
-import { __, sprintf } from '@wordpress/i18n';
-import { store as noticesStore } from '@wordpress/notices';
+import { useRef, useEffect, useCallback, lazy, Suspense } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
 /*
  * Internal dependencies
@@ -52,6 +49,7 @@ import { SyncedAttributeProvider } from '../shared/hooks/use-synced-attributes.j
 import { CORE_BLOCKS, FORM_POST_TYPE } from '../shared/util/constants.js';
 import { childBlocks } from './child-blocks.js';
 import { ConvertFormToolbar } from './components/convert-form-toolbar.tsx';
+import FormStatusNotice from './components/form-status-notice.tsx';
 import { ContactFormPlaceholder } from './components/jetpack-contact-form-placeholder.js';
 import ContactFormSkeletonLoader from './components/jetpack-contact-form-skeleton-loader.js';
 import NotificationsSettings from './components/notifications-settings.js';
@@ -345,8 +343,7 @@ function JetpackContactFormEdit( {
 	const { replaceInnerBlocks, __unstableMarkNextChangeAsNotPersistent, updateBlockAttributes } =
 		useDispatch( blockEditorStore );
 
-	const { editEntityRecord, saveEditedEntityRecord } = useDispatch( coreStore );
-	const { createErrorNotice, createSuccessNotice } = useDispatch( noticesStore );
+	const { editEntityRecord } = useDispatch( coreStore );
 	const { setActiveStep } = useDispatch( singleStepStore );
 
 	const currentInnerBlocks = useSelect(
@@ -375,34 +372,6 @@ function JetpackContactFormEdit( {
 		isSyncingRef,
 		editEntityRecord,
 	} );
-
-	// State for publishing synced forms
-	const [ isPublishingForm, setIsPublishingForm ] = useState( false );
-
-	// Handler to publish a synced form
-	const handlePublishForm = useCallback( async () => {
-		if ( ! ref ) {
-			return;
-		}
-		setIsPublishingForm( true );
-		try {
-			await editEntityRecord( 'postType', FORM_POST_TYPE, ref, { status: 'publish' } );
-			await saveEditedEntityRecord( 'postType', FORM_POST_TYPE, ref );
-			createSuccessNotice( __( 'Form published successfully.', 'jetpack-forms' ), {
-				type: 'snackbar',
-			} );
-		} catch {
-			createErrorNotice(
-				__(
-					'Failed to publish form. Please try again or check your permissions.',
-					'jetpack-forms'
-				),
-				{ type: 'snackbar' }
-			);
-		} finally {
-			setIsPublishingForm( false );
-		}
-	}, [ ref, editEntityRecord, saveEditedEntityRecord, createSuccessNotice, createErrorNotice ] );
 
 	// Note: We don't clear attributes in memory when ref is set, as they're needed
 	// for the form to work properly in the editor. The save() method ensures that
@@ -931,71 +900,8 @@ function JetpackContactFormEdit( {
 		stepBlock,
 	] );
 
-	// Status notice messages for synced forms with non-publish status
-	const statusNoticeConfig: Record<
-		string,
-		{ status: 'error' | 'warning' | 'info'; message: string }
-	> = {
-		trash: {
-			status: 'error',
-			message: __( 'Trashed — not visible to visitors.', 'jetpack-forms' ),
-		},
-		draft: {
-			status: 'warning',
-			message: __( 'Draft form — not visible to visitors.', 'jetpack-forms' ),
-		},
-		pending: {
-			status: 'warning',
-			message: __( 'Pending Review - not visible to visitors.', 'jetpack-forms' ),
-		},
-		future: {
-			status: 'info',
-			message: syncedForm?.date
-				? sprintf(
-						/* translators: %s: scheduled publish date */
-						__( 'Hidden until publication on %s.', 'jetpack-forms' ),
-						dateI18n( 'F j, Y g:i a', syncedForm.date )
-				  )
-				: __( 'Hidden until publication date.', 'jetpack-forms' ),
-		},
-		private: {
-			status: 'warning',
-			message: __( 'Private form — not visible to visitors.', 'jetpack-forms' ),
-		},
-	};
-
-	// Render status notice for synced forms with non-publish status (only when form or child is selected)
-	const formStatus = syncedForm?.status;
+	// Determine if form or any child is selected for status notice visibility
 	const isFormOrChildSelected = isSelected || hasChildSelected;
-	const statusNotice = isFormOrChildSelected && ref && formStatus && formStatus !== 'publish' && (
-		<Notice
-			status={ statusNoticeConfig[ formStatus ]?.status || 'warning' }
-			isDismissible={ false }
-			className="jetpack-contact-form__status-notice"
-		>
-			{ statusNoticeConfig[ formStatus ]?.message ||
-				sprintf(
-					/* translators: %s: form status */
-					__(
-						'This form has status "%s" and will not be displayed on the frontend until it is published.',
-						'jetpack-forms'
-					),
-					formStatus
-				) }
-			{ formStatus !== 'trash' && (
-				<Button
-					variant="secondary"
-					size="small"
-					__next40pxDefaultSize={ true }
-					onClick={ handlePublishForm }
-					isBusy={ isPublishingForm }
-					disabled={ isPublishingForm }
-				>
-					{ __( 'Publish now', 'jetpack-forms' ) }
-				</Button>
-			) }
-		</Notice>
-	);
 
 	let elt;
 
@@ -1209,7 +1115,11 @@ function JetpackContactFormEdit( {
 		<SyncedAttributeProvider>
 			<ThemeProvider targetDom={ wrapperRef.current }>
 				<div { ...blockProps }>
-					{ statusNotice }
+					<FormStatusNotice
+						syncedForm={ syncedForm }
+						formRef={ ref }
+						isVisible={ isFormOrChildSelected }
+					/>
 					{ elt }
 				</div>
 			</ThemeProvider>

--- a/projects/packages/forms/src/blocks/contact-form/edit.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/edit.tsx
@@ -16,6 +16,7 @@ import {
 } from '@wordpress/block-editor';
 import { createBlock } from '@wordpress/blocks';
 import {
+	Button,
 	ExternalLink,
 	Notice,
 	PanelBody,
@@ -28,8 +29,8 @@ import { useInstanceId } from '@wordpress/compose';
 import { store as coreStore } from '@wordpress/core-data';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
-import { useRef, useEffect, useCallback, lazy, Suspense } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { useRef, useEffect, useCallback, lazy, Suspense, useState } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
 import clsx from 'clsx';
 /*
  * Internal dependencies
@@ -333,7 +334,7 @@ function JetpackContactFormEdit( {
 	const { replaceInnerBlocks, __unstableMarkNextChangeAsNotPersistent, updateBlockAttributes } =
 		useDispatch( blockEditorStore );
 
-	const { editEntityRecord } = useDispatch( coreStore );
+	const { editEntityRecord, saveEditedEntityRecord } = useDispatch( coreStore );
 	const { setActiveStep } = useDispatch( singleStepStore );
 
 	const currentInnerBlocks = useSelect(
@@ -362,6 +363,23 @@ function JetpackContactFormEdit( {
 		isSyncingRef,
 		editEntityRecord,
 	} );
+
+	// State for publishing synced forms
+	const [ isPublishingForm, setIsPublishingForm ] = useState( false );
+
+	// Handler to publish a synced form
+	const handlePublishForm = useCallback( async () => {
+		if ( ! ref ) {
+			return;
+		}
+		setIsPublishingForm( true );
+		try {
+			await editEntityRecord( 'postType', FORM_POST_TYPE, ref, { status: 'publish' } );
+			await saveEditedEntityRecord( 'postType', FORM_POST_TYPE, ref );
+		} finally {
+			setIsPublishingForm( false );
+		}
+	}, [ ref, editEntityRecord, saveEditedEntityRecord ] );
 
 	// Note: We don't clear attributes in memory when ref is set, as they're needed
 	// for the form to work properly in the editor. The save() method ensures that
@@ -890,6 +908,75 @@ function JetpackContactFormEdit( {
 		stepBlock,
 	] );
 
+	// Status notice messages for synced forms with non-publish status
+	const statusNoticeConfig: Record<
+		string,
+		{ status: 'error' | 'warning' | 'info'; message: string }
+	> = {
+		trash: {
+			status: 'error',
+			message: __(
+				'This form has been trashed and will not be displayed on the frontend.',
+				'jetpack-forms'
+			),
+		},
+		draft: {
+			status: 'warning',
+			message: __(
+				'This form is a draft and will not be displayed on the frontend until published.',
+				'jetpack-forms'
+			),
+		},
+		pending: {
+			status: 'warning',
+			message: __(
+				'This form is pending review and will not be displayed on the frontend.',
+				'jetpack-forms'
+			),
+		},
+		future: {
+			status: 'info',
+			message: __(
+				'This form is scheduled and will not be displayed until its publish date.',
+				'jetpack-forms'
+			),
+		},
+		private: {
+			status: 'info',
+			message: __(
+				'This form is private and only visible to site administrators.',
+				'jetpack-forms'
+			),
+		},
+	};
+
+	// Render status notice for synced forms with non-publish status
+	const formStatus = syncedForm?.status;
+	const statusNotice = ref && formStatus && formStatus !== 'publish' && (
+		<Notice
+			status={ statusNoticeConfig[ formStatus ]?.status || 'warning' }
+			isDismissible={ false }
+			className="jetpack-contact-form__status-notice"
+		>
+			{ statusNoticeConfig[ formStatus ]?.message ||
+				sprintf(
+					/* translators: %s: form status */
+					__( 'This form has status "%s" and may not display correctly.', 'jetpack-forms' ),
+					formStatus
+				) }
+			{ formStatus !== 'trash' && (
+				<Button
+					variant="link"
+					onClick={ handlePublishForm }
+					isBusy={ isPublishingForm }
+					disabled={ isPublishingForm }
+				>
+					{ __( 'Publish now', 'jetpack-forms' ) }
+				</Button>
+			) }
+		</Notice>
+	);
+
 	let elt;
 
 	// Show loading state when resolving synced form
@@ -1101,7 +1188,10 @@ function JetpackContactFormEdit( {
 	return (
 		<SyncedAttributeProvider>
 			<ThemeProvider targetDom={ wrapperRef.current }>
-				<div { ...blockProps }>{ elt }</div>
+				<div { ...blockProps }>
+					{ statusNotice }
+					{ elt }
+				</div>
 			</ThemeProvider>
 		</SyncedAttributeProvider>
 	);

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -1229,8 +1229,4 @@
 /* Status notice for synced forms with non-publish status */
 .jetpack-contact-form__status-notice {
 	margin-bottom: 16px;
-
-	.components-button {
-		margin-inline-start: 8px;
-	}
 }

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -1231,6 +1231,6 @@
 	margin-bottom: 16px;
 
 	.components-button {
-		margin-left: 8px;
+		margin-inline-start: 8px;
 	}
 }

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -1225,3 +1225,12 @@
 		}
 	}
 }
+
+/* Status notice for synced forms with non-publish status */
+.jetpack-contact-form__status-notice {
+	margin-bottom: 16px;
+
+	.components-button {
+		margin-left: 8px;
+	}
+}

--- a/projects/packages/forms/src/blocks/contact-form/hooks/use-synced-form.ts
+++ b/projects/packages/forms/src/blocks/contact-form/hooks/use-synced-form.ts
@@ -11,7 +11,8 @@ import { FORM_POST_TYPE } from '../../shared/util/constants.js';
 type ParsedBlock = ReturnType< typeof parse >[ number ];
 interface JetpackForm {
 	content?: { raw: string } | undefined;
-	status?: string;
+	status: string;
+	date: string;
 }
 
 interface UseSyncedFormResult {

--- a/projects/packages/forms/src/blocks/contact-form/hooks/use-synced-form.ts
+++ b/projects/packages/forms/src/blocks/contact-form/hooks/use-synced-form.ts
@@ -11,6 +11,7 @@ import { FORM_POST_TYPE } from '../../shared/util/constants.js';
 type ParsedBlock = ReturnType< typeof parse >[ number ];
 interface JetpackForm {
 	content?: { raw: string } | undefined;
+	status?: string;
 }
 
 interface UseSyncedFormResult {

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -199,6 +199,14 @@ class Contact_Form extends Contact_Form_Shortcode {
 	}
 
 	/**
+	 * Reset the seen reference IDs for the contact form.
+	 */
+	public static function reset_seen_refs() {
+		self::$seen_ref = array();
+		self::$ref_id   = null;
+	}
+
+	/**
 	 * Construction function.
 	 *
 	 * @param array  $attributes - the attributes.

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -153,19 +153,30 @@ class Contact_Form extends Contact_Form_Shortcode {
 	private static $ref_id = null;
 
 	/**
+	 * Seen reference IDs for the contact form.
+	 *
+	 * @var array
+	 */
+	private static $seen_ref = array();
+
+	/**
 	 * Set the reference ID for the contact form.
 	 *
 	 * @param int $ref_id The reference ID.
 	 */
 	public static function set_ref_id( $ref_id ) {
-		self::$ref_id = $ref_id;
+		self::$ref_id              = $ref_id;
+		self::$seen_ref[ $ref_id ] = true;
 	}
 
 	/**
 	 * Clear the reference ID for the contact form.
+	 *
+	 * @param int $ref_id The reference ID to clear.
 	 */
-	public static function clear_ref_id() {
-		self::$ref_id = null;
+	public static function clear_ref_id( $ref_id ) {
+		self::$ref_id              = null;
+		self::$seen_ref[ $ref_id ] = false;
 	}
 
 	/**
@@ -175,6 +186,16 @@ class Contact_Form extends Contact_Form_Shortcode {
 	 */
 	public static function get_ref_id() {
 		return self::$ref_id;
+	}
+
+	/**
+	 * Check if the reference ID has been seen for the contact form.
+	 *
+	 * @param int $ref_id The reference ID.
+	 * @return bool True if the reference ID has been seen, false otherwise.
+	 */
+	public static function has_seen( $ref_id ) {
+		return isset( self::$seen_ref[ $ref_id ] ) && self::$seen_ref[ $ref_id ];
 	}
 
 	/**

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -169,6 +169,15 @@ class Contact_Form extends Contact_Form_Shortcode {
 	}
 
 	/**
+	 * Get the reference ID for the contact form.
+	 *
+	 * @return int|null The reference ID.
+	 */
+	public static function get_ref_id() {
+		return self::$ref_id;
+	}
+
+	/**
 	 * Construction function.
 	 *
 	 * @param array  $attributes - the attributes.

--- a/projects/packages/forms/src/contact-form/css/grunion.scss
+++ b/projects/packages/forms/src/contact-form/css/grunion.scss
@@ -1591,9 +1591,6 @@ on production builds, the attributes are being reordered, causing side-effects
 
 	&__edit-link {
 		font-weight: 500;
-	}
-
-	.jetpack-form-status-notice__edit-link {
 		white-space: nowrap;
 		color: #1e1e1e;
 
@@ -1605,7 +1602,7 @@ on production builds, the attributes are being reordered, causing side-effects
 
 	&--warning {
 		background-color: #fcf9e8;
-		border-left: 4px solid #dba617;
+		border-inline-start: 4px solid #dba617;
 		color: #1e1e1e;
 
 
@@ -1613,7 +1610,7 @@ on production builds, the attributes are being reordered, causing side-effects
 
 	&--info {
 		background-color: #e7f5fe;
-		border-left: 4px solid #0675c4;
+		border-inline-start: 4px solid #0675c4;
 		color: #1e1e1e;
 	}
 }

--- a/projects/packages/forms/src/contact-form/css/grunion.scss
+++ b/projects/packages/forms/src/contact-form/css/grunion.scss
@@ -1594,33 +1594,26 @@ on production builds, the attributes are being reordered, causing side-effects
 		font-weight: 500;
 	}
 
+	.jetpack-form-status-notice__edit-link {
+		color: #1e1e1e;
+
+		&:hover,
+		&:focus {
+			color: #000;
+		}
+	}
+
 	&--warning {
 		background-color: #fcf9e8;
 		border-left: 4px solid #dba617;
 		color: #1e1e1e;
 
-		.jetpack-form-status-notice__edit-link {
-			color: #996800;
 
-			&:hover,
-			&:focus {
-				color: #6e4b00;
-			}
-		}
 	}
 
 	&--info {
 		background-color: #e7f5fe;
 		border-left: 4px solid #0675c4;
 		color: #1e1e1e;
-
-		.jetpack-form-status-notice__edit-link {
-			color: #0675c4;
-
-			&:hover,
-			&:focus {
-				color: #044b7a;
-			}
-		}
 	}
 }

--- a/projects/packages/forms/src/contact-form/css/grunion.scss
+++ b/projects/packages/forms/src/contact-form/css/grunion.scss
@@ -1576,3 +1576,28 @@ on production builds, the attributes are being reordered, causing side-effects
 		transform: rotate(360deg);
 	}
 }
+
+/* Frontend status notice for non-published forms (visible to editors only) */
+.jetpack-form-status-notice {
+	padding: 12px 16px;
+	margin-bottom: 16px;
+	border-radius: 4px;
+	font-size: 14px;
+	line-height: 1.5;
+
+	p {
+		margin: 0;
+	}
+
+	&--warning {
+		background-color: #fcf9e8;
+		border-left: 4px solid #dba617;
+		color: #1e1e1e;
+	}
+
+	&--info {
+		background-color: #e7f5fe;
+		border-left: 4px solid #0675c4;
+		color: #1e1e1e;
+	}
+}

--- a/projects/packages/forms/src/contact-form/css/grunion.scss
+++ b/projects/packages/forms/src/contact-form/css/grunion.scss
@@ -1580,8 +1580,8 @@ on production builds, the attributes are being reordered, causing side-effects
 /* Frontend status notice for non-published forms (visible to editors only) */
 .jetpack-form-status-notice {
 	padding: 12px 16px;
-	margin-bottom: 16px;
-	border-radius: 4px;
+	margin-bottom: 8px;
+	margin-top: 16px;
 	font-size: 14px;
 	line-height: 1.5;
 
@@ -1589,15 +1589,38 @@ on production builds, the attributes are being reordered, causing side-effects
 		margin: 0;
 	}
 
+	&__edit-link {
+		margin-inline-start: 8px;
+		font-weight: 500;
+	}
+
 	&--warning {
 		background-color: #fcf9e8;
 		border-left: 4px solid #dba617;
 		color: #1e1e1e;
+
+		.jetpack-form-status-notice__edit-link {
+			color: #996800;
+
+			&:hover,
+			&:focus {
+				color: #6e4b00;
+			}
+		}
 	}
 
 	&--info {
 		background-color: #e7f5fe;
 		border-left: 4px solid #0675c4;
 		color: #1e1e1e;
+
+		.jetpack-form-status-notice__edit-link {
+			color: #0675c4;
+
+			&:hover,
+			&:focus {
+				color: #044b7a;
+			}
+		}
 	}
 }

--- a/projects/packages/forms/src/contact-form/css/grunion.scss
+++ b/projects/packages/forms/src/contact-form/css/grunion.scss
@@ -1590,11 +1590,11 @@ on production builds, the attributes are being reordered, causing side-effects
 	}
 
 	&__edit-link {
-		margin-inline-start: 8px;
 		font-weight: 500;
 	}
 
 	.jetpack-form-status-notice__edit-link {
+		white-space: nowrap;
 		color: #1e1e1e;
 
 		&:hover,

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Synced_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Synced_Test.php
@@ -36,14 +36,7 @@ class Contact_Form_Synced_Test extends BaseTestCase {
 	 */
 	public function tear_down() {
 		// Reset the seen refs to avoid state pollution between tests.
-		// We use reflection to access the private static property.
-		$reflection = new \ReflectionClass( Contact_Form::class );
-		$property   = $reflection->getProperty( 'seen_ref' );
-		$property->setValue( null, array() );
-
-		$ref_id_property = $reflection->getProperty( 'ref_id' );
-		$ref_id_property->setValue( null, null );
-
+		Contact_Form::reset_seen_refs();
 		parent::tear_down();
 	}
 

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Synced_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Synced_Test.php
@@ -39,11 +39,9 @@ class Contact_Form_Synced_Test extends BaseTestCase {
 		// We use reflection to access the private static property.
 		$reflection = new \ReflectionClass( Contact_Form::class );
 		$property   = $reflection->getProperty( 'seen_ref' );
-		$property->setAccessible( true );
 		$property->setValue( null, array() );
 
 		$ref_id_property = $reflection->getProperty( 'ref_id' );
-		$ref_id_property->setAccessible( true );
 		$ref_id_property->setValue( null, null );
 
 		parent::tear_down();

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Synced_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Synced_Test.php
@@ -27,13 +27,35 @@ class Contact_Form_Synced_Test extends BaseTestCase {
 	 */
 	public function set_up() {
 		parent::set_up();
+		Contact_Form_Block::register_block();
 		Contact_Form_Block::register_child_blocks();
+	}
+
+	/**
+	 * Tear down the test environment.
+	 */
+	public function tear_down() {
+		// Reset the seen refs to avoid state pollution between tests.
+		// We use reflection to access the private static property.
+		$reflection = new \ReflectionClass( Contact_Form::class );
+		$property   = $reflection->getProperty( 'seen_ref' );
+		$property->setAccessible( true );
+		$property->setValue( null, array() );
+
+		$ref_id_property = $reflection->getProperty( 'ref_id' );
+		$ref_id_property->setAccessible( true );
+		$ref_id_property->setValue( null, null );
+
+		parent::tear_down();
 	}
 
 	/**
 	 * Test that form with ref attribute loads content from synced form post.
 	 */
 	public function test_render_synced_form_loads_content() {
+		// Disable content filtering to prevent WordPress from escaping JSON
+		kses_remove_filters();
+
 		// Create a jetpack_form post with form content
 		$form_id = wp_insert_post(
 			array(
@@ -46,6 +68,8 @@ class Contact_Form_Synced_Test extends BaseTestCase {
 					<!-- /wp:jetpack/contact-form -->',
 			)
 		);
+
+		kses_init_filters();
 
 		$this->assertGreaterThan( 0, $form_id, 'Synced form post should be created' );
 
@@ -60,8 +84,9 @@ class Contact_Form_Synced_Test extends BaseTestCase {
 		// Render the block
 		$output = Contact_Form_Block::gutenblock_render_form( $block->attributes, '' );
 
-		// Verify the output contains the email field from the synced form
-		$this->assertStringContainsString( '[contact-field type="email" label="Email"/]', trim( $output ), 'Output should contain email field from synced form' );
+		// Verify the output contains the email field from the synced form (rendered as HTML)
+		$this->assertStringContainsString( 'type=\'email\'', $output, 'Output should contain email input type' );
+		$this->assertStringContainsString( 'grunion-field-label email', $output, 'Output should contain email field label class' );
 	}
 
 	/**
@@ -97,15 +122,16 @@ class Contact_Form_Synced_Test extends BaseTestCase {
 		);
 
 		// Update the form to reference itself (circular reference)
+		// Disable content filtering to prevent WordPress from escaping JSON
+		kses_remove_filters();
+		$circular_content = sprintf( '<!-- wp:jetpack/contact-form {"ref":%d} /-->', $form_id );
 		wp_update_post(
 			array(
 				'ID'           => $form_id,
-				'post_content' => sprintf(
-					'<!-- wp:jetpack/contact-form {"ref":%d} /-->',
-					$form_id
-				),
+				'post_content' => $circular_content,
 			)
 		);
+		kses_init_filters();
 
 		// Try to render this form
 		$block = new WP_Block(
@@ -246,5 +272,329 @@ class Contact_Form_Synced_Test extends BaseTestCase {
 
 		// Verify that form was rendered successfully (proves ref_id was set and cleared properly)
 		$this->assertNotEmpty( $output, 'Form should render successfully with ref_id management' );
+	}
+
+	/**
+	 * Test set_ref_id marks the ID as seen.
+	 */
+	public function test_set_ref_id_marks_as_seen() {
+		$ref_id = 123;
+
+		// Initially not seen
+		$this->assertFalse( Contact_Form::has_seen( $ref_id ), 'Ref ID should not be seen initially' );
+
+		// Set ref_id
+		Contact_Form::set_ref_id( $ref_id );
+
+		// Should now be seen
+		$this->assertTrue( Contact_Form::has_seen( $ref_id ), 'Ref ID should be seen after set_ref_id' );
+		$this->assertSame( $ref_id, Contact_Form::get_ref_id(), 'get_ref_id should return the set ref_id' );
+
+		// Clean up
+		Contact_Form::clear_ref_id( $ref_id );
+	}
+
+	/**
+	 * Test that has_seen works correctly during form rendering context.
+	 */
+	public function test_has_seen_during_render_context() {
+		// Create a simple form with actual content
+		$form_id = wp_insert_post(
+			array(
+				'post_type'    => 'jetpack_form',
+				'post_status'  => 'publish',
+				'post_title'   => 'Test Form',
+				'post_content' => '<!-- wp:jetpack/contact-form --><!-- wp:jetpack/field-text {"label":"Name"} /--><!-- /wp:jetpack/contact-form -->',
+			)
+		);
+
+		// Manually set the ref_id as if we were in the middle of rendering
+		Contact_Form::set_ref_id( $form_id );
+
+		// Verify has_seen returns true for the form we're "rendering"
+		$this->assertTrue( Contact_Form::has_seen( $form_id ), 'has_seen should return true for form being rendered' );
+
+		// Try to render the same form - should detect the circular reference
+		$block = new WP_Block(
+			array(
+				'blockName' => 'jetpack/contact-form',
+				'attrs'     => array( 'ref' => $form_id ),
+			)
+		);
+
+		// This call should detect that form_id is already being rendered and return empty
+		$output = Contact_Form_Block::gutenblock_render_form( $block->attributes, '' );
+
+		// Clean up
+		Contact_Form::clear_ref_id( $form_id );
+
+		// The output should be empty because we detected circular reference
+		$this->assertEmpty( $output, 'Attempting to render a form already being rendered should return empty' );
+	}
+
+	/**
+	 * Test clear_ref_id removes the seen status.
+	 */
+	public function test_clear_ref_id_removes_seen_status() {
+		$ref_id = 456;
+
+		// Set and verify it's seen
+		Contact_Form::set_ref_id( $ref_id );
+		$this->assertTrue( Contact_Form::has_seen( $ref_id ), 'Ref ID should be seen after set' );
+
+		// Clear it
+		Contact_Form::clear_ref_id( $ref_id );
+
+		// Should no longer be seen
+		$this->assertFalse( Contact_Form::has_seen( $ref_id ), 'Ref ID should not be seen after clear' );
+		$this->assertNull( Contact_Form::get_ref_id(), 'get_ref_id should return null after clear' );
+	}
+
+	/**
+	 * Test multiple ref_ids can be tracked simultaneously.
+	 */
+	public function test_multiple_ref_ids_tracked_simultaneously() {
+		$ref_a = 100;
+		$ref_b = 200;
+
+		// Set ref A
+		Contact_Form::set_ref_id( $ref_a );
+		$this->assertTrue( Contact_Form::has_seen( $ref_a ), 'Ref A should be seen' );
+		$this->assertFalse( Contact_Form::has_seen( $ref_b ), 'Ref B should not be seen yet' );
+
+		// Set ref B (simulating nested form)
+		Contact_Form::set_ref_id( $ref_b );
+		$this->assertTrue( Contact_Form::has_seen( $ref_a ), 'Ref A should still be seen' );
+		$this->assertTrue( Contact_Form::has_seen( $ref_b ), 'Ref B should now be seen' );
+
+		// Clear ref B (inner form done)
+		Contact_Form::clear_ref_id( $ref_b );
+		$this->assertTrue( Contact_Form::has_seen( $ref_a ), 'Ref A should still be seen after clearing B' );
+		$this->assertFalse( Contact_Form::has_seen( $ref_b ), 'Ref B should no longer be seen' );
+
+		// Clear ref A (outer form done)
+		Contact_Form::clear_ref_id( $ref_a );
+		$this->assertFalse( Contact_Form::has_seen( $ref_a ), 'Ref A should no longer be seen' );
+	}
+
+	/**
+	 * Test indirect circular reference prevention (Form A -> Form B -> Form A).
+	 */
+	public function test_render_synced_form_prevents_indirect_circular_reference() {
+		// Create Form A (will be updated to reference Form B)
+		$form_a_id = wp_insert_post(
+			array(
+				'post_type'   => 'jetpack_form',
+				'post_status' => 'publish',
+				'post_title'  => 'Form A',
+			)
+		);
+
+		// Disable content filtering to prevent WordPress from escaping JSON
+		kses_remove_filters();
+
+		// Create Form B that references Form A
+		$form_b_content = sprintf( '<!-- wp:jetpack/contact-form {"ref":%d} /-->', $form_a_id );
+		$form_b_id      = wp_insert_post(
+			array(
+				'post_type'    => 'jetpack_form',
+				'post_status'  => 'publish',
+				'post_title'   => 'Form B',
+				'post_content' => $form_b_content,
+			)
+		);
+
+		// Update Form A to reference Form B (creating indirect circular reference: A -> B -> A)
+		$form_a_content = sprintf( '<!-- wp:jetpack/contact-form {"ref":%d} /-->', $form_b_id );
+		wp_update_post(
+			array(
+				'ID'           => $form_a_id,
+				'post_content' => $form_a_content,
+			)
+		);
+
+		kses_init_filters();
+
+		// Try to render Form A
+		$block = new WP_Block(
+			array(
+				'blockName' => 'jetpack/contact-form',
+				'attrs'     => array( 'ref' => $form_a_id ),
+			)
+		);
+
+		$output = Contact_Form_Block::gutenblock_render_form( $block->attributes, '' );
+
+		// Should return empty string to prevent infinite loop
+		// The rendering chain is: Form A -> Form B -> Form A (blocked)
+		$this->assertEmpty( $output, 'Indirect circular reference (A->B->A) should be prevented' );
+	}
+
+	/**
+	 * Test three-level indirect circular reference (Form A -> Form B -> Form C -> Form A).
+	 */
+	public function test_render_synced_form_prevents_three_level_circular_reference() {
+		// Create Form A
+		$form_a_id = wp_insert_post(
+			array(
+				'post_type'   => 'jetpack_form',
+				'post_status' => 'publish',
+				'post_title'  => 'Form A',
+			)
+		);
+
+		// Disable content filtering to prevent WordPress from escaping JSON
+		kses_remove_filters();
+
+		// Create Form C that references Form A
+		$form_c_content = sprintf( '<!-- wp:jetpack/contact-form {"ref":%d} /-->', $form_a_id );
+		$form_c_id      = wp_insert_post(
+			array(
+				'post_type'    => 'jetpack_form',
+				'post_status'  => 'publish',
+				'post_title'   => 'Form C',
+				'post_content' => $form_c_content,
+			)
+		);
+
+		// Create Form B that references Form C
+		$form_b_content = sprintf( '<!-- wp:jetpack/contact-form {"ref":%d} /-->', $form_c_id );
+		$form_b_id      = wp_insert_post(
+			array(
+				'post_type'    => 'jetpack_form',
+				'post_status'  => 'publish',
+				'post_title'   => 'Form B',
+				'post_content' => $form_b_content,
+			)
+		);
+
+		// Update Form A to reference Form B (A -> B -> C -> A)
+		$form_a_content = sprintf( '<!-- wp:jetpack/contact-form {"ref":%d} /-->', $form_b_id );
+		wp_update_post(
+			array(
+				'ID'           => $form_a_id,
+				'post_content' => $form_a_content,
+			)
+		);
+
+		kses_init_filters();
+
+		// Try to render Form A
+		$block = new WP_Block(
+			array(
+				'blockName' => 'jetpack/contact-form',
+				'attrs'     => array( 'ref' => $form_a_id ),
+			)
+		);
+
+		$output = Contact_Form_Block::gutenblock_render_form( $block->attributes, '' );
+
+		// Should return empty string to prevent infinite loop
+		$this->assertEmpty( $output, 'Three-level circular reference (A->B->C->A) should be prevented' );
+	}
+
+	/**
+	 * Test simple two-level nested forms (A -> B where B has content).
+	 */
+	public function test_two_level_nested_forms_render() {
+		// Disable content filtering to prevent WordPress from escaping JSON
+		kses_remove_filters();
+
+		// Create Form B with actual content
+		$form_b_id = wp_insert_post(
+			array(
+				'post_type'    => 'jetpack_form',
+				'post_status'  => 'publish',
+				'post_title'   => 'Form B',
+				'post_content' => '<!-- wp:jetpack/contact-form --><!-- wp:jetpack/field-email {"label":"Email"} /--><!-- /wp:jetpack/contact-form -->',
+			)
+		);
+
+		// Create Form A that references Form B
+		$form_a_content = sprintf( '<!-- wp:jetpack/contact-form {"ref":%d} /-->', $form_b_id );
+		$form_a_id      = wp_insert_post(
+			array(
+				'post_type'    => 'jetpack_form',
+				'post_status'  => 'publish',
+				'post_title'   => 'Form A',
+				'post_content' => $form_a_content,
+			)
+		);
+
+		// Verify Form A's content is stored correctly
+		$form_a = get_post( $form_a_id );
+		$blocks = parse_blocks( $form_a->post_content );
+		$this->assertNotEmpty( $blocks, 'Form A should have blocks' );
+		$this->assertArrayHasKey( 'ref', $blocks[0]['attrs'] ?? array(), sprintf( 'Block should have ref attr. Content: %s', $form_a->post_content ) );
+
+		// Render Form A (keep kses disabled during rendering for nested form loading)
+		$block = new WP_Block(
+			array(
+				'blockName' => 'jetpack/contact-form',
+				'attrs'     => array( 'ref' => $form_a_id ),
+			)
+		);
+
+		$output = Contact_Form_Block::gutenblock_render_form( $block->attributes, '' );
+
+		kses_init_filters();
+
+		// Should render Form B's content since there's no circular reference
+		$this->assertStringContainsString( 'email', $output, 'Two-level nested forms should render the leaf form content' );
+	}
+
+	/**
+	 * Test that non-circular nested forms render successfully.
+	 */
+	public function test_non_circular_nested_forms_render() {
+		// Disable content filtering to prevent WordPress from escaping JSON
+		kses_remove_filters();
+
+		// Create Form C (leaf form with actual content)
+		$form_c_id = wp_insert_post(
+			array(
+				'post_type'    => 'jetpack_form',
+				'post_status'  => 'publish',
+				'post_title'   => 'Form C',
+				'post_content' => '<!-- wp:jetpack/contact-form --><!-- wp:jetpack/field-email {"label":"Email"} /--><!-- /wp:jetpack/contact-form -->',
+			)
+		);
+
+		// Create Form B that references Form C
+		$form_b_content = sprintf( '<!-- wp:jetpack/contact-form {"ref":%d} /-->', $form_c_id );
+		$form_b_id      = wp_insert_post(
+			array(
+				'post_type'    => 'jetpack_form',
+				'post_status'  => 'publish',
+				'post_title'   => 'Form B',
+				'post_content' => $form_b_content,
+			)
+		);
+
+		// Create Form A that references Form B (A -> B -> C, no cycle)
+		$form_a_content = sprintf( '<!-- wp:jetpack/contact-form {"ref":%d} /-->', $form_b_id );
+		$form_a_id      = wp_insert_post(
+			array(
+				'post_type'    => 'jetpack_form',
+				'post_status'  => 'publish',
+				'post_title'   => 'Form A',
+				'post_content' => $form_a_content,
+			)
+		);
+
+		// Render Form A (keep kses disabled during rendering for nested form loading)
+		$block = new WP_Block(
+			array(
+				'blockName' => 'jetpack/contact-form',
+				'attrs'     => array( 'ref' => $form_a_id ),
+			)
+		);
+
+		$output = Contact_Form_Block::gutenblock_render_form( $block->attributes, '' );
+
+		kses_init_filters();
+
+		// Should render successfully since there's no circular reference
+		$this->assertStringContainsString( 'email', $output, 'Non-circular nested forms should render the leaf form content' );
 	}
 }


### PR DESCRIPTION
Draft:

<img width="715" height="283" alt="Screenshot 2026-02-04 at 12 24 55 PM" src="https://github.com/user-attachments/assets/66f8da19-894d-4d89-ad65-ce87fc2ecf2e" />

Pending:
<img width="742" height="307" alt="Screenshot 2026-02-04 at 12 07 15 PM" src="https://github.com/user-attachments/assets/964e304b-31e2-40a2-bc1e-89c27f5b07ef" />

Private:
<img width="708" height="252" alt="Screenshot 2026-02-04 at 12 07 22 PM" src="https://github.com/user-attachments/assets/bc2ffe71-7c8b-425a-8fd4-516fdf99d793" />

Scheduled: 
<img width="776" height="569" alt="Screenshot 2026-02-04 at 12 07 26 PM" src="https://github.com/user-attachments/assets/fb5959d4-c599-4904-8e5c-6e742536b825" />

Trashed:
(latest copy)
https://github.com/user-attachments/assets/f2b40a43-c85b-4dc1-a2b1-d3962032cc7a

Frontend:
<img width="620" height="1080" alt="Screenshot 2026-02-04 at 12 11 32 PM" src="https://github.com/user-attachments/assets/ec8723e9-997b-477a-b5c4-c6e56214519f" />



## Proposed changes:

   When a synced form is displayed in the block editor, users
   currently have no indication of the form's post status. A form
    could be trashed or in draft status, but this is invisible to
    editors.

   This PR adds a notice that displays when a synced form has a
   status other than "publish":

   - **Error notice** for trashed forms
   - **Warning notice** for draft and pending forms
   - **Info notice** for scheduled (future) and private forms

   For non-trashed forms, a "Publish now" button allows users to
   publish the form directly from the notice.

   ### Other information:

   - [ ] Have you written new tests for your changes, if applicable?
   - [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
   - [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
No

## Does this pull request change what data or activity we track or use?

   No

## Testing instructions:

Enable CFM via

```
add_filter( 'jetpack_block_editor_feature_flags', 'eb_register_feature' );

function eb_register_feature( $flags ) {
    $flags['central-form-management'] = ! isset( $_GET[  'not-cfm' ] );
    return $flags;
}
```

      1. Create a new synced form (insert a Contact Form block and
   save)
   2. In the WordPress admin, go to Posts > All Posts (or use the
    database) and find the `jetpack_form` post type entry
   3. Change the form's status to `draft` via quick edit or the
   database
   4. Insert the same form into a post using the Form block with
   a reference
   5. Verify that a **warning notice** appears above the form
   stating "This form is a draft and will not be displayed on the frontend until published."
   6. Verify there is a "Publish now" button in the notice
   7. Click "Publish now" and verify the notice disappears after the form is published
   8. Repeat testing with other statuses:
      - `trash` - should show error notice without publish button
      - `pending` - should show warning notice with publish button
      - `private` - should show info notice with publish button
   9. Verify that published forms show no notice