### PR TITLE
SOCIAL-345 Fixing modal close button colour

### DIFF
--- a/projects/packages/publicize/_inc/components/unified-modal/styles.module.scss
+++ b/projects/packages/publicize/_inc/components/unified-modal/styles.module.scss
@@ -11,7 +11,7 @@
 	}
 
 	// Override global .components-button svg fill causing blue close icon
-	:global(.components-button svg) {
+	:global(.jp-navigator-modal__header .components-button svg) {
 		fill: inherit;
 	}
 }

--- a/projects/packages/publicize/_inc/components/unified-modal/styles.module.scss
+++ b/projects/packages/publicize/_inc/components/unified-modal/styles.module.scss
@@ -9,4 +9,9 @@
 	@include gb.break-small {
 		width: calc(100vw - 40px);
 	}
+
+	// Override global .components-button svg fill causing blue close icon
+	:global(.components-button svg) {
+		fill: inherit;
+	}
 }

--- a/projects/packages/publicize/changelog/update-SOCIAL-345-button-unification
+++ b/projects/packages/publicize/changelog/update-SOCIAL-345-button-unification
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Social: Unified close button colour.
+
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes SOCIAL-345

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Reset the SVG fill property to its default state within the unified modal and prevent CSS bleeding from other global styles

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply Jetpack Social feature flag and connect Jetpack
* Go to unified modal and verify that the close X button is not blue

| Before | After |
| --- | --- |
| <img width="824" height="438" alt="CleanShot 2026-02-03 at 12 18 03@2x" src="https://github.com/user-attachments/assets/1d917612-8054-450d-8a86-f46e72c918c6" /> | <img width="1046" height="382" alt="CleanShot 2026-02-03 at 12 23 25@2x" src="https://github.com/user-attachments/assets/f32bb9aa-6a32-49bd-8522-193e88b2c8ca" /> |


