### PR TITLE
SOCIAL-346 Use featured image as default media and fix media removal

### DIFF
--- a/projects/packages/publicize/_inc/components/customize-and-preview/customization-forms/per-network.tsx
+++ b/projects/packages/publicize/_inc/components/customize-and-preview/customization-forms/per-network.tsx
@@ -25,7 +25,7 @@ export function PerNetworkCustomizationForm( { connection }: PerNetworkCustomiza
 
 	const message = connection.message ?? globalMessage ?? '';
 	const attachedMedia = connection.attached_media ?? globalAttachedMedia ?? [];
-	const mediaSource = connection.media_source ?? globalMediaSource ?? 'none';
+	const mediaSource = connection.media_source ?? globalMediaSource ?? undefined;
 
 	// Handler for message changes
 	const handleMessageChange = useCallback(

--- a/projects/packages/publicize/_inc/components/media-section-v2/index.tsx
+++ b/projects/packages/publicize/_inc/components/media-section-v2/index.tsx
@@ -114,6 +114,18 @@ export default function MediaSectionV2( {
 
 	const [ mediaDetails ] = useMediaDetails( mediaId );
 
+	// Determine if media is currently loading
+	const isMediaLoading = useMemo( () => {
+		if ( currentSource === 'sig' ) {
+			return sigIsLoading;
+		}
+		if ( currentSource === 'featured-image' && featuredImageId ) {
+			// Media details are loading if we have an ID but no data yet
+			return ! mediaDetails?.mediaData;
+		}
+		return false;
+	}, [ currentSource, sigIsLoading, featuredImageId, mediaDetails ] );
+
 	const previewData: MediaPreviewData | null = useMemo( () => {
 		// Use SIG preview URL when SIG is selected
 		// Always return an object (even with empty URL) so the loading spinner can show
@@ -125,6 +137,7 @@ export default function MediaSectionV2( {
 			};
 		}
 
+		// Return null if no media or still loading media details
 		if ( ! mediaId || ! mediaDetails?.mediaData ) {
 			return null;
 		}
@@ -299,7 +312,7 @@ export default function MediaSectionV2( {
 								{ ( { open } ) => (
 									<MediaPreview
 										media={ previewData }
-										isLoading={ currentSource === 'sig' && sigIsLoading }
+										isLoading={ isMediaLoading }
 										onReplace={ open }
 										onRemove={ handleRemove }
 										disabled={ disabled }

--- a/projects/packages/publicize/_inc/hooks/use-connection-preview-data/index.ts
+++ b/projects/packages/publicize/_inc/hooks/use-connection-preview-data/index.ts
@@ -70,10 +70,14 @@ export function useConnectionPreviewData( connection: Connection ) {
 				break;
 		}
 
+		// Don't show image when media source is explicitly 'none'
+		const image = connection.media_source === 'none' ? '' : postData.image;
+
 		return {
 			...postData,
 			message: ( connection.message ?? globalMessage ).trim(),
 			media,
+			image,
 		};
 	}, [
 		connection,

--- a/projects/packages/publicize/_inc/hooks/use-social-preview-post-data/index.ts
+++ b/projects/packages/publicize/_inc/hooks/use-social-preview-post-data/index.ts
@@ -14,7 +14,7 @@ import { getMediaSourceUrl, getPostImageUrl } from './utils';
  * @return The post data.
  */
 export function useSocialPreviewPostData(): PostData {
-	const { attachedMedia, imageGeneratorSettings } = usePostMeta();
+	const { attachedMedia, imageGeneratorSettings, mediaSource } = usePostMeta();
 
 	const { getEditedPostAttribute } = useSelect( editorStore, [] );
 
@@ -75,8 +75,12 @@ export function useSocialPreviewPostData(): PostData {
 
 	const image = useSelect(
 		select => {
-			const { getEntityRecord } = select( coreStore );
+			// Don't use featured image if media source is explicitly set to 'none'
+			if ( mediaSource === 'none' ) {
+				return '';
+			}
 
+			const { getEntityRecord } = select( coreStore );
 			const featuredImageId = select( editorStore ).getEditedPostAttribute( 'featured_media' );
 
 			// Use the featured image by default, if it's available.
@@ -103,7 +107,7 @@ export function useSocialPreviewPostData(): PostData {
 
 			return _image;
 		},
-		[ imageGeneratorSettings.enabled, imageGeneratorSettings.token ]
+		[ imageGeneratorSettings.enabled, imageGeneratorSettings.token, mediaSource ]
 	);
 
 	return useMemo( () => {

--- a/projects/packages/publicize/changelog/update-SOCIAL-346-custom-media
+++ b/projects/packages/publicize/changelog/update-SOCIAL-346-custom-media
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Social: Making featured image default for sharing previews and fixing a bug with removal not reflected in the preview.

--- a/projects/plugins/jetpack/changelog/update-SOCIAL-346-custom-media
+++ b/projects/plugins/jetpack/changelog/update-SOCIAL-346-custom-media
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Social: Making featured image default for sharing previews and fixing a bug with removal not reflected in the preview.

--- a/projects/plugins/social/changelog/update-SOCIAL-346-custom-media
+++ b/projects/plugins/social/changelog/update-SOCIAL-346-custom-media
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Social: Making featured image default for sharing previews and fixing a bug with removal not reflected in the preview.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes SOCIAL-346

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Fixed media state when switching to "Customize each" mode with a featured image. 
* Changed the per-network fallback from 'none' to undefined (allowing selection detection to run)
* Updated loading state tracking for featured images
* Fixed a bug where the preview panel wasn't clearing images when "Remove" was clicked in both global and per-network modes. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply Jetpack Social feature flag and activate the plugin
* Create a post with a featured image and open the Jetpack Social modal
* Test global mode: Click "Remove" in media section → verify preview panel clears the image
* Select the featured image as the media once again
* Switch to "Customize each" → verify featured image appears in media section and preview panel
* Test per-network mode: Click "Remove" for a connection → verify that connection's preview panel clears the image
* Test loading state: Switch between featured images and a template → verify spinner shows briefly while loading  

