### PR TITLE
wpcomsh: Modified error logging for mismatched email state

### DIFF
--- a/projects/plugins/wpcomsh/.phan/baseline.php
+++ b/projects/plugins/wpcomsh/.phan/baseline.php
@@ -9,7 +9,7 @@
  */
 return [
     // # Issue statistics:
-    // PhanPluginMixedKeyNoKey : 45+ occurrences
+    // PhanPluginMixedKeyNoKey : 50+ occurrences
     // PhanUndeclaredStaticMethod : 15+ occurrences
     // PhanTypeMismatchArgument : 6 occurrences
     // PhanTypeMismatchArgumentNullable : 5 occurrences
@@ -42,7 +42,6 @@ return [
         'imports/playground/class-sql-importer.php' => ['PhanUndeclaredConstant'],
         'safeguard/utils.php' => ['PhanTypeMismatchArgument'],
         'tests/AnyoneCanRegisterNoticeTest.php' => ['PhanTypeMismatchArgument', 'PhanTypeVoidArgument', 'PhanTypeVoidAssignment'],
-        'tests/AtomicStorageProviderTest.php' => ['PhanUndeclaredStaticMethod'],
         'tests/FrontendNoticesTest.php' => ['PhanUndeclaredStaticMethod'],
         'tests/PlanNoticesTest.php' => ['PhanDeprecatedProperty', 'PhanPluginUseReturnValueInternalKnown', 'PhanUndeclaredStaticMethod'],
         'tests/WpcomFeaturesTest.php' => ['PhanTypeMismatchArgument', 'PhanUndeclaredStaticMethod'],

--- a/projects/plugins/wpcomsh/.phan/baseline.php
+++ b/projects/plugins/wpcomsh/.phan/baseline.php
@@ -42,6 +42,7 @@ return [
         'imports/playground/class-sql-importer.php' => ['PhanUndeclaredConstant'],
         'safeguard/utils.php' => ['PhanTypeMismatchArgument'],
         'tests/AnyoneCanRegisterNoticeTest.php' => ['PhanTypeMismatchArgument', 'PhanTypeVoidArgument', 'PhanTypeVoidAssignment'],
+        'tests/AtomicStorageProviderTest.php' => ['PhanUndeclaredStaticMethod'],
         'tests/FrontendNoticesTest.php' => ['PhanUndeclaredStaticMethod'],
         'tests/PlanNoticesTest.php' => ['PhanDeprecatedProperty', 'PhanPluginUseReturnValueInternalKnown', 'PhanUndeclaredStaticMethod'],
         'tests/WpcomFeaturesTest.php' => ['PhanTypeMismatchArgument', 'PhanUndeclaredStaticMethod'],

--- a/projects/plugins/wpcomsh/changelog/update-wpcomsh-apd-inconsistency-logging
+++ b/projects/plugins/wpcomsh/changelog/update-wpcomsh-apd-inconsistency-logging
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Modified error logging.

--- a/projects/plugins/wpcomsh/connection/class-atomic-storage-provider.php
+++ b/projects/plugins/wpcomsh/connection/class-atomic-storage-provider.php
@@ -96,6 +96,29 @@ if ( interface_exists( 'Automattic\Jetpack\Connection\Storage_Provider_Interface
 		 * @param string $environment The environment identifier.
 		 */
 		public function handle_error_event( $event_type, $key, $details, $environment ) {
+			// For master_user and user_tokens, distinguish between:
+			// 1. APD truly empty (config problem) - log error
+			// 2. APD has values but no local user matches - expected state, don't log
+			// Protected_Owner_Error_Handler handles the UI for case 2.
+			if ( 'empty' === $event_type && in_array( $key, array( 'master_user', 'user_tokens' ), true ) ) {
+				$persistent_data = new \Atomic_Persistent_Data();
+				$owner_email     = $persistent_data->JETPACK_CONNECTION_OWNER_EMAIL; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+				$owner_secret    = $persistent_data->JETPACK_CONNECTION_OWNER_TOKEN_SECRET; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+
+				// For master_user: only need email to be set
+				// For user_tokens: need both email and secret to be set
+				$apd_has_required_values = ( 'master_user' === $key )
+					? ! empty( $owner_email )
+					: ( ! empty( $owner_email ) && ! empty( $owner_secret ) );
+
+				if ( $apd_has_required_values ) {
+					// APD is configured, but no local user matches the email.
+					// This is an expected intermediate state, not a config error.
+					return;
+				}
+				// APD is truly empty/incomplete - fall through to log the error
+			}
+
 			// Build log message
 			$message = sprintf(
 				'External Storage %s: %s',

--- a/projects/plugins/wpcomsh/tests/AtomicStorageProviderTest.php
+++ b/projects/plugins/wpcomsh/tests/AtomicStorageProviderTest.php
@@ -229,4 +229,98 @@ class AtomicStorageProviderTest extends WP_UnitTestCase {
 		// Should have replaced with new token
 		$this->assertSame( 'new.secret.' . $user_id, $result[ $user_id ] );
 	}
+
+	/**
+	 * Test handle_error_event suppresses empty errors when APD has values but no local user matches.
+	 *
+	 * When APD has email/secret configured but no local WordPress user matches,
+	 * this is an expected intermediate state handled by Protected_Owner_Error_Handler.
+	 */
+	public function test_handle_error_event_suppresses_when_apd_configured_but_no_user() {
+		// APD has values - this simulates "user changed email locally" scenario
+		\Atomic_Persistent_Data::set( 'JETPACK_CONNECTION_OWNER_EMAIL', 'owner@example.com' );
+		\Atomic_Persistent_Data::set( 'JETPACK_CONNECTION_OWNER_TOKEN_SECRET', 'abc.xyz' );
+
+		// These should be suppressed - APD is configured, just no local user matches
+		$this->provider->handle_error_event( 'empty', 'master_user', '', 'woa' );
+		$this->provider->handle_error_event( 'empty', 'user_tokens', '', 'woa' );
+
+		// If we got here without errors, the suppression logic worked
+		$this->assertTrue( true );
+
+		// Cleanup
+		\Atomic_Persistent_Data::delete( 'JETPACK_CONNECTION_OWNER_EMAIL' );
+		\Atomic_Persistent_Data::delete( 'JETPACK_CONNECTION_OWNER_TOKEN_SECRET' );
+	}
+
+	/**
+	 * Test handle_error_event logs when APD is truly empty.
+	 *
+	 * When APD doesn't have email/secret configured, this is a real configuration
+	 * problem that should be logged.
+	 */
+	public function test_handle_error_event_logs_when_apd_truly_empty() {
+		// APD is empty - this is a real config problem
+		\Atomic_Persistent_Data::delete( 'JETPACK_CONNECTION_OWNER_EMAIL' );
+		\Atomic_Persistent_Data::delete( 'JETPACK_CONNECTION_OWNER_TOKEN_SECRET' );
+
+		// These should proceed to logging (though WPCOMSH_Log doesn't exist in tests)
+		$this->provider->handle_error_event( 'empty', 'master_user', '', 'woa' );
+		$this->provider->handle_error_event( 'empty', 'user_tokens', '', 'woa' );
+
+		// If we got here without errors, the logic worked
+		$this->assertTrue( true );
+	}
+
+	/**
+	 * Test handle_error_event logs user_tokens when only email exists (no secret).
+	 */
+	public function test_handle_error_event_logs_user_tokens_when_secret_missing() {
+		// APD has email but no secret - incomplete config for user_tokens
+		\Atomic_Persistent_Data::set( 'JETPACK_CONNECTION_OWNER_EMAIL', 'owner@example.com' );
+		\Atomic_Persistent_Data::delete( 'JETPACK_CONNECTION_OWNER_TOKEN_SECRET' );
+
+		// master_user only needs email, so should be suppressed
+		$this->provider->handle_error_event( 'empty', 'master_user', '', 'woa' );
+
+		// user_tokens needs both email AND secret, so should be logged
+		$this->provider->handle_error_event( 'empty', 'user_tokens', '', 'woa' );
+
+		// If we got here without errors, the logic worked
+		$this->assertTrue( true );
+
+		// Cleanup
+		\Atomic_Persistent_Data::delete( 'JETPACK_CONNECTION_OWNER_EMAIL' );
+	}
+
+	/**
+	 * Test handle_error_event always logs actual error events (not just empty).
+	 */
+	public function test_handle_error_event_logs_error_events() {
+		\Atomic_Persistent_Data::set( 'JETPACK_CONNECTION_OWNER_EMAIL', 'owner@example.com' );
+		\Atomic_Persistent_Data::set( 'JETPACK_CONNECTION_OWNER_TOKEN_SECRET', 'abc.xyz' );
+
+		// "error" events (exceptions, etc.) should always be logged regardless of APD state
+		$this->provider->handle_error_event( 'error', 'master_user', 'Some error', 'woa' );
+		$this->provider->handle_error_event( 'error', 'user_tokens', 'Some error', 'woa' );
+
+		// If we got here without errors, the logic worked
+		$this->assertTrue( true );
+
+		// Cleanup
+		\Atomic_Persistent_Data::delete( 'JETPACK_CONNECTION_OWNER_EMAIL' );
+		\Atomic_Persistent_Data::delete( 'JETPACK_CONNECTION_OWNER_TOKEN_SECRET' );
+	}
+
+	/**
+	 * Test handle_error_event processes events for other keys normally.
+	 */
+	public function test_handle_error_event_processes_other_keys() {
+		// Events for other keys (blog_token, id) should always be processed
+		$this->provider->handle_error_event( 'empty', 'blog_token', '', 'woa' );
+		$this->provider->handle_error_event( 'error', 'id', 'Some error', 'woa' );
+
+		// If we got here without errors, the logic worked
+		$this->assertTrue( true );
+	}
 }

--- a/projects/plugins/wpcomsh/tests/AtomicStorageProviderTest.php
+++ b/projects/plugins/wpcomsh/tests/AtomicStorageProviderTest.php
@@ -239,11 +239,11 @@ class AtomicStorageProviderTest extends WP_UnitTestCase {
 	 */
 	private function set_apd_value( $key, $value ) {
 		if ( method_exists( \Atomic_Persistent_Data::class, 'set' ) ) {
-			\Atomic_Persistent_Data::set( $key, $value );
+			\Atomic_Persistent_Data::set( $key, $value ); // @phan-suppress-current-line PhanUndeclaredStaticMethod
 			return true;
 		}
 		if ( property_exists( \Atomic_Persistent_Data::class, 'data' ) ) {
-			\Atomic_Persistent_Data::$data[ $key ] = $value;
+			\Atomic_Persistent_Data::$data[ $key ] = $value; // @phan-suppress-current-line PhanUndeclaredStaticProperty
 			return true;
 		}
 		return false;
@@ -257,11 +257,11 @@ class AtomicStorageProviderTest extends WP_UnitTestCase {
 	 */
 	private function delete_apd_value( $key ) {
 		if ( method_exists( \Atomic_Persistent_Data::class, 'delete' ) ) {
-			\Atomic_Persistent_Data::delete( $key );
+			\Atomic_Persistent_Data::delete( $key ); // @phan-suppress-current-line PhanUndeclaredStaticMethod
 			return true;
 		}
 		if ( property_exists( \Atomic_Persistent_Data::class, 'data' ) ) {
-			unset( \Atomic_Persistent_Data::$data[ $key ] );
+			unset( \Atomic_Persistent_Data::$data[ $key ] ); // @phan-suppress-current-line PhanUndeclaredStaticProperty
 			return true;
 		}
 		return false;

--- a/projects/plugins/wpcomsh/tests/AtomicStorageProviderTest.php
+++ b/projects/plugins/wpcomsh/tests/AtomicStorageProviderTest.php
@@ -231,15 +231,66 @@ class AtomicStorageProviderTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Helper to set APD value, works with both mock and environments with static $data.
+	 *
+	 * @param string $key   Key to set.
+	 * @param string $value Value to set.
+	 * @return bool True if set was possible, false otherwise.
+	 */
+	private function set_apd_value( $key, $value ) {
+		if ( method_exists( \Atomic_Persistent_Data::class, 'set' ) ) {
+			\Atomic_Persistent_Data::set( $key, $value );
+			return true;
+		}
+		if ( property_exists( \Atomic_Persistent_Data::class, 'data' ) ) {
+			\Atomic_Persistent_Data::$data[ $key ] = $value;
+			return true;
+		}
+		return false;
+	}
+
+	/**
+	 * Helper to delete APD value, works with both mock and environments with static $data.
+	 *
+	 * @param string $key Key to delete.
+	 * @return bool True if delete was possible, false otherwise.
+	 */
+	private function delete_apd_value( $key ) {
+		if ( method_exists( \Atomic_Persistent_Data::class, 'delete' ) ) {
+			\Atomic_Persistent_Data::delete( $key );
+			return true;
+		}
+		if ( property_exists( \Atomic_Persistent_Data::class, 'data' ) ) {
+			unset( \Atomic_Persistent_Data::$data[ $key ] );
+			return true;
+		}
+		return false;
+	}
+
+	/**
+	 * Check if APD manipulation is available for testing.
+	 *
+	 * @return bool True if we can manipulate APD for testing.
+	 */
+	private function can_manipulate_apd() {
+		return method_exists( \Atomic_Persistent_Data::class, 'set' )
+			|| property_exists( \Atomic_Persistent_Data::class, 'data' );
+	}
+
+	/**
 	 * Test handle_error_event suppresses empty errors when APD has values but no local user matches.
 	 *
 	 * When APD has email/secret configured but no local WordPress user matches,
 	 * this is an expected intermediate state handled by Protected_Owner_Error_Handler.
 	 */
 	public function test_handle_error_event_suppresses_when_apd_configured_but_no_user() {
+		if ( ! $this->can_manipulate_apd() ) {
+			$this->markTestSkipped( 'Test requires mock Atomic_Persistent_Data with set/delete methods.' );
+		}
+
 		// APD has values - this simulates "user changed email locally" scenario
-		\Atomic_Persistent_Data::set( 'JETPACK_CONNECTION_OWNER_EMAIL', 'owner@example.com' );
-		\Atomic_Persistent_Data::set( 'JETPACK_CONNECTION_OWNER_TOKEN_SECRET', 'abc.xyz' );
+		$this->set_apd_value( 'JETPACK_CONNECTION_OWNER_EMAIL', 'owner@example.com' );
+		$this->set_apd_value( 'JETPACK_CONNECTION_OWNER_TOKEN_SECRET', 'abc.xyz' );
 
 		// These should be suppressed - APD is configured, just no local user matches
 		$this->provider->handle_error_event( 'empty', 'master_user', '', 'woa' );
@@ -249,8 +300,8 @@ class AtomicStorageProviderTest extends WP_UnitTestCase {
 		$this->assertTrue( true );
 
 		// Cleanup
-		\Atomic_Persistent_Data::delete( 'JETPACK_CONNECTION_OWNER_EMAIL' );
-		\Atomic_Persistent_Data::delete( 'JETPACK_CONNECTION_OWNER_TOKEN_SECRET' );
+		$this->delete_apd_value( 'JETPACK_CONNECTION_OWNER_EMAIL' );
+		$this->delete_apd_value( 'JETPACK_CONNECTION_OWNER_TOKEN_SECRET' );
 	}
 
 	/**
@@ -260,9 +311,13 @@ class AtomicStorageProviderTest extends WP_UnitTestCase {
 	 * problem that should be logged.
 	 */
 	public function test_handle_error_event_logs_when_apd_truly_empty() {
+		if ( ! $this->can_manipulate_apd() ) {
+			$this->markTestSkipped( 'Test requires mock Atomic_Persistent_Data with set/delete methods.' );
+		}
+
 		// APD is empty - this is a real config problem
-		\Atomic_Persistent_Data::delete( 'JETPACK_CONNECTION_OWNER_EMAIL' );
-		\Atomic_Persistent_Data::delete( 'JETPACK_CONNECTION_OWNER_TOKEN_SECRET' );
+		$this->delete_apd_value( 'JETPACK_CONNECTION_OWNER_EMAIL' );
+		$this->delete_apd_value( 'JETPACK_CONNECTION_OWNER_TOKEN_SECRET' );
 
 		// These should proceed to logging (though WPCOMSH_Log doesn't exist in tests)
 		$this->provider->handle_error_event( 'empty', 'master_user', '', 'woa' );
@@ -276,9 +331,13 @@ class AtomicStorageProviderTest extends WP_UnitTestCase {
 	 * Test handle_error_event logs user_tokens when only email exists (no secret).
 	 */
 	public function test_handle_error_event_logs_user_tokens_when_secret_missing() {
+		if ( ! $this->can_manipulate_apd() ) {
+			$this->markTestSkipped( 'Test requires mock Atomic_Persistent_Data with set/delete methods.' );
+		}
+
 		// APD has email but no secret - incomplete config for user_tokens
-		\Atomic_Persistent_Data::set( 'JETPACK_CONNECTION_OWNER_EMAIL', 'owner@example.com' );
-		\Atomic_Persistent_Data::delete( 'JETPACK_CONNECTION_OWNER_TOKEN_SECRET' );
+		$this->set_apd_value( 'JETPACK_CONNECTION_OWNER_EMAIL', 'owner@example.com' );
+		$this->delete_apd_value( 'JETPACK_CONNECTION_OWNER_TOKEN_SECRET' );
 
 		// master_user only needs email, so should be suppressed
 		$this->provider->handle_error_event( 'empty', 'master_user', '', 'woa' );
@@ -290,15 +349,19 @@ class AtomicStorageProviderTest extends WP_UnitTestCase {
 		$this->assertTrue( true );
 
 		// Cleanup
-		\Atomic_Persistent_Data::delete( 'JETPACK_CONNECTION_OWNER_EMAIL' );
+		$this->delete_apd_value( 'JETPACK_CONNECTION_OWNER_EMAIL' );
 	}
 
 	/**
 	 * Test handle_error_event always logs actual error events (not just empty).
 	 */
 	public function test_handle_error_event_logs_error_events() {
-		\Atomic_Persistent_Data::set( 'JETPACK_CONNECTION_OWNER_EMAIL', 'owner@example.com' );
-		\Atomic_Persistent_Data::set( 'JETPACK_CONNECTION_OWNER_TOKEN_SECRET', 'abc.xyz' );
+		if ( ! $this->can_manipulate_apd() ) {
+			$this->markTestSkipped( 'Test requires mock Atomic_Persistent_Data with set/delete methods.' );
+		}
+
+		$this->set_apd_value( 'JETPACK_CONNECTION_OWNER_EMAIL', 'owner@example.com' );
+		$this->set_apd_value( 'JETPACK_CONNECTION_OWNER_TOKEN_SECRET', 'abc.xyz' );
 
 		// "error" events (exceptions, etc.) should always be logged regardless of APD state
 		$this->provider->handle_error_event( 'error', 'master_user', 'Some error', 'woa' );
@@ -308,8 +371,8 @@ class AtomicStorageProviderTest extends WP_UnitTestCase {
 		$this->assertTrue( true );
 
 		// Cleanup
-		\Atomic_Persistent_Data::delete( 'JETPACK_CONNECTION_OWNER_EMAIL' );
-		\Atomic_Persistent_Data::delete( 'JETPACK_CONNECTION_OWNER_TOKEN_SECRET' );
+		$this->delete_apd_value( 'JETPACK_CONNECTION_OWNER_EMAIL' );
+		$this->delete_apd_value( 'JETPACK_CONNECTION_OWNER_TOKEN_SECRET' );
 	}
 
 	/**


### PR DESCRIPTION
When a user changes their local email address after the connection was created, the email in APD will not match the one in the database, although the connection will work and the token will be valid. This will produce 'empty' type of External Storage errors and report them. 

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Verify the APD is actually empty before reporting the error and don't report if the problem is a mismatch.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Code review
