### PR TITLE
Social: Improve removing media behavior and link preview image handling

### DIFF
--- a/projects/packages/publicize/_inc/components/customize-and-preview/customization-forms/per-network.tsx
+++ b/projects/packages/publicize/_inc/components/customize-and-preview/customization-forms/per-network.tsx
@@ -1,5 +1,8 @@
 import { useDispatch } from '@wordpress/data';
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
+import useFeaturedImage from '../../../hooks/use-featured-image';
+import useMediaDetails from '../../../hooks/use-media-details';
+import { computeAttachedMediaForSource } from '../../../hooks/use-per-network-customization/utils';
 import { usePostMeta } from '../../../hooks/use-post-meta';
 import { store as socialStore } from '../../../social-store';
 import { Connection } from '../../../social-store/types';
@@ -23,10 +26,43 @@ export function PerNetworkCustomizationForm( { connection }: PerNetworkCustomiza
 		mediaSource: globalMediaSource,
 	} = usePostMeta();
 
+	// Get featured image details for forced attachment
+	const featuredImageId = useFeaturedImage();
+	const [ featuredImageDetails ] = useMediaDetails( featuredImageId );
+	const featuredImageUrl = featuredImageDetails?.mediaData?.sourceUrl;
+	const featuredImageMime = featuredImageDetails?.metaData?.mime ?? 'image/jpeg';
+
 	const message = connection.message ?? globalMessage ?? '';
-	const attachedMedia = connection.attached_media ?? globalAttachedMedia ?? [];
+
 	// Don't default to 'none' - let undefined trigger featured image fallback detection
 	const mediaSource = connection.media_source ?? globalMediaSource;
+
+	// Compute attached media with forced attachment logic
+	// Per-network mode forces attachment, so we need to populate attached_media appropriately
+	const attachedMedia = useMemo( () => {
+		// If connection has explicit attached_media, use it
+		if ( connection.attached_media && connection.attached_media.length > 0 ) {
+			return connection.attached_media;
+		}
+
+		// Otherwise, compute based on effective media source (like syncConnections does)
+		return (
+			computeAttachedMediaForSource( {
+				mediaSource,
+				globalAttachedMedia,
+				featuredImageId,
+				featuredImageUrl,
+				featuredImageMime,
+			} ) ?? []
+		);
+	}, [
+		connection.attached_media,
+		mediaSource,
+		featuredImageId,
+		featuredImageUrl,
+		featuredImageMime,
+		globalAttachedMedia,
+	] );
 
 	// Handler for message changes
 	const handleMessageChange = useCallback(
@@ -36,15 +72,46 @@ export function PerNetworkCustomizationForm( { connection }: PerNetworkCustomiza
 		[ connection.connection_id, customizeConnectionById ]
 	);
 
-	// Handler for media changes - only stores attached_media in the override
+	// Handler for media changes
+	// Per-network mode forces attachment, so when media is cleared (Remove button),
+	// we reset to featured image (if available) or nothing
 	const handleMediaChange = useCallback< SharePostFormProps[ 'onMediaChange' ] >(
 		updates => {
+			let attachedMediaToStore = updates.attached_media;
+			let mediaSourceToStore = updates.media_source;
+
+			// When clearing media (Remove button), reset to featured image or nothing
+			// Don't use SIG as fallback - SIG is an explicit selection, not a default
+			const isClearing =
+				( ! updates.attached_media || updates.attached_media.length === 0 ) &&
+				updates.media_source === undefined;
+
+			if ( isClearing ) {
+				// Reset to featured image if available, otherwise no media
+				if ( featuredImageId && featuredImageUrl ) {
+					attachedMediaToStore = [
+						{ id: featuredImageId, url: featuredImageUrl, type: featuredImageMime },
+					];
+					mediaSourceToStore = 'featured-image';
+				} else {
+					// No featured image - explicitly set 'none' to prevent fallback to global
+					attachedMediaToStore = undefined;
+					mediaSourceToStore = 'none';
+				}
+			}
+
 			customizeConnectionById( connection.connection_id, {
-				attached_media: updates.attached_media,
-				media_source: updates.media_source,
+				attached_media: attachedMediaToStore,
+				media_source: mediaSourceToStore,
 			} );
 		},
-		[ connection.connection_id, customizeConnectionById ]
+		[
+			connection.connection_id,
+			customizeConnectionById,
+			featuredImageId,
+			featuredImageUrl,
+			featuredImageMime,
+		]
 	);
 
 	return (

--- a/projects/packages/publicize/_inc/components/customize-and-preview/customization-forms/per-network.tsx
+++ b/projects/packages/publicize/_inc/components/customize-and-preview/customization-forms/per-network.tsx
@@ -25,7 +25,8 @@ export function PerNetworkCustomizationForm( { connection }: PerNetworkCustomiza
 
 	const message = connection.message ?? globalMessage ?? '';
 	const attachedMedia = connection.attached_media ?? globalAttachedMedia ?? [];
-	const mediaSource = connection.media_source ?? globalMediaSource ?? 'none';
+	// Don't default to 'none' - let undefined trigger featured image fallback detection
+	const mediaSource = connection.media_source ?? globalMediaSource;
 
 	// Handler for message changes
 	const handleMessageChange = useCallback(

--- a/projects/packages/publicize/_inc/components/media-section-v2/index.tsx
+++ b/projects/packages/publicize/_inc/components/media-section-v2/index.tsx
@@ -7,7 +7,7 @@ import { GeneralPurposeImage } from '@automattic/jetpack-ai-client';
 import { getRedirectUrl, ThemeProvider } from '@automattic/jetpack-components';
 import { useAnalytics } from '@automattic/jetpack-shared-extension-utils';
 import { MediaUpload } from '@wordpress/block-editor';
-import { BaseControl, Button, ExternalLink, Notice } from '@wordpress/components';
+import { BaseControl, Button, ExternalLink } from '@wordpress/components';
 import { useCallback, useMemo, useReducer, useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
@@ -64,8 +64,10 @@ export default function MediaSectionV2( {
 			isControlled ? imageGeneratorSettingsProp ?? { enabled: false } : storeImageGeneratorSettings,
 		[ isControlled, imageGeneratorSettingsProp, storeImageGeneratorSettings ]
 	);
+	// In controlled mode, use the prop value directly (even if undefined)
+	// to allow automatic fallback detection (e.g., featured image)
 	const mediaSource = useMemo(
-		() => ( isControlled ? mediaSourceProp ?? storeMediaSource : storeMediaSource ),
+		() => ( isControlled ? mediaSourceProp : storeMediaSource ),
 		[ isControlled, mediaSourceProp, storeMediaSource ]
 	);
 
@@ -75,9 +77,10 @@ export default function MediaSectionV2( {
 		[ isControlled, onMediaChange, updateJetpackSocialOptions ]
 	);
 
-	// Get SIG preview URL when SIG is enabled
+	// Get SIG preview URL when SIG is enabled or when attachment mode is on
+	// (so it's available when switching sources with attachment preserved)
 	const { url: sigPreviewUrl, isLoading: sigIsLoading } = useSigPreview(
-		sigEnabled || mediaSource === 'sig'
+		sigEnabled || mediaSource === 'sig' || attachedMedia?.length > 0
 	);
 
 	// Ref to store the MediaUpload open function
@@ -114,6 +117,22 @@ export default function MediaSectionV2( {
 
 	const [ mediaDetails ] = useMediaDetails( mediaId );
 
+	// Always fetch featured image details so it's available when switching sources
+	const [ featuredImageDetails ] = useMediaDetails( featuredImageId );
+
+	const featuredImageData: MediaPreviewData | null = useMemo( () => {
+		if ( ! featuredImageId || ! featuredImageDetails?.mediaData ) {
+			return null;
+		}
+		const { sourceUrl } = featuredImageDetails.mediaData;
+
+		return {
+			id: featuredImageId,
+			url: sourceUrl,
+			type: 'image',
+		};
+	}, [ featuredImageId, featuredImageDetails ] );
+
 	const previewData: MediaPreviewData | null = useMemo( () => {
 		// Use SIG preview URL when SIG is selected
 		// Always return an object (even with empty URL) so the loading spinner can show
@@ -126,6 +145,10 @@ export default function MediaSectionV2( {
 		}
 
 		if ( ! mediaId || ! mediaDetails?.mediaData ) {
+			// Fallback to featured image when no explicit media and source is undefined/null
+			if ( ! currentSource && featuredImageData ) {
+				return featuredImageData;
+			}
 			return null;
 		}
 
@@ -137,7 +160,7 @@ export default function MediaSectionV2( {
 			url: sourceUrl,
 			type: mime?.startsWith( 'video/' ) ? 'video' : 'image',
 		};
-	}, [ currentSource, mediaId, mediaDetails, sigPreviewUrl ] );
+	}, [ currentSource, mediaId, mediaDetails, sigPreviewUrl, featuredImageData ] );
 
 	// Handle media source selection from dropdown
 	const handleSourceSelect = useCallback(
@@ -147,17 +170,40 @@ export default function MediaSectionV2( {
 				source,
 			} );
 
+			// Determine attached_media based on source and current attachment state
+			let attachedMediaUpdate: Array< { id: number; url: string; type: string } > = [];
+
+			// Preserve attachment state when switching to link preview sources
+			if ( isShareAsAttachment ) {
+				if ( source === 'featured-image' && featuredImageData ) {
+					attachedMediaUpdate = [
+						{ id: featuredImageData.id, url: featuredImageData.url, type: 'image/jpeg' },
+					];
+				} else if ( source === 'sig' ) {
+					// Set placeholder even if sigPreviewUrl isn't ready yet - URL will be resolved by backend
+					attachedMediaUpdate = [ { id: 0, url: sigPreviewUrl || '', type: 'image/jpeg' } ];
+				}
+			}
+
 			// Single batch update with explicit media_source and all related fields
 			updateMediaOptions( {
 				media_source: source || 'none',
-				attached_media: [], // Reset attachment when changing source
+				attached_media: attachedMediaUpdate,
 				image_generator_settings: {
 					...imageGeneratorSettings,
 					enabled: source === 'sig',
 				},
 			} );
 		},
-		[ recordEvent, analyticsData, updateMediaOptions, imageGeneratorSettings ]
+		[
+			recordEvent,
+			analyticsData,
+			updateMediaOptions,
+			imageGeneratorSettings,
+			isShareAsAttachment,
+			featuredImageData,
+			sigPreviewUrl,
+		]
 	);
 
 	// Handle media selection from Media Library
@@ -212,11 +258,11 @@ export default function MediaSectionV2( {
 		return null;
 	}, [] );
 
-	// Handle remove - go to "no image" state
+	// Handle remove - reset to automatic detection (allows featured image fallback)
 	const handleRemove = useCallback( () => {
-		// Single batch update with explicit 'none' source
+		// Reset to undefined to allow automatic detection (e.g., featured image fallback)
 		updateMediaOptions( {
-			media_source: 'none',
+			media_source: undefined,
 			attached_media: [],
 			image_generator_settings: { ...imageGeneratorSettings, enabled: false },
 		} );
@@ -227,24 +273,47 @@ export default function MediaSectionV2( {
 		} );
 	}, [ updateMediaOptions, imageGeneratorSettings, recordEvent, analyticsData, currentSource ] );
 
+	// Determine the effective source - for featured image fallback (currentSource is null),
+	// treat it as 'featured-image' when there's preview data from featured image
+	const effectiveSource = useMemo( () => {
+		if ( currentSource ) {
+			return currentSource;
+		}
+		// If no explicit source but we have featured image data showing, treat as featured-image
+		if ( featuredImageData && previewData?.id === featuredImageData.id ) {
+			return 'featured-image';
+		}
+		return null;
+	}, [ currentSource, featuredImageData, previewData ] );
+
 	// Handle attachment toggle change
 	const handleAttachmentToggle = useCallback(
 		( checked: boolean ) => {
-			if ( currentSource === 'featured-image' && previewData ) {
-				// Featured image: toggle attachment mode
+			if ( checked ) {
+				// When turning ON, set the explicit source and attached media
+				if ( effectiveSource === 'featured-image' && previewData ) {
+					updateMediaOptions( {
+						media_source: 'featured-image',
+						attached_media: [ { id: previewData.id, url: previewData.url, type: 'image/jpeg' } ],
+					} );
+				} else if ( effectiveSource === 'sig' ) {
+					// Set placeholder even if sigPreviewUrl isn't ready yet - URL will be resolved by backend
+					updateMediaOptions( {
+						media_source: 'sig',
+						attached_media: [ { id: 0, url: sigPreviewUrl || '', type: 'image/jpeg' } ],
+						image_generator_settings: { ...imageGeneratorSettings, enabled: true },
+					} );
+				}
+			} else {
+				// When turning OFF, keep the current source but clear attachment
 				updateMediaOptions( {
-					media_source: 'featured-image',
-					attached_media: checked
-						? [ { id: previewData.id, url: previewData.url, type: 'image/jpeg' } ]
-						: [],
-				} );
-			} else if ( currentSource === 'sig' && sigPreviewUrl ) {
-				// SIG: toggle attachment mode (add SIG URL to attached_media)
-				updateMediaOptions( {
-					media_source: 'sig',
-					attached_media: checked ? [ { id: 0, url: sigPreviewUrl, type: 'image/jpeg' } ] : [],
-					// Keep SIG enabled regardless
-					image_generator_settings: { ...imageGeneratorSettings, enabled: true },
+					media_source: effectiveSource,
+					attached_media: [],
+					// Keep SIG enabled if that's the current source
+					image_generator_settings: {
+						...imageGeneratorSettings,
+						enabled: effectiveSource === 'sig',
+					},
 				} );
 			}
 
@@ -254,12 +323,12 @@ export default function MediaSectionV2( {
 					: 'jetpack_social_share_as_attachment_disabled',
 				{
 					...analyticsData,
-					source: currentSource,
+					source: effectiveSource,
 				}
 			);
 		},
 		[
-			currentSource,
+			effectiveSource,
 			previewData,
 			sigPreviewUrl,
 			updateMediaOptions,
@@ -276,7 +345,9 @@ export default function MediaSectionV2( {
 					<BaseControl.VisualLabel>
 						{ __( 'Media', 'jetpack-publicize-pkg' ) }
 					</BaseControl.VisualLabel>
-					<p className={ styles.description }>{ getMediaSourceDescription( currentSource ) }</p>
+					<p className={ styles.description }>
+						{ getMediaSourceDescription( currentSource, { featuredImageId } ) }
+					</p>
 
 					{ /* MediaUpload component - rendered once, open function stored in ref */ }
 					<MediaUpload
@@ -295,6 +366,7 @@ export default function MediaSectionV2( {
 								onMediaLibraryClick={ handleMediaLibraryClick }
 								onAiImageClick={ toggleShowAiImageModal }
 								disabled={ disabled }
+								featuredImageId={ featuredImageId }
 							>
 								{ ( { open } ) => (
 									<MediaPreview
@@ -303,6 +375,7 @@ export default function MediaSectionV2( {
 										onReplace={ open }
 										onRemove={ handleRemove }
 										disabled={ disabled }
+										showRemove={ currentSource === 'media-library' || currentSource === 'sig' }
 									/>
 								) }
 							</MediaSourceMenu>
@@ -327,20 +400,14 @@ export default function MediaSectionV2( {
 
 					{ /* Show dropdown when no media */ }
 					{ ! previewData && (
-						<>
-							<MediaSourceMenu
-								currentSource={ currentSource }
-								onSelect={ handleSourceSelect }
-								onMediaLibraryClick={ handleMediaLibraryClick }
-								onAiImageClick={ toggleShowAiImageModal }
-								disabled={ disabled }
-							/>
-							{ currentSource === 'featured-image' && ! featuredImageId && (
-								<Notice status="warning" isDismissible={ false } className={ styles.notice }>
-									{ __( 'Your post does not have a featured image.', 'jetpack-publicize-pkg' ) }
-								</Notice>
-							) }
-						</>
+						<MediaSourceMenu
+							currentSource={ currentSource }
+							onSelect={ handleSourceSelect }
+							onMediaLibraryClick={ handleMediaLibraryClick }
+							onAiImageClick={ toggleShowAiImageModal }
+							disabled={ disabled }
+							featuredImageId={ featuredImageId }
+						/>
 					) }
 					{ currentSource === 'media-library' && (
 						<ExternalLink

--- a/projects/packages/publicize/_inc/components/media-section-v2/index.tsx
+++ b/projects/packages/publicize/_inc/components/media-section-v2/index.tsx
@@ -260,12 +260,12 @@ export default function MediaSectionV2( {
 
 	// Handle remove - reset to automatic detection (allows featured image fallback)
 	const handleRemove = useCallback( () => {
-		// Reset to undefined to allow:
-		// 1. Automatic detection (e.g., featured image fallback) in global mode
-		// 2. Proper inheritance from global settings in per-network mode
+		// Reset to allow automatic detection and inheritance:
+		// - media_source: undefined allows fallback detection in global mode
+		// - attached_media: [] clears explicit attachment, triggering forced attachment logic in per-network mode
 		updateMediaOptions( {
 			media_source: undefined,
-			attached_media: undefined,
+			attached_media: [],
 			image_generator_settings: { ...imageGeneratorSettings, enabled: false },
 		} );
 

--- a/projects/packages/publicize/_inc/components/media-section-v2/index.tsx
+++ b/projects/packages/publicize/_inc/components/media-section-v2/index.tsx
@@ -390,7 +390,7 @@ export default function MediaSectionV2( {
 								</Button>
 							) }
 							<CustomMediaToggle
-								source={ currentSource }
+								source={ effectiveSource }
 								checked={ isShareAsAttachment }
 								onChange={ handleAttachmentToggle }
 								disabled={ forceAsAttachment || disabled }

--- a/projects/packages/publicize/_inc/components/media-section-v2/index.tsx
+++ b/projects/packages/publicize/_inc/components/media-section-v2/index.tsx
@@ -260,10 +260,12 @@ export default function MediaSectionV2( {
 
 	// Handle remove - reset to automatic detection (allows featured image fallback)
 	const handleRemove = useCallback( () => {
-		// Reset to undefined to allow automatic detection (e.g., featured image fallback)
+		// Reset to undefined to allow:
+		// 1. Automatic detection (e.g., featured image fallback) in global mode
+		// 2. Proper inheritance from global settings in per-network mode
 		updateMediaOptions( {
 			media_source: undefined,
-			attached_media: [],
+			attached_media: undefined,
 			image_generator_settings: { ...imageGeneratorSettings, enabled: false },
 		} );
 

--- a/projects/packages/publicize/_inc/components/media-section-v2/media-preview.tsx
+++ b/projects/packages/publicize/_inc/components/media-section-v2/media-preview.tsx
@@ -24,6 +24,7 @@ export default function MediaPreview( {
 	onReplace,
 	onRemove,
 	disabled = false,
+	showRemove = true,
 }: MediaPreviewProps ) {
 	if ( ! media && ! isLoading ) {
 		return null;
@@ -57,14 +58,16 @@ export default function MediaPreview( {
 					>
 						{ __( 'Replace', 'jetpack-publicize-pkg' ) }
 					</Button>
-					<Button
-						__next40pxDefaultSize
-						className={ styles.action }
-						onClick={ onRemove }
-						disabled={ disabled }
-					>
-						{ __( 'Remove', 'jetpack-publicize-pkg' ) }
-					</Button>
+					{ showRemove && (
+						<Button
+							__next40pxDefaultSize
+							className={ styles.action }
+							onClick={ onRemove }
+							disabled={ disabled }
+						>
+							{ __( 'Remove', 'jetpack-publicize-pkg' ) }
+						</Button>
+					) }
 				</HStack>
 			) }
 		</div>

--- a/projects/packages/publicize/_inc/components/media-section-v2/media-source-menu-item.tsx
+++ b/projects/packages/publicize/_inc/components/media-section-v2/media-source-menu-item.tsx
@@ -39,6 +39,11 @@ export interface MediaSourceMenuItemProps {
 	 * Callback when Generate with AI option is clicked
 	 */
 	onAiImageClick?: () => void;
+
+	/**
+	 * Whether the menu item is disabled
+	 */
+	disabled?: boolean;
 }
 
 /**
@@ -54,6 +59,7 @@ export default function MediaSourceMenuItem( {
 	onClose,
 	onMediaLibraryClick,
 	onAiImageClick,
+	disabled = false,
 }: MediaSourceMenuItemProps ) {
 	const handleClick = useCallback( () => {
 		if ( option.id === 'media-library' ) {
@@ -72,6 +78,7 @@ export default function MediaSourceMenuItem( {
 			icon={ option.icon }
 			isSelected={ isSelected }
 			onClick={ handleClick }
+			disabled={ disabled }
 		>
 			{ option.label }
 		</MenuItem>

--- a/projects/packages/publicize/_inc/components/media-section-v2/media-source-menu.tsx
+++ b/projects/packages/publicize/_inc/components/media-section-v2/media-source-menu.tsx
@@ -23,6 +23,7 @@ export default function MediaSourceMenu( {
 	onMediaLibraryClick,
 	onAiImageClick,
 	disabled = false,
+	featuredImageId,
 	children,
 }: MediaSourceMenuProps ) {
 	// Get options from function to ensure translations are loaded
@@ -75,6 +76,10 @@ export default function MediaSourceMenu( {
 							isSelected={ currentSource === option.id }
 							onSelect={ onSelect }
 							onClose={ onClose }
+							disabled={
+								currentSource === option.id ||
+								( option.id === 'featured-image' && ! featuredImageId )
+							}
 						/>
 					) ) }
 				</MenuGroup>
@@ -103,6 +108,7 @@ export default function MediaSourceMenu( {
 			linkPreviewOptions,
 			attachmentOptions,
 			currentSource,
+			featuredImageId,
 			onSelect,
 			onMediaLibraryClick,
 			onAiImageClick,

--- a/projects/packages/publicize/_inc/components/media-section-v2/test/index.test.tsx
+++ b/projects/packages/publicize/_inc/components/media-section-v2/test/index.test.tsx
@@ -305,6 +305,25 @@ describe( 'MediaSectionV2', () => {
 	} );
 
 	describe( 'Remove media', () => {
+		beforeEach( () => {
+			// Set up explicit media selection to show Remove button
+			( usePostMeta as jest.Mock ).mockReturnValue( {
+				attachedMedia: [ { id: 789, url: 'https://example.com/attached.jpg', type: 'image/jpeg' } ],
+				imageGeneratorSettings: { enabled: false },
+				mediaSource: 'media-library',
+				updateJetpackSocialOptions: mockUpdateJetpackSocialOptions,
+			} );
+		} );
+
+		afterEach( () => {
+			( usePostMeta as jest.Mock ).mockReturnValue( {
+				attachedMedia: [],
+				imageGeneratorSettings: { enabled: false },
+				mediaSource: undefined,
+				updateJetpackSocialOptions: mockUpdateJetpackSocialOptions,
+			} );
+		} );
+
 		it( 'should clear media and record event when Remove is clicked', async () => {
 			const user = userEvent.setup();
 
@@ -313,18 +332,54 @@ describe( 'MediaSectionV2', () => {
 			await user.click( screen.getByRole( 'button', { name: 'Remove' } ) );
 
 			expect( mockUpdateJetpackSocialOptions ).toHaveBeenCalledWith( {
-				media_source: 'none',
+				media_source: undefined,
 				attached_media: [],
 				image_generator_settings: { enabled: false },
 			} );
 			expect( mockRecordEvent ).toHaveBeenCalledWith( 'jetpack_social_media_removed', {
 				test: 'data',
-				source: 'featured-image',
+				source: 'media-library',
 			} );
+		} );
+
+		it( 'should not show Remove button for featured image fallback', () => {
+			// Reset to featured image fallback state
+			( usePostMeta as jest.Mock ).mockReturnValue( {
+				attachedMedia: [],
+				imageGeneratorSettings: { enabled: false },
+				mediaSource: undefined,
+				updateJetpackSocialOptions: mockUpdateJetpackSocialOptions,
+			} );
+
+			render( <MediaSectionV2 /> );
+
+			// Featured image preview should be shown
+			expect( screen.getByRole( 'img' ) ).toBeInTheDocument();
+			// But Remove button should not be shown
+			expect( screen.queryByRole( 'button', { name: 'Remove' } ) ).not.toBeInTheDocument();
 		} );
 	} );
 
 	describe( 'Disabled state', () => {
+		beforeEach( () => {
+			// Set up explicit media selection to show Remove button
+			( usePostMeta as jest.Mock ).mockReturnValue( {
+				attachedMedia: [ { id: 789, url: 'https://example.com/attached.jpg', type: 'image/jpeg' } ],
+				imageGeneratorSettings: { enabled: false },
+				mediaSource: 'media-library',
+				updateJetpackSocialOptions: mockUpdateJetpackSocialOptions,
+			} );
+		} );
+
+		afterEach( () => {
+			( usePostMeta as jest.Mock ).mockReturnValue( {
+				attachedMedia: [],
+				imageGeneratorSettings: { enabled: false },
+				mediaSource: undefined,
+				updateJetpackSocialOptions: mockUpdateJetpackSocialOptions,
+			} );
+		} );
+
 		it( 'should disable buttons when disabled prop is true', () => {
 			render( <MediaSectionV2 disabled={ true } /> );
 

--- a/projects/packages/publicize/_inc/components/media-section-v2/test/media-source-menu.test.tsx
+++ b/projects/packages/publicize/_inc/components/media-section-v2/test/media-source-menu.test.tsx
@@ -87,6 +87,7 @@ describe( 'MediaSourceMenu', () => {
 				currentSource={ null }
 				onSelect={ mockOnSelect }
 				onMediaLibraryClick={ mockOnMediaLibraryClick }
+				featuredImageId={ 123 }
 			/>
 		);
 
@@ -163,7 +164,7 @@ describe( 'MediaSourceMenu', () => {
 		expect( screen.getByText( 'For link preview' ) ).toBeInTheDocument();
 	} );
 
-	it( 'should render menu with current source item', async () => {
+	it( 'should disable the current source item', async () => {
 		const user = userEvent.setup();
 
 		render(
@@ -171,17 +172,19 @@ describe( 'MediaSourceMenu', () => {
 				currentSource="featured-image"
 				onSelect={ mockOnSelect }
 				onMediaLibraryClick={ mockOnMediaLibraryClick }
+				featuredImageId={ 123 }
 			/>
 		);
 
 		await user.click( screen.getByRole( 'button', { name: 'Select' } ) );
 
-		// Verify the menu renders with all options including the current source
+		// Verify the menu renders with the current source item disabled
 		const featuredImageItem = screen.getByRole( 'menuitem', { name: 'Use featured image' } );
 		expect( featuredImageItem ).toBeInTheDocument();
+		expect( featuredImageItem ).toHaveAttribute( 'aria-disabled', 'true' );
 
-		// Verify clicking the current source still triggers onSelect
+		// Verify clicking the disabled item does not trigger onSelect
 		await user.click( featuredImageItem );
-		expect( mockOnSelect ).toHaveBeenCalledWith( 'featured-image' );
+		expect( mockOnSelect ).not.toHaveBeenCalled();
 	} );
 } );

--- a/projects/packages/publicize/_inc/components/media-section-v2/types.ts
+++ b/projects/packages/publicize/_inc/components/media-section-v2/types.ts
@@ -7,7 +7,7 @@ import type { AttachedMedia, JetpackSocialOptions, SIGSettings } from '../../uti
 /**
  * Media source types
  */
-export type MediaSourceType = 'featured-image' | 'media-library' | 'sig' | null;
+export type MediaSourceType = 'featured-image' | 'media-library' | 'upload-video' | 'sig' | null;
 
 /**
  * Menu option IDs - includes all menu items including 'ai-image' which is handled specially

--- a/projects/packages/publicize/_inc/components/media-section-v2/types.ts
+++ b/projects/packages/publicize/_inc/components/media-section-v2/types.ts
@@ -130,6 +130,11 @@ export interface MediaSourceMenuProps {
 	disabled?: boolean;
 
 	/**
+	 * Featured image ID - used to disable "Use featured image" option when not available
+	 */
+	featuredImageId?: number;
+
+	/**
 	 * Optional children render function that receives open function
 	 */
 	children?: ( { open }: { open: () => void } ) => React.ReactNode;
@@ -163,4 +168,10 @@ export interface MediaPreviewProps {
 	 * Whether the actions are disabled
 	 */
 	disabled?: boolean;
+
+	/**
+	 * Whether to show the remove button. Defaults to true.
+	 * Set to false for auto-detected media like featured image fallback.
+	 */
+	showRemove?: boolean;
 }

--- a/projects/packages/publicize/_inc/components/media-section-v2/utils/media-source-options.ts
+++ b/projects/packages/publicize/_inc/components/media-section-v2/utils/media-source-options.ts
@@ -58,19 +58,35 @@ export function getMediaSourceOptions(): MediaSourceOption[] {
 	];
 }
 
+interface MediaSourceContext {
+	featuredImageId?: number;
+}
+
 /**
  * Get the description for a media source
  *
- * @param {MediaSourceType} sourceType - Media source type
+ * @param {MediaSourceType}    sourceType - Media source type
+ * @param {MediaSourceContext} context    - Optional context with additional info
  * @return {string} Description for the media source
  */
-export function getMediaSourceDescription( sourceType: MediaSourceType ): string {
+export function getMediaSourceDescription(
+	sourceType: MediaSourceType,
+	context?: MediaSourceContext
+): string {
+	const noImageMessage = __( "Your post won't show an image.", 'jetpack-publicize-pkg' );
+
 	if ( ! sourceType ) {
-		return __( "Your post won't show an image.", 'jetpack-publicize-pkg' );
+		return noImageMessage;
 	}
+
+	// If featured image is selected but doesn't exist, show "no image" message
+	if ( sourceType === 'featured-image' && context && ! context.featuredImageId ) {
+		return noImageMessage;
+	}
+
 	const options = getMediaSourceOptions();
 	const option = options.find( opt => opt.id === sourceType );
-	return option?.description || __( "Your post won't show an image.", 'jetpack-publicize-pkg' );
+	return option?.description || noImageMessage;
 }
 
 /**

--- a/projects/packages/publicize/_inc/hooks/use-connection-preview-data/index.ts
+++ b/projects/packages/publicize/_inc/hooks/use-connection-preview-data/index.ts
@@ -6,6 +6,7 @@ import { Connection } from '../../social-store/types';
 import { features } from '../../utils';
 import useMediaDetails from '../use-media-details';
 import { usePerNetworkCustomization } from '../use-per-network-customization';
+import { usePostMeta } from '../use-post-meta';
 import useSigPreview from '../use-sig-preview';
 import useSocialMediaMessage from '../use-social-media-message';
 import { useSocialPreviewPostData } from '../use-social-preview-post-data';
@@ -19,6 +20,7 @@ import { PostData } from '../use-social-preview-post-data/types';
  */
 export function useConnectionPreviewData( connection: Connection ) {
 	const { isEnabled: usingPerNetworkCustomization } = usePerNetworkCustomization();
+	const { mediaSource: globalMediaSource } = usePostMeta();
 
 	const postData = useSocialPreviewPostData();
 	const { message: globalMessage } = useSocialMediaMessage();
@@ -27,17 +29,28 @@ export function useConnectionPreviewData( connection: Connection ) {
 	);
 	const [ featuredImageDetails ] = useMediaDetails( featuredImageId );
 
-	// Generate SIG preview only if site has the feature and connection is set to use SIG.
+	// Generate SIG preview if site has the feature and either:
+	// - Connection is set to use SIG (per-network customization)
+	// - Global media source is SIG (same for all mode)
 	const generateSigPreview =
-		siteHasFeature( features.IMAGE_GENERATOR ) && connection.media_source === 'sig';
+		siteHasFeature( features.IMAGE_GENERATOR ) &&
+		( connection.media_source === 'sig' || globalMediaSource === 'sig' );
 
 	const sig = useSigPreview( generateSigPreview );
 
 	return useMemo( () => {
 		if ( ! siteHasFeature( features.ENHANCED_PUBLISHING ) || ! usingPerNetworkCustomization ) {
+			// In global mode, resolve SIG URL dynamically when attachment mode is on
+			// so preview updates when template is edited
+			let media = postData.media;
+			if ( globalMediaSource === 'sig' && sig.url && postData.media.length > 0 ) {
+				media = [ { url: sig.url, type: 'image/png' } ];
+			}
+
 			return {
 				...postData,
 				message: globalMessage.trim(),
+				media,
 			};
 		}
 
@@ -78,6 +91,7 @@ export function useConnectionPreviewData( connection: Connection ) {
 	}, [
 		connection,
 		featuredImageDetails,
+		globalMediaSource,
 		globalMessage,
 		postData,
 		sig.url,

--- a/projects/packages/publicize/_inc/hooks/use-connection-preview-data/test/index.test.ts
+++ b/projects/packages/publicize/_inc/hooks/use-connection-preview-data/test/index.test.ts
@@ -47,11 +47,16 @@ jest.mock( '../../use-sig-preview', () => ( {
 	default: jest.fn(),
 } ) );
 
+jest.mock( '../../use-post-meta', () => ( {
+	usePostMeta: jest.fn(),
+} ) );
+
 import { renderHook } from '@testing-library/react';
 import { useSelect } from '@wordpress/data';
 import { useConnectionPreviewData } from '../';
 import useMediaDetails from '../../use-media-details';
 import { usePerNetworkCustomization } from '../../use-per-network-customization';
+import { usePostMeta } from '../../use-post-meta';
 import useSigPreview from '../../use-sig-preview';
 import useSocialMediaMessage from '../../use-social-media-message';
 import { useSocialPreviewPostData } from '../../use-social-preview-post-data';
@@ -71,6 +76,7 @@ const mockUseSocialPreviewPostData = useSocialPreviewPostData as jest.MockedFunc
 >;
 const mockUseMediaDetails = useMediaDetails as jest.MockedFunction< typeof useMediaDetails >;
 const mockUseSigPreview = useSigPreview as jest.MockedFunction< typeof useSigPreview >;
+const mockUsePostMeta = usePostMeta as jest.MockedFunction< typeof usePostMeta >;
 
 const createMockConnection = ( overrides: Partial< Connection > = {} ): Connection => ( {
 	connection_id: '123',
@@ -113,6 +119,9 @@ describe( 'useConnectionPreviewData', () => {
 		mockUseSocialPreviewPostData.mockReturnValue( defaultPostData );
 		mockUseMediaDetails.mockReturnValue( [ null ] );
 		mockUseSigPreview.mockReturnValue( { url: null, isLoading: false } );
+		mockUsePostMeta.mockReturnValue( {
+			mediaSource: undefined,
+		} as ReturnType< typeof usePostMeta > );
 	} );
 
 	afterAll( () => {

--- a/projects/packages/publicize/_inc/hooks/use-image-generator-config/index.js
+++ b/projects/packages/publicize/_inc/hooks/use-image-generator-config/index.js
@@ -1,6 +1,6 @@
 import { useSelect } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
-import { useCallback } from '@wordpress/element';
+import { useCallback, useRef } from '@wordpress/element';
 import { usePostMeta } from '../use-post-meta';
 
 const getCurrentSettings = ( sigSettings, isPostPublished ) => ( {
@@ -44,6 +44,10 @@ export default function useImageGeneratorConfig() {
 		isPostPublished: select( editorStore ).isCurrentPostPublished(),
 	} ) );
 
+	// Ref to always have latest settings, avoiding stale closure issues in async callbacks
+	const imageGeneratorSettingsRef = useRef( imageGeneratorSettings );
+	imageGeneratorSettingsRef.current = imageGeneratorSettings;
+
 	const updateProperty = useCallback(
 		( key, value ) => {
 			const settings = { ...imageGeneratorSettings, [ key ]: value };
@@ -60,10 +64,24 @@ export default function useImageGeneratorConfig() {
 		[ imageGeneratorSettings, updateJetpackSocialOptions ]
 	);
 
+	// setToken uses a ref to get the LATEST settings at execution time,
+	// preventing race conditions where async SIG fetch could overwrite
+	// user's changes (like enabled: false) with stale closure values.
+	const setToken = useCallback(
+		value => {
+			const currentSettings = imageGeneratorSettingsRef.current;
+			updateJetpackSocialOptions( 'image_generator_settings', {
+				...currentSettings,
+				token: value,
+			} );
+		},
+		[ updateJetpackSocialOptions ]
+	);
+
 	return {
 		...getCurrentSettings( jetpackSocialOptions.image_generator_settings, isPostPublished ),
 		setIsEnabled: value => updateProperty( 'enabled', value ),
-		setToken: value => updateProperty( 'token', value ),
+		setToken,
 		updateSettings,
 	};
 }

--- a/projects/packages/publicize/_inc/hooks/use-per-network-customization/index.ts
+++ b/projects/packages/publicize/_inc/hooks/use-per-network-customization/index.ts
@@ -2,6 +2,9 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
 import { useCallback, useMemo } from '@wordpress/element';
 import { store as socialStore } from '../../social-store';
+import { AttachedMedia } from '../../utils';
+import useFeaturedImage from '../use-featured-image';
+import useMediaDetails from '../use-media-details';
 import { usePostMeta } from '../use-post-meta';
 
 const TOGGLE_KEY = '_wpas_customize_per_network';
@@ -18,6 +21,12 @@ export function usePerNetworkCustomization() {
 	const { customizeConnectionById } = useDispatch( socialStore );
 	const connections = useSelect( select => select( socialStore ).getConnections(), [] );
 
+	// Get featured image details for syncing to connections
+	const featuredImageId = useFeaturedImage();
+	const [ featuredImageDetails ] = useMediaDetails( featuredImageId );
+	const featuredImageUrl = featuredImageDetails?.mediaData?.sourceUrl;
+	const featuredImageMime = featuredImageDetails?.metaData?.mime ?? 'image/jpeg';
+
 	const isEnabled = useSelect( select => {
 		const meta = select( editorStore ).getEditedPostAttribute( 'meta' );
 
@@ -26,23 +35,54 @@ export function usePerNetworkCustomization() {
 
 	const syncConnections = useCallback( () => {
 		// Copy global settings to each connection.
+		// Per-network mode forces attachment, so we need to populate attached_media for all sources.
 		connections.forEach( connection => {
 			// Only copy if no existing customization.
 			if ( connection.message === undefined ) {
+				// Determine the effective media source (detect featured image fallback if undefined)
+				let effectiveSource = postMeta.mediaSource;
+				if ( effectiveSource === undefined && featuredImageId ) {
+					effectiveSource = 'featured-image';
+				}
+
+				// Determine attached_media based on source
+				// Per-network mode forces attachment, so we need to populate for all sources
+				let attachedMedia: Array< AttachedMedia > | undefined;
+				switch ( effectiveSource ) {
+					case 'media-library':
+					case 'upload-video':
+						attachedMedia = postMeta.attachedMedia;
+						break;
+					case 'featured-image':
+						if ( featuredImageId && featuredImageUrl ) {
+							attachedMedia = [
+								{ id: featuredImageId, url: featuredImageUrl, type: featuredImageMime },
+							];
+						}
+						break;
+					case 'sig':
+						// For SIG, use the global attached media (contains SIG URL)
+						attachedMedia = postMeta.attachedMedia;
+						break;
+					default:
+						attachedMedia = undefined;
+				}
+
 				customizeConnectionById( connection.connection_id, {
 					message: postMeta.shareMessage || '',
-					// We want to copy the attached media only if the media source is from media library or upload video.
-					// For other media sources (like featured image, sig), we don't copy the attached media
-					// Because those are resolved from the source directly.
-					attached_media:
-						postMeta.mediaSource === 'media-library' || postMeta.mediaSource === 'upload-video'
-							? postMeta.attachedMedia
-							: undefined,
-					media_source: postMeta.mediaSource,
+					attached_media: attachedMedia,
+					media_source: effectiveSource,
 				} );
 			}
 		} );
-	}, [ connections, customizeConnectionById, postMeta ] );
+	}, [
+		connections,
+		customizeConnectionById,
+		postMeta,
+		featuredImageId,
+		featuredImageUrl,
+		featuredImageMime,
+	] );
 
 	const toggle = useCallback( () => {
 		const isNowEnabled = ! isEnabled;

--- a/projects/packages/publicize/_inc/hooks/use-per-network-customization/index.ts
+++ b/projects/packages/publicize/_inc/hooks/use-per-network-customization/index.ts
@@ -2,10 +2,10 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
 import { useCallback, useMemo } from '@wordpress/element';
 import { store as socialStore } from '../../social-store';
-import { AttachedMedia } from '../../utils';
 import useFeaturedImage from '../use-featured-image';
 import useMediaDetails from '../use-media-details';
 import { usePostMeta } from '../use-post-meta';
+import { computeAttachedMediaForSource, getEffectiveMediaSource } from './utils';
 
 const TOGGLE_KEY = '_wpas_customize_per_network';
 
@@ -39,34 +39,14 @@ export function usePerNetworkCustomization() {
 		connections.forEach( connection => {
 			// Only copy if no existing customization.
 			if ( connection.message === undefined ) {
-				// Determine the effective media source (detect featured image fallback if undefined)
-				let effectiveSource = postMeta.mediaSource;
-				if ( effectiveSource === undefined && featuredImageId ) {
-					effectiveSource = 'featured-image';
-				}
-
-				// Determine attached_media based on source
-				// Per-network mode forces attachment, so we need to populate for all sources
-				let attachedMedia: Array< AttachedMedia > | undefined;
-				switch ( effectiveSource ) {
-					case 'media-library':
-					case 'upload-video':
-						attachedMedia = postMeta.attachedMedia;
-						break;
-					case 'featured-image':
-						if ( featuredImageId && featuredImageUrl ) {
-							attachedMedia = [
-								{ id: featuredImageId, url: featuredImageUrl, type: featuredImageMime },
-							];
-						}
-						break;
-					case 'sig':
-						// For SIG, use the global attached media (contains SIG URL)
-						attachedMedia = postMeta.attachedMedia;
-						break;
-					default:
-						attachedMedia = undefined;
-				}
+				const effectiveSource = getEffectiveMediaSource( postMeta.mediaSource, featuredImageId );
+				const attachedMedia = computeAttachedMediaForSource( {
+					mediaSource: postMeta.mediaSource,
+					globalAttachedMedia: postMeta.attachedMedia,
+					featuredImageId,
+					featuredImageUrl,
+					featuredImageMime,
+				} );
 
 				customizeConnectionById( connection.connection_id, {
 					message: postMeta.shareMessage || '',

--- a/projects/packages/publicize/_inc/hooks/use-per-network-customization/test/index.test.ts
+++ b/projects/packages/publicize/_inc/hooks/use-per-network-customization/test/index.test.ts
@@ -15,6 +15,22 @@ jest.mock( '@wordpress/data', () => {
 	} );
 } );
 
+// Mock useFeaturedImage to avoid nested useSelect calls
+jest.mock( '../../use-featured-image', () => jest.fn( () => null ) );
+
+// Mock useMediaDetails to avoid nested useSelect calls
+jest.mock( '../../use-media-details', () => jest.fn( () => [ null ] ) );
+
+// Mock usePostMeta to avoid nested hook calls
+jest.mock( '../../use-post-meta', () => ( {
+	usePostMeta: jest.fn( () => ( {
+		attachedMedia: [],
+		imageGeneratorSettings: { enabled: false },
+		mediaSource: undefined,
+		shareMessage: '',
+	} ) ),
+} ) );
+
 const mockUseDispatch = useDispatch as jest.MockedFunction< typeof useDispatch >;
 const mockUseSelect = useSelect as jest.MockedFunction< typeof useSelect >;
 

--- a/projects/packages/publicize/_inc/hooks/use-per-network-customization/utils.ts
+++ b/projects/packages/publicize/_inc/hooks/use-per-network-customization/utils.ts
@@ -1,0 +1,64 @@
+import { AttachedMedia, MediaSourceValue } from '../../utils';
+
+interface ComputeAttachedMediaParams {
+	mediaSource: MediaSourceValue | undefined;
+	globalAttachedMedia: Array< AttachedMedia > | undefined;
+	featuredImageId: number | undefined;
+	featuredImageUrl: string | undefined;
+	featuredImageMime: string;
+}
+
+/**
+ * Compute attached media for per-network mode based on media source.
+ * Per-network mode forces attachment, so we need to populate attached_media
+ * appropriately based on the effective source.
+ *
+ * @param {ComputeAttachedMediaParams} params - Parameters for computing attached media
+ * @return {Array<AttachedMedia> | undefined} The computed attached media
+ */
+export function computeAttachedMediaForSource( {
+	mediaSource,
+	globalAttachedMedia,
+	featuredImageId,
+	featuredImageUrl,
+	featuredImageMime,
+}: ComputeAttachedMediaParams ): Array< AttachedMedia > | undefined {
+	// Determine effective source (detect featured image fallback if undefined)
+	let effectiveSource: MediaSourceValue | undefined = mediaSource;
+	if ( effectiveSource === undefined && featuredImageId ) {
+		effectiveSource = 'featured-image';
+	}
+
+	switch ( effectiveSource ) {
+		case 'media-library':
+		case 'upload-video':
+			return globalAttachedMedia;
+		case 'featured-image':
+			if ( featuredImageId && featuredImageUrl ) {
+				return [ { id: featuredImageId, url: featuredImageUrl, type: featuredImageMime } ];
+			}
+			return undefined;
+		case 'sig':
+			// For SIG, use global attached media (contains SIG URL)
+			return globalAttachedMedia;
+		default:
+			return undefined;
+	}
+}
+
+/**
+ * Get the effective media source, detecting featured image fallback if needed.
+ *
+ * @param {MediaSourceValue | undefined} mediaSource     - The explicit media source
+ * @param {number | undefined}           featuredImageId - The featured image ID
+ * @return {MediaSourceValue | undefined} The effective media source
+ */
+export function getEffectiveMediaSource(
+	mediaSource: MediaSourceValue | undefined,
+	featuredImageId: number | undefined
+): MediaSourceValue | undefined {
+	if ( mediaSource === undefined && featuredImageId ) {
+		return 'featured-image';
+	}
+	return mediaSource;
+}

--- a/projects/packages/publicize/_inc/hooks/use-post-meta/index.js
+++ b/projects/packages/publicize/_inc/hooks/use-post-meta/index.js
@@ -1,6 +1,6 @@
 import { useDispatch, useSelect } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
-import { useCallback, useMemo } from '@wordpress/element';
+import { useCallback, useMemo, useRef } from '@wordpress/element';
 import { useShareMessageMaxLength } from '../../utils';
 
 /**
@@ -66,18 +66,24 @@ export function usePostMeta() {
 		updateMeta( 'jetpack_publicize_feature_enabled', ! metaValues.isPublicizeEnabled );
 	}, [ metaValues.isPublicizeEnabled, updateMeta ] );
 
+	// Use a ref to always have the latest jetpackSocialOptions value
+	// This prevents stale closure issues when async operations (like SIG token fetch)
+	// call updateJetpackSocialOptions after user has made other changes
+	const jetpackSocialOptionsRef = useRef( metaValues.jetpackSocialOptions );
+	jetpackSocialOptionsRef.current = metaValues.jetpackSocialOptions;
+
 	const updateJetpackSocialOptions = useCallback(
 		( keyOrUpdates, value ) => {
 			// Support both single key-value and object of updates
 			const updates = typeof keyOrUpdates === 'string' ? { [ keyOrUpdates ]: value } : keyOrUpdates;
 
 			updateMeta( 'jetpack_social_options', {
-				...metaValues.jetpackSocialOptions,
+				...jetpackSocialOptionsRef.current,
 				...updates,
 				version: 2,
 			} );
 		},
-		[ metaValues.jetpackSocialOptions, updateMeta ]
+		[ updateMeta ]
 	);
 
 	return useMemo(

--- a/projects/packages/publicize/_inc/hooks/use-sig-preview/index.ts
+++ b/projects/packages/publicize/_inc/hooks/use-sig-preview/index.ts
@@ -95,6 +95,11 @@ export default function useSigPreview(
 	const imageTitleRef = useRef( imageTitle );
 	const generatedImageUrlRef = useRef( generatedImageUrl );
 
+	// Ref to track current enabled state, used to prevent stale closure issues
+	// when async fetch completes after user has disabled SIG
+	const enabledRef = useRef( enabled );
+	enabledRef.current = enabled;
+
 	useEffect( () => {
 		generatedImageUrlRef.current = generatedImageUrl;
 	} );
@@ -122,6 +127,13 @@ export default function useSigPreview(
 						font,
 					},
 				} );
+
+				// Check if SIG is still enabled before updating token
+				// This prevents race conditions where user disabled SIG while fetch was in progress
+				if ( ! enabledRef.current ) {
+					setIsLoading( false );
+					return;
+				}
 
 				setToken?.( sigToken );
 				onNewToken?.( sigToken );

--- a/projects/packages/publicize/_inc/social-store/actions/connection-data.ts
+++ b/projects/packages/publicize/_inc/social-store/actions/connection-data.ts
@@ -568,11 +568,11 @@ export function customizeConnectionById(
 	data: Omit< EditorConnection, 'enabled' >,
 	syncToMeta = true
 ) {
-	return function ( { dispatch } ) {
-		dispatch( customizeConnection( connectionId, data ) );
+	return async function ( { dispatch } ) {
+		await dispatch( customizeConnection( connectionId, data ) );
 
 		if ( syncToMeta ) {
-			dispatch( syncConnectionsToPostMeta() );
+			await dispatch( syncConnectionsToPostMeta() );
 		}
 	};
 }

--- a/projects/packages/publicize/changelog/update-social-improve-media-ui
+++ b/projects/packages/publicize/changelog/update-social-improve-media-ui
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Improve the media selection UI in preview modal.


### PR DESCRIPTION
Fixes SOCIAL-348

## Proposed changes:

- Show featured image as fallback preview when no explicit media selection is made
- Only show the "Remove" button for explicitly selected media (media library, SIG template), not for auto-detected fallbacks (featured image)
- Preserve "Share as attachment" toggle state when switching between link preview sources (Featured Image, Use Template)
- Fix per-network customization to correctly inherit global media settings and show featured image fallback
- Fix Remove button not working in per-network mode when global media (SIG/media library) is selected and post has no featured image
- Fix stale SIG preview when editing template in "Same for all" mode
- Disable "Use featured image" option in media source menu when post has no featured image
- Fix description text to show "Your post won't show an image" when featured image is selected but doesn't exist
- Fix race condition where async SIG fetch could overwrite user's media selection changes

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

### Prerequisites

- A site with Social paid features enabled
- A post with a featured image set
- Multiple social connections configured

### Test 1: Featured image fallback

- Create a new post with a featured image
- Open the Social preview modal ("Preview and customize")
- Verify the media section shows the featured image preview
- Verify there is NO "Remove" button in the media preview

### Test 2: Explicit media selection

- In the media section, click "Replace" and select "Choose from media library"
- Select an image from the media library
- Verify the "Remove" button now appears on the preview
- Click "Remove" and verify it falls back to the featured image (without Remove button)

### Test 3: Share as attachment toggle preservation

- With featured image showing, turn ON "Share as attachment" toggle
- Click "Replace" and select "Use template" (SIG)
- Verify the toggle remains ON
- Click "Replace" and select "Use featured image"
- Verify the toggle still remains ON

### Test 4: SIG template editing (Same for all mode)

- Stay in "Same for all" mode
- Select "Use template" as media source
- Turn ON "Share as attachment"
- Click "Edit template" and modify the template text
- Click "Done" to save
- Verify the preview updates to show the new template design

### Test 5: Per-network customization fallback

- Switch to "Customize each" mode
- Select a connection
- Verify the media section shows the featured image fallback (inherited from global settings)
- Verify changing media for one connection doesn't affect others

### Test 6: Post without featured image

- Create a new post WITHOUT a featured image
- Open the Social preview modal
- Verify the media section shows "Your post won't show an image" message
- Click "Select" and verify "Use featured image" option is disabled (greyed out)
- Select an image from the media library
- Verify the Remove button appears
- Click Remove and verify it returns to empty state (no fallback available)

### Test 7: Per-network Remove button (no featured image)

- Create a new post WITHOUT a featured image
- In the media section, select "Use template" (SIG) or "Choose from media library"
- Turn ON "Customize each" mode (per-network customization)
- Select a connection and verify the media preview shows
- Click the "Remove" button
- Verify the media is cleared and shows "Your post won't show an image"

### Test 8: Featured image removed after selection

- Create a post WITH a featured image
- Open the Social preview modal
- Select "Use template" and then switch back to "Use featured image"
- Close the modal and remove the featured image from the post
- Open the Social preview modal again
- Verify the description now says "Your post won't show an image"
- Verify "Use featured image" option is now disabled in the dropdown

- When there is no featured image for the post, the featured image option is disabled
    <img width="372" height="389" alt="image" src="https://github.com/user-attachments/assets/dd751e50-391a-4b21-93f2-261e72ec3c21" />
- Currently selected option is disabled in the dropdown
    <img width="351" height="387" alt="image" src="https://github.com/user-attachments/assets/005b61a0-b74f-4119-bec1-ddeaceb9cfa1" />
- When the post has a featured image, it will always be shown in the media preview
    <img width="353" height="336" alt="image" src="https://github.com/user-attachments/assets/e4e6b31d-fd22-4168-9aaf-2863534e26b7" />


Note: It was hard to deal with the MediaSectionV2 component as it's quite complicated and difficult to follow. For many cases, I had to use Claude Code to help me out. I think that component is not maintainable and we should try to simplify the logic and break it into smaller ones.