### PR TITLE
Forms: add @wordpress/admin-ui Page styles for external admin compatibility

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-admin-ui-styles
+++ b/projects/packages/forms/changelog/fix-forms-admin-ui-styles
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Dashboard: add base @wordpress/admin-ui Page component styles for external admin compatibility.

--- a/projects/packages/forms/routes/responses/style.scss
+++ b/projects/packages/forms/routes/responses/style.scss
@@ -1,13 +1,50 @@
 @use "@wordpress/base-styles/variables";
 
-// Fix for sticky header on mobile in wp-admin
-// The header needs to account for the wp-admin bar
-// (46px on mobile, 32px on tablet+)
+// Base styles for @wordpress/admin-ui Page component.
+// Copied from @wordpress/admin-ui/build-style/style.css because
+// sideEffects:false causes CSS imports to be tree-shaken.
+.admin-ui-page {
+	display: flex;
+	height: 100%;
+	background-color: #fff;
+	color: #2f2f2f;
+	position: relative;
+	z-index: 1;
+	flex-flow: column;
+}
+
 .admin-ui-page__header {
+	padding: 16px 24px;
+	border-bottom: 1px solid #f0f0f0;
+	background: #fff;
+	position: sticky;
+	top: 0;
+	z-index: 1;
 
 	@media (max-width: 782px) {
 		// On mobile, the admin bar is fixed, so sticky header needs to be below it
 		top: 46px;
+	}
+}
+
+.admin-ui-page__header-subtitle {
+	padding-block-end: 8px;
+	color: #757575;
+	font-family: -apple-system, system-ui, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+	font-weight: 400;
+	font-size: 13px;
+	line-height: 20px;
+	margin: 0;
+}
+
+.admin-ui-page__content {
+	flex-grow: 1;
+	overflow: auto;
+	display: flex;
+	flex-direction: column;
+
+	&.has-padding {
+		padding: 16px 24px;
 	}
 }
 


### PR DESCRIPTION
## Summary

Adds base styles for `@wordpress/admin-ui` Page component directly to the Forms wp-build routes stylesheet.

### Problem
The `@wordpress/admin-ui` package has `sideEffects: false` in its `package.json`, which causes CSS imports like `import '@wordpress/admin-ui/build-style/style.css'` to be tree-shaken by bundlers. This results in missing styles (padding, background, border) for the Page header when Forms is loaded in external admin contexts that don't include Gutenberg's `editor/style.css`.

### Solution
Copy the necessary Page component styles directly into `routes/responses/style.scss`. This ensures the styles are always bundled with the Forms wp-build output.

## Testing instructions

1. Load the Forms wp-build dashboard in an external admin context
2. Verify the page header has proper styling:
   - `padding: 16px 24px`
   - White background
   - Bottom border

## Other information

<!-- Include any links to relevant P2 posts, GitHub issues, Pivotal Tracker stories, internal docs, etc. -->

### Does this pull request change what data or activity we track or use?
No

### Testing instructions for the development team
Same as above.

### Does this pull request add a new feature or change an existing feature?
No - this is a styling fix.

---

🤖 Generated with [Claude Code](https://claude.ai/code)