### PR TITLE
Slideshow: Fix image sizing on lazy load

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-slideshow-aspectRatio-html-fallback
+++ b/projects/plugins/jetpack/changelog/fix-slideshow-aspectRatio-html-fallback
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Slideshow: fix an issue with sizing when images are lazily loaded.

--- a/projects/plugins/jetpack/extensions/blocks/slideshow/swiper-callbacks.js
+++ b/projects/plugins/jetpack/extensions/blocks/slideshow/swiper-callbacks.js
@@ -47,9 +47,34 @@ function swiperResize( swiper ) {
 	if ( ! img ) {
 		return;
 	}
+
+	let aspectRatio;
 	const hasNatural = img.naturalWidth > 0 && img.naturalHeight > 0;
-	const aspectRatio = hasNatural ? img.naturalWidth / img.naturalHeight : SIXTEEN_BY_NINE;
+
+	// If the image element has `naturalWidth` and `naturalHeight` defined, we prefer using
+	// those numbers, because they're guaranteed to be up to date and correct, since they're
+	// taken from the actual image that the browser loaded.
+	//
+	// However, in some cases these numbers will be missing, due to e.g. lazy image loading.
+	// In those situations, we first fall back to the recorded aspect ratio in the HTML, and
+	// if that's missing as well, we fall back to a hardcoded 16:9.
+	if ( hasNatural ) {
+		aspectRatio = img.naturalWidth / img.naturalHeight;
+	} else {
+		if ( img.dataset.aspectRatio ) {
+			const matches = img.dataset.aspectRatio.match( /(\d+) \/ (\d+)/ );
+			if ( matches && matches[ 1 ] && matches[ 2 ] ) {
+				aspectRatio = parseInt( matches[ 1 ], 10 ) / parseInt( matches[ 2 ], 10 );
+			}
+		}
+		aspectRatio = aspectRatio || SIXTEEN_BY_NINE;
+	}
+
+	// After we have an aspect ratio, we run a final check to make sure it's within an
+	// acceptable range of values, and clamp it if necessary.
 	const sanityAspectRatio = Math.max( Math.min( aspectRatio, SIXTEEN_BY_NINE ), 1 );
+
+	// Finally, we also clamp the height to a sane maximum.
 	const sanityHeight =
 		typeof window !== 'undefined'
 			? window.innerHeight * MAX_HEIGHT_PERCENT_OF_WINDOW_HEIGHT


### PR DESCRIPTION
This PR fixes a slideshow sizing issue when the image's `naturalHeight` / `naturalWidth` aren't present, e.g. because of lazy image loading. It builds on top of #46450, which attempted to fix the same issue, but didn't cover all cases.

Fixes JETPACK-1217

## Proposed changes:

- Change the logic to prefer calculating the aspect ratio with the following decreasing priorities:
  - If `naturalWidth` and `naturalHeight` are present, use them to calculate the aspect ratio
  - If `data-aspect-ratio` is present, parse it and calculate the aspect ratio
  - Use a hardcoded 16:9 aspect ratio

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

JETPACK-1217

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

Testing this issue can be tricky, as it involves lazy loading, which can depend on resource loading order and a number of other aspects. The best approach may be to clone one of the pages identified in JETPACK-1217.

The other approach is to create a new test page using the following guidelines:
- Start by adding at least three image blocks using attachment images (not external ones). This will ensure that whatever images follow will be marked for lazy loading.
- Add a slideshow with attachment images (not external ones). Be sure not to reuse any images from the above blocks, or they might be eagerly loaded.
- Ensure that the slideshow is at least 1000px below the fold in your test browser window, prepending more content if it's not. This will increase the chances that the browser loads the slideshow images lazily.
- Always clear everything before reloading the page, e.g. by having DevTools open, long-pressing on the reload button, and choosing "Empty cache and hard reload":
  <img width="304" height="157" alt="image" src="https://github.com/user-attachments/assets/59d23ec9-d32f-4680-aba2-92680ea38808" />
