### PR TITLE
Social: Fix modal scroll empty space on smaller screens

### DIFF
--- a/projects/js-packages/components/changelog/fix-social-preview-modal-scroll
+++ b/projects/js-packages/components/changelog/fix-social-preview-modal-scroll
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+NavigatorModal: Prevent scrolling for navigator screen for large content.

--- a/projects/js-packages/components/components/navigator-modal/styles.scss
+++ b/projects/js-packages/components/components/navigator-modal/styles.scss
@@ -28,6 +28,7 @@
 	&__screen {
 		height: 100%;
 		padding: 0;
+		overflow: hidden;
 	}
 
 	&__header {

--- a/projects/packages/publicize/_inc/components/unified-modal/index.tsx
+++ b/projects/packages/publicize/_inc/components/unified-modal/index.tsx
@@ -31,6 +31,7 @@ function ThemedUnifiedModal() {
 				className={ styles[ 'unified-modal' ] }
 				initialPath={ initialPath || '/' }
 				onClose={ onClose }
+				size="fill"
 			>
 				<NavigatorModal.Screen { ...socialPostPreviewModalScreen } />
 				<NavigatorModal.Screen { ...editTemplateModalScreen } />

--- a/projects/packages/publicize/_inc/components/unified-modal/styles.module.scss
+++ b/projects/packages/publicize/_inc/components/unified-modal/styles.module.scss
@@ -1,12 +1,12 @@
 @use "@automattic/jetpack-base-styles/gutenberg-base-styles" as gb;
 
 .unified-modal {
-	max-width: gb.$wide-content-width;
-	width: 100%;
-	height: calc(100vh - 3rem);
-	max-height: 64rem;
 
-	@include gb.break-small {
-		width: calc(100vw - 40px);
+	&:global(.components-modal__frame.is-full-screen) {
+
+		@include gb.break-medium() {
+			max-width: gb.$wide-content-width;
+			max-height: 64rem;
+		}
 	}
 }

--- a/projects/packages/publicize/_inc/components/unified-modal/styles.module.scss
+++ b/projects/packages/publicize/_inc/components/unified-modal/styles.module.scss
@@ -8,5 +8,10 @@
 			max-width: gb.$wide-content-width;
 			max-height: 64rem;
 		}
+
+		// Override default bottom margin for full screen modals
+		:global(:where(.components-modal__content)) {
+			margin-bottom: 0;
+		}
 	}
 }

--- a/projects/packages/publicize/changelog/fix-social-preview-modal-scroll
+++ b/projects/packages/publicize/changelog/fix-social-preview-modal-scroll
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Preview Modal: Fix footer scroll on smaller screens.


### PR DESCRIPTION
Fixes SOCIAL-353

## Proposed changes:

On smaller screens (like 600px width), the preview modal had a weird scrollbar and empty space in the footer when the content was long enough. This PR fixes these visual issues.

### Changes:

- **Use fullscreen modal with constraints**: Changed the modal to use `size="fill"` (fullscreen) which properly handles viewport constraints, then added max-width and max-height on medium+ screens to maintain the current appearance on larger screens
- **Prevent navigator screen scroll**: Added `overflow: hidden` to the navigator screen in the shared `NavigatorModal` component to prevent the unwanted scrollbar
- **Remove default bottom margin**: Override the default bottom margin that WordPress applies to fullscreen modals, which was causing the empty space in the footer

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

SOCIAL-353

## Does this pull request change what data or activity we track or use?

No changes to data tracking.

## Testing instructions:

- Create or edit a post with Jetpack Social connections configured
- Open the Social preview modal
- Resize your browser window to a smaller width (~600px) or use device simulation
- Select a connection with long content (e.g., a post with a large image preview)
- **Verify**:
  - No weird scrollbar appears on the modal
  - No empty space in the footer area (the Close button should be at the bottom edge)
- Test on various screen sizes to ensure the modal displays correctly

## Screenshots

<table>
    <tbody>
        <tr>
            <th>BEFORE</th>
            <th>AFTER</th>
        </tr>
        <tr>
            <td>

https://github.com/user-attachments/assets/94778843-14dc-47a4-a823-9f0a36db24f2

</td>
            <td>

https://github.com/user-attachments/assets/75c49eaf-4934-41a8-a844-a86f23f79fd7

</td>
        </tr>
    </tbody>
</table>