### PR TITLE
VideoPress: Fix compatibility with Gutenberg 22.4

### DIFF
--- a/projects/packages/videopress/changelog/vidp-212-empty-page-at-jetpack-videopress
+++ b/projects/packages/videopress/changelog/vidp-212-empty-page-at-jetpack-videopress
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix compatibility with Gutenberg 22.4 by removing invalid null timezone argument from dateI18n calls.

--- a/projects/packages/videopress/src/client/admin/components/video-row/error.tsx
+++ b/projects/packages/videopress/src/client/admin/components/video-row/error.tsx
@@ -37,7 +37,7 @@ export const VideoRowError = ( { id, className = '', title }: VideoRowProps ) =>
 
 	const { dismissErroredVideo } = useDispatch( STORE_ID );
 
-	const uploadDateFormatted = dateI18n( 'M j, Y', new Date(), null );
+	const uploadDateFormatted = dateI18n( 'M j, Y', new Date() );
 	const isEllipsisActive = textRef?.current?.offsetWidth < textRef?.current?.scrollWidth;
 
 	const showTitleLabel = ! isSmall && isEllipsisActive;

--- a/projects/packages/videopress/src/client/admin/components/video-row/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/video-row/index.tsx
@@ -138,7 +138,7 @@ export const VideoRow = ( {
 	const [ anchor, setAnchor ] = useState( null );
 
 	const durationInMinutesAndSeconds = millisecondsToMinutesAndSeconds( duration );
-	const uploadDateFormatted = dateI18n( 'M j, Y', uploadDate, null );
+	const uploadDateFormatted = dateI18n( 'M j, Y', uploadDate );
 	const isEllipsisActive = textRef?.current?.offsetWidth < textRef?.current?.scrollWidth;
 
 	const showTitleLabel = ! isSmall && isEllipsisActive;


### PR DESCRIPTION
Fixes VIDP-212

## Proposed changes:

* Fix blank screen on VideoPress admin dashboard when Gutenberg 22.4+ is active
* Remove invalid `null` timezone argument from `dateI18n()` calls in video-row components

### Other information:

Gutenberg 22.4 changed timezone handling in `@wordpress/date` to fix UTC offset `0` being treated as falsy. This broke VideoPress because it passed `null` as the third argument to `dateI18n()`, which was never a valid type (only `string | number | boolean`). The null happened to work before because the old code used truthy checks (`if (timezone && ...)`), but now `null !== ''` evaluates to true and causes the error:

```
TypeError: Cannot read properties of undefined (reading 'locale')
```

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

N/A - Bug fix for Gutenberg compatibility

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

* Install and activate Gutenberg plugin version 22.4 or later
* Go to Jetpack → VideoPress in wp-admin
* Verify the admin page loads without a blank screen
* Verify dates display correctly in the video list (both grid and list views)
* If you have videos, verify the upload date is shown correctly
* If you trigger an upload error, verify the error row also displays the date correctly