### PR TITLE
Forms: new header for response sidebar & styles refactor

### DIFF
--- a/projects/packages/forms/changelog/update-forms-wp-build-sidebar-styles
+++ b/projects/packages/forms/changelog/update-forms-wp-build-sidebar-styles
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Forms: update response sidebar meta section visually and refactor styles.

--- a/projects/packages/forms/routes/responses/response/actions.tsx
+++ b/projects/packages/forms/routes/responses/response/actions.tsx
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import apiFetch from '@wordpress/api-fetch';
-import { Button, DropdownMenu, MenuGroup, MenuItem } from '@wordpress/components';
+import { Button, DropdownMenu } from '@wordpress/components';
 import { store as coreStore } from '@wordpress/core-data';
 import { useDispatch } from '@wordpress/data';
 import { useCallback, useState } from '@wordpress/element';
@@ -204,17 +204,15 @@ export function ResponseActions( {
 				className: 'jp-forms-response-actions-dropdown',
 				size: 'compact',
 			} }
-		>
-			{ ( { onClose } ) => (
-				<MenuGroup>
-					<MenuItem onClick={ handleToggleRead } onClose={ onClose }>
-						{ response.is_unread
-							? __( 'Mark as read', 'jetpack-forms' )
-							: __( 'Mark as unread', 'jetpack-forms' ) }
-					</MenuItem>
-				</MenuGroup>
-			) }
-		</DropdownMenu>
+			controls={ [
+				{
+					onClick: handleToggleRead,
+					title: response.is_unread
+						? __( 'Mark as read', 'jetpack-forms' )
+						: __( 'Mark as unread', 'jetpack-forms' ),
+				},
+			] }
+		/>
 	);
 
 	const trashButton = (

--- a/projects/packages/forms/routes/responses/response/actions.tsx
+++ b/projects/packages/forms/routes/responses/response/actions.tsx
@@ -2,12 +2,11 @@
  * WordPress dependencies
  */
 import apiFetch from '@wordpress/api-fetch';
-import { Button, DropdownMenu } from '@wordpress/components';
+import { Button } from '@wordpress/components';
 import { store as coreStore } from '@wordpress/core-data';
 import { useDispatch } from '@wordpress/data';
 import { useCallback, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { moreVertical } from '@wordpress/icons';
 import { Stack } from '@wordpress/ui';
 import * as React from 'react';
 /**
@@ -197,22 +196,11 @@ export function ResponseActions( {
 	};
 
 	const readUnreadButtons = (
-		<DropdownMenu
-			icon={ moreVertical }
-			label={ __( 'Actions', 'jetpack-forms' ) }
-			toggleProps={ {
-				className: 'jp-forms-response-actions-dropdown',
-				size: 'compact',
-			} }
-			controls={ [
-				{
-					onClick: handleToggleRead,
-					title: response.is_unread
-						? __( 'Mark as read', 'jetpack-forms' )
-						: __( 'Mark as unread', 'jetpack-forms' ),
-				},
-			] }
-		/>
+		<Button onClick={ handleToggleRead } { ...sharedProps }>
+			{ response.is_unread
+				? __( 'Mark as read', 'jetpack-forms' )
+				: __( 'Mark as unread', 'jetpack-forms' ) }
+		</Button>
 	);
 
 	const trashButton = (
@@ -249,23 +237,23 @@ export function ResponseActions( {
 		<Stack direction="row" gap="xs" align="center" justify="start" wrap="wrap">
 			{ response.status === 'publish' && (
 				<>
+					{ readUnreadButtons }
 					{ spamButton }
 					{ trashButton }
-					{ readUnreadButtons }
 				</>
 			) }
 			{ response.status === 'trash' && (
 				<>
+					{ readUnreadButtons }
 					{ restoreButton }
 					{ deleteButton }
-					{ readUnreadButtons }
 				</>
 			) }
 			{ response.status === 'spam' && (
 				<>
+					{ readUnreadButtons }
 					{ notSpamButton }
 					{ trashButton }
-					{ readUnreadButtons }
 				</>
 			) }
 		</Stack>

--- a/projects/packages/forms/routes/responses/response/actions.tsx
+++ b/projects/packages/forms/routes/responses/response/actions.tsx
@@ -2,11 +2,12 @@
  * WordPress dependencies
  */
 import apiFetch from '@wordpress/api-fetch';
-import { Button } from '@wordpress/components';
+import { Button, DropdownMenu, MenuGroup, MenuItem } from '@wordpress/components';
 import { store as coreStore } from '@wordpress/core-data';
 import { useDispatch } from '@wordpress/data';
 import { useCallback, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { moreVertical } from '@wordpress/icons';
 import { Stack } from '@wordpress/ui';
 import * as React from 'react';
 /**
@@ -196,11 +197,24 @@ export function ResponseActions( {
 	};
 
 	const readUnreadButtons = (
-		<Button onClick={ handleToggleRead } { ...sharedProps }>
-			{ response.is_unread
-				? __( 'Mark as read', 'jetpack-forms' )
-				: __( 'Mark as unread', 'jetpack-forms' ) }
-		</Button>
+		<DropdownMenu
+			icon={ moreVertical }
+			label={ __( 'Actions', 'jetpack-forms' ) }
+			toggleProps={ {
+				className: 'jp-forms-response-actions-dropdown',
+				size: 'compact',
+			} }
+		>
+			{ ( { onClose } ) => (
+				<MenuGroup>
+					<MenuItem onClick={ handleToggleRead } onClose={ onClose }>
+						{ response.is_unread
+							? __( 'Mark as read', 'jetpack-forms' )
+							: __( 'Mark as unread', 'jetpack-forms' ) }
+					</MenuItem>
+				</MenuGroup>
+			) }
+		</DropdownMenu>
 	);
 
 	const trashButton = (
@@ -237,16 +251,16 @@ export function ResponseActions( {
 		<Stack direction="row" gap="xs" align="center" justify="start" wrap="wrap">
 			{ response.status === 'publish' && (
 				<>
-					{ readUnreadButtons }
 					{ spamButton }
 					{ trashButton }
+					{ readUnreadButtons }
 				</>
 			) }
 			{ response.status === 'trash' && (
 				<>
-					{ readUnreadButtons }
 					{ restoreButton }
 					{ deleteButton }
+					{ readUnreadButtons }
 				</>
 			) }
 			{ response.status === 'spam' && (

--- a/projects/packages/forms/routes/responses/response/actions.tsx
+++ b/projects/packages/forms/routes/responses/response/actions.tsx
@@ -234,7 +234,13 @@ export function ResponseActions( {
 	);
 
 	return (
-		<Stack direction="row" gap="xs" align="center" justify="start" wrap="wrap">
+		<Stack
+			direction="row"
+			gap="xs"
+			justify="start"
+			wrap="wrap"
+			className="jp-forms-response-header-actions"
+		>
 			{ response.status === 'publish' && (
 				<>
 					{ readUnreadButtons }

--- a/projects/packages/forms/routes/responses/response/actions.tsx
+++ b/projects/packages/forms/routes/responses/response/actions.tsx
@@ -265,9 +265,9 @@ export function ResponseActions( {
 			) }
 			{ response.status === 'spam' && (
 				<>
-					{ readUnreadButtons }
 					{ notSpamButton }
 					{ trashButton }
+					{ readUnreadButtons }
 				</>
 			) }
 		</Stack>

--- a/projects/packages/forms/routes/responses/response/actions.tsx
+++ b/projects/packages/forms/routes/responses/response/actions.tsx
@@ -7,6 +7,7 @@ import { store as coreStore } from '@wordpress/core-data';
 import { useDispatch } from '@wordpress/data';
 import { useCallback, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { Stack } from '@wordpress/ui';
 import * as React from 'react';
 /**
  * Internal dependencies
@@ -189,62 +190,72 @@ export function ResponseActions( {
 		}
 	}, [ response, editEntityRecord, onActionComplete ] );
 
-	const containerStyle = {
-		display: 'flex',
-		gap: '4px',
-		alignItems: 'center',
-		marginLeft: '-12px', // Compensate for button internal padding
+	const sharedProps = {
+		isBusy: isLoading,
+		size: 'compact' as const,
 	};
 
-	if ( response.status === 'trash' ) {
-		return (
-			<div style={ containerStyle }>
-				<Button onClick={ handleToggleRead } isBusy={ isLoading } size="compact">
-					{ response.is_unread
-						? __( 'Mark as read', 'jetpack-forms' )
-						: __( 'Mark as unread', 'jetpack-forms' ) }
-				</Button>
-				<Button onClick={ handleRestore } isBusy={ isLoading } size="compact">
-					{ __( 'Restore', 'jetpack-forms' ) }
-				</Button>
-				<Button onClick={ handleDelete } isBusy={ isLoading } size="compact">
-					{ __( 'Delete', 'jetpack-forms' ) }
-				</Button>
-			</div>
-		);
-	}
+	const readUnreadButtons = (
+		<Button onClick={ handleToggleRead } { ...sharedProps }>
+			{ response.is_unread
+				? __( 'Mark as read', 'jetpack-forms' )
+				: __( 'Mark as unread', 'jetpack-forms' ) }
+		</Button>
+	);
 
-	if ( response.status === 'spam' ) {
-		return (
-			<div style={ containerStyle }>
-				<Button onClick={ handleToggleRead } isBusy={ isLoading } size="compact">
-					{ response.is_unread
-						? __( 'Mark as read', 'jetpack-forms' )
-						: __( 'Mark as unread', 'jetpack-forms' ) }
-				</Button>
-				<Button onClick={ handleMarkAsNotSpam } isBusy={ isLoading } size="compact">
-					{ __( 'Not spam', 'jetpack-forms' ) }
-				</Button>
-				<Button onClick={ handleMoveToTrash } isBusy={ isLoading } size="compact">
-					{ __( 'Trash', 'jetpack-forms' ) }
-				</Button>
-			</div>
-		);
-	}
+	const trashButton = (
+		<Button onClick={ handleMoveToTrash } { ...sharedProps }>
+			{ __( 'Trash', 'jetpack-forms' ) }
+		</Button>
+	);
+
+	const spamButton = (
+		<Button onClick={ handleMarkAsSpam } { ...sharedProps }>
+			{ __( 'Spam', 'jetpack-forms' ) }
+		</Button>
+	);
+
+	const notSpamButton = (
+		<Button onClick={ handleMarkAsNotSpam } { ...sharedProps }>
+			{ __( 'Not spam', 'jetpack-forms' ) }
+		</Button>
+	);
+
+	const deleteButton = (
+		<Button onClick={ handleDelete } { ...sharedProps }>
+			{ __( 'Delete', 'jetpack-forms' ) }
+		</Button>
+	);
+
+	const restoreButton = (
+		<Button onClick={ handleRestore } { ...sharedProps }>
+			{ __( 'Restore', 'jetpack-forms' ) }
+		</Button>
+	);
 
 	return (
-		<div style={ containerStyle }>
-			<Button onClick={ handleToggleRead } isBusy={ isLoading } size="compact">
-				{ response.is_unread
-					? __( 'Mark as read', 'jetpack-forms' )
-					: __( 'Mark as unread', 'jetpack-forms' ) }
-			</Button>
-			<Button onClick={ handleMarkAsSpam } isBusy={ isLoading } size="compact">
-				{ __( 'Spam', 'jetpack-forms' ) }
-			</Button>
-			<Button onClick={ handleMoveToTrash } isBusy={ isLoading } size="compact">
-				{ __( 'Trash', 'jetpack-forms' ) }
-			</Button>
-		</div>
+		<Stack direction="row" gap="xs" align="center" justify="start" wrap="wrap">
+			{ response.status === 'publish' && (
+				<>
+					{ readUnreadButtons }
+					{ spamButton }
+					{ trashButton }
+				</>
+			) }
+			{ response.status === 'trash' && (
+				<>
+					{ readUnreadButtons }
+					{ restoreButton }
+					{ deleteButton }
+				</>
+			) }
+			{ response.status === 'spam' && (
+				<>
+					{ readUnreadButtons }
+					{ notSpamButton }
+					{ trashButton }
+				</>
+			) }
+		</Stack>
 	);
 }

--- a/projects/packages/forms/routes/responses/response/index.tsx
+++ b/projects/packages/forms/routes/responses/response/index.tsx
@@ -187,15 +187,11 @@ function SingleResponseView( {
 	return (
 		<>
 			<Stack
-				direction="row"
-				justify="space-between"
 				align="center"
+				className="jp-forms-response-navigation"
+				direction="row"
 				gap="xs"
-				wrap="wrap"
-				style={ {
-					padding: '8px 16px',
-					borderBottom: '1px solid #e0e0e0',
-				} }
+				justify="space-between"
 			>
 				<ResponseActions response={ response } onActionComplete={ handleActionComplete } />
 				<ResponseNavigation

--- a/projects/packages/forms/routes/responses/response/index.tsx
+++ b/projects/packages/forms/routes/responses/response/index.tsx
@@ -209,48 +209,48 @@ function SingleResponseView( {
 
 			<ResponseMeta response={ response } />
 
-			<div style={ { padding: '20px', overflowY: 'auto' } }>
+			<div className="jp-forms__inbox-response-data">
 				<ResponseFieldsIterator
 					fields={ response.fields }
 					onFilePreview={ handleFilePreview }
 					className="jp-forms__inbox-response-data"
 				/>
-
-				{ response.status === 'spam' && (
-					<div className="jp-forms__inbox__tip-container">
-						<Tip>
-							{ sprintf(
-								/* translators: %d number of days. */
-								_n(
-									'Spam responses are permanently deleted after %d day.',
-									'Spam responses are permanently deleted after %d days.',
-									15,
-									'jetpack-forms'
-								),
-								// Number from https://github.com/Automattic/jetpack/blob/bde3cf9a89ce0d02e50469df173a6253383bd276/projects/packages/forms/src/contact-form/class-contact-form-plugin.php#L132
-								15
-							) }
-						</Tip>
-					</div>
-				) }
-
-				{ response.status === 'trash' && (
-					<div className="jp-forms__inbox__tip-container">
-						<Tip>
-							{ sprintf(
-								/* translators: %d number of days. */
-								_n(
-									'Items in trash are permanently deleted after %d day.',
-									'Items in trash are permanently deleted after %d days.',
-									emptyTrashDays,
-									'jetpack-forms'
-								),
-								emptyTrashDays
-							) }
-						</Tip>
-					</div>
-				) }
 			</div>
+
+			{ response.status === 'spam' && (
+				<div className="jp-forms__inbox__tip-container">
+					<Tip>
+						{ sprintf(
+							/* translators: %d number of days. */
+							_n(
+								'Spam responses are permanently deleted after %d day.',
+								'Spam responses are permanently deleted after %d days.',
+								15,
+								'jetpack-forms'
+							),
+							// Number from https://github.com/Automattic/jetpack/blob/bde3cf9a89ce0d02e50469df173a6253383bd276/projects/packages/forms/src/contact-form/class-contact-form-plugin.php#L132
+							15
+						) }
+					</Tip>
+				</div>
+			) }
+
+			{ response.status === 'trash' && (
+				<div className="jp-forms__inbox__tip-container">
+					<Tip>
+						{ sprintf(
+							/* translators: %d number of days. */
+							_n(
+								'Items in trash are permanently deleted after %d day.',
+								'Items in trash are permanently deleted after %d days.',
+								emptyTrashDays,
+								'jetpack-forms'
+							),
+							emptyTrashDays
+						) }
+					</Tip>
+				</div>
+			) }
 
 			{ previewFile && (
 				<Modal title={ decodeEntities( previewFile.name ) } onRequestClose={ closePreviewModal }>

--- a/projects/packages/forms/routes/responses/response/index.tsx
+++ b/projects/packages/forms/routes/responses/response/index.tsx
@@ -9,6 +9,7 @@ import { useCallback, useEffect, useState } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { useParams, useSearch, useNavigate } from '@wordpress/route';
+import { Stack } from '@wordpress/ui';
 import * as React from 'react';
 /**
  * Internal dependencies
@@ -22,7 +23,7 @@ import { ResponseActions } from './actions';
 import { ResponseNavigation } from './navigation';
 import type { DispatchActions, SelectActions } from '../../../src/dashboard/inbox/stage/types.tsx';
 import type { FormResponse } from '../../../src/types/index.ts';
-import '../../../src/dashboard/components/inspector/style.scss';
+import './style.scss';
 
 /**
  * Renders a single response.
@@ -169,31 +170,31 @@ function SingleResponseView( {
 
 	if ( isLoading ) {
 		return (
-			<div style={ { display: 'flex', justifyContent: 'center', padding: '40px' } }>
+			<Stack direction="row" justify="center" style={ { padding: '40px' } }>
 				<Spinner />
-			</div>
+			</Stack>
 		);
 	}
 
 	if ( ! response ) {
 		return (
-			<div style={ { padding: '20px' } }>
+			<Stack direction="row" justify="center" style={ { padding: '40px' } }>
 				<p>{ __( 'Response not found.', 'jetpack-forms' ) }</p>
-			</div>
+			</Stack>
 		);
 	}
 
 	return (
 		<>
-			<div
+			<Stack
+				direction="row"
+				justify="space-between"
+				align="center"
+				gap="xs"
+				wrap="wrap"
 				style={ {
-					display: 'flex',
-					justifyContent: 'space-between',
-					alignItems: 'center',
 					padding: '8px 16px',
 					borderBottom: '1px solid #e0e0e0',
-					gap: '8px',
-					flexWrap: 'wrap',
 				} }
 			>
 				<ResponseActions response={ response } onActionComplete={ handleActionComplete } />
@@ -204,11 +205,11 @@ function SingleResponseView( {
 					onPrevious={ handlePrevious }
 					onClose={ onClose }
 				/>
-			</div>
+			</Stack>
+
+			<ResponseMeta response={ response } />
 
 			<div style={ { padding: '20px', overflowY: 'auto' } }>
-				<ResponseMeta response={ response } />
-
 				<ResponseFieldsIterator
 					fields={ response.fields }
 					onFilePreview={ handleFilePreview }

--- a/projects/packages/forms/routes/responses/response/index.tsx
+++ b/projects/packages/forms/routes/responses/response/index.tsx
@@ -186,13 +186,7 @@ function SingleResponseView( {
 
 	return (
 		<>
-			<Stack
-				align="center"
-				className="jp-forms-response-navigation"
-				direction="row"
-				gap="xs"
-				justify="space-between"
-			>
+			<Stack className="jp-forms-response-header" direction="row" gap="xs" justify="space-between">
 				<ResponseActions response={ response } onActionComplete={ handleActionComplete } />
 				<ResponseNavigation
 					hasNext={ hasNext }

--- a/projects/packages/forms/routes/responses/response/navigation.tsx
+++ b/projects/packages/forms/routes/responses/response/navigation.tsx
@@ -2,9 +2,9 @@
  * WordPress dependencies
  */
 import { Button } from '@wordpress/components';
-import { Stack } from '@wordpress/ui';
 import { __ } from '@wordpress/i18n';
 import { chevronUp, chevronDown, close } from '@wordpress/icons';
+import { Stack } from '@wordpress/ui';
 import * as React from 'react';
 
 /**
@@ -40,33 +40,38 @@ export function ResponseNavigation( {
 	};
 
 	return (
-		<Stack direction="row" align="center" gap="xs" style={ { flexShrink: 0 } }>
-			<Stack direction="row" align="center">
-				<Button
-					{ ...sharedProps }
-					disabled={ ! hasPrevious }
-					icon={ chevronUp }
-					label={ __( 'Previous', 'jetpack-forms' ) }
-					onClick={ onPrevious }
-				/>
-				<Button
-					{ ...sharedProps }
-					disabled={ ! hasNext }
-					icon={ chevronDown }
-					label={ __( 'Next', 'jetpack-forms' ) }
-					onClick={ onNext }
-				/>
-				<span
-					style={ {
-						display: 'inline-block',
-						width: '1px',
-						height: '20px',
-						backgroundColor: 'var(--wp-admin-theme-color-darker-10, #135e96)',
-						opacity: 0.2,
-						marginLeft: '4px',
-					} }
-				/>
-			</Stack>
+		<Stack
+			align="center"
+			direction="row"
+			gap="xs"
+			justify="end"
+			style={ { flexShrink: 0 } }
+			wrap="wrap"
+		>
+			<Button
+				{ ...sharedProps }
+				disabled={ ! hasPrevious }
+				icon={ chevronUp }
+				label={ __( 'Previous', 'jetpack-forms' ) }
+				onClick={ onPrevious }
+			/>
+			<Button
+				{ ...sharedProps }
+				disabled={ ! hasNext }
+				icon={ chevronDown }
+				label={ __( 'Next', 'jetpack-forms' ) }
+				onClick={ onNext }
+			/>
+			<span
+				style={ {
+					display: 'inline-block',
+					width: '1px',
+					height: '20px',
+					backgroundColor: 'var(--wp-admin-theme-color-darker-10, #135e96)',
+					opacity: 0.2,
+					marginLeft: '4px',
+				} }
+			/>
 			<Button
 				{ ...sharedProps }
 				iconSize={ 20 }

--- a/projects/packages/forms/routes/responses/response/navigation.tsx
+++ b/projects/packages/forms/routes/responses/response/navigation.tsx
@@ -57,12 +57,12 @@ export function ResponseNavigation( {
 			/>
 			<span
 				style={ {
-					display: 'inline-block',
-					width: '1px',
-					height: '20px',
 					backgroundColor: 'var(--wp-admin-theme-color-darker-10, #135e96)',
+					display: 'inline-block',
+					height: '20px',
+					margin: '6px 4px 6px 0',
 					opacity: 0.2,
-					marginLeft: '4px',
+					width: '1px',
 				} }
 			/>
 			<Button

--- a/projects/packages/forms/routes/responses/response/navigation.tsx
+++ b/projects/packages/forms/routes/responses/response/navigation.tsx
@@ -40,14 +40,7 @@ export function ResponseNavigation( {
 	};
 
 	return (
-		<Stack
-			align="center"
-			direction="row"
-			gap="xs"
-			justify="end"
-			style={ { flexShrink: 0 } }
-			wrap="wrap"
-		>
+		<Stack direction="row" gap="xs" justify="end" style={ { flexShrink: 0 } } wrap="wrap">
 			<Button
 				{ ...sharedProps }
 				disabled={ ! hasPrevious }

--- a/projects/packages/forms/routes/responses/response/navigation.tsx
+++ b/projects/packages/forms/routes/responses/response/navigation.tsx
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import { Button } from '@wordpress/components';
+import { Stack } from '@wordpress/ui';
 import { __ } from '@wordpress/i18n';
 import { chevronUp, chevronDown, close } from '@wordpress/icons';
 import * as React from 'react';
@@ -39,8 +40,8 @@ export function ResponseNavigation( {
 	};
 
 	return (
-		<div style={ { display: 'flex', alignItems: 'center', gap: '8px', flexShrink: 0 } }>
-			<div style={ { display: 'flex', alignItems: 'center' } }>
+		<Stack direction="row" align="center" gap="xs" style={ { flexShrink: 0 } }>
+			<Stack direction="row" align="center">
 				<Button
 					{ ...sharedProps }
 					disabled={ ! hasPrevious }
@@ -65,7 +66,7 @@ export function ResponseNavigation( {
 						marginLeft: '4px',
 					} }
 				/>
-			</div>
+			</Stack>
 			<Button
 				{ ...sharedProps }
 				iconSize={ 20 }
@@ -73,6 +74,6 @@ export function ResponseNavigation( {
 				label={ __( 'Close', 'jetpack-forms' ) }
 				onClick={ onClose }
 			/>
-		</div>
+		</Stack>
 	);
 }

--- a/projects/packages/forms/routes/responses/response/style.scss
+++ b/projects/packages/forms/routes/responses/response/style.scss
@@ -13,25 +13,18 @@ $inspector-padding: 16px;
 }
 
 .jp-forms-response-navigation {
-	display: flex;
-	align-items: center;
-	gap: 8px;
-
-	.jp-forms-response-navigation__arrows {
-		display: flex;
-		align-items: center;
-
-		// Add separator after the arrows group (before close button)
-		&::after {
-			content: "";
-			display: inline-block;
-			width: 1px;
-			height: 20px;
-			background-color: var(--wp-admin-theme-color-darker-10, #135e96);
-			opacity: 0.2;
-			margin-left: 4px;
-		}
-	}
+	padding: 8px 0;
+	border-bottom: 1px solid var(--wpds-color-stroke-surface-neutral, #e0e0e0);
+}
+// Add separator after the arrows group (before close button)
+.jp-forms-response-navigation__arrows::after {
+	content: "";
+	display: inline-block;
+	width: 1px;
+	height: 20px;
+	background-color: var(--wp-admin-theme-color-darker-10, #135e96);
+	opacity: 0.2;
+	margin-left: 4px;
 }
 
 .jp-forms__inbox-response-data {

--- a/projects/packages/forms/routes/responses/response/style.scss
+++ b/projects/packages/forms/routes/responses/response/style.scss
@@ -16,16 +16,6 @@ $inspector-padding: 16px;
 	padding: 8px 0;
 	border-bottom: 1px solid var(--wpds-color-stroke-surface-neutral, #e0e0e0);
 }
-// Add separator after the arrows group (before close button)
-.jp-forms-response-navigation__arrows::after {
-	content: "";
-	display: inline-block;
-	width: 1px;
-	height: 20px;
-	background-color: var(--wp-admin-theme-color-darker-10, #135e96);
-	opacity: 0.2;
-	margin-left: 4px;
-}
 
 .jp-forms__inbox-response-data {
 	font-size: var(--jp-forms-font-size-regular);

--- a/projects/packages/forms/routes/responses/response/style.scss
+++ b/projects/packages/forms/routes/responses/response/style.scss
@@ -7,15 +7,13 @@
 
 $inspector-padding: 16px;
 
-.jp-forms-response-actions {
-	padding: 8px $inspector-padding;
-	gap: 0;
+.jp-forms-response-header {
+	padding: 8px;
 	border-bottom: 1px solid var(--wpds-color-stroke-surface-neutral, #e0e0e0);
 }
 
-.jp-forms-response-navigation {
-	padding: 8px 0;
-	border-bottom: 1px solid var(--wpds-color-stroke-surface-neutral, #e0e0e0);
+.jp-forms-response-header-actions {
+	gap: 0 !important;
 }
 
 .jp-forms__inbox-response-data {

--- a/projects/packages/forms/routes/responses/response/style.scss
+++ b/projects/packages/forms/routes/responses/response/style.scss
@@ -9,6 +9,7 @@ $inspector-padding: 16px;
 
 .jp-forms-response-actions {
 	padding: 8px $inspector-padding;
+	gap: 0;
 	border-bottom: 1px solid var(--wpds-color-stroke-surface-neutral, #e0e0e0);
 }
 

--- a/projects/packages/forms/routes/responses/response/style.scss
+++ b/projects/packages/forms/routes/responses/response/style.scss
@@ -5,11 +5,11 @@
 @use "@wordpress/base-styles/breakpoints";
 @use "@wordpress/base-styles/variables";
 
-// Main response container
+$inspector-padding: 16px;
 
 .jp-forms-response-actions {
-	padding: 8px 16px;
-	border-bottom: 1px solid var(--jp-forms-border-color);
+	padding: 8px $inspector-padding;
+	border-bottom: 1px solid var(--wpds-color-stroke-surface-neutral, #e0e0e0);
 }
 
 .jp-forms-response-navigation {
@@ -35,10 +35,9 @@
 }
 
 .jp-forms__inbox-response-data {
-	border-top: 1px solid var(--jp-forms-border-color);
 	font-size: var(--jp-forms-font-size-regular);
 	line-height: 24px;
-	padding: 0 16px;
+	padding: 0 $inspector-padding;
 
 	// old field format renders without .jp-forms__field-preview
 	&:not(.is-collection-format) {
@@ -60,9 +59,9 @@
 }
 
 .jp-forms__inbox__tip-container {
-	border-top: 1px solid var(--jp-forms-border-color);
-	margin: 8px 0 0 0;
-	padding: 16px 0;
+	border-top: 1px solid var(--wpds-color-stroke-surface-neutral, #e0e0e0);
+	margin: auto 0 0 0;
+	padding: $inspector-padding;
 	text-wrap: pretty;
 
 	// https://wordpress.github.io/gutenberg/?path=/docs/components-tip--docs

--- a/projects/packages/forms/routes/responses/response/style.scss
+++ b/projects/packages/forms/routes/responses/response/style.scss
@@ -1,0 +1,72 @@
+/**
+ * Response View Component Styles
+ */
+
+@use "@wordpress/base-styles/breakpoints";
+@use "@wordpress/base-styles/variables";
+
+// Main response container
+
+.jp-forms-response-actions {
+	padding: 8px 16px;
+	border-bottom: 1px solid var(--jp-forms-border-color);
+}
+
+.jp-forms-response-navigation {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+
+	.jp-forms-response-navigation__arrows {
+		display: flex;
+		align-items: center;
+
+		// Add separator after the arrows group (before close button)
+		&::after {
+			content: "";
+			display: inline-block;
+			width: 1px;
+			height: 20px;
+			background-color: var(--wp-admin-theme-color-darker-10, #135e96);
+			opacity: 0.2;
+			margin-left: 4px;
+		}
+	}
+}
+
+.jp-forms__inbox-response-data {
+	border-top: 1px solid var(--jp-forms-border-color);
+	font-size: var(--jp-forms-font-size-regular);
+	line-height: 24px;
+	padding: 0 16px;
+
+	// old field format renders without .jp-forms__field-preview
+	&:not(.is-collection-format) {
+
+		display: flex;
+		flex-direction: column;
+		row-gap: 24px;
+		padding-top: 24px;
+		padding-bottom: 24px;
+
+		.jp-forms__inbox-response-data-label {
+			font-weight: 600;
+		}
+
+		.jp-forms__inbox-response-data-value {
+			white-space: pre-wrap;
+		}
+	}
+}
+
+.jp-forms__inbox__tip-container {
+	border-top: 1px solid var(--jp-forms-border-color);
+	margin: 8px 0 0 0;
+	padding: 16px 0;
+	text-wrap: pretty;
+
+	// https://wordpress.github.io/gutenberg/?path=/docs/components-tip--docs
+	.components-tip {
+		align-items: anchor-center;
+	}
+}

--- a/projects/packages/forms/src/dashboard/components/copy-clipboard-button/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/copy-clipboard-button/index.tsx
@@ -6,6 +6,7 @@ import { useCopyToClipboard } from '@wordpress/compose';
 import { useEffect, useRef, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { copySmall, check } from '@wordpress/icons';
+import './style.scss';
 
 type CopyClipboardButtonProps = {
 	text: string;
@@ -45,6 +46,7 @@ export default function CopyClipboardButton( { text }: CopyClipboardButtonProps 
 	return (
 		<Tooltip delay={ 0 } hideOnClick={ false } text={ emailCopyLabel }>
 			<Button
+				className="jp-forms__copy-clipboard-button"
 				size="small"
 				aria-label={ emailCopyLabel }
 				ref={ ref }

--- a/projects/packages/forms/src/dashboard/components/copy-clipboard-button/style.scss
+++ b/projects/packages/forms/src/dashboard/components/copy-clipboard-button/style.scss
@@ -1,0 +1,4 @@
+.jp-forms__copy-clipboard-button svg {
+	width: 20px;
+	height: 20px;
+}

--- a/projects/packages/forms/src/dashboard/components/inspector/body.tsx
+++ b/projects/packages/forms/src/dashboard/components/inspector/body.tsx
@@ -20,7 +20,7 @@ import { useMarkAsSpam } from '../../hooks/use-mark-as-spam.ts';
 import { updateMenuCounter, updateMenuCounterOptimistically } from '../../inbox/utils.js';
 import { store as dashboardStore } from '../../store/index.js';
 import FeedbackComments from '../feedback-comments/index.tsx';
-import PreviewFile from './preview-file';
+import PreviewFile from './preview-file/index';
 import ResponseFieldsIterator from './response-fields/index.tsx';
 import ResponseMeta from './response-meta';
 import type { FormResponse } from '../../../types/index.ts';

--- a/projects/packages/forms/src/dashboard/components/inspector/preview-file/style.scss
+++ b/projects/packages/forms/src/dashboard/components/inspector/preview-file/style.scss
@@ -1,4 +1,3 @@
-
 .jp-forms__inbox-file-preview-shell {
 	max-height: 70vh;
 	overflow: hidden;

--- a/projects/packages/forms/src/dashboard/components/inspector/response-fields/field-preview/style.scss
+++ b/projects/packages/forms/src/dashboard/components/inspector/response-fields/field-preview/style.scss
@@ -12,6 +12,7 @@
 
 	.jp-forms__field-preview-content {
 		min-width: 0; // Prevents flex item from overflowing
+		word-break: break-word;
 	}
 
 	.jp-forms__field-preview-label {

--- a/projects/packages/forms/src/dashboard/components/inspector/response-meta/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/inspector/response-meta/index.tsx
@@ -4,12 +4,13 @@
 import {
 	ExternalLink,
 	Tooltip,
+	__experimentalText as Text, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 	__experimentalHStack as HStack, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 	__experimentalVStack as VStack, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 } from '@wordpress/components';
 import { dateI18n, getSettings as getDateSettings } from '@wordpress/date';
 import { decodeEntities } from '@wordpress/html-entities';
-import { __, sprintf } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
@@ -44,45 +45,39 @@ const ResponseMeta = ( { response }: ResponseMetaProps ): import('react').JSX.El
 
 	const responseAuthorEmailParts = response.author_email?.split( '@' ) ?? [];
 
-	return (
-		<>
-			<div className="jp-forms__inbox-response-header">
-				<HStack alignment="topLeft" spacing="3">
-					<Gravatar
-						email={ gravatarEmail }
-						defaultImage={ defaultImage }
-						displayName={ displayName }
-						key={ gravatarEmail }
-					/>
-					<VStack spacing="0" className="jp-forms__inbox-response-header-title">
-						<h3 className="jp-forms__inbox-response-name">{ displayName }</h3>
-						{ response.author_email && displayName !== response.author_email && (
-							<p className="jp-forms__inbox-response-email">
-								<a href={ `mailto:${ response.author_email }` }>
-									{ responseAuthorEmailParts[ 0 ] }
-									<wbr />@{ responseAuthorEmailParts[ 1 ] }
-								</a>
-								<CopyClipboardButton text={ response.author_email } />
-							</p>
-						) }
-					</VStack>
-				</HStack>
-			</div>
+	const dateSettings = getDateSettings();
 
-			<div className="jp-forms__inbox-response-meta">
+	return (
+		<div className="jp-forms__inbox-response-meta">
+			<HStack alignment="topLeft" spacing="3" wrap={ false }>
+				<Gravatar
+					email={ gravatarEmail }
+					defaultImage={ defaultImage }
+					displayName={ displayName }
+					key={ gravatarEmail }
+				/>
+				<VStack spacing="0" className="jp-forms__inbox-response-meta-from">
+					<Text weight="600" className="jp-forms__inbox-response-meta-from-name">
+						{ displayName }
+					</Text>
+					{ response.author_email && displayName !== response.author_email && (
+						<HStack alignment="center" className="jp-forms__inbox-response-meta-from-email">
+							<Text as="a" variant="muted" href={ `mailto:${ response.author_email }` }>
+								{ responseAuthorEmailParts[ 0 ] }
+								<wbr />@{ responseAuthorEmailParts[ 1 ] }
+							</Text>
+							<CopyClipboardButton text={ response.author_email } />
+						</HStack>
+					) }
+				</VStack>
+				<Text variant="muted" className="jp-forms__inbox-response-meta-date">
+					{ dateI18n( dateSettings.formats.datetime, response.date ) }
+				</Text>
+			</HStack>
+
+			<div className="jp-forms__inbox-response-meta-data">
 				<table>
 					<tbody>
-						<tr>
-							<th>{ __( 'Date:', 'jetpack-forms' ) }</th>
-							<td>
-								{ sprintf(
-									/* Translators: %1$s is the date, %2$s is the time. */
-									__( '%1$s at %2$s', 'jetpack-forms' ),
-									dateI18n( getDateSettings().formats.date, response.date ),
-									dateI18n( getDateSettings().formats.time, response.date )
-								) }
-							</td>
-						</tr>
 						<tr>
 							<th>{ __( 'Source:', 'jetpack-forms' ) }</th>
 							<td>
@@ -117,7 +112,7 @@ const ResponseMeta = ( { response }: ResponseMetaProps ): import('react').JSX.El
 					</tbody>
 				</table>
 			</div>
-		</>
+		</div>
 	);
 };
 

--- a/projects/packages/forms/src/dashboard/components/inspector/response-meta/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/inspector/response-meta/index.tsx
@@ -57,12 +57,24 @@ const ResponseMeta = ( { response }: ResponseMetaProps ): import('react').JSX.El
 					key={ gravatarEmail }
 				/>
 				<VStack spacing="0" className="jp-forms__inbox-response-meta-from">
-					<Text weight="600" className="jp-forms__inbox-response-meta-from-name">
+					<Text
+						className="jp-forms__inbox-response-meta-from-name"
+						lineHeight="20px"
+						size="15px"
+						weight="600"
+					>
 						{ displayName }
 					</Text>
 					{ response.author_email && displayName !== response.author_email && (
 						<HStack alignment="center" className="jp-forms__inbox-response-meta-from-email">
-							<Text as="a" variant="muted" href={ `mailto:${ response.author_email }` }>
+							<Text
+								as="a"
+								href={ `mailto:${ response.author_email }` }
+								lineHeight="20px"
+								size="13px"
+								variant="muted"
+								weight="400"
+							>
 								{ responseAuthorEmailParts[ 0 ] }
 								<wbr />@{ responseAuthorEmailParts[ 1 ] }
 							</Text>

--- a/projects/packages/forms/src/dashboard/components/inspector/response-meta/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/inspector/response-meta/index.tsx
@@ -66,7 +66,11 @@ const ResponseMeta = ( { response }: ResponseMetaProps ): import('react').JSX.El
 						{ displayName }
 					</Text>
 					{ response.author_email && displayName !== response.author_email && (
-						<HStack alignment="center" className="jp-forms__inbox-response-meta-from-email">
+						<HStack
+							alignment="center"
+							className="jp-forms__inbox-response-meta-from-email"
+							justify="start"
+						>
 							<Text
 								as="a"
 								href={ `mailto:${ response.author_email }` }
@@ -83,48 +87,45 @@ const ResponseMeta = ( { response }: ResponseMetaProps ): import('react').JSX.El
 					) }
 				</VStack>
 			</HStack>
-
-			<div className="jp-forms__inbox-response-meta-data">
-				<table>
-					<tbody>
-						<tr>
-							<th>{ __( 'Date:', 'jetpack-forms' ) }</th>
-							<td>{ dateI18n( dateSettings.formats.datetime, response.date ) }</td>
-						</tr>
-						<tr>
-							<th>{ __( 'Source:', 'jetpack-forms' ) }</th>
-							<td>
-								{ response.entry_permalink && (
-									<ExternalLink href={ response.entry_permalink }>
-										{ decodeEntities( response.entry_title ) || getPath( response ) }
+			<table className="jp-forms__inbox-response-meta-table">
+				<tbody>
+					<tr>
+						<th>{ __( 'Date:', 'jetpack-forms' ) }</th>
+						<td>{ dateI18n( dateSettings.formats.datetime, response.date ) }</td>
+					</tr>
+					<tr>
+						<th>{ __( 'Source:', 'jetpack-forms' ) }</th>
+						<td>
+							{ response.entry_permalink && (
+								<ExternalLink href={ response.entry_permalink }>
+									{ decodeEntities( response.entry_title ) || getPath( response ) }
+								</ExternalLink>
+							) }
+							{ ! response.entry_permalink && decodeEntities( response.entry_title ) }
+						</td>
+					</tr>
+					<tr>
+						<th>{ __( 'IP address:', 'jetpack-forms' ) }&nbsp;</th>
+						<td>
+							<TextWithFlag countryCode={ response.country_code }>
+								<Tooltip text={ __( 'Lookup IP address', 'jetpack-forms' ) }>
+									<ExternalLink
+										href={ `https://apps.db.ripe.net/db-web-ui/query?searchtext=/${ response.ip }` }
+									>
+										{ response.ip }
 									</ExternalLink>
-								) }
-								{ ! response.entry_permalink && decodeEntities( response.entry_title ) }
-							</td>
-						</tr>
+								</Tooltip>
+							</TextWithFlag>
+						</td>
+					</tr>
+					{ response.browser && (
 						<tr>
-							<th>{ __( 'IP address:', 'jetpack-forms' ) }&nbsp;</th>
-							<td>
-								<TextWithFlag countryCode={ response.country_code }>
-									<Tooltip text={ __( 'Lookup IP address', 'jetpack-forms' ) }>
-										<ExternalLink
-											href={ `https://apps.db.ripe.net/db-web-ui/query?searchtext=/${ response.ip }` }
-										>
-											{ response.ip }
-										</ExternalLink>
-									</Tooltip>
-								</TextWithFlag>
-							</td>
+							<th>{ __( 'Browser:', 'jetpack-forms' ) }&nbsp;</th>
+							<td>{ response.browser }</td>
 						</tr>
-						{ response.browser && (
-							<tr>
-								<th>{ __( 'Browser:', 'jetpack-forms' ) }&nbsp;</th>
-								<td>{ response.browser }</td>
-							</tr>
-						) }
-					</tbody>
-				</table>
-			</div>
+					) }
+				</tbody>
+			</table>
 		</div>
 	);
 };

--- a/projects/packages/forms/src/dashboard/components/inspector/response-meta/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/inspector/response-meta/index.tsx
@@ -70,14 +70,15 @@ const ResponseMeta = ( { response }: ResponseMetaProps ): import('react').JSX.El
 						</HStack>
 					) }
 				</VStack>
-				<Text variant="muted" className="jp-forms__inbox-response-meta-date">
-					{ dateI18n( dateSettings.formats.datetime, response.date ) }
-				</Text>
 			</HStack>
 
 			<div className="jp-forms__inbox-response-meta-data">
 				<table>
 					<tbody>
+						<tr>
+							<th>{ __( 'Date:', 'jetpack-forms' ) }</th>
+							<td>{ dateI18n( dateSettings.formats.datetime, response.date ) }</td>
+						</tr>
 						<tr>
 							<th>{ __( 'Source:', 'jetpack-forms' ) }</th>
 							<td>

--- a/projects/packages/forms/src/dashboard/components/inspector/response-meta/style.scss
+++ b/projects/packages/forms/src/dashboard/components/inspector/response-meta/style.scss
@@ -3,7 +3,7 @@
 @use "@wordpress/base-styles/variables";
 
 .jp-forms__inbox-response-meta {
-	background-color: #fcfcfc; // TODO: use wpds variable
+	background-color: var(--wpds-color-bg-surface-neutral, #f8f8f8);
 	padding: variables.$grid-unit-30 variables.$grid-unit-20;
 
 	// Multiple variables as fallback until style tokens are available everywhere.

--- a/projects/packages/forms/src/dashboard/components/inspector/response-meta/style.scss
+++ b/projects/packages/forms/src/dashboard/components/inspector/response-meta/style.scss
@@ -3,7 +3,7 @@
 @use "@wordpress/base-styles/variables";
 
 .jp-forms__inbox-response-meta {
-	background-color: var(--wpds-color-bg-surface-neutral, #f8f8f8);
+	background-color: #fcfcfc;
 	padding: variables.$grid-unit-30 variables.$grid-unit-20;
 
 	// Multiple variables as fallback until style tokens are available everywhere.

--- a/projects/packages/forms/src/dashboard/components/inspector/response-meta/style.scss
+++ b/projects/packages/forms/src/dashboard/components/inspector/response-meta/style.scss
@@ -10,6 +10,7 @@
 
 .jp-forms__inbox-response-meta-from {
 	min-height: 48px; // Same as avatar to middle-align single lines
+	word-break: break-word;
 }
 
 // Reset margins and padding for response header elements
@@ -19,30 +20,10 @@
 	padding: 0;
 }
 
-.jp-forms__inbox-response-meta-from-name {
-	font-size: 24px;
-	font-weight: 700;
-	line-height: 24px;
-}
-
-.jp-forms__inbox-response-meta-from-email {
-	display: flex;
-	align-items: center;
-	flex-shrink: 0;
-	font-size: 14px;
-	font-weight: 500;
-	gap: 4px;
-	line-height: 24px;
-	max-width: 100%;
-	min-height: 24px;
-	word-break: break-word;
-}
-
 .jp-forms__inbox-response-meta-data {
 	color: var(--jp-gray-80);
 	font-size: 12px;
 	padding-top: 12px;
-	padding-bottom: 24px;
 
 	table {
 		text-align: left;

--- a/projects/packages/forms/src/dashboard/components/inspector/response-meta/style.scss
+++ b/projects/packages/forms/src/dashboard/components/inspector/response-meta/style.scss
@@ -38,7 +38,7 @@
 
 	th {
 		font-weight: 400;
-		padding-right: variables.$grid-unit-10;
+		padding-right: variables.$grid-unit-20;
 		vertical-align: top;
 		white-space: nowrap;
 		color: var(--jp-gray-50, #646970);

--- a/projects/packages/forms/src/dashboard/components/inspector/response-meta/style.scss
+++ b/projects/packages/forms/src/dashboard/components/inspector/response-meta/style.scss
@@ -8,10 +8,6 @@
 	border-bottom: 1px solid rgb(238, 238, 238); /* TODO: use variable: 1px solid var(--jp-forms-border-color);*/
 }
 
-.jp-forms__inbox-response-meta-date {
-	margin-left: auto;
-}
-
 .jp-forms__inbox-response-meta-from {
 	min-height: 48px; // Same as avatar to middle-align single lines
 }

--- a/projects/packages/forms/src/dashboard/components/inspector/response-meta/style.scss
+++ b/projects/packages/forms/src/dashboard/components/inspector/response-meta/style.scss
@@ -1,28 +1,37 @@
 
 @use "@wordpress/base-styles/breakpoints";
 @use "@wordpress/base-styles/variables";
-@use "../../../mixins";
 
-.jp-forms__inbox-response-header-title {
+.jp-forms__inbox-response-meta {
+	background-color: #fcfcfc; // TODO: use variable
+	padding: variables.$grid-unit-30 variables.$grid-unit-20;
+	border-bottom: 1px solid rgb(238, 238, 238); /* TODO: use variable: 1px solid var(--jp-forms-border-color);*/
+}
+
+.jp-forms__inbox-response-meta-date {
+	margin-left: auto;
+}
+
+.jp-forms__inbox-response-meta-from {
 	min-height: 48px; // Same as avatar to middle-align single lines
 }
 
 // Reset margins and padding for response header elements
-.jp-forms__inbox-response-name,
-.jp-forms__inbox-response-email {
+.jp-forms__inbox-response-meta-from-name,
+.jp-forms__inbox-response-meta-from-email {
 	margin: 0;
 	padding: 0;
 }
 
-.jp-forms__inbox-response-name {
+.jp-forms__inbox-response-meta-from-name {
 	font-size: 24px;
 	font-weight: 700;
 	line-height: 24px;
 }
 
-.jp-forms__inbox-response-email {
-
-	@include mixins.flex-center;
+.jp-forms__inbox-response-meta-from-email {
+	display: flex;
+	align-items: center;
 	flex-shrink: 0;
 	font-size: 14px;
 	font-weight: 500;
@@ -33,7 +42,7 @@
 	word-break: break-word;
 }
 
-.jp-forms__inbox-response-meta {
+.jp-forms__inbox-response-meta-data {
 	color: var(--jp-gray-80);
 	font-size: 12px;
 	padding-top: 12px;

--- a/projects/packages/forms/src/dashboard/components/inspector/response-meta/style.scss
+++ b/projects/packages/forms/src/dashboard/components/inspector/response-meta/style.scss
@@ -3,9 +3,11 @@
 @use "@wordpress/base-styles/variables";
 
 .jp-forms__inbox-response-meta {
-	background-color: #fcfcfc; // TODO: use variable
+	background-color: #fcfcfc; // TODO: use wpds variable
 	padding: variables.$grid-unit-30 variables.$grid-unit-20;
-	border-bottom: 1px solid rgb(238, 238, 238); /* TODO: use variable: 1px solid var(--jp-forms-border-color);*/
+
+	// Multiple variables as fallback until style tokens are available everywhere.
+	border-bottom: 1px solid var(--wpds-color-stroke-surface-neutral, var(--jp-forms-border-color, #e0e0e0));
 }
 
 .jp-forms__inbox-response-meta-from {
@@ -20,25 +22,25 @@
 	padding: 0;
 }
 
-.jp-forms__inbox-response-meta-data {
-	color: var(--jp-gray-80);
-	font-size: 12px;
-	padding-top: 12px;
+.jp-forms__inbox-response-meta-table {
+	color: var(--jp-gray-80, #2c3338);
+	font-size: 13px;
+	padding-top: 16px;
+	text-align: left;
+	width: fit-content;
 
-	table {
-		text-align: left;
-		width: fit-content;
+	td,
+	th {
+		margin: 0;
+		padding: 0 0 6px 0;
+		word-break: break-word;
+	}
 
-		td,
-		th {
-			padding: 0;
-		}
-
-		th {
-			font-weight: 400;
-			padding-right: variables.$grid-unit-10;
-			vertical-align: top;
-			white-space: nowrap;
-		}
+	th {
+		font-weight: 400;
+		padding-right: variables.$grid-unit-10;
+		vertical-align: top;
+		white-space: nowrap;
+		color: var(--jp-gray-50, #646970);
 	}
 }

--- a/projects/packages/forms/src/dashboard/components/inspector/style.scss
+++ b/projects/packages/forms/src/dashboard/components/inspector/style.scss
@@ -101,7 +101,6 @@
 
 	@media (min-width: #{ (breakpoints.$break-medium + 1) }) {
 		padding: 16px 16px;
-		margin-bottom: 57px; // Compensate for fixed footer from DataViews
 	}
 }
 
@@ -127,6 +126,14 @@
 	.jp-forms__inbox-response-data {
 		padding-left: 0;
 		padding-right: 0;
+	}
+
+	.jp-forms__inbox-response-meta {
+		background-color: transparent;
+	}
+
+	.jp-forms__inbox__tip-container {
+		border-top: none;
 	}
 
 	.jp-forms__inbox-file-preview-modal {

--- a/projects/packages/forms/src/dashboard/components/inspector/style.scss
+++ b/projects/packages/forms/src/dashboard/components/inspector/style.scss
@@ -59,7 +59,6 @@
 
 .jp-forms__inbox-response-data {
 
-	/*border-top: 1px solid var(--jp-forms-border-color);*/
 	font-size: var(--jp-forms-font-size-regular);
 	line-height: 24px;
 	padding: 0 16px;

--- a/projects/packages/forms/src/dashboard/components/inspector/style.scss
+++ b/projects/packages/forms/src/dashboard/components/inspector/style.scss
@@ -17,7 +17,6 @@
 	flex-grow: 2;
 
 	.jp-forms__inbox-response-header {
-		margin: 24px 0 0;
 		padding: 0 16px 0 0;
 
 		@media (min-width: #{ (breakpoints.$break-medium + 1) }) {
@@ -59,7 +58,8 @@
 }
 
 .jp-forms__inbox-response-data {
-	border-top: 1px solid var(--jp-forms-border-color);
+
+	/*border-top: 1px solid var(--jp-forms-border-color);*/
 	font-size: var(--jp-forms-font-size-regular);
 	line-height: 24px;
 	padding: 0 16px;

--- a/projects/plugins/jetpack/changelog/update-forms-wp-build-sidebar-styles
+++ b/projects/plugins/jetpack/changelog/update-forms-wp-build-sidebar-styles
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Forms: update response sidebar styles.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->


## Proposed changes:
<!--- Explain what functional changes your PR includes -->

- Implements new header design for response sidebar, for both old and new dashboards.
- Refactor styles and improve componentry; previously, both sidebars shared the same styles file, but that wasn't optimal and was carrying over some old baggage/inefficient styles. Now:
   - Meta/header area styles are shared via same component
   - WP Build inspector has its own stylesheet
   - Old dashboard has its own stylesheet
- Ensure long words flow to multiple lines
- Improve sidebar header component code structure to be less repetitive
- Overall use more Stack components rather than inline styles
- Unlike in design, the date is still in the table as it was tricky to get it work with longer names.

TODO in separate PRs:
- Update how IP+country are rendered.
- Update how fields are rendered in the WP Build dash sidebar

Design:

<img width="394" height="371" alt="image" src="https://github.com/user-attachments/assets/0d6290ad-3cc5-4526-a9f8-b1f1ef0d4dc1" />


### Before:

#### WP Build dashboard
<img width="1629" height="1148" alt="image" src="https://github.com/user-attachments/assets/da336853-f642-46f5-8152-f907991329fc" />


#### Old Dashboard
<img width="1448" height="1106" alt="image" src="https://github.com/user-attachments/assets/1a5c41a2-a507-4dc7-904b-7655049c50b4" />


### After:

#### WP Build dashboard
<img width="1636" height="1149" alt="image" src="https://github.com/user-attachments/assets/b459d4f6-caf9-4c12-973f-cd208a679355" />



#### Old Dashboard
<img width="1220" height="823" alt="Screenshot 2026-02-04 at 14 07 17" src="https://github.com/user-attachments/assets/28c0b90f-5ccd-4906-baf3-deb889cb7033" />


#### Modal (old dashboard)
<img width="752" height="1001" alt="Screenshot 2026-02-04 at 14 06 59" src="https://github.com/user-attachments/assets/68bde5b6-a621-485d-a9e7-131cf1fc5cab" />


#### Mobile (old dashboard)
<img width="432" height="866" alt="Screenshot 2026-02-04 at 14 06 31" src="https://github.com/user-attachments/assets/bb5d9b18-6415-4693-ab42-c749a91cb61e" />



### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Build forms `jetpack build package/forms`
* Enable new dashboard `add_filter('jetpack_forms_alpha', '__return_true');`
* Test new dashboard and old dashboard, try different screensizes down to mobile
* Try inbox/spam/trash

