### PR TITLE
Newsletter: Fix API endpoints on WordPress.com Simple sites

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3097,6 +3097,9 @@ importers:
       '@automattic/jetpack-shared-extension-utils':
         specifier: workspace:*
         version: link:../../js-packages/shared-extension-utils
+      '@wordpress/api-fetch':
+        specifier: 7.39.0
+        version: 7.39.0
       '@wordpress/components':
         specifier: 32.1.0
         version: 32.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)

--- a/projects/packages/newsletter/changelog/dotcom-15873-fix-issue-with-dotcom-simple-and-api-endpoints
+++ b/projects/packages/newsletter/changelog/dotcom-15873-fix-issue-with-dotcom-simple-and-api-endpoints
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix settings and categories API endpoints on WordPress.com Simple sites.

--- a/projects/packages/newsletter/package.json
+++ b/projects/packages/newsletter/package.json
@@ -35,6 +35,7 @@
 		"@automattic/jetpack-api": "workspace:*",
 		"@automattic/jetpack-components": "workspace:*",
 		"@automattic/jetpack-shared-extension-utils": "workspace:*",
+		"@wordpress/api-fetch": "7.39.0",
 		"@wordpress/components": "32.1.0",
 		"@wordpress/dataviews": "11.3.0",
 		"@wordpress/element": "6.39.0",

--- a/projects/packages/newsletter/src/settings/api.ts
+++ b/projects/packages/newsletter/src/settings/api.ts
@@ -1,0 +1,108 @@
+/**
+ * API utilities for newsletter settings
+ *
+ * On WordPress.com Simple sites, the Jetpack REST API is not directly accessible.
+ * Instead, we use the WordPress.com REST API endpoint via `@wordpress/api-fetch`:
+ * /rest/v1.4/sites/{SITE_ID}/settings
+ */
+
+import restApi from '@automattic/jetpack-api';
+import apiFetch from '@wordpress/api-fetch';
+import type { JetpackNewsletterSettings } from './types';
+
+let apiInitialized = false;
+
+/**
+ * Initialize the REST API with settings from PHP.
+ * Only needed for non-Simple sites. Call this before making API requests.
+ *
+ * @param {JetpackNewsletterSettings} jetpackSettings - Settings from PHP
+ */
+export function initializeApi( jetpackSettings: JetpackNewsletterSettings | undefined ): void {
+	if ( apiInitialized || jetpackSettings?.isWpcomSimple ) {
+		return;
+	}
+
+	if ( jetpackSettings?.restApiRoot && jetpackSettings?.restApiNonce ) {
+		restApi.setApiRoot( jetpackSettings.restApiRoot );
+		restApi.setApiNonce( jetpackSettings.restApiNonce );
+		apiInitialized = true;
+	}
+}
+
+/**
+ * Fetch settings from the Jetpack REST API.
+ * On Simple sites, uses the WordPress.com REST API.
+ *
+ * @param {JetpackNewsletterSettings} jetpackSettings - Settings from PHP
+ * @return {Promise<Record<string, unknown>>} The settings object
+ */
+export async function fetchSettings(
+	jetpackSettings: JetpackNewsletterSettings | undefined
+): Promise< Record< string, unknown > > {
+	if ( jetpackSettings?.isWpcomSimple && jetpackSettings?.blogID ) {
+		return fetchSettingsViaWpcomApi( jetpackSettings.blogID );
+	}
+
+	// For non-Simple sites, use the standard API
+	initializeApi( jetpackSettings );
+	return restApi.fetchSettings();
+}
+
+/**
+ * Update settings via the Jetpack REST API.
+ * On Simple sites, uses the WordPress.com REST API.
+ *
+ * @param {Record<string, unknown>}   updates         - The settings to update
+ * @param {JetpackNewsletterSettings} jetpackSettings - Settings from PHP
+ * @return {Promise<Record<string, unknown>>} The response
+ */
+export async function updateSettings(
+	updates: Record< string, unknown >,
+	jetpackSettings: JetpackNewsletterSettings | undefined
+): Promise< Record< string, unknown > > {
+	if ( jetpackSettings?.isWpcomSimple && jetpackSettings?.blogID ) {
+		return updateSettingsViaWpcomApi( updates, jetpackSettings.blogID );
+	}
+
+	// For non-Simple sites, use the standard API
+	initializeApi( jetpackSettings );
+	return restApi.updateSettings( updates );
+}
+
+/**
+ * Fetch settings via the WordPress.com REST API.
+ * Uses `@wordpress/api-fetch` which handles authentication on Simple sites.
+ *
+ * @param {number} blogId - The blog ID
+ * @return {Promise<Record<string, unknown>>} The settings object
+ */
+async function fetchSettingsViaWpcomApi( blogId: number ): Promise< Record< string, unknown > > {
+	const result = ( await apiFetch( {
+		path: `/rest/v1.4/sites/${ blogId }/settings`,
+		method: 'GET',
+	} ) ) as { settings?: Record< string, unknown > };
+
+	return result.settings || result;
+}
+
+/**
+ * Update settings via the WordPress.com REST API.
+ * Uses apiFetch which handles authentication on Simple sites.
+ *
+ * @param {Record<string, unknown>} updates - The settings to update
+ * @param {number}                  blogId  - The blog ID
+ * @return {Promise<Record<string, unknown>>} The response
+ */
+async function updateSettingsViaWpcomApi(
+	updates: Record< string, unknown >,
+	blogId: number
+): Promise< Record< string, unknown > > {
+	const result = ( await apiFetch( {
+		path: `/rest/v1.4/sites/${ blogId }/settings`,
+		method: 'POST',
+		data: updates,
+	} ) ) as { updated?: Record< string, unknown > };
+
+	return result.updated || result;
+}

--- a/projects/packages/newsletter/src/settings/api.ts
+++ b/projects/packages/newsletter/src/settings/api.ts
@@ -83,7 +83,11 @@ async function fetchSettingsViaWpcomApi( blogId: number ): Promise< Record< stri
 		method: 'GET',
 	} ) ) as { settings?: Record< string, unknown > };
 
-	return result.settings || result;
+	const settings = result.settings || result;
+
+	// WordPress.com Simple sites don't return a `subscriptions` key,
+	// but subscriptions are always enabled on Simple sites.
+	return { subscriptions: true, ...settings };
 }
 
 /**

--- a/projects/packages/newsletter/src/settings/api.ts
+++ b/projects/packages/newsletter/src/settings/api.ts
@@ -106,3 +106,89 @@ async function updateSettingsViaWpcomApi(
 
 	return result.updated || result;
 }
+
+/**
+ * Category type used by the API.
+ */
+export interface Category {
+	id: number;
+	name: string;
+}
+
+/**
+ * Fetch all categories, handling pagination.
+ * On Simple sites, uses the WordPress.com REST API.
+ *
+ * @param {JetpackNewsletterSettings} jetpackSettings - Settings from PHP
+ * @return {Promise<Category[]>} Array of categories
+ */
+export async function fetchCategories(
+	jetpackSettings: JetpackNewsletterSettings | undefined
+): Promise< Category[] > {
+	if ( jetpackSettings?.isWpcomSimple && jetpackSettings?.blogID ) {
+		return fetchCategoriesViaWpcomApi( jetpackSettings.blogID );
+	}
+
+	return fetchCategoriesViaWpApi();
+}
+
+/**
+ * Fetch categories via the WordPress.com REST API.
+ * Uses `@wordpress/api-fetch` which handles authentication on Simple sites.
+ *
+ * @param {number} blogId - The blog ID
+ * @return {Promise<Category[]>} Array of categories
+ */
+async function fetchCategoriesViaWpcomApi( blogId: number ): Promise< Category[] > {
+	const allCategories: Category[] = [];
+	let page = 1;
+	let hasMore = true;
+
+	while ( hasMore ) {
+		const result = ( await apiFetch( {
+			path: `/rest/v1.1/sites/${ blogId }/taxonomies/category/terms?page=${ page }&number=100`,
+			method: 'GET',
+		} ) ) as { terms?: Array< { ID: number; name: string } >; found?: number };
+
+		const terms = result.terms || [];
+		// WordPress.com API returns ID (uppercase), normalize to id (lowercase)
+		allCategories.push( ...terms.map( term => ( { id: term.ID, name: term.name } ) ) );
+
+		// Check if there are more pages
+		const found = result.found || 0;
+		hasMore = allCategories.length < found;
+		page++;
+	}
+
+	return allCategories;
+}
+
+/**
+ * Fetch categories via the WordPress REST API.
+ * Uses `@wordpress/api-fetch` for consistent handling.
+ *
+ * @return {Promise<Category[]>} Array of categories
+ */
+async function fetchCategoriesViaWpApi(): Promise< Category[] > {
+	const allCategories: Category[] = [];
+	let page = 1;
+	let hasMore = true;
+
+	while ( hasMore ) {
+		const result = ( await apiFetch( {
+			path: `/wp/v2/categories?per_page=100&page=${ page }`,
+			method: 'GET',
+			parse: false, // Get raw response to access headers
+		} ) ) as Response;
+
+		const categories: Category[] = await result.json();
+		allCategories.push( ...categories.map( cat => ( { id: cat.id, name: cat.name } ) ) );
+
+		// Check if there are more pages
+		const totalPages = parseInt( result.headers.get( 'X-WP-TotalPages' ) || '1', 10 );
+		hasMore = page < totalPages;
+		page++;
+	}
+
+	return allCategories;
+}

--- a/projects/packages/newsletter/src/settings/index.tsx
+++ b/projects/packages/newsletter/src/settings/index.tsx
@@ -1,13 +1,13 @@
 /**
  * External dependencies
  */
-import restApi from '@automattic/jetpack-api';
 import { Notice, Snackbar } from '@wordpress/components';
 import { createRoot, useCallback, useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
+import { fetchSettings, updateSettings } from './api';
 import { Header } from './components/header';
 import {
 	EmailContentSection,
@@ -89,14 +89,7 @@ function NewsletterSettingsApp(): JSX.Element | null {
 
 	// Load settings on mount
 	useEffect( () => {
-		// Initialize the REST API with settings from PHP
-		if ( jetpackSettings?.restApiRoot && jetpackSettings?.restApiNonce ) {
-			restApi.setApiRoot( jetpackSettings.restApiRoot );
-			restApi.setApiNonce( jetpackSettings.restApiNonce );
-		}
-
-		restApi
-			.fetchSettings()
+		fetchSettings( jetpackSettings )
 			.then( ( settings: Record< string, unknown > ) => {
 				setData( normalizeSettings( settings ) );
 				setIsLoading( false );
@@ -107,7 +100,7 @@ function NewsletterSettingsApp(): JSX.Element | null {
 				setError( err.message || __( 'Failed to load settings', 'jetpack-newsletter' ) );
 				setIsLoading( false );
 			} );
-	}, [ jetpackSettings?.restApiRoot, jetpackSettings?.restApiNonce ] );
+	}, [ jetpackSettings ] );
 
 	// Handle auto-save for newsletter toggle and email settings
 	const handleAutoSave = useCallback(
@@ -120,8 +113,7 @@ function NewsletterSettingsApp(): JSX.Element | null {
 			setData( prev => ( { ...prev, ...updates } ) );
 
 			// Save to backend
-			restApi
-				.updateSettings( updates )
+			updateSettings( updates, jetpackSettings )
 				.then( () => {
 					setError( null );
 				} )
@@ -133,7 +125,7 @@ function NewsletterSettingsApp(): JSX.Element | null {
 					setData( data );
 				} );
 		},
-		[ data ]
+		[ data, jetpackSettings ]
 	);
 
 	// Handle sender name changes (staged, not auto-saved)
@@ -153,8 +145,7 @@ function NewsletterSettingsApp(): JSX.Element | null {
 		setIsSavingSenderName( true );
 		setError( null );
 
-		restApi
-			.updateSettings( senderNameChanges )
+		updateSettings( senderNameChanges, jetpackSettings )
 			.then( () => {
 				setError( null );
 				setSenderNameChanges( {} );
@@ -168,7 +159,7 @@ function NewsletterSettingsApp(): JSX.Element | null {
 			.finally( () => {
 				setIsSavingSenderName( false );
 			} );
-	}, [ senderNameChanges, data ] );
+	}, [ senderNameChanges, data, jetpackSettings ] );
 
 	// Handle subscription settings changes (staged, not auto-saved)
 	const handleSubscriptionChange = useCallback( ( updates: Partial< NewsletterSettings > ) => {
@@ -187,8 +178,7 @@ function NewsletterSettingsApp(): JSX.Element | null {
 		setIsSavingSubscriptions( true );
 		setError( null );
 
-		restApi
-			.updateSettings( subscriptionChanges )
+		updateSettings( subscriptionChanges, jetpackSettings )
 			.then( () => {
 				setError( null );
 				setSubscriptionChanges( {} );
@@ -204,7 +194,7 @@ function NewsletterSettingsApp(): JSX.Element | null {
 			.finally( () => {
 				setIsSavingSubscriptions( false );
 			} );
-	}, [ subscriptionChanges, data ] );
+	}, [ subscriptionChanges, data, jetpackSettings ] );
 
 	// Handle newsletter categories changes (staged, not auto-saved)
 	const handleNewsletterCategoriesChange = useCallback(
@@ -244,8 +234,7 @@ function NewsletterSettingsApp(): JSX.Element | null {
 			}
 		}
 
-		restApi
-			.updateSettings( apiUpdates )
+		updateSettings( apiUpdates, jetpackSettings )
 			.then( () => {
 				setError( null );
 				setNewsletterCategoriesChanges( {} );
@@ -261,7 +250,7 @@ function NewsletterSettingsApp(): JSX.Element | null {
 			.finally( () => {
 				setIsSavingNewsletterCategories( false );
 			} );
-	}, [ newsletterCategoriesChanges, data ] );
+	}, [ newsletterCategoriesChanges, data, jetpackSettings ] );
 
 	// Handle welcome email changes (staged, not auto-saved)
 	const handleWelcomeEmailChange = useCallback( ( updates: Partial< NewsletterSettings > ) => {
@@ -280,8 +269,7 @@ function NewsletterSettingsApp(): JSX.Element | null {
 		setIsSavingWelcomeEmail( true );
 		setError( null );
 
-		restApi
-			.updateSettings( welcomeEmailChanges )
+		updateSettings( welcomeEmailChanges, jetpackSettings )
 			.then( () => {
 				setError( null );
 				setWelcomeEmailChanges( {} );
@@ -297,7 +285,7 @@ function NewsletterSettingsApp(): JSX.Element | null {
 			.finally( () => {
 				setIsSavingWelcomeEmail( false );
 			} );
-	}, [ welcomeEmailChanges, data ] );
+	}, [ welcomeEmailChanges, data, jetpackSettings ] );
 
 	if ( isLoading ) {
 		return (

--- a/projects/packages/newsletter/src/settings/sections/newsletter-categories-section.tsx
+++ b/projects/packages/newsletter/src/settings/sections/newsletter-categories-section.tsx
@@ -9,6 +9,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
+import { fetchCategories } from '../api';
 import type { NewsletterSettings, JetpackNewsletterSettings, WordPressCategory } from '../types';
 
 interface NewsletterCategoriesSectionProps {
@@ -43,51 +44,8 @@ export function NewsletterCategoriesSection( {
 
 	// Fetch WordPress categories on mount
 	useEffect( () => {
-		const wpApiSettings = ( window as Window & { wpApiSettings?: { root: string; nonce: string } } )
-			.wpApiSettings;
-
-		if ( ! wpApiSettings?.root ) {
-			setIsFetchingCategories( false );
-			return;
-		}
-
-		// Recursive function to fetch all pages of categories
-		const fetchAllCategories = async (
-			page = 1,
-			allCategories: { id: number; name: string }[] = []
-		): Promise< { id: number; name: string }[] > => {
-			const url = new URL( 'wp/v2/categories', wpApiSettings.root );
-			url.searchParams.set( 'per_page', '100' );
-			url.searchParams.set( 'page', String( page ) );
-
-			const response = await fetch( url.toString(), {
-				credentials: 'same-origin',
-				headers: {
-					'X-WP-Nonce': wpApiSettings.nonce,
-				},
-			} );
-
-			if ( ! response.ok ) {
-				throw new Error(
-					`Failed to load categories: ${ response.status } ${ response.statusText }`
-				);
-			}
-
-			const pageCategories = await response.json();
-			const totalPages = parseInt( response.headers.get( 'X-WP-TotalPages' ) || '1', 10 );
-			const combined = [ ...allCategories, ...pageCategories ];
-
-			// If there are more pages, fetch them recursively
-			if ( page < totalPages ) {
-				return fetchAllCategories( page + 1, combined );
-			}
-
-			return combined;
-		};
-
-		// Fetch all categories from WordPress REST API
-		fetchAllCategories()
-			.then( ( fetchedCategories: { id: number; name: string }[] ) => {
+		fetchCategories( jetpackSettings )
+			.then( fetchedCategories => {
 				// Convert category IDs to strings
 				setCategories(
 					fetchedCategories.map( cat => ( {
@@ -101,7 +59,7 @@ export function NewsletterCategoriesSection( {
 				onError( err.message || __( 'Failed to load categories', 'jetpack-newsletter' ) );
 				setIsFetchingCategories( false );
 			} );
-	}, [ onError ] );
+	}, [ jetpackSettings, onError ] );
 
 	// Define fields
 	const fields: Field< NewsletterSettings >[] = [


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/DOTCOM-15873

Builds upon #46787 which adds the link into the menu and makes the page available at all.

## Proposed changes:
* Fix Newsletter settings API on WordPress.com Simple sites by using the WordPress.com REST API (`/rest/v1.4/sites/{siteId}/settings`) instead of the Jetpack REST API which isn't accessible on Simple sites
* Fix Newsletter categories API on Simple sites by using `/rest/v1.1/sites/{siteId}/taxonomies/category/terms`
* Default `subscriptions` to `true` on Simple sites since the WordPress.com settings API doesn't return this key but subscriptions are always enabled

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
N/A

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

* Add `add_filter( 'jetpack_wp_admin_newsletter_settings_enabled', '__return_true' );` to your 0-sandbox so the new screen will be used.
* Go to Jetpack → Newsletter in wp-admin
* Verify the settings page loads without errors
* Verify categories are displayed in the Newsletter Categories section
* Toggle settings and verify they save correctly

Similarly, test Jetpack or WoW site to check for regressions. You can add `add_filter( 'jetpack_wp_admin_newsletter_settings_enabled', '__return_true' );` to an mu-plugin or to the top of wp-content/mu-plugins/wpcomsh-dev/wpcomsh.php to test the new screen
