### PR TITLE
Forms: Prevent creating synced forms during block preview

### DIFF
--- a/projects/packages/forms/changelog/fix-create-jetpack_form-on-preview
+++ b/projects/packages/forms/changelog/fix-create-jetpack_form-on-preview
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Form Wrapper: prevent creating synced jetpack_form posts during block preview, and skip form wrapping when editing jetpack_form post type directly.

--- a/projects/packages/forms/changelog/fix-create-jetpack_form-on-preview
+++ b/projects/packages/forms/changelog/fix-create-jetpack_form-on-preview
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Form Wrapper: prevent creating synced jetpack_form posts during block preview, and skip form wrapping when editing jetpack_form post type directly.
+Prevent creating synced jetpack_form posts during block preview, and skip form wrapping when editing jetpack_form post type directly.

--- a/projects/packages/forms/src/blocks/input-phone/editor.scss
+++ b/projects/packages/forms/src/blocks/input-phone/editor.scss
@@ -1,3 +1,5 @@
+.jetpack-field.jetpack-field-phone,
+.jetpack-field.jetpack-field-telephone,
 .jetpack-contact-form .jetpack-field.jetpack-field-phone,
 .jetpack-contact-form .jetpack-field.jetpack-field-telephone {
 

--- a/projects/packages/forms/src/blocks/shared/hooks/use-form-wrapper.js
+++ b/projects/packages/forms/src/blocks/shared/hooks/use-form-wrapper.js
@@ -9,6 +9,93 @@ import useConfigValue from '../../../hooks/use-config-value.ts';
 import { createSyncedForm } from '../../contact-form/util/create-synced-form.ts';
 import { FORM_BLOCK_NAME, FORM_POST_TYPE } from '../util/constants.js';
 
+/**
+ * Creates the form block structure with a field and submit button.
+ *
+ * @param {string} fieldBlockName   - The name of the field block.
+ * @param {object} fieldAttributes  - The attributes for the field block.
+ * @param {Array}  fieldInnerBlocks - The inner blocks for the field block.
+ * @return {object} Object containing formBlock, fieldBlock, and submitButton.
+ */
+export function createFormBlockStructure( fieldBlockName, fieldAttributes, fieldInnerBlocks = [] ) {
+	const fieldBlock = createBlock( fieldBlockName, fieldAttributes, fieldInnerBlocks );
+	const submitButton = createBlock( 'core/button', {
+		text: __( 'Submit', 'jetpack-forms' ),
+		type: 'submit',
+		tagName: 'button',
+	} );
+	const formBlock = createBlock( FORM_BLOCK_NAME, {}, [ fieldBlock, submitButton ] );
+
+	return { formBlock, fieldBlock, submitButton };
+}
+
+/**
+ * Converts a form block to a synced form by creating a jetpack_form post.
+ *
+ * @param {object}   formBlock                     - The form block to convert.
+ * @param {object}   fieldBlock                    - The field block inside the form.
+ * @param {object}   submitButton                  - The submit button block.
+ * @param {string}   postTitle                     - The title of the current post.
+ * @param {number}   currentPostId                 - The ID of the current post.
+ * @param {Function} updateBlockAttributes         - Function to update block attributes.
+ * @param {Function} markNextChangeAsNotPersistent - Function to mark changes as not persistent.
+ */
+export async function convertFormToSynced(
+	formBlock,
+	fieldBlock,
+	submitButton,
+	postTitle,
+	currentPostId,
+	updateBlockAttributes,
+	markNextChangeAsNotPersistent
+) {
+	const formId = await createSyncedForm(
+		{
+			attributes: {},
+			innerBlocks: [ fieldBlock, submitButton ],
+		},
+		postTitle,
+		currentPostId
+	);
+
+	// Preload the entity record into the cache BEFORE setting ref.
+	// This ensures the form component won't show a loading skeleton
+	// because the data will already be available in the store.
+	await resolveSelect( coreStore ).getEntityRecord( 'postType', FORM_POST_TYPE, formId );
+
+	// Now set the ref - the form data is already cached, so no loading state
+	markNextChangeAsNotPersistent();
+	updateBlockAttributes( formBlock.clientId, { ref: formId } );
+}
+
+/**
+ * Determines if a field block should be wrapped in a form.
+ *
+ * @param {string} currentPostType - The current post type being edited.
+ * @param {Array}  parentForms     - Array of parent form block IDs.
+ * @return {boolean} Whether the field should be wrapped.
+ */
+export function shouldWrapFieldInForm( currentPostType, parentForms ) {
+	// Don't wrap fields when editing a jetpack_form post type directly
+	if ( currentPostType === FORM_POST_TYPE ) {
+		return false;
+	}
+
+	// Wrap if there's no parent form
+	return ! parentForms?.length;
+}
+
+/**
+ * Determines if a synced form should be created.
+ *
+ * @param {boolean} isCentralFormManagementEnabled - Whether the feature flag is enabled.
+ * @param {boolean} wasBlockJustInserted           - Whether the block was just inserted.
+ * @return {boolean} Whether a synced form should be created.
+ */
+export function shouldCreateSyncedForm( isCentralFormManagementEnabled, wasBlockJustInserted ) {
+	return isCentralFormManagementEnabled && wasBlockJustInserted;
+}
+
 export default function useFormWrapper( { attributes, clientId, name } ) {
 	const { replaceBlock, updateBlockAttributes, __unstableMarkNextChangeAsNotPersistent } =
 		useDispatch( blockEditorStore );
@@ -17,65 +104,52 @@ export default function useFormWrapper( { attributes, clientId, name } ) {
 	// Feature flag for central form management
 	const isCentralFormManagementEnabled = useConfigValue( 'isCentralFormManagementEnabled' );
 
-	const { parentForms, postTitle, currentPostId } = useSelect(
-		select => {
-			return {
-				parentForms: select( blockEditorStore ).getBlockParentsByBlockName(
-					clientId,
-					FORM_BLOCK_NAME
-				),
-				postTitle: select( editorStore ).getEditedPostAttribute( 'title' ) || 'Untitled',
-				currentPostId: select( editorStore ).getEditedPostAttribute( 'id' ),
-			};
-		},
-		[ clientId ]
-	);
+	const { parentForms, postTitle, currentPostId, currentPostType, wasBlockJustInserted } =
+		useSelect(
+			select => {
+				return {
+					parentForms: select( blockEditorStore ).getBlockParentsByBlockName(
+						clientId,
+						FORM_BLOCK_NAME
+					),
+					postTitle: select( editorStore ).getEditedPostAttribute( 'title' ) || 'Untitled',
+					currentPostId: select( editorStore ).getEditedPostAttribute( 'id' ),
+					currentPostType: select( editorStore ).getCurrentPostType(),
+					wasBlockJustInserted: select( blockEditorStore ).wasBlockJustInserted( clientId ),
+				};
+			},
+			[ clientId ]
+		);
 
 	useEffect( () => {
-		if ( ! parentForms?.length ) {
-			// Create the form block structure
-			const fieldBlock = createBlock( name, attributes, getBlocks( clientId ) );
-			const submitButton = createBlock( 'core/button', {
-				text: __( 'Submit', 'jetpack-forms' ),
-				type: 'submit',
-				tagName: 'button',
+		if ( ! shouldWrapFieldInForm( currentPostType, parentForms ) ) {
+			return;
+		}
+
+		const { formBlock, fieldBlock, submitButton } = createFormBlockStructure(
+			name,
+			attributes,
+			getBlocks( clientId )
+		);
+
+		// Replace field with form (immediate visual feedback)
+		// Mark as not persistent so it doesn't end up in the undo stack
+		__unstableMarkNextChangeAsNotPersistent();
+		replaceBlock( clientId, formBlock );
+
+		// Convert to synced form (async) - only if conditions are met
+		if ( shouldCreateSyncedForm( isCentralFormManagementEnabled, wasBlockJustInserted ) ) {
+			convertFormToSynced(
+				formBlock,
+				fieldBlock,
+				submitButton,
+				postTitle,
+				currentPostId,
+				updateBlockAttributes,
+				__unstableMarkNextChangeAsNotPersistent
+			).catch( () => {
+				// If synced form creation fails, keep as inline form (graceful degradation)
 			} );
-			const formBlock = createBlock( FORM_BLOCK_NAME, {}, [ fieldBlock, submitButton ] );
-
-			// Phase 1: Replace field with form (immediate visual feedback)
-			// As this is an automated update, ensure it doesn't end up in the undo stack
-			// by calling `__unstableMarkNextChangeAsNotPersistent`.
-			__unstableMarkNextChangeAsNotPersistent();
-			replaceBlock( clientId, formBlock );
-
-			// Phase 2: Convert to synced form (async) - only if feature flag is enabled
-			if ( isCentralFormManagementEnabled ) {
-				const convertToSynced = async () => {
-					try {
-						const formId = await createSyncedForm(
-							{
-								attributes: {},
-								innerBlocks: [ fieldBlock, submitButton ],
-							},
-							postTitle,
-							currentPostId
-						);
-
-						// Preload the entity record into the cache BEFORE setting ref.
-						// This ensures the form component won't show a loading skeleton
-						// because the data will already be available in the store.
-						await resolveSelect( coreStore ).getEntityRecord( 'postType', FORM_POST_TYPE, formId );
-
-						// Now set the ref - the form data is already cached, so no loading state
-						__unstableMarkNextChangeAsNotPersistent();
-						updateBlockAttributes( formBlock.clientId, { ref: formId } );
-					} catch {
-						// If synced form creation fails, keep as inline form (graceful degradation)
-					}
-				};
-
-				convertToSynced();
-			}
 		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [] );

--- a/projects/packages/forms/src/blocks/shared/hooks/use-form-wrapper.js
+++ b/projects/packages/forms/src/blocks/shared/hooks/use-form-wrapper.js
@@ -3,7 +3,7 @@ import { createBlock } from '@wordpress/blocks';
 import { store as coreStore } from '@wordpress/core-data';
 import { resolveSelect, useDispatch, useSelect } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
-import { useEffect } from '@wordpress/element';
+import { useEffect, useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import useConfigValue from '../../../hooks/use-config-value.ts';
 import { createSyncedForm } from '../../contact-form/util/create-synced-form.ts';
@@ -69,6 +69,22 @@ export async function convertFormToSynced(
 }
 
 /**
+ * Checks if we're in a block preview context (e.g., block inserter preview).
+ * Block previews are typically rendered in an iframe.
+ *
+ * @return {boolean} Whether we're in a preview context.
+ */
+export function isBlockPreviewContext() {
+	try {
+		// Block previews are rendered in an iframe
+		return window.self !== window.top;
+	} catch {
+		// If we can't access window.top due to cross-origin restrictions, we're likely in an iframe
+		return true;
+	}
+}
+
+/**
  * Determines if a field block should be wrapped in a form.
  *
  * @param {string} currentPostType - The current post type being edited.
@@ -76,6 +92,11 @@ export async function convertFormToSynced(
  * @return {boolean} Whether the field should be wrapped.
  */
 export function shouldWrapFieldInForm( currentPostType, parentForms ) {
+	// Don't wrap in preview context (block inserter preview is rendered in an iframe)
+	if ( isBlockPreviewContext() ) {
+		return false;
+	}
+
 	// Don't wrap fields when editing a jetpack_form post type directly
 	if ( currentPostType === FORM_POST_TYPE ) {
 		return false;
@@ -121,10 +142,20 @@ export default function useFormWrapper( { attributes, clientId, name } ) {
 			[ clientId ]
 		);
 
+	// Guard against StrictMode double-invocation and re-renders
+	const hasAttemptedWrap = useRef( false );
+
 	useEffect( () => {
+		// Prevent double execution from React StrictMode
+		if ( hasAttemptedWrap.current ) {
+			return;
+		}
+
 		if ( ! shouldWrapFieldInForm( currentPostType, parentForms ) ) {
 			return;
 		}
+
+		hasAttemptedWrap.current = true;
 
 		const { formBlock, fieldBlock, submitButton } = createFormBlockStructure(
 			name,

--- a/projects/packages/forms/src/blocks/shared/hooks/use-form-wrapper.js
+++ b/projects/packages/forms/src/blocks/shared/hooks/use-form-wrapper.js
@@ -69,22 +69,6 @@ export async function convertFormToSynced(
 }
 
 /**
- * Checks if we're in a block preview context (e.g., block inserter preview).
- * Block previews are typically rendered in an iframe.
- *
- * @return {boolean} Whether we're in a preview context.
- */
-export function isBlockPreviewContext() {
-	try {
-		// Block previews are rendered in an iframe
-		return window.self !== window.top;
-	} catch {
-		// If we can't access window.top due to cross-origin restrictions, we're likely in an iframe
-		return true;
-	}
-}
-
-/**
  * Determines if a field block should be wrapped in a form.
  *
  * @param {string} currentPostType - The current post type being edited.
@@ -92,11 +76,6 @@ export function isBlockPreviewContext() {
  * @return {boolean} Whether the field should be wrapped.
  */
 export function shouldWrapFieldInForm( currentPostType, parentForms ) {
-	// Don't wrap in preview context (block inserter preview is rendered in an iframe)
-	if ( isBlockPreviewContext() ) {
-		return false;
-	}
-
 	// Don't wrap fields when editing a jetpack_form post type directly
 	if ( currentPostType === FORM_POST_TYPE ) {
 		return false;
@@ -107,16 +86,14 @@ export function shouldWrapFieldInForm( currentPostType, parentForms ) {
 }
 
 /**
- * Determines if a synced form should be created.
  *
- * @param {boolean} isCentralFormManagementEnabled - Whether the feature flag is enabled.
- * @param {boolean} wasBlockJustInserted           - Whether the block was just inserted.
- * @return {boolean} Whether a synced form should be created.
+ * Custom hook to wrap a field block in a form block when conditions are met.
+ *
+ * @param {*}      param0            - The parameters object.
+ * @param {object} param0.attributes - The block attributes.
+ * @param {string} param0.clientId   - The block client ID.
+ * @param {string} param0.name       - The block name.
  */
-export function shouldCreateSyncedForm( isCentralFormManagementEnabled, wasBlockJustInserted ) {
-	return isCentralFormManagementEnabled && wasBlockJustInserted;
-}
-
 export default function useFormWrapper( { attributes, clientId, name } ) {
 	const { replaceBlock, updateBlockAttributes, __unstableMarkNextChangeAsNotPersistent } =
 		useDispatch( blockEditorStore );
@@ -169,7 +146,7 @@ export default function useFormWrapper( { attributes, clientId, name } ) {
 		replaceBlock( clientId, formBlock );
 
 		// Convert to synced form (async) - only if conditions are met
-		if ( shouldCreateSyncedForm( isCentralFormManagementEnabled, wasBlockJustInserted ) ) {
+		if ( isCentralFormManagementEnabled && wasBlockJustInserted ) {
 			convertFormToSynced(
 				formBlock,
 				fieldBlock,

--- a/projects/packages/forms/tests/js/blocks/shared/hooks/use-form-wrapper.test.js
+++ b/projects/packages/forms/tests/js/blocks/shared/hooks/use-form-wrapper.test.js
@@ -1,10 +1,18 @@
 import {
 	shouldWrapFieldInForm,
 	shouldCreateSyncedForm,
+	isBlockPreviewContext,
 } from '../../../../../src/blocks/shared/hooks/use-form-wrapper.js';
 import { FORM_POST_TYPE } from '../../../../../src/blocks/shared/util/constants.js';
 
 describe( 'use-form-wrapper helpers', () => {
+	describe( 'isBlockPreviewContext', () => {
+		it( 'should return false when not in iframe (Jest default environment)', () => {
+			// In Jest/jsdom, window.self === window.top by default (not in iframe)
+			expect( isBlockPreviewContext() ).toBe( false );
+		} );
+	} );
+
 	describe( 'shouldWrapFieldInForm', () => {
 		it( 'should return false when editing a jetpack_form post type', () => {
 			expect( shouldWrapFieldInForm( FORM_POST_TYPE, [] ) ).toBe( false );

--- a/projects/packages/forms/tests/js/blocks/shared/hooks/use-form-wrapper.test.js
+++ b/projects/packages/forms/tests/js/blocks/shared/hooks/use-form-wrapper.test.js
@@ -1,18 +1,7 @@
-import {
-	shouldWrapFieldInForm,
-	shouldCreateSyncedForm,
-	isBlockPreviewContext,
-} from '../../../../../src/blocks/shared/hooks/use-form-wrapper.js';
+import { shouldWrapFieldInForm } from '../../../../../src/blocks/shared/hooks/use-form-wrapper.js';
 import { FORM_POST_TYPE } from '../../../../../src/blocks/shared/util/constants.js';
 
 describe( 'use-form-wrapper helpers', () => {
-	describe( 'isBlockPreviewContext', () => {
-		it( 'should return false when not in iframe (Jest default environment)', () => {
-			// In Jest/jsdom, window.self === window.top by default (not in iframe)
-			expect( isBlockPreviewContext() ).toBe( false );
-		} );
-	} );
-
 	describe( 'shouldWrapFieldInForm', () => {
 		it( 'should return false when editing a jetpack_form post type', () => {
 			expect( shouldWrapFieldInForm( FORM_POST_TYPE, [] ) ).toBe( false );
@@ -26,34 +15,12 @@ describe( 'use-form-wrapper helpers', () => {
 			expect( shouldWrapFieldInForm( 'post', [] ) ).toBe( true );
 		} );
 
-		it( 'should return true when editing a page with no parent form', () => {
-			expect( shouldWrapFieldInForm( 'page', [] ) ).toBe( true );
-		} );
-
 		it( 'should handle undefined parentForms', () => {
 			expect( shouldWrapFieldInForm( 'post', undefined ) ).toBe( true );
 		} );
 
 		it( 'should handle null parentForms', () => {
 			expect( shouldWrapFieldInForm( 'post', null ) ).toBe( true );
-		} );
-	} );
-
-	describe( 'shouldCreateSyncedForm', () => {
-		it( 'should return true when feature flag is enabled and block was just inserted', () => {
-			expect( shouldCreateSyncedForm( true, true ) ).toBe( true );
-		} );
-
-		it( 'should return false when feature flag is disabled', () => {
-			expect( shouldCreateSyncedForm( false, true ) ).toBe( false );
-		} );
-
-		it( 'should return false when block was not just inserted (e.g., preview)', () => {
-			expect( shouldCreateSyncedForm( true, false ) ).toBe( false );
-		} );
-
-		it( 'should return false when both conditions are false', () => {
-			expect( shouldCreateSyncedForm( false, false ) ).toBe( false );
 		} );
 	} );
 } );

--- a/projects/packages/forms/tests/js/blocks/shared/hooks/use-form-wrapper.test.js
+++ b/projects/packages/forms/tests/js/blocks/shared/hooks/use-form-wrapper.test.js
@@ -1,0 +1,51 @@
+import {
+	shouldWrapFieldInForm,
+	shouldCreateSyncedForm,
+} from '../../../../../src/blocks/shared/hooks/use-form-wrapper.js';
+import { FORM_POST_TYPE } from '../../../../../src/blocks/shared/util/constants.js';
+
+describe( 'use-form-wrapper helpers', () => {
+	describe( 'shouldWrapFieldInForm', () => {
+		it( 'should return false when editing a jetpack_form post type', () => {
+			expect( shouldWrapFieldInForm( FORM_POST_TYPE, [] ) ).toBe( false );
+		} );
+
+		it( 'should return false when field has parent forms', () => {
+			expect( shouldWrapFieldInForm( 'post', [ 'parent-form-id' ] ) ).toBe( false );
+		} );
+
+		it( 'should return true when editing a regular post with no parent form', () => {
+			expect( shouldWrapFieldInForm( 'post', [] ) ).toBe( true );
+		} );
+
+		it( 'should return true when editing a page with no parent form', () => {
+			expect( shouldWrapFieldInForm( 'page', [] ) ).toBe( true );
+		} );
+
+		it( 'should handle undefined parentForms', () => {
+			expect( shouldWrapFieldInForm( 'post', undefined ) ).toBe( true );
+		} );
+
+		it( 'should handle null parentForms', () => {
+			expect( shouldWrapFieldInForm( 'post', null ) ).toBe( true );
+		} );
+	} );
+
+	describe( 'shouldCreateSyncedForm', () => {
+		it( 'should return true when feature flag is enabled and block was just inserted', () => {
+			expect( shouldCreateSyncedForm( true, true ) ).toBe( true );
+		} );
+
+		it( 'should return false when feature flag is disabled', () => {
+			expect( shouldCreateSyncedForm( false, true ) ).toBe( false );
+		} );
+
+		it( 'should return false when block was not just inserted (e.g., preview)', () => {
+			expect( shouldCreateSyncedForm( true, false ) ).toBe( false );
+		} );
+
+		it( 'should return false when both conditions are false', () => {
+			expect( shouldCreateSyncedForm( false, false ) ).toBe( false );
+		} );
+	} );
+} );


### PR DESCRIPTION
## Proposed changes:

* Prevent creating `jetpack_form` posts when previewing form field blocks in the block inserter
* Skip form wrapping entirely when editing a `jetpack_form` post type directly (fields should remain unwrapped in that context)
* Refactor `useFormWrapper` hook by extracting helper functions for better testability:
  - `shouldWrapFieldInForm()` - determines if a field needs form wrapping
  - `shouldCreateSyncedForm()` - determines if a synced form post should be created
  - `createFormBlockStructure()` - creates the form/field/button block structure
  - `convertFormToSynced()` - handles async conversion to synced form
* Add unit tests for the helper predicates

In the form editor the previews now don't show the submit button any more.
Before:

<img width="714" height="333" alt="Screenshot 2026-02-03 at 11 19 32 AM" src="https://github.com/user-attachments/assets/2a4d337c-2bb8-40d9-9552-db9b13eeb9ba" />

After:

<img width="640" height="277" alt="Screenshot 2026-02-03 at 11 19 56 AM" src="https://github.com/user-attachments/assets/9f540ccf-0fbb-42ea-9f1b-e3cc9b60332f" />


### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
N/A

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

Enable Central Form Management. 

```
add_filter( 'jetpack_block_editor_feature_flags', 'eb_register_feature' );

function eb_register_feature( $flags ) {
    $flags['central-form-management'] = true;
    return $flags;
}
```


### Test 1: Preview doesn't create synced forms
1. Open a post or page in the block editor
2. Open the block inserter and hover over a form field block (e.g., Email field)
3. Observe the preview - the field should be wrapped in a form visually
4. Check the database or network requests - no new `jetpack_form` post should be created during preview
5. Actually insert the field block
6. Verify the field is wrapped in a form AND a synced `jetpack_form` post is created (if central form management is enabled)

### Test 2: Fields in jetpack_form editor
1. Navigate to Forms > All Forms in the admin
2. Edit an existing form (or create a new one)
3. Add a form field block (e.g., Text field)
4. Verify the field is inserted WITHOUT being wrapped in another form block