### PR TITLE
Forms: update tab counts in wp-build dashboard

### DIFF
--- a/projects/packages/forms/changelog/update-wpbuild-forms-udpate-counts
+++ b/projects/packages/forms/changelog/update-wpbuild-forms-udpate-counts
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Dashboard: update header tab counts.

--- a/projects/packages/forms/routes/forms/route.tsx
+++ b/projects/packages/forms/routes/forms/route.tsx
@@ -1,0 +1,31 @@
+/**
+ * WordPress dependencies
+ */
+import { resolveSelect } from '@wordpress/data';
+/**
+ * Internal dependencies
+ */
+import { STORE_NAME as FORM_RESPONSES_STORE_NAME } from '../../src/dashboard/store/index.js';
+
+const NON_TRASH_FORM_STATUSES = 'publish,draft,pending,future,private';
+
+export const route = {
+	/**
+	 * Preload data before the route renders.
+	 */
+	loader: async () => {
+		// Preload global inbox/spam/trash counts (used by the top header tabs).
+		await resolveSelect( FORM_RESPONSES_STORE_NAME ).getCounts();
+
+		// Preload global non-trash forms count (used by the top header tabs).
+		await resolveSelect( 'core' ).getEntityRecords( 'postType', 'jetpack_form', {
+			context: 'edit',
+			jetpack_forms_context: 'dashboard',
+			order: 'desc',
+			orderby: 'modified',
+			page: 1,
+			per_page: 1,
+			status: NON_TRASH_FORM_STATUSES,
+		} );
+	},
+};

--- a/projects/packages/forms/routes/forms/route.tsx
+++ b/projects/packages/forms/routes/forms/route.tsx
@@ -1,31 +1,16 @@
 /**
  * WordPress dependencies
  */
-import { resolveSelect } from '@wordpress/data';
 /**
  * Internal dependencies
  */
-import { STORE_NAME as FORM_RESPONSES_STORE_NAME } from '../../src/dashboard/store/index.js';
-
-const NON_TRASH_FORM_STATUSES = 'publish,draft,pending,future,private';
+import { preloadGlobalTabCounts } from '../../src/dashboard/wp-build/utils/preload';
 
 export const route = {
 	/**
 	 * Preload data before the route renders.
 	 */
 	loader: async () => {
-		// Preload global inbox/spam/trash counts (used by the top header tabs).
-		await resolveSelect( FORM_RESPONSES_STORE_NAME ).getCounts();
-
-		// Preload global non-trash forms count (used by the top header tabs).
-		await resolveSelect( 'core' ).getEntityRecords( 'postType', 'jetpack_form', {
-			context: 'edit',
-			jetpack_forms_context: 'dashboard',
-			order: 'desc',
-			orderby: 'modified',
-			page: 1,
-			per_page: 1,
-			status: NON_TRASH_FORM_STATUSES,
-		} );
+		await preloadGlobalTabCounts();
 	},
 };

--- a/projects/packages/forms/routes/forms/route.tsx
+++ b/projects/packages/forms/routes/forms/route.tsx
@@ -1,7 +1,4 @@
 /**
- * WordPress dependencies
- */
-/**
  * Internal dependencies
  */
 import { preloadGlobalTabCounts } from '../../src/dashboard/wp-build/utils/preload';

--- a/projects/packages/forms/routes/forms/stage.tsx
+++ b/projects/packages/forms/routes/forms/stage.tsx
@@ -1,5 +1,5 @@
 /**
- * WordPress dependencies
+ * External dependencies
  */
 import { Page } from '@wordpress/admin-ui';
 import { __experimentalConfirmDialog as ConfirmDialog } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis

--- a/projects/packages/forms/routes/forms/stage.tsx
+++ b/projects/packages/forms/routes/forms/stage.tsx
@@ -16,6 +16,7 @@ import * as React from 'react';
 import IntegrationsModal from '../../src/blocks/contact-form/components/jetpack-integrations-modal';
 import CreateFormButton from '../../src/dashboard/components/create-form-button/index.tsx';
 import { EmptyWrapper } from '../../src/dashboard/components/empty-responses/index.tsx';
+import { NON_TRASH_FORM_STATUSES } from '../../src/dashboard/constants';
 import useDeleteForm from '../../src/dashboard/hooks/use-delete-form.ts';
 import useFormsData from '../../src/dashboard/hooks/use-forms-data.ts';
 import DataViewsHeaderRow from '../../src/dashboard/wp-build/components/dataviews-header-row';
@@ -81,10 +82,8 @@ function StageInner() {
 		const statusFilterValue = view.filters?.find( filter => filter.field === 'status' )?.value;
 
 		// Default: show all non-trash forms (matches WP core list behavior).
-		const nonTrashStatuses = 'publish,draft,pending,future,private';
-
 		if ( ! statusFilterValue || statusFilterValue === 'all' ) {
-			return nonTrashStatuses;
+			return NON_TRASH_FORM_STATUSES;
 		}
 
 		return statusFilterValue as string;

--- a/projects/packages/forms/routes/responses/route.tsx
+++ b/projects/packages/forms/routes/responses/route.tsx
@@ -5,9 +5,7 @@ import { resolveSelect } from '@wordpress/data';
 /**
  * Internal dependencies
  */
-import { STORE_NAME as FORM_RESPONSES_STORE_NAME } from '../../src/dashboard/store/index.js';
-
-const NON_TRASH_FORM_STATUSES = 'publish,draft,pending,future,private';
+import { preloadGlobalTabCounts } from '../../src/dashboard/wp-build/utils/preload';
 
 export const route = {
 	/**
@@ -55,19 +53,8 @@ export const route = {
 			order: 'desc',
 		} );
 
-		// Preload global inbox/spam/trash counts (used by the top header tabs).
-		await resolveSelect( FORM_RESPONSES_STORE_NAME ).getCounts();
-
-		// Preload global non-trash forms count (used by the top header tabs).
-		await resolveSelect( 'core' ).getEntityRecords( 'postType', 'jetpack_form', {
-			context: 'edit',
-			jetpack_forms_context: 'dashboard',
-			order: 'desc',
-			orderby: 'modified',
-			page: 1,
-			per_page: 1,
-			status: NON_TRASH_FORM_STATUSES,
-		} );
+		// Preload global header tab counts.
+		await preloadGlobalTabCounts();
 	},
 
 	/**

--- a/projects/packages/forms/routes/responses/route.tsx
+++ b/projects/packages/forms/routes/responses/route.tsx
@@ -2,6 +2,12 @@
  * WordPress dependencies
  */
 import { resolveSelect } from '@wordpress/data';
+/**
+ * Internal dependencies
+ */
+import { STORE_NAME as FORM_RESPONSES_STORE_NAME } from '../../src/dashboard/store/index.js';
+
+const NON_TRASH_FORM_STATUSES = 'publish,draft,pending,future,private';
 
 export const route = {
 	/**
@@ -47,6 +53,20 @@ export const route = {
 			status,
 			orderby: 'date',
 			order: 'desc',
+		} );
+
+		// Preload global inbox/spam/trash counts (used by the top header tabs).
+		await resolveSelect( FORM_RESPONSES_STORE_NAME ).getCounts();
+
+		// Preload global non-trash forms count (used by the top header tabs).
+		await resolveSelect( 'core' ).getEntityRecords( 'postType', 'jetpack_form', {
+			context: 'edit',
+			jetpack_forms_context: 'dashboard',
+			order: 'desc',
+			orderby: 'modified',
+			page: 1,
+			per_page: 1,
+			status: NON_TRASH_FORM_STATUSES,
 		} );
 	},
 

--- a/projects/packages/forms/routes/responses/stage.tsx
+++ b/projects/packages/forms/routes/responses/stage.tsx
@@ -3,7 +3,6 @@
  */
 import { formatNumber } from '@automattic/number-formatters';
 import { Badge } from '@automattic/ui';
-import '@automattic/ui/style.css';
 /**
  * WordPress dependencies
  */

--- a/projects/packages/forms/src/dashboard/constants.ts
+++ b/projects/packages/forms/src/dashboard/constants.ts
@@ -1,0 +1,10 @@
+/**
+ * Shared dashboard constants (JS/TS).
+ */
+
+/**
+ * Non-trash form statuses (matches WP core list behavior).
+ *
+ * Used for global counts and default "All" filters where trash should be excluded.
+ */
+export const NON_TRASH_FORM_STATUSES = 'publish,draft,pending,future,private';

--- a/projects/packages/forms/src/dashboard/forms/index.tsx
+++ b/projects/packages/forms/src/dashboard/forms/index.tsx
@@ -16,6 +16,7 @@ import CreateFormButton from '../components/create-form-button/index.tsx';
 import DataViewsHeaderRow from '../components/dataviews-header-row/index.tsx';
 import { EmptyWrapper } from '../components/empty-responses/index.tsx';
 import Page from '../components/page/index.tsx';
+import { NON_TRASH_FORM_STATUSES } from '../constants.ts';
 import useDeleteForm from '../hooks/use-delete-form.ts';
 import useFormsData from '../hooks/use-forms-data.ts';
 import { defaultLayouts, useView } from './views.ts';
@@ -40,14 +41,12 @@ export default function FormsDashboardForms(): JSX.Element | null {
 		const statusFilterValue = view.filters?.find( filter => filter.field === 'status' )?.value;
 
 		// Default: show all non-trash forms (matches WP core list behavior).
-		const nonTrashStatuses = 'publish,draft,pending,future,private';
-
 		if ( ! statusFilterValue ) {
-			return nonTrashStatuses;
+			return NON_TRASH_FORM_STATUSES;
 		}
 
 		if ( statusFilterValue === 'all' ) {
-			return nonTrashStatuses;
+			return NON_TRASH_FORM_STATUSES;
 		}
 
 		return statusFilterValue;

--- a/projects/packages/forms/src/dashboard/store/index.js
+++ b/projects/packages/forms/src/dashboard/store/index.js
@@ -5,7 +5,7 @@ import reducer from './reducer.js';
 import * as resolvers from './resolvers.js';
 import * as selectors from './selectors.js';
 
-const STORE_NAME = 'FORM_RESPONSES';
+export const STORE_NAME = 'FORM_RESPONSES';
 
 export const store = createReduxStore( STORE_NAME, {
 	actions,

--- a/projects/packages/forms/src/dashboard/wp-build/components/dataviews-header-row/index.tsx
+++ b/projects/packages/forms/src/dashboard/wp-build/components/dataviews-header-row/index.tsx
@@ -16,6 +16,7 @@ import { Stack } from '@wordpress/ui';
  * Internal dependencies
  */
 import * as Tabs from '../../../components/tabs';
+import { NON_TRASH_FORM_STATUSES } from '../../../constants.ts';
 import useFormsData from '../../../hooks/use-forms-data.ts';
 import { store as dashboardStore } from '../../../store/index.js';
 import InboxStatusToggle from '../inbox-status-toggle';
@@ -31,8 +32,6 @@ type DataViewsHeaderRowProps = {
 	statusCounts?: { inbox: number; spam: number; trash: number };
 	onStatusChange?: ( nextStatus: StatusTab ) => void;
 };
-
-const NON_TRASH_FORM_STATUSES = 'publish,draft,pending,future,private';
 
 /**
  * Shared wp-build DataViews header row:

--- a/projects/packages/forms/src/dashboard/wp-build/components/dataviews-header-row/index.tsx
+++ b/projects/packages/forms/src/dashboard/wp-build/components/dataviews-header-row/index.tsx
@@ -1,6 +1,12 @@
 /**
+ * External dependencies
+ */
+import { formatNumberCompact } from '@automattic/number-formatters';
+import { Badge } from '@automattic/ui';
+/**
  * WordPress dependencies
  */
+import { useSelect } from '@wordpress/data';
 import { DataViews } from '@wordpress/dataviews';
 import { useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -10,6 +16,8 @@ import { Stack } from '@wordpress/ui';
  * Internal dependencies
  */
 import * as Tabs from '../../../components/tabs';
+import useFormsData from '../../../hooks/use-forms-data.ts';
+import { store as dashboardStore } from '../../../store/index.js';
 import InboxStatusToggle from '../inbox-status-toggle';
 import './style.scss';
 
@@ -23,6 +31,8 @@ type DataViewsHeaderRowProps = {
 	statusCounts?: { inbox: number; spam: number; trash: number };
 	onStatusChange?: ( nextStatus: StatusTab ) => void;
 };
+
+const NON_TRASH_FORM_STATUSES = 'publish,draft,pending,future,private';
 
 /**
  * Shared wp-build DataViews header row:
@@ -47,6 +57,13 @@ export default function DataViewsHeaderRow( {
 	onStatusChange,
 }: DataViewsHeaderRowProps ): JSX.Element {
 	const navigate = useNavigate();
+	const { totalItems: formsCount = 0 } = useFormsData( 1, 1, '', NON_TRASH_FORM_STATUSES );
+
+	const responsesInboxCount = useSelect( select => {
+		// Trigger resolver if needed.
+		select( dashboardStore ).getCounts();
+		return select( dashboardStore ).getInboxCount() ?? 0;
+	}, [] );
 
 	const onTabChange = useCallback(
 		( nextValue: ActiveTab ) => {
@@ -79,8 +96,22 @@ export default function DataViewsHeaderRow( {
 					) : (
 						<Tabs.Root value={ activeTab } onValueChange={ onTabChange }>
 							<Tabs.List density="compact">
-								<Tabs.Tab value="responses">{ __( 'Responses', 'jetpack-forms' ) }</Tabs.Tab>
-								<Tabs.Tab value="forms">{ __( 'Forms', 'jetpack-forms' ) }</Tabs.Tab>
+								<Tabs.Tab value="responses">
+									<span>
+										{ __( 'Responses', 'jetpack-forms' ) }
+										<Badge intent="default" className="jp-forms-count-badge">
+											{ formatNumberCompact( responsesInboxCount || 0 ) }
+										</Badge>
+									</span>
+								</Tabs.Tab>
+								<Tabs.Tab value="forms">
+									<span>
+										{ __( 'Forms', 'jetpack-forms' ) }
+										<Badge intent="default" className="jp-forms-count-badge">
+											{ formatNumberCompact( formsCount || 0 ) }
+										</Badge>
+									</span>
+								</Tabs.Tab>
 							</Tabs.List>
 						</Tabs.Root>
 					) }

--- a/projects/packages/forms/src/dashboard/wp-build/components/dataviews-header-row/style.scss
+++ b/projects/packages/forms/src/dashboard/wp-build/components/dataviews-header-row/style.scss
@@ -31,3 +31,11 @@
 	padding-block: variables.$grid-unit * 1.5;
 }
 
+// Temporary hard-coded styles for tab count badges in wp-build dashboard.
+.jp-forms-count-badge {
+	background-color: #f0f0f0;
+	color: #2f2f2f;
+	margin-inline-start: 4px;
+	vertical-align: middle;
+}
+

--- a/projects/packages/forms/src/dashboard/wp-build/components/inbox-status-toggle/index.tsx
+++ b/projects/packages/forms/src/dashboard/wp-build/components/inbox-status-toggle/index.tsx
@@ -1,13 +1,10 @@
 /**
- * WordPress dependencies
+ * External dependencies
  */
 import { formatNumberCompact } from '@automattic/number-formatters';
 import { Badge } from '@automattic/ui';
 import { useCallback, useMemo } from '@wordpress/element';
 import { __, _x } from '@wordpress/i18n';
-/**
- * External dependencies
- */
 /**
  * Internal dependencies
  */

--- a/projects/packages/forms/src/dashboard/wp-build/components/inbox-status-toggle/index.tsx
+++ b/projects/packages/forms/src/dashboard/wp-build/components/inbox-status-toggle/index.tsx
@@ -1,8 +1,13 @@
 /**
  * WordPress dependencies
  */
+import { formatNumberCompact } from '@automattic/number-formatters';
+import { Badge } from '@automattic/ui';
 import { useCallback, useMemo } from '@wordpress/element';
-import { __, sprintf } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
+/**
+ * External dependencies
+ */
 /**
  * Internal dependencies
  */
@@ -22,27 +27,28 @@ type Props = {
 	onChange: ( nextStatus: Status ) => void;
 };
 
-const getLabel = ( status: Status, count: number ): string => {
+const getLabel = ( status: Status, count: number ): JSX.Element => {
+	let label: string;
 	switch ( status ) {
 		case 'inbox':
-			return sprintf(
-				/* translators: %d is the number of inbox responses. */
-				__( 'Inbox (%d)', 'jetpack-forms' ),
-				count
-			);
+			label = __( 'Inbox', 'jetpack-forms' );
+			break;
 		case 'spam':
-			return sprintf(
-				/* translators: %d is the number of spam responses. */
-				__( 'Spam (%d)', 'jetpack-forms' ),
-				count
-			);
+			label = __( 'Spam', 'jetpack-forms' );
+			break;
 		case 'trash':
-			return sprintf(
-				/* translators: %d is the number of trash responses. */
-				__( 'Trash (%d)', 'jetpack-forms' ),
-				count
-			);
+			label = _x( 'Trash', 'noun', 'jetpack-forms' );
+			break;
 	}
+
+	return (
+		<span>
+			{ label }
+			<Badge intent="default" className="jp-forms-count-badge">
+				{ formatNumberCompact( count || 0 ) }
+			</Badge>
+		</span>
+	);
 };
 
 /**
@@ -69,7 +75,7 @@ export default function InboxStatusToggle( {
 		[ activeStatus, onChange ]
 	);
 
-	const statusTabs: Array< { value: Status; label: string } > = useMemo(
+	const statusTabs: Array< { value: Status; label: JSX.Element } > = useMemo(
 		() => [
 			{ value: 'inbox', label: getLabel( 'inbox', counts.inbox ) },
 			{ value: 'spam', label: getLabel( 'spam', counts.spam ) },

--- a/projects/packages/forms/src/dashboard/wp-build/utils/preload.ts
+++ b/projects/packages/forms/src/dashboard/wp-build/utils/preload.ts
@@ -1,0 +1,43 @@
+/**
+ * WordPress dependencies
+ */
+import { resolveSelect } from '@wordpress/data';
+/**
+ * Internal dependencies
+ */
+import { NON_TRASH_FORM_STATUSES } from '../../constants.ts';
+import { STORE_NAME as FORM_RESPONSES_STORE_NAME } from '../../store/index.js';
+
+/**
+ * Preload global inbox/spam/trash counts.
+ *
+ * This warms the `FORM_RESPONSES` store cache used by the wp-build header tabs.
+ */
+export async function preloadGlobalInboxCounts(): Promise< void > {
+	await resolveSelect( FORM_RESPONSES_STORE_NAME ).getCounts();
+}
+
+/**
+ * Preload global non-trash forms count.
+ *
+ * This warms the core-data cache so `useFormsData( 1, 1, '', statuses ).totalItems`
+ * can resolve quickly (we only need totals, not records).
+ */
+export async function preloadGlobalNonTrashFormsCount(): Promise< void > {
+	await resolveSelect( 'core' ).getEntityRecords( 'postType', 'jetpack_form', {
+		context: 'edit',
+		jetpack_forms_context: 'dashboard',
+		order: 'desc',
+		orderby: 'modified',
+		page: 1,
+		per_page: 1,
+		status: NON_TRASH_FORM_STATUSES,
+	} );
+}
+
+/**
+ * Preload global data needed for the wp-build "Forms / Responses" header tab counts.
+ */
+export async function preloadGlobalTabCounts(): Promise< void > {
+	await Promise.all( [ preloadGlobalInboxCounts(), preloadGlobalNonTrashFormsCount() ] );
+}


### PR DESCRIPTION
## Proposed changes:

Changes:
* Add counts to the main Forms and Responses tabs for total # of forms and # of inbox responses
* Update the styling of counts from parenthesis to badges for consistency with legacy dashboard
* Preload form and inbox counts so the counts show on the tabs immediately
* We were having a lot of separate files define NON-TRASH FEEDBACK STATUSES, so I following copilot's suggestion, I defined a single const for that and updated all references. That increases the footprint of the PR. 

**Forms: Before**
<img width="1311" height="303" alt="forms-before" src="https://github.com/user-attachments/assets/90668f90-a347-480f-b947-0dd9679bc82d" />

**Forms: After**
<img width="1323" height="308" alt="forms-after" src="https://github.com/user-attachments/assets/5bd906bd-0b74-4010-9987-b6b7e54321fa" />

**Single Form: Before**
<img width="1320" height="260" alt="forms-single-before" src="https://github.com/user-attachments/assets/5cd0716a-46a2-4eb4-b6ef-2773b0a8a751" />

**Single Form: After**
<img width="1320" height="256" alt="single-form-after" src="https://github.com/user-attachments/assets/29a116e0-dc3a-40ad-8778-306aa405a435" />

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Enable these feature flags: 

```
add_filter( 'jetpack_forms_alpha', '__return_true', 20 );
add_filter( 'jetpack_block_editor_feature_flags', 'eb_register_feature' );
function eb_register_feature( $flags ) {
    $flags['central-form-management'] = true;
    return $flags;
}
```

Test:
* Go to Jetpack > Forms (WP-Build)
* Confirm accurate counts immediately load on the Forms and Responses tab.
* Go to Forms, open a specific Form with responses, and confirm the counts on the tabs are styled correctly. 