### PR TITLE
Forms: add form preview functionality

### DIFF
--- a/projects/packages/forms/changelog/add-form-preview
+++ b/projects/packages/forms/changelog/add-form-preview
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Forms: add preview functionality allowing admins to preview forms at a temporary nonce-based URL.

--- a/projects/packages/forms/changelog/add-form-preview
+++ b/projects/packages/forms/changelog/add-form-preview
@@ -1,4 +1,4 @@
 Significance: minor
 Type: added
 
-Forms: add preview functionality allowing admins to preview forms at a temporary nonce-based URL.
+Forms: add preview functionality allowing users with edit permissions to preview forms at a temporary nonce-based URL.

--- a/projects/packages/forms/routes/forms/package.json
+++ b/projects/packages/forms/routes/forms/package.json
@@ -7,6 +7,7 @@
 		"@base-ui-components/react": "^1.0.0-beta.4",
 		"@types/react": "18.3.26",
 		"@wordpress/admin-ui": "1.7.0",
+		"@wordpress/api-fetch": "7.39.0",
 		"@wordpress/components": "32.1.0",
 		"@wordpress/core-data": "7.39.0",
 		"@wordpress/data": "10.39.0",

--- a/projects/packages/forms/routes/forms/stage.tsx
+++ b/projects/packages/forms/routes/forms/stage.tsx
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import { Page } from '@wordpress/admin-ui';
+import apiFetch from '@wordpress/api-fetch';
 import { __experimentalConfirmDialog as ConfirmDialog } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
 import { DataViews } from '@wordpress/dataviews';
 import { dateI18n, getSettings as getDateSettings } from '@wordpress/date';
@@ -235,6 +236,28 @@ function StageInner() {
 					const editUrl = item.editUrl || fallbackEditUrl;
 					const url = new URL( editUrl, window.location.origin );
 					window.location.href = url.toString();
+				},
+			},
+			{
+				id: 'preview-form',
+				isPrimary: false,
+				label: __( 'Preview', 'jetpack-forms' ),
+				supportsBulk: false,
+				async callback( items: FormListItem[] ) {
+					const [ item ] = items;
+					if ( ! item ) {
+						return;
+					}
+
+					try {
+						const response = await apiFetch< { preview_url: string } >( {
+							path: `/wp/v2/jetpack-forms/${ item.id }/preview-url`,
+						} );
+						window.open( response.preview_url, '_blank' );
+					} catch ( error ) {
+						// eslint-disable-next-line no-console
+						console.error( 'Failed to get preview URL:', error );
+					}
 				},
 			},
 		];

--- a/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
+++ b/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
@@ -12,6 +12,7 @@ use Automattic\Jetpack\Blocks;
 use Automattic\Jetpack\Current_Plan;
 use Automattic\Jetpack\Forms\ContactForm\Contact_Form;
 use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin;
+use Automattic\Jetpack\Forms\ContactForm\Form_Preview;
 use Automattic\Jetpack\Forms\Dashboard\Dashboard as Forms_Dashboard;
 use Automattic\Jetpack\Forms\Jetpack_Forms;
 use Automattic\Jetpack\Modules;
@@ -758,11 +759,13 @@ class Contact_Form_Block {
 	 */
 	public static function gutenblock_render_form( $atts, $content ) {
 		// We should not render block if the module is disabled on a site using the Jetpack plugin.
-		if ( class_exists( 'Jetpack' ) && ! ( new Modules() )->is_active( 'contact-form' ) ) {
+		// Exception: allow rendering in preview mode so form previews work.
+		if ( class_exists( 'Jetpack' ) && ! ( new Modules() )->is_active( 'contact-form' ) && ! Form_Preview::is_preview_mode() ) {
 			return '';
 		}
 		// Render fallback in other contexts than frontend (i.e. feed, emails, API, etc.), unless the form is being submitted.
-		if ( ! Request::is_frontend() && ! isset( $_POST['contact-form-id'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing
+		// Exception: allow rendering in preview mode.
+		if ( ! Request::is_frontend() && ! isset( $_POST['contact-form-id'] ) && ! Form_Preview::is_preview_mode() ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing
 			return self::render_fallback( $atts );
 		}
 

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -1558,10 +1558,7 @@ class Contact_Form_Plugin {
 	public function process_form_submission() {
 		// Block submissions in preview mode.
 		if ( Form_Preview::is_preview_mode() ) {
-			return new \WP_Error(
-				'preview_mode',
-				__( 'Form submissions are disabled in preview mode.', 'jetpack-forms' )
-			);
+			return;
 		}
 
 		// Add a filter to replace tokens in the subject field with sanitized field values.

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -31,6 +31,9 @@ use WP_Post;
 // Load the Form_Submission_Error class.
 require_once __DIR__ . '/class-form-submission-error.php';
 
+// Load the Form_Preview class.
+require_once __DIR__ . '/class-form-preview.php';
+
 /**
  * Sets up various actions, filters, post types, post statuses, shortcodes.
  */
@@ -377,6 +380,7 @@ class Contact_Form_Plugin {
 		if ( self::has_editor_feature_flag( 'central-form-management' ) ) {
 			Contact_Form::register_post_type();
 			Form_Editor::init();
+			Form_Preview::init();
 		}
 	}
 
@@ -1552,6 +1556,14 @@ class Contact_Form_Plugin {
 	 * Conditionally attached to `template_redirect`
 	 */
 	public function process_form_submission() {
+		// Block submissions in preview mode.
+		if ( Form_Preview::is_preview_mode() ) {
+			return new \WP_Error(
+				'preview_mode',
+				__( 'Form submissions are disabled in preview mode.', 'jetpack-forms' )
+			);
+		}
+
 		// Add a filter to replace tokens in the subject field with sanitized field values.
 		add_filter( 'contact_form_subject', array( $this, 'replace_tokens_with_input' ), 10, 2 );
 

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -1067,6 +1067,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 				'invalid_form_empty' => __( 'The form you are trying to submit is empty.', 'jetpack-forms' ),
 				'invalid_form'       => __( 'Please fill out the form correctly.', 'jetpack-forms' ),
 				'network_error'      => __( 'Connection issue while submitting the form. Check that you are connected to the Internet and try again.', 'jetpack-forms' ),
+				'preview_mode'       => __( 'Form submissions are disabled in preview mode.', 'jetpack-forms' ),
 			),
 			'admin_ajax_url' => admin_url( 'admin-ajax.php' ),
 		);

--- a/projects/packages/forms/src/contact-form/class-form-preview.php
+++ b/projects/packages/forms/src/contact-form/class-form-preview.php
@@ -320,11 +320,14 @@ class Form_Preview {
 	 * Enqueue preview styles.
 	 */
 	public static function enqueue_preview_styles() {
+		$css_file = __DIR__ . '/css/form-preview.css';
+		$version  = file_exists( $css_file ) ? (string) filemtime( $css_file ) : JETPACK_FORMS_VERSION;
+
 		wp_enqueue_style(
 			'jetpack-form-preview',
 			plugins_url( 'css/form-preview.css', __FILE__ ),
 			array(),
-			filemtime( __DIR__ . '/css/form-preview.css' )
+			$version
 		);
 	}
 

--- a/projects/packages/forms/src/contact-form/class-form-preview.php
+++ b/projects/packages/forms/src/contact-form/class-form-preview.php
@@ -50,6 +50,22 @@ class Form_Preview {
 	public static function init() {
 		add_filter( 'query_vars', array( __CLASS__, 'register_query_vars' ) );
 		add_filter( 'template_include', array( __CLASS__, 'maybe_render_preview' ), 99 );
+		add_filter( 'jetpack_is_frontend', array( __CLASS__, 'filter_is_frontend' ) );
+	}
+
+	/**
+	 * Filter jetpack_is_frontend to return true during preview mode.
+	 *
+	 * This ensures the form block renders properly instead of showing a fallback.
+	 *
+	 * @param bool $is_frontend Whether the current request is for the frontend.
+	 * @return bool True if in preview mode, otherwise the original value.
+	 */
+	public static function filter_is_frontend( $is_frontend ) {
+		if ( self::$is_preview_mode ) {
+			return true;
+		}
+		return $is_frontend;
 	}
 
 	/**
@@ -182,10 +198,15 @@ class Form_Preview {
 		$wp_query->is_home     = false;
 		$wp_query->is_archive  = false;
 		$wp_query->is_category = false;
+		$wp_query->is_404      = false;
+		$wp_query->is_feed     = false;
 
 		// Create a fake post object for the page.
+		// Use the form's ID as the fake post ID to ensure proper form context.
+		// Note: Using 0 as the ID causes issues because '0' is falsy in PHP,
+		// which breaks the form ID validation in Contact_Form::parse().
 		$fake_post                = new \stdClass();
-		$fake_post->ID            = 0;
+		$fake_post->ID            = $form_id;
 		$fake_post->post_author   = get_current_user_id();
 		$fake_post->post_date     = current_time( 'mysql' );
 		$fake_post->post_date_gmt = current_time( 'mysql', 1 );
@@ -194,8 +215,8 @@ class Form_Preview {
 			__( 'Preview: %s', 'jetpack-forms' ),
 			$form->post_title ? $form->post_title : __( 'Untitled Form', 'jetpack-forms' )
 		);
-		$fake_post->post_content  = '';
-		$fake_post->post_status   = 'publish';
+		$fake_post->post_content   = '';
+		$fake_post->post_status    = 'publish';
 		$fake_post->comment_status = 'closed';
 		$fake_post->ping_status    = 'closed';
 		$fake_post->post_name      = 'form-preview';
@@ -203,14 +224,14 @@ class Form_Preview {
 		$fake_post->filter         = 'raw';
 
 		// Set up query vars.
-		$wp_query->post                 = new WP_Post( $fake_post );
-		$wp_query->posts                = array( $wp_query->post );
-		$wp_query->post_count           = 1;
-		$wp_query->found_posts          = 1;
-		$wp_query->max_num_pages        = 1;
-		$wp_query->queried_object       = $wp_query->post;
-		$wp_query->queried_object_id    = 0;
-		$GLOBALS['post']                = $wp_query->post;
+		$wp_query->post              = new WP_Post( $fake_post );
+		$wp_query->posts             = array( $wp_query->post );
+		$wp_query->post_count        = 1;
+		$wp_query->found_posts       = 1;
+		$wp_query->max_num_pages     = 1;
+		$wp_query->queried_object    = $wp_query->post;
+		$wp_query->queried_object_id = $form_id;
+		$GLOBALS['post']             = $wp_query->post; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Necessary to set up fake post context for preview.
 
 		// Enqueue preview styles.
 		add_action( 'wp_enqueue_scripts', array( __CLASS__, 'enqueue_preview_styles' ) );
@@ -219,21 +240,30 @@ class Form_Preview {
 		add_action( 'wp_head', array( __CLASS__, 'add_preview_mode_script' ) );
 
 		// Hook the_content filter to render the form.
-		add_filter( 'the_content', function ( $content ) use ( $form ) {
-			return self::render_form_preview_content( $form );
-		}, 999 );
+		add_filter(
+			'the_content',
+			function ( $_content ) use ( $form ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- We replace the content entirely.
+				return self::render_form_preview_content( $form );
+			},
+			999
+		);
 
 		// Hook the_title filter to show preview title.
-		add_filter( 'the_title', function ( $title, $id = null ) use ( $form, $fake_post ) {
-			if ( $id === 0 || ( isset( $GLOBALS['post'] ) && $GLOBALS['post'] === $fake_post ) ) {
-				return sprintf(
+		add_filter(
+			'the_title',
+			function ( $title, $id = null ) use ( $form, $form_id ) {
+				if ( $id === $form_id || ( isset( $GLOBALS['post'] ) && $GLOBALS['post']->ID === $form_id ) ) {
+					return sprintf(
 					/* translators: %s: Form title */
-					__( 'Preview: %s', 'jetpack-forms' ),
-					$form->post_title ? $form->post_title : __( 'Untitled Form', 'jetpack-forms' )
-				);
-			}
-			return $title;
-		}, 10, 2 );
+						__( 'Preview: %s', 'jetpack-forms' ),
+						$form->post_title ? $form->post_title : __( 'Untitled Form', 'jetpack-forms' )
+					);
+				}
+				return $title;
+			},
+			10,
+			2
+		);
 
 		// Use page template.
 		$page_template = get_page_template();

--- a/projects/packages/forms/src/contact-form/class-form-preview.php
+++ b/projects/packages/forms/src/contact-form/class-form-preview.php
@@ -189,6 +189,13 @@ class Form_Preview {
 			);
 		}
 
+		// Check for autosave and use its content if available.
+		// This ensures the preview shows the latest unsaved changes.
+		$autosave = wp_get_post_autosave( $form_id, get_current_user_id() );
+		if ( $autosave && strtotime( $autosave->post_modified ) > strtotime( $form->post_modified ) ) {
+			$form = $autosave;
+		}
+
 		// Set preview mode flag.
 		self::$is_preview_mode = true;
 

--- a/projects/packages/forms/src/contact-form/class-form-preview.php
+++ b/projects/packages/forms/src/contact-form/class-form-preview.php
@@ -295,6 +295,6 @@ class Form_Preview {
 	 * Add preview mode script variable.
 	 */
 	public static function add_preview_mode_script() {
-		echo '<script>window.jetpackFormsPreviewMode = true;</script>' . "\n";
+		wp_print_inline_script_tag( 'window.jetpackFormsPreviewMode = true;' );
 	}
 }

--- a/projects/packages/forms/src/contact-form/class-form-preview.php
+++ b/projects/packages/forms/src/contact-form/class-form-preview.php
@@ -1,0 +1,300 @@
+<?php
+/**
+ * Form_Preview class.
+ *
+ * Handles form preview functionality for Jetpack Forms.
+ *
+ * @package automattic/jetpack-forms
+ */
+
+namespace Automattic\Jetpack\Forms\ContactForm;
+
+use WP_Post;
+
+/**
+ * Handles form preview rendering with nonce-based authentication.
+ */
+class Form_Preview {
+
+	/**
+	 * The nonce action prefix for form preview.
+	 *
+	 * @var string
+	 */
+	const PREVIEW_NONCE_ACTION = 'jetpack_form_preview_';
+
+	/**
+	 * The query variable for form preview.
+	 *
+	 * @var string
+	 */
+	const PREVIEW_QUERY_VAR = 'jetpack_form_preview';
+
+	/**
+	 * The query variable for preview nonce.
+	 *
+	 * @var string
+	 */
+	const PREVIEW_NONCE_QUERY_VAR = 'preview_nonce';
+
+	/**
+	 * Flag to track if we're in preview mode.
+	 *
+	 * @var bool
+	 */
+	private static $is_preview_mode = false;
+
+	/**
+	 * Initialize the form preview handler.
+	 */
+	public static function init() {
+		add_filter( 'query_vars', array( __CLASS__, 'register_query_vars' ) );
+		add_filter( 'template_include', array( __CLASS__, 'maybe_render_preview' ), 99 );
+	}
+
+	/**
+	 * Register custom query variables.
+	 *
+	 * @param array $vars Existing query variables.
+	 * @return array Modified query variables.
+	 */
+	public static function register_query_vars( $vars ) {
+		$vars[] = self::PREVIEW_QUERY_VAR;
+		$vars[] = self::PREVIEW_NONCE_QUERY_VAR;
+		return $vars;
+	}
+
+	/**
+	 * Check if we're currently in preview mode.
+	 *
+	 * @return bool True if in preview mode, false otherwise.
+	 */
+	public static function is_preview_mode() {
+		return self::$is_preview_mode;
+	}
+
+	/**
+	 * Generate a preview URL for a form.
+	 *
+	 * @param int $form_id The form post ID.
+	 * @return string|null The preview URL, or null if generation fails.
+	 */
+	public static function generate_preview_url( $form_id ) {
+		$form_id = absint( $form_id );
+
+		// Validate form exists.
+		$form = get_post( $form_id );
+		if ( ! $form || Contact_Form::POST_TYPE !== $form->post_type ) {
+			return null;
+		}
+
+		// Check user can edit this form.
+		if ( ! current_user_can( 'edit_post', $form_id ) ) {
+			return null;
+		}
+
+		// Generate nonce for this form.
+		$nonce = wp_create_nonce( self::PREVIEW_NONCE_ACTION . $form_id );
+
+		// Build preview URL.
+		$preview_url = add_query_arg(
+			array(
+				self::PREVIEW_QUERY_VAR       => $form_id,
+				self::PREVIEW_NONCE_QUERY_VAR => $nonce,
+			),
+			home_url( '/' )
+		);
+
+		return $preview_url;
+	}
+
+	/**
+	 * Verify preview access for a form.
+	 *
+	 * @param int    $form_id The form post ID.
+	 * @param string $nonce   The preview nonce.
+	 * @return bool True if access is verified, false otherwise.
+	 */
+	public static function verify_preview_access( $form_id, $nonce ) {
+		// Must be logged in.
+		if ( ! is_user_logged_in() ) {
+			return false;
+		}
+
+		// Must have edit capability for this form.
+		if ( ! current_user_can( 'edit_post', $form_id ) ) {
+			return false;
+		}
+
+		// Verify nonce.
+		if ( ! wp_verify_nonce( $nonce, self::PREVIEW_NONCE_ACTION . $form_id ) ) {
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Maybe render a form preview.
+	 *
+	 * @param string $template The template to include.
+	 * @return string The template to include (potentially modified).
+	 */
+	public static function maybe_render_preview( $template ) {
+		global $wp_query;
+
+		// Get form_id and nonce from query vars.
+		$form_id = get_query_var( self::PREVIEW_QUERY_VAR );
+		$nonce   = get_query_var( self::PREVIEW_NONCE_QUERY_VAR );
+
+		// If not a preview request, return template unchanged.
+		if ( empty( $form_id ) || empty( $nonce ) ) {
+			return $template;
+		}
+
+		$form_id = absint( $form_id );
+
+		// Verify access.
+		if ( ! self::verify_preview_access( $form_id, $nonce ) ) {
+			wp_die(
+				esc_html__( 'You do not have permission to preview this form.', 'jetpack-forms' ),
+				esc_html__( 'Access Denied', 'jetpack-forms' ),
+				array( 'response' => 403 )
+			);
+		}
+
+		// Get the form post.
+		$form = get_post( $form_id );
+		if ( ! $form || Contact_Form::POST_TYPE !== $form->post_type ) {
+			wp_die(
+				esc_html__( 'Form not found.', 'jetpack-forms' ),
+				esc_html__( 'Not Found', 'jetpack-forms' ),
+				array( 'response' => 404 )
+			);
+		}
+
+		// Set preview mode flag.
+		self::$is_preview_mode = true;
+
+		// Set up fake page query context.
+		$wp_query->is_page     = true;
+		$wp_query->is_singular = true;
+		$wp_query->is_home     = false;
+		$wp_query->is_archive  = false;
+		$wp_query->is_category = false;
+
+		// Create a fake post object for the page.
+		$fake_post                = new \stdClass();
+		$fake_post->ID            = 0;
+		$fake_post->post_author   = get_current_user_id();
+		$fake_post->post_date     = current_time( 'mysql' );
+		$fake_post->post_date_gmt = current_time( 'mysql', 1 );
+		$fake_post->post_title    = sprintf(
+			/* translators: %s: Form title */
+			__( 'Preview: %s', 'jetpack-forms' ),
+			$form->post_title ? $form->post_title : __( 'Untitled Form', 'jetpack-forms' )
+		);
+		$fake_post->post_content  = '';
+		$fake_post->post_status   = 'publish';
+		$fake_post->comment_status = 'closed';
+		$fake_post->ping_status    = 'closed';
+		$fake_post->post_name      = 'form-preview';
+		$fake_post->post_type      = 'page';
+		$fake_post->filter         = 'raw';
+
+		// Set up query vars.
+		$wp_query->post                 = new WP_Post( $fake_post );
+		$wp_query->posts                = array( $wp_query->post );
+		$wp_query->post_count           = 1;
+		$wp_query->found_posts          = 1;
+		$wp_query->max_num_pages        = 1;
+		$wp_query->queried_object       = $wp_query->post;
+		$wp_query->queried_object_id    = 0;
+		$GLOBALS['post']                = $wp_query->post;
+
+		// Enqueue preview styles.
+		add_action( 'wp_enqueue_scripts', array( __CLASS__, 'enqueue_preview_styles' ) );
+
+		// Add preview mode script variable.
+		add_action( 'wp_head', array( __CLASS__, 'add_preview_mode_script' ) );
+
+		// Hook the_content filter to render the form.
+		add_filter( 'the_content', function ( $content ) use ( $form ) {
+			return self::render_form_preview_content( $form );
+		}, 999 );
+
+		// Hook the_title filter to show preview title.
+		add_filter( 'the_title', function ( $title, $id = null ) use ( $form, $fake_post ) {
+			if ( $id === 0 || ( isset( $GLOBALS['post'] ) && $GLOBALS['post'] === $fake_post ) ) {
+				return sprintf(
+					/* translators: %s: Form title */
+					__( 'Preview: %s', 'jetpack-forms' ),
+					$form->post_title ? $form->post_title : __( 'Untitled Form', 'jetpack-forms' )
+				);
+			}
+			return $title;
+		}, 10, 2 );
+
+		// Use page template.
+		$page_template = get_page_template();
+		if ( $page_template ) {
+			return $page_template;
+		}
+
+		// Fallback to singular, index, or original template.
+		$singular_template = get_singular_template();
+		if ( $singular_template ) {
+			return $singular_template;
+		}
+
+		$index_template = get_index_template();
+		if ( $index_template ) {
+			return $index_template;
+		}
+
+		return $template;
+	}
+
+	/**
+	 * Render the form preview content.
+	 *
+	 * @param WP_Post $form The form post.
+	 * @return string The rendered content.
+	 */
+	private static function render_form_preview_content( $form ) {
+		$output = '';
+
+		// Add preview banner.
+		$output .= '<div class="jetpack-form-preview-banner">';
+		$output .= esc_html__( 'This is a preview. Form submissions are disabled.', 'jetpack-forms' );
+		$output .= '</div>';
+
+		// Parse and render the form blocks.
+		$blocks = parse_blocks( $form->post_content );
+
+		foreach ( $blocks as $block ) {
+			$output .= render_block( $block );
+		}
+
+		return $output;
+	}
+
+	/**
+	 * Enqueue preview styles.
+	 */
+	public static function enqueue_preview_styles() {
+		wp_enqueue_style(
+			'jetpack-form-preview',
+			plugins_url( 'css/form-preview.css', __FILE__ ),
+			array(),
+			filemtime( __DIR__ . '/css/form-preview.css' )
+		);
+	}
+
+	/**
+	 * Add preview mode script variable.
+	 */
+	public static function add_preview_mode_script() {
+		echo '<script>window.jetpackFormsPreviewMode = true;</script>' . "\n";
+	}
+}

--- a/projects/packages/forms/src/contact-form/class-form-preview.php
+++ b/projects/packages/forms/src/contact-form/class-form-preview.php
@@ -216,7 +216,7 @@ class Form_Preview {
 		$fake_post->ID            = $form_id;
 		$fake_post->post_author   = get_current_user_id();
 		$fake_post->post_date     = current_time( 'mysql' );
-		$fake_post->post_date_gmt = current_time( 'mysql', 1 );
+		$fake_post->post_date_gmt = current_time( 'mysql', true );
 		$fake_post->post_title    = sprintf(
 			/* translators: %s: Form title */
 			__( 'Preview: %s', 'jetpack-forms' ),
@@ -295,10 +295,14 @@ class Form_Preview {
 	/**
 	 * Render the form preview content.
 	 *
-	 * @param WP_Post $form The form post.
+	 * @param WP_Post|null $form The form post.
 	 * @return string The rendered content.
 	 */
-	private static function render_form_preview_content( $form ) {
+	private static function render_form_preview_content( ?WP_Post $form ) {
+		if ( ! $form ) {
+			return '';
+		}
+
 		$output = '';
 
 		// Add preview banner.
@@ -321,7 +325,7 @@ class Form_Preview {
 	 */
 	public static function enqueue_preview_styles() {
 		$css_file = __DIR__ . '/css/form-preview.css';
-		$version  = file_exists( $css_file ) ? (string) filemtime( $css_file ) : JETPACK_FORMS_VERSION;
+		$version  = file_exists( $css_file ) ? (string) filemtime( $css_file ) : \Automattic\Jetpack\Forms\Jetpack_Forms::PACKAGE_VERSION;
 
 		wp_enqueue_style(
 			'jetpack-form-preview',

--- a/projects/packages/forms/src/contact-form/class-jetpack-form-endpoint.php
+++ b/projects/packages/forms/src/contact-form/class-jetpack-form-endpoint.php
@@ -28,6 +28,53 @@ class Jetpack_Form_Endpoint extends \WP_REST_Posts_Controller {
 	}
 
 	/**
+	 * Registers the routes for the objects of the controller.
+	 */
+	public function register_routes() {
+		parent::register_routes();
+
+		// Register custom preview-url route.
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/(?P<id>[\d]+)/preview-url',
+			array(
+				'methods'             => \WP_REST_Server::READABLE,
+				'callback'            => array( $this, 'get_preview_url' ),
+				'permission_callback' => array( $this, 'get_item_permissions_check' ),
+				'args'                => array(
+					'id' => array(
+						'description'       => __( 'Unique identifier for the form.', 'jetpack-forms' ),
+						'type'              => 'integer',
+						'required'          => true,
+						'sanitize_callback' => 'absint',
+					),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Get the preview URL for a form.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return \WP_REST_Response|\WP_Error Response object or WP_Error.
+	 */
+	public function get_preview_url( $request ) {
+		$form_id     = $request->get_param( 'id' );
+		$preview_url = Form_Preview::generate_preview_url( $form_id );
+
+		if ( ! $preview_url ) {
+			return new \WP_Error(
+				'rest_cannot_preview',
+				__( 'Unable to generate preview URL.', 'jetpack-forms' ),
+				array( 'status' => 403 )
+			);
+		}
+
+		return rest_ensure_response( array( 'preview_url' => $preview_url ) );
+	}
+
+	/**
 	 * Add opt-in dashboard fields.
 	 *
 	 * @return array

--- a/projects/packages/forms/src/contact-form/css/form-preview.css
+++ b/projects/packages/forms/src/contact-form/css/form-preview.css
@@ -1,0 +1,10 @@
+.jetpack-form-preview-banner {
+	background-color: #f0f0f1;
+	border: 1px solid #c3c4c7;
+	border-radius: 4px;
+	color: #50575e;
+	font-size: 14px;
+	margin-bottom: 24px;
+	padding: 12px 16px;
+	text-align: center;
+}

--- a/projects/packages/forms/src/contact-form/css/form-preview.css
+++ b/projects/packages/forms/src/contact-form/css/form-preview.css
@@ -4,7 +4,7 @@
 	border-radius: 4px;
 	color: #50575e;
 	font-size: 14px;
-	margin-bottom: 24px;
+	margin-block-end: 24px;
 	padding: 12px 16px;
 	text-align: center;
 }

--- a/projects/packages/forms/src/dashboard/forms/index.tsx
+++ b/projects/packages/forms/src/dashboard/forms/index.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { JetpackLogo } from '@automattic/jetpack-components';
+import apiFetch from '@wordpress/api-fetch';
 import { __experimentalConfirmDialog as ConfirmDialog } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
 import { DataViews } from '@wordpress/dataviews/wp';
 import { dateI18n, getSettings as getDateSettings } from '@wordpress/date';
@@ -210,6 +211,28 @@ export default function FormsDashboardForms(): JSX.Element | null {
 					const editUrl = item.editUrl || fallbackEditUrl;
 					const url = new URL( editUrl, window.location.origin );
 					window.location.href = url.toString();
+				},
+			},
+			{
+				id: 'preview-form',
+				isPrimary: false,
+				label: __( 'Preview', 'jetpack-forms' ),
+				supportsBulk: false,
+				async callback( items: FormListItem[] ) {
+					const [ item ] = items;
+					if ( ! item ) {
+						return;
+					}
+
+					try {
+						const response = await apiFetch< { preview_url: string } >( {
+							path: `/wp/v2/jetpack-forms/${ item.id }/preview-url`,
+						} );
+						window.open( response.preview_url, '_blank' );
+					} catch ( error ) {
+						// eslint-disable-next-line no-console
+						console.error( 'Failed to get preview URL:', error );
+					}
 				},
 			},
 		];

--- a/projects/packages/forms/src/dashboard/forms/index.tsx
+++ b/projects/packages/forms/src/dashboard/forms/index.tsx
@@ -4,10 +4,12 @@
 import { JetpackLogo } from '@automattic/jetpack-components';
 import apiFetch from '@wordpress/api-fetch';
 import { __experimentalConfirmDialog as ConfirmDialog } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
+import { useDispatch } from '@wordpress/data';
 import { DataViews } from '@wordpress/dataviews/wp';
 import { dateI18n, getSettings as getDateSettings } from '@wordpress/date';
 import { useCallback, useEffect, useMemo, useState } from '@wordpress/element';
 import { __, _n, sprintf } from '@wordpress/i18n';
+import { store as noticesStore } from '@wordpress/notices';
 import { useNavigate } from 'react-router';
 /**
  * Internal dependencies
@@ -79,6 +81,8 @@ export default function FormsDashboardForms(): JSX.Element | null {
 		recordsLength: records?.length ?? 0,
 		statusQuery,
 	} );
+
+	const { createErrorNotice } = useDispatch( noticesStore );
 
 	const [ selection, setSelection ] = useState< string[] >( [] );
 	const [ pendingPermanentDeleteCount, setPendingPermanentDeleteCount ] = useState( 0 );
@@ -230,6 +234,10 @@ export default function FormsDashboardForms(): JSX.Element | null {
 						} );
 						window.open( response.preview_url, '_blank' );
 					} catch ( error ) {
+						createErrorNotice(
+							__( 'Failed to generate preview URL. Please try again.', 'jetpack-forms' ),
+							{ type: 'snackbar' }
+						);
 						// eslint-disable-next-line no-console
 						console.error( 'Failed to get preview URL:', error );
 					}
@@ -291,6 +299,7 @@ export default function FormsDashboardForms(): JSX.Element | null {
 
 		return actionsList;
 	}, [
+		createErrorNotice,
 		isDeleting,
 		isViewingTrash,
 		navigate,

--- a/projects/packages/forms/src/form-editor/index.tsx
+++ b/projects/packages/forms/src/form-editor/index.tsx
@@ -422,3 +422,6 @@ const setupFormEditorSubscription = () => {
 };
 
 setupFormEditorSubscription();
+
+// Import plugins
+import './plugins/preview-button';

--- a/projects/packages/forms/src/form-editor/plugins/preview-button.tsx
+++ b/projects/packages/forms/src/form-editor/plugins/preview-button.tsx
@@ -7,6 +7,7 @@ import { PluginPreviewMenuItem } from '@wordpress/editor';
 import { useCallback, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { external } from '@wordpress/icons';
+import { store as noticesStore } from '@wordpress/notices';
 import { registerPlugin } from '@wordpress/plugins';
 /**
  * Internal dependencies
@@ -42,6 +43,7 @@ const FormPreviewMenuItem = () => {
 	} );
 
 	const { autosave } = useDispatch( 'core/editor' );
+	const { createErrorNotice } = useDispatch( noticesStore );
 
 	const handlePreview = useCallback( async () => {
 		if ( isLoading ) {
@@ -60,12 +62,18 @@ const FormPreviewMenuItem = () => {
 			} );
 			window.open( response.preview_url, '_blank' );
 		} catch ( error ) {
+			createErrorNotice(
+				__( 'Failed to generate preview URL. Please try again.', 'jetpack-forms' ),
+				{
+					type: 'snackbar',
+				}
+			);
 			// eslint-disable-next-line no-console
 			console.error( 'Failed to get preview URL:', error );
 		} finally {
 			setIsLoading( false );
 		}
-	}, [ postId, isLoading, isDirty, isAutosaveable, autosave ] );
+	}, [ postId, isLoading, isDirty, isAutosaveable, autosave, createErrorNotice ] );
 
 	// Only show for jetpack_form post type.
 	if ( postType !== FORM_POST_TYPE ) {

--- a/projects/packages/forms/src/form-editor/plugins/preview-button.tsx
+++ b/projects/packages/forms/src/form-editor/plugins/preview-button.tsx
@@ -14,6 +14,9 @@ import { registerPlugin } from '@wordpress/plugins';
  */
 import { FORM_POST_TYPE } from '../../blocks/shared/util/constants.js';
 
+const savingAndOpeningMessage = __( 'Saving & opening', 'jetpack-forms' );
+const previewFormMessage = __( 'Preview form', 'jetpack-forms' );
+
 /**
  * Form Preview Menu Item component.
  *
@@ -87,9 +90,7 @@ const FormPreviewMenuItem = () => {
 
 	return (
 		<PluginPreviewMenuItem icon={ external } onClick={ handlePreview }>
-			{ isLoading
-				? __( 'Saving & opening', 'jetpack-forms' )
-				: __( 'Preview form', 'jetpack-forms' ) }
+			{ isLoading ? savingAndOpeningMessage : previewFormMessage }
 		</PluginPreviewMenuItem>
 	);
 };

--- a/projects/packages/forms/src/form-editor/plugins/preview-button.tsx
+++ b/projects/packages/forms/src/form-editor/plugins/preview-button.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import apiFetch from '@wordpress/api-fetch';
-import { useSelect } from '@wordpress/data';
+import { useSelect, useDispatch } from '@wordpress/data';
 import { PluginPreviewMenuItem } from '@wordpress/editor';
 import { useCallback, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -26,12 +26,22 @@ import { FORM_POST_TYPE } from '../../blocks/shared/util/constants.js';
 const FormPreviewMenuItem = () => {
 	const [ isLoading, setIsLoading ] = useState( false );
 
-	const { postId, postType } = useSelect( select => ( {
-		postId: ( select( 'core/editor' ) as { getCurrentPostId: () => number } ).getCurrentPostId(),
-		postType: (
-			select( 'core/editor' ) as { getCurrentPostType: () => string }
-		 ).getCurrentPostType(),
-	} ) );
+	const { postId, postType, isDirty, isAutosaveable } = useSelect( select => {
+		const editor = select( 'core/editor' ) as {
+			getCurrentPostId: () => number;
+			getCurrentPostType: () => string;
+			isEditedPostDirty: () => boolean;
+			isEditedPostAutosaveable: () => boolean;
+		};
+		return {
+			postId: editor.getCurrentPostId(),
+			postType: editor.getCurrentPostType(),
+			isDirty: editor.isEditedPostDirty(),
+			isAutosaveable: editor.isEditedPostAutosaveable(),
+		};
+	} );
+
+	const { autosave } = useDispatch( 'core/editor' );
 
 	const handlePreview = useCallback( async () => {
 		if ( isLoading ) {
@@ -40,6 +50,11 @@ const FormPreviewMenuItem = () => {
 
 		setIsLoading( true );
 		try {
+			// Autosave if there are unsaved changes.
+			if ( isDirty && isAutosaveable ) {
+				await autosave();
+			}
+
 			const response = await apiFetch< { preview_url: string } >( {
 				path: `/wp/v2/jetpack-forms/${ postId }/preview-url`,
 			} );
@@ -50,7 +65,7 @@ const FormPreviewMenuItem = () => {
 		} finally {
 			setIsLoading( false );
 		}
-	}, [ postId, isLoading ] );
+	}, [ postId, isLoading, isDirty, isAutosaveable, autosave ] );
 
 	// Only show for jetpack_form post type.
 	if ( postType !== FORM_POST_TYPE ) {
@@ -65,7 +80,7 @@ const FormPreviewMenuItem = () => {
 	return (
 		<PluginPreviewMenuItem icon={ external } onClick={ handlePreview }>
 			{ isLoading
-				? __( 'Opening preview…', 'jetpack-forms' )
+				? __( 'Saving & opening…', 'jetpack-forms' )
 				: __( 'Preview form', 'jetpack-forms' ) }
 		</PluginPreviewMenuItem>
 	);

--- a/projects/packages/forms/src/form-editor/plugins/preview-button.tsx
+++ b/projects/packages/forms/src/form-editor/plugins/preview-button.tsx
@@ -88,7 +88,7 @@ const FormPreviewMenuItem = () => {
 	return (
 		<PluginPreviewMenuItem icon={ external } onClick={ handlePreview }>
 			{ isLoading
-				? __( 'Saving & opening…', 'jetpack-forms' )
+				? __( 'Saving & opening', 'jetpack-forms' )
 				: __( 'Preview form', 'jetpack-forms' ) }
 		</PluginPreviewMenuItem>
 	);

--- a/projects/packages/forms/src/form-editor/plugins/preview-button.tsx
+++ b/projects/packages/forms/src/form-editor/plugins/preview-button.tsx
@@ -1,13 +1,13 @@
 /**
  * External dependencies
  */
-import { registerJetpackPlugin } from '@automattic/jetpack-shared-extension-utils';
 import apiFetch from '@wordpress/api-fetch';
 import { useSelect } from '@wordpress/data';
 import { PluginPreviewMenuItem } from '@wordpress/editor';
-import { useCallback } from '@wordpress/element';
+import { useCallback, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { external } from '@wordpress/icons';
+import { registerPlugin } from '@wordpress/plugins';
 /**
  * Internal dependencies
  */
@@ -16,12 +16,16 @@ import { FORM_POST_TYPE } from '../../blocks/shared/util/constants.js';
 /**
  * Form Preview Menu Item component.
  *
- * Adds a "Preview form" item to the editor's Preview dropdown menu.
+ * Adds a "Preview form" item to the editor's preview dropdown menu.
+ * Uses the PluginPreviewMenuItem slot introduced in WordPress 6.7.
  * Only renders when editing a jetpack_form post type.
  *
+ * @see https://make.wordpress.org/core/2024/10/18/extending-the-preview-dropdown-menu-in-wordpress-6-7/
  * @return {JSX.Element|null} The preview menu item or null.
  */
 const FormPreviewMenuItem = () => {
+	const [ isLoading, setIsLoading ] = useState( false );
+
 	const { postId, postType } = useSelect( select => ( {
 		postId: ( select( 'core/editor' ) as { getCurrentPostId: () => number } ).getCurrentPostId(),
 		postType: (
@@ -30,6 +34,11 @@ const FormPreviewMenuItem = () => {
 	} ) );
 
 	const handlePreview = useCallback( async () => {
+		if ( isLoading ) {
+			return;
+		}
+
+		setIsLoading( true );
 		try {
 			const response = await apiFetch< { preview_url: string } >( {
 				path: `/wp/v2/jetpack-forms/${ postId }/preview-url`,
@@ -38,28 +47,31 @@ const FormPreviewMenuItem = () => {
 		} catch ( error ) {
 			// eslint-disable-next-line no-console
 			console.error( 'Failed to get preview URL:', error );
+		} finally {
+			setIsLoading( false );
 		}
-	}, [ postId ] );
+	}, [ postId, isLoading ] );
 
 	// Only show for jetpack_form post type.
 	if ( postType !== FORM_POST_TYPE ) {
 		return null;
 	}
 
-	// PluginPreviewMenuItem adds item to the Preview dropdown in editor header.
-	// Check if PluginPreviewMenuItem exists (it may not be available in all WP versions).
+	// PluginPreviewMenuItem may not be available in older WordPress versions (pre-6.7).
 	if ( ! PluginPreviewMenuItem ) {
 		return null;
 	}
 
 	return (
-		<PluginPreviewMenuItem onClick={ handlePreview } icon={ external }>
-			{ __( 'Preview form', 'jetpack-forms' ) }
+		<PluginPreviewMenuItem icon={ external } onClick={ handlePreview }>
+			{ isLoading
+				? __( 'Opening preview…', 'jetpack-forms' )
+				: __( 'Preview form', 'jetpack-forms' ) }
 		</PluginPreviewMenuItem>
 	);
 };
 
-// Register as a Jetpack plugin.
-registerJetpackPlugin( 'jetpack-form-preview', {
+// Register the preview menu item plugin.
+registerPlugin( 'jetpack-form-preview', {
 	render: FormPreviewMenuItem,
 } );

--- a/projects/packages/forms/src/form-editor/plugins/preview-button.tsx
+++ b/projects/packages/forms/src/form-editor/plugins/preview-button.tsx
@@ -1,0 +1,65 @@
+/**
+ * External dependencies
+ */
+import { registerJetpackPlugin } from '@automattic/jetpack-shared-extension-utils';
+import apiFetch from '@wordpress/api-fetch';
+import { useSelect } from '@wordpress/data';
+import { PluginPreviewMenuItem } from '@wordpress/editor';
+import { useCallback } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { external } from '@wordpress/icons';
+/**
+ * Internal dependencies
+ */
+import { FORM_POST_TYPE } from '../../blocks/shared/util/constants.js';
+
+/**
+ * Form Preview Menu Item component.
+ *
+ * Adds a "Preview form" item to the editor's Preview dropdown menu.
+ * Only renders when editing a jetpack_form post type.
+ *
+ * @return {JSX.Element|null} The preview menu item or null.
+ */
+const FormPreviewMenuItem = () => {
+	const { postId, postType } = useSelect( select => ( {
+		postId: ( select( 'core/editor' ) as { getCurrentPostId: () => number } ).getCurrentPostId(),
+		postType: (
+			select( 'core/editor' ) as { getCurrentPostType: () => string }
+		 ).getCurrentPostType(),
+	} ) );
+
+	const handlePreview = useCallback( async () => {
+		try {
+			const response = await apiFetch< { preview_url: string } >( {
+				path: `/wp/v2/jetpack-forms/${ postId }/preview-url`,
+			} );
+			window.open( response.preview_url, '_blank' );
+		} catch ( error ) {
+			// eslint-disable-next-line no-console
+			console.error( 'Failed to get preview URL:', error );
+		}
+	}, [ postId ] );
+
+	// Only show for jetpack_form post type.
+	if ( postType !== FORM_POST_TYPE ) {
+		return null;
+	}
+
+	// PluginPreviewMenuItem adds item to the Preview dropdown in editor header.
+	// Check if PluginPreviewMenuItem exists (it may not be available in all WP versions).
+	if ( ! PluginPreviewMenuItem ) {
+		return null;
+	}
+
+	return (
+		<PluginPreviewMenuItem onClick={ handlePreview } icon={ external }>
+			{ __( 'Preview form', 'jetpack-forms' ) }
+		</PluginPreviewMenuItem>
+	);
+};
+
+// Register as a Jetpack plugin.
+registerJetpackPlugin( 'jetpack-form-preview', {
+	render: FormPreviewMenuItem,
+} );

--- a/projects/packages/forms/src/modules/form/view.js
+++ b/projects/packages/forms/src/modules/form/view.js
@@ -510,6 +510,24 @@ const { state, actions } = store( NAMESPACE, {
 		onFormSubmit: withSyncEvent( function* ( event ) {
 			const context = getContext();
 
+			// Check if we're in preview mode and block submission.
+			if ( window.jetpackFormsPreviewMode ) {
+				event.preventDefault();
+				event.stopPropagation();
+				context.submissionError =
+					config.error_types?.preview_mode || 'Form submissions are disabled in preview mode.';
+
+				if ( errorTimeout ) {
+					clearTimeout( errorTimeout );
+				}
+
+				errorTimeout = setTimeout( () => {
+					context.submissionError = null;
+				}, 5000 );
+
+				return;
+			}
+
 			if ( ! state.isFormValid ) {
 				context.showErrors = true;
 				event.preventDefault();

--- a/projects/packages/forms/src/modules/form/view.js
+++ b/projects/packages/forms/src/modules/form/view.js
@@ -514,8 +514,7 @@ const { state, actions } = store( NAMESPACE, {
 			if ( window.jetpackFormsPreviewMode ) {
 				event.preventDefault();
 				event.stopPropagation();
-				context.submissionError =
-					config.error_types?.preview_mode || 'Form submissions are disabled in preview mode.';
+				context.submissionError = config.error_types?.preview_mode;
 
 				if ( errorTimeout ) {
 					clearTimeout( errorTimeout );

--- a/projects/packages/forms/tests/php/contact-form/Form_Preview_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Form_Preview_Test.php
@@ -1,0 +1,432 @@
+<?php
+/**
+ * Unit Tests for Automattic\Jetpack\Forms\ContactForm\Form_Preview.
+ *
+ * @package automattic/jetpack-forms
+ */
+
+namespace Automattic\Jetpack\Forms\ContactForm;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use WorDBless\BaseTestCase;
+
+/**
+ * Test class for Form_Preview
+ *
+ * @covers \Automattic\Jetpack\Forms\ContactForm\Form_Preview
+ */
+#[CoversClass( Form_Preview::class )]
+class Form_Preview_Test extends BaseTestCase {
+
+	/**
+	 * The test user ID with editor capabilities.
+	 *
+	 * @var int
+	 */
+	private $editor_user_id;
+
+	/**
+	 * The test user ID with subscriber capabilities (no edit access).
+	 *
+	 * @var int
+	 */
+	private $subscriber_user_id;
+
+	/**
+	 * A test form post ID.
+	 *
+	 * @var int
+	 */
+	private $form_id;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		// Register the jetpack_form post type for testing.
+		if ( ! post_type_exists( Contact_Form::POST_TYPE ) ) {
+			register_post_type(
+				Contact_Form::POST_TYPE,
+				array(
+					'public'       => false,
+					'show_ui'      => true,
+					'supports'     => array( 'title', 'editor' ),
+					'capabilities' => array(
+						'edit_post'          => 'edit_posts',
+						'edit_posts'         => 'edit_posts',
+						'edit_others_posts'  => 'edit_others_posts',
+						'publish_posts'      => 'publish_posts',
+						'read_post'          => 'read',
+						'read_private_posts' => 'read_private_posts',
+						'delete_post'        => 'delete_posts',
+					),
+					'map_meta_cap' => true,
+				)
+			);
+		}
+
+		// Create an editor user who can edit posts.
+		$this->editor_user_id = wp_insert_user(
+			array(
+				'user_login' => 'test_editor',
+				'user_pass'  => 'password',
+				'user_email' => 'editor@example.com',
+				'role'       => 'editor',
+			)
+		);
+
+		// Create a subscriber user who cannot edit posts.
+		$this->subscriber_user_id = wp_insert_user(
+			array(
+				'user_login' => 'test_subscriber',
+				'user_pass'  => 'password',
+				'user_email' => 'subscriber@example.com',
+				'role'       => 'subscriber',
+			)
+		);
+
+		// Create a test form.
+		$this->form_id = wp_insert_post(
+			array(
+				'post_type'    => Contact_Form::POST_TYPE,
+				'post_status'  => 'publish',
+				'post_title'   => 'Test Form',
+				'post_content' => '<!-- wp:jetpack/contact-form --><div class="wp-block-jetpack-contact-form"><!-- wp:jetpack/field-email /--></div><!-- /wp:jetpack/contact-form -->',
+				'post_author'  => $this->editor_user_id,
+			)
+		);
+	}
+
+	/**
+	 * Tear down test fixtures.
+	 */
+	protected function tearDown(): void {
+		parent::tearDown();
+
+		// Clean up users.
+		if ( $this->editor_user_id ) {
+			wp_delete_user( $this->editor_user_id );
+		}
+		if ( $this->subscriber_user_id ) {
+			wp_delete_user( $this->subscriber_user_id );
+		}
+
+		// Clean up form post.
+		if ( $this->form_id ) {
+			wp_delete_post( $this->form_id, true );
+		}
+
+		// Reset current user.
+		wp_set_current_user( 0 );
+
+		// Clean up globals.
+		unset( $_POST, $_GET );
+
+		// Reset preview mode via reflection.
+		$this->reset_preview_mode();
+	}
+
+	/**
+	 * Reset the static preview mode flag via reflection.
+	 */
+	private function reset_preview_mode() {
+		$reflection = new \ReflectionClass( Form_Preview::class );
+		$property   = $reflection->getProperty( 'is_preview_mode' );
+		$property->setAccessible( true );
+		$property->setValue( null, false );
+	}
+
+	/**
+	 * Set the static preview mode flag via reflection.
+	 *
+	 * @param bool $value The value to set.
+	 */
+	private function set_preview_mode( $value ) {
+		$reflection = new \ReflectionClass( Form_Preview::class );
+		$property   = $reflection->getProperty( 'is_preview_mode' );
+		$property->setAccessible( true );
+		$property->setValue( null, $value );
+	}
+
+	/**
+	 * Test that init() registers the required filters.
+	 */
+	public function test_init_registers_filters() {
+		// Remove any existing filters first.
+		remove_all_filters( 'query_vars' );
+		remove_all_filters( 'template_include' );
+		remove_all_filters( 'jetpack_is_frontend' );
+
+		// Call init.
+		Form_Preview::init();
+
+		// Check that filters are registered.
+		$this->assertNotFalse( has_filter( 'query_vars', array( Form_Preview::class, 'register_query_vars' ) ) );
+		$this->assertNotFalse( has_filter( 'template_include', array( Form_Preview::class, 'maybe_render_preview' ) ) );
+		$this->assertNotFalse( has_filter( 'jetpack_is_frontend', array( Form_Preview::class, 'filter_is_frontend' ) ) );
+	}
+
+	/**
+	 * Test that register_query_vars() adds the required query variables.
+	 */
+	public function test_register_query_vars_adds_preview_vars() {
+		$vars = array( 'existing_var' );
+
+		$result = Form_Preview::register_query_vars( $vars );
+
+		$this->assertContains( 'existing_var', $result );
+		$this->assertContains( 'jetpack_form_preview', $result );
+		$this->assertContains( 'preview_nonce', $result );
+	}
+
+	/**
+	 * Test is_preview_mode() returns false by default.
+	 */
+	public function test_is_preview_mode_returns_false_by_default() {
+		$this->reset_preview_mode();
+
+		$this->assertFalse( Form_Preview::is_preview_mode() );
+	}
+
+	/**
+	 * Test is_preview_mode() returns true when set.
+	 */
+	public function test_is_preview_mode_returns_true_when_set() {
+		$this->set_preview_mode( true );
+
+		$this->assertTrue( Form_Preview::is_preview_mode() );
+	}
+
+	/**
+	 * Test generate_preview_url() returns null for non-existent form.
+	 */
+	public function test_generate_preview_url_returns_null_for_nonexistent_form() {
+		wp_set_current_user( $this->editor_user_id );
+
+		$result = Form_Preview::generate_preview_url( 999999 );
+
+		$this->assertNull( $result );
+	}
+
+	/**
+	 * Test generate_preview_url() returns null for wrong post type.
+	 */
+	public function test_generate_preview_url_returns_null_for_wrong_post_type() {
+		wp_set_current_user( $this->editor_user_id );
+
+		// Create a regular post (not a form).
+		$post_id = wp_insert_post(
+			array(
+				'post_type'   => 'post',
+				'post_status' => 'publish',
+				'post_title'  => 'Regular Post',
+			)
+		);
+
+		$result = Form_Preview::generate_preview_url( $post_id );
+
+		$this->assertNull( $result );
+
+		wp_delete_post( $post_id, true );
+	}
+
+	/**
+	 * Test generate_preview_url() returns null for user without edit capability.
+	 */
+	public function test_generate_preview_url_returns_null_for_user_without_capability() {
+		wp_set_current_user( $this->subscriber_user_id );
+
+		$result = Form_Preview::generate_preview_url( $this->form_id );
+
+		$this->assertNull( $result );
+	}
+
+	/**
+	 * Test generate_preview_url() returns valid URL for authorized user.
+	 */
+	public function test_generate_preview_url_returns_valid_url_for_authorized_user() {
+		wp_set_current_user( $this->editor_user_id );
+
+		$result = Form_Preview::generate_preview_url( $this->form_id );
+
+		$this->assertNotNull( $result );
+		$this->assertStringContainsString( 'jetpack_form_preview=' . $this->form_id, $result );
+		$this->assertStringContainsString( 'preview_nonce=', $result );
+	}
+
+	/**
+	 * Test verify_preview_access() returns false for logged-out user.
+	 */
+	public function test_verify_preview_access_returns_false_for_logged_out_user() {
+		wp_set_current_user( 0 );
+
+		$nonce  = wp_create_nonce( 'jetpack_form_preview_' . $this->form_id );
+		$result = Form_Preview::verify_preview_access( $this->form_id, $nonce );
+
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * Test verify_preview_access() returns false for user without capability.
+	 */
+	public function test_verify_preview_access_returns_false_for_user_without_capability() {
+		wp_set_current_user( $this->subscriber_user_id );
+
+		$nonce  = wp_create_nonce( 'jetpack_form_preview_' . $this->form_id );
+		$result = Form_Preview::verify_preview_access( $this->form_id, $nonce );
+
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * Test verify_preview_access() returns false for invalid nonce.
+	 */
+	public function test_verify_preview_access_returns_false_for_invalid_nonce() {
+		wp_set_current_user( $this->editor_user_id );
+
+		$result = Form_Preview::verify_preview_access( $this->form_id, 'invalid_nonce' );
+
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * Test verify_preview_access() returns true for valid access.
+	 */
+	public function test_verify_preview_access_returns_true_for_valid_access() {
+		wp_set_current_user( $this->editor_user_id );
+
+		$nonce  = wp_create_nonce( 'jetpack_form_preview_' . $this->form_id );
+		$result = Form_Preview::verify_preview_access( $this->form_id, $nonce );
+
+		$this->assertTrue( $result );
+	}
+
+	/**
+	 * Test filter_is_frontend() returns original value when not in preview mode.
+	 */
+	public function test_filter_is_frontend_returns_original_when_not_in_preview_mode() {
+		$this->reset_preview_mode();
+
+		$this->assertTrue( Form_Preview::filter_is_frontend( true ) );
+		$this->assertFalse( Form_Preview::filter_is_frontend( false ) );
+	}
+
+	/**
+	 * Test filter_is_frontend() returns true when in preview mode.
+	 */
+	public function test_filter_is_frontend_returns_true_when_in_preview_mode() {
+		$this->set_preview_mode( true );
+
+		$this->assertTrue( Form_Preview::filter_is_frontend( false ) );
+		$this->assertTrue( Form_Preview::filter_is_frontend( true ) );
+	}
+
+	/**
+	 * Test that maybe_render_preview() returns template unchanged when no preview vars.
+	 */
+	public function test_maybe_render_preview_returns_template_when_no_preview_vars() {
+		// Set up query vars without preview parameters.
+		set_query_var( 'jetpack_form_preview', '' );
+		set_query_var( 'preview_nonce', '' );
+
+		$template = '/path/to/template.php';
+		$result   = Form_Preview::maybe_render_preview( $template );
+
+		$this->assertEquals( $template, $result );
+	}
+
+	/**
+	 * Data provider for preview URL generation test.
+	 *
+	 * @return array
+	 */
+	public static function provide_form_ids() {
+		return array(
+			'zero form id'     => array( 0 ),
+			'negative form id' => array( -1 ),
+			'string form id'   => array( 'invalid' ),
+		);
+	}
+
+	/**
+	 * Test generate_preview_url() handles invalid form IDs.
+	 *
+	 * @param mixed $form_id The form ID to test.
+	 * @dataProvider provide_form_ids
+	 */
+	#[DataProvider( 'provide_form_ids' )]
+	public function test_generate_preview_url_handles_invalid_form_ids( $form_id ) {
+		wp_set_current_user( $this->editor_user_id );
+
+		$result = Form_Preview::generate_preview_url( $form_id );
+
+		$this->assertNull( $result );
+	}
+
+	/**
+	 * Test that preview mode affects Contact_Form_Block rendering.
+	 */
+	public function test_preview_mode_allows_form_block_rendering() {
+		// This test verifies the integration between Form_Preview and Contact_Form_Block.
+		$this->set_preview_mode( true );
+
+		// When in preview mode, is_preview_mode should return true.
+		$this->assertTrue( Form_Preview::is_preview_mode() );
+
+		// And filter_is_frontend should return true regardless of input.
+		$this->assertTrue( Form_Preview::filter_is_frontend( false ) );
+	}
+
+	/**
+	 * Test generate_preview_url() with draft form.
+	 */
+	public function test_generate_preview_url_works_with_draft_form() {
+		wp_set_current_user( $this->editor_user_id );
+
+		// Create a draft form.
+		$draft_form_id = wp_insert_post(
+			array(
+				'post_type'    => Contact_Form::POST_TYPE,
+				'post_status'  => 'draft',
+				'post_title'   => 'Draft Form',
+				'post_content' => '<!-- wp:jetpack/contact-form /-->',
+				'post_author'  => $this->editor_user_id,
+			)
+		);
+
+		$result = Form_Preview::generate_preview_url( $draft_form_id );
+
+		$this->assertNotNull( $result );
+		$this->assertStringContainsString( 'jetpack_form_preview=' . $draft_form_id, $result );
+
+		wp_delete_post( $draft_form_id, true );
+	}
+
+	/**
+	 * Test verify_preview_access() works with draft form.
+	 */
+	public function test_verify_preview_access_works_with_draft_form() {
+		wp_set_current_user( $this->editor_user_id );
+
+		// Create a draft form.
+		$draft_form_id = wp_insert_post(
+			array(
+				'post_type'    => Contact_Form::POST_TYPE,
+				'post_status'  => 'draft',
+				'post_title'   => 'Draft Form',
+				'post_content' => '<!-- wp:jetpack/contact-form /-->',
+				'post_author'  => $this->editor_user_id,
+			)
+		);
+
+		$nonce  = wp_create_nonce( 'jetpack_form_preview_' . $draft_form_id );
+		$result = Form_Preview::verify_preview_access( $draft_form_id, $nonce );
+
+		$this->assertTrue( $result );
+
+		wp_delete_post( $draft_form_id, true );
+	}
+}

--- a/projects/packages/forms/tests/php/contact-form/Form_Preview_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Form_Preview_Test.php
@@ -135,7 +135,6 @@ class Form_Preview_Test extends BaseTestCase {
 	private function reset_preview_mode() {
 		$reflection = new \ReflectionClass( Form_Preview::class );
 		$property   = $reflection->getProperty( 'is_preview_mode' );
-		$property->setAccessible( true );
 		$property->setValue( null, false );
 	}
 
@@ -147,7 +146,6 @@ class Form_Preview_Test extends BaseTestCase {
 	private function set_preview_mode( $value ) {
 		$reflection = new \ReflectionClass( Form_Preview::class );
 		$property   = $reflection->getProperty( 'is_preview_mode' );
-		$property->setAccessible( true );
 		$property->setValue( null, $value );
 	}
 

--- a/projects/packages/forms/tests/php/contact-form/Form_Preview_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Form_Preview_Test.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Unit Tests for Automattic\Jetpack\Forms\ContactForm\Form_Preview.
+ * Tests for Form_Preview class.
  *
  * @package automattic/jetpack-forms
  */
@@ -8,11 +8,10 @@
 namespace Automattic\Jetpack\Forms\ContactForm;
 
 use PHPUnit\Framework\Attributes\CoversClass;
-use PHPUnit\Framework\Attributes\DataProvider;
 use WorDBless\BaseTestCase;
 
 /**
- * Test class for Form_Preview
+ * Test class for Form_Preview.
  *
  * @covers \Automattic\Jetpack\Forms\ContactForm\Form_Preview
  */
@@ -20,21 +19,21 @@ use WorDBless\BaseTestCase;
 class Form_Preview_Test extends BaseTestCase {
 
 	/**
-	 * The test user ID with editor capabilities.
+	 * Editor user ID.
 	 *
 	 * @var int
 	 */
-	private $editor_user_id;
+	private $editor_id;
 
 	/**
-	 * The test user ID with subscriber capabilities (no edit access).
+	 * Subscriber user ID.
 	 *
 	 * @var int
 	 */
-	private $subscriber_user_id;
+	private $subscriber_id;
 
 	/**
-	 * A test form post ID.
+	 * Test form ID.
 	 *
 	 * @var int
 	 */
@@ -46,56 +45,45 @@ class Form_Preview_Test extends BaseTestCase {
 	protected function setUp(): void {
 		parent::setUp();
 
-		// Register the jetpack_form post type for testing.
+		// Register the form post type.
 		if ( ! post_type_exists( Contact_Form::POST_TYPE ) ) {
 			register_post_type(
 				Contact_Form::POST_TYPE,
 				array(
 					'public'       => false,
 					'show_ui'      => true,
-					'supports'     => array( 'title', 'editor' ),
-					'capabilities' => array(
-						'edit_post'          => 'edit_posts',
-						'edit_posts'         => 'edit_posts',
-						'edit_others_posts'  => 'edit_others_posts',
-						'publish_posts'      => 'publish_posts',
-						'read_post'          => 'read',
-						'read_private_posts' => 'read_private_posts',
-						'delete_post'        => 'delete_posts',
-					),
 					'map_meta_cap' => true,
 				)
 			);
 		}
 
-		// Create an editor user who can edit posts.
-		$this->editor_user_id = wp_insert_user(
+		// Create test users.
+		$this->editor_id = wp_insert_user(
 			array(
-				'user_login' => 'test_editor',
+				'user_login' => 'test_editor_' . wp_rand(),
 				'user_pass'  => 'password',
-				'user_email' => 'editor@example.com',
+				'user_email' => 'editor_' . wp_rand() . '@test.com',
 				'role'       => 'editor',
 			)
 		);
 
-		// Create a subscriber user who cannot edit posts.
-		$this->subscriber_user_id = wp_insert_user(
+		$this->subscriber_id = wp_insert_user(
 			array(
-				'user_login' => 'test_subscriber',
+				'user_login' => 'test_subscriber_' . wp_rand(),
 				'user_pass'  => 'password',
-				'user_email' => 'subscriber@example.com',
+				'user_email' => 'subscriber_' . wp_rand() . '@test.com',
 				'role'       => 'subscriber',
 			)
 		);
 
-		// Create a test form.
+		// Create test form.
 		$this->form_id = wp_insert_post(
 			array(
 				'post_type'    => Contact_Form::POST_TYPE,
 				'post_status'  => 'publish',
 				'post_title'   => 'Test Form',
-				'post_content' => '<!-- wp:jetpack/contact-form --><div class="wp-block-jetpack-contact-form"><!-- wp:jetpack/field-email /--></div><!-- /wp:jetpack/contact-form -->',
-				'post_author'  => $this->editor_user_id,
+				'post_content' => '<!-- wp:jetpack/contact-form /-->',
+				'post_author'  => $this->editor_id,
 			)
 		);
 	}
@@ -104,118 +92,79 @@ class Form_Preview_Test extends BaseTestCase {
 	 * Tear down test fixtures.
 	 */
 	protected function tearDown(): void {
-		parent::tearDown();
-
-		// Clean up users.
-		if ( $this->editor_user_id ) {
-			wp_delete_user( $this->editor_user_id );
-		}
-		if ( $this->subscriber_user_id ) {
-			wp_delete_user( $this->subscriber_user_id );
-		}
-
-		// Clean up form post.
-		if ( $this->form_id ) {
-			wp_delete_post( $this->form_id, true );
-		}
-
-		// Reset current user.
+		wp_delete_user( $this->editor_id );
+		wp_delete_user( $this->subscriber_id );
+		wp_delete_post( $this->form_id, true );
 		wp_set_current_user( 0 );
 
-		// Clean up globals.
-		unset( $_POST, $_GET );
-
-		// Reset preview mode via reflection.
-		$this->reset_preview_mode();
+		parent::tearDown();
 	}
 
 	/**
-	 * Reset the static preview mode flag via reflection.
+	 * Test init() registers required hooks.
 	 */
-	private function reset_preview_mode() {
-		$reflection = new \ReflectionClass( Form_Preview::class );
-		$property   = $reflection->getProperty( 'is_preview_mode' );
-		$property->setValue( null, false );
-	}
-
-	/**
-	 * Set the static preview mode flag via reflection.
-	 *
-	 * @param bool $value The value to set.
-	 */
-	private function set_preview_mode( $value ) {
-		$reflection = new \ReflectionClass( Form_Preview::class );
-		$property   = $reflection->getProperty( 'is_preview_mode' );
-		$property->setValue( null, $value );
-	}
-
-	/**
-	 * Test that init() registers the required filters.
-	 */
-	public function test_init_registers_filters() {
-		// Remove any existing filters first.
+	public function test_init_registers_hooks() {
 		remove_all_filters( 'query_vars' );
 		remove_all_filters( 'template_include' );
 		remove_all_filters( 'jetpack_is_frontend' );
 
-		// Call init.
 		Form_Preview::init();
 
-		// Check that filters are registered.
 		$this->assertNotFalse( has_filter( 'query_vars', array( Form_Preview::class, 'register_query_vars' ) ) );
 		$this->assertNotFalse( has_filter( 'template_include', array( Form_Preview::class, 'maybe_render_preview' ) ) );
 		$this->assertNotFalse( has_filter( 'jetpack_is_frontend', array( Form_Preview::class, 'filter_is_frontend' ) ) );
 	}
 
 	/**
-	 * Test that register_query_vars() adds the required query variables.
+	 * Test register_query_vars() adds preview query vars.
 	 */
-	public function test_register_query_vars_adds_preview_vars() {
-		$vars = array( 'existing_var' );
-
+	public function test_register_query_vars() {
+		$vars   = array( 'existing' );
 		$result = Form_Preview::register_query_vars( $vars );
 
-		$this->assertContains( 'existing_var', $result );
+		$this->assertContains( 'existing', $result );
 		$this->assertContains( 'jetpack_form_preview', $result );
 		$this->assertContains( 'preview_nonce', $result );
 	}
 
 	/**
-	 * Test is_preview_mode() returns false by default.
+	 * Test generate_preview_url() for authorized editor.
 	 */
-	public function test_is_preview_mode_returns_false_by_default() {
-		$this->reset_preview_mode();
+	public function test_generate_preview_url_for_editor() {
+		wp_set_current_user( $this->editor_id );
 
-		$this->assertFalse( Form_Preview::is_preview_mode() );
+		$url = Form_Preview::generate_preview_url( $this->form_id );
+
+		$this->assertNotNull( $url );
+		$this->assertStringContainsString( 'jetpack_form_preview=' . $this->form_id, $url );
+		$this->assertStringContainsString( 'preview_nonce=', $url );
 	}
 
 	/**
-	 * Test is_preview_mode() returns true when set.
+	 * Test generate_preview_url() returns null for unauthorized user.
 	 */
-	public function test_is_preview_mode_returns_true_when_set() {
-		$this->set_preview_mode( true );
+	public function test_generate_preview_url_unauthorized() {
+		wp_set_current_user( $this->subscriber_id );
 
-		$this->assertTrue( Form_Preview::is_preview_mode() );
+		$this->assertNull( Form_Preview::generate_preview_url( $this->form_id ) );
 	}
 
 	/**
-	 * Test generate_preview_url() returns null for non-existent form.
+	 * Test generate_preview_url() returns null for invalid form.
 	 */
-	public function test_generate_preview_url_returns_null_for_nonexistent_form() {
-		wp_set_current_user( $this->editor_user_id );
+	public function test_generate_preview_url_invalid_form() {
+		wp_set_current_user( $this->editor_id );
 
-		$result = Form_Preview::generate_preview_url( 999999 );
-
-		$this->assertNull( $result );
+		$this->assertNull( Form_Preview::generate_preview_url( 0 ) );
+		$this->assertNull( Form_Preview::generate_preview_url( 999999 ) );
 	}
 
 	/**
 	 * Test generate_preview_url() returns null for wrong post type.
 	 */
-	public function test_generate_preview_url_returns_null_for_wrong_post_type() {
-		wp_set_current_user( $this->editor_user_id );
+	public function test_generate_preview_url_wrong_post_type() {
+		wp_set_current_user( $this->editor_id );
 
-		// Create a regular post (not a form).
 		$post_id = wp_insert_post(
 			array(
 				'post_type'   => 'post',
@@ -224,207 +173,84 @@ class Form_Preview_Test extends BaseTestCase {
 			)
 		);
 
-		$result = Form_Preview::generate_preview_url( $post_id );
-
-		$this->assertNull( $result );
+		$this->assertNull( Form_Preview::generate_preview_url( $post_id ) );
 
 		wp_delete_post( $post_id, true );
 	}
 
 	/**
-	 * Test generate_preview_url() returns null for user without edit capability.
+	 * Test verify_preview_access() for valid access.
 	 */
-	public function test_generate_preview_url_returns_null_for_user_without_capability() {
-		wp_set_current_user( $this->subscriber_user_id );
+	public function test_verify_preview_access_valid() {
+		wp_set_current_user( $this->editor_id );
+		$nonce = wp_create_nonce( 'jetpack_form_preview_' . $this->form_id );
 
-		$result = Form_Preview::generate_preview_url( $this->form_id );
-
-		$this->assertNull( $result );
-	}
-
-	/**
-	 * Test generate_preview_url() returns valid URL for authorized user.
-	 */
-	public function test_generate_preview_url_returns_valid_url_for_authorized_user() {
-		wp_set_current_user( $this->editor_user_id );
-
-		$result = Form_Preview::generate_preview_url( $this->form_id );
-
-		$this->assertNotNull( $result );
-		$this->assertStringContainsString( 'jetpack_form_preview=' . $this->form_id, $result );
-		$this->assertStringContainsString( 'preview_nonce=', $result );
+		$this->assertTrue( Form_Preview::verify_preview_access( $this->form_id, $nonce ) );
 	}
 
 	/**
 	 * Test verify_preview_access() returns false for logged-out user.
 	 */
-	public function test_verify_preview_access_returns_false_for_logged_out_user() {
+	public function test_verify_preview_access_logged_out() {
 		wp_set_current_user( 0 );
+		$nonce = wp_create_nonce( 'jetpack_form_preview_' . $this->form_id );
 
-		$nonce  = wp_create_nonce( 'jetpack_form_preview_' . $this->form_id );
-		$result = Form_Preview::verify_preview_access( $this->form_id, $nonce );
-
-		$this->assertFalse( $result );
+		$this->assertFalse( Form_Preview::verify_preview_access( $this->form_id, $nonce ) );
 	}
 
 	/**
-	 * Test verify_preview_access() returns false for user without capability.
+	 * Test verify_preview_access() returns false for unauthorized user.
 	 */
-	public function test_verify_preview_access_returns_false_for_user_without_capability() {
-		wp_set_current_user( $this->subscriber_user_id );
+	public function test_verify_preview_access_unauthorized() {
+		wp_set_current_user( $this->subscriber_id );
+		$nonce = wp_create_nonce( 'jetpack_form_preview_' . $this->form_id );
 
-		$nonce  = wp_create_nonce( 'jetpack_form_preview_' . $this->form_id );
-		$result = Form_Preview::verify_preview_access( $this->form_id, $nonce );
-
-		$this->assertFalse( $result );
+		$this->assertFalse( Form_Preview::verify_preview_access( $this->form_id, $nonce ) );
 	}
 
 	/**
 	 * Test verify_preview_access() returns false for invalid nonce.
 	 */
-	public function test_verify_preview_access_returns_false_for_invalid_nonce() {
-		wp_set_current_user( $this->editor_user_id );
+	public function test_verify_preview_access_invalid_nonce() {
+		wp_set_current_user( $this->editor_id );
 
-		$result = Form_Preview::verify_preview_access( $this->form_id, 'invalid_nonce' );
-
-		$this->assertFalse( $result );
+		$this->assertFalse( Form_Preview::verify_preview_access( $this->form_id, 'invalid' ) );
 	}
 
 	/**
-	 * Test verify_preview_access() returns true for valid access.
+	 * Test maybe_render_preview() returns template when no preview vars.
 	 */
-	public function test_verify_preview_access_returns_true_for_valid_access() {
-		wp_set_current_user( $this->editor_user_id );
-
-		$nonce  = wp_create_nonce( 'jetpack_form_preview_' . $this->form_id );
-		$result = Form_Preview::verify_preview_access( $this->form_id, $nonce );
-
-		$this->assertTrue( $result );
-	}
-
-	/**
-	 * Test filter_is_frontend() returns original value when not in preview mode.
-	 */
-	public function test_filter_is_frontend_returns_original_when_not_in_preview_mode() {
-		$this->reset_preview_mode();
-
-		$this->assertTrue( Form_Preview::filter_is_frontend( true ) );
-		$this->assertFalse( Form_Preview::filter_is_frontend( false ) );
-	}
-
-	/**
-	 * Test filter_is_frontend() returns true when in preview mode.
-	 */
-	public function test_filter_is_frontend_returns_true_when_in_preview_mode() {
-		$this->set_preview_mode( true );
-
-		$this->assertTrue( Form_Preview::filter_is_frontend( false ) );
-		$this->assertTrue( Form_Preview::filter_is_frontend( true ) );
-	}
-
-	/**
-	 * Test that maybe_render_preview() returns template unchanged when no preview vars.
-	 */
-	public function test_maybe_render_preview_returns_template_when_no_preview_vars() {
-		// Set up query vars without preview parameters.
+	public function test_maybe_render_preview_no_vars() {
 		set_query_var( 'jetpack_form_preview', '' );
 		set_query_var( 'preview_nonce', '' );
 
 		$template = '/path/to/template.php';
-		$result   = Form_Preview::maybe_render_preview( $template );
 
-		$this->assertEquals( $template, $result );
+		$this->assertEquals( $template, Form_Preview::maybe_render_preview( $template ) );
 	}
 
 	/**
-	 * Data provider for preview URL generation test.
-	 *
-	 * @return array
+	 * Test preview works with draft forms.
 	 */
-	public static function provide_form_ids() {
-		return array(
-			'zero form id'     => array( 0 ),
-			'negative form id' => array( -1 ),
-			'string form id'   => array( 'invalid' ),
-		);
-	}
+	public function test_preview_works_with_draft_form() {
+		wp_set_current_user( $this->editor_id );
 
-	/**
-	 * Test generate_preview_url() handles invalid form IDs.
-	 *
-	 * @param mixed $form_id The form ID to test.
-	 * @dataProvider provide_form_ids
-	 */
-	#[DataProvider( 'provide_form_ids' )]
-	public function test_generate_preview_url_handles_invalid_form_ids( $form_id ) {
-		wp_set_current_user( $this->editor_user_id );
-
-		$result = Form_Preview::generate_preview_url( $form_id );
-
-		$this->assertNull( $result );
-	}
-
-	/**
-	 * Test that preview mode affects Contact_Form_Block rendering.
-	 */
-	public function test_preview_mode_allows_form_block_rendering() {
-		// This test verifies the integration between Form_Preview and Contact_Form_Block.
-		$this->set_preview_mode( true );
-
-		// When in preview mode, is_preview_mode should return true.
-		$this->assertTrue( Form_Preview::is_preview_mode() );
-
-		// And filter_is_frontend should return true regardless of input.
-		$this->assertTrue( Form_Preview::filter_is_frontend( false ) );
-	}
-
-	/**
-	 * Test generate_preview_url() with draft form.
-	 */
-	public function test_generate_preview_url_works_with_draft_form() {
-		wp_set_current_user( $this->editor_user_id );
-
-		// Create a draft form.
-		$draft_form_id = wp_insert_post(
+		$draft_id = wp_insert_post(
 			array(
 				'post_type'    => Contact_Form::POST_TYPE,
 				'post_status'  => 'draft',
 				'post_title'   => 'Draft Form',
 				'post_content' => '<!-- wp:jetpack/contact-form /-->',
-				'post_author'  => $this->editor_user_id,
+				'post_author'  => $this->editor_id,
 			)
 		);
 
-		$result = Form_Preview::generate_preview_url( $draft_form_id );
+		$url = Form_Preview::generate_preview_url( $draft_id );
+		$this->assertNotNull( $url );
 
-		$this->assertNotNull( $result );
-		$this->assertStringContainsString( 'jetpack_form_preview=' . $draft_form_id, $result );
+		$nonce = wp_create_nonce( 'jetpack_form_preview_' . $draft_id );
+		$this->assertTrue( Form_Preview::verify_preview_access( $draft_id, $nonce ) );
 
-		wp_delete_post( $draft_form_id, true );
-	}
-
-	/**
-	 * Test verify_preview_access() works with draft form.
-	 */
-	public function test_verify_preview_access_works_with_draft_form() {
-		wp_set_current_user( $this->editor_user_id );
-
-		// Create a draft form.
-		$draft_form_id = wp_insert_post(
-			array(
-				'post_type'    => Contact_Form::POST_TYPE,
-				'post_status'  => 'draft',
-				'post_title'   => 'Draft Form',
-				'post_content' => '<!-- wp:jetpack/contact-form /-->',
-				'post_author'  => $this->editor_user_id,
-			)
-		);
-
-		$nonce  = wp_create_nonce( 'jetpack_form_preview_' . $draft_form_id );
-		$result = Form_Preview::verify_preview_access( $draft_form_id, $nonce );
-
-		$this->assertTrue( $result );
-
-		wp_delete_post( $draft_form_id, true );
+		wp_delete_post( $draft_id, true );
 	}
 }


### PR DESCRIPTION

Screen recording

https://github.com/user-attachments/assets/49280a8b-1f7c-420d-abfe-670ca7f3281a


## Proposed changes:

* Add form preview functionality allowing admins/editors to preview Jetpack Forms at a temporary nonce-based URL
* Forms render within the site's page template with a preview banner indicating submission is disabled
* Preview URLs use nonce-based authentication that expires after 24 hours
* Form submissions are blocked in preview mode (both PHP and JS-side)

### Implementation details:

* New `Form_Preview` class handles preview rendering via `template_include` filter
* New REST endpoint `/wp/v2/jetpack-forms/{id}/preview-url` generates preview URLs
* Preview action added to forms dashboard list (DataViews actions menu)
* Preview menu item added to form editor (via `PluginPreviewMenuItem`)
* Preview styles added for the preview banner

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

**Prerequisites:** Enable the `central-form-management` feature flag.

### Test preview from Forms Dashboard:
1. Go to Jetpack → Forms in the admin sidebar
2. Create a new form or select an existing form
3. Click the actions menu (three dots) on a form row
4. Click "Preview"
5. Verify the form opens in a new tab with:
   - A banner saying "This is a preview. Form submissions are disabled."
   - The form rendered within the site's page template
6. Try to submit the form
7. Verify an error message appears indicating submissions are disabled in preview mode

### Test preview from Form Editor:
1. Edit a form in the form editor
2. Click the "Preview" dropdown in the editor header
3. Select "Preview form"
4. Verify the same preview behavior as above

### Test security:
1. Copy a preview URL
2. Log out of WordPress
3. Try to access the preview URL
4. Verify access is denied (403 error)
5. Log in as a user without edit capabilities
6. Verify the preview URL still shows access denied
