### PR TITLE
Forms: Replace jetpack/button with core/button in multi-step navigation

### DIFF
--- a/projects/packages/forms/changelog/update-multistep-core-button
+++ b/projects/packages/forms/changelog/update-multistep-core-button
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Multi-step Forms: Replace jetpack/button with core/button for navigation buttons, with backwards compatibility for existing forms.

--- a/projects/packages/forms/src/blocks/contact-form/edit.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/edit.tsx
@@ -556,9 +556,25 @@ function JetpackContactFormEdit( {
 			if ( ! button ) return null;
 
 			const preparedButton = button;
-			preparedButton.attributes.uniqueId = 'submit-step';
-			preparedButton.attributes.customVariant = 'submit';
-			preparedButton.attributes.metaName = __( 'Submit button', 'jetpack-forms' );
+			// Add the form-button-submit and is-submit classes for identification and CSS visibility
+			const existingClassName = preparedButton.attributes.className || '';
+			const classesToAdd = [];
+			if ( ! existingClassName.includes( 'form-button-submit' ) ) {
+				classesToAdd.push( 'form-button-submit' );
+			}
+			if ( ! existingClassName.includes( 'is-submit' ) ) {
+				classesToAdd.push( 'is-submit' );
+			}
+			if ( classesToAdd.length > 0 ) {
+				preparedButton.attributes.className = existingClassName
+					? `${ existingClassName } ${ classesToAdd.join( ' ' ) }`
+					: classesToAdd.join( ' ' );
+			}
+			// Set metadata name for core/button
+			preparedButton.attributes.metadata = {
+				...( preparedButton.attributes.metadata || {} ),
+				name: __( 'Submit button', 'jetpack-forms' ),
+			};
 			return preparedButton;
 		};
 
@@ -588,8 +604,12 @@ function JetpackContactFormEdit( {
 					},
 				},
 				button
-					? [ createBlock( PREVIOUS_BUTTON_TEMPLATE ), createBlock( NEXT_BUTTON_TEMPLATE ), button ]
-					: NAVIGATION_TEMPLATE.map( createBlock )
+					? [
+							createBlock( ...PREVIOUS_BUTTON_TEMPLATE ),
+							createBlock( ...NEXT_BUTTON_TEMPLATE ),
+							button,
+					  ]
+					: NAVIGATION_TEMPLATE.map( template => createBlock( ...template ) )
 			);
 		};
 
@@ -770,10 +790,21 @@ function JetpackContactFormEdit( {
 				) {
 					// Capture submit button (if any) inside navigation but skip the wrapper.
 					if ( ! finalSubmitButton ) {
-						finalSubmitButton = block.innerBlocks?.find(
-							inner =>
-								inner.name === 'jetpack/button' && inner.attributes?.customVariant === 'submit'
-						);
+						finalSubmitButton = block.innerBlocks?.find( inner => {
+							// Check for jetpack/button with customVariant (legacy)
+							if (
+								inner.name === 'jetpack/button' &&
+								inner.attributes?.customVariant === 'submit'
+							) {
+								return true;
+							}
+							// Check for core/button with form-button-submit class
+							if ( inner.name === 'core/button' ) {
+								const buttonClassName = inner.attributes?.className || '';
+								return buttonClassName.split( /\s+/ ).includes( 'form-button-submit' );
+							}
+							return false;
+						} );
 					}
 					return; // Omit multistep-specific blocks.
 				}

--- a/projects/packages/forms/src/blocks/contact-form/edit.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/edit.tsx
@@ -558,11 +558,12 @@ function JetpackContactFormEdit( {
 			const preparedButton = button;
 			// Add the form-button-submit and is-submit classes for identification and CSS visibility
 			const existingClassName = preparedButton.attributes.className || '';
+			const existingClassTokens = existingClassName.split( /\s+/ ).filter( Boolean );
 			const classesToAdd = [];
-			if ( ! existingClassName.includes( 'form-button-submit' ) ) {
+			if ( ! existingClassTokens.includes( 'form-button-submit' ) ) {
 				classesToAdd.push( 'form-button-submit' );
 			}
-			if ( ! existingClassName.includes( 'is-submit' ) ) {
+			if ( ! existingClassTokens.includes( 'is-submit' ) ) {
 				classesToAdd.push( 'is-submit' );
 			}
 			if ( classesToAdd.length > 0 ) {

--- a/projects/packages/forms/src/blocks/form-step-navigation/edit.js
+++ b/projects/packages/forms/src/blocks/form-step-navigation/edit.js
@@ -100,7 +100,81 @@ export const getButtonType = block => {
 };
 
 /**
- * Migrate a legacy jetpack/button to core/button, preserving custom text.
+ * Extract style attributes from a legacy jetpack/button block and map them
+ * to core/button format.
+ *
+ * @param {object} attrs - The legacy block attributes.
+ * @return {object} Mapped attributes for core/button.
+ */
+const mapLegacyStyleAttributes = attrs => {
+	const mapped = {};
+
+	// Direct palette-based attributes (same name in both blocks)
+	if ( attrs.backgroundColor ) {
+		mapped.backgroundColor = attrs.backgroundColor;
+	}
+	if ( attrs.textColor ) {
+		mapped.textColor = attrs.textColor;
+	}
+	if ( attrs.gradient ) {
+		mapped.gradient = attrs.gradient;
+	}
+
+	// Width: jetpack/button stores as string, core/button expects number
+	if ( attrs.width ) {
+		const numWidth = parseInt( attrs.width, 10 );
+		if ( ! isNaN( numWidth ) ) {
+			mapped.width = numWidth;
+		}
+	}
+
+	// Preset font size (e.g. "small", "medium") is a direct attribute
+	if ( attrs.fontSize ) {
+		mapped.fontSize = attrs.fontSize;
+	}
+
+	// Start from the existing style object (block supports store typography,
+	// border width, etc. here) and layer explicit attribute mappings on top.
+	const existingStyle = attrs.style || {};
+
+	// Custom color values map to style.color
+	const colorStyle = {
+		...( existingStyle.color || {} ),
+	};
+	if ( attrs.customBackgroundColor ) {
+		colorStyle.background = attrs.customBackgroundColor;
+	}
+	if ( attrs.customTextColor ) {
+		colorStyle.text = attrs.customTextColor;
+	}
+	if ( attrs.customGradient ) {
+		colorStyle.gradient = attrs.customGradient;
+	}
+
+	// Border radius from the explicit attribute maps to style.border.radius
+	const borderStyle = {
+		...( existingStyle.border || {} ),
+	};
+	if ( attrs.borderRadius !== undefined ) {
+		borderStyle.radius = `${ attrs.borderRadius }px`;
+	}
+
+	// Build the style object merging existing block support values with mapped attributes
+	const style = {
+		...existingStyle,
+		...( Object.keys( colorStyle ).length && { color: colorStyle } ),
+		...( Object.keys( borderStyle ).length && { border: borderStyle } ),
+	};
+
+	if ( Object.keys( style ).length ) {
+		mapped.style = style;
+	}
+
+	return mapped;
+};
+
+/**
+ * Migrate a legacy jetpack/button to core/button, preserving custom text and styles.
  *
  * @param {object} legacyBlock - The legacy jetpack/button block.
  * @param {string} buttonType  - The button type ('previous', 'next', 'submit').
@@ -110,11 +184,17 @@ export const migrateLegacyButton = ( legacyBlock, buttonType ) => {
 	const template = BUTTON_TEMPLATES[ buttonType ];
 	const [ blockName, templateAttributes ] = template;
 
+	const attrs = legacyBlock.attributes || {};
+
 	// Preserve custom text from the legacy button
-	const customText = legacyBlock.attributes?.text;
+	const customText = attrs.text;
+
+	// Map style attributes from jetpack/button to core/button format
+	const styleAttributes = mapLegacyStyleAttributes( attrs );
 
 	return createBlock( blockName, {
 		...templateAttributes,
+		...styleAttributes,
 		...( customText && { text: customText } ),
 	} );
 };

--- a/projects/packages/forms/src/blocks/form-step-navigation/edit.js
+++ b/projects/packages/forms/src/blocks/form-step-navigation/edit.js
@@ -52,27 +52,71 @@ export const NAVIGATION_TEMPLATE = [
 
 const ALLOWED_BLOCKS = [ 'core/button' ];
 
-/**
- * Check if a block's className contains a specific button type class.
- *
- * @param {object} block     - The block to check.
- * @param {string} typeClass - The class to look for (e.g., 'form-button-previous').
- * @return {boolean} Whether the block has the specified class.
- */
-const hasButtonTypeClass = ( block, typeClass ) => {
-	const className = block?.attributes?.className || '';
-	return className.split( /\s+/ ).includes( typeClass );
+// Map button types to their templates
+const BUTTON_TEMPLATES = {
+	previous: PREVIOUS_BUTTON_TEMPLATE,
+	next: NEXT_BUTTON_TEMPLATE,
+	submit: SUBMIT_BUTTON_TEMPLATE,
 };
 
 /**
- * Get the button type identifier from a template's className.
+ * Identify the button type from a block.
+ * Supports both legacy jetpack/button and new core/button formats.
  *
- * @param {string} className - The className string from template attributes.
- * @return {string|null} The button type (e.g., 'form-button-previous') or null.
+ * @param {object} block - The block to identify.
+ * @return {string|null} Button type ('previous', 'next', 'submit') or null.
  */
-const getButtonTypeFromClassName = className => {
-	const classes = ( className || '' ).split( /\s+/ );
-	return classes.find( cls => cls.startsWith( 'form-button-' ) ) || null;
+export const getButtonType = block => {
+	// New format: core/button with form-button-* class
+	if ( block.name === 'core/button' ) {
+		const className = block.attributes?.className || '';
+		const classes = className.split( /\s+/ );
+		if ( classes.includes( 'form-button-previous' ) ) {
+			return 'previous';
+		}
+		if ( classes.includes( 'form-button-next' ) ) {
+			return 'next';
+		}
+		if ( classes.includes( 'form-button-submit' ) ) {
+			return 'submit';
+		}
+	}
+
+	// Legacy format: jetpack/button with uniqueId matching data-id-attr values
+	if ( block.name === 'jetpack/button' ) {
+		const uniqueId = block.attributes?.uniqueId || '';
+		if ( uniqueId === 'previous-step' ) {
+			return 'previous';
+		}
+		if ( uniqueId === 'next-step' ) {
+			return 'next';
+		}
+		if ( uniqueId === 'submit-step' ) {
+			return 'submit';
+		}
+	}
+
+	return null;
+};
+
+/**
+ * Migrate a legacy jetpack/button to core/button, preserving custom text.
+ *
+ * @param {object} legacyBlock - The legacy jetpack/button block.
+ * @param {string} buttonType  - The button type ('previous', 'next', 'submit').
+ * @return {object} A new core/button block with preserved customizations.
+ */
+export const migrateLegacyButton = ( legacyBlock, buttonType ) => {
+	const template = BUTTON_TEMPLATES[ buttonType ];
+	const [ blockName, templateAttributes ] = template;
+
+	// Preserve custom text from the legacy button
+	const customText = legacyBlock.attributes?.text;
+
+	return createBlock( blockName, {
+		...templateAttributes,
+		...( customText && { text: customText } ),
+	} );
 };
 
 export default function Edit( { clientId } ) {
@@ -139,75 +183,52 @@ export default function Edit( { clientId } ) {
 		if ( typeof currentIndex === 'undefined' ) {
 			return;
 		}
-		let shouldReplaceInnerBlocks = false;
 
-		// First identify existing buttons in the navigation by their class names
+		// Identify existing buttons (supports both legacy jetpack/button and new core/button)
 		const existingButtons = {
-			'form-button-previous': navigationBlocks.find(
-				block => block.name === 'core/button' && hasButtonTypeClass( block, 'form-button-previous' )
-			),
-			'form-button-next': navigationBlocks.find(
-				block => block.name === 'core/button' && hasButtonTypeClass( block, 'form-button-next' )
-			),
-			'form-button-submit': navigationBlocks.find(
-				block => block.name === 'core/button' && hasButtonTypeClass( block, 'form-button-submit' )
-			),
+			previous: null,
+			next: null,
+			submit: null,
 		};
 
-		// Create a map of button types to track required changes
-		const buttonUpdates = {
-			'form-button-previous': {
-				needed: false,
-				existing: existingButtons[ 'form-button-previous' ],
-			},
-			'form-button-next': {
-				needed: false,
-				existing: existingButtons[ 'form-button-next' ],
-			},
-			'form-button-submit': {
-				needed: false,
-				existing: existingButtons[ 'form-button-submit' ],
-			},
-		};
-
-		// Flag needed buttons based on template
-		NAVIGATION_TEMPLATE.forEach( ( [ , blockAttributes ] ) => {
-			const buttonType = getButtonTypeFromClassName( blockAttributes.className );
-			if ( buttonType ) {
-				buttonUpdates[ buttonType ].needed = true;
-
-				// If button doesn't exist but is needed, we'll need to replace inner blocks
-				if ( ! buttonUpdates[ buttonType ].existing ) {
-					shouldReplaceInnerBlocks = true;
-				}
+		navigationBlocks.forEach( block => {
+			const buttonType = getButtonType( block );
+			if ( buttonType && ! existingButtons[ buttonType ] ) {
+				existingButtons[ buttonType ] = block;
 			}
 		} );
 
-		// Build the updated button collection
-		const replacementInnerBlocks = NAVIGATION_TEMPLATE.map( ( [ blockName, blockAttributes ] ) => {
-			const buttonType = getButtonTypeFromClassName( blockAttributes.className );
-			return buttonUpdates[ buttonType ]?.existing || createBlock( blockName, blockAttributes );
-		} );
+		// Check if we need to make any changes
+		const hasMissingButtons =
+			! existingButtons.previous || ! existingButtons.next || ! existingButtons.submit;
+		const hasLegacyButtons = navigationBlocks.some( block => block.name === 'jetpack/button' );
 
-		if ( shouldReplaceInnerBlocks ) {
-			__unstableMarkNextChangeAsNotPersistent();
-			replaceInnerBlocks( clientId, replacementInnerBlocks, false );
+		// Only proceed if buttons are missing or need migration
+		if ( ! hasMissingButtons && ! hasLegacyButtons ) {
 			return;
 		}
 
-		navigationBlocks.forEach( block => {
-			const buttonType = getButtonTypeFromClassName( block.attributes?.className );
-			// If a button exists but isn't needed in the new template, we need to update
-			if ( buttonType && ! buttonUpdates[ buttonType ]?.needed ) {
-				shouldReplaceInnerBlocks = true;
+		// Build the button collection: preserve existing core/buttons, migrate legacy, create missing
+		const replacementBlocks = [ 'previous', 'next', 'submit' ].map( buttonType => {
+			const existing = existingButtons[ buttonType ];
+
+			if ( ! existing ) {
+				// Button is missing - create from template
+				const [ blockName, blockAttributes ] = BUTTON_TEMPLATES[ buttonType ];
+				return createBlock( blockName, blockAttributes );
 			}
+
+			if ( existing.name === 'jetpack/button' ) {
+				// Legacy button - migrate to core/button preserving text
+				return migrateLegacyButton( existing, buttonType );
+			}
+
+			// Existing core/button - keep as-is
+			return existing;
 		} );
 
-		// Only update blocks if needed
-		if ( shouldReplaceInnerBlocks ) {
-			__unstableMarkNextChangeAsNotPersistent();
-			replaceInnerBlocks( clientId, replacementInnerBlocks, false );
-		}
+		__unstableMarkNextChangeAsNotPersistent();
+		replaceInnerBlocks( clientId, replacementBlocks, false );
 	}, [
 		navigationBlocks,
 		replaceInnerBlocks,

--- a/projects/packages/forms/src/blocks/form-step-navigation/edit.js
+++ b/projects/packages/forms/src/blocks/form-step-navigation/edit.js
@@ -37,6 +37,7 @@ const SUBMIT_BUTTON_TEMPLATE = [
 	'core/button',
 	{
 		tagName: 'button',
+		type: 'submit',
 		text: __( 'Submit', 'jetpack-forms' ),
 		className: 'form-button-submit is-submit',
 		metadata: { name: __( 'Submit button', 'jetpack-forms' ) },

--- a/projects/packages/forms/src/blocks/form-step-navigation/edit.js
+++ b/projects/packages/forms/src/blocks/form-step-navigation/edit.js
@@ -15,35 +15,31 @@ import useParentFormClientId from '../shared/hooks/use-parent-form-client-id.js'
 import './editor.scss';
 
 export const PREVIOUS_BUTTON_TEMPLATE = [
-	'jetpack/button',
+	'core/button',
 	{
-		element: 'button',
+		tagName: 'button',
 		text: __( 'Previous', 'jetpack-forms' ),
-		uniqueId: 'previous-step',
-		customVariant: 'previous',
-		className: 'is-style-outline',
-		metaName: __( 'Previous button', 'jetpack-forms' ),
+		className: 'is-style-outline form-button-previous is-previous',
+		metadata: { name: __( 'Previous button', 'jetpack-forms' ) },
 	},
 ];
 export const NEXT_BUTTON_TEMPLATE = [
-	'jetpack/button',
+	'core/button',
 	{
-		element: 'button',
+		tagName: 'button',
 		text: __( 'Next', 'jetpack-forms' ),
-		uniqueId: 'next-step',
-		customVariant: 'next',
-		metaName: __( 'Next button', 'jetpack-forms' ),
+		className: 'form-button-next is-next',
+		metadata: { name: __( 'Next button', 'jetpack-forms' ) },
 	},
 ];
 
 const SUBMIT_BUTTON_TEMPLATE = [
-	'jetpack/button',
+	'core/button',
 	{
-		element: 'button',
+		tagName: 'button',
 		text: __( 'Submit', 'jetpack-forms' ),
-		uniqueId: 'submit-step',
-		customVariant: 'submit',
-		metaName: __( 'Submit button', 'jetpack-forms' ),
+		className: 'form-button-submit is-submit',
+		metadata: { name: __( 'Submit button', 'jetpack-forms' ) },
 	},
 ];
 
@@ -53,7 +49,30 @@ export const NAVIGATION_TEMPLATE = [
 	SUBMIT_BUTTON_TEMPLATE,
 ];
 
-const ALLOWED_BLOCKS = [ 'jetpack/button' ];
+const ALLOWED_BLOCKS = [ 'core/button' ];
+
+/**
+ * Check if a block's className contains a specific button type class.
+ *
+ * @param {object} block     - The block to check.
+ * @param {string} typeClass - The class to look for (e.g., 'form-button-previous').
+ * @return {boolean} Whether the block has the specified class.
+ */
+const hasButtonTypeClass = ( block, typeClass ) => {
+	const className = block?.attributes?.className || '';
+	return className.split( /\s+/ ).includes( typeClass );
+};
+
+/**
+ * Get the button type identifier from a template's className.
+ *
+ * @param {string} className - The className string from template attributes.
+ * @return {string|null} The button type (e.g., 'form-button-previous') or null.
+ */
+const getButtonTypeFromClassName = className => {
+	const classes = ( className || '' ).split( /\s+/ );
+	return classes.find( cls => cls.startsWith( 'form-button-' ) ) || null;
+};
 
 export default function Edit( { clientId } ) {
 	const blockProps = useBlockProps();
@@ -121,45 +140,52 @@ export default function Edit( { clientId } ) {
 		}
 		let shouldReplaceInnerBlocks = false;
 
-		// First identify existing buttons in the navigation
+		// First identify existing buttons in the navigation by their class names
 		const existingButtons = {
-			previous: navigationBlocks.find(
-				block => block.name === 'jetpack/button' && block.attributes.uniqueId === 'previous-step'
+			'form-button-previous': navigationBlocks.find(
+				block => block.name === 'core/button' && hasButtonTypeClass( block, 'form-button-previous' )
 			),
-			next: navigationBlocks.find(
-				block => block.name === 'jetpack/button' && block.attributes.uniqueId === 'next-step'
+			'form-button-next': navigationBlocks.find(
+				block => block.name === 'core/button' && hasButtonTypeClass( block, 'form-button-next' )
 			),
-			submit: navigationBlocks.find(
-				block => block.name === 'jetpack/button' && block.attributes.uniqueId === 'submit-step'
+			'form-button-submit': navigationBlocks.find(
+				block => block.name === 'core/button' && hasButtonTypeClass( block, 'form-button-submit' )
 			),
 		};
 
 		// Create a map of button types to track required changes
 		const buttonUpdates = {
-			'previous-step': { needed: false, existing: existingButtons.previous },
-			'next-step': { needed: false, existing: existingButtons.next },
-			'submit-step': { needed: false, existing: existingButtons.submit },
+			'form-button-previous': {
+				needed: false,
+				existing: existingButtons[ 'form-button-previous' ],
+			},
+			'form-button-next': {
+				needed: false,
+				existing: existingButtons[ 'form-button-next' ],
+			},
+			'form-button-submit': {
+				needed: false,
+				existing: existingButtons[ 'form-button-submit' ],
+			},
 		};
 
 		// Flag needed buttons based on template
 		NAVIGATION_TEMPLATE.forEach( ( [ , blockAttributes ] ) => {
-			buttonUpdates[ blockAttributes.uniqueId ].needed = true;
+			const buttonType = getButtonTypeFromClassName( blockAttributes.className );
+			if ( buttonType ) {
+				buttonUpdates[ buttonType ].needed = true;
 
-			// If button doesn't exist but is needed, we'll need to replace inner blocks
-			if ( ! buttonUpdates[ blockAttributes.uniqueId ].existing ) {
-				shouldReplaceInnerBlocks = true;
+				// If button doesn't exist but is needed, we'll need to replace inner blocks
+				if ( ! buttonUpdates[ buttonType ].existing ) {
+					shouldReplaceInnerBlocks = true;
+				}
 			}
 		} );
 
 		// Build the updated button collection
 		const replacementInnerBlocks = NAVIGATION_TEMPLATE.map( ( [ blockName, blockAttributes ] ) => {
-			return (
-				buttonUpdates[ blockAttributes.uniqueId ].existing ||
-				createBlock( blockName, {
-					...blockAttributes,
-					uniqueId: blockAttributes.uniqueId,
-				} )
-			);
+			const buttonType = getButtonTypeFromClassName( blockAttributes.className );
+			return buttonUpdates[ buttonType ]?.existing || createBlock( blockName, blockAttributes );
 		} );
 
 		if ( shouldReplaceInnerBlocks ) {
@@ -169,8 +195,9 @@ export default function Edit( { clientId } ) {
 		}
 
 		navigationBlocks.forEach( block => {
+			const buttonType = getButtonTypeFromClassName( block.attributes?.className );
 			// If a button exists but isn't needed in the new template, we need to update
-			if ( ! buttonUpdates[ block.attributes.uniqueId ]?.needed ) {
+			if ( buttonType && ! buttonUpdates[ buttonType ]?.needed ) {
 				shouldReplaceInnerBlocks = true;
 			}
 		} );

--- a/projects/packages/forms/src/blocks/form-step-navigation/editor.scss
+++ b/projects/packages/forms/src/blocks/form-step-navigation/editor.scss
@@ -1,25 +1,35 @@
 .jetpack-contact-form.is-previewing-step {
 
+	// jetpack/button: class is on inner element, use :has()
+	// core/button: class is on wrapper element, use direct selector
 	.wp-block-jetpack-button:has(.is-submit),
+	.wp-block-button.is-submit,
 	&.is-last-step .wp-block-jetpack-button:has(.is-next),
-	&.is-first-step .wp-block-jetpack-button:has(.is-previous) {
+	&.is-last-step .wp-block-button.is-next,
+	&.is-first-step .wp-block-jetpack-button:has(.is-previous),
+	&.is-first-step .wp-block-button.is-previous {
 		display: none;
 	}
 
-	&.is-last-step .wp-block-jetpack-button:has(.is-submit) {
+	&.is-last-step .wp-block-jetpack-button:has(.is-submit),
+	&.is-last-step .wp-block-button.is-submit {
 		display: inline-block;
 	}
 }
 
-.editor-styles-wrapper .wp-block-jetpack-form-step-navigation:has(.wp-block-jetpack-button[style*="width:"]) {
+.editor-styles-wrapper .wp-block-jetpack-form-step-navigation:has(.wp-block-jetpack-button[style*="width:"]),
+.editor-styles-wrapper .wp-block-jetpack-form-step-navigation:has(.wp-block-button[style*="width:"]) {
 	gap: var(--wp--style--block-gap, 1.5rem) 0;
 }
 
-.editor-styles-wrapper .wp-block-jetpack-form-step-navigation .wp-block-jetpack-button[style*="width:"] .wp-block-button__link {
+.editor-styles-wrapper .wp-block-jetpack-form-step-navigation .wp-block-jetpack-button[style*="width:"] .wp-block-button__link,
+.editor-styles-wrapper .wp-block-jetpack-form-step-navigation .wp-block-button[style*="width:"] .wp-block-button__link {
 	width: calc(100% - var(--wp--style--block-gap, 1.5rem) / 2);
 }
 
 .editor-styles-wrapper .wp-block-jetpack-form-step-navigation .wp-block-jetpack-button[style*="width:"] .is-next,
-.editor-styles-wrapper .wp-block-jetpack-form-step-navigation .wp-block-jetpack-button[style*="width:"] .is-submit {
+.editor-styles-wrapper .wp-block-jetpack-form-step-navigation .wp-block-jetpack-button[style*="width:"] .is-submit,
+.editor-styles-wrapper .wp-block-jetpack-form-step-navigation .wp-block-button[style*="width:"].is-next,
+.editor-styles-wrapper .wp-block-jetpack-form-step-navigation .wp-block-button[style*="width:"].is-submit {
 	float: right;
 }

--- a/projects/packages/forms/src/blocks/form-step-navigation/style.scss
+++ b/projects/packages/forms/src/blocks/form-step-navigation/style.scss
@@ -5,17 +5,21 @@
 	flex-wrap: inherit;
 }
 
-.wp-block-jetpack-form-step-navigation:has(.wp-block-jetpack-button[style*="width:"]) {
+.wp-block-jetpack-form-step-navigation:has(.wp-block-jetpack-button[style*="width:"]),
+.wp-block-jetpack-form-step-navigation:has(.wp-block-button[style*="width:"]) {
 	gap: 0;
 }
 
-.wp-block-jetpack-form-step-navigation .wp-block-jetpack-button[style*="width:"] .wp-block-button__link {
+.wp-block-jetpack-form-step-navigation .wp-block-jetpack-button[style*="width:"] .wp-block-button__link,
+.wp-block-jetpack-form-step-navigation .wp-block-button[style*="width:"] .wp-block-button__link {
 	width: calc(100% - var(--wp--style--block-gap, 1.5rem) / 2);
 	white-space: nowrap;
 }
 
 .wp-block-jetpack-form-step-navigation .wp-block-jetpack-button[style*="width:"] .is-next,
-.wp-block-jetpack-form-step-navigation .wp-block-jetpack-button[style*="width:"] .is-submit {
+.wp-block-jetpack-form-step-navigation .wp-block-jetpack-button[style*="width:"] .is-submit,
+.wp-block-jetpack-form-step-navigation .wp-block-button[style*="width:"].is-next,
+.wp-block-jetpack-form-step-navigation .wp-block-button[style*="width:"].is-submit {
 	float: right;
 }
 
@@ -23,7 +27,9 @@
 	width: 100%;
 }
 
-.is-content-justification-space-between .wp-block-jetpack-button:has(.is-next, .is-submit) {
+.is-content-justification-space-between .wp-block-jetpack-button:has(.is-next, .is-submit),
+.is-content-justification-space-between .wp-block-button.is-next,
+.is-content-justification-space-between .wp-block-button.is-submit {
 	margin-left: auto;
 }
 

--- a/projects/packages/forms/src/blocks/form-step-navigation/test/edit.test.js
+++ b/projects/packages/forms/src/blocks/form-step-navigation/test/edit.test.js
@@ -1,0 +1,295 @@
+import { describe, expect, jest, test, beforeEach } from '@jest/globals';
+
+// Mock createBlock to avoid WordPress block registration issues in tests
+await jest.unstable_mockModule( '@wordpress/blocks', () => ( {
+	createBlock: jest.fn( ( blockName, attributes ) => ( {
+		name: blockName,
+		attributes: attributes || {},
+		clientId: 'mock-client-id',
+	} ) ),
+} ) );
+
+// Mock other WordPress dependencies used by edit.js
+await jest.unstable_mockModule( '@wordpress/block-editor', () => ( {
+	useBlockProps: jest.fn( () => ( {} ) ),
+	useInnerBlocksProps: jest.fn( () => ( {} ) ),
+	store: 'core/block-editor',
+} ) );
+
+await jest.unstable_mockModule( '@wordpress/data', () => ( {
+	useDispatch: jest.fn( () => ( {
+		replaceInnerBlocks: jest.fn(),
+		__unstableMarkNextChangeAsNotPersistent: jest.fn(),
+	} ) ),
+	useSelect: jest.fn( () => ( {
+		ancestorStepClientId: null,
+		navigationBlocks: [],
+	} ) ),
+} ) );
+
+await jest.unstable_mockModule( '@wordpress/element', () => ( {
+	useEffect: jest.fn(),
+} ) );
+
+await jest.unstable_mockModule( '@wordpress/i18n', () => ( {
+	__: jest.fn( str => str ),
+} ) );
+
+// Mock internal dependencies
+await jest.unstable_mockModule( '../../../store/form-step-preview.js', () => ( {
+	store: 'jetpack/form-step-preview',
+} ) );
+
+await jest.unstable_mockModule( '../../shared/components/form-step-controls/index.js', () => ( {
+	default: jest.fn( () => null ),
+} ) );
+
+await jest.unstable_mockModule( '../../shared/hooks/use-form-steps.js', () => ( {
+	default: jest.fn( () => [] ),
+} ) );
+
+await jest.unstable_mockModule( '../../shared/hooks/use-parent-form-client-id.js', () => ( {
+	default: jest.fn( () => null ),
+} ) );
+
+// Import the functions we want to test after mocks are set up
+const { getButtonType, migrateLegacyButton } = await import( '../edit.js' );
+const { createBlock } = await import( '@wordpress/blocks' );
+
+describe( 'getButtonType', () => {
+	describe( 'core/button blocks (new format)', () => {
+		test( 'should identify previous button by form-button-previous class', () => {
+			const block = {
+				name: 'core/button',
+				attributes: {
+					className: 'is-style-outline form-button-previous is-previous',
+				},
+			};
+
+			expect( getButtonType( block ) ).toBe( 'previous' );
+		} );
+
+		test( 'should identify next button by form-button-next class', () => {
+			const block = {
+				name: 'core/button',
+				attributes: {
+					className: 'form-button-next is-next',
+				},
+			};
+
+			expect( getButtonType( block ) ).toBe( 'next' );
+		} );
+
+		test( 'should identify submit button by form-button-submit class', () => {
+			const block = {
+				name: 'core/button',
+				attributes: {
+					className: 'form-button-submit is-submit',
+				},
+			};
+
+			expect( getButtonType( block ) ).toBe( 'submit' );
+		} );
+
+		test( 'should return null for core/button without navigation classes', () => {
+			const block = {
+				name: 'core/button',
+				attributes: {
+					className: 'wp-block-button',
+				},
+			};
+
+			expect( getButtonType( block ) ).toBeNull();
+		} );
+
+		test( 'should return null for core/button with empty className', () => {
+			const block = {
+				name: 'core/button',
+				attributes: {},
+			};
+
+			expect( getButtonType( block ) ).toBeNull();
+		} );
+	} );
+
+	describe( 'jetpack/button blocks (legacy format)', () => {
+		test( 'should identify previous button by previous-step uniqueId', () => {
+			const block = {
+				name: 'jetpack/button',
+				attributes: {
+					uniqueId: 'previous-step',
+				},
+			};
+
+			expect( getButtonType( block ) ).toBe( 'previous' );
+		} );
+
+		test( 'should identify next button by next-step uniqueId', () => {
+			const block = {
+				name: 'jetpack/button',
+				attributes: {
+					uniqueId: 'next-step',
+				},
+			};
+
+			expect( getButtonType( block ) ).toBe( 'next' );
+		} );
+
+		test( 'should identify submit button by submit-step uniqueId', () => {
+			const block = {
+				name: 'jetpack/button',
+				attributes: {
+					uniqueId: 'submit-step',
+				},
+			};
+
+			expect( getButtonType( block ) ).toBe( 'submit' );
+		} );
+
+		test( 'should return null for jetpack/button without navigation uniqueId', () => {
+			const block = {
+				name: 'jetpack/button',
+				attributes: {
+					uniqueId: 'some-other-button',
+				},
+			};
+
+			expect( getButtonType( block ) ).toBeNull();
+		} );
+
+		test( 'should return null for jetpack/button with empty uniqueId', () => {
+			const block = {
+				name: 'jetpack/button',
+				attributes: {},
+			};
+
+			expect( getButtonType( block ) ).toBeNull();
+		} );
+	} );
+
+	describe( 'other block types', () => {
+		test( 'should return null for non-button blocks', () => {
+			const block = {
+				name: 'core/paragraph',
+				attributes: {
+					content: 'Hello',
+				},
+			};
+
+			expect( getButtonType( block ) ).toBeNull();
+		} );
+	} );
+} );
+
+describe( 'migrateLegacyButton', () => {
+	beforeEach( () => {
+		createBlock.mockClear();
+	} );
+
+	test( 'should migrate previous button preserving custom text', () => {
+		const legacyBlock = {
+			name: 'jetpack/button',
+			attributes: {
+				uniqueId: 'previous-step',
+				text: 'Go Back',
+			},
+		};
+
+		const result = migrateLegacyButton( legacyBlock, 'previous' );
+
+		expect( createBlock ).toHaveBeenCalledWith(
+			'core/button',
+			expect.objectContaining( {
+				tagName: 'button',
+				className: expect.stringContaining( 'form-button-previous' ),
+				text: 'Go Back',
+			} )
+		);
+		expect( result.name ).toBe( 'core/button' );
+	} );
+
+	test( 'should migrate next button preserving custom text', () => {
+		const legacyBlock = {
+			name: 'jetpack/button',
+			attributes: {
+				uniqueId: 'next-step',
+				text: 'Continue',
+			},
+		};
+
+		const result = migrateLegacyButton( legacyBlock, 'next' );
+
+		expect( createBlock ).toHaveBeenCalledWith(
+			'core/button',
+			expect.objectContaining( {
+				tagName: 'button',
+				className: expect.stringContaining( 'form-button-next' ),
+				text: 'Continue',
+			} )
+		);
+		expect( result.name ).toBe( 'core/button' );
+	} );
+
+	test( 'should migrate submit button preserving custom text and setting type', () => {
+		const legacyBlock = {
+			name: 'jetpack/button',
+			attributes: {
+				uniqueId: 'submit-step',
+				text: 'Send Form',
+			},
+		};
+
+		const result = migrateLegacyButton( legacyBlock, 'submit' );
+
+		expect( createBlock ).toHaveBeenCalledWith(
+			'core/button',
+			expect.objectContaining( {
+				tagName: 'button',
+				type: 'submit',
+				className: expect.stringContaining( 'form-button-submit' ),
+				text: 'Send Form',
+			} )
+		);
+		expect( result.name ).toBe( 'core/button' );
+	} );
+
+	test( 'should use template text when legacy button has no custom text', () => {
+		const legacyBlock = {
+			name: 'jetpack/button',
+			attributes: {
+				uniqueId: 'previous-step',
+				// no text attribute
+			},
+		};
+
+		migrateLegacyButton( legacyBlock, 'previous' );
+
+		// Should be called with template attributes, text should be 'Previous' from template
+		expect( createBlock ).toHaveBeenCalledWith(
+			'core/button',
+			expect.objectContaining( {
+				text: 'Previous',
+			} )
+		);
+	} );
+
+	test( 'should preserve empty string text if explicitly set', () => {
+		const legacyBlock = {
+			name: 'jetpack/button',
+			attributes: {
+				uniqueId: 'next-step',
+				text: '',
+			},
+		};
+
+		migrateLegacyButton( legacyBlock, 'next' );
+
+		// Empty string is falsy, so template text should be used
+		expect( createBlock ).toHaveBeenCalledWith(
+			'core/button',
+			expect.objectContaining( {
+				text: 'Next',
+			} )
+		);
+	} );
+} );

--- a/projects/packages/forms/src/blocks/form-step-navigation/test/edit.test.js
+++ b/projects/packages/forms/src/blocks/form-step-navigation/test/edit.test.js
@@ -292,4 +292,279 @@ describe( 'migrateLegacyButton', () => {
 			} )
 		);
 	} );
+
+	test( 'should preserve palette-based backgroundColor and textColor', () => {
+		const legacyBlock = {
+			name: 'jetpack/button',
+			attributes: {
+				uniqueId: 'next-step',
+				text: 'Next',
+				backgroundColor: 'vivid-red',
+				textColor: 'white',
+			},
+		};
+
+		migrateLegacyButton( legacyBlock, 'next' );
+
+		expect( createBlock ).toHaveBeenCalledWith(
+			'core/button',
+			expect.objectContaining( {
+				backgroundColor: 'vivid-red',
+				textColor: 'white',
+			} )
+		);
+	} );
+
+	test( 'should map custom colors to style.color object', () => {
+		const legacyBlock = {
+			name: 'jetpack/button',
+			attributes: {
+				uniqueId: 'submit-step',
+				text: 'Send',
+				customBackgroundColor: '#ff0000',
+				customTextColor: '#ffffff',
+			},
+		};
+
+		migrateLegacyButton( legacyBlock, 'submit' );
+
+		expect( createBlock ).toHaveBeenCalledWith(
+			'core/button',
+			expect.objectContaining( {
+				style: expect.objectContaining( {
+					color: {
+						background: '#ff0000',
+						text: '#ffffff',
+					},
+				} ),
+			} )
+		);
+	} );
+
+	test( 'should preserve gradient attribute', () => {
+		const legacyBlock = {
+			name: 'jetpack/button',
+			attributes: {
+				uniqueId: 'next-step',
+				text: 'Next',
+				gradient: 'vivid-cyan-blue-to-vivid-purple',
+			},
+		};
+
+		migrateLegacyButton( legacyBlock, 'next' );
+
+		expect( createBlock ).toHaveBeenCalledWith(
+			'core/button',
+			expect.objectContaining( {
+				gradient: 'vivid-cyan-blue-to-vivid-purple',
+			} )
+		);
+	} );
+
+	test( 'should map customGradient to style.color.gradient', () => {
+		const legacyBlock = {
+			name: 'jetpack/button',
+			attributes: {
+				uniqueId: 'next-step',
+				text: 'Next',
+				customGradient: 'linear-gradient(135deg,#12c2e9 0%,#c471ed 50%,#f64f59 100%)',
+			},
+		};
+
+		migrateLegacyButton( legacyBlock, 'next' );
+
+		expect( createBlock ).toHaveBeenCalledWith(
+			'core/button',
+			expect.objectContaining( {
+				style: expect.objectContaining( {
+					color: {
+						gradient: 'linear-gradient(135deg,#12c2e9 0%,#c471ed 50%,#f64f59 100%)',
+					},
+				} ),
+			} )
+		);
+	} );
+
+	test( 'should map borderRadius to style.border.radius', () => {
+		const legacyBlock = {
+			name: 'jetpack/button',
+			attributes: {
+				uniqueId: 'previous-step',
+				text: 'Back',
+				borderRadius: 10,
+			},
+		};
+
+		migrateLegacyButton( legacyBlock, 'previous' );
+
+		expect( createBlock ).toHaveBeenCalledWith(
+			'core/button',
+			expect.objectContaining( {
+				style: expect.objectContaining( {
+					border: {
+						radius: '10px',
+					},
+				} ),
+			} )
+		);
+	} );
+
+	test( 'should preserve all style attributes together with custom text', () => {
+		const legacyBlock = {
+			name: 'jetpack/button',
+			attributes: {
+				uniqueId: 'submit-step',
+				text: 'Send Form',
+				backgroundColor: 'vivid-red',
+				customTextColor: '#ffffff',
+				borderRadius: 5,
+			},
+		};
+
+		migrateLegacyButton( legacyBlock, 'submit' );
+
+		expect( createBlock ).toHaveBeenCalledWith(
+			'core/button',
+			expect.objectContaining( {
+				text: 'Send Form',
+				backgroundColor: 'vivid-red',
+				style: {
+					color: { text: '#ffffff' },
+					border: { radius: '5px' },
+				},
+			} )
+		);
+	} );
+
+	test( 'should not include style object when no custom values exist', () => {
+		const legacyBlock = {
+			name: 'jetpack/button',
+			attributes: {
+				uniqueId: 'next-step',
+				text: 'Continue',
+			},
+		};
+
+		migrateLegacyButton( legacyBlock, 'next' );
+
+		const callArgs = createBlock.mock.calls[ 0 ][ 1 ];
+		expect( callArgs ).not.toHaveProperty( 'style' );
+	} );
+
+	test( 'should preserve border width from style attribute', () => {
+		const legacyBlock = {
+			name: 'jetpack/button',
+			attributes: {
+				uniqueId: 'next-step',
+				text: 'Next',
+				style: {
+					border: { width: '3px', style: 'solid', color: '#000000' },
+				},
+			},
+		};
+
+		migrateLegacyButton( legacyBlock, 'next' );
+
+		expect( createBlock ).toHaveBeenCalledWith(
+			'core/button',
+			expect.objectContaining( {
+				style: expect.objectContaining( {
+					border: { width: '3px', style: 'solid', color: '#000000' },
+				} ),
+			} )
+		);
+	} );
+
+	test( 'should preserve font size from style.typography', () => {
+		const legacyBlock = {
+			name: 'jetpack/button',
+			attributes: {
+				uniqueId: 'submit-step',
+				text: 'Submit',
+				style: {
+					typography: { fontSize: '22px' },
+				},
+			},
+		};
+
+		migrateLegacyButton( legacyBlock, 'submit' );
+
+		expect( createBlock ).toHaveBeenCalledWith(
+			'core/button',
+			expect.objectContaining( {
+				style: expect.objectContaining( {
+					typography: { fontSize: '22px' },
+				} ),
+			} )
+		);
+	} );
+
+	test( 'should preserve preset fontSize attribute', () => {
+		const legacyBlock = {
+			name: 'jetpack/button',
+			attributes: {
+				uniqueId: 'next-step',
+				text: 'Next',
+				fontSize: 'large',
+			},
+		};
+
+		migrateLegacyButton( legacyBlock, 'next' );
+
+		expect( createBlock ).toHaveBeenCalledWith(
+			'core/button',
+			expect.objectContaining( {
+				fontSize: 'large',
+			} )
+		);
+	} );
+
+	test( 'should convert width from string to number', () => {
+		const legacyBlock = {
+			name: 'jetpack/button',
+			attributes: {
+				uniqueId: 'next-step',
+				text: 'Next',
+				width: '75',
+			},
+		};
+
+		migrateLegacyButton( legacyBlock, 'next' );
+
+		expect( createBlock ).toHaveBeenCalledWith(
+			'core/button',
+			expect.objectContaining( {
+				width: 75,
+			} )
+		);
+	} );
+
+	test( 'should merge explicit attributes with existing style object', () => {
+		const legacyBlock = {
+			name: 'jetpack/button',
+			attributes: {
+				uniqueId: 'submit-step',
+				text: 'Send',
+				customBackgroundColor: '#ff0000',
+				borderRadius: 8,
+				style: {
+					border: { width: '2px', style: 'dashed' },
+					typography: { fontSize: '18px', fontFamily: 'serif' },
+				},
+			},
+		};
+
+		migrateLegacyButton( legacyBlock, 'submit' );
+
+		expect( createBlock ).toHaveBeenCalledWith(
+			'core/button',
+			expect.objectContaining( {
+				style: {
+					color: { background: '#ff0000' },
+					border: { width: '2px', style: 'dashed', radius: '8px' },
+					typography: { fontSize: '18px', fontFamily: 'serif' },
+				},
+			} )
+		);
+	} );
 } );

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -951,20 +951,25 @@ class Contact_Form_Plugin {
 		}
 
 		while ( $processor->next_tag() ) {
-			$id = $processor->get_attribute( 'data-id-attr' );
-			if ( 'previous-step' === $id ) {
+			// Check for button type - support both legacy (data-id-attr) and new (class-based) identification.
+			$id              = $processor->get_attribute( 'data-id-attr' );
+			$is_previous_btn = 'previous-step' === $id || $processor->has_class( 'form-button-previous' );
+			$is_next_btn     = 'next-step' === $id || $processor->has_class( 'form-button-next' );
+			$is_submit_btn   = 'submit-step' === $id || $processor->has_class( 'form-button-submit' );
+
+			if ( $is_previous_btn ) {
 				$processor->remove_attribute( 'id' );
 				$processor->add_class( 'disable-spinner is-previous is-hidden' );
 				$processor->set_attribute( 'data-wp-on--click', 'actions.previousStep' );
 				$processor->set_attribute( 'data-wp-class--is-hidden', 'state.isFirstStep' );
 			}
-			if ( 'next-step' === $id ) {
+			if ( $is_next_btn ) {
 				$processor->remove_attribute( 'id' );
 				$processor->add_class( 'disable-spinner is-next' );
 				$processor->set_attribute( 'data-wp-on--click', 'actions.nextStep' );
 				$processor->set_attribute( 'data-wp-class--is-hidden', 'state.isLastStep' );
 			}
-			if ( 'submit-step' === $id ) {
+			if ( $is_submit_btn ) {
 				$processor->remove_attribute( 'id' );
 				$processor->add_class( 'is-submit is-hidden' );
 				$processor->set_attribute( 'data-wp-class--is-hidden', 'state.isNotLastStep' );

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -1352,7 +1352,9 @@ class Contact_Form extends Contact_Form_Shortcode {
 
 	/**
 	 * Prepare the submit button for the contact form.
-	 * Add interactivity attributes to the LAST submit button found in the content.
+	 * Add interactivity attributes to submit buttons identified by:
+	 * - Legacy: type="submit" attribute
+	 * - New: is-submit or form-button-submit class
 	 *
 	 * @param string $content - the content of the submit button.
 	 *
@@ -1362,34 +1364,19 @@ class Contact_Form extends Contact_Form_Shortcode {
 		if ( ! class_exists( \WP_HTML_Tag_Processor::class ) ) {
 			return $content;
 		}
-		$button_count = 0;
-		$p            = new \WP_HTML_Tag_Processor( $content );
-		while ( $p->next_tag(
-			array(
-				'tag_name' => 'button',
-				'type'     => 'submit',
-			)
-		) ) {
-			++$button_count;
-		}
-		if ( $button_count === 0 ) {
-			return $content;
-		}
-		$occurrence = 0;
-		$p          = new \WP_HTML_Tag_Processor( $content );
-		while ( $p->next_tag(
-			array(
-				'tag_name' => 'button',
-				'type'     => 'submit',
-			)
-		) ) {
-			if ( $occurrence === $button_count - 1 ) {
+
+		$p = new \WP_HTML_Tag_Processor( $content );
+		while ( $p->next_tag( 'button' ) ) {
+			$is_submit_by_type  = 'submit' === $p->get_attribute( 'type' );
+			$is_submit_by_class = $p->has_class( 'is-submit' ) || $p->has_class( 'form-button-submit' );
+
+			if ( $is_submit_by_type || $is_submit_by_class ) {
 				$p->set_attribute( 'data-wp-class--is-submitting', 'state.isSubmitting' );
 				$p->set_attribute( 'data-wp-bind--aria-disabled', 'state.isAriaDisabled' );
 				$p->set_attribute( 'data-wp-bind--disabled', 'state.isAriaDisabled' );
 			}
-			++$occurrence;
 		}
+
 		return $p->get_updated_html();
 	}
 

--- a/projects/packages/forms/src/contact-form/css/grunion.scss
+++ b/projects/packages/forms/src/contact-form/css/grunion.scss
@@ -52,8 +52,14 @@
 	display: block;
 }
 
+// jetpack/button: is-hidden class is on inner button element
 .contact-form .wp-block-button:has(button.is-hidden),
 .contact-form .wp-block-jetpack-button:has(button.is-hidden) {
+	display: none;
+}
+
+// core/button: is-hidden class is on wrapper element
+.contact-form .wp-block-button.is-hidden {
 	display: none;
 }
 

--- a/projects/packages/forms/src/form-editor/class-form-editor.php
+++ b/projects/packages/forms/src/form-editor/class-form-editor.php
@@ -76,6 +76,7 @@ class Form_Editor {
 
 			// Supporting blocks.
 			'jetpack/button',
+			'core/button',
 			'jetpack/label',
 			'jetpack/input',
 			'jetpack/options',

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
@@ -1506,4 +1506,87 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 		$spam_meta = get_post_meta( $post_id, '_spam_status_changed_gmt', true );
 		$this->assertEmpty( $spam_meta, 'Spam meta should not be set for non-feedback posts' );
 	}
+
+	/**
+	 * Test navigation button processing with class-based identification (core/button).
+	 *
+	 * @dataProvider data_provider_navigation_button_class_identification
+	 */
+	#[DataProvider( 'data_provider_navigation_button_class_identification' )]
+	public function test_navigation_button_class_identification( $input_html, $expected_attributes, $description ) {
+		// Create minimal wrapper structure that gutenblock_render_form_step_navigation expects
+		$wrapped_html = '<div class="wp-block-jetpack-form-step-navigation"><div class="wp-block-jetpack-form-step-navigation__wrapper">' . $input_html . '</div></div>';
+
+		$result = Contact_Form_Plugin::gutenblock_render_form_step_navigation( array(), $wrapped_html );
+
+		foreach ( $expected_attributes as $attr => $value ) {
+			if ( $value === null ) {
+				$this->assertStringNotContainsString( $attr, $result, "$description: should NOT contain $attr" );
+			} else {
+				$this->assertStringContainsString( "$attr=\"$value\"", $result, "$description: should contain $attr=\"$value\"" );
+			}
+		}
+	}
+
+	/**
+	 * Data provider for navigation button class identification tests.
+	 */
+	public static function data_provider_navigation_button_class_identification() {
+		return array(
+			'previous button by class'       => array(
+				'<button class="form-button-previous">Previous</button>',
+				array(
+					'data-wp-on--click'        => 'actions.previousStep',
+					'data-wp-class--is-hidden' => 'state.isFirstStep',
+				),
+				'Previous button identified by form-button-previous class',
+			),
+			'next button by class'           => array(
+				'<button class="form-button-next">Next</button>',
+				array(
+					'data-wp-on--click'        => 'actions.nextStep',
+					'data-wp-class--is-hidden' => 'state.isLastStep',
+				),
+				'Next button identified by form-button-next class',
+			),
+			'submit button by class'         => array(
+				'<button class="form-button-submit">Submit</button>',
+				array(
+					'data-wp-class--is-hidden' => 'state.isNotLastStep',
+				),
+				'Submit button identified by form-button-submit class',
+			),
+			'previous button by legacy attr' => array(
+				'<button data-id-attr="previous-step">Previous</button>',
+				array(
+					'data-wp-on--click'        => 'actions.previousStep',
+					'data-wp-class--is-hidden' => 'state.isFirstStep',
+				),
+				'Previous button identified by legacy data-id-attr',
+			),
+			'next button by legacy attr'     => array(
+				'<button data-id-attr="next-step">Next</button>',
+				array(
+					'data-wp-on--click'        => 'actions.nextStep',
+					'data-wp-class--is-hidden' => 'state.isLastStep',
+				),
+				'Next button identified by legacy data-id-attr',
+			),
+			'submit button by legacy attr'   => array(
+				'<button data-id-attr="submit-step">Submit</button>',
+				array(
+					'data-wp-class--is-hidden' => 'state.isNotLastStep',
+				),
+				'Submit button identified by legacy data-id-attr',
+			),
+			'regular button not affected'    => array(
+				'<button class="some-other-class">Click me</button>',
+				array(
+					'data-wp-on--click'        => null,
+					'data-wp-class--is-hidden' => null,
+				),
+				'Regular button should not get navigation attributes',
+			),
+		);
+	}
 }

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
@@ -15,6 +15,7 @@ use DOMElement;
 use PHPUnit\Framework\Attributes\Before;
 use PHPUnit\Framework\Attributes\BeforeClass;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use WorDBless\BaseTestCase;
 use WorDBless\Posts;
 use WP_Block;
@@ -3895,5 +3896,94 @@ class Contact_Form_Test extends BaseTestCase {
 		$this->assertFalse( \Automattic\Jetpack\Forms\Jetpack_Forms::is_webhooks_enabled() );
 
 		remove_filter( 'jetpack_forms_webhooks_enabled', '__return_false' );
+	}
+
+	/**
+	 * Test prepare_submit_button adds interactivity attributes to submit buttons.
+	 *
+	 * @dataProvider data_provider_prepare_submit_button
+	 */
+	#[DataProvider( 'data_provider_prepare_submit_button' )]
+	public function test_prepare_submit_button( $input_html, $expected_contains, $expected_not_contains, $description ) {
+		// Use reflection to access private method
+		$reflection = new \ReflectionClass( Contact_Form::class );
+		$method     = $reflection->getMethod( 'prepare_submit_button' );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
+
+		$result = $method->invoke( null, $input_html );
+
+		foreach ( $expected_contains as $expected ) {
+			$this->assertStringContainsString( $expected, $result, "$description: should contain $expected" );
+		}
+
+		foreach ( $expected_not_contains as $not_expected ) {
+			$this->assertStringNotContainsString( $not_expected, $result, "$description: should NOT contain $not_expected" );
+		}
+	}
+
+	/**
+	 * Data provider for prepare_submit_button tests.
+	 */
+	public static function data_provider_prepare_submit_button() {
+		return array(
+			'button with type=submit'        => array(
+				'<button type="submit">Submit</button>',
+				array(
+					'data-wp-class--is-submitting="state.isSubmitting"',
+					'data-wp-bind--aria-disabled="state.isAriaDisabled"',
+					'data-wp-bind--disabled="state.isAriaDisabled"',
+				),
+				array(),
+				'Button with type=submit should get interactivity attributes',
+			),
+			'button with is-submit class'    => array(
+				'<button class="is-submit">Submit</button>',
+				array(
+					'data-wp-class--is-submitting="state.isSubmitting"',
+					'data-wp-bind--aria-disabled="state.isAriaDisabled"',
+					'data-wp-bind--disabled="state.isAriaDisabled"',
+				),
+				array(),
+				'Button with is-submit class should get interactivity attributes',
+			),
+			'button with form-button-submit' => array(
+				'<button class="form-button-submit">Submit</button>',
+				array(
+					'data-wp-class--is-submitting="state.isSubmitting"',
+					'data-wp-bind--aria-disabled="state.isAriaDisabled"',
+					'data-wp-bind--disabled="state.isAriaDisabled"',
+				),
+				array(),
+				'Button with form-button-submit class should get interactivity attributes',
+			),
+			'regular button not affected'    => array(
+				'<button class="some-other-class">Click</button>',
+				array(),
+				array(
+					'data-wp-class--is-submitting',
+					'data-wp-bind--aria-disabled',
+					'data-wp-bind--disabled',
+				),
+				'Regular button should NOT get interactivity attributes',
+			),
+			'multiple buttons mixed'         => array(
+				'<button class="is-previous">Previous</button><button class="is-next">Next</button><button class="is-submit">Submit</button>',
+				array(
+					'data-wp-class--is-submitting="state.isSubmitting"',
+				),
+				array(),
+				'Only submit button should get interactivity attributes in mixed buttons',
+			),
+			'button with multiple classes'   => array(
+				'<button class="wp-block-button__link is-submit form-button-submit">Submit</button>',
+				array(
+					'data-wp-class--is-submitting="state.isSubmitting"',
+				),
+				array(),
+				'Button with multiple classes including is-submit should get attributes',
+			),
+		);
 	}
 }


### PR DESCRIPTION
Fixes FORMS-570

## Proposed changes:

Replace `jetpack/button` with `core/button` for navigation buttons in multi-step forms. This aligns with WordPress core components while maintaining backwards compatibility with existing forms.

**Block Editor:**
- Update button templates to use `core/button` instead of `jetpack/button`
- Map attributes: `element` → `tagName`, `metaName` → `metadata.name`
- Use class-based button identification (`form-button-previous`, `form-button-next`, `form-button-submit`)
- Add visibility classes (`is-previous`, `is-next`, `is-submit`) for CSS control
- Set `type="submit"` on submit button template for proper form submission

**Button Reconciliation (Editor):**
- Support for legacy `jetpack/button` blocks (via `uniqueId` attribute)
- Migrate legacy buttons to `core/button` while preserving custom text
- Only replace inner blocks when buttons are missing or need migration
- Existing `core/button` blocks are preserved as-is (no overwriting)

**PHP Backend:**
- Support both legacy (`data-id-attr`) and new (class-based) button identification
- Improve submit button loading state to use class-based identification instead of "last button" logic

**CSS:**
- Update selectors to handle `core/button` structure (classes on wrapper element vs inner element)
- Support both `jetpack/button` (`:has()` selector) and `core/button` (direct class)

**Tests:**
- `getButtonType()`: Tests for both `core/button` (new format) and `jetpack/button` (legacy format) detection
- `migrateLegacyButton()`: Tests for preserving custom button text during migration, template text fallback, and `type="submit"` for submit buttons

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

## Does this pull request change what data or activity we track or use?

No changes to data tracking.

## Testing instructions:

* Create a new form and convert it to multi-step (add steps)
* Verify navigation buttons show correctly per step:
  - First step: only "Next" visible
  - Middle steps: "Previous" and "Next" visible
  - Last step: "Previous" and "Submit" visible
* Verify submit button shows loading state when form is submitted
* Test an existing multi-step form (created before this change) still works correctly
* **Legacy migration:** If you have an old multi-step form with `jetpack/button` blocks, open it in the editor and verify buttons are migrated while preserving custom labels

🤖 Generated with [Claude Code](https://claude.ai/code)
