### PR TITLE
Social: Fix a couple of styling issues.

### DIFF
--- a/projects/packages/publicize/_inc/components/customize-and-preview/customization-section/styles.module.scss
+++ b/projects/packages/publicize/_inc/components/customize-and-preview/customization-section/styles.module.scss
@@ -13,6 +13,8 @@
 		color: gb.$gray-700;
 		// Float fixes the default fieldset/legend border and padding issues.
 		float: inline-start;
+		// Prevents height collapse in flex fieldsets.
+		min-block-size: fit-content;
 		// Truncate long legend names with ellipsis.
 		overflow: hidden;
 		text-overflow: ellipsis;

--- a/projects/packages/publicize/_inc/components/customize-and-preview/tab-panels/styles.module.scss
+++ b/projects/packages/publicize/_inc/components/customize-and-preview/tab-panels/styles.module.scss
@@ -69,6 +69,7 @@
 
 		.connection-toggle-wrapper {
 			order: -1;
+			background-color: gb.$white;
 		}
 	}
 
@@ -88,6 +89,7 @@
 
 			.connection-toggle-wrapper {
 				order: unset;
+				background: gb.$gray-100;
 			}
 		}
 	}
@@ -106,5 +108,4 @@
 .connection-toggle-wrapper {
 	background: gb.$gray-100;
 	padding: 1rem;
-	padding-bottom: 0;
 }

--- a/projects/packages/publicize/changelog/fix-social-preview-styling
+++ b/projects/packages/publicize/changelog/fix-social-preview-styling
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix customization form legend visibility and connection toggle margin.


### PR DESCRIPTION
Fixes SOCIAL-361

## Proposed changes:

While working on #46945, I noticed a couple of issues, and this PR fixes them.

- **Fix customization section legend not visible**: The `legend` element inside the flex-based `fieldset` was collapsing to zero height. This was a regression introduced by #46925 which changed the modal to use `size="fill"`. Adding `min-block-size: fit-content` prevents the height collapse in flex fieldsets.
- **Fix connection toggle padding and background on smaller screens for per-network mode**: Related to #46889. On mobile in per-network mode, the connection toggle wrapper was missing its white background and had uneven bottom padding. This sets the correct `background-color` for mobile and restores consistent padding.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

N/A

## Does this pull request change what data or activity we track or use?

No changes to data tracking.

## Testing instructions:

- Create or edit a post with Jetpack Social connections configured
- Open the Social preview modal

### 1. Legend visibility

- Switch to "Same for all" mode
- **Verify**: The customization section legend "Customizing for all connections." is visible on all screen sizes

<table>
<tr>
<th>Before</th>
<th>After</th>
</tr>
<tr>
<td>

<img width="911" height="787" alt="Screenshot 2026-02-04 at 3 23 11 PM" src="https://github.com/user-attachments/assets/dcdbef0d-5999-486d-ab9c-40533572faf5" />

</td>
<td>

<img width="905" height="781" alt="Screenshot 2026-02-04 at 3 23 38 PM" src="https://github.com/user-attachments/assets/eca7f370-7f33-44c2-a89c-f138de88ca6b" />

</td>
</tr>
</table>

### 2. Connection toggle padding and background

- Resize your browser to a smaller width (~600px) or use device simulation
- In per-network mode, observe the connection toggle area above the customization section
- **Verify**: The toggle has a white background (not gray) on mobile, and consistent padding all around

<table>
<tr>
<th>Before</th>
<th>After</th>
</tr>
<tr>
<td>

<img width="627" height="414" alt="Screenshot 2026-02-04 at 3 18 18 PM" src="https://github.com/user-attachments/assets/618ea4f5-1406-4c05-8b13-4473d53c7e43" />

</td>
<td>

<img width="628" height="437" alt="Screenshot 2026-02-04 at 3 19 21 PM" src="https://github.com/user-attachments/assets/352f08eb-6066-4530-a5b4-6fc12c4c1df8" />

</td>
</tr>
</table>
