### PR TITLE
IDC: update debug error test

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/debugger/class-jetpack-cxn-tests.php
+++ b/projects/plugins/jetpack/_inc/lib/debugger/class-jetpack-cxn-tests.php
@@ -461,7 +461,7 @@ class Jetpack_Cxn_Tests extends Jetpack_Cxn_Test_Base {
 			if ( isset( $identity_crisis['home'] ) && isset( $identity_crisis['wpcom_home'] ) && $identity_crisis['home'] !== $identity_crisis['wpcom_home'] ) {
 				$messages[] = sprintf(
 					/* translators: Two URLs. The first is the locally-recorded value, the second is the value as recorded on WP.com. */
-					__( 'Your home url is set as `%1$s`, but your WordPress.com connection lists it as `%2$s`.', 'jetpack' ),
+					__( 'Your home URL is set as `%1$s`, but your WordPress.com connection lists it as `%2$s`.', 'jetpack' ),
 					$identity_crisis['home'],
 					$identity_crisis['wpcom_home']
 				);
@@ -470,7 +470,7 @@ class Jetpack_Cxn_Tests extends Jetpack_Cxn_Test_Base {
 			if ( isset( $identity_crisis['siteurl'] ) && isset( $identity_crisis['wpcom_siteurl'] ) && $identity_crisis['siteurl'] !== $identity_crisis['wpcom_siteurl'] ) {
 				$messages[] = sprintf(
 					/* translators: Two URLs. The first is the locally-recorded value, the second is the value as recorded on WP.com. */
-					__( 'Your site url is set as `%1$s`, but your WordPress.com connection lists it as `%2$s`.', 'jetpack' ),
+					__( 'Your site URL is set as `%1$s`, but your WordPress.com connection lists it as `%2$s`.', 'jetpack' ),
 					$identity_crisis['siteurl'],
 					$identity_crisis['wpcom_siteurl']
 				);

--- a/projects/plugins/jetpack/_inc/lib/debugger/class-jetpack-cxn-tests.php
+++ b/projects/plugins/jetpack/_inc/lib/debugger/class-jetpack-cxn-tests.php
@@ -455,15 +455,36 @@ class Jetpack_Cxn_Tests extends Jetpack_Cxn_Test_Base {
 		if ( ! $identity_crisis ) {
 			$result = self::passing_test( array( 'name' => $name ) );
 		} else {
+			$messages = array();
+
+			// Check each URL pair and add a message for any that mismatch.
+			if ( isset( $identity_crisis['home'] ) && isset( $identity_crisis['wpcom_home'] ) && $identity_crisis['home'] !== $identity_crisis['wpcom_home'] ) {
+				$messages[] = sprintf(
+					/* translators: Two URLs. The first is the locally-recorded value, the second is the value as recorded on WP.com. */
+					__( 'Your home url is set as `%1$s`, but your WordPress.com connection lists it as `%2$s`.', 'jetpack' ),
+					$identity_crisis['home'],
+					$identity_crisis['wpcom_home']
+				);
+			}
+
+			if ( isset( $identity_crisis['siteurl'] ) && isset( $identity_crisis['wpcom_siteurl'] ) && $identity_crisis['siteurl'] !== $identity_crisis['wpcom_siteurl'] ) {
+				$messages[] = sprintf(
+					/* translators: Two URLs. The first is the locally-recorded value, the second is the value as recorded on WP.com. */
+					__( 'Your site url is set as `%1$s`, but your WordPress.com connection lists it as `%2$s`.', 'jetpack' ),
+					$identity_crisis['siteurl'],
+					$identity_crisis['wpcom_siteurl']
+				);
+			}
+
+			// Fallback if no specific mismatch was detected (shouldn't happen, but be safe).
+			if ( empty( $messages ) ) {
+				$messages[] = __( 'A URL mismatch was detected between your site and WordPress.com.', 'jetpack' );
+			}
+
 			$result = self::failing_test(
 				array(
 					'name'              => $name,
-					'short_description' => sprintf(
-						/* translators: Two URLs. The first is the locally-recorded value, the second is the value as recorded on WP.com. */
-						__( 'Your url is set as `%1$s`, but your WordPress.com connection lists it as `%2$s`!', 'jetpack' ),
-						$identity_crisis['home'],
-						$identity_crisis['wpcom_home']
-					),
+					'short_description' => implode( ' ', $messages ),
 					'action_label'      => $this->helper_get_support_text(),
 					'action'            => $this->helper_get_support_url(),
 				)

--- a/projects/plugins/jetpack/changelog/update-idc-debug-error
+++ b/projects/plugins/jetpack/changelog/update-idc-debug-error
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Minor debug log text update.
+
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->
The debug test for IDC has a confusing message that only considers home URL misalignment. Since siteurl is the one that is often causing issues, the debug message often sounds like "Your url is set as example.com, but your WordPress.com connection lists it as example.com!".

This PR updates the message to be more useful.

Closes CONNECT-130

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

