### PR TITLE
Help Center: Load for logged out users on experiment

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/DOTCOM-15929-add-the-experiment
+++ b/projects/packages/jetpack-mu-wpcom/changelog/DOTCOM-15929-add-the-experiment
@@ -1,4 +1,4 @@
 Significance: minor
 Type: added
 
-Load the Help Center for logged-out users on /support
+Load the Help Center for logged-out users on /support.

--- a/projects/packages/jetpack-mu-wpcom/changelog/DOTCOM-15929-add-the-experiment
+++ b/projects/packages/jetpack-mu-wpcom/changelog/DOTCOM-15929-add-the-experiment
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Load the Help Center for logged-out users on /support

--- a/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-help-center.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-help-center.php
@@ -633,7 +633,8 @@ class Help_Center {
 		}
 
 		// Support sites only support logged-out users when the Odie answers feature is enabled.
-		if ( ! is_user_logged_in() && ! self::is_proxied() && ! get_option( 'dotcom_support_enable_odie_answers', false ) ) {
+		$experiment_variation = \ExPlat\assign_maybe_anon_user( 'wpcom_ai_on_logged_out_support_pages' );
+		if ( ! is_user_logged_in() && ! self::is_proxied() && ! get_option( 'dotcom_support_enable_odie_answers', false ) && $experiment_variation !== 'treatment' ) {
 			return;
 		}
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-help-center.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-help-center.php
@@ -642,7 +642,7 @@ class Help_Center {
 			if ( function_exists( '\ExPlat\assign_maybe_anon_user' ) ) {
 				$experiment_variation = \ExPlat\assign_maybe_anon_user( 'wpcom_ai_on_logged_out_support_pages' );
 			}
-			if ( ! $experiment_variation === 'treatment' ) {
+			if ( $experiment_variation !== 'treatment' ) {
 				return;
 			}
 		}

--- a/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-help-center.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-help-center.php
@@ -632,13 +632,16 @@ class Help_Center {
 			return;
 		}
 
-		// Support sites only support logged-out users when the Odie answers feature is enabled.
-		$experiment_variation = null;
-		if ( ! is_user_logged_in() && function_exists( '\ExPlat\assign_maybe_anon_user' ) ) {
-			$experiment_variation = \ExPlat\assign_maybe_anon_user( 'wpcom_ai_on_logged_out_support_pages' );
-		}
-		if ( $this->is_support_site && ! is_user_logged_in() && ! self::is_proxied() && ! get_option( 'dotcom_support_enable_odie_answers', false ) && $experiment_variation !== 'treatment' ) {
-			return;
+		// Do not load Help Center for logged-out users on support sites when the experiment variation is not the treatment.
+		if ( $this->is_support_site && ! is_user_logged_in() && ! self::is_proxied() ) {
+			$experiment_variation = null;
+
+			if ( function_exists( '\ExPlat\assign_maybe_anon_user' ) ) {
+				$experiment_variation = \ExPlat\assign_maybe_anon_user( 'calypso_help_center_load_on_logged_out_support_sites' );
+			}
+			if ( $experiment_variation !== 'treatment' ) {
+				return;
+			}
 		}
 
 		if ( $is_next_admin ) {

--- a/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-help-center.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-help-center.php
@@ -637,7 +637,7 @@ class Help_Center {
 		if ( ! is_user_logged_in() && function_exists( '\ExPlat\assign_maybe_anon_user' ) ) {
 			$experiment_variation = \ExPlat\assign_maybe_anon_user( 'wpcom_ai_on_logged_out_support_pages' );
 		}
-		if ( ! is_user_logged_in() && ! self::is_proxied() && ! get_option( 'dotcom_support_enable_odie_answers', false ) && $experiment_variation !== 'treatment' ) {
+		if ( $this->is_support_site && ! is_user_logged_in() && ! self::is_proxied() && ! get_option( 'dotcom_support_enable_odie_answers', false ) && $experiment_variation !== 'treatment' ) {
 			return;
 		}
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-help-center.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-help-center.php
@@ -632,14 +632,17 @@ class Help_Center {
 			return;
 		}
 
-		// Do not load Help Center for logged-out users on support sites when the experiment variation is not the treatment.
-		if ( $this->is_support_site && ! is_user_logged_in() && ! self::is_proxied() ) {
-			$experiment_variation = null;
-
-			if ( function_exists( '\ExPlat\assign_maybe_anon_user' ) ) {
-				$experiment_variation = \ExPlat\assign_maybe_anon_user( 'calypso_help_center_load_on_logged_out_support_sites' );
+		// Do not load Help Center for logged-out users if we are not on support sites and the experiment variation is the treatment.
+		if ( ! is_user_logged_in() && ! self::is_proxied() ) {
+			if ( ! $this->is_support_site ) {
+				return;
 			}
-			if ( $experiment_variation !== 'treatment' ) {
+
+			$experiment_variation = null;
+			if ( function_exists( '\ExPlat\assign_maybe_anon_user' ) ) {
+				$experiment_variation = \ExPlat\assign_maybe_anon_user( 'wpcom_ai_on_logged_out_support_pages' );
+			}
+			if ( ! $experiment_variation === 'treatment' ) {
 				return;
 			}
 		}

--- a/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-help-center.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-help-center.php
@@ -641,6 +641,13 @@ class Help_Center {
 			$experiment_variation = null;
 			if ( function_exists( '\ExPlat\assign_maybe_anon_user' ) ) {
 				$experiment_variation = \ExPlat\assign_maybe_anon_user( 'wpcom_ai_on_logged_out_support_pages' );
+			} else {
+				log2logstash(
+					array(
+						'feature' => 'help-center',
+						'message' => 'ExPlat\assign_maybe_anon_user function is unavailable',
+					)
+				);
 			}
 			if ( $experiment_variation !== 'treatment' ) {
 				return;

--- a/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-help-center.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-help-center.php
@@ -633,7 +633,10 @@ class Help_Center {
 		}
 
 		// Support sites only support logged-out users when the Odie answers feature is enabled.
-		$experiment_variation = \ExPlat\assign_maybe_anon_user( 'wpcom_ai_on_logged_out_support_pages' );
+		$experiment_variation = null;
+		if ( ! is_user_logged_in() && function_exists( '\ExPlat\assign_maybe_anon_user' ) ) {
+			$experiment_variation = \ExPlat\assign_maybe_anon_user( 'wpcom_ai_on_logged_out_support_pages' );
+		}
 		if ( ! is_user_logged_in() && ! self::is_proxied() && ! get_option( 'dotcom_support_enable_odie_answers', false ) && $experiment_variation !== 'treatment' ) {
 			return;
 		}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://linear.app/a8c/issue/DOTCOM-15929/add-the-experiment

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Loads the Help Center for logged out users on /support if they are on 'treatment' for the experiment.


