### PR TITLE
Sync: Minor readme cleanup

### DIFF
--- a/projects/packages/sync/README.md
+++ b/projects/packages/sync/README.md
@@ -87,7 +87,6 @@ $config->ensure(
 
 It's important to note that we consider a list of certain options required for Sync to properly function, therefore the following options will be synced no matter the configuration:
 
-- `jetpack_sync_active_modules`, // Sync related option
 - `jetpack_sync_non_blocking`, // Sync related option
 - `jetpack_sync_non_public_post_stati`, // Sync related option
 - `jetpack_sync_settings_comment_meta_whitelist`, // Sync related option
@@ -149,6 +148,7 @@ It's important to note that we consider a list of certain callables required for
 - `wp_version`
 - `jetpack_connection_active_plugins` // Connection related callable
 - `jetpack_package_versions` // Connection related callable
+- `jetpack_sync_active_modules`
 
 Passing a list of callables will result in syncing those callables plus the required ones.
 

--- a/projects/packages/sync/changelog/update-sync-readme
+++ b/projects/packages/sync/changelog/update-sync-readme
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Minor text update on the readme file.
+
+


### PR DESCRIPTION


## Proposed changes:

* This PR just moves `jetpack_sync_active_modules` from the must-use options list to the must-use callables list, within the Sync package readme.
* For context, this was added to the `jetpack_sync_callable_whitelist` (`MUST_SYNC_DATA_SETTINGS`) in the `Data_Settings` class here: https://github.com/Automattic/jetpack/pull/43134. It was added as a callable here: https://github.com/Automattic/jetpack/pull/38831

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion


## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:

* Proof-read
* @fgiannar I added you as a reviewer even though this is a PR that could just be merged, due to the addition here originally: https://github.com/Automattic/jetpack/pull/43188 - just to be safe.

