### PR TITLE
FormsAdd/form editor back button

### DIFF
--- a/projects/packages/forms/changelog/add-form-editor-back-button
+++ b/projects/packages/forms/changelog/add-form-editor-back-button
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Form editor: add nav button to header.

--- a/projects/packages/forms/src/dashboard/components/edit-form-button/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/edit-form-button/index.tsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { Button } from '@wordpress/components';
-import { useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
@@ -11,25 +10,27 @@ import useConfigValue from '../../../hooks/use-config-value';
 
 type EditFormButtonProps = {
 	formId: number;
+	sourceId?: number;
 };
 
 /**
  * Button that navigates to edit the given `jetpack_form`.
  *
- * @param props        - Props.
- * @param props.formId - Form (post) ID.
+ * @param props          - Props.
+ * @param props.formId   - Form (post) ID.
+ * @param props.sourceId - Optional source form ID for return navigation.
  * @return JSX element.
  */
-export default function EditFormButton( { formId }: EditFormButtonProps ): JSX.Element {
+export default function EditFormButton( { formId, sourceId }: EditFormButtonProps ): JSX.Element {
 	const adminUrl = useConfigValue( 'adminUrl' ) || '';
 
-	const onClick = useCallback( () => {
-		const editPath = `post.php?post=${ formId }&action=edit`;
-		window.location.href = adminUrl ? `${ adminUrl }${ editPath }` : editPath;
-	}, [ adminUrl, formId ] );
+	const sourceParam =
+		typeof sourceId === 'number' ? `&source_id=${ encodeURIComponent( String( sourceId ) ) }` : '';
+	const editPath = `post.php?post=${ formId }&action=edit${ sourceParam }`;
+	const href = adminUrl ? `${ adminUrl }${ editPath }` : editPath;
 
 	return (
-		<Button size="compact" variant="secondary" onClick={ onClick }>
+		<Button size="compact" variant="secondary" href={ href }>
 			{ __( 'Edit form', 'jetpack-forms' ) }
 		</Button>
 	);

--- a/projects/packages/forms/src/dashboard/wp-build/hooks/use-page-header-details.tsx
+++ b/projects/packages/forms/src/dashboard/wp-build/hooks/use-page-header-details.tsx
@@ -141,7 +141,13 @@ export default function usePageHeaderDetails(
 			return [
 				<BackToFormsButton key="back-to-forms" />,
 				...( sourceIdNumber
-					? [ <EditFormButton key="edit-form" formId={ sourceIdNumber } /> ]
+					? [
+							<EditFormButton
+								key="edit-form"
+								formId={ sourceIdNumber }
+								sourceId={ sourceIdNumber }
+							/>,
+					  ]
 					: [] ),
 				<ExportResponsesButton key="export" isPrimary={ false } />,
 				...( statusView === 'trash' ? [ <EmptyTrashButton key="empty-trash" /> ] : [] ),

--- a/projects/packages/forms/src/form-editor/components/editor-back-button/index.tsx
+++ b/projects/packages/forms/src/form-editor/components/editor-back-button/index.tsx
@@ -1,0 +1,51 @@
+/**
+ * WordPress dependencies
+ */
+import { Button, Fill } from '@wordpress/components';
+import { useSelect } from '@wordpress/data';
+import { useMemo } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+/**
+ * Internal dependencies
+ */
+import { FORM_POST_TYPE } from '../../../blocks/shared/util/constants.js';
+import { getFormsReturnUrl } from '../../utils/get-return-url';
+
+/**
+ * Slot fill for editor header back button.
+ *
+ * @return Back button fill or null when not in form editor.
+ */
+export default function EditorBackButton(): JSX.Element | null {
+	const postType = useSelect( select => select( 'core/editor' ).getCurrentPostType(), [] );
+
+	const sourceId = useMemo( () => {
+		const url = new URL( window.location.href );
+		return url.searchParams.get( 'source_id' );
+	}, [] );
+
+	if ( postType !== FORM_POST_TYPE ) {
+		return null;
+	}
+
+	const label = sourceId
+		? __( 'Back to Form', 'jetpack-forms' )
+		: __( 'View Forms', 'jetpack-forms' );
+
+	const href = getFormsReturnUrl( sourceId );
+
+	return (
+		<Fill name="PinnedItems/core">
+			<Button
+				className="jp-forms-editor-back-button"
+				href={ href }
+				label={ label }
+				showTooltip
+				size="compact"
+				variant="secondary"
+			>
+				{ label }
+			</Button>
+		</Fill>
+	);
+}

--- a/projects/packages/forms/src/form-editor/index.tsx
+++ b/projects/packages/forms/src/form-editor/index.tsx
@@ -10,6 +10,7 @@
 import { subscribe, select, dispatch } from '@wordpress/data';
 import { getPlugin, registerPlugin, unregisterPlugin } from '@wordpress/plugins';
 import { FORM_POST_TYPE } from '../blocks/shared/util/constants.js';
+import EditorBackButton from './components/editor-back-button';
 import {
 	activateBlockCategoryOverrides,
 	deactivateBlockCategoryOverrides,
@@ -422,3 +423,8 @@ const setupFormEditorSubscription = () => {
 };
 
 setupFormEditorSubscription();
+
+registerPlugin( 'jetpack-forms-editor-back-button', {
+	render: EditorBackButton,
+	icon: null,
+} );

--- a/projects/packages/forms/src/form-editor/utils/get-return-url.ts
+++ b/projects/packages/forms/src/form-editor/utils/get-return-url.ts
@@ -1,0 +1,21 @@
+/**
+ * Build a Forms dashboard URL for editor return navigation.
+ *
+ * @param sourceId - Optional form ID for single-form responses route.
+ * @return Dashboard URL for Forms or single-form responses.
+ */
+export const getFormsReturnUrl = ( sourceId?: string | null ): string => {
+	const { origin, pathname } = window.location;
+	const wpAdminIndex = pathname.indexOf( '/wp-admin/' );
+	const adminBase =
+		wpAdminIndex >= 0 ? pathname.slice( 0, wpAdminIndex + '/wp-admin/'.length ) : '/wp-admin/';
+	const dashboardBase = `${ origin }${ adminBase }admin.php?page=jetpack-forms-responses-wp-admin`;
+
+	if ( ! sourceId ) {
+		const returnPath = '/forms';
+		return `${ dashboardBase }&p=${ encodeURIComponent( returnPath ) }`;
+	}
+
+	const returnPath = `/responses/inbox?sourceId=${ encodeURIComponent( sourceId ) }`;
+	return `${ dashboardBase }&p=${ encodeURIComponent( returnPath ) }`;
+};


### PR DESCRIPTION
DO NOT MERGE - TRIAL

This demonstrates how we could add a nav button to the form editor header. It is added via one of the two editor header slots, on the right hand side. As currently coded, it will either show View Forms or Back to Form (if a user clicks Edit Form fro the Dashboard > Single Form view). 

Just prepping the PR to share code as is. But this is mostly vibe coded for now, so it needs more review by me prior to any deep review by others. 

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

