### PR TITLE
Charts: Remove redundant moduleNameMapper from jest config

### DIFF
--- a/projects/js-packages/charts/changelog/remove-redundant-jest-config
+++ b/projects/js-packages/charts/changelog/remove-redundant-jest-config
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Remove redundant moduleNameMapper from jest config.

--- a/projects/js-packages/charts/tests/jest.config.cjs
+++ b/projects/js-packages/charts/tests/jest.config.cjs
@@ -12,9 +12,6 @@ module.exports = {
 	},
 	// Transform d3-* ESM packages (pattern accounts for pnpm .pnpm directory structure)
 	transformIgnorePatterns: [ '/node_modules/(?!(\\.pnpm/(d3-|internmap)|d3-|internmap))' ],
-	moduleNameMapper: {
-		...baseConfig.moduleNameMapper,
-	},
 	setupFilesAfterEnv: [
 		...( baseConfig.setupFilesAfterEnv || [] ),
 		path.join( __dirname, 'setup-visx-tooltip-mock.js' ),


### PR DESCRIPTION
## Proposed changes:

* Remove redundant `moduleNameMapper` from the charts jest config - since `baseConfig` is already spread at the top level, explicitly spreading `moduleNameMapper` again served no purpose

### Other information:

- [x] Have you written new tests for your changes, if applicable? N/A - config cleanup only
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them? N/A
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)? N/A

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

* Run `pnpm jest` in `projects/js-packages/charts` to verify tests still pass
* Confirm no behavior change - this is purely cleanup of redundant configuration

Made with [Cursor](https://cursor.com)