### PR TITLE
fix(charts): use containerBounds for tooltip positioning

### DIFF
--- a/projects/js-packages/charts/changelog/fix-charts-tooltip-stale-container-bounds
+++ b/projects/js-packages/charts/changelog/fix-charts-tooltip-stale-container-bounds
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Charts: prevent tooltips from appearing outside container boundaries on page refresh by checking container bounds before positioning.
+Fix tooltip positioning when container moves without triggering containerBounds refresh.

--- a/projects/js-packages/charts/changelog/fix-charts-tooltip-stale-container-bounds
+++ b/projects/js-packages/charts/changelog/fix-charts-tooltip-stale-container-bounds
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Charts: fix tooltip positioning when container bounds become stale after dashboard customization.
+Charts: prevent tooltips from appearing outside container boundaries on page refresh by checking container bounds before positioning.

--- a/projects/js-packages/charts/changelog/fix-charts-tooltip-stale-container-bounds
+++ b/projects/js-packages/charts/changelog/fix-charts-tooltip-stale-container-bounds
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Charts: fix tooltip positioning when container bounds become stale after dashboard customization.

--- a/projects/js-packages/charts/src/charts/conversion-funnel-chart/conversion-funnel-chart.tsx
+++ b/projects/js-packages/charts/src/charts/conversion-funnel-chart/conversion-funnel-chart.tsx
@@ -1,4 +1,3 @@
-import { localPoint } from '@visx/event';
 import { useTooltip, useTooltipInPortal } from '@visx/tooltip';
 import clsx from 'clsx';
 import { type FC, useRef, useMemo, useEffect, useCallback, useContext } from 'react';
@@ -61,7 +60,11 @@ const ConversionFunnelChartInternal: FC< ConversionFunnelChartProps > = ( {
 	// Use custom hook for selection management
 	const { handleBarClick, handleBarKeyDown, clearSelection, getStepState } =
 		useFunnelSelection( hideTooltip );
-	const { containerRef: portalContainerRef, TooltipInPortal } = useTooltipInPortal( {
+	const {
+		containerRef: portalContainerRef,
+		TooltipInPortal,
+		containerBounds,
+	} = useTooltipInPortal( {
 		// use TooltipWithBounds for boundary detection
 		detectBounds: true,
 		// when tooltip containers are scrolled, this will correctly update the Tooltip position
@@ -88,29 +91,32 @@ const ConversionFunnelChartInternal: FC< ConversionFunnelChartProps > = ( {
 	);
 
 	// Helper function to get tooltip coordinates for mouse events
-	const getMouseTooltipCoords = useCallback( ( event: React.MouseEvent ) => {
-		const containerElement = chartRef.current;
-		if ( containerElement ) {
-			const coords = localPoint( containerElement, event.nativeEvent );
-			if ( coords ) {
-				return { x: coords.x, y: coords.y };
-			}
-		}
-		return null;
-	}, [] );
+	// Use clientX/Y and subtract containerBounds to cancel out any stale offset.
+	// TooltipInPortal calculates: tooltipLeft + containerBounds.left + scrollX
+	// By passing (clientX - containerBounds.left), we get correct page coordinates
+	// regardless of whether bounds are stale (e.g., after dashboard customization).
+	const getMouseTooltipCoords = useCallback(
+		( event: React.MouseEvent ) => {
+			return {
+				x: event.clientX - containerBounds.left,
+				y: event.clientY - containerBounds.top,
+			};
+		},
+		[ containerBounds.left, containerBounds.top ]
+	);
 
 	// Helper function to get tooltip coordinates for keyboard events
-	const getKeyboardTooltipCoords = useCallback( ( event: React.KeyboardEvent ) => {
-		const rect = event.currentTarget.getBoundingClientRect();
-		const containerElement = chartRef.current;
-		if ( containerElement ) {
-			const containerRect = containerElement.getBoundingClientRect();
-			const x = rect.left + rect.width / 2 - containerRect.left;
-			const y = rect.top - containerRect.top;
+	// Use fresh getBoundingClientRect() and subtract containerBounds to cancel out stale offset.
+	const getKeyboardTooltipCoords = useCallback(
+		( event: React.KeyboardEvent ) => {
+			const rect = event.currentTarget.getBoundingClientRect();
+			// Calculate center of element in viewport coordinates, then subtract containerBounds
+			const x = rect.left + rect.width / 2 - containerBounds.left;
+			const y = rect.top - containerBounds.top;
 			return { x, y };
-		}
-		return null;
-	}, [] );
+		},
+		[ containerBounds.left, containerBounds.top ]
+	);
 
 	// Helper function to handle step interaction (both click and keyboard)
 	const handleStepInteraction = useCallback(

--- a/projects/js-packages/charts/src/charts/conversion-funnel-chart/conversion-funnel-chart.tsx
+++ b/projects/js-packages/charts/src/charts/conversion-funnel-chart/conversion-funnel-chart.tsx
@@ -97,25 +97,35 @@ const ConversionFunnelChartInternal: FC< ConversionFunnelChartProps > = ( {
 	// regardless of whether bounds are stale (e.g., after dashboard customization).
 	const getMouseTooltipCoords = useCallback(
 		( event: React.MouseEvent ) => {
+			// Don't return coords until container bounds are measured
+			if ( containerBounds.width === 0 || containerBounds.height === 0 ) {
+				return null;
+			}
+
 			return {
 				x: event.clientX - containerBounds.left,
 				y: event.clientY - containerBounds.top,
 			};
 		},
-		[ containerBounds.left, containerBounds.top ]
+		[ containerBounds.width, containerBounds.height, containerBounds.left, containerBounds.top ]
 	);
 
 	// Helper function to get tooltip coordinates for keyboard events
 	// Use fresh getBoundingClientRect() and subtract containerBounds to cancel out stale offset.
 	const getKeyboardTooltipCoords = useCallback(
 		( event: React.KeyboardEvent ) => {
+			// Don't return coords until container bounds are measured
+			if ( containerBounds.width === 0 || containerBounds.height === 0 ) {
+				return null;
+			}
+
 			const rect = event.currentTarget.getBoundingClientRect();
 			// Calculate center of element in viewport coordinates, then subtract containerBounds
 			const x = rect.left + rect.width / 2 - containerBounds.left;
 			const y = rect.top - containerBounds.top;
 			return { x, y };
 		},
-		[ containerBounds.left, containerBounds.top ]
+		[ containerBounds.width, containerBounds.height, containerBounds.left, containerBounds.top ]
 	);
 
 	// Helper function to handle step interaction (both click and keyboard)

--- a/projects/js-packages/charts/src/charts/pie-chart/pie-chart.tsx
+++ b/projects/js-packages/charts/src/charts/pie-chart/pie-chart.tsx
@@ -338,6 +338,11 @@ const PieChartInternal = ( {
 												return;
 											}
 
+											// Don't show tooltip until container bounds are measured
+											if ( containerBounds.width === 0 || containerBounds.height === 0 ) {
+												return;
+											}
+
 											// Use clientX/Y and subtract containerBounds to cancel out any stale offset.
 											// TooltipInPortal calculates: tooltipLeft + containerBounds.left + scrollX
 											// By passing (clientX - containerBounds.left), we get:

--- a/projects/js-packages/charts/src/charts/pie-chart/pie-chart.tsx
+++ b/projects/js-packages/charts/src/charts/pie-chart/pie-chart.tsx
@@ -1,4 +1,3 @@
-import { localPoint } from '@visx/event';
 import { Group } from '@visx/group';
 import { Pie } from '@visx/shape';
 import { useTooltip, useTooltipInPortal } from '@visx/tooltip';
@@ -169,10 +168,10 @@ const PieChartInternal = ( {
 		useTooltip< DataPointPercentage >();
 
 	// Set up portal tooltip for better z-index handling
-	const { containerRef, TooltipInPortal } = useTooltipInPortal( {
+	// We get containerBounds to cancel out stale offsets in the position calculation
+	const { containerRef, TooltipInPortal, containerBounds } = useTooltipInPortal( {
 		detectBounds: true,
 		scroll: true,
-		debounce: 0,
 	} );
 
 	const onMouseLeave = useCallback( () => {
@@ -339,18 +338,16 @@ const PieChartInternal = ( {
 												return;
 											}
 
-											// Get coordinates relative to the current target element
-											const coords = localPoint( event );
-											if ( coords ) {
-												// Account for legend offset when legend is on top
-												const legendOffset =
-													showLegend && legendPosition === 'top' ? legendHeight : 0;
-												showTooltip( {
-													tooltipData: arc.data,
-													tooltipLeft: coords.x + tooltipOffsetX,
-													tooltipTop: coords.y + legendOffset + tooltipOffsetY,
-												} );
-											}
+											// Use clientX/Y and subtract containerBounds to cancel out any stale offset.
+											// TooltipInPortal calculates: tooltipLeft + containerBounds.left + scrollX
+											// By passing (clientX - containerBounds.left), we get:
+											// (clientX - containerBounds.left) + containerBounds.left + scrollX = clientX + scrollX
+											// This gives correct page coordinates regardless of stale bounds.
+											showTooltip( {
+												tooltipData: arc.data,
+												tooltipLeft: event.clientX - containerBounds.left + tooltipOffsetX,
+												tooltipTop: event.clientY - containerBounds.top + tooltipOffsetY,
+											} );
 										};
 
 										const pathProps: SVGProps< SVGPathElement > & { 'data-testid'?: string } = {

--- a/projects/js-packages/charts/src/charts/pie-chart/pie-chart.tsx
+++ b/projects/js-packages/charts/src/charts/pie-chart/pie-chart.tsx
@@ -172,6 +172,7 @@ const PieChartInternal = ( {
 	const { containerRef, TooltipInPortal, containerBounds } = useTooltipInPortal( {
 		detectBounds: true,
 		scroll: true,
+		debounce: 0,
 	} );
 
 	const onMouseLeave = useCallback( () => {

--- a/projects/js-packages/charts/src/charts/pie-semi-circle-chart/pie-semi-circle-chart.tsx
+++ b/projects/js-packages/charts/src/charts/pie-semi-circle-chart/pie-semi-circle-chart.tsx
@@ -164,6 +164,11 @@ const PieSemiCircleChartInternal: FC< PieSemiCircleChartProps > = ( {
 
 	const handleMouseMove = useCallback(
 		( event: MouseEvent< SVGElement >, arc: ArcData ) => {
+			// Don't show tooltip until container bounds are measured
+			if ( containerBounds.width === 0 || containerBounds.height === 0 ) {
+				return;
+			}
+
 			// Use clientX/Y and subtract containerBounds to cancel out any stale offset.
 			// TooltipInPortal calculates: tooltipLeft + containerBounds.left + scrollX
 			// By passing (clientX - containerBounds.left), we get:
@@ -175,7 +180,15 @@ const PieSemiCircleChartInternal: FC< PieSemiCircleChartProps > = ( {
 				tooltipTop: event.clientY - containerBounds.top + tooltipOffsetY,
 			} );
 		},
-		[ containerBounds.left, containerBounds.top, showTooltip, tooltipOffsetX, tooltipOffsetY ]
+		[
+			containerBounds.width,
+			containerBounds.height,
+			containerBounds.left,
+			containerBounds.top,
+			showTooltip,
+			tooltipOffsetX,
+			tooltipOffsetY,
+		]
 	);
 
 	const handleMouseLeave = useCallback( () => {

--- a/projects/js-packages/charts/src/charts/pie-semi-circle-chart/pie-semi-circle-chart.tsx
+++ b/projects/js-packages/charts/src/charts/pie-semi-circle-chart/pie-semi-circle-chart.tsx
@@ -1,4 +1,3 @@
-import { localPoint } from '@visx/event';
 import { Group } from '@visx/group';
 import { Pie } from '@visx/shape';
 import { Text } from '@visx/text';
@@ -157,27 +156,26 @@ const PieSemiCircleChartInternal: FC< PieSemiCircleChartProps > = ( {
 		useTooltip< DataPointPercentage >();
 
 	// Set up portal tooltip for better z-index handling
-	const { containerRef, TooltipInPortal } = useTooltipInPortal( {
+	// We get containerBounds to cancel out stale offsets in the position calculation
+	const { containerRef, TooltipInPortal, containerBounds } = useTooltipInPortal( {
 		detectBounds: true,
 		scroll: true,
-		debounce: 0,
 	} );
 
 	const handleMouseMove = useCallback(
 		( event: MouseEvent< SVGElement >, arc: ArcData ) => {
-			// Get coordinates relative to the current target element
-			const coords = localPoint( event );
-			if ( coords ) {
-				// Account for legend offset when legend is on top
-				const legendOffset = showLegend && legendPosition === 'top' ? legendHeight : 0;
-				showTooltip( {
-					tooltipData: arc.data,
-					tooltipLeft: coords.x + tooltipOffsetX,
-					tooltipTop: coords.y + legendOffset + tooltipOffsetY,
-				} );
-			}
+			// Use clientX/Y and subtract containerBounds to cancel out any stale offset.
+			// TooltipInPortal calculates: tooltipLeft + containerBounds.left + scrollX
+			// By passing (clientX - containerBounds.left), we get:
+			// (clientX - containerBounds.left) + containerBounds.left + scrollX = clientX + scrollX
+			// This gives correct page coordinates regardless of stale bounds.
+			showTooltip( {
+				tooltipData: arc.data,
+				tooltipLeft: event.clientX - containerBounds.left + tooltipOffsetX,
+				tooltipTop: event.clientY - containerBounds.top + tooltipOffsetY,
+			} );
 		},
-		[ showTooltip, tooltipOffsetX, tooltipOffsetY, showLegend, legendPosition, legendHeight ]
+		[ containerBounds.left, containerBounds.top, showTooltip, tooltipOffsetX, tooltipOffsetY ]
 	);
 
 	const handleMouseLeave = useCallback( () => {

--- a/projects/js-packages/charts/src/charts/pie-semi-circle-chart/pie-semi-circle-chart.tsx
+++ b/projects/js-packages/charts/src/charts/pie-semi-circle-chart/pie-semi-circle-chart.tsx
@@ -160,6 +160,7 @@ const PieSemiCircleChartInternal: FC< PieSemiCircleChartProps > = ( {
 	const { containerRef, TooltipInPortal, containerBounds } = useTooltipInPortal( {
 		detectBounds: true,
 		scroll: true,
+		debounce: 0,
 	} );
 
 	const handleMouseMove = useCallback(

--- a/projects/js-packages/charts/src/stories/chart-decorator.tsx
+++ b/projects/js-packages/charts/src/stories/chart-decorator.tsx
@@ -1,5 +1,5 @@
 import { setLocale } from '@automattic/number-formatters';
-import { useEffect } from 'react';
+import { useEffect, useRef, useCallback } from 'react';
 import { GlobalChartsProvider } from '../providers';
 import { CHART_THEME_MAP, DEFAULT_ACCENT_COLOR } from './theme-config';
 import type { Decorator } from '@storybook/react';
@@ -13,8 +13,7 @@ export type ChartStoryArgs< T = Record< string, unknown > > = T & {
 	accentColor?: string;
 	containerWidth?: string;
 	containerHeight?: string;
-	containerOffsetX?: number;
-	containerOffsetY?: number;
+	showOffsetTestButtons?: boolean;
 	resize?: 'none' | 'both' | 'horizontal' | 'vertical';
 	withPadding?: boolean;
 };
@@ -31,28 +30,75 @@ export type ChartStoryArgs< T = Record< string, unknown > > = T & {
 export const chartDecorator: Decorator = ( Story, context ) => {
 	const args = context.args as ChartStoryArgs;
 	const withPadding = args.withPadding !== false;
+	const showOffsetTestButtons = args.showOffsetTestButtons === true;
 
-	const offsetX = args.containerOffsetX || 0;
-	const offsetY = args.containerOffsetY || 0;
-	const hasOffset = offsetX !== 0 || offsetY !== 0;
+	const StoryWithContainer = () => {
+		const containerRef = useRef< HTMLDivElement >( null );
+		const offsetRef = useRef( { x: 0, y: 0 } );
 
-	const StoryWithContainer = () => (
-		<div
-			style={ {
-				resize: args.resize || 'both',
-				overflow: 'auto',
-				padding: withPadding ? '1rem' : undefined,
-				width: args.containerWidth || '800px',
-				height: args.containerHeight || '400px',
-				maxWidth: '1200px',
-				border: '1px dashed #ccc',
-				display: 'inline-block',
-				transform: hasOffset ? `translate(${ offsetX }px, ${ offsetY }px)` : undefined,
-			} }
-		>
-			<Story />
-		</div>
-	);
+		// Direct DOM manipulation to move container without React re-render
+		const moveContainer = useCallback( ( dx: number, dy: number ) => {
+			if ( containerRef.current ) {
+				offsetRef.current.x += dx;
+				offsetRef.current.y += dy;
+				containerRef.current.style.transform = `translate(${ offsetRef.current.x }px, ${ offsetRef.current.y }px)`;
+			}
+		}, [] );
+
+		const resetPosition = useCallback( () => {
+			if ( containerRef.current ) {
+				offsetRef.current = { x: 0, y: 0 };
+				containerRef.current.style.transform = '';
+			}
+		}, [] );
+
+		const moveLeft = useCallback( () => moveContainer( -50, 0 ), [ moveContainer ] );
+		const moveRight = useCallback( () => moveContainer( 50, 0 ), [ moveContainer ] );
+		const moveUp = useCallback( () => moveContainer( 0, -50 ), [ moveContainer ] );
+		const moveDown = useCallback( () => moveContainer( 0, 50 ), [ moveContainer ] );
+
+		return (
+			<>
+				{ showOffsetTestButtons && (
+					<div style={ { marginBottom: '12px', display: 'flex', gap: '8px', flexWrap: 'wrap' } }>
+						<span style={ { fontSize: '12px', color: '#666', alignSelf: 'center' } }>
+							Move container (no re-render):
+						</span>
+						<button type="button" onClick={ moveLeft }>
+							← Left
+						</button>
+						<button type="button" onClick={ moveRight }>
+							Right →
+						</button>
+						<button type="button" onClick={ moveUp }>
+							↑ Up
+						</button>
+						<button type="button" onClick={ moveDown }>
+							Down ↓
+						</button>
+						<button type="button" onClick={ resetPosition }>
+							Reset
+						</button>
+					</div>
+				) }
+				<div
+					ref={ containerRef }
+					style={ {
+						resize: args.resize || 'both',
+						overflow: 'auto',
+						padding: withPadding ? '1rem' : undefined,
+						width: args.containerWidth || '800px',
+						height: args.containerHeight || '400px',
+						maxWidth: '1200px',
+						border: '1px dashed #ccc',
+						display: 'inline-block',
+					} }
+				>
+					<Story />
+				</div>
+			</>
+		);
+	};
 
 	return simpleChartDecorator( StoryWithContainer, context );
 };
@@ -182,14 +228,10 @@ export const sharedChartArgTypes = {
 		control: { type: 'text' },
 		description: 'CSS height value for the chart container (e.g., "400px", "100%")',
 	},
-	containerOffsetX: {
-		control: { type: 'range', min: -300, max: 300, step: 10 },
-		description: 'Horizontal offset to test tooltip positioning after container movement',
-		table: { category: 'Testing' },
-	},
-	containerOffsetY: {
-		control: { type: 'range', min: -300, max: 300, step: 10 },
-		description: 'Vertical offset to test tooltip positioning after container movement',
+	showOffsetTestButtons: {
+		control: 'boolean',
+		description:
+			'Show buttons to move the container via DOM manipulation (no re-render) for testing tooltip positioning',
 		table: { category: 'Testing' },
 	},
 	resize: {

--- a/projects/js-packages/charts/src/stories/chart-decorator.tsx
+++ b/projects/js-packages/charts/src/stories/chart-decorator.tsx
@@ -13,6 +13,8 @@ export type ChartStoryArgs< T = Record< string, unknown > > = T & {
 	accentColor?: string;
 	containerWidth?: string;
 	containerHeight?: string;
+	containerOffsetX?: number;
+	containerOffsetY?: number;
 	resize?: 'none' | 'both' | 'horizontal' | 'vertical';
 	withPadding?: boolean;
 };
@@ -30,6 +32,10 @@ export const chartDecorator: Decorator = ( Story, context ) => {
 	const args = context.args as ChartStoryArgs;
 	const withPadding = args.withPadding !== false;
 
+	const offsetX = args.containerOffsetX || 0;
+	const offsetY = args.containerOffsetY || 0;
+	const hasOffset = offsetX !== 0 || offsetY !== 0;
+
 	const StoryWithContainer = () => (
 		<div
 			style={ {
@@ -41,6 +47,7 @@ export const chartDecorator: Decorator = ( Story, context ) => {
 				maxWidth: '1200px',
 				border: '1px dashed #ccc',
 				display: 'inline-block',
+				transform: hasOffset ? `translate(${ offsetX }px, ${ offsetY }px)` : undefined,
 			} }
 		>
 			<Story />
@@ -174,6 +181,16 @@ export const sharedChartArgTypes = {
 	containerHeight: {
 		control: { type: 'text' },
 		description: 'CSS height value for the chart container (e.g., "400px", "100%")',
+	},
+	containerOffsetX: {
+		control: { type: 'range', min: -300, max: 300, step: 10 },
+		description: 'Horizontal offset to test tooltip positioning after container movement',
+		table: { category: 'Testing' },
+	},
+	containerOffsetY: {
+		control: { type: 'range', min: -300, max: 300, step: 10 },
+		description: 'Vertical offset to test tooltip positioning after container movement',
+		table: { category: 'Testing' },
 	},
 	resize: {
 		control: { type: 'select' },

--- a/projects/js-packages/charts/tests/jest.config.cjs
+++ b/projects/js-packages/charts/tests/jest.config.cjs
@@ -15,4 +15,8 @@ module.exports = {
 	moduleNameMapper: {
 		...baseConfig.moduleNameMapper,
 	},
+	setupFilesAfterEnv: [
+		...( baseConfig.setupFilesAfterEnv || [] ),
+		path.join( __dirname, 'setup-visx-tooltip-mock.js' ),
+	],
 };

--- a/projects/js-packages/charts/tests/setup-visx-tooltip-mock.js
+++ b/projects/js-packages/charts/tests/setup-visx-tooltip-mock.js
@@ -1,0 +1,28 @@
+/**
+ * Mock for `@visx/tooltip`'s useTooltipInPortal hook to provide valid containerBounds in tests.
+ *
+ * In JSDOM, getBoundingClientRect() returns zeros since there's no real layout.
+ * This causes our tooltip positioning guard (which checks containerBounds.width/height > 0)
+ * to prevent tooltips from showing in tests.
+ *
+ * This mock wraps the real hook and overrides containerBounds with non-zero values.
+ */
+
+jest.mock( '@visx/tooltip', () => {
+	const actualVisxTooltip = jest.requireActual( '@visx/tooltip' );
+	return {
+		...actualVisxTooltip,
+		useTooltipInPortal: config => {
+			const result = actualVisxTooltip.useTooltipInPortal( config );
+			return {
+				...result,
+				// Provide non-zero bounds so tooltip positioning guard passes in tests
+				containerBounds: {
+					...result.containerBounds,
+					width: result.containerBounds.width || 500,
+					height: result.containerBounds.height || 500,
+				},
+			};
+		},
+	};
+} );

--- a/projects/js-packages/charts/tests/setup-visx-tooltip-mock.js
+++ b/projects/js-packages/charts/tests/setup-visx-tooltip-mock.js
@@ -21,6 +21,8 @@ jest.mock( '@visx/tooltip', () => {
 					...result.containerBounds,
 					width: result.containerBounds.width || 500,
 					height: result.containerBounds.height || 500,
+					left: result.containerBounds.left || 0,
+					top: result.containerBounds.top || 0,
 				},
 			};
 		},


### PR DESCRIPTION
## Proposed changes:
- Fix tooltip positioning in chart components when container bounds become stale
- Replace `localPoint()` with `clientX/Y` minus `containerBounds` to cancel out stale offsets
- The issue occurs when the chart container is moved (e.g., after dashboard customization) but `containerBounds` hasn't been refreshed yet
- The fix ensures TooltipInPortal calculates correct page coordinates: `(clientX - containerBounds.left) + containerBounds.left + scrollX = clientX + scrollX`

**Components updated:**
- Conversion Funnel Chart
- Pie Chart
- Pie Semi-Circle Chart

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion


## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

### Using Storybook (Recommended)

1. Run Storybook:
   ```bash
   cd projects/js-packages/charts && pnpm run storybook
   ```

2. Navigate to **Charts Library > Pie Chart > WithTooltips**

3. In the Controls panel, enable **showOffsetTestButtons** (under "Testing" category)

4. Hover over pie segments - verify tooltip appears at cursor position

5. Click the **Right →** or **Down ↓** buttons to move the container (these use direct DOM manipulation, no React re-render)

6. Hover over segments again - **tooltip should still follow the cursor correctly**

**Expected (with fix):** Tooltip stays aligned with cursor after moving container.

**Bug (without fix):** Tooltip appears offset from cursor position.

This works for all chart stories: Pie Chart, Pie Semi Circle Chart, Conversion Funnel Chart, etc.

### Before

https://github.com/user-attachments/assets/b759da33-5019-4147-aca3-23640e2cf371

### After


https://github.com/user-attachments/assets/5b38924b-d90e-4b87-a588-32816d8f6f6f




### In Production

* Go to a dashboard or page that uses any of the affected chart components
* Hover over chart elements to see tooltips
* Move/resize the chart container (e.g., via dashboard customization)
* Hover again - tooltips should still appear at the correct position near the cursor