### PR TITLE
Forms: refined shared styles for inspector fields

### DIFF
--- a/projects/packages/forms/changelog/update-forms-dash-shared-styles
+++ b/projects/packages/forms/changelog/update-forms-dash-shared-styles
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Refine inspector field styles.

--- a/projects/packages/forms/routes/responses/response/index.tsx
+++ b/projects/packages/forms/routes/responses/response/index.tsx
@@ -202,7 +202,6 @@ function SingleResponseView( {
 			<ResponseFieldsIterator
 				fields={ response.fields }
 				onFilePreview={ handleFilePreview }
-				className="jp-forms__inbox-response-data"
 			/>
 
 			{ response.status === 'spam' && (

--- a/projects/packages/forms/routes/responses/response/index.tsx
+++ b/projects/packages/forms/routes/responses/response/index.tsx
@@ -199,13 +199,11 @@ function SingleResponseView( {
 
 			<ResponseMeta response={ response } />
 
-			<div className="jp-forms__inbox-response-data">
-				<ResponseFieldsIterator
-					fields={ response.fields }
-					onFilePreview={ handleFilePreview }
-					className="jp-forms__inbox-response-data"
-				/>
-			</div>
+			<ResponseFieldsIterator
+				fields={ response.fields }
+				onFilePreview={ handleFilePreview }
+				className="jp-forms__inbox-response-data"
+			/>
 
 			{ response.status === 'spam' && (
 				<div className="jp-forms__inbox__tip-container">

--- a/projects/packages/forms/routes/responses/response/index.tsx
+++ b/projects/packages/forms/routes/responses/response/index.tsx
@@ -199,10 +199,7 @@ function SingleResponseView( {
 
 			<ResponseMeta response={ response } />
 
-			<ResponseFieldsIterator
-				fields={ response.fields }
-				onFilePreview={ handleFilePreview }
-			/>
+			<ResponseFieldsIterator fields={ response.fields } onFilePreview={ handleFilePreview } />
 
 			{ response.status === 'spam' && (
 				<div className="jp-forms__inbox__tip-container">

--- a/projects/packages/forms/routes/responses/response/style.scss
+++ b/projects/packages/forms/routes/responses/response/style.scss
@@ -17,8 +17,6 @@ $inspector-padding: 16px;
 }
 
 .jp-forms__inbox-response-data {
-	font-size: var(--jp-forms-font-size-regular);
-	line-height: 24px;
 	padding: 0 $inspector-padding;
 
 	// old field format renders without .jp-forms__field-preview

--- a/projects/packages/forms/routes/responses/response/style.scss
+++ b/projects/packages/forms/routes/responses/response/style.scss
@@ -16,28 +16,6 @@ $inspector-padding: 16px;
 	gap: 0 !important;
 }
 
-.jp-forms__inbox-response-data {
-	padding: 0 $inspector-padding;
-
-	// old field format renders without .jp-forms__field-preview
-	&:not(.is-collection-format) {
-
-		display: flex;
-		flex-direction: column;
-		row-gap: 24px;
-		padding-top: 24px;
-		padding-bottom: 24px;
-
-		.jp-forms__inbox-response-data-label {
-			font-weight: 600;
-		}
-
-		.jp-forms__inbox-response-data-value {
-			white-space: pre-wrap;
-		}
-	}
-}
-
 .jp-forms__inbox__tip-container {
 	border-top: 1px solid var(--wpds-color-stroke-surface-neutral, #e0e0e0);
 	margin: auto 0 0 0;

--- a/projects/packages/forms/src/dashboard/components/inspector/body.tsx
+++ b/projects/packages/forms/src/dashboard/components/inspector/body.tsx
@@ -181,11 +181,7 @@ const ResponseViewBody = ( {
 			<div ref={ ref } className="jp-forms__inbox-response">
 				<ResponseMeta response={ response } />
 
-				<ResponseFieldsIterator
-					fields={ response.fields }
-					onFilePreview={ handleFilePreview }
-					className="jp-forms__inbox-response-data"
-				/>
+				<ResponseFieldsIterator fields={ response.fields } onFilePreview={ handleFilePreview } />
 				{ isPreviewModalOpen && previewFile && onModalStateChange && (
 					<Modal
 						title={ decodeEntities( previewFile.name ) }

--- a/projects/packages/forms/src/dashboard/components/inspector/response-fields/field-preview/style.scss
+++ b/projects/packages/forms/src/dashboard/components/inspector/response-fields/field-preview/style.scss
@@ -1,35 +1,49 @@
-.jp-forms__inbox-response-data.is-collection-format {
+.jp-forms__inbox-response-data {
+	padding: 0 16px;
+	word-break: break-word;
 
-	.jp-forms__field-preview {
+	&.is-collection-format {
+
+		.jp-forms__field-preview {
+			padding-top: 24px;
+			padding-bottom: 24px;
+			// Multiple variables as fallback until style tokens are available everywhere.
+			border-bottom: 1px solid var(--wpds-color-stroke-surface-neutral, var(--jp-forms-border-color, #e0e0e0));
+		}
+
+		.jp-forms__field-preview-icon {
+			flex-shrink: 0;
+		}
+
+		.jp-forms__field-preview-content {
+			min-width: 0; // Prevents flex item from overflowing
+			word-break: break-word;
+			line-height: var(--wpds-font-line-height-sm, 20px);
+		}
+
+		// Value needed for positioning with the icon in case label is missing.
+		.jp-forms__field-preview-label,
+		.jp-forms__field-preview-value {
+			// Align first line centrally with the 24px icon.
+			margin-top: calc((24px - var(--wpds-font-line-height-sm, 20px)) / 2);
+		}
+	}
+
+	// Old field format renders without .jp-forms__field-preview.
+	&:not(.is-collection-format) {
+		display: flex;
+		flex-direction: column;
+		row-gap: 24px;
 		padding-top: 24px;
 		padding-bottom: 24px;
-		// Multiple variables as fallback until style tokens are available everywhere.
-		border-bottom: 1px solid var(--wpds-color-stroke-surface-neutral, var(--jp-forms-border-color, #e0e0e0));
 	}
+}
 
-	.jp-forms__field-preview-icon {
-		flex-shrink: 0;
-	}
+.jp-forms__field-preview-label {
+	color: var(--wpds-color-fg-content-neutral-weak, #6d6d6d);
+	font-weight: 300;
+}
 
-	.jp-forms__field-preview-content {
-		min-width: 0; // Prevents flex item from overflowing
-		word-break: break-word;
-		line-height: var(--wpds-font-line-height-sm, 20px);
-	}
-
-	.jp-forms__field-preview-label {
-		color: var(--wpds-color-fg-content-neutral-weak, #6d6d6d);
-		font-weight: 300;
-	}
-
-	// Value needed for positioning with the icon in case label is missing.
-	.jp-forms__field-preview-label,
-	.jp-forms__field-preview-value {
-		// Align first line centrally with the 24px icon.
-		margin-top: calc((24px - var(--wpds-font-line-height-sm, 20px)) / 2);
-	}
-
-	.jp-forms__field-preview-value {
-		white-space: pre-wrap;
-	}
+.jp-forms__inbox-response-data-value {
+	white-space: pre-wrap;
 }

--- a/projects/packages/forms/src/dashboard/components/inspector/response-fields/field-preview/style.scss
+++ b/projects/packages/forms/src/dashboard/components/inspector/response-fields/field-preview/style.scss
@@ -7,7 +7,7 @@
 		.jp-forms__field-preview {
 			padding-top: 24px;
 			padding-bottom: 24px;
-			// Multiple variables as fallback until style tokens are available everywhere.
+			// Multiple variables as fallback until style tokens are fully available.
 			border-bottom: 1px solid var(--wpds-color-stroke-surface-neutral, var(--jp-forms-border-color, #e0e0e0));
 		}
 

--- a/projects/packages/forms/src/dashboard/components/inspector/response-fields/field-preview/style.scss
+++ b/projects/packages/forms/src/dashboard/components/inspector/response-fields/field-preview/style.scss
@@ -3,7 +3,8 @@
 	.jp-forms__field-preview {
 		padding-top: 24px;
 		padding-bottom: 24px;
-		border-bottom: 1px solid var(--jp-forms-border-color);
+		// Multiple variables as fallback until style tokens are available everywhere.
+		border-bottom: 1px solid var(--wpds-color-stroke-surface-neutral, var(--jp-forms-border-color, #e0e0e0));
 	}
 
 	.jp-forms__field-preview-icon {
@@ -13,12 +14,19 @@
 	.jp-forms__field-preview-content {
 		min-width: 0; // Prevents flex item from overflowing
 		word-break: break-word;
+		line-height: var(--wpds-font-line-height-sm, 20px);
 	}
 
 	.jp-forms__field-preview-label {
-		line-height: 24px; // size of the icon
+		color: var(--wpds-color-fg-content-neutral-weak, #6d6d6d);
 		font-weight: 300;
-		color: var(--jp-gray-40, #757575);
+	}
+
+	// Value needed for positioning with the icon in case label is missing.
+	.jp-forms__field-preview-label,
+	.jp-forms__field-preview-value {
+		// Align first line centrally with the 24px icon.
+		margin-top: calc((24px - var(--wpds-font-line-height-sm, 20px)) / 2);
 	}
 
 	.jp-forms__field-preview-value {

--- a/projects/packages/forms/src/dashboard/components/inspector/response-fields/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/inspector/response-fields/index.tsx
@@ -17,7 +17,6 @@ import type { FileItem, ResponseField, ResponseFields } from '../../../../types/
 export type ResponseFieldsProps = {
 	fields: ResponseFields;
 	onFilePreview: ( file: FileItem | { url: string; name: string } ) => () => void;
-	className: string;
 };
 
 /**
@@ -26,16 +25,14 @@ export type ResponseFieldsProps = {
  * @param props               - Component props.
  * @param props.fields        - The response fields (array or record).
  * @param props.onFilePreview - Callback that returns a handler to open file preview for a given file.
- * @param props.className     - CSS class for the container.
  * @return The response fields view.
  */
 const ResponseFieldsIterator = ( {
 	fields,
 	onFilePreview,
-	className,
 }: ResponseFieldsProps ): import('react').JSX.Element => {
 	const fieldsAreNewFormat = isFieldsCollection( fields );
-	const rootClass = clsx( className, {
+	const rootClass = clsx( 'jp-forms__inbox-response-data', {
 		'is-collection-format': fieldsAreNewFormat,
 	} );
 	const renderFieldValue = ( value: unknown ) => {

--- a/projects/packages/forms/src/dashboard/components/inspector/style.scss
+++ b/projects/packages/forms/src/dashboard/components/inspector/style.scss
@@ -58,9 +58,6 @@
 }
 
 .jp-forms__inbox-response-data {
-
-	font-size: var(--jp-forms-font-size-regular);
-	line-height: 24px;
 	padding: 0 16px;
 
 	// old field format renders without .jp-forms__field-preview

--- a/projects/packages/forms/src/dashboard/components/inspector/style.scss
+++ b/projects/packages/forms/src/dashboard/components/inspector/style.scss
@@ -57,27 +57,6 @@
 	}
 }
 
-.jp-forms__inbox-response-data {
-	padding: 0 16px;
-
-	// old field format renders without .jp-forms__field-preview
-	&:not(.is-collection-format) {
-
-		@include mixins.flex-column;
-		row-gap: 24px;
-		padding-top: 24px;
-		padding-bottom: 24px;
-
-		.jp-forms__inbox-response-data-label {
-			font-weight: 600;
-		}
-
-		.jp-forms__inbox-response-data-value {
-			white-space: pre-wrap;
-		}
-	}
-}
-
 .jp-forms-response-content {
 	display: flex;
 	flex-direction: column;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Follow-up to:
- https://github.com/Automattic/jetpack/pull/46929
- https://github.com/Automattic/jetpack/pull/46799
- https://github.com/Automattic/jetpack/pull/46938

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Remove double wrapping of fields which caused double padding in sidebar (slipped in with https://github.com/Automattic/jetpack/pull/46938)
* Use design tokens with fallbacks to either JP system variables or Hex; ensures things work between old and new dash
* Move typography styles from all fields wrapper to singular field wrapper
* Update typography rules to match latest designs (line height 24px → 20px) 
* Use margin-top calculation for positioning texts with icon; the previous `line-height: 24px` for positioning was problematic when there were multi-line labels. Now positioning works also when label is missing:
    <img width="390" height="370" alt="Screenshot 2026-02-05 at 14 31 15" src="https://github.com/user-attachments/assets/dbba0bf5-8cd3-4359-bc97-4ce10b25a5fb" />


#### WP Build dash

| Before | After |
|--------|-------|
| <img width="405" alt="image" src="https://github.com/user-attachments/assets/27b28647-6772-4cec-874e-9dec818ba977" /> | <img width="412" alt="image" src="https://github.com/user-attachments/assets/0cc312c5-100f-4573-b118-68dda332f84f" /> |

#### Old dash

| Before | After |
|--------|-------|
| <img width="430" alt="image" src="https://github.com/user-attachments/assets/a869d90e-958a-48a5-a3ac-5aa8f9227af4" /> | <img width="430" alt="image" src="https://github.com/user-attachments/assets/bb78319f-f363-4bcd-87cb-613358dea46c" /> |


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Test fields in old and new dashboard
