### PR TITLE
CHARTS-162: Add renderTooltip prop for custom tooltip rendering in pie charts

### DIFF
--- a/projects/js-packages/charts/changelog/add-charts-render-tooltip
+++ b/projects/js-packages/charts/changelog/add-charts-render-tooltip
@@ -1,4 +1,4 @@
 Significance: minor
 Type: added
 
-Add renderTooltip prop for custom tooltip rendering in pie charts
+Add renderTooltip prop for custom tooltip rendering in pie charts.

--- a/projects/js-packages/charts/changelog/add-charts-render-tooltip
+++ b/projects/js-packages/charts/changelog/add-charts-render-tooltip
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add renderTooltip prop for custom tooltip rendering in pie charts

--- a/projects/js-packages/charts/src/charts/pie-chart/index.ts
+++ b/projects/js-packages/charts/src/charts/pie-chart/index.ts
@@ -1,2 +1,2 @@
 export { default as PieChart, PieChartUnresponsive } from './pie-chart';
-export type { PieChartProps } from './pie-chart';
+export type { PieChartProps, PieChartRenderTooltipParams } from './pie-chart';

--- a/projects/js-packages/charts/src/charts/pie-chart/pie-chart.tsx
+++ b/projects/js-packages/charts/src/charts/pie-chart/pie-chart.tsx
@@ -27,6 +27,27 @@ import type { BaseChartProps, DataPointPercentage, Optional } from '../../types'
 import type { ChartComponentWithComposition } from '../private/chart-composition';
 import type { SVGProps, MouseEvent, ReactNode, FC } from 'react';
 
+/**
+ * Parameters passed to the renderTooltip function for pie charts.
+ */
+export type PieChartRenderTooltipParams = {
+	/**
+	 * The data point being hovered, including label, value, and percentage.
+	 */
+	tooltipData: DataPointPercentage;
+};
+
+/**
+ * Default tooltip renderer for pie charts.
+ * Renders a BaseTooltip with the hovered segment's data.
+ *
+ * @param {PieChartRenderTooltipParams} params - The tooltip parameters containing the hovered data point
+ * @return {ReactNode} The rendered tooltip content
+ */
+const renderDefaultPieTooltip = ( { tooltipData }: PieChartRenderTooltipParams ): ReactNode => {
+	return <BaseTooltip data={ tooltipData } top={ 0 } left={ 0 } renderContainer={ false } />;
+};
+
 export interface PieChartProps extends BaseChartProps< DataPointPercentage[] > {
 	/**
 	 * Inner radius in pixels. If > 0, creates a donut chart. Defaults to 0.
@@ -92,6 +113,12 @@ export interface PieChartProps extends BaseChartProps< DataPointPercentage[] > {
 	 * Vertical offset for tooltip positioning in pixels (default: -15)
 	 */
 	tooltipOffsetY?: number;
+
+	/**
+	 * Custom render function for tooltip content.
+	 * When provided, replaces the default BaseTooltip with custom content.
+	 */
+	renderTooltip?: ( params: PieChartRenderTooltipParams ) => ReactNode;
 }
 
 // Base props type with optional responsive properties
@@ -160,6 +187,7 @@ const PieChartInternal = ( {
 	children = null,
 	tooltipOffsetX = 0,
 	tooltipOffsetY = -15,
+	renderTooltip = renderDefaultPieTooltip,
 }: PieChartProps ) => {
 	const providerTheme = useGlobalChartsTheme();
 	const chartId = useChartId( providedChartId );
@@ -435,9 +463,7 @@ const PieChartInternal = ( {
 
 				{ withTooltips && tooltipOpen && tooltipData && (
 					<TooltipInPortal top={ tooltipTop || 0 } left={ tooltipLeft || 0 }>
-						<div role="tooltip">
-							<BaseTooltip data={ tooltipData } top={ 0 } left={ 0 } renderContainer={ false } />
-						</div>
+						<div role="tooltip">{ renderTooltip( { tooltipData } ) }</div>
 					</TooltipInPortal>
 				) }
 

--- a/projects/js-packages/charts/src/charts/pie-chart/stories/index.api.mdx
+++ b/projects/js-packages/charts/src/charts/pie-chart/stories/index.api.mdx
@@ -19,6 +19,7 @@ Main component for rendering pie and donut charts.
 | `gapScale` | `number` | `0` | Scale of gaps between segments (0-1) |
 | `cornerScale` | `number` | `0` | Scale of corner rounding for segments (0-1) |
 | `withTooltips` | `boolean` | `false` | Enable interactive tooltips on hover |
+| `renderTooltip` | `(params: PieChartRenderTooltipParams) => ReactNode` | - | Custom tooltip render function |
 | `animation` | `boolean` | `false` | Enable entry animation on initial render. Creates a radial wipe reveal effect. Automatically respects user's `prefers-reduced-motion` system setting |
 | `showLegend` | `boolean` | `false` | Display chart legend |
 | `legendInteractive` | `boolean` | `false` | Enable clickable legend items to show/hide segments. Requires `chartId` and `GlobalChartsProvider`. When segments are hidden, percentages recalculate so visible segments total 100%. **Note:** Only works with props-based legends (`showLegend={true}`), not with composition API (`<PieChart.Legend />`) |
@@ -77,6 +78,15 @@ The Legend component for displaying chart data labels. Can be used either as a p
 <PieChart>
   <PieChart.Legend position="bottom" orientation="horizontal" />
 </PieChart>
+```
+
+## PieChartRenderTooltipParams Type
+
+```typescript
+type PieChartRenderTooltipParams = {
+	/** The data point being hovered, including label, value, and percentage. */
+	tooltipData: DataPointPercentage;
+};
 ```
 
 ## DataPointPercentage Type

--- a/projects/js-packages/charts/src/charts/pie-chart/stories/tooltip.stories.tsx
+++ b/projects/js-packages/charts/src/charts/pie-chart/stories/tooltip.stories.tsx
@@ -1,0 +1,290 @@
+import { formatNumber } from '@automattic/number-formatters';
+import { GlobalChartsProvider } from '../../../providers';
+import {
+	chartDecorator,
+	sharedChartArgTypes,
+	ChartStoryArgs,
+} from '../../../stories/chart-decorator';
+import { legendArgTypes } from '../../../stories/legend-config';
+import { osUsageData as data } from '../../../stories/sample-data';
+import { sharedThemeArgs, themeArgTypes } from '../../../stories/theme-config';
+import { PieChart, PieChartRenderTooltipParams } from '../index';
+import type { Meta, StoryFn, StoryObj } from '@storybook/react';
+
+type StoryArgs = ChartStoryArgs< React.ComponentProps< typeof PieChart > >;
+
+const meta: Meta< StoryArgs > = {
+	title: 'JS Packages/Charts Library/Charts/Pie Chart/Tooltips',
+	component: PieChart,
+	parameters: {
+		layout: 'centered',
+	},
+	decorators: [ chartDecorator ],
+	argTypes: {
+		...sharedChartArgTypes,
+		...themeArgTypes,
+		...legendArgTypes,
+		size: {
+			control: {
+				type: 'range',
+				min: 100,
+				max: 800,
+				step: 10,
+				default: 400,
+			},
+			description: 'Diameter of the pie chart in pixels',
+			table: { category: 'Dimensions' },
+		},
+	},
+};
+
+export default meta;
+
+const Template: StoryFn< typeof PieChart > = args => <PieChart { ...args } />;
+
+const tooltipStoryArgs = {
+	...sharedThemeArgs,
+	data,
+	size: 400,
+	withTooltips: true,
+	containerWidth: '432px',
+	containerHeight: '432px',
+	resize: 'none' as const,
+};
+
+export const Default: StoryObj< typeof PieChart > = Template.bind( {} );
+Default.args = {
+	...tooltipStoryArgs,
+};
+Default.parameters = {
+	docs: {
+		description: {
+			story: 'Default pie chart with tooltips enabled using the built-in BaseTooltip component.',
+		},
+	},
+};
+
+export const NoTooltips: StoryObj< typeof PieChart > = Template.bind( {} );
+NoTooltips.args = {
+	...tooltipStoryArgs,
+	withTooltips: false,
+};
+NoTooltips.parameters = {
+	docs: {
+		description: {
+			story: 'Pie chart with tooltips disabled.',
+		},
+	},
+};
+
+export const Custom: StoryObj< typeof PieChart > = Template.bind( {} );
+Custom.args = {
+	...tooltipStoryArgs,
+	renderTooltip: ( { tooltipData }: PieChartRenderTooltipParams ) => {
+		return (
+			<div
+				style={ {
+					backgroundColor: '#1a1a2e',
+					color: '#eaeaea',
+					padding: '12px 16px',
+					borderRadius: '8px',
+					boxShadow: '0 4px 12px rgba(0, 0, 0, 0.3)',
+					minWidth: '150px',
+				} }
+			>
+				<div
+					style={ {
+						fontSize: '16px',
+						fontWeight: 'bold',
+						marginBottom: '8px',
+						borderBottom: '1px solid #333',
+						paddingBottom: '8px',
+					} }
+				>
+					{ tooltipData.label }
+				</div>
+				<div style={ { display: 'flex', flexDirection: 'column', gap: '4px' } }>
+					<div style={ { display: 'flex', justifyContent: 'space-between' } }>
+						<span style={ { color: '#888' } }>Value:</span>
+						<span style={ { fontWeight: 'bold' } }>{ formatNumber( tooltipData.value ) }</span>
+					</div>
+					<div style={ { display: 'flex', justifyContent: 'space-between' } }>
+						<span style={ { color: '#888' } }>Percentage:</span>
+						<span
+							style={ {
+								fontWeight: 'bold',
+								color: '#4ade80',
+							} }
+						>
+							{ tooltipData.percentage }%
+						</span>
+					</div>
+				</div>
+			</div>
+		);
+	},
+};
+Custom.parameters = {
+	docs: {
+		description: {
+			story: `Custom tooltip rendering using the \`renderTooltip\` prop. This example demonstrates a dark-themed tooltip with styled layout.
+
+**Usage:**
+\`\`\`tsx
+<PieChart
+  data={data}
+  withTooltips={true}
+  renderTooltip={({ tooltipData }) => (
+    <div>
+      <h3>{tooltipData.label}</h3>
+      <p>Value: {tooltipData.value}</p>
+      <p>Percentage: {tooltipData.percentage}%</p>
+    </div>
+  )}
+/>
+\`\`\``,
+		},
+	},
+};
+
+export const CustomWithEmoji: StoryObj< typeof PieChart > = Template.bind( {} );
+CustomWithEmoji.args = {
+	...tooltipStoryArgs,
+	renderTooltip: ( { tooltipData }: PieChartRenderTooltipParams ) => {
+		const getEmoji = ( label: string ) => {
+			const emojiMap: Record< string, string > = {
+				Windows: '🪟',
+				MacOS: '🍎',
+				Linux: '🐧',
+				Other: '🖥️',
+			};
+			return emojiMap[ label ] || '📊';
+		};
+
+		return (
+			<div
+				style={ {
+					backgroundColor: 'white',
+					padding: '12px',
+					borderRadius: '12px',
+					boxShadow: '0 2px 8px rgba(0, 0, 0, 0.15)',
+					textAlign: 'center',
+				} }
+			>
+				<div style={ { fontSize: '32px', marginBottom: '4px' } }>
+					{ getEmoji( tooltipData.label ) }
+				</div>
+				<div style={ { fontWeight: 'bold', fontSize: '14px' } }>{ tooltipData.label }</div>
+				<div style={ { color: '#666', fontSize: '12px' } }>{ tooltipData.percentage }% share</div>
+			</div>
+		);
+	},
+};
+CustomWithEmoji.parameters = {
+	docs: {
+		description: {
+			story:
+				'Custom tooltip with emoji icons based on the data label. Demonstrates dynamic content rendering.',
+		},
+	},
+};
+
+export const CustomTableTooltip: StoryObj< typeof PieChart > = Template.bind( {} );
+CustomTableTooltip.args = {
+	...tooltipStoryArgs,
+	renderTooltip: ( { tooltipData }: PieChartRenderTooltipParams ) => {
+		return (
+			<table
+				style={ {
+					borderCollapse: 'collapse',
+					backgroundColor: 'white',
+					boxShadow: '0 2px 8px rgba(0, 0, 0, 0.15)',
+					borderRadius: '4px',
+					overflow: 'hidden',
+				} }
+			>
+				<thead>
+					<tr style={ { backgroundColor: '#f5f5f5' } }>
+						<th
+							colSpan={ 2 }
+							style={ { padding: '8px 12px', borderBottom: '1px solid #ddd', fontWeight: 'bold' } }
+						>
+							{ tooltipData.label }
+						</th>
+					</tr>
+				</thead>
+				<tbody>
+					<tr>
+						<td style={ { padding: '6px 12px', borderBottom: '1px solid #eee', color: '#666' } }>
+							Value
+						</td>
+						<td
+							style={ {
+								padding: '6px 12px',
+								borderBottom: '1px solid #eee',
+								textAlign: 'right',
+								fontWeight: 'bold',
+							} }
+						>
+							{ formatNumber( tooltipData.value ) }
+						</td>
+					</tr>
+					<tr>
+						<td style={ { padding: '6px 12px', color: '#666' } }>Share</td>
+						<td style={ { padding: '6px 12px', textAlign: 'right', fontWeight: 'bold' } }>
+							{ tooltipData.percentage }%
+						</td>
+					</tr>
+				</tbody>
+			</table>
+		);
+	},
+};
+CustomTableTooltip.parameters = {
+	docs: {
+		description: {
+			story: 'Custom tooltip rendered as an HTML table for a more structured data presentation.',
+		},
+	},
+};
+
+export const TooltipOffset: StoryObj< typeof PieChart > = {
+	render: () => (
+		<GlobalChartsProvider>
+			<div
+				style={ {
+					display: 'grid',
+					gap: '2rem',
+					gridTemplateColumns: 'repeat(2, 1fr)',
+					alignItems: 'start',
+				} }
+			>
+				<div>
+					<h3>Default Offset (0, -15)</h3>
+					<PieChart { ...tooltipStoryArgs } size={ 300 } />
+				</div>
+				<div>
+					<h3>Custom Offset (20, -30)</h3>
+					<PieChart
+						{ ...tooltipStoryArgs }
+						size={ 300 }
+						tooltipOffsetX={ 20 }
+						tooltipOffsetY={ -30 }
+					/>
+				</div>
+			</div>
+		</GlobalChartsProvider>
+	),
+	args: {
+		containerWidth: '700px',
+		containerHeight: '400px',
+	},
+	parameters: {
+		docs: {
+			description: {
+				story:
+					'Demonstrates tooltip positioning with `tooltipOffsetX` and `tooltipOffsetY` props. The right chart has a custom offset applied.',
+			},
+		},
+	},
+};

--- a/projects/js-packages/charts/src/charts/pie-chart/test/pie-chart.test.tsx
+++ b/projects/js-packages/charts/src/charts/pie-chart/test/pie-chart.test.tsx
@@ -329,6 +329,43 @@ describe( 'PieChart', () => {
 			} );
 			expect( screen.getByRole( 'tooltip' ) ).toHaveTextContent( 'Test: 42' );
 		} );
+
+		test( 'renders custom tooltip when renderTooltip prop is provided', async () => {
+			const user = userEvent.setup();
+			const customTooltipRenderer = jest.fn( ( { tooltipData } ) => (
+				<div role="tooltip" data-testid="custom-tooltip">
+					Custom: { tooltipData.label } - { tooltipData.value }
+				</div>
+			) );
+
+			renderWithTheme( {
+				data: testData,
+				withTooltips: true,
+				renderTooltip: customTooltipRenderer,
+			} );
+
+			const segments = screen.getAllByTestId( 'pie-segment' );
+			await user.hover( segments[ 0 ] );
+
+			await waitFor( () => {
+				expect( screen.getByTestId( 'custom-tooltip' ) ).toBeInTheDocument();
+			} );
+
+			const customTooltip = screen.getByTestId( 'custom-tooltip' );
+			expect( customTooltip ).toHaveTextContent( 'Custom: Windows - 80000' );
+			expect( customTooltipRenderer ).toHaveBeenCalled();
+
+			// Verify the renderer received correct parameters
+			expect( customTooltipRenderer ).toHaveBeenCalledWith(
+				expect.objectContaining( {
+					tooltipData: expect.objectContaining( {
+						label: 'Windows',
+						value: 80000,
+						percentage: 70,
+					} ),
+				} )
+			);
+		} );
 	} );
 
 	describe( 'Interactive Legend', () => {

--- a/projects/js-packages/charts/src/charts/pie-semi-circle-chart/index.ts
+++ b/projects/js-packages/charts/src/charts/pie-semi-circle-chart/index.ts
@@ -2,4 +2,8 @@ export {
 	default as PieSemiCircleChart,
 	PieSemiCircleChartUnresponsive,
 } from './pie-semi-circle-chart';
-export type { PieSemiCircleChartProps, ArcData } from './pie-semi-circle-chart';
+export type {
+	PieSemiCircleChartProps,
+	PieSemiCircleChartRenderTooltipParams,
+	ArcData,
+} from './pie-semi-circle-chart';

--- a/projects/js-packages/charts/src/charts/pie-semi-circle-chart/pie-semi-circle-chart.tsx
+++ b/projects/js-packages/charts/src/charts/pie-semi-circle-chart/pie-semi-circle-chart.tsx
@@ -28,6 +28,29 @@ import type { ResponsiveConfig } from '../private/with-responsive';
 import type { PieArcDatum } from '@visx/shape/lib/shapes/Pie';
 import type { FC, MouseEvent, ReactNode } from 'react';
 
+/**
+ * Parameters passed to the renderTooltip function for semi-circle charts.
+ */
+export type PieSemiCircleChartRenderTooltipParams = {
+	/**
+	 * The data point being hovered, including label, value, and percentage.
+	 */
+	tooltipData: DataPointPercentage;
+};
+
+/**
+ * Default tooltip renderer for semi-circle pie charts.
+ * Renders a BaseTooltip with the hovered segment's data.
+ *
+ * @param {PieSemiCircleChartRenderTooltipParams} params - The tooltip parameters containing the hovered data point
+ * @return {ReactNode} The rendered tooltip content
+ */
+const renderDefaultPieSemiCircleTooltip = ( {
+	tooltipData,
+}: PieSemiCircleChartRenderTooltipParams ): ReactNode => {
+	return <BaseTooltip data={ tooltipData } top={ 0 } left={ 0 } renderContainer={ false } />;
+};
+
 const PAD_ANGLE = 0.03; // Padding between segments
 
 export interface PieSemiCircleChartProps extends BaseChartProps< DataPointPercentage[] > {
@@ -87,6 +110,12 @@ export interface PieSemiCircleChartProps extends BaseChartProps< DataPointPercen
 	 * Vertical offset for tooltip positioning in pixels (default: -15)
 	 */
 	tooltipOffsetY?: number;
+
+	/**
+	 * Custom render function for tooltip content.
+	 * When provided, replaces the default BaseTooltip with custom content.
+	 */
+	renderTooltip?: ( params: PieSemiCircleChartRenderTooltipParams ) => ReactNode;
 }
 
 // Base props type with optional responsive properties
@@ -149,6 +178,7 @@ const PieSemiCircleChartInternal: FC< PieSemiCircleChartProps > = ( {
 	children,
 	tooltipOffsetX = 0,
 	tooltipOffsetY = -15,
+	renderTooltip = renderDefaultPieSemiCircleTooltip,
 } ) => {
 	const chartId = useChartId( providedChartId );
 	const [ legendRef, legendHeight ] = useElementHeight< HTMLDivElement >();
@@ -415,9 +445,7 @@ const PieSemiCircleChartInternal: FC< PieSemiCircleChartProps > = ( {
 
 				{ withTooltips && tooltipOpen && tooltipData && (
 					<TooltipInPortal top={ tooltipTop || 0 } left={ tooltipLeft || 0 }>
-						<div role="tooltip">
-							<BaseTooltip data={ tooltipData } top={ 0 } left={ 0 } renderContainer={ false } />
-						</div>
+						<div role="tooltip">{ renderTooltip( { tooltipData } ) }</div>
 					</TooltipInPortal>
 				) }
 

--- a/projects/js-packages/charts/src/charts/pie-semi-circle-chart/stories/index.api.mdx
+++ b/projects/js-packages/charts/src/charts/pie-semi-circle-chart/stories/index.api.mdx
@@ -19,6 +19,7 @@ Main component for rendering semi-circular pie charts.
 | `label` | `string` | - | Text displayed above the chart |
 | `note` | `string` | - | Additional text displayed below the label |
 | `withTooltips` | `boolean` | `false` | Enable interactive tooltips on hover |
+| `renderTooltip` | `(params: PieSemiCircleChartRenderTooltipParams) => ReactNode` | - | Custom tooltip render function |
 | `animation` | `boolean` | `false` | Enable entry animation on initial render. Creates a radial wipe reveal effect. Automatically respects user's `prefers-reduced-motion` system setting |
 | `showLegend` | `boolean` | `false` | Display legend below the chart |
 | `legendInteractive` | `boolean` | `false` | Enable clickable legend items to show/hide segments. Requires `chartId` and `GlobalChartsProvider`. When segments are hidden, percentages recalculate so visible segments total 100% |
@@ -28,6 +29,15 @@ Main component for rendering semi-circular pie charts.
 | `legendShape` | `'circle' \| 'rect' \| 'line'` | `'circle'` | Shape of legend indicators |
 | `className` | `string` | - | Additional CSS class for the container |
 | `chartId` | `string` | - | Optional unique identifier (auto-generated if not provided) |
+
+## PieSemiCircleChartRenderTooltipParams Type
+
+```typescript
+type PieSemiCircleChartRenderTooltipParams = {
+	/** The data point being hovered, including label, value, and percentage. */
+	tooltipData: DataPointPercentage;
+};
+```
 
 ## DataPointPercentage Type
 

--- a/projects/js-packages/charts/src/charts/pie-semi-circle-chart/stories/tooltip.stories.tsx
+++ b/projects/js-packages/charts/src/charts/pie-semi-circle-chart/stories/tooltip.stories.tsx
@@ -1,0 +1,297 @@
+import { formatNumber } from '@automattic/number-formatters';
+import { GlobalChartsProvider } from '../../../providers';
+import {
+	chartDecorator,
+	sharedChartArgTypes,
+	ChartStoryArgs,
+} from '../../../stories/chart-decorator';
+import { legendArgTypes } from '../../../stories/legend-config';
+import { partialOsUsageData as data } from '../../../stories/sample-data';
+import { sharedThemeArgs, themeArgTypes } from '../../../stories/theme-config';
+import { PieSemiCircleChart, PieSemiCircleChartRenderTooltipParams } from '../index';
+import type { Meta, StoryFn, StoryObj } from '@storybook/react';
+
+type StoryArgs = ChartStoryArgs< React.ComponentProps< typeof PieSemiCircleChart > >;
+
+const meta: Meta< StoryArgs > = {
+	title: 'JS Packages/Charts Library/Charts/Pie Semi Circle Chart/Tooltips',
+	component: PieSemiCircleChart,
+	parameters: {
+		layout: 'centered',
+	},
+	decorators: [ chartDecorator ],
+	argTypes: {
+		...sharedChartArgTypes,
+		...themeArgTypes,
+		...legendArgTypes,
+		width: {
+			control: {
+				type: 'range',
+				min: 100,
+				max: 1000,
+				step: 10,
+			},
+		},
+		thickness: {
+			control: {
+				type: 'range',
+				min: 0,
+				max: 1,
+				step: 0.01,
+			},
+		},
+	},
+};
+
+export default meta;
+
+const Template: StoryFn< typeof PieSemiCircleChart > = args => <PieSemiCircleChart { ...args } />;
+
+const tooltipStoryArgs = {
+	...sharedThemeArgs,
+	data,
+	width: 400,
+	withTooltips: true,
+	label: 'OS Usage',
+	note: 'Q4 2023',
+	containerWidth: '500px',
+	resize: 'none' as const,
+};
+
+export const Default: StoryObj< typeof PieSemiCircleChart > = Template.bind( {} );
+Default.args = {
+	...tooltipStoryArgs,
+};
+Default.parameters = {
+	docs: {
+		description: {
+			story:
+				'Default semi-circle pie chart with tooltips enabled using the built-in BaseTooltip component.',
+		},
+	},
+};
+
+export const NoTooltips: StoryObj< typeof PieSemiCircleChart > = Template.bind( {} );
+NoTooltips.args = {
+	...tooltipStoryArgs,
+	withTooltips: false,
+};
+NoTooltips.parameters = {
+	docs: {
+		description: {
+			story: 'Semi-circle pie chart with tooltips disabled.',
+		},
+	},
+};
+
+export const Custom: StoryObj< typeof PieSemiCircleChart > = Template.bind( {} );
+Custom.args = {
+	...tooltipStoryArgs,
+	renderTooltip: ( { tooltipData }: PieSemiCircleChartRenderTooltipParams ) => {
+		return (
+			<div
+				style={ {
+					backgroundColor: '#1a1a2e',
+					color: '#eaeaea',
+					padding: '12px 16px',
+					borderRadius: '8px',
+					boxShadow: '0 4px 12px rgba(0, 0, 0, 0.3)',
+					minWidth: '150px',
+				} }
+			>
+				<div
+					style={ {
+						fontSize: '16px',
+						fontWeight: 'bold',
+						marginBottom: '8px',
+						borderBottom: '1px solid #333',
+						paddingBottom: '8px',
+					} }
+				>
+					{ tooltipData.label }
+				</div>
+				<div style={ { display: 'flex', flexDirection: 'column', gap: '4px' } }>
+					<div style={ { display: 'flex', justifyContent: 'space-between' } }>
+						<span style={ { color: '#888' } }>Value:</span>
+						<span style={ { fontWeight: 'bold' } }>{ formatNumber( tooltipData.value ) }</span>
+					</div>
+					<div style={ { display: 'flex', justifyContent: 'space-between' } }>
+						<span style={ { color: '#888' } }>Percentage:</span>
+						<span
+							style={ {
+								fontWeight: 'bold',
+								color: '#4ade80',
+							} }
+						>
+							{ tooltipData.percentage }%
+						</span>
+					</div>
+				</div>
+			</div>
+		);
+	},
+};
+Custom.parameters = {
+	docs: {
+		description: {
+			story: `Custom tooltip rendering using the \`renderTooltip\` prop. This example demonstrates a dark-themed tooltip with styled layout.
+
+**Usage:**
+\`\`\`tsx
+<PieSemiCircleChart
+  data={data}
+  withTooltips={true}
+  renderTooltip={({ tooltipData }) => (
+    <div>
+      <h3>{tooltipData.label}</h3>
+      <p>Value: {tooltipData.value}</p>
+      <p>Percentage: {tooltipData.percentage}%</p>
+    </div>
+  )}
+/>
+\`\`\``,
+		},
+	},
+};
+
+export const CustomWithEmoji: StoryObj< typeof PieSemiCircleChart > = Template.bind( {} );
+CustomWithEmoji.args = {
+	...tooltipStoryArgs,
+	renderTooltip: ( { tooltipData }: PieSemiCircleChartRenderTooltipParams ) => {
+		const getEmoji = ( label: string ) => {
+			const emojiMap: Record< string, string > = {
+				Windows: '🪟',
+				MacOS: '🍎',
+				Linux: '🐧',
+				Other: '🖥️',
+			};
+			return emojiMap[ label ] || '📊';
+		};
+
+		return (
+			<div
+				style={ {
+					backgroundColor: 'white',
+					padding: '12px',
+					borderRadius: '12px',
+					boxShadow: '0 2px 8px rgba(0, 0, 0, 0.15)',
+					textAlign: 'center',
+				} }
+			>
+				<div style={ { fontSize: '32px', marginBottom: '4px' } }>
+					{ getEmoji( tooltipData.label ) }
+				</div>
+				<div style={ { fontWeight: 'bold', fontSize: '14px' } }>{ tooltipData.label }</div>
+				<div style={ { color: '#666', fontSize: '12px' } }>{ tooltipData.percentage }% share</div>
+			</div>
+		);
+	},
+};
+CustomWithEmoji.parameters = {
+	docs: {
+		description: {
+			story:
+				'Custom tooltip with emoji icons based on the data label. Demonstrates dynamic content rendering.',
+		},
+	},
+};
+
+export const CustomTableTooltip: StoryObj< typeof PieSemiCircleChart > = Template.bind( {} );
+CustomTableTooltip.args = {
+	...tooltipStoryArgs,
+	renderTooltip: ( { tooltipData }: PieSemiCircleChartRenderTooltipParams ) => {
+		return (
+			<table
+				style={ {
+					borderCollapse: 'collapse',
+					backgroundColor: 'white',
+					boxShadow: '0 2px 8px rgba(0, 0, 0, 0.15)',
+					borderRadius: '4px',
+					overflow: 'hidden',
+				} }
+			>
+				<thead>
+					<tr style={ { backgroundColor: '#f5f5f5' } }>
+						<th
+							colSpan={ 2 }
+							style={ { padding: '8px 12px', borderBottom: '1px solid #ddd', fontWeight: 'bold' } }
+						>
+							{ tooltipData.label }
+						</th>
+					</tr>
+				</thead>
+				<tbody>
+					<tr>
+						<td style={ { padding: '6px 12px', borderBottom: '1px solid #eee', color: '#666' } }>
+							Value
+						</td>
+						<td
+							style={ {
+								padding: '6px 12px',
+								borderBottom: '1px solid #eee',
+								textAlign: 'right',
+								fontWeight: 'bold',
+							} }
+						>
+							{ formatNumber( tooltipData.value ) }
+						</td>
+					</tr>
+					<tr>
+						<td style={ { padding: '6px 12px', color: '#666' } }>Share</td>
+						<td style={ { padding: '6px 12px', textAlign: 'right', fontWeight: 'bold' } }>
+							{ tooltipData.percentage }%
+						</td>
+					</tr>
+				</tbody>
+			</table>
+		);
+	},
+};
+CustomTableTooltip.parameters = {
+	docs: {
+		description: {
+			story: 'Custom tooltip rendered as an HTML table for a more structured data presentation.',
+		},
+	},
+};
+
+export const TooltipOffset: StoryObj< typeof PieSemiCircleChart > = {
+	render: () => (
+		<GlobalChartsProvider>
+			<div
+				style={ {
+					display: 'grid',
+					gap: '2rem',
+					gridTemplateColumns: 'repeat(2, 1fr)',
+					alignItems: 'start',
+				} }
+			>
+				<div>
+					<h3>Default Offset (0, -15)</h3>
+					<PieSemiCircleChart { ...tooltipStoryArgs } width={ 350 } />
+				</div>
+				<div>
+					<h3>Custom Offset (20, -30)</h3>
+					<PieSemiCircleChart
+						{ ...tooltipStoryArgs }
+						width={ 350 }
+						tooltipOffsetX={ 20 }
+						tooltipOffsetY={ -30 }
+					/>
+				</div>
+			</div>
+		</GlobalChartsProvider>
+	),
+	args: {
+		containerWidth: '800px',
+		containerHeight: '300px',
+	},
+	parameters: {
+		docs: {
+			description: {
+				story:
+					'Demonstrates tooltip positioning with `tooltipOffsetX` and `tooltipOffsetY` props. The right chart has a custom offset applied.',
+			},
+		},
+	},
+};

--- a/projects/js-packages/charts/src/charts/pie-semi-circle-chart/stories/tooltip.stories.tsx
+++ b/projects/js-packages/charts/src/charts/pie-semi-circle-chart/stories/tooltip.stories.tsx
@@ -1,5 +1,4 @@
 import { formatNumber } from '@automattic/number-formatters';
-import { GlobalChartsProvider } from '../../../providers';
 import {
 	chartDecorator,
 	sharedChartArgTypes,
@@ -10,6 +9,17 @@ import { partialOsUsageData as data } from '../../../stories/sample-data';
 import { sharedThemeArgs, themeArgTypes } from '../../../stories/theme-config';
 import { PieSemiCircleChart, PieSemiCircleChartRenderTooltipParams } from '../index';
 import type { Meta, StoryFn, StoryObj } from '@storybook/react';
+
+const emojiMap: Record< string, string > = {
+	Windows: '🪟',
+	MacOS: '🍎',
+	Linux: '🐧',
+	Other: '🖥️',
+};
+
+const getEmoji = ( label: string ) => {
+	return emojiMap[ label ] || '📊';
+};
 
 type StoryArgs = ChartStoryArgs< React.ComponentProps< typeof PieSemiCircleChart > >;
 
@@ -158,16 +168,6 @@ export const CustomWithEmoji: StoryObj< typeof PieSemiCircleChart > = Template.b
 CustomWithEmoji.args = {
 	...tooltipStoryArgs,
 	renderTooltip: ( { tooltipData }: PieSemiCircleChartRenderTooltipParams ) => {
-		const getEmoji = ( label: string ) => {
-			const emojiMap: Record< string, string > = {
-				Windows: '🪟',
-				MacOS: '🍎',
-				Linux: '🐧',
-				Other: '🖥️',
-			};
-			return emojiMap[ label ] || '📊';
-		};
-
 		return (
 			<div
 				style={ {
@@ -257,30 +257,28 @@ CustomTableTooltip.parameters = {
 
 export const TooltipOffset: StoryObj< typeof PieSemiCircleChart > = {
 	render: () => (
-		<GlobalChartsProvider>
-			<div
-				style={ {
-					display: 'grid',
-					gap: '2rem',
-					gridTemplateColumns: 'repeat(2, 1fr)',
-					alignItems: 'start',
-				} }
-			>
-				<div>
-					<h3>Default Offset (0, -15)</h3>
-					<PieSemiCircleChart { ...tooltipStoryArgs } width={ 350 } />
-				</div>
-				<div>
-					<h3>Custom Offset (20, -30)</h3>
-					<PieSemiCircleChart
-						{ ...tooltipStoryArgs }
-						width={ 350 }
-						tooltipOffsetX={ 20 }
-						tooltipOffsetY={ -30 }
-					/>
-				</div>
+		<div
+			style={ {
+				display: 'grid',
+				gap: '2rem',
+				gridTemplateColumns: 'repeat(2, 1fr)',
+				alignItems: 'start',
+			} }
+		>
+			<div>
+				<h3>Default Offset (0, -15)</h3>
+				<PieSemiCircleChart { ...tooltipStoryArgs } width={ 350 } />
 			</div>
-		</GlobalChartsProvider>
+			<div>
+				<h3>Custom Offset (20, -30)</h3>
+				<PieSemiCircleChart
+					{ ...tooltipStoryArgs }
+					width={ 350 }
+					tooltipOffsetX={ 20 }
+					tooltipOffsetY={ -30 }
+				/>
+			</div>
+		</div>
 	),
 	args: {
 		containerWidth: '800px',

--- a/projects/js-packages/charts/src/charts/pie-semi-circle-chart/test/pie-semi-circle-chart.test.tsx
+++ b/projects/js-packages/charts/src/charts/pie-semi-circle-chart/test/pie-semi-circle-chart.test.tsx
@@ -101,6 +101,50 @@ describe( 'PieSemiCircleChart', () => {
 		} );
 	} );
 
+	it( 'renders custom tooltip when renderTooltip prop is provided', async () => {
+		const user = userEvent.setup();
+		const testData = [
+			{ label: 'MacOS', value: 30000, valueDisplay: '30K', percentage: 5 },
+			{ label: 'Linux', value: 22000, valueDisplay: '22K', percentage: 1 },
+			{ label: 'Windows', value: 80000, valueDisplay: '80K', percentage: 2 },
+		];
+
+		const customTooltipRenderer = jest.fn( ( { tooltipData } ) => (
+			<div role="tooltip" data-testid="custom-tooltip">
+				Custom: { tooltipData.label } - { tooltipData.value }
+			</div>
+		) );
+
+		renderPieChart( {
+			data: testData,
+			withTooltips: true,
+			width: 400,
+			renderTooltip: customTooltipRenderer,
+		} );
+
+		const segments = screen.getAllByTestId( 'pie-segment' );
+		await user.hover( segments[ 0 ] );
+
+		await waitFor( () => {
+			expect( screen.getByTestId( 'custom-tooltip' ) ).toBeInTheDocument();
+		} );
+
+		const customTooltip = screen.getByTestId( 'custom-tooltip' );
+		expect( customTooltip ).toHaveTextContent( 'Custom: MacOS - 30000' );
+		expect( customTooltipRenderer ).toHaveBeenCalled();
+
+		// Verify the renderer received correct parameters
+		expect( customTooltipRenderer ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				tooltipData: expect.objectContaining( {
+					label: 'MacOS',
+					value: 30000,
+					percentage: 5,
+				} ),
+			} )
+		);
+	} );
+
 	it( 'applies custom className', () => {
 		const customClass = 'custom-chart';
 		renderPieChart( { data: mockData, className: customClass } );

--- a/projects/js-packages/charts/src/index.ts
+++ b/projects/js-packages/charts/src/index.ts
@@ -31,7 +31,11 @@ export {
 // Types
 export type * from './types';
 export type * from './visx/types';
-export type { PieChartProps } from './charts/pie-chart';
+export type { PieChartProps, PieChartRenderTooltipParams } from './charts/pie-chart';
+export type {
+	PieSemiCircleChartProps,
+	PieSemiCircleChartRenderTooltipParams,
+} from './charts/pie-semi-circle-chart';
 export type { GeoChartProps, GeoRegion, GeoResolution } from './charts/geo-chart';
 export type { LegendValueDisplay, BaseLegendItem } from './components/legend';
 export type { TrendIndicatorProps, TrendDirection } from './components/trend-indicator';


### PR DESCRIPTION
Fixes CHARTS-162

## Proposed changes:
* Add a `renderTooltip` prop to `PieChart` and `PieSemiCircleChart` components, enabling consumers to customize tooltip content
* Export new types `PieChartRenderTooltipParams` and `PieSemiCircleChartRenderTooltipParams` for type-safe custom tooltip implementations
* Add dedicated Storybook stories demonstrating tooltip functionality including:
  - Default tooltips
  - Custom renderTooltip examples with emoji variants
  - Table layouts
  - Offset positioning

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- N/A - Internal charts package enhancement -->

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

* Run Storybook for the charts package: `pnpm --filter @automattic/jetpack-charts run storybook`
* Navigate to the PieChart and PieSemiCircleChart stories
* Check the new "Tooltip" story sections:
  - Verify default tooltip displays label, value, and percentage
  - Verify custom tooltip with emoji renders correctly
  - Verify table layout tooltip works
  - Verify tooltip offset positioning works as expected
* Verify existing pie chart functionality is not affected