### PR TITLE
rolling-releases: Keep releases up to one day old

### DIFF
--- a/.github/files/gh-autorelease/files/autorelease.sh
+++ b/.github/files/gh-autorelease/files/autorelease.sh
@@ -127,7 +127,7 @@ fi
 if [[ -n "$ROLLING_MODE" ]]; then
 	echo "::group::Deleting stale rolling release"
 
-	for R in $( gh release list --limit 100 --json tagName --jq '.[].tagName | select( contains( "+rolling" ) )' ); do
+	for R in $( gh release list --limit 1000000 --json tagName,publishedAt --jq '.[] | select( ( .tagName | contains( "+rolling" ) ) and ( .publishedAt | fromdateiso8601 < now - 86400 ) ) | .tagName' ); do
 		echo "Found $R, deleting"
 		gh release delete "$R" --cleanup-tag --yes
 	done


### PR DESCRIPTION
Closes MONOREP-346

 <!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Per request, we want to keep older rolling releases up to 1 day old.

Note the cleanup still only happens when a new release is made, so if no new releases come in then old ones over a day old might still remain until a new one does happen.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1770309873489899-slack-C08PN0LHCCT

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Either set up a fork with the patched copy of the workflow and then trigger some releases, or just merge and observe.