### PR TITLE
Forms: add editor canvas to wp-build dashboard

### DIFF
--- a/projects/packages/forms/changelog/add-forms-dashboard-editor-canvas
+++ b/projects/packages/forms/changelog/add-forms-dashboard-editor-canvas
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Dashboard: add editor canvas.

--- a/projects/packages/forms/routes/forms/route.tsx
+++ b/projects/packages/forms/routes/forms/route.tsx
@@ -10,4 +10,24 @@ export const route = {
 	loader: async () => {
 		await preloadGlobalTabCounts();
 	},
+	/**
+	 * Render the editor canvas when editing a form from the list.
+	 *
+	 * @param props                   - Route props.
+	 * @param props.search            - Search params.
+	 * @param props.search.editFormId - Form ID to edit.
+	 * @return Canvas data or undefined.
+	 */
+	canvas: ( { search }: { search: { editFormId?: number | string } } ) => {
+		const editFormId =
+			typeof search.editFormId === 'number' ? search.editFormId : Number( search.editFormId );
+		if ( ! Number.isFinite( editFormId ) || editFormId <= 0 ) {
+			return;
+		}
+
+		return {
+			postType: 'jetpack_form',
+			postId: String( editFormId ),
+		};
+	},
 };

--- a/projects/packages/forms/routes/forms/route.tsx
+++ b/projects/packages/forms/routes/forms/route.tsx
@@ -1,6 +1,7 @@
 /**
  * Internal dependencies
  */
+import { getJetpackFormCanvasData } from '../../src/dashboard/wp-build/utils/canvas-editor';
 import { preloadGlobalTabCounts } from '../../src/dashboard/wp-build/utils/preload';
 
 export const route = {
@@ -18,16 +19,6 @@ export const route = {
 	 * @param props.search.editFormId - Form ID to edit.
 	 * @return Canvas data or undefined.
 	 */
-	canvas: ( { search }: { search: { editFormId?: number | string } } ) => {
-		const editFormId =
-			typeof search.editFormId === 'number' ? search.editFormId : Number( search.editFormId );
-		if ( ! Number.isFinite( editFormId ) || editFormId <= 0 ) {
-			return;
-		}
-
-		return {
-			postType: 'jetpack_form',
-			postId: String( editFormId ),
-		};
-	},
+	canvas: ( { search }: { search: { editFormId?: number | string } } ) =>
+		getJetpackFormCanvasData( search.editFormId ),
 };

--- a/projects/packages/forms/routes/forms/stage.tsx
+++ b/projects/packages/forms/routes/forms/stage.tsx
@@ -15,11 +15,11 @@ import * as React from 'react';
  * Internal dependencies
  */
 import IntegrationsModal from '../../src/blocks/contact-form/components/jetpack-integrations-modal';
-import CreateFormButton from '../../src/dashboard/components/create-form-button/index.tsx';
 import { EmptyWrapper } from '../../src/dashboard/components/empty-responses/index.tsx';
 import { NON_TRASH_FORM_STATUSES } from '../../src/dashboard/constants';
 import useDeleteForm from '../../src/dashboard/hooks/use-delete-form.ts';
 import useFormsData from '../../src/dashboard/hooks/use-forms-data.ts';
+import CreateFormButton from '../../src/dashboard/wp-build/components/create-form-button';
 import DataViewsHeaderRow from '../../src/dashboard/wp-build/components/dataviews-header-row';
 import usePageHeaderDetails from '../../src/dashboard/wp-build/hooks/use-page-header-details';
 import useConfigValue from '../../src/hooks/use-config-value';
@@ -414,6 +414,7 @@ function StageInner() {
 							<CreateFormButton
 								label={ __( 'Create a new form', 'jetpack-forms' ) }
 								variant="primary"
+								from="/forms"
 							/>
 						}
 					/>

--- a/projects/packages/forms/routes/forms/stage.tsx
+++ b/projects/packages/forms/routes/forms/stage.tsx
@@ -243,10 +243,12 @@ function StageInner() {
 					if ( ! item ) {
 						return;
 					}
-					const fallbackEditUrl = `post.php?post=${ item.id }&action=edit&post_type=jetpack_form`;
-					const editUrl = item.editUrl || fallbackEditUrl;
-					const url = new URL( editUrl, window.location.origin );
-					window.location.href = url.toString();
+					navigate( {
+						search: {
+							...searchParams,
+							editFormId: String( item.id ),
+						},
+					} );
 				},
 			},
 			{
@@ -329,9 +331,11 @@ function StageInner() {
 	}, [
 		isDeleting,
 		isViewingTrash,
+		navigate,
 		onOpenPermanentDeleteConfirm,
 		openSingleFormView,
 		restoreForms,
+		searchParams,
 		trashForms,
 	] );
 

--- a/projects/packages/forms/routes/responses/route.tsx
+++ b/projects/packages/forms/routes/responses/route.tsx
@@ -5,6 +5,7 @@ import { resolveSelect } from '@wordpress/data';
 /**
  * Internal dependencies
  */
+import { getJetpackFormCanvasData } from '../../src/dashboard/wp-build/utils/canvas-editor';
 import { preloadGlobalTabCounts } from '../../src/dashboard/wp-build/utils/preload';
 
 export const route = {
@@ -65,18 +66,8 @@ export const route = {
 	 * @param props.search.editFormId - Form ID to edit.
 	 * @return Canvas data or undefined.
 	 */
-	canvas: ( { search }: { search: { editFormId?: number | string } } ) => {
-		const editFormId =
-			typeof search.editFormId === 'number' ? search.editFormId : Number( search.editFormId );
-		if ( ! Number.isFinite( editFormId ) || editFormId <= 0 ) {
-			return;
-		}
-
-		return {
-			postType: 'jetpack_form',
-			postId: String( editFormId ),
-		};
-	},
+	canvas: ( { search }: { search: { editFormId?: number | string } } ) =>
+		getJetpackFormCanvasData( search.editFormId ),
 
 	/**
 	 * Validates that the route can be accessed.

--- a/projects/packages/forms/routes/responses/route.tsx
+++ b/projects/packages/forms/routes/responses/route.tsx
@@ -58,6 +58,27 @@ export const route = {
 	},
 
 	/**
+	 * Render the editor canvas when editing a form from the responses view.
+	 *
+	 * @param props                   - Route props.
+	 * @param props.search            - Search params.
+	 * @param props.search.editFormId - Form ID to edit.
+	 * @return Canvas data or undefined.
+	 */
+	canvas: ( { search }: { search: { editFormId?: number | string } } ) => {
+		const editFormId =
+			typeof search.editFormId === 'number' ? search.editFormId : Number( search.editFormId );
+		if ( ! Number.isFinite( editFormId ) || editFormId <= 0 ) {
+			return;
+		}
+
+		return {
+			postType: 'jetpack_form',
+			postId: String( editFormId ),
+		};
+	},
+
+	/**
 	 * Validates that the route can be accessed.
 	 * Checks if the feedback post type exists.
 	 */

--- a/projects/packages/forms/src/dashboard/wp-build/components/create-form-button/index.tsx
+++ b/projects/packages/forms/src/dashboard/wp-build/components/create-form-button/index.tsx
@@ -8,9 +8,10 @@ import jetpackAnalytics from '@automattic/jetpack-analytics';
 import { Button } from '@wordpress/components';
 import { store as coreStore } from '@wordpress/core-data';
 import { dispatch } from '@wordpress/data';
-import { useCallback } from '@wordpress/element';
+import { useCallback, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { plus } from '@wordpress/icons';
+import { store as noticesStore } from '@wordpress/notices';
 import { useNavigate, useSearch } from '@wordpress/route';
 
 type CreateFormButtonProps = {
@@ -37,32 +38,59 @@ export default function WpBuildCreateFormButton( {
 }: CreateFormButtonProps ): JSX.Element {
 	const navigate = useNavigate();
 	const searchParams = useSearch( { from } );
+	const [ isCreating, setIsCreating ] = useState( false );
 
 	const onClick = useCallback( async () => {
-		jetpackAnalytics.tracks.recordEvent( 'jetpack_wpa_forms_landing_page_cta_click', {
-			button: 'forms',
-		} );
+		if ( isCreating ) {
+			return;
+		}
 
-		const newPost = await dispatch( coreStore ).saveEntityRecord( 'postType', 'jetpack_form', {
-			title: __( 'Contact Form', 'jetpack-forms' ),
-			// Seed the form post with the contact-form block so the editor opens with a form.
-			content: '<!-- wp:jetpack/contact-form /-->',
-			status: 'auto-draft',
-		} );
+		setIsCreating( true );
+		try {
+			jetpackAnalytics.tracks.recordEvent( 'jetpack_wpa_forms_landing_page_cta_click', {
+				button: 'forms',
+			} );
 
-		navigate( {
-			search: {
-				...searchParams,
-				editFormId: String( ( newPost as { id: number | string } ).id ),
-			},
-		} );
-	}, [ navigate, searchParams ] );
+			const newPost = await dispatch( coreStore ).saveEntityRecord(
+				'postType',
+				'jetpack_form',
+				{
+					title: __( 'Contact Form', 'jetpack-forms' ),
+					// Seed the form post with the contact-form block so the editor opens with a form.
+					content: '<!-- wp:jetpack/contact-form /-->',
+					status: 'auto-draft',
+				},
+				{ throwOnError: true }
+			);
+
+			const newPostId = Number( ( newPost as { id?: number | string } | undefined )?.id );
+			if ( ! Number.isFinite( newPostId ) || newPostId <= 0 ) {
+				throw new Error( 'Failed to create a form: missing post id.' );
+			}
+
+			navigate( {
+				search: {
+					...searchParams,
+					editFormId: String( newPostId ),
+				},
+			} );
+		} catch {
+			dispatch( noticesStore ).createErrorNotice(
+				__( 'Failed to create a form. Please try again.', 'jetpack-forms' ),
+				{ type: 'snackbar' }
+			);
+		} finally {
+			setIsCreating( false );
+		}
+	}, [ isCreating, navigate, searchParams ] );
 
 	return (
 		<Button
 			size="compact"
 			variant={ variant }
 			onClick={ onClick }
+			disabled={ isCreating }
+			isBusy={ isCreating }
 			icon={ plus }
 			className="create-form-button"
 		>

--- a/projects/packages/forms/src/dashboard/wp-build/components/create-form-button/index.tsx
+++ b/projects/packages/forms/src/dashboard/wp-build/components/create-form-button/index.tsx
@@ -1,0 +1,72 @@
+/**
+ * External dependencies
+ */
+import jetpackAnalytics from '@automattic/jetpack-analytics';
+/**
+ * WordPress dependencies
+ */
+import { Button } from '@wordpress/components';
+import { store as coreStore } from '@wordpress/core-data';
+import { dispatch } from '@wordpress/data';
+import { useCallback } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { plus } from '@wordpress/icons';
+import { useNavigate, useSearch } from '@wordpress/route';
+
+type CreateFormButtonProps = {
+	label?: string;
+	variant?: 'primary' | 'secondary';
+	from?: '/forms' | '/responses/$view';
+};
+
+/**
+ * wp-build only create form button:
+ * - creates an auto-draft `jetpack_form`
+ * - navigates within the wp-build router so the route `canvas()` opens the editor.
+ *
+ * @param props         - Props.
+ * @param props.label   - Button label.
+ * @param props.variant - Button variant.
+ * @param props.from    - Route pattern used as the `useSearch( { from } )` context.
+ * @return Button.
+ */
+export default function WpBuildCreateFormButton( {
+	label = __( 'Create a form', 'jetpack-forms' ),
+	variant = 'secondary',
+	from = '/forms',
+}: CreateFormButtonProps ): JSX.Element {
+	const navigate = useNavigate();
+	const searchParams = useSearch( { from } );
+
+	const onClick = useCallback( async () => {
+		jetpackAnalytics.tracks.recordEvent( 'jetpack_wpa_forms_landing_page_cta_click', {
+			button: 'forms',
+		} );
+
+		const newPost = await dispatch( coreStore ).saveEntityRecord( 'postType', 'jetpack_form', {
+			title: __( 'Contact Form', 'jetpack-forms' ),
+			// Seed the form post with the contact-form block so the editor opens with a form.
+			content: '<!-- wp:jetpack/contact-form /-->',
+			status: 'auto-draft',
+		} );
+
+		navigate( {
+			search: {
+				...searchParams,
+				editFormId: String( ( newPost as { id: number | string } ).id ),
+			},
+		} );
+	}, [ navigate, searchParams ] );
+
+	return (
+		<Button
+			size="compact"
+			variant={ variant }
+			onClick={ onClick }
+			icon={ plus }
+			className="create-form-button"
+		>
+			{ label }
+		</Button>
+	);
+}

--- a/projects/packages/forms/src/dashboard/wp-build/hooks/use-page-header-details.tsx
+++ b/projects/packages/forms/src/dashboard/wp-build/hooks/use-page-header-details.tsx
@@ -17,11 +17,11 @@ import { Stack } from '@wordpress/ui';
 /**
  * Internal dependencies
  */
-import CreateFormButton from '../../components/create-form-button';
 import EmptySpamButton from '../../components/empty-spam-button';
 import EmptyTrashButton from '../../components/empty-trash-button';
 import ExportResponsesButton from '../../components/export-responses/button';
 import BackToFormsButton from '../components/back-to-forms-button';
+import CreateFormButton from '../components/create-form-button';
 import ManageIntegrationsButton from '../components/manage-integrations-button';
 import type { ReactNode } from 'react';
 
@@ -147,7 +147,7 @@ export default function usePageHeaderDetails(
 				...( isIntegrationsEnabled && showDashboardIntegrations
 					? [ <ManageIntegrationsButton key="integrations" onClick={ onOpenIntegrations } /> ]
 					: [] ),
-				<CreateFormButton key="create" />,
+				<CreateFormButton key="create" from="/forms" />,
 			];
 		}
 
@@ -173,7 +173,7 @@ export default function usePageHeaderDetails(
 				? [ <ManageIntegrationsButton key="integrations" onClick={ onOpenIntegrations } /> ]
 				: [] ),
 			...( statusView === 'inbox'
-				? [ <CreateFormButton key="create" variant="secondary" showPatterns={ false } /> ]
+				? [ <CreateFormButton key="create" from="/responses/$view" variant="secondary" /> ]
 				: [] ),
 			<ExportResponsesButton key="export" isPrimary={ statusView === 'inbox' } />,
 			...( statusView === 'trash' ? [ <EmptyTrashButton key="empty-trash" /> ] : [] ),

--- a/projects/packages/forms/src/dashboard/wp-build/hooks/use-page-header-details.tsx
+++ b/projects/packages/forms/src/dashboard/wp-build/hooks/use-page-header-details.tsx
@@ -6,17 +6,18 @@ import JetpackLogo from '@automattic/jetpack-components/jetpack-logo';
  * WordPress dependencies
  */
 import { Breadcrumbs } from '@wordpress/admin-ui';
+import { Button } from '@wordpress/components';
 import { store as coreDataStore } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
-import { useMemo } from '@wordpress/element';
+import { useCallback, useMemo } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
 import { __, sprintf } from '@wordpress/i18n';
+import { useNavigate, useSearch } from '@wordpress/route';
 import { Stack } from '@wordpress/ui';
 /**
  * Internal dependencies
  */
 import CreateFormButton from '../../components/create-form-button';
-import EditFormButton from '../../components/edit-form-button';
 import EmptySpamButton from '../../components/empty-spam-button';
 import EmptyTrashButton from '../../components/empty-trash-button';
 import ExportResponsesButton from '../../components/export-responses/button';
@@ -56,6 +57,10 @@ export default function usePageHeaderDetails(
 	const { screen, sourceId, isIntegrationsEnabled, showDashboardIntegrations, onOpenIntegrations } =
 		props;
 	const statusView: ResponsesStatusView = props.statusView ?? 'inbox';
+	const navigate = useNavigate();
+	const responsesSearchParams = useSearch( {
+		from: screen === 'responses' ? '/responses/$view' : '/forms',
+	} );
 	const sourceIdNumber = useMemo( () => {
 		const value = sourceId;
 		const numberValue = typeof value === 'number' ? value : Number( value );
@@ -127,6 +132,15 @@ export default function usePageHeaderDetails(
 		return __( 'View and manage all your form submissions in one place.', 'jetpack-forms' );
 	}, [ formTitle, isFormsScreen, isSingleFormScreen ] );
 
+	const onEditForm = useCallback( () => {
+		navigate( {
+			search: {
+				...responsesSearchParams,
+				editFormId: String( sourceIdNumber ),
+			},
+		} );
+	}, [ navigate, responsesSearchParams, sourceIdNumber ] );
+
 	const actions = useMemo( () => {
 		if ( isFormsScreen ) {
 			return [
@@ -141,7 +155,11 @@ export default function usePageHeaderDetails(
 			return [
 				<BackToFormsButton key="back-to-forms" />,
 				...( sourceIdNumber
-					? [ <EditFormButton key="edit-form" formId={ sourceIdNumber } /> ]
+					? [
+							<Button key="edit-form" size="compact" variant="secondary" onClick={ onEditForm }>
+								{ __( 'Edit form', 'jetpack-forms' ) }
+							</Button>,
+					  ]
 					: [] ),
 				<ExportResponsesButton key="export" isPrimary={ false } />,
 				...( statusView === 'trash' ? [ <EmptyTrashButton key="empty-trash" /> ] : [] ),
@@ -164,6 +182,7 @@ export default function usePageHeaderDetails(
 	}, [
 		isIntegrationsEnabled,
 		onOpenIntegrations,
+		onEditForm,
 		showDashboardIntegrations,
 		sourceIdNumber,
 		isFormsScreen,

--- a/projects/packages/forms/src/dashboard/wp-build/utils/canvas-editor.ts
+++ b/projects/packages/forms/src/dashboard/wp-build/utils/canvas-editor.ts
@@ -1,0 +1,27 @@
+/**
+ * Canvas editor helpers for wp-build routes.
+ */
+
+type CanvasData = {
+	postType: string;
+	postId: string;
+	isPreview?: boolean;
+	component?: unknown;
+};
+
+/**
+ * Convert a search param into CanvasData for editing a `jetpack_form`.
+ *
+ * @param editFormId - Form ID to edit.
+ * @return CanvasData or undefined.
+ */
+export function getJetpackFormCanvasData( editFormId?: number | string ): CanvasData | undefined {
+	const id = typeof editFormId === 'number' ? editFormId : Number( editFormId );
+	if ( ! Number.isFinite( id ) || id <= 0 ) {
+		return;
+	}
+	return {
+		postType: 'jetpack_form',
+		postId: String( id ),
+	};
+}


### PR DESCRIPTION
## Proposed changes:

This adds the editor canvas to the wp-build dashboard. This allows us to send users from the dashboard to the form editor entirely via JavaScript / routing rather than page reload. It also allows users to click the WordPress icon in the form editor to return to the starting page in forms dashboard. This works for both the Create a Form and Edit Form buttons. 

**MANY KNOWN ISSUES**
* To open the block editor via canvas, we need to pass it a post ID. So the post needs to exist. You can't go to the 'new post editor' like you normally would if creating a new jetpack_form post. To accommodate this, the Create Form button much (a) create a form post (b) add a form block to it and (c) only then redirect to that post in the editor. 
* On first load, there's an extended block loading screen for the editor canvas. 
* When first adding a new form, when you first arrive in the editor, the form block is very wide and snaps into normal place. 
* There's a styling conflict that makes some of the editor text and elements white. The editor canvas is rendered inside the wp‑build admin page, so global WPDS design‑system CSS variables from @wordpress/admin-ui bleed into the editor. That overrides --wp-components-color-foreground and flips body text to white in the editor UI.
* There is a plugin conflict with Sure Forms (and likely others). Opening the editor in the canvas from the forms scree triggers a fatal error plugin conflict: PHP Fatal error:  Uncaught Error: Call to undefined function SRFM\Inc\get_current_screen() in /var/www/html/wp-content/plugins/sureforms/inc/gutenberg-hooks.php:102 . SureForms hooks into block editor settings and calls get_current_screen(), which isn’t available in REST requests. When the editor loads it hits /wp-block-editor/v1/settings, and that call fatals, returning 500 and preventing the canvas editor from loading.

https://github.com/user-attachments/assets/0d4684da-92fe-43dd-8552-e74976b025e8


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
Slack: p1770235627875889-slack-C052XEUUBL4

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Enable these feature flags: 

```
add_filter( 'jetpack_forms_alpha', '__return_true', 20 );
add_filter( 'jetpack_block_editor_feature_flags', 'eb_register_feature' );
function eb_register_feature( $flags ) {
    $flags['central-form-management'] = true;
    return $flags;
}
```

Test:
* Go to Jetpack > Forms (WP-Build)
* Test Create Form
   - Click the create form button in the header
   - Confirm the canvas editor loads - no page reload, all JS/routing
   - Click the WordPress icon in the upper left corner and confirm you return to your starting dashboard screen
 * Test Edit Form Action
   - From forms list, for one form row, click the three dots in the actions row and click Edit Form
   - Confirm the canvas editor loads with the correct form
   - Click the WordPress icon in the upper left corner and confirm you return to the forms list
 * Test Edit Form Action
   - From forms list, click on the title or View responses action to go to the single form view
   - Click the Edit Form button in the header
   - Confirm the canvas editor loads with the correct form
   - Click the WordPress icon in the upper left corner and confirm you return to the single form view in the the dashboard for your form.