### PR TITLE
Change Forms header to Forms test

### DIFF
--- a/projects/packages/forms/changelog/update-forms-header-test
+++ b/projects/packages/forms/changelog/update-forms-header-test
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Testing purposes only

--- a/projects/packages/forms/src/dashboard/inbox/stage/index.js
+++ b/projects/packages/forms/src/dashboard/inbox/stage/index.js
@@ -624,7 +624,7 @@ export default function InboxView( { parentId, pageTitle, pageSubtitle } = {} ) 
 			title={
 				<div className="jp-forms-page-header-title">
 					<JetpackLogo showText={ false } width={ 20 } />
-					{ pageTitle ? pageTitle : __( 'Forms', 'jetpack-forms' ) }
+					{ pageTitle ? pageTitle : __( 'Forms test', 'jetpack-forms' ) }
 				</div>
 			}
 			subTitle={

--- a/projects/plugins/jetpack/changelog/update-forms-header-test
+++ b/projects/plugins/jetpack/changelog/update-forms-header-test
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+test


### PR DESCRIPTION
## Summary
- Changed 'Forms' header to 'Forms test' on the Jetpack Forms Responses page

## Test plan
- [ ] Go to wp-admin → Jetpack → Forms
- [ ] Verify the header shows 'Forms test' instead of 'Forms'

🤖 Generated with [Claude Code](https://claude.com/claude-code)