### PR TITLE
Newsletter: Improve settings save feedback with toast notifications

### DIFF
--- a/projects/packages/newsletter/changelog/fix-settings-notifications
+++ b/projects/packages/newsletter/changelog/fix-settings-notifications
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Settings: Improve feedback with toast notifications for save success/error and inline error for category load failures.

--- a/projects/packages/newsletter/src/settings/index.tsx
+++ b/projects/packages/newsletter/src/settings/index.tsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import { Notice, Snackbar } from '@wordpress/components';
+import { GlobalNotices, useGlobalNotices } from '@automattic/jetpack-components';
+import { Notice } from '@wordpress/components';
 import { createRoot, useCallback, useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 /**
@@ -64,9 +65,6 @@ function NewsletterSettingsApp(): JSX.Element | null {
 	);
 	const [ isSavingSenderName, setIsSavingSenderName ] = useState( false );
 
-	// Snackbar notification state
-	const [ snackbarMessage, setSnackbarMessage ] = useState< string | null >( null );
-
 	// Newsletter categories state (for manual save)
 	const [ newsletterCategoriesChanges, setNewsletterCategoriesChanges ] = useState<
 		Partial< NewsletterSettings >
@@ -84,8 +82,8 @@ function NewsletterSettingsApp(): JSX.Element | null {
 		window as Window & { jetpackNewsletterSettings?: JetpackNewsletterSettings }
 	 ).jetpackNewsletterSettings;
 
-	// Callback to clear snackbar
-	const clearSnackbar = useCallback( () => setSnackbarMessage( null ), [] );
+	// Global notices for success messages
+	const { createSuccessNotice } = useGlobalNotices();
 
 	// Load settings on mount
 	useEffect( () => {
@@ -116,6 +114,7 @@ function NewsletterSettingsApp(): JSX.Element | null {
 			updateSettings( updates, jetpackSettings )
 				.then( () => {
 					setError( null );
+					createSuccessNotice( __( 'Settings saved', 'jetpack-newsletter' ) );
 				} )
 				.catch( ( err: Error ) => {
 					// eslint-disable-next-line no-console
@@ -125,7 +124,7 @@ function NewsletterSettingsApp(): JSX.Element | null {
 					setData( data );
 				} );
 		},
-		[ data, jetpackSettings ]
+		[ createSuccessNotice, data, jetpackSettings ]
 	);
 
 	// Handle sender name changes (staged, not auto-saved)
@@ -149,7 +148,7 @@ function NewsletterSettingsApp(): JSX.Element | null {
 			.then( () => {
 				setError( null );
 				setSenderNameChanges( {} );
-				setSnackbarMessage( __( 'Sender name saved', 'jetpack-newsletter' ) );
+				createSuccessNotice( __( 'Sender name saved', 'jetpack-newsletter' ) );
 			} )
 			.catch( ( err: Error ) => {
 				// eslint-disable-next-line no-console
@@ -159,7 +158,7 @@ function NewsletterSettingsApp(): JSX.Element | null {
 			.finally( () => {
 				setIsSavingSenderName( false );
 			} );
-	}, [ senderNameChanges, data, jetpackSettings ] );
+	}, [ createSuccessNotice, senderNameChanges, data, jetpackSettings ] );
 
 	// Handle subscription settings changes (staged, not auto-saved)
 	const handleSubscriptionChange = useCallback( ( updates: Partial< NewsletterSettings > ) => {
@@ -182,7 +181,7 @@ function NewsletterSettingsApp(): JSX.Element | null {
 			.then( () => {
 				setError( null );
 				setSubscriptionChanges( {} );
-				setSnackbarMessage( __( 'Settings saved', 'jetpack-newsletter' ) );
+				createSuccessNotice( __( 'Settings saved', 'jetpack-newsletter' ) );
 			} )
 			.catch( ( err: Error ) => {
 				// eslint-disable-next-line no-console
@@ -194,7 +193,7 @@ function NewsletterSettingsApp(): JSX.Element | null {
 			.finally( () => {
 				setIsSavingSubscriptions( false );
 			} );
-	}, [ subscriptionChanges, data, jetpackSettings ] );
+	}, [ createSuccessNotice, subscriptionChanges, data, jetpackSettings ] );
 
 	// Handle newsletter categories changes (staged, not auto-saved)
 	const handleNewsletterCategoriesChange = useCallback(
@@ -238,7 +237,7 @@ function NewsletterSettingsApp(): JSX.Element | null {
 			.then( () => {
 				setError( null );
 				setNewsletterCategoriesChanges( {} );
-				setSnackbarMessage( __( 'Newsletter categories saved', 'jetpack-newsletter' ) );
+				createSuccessNotice( __( 'Newsletter categories saved', 'jetpack-newsletter' ) );
 			} )
 			.catch( ( err: Error ) => {
 				// eslint-disable-next-line no-console
@@ -250,7 +249,7 @@ function NewsletterSettingsApp(): JSX.Element | null {
 			.finally( () => {
 				setIsSavingNewsletterCategories( false );
 			} );
-	}, [ newsletterCategoriesChanges, data, jetpackSettings ] );
+	}, [ createSuccessNotice, newsletterCategoriesChanges, data, jetpackSettings ] );
 
 	// Handle welcome email changes (staged, not auto-saved)
 	const handleWelcomeEmailChange = useCallback( ( updates: Partial< NewsletterSettings > ) => {
@@ -273,7 +272,7 @@ function NewsletterSettingsApp(): JSX.Element | null {
 			.then( () => {
 				setError( null );
 				setWelcomeEmailChanges( {} );
-				setSnackbarMessage( __( 'Welcome email message saved', 'jetpack-newsletter' ) );
+				createSuccessNotice( __( 'Welcome email message saved', 'jetpack-newsletter' ) );
 			} )
 			.catch( ( err: Error ) => {
 				// eslint-disable-next-line no-console
@@ -285,7 +284,7 @@ function NewsletterSettingsApp(): JSX.Element | null {
 			.finally( () => {
 				setIsSavingWelcomeEmail( false );
 			} );
-	}, [ welcomeEmailChanges, data, jetpackSettings ] );
+	}, [ createSuccessNotice, welcomeEmailChanges, data, jetpackSettings ] );
 
 	if ( isLoading ) {
 		return (
@@ -391,7 +390,7 @@ function NewsletterSettingsApp(): JSX.Element | null {
 				isNewsletterEnabled={ data.subscriptions }
 			/>
 
-			{ snackbarMessage && <Snackbar onRemove={ clearSnackbar }>{ snackbarMessage }</Snackbar> }
+			<GlobalNotices />
 		</div>
 	);
 }

--- a/projects/packages/newsletter/src/settings/index.tsx
+++ b/projects/packages/newsletter/src/settings/index.tsx
@@ -146,7 +146,6 @@ function NewsletterSettingsApp(): JSX.Element | null {
 
 		updateSettings( senderNameChanges, jetpackSettings )
 			.then( () => {
-				setError( null );
 				setSenderNameChanges( {} );
 				createSuccessNotice( __( 'Sender name saved', 'jetpack-newsletter' ) );
 			} )
@@ -179,7 +178,6 @@ function NewsletterSettingsApp(): JSX.Element | null {
 
 		updateSettings( subscriptionChanges, jetpackSettings )
 			.then( () => {
-				setError( null );
 				setSubscriptionChanges( {} );
 				createSuccessNotice( __( 'Settings saved', 'jetpack-newsletter' ) );
 			} )
@@ -235,7 +233,6 @@ function NewsletterSettingsApp(): JSX.Element | null {
 
 		updateSettings( apiUpdates, jetpackSettings )
 			.then( () => {
-				setError( null );
 				setNewsletterCategoriesChanges( {} );
 				createSuccessNotice( __( 'Newsletter categories saved', 'jetpack-newsletter' ) );
 			} )
@@ -270,7 +267,6 @@ function NewsletterSettingsApp(): JSX.Element | null {
 
 		updateSettings( welcomeEmailChanges, jetpackSettings )
 			.then( () => {
-				setError( null );
 				setWelcomeEmailChanges( {} );
 				createSuccessNotice( __( 'Welcome email message saved', 'jetpack-newsletter' ) );
 			} )

--- a/projects/packages/newsletter/src/settings/index.tsx
+++ b/projects/packages/newsletter/src/settings/index.tsx
@@ -82,8 +82,8 @@ function NewsletterSettingsApp(): JSX.Element | null {
 		window as Window & { jetpackNewsletterSettings?: JetpackNewsletterSettings }
 	 ).jetpackNewsletterSettings;
 
-	// Global notices for success messages
-	const { createSuccessNotice } = useGlobalNotices();
+	// Global notices for success/error messages
+	const { createSuccessNotice, createErrorNotice } = useGlobalNotices();
 
 	// Load settings on mount
 	useEffect( () => {
@@ -113,18 +113,19 @@ function NewsletterSettingsApp(): JSX.Element | null {
 			// Save to backend
 			updateSettings( updates, jetpackSettings )
 				.then( () => {
-					setError( null );
 					createSuccessNotice( __( 'Settings saved', 'jetpack-newsletter' ) );
 				} )
 				.catch( ( err: Error ) => {
 					// eslint-disable-next-line no-console
 					console.error( 'Newsletter settings auto-save error:', err );
-					setError( err.message || __( 'Failed to save settings', 'jetpack-newsletter' ) );
+					createErrorNotice( err.message || __( 'Failed to save settings', 'jetpack-newsletter' ), {
+						explicitDismiss: true,
+					} );
 					// Revert optimistic update on error
 					setData( data );
 				} );
 		},
-		[ createSuccessNotice, data, jetpackSettings ]
+		[ createErrorNotice, createSuccessNotice, data, jetpackSettings ]
 	);
 
 	// Handle sender name changes (staged, not auto-saved)
@@ -142,7 +143,6 @@ function NewsletterSettingsApp(): JSX.Element | null {
 		}
 
 		setIsSavingSenderName( true );
-		setError( null );
 
 		updateSettings( senderNameChanges, jetpackSettings )
 			.then( () => {
@@ -152,12 +152,15 @@ function NewsletterSettingsApp(): JSX.Element | null {
 			.catch( ( err: Error ) => {
 				// eslint-disable-next-line no-console
 				console.error( 'Newsletter sender name save error:', err );
-				setError( err.message || __( 'Failed to save sender name', 'jetpack-newsletter' ) );
+				createErrorNotice(
+					err.message || __( 'Failed to save sender name', 'jetpack-newsletter' ),
+					{ explicitDismiss: true }
+				);
 			} )
 			.finally( () => {
 				setIsSavingSenderName( false );
 			} );
-	}, [ createSuccessNotice, senderNameChanges, data, jetpackSettings ] );
+	}, [ createErrorNotice, createSuccessNotice, senderNameChanges, data, jetpackSettings ] );
 
 	// Handle subscription settings changes (staged, not auto-saved)
 	const handleSubscriptionChange = useCallback( ( updates: Partial< NewsletterSettings > ) => {
@@ -174,7 +177,6 @@ function NewsletterSettingsApp(): JSX.Element | null {
 		}
 
 		setIsSavingSubscriptions( true );
-		setError( null );
 
 		updateSettings( subscriptionChanges, jetpackSettings )
 			.then( () => {
@@ -184,14 +186,15 @@ function NewsletterSettingsApp(): JSX.Element | null {
 			.catch( ( err: Error ) => {
 				// eslint-disable-next-line no-console
 				console.error( 'Newsletter subscription settings save error:', err );
-				setError(
-					err.message || __( 'Failed to save subscription settings', 'jetpack-newsletter' )
+				createErrorNotice(
+					err.message || __( 'Failed to save subscription settings', 'jetpack-newsletter' ),
+					{ explicitDismiss: true }
 				);
 			} )
 			.finally( () => {
 				setIsSavingSubscriptions( false );
 			} );
-	}, [ createSuccessNotice, subscriptionChanges, data, jetpackSettings ] );
+	}, [ createErrorNotice, createSuccessNotice, subscriptionChanges, data, jetpackSettings ] );
 
 	// Handle newsletter categories changes (staged, not auto-saved)
 	const handleNewsletterCategoriesChange = useCallback(
@@ -211,7 +214,6 @@ function NewsletterSettingsApp(): JSX.Element | null {
 		}
 
 		setIsSavingNewsletterCategories( true );
-		setError( null );
 
 		// Convert categories from strings to numbers for API
 		const apiUpdates: Record< string, unknown > = { ...newsletterCategoriesChanges };
@@ -239,14 +241,21 @@ function NewsletterSettingsApp(): JSX.Element | null {
 			.catch( ( err: Error ) => {
 				// eslint-disable-next-line no-console
 				console.error( 'Newsletter categories save error:', err );
-				setError(
-					err.message || __( 'Failed to save newsletter categories', 'jetpack-newsletter' )
+				createErrorNotice(
+					err.message || __( 'Failed to save newsletter categories', 'jetpack-newsletter' ),
+					{ explicitDismiss: true }
 				);
 			} )
 			.finally( () => {
 				setIsSavingNewsletterCategories( false );
 			} );
-	}, [ createSuccessNotice, newsletterCategoriesChanges, data, jetpackSettings ] );
+	}, [
+		createErrorNotice,
+		createSuccessNotice,
+		newsletterCategoriesChanges,
+		data,
+		jetpackSettings,
+	] );
 
 	// Handle welcome email changes (staged, not auto-saved)
 	const handleWelcomeEmailChange = useCallback( ( updates: Partial< NewsletterSettings > ) => {
@@ -263,7 +272,6 @@ function NewsletterSettingsApp(): JSX.Element | null {
 		}
 
 		setIsSavingWelcomeEmail( true );
-		setError( null );
 
 		updateSettings( welcomeEmailChanges, jetpackSettings )
 			.then( () => {
@@ -273,14 +281,15 @@ function NewsletterSettingsApp(): JSX.Element | null {
 			.catch( ( err: Error ) => {
 				// eslint-disable-next-line no-console
 				console.error( 'Newsletter welcome email save error:', err );
-				setError(
-					err.message || __( 'Failed to save welcome email message', 'jetpack-newsletter' )
+				createErrorNotice(
+					err.message || __( 'Failed to save welcome email message', 'jetpack-newsletter' ),
+					{ explicitDismiss: true }
 				);
 			} )
 			.finally( () => {
 				setIsSavingWelcomeEmail( false );
 			} );
-	}, [ createSuccessNotice, welcomeEmailChanges, data, jetpackSettings ] );
+	}, [ createErrorNotice, createSuccessNotice, welcomeEmailChanges, data, jetpackSettings ] );
 
 	if ( isLoading ) {
 		return (
@@ -343,7 +352,6 @@ function NewsletterSettingsApp(): JSX.Element | null {
 				isSaving={ isSavingNewsletterCategories }
 				hasChanges={ hasNewsletterCategoriesChanges }
 				jetpackSettings={ jetpackSettings }
-				onError={ setError }
 				isNewsletterEnabled={ data.subscriptions }
 			/>
 

--- a/projects/packages/newsletter/src/settings/sections/newsletter-categories-section.tsx
+++ b/projects/packages/newsletter/src/settings/sections/newsletter-categories-section.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { WpcomSupportLink } from '@automattic/jetpack-shared-extension-utils/components';
-import { Button, ExternalLink } from '@wordpress/components';
+import { Button, ExternalLink, Notice } from '@wordpress/components';
 import { DataForm, type Field, useFormValidity } from '@wordpress/dataviews/wp';
 import { createInterpolateElement, useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -19,7 +19,6 @@ interface NewsletterCategoriesSectionProps {
 	isSaving: boolean;
 	hasChanges: boolean;
 	jetpackSettings: JetpackNewsletterSettings | undefined;
-	onError: ( error: string ) => void;
 	isNewsletterEnabled: boolean;
 }
 
@@ -36,11 +35,11 @@ export function NewsletterCategoriesSection( {
 	isSaving,
 	hasChanges,
 	jetpackSettings,
-	onError,
 	isNewsletterEnabled,
 }: NewsletterCategoriesSectionProps ): JSX.Element {
 	const [ categories, setCategories ] = useState< WordPressCategory[] >( [] );
 	const [ isFetchingCategories, setIsFetchingCategories ] = useState( true );
+	const [ categoriesError, setCategoriesError ] = useState< string | null >( null );
 
 	// Fetch WordPress categories on mount
 	useEffect( () => {
@@ -56,10 +55,12 @@ export function NewsletterCategoriesSection( {
 				setIsFetchingCategories( false );
 			} )
 			.catch( ( err: Error ) => {
-				onError( err.message || __( 'Failed to load categories', 'jetpack-newsletter' ) );
+				setCategoriesError(
+					err.message || __( 'Failed to load categories', 'jetpack-newsletter' )
+				);
 				setIsFetchingCategories( false );
 			} );
-	}, [ jetpackSettings, onError ] );
+	}, [ jetpackSettings ] );
 
 	// Define fields
 	const fields: Field< NewsletterSettings >[] = [
@@ -153,7 +154,15 @@ export function NewsletterCategoriesSection( {
 					}
 				) }
 			</p>
-			<fieldset className="newsletter-settings__section-content" disabled={ ! isNewsletterEnabled }>
+			{ categoriesError && (
+				<Notice status="error" isDismissible={ false }>
+					{ categoriesError }
+				</Notice>
+			) }
+			<fieldset
+				className="newsletter-settings__section-content"
+				disabled={ ! isNewsletterEnabled || !! categoriesError }
+			>
 				<DataForm
 					data={ data }
 					fields={ newsletterCategoriesFields }


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/DOTCOM-15756

## Proposed changes:
- Replace local `Snackbar` with `GlobalNotices` component from `@automattic/jetpack-components` for consistent toast notifications
- Add success toast notifications for all save operations (including auto-save)
- Change save error handling to use persistent toast notifications (`explicitDismiss: true`) instead of inline errors that hide the form
- Add local error state for category fetch failures with inline Notice in the Newsletter Categories section
- Disable Newsletter Categories section when categories fail to load

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

0. Enable the new Newsletter settings page by making `add_filter( 'jetpack_wp_admin_newsletter_settings_enabled', '__return_true' );` run early,
   - Add to a new mu-plugin
   - Pasting it into the top of jetpack-dev/jetpack.php using the plugin file editor on a jurassic ninja site.
   - Add to your 0-sandbox.php on your sandbox
2. Go to the Newsletter settings page in the Jetpack menu
3. **Test success toasts:**
   - Toggle any auto-save setting (e.g., email content options) - you should see a "Settings saved" toast
   - Change a manual-save setting (e.g., sender name) and click Save - you should see a success toast
4. **Test error handling:**
   - Open browser DevTools → Network tab
   - Check "Offline" mode
   - Try saving any setting - you should see a persistent error toast that requires manual dismissal
   - The form should remain visible and usable (not hidden by an error)
5. **Test category load errors:**
   - This is probably really unlikely to happen.
   - In DevTools block access to `/wp-json/wp/v2/categories?per_page=100&page=1&_locale=user`
   - Refresh the page
   - The Newsletter Categories section should show an inline error Notice and be disabled

Saved | Fail to save | Fail to load categories |
-------|-------|------
<img width="1246" height="627" alt="Screenshot 2026-02-05 at 19 04 47" src="https://github.com/user-attachments/assets/a945f51e-7f7e-4c0f-9ee9-567aabafcf86" /> | <img width="1250" height="399" alt="Screenshot 2026-02-05 at 19 00 13" src="https://github.com/user-attachments/assets/bbead434-7eb3-4676-be54-c6bbcad3bc3c" /> | <img width="1240" height="442" alt="Screenshot 2026-02-05 at 19 01 38" src="https://github.com/user-attachments/assets/da458663-1589-4dce-a1de-77399cbe625b" />

