### PR TITLE
Restore Chrome AI script registration to fix P2 block breakage

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-restore-chrome-ai-script
+++ b/projects/plugins/jetpack/changelog/fix-restore-chrome-ai-script
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Restore Chrome AI script registration to fix P2 block breakage on wpcom.

--- a/projects/plugins/jetpack/class.jetpack-gutenberg.php
+++ b/projects/plugins/jetpack/class.jetpack-gutenberg.php
@@ -848,6 +848,24 @@ class Jetpack_Gutenberg {
 
 		// Adds Connection package initial state.
 		Connection_Initial_State::render_script( 'jetpack-blocks-editor' );
+
+		/*
+		 * Chrome AI Origin Trial tokens script.
+		 *
+		 * This script registration must be kept even though Chrome AI experiment code was removed.
+		 * Removing it breaks P2 blocks on wpcom due to script concatenation/bundling behavior.
+		 * The tokens will quietly expire and do nothing harmful.
+		 *
+		 * @see https://github.com/Automattic/jetpack/pull/46896
+		 */
+		wp_register_script(
+			'jetpack-chrome-ai-token',
+			'https://widgets.wp.com/jetpack-chrome-ai/v1/3p-token.js',
+			array(),
+			gmdate( 'Ymd' ) . floor( (int) gmdate( 'G' ) / 12 ),
+			true
+		);
+		wp_enqueue_script( 'jetpack-chrome-ai-token' );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #

## Proposed changes:

* Restore the `jetpack-chrome-ai-token` script registration that was removed in #46896
* After #46896 was deployed, P2 blocks (`p2/task`, `p2/spoiler`) stopped working with the error: "Your site doesn't include support for the 'p2/task' block"
* **Hypothesis**: Removing the script registration changed wpcom's script concatenation/bundling behavior, breaking P2 block registration - even though P2 doesn't actually depend on Chrome AI code
* The Chrome AI tokens will quietly expire and do nothing harmful

### Other information:

- [x] Have you written new tests for your changes, if applicable? N/A - restoring previously working code
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

* Deploy to a wpcom sandbox
* Open a P2 site in the block editor
* Insert a `p2/task` or `p2/spoiler` block
* Verify the block renders correctly without "Your site doesn't include support for the block" error
* Verify no console errors related to block registration