### PR TITLE
Forms: Add new HTML email template structure for form notifications

### DIFF
--- a/projects/packages/forms/changelog/add-forms-email-template
+++ b/projects/packages/forms/changelog/add-forms-email-template
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Form Notifications: Add new HTML email template structure with respondent info section, metadata section (date, source, device, IP), and updated action buttons.

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -3253,7 +3253,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 
 		// Use table layout for better email client compatibility.
 		$html = '
-		<table role="presentation" border="0" cellpadding="0" cellspacing="0" class="respondent-table" style="margin-bottom: 24px; padding-bottom: 20px; border-bottom: 1px solid #e0e0e0;">
+		<table role="presentation" border="0" cellpadding="0" cellspacing="0" class="respondent-table" style="margin-bottom: 16px;">
 			<tr>
 				<td class="respondent-avatar-cell" style="width: 64px; vertical-align: top;">
 					<div class="respondent-avatar-wrapper" style="width: 48px; height: 48px; border-radius: 24px; background-color: #f0f0f0; text-align: center; line-height: 48px; font-size: 18px; font-weight: 600; color: #50575e;">
@@ -3317,11 +3317,9 @@ class Contact_Form extends Contact_Form_Shortcode {
 		}
 
 		$html = '
-		<div class="metadata-section" style="background-color: #f6f7f7; border-radius: 4px; padding: 16px; margin-bottom: 24px;">
-			<table role="presentation" border="0" cellpadding="0" cellspacing="0" class="metadata-table" style="width: 100%;">
-				' . implode( '', $rows ) . '
-			</table>
-		</div>';
+		<table role="presentation" border="0" cellpadding="0" cellspacing="0" class="metadata-table" style="width: 100%; margin-bottom: 24px;">
+			' . implode( '', $rows ) . '
+		</table>';
 
 		return str_replace( "\t", '', $html );
 	}

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -1921,13 +1921,18 @@ class Contact_Form extends Contact_Form_Shortcode {
 
 				if ( ! empty( $safe_display_label ) ) {
 					$compiled_form[ $key ] = sprintf(
-						'<p><strong>%1$s</strong><br /><span>%2$s</span></p>',
-						self::maybe_add_colon_to_label( $safe_display_label ),
+						'<div class="form-field" style="padding: 16px 0; border-bottom: 1px solid #e0e0e0;">
+							<div class="field-label" style="font-size: 12px; color: #50575e; margin: 0 0 4px 0;">%1$s</div>
+							<div class="field-value" style="font-size: 14px; color: #1e1e1e; margin: 0;">%2$s</div>
+						</div>',
+						$safe_display_label,
 						$safe_display_value
 					);
 				} else {
 					$compiled_form[ $key ] = sprintf(
-						'<p><span>%s</span></p>',
+						'<div class="form-field" style="padding: 16px 0; border-bottom: 1px solid #e0e0e0;">
+							<div class="field-value" style="font-size: 14px; color: #1e1e1e; margin: 0;">%s</div>
+						</div>',
 						$safe_display_value
 					);
 				}
@@ -3223,6 +3228,11 @@ class Contact_Form extends Contact_Form_Shortcode {
 		$name   = isset( $respondent_info['name'] ) ? esc_html( $respondent_info['name'] ) : '';
 		$email  = isset( $respondent_info['email'] ) ? esc_html( $respondent_info['email'] ) : '';
 		$avatar = isset( $respondent_info['avatar'] ) ? esc_url( $respondent_info['avatar'] ) : '';
+
+		// Don't show section if there's no name or email.
+		if ( empty( $name ) && empty( $email ) ) {
+			return '';
+		}
 
 		// Get initials for avatar fallback.
 		$initials = '';

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -2777,16 +2777,10 @@ class Contact_Form extends Contact_Form_Shortcode {
 		$actions = '';
 		if ( $dashboard_url ) {
 			$actions = sprintf(
-				'<table role="presentation" border="0" cellpadding="0" cellspacing="0" style="margin: 0 auto;">
-					<tr>
-						<td align="center" style="padding: 0 8px;">
-							<a href="%1$s" class="action-button action-button-secondary" style="display: inline-block; padding: 12px 24px; border-radius: 4px; font-size: 14px; font-weight: 500; text-decoration: none; background-color: transparent; color: #1e1e1e; border: 1px solid #1e1e1e;">%2$s</a>
-						</td>
-						<td align="center" style="padding: 0 8px;">
-							<a href="%3$s" class="action-button action-button-primary" style="display: inline-block; padding: 12px 24px; border-radius: 4px; font-size: 14px; font-weight: 500; text-decoration: none; background-color: #3858e9; color: #ffffff;">%4$s</a>
-						</td>
-					</tr>
-				</table>',
+				'<div style="text-align: center;">
+					<a href="%1$s" class="action-button action-button-secondary" style="display: inline-block; height: 40px; line-height: 40px; padding: 0 24px; border-radius: 4px; font-size: 14px; font-weight: 500; text-decoration: none; background-color: transparent; color: #1e1e1e; border: 1px solid #1e1e1e; margin-right: 8px;">%2$s</a>
+					<a href="%3$s" class="action-button action-button-primary" style="display: inline-block; height: 40px; line-height: 40px; padding: 0 24px; border-radius: 4px; font-size: 14px; font-weight: 500; text-decoration: none; background-color: #3858e9; color: #ffffff;">%4$s</a>
+				</div>',
 				esc_url( $mark_as_spam_url ),
 				__( 'Mark as spam', 'jetpack-forms' ),
 				esc_url( $dashboard_url ),
@@ -3171,16 +3165,16 @@ class Contact_Form extends Contact_Form_Shortcode {
 				"\t",
 				'',
 				'
-				<tr>
-					<td class="content-block powered-by">
-					' .
+				<div class="powered-by" style="text-align: center; padding: 24px 0 0 0; margin-top: 24px;">
+					<!-- TODO: Replace this placeholder logo with a proper Jetpack logo hosted on a CDN for email use -->
+					<img src="https://jetpack.com/wp-content/uploads/2022/06/cropped-jp-favicon-new-3.png?w=40" alt="Jetpack" width="20" height="20" style="vertical-align: middle; margin-right: 6px;">
+					<span style="font-size: 13px; color: #50575e;">' .
 					sprintf(
 						// translators: %1$s is a link to the Jetpack Forms page.
 						__( 'Powered by %1$s', 'jetpack-forms' ),
-						'<a href="https://jetpack.com/forms/?utm_source=jetpack-forms&utm_medium=email&utm_campaign=form-submissions">Jetpack Forms</a>'
-					) . '
-					</td>
-				</tr>'
+						'<a href="https://jetpack.com/forms/?utm_source=jetpack-forms&utm_medium=email&utm_campaign=form-submissions" style="color: #50575e; text-decoration: none;">Jetpack Forms</a>'
+					) . '</span>
+				</div>'
 			)
 		);
 
@@ -3262,7 +3256,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 				</td>
 				<td class="respondent-details-cell" style="vertical-align: middle;">
 					' . ( ! empty( $name ) ? '<div class="respondent-name" style="font-size: 16px; font-weight: 600; color: #1e1e1e; margin: 0 0 2px 0;">' . $name . '</div>' : '' ) . '
-					' . ( ! empty( $email ) ? '<div class="respondent-email" style="font-size: 14px; color: #50575e; margin: 0;">' . $email . '</div>' : '' ) . '
+					' . ( ! empty( $email ) ? '<div class="respondent-email" style="font-size: 14px; color: #50575e; margin: 0;"><a href="mailto:' . $email . '" style="color: #3858e9; text-decoration: none;">' . $email . '</a></div>' : '' ) . '
 				</td>
 			</tr>
 		</table>';
@@ -3334,7 +3328,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 	private static function generate_metadata_row( $label, $value ) {
 		return '
 			<tr>
-				<td class="metadata-label" style="color: #50575e; width: 100px; padding: 4px 12px 4px 0; font-size: 13px; vertical-align: top;">' . esc_html( $label ) . '</td>
+				<td class="metadata-label" style="color: #50575e; width: 100px; padding: 4px 12px 4px 0; font-size: 13px; vertical-align: top;">' . esc_html( $label ) . ':</td>
 				<td class="metadata-value" style="color: #1e1e1e; padding: 4px 0; font-size: 13px; vertical-align: top;">' . $value . '</td>
 			</tr>';
 	}

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -1919,20 +1919,29 @@ class Contact_Form extends Contact_Form_Shortcode {
 				$safe_display_label = self::escape_and_sanitize_field_label( $value['label'] );
 				$safe_display_value = self::escape_and_sanitize_field_value( $value['value'] );
 
+				// Use table-based layout for maximum email client compatibility.
 				if ( ! empty( $safe_display_label ) ) {
 					$compiled_form[ $key ] = sprintf(
-						'<div class="form-field" style="padding: 16px 0; border-bottom: 1px solid #e0e0e0;">
-							<div class="field-label" style="font-size: 12px; color: #50575e; margin: 0 0 4px 0;">%1$s</div>
-							<div class="field-value" style="font-size: 14px; color: #1e1e1e; margin: 0;">%2$s</div>
-						</div>',
+						'<table role="presentation" border="0" cellpadding="0" cellspacing="0" width="100%%" style="border-collapse: collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt;">
+							<tr>
+								<td style="padding: 16px 0; border-bottom: 1px solid #e0e0e0; font-family: -apple-system, BlinkMacSystemFont, \'Segoe UI\', Roboto, Oxygen-Sans, Ubuntu, Cantarell, \'Helvetica Neue\', sans-serif;">
+									<div style="font-size: 12px; color: #50575e; margin: 0 0 4px 0; line-height: 1.4;">%1$s</div>
+									<div style="font-size: 14px; color: #1e1e1e; margin: 0; line-height: 1.5;">%2$s</div>
+								</td>
+							</tr>
+						</table>',
 						$safe_display_label,
 						$safe_display_value
 					);
 				} else {
 					$compiled_form[ $key ] = sprintf(
-						'<div class="form-field" style="padding: 16px 0; border-bottom: 1px solid #e0e0e0;">
-							<div class="field-value" style="font-size: 14px; color: #1e1e1e; margin: 0;">%s</div>
-						</div>',
+						'<table role="presentation" border="0" cellpadding="0" cellspacing="0" width="100%%" style="border-collapse: collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt;">
+							<tr>
+								<td style="padding: 16px 0; border-bottom: 1px solid #e0e0e0; font-family: -apple-system, BlinkMacSystemFont, \'Segoe UI\', Roboto, Oxygen-Sans, Ubuntu, Cantarell, \'Helvetica Neue\', sans-serif;">
+									<div style="font-size: 14px; color: #1e1e1e; margin: 0; line-height: 1.5;">%s</div>
+								</td>
+							</tr>
+						</table>',
 						$safe_display_value
 					);
 				}
@@ -1969,7 +1978,8 @@ class Contact_Form extends Contact_Form_Shortcode {
 
 					$html = esc_html( $file_name );
 					if ( ! empty( $file_size ) ) {
-						$html .= sprintf( ' <span class="jetpack-forms-file-size">(%s)</span>', esc_html( $file_size ) );
+						// Use inline styles only for maximum email client compatibility.
+						$html .= sprintf( ' <span style="color: #757575;">(%s)</span>', esc_html( $file_size ) );
 					}
 
 					$file_links[] = $html;
@@ -2774,13 +2784,20 @@ class Contact_Form extends Contact_Form_Shortcode {
 		);
 
 		// Build the actions with both Mark as spam and View in dashboard buttons.
+		// Use fully table-based layout for maximum email client compatibility - no display:inline-block.
 		$actions = '';
 		if ( $dashboard_url ) {
 			$actions = sprintf(
-				'<div style="text-align: center;">
-					<a href="%1$s" class="action-button action-button-secondary" style="display: inline-block; height: 40px; line-height: 40px; padding: 0 24px; border-radius: 4px; font-size: 14px; font-weight: 500; text-decoration: none; background-color: transparent; color: #1e1e1e; border: 1px solid #1e1e1e; margin-right: 8px;">%2$s</a>
-					<a href="%3$s" class="action-button action-button-primary" style="display: inline-block; height: 40px; line-height: 40px; padding: 0 24px; border-radius: 4px; font-size: 14px; font-weight: 500; text-decoration: none; background-color: #3858e9; color: #ffffff;">%4$s</a>
-				</div>',
+				'<table role="presentation" border="0" cellpadding="0" cellspacing="0" align="center" style="border-collapse: collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; margin: 0 auto;">
+					<tr>
+						<td style="padding-right: 8px; font-family: -apple-system, BlinkMacSystemFont, \'Segoe UI\', Roboto, Oxygen-Sans, Ubuntu, Cantarell, \'Helvetica Neue\', sans-serif;">
+							<a href="%1$s" style="background-color: transparent; color: #1e1e1e; border: 1px solid #1e1e1e; border-radius: 4px; font-size: 14px; font-weight: 500; text-decoration: none; padding: 12px 24px; text-align: center; mso-padding-alt: 0;">%2$s</a>
+						</td>
+						<td style="font-family: -apple-system, BlinkMacSystemFont, \'Segoe UI\', Roboto, Oxygen-Sans, Ubuntu, Cantarell, \'Helvetica Neue\', sans-serif;">
+							<a href="%3$s" style="background-color: #3858e9; color: #ffffff; border-radius: 4px; font-size: 14px; font-weight: 500; text-decoration: none; padding: 12px 24px; text-align: center; mso-padding-alt: 0;">%4$s</a>
+						</td>
+					</tr>
+				</table>',
 				esc_url( $mark_as_spam_url ),
 				__( 'Mark as spam', 'jetpack-forms' ),
 				esc_url( $dashboard_url ),
@@ -3159,22 +3176,27 @@ class Contact_Form extends Contact_Form_Shortcode {
 		 *
 		 * @param string $powered_by_html The HTML for the powered by section in the email.
 		 */
+		// Use table-based layout for maximum email client compatibility.
 		$powered_by_html = apply_filters(
 			'jetpack_forms_email_powered_by_html',
 			str_replace(
 				"\t",
 				'',
 				'
-				<div class="powered-by" style="text-align: center; padding: 24px 0 0 0; margin-top: 24px;">
-					<!-- TODO: Replace this placeholder logo with a proper Jetpack logo hosted on a CDN for email use -->
-					<img src="https://jetpack.com/wp-content/uploads/2022/06/cropped-jp-favicon-new-3.png?w=40" alt="Jetpack" width="20" height="20" style="vertical-align: middle; margin-right: 6px;">
-					<span style="font-size: 13px; color: #50575e;">' .
+				<table role="presentation" border="0" cellpadding="0" cellspacing="0" width="100%" style="border-collapse: collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; margin-top: 24px;">
+					<tr>
+						<td align="center" style="padding: 24px 0 0 0; font-family: -apple-system, BlinkMacSystemFont, \'Segoe UI\', Roboto, Oxygen-Sans, Ubuntu, Cantarell, \'Helvetica Neue\', sans-serif;">
+							<!-- TODO: Replace this placeholder logo with a proper Jetpack logo hosted on a CDN for email use -->
+							<img src="https://jetpack.com/wp-content/uploads/2022/06/cropped-jp-favicon-new-3.png?w=40" alt="Jetpack" width="20" height="20" style="vertical-align: middle; margin-right: 6px; border: 0; outline: none; text-decoration: none;">
+							<span style="font-size: 13px; color: #50575e; line-height: 20px;">' .
 					sprintf(
 						// translators: %1$s is a link to the Jetpack Forms page.
 						__( 'Powered by %1$s', 'jetpack-forms' ),
 						'<a href="https://jetpack.com/forms/?utm_source=jetpack-forms&utm_medium=email&utm_campaign=form-submissions" style="color: #50575e; text-decoration: none;">Jetpack Forms</a>'
 					) . '</span>
-				</div>'
+						</td>
+					</tr>
+				</table>'
 			)
 		);
 
@@ -3245,18 +3267,28 @@ class Contact_Form extends Contact_Form_Shortcode {
 			? '<img src="' . $avatar . '" alt="" width="48" height="48" style="border-radius: 24px;">'
 			: esc_html( $initials );
 
-		// Use table layout for better email client compatibility.
+		// Use table layout for maximum email client compatibility - no CSS classes, only inline styles.
 		$html = '
-		<table role="presentation" border="0" cellpadding="0" cellspacing="0" class="respondent-table" style="margin-bottom: 16px;">
+		<table role="presentation" border="0" cellpadding="0" cellspacing="0" width="100%" style="border-collapse: collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; margin-bottom: 16px;">
 			<tr>
-				<td class="respondent-avatar-cell" style="width: 64px; vertical-align: top;">
-					<div class="respondent-avatar-wrapper" style="width: 48px; height: 48px; border-radius: 24px; background-color: #f0f0f0; text-align: center; line-height: 48px; font-size: 18px; font-weight: 600; color: #50575e;">
+				<td style="width: 64px; vertical-align: top; font-family: -apple-system, BlinkMacSystemFont, \'Segoe UI\', Roboto, Oxygen-Sans, Ubuntu, Cantarell, \'Helvetica Neue\', sans-serif;">
+					<!--[if mso]>
+					<table role="presentation" border="0" cellpadding="0" cellspacing="0" width="48" height="48" style="width: 48px; height: 48px;">
+					<tr>
+					<td align="center" valign="middle" style="width: 48px; height: 48px; background-color: #f0f0f0; border-radius: 24px; font-size: 18px; font-weight: 600; color: #50575e;">
+					<![endif]-->
+					<div style="width: 48px; height: 48px; border-radius: 24px; background-color: #f0f0f0; text-align: center; line-height: 48px; font-size: 18px; font-weight: 600; color: #50575e;">
 						' . $avatar_content . '
 					</div>
+					<!--[if mso]>
+					</td>
+					</tr>
+					</table>
+					<![endif]-->
 				</td>
-				<td class="respondent-details-cell" style="vertical-align: middle;">
-					' . ( ! empty( $name ) ? '<div class="respondent-name" style="font-size: 16px; font-weight: 600; color: #1e1e1e; margin: 0 0 2px 0;">' . $name . '</div>' : '' ) . '
-					' . ( ! empty( $email ) ? '<div class="respondent-email" style="font-size: 14px; color: #50575e; margin: 0;"><a href="mailto:' . $email . '" style="color: #3858e9; text-decoration: none;">' . $email . '</a></div>' : '' ) . '
+				<td style="vertical-align: middle; font-family: -apple-system, BlinkMacSystemFont, \'Segoe UI\', Roboto, Oxygen-Sans, Ubuntu, Cantarell, \'Helvetica Neue\', sans-serif;">
+					' . ( ! empty( $name ) ? '<div style="font-size: 16px; font-weight: 600; color: #1e1e1e; margin: 0 0 2px 0; line-height: 1.4;">' . $name . '</div>' : '' ) . '
+					' . ( ! empty( $email ) ? '<div style="font-size: 14px; color: #50575e; margin: 0; line-height: 1.4;"><a href="mailto:' . $email . '" style="color: #3858e9; text-decoration: none;">' . $email . '</a></div>' : '' ) . '
 				</td>
 			</tr>
 		</table>';
@@ -3310,8 +3342,9 @@ class Contact_Form extends Contact_Form_Shortcode {
 			return '';
 		}
 
+		// Use table layout for maximum email client compatibility - no CSS classes, only inline styles.
 		$html = '
-		<table role="presentation" border="0" cellpadding="0" cellspacing="0" class="metadata-table" style="width: 100%; margin-bottom: 24px;">
+		<table role="presentation" border="0" cellpadding="0" cellspacing="0" width="100%" style="border-collapse: collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; margin-bottom: 24px;">
 			' . implode( '', $rows ) . '
 		</table>';
 
@@ -3326,10 +3359,11 @@ class Contact_Form extends Contact_Form_Shortcode {
 	 * @return string HTML for the row.
 	 */
 	private static function generate_metadata_row( $label, $value ) {
+		// Use inline styles only for maximum email client compatibility - no CSS classes.
 		return '
 			<tr>
-				<td class="metadata-label" style="color: #50575e; width: 100px; padding: 4px 12px 4px 0; font-size: 13px; vertical-align: top;">' . esc_html( $label ) . ':</td>
-				<td class="metadata-value" style="color: #1e1e1e; padding: 4px 0; font-size: 13px; vertical-align: top;">' . $value . '</td>
+				<td style="color: #50575e; width: 100px; padding: 4px 12px 4px 0; font-size: 13px; vertical-align: top; font-family: -apple-system, BlinkMacSystemFont, \'Segoe UI\', Roboto, Oxygen-Sans, Ubuntu, Cantarell, \'Helvetica Neue\', sans-serif; line-height: 1.4;">' . esc_html( $label ) . ':</td>
+				<td style="color: #1e1e1e; padding: 4px 0; font-size: 13px; vertical-align: top; font-family: -apple-system, BlinkMacSystemFont, \'Segoe UI\', Roboto, Oxygen-Sans, Ubuntu, Cantarell, \'Helvetica Neue\', sans-serif; line-height: 1.4;">' . $value . '</td>
 			</tr>';
 	}
 

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -2678,8 +2678,9 @@ class Contact_Form extends Contact_Form_Shortcode {
 		 *
 		 * @param string the title of the email
 		 */
-		$title   = (string) apply_filters( 'jetpack_forms_response_email_title', '' );
-		$message = self::get_compiled_form_for_email( $post_id, $this );
+		$default_email_title = __( 'Hey, a new form response just came in!', 'jetpack-forms' );
+		$title               = (string) apply_filters( 'jetpack_forms_response_email_title', $default_email_title );
+		$message             = self::get_compiled_form_for_email( $post_id, $this );
 
 		if ( is_user_logged_in() ) {
 			$sent_by_text = sprintf(
@@ -2727,6 +2728,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 
 		// Build the dashboard URL with the status and the feedback's post id if we have a post id
 		$dashboard_url           = '';
+		$mark_as_spam_url        = '';
 		$footer_mark_as_spam_url = '';
 		if ( $feedback_status !== 'jp-temp-feedback' ) {
 			$dashboard_url           = Forms_Dashboard::get_forms_admin_url( $status ) . '&r=' . $post_id;
@@ -2766,29 +2768,49 @@ class Contact_Form extends Contact_Form_Shortcode {
 			)
 		);
 
-		// Build the actions url if we have a dashboard url
+		// Build the actions with both Mark as spam and View in dashboard buttons.
 		$actions = '';
 		if ( $dashboard_url ) {
 			$actions = sprintf(
-				'<table class="button_block" border="0" cellpadding="0" cellspacing="0" role="presentation">
+				'<table role="presentation" border="0" cellpadding="0" cellspacing="0" style="margin: 0 auto;">
 					<tr>
-						<td class="pad" align="center">
-							<a rel="noopener" target="_blank" href="%1$s" data-tracks-link-desc="">
-								<!--[if mso]>
-								<i style="mso-text-raise: 30pt;">&nbsp;</i>
-								<![endif]-->
-								<span>%2$s</span>
-								<!--[if mso]>
-								<i>&nbsp;</i>
-								<![endif]-->
-							</a>
+						<td align="center" style="padding: 0 8px;">
+							<a href="%1$s" class="action-button action-button-secondary" style="display: inline-block; padding: 12px 24px; border-radius: 4px; font-size: 14px; font-weight: 500; text-decoration: none; background-color: transparent; color: #1e1e1e; border: 1px solid #1e1e1e;">%2$s</a>
+						</td>
+						<td align="center" style="padding: 0 8px;">
+							<a href="%3$s" class="action-button action-button-primary" style="display: inline-block; padding: 12px 24px; border-radius: 4px; font-size: 14px; font-weight: 500; text-decoration: none; background-color: #3858e9; color: #ffffff;">%4$s</a>
 						</td>
 					</tr>
 				</table>',
+				esc_url( $mark_as_spam_url ),
+				__( 'Mark as spam', 'jetpack-forms' ),
 				esc_url( $dashboard_url ),
 				__( 'View in dashboard', 'jetpack-forms' )
 			);
 		}
+
+		// Build respondent info for the new email template.
+		$respondent_info = array(
+			'name'   => $comment_author,
+			'email'  => $comment_author_email,
+			'avatar' => $response->get_author_avatar(),
+		);
+
+		// Get the form title for source metadata.
+		$form_title = $this->get_attribute( 'formTitle' );
+		if ( empty( $form_title ) && $this->current_post ) {
+			$form_title = self::get_post_property( $this->current_post, 'post_title' );
+		}
+
+		// Build metadata for the new email template.
+		$metadata = array(
+			'date'       => $time,
+			'source'     => $form_title,
+			'source_url' => $url,
+			'device'     => $response->get_browser(),
+			'ip'         => $comment_author_ip,
+			'ip_flag'    => $response->get_country_flag(),
+		);
 
 		/**
 		 * Filters the message sent via email after a successful form submission.
@@ -2803,7 +2825,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 		$message = apply_filters( 'contact_form_message', implode( '', $message ), $message );
 
 		// This is called after `contact_form_message`, in order to preserve back-compat
-		$message = self::wrap_message_in_html_tags( $title, $message, $footer, $actions );
+		$message = self::wrap_message_in_html_tags( $title, $message, $footer, $actions, $respondent_info, $metadata );
 
 		update_post_meta( $post_id, '_feedback_email', $this->addslashes_deep( compact( 'to', 'message' ) ) );
 
@@ -3091,10 +3113,12 @@ class Contact_Form extends Contact_Form_Shortcode {
 	 * @param string $body - the message body.
 	 * @param string $footer - the footer containing meta information.
 	 * @param string $actions - HTML for actions displayed in the email.
+	 * @param array  $respondent_info - Optional. Respondent information array with 'name', 'email', 'avatar'.
+	 * @param array  $metadata - Optional. Metadata array with 'date', 'source', 'source_url', 'device', 'ip', 'ip_flag'.
 	 *
 	 * @return string
 	 */
-	public static function wrap_message_in_html_tags( $title, $body, $footer, $actions = '' ) {
+	public static function wrap_message_in_html_tags( $title, $body, $footer, $actions = '', $respondent_info = array(), $metadata = array() ) {
 		// Don't do anything if the message was already wrapped in HTML tags
 		// That could have be done by a plugin via filters
 		if ( str_contains( $body, '<html' ) ) {
@@ -3155,6 +3179,12 @@ class Contact_Form extends Contact_Form_Shortcode {
 			)
 		);
 
+		// Generate respondent info HTML.
+		$respondent_html = self::generate_respondent_info_html( $respondent_info );
+
+		// Generate metadata HTML.
+		$metadata_html = self::generate_metadata_html( $metadata );
+
 		$html_message = sprintf(
 			// The tabs are just here so that the raw code is correctly formatted for developers
 			// They're removed so that they don't affect the final message sent to users
@@ -3163,7 +3193,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 				'',
 				$template
 			),
-			( $title !== '' ? '<h1>' . $title . '</h1>' : '' ),
+			esc_html( $title ),
 			$body,
 			'',
 			'',
@@ -3171,10 +3201,134 @@ class Contact_Form extends Contact_Form_Shortcode {
 			$style,
 			$tracking_pixel,
 			$actions,
-			$powered_by_html
+			$powered_by_html,
+			$respondent_html,
+			$metadata_html
 		);
 
 		return $html_message;
+	}
+
+	/**
+	 * Generate HTML for respondent info section in email.
+	 *
+	 * @param array $respondent_info Array with 'name', 'email', 'avatar' keys.
+	 * @return string HTML for respondent info section.
+	 */
+	private static function generate_respondent_info_html( $respondent_info ) {
+		if ( empty( $respondent_info ) ) {
+			return '';
+		}
+
+		$name   = isset( $respondent_info['name'] ) ? esc_html( $respondent_info['name'] ) : '';
+		$email  = isset( $respondent_info['email'] ) ? esc_html( $respondent_info['email'] ) : '';
+		$avatar = isset( $respondent_info['avatar'] ) ? esc_url( $respondent_info['avatar'] ) : '';
+
+		// Get initials for avatar fallback.
+		$initials = '';
+		if ( ! empty( $name ) ) {
+			$name_parts = explode( ' ', $name );
+			$initials   = strtoupper( substr( $name_parts[0], 0, 1 ) );
+			if ( count( $name_parts ) > 1 ) {
+				$initials .= strtoupper( substr( end( $name_parts ), 0, 1 ) );
+			}
+		} elseif ( ! empty( $email ) ) {
+			$initials = strtoupper( substr( $email, 0, 1 ) );
+		}
+
+		// Avatar content - either image or initials.
+		$avatar_content = ! empty( $avatar )
+			? '<img src="' . $avatar . '" alt="" width="48" height="48" style="border-radius: 24px;">'
+			: esc_html( $initials );
+
+		// Use table layout for better email client compatibility.
+		$html = '
+		<table role="presentation" border="0" cellpadding="0" cellspacing="0" class="respondent-table" style="margin-bottom: 24px; padding-bottom: 20px; border-bottom: 1px solid #e0e0e0;">
+			<tr>
+				<td class="respondent-avatar-cell" style="width: 64px; vertical-align: top;">
+					<div class="respondent-avatar-wrapper" style="width: 48px; height: 48px; border-radius: 24px; background-color: #f0f0f0; text-align: center; line-height: 48px; font-size: 18px; font-weight: 600; color: #50575e;">
+						' . $avatar_content . '
+					</div>
+				</td>
+				<td class="respondent-details-cell" style="vertical-align: middle;">
+					' . ( ! empty( $name ) ? '<div class="respondent-name" style="font-size: 16px; font-weight: 600; color: #1e1e1e; margin: 0 0 2px 0;">' . $name . '</div>' : '' ) . '
+					' . ( ! empty( $email ) ? '<div class="respondent-email" style="font-size: 14px; color: #50575e; margin: 0;">' . $email . '</div>' : '' ) . '
+				</td>
+			</tr>
+		</table>';
+
+		return str_replace( "\t", '', $html );
+	}
+
+	/**
+	 * Generate HTML for metadata section in email.
+	 *
+	 * @param array $metadata Array with 'date', 'source', 'source_url', 'device', 'ip', 'ip_flag' keys.
+	 * @return string HTML for metadata section.
+	 */
+	private static function generate_metadata_html( $metadata ) {
+		if ( empty( $metadata ) ) {
+			return '';
+		}
+
+		$rows = array();
+
+		// Date row.
+		if ( ! empty( $metadata['date'] ) ) {
+			$rows[] = self::generate_metadata_row( __( 'Date', 'jetpack-forms' ), esc_html( $metadata['date'] ) );
+		}
+
+		// Source row.
+		if ( ! empty( $metadata['source'] ) ) {
+			$source_value = esc_html( $metadata['source'] );
+			if ( ! empty( $metadata['source_url'] ) ) {
+				$source_value = '<a href="' . esc_url( $metadata['source_url'] ) . '" style="color: #3858e9; text-decoration: none;">' . $source_value . '</a>';
+			}
+			$rows[] = self::generate_metadata_row( __( 'Source', 'jetpack-forms' ), $source_value );
+		}
+
+		// Device row.
+		if ( ! empty( $metadata['device'] ) ) {
+			$rows[] = self::generate_metadata_row( __( 'Device', 'jetpack-forms' ), esc_html( $metadata['device'] ) );
+		}
+
+		// IP Address row.
+		if ( ! empty( $metadata['ip'] ) ) {
+			$ip_value = '';
+			if ( ! empty( $metadata['ip_flag'] ) ) {
+				$ip_value .= $metadata['ip_flag'] . ' ';
+			}
+			$ip_value .= esc_html( $metadata['ip'] );
+			$rows[]    = self::generate_metadata_row( __( 'IP address', 'jetpack-forms' ), $ip_value );
+		}
+
+		if ( empty( $rows ) ) {
+			return '';
+		}
+
+		$html = '
+		<div class="metadata-section" style="background-color: #f6f7f7; border-radius: 4px; padding: 16px; margin-bottom: 24px;">
+			<table role="presentation" border="0" cellpadding="0" cellspacing="0" class="metadata-table" style="width: 100%;">
+				' . implode( '', $rows ) . '
+			</table>
+		</div>';
+
+		return str_replace( "\t", '', $html );
+	}
+
+	/**
+	 * Generate a single metadata row.
+	 *
+	 * @param string $label The label text.
+	 * @param string $value The value (can contain HTML).
+	 * @return string HTML for the row.
+	 */
+	private static function generate_metadata_row( $label, $value ) {
+		return '
+			<tr>
+				<td class="metadata-label" style="color: #50575e; width: 100px; padding: 4px 12px 4px 0; font-size: 13px; vertical-align: top;">' . esc_html( $label ) . '</td>
+				<td class="metadata-value" style="color: #1e1e1e; padding: 4px 0; font-size: 13px; vertical-align: top;">' . $value . '</td>
+			</tr>';
 	}
 
 	/**

--- a/projects/packages/forms/src/contact-form/templates/email-response.php
+++ b/projects/packages/forms/src/contact-form/templates/email-response.php
@@ -59,22 +59,12 @@ $template = '
 								<div class="actions">
 									%8$s
 								</div>
+
+								<!-- Powered By -->
+								%9$s
 							</td>
 						</tr>
 					</table>
-
-					<!-- START FOOTER -->
-					<div class="footer">
-						<table role="presentation" border="0" cellpadding="0" cellspacing="0">
-							<tr>
-								<td class="content-block wrapper footer-content">
-									<!-- footer -->
-									<p>%5$s</p>
-								</td>
-							</tr>
-							%9$s
-						</table>
-					</div>
 				</div>
 			</td>
 			<td class="collapse">&nbsp;</td>
@@ -123,17 +113,17 @@ $style = '<style media="all" type="text/css">
 
 	.container {
 		margin: 0 auto !important;
-		max-width: 600px;
+		max-width: 830px;
 		padding: 0;
 		padding-top: 24px;
-		width: 600px;
+		width: 830px;
 	}
 
 	.content {
 		box-sizing: border-box;
 		display: block;
 		margin: 0 auto;
-		max-width: 600px;
+		max-width: 830px;
 		padding: 0;
 	}
 
@@ -145,7 +135,7 @@ $style = '<style media="all" type="text/css">
 
 	.wrapper {
 		box-sizing: border-box;
-		padding: 32px;
+		padding: 40px 48px;
 	}
 
 	.content-block {
@@ -232,6 +222,8 @@ $style = '<style media="all" type="text/css">
 
 	.metadata-table {
 		width: 100%;
+		padding-bottom: 20px;
+		border-bottom: 1px solid #e0e0e0;
 	}
 
 	.metadata-table td {
@@ -519,9 +511,7 @@ $style = '<style media="all" type="text/css">
 
 	/* Email client table layout for respondent info */
 	.respondent-table {
-		margin-bottom: 24px;
-		padding-bottom: 20px;
-		border-bottom: 1px solid #e0e0e0;
+		margin-bottom: 16px;
 	}
 
 	.respondent-avatar-cell {

--- a/projects/packages/forms/src/contact-form/templates/email-response.php
+++ b/projects/packages/forms/src/contact-form/templates/email-response.php
@@ -1,16 +1,19 @@
 <?php
 /**
- * Grunion Contact Form Template
+ * Jetpack Forms Email Response Template
+ *
  * The template contains several placeholders:
- * %1$s is the hero text to display above the response
- * %2$s is the response itself.
+ * %1$s is the hero text to display above the response (e.g., "Hey, a new form response just came in!")
+ * %2$s is the response itself (form fields HTML).
  * %3$s was a link to the response page in wp-admin (left empty for backwards compatibility)
  * %4$s was a link to the embedded form to allow the site owner to edit it to change their email address (left empty for backwards compatibility)
- * %5$s is the footer HTML.
+ * %5$s is the footer HTML (metadata: time, IP, browser, source URL).
  * %6$s style HTML tag.
  * %7$s tracking pixel
- * %8$s is the actions HTML.
+ * %8$s is the actions HTML (buttons).
  * %9$s is powered by email logo.
+ * %10$s is the respondent info section (avatar, name, email).
+ * %11$s is the metadata section (Date, Source, Device, IP).
  *
  * @package automattic/jetpack
  */
@@ -37,28 +40,42 @@ $template = '
 					<span class="preheader">%1$s</span>
 					<table role="presentation" border="0" cellpadding="0" cellspacing="0" class="main">
 						<tr>
-						<td class="wrapper">
-							<!-- response -->
-							<p>%2$s</p>
-							%3$s
-							%4$s
-							<div class="actions">
-								%8$s
-							</div>
-						</td>
+							<td class="wrapper">
+								<!-- Header -->
+								<h1 class="email-header">%1$s</h1>
+
+								<!-- Respondent Info -->
+								%10$s
+
+								<!-- Metadata -->
+								%11$s
+
+								<!-- Form Fields -->
+								<div class="form-fields">
+									%2$s
+								</div>
+
+								%3$s
+								%4$s
+
+								<!-- Actions -->
+								<div class="actions">
+									%8$s
+								</div>
+							</td>
 						</tr>
 					</table>
 
 					<!-- START FOOTER -->
 					<div class="footer">
 						<table role="presentation" border="0" cellpadding="0" cellspacing="0">
-						<tr>
-							<td class="content-block wrapper">
-								<!-- footer -->
-								<p>%5$s</p>
-							</td>
-						</tr>
-						%9$s
+							<tr>
+								<td class="content-block wrapper footer-content">
+									<!-- footer -->
+									<p>%5$s</p>
+								</td>
+							</tr>
+							%9$s
 						</table>
 					</div>
 				</div>
@@ -74,12 +91,13 @@ $template = '
 // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- used in class-contact-form.php
 $style = '<style media="all" type="text/css">
 	body {
-		font-family: sans-serif;
+		font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
 		-webkit-font-smoothing: antialiased;
-		font-size: 16px;
-		line-height: 1.3;
+		font-size: 14px;
+		line-height: 1.5;
 		-ms-text-size-adjust: 100%;
 		-webkit-text-size-adjust: 100%;
+		color: #1e1e1e;
 	}
 
 	table {
@@ -90,8 +108,8 @@ $style = '<style media="all" type="text/css">
 	}
 
 	table td {
-		font-family: Helvetica, sans-serif;
-		font-size: 16px;
+		font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+		font-size: 14px;
 		vertical-align: top;
 	}
 
@@ -108,39 +126,316 @@ $style = '<style media="all" type="text/css">
 
 	.container {
 		margin: 0 auto !important;
-		max-width: 640px;
+		max-width: 600px;
 		padding: 0;
 		padding-top: 24px;
-		width: 640px;
-	}
-
-	.powered-by a {
-		text-decoration: none;
+		width: 600px;
 	}
 
 	.content {
 		box-sizing: border-box;
 		display: block;
 		margin: 0 auto;
-		max-width: 640px;
+		max-width: 600px;
 		padding: 0;
 	}
 
 	.main {
-		background: #fff;
+		background: #ffffff;
+		border-radius: 8px;
 		width: 100%;
 	}
 
 	.wrapper {
 		box-sizing: border-box;
-		padding: 24px;
+		padding: 32px;
 	}
 
 	.content-block {
 		box-sizing: border-box;
-		padding: 0 24px 24px;
+		padding: 0 32px 24px;
 	}
 
+	.preheader {
+		color: transparent;
+		display: none;
+		height: 0;
+		max-height: 0;
+		max-width: 0;
+		opacity: 0;
+		overflow: hidden;
+		mso-hide: all;
+		visibility: hidden;
+		width: 0;
+	}
+
+	/* Header */
+	.email-header {
+		font-size: 20px;
+		font-weight: 600;
+		color: #1e1e1e;
+		margin: 0 0 24px 0;
+		padding: 0;
+	}
+
+	/* Respondent Info Section */
+	.respondent-info {
+		display: flex;
+		align-items: center;
+		margin-bottom: 24px;
+		padding-bottom: 20px;
+		border-bottom: 1px solid #e0e0e0;
+	}
+
+	.respondent-avatar {
+		width: 48px;
+		height: 48px;
+		border-radius: 50%;
+		background-color: #f0f0f0;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		font-size: 18px;
+		font-weight: 600;
+		color: #50575e;
+		margin-right: 16px;
+		flex-shrink: 0;
+	}
+
+	.respondent-avatar img {
+		width: 48px;
+		height: 48px;
+		border-radius: 50%;
+	}
+
+	.respondent-details {
+		flex: 1;
+	}
+
+	.respondent-name {
+		font-size: 16px;
+		font-weight: 600;
+		color: #1e1e1e;
+		margin: 0 0 2px 0;
+	}
+
+	.respondent-email {
+		font-size: 14px;
+		color: #50575e;
+		margin: 0;
+	}
+
+	/* Metadata Section */
+	.metadata-section {
+		background-color: #f6f7f7;
+		border-radius: 4px;
+		padding: 16px;
+		margin-bottom: 24px;
+	}
+
+	.metadata-table {
+		width: 100%;
+	}
+
+	.metadata-table td {
+		padding: 4px 0;
+		font-size: 13px;
+		vertical-align: top;
+	}
+
+	.metadata-label {
+		color: #50575e;
+		width: 100px;
+		padding-right: 12px;
+	}
+
+	.metadata-value {
+		color: #1e1e1e;
+	}
+
+	.metadata-value a {
+		color: #3858e9;
+		text-decoration: none;
+	}
+
+	/* Form Fields */
+	.form-fields {
+		margin-top: 8px;
+	}
+
+	.form-field {
+		padding: 16px 0;
+		border-bottom: 1px solid #e0e0e0;
+	}
+
+	.form-field:last-child {
+		border-bottom: none;
+	}
+
+	.field-row {
+		display: flex;
+		align-items: flex-start;
+	}
+
+	.field-icon {
+		width: 20px;
+		height: 20px;
+		margin-right: 12px;
+		flex-shrink: 0;
+		margin-top: 2px;
+	}
+
+	.field-icon svg {
+		width: 20px;
+		height: 20px;
+		fill: #50575e;
+	}
+
+	.field-content {
+		flex: 1;
+		min-width: 0;
+	}
+
+	.field-label {
+		font-size: 12px;
+		color: #50575e;
+		margin: 0 0 4px 0;
+		text-transform: none;
+	}
+
+	.field-value {
+		font-size: 14px;
+		color: #1e1e1e;
+		margin: 0;
+		word-wrap: break-word;
+	}
+
+	.field-value a {
+		color: #3858e9;
+		text-decoration: underline;
+	}
+
+	/* Tag/Chip Styles for Multi-select */
+	.field-tags {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 6px;
+		margin-top: 4px;
+	}
+
+	.field-tag {
+		display: inline-block;
+		background-color: #f0f0f0;
+		border-radius: 12px;
+		padding: 4px 12px;
+		font-size: 13px;
+		color: #1e1e1e;
+	}
+
+	/* Image Select Styles */
+	.image-choices {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 12px;
+		margin-top: 8px;
+	}
+
+	.image-choice {
+		text-align: center;
+	}
+
+	.image-choice img {
+		width: 80px;
+		height: 80px;
+		object-fit: cover;
+		border-radius: 4px;
+		border: 1px solid #e0e0e0;
+	}
+
+	.image-choice-label {
+		font-size: 12px;
+		color: #50575e;
+		margin-top: 4px;
+	}
+
+	/* Rating Styles */
+	.rating-stars {
+		color: #f5c518;
+		font-size: 18px;
+		letter-spacing: 2px;
+	}
+
+	/* File Upload Styles */
+	.file-item {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+		margin-top: 4px;
+	}
+
+	.file-icon {
+		width: 16px;
+		height: 16px;
+		fill: #50575e;
+	}
+
+	.file-name {
+		color: #3858e9;
+		text-decoration: underline;
+	}
+
+	.file-size {
+		color: #50575e;
+		font-size: 12px;
+	}
+
+	/* Consent Chip */
+	.consent-chip {
+		display: inline-block;
+		background-color: #d4edda;
+		color: #155724;
+		border-radius: 12px;
+		padding: 4px 12px;
+		font-size: 13px;
+	}
+
+	.consent-chip.no {
+		background-color: #f8d7da;
+		color: #721c24;
+	}
+
+	/* Actions Section */
+	.actions {
+		margin-top: 24px;
+		text-align: center;
+	}
+
+	.actions-table {
+		width: 100%;
+	}
+
+	.action-button {
+		display: inline-block;
+		padding: 12px 24px;
+		border-radius: 4px;
+		font-size: 14px;
+		font-weight: 500;
+		text-decoration: none;
+		margin: 0 6px;
+	}
+
+	.action-button-primary {
+		background-color: #3858e9;
+		color: #ffffff !important;
+	}
+
+	.action-button-secondary {
+		background-color: transparent;
+		color: #1e1e1e !important;
+		border: 1px solid #1e1e1e;
+	}
+
+	/* Legacy Actions Support */
 	.actions .button_block {
 		mso-table-lspace: 0pt;
 		mso-table-rspace: 0pt;
@@ -157,11 +452,11 @@ $style = '<style media="all" type="text/css">
 	}
 
 	.actions .button_block .pad a {
-		font-size: 16px;
-		font-family: Inter, Helvetica, Arial, sans-serif;
+		font-size: 14px;
+		font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
 		font-weight: 500;
 		text-decoration: none;
-		padding: 13px 24px;
+		padding: 12px 24px;
 		color: #ffffff;
 		border-radius: 4px;
 		display: inline-block;
@@ -177,41 +472,92 @@ $style = '<style media="all" type="text/css">
 		mso-font-width: -100%;
 	}
 
+	/* Footer */
 	.footer {
 		clear: both;
 		padding: 24px 0;
 		width: 100%;
 	}
 
+	.footer-content {
+		text-align: center;
+	}
+
 	.footer td,
 	.footer p,
 	.footer span,
 	.footer a {
-		color: #101517;
+		color: #50575e;
 		font-size: 12px;
+	}
+
+	.powered-by {
+		text-align: center;
+		padding: 16px 0;
+	}
+
+	.powered-by a {
+		color: #50575e;
+		text-decoration: none;
+		font-size: 12px;
+	}
+
+	.powered-by img {
+		vertical-align: middle;
+		margin-right: 4px;
 	}
 
 	h1 {
 		font-size: 20px;
+		font-weight: 600;
 	}
 
 	p {
-		font-family: sans-serif;
-		font-size: 16px;
+		font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+		font-size: 14px;
 		font-weight: normal;
 		margin: 0;
 		margin-bottom: 16px;
 	}
 
+	/* Email client table layout for respondent info */
+	.respondent-table {
+		margin-bottom: 24px;
+		padding-bottom: 20px;
+		border-bottom: 1px solid #e0e0e0;
+	}
+
+	.respondent-avatar-cell {
+		width: 64px;
+		vertical-align: top;
+	}
+
+	.respondent-avatar-wrapper {
+		width: 48px;
+		height: 48px;
+		border-radius: 24px;
+		background-color: #f0f0f0;
+		text-align: center;
+		line-height: 48px;
+		font-size: 18px;
+		font-weight: 600;
+		color: #50575e;
+	}
+
+	.respondent-details-cell {
+		vertical-align: middle;
+	}
+
+	/* Responsive */
 	@media only screen and (max-width: 640px) {
 		.main p,
 		.main td,
 		.main span {
-			font-size: 16px !important;
+			font-size: 14px !important;
 		}
 
 		.wrapper {
-			padding: 8px 16px !important;
+			padding: 16px !important;
 		}
 
 		.content {
@@ -230,12 +576,25 @@ $style = '<style media="all" type="text/css">
 			border-right-width: 0 !important;
 		}
 
-		.collapse { display: none; }
+		.collapse {
+			display: none;
+		}
 
-		h1 { padding:0 16px; }
+		h1 {
+			padding: 0 16px;
+		}
 
 		.powered-by {
-			padding: 0 16px 16px!important;
+			padding: 0 16px 16px !important;
+		}
+
+		.metadata-label {
+			width: 80px !important;
+		}
+
+		.action-button {
+			display: block !important;
+			margin: 8px 0 !important;
 		}
 	}
 

--- a/projects/packages/forms/src/contact-form/templates/email-response.php
+++ b/projects/packages/forms/src/contact-form/templates/email-response.php
@@ -83,8 +83,8 @@ $template = '
 </html>
 ';
 
-// phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- used in class-contact-form.php
 // Minimal CSS for email client fixes only - all styling is inline for maximum compatibility.
+// phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- used in class-contact-form.php
 $style = '<style media="all" type="text/css">
 	/* Email client fixes for Outlook.com and Gmail */
 	.ExternalClass {width: 100%;}

--- a/projects/packages/forms/src/contact-form/templates/email-response.php
+++ b/projects/packages/forms/src/contact-form/templates/email-response.php
@@ -41,9 +41,6 @@ $template = '
 					<table role="presentation" border="0" cellpadding="0" cellspacing="0" class="main">
 						<tr>
 							<td class="wrapper">
-								<!-- Header -->
-								<h1 class="email-header">%1$s</h1>
-
 								<!-- Respondent Info -->
 								%10$s
 

--- a/projects/packages/forms/src/contact-form/templates/email-response.php
+++ b/projects/packages/forms/src/contact-form/templates/email-response.php
@@ -57,6 +57,9 @@ $template = '
 							%3$s
 							%4$s
 
+							<!-- Footer (legacy metadata) -->
+							%5$s
+
 							<!-- Actions -->
 							<table role="presentation" border="0" cellpadding="0" cellspacing="0" width="100%%" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; margin-top: 24px;">
 								<tr>

--- a/projects/packages/forms/src/contact-form/templates/email-response.php
+++ b/projects/packages/forms/src/contact-form/templates/email-response.php
@@ -31,43 +31,48 @@ $template = '
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	%6$s
 </head>
-<body>
-	<table role="presentation" border="0" cellpadding="0" cellspacing="0" class="body">
+<body style="font-family: -apple-system, BlinkMacSystemFont, \'Segoe UI\', Roboto, Oxygen-Sans, Ubuntu, Cantarell, \'Helvetica Neue\', sans-serif; -webkit-font-smoothing: antialiased; font-size: 14px; line-height: 1.5; -ms-text-size-adjust: 100%%; -webkit-text-size-adjust: 100%%; color: #1e1e1e; background-color: #f6f7f7; margin: 0; padding: 0;">
+	<!--[if mso]>
+	<style type="text/css">
+		body, table, td {font-family: Arial, Helvetica, sans-serif !important;}
+	</style>
+	<![endif]-->
+	<span style="display: none; font-size: 1px; color: #f6f7f7; line-height: 1px; mso-hide: all;">%1$s</span>
+	<table role="presentation" border="0" cellpadding="0" cellspacing="0" width="100%%" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; background-color: #f6f7f7;">
 		<tr>
-			<td class="collapse">&nbsp;</td>
-			<td class="container">
-				<div class="content">
-					<span class="preheader">%1$s</span>
-					<table role="presentation" border="0" cellpadding="0" cellspacing="0" class="main">
-						<tr>
-							<td class="wrapper">
-								<!-- Respondent Info -->
-								%10$s
+			<td style="font-family: -apple-system, BlinkMacSystemFont, \'Segoe UI\', Roboto, Oxygen-Sans, Ubuntu, Cantarell, \'Helvetica Neue\', sans-serif; font-size: 14px; vertical-align: top;">&nbsp;</td>
+			<td style="font-family: -apple-system, BlinkMacSystemFont, \'Segoe UI\', Roboto, Oxygen-Sans, Ubuntu, Cantarell, \'Helvetica Neue\', sans-serif; font-size: 14px; vertical-align: top; width: 830px; max-width: 830px; padding: 24px 0 0 0;" width="830">
+				<table role="presentation" border="0" cellpadding="0" cellspacing="0" width="100%%" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; background-color: #ffffff; border-radius: 8px;">
+					<tr>
+						<td style="font-family: -apple-system, BlinkMacSystemFont, \'Segoe UI\', Roboto, Oxygen-Sans, Ubuntu, Cantarell, \'Helvetica Neue\', sans-serif; font-size: 14px; vertical-align: top; padding: 40px 48px;">
+							<!-- Respondent Info -->
+							%10$s
 
-								<!-- Metadata -->
-								%11$s
+							<!-- Metadata -->
+							%11$s
 
-								<!-- Form Fields -->
-								<div class="form-fields">
-									%2$s
-								</div>
+							<!-- Form Fields -->
+							%2$s
 
-								%3$s
-								%4$s
+							%3$s
+							%4$s
 
-								<!-- Actions -->
-								<div class="actions">
-									%8$s
-								</div>
+							<!-- Actions -->
+							<table role="presentation" border="0" cellpadding="0" cellspacing="0" width="100%%" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; margin-top: 24px;">
+								<tr>
+									<td align="center" style="font-family: -apple-system, BlinkMacSystemFont, \'Segoe UI\', Roboto, Oxygen-Sans, Ubuntu, Cantarell, \'Helvetica Neue\', sans-serif; font-size: 14px; vertical-align: top;">
+										%8$s
+									</td>
+								</tr>
+							</table>
 
-								<!-- Powered By -->
-								%9$s
-							</td>
-						</tr>
-					</table>
-				</div>
+							<!-- Powered By -->
+							%9$s
+						</td>
+					</tr>
+				</table>
 			</td>
-			<td class="collapse">&nbsp;</td>
+			<td style="font-family: -apple-system, BlinkMacSystemFont, \'Segoe UI\', Roboto, Oxygen-Sans, Ubuntu, Cantarell, \'Helvetica Neue\', sans-serif; font-size: 14px; vertical-align: top;">&nbsp;</td>
 		</tr>
 	</table>
 	%7$s
@@ -76,545 +81,15 @@ $template = '
 ';
 
 // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- used in class-contact-form.php
+// Minimal CSS for email client fixes only - all styling is inline for maximum compatibility.
 $style = '<style media="all" type="text/css">
-	body {
-		font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
-		-webkit-font-smoothing: antialiased;
-		font-size: 14px;
-		line-height: 1.5;
-		-ms-text-size-adjust: 100%;
-		-webkit-text-size-adjust: 100%;
-		color: #1e1e1e;
-	}
-
-	table {
-		border-collapse: separate;
-		mso-table-lspace: 0pt;
-		mso-table-rspace: 0pt;
-		width: 100%;
-	}
-
-	table td {
-		font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
-		font-size: 14px;
-		vertical-align: top;
-	}
-
-	body {
-		background-color: #f6f7f7;
-		margin: 0;
-		padding: 0;
-	}
-
-	.body {
-		background-color: #f6f7f7;
-		width: 100%;
-	}
-
-	.container {
-		margin: 0 auto !important;
-		max-width: 830px;
-		padding: 0;
-		padding-top: 24px;
-		width: 830px;
-	}
-
-	.content {
-		box-sizing: border-box;
-		display: block;
-		margin: 0 auto;
-		max-width: 830px;
-		padding: 0;
-	}
-
-	.main {
-		background: #ffffff;
-		border-radius: 8px;
-		width: 100%;
-	}
-
-	.wrapper {
-		box-sizing: border-box;
-		padding: 40px 48px;
-	}
-
-	.content-block {
-		box-sizing: border-box;
-		padding: 0 32px 24px;
-	}
-
-	.preheader {
-		color: transparent;
-		display: none;
-		height: 0;
-		max-height: 0;
-		max-width: 0;
-		opacity: 0;
-		overflow: hidden;
-		mso-hide: all;
-		visibility: hidden;
-		width: 0;
-	}
-
-	/* Header */
-	.email-header {
-		font-size: 20px;
-		font-weight: 600;
-		color: #1e1e1e;
-		margin: 0 0 24px 0;
-		padding: 0;
-	}
-
-	/* Respondent Info Section */
-	.respondent-info {
-		display: flex;
-		align-items: center;
-		margin-bottom: 24px;
-		padding-bottom: 20px;
-		border-bottom: 1px solid #e0e0e0;
-	}
-
-	.respondent-avatar {
-		width: 48px;
-		height: 48px;
-		border-radius: 50%;
-		background-color: #f0f0f0;
-		display: flex;
-		align-items: center;
-		justify-content: center;
-		font-size: 18px;
-		font-weight: 600;
-		color: #50575e;
-		margin-right: 16px;
-		flex-shrink: 0;
-	}
-
-	.respondent-avatar img {
-		width: 48px;
-		height: 48px;
-		border-radius: 50%;
-	}
-
-	.respondent-details {
-		flex: 1;
-	}
-
-	.respondent-name {
-		font-size: 16px;
-		font-weight: 600;
-		color: #1e1e1e;
-		margin: 0 0 2px 0;
-	}
-
-	.respondent-email {
-		font-size: 14px;
-		color: #50575e;
-		margin: 0;
-	}
-
-	/* Metadata Section */
-	.metadata-section {
-		background-color: #f6f7f7;
-		border-radius: 4px;
-		padding: 16px;
-		margin-bottom: 24px;
-	}
-
-	.metadata-table {
-		width: 100%;
-		padding-bottom: 20px;
-		border-bottom: 1px solid #e0e0e0;
-	}
-
-	.metadata-table td {
-		padding: 4px 0;
-		font-size: 13px;
-		vertical-align: top;
-	}
-
-	.metadata-label {
-		color: #50575e;
-		width: 100px;
-		padding-right: 12px;
-	}
-
-	.metadata-value {
-		color: #1e1e1e;
-	}
-
-	.metadata-value a {
-		color: #3858e9;
-		text-decoration: none;
-	}
-
-	/* Form Fields */
-	.form-fields {
-		margin-top: 8px;
-	}
-
-	.form-field {
-		padding: 16px 0;
-		border-bottom: 1px solid #e0e0e0;
-	}
-
-	.form-field:last-child {
-		border-bottom: none;
-	}
-
-	.field-row {
-		display: flex;
-		align-items: flex-start;
-	}
-
-	.field-icon {
-		width: 20px;
-		height: 20px;
-		margin-right: 12px;
-		flex-shrink: 0;
-		margin-top: 2px;
-	}
-
-	.field-icon svg {
-		width: 20px;
-		height: 20px;
-		fill: #50575e;
-	}
-
-	.field-content {
-		flex: 1;
-		min-width: 0;
-	}
-
-	.field-label {
-		font-size: 12px;
-		color: #50575e;
-		margin: 0 0 4px 0;
-		text-transform: none;
-	}
-
-	.field-value {
-		font-size: 14px;
-		color: #1e1e1e;
-		margin: 0;
-		word-wrap: break-word;
-	}
-
-	.field-value a {
-		color: #3858e9;
-		text-decoration: underline;
-	}
-
-	/* Tag/Chip Styles for Multi-select */
-	.field-tags {
-		display: flex;
-		flex-wrap: wrap;
-		gap: 6px;
-		margin-top: 4px;
-	}
-
-	.field-tag {
-		display: inline-block;
-		background-color: #f0f0f0;
-		border-radius: 12px;
-		padding: 4px 12px;
-		font-size: 13px;
-		color: #1e1e1e;
-	}
-
-	/* Image Select Styles */
-	.image-choices {
-		display: flex;
-		flex-wrap: wrap;
-		gap: 12px;
-		margin-top: 8px;
-	}
-
-	.image-choice {
-		text-align: center;
-	}
-
-	.image-choice img {
-		width: 80px;
-		height: 80px;
-		object-fit: cover;
-		border-radius: 4px;
-		border: 1px solid #e0e0e0;
-	}
-
-	.image-choice-label {
-		font-size: 12px;
-		color: #50575e;
-		margin-top: 4px;
-	}
-
-	/* Rating Styles */
-	.rating-stars {
-		color: #f5c518;
-		font-size: 18px;
-		letter-spacing: 2px;
-	}
-
-	/* File Upload Styles */
-	.file-item {
-		display: flex;
-		align-items: center;
-		gap: 8px;
-		margin-top: 4px;
-	}
-
-	.file-icon {
-		width: 16px;
-		height: 16px;
-		fill: #50575e;
-	}
-
-	.file-name {
-		color: #3858e9;
-		text-decoration: underline;
-	}
-
-	.file-size {
-		color: #50575e;
-		font-size: 12px;
-	}
-
-	/* Consent Chip */
-	.consent-chip {
-		display: inline-block;
-		background-color: #d4edda;
-		color: #155724;
-		border-radius: 12px;
-		padding: 4px 12px;
-		font-size: 13px;
-	}
-
-	.consent-chip.no {
-		background-color: #f8d7da;
-		color: #721c24;
-	}
-
-	/* Actions Section */
-	.actions {
-		margin-top: 24px;
-		text-align: center;
-	}
-
-	.actions-table {
-		width: 100%;
-	}
-
-	.action-button {
-		display: inline-block;
-		padding: 12px 24px;
-		border-radius: 4px;
-		font-size: 14px;
-		font-weight: 500;
-		text-decoration: none;
-		margin: 0 6px;
-	}
-
-	.action-button-primary {
-		background-color: #3858e9;
-		color: #ffffff !important;
-	}
-
-	.action-button-secondary {
-		background-color: transparent;
-		color: #1e1e1e !important;
-		border: 1px solid #1e1e1e;
-	}
-
-	/* Legacy Actions Support */
-	.actions .button_block {
-		mso-table-lspace: 0pt;
-		mso-table-rspace: 0pt;
-		width: unset;
-		margin-top: 24px;
-	}
-
-	.actions .button_block .pad,
-	.actions .button_block .pad a {
-		border-radius: 4px;
-		background-image: url(\'https://s0.wordpress.com/i/emails/marketing/wpcom/2024/blueberry-px.png\');
-		background-size: cover;
-		background-color: #3858E9;
-	}
-
-	.actions .button_block .pad a {
-		font-size: 14px;
-		font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
-		font-weight: 500;
-		text-decoration: none;
-		padding: 12px 24px;
-		color: #ffffff;
-		border-radius: 4px;
-		display: inline-block;
-		mso-padding-alt: 0;
-	}
-
-	.actions .button_block .pad a span {
-		mso-text-raise: 15pt;
-	}
-
-	.actions .button_block .pad i {
-		letter-spacing: 25px;
-		mso-font-width: -100%;
-	}
-
-	/* Footer */
-	.footer {
-		clear: both;
-		padding: 24px 0;
-		width: 100%;
-	}
-
-	.footer-content {
-		text-align: center;
-	}
-
-	.footer td,
-	.footer p,
-	.footer span,
-	.footer a {
-		color: #50575e;
-		font-size: 12px;
-	}
-
-	.powered-by {
-		text-align: center;
-		padding: 16px 0;
-	}
-
-	.powered-by a {
-		color: #50575e;
-		text-decoration: none;
-		font-size: 12px;
-	}
-
-	.powered-by img {
-		vertical-align: middle;
-		margin-right: 4px;
-	}
-
-	h1 {
-		font-size: 20px;
-		font-weight: 600;
-	}
-
-	p {
-		font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
-		font-size: 14px;
-		font-weight: normal;
-		margin: 0;
-		margin-bottom: 16px;
-	}
-
-	/* Email client table layout for respondent info */
-	.respondent-table {
-		margin-bottom: 16px;
-	}
-
-	.respondent-avatar-cell {
-		width: 64px;
-		vertical-align: top;
-	}
-
-	.respondent-avatar-wrapper {
-		width: 48px;
-		height: 48px;
-		border-radius: 24px;
-		background-color: #f0f0f0;
-		text-align: center;
-		line-height: 48px;
-		font-size: 18px;
-		font-weight: 600;
-		color: #50575e;
-	}
-
-	.respondent-details-cell {
-		vertical-align: middle;
-	}
-
-	/* Responsive */
-	@media only screen and (max-width: 640px) {
-		.main p,
-		.main td,
-		.main span {
-			font-size: 14px !important;
-		}
-
-		.wrapper {
-			padding: 16px !important;
-		}
-
-		.content {
-			padding: 0 !important;
-		}
-
-		.container {
-			padding: 0 !important;
-			padding-top: 8px !important;
-			width: 100% !important;
-		}
-
-		.main {
-			border-left-width: 0 !important;
-			border-radius: 0 !important;
-			border-right-width: 0 !important;
-		}
-
-		.collapse {
-			display: none;
-		}
-
-		h1 {
-			padding: 0 16px;
-		}
-
-		.powered-by {
-			padding: 0 16px 16px !important;
-		}
-
-		.metadata-label {
-			width: 80px !important;
-		}
-
-		.action-button {
-			display: block !important;
-			margin: 8px 0 !important;
-		}
-	}
-
-	@media all {
-		.ExternalClass {
-			width: 100%;
-		}
-
-		.ExternalClass,
-		.ExternalClass p,
-		.ExternalClass span,
-		.ExternalClass font,
-		.ExternalClass td,
-		.ExternalClass div {
-			line-height: 100%;
-		}
-
-		.apple-link a {
-			color: inherit !important;
-			font-family: inherit !important;
-			font-size: inherit !important;
-			font-weight: inherit !important;
-			line-height: inherit !important;
-			text-decoration: none !important;
-		}
-
-		#MessageViewBody a {
-			color: inherit;
-			text-decoration: none;
-			font-size: inherit;
-			font-family: inherit;
-			font-weight: inherit;
-			line-height: inherit;
-		}
-	}
+	/* Email client fixes for Outlook.com and Gmail */
+	.ExternalClass {width: 100%;}
+	.ExternalClass, .ExternalClass p, .ExternalClass span, .ExternalClass font, .ExternalClass td, .ExternalClass div {line-height: 100%;}
+	/* iOS link color fix */
+	a[x-apple-data-detectors] {color: inherit !important; text-decoration: none !important; font-size: inherit !important; font-family: inherit !important; font-weight: inherit !important; line-height: inherit !important;}
+	/* Gmail link color fix */
+	u + #body a {color: inherit; text-decoration: none; font-size: inherit; font-family: inherit; font-weight: inherit; line-height: inherit;}
+	/* Samsung Mail link color fix */
+	#MessageViewBody a {color: inherit; text-decoration: none; font-size: inherit; font-family: inherit; font-weight: inherit; line-height: inherit;}
 </style>';

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
@@ -429,7 +429,7 @@ class Contact_Form_Test extends BaseTestCase {
 		$result = Contact_Form::escape_and_sanitize_field_value( $file_upload_value );
 		$this->assertStringContainsString( 'test-document.pdf', $result );
 		$this->assertStringContainsString( 'another-document.docx', $result );
-		$this->assertStringContainsString( '<span class="jetpack-forms-file-size">', $result );
+		$this->assertStringContainsString( '<span style="color: #757575;">', $result );
 		$this->assertStringContainsString( '(1 KB)', $result );
 		$this->assertStringContainsString( '(2 KB)', $result );
 
@@ -722,12 +722,16 @@ class Contact_Form_Test extends BaseTestCase {
 
 		$email = get_post_meta( $submission->ID, '_feedback_email', true );
 
-		$expected  = '<p><strong>Name:</strong><br /><span>John Doe</span></p>';
-		$expected .= '<p><strong>Dropdown:</strong><br /><span>First option</span></p>';
-		$expected .= '<p><strong>Radio:</strong><br /><span>Second option</span></p>';
-		$expected .= '<p><strong>Text:</strong><br /><span>Texty text</span></p>';
-
-		$this->assertStringContainsString( $expected, $email['message'] );
+		// Check that field labels and values are present in the email (using new table-based format).
+		// Labels don't have colons in the new format - they're in separate styled divs.
+		$this->assertStringContainsString( '>Name<', $email['message'] );
+		$this->assertStringContainsString( 'John Doe', $email['message'] );
+		$this->assertStringContainsString( '>Dropdown<', $email['message'] );
+		$this->assertStringContainsString( 'First option', $email['message'] );
+		$this->assertStringContainsString( '>Radio<', $email['message'] );
+		$this->assertStringContainsString( 'Second option', $email['message'] );
+		$this->assertStringContainsString( '>Text<', $email['message'] );
+		$this->assertStringContainsString( 'Texty text', $email['message'] );
 	}
 
 	/**
@@ -771,12 +775,16 @@ class Contact_Form_Test extends BaseTestCase {
 		$this->assertContains( 'john <john@example.com>', $args['to'] );
 		$this->assertEquals( 'Hello there!', $args['subject'] );
 
-		$expected  = '<p><strong>Name:</strong><br /><span>John Doe</span></p>';
-		$expected .= '<p><strong>Dropdown:</strong><br /><span>First option</span></p>';
-		$expected .= '<p><strong>Radio:</strong><br /><span>Second option</span></p>';
-		$expected .= '<p><strong>Text:</strong><br /><span>Texty text</span></p>';
-
-		$this->assertStringContainsString( $expected, $args['message'] );
+		// Check that field labels and values are present in the email (using new table-based format).
+		// Labels don't have colons in the new format - they're in separate styled divs.
+		$this->assertStringContainsString( '>Name<', $args['message'] );
+		$this->assertStringContainsString( 'John Doe', $args['message'] );
+		$this->assertStringContainsString( '>Dropdown<', $args['message'] );
+		$this->assertStringContainsString( 'First option', $args['message'] );
+		$this->assertStringContainsString( '>Radio<', $args['message'] );
+		$this->assertStringContainsString( 'Second option', $args['message'] );
+		$this->assertStringContainsString( '>Text<', $args['message'] );
+		$this->assertStringContainsString( 'Texty text', $args['message'] );
 	}
 
 	/**

--- a/projects/plugins/jetpack/changelog/add-forms-email-template
+++ b/projects/plugins/jetpack/changelog/add-forms-email-template
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Form Notifications: Add new HTML email template design with respondent info header, metadata section, and improved action buttons.


### PR DESCRIPTION
Fixes #

## Proposed changes:

* Add new HTML email template structure for form submission notifications
* Add respondent info section with avatar (initials fallback), name, and email
* Add metadata section displaying Date, Source (form title), Device, and IP address with country flag
* Update email header to "Hey, a new form response just came in!"
* Update action buttons with "Mark as spam" (secondary) and "View in dashboard" (primary) side by side
* Add helper methods: `generate_respondent_info_html()`, `generate_metadata_html()`, `generate_metadata_row()`
* Update `wrap_message_in_html_tags()` to accept optional respondent_info and metadata arrays
* Add comprehensive inline CSS for email client compatibility
* Maintain backward compatibility with existing filters and hooks

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

* Set up a Jetpack site with a contact form
* Configure the form to send email notifications
* Submit the form as a visitor
* Check the notification email received by the form owner
* Verify the email displays:
  - Header: "Hey, a new form response just came in!"
  - Respondent info section with avatar circle (showing initials), name, and email
  - Metadata section with Date, Source, Device, and IP address (with country flag if available)
  - Form field values
  - Two action buttons: "Mark as spam" and "View in dashboard"
  - "Powered by Jetpack Forms" footer
* Test on multiple email clients (Gmail, Outlook, Apple Mail) to verify styling