### PR TITLE
test-results-to-slack: Convert to ESM

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -93,11 +93,11 @@ importers:
   projects/github-actions/test-results-to-slack:
     dependencies:
       '@actions/core':
-        specifier: 2.0.2
-        version: 2.0.2
+        specifier: 3.0.0
+        version: 3.0.0
       '@actions/github':
-        specifier: 7.0.0
-        version: 7.0.0
+        specifier: 9.0.0
+        version: 9.0.0
       '@slack/web-api':
         specifier: 7.12.0
         version: 7.12.0

--- a/projects/github-actions/required-review/changelog/update-github-actions-test-results-to-slack-to-esm
+++ b/projects/github-actions/required-review/changelog/update-github-actions-test-results-to-slack-to-esm
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix eslint configuration.
+
+

--- a/projects/github-actions/required-review/eslint.config.mjs
+++ b/projects/github-actions/required-review/eslint.config.mjs
@@ -1,3 +1,3 @@
 import { makeBaseConfig } from 'jetpack-js-tools/eslintrc/base.mjs';
 
-export default makeBaseConfig( import.meta.url, { envs: [ 'node', 'commonjs' ] } );
+export default makeBaseConfig( import.meta.url, { envs: [ 'node' ] } );

--- a/projects/github-actions/test-results-to-slack/changelog/update-github-actions-test-results-to-slack-to-esm
+++ b/projects/github-actions/test-results-to-slack/changelog/update-github-actions-test-results-to-slack-to-esm
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Convert to ESM. This should not affect the operation of the action.

--- a/projects/github-actions/test-results-to-slack/eslint.config.mjs
+++ b/projects/github-actions/test-results-to-slack/eslint.config.mjs
@@ -1,3 +1,3 @@
 import { makeBaseConfig } from 'jetpack-js-tools/eslintrc/base.mjs';
 
-export default makeBaseConfig( import.meta.url, { envs: [ 'node', 'commonjs' ] } );
+export default makeBaseConfig( import.meta.url, { envs: [ 'node' ] } );

--- a/projects/github-actions/test-results-to-slack/package.json
+++ b/projects/github-actions/test-results-to-slack/package.json
@@ -11,15 +11,16 @@
 	],
 	"license": "GPL-2.0-or-later",
 	"author": "Automattic",
+	"type": "module",
 	"main": "src/index.js",
 	"scripts": {
 		"build": "ncc build src/index.js -o dist --source-map --license licenses.txt",
-		"test": "jest --config=tests/jest.config.js --verbose --runInBand",
+		"test": "NODE_OPTIONS=--experimental-vm-modules jest --config=tests/jest.config.js --verbose --runInBand",
 		"test-coverage": "pnpm run test --coverage"
 	},
 	"dependencies": {
-		"@actions/core": "2.0.2",
-		"@actions/github": "7.0.0",
+		"@actions/core": "3.0.0",
+		"@actions/github": "9.0.0",
 		"@slack/web-api": "7.12.0",
 		"glob": "13.0.0",
 		"minimatch": "5.1.6"

--- a/projects/github-actions/test-results-to-slack/src/debug.js
+++ b/projects/github-actions/test-results-to-slack/src/debug.js
@@ -3,7 +3,7 @@
  *
  * @param {string} message - The message to print.
  */
-function debug( message ) {
+export function debug( message ) {
 	if ( process.env.NODE_ENV !== 'test' ) {
 		process.stdout.write( message + '\n' );
 	}
@@ -14,8 +14,6 @@ function debug( message ) {
  *
  * @param {string} message - The message to print.
  */
-function error( message ) {
+export function error( message ) {
 	process.stdout.write( message + '\n' );
 }
-
-module.exports = { debug, error };

--- a/projects/github-actions/test-results-to-slack/src/extra-context.js
+++ b/projects/github-actions/test-results-to-slack/src/extra-context.js
@@ -6,4 +6,4 @@ const extras = {
 	triggeringActor: process.env.GITHUB_TRIGGERING_ACTOR,
 };
 
-module.exports = extras;
+export default extras;

--- a/projects/github-actions/test-results-to-slack/src/github.js
+++ b/projects/github-actions/test-results-to-slack/src/github.js
@@ -1,5 +1,5 @@
-const github = require( '@actions/github' );
-const extras = require( './extra-context' );
+import * as github from '@actions/github';
+import extras from './extra-context.js';
 
 /**
  * Decides if the current workflow failed
@@ -7,7 +7,7 @@ const extras = require( './extra-context' );
  * @param {string} token - GitHub token
  * @return {boolean} Whether it failed.
  */
-async function isWorkflowFailed( token ) {
+export async function isWorkflowFailed( token ) {
 	// eslint-disable-next-line new-cap
 	const octokit = new github.getOctokit( token );
 
@@ -39,12 +39,10 @@ async function isWorkflowFailed( token ) {
  * @param {boolean} withAttempt - whether to include the run attempt in the url
  * @return {string} the run url
  */
-function getRunUrl( withAttempt = true ) {
+export function getRunUrl( withAttempt = true ) {
 	const { serverUrl, runId } = github.context;
 	const { repository, runAttempt } = extras;
 	return `${ serverUrl }/${ repository }/actions/runs/${ runId }/${
 		withAttempt ? `attempts/${ runAttempt }` : ''
 	}`;
 }
-
-module.exports = { isWorkflowFailed, getRunUrl };

--- a/projects/github-actions/test-results-to-slack/src/index.js
+++ b/projects/github-actions/test-results-to-slack/src/index.js
@@ -1,6 +1,6 @@
-const { setFailed, getInput, startGroup, endGroup } = require( '@actions/core' );
-const { sendMessage } = require( './message' );
-const { getChannels } = require( './rules' );
+import { setFailed, getInput, startGroup, endGroup } from '@actions/core';
+import { sendMessage } from './message.js';
+import { getChannels } from './rules.js';
 
 ( async function main() {
 	startGroup( 'Send results to Slack' );

--- a/projects/github-actions/test-results-to-slack/src/message.js
+++ b/projects/github-actions/test-results-to-slack/src/message.js
@@ -1,11 +1,11 @@
-const { getInput } = require( '@actions/core' );
-const github = require( '@actions/github' );
-const { WebClient } = require( '@slack/web-api' );
-const { debug } = require( './debug' );
-const extras = require( './extra-context' );
-const { isWorkflowFailed, getRunUrl } = require( './github' );
-const { getPlaywrightBlocks } = require( './playwright' );
-const { getMessage, postOrUpdateMessage } = require( './slack' );
+import { getInput } from '@actions/core';
+import * as github from '@actions/github';
+import { WebClient } from '@slack/web-api';
+import { debug } from './debug.js';
+import extras from './extra-context.js';
+import { isWorkflowFailed, getRunUrl } from './github.js';
+import { getPlaywrightBlocks } from './playwright.js';
+import { getMessage, postOrUpdateMessage } from './slack.js';
 const {
 	context: { eventName, sha, payload, runId, actor, serverUrl },
 } = github;
@@ -19,7 +19,7 @@ const { refType, refName, runAttempt, triggeringActor, repository } = extras;
  * @param {boolean} isFailure - whether the workflow is failed or not
  * @return {object} Notificaton data as described
  */
-async function createMessage( isFailure ) {
+export async function createMessage( isFailure ) {
 	let target = `for ${ sha }`;
 	let msgId;
 	const contextElements = [];
@@ -179,7 +179,7 @@ function getButton( text, url ) {
  * @param {string} channel    - the id of the channel to send the message to
  * @param {string} username   - the username to use when sending the message
  */
-async function sendMessage( slackToken, ghToken, channel, username ) {
+export async function sendMessage( slackToken, ghToken, channel, username ) {
 	const client = new WebClient( slackToken );
 	const isFailure = await isWorkflowFailed( ghToken );
 	const { text, id, mainMsgBlocks, detailsMsgBlocksChunks } = await createMessage( isFailure );
@@ -241,5 +241,3 @@ async function sendMessage( slackToken, ghToken, channel, username ) {
 		}
 	}
 }
-
-module.exports = { sendMessage, createMessage };

--- a/projects/github-actions/test-results-to-slack/src/playwright.js
+++ b/projects/github-actions/test-results-to-slack/src/playwright.js
@@ -1,14 +1,14 @@
-const fs = require( 'fs' );
-const { getInput } = require( '@actions/core' );
-const { glob } = require( 'glob' );
-const { debug } = require( './debug' );
+import fs from 'fs';
+import { getInput } from '@actions/core';
+import { glob } from 'glob';
+import { debug } from './debug.js';
 
 /**
  * Parses multiple Playwright JSON reports and returns details about the failed tests.
  *
  * @return {object} an array of Slack blocks with test failure details.
  */
-function getPlaywrightBlocks() {
+export function getPlaywrightBlocks() {
 	const blocks = [];
 	const { reports, parseError } = getPlaywrightReports();
 	const failedTests = [];
@@ -150,7 +150,7 @@ function getPlaywrightReportsPaths() {
  * @param {string} attachmentPath - the original path to the attachment, as defined in the Playwright report
  * @return {string} the final path to the attachment
  */
-function getAttachmentPath( outputPath, attachmentPath ) {
+export function getAttachmentPath( outputPath, attachmentPath ) {
 	const resultsPath = getInput( 'playwright_output_dir' );
 
 	if ( resultsPath ) {
@@ -188,5 +188,3 @@ function flattenSuites( suites ) {
 		return all;
 	}, [] );
 }
-
-module.exports = { getPlaywrightBlocks, getAttachmentPath };

--- a/projects/github-actions/test-results-to-slack/src/rules.js
+++ b/projects/github-actions/test-results-to-slack/src/rules.js
@@ -1,14 +1,14 @@
-const fs = require( 'fs' );
-const { getInput } = require( '@actions/core' );
-const minimatch = require( 'minimatch' );
-const { debug } = require( './debug' );
-const extras = require( './extra-context' );
+import fs from 'fs';
+import { getInput } from '@actions/core';
+import minimatch from 'minimatch';
+import { debug } from './debug.js';
+import extras from './extra-context.js';
 /**
  * Returns a list o Slack channel ids, based on context and rules configuration.
  *
  * @return {string[]} an array of channels ids
  */
-function getChannels() {
+export function getChannels() {
 	const channels = [];
 	const defaultChannel = getInput( 'slack_channel' );
 	const rulesConfigurationPath = getInput( 'rules_configuration_path' );
@@ -59,5 +59,3 @@ function getChannels() {
 	debug( `Found ${ uniqueChannels.length } channels` );
 	return uniqueChannels;
 }
-
-module.exports = { getChannels };

--- a/projects/github-actions/test-results-to-slack/src/slack.js
+++ b/projects/github-actions/test-results-to-slack/src/slack.js
@@ -1,6 +1,6 @@
-const fs = require( 'fs' );
-const path = require( 'path' );
-const { debug, error } = require( './debug' );
+import fs from 'fs';
+import path from 'path';
+import { debug, error } from './debug.js';
 
 /**
  * Sends a Slack message.
@@ -10,7 +10,7 @@ const { debug, error } = require( './debug' );
  * @param {object}  options - options
  * @return {Promise<*>} the response from the Slack API. In case when multiple messages are sent due to the blocks length the last message response is returned.
  */
-async function postOrUpdateMessage( client, update, options ) {
+export async function postOrUpdateMessage( client, update, options ) {
 	const { text, blocks = [], channel, username, icon_emoji, ts, thread_ts } = options;
 
 	const method = update ? 'update' : 'postMessage';
@@ -115,7 +115,7 @@ function getBlocksChunksByType( blocks, type ) {
  * @param {string}   typeDelimiter - the type property to use as delimiter
  * @return {[object]} the array of chunks
  */
-function getBlocksChunks( blocks, maxSize, typeDelimiter ) {
+export function getBlocksChunks( blocks, maxSize, typeDelimiter ) {
 	const chunksByType = getBlocksChunksByType( blocks, typeDelimiter );
 	const chunks = [];
 
@@ -136,7 +136,7 @@ function getBlocksChunks( blocks, maxSize, typeDelimiter ) {
  * @param {string} identifier - the string to search for in the messages text
  * @return {Promise<*|null>} the message Object
  */
-async function getMessage( client, channelId, identifier ) {
+export async function getMessage( client, channelId, identifier ) {
 	debug( `Looking for ${ identifier }` );
 	let message;
 	// Get the messages in the channel. It only returns parent messages in case of threads.
@@ -157,9 +157,3 @@ async function getMessage( client, channelId, identifier ) {
 
 	return message;
 }
-
-module.exports = {
-	getMessage,
-	postOrUpdateMessage,
-	getBlocksChunks,
-};

--- a/projects/github-actions/test-results-to-slack/tests/extra-context.test.js
+++ b/projects/github-actions/test-results-to-slack/tests/extra-context.test.js
@@ -1,4 +1,4 @@
-const { mockContextExtras } = require( './test-utils' );
+import { mockContextExtras } from './test-utils.js';
 
 describe( 'Extra context', () => {
 	const runAttempt = '3';
@@ -10,7 +10,7 @@ describe( 'Extra context', () => {
 	mockContextExtras( { repository, refType, refName, triggeringActor, runAttempt } );
 
 	test( 'Environment variables are exposed in extra context', async () => {
-		const extras = require( '../src/extra-context' );
+		const { default: extras } = await import( '../src/extra-context.js' );
 
 		expect( extras.runAttempt ).toBe( runAttempt );
 		expect( extras.refType ).toBe( refType );

--- a/projects/github-actions/test-results-to-slack/tests/github.test.js
+++ b/projects/github-actions/test-results-to-slack/tests/github.test.js
@@ -1,5 +1,5 @@
-const { MockAgent, setGlobalDispatcher } = require( 'undici' );
-const { mockContextExtras } = require( './test-utils' );
+import { MockAgent, setGlobalDispatcher } from 'undici';
+import { mockGitHubContext, mockContextExtras } from './test-utils.js';
 
 describe( 'Workflow conclusion', () => {
 	test.each`
@@ -10,12 +10,11 @@ describe( 'Workflow conclusion', () => {
 		${ false } | ${ 'Workflow is successful for skipped jobs' }                | ${ [ { status: 'completed', conclusion: 'skipped' }, { status: 'completed', conclusion: 'success' } ] }
 		${ true }  | ${ 'Workflow is failed for one failed job' }                  | ${ [ { status: 'completed', conclusion: 'success' }, { status: 'completed', conclusion: 'failed' } ] }
 	`( '$description', async ( { expected, jobs } ) => {
-		const { mockGitHubContext } = require( './test-utils' );
 		const runId = '12345';
 		const repository = 'foo/bar';
 
 		// Mock GitHub context
-		mockGitHubContext( { runId } );
+		await mockGitHubContext( { runId } );
 		mockContextExtras( { repository } );
 
 		// Intercept request to GitHub Api and mock response
@@ -26,7 +25,7 @@ describe( 'Workflow conclusion', () => {
 			.intercept( { path: `/repos/${ repository }/actions/runs/${ runId }/jobs` } )
 			.reply( 200, { jobs }, { headers: { 'content-type': 'application/json' } } );
 
-		const { isWorkflowFailed } = require( '../src/github' );
+		const { isWorkflowFailed } = await import( '../src/github.js' );
 		const conclusion = await isWorkflowFailed( 'token' );
 		await expect( conclusion ).toBe( expected );
 	} );

--- a/projects/github-actions/test-results-to-slack/tests/jest.config.js
+++ b/projects/github-actions/test-results-to-slack/tests/jest.config.js
@@ -1,11 +1,11 @@
-const path = require( 'path' );
-const coverageConfig = require( 'jetpack-js-tools/jest/config.coverage.js' );
+import { fileURLToPath } from 'url';
+import coverageConfig from 'jetpack-js-tools/jest/config.coverage.js';
 
-module.exports = {
+export default {
 	...coverageConfig,
-	rootDir: path.resolve( __dirname, '..' ),
+	rootDir: fileURLToPath( new URL( '..', import.meta.url ) ),
 	roots: [ '<rootDir>/src/', '<rootDir>/tests/' ],
-	resolver: require.resolve( 'jetpack-js-tools/jest/jest-resolver.js' ),
+	resolver: fileURLToPath( import.meta.resolve( 'jetpack-js-tools/jest/jest-resolver.js' ) ),
 	clearMocks: true,
 	resetModules: true,
 };

--- a/projects/github-actions/test-results-to-slack/tests/message.test.js
+++ b/projects/github-actions/test-results-to-slack/tests/message.test.js
@@ -1,4 +1,5 @@
-const { mockContextExtras, setInputData } = require( './test-utils' );
+import { jest } from '@jest/globals';
+import { mockContextExtras, mockGitHubContext, setInputData } from './test-utils.js';
 
 describe( 'Message content', () => {
 	const repository = 'foo/bar';
@@ -28,12 +29,10 @@ describe( 'Message content', () => {
 	`(
 		`Message text is correct for $eventName and workflow failed=$isFailure and suiteName=$suiteName`,
 		async ( { eventName, isFailure, suiteName, expected } ) => {
-			const { mockGitHubContext } = require( './test-utils' );
-
 			setInputData( { suiteName } );
 
 			// Mock GitHub context
-			mockGitHubContext( {
+			await mockGitHubContext( {
 				payload: {
 					head_commit: { id: '123', message: 'Some commit message' },
 					pull_request: { number: prNumber },
@@ -45,7 +44,7 @@ describe( 'Message content', () => {
 			} );
 			mockContextExtras( { repository, refType, refName } );
 
-			const { createMessage } = require( '../src/message' );
+			const { createMessage } = await import( '../src/message.js' );
 			const { text, mainMsgBlocks } = await createMessage( isFailure );
 
 			expect( text ).toBe( expected.text );
@@ -60,17 +59,15 @@ describe( 'Message content', () => {
 	`(
 		`First main message context line is correct for push`,
 		async ( { commitId, commitMsg, expected } ) => {
-			const { mockGitHubContext } = require( './test-utils' );
-
 			// Mock GitHub context
-			mockGitHubContext( {
+			await mockGitHubContext( {
 				payload: {
 					head_commit: { id: commitId, message: commitMsg },
 				},
 				eventName: 'push',
 			} );
 
-			const { createMessage } = require( '../src/message' );
+			const { createMessage } = await import( '../src/message.js' );
 			const { mainMsgBlocks } = await createMessage( true );
 
 			expect( mainMsgBlocks[ 1 ].elements[ 0 ].text ).toBe( expected.text );
@@ -79,10 +76,9 @@ describe( 'Message content', () => {
 
 	test( `First main message context line is correct for pull_request`, async () => {
 		const title = 'Pull request title';
-		const { mockGitHubContext } = require( './test-utils' );
 
 		// Mock GitHub context
-		mockGitHubContext( {
+		await mockGitHubContext( {
 			payload: {
 				head_commit: { message: 'Some commit message' },
 				pull_request: { title },
@@ -90,17 +86,15 @@ describe( 'Message content', () => {
 			eventName: 'pull_request',
 		} );
 
-		const { createMessage } = require( '../src/message' );
+		const { createMessage } = await import( '../src/message.js' );
 		const { mainMsgBlocks } = await createMessage( true );
 
 		expect( mainMsgBlocks[ 1 ].elements[ 0 ].text ).toBe( `Title: ${ title }` );
 	} );
 
 	test( `First main message context line is correct for schedule`, async () => {
-		const { mockGitHubContext } = require( './test-utils' );
-
 		// Mock GitHub context
-		mockGitHubContext( {
+		await mockGitHubContext( {
 			payload: {
 				head_commit: { message: 'Some commit message' },
 			},
@@ -108,7 +102,7 @@ describe( 'Message content', () => {
 			sha: '5dc6ab9d13d9b79317b719a32a60cc682cd6930d',
 		} );
 
-		const { createMessage } = require( '../src/message' );
+		const { createMessage } = await import( '../src/message.js' );
 		const { mainMsgBlocks } = await createMessage( true );
 
 		expect( mainMsgBlocks[ 1 ].elements[ 0 ].text ).toBe( `Last commit: 5dc6ab9d` );
@@ -123,10 +117,8 @@ describe( 'Message content', () => {
 		${ 'repository_dispatch' }
 		${ 'unsupported' }
 	`( 'There are no empty blocks elements lists for $eventName event', async ( { eventName } ) => {
-		const { mockGitHubContext } = require( './test-utils' );
-
 		// Mock GitHub context
-		mockGitHubContext( {
+		await mockGitHubContext( {
 			payload: {
 				head_commit: { id: '123', message: 'Some commit message' },
 				pull_request: { number: prNumber },
@@ -138,7 +130,7 @@ describe( 'Message content', () => {
 		} );
 		mockContextExtras( { repository, refType, refName } );
 
-		const { createMessage } = require( '../src/message' );
+		const { createMessage } = await import( '../src/message.js' );
 		const { mainMsgBlocks } = await createMessage( true );
 
 		expect( mainMsgBlocks[ 1 ].type ).toBe( 'context' );
@@ -155,10 +147,8 @@ describe( 'Message content', () => {
 	`(
 		`Repository dispatch blocks for #description`,
 		async ( { clientPayload, expectedContextLength, expectedButtonsLength } ) => {
-			const { mockGitHubContext } = require( './test-utils' );
-
 			// Mock GitHub context
-			mockGitHubContext( {
+			await mockGitHubContext( {
 				payload: {
 					action: 'some action',
 					client_payload: clientPayload,
@@ -166,7 +156,7 @@ describe( 'Message content', () => {
 				eventName: 'repository_dispatch',
 			} );
 
-			const { createMessage } = require( '../src/message' );
+			const { createMessage } = await import( '../src/message.js' );
 			const { mainMsgBlocks } = await createMessage( true );
 
 			expect( mainMsgBlocks[ 1 ].elements ).toHaveLength( expectedContextLength );
@@ -183,27 +173,29 @@ describe( 'Send message', () => {
 		${ 'Should create main message and send reply on failure' }    | ${ false }        | ${ true }  | ${ [ { update: false }, { update: false } ] }
 		${ 'Should not send anything on success and no main message' } | ${ false }        | ${ false } | ${ [] }
 	`( `$description`, async ( { isFailure, mainMessageExists, expectedCalls } ) => {
-		const slack = require( '../src/slack' );
+		// Mock Slack message existence
+		const slack = { ...( await import( '../src/slack.js' ) ) };
 		const spy = jest
 			.spyOn( slack, 'postOrUpdateMessage' )
 			.mockImplementation()
 			.mockReturnValue( { ts: '123' } );
-
-		// Mock message existence
 		jest.spyOn( slack, 'getMessage' ).mockReturnValue( mainMessageExists );
+		jest.unstable_mockModule( '../src/slack.js', () => slack );
 
 		// Mock the run conclusion
-		const github = require( '../src/github' );
+		const github = { ...( await import( '../src/github.js' ) ) };
 		jest.spyOn( github, 'isWorkflowFailed' ).mockReturnValue( isFailure );
+		jest.unstable_mockModule( '../src/github.js', () => github );
 
 		// Mock message content
-		const message = require( '../src/message' );
+		const message = { ...( await import( '../src/message.js' ) ) };
 		jest.spyOn( message, 'createMessage' ).mockReturnValue( {
 			text: 'message text',
 			id: 'msg-id',
 			mainMsgBlocks: [],
 			detailsMsgBlocksChunks: [],
 		} );
+		jest.unstable_mockModule( '../src/message.js', () => message );
 
 		await message.sendMessage( '', '', '', '' );
 

--- a/projects/github-actions/test-results-to-slack/tests/playwright.test.js
+++ b/projects/github-actions/test-results-to-slack/tests/playwright.test.js
@@ -1,5 +1,5 @@
-const fs = require( 'fs' );
-const { setInputData } = require( './test-utils' );
+import fs from 'fs';
+import { setInputData } from './test-utils.js';
 
 describe( 'Playwright report content', () => {
 	const rootPath = 'tests/resources/playwright';
@@ -18,7 +18,7 @@ describe( 'Playwright report content', () => {
 			expected = JSON.parse( fs.readFileSync( expected, { encoding: 'utf8' } ) );
 		}
 
-		const { getPlaywrightBlocks } = require( '../src/playwright' );
+		const { getPlaywrightBlocks } = await import( '../src/playwright.js' );
 		expect( getPlaywrightBlocks() ).toEqual( expected );
 	} );
 
@@ -33,7 +33,7 @@ describe( 'Playwright report content', () => {
 			const playwrightOutputDir = `${ rootPath }/**/results`;
 			setInputData( { playwrightOutputDir } );
 
-			const { getAttachmentPath } = require( '../src/playwright' );
+			const { getAttachmentPath } = await import( '../src/playwright.js' );
 			expect( getAttachmentPath( outputPath, attachmentPath ) ).toEqual( expected );
 		}
 	);

--- a/projects/github-actions/test-results-to-slack/tests/rules.test.js
+++ b/projects/github-actions/test-results-to-slack/tests/rules.test.js
@@ -1,7 +1,7 @@
-const crypto = require( 'crypto' );
-const fs = require( 'fs' );
-const path = require( 'path' );
-const { mockContextExtras, setInputData } = require( './test-utils' );
+import crypto from 'crypto';
+import fs from 'fs';
+import path from 'path';
+import { mockContextExtras, setInputData } from './test-utils.js';
 
 describe( 'Notification rules', () => {
 	const defaultChannel = 'DEFAULT_CHANNEL_ID';
@@ -33,7 +33,7 @@ describe( 'Notification rules', () => {
 		setInputData( { slackChannel: defaultChannel, suiteName, rulesConfigurationPath } );
 		mockContextExtras( { refType, refName } );
 
-		const { getChannels } = require( '../src/rules' );
+		const { getChannels } = await import( '../src/rules.js' );
 
 		expect( getChannels().sort() ).toEqual( expectedChannels.sort() );
 	} );

--- a/projects/github-actions/test-results-to-slack/tests/slack.test.js
+++ b/projects/github-actions/test-results-to-slack/tests/slack.test.js
@@ -1,7 +1,7 @@
-const path = require( 'path' );
-const { WebClient } = require( '@slack/web-api' );
+import path from 'path';
+import { jest } from '@jest/globals';
 
-jest.mock( '@slack/web-api', () => {
+jest.unstable_mockModule( '@slack/web-api', () => {
 	const slack = {
 		chat: {
 			postMessage: jest.fn(),
@@ -14,6 +14,7 @@ jest.mock( '@slack/web-api', () => {
 	};
 	return { WebClient: jest.fn( () => slack ) };
 } );
+const { WebClient } = await import( '@slack/web-api' );
 
 const slackClient = new WebClient();
 
@@ -30,7 +31,7 @@ describe( 'Find existing messages', () => {
 	`( '$description', async ( { expected, response } ) => {
 		slackClient.conversations.history.mockResolvedValue( response );
 
-		const { getMessage } = require( '../src/slack' );
+		const { getMessage } = await import( '../src/slack.js' );
 		const message = await getMessage( slackClient, '123abc', messageIdentifier );
 		await expect( JSON.stringify( message ) ).toBe( JSON.stringify( expected ) );
 	} );
@@ -46,7 +47,7 @@ describe( 'Blocks chunks', () => {
 	`(
 		'Blocks are chunked by delimiter: $description',
 		async ( { blocks, maxSize, type, expected } ) => {
-			const { getBlocksChunks } = require( '../src/slack' );
+			const { getBlocksChunks } = await import( '../src/slack.js' );
 			const chunks = getBlocksChunks( blocks, maxSize, type );
 			expect( chunks ).toEqual( expected );
 		}
@@ -59,7 +60,7 @@ describe( 'Post message', () => {
 		${ false } | ${ 'postMessage' }
 		${ true }  | ${ 'update' }
 	`( 'Message is sent: $expectedMethod', async ( { isUpdate, expectedMethod } ) => {
-		const { postOrUpdateMessage } = require( '../src/slack' );
+		const { postOrUpdateMessage } = await import( '../src/slack.js' );
 		const text = 'Notification text';
 		const blocks = [ { type: 'context' } ];
 		const channel = '123abc';
@@ -91,7 +92,7 @@ describe( 'Post message', () => {
 	} );
 
 	test( 'File is uploaded', async () => {
-		const { postOrUpdateMessage } = require( '../src/slack' );
+		const { postOrUpdateMessage } = await import( '../src/slack.js' );
 		const filePath = path.resolve(
 			'tests/resources/playwright/suite-1/results/spec-1/test-failed-1.png'
 		);

--- a/projects/github-actions/test-results-to-slack/tests/test-utils.js
+++ b/projects/github-actions/test-results-to-slack/tests/test-utils.js
@@ -1,14 +1,17 @@
-const github = require( '@actions/github' );
+import { jest } from '@jest/globals';
 
 /**
  * Mocks the GitHub context exposed by `@actions/github`
  *
  * @param {object} value - context object
  */
-function mockGitHubContext( value ) {
-	Object.defineProperty( github, 'context', {
-		value,
-	} );
+export async function mockGitHubContext( value ) {
+	jest.unstable_unmockModule( '@actions/github' );
+	const actualGithub = await import( '@actions/github' );
+	jest.unstable_mockModule( '@actions/github', () => ( {
+		...actualGithub,
+		context: value,
+	} ) );
 }
 
 /**
@@ -16,7 +19,7 @@ function mockGitHubContext( value ) {
  *
  * @param {object} options - options object
  */
-function setInputData( options ) {
+export function setInputData( options ) {
 	const {
 		ghToken,
 		slackToken,
@@ -88,7 +91,7 @@ function setInputData( options ) {
  *
  * @param {object} options - options object
  */
-function mockContextExtras( options ) {
+export function mockContextExtras( options ) {
 	const {
 		runAttempt = '1',
 		refType = 'branch',
@@ -103,9 +106,3 @@ function mockContextExtras( options ) {
 	process.env.GITHUB_REPOSITORY = repository;
 	process.env.GITHUB_TRIGGERING_ACTOR = triggeringActor;
 }
-
-module.exports = {
-	mockGitHubContext,
-	setInputData,
-	mockContextExtras,
-};


### PR DESCRIPTION
Closes MONOREP-349

 <!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
GitHub's `@actions/github` and `@actions/core` are going ESM-only. To continue updating those, we'll have to follow suit.

The `jest` mocking here is fairly unpleasant.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Have the E2Es run, see if it works.
