### PR TITLE
fix(charts): bundle @wordpress/ui into dist output

### DIFF
--- a/projects/js-packages/charts/changelog/fix-charts-bundle-wordpress-ui
+++ b/projects/js-packages/charts/changelog/fix-charts-bundle-wordpress-ui
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Bundle @wordpress/ui into dist output to prevent runtime errors in consumers using wp-build.

--- a/projects/js-packages/charts/tsup.config.ts
+++ b/projects/js-packages/charts/tsup.config.ts
@@ -15,6 +15,7 @@ export default defineConfig( {
 	dts: true,
 	format: [ 'esm', 'cjs' ],
 	outDir: 'dist',
+	noExternal: [ '@wordpress/ui', '@wordpress/theme' ],
 	loader: {
 		'.jpg': 'file',
 		'.gif': 'file',

--- a/projects/js-packages/charts/tsup.config.ts
+++ b/projects/js-packages/charts/tsup.config.ts
@@ -15,7 +15,7 @@ export default defineConfig( {
 	dts: true,
 	format: [ 'esm', 'cjs' ],
 	outDir: 'dist',
-	noExternal: [ '@wordpress/ui', '@wordpress/theme' ],
+	noExternal: [ '@wordpress/ui' ],
 	loader: {
 		'.jpg': 'file',
 		'.gif': 'file',


### PR DESCRIPTION
Fixes #

## Proposed changes:
* Bundle `@wordpress/ui` into the charts package dist output by adding it to `noExternal` in the tsup config.
* By default, tsup treats all `package.json` dependencies as external, excluding them from the bundle. However, `@wordpress/ui` is an npm-only package — it is not shipped by Gutenberg as a WordPress script or module, so `window.wp.ui` does not exist at runtime. This causes runtime errors (`React.jsx: type is invalid`) when a consumer's bundler (e.g., `@automattic/wp-build`) externalizes `@wordpress/ui` to the non-existent WordPress global.
* `@wordpress/theme` is NOT included in `noExternal` because Gutenberg does register it as a classic script (`build/scripts/theme/`), making it available as `window.wp.theme` at runtime.
* Adding `@wordpress/ui` to `noExternal` instructs tsup/esbuild to inline its code directly into the charts bundle, producing a self-contained build that works without requiring consumers to independently provide this package.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
* Build the charts package: `jp build js-packages/charts`
* Verify that the dist output does NOT contain `import { Stack } from "@wordpress/ui"` — it should be inlined.
* Verify that `@wordpress/theme` and `@wordpress/i18n` are still external imports in the dist output (not bundled).
* Import the charts package from a consuming application (e.g., WooCommerce Analytics) that uses `@automattic/wp-build` and confirm charts render without runtime errors.