### PR TITLE
Sharing: Fix LinkedIn sharing by updating to the current share URL endpoint

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-sharedaddy-linkedin-sharing-link
+++ b/projects/plugins/jetpack/changelog/fix-sharedaddy-linkedin-sharing-link
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Sharing: Fix LinkedIn sharing by updating to the current share URL endpoint.

--- a/projects/plugins/jetpack/extensions/blocks/sharing-button/class-sharing-source-block.php
+++ b/projects/plugins/jetpack/extensions/blocks/sharing-button/class-sharing-source-block.php
@@ -1429,13 +1429,11 @@ class Share_LinkedIn_Block extends Sharing_Source_Block {
 
 		$post_link = $this->get_share_url( $post->ID );
 
-		// Using the same URL as the official button, which is *not* LinkedIn's documented sharing link
-		// https://www.linkedin.com/cws/share?url={url}&token=&isFramed=false
 		$linkedin_url = add_query_arg(
 			array(
 				'url' => rawurlencode( $post_link ),
 			),
-			'https://www.linkedin.com/cws/share?token=&isFramed=false'
+			'https://www.linkedin.com/sharing/share-offsite/'
 		);
 
 		// Record stats

--- a/projects/plugins/jetpack/modules/sharedaddy/sharing-sources.php
+++ b/projects/plugins/jetpack/modules/sharedaddy/sharing-sources.php
@@ -1775,13 +1775,11 @@ class Share_LinkedIn extends Sharing_Source {
 
 		$post_link = $this->get_share_url( $post->ID );
 
-		// Using the same URL as the official button, which is *not* LinkedIn's documented sharing link
-		// https://www.linkedin.com/cws/share?url={url}&token=&isFramed=false
 		$linkedin_url = add_query_arg(
 			array(
 				'url' => rawurlencode( $post_link ),
 			),
-			'https://www.linkedin.com/cws/share?token=&isFramed=false'
+			'https://www.linkedin.com/sharing/share-offsite/'
 		);
 
 		// Record stats


### PR DESCRIPTION
Fixes SOCIAL-338

## Proposed changes:
- Update the LinkedIn sharing URL from the deprecated `https://www.linkedin.com/cws/share` endpoint to the current `https://www.linkedin.com/sharing/share-offsite/` endpoint. Note: LinkedIn does not provide official documentation for this URL, but it is the de facto standard used by all major sharing implementations (Drupal, Ghost, react-share, etc.).
- The old `/cws/share` endpoint is no longer functional, causing LinkedIn to show an error when users attempt to share posts via the sharing button.
- The fix applies to both the classic Sharedaddy sharing button and the Sharing Buttons block.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:

* Go to a site and enable sharing buttons in Jetpack > Settings > Sharing.
* Ensure the LinkedIn sharing button is enabled (via Sharing settings or by adding a Sharing Buttons block to the single post template).
* View a published post on the frontend.
* Click the LinkedIn sharing button.
* Verify that LinkedIn's share dialog opens correctly with the post URL pre-filled and that you can successfully share the post.
* Test both the classic Sharedaddy sharing buttons (if using the legacy sharing settings) and the Sharing Buttons block.
