### PR TITLE
Social: Update confirmation modal copy and width

### DIFF
--- a/projects/packages/publicize/_inc/components/unified-modal/social-post-preview/use-footer-actions.tsx
+++ b/projects/packages/publicize/_inc/components/unified-modal/social-post-preview/use-footer-actions.tsx
@@ -1,7 +1,7 @@
 import { Button } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
-import { _x } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import { useMemo } from 'react';
 import usePublicizeConfig from '../../../hooks/use-publicize-config';
 import ScheduleButton from '../../schedule-button';
@@ -17,6 +17,11 @@ export function useFooterActions(): ScreenDetails[ 'footerActions' ] {
 	const isPostPublished = useSelect( select => select( editorStore ).isCurrentPostPublished(), [] );
 	const { isRePublicizeFeatureAvailable } = usePublicizeConfig();
 
+	const isPrePublishScreen = useSelect( select => {
+		const store = select( editorStore );
+		return ! store.isCurrentPostPublished() && store.isPublishSidebarOpened();
+	}, [] );
+
 	return useMemo( () => {
 		if ( isPostPublished && isRePublicizeFeatureAvailable ) {
 			return [
@@ -28,9 +33,11 @@ export function useFooterActions(): ScreenDetails[ 'footerActions' ] {
 		return [
 			( { navigate } ) => (
 				<Button key="save" variant="primary" onClick={ navigate }>
-					{ _x( 'Close', 'Button text to close the modal.', 'jetpack-publicize-pkg' ) }
+					{ isPrePublishScreen
+						? __( 'Continue', 'jetpack-publicize-pkg' )
+						: _x( 'Close', 'Button text to close the modal.', 'jetpack-publicize-pkg' ) }
 				</Button>
 			),
 		];
-	}, [ isPostPublished, isRePublicizeFeatureAvailable ] );
+	}, [ isPostPublished, isRePublicizeFeatureAvailable, isPrePublishScreen ] );
 }

--- a/projects/packages/publicize/_inc/components/unified-modal/social-post-preview/use-modal-screen.tsx
+++ b/projects/packages/publicize/_inc/components/unified-modal/social-post-preview/use-modal-screen.tsx
@@ -25,16 +25,26 @@ export function useModalScreen() {
 		return ! store.isCurrentPostPublished() && store.isPublishSidebarOpened();
 	}, [] );
 
+	let title: string = __( 'Preview and customize', 'jetpack-publicize-pkg' );
+
+	if ( isPrePublishScreen ) {
+		title = _x(
+			'Confirm social sharing',
+			'Share here is imperative verb',
+			'jetpack-publicize-pkg'
+		);
+	} else if ( isPostPublished ) {
+		title = _x(
+			'Customize and share to social media',
+			'Share here is imperative verb',
+			'jetpack-publicize-pkg'
+		);
+	}
+
 	return useMemo< ScreenDetails >(
 		() => ( {
 			path: '/',
-			title: ! isPostPublished
-				? __( 'Preview and customize', 'jetpack-publicize-pkg' )
-				: _x(
-						'Customize and share to social media',
-						'Share here is imperative verb',
-						'jetpack-publicize-pkg'
-				  ),
+			title,
 			isScreenLocked: true,
 			headerIcon: isPrePublishScreen ? <JetpackLogo /> : null,
 			content: <Content />,
@@ -43,6 +53,6 @@ export function useModalScreen() {
 			className: styles[ 'social-post-preview-screen' ],
 			'data-plan': hasSocialPaidFeatures() ? 'paid' : 'free',
 		} ),
-		[ isPostPublished, isPrePublishScreen, footerActions ]
+		[ isPrePublishScreen, footerActions, title ]
 	);
 }

--- a/projects/packages/publicize/_inc/components/unified-modal/social-post-preview/use-modal-screen.tsx
+++ b/projects/packages/publicize/_inc/components/unified-modal/social-post-preview/use-modal-screen.tsx
@@ -25,21 +25,26 @@ export function useModalScreen() {
 		return ! store.isCurrentPostPublished() && store.isPublishSidebarOpened();
 	}, [] );
 
-	let title: string = __( 'Preview and customize', 'jetpack-publicize-pkg' );
+	// useMemo not really needed but it encapsulates the logic.
+	const title = useMemo( () => {
+		if ( isPrePublishScreen ) {
+			return _x(
+				'Confirm social sharing',
+				'Modal title for pre-publish confimation',
+				'jetpack-publicize-pkg'
+			);
+		}
 
-	if ( isPrePublishScreen ) {
-		title = _x(
-			'Confirm social sharing',
-			'Share here is imperative verb',
+		if ( isPostPublished ) {
+			return __( 'Customize and share to social media', 'jetpack-publicize-pkg' );
+		}
+
+		return _x(
+			'Preview and customize',
+			'Title for social post preview modal',
 			'jetpack-publicize-pkg'
 		);
-	} else if ( isPostPublished ) {
-		title = _x(
-			'Customize and share to social media',
-			'Share here is imperative verb',
-			'jetpack-publicize-pkg'
-		);
-	}
+	}, [ isPrePublishScreen, isPostPublished ] );
 
 	return useMemo< ScreenDetails >(
 		() => ( {

--- a/projects/packages/publicize/_inc/components/unified-modal/social-post-preview/use-modal-screen.tsx
+++ b/projects/packages/publicize/_inc/components/unified-modal/social-post-preview/use-modal-screen.tsx
@@ -30,7 +30,7 @@ export function useModalScreen() {
 		if ( isPrePublishScreen ) {
 			return _x(
 				'Confirm social sharing',
-				'Modal title for pre-publish confimation',
+				'Modal title for pre-publish confirmation',
 				'jetpack-publicize-pkg'
 			);
 		}

--- a/projects/packages/publicize/_inc/components/unified-modal/styles.module.scss
+++ b/projects/packages/publicize/_inc/components/unified-modal/styles.module.scss
@@ -5,7 +5,7 @@
 	&:global(.components-modal__frame.is-full-screen) {
 
 		@include gb.break-medium() {
-			max-width: gb.$wide-content-width;
+			max-width: gb.$break-wide;
 			max-height: 64rem;
 		}
 

--- a/projects/packages/publicize/changelog/update-social-pre-publish-preview-modal-title
+++ b/projects/packages/publicize/changelog/update-social-pre-publish-preview-modal-title
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update preview modal copy on pre-publish screen.


### PR DESCRIPTION
Closes SOCIAL-364

## Proposed changes:

Updates the confirmation modal copy and width based on design feedback. When the modal is shown from the pre-publish sidebar, the title and action button were not clearly communicating that the user is about to publish with social sharing.

- Update the modal title to "Confirm social sharing" on the pre-publish screen
- Change the footer action button label from "Close" to "Continue" on the pre-publish screen
- Increase the modal max-width from `1100px` to `1280px` for better use of screen space

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

SOCIAL-364

## Does this pull request change what data or activity we track or use?

No changes to data tracking.

## Testing instructions:

- Create or edit a post with Jetpack Social connections configured

### Pre-publish screen

- Click "Publish" to open the pre-publish sidebar
- The Social preview modal should open automatically
- **Verify**: The modal title reads "Confirm social sharing"
- **Verify**: The footer button reads "Continue" (not "Close")

### Regular preview

- Open the Social preview modal from the sidebar (not from pre-publish)
- **Verify**: The modal title reads "Preview and customize"
- **Verify**: The footer button reads "Close"

### Post-publish (reshare)

- On an already published post, open the Social modal
- **Verify**: The modal title reads "Customize and share to social media"

### Modal width

- On a wide screen, open the modal
- **Verify**: The modal is wider than before (1280px max-width instead of 1100px)

<img width="953" height="869" alt="Screenshot 2026-02-06 at 9 52 15 PM" src="https://github.com/user-attachments/assets/ac6b31d9-cbd1-4f61-b205-2f978ee2d92c" />
