### PR TITLE
Forms: Fix duplicate form display on successful submission

### DIFF
--- a/projects/packages/forms/changelog/fix-frontend-duplicate-form
+++ b/projects/packages/forms/changelog/fix-frontend-duplicate-form
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Contact Form: fix duplicate form display on frontend when submission is successful.

--- a/projects/packages/forms/changelog/fix-frontend-duplicate-form
+++ b/projects/packages/forms/changelog/fix-frontend-duplicate-form
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Contact Form: fix duplicate form display on frontend when submission is successful.
+Contact Form: Prevent duplicate form display on the frontend after a successful submission.

--- a/projects/packages/forms/src/contact-form/css/grunion.scss
+++ b/projects/packages/forms/src/contact-form/css/grunion.scss
@@ -1533,8 +1533,8 @@ on production builds, the attributes are being reordered, causing side-effects
 	display: block;
 }
 
-.contact-form.is-ajax-form.submission-success {
-	display: none;
+.contact-form.submission-success {
+	display: none; // hide the form when the submission is successful, and show the success message instead
 }
 
 .contact-form-ajax-submission:not(.submission-success) {


### PR DESCRIPTION
Fixes FORMS-579

I think the main issue is the following. There are some cases where the redirect is set via the filter but the redirect only is set for classic themes and the redirect is such that the final URL doesn't change much (it add more query parameters). So that we still end on the same page/post that the form is on. 

We always assumed that the redirect would send the user to a different URL. 
In our case this is not the case and we end up with a situation. Where the we redirect to the same page that the form is on but since the form is a redirect we `.is-ajax-form` never gets applied correctly. This makes sure that we get end up with a hidden form whether we are using an ajax form or not. 

## Proposed changes:
* Remove `.is-ajax-form` class requirement from the success selector, ensuring the form is hidden after a successful submission regardless of whether AJAX submission is enabled. 



### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

p1770340035260609-slack-C052XEUUBL4

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
* Create a page with a Jetpack Contact Form
* Configure the form to NOT use AJAX submission (or test with a form that uses non-AJAX submission)
* Submit the form with valid data
* After submission, verify that the form is hidden and only the success message is displayed
* Previously, the form would remain visible alongside the success message because the CSS selector required `.is-ajax-form` class