### PR TITLE
Forms: Hide 'Last Edited' panel in form editor

### DIFF
--- a/projects/packages/forms/changelog/remove-form-editor-last-edited
+++ b/projects/packages/forms/changelog/remove-form-editor-last-edited
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Forms: hide 'Last Edited' panel in form editor.
+Hide 'Last Edited' panel in form editor.

--- a/projects/packages/forms/changelog/remove-form-editor-last-edited
+++ b/projects/packages/forms/changelog/remove-form-editor-last-edited
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Forms: hide 'Last Edited' panel in form editor.

--- a/projects/packages/forms/src/form-editor/style.scss
+++ b/projects/packages/forms/src/form-editor/style.scss
@@ -1,3 +1,7 @@
 .post-type-jetpack_form .block-editor-block-breadcrumb li:first-child {
 	display: none;
 }
+
+.post-type-jetpack_form .editor-post-last-edited-panel {
+	display: none;
+}


### PR DESCRIPTION
Before:

<img width="309" height="355" alt="Screenshot 2026-02-06 at 12 08 07 PM" src="https://github.com/user-attachments/assets/a5b05cbd-98b8-44d9-9264-168d8871596c" />

After:

<img width="308" height="348" alt="Screenshot 2026-02-06 at 12 07 22 PM" src="https://github.com/user-attachments/assets/c66637c4-924e-4f4e-8805-a29330dd088c" />

## Proposed changes:
* Hide the "Last Edited" panel in the Jetpack Forms editor sidebar via CSS
* This panel is not useful in the context of form editing and adds visual clutter

### Other information:

- [x] Have you written new tests for your changes, if applicable? (N/A - CSS-only change)
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion


## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

* Go to WP Admin > Jetpack > Forms > Edit any form (or create a new one)
* In the form editor, observe that the "Last Edited" panel is no longer visible in the sidebar
* Confirm other editor functionality is unaffected