### PR TITLE
Forms: Fix the header actions for responses on wp-build dashboard

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-wp-build-response-header-actions
+++ b/projects/packages/forms/changelog/fix-forms-wp-build-response-header-actions
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Unreleased, under feature flag. Fix the header actions for responses on wp-build dashboard
+
+

--- a/projects/packages/forms/routes/responses/actions.tsx
+++ b/projects/packages/forms/routes/responses/actions.tsx
@@ -291,27 +291,38 @@ type SearchParams = {
 	[ key: string ]: string | string[] | undefined;
 };
 
-type GetActionsParams = {
-	navigate: NavigateFunction;
-	searchParams: SearchParams;
-	view: string | undefined;
-};
-
 type ActionWithDestructive = Action & {
 	isDestructive?: boolean;
 };
 
+type GetActionsParams = {
+	navigate: NavigateFunction;
+	searchParams: SearchParams;
+};
+
+type getActionsReturn = {
+	viewAction: Action;
+	editFormAction: Action;
+	markAsSpamAction: Action;
+	markAsNotSpamAction: Action;
+	restoreAction: Action;
+	moveToTrashAction: Action;
+	deleteAction: ActionWithDestructive;
+	markAsReadAction: Action;
+	markAsUnreadAction: Action;
+};
+
+type GetRowActionsParams = GetActionsParams & {
+	view: string | undefined;
+};
+
 /**
- * Get actions configuration for form responses DataViews.
+ * Get the actions for the form responses DataViews.
  *
  * @param {GetActionsParams} params - Parameters for generating actions.
- * @return {ActionWithDestructive[]} Array of action configurations.
+ * @return {getActionsReturn} Object containing the actions.
  */
-export function getActions( {
-	navigate,
-	searchParams,
-	view,
-}: GetActionsParams ): ActionWithDestructive[] {
+export function getActions( { navigate, searchParams }: GetActionsParams ): getActionsReturn {
 	const viewAction: Action = {
 		id: 'view-response',
 		isPrimary: true,
@@ -1207,6 +1218,45 @@ export function getActions( {
 			createErrorNotice( errorMessage, { type: 'snackbar' } );
 		},
 	};
+
+	return {
+		viewAction,
+		editFormAction,
+		markAsSpamAction,
+		markAsNotSpamAction,
+		restoreAction,
+		moveToTrashAction,
+		deleteAction,
+		markAsReadAction,
+		markAsUnreadAction,
+	};
+}
+
+/**
+ * Get actions configuration for form responses DataViews.
+ *
+ * @param {GetRowActionsParams} params - Parameters for generating actions.
+ * @return {ActionWithDestructive[]} Array of action configurations.
+ */
+export function getRowActions( {
+	navigate,
+	searchParams,
+	view,
+}: GetRowActionsParams ): ActionWithDestructive[] {
+	const {
+		viewAction,
+		editFormAction,
+		markAsSpamAction,
+		markAsNotSpamAction,
+		restoreAction,
+		moveToTrashAction,
+		deleteAction,
+		markAsReadAction,
+		markAsUnreadAction,
+	} = getActions( {
+		navigate,
+		searchParams,
+	} );
 
 	switch ( view ) {
 		case 'trash':

--- a/projects/packages/forms/routes/responses/actions.tsx
+++ b/projects/packages/forms/routes/responses/actions.tsx
@@ -300,7 +300,7 @@ type GetActionsParams = {
 	searchParams: SearchParams;
 };
 
-type getActionsReturn = {
+type GetActionsReturn = {
 	viewAction: Action;
 	editFormAction: Action;
 	markAsSpamAction: Action;
@@ -320,9 +320,9 @@ type GetRowActionsParams = GetActionsParams & {
  * Get the actions for the form responses DataViews.
  *
  * @param {GetActionsParams} params - Parameters for generating actions.
- * @return {getActionsReturn} Object containing the actions.
+ * @return {GetActionsReturn} Object containing the actions.
  */
-export function getActions( { navigate, searchParams }: GetActionsParams ): getActionsReturn {
+export function getActions( { navigate, searchParams }: GetActionsParams ): GetActionsReturn {
 	const viewAction: Action = {
 		id: 'view-response',
 		isPrimary: true,

--- a/projects/packages/forms/routes/responses/response/actions.tsx
+++ b/projects/packages/forms/routes/responses/response/actions.tsx
@@ -1,20 +1,22 @@
 /**
  * WordPress dependencies
  */
-import apiFetch from '@wordpress/api-fetch';
 import { Button } from '@wordpress/components';
-import { store as coreStore } from '@wordpress/core-data';
-import { useDispatch } from '@wordpress/data';
-import { useCallback, useState } from '@wordpress/element';
+import { useRegistry } from '@wordpress/data';
+import { useCallback, useMemo, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { useSearch, useNavigate } from '@wordpress/route';
 import { Stack } from '@wordpress/ui';
 import * as React from 'react';
 /**
  * Internal dependencies
  */
-import { store as dashboardStore } from '../../../src/dashboard/store';
-import type { DispatchActions } from '../../../src/dashboard/inbox/stage/types.tsx';
-import type { FormResponse } from '../../../src/types/index.ts';
+import { getActions } from '../actions';
+/**
+ * Types
+ */
+import type { Registry } from '../../../src/dashboard/inbox/stage/types.tsx';
+import type { FormResponse } from '../../../src/types/index';
 
 /**
  * Renders the actions for a response.
@@ -32,203 +34,132 @@ export function ResponseActions( {
 	response: FormResponse;
 	onActionComplete: ( item: FormResponse ) => void;
 } ) {
-	const { saveEntityRecord, deleteEntityRecord, editEntityRecord } = useDispatch(
-		coreStore
-	) as DispatchActions;
-	const { updateCountsOptimistically, invalidateCounts } = useDispatch(
-		dashboardStore
-	) as DispatchActions;
-	const [ isLoading ] = useState( false );
+	const searchParams = useSearch( { from: '/responses/$view' } );
+	const navigate = useNavigate();
+
+	const {
+		markAsSpamAction,
+		markAsNotSpamAction,
+		moveToTrashAction,
+		restoreAction,
+		deleteAction,
+		markAsReadAction,
+		markAsUnreadAction,
+	} = useMemo(
+		() =>
+			getActions( {
+				navigate,
+				searchParams,
+			} ),
+		[ navigate, searchParams ]
+	);
+
+	const [ isMarkingAsSpam, setIsMarkingAsSpam ] = useState( false );
+	const [ isMarkingAsNotSpam, setIsMarkingAsNotSpam ] = useState( false );
+	const [ isMovingToTrash, setIsMovingToTrash ] = useState( false );
+	const [ isRestoring, setIsRestoring ] = useState( false );
+	const [ isDeleting, setIsDeleting ] = useState( false );
+	const [ isTogglingReadStatus, setIsTogglingReadStatus ] = useState( false );
+
+	const registry = useRegistry() as unknown as Registry;
 
 	const handleMarkAsSpam = useCallback( async () => {
-		const originalStatus = response.status;
-
-		// Optimistic update
-		editEntityRecord( 'postType', 'feedback', response.id, { status: 'spam' } );
-		updateCountsOptimistically( originalStatus, 'spam', 1 );
-		onActionComplete( { ...response, status: 'spam' } );
-
-		try {
-			await saveEntityRecord( 'postType', 'feedback', {
-				id: response.id,
-				status: 'spam',
-			} );
-			invalidateCounts();
-		} catch {
-			// Revert on error
-			editEntityRecord( 'postType', 'feedback', response.id, { status: originalStatus } );
-			updateCountsOptimistically( 'spam', originalStatus, 1 );
-		}
-	}, [
-		response,
-		saveEntityRecord,
-		editEntityRecord,
-		onActionComplete,
-		updateCountsOptimistically,
-		invalidateCounts,
-	] );
+		onActionComplete?.( response );
+		setIsMarkingAsSpam( true );
+		await markAsSpamAction.callback?.( [ response ], { registry } );
+		setIsMarkingAsSpam( false );
+	}, [ onActionComplete, response, markAsSpamAction, registry ] );
 
 	const handleMarkAsNotSpam = useCallback( async () => {
-		const originalStatus = response.status;
-
-		// Optimistic update
-		editEntityRecord( 'postType', 'feedback', response.id, { status: 'publish' } );
-		updateCountsOptimistically( originalStatus, 'publish', 1 );
-		onActionComplete( { ...response, status: 'publish' } );
-
-		try {
-			await saveEntityRecord( 'postType', 'feedback', {
-				id: response.id,
-				status: 'publish',
-			} );
-			invalidateCounts();
-		} catch {
-			// Revert on error
-			editEntityRecord( 'postType', 'feedback', response.id, { status: originalStatus } );
-			updateCountsOptimistically( 'publish', originalStatus, 1 );
-		}
-	}, [
-		response,
-		saveEntityRecord,
-		editEntityRecord,
-		onActionComplete,
-		updateCountsOptimistically,
-		invalidateCounts,
-	] );
+		onActionComplete?.( response );
+		setIsMarkingAsNotSpam( true );
+		await markAsNotSpamAction?.callback?.( [ response ], { registry } );
+		setIsMarkingAsNotSpam( false );
+	}, [ onActionComplete, response, markAsNotSpamAction, registry ] );
 
 	const handleMoveToTrash = useCallback( async () => {
-		const originalStatus = response.status;
-
-		// Optimistic update
-		editEntityRecord( 'postType', 'feedback', response.id, { status: 'trash' } );
-		updateCountsOptimistically( originalStatus, 'trash', 1 );
-		onActionComplete( { ...response, status: 'trash' } );
-
-		try {
-			await deleteEntityRecord( 'postType', 'feedback', response.id );
-			invalidateCounts();
-		} catch {
-			// Revert on error
-			editEntityRecord( 'postType', 'feedback', response.id, { status: originalStatus } );
-			updateCountsOptimistically( 'trash', originalStatus, 1 );
-		}
-	}, [
-		response,
-		deleteEntityRecord,
-		editEntityRecord,
-		onActionComplete,
-		updateCountsOptimistically,
-		invalidateCounts,
-	] );
+		onActionComplete?.( response );
+		setIsMovingToTrash( true );
+		await moveToTrashAction?.callback?.( [ response ], { registry } );
+		setIsMovingToTrash( false );
+	}, [ onActionComplete, response, moveToTrashAction, registry ] );
 
 	const handleRestore = useCallback( async () => {
-		const originalStatus = response.status;
-
-		// Optimistic update
-		editEntityRecord( 'postType', 'feedback', response.id, { status: 'publish' } );
-		updateCountsOptimistically( originalStatus, 'publish', 1 );
-		onActionComplete( { ...response, status: 'publish' } );
-
-		try {
-			await saveEntityRecord( 'postType', 'feedback', {
-				id: response.id,
-				status: 'publish',
-			} );
-			invalidateCounts();
-		} catch {
-			// Revert on error
-			editEntityRecord( 'postType', 'feedback', response.id, { status: originalStatus } );
-			updateCountsOptimistically( 'publish', originalStatus, 1 );
-		}
-	}, [
-		response,
-		saveEntityRecord,
-		editEntityRecord,
-		onActionComplete,
-		updateCountsOptimistically,
-		invalidateCounts,
-	] );
+		onActionComplete?.( response );
+		setIsRestoring( true );
+		await restoreAction?.callback?.( [ response ], { registry } );
+		setIsRestoring( false );
+	}, [ onActionComplete, response, restoreAction, registry ] );
 
 	const handleDelete = useCallback( async () => {
-		const originalStatus = response.status;
+		onActionComplete?.( response );
+		setIsDeleting( true );
+		await deleteAction?.callback?.( [ response ], { registry } );
+		setIsDeleting( false );
+	}, [ onActionComplete, response, deleteAction, registry ] );
 
-		// Optimistic update
-		updateCountsOptimistically( originalStatus, '', 1 );
-		onActionComplete( response );
+	const handleMarkAsRead = useCallback( async () => {
+		setIsTogglingReadStatus( true );
+		await markAsReadAction?.callback?.( [ response ], { registry } );
+		setIsTogglingReadStatus( false );
+		onActionComplete?.( { ...response, is_unread: false } );
+	}, [ onActionComplete, response, markAsReadAction, registry ] );
 
-		try {
-			await deleteEntityRecord( 'postType', 'feedback', response.id, { force: true } );
-			invalidateCounts();
-		} catch {
-			// Revert on error
-			updateCountsOptimistically( '', originalStatus, 1 );
-		}
-	}, [
-		response,
-		deleteEntityRecord,
-		onActionComplete,
-		updateCountsOptimistically,
-		invalidateCounts,
-	] );
+	const handleMarkAsUnread = useCallback( async () => {
+		setIsTogglingReadStatus( true );
+		await markAsUnreadAction?.callback?.( [ response ], { registry } );
+		setIsTogglingReadStatus( false );
+		onActionComplete?.( { ...response, is_unread: true } );
+	}, [ onActionComplete, response, markAsUnreadAction, registry ] );
 
-	const handleToggleRead = useCallback( async () => {
-		const newIsUnread = ! response.is_unread;
-
-		// Optimistic update
-		editEntityRecord( 'postType', 'feedback', response.id, { is_unread: newIsUnread } );
-		onActionComplete( { ...response, is_unread: newIsUnread } );
-
-		try {
-			await apiFetch( {
-				path: `/wp/v2/feedback/${ response.id }/read`,
-				method: 'POST',
-				data: { is_unread: newIsUnread },
-			} );
-		} catch {
-			// Revert on error
-			editEntityRecord( 'postType', 'feedback', response.id, { is_unread: ! newIsUnread } );
-		}
-	}, [ response, editEntityRecord, onActionComplete ] );
-
-	const sharedProps = {
-		isBusy: isLoading,
-		size: 'compact' as const,
-	};
+	const sharedProps = useMemo(
+		() => ( {
+			size: 'compact' as const,
+		} ),
+		[]
+	);
 
 	const readUnreadButtons = (
-		<Button onClick={ handleToggleRead } { ...sharedProps }>
-			{ response.is_unread
-				? __( 'Mark as read', 'jetpack-forms' )
-				: __( 'Mark as unread', 'jetpack-forms' ) }
-		</Button>
+		<>
+			{ response.is_unread && (
+				<Button onClick={ handleMarkAsRead } { ...sharedProps } isBusy={ isTogglingReadStatus }>
+					{ __( 'Mark as read', 'jetpack-forms' ) }
+				</Button>
+			) }
+			{ ! response.is_unread && (
+				<Button onClick={ handleMarkAsUnread } { ...sharedProps } isBusy={ isTogglingReadStatus }>
+					{ __( 'Mark as unread', 'jetpack-forms' ) }
+				</Button>
+			) }
+		</>
 	);
 
 	const trashButton = (
-		<Button onClick={ handleMoveToTrash } { ...sharedProps }>
+		<Button onClick={ handleMoveToTrash } { ...sharedProps } isBusy={ isMovingToTrash }>
 			{ __( 'Trash', 'jetpack-forms' ) }
 		</Button>
 	);
 
 	const spamButton = (
-		<Button onClick={ handleMarkAsSpam } { ...sharedProps }>
+		<Button onClick={ handleMarkAsSpam } { ...sharedProps } isBusy={ isMarkingAsSpam }>
 			{ __( 'Spam', 'jetpack-forms' ) }
 		</Button>
 	);
 
 	const notSpamButton = (
-		<Button onClick={ handleMarkAsNotSpam } { ...sharedProps }>
+		<Button onClick={ handleMarkAsNotSpam } { ...sharedProps } isBusy={ isMarkingAsNotSpam }>
 			{ __( 'Not spam', 'jetpack-forms' ) }
 		</Button>
 	);
 
 	const deleteButton = (
-		<Button onClick={ handleDelete } { ...sharedProps }>
+		<Button onClick={ handleDelete } { ...sharedProps } isBusy={ isDeleting }>
 			{ __( 'Delete', 'jetpack-forms' ) }
 		</Button>
 	);
 
 	const restoreButton = (
-		<Button onClick={ handleRestore } { ...sharedProps }>
+		<Button onClick={ handleRestore } { ...sharedProps } isBusy={ isRestoring }>
 			{ __( 'Restore', 'jetpack-forms' ) }
 		</Button>
 	);

--- a/projects/packages/forms/routes/responses/response/actions.tsx
+++ b/projects/packages/forms/routes/responses/response/actions.tsx
@@ -11,12 +11,12 @@ import * as React from 'react';
 /**
  * Internal dependencies
  */
-import { getActions } from '../actions';
+import { getActions } from '../actions.tsx';
 /**
  * Types
  */
 import type { Registry } from '../../../src/dashboard/inbox/stage/types.tsx';
-import type { FormResponse } from '../../../src/types/index';
+import type { FormResponse } from '../../../src/types/index.ts';
 
 /**
  * Renders the actions for a response.

--- a/projects/packages/forms/routes/responses/response/actions.tsx
+++ b/projects/packages/forms/routes/responses/response/actions.tsx
@@ -112,22 +112,15 @@ export function ResponseActions( {
 		onActionComplete?.( { ...response, is_unread: true } );
 	}, [ onActionComplete, response, markAsUnreadAction, registry ] );
 
-	const sharedProps = useMemo(
-		() => ( {
-			size: 'compact' as const,
-		} ),
-		[]
-	);
-
 	const readUnreadButtons = (
 		<>
 			{ response.is_unread && (
-				<Button onClick={ handleMarkAsRead } { ...sharedProps } isBusy={ isTogglingReadStatus }>
+				<Button isBusy={ isTogglingReadStatus } onClick={ handleMarkAsRead } size="compact">
 					{ __( 'Mark as read', 'jetpack-forms' ) }
 				</Button>
 			) }
 			{ ! response.is_unread && (
-				<Button onClick={ handleMarkAsUnread } { ...sharedProps } isBusy={ isTogglingReadStatus }>
+				<Button isBusy={ isTogglingReadStatus } onClick={ handleMarkAsUnread } size="compact">
 					{ __( 'Mark as unread', 'jetpack-forms' ) }
 				</Button>
 			) }
@@ -135,31 +128,31 @@ export function ResponseActions( {
 	);
 
 	const trashButton = (
-		<Button onClick={ handleMoveToTrash } { ...sharedProps } isBusy={ isMovingToTrash }>
+		<Button isBusy={ isMovingToTrash } onClick={ handleMoveToTrash } size="compact">
 			{ __( 'Trash', 'jetpack-forms' ) }
 		</Button>
 	);
 
 	const spamButton = (
-		<Button onClick={ handleMarkAsSpam } { ...sharedProps } isBusy={ isMarkingAsSpam }>
+		<Button isBusy={ isMarkingAsSpam } onClick={ handleMarkAsSpam } size="compact">
 			{ __( 'Spam', 'jetpack-forms' ) }
 		</Button>
 	);
 
 	const notSpamButton = (
-		<Button onClick={ handleMarkAsNotSpam } { ...sharedProps } isBusy={ isMarkingAsNotSpam }>
+		<Button isBusy={ isMarkingAsNotSpam } onClick={ handleMarkAsNotSpam } size="compact">
 			{ __( 'Not spam', 'jetpack-forms' ) }
 		</Button>
 	);
 
 	const deleteButton = (
-		<Button onClick={ handleDelete } { ...sharedProps } isBusy={ isDeleting }>
+		<Button isBusy={ isDeleting } onClick={ handleDelete } size="compact">
 			{ __( 'Delete', 'jetpack-forms' ) }
 		</Button>
 	);
 
 	const restoreButton = (
-		<Button onClick={ handleRestore } { ...sharedProps } isBusy={ isRestoring }>
+		<Button isBusy={ isRestoring } onClick={ handleRestore } size="compact">
 			{ __( 'Restore', 'jetpack-forms' ) }
 		</Button>
 	);

--- a/projects/packages/forms/routes/responses/response/index.tsx
+++ b/projects/packages/forms/routes/responses/response/index.tsx
@@ -62,7 +62,7 @@ function SingleResponseView( {
 			}
 
 			return {
-				response: ( select( coreStore ) as unknown as SelectActions ).getEntityRecord(
+				response: select( coreStore ).getEditedEntityRecord(
 					'postType',
 					'feedback',
 					responseId

--- a/projects/packages/forms/routes/responses/stage.tsx
+++ b/projects/packages/forms/routes/responses/stage.tsx
@@ -33,7 +33,7 @@ import DataViewsHeaderRow from '../../src/dashboard/wp-build/components/dataview
 import usePageHeaderDetails from '../../src/dashboard/wp-build/hooks/use-page-header-details';
 import useConfigValue from '../../src/hooks/use-config-value';
 import { INTEGRATIONS_STORE, IntegrationsSelectors } from '../../src/store/integrations';
-import { getActions } from './actions';
+import { getRowActions } from './actions';
 import './style.scss';
 /**
  * Types
@@ -522,7 +522,7 @@ function StageInner() {
 
 	const actions = useMemo(
 		() =>
-			getActions( {
+			getRowActions( {
 				navigate,
 				searchParams,
 				view: statusView,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes FORMS-580

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Refactors the actions so we can use their callbacks directly instead of duplicating them
* Brings the implementation close to what the other dashboard does with said callbacks
* Fixes an issue with `getEntityRecord` being used when `getEditedEntityRecord` should be used instead so that the "mark as read" button updates correctly

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the wp-build dashboard and select a response
* Use the header actions
* Check that they work as expected
