### PR TITLE
Forms: prevent empty paragraphs outside form block in Form Editor

### DIFF
--- a/projects/packages/forms/changelog/fix-form-editor-prevent-empty-paragraphs
+++ b/projects/packages/forms/changelog/fix-form-editor-prevent-empty-paragraphs
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Form Editor: prevent empty paragraphs from being inserted outside form block.

--- a/projects/packages/forms/changelog/fix-form-editor-prevent-empty-paragraphs
+++ b/projects/packages/forms/changelog/fix-form-editor-prevent-empty-paragraphs
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Form Editor: prevent empty paragraphs from being inserted outside form block.
+Form Editor: Prevent empty paragraphs from being inserted outside the form block.

--- a/projects/packages/forms/src/form-editor/index.tsx
+++ b/projects/packages/forms/src/form-editor/index.tsx
@@ -17,12 +17,7 @@ import {
 	deactivateBlockCategoryOverrides,
 } from './utils/block-category-override';
 import { determineBlockNestingAction } from './utils/block-nesting-logic';
-import {
-	BlockLock,
-	findFormBlock,
-	shouldLockBlock,
-	getBlocksToMove,
-} from './utils/block-utils';
+import { BlockLock, findFormBlock, shouldLockBlock, getBlocksToMove } from './utils/block-utils';
 import {
 	moveContactFormCategoryToFront as moveCategoryToFront,
 	moveContactFormCategoryToBack as moveCategoryToBack,

--- a/projects/packages/forms/src/form-editor/index.tsx
+++ b/projects/packages/forms/src/form-editor/index.tsx
@@ -7,7 +7,9 @@
  * It also locks the form block to prevent it from being moved or removed.
  */
 
+import { createBlock, cloneBlock } from '@wordpress/blocks';
 import { subscribe, select, dispatch } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
 import { getPlugin, registerPlugin, unregisterPlugin } from '@wordpress/plugins';
 import { FORM_POST_TYPE } from '../blocks/shared/util/constants.js';
 import {
@@ -20,6 +22,7 @@ import {
 	getInsertionIndex,
 	shouldLockBlock,
 	getBlocksToMove,
+	isEmptyParagraph,
 } from './utils/block-utils';
 import {
 	moveContactFormCategoryToFront as moveCategoryToFront,
@@ -247,26 +250,80 @@ const enforceBlockNesting = () => {
 
 	// Get the form block to determine where to insert the blocks
 	const formBlock = rootBlocks.find( b => b.clientId === state.formBlockClientId );
-	const targetIndex = formBlock ? getInsertionIndex( formBlock ) : 0;
+	if ( ! formBlock ) {
+		return;
+	}
 
-	// Collect all client IDs to move
-	const clientIdsToMove = blocksToMove.map( block => block.clientId );
+	// Check if form was empty (placeholder state)
+	const wasEmpty = formBlock.innerBlocks.length === 0;
 
-	const { moveBlocksToPosition } = dispatch( 'core/block-editor' ) as {
-		moveBlocksToPosition: (
-			clientIds: string[],
-			source: string,
-			destination: string,
-			index: number
+	const { replaceInnerBlocks, removeBlocks } = dispatch( 'core/block-editor' ) as {
+		replaceInnerBlocks: (
+			rootClientId: string,
+			blocks: ReturnType< typeof createBlock >[],
+			updateSelection?: boolean
 		) => void;
+		removeBlocks: ( clientIds: string[] ) => void;
 	};
-	// Move all blocks at once to avoid state conflicts
-	moveBlocksToPosition(
-		clientIdsToMove,
-		'', // From root
-		state.formBlockClientId, // To form block
-		targetIndex
+
+	const { selectBlock } = dispatch( 'core/block-editor' ) as {
+		selectBlock: ( clientId: string ) => void;
+	};
+
+	// If the only block to move is an empty paragraph and the form already has an empty
+	// paragraph at the end (before the submit button), just select the existing one
+	if ( ! wasEmpty && blocksToMove.length === 1 && isEmptyParagraph( blocksToMove[ 0 ] ) ) {
+		// Find the last non-button block in the form
+		const lastNonButtonBlock = [ ...formBlock.innerBlocks ]
+			.reverse()
+			.find( b => b.name !== 'jetpack/button' && b.name !== 'core/button' );
+
+		if ( lastNonButtonBlock && isEmptyParagraph( lastNonButtonBlock ) ) {
+			// Just remove the stray paragraph and select the existing empty one
+			removeBlocks( [ blocksToMove[ 0 ].clientId ] );
+			selectBlock( lastNonButtonBlock.clientId );
+			return;
+		}
+	}
+
+	// Clone blocks so they have new clientIds (originals will be removed from root)
+	const clonedBlocks = blocksToMove.map( block => cloneBlock( block ) );
+
+	// Build the new inner blocks array
+	let newInnerBlocks: ReturnType< typeof createBlock >[];
+
+	if ( wasEmpty ) {
+		// Form was empty, add a submit button after the moved blocks
+		const submitButton = createBlock( 'jetpack/button', {
+			element: 'button',
+			text: __( 'Submit', 'jetpack-forms' ),
+			lock: { move: false, remove: true },
+		} );
+
+		newInnerBlocks = [ ...clonedBlocks, submitButton ];
+	} else {
+		// Form already has blocks, insert new blocks at the target index
+		const targetIndex = getInsertionIndex( formBlock );
+		const existingBlocks = [ ...formBlock.innerBlocks ];
+		existingBlocks.splice( targetIndex, 0, ...clonedBlocks );
+		newInnerBlocks = existingBlocks;
+	}
+
+	// First remove the original blocks from root level
+	const clientIdsToRemove = blocksToMove.map( block => block.clientId );
+	removeBlocks( clientIdsToRemove );
+
+	// Then use replaceInnerBlocks to set the form's inner blocks
+	replaceInnerBlocks(
+		state.formBlockClientId,
+		newInnerBlocks,
+		false // Don't update selection
 	);
+
+	// Select the first of the newly added blocks
+	if ( clonedBlocks.length > 0 ) {
+		selectBlock( clonedBlocks[ 0 ].clientId );
+	}
 };
 
 let unsubscribe: ( () => void ) | null = null;

--- a/projects/packages/forms/src/form-editor/index.tsx
+++ b/projects/packages/forms/src/form-editor/index.tsx
@@ -274,6 +274,7 @@ const enforceBlockNesting = () => {
 
 	// Handle dedupe-empty-paragraph case: just remove the stray paragraph and select the existing one
 	if ( action.type === 'dedupe-empty-paragraph' ) {
+		__unstableMarkNextChangeAsNotPersistent();
 		removeBlocks( [ blocksToMove[ 0 ].clientId ] );
 		selectBlock( action.existingEmptyParagraphId! );
 		return;

--- a/projects/packages/forms/src/form-editor/index.tsx
+++ b/projects/packages/forms/src/form-editor/index.tsx
@@ -303,12 +303,12 @@ const enforceBlockNesting = () => {
 		newInnerBlocks = existingBlocks;
 	}
 
-	// First remove the original blocks from root level (mark as non-persistent)
+	// First remove the original blocks from root level
 	const clientIdsToRemove = blocksToMove.map( block => block.clientId );
 	__unstableMarkNextChangeAsNotPersistent();
 	removeBlocks( clientIdsToRemove );
 
-	// Then use replaceInnerBlocks to set the form's inner blocks (mark as non-persistent)
+	// Then use replaceInnerBlocks to set the form's inner blocks
 	__unstableMarkNextChangeAsNotPersistent();
 	replaceInnerBlocks(
 		state.formBlockClientId,

--- a/projects/packages/forms/src/form-editor/index.tsx
+++ b/projects/packages/forms/src/form-editor/index.tsx
@@ -20,10 +20,8 @@ import { determineBlockNestingAction } from './utils/block-nesting-logic';
 import {
 	BlockLock,
 	findFormBlock,
-	getInsertionIndex,
 	shouldLockBlock,
 	getBlocksToMove,
-	isEmptyParagraph,
 } from './utils/block-utils';
 import {
 	moveContactFormCategoryToFront as moveCategoryToFront,

--- a/projects/packages/forms/src/form-editor/index.tsx
+++ b/projects/packages/forms/src/form-editor/index.tsx
@@ -24,6 +24,7 @@ import {
 	getBlocksToMove,
 	isEmptyParagraph,
 } from './utils/block-utils';
+import { determineBlockNestingAction } from './utils/block-nesting-logic';
 import {
 	moveContactFormCategoryToFront as moveCategoryToFront,
 	moveContactFormCategoryToBack as moveCategoryToBack,
@@ -254,8 +255,8 @@ const enforceBlockNesting = () => {
 		return;
 	}
 
-	// Check if form was empty (placeholder state)
-	const wasEmpty = formBlock.innerBlocks.length === 0;
+	// Determine what action to take based on form state and blocks to move
+	const action = determineBlockNestingAction( formBlock, blocksToMove );
 
 	const { replaceInnerBlocks, removeBlocks } = dispatch( 'core/block-editor' ) as {
 		replaceInnerBlocks: (
@@ -270,29 +271,20 @@ const enforceBlockNesting = () => {
 		selectBlock: ( clientId: string ) => void;
 	};
 
-	// If the only block to move is an empty paragraph and the form already has an empty
-	// paragraph at the end (before the submit button), just select the existing one
-	if ( ! wasEmpty && blocksToMove.length === 1 && isEmptyParagraph( blocksToMove[ 0 ] ) ) {
-		// Find the last non-button block in the form
-		const lastNonButtonBlock = [ ...formBlock.innerBlocks ]
-			.reverse()
-			.find( b => b.name !== 'jetpack/button' && b.name !== 'core/button' );
-
-		if ( lastNonButtonBlock && isEmptyParagraph( lastNonButtonBlock ) ) {
-			// Just remove the stray paragraph and select the existing empty one
-			removeBlocks( [ blocksToMove[ 0 ].clientId ] );
-			selectBlock( lastNonButtonBlock.clientId );
-			return;
-		}
+	// Handle dedupe-empty-paragraph case: just remove the stray paragraph and select the existing one
+	if ( action.type === 'dedupe-empty-paragraph' ) {
+		removeBlocks( [ blocksToMove[ 0 ].clientId ] );
+		selectBlock( action.existingEmptyParagraphId! );
+		return;
 	}
 
-	// Clone blocks so they have new clientIds (originals will be removed from root)
+	// Handle move-blocks case: clone blocks and insert them into the form
 	const clonedBlocks = blocksToMove.map( block => cloneBlock( block ) );
 
 	// Build the new inner blocks array
 	let newInnerBlocks: ReturnType< typeof createBlock >[];
 
-	if ( wasEmpty ) {
+	if ( action.addSubmitButton ) {
 		// Form was empty, add a submit button after the moved blocks
 		const submitButton = createBlock( 'jetpack/button', {
 			element: 'button',
@@ -303,9 +295,8 @@ const enforceBlockNesting = () => {
 		newInnerBlocks = [ ...clonedBlocks, submitButton ];
 	} else {
 		// Form already has blocks, insert new blocks at the target index
-		const targetIndex = getInsertionIndex( formBlock );
 		const existingBlocks = [ ...formBlock.innerBlocks ];
-		existingBlocks.splice( targetIndex, 0, ...clonedBlocks );
+		existingBlocks.splice( action.insertionIndex!, 0, ...clonedBlocks );
 		newInnerBlocks = existingBlocks;
 	}
 

--- a/projects/packages/forms/src/form-editor/index.tsx
+++ b/projects/packages/forms/src/form-editor/index.tsx
@@ -16,6 +16,7 @@ import {
 	activateBlockCategoryOverrides,
 	deactivateBlockCategoryOverrides,
 } from './utils/block-category-override';
+import { determineBlockNestingAction } from './utils/block-nesting-logic';
 import {
 	BlockLock,
 	findFormBlock,
@@ -24,7 +25,6 @@ import {
 	getBlocksToMove,
 	isEmptyParagraph,
 } from './utils/block-utils';
-import { determineBlockNestingAction } from './utils/block-nesting-logic';
 import {
 	moveContactFormCategoryToFront as moveCategoryToFront,
 	moveContactFormCategoryToBack as moveCategoryToBack,
@@ -258,13 +258,16 @@ const enforceBlockNesting = () => {
 	// Determine what action to take based on form state and blocks to move
 	const action = determineBlockNestingAction( formBlock, blocksToMove );
 
-	const { replaceInnerBlocks, removeBlocks } = dispatch( 'core/block-editor' ) as {
+	const { replaceInnerBlocks, removeBlocks, __unstableMarkNextChangeAsNotPersistent } = dispatch(
+		'core/block-editor'
+	) as {
 		replaceInnerBlocks: (
 			rootClientId: string,
 			blocks: ReturnType< typeof createBlock >[],
 			updateSelection?: boolean
 		) => void;
 		removeBlocks: ( clientIds: string[] ) => void;
+		__unstableMarkNextChangeAsNotPersistent: () => void;
 	};
 
 	const { selectBlock } = dispatch( 'core/block-editor' ) as {
@@ -300,11 +303,13 @@ const enforceBlockNesting = () => {
 		newInnerBlocks = existingBlocks;
 	}
 
-	// First remove the original blocks from root level
+	// First remove the original blocks from root level (mark as non-persistent)
 	const clientIdsToRemove = blocksToMove.map( block => block.clientId );
+	__unstableMarkNextChangeAsNotPersistent();
 	removeBlocks( clientIdsToRemove );
 
-	// Then use replaceInnerBlocks to set the form's inner blocks
+	// Then use replaceInnerBlocks to set the form's inner blocks (mark as non-persistent)
+	__unstableMarkNextChangeAsNotPersistent();
 	replaceInnerBlocks(
 		state.formBlockClientId,
 		newInnerBlocks,

--- a/projects/packages/forms/src/form-editor/utils/block-nesting-logic.ts
+++ b/projects/packages/forms/src/form-editor/utils/block-nesting-logic.ts
@@ -10,8 +10,8 @@
  * @package
  */
 
-import type { Block } from '@wordpress/blocks';
 import { getInsertionIndex, isEmptyParagraph } from './block-utils';
+import type { Block } from '@wordpress/blocks';
 
 export interface BlockNestingAction {
 	/**
@@ -36,8 +36,7 @@ export interface BlockNestingAction {
  * Determines what action to take when moving blocks into the form.
  *
  * This function encapsulates the decision logic for:
- * 1. Detecting when to dedupe empty paragraphs (when moving a single empty paragraph
- *    and the form already has an empty paragraph at the end)
+ * 1. Detecting when to dedupe empty paragraphs (when moving a single empty paragraph and the form already has an empty paragraph at the end)
  * 2. Detecting when to add a submit button (when the form was empty/placeholder state)
  * 3. Calculating the correct insertion index (before the submit button if one exists)
  *

--- a/projects/packages/forms/src/form-editor/utils/block-nesting-logic.ts
+++ b/projects/packages/forms/src/form-editor/utils/block-nesting-logic.ts
@@ -1,0 +1,87 @@
+/**
+ * Block nesting logic utilities
+ *
+ * Pure functions for determining how to handle blocks that need to be moved
+ * into the form. These functions contain the decision logic for:
+ * - When to dedupe empty paragraphs
+ * - When to add a submit button (empty/placeholder form state)
+ * - Where to insert blocks in the form
+ *
+ * @package
+ */
+
+import type { Block } from '@wordpress/blocks';
+import { getInsertionIndex, isEmptyParagraph } from './block-utils';
+
+export interface BlockNestingAction {
+	/**
+	 * The action to take when moving blocks into the form
+	 */
+	type: 'move-blocks' | 'dedupe-empty-paragraph';
+	/**
+	 * The index where blocks should be inserted (for move-blocks action)
+	 */
+	insertionIndex?: number;
+	/**
+	 * Whether to add a submit button after the moved blocks (for move-blocks action)
+	 */
+	addSubmitButton?: boolean;
+	/**
+	 * The clientId of the existing empty paragraph to select (for dedupe-empty-paragraph action)
+	 */
+	existingEmptyParagraphId?: string;
+}
+
+/**
+ * Determines what action to take when moving blocks into the form.
+ *
+ * This function encapsulates the decision logic for:
+ * 1. Detecting when to dedupe empty paragraphs (when moving a single empty paragraph
+ *    and the form already has an empty paragraph at the end)
+ * 2. Detecting when to add a submit button (when the form was empty/placeholder state)
+ * 3. Calculating the correct insertion index (before the submit button if one exists)
+ *
+ * @param formBlock    - The form block that will receive the moved blocks
+ * @param blocksToMove - The blocks that need to be moved into the form
+ * @return Action object describing what to do
+ */
+export function determineBlockNestingAction(
+	formBlock: Block,
+	blocksToMove: Block[]
+): BlockNestingAction {
+	const wasEmpty = formBlock.innerBlocks.length === 0;
+
+	// Check for dedupe-empty-paragraph case:
+	// If the only block to move is an empty paragraph and the form already has an empty
+	// paragraph at the end (before the submit button), just select the existing one
+	if ( ! wasEmpty && blocksToMove.length === 1 && isEmptyParagraph( blocksToMove[ 0 ] ) ) {
+		// Find the last non-button block in the form
+		const lastNonButtonBlock = [ ...formBlock.innerBlocks ]
+			.reverse()
+			.find( b => b.name !== 'jetpack/button' && b.name !== 'core/button' );
+
+		if ( lastNonButtonBlock && isEmptyParagraph( lastNonButtonBlock ) ) {
+			return {
+				type: 'dedupe-empty-paragraph',
+				existingEmptyParagraphId: lastNonButtonBlock.clientId,
+			};
+		}
+	}
+
+	// Move blocks case
+	if ( wasEmpty ) {
+		// Form was empty (placeholder state), add a submit button after the moved blocks
+		return {
+			type: 'move-blocks',
+			insertionIndex: 0,
+			addSubmitButton: true,
+		};
+	}
+
+	// Form already has blocks, insert new blocks at the target index (before submit button if exists)
+	return {
+		type: 'move-blocks',
+		insertionIndex: getInsertionIndex( formBlock ),
+		addSubmitButton: false,
+	};
+}

--- a/projects/packages/forms/src/form-editor/utils/block-utils.ts
+++ b/projects/packages/forms/src/form-editor/utils/block-utils.ts
@@ -72,3 +72,47 @@ export function shouldLockBlock( block: Block ): boolean {
 export function getBlocksToMove( blocks: Block[], formBlockClientId: string ): Block[] {
 	return blocks.filter( block => block.clientId !== formBlockClientId );
 }
+
+/**
+ * Checks if a block is an empty paragraph.
+ *
+ * Handles various content types: undefined, null, empty string, empty object {},
+ * and RichText value objects with a toString() method.
+ *
+ * @param block                    - The block to check
+ * @param block.name               - The block name
+ * @param block.attributes         - The block attributes
+ * @param block.attributes.content - The paragraph content
+ * @return True if the block is an empty paragraph
+ */
+export function isEmptyParagraph( block: {
+	name: string;
+	attributes?: { content?: unknown };
+} ): boolean {
+	if ( block.name !== 'core/paragraph' ) {
+		return false;
+	}
+	const content = block.attributes?.content;
+	// Handle: undefined, null
+	if ( content === undefined || content === null ) {
+		return true;
+	}
+	// Handle string content
+	if ( typeof content === 'string' ) {
+		return content === '';
+	}
+	// Handle object content (RichText or empty object)
+	if ( typeof content === 'object' ) {
+		// Check for empty plain object {} first
+		if ( Object.keys( content ).length === 0 ) {
+			return true;
+		}
+		// RichText objects have a custom toString() method that returns the text content
+		// Check if toString returns something other than the default "[object Object]"
+		const textContent = String( content );
+		if ( textContent !== '[object Object]' ) {
+			return textContent === '';
+		}
+	}
+	return false;
+}

--- a/projects/packages/forms/tests/js/form-editor/utils/block-nesting-logic.test.js
+++ b/projects/packages/forms/tests/js/form-editor/utils/block-nesting-logic.test.js
@@ -465,7 +465,7 @@ describe( 'block-nesting-logic', () => {
 				};
 
 				const blocksToMove = [
-					// @ts-expect-error - Testing malformed block
+					// Testing malformed block
 					{ clientId: 'malformed-1' },
 				];
 

--- a/projects/packages/forms/tests/js/form-editor/utils/block-nesting-logic.test.js
+++ b/projects/packages/forms/tests/js/form-editor/utils/block-nesting-logic.test.js
@@ -461,9 +461,7 @@ describe( 'block-nesting-logic', () => {
 				const formBlock = {
 					name: 'jetpack/contact-form',
 					clientId: 'form-1',
-					innerBlocks: [
-						{ name: 'jetpack/field-email', clientId: 'email-1', innerBlocks: [] },
-					],
+					innerBlocks: [ { name: 'jetpack/field-email', clientId: 'email-1', innerBlocks: [] } ],
 				};
 
 				const blocksToMove = [
@@ -480,12 +478,10 @@ describe( 'block-nesting-logic', () => {
 				const formBlock = {
 					name: 'jetpack/contact-form',
 					clientId: 'form-1',
-					innerBlocks: [
-						{ name: 'jetpack/field-email', clientId: 'email-1', innerBlocks: [] },
-					],
+					innerBlocks: [ { name: 'jetpack/field-email', clientId: 'email-1', innerBlocks: [] } ],
 				};
 
-				const blocksToMove: unknown[] = [];
+				const blocksToMove = [];
 
 				const result = determineBlockNestingAction( formBlock, blocksToMove );
 

--- a/projects/packages/forms/tests/js/form-editor/utils/block-nesting-logic.test.js
+++ b/projects/packages/forms/tests/js/form-editor/utils/block-nesting-logic.test.js
@@ -1,0 +1,496 @@
+/**
+ * Tests for block-nesting-logic
+ *
+ * These tests verify the pure function that determines what action to take
+ * when moving blocks into the form. Covers:
+ * - Empty form (placeholder state) -> add submit button
+ * - Dedupe empty paragraph logic
+ * - Correct insertion index calculation when submit button exists
+ */
+
+import { determineBlockNestingAction } from '../../../../src/form-editor/utils/block-nesting-logic';
+
+describe( 'block-nesting-logic', () => {
+	describe( 'determineBlockNestingAction', () => {
+		describe( 'empty form (placeholder state)', () => {
+			test( 'should add submit button when form is empty', () => {
+				const formBlock = {
+					name: 'jetpack/contact-form',
+					clientId: 'form-1',
+					innerBlocks: [],
+				};
+
+				const blocksToMove = [
+					{ name: 'jetpack/field-email', clientId: 'email-1', innerBlocks: [] },
+				];
+
+				const result = determineBlockNestingAction( formBlock, blocksToMove );
+
+				expect( result ).toEqual( {
+					type: 'move-blocks',
+					insertionIndex: 0,
+					addSubmitButton: true,
+				} );
+			} );
+
+			test( 'should add submit button when moving multiple blocks into empty form', () => {
+				const formBlock = {
+					name: 'jetpack/contact-form',
+					clientId: 'form-1',
+					innerBlocks: [],
+				};
+
+				const blocksToMove = [
+					{ name: 'jetpack/field-email', clientId: 'email-1', innerBlocks: [] },
+					{ name: 'jetpack/field-text', clientId: 'text-1', innerBlocks: [] },
+					{ name: 'core/paragraph', clientId: 'para-1', innerBlocks: [], attributes: {} },
+				];
+
+				const result = determineBlockNestingAction( formBlock, blocksToMove );
+
+				expect( result ).toEqual( {
+					type: 'move-blocks',
+					insertionIndex: 0,
+					addSubmitButton: true,
+				} );
+			} );
+
+			test( 'should add submit button when moving empty paragraph into empty form', () => {
+				const formBlock = {
+					name: 'jetpack/contact-form',
+					clientId: 'form-1',
+					innerBlocks: [],
+				};
+
+				const blocksToMove = [
+					{
+						name: 'core/paragraph',
+						clientId: 'para-1',
+						innerBlocks: [],
+						attributes: { content: '' },
+					},
+				];
+
+				const result = determineBlockNestingAction( formBlock, blocksToMove );
+
+				expect( result ).toEqual( {
+					type: 'move-blocks',
+					insertionIndex: 0,
+					addSubmitButton: true,
+				} );
+			} );
+		} );
+
+		describe( 'dedupe empty paragraph', () => {
+			test( 'should dedupe when moving single empty paragraph and form has one at end', () => {
+				const formBlock = {
+					name: 'jetpack/contact-form',
+					clientId: 'form-1',
+					innerBlocks: [
+						{ name: 'jetpack/field-email', clientId: 'email-1', innerBlocks: [] },
+						{
+							name: 'core/paragraph',
+							clientId: 'existing-para',
+							innerBlocks: [],
+							attributes: { content: '' },
+						},
+						{ name: 'jetpack/button', clientId: 'button-1', innerBlocks: [] },
+					],
+				};
+
+				const blocksToMove = [
+					{
+						name: 'core/paragraph',
+						clientId: 'new-para',
+						innerBlocks: [],
+						attributes: { content: '' },
+					},
+				];
+
+				const result = determineBlockNestingAction( formBlock, blocksToMove );
+
+				expect( result ).toEqual( {
+					type: 'dedupe-empty-paragraph',
+					existingEmptyParagraphId: 'existing-para',
+				} );
+			} );
+
+			test( 'should dedupe when form has empty paragraph with no button', () => {
+				const formBlock = {
+					name: 'jetpack/contact-form',
+					clientId: 'form-1',
+					innerBlocks: [
+						{ name: 'jetpack/field-email', clientId: 'email-1', innerBlocks: [] },
+						{
+							name: 'core/paragraph',
+							clientId: 'existing-para',
+							innerBlocks: [],
+							attributes: { content: '' },
+						},
+					],
+				};
+
+				const blocksToMove = [
+					{
+						name: 'core/paragraph',
+						clientId: 'new-para',
+						innerBlocks: [],
+						attributes: { content: '' },
+					},
+				];
+
+				const result = determineBlockNestingAction( formBlock, blocksToMove );
+
+				expect( result ).toEqual( {
+					type: 'dedupe-empty-paragraph',
+					existingEmptyParagraphId: 'existing-para',
+				} );
+			} );
+
+			test( 'should dedupe with empty paragraph object content', () => {
+				const formBlock = {
+					name: 'jetpack/contact-form',
+					clientId: 'form-1',
+					innerBlocks: [
+						{ name: 'jetpack/field-text', clientId: 'text-1', innerBlocks: [] },
+						{
+							name: 'core/paragraph',
+							clientId: 'existing-para',
+							innerBlocks: [],
+							attributes: { content: {} },
+						},
+					],
+				};
+
+				const blocksToMove = [
+					{
+						name: 'core/paragraph',
+						clientId: 'new-para',
+						innerBlocks: [],
+						attributes: { content: {} },
+					},
+				];
+
+				const result = determineBlockNestingAction( formBlock, blocksToMove );
+
+				expect( result ).toEqual( {
+					type: 'dedupe-empty-paragraph',
+					existingEmptyParagraphId: 'existing-para',
+				} );
+			} );
+
+			test( 'should not dedupe when moving multiple blocks including empty paragraph', () => {
+				const formBlock = {
+					name: 'jetpack/contact-form',
+					clientId: 'form-1',
+					innerBlocks: [
+						{ name: 'jetpack/field-email', clientId: 'email-1', innerBlocks: [] },
+						{
+							name: 'core/paragraph',
+							clientId: 'existing-para',
+							innerBlocks: [],
+							attributes: { content: '' },
+						},
+						{ name: 'jetpack/button', clientId: 'button-1', innerBlocks: [] },
+					],
+				};
+
+				const blocksToMove = [
+					{ name: 'jetpack/field-text', clientId: 'text-1', innerBlocks: [] },
+					{
+						name: 'core/paragraph',
+						clientId: 'new-para',
+						innerBlocks: [],
+						attributes: { content: '' },
+					},
+				];
+
+				const result = determineBlockNestingAction( formBlock, blocksToMove );
+
+				expect( result.type ).toBe( 'move-blocks' );
+			} );
+
+			test( 'should not dedupe when moving non-empty paragraph', () => {
+				const formBlock = {
+					name: 'jetpack/contact-form',
+					clientId: 'form-1',
+					innerBlocks: [
+						{ name: 'jetpack/field-email', clientId: 'email-1', innerBlocks: [] },
+						{
+							name: 'core/paragraph',
+							clientId: 'existing-para',
+							innerBlocks: [],
+							attributes: { content: '' },
+						},
+						{ name: 'jetpack/button', clientId: 'button-1', innerBlocks: [] },
+					],
+				};
+
+				const blocksToMove = [
+					{
+						name: 'core/paragraph',
+						clientId: 'new-para',
+						innerBlocks: [],
+						attributes: { content: 'Some text' },
+					},
+				];
+
+				const result = determineBlockNestingAction( formBlock, blocksToMove );
+
+				expect( result.type ).toBe( 'move-blocks' );
+			} );
+
+			test( 'should not dedupe when form has no empty paragraph at end', () => {
+				const formBlock = {
+					name: 'jetpack/contact-form',
+					clientId: 'form-1',
+					innerBlocks: [
+						{ name: 'jetpack/field-email', clientId: 'email-1', innerBlocks: [] },
+						{
+							name: 'core/paragraph',
+							clientId: 'para-with-text',
+							innerBlocks: [],
+							attributes: { content: 'Not empty' },
+						},
+						{ name: 'jetpack/button', clientId: 'button-1', innerBlocks: [] },
+					],
+				};
+
+				const blocksToMove = [
+					{
+						name: 'core/paragraph',
+						clientId: 'new-para',
+						innerBlocks: [],
+						attributes: { content: '' },
+					},
+				];
+
+				const result = determineBlockNestingAction( formBlock, blocksToMove );
+
+				expect( result.type ).toBe( 'move-blocks' );
+			} );
+
+			test( 'should find empty paragraph before button, not button itself', () => {
+				const formBlock = {
+					name: 'jetpack/contact-form',
+					clientId: 'form-1',
+					innerBlocks: [
+						{ name: 'jetpack/field-email', clientId: 'email-1', innerBlocks: [] },
+						{
+							name: 'core/paragraph',
+							clientId: 'existing-para',
+							innerBlocks: [],
+							attributes: { content: '' },
+						},
+						{ name: 'jetpack/button', clientId: 'button-1', innerBlocks: [] },
+					],
+				};
+
+				const blocksToMove = [
+					{
+						name: 'core/paragraph',
+						clientId: 'new-para',
+						innerBlocks: [],
+						attributes: {},
+					},
+				];
+
+				const result = determineBlockNestingAction( formBlock, blocksToMove );
+
+				expect( result ).toEqual( {
+					type: 'dedupe-empty-paragraph',
+					existingEmptyParagraphId: 'existing-para',
+				} );
+			} );
+
+			test( 'should handle core/button instead of jetpack/button', () => {
+				const formBlock = {
+					name: 'jetpack/contact-form',
+					clientId: 'form-1',
+					innerBlocks: [
+						{ name: 'jetpack/field-email', clientId: 'email-1', innerBlocks: [] },
+						{
+							name: 'core/paragraph',
+							clientId: 'existing-para',
+							innerBlocks: [],
+							attributes: { content: '' },
+						},
+						{ name: 'core/button', clientId: 'button-1', innerBlocks: [] },
+					],
+				};
+
+				const blocksToMove = [
+					{
+						name: 'core/paragraph',
+						clientId: 'new-para',
+						innerBlocks: [],
+						attributes: { content: '' },
+					},
+				];
+
+				const result = determineBlockNestingAction( formBlock, blocksToMove );
+
+				expect( result ).toEqual( {
+					type: 'dedupe-empty-paragraph',
+					existingEmptyParagraphId: 'existing-para',
+				} );
+			} );
+		} );
+
+		describe( 'insertion index with submit button', () => {
+			test( 'should insert before jetpack/button when it exists', () => {
+				const formBlock = {
+					name: 'jetpack/contact-form',
+					clientId: 'form-1',
+					innerBlocks: [
+						{ name: 'jetpack/field-email', clientId: 'email-1', innerBlocks: [] },
+						{ name: 'jetpack/field-text', clientId: 'text-1', innerBlocks: [] },
+						{ name: 'jetpack/button', clientId: 'button-1', innerBlocks: [] },
+					],
+				};
+
+				const blocksToMove = [
+					{ name: 'jetpack/field-name', clientId: 'name-1', innerBlocks: [] },
+				];
+
+				const result = determineBlockNestingAction( formBlock, blocksToMove );
+
+				expect( result ).toEqual( {
+					type: 'move-blocks',
+					insertionIndex: 2, // Before button at index 2
+					addSubmitButton: false,
+				} );
+			} );
+
+			test( 'should insert before core/button when it exists', () => {
+				const formBlock = {
+					name: 'jetpack/contact-form',
+					clientId: 'form-1',
+					innerBlocks: [
+						{ name: 'jetpack/field-email', clientId: 'email-1', innerBlocks: [] },
+						{ name: 'core/button', clientId: 'button-1', innerBlocks: [] },
+					],
+				};
+
+				const blocksToMove = [
+					{ name: 'jetpack/field-text', clientId: 'text-1', innerBlocks: [] },
+				];
+
+				const result = determineBlockNestingAction( formBlock, blocksToMove );
+
+				expect( result ).toEqual( {
+					type: 'move-blocks',
+					insertionIndex: 1, // Before button at index 1
+					addSubmitButton: false,
+				} );
+			} );
+
+			test( 'should insert at end when no button exists', () => {
+				const formBlock = {
+					name: 'jetpack/contact-form',
+					clientId: 'form-1',
+					innerBlocks: [
+						{ name: 'jetpack/field-email', clientId: 'email-1', innerBlocks: [] },
+						{ name: 'jetpack/field-text', clientId: 'text-1', innerBlocks: [] },
+					],
+				};
+
+				const blocksToMove = [
+					{ name: 'jetpack/field-name', clientId: 'name-1', innerBlocks: [] },
+				];
+
+				const result = determineBlockNestingAction( formBlock, blocksToMove );
+
+				expect( result ).toEqual( {
+					type: 'move-blocks',
+					insertionIndex: 2, // At the end
+					addSubmitButton: false,
+				} );
+			} );
+
+			test( 'should insert before first button when multiple buttons exist', () => {
+				const formBlock = {
+					name: 'jetpack/contact-form',
+					clientId: 'form-1',
+					innerBlocks: [
+						{ name: 'jetpack/field-email', clientId: 'email-1', innerBlocks: [] },
+						{ name: 'jetpack/button', clientId: 'button-1', innerBlocks: [] },
+						{ name: 'core/button', clientId: 'button-2', innerBlocks: [] },
+					],
+				};
+
+				const blocksToMove = [
+					{ name: 'jetpack/field-text', clientId: 'text-1', innerBlocks: [] },
+				];
+
+				const result = determineBlockNestingAction( formBlock, blocksToMove );
+
+				expect( result ).toEqual( {
+					type: 'move-blocks',
+					insertionIndex: 1, // Before first button
+					addSubmitButton: false,
+				} );
+			} );
+
+			test( 'should handle button at the beginning', () => {
+				const formBlock = {
+					name: 'jetpack/contact-form',
+					clientId: 'form-1',
+					innerBlocks: [
+						{ name: 'jetpack/button', clientId: 'button-1', innerBlocks: [] },
+						{ name: 'jetpack/field-email', clientId: 'email-1', innerBlocks: [] },
+					],
+				};
+
+				const blocksToMove = [
+					{ name: 'jetpack/field-text', clientId: 'text-1', innerBlocks: [] },
+				];
+
+				const result = determineBlockNestingAction( formBlock, blocksToMove );
+
+				expect( result ).toEqual( {
+					type: 'move-blocks',
+					insertionIndex: 0, // Before button at beginning
+					addSubmitButton: false,
+				} );
+			} );
+		} );
+
+		describe( 'edge cases', () => {
+			test( 'should not crash with malformed blocks', () => {
+				const formBlock = {
+					name: 'jetpack/contact-form',
+					clientId: 'form-1',
+					innerBlocks: [
+						{ name: 'jetpack/field-email', clientId: 'email-1', innerBlocks: [] },
+					],
+				};
+
+				const blocksToMove = [
+					// @ts-expect-error - Testing malformed block
+					{ clientId: 'malformed-1' },
+				];
+
+				const result = determineBlockNestingAction( formBlock, blocksToMove );
+
+				expect( result.type ).toBe( 'move-blocks' );
+			} );
+
+			test( 'should handle empty blocksToMove array', () => {
+				const formBlock = {
+					name: 'jetpack/contact-form',
+					clientId: 'form-1',
+					innerBlocks: [
+						{ name: 'jetpack/field-email', clientId: 'email-1', innerBlocks: [] },
+					],
+				};
+
+				const blocksToMove: unknown[] = [];
+
+				const result = determineBlockNestingAction( formBlock, blocksToMove );
+
+				expect( result.type ).toBe( 'move-blocks' );
+			} );
+		} );
+	} );
+} );

--- a/projects/packages/forms/tests/js/form-editor/utils/block-utils.test.js
+++ b/projects/packages/forms/tests/js/form-editor/utils/block-utils.test.js
@@ -9,6 +9,7 @@ import {
 	getInsertionIndex,
 	shouldLockBlock,
 	getBlocksToMove,
+	isEmptyParagraph,
 } from '../../../../src/form-editor/utils/block-utils';
 
 describe( 'block-utils', () => {
@@ -481,6 +482,78 @@ describe( 'block-utils', () => {
 
 			expect( result ).toHaveLength( 1 );
 			expect( result[ 0 ].clientId ).toBe( 'para-1' );
+		} );
+	} );
+
+	describe( 'isEmptyParagraph', () => {
+		test( 'returns false for non-paragraph blocks', () => {
+			const block = { name: 'core/heading', attributes: { content: '' } };
+			expect( isEmptyParagraph( block ) ).toBe( false );
+		} );
+
+		test( 'returns false for jetpack blocks', () => {
+			const block = { name: 'jetpack/field-text', attributes: {} };
+			expect( isEmptyParagraph( block ) ).toBe( false );
+		} );
+
+		test( 'returns true when content is undefined', () => {
+			const block = { name: 'core/paragraph', attributes: {} };
+			expect( isEmptyParagraph( block ) ).toBe( true );
+		} );
+
+		test( 'returns true when attributes is undefined', () => {
+			const block = { name: 'core/paragraph' };
+			expect( isEmptyParagraph( block ) ).toBe( true );
+		} );
+
+		test( 'returns true when content is null', () => {
+			const block = { name: 'core/paragraph', attributes: { content: null } };
+			expect( isEmptyParagraph( block ) ).toBe( true );
+		} );
+
+		test( 'returns true when content is empty string', () => {
+			const block = { name: 'core/paragraph', attributes: { content: '' } };
+			expect( isEmptyParagraph( block ) ).toBe( true );
+		} );
+
+		test( 'returns false when content is non-empty string', () => {
+			const block = { name: 'core/paragraph', attributes: { content: 'Hello world' } };
+			expect( isEmptyParagraph( block ) ).toBe( false );
+		} );
+
+		test( 'returns false when content is whitespace-only string', () => {
+			const block = { name: 'core/paragraph', attributes: { content: '   ' } };
+			expect( isEmptyParagraph( block ) ).toBe( false );
+		} );
+
+		test( 'returns true when content is empty object {}', () => {
+			const block = { name: 'core/paragraph', attributes: { content: {} } };
+			expect( isEmptyParagraph( block ) ).toBe( true );
+		} );
+
+		test( 'returns false when content is object with toString returning non-empty', () => {
+			const richTextValue = {
+				toString() {
+					return 'Some content';
+				},
+			};
+			const block = { name: 'core/paragraph', attributes: { content: richTextValue } };
+			expect( isEmptyParagraph( block ) ).toBe( false );
+		} );
+
+		test( 'returns true when content is object with toString returning empty', () => {
+			const emptyRichTextValue = {
+				toString() {
+					return '';
+				},
+			};
+			const block = { name: 'core/paragraph', attributes: { content: emptyRichTextValue } };
+			expect( isEmptyParagraph( block ) ).toBe( true );
+		} );
+
+		test( 'returns false for paragraph with HTML content', () => {
+			const block = { name: 'core/paragraph', attributes: { content: '<strong>Bold</strong>' } };
+			expect( isEmptyParagraph( block ) ).toBe( false );
 		} );
 	} );
 } );


### PR DESCRIPTION
## Proposed changes:

When editing a `jetpack_form` post type, clicking outside the form block (especially when in placeholder/variation picker state) would cause WordPress to insert a paragraph block as a sibling to the form. This PR fixes that behavior by:

- Using `replaceInnerBlocks` instead of `moveBlocksToPosition` (which doesn't work when the form has no InnerBlocks component rendered in placeholder state)
- Cloning blocks before moving them to avoid reference issues
- Adding a submit button automatically when the form was empty (placeholder state) and blocks are moved in
- Detecting when an empty paragraph already exists in the form and selecting it instead of adding duplicates
- Selecting newly added blocks for better UX

Also adds the `isEmptyParagraph()` utility function to detect empty paragraph blocks, handling various content types including RichText value objects.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

1. Go to wp-admin and create a new Form (Jetpack > Form Responses > Add New Form, or navigate to `/wp-admin/post-new.php?post_type=jetpack_form`)
2. You should see the form block in placeholder state showing the variation picker (e.g., "Contact Form", "Newsletter Sign-up", etc.)
3. Click outside/below the form block in the empty editor area
4. **Expected behavior**: The paragraph block that WordPress creates should be moved inside the form, a Submit button should be added, and the paragraph should be selected
5. Type some content in the paragraph
6. Click outside the form again
7. **Expected behavior**: A new empty paragraph should be added inside the form and selected
8. Click outside the form again (without typing anything)
9. **Expected behavior**: The existing empty paragraph should be selected (no duplicate empty paragraphs)
10. Verify undo works correctly to get back to the placeholder state

🤖 Generated with [Claude Code](https://claude.ai/code)