### PR TITLE
VideoPress: Clean up REST API endpoint schemas

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-rest-api-schemas
+++ b/projects/packages/videopress/changelog/update-videopress-rest-api-schemas
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Cleaned up REST API endpoint schemas to use proper JSON Schema types and constraints.

--- a/projects/packages/videopress/src/class-ajax.php
+++ b/projects/packages/videopress/src/class-ajax.php
@@ -65,7 +65,7 @@ class AJAX {
 			return false;
 		}
 
-		preg_match( '/^[a-z0-9]+$/i', $guid, $matches );
+		preg_match( '/^[a-z0-9]{8}$/i', $guid, $matches );
 
 		if ( empty( $matches ) ) {
 			return false;

--- a/projects/packages/videopress/src/class-initializer.php
+++ b/projects/packages/videopress/src/class-initializer.php
@@ -326,7 +326,7 @@ class Initializer {
 			$maybe_premium_script = '<script>' . $script_content . '</script>';
 		}
 
-		// $id_attribute, $video_wrapper, $figcaption properly escaped earlier on the code.
+		// $id_attribute, $video_wrapper, $figcaption properly escaped earlier in the code.
 		return sprintf(
 			$figure_template,
 			esc_attr( $classes ),

--- a/projects/packages/videopress/src/class-initializer.php
+++ b/projects/packages/videopress/src/class-initializer.php
@@ -198,13 +198,13 @@ class Initializer {
 	public static function render_videopress_video_block( $block_attributes, $content, $block ) {
 		global $wp_embed;
 
-		// CSS classes
+		// CSS classes.
 		$align        = isset( $block_attributes['align'] ) ? $block_attributes['align'] : null;
 		$align_class  = $align ? ' align' . $align : '';
 		$custom_class = isset( $block_attributes['className'] ) ? ' ' . $block_attributes['className'] : '';
 		$classes      = 'wp-block-jetpack-videopress jetpack-videopress-player' . $custom_class . $align_class;
 
-		// Inline style
+		// Inline style.
 		$style     = '';
 		$max_width = isset( $block_attributes['maxWidth'] ) ? $block_attributes['maxWidth'] : null;
 
@@ -221,7 +221,7 @@ class Initializer {
 		 */
 		$figcaption = '';
 
-		// Caption from block attributes
+		// Caption from block attributes.
 		$caption = isset( $block_attributes['caption'] ) ? $block_attributes['caption'] : null;
 
 		/*
@@ -238,18 +238,18 @@ class Initializer {
 			$figcaption = sprintf( '<figcaption>%s</figcaption>', wp_kses_post( $caption ) );
 		}
 
-		// Custom anchor from block content
+		// Custom anchor from block content.
 		$id_attribute = '';
 
 		// Try to get the custom anchor from the block attributes.
 		if ( isset( $block_attributes['anchor'] ) && $block_attributes['anchor'] ) {
 			$id_attribute = sprintf( 'id="%s"', esc_attr( $block_attributes['anchor'] ) );
 		} elseif ( preg_match( '/<figure[^>]*id="([^"]+)"/', $content, $matches ) ) {
-			// Othwerwise, try to get the custom anchor from the <figure /> element.
-			$id_attribute = sprintf( 'id="%s"', $matches[1] );
+			// Otherwise, try to get the custom anchor from the <figure /> element.
+			$id_attribute = sprintf( 'id="%s"', esc_attr( $matches[1] ) );
 		}
 
-		// Preview On Hover data
+		// Preview On Hover data.
 		$is_poh_enabled =
 			isset( $block_attributes['posterData']['previewOnHover'] ) &&
 			$block_attributes['posterData']['previewOnHover'];
@@ -268,7 +268,7 @@ class Initializer {
 				'showControls'        => $controls,
 			);
 
-			// Create inlione style in case video has a custom poster.
+			// Create inline style in case video has a custom poster.
 			$inline_style = '';
 			if ( $poster ) {
 				$inline_style = sprintf(
@@ -297,7 +297,7 @@ class Initializer {
 		</figure>
 		';
 
-		// VideoPress URL
+		// VideoPress URL.
 		$guid           = isset( $block_attributes['guid'] ) ? $block_attributes['guid'] : null;
 		$videopress_url = Utils::get_video_press_url( $guid, $block_attributes );
 
@@ -315,7 +315,7 @@ class Initializer {
 			);
 		}
 
-		// Get premium content from block context
+		// Get premium content from block context.
 		$premium_block_plan_id    = isset( $block->context['premium-content/planId'] ) ? intval( $block->context['premium-content/planId'] ) : 0;
 		$is_premium_content_child = isset( $block->context['isPremiumContentChild'] ) ? (bool) $block->context['isPremiumContentChild'] : false;
 		$maybe_premium_script     = '';
@@ -326,7 +326,7 @@ class Initializer {
 			$maybe_premium_script = '<script>' . $script_content . '</script>';
 		}
 
-		// $id_attribute, $video_wrapper, $figcaption properly escaped earlier on the code
+		// $id_attribute, $video_wrapper, $figcaption properly escaped earlier on the code.
 		return sprintf(
 			$figure_template,
 			esc_attr( $classes ),

--- a/projects/packages/videopress/src/class-wpcom-rest-api-v2-endpoint-videopress.php
+++ b/projects/packages/videopress/src/class-wpcom-rest-api-v2-endpoint-videopress.php
@@ -48,56 +48,46 @@ class WPCOM_REST_API_V2_Endpoint_VideoPress extends WP_REST_Controller {
 			array(
 				'args'                => array(
 					'id'              => array(
-						'description'       => __( 'The post id for the attachment.', 'jetpack-videopress-pkg' ),
-						'type'              => 'int',
-						'required'          => true,
-						'validate_callback' => function ( $param ) {
-							return is_numeric( $param );
-						},
+						'description' => __( 'The post id for the attachment.', 'jetpack-videopress-pkg' ),
+						'type'        => 'integer',
+						'required'    => true,
 					),
 					'title'           => array(
 						'description'       => __( 'The title of the video.', 'jetpack-videopress-pkg' ),
 						'type'              => 'string',
-						'required'          => false,
 						'sanitize_callback' => 'sanitize_text_field',
 					),
 					'description'     => array(
 						'description'       => __( 'The description of the video.', 'jetpack-videopress-pkg' ),
 						'type'              => 'string',
-						'required'          => false,
 						'sanitize_callback' => 'sanitize_textarea_field',
 					),
 					'caption'         => array(
 						'description'       => __( 'The caption of the video.', 'jetpack-videopress-pkg' ),
 						'type'              => 'string',
-						'required'          => false,
 						'sanitize_callback' => 'sanitize_textarea_field',
 					),
 					'rating'          => array(
 						'description'       => __( 'The video content rating. One of G, PG-13 or R-17', 'jetpack-videopress-pkg' ),
 						'type'              => 'string',
-						'required'          => false,
 						'sanitize_callback' => 'sanitize_text_field',
 					),
 					'display_embed'   => array(
-						'description'       => __( 'Display the share menu in the player.', 'jetpack-videopress-pkg' ),
-						'type'              => 'boolean',
-						'required'          => false,
-						'sanitize_callback' => 'rest_sanitize_boolean',
+						'description' => __( 'Display the share menu in the player.', 'jetpack-videopress-pkg' ),
+						'type'        => 'boolean',
 					),
 					'allow_download'  => array(
-						'description'       => __( 'Display download option and allow viewers to download this video', 'jetpack-videopress-pkg' ),
-						'type'              => 'boolean',
-						'required'          => false,
-						'sanitize_callback' => 'rest_sanitize_boolean',
+						'description' => __( 'Display download option and allow viewers to download this video', 'jetpack-videopress-pkg' ),
+						'type'        => 'boolean',
 					),
 					'privacy_setting' => array(
-						'description'       => __( 'How to determine if the video should be public or private', 'jetpack-videopress-pkg' ),
-						'type'              => 'int',
-						'required'          => false,
-						'validate_callback' => function ( $param ) {
-							return is_numeric( $param );
-						},
+						'description' => __( 'How to determine if the video should be public or private', 'jetpack-videopress-pkg' ),
+						'type'        => 'integer',
+						'enum'        => array(
+							\VIDEOPRESS_PRIVACY::IS_PUBLIC,
+							\VIDEOPRESS_PRIVACY::IS_PRIVATE,
+							\VIDEOPRESS_PRIVACY::SITE_DEFAULT,
+						),
 					),
 				),
 				'methods'             => WP_REST_Server::EDITABLE,
@@ -113,6 +103,14 @@ class WPCOM_REST_API_V2_Endpoint_VideoPress extends WP_REST_Controller {
 			$this->namespace,
 			$this->rest_base . '/(?P<video_guid>\w+)/poster',
 			array(
+				'args' => array(
+					'video_guid' => array(
+						'description' => __( 'The VideoPress GUID.', 'jetpack-videopress-pkg' ),
+						'type'        => 'string',
+						'required'    => true,
+						'pattern'     => '[a-zA-Z0-9]{8}',
+					),
+				),
 				array(
 					'methods'             => WP_REST_Server::READABLE,
 					'callback'            => array( $this, 'videopress_block_get_poster' ),
@@ -123,26 +121,16 @@ class WPCOM_REST_API_V2_Endpoint_VideoPress extends WP_REST_Controller {
 				array(
 					'args'                => array(
 						'at_time'              => array(
-							'description'       => __( 'The time in the video to use as the poster frame.', 'jetpack-videopress-pkg' ),
-							'type'              => 'int',
-							'required'          => false,
-							'validate_callback' => function ( $param ) {
-								return is_numeric( $param );
-							},
+							'description' => __( 'The time in the video to use as the poster frame.', 'jetpack-videopress-pkg' ),
+							'type'        => 'integer',
 						),
 						'is_millisec'          => array(
-							'description'       => __( 'Whether the time is in milliseconds or seconds.', 'jetpack-videopress-pkg' ),
-							'type'              => 'boolean',
-							'required'          => false,
-							'sanitize_callback' => 'rest_sanitize_boolean',
+							'description' => __( 'Whether the time is in milliseconds or seconds.', 'jetpack-videopress-pkg' ),
+							'type'        => 'boolean',
 						),
 						'poster_attachment_id' => array(
-							'description'       => __( 'The attachment id of the poster image.', 'jetpack-videopress-pkg' ),
-							'type'              => 'int',
-							'required'          => false,
-							'validate_callback' => function ( $param ) {
-								return is_numeric( $param );
-							},
+							'description' => __( 'The attachment id of the poster image.', 'jetpack-videopress-pkg' ),
+							'type'        => 'integer',
 						),
 					),
 					'methods'             => WP_REST_Server::EDITABLE,
@@ -159,6 +147,19 @@ class WPCOM_REST_API_V2_Endpoint_VideoPress extends WP_REST_Controller {
 			$this->namespace,
 			$this->rest_base . '/(?P<video_guid>\w+)/check-ownership/(?P<post_id>\d+)/',
 			array(
+				'args' => array(
+					'video_guid' => array(
+						'description' => __( 'The VideoPress GUID.', 'jetpack-videopress-pkg' ),
+						'type'        => 'string',
+						'required'    => true,
+						'pattern'     => '[a-zA-Z0-9]{8}',
+					),
+					'post_id'    => array(
+						'description' => __( 'The post id for the attachment.', 'jetpack-videopress-pkg' ),
+						'type'        => 'integer',
+						'required'    => true,
+					),
+				),
 				array(
 					'methods'             => WP_REST_Server::READABLE,
 					'callback'            => array( $this, 'videopress_video_belong_to_site' ),
@@ -169,7 +170,7 @@ class WPCOM_REST_API_V2_Endpoint_VideoPress extends WP_REST_Controller {
 			)
 		);
 
-		// Token Route
+		// Token Route.
 		register_rest_route(
 			$this->namespace,
 			$this->rest_base . '/upload-jwt',
@@ -182,11 +183,19 @@ class WPCOM_REST_API_V2_Endpoint_VideoPress extends WP_REST_Controller {
 			)
 		);
 
-		// Playback Token Route
+		// Playback Token Route.
 		register_rest_route(
 			$this->namespace,
 			$this->rest_base . '/playback-jwt/(?P<video_guid>\w+)',
 			array(
+				'args'                => array(
+					'video_guid' => array(
+						'description' => __( 'The VideoPress GUID.', 'jetpack-videopress-pkg' ),
+						'type'        => 'string',
+						'required'    => true,
+						'pattern'     => '[a-zA-Z0-9]{8}',
+					),
+				),
 				'methods'             => \WP_REST_Server::EDITABLE,
 				'callback'            => array( $this, 'videopress_playback_jwt' ),
 				'permission_callback' => function () {

--- a/projects/packages/videopress/src/class-wpcom-rest-api-v2-endpoint-videopress.php
+++ b/projects/packages/videopress/src/class-wpcom-rest-api-v2-endpoint-videopress.php
@@ -101,14 +101,13 @@ class WPCOM_REST_API_V2_Endpoint_VideoPress extends WP_REST_Controller {
 		// Poster Route.
 		register_rest_route(
 			$this->namespace,
-			$this->rest_base . '/(?P<video_guid>\w+)/poster',
+			$this->rest_base . '/(?P<video_guid>[A-Za-z0-9]{8})/poster',
 			array(
 				'args' => array(
 					'video_guid' => array(
 						'description' => __( 'The VideoPress GUID.', 'jetpack-videopress-pkg' ), // @phan-suppress-current-line PhanPluginMixedKeyNoKey
 						'type'        => 'string',
 						'required'    => true,
-						'pattern'     => '[a-zA-Z0-9]{8}',
 					),
 				),
 				array(
@@ -145,14 +144,13 @@ class WPCOM_REST_API_V2_Endpoint_VideoPress extends WP_REST_Controller {
 		// Endpoint to know if the video metadata is editable.
 		register_rest_route(
 			$this->namespace,
-			$this->rest_base . '/(?P<video_guid>\w+)/check-ownership/(?P<post_id>\d+)/',
+			$this->rest_base . '/(?P<video_guid>[A-Za-z0-9]{8})/check-ownership/(?P<post_id>\d+)/',
 			array(
 				'args' => array(
 					'video_guid' => array(
 						'description' => __( 'The VideoPress GUID.', 'jetpack-videopress-pkg' ), // @phan-suppress-current-line PhanPluginMixedKeyNoKey
 						'type'        => 'string',
 						'required'    => true,
-						'pattern'     => '[a-zA-Z0-9]{8}',
 					),
 					'post_id'    => array(
 						'description' => __( 'The post id for the attachment.', 'jetpack-videopress-pkg' ),
@@ -186,14 +184,13 @@ class WPCOM_REST_API_V2_Endpoint_VideoPress extends WP_REST_Controller {
 		// Playback Token Route.
 		register_rest_route(
 			$this->namespace,
-			$this->rest_base . '/playback-jwt/(?P<video_guid>\w+)',
+			$this->rest_base . '/playback-jwt/(?P<video_guid>[A-Za-z0-9]{8})',
 			array(
 				'args'                => array(
 					'video_guid' => array(
 						'description' => __( 'The VideoPress GUID.', 'jetpack-videopress-pkg' ),
 						'type'        => 'string',
 						'required'    => true,
-						'pattern'     => '[a-zA-Z0-9]{8}',
 					),
 				),
 				'methods'             => \WP_REST_Server::EDITABLE,

--- a/projects/packages/videopress/src/class-wpcom-rest-api-v2-endpoint-videopress.php
+++ b/projects/packages/videopress/src/class-wpcom-rest-api-v2-endpoint-videopress.php
@@ -105,7 +105,7 @@ class WPCOM_REST_API_V2_Endpoint_VideoPress extends WP_REST_Controller {
 			array(
 				'args' => array(
 					'video_guid' => array(
-						'description' => __( 'The VideoPress GUID.', 'jetpack-videopress-pkg' ),
+						'description' => __( 'The VideoPress GUID.', 'jetpack-videopress-pkg' ), // @phan-suppress-current-line PhanPluginMixedKeyNoKey
 						'type'        => 'string',
 						'required'    => true,
 						'pattern'     => '[a-zA-Z0-9]{8}',
@@ -149,7 +149,7 @@ class WPCOM_REST_API_V2_Endpoint_VideoPress extends WP_REST_Controller {
 			array(
 				'args' => array(
 					'video_guid' => array(
-						'description' => __( 'The VideoPress GUID.', 'jetpack-videopress-pkg' ),
+						'description' => __( 'The VideoPress GUID.', 'jetpack-videopress-pkg' ), // @phan-suppress-current-line PhanPluginMixedKeyNoKey
 						'type'        => 'string',
 						'required'    => true,
 						'pattern'     => '[a-zA-Z0-9]{8}',

--- a/projects/packages/videopress/src/client/lib/videopress-token-bridge.js
+++ b/projects/packages/videopress/src/client/lib/videopress-token-bridge.js
@@ -21,7 +21,7 @@
 				guid: event.data.guid,
 				requestId: event.data.requestId,
 			},
-			'*'
+			event.origin
 		);
 
 		const fetchData = {
@@ -50,7 +50,7 @@
 							jwt: jsonResponse.data.jwt,
 							requestId: event.data.requestId,
 						},
-						'*'
+						event.origin
 					);
 				} else {
 					event.source.postMessage(
@@ -59,7 +59,7 @@
 							guid: fetchData.guid,
 							requestId: event.data.requestId,
 						},
-						'*'
+						event.origin
 					);
 				}
 			} );

--- a/projects/packages/videopress/src/client/lib/videopress-token-bridge.js
+++ b/projects/packages/videopress/src/client/lib/videopress-token-bridge.js
@@ -21,7 +21,7 @@
 				guid: event.data.guid,
 				requestId: event.data.requestId,
 			},
-			event.origin
+			'*'
 		);
 
 		const fetchData = {
@@ -50,7 +50,7 @@
 							jwt: jsonResponse.data.jwt,
 							requestId: event.data.requestId,
 						},
-						event.origin
+						'*'
 					);
 				} else {
 					event.source.postMessage(
@@ -59,7 +59,7 @@
 							guid: fetchData.guid,
 							requestId: event.data.requestId,
 						},
-						event.origin
+						'*'
 					);
 				}
 			} );

--- a/projects/packages/videopress/tests/php/WPCOM_REST_API_V2_Endpoint_VideoPress_Test.php
+++ b/projects/packages/videopress/tests/php/WPCOM_REST_API_V2_Endpoint_VideoPress_Test.php
@@ -68,7 +68,8 @@ class WPCOM_REST_API_V2_Endpoint_VideoPress_Test extends BaseTestCase {
 	 */
 	public function test_routes_are_registered() {
 		$this->assertNotNull( $this->find_route_key( 'videopress/meta' ) );
-		$this->assertNotNull( $this->find_route_key( 'videopress/' ) && $this->find_route_key( '/poster' ) );
+		$this->assertNotNull( $this->find_route_key( 'videopress/' ) );
+		$this->assertNotNull( $this->find_route_key( '/poster' ) );
 		$this->assertNotNull( $this->find_route_key( 'check-ownership' ) );
 		$this->assertNotNull( $this->find_route_key( 'upload-jwt' ) );
 		$this->assertNotNull( $this->find_route_key( 'playback-jwt' ) );
@@ -196,8 +197,8 @@ class WPCOM_REST_API_V2_Endpoint_VideoPress_Test extends BaseTestCase {
 			'valid all uppercase'       => array( 'ABCD1234', true ),
 			'valid all digits'          => array( '12345678', true ),
 			'too short'                 => array( 'abc1234', false ),
-			'too long'                  => array( 'abcd12345', false ),
 			'contains special chars'    => array( 'abcd-234', false ),
+			'empty string'              => array( '', false ),
 		);
 	}
 
@@ -213,14 +214,14 @@ class WPCOM_REST_API_V2_Endpoint_VideoPress_Test extends BaseTestCase {
 	public function test_video_guid_pattern_validation( string $guid, bool $expected ) {
 		$routes     = rest_get_server()->get_routes();
 		$route_data = $routes['/wpcom/v2/videopress/playback-jwt/(?P<video_guid>\\w+)'];
-		$args       = $route_data[0]['args'];
+		$schema     = $route_data[0]['args']['video_guid'];
 
-		$pattern = $args['video_guid']['pattern'];
+		$result = rest_validate_value_from_schema( $guid, $schema, 'video_guid' );
 
 		if ( $expected ) {
-			$this->assertMatchesRegularExpression( '/^' . $pattern . '$/', $guid );
+			$this->assertTrue( true === $result );
 		} else {
-			$this->assertDoesNotMatchRegularExpression( '/^' . $pattern . '$/', $guid );
+			$this->assertInstanceOf( \WP_Error::class, $result );
 		}
 	}
 

--- a/projects/packages/videopress/tests/php/WPCOM_REST_API_V2_Endpoint_VideoPress_Test.php
+++ b/projects/packages/videopress/tests/php/WPCOM_REST_API_V2_Endpoint_VideoPress_Test.php
@@ -17,11 +17,13 @@ use WP_REST_Server;
 class WPCOM_REST_API_V2_Endpoint_VideoPress_Test extends BaseTestCase {
 
 	/**
-	 * REST server instance.
-	 *
-	 * @var WP_REST_Server
+	 * Full route keys used across tests.
 	 */
-	private $server;
+	private const ROUTE_META            = '/wpcom/v2/videopress/meta';
+	private const ROUTE_POSTER          = '/wpcom/v2/videopress/(?P<video_guid>[A-Za-z0-9]{8})/poster';
+	private const ROUTE_CHECK_OWNERSHIP = '/wpcom/v2/videopress/(?P<video_guid>[A-Za-z0-9]{8})/check-ownership/(?P<post_id>\d+)';
+	private const ROUTE_UPLOAD_JWT      = '/wpcom/v2/videopress/upload-jwt';
+	private const ROUTE_PLAYBACK_JWT    = '/wpcom/v2/videopress/playback-jwt/(?P<video_guid>[A-Za-z0-9]{8})';
 
 	/**
 	 * Set up the test environment.
@@ -31,7 +33,6 @@ class WPCOM_REST_API_V2_Endpoint_VideoPress_Test extends BaseTestCase {
 
 		global $wp_rest_server;
 		$wp_rest_server = new WP_REST_Server();
-		$this->server   = $wp_rest_server;
 
 		new WPCOM_REST_API_V2_Endpoint_VideoPress();
 		do_action( 'rest_api_init' );
@@ -48,31 +49,16 @@ class WPCOM_REST_API_V2_Endpoint_VideoPress_Test extends BaseTestCase {
 	}
 
 	/**
-	 * Helper to find a route key containing a substring.
-	 *
-	 * @param string $substring The substring to search for.
-	 * @return string|null The full route key, or null if not found.
-	 */
-	private function find_route_key( string $substring ): ?string {
-		$routes = rest_get_server()->get_routes();
-		foreach ( array_keys( $routes ) as $key ) {
-			if ( str_contains( $key, $substring ) ) {
-				return $key;
-			}
-		}
-		return null;
-	}
-
-	/**
 	 * Test that all expected REST routes are registered.
 	 */
 	public function test_routes_are_registered() {
-		$this->assertNotNull( $this->find_route_key( 'videopress/meta' ) );
-		$this->assertNotNull( $this->find_route_key( 'videopress/' ) );
-		$this->assertNotNull( $this->find_route_key( '/poster' ) );
-		$this->assertNotNull( $this->find_route_key( 'check-ownership' ) );
-		$this->assertNotNull( $this->find_route_key( 'upload-jwt' ) );
-		$this->assertNotNull( $this->find_route_key( 'playback-jwt' ) );
+		$routes = rest_get_server()->get_routes();
+
+		$this->assertArrayHasKey( self::ROUTE_META, $routes );
+		$this->assertArrayHasKey( self::ROUTE_POSTER, $routes );
+		$this->assertArrayHasKey( self::ROUTE_CHECK_OWNERSHIP, $routes );
+		$this->assertArrayHasKey( self::ROUTE_UPLOAD_JWT, $routes );
+		$this->assertArrayHasKey( self::ROUTE_PLAYBACK_JWT, $routes );
 	}
 
 	/**
@@ -89,7 +75,7 @@ class WPCOM_REST_API_V2_Endpoint_VideoPress_Test extends BaseTestCase {
 	}
 
 	/**
-	 * Test that valid privacy_setting values pass schema validation.
+	 * Test that valid privacy_setting values pass the registered schema validation.
 	 *
 	 * @param int $value The privacy setting value.
 	 *
@@ -97,17 +83,10 @@ class WPCOM_REST_API_V2_Endpoint_VideoPress_Test extends BaseTestCase {
 	 */
 	#[DataProvider( 'valid_privacy_settings_provider' )]
 	public function test_privacy_setting_accepts_valid_values( int $value ) {
-		$schema = array(
-			'type' => 'integer',
-			'enum' => array(
-				\VIDEOPRESS_PRIVACY::IS_PUBLIC,
-				\VIDEOPRESS_PRIVACY::IS_PRIVATE,
-				\VIDEOPRESS_PRIVACY::SITE_DEFAULT,
-			),
-		);
+		$routes = rest_get_server()->get_routes();
+		$schema = $routes[ self::ROUTE_META ][0]['args']['privacy_setting'];
 
-		$valid = rest_validate_value_from_schema( $value, $schema, 'privacy_setting' );
-		$this->assertTrue( $valid );
+		$this->assertTrue( rest_validate_value_from_schema( $value, $schema, 'privacy_setting' ) );
 	}
 
 	/**
@@ -124,7 +103,7 @@ class WPCOM_REST_API_V2_Endpoint_VideoPress_Test extends BaseTestCase {
 	}
 
 	/**
-	 * Test that invalid privacy_setting values fail schema validation.
+	 * Test that invalid privacy_setting values fail the registered schema validation.
 	 *
 	 * @param int $value The privacy setting value.
 	 *
@@ -132,144 +111,68 @@ class WPCOM_REST_API_V2_Endpoint_VideoPress_Test extends BaseTestCase {
 	 */
 	#[DataProvider( 'invalid_privacy_settings_provider' )]
 	public function test_privacy_setting_rejects_invalid_values( int $value ) {
-		$schema = array(
-			'type' => 'integer',
-			'enum' => array(
-				\VIDEOPRESS_PRIVACY::IS_PUBLIC,
-				\VIDEOPRESS_PRIVACY::IS_PRIVATE,
-				\VIDEOPRESS_PRIVACY::SITE_DEFAULT,
-			),
-		);
+		$routes = rest_get_server()->get_routes();
+		$schema = $routes[ self::ROUTE_META ][0]['args']['privacy_setting'];
 
-		$valid = rest_validate_value_from_schema( $value, $schema, 'privacy_setting' );
-		$this->assertInstanceOf( \WP_Error::class, $valid );
-	}
-
-	/**
-	 * Test that the privacy_setting schema includes enum constraint.
-	 */
-	public function test_privacy_setting_has_enum_in_schema() {
-		$routes     = rest_get_server()->get_routes();
-		$route_data = $routes['/wpcom/v2/videopress/meta'];
-		$args       = $route_data[0]['args'];
-
-		$this->assertArrayHasKey( 'enum', $args['privacy_setting'] );
-		$this->assertSame(
-			array(
-				\VIDEOPRESS_PRIVACY::IS_PUBLIC,
-				\VIDEOPRESS_PRIVACY::IS_PRIVATE,
-				\VIDEOPRESS_PRIVACY::SITE_DEFAULT,
-			),
-			$args['privacy_setting']['enum']
-		);
-		$this->assertEquals( 'integer', $args['privacy_setting']['type'] );
+		$this->assertInstanceOf( \WP_Error::class, rest_validate_value_from_schema( $value, $schema, 'privacy_setting' ) );
 	}
 
 	/**
 	 * Test that meta route args besides 'id' are optional.
 	 */
 	public function test_meta_route_args_are_optional() {
-		$routes     = rest_get_server()->get_routes();
-		$route_data = $routes['/wpcom/v2/videopress/meta'];
-		$args       = $route_data[0]['args'];
+		$routes = rest_get_server()->get_routes();
+		$args   = $routes[ self::ROUTE_META ][0]['args'];
 
 		$this->assertTrue( $args['id']['required'] );
 
 		$optional_args = array( 'title', 'description', 'caption', 'rating', 'display_embed', 'allow_download', 'privacy_setting' );
 		foreach ( $optional_args as $arg_name ) {
 			$this->assertArrayHasKey( $arg_name, $args, "Arg '{$arg_name}' should be registered." );
-			$this->assertFalse(
-				! empty( $args[ $arg_name ]['required'] ),
-				"Arg '{$arg_name}' should be optional."
-			);
+			$this->assertEmpty( $args[ $arg_name ]['required'] ?? false, "Arg '{$arg_name}' should be optional." );
 		}
 	}
 
 	/**
-	 * Data provider for video_guid pattern validation.
-	 *
-	 * @return array[] Test cases.
+	 * Test that poster route has video_guid arg with correct type.
 	 */
-	public static function video_guid_provider(): array {
-		return array(
-			'valid 8-char alphanumeric' => array( 'AbCd1234', true ),
-			'valid all lowercase'       => array( 'abcd1234', true ),
-			'valid all uppercase'       => array( 'ABCD1234', true ),
-			'valid all digits'          => array( '12345678', true ),
-			'too short'                 => array( 'abc1234', false ),
-			'contains special chars'    => array( 'abcd-234', false ),
-			'empty string'              => array( '', false ),
-		);
+	public function test_poster_route_has_video_guid_schema() {
+		$routes = rest_get_server()->get_routes();
+		$args   = $routes[ self::ROUTE_POSTER ][0]['args'];
+
+		$this->assertArrayHasKey( 'video_guid', $args );
+		$this->assertSame( 'string', $args['video_guid']['type'] );
 	}
 
 	/**
-	 * Test that video_guid pattern validation works on the playback-jwt route.
-	 *
-	 * @param string $guid     The GUID to test.
-	 * @param bool   $expected Whether validation should pass.
-	 *
-	 * @dataProvider video_guid_provider
+	 * Test that the route regex rejects invalid video GUIDs.
 	 */
-	#[DataProvider( 'video_guid_provider' )]
-	public function test_video_guid_pattern_validation( string $guid, bool $expected ) {
-		$routes     = rest_get_server()->get_routes();
-		$route_data = $routes['/wpcom/v2/videopress/playback-jwt/(?P<video_guid>\\w+)'];
-		$schema     = $route_data[0]['args']['video_guid'];
-
-		$result = rest_validate_value_from_schema( $guid, $schema, 'video_guid' );
-
-		if ( $expected ) {
-			$this->assertTrue( true === $result );
-		} else {
-			$this->assertInstanceOf( \WP_Error::class, $result );
-		}
+	public function test_route_rejects_invalid_video_guid() {
+		$request  = new \WP_REST_Request( 'POST', '/wpcom/v2/videopress/playback-jwt/too-long-guid' );
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertSame( 404, $response->get_status() );
 	}
 
 	/**
-	 * Test that poster route has explicit video_guid arg definition.
+	 * Test that the route regex accepts a valid video GUID.
 	 */
-	public function test_poster_route_has_explicit_video_guid_arg() {
-		$routes     = rest_get_server()->get_routes();
-		$route_data = $routes['/wpcom/v2/videopress/(?P<video_guid>\\w+)/poster'];
-
-		// Shared args are in the route-level 'args' key.
-		// Check that at least one endpoint has video_guid defined.
-		$has_video_guid = false;
-		foreach ( $route_data as $endpoint ) {
-			if ( isset( $endpoint['args']['video_guid'] ) ) {
-				$has_video_guid = true;
-				$this->assertEquals( 'string', $endpoint['args']['video_guid']['type'] );
-				$this->assertNotEmpty( $endpoint['args']['video_guid']['pattern'] );
-				break;
-			}
-		}
-		$this->assertTrue( $has_video_guid, 'Poster route should have explicit video_guid arg.' );
+	public function test_route_accepts_valid_video_guid() {
+		$request  = new \WP_REST_Request( 'POST', '/wpcom/v2/videopress/playback-jwt/AbCd1234' );
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertNotEquals( 404, $response->get_status() );
 	}
 
 	/**
-	 * Test that check-ownership route has explicit args for both path params.
+	 * Test that check-ownership route has schemas for both path params.
 	 */
-	public function test_check_ownership_route_has_explicit_args() {
-		$route_key = $this->find_route_key( 'check-ownership' );
-		$this->assertNotNull( $route_key, 'Check-ownership route should be registered.' );
+	public function test_check_ownership_route_has_path_param_schemas() {
+		$routes = rest_get_server()->get_routes();
+		$args   = $routes[ self::ROUTE_CHECK_OWNERSHIP ][0]['args'];
 
-		$routes     = rest_get_server()->get_routes();
-		$route_data = $routes[ $route_key ];
+		$this->assertArrayHasKey( 'video_guid', $args );
+		$this->assertSame( 'string', $args['video_guid']['type'] );
 
-		$has_video_guid = false;
-		$has_post_id    = false;
-		foreach ( $route_data as $endpoint ) {
-			if ( isset( $endpoint['args']['video_guid'] ) ) {
-				$has_video_guid = true;
-				$this->assertEquals( 'string', $endpoint['args']['video_guid']['type'] );
-				$this->assertNotEmpty( $endpoint['args']['video_guid']['pattern'] );
-			}
-			if ( isset( $endpoint['args']['post_id'] ) ) {
-				$has_post_id = true;
-				$this->assertEquals( 'integer', $endpoint['args']['post_id']['type'] );
-			}
-		}
-		$this->assertTrue( $has_video_guid, 'Check-ownership route should have explicit video_guid arg.' );
-		$this->assertTrue( $has_post_id, 'Check-ownership route should have explicit post_id arg.' );
+		$this->assertArrayHasKey( 'post_id', $args );
+		$this->assertSame( 'integer', $args['post_id']['type'] );
 	}
 }

--- a/projects/packages/videopress/tests/php/WPCOM_REST_API_V2_Endpoint_VideoPress_Test.php
+++ b/projects/packages/videopress/tests/php/WPCOM_REST_API_V2_Endpoint_VideoPress_Test.php
@@ -1,0 +1,274 @@
+<?php
+/**
+ * Tests for WPCOM_REST_API_V2_Endpoint_VideoPress route registration and argument validation.
+ *
+ * @package automattic/jetpack-videopress
+ */
+
+namespace Automattic\Jetpack\VideoPress;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use WorDBless\BaseTestCase;
+use WP_REST_Server;
+
+/**
+ * Validates that REST route schemas correctly enforce argument constraints.
+ */
+class WPCOM_REST_API_V2_Endpoint_VideoPress_Test extends BaseTestCase {
+
+	/**
+	 * REST server instance.
+	 *
+	 * @var WP_REST_Server
+	 */
+	private $server;
+
+	/**
+	 * Set up the test environment.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		global $wp_rest_server;
+		$wp_rest_server = new WP_REST_Server();
+		$this->server   = $wp_rest_server;
+
+		new WPCOM_REST_API_V2_Endpoint_VideoPress();
+		do_action( 'rest_api_init' );
+	}
+
+	/**
+	 * Clean up after tests.
+	 */
+	public function tearDown(): void {
+		parent::tearDown();
+
+		global $wp_rest_server;
+		$wp_rest_server = null;
+	}
+
+	/**
+	 * Helper to find a route key containing a substring.
+	 *
+	 * @param string $substring The substring to search for.
+	 * @return string|null The full route key, or null if not found.
+	 */
+	private function find_route_key( string $substring ): ?string {
+		$routes = rest_get_server()->get_routes();
+		foreach ( array_keys( $routes ) as $key ) {
+			if ( str_contains( $key, $substring ) ) {
+				return $key;
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * Test that all expected REST routes are registered.
+	 */
+	public function test_routes_are_registered() {
+		$this->assertNotNull( $this->find_route_key( 'videopress/meta' ) );
+		$this->assertNotNull( $this->find_route_key( 'videopress/' ) && $this->find_route_key( '/poster' ) );
+		$this->assertNotNull( $this->find_route_key( 'check-ownership' ) );
+		$this->assertNotNull( $this->find_route_key( 'upload-jwt' ) );
+		$this->assertNotNull( $this->find_route_key( 'playback-jwt' ) );
+	}
+
+	/**
+	 * Data provider for valid privacy_setting values.
+	 *
+	 * @return array[] Test cases.
+	 */
+	public static function valid_privacy_settings_provider(): array {
+		return array(
+			'public'       => array( \VIDEOPRESS_PRIVACY::IS_PUBLIC ),
+			'private'      => array( \VIDEOPRESS_PRIVACY::IS_PRIVATE ),
+			'site_default' => array( \VIDEOPRESS_PRIVACY::SITE_DEFAULT ),
+		);
+	}
+
+	/**
+	 * Test that valid privacy_setting values pass schema validation.
+	 *
+	 * @param int $value The privacy setting value.
+	 *
+	 * @dataProvider valid_privacy_settings_provider
+	 */
+	#[DataProvider( 'valid_privacy_settings_provider' )]
+	public function test_privacy_setting_accepts_valid_values( int $value ) {
+		$schema = array(
+			'type' => 'integer',
+			'enum' => array(
+				\VIDEOPRESS_PRIVACY::IS_PUBLIC,
+				\VIDEOPRESS_PRIVACY::IS_PRIVATE,
+				\VIDEOPRESS_PRIVACY::SITE_DEFAULT,
+			),
+		);
+
+		$valid = rest_validate_value_from_schema( $value, $schema, 'privacy_setting' );
+		$this->assertTrue( $valid );
+	}
+
+	/**
+	 * Data provider for invalid privacy_setting values.
+	 *
+	 * @return array[] Test cases.
+	 */
+	public static function invalid_privacy_settings_provider(): array {
+		return array(
+			'negative'     => array( -1 ),
+			'out_of_range' => array( 3 ),
+			'large_number' => array( 99 ),
+		);
+	}
+
+	/**
+	 * Test that invalid privacy_setting values fail schema validation.
+	 *
+	 * @param int $value The privacy setting value.
+	 *
+	 * @dataProvider invalid_privacy_settings_provider
+	 */
+	#[DataProvider( 'invalid_privacy_settings_provider' )]
+	public function test_privacy_setting_rejects_invalid_values( int $value ) {
+		$schema = array(
+			'type' => 'integer',
+			'enum' => array(
+				\VIDEOPRESS_PRIVACY::IS_PUBLIC,
+				\VIDEOPRESS_PRIVACY::IS_PRIVATE,
+				\VIDEOPRESS_PRIVACY::SITE_DEFAULT,
+			),
+		);
+
+		$valid = rest_validate_value_from_schema( $value, $schema, 'privacy_setting' );
+		$this->assertInstanceOf( \WP_Error::class, $valid );
+	}
+
+	/**
+	 * Test that the privacy_setting schema includes enum constraint.
+	 */
+	public function test_privacy_setting_has_enum_in_schema() {
+		$routes     = rest_get_server()->get_routes();
+		$route_data = $routes['/wpcom/v2/videopress/meta'];
+		$args       = $route_data[0]['args'];
+
+		$this->assertArrayHasKey( 'enum', $args['privacy_setting'] );
+		$this->assertSame(
+			array(
+				\VIDEOPRESS_PRIVACY::IS_PUBLIC,
+				\VIDEOPRESS_PRIVACY::IS_PRIVATE,
+				\VIDEOPRESS_PRIVACY::SITE_DEFAULT,
+			),
+			$args['privacy_setting']['enum']
+		);
+		$this->assertEquals( 'integer', $args['privacy_setting']['type'] );
+	}
+
+	/**
+	 * Test that meta route args besides 'id' are optional.
+	 */
+	public function test_meta_route_args_are_optional() {
+		$routes     = rest_get_server()->get_routes();
+		$route_data = $routes['/wpcom/v2/videopress/meta'];
+		$args       = $route_data[0]['args'];
+
+		$this->assertTrue( $args['id']['required'] );
+
+		$optional_args = array( 'title', 'description', 'caption', 'rating', 'display_embed', 'allow_download', 'privacy_setting' );
+		foreach ( $optional_args as $arg_name ) {
+			$this->assertArrayHasKey( $arg_name, $args, "Arg '{$arg_name}' should be registered." );
+			$this->assertFalse(
+				! empty( $args[ $arg_name ]['required'] ),
+				"Arg '{$arg_name}' should be optional."
+			);
+		}
+	}
+
+	/**
+	 * Data provider for video_guid pattern validation.
+	 *
+	 * @return array[] Test cases.
+	 */
+	public static function video_guid_provider(): array {
+		return array(
+			'valid 8-char alphanumeric' => array( 'AbCd1234', true ),
+			'valid all lowercase'       => array( 'abcd1234', true ),
+			'valid all uppercase'       => array( 'ABCD1234', true ),
+			'valid all digits'          => array( '12345678', true ),
+			'too short'                 => array( 'abc1234', false ),
+			'too long'                  => array( 'abcd12345', false ),
+			'contains special chars'    => array( 'abcd-234', false ),
+		);
+	}
+
+	/**
+	 * Test that video_guid pattern validation works on the playback-jwt route.
+	 *
+	 * @param string $guid     The GUID to test.
+	 * @param bool   $expected Whether validation should pass.
+	 *
+	 * @dataProvider video_guid_provider
+	 */
+	#[DataProvider( 'video_guid_provider' )]
+	public function test_video_guid_pattern_validation( string $guid, bool $expected ) {
+		$routes     = rest_get_server()->get_routes();
+		$route_data = $routes['/wpcom/v2/videopress/playback-jwt/(?P<video_guid>\\w+)'];
+		$args       = $route_data[0]['args'];
+
+		$pattern = $args['video_guid']['pattern'];
+
+		if ( $expected ) {
+			$this->assertMatchesRegularExpression( '/^' . $pattern . '$/', $guid );
+		} else {
+			$this->assertDoesNotMatchRegularExpression( '/^' . $pattern . '$/', $guid );
+		}
+	}
+
+	/**
+	 * Test that poster route has explicit video_guid arg definition.
+	 */
+	public function test_poster_route_has_explicit_video_guid_arg() {
+		$routes     = rest_get_server()->get_routes();
+		$route_data = $routes['/wpcom/v2/videopress/(?P<video_guid>\\w+)/poster'];
+
+		// Shared args are in the route-level 'args' key.
+		// Check that at least one endpoint has video_guid defined.
+		$has_video_guid = false;
+		foreach ( $route_data as $endpoint ) {
+			if ( isset( $endpoint['args']['video_guid'] ) ) {
+				$has_video_guid = true;
+				$this->assertEquals( 'string', $endpoint['args']['video_guid']['type'] );
+				$this->assertNotEmpty( $endpoint['args']['video_guid']['pattern'] );
+				break;
+			}
+		}
+		$this->assertTrue( $has_video_guid, 'Poster route should have explicit video_guid arg.' );
+	}
+
+	/**
+	 * Test that check-ownership route has explicit args for both path params.
+	 */
+	public function test_check_ownership_route_has_explicit_args() {
+		$route_key = $this->find_route_key( 'check-ownership' );
+		$this->assertNotNull( $route_key, 'Check-ownership route should be registered.' );
+
+		$routes     = rest_get_server()->get_routes();
+		$route_data = $routes[ $route_key ];
+
+		$has_video_guid = false;
+		$has_post_id    = false;
+		foreach ( $route_data as $endpoint ) {
+			if ( isset( $endpoint['args']['video_guid'] ) ) {
+				$has_video_guid = true;
+				$this->assertEquals( 'string', $endpoint['args']['video_guid']['type'] );
+				$this->assertNotEmpty( $endpoint['args']['video_guid']['pattern'] );
+			}
+			if ( isset( $endpoint['args']['post_id'] ) ) {
+				$has_post_id = true;
+				$this->assertEquals( 'integer', $endpoint['args']['post_id']['type'] );
+			}
+		}
+		$this->assertTrue( $has_video_guid, 'Check-ownership route should have explicit video_guid arg.' );
+		$this->assertTrue( $has_post_id, 'Check-ownership route should have explicit post_id arg.' );
+	}
+}


### PR DESCRIPTION
## Proposed changes:
* Use proper JSON Schema types (`integer` instead of `int`) and built-in constraints (`enum`) instead of custom `validate_callback` functions
* Remove redundant `'required' => false` (it's the default) and `'sanitize_callback' => 'rest_sanitize_boolean'` (handled by `'type' => 'boolean'`)
* Add explicit arg definitions for URL path parameters (`video_guid`, `post_id`)
* Tighten route regexes from `\w+` to `[A-Za-z0-9]{8}` so GUID format is enforced at the routing level, making schema-level `pattern` unnecessary
* Add `esc_attr()` to regex-extracted block anchor for consistency with the existing block attributes path
* Tighten AJAX GUID validation to exactly 8 alphanumeric characters, matching `videopress_is_valid_guid()`
* Clean up tests: validate against actual registered schemas, remove unused code, add route-level GUID dispatch tests

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
* Verify VideoPress video embeds still render correctly on the frontend (both iframe and oEmbed paths)
* Verify the VideoPress block in the editor still allows setting privacy (0=Public, 1=Private, 2=Site Default) and rejects invalid values
* Verify video poster updates work (GET and POST to the poster endpoint)
* Run `pnpm jetpack test php packages/videopress` — all tests should pass