### PR TITLE
Forms: hide "new form" button for specific form's responses

### DIFF
--- a/projects/packages/forms/changelog/update-forms-hide-new-button
+++ b/projects/packages/forms/changelog/update-forms-hide-new-button
@@ -1,4 +1,4 @@
 Significance: minor
 Type: changed
 
-Forms: hide 'new form' button for form response page at new wp-build dashboard.
+Dashboard: Hide "New form" button on form responses page.

--- a/projects/packages/forms/changelog/update-forms-hide-new-button
+++ b/projects/packages/forms/changelog/update-forms-hide-new-button
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Forms: hide 'new form' button for form response page at new wp-build dashboard.

--- a/projects/packages/forms/routes/responses/stage.tsx
+++ b/projects/packages/forms/routes/responses/stage.tsx
@@ -580,9 +580,10 @@ function StageInner() {
 			<DataViews
 				empty={
 					<EmptyResponses
-						status={ statusView }
 						isSearch={ !! view.search }
+						isSingleFormView={ isSingleFormView }
 						readStatusFilter={ readStatusFilter }
+						status={ statusView }
 					/>
 				}
 				data={ records || EMPTY_ARRAY }

--- a/projects/packages/forms/src/dashboard/components/empty-responses/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/empty-responses/index.tsx
@@ -38,9 +38,10 @@ type UseInstallAkismetReturn = {
 };
 
 type EmptyResponsesProps = {
-	status: string;
 	isSearch: boolean;
+	isSingleFormView?: boolean;
 	readStatusFilter?: 'unread' | 'read';
+	status: string;
 };
 
 type EmptyWrapperProps = {
@@ -163,7 +164,12 @@ export const EmptyWrapper = ( { heading = '', body = '', actions = null }: Empty
 	</VStack>
 );
 
-const EmptyResponses = ( { status, isSearch, readStatusFilter }: EmptyResponsesProps ) => {
+const EmptyResponses = ( {
+	isSearch,
+	isSingleFormView = false,
+	readStatusFilter,
+	status,
+}: EmptyResponsesProps ) => {
 	const emptyTrashDays = useConfigValue( 'emptyTrashDays' ) ?? 0;
 	const {
 		shouldShowAkismetCta,
@@ -240,7 +246,12 @@ const EmptyResponses = ( { status, isSearch, readStatusFilter }: EmptyResponsesP
 				'jetpack-forms'
 			) }
 			actions={
-				<CreateFormButton label={ __( 'Create a new form', 'jetpack-forms' ) } variant="primary" />
+				! isSingleFormView && (
+					<CreateFormButton
+						label={ __( 'Create a new form', 'jetpack-forms' ) }
+						variant="primary"
+					/>
+				)
 			}
 		/>
 	);

--- a/projects/packages/forms/src/dashboard/inbox/stage/index.js
+++ b/projects/packages/forms/src/dashboard/inbox/stage/index.js
@@ -651,6 +651,7 @@ export default function InboxView( { parentId, pageTitle, pageSubtitle } = {} ) 
 					<EmptyResponses
 						status={ statusFilter }
 						isSearch={ !! view.search }
+						isSingleFormView={ isSingleFormView }
 						readStatusFilter={ readStatusFilter }
 					/>
 				}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Hides "new form" button when looking at specific form's responses at wp-build dashboard: the form is already created.

Before
<img width="1704" height="1192" alt="Screenshot 2026-02-09 at 11 10 08" src="https://github.com/user-attachments/assets/44761ec3-8199-4a64-9fce-bf69535dead0" />


After
<img width="1710" height="1203" alt="Screenshot 2026-02-09 at 12 02 59" src="https://github.com/user-attachments/assets/4f32ea56-302b-4e03-9358-46ae852a4634" />


On "all responses" view the button remains:
<img width="1659" height="1179" alt="Screenshot 2026-02-09 at 11 08 08" src="https://github.com/user-attachments/assets/1b68f4ab-76cc-4cfc-a40c-90c0172deb96" />


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Enable new WP build dashboard with `add_filter('jetpack_forms_alpha', '__return_true');`
* Create a new form
* Look at responses 
