### PR TITLE
Forms: move "integration enabled" tooltip copy to backend

### DIFF
--- a/projects/packages/forms/changelog/update-forms-integrations-editor-tooltips
+++ b/projects/packages/forms/changelog/update-forms-integrations-editor-tooltips
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Forms: allow filtering "active tooltip" for integrations" from backend.

--- a/projects/packages/forms/changelog/update-forms-integrations-editor-tooltips
+++ b/projects/packages/forms/changelog/update-forms-integrations-editor-tooltips
@@ -1,4 +1,4 @@
 Significance: minor
 Type: changed
 
-Forms: allow filtering "active tooltip" for integrations" from backend.
+Allow filtering active tooltips for integrations from the backend.

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/active-integrations/index.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/active-integrations/index.js
@@ -9,18 +9,12 @@ export default function ActiveIntegrations( { integrations, attributes, isLoadin
 		switch ( integration.id ) {
 			case 'akismet':
 				if ( integration.isConnected ) {
-					acc.push( {
-						...integration,
-						tooltip: __( 'Akismet is connected for this form', 'jetpack-forms' ),
-					} );
+					acc.push( integration );
 				}
 				break;
 			case 'zero-bs-crm':
 				if ( integration.isActive && integration.details?.hasExtension && attributes.jetpackCRM ) {
-					acc.push( {
-						...integration,
-						tooltip: __( 'Jetpack CRM is connected for this form', 'jetpack-forms' ),
-					} );
+					acc.push( integration );
 				}
 				break;
 			case 'mailpoet':
@@ -29,10 +23,7 @@ export default function ActiveIntegrations( { integrations, attributes, isLoadin
 					integration.isConnected &&
 					attributes.mailpoet?.enabledForForm
 				) {
-					acc.push( {
-						...integration,
-						tooltip: __( 'MailPoet is connected for this form', 'jetpack-forms' ),
-					} );
+					acc.push( integration );
 				}
 				break;
 			case 'hostinger-reach':
@@ -41,10 +32,7 @@ export default function ActiveIntegrations( { integrations, attributes, isLoadin
 					integration.isConnected &&
 					attributes.hostingerReach?.enabledForForm
 				) {
-					acc.push( {
-						...integration,
-						tooltip: __( 'Hostinger Reach is connected for this form', 'jetpack-forms' ),
-					} );
+					acc.push( integration );
 				}
 				break;
 			case 'salesforce':
@@ -53,10 +41,7 @@ export default function ActiveIntegrations( { integrations, attributes, isLoadin
 					attributes.salesforceData?.organizationId &&
 					isValidSalesforceOrgId( attributes.salesforceData.organizationId )
 				) {
-					acc.push( {
-						...integration,
-						tooltip: __( 'Salesforce is connected for this form', 'jetpack-forms' ),
-					} );
+					acc.push( integration );
 				}
 				break;
 		}
@@ -82,7 +67,10 @@ export default function ActiveIntegrations( { integrations, attributes, isLoadin
 	return (
 		<div className="jetpack-forms-active-integrations">
 			{ activeIntegrations.map( integration => (
-				<Tooltip key={ integration.id } text={ integration.tooltip }>
+				<Tooltip
+					key={ integration.id }
+					text={ integration.activeTooltip || integration.title || '' }
+				>
 					<span className="jetpack-forms-active-integrations__item">
 						{ integration.iconUrl ? (
 							<img

--- a/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
@@ -134,6 +134,7 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 		 *                            - marketing_redirect_slug (string|null) : Redirect slug for marketing links, or null.
 		 *                            - title (string)                 : Default UI title for the integration.
 		 *                            - subtitle (string)              : Default UI subtitle/description for the integration.
+		 *                            - active_tooltip (string)        : Tooltip copy for when the integration is active/connected.
 		 *                            - enabled_by_default (bool)      : Whether the integration is enabled by default on new forms.
 		 *                            - icon_url (string|null)         : Absolute URL to an icon to display in the UI.
 		 */

--- a/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
@@ -46,6 +46,7 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 				'marketing_redirect_slug' => 'org-spam',
 				'title'                   => __( 'Akismet Spam Protection', 'jetpack-forms' ),
 				'subtitle'                => __( 'Akismet filters out form spam with 99% accuracy', 'jetpack-forms' ),
+				'active_tooltip'          => __( 'This form is protected with Akismet spam protection.', 'jetpack-forms' ),
 				// Overriding this may automatically enable/disable the integration when editing a form.
 				'enabled_by_default'      => false,
 				'icon_url'                => trailingslashit( Jetpack_Forms::assets_url() ) . 'images/integrations/akismet.svg',
@@ -57,6 +58,7 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 				'marketing_redirect_slug' => 'org-crm',
 				'title'                   => __( 'Jetpack CRM', 'jetpack-forms' ),
 				'subtitle'                => __( 'Store contact form submissions in your CRM', 'jetpack-forms' ),
+				'active_tooltip'          => __( 'Jetpack CRM is connected for this form.', 'jetpack-forms' ),
 				// Overriding this may automatically enable/disable the integration when editing a form.
 				'enabled_by_default'      => false,
 				'icon_url'                => trailingslashit( Jetpack_Forms::assets_url() ) . 'images/integrations/zero-bs-crm.svg',
@@ -68,6 +70,7 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 				'marketing_redirect_slug' => null,
 				'title'                   => __( 'Salesforce', 'jetpack-forms' ),
 				'subtitle'                => __( 'Send form contacts to Salesforce', 'jetpack-forms' ),
+				'active_tooltip'          => __( 'Salesforce is connected for this form.', 'jetpack-forms' ),
 				// Overriding this may automatically enable/disable the integration when editing a form.
 				'enabled_by_default'      => false,
 				'icon_url'                => trailingslashit( Jetpack_Forms::assets_url() ) . 'images/integrations/salesforce.svg',
@@ -79,6 +82,7 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 				'marketing_redirect_slug' => null,
 				'title'                   => __( 'Google Sheets', 'jetpack-forms' ),
 				'subtitle'                => __( 'Export form responses to Google Sheets.', 'jetpack-forms' ),
+				'active_tooltip'          => __( 'Google Sheets is connected for this form.', 'jetpack-forms' ),
 				// Overriding this may automatically enable/disable the integration when editing a form.
 				'enabled_by_default'      => false,
 				'icon_url'                => trailingslashit( Jetpack_Forms::assets_url() ) . 'images/integrations/google-drive.svg',
@@ -90,6 +94,7 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 				'marketing_redirect_slug' => 'org-mailpoet',
 				'title'                   => __( 'MailPoet email marketing', 'jetpack-forms' ),
 				'subtitle'                => __( 'Send newsletters and marketing emails directly from your site.', 'jetpack-forms' ),
+				'active_tooltip'          => __( 'MailPoet is connected for this form.', 'jetpack-forms' ),
 				// Overriding this may automatically enable/disable the integration when editing a form.
 				'enabled_by_default'      => false,
 				'icon_url'                => trailingslashit( Jetpack_Forms::assets_url() ) . 'images/integrations/mailpoet.svg',
@@ -105,6 +110,7 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 				'marketing_redirect_slug' => 'hostinger-reach',
 				'title'                   => __( 'Hostinger Reach', 'jetpack-forms' ),
 				'subtitle'                => __( 'Send newsletters and marketing emails via Hostinger Reach.', 'jetpack-forms' ),
+				'active_tooltip'          => __( 'Hostinger Reach is connected for this form.', 'jetpack-forms' ),
 				// Overriding this may automatically enable/disable the integration when editing a form.
 				'enabled_by_default'      => false,
 				'icon_url'                => trailingslashit( Jetpack_Forms::assets_url() ) . 'images/integrations/hostinger-reach.svg',

--- a/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
@@ -1270,6 +1270,7 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 			'marketingUrl'     => $marketing_redirect_slug ? Redirect::get_url( $marketing_redirect_slug ) : null,
 			'enabledByDefault' => isset( $config['enabled_by_default'] ) ? (bool) $config['enabled_by_default'] : false,
 			'iconUrl'          => $icon_url ? esc_url_raw( $icon_url ) : null,
+			'activeTooltip'    => isset( $config['active_tooltip'] ) ? sanitize_text_field( $config['active_tooltip'] ) : '',
 		);
 	}
 

--- a/projects/packages/forms/src/types/index.ts
+++ b/projects/packages/forms/src/types/index.ts
@@ -22,6 +22,8 @@ export interface IntegrationMetadata {
 	enabledByDefault?: boolean;
 	/** URL to an SVG/icon for this integration provided by the backend. */
 	iconUrl?: string | null;
+	/** Tooltip for the integration when it is active. */
+	activeTooltip?: string;
 }
 
 /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->



## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Move tooltip copy to backend, allowing us to filter it.
* Improve Akismet copy.

Before, if you had adjusted card titles to something custom:
<img width="860" height="293" alt="Screenshot 2026-02-09 at 16 56 32" src="https://github.com/user-attachments/assets/67c6c625-e426-4b7a-85e1-73041bec7a41" />

The active list showed custom icons, but still nota  custom tooltip:
<img width="415" height="180" alt="Screenshot 2026-02-09 at 16 56 29" src="https://github.com/user-attachments/assets/d980bf86-e86e-471d-b939-efedd13c0ba6" />
<img width="343" height="138" alt="Screenshot 2026-02-09 at 16 56 26" src="https://github.com/user-attachments/assets/0fd2d6ef-a893-40e2-aac0-d893b52a52e3" />

Here's without customization:
<img width="437" height="177" alt="Screenshot 2026-02-09 at 17 23 15" src="https://github.com/user-attachments/assets/f39b019c-56a9-4020-a964-718434747247" />

Here's with:
<img width="338" height="162" alt="Screenshot 2026-02-09 at 17 24 18" src="https://github.com/user-attachments/assets/d98b930e-63ae-480a-aa97-4479ee19db87" />



### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Note how tooltip still apperas for connected integrations 
* Use filter to modify the copy, e.g.:
```php
function my_filter_forms_integrations( $integrations ) {
	if ( isset( $integrations['akismet'] ) ) {
		$integrations['akismet']['active_tooltip'] = 'Test!';
	}
	return $integrations;
}
add_filter( 'jetpack_forms_supported_integrations', 'my_filter_forms_integrations' );
```