### PR TITLE
Forms: use wp build dashboard URLs in the email & masterbar

### DIFF
--- a/projects/packages/forms/changelog/update-forms-filter-dashboard-url
+++ b/projects/packages/forms/changelog/update-forms-filter-dashboard-url
@@ -1,4 +1,4 @@
 Significance: minor
-Type: added
+Type: changed
 
-Allow filtering forms dashboard URL.
+Change forms dashboard URL filter to allow customizing the dashboard location.

--- a/projects/packages/forms/changelog/update-forms-filter-dashboard-url
+++ b/projects/packages/forms/changelog/update-forms-filter-dashboard-url
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Allow filtering forms dashboard URL.

--- a/projects/packages/forms/changelog/update-forms-filter-dashboard-url
+++ b/projects/packages/forms/changelog/update-forms-filter-dashboard-url
@@ -1,4 +1,4 @@
 Significance: minor
 Type: changed
 
-Change forms dashboard URL filter to allow customizing the dashboard location.
+Change forms dashboard URL filter to allow customizing the dashboard location and resolve legacy hash fragments from email links.

--- a/projects/packages/forms/routes/responses/route.tsx
+++ b/projects/packages/forms/routes/responses/route.tsx
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import { resolveSelect } from '@wordpress/data';
+import { redirect } from '@wordpress/route';
 /**
  * Internal dependencies
  */
@@ -62,6 +63,29 @@ export const route = {
 	 * Checks if the feedback post type exists.
 	 */
 	beforeLoad: async () => {
+		// Redirect legacy hash from email links (e.g. #/responses?status=inbox&r=2879).
+		// The hash survives server redirects but is never sent to the server, so we must
+		// convert it client-side to the wp-build URL with responseIds in the path.
+		const hash = window.location.hash;
+		const legacyMatch = hash.match( /^#\/responses\?(.*)$/ );
+
+		if ( legacyMatch ) {
+			const params = new URLSearchParams( legacyMatch[ 1 ] );
+			const r = params.get( 'r' );
+
+			if ( r ) {
+				const status = params.get( 'status' ) || 'inbox';
+				const validStatuses = [ 'inbox', 'spam', 'trash' ];
+				const view = validStatuses.includes( status ) ? status : 'inbox';
+
+				throw redirect( {
+					href: `/responses/${ view }?responseIds=${ encodeURIComponent(
+						JSON.stringify( [ r ] )
+					) }`,
+				} );
+			}
+		}
+
 		// The feedback post type is registered by Jetpack Forms
 		// This will throw notFound() if the post type doesn't exist
 		try {

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -3850,7 +3850,7 @@ class Contact_Form_Plugin {
 			return;
 		}
 
-		$redirect = Dashboard::get_admin_url( $screen->id );
+		$redirect = Dashboard::get_forms_admin_url();
 		if ( $redirect ) {
 			wp_safe_redirect( $redirect );
 			exit;

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -3831,26 +3831,38 @@ class Contact_Form_Plugin {
 	}
 
 	/**
-	 * Redirect users from the edit-feedback screen to the Jetpack Forms admin page.
+	 * Redirect users from the edit-feedback and edit-jetpack_form screens to the Jetpack Forms admin page.
 	 *
-	 * This method is hooked to 'current_screen' and checks if the current screen
-	 * is 'edit-feedback'. If so, it redirects the user to admin.php?page=jetpack-forms-admin.
+	 * This method is hooked to 'current_screen' and redirects:
+	 * - edit-jetpack_form: to #/forms (legacy) or &p=/forms (wp-build)
+	 * - edit-feedback: to #/responses?status=inbox (legacy) or &p=/responses/inbox (wp-build)
 	 *
 	 * @since 6.0.0
 	 */
 	public function redirect_edit_feedback_to_jetpack_forms() {
-		// Only proceed if we have a valid screen object
 		if ( ! function_exists( 'get_current_screen' ) ) {
 			return;
 		}
 
 		$screen = get_current_screen();
 
-		if ( ! $screen || ! isset( $screen->id ) || $screen->id !== 'edit-feedback' ) {
+		if ( ! $screen || ! isset( $screen->id ) ) {
 			return;
 		}
 
-		$redirect = Dashboard::get_forms_admin_url();
+		// Don't redirect if we're already on the Forms admin page (prevents redirect loop).
+		if ( Dashboard::is_jetpack_forms_admin_page() ) {
+			return;
+		}
+
+		$redirect = null;
+
+		if ( 'edit-jetpack_form' === $screen->id ) {
+			$redirect = Dashboard::get_forms_admin_url( 'forms' );
+		} elseif ( 'edit-feedback' === $screen->id ) {
+			$redirect = Dashboard::get_forms_admin_url( 'inbox' );
+		}
+
 		if ( $redirect ) {
 			wp_safe_redirect( $redirect );
 			exit;

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -3846,7 +3846,7 @@ class Contact_Form_Plugin {
 
 		$screen = get_current_screen();
 
-		if ( ! $screen || ! isset( $screen->id ) ) {
+		if ( ! $screen || ! isset( $screen->id ) || $screen->id !== 'edit-feedback' ) {
 			return;
 		}
 

--- a/projects/packages/forms/src/contact-form/class-feedback-email-renderer.php
+++ b/projects/packages/forms/src/contact-form/class-feedback-email-renderer.php
@@ -131,8 +131,9 @@ class Feedback_Email_Renderer {
 		$dashboard_url           = '';
 		$mark_as_spam_url        = '';
 		$footer_mark_as_spam_url = '';
+
 		if ( $feedback_status !== 'jp-temp-feedback' ) {
-			$dashboard_url           = Forms_Dashboard::get_forms_admin_url( $status ) . '&r=' . $post_id;
+			$dashboard_url           = Forms_Dashboard::get_forms_admin_url( $status, $post_id );
 			$mark_as_spam_url        = $dashboard_url . '&mark_as_spam';
 			$footer_mark_as_spam_url = sprintf(
 				'<a href="%1$s">%2$s</a>',

--- a/projects/packages/forms/src/dashboard/class-dashboard.php
+++ b/projects/packages/forms/src/dashboard/class-dashboard.php
@@ -315,6 +315,7 @@ class Dashboard {
 	 * @return string URL path (e.g. '/', '/responses/inbox', '/forms').
 	 */
 	private static function get_forms_admin_path_wp_build( $tab, $post_id ) {
+		$post_id      = ! empty( $post_id ) ? absint( $post_id ) : null;
 		$response_ids = ! empty( $post_id ) ? '?responseIds=["' . $post_id . '"]' : '';
 
 		$path_map = array(
@@ -342,6 +343,7 @@ class Dashboard {
 	 * @return string URL suffix (e.g. '#/responses?status=inbox' or '&r=123').
 	 */
 	private static function get_forms_admin_suffix_legacy( $tab, $post_id ) {
+		$post_id    = ! empty( $post_id ) ? absint( $post_id ) : null;
 		$valid_tabs = array( 'spam', 'inbox', 'trash' );
 		$r_param    = ! empty( $post_id ) ? '&r=' . $post_id : '';
 
@@ -396,8 +398,17 @@ class Dashboard {
 	 * @param string $screen_id Screen ID.
 	 * @return string Admin URL.
 	 */
-	public static function get_admin_url( $screen_id ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+	public static function get_admin_url( $screen_id ) {
 		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Dashboard::get_forms_admin_url' );
+
+		if ( 'edit-jetpack_form' === $screen_id ) {
+			return self::get_forms_admin_url( 'forms' );
+		}
+
+		if ( 'edit-feedback' === $screen_id ) {
+			return self::get_forms_admin_url( 'inbox' );
+		}
+
 		return self::get_forms_admin_url();
 	}
 }

--- a/projects/packages/forms/src/dashboard/class-dashboard.php
+++ b/projects/packages/forms/src/dashboard/class-dashboard.php
@@ -278,7 +278,7 @@ class Dashboard {
 
 		$is_wp_build_enabled = apply_filters( 'jetpack_forms_alpha', false );
 		$valid_tabs          = array( 'spam', 'inbox', 'trash' );
-		$url                 = get_admin_url() . 'admin.php';
+		$url                 = admin_url( 'admin.php' );
 
 		// Dashboard
 		if ( $is_wp_build_enabled ) {
@@ -287,7 +287,7 @@ class Dashboard {
 			$url .= '?page=' . self::ADMIN_SLUG;
 		}
 
-		// Tab
+		// Tab & response
 		if ( in_array( $tab, $valid_tabs, true ) ) {
 			if ( $is_wp_build_enabled ) {
 				$path = '/responses/' . $tab;
@@ -360,16 +360,13 @@ class Dashboard {
 	/**
 	 * Get admin URL for given screen ID.
 	 *
+	 * @deprecated $$next-version$$ Use Dashboard::get_forms_admin_url() instead.
+	 *
 	 * @param string $screen_id Screen ID.
-	 * @return string|null Admin URL or null if not found.
+	 * @return string Admin URL.
 	 */
-	public static function get_admin_url( $screen_id ) {
-		switch ( $screen_id ) {
-			case 'edit-jetpack_form':
-				return self::get_forms_admin_url( 'forms' );
-			case 'edit-feedback':
-				return self::get_forms_admin_url( 'responses/inbox' );
-		}
-		return null;
+	public static function get_admin_url( $screen_id ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Dashboard::get_forms_admin_url' );
+		return self::get_forms_admin_url();
 	}
 }

--- a/projects/packages/forms/src/dashboard/class-dashboard.php
+++ b/projects/packages/forms/src/dashboard/class-dashboard.php
@@ -276,22 +276,20 @@ class Dashboard {
 	 */
 	public static function get_forms_admin_url( $tab = null, $post_id = null ) {
 
-		$central_form_management_enabled = Contact_Form_Plugin::has_editor_feature_flag( 'central-form-management' );
-		$valid_tabs                      = array( 'spam', 'inbox', 'trash' );
-
-		// Base URL
-		$url = get_admin_url() . 'admin.php';
+		$is_wp_build_enabled = apply_filters( 'jetpack_forms_alpha', false );
+		$valid_tabs          = array( 'spam', 'inbox', 'trash' );
+		$url                 = get_admin_url() . 'admin.php';
 
 		// Dashboard
-		if ( $central_form_management_enabled ) {
-			$url = get_admin_url() . '?page=jetpack-forms-responses-wp-admin';
+		if ( $is_wp_build_enabled ) {
+			$url .= '?page=jetpack-forms-responses-wp-admin';
 		} else {
 			$url .= '?page=jetpack-forms-admin';
 		}
 
 		// Tab
 		if ( in_array( $tab, $valid_tabs, true ) ) {
-			if ( $central_form_management_enabled ) {
+			if ( $is_wp_build_enabled ) {
 				$url = '&p=%2Fresponses%2F' . $tab;
 			} else {
 				$url .= '#/responses?status=' . $tab;
@@ -300,7 +298,7 @@ class Dashboard {
 
 		// Response ID
 		if ( ! empty( $post_id ) ) {
-			if ( $central_form_management_enabled ) {
+			if ( $is_wp_build_enabled ) {
 				$url .= '?responseIds=["' . $post_id . '"]';
 			} else {
 				$url .= '&r=' . $post_id;

--- a/projects/packages/forms/src/dashboard/class-dashboard.php
+++ b/projects/packages/forms/src/dashboard/class-dashboard.php
@@ -282,9 +282,9 @@ class Dashboard {
 
 		// Dashboard
 		if ( $is_wp_build_enabled ) {
-			$url .= '?page=jetpack-forms-responses-wp-admin';
+			$url .= '?page=' . self::FORMS_WPBUILD_ADMIN_SLUG;
 		} else {
-			$url .= '?page=jetpack-forms-admin';
+			$url .= '?page=' . self::ADMIN_SLUG;
 		}
 
 		// Tab

--- a/projects/packages/forms/src/dashboard/class-dashboard.php
+++ b/projects/packages/forms/src/dashboard/class-dashboard.php
@@ -110,16 +110,9 @@ class Dashboard {
 
 		// Legacy URL requested but wp-build is now active → redirect to wp-build.
 		if ( $page === self::ADMIN_SLUG && $is_wp_build_enabled ) {
-			// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-			$status         = isset( $_GET['status'] ) ? sanitize_text_field( wp_unslash( $_GET['status'] ) ) : 'inbox';
-			$valid_statuses = array( 'spam', 'inbox', 'trash' );
-
-			if ( ! in_array( $status, $valid_statuses, true ) ) {
-				$status = 'inbox';
-			}
-
-			// The hash is never sent to the server, so it is handled client-side on the routes' beforeLoad hook.
-			$redirect = self::get_forms_admin_url( $status );
+			// The hash is never sent to the server. "inbox" used as default tab so we end up specifically in the responses
+			// route, where the client-side router will handle the redirect to the correct status in its beforeLoad hook.
+			$redirect = self::get_forms_admin_url( 'inbox' );
 			wp_safe_redirect( $redirect );
 			exit;
 		}
@@ -399,7 +392,7 @@ class Dashboard {
 	 *
 	 * @param string|null $tab    Tab to open.
 	 * @param int|null    $post_id Post ID of response.
-	 * @return string URL suffix (e.g. '#/responses?status=inbox' or '&r=123').
+	 * @return string URL suffix (e.g. '#/responses?status=inbox&r=123', or '#/forms').
 	 */
 	private static function get_forms_admin_suffix_legacy( $tab, $post_id ) {
 		$post_id    = ! empty( $post_id ) ? absint( $post_id ) : null;

--- a/projects/packages/forms/src/dashboard/class-dashboard.php
+++ b/projects/packages/forms/src/dashboard/class-dashboard.php
@@ -370,7 +370,17 @@ class Dashboard {
 		}
 
 		$screen = get_current_screen();
-		return $screen && $screen->id === 'jetpack_page_jetpack-forms-admin';
+
+		if ( ! $screen || ! isset( $screen->id ) ) {
+			return false;
+		}
+
+		$forms_admin_screens = array(
+			'jetpack_page_' . self::ADMIN_SLUG,
+			'jetpack_page_' . self::FORMS_WPBUILD_ADMIN_SLUG,
+		);
+
+		return in_array( $screen->id, $forms_admin_screens, true );
 	}
 
 	/**

--- a/projects/packages/forms/src/dashboard/class-dashboard.php
+++ b/projects/packages/forms/src/dashboard/class-dashboard.php
@@ -323,27 +323,6 @@ class Dashboard {
 	}
 
 	/**
-	 * Appends the appropriate tab parameter to the URL based on the view type.
-	 *
-	 * @param string $url              Base URL to append to.
-	 * @param string $tab              Tab to open.
-	 *
-	 * @return string
-	 */
-	private static function append_tab_to_url( $url, $tab ) {
-		$valid_tabs = array( 'spam', 'inbox', 'trash' );
-		if ( ! in_array( $tab, $valid_tabs, true ) ) {
-
-			if ( $tab === 'forms' ) {
-				return $url . '#/forms';
-			}
-			return $url;
-		}
-
-		return $url . '#/responses?status=' . $tab;
-	}
-
-	/**
 	 * Returns true if the current screen is the Jetpack Forms admin page.
 	 *
 	 * @return boolean

--- a/projects/packages/forms/src/dashboard/class-dashboard.php
+++ b/projects/packages/forms/src/dashboard/class-dashboard.php
@@ -136,8 +136,6 @@ class Dashboard {
 				if ( preg_match( '#^/responses/(inbox|spam|trash)(?:\?responseIds=\["(\d+)"\])?$#', $p, $m ) ) {
 					$tab     = $m[1];
 					$post_id = ! empty( $m[2] ) ? absint( $m[2] ) : null;
-				} elseif ( preg_match( '#^/responses/inbox\?responseIds=\["(\d+)"\]#', $p, $m ) ) {
-					$post_id = absint( $m[1] );
 				} elseif ( preg_match( '#^/forms#', $p ) ) {
 					$tab = 'forms';
 				}

--- a/projects/packages/forms/src/dashboard/class-dashboard.php
+++ b/projects/packages/forms/src/dashboard/class-dashboard.php
@@ -270,16 +270,41 @@ class Dashboard {
 	 * Returns url of forms admin page.
 	 *
 	 * @param string|null $tab Tab to open in the forms admin page.
+	 * @param string|null $post_id Post ID of response to open in the forms responses page.
 	 *
 	 * @return string
 	 */
-	public static function get_forms_admin_url( $tab = null ) {
-		if ( apply_filters( 'jetpack_forms_alpha', false ) ) {
-			$base_url = get_admin_url() . 'admin.php?page=' . self::FORMS_WPBUILD_ADMIN_SLUG;
-			$url      = $base_url . '&p=%2F' . $tab;
+	public static function get_forms_admin_url( $tab = null, $post_id = null ) {
+
+		$central_form_management_enabled = Contact_Form_Plugin::has_editor_feature_flag( 'central-form-management' );
+		$valid_tabs                      = array( 'spam', 'inbox', 'trash' );
+
+		// Base URL
+		$url = get_admin_url() . 'admin.php';
+
+		// Dashboard
+		if ( $central_form_management_enabled ) {
+			$url = get_admin_url() . '?page=jetpack-forms-responses-wp-admin';
 		} else {
-			$base_url = get_admin_url() . 'admin.php?page=' . self::ADMIN_SLUG;
-			$url      = self::append_tab_to_url( $base_url, $tab );
+			$url .= '?page=jetpack-forms-admin';
+		}
+
+		// Tab
+		if ( in_array( $tab, $valid_tabs, true ) ) {
+			if ( $central_form_management_enabled ) {
+				$url = '&p=%2Fresponses%2F' . $tab;
+			} else {
+				$url .= '#/responses?status=' . $tab;
+			}
+		}
+
+		// Response ID
+		if ( ! empty( $post_id ) ) {
+			if ( $central_form_management_enabled ) {
+				$url .= '?responseIds=["' . $post_id . '"]';
+			} else {
+				$url .= '&r=' . $post_id;
+			}
 		}
 
 		/**
@@ -290,10 +315,11 @@ class Dashboard {
 		 *
 		 * @param string      $url The Forms admin page URL.
 		 * @param string|null $tab Tab to open in the forms admin page.
+		 * @param string|null $post_id Post ID of response to open in the forms responses page.
 		 *
 		 * @return string The filtered Forms admin page URL.
 		 */
-		return apply_filters( 'jetpack_forms_admin_url', $url, $tab );
+		return apply_filters( 'jetpack_forms_admin_url', $url, $tab, $post_id );
 	}
 
 	/**

--- a/projects/packages/forms/src/dashboard/class-dashboard.php
+++ b/projects/packages/forms/src/dashboard/class-dashboard.php
@@ -270,7 +270,7 @@ class Dashboard {
 	 * Returns url of forms admin page.
 	 *
 	 * @param string|null $tab Tab to open in the forms admin page.
-	 * @param string|null $post_id Post ID of response to open in the forms responses page.
+	 * @param int|null    $post_id Post ID of response to open in the forms responses page.
 	 *
 	 * @return string
 	 */
@@ -287,7 +287,7 @@ class Dashboard {
 			$url .= '?page=' . self::ADMIN_SLUG;
 		}
 
-		// Tab & response
+		// Tab & Response
 		if ( in_array( $tab, $valid_tabs, true ) ) {
 			if ( $is_wp_build_enabled ) {
 				$path = '/responses/' . $tab;
@@ -319,7 +319,7 @@ class Dashboard {
 		 *
 		 * @param string      $url The Forms admin page URL.
 		 * @param string|null $tab Tab to open in the forms admin page.
-		 * @param string|null $post_id Post ID of response to open in the forms responses page.
+		 * @param int|null $post_id Post ID of response to open in the forms responses page.
 		 *
 		 * @return string The filtered Forms admin page URL.
 		 */

--- a/projects/packages/forms/src/dashboard/class-dashboard.php
+++ b/projects/packages/forms/src/dashboard/class-dashboard.php
@@ -290,16 +290,22 @@ class Dashboard {
 		// Tab
 		if ( in_array( $tab, $valid_tabs, true ) ) {
 			if ( $is_wp_build_enabled ) {
-				$url = '&p=%2Fresponses%2F' . $tab;
+				$path = '/responses/' . $tab;
+				if ( ! empty( $post_id ) ) {
+					$path .= '?responseIds=["' . $post_id . '"]';
+				}
+				$url .= '&p=' . rawurlencode( $path );
 			} else {
 				$url .= '#/responses?status=' . $tab;
+				if ( ! empty( $post_id ) ) {
+					$url .= '&r=' . $post_id;
+				}
 			}
-		}
-
-		// Response ID
-		if ( ! empty( $post_id ) ) {
+		} elseif ( ! empty( $post_id ) ) {
+			// Post ID without tab: default to inbox for wp-build.
 			if ( $is_wp_build_enabled ) {
-				$url .= '?responseIds=["' . $post_id . '"]';
+				$path = '/responses/inbox?responseIds=["' . $post_id . '"]';
+				$url .= '&p=' . rawurlencode( $path );
 			} else {
 				$url .= '&r=' . $post_id;
 			}

--- a/projects/packages/forms/src/dashboard/class-dashboard.php
+++ b/projects/packages/forms/src/dashboard/class-dashboard.php
@@ -75,6 +75,7 @@ class Dashboard {
 	 */
 	public function init() {
 		add_action( 'admin_menu', array( $this, 'add_admin_submenu' ), self::MENU_PRIORITY );
+		add_action( 'admin_menu', array( __CLASS__, 'redirect_dashboard_url_cross_variant' ), 1 );
 
 		// Flag to enable the wp-build-based dashboard.
 		$is_wp_build_enabled = apply_filters( 'jetpack_forms_alpha', false );
@@ -88,6 +89,63 @@ class Dashboard {
 		// Removed all admin notices on the Jetpack Forms admin page.
 		if ( self::get_admin_query_page() === self::ADMIN_SLUG ) {
 			remove_all_actions( 'admin_notices' );
+		}
+	}
+
+	/**
+	 * Redirect dashboard URLs when the wp-build flag has changed since the link was generated.
+	 *
+	 * Email links may point to the legacy or wp-build dashboard. If the flag has toggled,
+	 * the requested page may not exist. This redirects to the correct variant.
+	 */
+	public static function redirect_dashboard_url_cross_variant() {
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$page = isset( $_GET['page'] ) ? sanitize_text_field( wp_unslash( $_GET['page'] ) ) : '';
+
+		if ( $page !== self::ADMIN_SLUG && $page !== self::FORMS_WPBUILD_ADMIN_SLUG ) {
+			return;
+		}
+
+		$is_wp_build_enabled = apply_filters( 'jetpack_forms_alpha', false );
+
+		// Legacy URL requested but wp-build is now active → redirect to wp-build.
+		if ( $page === self::ADMIN_SLUG && $is_wp_build_enabled ) {
+			// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			$status         = isset( $_GET['status'] ) ? sanitize_text_field( wp_unslash( $_GET['status'] ) ) : 'inbox';
+			$valid_statuses = array( 'spam', 'inbox', 'trash' );
+
+			if ( ! in_array( $status, $valid_statuses, true ) ) {
+				$status = 'inbox';
+			}
+
+			// The hash is never sent to the server, so it is handled client-side on the routes' beforeLoad hook.
+			$redirect = self::get_forms_admin_url( $status );
+			wp_safe_redirect( $redirect );
+			exit;
+		}
+
+		// WP-Build URL requested but legacy is now active → redirect to legacy.
+		if ( $page === self::FORMS_WPBUILD_ADMIN_SLUG && ! $is_wp_build_enabled ) {
+			// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			$p       = isset( $_GET['p'] ) ? rawurldecode( sanitize_text_field( wp_unslash( $_GET['p'] ) ) ) : '';
+			$tab     = 'inbox';
+			$post_id = null;
+
+			if ( $p !== '' ) {
+				// Parse path like /responses/inbox?responseIds=["2879"] or /forms.
+				if ( preg_match( '#^/responses/(inbox|spam|trash)(?:\?responseIds=\["(\d+)"\])?$#', $p, $m ) ) {
+					$tab     = $m[1];
+					$post_id = ! empty( $m[2] ) ? absint( $m[2] ) : null;
+				} elseif ( preg_match( '#^/responses/inbox\?responseIds=\["(\d+)"\]#', $p, $m ) ) {
+					$post_id = absint( $m[1] );
+				} elseif ( preg_match( '#^/forms#', $p ) ) {
+					$tab = 'forms';
+				}
+			}
+
+			$redirect = self::get_forms_admin_url( $tab, $post_id );
+			wp_safe_redirect( $redirect );
+			exit;
 		}
 	}
 
@@ -287,6 +345,7 @@ class Dashboard {
 			$url .= '&p=' . rawurlencode( $path );
 		} else {
 			$suffix = self::get_forms_admin_suffix_legacy( $tab, $post_id );
+
 			if ( $suffix !== '' ) {
 				$url .= $suffix;
 			}
@@ -329,9 +388,11 @@ class Dashboard {
 		if ( $tab !== null && $tab !== '' && isset( $path_map[ $tab ] ) ) {
 			return $path_map[ $tab ] . $response_ids;
 		}
+
 		if ( ! empty( $post_id ) ) {
 			return '/responses/inbox?responseIds=["' . $post_id . '"]';
 		}
+
 		return '/';
 	}
 
@@ -350,12 +411,15 @@ class Dashboard {
 		if ( in_array( $tab, $valid_tabs, true ) ) {
 			return '#/responses?status=' . $tab . $r_param;
 		}
+
 		if ( $tab === 'forms' ) {
 			return '#/forms';
 		}
+
 		if ( ! empty( $post_id ) ) {
-			return '&r=' . $post_id;
+			return '#/responses?status=inbox' . $r_param;
 		}
+
 		return '';
 	}
 

--- a/projects/packages/forms/src/dashboard/class-dashboard.php
+++ b/projects/packages/forms/src/dashboard/class-dashboard.php
@@ -325,7 +325,7 @@ class Dashboard {
 			'responses/inbox' => '/responses/inbox',
 		);
 
-		if ( isset( $path_map[ $tab ] ) ) {
+		if ( $tab !== null && $tab !== '' && isset( $path_map[ $tab ] ) ) {
 			return $path_map[ $tab ] . $response_ids;
 		}
 		if ( ! empty( $post_id ) ) {

--- a/projects/packages/forms/src/dashboard/class-dashboard.php
+++ b/projects/packages/forms/src/dashboard/class-dashboard.php
@@ -275,39 +275,20 @@ class Dashboard {
 	 * @return string
 	 */
 	public static function get_forms_admin_url( $tab = null, $post_id = null ) {
-
 		$is_wp_build_enabled = apply_filters( 'jetpack_forms_alpha', false );
-		$valid_tabs          = array( 'spam', 'inbox', 'trash' );
 		$url                 = admin_url( 'admin.php' );
 
-		// Dashboard
-		if ( $is_wp_build_enabled ) {
-			$url .= '?page=' . self::FORMS_WPBUILD_ADMIN_SLUG;
-		} else {
-			$url .= '?page=' . self::ADMIN_SLUG;
-		}
+		$url .= $is_wp_build_enabled
+			? '?page=' . self::FORMS_WPBUILD_ADMIN_SLUG
+			: '?page=' . self::ADMIN_SLUG;
 
-		// Tab & Response
-		if ( in_array( $tab, $valid_tabs, true ) ) {
-			if ( $is_wp_build_enabled ) {
-				$path = '/responses/' . $tab;
-				if ( ! empty( $post_id ) ) {
-					$path .= '?responseIds=["' . $post_id . '"]';
-				}
-				$url .= '&p=' . rawurlencode( $path );
-			} else {
-				$url .= '#/responses?status=' . $tab;
-				if ( ! empty( $post_id ) ) {
-					$url .= '&r=' . $post_id;
-				}
-			}
-		} elseif ( ! empty( $post_id ) ) {
-			// Post ID without tab: default to inbox for wp-build.
-			if ( $is_wp_build_enabled ) {
-				$path = '/responses/inbox?responseIds=["' . $post_id . '"]';
-				$url .= '&p=' . rawurlencode( $path );
-			} else {
-				$url .= '&r=' . $post_id;
+		if ( $is_wp_build_enabled ) {
+			$path = self::get_forms_admin_path_wp_build( $tab, $post_id );
+			$url .= '&p=' . rawurlencode( $path );
+		} else {
+			$suffix = self::get_forms_admin_suffix_legacy( $tab, $post_id );
+			if ( $suffix !== '' ) {
+				$url .= $suffix;
 			}
 		}
 
@@ -324,6 +305,56 @@ class Dashboard {
 		 * @return string The filtered Forms admin page URL.
 		 */
 		return apply_filters( 'jetpack_forms_admin_url', $url, $tab, $post_id );
+	}
+
+	/**
+	 * WP-Build path for the forms admin URL.
+	 *
+	 * @param string|null $tab    Tab to open.
+	 * @param int|null    $post_id Post ID of response.
+	 * @return string URL path (e.g. '/', '/responses/inbox', '/forms').
+	 */
+	private static function get_forms_admin_path_wp_build( $tab, $post_id ) {
+		$response_ids = ! empty( $post_id ) ? '?responseIds=["' . $post_id . '"]' : '';
+
+		$path_map = array(
+			'inbox'           => '/responses/inbox',
+			'spam'            => '/responses/spam',
+			'trash'           => '/responses/trash',
+			'forms'           => '/forms',
+			'responses/inbox' => '/responses/inbox',
+		);
+
+		if ( isset( $path_map[ $tab ] ) ) {
+			return $path_map[ $tab ] . $response_ids;
+		}
+		if ( ! empty( $post_id ) ) {
+			return '/responses/inbox?responseIds=["' . $post_id . '"]';
+		}
+		return '/';
+	}
+
+	/**
+	 * Legacy (hash-based) URL suffix for the forms admin page.
+	 *
+	 * @param string|null $tab    Tab to open.
+	 * @param int|null    $post_id Post ID of response.
+	 * @return string URL suffix (e.g. '#/responses?status=inbox' or '&r=123').
+	 */
+	private static function get_forms_admin_suffix_legacy( $tab, $post_id ) {
+		$valid_tabs = array( 'spam', 'inbox', 'trash' );
+		$r_param    = ! empty( $post_id ) ? '&r=' . $post_id : '';
+
+		if ( in_array( $tab, $valid_tabs, true ) ) {
+			return '#/responses?status=' . $tab . $r_param;
+		}
+		if ( $tab === 'forms' ) {
+			return '#/forms';
+		}
+		if ( ! empty( $post_id ) ) {
+			return '&r=' . $post_id;
+		}
+		return '';
 	}
 
 	/**

--- a/projects/packages/forms/tests/php/dashboard/Dashboard_Test.php
+++ b/projects/packages/forms/tests/php/dashboard/Dashboard_Test.php
@@ -57,9 +57,9 @@ class Dashboard_Test extends BaseTestCase {
 	}
 
 	/**
-	 * Test get_forms_admin_url without tab when alpha filter is enabled
+	 * Test get_forms_admin_url without tab for wp-build dashboard
 	 */
-	public function test_get_forms_admin_url_alpha_without_tab() {
+	public function test_get_forms_admin_url_wp_build_without_tab() {
 		add_filter( 'jetpack_forms_alpha', '__return_true' );
 		$expected = get_admin_url() . 'admin.php?page=' . Dashboard::FORMS_WPBUILD_ADMIN_SLUG . '&p=%2F';
 		$this->assertEquals( $expected, Dashboard::get_forms_admin_url() );
@@ -67,9 +67,9 @@ class Dashboard_Test extends BaseTestCase {
 	}
 
 	/**
-	 * Test get_forms_admin_url with tab when alpha filter is enabled
+	 * Test get_forms_admin_url with tab for wp-build dashboard
 	 */
-	public function test_get_forms_admin_url_alpha_with_tab() {
+	public function test_get_forms_admin_url_wp_build_with_tab() {
 		add_filter( 'jetpack_forms_alpha', '__return_true' );
 
 		$expected = get_admin_url() . 'admin.php?page=' . Dashboard::FORMS_WPBUILD_ADMIN_SLUG . '&p=' . rawurlencode( '/responses/inbox' );
@@ -116,7 +116,7 @@ class Dashboard_Test extends BaseTestCase {
 		$this->assertStringContainsString( 'admin.php?page=' . Dashboard::ADMIN_SLUG, $url_form );
 		$this->assertStringContainsString( '#/forms', $url_form );
 
-		// For non-alpha, edit-feedback equivalent is base URL (no tab).
+		// For legacy dashboard, edit-feedback equivalent is base URL (no tab).
 		$url_feedback = Dashboard::get_forms_admin_url();
 		$expected     = get_admin_url() . 'admin.php?page=' . Dashboard::ADMIN_SLUG;
 		$this->assertEquals( $expected, $url_feedback );
@@ -135,9 +135,9 @@ class Dashboard_Test extends BaseTestCase {
 	}
 
 	/**
-	 * Test get_forms_admin_url with screen ID equivalents when alpha filter is enabled.
+	 * Test get_forms_admin_url with screen ID equivalents for wp-build dashboard
 	 */
-	public function test_get_forms_admin_url_alpha_with_screen_id_equivalents() {
+	public function test_get_forms_admin_url_wp_build_with_screen_id_equivalents() {
 		add_filter( 'jetpack_forms_alpha', '__return_true' );
 
 		$url_form = Dashboard::get_forms_admin_url( 'forms' );

--- a/projects/packages/forms/tests/php/dashboard/Dashboard_Test.php
+++ b/projects/packages/forms/tests/php/dashboard/Dashboard_Test.php
@@ -57,6 +57,44 @@ class Dashboard_Test extends BaseTestCase {
 	}
 
 	/**
+	 * Test get_forms_admin_url with post_id parameter (legacy mode).
+	 * Verifies the r query parameter is correctly appended.
+	 */
+	public function test_get_forms_admin_url_with_post_id_legacy() {
+		// Tab + post_id: appends &r= to the hash fragment.
+		$expected = get_admin_url() . 'admin.php?page=jetpack-forms-admin#/responses?status=inbox&r=123';
+		$this->assertEquals( $expected, Dashboard::get_forms_admin_url( 'inbox', 123 ) );
+
+		$expected = get_admin_url() . 'admin.php?page=jetpack-forms-admin#/responses?status=spam&r=456';
+		$this->assertEquals( $expected, Dashboard::get_forms_admin_url( 'spam', 456 ) );
+
+		// post_id only (no tab): appends &r= to the base URL.
+		$expected = get_admin_url() . 'admin.php?page=jetpack-forms-admin&r=789';
+		$this->assertEquals( $expected, Dashboard::get_forms_admin_url( null, 789 ) );
+	}
+
+	/**
+	 * Test get_forms_admin_url with post_id parameter (wp-build mode).
+	 * Verifies the responseIds query parameter is correctly encoded in the path.
+	 */
+	public function test_get_forms_admin_url_with_post_id_wp_build() {
+		add_filter( 'jetpack_forms_alpha', '__return_true' );
+
+		// Tab + post_id: path includes responseIds in the path.
+		$expected = get_admin_url() . 'admin.php?page=' . Dashboard::FORMS_WPBUILD_ADMIN_SLUG . '&p=' . rawurlencode( '/responses/inbox?responseIds=["123"]' );
+		$this->assertEquals( $expected, Dashboard::get_forms_admin_url( 'inbox', 123 ) );
+
+		$expected = get_admin_url() . 'admin.php?page=' . Dashboard::FORMS_WPBUILD_ADMIN_SLUG . '&p=' . rawurlencode( '/responses/spam?responseIds=["456"]' );
+		$this->assertEquals( $expected, Dashboard::get_forms_admin_url( 'spam', 456 ) );
+
+		// post_id only (no tab): defaults to /responses/inbox with responseIds.
+		$expected = get_admin_url() . 'admin.php?page=' . Dashboard::FORMS_WPBUILD_ADMIN_SLUG . '&p=' . rawurlencode( '/responses/inbox?responseIds=["789"]' );
+		$this->assertEquals( $expected, Dashboard::get_forms_admin_url( null, 789 ) );
+
+		remove_filter( 'jetpack_forms_alpha', '__return_true' );
+	}
+
+	/**
 	 * Test get_forms_admin_url without tab for wp-build dashboard
 	 */
 	public function test_get_forms_admin_url_wp_build_without_tab() {

--- a/projects/packages/forms/tests/php/dashboard/Dashboard_Test.php
+++ b/projects/packages/forms/tests/php/dashboard/Dashboard_Test.php
@@ -58,18 +58,18 @@ class Dashboard_Test extends BaseTestCase {
 
 	/**
 	 * Test get_forms_admin_url with post_id parameter (legacy mode).
-	 * Verifies the r query parameter is correctly appended.
+	 * Verifies the r parameter is correctly appended in the hash fragment.
 	 */
 	public function test_get_forms_admin_url_with_post_id_legacy() {
-		// Tab + post_id: appends &r= to the hash fragment.
+		// Tab + post_id: appends r and status in hash fragment (client-side handles redirect).
 		$expected = get_admin_url() . 'admin.php?page=jetpack-forms-admin#/responses?status=inbox&r=123';
 		$this->assertEquals( $expected, Dashboard::get_forms_admin_url( 'inbox', 123 ) );
 
 		$expected = get_admin_url() . 'admin.php?page=jetpack-forms-admin#/responses?status=spam&r=456';
 		$this->assertEquals( $expected, Dashboard::get_forms_admin_url( 'spam', 456 ) );
 
-		// post_id only (no tab): appends &r= to the base URL.
-		$expected = get_admin_url() . 'admin.php?page=jetpack-forms-admin&r=789';
+		// post_id only (no tab): appends r and status=inbox in hash fragment.
+		$expected = get_admin_url() . 'admin.php?page=jetpack-forms-admin#/responses?status=inbox&r=789';
 		$this->assertEquals( $expected, Dashboard::get_forms_admin_url( null, 789 ) );
 	}
 

--- a/projects/packages/forms/tests/php/dashboard/Dashboard_Test.php
+++ b/projects/packages/forms/tests/php/dashboard/Dashboard_Test.php
@@ -72,13 +72,13 @@ class Dashboard_Test extends BaseTestCase {
 	public function test_get_forms_admin_url_alpha_with_tab() {
 		add_filter( 'jetpack_forms_alpha', '__return_true' );
 
-		$expected = get_admin_url() . 'admin.php?page=' . Dashboard::FORMS_WPBUILD_ADMIN_SLUG . '&p=%2Finbox';
+		$expected = get_admin_url() . 'admin.php?page=' . Dashboard::FORMS_WPBUILD_ADMIN_SLUG . '&p=' . rawurlencode( '/responses/inbox' );
 		$this->assertEquals( $expected, Dashboard::get_forms_admin_url( 'inbox' ) );
 
 		$expected = get_admin_url() . 'admin.php?page=' . Dashboard::FORMS_WPBUILD_ADMIN_SLUG . '&p=%2Fforms';
 		$this->assertEquals( $expected, Dashboard::get_forms_admin_url( 'forms' ) );
 
-		$expected = get_admin_url() . 'admin.php?page=' . Dashboard::FORMS_WPBUILD_ADMIN_SLUG . '&p=%2Fresponses/inbox';
+		$expected = get_admin_url() . 'admin.php?page=' . Dashboard::FORMS_WPBUILD_ADMIN_SLUG . '&p=' . rawurlencode( '/responses/inbox' );
 		$this->assertEquals( $expected, Dashboard::get_forms_admin_url( 'responses/inbox' ) );
 
 		remove_filter( 'jetpack_forms_alpha', '__return_true' );
@@ -109,42 +109,44 @@ class Dashboard_Test extends BaseTestCase {
 	}
 
 	/**
-	 * Test get_admin_url with valid screen IDs
+	 * Test get_forms_admin_url with screen ID equivalents (edit-jetpack_form -> forms, edit-feedback -> base/inbox).
 	 */
-	public function test_get_admin_url_with_valid_screen_ids() {
-		$url_form = Dashboard::get_admin_url( 'edit-jetpack_form' );
+	public function test_get_forms_admin_url_with_screen_id_equivalents() {
+		$url_form = Dashboard::get_forms_admin_url( 'forms' );
 		$this->assertStringContainsString( 'admin.php?page=' . Dashboard::ADMIN_SLUG, $url_form );
 		$this->assertStringContainsString( '#/forms', $url_form );
 
-		// For non-alpha, 'responses/inbox' is not a valid tab, so returns base URL only.
-		$url_feedback = Dashboard::get_admin_url( 'edit-feedback' );
+		// For non-alpha, edit-feedback equivalent is base URL (no tab).
+		$url_feedback = Dashboard::get_forms_admin_url();
 		$expected     = get_admin_url() . 'admin.php?page=' . Dashboard::ADMIN_SLUG;
 		$this->assertEquals( $expected, $url_feedback );
 	}
 
 	/**
-	 * Test get_admin_url with invalid screen ID returns null.
+	 * Test get_forms_admin_url with invalid tab returns base URL.
 	 */
-	public function test_get_admin_url_with_invalid_screen() {
-		$url = Dashboard::get_admin_url( 'invalid-screen' );
-		$this->assertNull( $url );
-		$url = Dashboard::get_admin_url( '' );
-		$this->assertNull( $url );
+	public function test_get_forms_admin_url_with_invalid_tab_returns_base_url() {
+		$url = Dashboard::get_forms_admin_url( 'invalid-screen' );
+		$this->assertStringContainsString( 'admin.php?page=' . Dashboard::ADMIN_SLUG, $url );
+		$this->assertStringNotContainsString( '#/', $url );
+
+		$url = Dashboard::get_forms_admin_url( '' );
+		$this->assertStringContainsString( 'admin.php?page=' . Dashboard::ADMIN_SLUG, $url );
 	}
 
 	/**
-	 * Test get_admin_url with valid screen IDs when alpha filter is enabled.
+	 * Test get_forms_admin_url with screen ID equivalents when alpha filter is enabled.
 	 */
-	public function test_get_admin_url_alpha_with_valid_screen_ids() {
+	public function test_get_forms_admin_url_alpha_with_screen_id_equivalents() {
 		add_filter( 'jetpack_forms_alpha', '__return_true' );
 
-		$url_form = Dashboard::get_admin_url( 'edit-jetpack_form' );
+		$url_form = Dashboard::get_forms_admin_url( 'forms' );
 		$this->assertStringContainsString( 'admin.php?page=' . Dashboard::FORMS_WPBUILD_ADMIN_SLUG, $url_form );
 		$this->assertStringContainsString( '&p=%2Fforms', $url_form );
 
-		$url_feedback = Dashboard::get_admin_url( 'edit-feedback' );
+		$url_feedback = Dashboard::get_forms_admin_url( 'inbox' );
 		$this->assertStringContainsString( 'admin.php?page=' . Dashboard::FORMS_WPBUILD_ADMIN_SLUG, $url_feedback );
-		$this->assertStringContainsString( '&p=%2Fresponses/inbox', $url_feedback );
+		$this->assertStringContainsString( '&p=%2Fresponses%2Finbox', $url_feedback );
 
 		remove_filter( 'jetpack_forms_alpha', '__return_true' );
 	}

--- a/projects/plugins/jetpack/changelog/update-forms-filter-dashboard-url
+++ b/projects/plugins/jetpack/changelog/update-forms-filter-dashboard-url
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Forms: allow filtering forms dashboard URL.

--- a/projects/plugins/jetpack/changelog/update-forms-filter-dashboard-url
+++ b/projects/plugins/jetpack/changelog/update-forms-filter-dashboard-url
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-Forms: allow filtering forms dashboard URL.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Support central form management URLs when enabled

Places using the link:

WP Admin header on form page on frontend
<img width="870" height="122" alt="Screenshot 2026-02-09 at 19 36 20" src="https://github.com/user-attachments/assets/f5d10c5c-3796-4c76-86c6-235c76638384" />

Email template
<img width="347" height="562" alt="image" src="https://github.com/user-attachments/assets/3d6a4f42-967b-4a7d-b301-60e0ec1c5ca2" />

Known issue/TODO: `mark_as_spam` feature on wp-build will be resolved in a follow-up PR.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Try with and without CFM enabled:
```php
add_filter( 'jetpack_block_editor_feature_flags', 'central_form_management_feature' );
function central_form_management_feature( $flags ) {
	$flags['reusable-forms'] = true;
	$flags['central-form-management'] = true;
	return $flags;
}
```
When new submissions come in, see the links in the email.

When looking at page with form on frontend, see the link in the masterbar.
