### PR TITLE
WPCOM Reader module: automatically enable on newly connected sites

### DIFF
--- a/projects/packages/newsletter/changelog/update-auto-enable-wpcom-reader
+++ b/projects/packages/newsletter/changelog/update-auto-enable-wpcom-reader
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Automatically enable the admin bar link on sites newly connected to WordPress.com.

--- a/projects/packages/newsletter/src/class-reader-link.php
+++ b/projects/packages/newsletter/src/class-reader-link.php
@@ -8,6 +8,7 @@
 namespace Automattic\Jetpack\Newsletter;
 
 use Automattic\Jetpack\Connection\Urls;
+use Automattic\Jetpack\Modules;
 use WP_Admin_Bar;
 
 /**
@@ -92,5 +93,21 @@ class Reader_Link {
 				'parent' => 'top-secondary',
 			)
 		);
+	}
+
+	/**
+	 * Activate the wpcom-reader module when a site is first connected to WordPress.com.
+	 *
+	 * Only activates on truly fresh connections. If modules were previously initialized
+	 * (e.g., the user disconnected and reconnected), we respect their prior module choices.
+	 *
+	 * @since $$next-version$$
+	 */
+	public static function activate_on_connection() {
+		if ( \Jetpack_Options::get_option( 'active_modules_initialized' ) ) {
+			return;
+		}
+
+		( new Modules() )->activate( 'wpcom-reader', false, false );
 	}
 }

--- a/projects/plugins/jetpack/changelog/update-auto-enable-wpcom-reader
+++ b/projects/plugins/jetpack/changelog/update-auto-enable-wpcom-reader
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+WordPress.com Reader: automatically enable the admin bar link on sites newly connected to WordPress.com.

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -27,6 +27,7 @@ use Automattic\Jetpack\Identity_Crisis;
 use Automattic\Jetpack\Licensing;
 use Automattic\Jetpack\Modules;
 use Automattic\Jetpack\My_Jetpack\Initializer as My_Jetpack_Initializer;
+use Automattic\Jetpack\Newsletter\Reader_Link;
 use Automattic\Jetpack\Paths;
 use Automattic\Jetpack\Plugin\Deprecate;
 use Automattic\Jetpack\Plugin\Tracking as Plugin_Tracking;
@@ -699,6 +700,7 @@ class Jetpack {
 		// After a successful connection.
 		add_action( 'jetpack_site_registered', array( $this, 'activate_default_modules_on_site_register' ) );
 		add_action( 'jetpack_site_registered', array( $this, 'handle_unique_registrations_stats' ) );
+		add_action( 'jetpack_site_registered', array( Reader_Link::class, 'activate_on_connection' ), 9 );
 
 		// Actions for Manager::authorize().
 		add_action( 'jetpack_authorize_starting', array( $this, 'authorize_starting' ) );


### PR DESCRIPTION
Fixes READ-230

> [!WARNING]
> This needs #46783 to be merged first.

## Proposed changes:

When a site is first connected to WordPress.com, we now automatically activate the `wpcom-reader` module; this adds the Reader link to the admin bar right away, so new users can discover it without having to enable it manually.

Of note, the module is only auto-enabled on **truly fresh connections**. If a site was previously connected and the user had explicitly deactivated the module, reconnecting won't force it back on.


**Note**:  We achieve this by checking the `active_modules_initialized` option before activating, and hooking into `jetpack_site_registered` at priority 9 so the check runs before `handle_default_module_activation` has a chance to update that flag.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* Yes, this would need to be mentioned in the support doc for the WordPress.com Reader module (see JPHDOC-390 ) 

cc @StefMattana 

## Testing instructions:

You can test with Jurassic Ninja sites, where you'll be able to connect sites for the first time easily. However, since Jurassic Ninja sites are on the Atomic platform but without the wpcomsh plugin, the Reader interface is a bit different and unique. To avoid that, I would recommend adding the following code snippet to your site before you connect the site to WordPress.com:

```php
add_filter(
	'jetpack_admin_js_script_data',
	function ( $data ) {
		$data['site']['host'] = 'unknown';
		return $data;
	}
);
```

The alternative is to test on a real self-hosted site of course. :)

**On a new site**

* Connect a brand new test site to WordPress.com for the first time.
* After connection, verify that the `wpcom-reader` module is active and the Reader link appears in the admin bar.
* Now deactivate the `wpcom-reader` module from Jetpack > Settings > Reader.
* Under My Jetpack, at the bottom of the page, disconnect the site from WordPress.com.
* Reconnect it.
* Verify that the `wpcom-reader` module is **not** re-activated — the user's choice to disable it should be respected.

**On an existing site, that's already connected to WordPress.com**

* Switch to this branch
* The module should not be automatically activated.