### PR TITLE
Forms: Load wp-build dashboard independently of Gutenberg plugin

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-wp-build-boot
+++ b/projects/packages/forms/changelog/fix-forms-wp-build-boot
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Load the wp-build dashboard independently of the Gutenberg plugin.

--- a/projects/packages/forms/routes/dataviews.scss
+++ b/projects/packages/forms/routes/dataviews.scss
@@ -1,5 +1,0 @@
-@use "sass:meta";
-
-// DataViews styles are not included if Gutenberg is not installed,
-// so we must load them on any route that uses DataViews.
-@include meta.load-css("@wordpress/dataviews/build-style/style.css");

--- a/projects/packages/forms/routes/dataviews.scss
+++ b/projects/packages/forms/routes/dataviews.scss
@@ -1,0 +1,5 @@
+@use "sass:meta";
+
+// DataViews styles are not included if Gutenberg is not installed,
+// so we must load them on any route that uses DataViews.
+@include meta.load-css("@wordpress/dataviews/build-style/style.css");

--- a/projects/packages/forms/routes/forms/stage.tsx
+++ b/projects/packages/forms/routes/forms/stage.tsx
@@ -24,6 +24,10 @@ import DataViewsHeaderRow from '../../src/dashboard/wp-build/components/dataview
 import usePageHeaderDetails from '../../src/dashboard/wp-build/hooks/use-page-header-details';
 import useConfigValue from '../../src/hooks/use-config-value';
 import { INTEGRATIONS_STORE, IntegrationsSelectors } from '../../src/store/integrations';
+import './style.scss';
+/**
+ * Types
+ */
 import type { FormListItem } from '../../src/dashboard/hooks/use-forms-data.ts';
 import type { Action, Operator, View } from '@wordpress/dataviews';
 

--- a/projects/packages/forms/routes/forms/style.scss
+++ b/projects/packages/forms/routes/forms/style.scss
@@ -1,1 +1,2 @@
-@use "../dataviews";
+@use "sass:meta";
+@include meta.load-css("@wordpress/dataviews/build-style/style.css");

--- a/projects/packages/forms/routes/forms/style.scss
+++ b/projects/packages/forms/routes/forms/style.scss
@@ -1,0 +1,1 @@
+@use "../dataviews";

--- a/projects/packages/forms/routes/responses/style.scss
+++ b/projects/packages/forms/routes/responses/style.scss
@@ -1,5 +1,6 @@
+@use "sass:meta";
 @use "@wordpress/base-styles/variables";
-@use "../dataviews";
+@include meta.load-css("@wordpress/dataviews/build-style/style.css");
 
 // Fix for sticky header on mobile in wp-admin
 // The header needs to account for the wp-admin bar

--- a/projects/packages/forms/routes/responses/style.scss
+++ b/projects/packages/forms/routes/responses/style.scss
@@ -1,4 +1,5 @@
 @use "@wordpress/base-styles/variables";
+@use "../dataviews";
 
 // Fix for sticky header on mobile in wp-admin
 // The header needs to account for the wp-admin bar

--- a/projects/packages/forms/src/dashboard/class-dashboard.php
+++ b/projects/packages/forms/src/dashboard/class-dashboard.php
@@ -21,7 +21,6 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Handles the Jetpack Forms dashboard.
  */
 class Dashboard {
-
 	/**
 	 * Load wp-build generated files if available.
 	 * This is for the new DataViews-based responses list.
@@ -29,8 +28,18 @@ class Dashboard {
 	public static function load_wp_build() {
 		if ( self::get_admin_query_page() === self::FORMS_WPBUILD_ADMIN_SLUG ) {
 			$wp_build_index = dirname( __DIR__, 2 ) . '/build/build.php';
+
 			if ( file_exists( $wp_build_index ) ) {
 				require_once $wp_build_index;
+
+				// Re-add core's registration only when Gutenberg isn't providing it
+				if ( ! defined( 'IS_GUTENBERG_PLUGIN' ) || ! IS_GUTENBERG_PLUGIN ) {
+					// `wp-build` currently removes `wp_default_script_modules` from `wp_default_scripts`.
+					// Re-add the core hook so script modules work in vanilla wp-admin (no Gutenberg plugin).
+					if ( function_exists( 'wp_default_script_modules' ) ) {
+						add_action( 'wp_default_scripts', 'wp_default_script_modules', 0 );
+					}
+				}
 			}
 		}
 	}
@@ -65,16 +74,14 @@ class Dashboard {
 	 * Initialize the dashboard.
 	 */
 	public function init() {
+		add_action( 'admin_menu', array( $this, 'add_new_admin_submenu' ), self::MENU_PRIORITY );
+
+		// Flag to enable the wp-build-based dashboard.
 		$is_wp_build_enabled = apply_filters( 'jetpack_forms_alpha', false );
 
 		if ( $is_wp_build_enabled ) {
-			// Load wp-build generated files for the new DataViews-based UI.
 			self::load_wp_build();
-		}
 
-		add_action( 'admin_menu', array( $this, 'add_new_admin_submenu' ), self::MENU_PRIORITY );
-
-		if ( $is_wp_build_enabled ) {
 			add_action( 'admin_menu', array( $this, 'add_forms_wpbuild_submenu' ), self::MENU_PRIORITY );
 		}
 

--- a/projects/packages/forms/src/dashboard/class-dashboard.php
+++ b/projects/packages/forms/src/dashboard/class-dashboard.php
@@ -82,7 +82,7 @@ class Dashboard {
 		if ( $is_wp_build_enabled ) {
 			self::load_wp_build();
 
-			add_action( 'admin_menu', array( $this, 'add_forms_wpbuild_submenu' ), self::MENU_PRIORITY );
+			add_action( 'admin_menu', array( $this, 'add_forms_wpbuild_submenu' ) );
 		}
 
 		add_action( 'admin_enqueue_scripts', array( $this, 'load_admin_scripts' ) );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes FORMS-581

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
- Imports the DataViews styles instead of relying on them already being loaded.
- Fixes an error that happened on boot, when `@wordpress/boot` tried importing from `@wordpress/a11y` and failed, causing the dashboard to abort rendering.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Disable Gutenberg or test on a new site without Gutenberg installed
* Enable the feature flag
* Go to the wp-build dashboard
* Check that it loads and is styled as expected
* Install and enable Gutenberg
* Check that it still works as expected
