### PR TITLE
Agents Manager: Make should_display_menu_panel() respect the filter.

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/agents-manager-filterable-menu-panel
+++ b/projects/packages/jetpack-mu-wpcom/changelog/agents-manager-filterable-menu-panel
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Agents Manager: Make should_display_menu_panel() respect the agents_manager_use_unified_experience filter.

--- a/projects/packages/jetpack-mu-wpcom/src/features/agents-manager/class-agents-manager.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/agents-manager/class-agents-manager.php
@@ -38,7 +38,7 @@ class Agents_Manager {
 	 * @return bool True if the menu panel should be displayed.
 	 */
 	public function should_display_menu_panel() {
-		return $this->should_use_unified_experience();
+		return apply_filters( 'agents_manager_use_unified_experience', false );
 	}
 
 	/**

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/agents-manager/Agents_Manager_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/agents-manager/Agents_Manager_Test.php
@@ -465,6 +465,38 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
+	 * Tests that should_display_menu_panel returns false by default.
+	 */
+	public function test_should_display_menu_panel_returns_false_by_default() {
+		wp_set_current_user( 0 );
+
+		$result = $this->agents_manager->should_display_menu_panel();
+
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * Tests that should_display_menu_panel respects the agents_manager_use_unified_experience filter.
+	 *
+	 * External code (e.g. mu-plugins in test environments) should be able to control
+	 * whether the admin bar menu panel is displayed via the filter.
+	 */
+	public function test_should_display_menu_panel_respects_filter() {
+		add_filter(
+			'agents_manager_use_unified_experience',
+			'__return_true',
+			// Use a higher priority to ensure it runs after the class's own filter.
+			20
+		);
+
+		$result = $this->agents_manager->should_display_menu_panel();
+
+		remove_filter( 'agents_manager_use_unified_experience', '__return_true', 20 );
+
+		$this->assertTrue( $result );
+	}
+
+	/**
 	 * Tests that the agents_manager_use_unified_experience filter is registered.
 	 */
 	public function test_unified_experience_filter_is_registered() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Part of BSKY-1481

Previously, `should_display_menu_panel()` called `should_use_unified_experience()` directly, bypassing the `agents_manager_use_unified_experience` filter.
This meant external code (e.g. mu-plugins in test environments) could not control whether the admin bar menu panel is displayed via the filter.

Use apply_filters() instead, consistent with should_enqueue_script(). The default behavior is unchanged since should_use_unified_experience() is already hooked as the default filter handler in the constructor.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Change `should_display_menu_panel` function to consume filter instead of calling directly the API.

## Does this pull request change what data or activity we track or use?

No.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* [x] Check code.
* Enable [unified experience setting](pgatNH-1CI-p2).
* [x] Confirm the unified experience loads.
* Disable unified experience setting (previously enabled).
* [x] Confirm the unified experience does not load.