### PR TITLE
tests: Fix PHPUnit 12.5.11 breakage

### DIFF
--- a/projects/packages/assets/changelog/fix-phpunit-12-5-11-breakage
+++ b/projects/packages/assets/changelog/fix-phpunit-12-5-11-breakage
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix tests for PHPUnit 12.5.11 breakage.
+
+

--- a/projects/packages/assets/tests/php/AssetsTest.php
+++ b/projects/packages/assets/tests/php/AssetsTest.php
@@ -363,7 +363,7 @@ class AssetsTest extends TestCase {
 			$this->expectExceptionMessage( $extra['exception']->getMessage() );
 		}
 		if ( isset( $extra['enqueue'] ) ) {
-			$obj = $this->createStub( AssetsTest_test_wp_default_scripts_hook::class );
+			$obj = $this->createMock( AssetsTest_test_wp_default_scripts_hook::class );
 			$obj->method( 'get_data' )->with( ...$extra['enqueue'][0] )->willReturn( $extra['enqueue'][1] );
 			Functions\expect( 'wp_scripts' )->andReturn( $obj );
 		}

--- a/projects/packages/autoloader/changelog/fix-phpunit-12-5-11-breakage
+++ b/projects/packages/autoloader/changelog/fix-phpunit-12-5-11-breakage
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix tests for PHPUnit 12.5.11 breakage.
+
+

--- a/projects/packages/autoloader/tests/php/tests/unit/LatestAutoloaderGuardTest.php
+++ b/projects/packages/autoloader/tests/php/tests/unit/LatestAutoloaderGuardTest.php
@@ -8,6 +8,7 @@
 // We live in the namespace of the test autoloader to avoid many use statements.
 namespace Automattic\Jetpack\Autoloader\jpCurrent;
 
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\PreserveGlobalState;
 use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use PHPUnit\Framework\TestCase;
@@ -16,6 +17,7 @@ use Test_Plugin_Factory;
 /**
  * Test suite class for the Autoloader part responsible for ensuring only the latest autoloader is ever executed.
  */
+#[AllowMockObjectsWithoutExpectations /* Mocks created in setUp, some tests add expectations and others don't. */ ]
 class LatestAutoloaderGuardTest extends TestCase {
 
 	/**
@@ -51,9 +53,9 @@ class LatestAutoloaderGuardTest extends TestCase {
 	 */
 	public function setUp(): void {
 		parent::setUp();
-		$this->plugins_handler    = $this->createStub( Plugins_Handler::class );
+		$this->plugins_handler    = $this->createMock( Plugins_Handler::class );
 		$this->autoloader_handler = $this->createMock( Autoloader_Handler::class );
-		$this->autoloader_locator = $this->createStub( Autoloader_Locator::class );
+		$this->autoloader_locator = $this->createMock( Autoloader_Locator::class );
 		$this->guard              = new Latest_Autoloader_Guard(
 			$this->plugins_handler,
 			$this->autoloader_handler,

--- a/projects/packages/changelogger/changelog/fix-phpunit-12-5-11-breakage
+++ b/projects/packages/changelogger/changelog/fix-phpunit-12-5-11-breakage
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix tests for PHPUnit 12.5.11 breakage.
+
+

--- a/projects/packages/changelogger/tests/php/tests/lib/ParserTest.php
+++ b/projects/packages/changelogger/tests/php/tests/lib/ParserTest.php
@@ -23,7 +23,7 @@ use PHPUnit\Framework\TestCase;
 class ParserTest extends TestCase {
 
 	/**
-	 * Get a mock Parser.
+	 * Get a stub Parser.
 	 *
 	 * @return Parser&\PHPUnit\Framework\MockObject\Stub
 	 */
@@ -33,10 +33,19 @@ class ParserTest extends TestCase {
 				->onlyMethods( array( 'parse', 'format' ) )
 				->getStub();
 		} else {
-			return $this->getMockBuilder( Parser::class )
-				->onlyMethods( array( 'parse', 'format' ) )
-				->getMock();
+			return $this->getMockParser();
 		}
+	}
+
+	/**
+	 * Get a mock Parser.
+	 *
+	 * @return Parser&\PHPUnit\Framework\MockObject\MockObject
+	 */
+	private function getMockParser() {
+		return $this->getMockBuilder( Parser::class )
+			->onlyMethods( array( 'parse', 'format' ) )
+			->getMock();
 	}
 
 	/**
@@ -64,7 +73,7 @@ class ParserTest extends TestCase {
 	 * Test formatToFile.
 	 */
 	public function testFormatToFile() {
-		$mock      = $this->getStubParser();
+		$mock      = $this->getMockParser();
 		$changelog = new Changelog();
 		$mock->method( 'format' )
 			->with( $this->identicalTo( $changelog ) )


### PR DESCRIPTION
Closes MONOREP-353

 <!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
PHPUnit 12.5.11 has started throwing deprecation warnings about using `->with*()` functions on its stubs (versus mocks), and also backed out some of the corresponding whining that was fixed in #46260 that caused us to switch some things from mocks to stubs in the first place. Whee.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1770734220690209-slack-CDLH4C1UZ
p1770728316452899-slack-C034JEXD1RD

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* CI happy?