### PR TITLE
Move SEO panel outside of Jetpack stack

### DIFF
--- a/projects/plugins/jetpack/changelog/move-seo-panel-to-page-stack
+++ b/projects/plugins/jetpack/changelog/move-seo-panel-to-page-stack
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+SEO: Move the Optimize SEO panel from the Jetpack sidebar to the document settings panel.

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/seo-enhancer.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/seo-enhancer.tsx
@@ -35,7 +35,7 @@ export function SeoEnhancer( {
 	placement = null,
 }: {
 	disableAutoEnhance?: boolean;
-	placement?: 'jetpack-sidebar' | 'jetpack-prepublish-sidebar';
+	placement?: 'jetpack-sidebar' | 'document-settings' | 'jetpack-prepublish-sidebar';
 } ) {
 	const { tracks } = useAnalytics();
 	const { isEnabled, toggleEnhancer, isToggling } = useSeoModuleSettings();

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/use-seo-module-settings.ts
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/use-seo-module-settings.ts
@@ -23,7 +23,11 @@ export const useSeoModuleSettings = () => {
 	const setIsEnabled = useDispatch( store ).setIsAutoEnhanceEnabled;
 
 	const toggleEnhancer = useCallback(
-		async ( { placement }: { placement: 'jetpack-sidebar' | 'jetpack-prepublish-sidebar' } ) => {
+		async ( {
+			placement,
+		}: {
+			placement: 'jetpack-sidebar' | 'document-settings' | 'jetpack-prepublish-sidebar';
+		} ) => {
 			setIsToggling( true );
 			try {
 				await apiFetch( {

--- a/projects/plugins/jetpack/extensions/plugins/seo/editor.scss
+++ b/projects/plugins/jetpack/extensions/plugins/seo/editor.scss
@@ -2,3 +2,16 @@
 	width: 100%;
 }
 
+.jetpack-seo-sidebar__feature-section {
+	display: block;
+
+	p,
+	p > * {
+		text-wrap: pretty;
+	}
+
+	button {
+		width: 100%;
+		justify-content: center;
+	}
+}

--- a/projects/plugins/jetpack/extensions/plugins/seo/editor.scss
+++ b/projects/plugins/jetpack/extensions/plugins/seo/editor.scss
@@ -2,17 +2,3 @@
 	width: 100%;
 }
 
-.jetpack-seo-sidebar__feature-section {
-	display: block;
-
-	p,
-	p > * {
-		text-wrap: pretty;
-	}
-
-	button {
-		width: 100%;
-		justify-content: center;
-	}
-}
-

--- a/projects/plugins/jetpack/extensions/plugins/seo/index.js
+++ b/projects/plugins/jetpack/extensions/plugins/seo/index.js
@@ -143,7 +143,7 @@ const Seo = () => {
 				name="jetpack-seo"
 			>
 				{ isSeoEnhancerEnabled && hasRequiredPlanForEnhancer && (
-					<SeoEnhancer placement="jetpack-sidebar" disableAutoEnhance={ ! canHaveAutoEnhance } />
+					<SeoEnhancer placement="document-settings" disableAutoEnhance={ ! canHaveAutoEnhance } />
 				) }
 				<PanelRow>
 					<SeoTitlePanel />

--- a/projects/plugins/jetpack/extensions/plugins/seo/index.js
+++ b/projects/plugins/jetpack/extensions/plugins/seo/index.js
@@ -7,22 +7,20 @@ import {
 	getJetpackExtensionAvailability,
 	getRequiredPlan,
 } from '@automattic/jetpack-shared-extension-utils';
-import { JetpackEditorPanelLogo } from '@automattic/jetpack-shared-extension-utils/components';
-import { PanelBody, PanelRow } from '@wordpress/components';
+import { PanelRow } from '@wordpress/components';
 import { store as coreStore } from '@wordpress/core-data';
 import { useSelect, select as globalSelect, useDispatch } from '@wordpress/data';
 import {
+	PluginDocumentSettingPanel,
 	PluginPrePublishPanel,
 	PluginPostPublishPanel,
 	store as editorStore,
 } from '@wordpress/editor';
 import { useEffect, useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import clsx from 'clsx';
 /**
  * Internal dependencies
  */
-import JetpackPluginSidebar from '../../shared/jetpack-plugin-sidebar';
 import { SeoEnhancer } from '../ai-assistant-plugin/components/seo-enhancer';
 import { SeoSummary } from '../ai-assistant-plugin/components/seo-enhancer/seo-summary';
 import { useSeoModuleSettings } from '../ai-assistant-plugin/components/seo-enhancer/use-seo-module-settings';
@@ -98,52 +96,40 @@ const Seo = () => {
 	const canShowUpsell = isWpcomPlatformSite();
 	const hasRequiredPlanForEnhancer = ! getRequiredPlan( 'ai-seo-enhancer' );
 
-	const jetpackSeoPanelProps = {
-		title: __( 'Optimize SEO', 'jetpack' ),
-	};
-
 	if ( canShowUpsell && requiredPlan !== false ) {
 		return (
-			<>
-				<JetpackPluginSidebar>
-					<PanelBody
-						className="jetpack-seo-panel"
-						{ ...jetpackSeoPanelProps }
-						initialOpen={ false }
-					>
-						<UpsellNotice requiredPlan={ requiredPlan } />
-					</PanelBody>
-				</JetpackPluginSidebar>
-			</>
+			<PluginDocumentSettingPanel
+				className="jetpack-seo-panel"
+				title={ __( 'Optimize SEO', 'jetpack' ) }
+				name="jetpack-seo"
+			>
+				<UpsellNotice requiredPlan={ requiredPlan } />
+			</PluginDocumentSettingPanel>
 		);
 	}
 
 	if ( ! isModuleActive ) {
 		return (
-			<>
-				<JetpackPluginSidebar>
-					<PanelBody
-						className="jetpack-seo-panel"
-						{ ...jetpackSeoPanelProps }
-						initialOpen={ false }
-					>
-						{ isLoadingModules ? (
-							<SeoSkeletonLoader />
-						) : (
-							<SeoPlaceholder
-								changeStatus={ changeStatus }
-								isModuleActive={ isModuleActive }
-								isLoading={ isChangingStatus }
-							/>
-						) }
-					</PanelBody>
-				</JetpackPluginSidebar>
-			</>
+			<PluginDocumentSettingPanel
+				className="jetpack-seo-panel"
+				title={ __( 'Optimize SEO', 'jetpack' ) }
+				name="jetpack-seo"
+			>
+				{ isLoadingModules ? (
+					<SeoSkeletonLoader />
+				) : (
+					<SeoPlaceholder
+						changeStatus={ changeStatus }
+						isModuleActive={ isModuleActive }
+						isLoading={ isChangingStatus }
+					/>
+				) }
+			</PluginDocumentSettingPanel>
 		);
 	}
 
 	const jetpackSeoPublishPanelsProps = {
-		icon: <JetpackEditorPanelLogo />,
+		icon: false,
 		title: __( 'SEO', 'jetpack' ),
 		initialOpen: isSeoEnhancerEnabled,
 	};
@@ -151,34 +137,24 @@ const Seo = () => {
 	// TODO: remove all code related to the SeoAssistantWizard if it's a no-go
 	return (
 		<>
-			<JetpackPluginSidebar>
-				<PanelBody className="jetpack-seo-panel" { ...jetpackSeoPanelProps }>
-					{ isSeoEnhancerEnabled && hasRequiredPlanForEnhancer && (
-						<SeoEnhancer placement="jetpack-sidebar" disableAutoEnhance={ ! canHaveAutoEnhance } />
-					) }
-					<PanelRow
-						className={ clsx( {
-							'jetpack-seo-sidebar__feature-section': isSeoEnhancerEnabled,
-						} ) }
-					>
-						<SeoTitlePanel />
-					</PanelRow>
-					<PanelRow
-						className={ clsx( {
-							'jetpack-seo-sidebar__feature-section': isSeoEnhancerEnabled,
-						} ) }
-					>
-						<SeoDescriptionPanel />
-					</PanelRow>
-					<PanelRow
-						className={ clsx( {
-							'jetpack-seo-sidebar__feature-section': isSeoEnhancerEnabled,
-						} ) }
-					>
-						<SeoNoindexPanel />
-					</PanelRow>
-				</PanelBody>
-			</JetpackPluginSidebar>
+			<PluginDocumentSettingPanel
+				className="jetpack-seo-panel"
+				title={ __( 'Optimize SEO', 'jetpack' ) }
+				name="jetpack-seo"
+			>
+				{ isSeoEnhancerEnabled && hasRequiredPlanForEnhancer && (
+					<SeoEnhancer placement="jetpack-sidebar" disableAutoEnhance={ ! canHaveAutoEnhance } />
+				) }
+				<PanelRow>
+					<SeoTitlePanel />
+				</PanelRow>
+				<PanelRow>
+					<SeoDescriptionPanel />
+				</PanelRow>
+				<PanelRow>
+					<SeoNoindexPanel />
+				</PanelRow>
+			</PluginDocumentSettingPanel>
 
 			<PluginPrePublishPanel { ...jetpackSeoPublishPanelsProps }>
 				<div className="jetpack-seo-panel">

--- a/projects/plugins/jetpack/extensions/plugins/seo/index.js
+++ b/projects/plugins/jetpack/extensions/plugins/seo/index.js
@@ -7,7 +7,6 @@ import {
 	getJetpackExtensionAvailability,
 	getRequiredPlan,
 } from '@automattic/jetpack-shared-extension-utils';
-import { JetpackEditorPanelLogo } from '@automattic/jetpack-shared-extension-utils/components';
 import { PanelRow } from '@wordpress/components';
 import { store as coreStore } from '@wordpress/core-data';
 import { useSelect, select as globalSelect, useDispatch } from '@wordpress/data';
@@ -130,7 +129,7 @@ const Seo = () => {
 	}
 
 	const jetpackSeoPublishPanelsProps = {
-		icon: <JetpackEditorPanelLogo />,
+		icon: false,
 		title: __( 'SEO', 'jetpack' ),
 		initialOpen: isSeoEnhancerEnabled,
 	};

--- a/projects/plugins/jetpack/extensions/plugins/seo/index.js
+++ b/projects/plugins/jetpack/extensions/plugins/seo/index.js
@@ -7,6 +7,7 @@ import {
 	getJetpackExtensionAvailability,
 	getRequiredPlan,
 } from '@automattic/jetpack-shared-extension-utils';
+import { JetpackEditorPanelLogo } from '@automattic/jetpack-shared-extension-utils/components';
 import { PanelRow } from '@wordpress/components';
 import { store as coreStore } from '@wordpress/core-data';
 import { useSelect, select as globalSelect, useDispatch } from '@wordpress/data';
@@ -129,7 +130,7 @@ const Seo = () => {
 	}
 
 	const jetpackSeoPublishPanelsProps = {
-		icon: false,
+		icon: <JetpackEditorPanelLogo />,
 		title: __( 'SEO', 'jetpack' ),
 		initialOpen: isSeoEnhancerEnabled,
 	};

--- a/projects/plugins/jetpack/extensions/plugins/seo/show-seo-section.js
+++ b/projects/plugins/jetpack/extensions/plugins/seo/show-seo-section.js
@@ -1,26 +1,28 @@
 /**
  * External dependencies
  */
-import { dispatch } from '@wordpress/data';
+import { dispatch, select } from '@wordpress/data';
+import { store as editorStore } from '@wordpress/editor';
 
 export const showSeoSection = async () => {
 	const { clearSelectedBlock } = dispatch( 'core/block-editor' );
-	const { enableComplementaryArea } = dispatch( 'core/interface' );
+	const { openGeneralSidebar } = dispatch( 'core/edit-post' );
 
-	// Clear any block selection, because selected blocks have precedence on settings sidebar
+	// Clear block selection so right sidebar shows document settings, not block settings
 	clearSelectedBlock();
-	await enableComplementaryArea( 'core/edit-post', 'jetpack-sidebar/jetpack' );
 
-	const panel = document.querySelector( '.jetpack-seo-panel' );
-	const isAlreadyOpen = panel?.classList.contains( 'is-opened' );
-	const button = panel?.querySelector( 'h2 button' );
+	// Open the document/post settings sidebar
+	await openGeneralSidebar( 'edit-post/document' );
 
-	if ( isAlreadyOpen ) {
-		// Close it before opening it to ensure the content is scrolled to view
-		button?.click();
+	// Ensure the SEO panel is expanded (panel name = pluginName/panelName)
+	const panelName = 'jetpack-seo/jetpack-seo';
+	const isOpen = select( editorStore ).isEditorPanelOpened( panelName );
+	if ( ! isOpen ) {
+		dispatch( editorStore ).toggleEditorPanelOpened( panelName );
 	}
 
+	// Scroll into view after DOM updates
 	setTimeout( () => {
-		button?.click();
-	}, 50 );
+		document.querySelector( '.jetpack-seo-panel' )?.scrollIntoView( { behavior: 'smooth' } );
+	}, 100 );
 };


### PR DESCRIPTION
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes JETPACK-1287

## Proposed changes:
* Move SEO panel outside of Jetpack stack.
* Even though the panel is outside of JP stack, it is unbranded (see p1770308909225799-slack-C0AE29MU8KS)

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1770308909225799-slack-C0AE29MU8KS

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
1. Go to **WP Admin → Posts → Add New** (or edit an existing post) in the block editor.
2. Open the right sidebar (**Settings**, Document tab).
3. Confirm **Optimize SEO** appears in **Document Settings**.
4. Confirm there is no duplicate SEO panel in the old **Jetpack** sidebar stack.
5. Expand **Optimize SEO** and verify the SEO controls render correctly:
   - SEO title
   - SEO description
   - Noindex
6. Change SEO values, save/publish, reload the editor, and confirm values persist.
7. Open the **Pre-publish** flow and verify the **SEO** pre-publish panel still appears and works.
8. Publish the post and verify the **Post-publish SEO summary** still appears (when SEO Enhancer is available).
9. From the post-publish summary, click **Edit** and confirm it:
   - Opens the document settings sidebar
   - Expands the SEO panel
   - Scrolls the SEO panel into view
10. Confirm there are no console errors during these interactions.


## Screenshots
<img width="370" height="979" alt="image" src="https://github.com/user-attachments/assets/a7471989-055f-497f-af76-f95fde990fa6" />
<img width="335" height="1008" alt="image" src="https://github.com/user-attachments/assets/90f1a60f-82a5-4bae-bbbd-52a4dd214840" />

<img width="342" height="754" alt="image" src="https://github.com/user-attachments/assets/e9355cbb-3ba3-4884-a0d5-8eea47f103bd" />
