### PR TITLE
Jetpack: Fix a warning in a test

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-random-test-warning
+++ b/projects/plugins/jetpack/changelog/fix-random-test-warning
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Fix a warning in a test.
+
+

--- a/projects/plugins/jetpack/extensions/blocks/repeat-visitor/test/validate.js
+++ b/projects/plugins/jetpack/extensions/blocks/repeat-visitor/test/validate.js
@@ -10,6 +10,7 @@ import v1 from '../deprecated/v1/attributes';
 // in innerBlocks within the block under test, with the generated fixtures
 // preserving the markup in the parsed JSON and serialized HTML.
 const fakeParagraphBlockSettings = {
+	apiVersion: 3,
 	attributes: {
 		content: {
 			type: 'string',


### PR DESCRIPTION
Closes MONOREP-354

 <!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
The test was complaining that a fake block being registered was apiVersion 1, which is deprecated in WP 6.9. The tests still pass if it's registered with apiVersion 3, so let's go with that.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* CI happy?
