### PR TITLE
Forms: Fix synced form changes being lost when navigating to form editor

### DIFF
--- a/projects/packages/forms/changelog/fix-form-editor-missing-save
+++ b/projects/packages/forms/changelog/fix-form-editor-missing-save
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Form Editor: Fix synced form changes being lost when navigating between page editor and form editor.

--- a/projects/packages/forms/src/blocks/contact-form/components/convert-form-toolbar.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/components/convert-form-toolbar.tsx
@@ -54,7 +54,7 @@ interface ConvertFormToolbarProps {
  * @param props                  - Component props.
  * @param props.clientId         - The block client ID.
  * @param props.attributes       - The block attributes.
- * @param props.onBeforeNavigate
+ * @param props.onBeforeNavigate - Callback to stage pending edits before navigation.
  * @return Toolbar with edit/convert buttons.
  */
 export function ConvertFormToolbar( {

--- a/projects/packages/forms/src/blocks/contact-form/components/convert-form-toolbar.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/components/convert-form-toolbar.tsx
@@ -43,9 +43,9 @@ interface ConvertFormToolbarProps {
 	attributes: Record< string, unknown >;
 	/**
 	 * Optional callback to run before navigating to form editor.
-	 * Use this to flush any pending saves. Returns a promise that resolves when save is complete.
+	 * Use this to stage any pending edits in the entity store (not save to database).
 	 */
-	onBeforeNavigate?: () => Promise< void >;
+	onBeforeNavigate?: () => void;
 }
 
 /**
@@ -141,18 +141,10 @@ export function ConvertFormToolbar( {
 		}
 	};
 
-	const handleEditOriginal = async () => {
-		console.log( '[ConvertFormToolbar] handleEditOriginal called', {
-			ref: attributes.ref,
-			hasOnBeforeNavigate: !! onBeforeNavigate,
-		} );
+	const handleEditOriginal = () => {
 		if ( attributes.ref ) {
-			// Flush any pending saves before navigating (wait for save to complete)
-			if ( onBeforeNavigate ) {
-				console.log( '[ConvertFormToolbar] Calling onBeforeNavigate (flushPendingSave)' );
-				await onBeforeNavigate();
-				console.log( '[ConvertFormToolbar] onBeforeNavigate completed, now navigating' );
-			}
+			// Stage any pending edits in the entity store before navigating
+			onBeforeNavigate?.();
 			navigateToForm( attributes.ref as number, editorContext, onNavigateToEntityRecord );
 		}
 	};

--- a/projects/packages/forms/src/blocks/contact-form/components/convert-form-toolbar.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/components/convert-form-toolbar.tsx
@@ -41,17 +41,27 @@ export const navigateToForm = (
 interface ConvertFormToolbarProps {
 	clientId: string;
 	attributes: Record< string, unknown >;
+	/**
+	 * Optional callback to run before navigating to form editor.
+	 * Use this to flush any pending saves. Returns a promise that resolves when save is complete.
+	 */
+	onBeforeNavigate?: () => Promise< void >;
 }
 
 /**
  * Toolbar component for converting inline forms to synced forms and editing synced forms.
  *
- * @param props            - Component props.
- * @param props.clientId   - The block client ID.
- * @param props.attributes - The block attributes.
+ * @param props                  - Component props.
+ * @param props.clientId         - The block client ID.
+ * @param props.attributes       - The block attributes.
+ * @param props.onBeforeNavigate
  * @return Toolbar with edit/convert buttons.
  */
-export function ConvertFormToolbar( { clientId, attributes }: ConvertFormToolbarProps ) {
+export function ConvertFormToolbar( {
+	clientId,
+	attributes,
+	onBeforeNavigate,
+}: ConvertFormToolbarProps ) {
 	const editorContext = getEditorContext();
 	const isWidgetEditor = editorContext === 'widget';
 
@@ -131,8 +141,18 @@ export function ConvertFormToolbar( { clientId, attributes }: ConvertFormToolbar
 		}
 	};
 
-	const handleEditOriginal = () => {
+	const handleEditOriginal = async () => {
+		console.log( '[ConvertFormToolbar] handleEditOriginal called', {
+			ref: attributes.ref,
+			hasOnBeforeNavigate: !! onBeforeNavigate,
+		} );
 		if ( attributes.ref ) {
+			// Flush any pending saves before navigating (wait for save to complete)
+			if ( onBeforeNavigate ) {
+				console.log( '[ConvertFormToolbar] Calling onBeforeNavigate (flushPendingSave)' );
+				await onBeforeNavigate();
+				console.log( '[ConvertFormToolbar] onBeforeNavigate completed, now navigating' );
+			}
 			navigateToForm( attributes.ref as number, editorContext, onNavigateToEntityRecord );
 		}
 	};

--- a/projects/packages/forms/src/blocks/contact-form/edit.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/edit.tsx
@@ -354,7 +354,7 @@ function JetpackContactFormEdit( {
 	} );
 
 	// Auto-save editor changes BACK to the synced form post
-	useSyncedFormAutoSave( {
+	const { flushPendingSave } = useSyncedFormAutoSave( {
 		ref,
 		syncedForm,
 		attributes,
@@ -945,7 +945,11 @@ function JetpackContactFormEdit( {
 			<>
 				<BlockControls>
 					{ isCentralFormManagementEnabled && ! isJetpackFormEditor && (
-						<ConvertFormToolbar clientId={ clientId } attributes={ attributes } />
+						<ConvertFormToolbar
+							clientId={ clientId }
+							attributes={ attributes }
+							onBeforeNavigate={ flushPendingSave }
+						/>
 					) }
 					{ variationName === 'multistep' && <StepControls formClientId={ clientId } /> }
 				</BlockControls>

--- a/projects/packages/forms/src/blocks/contact-form/hooks/use-synced-form-auto-save.ts
+++ b/projects/packages/forms/src/blocks/contact-form/hooks/use-synced-form-auto-save.ts
@@ -115,13 +115,15 @@ export function useSyncedFormAutoSave( {
 	const pendingTimeoutRef = useRef< ReturnType< typeof setTimeout > | null >( null );
 	const baselineRef = useRef< { ref: number; serialized: string } | null >( null );
 
-	// Reset baseline when ref changes
-	const prevRefRef = useRef< number | undefined >( undefined );
-	if ( ref !== prevRefRef.current ) {
+	// Reset baseline and clear any pending timeout when ref changes.
+	useEffect( () => {
 		baselineRef.current = null;
-		prevRefRef.current = ref;
-	}
 
+		if ( pendingTimeoutRef.current ) {
+			clearTimeout( pendingTimeoutRef.current );
+			pendingTimeoutRef.current = null;
+		}
+	}, [ ref ] );
 	useEffect( () => {
 		if ( ! ref ) {
 			return;

--- a/projects/packages/forms/src/blocks/contact-form/hooks/use-synced-form-auto-save.ts
+++ b/projects/packages/forms/src/blocks/contact-form/hooks/use-synced-form-auto-save.ts
@@ -9,17 +9,11 @@ import { FORM_POST_TYPE } from '../../shared/util/constants.js';
 import { createSyncedFormBlock, serializeSyncedForm } from '../util/form-sync.ts';
 
 interface UseSyncedFormAutoSaveParams {
-	/** The synced form post ID */
 	ref?: number;
-	/** The synced form record from the entity store */
 	syncedForm: { content?: { raw?: string } } | null;
-	/** Current form block attributes */
 	attributes: Record< string, unknown >;
-	/** Current form inner blocks */
 	currentInnerBlocks: unknown[];
-	/** Ref indicating if form is currently being synced from source */
 	isSyncingRef: React.MutableRefObject< boolean >;
-	/** Function to stage edits in the entity store */
 	editEntityRecord: (
 		kind: string,
 		name: string,
@@ -129,6 +123,9 @@ export function useSyncedFormAutoSave( {
 	}
 
 	useEffect( () => {
+		if ( ! ref ) {
+			return;
+		}
 		// Only capture baseline after sync completes to ensure it reflects synced content
 		const baseline = captureBaseline(
 			ref,
@@ -140,7 +137,7 @@ export function useSyncedFormAutoSave( {
 		);
 
 		// Not ready or no changes - don't stage
-		if ( ! baseline || ! ref ) {
+		if ( ! baseline ) {
 			return;
 		}
 
@@ -167,6 +164,9 @@ export function useSyncedFormAutoSave( {
 	}, [ currentInnerBlocks, ref, syncedForm, editEntityRecord, attributes, isSyncingRef ] );
 
 	const flushPendingSave = useCallback( () => {
+		if ( ! ref ) {
+			return;
+		}
 		const baseline = captureBaseline(
 			ref,
 			syncedForm,

--- a/projects/packages/forms/src/blocks/contact-form/hooks/use-synced-form-auto-save.ts
+++ b/projects/packages/forms/src/blocks/contact-form/hooks/use-synced-form-auto-save.ts
@@ -37,24 +37,25 @@ interface UseSyncedFormAutoSaveResult {
 
 /**
  * Captures a baseline serialization when the form first loads.
- * Returns the baseline if ready, or null if still loading/syncing.
- * @param ref
- * @param syncedForm
- * @param isSyncing
- * @param attributes
- * @param currentInnerBlocks
- * @param baselineRef
+ * Baseline is captured even during sync so it's ready when sync completes.
+ * Returns the baseline if ready, or null if still loading.
+ *
+ * @param {number | undefined}      ref                - The synced form post ID.
+ * @param {Object | null}           syncedForm         - The synced form record.
+ * @param {Record<string, unknown>} attributes         - Current form attributes.
+ * @param {unknown[]}               currentInnerBlocks - Current form inner blocks.
+ * @param {React.MutableRefObject}  baselineRef        - Ref to store the baseline.
+ * @return {string | null} The baseline serialization, or null if not ready.
  */
 export function captureBaseline(
 	ref: number | undefined,
 	syncedForm: { content?: { raw?: string } } | null,
-	isSyncing: boolean,
 	attributes: Record< string, unknown >,
 	currentInnerBlocks: unknown[],
 	baselineRef: React.MutableRefObject< { ref: number; serialized: string } | null >
 ): string | null {
-	// Not ready yet
-	if ( ! ref || ! syncedForm || isSyncing ) {
+	// Not ready yet - need ref and syncedForm to be available
+	if ( ! ref || ! syncedForm ) {
 		return null;
 	}
 
@@ -72,10 +73,11 @@ export function captureBaseline(
 /**
  * Stages form edits to the entity store.
  * Stores both serialized content and parsed blocks so the form editor can pick them up.
- * @param ref
- * @param attributes
- * @param currentInnerBlocks
- * @param editEntityRecord
+ *
+ * @param {number}                  ref                - The synced form post ID.
+ * @param {Record<string, unknown>} attributes         - Current form attributes.
+ * @param {unknown[]}               currentInnerBlocks - Current form inner blocks.
+ * @param {Function}                editEntityRecord   - Function to stage edits in entity store.
  */
 export function stageFormEdits(
 	ref: number,
@@ -100,13 +102,9 @@ export function stageFormEdits(
  * - Only stages edits when content differs from baseline
  * - Stages both `content` and `blocks` so form editor can pick up changes
  * - Does NOT save to database - only stages in entity store
- * @param root0
- * @param root0.ref
- * @param root0.syncedForm
- * @param root0.attributes
- * @param root0.currentInnerBlocks
- * @param root0.isSyncingRef
- * @param root0.editEntityRecord
+ *
+ * @param {UseSyncedFormAutoSaveParams} params - Hook parameters.
+ * @return {UseSyncedFormAutoSaveResult} Object with flushPendingSave function.
  */
 export function useSyncedFormAutoSave( {
 	ref,
@@ -127,17 +125,17 @@ export function useSyncedFormAutoSave( {
 	}
 
 	useEffect( () => {
+		// Capture baseline even during sync so it's ready when sync completes
 		const baseline = captureBaseline(
 			ref,
 			syncedForm,
-			isSyncingRef.current,
 			attributes,
 			currentInnerBlocks,
 			baselineRef
 		);
 
-		// Not ready or no changes
-		if ( ! baseline || ! ref ) {
+		// Not ready, still syncing, or no changes - don't stage
+		if ( ! baseline || ! ref || isSyncingRef.current ) {
 			return;
 		}
 
@@ -149,7 +147,10 @@ export function useSyncedFormAutoSave( {
 		// Debounce staging
 		const timeoutId = setTimeout( () => {
 			pendingTimeoutRef.current = null;
-			stageFormEdits( ref, attributes, currentInnerBlocks, editEntityRecord );
+			// Double-check we're not syncing when the timeout fires
+			if ( ! isSyncingRef.current ) {
+				stageFormEdits( ref, attributes, currentInnerBlocks, editEntityRecord );
+			}
 		}, 1000 );
 
 		pendingTimeoutRef.current = timeoutId;
@@ -161,10 +162,14 @@ export function useSyncedFormAutoSave( {
 	}, [ currentInnerBlocks, ref, syncedForm, editEntityRecord, attributes, isSyncingRef ] );
 
 	const flushPendingSave = useCallback( () => {
+		// Don't flush while syncing
+		if ( isSyncingRef.current ) {
+			return;
+		}
+
 		const baseline = captureBaseline(
 			ref,
 			syncedForm,
-			isSyncingRef.current,
 			attributes,
 			currentInnerBlocks,
 			baselineRef

--- a/projects/packages/forms/src/blocks/contact-form/hooks/use-synced-form-auto-save.ts
+++ b/projects/packages/forms/src/blocks/contact-form/hooks/use-synced-form-auto-save.ts
@@ -3,6 +3,7 @@
  * Changes are staged (not saved to DB) so they can be picked up by the form editor.
  */
 
+import { serialize } from '@wordpress/blocks';
 import { useCallback, useEffect, useRef } from '@wordpress/element';
 import { FORM_POST_TYPE } from '../../shared/util/constants.js';
 import { createSyncedFormBlock, serializeSyncedForm } from '../util/form-sync.ts';
@@ -85,8 +86,9 @@ export function stageFormEdits(
 	currentInnerBlocks: unknown[],
 	editEntityRecord: UseSyncedFormAutoSaveParams[ 'editEntityRecord' ]
 ): void {
-	const serialized = serializeSyncedForm( attributes, currentInnerBlocks );
+	// Create block once and reuse for both serialization and staging
 	const formBlock = createSyncedFormBlock( attributes, currentInnerBlocks );
+	const serialized = serialize( formBlock );
 	editEntityRecord( 'postType', FORM_POST_TYPE, ref, {
 		content: serialized,
 		blocks: [ formBlock ],

--- a/projects/packages/forms/src/blocks/contact-form/hooks/use-synced-form-auto-save.ts
+++ b/projects/packages/forms/src/blocks/contact-form/hooks/use-synced-form-auto-save.ts
@@ -38,11 +38,12 @@ interface UseSyncedFormAutoSaveResult {
 
 /**
  * Captures a baseline serialization when the form first loads.
- * Baseline is captured even during sync so it's ready when sync completes.
- * Returns the baseline if ready, or null if still loading.
+ * Only captures after sync completes to ensure baseline reflects synced content.
+ * Returns the baseline if ready, or null if still loading/syncing.
  *
  * @param {number | undefined}      ref                - The synced form post ID.
  * @param {Object | null}           syncedForm         - The synced form record.
+ * @param {boolean}                 isSyncing          - Whether sync is in progress.
  * @param {Record<string, unknown>} attributes         - Current form attributes.
  * @param {unknown[]}               currentInnerBlocks - Current form inner blocks.
  * @param {React.MutableRefObject}  baselineRef        - Ref to store the baseline.
@@ -51,12 +52,13 @@ interface UseSyncedFormAutoSaveResult {
 export function captureBaseline(
 	ref: number | undefined,
 	syncedForm: { content?: { raw?: string } } | null,
+	isSyncing: boolean,
 	attributes: Record< string, unknown >,
 	currentInnerBlocks: unknown[],
 	baselineRef: React.MutableRefObject< { ref: number; serialized: string } | null >
 ): string | null {
-	// Not ready yet - need ref and syncedForm to be available
-	if ( ! ref || ! syncedForm ) {
+	// Not ready yet - need ref and syncedForm, and sync must be complete
+	if ( ! ref || ! syncedForm || isSyncing ) {
 		return null;
 	}
 
@@ -127,17 +129,18 @@ export function useSyncedFormAutoSave( {
 	}
 
 	useEffect( () => {
-		// Capture baseline even during sync so it's ready when sync completes
+		// Only capture baseline after sync completes to ensure it reflects synced content
 		const baseline = captureBaseline(
 			ref,
 			syncedForm,
+			isSyncingRef.current,
 			attributes,
 			currentInnerBlocks,
 			baselineRef
 		);
 
-		// Not ready, still syncing, or no changes - don't stage
-		if ( ! baseline || ! ref || isSyncingRef.current ) {
+		// Not ready or no changes - don't stage
+		if ( ! baseline || ! ref ) {
 			return;
 		}
 
@@ -164,14 +167,10 @@ export function useSyncedFormAutoSave( {
 	}, [ currentInnerBlocks, ref, syncedForm, editEntityRecord, attributes, isSyncingRef ] );
 
 	const flushPendingSave = useCallback( () => {
-		// Don't flush while syncing
-		if ( isSyncingRef.current ) {
-			return;
-		}
-
 		const baseline = captureBaseline(
 			ref,
 			syncedForm,
+			isSyncingRef.current,
 			attributes,
 			currentInnerBlocks,
 			baselineRef

--- a/projects/packages/forms/src/blocks/contact-form/hooks/use-synced-form-auto-save.ts
+++ b/projects/packages/forms/src/blocks/contact-form/hooks/use-synced-form-auto-save.ts
@@ -2,20 +2,13 @@
  * Hook to auto-save editor changes back to synced form post
  */
 
-import { store as coreStore } from '@wordpress/core-data';
-import { useDispatch } from '@wordpress/data';
 import { useCallback, useEffect, useRef } from '@wordpress/element';
 import { FORM_POST_TYPE } from '../../shared/util/constants.js';
-import { serializeSyncedForm } from '../util/form-sync.ts';
+import { createSyncedFormBlock, serializeSyncedForm } from '../util/form-sync.ts';
 
-const DEBUG = true;
-const log = ( ...args: unknown[] ) => DEBUG && console.log( '[useSyncedFormAutoSave]', ...args );
-
-// Track saves for debugging
-let effectRunCount = 0;
-let saveScheduledCount = 0;
-let saveExecutedCount = 0;
-let cleanupCount = 0;
+const DEBUG = false;
+// eslint-disable-next-line no-console
+const log = ( ...args: unknown[] ) => DEBUG && console.log( '[AutoSave]', ...args );
 
 interface UseSyncedFormAutoSaveParams {
 	ref?: number;
@@ -33,8 +26,9 @@ interface UseSyncedFormAutoSaveParams {
 
 interface UseSyncedFormAutoSaveResult {
 	/**
-	 * Immediately save any pending changes, bypassing the debounce.
-	 * Call this before navigation to ensure changes are persisted.
+	 * Immediately stage any pending changes to the entity store, bypassing the debounce.
+	 * Call this before navigation to ensure edits are available in the shared store.
+	 * Note: This does NOT save to the database - it only stages edits so the form editor can access them.
 	 */
 	flushPendingSave: () => void;
 }
@@ -43,9 +37,13 @@ interface UseSyncedFormAutoSaveResult {
  * Hook to automatically save changes from the editor back to the synced form post
  * Uses a debounce strategy to avoid excessive saves (1 second delay)
  * Only saves if content has changed and we're not currently loading
- *
- * @param {UseSyncedFormAutoSaveParams} params - Configuration parameters
- * @return {UseSyncedFormAutoSaveResult} Object containing flushPendingSave function
+ * @param root0
+ * @param root0.ref
+ * @param root0.syncedForm
+ * @param root0.attributes
+ * @param root0.currentInnerBlocks
+ * @param root0.isSyncingRef
+ * @param root0.editEntityRecord
  */
 export function useSyncedFormAutoSave( {
 	ref,
@@ -55,135 +53,72 @@ export function useSyncedFormAutoSave( {
 	isSyncingRef,
 	editEntityRecord,
 }: UseSyncedFormAutoSaveParams ): UseSyncedFormAutoSaveResult {
-	const { saveEditedEntityRecord } = useDispatch( coreStore );
-
-	const renderCountRef = useRef( 0 );
-	const prevInnerBlocksRef = useRef< unknown[] | null >( null );
-	const prevAttributesRef = useRef< Record< string, unknown > | null >( null );
-	const prevSyncedFormRef = useRef< typeof syncedForm | null >( null );
-
 	// Track pending timeout so we can cancel it when flushing
 	const pendingTimeoutRef = useRef< ReturnType< typeof setTimeout > | null >( null );
-	// Track if there's a pending save that hasn't executed yet
 	const hasPendingSaveRef = useRef( false );
 
-	renderCountRef.current++;
+	// Track the initial serialized state after syncing completes.
+	// We compare against this baseline instead of the raw database content because
+	// the database content may have fewer attributes (only non-defaults are saved),
+	// while the editor block has all attributes including defaults.
+	const initialSerializedRef = useRef< string | null >( null );
+	const lastSyncedRefId = useRef< number | null >( null );
+	const wasSyncingRef = useRef( false );
 
-	// Check what changed since last render
-	const innerBlocksChanged = prevInnerBlocksRef.current !== currentInnerBlocks;
-	const attributesChanged = prevAttributesRef.current !== attributes;
-	const syncedFormChanged = prevSyncedFormRef.current !== syncedForm;
+	// Detect when syncing completes (transition from syncing to not syncing)
+	const justFinishedSyncing = wasSyncingRef.current && ! isSyncingRef.current;
+	wasSyncingRef.current = isSyncingRef.current;
 
-	log( `Render #${ renderCountRef.current }`, {
-		ref,
-		hasSyncedForm: !! syncedForm,
-		syncedFormContentLength: syncedForm?.content?.raw?.length,
-		isSyncing: isSyncingRef.current,
-		attributeKeys: Object.keys( attributes ),
-		innerBlocksCount: currentInnerBlocks.length,
-		// Track what changed
-		changes: {
-			innerBlocksChanged,
-			attributesChanged,
-			syncedFormChanged,
-		},
-	} );
+	// Reset baseline when ref changes
+	if ( ref !== lastSyncedRefId.current ) {
+		initialSerializedRef.current = null;
+		lastSyncedRefId.current = ref ?? null;
+	}
 
-	// Update refs for next comparison
-	prevInnerBlocksRef.current = currentInnerBlocks;
-	prevAttributesRef.current = attributes;
-	prevSyncedFormRef.current = syncedForm;
+	// Capture baseline after syncing completes
+	if ( justFinishedSyncing && ref && ! initialSerializedRef.current ) {
+		initialSerializedRef.current = serializeSyncedForm( attributes, currentInnerBlocks );
+		log( '📌 Baseline captured', { ref, length: initialSerializedRef.current.length } );
+	}
 
 	useEffect( () => {
-		effectRunCount++;
-		const thisEffectRun = effectRunCount;
-
-		log( `Effect #${ thisEffectRun } triggered`, {
-			ref,
-			hasSyncedForm: !! syncedForm,
-			isSyncing: isSyncingRef.current,
-			stats: { effectRunCount, saveScheduledCount, saveExecutedCount, cleanupCount },
-		} );
-
-		if ( ! ref ) {
-			log( `Effect #${ thisEffectRun } ⏭️ Skipping: no ref` );
+		// Skip if not ready
+		if ( ! ref || ! syncedForm || isSyncingRef.current || ! initialSerializedRef.current ) {
 			return;
 		}
 
-		if ( ! syncedForm ) {
-			log( `Effect #${ thisEffectRun } ⏭️ Skipping: no syncedForm` );
-			return;
-		}
-
-		if ( isSyncingRef.current ) {
-			log(
-				`Effect #${ thisEffectRun } ⏭️ Skipping: currently syncing (isSyncingRef.current = true)`
-			);
-			return;
-		}
-
-		// Serialize the entire form block
 		const serialized = serializeSyncedForm( attributes, currentInnerBlocks );
-		const savedContent = syncedForm.content?.raw;
+		const baseline = initialSerializedRef.current;
 
-		log( `Effect #${ thisEffectRun } 📊 Content comparison`, {
-			serializedLength: serialized.length,
-			savedContentLength: savedContent?.length ?? 0,
-			areEqual: serialized === savedContent,
-			serializedPreview: serialized.substring( 0, 200 ),
-			savedContentPreview: savedContent?.substring( 0, 200 ),
-		} );
-
-		// Only update if content has changed
-		if ( serialized !== savedContent ) {
-			saveScheduledCount++;
-			const thisSaveScheduled = saveScheduledCount;
-			log(
-				`Effect #${ thisEffectRun } ⏳ Save #${ thisSaveScheduled } scheduled (1000ms debounce)`
-			);
-
-			// Mark that we have a pending save
+		// Only stage edits if content changed from baseline
+		if ( serialized !== baseline ) {
 			hasPendingSaveRef.current = true;
 
-			// Debounce to avoid excessive saves
 			const timeoutId = setTimeout( () => {
-				saveExecutedCount++;
 				hasPendingSaveRef.current = false;
 				pendingTimeoutRef.current = null;
-				log(
-					`Effect #${ thisEffectRun } 💾 Save #${ thisSaveScheduled } EXECUTING (executed: ${ saveExecutedCount })`,
-					{
-						ref,
-						contentLength: serialized.length,
-					}
-				);
+				log( '💾 Staging edits', { ref } );
+				// Stage both content (for saving) and blocks (for block editor to pick up)
+				const formBlock = createSyncedFormBlock( attributes, currentInnerBlocks );
 				editEntityRecord( 'postType', FORM_POST_TYPE, ref, {
 					content: serialized,
+					blocks: [ formBlock ],
 				} );
-			}, 1000 ); // 1 second debounce
+			}, 1000 );
 
-			// Store timeout ref so flushPendingSave can cancel it
 			pendingTimeoutRef.current = timeoutId;
 
 			return () => {
-				cleanupCount++;
-				log(
-					`Effect #${ thisEffectRun } 🧹 Cleanup #${ cleanupCount }: Save #${ thisSaveScheduled } CANCELLED`
-				);
 				clearTimeout( timeoutId );
 				pendingTimeoutRef.current = null;
-				// Note: hasPendingSaveRef stays true because the save was cancelled, not completed
 			};
 		}
-		hasPendingSaveRef.current = false;
 
-		log( `Effect #${ thisEffectRun } ✅ Content matches saved, no save needed` );
+		hasPendingSaveRef.current = false;
 	}, [ currentInnerBlocks, ref, syncedForm, editEntityRecord, attributes, isSyncingRef ] );
 
-	// Function to immediately save any pending changes to the database
-	const flushPendingSave = useCallback( async () => {
-		if ( ! ref || ! syncedForm || isSyncingRef.current ) {
-			log( 'flushPendingSave: skipping (no ref, no syncedForm, or syncing)' );
+	const flushPendingSave = useCallback( () => {
+		if ( ! ref || ! syncedForm || isSyncingRef.current || ! initialSerializedRef.current ) {
 			return;
 		}
 
@@ -193,43 +128,22 @@ export function useSyncedFormAutoSave( {
 			pendingTimeoutRef.current = null;
 		}
 
-		// Serialize and save immediately
 		const serialized = serializeSyncedForm( attributes, currentInnerBlocks );
-		const savedContent = syncedForm.content?.raw;
+		const baseline = initialSerializedRef.current;
 
-		if ( serialized !== savedContent ) {
-			log( '🚨 flushPendingSave: SAVING TO DATABASE', {
-				ref,
-				contentLength: serialized.length,
-				hadPendingSave: hasPendingSaveRef.current,
-			} );
-
-			// First update the entity record (creates pending edits)
+		if ( serialized !== baseline ) {
+			log( '📝 Flush: staging edits', { ref } );
+			// Stage both content (for saving) and blocks (for block editor to pick up)
+			const formBlock = createSyncedFormBlock( attributes, currentInnerBlocks );
 			editEntityRecord( 'postType', FORM_POST_TYPE, ref, {
 				content: serialized,
+				blocks: [ formBlock ],
 			} );
-
-			// Then actually save to the database
-			try {
-				await saveEditedEntityRecord( 'postType', FORM_POST_TYPE, ref );
-				log( '✅ flushPendingSave: saved to database successfully' );
-			} catch ( error ) {
-				log( '❌ flushPendingSave: failed to save to database', error );
-			}
-
 			hasPendingSaveRef.current = false;
 		} else {
-			log( 'flushPendingSave: no changes to save' );
+			log( '✅ Flush: no changes' );
 		}
-	}, [
-		ref,
-		syncedForm,
-		attributes,
-		currentInnerBlocks,
-		isSyncingRef,
-		editEntityRecord,
-		saveEditedEntityRecord,
-	] );
+	}, [ ref, syncedForm, attributes, currentInnerBlocks, isSyncingRef, editEntityRecord ] );
 
 	return { flushPendingSave };
 }

--- a/projects/packages/forms/src/blocks/contact-form/hooks/use-synced-form-auto-save.ts
+++ b/projects/packages/forms/src/blocks/contact-form/hooks/use-synced-form-auto-save.ts
@@ -1,21 +1,24 @@
 /**
- * Hook to auto-save editor changes back to synced form post
+ * Hook to stage editor changes to the entity store for synced forms.
+ * Changes are staged (not saved to DB) so they can be picked up by the form editor.
  */
 
 import { useCallback, useEffect, useRef } from '@wordpress/element';
 import { FORM_POST_TYPE } from '../../shared/util/constants.js';
 import { createSyncedFormBlock, serializeSyncedForm } from '../util/form-sync.ts';
 
-const DEBUG = false;
-// eslint-disable-next-line no-console
-const log = ( ...args: unknown[] ) => DEBUG && console.log( '[AutoSave]', ...args );
-
 interface UseSyncedFormAutoSaveParams {
+	/** The synced form post ID */
 	ref?: number;
+	/** The synced form record from the entity store */
 	syncedForm: { content?: { raw?: string } } | null;
+	/** Current form block attributes */
 	attributes: Record< string, unknown >;
+	/** Current form inner blocks */
 	currentInnerBlocks: unknown[];
+	/** Ref indicating if form is currently being synced from source */
 	isSyncingRef: React.MutableRefObject< boolean >;
+	/** Function to stage edits in the entity store */
 	editEntityRecord: (
 		kind: string,
 		name: string,
@@ -26,17 +29,77 @@ interface UseSyncedFormAutoSaveParams {
 
 interface UseSyncedFormAutoSaveResult {
 	/**
-	 * Immediately stage any pending changes to the entity store, bypassing the debounce.
+	 * Stage any pending changes to the entity store immediately.
 	 * Call this before navigation to ensure edits are available in the shared store.
-	 * Note: This does NOT save to the database - it only stages edits so the form editor can access them.
 	 */
 	flushPendingSave: () => void;
 }
 
 /**
- * Hook to automatically save changes from the editor back to the synced form post
- * Uses a debounce strategy to avoid excessive saves (1 second delay)
- * Only saves if content has changed and we're not currently loading
+ * Captures a baseline serialization when the form first loads.
+ * Returns the baseline if ready, or null if still loading/syncing.
+ * @param ref
+ * @param syncedForm
+ * @param isSyncing
+ * @param attributes
+ * @param currentInnerBlocks
+ * @param baselineRef
+ */
+export function captureBaseline(
+	ref: number | undefined,
+	syncedForm: { content?: { raw?: string } } | null,
+	isSyncing: boolean,
+	attributes: Record< string, unknown >,
+	currentInnerBlocks: unknown[],
+	baselineRef: React.MutableRefObject< { ref: number; serialized: string } | null >
+): string | null {
+	// Not ready yet
+	if ( ! ref || ! syncedForm || isSyncing ) {
+		return null;
+	}
+
+	// Already have baseline for this ref
+	if ( baselineRef.current?.ref === ref ) {
+		return baselineRef.current.serialized;
+	}
+
+	// Capture new baseline
+	const serialized = serializeSyncedForm( attributes, currentInnerBlocks );
+	baselineRef.current = { ref, serialized };
+	return serialized;
+}
+
+/**
+ * Stages form edits to the entity store.
+ * Stores both serialized content and parsed blocks so the form editor can pick them up.
+ * @param ref
+ * @param attributes
+ * @param currentInnerBlocks
+ * @param editEntityRecord
+ */
+export function stageFormEdits(
+	ref: number,
+	attributes: Record< string, unknown >,
+	currentInnerBlocks: unknown[],
+	editEntityRecord: UseSyncedFormAutoSaveParams[ 'editEntityRecord' ]
+): void {
+	const serialized = serializeSyncedForm( attributes, currentInnerBlocks );
+	const formBlock = createSyncedFormBlock( attributes, currentInnerBlocks );
+	editEntityRecord( 'postType', FORM_POST_TYPE, ref, {
+		content: serialized,
+		blocks: [ formBlock ],
+	} );
+}
+
+/**
+ * Hook to automatically stage changes from the editor to the entity store.
+ * Uses a 1 second debounce to avoid excessive updates.
+ *
+ * Key behaviors:
+ * - Captures a baseline when the form first loads (after sync completes)
+ * - Only stages edits when content differs from baseline
+ * - Stages both `content` and `blocks` so form editor can pick up changes
+ * - Does NOT save to database - only stages in entity store
  * @param root0
  * @param root0.ref
  * @param root0.syncedForm
@@ -53,95 +116,73 @@ export function useSyncedFormAutoSave( {
 	isSyncingRef,
 	editEntityRecord,
 }: UseSyncedFormAutoSaveParams ): UseSyncedFormAutoSaveResult {
-	// Track pending timeout so we can cancel it when flushing
 	const pendingTimeoutRef = useRef< ReturnType< typeof setTimeout > | null >( null );
-	const hasPendingSaveRef = useRef( false );
-
-	// Track the initial serialized state after syncing completes.
-	// We compare against this baseline instead of the raw database content because
-	// the database content may have fewer attributes (only non-defaults are saved),
-	// while the editor block has all attributes including defaults.
-	const initialSerializedRef = useRef< string | null >( null );
-	const lastSyncedRefId = useRef< number | null >( null );
-	const wasSyncingRef = useRef( false );
-
-	// Detect when syncing completes (transition from syncing to not syncing)
-	const justFinishedSyncing = wasSyncingRef.current && ! isSyncingRef.current;
-	wasSyncingRef.current = isSyncingRef.current;
+	const baselineRef = useRef< { ref: number; serialized: string } | null >( null );
 
 	// Reset baseline when ref changes
-	if ( ref !== lastSyncedRefId.current ) {
-		initialSerializedRef.current = null;
-		lastSyncedRefId.current = ref ?? null;
-	}
-
-	// Capture baseline after syncing completes
-	if ( justFinishedSyncing && ref && ! initialSerializedRef.current ) {
-		initialSerializedRef.current = serializeSyncedForm( attributes, currentInnerBlocks );
-		log( '📌 Baseline captured', { ref, length: initialSerializedRef.current.length } );
+	const prevRefRef = useRef< number | undefined >( undefined );
+	if ( ref !== prevRefRef.current ) {
+		baselineRef.current = null;
+		prevRefRef.current = ref;
 	}
 
 	useEffect( () => {
-		// Skip if not ready
-		if ( ! ref || ! syncedForm || isSyncingRef.current || ! initialSerializedRef.current ) {
+		const baseline = captureBaseline(
+			ref,
+			syncedForm,
+			isSyncingRef.current,
+			attributes,
+			currentInnerBlocks,
+			baselineRef
+		);
+
+		// Not ready or no changes
+		if ( ! baseline || ! ref ) {
 			return;
 		}
 
 		const serialized = serializeSyncedForm( attributes, currentInnerBlocks );
-		const baseline = initialSerializedRef.current;
-
-		// Only stage edits if content changed from baseline
-		if ( serialized !== baseline ) {
-			hasPendingSaveRef.current = true;
-
-			const timeoutId = setTimeout( () => {
-				hasPendingSaveRef.current = false;
-				pendingTimeoutRef.current = null;
-				log( '💾 Staging edits', { ref } );
-				// Stage both content (for saving) and blocks (for block editor to pick up)
-				const formBlock = createSyncedFormBlock( attributes, currentInnerBlocks );
-				editEntityRecord( 'postType', FORM_POST_TYPE, ref, {
-					content: serialized,
-					blocks: [ formBlock ],
-				} );
-			}, 1000 );
-
-			pendingTimeoutRef.current = timeoutId;
-
-			return () => {
-				clearTimeout( timeoutId );
-				pendingTimeoutRef.current = null;
-			};
-		}
-
-		hasPendingSaveRef.current = false;
-	}, [ currentInnerBlocks, ref, syncedForm, editEntityRecord, attributes, isSyncingRef ] );
-
-	const flushPendingSave = useCallback( () => {
-		if ( ! ref || ! syncedForm || isSyncingRef.current || ! initialSerializedRef.current ) {
+		if ( serialized === baseline ) {
 			return;
 		}
 
-		// Cancel pending timeout if any
+		// Debounce staging
+		const timeoutId = setTimeout( () => {
+			pendingTimeoutRef.current = null;
+			stageFormEdits( ref, attributes, currentInnerBlocks, editEntityRecord );
+		}, 1000 );
+
+		pendingTimeoutRef.current = timeoutId;
+
+		return () => {
+			clearTimeout( timeoutId );
+			pendingTimeoutRef.current = null;
+		};
+	}, [ currentInnerBlocks, ref, syncedForm, editEntityRecord, attributes, isSyncingRef ] );
+
+	const flushPendingSave = useCallback( () => {
+		const baseline = captureBaseline(
+			ref,
+			syncedForm,
+			isSyncingRef.current,
+			attributes,
+			currentInnerBlocks,
+			baselineRef
+		);
+
+		if ( ! baseline || ! ref ) {
+			return;
+		}
+
+		// Cancel pending debounced save
 		if ( pendingTimeoutRef.current ) {
 			clearTimeout( pendingTimeoutRef.current );
 			pendingTimeoutRef.current = null;
 		}
 
 		const serialized = serializeSyncedForm( attributes, currentInnerBlocks );
-		const baseline = initialSerializedRef.current;
-
 		if ( serialized !== baseline ) {
-			log( '📝 Flush: staging edits', { ref } );
-			// Stage both content (for saving) and blocks (for block editor to pick up)
-			const formBlock = createSyncedFormBlock( attributes, currentInnerBlocks );
-			editEntityRecord( 'postType', FORM_POST_TYPE, ref, {
-				content: serialized,
-				blocks: [ formBlock ],
-			} );
-			hasPendingSaveRef.current = false;
-		} else {
-			log( '✅ Flush: no changes' );
+			stageFormEdits( ref, attributes, currentInnerBlocks, editEntityRecord );
 		}
 	}, [ ref, syncedForm, attributes, currentInnerBlocks, isSyncingRef, editEntityRecord ] );
 

--- a/projects/packages/forms/src/blocks/contact-form/hooks/use-synced-form-auto-save.ts
+++ b/projects/packages/forms/src/blocks/contact-form/hooks/use-synced-form-auto-save.ts
@@ -2,9 +2,20 @@
  * Hook to auto-save editor changes back to synced form post
  */
 
-import { useEffect } from '@wordpress/element';
+import { store as coreStore } from '@wordpress/core-data';
+import { useDispatch } from '@wordpress/data';
+import { useCallback, useEffect, useRef } from '@wordpress/element';
 import { FORM_POST_TYPE } from '../../shared/util/constants.js';
 import { serializeSyncedForm } from '../util/form-sync.ts';
+
+const DEBUG = true;
+const log = ( ...args: unknown[] ) => DEBUG && console.log( '[useSyncedFormAutoSave]', ...args );
+
+// Track saves for debugging
+let effectRunCount = 0;
+let saveScheduledCount = 0;
+let saveExecutedCount = 0;
+let cleanupCount = 0;
 
 interface UseSyncedFormAutoSaveParams {
 	ref?: number;
@@ -20,12 +31,21 @@ interface UseSyncedFormAutoSaveParams {
 	) => void;
 }
 
+interface UseSyncedFormAutoSaveResult {
+	/**
+	 * Immediately save any pending changes, bypassing the debounce.
+	 * Call this before navigation to ensure changes are persisted.
+	 */
+	flushPendingSave: () => void;
+}
+
 /**
  * Hook to automatically save changes from the editor back to the synced form post
  * Uses a debounce strategy to avoid excessive saves (1 second delay)
  * Only saves if content has changed and we're not currently loading
  *
  * @param {UseSyncedFormAutoSaveParams} params - Configuration parameters
+ * @return {UseSyncedFormAutoSaveResult} Object containing flushPendingSave function
  */
 export function useSyncedFormAutoSave( {
 	ref,
@@ -34,25 +54,182 @@ export function useSyncedFormAutoSave( {
 	currentInnerBlocks,
 	isSyncingRef,
 	editEntityRecord,
-}: UseSyncedFormAutoSaveParams ): void {
+}: UseSyncedFormAutoSaveParams ): UseSyncedFormAutoSaveResult {
+	const { saveEditedEntityRecord } = useDispatch( coreStore );
+
+	const renderCountRef = useRef( 0 );
+	const prevInnerBlocksRef = useRef< unknown[] | null >( null );
+	const prevAttributesRef = useRef< Record< string, unknown > | null >( null );
+	const prevSyncedFormRef = useRef< typeof syncedForm | null >( null );
+
+	// Track pending timeout so we can cancel it when flushing
+	const pendingTimeoutRef = useRef< ReturnType< typeof setTimeout > | null >( null );
+	// Track if there's a pending save that hasn't executed yet
+	const hasPendingSaveRef = useRef( false );
+
+	renderCountRef.current++;
+
+	// Check what changed since last render
+	const innerBlocksChanged = prevInnerBlocksRef.current !== currentInnerBlocks;
+	const attributesChanged = prevAttributesRef.current !== attributes;
+	const syncedFormChanged = prevSyncedFormRef.current !== syncedForm;
+
+	log( `Render #${ renderCountRef.current }`, {
+		ref,
+		hasSyncedForm: !! syncedForm,
+		syncedFormContentLength: syncedForm?.content?.raw?.length,
+		isSyncing: isSyncingRef.current,
+		attributeKeys: Object.keys( attributes ),
+		innerBlocksCount: currentInnerBlocks.length,
+		// Track what changed
+		changes: {
+			innerBlocksChanged,
+			attributesChanged,
+			syncedFormChanged,
+		},
+	} );
+
+	// Update refs for next comparison
+	prevInnerBlocksRef.current = currentInnerBlocks;
+	prevAttributesRef.current = attributes;
+	prevSyncedFormRef.current = syncedForm;
+
 	useEffect( () => {
-		if ( ! ref || ! syncedForm || isSyncingRef.current ) {
-			return; // Not a synced form or currently syncing
+		effectRunCount++;
+		const thisEffectRun = effectRunCount;
+
+		log( `Effect #${ thisEffectRun } triggered`, {
+			ref,
+			hasSyncedForm: !! syncedForm,
+			isSyncing: isSyncingRef.current,
+			stats: { effectRunCount, saveScheduledCount, saveExecutedCount, cleanupCount },
+		} );
+
+		if ( ! ref ) {
+			log( `Effect #${ thisEffectRun } ⏭️ Skipping: no ref` );
+			return;
+		}
+
+		if ( ! syncedForm ) {
+			log( `Effect #${ thisEffectRun } ⏭️ Skipping: no syncedForm` );
+			return;
+		}
+
+		if ( isSyncingRef.current ) {
+			log(
+				`Effect #${ thisEffectRun } ⏭️ Skipping: currently syncing (isSyncingRef.current = true)`
+			);
+			return;
 		}
 
 		// Serialize the entire form block
 		const serialized = serializeSyncedForm( attributes, currentInnerBlocks );
+		const savedContent = syncedForm.content?.raw;
+
+		log( `Effect #${ thisEffectRun } 📊 Content comparison`, {
+			serializedLength: serialized.length,
+			savedContentLength: savedContent?.length ?? 0,
+			areEqual: serialized === savedContent,
+			serializedPreview: serialized.substring( 0, 200 ),
+			savedContentPreview: savedContent?.substring( 0, 200 ),
+		} );
 
 		// Only update if content has changed
-		if ( serialized !== syncedForm.content?.raw ) {
+		if ( serialized !== savedContent ) {
+			saveScheduledCount++;
+			const thisSaveScheduled = saveScheduledCount;
+			log(
+				`Effect #${ thisEffectRun } ⏳ Save #${ thisSaveScheduled } scheduled (1000ms debounce)`
+			);
+
+			// Mark that we have a pending save
+			hasPendingSaveRef.current = true;
+
 			// Debounce to avoid excessive saves
 			const timeoutId = setTimeout( () => {
+				saveExecutedCount++;
+				hasPendingSaveRef.current = false;
+				pendingTimeoutRef.current = null;
+				log(
+					`Effect #${ thisEffectRun } 💾 Save #${ thisSaveScheduled } EXECUTING (executed: ${ saveExecutedCount })`,
+					{
+						ref,
+						contentLength: serialized.length,
+					}
+				);
 				editEntityRecord( 'postType', FORM_POST_TYPE, ref, {
 					content: serialized,
 				} );
 			}, 1000 ); // 1 second debounce
 
-			return () => clearTimeout( timeoutId );
+			// Store timeout ref so flushPendingSave can cancel it
+			pendingTimeoutRef.current = timeoutId;
+
+			return () => {
+				cleanupCount++;
+				log(
+					`Effect #${ thisEffectRun } 🧹 Cleanup #${ cleanupCount }: Save #${ thisSaveScheduled } CANCELLED`
+				);
+				clearTimeout( timeoutId );
+				pendingTimeoutRef.current = null;
+				// Note: hasPendingSaveRef stays true because the save was cancelled, not completed
+			};
 		}
+		hasPendingSaveRef.current = false;
+
+		log( `Effect #${ thisEffectRun } ✅ Content matches saved, no save needed` );
 	}, [ currentInnerBlocks, ref, syncedForm, editEntityRecord, attributes, isSyncingRef ] );
+
+	// Function to immediately save any pending changes to the database
+	const flushPendingSave = useCallback( async () => {
+		if ( ! ref || ! syncedForm || isSyncingRef.current ) {
+			log( 'flushPendingSave: skipping (no ref, no syncedForm, or syncing)' );
+			return;
+		}
+
+		// Cancel pending timeout if any
+		if ( pendingTimeoutRef.current ) {
+			clearTimeout( pendingTimeoutRef.current );
+			pendingTimeoutRef.current = null;
+		}
+
+		// Serialize and save immediately
+		const serialized = serializeSyncedForm( attributes, currentInnerBlocks );
+		const savedContent = syncedForm.content?.raw;
+
+		if ( serialized !== savedContent ) {
+			log( '🚨 flushPendingSave: SAVING TO DATABASE', {
+				ref,
+				contentLength: serialized.length,
+				hadPendingSave: hasPendingSaveRef.current,
+			} );
+
+			// First update the entity record (creates pending edits)
+			editEntityRecord( 'postType', FORM_POST_TYPE, ref, {
+				content: serialized,
+			} );
+
+			// Then actually save to the database
+			try {
+				await saveEditedEntityRecord( 'postType', FORM_POST_TYPE, ref );
+				log( '✅ flushPendingSave: saved to database successfully' );
+			} catch ( error ) {
+				log( '❌ flushPendingSave: failed to save to database', error );
+			}
+
+			hasPendingSaveRef.current = false;
+		} else {
+			log( 'flushPendingSave: no changes to save' );
+		}
+	}, [
+		ref,
+		syncedForm,
+		attributes,
+		currentInnerBlocks,
+		isSyncingRef,
+		editEntityRecord,
+		saveEditedEntityRecord,
+	] );
+
+	return { flushPendingSave };
 }

--- a/projects/packages/forms/src/blocks/contact-form/hooks/use-synced-form-auto-save.ts
+++ b/projects/packages/forms/src/blocks/contact-form/hooks/use-synced-form-auto-save.ts
@@ -176,7 +176,7 @@ export function useSyncedFormAutoSave( {
 			baselineRef
 		);
 
-		if ( ! baseline || ! ref ) {
+		if ( ! baseline ) {
 			return;
 		}
 

--- a/projects/packages/forms/src/blocks/contact-form/hooks/use-synced-form-loader.ts
+++ b/projects/packages/forms/src/blocks/contact-form/hooks/use-synced-form-loader.ts
@@ -46,7 +46,7 @@ function findFirstStepClientId( blocks: Block[] ): string | null {
 /**
  * Hook to handle loading synced form content into the editor.
  * Performs a one-time sync when the ref changes or loads for the first time.
- * After loading, the user can edit freely and changes will be saved back via auto-save.
+ * After loading, the user can edit freely and changes will be staged via auto-save.
  *
  * @param {UseSyncedFormLoaderParams} params - Configuration parameters.
  * @return {UseSyncedFormLoaderResult} Object containing syncing state ref.

--- a/projects/packages/forms/src/blocks/contact-form/hooks/use-synced-form-loader.ts
+++ b/projects/packages/forms/src/blocks/contact-form/hooks/use-synced-form-loader.ts
@@ -6,9 +6,6 @@ import { useEffect, useRef } from '@wordpress/element';
 import { filterSyncedAttributes } from '../util/form-sync.ts';
 import type { Block } from '@wordpress/blocks';
 
-const DEBUG = true;
-const log = ( ...args: unknown[] ) => DEBUG && console.log( '[useSyncedFormLoader]', ...args );
-
 interface UseSyncedFormLoaderParams {
 	ref?: number;
 	syncedFormBlocks: Block[] | null;
@@ -26,9 +23,7 @@ interface UseSyncedFormLoaderResult {
 
 /**
  * Helper to find the first step block in a multistep form structure.
- *
- * @param {Block[]} blocks - The blocks to search through.
- * @return {string|null} The clientId of the first step block, or null if not found.
+ * @param blocks
  */
 function findFirstStepClientId( blocks: Block[] ): string | null {
 	for ( const block of blocks ) {
@@ -50,9 +45,15 @@ function findFirstStepClientId( blocks: Block[] ): string | null {
  * Hook to handle loading synced form content into the editor
  * This performs a one-time sync when the ref changes or loads for the first time
  * After loading, the user can edit freely and changes will be saved back via auto-save
- *
- * @param {UseSyncedFormLoaderParams} params - Configuration parameters
- * @return {UseSyncedFormLoaderResult} Object containing syncing state ref
+ * @param root0
+ * @param root0.ref
+ * @param root0.syncedFormBlocks
+ * @param root0.syncedFormAttributes
+ * @param root0.clientId
+ * @param root0.setAttributes
+ * @param root0.replaceInnerBlocks
+ * @param root0.__unstableMarkNextChangeAsNotPersistent
+ * @param root0.setActiveStep
  */
 export function useSyncedFormLoader( {
 	ref,
@@ -69,63 +70,38 @@ export function useSyncedFormLoader( {
 	const lastLoadedRefId = useRef< number | null >( null );
 
 	useEffect( () => {
-		log( 'Effect triggered', {
-			ref,
-			hasSyncedFormBlocks: !! syncedFormBlocks,
-			syncedFormBlocksCount: syncedFormBlocks?.length,
-			lastLoadedRefId: lastLoadedRefId.current,
-		} );
-
 		if ( ! ref || ! syncedFormBlocks ) {
-			log( '⏭️ Skipping: no ref or no syncedFormBlocks' );
 			return;
 		}
 
 		// Only sync when ref changes or loads for the first time
-		// Don't re-sync when syncedFormBlocks changes due to our own edits
 		if ( lastLoadedRefId.current === ref ) {
-			log( '⏭️ Skipping: already loaded this ref', { ref } );
-			return; // Already loaded this ref
+			return;
 		}
-
-		log( '🔄 Loading synced form content', {
-			ref,
-			blocksCount: syncedFormBlocks.length,
-			hasAttributes: !! syncedFormAttributes,
-		} );
 
 		// Mark this ref as loaded
 		lastLoadedRefId.current = ref;
-
-		// Sync on initial load
-		// Once loaded, the user can edit freely and changes will save back to the source
 		isSyncingRef.current = true;
 
 		// Apply form attributes from the synced form (except ref and layout attrs)
-		// Mark as non-persistent so they're not saved locally - only ref is saved
 		if ( syncedFormAttributes ) {
 			const attrsToApply = filterSyncedAttributes( syncedFormAttributes );
-			log( '📝 Applying synced attributes', { attrsToApply } );
 			__unstableMarkNextChangeAsNotPersistent();
 			setAttributes( attrsToApply );
 		}
 
 		// Load inner blocks from source
-		log( '📦 Replacing inner blocks', { blocksCount: syncedFormBlocks.length } );
 		__unstableMarkNextChangeAsNotPersistent();
 		replaceInnerBlocks( clientId, syncedFormBlocks, false );
 
-		// For multistep forms, select the first step so the editor shows it immediately
+		// For multistep forms, select the first step
 		const firstStepClientId = findFirstStepClientId( syncedFormBlocks );
 		if ( firstStepClientId ) {
-			log( '📍 Setting active step', { firstStepClientId } );
 			setActiveStep( clientId, firstStepClientId );
 		}
 
-		// Reset syncing flag immediately after operations complete
-		// Using requestAnimationFrame to ensure it happens after React commits
+		// Reset syncing flag after React commits
 		requestAnimationFrame( () => {
-			log( '✅ Syncing complete, resetting isSyncingRef' );
 			isSyncingRef.current = false;
 		} );
 	}, [

--- a/projects/packages/forms/src/blocks/contact-form/hooks/use-synced-form-loader.ts
+++ b/projects/packages/forms/src/blocks/contact-form/hooks/use-synced-form-loader.ts
@@ -108,6 +108,8 @@ export function useSyncedFormLoader( {
 			if ( rafIdRef.current !== null ) {
 				cancelAnimationFrame( rafIdRef.current );
 				rafIdRef.current = null;
+				// Reset syncing flag since we're canceling the scheduled reset
+				isSyncingRef.current = false;
 			}
 		};
 	}, [

--- a/projects/packages/forms/src/blocks/contact-form/hooks/use-synced-form-loader.ts
+++ b/projects/packages/forms/src/blocks/contact-form/hooks/use-synced-form-loader.ts
@@ -23,7 +23,9 @@ interface UseSyncedFormLoaderResult {
 
 /**
  * Helper to find the first step block in a multistep form structure.
- * @param blocks
+ *
+ * @param {Block[]} blocks - The blocks to search through.
+ * @return {string | null} The clientId of the first step block, or null if not found.
  */
 function findFirstStepClientId( blocks: Block[] ): string | null {
 	for ( const block of blocks ) {
@@ -42,18 +44,12 @@ function findFirstStepClientId( blocks: Block[] ): string | null {
 }
 
 /**
- * Hook to handle loading synced form content into the editor
- * This performs a one-time sync when the ref changes or loads for the first time
- * After loading, the user can edit freely and changes will be saved back via auto-save
- * @param root0
- * @param root0.ref
- * @param root0.syncedFormBlocks
- * @param root0.syncedFormAttributes
- * @param root0.clientId
- * @param root0.setAttributes
- * @param root0.replaceInnerBlocks
- * @param root0.__unstableMarkNextChangeAsNotPersistent
- * @param root0.setActiveStep
+ * Hook to handle loading synced form content into the editor.
+ * Performs a one-time sync when the ref changes or loads for the first time.
+ * After loading, the user can edit freely and changes will be saved back via auto-save.
+ *
+ * @param {UseSyncedFormLoaderParams} params - Configuration parameters.
+ * @return {UseSyncedFormLoaderResult} Object containing syncing state ref.
  */
 export function useSyncedFormLoader( {
 	ref,
@@ -68,6 +64,7 @@ export function useSyncedFormLoader( {
 	// Track if we're currently syncing to prevent save-back loops
 	const isSyncingRef = useRef( false );
 	const lastLoadedRefId = useRef< number | null >( null );
+	const rafIdRef = useRef< number | null >( null );
 
 	useEffect( () => {
 		if ( ! ref || ! syncedFormBlocks ) {
@@ -101,9 +98,18 @@ export function useSyncedFormLoader( {
 		}
 
 		// Reset syncing flag after React commits
-		requestAnimationFrame( () => {
+		rafIdRef.current = requestAnimationFrame( () => {
+			rafIdRef.current = null;
 			isSyncingRef.current = false;
 		} );
+
+		// Cleanup: cancel pending rAF if component unmounts or effect re-runs
+		return () => {
+			if ( rafIdRef.current !== null ) {
+				cancelAnimationFrame( rafIdRef.current );
+				rafIdRef.current = null;
+			}
+		};
 	}, [
 		ref,
 		syncedFormBlocks,

--- a/projects/packages/forms/src/blocks/contact-form/hooks/use-synced-form-loader.ts
+++ b/projects/packages/forms/src/blocks/contact-form/hooks/use-synced-form-loader.ts
@@ -6,6 +6,9 @@ import { useEffect, useRef } from '@wordpress/element';
 import { filterSyncedAttributes } from '../util/form-sync.ts';
 import type { Block } from '@wordpress/blocks';
 
+const DEBUG = true;
+const log = ( ...args: unknown[] ) => DEBUG && console.log( '[useSyncedFormLoader]', ...args );
+
 interface UseSyncedFormLoaderParams {
 	ref?: number;
 	syncedFormBlocks: Block[] | null;
@@ -66,15 +69,30 @@ export function useSyncedFormLoader( {
 	const lastLoadedRefId = useRef< number | null >( null );
 
 	useEffect( () => {
+		log( 'Effect triggered', {
+			ref,
+			hasSyncedFormBlocks: !! syncedFormBlocks,
+			syncedFormBlocksCount: syncedFormBlocks?.length,
+			lastLoadedRefId: lastLoadedRefId.current,
+		} );
+
 		if ( ! ref || ! syncedFormBlocks ) {
+			log( '⏭️ Skipping: no ref or no syncedFormBlocks' );
 			return;
 		}
 
 		// Only sync when ref changes or loads for the first time
 		// Don't re-sync when syncedFormBlocks changes due to our own edits
 		if ( lastLoadedRefId.current === ref ) {
+			log( '⏭️ Skipping: already loaded this ref', { ref } );
 			return; // Already loaded this ref
 		}
+
+		log( '🔄 Loading synced form content', {
+			ref,
+			blocksCount: syncedFormBlocks.length,
+			hasAttributes: !! syncedFormAttributes,
+		} );
 
 		// Mark this ref as loaded
 		lastLoadedRefId.current = ref;
@@ -87,29 +105,29 @@ export function useSyncedFormLoader( {
 		// Mark as non-persistent so they're not saved locally - only ref is saved
 		if ( syncedFormAttributes ) {
 			const attrsToApply = filterSyncedAttributes( syncedFormAttributes );
-
+			log( '📝 Applying synced attributes', { attrsToApply } );
 			__unstableMarkNextChangeAsNotPersistent();
 			setAttributes( attrsToApply );
 		}
 
 		// Load inner blocks from source
+		log( '📦 Replacing inner blocks', { blocksCount: syncedFormBlocks.length } );
 		__unstableMarkNextChangeAsNotPersistent();
 		replaceInnerBlocks( clientId, syncedFormBlocks, false );
 
 		// For multistep forms, select the first step so the editor shows it immediately
 		const firstStepClientId = findFirstStepClientId( syncedFormBlocks );
 		if ( firstStepClientId ) {
+			log( '📍 Setting active step', { firstStepClientId } );
 			setActiveStep( clientId, firstStepClientId );
 		}
 
-		// Reset syncing flag after a short delay
-		const timeoutId = setTimeout( () => {
+		// Reset syncing flag immediately after operations complete
+		// Using requestAnimationFrame to ensure it happens after React commits
+		requestAnimationFrame( () => {
+			log( '✅ Syncing complete, resetting isSyncingRef' );
 			isSyncingRef.current = false;
-		}, 100 );
-
-		return () => {
-			clearTimeout( timeoutId );
-		};
+		} );
 	}, [
 		ref,
 		syncedFormBlocks,

--- a/projects/packages/forms/src/blocks/contact-form/hooks/use-synced-form-loader.ts
+++ b/projects/packages/forms/src/blocks/contact-form/hooks/use-synced-form-loader.ts
@@ -64,7 +64,7 @@ export function useSyncedFormLoader( {
 	// Track if we're currently syncing to prevent save-back loops
 	const isSyncingRef = useRef( false );
 	const lastLoadedRefId = useRef< number | null >( null );
-	const rafIdRef = useRef< number | null >( null );
+	const animationFrameIdRef = useRef< number | null >( null );
 
 	useEffect( () => {
 		if ( ! ref || ! syncedFormBlocks ) {
@@ -98,16 +98,16 @@ export function useSyncedFormLoader( {
 		}
 
 		// Reset syncing flag after React commits
-		rafIdRef.current = requestAnimationFrame( () => {
-			rafIdRef.current = null;
+		animationFrameIdRef.current = requestAnimationFrame( () => {
+			animationFrameIdRef.current = null;
 			isSyncingRef.current = false;
 		} );
 
 		// Cleanup: cancel pending rAF if component unmounts or effect re-runs
 		return () => {
-			if ( rafIdRef.current !== null ) {
-				cancelAnimationFrame( rafIdRef.current );
-				rafIdRef.current = null;
+			if ( animationFrameIdRef.current !== null ) {
+				cancelAnimationFrame( animationFrameIdRef.current );
+				animationFrameIdRef.current = null;
 				// Reset syncing flag since we're canceling the scheduled reset
 				isSyncingRef.current = false;
 			}

--- a/projects/packages/forms/src/blocks/contact-form/hooks/use-synced-form.ts
+++ b/projects/packages/forms/src/blocks/contact-form/hooks/use-synced-form.ts
@@ -3,9 +3,11 @@
  */
 
 import { parse } from '@wordpress/blocks';
-import { useEntityRecord } from '@wordpress/core-data';
+import { store as coreStore, useEntityRecord } from '@wordpress/core-data';
+import { useSelect } from '@wordpress/data';
 import { useMemo } from '@wordpress/element';
 import { FORM_POST_TYPE } from '../../shared/util/constants.js';
+import type { Block } from '@wordpress/blocks';
 
 // Infer the block type from the parse function's return type
 type ParsedBlock = ReturnType< typeof parse >[ number ];
@@ -28,11 +30,91 @@ interface UseSyncedFormResult {
  * @param {number | undefined} ref - The jetpack_form post ID to load
  * @return {UseSyncedFormResult} Object containing loading state and parsed block data
  */
-export function useSyncedForm( ref: number | undefined ): UseSyncedFormResult {
-	const { record, isResolving } = useEntityRecord< JetpackForm >( 'postType', FORM_POST_TYPE, ref );
+const DEBUG = true;
+const log = ( ...args: unknown[] ) => DEBUG && console.log( '[useSyncedForm]', ...args );
 
-	// Parse the block content when the post is loaded
+export function useSyncedForm( ref: number | undefined ): UseSyncedFormResult {
+	const { record, isResolving, hasEdits } = useEntityRecord< JetpackForm >(
+		'postType',
+		FORM_POST_TYPE,
+		ref
+	);
+
+	// Get the actual pending edits object to see exactly what's being changed
+	const pendingEdits = useSelect(
+		select => {
+			if ( ! ref ) {
+				return null;
+			}
+			return select( coreStore ).getEntityRecordEdits( 'postType', FORM_POST_TYPE, ref );
+		},
+		[ ref ]
+	);
+
+	log( 'Hook called', {
+		ref,
+		isResolving,
+		hasEdits,
+		hasRecord: !! record,
+		recordContentLength: record?.content?.raw?.length,
+		hasPendingEdits: !! pendingEdits,
+		pendingEditKeys: pendingEdits ? Object.keys( pendingEdits ) : [],
+	} );
+
+	// Check if there are pending block edits
+	const pendingBlocks = useMemo( () => {
+		if ( ! hasEdits || ! pendingEdits ) {
+			log( 'No pending blocks', { hasEdits, hasPendingEdits: !! pendingEdits } );
+			return null;
+		}
+		const edits = pendingEdits as Record< string, unknown >;
+		if ( ! edits.blocks || ! Array.isArray( edits.blocks ) ) {
+			log( 'Pending edits exist but no blocks field', { editKeys: Object.keys( edits ) } );
+			return null;
+		}
+		log( 'Found pending blocks', { blockCount: edits.blocks.length } );
+		return edits.blocks as Block[];
+	}, [ hasEdits, pendingEdits ] );
+
+	// Parse the block content - prefer pending edits over saved record
 	const { syncedAttributes, syncedInnerBlocks } = useMemo( () => {
+		// If we have pending block edits, use those instead of saved content
+		if ( pendingBlocks && pendingBlocks.length > 0 ) {
+			const formBlock = pendingBlocks[ 0 ];
+
+			if ( formBlock.name !== 'jetpack/contact-form' ) {
+				console.log(
+					'[useSyncedForm] Pending blocks first block is not contact-form:',
+					formBlock.name
+				);
+				return { syncedAttributes: null, syncedInnerBlocks: null };
+			}
+
+			// Get attributes, strip out 'lock', and add 'ref'
+			const { lock, ...attributesWithoutLock } = ( formBlock.attributes || {} ) as Record<
+				string,
+				unknown
+			>;
+			const finalAttributes = {
+				...attributesWithoutLock,
+				ref,
+			};
+
+			console.log( '[useSyncedForm] Using pending edits for synced form', {
+				source: 'pendingEdits',
+				ref,
+				strippedLock: !! lock,
+				attributeKeys: Object.keys( finalAttributes ),
+				innerBlocksCount: formBlock.innerBlocks?.length ?? 0,
+			} );
+
+			return {
+				syncedAttributes: finalAttributes,
+				syncedInnerBlocks: formBlock.innerBlocks || [],
+			};
+		}
+
+		// Fall back to saved record content
 		if ( ! record?.content?.raw ) {
 			return { syncedAttributes: null, syncedInnerBlocks: null };
 		}
@@ -50,11 +132,29 @@ export function useSyncedForm( ref: number | undefined ): UseSyncedFormResult {
 			return { syncedAttributes: null, syncedInnerBlocks: null };
 		}
 
+		// Get attributes, strip out 'lock', and add 'ref'
+		const { lock, ...attributesWithoutLock } = ( formBlock.attributes || {} ) as Record<
+			string,
+			unknown
+		>;
+		const finalAttributes = {
+			...attributesWithoutLock,
+			ref,
+		};
+
+		console.log( '[useSyncedForm] Using saved record for synced form', {
+			source: 'record',
+			ref,
+			strippedLock: !! lock,
+			attributeKeys: Object.keys( finalAttributes ),
+			innerBlocksCount: formBlock.innerBlocks?.length ?? 0,
+		} );
+
 		return {
-			syncedAttributes: formBlock.attributes || {},
+			syncedAttributes: finalAttributes,
 			syncedInnerBlocks: formBlock.innerBlocks || [],
 		};
-	}, [ record ] );
+	}, [ pendingBlocks, record, record?.content?.raw, ref ] );
 
 	if ( ! ref ) {
 		return {

--- a/projects/packages/forms/src/blocks/contact-form/hooks/use-synced-form.ts
+++ b/projects/packages/forms/src/blocks/contact-form/hooks/use-synced-form.ts
@@ -34,7 +34,8 @@ export function useSyncedForm( ref: number | undefined ): UseSyncedFormResult {
 	const { record, isResolving, hasEdits } = useEntityRecord< JetpackForm >(
 		'postType',
 		FORM_POST_TYPE,
-		ref
+		ref,
+		{ enabled: !! ref }
 	);
 
 	// Get the actual pending edits object to see exactly what's being changed

--- a/projects/packages/forms/src/blocks/contact-form/hooks/use-synced-form.ts
+++ b/projects/packages/forms/src/blocks/contact-form/hooks/use-synced-form.ts
@@ -30,9 +30,6 @@ interface UseSyncedFormResult {
  * @param {number | undefined} ref - The jetpack_form post ID to load
  * @return {UseSyncedFormResult} Object containing loading state and parsed block data
  */
-const DEBUG = true;
-const log = ( ...args: unknown[] ) => DEBUG && console.log( '[useSyncedForm]', ...args );
-
 export function useSyncedForm( ref: number | undefined ): UseSyncedFormResult {
 	const { record, isResolving, hasEdits } = useEntityRecord< JetpackForm >(
 		'postType',
@@ -51,29 +48,25 @@ export function useSyncedForm( ref: number | undefined ): UseSyncedFormResult {
 		[ ref ]
 	);
 
-	log( 'Hook called', {
-		ref,
-		isResolving,
-		hasEdits,
-		hasRecord: !! record,
-		recordContentLength: record?.content?.raw?.length,
-		hasPendingEdits: !! pendingEdits,
-		pendingEditKeys: pendingEdits ? Object.keys( pendingEdits ) : [],
-	} );
-
-	// Check if there are pending block edits
+	// Check if there are pending edits (either blocks or content)
 	const pendingBlocks = useMemo( () => {
 		if ( ! hasEdits || ! pendingEdits ) {
-			log( 'No pending blocks', { hasEdits, hasPendingEdits: !! pendingEdits } );
 			return null;
 		}
 		const edits = pendingEdits as Record< string, unknown >;
-		if ( ! edits.blocks || ! Array.isArray( edits.blocks ) ) {
-			log( 'Pending edits exist but no blocks field', { editKeys: Object.keys( edits ) } );
-			return null;
+
+		// First check for block edits (from block editor)
+		if ( edits.blocks && Array.isArray( edits.blocks ) ) {
+			return edits.blocks as Block[];
 		}
-		log( 'Found pending blocks', { blockCount: edits.blocks.length } );
-		return edits.blocks as Block[];
+
+		// Then check for content edits (from our auto-save which stores serialized content)
+		if ( typeof edits.content === 'string' ) {
+			const parsedBlocks = parse( edits.content );
+			return parsedBlocks.length > 0 ? parsedBlocks : null;
+		}
+
+		return null;
 	}, [ hasEdits, pendingEdits ] );
 
 	// Parse the block content - prefer pending edits over saved record
@@ -83,30 +76,17 @@ export function useSyncedForm( ref: number | undefined ): UseSyncedFormResult {
 			const formBlock = pendingBlocks[ 0 ];
 
 			if ( formBlock.name !== 'jetpack/contact-form' ) {
-				console.log(
-					'[useSyncedForm] Pending blocks first block is not contact-form:',
-					formBlock.name
-				);
 				return { syncedAttributes: null, syncedInnerBlocks: null };
 			}
 
-			// Get attributes, strip out 'lock', and add 'ref'
-			const { lock, ...attributesWithoutLock } = ( formBlock.attributes || {} ) as Record<
-				string,
-				unknown
-			>;
+			// Get attributes and add 'ref' (lock is stripped via destructuring)
+			const attrs = ( formBlock.attributes || {} ) as Record< string, unknown >;
+			const { lock, ...attributesWithoutLock } = attrs;
+			void lock; // Intentionally unused - stripped from synced attributes
 			const finalAttributes = {
 				...attributesWithoutLock,
 				ref,
 			};
-
-			console.log( '[useSyncedForm] Using pending edits for synced form', {
-				source: 'pendingEdits',
-				ref,
-				strippedLock: !! lock,
-				attributeKeys: Object.keys( finalAttributes ),
-				innerBlocksCount: formBlock.innerBlocks?.length ?? 0,
-			} );
 
 			return {
 				syncedAttributes: finalAttributes,
@@ -132,29 +112,20 @@ export function useSyncedForm( ref: number | undefined ): UseSyncedFormResult {
 			return { syncedAttributes: null, syncedInnerBlocks: null };
 		}
 
-		// Get attributes, strip out 'lock', and add 'ref'
-		const { lock, ...attributesWithoutLock } = ( formBlock.attributes || {} ) as Record<
-			string,
-			unknown
-		>;
+		// Get attributes and add 'ref' (lock is stripped via destructuring)
+		const attrs = ( formBlock.attributes || {} ) as Record< string, unknown >;
+		const { lock, ...attributesWithoutLock } = attrs;
+		void lock; // Intentionally unused - stripped from synced attributes
 		const finalAttributes = {
 			...attributesWithoutLock,
 			ref,
 		};
 
-		console.log( '[useSyncedForm] Using saved record for synced form', {
-			source: 'record',
-			ref,
-			strippedLock: !! lock,
-			attributeKeys: Object.keys( finalAttributes ),
-			innerBlocksCount: formBlock.innerBlocks?.length ?? 0,
-		} );
-
 		return {
 			syncedAttributes: finalAttributes,
 			syncedInnerBlocks: formBlock.innerBlocks || [],
 		};
-	}, [ pendingBlocks, record, record?.content?.raw, ref ] );
+	}, [ pendingBlocks, record, ref ] );
 
 	if ( ! ref ) {
 		return {

--- a/projects/packages/forms/src/blocks/contact-form/util/form-sync.ts
+++ b/projects/packages/forms/src/blocks/contact-form/util/form-sync.ts
@@ -35,7 +35,7 @@ export function filterSyncedAttributes(
  */
 export function createSyncedFormBlock(
 	attributes: Record< string, unknown >,
-	innerBlocks: unknown[]
+	innerBlocks: Block[]
 ): Block {
 	const attributesToSave = { ...attributes };
 	delete attributesToSave.ref;
@@ -49,12 +49,12 @@ export function createSyncedFormBlock(
  * Excludes the ref attribute since it's not part of the form definition
  *
  * @param {Record<string, unknown>} attributes  - Form attributes
- * @param {Array}                   innerBlocks - Form inner blocks
+ * @param {Block[]}                 innerBlocks - Form inner blocks
  * @return {string} Serialized block content
  */
 export function serializeSyncedForm(
 	attributes: Record< string, unknown >,
-	innerBlocks: unknown[]
+	innerBlocks: Block[]
 ): string {
 	const formBlock = createSyncedFormBlock( attributes, innerBlocks );
 	return serialize( formBlock );

--- a/projects/packages/forms/src/blocks/contact-form/util/form-sync.ts
+++ b/projects/packages/forms/src/blocks/contact-form/util/form-sync.ts
@@ -25,6 +25,24 @@ export function filterSyncedAttributes(
 }
 
 /**
+ * Create a form block for staging/saving
+ * Excludes the ref attribute since it's not part of the form definition
+ *
+ * @param {Record<string, unknown>} attributes  - Form attributes
+ * @param {Array}                   innerBlocks - Form inner blocks
+ * @return {Block} The created form block
+ */
+export function createSyncedFormBlock(
+	attributes: Record< string, unknown >,
+	innerBlocks: unknown[]
+) {
+	const attributesToSave = { ...attributes };
+	delete attributesToSave.ref;
+
+	return createBlock( 'jetpack/contact-form', attributesToSave, innerBlocks );
+}
+
+/**
  * Serialize form attributes and blocks for saving to synced form post
  * Excludes the ref attribute since it's not part of the form definition
  *
@@ -36,10 +54,6 @@ export function serializeSyncedForm(
 	attributes: Record< string, unknown >,
 	innerBlocks: unknown[]
 ): string {
-	const attributesToSave = { ...attributes };
-	delete attributesToSave.ref;
-
-	const formBlock = createBlock( 'jetpack/contact-form', attributesToSave, innerBlocks );
-
+	const formBlock = createSyncedFormBlock( attributes, innerBlocks );
 	return serialize( formBlock );
 }

--- a/projects/packages/forms/src/blocks/contact-form/util/form-sync.ts
+++ b/projects/packages/forms/src/blocks/contact-form/util/form-sync.ts
@@ -25,12 +25,12 @@ export function filterSyncedAttributes(
 }
 
 /**
- * Create a form block for staging/saving
- * Excludes the ref attribute since it's not part of the form definition
+ * Create a form block for staging/saving.
+ * Excludes ref and lock attributes since they're not part of the form definition.
  *
- * @param {Record<string, unknown>} attributes  - Form attributes
- * @param {Array}                   innerBlocks - Form inner blocks
- * @return {Block} The created form block
+ * @param {Record<string, unknown>} attributes  - Form attributes.
+ * @param {Array}                   innerBlocks - Form inner blocks.
+ * @return {Block} The created form block.
  */
 export function createSyncedFormBlock(
 	attributes: Record< string, unknown >,
@@ -38,6 +38,7 @@ export function createSyncedFormBlock(
 ) {
 	const attributesToSave = { ...attributes };
 	delete attributesToSave.ref;
+	delete attributesToSave.lock;
 
 	return createBlock( 'jetpack/contact-form', attributesToSave, innerBlocks );
 }

--- a/projects/packages/forms/src/blocks/contact-form/util/form-sync.ts
+++ b/projects/packages/forms/src/blocks/contact-form/util/form-sync.ts
@@ -3,6 +3,7 @@
  */
 
 import { createBlock, serialize } from '@wordpress/blocks';
+import type { Block } from '@wordpress/blocks';
 
 /**
  * Filter out attributes that shouldn't be synced from source
@@ -35,7 +36,7 @@ export function filterSyncedAttributes(
 export function createSyncedFormBlock(
 	attributes: Record< string, unknown >,
 	innerBlocks: unknown[]
-) {
+): Block {
 	const attributesToSave = { ...attributes };
 	delete attributesToSave.ref;
 	delete attributesToSave.lock;

--- a/projects/packages/forms/tests/js/contact-form/components/convert-form-toolbar.test.js
+++ b/projects/packages/forms/tests/js/contact-form/components/convert-form-toolbar.test.js
@@ -130,6 +130,21 @@ describe( 'ConvertFormToolbar', () => {
 			} );
 		} );
 
+		it( 'calls onBeforeNavigate before navigating to synced form', async () => {
+			const mockOnBeforeNavigate = jest.fn();
+			render(
+				<ConvertFormToolbar
+					clientId="test-id"
+					attributes={ { ref: 456 } }
+					onBeforeNavigate={ mockOnBeforeNavigate }
+				/>
+			);
+			await userEvent.click( screen.getByRole( 'button' ) );
+
+			expect( mockOnBeforeNavigate ).toHaveBeenCalled();
+			expect( mockOnNavigateToEntityRecord ).toHaveBeenCalled();
+		} );
+
 		it( 'creates synced form and navigates on convert', async () => {
 			mockCreateSyncedForm.mockResolvedValue( 789 );
 

--- a/projects/packages/forms/tests/js/contact-form/form-sync.test.js
+++ b/projects/packages/forms/tests/js/contact-form/form-sync.test.js
@@ -1,13 +1,24 @@
 /**
- * Tests for synced-form-helpers
- *
- * These tests verify the utility functions used for synced form operations.
+ * Tests for form-sync utility functions
  */
 
-import { filterSyncedAttributes } from '../../../src/blocks/contact-form/util/form-sync';
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+
+// Mock WordPress dependencies before importing
+const mockCreateBlock = jest.fn();
+const mockSerialize = jest.fn();
+
+await jest.unstable_mockModule( '@wordpress/blocks', () => ( {
+	createBlock: mockCreateBlock,
+	serialize: mockSerialize,
+} ) );
+
+const { filterSyncedAttributes, serializeSyncedForm, createSyncedFormBlock } = await import(
+	'../../../src/blocks/contact-form/util/form-sync.ts'
+);
 
 describe( 'filterSyncedAttributes', () => {
-	test( 'removes layout attributes and ref', () => {
+	it( 'removes layout attributes and ref', () => {
 		const attributes = {
 			className: 'my-class',
 			align: 'wide',
@@ -29,7 +40,7 @@ describe( 'filterSyncedAttributes', () => {
 		expect( result.subject ).toBe( 'Test Subject' );
 	} );
 
-	test( 'preserves form-specific attributes', () => {
+	it( 'preserves form-specific attributes', () => {
 		const attributes = {
 			to: 'test@example.com',
 			subject: 'Test Subject',
@@ -45,7 +56,7 @@ describe( 'filterSyncedAttributes', () => {
 		expect( result.emailNotifications ).toBe( true );
 	} );
 
-	test( 'does not mutate original attributes object', () => {
+	it( 'does not mutate original attributes object', () => {
 		const attributes = {
 			ref: 123,
 			to: 'test@example.com',
@@ -55,5 +66,99 @@ describe( 'filterSyncedAttributes', () => {
 
 		expect( attributes.ref ).toBe( 123 );
 		expect( result.ref ).toBeUndefined();
+	} );
+
+	it( 'handles empty attributes', () => {
+		const result = filterSyncedAttributes( {} );
+		expect( result ).toEqual( {} );
+	} );
+} );
+
+describe( 'createSyncedFormBlock', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		mockCreateBlock.mockReturnValue( { name: 'jetpack/contact-form' } );
+	} );
+
+	it( 'creates a block without the ref attribute', () => {
+		const attributes = { ref: 123, to: 'test@example.com' };
+		const innerBlocks = [ { name: 'jetpack/field-name' } ];
+
+		createSyncedFormBlock( attributes, innerBlocks );
+
+		expect( mockCreateBlock ).toHaveBeenCalledWith(
+			'jetpack/contact-form',
+			{ to: 'test@example.com' },
+			innerBlocks
+		);
+	} );
+
+	it( 'preserves all non-ref attributes', () => {
+		const attributes = {
+			ref: 456,
+			to: 'admin@example.com',
+			subject: 'Contact Form',
+			jetpackCRM: true,
+		};
+
+		createSyncedFormBlock( attributes, [] );
+
+		expect( mockCreateBlock ).toHaveBeenCalledWith(
+			'jetpack/contact-form',
+			{
+				to: 'admin@example.com',
+				subject: 'Contact Form',
+				jetpackCRM: true,
+			},
+			[]
+		);
+	} );
+
+	it( 'returns the created block', () => {
+		const mockBlock = { name: 'jetpack/contact-form', attributes: {} };
+		mockCreateBlock.mockReturnValue( mockBlock );
+
+		const result = createSyncedFormBlock( {}, [] );
+
+		expect( result ).toBe( mockBlock );
+	} );
+} );
+
+describe( 'serializeSyncedForm', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		mockCreateBlock.mockReturnValue( { name: 'jetpack/contact-form' } );
+		mockSerialize.mockReturnValue( '<!-- wp:jetpack/contact-form /-->' );
+	} );
+
+	it( 'serializes the form block without ref', () => {
+		const attributes = { ref: 123, to: 'test@example.com' };
+		const innerBlocks = [];
+
+		serializeSyncedForm( attributes, innerBlocks );
+
+		expect( mockCreateBlock ).toHaveBeenCalledWith(
+			'jetpack/contact-form',
+			{ to: 'test@example.com' },
+			innerBlocks
+		);
+		expect( mockSerialize ).toHaveBeenCalled();
+	} );
+
+	it( 'returns serialized content', () => {
+		const expectedContent = '<!-- wp:jetpack/contact-form {"to":"test@example.com"} /-->';
+		mockSerialize.mockReturnValue( expectedContent );
+
+		const result = serializeSyncedForm( { to: 'test@example.com' }, [] );
+
+		expect( result ).toBe( expectedContent );
+	} );
+
+	it( 'passes inner blocks to createBlock', () => {
+		const innerBlocks = [ { name: 'jetpack/field-name' }, { name: 'jetpack/field-email' } ];
+
+		serializeSyncedForm( {}, innerBlocks );
+
+		expect( mockCreateBlock ).toHaveBeenCalledWith( 'jetpack/contact-form', {}, innerBlocks );
 	} );
 } );

--- a/projects/packages/forms/tests/js/contact-form/form-sync.test.js
+++ b/projects/packages/forms/tests/js/contact-form/form-sync.test.js
@@ -93,6 +93,18 @@ describe( 'createSyncedFormBlock', () => {
 		);
 	} );
 
+	it( 'creates a block without the lock attribute', () => {
+		const attributes = { lock: { move: true, remove: true }, to: 'test@example.com' };
+
+		createSyncedFormBlock( attributes, [] );
+
+		expect( mockCreateBlock ).toHaveBeenCalledWith(
+			'jetpack/contact-form',
+			{ to: 'test@example.com' },
+			[]
+		);
+	} );
+
 	it( 'preserves all non-ref attributes', () => {
 		const attributes = {
 			ref: 456,

--- a/projects/packages/forms/tests/js/contact-form/use-synced-form-auto-save.test.js
+++ b/projects/packages/forms/tests/js/contact-form/use-synced-form-auto-save.test.js
@@ -1,0 +1,198 @@
+/**
+ * Tests for synced form auto-save helper functions
+ */
+
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+
+// Mock WordPress dependencies before importing
+const mockCreateBlock = jest.fn();
+const mockSerialize = jest.fn();
+
+await jest.unstable_mockModule( '@wordpress/blocks', () => ( {
+	createBlock: mockCreateBlock,
+	serialize: mockSerialize,
+} ) );
+
+const { captureBaseline, stageFormEdits } = await import(
+	'../../../src/blocks/contact-form/hooks/use-synced-form-auto-save.ts'
+);
+
+describe( 'captureBaseline', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		mockCreateBlock.mockReturnValue( { name: 'jetpack/contact-form' } );
+		mockSerialize.mockReturnValue( '<!-- wp:jetpack/contact-form /-->' );
+	} );
+
+	it( 'returns null when ref is undefined', () => {
+		const baselineRef = { current: null };
+		const result = captureBaseline(
+			undefined,
+			{ content: { raw: '...' } },
+			false,
+			{},
+			[],
+			baselineRef
+		);
+
+		expect( result ).toBeNull();
+		expect( baselineRef.current ).toBeNull();
+	} );
+
+	it( 'returns null when syncedForm is null', () => {
+		const baselineRef = { current: null };
+		const result = captureBaseline( 123, null, false, {}, [], baselineRef );
+
+		expect( result ).toBeNull();
+		expect( baselineRef.current ).toBeNull();
+	} );
+
+	it( 'returns null when isSyncing is true', () => {
+		const baselineRef = { current: null };
+		const result = captureBaseline( 123, { content: { raw: '...' } }, true, {}, [], baselineRef );
+
+		expect( result ).toBeNull();
+		expect( baselineRef.current ).toBeNull();
+	} );
+
+	it( 'captures baseline on first call with valid params', () => {
+		const expectedSerialized = '<!-- wp:jetpack/contact-form {"to":"test@example.com"} /-->';
+		mockSerialize.mockReturnValue( expectedSerialized );
+
+		const baselineRef = { current: null };
+		const attributes = { to: 'test@example.com' };
+		const innerBlocks = [];
+
+		const result = captureBaseline(
+			123,
+			{ content: { raw: '...' } },
+			false,
+			attributes,
+			innerBlocks,
+			baselineRef
+		);
+
+		expect( result ).toBe( expectedSerialized );
+		expect( baselineRef.current ).toEqual( {
+			ref: 123,
+			serialized: expectedSerialized,
+		} );
+	} );
+
+	it( 'returns cached baseline for same ref', () => {
+		const cachedSerialized = '<!-- wp:jetpack/contact-form {"cached":true} /-->';
+		const baselineRef = { current: { ref: 123, serialized: cachedSerialized } };
+
+		const result = captureBaseline(
+			123,
+			{ content: { raw: '...' } },
+			false,
+			{ to: 'new@example.com' },
+			[],
+			baselineRef
+		);
+
+		expect( result ).toBe( cachedSerialized );
+		// Should not have called serialize again
+		expect( mockSerialize ).not.toHaveBeenCalled();
+	} );
+
+	it( 'recaptures baseline when ref changes', () => {
+		const oldSerialized = '<!-- wp:jetpack/contact-form {"old":true} /-->';
+		const newSerialized = '<!-- wp:jetpack/contact-form {"new":true} /-->';
+		mockSerialize.mockReturnValue( newSerialized );
+
+		const baselineRef = { current: { ref: 100, serialized: oldSerialized } };
+
+		const result = captureBaseline(
+			200,
+			{ content: { raw: '...' } },
+			false,
+			{ new: true },
+			[],
+			baselineRef
+		);
+
+		expect( result ).toBe( newSerialized );
+		expect( baselineRef.current ).toEqual( {
+			ref: 200,
+			serialized: newSerialized,
+		} );
+	} );
+} );
+
+describe( 'stageFormEdits', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'calls editEntityRecord with correct parameters', () => {
+		const mockFormBlock = { name: 'jetpack/contact-form', attributes: {} };
+		const serializedContent = '<!-- wp:jetpack/contact-form {"to":"test@example.com"} /-->';
+
+		mockCreateBlock.mockReturnValue( mockFormBlock );
+		mockSerialize.mockReturnValue( serializedContent );
+
+		const mockEditEntityRecord = jest.fn();
+		const attributes = { to: 'test@example.com', ref: 123 };
+		const innerBlocks = [ { name: 'jetpack/field-name' } ];
+
+		stageFormEdits( 123, attributes, innerBlocks, mockEditEntityRecord );
+
+		expect( mockEditEntityRecord ).toHaveBeenCalledWith( 'postType', 'jetpack_form', 123, {
+			content: serializedContent,
+			blocks: [ mockFormBlock ],
+		} );
+	} );
+
+	it( 'creates form block with ref attribute removed', () => {
+		const mockEditEntityRecord = jest.fn();
+		const attributes = { to: 'test@example.com', ref: 456, subject: 'Test' };
+		const innerBlocks = [];
+
+		mockCreateBlock.mockReturnValue( { name: 'jetpack/contact-form' } );
+		mockSerialize.mockReturnValue( '...' );
+
+		stageFormEdits( 456, attributes, innerBlocks, mockEditEntityRecord );
+
+		// Check that createBlock was called without ref
+		expect( mockCreateBlock ).toHaveBeenCalledWith(
+			'jetpack/contact-form',
+			{ to: 'test@example.com', subject: 'Test' },
+			innerBlocks
+		);
+	} );
+
+	it( 'passes inner blocks to createBlock', () => {
+		const mockEditEntityRecord = jest.fn();
+		const innerBlocks = [
+			{ name: 'jetpack/field-name' },
+			{ name: 'jetpack/field-email' },
+			{ name: 'jetpack/button' },
+		];
+
+		mockCreateBlock.mockReturnValue( { name: 'jetpack/contact-form' } );
+		mockSerialize.mockReturnValue( '...' );
+
+		stageFormEdits( 123, {}, innerBlocks, mockEditEntityRecord );
+
+		expect( mockCreateBlock ).toHaveBeenCalledWith( 'jetpack/contact-form', {}, innerBlocks );
+	} );
+
+	it( 'stages both content and blocks for form editor pickup', () => {
+		const mockFormBlock = { name: 'jetpack/contact-form', innerBlocks: [] };
+		const serialized = '<!-- wp:jetpack/contact-form /-->';
+
+		mockCreateBlock.mockReturnValue( mockFormBlock );
+		mockSerialize.mockReturnValue( serialized );
+
+		const mockEditEntityRecord = jest.fn();
+
+		stageFormEdits( 789, {}, [], mockEditEntityRecord );
+
+		const [ , , , edits ] = mockEditEntityRecord.mock.calls[ 0 ];
+		expect( edits ).toHaveProperty( 'content', serialized );
+		expect( edits ).toHaveProperty( 'blocks' );
+		expect( edits.blocks ).toEqual( [ mockFormBlock ] );
+	} );
+} );

--- a/projects/packages/forms/tests/js/contact-form/use-synced-form-auto-save.test.js
+++ b/projects/packages/forms/tests/js/contact-form/use-synced-form-auto-save.test.js
@@ -26,14 +26,7 @@ describe( 'captureBaseline', () => {
 
 	it( 'returns null when ref is undefined', () => {
 		const baselineRef = { current: null };
-		const result = captureBaseline(
-			undefined,
-			{ content: { raw: '...' } },
-			false,
-			{},
-			[],
-			baselineRef
-		);
+		const result = captureBaseline( undefined, { content: { raw: '...' } }, {}, [], baselineRef );
 
 		expect( result ).toBeNull();
 		expect( baselineRef.current ).toBeNull();
@@ -41,15 +34,7 @@ describe( 'captureBaseline', () => {
 
 	it( 'returns null when syncedForm is null', () => {
 		const baselineRef = { current: null };
-		const result = captureBaseline( 123, null, false, {}, [], baselineRef );
-
-		expect( result ).toBeNull();
-		expect( baselineRef.current ).toBeNull();
-	} );
-
-	it( 'returns null when isSyncing is true', () => {
-		const baselineRef = { current: null };
-		const result = captureBaseline( 123, { content: { raw: '...' } }, true, {}, [], baselineRef );
+		const result = captureBaseline( 123, null, {}, [], baselineRef );
 
 		expect( result ).toBeNull();
 		expect( baselineRef.current ).toBeNull();
@@ -66,7 +51,6 @@ describe( 'captureBaseline', () => {
 		const result = captureBaseline(
 			123,
 			{ content: { raw: '...' } },
-			false,
 			attributes,
 			innerBlocks,
 			baselineRef
@@ -86,7 +70,6 @@ describe( 'captureBaseline', () => {
 		const result = captureBaseline(
 			123,
 			{ content: { raw: '...' } },
-			false,
 			{ to: 'new@example.com' },
 			[],
 			baselineRef
@@ -107,7 +90,6 @@ describe( 'captureBaseline', () => {
 		const result = captureBaseline(
 			200,
 			{ content: { raw: '...' } },
-			false,
 			{ new: true },
 			[],
 			baselineRef

--- a/projects/packages/forms/tests/js/contact-form/use-synced-form-auto-save.test.js
+++ b/projects/packages/forms/tests/js/contact-form/use-synced-form-auto-save.test.js
@@ -26,7 +26,14 @@ describe( 'captureBaseline', () => {
 
 	it( 'returns null when ref is undefined', () => {
 		const baselineRef = { current: null };
-		const result = captureBaseline( undefined, { content: { raw: '...' } }, {}, [], baselineRef );
+		const result = captureBaseline(
+			undefined,
+			{ content: { raw: '...' } },
+			false,
+			{},
+			[],
+			baselineRef
+		);
 
 		expect( result ).toBeNull();
 		expect( baselineRef.current ).toBeNull();
@@ -34,7 +41,15 @@ describe( 'captureBaseline', () => {
 
 	it( 'returns null when syncedForm is null', () => {
 		const baselineRef = { current: null };
-		const result = captureBaseline( 123, null, {}, [], baselineRef );
+		const result = captureBaseline( 123, null, false, {}, [], baselineRef );
+
+		expect( result ).toBeNull();
+		expect( baselineRef.current ).toBeNull();
+	} );
+
+	it( 'returns null when isSyncing is true', () => {
+		const baselineRef = { current: null };
+		const result = captureBaseline( 123, { content: { raw: '...' } }, true, {}, [], baselineRef );
 
 		expect( result ).toBeNull();
 		expect( baselineRef.current ).toBeNull();
@@ -51,6 +66,7 @@ describe( 'captureBaseline', () => {
 		const result = captureBaseline(
 			123,
 			{ content: { raw: '...' } },
+			false,
 			attributes,
 			innerBlocks,
 			baselineRef
@@ -70,6 +86,7 @@ describe( 'captureBaseline', () => {
 		const result = captureBaseline(
 			123,
 			{ content: { raw: '...' } },
+			false,
 			{ to: 'new@example.com' },
 			[],
 			baselineRef
@@ -90,6 +107,7 @@ describe( 'captureBaseline', () => {
 		const result = captureBaseline(
 			200,
 			{ content: { raw: '...' } },
+			false,
 			{ new: true },
 			[],
 			baselineRef

--- a/projects/packages/forms/tests/js/contact-form/use-synced-form-loader.test.js
+++ b/projects/packages/forms/tests/js/contact-form/use-synced-form-loader.test.js
@@ -1,0 +1,108 @@
+/**
+ * Tests for useSyncedFormLoader hook
+ */
+
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { renderHook } from '@testing-library/react';
+
+// Mock WordPress dependencies
+const mockUseEffect = jest.fn();
+const mockUseRef = jest.fn();
+
+// Track rAF callbacks and cleanup
+let rafCallback = null;
+let rafId = 1;
+let cleanupFn = null;
+
+await jest.unstable_mockModule( '@wordpress/element', () => ( {
+	useEffect: callback => {
+		mockUseEffect( callback );
+		cleanupFn = callback();
+	},
+	useRef: initialValue => {
+		const ref = { current: initialValue };
+		mockUseRef( ref );
+		return ref;
+	},
+} ) );
+
+await jest.unstable_mockModule( '../../../src/blocks/contact-form/util/form-sync.ts', () => ( {
+	filterSyncedAttributes: attrs => attrs,
+} ) );
+
+// Mock global requestAnimationFrame and cancelAnimationFrame
+jest.spyOn( global, 'requestAnimationFrame' ).mockImplementation( callback => {
+	rafCallback = callback;
+	return rafId++;
+} );
+
+jest.spyOn( global, 'cancelAnimationFrame' ).mockImplementation( () => {
+	rafCallback = null;
+} );
+
+const { useSyncedFormLoader } = await import(
+	'../../../src/blocks/contact-form/hooks/use-synced-form-loader.ts'
+);
+
+describe( 'useSyncedFormLoader', () => {
+	const defaultProps = {
+		ref: 123,
+		syncedFormBlocks: [ { name: 'jetpack/field-name', innerBlocks: [] } ],
+		syncedFormAttributes: { to: 'test@example.com' },
+		clientId: 'test-client-id',
+		setAttributes: jest.fn(),
+		replaceInnerBlocks: jest.fn(),
+		__unstableMarkNextChangeAsNotPersistent: jest.fn(),
+		setActiveStep: jest.fn(),
+	};
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+		rafCallback = null;
+		rafId = 1;
+		cleanupFn = null;
+	} );
+
+	it( 'returns isSyncingRef', () => {
+		const { result } = renderHook( () => useSyncedFormLoader( defaultProps ) );
+
+		expect( result.current.isSyncingRef ).toBeDefined();
+		expect( result.current.isSyncingRef.current ).toBeDefined();
+	} );
+
+	it( 'resets isSyncingRef when cleanup cancels pending rAF', () => {
+		// Render the hook - this triggers the effect
+		const { result } = renderHook( () => useSyncedFormLoader( defaultProps ) );
+
+		// The effect should have scheduled a rAF
+		expect( global.requestAnimationFrame ).toHaveBeenCalled();
+
+		// Simulate isSyncingRef being set to true during sync
+		result.current.isSyncingRef.current = true;
+
+		// Simulate cleanup being called (e.g., when deps change or unmount)
+		if ( cleanupFn ) {
+			cleanupFn();
+		}
+
+		// Verify cancelAnimationFrame was called
+		expect( global.cancelAnimationFrame ).toHaveBeenCalled();
+
+		// The key assertion: isSyncingRef should be reset to false
+		expect( result.current.isSyncingRef.current ).toBe( false );
+	} );
+
+	it( 'sets isSyncingRef to false when rAF callback fires', () => {
+		const { result } = renderHook( () => useSyncedFormLoader( defaultProps ) );
+
+		// Simulate isSyncingRef being true
+		result.current.isSyncingRef.current = true;
+
+		// Fire the rAF callback
+		if ( rafCallback ) {
+			rafCallback();
+		}
+
+		expect( result.current.isSyncingRef.current ).toBe( false );
+	} );
+} );

--- a/projects/packages/forms/tests/js/contact-form/use-synced-form-loader.test.js
+++ b/projects/packages/forms/tests/js/contact-form/use-synced-form-loader.test.js
@@ -2,7 +2,7 @@
  * Tests for useSyncedFormLoader hook
  */
 
-import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { afterAll, beforeEach, describe, expect, it, jest } from '@jest/globals';
 import { renderHook } from '@testing-library/react';
 
 // Mock WordPress dependencies
@@ -61,6 +61,10 @@ describe( 'useSyncedFormLoader', () => {
 		rafCallback = null;
 		rafId = 1;
 		cleanupFn = null;
+	} );
+
+	afterAll( () => {
+		jest.restoreAllMocks();
 	} );
 
 	it( 'returns isSyncingRef', () => {

--- a/projects/packages/forms/tests/js/contact-form/use-synced-form.test.js
+++ b/projects/packages/forms/tests/js/contact-form/use-synced-form.test.js
@@ -1,0 +1,185 @@
+/**
+ * Tests for useSyncedForm hook logic
+ */
+
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+
+// Mock WordPress dependencies
+const mockParse = jest.fn();
+const mockUseEntityRecord = jest.fn();
+const mockUseSelect = jest.fn();
+
+await jest.unstable_mockModule( '@wordpress/blocks', () => ( {
+	parse: mockParse,
+} ) );
+
+await jest.unstable_mockModule( '@wordpress/core-data', () => ( {
+	store: 'core',
+	useEntityRecord: mockUseEntityRecord,
+} ) );
+
+await jest.unstable_mockModule( '@wordpress/data', () => ( {
+	useSelect: mockUseSelect,
+} ) );
+
+await jest.unstable_mockModule( '@wordpress/element', () => ( {
+	useMemo: fn => fn(),
+} ) );
+
+const { useSyncedForm } = await import(
+	'../../../src/blocks/contact-form/hooks/use-synced-form.ts'
+);
+
+describe( 'useSyncedForm', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		mockUseEntityRecord.mockReturnValue( {
+			record: null,
+			isResolving: false,
+			hasEdits: false,
+		} );
+		mockUseSelect.mockReturnValue( null );
+	} );
+
+	it( 'returns null values when ref is undefined', () => {
+		const result = useSyncedForm( undefined );
+
+		expect( result.isLoading ).toBe( false );
+		expect( result.syncedAttributes ).toBeNull();
+		expect( result.syncedInnerBlocks ).toBeNull();
+		expect( result.syncedForm ).toBeNull();
+	} );
+
+	it( 'returns loading state when resolving', () => {
+		mockUseEntityRecord.mockReturnValue( {
+			record: null,
+			isResolving: true,
+			hasEdits: false,
+		} );
+
+		const result = useSyncedForm( 123 );
+
+		expect( result.isLoading ).toBe( true );
+	} );
+
+	it( 'uses pending block edits when available', () => {
+		const pendingBlocks = [
+			{
+				name: 'jetpack/contact-form',
+				attributes: { to: 'test@example.com', lock: { remove: true } },
+				innerBlocks: [ { name: 'jetpack/field-name' } ],
+			},
+		];
+
+		mockUseEntityRecord.mockReturnValue( {
+			record: { content: { raw: '<!-- old content -->' } },
+			isResolving: false,
+			hasEdits: true,
+		} );
+		mockUseSelect.mockReturnValue( { blocks: pendingBlocks } );
+
+		const result = useSyncedForm( 123 );
+
+		expect( result.syncedAttributes ).toEqual( {
+			to: 'test@example.com',
+			ref: 123,
+		} );
+		expect( result.syncedInnerBlocks ).toEqual( [ { name: 'jetpack/field-name' } ] );
+	} );
+
+	it( 'parses pending content edits when blocks not available', () => {
+		const parsedBlocks = [
+			{
+				name: 'jetpack/contact-form',
+				attributes: { subject: 'Contact Us' },
+				innerBlocks: [],
+			},
+		];
+
+		mockUseEntityRecord.mockReturnValue( {
+			record: { content: { raw: '<!-- saved content -->' } },
+			isResolving: false,
+			hasEdits: true,
+		} );
+		mockUseSelect.mockReturnValue( { content: '<!-- pending content -->' } );
+		mockParse.mockReturnValue( parsedBlocks );
+
+		const result = useSyncedForm( 456 );
+
+		expect( mockParse ).toHaveBeenCalledWith( '<!-- pending content -->' );
+		expect( result.syncedAttributes ).toEqual( {
+			subject: 'Contact Us',
+			ref: 456,
+		} );
+	} );
+
+	it( 'falls back to saved record when no pending edits', () => {
+		const savedBlocks = [
+			{
+				name: 'jetpack/contact-form',
+				attributes: { to: 'saved@example.com' },
+				innerBlocks: [ { name: 'jetpack/field-email' } ],
+			},
+		];
+
+		mockUseEntityRecord.mockReturnValue( {
+			record: { content: { raw: '<!-- saved form -->' } },
+			isResolving: false,
+			hasEdits: false,
+		} );
+		mockUseSelect.mockReturnValue( null );
+		mockParse.mockReturnValue( savedBlocks );
+
+		const result = useSyncedForm( 789 );
+
+		expect( mockParse ).toHaveBeenCalledWith( '<!-- saved form -->' );
+		expect( result.syncedAttributes ).toEqual( {
+			to: 'saved@example.com',
+			ref: 789,
+		} );
+	} );
+
+	it( 'strips lock attribute from synced attributes', () => {
+		const blocksWithLock = [
+			{
+				name: 'jetpack/contact-form',
+				attributes: { to: 'test@example.com', lock: { move: true, remove: true } },
+				innerBlocks: [],
+			},
+		];
+
+		mockUseEntityRecord.mockReturnValue( {
+			record: { content: { raw: '...' } },
+			isResolving: false,
+			hasEdits: true,
+		} );
+		mockUseSelect.mockReturnValue( { blocks: blocksWithLock } );
+
+		const result = useSyncedForm( 123 );
+
+		expect( result.syncedAttributes.lock ).toBeUndefined();
+		expect( result.syncedAttributes.to ).toBe( 'test@example.com' );
+	} );
+
+	it( 'returns null when block is not jetpack/contact-form', () => {
+		const wrongBlock = [
+			{
+				name: 'core/paragraph',
+				attributes: {},
+				innerBlocks: [],
+			},
+		];
+
+		mockUseEntityRecord.mockReturnValue( {
+			record: { content: { raw: '...' } },
+			isResolving: false,
+			hasEdits: true,
+		} );
+		mockUseSelect.mockReturnValue( { blocks: wrongBlock } );
+
+		const result = useSyncedForm( 123 );
+
+		expect( result.syncedAttributes ).toBeNull();
+		expect( result.syncedInnerBlocks ).toBeNull();
+	} );
+} );


### PR DESCRIPTION
Before:

https://github.com/user-attachments/assets/bb17f5c6-0a12-4362-aebf-6cbf7557439d

After:

https://github.com/user-attachments/assets/41ba8a35-2e1b-4126-bb83-74df4d02fdd4



## Proposed changes:

When editing a synced form in the page editor, changes were being lost when clicking "Edit Form" to navigate to the form editor. This PR fixes the issue by:

* **Fix entity store staging**: Change from `saveEditedEntityRecord` (which persists to database) to `editEntityRecord` (which only stages in Redux store), preventing unexpected backend saves when clicking "Edit Form"
* **Improve change detection**: Capture a baseline serialization after the form loads to compare against, avoiding false positives from serialization differences (editor includes default attributes that aren't in saved content)
* **Stage both content and blocks**: Store both serialized `content` and parsed `blocks` in entity edits so the form editor can pick up changes from the shared store
* **Refactor for testability**: Extract pure functions (`captureBaseline`, `stageFormEdits`) from the auto-save hook for easier testing
* **Add comprehensive tests**: New test coverage for `form-sync.ts` utilities and `use-synced-form-auto-save.ts` helper functions

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack Product Discussion


## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

1. Create a new synced form (or use an existing one with `ref` attribute)
2. Add the form to a page in the page editor
3. Make some changes to the form (add a field, modify settings, etc.)
4. Click "Edit Form" in the toolbar to navigate to the form editor
5. **Expected**: The changes you made should be visible in the form editor
6. **Expected**: The form should NOT have been saved to the backend (check network requests - no POST to save the form)
7. Navigate back to the page editor
8. **Expected**: Your changes should still be present
9. Save the page - this should now persist the form changes