### PR TITLE
Forms: set primary actions for wp-build forms list

### DIFF
--- a/projects/packages/forms/changelog/update-forms-wpbuild-primary-actions
+++ b/projects/packages/forms/changelog/update-forms-wpbuild-primary-actions
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Dashboard: set primary actions for wp-build forms list.

--- a/projects/packages/forms/routes/forms/stage.tsx
+++ b/projects/packages/forms/routes/forms/stage.tsx
@@ -222,8 +222,8 @@ function StageInner() {
 		const actionsList: Action< FormListItem >[] = [
 			{
 				id: 'view-responses',
-				isPrimary: false,
-				label: __( 'View responses', 'jetpack-forms' ),
+				isPrimary: true,
+				label: __( 'Responses', 'jetpack-forms' ),
 				supportsBulk: false,
 				callback( items: FormListItem[] ) {
 					const [ item ] = items;
@@ -235,7 +235,7 @@ function StageInner() {
 			},
 			{
 				id: 'edit-form',
-				isPrimary: false,
+				isPrimary: true,
 				label: __( 'Edit', 'jetpack-forms' ),
 				supportsBulk: false,
 				async callback( items: FormListItem[] ) {


### PR DESCRIPTION
## Proposed changes:

Sets `Responses` and `Edit` as primary actions for the forms table in the wp-build dashboard. This moves them out of the three-dot menu, and onto the the forms row for visibility. 

**Screenshot**
<img width="949" height="272" alt="forms-primary-actions" src="https://github.com/user-attachments/assets/13d3b811-46ef-42dc-bc85-555cfd0c0527" />

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
Slack: p1770285091516359/1770134429.733889-slack-C052XEUUBL4

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Enable these feature flags: 

```
add_filter( 'jetpack_forms_alpha', '__return_true', 20 );
add_filter( 'jetpack_block_editor_feature_flags', 'eb_register_feature' );
function eb_register_feature( $flags ) {
    $flags['central-form-management'] = true;
    return $flags;
}
```

Test:
* Go to Jetpack > Forms (WP-Build) and click the Forms tab
* If you hover over any row, you should see 'Responses' and 'Edit' show on the row. 
* Click and confirm both actions work as expected