### PR TITLE
Codeowners: Remove Vulcan as codeowners from Sync/Connection package version files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,6 +12,8 @@
 /projects/packages/connection/src @Automattic/jetpack-vulcan
 /projects/packages/connection/legacy @Automattic/jetpack-vulcan
 /projects/packages/sync/src @Automattic/jetpack-vulcan
+/projects/packages/connection/src/class-package-version.php
+/projects/packages/sync/src/class-package-version.php
 
 # Plugins
 


### PR DESCRIPTION
Follow up from https://github.com/Automattic/jetpack/pull/46860

## Proposed changes:

* This PR removes Vulcan as codeowners from the `class-package-version.php` files for Connection and Sync, which are updated every time a package version is updated (eg. backport PRs), and we don't need to be marked as reviewers on those.
* Slack: p1770731666531559/1769418905.409339-slack-C05Q5HSS013

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:

* Proof-read