### PR TITLE
Verbum Comments: fix backslashes being stripped from comments

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/cm-516-fix-backslash-removal
+++ b/projects/packages/jetpack-mu-wpcom/changelog/cm-516-fix-backslash-removal
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Verbum Comments: fix backslashes being stripped from comments.

--- a/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/assets/class-verbum-block-utils.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/assets/class-verbum-block-utils.php
@@ -23,14 +23,13 @@ class Verbum_Block_Utils {
 			return $content;
 		}
 
-		// The block attributes come slashed and `parse_blocks` won't be able to parse them.
-		$unslashed_content = wp_unslash( $content );
-
-		if ( ! self::has_disallowed_blocks( $unslashed_content ) ) {
-			return $unslashed_content;
+		if ( ! self::has_disallowed_blocks( $content ) ) {
+			return $content;
 		}
 
-		return self::remove_blocks_with_parse_blocks( $unslashed_content );
+		// Unslash for parse_blocks: slashed JSON attributes can't be parsed.
+		// Re-slash after: pre_comment_content filters must return slashed data.
+		return wp_slash( self::remove_blocks_with_parse_blocks( wp_unslash( $content ) ) );
 	}
 
 	/**

--- a/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/assets/class-verbum-block-utils.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/assets/class-verbum-block-utils.php
@@ -38,7 +38,7 @@ class Verbum_Block_Utils {
 	 * This method provides significant performance benefits by avoiding expensive
 	 * parse_blocks() processing when all blocks are allowed (the common case).
 	 *
-	 * @param string $content Unslashed content to scan.
+	 * @param string $content Content to scan (may be slashed).
 	 * @return bool True if disallowed blocks found, false if all blocks are allowed.
 	 */
 	private static function has_disallowed_blocks( $content ) {

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/verbum-comments/Verbum_Block_Utils_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/verbum-comments/Verbum_Block_Utils_Test.php
@@ -108,7 +108,10 @@ HTML;
 <!-- /wp:quote -->
 HTML;
 
-		$filtered_content = Verbum_Block_Utils::remove_blocks( $comment_content );
+		// Simulate WordPress flow: pre_comment_content filters receive slashed data.
+		$filtered_content = Verbum_Block_Utils::remove_blocks( wp_slash( $comment_content ) );
+		// Unslash the result for comparison since the filter returns slashed data.
+		$filtered_content = wp_unslash( $filtered_content );
 		// Normalize whitespace before comparison
 		$filtered_content = preg_replace( '/\s+/', ' ', $filtered_content );
 		$expected_content = preg_replace( '/\s+/', ' ', $expected_content );
@@ -229,6 +232,26 @@ HTML;
 		$many_blocks = str_repeat( '<!-- wp:paragraph -->content<!-- /wp:paragraph -->', 100 );
 		$result      = Verbum_Block_Utils::remove_blocks( $many_blocks );
 		$this->assertIsString( $result );
+	}
+
+	/**
+	 * Ensure backslashes in comment content are preserved through the remove_blocks filter.
+	 *
+	 * The pre_comment_content filter receives slashed data and must return slashed data.
+	 * Previously, remove_blocks() called wp_unslash() for block parsing but did not
+	 * re-slash the content, causing WordPress to double-unslash and strip user backslashes.
+	 *
+	 * @see https://linear.app/a8c/issue/CM-516
+	 */
+	public function test_remove_blocks_preserves_backslashes() {
+		// Simulate what WordPress does: slash the comment content before applying pre_comment_content filters.
+		$user_input    = '<!-- wp:paragraph --><p>Hello \\ World and some \\LaTeX</p><!-- /wp:paragraph -->';
+		$slashed_input = wp_slash( $user_input );
+
+		$result = Verbum_Block_Utils::remove_blocks( $slashed_input );
+
+		// The result must still be slashed so WordPress can unslash it once to get the original content.
+		$this->assertSame( $user_input, wp_unslash( $result ), 'Backslashes should survive a single wp_unslash after remove_blocks processing.' );
 	}
 
 	/**

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/verbum-comments/Verbum_Block_Utils_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/verbum-comments/Verbum_Block_Utils_Test.php
@@ -241,7 +241,7 @@ HTML;
 	 * Previously, remove_blocks() called wp_unslash() for block parsing but did not
 	 * re-slash the content, causing WordPress to double-unslash and strip user backslashes.
 	 *
-	 * @see https://linear.app/a8c/issue/CM-516
+	 * @see CM-516
 	 */
 	public function test_remove_blocks_preserves_backslashes() {
 		// Simulate what WordPress does: slash the comment content before applying pre_comment_content filters.


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/CM-516

## Proposed changes:

* Fix `remove_blocks()` stripping backslashes from comment content.
* The `pre_comment_content` filter receives slashed data and must return slashed data. Previously, `wp_unslash()` was called for block parsing but the result was never re-slashed, causing WordPress to double-unslash and strip user backslashes.
* Scope the `wp_unslash()`/`wp_slash()` pair to only the code path that actually needs it (`parse_blocks`), so comments without disallowed blocks are returned untouched.
* Add a dedicated test for backslash preservation.

<img width="487" height="415" alt="Screen Shot 2026-02-11 at 16 34 13" src="https://github.com/user-attachments/assets/e709bb8e-768b-4b53-a675-37131ed03af9" />

### Other information:

- [X] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [X] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

This bug was reported by Team 51 on behalf of mathematician Terry Tao, whose blog readers rely on LaTeX (backslash-heavy) in comments. With Verbum enabled, `Verbum_Block_Utils::remove_blocks()` called `wp_unslash()` on the incoming content for `parse_blocks` compatibility but returned the unslashed result. Since `pre_comment_content` filters must return slashed data, WordPress then applied its own `wp_unslash()`, double-unslashing and destroying user backslashes.

The fix wraps only the `parse_blocks` call in `wp_unslash()`/`wp_slash()` so the filter contract is preserved.

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

1. On a WordPress.com Simple Site, enable Verbum under **WP Admin > Settings > Discussion > Verbum**.
2. Create or open a post.
3. Leave a comment containing backslashes, e.g. `Hello \World and some \\LaTeX`.
4. Publish the comment.
5. Verify the backslashes are preserved in the published comment.
