### PR TITLE
Image Studio: Enqueue assets in Jetpack plugins

### DIFF
--- a/projects/plugins/jetpack/changelog/forno-167-image-studio-jetpack-plugin
+++ b/projects/plugins/jetpack/changelog/forno-167-image-studio-jetpack-plugin
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Image Studio: add Image Studio plugin support to block editor and media library.

--- a/projects/plugins/jetpack/extensions/index.json
+++ b/projects/plugins/jetpack/extensions/index.json
@@ -74,7 +74,8 @@
 		"ai-response-feedback",
 		"ai-assistant-image-extension",
 		"ai-seo-enhancer",
-		"paypal-payment-buttons"
+		"paypal-payment-buttons",
+		"image-studio"
 	],
 	"beta": [
 		"google-docs-embed",

--- a/projects/plugins/jetpack/extensions/plugins/image-studio/image-studio.php
+++ b/projects/plugins/jetpack/extensions/plugins/image-studio/image-studio.php
@@ -316,14 +316,14 @@ add_filter( 'agents_manager_use_unified_experience', __NAMESPACE__ . '\enable_ag
 /**
  * Register the Image Studio headless agent provider with the agents manager.
  *
- * When jetpack_image_studio_enabled is true, adds the Image Studio headless
+ * When Image Studio is enabled, adds the Image Studio headless
  * agent provider module so the agents manager can load it.
  *
  * @param array $providers Existing agent provider module IDs.
  * @return array Modified array of provider module IDs.
  */
 function register_headless_agent_provider( $providers ) {
-	if ( ! apply_filters( 'jetpack_image_studio_enabled', false ) ) {
+	if ( ! is_image_studio_enabled() ) {
 		return $providers;
 	}
 

--- a/projects/plugins/jetpack/extensions/plugins/image-studio/image-studio.php
+++ b/projects/plugins/jetpack/extensions/plugins/image-studio/image-studio.php
@@ -7,14 +7,15 @@
 
 namespace Automattic\Jetpack\Extensions\ImageStudio;
 
-const FEATURE_NAME    = 'image-studio';
-const ASSET_BASE_PATH = 'widgets.wp.com/agents-manager/';
-const ASSET_JS_URL    = 'https://' . ASSET_BASE_PATH . 'image-studio.min.js';
-const ASSET_CSS_URL   = 'https://' . ASSET_BASE_PATH . 'image-studio.css';
-const ASSET_RTL_URL   = 'https://' . ASSET_BASE_PATH . 'image-studio.rtl.css';
-const ASSET_JSON_URL  = 'https://' . ASSET_BASE_PATH . 'image-studio.asset.json';
-const ASSET_JSON_PATH = ASSET_BASE_PATH . 'image-studio.asset.json';
-const ASSET_TRANSIENT = 'jetpack_image_studio_asset';
+const FEATURE_NAME            = 'image-studio';
+const ASSET_BASE_PATH         = 'widgets.wp.com/agents-manager/';
+const ASSET_JS_URL            = 'https://' . ASSET_BASE_PATH . 'image-studio.min.js';
+const ASSET_CSS_URL           = 'https://' . ASSET_BASE_PATH . 'image-studio.css';
+const ASSET_RTL_URL           = 'https://' . ASSET_BASE_PATH . 'image-studio.rtl.css';
+const ASSET_JSON_URL          = 'https://' . ASSET_BASE_PATH . 'image-studio.asset.json';
+const ASSET_JSON_PATH         = ASSET_BASE_PATH . 'image-studio.asset.json';
+const ASSET_TRANSIENT         = 'jetpack_image_studio_asset';
+const HEADLESS_AGENT_PROVIDER = 'image-studio/headless-agent-provider';
 
 /**
  * Check if Image Studio is enabled.
@@ -315,3 +316,41 @@ function disable_jetpack_ai_image_extensions() {
 }
 // Priority 99 ensures this runs after all AI extensions are registered at default priority.
 add_action( 'jetpack_register_gutenberg_extensions', __NAMESPACE__ . '\disable_jetpack_ai_image_extensions', 99 );
+
+/**
+ * Enable the agents manager unified experience on self-hosted sites
+ * when jetpack_image_studio_enabled is true.
+ *
+ * This ensures the agents manager loads and can host the headless agent
+ * even when the unified chat experience is not otherwise enabled.
+ *
+ * @param bool $use_unified_experience Current value of the filter.
+ * @return bool
+ */
+function enable_agents_manager_for_image_studio( $use_unified_experience ) {
+	if ( $use_unified_experience ) {
+		return true;
+	}
+
+	return (bool) apply_filters( 'jetpack_image_studio_enabled', false );
+}
+add_filter( 'agents_manager_use_unified_experience', __NAMESPACE__ . '\enable_agents_manager_for_image_studio' );
+
+/**
+ * Register the Image Studio headless agent provider with the agents manager.
+ *
+ * When jetpack_image_studio_enabled is true, adds the Image Studio headless
+ * agent provider module so the agents manager can load it.
+ *
+ * @param array $providers Existing agent provider module IDs.
+ * @return array Modified array of provider module IDs.
+ */
+function register_headless_agent_provider( $providers ) {
+	if ( ! apply_filters( 'jetpack_image_studio_enabled', false ) ) {
+		return $providers;
+	}
+
+	$providers[] = HEADLESS_AGENT_PROVIDER;
+	return $providers;
+}
+add_filter( 'agents_manager_agent_providers', __NAMESPACE__ . '\register_headless_agent_provider' );

--- a/projects/plugins/jetpack/extensions/plugins/image-studio/image-studio.php
+++ b/projects/plugins/jetpack/extensions/plugins/image-studio/image-studio.php
@@ -7,6 +7,10 @@
 
 namespace Automattic\Jetpack\Extensions\ImageStudio;
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 const FEATURE_NAME            = 'image-studio';
 const ASSET_BASE_PATH         = 'widgets.wp.com/agents-manager/';
 const ASSET_JS_URL            = 'https://' . ASSET_BASE_PATH . 'image-studio.min.js';

--- a/projects/plugins/jetpack/extensions/plugins/image-studio/image-studio.php
+++ b/projects/plugins/jetpack/extensions/plugins/image-studio/image-studio.php
@@ -266,12 +266,13 @@ function get_ai_image_extensions() {
  * and again inside Jetpack_Gutenberg::get_availability() during enqueue (where the
  * screen IS available).
  *
- * - First call (no screen): blanket disable as a safe default.
- * - Subsequent calls (screen available): only disable if Image Studio will actually
- *   load on this screen (i.e. should_load_on_current_screen() is true).
+ * Only disables AI extensions when we can confirm Image Studio will actually load
+ * on the current screen (i.e. screen is available and should_load_on_current_screen()
+ * returns true). If the screen is not available or Image Studio won't load on this
+ * screen, AI extensions remain enabled.
  *
- * This ensures AI extensions are restored on screens where Image Studio won't load
- * (e.g. dashboard or other non-editor screens).
+ * This ensures AI extensions are available on screens where Image Studio won't load
+ * (e.g. dashboard, other non-editor screens, or early initialization).
  *
  * @return void
  */
@@ -280,11 +281,9 @@ function disable_jetpack_ai_image_extensions() {
 		return;
 	}
 
-	// When the screen is available, only disable if Image Studio will actually load.
-	if ( function_exists( 'get_current_screen' ) && get_current_screen() ) {
-		if ( ! should_load_on_current_screen() ) {
-			return;
-		}
+	// Only disable if screen is available and Image Studio will actually load.
+	if ( ! function_exists( 'get_current_screen' ) || ! get_current_screen() || ! should_load_on_current_screen() ) {
+		return;
 	}
 
 	foreach ( get_ai_image_extensions() as $extension ) {

--- a/projects/plugins/jetpack/extensions/plugins/image-studio/image-studio.php
+++ b/projects/plugins/jetpack/extensions/plugins/image-studio/image-studio.php
@@ -1,0 +1,316 @@
+<?php
+/**
+ * Block Editor & Media Library - Image Studio plugin feature.
+ *
+ * @package automattic/jetpack
+ */
+
+namespace Automattic\Jetpack\Extensions\ImageStudio;
+
+const FEATURE_NAME    = 'image-studio';
+const ASSET_BASE_PATH = 'widgets.wp.com/agents-manager/';
+const ASSET_JS_URL    = 'https://' . ASSET_BASE_PATH . 'image-studio.min.js';
+const ASSET_CSS_URL   = 'https://' . ASSET_BASE_PATH . 'image-studio.css';
+const ASSET_RTL_URL   = 'https://' . ASSET_BASE_PATH . 'image-studio.rtl.css';
+const ASSET_JSON_URL  = 'https://' . ASSET_BASE_PATH . 'image-studio.asset.json';
+const ASSET_JSON_PATH = ASSET_BASE_PATH . 'image-studio.asset.json';
+const ASSET_TRANSIENT = 'jetpack_image_studio_asset';
+
+/**
+ * Check if Image Studio is enabled.
+ *
+ * Returns true if either the unified chat experience or the
+ * jetpack_image_studio_enabled filter is active.
+ *
+ * @return bool
+ */
+function is_image_studio_enabled() {
+	return apply_filters( 'agents_manager_use_unified_experience', false )
+		|| apply_filters( 'jetpack_image_studio_enabled', false );
+}
+
+/**
+ * Check if the current screen is a block editor (Post Editor or Site Editor).
+ *
+ * @return bool
+ */
+function is_block_editor() {
+	if ( ! function_exists( 'get_current_screen' ) ) {
+		return false;
+	}
+
+	$screen = get_current_screen();
+	return $screen && $screen->is_block_editor();
+}
+
+/**
+ * Check if the current screen is the Media Library.
+ *
+ * @return bool
+ */
+function is_media_library() {
+	if ( ! function_exists( 'get_current_screen' ) ) {
+		return false;
+	}
+
+	$screen = get_current_screen();
+	return $screen && 'upload' === $screen->base;
+}
+
+/**
+ * Check if Image Studio has been explicitly enabled via query parameter.
+ *
+ * @return bool
+ */
+function has_enable_image_studio_param() {
+	// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- This is a feature flag check, not a form submission.
+	if ( ! isset( $_GET['enable_image_studio'] ) || ! is_string( $_GET['enable_image_studio'] ) ) {
+		return false;
+	}
+	// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- This is a feature flag check, not a form submission.
+	return '1' === sanitize_text_field( wp_unslash( $_GET['enable_image_studio'] ) );
+}
+
+/**
+ * Determine if Image Studio should load on the current screen.
+ *
+ * - Media Library: load if either filter is true (no query param needed).
+ * - Block editors (Post/Site Editor): load only with `enable_image_studio=1` query param.
+ * - Other screens: don't load.
+ *
+ * @return bool
+ */
+function should_load_on_current_screen() {
+	return is_media_library() || ( is_block_editor() && has_enable_image_studio_param() );
+}
+
+/**
+ * Register the Image Studio plugin.
+ *
+ * Registers unconditionally when either filter is true. Screen-level gating
+ * happens at enqueue time since get_current_screen() is not available here.
+ *
+ * @return void
+ */
+function register_plugin() {
+	if ( ! is_image_studio_enabled() ) {
+		return;
+	}
+
+	\Jetpack_Gutenberg::set_extension_available( FEATURE_NAME );
+}
+add_action( 'jetpack_register_gutenberg_extensions', __NAMESPACE__ . '\register_plugin' );
+
+// Populate the available extensions with image-studio.
+add_filter(
+	'jetpack_set_available_extensions',
+	function ( $extensions ) {
+		return array_merge(
+			(array) $extensions,
+			array(
+				FEATURE_NAME,
+			)
+		);
+	}
+);
+
+/**
+ * Fetch and cache the remote asset manifest.
+ *
+ * On WordPress.com, the asset file may be accessible on the local filesystem
+ * (under ABSPATH). This avoids an HTTP round-trip and works on sandboxes where
+ * outbound requests to widgets.wp.com may be blocked.
+ *
+ * @return array|false The decoded asset data, or false on failure.
+ */
+function get_asset_data() {
+	$cached = get_transient( ASSET_TRANSIENT );
+	if ( false !== $cached ) {
+		return $cached;
+	}
+
+	$data = get_asset_data_from_file();
+	if ( false === $data ) {
+		$data = get_asset_data_from_remote();
+	}
+
+	if ( false === $data ) {
+		return false;
+	}
+
+	$cache_duration = ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) ? 0 : HOUR_IN_SECONDS;
+	set_transient( ASSET_TRANSIENT, $data, $cache_duration );
+	return $data;
+}
+
+/**
+ * Try to read the asset manifest from the local filesystem.
+ *
+ * On WordPress.com, widgets.wp.com assets are available at ABSPATH.
+ *
+ * @return array|false The decoded asset data, or false if not available locally.
+ */
+function get_asset_data_from_file() {
+	$local_path = ABSPATH . ASSET_JSON_PATH;
+	if ( ! file_exists( $local_path ) ) {
+		return false;
+	}
+
+	// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Reading a local file, not a remote URL.
+	$contents = file_get_contents( $local_path );
+	if ( false === $contents ) {
+		return false;
+	}
+
+	$data = json_decode( $contents, true );
+	if ( json_last_error() !== JSON_ERROR_NONE || ! is_array( $data ) ) {
+		return false;
+	}
+
+	return $data;
+}
+
+/**
+ * Fetch the asset manifest via HTTP.
+ *
+ * Used as a fallback when the file is not available locally (e.g. self-hosted sites).
+ *
+ * @return array|false The decoded asset data, or false on failure.
+ */
+function get_asset_data_from_remote() {
+	$response = wp_remote_get( ASSET_JSON_URL );
+	if ( is_wp_error( $response ) || 200 !== wp_remote_retrieve_response_code( $response ) ) {
+		return false;
+	}
+
+	$content_type = wp_remote_retrieve_header( $response, 'content-type' );
+	if ( is_string( $content_type ) && false === strpos( $content_type, 'json' ) ) {
+		return false;
+	}
+
+	$body = wp_remote_retrieve_body( $response );
+	$data = json_decode( $body, true );
+	if ( json_last_error() !== JSON_ERROR_NONE || ! is_array( $data ) ) {
+		return false;
+	}
+
+	return $data;
+}
+
+/**
+ * Enqueue Image Studio script and style assets.
+ *
+ * @return void
+ */
+function do_enqueue_assets() {
+	if ( ! is_image_studio_enabled() ) {
+		return;
+	}
+
+	$asset_data = get_asset_data();
+	if ( ! $asset_data ) {
+		return;
+	}
+
+	$version      = $asset_data['version'] ?? false;
+	$dependencies = $asset_data['dependencies'] ?? array();
+
+	wp_enqueue_script(
+		FEATURE_NAME,
+		ASSET_JS_URL,
+		$dependencies,
+		$version,
+		true
+	);
+
+	wp_add_inline_script(
+		FEATURE_NAME,
+		'if ( typeof window.imageStudioData === "undefined" ) { window.imageStudioData = ' . wp_json_encode( array( 'enabled' => true ), JSON_HEX_TAG | JSON_HEX_AMP ) . '; }',
+		'before'
+	);
+
+	wp_enqueue_style(
+		FEATURE_NAME . '-style',
+		is_rtl() ? ASSET_RTL_URL : ASSET_CSS_URL,
+		array( 'wp-components' ),
+		$version
+	);
+}
+
+/**
+ * Enqueue Image Studio assets in the block editor when opted in via query param.
+ *
+ * @return void
+ */
+function enqueue_image_studio() {
+	if ( ! is_block_editor() || ! has_enable_image_studio_param() ) {
+		return;
+	}
+
+	do_enqueue_assets();
+}
+add_action( 'enqueue_block_editor_assets', __NAMESPACE__ . '\enqueue_image_studio' );
+
+/**
+ * Enqueue Image Studio assets on admin screens (Media Library).
+ *
+ * @return void
+ */
+function enqueue_image_studio_admin() {
+	if ( ! is_media_library() ) {
+		return;
+	}
+
+	do_enqueue_assets();
+}
+add_action( 'admin_enqueue_scripts', __NAMESPACE__ . '\enqueue_image_studio_admin' );
+
+/**
+ * Get the list of AI image extensions that conflict with Image Studio.
+ *
+ * @return array
+ */
+function get_ai_image_extensions() {
+	return array(
+		'ai-featured-image-generator',
+		'ai-assistant-image-extension',
+		'ai-general-purpose-image-generator',
+		'ai-assistant-experimental-image-generation-support',
+	);
+}
+
+/**
+ * Disable Jetpack AI image extensions when Image Studio is active on the current screen.
+ *
+ * This hook fires on `jetpack_register_gutenberg_extensions` which may run multiple
+ * times: once during initial module load (before get_current_screen() is available)
+ * and again inside Jetpack_Gutenberg::get_availability() during enqueue (where the
+ * screen IS available).
+ *
+ * - First call (no screen): blanket disable as a safe default.
+ * - Subsequent calls (screen available): only disable if Image Studio will actually
+ *   load on this screen (i.e. should_load_on_current_screen() is true).
+ *
+ * This ensures AI extensions are restored on screens where Image Studio won't load
+ * (e.g. Post Editor without the enable_image_studio=1 query param).
+ *
+ * @return void
+ */
+function disable_jetpack_ai_image_extensions() {
+	if ( ! is_image_studio_enabled() ) {
+		return;
+	}
+
+	// When the screen is available, only disable if Image Studio will actually load.
+	if ( function_exists( 'get_current_screen' ) && get_current_screen() ) {
+		if ( ! should_load_on_current_screen() ) {
+			return;
+		}
+	}
+
+	foreach ( get_ai_image_extensions() as $extension ) {
+		\Jetpack_Gutenberg::set_extension_unavailable( $extension, 'image_studio_active' );
+	}
+}
+// Priority 99 ensures this runs after all AI extensions are registered at default priority.
+add_action( 'jetpack_register_gutenberg_extensions', __NAMESPACE__ . '\disable_jetpack_ai_image_extensions', 99 );

--- a/projects/plugins/jetpack/extensions/plugins/image-studio/image-studio.php
+++ b/projects/plugins/jetpack/extensions/plugins/image-studio/image-studio.php
@@ -185,7 +185,7 @@ function get_asset_data_from_remote() {
 	}
 
 	$content_type = wp_remote_retrieve_header( $response, 'content-type' );
-	if ( is_string( $content_type ) && false === strpos( $content_type, 'json' ) ) {
+	if ( is_string( $content_type ) && false === stripos( $content_type, 'json' ) ) {
 		return false;
 	}
 

--- a/projects/plugins/jetpack/extensions/plugins/image-studio/image-studio.php
+++ b/projects/plugins/jetpack/extensions/plugins/image-studio/image-studio.php
@@ -102,19 +102,6 @@ function register_plugin() {
 }
 add_action( 'jetpack_register_gutenberg_extensions', __NAMESPACE__ . '\register_plugin' );
 
-// Populate the available extensions with image-studio.
-add_filter(
-	'jetpack_set_available_extensions',
-	function ( $extensions ) {
-		return array_merge(
-			(array) $extensions,
-			array(
-				FEATURE_NAME,
-			)
-		);
-	}
-);
-
 /**
  * Fetch and cache the remote asset manifest.
  *

--- a/projects/plugins/jetpack/extensions/plugins/image-studio/image-studio.php
+++ b/projects/plugins/jetpack/extensions/plugins/image-studio/image-studio.php
@@ -59,30 +59,16 @@ function is_media_library() {
 }
 
 /**
- * Check if Image Studio has been explicitly enabled via query parameter.
- *
- * @return bool
- */
-function has_enable_image_studio_param() {
-	// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- This is a feature flag check, not a form submission.
-	if ( ! isset( $_GET['enable_image_studio'] ) || ! is_string( $_GET['enable_image_studio'] ) ) {
-		return false;
-	}
-	// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- This is a feature flag check, not a form submission.
-	return '1' === sanitize_text_field( wp_unslash( $_GET['enable_image_studio'] ) );
-}
-
-/**
  * Determine if Image Studio should load on the current screen.
  *
- * - Media Library: load if either filter is true (no query param needed).
- * - Block editors (Post/Site Editor): load only with `enable_image_studio=1` query param.
+ * - Media Library: load if either filter is true.
+ * - Block editors (Post/Site Editor): load if either filter is true.
  * - Other screens: don't load.
  *
  * @return bool
  */
 function should_load_on_current_screen() {
-	return is_media_library() || ( is_block_editor() && has_enable_image_studio_param() );
+	return is_media_library() || is_block_editor();
 }
 
 /**
@@ -227,12 +213,12 @@ function do_enqueue_assets() {
 }
 
 /**
- * Enqueue Image Studio assets in the block editor when opted in via query param.
+ * Enqueue Image Studio assets in the block editor.
  *
  * @return void
  */
 function enqueue_image_studio() {
-	if ( ! is_block_editor() || ! has_enable_image_studio_param() ) {
+	if ( ! is_block_editor() ) {
 		return;
 	}
 
@@ -281,7 +267,7 @@ function get_ai_image_extensions() {
  *   load on this screen (i.e. should_load_on_current_screen() is true).
  *
  * This ensures AI extensions are restored on screens where Image Studio won't load
- * (e.g. Post Editor without the enable_image_studio=1 query param).
+ * (e.g. dashboard or other non-editor screens).
  *
  * @return void
  */

--- a/projects/plugins/jetpack/extensions/plugins/image-studio/image-studio.php
+++ b/projects/plugins/jetpack/extensions/plugins/image-studio/image-studio.php
@@ -157,7 +157,7 @@ function get_asset_data_from_file() {
  * @return array|false The decoded asset data, or false on failure.
  */
 function get_asset_data_from_remote() {
-	$response = wp_remote_get( ASSET_JSON_URL );
+	$response = wp_safe_remote_get( ASSET_JSON_URL );
 	if ( is_wp_error( $response ) || 200 !== wp_remote_retrieve_response_code( $response ) ) {
 		return false;
 	}

--- a/projects/plugins/jetpack/extensions/plugins/image-studio/image-studio.php
+++ b/projects/plugins/jetpack/extensions/plugins/image-studio/image-studio.php
@@ -138,8 +138,9 @@ function get_asset_data() {
 		return false;
 	}
 
-	$cache_duration = ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) ? 0 : HOUR_IN_SECONDS;
-	set_transient( ASSET_TRANSIENT, $data, $cache_duration );
+	if ( ! ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) ) {
+		set_transient( ASSET_TRANSIENT, $data, HOUR_IN_SECONDS );
+	}
 	return $data;
 }
 

--- a/projects/plugins/jetpack/extensions/plugins/image-studio/image-studio.php
+++ b/projects/plugins/jetpack/extensions/plugins/image-studio/image-studio.php
@@ -8,7 +8,7 @@
 namespace Automattic\Jetpack\Extensions\ImageStudio;
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit;
+	exit( 0 );
 }
 
 const FEATURE_NAME            = 'image-studio';

--- a/projects/plugins/jetpack/tests/php/extensions/plugins/image-studio/Image_Studio_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/plugins/image-studio/Image_Studio_Test.php
@@ -65,7 +65,6 @@ class Image_Studio_Test extends \WP_UnitTestCase {
 	private function reset_availability() {
 		$reflection = new ReflectionClass( 'Jetpack_Gutenberg' );
 		$property   = $reflection->getProperty( 'availability' );
-		$property->setAccessible( true );
 		$property->setValue( null, array() );
 	}
 

--- a/projects/plugins/jetpack/tests/php/extensions/plugins/image-studio/Image_Studio_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/plugins/image-studio/Image_Studio_Test.php
@@ -18,12 +18,14 @@ class Image_Studio_Test extends \WP_UnitTestCase {
 	/**
 	 * AI image extensions that Image Studio replaces.
 	 */
-	private const AI_IMAGE_EXTENSIONS = array(
-		'ai-featured-image-generator',
-		'ai-assistant-image-extension',
-		'ai-general-purpose-image-generator',
-		'ai-assistant-experimental-image-generation-support',
-	);
+	/**
+	 * Get the AI image extensions list from the source function.
+	 *
+	 * @return array
+	 */
+	private static function get_ai_image_extensions() {
+		return ImageStudio\get_ai_image_extensions();
+	}
 
 	/**
 	 * Saved current screen for restoration in tear_down.
@@ -113,7 +115,7 @@ class Image_Studio_Test extends \WP_UnitTestCase {
 	 * Register all AI image extensions as available.
 	 */
 	private function make_ai_extensions_available() {
-		foreach ( self::AI_IMAGE_EXTENSIONS as $ext ) {
+		foreach ( self::get_ai_image_extensions() as $ext ) {
 			\Jetpack_Gutenberg::set_extension_available( $ext );
 		}
 	}
@@ -916,7 +918,7 @@ class Image_Studio_Test extends \WP_UnitTestCase {
 
 		ImageStudio\disable_jetpack_ai_image_extensions();
 
-		foreach ( self::AI_IMAGE_EXTENSIONS as $ext ) {
+		foreach ( self::get_ai_image_extensions() as $ext ) {
 			$this->assertFalse(
 				\Jetpack_Gutenberg::is_available( $ext ),
 				"Extension $ext should be unavailable when Image Studio is enabled."
@@ -933,7 +935,7 @@ class Image_Studio_Test extends \WP_UnitTestCase {
 
 		ImageStudio\disable_jetpack_ai_image_extensions();
 
-		foreach ( self::AI_IMAGE_EXTENSIONS as $ext ) {
+		foreach ( self::get_ai_image_extensions() as $ext ) {
 			$this->assertFalse(
 				\Jetpack_Gutenberg::is_available( $ext ),
 				"Extension $ext should be unavailable when unified experience is enabled."
@@ -950,7 +952,7 @@ class Image_Studio_Test extends \WP_UnitTestCase {
 
 		ImageStudio\disable_jetpack_ai_image_extensions();
 
-		foreach ( self::AI_IMAGE_EXTENSIONS as $ext ) {
+		foreach ( self::get_ai_image_extensions() as $ext ) {
 			$this->assertTrue(
 				\Jetpack_Gutenberg::is_available( $ext ),
 				"Extension $ext should remain available when Image Studio is disabled."
@@ -976,7 +978,7 @@ class Image_Studio_Test extends \WP_UnitTestCase {
 		$this->set_block_editor_screen();
 		ImageStudio\disable_jetpack_ai_image_extensions();
 
-		foreach ( self::AI_IMAGE_EXTENSIONS as $ext ) {
+		foreach ( self::get_ai_image_extensions() as $ext ) {
 			$this->assertTrue(
 				\Jetpack_Gutenberg::is_available( $ext ),
 				"Extension $ext should stay available on block editor without query param."
@@ -995,7 +997,7 @@ class Image_Studio_Test extends \WP_UnitTestCase {
 		$this->set_enable_image_studio_param();
 		ImageStudio\disable_jetpack_ai_image_extensions();
 
-		foreach ( self::AI_IMAGE_EXTENSIONS as $ext ) {
+		foreach ( self::get_ai_image_extensions() as $ext ) {
 			$this->assertFalse(
 				\Jetpack_Gutenberg::is_available( $ext ),
 				"Extension $ext should be disabled on block editor with query param."
@@ -1013,7 +1015,7 @@ class Image_Studio_Test extends \WP_UnitTestCase {
 		$this->set_media_library_screen();
 		ImageStudio\disable_jetpack_ai_image_extensions();
 
-		foreach ( self::AI_IMAGE_EXTENSIONS as $ext ) {
+		foreach ( self::get_ai_image_extensions() as $ext ) {
 			$this->assertFalse(
 				\Jetpack_Gutenberg::is_available( $ext ),
 				"Extension $ext should be disabled on Media Library."
@@ -1031,7 +1033,7 @@ class Image_Studio_Test extends \WP_UnitTestCase {
 		set_current_screen( 'dashboard' );
 		ImageStudio\disable_jetpack_ai_image_extensions();
 
-		foreach ( self::AI_IMAGE_EXTENSIONS as $ext ) {
+		foreach ( self::get_ai_image_extensions() as $ext ) {
 			$this->assertTrue(
 				\Jetpack_Gutenberg::is_available( $ext ),
 				"Extension $ext should stay available on dashboard."
@@ -1052,7 +1054,7 @@ class Image_Studio_Test extends \WP_UnitTestCase {
 		$GLOBALS['current_screen'] = null;
 		ImageStudio\disable_jetpack_ai_image_extensions();
 
-		foreach ( self::AI_IMAGE_EXTENSIONS as $ext ) {
+		foreach ( self::get_ai_image_extensions() as $ext ) {
 			$this->assertFalse(
 				\Jetpack_Gutenberg::is_available( $ext ),
 				"Extension $ext should be disabled when no screen is available (blanket disable)."
@@ -1296,7 +1298,7 @@ class Image_Studio_Test extends \WP_UnitTestCase {
 	 */
 	public function test_get_ai_image_extensions_returns_expected_list() {
 		$extensions = ImageStudio\get_ai_image_extensions();
-		$this->assertEquals( self::AI_IMAGE_EXTENSIONS, $extensions );
+		$this->assertEquals( self::get_ai_image_extensions(), $extensions );
 	}
 
 	// -------------------------------------------------------------------------

--- a/projects/plugins/jetpack/tests/php/extensions/plugins/image-studio/Image_Studio_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/plugins/image-studio/Image_Studio_Test.php
@@ -33,13 +33,29 @@ class Image_Studio_Test extends \WP_UnitTestCase {
 	private $saved_screen;
 
 	/**
+	 * Saved wp_scripts global.
+	 *
+	 * @var mixed
+	 */
+	private $saved_wp_scripts;
+
+	/**
+	 * Saved wp_styles global.
+	 *
+	 * @var mixed
+	 */
+	private $saved_wp_styles;
+
+	/**
 	 * Set up before each test.
 	 */
 	public function set_up() {
 		parent::set_up();
 		delete_transient( ImageStudio\ASSET_TRANSIENT );
-		$GLOBALS['wp_scripts'] = new WP_Scripts();
-		$GLOBALS['wp_styles']  = new WP_Styles();
+		$this->saved_wp_scripts = $GLOBALS['wp_scripts'] ?? null;
+		$this->saved_wp_styles  = $GLOBALS['wp_styles'] ?? null;
+		$GLOBALS['wp_scripts']  = new WP_Scripts();
+		$GLOBALS['wp_styles']   = new WP_Styles();
 		$this->reset_availability();
 		unset( $_GET['enable_image_studio'] );
 		$this->saved_screen = $GLOBALS['current_screen'] ?? null;
@@ -56,6 +72,8 @@ class Image_Studio_Test extends \WP_UnitTestCase {
 		remove_all_filters( 'jetpack_set_available_extensions' );
 		unset( $_GET['enable_image_studio'] );
 		$GLOBALS['current_screen'] = $this->saved_screen;
+		$GLOBALS['wp_scripts']     = $this->saved_wp_scripts;
+		$GLOBALS['wp_styles']      = $this->saved_wp_styles;
 		parent::tear_down();
 	}
 

--- a/projects/plugins/jetpack/tests/php/extensions/plugins/image-studio/Image_Studio_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/plugins/image-studio/Image_Studio_Test.php
@@ -16,10 +16,9 @@ class Image_Studio_Test extends \WP_UnitTestCase {
 	use \Automattic\Jetpack\PHPUnit\WP_UnitTestCase_Fix;
 
 	/**
-	 * AI image extensions that Image Studio replaces.
-	 */
-	/**
 	 * Get the AI image extensions list from the source function.
+	 *
+	 * AI image extensions that Image Studio replaces.
 	 *
 	 * @return array
 	 */
@@ -731,7 +730,14 @@ class Image_Studio_Test extends \WP_UnitTestCase {
 		$result = ImageStudio\get_asset_data();
 
 		$this->assertEquals( $asset_data, $result );
-		$this->assertEquals( $asset_data, get_transient( ImageStudio\ASSET_TRANSIENT ) );
+
+		if ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) {
+			// In debug mode, asset data should not be cached in a transient.
+			$this->assertFalse( get_transient( ImageStudio\ASSET_TRANSIENT ) );
+		} else {
+			// When not in debug mode, the transient should contain the fetched asset data.
+			$this->assertEquals( $asset_data, get_transient( ImageStudio\ASSET_TRANSIENT ) );
+		}
 	}
 
 	/**

--- a/projects/plugins/jetpack/tests/php/extensions/plugins/image-studio/Image_Studio_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/plugins/image-studio/Image_Studio_Test.php
@@ -855,6 +855,7 @@ class Image_Studio_Test extends \WP_UnitTestCase {
 	public function test_ai_extensions_disabled_when_enabled() {
 		$this->enable_image_studio();
 		$this->make_ai_extensions_available();
+		$this->set_block_editor_screen();
 
 		ImageStudio\disable_jetpack_ai_image_extensions();
 
@@ -872,6 +873,7 @@ class Image_Studio_Test extends \WP_UnitTestCase {
 	public function test_ai_extensions_disabled_when_unified_experience() {
 		$this->enable_unified_experience();
 		$this->make_ai_extensions_available();
+		$this->set_block_editor_screen();
 
 		ImageStudio\disable_jetpack_ai_image_extensions();
 

--- a/projects/plugins/jetpack/tests/php/extensions/plugins/image-studio/Image_Studio_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/plugins/image-studio/Image_Studio_Test.php
@@ -65,6 +65,7 @@ class Image_Studio_Test extends \WP_UnitTestCase {
 	private function reset_availability() {
 		$reflection = new ReflectionClass( 'Jetpack_Gutenberg' );
 		$property   = $reflection->getProperty( 'availability' );
+		@$property->setAccessible( true ); // @codingStandardsIgnoreLine — needed for PHP < 8.1, suppressed for PHP 8.5+ deprecation.
 		$property->setValue( null, array() );
 	}
 

--- a/projects/plugins/jetpack/tests/php/extensions/plugins/image-studio/Image_Studio_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/plugins/image-studio/Image_Studio_Test.php
@@ -72,7 +72,6 @@ class Image_Studio_Test extends \WP_UnitTestCase {
 		remove_all_filters( 'agents_manager_use_unified_experience' );
 		remove_all_filters( 'agents_manager_agent_providers' );
 		remove_all_filters( 'pre_http_request' );
-		remove_all_filters( 'jetpack_set_available_extensions' );
 		unset( $_GET['enable_image_studio'] );
 		$GLOBALS['current_screen'] = $this->saved_screen;
 		$GLOBALS['wp_scripts']     = $this->saved_wp_scripts;
@@ -1060,27 +1059,6 @@ class Image_Studio_Test extends \WP_UnitTestCase {
 				"Extension $ext should be disabled when no screen is available (blanket disable)."
 			);
 		}
-	}
-
-	// -------------------------------------------------------------------------
-	// jetpack_set_available_extensions filter tests
-	// -------------------------------------------------------------------------
-
-	/**
-	 * Test that the jetpack_set_available_extensions filter includes image-studio.
-	 */
-	public function test_available_extensions_filter_includes_image_studio() {
-		$extensions = apply_filters( 'jetpack_set_available_extensions', array() );
-		$this->assertContains( ImageStudio\FEATURE_NAME, $extensions );
-	}
-
-	/**
-	 * Test that the filter merges with existing extensions.
-	 */
-	public function test_available_extensions_filter_merges_with_existing() {
-		$extensions = apply_filters( 'jetpack_set_available_extensions', array( 'some-other-extension' ) );
-		$this->assertContains( 'some-other-extension', $extensions );
-		$this->assertContains( ImageStudio\FEATURE_NAME, $extensions );
 	}
 
 	// -------------------------------------------------------------------------

--- a/projects/plugins/jetpack/tests/php/extensions/plugins/image-studio/Image_Studio_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/plugins/image-studio/Image_Studio_Test.php
@@ -959,12 +959,12 @@ class Image_Studio_Test extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Test AI extensions blanket-disabled when no screen is available.
+	 * Test AI extensions remain available when no screen is available.
 	 *
-	 * On the first call (during module load), get_current_screen() is not
-	 * available, so we blanket disable as a safe default.
+	 * When get_current_screen() is not available (early in module load),
+	 * Image Studio won't load either, so AI extensions remain available.
 	 */
-	public function test_ai_extensions_blanket_disabled_when_no_screen() {
+	public function test_ai_extensions_not_disabled_when_no_screen() {
 		$this->enable_image_studio();
 		$this->make_ai_extensions_available();
 
@@ -972,9 +972,9 @@ class Image_Studio_Test extends \WP_UnitTestCase {
 		ImageStudio\disable_jetpack_ai_image_extensions();
 
 		foreach ( self::get_ai_image_extensions() as $ext ) {
-			$this->assertFalse(
+			$this->assertTrue(
 				\Jetpack_Gutenberg::is_available( $ext ),
-				"Extension $ext should be disabled when no screen is available (blanket disable)."
+				"Extension $ext should remain available when no screen is available (Image Studio won't load)."
 			);
 		}
 	}

--- a/projects/plugins/jetpack/tests/php/extensions/plugins/image-studio/Image_Studio_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/plugins/image-studio/Image_Studio_Test.php
@@ -68,6 +68,7 @@ class Image_Studio_Test extends \WP_UnitTestCase {
 		delete_transient( ImageStudio\ASSET_TRANSIENT );
 		remove_all_filters( 'jetpack_image_studio_enabled' );
 		remove_all_filters( 'agents_manager_use_unified_experience' );
+		remove_all_filters( 'agents_manager_agent_providers' );
 		remove_all_filters( 'pre_http_request' );
 		remove_all_filters( 'jetpack_set_available_extensions' );
 		unset( $_GET['enable_image_studio'] );
@@ -1296,6 +1297,112 @@ class Image_Studio_Test extends \WP_UnitTestCase {
 	public function test_get_ai_image_extensions_returns_expected_list() {
 		$extensions = ImageStudio\get_ai_image_extensions();
 		$this->assertEquals( self::AI_IMAGE_EXTENSIONS, $extensions );
+	}
+
+	// -------------------------------------------------------------------------
+	// Headless agent loading tests
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Test that agents_manager_agent_providers includes Image Studio provider
+	 * when jetpack_image_studio_enabled is true.
+	 */
+	public function test_agent_providers_includes_image_studio_when_enabled() {
+		$this->enable_image_studio();
+
+		$providers = ImageStudio\register_headless_agent_provider( array() );
+
+		$this->assertContains( ImageStudio\HEADLESS_AGENT_PROVIDER, $providers );
+	}
+
+	/**
+	 * Test that agents_manager_agent_providers does NOT include Image Studio
+	 * provider when jetpack_image_studio_enabled is false.
+	 */
+	public function test_agent_providers_excludes_image_studio_when_disabled() {
+		$this->disable_image_studio();
+
+		$providers = ImageStudio\register_headless_agent_provider( array() );
+
+		$this->assertNotContains( ImageStudio\HEADLESS_AGENT_PROVIDER, $providers );
+	}
+
+	/**
+	 * Test that agents_manager_agent_providers does NOT include Image Studio
+	 * provider when no filter is set (default false).
+	 */
+	public function test_agent_providers_excludes_image_studio_by_default() {
+		$providers = ImageStudio\register_headless_agent_provider( array() );
+
+		$this->assertNotContains( ImageStudio\HEADLESS_AGENT_PROVIDER, $providers );
+	}
+
+	/**
+	 * Test that register_headless_agent_provider preserves existing providers.
+	 */
+	public function test_agent_providers_preserves_existing_providers() {
+		$this->enable_image_studio();
+
+		$existing  = array( 'some-other/provider' );
+		$providers = ImageStudio\register_headless_agent_provider( $existing );
+
+		$this->assertContains( 'some-other/provider', $providers );
+		$this->assertContains( ImageStudio\HEADLESS_AGENT_PROVIDER, $providers );
+	}
+
+	/**
+	 * Test that enable_agents_manager_for_image_studio returns true
+	 * when jetpack_image_studio_enabled is true.
+	 */
+	public function test_enable_agents_manager_returns_true_when_image_studio_enabled() {
+		$this->enable_image_studio();
+
+		$result = ImageStudio\enable_agents_manager_for_image_studio( false );
+
+		$this->assertTrue( $result );
+	}
+
+	/**
+	 * Test that enable_agents_manager_for_image_studio returns false
+	 * when jetpack_image_studio_enabled is false and input is false.
+	 */
+	public function test_enable_agents_manager_returns_false_when_image_studio_disabled() {
+		$this->disable_image_studio();
+
+		$result = ImageStudio\enable_agents_manager_for_image_studio( false );
+
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * Test that enable_agents_manager_for_image_studio does not override
+	 * when agents_manager_use_unified_experience is already true.
+	 */
+	public function test_enable_agents_manager_preserves_existing_true() {
+		// Even without image studio enabled, if already true, stay true.
+		$result = ImageStudio\enable_agents_manager_for_image_studio( true );
+
+		$this->assertTrue( $result );
+	}
+
+	/**
+	 * Test that enable_agents_manager_for_image_studio preserves true
+	 * when both unified experience and image studio are enabled (no double-registration).
+	 */
+	public function test_enable_agents_manager_no_double_registration() {
+		$this->enable_image_studio();
+
+		// Already true — should return early without re-evaluating jetpack_image_studio_enabled.
+		$result = ImageStudio\enable_agents_manager_for_image_studio( true );
+
+		$this->assertTrue( $result );
+	}
+
+	/**
+	 * Test HEADLESS_AGENT_PROVIDER constant value.
+	 */
+	public function test_headless_agent_provider_constant() {
+		$this->assertEquals( 'image-studio/headless-agent-provider', ImageStudio\HEADLESS_AGENT_PROVIDER );
 	}
 
 	// -------------------------------------------------------------------------

--- a/projects/plugins/jetpack/tests/php/extensions/plugins/image-studio/Image_Studio_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/plugins/image-studio/Image_Studio_Test.php
@@ -1,0 +1,1333 @@
+<?php
+/**
+ * Image Studio extension tests.
+ *
+ * @package automattic/jetpack
+ */
+
+use Automattic\Jetpack\Extensions\ImageStudio;
+
+require_once JETPACK__PLUGIN_DIR . '/extensions/plugins/image-studio/image-studio.php';
+
+/**
+ * Image Studio extension tests.
+ */
+class Image_Studio_Test extends \WP_UnitTestCase {
+	use \Automattic\Jetpack\PHPUnit\WP_UnitTestCase_Fix;
+
+	/**
+	 * AI image extensions that Image Studio replaces.
+	 */
+	private const AI_IMAGE_EXTENSIONS = array(
+		'ai-featured-image-generator',
+		'ai-assistant-image-extension',
+		'ai-general-purpose-image-generator',
+		'ai-assistant-experimental-image-generation-support',
+	);
+
+	/**
+	 * Saved current screen for restoration in tear_down.
+	 *
+	 * @var mixed
+	 */
+	private $saved_screen;
+
+	/**
+	 * Set up before each test.
+	 */
+	public function set_up() {
+		parent::set_up();
+		delete_transient( ImageStudio\ASSET_TRANSIENT );
+		$GLOBALS['wp_scripts'] = new WP_Scripts();
+		$GLOBALS['wp_styles']  = new WP_Styles();
+		$this->reset_availability();
+		unset( $_GET['enable_image_studio'] );
+		$this->saved_screen = $GLOBALS['current_screen'] ?? null;
+	}
+
+	/**
+	 * Tear down after each test.
+	 */
+	public function tear_down() {
+		delete_transient( ImageStudio\ASSET_TRANSIENT );
+		remove_all_filters( 'jetpack_image_studio_enabled' );
+		remove_all_filters( 'agents_manager_use_unified_experience' );
+		remove_all_filters( 'pre_http_request' );
+		remove_all_filters( 'jetpack_set_available_extensions' );
+		unset( $_GET['enable_image_studio'] );
+		$GLOBALS['current_screen'] = $this->saved_screen;
+		parent::tear_down();
+	}
+
+	/**
+	 * Reset Jetpack Gutenberg extension availability.
+	 */
+	private function reset_availability() {
+		$reflection = new ReflectionClass( 'Jetpack_Gutenberg' );
+		$property   = $reflection->getProperty( 'availability' );
+		$property->setAccessible( true );
+		$property->setValue( null, array() );
+	}
+
+	/**
+	 * Enable Image Studio via jetpack_image_studio_enabled filter.
+	 */
+	private function enable_image_studio() {
+		add_filter( 'jetpack_image_studio_enabled', '__return_true' );
+	}
+
+	/**
+	 * Disable Image Studio via filter.
+	 */
+	private function disable_image_studio() {
+		add_filter( 'jetpack_image_studio_enabled', '__return_false' );
+	}
+
+	/**
+	 * Enable unified chat experience filter.
+	 */
+	private function enable_unified_experience() {
+		add_filter( 'agents_manager_use_unified_experience', '__return_true' );
+	}
+
+	/**
+	 * Register all AI image extensions as available.
+	 */
+	private function make_ai_extensions_available() {
+		foreach ( self::AI_IMAGE_EXTENSIONS as $ext ) {
+			\Jetpack_Gutenberg::set_extension_available( $ext );
+		}
+	}
+
+	/**
+	 * Set the enable_image_studio query parameter.
+	 */
+	private function set_enable_image_studio_param() {
+		$_GET['enable_image_studio'] = '1';
+	}
+
+	/**
+	 * Set the current screen to a block editor.
+	 */
+	private function set_block_editor_screen() {
+		set_current_screen( 'post' );
+		get_current_screen()->is_block_editor = true;
+	}
+
+	/**
+	 * Set the current screen to the Media Library.
+	 */
+	private function set_media_library_screen() {
+		set_current_screen( 'upload' );
+	}
+
+	/**
+	 * Enable Image Studio, cache asset data, and enqueue via block editor path.
+	 *
+	 * Sets up block editor screen with query param before enqueuing.
+	 *
+	 * @param array|null $asset_data The asset data to cache.
+	 */
+	private function enable_and_enqueue_block_editor( $asset_data = null ) {
+		if ( null === $asset_data ) {
+			$asset_data = array(
+				'version'      => '1.0.0',
+				'dependencies' => array(),
+			);
+		}
+		$this->enable_image_studio();
+		$this->set_block_editor_screen();
+		$this->set_enable_image_studio_param();
+		ImageStudio\register_plugin();
+		set_transient( ImageStudio\ASSET_TRANSIENT, $asset_data, HOUR_IN_SECONDS );
+		ImageStudio\enqueue_image_studio();
+	}
+
+	/**
+	 * Enable Image Studio, cache asset data, and enqueue via Media Library path.
+	 *
+	 * @param array|null $asset_data The asset data to cache.
+	 */
+	private function enable_and_enqueue_media_library( $asset_data = null ) {
+		if ( null === $asset_data ) {
+			$asset_data = array(
+				'version'      => '1.0.0',
+				'dependencies' => array(),
+			);
+		}
+		$this->enable_image_studio();
+		$this->set_media_library_screen();
+		ImageStudio\register_plugin();
+		set_transient( ImageStudio\ASSET_TRANSIENT, $asset_data, HOUR_IN_SECONDS );
+		ImageStudio\enqueue_image_studio_admin();
+	}
+
+	/**
+	 * Mock the remote asset manifest fetch.
+	 *
+	 * @param array|false $asset_data The asset data to return, or false for failure.
+	 */
+	private function mock_remote_asset( $asset_data ) {
+		if ( false === $asset_data ) {
+			add_filter(
+				'pre_http_request',
+				function () {
+					return new WP_Error( 'http_request_failed', 'Request failed' );
+				}
+			);
+			return;
+		}
+
+		add_filter(
+			'pre_http_request',
+			function () use ( $asset_data ) {
+				return array(
+					'response' => array( 'code' => 200 ),
+					'headers'  => array( 'content-type' => 'application/json' ),
+					'body'     => wp_json_encode( $asset_data, JSON_HEX_TAG | JSON_HEX_AMP ),
+				);
+			}
+		);
+	}
+
+	/**
+	 * Mock the remote asset manifest fetch with a specific HTTP status code.
+	 *
+	 * @param int    $status_code  The HTTP status code to return.
+	 * @param string $body         The response body.
+	 * @param string $content_type The Content-Type header value.
+	 */
+	private function mock_remote_asset_with_status( $status_code, $body = '', $content_type = 'application/json' ) {
+		add_filter(
+			'pre_http_request',
+			function () use ( $status_code, $body, $content_type ) {
+				return array(
+					'response' => array( 'code' => $status_code ),
+					'headers'  => array( 'content-type' => $content_type ),
+					'body'     => $body,
+				);
+			}
+		);
+	}
+
+	// -------------------------------------------------------------------------
+	// is_image_studio_enabled() tests
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Test is_image_studio_enabled returns true when jetpack_image_studio_enabled is true.
+	 */
+	public function test_is_enabled_via_jetpack_filter() {
+		$this->enable_image_studio();
+		$this->assertTrue( ImageStudio\is_image_studio_enabled() );
+	}
+
+	/**
+	 * Test is_image_studio_enabled returns true when unified experience is true.
+	 */
+	public function test_is_enabled_via_unified_experience() {
+		$this->enable_unified_experience();
+		$this->assertTrue( ImageStudio\is_image_studio_enabled() );
+	}
+
+	/**
+	 * Test is_image_studio_enabled returns false when both filters are false.
+	 */
+	public function test_is_not_enabled_when_both_filters_false() {
+		$this->assertFalse( ImageStudio\is_image_studio_enabled() );
+	}
+
+	/**
+	 * Test is_image_studio_enabled returns true when both filters are true.
+	 */
+	public function test_is_enabled_when_both_filters_true() {
+		$this->enable_image_studio();
+		$this->enable_unified_experience();
+		$this->assertTrue( ImageStudio\is_image_studio_enabled() );
+	}
+
+	// -------------------------------------------------------------------------
+	// is_block_editor() tests
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Test is_block_editor returns true when current screen is a block editor.
+	 */
+	public function test_is_block_editor_true() {
+		$this->set_block_editor_screen();
+		$this->assertTrue( ImageStudio\is_block_editor() );
+	}
+
+	/**
+	 * Test is_block_editor returns false on a non-editor admin screen.
+	 */
+	public function test_is_block_editor_false_on_other_screen() {
+		set_current_screen( 'dashboard' );
+		$this->assertFalse( ImageStudio\is_block_editor() );
+	}
+
+	/**
+	 * Test is_block_editor returns false when no current screen is set.
+	 */
+	public function test_is_block_editor_false_when_no_screen() {
+		$GLOBALS['current_screen'] = null;
+		$this->assertFalse( ImageStudio\is_block_editor() );
+	}
+
+	/**
+	 * Test is_block_editor returns false on Media Library screen.
+	 */
+	public function test_is_block_editor_false_on_media_library() {
+		$this->set_media_library_screen();
+		$this->assertFalse( ImageStudio\is_block_editor() );
+	}
+
+	// -------------------------------------------------------------------------
+	// is_media_library() tests
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Test is_media_library returns true when current screen is upload.
+	 */
+	public function test_is_media_library_true() {
+		$this->set_media_library_screen();
+		$this->assertTrue( ImageStudio\is_media_library() );
+	}
+
+	/**
+	 * Test is_media_library returns false on a non-upload screen.
+	 */
+	public function test_is_media_library_false_on_other_screen() {
+		set_current_screen( 'dashboard' );
+		$this->assertFalse( ImageStudio\is_media_library() );
+	}
+
+	/**
+	 * Test is_media_library returns false when no current screen is set.
+	 */
+	public function test_is_media_library_false_when_no_screen() {
+		$GLOBALS['current_screen'] = null;
+		$this->assertFalse( ImageStudio\is_media_library() );
+	}
+
+	/**
+	 * Test is_media_library returns false on block editor screen.
+	 */
+	public function test_is_media_library_false_on_block_editor() {
+		$this->set_block_editor_screen();
+		$this->assertFalse( ImageStudio\is_media_library() );
+	}
+
+	// -------------------------------------------------------------------------
+	// has_enable_image_studio_param() tests
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Test has_enable_image_studio_param returns true when query param is "1".
+	 */
+	public function test_has_enable_image_studio_param_true() {
+		$this->set_enable_image_studio_param();
+		$this->assertTrue( ImageStudio\has_enable_image_studio_param() );
+	}
+
+	/**
+	 * Test has_enable_image_studio_param returns false when query param is not set.
+	 */
+	public function test_has_enable_image_studio_param_false() {
+		$this->assertFalse( ImageStudio\has_enable_image_studio_param() );
+	}
+
+	/**
+	 * Test has_enable_image_studio_param returns false when query param is "0".
+	 */
+	public function test_has_enable_image_studio_param_false_when_zero() {
+		$_GET['enable_image_studio'] = '0';
+		$this->assertFalse( ImageStudio\has_enable_image_studio_param() );
+	}
+
+	/**
+	 * Test has_enable_image_studio_param returns false when query param is "true" string.
+	 */
+	public function test_has_enable_image_studio_param_false_when_true_string() {
+		$_GET['enable_image_studio'] = 'true';
+		$this->assertFalse( ImageStudio\has_enable_image_studio_param() );
+	}
+
+	/**
+	 * Test has_enable_image_studio_param returns false when query param is empty string.
+	 */
+	public function test_has_enable_image_studio_param_false_when_empty() {
+		$_GET['enable_image_studio'] = '';
+		$this->assertFalse( ImageStudio\has_enable_image_studio_param() );
+	}
+
+	// -------------------------------------------------------------------------
+	// should_load_on_current_screen() tests
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Test should_load_on_current_screen returns true on Media Library.
+	 */
+	public function test_should_load_on_media_library() {
+		$this->set_media_library_screen();
+		$this->assertTrue( ImageStudio\should_load_on_current_screen() );
+	}
+
+	/**
+	 * Test should_load_on_current_screen returns true on block editor with param.
+	 */
+	public function test_should_load_on_block_editor_with_param() {
+		$this->set_block_editor_screen();
+		$this->set_enable_image_studio_param();
+		$this->assertTrue( ImageStudio\should_load_on_current_screen() );
+	}
+
+	/**
+	 * Test should_load_on_current_screen returns false on block editor without param.
+	 */
+	public function test_should_not_load_on_block_editor_without_param() {
+		$this->set_block_editor_screen();
+		$this->assertFalse( ImageStudio\should_load_on_current_screen() );
+	}
+
+	/**
+	 * Test should_load_on_current_screen returns false on dashboard.
+	 */
+	public function test_should_not_load_on_dashboard() {
+		set_current_screen( 'dashboard' );
+		$this->assertFalse( ImageStudio\should_load_on_current_screen() );
+	}
+
+	/**
+	 * Test should_load_on_current_screen returns false when no screen.
+	 */
+	public function test_should_not_load_when_no_screen() {
+		$GLOBALS['current_screen'] = null;
+		$this->assertFalse( ImageStudio\should_load_on_current_screen() );
+	}
+
+	// -------------------------------------------------------------------------
+	// register_plugin() tests
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Test that register_plugin sets extension available when jetpack_image_studio_enabled is true.
+	 */
+	public function test_register_plugin_sets_available_when_enabled() {
+		$this->enable_image_studio();
+		ImageStudio\register_plugin();
+		$this->assertTrue( \Jetpack_Gutenberg::is_available( ImageStudio\FEATURE_NAME ) );
+	}
+
+	/**
+	 * Test that register_plugin sets extension available when unified experience is true.
+	 */
+	public function test_register_plugin_sets_available_when_unified_experience() {
+		$this->enable_unified_experience();
+		ImageStudio\register_plugin();
+		$this->assertTrue( \Jetpack_Gutenberg::is_available( ImageStudio\FEATURE_NAME ) );
+	}
+
+	/**
+	 * Test that register_plugin does not set extension available when both filters are false.
+	 */
+	public function test_register_plugin_not_available_when_disabled() {
+		$this->disable_image_studio();
+		ImageStudio\register_plugin();
+		$this->assertFalse( \Jetpack_Gutenberg::is_available( ImageStudio\FEATURE_NAME ) );
+	}
+
+	/**
+	 * Test that register_plugin registers unconditionally regardless of screen.
+	 *
+	 * Screen-level gating happens at enqueue time, not registration.
+	 */
+	public function test_register_plugin_available_regardless_of_screen() {
+		$this->enable_image_studio();
+
+		// Block editor without param - still registers.
+		$this->set_block_editor_screen();
+		ImageStudio\register_plugin();
+		$this->assertTrue( \Jetpack_Gutenberg::is_available( ImageStudio\FEATURE_NAME ) );
+
+		$this->reset_availability();
+
+		// Media Library - still registers.
+		$this->set_media_library_screen();
+		ImageStudio\register_plugin();
+		$this->assertTrue( \Jetpack_Gutenberg::is_available( ImageStudio\FEATURE_NAME ) );
+
+		$this->reset_availability();
+
+		// Dashboard - still registers.
+		set_current_screen( 'dashboard' );
+		ImageStudio\register_plugin();
+		$this->assertTrue( \Jetpack_Gutenberg::is_available( ImageStudio\FEATURE_NAME ) );
+	}
+
+	// -------------------------------------------------------------------------
+	// enqueue_image_studio() tests (block editor path)
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Test that script is enqueued in block editor with param.
+	 */
+	public function test_block_editor_script_enqueued_with_dependencies() {
+		$this->enable_and_enqueue_block_editor(
+			array(
+				'version'      => '1.2.3',
+				'dependencies' => array( 'wp-element', 'wp-plugins' ),
+			)
+		);
+
+		$this->assertTrue( wp_script_is( ImageStudio\FEATURE_NAME, 'enqueued' ) );
+
+		$script = $GLOBALS['wp_scripts']->registered[ ImageStudio\FEATURE_NAME ];
+		$this->assertContains( 'wp-element', $script->deps );
+		$this->assertContains( 'wp-plugins', $script->deps );
+	}
+
+	/**
+	 * Test nothing enqueued in block editor without query param.
+	 */
+	public function test_block_editor_nothing_enqueued_without_param() {
+		$this->enable_image_studio();
+		$this->set_block_editor_screen();
+		ImageStudio\register_plugin();
+		set_transient(
+			ImageStudio\ASSET_TRANSIENT,
+			array(
+				'version'      => '1.0.0',
+				'dependencies' => array(),
+			),
+			HOUR_IN_SECONDS
+		);
+
+		// No param set.
+		ImageStudio\enqueue_image_studio();
+
+		$this->assertFalse( wp_script_is( ImageStudio\FEATURE_NAME, 'enqueued' ) );
+		$this->assertFalse( wp_style_is( ImageStudio\FEATURE_NAME . '-style', 'enqueued' ) );
+	}
+
+	/**
+	 * Test nothing enqueued when not on block editor screen.
+	 */
+	public function test_nothing_enqueued_on_non_block_editor() {
+		$this->enable_image_studio();
+		set_current_screen( 'dashboard' );
+		ImageStudio\register_plugin();
+		set_transient(
+			ImageStudio\ASSET_TRANSIENT,
+			array(
+				'version'      => '1.0.0',
+				'dependencies' => array(),
+			),
+			HOUR_IN_SECONDS
+		);
+		$this->set_enable_image_studio_param();
+
+		ImageStudio\enqueue_image_studio();
+
+		$this->assertFalse( wp_script_is( ImageStudio\FEATURE_NAME, 'enqueued' ) );
+	}
+
+	/**
+	 * Test inline script sets imageStudioData with enabled true.
+	 */
+	public function test_inline_script_sets_image_studio_data() {
+		$this->enable_and_enqueue_block_editor();
+
+		$inline = $GLOBALS['wp_scripts']->get_data( ImageStudio\FEATURE_NAME, 'before' );
+
+		$this->assertIsArray( $inline );
+		$found = false;
+		foreach ( $inline as $line ) {
+			if ( is_string( $line ) && strpos( $line, 'imageStudioData' ) !== false ) {
+				$found = true;
+				$this->assertStringContainsString( '"enabled":true', $line );
+			}
+		}
+		$this->assertTrue( $found, 'Inline script with imageStudioData not found.' );
+	}
+
+	/**
+	 * Test style is enqueued with wp-components dependency.
+	 */
+	public function test_style_enqueued_with_wp_components() {
+		$this->enable_and_enqueue_block_editor();
+
+		$this->assertTrue( wp_style_is( ImageStudio\FEATURE_NAME . '-style', 'enqueued' ) );
+
+		$style = $GLOBALS['wp_styles']->registered[ ImageStudio\FEATURE_NAME . '-style' ];
+		$this->assertContains( 'wp-components', $style->deps );
+	}
+
+	/**
+	 * Test nothing enqueued when asset file is unavailable.
+	 */
+	public function test_nothing_enqueued_when_asset_unavailable() {
+		$this->enable_image_studio();
+		$this->set_block_editor_screen();
+		$this->set_enable_image_studio_param();
+		ImageStudio\register_plugin();
+		$this->mock_remote_asset( false );
+
+		ImageStudio\enqueue_image_studio();
+
+		$this->assertFalse( wp_script_is( ImageStudio\FEATURE_NAME, 'enqueued' ) );
+		$this->assertFalse( wp_style_is( ImageStudio\FEATURE_NAME . '-style', 'enqueued' ) );
+	}
+
+	/**
+	 * Test version from asset file is used for both script and style.
+	 */
+	public function test_version_from_asset_file() {
+		$this->enable_and_enqueue_block_editor(
+			array(
+				'version'      => '4.5.6',
+				'dependencies' => array(),
+			)
+		);
+
+		$script = $GLOBALS['wp_scripts']->registered[ ImageStudio\FEATURE_NAME ];
+		$this->assertEquals( '4.5.6', $script->ver );
+
+		$style = $GLOBALS['wp_styles']->registered[ ImageStudio\FEATURE_NAME . '-style' ];
+		$this->assertEquals( '4.5.6', $style->ver );
+	}
+
+	/**
+	 * Test nothing enqueued when extension is not available (disabled).
+	 */
+	public function test_nothing_enqueued_when_extension_not_available() {
+		$this->disable_image_studio();
+		$this->set_block_editor_screen();
+		$this->set_enable_image_studio_param();
+		ImageStudio\register_plugin();
+		set_transient(
+			ImageStudio\ASSET_TRANSIENT,
+			array(
+				'version'      => '1.0.0',
+				'dependencies' => array(),
+			),
+			HOUR_IN_SECONDS
+		);
+		ImageStudio\enqueue_image_studio();
+
+		$this->assertFalse( wp_script_is( ImageStudio\FEATURE_NAME, 'enqueued' ) );
+		$this->assertFalse( wp_style_is( ImageStudio\FEATURE_NAME . '-style', 'enqueued' ) );
+	}
+
+	/**
+	 * Test script URL points to widgets.wp.com.
+	 */
+	public function test_script_url_points_to_widgets() {
+		$this->enable_and_enqueue_block_editor();
+
+		$script = $GLOBALS['wp_scripts']->registered[ ImageStudio\FEATURE_NAME ];
+		$this->assertStringContainsString( 'widgets.wp.com', $script->src );
+		$this->assertStringContainsString( 'image-studio.min.js', $script->src );
+	}
+
+	/**
+	 * Test style URL points to widgets.wp.com.
+	 */
+	public function test_style_url_points_to_widgets() {
+		$this->enable_and_enqueue_block_editor();
+
+		$style = $GLOBALS['wp_styles']->registered[ ImageStudio\FEATURE_NAME . '-style' ];
+		$this->assertStringContainsString( 'widgets.wp.com', $style->src );
+		$this->assertStringContainsString( 'image-studio', $style->src );
+	}
+
+	/**
+	 * Test enqueue works with empty dependencies array.
+	 */
+	public function test_enqueue_with_empty_dependencies() {
+		$this->enable_and_enqueue_block_editor(
+			array(
+				'version'      => '1.0.0',
+				'dependencies' => array(),
+			)
+		);
+
+		$this->assertTrue( wp_script_is( ImageStudio\FEATURE_NAME, 'enqueued' ) );
+		$script = $GLOBALS['wp_scripts']->registered[ ImageStudio\FEATURE_NAME ];
+		$this->assertEmpty( $script->deps );
+	}
+
+	/**
+	 * Test script is loaded in footer.
+	 */
+	public function test_script_loaded_in_footer() {
+		$this->enable_and_enqueue_block_editor();
+
+		$script = $GLOBALS['wp_scripts']->registered[ ImageStudio\FEATURE_NAME ];
+		$this->assertSame( 1, $script->extra['group'] );
+	}
+
+	// -------------------------------------------------------------------------
+	// enqueue_image_studio_admin() tests (Media Library path)
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Test that script is enqueued on Media Library without query param.
+	 */
+	public function test_media_library_script_enqueued() {
+		$this->enable_and_enqueue_media_library();
+
+		$this->assertTrue( wp_script_is( ImageStudio\FEATURE_NAME, 'enqueued' ) );
+		$this->assertTrue( wp_style_is( ImageStudio\FEATURE_NAME . '-style', 'enqueued' ) );
+	}
+
+	/**
+	 * Test Media Library enqueue uses correct dependencies from asset data.
+	 */
+	public function test_media_library_enqueue_with_dependencies() {
+		$this->enable_and_enqueue_media_library(
+			array(
+				'version'      => '2.0.0',
+				'dependencies' => array( 'wp-element', 'wp-plugins' ),
+			)
+		);
+
+		$script = $GLOBALS['wp_scripts']->registered[ ImageStudio\FEATURE_NAME ];
+		$this->assertContains( 'wp-element', $script->deps );
+		$this->assertContains( 'wp-plugins', $script->deps );
+		$this->assertEquals( '2.0.0', $script->ver );
+	}
+
+	/**
+	 * Test nothing enqueued on non-Media Library screen via admin hook.
+	 */
+	public function test_media_library_nothing_enqueued_on_other_screen() {
+		$this->enable_image_studio();
+		set_current_screen( 'dashboard' );
+		ImageStudio\register_plugin();
+		set_transient(
+			ImageStudio\ASSET_TRANSIENT,
+			array(
+				'version'      => '1.0.0',
+				'dependencies' => array(),
+			),
+			HOUR_IN_SECONDS
+		);
+
+		ImageStudio\enqueue_image_studio_admin();
+
+		$this->assertFalse( wp_script_is( ImageStudio\FEATURE_NAME, 'enqueued' ) );
+	}
+
+	/**
+	 * Test nothing enqueued on Media Library when Image Studio is disabled.
+	 */
+	public function test_media_library_nothing_enqueued_when_disabled() {
+		$this->disable_image_studio();
+		$this->set_media_library_screen();
+		ImageStudio\register_plugin();
+		set_transient(
+			ImageStudio\ASSET_TRANSIENT,
+			array(
+				'version'      => '1.0.0',
+				'dependencies' => array(),
+			),
+			HOUR_IN_SECONDS
+		);
+
+		ImageStudio\enqueue_image_studio_admin();
+
+		$this->assertFalse( wp_script_is( ImageStudio\FEATURE_NAME, 'enqueued' ) );
+	}
+
+	/**
+	 * Test Media Library inline script sets imageStudioData.
+	 */
+	public function test_media_library_inline_script() {
+		$this->enable_and_enqueue_media_library();
+
+		$inline = $GLOBALS['wp_scripts']->get_data( ImageStudio\FEATURE_NAME, 'before' );
+
+		$this->assertIsArray( $inline );
+		$found = false;
+		foreach ( $inline as $line ) {
+			if ( is_string( $line ) && strpos( $line, 'imageStudioData' ) !== false ) {
+				$found = true;
+				$this->assertStringContainsString( '"enabled":true', $line );
+			}
+		}
+		$this->assertTrue( $found, 'Inline script with imageStudioData not found on Media Library.' );
+	}
+
+	// -------------------------------------------------------------------------
+	// get_asset_data() tests
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Test transient caching of asset file after fetch.
+	 */
+	public function test_transient_caching_after_fetch() {
+		$asset_data = array(
+			'version'      => '2.0.0',
+			'dependencies' => array( 'wp-element' ),
+		);
+		$this->mock_remote_asset( $asset_data );
+
+		$result = ImageStudio\get_asset_data();
+
+		$this->assertEquals( $asset_data, $result );
+		$this->assertEquals( $asset_data, get_transient( ImageStudio\ASSET_TRANSIENT ) );
+	}
+
+	/**
+	 * Test uses cached transient without HTTP request.
+	 */
+	public function test_uses_cached_transient() {
+		$asset_data = array(
+			'version'      => '3.0.0',
+			'dependencies' => array( 'wp-plugins' ),
+		);
+		set_transient( ImageStudio\ASSET_TRANSIENT, $asset_data, HOUR_IN_SECONDS );
+
+		$this->mock_remote_asset( false );
+
+		$result = ImageStudio\get_asset_data();
+
+		$this->assertEquals( $asset_data, $result );
+	}
+
+	/**
+	 * Test get_asset_data returns false on WP_Error.
+	 */
+	public function test_get_asset_data_returns_false_on_wp_error() {
+		$this->mock_remote_asset( false );
+
+		$result = ImageStudio\get_asset_data();
+
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * Test get_asset_data returns false on non-200 HTTP status code.
+	 */
+	public function test_get_asset_data_returns_false_on_non_200_status() {
+		$this->mock_remote_asset_with_status( 500, 'Internal Server Error' );
+
+		$result = ImageStudio\get_asset_data();
+
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * Test get_asset_data returns false on 404 HTTP status code.
+	 */
+	public function test_get_asset_data_returns_false_on_404_status() {
+		$this->mock_remote_asset_with_status( 404, 'Not Found' );
+
+		$result = ImageStudio\get_asset_data();
+
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * Test get_asset_data returns false when response body is invalid JSON.
+	 */
+	public function test_get_asset_data_returns_false_on_invalid_json() {
+		$this->mock_remote_asset_with_status( 200, 'not valid json{{{' );
+
+		$result = ImageStudio\get_asset_data();
+
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * Test get_asset_data returns false when response body is a JSON string instead of array.
+	 */
+	public function test_get_asset_data_returns_false_on_json_string() {
+		$this->mock_remote_asset_with_status( 200, '"just a string"' );
+
+		$result = ImageStudio\get_asset_data();
+
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * Test get_asset_data does not set transient when fetch fails.
+	 */
+	public function test_get_asset_data_no_transient_on_failure() {
+		$this->mock_remote_asset( false );
+
+		ImageStudio\get_asset_data();
+
+		$this->assertFalse( get_transient( ImageStudio\ASSET_TRANSIENT ) );
+	}
+
+	/**
+	 * Test get_asset_data does not set transient when JSON is invalid.
+	 */
+	public function test_get_asset_data_no_transient_on_invalid_json() {
+		$this->mock_remote_asset_with_status( 200, 'not json' );
+
+		ImageStudio\get_asset_data();
+
+		$this->assertFalse( get_transient( ImageStudio\ASSET_TRANSIENT ) );
+	}
+
+	/**
+	 * Test get_asset_data returns false when Content-Type is not JSON.
+	 */
+	public function test_get_asset_data_returns_false_on_non_json_content_type() {
+		$this->mock_remote_asset_with_status( 200, '<html>Not JSON</html>', 'text/html' );
+
+		$result = ImageStudio\get_asset_data();
+
+		$this->assertFalse( $result );
+	}
+
+	// -------------------------------------------------------------------------
+	// disable_jetpack_ai_image_extensions() tests
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Test AI image extensions are disabled when Image Studio is enabled.
+	 */
+	public function test_ai_extensions_disabled_when_enabled() {
+		$this->enable_image_studio();
+		$this->make_ai_extensions_available();
+
+		ImageStudio\disable_jetpack_ai_image_extensions();
+
+		foreach ( self::AI_IMAGE_EXTENSIONS as $ext ) {
+			$this->assertFalse(
+				\Jetpack_Gutenberg::is_available( $ext ),
+				"Extension $ext should be unavailable when Image Studio is enabled."
+			);
+		}
+	}
+
+	/**
+	 * Test AI image extensions are disabled when unified experience is enabled.
+	 */
+	public function test_ai_extensions_disabled_when_unified_experience() {
+		$this->enable_unified_experience();
+		$this->make_ai_extensions_available();
+
+		ImageStudio\disable_jetpack_ai_image_extensions();
+
+		foreach ( self::AI_IMAGE_EXTENSIONS as $ext ) {
+			$this->assertFalse(
+				\Jetpack_Gutenberg::is_available( $ext ),
+				"Extension $ext should be unavailable when unified experience is enabled."
+			);
+		}
+	}
+
+	/**
+	 * Test AI image extensions are NOT disabled when Image Studio is disabled.
+	 */
+	public function test_ai_extensions_not_disabled_when_disabled() {
+		$this->disable_image_studio();
+		$this->make_ai_extensions_available();
+
+		ImageStudio\disable_jetpack_ai_image_extensions();
+
+		foreach ( self::AI_IMAGE_EXTENSIONS as $ext ) {
+			$this->assertTrue(
+				\Jetpack_Gutenberg::is_available( $ext ),
+				"Extension $ext should remain available when Image Studio is disabled."
+			);
+		}
+	}
+
+	// -------------------------------------------------------------------------
+	// disable_jetpack_ai_image_extensions() screen-aware tests
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Test AI extensions are NOT disabled on block editor without query param.
+	 *
+	 * When get_current_screen() is available and Image Studio won't load
+	 * (no query param), the disable should be skipped.
+	 */
+	public function test_ai_extensions_not_disabled_on_block_editor_without_param() {
+		$this->enable_image_studio();
+		$this->make_ai_extensions_available();
+
+		// Screen available, block editor, no param → should_load is false → skip disable.
+		$this->set_block_editor_screen();
+		ImageStudio\disable_jetpack_ai_image_extensions();
+
+		foreach ( self::AI_IMAGE_EXTENSIONS as $ext ) {
+			$this->assertTrue(
+				\Jetpack_Gutenberg::is_available( $ext ),
+				"Extension $ext should stay available on block editor without query param."
+			);
+		}
+	}
+
+	/**
+	 * Test AI extensions ARE disabled on block editor with query param.
+	 */
+	public function test_ai_extensions_disabled_on_block_editor_with_param() {
+		$this->enable_image_studio();
+		$this->make_ai_extensions_available();
+
+		$this->set_block_editor_screen();
+		$this->set_enable_image_studio_param();
+		ImageStudio\disable_jetpack_ai_image_extensions();
+
+		foreach ( self::AI_IMAGE_EXTENSIONS as $ext ) {
+			$this->assertFalse(
+				\Jetpack_Gutenberg::is_available( $ext ),
+				"Extension $ext should be disabled on block editor with query param."
+			);
+		}
+	}
+
+	/**
+	 * Test AI extensions ARE disabled on Media Library.
+	 */
+	public function test_ai_extensions_disabled_on_media_library() {
+		$this->enable_image_studio();
+		$this->make_ai_extensions_available();
+
+		$this->set_media_library_screen();
+		ImageStudio\disable_jetpack_ai_image_extensions();
+
+		foreach ( self::AI_IMAGE_EXTENSIONS as $ext ) {
+			$this->assertFalse(
+				\Jetpack_Gutenberg::is_available( $ext ),
+				"Extension $ext should be disabled on Media Library."
+			);
+		}
+	}
+
+	/**
+	 * Test AI extensions are NOT disabled on non-editor, non-media screen.
+	 */
+	public function test_ai_extensions_not_disabled_on_dashboard() {
+		$this->enable_image_studio();
+		$this->make_ai_extensions_available();
+
+		set_current_screen( 'dashboard' );
+		ImageStudio\disable_jetpack_ai_image_extensions();
+
+		foreach ( self::AI_IMAGE_EXTENSIONS as $ext ) {
+			$this->assertTrue(
+				\Jetpack_Gutenberg::is_available( $ext ),
+				"Extension $ext should stay available on dashboard."
+			);
+		}
+	}
+
+	/**
+	 * Test AI extensions blanket-disabled when no screen is available.
+	 *
+	 * On the first call (during module load), get_current_screen() is not
+	 * available, so we blanket disable as a safe default.
+	 */
+	public function test_ai_extensions_blanket_disabled_when_no_screen() {
+		$this->enable_image_studio();
+		$this->make_ai_extensions_available();
+
+		$GLOBALS['current_screen'] = null;
+		ImageStudio\disable_jetpack_ai_image_extensions();
+
+		foreach ( self::AI_IMAGE_EXTENSIONS as $ext ) {
+			$this->assertFalse(
+				\Jetpack_Gutenberg::is_available( $ext ),
+				"Extension $ext should be disabled when no screen is available (blanket disable)."
+			);
+		}
+	}
+
+	// -------------------------------------------------------------------------
+	// jetpack_set_available_extensions filter tests
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Test that the jetpack_set_available_extensions filter includes image-studio.
+	 */
+	public function test_available_extensions_filter_includes_image_studio() {
+		$extensions = apply_filters( 'jetpack_set_available_extensions', array() );
+		$this->assertContains( ImageStudio\FEATURE_NAME, $extensions );
+	}
+
+	/**
+	 * Test that the filter merges with existing extensions.
+	 */
+	public function test_available_extensions_filter_merges_with_existing() {
+		$extensions = apply_filters( 'jetpack_set_available_extensions', array( 'some-other-extension' ) );
+		$this->assertContains( 'some-other-extension', $extensions );
+		$this->assertContains( ImageStudio\FEATURE_NAME, $extensions );
+	}
+
+	// -------------------------------------------------------------------------
+	// get_asset_data_from_file() tests
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Test get_asset_data_from_file returns false when file does not exist.
+	 */
+	public function test_get_asset_data_from_file_returns_false_when_file_missing() {
+		$result = ImageStudio\get_asset_data_from_file();
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * Test get_asset_data_from_file reads valid JSON from local file.
+	 */
+	public function test_get_asset_data_from_file_reads_valid_json() {
+		$asset_data = array(
+			'version'      => '5.0.0',
+			'dependencies' => array( 'wp-element' ),
+		);
+		$local_path = ABSPATH . ImageStudio\ASSET_JSON_PATH;
+		$dir        = dirname( $local_path );
+
+		// Create directory and file.
+		wp_mkdir_p( $dir );
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
+		file_put_contents( $local_path, wp_json_encode( $asset_data, JSON_UNESCAPED_SLASHES ) );
+
+		$result = ImageStudio\get_asset_data_from_file();
+
+		// Clean up.
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink
+		unlink( $local_path );
+
+		$this->assertEquals( $asset_data, $result );
+	}
+
+	/**
+	 * Test get_asset_data_from_file returns false when file contains invalid JSON.
+	 */
+	public function test_get_asset_data_from_file_returns_false_on_invalid_json() {
+		$local_path = ABSPATH . ImageStudio\ASSET_JSON_PATH;
+		$dir        = dirname( $local_path );
+
+		wp_mkdir_p( $dir );
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
+		file_put_contents( $local_path, 'not valid json{{{' );
+
+		$result = ImageStudio\get_asset_data_from_file();
+
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink
+		unlink( $local_path );
+
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * Test get_asset_data_from_file returns false when file contains a JSON string instead of array.
+	 */
+	public function test_get_asset_data_from_file_returns_false_on_json_string() {
+		$local_path = ABSPATH . ImageStudio\ASSET_JSON_PATH;
+		$dir        = dirname( $local_path );
+
+		wp_mkdir_p( $dir );
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
+		file_put_contents( $local_path, '"just a string"' );
+
+		$result = ImageStudio\get_asset_data_from_file();
+
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink
+		unlink( $local_path );
+
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * Test get_asset_data prefers local file over remote fetch.
+	 */
+	public function test_get_asset_data_prefers_local_file_over_remote() {
+		$local_data  = array(
+			'version'      => 'local-1.0.0',
+			'dependencies' => array(),
+		);
+		$remote_data = array(
+			'version'      => 'remote-2.0.0',
+			'dependencies' => array(),
+		);
+
+		$local_path = ABSPATH . ImageStudio\ASSET_JSON_PATH;
+		$dir        = dirname( $local_path );
+
+		wp_mkdir_p( $dir );
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
+		file_put_contents( $local_path, wp_json_encode( $local_data, JSON_UNESCAPED_SLASHES ) );
+
+		$this->mock_remote_asset( $remote_data );
+
+		$result = ImageStudio\get_asset_data();
+
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink
+		unlink( $local_path );
+
+		$this->assertEquals( $local_data, $result );
+	}
+
+	/**
+	 * Test get_asset_data falls back to remote when local file is missing.
+	 */
+	public function test_get_asset_data_falls_back_to_remote_when_no_local_file() {
+		$remote_data = array(
+			'version'      => 'remote-3.0.0',
+			'dependencies' => array( 'wp-plugins' ),
+		);
+
+		$this->mock_remote_asset( $remote_data );
+
+		$result = ImageStudio\get_asset_data();
+
+		$this->assertEquals( $remote_data, $result );
+	}
+
+	// -------------------------------------------------------------------------
+	// get_asset_data_from_remote() tests
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Test get_asset_data_from_remote returns valid asset data on success.
+	 */
+	public function test_get_asset_data_from_remote_returns_data_on_success() {
+		$asset_data = array(
+			'version'      => '6.0.0',
+			'dependencies' => array( 'wp-element', 'wp-plugins' ),
+		);
+		$this->mock_remote_asset( $asset_data );
+
+		$result = ImageStudio\get_asset_data_from_remote();
+
+		$this->assertEquals( $asset_data, $result );
+	}
+
+	/**
+	 * Test get_asset_data_from_remote returns false on WP_Error.
+	 */
+	public function test_get_asset_data_from_remote_returns_false_on_wp_error() {
+		$this->mock_remote_asset( false );
+
+		$result = ImageStudio\get_asset_data_from_remote();
+
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * Test get_asset_data_from_remote returns false on non-200 status code.
+	 */
+	public function test_get_asset_data_from_remote_returns_false_on_non_200() {
+		$this->mock_remote_asset_with_status( 500, 'Internal Server Error' );
+
+		$result = ImageStudio\get_asset_data_from_remote();
+
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * Test get_asset_data_from_remote returns false on 404 status code.
+	 */
+	public function test_get_asset_data_from_remote_returns_false_on_404() {
+		$this->mock_remote_asset_with_status( 404, 'Not Found' );
+
+		$result = ImageStudio\get_asset_data_from_remote();
+
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * Test get_asset_data_from_remote returns false on invalid JSON body.
+	 */
+	public function test_get_asset_data_from_remote_returns_false_on_invalid_json() {
+		$this->mock_remote_asset_with_status( 200, 'not valid json{{{' );
+
+		$result = ImageStudio\get_asset_data_from_remote();
+
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * Test get_asset_data_from_remote returns false on JSON string body.
+	 */
+	public function test_get_asset_data_from_remote_returns_false_on_json_string() {
+		$this->mock_remote_asset_with_status( 200, '"just a string"' );
+
+		$result = ImageStudio\get_asset_data_from_remote();
+
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * Test get_asset_data_from_remote returns false on non-JSON content type.
+	 */
+	public function test_get_asset_data_from_remote_returns_false_on_non_json_content_type() {
+		$this->mock_remote_asset_with_status( 200, '<html>Not JSON</html>', 'text/html' );
+
+		$result = ImageStudio\get_asset_data_from_remote();
+
+		$this->assertFalse( $result );
+	}
+
+	// -------------------------------------------------------------------------
+	// get_ai_image_extensions() tests
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Test get_ai_image_extensions returns all expected extensions.
+	 */
+	public function test_get_ai_image_extensions_returns_expected_list() {
+		$extensions = ImageStudio\get_ai_image_extensions();
+		$this->assertEquals( self::AI_IMAGE_EXTENSIONS, $extensions );
+	}
+
+	// -------------------------------------------------------------------------
+	// Constants tests
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Test that the feature name constant is defined correctly.
+	 */
+	public function test_feature_name_constant() {
+		$this->assertEquals( 'image-studio', ImageStudio\FEATURE_NAME );
+	}
+
+	/**
+	 * Test that ASSET_BASE_PATH is defined correctly.
+	 */
+	public function test_asset_base_path_constant() {
+		$this->assertEquals( 'widgets.wp.com/agents-manager/', ImageStudio\ASSET_BASE_PATH );
+	}
+
+	/**
+	 * Test that ASSET_JSON_PATH is defined correctly.
+	 */
+	public function test_asset_json_path_constant() {
+		$this->assertEquals( 'widgets.wp.com/agents-manager/image-studio.asset.json', ImageStudio\ASSET_JSON_PATH );
+	}
+
+	/**
+	 * Test that asset URLs point to the expected base URL.
+	 */
+	public function test_asset_urls_use_expected_base() {
+		$this->assertStringStartsWith( 'https://widgets.wp.com/agents-manager/', ImageStudio\ASSET_JS_URL );
+		$this->assertStringStartsWith( 'https://widgets.wp.com/agents-manager/', ImageStudio\ASSET_CSS_URL );
+		$this->assertStringStartsWith( 'https://widgets.wp.com/agents-manager/', ImageStudio\ASSET_RTL_URL );
+		$this->assertStringStartsWith( 'https://widgets.wp.com/agents-manager/', ImageStudio\ASSET_JSON_URL );
+	}
+
+	/**
+	 * Test that JS URL contains .min but CSS URLs do not.
+	 */
+	public function test_js_url_has_min_css_urls_do_not() {
+		$this->assertStringContainsString( '.min.js', ImageStudio\ASSET_JS_URL );
+		$this->assertStringNotContainsString( '.min', ImageStudio\ASSET_CSS_URL );
+		$this->assertStringNotContainsString( '.min', ImageStudio\ASSET_RTL_URL );
+	}
+
+	/**
+	 * Test that the asset transient constant is defined correctly.
+	 */
+	public function test_asset_transient_constant() {
+		$this->assertEquals( 'jetpack_image_studio_asset', ImageStudio\ASSET_TRANSIENT );
+	}
+}

--- a/projects/plugins/jetpack/tests/php/extensions/plugins/image-studio/Image_Studio_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/plugins/image-studio/Image_Studio_Test.php
@@ -120,13 +120,6 @@ class Image_Studio_Test extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Set the enable_image_studio query parameter.
-	 */
-	private function set_enable_image_studio_param() {
-		$_GET['enable_image_studio'] = '1';
-	}
-
-	/**
 	 * Set the current screen to a block editor.
 	 */
 	private function set_block_editor_screen() {
@@ -144,7 +137,7 @@ class Image_Studio_Test extends \WP_UnitTestCase {
 	/**
 	 * Enable Image Studio, cache asset data, and enqueue via block editor path.
 	 *
-	 * Sets up block editor screen with query param before enqueuing.
+	 * Sets up block editor screen before enqueuing.
 	 *
 	 * @param array|null $asset_data The asset data to cache.
 	 */
@@ -157,7 +150,6 @@ class Image_Studio_Test extends \WP_UnitTestCase {
 		}
 		$this->enable_image_studio();
 		$this->set_block_editor_screen();
-		$this->set_enable_image_studio_param();
 		ImageStudio\register_plugin();
 		set_transient( ImageStudio\ASSET_TRANSIENT, $asset_data, HOUR_IN_SECONDS );
 		ImageStudio\enqueue_image_studio();
@@ -339,49 +331,6 @@ class Image_Studio_Test extends \WP_UnitTestCase {
 	}
 
 	// -------------------------------------------------------------------------
-	// has_enable_image_studio_param() tests
-	// -------------------------------------------------------------------------
-
-	/**
-	 * Test has_enable_image_studio_param returns true when query param is "1".
-	 */
-	public function test_has_enable_image_studio_param_true() {
-		$this->set_enable_image_studio_param();
-		$this->assertTrue( ImageStudio\has_enable_image_studio_param() );
-	}
-
-	/**
-	 * Test has_enable_image_studio_param returns false when query param is not set.
-	 */
-	public function test_has_enable_image_studio_param_false() {
-		$this->assertFalse( ImageStudio\has_enable_image_studio_param() );
-	}
-
-	/**
-	 * Test has_enable_image_studio_param returns false when query param is "0".
-	 */
-	public function test_has_enable_image_studio_param_false_when_zero() {
-		$_GET['enable_image_studio'] = '0';
-		$this->assertFalse( ImageStudio\has_enable_image_studio_param() );
-	}
-
-	/**
-	 * Test has_enable_image_studio_param returns false when query param is "true" string.
-	 */
-	public function test_has_enable_image_studio_param_false_when_true_string() {
-		$_GET['enable_image_studio'] = 'true';
-		$this->assertFalse( ImageStudio\has_enable_image_studio_param() );
-	}
-
-	/**
-	 * Test has_enable_image_studio_param returns false when query param is empty string.
-	 */
-	public function test_has_enable_image_studio_param_false_when_empty() {
-		$_GET['enable_image_studio'] = '';
-		$this->assertFalse( ImageStudio\has_enable_image_studio_param() );
-	}
-
-	// -------------------------------------------------------------------------
 	// should_load_on_current_screen() tests
 	// -------------------------------------------------------------------------
 
@@ -394,20 +343,11 @@ class Image_Studio_Test extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Test should_load_on_current_screen returns true on block editor with param.
+	 * Test should_load_on_current_screen returns true on block editor.
 	 */
-	public function test_should_load_on_block_editor_with_param() {
+	public function test_should_load_on_block_editor() {
 		$this->set_block_editor_screen();
-		$this->set_enable_image_studio_param();
 		$this->assertTrue( ImageStudio\should_load_on_current_screen() );
-	}
-
-	/**
-	 * Test should_load_on_current_screen returns false on block editor without param.
-	 */
-	public function test_should_not_load_on_block_editor_without_param() {
-		$this->set_block_editor_screen();
-		$this->assertFalse( ImageStudio\should_load_on_current_screen() );
 	}
 
 	/**
@@ -465,7 +405,7 @@ class Image_Studio_Test extends \WP_UnitTestCase {
 	public function test_register_plugin_available_regardless_of_screen() {
 		$this->enable_image_studio();
 
-		// Block editor without param - still registers.
+		// Block editor - still registers.
 		$this->set_block_editor_screen();
 		ImageStudio\register_plugin();
 		$this->assertTrue( \Jetpack_Gutenberg::is_available( ImageStudio\FEATURE_NAME ) );
@@ -490,7 +430,7 @@ class Image_Studio_Test extends \WP_UnitTestCase {
 	// -------------------------------------------------------------------------
 
 	/**
-	 * Test that script is enqueued in block editor with param.
+	 * Test that script is enqueued in block editor.
 	 */
 	public function test_block_editor_script_enqueued_with_dependencies() {
 		$this->enable_and_enqueue_block_editor(
@@ -508,9 +448,9 @@ class Image_Studio_Test extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Test nothing enqueued in block editor without query param.
+	 * Test block editor enqueue does not require query param.
 	 */
-	public function test_block_editor_nothing_enqueued_without_param() {
+	public function test_block_editor_enqueued_without_query_param() {
 		$this->enable_image_studio();
 		$this->set_block_editor_screen();
 		ImageStudio\register_plugin();
@@ -523,11 +463,10 @@ class Image_Studio_Test extends \WP_UnitTestCase {
 			HOUR_IN_SECONDS
 		);
 
-		// No param set.
 		ImageStudio\enqueue_image_studio();
 
-		$this->assertFalse( wp_script_is( ImageStudio\FEATURE_NAME, 'enqueued' ) );
-		$this->assertFalse( wp_style_is( ImageStudio\FEATURE_NAME . '-style', 'enqueued' ) );
+		$this->assertTrue( wp_script_is( ImageStudio\FEATURE_NAME, 'enqueued' ) );
+		$this->assertTrue( wp_style_is( ImageStudio\FEATURE_NAME . '-style', 'enqueued' ) );
 	}
 
 	/**
@@ -545,8 +484,6 @@ class Image_Studio_Test extends \WP_UnitTestCase {
 			),
 			HOUR_IN_SECONDS
 		);
-		$this->set_enable_image_studio_param();
-
 		ImageStudio\enqueue_image_studio();
 
 		$this->assertFalse( wp_script_is( ImageStudio\FEATURE_NAME, 'enqueued' ) );
@@ -589,7 +526,6 @@ class Image_Studio_Test extends \WP_UnitTestCase {
 	public function test_nothing_enqueued_when_asset_unavailable() {
 		$this->enable_image_studio();
 		$this->set_block_editor_screen();
-		$this->set_enable_image_studio_param();
 		ImageStudio\register_plugin();
 		$this->mock_remote_asset( false );
 
@@ -623,7 +559,6 @@ class Image_Studio_Test extends \WP_UnitTestCase {
 	public function test_nothing_enqueued_when_extension_not_available() {
 		$this->disable_image_studio();
 		$this->set_block_editor_screen();
-		$this->set_enable_image_studio_param();
 		ImageStudio\register_plugin();
 		set_transient(
 			ImageStudio\ASSET_TRANSIENT,
@@ -692,7 +627,7 @@ class Image_Studio_Test extends \WP_UnitTestCase {
 	// -------------------------------------------------------------------------
 
 	/**
-	 * Test that script is enqueued on Media Library without query param.
+	 * Test that script is enqueued on Media Library.
 	 */
 	public function test_media_library_script_enqueued() {
 		$this->enable_and_enqueue_media_library();
@@ -964,42 +899,19 @@ class Image_Studio_Test extends \WP_UnitTestCase {
 	// -------------------------------------------------------------------------
 
 	/**
-	 * Test AI extensions are NOT disabled on block editor without query param.
-	 *
-	 * When get_current_screen() is available and Image Studio won't load
-	 * (no query param), the disable should be skipped.
+	 * Test AI extensions ARE disabled on block editor.
 	 */
-	public function test_ai_extensions_not_disabled_on_block_editor_without_param() {
-		$this->enable_image_studio();
-		$this->make_ai_extensions_available();
-
-		// Screen available, block editor, no param → should_load is false → skip disable.
-		$this->set_block_editor_screen();
-		ImageStudio\disable_jetpack_ai_image_extensions();
-
-		foreach ( self::get_ai_image_extensions() as $ext ) {
-			$this->assertTrue(
-				\Jetpack_Gutenberg::is_available( $ext ),
-				"Extension $ext should stay available on block editor without query param."
-			);
-		}
-	}
-
-	/**
-	 * Test AI extensions ARE disabled on block editor with query param.
-	 */
-	public function test_ai_extensions_disabled_on_block_editor_with_param() {
+	public function test_ai_extensions_disabled_on_block_editor() {
 		$this->enable_image_studio();
 		$this->make_ai_extensions_available();
 
 		$this->set_block_editor_screen();
-		$this->set_enable_image_studio_param();
 		ImageStudio\disable_jetpack_ai_image_extensions();
 
 		foreach ( self::get_ai_image_extensions() as $ext ) {
 			$this->assertFalse(
 				\Jetpack_Gutenberg::is_available( $ext ),
-				"Extension $ext should be disabled on block editor with query param."
+				"Extension $ext should be disabled on block editor."
 			);
 		}
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add enqueueing of Image Studio assets in Jetpack plugins to enable Image Studio in Simple, Atomic, and Self-hosted sites.

Checks for both Unified Chat flag or `jetpack_image_studio_enabled` filter

~~Out of scope: Self hosted sites.~~

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

**WPCOM Sandbox** 
1. Install to your sandbox:
```
bin/jetpack-downloader test jetpack forno-167/image-studio-jetpack-plugin
```
2. Deploy Big Sky PR 5597
3. Enable Image Studio by running in sandbox
```
echo "<?php add_filter( 'jetpack_image_studio_enabled', '__return_true' );" > ~/public_html/wp-content/mu-plugins/enable-image-studio.php
```

OR

Enabling Unified Chat, see pgatNH-1CI-p2

4. Go to Media Library 
Verify in Network tab `image-studio.min.js` is loaded from `widgets.wp.com` and `image-studio.js` (from BigSky) is not
<img width="811" height="139" alt="image" src="https://github.com/user-attachments/assets/a5806d5a-872e-4ecf-bf67-014834d0ac42" />

**Atomic**
~~Pre-requisite: This WP Calypso [PR](https://github.com/Automattic/wp-calypso/pull/108684) needs to be deployed first~~ Deployed!
 
1. Generate your test site with Jetpack Beta [here](https://href.li/?https://jurassic.ninja/create?jetpack-beta&branches.jetpack=add/mystuff)
2. Connect Jetpack
3. Go Jetpack Beta plugin > Settings > Jetpack > Manage > search for a feature branch > forno 167 > activate
4. Enable jetpack image studio flag
```
echo "<?php add_filter( 'jetpack_image_studio_enabled', '__return_true' );" > ~/htdocs/wp-content/mu-plugins/enable-image-studio.php
```
5. Go to Media Library > Generate Image > Verify you can generate an image without issues, also try editing
6. Go to Block Editor > Edit / Generate with Image Studio should work


