### PR TITLE
Forms: update wp-build header buttons

### DIFF
--- a/projects/packages/forms/changelog/update-forms-wpbuild-header-buttons
+++ b/projects/packages/forms/changelog/update-forms-wpbuild-header-buttons
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Dashboard: update wp-build header buttons.

--- a/projects/packages/forms/routes/forms/stage.tsx
+++ b/projects/packages/forms/routes/forms/stage.tsx
@@ -415,6 +415,7 @@ function StageInner() {
 							<CreateFormButton
 								label={ __( 'Create a new form', 'jetpack-forms' ) }
 								variant="primary"
+								showIcon={ false }
 							/>
 						}
 					/>

--- a/projects/packages/forms/src/dashboard/components/create-form-button/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/create-form-button/index.tsx
@@ -15,6 +15,7 @@ type CreateFormButtonProps = {
 	label?: string;
 	showPatterns?: boolean;
 	variant?: 'primary' | 'secondary';
+	showIcon?: boolean;
 };
 
 /**
@@ -24,12 +25,14 @@ type CreateFormButtonProps = {
  * @param {string}  props.label        - The label for the button.
  * @param {boolean} props.showPatterns - Whether to show the patterns on the editor immediately.
  * @param {string}  props.variant      - The button variant (primary or secondary).
+ * @param {boolean} props.showIcon     - Whether to show the plus icon.
  * @return {JSX.Element}                 The button to create a new form.
  */
 export default function CreateFormButton( {
 	label = __( 'Create a form', 'jetpack-forms' ),
 	showPatterns = false,
 	variant = 'secondary',
+	showIcon = true,
 }: CreateFormButtonProps ): JSX.Element {
 	const { openNewForm } = useCreateForm();
 
@@ -51,7 +54,7 @@ export default function CreateFormButton( {
 			size="compact"
 			variant={ variant }
 			onClick={ onButtonClickHandler }
-			icon={ plus }
+			icon={ showIcon ? plus : undefined }
 			className="create-form-button"
 		>
 			{ label }

--- a/projects/packages/forms/src/dashboard/components/export-responses/button.tsx
+++ b/projects/packages/forms/src/dashboard/components/export-responses/button.tsx
@@ -13,7 +13,13 @@ import ExportResponsesModal from './modal.tsx';
 
 import './style.scss';
 
-const ExportResponsesButton = ( { isPrimary = false }: { isPrimary?: boolean } ) => {
+const ExportResponsesButton = ( {
+	isPrimary = false,
+	showIcon = true,
+}: {
+	isPrimary?: boolean;
+	showIcon?: boolean;
+} ) => {
 	const {
 		showExportModal,
 		openModal,
@@ -37,7 +43,7 @@ const ExportResponsesButton = ( { isPrimary = false }: { isPrimary?: boolean } )
 			<Button
 				size="compact"
 				variant={ isPrimary ? 'primary' : 'secondary' }
-				icon={ download }
+				icon={ showIcon ? download : undefined }
 				onClick={ openModal }
 				accessibleWhenDisabled
 				disabled={ isDisabled }

--- a/projects/packages/forms/src/dashboard/wp-build/hooks/use-page-header-details.tsx
+++ b/projects/packages/forms/src/dashboard/wp-build/hooks/use-page-header-details.tsx
@@ -127,7 +127,7 @@ export default function usePageHeaderDetails(
 				...( isIntegrationsEnabled && showDashboardIntegrations
 					? [ <ManageIntegrationsButton key="integrations" onClick={ onOpenIntegrations } /> ]
 					: [] ),
-				<CreateFormButton key="create" />,
+				<CreateFormButton key="create" variant="primary" showIcon={ false } />,
 			];
 		}
 
@@ -136,7 +136,11 @@ export default function usePageHeaderDetails(
 				...( sourceIdNumber
 					? [ <EditFormButton key="edit-form" formId={ sourceIdNumber } /> ]
 					: [] ),
-				<ExportResponsesButton key="export" isPrimary={ false } />,
+				<ExportResponsesButton
+					key="export"
+					isPrimary={ statusView === 'inbox' }
+					showIcon={ false }
+				/>,
 				...( statusView === 'trash' ? [ <EmptyTrashButton key="empty-trash" /> ] : [] ),
 				...( statusView === 'spam' ? [ <EmptySpamButton key="empty-spam" /> ] : [] ),
 			];
@@ -148,9 +152,20 @@ export default function usePageHeaderDetails(
 				? [ <ManageIntegrationsButton key="integrations" onClick={ onOpenIntegrations } /> ]
 				: [] ),
 			...( statusView === 'inbox'
-				? [ <CreateFormButton key="create" variant="secondary" showPatterns={ false } /> ]
+				? [
+						<CreateFormButton
+							key="create"
+							variant="secondary"
+							showPatterns={ false }
+							showIcon={ false }
+						/>,
+				  ]
 				: [] ),
-			<ExportResponsesButton key="export" isPrimary={ statusView === 'inbox' } />,
+			<ExportResponsesButton
+				key="export"
+				isPrimary={ statusView === 'inbox' }
+				showIcon={ false }
+			/>,
 			...( statusView === 'trash' ? [ <EmptyTrashButton key="empty-trash" /> ] : [] ),
 			...( statusView === 'spam' ? [ <EmptySpamButton key="empty-spam" /> ] : [] ),
 		];


### PR DESCRIPTION
## Proposed changes:

This PR makes adjusts the header buttons on the wp-build forms dashboard to align it with designs: 
* Removes the button icons for Create a Form and Export buttons when on the wp-build dashboard
* Ensure export button is primary when it should be

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Enable these feature flags: 

```
add_filter( 'jetpack_forms_alpha', '__return_true', 20 );
add_filter( 'jetpack_block_editor_feature_flags', 'eb_register_feature' );
function eb_register_feature( $flags ) {
    $flags['central-form-management'] = true;
    return $flags;
}
```

Test:
* Go to Jetpack > Forms (WP-Build)
* Responses screen: confirm Create a Form and Export buttons appear and do not have icons
* Single form screen > inbox: confirm Export is primary
* Single form screen > inbox: confirm Export is not primary