### PR TITLE
Charts: Allow responsive wrapper to shrink in flex layouts

### DIFF
--- a/projects/js-packages/charts/changelog/fix-responsive-wrapper-flex-shrink
+++ b/projects/js-packages/charts/changelog/fix-responsive-wrapper-flex-shrink
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Allow responsive wrapper to shrink properly in flex layouts by adding min-width and min-height CSS properties.

--- a/projects/js-packages/charts/src/charts/private/with-responsive/with-responsive.module.scss
+++ b/projects/js-packages/charts/src/charts/private/with-responsive/with-responsive.module.scss
@@ -1,4 +1,4 @@
-.responsive-wrapper {
+.container {
 	// Allow wrapper to shrink in flex layouts
 	min-width: 0;
 	min-height: 0;

--- a/projects/js-packages/charts/src/charts/private/with-responsive/with-responsive.module.scss
+++ b/projects/js-packages/charts/src/charts/private/with-responsive/with-responsive.module.scss
@@ -1,0 +1,5 @@
+.responsive-wrapper {
+	// Allow wrapper to shrink in flex layouts
+	min-width: 0;
+	min-height: 0;
+}

--- a/projects/js-packages/charts/src/charts/private/with-responsive/with-responsive.tsx
+++ b/projects/js-packages/charts/src/charts/private/with-responsive/with-responsive.tsx
@@ -97,7 +97,7 @@ export function withResponsive< T extends Exclude< BaseChartProps< unknown >, 'o
 			<div
 				ref={ parentRef }
 				data-testid="responsive-wrapper"
-				className={ styles[ 'responsive-wrapper' ] }
+				className={ styles.container }
 				style={ {
 					width: size ?? width ?? '100%',
 					height: size ?? height ?? defaultHeight,

--- a/projects/js-packages/charts/src/charts/private/with-responsive/with-responsive.tsx
+++ b/projects/js-packages/charts/src/charts/private/with-responsive/with-responsive.tsx
@@ -1,6 +1,7 @@
 import { useParentSize } from '@visx/responsive';
 import type { BaseChartProps } from '../../../types';
 import type { ComponentType } from 'react';
+import styles from './with-responsive.module.scss';
 
 type DimensionProps = {
 	width?: number;
@@ -96,12 +97,10 @@ export function withResponsive< T extends Exclude< BaseChartProps< unknown >, 'o
 			<div
 				ref={ parentRef }
 				data-testid="responsive-wrapper"
+				className={ styles[ 'responsive-wrapper' ] }
 				style={ {
 					width: size ?? width ?? '100%',
 					height: size ?? height ?? defaultHeight,
-					// Allow wrapper to shrink in flex layouts
-					minWidth: 0,
-					minHeight: 0,
 				} }
 			>
 				<WrappedComponent

--- a/projects/js-packages/charts/src/charts/private/with-responsive/with-responsive.tsx
+++ b/projects/js-packages/charts/src/charts/private/with-responsive/with-responsive.tsx
@@ -1,7 +1,7 @@
 import { useParentSize } from '@visx/responsive';
+import styles from './with-responsive.module.scss';
 import type { BaseChartProps } from '../../../types';
 import type { ComponentType } from 'react';
-import styles from './with-responsive.module.scss';
 
 type DimensionProps = {
 	width?: number;

--- a/projects/js-packages/charts/src/charts/private/with-responsive/with-responsive.tsx
+++ b/projects/js-packages/charts/src/charts/private/with-responsive/with-responsive.tsx
@@ -99,6 +99,9 @@ export function withResponsive< T extends Exclude< BaseChartProps< unknown >, 'o
 				style={ {
 					width: size ?? width ?? '100%',
 					height: size ?? height ?? defaultHeight,
+					// Allow wrapper to shrink in flex layouts
+					minWidth: 0,
+					minHeight: 0,
 				} }
 			>
 				<WrappedComponent


### PR DESCRIPTION
Allow responsive wrapper to shrink in flex layouts

Fixes #CHARTS-166

## Proposed changes:
*   Added `minWidth: 0` and `minHeight: 0` CSS properties to the responsive wrapper's styles in `with-responsive.tsx`.
*   This ensures that charts using the responsive wrapper can properly shrink when placed within a flex container, addressing an issue where they would not shrink below their intrinsic content size.
*   This change centralizes a workaround previously applied individually to specific chart components.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

## Does this pull request change what data or activity we track or use?

## Testing instructions:

Smoke test the default stories, which all demonstrate the responsive behaviour. There should be no change.

For testing the behaviour in a flex container, it's easiest to test using the Metric Comparison widget in Woo Analytics, this PR reverts the workaround:  https://github.com/woocommerce/woocommerce-analytics/pull/1633
Link this branch there and follow the test instructions on the PR.

---
Linear Issue: [CHARTS-166](https://linear.app/a8c/issue/CHARTS-166/allow-responsive-wrapper-to-shrink-in-flex-layouts)

<p><a href="https://cursor.com/background-agent?bcId=bc-86af47ee-a999-4fb8-99ec-524ef7365ca1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-86af47ee-a999-4fb8-99ec-524ef7365ca1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

