### PR TITLE
fix: Use path-only matching for Gutenberg asset detection

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-block-editor-assets.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-block-editor-assets.php
@@ -25,11 +25,11 @@ class WPCOM_REST_API_V2_Endpoint_Block_Editor_Assets extends WP_REST_Controller 
 	private $handle_suffix_regex = '/-(js|css|extra|before|after)$/';
 
 	/**
-	 * Cached base URL for the plugins directory.
+	 * Cached base path for the plugins directory.
 	 *
 	 * @var string|null
 	 */
-	private $plugins_base_url = null;
+	private $plugins_base_path = null;
 
 	/**
 	 * List of allowed plugin handle prefixes whose assets should be preserved.
@@ -627,17 +627,19 @@ class WPCOM_REST_API_V2_Endpoint_Block_Editor_Assets extends WP_REST_Controller 
 	}
 
 	/**
-	 * Get the base URL for the plugins directory.
+	 * Get the base path for the plugins directory.
 	 *
-	 * Caches the result to avoid repeated function calls.
+	 * Extracts only the path component from the plugins URL, making it
+	 * CDN-safe by ignoring the domain. Caches the result to avoid repeated
+	 * function calls.
 	 *
-	 * @return string The base URL for the plugins directory with trailing slash.
+	 * @return string The base path for the plugins directory with trailing slash.
 	 */
-	private function get_plugins_base_url() {
-		if ( null === $this->plugins_base_url ) {
-			$this->plugins_base_url = trailingslashit( plugins_url() );
+	private function get_plugins_base_path() {
+		if ( null === $this->plugins_base_path ) {
+			$this->plugins_base_path = trailingslashit( wp_parse_url( plugins_url(), PHP_URL_PATH ) );
 		}
-		return $this->plugins_base_url;
+		return $this->plugins_base_path;
 	}
 
 	/**
@@ -651,10 +653,10 @@ class WPCOM_REST_API_V2_Endpoint_Block_Editor_Assets extends WP_REST_Controller 
 			return false;
 		}
 
-		$plugins_url = $this->get_plugins_base_url();
+		$plugins_path = $this->get_plugins_base_path();
 
-		return str_contains( $src, $plugins_url . 'gutenberg/' ) ||
-			str_contains( $src, $plugins_url . 'gutenberg-core/' ); // WPCOM-specific path
+		return str_contains( $src, $plugins_path . 'gutenberg/' ) ||
+			str_contains( $src, $plugins_path . 'gutenberg-core/' ); // WPCOM-specific path
 	}
 
 	/**

--- a/projects/plugins/jetpack/changelog/fix-cdn-gutenberg-asset-detection
+++ b/projects/plugins/jetpack/changelog/fix-cdn-gutenberg-asset-detection
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Block Editor Assets: fix Gutenberg asset detection when assets are served from a CDN.

--- a/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_Block_Editor_Assets_Test.php
+++ b/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_Block_Editor_Assets_Test.php
@@ -255,6 +255,70 @@ class WPCOM_REST_API_V2_Endpoint_Block_Editor_Assets_Test extends Jetpack_REST_T
 	}
 
 	/**
+	 * Test that WPCOM-specific Gutenberg assets are preserved when served from a CDN.
+	 */
+	public function test_wpcom_gutenberg_assets_are_preserved_with_cdn_urls() {
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'editor' ) ) );
+
+		add_action( 'enqueue_block_editor_assets', array( $this, 'mock_cdn_gutenberg_assets' ) );
+
+		$request  = new WP_REST_Request( Requests::GET, '/wpcom/v2/editor-assets' );
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		// Verify CDN-served Gutenberg assets are preserved in the output
+		$this->assertStringContainsString( 'cdn-gutenberg-script', $data['scripts'] );
+		$this->assertStringContainsString( 'cdn-gutenberg-style', $data['styles'] );
+		$this->assertStringContainsString( 'plugins/gutenberg/script.js', $data['scripts'] );
+		$this->assertStringContainsString( 'plugins/gutenberg/style.css', $data['styles'] );
+
+		remove_action( 'enqueue_block_editor_assets', array( $this, 'mock_cdn_gutenberg_assets' ) );
+	}
+
+	/**
+	 * Enqueue Gutenberg assets using a CDN domain.
+	 */
+	public function mock_cdn_gutenberg_assets() {
+		wp_register_script( 'cdn-gutenberg-script', 'https://cdn.example.com/wp-content/plugins/gutenberg/script.js', array(), '1.0', true );
+		wp_register_style( 'cdn-gutenberg-style', 'https://cdn.example.com/wp-content/plugins/gutenberg/style.css', array(), '1.0' );
+
+		wp_enqueue_script( 'cdn-gutenberg-script' );
+		wp_enqueue_style( 'cdn-gutenberg-style' );
+	}
+
+	/**
+	 * Test that WPCOM-specific gutenberg-core assets are preserved when served from a CDN.
+	 */
+	public function test_wpcom_gutenberg_core_assets_are_preserved_with_cdn_urls() {
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'editor' ) ) );
+
+		add_action( 'enqueue_block_editor_assets', array( $this, 'mock_cdn_gutenberg_core_assets' ) );
+
+		$request  = new WP_REST_Request( Requests::GET, '/wpcom/v2/editor-assets' );
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		// Verify CDN-served WPCOM Gutenberg core assets are preserved in the output
+		$this->assertStringContainsString( 'cdn-gutenberg-core-script', $data['scripts'] );
+		$this->assertStringContainsString( 'cdn-gutenberg-core-style', $data['styles'] );
+		$this->assertStringContainsString( 'plugins/gutenberg-core/script.js', $data['scripts'] );
+		$this->assertStringContainsString( 'plugins/gutenberg-core/style.css', $data['styles'] );
+
+		remove_action( 'enqueue_block_editor_assets', array( $this, 'mock_cdn_gutenberg_core_assets' ) );
+	}
+
+	/**
+	 * Enqueue WPCOM Gutenberg core assets using a CDN domain.
+	 */
+	public function mock_cdn_gutenberg_core_assets() {
+		wp_register_script( 'cdn-gutenberg-core-script', 'https://cdn.example.com/wp-content/plugins/gutenberg-core/script.js', array(), '1.0', true );
+		wp_register_style( 'cdn-gutenberg-core-style', 'https://cdn.example.com/wp-content/plugins/gutenberg-core/style.css', array(), '1.0' );
+
+		wp_enqueue_script( 'cdn-gutenberg-core-script' );
+		wp_enqueue_style( 'cdn-gutenberg-core-style' );
+	}
+
+	/**
 	 * Test that required WordPress actions are triggered.
 	 */
 	public function test_required_wordpress_actions_are_triggered() {
@@ -870,6 +934,42 @@ class WPCOM_REST_API_V2_Endpoint_Block_Editor_Assets_Test extends Jetpack_REST_T
 		// Gutenberg assets should be excluded
 		$this->assertStringNotContainsString( 'plugins/gutenberg/', $data['scripts'] );
 		$this->assertStringNotContainsString( 'plugins/gutenberg/', $data['styles'] );
+	}
+
+	/**
+	 * Test exclude parameter with 'gutenberg' value excludes CDN-served Gutenberg assets.
+	 */
+	public function test_exclude_parameter_with_cdn_gutenberg() {
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'editor' ) ) );
+
+		// Add mock CDN-served Gutenberg assets with jetpack- prefix so they survive unregister_disallowed_plugin_assets
+		add_action(
+			'enqueue_block_editor_assets',
+			function () {
+				wp_register_script( 'jetpack-cdn-gutenberg-script', 'https://cdn.example.com/wp-content/plugins/gutenberg/script.js', array(), '1.0', true );
+				wp_register_style( 'jetpack-cdn-gutenberg-style', 'https://cdn.example.com/wp-content/plugins/gutenberg/style.css', array(), '1.0' );
+				wp_enqueue_script( 'jetpack-cdn-gutenberg-script' );
+				wp_enqueue_style( 'jetpack-cdn-gutenberg-style' );
+			}
+		);
+
+		// First, verify CDN assets ARE present without exclusion
+		$request_without_exclude  = new WP_REST_Request( Requests::GET, '/wpcom/v2/editor-assets' );
+		$response_without_exclude = $this->server->dispatch( $request_without_exclude );
+		$data_without_exclude     = $response_without_exclude->get_data();
+
+		$this->assertStringContainsString( 'plugins/gutenberg/script.js', $data_without_exclude['scripts'], 'CDN Gutenberg script should be present without exclusion' );
+		$this->assertStringContainsString( 'plugins/gutenberg/style.css', $data_without_exclude['styles'], 'CDN Gutenberg style should be present without exclusion' );
+
+		// Now verify they ARE excluded with 'exclude=gutenberg'
+		$request = new WP_REST_Request( Requests::GET, '/wpcom/v2/editor-assets' );
+		$request->set_param( 'exclude', 'gutenberg' );
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		// CDN-served Gutenberg assets should be excluded
+		$this->assertStringNotContainsString( 'plugins/gutenberg/script.js', $data['scripts'], 'CDN Gutenberg script should be excluded' );
+		$this->assertStringNotContainsString( 'plugins/gutenberg/style.css', $data['styles'], 'CDN Gutenberg style should be excluded' );
 	}
 
 	/**


### PR DESCRIPTION
## Proposed changes:
* Fix CDN-incompatible Gutenberg asset detection in `class-wpcom-rest-api-v2-endpoint-block-editor-assets.php`.
* The incompatibility led to erroneous un-registering of Gutenberg assets (e.g., `react`). Some Jetpack assets (e.g., `jetpack-blocks-editor-js`) depend upon those un-register assets. This led to unexpectedly missing Jetpack assets in the endpoint return value as WordPress discards assets with missing dependencies. 
* The `is_gutenberg_asset()` method previously compared asset URLs using the full output of `plugins_url()` (e.g., `http://example.org/wp-content/plugins/`). When assets are served from a CDN with a different domain (e.g., `https://cdn.example.com/wp-content/plugins/gutenberg/script.js`), the `str_contains()` check failed because the domains differed, causing Gutenberg assets to be misclassified.
* Replace full-URL matching with path-only matching using `wp_parse_url( plugins_url(), PHP_URL_PATH )`, aligning `is_gutenberg_asset()` with `is_core_asset()` which already uses CDN-safe path-only matching (`/wp-includes/`, `/wp-admin/`).

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
N/A

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:

This is a nuanced issue that occurred in certain circumstances. I noted the issue while proxying `curl` requests through Proxyman with SSL Proxying enabled, which seemingly led to different CDN behavior for the request. Relying upon the new automated tests should suffice. 

The CI runs the PHPUnit tests for the block editor assets endpoint, but they can also be run locally with:
  ```
  jetpack docker phpunit jetpack -- --filter=WPCOM_REST_API_V2_Endpoint_Block_Editor_Assets_Test
  ```

The 3 new CDN tests verify:
  1. CDN-served `gutenberg/` assets are correctly detected and preserved.
  2. CDN-served `gutenberg-core/` (WPCOM-specific) assets are correctly detected and preserved.
  3. `exclude=gutenberg` correctly filters CDN-served Gutenberg assets from the response.