### PR TITLE
Charts: Fix chart height and size calculations for pie and donut charts

### DIFF
--- a/projects/js-packages/charts/changelog/charts-164-fix-chart-height-and-size-calculations-for-pie-chart-and
+++ b/projects/js-packages/charts/changelog/charts-164-fix-chart-height-and-size-calculations-for-pie-chart-and
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Charts: fix chart height and size calculations for Pie Chart and variants.

--- a/projects/js-packages/charts/src/charts/bar-chart/bar-chart.tsx
+++ b/projects/js-packages/charts/src/charts/bar-chart/bar-chart.tsx
@@ -12,7 +12,7 @@ import {
 	useChartDataTransform,
 	useZeroValueDisplay,
 	useChartMargin,
-	useElementHeight,
+	useElementSize,
 	useHasLegendChild,
 	usePrefersReducedMotion,
 } from '../../hooks';
@@ -125,7 +125,7 @@ const BarChartInternal: FC< BarChartProps > = ( {
 	const legendItems = useChartLegendItems( dataSorted );
 	const chartOptions = useBarChartOptions( dataWithVisibleZeros, horizontal, options );
 	const defaultMargin = useChartMargin( height, chartOptions, dataSorted, theme, horizontal );
-	const [ svgWrapperRef, svgWrapperHeight ] = useElementHeight< HTMLDivElement >();
+	const [ svgWrapperRef, , svgWrapperHeight ] = useElementSize< HTMLDivElement >();
 	const chartRef = useRef< HTMLDivElement >( null );
 
 	// Check if children contain a Legend component (composition pattern)

--- a/projects/js-packages/charts/src/charts/bar-chart/test/bar-chart.test.tsx
+++ b/projects/js-packages/charts/src/charts/bar-chart/test/bar-chart.test.tsx
@@ -3,10 +3,10 @@ import userEvent from '@testing-library/user-event';
 import { GlobalChartsProvider } from '../../../providers';
 import BarChart from '../bar-chart';
 
-// Mock useElementHeight to return a non-zero height in jsdom so charts render
+// Mock useElementSize to return non-zero dimensions in jsdom so charts render
 const mockRefCallback = jest.fn();
-jest.mock( '../../../hooks/use-element-height', () => ( {
-	useElementHeight: () => [ mockRefCallback, 300 ], // Return test height to allow chart rendering
+jest.mock( '../../../hooks/use-element-size', () => ( {
+	useElementSize: () => [ mockRefCallback, 500, 300 ],
 } ) );
 
 describe( 'BarChart', () => {

--- a/projects/js-packages/charts/src/charts/line-chart/line-chart.tsx
+++ b/projects/js-packages/charts/src/charts/line-chart/line-chart.tsx
@@ -14,7 +14,7 @@ import {
 	useXYChartTheme,
 	useChartDataTransform,
 	useChartMargin,
-	useElementHeight,
+	useElementSize,
 	useHasLegendChild,
 	usePrefersReducedMotion,
 } from '../../hooks';
@@ -288,7 +288,7 @@ const LineChartInternal = forwardRef< SingleChartRef, LineChartProps >(
 		const providerTheme = useGlobalChartsTheme();
 		const theme = useXYChartTheme( data );
 		const chartId = useChartId( providedChartId );
-		const [ svgWrapperRef, svgWrapperHeight ] = useElementHeight< HTMLDivElement >();
+		const [ svgWrapperRef, , svgWrapperHeight ] = useElementSize< HTMLDivElement >();
 		const chartRef = useRef< HTMLDivElement >( null );
 		const [ selectedIndex, setSelectedIndex ] = useState< number | undefined >( undefined );
 		const [ isNavigating, setIsNavigating ] = useState( false );

--- a/projects/js-packages/charts/src/charts/line-chart/test/line-chart.test.tsx
+++ b/projects/js-packages/charts/src/charts/line-chart/test/line-chart.test.tsx
@@ -8,10 +8,10 @@ import { GlobalChartsProvider, defaultTheme } from '../../../providers';
 import LineChart, { LineChartUnresponsive } from '../line-chart';
 import type { SingleChartRef } from '../../private/single-chart-context';
 
-// Mock useElementHeight to return a non-zero height in jsdom so charts render
+// Mock useElementSize to return non-zero dimensions in jsdom so charts render
 const mockRefCallback = jest.fn();
-jest.mock( '../../../hooks/use-element-height', () => ( {
-	useElementHeight: () => [ mockRefCallback, 300 ], // Return test height to allow chart rendering
+jest.mock( '../../../hooks/use-element-size', () => ( {
+	useElementSize: () => [ mockRefCallback, 500, 300 ],
 } ) );
 
 const customTheme = {

--- a/projects/js-packages/charts/src/charts/pie-chart/pie-chart.module.scss
+++ b/projects/js-packages/charts/src/charts/pie-chart/pie-chart.module.scss
@@ -3,9 +3,20 @@
 	flex-direction: column;
 	overflow: hidden;
 	align-items: center;
-	gap: 20px;
 
-	&--legend-top {
-		flex-direction: column-reverse;
+	// Fill parent when no explicit width/height provided
+	&--responsive {
+		height: 100%;
+		width: 100%;
+	}
+
+	&__svg-wrapper {
+		flex: 1;
+		min-height: 0; // Required for flex shrinking
+		min-width: 0; // Required for flex shrinking
+		width: 100%;
+		display: flex;
+		align-items: center;
+		justify-content: center;
 	}
 }

--- a/projects/js-packages/charts/src/charts/pie-chart/pie-chart.tsx
+++ b/projects/js-packages/charts/src/charts/pie-chart/pie-chart.tsx
@@ -2,6 +2,8 @@ import { Group } from '@visx/group';
 import { Pie } from '@visx/shape';
 import { useTooltip, useTooltipInPortal } from '@visx/tooltip';
 import { __ } from '@wordpress/i18n';
+import '@wordpress/theme/design-tokens.css';
+import { Stack } from '@wordpress/ui';
 import clsx from 'clsx';
 import { useCallback, useContext, useMemo } from 'react';
 import { Legend, useChartLegendItems } from '../../components/legend';
@@ -25,6 +27,7 @@ import styles from './pie-chart.module.scss';
 import type { LegendValueDisplay } from '../../components/legend';
 import type { BaseChartProps, DataPointPercentage, Optional } from '../../types';
 import type { ChartComponentWithComposition } from '../private/chart-composition';
+import type { GapSize } from '@wordpress/theme';
 import type { SVGProps, MouseEvent, ReactNode, FC } from 'react';
 
 /**
@@ -119,6 +122,13 @@ export interface PieChartProps extends BaseChartProps< DataPointPercentage[] > {
 	 * When provided, replaces the default BaseTooltip with custom content.
 	 */
 	renderTooltip?: ( params: PieChartRenderTooltipParams ) => ReactNode;
+
+	/**
+	 * Gap between chart elements (SVG, legend, children).
+	 * Uses WordPress design system tokens.
+	 * @default 'md'
+	 */
+	gap?: GapSize;
 }
 
 // Base props type with optional responsive properties
@@ -175,6 +185,8 @@ const PieChartInternal = ( {
 	legendTextOverflow = 'wrap',
 	legendItemClassName,
 	legendShape = 'circle',
+	width: propWidth,
+	height: propHeight,
 	size,
 	animation,
 	thickness = 1,
@@ -188,6 +200,7 @@ const PieChartInternal = ( {
 	tooltipOffsetX = 0,
 	tooltipOffsetY = -15,
 	renderTooltip = renderDefaultPieTooltip,
+	gap = 'md',
 }: PieChartProps ) => {
 	const providerTheme = useGlobalChartsTheme();
 	const chartId = useChartId( providedChartId );
@@ -263,16 +276,24 @@ const PieChartInternal = ( {
 		);
 	}
 
-	const width = size;
-	const height = size;
-	const adjustedHeight = showLegend && legendPosition === 'top' ? height - legendHeight : height;
+	// Calculate the actual pie size:
+	// - Measure available space from the svg-wrapper
+	// - If size prop provided: use it as max, but shrink if container is smaller
+	// - If no size prop: fill available space
+	const availableWidth = svgWrapperWidth > 0 ? svgWrapperWidth : 300;
+	const availableHeight = svgWrapperHeight > 0 ? svgWrapperHeight : 300;
+	const availableSize = Math.min( availableWidth, availableHeight );
+	const actualSize = size ? Math.min( size, availableSize ) : availableSize;
+
+	const width = actualSize;
+	const height = actualSize;
 
 	// Calculate radius based on width/height
-	const radius = Math.min( width, adjustedHeight ) / 2;
+	const radius = Math.min( width, height ) / 2;
 
 	// Center the chart in the available space
 	const centerX = width / 2;
-	const centerY = adjustedHeight / 2;
+	const centerY = height / 2;
 
 	// Calculate the angle between each (use original data length for consistent spacing)
 	const padAngle = gapScale * ( ( 2 * Math.PI ) / data.length );
@@ -300,165 +321,178 @@ const PieChartInternal = ( {
 		},
 	};
 
+	const legendElement = showLegend && (
+		<Legend
+			orientation={ legendOrientation }
+			position={ legendPosition }
+			alignment={ legendAlignment }
+			maxWidth={ legendMaxWidth }
+			textOverflow={ legendTextOverflow }
+			legendItemClassName={ legendItemClassName }
+			className={ styles[ 'pie-chart__legend' ] }
+			shape={ legendShape }
+			chartId={ chartId }
+			interactive={ legendInteractive }
+		/>
+	);
+
 	return (
 		<SingleChartContext.Provider
 			value={ {
 				chartId,
 				chartWidth: width,
-				chartHeight: adjustedHeight,
+				chartHeight: height,
 			} }
 		>
-			<div
+			<Stack
 				ref={ containerRef }
+				direction="column"
+				gap={ gap }
 				className={ clsx(
 					'pie-chart',
 					styles[ 'pie-chart' ],
-					{ [ styles[ 'pie-chart--legend-top' ] ]: showLegend && legendPosition === 'top' },
+					// Fill parent when no explicit dimensions provided
+					{ [ styles[ 'pie-chart--responsive' ] ]: ! propWidth && ! propHeight },
 					className
 				) }
+				style={ {
+					width: propWidth,
+					height: propHeight,
+				} }
 			>
-				<svg
-					viewBox={ `0 0 ${ width } ${ adjustedHeight }` }
-					preserveAspectRatio="xMidYMid meet"
-					width={ width }
-					height={ adjustedHeight }
-				>
-					<defs>
-						<RadialWipeAnimation
-							id={ `radial-wipe-${ chartId }` }
-							radius={ outerRadius }
-							innerRadius={ innerRadius }
-						/>
-					</defs>
+				{ legendPosition === 'top' && legendElement }
 
-					<Group
-						top={ centerY }
-						left={ centerX }
-						mask={ animation && ! prefersReducedMotion ? `url(#radial-wipe-${ chartId })` : null }
+				<div className={ styles[ 'pie-chart__svg-wrapper' ] } ref={ svgWrapperRef }>
+					<svg
+						viewBox={ `0 0 ${ width } ${ height }` }
+						preserveAspectRatio="xMidYMid meet"
+						width={ width }
+						height={ height }
 					>
-						{ allSegmentsHidden ? (
-							<text
-								textAnchor="middle"
-								dy=".33em"
-								fill={ providerTheme.gridColor || '#ccc' }
-								fontSize="14"
-								fontFamily="-apple-system,BlinkMacSystemFont,Roboto,Helvetica Neue,sans-serif"
-							>
-								{ __(
-									'All segments are hidden. Click legend items to show data.',
-									'jetpack-charts'
-								) }
-							</text>
-						) : (
-							<Pie< DataPointPercentage & { index: number } >
-								data={ dataWithIndex }
-								pieValue={ accessors.value }
-								outerRadius={ outerRadius }
+						<defs>
+							<RadialWipeAnimation
+								id={ `radial-wipe-${ chartId }` }
+								radius={ outerRadius }
 								innerRadius={ innerRadius }
-								padAngle={ padAngle }
-								cornerRadius={ cornerRadius }
-							>
-								{ pie => {
-									return pie.arcs.map( ( arc, index ) => {
-										const [ centroidX, centroidY ] = pie.path.centroid( arc );
-										const hasSpaceForLabel = arc.endAngle - arc.startAngle >= 0.25;
-										const handleMouseMove = ( event: MouseEvent< SVGElement > ) => {
-											if ( ! withTooltips ) {
-												return;
+							/>
+						</defs>
+
+						<Group
+							top={ centerY }
+							left={ centerX }
+							mask={ animation && ! prefersReducedMotion ? `url(#radial-wipe-${ chartId })` : null }
+						>
+							{ allSegmentsHidden ? (
+								<text
+									textAnchor="middle"
+									dy=".33em"
+									fill={ providerTheme.gridColor || '#ccc' }
+									fontSize="14"
+									fontFamily="-apple-system,BlinkMacSystemFont,Roboto,Helvetica Neue,sans-serif"
+								>
+									{ __(
+										'All segments are hidden. Click legend items to show data.',
+										'jetpack-charts'
+									) }
+								</text>
+							) : (
+								<Pie< DataPointPercentage & { index: number } >
+									data={ dataWithIndex }
+									pieValue={ accessors.value }
+									outerRadius={ outerRadius }
+									innerRadius={ innerRadius }
+									padAngle={ padAngle }
+									cornerRadius={ cornerRadius }
+								>
+									{ pie => {
+										return pie.arcs.map( ( arc, index ) => {
+											const [ centroidX, centroidY ] = pie.path.centroid( arc );
+											const hasSpaceForLabel = arc.endAngle - arc.startAngle >= 0.25;
+											const handleMouseMove = ( event: MouseEvent< SVGElement > ) => {
+												if ( ! withTooltips ) {
+													return;
+												}
+
+												// Don't show tooltip until container bounds are measured
+												if ( containerBounds.width === 0 || containerBounds.height === 0 ) {
+													return;
+												}
+
+												// Use clientX/Y and subtract containerBounds to cancel out any stale offset.
+												// TooltipInPortal calculates: tooltipLeft + containerBounds.left + scrollX
+												// By passing (clientX - containerBounds.left), we get:
+												// (clientX - containerBounds.left) + containerBounds.left + scrollX = clientX + scrollX
+												// This gives correct page coordinates regardless of stale bounds.
+												showTooltip( {
+													tooltipData: arc.data,
+													tooltipLeft: event.clientX - containerBounds.left + tooltipOffsetX,
+													tooltipTop: event.clientY - containerBounds.top + tooltipOffsetY,
+												} );
+											};
+
+											const pathProps: SVGProps< SVGPathElement > & { 'data-testid'?: string } = {
+												d: pie.path( arc ) || '',
+												fill: accessors.fill( arc.data ),
+												'data-testid': 'pie-segment',
+											};
+
+											const groupProps: SVGProps< SVGGElement > = {};
+											if ( withTooltips ) {
+												groupProps.onMouseMove = handleMouseMove;
+												groupProps.onMouseLeave = onMouseLeave;
 											}
 
-											// Don't show tooltip until container bounds are measured
-											if ( containerBounds.width === 0 || containerBounds.height === 0 ) {
-												return;
-											}
+											// Estimate text width more accurately for background sizing
+											const fontSize = 12;
+											const estimatedTextWidth = getStringWidth( arc.data.label, { fontSize } );
+											const labelPadding = 6;
+											const backgroundWidth = estimatedTextWidth + labelPadding * 2;
+											const backgroundHeight = fontSize + labelPadding * 2;
 
-											// Use clientX/Y and subtract containerBounds to cancel out any stale offset.
-											// TooltipInPortal calculates: tooltipLeft + containerBounds.left + scrollX
-											// By passing (clientX - containerBounds.left), we get:
-											// (clientX - containerBounds.left) + containerBounds.left + scrollX = clientX + scrollX
-											// This gives correct page coordinates regardless of stale bounds.
-											showTooltip( {
-												tooltipData: arc.data,
-												tooltipLeft: event.clientX - containerBounds.left + tooltipOffsetX,
-												tooltipTop: event.clientY - containerBounds.top + tooltipOffsetY,
-											} );
-										};
-
-										const pathProps: SVGProps< SVGPathElement > = {
-											d: pie.path( arc ) || '',
-											fill: accessors.fill( arc.data ),
-										};
-
-										const groupProps: SVGProps< SVGGElement > = {};
-										if ( withTooltips ) {
-											groupProps.onMouseMove = handleMouseMove;
-											groupProps.onMouseLeave = onMouseLeave;
-										}
-
-										// Estimate text width more accurately for background sizing
-										const fontSize = 12;
-										const estimatedTextWidth = getStringWidth( arc.data.label, { fontSize } );
-										const labelPadding = 6;
-										const backgroundWidth = estimatedTextWidth + labelPadding * 2;
-										const backgroundHeight = fontSize + labelPadding * 2;
-
-										return (
-											<g key={ `arc-${ index }` } { ...groupProps }>
-												<path { ...pathProps } data-testid="pie-segment" />
-												{ showLabels && hasSpaceForLabel && (
-													<g>
-														{ providerTheme.labelBackgroundColor && (
-															<rect
-																x={ centroidX - backgroundWidth / 2 }
-																y={ centroidY - backgroundHeight / 2 }
-																width={ backgroundWidth }
-																height={ backgroundHeight }
-																fill={ providerTheme.labelBackgroundColor }
-																rx={ 4 }
-																ry={ 4 }
+											return (
+												<g key={ `arc-${ index }` } { ...groupProps }>
+													<path { ...pathProps } />
+													{ showLabels && hasSpaceForLabel && (
+														<g>
+															{ providerTheme.labelBackgroundColor && (
+																<rect
+																	x={ centroidX - backgroundWidth / 2 }
+																	y={ centroidY - backgroundHeight / 2 }
+																	width={ backgroundWidth }
+																	height={ backgroundHeight }
+																	fill={ providerTheme.labelBackgroundColor }
+																	rx={ 4 }
+																	ry={ 4 }
+																	pointerEvents="none"
+																/>
+															) }
+															<text
+																x={ centroidX }
+																y={ centroidY }
+																dy=".33em"
+																fill={ providerTheme.labelTextColor || '#333' }
+																fontSize={ fontSize }
+																textAnchor="middle"
 																pointerEvents="none"
-															/>
-														) }
-														<text
-															x={ centroidX }
-															y={ centroidY }
-															dy=".33em"
-															fill={ providerTheme.labelTextColor || '#333' }
-															fontSize={ fontSize }
-															textAnchor="middle"
-															pointerEvents="none"
-														>
-															{ arc.data.label }
-														</text>
-													</g>
-												) }
-											</g>
-										);
-									} );
-								} }
-							</Pie>
-						) }
+															>
+																{ arc.data.label }
+															</text>
+														</g>
+													) }
+												</g>
+											);
+										} );
+									} }
+								</Pie>
+							) }
 
-						{ /* Render SVG children (like Group, Text) inside the SVG */ }
-						{ ! allSegmentsHidden && svgChildren }
-					</Group>
-				</svg>
+							{ /* Render SVG children (like Group, Text) inside the SVG */ }
+							{ ! allSegmentsHidden && svgChildren }
+						</Group>
+					</svg>
+				</div>
 
-				{ showLegend && (
-					<Legend
-						orientation={ legendOrientation }
-						position={ legendPosition }
-						alignment={ legendAlignment }
-						maxWidth={ legendMaxWidth }
-						textOverflow={ legendTextOverflow }
-						legendItemClassName={ legendItemClassName }
-						className={ styles[ 'pie-chart-legend' ] }
-						shape={ legendShape }
-						ref={ legendRef }
-						chartId={ chartId }
-						interactive={ legendInteractive }
-					/>
-				) }
+				{ legendPosition === 'bottom' && legendElement }
 
 				{ withTooltips && tooltipOpen && tooltipData && (
 					<TooltipInPortal top={ tooltipTop || 0 } left={ tooltipLeft || 0 }>
@@ -471,7 +505,7 @@ const PieChartInternal = ( {
 
 				{ /* Render other React children for backward compatibility */ }
 				{ otherChildren }
-			</div>
+			</Stack>
 		</SingleChartContext.Provider>
 	);
 };

--- a/projects/js-packages/charts/src/charts/pie-chart/pie-chart.tsx
+++ b/projects/js-packages/charts/src/charts/pie-chart/pie-chart.tsx
@@ -328,7 +328,6 @@ const PieChartInternal = ( {
 			maxWidth={ legendMaxWidth }
 			textOverflow={ legendTextOverflow }
 			legendItemClassName={ legendItemClassName }
-			className={ styles[ 'pie-chart__legend' ] }
 			shape={ legendShape }
 			chartId={ chartId }
 			interactive={ legendInteractive }

--- a/projects/js-packages/charts/src/charts/pie-chart/pie-chart.tsx
+++ b/projects/js-packages/charts/src/charts/pie-chart/pie-chart.tsx
@@ -6,7 +6,7 @@ import clsx from 'clsx';
 import { useCallback, useContext, useMemo } from 'react';
 import { Legend, useChartLegendItems } from '../../components/legend';
 import { BaseTooltip } from '../../components/tooltip';
-import { useElementHeight, useInteractiveLegendData, usePrefersReducedMotion } from '../../hooks';
+import { useElementSize, useInteractiveLegendData, usePrefersReducedMotion } from '../../hooks';
 import {
 	GlobalChartsProvider,
 	useChartId,
@@ -191,7 +191,7 @@ const PieChartInternal = ( {
 }: PieChartProps ) => {
 	const providerTheme = useGlobalChartsTheme();
 	const chartId = useChartId( providedChartId );
-	const [ legendRef, legendHeight ] = useElementHeight< HTMLDivElement >();
+	const [ svgWrapperRef, svgWrapperWidth, svgWrapperHeight ] = useElementSize< HTMLDivElement >();
 	const { tooltipOpen, tooltipLeft, tooltipTop, tooltipData, hideTooltip, showTooltip } =
 		useTooltip< DataPointPercentage >();
 

--- a/projects/js-packages/charts/src/charts/pie-chart/pie-chart.tsx
+++ b/projects/js-packages/charts/src/charts/pie-chart/pie-chart.tsx
@@ -2,7 +2,6 @@ import { Group } from '@visx/group';
 import { Pie } from '@visx/shape';
 import { useTooltip, useTooltipInPortal } from '@visx/tooltip';
 import { __ } from '@wordpress/i18n';
-import '@wordpress/theme/design-tokens.css';
 import { Stack } from '@wordpress/ui';
 import clsx from 'clsx';
 import { useCallback, useContext, useMemo } from 'react';

--- a/projects/js-packages/charts/src/charts/pie-chart/pie-chart.tsx
+++ b/projects/js-packages/charts/src/charts/pie-chart/pie-chart.tsx
@@ -355,8 +355,8 @@ const PieChartInternal = ( {
 					className
 				) }
 				style={ {
-					width: propWidth,
-					height: propHeight,
+					width: propWidth || undefined,
+					height: propHeight || undefined,
 				} }
 			>
 				{ legendPosition === 'top' && legendElement }

--- a/projects/js-packages/charts/src/charts/pie-chart/stories/donut.docs.mdx
+++ b/projects/js-packages/charts/src/charts/pie-chart/stories/donut.docs.mdx
@@ -9,7 +9,7 @@ Donut Charts are circular charts with a hollow center, perfect for displaying pr
 
 **Important:** There is no separate DonutChart component. Donuts are created by configuring the PieChart component with `thickness < 1`. This means all PieChart props, features, and styling options are available for donut charts.
 
-<Canvas of={ DonutStories.Doughnut } />
+<Canvas of={ DonutStories.Default } />
 
 ## API Reference
 
@@ -28,15 +28,17 @@ Create a donut chart by setting the `thickness` prop to a value between 0 and 1:
 <Source
 	language="jsx"
 	code={ `<PieChart
-		size={ 400 }
-		thickness={ 0.4 }
+		thickness={ 0.5 }
+		gapScale={ 0.03 }
+		cornerScale={ 0.03 }
+		withTooltips={ true }
 		data={[
 			{ label: 'Active Users', value: 65000, percentage: 65 },
 			{ label: 'Inactive Users', value: 35000, percentage: 35 },
 		]}
 	>
 		<Group>
-			<Text textAnchor="middle" verticalAnchor="middle" fontSize={ 24 }>
+			<Text textAnchor="middle" verticalAnchor="middle" fontSize={ 24 } y={ -16 }>
 				User Activity
 			</Text>
 			<Text textAnchor="middle" verticalAnchor="middle" fontSize={ 18 } y={ 16 }>
@@ -73,60 +75,16 @@ Create a thin ring by using a low thickness value:
 	language="jsx"
 	code={ `<PieChart
 		thickness={ 0.2 }
+		gapScale={ 0.01 }
+		showLabels={ false }
 		data={ data }
 	>
 		<Group>
-			<Text textAnchor="middle" verticalAnchor="middle" fontSize={ 32 } fontWeight="bold">
-				85%
+			<Text textAnchor="middle" verticalAnchor="middle" fontSize={ 24 } y={ -16 }>
+				Thin Donut
 			</Text>
-			<Text textAnchor="middle" verticalAnchor="middle" fontSize={ 14 } y={ 20 }>
-				Completion Rate
-			</Text>
-		</Group>
-	</PieChart>` }
-/>
-
-### Thick Donut
-
-Use a higher thickness value for more substantial donut rings:
-
-<Canvas of={ DonutStories.Default } />
-
-<Source
-	language="jsx"
-	code={ `<PieChart
-		thickness={ 0.8 }
-		data={ data }
-	>
-		<Group>
-			<Text textAnchor="middle" verticalAnchor="middle" fontSize={ 16 }>
-				Summary
-			</Text>
-		</Group>
-	</PieChart>` }
-/>
-
-### Styled Donut with Gaps
-
-Combine thickness with gaps and rounded corners for modern appearance:
-
-<Canvas of={ DonutStories.Doughnut } />
-
-<Source
-	language="jsx"
-	code={ `<PieChart
-		size={ 400 }
-		thickness={ 0.6 }
-		gapScale={ 0.05 }
-		cornerScale={ 0.1 }
-		data={ data }
-	>
-		<Group>
-			<Text textAnchor="middle" verticalAnchor="middle" fontSize={ 24 } fontWeight="bold">
-				$1.2M
-			</Text>
-			<Text textAnchor="middle" verticalAnchor="middle" fontSize={ 16 } y={ 20 }>
-				Total Revenue
+			<Text textAnchor="middle" verticalAnchor="middle" fontSize={ 18 } y={ 16 }>
+				Thickness: 20%
 			</Text>
 		</Group>
 	</PieChart>` }
@@ -138,18 +96,24 @@ Combine thickness with gaps and rounded corners for modern appearance:
 
 Tooltips work seamlessly with donut charts:
 
-<Canvas of={ DonutStories.WithTooltipsDoughnut } />
+<Canvas of={ DonutStories.WithTooltips } />
 
 <Source
 	language="jsx"
 	code={ `<PieChart
 		thickness={ 0.5 }
+		gapScale={ 0.03 }
+		cornerScale={ 0.03 }
+		showLabels={ false }
 		withTooltips={ true }
 		data={ data }
 	>
 		<Group>
-			<Text textAnchor="middle" verticalAnchor="middle">
-				Hover segments
+			<Text textAnchor="middle" verticalAnchor="middle" fontSize={ 14 } y={ -10 }>
+				Hover over segments
+			</Text>
+			<Text textAnchor="middle" verticalAnchor="middle" fontSize={ 14 } y={ 10 }>
+				to see tooltips
 			</Text>
 		</Group>
 	</PieChart>` }
@@ -159,21 +123,24 @@ Tooltips work seamlessly with donut charts:
 
 Combine legends with donut charts for comprehensive data presentation:
 
-<Canvas of={ DonutStories.CustomLegendPositioning } />
+<Canvas of={ DonutStories.WithLegend } />
 
 <Source
 	language="jsx"
 	code={ `<PieChart
-		thickness={ 0.4 }
+		thickness={ 0.5 }
+		gapScale={ 0.03 }
+		cornerScale={ 0.03 }
+		withTooltips={ true }
 		showLegend={ true }
-		legendOrientation="vertical"
-		legendAlignment="start"
-		legendPosition="top"
 		data={ data }
 	>
 		<Group>
-			<Text textAnchor="middle" verticalAnchor="middle" fontSize={ 18 }>
-				Distribution
+			<Text textAnchor="middle" verticalAnchor="middle" fontSize={ 24 } y={ -16 }>
+				User Activity
+			</Text>
+			<Text textAnchor="middle" verticalAnchor="middle" fontSize={ 18 } y={ 16 }>
+				Total: 100K Users
 			</Text>
 		</Group>
 	</PieChart>` }
@@ -303,14 +270,19 @@ Donut charts support an optional entry animation that creates a smooth reveal ef
 <Source
 	language="jsx"
 	code={ `<PieChart
-		size={ 400 }
-		thickness={ 0.4 }
+		thickness={ 0.5 }
+		gapScale={ 0.03 }
+		cornerScale={ 0.03 }
+		withTooltips={ true }
 		data={ data }
 		animation={ true }
 	>
 		<Group>
-			<Text textAnchor="middle" verticalAnchor="middle" fontSize={ 24 }>
-				Animated Donut
+			<Text textAnchor="middle" verticalAnchor="middle" fontSize={ 24 } y={ -16 }>
+				User Activity
+			</Text>
+			<Text textAnchor="middle" verticalAnchor="middle" fontSize={ 18 } y={ 16 }>
+				Total: 100K Users
 			</Text>
 		</Group>
 	</PieChart>` }

--- a/projects/js-packages/charts/src/charts/pie-chart/stories/donut.stories.tsx
+++ b/projects/js-packages/charts/src/charts/pie-chart/stories/donut.stories.tsx
@@ -90,10 +90,8 @@ type Story = StoryObj< StoryArgs >;
 export const Default: Story = {
 	args: {
 		...sharedThemeArgs,
-		size: 400,
 		containerWidth: '432px',
 		containerHeight: '432px',
-		resize: 'none',
 		thickness: 0.5,
 		gapScale: 0.03,
 		cornerScale: 0.03,
@@ -124,12 +122,12 @@ export const ErrorStates: Story = {
 		<div style={ { display: 'grid', gap: '2rem', gridTemplateColumns: 'repeat(2, 1fr)' } }>
 			<div>
 				<h3>Empty Data</h3>
-				<PieChart size={ 300 } thickness={ 0.6 } data={ [] } />
+				<PieChart height={ 300 } thickness={ 0.6 } data={ [] } />
 			</div>
 			<div>
 				<h3>Single Value</h3>
 				<PieChart
-					size={ 300 }
+					height={ 300 }
 					thickness={ 0.6 }
 					data={ [ { label: 'Single', value: 100, percentage: 100 } ] }
 				/>
@@ -159,50 +157,6 @@ export const Thin: Story = {
 	},
 };
 
-export const Doughnut: Story = {
-	args: {
-		...Default.args,
-		thickness: 0.5,
-		gapScale: 0.03,
-		cornerScale: 0.03,
-		size: 600,
-		containerWidth: '632px',
-		containerHeight: '632px',
-		children: (
-			<Group>
-				<Text textAnchor="middle" verticalAnchor="middle" fontSize={ 24 } y={ -16 }>
-					🍩 Doughnut
-				</Text>
-				<Text textAnchor="middle" verticalAnchor="middle" fill="#008A20" fontSize={ 18 } y={ 16 }>
-					Three donuts for the price of one!
-				</Text>
-			</Group>
-		),
-	},
-	parameters: {
-		docs: {
-			description: {
-				story: 'Doughnut chart variant with the thickness set to 0.5 (50%).',
-			},
-		},
-	},
-};
-
-export const WithTooltipsDoughnut: Story = {
-	args: {
-		...Default.args,
-		thickness: 0.5,
-		withTooltips: true,
-	},
-	parameters: {
-		docs: {
-			description: {
-				story: 'Doughnut chart with interactive tooltips that appear on hover.',
-			},
-		},
-	},
-};
-
 export const Animation: Story = {
 	args: {
 		...Default.args,
@@ -220,69 +174,32 @@ export const WithLegend: Story = {
 
 export const WithCompositionLegend: Story = {
 	render: args => (
-		<div
-			style={ {
-				display: 'grid',
-				gap: '2rem',
-				gridTemplateColumns: 'repeat(2, 1fr)',
-				alignItems: 'center',
-			} }
+		<PieChart
+			size={ 300 }
+			data={ args.data }
+			thickness={ 0.5 }
+			legendValueDisplay={ args.legendValueDisplay }
 		>
-			<div>
-				<h3>Traditional Props-based</h3>
-				<PieChart
-					size={ 300 }
-					data={ args.data }
-					thickness={ 0.5 }
-					showLegend={ true }
-					legendPosition={ args.legendPosition || 'bottom' }
-					legendOrientation={ args.legendOrientation || 'horizontal' }
-					legendAlignment={ args.legendAlignment || 'center' }
-					legendMaxWidth={ args.legendMaxWidth }
-					legendTextOverflow={ args.legendTextOverflow || 'wrap' }
-					legendValueDisplay={ args.legendValueDisplay }
-				>
-					<Group>
-						<Text textAnchor="middle" verticalAnchor="middle" fontSize={ 16 } y={ -8 }>
-							User Stats
-						</Text>
-						<Text textAnchor="middle" verticalAnchor="middle" fontSize={ 14 } y={ 12 } fill="#666">
-							100K Total
-						</Text>
-					</Group>
-				</PieChart>
-			</div>
-			<div>
-				<h3>Composition API</h3>
-				<PieChart
-					size={ 300 }
-					data={ args.data }
-					thickness={ 0.5 }
-					legendValueDisplay={ args.legendValueDisplay }
-				>
-					<Group>
-						<Text textAnchor="middle" verticalAnchor="middle" fontSize={ 16 } y={ -8 }>
-							User Stats
-						</Text>
-						<Text textAnchor="middle" verticalAnchor="middle" fontSize={ 14 } y={ 12 } fill="#666">
-							100K Total
-						</Text>
-					</Group>
-					<PieChart.Legend
-						position={ args.legendPosition || 'bottom' }
-						orientation={ args.legendOrientation || 'horizontal' }
-						alignment={ args.legendAlignment || 'center' }
-						maxWidth={ args.legendMaxWidth }
-						textOverflow={ args.legendTextOverflow || 'wrap' }
-					/>
-				</PieChart>
-			</div>
-		</div>
+			<Group>
+				<Text textAnchor="middle" verticalAnchor="middle" fontSize={ 16 } y={ -8 }>
+					User Stats
+				</Text>
+				<Text textAnchor="middle" verticalAnchor="middle" fontSize={ 14 } y={ 12 } fill="#666">
+					100K Total
+				</Text>
+			</Group>
+			<PieChart.Legend
+				position={ args.legendPosition || 'bottom' }
+				orientation={ args.legendOrientation || 'horizontal' }
+				alignment={ args.legendAlignment || 'center' }
+				maxWidth={ args.legendMaxWidth }
+				textOverflow={ args.legendTextOverflow || 'wrap' }
+			/>
+		</PieChart>
 	),
 	args: {
 		data,
 		thickness: 0.5,
-		containerHeight: '500px',
 	},
 	argTypes: {
 		legendInteractive: {
@@ -302,40 +219,35 @@ export const WithCompositionLegend: Story = {
 export const InteractiveLegend: Story = {
 	render: args => (
 		<GlobalChartsProvider>
-			<div style={ { padding: '20px' } }>
-				<h3>Interactive Donut Chart</h3>
-				<p style={ { marginBottom: '20px', color: '#666' } }>
+			<PieChartUnresponsive
+				chartId="interactive-donut-chart"
+				size={ args.size }
+				data={ args.data }
+				thickness={ 0.5 }
+				showLegend={ true }
+				legendInteractive={ true }
+				legendPosition={ args.legendPosition || 'bottom' }
+				legendOrientation={ args.legendOrientation || 'horizontal' }
+				legendAlignment={ args.legendAlignment || 'center' }
+				legendValueDisplay={ args.legendValueDisplay }
+			>
+				<Group>
+					<Text textAnchor="middle" verticalAnchor="middle" fontSize={ 16 } y={ -8 }>
+						User Stats
+					</Text>
+					<Text textAnchor="middle" verticalAnchor="middle" fontSize={ 14 } y={ 12 } fill="#666">
+						100K Total
+					</Text>
+				</Group>
+				<p style={ { color: '#666' } }>
 					Click legend items to show/hide segments. The total value updates dynamically.
 				</p>
-				<PieChartUnresponsive
-					chartId="interactive-donut-chart"
-					size={ args.size || 400 }
-					data={ args.data }
-					thickness={ 0.5 }
-					showLegend={ true }
-					legendInteractive={ true }
-					legendPosition={ args.legendPosition || 'bottom' }
-					legendOrientation={ args.legendOrientation || 'horizontal' }
-					legendAlignment={ args.legendAlignment || 'center' }
-					legendValueDisplay={ args.legendValueDisplay }
-				>
-					<Group>
-						<Text textAnchor="middle" verticalAnchor="middle" fontSize={ 16 } y={ -8 }>
-							User Stats
-						</Text>
-						<Text textAnchor="middle" verticalAnchor="middle" fontSize={ 14 } y={ 12 } fill="#666">
-							100K Total
-						</Text>
-					</Group>
-				</PieChartUnresponsive>
-			</div>
+			</PieChartUnresponsive>
 		</GlobalChartsProvider>
 	),
 	args: {
 		data,
-		size: 400,
 		thickness: 0.5,
-		containerHeight: '600px',
 	},
 	parameters: {
 		docs: {
@@ -455,7 +367,8 @@ export const CustomLegend: Story = {
 	),
 	args: {
 		...Default.args,
-		data: customerRevenueData.map( segment => ( { ...segment, label: '' } ) ),
+		data: customerRevenueData,
+		showLabels: false,
 		thickness: 0.3,
 		cornerScale: 0.03,
 		gapScale: 0.01,

--- a/projects/js-packages/charts/src/charts/pie-chart/stories/donut.stories.tsx
+++ b/projects/js-packages/charts/src/charts/pie-chart/stories/donut.stories.tsx
@@ -160,9 +160,7 @@ export const Thin: Story = {
 		...Default.args,
 		thickness: 0.2,
 		gapScale: 0.01,
-		size: 700,
-		containerWidth: '732px',
-		containerHeight: '732px',
+		showLabels: false,
 		children: (
 			<Group>
 				<Text textAnchor="middle" verticalAnchor="middle" fontSize={ 24 } y={ -16 }>
@@ -180,6 +178,24 @@ export const Animation: Story = {
 	args: {
 		...Default.args,
 		animation: true,
+	},
+};
+
+export const WithTooltips: Story = {
+	args: {
+		...Default.args,
+		showLabels: false,
+		withTooltips: true,
+		children: (
+			<Group>
+				<Text textAnchor="middle" verticalAnchor="middle" fontSize={ 14 } y={ -10 }>
+					Hover over segments
+				</Text>
+				<Text textAnchor="middle" verticalAnchor="middle" fontSize={ 14 } y={ 10 }>
+					to see tooltips
+				</Text>
+			</Group>
+		),
 	},
 };
 

--- a/projects/js-packages/charts/src/charts/pie-chart/stories/donut.stories.tsx
+++ b/projects/js-packages/charts/src/charts/pie-chart/stories/donut.stories.tsx
@@ -110,6 +110,25 @@ export const Default: Story = {
 	},
 };
 
+export const WithSize: Story = {
+	args: {
+		...Default.args,
+		size: 200,
+		thickness: 0.3,
+		showLabels: false,
+		children: (
+			<Group>
+				<Text textAnchor="middle" verticalAnchor="middle" fontSize={ 18 } y={ -16 }>
+					User Activity
+				</Text>
+				<Text textAnchor="middle" verticalAnchor="middle" fontSize={ 14 } y={ 16 }>
+					Total: 100K Users
+				</Text>
+			</Group>
+		),
+	},
+};
+
 export const WithoutCenter: Story = {
 	args: {
 		...Default.args,

--- a/projects/js-packages/charts/src/charts/pie-chart/stories/index.api.mdx
+++ b/projects/js-packages/charts/src/charts/pie-chart/stories/index.api.mdx
@@ -13,7 +13,10 @@ Main component for rendering pie and donut charts.
 | Prop | Type | Default | Description |
 | ---- | ---- | ------- | ----------- |
 | `data` | `DataPointPercentage[]` | - | **Required.** Array of data objects with label, value, and percentage |
-| `size` | `number` | - | Diameter of the chart in pixels (omit for responsive behavior) |
+| `width` | `number` | - | Width of the chart container in pixels. When omitted, fills parent width |
+| `height` | `number` | - | Height of the chart container in pixels. When omitted, fills parent height |
+| `size` | `number` | - | Maximum diameter of the pie in pixels. The pie shrinks if the container is smaller. When omitted, fills available space |
+| `gap` | `GapSize` | `'md'` | Gap between chart elements (SVG, legend, children). Uses WordPress design system tokens |
 | `thickness` | `number` | `1` | Thickness of the pie chart segments (0-1). Values less than 1 create donut charts |
 | `padding` | `number` | `20` | Padding around the chart in pixels |
 | `gapScale` | `number` | `0` | Scale of gaps between segments (0-1) |

--- a/projects/js-packages/charts/src/charts/pie-chart/stories/index.docs.mdx
+++ b/projects/js-packages/charts/src/charts/pie-chart/stories/index.docs.mdx
@@ -41,7 +41,6 @@ The simplest pie chart requires only a `data` prop with percentage-based data:
 <Source
 	language="jsx"
 	code={ `<PieChart
-		size={ 400 }
 		data={[
 			{ label: 'MacOS', value: 30000, valueDisplay: '30K', percentage: 23 },
 			{ label: 'Linux', value: 22000, valueDisplay: '22K', percentage: 17 },
@@ -53,16 +52,18 @@ The simplest pie chart requires only a `data` prop with percentage-based data:
 ### Required Props
 
 - **`data`**: Array of `DataPointPercentage` objects containing label, value, and percentage
-- **`size`**: Diameter of the chart in pixels (when not using responsive mode)
 
 ### Optional Props
 
+- **`size`**: Maximum diameter of the pie in pixels. The pie shrinks if the container is smaller. When omitted, the pie fills available space.
+- **`width`** / **`height`**: Explicit container dimensions in pixels. When omitted, the chart fills its parent.
 - **`padding`** (default: `20`): Padding around the chart in pixels
 - **`withTooltips`** (default: `false`): Enables interactive tooltips on hover
 - **`showLegend`** (default: `false`): Shows a legend for the chart data
 - **`thickness`** (default: `1`): Thickness of the pie chart segments (0-1). Values less than 1 create donut charts
 - **`gapScale`** (default: `0`): Scale of gaps between segments (0-1)
 - **`cornerScale`** (default: `0`): Scale of corner rounding for segments (0-1)
+- **`gap`** (default: `'md'`): Gap between chart elements (SVG, legend, children). Uses WordPress design system tokens.
 - **`children`**: Optional React node to render inside the chart center (useful for donut charts)
 
 For detailed prop information, compound components, and type definitions, see the [Pie Chart API Reference](./?path=/docs/js-packages-charts-library-charts-pie-chart-api-reference--docs).
@@ -80,24 +81,24 @@ The composition API allows you to add custom SVG and HTML elements to your chart
 <Source
 	language="jsx"
 	code={ `<PieChart data={ data } size={ 400 }>
-	{/* HTML elements rendered outside the SVG */}
-	<PieChart.HTML>
-		<h3>Chart Title</h3>
-	</PieChart.HTML>
+		{/* HTML elements rendered outside the SVG */}
+		<PieChart.HTML>
+			<h3>Chart Title</h3>
+		</PieChart.HTML>
 
-	{/* SVG elements rendered inside the chart */}
-	<PieChart.SVG>
-		<text x={ 0 } y={ 0 } textAnchor="middle">
-			Center Text
-		</text>
-	</PieChart.SVG>
+		{/* SVG elements rendered inside the chart */}
+		<PieChart.SVG>
+			<text x={ 0 } y={ 0 } textAnchor="middle">
+				Center Text
+			</text>
+		</PieChart.SVG>
 
-	{/* More HTML elements */}
-	<PieChart.HTML>
-		<PieChart.Legend position="bottom" />
-		<p>Additional information</p>
-	</PieChart.HTML>
-</PieChart>` }
+		{/* More HTML elements */}
+		<PieChart.HTML>
+			<PieChart.Legend position="bottom" />
+			<p>Additional information</p>
+		</PieChart.HTML>
+	</PieChart>` }
 />
 
 ### Benefits of Composition API
@@ -128,26 +129,30 @@ Enable interactive tooltips that display data information on hover:
 
 ### Responsive Behavior
 
-The Pie Chart component supports responsive sizing by omitting the `size` prop:
-
-<Canvas of={ PieChartStories.Responsiveness } />
+By default, charts **fill their parent container's dimensions**. The parent must have an explicit height:
 
 <Source
 	language="jsx"
-	code={ `// Responsive - fills parent container
-	<PieChart
-		data={ data }
-		maxWidth={ 600 }
-		aspectRatio={ 1 }
-	/>
+	code={ `// Fill parent container (default) - parent needs explicit height
+	<div style={{ width: '100%', height: '400px' }}>
+		<PieChart data={data} />
+	</div>
 
-    // Fixed size
-    <PieChart
-    	size={ 400 }
-    	data={ data }
-    />` }
-
+	// Fixed dimensions
+	<PieChart data={data} width={400} height={400} />` }
 />
+
+Use the `size` prop to constrain the maximum pie diameter. The pie will shrink if the container is smaller, but won't grow beyond this value:
+
+<Canvas of={ PieChartStories.WithSize } />
+
+<Source
+	language="jsx"
+	code={ `// Constrained pie diameter (container still fills parent)
+<PieChart data={data} size={200} />` }
+/>
+
+For more details on responsive behavior, see the [Responsive Design section](./?path=/docs/js-packages-charts-library-introduction--docs#responsive-design) in the introduction.
 
 ### Data Validation and Error Handling
 

--- a/projects/js-packages/charts/src/charts/pie-chart/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/charts/pie-chart/stories/index.stories.tsx
@@ -429,12 +429,11 @@ export const ErrorStates: Story = {
 		<div style={ { display: 'grid', gap: '2rem', gridTemplateColumns: 'repeat(2, 1fr)' } }>
 			<div>
 				<h3>Empty Data</h3>
-				<PieChart size={ 300 } data={ [] } />
+				<PieChart data={ [] } />
 			</div>
 			<div>
 				<h3>Invalid Percentage Total</h3>
 				<PieChart
-					size={ 300 }
 					data={ [
 						{ label: 'A', value: 30, percentage: 30 },
 						{ label: 'B', value: 40, percentage: 40 },
@@ -444,7 +443,6 @@ export const ErrorStates: Story = {
 			<div>
 				<h3>Negative Values</h3>
 				<PieChart
-					size={ 300 }
 					data={ [
 						{ label: 'A', value: -30, percentage: -30 },
 						{ label: 'B', value: 130, percentage: 130 },
@@ -453,11 +451,7 @@ export const ErrorStates: Story = {
 			</div>
 			<div>
 				<h3>Single Data Point</h3>
-				<PieChart
-					size={ 300 }
-					height={ 300 }
-					data={ [ { label: 'A', value: 100, percentage: 100 } ] }
-				/>
+				<PieChart height={ 300 } data={ [ { label: 'A', value: 100, percentage: 100 } ] } />
 			</div>
 		</div>
 	),

--- a/projects/js-packages/charts/src/charts/pie-chart/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/charts/pie-chart/stories/index.stories.tsx
@@ -125,10 +125,15 @@ export const Default: Story = {
 		cornerScale: 0,
 		withTooltips: false,
 		data,
-		resize: 'none',
-		size: 400,
 		containerWidth: '432px',
 		containerHeight: '432px',
+	},
+};
+
+export const WithSize: Story = {
+	args: {
+		...Default.args,
+		size: 200,
 	},
 };
 
@@ -157,51 +162,23 @@ export const WithLegend: Story = {
 	args: {
 		...Default.args,
 		showLegend: true,
-		containerHeight: '500px',
 	},
 };
 
 export const WithCompositionLegend: Story = {
 	render: args => (
-		<div
-			style={ {
-				display: 'grid',
-				gap: '2rem',
-				gridTemplateColumns: 'repeat(2, 1fr)',
-				alignItems: 'center',
-			} }
-		>
-			<div>
-				<h3>Traditional Props-based Legend</h3>
-				<PieChart
-					size={ 300 }
-					data={ args.data }
-					showLegend={ true }
-					legendPosition={ args.legendPosition || 'bottom' }
-					legendOrientation={ args.legendOrientation || 'horizontal' }
-					legendAlignment={ args.legendAlignment || 'center' }
-					legendMaxWidth={ args.legendMaxWidth }
-					legendTextOverflow={ args.legendTextOverflow || 'wrap' }
-					legendValueDisplay={ args.legendValueDisplay }
-				/>
-			</div>
-			<div>
-				<h3>Composition API with Legend Component</h3>
-				<PieChart size={ 300 } data={ args.data } legendValueDisplay={ args.legendValueDisplay }>
-					<PieChart.Legend
-						position={ args.legendPosition || 'bottom' }
-						orientation={ args.legendOrientation || 'horizontal' }
-						alignment={ args.legendAlignment || 'center' }
-						maxWidth={ args.legendMaxWidth }
-						textOverflow={ args.legendTextOverflow || 'wrap' }
-					/>
-				</PieChart>
-			</div>
-		</div>
+		<PieChart size={ 300 } data={ args.data } legendValueDisplay={ args.legendValueDisplay }>
+			<PieChart.Legend
+				position={ args.legendPosition || 'bottom' }
+				orientation={ args.legendOrientation || 'horizontal' }
+				alignment={ args.legendAlignment || 'center' }
+				maxWidth={ args.legendMaxWidth }
+				textOverflow={ args.legendTextOverflow || 'wrap' }
+			/>
+		</PieChart>
 	),
 	args: {
 		data,
-		containerHeight: '500px',
 	},
 	argTypes: {
 		legendInteractive: {
@@ -221,30 +198,27 @@ export const WithCompositionLegend: Story = {
 export const InteractiveLegend: Story = {
 	render: args => (
 		<GlobalChartsProvider>
-			<div style={ { padding: '20px' } }>
-				<h3>Interactive Legend</h3>
-				<p style={ { marginBottom: '20px', color: '#666' } }>
+			<PieChartUnresponsive
+				chartId="interactive-pie-chart"
+				size={ args.size }
+				data={ args.data }
+				showLegend={ true }
+				legendInteractive={ true }
+				legendPosition={ args.legendPosition || 'bottom' }
+				legendOrientation={ args.legendOrientation || 'horizontal' }
+				legendAlignment={ args.legendAlignment || 'center' }
+				legendValueDisplay={ args.legendValueDisplay }
+			>
+				<p style={ { color: '#666' } }>
 					Click legend items to show/hide segments. Percentages recalculate automatically for
 					visible segments.
 				</p>
-				<PieChartUnresponsive
-					chartId="interactive-pie-chart"
-					size={ args.size || 400 }
-					data={ args.data }
-					showLegend={ true }
-					legendInteractive={ true }
-					legendPosition={ args.legendPosition || 'bottom' }
-					legendOrientation={ args.legendOrientation || 'horizontal' }
-					legendAlignment={ args.legendAlignment || 'center' }
-					legendValueDisplay={ args.legendValueDisplay }
-				/>
-			</div>
+			</PieChartUnresponsive>
 		</GlobalChartsProvider>
 	),
 	args: {
 		data,
 		size: 400,
-		containerHeight: '600px',
 	},
 	parameters: {
 		docs: {
@@ -290,27 +264,13 @@ export const CustomLegendPositioning: Story = {
 		legendShape: 'circle',
 		size: 400,
 		containerWidth: '432px',
-		containerHeight: '480px',
-		resize: 'none',
+		containerHeight: '432px',
 	},
 	parameters: {
 		docs: {
 			description: {
 				story:
 					'Pie chart with top-end positioned vertical legend. This demonstrates non-default legend positioning to showcase different legend placement possibilities with device usage data.',
-			},
-		},
-	},
-};
-
-const responsiveArgs = { ...Default.args, resize: 'both' as const };
-delete responsiveArgs.size;
-export const Responsiveness: Story = {
-	args: responsiveArgs,
-	parameters: {
-		docs: {
-			description: {
-				story: 'Pie chart with responsive behavior. Uses size prop instead of width/height.',
 			},
 		},
 	},
@@ -437,7 +397,6 @@ export const CustomLabelColors: Story = {
 		labelTextColor: '#FFFFFF', // White text for contrast against dark background
 		labelBackgroundColor: 'rgba(0, 0, 0, 0.75)', // Dark semi-transparent background
 		size: 400,
-		containerHeight: '500px',
 	},
 	parameters: {
 		docs: {
@@ -485,10 +444,17 @@ export const ErrorStates: Story = {
 			</div>
 			<div>
 				<h3>Single Data Point</h3>
-				<PieChart size={ 300 } data={ [ { label: 'A', value: 100, percentage: 100 } ] } />
+				<PieChart
+					size={ 300 }
+					height={ 300 }
+					data={ [ { label: 'A', value: 100, percentage: 100 } ] }
+				/>
 			</div>
 		</div>
 	),
+	args: {
+		containerHeight: '600px',
+	},
 	parameters: {
 		docs: {
 			description: {

--- a/projects/js-packages/charts/src/charts/pie-chart/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/charts/pie-chart/stories/index.stories.tsx
@@ -35,7 +35,8 @@ const meta: Meta< StoryArgs > = {
 				step: 10,
 				default: 400,
 			},
-			description: 'Diameter of the pie chart in pixels',
+			description:
+				'Maximum diameter of the pie in pixels. The pie shrinks if the container is smaller. When omitted, fills available space.',
 			table: { category: 'Dimensions' },
 		},
 		thickness: {
@@ -134,6 +135,14 @@ export const WithSize: Story = {
 	args: {
 		...Default.args,
 		size: 200,
+	},
+};
+
+export const FixedDimensions: Story = {
+	args: {
+		...Default.args,
+		width: 300,
+		height: 300,
 	},
 };
 

--- a/projects/js-packages/charts/src/charts/pie-chart/stories/tooltip.stories.tsx
+++ b/projects/js-packages/charts/src/charts/pie-chart/stories/tooltip.stories.tsx
@@ -45,11 +45,9 @@ const Template: StoryFn< typeof PieChart > = args => <PieChart { ...args } />;
 const tooltipStoryArgs = {
 	...sharedThemeArgs,
 	data,
-	size: 400,
 	withTooltips: true,
 	containerWidth: '432px',
 	containerHeight: '432px',
-	resize: 'none' as const,
 };
 
 export const Default: StoryObj< typeof PieChart > = Template.bind( {} );
@@ -261,13 +259,13 @@ export const TooltipOffset: StoryObj< typeof PieChart > = {
 			>
 				<div>
 					<h3>Default Offset (0, -15)</h3>
-					<PieChart { ...tooltipStoryArgs } size={ 300 } />
+					<PieChart { ...tooltipStoryArgs } height={ 300 } />
 				</div>
 				<div>
 					<h3>Custom Offset (20, -30)</h3>
 					<PieChart
 						{ ...tooltipStoryArgs }
-						size={ 300 }
+						height={ 300 }
 						tooltipOffsetX={ 20 }
 						tooltipOffsetY={ -30 }
 					/>

--- a/projects/js-packages/charts/src/charts/pie-semi-circle-chart/pie-semi-circle-chart.tsx
+++ b/projects/js-packages/charts/src/charts/pie-semi-circle-chart/pie-semi-circle-chart.tsx
@@ -7,7 +7,7 @@ import clsx from 'clsx';
 import { useCallback, useContext, useMemo } from 'react';
 import { Legend, useChartLegendItems } from '../../components/legend';
 import { BaseTooltip } from '../../components/tooltip';
-import { useElementHeight, useInteractiveLegendData, usePrefersReducedMotion } from '../../hooks';
+import { useElementSize, useInteractiveLegendData, usePrefersReducedMotion } from '../../hooks';
 import {
 	GlobalChartsProvider,
 	useChartId,
@@ -181,7 +181,7 @@ const PieSemiCircleChartInternal: FC< PieSemiCircleChartProps > = ( {
 	renderTooltip = renderDefaultPieSemiCircleTooltip,
 } ) => {
 	const chartId = useChartId( providedChartId );
-	const [ legendRef, legendHeight ] = useElementHeight< HTMLDivElement >();
+	const [ legendRef, , legendHeight ] = useElementSize< HTMLDivElement >();
 	const { tooltipOpen, tooltipLeft, tooltipTop, tooltipData, hideTooltip, showTooltip } =
 		useTooltip< DataPointPercentage >();
 

--- a/projects/js-packages/charts/src/charts/private/with-responsive/test/with-responsive.test.tsx
+++ b/projects/js-packages/charts/src/charts/private/with-responsive/test/with-responsive.test.tsx
@@ -47,10 +47,10 @@ describe( 'withResponsive', () => {
 			expect( component ).toHaveStyle( { width: '400px' } );
 		} );
 
-		test( 'passes size prop equal to container width', () => {
-			render( <ResponsiveComponent data={ [] } /> );
+		test( 'passes explicit size prop through to component', () => {
+			render( <ResponsiveComponent data={ [] } size={ 200 } /> );
 			const component = screen.getByTestId( 'mock-component' );
-			expect( component ).toHaveAttribute( 'data-size', '600' );
+			expect( component ).toHaveAttribute( 'data-size', '200' );
 		} );
 	} );
 
@@ -61,8 +61,8 @@ describe( 'withResponsive', () => {
 			expect( wrapper ).toHaveStyle( { width: '100%', height: '100%' } );
 		} );
 
-		test( 'wrapper uses size prop for dimensions when provided', () => {
-			render( <ResponsiveComponent data={ [] } size={ 200 } /> );
+		test( 'wrapper uses explicit width/height for dimensions when provided', () => {
+			render( <ResponsiveComponent data={ [] } width={ 200 } height={ 200 } /> );
 			const wrapper = screen.getByTestId( 'responsive-wrapper' );
 			expect( wrapper ).toHaveStyle( { width: '200px', height: '200px' } );
 		} );

--- a/projects/js-packages/charts/src/charts/private/with-responsive/with-responsive.tsx
+++ b/projects/js-packages/charts/src/charts/private/with-responsive/with-responsive.tsx
@@ -86,10 +86,11 @@ export function withResponsive< T extends Exclude< BaseChartProps< unknown >, 'o
 			aspectRatio,
 		} );
 
-		// Use measured dimensions, but fall back to explicit props if measurement returns 0
-		// (e.g., during initial render or in test environments without DOM measurement)
-		const effectiveWidth = measuredWidth || size || width || 0;
-		const effectiveHeight = measuredHeight || size || height || 0;
+		// Use measured dimensions, but fall back to explicit width/height props if measurement returns 0
+		// (e.g., during initial render or in test environments without DOM measurement).
+		// Do not use size here — size controls chart element dimensions (e.g. pie diameter), not container dimensions.
+		const effectiveWidth = measuredWidth || width || 0;
+		const effectiveHeight = measuredHeight || height || 0;
 
 		const defaultHeight = hasAspectRatio ? 'auto' : '100%';
 
@@ -99,14 +100,14 @@ export function withResponsive< T extends Exclude< BaseChartProps< unknown >, 'o
 				data-testid="responsive-wrapper"
 				className={ styles.container }
 				style={ {
-					width: size ?? width ?? '100%',
-					height: size ?? height ?? defaultHeight,
+					width: width ?? '100%',
+					height: height ?? defaultHeight,
 				} }
 			>
 				<WrappedComponent
 					width={ effectiveWidth }
 					height={ effectiveHeight }
-					size={ effectiveWidth }
+					size={ size }
 					{ ...( chartProps as T ) }
 				/>
 			</div>

--- a/projects/js-packages/charts/src/hooks/index.ts
+++ b/projects/js-packages/charts/src/hooks/index.ts
@@ -3,7 +3,7 @@ export { useChartMouseHandler } from './use-chart-mouse-handler';
 export { useXYChartTheme } from './use-xychart-theme';
 export { useChartDataTransform } from './use-chart-data-transform';
 export { useChartMargin } from './use-chart-margin';
-export { useElementHeight } from './use-element-height';
+export { useElementSize } from './use-element-size';
 export { useHasLegendChild } from './use-has-legend-child';
 export { useTextTruncation } from './use-text-truncation';
 export { useZeroValueDisplay } from './use-zero-value-display';

--- a/projects/js-packages/charts/src/hooks/test/use-element-size.test.tsx
+++ b/projects/js-packages/charts/src/hooks/test/use-element-size.test.tsx
@@ -31,7 +31,6 @@ describe( 'useElementSize', () => {
 	beforeEach( () => {
 		mockResizeObserver = MockResizeObserver;
 		globalThis.ResizeObserver = mockResizeObserver;
-		globalThis.window.ResizeObserver = mockResizeObserver;
 	} );
 
 	afterEach( () => {

--- a/projects/js-packages/charts/src/hooks/test/use-element-size.test.tsx
+++ b/projects/js-packages/charts/src/hooks/test/use-element-size.test.tsx
@@ -1,5 +1,5 @@
 import { renderHook, waitFor } from '@testing-library/react';
-import { useElementHeight } from '../use-element-height';
+import { useElementSize } from '../use-element-size';
 
 // Mock ResizeObserver
 class MockResizeObserver {
@@ -25,7 +25,7 @@ class MockResizeObserver {
 // Store original ResizeObserver
 const originalResizeObserver = globalThis.ResizeObserver;
 
-describe( 'useElementHeight', () => {
+describe( 'useElementSize', () => {
 	let mockResizeObserver;
 
 	beforeEach( () => {
@@ -39,75 +39,82 @@ describe( 'useElementHeight', () => {
 		jest.clearAllMocks();
 	} );
 
-	it( 'should return initial height of 0 by default', () => {
-		const { result } = renderHook( () => useElementHeight() );
-		const [ refCallback, height ] = result.current;
+	it( 'should return initial dimensions of 0 by default', () => {
+		const { result } = renderHook( () => useElementSize() );
+		const [ refCallback, width, height ] = result.current;
 
+		expect( width ).toBe( 0 );
 		expect( height ).toBe( 0 );
 		expect( typeof refCallback ).toBe( 'function' );
 	} );
 
-	it( 'should return custom initial height when provided', () => {
-		const { result } = renderHook( () => useElementHeight( { initialHeight: 100 } ) );
-		const [ , height ] = result.current;
+	it( 'should return custom initial dimensions when provided', () => {
+		const { result } = renderHook( () =>
+			useElementSize( { initialWidth: 200, initialHeight: 100 } )
+		);
+		const [ , width, height ] = result.current;
 
+		expect( width ).toBe( 200 );
 		expect( height ).toBe( 100 );
 	} );
 
-	it( 'should update height when element is attached', async () => {
+	it( 'should update dimensions when element is attached', async () => {
 		const mockElement = {
-			getBoundingClientRect: jest.fn( () => ( { height: 150 } ) ),
+			getBoundingClientRect: jest.fn( () => ( { width: 300, height: 150 } ) ),
 		};
 
-		const { result } = renderHook( () => useElementHeight() );
+		const { result } = renderHook( () => useElementSize() );
 		const [ refCallback ] = result.current;
 
 		// Attach the element
 		refCallback( mockElement as unknown as HTMLDivElement );
 
 		await waitFor( () => {
-			expect( result.current[ 1 ] ).toBe( 150 );
+			expect( result.current[ 1 ] ).toBe( 300 );
+			expect( result.current[ 2 ] ).toBe( 150 );
 		} );
 
 		expect( mockElement.getBoundingClientRect ).toHaveBeenCalled();
 	} );
 
-	it( 'should handle element with zero height', async () => {
+	it( 'should handle element with zero dimensions', async () => {
 		const mockElement = {
-			getBoundingClientRect: jest.fn( () => ( { height: 0 } ) ),
+			getBoundingClientRect: jest.fn( () => ( { width: 0, height: 0 } ) ),
 		};
 
-		const { result } = renderHook( () => useElementHeight() );
+		const { result } = renderHook( () => useElementSize() );
 		const [ refCallback ] = result.current;
 
 		refCallback( mockElement as unknown as HTMLDivElement );
 
 		await waitFor( () => {
 			expect( result.current[ 1 ] ).toBe( 0 );
+			expect( result.current[ 2 ] ).toBe( 0 );
 		} );
 	} );
 
-	it( 'should handle getBoundingClientRect returning undefined height', async () => {
+	it( 'should handle getBoundingClientRect returning undefined dimensions', async () => {
 		const mockElement = {
-			getBoundingClientRect: jest.fn( () => ( { height: undefined } ) ),
+			getBoundingClientRect: jest.fn( () => ( { width: undefined, height: undefined } ) ),
 		};
 
-		const { result } = renderHook( () => useElementHeight() );
+		const { result } = renderHook( () => useElementSize() );
 		const [ refCallback ] = result.current;
 
 		refCallback( mockElement as unknown as HTMLDivElement );
 
 		await waitFor( () => {
 			expect( result.current[ 1 ] ).toBe( 0 );
+			expect( result.current[ 2 ] ).toBe( 0 );
 		} );
 	} );
 
 	it( 'should disconnect previous observer when new element is attached', () => {
 		const mockElement1 = {
-			getBoundingClientRect: jest.fn( () => ( { height: 100 } ) ),
+			getBoundingClientRect: jest.fn( () => ( { width: 100, height: 100 } ) ),
 		};
 		const mockElement2 = {
-			getBoundingClientRect: jest.fn( () => ( { height: 200 } ) ),
+			getBoundingClientRect: jest.fn( () => ( { width: 200, height: 200 } ) ),
 		};
 
 		const disconnectSpy = jest.fn();
@@ -119,7 +126,7 @@ describe( 'useElementHeight', () => {
 
 		jest.spyOn( globalThis, 'ResizeObserver' ).mockImplementation( () => mockObserver );
 
-		const { result } = renderHook( () => useElementHeight() );
+		const { result } = renderHook( () => useElementSize() );
 		const [ refCallback ] = result.current;
 
 		// Attach first element
@@ -133,7 +140,7 @@ describe( 'useElementHeight', () => {
 
 	it( 'should disconnect observer when element is removed (null)', () => {
 		const mockElement = {
-			getBoundingClientRect: jest.fn( () => ( { height: 100 } ) ),
+			getBoundingClientRect: jest.fn( () => ( { width: 100, height: 100 } ) ),
 		};
 
 		const disconnectSpy = jest.fn();
@@ -145,7 +152,7 @@ describe( 'useElementHeight', () => {
 
 		jest.spyOn( globalThis, 'ResizeObserver' ).mockImplementation( () => mockObserver );
 
-		const { result } = renderHook( () => useElementHeight() );
+		const { result } = renderHook( () => useElementSize() );
 		const [ refCallback ] = result.current;
 
 		// Attach element
@@ -159,7 +166,7 @@ describe( 'useElementHeight', () => {
 
 	it( 'should create ResizeObserver and observe element', () => {
 		const mockElement = {
-			getBoundingClientRect: jest.fn( () => ( { height: 100 } ) ),
+			getBoundingClientRect: jest.fn( () => ( { width: 100, height: 100 } ) ),
 		};
 
 		const observeSpy = jest.fn();
@@ -171,7 +178,7 @@ describe( 'useElementHeight', () => {
 
 		jest.spyOn( globalThis, 'ResizeObserver' ).mockImplementation( () => mockObserver );
 
-		const { result } = renderHook( () => useElementHeight() );
+		const { result } = renderHook( () => useElementSize() );
 		const [ refCallback ] = result.current;
 
 		refCallback( mockElement as unknown as HTMLDivElement );
@@ -181,7 +188,7 @@ describe( 'useElementHeight', () => {
 	} );
 
 	it( 'should maintain stable refCallback reference across re-renders', () => {
-		const { result, rerender } = renderHook( () => useElementHeight() );
+		const { result, rerender } = renderHook( () => useElementSize() );
 
 		const firstRefCallback = result.current[ 0 ];
 
@@ -195,26 +202,27 @@ describe( 'useElementHeight', () => {
 
 	it( 'should work with different element types', async () => {
 		const mockSpanElement = {
-			getBoundingClientRect: jest.fn( () => ( { height: 50 } ) ),
+			getBoundingClientRect: jest.fn( () => ( { width: 75, height: 50 } ) ),
 		};
 
-		const { result } = renderHook( () => useElementHeight() );
+		const { result } = renderHook( () => useElementSize() );
 		const [ refCallback ] = result.current;
 
 		refCallback( mockSpanElement as unknown as HTMLDivElement );
 
 		await waitFor( () => {
-			expect( result.current[ 1 ] ).toBe( 50 );
+			expect( result.current[ 1 ] ).toBe( 75 );
+			expect( result.current[ 2 ] ).toBe( 50 );
 		} );
 	} );
 
-	it( 'should update height when ResizeObserver callback is triggered', async () => {
+	it( 'should update dimensions when ResizeObserver callback is triggered', async () => {
 		let resizeCallback;
 		const mockElement = {
 			getBoundingClientRect: jest
 				.fn()
-				.mockReturnValueOnce( { height: 100 } )
-				.mockReturnValueOnce( { height: 200 } ),
+				.mockReturnValueOnce( { width: 100, height: 100 } )
+				.mockReturnValueOnce( { width: 200, height: 150 } ),
 		};
 
 		jest.spyOn( globalThis, 'ResizeObserver' ).mockImplementation( callback => {
@@ -226,13 +234,14 @@ describe( 'useElementHeight', () => {
 			};
 		} );
 
-		const { result } = renderHook( () => useElementHeight() );
+		const { result } = renderHook( () => useElementSize() );
 		const [ refCallback ] = result.current;
 
 		refCallback( mockElement as unknown as HTMLDivElement );
 
 		await waitFor( () => {
 			expect( result.current[ 1 ] ).toBe( 100 );
+			expect( result.current[ 2 ] ).toBe( 100 );
 		} );
 
 		// Simulate resize
@@ -240,6 +249,7 @@ describe( 'useElementHeight', () => {
 
 		await waitFor( () => {
 			expect( result.current[ 1 ] ).toBe( 200 );
+			expect( result.current[ 2 ] ).toBe( 150 );
 		} );
 
 		expect( mockElement.getBoundingClientRect ).toHaveBeenCalledTimes( 2 );
@@ -247,7 +257,7 @@ describe( 'useElementHeight', () => {
 
 	it( 'should handle unmount properly', () => {
 		const mockElement = {
-			getBoundingClientRect: jest.fn( () => ( { height: 100 } ) ),
+			getBoundingClientRect: jest.fn( () => ( { width: 100, height: 100 } ) ),
 		};
 
 		const disconnectSpy = jest.fn();
@@ -257,7 +267,7 @@ describe( 'useElementHeight', () => {
 			unobserve: jest.fn(),
 		} ) );
 
-		const { result, unmount } = renderHook( () => useElementHeight() );
+		const { result, unmount } = renderHook( () => useElementSize() );
 		const [ refCallback ] = result.current;
 
 		refCallback( mockElement as unknown as HTMLDivElement );

--- a/projects/js-packages/charts/src/hooks/use-element-size.ts
+++ b/projects/js-packages/charts/src/hooks/use-element-size.ts
@@ -33,7 +33,7 @@ export function useElementSize< T extends HTMLElement = HTMLDivElement >( {
 				setHeight( rect.height || 0 );
 			};
 			handleResize();
-			const resizeObserver = new window.ResizeObserver( handleResize );
+			const resizeObserver = new ResizeObserver( handleResize );
 			resizeObserver.observe( node );
 			observerRef.current = resizeObserver;
 		}

--- a/projects/js-packages/charts/src/hooks/use-element-size.ts
+++ b/projects/js-packages/charts/src/hooks/use-element-size.ts
@@ -1,19 +1,23 @@
 import { useState, useCallback, useRef } from 'react';
 
 /**
- * Hook to measure the height of a DOM element.
- * Returns a ref to attach to the element and the current height in pixels.
+ * Hook to measure the width and height of a DOM element.
+ * Returns a ref callback to attach to the element and the current dimensions in pixels.
  *
  * @param {object} props               - Optional props.
+ * @param {number} props.initialWidth  - The initial width to use.
  * @param {number} props.initialHeight - The initial height to use.
  *
- * @return {[Function, number]} A tuple containing a ref to attach to the element and the current height in pixels
+ * @return {[Function, number, number]} A tuple containing a ref callback, width, and height in pixels
  */
-export function useElementHeight< T extends HTMLElement = HTMLDivElement >( {
+export function useElementSize< T extends HTMLElement = HTMLDivElement >( {
+	initialWidth = 0,
 	initialHeight = 0,
 }: {
+	initialWidth?: number;
 	initialHeight?: number;
-} = {} ): [ ( node: T | null ) => void, number ] {
+} = {} ): [ ( node: T | null ) => void, number, number ] {
+	const [ width, setWidth ] = useState( initialWidth );
 	const [ height, setHeight ] = useState( initialHeight );
 	const observerRef = useRef< ResizeObserver | null >( null );
 
@@ -24,7 +28,9 @@ export function useElementHeight< T extends HTMLElement = HTMLDivElement >( {
 		}
 		if ( node ) {
 			const handleResize = () => {
-				setHeight( node.getBoundingClientRect().height || 0 );
+				const rect = node.getBoundingClientRect();
+				setWidth( rect.width || 0 );
+				setHeight( rect.height || 0 );
 			};
 			handleResize();
 			const resizeObserver = new window.ResizeObserver( handleResize );
@@ -33,5 +39,5 @@ export function useElementHeight< T extends HTMLElement = HTMLDivElement >( {
 		}
 	}, [] );
 
-	return [ refCallback, height ];
+	return [ refCallback, width, height ];
 }

--- a/projects/js-packages/charts/src/types.ts
+++ b/projects/js-packages/charts/src/types.ts
@@ -364,15 +364,17 @@ export type BaseChartProps< T = DataPoint | DataPointDate | LeaderboardEntry > =
 	 */
 	className?: string;
 	/**
-	 * Width of the chart in pixels
+	 * Width of the chart container in pixels. When omitted, the chart fills its parent's width.
 	 */
 	width?: number;
 	/**
-	 * Height of the chart in pixels
+	 * Height of the chart container in pixels. When omitted, the chart fills its parent's height.
 	 */
 	height?: number;
 	/**
-	 * Size of the chart in pixels for pie and donut charts
+	 * Maximum diameter of the pie in pixels (pie and donut charts only).
+	 * The pie will shrink if the container is smaller than this value.
+	 * When omitted, the pie fills the available space.
 	 */
 	size?: number;
 	/**


### PR DESCRIPTION
Fixes CHARTS-164

## Overview

The `size` prop on pie and donut charts was pulling double duty — controlling both the container dimensions (via `withResponsive`) and the pie diameter. This caused incorrect sizing in responsive contexts: charts would either overflow their container or fail to fill available space, because the responsive wrapper and the pie itself were fighting over the same value.

This PR separates those concerns. `size` now only constrains the maximum pie diameter, while `width`/`height` control the container. A new SVG wrapper element measures available space so the pie can shrink to fit or fill its container automatically. The underlying `useElementHeight` hook is generalized to `useElementSize` to support these two-dimensional measurements across all chart types.

## Proposed changes:

* Generalized `useElementHeight` hook to `useElementSize`, adding width measurement alongside height. This enables components to measure both dimensions of their container.
* Decoupled pie chart size from container dimensions — the `size` prop now controls only the pie diameter (not the responsive wrapper), and the pie auto-sizes to fit available space when no `size` is specified.
* Replaced the pie chart's manual flex layout with a `Stack` component from `@wordpress/ui` for proper gap control and column layout.
* Added an SVG wrapper element so the pie chart can measure available space and shrink responsively within flex containers.
* Added a `gap` prop to `PieChart` for controlling spacing between chart elements (SVG, legend, children) using WordPress design system tokens.
* Updated the responsive wrapper (`withResponsive`) to stop using `size` for container dimensions — `size` is now passed through as a chart-level prop only.
* Removed the explicit `design-tokens` CSS import from the pie chart — loading global CSS is the responsibility of the consuming application, not individual components.
* Fixed donut story color indexing bug where blanking labels with `label: ''` caused `findIndex` to always return 0, giving all segments the same color. Uses `showLabels: false` instead.
* Updated stories to reflect the new responsive sizing behaviour and removed stale stories/args.
* Updated all tests to cover the new `useElementSize` return signature `[ref, width, height]`.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

1. Run the Charts Storybook: `cd projects/js-packages/charts && pnpm run storybook`
2. Navigate to the **Pie Chart** stories
3. Verify the **Default** story renders a pie that fills its container responsively (no explicit `size` prop)
4. Verify the **WithSize** story constrains the pie to 200px diameter
5. Verify the **WithLegend** story shows the legend below the pie with proper spacing and the pie shrinks to accommodate it
6. Verify the **InteractiveLegend** story allows toggling segments via legend clicks
7. Navigate to the **Donut Chart** stories and repeat 3 - 6
8. Check the **Bar Chart**, **Line Chart** and **Semi Circle Pie Chart** default stories still render correctly (they now use `useElementSize`)
9. Resize the browser window and verify all charts respond to container size changes

---
Linear Issue: [CHARTS-164](https://linear.app/a8c/issue/CHARTS-164/fix-chart-height-and-size-calculations-for-pie-chart-and-variants)

Made with [Cursor](https://cursor.com)
