### PR TITLE
Social: Fix Tumblr preview when custom message is set

### DIFF
--- a/projects/js-packages/social-previews/changelog/fix-social-tumblr-preview
+++ b/projects/js-packages/social-previews/changelog/fix-social-tumblr-preview
@@ -1,0 +1,4 @@
+Significance: patch
+Type: removed
+
+Remove custom text for Tumblr preview in favor of description

--- a/projects/js-packages/social-previews/changelog/fix-social-tumblr-preview
+++ b/projects/js-packages/social-previews/changelog/fix-social-tumblr-preview
@@ -1,4 +1,4 @@
 Significance: patch
 Type: removed
 
-Remove custom text for Tumblr preview in favor of description
+Remove custom text for Tumblr preview in favor of description.

--- a/projects/js-packages/social-previews/src/tumblr-preview/post-preview.tsx
+++ b/projects/js-packages/social-previews/src/tumblr-preview/post-preview.tsx
@@ -25,7 +25,7 @@ export const TumblrPostPreview: React.FC< TumblrPreviewProps > = ( {
 			<div className="tumblr-preview__card">
 				<TumblrPostHeader user={ user } />
 				<div className="tumblr-preview__body">
-					<div className="tumblr-preview__title">{ tumblrTitle( title ) }</div>
+					{ title ? <div className="tumblr-preview__title">{ tumblrTitle( title ) }</div> : null }
 					{ description && (
 						<div className="tumblr-preview__description">
 							{ preparePreviewText( tumblrDescription( description ), {

--- a/projects/js-packages/social-previews/src/tumblr-preview/post-preview.tsx
+++ b/projects/js-packages/social-previews/src/tumblr-preview/post-preview.tsx
@@ -13,7 +13,6 @@ export const TumblrPostPreview: React.FC< TumblrPreviewProps > = ( {
 	image,
 	user,
 	url,
-	customText,
 	media,
 } ) => {
 	const avatarUrl = user?.avatarUrl;
@@ -27,7 +26,6 @@ export const TumblrPostPreview: React.FC< TumblrPreviewProps > = ( {
 				<TumblrPostHeader user={ user } />
 				<div className="tumblr-preview__body">
 					<div className="tumblr-preview__title">{ tumblrTitle( title ) }</div>
-					{ customText && <div className="tumblr-preview__custom-text">{ customText }</div> }
 					{ description && (
 						<div className="tumblr-preview__description">
 							{ preparePreviewText( tumblrDescription( description ), {

--- a/projects/js-packages/social-previews/src/tumblr-preview/types.ts
+++ b/projects/js-packages/social-previews/src/tumblr-preview/types.ts
@@ -7,5 +7,4 @@ export type TumblrUser = {
 
 export type TumblrPreviewProps = SocialPreviewBaseProps & {
 	user?: TumblrUser;
-	customText?: string;
 };

--- a/projects/packages/publicize/_inc/components/social-post-modal/post-preview.tsx
+++ b/projects/packages/publicize/_inc/components/social-post-modal/post-preview.tsx
@@ -253,14 +253,18 @@ export function PostPreview( { connection }: PostPreviewProps ) {
 			);
 		}
 
-		case 'tumblr':
+		case 'tumblr': {
+			const desc = message || description;
+
 			return (
 				<TumblrPostPreview
 					{ ...commonProps }
+					title={ message ? '' : title }
+					description={ desc }
 					user={ { displayName: user.displayName, avatarUrl: user.profileImage } }
-					customText={ message }
 				/>
 			);
+		}
 
 		default:
 			return null;

--- a/projects/packages/publicize/changelog/fix-social-tumblr-preview
+++ b/projects/packages/publicize/changelog/fix-social-tumblr-preview
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix Tumblr preview to prioritize custom message when it is set.

--- a/projects/plugins/jetpack/changelog/fix-social-tumblr-preview
+++ b/projects/plugins/jetpack/changelog/fix-social-tumblr-preview
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Social: Fix Tumblr preview to prioritize custom message when it is set.

--- a/projects/plugins/social/changelog/fix-social-tumblr-preview
+++ b/projects/plugins/social/changelog/fix-social-tumblr-preview
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix Tumblr preview to prioritize custom message when it is set.


### PR DESCRIPTION
Closes SOCIAL-358

## Proposed changes:

The Tumblr preview was not reflecting the custom share message. When a user set a custom message (globally or per-network), the preview still showed the post title and description instead of using the custom message as the post body.

- When a custom message is set, use it as the Tumblr preview description and hide the title (matching how Tumblr actually renders the shared post)
- Remove the unused `customText` prop from the Tumblr preview component in `social-previews`, which was rendering the message separately from the description rather than replacing it

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

SOCIAL-358

## Does this pull request change what data or activity we track or use?

No changes to data tracking.

## Testing instructions:

- Create or edit a post with a Tumblr connection configured
- Open the Social preview modal and select the Tumblr connection

### Without custom message
- Leave the share message empty
- **Verify**: The Tumblr preview shows the post title and description as usual

### With custom message (global)
- Set a custom share message
- **Verify**: The Tumblr preview shows only the custom message as the body (no title)
- **Verify**: This matches how the post actually appears on Tumblr after sharing

| BEFORE | AFTER
|--------|--------|
| <img width="1192" height="731" alt="Screenshot 2026-02-12 at 11 30 23 AM" src="https://github.com/user-attachments/assets/b3aa2f38-f5fc-44f3-8b3c-af63629f2af1" /> | <img width="1188" height="729" alt="Screenshot 2026-02-12 at 11 29 21 AM" src="https://github.com/user-attachments/assets/9addef81-2e41-45df-8630-2a68c008555a" /> | 