### PR TITLE
Replace dashicons-external with Unicode arrow in menu items

### DIFF
--- a/projects/packages/my-jetpack/changelog/update-external-link-icon
+++ b/projects/packages/my-jetpack/changelog/update-external-link-icon
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Replace dashicons-external with Unicode arrow (↗) in external menu links for improved performance and modern appearance.
+Update external menu links in My Jetpack to use an external-link arrow indicator (↗) for improved clarity and modern appearance.

--- a/projects/packages/my-jetpack/changelog/update-external-link-icon
+++ b/projects/packages/my-jetpack/changelog/update-external-link-icon
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Replace dashicons-external with Unicode arrow (↗) in external menu links for improved performance and modern appearance.

--- a/projects/packages/my-jetpack/src/class-activitylog.php
+++ b/projects/packages/my-jetpack/src/class-activitylog.php
@@ -48,7 +48,7 @@ class Activitylog {
 		return Admin_Menu::add_menu(
 			/** "Activity Log" is a product name, do not translate. */
 			'Activity Log',
-			'Activity Log <span class="dashicons dashicons-external"></span>',
+			'Activity Log ↗',
 			'manage_options',
 			esc_url( Redirect::get_url( 'cloud-activity-log-wp-menu', $args ) ),
 			null,

--- a/projects/packages/my-jetpack/src/class-activitylog.php
+++ b/projects/packages/my-jetpack/src/class-activitylog.php
@@ -48,7 +48,7 @@ class Activitylog {
 		return Admin_Menu::add_menu(
 			/** "Activity Log" is a product name, do not translate. */
 			'Activity Log',
-			'Activity Log ↗',
+			'Activity Log <span aria-hidden="true">↗</span>',
 			'manage_options',
 			esc_url( Redirect::get_url( 'cloud-activity-log-wp-menu', $args ) ),
 			null,

--- a/projects/packages/my-jetpack/src/class-jetpack-manage.php
+++ b/projects/packages/my-jetpack/src/class-jetpack-manage.php
@@ -76,7 +76,7 @@ class Jetpack_Manage {
 
 		return Admin_Menu::add_menu(
 			__( 'Jetpack Manage', 'jetpack-my-jetpack' ),
-			_x( 'Jetpack Manage', 'product name shown in menu', 'jetpack-my-jetpack' ) . ' ↗',
+			_x( 'Jetpack Manage', 'product name shown in menu', 'jetpack-my-jetpack' ) . ' <span aria-hidden="true">↗</span>',
 			'manage_options',
 			esc_url( Redirect::get_url( 'cloud-manage-dashboard-wp-menu', $args ) ),
 			null,

--- a/projects/packages/my-jetpack/src/class-jetpack-manage.php
+++ b/projects/packages/my-jetpack/src/class-jetpack-manage.php
@@ -76,7 +76,7 @@ class Jetpack_Manage {
 
 		return Admin_Menu::add_menu(
 			__( 'Jetpack Manage', 'jetpack-my-jetpack' ),
-			_x( 'Jetpack Manage', 'product name shown in menu', 'jetpack-my-jetpack' ) . ' <span class="dashicons dashicons-external"></span>',
+			_x( 'Jetpack Manage', 'product name shown in menu', 'jetpack-my-jetpack' ) . ' ↗',
 			'manage_options',
 			esc_url( Redirect::get_url( 'cloud-manage-dashboard-wp-menu', $args ) ),
 			null,

--- a/projects/plugins/jetpack/changelog/update-external-link-icon
+++ b/projects/plugins/jetpack/changelog/update-external-link-icon
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Replace dashicons-external with Unicode arrow (↗) in external menu links for improved performance and modern appearance.

--- a/projects/plugins/jetpack/changelog/update-external-link-icon
+++ b/projects/plugins/jetpack/changelog/update-external-link-icon
@@ -1,4 +1,4 @@
 Significance: patch
-Type: changed
+Type: enhancement
 
 Replace dashicons-external with Unicode arrow (↗) in external menu links for improved performance and modern appearance.

--- a/projects/plugins/jetpack/changelog/update-external-link-icon
+++ b/projects/plugins/jetpack/changelog/update-external-link-icon
@@ -1,4 +1,4 @@
 Significance: patch
 Type: enhancement
 
-Replace dashicons-external with Unicode arrow (↗) in external menu links for improved performance and modern appearance.
+Update external menu links to display an arrow indicator for improved performance and a more modern appearance.

--- a/projects/plugins/jetpack/changelog/update-external-link-icon
+++ b/projects/plugins/jetpack/changelog/update-external-link-icon
@@ -1,4 +1,4 @@
 Significance: patch
-Type: changed
+Type: enhancement
 
 Update external menu links to display an arrow indicator for improved performance and a more modern appearance.

--- a/projects/plugins/jetpack/changelog/update-external-link-icon
+++ b/projects/plugins/jetpack/changelog/update-external-link-icon
@@ -1,4 +1,4 @@
 Significance: patch
-Type: enhancement
+Type: changed
 
 Update external menu links to display an arrow indicator for improved performance and a more modern appearance.

--- a/projects/plugins/jetpack/modules/scan/class-admin-sidebar-link.php
+++ b/projects/plugins/jetpack/modules/scan/class-admin-sidebar-link.php
@@ -72,7 +72,7 @@ class Admin_Sidebar_Link {
 			Admin_Menu::add_menu(
 				/** "Scan" is a product name, do not translate. */
 				'Scan',
-				'Scan <span class="dashicons dashicons-external"></span>',
+				'Scan ↗',
 				'manage_options',
 				esc_url( Redirect::get_url( 'cloud-scan-history-wp-menu' ) ),
 				null,
@@ -85,7 +85,7 @@ class Admin_Sidebar_Link {
 			Admin_Menu::add_menu(
 				/** "Scan" is a product name, do not translate. */
 				'Scan',
-				'Scan <span class="dashicons dashicons-external"></span>',
+				'Scan ↗',
 				'manage_options',
 				esc_url( Redirect::get_url( 'cloud-scan-history-wp-menu' ) ),
 				null,
@@ -97,7 +97,7 @@ class Admin_Sidebar_Link {
 			Admin_Menu::add_menu(
 				/** "VaultPress Backup" is a product name, do not translate. */
 				'VaultPress Backup',
-				'VaultPress Backup <span class="dashicons dashicons-external"></span>',
+				'VaultPress Backup ↗',
 				'manage_options',
 				esc_url( Redirect::get_url( 'calypso-backups' ) ),
 				null,

--- a/projects/plugins/jetpack/modules/scan/class-admin-sidebar-link.php
+++ b/projects/plugins/jetpack/modules/scan/class-admin-sidebar-link.php
@@ -72,7 +72,7 @@ class Admin_Sidebar_Link {
 			Admin_Menu::add_menu(
 				/** "Scan" is a product name, do not translate. */
 				'Scan',
-				'Scan ↗',
+				'Scan <span aria-hidden="true">↗</span>',
 				'manage_options',
 				esc_url( Redirect::get_url( 'cloud-scan-history-wp-menu' ) ),
 				null,
@@ -85,7 +85,7 @@ class Admin_Sidebar_Link {
 			Admin_Menu::add_menu(
 				/** "Scan" is a product name, do not translate. */
 				'Scan',
-				'Scan ↗',
+				'Scan <span aria-hidden="true">↗</span>',
 				'manage_options',
 				esc_url( Redirect::get_url( 'cloud-scan-history-wp-menu' ) ),
 				null,
@@ -97,7 +97,7 @@ class Admin_Sidebar_Link {
 			Admin_Menu::add_menu(
 				/** "VaultPress Backup" is a product name, do not translate. */
 				'VaultPress Backup',
-				'VaultPress Backup ↗',
+				'VaultPress Backup <span aria-hidden="true">↗</span>',
 				'manage_options',
 				esc_url( Redirect::get_url( 'calypso-backups' ) ),
 				null,

--- a/projects/plugins/jetpack/modules/subscriptions.php
+++ b/projects/plugins/jetpack/modules/subscriptions.php
@@ -1054,7 +1054,7 @@ class Jetpack_Subscriptions {
 
 		Admin_Menu::add_menu(
 			__( 'Subscribers', 'jetpack' ),
-			__( 'Subscribers', 'jetpack' ) . ' <span class="dashicons dashicons-external"></span>',
+			__( 'Subscribers', 'jetpack' ) . ' ↗',
 			'manage_options',
 			esc_url( $link ),
 			null,

--- a/projects/plugins/jetpack/modules/subscriptions.php
+++ b/projects/plugins/jetpack/modules/subscriptions.php
@@ -1054,7 +1054,7 @@ class Jetpack_Subscriptions {
 
 		Admin_Menu::add_menu(
 			__( 'Subscribers', 'jetpack' ),
-			__( 'Subscribers', 'jetpack' ) . ' ↗',
+			__( 'Subscribers', 'jetpack' ) . ' <span aria-hidden="true">↗</span>',
 			'manage_options',
 			esc_url( $link ),
 			null,


### PR DESCRIPTION
## Summary

Fixes [JETPACK-1311](https://linear.app/a8c/issue/JETPACK-1311/fix-jetpacks-admin-off-site-link-menu-icons-and-breaking-to-two-lines)

Replace the deprecated `dashicons-external` icon with the Unicode arrow (↗) in Jetpack menu items that link to external pages.

*Before:*

<img width="198" height="439" alt="2026-02-11_22-40-19" src="https://github.com/user-attachments/assets/e9c8e6d4-8a4a-414e-99fc-6e75566f811d" />

*After*

<img width="169" height="331" alt="2026-02-11_23-03-31" src="https://github.com/user-attachments/assets/cf6c22b9-9b25-435a-9eeb-ff52ae078cd1" />

Trust me, this feels so much better and is a good, quick improvement.

## Why?

- **Dashicons is deprecated**: No longer maintained or accepting new icons
- **WordPress alignment**: Modern `@wordpress/icons` uses the same Unicode character for `arrowUpRight`
- **Performance**: 3-byte character vs loading icon font
- **Universal compatibility**: Supported since Unicode 1.1 (1993)

## Changes

Updated 5 menu items to use ↗:
- Activity Log (my-jetpack)
- Jetpack Manage (my-jetpack)  
- Subscribers (jetpack)
- Scan (jetpack, 2 instances)
- VaultPress Backup (jetpack)

**Before:** `'Menu Item <span class="dashicons dashicons-external"></span>'`  
**After:** `'Menu Item ↗'`

## Testing instructions:

Verify the ↗ arrow displays correctly in the Jetpack admin menu for each affected menu item on desktop and mobile browsers.

## Does this pull request change what data or activity we track or use?

No