### PR TITLE
Fix missing Help Center link for heading block inspector

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-heading-block-help-link
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-heading-block-help-link
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Block Description Links: fix missing Help Center link for blocks with variations like core/heading.

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-block-description-links/index.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-block-description-links/index.tsx
@@ -104,9 +104,6 @@ const addBlockSupportLinks = (
 
 			if ( isBlockLink( variationInfo ) ) {
 				// "Flat" entry: same link for all variations
-				if ( ! variation.description ) {
-					return variation;
-				}
 				link = variationInfo.link;
 				postId = variationInfo.postId;
 			} else {
@@ -121,6 +118,10 @@ const addBlockSupportLinks = (
 				} else if ( ! link ) {
 					return variation;
 				}
+			}
+
+			if ( ! variation.description ) {
+				return variation;
 			}
 
 			variation.description = createLocalizedDescriptionWithLearnMore(

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-block-description-links/index.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-block-description-links/index.tsx
@@ -3,6 +3,7 @@ import { createInterpolateElement } from '@wordpress/element';
 import { addFilter } from '@wordpress/hooks';
 import { JSXElementConstructor, ReactElement } from 'react';
 import blockInfoMapping, {
+	type BlockLink,
 	blockInfoWithVariations,
 	childrenBlockInfoWithDifferentUrl,
 } from './src/block-links-map';
@@ -24,6 +25,19 @@ const createLocalizedDescriptionWithLearnMore = (
 		),
 	} );
 };
+
+/**
+ * Check whether info is a flat BlockLink rather than a per-variation map.
+ *
+ * @param info - Block link info to check.
+ * @return Whether info is a BlockLink.
+ */
+function isBlockLink( info: BlockLink | { [ key: string ]: BlockLink } ): info is BlockLink {
+	return (
+		typeof ( info as BlockLink ).link === 'string' &&
+		typeof ( info as BlockLink ).postId === 'number'
+	);
+}
 
 const processedBlocks: { [ key: string ]: true } = {};
 
@@ -82,34 +96,42 @@ const addBlockSupportLinks = (
 		settings.variations &&
 		Array.isArray( settings.variations )
 	) {
-		settings.variations = settings.variations.map(
-			( variation: {
-				title: string;
-				name: string;
-				// eslint-disable-next-line @typescript-eslint/no-explicit-any
-				description: string | ReactElement< string | JSXElementConstructor< any > >;
-			} ) => {
-				let link = blockInfoWithVariations[ name ][ variation.name ]?.link;
-				let postId = blockInfoWithVariations[ name ][ variation.name ]?.postId;
+		const variationInfo = blockInfoWithVariations[ name ];
 
-				// Set the default link for all embed variations that don't have a specific guide.
+		settings.variations = settings.variations.map( variation => {
+			let link: string | undefined;
+			let postId: number | undefined;
+
+			if ( isBlockLink( variationInfo ) ) {
+				// "Flat" entry: same link for all variations
+				if ( ! variation.description ) {
+					return variation;
+				}
+				link = variationInfo.link;
+				postId = variationInfo.postId;
+			} else {
+				// Per-variation entries: each variation gets its own link
+				link = variationInfo[ variation.name ]?.link;
+				postId = variationInfo[ variation.name ]?.postId;
+
+				// Default link for embed variations without a specific guide.
 				if ( ! link && name === 'core/embed' ) {
 					link = 'https://wordpress.com/support/wordpress-editor/blocks/embed-block/';
 					postId = 150644;
 				} else if ( ! link ) {
 					return variation;
 				}
-
-				variation.description = createLocalizedDescriptionWithLearnMore(
-					variation.title,
-					variation.description,
-					link,
-					postId
-				);
-
-				return variation;
 			}
-		);
+
+			variation.description = createLocalizedDescriptionWithLearnMore(
+				variation.title,
+				variation.description,
+				link,
+				postId
+			);
+
+			return variation;
+		} );
 	}
 
 	return settings;

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-block-description-links/src/block-links-map.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-block-description-links/src/block-links-map.ts
@@ -91,10 +91,6 @@ const blockInfoMapping: { [ key: string ]: { link: string; postId: number } } = 
 		link: 'https://wordpress.com/support/wordpress-editor/blocks/latest-comments-block/',
 		postId: 149811,
 	},
-	'core/heading': {
-		link: 'https://wordpress.com/support/wordpress-editor/blocks/heading-block/',
-		postId: 148403,
-	},
 	'core/file': {
 		link: 'https://wordpress.com/support/wordpress-editor/blocks/file-block/',
 		postId: 148586,
@@ -406,9 +402,15 @@ const blockInfoMapping: { [ key: string ]: { link: string; postId: number } } = 
 	},
 };
 
+export type BlockLink = { link: string; postId: number };
+
 export const blockInfoWithVariations: {
-	[ key: string ]: { [ key: string ]: { link: string; postId: number } };
+	[ key: string ]: BlockLink | { [ key: string ]: BlockLink };
 } = {
+	'core/heading': {
+		link: 'https://wordpress.com/support/wordpress-editor/blocks/heading-block/',
+		postId: 148403,
+	},
 	'core/embed': {
 		soundcloud: {
 			link: 'https://wordpress.com/support/soundcloud-audio-player/',


### PR DESCRIPTION
Fixes DOTCOM-15899

## Proposed changes:
* Fix the "Learn more" help center link not appearing for the `core/heading` block in the block inspector sidebar.

Since Gutenberg v22.4.0, `core/heading` defines h1-h6 variations with `scope: ["block", "transform"]`. Each variation has its own `description`. When a heading block is selected, the inspector shows the active variation's description instead of the main block description. The `addBlockSupportLinks` function only modified `settings.description`, so the "Learn more" link was never displayed.

This change updates `addBlockSupportLinks` to also append the help center link to variation descriptions for blocks that are not already handled by `blockInfoWithVariations` (avoiding double-wrapping for blocks like `core/embed`).

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
* Open the WordPress editor on a wpcom site.
* Add a Heading block (any level: H1-H6).
* Select the heading block and open the block inspector sidebar.
* Verify the "Learn more" help center link appears in the block description.
* Also verify that blocks with per-variation links (e.g., `core/embed`) still show their specific variation links correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)