### PR TITLE
Forms: Add form naming modal and rename functionality

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2389,6 +2389,9 @@ importers:
       '@wordpress/boot':
         specifier: 0.6.0
         version: 0.6.0(@types/react-dom@18.3.7(@types/react@18.3.26))(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@16.26.1)
+      '@wordpress/commands':
+        specifier: 1.39.0
+        version: 1.39.0(@types/react-dom@18.3.7(@types/react@18.3.26))(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/components':
         specifier: 32.1.0
         version: 32.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)

--- a/projects/packages/forms/changelog/add-form-title-modal
+++ b/projects/packages/forms/changelog/add-form-title-modal
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Forms: Add form naming modal and rename functionality for synced forms.

--- a/projects/packages/forms/package.json
+++ b/projects/packages/forms/package.json
@@ -57,6 +57,7 @@
 		"@wordpress/block-editor": "15.12.0",
 		"@wordpress/blocks": "15.12.0",
 		"@wordpress/boot": "0.6.0",
+		"@wordpress/commands": "1.39.0",
 		"@wordpress/components": "32.1.0",
 		"@wordpress/compose": "7.39.0",
 		"@wordpress/core-data": "7.39.0",

--- a/projects/packages/forms/routes/forms/stage.tsx
+++ b/projects/packages/forms/routes/forms/stage.tsx
@@ -3,12 +3,19 @@
  */
 import { Page } from '@wordpress/admin-ui';
 import apiFetch from '@wordpress/api-fetch';
-import { __experimentalConfirmDialog as ConfirmDialog } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
+import {
+	__experimentalConfirmDialog as ConfirmDialog, // eslint-disable-line @wordpress/no-unsafe-wp-apis
+	Button,
+	Modal,
+	TextControl,
+} from '@wordpress/components';
+import { store as coreStore } from '@wordpress/core-data';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { DataViews } from '@wordpress/dataviews';
 import { dateI18n, getSettings as getDateSettings } from '@wordpress/date';
 import { useEffect, useMemo, useState, useCallback } from '@wordpress/element';
 import { __, _n, sprintf } from '@wordpress/i18n';
+import { store as noticesStore } from '@wordpress/notices';
 import { useSearch, useNavigate } from '@wordpress/route';
 import * as React from 'react';
 /**
@@ -125,6 +132,15 @@ function StageInner() {
 	const [ selection, setSelection ] = useState< string[] >( [] );
 	const [ pendingPermanentDeleteCount, setPendingPermanentDeleteCount ] = useState( 0 );
 
+	// Rename modal state
+	const [ isRenameModalOpen, setIsRenameModalOpen ] = useState( false );
+	const [ renameFormItem, setRenameFormItem ] = useState< FormListItem | null >( null );
+	const [ renameTitle, setRenameTitle ] = useState( '' );
+	const [ isRenaming, setIsRenaming ] = useState( false );
+
+	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
+	const { editEntityRecord, saveEditedEntityRecord } = useDispatch( coreStore );
+
 	// Selection is local state. Clear it whenever the view changes (page/perPage/search/filters).
 	useEffect( () => {
 		setSelection( [] );
@@ -151,6 +167,65 @@ function StageInner() {
 			setSelection( [] );
 		}
 	}, [ confirmPermanentDelete ] );
+
+	const openRenameModal = useCallback( ( item: FormListItem ) => {
+		setRenameFormItem( item );
+		setRenameTitle( item.title || '' );
+		setIsRenameModalOpen( true );
+	}, [] );
+
+	const closeRenameModal = useCallback( () => {
+		setIsRenameModalOpen( false );
+		setRenameFormItem( null );
+		setRenameTitle( '' );
+	}, [] );
+
+	const handleRename = useCallback( async () => {
+		if ( ! renameFormItem || isRenaming ) {
+			return;
+		}
+
+		setIsRenaming( true );
+		const newTitle = renameTitle.trim() || __( 'Untitled Form', 'jetpack-forms' );
+
+		try {
+			await editEntityRecord( 'postType', 'jetpack_form', renameFormItem.id, {
+				title: newTitle,
+			} );
+			await saveEditedEntityRecord( 'postType', 'jetpack_form', renameFormItem.id );
+
+			createSuccessNotice( __( 'Form renamed.', 'jetpack-forms' ), { type: 'snackbar' } );
+		} catch ( error ) {
+			createErrorNotice( __( 'Failed to rename form. Please try again.', 'jetpack-forms' ), {
+				type: 'snackbar',
+			} );
+			// eslint-disable-next-line no-console
+			console.error( 'Failed to rename form:', error );
+		} finally {
+			setIsRenaming( false );
+			closeRenameModal();
+		}
+	}, [
+		renameFormItem,
+		renameTitle,
+		isRenaming,
+		editEntityRecord,
+		saveEditedEntityRecord,
+		createSuccessNotice,
+		createErrorNotice,
+		closeRenameModal,
+	] );
+
+	const onRenameFormSubmit = useCallback(
+		( event: React.FormEvent ) => {
+			event.preventDefault();
+			if ( isRenaming ) {
+				return;
+			}
+			handleRename();
+		},
+		[ handleRename, isRenaming ]
+	);
 
 	const statusLabel = useCallback( ( status: string ) => {
 		switch ( status ) {
@@ -276,6 +351,19 @@ function StageInner() {
 					}
 				},
 			},
+			{
+				id: 'rename-form',
+				isPrimary: false,
+				label: __( 'Rename', 'jetpack-forms' ),
+				supportsBulk: false,
+				callback( items: FormListItem[] ) {
+					const [ item ] = items;
+					if ( ! item ) {
+						return;
+					}
+					openRenameModal( item );
+				},
+			},
 		];
 
 		if ( isViewingTrash ) {
@@ -335,6 +423,7 @@ function StageInner() {
 		isDeleting,
 		isViewingTrash,
 		onOpenPermanentDeleteConfirm,
+		openRenameModal,
 		openSingleFormView,
 		restoreForms,
 		trashForms,
@@ -457,6 +546,42 @@ function StageInner() {
 				<DataViews.Layout />
 				<DataViews.Footer />
 			</DataViews>
+			{ isRenameModalOpen && (
+				<Modal
+					title={ __( 'Rename Form', 'jetpack-forms' ) }
+					onRequestClose={ closeRenameModal }
+					size="medium"
+				>
+					<form onSubmit={ onRenameFormSubmit }>
+						<TextControl
+							label={ __( 'Name', 'jetpack-forms' ) }
+							value={ renameTitle }
+							onChange={ setRenameTitle }
+							__next40pxDefaultSize
+						/>
+						<div
+							style={ {
+								display: 'flex',
+								justifyContent: 'flex-end',
+								gap: '8px',
+								marginTop: '16px',
+							} }
+						>
+							<Button variant="tertiary" onClick={ closeRenameModal }>
+								{ __( 'Cancel', 'jetpack-forms' ) }
+							</Button>
+							<Button
+								aria-disabled={ isRenaming }
+								isBusy={ isRenaming }
+								variant="primary"
+								type="submit"
+							>
+								{ __( 'Save', 'jetpack-forms' ) }
+							</Button>
+						</div>
+					</form>
+				</Modal>
+			) }
 			<IntegrationsModal
 				isOpen={ isIntegrationsModalOpen }
 				onClose={ closeIntegrationsModal }

--- a/projects/packages/forms/routes/forms/stage.tsx
+++ b/projects/packages/forms/routes/forms/stage.tsx
@@ -26,7 +26,7 @@ import CreateFormButton from '../../src/dashboard/components/create-form-button/
 import { EmptyWrapper } from '../../src/dashboard/components/empty-responses/index.tsx';
 import { NON_TRASH_FORM_STATUSES } from '../../src/dashboard/constants';
 import useDeleteForm from '../../src/dashboard/hooks/use-delete-form.ts';
-import useFormsData from '../../src/dashboard/hooks/use-forms-data.ts';
+import useFormsData, { getFormsListQuery } from '../../src/dashboard/hooks/use-forms-data.ts';
 import DataViewsHeaderRow from '../../src/dashboard/wp-build/components/dataviews-header-row';
 import usePageHeaderDetails from '../../src/dashboard/wp-build/hooks/use-page-header-details';
 import '../../src/dashboard/wp-build/style.scss';
@@ -139,7 +139,7 @@ function StageInner() {
 	const [ isRenaming, setIsRenaming ] = useState( false );
 
 	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
-	const { editEntityRecord, saveEditedEntityRecord } = useDispatch( coreStore );
+	const { invalidateResolution } = useDispatch( coreStore );
 
 	// Selection is local state. Clear it whenever the view changes (page/perPage/search/filters).
 	useEffect( () => {
@@ -189,10 +189,20 @@ function StageInner() {
 		const newTitle = renameTitle.trim() || __( 'Untitled Form', 'jetpack-forms' );
 
 		try {
-			await editEntityRecord( 'postType', 'jetpack_form', renameFormItem.id, {
-				title: newTitle,
+			await apiFetch( {
+				path: `/wp/v2/jetpack-forms/${ renameFormItem.id }`,
+				method: 'POST',
+				data: { title: newTitle },
 			} );
-			await saveEditedEntityRecord( 'postType', 'jetpack_form', renameFormItem.id );
+
+			// Invalidate the forms list cache to refresh the data
+			const query = getFormsListQuery(
+				view.page ?? 1,
+				view.perPage ?? 20,
+				view.search ?? '',
+				statusQuery
+			);
+			invalidateResolution( 'getEntityRecords', [ 'postType', 'jetpack_form', query ] );
 
 			createSuccessNotice( __( 'Form renamed.', 'jetpack-forms' ), { type: 'snackbar' } );
 		} catch ( error ) {
@@ -209,8 +219,11 @@ function StageInner() {
 		renameFormItem,
 		renameTitle,
 		isRenaming,
-		editEntityRecord,
-		saveEditedEntityRecord,
+		view.page,
+		view.perPage,
+		view.search,
+		statusQuery,
+		invalidateResolution,
 		createSuccessNotice,
 		createErrorNotice,
 		closeRenameModal,

--- a/projects/packages/forms/src/blocks/contact-form/components/form-commands.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/components/form-commands.tsx
@@ -1,27 +1,40 @@
+import { store as blockEditorStore } from '@wordpress/block-editor';
 import { useCommandLoader } from '@wordpress/commands';
 import { store as coreStore } from '@wordpress/core-data';
-import { useSelect } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
-import { useState, useMemo, useRef } from '@wordpress/element';
+import { useState, useMemo, useRef, useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { pencil } from '@wordpress/icons';
 import { FORM_POST_TYPE } from '../../shared/util/constants.js';
 import FormNameModal from './form-name-modal.tsx';
 
-export default function FormCommands() {
+type FormCommandsProps = {
+	clientId: string;
+};
+
+export default function FormCommands( { clientId }: FormCommandsProps ) {
 	const [ isRenameModalOpen, setIsRenameModalOpen ] = useState( false );
 
-	const { currentPostTitle } = useSelect( select => {
-		const { getCurrentPostId } = select( editorStore );
-		const { getEditedEntityRecord } = select( coreStore );
+	const { updateBlockAttributes } = useDispatch( blockEditorStore );
 
-		const postId = getCurrentPostId();
-		const post = postId ? getEditedEntityRecord( 'postType', FORM_POST_TYPE, postId ) : null;
+	const { currentPostTitle, metadata } = useSelect(
+		select => {
+			const { getCurrentPostId } = select( editorStore );
+			const { getEditedEntityRecord } = select( coreStore );
+			const { getBlockAttributes } = select( blockEditorStore );
 
-		return {
-			currentPostTitle: ( post as { title?: string } )?.title || '',
-		};
-	}, [] );
+			const postId = getCurrentPostId();
+			const post = postId ? getEditedEntityRecord( 'postType', FORM_POST_TYPE, postId ) : null;
+			const blockAttributes = getBlockAttributes( clientId );
+
+			return {
+				currentPostTitle: ( post as { title?: string } )?.title || '',
+				metadata: blockAttributes?.metadata || {},
+			};
+		},
+		[ clientId ]
+	);
 
 	// Use ref to store the callback so the command loader always has access to latest state
 	const openRenameModalRef = useRef< () => void >( () => {} );
@@ -32,6 +45,18 @@ export default function FormCommands() {
 	const handleClose = () => {
 		setIsRenameModalOpen( false );
 	};
+
+	const handleSave = useCallback(
+		( title: string ) => {
+			updateBlockAttributes( clientId, {
+				metadata: {
+					...metadata,
+					name: title,
+				},
+			} );
+		},
+		[ clientId, metadata, updateBlockAttributes ]
+	);
 
 	// Command loader hook - defined as a proper hook function
 	function useRenameFormCommandLoader() {
@@ -75,6 +100,7 @@ export default function FormCommands() {
 		<FormNameModal
 			isOpen={ isRenameModalOpen }
 			onClose={ handleClose }
+			onSave={ handleSave }
 			initialTitle={ currentPostTitle }
 			modalTitle={ __( 'Rename Form', 'jetpack-forms' ) }
 			cancelLabel={ __( 'Cancel', 'jetpack-forms' ) }

--- a/projects/packages/forms/src/blocks/contact-form/components/form-commands.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/components/form-commands.tsx
@@ -3,7 +3,7 @@ import { useCommandLoader } from '@wordpress/commands';
 import { store as coreStore } from '@wordpress/core-data';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
-import { useState, useMemo, useRef, useCallback } from '@wordpress/element';
+import { useState, useCallback, useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { pencil } from '@wordpress/icons';
 import { FORM_POST_TYPE } from '../../shared/util/constants.js';
@@ -12,6 +12,33 @@ import FormNameModal from './form-name-modal.tsx';
 type FormCommandsProps = {
 	clientId: string;
 };
+
+// Factory function that creates the command loader hook
+const getRenameFormCommandLoader = ( openModalRef: React.RefObject< () => void > ) =>
+	function useRenameFormCommandLoader() {
+		const { postType } = useSelect( select => {
+			const { getCurrentPostType } = select( editorStore );
+			return {
+				postType: getCurrentPostType(),
+			};
+		}, [] );
+
+		const commands = [];
+
+		if ( postType === FORM_POST_TYPE ) {
+			commands.push( {
+				name: 'jetpack-forms/rename-form',
+				label: __( 'Rename form', 'jetpack-forms' ),
+				icon: pencil,
+				callback: ( { close }: { close: () => void } ) => {
+					openModalRef.current?.();
+					close();
+				},
+			} );
+		}
+
+		return { isLoading: false, commands };
+	};
 
 export default function FormCommands( { clientId }: FormCommandsProps ) {
 	const [ isRenameModalOpen, setIsRenameModalOpen ] = useState( false );
@@ -36,12 +63,6 @@ export default function FormCommands( { clientId }: FormCommandsProps ) {
 		[ clientId ]
 	);
 
-	// Use ref to store the callback so the command loader always has access to latest state
-	const openRenameModalRef = useRef< () => void >( () => {} );
-	openRenameModalRef.current = () => {
-		setIsRenameModalOpen( true );
-	};
-
 	const handleClose = () => {
 		setIsRenameModalOpen( false );
 	};
@@ -58,42 +79,15 @@ export default function FormCommands( { clientId }: FormCommandsProps ) {
 		[ clientId, metadata, updateBlockAttributes ]
 	);
 
-	// Command loader hook - defined as a proper hook function
-	function useRenameFormCommandLoader() {
-		const { isJetpackFormEditor } = useSelect( select => {
-			const { getCurrentPostType } = select( editorStore );
-			return {
-				isJetpackFormEditor: getCurrentPostType() === FORM_POST_TYPE,
-			};
-		}, [] );
-
-		const commands = useMemo( () => {
-			if ( ! isJetpackFormEditor ) {
-				return [];
-			}
-
-			return [
-				{
-					name: 'jetpack-forms/rename-form',
-					label: __( 'Rename form', 'jetpack-forms' ),
-					icon: pencil,
-					callback: ( { close }: { close: () => void } ) => {
-						openRenameModalRef.current();
-						close();
-					},
-				},
-			];
-		}, [ isJetpackFormEditor ] );
-
-		return {
-			commands,
-			isLoading: false,
-		};
-	}
+	// Use ref to store the openModal callback so the command loader always has access to latest state
+	const openModalRef = useRef( () => {
+		setIsRenameModalOpen( true );
+	} );
 
 	useCommandLoader( {
 		name: 'jetpack-forms/form-commands',
-		hook: useRenameFormCommandLoader,
+		hook: getRenameFormCommandLoader( openModalRef ),
+		context: 'block-selection-edit',
 	} );
 
 	return (

--- a/projects/packages/forms/src/blocks/contact-form/components/form-commands.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/components/form-commands.tsx
@@ -1,0 +1,141 @@
+import { useCommandLoader } from '@wordpress/commands';
+import { Button, Modal, TextControl } from '@wordpress/components';
+import { store as coreStore } from '@wordpress/core-data';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { store as editorStore } from '@wordpress/editor';
+import { useState, useCallback, useMemo, useRef } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { pencil } from '@wordpress/icons';
+import { FORM_POST_TYPE } from '../../shared/util/constants.js';
+
+export default function FormCommands() {
+	const [ isRenameModalOpen, setIsRenameModalOpen ] = useState( false );
+	const [ title, setTitle ] = useState( '' );
+	const [ isSaving, setIsSaving ] = useState( false );
+
+	const { editEntityRecord, saveEditedEntityRecord } = useDispatch( coreStore );
+
+	const { currentPostId, currentPostTitle } = useSelect( select => {
+		const { getCurrentPostId } = select( editorStore );
+		const { getEditedEntityRecord } = select( coreStore );
+
+		const postId = getCurrentPostId();
+		const post = postId ? getEditedEntityRecord( 'postType', FORM_POST_TYPE, postId ) : null;
+
+		return {
+			currentPostId: postId,
+			currentPostTitle: ( post as { title?: string } )?.title || '',
+		};
+	}, [] );
+
+	// Use ref to store the callback so the command loader always has access to latest state
+	const openRenameModalRef = useRef< () => void >( () => {} );
+	openRenameModalRef.current = () => {
+		setTitle( currentPostTitle );
+		setIsRenameModalOpen( true );
+	};
+
+	const handleClose = useCallback( () => {
+		setIsRenameModalOpen( false );
+		setTitle( '' );
+	}, [] );
+
+	const handleConfirm = useCallback( async () => {
+		setIsSaving( true );
+		const newTitle = title.trim() || __( 'Untitled Form', 'jetpack-forms' );
+
+		if ( currentPostId ) {
+			await editEntityRecord( 'postType', FORM_POST_TYPE, currentPostId, {
+				title: newTitle,
+			} );
+			await saveEditedEntityRecord( 'postType', FORM_POST_TYPE, currentPostId );
+		}
+		setIsSaving( false );
+		setIsRenameModalOpen( false );
+	}, [ title, currentPostId, editEntityRecord, saveEditedEntityRecord ] );
+
+	const onSubmitForm = useCallback(
+		( event: React.FormEvent ) => {
+			event.preventDefault();
+			if ( isSaving ) {
+				return;
+			}
+			handleConfirm();
+		},
+		[ handleConfirm, isSaving ]
+	);
+
+	// Command loader hook - defined as a proper hook function
+	function useRenameFormCommandLoader() {
+		const { isJetpackFormEditor } = useSelect( select => {
+			const { getCurrentPostType } = select( editorStore );
+			return {
+				isJetpackFormEditor: getCurrentPostType() === FORM_POST_TYPE,
+			};
+		}, [] );
+
+		const commands = useMemo( () => {
+			if ( ! isJetpackFormEditor ) {
+				return [];
+			}
+
+			return [
+				{
+					name: 'jetpack-forms/rename-form',
+					label: __( 'Rename form', 'jetpack-forms' ),
+					icon: pencil,
+					callback: ( { close }: { close: () => void } ) => {
+						openRenameModalRef.current();
+						close();
+					},
+				},
+			];
+		}, [ isJetpackFormEditor ] );
+
+		return {
+			commands,
+			isLoading: false,
+		};
+	}
+
+	useCommandLoader( {
+		name: 'jetpack-forms/form-commands',
+		hook: useRenameFormCommandLoader,
+	} );
+
+	if ( ! isRenameModalOpen ) {
+		return null;
+	}
+
+	return (
+		<Modal
+			title={ __( 'Rename Form', 'jetpack-forms' ) }
+			onRequestClose={ handleClose }
+			size="medium"
+		>
+			<form onSubmit={ onSubmitForm }>
+				<TextControl
+					label={ __( 'Name', 'jetpack-forms' ) }
+					value={ title }
+					onChange={ setTitle }
+					__next40pxDefaultSize
+				/>
+				<div
+					style={ {
+						display: 'flex',
+						justifyContent: 'flex-end',
+						gap: '8px',
+						marginTop: '16px',
+					} }
+				>
+					<Button variant="tertiary" onClick={ handleClose }>
+						{ __( 'Cancel', 'jetpack-forms' ) }
+					</Button>
+					<Button aria-disabled={ isSaving } isBusy={ isSaving } variant="primary" type="submit">
+						{ __( 'Save', 'jetpack-forms' ) }
+					</Button>
+				</div>
+			</form>
+		</Modal>
+	);
+}

--- a/projects/packages/forms/src/blocks/contact-form/components/form-commands.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/components/form-commands.tsx
@@ -1,21 +1,17 @@
 import { useCommandLoader } from '@wordpress/commands';
-import { Button, Modal, TextControl } from '@wordpress/components';
 import { store as coreStore } from '@wordpress/core-data';
-import { useDispatch, useSelect } from '@wordpress/data';
+import { useSelect } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
-import { useState, useCallback, useMemo, useRef } from '@wordpress/element';
+import { useState, useMemo, useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { pencil } from '@wordpress/icons';
 import { FORM_POST_TYPE } from '../../shared/util/constants.js';
+import FormNameModal from './form-name-modal.tsx';
 
 export default function FormCommands() {
 	const [ isRenameModalOpen, setIsRenameModalOpen ] = useState( false );
-	const [ title, setTitle ] = useState( '' );
-	const [ isSaving, setIsSaving ] = useState( false );
 
-	const { editEntityRecord, saveEditedEntityRecord } = useDispatch( coreStore );
-
-	const { currentPostId, currentPostTitle } = useSelect( select => {
+	const { currentPostTitle } = useSelect( select => {
 		const { getCurrentPostId } = select( editorStore );
 		const { getEditedEntityRecord } = select( coreStore );
 
@@ -23,7 +19,6 @@ export default function FormCommands() {
 		const post = postId ? getEditedEntityRecord( 'postType', FORM_POST_TYPE, postId ) : null;
 
 		return {
-			currentPostId: postId,
 			currentPostTitle: ( post as { title?: string } )?.title || '',
 		};
 	}, [] );
@@ -31,39 +26,12 @@ export default function FormCommands() {
 	// Use ref to store the callback so the command loader always has access to latest state
 	const openRenameModalRef = useRef< () => void >( () => {} );
 	openRenameModalRef.current = () => {
-		setTitle( currentPostTitle );
 		setIsRenameModalOpen( true );
 	};
 
-	const handleClose = useCallback( () => {
+	const handleClose = () => {
 		setIsRenameModalOpen( false );
-		setTitle( '' );
-	}, [] );
-
-	const handleConfirm = useCallback( async () => {
-		setIsSaving( true );
-		const newTitle = title.trim() || __( 'Untitled Form', 'jetpack-forms' );
-
-		if ( currentPostId ) {
-			await editEntityRecord( 'postType', FORM_POST_TYPE, currentPostId, {
-				title: newTitle,
-			} );
-			await saveEditedEntityRecord( 'postType', FORM_POST_TYPE, currentPostId );
-		}
-		setIsSaving( false );
-		setIsRenameModalOpen( false );
-	}, [ title, currentPostId, editEntityRecord, saveEditedEntityRecord ] );
-
-	const onSubmitForm = useCallback(
-		( event: React.FormEvent ) => {
-			event.preventDefault();
-			if ( isSaving ) {
-				return;
-			}
-			handleConfirm();
-		},
-		[ handleConfirm, isSaving ]
-	);
+	};
 
 	// Command loader hook - defined as a proper hook function
 	function useRenameFormCommandLoader() {
@@ -103,39 +71,14 @@ export default function FormCommands() {
 		hook: useRenameFormCommandLoader,
 	} );
 
-	if ( ! isRenameModalOpen ) {
-		return null;
-	}
-
 	return (
-		<Modal
-			title={ __( 'Rename Form', 'jetpack-forms' ) }
-			onRequestClose={ handleClose }
-			size="medium"
-		>
-			<form onSubmit={ onSubmitForm }>
-				<TextControl
-					label={ __( 'Name', 'jetpack-forms' ) }
-					value={ title }
-					onChange={ setTitle }
-					__next40pxDefaultSize
-				/>
-				<div
-					style={ {
-						display: 'flex',
-						justifyContent: 'flex-end',
-						gap: '8px',
-						marginTop: '16px',
-					} }
-				>
-					<Button variant="tertiary" onClick={ handleClose }>
-						{ __( 'Cancel', 'jetpack-forms' ) }
-					</Button>
-					<Button aria-disabled={ isSaving } isBusy={ isSaving } variant="primary" type="submit">
-						{ __( 'Save', 'jetpack-forms' ) }
-					</Button>
-				</div>
-			</form>
-		</Modal>
+		<FormNameModal
+			isOpen={ isRenameModalOpen }
+			onClose={ handleClose }
+			initialTitle={ currentPostTitle }
+			modalTitle={ __( 'Rename Form', 'jetpack-forms' ) }
+			cancelLabel={ __( 'Cancel', 'jetpack-forms' ) }
+			submitLabel={ __( 'Save', 'jetpack-forms' ) }
+		/>
 	);
 }

--- a/projects/packages/forms/src/blocks/contact-form/components/form-commands.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/components/form-commands.tsx
@@ -1,12 +1,11 @@
-import { store as blockEditorStore } from '@wordpress/block-editor';
 import { useCommandLoader } from '@wordpress/commands';
-import { store as coreStore } from '@wordpress/core-data';
-import { useDispatch, useSelect } from '@wordpress/data';
+import { useSelect } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
-import { useState, useCallback, useRef } from '@wordpress/element';
+import { useState, useCallback, useRef, useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { pencil } from '@wordpress/icons';
 import { FORM_POST_TYPE } from '../../shared/util/constants.js';
+import { useFormMetadata } from '../hooks/use-form-metadata.ts';
 import FormNameModal from './form-name-modal.tsx';
 
 type FormCommandsProps = {
@@ -43,40 +42,17 @@ const getRenameFormCommandLoader = ( openModalRef: React.RefObject< () => void >
 export default function FormCommands( { clientId }: FormCommandsProps ) {
 	const [ isRenameModalOpen, setIsRenameModalOpen ] = useState( false );
 
-	const { updateBlockAttributes } = useDispatch( blockEditorStore );
+	const { currentPostTitle, updateMetadataName } = useFormMetadata( clientId );
 
-	const { currentPostTitle, metadata } = useSelect(
-		select => {
-			const { getCurrentPostId } = select( editorStore );
-			const { getEditedEntityRecord } = select( coreStore );
-			const { getBlockAttributes } = select( blockEditorStore );
-
-			const postId = getCurrentPostId();
-			const post = postId ? getEditedEntityRecord( 'postType', FORM_POST_TYPE, postId ) : null;
-			const blockAttributes = getBlockAttributes( clientId );
-
-			return {
-				currentPostTitle: ( post as { title?: string } )?.title || '',
-				metadata: blockAttributes?.metadata || {},
-			};
-		},
-		[ clientId ]
-	);
-
-	const handleClose = () => {
+	const handleClose = useCallback( () => {
 		setIsRenameModalOpen( false );
-	};
+	}, [] );
 
 	const handleSave = useCallback(
 		( title: string ) => {
-			updateBlockAttributes( clientId, {
-				metadata: {
-					...metadata,
-					name: title,
-				},
-			} );
+			updateMetadataName( title );
 		},
-		[ clientId, metadata, updateBlockAttributes ]
+		[ updateMetadataName ]
 	);
 
 	// Use ref to store the openModal callback so the command loader always has access to latest state
@@ -84,9 +60,15 @@ export default function FormCommands( { clientId }: FormCommandsProps ) {
 		setIsRenameModalOpen( true );
 	} );
 
+	// Memoize the hook creation to prevent unnecessary re-renders
+	const commandLoaderHook = useMemo(
+		() => getRenameFormCommandLoader( openModalRef ),
+		[] // openModalRef is stable (useRef)
+	);
+
 	useCommandLoader( {
 		name: 'jetpack-forms/form-commands',
-		hook: getRenameFormCommandLoader( openModalRef ),
+		hook: commandLoaderHook,
 		context: 'block-selection-edit',
 	} );
 

--- a/projects/packages/forms/src/blocks/contact-form/components/form-name-modal.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/components/form-name-modal.tsx
@@ -9,6 +9,7 @@ import { FORM_POST_TYPE } from '../../shared/util/constants.js';
 type FormNameModalProps = {
 	isOpen: boolean;
 	onClose: () => void;
+	onSave?: ( title: string ) => void;
 	initialTitle?: string;
 	modalTitle: string;
 	cancelLabel: string;
@@ -18,6 +19,7 @@ type FormNameModalProps = {
 export default function FormNameModal( {
 	isOpen,
 	onClose,
+	onSave,
 	initialTitle = '',
 	modalTitle,
 	cancelLabel,
@@ -57,9 +59,11 @@ export default function FormNameModal( {
 			} );
 			await saveEditedEntityRecord( 'postType', FORM_POST_TYPE, currentPostId );
 		}
+
+		onSave?.( newTitle );
 		setIsSaving( false );
 		onClose();
-	}, [ title, currentPostId, editEntityRecord, saveEditedEntityRecord, onClose ] );
+	}, [ title, currentPostId, editEntityRecord, saveEditedEntityRecord, onSave, onClose ] );
 
 	const onSubmitForm = useCallback(
 		( event: React.FormEvent ) => {

--- a/projects/packages/forms/src/blocks/contact-form/components/form-name-modal.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/components/form-name-modal.tsx
@@ -1,0 +1,106 @@
+import { Button, Modal, TextControl } from '@wordpress/components';
+import { store as coreStore } from '@wordpress/core-data';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { store as editorStore } from '@wordpress/editor';
+import { useState, useCallback, useEffect } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { FORM_POST_TYPE } from '../../shared/util/constants.js';
+
+type FormNameModalProps = {
+	isOpen: boolean;
+	onClose: () => void;
+	initialTitle?: string;
+	modalTitle: string;
+	cancelLabel: string;
+	submitLabel: string;
+};
+
+export default function FormNameModal( {
+	isOpen,
+	onClose,
+	initialTitle = '',
+	modalTitle,
+	cancelLabel,
+	submitLabel,
+}: FormNameModalProps ) {
+	const [ title, setTitle ] = useState( initialTitle );
+	const [ isSaving, setIsSaving ] = useState( false );
+
+	const { editEntityRecord, saveEditedEntityRecord } = useDispatch( coreStore );
+
+	const { currentPostId } = useSelect( select => {
+		const { getCurrentPostId } = select( editorStore );
+		return {
+			currentPostId: getCurrentPostId(),
+		};
+	}, [] );
+
+	// Reset title when modal opens with new initialTitle
+	useEffect( () => {
+		if ( isOpen ) {
+			setTitle( initialTitle );
+		}
+	}, [ isOpen, initialTitle ] );
+
+	const handleClose = useCallback( () => {
+		setTitle( '' );
+		onClose();
+	}, [ onClose ] );
+
+	const handleConfirm = useCallback( async () => {
+		setIsSaving( true );
+		const newTitle = title.trim() || __( 'Untitled Form', 'jetpack-forms' );
+
+		if ( currentPostId ) {
+			await editEntityRecord( 'postType', FORM_POST_TYPE, currentPostId, {
+				title: newTitle,
+			} );
+			await saveEditedEntityRecord( 'postType', FORM_POST_TYPE, currentPostId );
+		}
+		setIsSaving( false );
+		onClose();
+	}, [ title, currentPostId, editEntityRecord, saveEditedEntityRecord, onClose ] );
+
+	const onSubmitForm = useCallback(
+		( event: React.FormEvent ) => {
+			event.preventDefault();
+			if ( isSaving ) {
+				return;
+			}
+			handleConfirm();
+		},
+		[ handleConfirm, isSaving ]
+	);
+
+	if ( ! isOpen ) {
+		return null;
+	}
+
+	return (
+		<Modal title={ modalTitle } onRequestClose={ handleClose } size="medium">
+			<form onSubmit={ onSubmitForm }>
+				<TextControl
+					label={ __( 'Name', 'jetpack-forms' ) }
+					value={ title }
+					onChange={ setTitle }
+					__next40pxDefaultSize
+				/>
+				<div
+					style={ {
+						display: 'flex',
+						justifyContent: 'flex-end',
+						gap: '8px',
+						marginTop: '16px',
+					} }
+				>
+					<Button variant="tertiary" onClick={ handleClose }>
+						{ cancelLabel }
+					</Button>
+					<Button aria-disabled={ isSaving } isBusy={ isSaving } variant="primary" type="submit">
+						{ submitLabel }
+					</Button>
+				</div>
+			</form>
+		</Modal>
+	);
+}

--- a/projects/packages/forms/src/blocks/contact-form/components/form-name-modal.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/components/form-name-modal.tsx
@@ -4,6 +4,7 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
 import { useState, useCallback, useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { store as noticesStore } from '@wordpress/notices';
 import { FORM_POST_TYPE } from '../../shared/util/constants.js';
 
 type FormNameModalProps = {
@@ -29,6 +30,7 @@ export default function FormNameModal( {
 	const [ isSaving, setIsSaving ] = useState( false );
 
 	const { editEntityRecord, saveEditedEntityRecord } = useDispatch( coreStore );
+	const { createErrorNotice } = useDispatch( noticesStore );
 
 	const { currentPostId } = useSelect( select => {
 		const { getCurrentPostId } = select( editorStore );
@@ -53,17 +55,31 @@ export default function FormNameModal( {
 		setIsSaving( true );
 		const newTitle = title.trim() || __( 'Untitled Form', 'jetpack-forms' );
 
-		if ( currentPostId ) {
-			await editEntityRecord( 'postType', FORM_POST_TYPE, currentPostId, {
-				title: newTitle,
+		try {
+			if ( currentPostId ) {
+				await editEntityRecord( 'postType', FORM_POST_TYPE, currentPostId, {
+					title: newTitle,
+				} );
+				await saveEditedEntityRecord( 'postType', FORM_POST_TYPE, currentPostId );
+			}
+			onSave?.( newTitle );
+			onClose();
+		} catch {
+			createErrorNotice( __( 'Failed to save form name.', 'jetpack-forms' ), {
+				type: 'snackbar',
 			} );
-			await saveEditedEntityRecord( 'postType', FORM_POST_TYPE, currentPostId );
+		} finally {
+			setIsSaving( false );
 		}
-
-		onSave?.( newTitle );
-		setIsSaving( false );
-		onClose();
-	}, [ title, currentPostId, editEntityRecord, saveEditedEntityRecord, onSave, onClose ] );
+	}, [
+		title,
+		currentPostId,
+		editEntityRecord,
+		saveEditedEntityRecord,
+		onSave,
+		onClose,
+		createErrorNotice,
+	] );
 
 	const onSubmitForm = useCallback(
 		( event: React.FormEvent ) => {
@@ -87,6 +103,7 @@ export default function FormNameModal( {
 					label={ __( 'Name', 'jetpack-forms' ) }
 					value={ title }
 					onChange={ setTitle }
+					maxLength={ 200 }
 					__next40pxDefaultSize
 				/>
 				<div

--- a/projects/packages/forms/src/blocks/contact-form/components/form-title-modal.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/components/form-title-modal.tsx
@@ -1,10 +1,10 @@
-import { Button, Modal, TextControl } from '@wordpress/components';
 import { store as coreStore } from '@wordpress/core-data';
-import { useDispatch, useSelect } from '@wordpress/data';
+import { useSelect } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
 import { useState, useCallback, useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { FORM_POST_TYPE } from '../../shared/util/constants.js';
+import FormNameModal from './form-name-modal.tsx';
 
 type FormTitleModalProps = {
 	hasInnerBlocks: boolean;
@@ -13,12 +13,8 @@ type FormTitleModalProps = {
 export default function FormTitleModal( { hasInnerBlocks }: FormTitleModalProps ) {
 	const [ isOpen, setIsOpen ] = useState( false );
 	const [ hasShown, setHasShown ] = useState( false );
-	const [ title, setTitle ] = useState( '' );
-	const [ isSaving, setIsSaving ] = useState( false );
 
-	const { editEntityRecord, saveEditedEntityRecord } = useDispatch( coreStore );
-
-	const { currentPostId, currentPostTitle } = useSelect( select => {
+	const { currentPostTitle } = useSelect( select => {
 		const { getCurrentPostId } = select( editorStore );
 		const { getEditedEntityRecord } = select( coreStore );
 
@@ -26,7 +22,6 @@ export default function FormTitleModal( { hasInnerBlocks }: FormTitleModalProps 
 		const post = postId ? getEditedEntityRecord( 'postType', FORM_POST_TYPE, postId ) : null;
 
 		return {
-			currentPostId: postId,
 			currentPostTitle: ( post as { title?: string } )?.title || '',
 		};
 	}, [] );
@@ -48,75 +43,14 @@ export default function FormTitleModal( { hasInnerBlocks }: FormTitleModalProps 
 		setIsOpen( false );
 	}, [] );
 
-	const handleConfirm = useCallback( async () => {
-		setIsSaving( true );
-		const newTitle = title.trim() || __( 'Untitled Form', 'jetpack-forms' );
-
-		if ( currentPostId ) {
-			await editEntityRecord( 'postType', FORM_POST_TYPE, currentPostId, {
-				title: newTitle,
-			} );
-			await saveEditedEntityRecord( 'postType', FORM_POST_TYPE, currentPostId );
-		}
-		setIsSaving( false );
-		setIsOpen( false );
-	}, [ title, currentPostId, editEntityRecord, saveEditedEntityRecord ] );
-
-	const onSubmitForm = useCallback(
-		( event: React.FormEvent ) => {
-			event.preventDefault();
-			if ( isSaving ) {
-				return;
-			}
-			handleConfirm();
-		},
-		[ handleConfirm, isSaving ]
-	);
-
-	const handleKeyDown = useCallback(
-		( event: React.KeyboardEvent ) => {
-			if ( event.key === 'Enter' ) {
-				event.preventDefault();
-				handleConfirm();
-			}
-		},
-		[ handleConfirm ]
-	);
-
-	if ( ! isOpen ) {
-		return null;
-	}
-
 	return (
-		<Modal
-			title={ __( 'Create Form', 'jetpack-forms' ) }
-			onRequestClose={ handleClose }
-			size="medium"
-		>
-			<form onSubmit={ onSubmitForm }>
-				<TextControl
-					label={ __( 'Name', 'jetpack-forms' ) }
-					value={ title }
-					onChange={ setTitle }
-					onKeyDown={ handleKeyDown }
-					__next40pxDefaultSize
-				/>
-				<div
-					style={ {
-						display: 'flex',
-						justifyContent: 'flex-end',
-						gap: '8px',
-						marginTop: '16px',
-					} }
-				>
-					<Button variant="tertiary" onClick={ handleClose }>
-						{ __( 'Skip', 'jetpack-forms' ) }
-					</Button>
-					<Button aria-disabled={ isSaving } isBusy={ isSaving } variant="primary" type="submit">
-						{ __( 'Create', 'jetpack-forms' ) }
-					</Button>
-				</div>
-			</form>
-		</Modal>
+		<FormNameModal
+			isOpen={ isOpen }
+			onClose={ handleClose }
+			initialTitle=""
+			modalTitle={ __( 'Create Form', 'jetpack-forms' ) }
+			cancelLabel={ __( 'Skip', 'jetpack-forms' ) }
+			submitLabel={ __( 'Create', 'jetpack-forms' ) }
+		/>
 	);
 }

--- a/projects/packages/forms/src/blocks/contact-form/components/form-title-modal.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/components/form-title-modal.tsx
@@ -1,0 +1,122 @@
+import { Button, Modal, TextControl } from '@wordpress/components';
+import { store as coreStore } from '@wordpress/core-data';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { store as editorStore } from '@wordpress/editor';
+import { useState, useCallback, useEffect } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { FORM_POST_TYPE } from '../../shared/util/constants.js';
+
+type FormTitleModalProps = {
+	hasInnerBlocks: boolean;
+};
+
+export default function FormTitleModal( { hasInnerBlocks }: FormTitleModalProps ) {
+	const [ isOpen, setIsOpen ] = useState( false );
+	const [ hasShown, setHasShown ] = useState( false );
+	const [ title, setTitle ] = useState( '' );
+	const [ isSaving, setIsSaving ] = useState( false );
+
+	const { editEntityRecord, saveEditedEntityRecord } = useDispatch( coreStore );
+
+	const { currentPostId, currentPostTitle } = useSelect( select => {
+		const { getCurrentPostId } = select( editorStore );
+		const { getEditedEntityRecord } = select( coreStore );
+
+		const postId = getCurrentPostId();
+		const post = postId ? getEditedEntityRecord( 'postType', FORM_POST_TYPE, postId ) : null;
+
+		return {
+			currentPostId: postId,
+			currentPostTitle: ( post as { title?: string } )?.title || '',
+		};
+	}, [] );
+
+	const isNewForm =
+		! currentPostTitle ||
+		currentPostTitle === __( 'Untitled Form', 'jetpack-forms' ) ||
+		currentPostTitle === 'Untitled Form';
+
+	// Show modal on first render if this is a new placeholder form in the form editor
+	useEffect( () => {
+		if ( ! hasInnerBlocks && isNewForm && ! hasShown ) {
+			setIsOpen( true );
+			setHasShown( true );
+		}
+	}, [ hasInnerBlocks, isNewForm, hasShown ] );
+
+	const handleClose = useCallback( () => {
+		setIsOpen( false );
+	}, [] );
+
+	const handleConfirm = useCallback( async () => {
+		setIsSaving( true );
+		const newTitle = title.trim() || __( 'Untitled Form', 'jetpack-forms' );
+
+		if ( currentPostId ) {
+			await editEntityRecord( 'postType', FORM_POST_TYPE, currentPostId, {
+				title: newTitle,
+			} );
+			await saveEditedEntityRecord( 'postType', FORM_POST_TYPE, currentPostId );
+		}
+		setIsSaving( false );
+		setIsOpen( false );
+	}, [ title, currentPostId, editEntityRecord, saveEditedEntityRecord ] );
+
+	const onSubmitForm = useCallback(
+		( event: React.FormEvent ) => {
+			event.preventDefault();
+			if ( isSaving ) {
+				return;
+			}
+			handleConfirm();
+		},
+		[ handleConfirm, isSaving ]
+	);
+
+	const handleKeyDown = useCallback(
+		( event: React.KeyboardEvent ) => {
+			if ( event.key === 'Enter' ) {
+				event.preventDefault();
+				handleConfirm();
+			}
+		},
+		[ handleConfirm ]
+	);
+
+	if ( ! isOpen ) {
+		return null;
+	}
+
+	return (
+		<Modal
+			title={ __( 'Create Form', 'jetpack-forms' ) }
+			onRequestClose={ handleClose }
+			size="medium"
+		>
+			<form onSubmit={ onSubmitForm }>
+				<TextControl
+					label={ __( 'Name', 'jetpack-forms' ) }
+					value={ title }
+					onChange={ setTitle }
+					onKeyDown={ handleKeyDown }
+					__next40pxDefaultSize
+				/>
+				<div
+					style={ {
+						display: 'flex',
+						justifyContent: 'flex-end',
+						gap: '8px',
+						marginTop: '16px',
+					} }
+				>
+					<Button variant="tertiary" onClick={ handleClose }>
+						{ __( 'Skip', 'jetpack-forms' ) }
+					</Button>
+					<Button aria-disabled={ isSaving } isBusy={ isSaving } variant="primary" type="submit">
+						{ __( 'Create', 'jetpack-forms' ) }
+					</Button>
+				</div>
+			</form>
+		</Modal>
+	);
+}

--- a/projects/packages/forms/src/blocks/contact-form/components/form-title-modal.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/components/form-title-modal.tsx
@@ -1,10 +1,6 @@
-import { store as blockEditorStore } from '@wordpress/block-editor';
-import { store as coreStore } from '@wordpress/core-data';
-import { useDispatch, useSelect } from '@wordpress/data';
-import { store as editorStore } from '@wordpress/editor';
 import { useState, useCallback, useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { FORM_POST_TYPE } from '../../shared/util/constants.js';
+import { useFormMetadata } from '../hooks/use-form-metadata.ts';
 import FormNameModal from './form-name-modal.tsx';
 
 type FormTitleModalProps = {
@@ -16,25 +12,7 @@ export default function FormTitleModal( { hasInnerBlocks, clientId }: FormTitleM
 	const [ isOpen, setIsOpen ] = useState( false );
 	const [ hasShown, setHasShown ] = useState( false );
 
-	const { updateBlockAttributes } = useDispatch( blockEditorStore );
-
-	const { currentPostTitle, metadata } = useSelect(
-		select => {
-			const { getCurrentPostId } = select( editorStore );
-			const { getEditedEntityRecord } = select( coreStore );
-			const { getBlockAttributes } = select( blockEditorStore );
-
-			const postId = getCurrentPostId();
-			const post = postId ? getEditedEntityRecord( 'postType', FORM_POST_TYPE, postId ) : null;
-			const blockAttributes = getBlockAttributes( clientId );
-
-			return {
-				currentPostTitle: ( post as { title?: string } )?.title || '',
-				metadata: blockAttributes?.metadata || {},
-			};
-		},
-		[ clientId ]
-	);
+	const { currentPostTitle, updateMetadataName } = useFormMetadata( clientId );
 
 	const isNewForm =
 		! currentPostTitle ||
@@ -55,14 +33,9 @@ export default function FormTitleModal( { hasInnerBlocks, clientId }: FormTitleM
 
 	const handleSave = useCallback(
 		( title: string ) => {
-			updateBlockAttributes( clientId, {
-				metadata: {
-					...metadata,
-					name: title,
-				},
-			} );
+			updateMetadataName( title );
 		},
-		[ clientId, metadata, updateBlockAttributes ]
+		[ updateMetadataName ]
 	);
 
 	return (

--- a/projects/packages/forms/src/blocks/contact-form/components/form-title-modal.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/components/form-title-modal.tsx
@@ -1,5 +1,6 @@
+import { store as blockEditorStore } from '@wordpress/block-editor';
 import { store as coreStore } from '@wordpress/core-data';
-import { useSelect } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
 import { useState, useCallback, useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -8,23 +9,32 @@ import FormNameModal from './form-name-modal.tsx';
 
 type FormTitleModalProps = {
 	hasInnerBlocks: boolean;
+	clientId: string;
 };
 
-export default function FormTitleModal( { hasInnerBlocks }: FormTitleModalProps ) {
+export default function FormTitleModal( { hasInnerBlocks, clientId }: FormTitleModalProps ) {
 	const [ isOpen, setIsOpen ] = useState( false );
 	const [ hasShown, setHasShown ] = useState( false );
 
-	const { currentPostTitle } = useSelect( select => {
-		const { getCurrentPostId } = select( editorStore );
-		const { getEditedEntityRecord } = select( coreStore );
+	const { updateBlockAttributes } = useDispatch( blockEditorStore );
 
-		const postId = getCurrentPostId();
-		const post = postId ? getEditedEntityRecord( 'postType', FORM_POST_TYPE, postId ) : null;
+	const { currentPostTitle, metadata } = useSelect(
+		select => {
+			const { getCurrentPostId } = select( editorStore );
+			const { getEditedEntityRecord } = select( coreStore );
+			const { getBlockAttributes } = select( blockEditorStore );
 
-		return {
-			currentPostTitle: ( post as { title?: string } )?.title || '',
-		};
-	}, [] );
+			const postId = getCurrentPostId();
+			const post = postId ? getEditedEntityRecord( 'postType', FORM_POST_TYPE, postId ) : null;
+			const blockAttributes = getBlockAttributes( clientId );
+
+			return {
+				currentPostTitle: ( post as { title?: string } )?.title || '',
+				metadata: blockAttributes?.metadata || {},
+			};
+		},
+		[ clientId ]
+	);
 
 	const isNewForm =
 		! currentPostTitle ||
@@ -43,10 +53,23 @@ export default function FormTitleModal( { hasInnerBlocks }: FormTitleModalProps 
 		setIsOpen( false );
 	}, [] );
 
+	const handleSave = useCallback(
+		( title: string ) => {
+			updateBlockAttributes( clientId, {
+				metadata: {
+					...metadata,
+					name: title,
+				},
+			} );
+		},
+		[ clientId, metadata, updateBlockAttributes ]
+	);
+
 	return (
 		<FormNameModal
 			isOpen={ isOpen }
 			onClose={ handleClose }
+			onSave={ handleSave }
 			initialTitle=""
 			modalTitle={ __( 'Create Form', 'jetpack-forms' ) }
 			cancelLabel={ __( 'Skip', 'jetpack-forms' ) }

--- a/projects/packages/forms/src/blocks/contact-form/edit.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/edit.tsx
@@ -1123,8 +1123,8 @@ function JetpackContactFormEdit( {
 				<div { ...blockProps }>
 					{ isCentralFormManagementEnabled && isJetpackFormEditor && (
 						<>
-							<FormTitleModal hasInnerBlocks={ hasAnyInnerBlocks } />
-							<FormCommands />
+							<FormTitleModal hasInnerBlocks={ hasAnyInnerBlocks } clientId={ clientId } />
+							<FormCommands clientId={ clientId } />
 						</>
 					) }
 					{ ref && (

--- a/projects/packages/forms/src/blocks/contact-form/edit.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/edit.tsx
@@ -56,6 +56,7 @@ import { ContactFormPlaceholder } from './components/jetpack-contact-form-placeh
 import ContactFormSkeletonLoader from './components/jetpack-contact-form-skeleton-loader.js';
 import NotificationsSettings from './components/notifications-settings.js';
 import WebhooksSettings from './components/webhooks-settings.js';
+import { useSyncFormName } from './hooks/use-sync-form-name.ts';
 import { useSyncedFormAutoSave } from './hooks/use-synced-form-auto-save.ts';
 import { useSyncedFormLoader } from './hooks/use-synced-form-loader.ts';
 import { useSyncedForm } from './hooks/use-synced-form.ts';
@@ -209,6 +210,9 @@ function JetpackContactFormEdit( {
 		syncedAttributes: syncedFormAttributes,
 		syncedInnerBlocks: syncedFormBlocks,
 	} = useSyncedForm( ref );
+
+	// Sync block metadata.name to form post title when changed via List View (only for synced forms)
+	useSyncFormName( clientId, ref, syncedForm?.title );
 
 	// Backward compatibility for the deprecated customThankyou attribute.
 	// Older forms will have a customThankyou attribute set, but not a confirmationType attribute

--- a/projects/packages/forms/src/blocks/contact-form/edit.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/edit.tsx
@@ -50,6 +50,7 @@ import { CORE_BLOCKS, FORM_POST_TYPE } from '../shared/util/constants.js';
 import { childBlocks } from './child-blocks.js';
 import { ConvertFormToolbar } from './components/convert-form-toolbar.tsx';
 import FormStatusNotice from './components/form-status-notice.tsx';
+import FormTitleModal from './components/form-title-modal.tsx';
 import { ContactFormPlaceholder } from './components/jetpack-contact-form-placeholder.js';
 import ContactFormSkeletonLoader from './components/jetpack-contact-form-skeleton-loader.js';
 import NotificationsSettings from './components/notifications-settings.js';
@@ -1119,6 +1120,9 @@ function JetpackContactFormEdit( {
 		<SyncedAttributeProvider>
 			<ThemeProvider targetDom={ wrapperRef.current }>
 				<div { ...blockProps }>
+					{ isCentralFormManagementEnabled && isJetpackFormEditor && (
+						<FormTitleModal hasInnerBlocks={ hasAnyInnerBlocks } />
+					) }
 					{ ref && (
 						<FormStatusNotice
 							syncedForm={ syncedForm }

--- a/projects/packages/forms/src/blocks/contact-form/edit.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/edit.tsx
@@ -49,6 +49,7 @@ import { SyncedAttributeProvider } from '../shared/hooks/use-synced-attributes.j
 import { CORE_BLOCKS, FORM_POST_TYPE } from '../shared/util/constants.js';
 import { childBlocks } from './child-blocks.js';
 import { ConvertFormToolbar } from './components/convert-form-toolbar.tsx';
+import FormCommands from './components/form-commands.tsx';
 import FormStatusNotice from './components/form-status-notice.tsx';
 import FormTitleModal from './components/form-title-modal.tsx';
 import { ContactFormPlaceholder } from './components/jetpack-contact-form-placeholder.js';
@@ -1121,7 +1122,10 @@ function JetpackContactFormEdit( {
 			<ThemeProvider targetDom={ wrapperRef.current }>
 				<div { ...blockProps }>
 					{ isCentralFormManagementEnabled && isJetpackFormEditor && (
-						<FormTitleModal hasInnerBlocks={ hasAnyInnerBlocks } />
+						<>
+							<FormTitleModal hasInnerBlocks={ hasAnyInnerBlocks } />
+							<FormCommands />
+						</>
 					) }
 					{ ref && (
 						<FormStatusNotice

--- a/projects/packages/forms/src/blocks/contact-form/hooks/use-form-metadata.ts
+++ b/projects/packages/forms/src/blocks/contact-form/hooks/use-form-metadata.ts
@@ -1,0 +1,49 @@
+import { store as blockEditorStore } from '@wordpress/block-editor';
+import { store as coreStore } from '@wordpress/core-data';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { store as editorStore } from '@wordpress/editor';
+import { useCallback } from '@wordpress/element';
+import { FORM_POST_TYPE } from '../../shared/util/constants.js';
+
+/**
+ * Hook that provides form metadata and utilities for updating it.
+ * Extracts shared logic from FormCommands and FormTitleModal.
+ *
+ * @param clientId - The block's client ID
+ * @return Object containing currentPostTitle, metadata, and updateMetadataName function
+ */
+export function useFormMetadata( clientId: string ) {
+	const { updateBlockAttributes } = useDispatch( blockEditorStore );
+
+	const { currentPostTitle, metadata } = useSelect(
+		select => {
+			const { getCurrentPostId } = select( editorStore );
+			const { getEditedEntityRecord } = select( coreStore );
+			const { getBlockAttributes } = select( blockEditorStore );
+
+			const postId = getCurrentPostId();
+			const post = postId ? getEditedEntityRecord( 'postType', FORM_POST_TYPE, postId ) : null;
+			const blockAttributes = getBlockAttributes( clientId );
+
+			return {
+				currentPostTitle: ( post as { title?: string } )?.title || '',
+				metadata: blockAttributes?.metadata || {},
+			};
+		},
+		[ clientId ]
+	);
+
+	const updateMetadataName = useCallback(
+		( name: string ) => {
+			updateBlockAttributes( clientId, {
+				metadata: {
+					...metadata,
+					name,
+				},
+			} );
+		},
+		[ clientId, metadata, updateBlockAttributes ]
+	);
+
+	return { currentPostTitle, metadata, updateMetadataName };
+}

--- a/projects/packages/forms/src/blocks/contact-form/hooks/use-sync-form-name.ts
+++ b/projects/packages/forms/src/blocks/contact-form/hooks/use-sync-form-name.ts
@@ -1,0 +1,71 @@
+import { store as blockEditorStore } from '@wordpress/block-editor';
+import { store as coreStore } from '@wordpress/core-data';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { useEffect, useRef } from '@wordpress/element';
+import { FORM_POST_TYPE } from '../../shared/util/constants.js';
+
+/**
+ * Hook that syncs the block's metadata.name to the form post title.
+ * When the block name is changed (e.g., via the List View), the post title is updated to match.
+ * Only applies to synced forms (forms with a ref attribute).
+ *
+ * @param clientId        - The block's client ID
+ * @param formRef         - The form's post ID (ref attribute)
+ * @param syncedFormTitle - The current synced form's title
+ */
+export function useSyncFormName(
+	clientId: string,
+	formRef: number | undefined,
+	syncedFormTitle: string | undefined
+) {
+	const { editEntityRecord } = useDispatch( coreStore );
+
+	const { metadataName, formBlock } = useSelect(
+		select => {
+			if ( ! formRef ) {
+				return {
+					metadataName: '',
+				};
+			}
+
+			const { getBlock, getBlockAttributes } = select( blockEditorStore );
+			const blockAttributes = getBlockAttributes( clientId );
+
+			return {
+				metadataName: ( blockAttributes?.metadata?.name as string ) || '',
+				formBlock: getBlock( clientId ),
+			};
+		},
+		[ clientId, formRef ]
+	);
+
+	// Track the previous metadata name to detect changes
+	const prevMetadataNameRef = useRef( metadataName );
+
+	useEffect( () => {
+		// Only sync for synced forms (forms with a ref)
+		if ( ! formRef ) {
+			return;
+		}
+
+		// Skip if metadata name hasn't changed or is empty
+		if ( ! metadataName || metadataName === prevMetadataNameRef.current ) {
+			prevMetadataNameRef.current = metadataName;
+			return;
+		}
+
+		// Skip if the post title already matches the metadata name
+		if ( metadataName === syncedFormTitle ) {
+			prevMetadataNameRef.current = metadataName;
+			return;
+		}
+
+		// Update the synced form's post title to match the metadata name
+		editEntityRecord( 'postType', FORM_POST_TYPE, formRef, {
+			title: metadataName,
+			blocks: [ formBlock ],
+		} );
+
+		prevMetadataNameRef.current = metadataName;
+	}, [ formRef, metadataName, syncedFormTitle, editEntityRecord, formBlock ] );
+}

--- a/projects/packages/forms/src/blocks/contact-form/hooks/use-sync-form-name.ts
+++ b/projects/packages/forms/src/blocks/contact-form/hooks/use-sync-form-name.ts
@@ -20,7 +20,7 @@ export function useSyncFormName(
 ) {
 	const { editEntityRecord } = useDispatch( coreStore );
 
-	const { metadataName, formBlock } = useSelect(
+	const { metadataName } = useSelect(
 		select => {
 			if ( ! formRef ) {
 				return {
@@ -28,12 +28,11 @@ export function useSyncFormName(
 				};
 			}
 
-			const { getBlock, getBlockAttributes } = select( blockEditorStore );
+			const { getBlockAttributes } = select( blockEditorStore );
 			const blockAttributes = getBlockAttributes( clientId );
 
 			return {
 				metadataName: ( blockAttributes?.metadata?.name as string ) || '',
-				formBlock: getBlock( clientId ),
 			};
 		},
 		[ clientId, formRef ]
@@ -63,9 +62,8 @@ export function useSyncFormName(
 		// Update the synced form's post title to match the metadata name
 		editEntityRecord( 'postType', FORM_POST_TYPE, formRef, {
 			title: metadataName,
-			blocks: [ formBlock ],
 		} );
 
 		prevMetadataNameRef.current = metadataName;
-	}, [ formRef, metadataName, syncedFormTitle, editEntityRecord, formBlock ] );
+	}, [ formRef, metadataName, syncedFormTitle, editEntityRecord ] );
 }

--- a/projects/packages/forms/src/blocks/contact-form/hooks/use-synced-form.ts
+++ b/projects/packages/forms/src/blocks/contact-form/hooks/use-synced-form.ts
@@ -15,6 +15,7 @@ interface JetpackForm {
 	content?: { raw: string } | undefined;
 	status: string;
 	date: string;
+	title?: string;
 }
 
 interface UseSyncedFormResult {

--- a/projects/packages/forms/src/dashboard/forms/index.tsx
+++ b/projects/packages/forms/src/dashboard/forms/index.tsx
@@ -27,7 +27,7 @@ import { EmptyWrapper } from '../components/empty-responses/index.tsx';
 import Page from '../components/page/index.tsx';
 import { NON_TRASH_FORM_STATUSES } from '../constants.ts';
 import useDeleteForm from '../hooks/use-delete-form.ts';
-import useFormsData from '../hooks/use-forms-data.ts';
+import useFormsData, { getFormsListQuery } from '../hooks/use-forms-data.ts';
 import { defaultLayouts, useView } from './views.ts';
 import './style.scss';
 import type { FormListItem } from '../hooks/use-forms-data.ts';
@@ -88,7 +88,7 @@ export default function FormsDashboardForms(): JSX.Element | null {
 	} );
 
 	const { createErrorNotice, createSuccessNotice } = useDispatch( noticesStore );
-	const { editEntityRecord, saveEditedEntityRecord } = useDispatch( coreStore );
+	const { invalidateResolution } = useDispatch( coreStore );
 
 	const [ selection, setSelection ] = useState< string[] >( [] );
 	const [ pendingPermanentDeleteCount, setPendingPermanentDeleteCount ] = useState( 0 );
@@ -153,10 +153,15 @@ export default function FormsDashboardForms(): JSX.Element | null {
 		const newTitle = renameTitle.trim() || __( 'Untitled Form', 'jetpack-forms' );
 
 		try {
-			await editEntityRecord( 'postType', 'jetpack_form', renameFormItem.id, {
-				title: newTitle,
+			await apiFetch( {
+				path: `/wp/v2/jetpack-forms/${ renameFormItem.id }`,
+				method: 'POST',
+				data: { title: newTitle },
 			} );
-			await saveEditedEntityRecord( 'postType', 'jetpack_form', renameFormItem.id );
+
+			// Invalidate the forms list cache to refresh the data
+			const query = getFormsListQuery( view.page, view.perPage, view.search, statusQuery );
+			invalidateResolution( 'getEntityRecords', [ 'postType', 'jetpack_form', query ] );
 
 			createSuccessNotice( __( 'Form renamed.', 'jetpack-forms' ), { type: 'snackbar' } );
 		} catch ( error ) {
@@ -173,8 +178,11 @@ export default function FormsDashboardForms(): JSX.Element | null {
 		renameFormItem,
 		renameTitle,
 		isRenaming,
-		editEntityRecord,
-		saveEditedEntityRecord,
+		view.page,
+		view.perPage,
+		view.search,
+		statusQuery,
+		invalidateResolution,
 		createSuccessNotice,
 		createErrorNotice,
 		closeRenameModal,

--- a/projects/packages/forms/src/dashboard/forms/index.tsx
+++ b/projects/packages/forms/src/dashboard/forms/index.tsx
@@ -3,7 +3,13 @@
  */
 import { JetpackLogo } from '@automattic/jetpack-components';
 import apiFetch from '@wordpress/api-fetch';
-import { __experimentalConfirmDialog as ConfirmDialog } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
+import {
+	__experimentalConfirmDialog as ConfirmDialog, // eslint-disable-line @wordpress/no-unsafe-wp-apis
+	Button,
+	Modal,
+	TextControl,
+} from '@wordpress/components';
+import { store as coreStore } from '@wordpress/core-data';
 import { useDispatch } from '@wordpress/data';
 import { DataViews } from '@wordpress/dataviews/wp';
 import { dateI18n, getSettings as getDateSettings } from '@wordpress/date';
@@ -81,10 +87,17 @@ export default function FormsDashboardForms(): JSX.Element | null {
 		statusQuery,
 	} );
 
-	const { createErrorNotice } = useDispatch( noticesStore );
+	const { createErrorNotice, createSuccessNotice } = useDispatch( noticesStore );
+	const { editEntityRecord, saveEditedEntityRecord } = useDispatch( coreStore );
 
 	const [ selection, setSelection ] = useState< string[] >( [] );
 	const [ pendingPermanentDeleteCount, setPendingPermanentDeleteCount ] = useState( 0 );
+
+	// Rename modal state
+	const [ isRenameModalOpen, setIsRenameModalOpen ] = useState( false );
+	const [ renameFormItem, setRenameFormItem ] = useState< FormListItem | null >( null );
+	const [ renameTitle, setRenameTitle ] = useState( '' );
+	const [ isRenaming, setIsRenaming ] = useState( false );
 
 	useEffect( () => {
 		if ( isCentralFormManagementDisabled ) {
@@ -118,6 +131,65 @@ export default function FormsDashboardForms(): JSX.Element | null {
 			setSelection( [] );
 		}
 	}, [ confirmPermanentDelete ] );
+
+	const openRenameModal = useCallback( ( item: FormListItem ) => {
+		setRenameFormItem( item );
+		setRenameTitle( item.title || '' );
+		setIsRenameModalOpen( true );
+	}, [] );
+
+	const closeRenameModal = useCallback( () => {
+		setIsRenameModalOpen( false );
+		setRenameFormItem( null );
+		setRenameTitle( '' );
+	}, [] );
+
+	const handleRename = useCallback( async () => {
+		if ( ! renameFormItem || isRenaming ) {
+			return;
+		}
+
+		setIsRenaming( true );
+		const newTitle = renameTitle.trim() || __( 'Untitled Form', 'jetpack-forms' );
+
+		try {
+			await editEntityRecord( 'postType', 'jetpack_form', renameFormItem.id, {
+				title: newTitle,
+			} );
+			await saveEditedEntityRecord( 'postType', 'jetpack_form', renameFormItem.id );
+
+			createSuccessNotice( __( 'Form renamed.', 'jetpack-forms' ), { type: 'snackbar' } );
+		} catch ( error ) {
+			createErrorNotice( __( 'Failed to rename form. Please try again.', 'jetpack-forms' ), {
+				type: 'snackbar',
+			} );
+			// eslint-disable-next-line no-console
+			console.error( 'Failed to rename form:', error );
+		} finally {
+			setIsRenaming( false );
+			closeRenameModal();
+		}
+	}, [
+		renameFormItem,
+		renameTitle,
+		isRenaming,
+		editEntityRecord,
+		saveEditedEntityRecord,
+		createSuccessNotice,
+		createErrorNotice,
+		closeRenameModal,
+	] );
+
+	const onRenameFormSubmit = useCallback(
+		( event: React.FormEvent ) => {
+			event.preventDefault();
+			if ( isRenaming ) {
+				return;
+			}
+			handleRename();
+		},
+		[ handleRename, isRenaming ]
+	);
 
 	const statusLabel = useCallback( ( status: string ) => {
 		switch ( status ) {
@@ -242,6 +314,19 @@ export default function FormsDashboardForms(): JSX.Element | null {
 					}
 				},
 			},
+			{
+				id: 'rename-form',
+				isPrimary: false,
+				label: __( 'Rename', 'jetpack-forms' ),
+				supportsBulk: false,
+				callback( items: FormListItem[] ) {
+					const [ item ] = items;
+					if ( ! item ) {
+						return;
+					}
+					openRenameModal( item );
+				},
+			},
 		];
 
 		if ( isViewingTrash ) {
@@ -303,6 +388,7 @@ export default function FormsDashboardForms(): JSX.Element | null {
 		isViewingTrash,
 		navigate,
 		onOpenPermanentDeleteConfirm,
+		openRenameModal,
 		restoreForms,
 		trashForms,
 	] );
@@ -344,6 +430,42 @@ export default function FormsDashboardForms(): JSX.Element | null {
 				actions={ headerActions }
 				hasPadding={ false }
 			>
+				{ isRenameModalOpen && (
+					<Modal
+						title={ __( 'Rename Form', 'jetpack-forms' ) }
+						onRequestClose={ closeRenameModal }
+						size="medium"
+					>
+						<form onSubmit={ onRenameFormSubmit }>
+							<TextControl
+								label={ __( 'Name', 'jetpack-forms' ) }
+								value={ renameTitle }
+								onChange={ setRenameTitle }
+								__next40pxDefaultSize
+							/>
+							<div
+								style={ {
+									display: 'flex',
+									justifyContent: 'flex-end',
+									gap: '8px',
+									marginTop: '16px',
+								} }
+							>
+								<Button variant="tertiary" onClick={ closeRenameModal }>
+									{ __( 'Cancel', 'jetpack-forms' ) }
+								</Button>
+								<Button
+									aria-disabled={ isRenaming }
+									isBusy={ isRenaming }
+									variant="primary"
+									type="submit"
+								>
+									{ __( 'Save', 'jetpack-forms' ) }
+								</Button>
+							</div>
+						</form>
+					</Modal>
+				) }
 				<DataViews
 					paginationInfo={ paginationInfo }
 					fields={ fields }


### PR DESCRIPTION
## Summary

Adds comprehensive form naming and renaming functionality for synced forms in Jetpack Forms:

- **Form title modal on creation**: When creating a new synced form, a modal prompts the user to name the form
- **Rename command in command palette**: Adds a "Rename form" command accessible via the WordPress command palette (Cmd+K) when editing a synced form
- **Rename action in forms dashboard**: Adds a "Rename" action to the forms DataViews in both standard and wp-build dashboards
- **Block metadata sync**: When a form is named/renamed, the block's `metadata.name` is also updated, which displays in the List View
- **Bidirectional sync**: If a user renames the block via List View, the form post title is synced to match

## Test plan

- [ ] Create a new synced form - verify the naming modal appears
- [ ] Skip the modal - verify form is created with "Untitled Form"
- [ ] Enter a name in the modal - verify form is created with that name
- [ ] Open command palette (Cmd+K) in form editor - verify "Rename form" command appears
- [ ] Use the rename command - verify form title and List View name both update
- [ ] Go to Forms dashboard - verify "Rename" action appears in form actions menu
- [ ] Rename a form from the dashboard - verify name updates immediately in the list
- [ ] Rename a block via List View - verify form post title syncs to match

🤖 Generated with [Claude Code](https://claude.com/claude-code)