### PR TITLE
Fix Merpress block inconsistent render on P2

### DIFF
--- a/projects/js-packages/script-data/changelog/fix-p2hq-60-jetpack-script-data-module-error
+++ b/projects/js-packages/script-data/changelog/fix-p2hq-60-jetpack-script-data-module-error
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Script Data: add defensive fallback when window.JetpackScriptData is undefined.

--- a/projects/js-packages/script-data/src/utils.ts
+++ b/projects/js-packages/script-data/src/utils.ts
@@ -1,4 +1,4 @@
-import { CurrentUserData } from './types.ts';
+import { CurrentUserData, JetpackScriptData } from './types.ts';
 
 /**
  * Get the script data from the window object.
@@ -9,7 +9,7 @@ export function getScriptData() {
 	// Provide a safe fallback if window.JetpackScriptData is not defined
 	// This can happen on public pages where no script data is provided
 	if ( typeof window === 'undefined' || typeof window.JetpackScriptData === 'undefined' ) {
-		return {};
+		return {} as JetpackScriptData;
 	}
 	return window.JetpackScriptData;
 }

--- a/projects/js-packages/script-data/src/utils.ts
+++ b/projects/js-packages/script-data/src/utils.ts
@@ -6,6 +6,11 @@ import { CurrentUserData } from './types.ts';
  * @return {import('./types').JetpackScriptData} The script data.
  */
 export function getScriptData() {
+	// Provide a safe fallback if window.JetpackScriptData is not defined
+	// This can happen on public pages where no script data is provided
+	if ( typeof window.JetpackScriptData === 'undefined' ) {
+		return {} as import('./types').JetpackScriptData;
+	}
 	return window.JetpackScriptData;
 }
 
@@ -26,7 +31,11 @@ export function getSiteData() {
  * @return {string} The admin URL.
  */
 export function getAdminUrl( path = '' ) {
-	return `${ getScriptData()?.site.admin_url }${ path }`;
+	const adminUrl = getScriptData()?.site?.admin_url;
+	if ( ! adminUrl ) {
+		return '';
+	}
+	return `${ adminUrl }${ path }`;
 }
 
 /**
@@ -98,7 +107,7 @@ export function isWoASite() {
  * @return Whether the site is a WordPress.com site.
  */
 export function isWpcomPlatformSite() {
-	return getScriptData()?.site?.is_wpcom_platform;
+	return getScriptData()?.site?.is_wpcom_platform ?? false;
 }
 
 /**
@@ -118,5 +127,5 @@ export function isJetpackSelfHostedSite() {
  * @return Whether the current user has that capability.
  */
 export function currentUserCan( capability: keyof CurrentUserData[ 'capabilities' ] ): boolean {
-	return getScriptData()?.user.current_user.capabilities[ capability ];
+	return getScriptData()?.user?.current_user?.capabilities?.[ capability ] ?? false;
 }

--- a/projects/js-packages/script-data/src/utils.ts
+++ b/projects/js-packages/script-data/src/utils.ts
@@ -9,7 +9,7 @@ export function getScriptData() {
 	// Provide a safe fallback if window.JetpackScriptData is not defined
 	// This can happen on public pages where no script data is provided
 	if ( typeof window.JetpackScriptData === 'undefined' ) {
-		return {} as import('./types').JetpackScriptData;
+		return {};
 	}
 	return window.JetpackScriptData;
 }

--- a/projects/js-packages/script-data/src/utils.ts
+++ b/projects/js-packages/script-data/src/utils.ts
@@ -8,7 +8,7 @@ import { CurrentUserData } from './types.ts';
 export function getScriptData() {
 	// Provide a safe fallback if window.JetpackScriptData is not defined
 	// This can happen on public pages where no script data is provided
-	if ( typeof window.JetpackScriptData === 'undefined' ) {
+	if ( typeof window === 'undefined' || typeof window.JetpackScriptData === 'undefined' ) {
 		return {};
 	}
 	return window.JetpackScriptData;

--- a/projects/packages/assets/changelog/fix-p2hq-60-jetpack-script-data-module-error
+++ b/projects/packages/assets/changelog/fix-p2hq-60-jetpack-script-data-module-error
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Script Data: ensure JetpackScriptData object always exists to prevent TypeError in blocks.

--- a/projects/packages/assets/src/class-script-data.php
+++ b/projects/packages/assets/src/class-script-data.php
@@ -89,28 +89,24 @@ class Script_Data {
 			? self::get_admin_script_data()
 			: self::get_public_script_data();
 
-		// Always render at least an empty object to prevent TypeError in JS code
-		// that assumes window.JetpackScriptData exists.
-		if ( empty( $script_data ) ) {
-			$script_data = array();
-		}
+		if ( ! empty( $script_data ) ) {
+			$script_data = wp_json_encode(
+				$script_data,
+				JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP | JSON_UNESCAPED_UNICODE
+			);
 
-		$script_data = wp_json_encode(
-			$script_data,
-			JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP | JSON_UNESCAPED_UNICODE
-		);
-
-		// Guard against JSON encoding failure. Fall back to an empty object string
-		// to avoid generating invalid JavaScript (e.g., "window.JetpackScriptData = ;").
-		if ( false === $script_data ) {
-			$script_data = '{}';
+			// Guard against JSON encoding failure. Fall back to an empty object string
+			// to avoid generating invalid JavaScript (e.g., "window.JetpackScriptData = ;").
+			if (false === $script_data) {
+				$script_data = '{}';
+			}
+			wp_add_inline_script(
+				self::SCRIPT_HANDLE,
+				sprintf('window.JetpackScriptData = %s;', $script_data),
+				'before'
+			);
+			Assets::enqueue_script(self::SCRIPT_HANDLE);
 		}
-		wp_add_inline_script(
-			self::SCRIPT_HANDLE,
-			sprintf( 'window.JetpackScriptData = %s;', $script_data ),
-			'before'
-		);
-		Assets::enqueue_script( self::SCRIPT_HANDLE );
 	}
 
 	/**

--- a/projects/packages/assets/src/class-script-data.php
+++ b/projects/packages/assets/src/class-script-data.php
@@ -64,7 +64,7 @@ class Script_Data {
 			'../build/jetpack-script-data.js',
 			__FILE__,
 			array(
-				'in_footer'  => false,
+				'in_footer'  => true,
 				'textdomain' => 'jetpack-assets',
 			)
 		);

--- a/projects/packages/assets/src/class-script-data.php
+++ b/projects/packages/assets/src/class-script-data.php
@@ -64,7 +64,7 @@ class Script_Data {
 			'../build/jetpack-script-data.js',
 			__FILE__,
 			array(
-				'in_footer'  => true,
+				'in_footer'  => false,
 				'textdomain' => 'jetpack-assets',
 			)
 		);
@@ -89,19 +89,23 @@ class Script_Data {
 			? self::get_admin_script_data()
 			: self::get_public_script_data();
 
-		if ( ! empty( $script_data ) ) {
-			$script_data = wp_json_encode(
-				$script_data,
-				JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP | JSON_UNESCAPED_UNICODE
-			);
-
-			wp_add_inline_script(
-				self::SCRIPT_HANDLE,
-				sprintf( 'window.JetpackScriptData = %s;', $script_data ),
-				'before'
-			);
-			Assets::enqueue_script( self::SCRIPT_HANDLE );
+		// Always render at least an empty object to prevent TypeError in JS code
+		// that assumes window.JetpackScriptData exists.
+		if ( empty( $script_data ) ) {
+			$script_data = array();
 		}
+
+		$script_data = wp_json_encode(
+			$script_data,
+			JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP | JSON_UNESCAPED_UNICODE
+		);
+
+		wp_add_inline_script(
+			self::SCRIPT_HANDLE,
+			sprintf( 'window.JetpackScriptData = %s;', $script_data ),
+			'before'
+		);
+		Assets::enqueue_script( self::SCRIPT_HANDLE );
 	}
 
 	/**

--- a/projects/packages/assets/src/class-script-data.php
+++ b/projects/packages/assets/src/class-script-data.php
@@ -100,6 +100,11 @@ class Script_Data {
 			JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP | JSON_UNESCAPED_UNICODE
 		);
 
+		// Guard against JSON encoding failure. Fall back to an empty object string
+		// to avoid generating invalid JavaScript (e.g., "window.JetpackScriptData = ;").
+		if ( false === $script_data ) {
+			$script_data = '{}';
+		}
 		wp_add_inline_script(
 			self::SCRIPT_HANDLE,
 			sprintf( 'window.JetpackScriptData = %s;', $script_data ),

--- a/projects/packages/assets/src/class-script-data.php
+++ b/projects/packages/assets/src/class-script-data.php
@@ -97,15 +97,15 @@ class Script_Data {
 
 			// Guard against JSON encoding failure. Fall back to an empty object string
 			// to avoid generating invalid JavaScript (e.g., "window.JetpackScriptData = ;").
-			if (false === $script_data) {
+			if ( false === $script_data ) {
 				$script_data = '{}';
 			}
 			wp_add_inline_script(
 				self::SCRIPT_HANDLE,
-				sprintf('window.JetpackScriptData = %s;', $script_data),
+				sprintf( 'window.JetpackScriptData = %s;', $script_data ),
 				'before'
 			);
-			Assets::enqueue_script(self::SCRIPT_HANDLE);
+			Assets::enqueue_script( self::SCRIPT_HANDLE );
 		}
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://linear.app/a8c/issue/P2HQ-60/merpress-block-inconsistent-render-on-p2

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Prevent error that would block other blocks to render

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

