### PR TITLE
Restore Jetpack logo in AI pre-publish panel

### DIFF
--- a/projects/plugins/jetpack/changelog/2026-02-12-11-02-55-057124
+++ b/projects/plugins/jetpack/changelog/2026-02-12-11-02-55-057124
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+AI Assistant: restore Jetpack logo in pre-publish panel where branding is not otherwise apparent.

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/index.tsx
@@ -13,6 +13,7 @@ import {
 	PLAN_TYPE_UNLIMITED,
 	usePlanType,
 } from '@automattic/jetpack-shared-extension-utils';
+import { JetpackEditorPanelLogo } from '@automattic/jetpack-shared-extension-utils/components';
 import { PanelBody, PanelRow, BaseControl, ExternalLink, Notice } from '@wordpress/components';
 import { store as coreStore } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
@@ -241,7 +242,7 @@ export default function AiAssistantPluginSidebar() {
 				/>
 			</DocumentPanel>
 
-			<PrePublishPanel title={ title } initialOpen={ false }>
+			<PrePublishPanel title={ title } icon={ <JetpackEditorPanelLogo /> } initialOpen={ false }>
 				<>
 					{ isAITitleOptimizationAvailable && (
 						<TitleOptimization


### PR DESCRIPTION
Follow-up to #47040

## Proposed changes:
* Restore the Jetpack logo in the AI Assistant pre-publish panel. The previous PR removed it from both the Document Settings panel and the Pre-publish panel, but in the pre-publish flow other Jetpack panels (SEO, Newsletter, Share to social media) show the logo — and "Improve with AI" alone doesn't indicate it's a Jetpack feature.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
* Open the WordPress editor for any post/page
* Click "Publish" or "Update" to open the pre-publish panel
* Verify the "Improve with AI" panel shows the Jetpack logo
* Open the Page/Document Settings sidebar and verify the "Improve with AI" panel there does NOT show the Jetpack logo

| Pre-publish | Jetpack sidebar |
|--------|--------|
|<img width="646" height="966" alt="CleanShot 2026-02-12 at 12 02 26@2x" src="https://github.com/user-attachments/assets/48f5a4ff-c9d5-4519-a1fa-6bd7c84f58de" /> | <img width="704" height="1182" alt="CleanShot 2026-02-12 at 12 02 21@2x" src="https://github.com/user-attachments/assets/3a9d4ad4-bed5-4423-956c-c877881dcde4" /> | 



