### PR TITLE
Add WebP to default file extensions in webpack FileRule

### DIFF
--- a/projects/js-packages/webpack-config/README.md
+++ b/projects/js-packages/webpack-config/README.md
@@ -306,7 +306,7 @@ This is a simple [asset module](https://webpack.js.org/guides/asset-modules/) ru
 
 Options are:
 - `filename`: Output filename pattern. Default is `images/[name]-[contenthash][ext]`.
-- `extensions`: Array of extensions to handle. Default is `[ 'gif', 'jpg', 'jpeg', 'png', 'svg' ]`.
+- `extensions`: Array of extensions to handle. Default is `[ 'gif', 'jpg', 'jpeg', 'png', 'svg', 'webp' ]`.
 - `maxInlineSize`: If set to a number greater than 0, files will be inlined if they are smaller than this. Default is 0.
 
 ### Babel

--- a/projects/js-packages/webpack-config/changelog/convert-png-to-webp
+++ b/projects/js-packages/webpack-config/changelog/convert-png-to-webp
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Added WebP to default file extensions handled by FileRule.

--- a/projects/js-packages/webpack-config/src/webpack/file-rule.js
+++ b/projects/js-packages/webpack-config/src/webpack/file-rule.js
@@ -1,5 +1,5 @@
 const FileRule = ( options = {} ) => {
-	const exts = options.extensions || [ 'gif', 'jpg', 'jpeg', 'png', 'svg' ];
+	const exts = options.extensions || [ 'gif', 'jpg', 'jpeg', 'png', 'svg', 'webp' ];
 
 	let type;
 	if ( options.maxInlineSize > 0 ) {

--- a/tools/js-tools/jest/config.base.js
+++ b/tools/js-tools/jest/config.base.js
@@ -12,7 +12,7 @@ module.exports = {
 		],
 	},
 	transform: {
-		'\\.(gif|jpg|jpeg|png|svg|scss|sass|css|ttf|woff|woff2)$': path.join(
+		'\\.(gif|jpg|jpeg|png|webp|svg|scss|sass|css|ttf|woff|woff2)$': path.join(
 			__dirname,
 			'jest-extensions-asset-stub.js'
 		),

--- a/tools/js-tools/types/global.d.ts
+++ b/tools/js-tools/types/global.d.ts
@@ -6,6 +6,7 @@ declare module '*.module.scss' {
 declare module '*.gif';
 declare module '*.png';
 declare module '*.svg';
+declare module '*.webp';
 
 // Add the process declaration
 declare const process: {


### PR DESCRIPTION
Partial fix for [MONOREP-357](https://linear.app/a8c/issue/MONOREP-357/convert-vendored-package-pngs-to-webp-3-4-mb-savings)

## Proposed changes:
* Add `webp` to the default file extensions handled by the shared `FileRule` webpack configuration
* This enables webpack to process WebP images alongside the existing gif, jpg, jpeg, png, and svg formats
* Required by upcoming PRs that convert vendored package PNGs to WebP

### Details

Currently the shared `FileRule` in `projects/js-packages/webpack-config/src/webpack/file-rule.js` processes `gif`, `jpg`, `jpeg`, `png`, and `svg`. This PR adds `webp` to that list.

Without this change, webpack wouldn't know how to handle `.webp` files and builds would fail when importing them. With it, any Jetpack package/plugin that imports a `.webp` file in JS/TS will have webpack emit it to the `build/images/` output directory with a content hash filename, just like it already does for PNGs, JPGs, etc.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
1. Check out this branch
2. Place a test `.webp` image in any package that uses the shared webpack config (e.g. `projects/packages/my-jetpack/_inc/components/` or create a temporary test file)
3. Import the `.webp` file in a JS/TS module: `import myImage from './test-image.webp';`
4. Run `pnpm jetpack build packages/my-jetpack` (or whichever package you placed the image in)
5. Verify the build succeeds without errors and the `.webp` file appears in the `build/images/` output directory with a content hash in the filename (e.g. `test-image-abc123.webp`)
6. Confirm existing image formats (png, jpg, gif, svg) still build correctly — no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)