### PR TITLE
Newsletter: wrap settings page with AdminPage component

### DIFF
--- a/projects/packages/newsletter/changelog/dotcom-16044-match-headers-and-footers-with-other-jetpack-pages
+++ b/projects/packages/newsletter/changelog/dotcom-16044-match-headers-and-footers-with-other-jetpack-pages
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Settings: wrap page with AdminPage component for consistency with other Jetpack pages.

--- a/projects/packages/newsletter/src/settings/components/header.scss
+++ b/projects/packages/newsletter/src/settings/components/header.scss
@@ -1,5 +1,4 @@
 .newsletter-settings__header {
-	margin-bottom: 2em;
 
 	&-top {
 		display: flex;

--- a/projects/packages/newsletter/src/settings/index.tsx
+++ b/projects/packages/newsletter/src/settings/index.tsx
@@ -1,7 +1,13 @@
 /**
  * External dependencies
  */
-import { GlobalNotices, useGlobalNotices } from '@automattic/jetpack-components';
+import {
+	AdminPage,
+	Col,
+	Container,
+	GlobalNotices,
+	useGlobalNotices,
+} from '@automattic/jetpack-components';
 import { Notice } from '@wordpress/components';
 import { createRoot, useCallback, useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -293,19 +299,31 @@ function NewsletterSettingsApp(): JSX.Element | null {
 
 	if ( isLoading ) {
 		return (
-			<div className="newsletter-settings">
-				<p>{ __( 'Loading newsletter settings…', 'jetpack-newsletter' ) }</p>
-			</div>
+			<AdminPage moduleName="Jetpack Newsletter" header={ <Header /> }>
+				<Container horizontalSpacing={ 3 }>
+					<Col>
+						<div className="newsletter-settings">
+							<p>{ __( 'Loading newsletter settings…', 'jetpack-newsletter' ) }</p>
+						</div>
+					</Col>
+				</Container>
+			</AdminPage>
 		);
 	}
 
 	if ( error ) {
 		return (
-			<div className="newsletter-settings newsletter-settings--error">
-				<Notice status="error" isDismissible={ false }>
-					{ error }
-				</Notice>
-			</div>
+			<AdminPage moduleName="Jetpack Newsletter" header={ <Header /> }>
+				<Container horizontalSpacing={ 3 }>
+					<Col>
+						<div className="newsletter-settings newsletter-settings--error">
+							<Notice status="error" isDismissible={ false }>
+								{ error }
+							</Notice>
+						</div>
+					</Col>
+				</Container>
+			</AdminPage>
 		);
 	}
 
@@ -319,83 +337,87 @@ function NewsletterSettingsApp(): JSX.Element | null {
 	const hasWelcomeEmailChanges = Object.keys( welcomeEmailChanges ).length > 0;
 
 	return (
-		<div className="newsletter-settings">
-			<Header />
+		<AdminPage moduleName="Jetpack Newsletter" header={ <Header /> }>
+			<Container horizontalSpacing={ 3 }>
+				<Col>
+					<div className="newsletter-settings">
+						{ ! jetpackSettings?.isWpcomSimple && (
+							<NewsletterSection
+								data={ data }
+								jetpackSettings={ jetpackSettings }
+								onChange={ handleAutoSave }
+							/>
+						) }
 
-			{ ! jetpackSettings?.isWpcomSimple && (
-				<NewsletterSection
-					data={ data }
-					jetpackSettings={ jetpackSettings }
-					onChange={ handleAutoSave }
-				/>
-			) }
+						<SubscriptionsSection
+							data={ data }
+							jetpackSettings={ jetpackSettings }
+							onChange={ handleSubscriptionChange }
+							onSave={ saveSubscriptionSettings }
+							isSaving={ isSavingSubscriptions }
+							hasChanges={ hasSubscriptionChanges }
+							isNewsletterEnabled={ data.subscriptions }
+						/>
 
-			<SubscriptionsSection
-				data={ data }
-				jetpackSettings={ jetpackSettings }
-				onChange={ handleSubscriptionChange }
-				onSave={ saveSubscriptionSettings }
-				isSaving={ isSavingSubscriptions }
-				hasChanges={ hasSubscriptionChanges }
-				isNewsletterEnabled={ data.subscriptions }
-			/>
+						<PaidNewsletterSection
+							jetpackSettings={ jetpackSettings }
+							isNewsletterEnabled={ data.subscriptions }
+						/>
 
-			<PaidNewsletterSection
-				jetpackSettings={ jetpackSettings }
-				isNewsletterEnabled={ data.subscriptions }
-			/>
+						<NewsletterCategoriesSection
+							data={ data }
+							onChange={ handleNewsletterCategoriesChange }
+							onSave={ saveNewsletterCategories }
+							isSaving={ isSavingNewsletterCategories }
+							hasChanges={ hasNewsletterCategoriesChanges }
+							jetpackSettings={ jetpackSettings }
+							isNewsletterEnabled={ data.subscriptions }
+						/>
 
-			<NewsletterCategoriesSection
-				data={ data }
-				onChange={ handleNewsletterCategoriesChange }
-				onSave={ saveNewsletterCategories }
-				isSaving={ isSavingNewsletterCategories }
-				hasChanges={ hasNewsletterCategoriesChanges }
-				jetpackSettings={ jetpackSettings }
-				isNewsletterEnabled={ data.subscriptions }
-			/>
+						<EmailContentSection
+							data={ data }
+							onChange={ handleAutoSave }
+							isSitePublic={ jetpackSettings?.isSitePublic ?? true }
+							isNewsletterEnabled={ data.subscriptions }
+						/>
 
-			<EmailContentSection
-				data={ data }
-				onChange={ handleAutoSave }
-				isSitePublic={ jetpackSettings?.isSitePublic ?? true }
-				isNewsletterEnabled={ data.subscriptions }
-			/>
+						<EmailBylineSection
+							data={ data }
+							onChange={ handleAutoSave }
+							jetpackSettings={ jetpackSettings }
+							isNewsletterEnabled={ data.subscriptions }
+						/>
 
-			<EmailBylineSection
-				data={ data }
-				onChange={ handleAutoSave }
-				jetpackSettings={ jetpackSettings }
-				isNewsletterEnabled={ data.subscriptions }
-			/>
+						<EmailSenderSettingsSection
+							data={ data }
+							onChange={ handleSenderNameChange }
+							onSave={ saveSenderName }
+							isSaving={ isSavingSenderName }
+							hasChanges={ hasSenderNameChanges }
+							jetpackSettings={ jetpackSettings }
+							isNewsletterEnabled={ data.subscriptions }
+						/>
 
-			<EmailSenderSettingsSection
-				data={ data }
-				onChange={ handleSenderNameChange }
-				onSave={ saveSenderName }
-				isSaving={ isSavingSenderName }
-				hasChanges={ hasSenderNameChanges }
-				jetpackSettings={ jetpackSettings }
-				isNewsletterEnabled={ data.subscriptions }
-			/>
+						<EmailReplyToSettingsSection
+							data={ data }
+							onChange={ handleAutoSave }
+							isNewsletterEnabled={ data.subscriptions }
+						/>
 
-			<EmailReplyToSettingsSection
-				data={ data }
-				onChange={ handleAutoSave }
-				isNewsletterEnabled={ data.subscriptions }
-			/>
+						<WelcomeEmailSection
+							data={ data }
+							onChange={ handleWelcomeEmailChange }
+							onSave={ saveWelcomeEmail }
+							isSaving={ isSavingWelcomeEmail }
+							hasChanges={ hasWelcomeEmailChanges }
+							isNewsletterEnabled={ data.subscriptions }
+						/>
 
-			<WelcomeEmailSection
-				data={ data }
-				onChange={ handleWelcomeEmailChange }
-				onSave={ saveWelcomeEmail }
-				isSaving={ isSavingWelcomeEmail }
-				hasChanges={ hasWelcomeEmailChanges }
-				isNewsletterEnabled={ data.subscriptions }
-			/>
-
-			<GlobalNotices />
-		</div>
+						<GlobalNotices />
+					</div>
+				</Col>
+			</Container>
+		</AdminPage>
 	);
 }
 

--- a/projects/packages/newsletter/src/settings/index.tsx
+++ b/projects/packages/newsletter/src/settings/index.tsx
@@ -30,6 +30,8 @@ import {
 import type { NewsletterSettings, JetpackNewsletterSettings } from './types';
 import './style.scss';
 
+const MODULE_NAME = __( 'Jetpack Newsletter', 'jetpack-newsletter' );
+
 /**
  * Normalize settings from API response
  *
@@ -299,7 +301,7 @@ function NewsletterSettingsApp(): JSX.Element | null {
 
 	if ( isLoading ) {
 		return (
-			<AdminPage moduleName="Jetpack Newsletter" header={ <Header /> }>
+			<AdminPage moduleName={ MODULE_NAME } header={ <Header /> }>
 				<Container horizontalSpacing={ 3 }>
 					<Col>
 						<div className="newsletter-settings">
@@ -313,7 +315,7 @@ function NewsletterSettingsApp(): JSX.Element | null {
 
 	if ( error ) {
 		return (
-			<AdminPage moduleName="Jetpack Newsletter" header={ <Header /> }>
+			<AdminPage moduleName={ MODULE_NAME } header={ <Header /> }>
 				<Container horizontalSpacing={ 3 }>
 					<Col>
 						<div className="newsletter-settings newsletter-settings--error">
@@ -337,7 +339,7 @@ function NewsletterSettingsApp(): JSX.Element | null {
 	const hasWelcomeEmailChanges = Object.keys( welcomeEmailChanges ).length > 0;
 
 	return (
-		<AdminPage moduleName="Jetpack Newsletter" header={ <Header /> }>
+		<AdminPage moduleName={ MODULE_NAME } header={ <Header /> }>
 			<Container horizontalSpacing={ 3 }>
 				<Col>
 					<div className="newsletter-settings">

--- a/projects/packages/newsletter/src/settings/style.scss
+++ b/projects/packages/newsletter/src/settings/style.scss
@@ -4,8 +4,6 @@
 .newsletter-settings {
 	max-width: 1200px;
 	margin-inline: auto;
-	margin-block-start: 2em;
-	padding: 0;
 
 	// Card-based sections
 	&__section {


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/DOTCOM-16044

## Proposed changes:
* Wrap the Newsletter settings page with the `AdminPage` component from `@automattic/jetpack-components`
* Provides consistent header and footer styling with other Jetpack admin pages
* Adds the standard Jetpack footer to the settings page

### Other information:

- [x] Have you written new tests for your changes, if applicable? N/A - UI wrapper change only
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
N/A

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

0. Enable the new Newsletter settings page by making add_filter( 'jetpack_wp_admin_newsletter_settings_enabled', '__return_true' ); run early,
   - Add to a new mu-plugin
   - Pasting it into the top of jetpack-dev/jetpack.php using the plugin file editor on a jurassic ninja site.
   - Add to your 0-sandbox.php on your sandbox
1. Go to a site 
2. Navigate to the Newsletter Settings page (Jetpack → Newsletter)
3. Verify the page now has:
   - A consistent header with the Jetpack logo and "Newsletter Settings" title
   - The tagline "Transform your blog posts into newsletters to easily reach your subscribers."
   - A Jetpack footer at the bottom of the page
4. Quickly check that all existing functionality still works (toggle settings, save changes, etc.)

Before | After
-------|------
 <img width="2842" height="5556" alt="Screen Shot 2026-02-12 at 14 16 00-fullpage" src="https://github.com/user-attachments/assets/a9ef7f2b-c1c2-4830-bdba-6acb36c02792" /> |<img width="2884" height="5956" alt="Screen Shot 2026-02-12 at 16 09 16-fullpage" src="https://github.com/user-attachments/assets/debb36f4-d875-4e8c-b993-627db00ed914" />
