### PR TITLE
Prevent WooSync from overwriting existing company addresses in Jetpac…

### DIFF
--- a/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync-background-sync-job.php
+++ b/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync-background-sync-job.php
@@ -840,28 +840,88 @@ class Woo_Sync_Background_Sync_Job {
 
 			// Add/update company (if using b2b mode, and successfully added/updated contact):
 			$b2b_mode = zeroBSCRM_getSetting( 'companylevelcustomers' );
-			if ( $b2b_mode && isset( $crm_object_data['company']['name'] ) && ! empty( $crm_object_data['company']['name'] ) ) {
+if ( $b2b_mode && isset( $crm_object_data['company']['name'] ) && ! empty( $crm_object_data['company']['name'] ) ) {
 
-				/**
-				 * Note: we use existing company ID if we can find it by name; otherwise we create it
-				 *
-				 * WooCommerce orders only has one company field that we can use (company name). As such,
-				 * we can't rely on more accurate searches (e.g. by email)
-				 */
-				$potential_company = $zbs->DAL->companies->getCompany( -1, array( 'name' => $crm_object_data['company']['name'] ) ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+/**
+ * Note: we use existing company ID if we can find it by name; otherwise we create it
+ *
+ * WooCommerce orders only has one company field that we can use (company name). As such,
+ * we can't rely on more accurate searches (e.g. by email)
+ */
+	$company_args = array(
+		'data' => $crm_object_data['company'],
+	);
 
-				if ( $potential_company ) {
-					$company_id = $potential_company['id'];
-				} else {
-					// Add the company
-					$company_id = $zbs->DAL->companies->addUpdateCompany( // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
-						array(
-							'data' => $crm_object_data['company'],
-						)
-					);
+	$protect_company_address = false;
+	$existing_company_id     = 0;
+
+	// First, if this contact is already linked to a company, prefer that as the target.
+	if ( $contact_id > 0 ) {
+		$linked_companies = $zbs->DAL->contacts->getContactCompanies( $contact_id );
+
+		if ( is_array( $linked_companies ) && ! empty( $linked_companies ) ) {
+			$existing_company_id = (int) reset( $linked_companies );
+		}
+	}
+
+	/**
+	 * If there is no linked company yet, use an existing company with the same
+	 * name when available, otherwise create one.
+	 *
+	 * WooCommerce orders only has one company field that we can use (company name). As such,
+	 * we still can’t rely on more accurate searches (e.g. by email) as a primary key.
+	 */
+	if ( ! $existing_company_id ) {
+		$potential_company = $zbs->DAL->companies->getCompany(
+			-1,
+			array(
+				'name' => $crm_object_data['company']['name'],
+			)
+		); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+
+		if ( $potential_company ) {
+			$existing_company_id = (int) $potential_company['id'];
+		}
+	}
+
+	if ( $existing_company_id ) {
+		$company_args['id'] = $existing_company_id;
+
+		$existing_company     = $zbs->DAL->companies->getCompany( $existing_company_id );
+		$company_has_address  = false;
+		$company_address_keys = array( 'addr1', 'addr2', 'city', 'county', 'country', 'postcode' );
+
+		foreach ( $company_address_keys as $address_key ) {
+			if ( ! empty( $existing_company[ $address_key ] ) ) {
+				$company_has_address = true;
+				break;
+			}
+		}
+
+		// By default, protect an existing company's address from being overwritten by Woo checkout data.
+		$protect_company_address = apply_filters(
+			'jpcrm_woosync_protect_existing_company_address',
+			$company_has_address,
+			$existing_company,
+			$crm_object_data['company']
+		);
+
+		if ( $protect_company_address ) {
+
+			// Blank address fields so they are treated as "no update" when combined with do_not_update_blanks.
+			foreach ( $company_address_keys as $address_key ) {
+				if ( isset( $company_args['data'][ $address_key ] ) ) {
+					$company_args['data'][ $address_key ] = '';
 				}
+			}
 
-				if ( $company_id > 0 ) {
+			// Ensure we never overwrite existing non-empty values with these blank address fields.
+			$company_args['do_not_update_blanks'] = true;
+		}
+	}
+
+	// Add or update the company.
+	$company_id = $zbs->DAL->companies->addUpdateCompany( $company_args ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 
 					$this->debug( 'Company added/updated #' . $company_id );
 


### PR DESCRIPTION
## Summary
- Stop WooSync (Jetpack CRM) from overwriting existing company addresses when syncing repeat WooCommerce orders in B2B mode.
- Prefer the company already linked to the contact; if none, fall back to matching by company name (current Jetpack behavior).
- Protect existing company addresses by skipping address-field updates once a company already has an address, while still updating contacts and transactions.

## Technical details
- In `projects/plugins/crm/modules/woo-sync/includes/class-woo-sync-background-sync-job.php`, inside `Woo_Sync_Background_Sync_Job::import_crm_object_data`:
  - Build `$company_args` instead of always calling `addUpdateCompany()` with just `data`.
  - If the contact is already linked to a company, use that company ID as the primary target.
  - If there is no linked company, fall back to the existing Jetpack behavior of looking up a company by `name` before creating a new one.
  - For an existing company, detect whether any of `addr1`, `addr2`, `city`, `county`, `country`, or `postcode` are already populated.
  - When protection is enabled, blank those address fields in the incoming data and set `do_not_update_blanks = true` so DAL3 preserves the stored address while still updating other fields and links.
  - Expose / reuse the filter `jpcrm_woosync_protect_existing_company_address` so sites can override the default and allow address updates if needed.

## Testing
- Enabled B2B mode and created a company with a complete address and a linked contact in Jetpack CRM.
- Placed a WooCommerce order using the same company name but a different billing address and let WooSync run.
- Verified that:
  - The **company**’s address stayed as originally entered.
  - The **contact** and **transaction** reflect the new checkout address.

## Proposed changelog entry
* Added: Filter `jpcrm_woosync_protect_existing_company_address` to control whether WooSync is allowed to update existing company addresses in Jetpack CRM.
* Improved: WooSync B2B handling to prefer the company already linked to the contact when syncing WooCommerce orders.
* Fixed: WooSync overwriting existing company addresses with checkout addresses on repeat orders; addresses now stay with the company while contacts/transactions reflect the latest checkout details.