### PR TITLE
Agents Manager: add support for disconnected variants

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/agents-manager-disconnected-variants
+++ b/projects/packages/jetpack-mu-wpcom/changelog/agents-manager-disconnected-variants
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Agents Manager: Add lightweight help icon to disconnected views when unified experience is disabled.
+Agents Manager: Add lightweight help icon linking to the Help Center for disconnected Jetpack views when unified experience is enabled.

--- a/projects/packages/jetpack-mu-wpcom/changelog/agents-manager-disconnected-variants
+++ b/projects/packages/jetpack-mu-wpcom/changelog/agents-manager-disconnected-variants
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Agents Manager: add support for disconnected variants (wp-admin-disconnected, gutenberg-disconnected, ciab-disconnected) to provide lightweight help icon when unified experience is disabled.
+Agents Manager: Add lightweight help icon to disconnected views when unified experience is disabled.

--- a/projects/packages/jetpack-mu-wpcom/changelog/agents-manager-disconnected-variants
+++ b/projects/packages/jetpack-mu-wpcom/changelog/agents-manager-disconnected-variants
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Agents Manager: add support for disconnected variants (wp-admin-disconnected, gutenberg-disconnected, ciab-disconnected) to provide lightweight help icon when unified experience is disabled.

--- a/projects/packages/jetpack-mu-wpcom/src/features/agents-manager/class-agents-manager.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/agents-manager/class-agents-manager.php
@@ -719,7 +719,7 @@ class Agents_Manager {
 	 * Check if disconnected variant should be used.
 	 *
 	 * Disconnected variants are lightweight and only show a help icon
-	 * linking to Calypso. They are used when:
+	 * linking to the WordPress.com support page. They are used when:
 	 * - Unified experience is disabled
 	 * - Help center icon needs to display
 	 * - Full Agents Manager UI is not needed

--- a/projects/packages/jetpack-mu-wpcom/src/features/agents-manager/class-agents-manager.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/agents-manager/class-agents-manager.php
@@ -169,6 +169,13 @@ class Agents_Manager {
 		$use_disconnected = str_contains( $variant, 'disconnected' );
 		$is_gutenberg     = $this->is_block_editor();
 
+		// In Gutenberg, dequeue Help Center so we don't end up with two buttons.
+		// Agents Manager fires at priority 101, after Help Center at 100, so HC is already enqueued.
+		if ( $is_gutenberg ) {
+			wp_dequeue_script( 'help-center' );
+			wp_dequeue_style( 'help-center-style' );
+		}
+
 		// For non-Gutenberg environments, add to admin bar
 		// Gutenberg doesn't have an admin bar, so JS will handle UI insertion
 		if ( ! $is_gutenberg ) {

--- a/projects/packages/jetpack-mu-wpcom/src/features/agents-manager/class-agents-manager.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/agents-manager/class-agents-manager.php
@@ -14,6 +14,13 @@ use Automattic\Jetpack\Connection\Manager as Connection_Manager;
  */
 class Agents_Manager {
 	/**
+	 * Help Center URL for disconnected variants.
+	 *
+	 * @var string
+	 */
+	private const HELP_CENTER_URL = 'https://wordpress.com/support';
+
+	/**
 	 * Class instance.
 	 *
 	 * @var Agents_Manager
@@ -26,6 +33,13 @@ class Agents_Manager {
 	public function __construct() {
 		add_action( 'rest_api_init', array( $this, 'register_rest_api' ) );
 		add_filter( 'calypso_preferences_update', array( $this, 'calypso_preferences_update' ) );
+
+		// Hook early to prevent Help Center from loading in Gutenberg and CIAB when Agents Manager should handle it.
+		// Priority 50 runs before Help Center's priority 100 (for admin_enqueue_scripts).
+		// Priority 500 runs before Help Center's priority 1000 (for next_admin_init).
+		add_action( 'admin_enqueue_scripts', array( $this, 'maybe_prevent_help_center' ), 50 );
+		add_action( 'next_admin_init', array( $this, 'maybe_prevent_help_center' ), 500 );
+
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_scripts' ), 101 );
 		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_scripts' ), 101 );
 		add_action( 'next_admin_init', array( $this, 'enqueue_scripts' ), 1001 );
@@ -39,6 +53,53 @@ class Agents_Manager {
 	 */
 	public function should_display_menu_panel() {
 		return apply_filters( 'agents_manager_use_unified_experience', false );
+	}
+
+	/**
+	 * Prevent Help Center from loading when Agents Manager should handle it.
+	 *
+	 * This runs at:
+	 * - Priority 50 on admin_enqueue_scripts (before Help Center's priority 100)
+	 * - Priority 500 on next_admin_init (before Help Center's priority 1000)
+	 *
+	 * Prevents Help Center in Gutenberg and CIAB environments when using disconnected variants.
+	 */
+	public function maybe_prevent_help_center() {
+		// Detect which hook we're on to determine environment.
+		// When running on next_admin_init, we're in CIAB.
+		// Otherwise, check for Gutenberg block editor.
+		$current_filter = current_filter();
+		$is_ciab        = ( 'next_admin_init' === $current_filter );
+		$is_gutenberg   = ! $is_ciab && $this->is_block_editor();
+
+		if ( ! $is_gutenberg && ! $is_ciab ) {
+			return;
+		}
+
+		// Only prevent if Agents Manager will be loading.
+		if ( ! $this->should_enqueue_script() ) {
+			return;
+		}
+
+		// Get the Help Center singleton instance and remove its hooks.
+		$help_center_class = 'A8C\FSE\Help_Center';
+		if ( class_exists( $help_center_class ) ) {
+			// Try to get the instance via reflection to access the private static property.
+			try {
+				$reflection        = new \ReflectionClass( $help_center_class );
+				$instance_property = $reflection->getProperty( 'instance' );
+				$instance_property->setAccessible( true );
+				$instance = $instance_property->getValue();
+
+				if ( $instance ) {
+					// Remove Help Center from both admin_enqueue_scripts and next_admin_init hooks.
+					remove_action( 'admin_enqueue_scripts', array( $instance, 'enqueue_wp_admin_scripts' ), 100 );
+					remove_action( 'next_admin_init', array( $instance, 'enqueue_wp_admin_scripts' ), 1000 );
+				}
+			} catch ( \ReflectionException $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
+				// If reflection fails, silently continue - Agents Manager will still load.
+			}
+		}
 	}
 
 	/**
@@ -145,35 +206,60 @@ class Agents_Manager {
 	 * Enqueue Agents Manager scripts and add inline script data.
 	 */
 	public function enqueue_scripts() {
-		if ( $this->should_display_menu_panel() ) {
+		// Early return for P2 frontend - don't add admin bar or enqueue scripts.
+		$stylesheet = get_stylesheet();
+		$is_p2      = str_contains( $stylesheet, 'pub/p2' ) || function_exists( '\WPForTeams\is_wpforteams_site' ) && \WPForTeams\is_wpforteams_site( get_current_blog_id() );
+
+		if ( ! is_admin() && $is_p2 ) {
+			return;
+		}
+
+		$use_disconnected = $this->should_use_disconnected_variant();
+		$is_gutenberg     = $this->is_block_editor();
+
+		// For non-Gutenberg environments, add to admin bar
+		// Gutenberg doesn't have an admin bar, so JS will handle UI insertion
+		if ( ! $is_gutenberg ) {
 			add_action(
 				'admin_bar_menu',
-				function ( $wp_admin_bar ) {
+				function ( $wp_admin_bar ) use ( $use_disconnected ) {
 					// Remove the help-center menu item
 					$wp_admin_bar->remove_node( 'help-center' );
 
-					// Add the main agents manager menu node
-					$wp_admin_bar->add_menu(
-						array(
-							'id'     => 'agents-manager',
-							'title'  => '<span title="' . __( 'Help Center', 'jetpack-mu-wpcom' ) . '"><svg id="agents-manager-icon" class="ab-icon" width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-												<path fill="currentColor" fill-rule="evenodd" clip-rule="evenodd" d="M12 2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm-1 16v-2h2v2h-2zm2-3v-1.141A3.991 3.991 0 0016 10a4 4 0 00-8 0h2c0-1.103.897-2 2-2s2 .897 2 2-.897 2-2 2a1 1 0 00-1 1v2h2z" />
-											</svg></span>',
-							'parent' => 'top-secondary',
-							'meta'   => array(
-								'html'   => '<div id="agents-manager-masterbar" />',
-								'class'  => 'menupop',
-								'target' => '_blank',
-							),
-						)
+					$menu_args = array(
+						'id'     => 'agents-manager',
+						'title'  => '<span title="' . __( 'Help Center', 'jetpack-mu-wpcom' ) . '"><svg id="agents-manager-icon" class="ab-icon" width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+											<path fill="currentColor" fill-rule="evenodd" clip-rule="evenodd" d="M12 2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm-1 16v-2h2v2h-2zm2-3v-1.141A3.991 3.991 0 0016 10a4 4 0 00-8 0h2c0-1.103.897-2 2-2s2 .897 2 2-.897 2-2 2a1 1 0 00-1 1v2h2z" />
+										</svg></span>',
+						'parent' => 'top-secondary',
 					);
+
+					// For disconnected variants, link directly to help center instead of showing dropdown
+					if ( $use_disconnected ) {
+						$menu_args['href'] = self::HELP_CENTER_URL;
+						$menu_args['meta'] = array(
+							'target' => '_blank',
+						);
+					} else {
+						// For full variants, show the dropdown menu panel
+						$menu_args['meta'] = array(
+							'html'   => '<div id="agents-manager-masterbar" />',
+							'class'  => 'menupop',
+							'target' => '_blank',
+						);
+					}
+
+					// Add the main agents manager menu node
+					$wp_admin_bar->add_menu( $menu_args );
 				},
 				// Add the agents manager icon to the admin bar after the help center is added, so we can remove it.
 				100
 			);
 
-			// Initialize the agents manager menu panel
-			add_action( 'admin_bar_menu', array( $this, 'add_menu_panel' ), 100 );
+			// Initialize the agents manager menu panel (only for full variants, not disconnected)
+			if ( ! $use_disconnected ) {
+				add_action( 'admin_bar_menu', array( $this, 'add_menu_panel' ), 100 );
+			}
 		}
 
 		if ( ! $this->should_enqueue_script() ) {
@@ -201,10 +287,20 @@ class Agents_Manager {
 		 */
 		$use_unified_experience = apply_filters( 'agents_manager_use_unified_experience', false );
 
-		if ( $this->is_block_editor() ) {
+		// Determine if disconnected variant should be used.
+		$variant = 'wp-admin';
+
+		if ( $this->should_use_disconnected_variant() ) {
+			// Disconnected variants - lightweight help icon only.
+			$variant = 'wp-admin-disconnected';
+
+			if ( $this->is_block_editor() ) {
+				$variant = 'gutenberg-disconnected';
+			} elseif ( $this->is_ciab_environment() ) {
+				$variant = 'ciab-disconnected';
+			}
+		} elseif ( $this->is_block_editor() ) {
 			$variant = 'gutenberg';
-		} else {
-			$variant = 'wp-admin';
 		}
 
 		$this->enqueue_script( $variant );
@@ -219,6 +315,7 @@ class Agents_Manager {
 					'sectionName'          => $variant,
 					'currentUser'          => $this->get_current_user_data(),
 					'site'                 => $this->get_current_site(),
+					'helpCenterUrl'        => self::HELP_CENTER_URL,
 				),
 				JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP
 			) . ';',
@@ -250,11 +347,31 @@ class Agents_Manager {
 			return false;
 		}
 
+		// Load if unified experience is enabled (full UI).
 		if ( apply_filters( 'agents_manager_use_unified_experience', false ) ) {
 			return true;
 		}
 
+		// Load if block editor with unified Big Sky flag (full UI).
 		if ( $this->is_block_editor() && class_exists( 'Big_Sky' ) && $this->has_unified_big_sky_flag() ) {
+			return true;
+		}
+
+		// For disconnected variants, also load in block editor when disconnected variant is needed.
+		// This allows the lightweight help icon to display in Gutenberg.
+		if ( $this->is_block_editor() && $this->should_use_disconnected_variant() ) {
+			return true;
+		}
+
+		// For disconnected variants, also load in CIAB environment when disconnected variant is needed.
+		// This allows the lightweight help icon to display in CIAB admin.
+		if ( $this->is_ciab_environment() && $this->should_use_disconnected_variant() ) {
+			return true;
+		}
+
+		// For disconnected variants, also load in regular wp-admin when disconnected variant is needed.
+		// This allows the lightweight help icon to display in wp-admin.
+		if ( $this->should_use_disconnected_variant() ) {
 			return true;
 		}
 
@@ -596,6 +713,44 @@ class Agents_Manager {
 		$current_screen = get_current_screen();
 		// The widgets screen has the block editor but no Gutenberg top bar.
 		return $current_screen && $current_screen->is_block_editor() && $current_screen->id !== 'widgets';
+	}
+
+	/**
+	 * Check if current environment is CIAB (Commerce in a Box) / Next Admin.
+	 *
+	 * Uses the same detection method as Help Center: checks if next_admin_init has fired.
+	 *
+	 * @return bool True if CIAB/Next Admin environment.
+	 */
+	private function is_ciab_environment() {
+		return (bool) did_action( 'next_admin_init' );
+	}
+
+	/**
+	 * Check if disconnected variant should be used.
+	 *
+	 * Disconnected variants are lightweight and only show a help icon
+	 * linking to Calypso. They are used when:
+	 * - Unified experience is disabled
+	 * - Help center icon needs to display
+	 * - Full Agents Manager UI is not needed
+	 *
+	 * @return bool True if disconnected variant should be used.
+	 */
+	private function should_use_disconnected_variant() {
+		// Don't use disconnected variant if unified experience is enabled.
+		if ( $this->should_use_unified_experience() ) {
+			return false;
+		}
+
+		// Don't use disconnected variant if Big Sky full UI is enabled.
+		if ( $this->is_block_editor() && class_exists( 'Big_Sky' ) && $this->has_unified_big_sky_flag() ) {
+			return false;
+		}
+
+		// Use disconnected variant when help icon should show but not full UI.
+		// This can be controlled via filter for flexibility.
+		return apply_filters( 'agents_manager_use_disconnected_variant', true );
 	}
 
 	/**

--- a/projects/packages/jetpack-mu-wpcom/src/features/agents-manager/class-agents-manager.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/agents-manager/class-agents-manager.php
@@ -214,6 +214,12 @@ class Agents_Manager {
 			return;
 		}
 
+		// Check if scripts should be enqueued before adding admin bar UI.
+		// This prevents rendering non-functional UI on the frontend where scripts won't load.
+		if ( ! $this->should_enqueue_script() ) {
+			return;
+		}
+
 		$use_disconnected = $this->should_use_disconnected_variant();
 		$is_gutenberg     = $this->is_block_editor();
 
@@ -260,10 +266,6 @@ class Agents_Manager {
 			if ( ! $use_disconnected ) {
 				add_action( 'admin_bar_menu', array( $this, 'add_menu_panel' ), 100 );
 			}
-		}
-
-		if ( ! $this->should_enqueue_script() ) {
-			return;
 		}
 
 		/**
@@ -357,20 +359,8 @@ class Agents_Manager {
 			return true;
 		}
 
-		// For disconnected variants, also load in block editor when disconnected variant is needed.
-		// This allows the lightweight help icon to display in Gutenberg.
-		if ( $this->is_block_editor() && $this->should_use_disconnected_variant() ) {
-			return true;
-		}
-
-		// For disconnected variants, also load in CIAB environment when disconnected variant is needed.
-		// This allows the lightweight help icon to display in CIAB admin.
-		if ( $this->is_ciab_environment() && $this->should_use_disconnected_variant() ) {
-			return true;
-		}
-
-		// For disconnected variants, also load in regular wp-admin when disconnected variant is needed.
-		// This allows the lightweight help icon to display in wp-admin.
+		// For disconnected variants, also load when disconnected variant is needed.
+		// This allows the lightweight help icon to display in block editor, CIAB admin, and regular wp-admin.
 		if ( $this->should_use_disconnected_variant() ) {
 			return true;
 		}
@@ -408,12 +398,16 @@ class Agents_Manager {
 			true
 		);
 
-		wp_enqueue_style(
-			'agents-manager-style',
-			'https://widgets.wp.com/agents-manager/agents-manager-' . $variant . ( is_rtl() ? '.rtl.css' : '.css' ),
-			array(),
-			$version
-		);
+		// Only enqueue CSS for wp-admin variants.
+		// Gutenberg and CIAB variants don't have/need separate CSS files.
+		if ( str_starts_with( $variant, 'wp-admin' ) ) {
+			wp_enqueue_style(
+				'agents-manager-style',
+				'https://widgets.wp.com/agents-manager/agents-manager-' . $variant . ( is_rtl() ? '.rtl.css' : '.css' ),
+				array(),
+				$version
+			);
+		}
 	}
 
 	/**
@@ -739,7 +733,7 @@ class Agents_Manager {
 	 */
 	private function should_use_disconnected_variant() {
 		// Don't use disconnected variant if unified experience is enabled.
-		if ( $this->should_use_unified_experience() ) {
+		if ( apply_filters( 'agents_manager_use_unified_experience', false ) ) {
 			return false;
 		}
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/agents-manager/class-agents-manager.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/agents-manager/class-agents-manager.php
@@ -79,7 +79,7 @@ class Agents_Manager {
 			try {
 				$reflection        = new \ReflectionClass( $help_center_class );
 				$instance_property = $reflection->getProperty( 'instance' );
-				// setAccessible() is deprecated in PHP 8.5 and unnecessary since PHP 8.1.
+				// setAccessible() is deprecated in PHP 8.4 and unnecessary since PHP 8.1.
 				if ( PHP_VERSION_ID < 80100 ) {
 					$instance_property->setAccessible( true );
 				}

--- a/projects/packages/jetpack-mu-wpcom/src/features/agents-manager/class-agents-manager.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/agents-manager/class-agents-manager.php
@@ -62,7 +62,7 @@ class Agents_Manager {
 	 * - Priority 50 on admin_enqueue_scripts (before Help Center's priority 100)
 	 * - Priority 500 on next_admin_init (before Help Center's priority 1000)
 	 *
-	 * Prevents Help Center in Gutenberg and CIAB environments when using disconnected variants.
+	 * Prevents Help Center from loading when Agents Manager will be active to avoid duplicate UI elements.
 	 */
 	public function maybe_prevent_help_center() {
 		// Only prevent if Agents Manager will be loading.

--- a/projects/packages/jetpack-mu-wpcom/src/features/agents-manager/class-agents-manager.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/agents-manager/class-agents-manager.php
@@ -88,7 +88,10 @@ class Agents_Manager {
 			try {
 				$reflection        = new \ReflectionClass( $help_center_class );
 				$instance_property = $reflection->getProperty( 'instance' );
-				$instance_property->setAccessible( true );
+				// setAccessible() is deprecated in PHP 8.5 and unnecessary since PHP 8.1.
+				if ( PHP_VERSION_ID < 80100 ) {
+					$instance_property->setAccessible( true );
+				}
 				$instance = $instance_property->getValue();
 
 				if ( $instance ) {

--- a/projects/packages/jetpack-mu-wpcom/src/features/agents-manager/class-agents-manager.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/agents-manager/class-agents-manager.php
@@ -18,7 +18,7 @@ class Agents_Manager {
 	 *
 	 * @var string
 	 */
-	private const HELP_CENTER_URL = 'https://wordpress.com/support';
+	private const HELP_CENTER_URL = 'https://wordpress.com/help?help-center=home';
 
 	/**
 	 * Class instance.
@@ -34,12 +34,6 @@ class Agents_Manager {
 		add_action( 'rest_api_init', array( $this, 'register_rest_api' ) );
 		add_filter( 'calypso_preferences_update', array( $this, 'calypso_preferences_update' ) );
 
-		// Hook early to prevent Help Center from loading in Gutenberg and CIAB when Agents Manager should handle it.
-		// Priority 50 runs before Help Center's priority 100 (for admin_enqueue_scripts).
-		// Priority 500 runs before Help Center's priority 1000 (for next_admin_init).
-		add_action( 'admin_enqueue_scripts', array( $this, 'maybe_prevent_help_center' ), 50 );
-		add_action( 'next_admin_init', array( $this, 'maybe_prevent_help_center' ), 500 );
-
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_scripts' ), 101 );
 		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_scripts' ), 101 );
 		add_action( 'next_admin_init', array( $this, 'enqueue_scripts' ), 1001 );
@@ -53,47 +47,6 @@ class Agents_Manager {
 	 */
 	public function should_display_menu_panel() {
 		return apply_filters( 'agents_manager_use_unified_experience', false );
-	}
-
-	/**
-	 * Prevent Help Center from loading when Agents Manager should handle it.
-	 *
-	 * This runs at:
-	 * - Priority 50 on admin_enqueue_scripts (before Help Center's priority 100)
-	 * - Priority 500 on next_admin_init (before Help Center's priority 1000)
-	 *
-	 * Prevents Help Center from loading when Agents Manager will be active to avoid duplicate UI elements.
-	 */
-	public function maybe_prevent_help_center() {
-		// Only prevent if Agents Manager will be loading.
-		// This ensures Help Center doesn't enqueue duplicate JS/CSS in wp-admin,
-		// Gutenberg, or CIAB when Agents Manager is active.
-		if ( ! $this->should_enqueue_script() ) {
-			return;
-		}
-
-		// Get the Help Center singleton instance and remove its hooks.
-		$help_center_class = 'A8C\FSE\Help_Center';
-		if ( class_exists( $help_center_class ) ) {
-			// Try to get the instance via reflection to access the private static property.
-			try {
-				$reflection        = new \ReflectionClass( $help_center_class );
-				$instance_property = $reflection->getProperty( 'instance' );
-				// setAccessible() is deprecated in PHP 8.4 and unnecessary since PHP 8.1.
-				if ( PHP_VERSION_ID < 80100 ) {
-					$instance_property->setAccessible( true );
-				}
-				$instance = $instance_property->getValue();
-
-				if ( $instance ) {
-					// Remove Help Center from both admin_enqueue_scripts and next_admin_init hooks.
-					remove_action( 'admin_enqueue_scripts', array( $instance, 'enqueue_wp_admin_scripts' ), 100 );
-					remove_action( 'next_admin_init', array( $instance, 'enqueue_wp_admin_scripts' ), 1000 );
-				}
-			} catch ( \ReflectionException $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
-				// If reflection fails, silently continue - Agents Manager will still load.
-			}
-		}
 	}
 
 	/**
@@ -208,13 +161,12 @@ class Agents_Manager {
 			return;
 		}
 
-		// Check if scripts should be enqueued before adding admin bar UI.
-		// This prevents rendering non-functional UI on the frontend where scripts won't load.
-		if ( ! $this->should_enqueue_script() ) {
+		// Determine which variant to load (null = don't load).
+		$variant = $this->get_variant();
+		if ( null === $variant ) {
 			return;
 		}
-
-		$use_disconnected = $this->should_use_disconnected_variant();
+		$use_disconnected = str_contains( $variant, 'disconnected' );
 		$is_gutenberg     = $this->is_block_editor();
 
 		// For non-Gutenberg environments, add to admin bar
@@ -229,8 +181,8 @@ class Agents_Manager {
 					$menu_args = array(
 						'id'     => 'agents-manager',
 						'title'  => '<span title="' . __( 'Help Center', 'jetpack-mu-wpcom' ) . '"><svg id="agents-manager-icon" class="ab-icon" width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-											<path fill="currentColor" fill-rule="evenodd" clip-rule="evenodd" d="M12 2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm-1 16v-2h2v2h-2zm2-3v-1.141A3.991 3.991 0 0016 10a4 4 0 00-8 0h2c0-1.103.897-2 2-2s2 .897 2 2-.897 2-2 2a1 1 0 00-1 1v2h2z" />
-										</svg></span>',
+										<path fill="currentColor" fill-rule="evenodd" clip-rule="evenodd" d="M12 2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm-1 16v-2h2v2h-2zm2-3v-1.141A3.991 3.991 0 0016 10a4 4 0 00-8 0h2c0-1.103.897-2 2-2s2 .897 2 2-.897 2-2 2a1 1 0 00-1 1v2h2z" />
+									</svg></span>',
 						'parent' => 'top-secondary',
 					);
 
@@ -283,22 +235,6 @@ class Agents_Manager {
 		 */
 		$use_unified_experience = apply_filters( 'agents_manager_use_unified_experience', false );
 
-		// Determine if disconnected variant should be used.
-		$variant = 'wp-admin';
-
-		if ( $this->should_use_disconnected_variant() ) {
-			// Disconnected variants - lightweight help icon only.
-			$variant = 'wp-admin-disconnected';
-
-			if ( $this->is_block_editor() ) {
-				$variant = 'gutenberg-disconnected';
-			} elseif ( $this->is_ciab_environment() ) {
-				$variant = 'ciab-disconnected';
-			}
-		} elseif ( $this->is_block_editor() ) {
-			$variant = 'gutenberg';
-		}
-
 		$this->enqueue_script( $variant );
 
 		wp_add_inline_script(
@@ -320,53 +256,99 @@ class Agents_Manager {
 	}
 
 	/**
-	 * Determine if the agents manager files should be enqueued.
+	 * Determine which script variant to load, or null if none should be loaded.
+	 *
+	 * Combines the gating logic (should we load at all?) with variant selection
+	 * (which build to use?) into a single method so the two cannot get out of sync.
+	 *
+	 * @return string|null The variant name, or null if scripts should not be loaded.
 	 */
-	private function should_enqueue_script() {
-		// Don't load on site frontend - only load in wp-admin.
-		if ( ! is_admin() ) {
-			return false;
+	private function get_variant() {
+		// CIAB/Next Admin: only load when disconnected (connected CIAB is handled by Help Center).
+		if ( $this->is_ciab_environment() ) {
+			if ( $this->is_enabled() && $this->is_jetpack_disconnected() ) {
+				return 'ciab-disconnected';
+			}
+			return null;
 		}
 
+		// Frontend: load disconnected variant for eligible logged-in editors.
+		if ( ! is_admin() ) {
+			if ( $this->is_loading_on_frontend() && $this->is_enabled() ) {
+				return 'wp-admin-disconnected';
+			}
+			return null;
+		}
+
+		// Apply wp-admin exclusions (WooCommerce, customizer, preview contexts).
+		if ( ! $this->passes_admin_checks() ) {
+			return null;
+		}
+
+		if ( ! $this->is_enabled() ) {
+			return null;
+		}
+
+		$disconnected = $this->is_jetpack_disconnected();
+
+		if ( $this->is_block_editor() ) {
+			return $disconnected ? 'gutenberg-disconnected' : 'gutenberg';
+		}
+
+		return $disconnected ? 'wp-admin-disconnected' : 'wp-admin';
+	}
+
+	/**
+	 * Returns true if the Agents Manager should be loaded in the current context.
+	 *
+	 * True when the unified experience filter is enabled, or when the block editor
+	 * has the unified Big Sky flag active.
+	 *
+	 * @return bool
+	 */
+	private function is_enabled() {
+		if ( apply_filters( 'agents_manager_use_unified_experience', false ) ) {
+			return true;
+		}
+
+		if ( $this->is_block_editor() && class_exists( 'Big_Sky' ) && $this->has_unified_big_sky_flag() ) {
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
+	 * Returns true if the current wp-admin context passes all exclusion checks.
+	 *
+	 * Excludes WooCommerce Admin home, customizer preview, Gutenberg asset requests,
+	 * and preview query param contexts.
+	 *
+	 * @return bool
+	 */
+	private function passes_admin_checks() {
 		// Don't load on WooCommerce Admin home page to avoid UI conflicts.
-		// This matches the exclusion in Help_Center::enqueue_wp_admin_scripts().
 		global $current_screen;
 		if ( $current_screen && $current_screen->id === 'woocommerce_page_wc-admin' ) {
 			return false;
 		}
 
-		// Don't load in customizer preview iframe - Help Center handles customizer separately
-		// via customize_controls_enqueue_scripts hook (loads only in controls panel, not preview).
+		// Don't load in customizer preview iframe.
 		if ( is_customize_preview() ) {
 			return false;
 		}
 
-		// Don't load during Gutenberg asset requests or in preview contexts.
-		// This matches the logic in Help_Center::init() to prevent excessive/unnecessary loading.
+		// Don't load during Gutenberg asset requests or preview contexts.
 		$request_uri = isset( $_SERVER['REQUEST_URI'] ) ? sanitize_text_field( wp_unslash( $_SERVER['REQUEST_URI'] ) ) : '';
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- This is a context check, not a form submission.
 		$is_preview = isset( $_GET['preview'] ) && 'true' === sanitize_text_field( wp_unslash( $_GET['preview'] ) );
-		if ( str_contains( $request_uri, 'wp-content/plugins/gutenberg-core' ) || $is_preview ) {
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- This is a context check, not a form submission.
+		$is_preview_overlay = isset( $_GET['preview_overlay'] );
+		if ( str_contains( $request_uri, 'wp-content/plugins/gutenberg-core' ) || $is_preview || $is_preview_overlay ) {
 			return false;
 		}
 
-		// Load if unified experience is enabled (full UI).
-		if ( apply_filters( 'agents_manager_use_unified_experience', false ) ) {
-			return true;
-		}
-
-		// Load if block editor with unified Big Sky flag (full UI).
-		if ( $this->is_block_editor() && class_exists( 'Big_Sky' ) && $this->has_unified_big_sky_flag() ) {
-			return true;
-		}
-
-		// For disconnected variants, also load when disconnected variant is needed.
-		// This allows the lightweight help icon to display in block editor, CIAB admin, and regular wp-admin.
-		if ( $this->should_use_disconnected_variant() ) {
-			return true;
-		}
-
-		return false;
+		return true;
 	}
 
 	/**
@@ -697,6 +679,28 @@ class Agents_Manager {
 	}
 
 	/**
+	 * Returns true if the current request is on the frontend and the user can edit posts.
+	 *
+	 * Mirrors Help_Center::is_loading_on_frontend().
+	 *
+	 * @return bool True if loading on the frontend for an eligible user.
+	 */
+	private function is_loading_on_frontend() {
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- This is a context check, not a form submission.
+		if ( isset( $_GET['na_site_preview'] ) || isset( $_GET['preview_overlay'] ) ) {
+			return false;
+		}
+
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- This is a context check, not a form submission.
+		if ( isset( $_GET['preview'] ) && 'true' === sanitize_text_field( wp_unslash( $_GET['preview'] ) ) ) {
+			return false;
+		}
+
+		$can_edit_posts = current_user_can( 'edit_posts' ) && is_user_member_of_blog();
+		return ! is_admin() && ! $this->is_block_editor() && $can_edit_posts;
+	}
+
+	/**
 	 * Returns true if the current screen is the block editor.
 	 *
 	 * @return bool True if the current screen is the block editor.
@@ -723,30 +727,25 @@ class Agents_Manager {
 	}
 
 	/**
-	 * Check if disconnected variant should be used.
+	 * Returns true if the current user is connected through Jetpack.
 	 *
-	 * Disconnected variants are lightweight and only show a help icon
-	 * linking to the WordPress.com support page. They are used when:
-	 * - Unified experience is disabled
-	 * - Help center icon needs to display
-	 * - Full Agents Manager UI is not needed
+	 * Mirrors the logic from Help_Center::is_jetpack_disconnected().
 	 *
-	 * @return bool True if disconnected variant should be used.
+	 * @return bool True if the site uses Jetpack but the current user is not connected.
 	 */
-	private function should_use_disconnected_variant() {
-		// Don't use disconnected variant if unified experience is enabled.
-		if ( apply_filters( 'agents_manager_use_unified_experience', false ) ) {
-			return false;
+	private function is_jetpack_disconnected() {
+		$user_id = get_current_user_id();
+		$blog_id = get_current_blog_id();
+
+		if ( defined( 'IS_ATOMIC' ) && IS_ATOMIC ) {
+			return ! ( new Connection_Manager( 'jetpack' ) )->is_user_connected( $user_id );
 		}
 
-		// Don't use disconnected variant if Big Sky full UI is enabled.
-		if ( $this->is_block_editor() && class_exists( 'Big_Sky' ) && $this->has_unified_big_sky_flag() ) {
-			return false;
+		if ( true === apply_filters( 'is_jetpack_site', false, $blog_id ) ) {
+			return ! ( new Connection_Manager( 'jetpack' ) )->is_user_connected( $user_id );
 		}
 
-		// Use disconnected variant when help icon should show but not full UI.
-		// This can be controlled via filter for flexibility.
-		return apply_filters( 'agents_manager_use_disconnected_variant', true );
+		return false;
 	}
 
 	/**

--- a/projects/packages/jetpack-mu-wpcom/src/features/agents-manager/class-agents-manager.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/agents-manager/class-agents-manager.php
@@ -731,7 +731,7 @@ class Agents_Manager {
 	}
 
 	/**
-	 * Returns true if the current user is connected through Jetpack.
+	 * Returns true if the current user is NOT connected through Jetpack.
 	 *
 	 * Mirrors the logic from Help_Center::is_jetpack_disconnected().
 	 *

--- a/projects/packages/jetpack-mu-wpcom/src/features/agents-manager/class-agents-manager.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/agents-manager/class-agents-manager.php
@@ -328,6 +328,13 @@ class Agents_Manager {
 			return false;
 		}
 
+		// Don't load on WooCommerce Admin home page to avoid UI conflicts.
+		// This matches the exclusion in Help_Center::enqueue_wp_admin_scripts().
+		global $current_screen;
+		if ( $current_screen && $current_screen->id === 'woocommerce_page_wc-admin' ) {
+			return false;
+		}
+
 		// Don't load in customizer preview iframe - Help Center handles customizer separately
 		// via customize_controls_enqueue_scripts hook (loads only in controls panel, not preview).
 		if ( is_customize_preview() ) {

--- a/projects/packages/jetpack-mu-wpcom/src/features/agents-manager/class-agents-manager.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/agents-manager/class-agents-manager.php
@@ -65,18 +65,9 @@ class Agents_Manager {
 	 * Prevents Help Center in Gutenberg and CIAB environments when using disconnected variants.
 	 */
 	public function maybe_prevent_help_center() {
-		// Detect which hook we're on to determine environment.
-		// When running on next_admin_init, we're in CIAB.
-		// Otherwise, check for Gutenberg block editor.
-		$current_filter = current_filter();
-		$is_ciab        = ( 'next_admin_init' === $current_filter );
-		$is_gutenberg   = ! $is_ciab && $this->is_block_editor();
-
-		if ( ! $is_gutenberg && ! $is_ciab ) {
-			return;
-		}
-
 		// Only prevent if Agents Manager will be loading.
+		// This ensures Help Center doesn't enqueue duplicate JS/CSS in wp-admin,
+		// Gutenberg, or CIAB when Agents Manager is active.
 		if ( ! $this->should_enqueue_script() ) {
 			return;
 		}
@@ -402,7 +393,8 @@ class Agents_Manager {
 		);
 
 		// Only enqueue CSS for wp-admin variants.
-		// Gutenberg and CIAB variants don't have/need separate CSS files.
+		// Gutenberg and CIAB variants handle styling through their own interfaces
+		// and do not require separate CSS files for the help icon.
 		if ( str_starts_with( $variant, 'wp-admin' ) ) {
 			wp_enqueue_style(
 				'agents-manager-style',

--- a/projects/packages/jetpack-mu-wpcom/src/features/agents-manager/class-agents-manager.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/agents-manager/class-agents-manager.php
@@ -388,10 +388,7 @@ class Agents_Manager {
 			true
 		);
 
-		// Only enqueue CSS for wp-admin variants.
-		// Gutenberg and CIAB variants handle styling through their own interfaces
-		// and do not require separate CSS files for the help icon.
-		if ( str_starts_with( $variant, 'wp-admin' ) ) {
+		if ( 'gutenberg-disconnected' !== $variant && 'ciab-disconnected' !== $variant ) {
 			wp_enqueue_style(
 				'agents-manager-style',
 				'https://widgets.wp.com/agents-manager/agents-manager-' . $variant . ( is_rtl() ? '.rtl.css' : '.css' ),

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/agents-manager/Agents_Manager_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/agents-manager/Agents_Manager_Test.php
@@ -1187,17 +1187,28 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
-	 * Helper to call the private should_enqueue_script method via reflection.
+	 * Helper to call the private get_variant method via reflection.
 	 *
-	 * @return bool The result of should_enqueue_script.
+	 * @return string|null The variant name, or null if scripts should not be loaded.
 	 */
-	private function call_should_enqueue_script() {
+	private function call_get_variant() {
 		$reflection = new \ReflectionClass( Agents_Manager::class );
-		$method     = $reflection->getMethod( 'should_enqueue_script' );
+		$method     = $reflection->getMethod( 'get_variant' );
 		if ( PHP_VERSION_ID < 80100 ) {
 			$method->setAccessible( true );
 		}
 		return $method->invoke( $this->agents_manager );
+	}
+
+	/**
+	 * Helper to call get_variant and return a boolean (true = variant found, false = null).
+	 *
+	 * Convenience wrapper used by tests that only care whether scripts are loaded.
+	 *
+	 * @return bool True if a variant was returned (scripts will load), false if null.
+	 */
+	private function call_should_enqueue_script() {
+		return null !== $this->call_get_variant();
 	}
 
 	/**
@@ -1500,8 +1511,9 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 
 		wp_register_script( 'agents-manager', 'https://example.com/agents-manager.js', array(), '1.0', true );
 
+		// Enable unified experience. Jetpack is not connected (default test state),
+		// so is_jetpack_disconnected() returns false for non-Jetpack sites.
 		add_filter( 'agents_manager_use_unified_experience', '__return_true', 20 );
-		add_filter( 'agents_manager_use_disconnected_variant', '__return_false', 20 );
 
 		$this->agents_manager->enqueue_scripts();
 
@@ -1512,7 +1524,6 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 		$this->assertStringContainsString( '"sectionName":"wp-admin"', $inline_script );
 
 		remove_filter( 'agents_manager_use_unified_experience', '__return_true', 20 );
-		remove_filter( 'agents_manager_use_disconnected_variant', '__return_false', 20 );
 	}
 
 	/**
@@ -1539,8 +1550,9 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 
 		wp_register_script( 'agents-manager', 'https://example.com/agents-manager.js', array(), '1.0', true );
 
+		// Enable unified experience. Jetpack is not connected (default test state),
+		// so is_jetpack_disconnected() returns false for non-Jetpack sites.
 		add_filter( 'agents_manager_use_unified_experience', '__return_true', 20 );
-		add_filter( 'agents_manager_use_disconnected_variant', '__return_false', 20 );
 
 		$this->agents_manager->enqueue_scripts();
 
@@ -1551,7 +1563,6 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 		$this->assertStringContainsString( '"sectionName":"gutenberg"', $inline_script );
 
 		remove_filter( 'agents_manager_use_unified_experience', '__return_true', 20 );
-		remove_filter( 'agents_manager_use_disconnected_variant', '__return_false', 20 );
 	}
 
 	/**
@@ -1581,8 +1592,9 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 
 		wp_register_script( 'agents-manager', 'https://example.com/agents-manager.js', array(), '1.0', true );
 
+		// Enable unified experience. Jetpack is not connected (default test state),
+		// so is_jetpack_disconnected() returns false for non-Jetpack sites.
 		add_filter( 'agents_manager_use_unified_experience', '__return_true', 20 );
-		add_filter( 'agents_manager_use_disconnected_variant', '__return_false', 20 );
 
 		$this->agents_manager->enqueue_scripts();
 
@@ -1593,11 +1605,11 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 		$this->assertStringContainsString( '"sectionName":"wp-admin"', $inline_script );
 
 		remove_filter( 'agents_manager_use_unified_experience', '__return_true', 20 );
-		remove_filter( 'agents_manager_use_disconnected_variant', '__return_false', 20 );
 	}
 
 	/**
-	 * Tests that enqueue_scripts includes sectionName as wp-admin-disconnected when disconnected variant is enabled.
+	 * Tests that enqueue_scripts includes sectionName as wp-admin-disconnected when unified experience
+	 * is enabled but Jetpack is disconnected.
 	 */
 	public function test_enqueue_scripts_includes_section_name_wp_admin_disconnected() {
 		// Set admin context - scripts only enqueue in admin.
@@ -1609,9 +1621,10 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 
 		wp_register_script( 'agents-manager', 'https://example.com/agents-manager.js', array(), '1.0', true );
 
-		// Enable disconnected variant, disable unified experience.
-		add_filter( 'agents_manager_use_unified_experience', '__return_false', 20 );
-		add_filter( 'agents_manager_use_disconnected_variant', '__return_true', 20 );
+		// Enable unified experience and simulate a Jetpack site with a disconnected user.
+		add_filter( 'agents_manager_use_unified_experience', '__return_true', 20 );
+		add_filter( 'is_jetpack_site', '__return_true', 20 );
+		// Do not connect the user - is_user_connected() will return false by default.
 
 		$this->agents_manager->enqueue_scripts();
 
@@ -1621,12 +1634,13 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 
 		$this->assertStringContainsString( '"sectionName":"wp-admin-disconnected"', $inline_script );
 
-		remove_filter( 'agents_manager_use_unified_experience', '__return_false', 20 );
-		remove_filter( 'agents_manager_use_disconnected_variant', '__return_true', 20 );
+		remove_filter( 'agents_manager_use_unified_experience', '__return_true', 20 );
+		remove_filter( 'is_jetpack_site', '__return_true', 20 );
 	}
 
 	/**
-	 * Tests that enqueue_scripts includes sectionName as gutenberg-disconnected in block editor with disconnected variant.
+	 * Tests that enqueue_scripts includes sectionName as gutenberg-disconnected in block editor
+	 * when unified experience is enabled but Jetpack is disconnected.
 	 */
 	public function test_enqueue_scripts_includes_section_name_gutenberg_disconnected() {
 		require_once ABSPATH . 'wp-admin/includes/screen.php';
@@ -1649,9 +1663,10 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 
 		wp_register_script( 'agents-manager', 'https://example.com/agents-manager.js', array(), '1.0', true );
 
-		// Enable disconnected variant, disable unified experience.
-		add_filter( 'agents_manager_use_unified_experience', '__return_false', 20 );
-		add_filter( 'agents_manager_use_disconnected_variant', '__return_true', 20 );
+		// Enable unified experience and simulate a Jetpack site with a disconnected user.
+		add_filter( 'agents_manager_use_unified_experience', '__return_true', 20 );
+		add_filter( 'is_jetpack_site', '__return_true', 20 );
+		// Do not connect the user - is_user_connected() will return false by default.
 
 		$this->agents_manager->enqueue_scripts();
 
@@ -1661,12 +1676,13 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 
 		$this->assertStringContainsString( '"sectionName":"gutenberg-disconnected"', $inline_script );
 
-		remove_filter( 'agents_manager_use_unified_experience', '__return_false', 20 );
-		remove_filter( 'agents_manager_use_disconnected_variant', '__return_true', 20 );
+		remove_filter( 'agents_manager_use_unified_experience', '__return_true', 20 );
+		remove_filter( 'is_jetpack_site', '__return_true', 20 );
 	}
 
 	/**
-	 * Tests that enqueue_scripts includes sectionName as ciab-disconnected in CIAB environment with disconnected variant.
+	 * Tests that enqueue_scripts includes sectionName as ciab-disconnected in CIAB environment
+	 * when unified experience is enabled but Jetpack is disconnected.
 	 */
 	public function test_enqueue_scripts_includes_section_name_ciab_disconnected() {
 		// Set admin context - scripts only enqueue in admin.
@@ -1685,9 +1701,10 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 
 		wp_register_script( 'agents-manager', 'https://example.com/agents-manager.js', array(), '1.0', true );
 
-		// Enable disconnected variant, disable unified experience.
-		add_filter( 'agents_manager_use_unified_experience', '__return_false', 20 );
-		add_filter( 'agents_manager_use_disconnected_variant', '__return_true', 20 );
+		// Enable unified experience and simulate a Jetpack site with a disconnected user.
+		add_filter( 'agents_manager_use_unified_experience', '__return_true', 20 );
+		add_filter( 'is_jetpack_site', '__return_true', 20 );
+		// Do not connect the user - is_user_connected() will return false by default.
 
 		$this->agents_manager->enqueue_scripts();
 
@@ -1697,8 +1714,8 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 
 		$this->assertStringContainsString( '"sectionName":"ciab-disconnected"', $inline_script );
 
-		remove_filter( 'agents_manager_use_unified_experience', '__return_false', 20 );
-		remove_filter( 'agents_manager_use_disconnected_variant', '__return_true', 20 );
+		remove_filter( 'agents_manager_use_unified_experience', '__return_true', 20 );
+		remove_filter( 'is_jetpack_site', '__return_true', 20 );
 
 		// Restore the original did_action counter to prevent test order dependencies.
 		if ( $original_action_count === 0 ) {
@@ -1709,26 +1726,27 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
-	 * Tests that should_enqueue_script returns true when disconnected variant is enabled in wp-admin.
+	 * Tests that should_enqueue_script returns true when unified experience is enabled but Jetpack is disconnected (in wp-admin).
 	 */
 	public function test_should_enqueue_script_returns_true_when_disconnected_variant_enabled_in_admin() {
 		$this->set_admin_context();
 		$_SERVER['REQUEST_URI'] = '/wp-admin/index.php';
 
-		// Enable disconnected variant, disable unified experience.
-		add_filter( 'agents_manager_use_unified_experience', '__return_false', 20 );
-		add_filter( 'agents_manager_use_disconnected_variant', '__return_true', 20 );
+		// Enable unified experience and simulate a Jetpack site with a disconnected user.
+		add_filter( 'agents_manager_use_unified_experience', '__return_true', 20 );
+		add_filter( 'is_jetpack_site', '__return_true', 20 );
+		// Do not connect the user - is_user_connected() will return false by default.
 
 		$result = $this->call_should_enqueue_script();
 
-		remove_filter( 'agents_manager_use_unified_experience', '__return_false', 20 );
-		remove_filter( 'agents_manager_use_disconnected_variant', '__return_true', 20 );
+		remove_filter( 'agents_manager_use_unified_experience', '__return_true', 20 );
+		remove_filter( 'is_jetpack_site', '__return_true', 20 );
 
 		$this->assertTrue( $result );
 	}
 
 	/**
-	 * Tests that should_enqueue_script returns true when disconnected variant is enabled in block editor.
+	 * Tests that should_enqueue_script returns true when unified experience is enabled but Jetpack is disconnected (in block editor).
 	 */
 	public function test_should_enqueue_script_returns_true_when_disconnected_variant_enabled_in_block_editor() {
 		require_once ABSPATH . 'wp-admin/includes/screen.php';
@@ -1745,22 +1763,23 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 		}
 		$property->setValue( $screen, true );
 
-		// Enable disconnected variant, disable unified experience.
-		add_filter( 'agents_manager_use_unified_experience', '__return_false', 20 );
-		add_filter( 'agents_manager_use_disconnected_variant', '__return_true', 20 );
+		// Enable unified experience and simulate a Jetpack site with a disconnected user.
+		add_filter( 'agents_manager_use_unified_experience', '__return_true', 20 );
+		add_filter( 'is_jetpack_site', '__return_true', 20 );
+		// Do not connect the user - is_user_connected() will return false by default.
 
 		$result = $this->call_should_enqueue_script();
 
-		remove_filter( 'agents_manager_use_unified_experience', '__return_false', 20 );
-		remove_filter( 'agents_manager_use_disconnected_variant', '__return_true', 20 );
+		remove_filter( 'agents_manager_use_unified_experience', '__return_true', 20 );
+		remove_filter( 'is_jetpack_site', '__return_true', 20 );
 
 		$this->assertTrue( $result );
 	}
 
 	/**
-	 * Tests that disconnected variant is not used when unified experience is enabled.
+	 * Tests that disconnected variant is not used when unified experience is enabled and Jetpack is connected.
 	 */
-	public function test_disconnected_variant_not_used_when_unified_experience_enabled() {
+	public function test_disconnected_variant_not_used_when_unified_experience_enabled_and_connected() {
 		// Set admin context.
 		$this->set_admin_context();
 
@@ -1770,10 +1789,8 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 
 		wp_register_script( 'agents-manager', 'https://example.com/agents-manager.js', array(), '1.0', true );
 
-		// Enable both unified experience and disconnected variant filter.
-		// Unified experience should take precedence.
+		// Enable unified experience. Do not simulate a Jetpack site, so is_jetpack_disconnected() returns false.
 		add_filter( 'agents_manager_use_unified_experience', '__return_true', 20 );
-		add_filter( 'agents_manager_use_disconnected_variant', '__return_true', 20 );
 
 		$this->agents_manager->enqueue_scripts();
 
@@ -1781,29 +1798,28 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 		$inline_scripts = $wp_scripts->registered['agents-manager']->extra['before'] ?? array();
 		$inline_script  = implode( "\n", array_filter( $inline_scripts ) );
 
-		// Should use wp-admin, not wp-admin-disconnected, because unified experience takes precedence.
+		// Should use wp-admin, not wp-admin-disconnected, because Jetpack is connected (or not a Jetpack site).
 		$this->assertStringContainsString( '"sectionName":"wp-admin"', $inline_script );
 		$this->assertStringNotContainsString( '"sectionName":"wp-admin-disconnected"', $inline_script );
 		$this->assertStringNotContainsString( '"sectionName":"gutenberg-disconnected"', $inline_script );
 		$this->assertStringNotContainsString( '"sectionName":"ciab-disconnected"', $inline_script );
 
 		remove_filter( 'agents_manager_use_unified_experience', '__return_true', 20 );
-		remove_filter( 'agents_manager_use_disconnected_variant', '__return_true', 20 );
 	}
 
 	/**
 	 * Tests that CSS is enqueued for wp-admin variants but not for gutenberg or ciab variants.
 	 */
 	public function test_css_enqueued_only_for_wp_admin_variants() {
-		// Test wp-admin variant - should enqueue CSS.
+		// Test wp-admin variant (connected) - should enqueue CSS.
 		$this->set_admin_context();
 		global $wp_styles;
 		$wp_styles = null;
 
 		wp_register_script( 'agents-manager', 'https://example.com/agents-manager.js', array(), '1.0', true );
 
+		// Enable unified experience. Not a Jetpack site, so is_jetpack_disconnected() returns false.
 		add_filter( 'agents_manager_use_unified_experience', '__return_true', 20 );
-		add_filter( 'agents_manager_use_disconnected_variant', '__return_false', 20 );
 
 		$this->agents_manager->enqueue_scripts();
 
@@ -1811,9 +1827,8 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 		$this->assertTrue( isset( $wp_styles->registered['agents-manager-style'] ), 'CSS should be enqueued for wp-admin variant' );
 
 		remove_filter( 'agents_manager_use_unified_experience', '__return_true', 20 );
-		remove_filter( 'agents_manager_use_disconnected_variant', '__return_false', 20 );
 
-		// Test gutenberg-disconnected variant - should NOT enqueue CSS.
+		// Test gutenberg-disconnected variant (unified experience enabled + Jetpack disconnected) - should NOT enqueue CSS.
 		require_once ABSPATH . 'wp-admin/includes/screen.php';
 		set_current_screen( 'post' );
 		$screen = get_current_screen();
@@ -1828,8 +1843,10 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 		$wp_styles = null;
 		wp_register_script( 'agents-manager', 'https://example.com/agents-manager.js', array(), '1.0', true );
 
-		add_filter( 'agents_manager_use_unified_experience', '__return_false', 20 );
-		add_filter( 'agents_manager_use_disconnected_variant', '__return_true', 20 );
+		// Enable unified experience and simulate a Jetpack site with a disconnected user.
+		add_filter( 'agents_manager_use_unified_experience', '__return_true', 20 );
+		add_filter( 'is_jetpack_site', '__return_true', 20 );
+		// Do not connect the user - is_user_connected() will return false by default.
 
 		$this->agents_manager->enqueue_scripts();
 
@@ -1838,8 +1855,8 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 		// @phan-suppress-next-line PhanSuspiciousValueComparison - WordPress may initialize $wp_styles during enqueue
 		$this->assertTrue( null === $wp_styles || ! isset( $wp_styles->registered['agents-manager-style'] ), 'CSS should NOT be enqueued for gutenberg-disconnected variant' );
 
-		remove_filter( 'agents_manager_use_unified_experience', '__return_false', 20 );
-		remove_filter( 'agents_manager_use_disconnected_variant', '__return_true', 20 );
+		remove_filter( 'agents_manager_use_unified_experience', '__return_true', 20 );
+		remove_filter( 'is_jetpack_site', '__return_true', 20 );
 	}
 
 	/**
@@ -1877,6 +1894,37 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 		$this->assertNull( $node, 'No admin bar node should be added on P2 frontend' );
 
 		remove_all_filters( 'stylesheet' );
+	}
+
+	/**
+	 * Tests that should_enqueue_script returns false in CIAB environment when Jetpack is connected.
+	 *
+	 * Connected CIAB is handled by Help Center; Agents Manager should not load.
+	 */
+	public function test_should_enqueue_script_returns_false_in_ciab_when_connected() {
+		$this->set_admin_context();
+
+		// Save and simulate CIAB environment.
+		global $wp_actions;
+		$original_action_count = $wp_actions['next_admin_init'] ?? 0;
+		do_action( 'next_admin_init' );
+
+		// Enable unified experience but do NOT simulate a Jetpack disconnected site.
+		// is_jetpack_disconnected() returns false for non-Jetpack sites.
+		add_filter( 'agents_manager_use_unified_experience', '__return_true', 20 );
+
+		$result = $this->call_should_enqueue_script();
+
+		remove_filter( 'agents_manager_use_unified_experience', '__return_true', 20 );
+
+		// Restore did_action counter.
+		if ( $original_action_count === 0 ) {
+			unset( $wp_actions['next_admin_init'] );
+		} else {
+			$wp_actions['next_admin_init'] = $original_action_count;
+		}
+
+		$this->assertFalse( $result );
 	}
 
 	/**

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/agents-manager/Agents_Manager_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/agents-manager/Agents_Manager_Test.php
@@ -1501,6 +1501,7 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 		wp_register_script( 'agents-manager', 'https://example.com/agents-manager.js', array(), '1.0', true );
 
 		add_filter( 'agents_manager_use_unified_experience', '__return_true', 20 );
+		add_filter( 'agents_manager_use_disconnected_variant', '__return_false', 20 );
 
 		$this->agents_manager->enqueue_scripts();
 
@@ -1511,6 +1512,7 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 		$this->assertStringContainsString( '"sectionName":"wp-admin"', $inline_script );
 
 		remove_filter( 'agents_manager_use_unified_experience', '__return_true', 20 );
+		remove_filter( 'agents_manager_use_disconnected_variant', '__return_false', 20 );
 	}
 
 	/**
@@ -1538,6 +1540,7 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 		wp_register_script( 'agents-manager', 'https://example.com/agents-manager.js', array(), '1.0', true );
 
 		add_filter( 'agents_manager_use_unified_experience', '__return_true', 20 );
+		add_filter( 'agents_manager_use_disconnected_variant', '__return_false', 20 );
 
 		$this->agents_manager->enqueue_scripts();
 
@@ -1548,6 +1551,7 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 		$this->assertStringContainsString( '"sectionName":"gutenberg"', $inline_script );
 
 		remove_filter( 'agents_manager_use_unified_experience', '__return_true', 20 );
+		remove_filter( 'agents_manager_use_disconnected_variant', '__return_false', 20 );
 	}
 
 	/**
@@ -1578,6 +1582,7 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 		wp_register_script( 'agents-manager', 'https://example.com/agents-manager.js', array(), '1.0', true );
 
 		add_filter( 'agents_manager_use_unified_experience', '__return_true', 20 );
+		add_filter( 'agents_manager_use_disconnected_variant', '__return_false', 20 );
 
 		$this->agents_manager->enqueue_scripts();
 
@@ -1588,5 +1593,6 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 		$this->assertStringContainsString( '"sectionName":"wp-admin"', $inline_script );
 
 		remove_filter( 'agents_manager_use_unified_experience', '__return_true', 20 );
+		remove_filter( 'agents_manager_use_disconnected_variant', '__return_false', 20 );
 	}
 }

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/agents-manager/Agents_Manager_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/agents-manager/Agents_Manager_Test.php
@@ -1822,7 +1822,9 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 
 		$this->agents_manager->enqueue_scripts();
 
-		$this->assertFalse( isset( $wp_styles->registered['agents-manager-style'] ), 'CSS should NOT be enqueued for gutenberg-disconnected variant' );
+		// For gutenberg-disconnected variant, CSS should not be enqueued.
+		// $wp_styles may be null if wp_enqueue_style was never called.
+		$this->assertTrue( null === $wp_styles || ! isset( $wp_styles->registered['agents-manager-style'] ), 'CSS should NOT be enqueued for gutenberg-disconnected variant' );
 
 		remove_filter( 'agents_manager_use_unified_experience', '__return_false', 20 );
 		remove_filter( 'agents_manager_use_disconnected_variant', '__return_true', 20 );

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/agents-manager/Agents_Manager_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/agents-manager/Agents_Manager_Test.php
@@ -1772,9 +1772,59 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 
 		// Should use wp-admin, not wp-admin-disconnected, because unified experience takes precedence.
 		$this->assertStringContainsString( '"sectionName":"wp-admin"', $inline_script );
-		$this->assertStringNotContainsString( 'disconnected', $inline_script );
+		$this->assertStringNotContainsString( '"sectionName":"wp-admin-disconnected"', $inline_script );
+		$this->assertStringNotContainsString( '"sectionName":"gutenberg-disconnected"', $inline_script );
+		$this->assertStringNotContainsString( '"sectionName":"ciab-disconnected"', $inline_script );
 
 		remove_filter( 'agents_manager_use_unified_experience', '__return_true', 20 );
+		remove_filter( 'agents_manager_use_disconnected_variant', '__return_true', 20 );
+	}
+
+	/**
+	 * Tests that CSS is enqueued for wp-admin variants but not for gutenberg or ciab variants.
+	 */
+	public function test_css_enqueued_only_for_wp_admin_variants() {
+		// Test wp-admin variant - should enqueue CSS.
+		$this->set_admin_context();
+		global $wp_styles;
+		$wp_styles = null;
+
+		wp_register_script( 'agents-manager', 'https://example.com/agents-manager.js', array(), '1.0', true );
+
+		add_filter( 'agents_manager_use_unified_experience', '__return_true', 20 );
+		add_filter( 'agents_manager_use_disconnected_variant', '__return_false', 20 );
+
+		$this->agents_manager->enqueue_scripts();
+
+		$this->assertNotNull( $wp_styles, 'wp_styles should be initialized' );
+		$this->assertTrue( isset( $wp_styles->registered['agents-manager-style'] ), 'CSS should be enqueued for wp-admin variant' );
+
+		remove_filter( 'agents_manager_use_unified_experience', '__return_true', 20 );
+		remove_filter( 'agents_manager_use_disconnected_variant', '__return_false', 20 );
+
+		// Test gutenberg-disconnected variant - should NOT enqueue CSS.
+		require_once ABSPATH . 'wp-admin/includes/screen.php';
+		set_current_screen( 'post' );
+		$screen = get_current_screen();
+
+		$reflection = new \ReflectionClass( $screen );
+		$property   = $reflection->getProperty( 'is_block_editor' );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$property->setAccessible( true );
+		}
+		$property->setValue( $screen, true );
+
+		$wp_styles = null;
+		wp_register_script( 'agents-manager', 'https://example.com/agents-manager.js', array(), '1.0', true );
+
+		add_filter( 'agents_manager_use_unified_experience', '__return_false', 20 );
+		add_filter( 'agents_manager_use_disconnected_variant', '__return_true', 20 );
+
+		$this->agents_manager->enqueue_scripts();
+
+		$this->assertFalse( isset( $wp_styles->registered['agents-manager-style'] ), 'CSS should NOT be enqueued for gutenberg-disconnected variant' );
+
+		remove_filter( 'agents_manager_use_unified_experience', '__return_false', 20 );
 		remove_filter( 'agents_manager_use_disconnected_variant', '__return_true', 20 );
 	}
 }

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/agents-manager/Agents_Manager_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/agents-manager/Agents_Manager_Test.php
@@ -1817,6 +1817,7 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 		$wp_styles = null;
 
 		wp_register_script( 'agents-manager', 'https://example.com/agents-manager.js', array(), '1.0', true );
+		wp_register_style( 'agents-manager-style', 'https://example.com/agents-manager.css', array(), '1.0' );
 
 		// Enable unified experience. Not a Jetpack site, so is_jetpack_disconnected() returns false.
 		add_filter( 'agents_manager_use_unified_experience', '__return_true', 20 );

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/agents-manager/Agents_Manager_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/agents-manager/Agents_Manager_Test.php
@@ -1830,4 +1830,41 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 		remove_filter( 'agents_manager_use_unified_experience', '__return_false', 20 );
 		remove_filter( 'agents_manager_use_disconnected_variant', '__return_true', 20 );
 	}
+
+	/**
+	 * Tests that scripts are not enqueued on P2 frontend.
+	 *
+	 * This verifies the P2 frontend detection logic (lines 203-209 in class-agents-manager.php)
+	 * that prevents Agents Manager from loading on P2 sites when not in admin context.
+	 */
+	public function test_scripts_not_enqueued_on_p2_frontend() {
+		global $wp_admin_bar;
+
+		// Ensure we're on the frontend (not admin).
+		$this->assertFalse( is_admin() );
+
+		// Test with pub/p2 stylesheet.
+		add_filter(
+			'stylesheet',
+			function () {
+				return 'pub/p2v2';
+			}
+		);
+
+		// Initialize admin bar.
+		require_once ABSPATH . 'wp-includes/class-wp-admin-bar.php';
+		$wp_admin_bar = new \WP_Admin_Bar();
+		$wp_admin_bar->initialize();
+
+		// Call enqueue_scripts which should return early for P2 frontend.
+		// The method should detect P2 frontend and return before adding admin bar nodes or enqueuing scripts.
+		$this->agents_manager->enqueue_scripts();
+
+		// Verify no admin bar nodes were added.
+		// The agents-manager admin bar node should not exist if the method returned early.
+		$node = $wp_admin_bar->get_node( 'agents-manager' );
+		$this->assertNull( $node, 'No admin bar node should be added on P2 frontend' );
+
+		remove_all_filters( 'stylesheet' );
+	}
 }

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/agents-manager/Agents_Manager_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/agents-manager/Agents_Manager_Test.php
@@ -1824,6 +1824,7 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 
 		// For gutenberg-disconnected variant, CSS should not be enqueued.
 		// $wp_styles may be null if wp_enqueue_style was never called.
+		// @phan-suppress-next-line PhanSuspiciousValueComparison, PhanTypeExpectedObjectPropAccessButGotNull - WordPress may initialize $wp_styles during enqueue
 		$this->assertTrue( null === $wp_styles || ! isset( $wp_styles->registered['agents-manager-style'] ), 'CSS should NOT be enqueued for gutenberg-disconnected variant' );
 
 		remove_filter( 'agents_manager_use_unified_experience', '__return_false', 20 );

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/agents-manager/Agents_Manager_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/agents-manager/Agents_Manager_Test.php
@@ -1595,4 +1595,186 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 		remove_filter( 'agents_manager_use_unified_experience', '__return_true', 20 );
 		remove_filter( 'agents_manager_use_disconnected_variant', '__return_false', 20 );
 	}
+
+	/**
+	 * Tests that enqueue_scripts includes sectionName as wp-admin-disconnected when disconnected variant is enabled.
+	 */
+	public function test_enqueue_scripts_includes_section_name_wp_admin_disconnected() {
+		// Set admin context - scripts only enqueue in admin.
+		$this->set_admin_context();
+
+		// Reset the script registry.
+		global $wp_scripts;
+		$wp_scripts = null;
+
+		wp_register_script( 'agents-manager', 'https://example.com/agents-manager.js', array(), '1.0', true );
+
+		// Enable disconnected variant, disable unified experience.
+		add_filter( 'agents_manager_use_unified_experience', '__return_false', 20 );
+		add_filter( 'agents_manager_use_disconnected_variant', '__return_true', 20 );
+
+		$this->agents_manager->enqueue_scripts();
+
+		$this->assertNotNull( $wp_scripts, 'wp_scripts should be initialized after enqueue_scripts' );
+		$inline_scripts = $wp_scripts->registered['agents-manager']->extra['before'] ?? array();
+		$inline_script  = implode( "\n", array_filter( $inline_scripts ) );
+
+		$this->assertStringContainsString( '"sectionName":"wp-admin-disconnected"', $inline_script );
+
+		remove_filter( 'agents_manager_use_unified_experience', '__return_false', 20 );
+		remove_filter( 'agents_manager_use_disconnected_variant', '__return_true', 20 );
+	}
+
+	/**
+	 * Tests that enqueue_scripts includes sectionName as gutenberg-disconnected in block editor with disconnected variant.
+	 */
+	public function test_enqueue_scripts_includes_section_name_gutenberg_disconnected() {
+		require_once ABSPATH . 'wp-admin/includes/screen.php';
+
+		// Set up block editor context.
+		set_current_screen( 'post' );
+		$screen = get_current_screen();
+
+		// Use reflection to set the block_editor property.
+		$reflection = new \ReflectionClass( $screen );
+		$property   = $reflection->getProperty( 'is_block_editor' );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$property->setAccessible( true );
+		}
+		$property->setValue( $screen, true );
+
+		// Reset the script registry.
+		global $wp_scripts;
+		$wp_scripts = null;
+
+		wp_register_script( 'agents-manager', 'https://example.com/agents-manager.js', array(), '1.0', true );
+
+		// Enable disconnected variant, disable unified experience.
+		add_filter( 'agents_manager_use_unified_experience', '__return_false', 20 );
+		add_filter( 'agents_manager_use_disconnected_variant', '__return_true', 20 );
+
+		$this->agents_manager->enqueue_scripts();
+
+		$this->assertNotNull( $wp_scripts, 'wp_scripts should be initialized after enqueue_scripts' );
+		$inline_scripts = $wp_scripts->registered['agents-manager']->extra['before'] ?? array();
+		$inline_script  = implode( "\n", array_filter( $inline_scripts ) );
+
+		$this->assertStringContainsString( '"sectionName":"gutenberg-disconnected"', $inline_script );
+
+		remove_filter( 'agents_manager_use_unified_experience', '__return_false', 20 );
+		remove_filter( 'agents_manager_use_disconnected_variant', '__return_true', 20 );
+	}
+
+	/**
+	 * Tests that enqueue_scripts includes sectionName as ciab-disconnected in CIAB environment with disconnected variant.
+	 */
+	public function test_enqueue_scripts_includes_section_name_ciab_disconnected() {
+		// Set admin context - scripts only enqueue in admin.
+		$this->set_admin_context();
+
+		// Simulate CIAB environment by firing the next_admin_init action.
+		do_action( 'next_admin_init' );
+
+		// Reset the script registry.
+		global $wp_scripts;
+		$wp_scripts = null;
+
+		wp_register_script( 'agents-manager', 'https://example.com/agents-manager.js', array(), '1.0', true );
+
+		// Enable disconnected variant, disable unified experience.
+		add_filter( 'agents_manager_use_unified_experience', '__return_false', 20 );
+		add_filter( 'agents_manager_use_disconnected_variant', '__return_true', 20 );
+
+		$this->agents_manager->enqueue_scripts();
+
+		$this->assertNotNull( $wp_scripts, 'wp_scripts should be initialized after enqueue_scripts' );
+		$inline_scripts = $wp_scripts->registered['agents-manager']->extra['before'] ?? array();
+		$inline_script  = implode( "\n", array_filter( $inline_scripts ) );
+
+		$this->assertStringContainsString( '"sectionName":"ciab-disconnected"', $inline_script );
+
+		remove_filter( 'agents_manager_use_unified_experience', '__return_false', 20 );
+		remove_filter( 'agents_manager_use_disconnected_variant', '__return_true', 20 );
+	}
+
+	/**
+	 * Tests that should_enqueue_script returns true when disconnected variant is enabled in wp-admin.
+	 */
+	public function test_should_enqueue_script_returns_true_when_disconnected_variant_enabled_in_admin() {
+		$this->set_admin_context();
+		$_SERVER['REQUEST_URI'] = '/wp-admin/index.php';
+
+		// Enable disconnected variant, disable unified experience.
+		add_filter( 'agents_manager_use_unified_experience', '__return_false', 20 );
+		add_filter( 'agents_manager_use_disconnected_variant', '__return_true', 20 );
+
+		$result = $this->call_should_enqueue_script();
+
+		remove_filter( 'agents_manager_use_unified_experience', '__return_false', 20 );
+		remove_filter( 'agents_manager_use_disconnected_variant', '__return_true', 20 );
+
+		$this->assertTrue( $result );
+	}
+
+	/**
+	 * Tests that should_enqueue_script returns true when disconnected variant is enabled in block editor.
+	 */
+	public function test_should_enqueue_script_returns_true_when_disconnected_variant_enabled_in_block_editor() {
+		require_once ABSPATH . 'wp-admin/includes/screen.php';
+
+		// Set up block editor context.
+		set_current_screen( 'post' );
+		$screen = get_current_screen();
+
+		// Use reflection to set the block_editor property.
+		$reflection = new \ReflectionClass( $screen );
+		$property   = $reflection->getProperty( 'is_block_editor' );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$property->setAccessible( true );
+		}
+		$property->setValue( $screen, true );
+
+		// Enable disconnected variant, disable unified experience.
+		add_filter( 'agents_manager_use_unified_experience', '__return_false', 20 );
+		add_filter( 'agents_manager_use_disconnected_variant', '__return_true', 20 );
+
+		$result = $this->call_should_enqueue_script();
+
+		remove_filter( 'agents_manager_use_unified_experience', '__return_false', 20 );
+		remove_filter( 'agents_manager_use_disconnected_variant', '__return_true', 20 );
+
+		$this->assertTrue( $result );
+	}
+
+	/**
+	 * Tests that disconnected variant is not used when unified experience is enabled.
+	 */
+	public function test_disconnected_variant_not_used_when_unified_experience_enabled() {
+		// Set admin context.
+		$this->set_admin_context();
+
+		// Reset the script registry.
+		global $wp_scripts;
+		$wp_scripts = null;
+
+		wp_register_script( 'agents-manager', 'https://example.com/agents-manager.js', array(), '1.0', true );
+
+		// Enable both unified experience and disconnected variant filter.
+		// Unified experience should take precedence.
+		add_filter( 'agents_manager_use_unified_experience', '__return_true', 20 );
+		add_filter( 'agents_manager_use_disconnected_variant', '__return_true', 20 );
+
+		$this->agents_manager->enqueue_scripts();
+
+		$this->assertNotNull( $wp_scripts, 'wp_scripts should be initialized after enqueue_scripts' );
+		$inline_scripts = $wp_scripts->registered['agents-manager']->extra['before'] ?? array();
+		$inline_script  = implode( "\n", array_filter( $inline_scripts ) );
+
+		// Should use wp-admin, not wp-admin-disconnected, because unified experience takes precedence.
+		$this->assertStringContainsString( '"sectionName":"wp-admin"', $inline_script );
+		$this->assertStringNotContainsString( 'disconnected', $inline_script );
+
+		remove_filter( 'agents_manager_use_unified_experience', '__return_true', 20 );
+		remove_filter( 'agents_manager_use_disconnected_variant', '__return_true', 20 );
+	}
 }

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/agents-manager/Agents_Manager_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/agents-manager/Agents_Manager_Test.php
@@ -1229,6 +1229,37 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
+	 * Tests that get_variant returns wp-admin-disconnected on the frontend for eligible logged-in editors.
+	 *
+	 * Covers the frontend loading path in get_variant(): a logged-in editor (can edit_posts + member of blog)
+	 * on a non-admin, non-P2 page with unified experience enabled should get the wp-admin-disconnected variant.
+	 */
+	public function test_get_variant_returns_wp_admin_disconnected_on_frontend_for_eligible_editor() {
+		// Ensure we're on the frontend (not admin) - default test state.
+		$this->assertFalse( is_admin() );
+
+		// Create a user with editor capabilities so current_user_can( 'edit_posts' ) returns true.
+		$user_id = wp_insert_user(
+			array(
+				'user_login' => 'test_frontend_editor',
+				'user_pass'  => 'password',
+				'role'       => 'editor',
+			)
+		);
+		wp_set_current_user( $user_id );
+
+		// Enable unified experience.
+		add_filter( 'agents_manager_use_unified_experience', '__return_true', 20 );
+
+		$variant = $this->call_get_variant();
+
+		remove_filter( 'agents_manager_use_unified_experience', '__return_true', 20 );
+		wp_set_current_user( 0 );
+
+		$this->assertSame( 'wp-admin-disconnected', $variant );
+	}
+
+	/**
 	 * Tests that should_enqueue_script returns false in customizer preview.
 	 *
 	 * The is_customize_preview() function checks global $wp_customize, so we set it up directly
@@ -1852,7 +1883,7 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 		$this->agents_manager->enqueue_scripts();
 
 		$this->assertNotNull( $wp_styles, 'wp_styles should be initialized' );
-		$this->assertTrue( isset( $wp_styles->registered['agents-manager-style'] ), 'CSS should be enqueued for wp-admin variant' );
+		$this->assertTrue( wp_style_is( 'agents-manager-style', 'enqueued' ), 'CSS should be enqueued for wp-admin variant' );
 
 		remove_filter( 'agents_manager_use_unified_experience', '__return_true', 20 );
 
@@ -1879,9 +1910,7 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 		$this->agents_manager->enqueue_scripts();
 
 		// For gutenberg-disconnected variant, CSS should not be enqueued.
-		// $wp_styles may be null if wp_enqueue_style was never called.
-		// @phan-suppress-next-line PhanSuspiciousValueComparison - WordPress may initialize $wp_styles during enqueue
-		$this->assertTrue( null === $wp_styles || ! isset( $wp_styles->registered['agents-manager-style'] ), 'CSS should NOT be enqueued for gutenberg-disconnected variant' );
+		$this->assertFalse( wp_style_is( 'agents-manager-style', 'enqueued' ), 'CSS should NOT be enqueued for gutenberg-disconnected variant' );
 
 		remove_filter( 'agents_manager_use_unified_experience', '__return_true', 20 );
 		remove_filter( 'is_jetpack_site', '__return_true', 20 );
@@ -1900,12 +1929,10 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 		$this->assertFalse( is_admin() );
 
 		// Test with pub/p2 stylesheet.
-		add_filter(
-			'stylesheet',
-			function () {
-				return 'pub/p2v2';
-			}
-		);
+		$p2_stylesheet_filter = function () {
+			return 'pub/p2v2';
+		};
+		add_filter( 'stylesheet', $p2_stylesheet_filter );
 
 		// Initialize admin bar.
 		require_once ABSPATH . 'wp-includes/class-wp-admin-bar.php';
@@ -1921,7 +1948,7 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 		$node = $wp_admin_bar->get_node( 'agents-manager' );
 		$this->assertNull( $node, 'No admin bar node should be added on P2 frontend' );
 
-		remove_all_filters( 'stylesheet' );
+		remove_filter( 'stylesheet', $p2_stylesheet_filter );
 	}
 
 	/**
@@ -1966,6 +1993,13 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 		require_once ABSPATH . 'wp-admin/includes/screen.php';
 		set_current_screen( 'woocommerce_page_wc-admin' );
 
-		$this->assertFalse( $this->call_should_enqueue_script(), 'should_enqueue_script should return false on WooCommerce Admin home page' );
+		// Enable unified experience so that Agents Manager is active and the WooCommerce exclusion is exercised.
+		add_filter( 'agents_manager_use_unified_experience', '__return_true', 20 );
+
+		$result = $this->call_should_enqueue_script();
+
+		remove_filter( 'agents_manager_use_unified_experience', '__return_true', 20 );
+
+		$this->assertFalse( $result, 'should_enqueue_script should return false on WooCommerce Admin home page' );
 	}
 }

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/agents-manager/Agents_Manager_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/agents-manager/Agents_Manager_Test.php
@@ -1835,7 +1835,7 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
-	 * Tests that CSS is enqueued for wp-admin variants but not for gutenberg or ciab variants.
+	 * Tests that CSS is enqueued for connected variants but not for gutenberg-disconnected or ciab-disconnected.
 	 */
 	public function test_css_enqueued_only_for_wp_admin_variants() {
 		// Test wp-admin variant (connected) - should enqueue CSS.

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/agents-manager/Agents_Manager_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/agents-manager/Agents_Manager_Test.php
@@ -1672,6 +1672,10 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 		// Set admin context - scripts only enqueue in admin.
 		$this->set_admin_context();
 
+		// Save the current did_action counter for next_admin_init to restore later.
+		global $wp_actions;
+		$original_action_count = $wp_actions['next_admin_init'] ?? 0;
+
 		// Simulate CIAB environment by firing the next_admin_init action.
 		do_action( 'next_admin_init' );
 
@@ -1695,6 +1699,13 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 
 		remove_filter( 'agents_manager_use_unified_experience', '__return_false', 20 );
 		remove_filter( 'agents_manager_use_disconnected_variant', '__return_true', 20 );
+
+		// Restore the original did_action counter to prevent test order dependencies.
+		if ( $original_action_count === 0 ) {
+			unset( $wp_actions['next_admin_init'] );
+		} else {
+			$wp_actions['next_admin_init'] = $original_action_count;
+		}
 	}
 
 	/**
@@ -1824,7 +1835,7 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 
 		// For gutenberg-disconnected variant, CSS should not be enqueued.
 		// $wp_styles may be null if wp_enqueue_style was never called.
-		// @phan-suppress-next-line PhanSuspiciousValueComparison, PhanTypeExpectedObjectPropAccessButGotNull - WordPress may initialize $wp_styles during enqueue
+		// @phan-suppress-next-line PhanSuspiciousValueComparison - WordPress may initialize $wp_styles during enqueue
 		$this->assertTrue( null === $wp_styles || ! isset( $wp_styles->registered['agents-manager-style'] ), 'CSS should NOT be enqueued for gutenberg-disconnected variant' );
 
 		remove_filter( 'agents_manager_use_unified_experience', '__return_false', 20 );
@@ -1866,5 +1877,19 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 		$this->assertNull( $node, 'No admin bar node should be added on P2 frontend' );
 
 		remove_all_filters( 'stylesheet' );
+	}
+
+	/**
+	 * Tests that should_enqueue_script returns false on WooCommerce Admin home page.
+	 *
+	 * This verifies the WooCommerce Admin exclusion to avoid UI conflicts,
+	 * matching the same exclusion in Help_Center::enqueue_wp_admin_scripts().
+	 */
+	public function test_should_enqueue_script_returns_false_on_woocommerce_admin_home() {
+		// Set admin context first.
+		require_once ABSPATH . 'wp-admin/includes/screen.php';
+		set_current_screen( 'woocommerce_page_wc-admin' );
+
+		$this->assertFalse( $this->call_should_enqueue_script(), 'should_enqueue_script should return false on WooCommerce Admin home page' );
 	}
 }

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/agents-manager/Agents_Manager_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/agents-manager/Agents_Manager_Test.php
@@ -1499,6 +1499,33 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
+	 * Tests that enqueue_scripts includes helpCenterUrl in agentsManagerData.
+	 */
+	public function test_enqueue_scripts_includes_help_center_url() {
+		// Set admin context - scripts only enqueue in admin.
+		$this->set_admin_context();
+
+		// Reset the script registry.
+		global $wp_scripts;
+		$wp_scripts = null;
+
+		wp_register_script( 'agents-manager', 'https://example.com/agents-manager.js', array(), '1.0', true );
+
+		add_filter( 'agents_manager_use_unified_experience', '__return_true', 20 );
+
+		$this->agents_manager->enqueue_scripts();
+
+		$this->assertNotNull( $wp_scripts, 'wp_scripts should be initialized after enqueue_scripts' );
+		$inline_scripts = $wp_scripts->registered['agents-manager']->extra['before'] ?? array();
+		$inline_script  = implode( "\n", array_filter( $inline_scripts ) );
+
+		$this->assertStringContainsString( '"helpCenterUrl":', $inline_script );
+		$this->assertStringContainsString( 'https://wordpress.com/help?help-center=home', $inline_script );
+
+		remove_filter( 'agents_manager_use_unified_experience', '__return_true', 20 );
+	}
+
+	/**
 	 * Tests that enqueue_scripts includes sectionName as wp-admin by default.
 	 */
 	public function test_enqueue_scripts_includes_section_name_wp_admin() {
@@ -1863,8 +1890,8 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 	/**
 	 * Tests that scripts are not enqueued on P2 frontend.
 	 *
-	 * This verifies the P2 frontend detection logic (lines 203-209 in class-agents-manager.php)
-	 * that prevents Agents Manager from loading on P2 sites when not in admin context.
+	 * This verifies the P2 frontend detection logic that prevents Agents Manager
+	 * from loading on P2 sites when not in admin context.
 	 */
 	public function test_scripts_not_enqueued_on_p2_frontend() {
 		global $wp_admin_bar;


### PR DESCRIPTION
Adds disconnected variants to the Agents Manager init file. These load minimal versions that insert help icons in situations where the unified UI is enabled, but the Agents Manager can't otherwise be shown:
- wp-admin
- Gutenberg
- CIAB
- front-end (logged in)

Typically the situation where it can't be shown is when Jetpack is disconnected.

It also fixes an issue with P2, and now loads on general logged-in front end pages.

The new changes here will load https://wordpress.com/help?help-center=home, the same as Help Center. In general Help Center is left to load as normal, apart from Gutenberg where doing so interferes with Agents Manager.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Testing instructions:
The main thing is to test the 'new behaviour' parts. The 'no change' parts should be unaffected, but for completeness the unified connected & disconnected need testing to make sure nothing changes for the connected version.

Basic setup:
- In a sandbox run: `bin/jetpack-downloader test jetpack-mu-wpcom-plugin update/agents-manager-disconnected`
- In Calyspo:
  - `cd apps/agents-manager`
  - `yarn dev --sync`

### wp-admin

To connect/disconnect Jetpack you can edit both Agents Manager and Help Center so:
- `wp-content/mu-plugins/jetpack-mu-wpcom-plugin/[THING]/jetpack_vendor/automattic/jetpack-mu-wpcom/src/features/agents-manager/class-agents-manager.php` and `return true` in `is_jetpack_disconnected`
- `wp-content/mu-plugins/jetpack-mu-wpcom-plugin/[THING]/jetpack_vendor/automattic/jetpack-mu-wpcom/src/features/help-center/class-help-center.php` and `return true` in `is_jetpack_disconnected`


| Unified | Jetpack | Code loaded | Help icon | Note |
|---------|---------|-------------|-----------|------|
| true | connected | agents-manager-wp-admin | Agents Manager dropdown | ✅ no change |
| true | disconnected | agents-manager-wp-admin-disconnected | Help page | ⚠️ new behaviour  |
| false | connected | help-center | Help Center opens | ✅ no change |
| false | disconnected | help-center-wp-admin-disconnected | Help page | ✅ no change |


### Gutenberg

For Gutenberg you need to edit a post.

| Unified | Jetpack | Code loaded | Help icon | Note |
|---------|---------|-------------|-----------|------|
| true | connected | agents-manager-gutenberg | - | ✅ no change |
| true | disconnected | agents-manager-gutenberg-disconnected | Help page | ⚠️ changed from current (1) |
| false | connected | help-center | Help Center opens | ✅ no change (2) |
| false | disconnected | help-center-gutenberg-disconnected | Help page | ✅ no change (3) |

(1) No CSS should be loaded, only JS
(2) Both Big Sky and Help Center are loaded. The `?` button opens Help Center
(3) The help button doesn't seem to appear, although the code is there

### P2
| Unified | Jetpack | Code loaded | Help icon | Note |
|---------|---------|-------------|-----------|------|
| true | connected | - | - | ⚠️ changed from current |
| true | disconnected | - | - | ⚠️ changed from current |
| false | connected | - | - | ✅ no change |
| false | disconnected | - | - | ✅ no change |

### General WP front end page
When logged in:
| Unified | Jetpack | Code loaded | Help icon | Note |
|---------|---------|-------------|-----------|------|
| true | connected | agents-manager-wp-admin-disconnected | Help page | ⚠️ changed from current |
| true | disconnected | agents-manager-wp-admin-disconnected | Help page | ⚠️ changed from current |
| false | connected | help-center-wp-admin-disconnected | Help page | ✅ no change |
| false | disconnected | help-center-wp-admin-disconnected | Help page | ✅ no change |

### CIAB
- Set up a CIAB dev site with a `.wp-env.override.json` file (shown below)
- `wp-env start`
- Edit `class-agents-manager.php` in Jetpack, and shortcut `should_use_unified_experience` to return `true` - this fakes the unified UI

CIAB config:
This basically just maps the Agents Manager Jetpack plugin to your code
```json
{
  "port": 11080,
  "testsPort": 11089,
  "config": {
    "WP_MEMORY_LIMIT": "512M"
  },
  "mappings": {
    "wp-content/plugins/help-center": "[PATH TO HELP CENTER IN JETPACK]"
    "wp-content/plugins/agents-manager": "[PATH TO AGENTS MANAGER IN JETPACK]"
  }
}
```

| Unified | Jetpack | Code loaded | Help icon | Note |
|---------|---------|-------------|-----------|------|
| true | connected | - | - | ✅ no change |
| true | disconnected | agents-manager-ciab-disconnected | Help page | ⚠️ changed from current (1) |
| false | connected | help-center-ciab-disconnected | Help center | ✅ no change (2) |
| false | disconnected | help-center-ciab-disconnected | Help page | ✅ no change |

(1) Extra code has been added to exclude the CIAB site preview. Help center still loads in this but it doesn't make sense to do so
(2) Clicking the icon on a local CIAB does nothing on my setup
