### PR TITLE
Forms: add copy embed and shortcode action to dashboard

### DIFF
--- a/projects/packages/forms/changelog/add-forms-add-paste-code
+++ b/projects/packages/forms/changelog/add-forms-add-paste-code
@@ -1,4 +1,4 @@
 Significance: minor
 Type: added
 
-Dashboard: add 'Copy embed' action to copy form embed code to clipboard.
+Dashboard: add 'Copy embed' and 'Copy shortcode' actions to copy form code to clipboard.

--- a/projects/packages/forms/changelog/add-forms-add-paste-code
+++ b/projects/packages/forms/changelog/add-forms-add-paste-code
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Dashboard: add 'Copy shortcode' action to copy form shortcode to clipboard.

--- a/projects/packages/forms/changelog/add-forms-add-paste-code
+++ b/projects/packages/forms/changelog/add-forms-add-paste-code
@@ -1,4 +1,4 @@
 Significance: minor
 Type: added
 
-Dashboard: add 'Copy embed' action to copy form shortcode to clipboard.
+Dashboard: add 'Copy embed' action to copy form embed code to clipboard.

--- a/projects/packages/forms/changelog/add-forms-add-paste-code
+++ b/projects/packages/forms/changelog/add-forms-add-paste-code
@@ -1,4 +1,4 @@
 Significance: minor
 Type: added
 
-Dashboard: add 'Copy shortcode' action to copy form shortcode to clipboard.
+Dashboard: add 'Copy embed' action to copy form shortcode to clipboard.

--- a/projects/packages/forms/routes/forms/stage.tsx
+++ b/projects/packages/forms/routes/forms/stage.tsx
@@ -240,50 +240,12 @@ function StageInner() {
 					openSingleFormView( item.id );
 				},
 			},
-			{
-				id: 'edit-form',
-				isPrimary: true,
-				label: __( 'Edit', 'jetpack-forms' ),
-				supportsBulk: false,
-				async callback( items: FormListItem[] ) {
-					const [ item ] = items;
-					if ( ! item ) {
-						return;
-					}
-					const fallbackEditUrl = `post.php?post=${ item.id }&action=edit&post_type=jetpack_form`;
-					const editUrl = item.editUrl || fallbackEditUrl;
-					const url = new URL( editUrl, window.location.origin );
-					window.location.href = url.toString();
-				},
-			},
-			{
-				id: 'preview-form',
-				isPrimary: false,
-				label: __( 'Preview', 'jetpack-forms' ),
-				supportsBulk: false,
-				async callback( items: FormListItem[] ) {
-					const [ item ] = items;
-					if ( ! item ) {
-						return;
-					}
-
-					try {
-						const response = await apiFetch< { preview_url: string } >( {
-							path: `/wp/v2/jetpack-forms/${ item.id }/preview-url`,
-						} );
-						window.open( response.preview_url, '_blank' );
-					} catch ( error ) {
-						// eslint-disable-next-line no-console
-						console.error( 'Failed to get preview URL:', error );
-					}
-				},
-			},
 		];
 
 		if ( isViewingTrash ) {
 			actionsList.push( {
 				id: 'restore-form',
-				isPrimary: false,
+				isPrimary: true,
 				label: __( 'Restore', 'jetpack-forms' ),
 				supportsBulk: true,
 				async callback( items: FormListItem[] ) {
@@ -316,35 +278,26 @@ function StageInner() {
 		}
 
 		actionsList.push( {
-			id: 'copy-embed',
-			isPrimary: false,
-			label: __( 'Copy embed', 'jetpack-forms' ),
+			id: 'edit-form',
+			isPrimary: true,
+			label: __( 'Edit', 'jetpack-forms' ),
 			supportsBulk: false,
 			async callback( items: FormListItem[] ) {
 				const [ item ] = items;
 				if ( ! item ) {
 					return;
 				}
-
-				const embedCode = `<!-- wp:jetpack/contact-form {"ref":${ item.id }} /-->`;
-				try {
-					await navigator.clipboard.writeText( embedCode );
-					createSuccessNotice( __( 'Embed code copied to clipboard.', 'jetpack-forms' ), {
-						type: 'snackbar',
-					} );
-				} catch {
-					createErrorNotice(
-						__( 'Failed to copy embed code. Please try again.', 'jetpack-forms' ),
-						{ type: 'snackbar' }
-					);
-				}
+				const fallbackEditUrl = `post.php?post=${ item.id }&action=edit&post_type=jetpack_form`;
+				const editUrl = item.editUrl || fallbackEditUrl;
+				const url = new URL( editUrl, window.location.origin );
+				window.location.href = url.toString();
 			},
 		} );
 
 		actionsList.push( {
-			id: 'copy-shortcode',
+			id: 'preview-form',
 			isPrimary: false,
-			label: __( 'Copy shortcode', 'jetpack-forms' ),
+			label: __( 'Preview', 'jetpack-forms' ),
 			supportsBulk: false,
 			async callback( items: FormListItem[] ) {
 				const [ item ] = items;
@@ -352,23 +305,76 @@ function StageInner() {
 					return;
 				}
 
-				if ( ! navigator.clipboard ) {
-					return;
-				}
-
-				const embedCode = `[contact-form ref="${ item.id }"]`;
 				try {
-					await navigator.clipboard.writeText( embedCode );
-					createSuccessNotice( __( 'Shortcode copied to clipboard.', 'jetpack-forms' ), {
-						type: 'snackbar',
+					const response = await apiFetch< { preview_url: string } >( {
+						path: `/wp/v2/jetpack-forms/${ item.id }/preview-url`,
 					} );
-				} catch {
-					createErrorNotice( __( 'Failed to copy shortcode. Please try again.', 'jetpack-forms' ), {
-						type: 'snackbar',
-					} );
+					window.open( response.preview_url, '_blank' );
+				} catch ( error ) {
+					// eslint-disable-next-line no-console
+					console.error( 'Failed to get preview URL:', error );
 				}
 			},
 		} );
+		if ( navigator?.clipboard ) {
+			actionsList.push( {
+				id: 'copy-embed',
+				isPrimary: false,
+				label: __( 'Copy embed', 'jetpack-forms' ),
+				supportsBulk: false,
+				async callback( items: FormListItem[] ) {
+					const [ item ] = items;
+					if ( ! item ) {
+						return;
+					}
+
+					const embedCode = `<!-- wp:jetpack/contact-form {"ref":${ item.id }} /-->`;
+					try {
+						await navigator.clipboard.writeText( embedCode );
+						createSuccessNotice( __( 'Embed code copied to clipboard.', 'jetpack-forms' ), {
+							type: 'snackbar',
+						} );
+					} catch {
+						createErrorNotice(
+							__( 'Failed to copy embed code. Please try again.', 'jetpack-forms' ),
+							{ type: 'snackbar' }
+						);
+					}
+				},
+			} );
+
+			actionsList.push( {
+				id: 'copy-shortcode',
+				isPrimary: false,
+				label: __( 'Copy shortcode', 'jetpack-forms' ),
+				supportsBulk: false,
+				async callback( items: FormListItem[] ) {
+					const [ item ] = items;
+					if ( ! item ) {
+						return;
+					}
+
+					if ( ! navigator.clipboard ) {
+						return;
+					}
+
+					const embedCode = `[contact-form ref="${ item.id }"]`;
+					try {
+						await navigator.clipboard.writeText( embedCode );
+						createSuccessNotice( __( 'Shortcode copied to clipboard.', 'jetpack-forms' ), {
+							type: 'snackbar',
+						} );
+					} catch {
+						createErrorNotice(
+							__( 'Failed to copy shortcode. Please try again.', 'jetpack-forms' ),
+							{
+								type: 'snackbar',
+							}
+						);
+					}
+				},
+			} );
+		}
 
 		actionsList.push( {
 			id: 'trash-form',

--- a/projects/packages/forms/routes/forms/stage.tsx
+++ b/projects/packages/forms/routes/forms/stage.tsx
@@ -289,7 +289,7 @@ function StageInner() {
 						return;
 					}
 
-					const embedCode = `[contact-form ref="${ item.id }"]`;
+					const embedCode = `<!-- wp:jetpack/contact-form {"ref":${ item.id }} /-->`;
 					try {
 						await navigator.clipboard.writeText( embedCode );
 						createSuccessNotice( __( 'Embed code copied to clipboard.', 'jetpack-forms' ), {
@@ -298,6 +298,31 @@ function StageInner() {
 					} catch {
 						createErrorNotice(
 							__( 'Failed to copy embed code. Please try again.', 'jetpack-forms' ),
+							{ type: 'snackbar' }
+						);
+					}
+				},
+			},
+			{
+				id: 'copy-shortcode',
+				isPrimary: false,
+				label: __( 'Copy shortcode', 'jetpack-forms' ),
+				supportsBulk: false,
+				async callback( items: FormListItem[] ) {
+					const [ item ] = items;
+					if ( ! item ) {
+						return;
+					}
+
+					const embedCode = `[contact-form ref="${ item.id }"]`;
+					try {
+						await navigator.clipboard.writeText( embedCode );
+						createSuccessNotice( __( 'Shortcode copied to clipboard.', 'jetpack-forms' ), {
+							type: 'snackbar',
+						} );
+					} catch {
+						createErrorNotice(
+							__( 'Failed to copy shortcode. Please try again.', 'jetpack-forms' ),
 							{ type: 'snackbar' }
 						);
 					}

--- a/projects/packages/forms/routes/forms/stage.tsx
+++ b/projects/packages/forms/routes/forms/stage.tsx
@@ -279,7 +279,7 @@ function StageInner() {
 				},
 			},
 			{
-				id: 'copy-shortcode',
+				id: 'copy-embed',
 				isPrimary: false,
 				label: __( 'Copy embed', 'jetpack-forms' ),
 				supportsBulk: false,
@@ -289,15 +289,15 @@ function StageInner() {
 						return;
 					}
 
-					const shortcode = `[contact-form ref="${ item.id }"]`;
+					const embedCode = `[contact-form ref="${ item.id }"]`;
 					try {
-						await navigator.clipboard.writeText( shortcode );
-						createSuccessNotice( __( 'Shortcode copied to clipboard.', 'jetpack-forms' ), {
+						await navigator.clipboard.writeText( embedCode );
+						createSuccessNotice( __( 'Embed code copied to clipboard.', 'jetpack-forms' ), {
 							type: 'snackbar',
 						} );
 					} catch {
 						createErrorNotice(
-							__( 'Failed to copy shortcode. Please try again.', 'jetpack-forms' ),
+							__( 'Failed to copy embed code. Please try again.', 'jetpack-forms' ),
 							{ type: 'snackbar' }
 						);
 					}

--- a/projects/packages/forms/routes/forms/stage.tsx
+++ b/projects/packages/forms/routes/forms/stage.tsx
@@ -281,7 +281,7 @@ function StageInner() {
 			{
 				id: 'copy-shortcode',
 				isPrimary: false,
-				label: __( 'Copy shortcode', 'jetpack-forms' ),
+				label: __( 'Copy embed', 'jetpack-forms' ),
 				supportsBulk: false,
 				async callback( items: FormListItem[] ) {
 					const [ item ] = items;

--- a/projects/packages/forms/routes/forms/stage.tsx
+++ b/projects/packages/forms/routes/forms/stage.tsx
@@ -358,9 +358,9 @@ function StageInner() {
 						return;
 					}
 
-					const embedCode = `[contact-form ref="${ item.id }"]`;
+					const shortcode = `[contact-form ref="${ item.id }"]`;
 					try {
-						await navigator.clipboard.writeText( embedCode );
+						await navigator.clipboard.writeText( shortcode );
 						createSuccessNotice( __( 'Shortcode copied to clipboard.', 'jetpack-forms' ), {
 							type: 'snackbar',
 						} );

--- a/projects/packages/forms/routes/forms/stage.tsx
+++ b/projects/packages/forms/routes/forms/stage.tsx
@@ -9,6 +9,7 @@ import { DataViews } from '@wordpress/dataviews';
 import { dateI18n, getSettings as getDateSettings } from '@wordpress/date';
 import { useEffect, useMemo, useState, useCallback } from '@wordpress/element';
 import { __, _n, sprintf } from '@wordpress/i18n';
+import { store as noticesStore } from '@wordpress/notices';
 import { useSearch, useNavigate } from '@wordpress/route';
 import * as React from 'react';
 /**
@@ -68,6 +69,7 @@ function StageInner() {
 		[]
 	);
 	const { refreshIntegrations } = useDispatch( INTEGRATIONS_STORE );
+	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
 	const isIntegrationsEnabled = useConfigValue( 'isIntegrationsEnabled' );
 	const showDashboardIntegrations = useConfigValue( 'showDashboardIntegrations' );
 
@@ -276,6 +278,31 @@ function StageInner() {
 					}
 				},
 			},
+			{
+				id: 'copy-shortcode',
+				isPrimary: false,
+				label: __( 'Copy shortcode', 'jetpack-forms' ),
+				supportsBulk: false,
+				async callback( items: FormListItem[] ) {
+					const [ item ] = items;
+					if ( ! item ) {
+						return;
+					}
+
+					const shortcode = `[contact-form ref="${ item.id }"]`;
+					try {
+						await navigator.clipboard.writeText( shortcode );
+						createSuccessNotice( __( 'Shortcode copied to clipboard.', 'jetpack-forms' ), {
+							type: 'snackbar',
+						} );
+					} catch {
+						createErrorNotice(
+							__( 'Failed to copy shortcode. Please try again.', 'jetpack-forms' ),
+							{ type: 'snackbar' }
+						);
+					}
+				},
+			},
 		];
 
 		if ( isViewingTrash ) {
@@ -332,6 +359,8 @@ function StageInner() {
 
 		return actionsList;
 	}, [
+		createErrorNotice,
+		createSuccessNotice,
 		isDeleting,
 		isViewingTrash,
 		onOpenPermanentDeleteConfirm,

--- a/projects/packages/forms/routes/forms/stage.tsx
+++ b/projects/packages/forms/routes/forms/stage.tsx
@@ -278,56 +278,6 @@ function StageInner() {
 					}
 				},
 			},
-			{
-				id: 'copy-embed',
-				isPrimary: false,
-				label: __( 'Copy embed', 'jetpack-forms' ),
-				supportsBulk: false,
-				async callback( items: FormListItem[] ) {
-					const [ item ] = items;
-					if ( ! item ) {
-						return;
-					}
-
-					const embedCode = `<!-- wp:jetpack/contact-form {"ref":${ item.id }} /-->`;
-					try {
-						await navigator.clipboard.writeText( embedCode );
-						createSuccessNotice( __( 'Embed code copied to clipboard.', 'jetpack-forms' ), {
-							type: 'snackbar',
-						} );
-					} catch {
-						createErrorNotice(
-							__( 'Failed to copy embed code. Please try again.', 'jetpack-forms' ),
-							{ type: 'snackbar' }
-						);
-					}
-				},
-			},
-			{
-				id: 'copy-shortcode',
-				isPrimary: false,
-				label: __( 'Copy shortcode', 'jetpack-forms' ),
-				supportsBulk: false,
-				async callback( items: FormListItem[] ) {
-					const [ item ] = items;
-					if ( ! item ) {
-						return;
-					}
-
-					const embedCode = `[contact-form ref="${ item.id }"]`;
-					try {
-						await navigator.clipboard.writeText( embedCode );
-						createSuccessNotice( __( 'Shortcode copied to clipboard.', 'jetpack-forms' ), {
-							type: 'snackbar',
-						} );
-					} catch {
-						createErrorNotice(
-							__( 'Failed to copy shortcode. Please try again.', 'jetpack-forms' ),
-							{ type: 'snackbar' }
-						);
-					}
-				},
-			},
 		];
 
 		if ( isViewingTrash ) {
@@ -364,6 +314,61 @@ function StageInner() {
 			} );
 			return actionsList;
 		}
+
+		actionsList.push( {
+			id: 'copy-embed',
+			isPrimary: false,
+			label: __( 'Copy embed', 'jetpack-forms' ),
+			supportsBulk: false,
+			async callback( items: FormListItem[] ) {
+				const [ item ] = items;
+				if ( ! item ) {
+					return;
+				}
+
+				const embedCode = `<!-- wp:jetpack/contact-form {"ref":${ item.id }} /-->`;
+				try {
+					await navigator.clipboard.writeText( embedCode );
+					createSuccessNotice( __( 'Embed code copied to clipboard.', 'jetpack-forms' ), {
+						type: 'snackbar',
+					} );
+				} catch {
+					createErrorNotice(
+						__( 'Failed to copy embed code. Please try again.', 'jetpack-forms' ),
+						{ type: 'snackbar' }
+					);
+				}
+			},
+		} );
+
+		actionsList.push( {
+			id: 'copy-shortcode',
+			isPrimary: false,
+			label: __( 'Copy shortcode', 'jetpack-forms' ),
+			supportsBulk: false,
+			async callback( items: FormListItem[] ) {
+				const [ item ] = items;
+				if ( ! item ) {
+					return;
+				}
+
+				if ( ! navigator.clipboard ) {
+					return;
+				}
+
+				const embedCode = `[contact-form ref="${ item.id }"]`;
+				try {
+					await navigator.clipboard.writeText( embedCode );
+					createSuccessNotice( __( 'Shortcode copied to clipboard.', 'jetpack-forms' ), {
+						type: 'snackbar',
+					} );
+				} catch {
+					createErrorNotice( __( 'Failed to copy shortcode. Please try again.', 'jetpack-forms' ), {
+						type: 'snackbar',
+					} );
+				}
+			},
+		} );
 
 		actionsList.push( {
 			id: 'trash-form',

--- a/projects/packages/forms/src/dashboard/forms/index.tsx
+++ b/projects/packages/forms/src/dashboard/forms/index.tsx
@@ -243,7 +243,7 @@ export default function FormsDashboardForms(): JSX.Element | null {
 				},
 			},
 			{
-				id: 'copy-shortcode',
+				id: 'copy-embed',
 				isPrimary: false,
 				label: __( 'Copy embed', 'jetpack-forms' ),
 				supportsBulk: false,
@@ -253,15 +253,15 @@ export default function FormsDashboardForms(): JSX.Element | null {
 						return;
 					}
 
-					const shortcode = `[contact-form ref="${ item.id }"]`;
+					const embedCode = `[contact-form ref="${ item.id }"]`;
 					try {
-						await navigator.clipboard.writeText( shortcode );
-						createSuccessNotice( __( 'Shortcode copied to clipboard.', 'jetpack-forms' ), {
+						await navigator.clipboard.writeText( embedCode );
+						createSuccessNotice( __( 'Embed code copied to clipboard.', 'jetpack-forms' ), {
 							type: 'snackbar',
 						} );
 					} catch {
 						createErrorNotice(
-							__( 'Failed to copy shortcode. Please try again.', 'jetpack-forms' ),
+							__( 'Failed to copy embed code. Please try again.', 'jetpack-forms' ),
 							{ type: 'snackbar' }
 						);
 					}

--- a/projects/packages/forms/src/dashboard/forms/index.tsx
+++ b/projects/packages/forms/src/dashboard/forms/index.tsx
@@ -81,7 +81,7 @@ export default function FormsDashboardForms(): JSX.Element | null {
 		statusQuery,
 	} );
 
-	const { createErrorNotice } = useDispatch( noticesStore );
+	const { createErrorNotice, createSuccessNotice } = useDispatch( noticesStore );
 
 	const [ selection, setSelection ] = useState< string[] >( [] );
 	const [ pendingPermanentDeleteCount, setPendingPermanentDeleteCount ] = useState( 0 );
@@ -242,6 +242,31 @@ export default function FormsDashboardForms(): JSX.Element | null {
 					}
 				},
 			},
+			{
+				id: 'copy-shortcode',
+				isPrimary: false,
+				label: __( 'Copy shortcode', 'jetpack-forms' ),
+				supportsBulk: false,
+				async callback( items: FormListItem[] ) {
+					const [ item ] = items;
+					if ( ! item ) {
+						return;
+					}
+
+					const shortcode = `[contact-form ref="${ item.id }"]`;
+					try {
+						await navigator.clipboard.writeText( shortcode );
+						createSuccessNotice( __( 'Shortcode copied to clipboard.', 'jetpack-forms' ), {
+							type: 'snackbar',
+						} );
+					} catch {
+						createErrorNotice(
+							__( 'Failed to copy shortcode. Please try again.', 'jetpack-forms' ),
+							{ type: 'snackbar' }
+						);
+					}
+				},
+			},
 		];
 
 		if ( isViewingTrash ) {
@@ -299,6 +324,7 @@ export default function FormsDashboardForms(): JSX.Element | null {
 		return actionsList;
 	}, [
 		createErrorNotice,
+		createSuccessNotice,
 		isDeleting,
 		isViewingTrash,
 		navigate,

--- a/projects/packages/forms/src/dashboard/forms/index.tsx
+++ b/projects/packages/forms/src/dashboard/forms/index.tsx
@@ -245,7 +245,7 @@ export default function FormsDashboardForms(): JSX.Element | null {
 			{
 				id: 'copy-shortcode',
 				isPrimary: false,
-				label: __( 'Copy shortcode', 'jetpack-forms' ),
+				label: __( 'Copy embed', 'jetpack-forms' ),
 				supportsBulk: false,
 				async callback( items: FormListItem[] ) {
 					const [ item ] = items;

--- a/projects/packages/forms/src/dashboard/forms/index.tsx
+++ b/projects/packages/forms/src/dashboard/forms/index.tsx
@@ -253,7 +253,7 @@ export default function FormsDashboardForms(): JSX.Element | null {
 						return;
 					}
 
-					const embedCode = `[contact-form ref="${ item.id }"]`;
+					const embedCode = `<!-- wp:jetpack/contact-form {"ref":${ item.id }} /-->`;
 					try {
 						await navigator.clipboard.writeText( embedCode );
 						createSuccessNotice( __( 'Embed code copied to clipboard.', 'jetpack-forms' ), {
@@ -262,6 +262,31 @@ export default function FormsDashboardForms(): JSX.Element | null {
 					} catch {
 						createErrorNotice(
 							__( 'Failed to copy embed code. Please try again.', 'jetpack-forms' ),
+							{ type: 'snackbar' }
+						);
+					}
+				},
+			},
+			{
+				id: 'copy-shortcode',
+				isPrimary: false,
+				label: __( 'Copy shortcode', 'jetpack-forms' ),
+				supportsBulk: false,
+				async callback( items: FormListItem[] ) {
+					const [ item ] = items;
+					if ( ! item ) {
+						return;
+					}
+
+					const embedCode = `[contact-form ref="${ item.id }"]`;
+					try {
+						await navigator.clipboard.writeText( embedCode );
+						createSuccessNotice( __( 'Shortcode copied to clipboard.', 'jetpack-forms' ), {
+							type: 'snackbar',
+						} );
+					} catch {
+						createErrorNotice(
+							__( 'Failed to copy shortcode. Please try again.', 'jetpack-forms' ),
 							{ type: 'snackbar' }
 						);
 					}


### PR DESCRIPTION
Newly added 

old dash
<img width="242" height="248" alt="Screenshot 2026-02-12 at 10 25 43 AM" src="https://github.com/user-attachments/assets/56e704e4-3b51-419b-9d18-eba5ad0a7910" />

new dash 
<img width="198" height="261" alt="Screenshot 2026-02-12 at 12 42 48 PM" src="https://github.com/user-attachments/assets/a9602b6e-cf48-4e03-a7f7-cf3f6bd25ae4" />


Notice
<img width="288" height="95" alt="Screenshot 2026-02-12 at 10 25 39 AM" src="https://github.com/user-attachments/assets/29372ad7-d2f6-4744-bcb9-6a00e4da9a3d" />



## Proposed changes:

* Add a "Copy Embed" action to the forms dashboard that copies the form's (e.g., `[contact-form ref="123"]`) to the clipboard
* Available in both the main dashboard (`/src/dashboard/forms/index.tsx`) and wp-build dashboard (`/routes/forms/stage.tsx`)
* Shows a success snackbar notification when copied, or an error notification if clipboard access fails. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:

1. Go to Jetpack → Forms in the WordPress admin
2. Ensure you have at least one form in the list
3. Click the three-dot menu (actions) on any form row
4. Click "Copy Embed"
5. Verify a snackbar notification appears saying "Embed copied to clipboard"
6. Paste somewhere (e.g., a text editor) and verify the embed code in the block editor converts into the form. 

