### PR TITLE
Forms: fix button border color not following text color on frontend

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-button-border-color
+++ b/projects/packages/forms/changelog/fix-forms-button-border-color
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Contact Form: fix button border color not following the text color on the frontend.

--- a/projects/packages/forms/src/contact-form/css/grunion.scss
+++ b/projects/packages/forms/src/contact-form/css/grunion.scss
@@ -639,6 +639,7 @@
 		min-height: var(--jetpack--contact-form--input-height, auto);
 		padding-top: var(--jetpack--contact-form--input-padding-top);
 		padding-bottom: var(--jetpack--contact-form--input-padding-top);
+		border-color: currentColor;
 	}
 }
 


### PR DESCRIPTION
## Proposed changes:
* Fix button `border-color` not following the text color on the frontend when buttons have custom colors set.
* After migrating from `jetpack/button` to `core/button`, some themes' global styles set `border-width: 0` on `.wp-block-button__link`, which removes the border entirely. When users set a custom border-width, the border appears but with the wrong color because no explicit `border-color` was being set.
* This adds `border-color: currentColor` to the form's button link styles in `grunion.scss`, ensuring the border color follows the button's text color — matching the previous behavior with `jetpack/button`.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
* Create a multi-step form with navigation buttons (Previous/Next/Submit).
* Set a custom text color and border-width on the Next or Submit button.
* View the form on the frontend.
* Verify that the button border color matches the text color.
* Previously the border would render in the default/theme color instead of the button's text color.
