### PR TITLE
Forms: create new forms in same tab

### DIFF
--- a/projects/packages/forms/changelog/update-forms-create-form-button
+++ b/projects/packages/forms/changelog/update-forms-create-form-button
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Dashboard: create new forms in same tab.

--- a/projects/packages/forms/src/dashboard/hooks/use-create-form.ts
+++ b/projects/packages/forms/src/dashboard/hooks/use-create-form.ts
@@ -7,15 +7,13 @@ import { useCallback } from '@wordpress/element';
  */
 import useConfigValue from '../../hooks/use-config-value.ts';
 
-const openFormLinkInNewTab = ( url: string ) => {
+const openFormLink = ( url: string ) => {
 	/*
-	 * We are using a temporary link click to open the page. Using window.open() does not work reliably
-	 * due to Safari's popup blocker, especially after async work.
+	 * We are using a temporary link click to navigate. Using window.open() does not work reliably due
+	 * to Safari's popup blocker, especially after async work.
 	 */
 	const link = document.createElement( 'a' );
 	link.setAttribute( 'href', url );
-	link.setAttribute( 'target', '_blank' );
-	link.setAttribute( 'rel', 'noopener noreferrer' );
 	link.style.display = 'none';
 
 	document.body.appendChild( link );
@@ -83,7 +81,7 @@ export default function useCreateForm(): CreateFormReturn {
 					analyticsEvent?.( { formPattern: formPattern ?? '' } );
 					// Use config adminUrl to build full URL for external admin contexts.
 					const url = `${ adminUrl || '' }post-new.php?post_type=jetpack_form`;
-					openFormLinkInNewTab( url );
+					openFormLink( url );
 					return;
 				}
 
@@ -95,7 +93,7 @@ export default function useCreateForm(): CreateFormReturn {
 					const url = `${ postUrl }${
 						showPatterns && ! formPattern ? '&showJetpackFormsPatterns' : ''
 					}`;
-					openFormLinkInNewTab( url );
+					openFormLink( url );
 				}
 			} catch ( error ) {
 				console.error( error.message ); // eslint-disable-line no-console

--- a/projects/plugins/jetpack/changelog/update-forms-create-form-button
+++ b/projects/plugins/jetpack/changelog/update-forms-create-form-button
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Forms: create new forms in same tab.


### PR DESCRIPTION
## Proposed changes:

Following input from a recent walk through, we are updating the 'Create Form' button on the Jetpack dashboard to create a form and open the editor in the same tab vs a new tab. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to Jetpack > Forms, click the create form button and confirm it opens the editor in the same tab. 
* Go to Jetpack > Forms > Integrations > Salesforce, click the button to create a salesforce form, and confirm that also opens in the same tab. 

