### PR TITLE
Forms: add admin abilities for form CRUD and bulk responses

### DIFF
--- a/projects/packages/forms/changelog/add-admin-form-abilities
+++ b/projects/packages/forms/changelog/add-admin-form-abilities
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add admin abilities for form CRUD (list-forms, get-form, create-form, delete-form) and bulk-update-responses.

--- a/projects/packages/forms/composer.json
+++ b/projects/packages/forms/composer.json
@@ -16,7 +16,8 @@
 		"automattic/jetpack-plans": "@dev",
 		"automattic/jetpack-status": "@dev",
 		"automattic/jetpack-sync": "@dev",
-		"automattic/jetpack-admin-ui": "@dev"
+		"automattic/jetpack-admin-ui": "@dev",
+		"automattic/jetpack-wp-abilities": "@dev"
 	},
 	"require-dev": {
 		"yoast/phpunit-polyfills": "^4.0.0",

--- a/projects/packages/forms/src/abilities/class-forms-abilities.php
+++ b/projects/packages/forms/src/abilities/class-forms-abilities.php
@@ -12,15 +12,12 @@
 
 namespace Automattic\Jetpack\Forms\Abilities;
 
-use Automattic\Jetpack\Forms\ContactForm\Contact_Form;
-use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Endpoint;
-use Automattic\Jetpack\Forms\ContactForm\Jetpack_Form_Endpoint;
-
 /**
  * Class Forms_Abilities
  *
  * Registers Jetpack Forms abilities with the WordPress Abilities API.
- * Provides abilities for managing forms, form responses, and status counts.
+ * Ability callbacks delegate to REST endpoints via rest_do_request()
+ * so they inherit endpoint validation, sanitization, and hooks.
  */
 class Forms_Abilities {
 
@@ -37,14 +34,14 @@ class Forms_Abilities {
 	 * @return void
 	 */
 	public static function init() {
-		// Register category
+		// Register category.
 		if ( did_action( 'wp_abilities_api_categories_init' ) ) {
 			self::register_category();
 		} else {
 			add_action( 'wp_abilities_api_categories_init', array( __CLASS__, 'register_category' ) );
 		}
 
-		// Register abilities
+		// Register abilities.
 		if ( did_action( 'wp_abilities_api_init' ) ) {
 			self::register_abilities();
 		} else {
@@ -154,7 +151,7 @@ class Forms_Abilities {
 			'jetpack-forms/get-form',
 			array(
 				'label'               => __( 'Get form details', 'jetpack-forms' ),
-				'description'         => __( 'Get a single form with its full structure, field definitions, response count, status, and preview URL.', 'jetpack-forms' ),
+				'description'         => __( 'Get a single form with its full structure including field definitions, status, and edit URL.', 'jetpack-forms' ),
 				'category'            => self::CATEGORY_SLUG,
 				'input_schema'        => array(
 					'type'                 => 'object',
@@ -495,142 +492,49 @@ class Forms_Abilities {
 	}
 
 	/**
-	 * Helper to set multiple parameters on a request from args array.
+	 * Dispatch an internal REST request and return its data or WP_Error.
 	 *
-	 * @param \WP_REST_Request $request The request object.
-	 * @param array            $args    The arguments array.
-	 * @param array            $keys    The keys to copy from args to request.
-	 * @return void
+	 * @param \WP_REST_Request $request The REST request to dispatch.
+	 * @return array|\WP_Error Response data array, or WP_Error on failure.
 	 */
-	private static function set_params_from_args( $request, $args, $keys ) {
-		foreach ( $keys as $key ) {
-			if ( isset( $args[ $key ] ) ) {
-				$request->set_param( $key, $args[ $key ] );
-			}
-		}
-	}
+	private static function dispatch( $request ) {
+		$response = rest_do_request( $request );
 
-	/**
-	 * Get form responses callback.
-	 *
-	 * @param array $args Arguments from the ability input.
-	 * @return array|\WP_Error Returns array of responses or WP_Error on failure.
-	 */
-	public static function get_form_responses( $args = array() ) {
-		$args     = is_array( $args ) ? $args : array();
-		$endpoint = new Contact_Form_Endpoint( 'feedback' );
-		$request  = new \WP_REST_Request( 'GET', '/wp/v2/feedback' );
-
-		self::set_params_from_args(
-			$request,
-			$args,
-			array( 'page', 'per_page', 'parent', 'status', 'is_unread', 'search', 'before', 'after' )
-		);
-
-		// Filter by specific IDs if provided
-		if ( isset( $args['ids'] ) && is_array( $args['ids'] ) ) {
-			$request->set_param( 'include', $args['ids'] );
-		}
-
-		$response = $endpoint->get_items( $request );
-		if ( is_wp_error( $response ) ) {
-			return $response;
+		if ( $response->is_error() ) {
+			return $response->as_error();
 		}
 
 		return $response->get_data();
 	}
 
 	/**
-	 * Update form response callback.
-	 *
-	 * @param array $args Arguments from the ability input.
-	 * @return array|\WP_Error Returns updated response data or WP_Error on failure.
-	 */
-	public static function update_form_response( $args ) {
-		if ( ! isset( $args['id'] ) ) {
-			return new \WP_Error( 'missing_id', __( 'Response ID is required.', 'jetpack-forms' ) );
-		}
-
-		$endpoint = new Contact_Form_Endpoint( 'feedback' );
-		$result   = array();
-
-		// Update status if provided
-		if ( isset( $args['status'] ) ) {
-			$request = new \WP_REST_Request( 'POST', '/wp/v2/feedback/' . $args['id'] );
-			$request->set_url_params( array( 'id' => $args['id'] ) );
-			$request->set_body_params( array( 'status' => $args['status'] ) );
-
-			$response = $endpoint->update_item( $request );
-			if ( is_wp_error( $response ) ) {
-				return $response;
-			}
-			$result = $response->get_data();
-		}
-
-		// Update read status if provided
-		if ( isset( $args['is_unread'] ) ) {
-			$request = new \WP_REST_Request( 'POST', '/wp/v2/feedback/' . $args['id'] . '/read' );
-			$request->set_url_params( array( 'id' => $args['id'] ) );
-			$request->set_body_params( array( 'is_unread' => $args['is_unread'] ) );
-
-			$response = $endpoint->update_read_status( $request );
-			if ( is_wp_error( $response ) ) {
-				return $response;
-			}
-			$result = array_merge( $result, $response->get_data() );
-		}
-
-		return $result;
-	}
-
-	/**
-	 * Get status counts callback.
-	 *
-	 * @param array $args Arguments from the ability input.
-	 * @return array|\WP_Error Returns status counts or WP_Error on failure.
-	 */
-	public static function get_status_counts( $args = array() ) {
-		$args     = is_array( $args ) ? $args : array();
-		$endpoint = new Contact_Form_Endpoint( 'feedback' );
-		$request  = new \WP_REST_Request( 'GET', '/wp/v2/feedback/counts' );
-
-		self::set_params_from_args(
-			$request,
-			$args,
-			array( 'search', 'parent', 'before', 'after', 'is_unread' )
-		);
-
-		$response = $endpoint->get_status_counts( $request );
-		if ( $response instanceof \WP_Error ) {
-			return $response;
-		}
-
-		return (array) $response->get_data();
-	}
-
-	/**
 	 * List forms with admin-level detail callback.
+	 *
+	 * Delegates to GET /wp/v2/jetpack-forms with dashboard context,
+	 * then reshapes to a compact format for AI consumption.
 	 *
 	 * @param array $args Arguments from the ability input.
 	 * @return array|\WP_Error Returns array of forms with admin detail.
 	 */
 	public static function list_forms( $args = array() ) {
-		$args     = is_array( $args ) ? $args : array();
-		$endpoint = new Jetpack_Form_Endpoint();
-		$request  = new \WP_REST_Request( 'GET', '/wp/v2/jetpack-forms' );
+		$args    = is_array( $args ) ? $args : array();
+		$request = new \WP_REST_Request( 'GET', '/wp/v2/jetpack-forms' );
 
-		self::set_params_from_args( $request, $args, array( 'page', 'per_page', 'search', 'status' ) );
-
-		// Request dashboard context to include entries_count and edit_url.
 		$request->set_param( 'jetpack_forms_context', 'dashboard' );
 
-		$response = $endpoint->get_items( $request );
-		if ( is_wp_error( $response ) ) {
-			return $response;
+		foreach ( array( 'page', 'per_page', 'search', 'status' ) as $key ) {
+			if ( isset( $args[ $key ] ) ) {
+				$request->set_param( $key, $args[ $key ] );
+			}
+		}
+
+		$data = self::dispatch( $request );
+		if ( is_wp_error( $data ) ) {
+			return $data;
 		}
 
 		$result = array();
-		foreach ( $response->get_data() as $form ) {
+		foreach ( $data as $form ) {
 			$result[] = array(
 				'id'            => $form['id'],
 				'title'         => $form['title']['rendered'] ?? '',
@@ -648,6 +552,9 @@ class Forms_Abilities {
 	/**
 	 * Get a single form's full details callback.
 	 *
+	 * Delegates to GET /wp/v2/jetpack-forms/{id} for the base data,
+	 * then enriches with extracted field definitions from block content.
+	 *
 	 * @param array $args Arguments from the ability input.
 	 * @return array|\WP_Error Returns form data with fields, or WP_Error.
 	 */
@@ -656,26 +563,33 @@ class Forms_Abilities {
 			return new \WP_Error( 'missing_id', __( 'Form ID is required.', 'jetpack-forms' ) );
 		}
 
-		$form_post = get_post( absint( $args['id'] ) );
-		if ( ! $form_post || Contact_Form::POST_TYPE !== $form_post->post_type ) {
-			return new \WP_Error( 'not_found', __( 'Form not found.', 'jetpack-forms' ), array( 'status' => 404 ) );
+		$request = new \WP_REST_Request( 'GET', '/wp/v2/jetpack-forms/' . absint( $args['id'] ) );
+		$request->set_param( 'context', 'edit' );
+
+		$data = self::dispatch( $request );
+		if ( is_wp_error( $data ) ) {
+			return $data;
 		}
 
-		$fields = self::extract_fields_from_post( $form_post );
+		$post   = get_post( absint( $args['id'] ) );
+		$fields = $post ? self::extract_fields_from_post( $post ) : array();
 
 		return array(
-			'id'       => $form_post->ID,
-			'title'    => $form_post->post_title,
-			'status'   => $form_post->post_status,
+			'id'       => $data['id'],
+			'title'    => $data['title']['raw'] ?? $data['title']['rendered'] ?? '',
+			'status'   => $data['status'],
 			'fields'   => $fields,
-			'date'     => $form_post->post_date,
-			'modified' => $form_post->post_modified,
-			'edit_url' => get_edit_post_link( $form_post->ID, 'raw' ),
+			'date'     => $data['date'],
+			'modified' => $data['modified'],
+			'edit_url' => $data['link'] ?? get_edit_post_link( $data['id'], 'raw' ),
 		);
 	}
 
 	/**
 	 * Create a new form callback.
+	 *
+	 * Delegates to POST /wp/v2/jetpack-forms, which handles
+	 * sanitization, validation, and all insert hooks.
 	 *
 	 * @param array $args Arguments from the ability input.
 	 * @return array|\WP_Error Returns new form data or WP_Error.
@@ -687,35 +601,36 @@ class Forms_Abilities {
 
 		$content = $args['content'] ?? '';
 		if ( '' === $content ) {
-			// Default form structure with a submit button.
 			$content = '<!-- wp:jetpack/contact-form --><!-- wp:jetpack/button {"element":"button","text":"Submit","lock":{"remove":true}} /--><!-- /wp:jetpack/contact-form -->';
 		}
 
-		$status  = $args['status'] ?? 'publish';
-		$post_id = wp_insert_post(
+		$request = new \WP_REST_Request( 'POST', '/wp/v2/jetpack-forms' );
+		$request->set_body_params(
 			array(
-				'post_type'    => Contact_Form::POST_TYPE,
-				'post_title'   => sanitize_text_field( $args['title'] ),
-				'post_content' => $content,
-				'post_status'  => $status,
-			),
-			true
+				'title'   => $args['title'],
+				'content' => $content,
+				'status'  => $args['status'] ?? 'publish',
+			)
 		);
 
-		if ( is_wp_error( $post_id ) ) {
-			return $post_id;
+		$data = self::dispatch( $request );
+		if ( is_wp_error( $data ) ) {
+			return $data;
 		}
 
 		return array(
-			'id'       => $post_id,
-			'title'    => get_the_title( $post_id ),
-			'status'   => get_post_status( $post_id ),
-			'edit_url' => get_edit_post_link( $post_id, 'raw' ),
+			'id'       => $data['id'],
+			'title'    => $data['title']['rendered'] ?? $data['title']['raw'] ?? '',
+			'status'   => $data['status'],
+			'edit_url' => get_edit_post_link( $data['id'], 'raw' ),
 		);
 	}
 
 	/**
 	 * Delete (trash) a form callback.
+	 *
+	 * Delegates to DELETE /wp/v2/jetpack-forms/{id}, which handles
+	 * permission checks and trash logic.
 	 *
 	 * @param array $args Arguments from the ability input.
 	 * @return array|\WP_Error Returns deletion result or WP_Error.
@@ -725,25 +640,91 @@ class Forms_Abilities {
 			return new \WP_Error( 'missing_id', __( 'Form ID is required.', 'jetpack-forms' ) );
 		}
 
-		$form_post = get_post( absint( $args['id'] ) );
-		if ( ! $form_post || Contact_Form::POST_TYPE !== $form_post->post_type ) {
-			return new \WP_Error( 'not_found', __( 'Form not found.', 'jetpack-forms' ), array( 'status' => 404 ) );
-		}
+		$request = new \WP_REST_Request( 'DELETE', '/wp/v2/jetpack-forms/' . absint( $args['id'] ) );
 
-		$result = wp_trash_post( $form_post->ID );
-		if ( ! $result ) {
-			return new \WP_Error( 'delete_failed', __( 'Failed to delete form.', 'jetpack-forms' ) );
+		$data = self::dispatch( $request );
+		if ( is_wp_error( $data ) ) {
+			return $data;
 		}
 
 		return array(
-			'id'      => $form_post->ID,
+			'id'      => $data['id'] ?? absint( $args['id'] ),
 			'deleted' => true,
-			'status'  => 'trash',
+			'status'  => $data['status'] ?? 'trash',
 		);
 	}
 
 	/**
+	 * Get form responses callback.
+	 *
+	 * Delegates to GET /wp/v2/feedback.
+	 *
+	 * @param array $args Arguments from the ability input.
+	 * @return array|\WP_Error Returns array of responses or WP_Error on failure.
+	 */
+	public static function get_form_responses( $args = array() ) {
+		$args    = is_array( $args ) ? $args : array();
+		$request = new \WP_REST_Request( 'GET', '/wp/v2/feedback' );
+
+		foreach ( array( 'page', 'per_page', 'parent', 'status', 'is_unread', 'search', 'before', 'after' ) as $key ) {
+			if ( isset( $args[ $key ] ) ) {
+				$request->set_param( $key, $args[ $key ] );
+			}
+		}
+
+		if ( isset( $args['ids'] ) && is_array( $args['ids'] ) ) {
+			$request->set_param( 'include', $args['ids'] );
+		}
+
+		return self::dispatch( $request );
+	}
+
+	/**
+	 * Update form response callback.
+	 *
+	 * Delegates to POST /wp/v2/feedback/{id} for status changes
+	 * and POST /wp/v2/feedback/{id}/read for read state changes.
+	 *
+	 * @param array $args Arguments from the ability input.
+	 * @return array|\WP_Error Returns updated response data or WP_Error on failure.
+	 */
+	public static function update_form_response( $args ) {
+		if ( ! isset( $args['id'] ) ) {
+			return new \WP_Error( 'missing_id', __( 'Response ID is required.', 'jetpack-forms' ) );
+		}
+
+		$id     = absint( $args['id'] );
+		$result = array();
+
+		if ( isset( $args['status'] ) ) {
+			$request = new \WP_REST_Request( 'POST', '/wp/v2/feedback/' . $id );
+			$request->set_body_params( array( 'status' => $args['status'] ) );
+
+			$data = self::dispatch( $request );
+			if ( is_wp_error( $data ) ) {
+				return $data;
+			}
+			$result = $data;
+		}
+
+		if ( isset( $args['is_unread'] ) ) {
+			$request = new \WP_REST_Request( 'POST', '/wp/v2/feedback/' . $id . '/read' );
+			$request->set_body_params( array( 'is_unread' => $args['is_unread'] ) );
+
+			$data = self::dispatch( $request );
+			if ( is_wp_error( $data ) ) {
+				return $data;
+			}
+			$result = array_merge( $result, $data );
+		}
+
+		return $result;
+	}
+
+	/**
 	 * Bulk update responses callback.
+	 *
+	 * Delegates to POST /wp/v2/feedback/bulk_actions.
 	 *
 	 * @param array $args Arguments from the ability input.
 	 * @return array|\WP_Error Returns update result or WP_Error.
@@ -753,8 +734,7 @@ class Forms_Abilities {
 			return new \WP_Error( 'missing_params', __( 'Action and IDs are required.', 'jetpack-forms' ) );
 		}
 
-		$endpoint = new Contact_Form_Endpoint( 'feedback' );
-		$request  = new \WP_REST_Request( 'POST', '/wp/v2/feedback/bulk_actions' );
+		$request = new \WP_REST_Request( 'POST', '/wp/v2/feedback/bulk_actions' );
 		$request->set_body_params(
 			array(
 				'action'   => $args['action'],
@@ -762,12 +742,28 @@ class Forms_Abilities {
 			)
 		);
 
-		$response = $endpoint->bulk_actions( $request );
-		if ( is_wp_error( $response ) ) {
-			return $response;
+		return self::dispatch( $request );
+	}
+
+	/**
+	 * Get status counts callback.
+	 *
+	 * Delegates to GET /wp/v2/feedback/counts.
+	 *
+	 * @param array $args Arguments from the ability input.
+	 * @return array|\WP_Error Returns status counts or WP_Error on failure.
+	 */
+	public static function get_status_counts( $args = array() ) {
+		$args    = is_array( $args ) ? $args : array();
+		$request = new \WP_REST_Request( 'GET', '/wp/v2/feedback/counts' );
+
+		foreach ( array( 'search', 'parent', 'before', 'after', 'is_unread' ) as $key ) {
+			if ( isset( $args[ $key ] ) ) {
+				$request->set_param( $key, $args[ $key ] );
+			}
 		}
 
-		return $response->get_data();
+		return self::dispatch( $request );
 	}
 
 	/**

--- a/projects/packages/forms/src/abilities/class-forms-abilities.php
+++ b/projects/packages/forms/src/abilities/class-forms-abilities.php
@@ -534,6 +534,7 @@ class Forms_Abilities {
 		}
 
 		$result = array();
+		'@phan-var array[] $data'; // Phan doesn't narrow after is_wp_error + return.
 		foreach ( $data as $form ) {
 			$result[] = array(
 				'id'            => $form['id'],

--- a/projects/packages/forms/src/abilities/class-forms-abilities.php
+++ b/projects/packages/forms/src/abilities/class-forms-abilities.php
@@ -12,13 +12,15 @@
 
 namespace Automattic\Jetpack\Forms\Abilities;
 
+use Automattic\Jetpack\Forms\ContactForm\Contact_Form;
 use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Endpoint;
+use Automattic\Jetpack\Forms\ContactForm\Jetpack_Form_Endpoint;
 
 /**
  * Class Forms_Abilities
  *
  * Registers Jetpack Forms abilities with the WordPress Abilities API.
- * Provides abilities for managing form responses and status counts.
+ * Provides abilities for managing forms, form responses, and status counts.
  */
 class Forms_Abilities {
 
@@ -65,7 +67,7 @@ class Forms_Abilities {
 			array(
 				// "Jetpack Forms" is a product name and should not be translated.
 				'label'       => 'Jetpack Forms',
-				'description' => __( 'Abilities for managing Jetpack Forms responses.', 'jetpack-forms' ),
+				'description' => __( 'Abilities for managing Jetpack Forms and their responses.', 'jetpack-forms' ),
 			)
 		);
 	}
@@ -80,9 +82,187 @@ class Forms_Abilities {
 			return;
 		}
 
+		self::register_list_forms_ability();
+		self::register_get_form_ability();
+		self::register_create_form_ability();
+		self::register_delete_form_ability();
 		self::register_get_responses_ability();
 		self::register_update_response_ability();
+		self::register_bulk_update_responses_ability();
 		self::register_get_status_counts_ability();
+	}
+
+	/**
+	 * Register ability to list forms with admin-level detail.
+	 *
+	 * @return void
+	 */
+	private static function register_list_forms_ability() {
+		wp_register_ability(
+			'jetpack-forms/list-forms',
+			array(
+				'label'               => __( 'List forms (admin)', 'jetpack-forms' ),
+				'description'         => __( 'List all forms with admin detail including response counts, status, and edit URLs. Supports pagination, search, and status filtering.', 'jetpack-forms' ),
+				'category'            => self::CATEGORY_SLUG,
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'default'              => array(),
+					'properties'           => array(
+						'page'     => array(
+							'type'        => 'integer',
+							'description' => __( 'Page number for paginated results.', 'jetpack-forms' ),
+							'default'     => 1,
+						),
+						'per_page' => array(
+							'type'        => 'integer',
+							'description' => __( 'Number of forms per page (max 100).', 'jetpack-forms' ),
+							'default'     => 10,
+						),
+						'search'   => array(
+							'type'        => 'string',
+							'description' => __( 'Search forms by title.', 'jetpack-forms' ),
+						),
+						'status'   => array(
+							'type'        => 'string',
+							'description' => __( 'Filter by form status.', 'jetpack-forms' ),
+							'enum'        => array( 'publish', 'draft', 'trash' ),
+						),
+					),
+					'additionalProperties' => false,
+				),
+				'execute_callback'    => array( __CLASS__, 'list_forms' ),
+				'permission_callback' => array( __CLASS__, 'can_edit_pages' ),
+				'meta'                => array(
+					'annotations'  => array(
+						'readonly'    => true,
+						'destructive' => false,
+						'idempotent'  => true,
+					),
+					'show_in_rest' => true,
+				),
+			)
+		);
+	}
+
+	/**
+	 * Register ability to get a single form's full details.
+	 *
+	 * @return void
+	 */
+	private static function register_get_form_ability() {
+		wp_register_ability(
+			'jetpack-forms/get-form',
+			array(
+				'label'               => __( 'Get form details', 'jetpack-forms' ),
+				'description'         => __( 'Get a single form with its full structure, field definitions, response count, status, and preview URL.', 'jetpack-forms' ),
+				'category'            => self::CATEGORY_SLUG,
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'required'             => array( 'id' ),
+					'properties'           => array(
+						'id' => array(
+							'type'        => 'integer',
+							'description' => __( 'The form ID.', 'jetpack-forms' ),
+						),
+					),
+					'additionalProperties' => false,
+				),
+				'execute_callback'    => array( __CLASS__, 'get_form' ),
+				'permission_callback' => array( __CLASS__, 'can_edit_pages' ),
+				'meta'                => array(
+					'annotations'  => array(
+						'readonly'    => true,
+						'destructive' => false,
+						'idempotent'  => true,
+					),
+					'show_in_rest' => true,
+				),
+			)
+		);
+	}
+
+	/**
+	 * Register ability to create a new form.
+	 *
+	 * @return void
+	 */
+	private static function register_create_form_ability() {
+		wp_register_ability(
+			'jetpack-forms/create-form',
+			array(
+				'label'               => __( 'Create a form', 'jetpack-forms' ),
+				'description'         => __( 'Create a new form with a title. Optionally provide block content for the form structure. Returns the new form ID and edit URL.', 'jetpack-forms' ),
+				'category'            => self::CATEGORY_SLUG,
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'required'             => array( 'title' ),
+					'properties'           => array(
+						'title'   => array(
+							'type'        => 'string',
+							'description' => __( 'The form title/name.', 'jetpack-forms' ),
+						),
+						'content' => array(
+							'type'        => 'string',
+							'description' => __( 'Block content for the form structure. If omitted, creates an empty form with a submit button.', 'jetpack-forms' ),
+						),
+						'status'  => array(
+							'type'        => 'string',
+							'description' => __( 'Initial form status.', 'jetpack-forms' ),
+							'enum'        => array( 'publish', 'draft' ),
+							'default'     => 'publish',
+						),
+					),
+					'additionalProperties' => false,
+				),
+				'execute_callback'    => array( __CLASS__, 'create_form' ),
+				'permission_callback' => array( __CLASS__, 'can_edit_pages' ),
+				'meta'                => array(
+					'annotations'  => array(
+						'readonly'    => false,
+						'destructive' => false,
+						'idempotent'  => false,
+					),
+					'show_in_rest' => true,
+				),
+			)
+		);
+	}
+
+	/**
+	 * Register ability to delete a form.
+	 *
+	 * @return void
+	 */
+	private static function register_delete_form_ability() {
+		wp_register_ability(
+			'jetpack-forms/delete-form',
+			array(
+				'label'               => __( 'Delete a form', 'jetpack-forms' ),
+				'description'         => __( 'Move a form to the trash. Does not permanently delete. Trashed forms can be restored.', 'jetpack-forms' ),
+				'category'            => self::CATEGORY_SLUG,
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'required'             => array( 'id' ),
+					'properties'           => array(
+						'id' => array(
+							'type'        => 'integer',
+							'description' => __( 'The form ID to delete.', 'jetpack-forms' ),
+						),
+					),
+					'additionalProperties' => false,
+				),
+				'execute_callback'    => array( __CLASS__, 'delete_form' ),
+				'permission_callback' => array( __CLASS__, 'can_edit_pages' ),
+				'meta'                => array(
+					'annotations'  => array(
+						'readonly'    => false,
+						'destructive' => true,
+						'idempotent'  => true,
+					),
+					'show_in_rest' => true,
+				),
+			)
+		);
 	}
 
 	/**
@@ -194,6 +374,49 @@ class Forms_Abilities {
 					'additionalProperties' => false,
 				),
 				'execute_callback'    => array( __CLASS__, 'update_form_response' ),
+				'permission_callback' => array( __CLASS__, 'can_edit_pages' ),
+				'meta'                => array(
+					'annotations'  => array(
+						'readonly'    => false,
+						'destructive' => false,
+						'idempotent'  => true,
+					),
+					'show_in_rest' => true,
+				),
+			)
+		);
+	}
+
+	/**
+	 * Register ability to bulk-update form responses.
+	 *
+	 * @return void
+	 */
+	private static function register_bulk_update_responses_ability() {
+		wp_register_ability(
+			'jetpack-forms/bulk-update-responses',
+			array(
+				'label'               => __( 'Bulk update form responses', 'jetpack-forms' ),
+				'description'         => __( 'Mark multiple responses as spam or not-spam in a single operation.', 'jetpack-forms' ),
+				'category'            => self::CATEGORY_SLUG,
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'required'             => array( 'action', 'ids' ),
+					'properties'           => array(
+						'action' => array(
+							'type'        => 'string',
+							'description' => __( 'The bulk action to perform.', 'jetpack-forms' ),
+							'enum'        => array( 'mark_as_spam', 'mark_as_not_spam' ),
+						),
+						'ids'    => array(
+							'type'        => 'array',
+							'description' => __( 'Response IDs to update.', 'jetpack-forms' ),
+							'items'       => array( 'type' => 'integer' ),
+						),
+					),
+					'additionalProperties' => false,
+				),
+				'execute_callback'    => array( __CLASS__, 'bulk_update_responses' ),
 				'permission_callback' => array( __CLASS__, 'can_edit_pages' ),
 				'meta'                => array(
 					'annotations'  => array(
@@ -383,5 +606,222 @@ class Forms_Abilities {
 		}
 
 		return (array) $response->get_data();
+	}
+
+	/**
+	 * List forms with admin-level detail callback.
+	 *
+	 * @param array $args Arguments from the ability input.
+	 * @return array|\WP_Error Returns array of forms with admin detail.
+	 */
+	public static function list_forms( $args = array() ) {
+		$args     = is_array( $args ) ? $args : array();
+		$endpoint = new Jetpack_Form_Endpoint();
+		$request  = new \WP_REST_Request( 'GET', '/wp/v2/jetpack-forms' );
+
+		self::set_params_from_args( $request, $args, array( 'page', 'per_page', 'search', 'status' ) );
+
+		// Request dashboard context to include entries_count and edit_url.
+		$request->set_param( 'jetpack_forms_context', 'dashboard' );
+
+		$response = $endpoint->get_items( $request );
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
+
+		$result = array();
+		foreach ( $response->get_data() as $form ) {
+			$result[] = array(
+				'id'            => $form['id'],
+				'title'         => $form['title']['rendered'] ?? '',
+				'status'        => $form['status'],
+				'entries_count' => $form['entries_count'] ?? 0,
+				'edit_url'      => $form['edit_url'] ?? '',
+				'date'          => $form['date'],
+				'modified'      => $form['modified'],
+			);
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Get a single form's full details callback.
+	 *
+	 * @param array $args Arguments from the ability input.
+	 * @return array|\WP_Error Returns form data with fields, or WP_Error.
+	 */
+	public static function get_form( $args ) {
+		if ( ! isset( $args['id'] ) ) {
+			return new \WP_Error( 'missing_id', __( 'Form ID is required.', 'jetpack-forms' ) );
+		}
+
+		$form_post = get_post( absint( $args['id'] ) );
+		if ( ! $form_post || Contact_Form::POST_TYPE !== $form_post->post_type ) {
+			return new \WP_Error( 'not_found', __( 'Form not found.', 'jetpack-forms' ), array( 'status' => 404 ) );
+		}
+
+		$fields = self::extract_fields_from_post( $form_post );
+
+		return array(
+			'id'       => $form_post->ID,
+			'title'    => $form_post->post_title,
+			'status'   => $form_post->post_status,
+			'fields'   => $fields,
+			'date'     => $form_post->post_date,
+			'modified' => $form_post->post_modified,
+			'edit_url' => get_edit_post_link( $form_post->ID, 'raw' ),
+		);
+	}
+
+	/**
+	 * Create a new form callback.
+	 *
+	 * @param array $args Arguments from the ability input.
+	 * @return array|\WP_Error Returns new form data or WP_Error.
+	 */
+	public static function create_form( $args ) {
+		if ( empty( $args['title'] ) ) {
+			return new \WP_Error( 'missing_title', __( 'Form title is required.', 'jetpack-forms' ) );
+		}
+
+		$content = $args['content'] ?? '';
+		if ( '' === $content ) {
+			// Default form structure with a submit button.
+			$content = '<!-- wp:jetpack/contact-form --><!-- wp:jetpack/button {"element":"button","text":"Submit","lock":{"remove":true}} /--><!-- /wp:jetpack/contact-form -->';
+		}
+
+		$status  = $args['status'] ?? 'publish';
+		$post_id = wp_insert_post(
+			array(
+				'post_type'    => Contact_Form::POST_TYPE,
+				'post_title'   => sanitize_text_field( $args['title'] ),
+				'post_content' => $content,
+				'post_status'  => $status,
+			),
+			true
+		);
+
+		if ( is_wp_error( $post_id ) ) {
+			return $post_id;
+		}
+
+		return array(
+			'id'       => $post_id,
+			'title'    => get_the_title( $post_id ),
+			'status'   => get_post_status( $post_id ),
+			'edit_url' => get_edit_post_link( $post_id, 'raw' ),
+		);
+	}
+
+	/**
+	 * Delete (trash) a form callback.
+	 *
+	 * @param array $args Arguments from the ability input.
+	 * @return array|\WP_Error Returns deletion result or WP_Error.
+	 */
+	public static function delete_form( $args ) {
+		if ( ! isset( $args['id'] ) ) {
+			return new \WP_Error( 'missing_id', __( 'Form ID is required.', 'jetpack-forms' ) );
+		}
+
+		$form_post = get_post( absint( $args['id'] ) );
+		if ( ! $form_post || Contact_Form::POST_TYPE !== $form_post->post_type ) {
+			return new \WP_Error( 'not_found', __( 'Form not found.', 'jetpack-forms' ), array( 'status' => 404 ) );
+		}
+
+		$result = wp_trash_post( $form_post->ID );
+		if ( ! $result ) {
+			return new \WP_Error( 'delete_failed', __( 'Failed to delete form.', 'jetpack-forms' ) );
+		}
+
+		return array(
+			'id'      => $form_post->ID,
+			'deleted' => true,
+			'status'  => 'trash',
+		);
+	}
+
+	/**
+	 * Bulk update responses callback.
+	 *
+	 * @param array $args Arguments from the ability input.
+	 * @return array|\WP_Error Returns update result or WP_Error.
+	 */
+	public static function bulk_update_responses( $args ) {
+		if ( empty( $args['action'] ) || empty( $args['ids'] ) || ! is_array( $args['ids'] ) ) {
+			return new \WP_Error( 'missing_params', __( 'Action and IDs are required.', 'jetpack-forms' ) );
+		}
+
+		$endpoint = new Contact_Form_Endpoint( 'feedback' );
+		$request  = new \WP_REST_Request( 'POST', '/wp/v2/feedback/bulk_actions' );
+		$request->set_body_params(
+			array(
+				'action'   => $args['action'],
+				'post_ids' => array_map( 'absint', $args['ids'] ),
+			)
+		);
+
+		$response = $endpoint->bulk_actions( $request );
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
+
+		return $response->get_data();
+	}
+
+	/**
+	 * Extract field definitions from a form post's block content.
+	 *
+	 * @param \WP_Post $post The form post.
+	 * @return array Array of field definitions.
+	 */
+	private static function extract_fields_from_post( $post ) {
+		$blocks = parse_blocks( $post->post_content );
+		$fields = array();
+
+		self::extract_fields_from_blocks( $blocks, $fields );
+
+		return $fields;
+	}
+
+	/**
+	 * Recursively extract field definitions from blocks.
+	 *
+	 * @param array $blocks The blocks to process.
+	 * @param array $fields Reference to the fields array being built.
+	 */
+	private static function extract_fields_from_blocks( $blocks, &$fields ) {
+		foreach ( $blocks as $block ) {
+			if ( strpos( $block['blockName'] ?? '', 'jetpack/field-' ) === 0 ) {
+				$attrs = $block['attrs'] ?? array();
+				$label = $attrs['label'] ?? '';
+
+				// Skip fields without a label.
+				if ( '' === $label ) {
+					continue;
+				}
+
+				$field = array(
+					'label'    => $label,
+					'type'     => str_replace( 'jetpack/field-', '', $block['blockName'] ),
+					'required' => ! empty( $attrs['required'] ),
+				);
+
+				if ( ! empty( $attrs['options'] ) ) {
+					$field['options'] = $attrs['options'];
+				}
+
+				if ( ! empty( $attrs['placeholder'] ) ) {
+					$field['placeholder'] = $attrs['placeholder'];
+				}
+
+				$fields[] = $field;
+			}
+
+			if ( ! empty( $block['innerBlocks'] ) ) {
+				self::extract_fields_from_blocks( $block['innerBlocks'], $fields );
+			}
+		}
 	}
 }

--- a/projects/packages/forms/src/abilities/class-forms-abilities.php
+++ b/projects/packages/forms/src/abilities/class-forms-abilities.php
@@ -808,8 +808,10 @@ class Forms_Abilities extends Registrar {
 	 * Extract field definitions from raw block content.
 	 *
 	 * Walks `jetpack/field-*` blocks and projects each into a compact
-	 * `{ label, type, required, options?, placeholder? }` shape. Blocks
-	 * without a label are dropped — agents reference fields by label.
+	 * `{ label, type, required, options?, placeholder? }` shape. Modern
+	 * field blocks store the label/placeholder in `jetpack/label` and
+	 * `jetpack/input` sub-blocks; legacy fixtures keep them inline as
+	 * top-level attrs. Both layouts are supported.
 	 *
 	 * @param string $raw_content Raw block content (typically `content.raw` from REST).
 	 * @return array
@@ -826,34 +828,81 @@ class Forms_Abilities extends Registrar {
 	/**
 	 * Recursively walk parsed blocks and append field definitions to `$fields`.
 	 *
+	 * Field blocks are not recursed into — their inner blocks are layout
+	 * sub-blocks (`jetpack/label`, `jetpack/input`), not nested fields.
+	 * Non-field containers (columns, groups, the contact-form block itself)
+	 * are recursed so fields nested inside them still get picked up.
+	 *
 	 * @param array $blocks Parsed blocks.
 	 * @param array $fields Reference to the fields array being built.
 	 */
 	private static function collect_field_blocks( array $blocks, array &$fields ): void {
 		foreach ( $blocks as $block ) {
-			if ( strpos( $block['blockName'] ?? '', 'jetpack/field-' ) === 0 ) {
-				$attrs = $block['attrs'] ?? array();
-				$label = $attrs['label'] ?? '';
-				if ( '' === $label ) {
-					continue;
+			$name = $block['blockName'] ?? '';
+
+			if ( strpos( $name, 'jetpack/field-' ) === 0 ) {
+				$summary = self::summarize_field_block( $block );
+				if ( null !== $summary ) {
+					$fields[] = $summary;
 				}
-				$field = array(
-					'label'    => $label,
-					'type'     => str_replace( 'jetpack/field-', '', $block['blockName'] ),
-					'required' => ! empty( $attrs['required'] ),
-				);
-				if ( ! empty( $attrs['options'] ) ) {
-					$field['options'] = $attrs['options'];
-				}
-				if ( ! empty( $attrs['placeholder'] ) ) {
-					$field['placeholder'] = $attrs['placeholder'];
-				}
-				$fields[] = $field;
+				continue;
 			}
 
 			if ( ! empty( $block['innerBlocks'] ) ) {
 				self::collect_field_blocks( $block['innerBlocks'], $fields );
 			}
 		}
+	}
+
+	/**
+	 * Project a single `jetpack/field-*` block into the compact field shape.
+	 *
+	 * @param array $block Parsed block array.
+	 * @return array|null Field summary, or null if the block has no usable label.
+	 */
+	private static function summarize_field_block( array $block ): ?array {
+		$attrs       = $block['attrs'] ?? array();
+		$inner_attrs = self::collect_inner_attrs( $block['innerBlocks'] ?? array() );
+		$label_attrs = $inner_attrs['jetpack/label'] ?? array();
+		$input_attrs = $inner_attrs['jetpack/input'] ?? array();
+
+		$label = (string) ( $label_attrs['label'] ?? $attrs['label'] ?? '' );
+		if ( '' === $label ) {
+			return null;
+		}
+
+		$field = array(
+			'label'    => $label,
+			'type'     => str_replace( 'jetpack/field-', '', (string) ( $block['blockName'] ?? '' ) ),
+			'required' => ! empty( $attrs['required'] ),
+		);
+
+		if ( ! empty( $attrs['options'] ) ) {
+			$field['options'] = $attrs['options'];
+		}
+
+		$placeholder = $input_attrs['placeholder'] ?? $attrs['placeholder'] ?? '';
+		if ( '' !== $placeholder ) {
+			$field['placeholder'] = $placeholder;
+		}
+
+		return $field;
+	}
+
+	/**
+	 * Build a `block_name => attrs` lookup from the field's direct children.
+	 *
+	 * @param array $inner_blocks Direct children of a field block.
+	 * @return array
+	 */
+	private static function collect_inner_attrs( array $inner_blocks ): array {
+		$out = array();
+		foreach ( $inner_blocks as $child ) {
+			$name = $child['blockName'] ?? '';
+			if ( '' !== $name && ! isset( $out[ $name ] ) ) {
+				$out[ $name ] = $child['attrs'] ?? array();
+			}
+		}
+		return $out;
 	}
 }

--- a/projects/packages/forms/src/abilities/class-forms-abilities.php
+++ b/projects/packages/forms/src/abilities/class-forms-abilities.php
@@ -12,6 +12,8 @@
 
 namespace Automattic\Jetpack\Forms\Abilities;
 
+use Automattic\Jetpack\WP_Abilities\Registrar;
+
 /**
  * Class Forms_Abilities
  *
@@ -19,471 +21,437 @@ namespace Automattic\Jetpack\Forms\Abilities;
  * Ability callbacks delegate to REST endpoints via rest_do_request()
  * so they inherit endpoint validation, sanitization, and hooks.
  */
-class Forms_Abilities {
+class Forms_Abilities extends Registrar {
 
-	/**
-	 * The category slug for forms abilities.
-	 *
-	 * @var string
-	 */
 	const CATEGORY_SLUG = 'jetpack-forms';
 
 	/**
-	 * Initialize the abilities registration.
-	 *
-	 * @return void
+	 * Form post statuses accepted by list-forms.
 	 */
-	public static function init() {
-		// Register category.
-		if ( did_action( 'wp_abilities_api_categories_init' ) ) {
-			self::register_category();
-		} else {
-			add_action( 'wp_abilities_api_categories_init', array( __CLASS__, 'register_category' ) );
-		}
+	const FORM_STATUSES = array( 'publish', 'draft', 'trash' );
 
-		// Register abilities.
-		if ( did_action( 'wp_abilities_api_init' ) ) {
-			self::register_abilities();
-		} else {
-			add_action( 'wp_abilities_api_init', array( __CLASS__, 'register_abilities' ) );
-		}
+	/**
+	 * Form post statuses accepted by create-form.
+	 */
+	const CREATE_FORM_STATUSES = array( 'publish', 'draft' );
+
+	/**
+	 * Response post statuses accepted by get-responses / update-response.
+	 */
+	const RESPONSE_STATUSES = array( 'publish', 'draft', 'spam', 'trash' );
+
+	/**
+	 * Bulk actions accepted by bulk-update-responses.
+	 */
+	const BULK_ACTIONS = array( 'mark_as_spam', 'mark_as_not_spam' );
+
+	/**
+	 * Default block content used when create-form is called without `content`.
+	 */
+	const DEFAULT_FORM_CONTENT = '<!-- wp:jetpack/contact-form --><!-- wp:jetpack/button {"element":"button","text":"Submit","lock":{"remove":true}} /--><!-- /wp:jetpack/contact-form -->';
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public static function get_category_slug(): string {
+		return self::CATEGORY_SLUG;
 	}
 
 	/**
-	 * Register the Jetpack Forms ability category.
-	 *
-	 * @return void
+	 * {@inheritDoc}
 	 */
-	public static function register_category() {
-		if ( ! function_exists( 'wp_register_ability_category' ) ) {
-			return;
-		}
-
-		wp_register_ability_category(
-			self::CATEGORY_SLUG,
-			array(
-				// "Jetpack Forms" is a product name and should not be translated.
-				'label'       => 'Jetpack Forms',
-				'description' => __( 'Abilities for managing Jetpack Forms and their responses.', 'jetpack-forms' ),
-			)
+	public static function get_category_definition(): array {
+		return array(
+			// "Jetpack Forms" is a product name and should not be translated.
+			'label'       => 'Jetpack Forms',
+			'description' => __( 'Abilities for managing Jetpack Forms and their responses.', 'jetpack-forms' ),
 		);
 	}
 
 	/**
-	 * Register all Jetpack Forms abilities.
-	 *
-	 * @return void
+	 * {@inheritDoc}
 	 */
-	public static function register_abilities() {
-		if ( ! function_exists( 'wp_register_ability' ) ) {
-			return;
-		}
-
-		self::register_list_forms_ability();
-		self::register_get_form_ability();
-		self::register_create_form_ability();
-		self::register_delete_form_ability();
-		self::register_get_responses_ability();
-		self::register_update_response_ability();
-		self::register_bulk_update_responses_ability();
-		self::register_get_status_counts_ability();
+	public static function get_abilities(): array {
+		return array(
+			'jetpack-forms/list-forms'            => self::spec_list_forms(),
+			'jetpack-forms/get-form'              => self::spec_get_form(),
+			'jetpack-forms/create-form'           => self::spec_create_form(),
+			'jetpack-forms/delete-form'           => self::spec_delete_form(),
+			'jetpack-forms/get-responses'         => self::spec_get_responses(),
+			'jetpack-forms/update-response'       => self::spec_update_response(),
+			'jetpack-forms/bulk-update-responses' => self::spec_bulk_update_responses(),
+			'jetpack-forms/get-status-counts'     => self::spec_get_status_counts(),
+		);
 	}
 
-	/**
-	 * Register ability to list forms with admin-level detail.
-	 *
-	 * @return void
+	/*
+	---------------------------------------------------------------------
+	 * Ability specs
+	 * ---------------------------------------------------------------------
 	 */
-	private static function register_list_forms_ability() {
-		wp_register_ability(
-			'jetpack-forms/list-forms',
-			array(
-				'label'               => __( 'List forms (admin)', 'jetpack-forms' ),
-				'description'         => __( 'List all forms with admin detail including response counts, status, and edit URLs. Supports pagination, search, and status filtering.', 'jetpack-forms' ),
-				'category'            => self::CATEGORY_SLUG,
-				'input_schema'        => array(
-					'type'                 => 'object',
-					'default'              => array(),
-					'properties'           => array(
-						'page'     => array(
-							'type'        => 'integer',
-							'description' => __( 'Page number for paginated results.', 'jetpack-forms' ),
-							'default'     => 1,
-						),
-						'per_page' => array(
-							'type'        => 'integer',
-							'description' => __( 'Number of forms per page (max 100).', 'jetpack-forms' ),
-							'default'     => 10,
-						),
-						'search'   => array(
-							'type'        => 'string',
-							'description' => __( 'Search forms by title.', 'jetpack-forms' ),
-						),
-						'status'   => array(
-							'type'        => 'string',
-							'description' => __( 'Filter by form status.', 'jetpack-forms' ),
-							'enum'        => array( 'publish', 'draft', 'trash' ),
-						),
+
+	/**
+	 * Spec: jetpack-forms/list-forms.
+	 */
+	private static function spec_list_forms(): array {
+		return array(
+			'label'               => __( 'List forms (admin)', 'jetpack-forms' ),
+			'description'         => __( 'List all forms with admin detail including response counts, status, and edit URLs. Supports pagination, search, and status filtering.', 'jetpack-forms' ),
+			'input_schema'        => array(
+				'type'                 => 'object',
+				'default'              => array(),
+				'properties'           => array(
+					'page'     => array(
+						'type'        => 'integer',
+						'description' => __( 'Page number for paginated results.', 'jetpack-forms' ),
+						'default'     => 1,
+						'minimum'     => 1,
 					),
-					'additionalProperties' => false,
-				),
-				'execute_callback'    => array( __CLASS__, 'list_forms' ),
-				'permission_callback' => array( __CLASS__, 'can_edit_pages' ),
-				'meta'                => array(
-					'annotations'  => array(
-						'readonly'    => true,
-						'destructive' => false,
-						'idempotent'  => true,
+					'per_page' => array(
+						'type'        => 'integer',
+						'description' => __( 'Number of forms per page.', 'jetpack-forms' ),
+						'default'     => 10,
+						'minimum'     => 1,
+						'maximum'     => 100,
 					),
-					'show_in_rest' => true,
+					'search'   => array(
+						'type'        => 'string',
+						'description' => __( 'Search forms by title.', 'jetpack-forms' ),
+					),
+					'status'   => array(
+						'type'        => 'string',
+						'description' => __( 'Filter by form status.', 'jetpack-forms' ),
+						'enum'        => self::FORM_STATUSES,
+					),
 				),
-			)
+				'additionalProperties' => false,
+			),
+			'execute_callback'    => array( __CLASS__, 'list_forms' ),
+			'permission_callback' => array( __CLASS__, 'can_edit_pages' ),
+			'meta'                => array(
+				'annotations'  => array(
+					'readonly'    => true,
+					'destructive' => false,
+					'idempotent'  => true,
+				),
+				'show_in_rest' => true,
+			),
 		);
 	}
 
 	/**
-	 * Register ability to get a single form's full details.
-	 *
-	 * @return void
+	 * Spec: jetpack-forms/get-form.
 	 */
-	private static function register_get_form_ability() {
-		wp_register_ability(
-			'jetpack-forms/get-form',
-			array(
-				'label'               => __( 'Get form details', 'jetpack-forms' ),
-				'description'         => __( 'Get a single form with its full structure including field definitions, status, and edit URL.', 'jetpack-forms' ),
-				'category'            => self::CATEGORY_SLUG,
-				'input_schema'        => array(
-					'type'                 => 'object',
-					'required'             => array( 'id' ),
-					'properties'           => array(
-						'id' => array(
-							'type'        => 'integer',
-							'description' => __( 'The form ID.', 'jetpack-forms' ),
-						),
+	private static function spec_get_form(): array {
+		return array(
+			'label'               => __( 'Get form details', 'jetpack-forms' ),
+			'description'         => __( 'Get a single form with its full structure including field definitions, status, and edit URL.', 'jetpack-forms' ),
+			'input_schema'        => array(
+				'type'                 => 'object',
+				'required'             => array( 'id' ),
+				'properties'           => array(
+					'id' => array(
+						'type'        => 'integer',
+						'description' => __( 'The form ID.', 'jetpack-forms' ),
 					),
-					'additionalProperties' => false,
 				),
-				'execute_callback'    => array( __CLASS__, 'get_form' ),
-				'permission_callback' => array( __CLASS__, 'can_edit_pages' ),
-				'meta'                => array(
-					'annotations'  => array(
-						'readonly'    => true,
-						'destructive' => false,
-						'idempotent'  => true,
-					),
-					'show_in_rest' => true,
+				'additionalProperties' => false,
+			),
+			'execute_callback'    => array( __CLASS__, 'get_form' ),
+			'permission_callback' => array( __CLASS__, 'can_edit_pages' ),
+			'meta'                => array(
+				'annotations'  => array(
+					'readonly'    => true,
+					'destructive' => false,
+					'idempotent'  => true,
 				),
-			)
+				'show_in_rest' => true,
+			),
 		);
 	}
 
 	/**
-	 * Register ability to create a new form.
-	 *
-	 * @return void
+	 * Spec: jetpack-forms/create-form.
 	 */
-	private static function register_create_form_ability() {
-		wp_register_ability(
-			'jetpack-forms/create-form',
-			array(
-				'label'               => __( 'Create a form', 'jetpack-forms' ),
-				'description'         => __( 'Create a new form with a title. Optionally provide block content for the form structure. Returns the new form ID and edit URL.', 'jetpack-forms' ),
-				'category'            => self::CATEGORY_SLUG,
-				'input_schema'        => array(
-					'type'                 => 'object',
-					'required'             => array( 'title' ),
-					'properties'           => array(
-						'title'   => array(
-							'type'        => 'string',
-							'description' => __( 'The form title/name.', 'jetpack-forms' ),
-						),
-						'content' => array(
-							'type'        => 'string',
-							'description' => __( 'Block content for the form structure. If omitted, creates an empty form with a submit button.', 'jetpack-forms' ),
-						),
-						'status'  => array(
-							'type'        => 'string',
-							'description' => __( 'Initial form status.', 'jetpack-forms' ),
-							'enum'        => array( 'publish', 'draft' ),
-							'default'     => 'publish',
-						),
+	private static function spec_create_form(): array {
+		return array(
+			'label'               => __( 'Create a form', 'jetpack-forms' ),
+			'description'         => __( 'Create a new form with a title. Optionally provide block content for the form structure. Returns the new form ID and edit URL.', 'jetpack-forms' ),
+			'input_schema'        => array(
+				'type'                 => 'object',
+				'required'             => array( 'title' ),
+				'properties'           => array(
+					'title'   => array(
+						'type'        => 'string',
+						'description' => __( 'The form title/name.', 'jetpack-forms' ),
 					),
-					'additionalProperties' => false,
-				),
-				'execute_callback'    => array( __CLASS__, 'create_form' ),
-				'permission_callback' => array( __CLASS__, 'can_edit_pages' ),
-				'meta'                => array(
-					'annotations'  => array(
-						'readonly'    => false,
-						'destructive' => false,
-						'idempotent'  => false,
+					'content' => array(
+						'type'        => 'string',
+						'description' => __( 'Block content for the form structure. If omitted, creates an empty form with a submit button.', 'jetpack-forms' ),
 					),
-					'show_in_rest' => true,
+					'status'  => array(
+						'type'        => 'string',
+						'description' => __( 'Initial form status.', 'jetpack-forms' ),
+						'enum'        => self::CREATE_FORM_STATUSES,
+						'default'     => 'publish',
+					),
 				),
-			)
+				'additionalProperties' => false,
+			),
+			'execute_callback'    => array( __CLASS__, 'create_form' ),
+			'permission_callback' => array( __CLASS__, 'can_edit_pages' ),
+			'meta'                => array(
+				'annotations'  => array(
+					'readonly'    => false,
+					'destructive' => false,
+					'idempotent'  => false,
+				),
+				'show_in_rest' => true,
+			),
 		);
 	}
 
 	/**
-	 * Register ability to delete a form.
-	 *
-	 * @return void
+	 * Spec: jetpack-forms/delete-form.
 	 */
-	private static function register_delete_form_ability() {
-		wp_register_ability(
-			'jetpack-forms/delete-form',
-			array(
-				'label'               => __( 'Delete a form', 'jetpack-forms' ),
-				'description'         => __( 'Move a form to the trash. Does not permanently delete. Trashed forms can be restored.', 'jetpack-forms' ),
-				'category'            => self::CATEGORY_SLUG,
-				'input_schema'        => array(
-					'type'                 => 'object',
-					'required'             => array( 'id' ),
-					'properties'           => array(
-						'id' => array(
-							'type'        => 'integer',
-							'description' => __( 'The form ID to delete.', 'jetpack-forms' ),
-						),
+	private static function spec_delete_form(): array {
+		return array(
+			'label'               => __( 'Delete a form', 'jetpack-forms' ),
+			'description'         => __( 'Move a form to the trash. Does not permanently delete. Trashed forms can be restored.', 'jetpack-forms' ),
+			'input_schema'        => array(
+				'type'                 => 'object',
+				'required'             => array( 'id' ),
+				'properties'           => array(
+					'id' => array(
+						'type'        => 'integer',
+						'description' => __( 'The form ID to delete.', 'jetpack-forms' ),
 					),
-					'additionalProperties' => false,
 				),
-				'execute_callback'    => array( __CLASS__, 'delete_form' ),
-				'permission_callback' => array( __CLASS__, 'can_edit_pages' ),
-				'meta'                => array(
-					'annotations'  => array(
-						'readonly'    => false,
-						'destructive' => true,
-						'idempotent'  => true,
-					),
-					'show_in_rest' => true,
+				'additionalProperties' => false,
+			),
+			'execute_callback'    => array( __CLASS__, 'delete_form' ),
+			'permission_callback' => array( __CLASS__, 'can_edit_pages' ),
+			'meta'                => array(
+				'annotations'  => array(
+					'readonly'    => false,
+					'destructive' => true,
+					'idempotent'  => true,
 				),
-			)
+				'show_in_rest' => true,
+			),
 		);
 	}
 
 	/**
-	 * Register ability to get form responses.
-	 *
-	 * @return void
+	 * Spec: jetpack-forms/get-responses.
 	 */
-	private static function register_get_responses_ability() {
-		wp_register_ability(
-			'jetpack-forms/get-responses',
-			array(
-				'label'               => __( 'Get form responses', 'jetpack-forms' ),
-				'description'         => __( 'List or search form responses. Returns response data including sender info, form fields, and metadata. Supports filtering by status, date range, read state, and search terms.', 'jetpack-forms' ),
-				'category'            => self::CATEGORY_SLUG,
-				'input_schema'        => array(
-					'type'                 => 'object',
-					'default'              => array(),
-					'properties'           => array(
-						'ids'       => array(
-							'type'        => 'array',
-							'description' => __( 'Fetch specific responses by their IDs.', 'jetpack-forms' ),
-							'items'       => array( 'type' => 'integer' ),
-						),
-						'page'      => array(
-							'type'        => 'integer',
-							'description' => __( 'Page number for paginated results.', 'jetpack-forms' ),
-							'default'     => 1,
-						),
-						'per_page'  => array(
-							'type'        => 'integer',
-							'description' => __( 'Number of responses to return per page (max 100).', 'jetpack-forms' ),
-							'default'     => 10,
-						),
-						'parent'    => array(
-							'type'        => 'array',
-							'description' => __( 'Filter by the page or post ID where the form is embedded.', 'jetpack-forms' ),
-							'items'       => array( 'type' => 'integer' ),
-						),
-						'status'    => array(
-							'type'        => 'string',
-							'description' => __( 'Filter by response status.', 'jetpack-forms' ),
-							'enum'        => array( 'publish', 'draft', 'spam', 'trash' ),
-						),
-						'is_unread' => array(
-							'type'        => 'boolean',
-							'description' => __( 'Set true for unread only, false for read only.', 'jetpack-forms' ),
-						),
-						'search'    => array(
-							'type'        => 'string',
-							'description' => __( 'Search within response content and sender info.', 'jetpack-forms' ),
-						),
-						'before'    => array(
-							'type'        => 'string',
-							'description' => __( 'Only responses before this date (ISO8601 format).', 'jetpack-forms' ),
-							'format'      => 'date-time',
-						),
-						'after'     => array(
-							'type'        => 'string',
-							'description' => __( 'Only responses after this date (ISO8601 format).', 'jetpack-forms' ),
-							'format'      => 'date-time',
-						),
+	private static function spec_get_responses(): array {
+		return array(
+			'label'               => __( 'Get form responses', 'jetpack-forms' ),
+			'description'         => __( 'List or search form responses. Returns response data including sender info, form fields, and metadata. Supports filtering by status, date range, read state, and search terms.', 'jetpack-forms' ),
+			'input_schema'        => array(
+				'type'                 => 'object',
+				'default'              => array(),
+				'properties'           => array(
+					'ids'       => array(
+						'type'        => 'array',
+						'description' => __( 'Fetch specific responses by their IDs.', 'jetpack-forms' ),
+						'items'       => array( 'type' => 'integer' ),
 					),
-					'additionalProperties' => false,
-				),
-				'execute_callback'    => array( __CLASS__, 'get_form_responses' ),
-				'permission_callback' => array( __CLASS__, 'can_edit_pages' ),
-				'meta'                => array(
-					'annotations'  => array(
-						'readonly'    => true,
-						'destructive' => false,
-						'idempotent'  => true,
+					'page'      => array(
+						'type'        => 'integer',
+						'description' => __( 'Page number for paginated results.', 'jetpack-forms' ),
+						'default'     => 1,
+						'minimum'     => 1,
 					),
-					'show_in_rest' => true,
+					'per_page'  => array(
+						'type'        => 'integer',
+						'description' => __( 'Number of responses to return per page.', 'jetpack-forms' ),
+						'default'     => 10,
+						'minimum'     => 1,
+						'maximum'     => 100,
+					),
+					'parent'    => array(
+						'type'        => 'array',
+						'description' => __( 'Filter by the page or post ID where the form is embedded.', 'jetpack-forms' ),
+						'items'       => array( 'type' => 'integer' ),
+					),
+					'status'    => array(
+						'type'        => 'string',
+						'description' => __( 'Filter by response status.', 'jetpack-forms' ),
+						'enum'        => self::RESPONSE_STATUSES,
+					),
+					'is_unread' => array(
+						'type'        => 'boolean',
+						'description' => __( 'Set true for unread only, false for read only.', 'jetpack-forms' ),
+					),
+					'search'    => array(
+						'type'        => 'string',
+						'description' => __( 'Search within response content and sender info.', 'jetpack-forms' ),
+					),
+					'before'    => array(
+						'type'        => 'string',
+						'description' => __( 'Only responses before this date (ISO8601 format).', 'jetpack-forms' ),
+						'format'      => 'date-time',
+					),
+					'after'     => array(
+						'type'        => 'string',
+						'description' => __( 'Only responses after this date (ISO8601 format).', 'jetpack-forms' ),
+						'format'      => 'date-time',
+					),
 				),
-			)
+				'additionalProperties' => false,
+			),
+			'execute_callback'    => array( __CLASS__, 'get_form_responses' ),
+			'permission_callback' => array( __CLASS__, 'can_edit_pages' ),
+			'meta'                => array(
+				'annotations'  => array(
+					'readonly'    => true,
+					'destructive' => false,
+					'idempotent'  => true,
+				),
+				'show_in_rest' => true,
+			),
 		);
 	}
 
 	/**
-	 * Register ability to update a form response.
-	 *
-	 * @return void
+	 * Spec: jetpack-forms/update-response.
 	 */
-	private static function register_update_response_ability() {
-		wp_register_ability(
-			'jetpack-forms/update-response',
-			array(
-				'label'               => __( 'Update form response', 'jetpack-forms' ),
-				'description'         => __( 'Modify a form response. Use to mark as spam, move to trash, restore from trash, or toggle read/unread state.', 'jetpack-forms' ),
-				'category'            => self::CATEGORY_SLUG,
-				'input_schema'        => array(
-					'type'                 => 'object',
-					'required'             => array( 'id' ),
-					'properties'           => array(
-						'id'        => array(
-							'type'        => 'integer',
-							'description' => __( 'The response ID to update.', 'jetpack-forms' ),
-						),
-						'status'    => array(
-							'type'        => 'string',
-							'description' => __( 'New status: "publish" (restore), "spam" (mark spam), "trash" (soft delete).', 'jetpack-forms' ),
-							'enum'        => array( 'publish', 'draft', 'spam', 'trash' ),
-						),
-						'is_unread' => array(
-							'type'        => 'boolean',
-							'description' => __( 'Set false to mark as read, true to mark as unread.', 'jetpack-forms' ),
-						),
+	private static function spec_update_response(): array {
+		return array(
+			'label'               => __( 'Update form response', 'jetpack-forms' ),
+			'description'         => __( 'Modify a form response. Use to mark as spam, move to trash, restore from trash, or toggle read/unread state.', 'jetpack-forms' ),
+			'input_schema'        => array(
+				'type'                 => 'object',
+				'required'             => array( 'id' ),
+				'properties'           => array(
+					'id'        => array(
+						'type'        => 'integer',
+						'description' => __( 'The response ID to update.', 'jetpack-forms' ),
 					),
-					'additionalProperties' => false,
-				),
-				'execute_callback'    => array( __CLASS__, 'update_form_response' ),
-				'permission_callback' => array( __CLASS__, 'can_edit_pages' ),
-				'meta'                => array(
-					'annotations'  => array(
-						'readonly'    => false,
-						'destructive' => false,
-						'idempotent'  => true,
+					'status'    => array(
+						'type'        => 'string',
+						'description' => __( 'New status: "publish" (restore), "spam" (mark spam), "trash" (soft delete).', 'jetpack-forms' ),
+						'enum'        => self::RESPONSE_STATUSES,
 					),
-					'show_in_rest' => true,
+					'is_unread' => array(
+						'type'        => 'boolean',
+						'description' => __( 'Set false to mark as read, true to mark as unread.', 'jetpack-forms' ),
+					),
 				),
-			)
+				'additionalProperties' => false,
+			),
+			'execute_callback'    => array( __CLASS__, 'update_form_response' ),
+			'permission_callback' => array( __CLASS__, 'can_edit_pages' ),
+			'meta'                => array(
+				'annotations'  => array(
+					'readonly'    => false,
+					'destructive' => false,
+					'idempotent'  => true,
+				),
+				'show_in_rest' => true,
+			),
 		);
 	}
 
 	/**
-	 * Register ability to bulk-update form responses.
-	 *
-	 * @return void
+	 * Spec: jetpack-forms/bulk-update-responses.
 	 */
-	private static function register_bulk_update_responses_ability() {
-		wp_register_ability(
-			'jetpack-forms/bulk-update-responses',
-			array(
-				'label'               => __( 'Bulk update form responses', 'jetpack-forms' ),
-				'description'         => __( 'Mark multiple responses as spam or not-spam in a single operation.', 'jetpack-forms' ),
-				'category'            => self::CATEGORY_SLUG,
-				'input_schema'        => array(
-					'type'                 => 'object',
-					'required'             => array( 'action', 'ids' ),
-					'properties'           => array(
-						'action' => array(
-							'type'        => 'string',
-							'description' => __( 'The bulk action to perform.', 'jetpack-forms' ),
-							'enum'        => array( 'mark_as_spam', 'mark_as_not_spam' ),
-						),
-						'ids'    => array(
-							'type'        => 'array',
-							'description' => __( 'Response IDs to update.', 'jetpack-forms' ),
-							'items'       => array( 'type' => 'integer' ),
-						),
+	private static function spec_bulk_update_responses(): array {
+		return array(
+			'label'               => __( 'Bulk update form responses', 'jetpack-forms' ),
+			'description'         => __( 'Mark multiple responses as spam or not-spam in a single operation.', 'jetpack-forms' ),
+			'input_schema'        => array(
+				'type'                 => 'object',
+				'required'             => array( 'action', 'ids' ),
+				'properties'           => array(
+					'action' => array(
+						'type'        => 'string',
+						'description' => __( 'The bulk action to perform.', 'jetpack-forms' ),
+						'enum'        => self::BULK_ACTIONS,
 					),
-					'additionalProperties' => false,
-				),
-				'execute_callback'    => array( __CLASS__, 'bulk_update_responses' ),
-				'permission_callback' => array( __CLASS__, 'can_edit_pages' ),
-				'meta'                => array(
-					'annotations'  => array(
-						'readonly'    => false,
-						'destructive' => false,
-						'idempotent'  => true,
+					'ids'    => array(
+						'type'        => 'array',
+						'description' => __( 'Response IDs to update.', 'jetpack-forms' ),
+						'items'       => array( 'type' => 'integer' ),
+						'minItems'    => 1,
 					),
-					'show_in_rest' => true,
 				),
-			)
+				'additionalProperties' => false,
+			),
+			'execute_callback'    => array( __CLASS__, 'bulk_update_responses' ),
+			'permission_callback' => array( __CLASS__, 'can_edit_pages' ),
+			'meta'                => array(
+				'annotations'  => array(
+					'readonly'    => false,
+					'destructive' => false,
+					'idempotent'  => true,
+				),
+				'show_in_rest' => true,
+			),
 		);
 	}
 
 	/**
-	 * Register ability to get status counts.
-	 *
-	 * @return void
+	 * Spec: jetpack-forms/get-status-counts.
 	 */
-	private static function register_get_status_counts_ability() {
-		wp_register_ability(
-			'jetpack-forms/get-status-counts',
-			array(
-				'label'               => __( 'Get response status counts', 'jetpack-forms' ),
-				'description'         => __( 'Get a summary of form responses grouped by status. Returns counts for inbox (active), spam, and trash. Useful for dashboard stats or checking if there are new responses.', 'jetpack-forms' ),
-				'category'            => self::CATEGORY_SLUG,
-				'input_schema'        => array(
-					'type'                 => 'object',
-					'default'              => array(),
-					'properties'           => array(
-						'search'    => array(
-							'type'        => 'string',
-							'description' => __( 'Only count responses matching this search term.', 'jetpack-forms' ),
-						),
-						'parent'    => array(
-							'type'        => 'integer',
-							'description' => __( 'Only count responses from a specific page or post.', 'jetpack-forms' ),
-						),
-						'before'    => array(
-							'type'        => 'string',
-							'description' => __( 'Only count responses before this date (ISO8601 format).', 'jetpack-forms' ),
-							'format'      => 'date-time',
-						),
-						'after'     => array(
-							'type'        => 'string',
-							'description' => __( 'Only count responses after this date (ISO8601 format).', 'jetpack-forms' ),
-							'format'      => 'date-time',
-						),
-						'is_unread' => array(
-							'type'        => 'boolean',
-							'description' => __( 'Set true to count only unread, false for only read.', 'jetpack-forms' ),
-						),
+	private static function spec_get_status_counts(): array {
+		return array(
+			'label'               => __( 'Get response status counts', 'jetpack-forms' ),
+			'description'         => __( 'Get a summary of form responses grouped by status. Returns counts for inbox (active), spam, and trash. Useful for dashboard stats or checking if there are new responses.', 'jetpack-forms' ),
+			'input_schema'        => array(
+				'type'                 => 'object',
+				'default'              => array(),
+				'properties'           => array(
+					'search'    => array(
+						'type'        => 'string',
+						'description' => __( 'Only count responses matching this search term.', 'jetpack-forms' ),
 					),
-					'additionalProperties' => false,
-				),
-				'execute_callback'    => array( __CLASS__, 'get_status_counts' ),
-				'permission_callback' => array( __CLASS__, 'can_edit_pages' ),
-				'meta'                => array(
-					'annotations'  => array(
-						'readonly'    => true,
-						'destructive' => false,
-						'idempotent'  => true,
+					'parent'    => array(
+						'type'        => 'integer',
+						'description' => __( 'Only count responses from a specific page or post.', 'jetpack-forms' ),
 					),
-					'show_in_rest' => true,
+					'before'    => array(
+						'type'        => 'string',
+						'description' => __( 'Only count responses before this date (ISO8601 format).', 'jetpack-forms' ),
+						'format'      => 'date-time',
+					),
+					'after'     => array(
+						'type'        => 'string',
+						'description' => __( 'Only count responses after this date (ISO8601 format).', 'jetpack-forms' ),
+						'format'      => 'date-time',
+					),
+					'is_unread' => array(
+						'type'        => 'boolean',
+						'description' => __( 'Set true to count only unread, false for only read.', 'jetpack-forms' ),
+					),
 				),
-			)
+				'additionalProperties' => false,
+			),
+			'execute_callback'    => array( __CLASS__, 'get_status_counts' ),
+			'permission_callback' => array( __CLASS__, 'can_edit_pages' ),
+			'meta'                => array(
+				'annotations'  => array(
+					'readonly'    => true,
+					'destructive' => false,
+					'idempotent'  => true,
+				),
+				'show_in_rest' => true,
+			),
 		);
 	}
 
+	/*
+	---------------------------------------------------------------------
+	 * Permission callbacks
+	 * ---------------------------------------------------------------------
+	 */
+
 	/**
-	 * Check if user can edit pages.
+	 * Permission callback shared by every Forms ability. The delegated REST
+	 * controller re-checks the user's edit permission per-route, so this is
+	 * a coarse early-rejection gate, not the authoritative authorization.
 	 *
 	 * @return bool
 	 */
@@ -491,50 +459,37 @@ class Forms_Abilities {
 		return current_user_can( 'edit_pages' );
 	}
 
-	/**
-	 * Dispatch an internal REST request and return its data or WP_Error.
-	 *
-	 * @param \WP_REST_Request $request The REST request to dispatch.
-	 * @return array|\WP_Error Response data array, or WP_Error on failure.
+	/*
+	---------------------------------------------------------------------
+	 * Execute callbacks
+	 * ---------------------------------------------------------------------
 	 */
-	private static function dispatch( $request ) {
-		$response = rest_do_request( $request );
-
-		if ( $response->is_error() ) {
-			return $response->as_error();
-		}
-
-		return $response->get_data();
-	}
 
 	/**
-	 * List forms with admin-level detail callback.
+	 * Execute: list-forms.
 	 *
-	 * Delegates to GET /wp/v2/jetpack-forms with dashboard context,
-	 * then reshapes to a compact format for AI consumption.
+	 * Delegates to GET /wp/v2/jetpack-forms with dashboard context, then
+	 * reshapes to a compact format for AI consumption.
 	 *
 	 * @param array $args Arguments from the ability input.
-	 * @return array|\WP_Error Returns array of forms with admin detail.
+	 * @return array|\WP_Error
 	 */
 	public static function list_forms( $args = array() ) {
 		$args    = is_array( $args ) ? $args : array();
 		$request = new \WP_REST_Request( 'GET', '/wp/v2/jetpack-forms' );
-
 		$request->set_param( 'jetpack_forms_context', 'dashboard' );
-
-		foreach ( array( 'page', 'per_page', 'search', 'status' ) as $key ) {
-			if ( isset( $args[ $key ] ) ) {
-				$request->set_param( $key, $args[ $key ] );
-			}
-		}
+		self::set_params_from_args( $request, $args, array( 'page', 'per_page', 'search', 'status' ) );
 
 		$data = self::dispatch( $request );
 		if ( is_wp_error( $data ) ) {
 			return $data;
 		}
 
+		if ( ! is_array( $data ) ) {
+			return array();
+		}
+
 		$result = array();
-		'@phan-var array[] $data'; // Phan doesn't narrow after is_wp_error + return.
 		foreach ( $data as $form ) {
 			$result[] = array(
 				'id'            => $form['id'],
@@ -551,13 +506,14 @@ class Forms_Abilities {
 	}
 
 	/**
-	 * Get a single form's full details callback.
+	 * Execute: get-form.
 	 *
-	 * Delegates to GET /wp/v2/jetpack-forms/{id} for the base data,
-	 * then enriches with extracted field definitions from block content.
+	 * Delegates to GET /wp/v2/jetpack-forms/{id} with `context=edit` so the
+	 * raw block content comes back in the response — no second `get_post()`
+	 * fetch needed.
 	 *
 	 * @param array $args Arguments from the ability input.
-	 * @return array|\WP_Error Returns form data with fields, or WP_Error.
+	 * @return array|\WP_Error
 	 */
 	public static function get_form( $args ) {
 		if ( ! isset( $args['id'] ) ) {
@@ -572,14 +528,13 @@ class Forms_Abilities {
 			return $data;
 		}
 
-		$post   = get_post( absint( $args['id'] ) );
-		$fields = $post ? self::extract_fields_from_post( $post ) : array();
+		$raw_content = $data['content']['raw'] ?? '';
 
 		return array(
 			'id'       => $data['id'],
 			'title'    => $data['title']['raw'] ?? $data['title']['rendered'] ?? '',
 			'status'   => $data['status'],
-			'fields'   => $fields,
+			'fields'   => self::extract_fields_from_content( $raw_content ),
 			'date'     => $data['date'],
 			'modified' => $data['modified'],
 			'edit_url' => $data['link'] ?? get_edit_post_link( $data['id'], 'raw' ),
@@ -587,13 +542,10 @@ class Forms_Abilities {
 	}
 
 	/**
-	 * Create a new form callback.
-	 *
-	 * Delegates to POST /wp/v2/jetpack-forms, which handles
-	 * sanitization, validation, and all insert hooks.
+	 * Execute: create-form.
 	 *
 	 * @param array $args Arguments from the ability input.
-	 * @return array|\WP_Error Returns new form data or WP_Error.
+	 * @return array|\WP_Error
 	 */
 	public static function create_form( $args ) {
 		if ( empty( $args['title'] ) ) {
@@ -602,7 +554,7 @@ class Forms_Abilities {
 
 		$content = $args['content'] ?? '';
 		if ( '' === $content ) {
-			$content = '<!-- wp:jetpack/contact-form --><!-- wp:jetpack/button {"element":"button","text":"Submit","lock":{"remove":true}} /--><!-- /wp:jetpack/contact-form -->';
+			$content = self::DEFAULT_FORM_CONTENT;
 		}
 
 		$request = new \WP_REST_Request( 'POST', '/wp/v2/jetpack-forms' );
@@ -621,20 +573,17 @@ class Forms_Abilities {
 
 		return array(
 			'id'       => $data['id'],
-			'title'    => $data['title']['rendered'] ?? $data['title']['raw'] ?? '',
+			'title'    => $data['title']['raw'] ?? $data['title']['rendered'] ?? '',
 			'status'   => $data['status'],
 			'edit_url' => get_edit_post_link( $data['id'], 'raw' ),
 		);
 	}
 
 	/**
-	 * Delete (trash) a form callback.
-	 *
-	 * Delegates to DELETE /wp/v2/jetpack-forms/{id}, which handles
-	 * permission checks and trash logic.
+	 * Execute: delete-form.
 	 *
 	 * @param array $args Arguments from the ability input.
-	 * @return array|\WP_Error Returns deletion result or WP_Error.
+	 * @return array|\WP_Error
 	 */
 	public static function delete_form( $args ) {
 		if ( ! isset( $args['id'] ) ) {
@@ -656,22 +605,15 @@ class Forms_Abilities {
 	}
 
 	/**
-	 * Get form responses callback.
-	 *
-	 * Delegates to GET /wp/v2/feedback.
+	 * Execute: get-responses.
 	 *
 	 * @param array $args Arguments from the ability input.
-	 * @return array|\WP_Error Returns array of responses or WP_Error on failure.
+	 * @return array|\WP_Error
 	 */
 	public static function get_form_responses( $args = array() ) {
 		$args    = is_array( $args ) ? $args : array();
 		$request = new \WP_REST_Request( 'GET', '/wp/v2/feedback' );
-
-		foreach ( array( 'page', 'per_page', 'parent', 'status', 'is_unread', 'search', 'before', 'after' ) as $key ) {
-			if ( isset( $args[ $key ] ) ) {
-				$request->set_param( $key, $args[ $key ] );
-			}
-		}
+		self::set_params_from_args( $request, $args, array( 'page', 'per_page', 'parent', 'status', 'is_unread', 'search', 'before', 'after' ) );
 
 		if ( isset( $args['ids'] ) && is_array( $args['ids'] ) ) {
 			$request->set_param( 'include', $args['ids'] );
@@ -681,13 +623,10 @@ class Forms_Abilities {
 	}
 
 	/**
-	 * Update form response callback.
-	 *
-	 * Delegates to POST /wp/v2/feedback/{id} for status changes
-	 * and POST /wp/v2/feedback/{id}/read for read state changes.
+	 * Execute: update-response.
 	 *
 	 * @param array $args Arguments from the ability input.
-	 * @return array|\WP_Error Returns updated response data or WP_Error on failure.
+	 * @return array|\WP_Error
 	 */
 	public static function update_form_response( $args ) {
 		if ( ! isset( $args['id'] ) ) {
@@ -700,7 +639,6 @@ class Forms_Abilities {
 		if ( isset( $args['status'] ) ) {
 			$request = new \WP_REST_Request( 'POST', '/wp/v2/feedback/' . $id );
 			$request->set_body_params( array( 'status' => $args['status'] ) );
-
 			$data = self::dispatch( $request );
 			if ( is_wp_error( $data ) ) {
 				return $data;
@@ -711,7 +649,6 @@ class Forms_Abilities {
 		if ( isset( $args['is_unread'] ) ) {
 			$request = new \WP_REST_Request( 'POST', '/wp/v2/feedback/' . $id . '/read' );
 			$request->set_body_params( array( 'is_unread' => $args['is_unread'] ) );
-
 			$data = self::dispatch( $request );
 			if ( is_wp_error( $data ) ) {
 				return $data;
@@ -723,12 +660,10 @@ class Forms_Abilities {
 	}
 
 	/**
-	 * Bulk update responses callback.
-	 *
-	 * Delegates to POST /wp/v2/feedback/bulk_actions.
+	 * Execute: bulk-update-responses.
 	 *
 	 * @param array $args Arguments from the ability input.
-	 * @return array|\WP_Error Returns update result or WP_Error.
+	 * @return array|\WP_Error
 	 */
 	public static function bulk_update_responses( $args ) {
 		if ( empty( $args['action'] ) || empty( $args['ids'] ) || ! is_array( $args['ids'] ) ) {
@@ -747,77 +682,103 @@ class Forms_Abilities {
 	}
 
 	/**
-	 * Get status counts callback.
-	 *
-	 * Delegates to GET /wp/v2/feedback/counts.
+	 * Execute: get-status-counts.
 	 *
 	 * @param array $args Arguments from the ability input.
-	 * @return array|\WP_Error Returns status counts or WP_Error on failure.
+	 * @return array|\WP_Error
 	 */
 	public static function get_status_counts( $args = array() ) {
 		$args    = is_array( $args ) ? $args : array();
 		$request = new \WP_REST_Request( 'GET', '/wp/v2/feedback/counts' );
-
-		foreach ( array( 'search', 'parent', 'before', 'after', 'is_unread' ) as $key ) {
-			if ( isset( $args[ $key ] ) ) {
-				$request->set_param( $key, $args[ $key ] );
-			}
-		}
+		self::set_params_from_args( $request, $args, array( 'search', 'parent', 'before', 'after', 'is_unread' ) );
 
 		return self::dispatch( $request );
 	}
 
-	/**
-	 * Extract field definitions from a form post's block content.
-	 *
-	 * @param \WP_Post $post The form post.
-	 * @return array Array of field definitions.
+	/*
+	---------------------------------------------------------------------
+	 * Helpers
+	 * ---------------------------------------------------------------------
 	 */
-	private static function extract_fields_from_post( $post ) {
-		$blocks = parse_blocks( $post->post_content );
+
+	/**
+	 * Dispatch an internal REST request and unwrap the response.
+	 *
+	 * @param \WP_REST_Request $request The REST request to dispatch.
+	 * @return array|\WP_Error Response data array, or WP_Error on failure.
+	 */
+	private static function dispatch( $request ) {
+		$response = rest_do_request( $request );
+		if ( $response->is_error() ) {
+			return $response->as_error();
+		}
+		return $response->get_data();
+	}
+
+	/**
+	 * Copy a whitelisted subset of `$args` onto a REST request as parameters.
+	 *
+	 * @param \WP_REST_Request $request Target request.
+	 * @param array            $args    Caller-supplied arguments.
+	 * @param array            $keys    Allowed keys to forward.
+	 */
+	private static function set_params_from_args( \WP_REST_Request $request, array $args, array $keys ): void {
+		foreach ( $keys as $key ) {
+			if ( isset( $args[ $key ] ) ) {
+				$request->set_param( $key, $args[ $key ] );
+			}
+		}
+	}
+
+	/**
+	 * Extract field definitions from raw block content.
+	 *
+	 * Walks `jetpack/field-*` blocks and projects each into a compact
+	 * `{ label, type, required, options?, placeholder? }` shape. Blocks
+	 * without a label are dropped — agents reference fields by label.
+	 *
+	 * @param string $raw_content Raw block content (typically `content.raw` from REST).
+	 * @return array
+	 */
+	private static function extract_fields_from_content( string $raw_content ): array {
+		if ( '' === $raw_content ) {
+			return array();
+		}
 		$fields = array();
-
-		self::extract_fields_from_blocks( $blocks, $fields );
-
+		self::collect_field_blocks( parse_blocks( $raw_content ), $fields );
 		return $fields;
 	}
 
 	/**
-	 * Recursively extract field definitions from blocks.
+	 * Recursively walk parsed blocks and append field definitions to `$fields`.
 	 *
-	 * @param array $blocks The blocks to process.
+	 * @param array $blocks Parsed blocks.
 	 * @param array $fields Reference to the fields array being built.
 	 */
-	private static function extract_fields_from_blocks( $blocks, &$fields ) {
+	private static function collect_field_blocks( array $blocks, array &$fields ): void {
 		foreach ( $blocks as $block ) {
 			if ( strpos( $block['blockName'] ?? '', 'jetpack/field-' ) === 0 ) {
 				$attrs = $block['attrs'] ?? array();
 				$label = $attrs['label'] ?? '';
-
-				// Skip fields without a label.
 				if ( '' === $label ) {
 					continue;
 				}
-
 				$field = array(
 					'label'    => $label,
 					'type'     => str_replace( 'jetpack/field-', '', $block['blockName'] ),
 					'required' => ! empty( $attrs['required'] ),
 				);
-
 				if ( ! empty( $attrs['options'] ) ) {
 					$field['options'] = $attrs['options'];
 				}
-
 				if ( ! empty( $attrs['placeholder'] ) ) {
 					$field['placeholder'] = $attrs['placeholder'];
 				}
-
 				$fields[] = $field;
 			}
 
 			if ( ! empty( $block['innerBlocks'] ) ) {
-				self::extract_fields_from_blocks( $block['innerBlocks'], $fields );
+				self::collect_field_blocks( $block['innerBlocks'], $fields );
 			}
 		}
 	}

--- a/projects/packages/forms/src/abilities/class-forms-abilities.php
+++ b/projects/packages/forms/src/abilities/class-forms-abilities.php
@@ -361,7 +361,7 @@ class Forms_Abilities extends Registrar {
 	private static function spec_bulk_update_responses(): array {
 		return array(
 			'label'               => __( 'Bulk update form responses', 'jetpack-forms' ),
-			'description'         => __( 'Mark multiple responses as spam or not-spam in a single operation.', 'jetpack-forms' ),
+			'description'         => __( 'Mark multiple responses as spam (or restore from spam) in a single call. Each response is processed individually; the result reports per-id success and any per-id failures so callers can see exactly which responses were updated. Also teaches Akismet from the successful updates.', 'jetpack-forms' ),
 			'input_schema'        => array(
 				'type'                 => 'object',
 				'required'             => array( 'action', 'ids' ),
@@ -662,6 +662,13 @@ class Forms_Abilities extends Registrar {
 	/**
 	 * Execute: bulk-update-responses.
 	 *
+	 * The `/wp/v2/feedback/bulk_actions` REST endpoint only teaches Akismet —
+	 * it does not change post status. The dashboard handles bulk spam/not-spam
+	 * by issuing per-id status updates first, then calling bulk_actions to
+	 * teach Akismet from the successful flips. We mirror that here so callers
+	 * get a faithful per-id confirmation: each id either lands in `succeeded`
+	 * or in `failed` with the underlying error code/message.
+	 *
 	 * @param array $args Arguments from the ability input.
 	 * @return array|\WP_Error
 	 */
@@ -670,15 +677,54 @@ class Forms_Abilities extends Registrar {
 			return new \WP_Error( 'missing_params', __( 'Action and IDs are required.', 'jetpack-forms' ) );
 		}
 
-		$request = new \WP_REST_Request( 'POST', '/wp/v2/feedback/bulk_actions' );
-		$request->set_body_params(
-			array(
-				'action'   => $args['action'],
-				'post_ids' => array_map( 'absint', $args['ids'] ),
-			)
-		);
+		$action        = $args['action'];
+		$target_status = 'mark_as_spam' === $action ? 'spam' : 'publish';
+		$ids           = array_values( array_unique( array_map( 'absint', $args['ids'] ) ) );
 
-		return self::dispatch( $request );
+		$succeeded = array();
+		$failed    = array();
+		foreach ( $ids as $id ) {
+			if ( $id <= 0 ) {
+				$failed[] = array(
+					'id'      => $id,
+					'code'    => 'invalid_id',
+					'message' => __( 'Response IDs must be positive integers.', 'jetpack-forms' ),
+				);
+				continue;
+			}
+			$request = new \WP_REST_Request( 'POST', '/wp/v2/feedback/' . $id );
+			$request->set_body_params( array( 'status' => $target_status ) );
+			$data = self::dispatch( $request );
+			if ( is_wp_error( $data ) ) {
+				$failed[] = array(
+					'id'      => $id,
+					'code'    => $data->get_error_code(),
+					'message' => $data->get_error_message(),
+				);
+				continue;
+			}
+			$succeeded[] = $id;
+		}
+
+		// Teach Akismet from the responses whose status actually flipped.
+		// Akismet learning is best-effort and independent of the status update,
+		// so a failure here doesn't roll back the per-id changes above.
+		if ( ! empty( $succeeded ) ) {
+			$teach = new \WP_REST_Request( 'POST', '/wp/v2/feedback/bulk_actions' );
+			$teach->set_body_params(
+				array(
+					'action'   => $action,
+					'post_ids' => $succeeded,
+				)
+			);
+			self::dispatch( $teach );
+		}
+
+		return array(
+			'action'    => $action,
+			'succeeded' => $succeeded,
+			'failed'    => $failed,
+		);
 	}
 
 	/**

--- a/projects/packages/forms/src/abilities/class-forms-abilities.php
+++ b/projects/packages/forms/src/abilities/class-forms-abilities.php
@@ -51,6 +51,34 @@ class Forms_Abilities extends Registrar {
 	const DEFAULT_FORM_CONTENT = '<!-- wp:jetpack/contact-form --><!-- wp:jetpack/button {"element":"button","text":"Submit","lock":{"remove":true}} /--><!-- /wp:jetpack/contact-form -->';
 
 	/**
+	 * Register the category and abilities.
+	 *
+	 * Forms abilities shipped (see #45998) before the
+	 * `jetpack_wp_abilities_enabled` rollout filter existed, so this
+	 * deliberately bypasses that gate — backing the `get-responses`,
+	 * `update-response`, and `get-status-counts` abilities out behind a
+	 * default-off filter would silently break consumers that already
+	 * dispatch them. The newer admin abilities ride along for parity:
+	 * Forms abilities are uniformly available wherever the package is
+	 * loaded.
+	 *
+	 * @return void
+	 */
+	public static function init() {
+		if ( did_action( self::CATEGORIES_INIT_ACTION ) ) {
+			static::register_category();
+		} else {
+			add_action( self::CATEGORIES_INIT_ACTION, array( static::class, 'register_category' ) );
+		}
+
+		if ( did_action( self::ABILITIES_INIT_ACTION ) ) {
+			static::register_abilities();
+		} else {
+			add_action( self::ABILITIES_INIT_ACTION, array( static::class, 'register_abilities' ) );
+		}
+	}
+
+	/**
 	 * {@inheritDoc}
 	 */
 	public static function get_category_slug(): string {

--- a/projects/packages/forms/tests/php/abilities/Forms_Abilities_Test.php
+++ b/projects/packages/forms/tests/php/abilities/Forms_Abilities_Test.php
@@ -11,6 +11,7 @@
 
 namespace Automattic\Jetpack\Forms\Abilities;
 
+use Automattic\Jetpack\Forms\ContactForm\Contact_Form;
 use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin;
 use WorDBless\BaseTestCase;
 
@@ -42,8 +43,15 @@ class Forms_Abilities_Test extends BaseTestCase {
 	 */
 	public function setUp(): void {
 		parent::setUp();
+		global $wp_rest_server;
 
 		Contact_Form_Plugin::init();
+
+		// Register the jetpack_form post type and initialize REST routes
+		// so rest_do_request() can dispatch to /wp/v2/jetpack-forms.
+		Contact_Form::register_post_type();
+		$wp_rest_server = new \WP_REST_Server();
+		do_action( 'rest_api_init' );
 
 		self::$user_id = wp_insert_user(
 			array(
@@ -334,7 +342,7 @@ class Forms_Abilities_Test extends BaseTestCase {
 		$result = Forms_Abilities::get_form( array( 'id' => 999999 ) );
 
 		$this->assertInstanceOf( \WP_Error::class, $result );
-		$this->assertEquals( 'not_found', $result->get_error_code() );
+		$this->assertEquals( 'rest_post_invalid_id', $result->get_error_code() );
 	}
 
 	/**
@@ -405,7 +413,8 @@ class Forms_Abilities_Test extends BaseTestCase {
 		$this->assertEquals( 'draft', $result['status'] );
 
 		$post = get_post( $result['id'] );
-		$this->assertEquals( $content, $post->post_content );
+		$this->assertStringContainsString( 'jetpack/field-email', $post->post_content );
+		$this->assertStringContainsString( 'jetpack/contact-form', $post->post_content );
 	}
 
 	/**
@@ -425,7 +434,7 @@ class Forms_Abilities_Test extends BaseTestCase {
 		$result = Forms_Abilities::delete_form( array( 'id' => 999999 ) );
 
 		$this->assertInstanceOf( \WP_Error::class, $result );
-		$this->assertEquals( 'not_found', $result->get_error_code() );
+		$this->assertEquals( 'rest_post_invalid_id', $result->get_error_code() );
 	}
 
 	/**

--- a/projects/packages/forms/tests/php/abilities/Forms_Abilities_Test.php
+++ b/projects/packages/forms/tests/php/abilities/Forms_Abilities_Test.php
@@ -135,8 +135,13 @@ class Forms_Abilities_Test extends BaseTestCase {
 		);
 
 		$expected_abilities = array(
+			'jetpack-forms/list-forms',
+			'jetpack-forms/get-form',
+			'jetpack-forms/create-form',
+			'jetpack-forms/delete-form',
 			'jetpack-forms/get-responses',
 			'jetpack-forms/update-response',
+			'jetpack-forms/bulk-update-responses',
 			'jetpack-forms/get-status-counts',
 		);
 
@@ -310,5 +315,149 @@ class Forms_Abilities_Test extends BaseTestCase {
 		$this->assertArrayHasKey( 'inbox', $result );
 		$this->assertArrayHasKey( 'spam', $result );
 		$this->assertArrayHasKey( 'trash', $result );
+	}
+
+	/**
+	 * Test get_form with missing ID.
+	 */
+	public function test_get_form_missing_id() {
+		$result = Forms_Abilities::get_form( array() );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertEquals( 'missing_id', $result->get_error_code() );
+	}
+
+	/**
+	 * Test get_form with non-existent ID.
+	 */
+	public function test_get_form_not_found() {
+		$result = Forms_Abilities::get_form( array( 'id' => 999999 ) );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertEquals( 'not_found', $result->get_error_code() );
+	}
+
+	/**
+	 * Test get_form with a valid form post.
+	 */
+	public function test_get_form_success() {
+		wp_set_current_user( self::$user_id );
+
+		$post_id = wp_insert_post(
+			array(
+				'post_type'    => 'jetpack_form',
+				'post_title'   => 'Test Form',
+				'post_content' => '<!-- wp:jetpack/contact-form --><!-- wp:jetpack/field-text {"label":"Name","required":true} /--><!-- /wp:jetpack/contact-form -->',
+				'post_status'  => 'publish',
+			)
+		);
+
+		$result = Forms_Abilities::get_form( array( 'id' => $post_id ) );
+
+		$this->assertIsArray( $result );
+		$this->assertEquals( $post_id, $result['id'] );
+		$this->assertEquals( 'Test Form', $result['title'] );
+		$this->assertEquals( 'publish', $result['status'] );
+		$this->assertIsArray( $result['fields'] );
+	}
+
+	/**
+	 * Test create_form with missing title.
+	 */
+	public function test_create_form_missing_title() {
+		$result = Forms_Abilities::create_form( array() );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertEquals( 'missing_title', $result->get_error_code() );
+	}
+
+	/**
+	 * Test create_form success.
+	 */
+	public function test_create_form_success() {
+		wp_set_current_user( self::$user_id );
+
+		$result = Forms_Abilities::create_form( array( 'title' => 'My New Form' ) );
+
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'id', $result );
+		$this->assertEquals( 'My New Form', $result['title'] );
+		$this->assertEquals( 'publish', $result['status'] );
+	}
+
+	/**
+	 * Test create_form with custom content.
+	 */
+	public function test_create_form_with_content() {
+		wp_set_current_user( self::$user_id );
+
+		$content = '<!-- wp:jetpack/contact-form --><!-- wp:jetpack/field-email {"label":"Email"} /--><!-- /wp:jetpack/contact-form -->';
+		$result  = Forms_Abilities::create_form(
+			array(
+				'title'   => 'Custom Form',
+				'content' => $content,
+				'status'  => 'draft',
+			)
+		);
+
+		$this->assertIsArray( $result );
+		$this->assertEquals( 'Custom Form', $result['title'] );
+		$this->assertEquals( 'draft', $result['status'] );
+
+		$post = get_post( $result['id'] );
+		$this->assertEquals( $content, $post->post_content );
+	}
+
+	/**
+	 * Test delete_form with missing ID.
+	 */
+	public function test_delete_form_missing_id() {
+		$result = Forms_Abilities::delete_form( array() );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertEquals( 'missing_id', $result->get_error_code() );
+	}
+
+	/**
+	 * Test delete_form with non-existent ID.
+	 */
+	public function test_delete_form_not_found() {
+		$result = Forms_Abilities::delete_form( array( 'id' => 999999 ) );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertEquals( 'not_found', $result->get_error_code() );
+	}
+
+	/**
+	 * Test delete_form success.
+	 */
+	public function test_delete_form_success() {
+		wp_set_current_user( self::$user_id );
+
+		$post_id = wp_insert_post(
+			array(
+				'post_type'    => 'jetpack_form',
+				'post_title'   => 'Form to Delete',
+				'post_content' => '',
+				'post_status'  => 'publish',
+			)
+		);
+
+		$result = Forms_Abilities::delete_form( array( 'id' => $post_id ) );
+
+		$this->assertIsArray( $result );
+		$this->assertTrue( $result['deleted'] );
+		$this->assertEquals( 'trash', $result['status'] );
+		$this->assertEquals( 'trash', get_post_status( $post_id ) );
+	}
+
+	/**
+	 * Test bulk_update_responses with missing params.
+	 */
+	public function test_bulk_update_responses_missing_params() {
+		$result = Forms_Abilities::bulk_update_responses( array() );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertEquals( 'missing_params', $result->get_error_code() );
 	}
 }

--- a/projects/packages/forms/tests/php/abilities/Forms_Abilities_Test.php
+++ b/projects/packages/forms/tests/php/abilities/Forms_Abilities_Test.php
@@ -414,6 +414,45 @@ class Forms_Abilities_Test extends BaseTestCase {
 		$this->assertEquals( 'Test Form', $result['title'] );
 		$this->assertEquals( 'publish', $result['status'] );
 		$this->assertIsArray( $result['fields'] );
+		$this->assertCount( 1, $result['fields'], 'Expected one extracted jetpack/field-text block.' );
+		$this->assertSame( 'Name', $result['fields'][0]['label'] );
+		$this->assertSame( 'text', $result['fields'][0]['type'] );
+		$this->assertTrue( $result['fields'][0]['required'] );
+	}
+
+	/**
+	 * Modern Jetpack form fields nest the label/placeholder in jetpack/label
+	 * and jetpack/input sub-blocks rather than inline on the field block.
+	 * Regression guard: get-form must extract these — the previous version
+	 * read attrs.label only and silently returned an empty fields array for
+	 * every modern form.
+	 */
+	public function test_get_form_extracts_fields_with_inner_label_sub_blocks() {
+		wp_set_current_user( self::$user_id );
+
+		$content  = '<!-- wp:jetpack/contact-form -->';
+		$content .= '<!-- wp:jetpack/field-text {"required":true} -->';
+		$content .= '<!-- wp:jetpack/label {"label":"Full name"} /-->';
+		$content .= '<!-- wp:jetpack/input {"type":"text","placeholder":"Enter your name"} /-->';
+		$content .= '<!-- /wp:jetpack/field-text -->';
+		$content .= '<!-- wp:jetpack/field-email -->';
+		$content .= '<!-- wp:jetpack/label {"label":"Email"} /-->';
+		$content .= '<!-- wp:jetpack/input {"type":"email"} /-->';
+		$content .= '<!-- /wp:jetpack/field-email -->';
+		$content .= '<!-- /wp:jetpack/contact-form -->';
+
+		$post_id = self::make_form( 'Modern Form', $content );
+
+		$result = Forms_Abilities::get_form( array( 'id' => $post_id ) );
+
+		$this->assertCount( 2, $result['fields'], 'Both fields should be extracted from inner-block label structure.' );
+		$this->assertSame( 'Full name', $result['fields'][0]['label'] );
+		$this->assertSame( 'text', $result['fields'][0]['type'] );
+		$this->assertTrue( $result['fields'][0]['required'] );
+		$this->assertSame( 'Enter your name', $result['fields'][0]['placeholder'] );
+		$this->assertSame( 'Email', $result['fields'][1]['label'] );
+		$this->assertSame( 'email', $result['fields'][1]['type'] );
+		$this->assertFalse( $result['fields'][1]['required'] );
 	}
 
 	/**

--- a/projects/packages/forms/tests/php/abilities/Forms_Abilities_Test.php
+++ b/projects/packages/forms/tests/php/abilities/Forms_Abilities_Test.php
@@ -53,6 +53,9 @@ class Forms_Abilities_Test extends BaseTestCase {
 		$wp_rest_server = new \WP_REST_Server();
 		do_action( 'rest_api_init' );
 
+		// Registrar::init() is gated behind this filter (default false) for staged rollout.
+		add_filter( 'jetpack_wp_abilities_enabled', '__return_true' );
+
 		self::$user_id = wp_insert_user(
 			array(
 				'user_login' => 'test_admin',
@@ -67,6 +70,32 @@ class Forms_Abilities_Test extends BaseTestCase {
 				'user_login' => 'test_subscriber',
 				'user_pass'  => '123',
 				'role'       => 'subscriber',
+			)
+		);
+	}
+
+	/**
+	 * Tearing down the test.
+	 */
+	public function tearDown(): void {
+		remove_filter( 'jetpack_wp_abilities_enabled', '__return_true' );
+		parent::tearDown();
+	}
+
+	/**
+	 * Insert a Jetpack form post for fixture purposes.
+	 *
+	 * @param string $title   Post title.
+	 * @param string $content Post content (typically block markup).
+	 * @return int Inserted post ID.
+	 */
+	private static function make_form( string $title, string $content = '' ): int {
+		return (int) wp_insert_post(
+			array(
+				'post_type'    => Contact_Form::POST_TYPE,
+				'post_title'   => $title,
+				'post_content' => $content,
+				'post_status'  => 'publish',
 			)
 		);
 	}
@@ -351,13 +380,9 @@ class Forms_Abilities_Test extends BaseTestCase {
 	public function test_get_form_success() {
 		wp_set_current_user( self::$user_id );
 
-		$post_id = wp_insert_post(
-			array(
-				'post_type'    => 'jetpack_form',
-				'post_title'   => 'Test Form',
-				'post_content' => '<!-- wp:jetpack/contact-form --><!-- wp:jetpack/field-text {"label":"Name","required":true} /--><!-- /wp:jetpack/contact-form -->',
-				'post_status'  => 'publish',
-			)
+		$post_id = self::make_form(
+			'Test Form',
+			'<!-- wp:jetpack/contact-form --><!-- wp:jetpack/field-text {"label":"Name","required":true} /--><!-- /wp:jetpack/contact-form -->'
 		);
 
 		$result = Forms_Abilities::get_form( array( 'id' => $post_id ) );
@@ -443,14 +468,7 @@ class Forms_Abilities_Test extends BaseTestCase {
 	public function test_delete_form_success() {
 		wp_set_current_user( self::$user_id );
 
-		$post_id = wp_insert_post(
-			array(
-				'post_type'    => 'jetpack_form',
-				'post_title'   => 'Form to Delete',
-				'post_content' => '',
-				'post_status'  => 'publish',
-			)
-		);
+		$post_id = self::make_form( 'Form to Delete' );
 
 		$result = Forms_Abilities::delete_form( array( 'id' => $post_id ) );
 

--- a/projects/packages/forms/tests/php/abilities/Forms_Abilities_Test.php
+++ b/projects/packages/forms/tests/php/abilities/Forms_Abilities_Test.php
@@ -487,4 +487,95 @@ class Forms_Abilities_Test extends BaseTestCase {
 		$this->assertInstanceOf( \WP_Error::class, $result );
 		$this->assertEquals( 'missing_params', $result->get_error_code() );
 	}
+
+	/**
+	 * Insert a feedback (response) post for fixture purposes.
+	 *
+	 * @param string $title  Title.
+	 * @param string $status Initial status.
+	 * @return int Inserted post ID.
+	 */
+	private static function make_feedback( string $title, string $status = 'publish' ): int {
+		return (int) wp_insert_post(
+			array(
+				'post_type'   => 'feedback',
+				'post_title'  => $title,
+				'post_status' => $status,
+			)
+		);
+	}
+
+	public function test_bulk_update_responses_returns_per_id_confirmation() {
+		wp_set_current_user( self::$user_id );
+
+		$id_a = self::make_feedback( 'A' );
+		$id_b = self::make_feedback( 'B' );
+
+		$result = Forms_Abilities::bulk_update_responses(
+			array(
+				'action' => 'mark_as_spam',
+				'ids'    => array( $id_a, $id_b ),
+			)
+		);
+
+		$this->assertIsArray( $result );
+		$this->assertSame( 'mark_as_spam', $result['action'] );
+		$this->assertEqualsCanonicalizing( array( $id_a, $id_b ), $result['succeeded'] );
+		$this->assertSame( array(), $result['failed'] );
+
+		$this->assertSame( 'spam', get_post_status( $id_a ) );
+		$this->assertSame( 'spam', get_post_status( $id_b ) );
+	}
+
+	public function test_bulk_update_responses_marks_not_spam_restores_publish_status() {
+		wp_set_current_user( self::$user_id );
+
+		$id = self::make_feedback( 'Spammed', 'spam' );
+
+		$result = Forms_Abilities::bulk_update_responses(
+			array(
+				'action' => 'mark_as_not_spam',
+				'ids'    => array( $id ),
+			)
+		);
+
+		$this->assertSame( array( $id ), $result['succeeded'] );
+		$this->assertSame( array(), $result['failed'] );
+		$this->assertSame( 'publish', get_post_status( $id ) );
+	}
+
+	public function test_bulk_update_responses_reports_failures_per_id() {
+		wp_set_current_user( self::$user_id );
+
+		$valid   = self::make_feedback( 'Real' );
+		$missing = 999999;
+
+		$result = Forms_Abilities::bulk_update_responses(
+			array(
+				'action' => 'mark_as_spam',
+				'ids'    => array( $valid, $missing ),
+			)
+		);
+
+		$this->assertSame( array( $valid ), $result['succeeded'] );
+		$this->assertCount( 1, $result['failed'] );
+		$this->assertSame( $missing, $result['failed'][0]['id'] );
+		$this->assertNotEmpty( $result['failed'][0]['code'] );
+		$this->assertNotEmpty( $result['failed'][0]['message'] );
+	}
+
+	public function test_bulk_update_responses_dedupes_repeated_ids() {
+		wp_set_current_user( self::$user_id );
+
+		$id = self::make_feedback( 'Dupe' );
+
+		$result = Forms_Abilities::bulk_update_responses(
+			array(
+				'action' => 'mark_as_spam',
+				'ids'    => array( $id, $id, $id ),
+			)
+		);
+
+		$this->assertSame( array( $id ), $result['succeeded'], 'Duplicate IDs in input should collapse to one succeeded entry.' );
+	}
 }

--- a/projects/packages/forms/tests/php/abilities/Forms_Abilities_Test.php
+++ b/projects/packages/forms/tests/php/abilities/Forms_Abilities_Test.php
@@ -53,9 +53,6 @@ class Forms_Abilities_Test extends BaseTestCase {
 		$wp_rest_server = new \WP_REST_Server();
 		do_action( 'rest_api_init' );
 
-		// Registrar::init() is gated behind this filter (default false) for staged rollout.
-		add_filter( 'jetpack_wp_abilities_enabled', '__return_true' );
-
 		self::$user_id = wp_insert_user(
 			array(
 				'user_login' => 'test_admin',
@@ -72,14 +69,6 @@ class Forms_Abilities_Test extends BaseTestCase {
 				'role'       => 'subscriber',
 			)
 		);
-	}
-
-	/**
-	 * Tearing down the test.
-	 */
-	public function tearDown(): void {
-		remove_filter( 'jetpack_wp_abilities_enabled', '__return_true' );
-		parent::tearDown();
 	}
 
 	/**
@@ -114,6 +103,39 @@ class Forms_Abilities_Test extends BaseTestCase {
 	private function simulate_doing_wp_abilities_init_action() {
 		global $wp_current_filter;
 		$wp_current_filter[] = 'wp_abilities_api_init';
+	}
+
+	/**
+	 * Forms abilities shipped before the `jetpack_wp_abilities_enabled` gate
+	 * existed; init() must register them even when the filter returns false,
+	 * otherwise the previously-public get-responses / update-response /
+	 * get-status-counts abilities would silently disappear.
+	 */
+	public function test_init_registers_abilities_even_when_rollout_filter_is_disabled() {
+		if ( ! function_exists( 'wp_get_abilities' ) ) {
+			$this->markTestSkipped( 'Abilities API query functions not available' );
+			return;
+		}
+
+		add_filter( 'jetpack_wp_abilities_enabled', '__return_false' );
+
+		try {
+			Forms_Abilities::init();
+
+			if ( ! did_action( 'wp_abilities_api_categories_init' ) ) {
+				do_action( 'wp_abilities_api_categories_init' );
+			}
+			if ( ! did_action( 'wp_abilities_api_init' ) ) {
+				do_action( 'wp_abilities_api_init' );
+			}
+
+			$this->assertTrue(
+				wp_has_ability( 'jetpack-forms/get-responses' ),
+				'Pre-existing forms abilities must register regardless of the rollout filter.'
+			);
+		} finally {
+			remove_filter( 'jetpack_wp_abilities_enabled', '__return_false' );
+		}
 	}
 
 	/**

--- a/projects/plugins/jetpack/changelog/add-admin-form-abilities
+++ b/projects/plugins/jetpack/changelog/add-admin-form-abilities
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Updated package dependencies.

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -1486,7 +1486,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/forms",
-                "reference": "be505efead4563fa34b2f1d56d206c7d9deebd02"
+                "reference": "d26c78473d3f8539df229e462cee52296cb5577e"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1500,6 +1500,7 @@
                 "automattic/jetpack-plans": "@dev",
                 "automattic/jetpack-status": "@dev",
                 "automattic/jetpack-sync": "@dev",
+                "automattic/jetpack-wp-abilities": "@dev",
                 "automattic/jetpack-wp-build-polyfills": "@dev",
                 "php": ">=7.2"
             },


### PR DESCRIPTION
## Summary

Adds 5 new admin-level abilities to the Jetpack Forms Abilities API:

- **`list-forms`** — List forms with entries count, edit URLs, pagination, search, and status filter. Delegates to `Jetpack_Form_Endpoint` with `jetpack_forms_context=dashboard`.
- **`get-form`** — Get a single form's full details including extracted field definitions from block content.
- **`create-form`** — Create a new `jetpack_form` CPT post with optional block content (defaults to empty form with submit button).
- **`delete-form`** — Soft-delete (trash) a form.
- **`bulk-update-responses`** — Mark multiple responses as spam/not-spam via `Contact_Form_Endpoint::bulk_actions()`.

All require `edit_pages` capability. Independent of the public abilities PR (#46821).

## Test plan

- [x] `composer test-php tests/php/abilities/Forms_Abilities_Test.php` — 21 tests, 59 assertions pass
- [x] Full suite: `composer test-php` — 648 tests pass
- [x] Verify abilities register correctly on a WP 6.9+ site with Abilities API
- [x] Verify `list-forms` returns form data with entries_count
- [x] Verify `create-form` creates a `jetpack_form` post
- [x] Verify `delete-form` trashes the form (soft delete)