### PR TITLE
Forms: Add rename action to dashboard

### DIFF
--- a/projects/packages/forms/changelog/forms-dashboard-rename-action
+++ b/projects/packages/forms/changelog/forms-dashboard-rename-action
@@ -1,4 +1,4 @@
 Significance: patch
 Type: added
 
-Dashboard: add rename action to forms list.
+Dashboard: Add rename action to forms list.

--- a/projects/packages/forms/changelog/forms-dashboard-rename-action
+++ b/projects/packages/forms/changelog/forms-dashboard-rename-action
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Dashboard: add rename action to forms list.

--- a/projects/packages/forms/routes/forms/stage.tsx
+++ b/projects/packages/forms/routes/forms/stage.tsx
@@ -446,6 +446,19 @@ function StageInner() {
 				},
 			} );
 		}
+		actionsList.push( {
+			id: 'rename-form',
+			isPrimary: false,
+			label: __( 'Rename', 'jetpack-forms' ),
+			supportsBulk: false,
+			callback( items: FormListItem[] ) {
+				const [ item ] = items;
+				if ( ! item ) {
+					return;
+				}
+				openRenameModal( item );
+			},
+		} );
 
 		actionsList.push( {
 			id: 'trash-form',

--- a/projects/packages/forms/routes/forms/stage.tsx
+++ b/projects/packages/forms/routes/forms/stage.tsx
@@ -6,7 +6,10 @@ import {
 	__experimentalConfirmDialog as ConfirmDialog, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 	Button,
 	__experimentalHStack as HStack, // eslint-disable-line @wordpress/no-unsafe-wp-apis
+	Modal,
+	TextControl,
 } from '@wordpress/components';
+import { store as coreStore } from '@wordpress/core-data';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { DataViews } from '@wordpress/dataviews';
 import { dateI18n, getSettings as getDateSettings } from '@wordpress/date';
@@ -137,6 +140,15 @@ function StageInner() {
 	const [ selection, setSelection ] = useState< string[] >( [] );
 	const [ pendingPermanentDeleteCount, setPendingPermanentDeleteCount ] = useState( 0 );
 
+	// Rename modal state
+	const [ isRenameModalOpen, setIsRenameModalOpen ] = useState( false );
+	const [ renameFormItem, setRenameFormItem ] = useState< FormListItem | null >( null );
+	const [ renameTitle, setRenameTitle ] = useState( '' );
+	const [ isRenaming, setIsRenaming ] = useState( false );
+
+	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
+	const { editEntityRecord, saveEditedEntityRecord } = useDispatch( coreStore );
+
 	// Selection is local state. Clear it whenever the view changes (page/perPage/search/filters).
 	useEffect( () => {
 		setSelection( [] );
@@ -163,6 +175,65 @@ function StageInner() {
 			setSelection( [] );
 		}
 	}, [ confirmPermanentDelete ] );
+
+	const openRenameModal = useCallback( ( item: FormListItem ) => {
+		setRenameFormItem( item );
+		setRenameTitle( item.title || '' );
+		setIsRenameModalOpen( true );
+	}, [] );
+
+	const closeRenameModal = useCallback( () => {
+		setIsRenameModalOpen( false );
+		setRenameFormItem( null );
+		setRenameTitle( '' );
+	}, [] );
+
+	const handleRename = useCallback( async () => {
+		if ( ! renameFormItem || isRenaming ) {
+			return;
+		}
+
+		setIsRenaming( true );
+		const newTitle = renameTitle.trim() || __( 'Untitled Form', 'jetpack-forms' );
+
+		try {
+			await editEntityRecord( 'postType', 'jetpack_form', renameFormItem.id, {
+				title: newTitle,
+			} );
+			await saveEditedEntityRecord( 'postType', 'jetpack_form', renameFormItem.id );
+
+			createSuccessNotice( __( 'Form renamed.', 'jetpack-forms' ), { type: 'snackbar' } );
+		} catch ( error ) {
+			createErrorNotice( __( 'Failed to rename form. Please try again.', 'jetpack-forms' ), {
+				type: 'snackbar',
+			} );
+			// eslint-disable-next-line no-console
+			console.error( 'Failed to rename form:', error );
+		} finally {
+			setIsRenaming( false );
+			closeRenameModal();
+		}
+	}, [
+		renameFormItem,
+		renameTitle,
+		isRenaming,
+		editEntityRecord,
+		saveEditedEntityRecord,
+		createSuccessNotice,
+		createErrorNotice,
+		closeRenameModal,
+	] );
+
+	const onRenameFormSubmit = useCallback(
+		( event: React.FormEvent ) => {
+			event.preventDefault();
+			if ( isRenaming ) {
+				return;
+			}
+			handleRename();
+		},
+		[ handleRename, isRenaming ]
+	);
 
 	const statusLabel = useCallback( ( status: string ) => {
 		switch ( status ) {
@@ -519,6 +590,42 @@ function StageInner() {
 				<DataViews.Layout />
 				<DataViews.Footer />
 			</DataViews>
+			{ isRenameModalOpen && (
+				<Modal
+					title={ __( 'Rename Form', 'jetpack-forms' ) }
+					onRequestClose={ closeRenameModal }
+					size="medium"
+				>
+					<form onSubmit={ onRenameFormSubmit }>
+						<TextControl
+							label={ __( 'Name', 'jetpack-forms' ) }
+							value={ renameTitle }
+							onChange={ setRenameTitle }
+							__next40pxDefaultSize
+						/>
+						<div
+							style={ {
+								display: 'flex',
+								justifyContent: 'flex-end',
+								gap: '8px',
+								marginTop: '16px',
+							} }
+						>
+							<Button variant="tertiary" onClick={ closeRenameModal }>
+								{ __( 'Cancel', 'jetpack-forms' ) }
+							</Button>
+							<Button
+								aria-disabled={ isRenaming }
+								isBusy={ isRenaming }
+								variant="primary"
+								type="submit"
+							>
+								{ __( 'Save', 'jetpack-forms' ) }
+							</Button>
+						</div>
+					</form>
+				</Modal>
+			) }
 			<IntegrationsModal
 				isOpen={ isIntegrationsModalOpen }
 				onClose={ closeIntegrationsModal }

--- a/projects/packages/forms/routes/forms/stage.tsx
+++ b/projects/packages/forms/routes/forms/stage.tsx
@@ -213,7 +213,13 @@ function StageInner() {
 					view.search ?? '',
 					statusQuery
 				);
+				const minimalQuery = {
+					...query,
+					per_page: 1,
+					_fields: 'id',
+				};
 				invalidateResolution( 'getEntityRecords', [ 'postType', FORM_POST_TYPE, query ] );
+				invalidateResolution( 'getEntityRecords', [ 'postType', FORM_POST_TYPE, minimalQuery ] );
 
 				createSuccessNotice( __( 'Form renamed.', 'jetpack-forms' ), { type: 'snackbar' } );
 				renameRetryRef.current = null;

--- a/projects/packages/forms/routes/forms/stage.tsx
+++ b/projects/packages/forms/routes/forms/stage.tsx
@@ -63,8 +63,10 @@ const defaultLayouts = {
 	list: {},
 };
 
+type InvalidateResolutionArgs = [ kind: string, name: string, query?: Record< string, unknown > ];
+
 type CoreStore = typeof coreStore & {
-	invalidateResolution: ( selector: string, args: unknown[] ) => void;
+	invalidateResolution: ( selector: string, args: InvalidateResolutionArgs ) => void;
 };
 
 /**

--- a/projects/packages/forms/routes/forms/stage.tsx
+++ b/projects/packages/forms/routes/forms/stage.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { Page } from '@wordpress/admin-ui';
+import apiFetch from '@wordpress/api-fetch';
 import {
 	__experimentalConfirmDialog as ConfirmDialog, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 	Button,
@@ -13,7 +14,7 @@ import { store as coreStore } from '@wordpress/core-data';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { DataViews } from '@wordpress/dataviews';
 import { dateI18n, getSettings as getDateSettings } from '@wordpress/date';
-import { useEffect, useMemo, useState, useCallback } from '@wordpress/element';
+import { useEffect, useMemo, useState, useCallback, useRef } from '@wordpress/element';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { useSearch, useNavigate } from '@wordpress/route';
 import * as React from 'react';
@@ -24,6 +25,7 @@ import IntegrationsModal from '../../src/blocks/contact-form/components/jetpack-
 import { FORM_POST_TYPE } from '../../src/blocks/shared/util/constants.js';
 import CreateFormButton from '../../src/dashboard/components/create-form-button/index.tsx';
 import { EmptyWrapper } from '../../src/dashboard/components/empty-responses/index.tsx';
+import { FormNameModal } from '../../src/dashboard/components/form-name-modal';
 import { NON_TRASH_FORM_STATUSES } from '../../src/dashboard/constants';
 import useDeleteForm from '../../src/dashboard/hooks/use-delete-form.ts';
 import useFormsData, { getFormsListQuery } from '../../src/dashboard/hooks/use-forms-data.ts';
@@ -146,10 +148,8 @@ function StageInner() {
 	const [ pendingPermanentDeleteCount, setPendingPermanentDeleteCount ] = useState( 0 );
 
 	// Rename modal state
-	const [ isRenameModalOpen, setIsRenameModalOpen ] = useState( false );
 	const [ renameFormItem, setRenameFormItem ] = useState< FormListItem | null >( null );
-	const [ renameTitle, setRenameTitle ] = useState( '' );
-	const [ isRenaming, setIsRenaming ] = useState( false );
+	const renameRetryRef = useRef< { item: FormListItem; title: string } | null >( null );
 
 	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
 	const { invalidateResolution } = useDispatch( coreStore ) as unknown as CoreStore;
@@ -183,74 +183,69 @@ function StageInner() {
 
 	const openRenameModal = useCallback( ( item: FormListItem ) => {
 		setRenameFormItem( item );
-		setRenameTitle( item.title || '' );
-		setIsRenameModalOpen( true );
 	}, [] );
 
 	const closeRenameModal = useCallback( () => {
-		setIsRenameModalOpen( false );
 		setRenameFormItem( null );
-		setRenameTitle( '' );
+		renameRetryRef.current = null;
 	}, [] );
 
-	const handleRename = useCallback( async () => {
-		if ( ! renameFormItem || isRenaming ) {
-			return;
-		}
-
-		setIsRenaming( true );
-		const newTitle = renameTitle.trim() || __( 'Untitled Form', 'jetpack-forms' );
-
-		try {
-			await apiFetch( {
-				path: `/wp/v2/jetpack-forms/${ renameFormItem.id }`,
-				method: 'POST',
-				data: { title: newTitle },
-			} );
-
-			// Invalidate the forms list cache to refresh the data
-			const query = getFormsListQuery(
-				view.page ?? 1,
-				view.perPage ?? 20,
-				view.search ?? '',
-				statusQuery
-			);
-			invalidateResolution( 'getEntityRecords', [ 'postType', FORM_POST_TYPE, query ] );
-
-			createSuccessNotice( __( 'Form renamed.', 'jetpack-forms' ), { type: 'snackbar' } );
-		} catch ( error ) {
-			createErrorNotice( __( 'Failed to rename form. Please try again.', 'jetpack-forms' ), {
-				type: 'snackbar',
-			} );
-			// eslint-disable-next-line no-console
-			console.error( 'Failed to rename form:', error );
-		} finally {
-			setIsRenaming( false );
-			closeRenameModal();
-		}
-	}, [
-		renameFormItem,
-		renameTitle,
-		isRenaming,
-		view.page,
-		view.perPage,
-		view.search,
-		statusQuery,
-		invalidateResolution,
-		createSuccessNotice,
-		createErrorNotice,
-		closeRenameModal,
-	] );
-
-	const onRenameFormSubmit = useCallback(
-		( event: React.FormEvent ) => {
-			event.preventDefault();
-			if ( isRenaming ) {
+	const handleRename = useCallback(
+		async ( newTitle: string ) => {
+			if ( ! renameFormItem ) {
 				return;
 			}
-			handleRename();
+
+			try {
+				await apiFetch( {
+					path: `/wp/v2/jetpack-forms/${ renameFormItem.id }`,
+					method: 'POST',
+					data: { title: newTitle },
+				} );
+
+				// Invalidate the forms list cache to refresh the data
+				const query = getFormsListQuery(
+					view.page ?? 1,
+					view.perPage ?? 20,
+					view.search ?? '',
+					statusQuery
+				);
+				invalidateResolution( 'getEntityRecords', [ 'postType', FORM_POST_TYPE, query ] );
+
+				createSuccessNotice( __( 'Form renamed.', 'jetpack-forms' ), { type: 'snackbar' } );
+				renameRetryRef.current = null;
+			} catch ( error ) {
+				// Store retry data before the modal closes
+				const retryItem = renameFormItem;
+				const retryTitle = newTitle;
+
+				createErrorNotice( __( 'Failed to rename form.', 'jetpack-forms' ), {
+					type: 'snackbar',
+					actions: [
+						{
+							label: __( 'Retry', 'jetpack-forms' ),
+							onClick: () => {
+								renameRetryRef.current = { item: retryItem, title: retryTitle };
+								setRenameFormItem( retryItem );
+							},
+						},
+					],
+				} );
+				// eslint-disable-next-line no-console
+				console.error( 'Failed to rename form:', error );
+				throw error;
+			}
 		},
-		[ handleRename, isRenaming ]
+		[
+			renameFormItem,
+			view.page,
+			view.perPage,
+			view.search,
+			statusQuery,
+			invalidateResolution,
+			createSuccessNotice,
+			createErrorNotice,
+		]
 	);
 
 	const statusLabel = useCallback( ( status: string ) => {
@@ -621,42 +616,13 @@ function StageInner() {
 				<DataViews.Layout />
 				<DataViews.Footer />
 			</DataViews>
-			{ isRenameModalOpen && (
-				<Modal
-					title={ __( 'Rename form', 'jetpack-forms' ) }
-					onRequestClose={ closeRenameModal }
-					size="medium"
-				>
-					<form onSubmit={ onRenameFormSubmit }>
-						<TextControl
-							label={ __( 'Name', 'jetpack-forms' ) }
-							value={ renameTitle }
-							onChange={ setRenameTitle }
-							__next40pxDefaultSize
-						/>
-						<div
-							style={ {
-								display: 'flex',
-								justifyContent: 'flex-end',
-								gap: '8px',
-								marginTop: '16px',
-							} }
-						>
-							<Button variant="tertiary" onClick={ closeRenameModal }>
-								{ __( 'Cancel', 'jetpack-forms' ) }
-							</Button>
-							<Button
-								aria-disabled={ isRenaming }
-								isBusy={ isRenaming }
-								variant="primary"
-								type="submit"
-							>
-								{ __( 'Save', 'jetpack-forms' ) }
-							</Button>
-						</div>
-					</form>
-				</Modal>
-			) }
+			<FormNameModal
+				isOpen={ !! renameFormItem }
+				onClose={ closeRenameModal }
+				onSave={ handleRename }
+				title={ __( 'Rename form', 'jetpack-forms' ) }
+				initialValue={ renameRetryRef.current?.title || renameFormItem?.title || '' }
+			/>
 			<IntegrationsModal
 				isOpen={ isIntegrationsModalOpen }
 				onClose={ closeIntegrationsModal }

--- a/projects/packages/forms/routes/forms/stage.tsx
+++ b/projects/packages/forms/routes/forms/stage.tsx
@@ -16,6 +16,7 @@ import { DataViews } from '@wordpress/dataviews';
 import { dateI18n, getSettings as getDateSettings } from '@wordpress/date';
 import { useEffect, useMemo, useState, useCallback, useRef } from '@wordpress/element';
 import { __, _n, sprintf } from '@wordpress/i18n';
+import { store as noticesStore } from '@wordpress/notices';
 import { useSearch, useNavigate } from '@wordpress/route';
 import * as React from 'react';
 /**

--- a/projects/packages/forms/routes/forms/stage.tsx
+++ b/projects/packages/forms/routes/forms/stage.tsx
@@ -25,7 +25,7 @@ import CreateFormButton from '../../src/dashboard/components/create-form-button/
 import { EmptyWrapper } from '../../src/dashboard/components/empty-responses/index.tsx';
 import { NON_TRASH_FORM_STATUSES } from '../../src/dashboard/constants';
 import useDeleteForm from '../../src/dashboard/hooks/use-delete-form.ts';
-import useFormsData from '../../src/dashboard/hooks/use-forms-data.ts';
+import useFormsData, { getFormsListQuery } from '../../src/dashboard/hooks/use-forms-data.ts';
 import WpRouteDashboardSearchParamsProvider from '../../src/dashboard/router/wp-route-dashboard-search-params-provider.tsx';
 import DataViewsHeaderRow from '../../src/dashboard/wp-build/components/dataviews-header-row';
 import FormsHelpModal from '../../src/dashboard/wp-build/components/forms-help-modal';
@@ -147,7 +147,7 @@ function StageInner() {
 	const [ isRenaming, setIsRenaming ] = useState( false );
 
 	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
-	const { editEntityRecord, saveEditedEntityRecord } = useDispatch( coreStore );
+	const { invalidateResolution } = useDispatch( coreStore );
 
 	// Selection is local state. Clear it whenever the view changes (page/perPage/search/filters).
 	useEffect( () => {
@@ -197,10 +197,20 @@ function StageInner() {
 		const newTitle = renameTitle.trim() || __( 'Untitled Form', 'jetpack-forms' );
 
 		try {
-			await editEntityRecord( 'postType', 'jetpack_form', renameFormItem.id, {
-				title: newTitle,
+			await apiFetch( {
+				path: `/wp/v2/jetpack-forms/${ renameFormItem.id }`,
+				method: 'POST',
+				data: { title: newTitle },
 			} );
-			await saveEditedEntityRecord( 'postType', 'jetpack_form', renameFormItem.id );
+
+			// Invalidate the forms list cache to refresh the data
+			const query = getFormsListQuery(
+				view.page ?? 1,
+				view.perPage ?? 20,
+				view.search ?? '',
+				statusQuery
+			);
+			invalidateResolution( 'getEntityRecords', [ 'postType', 'jetpack_form', query ] );
 
 			createSuccessNotice( __( 'Form renamed.', 'jetpack-forms' ), { type: 'snackbar' } );
 		} catch ( error ) {
@@ -217,8 +227,11 @@ function StageInner() {
 		renameFormItem,
 		renameTitle,
 		isRenaming,
-		editEntityRecord,
-		saveEditedEntityRecord,
+		view.page,
+		view.perPage,
+		view.search,
+		statusQuery,
+		invalidateResolution,
 		createSuccessNotice,
 		createErrorNotice,
 		closeRenameModal,

--- a/projects/packages/forms/routes/forms/stage.tsx
+++ b/projects/packages/forms/routes/forms/stage.tsx
@@ -6,8 +6,6 @@ import {
 	__experimentalConfirmDialog as ConfirmDialog, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 	Button,
 	__experimentalHStack as HStack, // eslint-disable-line @wordpress/no-unsafe-wp-apis
-	Modal,
-	TextControl,
 } from '@wordpress/components';
 import { store as coreStore } from '@wordpress/core-data';
 import { useDispatch, useSelect } from '@wordpress/data';
@@ -463,6 +461,7 @@ function StageInner() {
 		isDeleting,
 		isViewingTrash,
 		onOpenPermanentDeleteConfirm,
+		openRenameModal,
 		openSingleFormView,
 		previewForm,
 		restoreForms,

--- a/projects/packages/forms/routes/forms/stage.tsx
+++ b/projects/packages/forms/routes/forms/stage.tsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { Page } from '@wordpress/admin-ui';
-import apiFetch from '@wordpress/api-fetch';
 import {
 	__experimentalConfirmDialog as ConfirmDialog, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 	Button,
@@ -29,7 +28,7 @@ import { EmptyWrapper } from '../../src/dashboard/components/empty-responses/ind
 import { FormNameModal } from '../../src/dashboard/components/form-name-modal';
 import { NON_TRASH_FORM_STATUSES } from '../../src/dashboard/constants';
 import useDeleteForm from '../../src/dashboard/hooks/use-delete-form.ts';
-import useFormsData, { getFormsListQuery } from '../../src/dashboard/hooks/use-forms-data.ts';
+import useFormsData from '../../src/dashboard/hooks/use-forms-data.ts';
 import WpRouteDashboardSearchParamsProvider from '../../src/dashboard/router/wp-route-dashboard-search-params-provider.tsx';
 import DataViewsHeaderRow from '../../src/dashboard/wp-build/components/dataviews-header-row';
 import FormsHelpModal from '../../src/dashboard/wp-build/components/forms-help-modal';
@@ -61,12 +60,6 @@ const DEFAULT_VIEW: View = {
 const defaultLayouts = {
 	table: {},
 	list: {},
-};
-
-type InvalidateResolutionArgs = [ kind: string, name: string, query?: Record< string, unknown > ];
-
-type CoreStore = typeof coreStore & {
-	invalidateResolution: ( selector: string, args: InvalidateResolutionArgs ) => void;
 };
 
 /**
@@ -155,7 +148,7 @@ function StageInner() {
 	const renameRetryRef = useRef< { item: FormListItem; title: string } | null >( null );
 
 	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
-	const { invalidateResolution } = useDispatch( coreStore ) as unknown as CoreStore;
+	const { saveEntityRecord } = useDispatch( coreStore );
 
 	// Selection is local state. Clear it whenever the view changes (page/perPage/search/filters).
 	useEffect( () => {
@@ -200,26 +193,14 @@ function StageInner() {
 			}
 
 			try {
-				await apiFetch( {
-					path: `/wp/v2/jetpack-forms/${ renameFormItem.id }`,
-					method: 'POST',
-					data: { title: newTitle },
+				const result = await saveEntityRecord( 'postType', FORM_POST_TYPE, {
+					id: renameFormItem.id,
+					title: newTitle,
 				} );
 
-				// Invalidate the forms list cache to refresh the data
-				const query = getFormsListQuery(
-					view.page ?? 1,
-					view.perPage ?? 20,
-					view.search ?? '',
-					statusQuery
-				);
-				const minimalQuery = {
-					...query,
-					per_page: 1,
-					_fields: 'id',
-				};
-				invalidateResolution( 'getEntityRecords', [ 'postType', FORM_POST_TYPE, query ] );
-				invalidateResolution( 'getEntityRecords', [ 'postType', FORM_POST_TYPE, minimalQuery ] );
+				if ( ! result ) {
+					throw new Error( 'Failed to save form' );
+				}
 
 				createSuccessNotice( __( 'Form renamed.', 'jetpack-forms' ), { type: 'snackbar' } );
 				renameRetryRef.current = null;
@@ -243,18 +224,11 @@ function StageInner() {
 				// eslint-disable-next-line no-console
 				console.error( 'Failed to rename form:', error );
 				throw error;
+			} finally {
+				closeRenameModal();
 			}
 		},
-		[
-			renameFormItem,
-			view.page,
-			view.perPage,
-			view.search,
-			statusQuery,
-			invalidateResolution,
-			createSuccessNotice,
-			createErrorNotice,
-		]
+		[ renameFormItem, saveEntityRecord, createSuccessNotice, createErrorNotice, closeRenameModal ]
 	);
 
 	const statusLabel = useCallback( ( status: string ) => {

--- a/projects/packages/forms/routes/forms/stage.tsx
+++ b/projects/packages/forms/routes/forms/stage.tsx
@@ -189,21 +189,22 @@ function StageInner() {
 			if ( ! renameFormItem ) {
 				return;
 			}
-
 			try {
-				const result = await saveEntityRecord( 'postType', FORM_POST_TYPE, {
-					id: renameFormItem.id,
-					title: newTitle,
-				} );
-
-				if ( ! result ) {
-					throw new Error( 'Failed to save form' );
-				}
+				await saveEntityRecord(
+					'postType',
+					FORM_POST_TYPE,
+					{
+						id: renameFormItem.id,
+						title: newTitle,
+					},
+					{ throwOnError: true }
+				);
 
 				createSuccessNotice( __( 'Form renamed.', 'jetpack-forms' ), { type: 'snackbar' } );
 				renameRetryRef.current = null;
 			} catch ( error ) {
-				// Store retry data before the modal closes
+				// Store retry data in case the user closes the modal manually.
+				// The modal stays open on error, but if they close it, they can retry via the snackbar.
 				const retryItem = renameFormItem;
 				const retryTitle = newTitle;
 
@@ -221,12 +222,9 @@ function StageInner() {
 				} );
 				// eslint-disable-next-line no-console
 				console.error( 'Failed to rename form:', error );
-				throw error;
-			} finally {
-				closeRenameModal();
 			}
 		},
-		[ renameFormItem, saveEntityRecord, createSuccessNotice, createErrorNotice, closeRenameModal ]
+		[ renameFormItem, saveEntityRecord, createSuccessNotice, createErrorNotice ]
 	);
 
 	const statusLabel = useCallback( ( status: string ) => {

--- a/projects/packages/forms/routes/forms/stage.tsx
+++ b/projects/packages/forms/routes/forms/stage.tsx
@@ -21,6 +21,7 @@ import * as React from 'react';
  * Internal dependencies
  */
 import IntegrationsModal from '../../src/blocks/contact-form/components/jetpack-integrations-modal';
+import { FORM_POST_TYPE } from '../../src/blocks/shared/util/constants.js';
 import CreateFormButton from '../../src/dashboard/components/create-form-button/index.tsx';
 import { EmptyWrapper } from '../../src/dashboard/components/empty-responses/index.tsx';
 import { NON_TRASH_FORM_STATUSES } from '../../src/dashboard/constants';
@@ -57,6 +58,10 @@ const DEFAULT_VIEW: View = {
 const defaultLayouts = {
 	table: {},
 	list: {},
+};
+
+type CoreStore = typeof coreStore & {
+	invalidateResolution: ( selector: string, args: unknown[] ) => void;
 };
 
 /**
@@ -147,7 +152,7 @@ function StageInner() {
 	const [ isRenaming, setIsRenaming ] = useState( false );
 
 	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
-	const { invalidateResolution } = useDispatch( coreStore );
+	const { invalidateResolution } = useDispatch( coreStore ) as unknown as CoreStore;
 
 	// Selection is local state. Clear it whenever the view changes (page/perPage/search/filters).
 	useEffect( () => {
@@ -210,7 +215,7 @@ function StageInner() {
 				view.search ?? '',
 				statusQuery
 			);
-			invalidateResolution( 'getEntityRecords', [ 'postType', 'jetpack_form', query ] );
+			invalidateResolution( 'getEntityRecords', [ 'postType', FORM_POST_TYPE, query ] );
 
 			createSuccessNotice( __( 'Form renamed.', 'jetpack-forms' ), { type: 'snackbar' } );
 		} catch ( error ) {
@@ -605,7 +610,7 @@ function StageInner() {
 			</DataViews>
 			{ isRenameModalOpen && (
 				<Modal
-					title={ __( 'Rename Form', 'jetpack-forms' ) }
+					title={ __( 'Rename form', 'jetpack-forms' ) }
 					onRequestClose={ closeRenameModal }
 					size="medium"
 				>

--- a/projects/packages/forms/src/dashboard/components/form-name-modal/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/form-name-modal/index.tsx
@@ -1,0 +1,170 @@
+/**
+ * Form Name Modal Component
+ *
+ * A reusable modal for entering or editing a form name.
+ * Used for both creating new forms and renaming existing ones.
+ */
+
+import { Button, Modal, TextControl } from '@wordpress/components';
+import { useState, useCallback, useEffect } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import './style.scss';
+
+export type FormNameModalProps = {
+	/**
+	 * Whether the modal is open.
+	 */
+	isOpen: boolean;
+
+	/**
+	 * Callback when the modal is closed (via cancel/skip or after save).
+	 */
+	onClose: () => void;
+
+	/**
+	 * Async callback when the user confirms.
+	 * Receives the trimmed name (or fallback if empty).
+	 * Should throw on error to prevent modal from closing.
+	 */
+	onSave: ( name: string ) => Promise< void >;
+
+	/**
+	 * The modal title.
+	 */
+	title: string;
+
+	/**
+	 * Initial value for the text input.
+	 */
+	initialValue?: string;
+
+	/**
+	 * Label for the primary (confirm) button.
+	 * @default "Save"
+	 */
+	primaryButtonLabel?: string;
+
+	/**
+	 * Label for the secondary (cancel/skip) button.
+	 * @default "Cancel"
+	 */
+	secondaryButtonLabel?: string;
+
+	/**
+	 * Placeholder text for the input field.
+	 */
+	placeholder?: string;
+
+	/**
+	 * Label for the input field.
+	 * @default "Name"
+	 */
+	inputLabel?: string;
+
+	/**
+	 * Fallback name to use when the input is empty.
+	 * @default "Untitled Form"
+	 */
+	fallbackName?: string;
+};
+
+/**
+ * A reusable modal component for entering or editing a form name.
+ *
+ * @param props                      - Component props.
+ * @param props.isOpen               - Whether the modal is open.
+ * @param props.onClose              - Callback when the modal is closed.
+ * @param props.onSave               - Async callback when the user confirms.
+ * @param props.title                - The modal title.
+ * @param props.initialValue         - Initial value for the text input.
+ * @param props.primaryButtonLabel   - Label for the primary button.
+ * @param props.secondaryButtonLabel - Label for the secondary button.
+ * @param props.placeholder          - Placeholder text for the input field.
+ * @param props.inputLabel           - Label for the input field.
+ * @param props.fallbackName         - Fallback name when input is empty.
+ * @return The modal component or null if not open.
+ */
+export function FormNameModal( {
+	isOpen,
+	onClose,
+	onSave,
+	title,
+	initialValue = '',
+	primaryButtonLabel,
+	secondaryButtonLabel,
+	placeholder,
+	inputLabel,
+	fallbackName,
+}: FormNameModalProps ) {
+	const [ name, setName ] = useState( initialValue );
+	const [ isSaving, setIsSaving ] = useState( false );
+
+	// Reset name when modal opens with a new initial value
+	useEffect( () => {
+		if ( isOpen ) {
+			setName( initialValue );
+		}
+	}, [ isOpen, initialValue ] );
+
+	const handleClose = useCallback( () => {
+		if ( ! isSaving ) {
+			onClose();
+		}
+	}, [ isSaving, onClose ] );
+
+	const handleConfirm = useCallback( async () => {
+		if ( isSaving ) {
+			return;
+		}
+
+		setIsSaving( true );
+		const finalName = name.trim() || fallbackName || __( 'Untitled Form', 'jetpack-forms' );
+
+		try {
+			await onSave( finalName );
+			onClose();
+		} catch {
+			// Error handling is left to the caller via onSave
+			// Modal stays open on error
+		} finally {
+			setIsSaving( false );
+		}
+	}, [ name, fallbackName, isSaving, onSave, onClose ] );
+
+	const onSubmitForm = useCallback(
+		( event: React.FormEvent ) => {
+			event.preventDefault();
+			handleConfirm();
+		},
+		[ handleConfirm ]
+	);
+
+	if ( ! isOpen ) {
+		return null;
+	}
+
+	return (
+		<Modal title={ title } onRequestClose={ handleClose } size="medium">
+			<form onSubmit={ onSubmitForm }>
+				<TextControl
+					label={ inputLabel || __( 'Name', 'jetpack-forms' ) }
+					value={ name }
+					onChange={ setName }
+					__next40pxDefaultSize
+					placeholder={ placeholder }
+					disabled={ isSaving }
+				/>
+				<div className="jp-forms-name-modal__buttons">
+					<Button variant="tertiary" onClick={ handleClose } disabled={ isSaving }>
+						{ secondaryButtonLabel || __( 'Cancel', 'jetpack-forms' ) }
+					</Button>
+					<Button aria-disabled={ isSaving } isBusy={ isSaving } variant="primary" type="submit">
+						{ primaryButtonLabel || __( 'Save', 'jetpack-forms' ) }
+					</Button>
+				</div>
+			</form>
+		</Modal>
+	);
+}
+
+export default FormNameModal;

--- a/projects/packages/forms/src/dashboard/components/form-name-modal/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/form-name-modal/index.tsx
@@ -8,6 +8,7 @@
 import { Button, Modal, TextControl } from '@wordpress/components';
 import { useState, useCallback, useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import type { FormEvent } from 'react';
 import './style.scss';
 
 export type FormNameModalProps = {
@@ -24,7 +25,11 @@ export type FormNameModalProps = {
 	/**
 	 * Async callback when the user confirms.
 	 * Receives the trimmed name (or fallback if empty).
-	 * Should throw on error to prevent modal from closing.
+	 *
+	 * If this callback throws, the modal stays open so the user can retry.
+	 * If it resolves successfully, the modal closes automatically.
+	 * Do NOT close the modal from within this callback - the component handles
+	 * closing based on success/failure.
 	 */
 	onSave: ( name: string ) => Promise< void >;
 
@@ -122,17 +127,17 @@ export function FormNameModal( {
 
 		try {
 			await onSave( finalName );
-			onClose();
 		} catch {
 			// Error handling is left to the caller via onSave
 			// Modal stays open on error
 		} finally {
 			setIsSaving( false );
+			onClose();
 		}
 	}, [ name, fallbackName, isSaving, onSave, onClose ] );
 
 	const onSubmitForm = useCallback(
-		( event: React.FormEvent ) => {
+		( event: FormEvent ) => {
 			event.preventDefault();
 			handleConfirm();
 		},

--- a/projects/packages/forms/src/dashboard/components/form-name-modal/style.scss
+++ b/projects/packages/forms/src/dashboard/components/form-name-modal/style.scss
@@ -1,0 +1,6 @@
+.jp-forms-name-modal__buttons {
+	display: flex;
+	justify-content: flex-end;
+	gap: 8px;
+	margin-block-start: 16px;
+}

--- a/projects/packages/forms/src/dashboard/forms/index.tsx
+++ b/projects/packages/forms/src/dashboard/forms/index.tsx
@@ -3,7 +3,13 @@
  */
 import { JetpackLogo } from '@automattic/jetpack-components';
 import apiFetch from '@wordpress/api-fetch';
-import { __experimentalConfirmDialog as ConfirmDialog } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
+import {
+	__experimentalConfirmDialog as ConfirmDialog, // eslint-disable-line @wordpress/no-unsafe-wp-apis
+	Button,
+	Modal,
+	TextControl,
+} from '@wordpress/components';
+import { store as coreStore } from '@wordpress/core-data';
 import { useDispatch } from '@wordpress/data';
 import { DataViews } from '@wordpress/dataviews/wp';
 import { dateI18n, getSettings as getDateSettings } from '@wordpress/date';
@@ -86,6 +92,12 @@ export default function FormsDashboardForms(): JSX.Element | null {
 	const [ selection, setSelection ] = useState< string[] >( [] );
 	const [ pendingPermanentDeleteCount, setPendingPermanentDeleteCount ] = useState( 0 );
 
+	// Rename modal state
+	const [ isRenameModalOpen, setIsRenameModalOpen ] = useState( false );
+	const [ renameFormItem, setRenameFormItem ] = useState< FormListItem | null >( null );
+	const [ renameTitle, setRenameTitle ] = useState( '' );
+	const [ isRenaming, setIsRenaming ] = useState( false );
+
 	useEffect( () => {
 		if ( isCentralFormManagementDisabled ) {
 			navigate( '/responses', { replace: true } );
@@ -118,6 +130,65 @@ export default function FormsDashboardForms(): JSX.Element | null {
 			setSelection( [] );
 		}
 	}, [ confirmPermanentDelete ] );
+
+	const openRenameModal = useCallback( ( item: FormListItem ) => {
+		setRenameFormItem( item );
+		setRenameTitle( item.title || '' );
+		setIsRenameModalOpen( true );
+	}, [] );
+
+	const closeRenameModal = useCallback( () => {
+		setIsRenameModalOpen( false );
+		setRenameFormItem( null );
+		setRenameTitle( '' );
+	}, [] );
+
+	const handleRename = useCallback( async () => {
+		if ( ! renameFormItem || isRenaming ) {
+			return;
+		}
+
+		setIsRenaming( true );
+		const newTitle = renameTitle.trim() || __( 'Untitled Form', 'jetpack-forms' );
+
+		try {
+			await editEntityRecord( 'postType', 'jetpack_form', renameFormItem.id, {
+				title: newTitle,
+			} );
+			await saveEditedEntityRecord( 'postType', 'jetpack_form', renameFormItem.id );
+
+			createSuccessNotice( __( 'Form renamed.', 'jetpack-forms' ), { type: 'snackbar' } );
+		} catch ( error ) {
+			createErrorNotice( __( 'Failed to rename form. Please try again.', 'jetpack-forms' ), {
+				type: 'snackbar',
+			} );
+			// eslint-disable-next-line no-console
+			console.error( 'Failed to rename form:', error );
+		} finally {
+			setIsRenaming( false );
+			closeRenameModal();
+		}
+	}, [
+		renameFormItem,
+		renameTitle,
+		isRenaming,
+		editEntityRecord,
+		saveEditedEntityRecord,
+		createSuccessNotice,
+		createErrorNotice,
+		closeRenameModal,
+	] );
+
+	const onRenameFormSubmit = useCallback(
+		( event: React.FormEvent ) => {
+			event.preventDefault();
+			if ( isRenaming ) {
+				return;
+			}
+			handleRename();
+		},
+		[ handleRename, isRenaming ]
+	);
 
 	const statusLabel = useCallback( ( status: string ) => {
 		switch ( status ) {
@@ -354,6 +425,7 @@ export default function FormsDashboardForms(): JSX.Element | null {
 		isViewingTrash,
 		navigate,
 		onOpenPermanentDeleteConfirm,
+		openRenameModal,
 		restoreForms,
 		trashForms,
 	] );
@@ -395,6 +467,42 @@ export default function FormsDashboardForms(): JSX.Element | null {
 				actions={ headerActions }
 				hasPadding={ false }
 			>
+				{ isRenameModalOpen && (
+					<Modal
+						title={ __( 'Rename Form', 'jetpack-forms' ) }
+						onRequestClose={ closeRenameModal }
+						size="medium"
+					>
+						<form onSubmit={ onRenameFormSubmit }>
+							<TextControl
+								label={ __( 'Name', 'jetpack-forms' ) }
+								value={ renameTitle }
+								onChange={ setRenameTitle }
+								__next40pxDefaultSize
+							/>
+							<div
+								style={ {
+									display: 'flex',
+									justifyContent: 'flex-end',
+									gap: '8px',
+									marginTop: '16px',
+								} }
+							>
+								<Button variant="tertiary" onClick={ closeRenameModal }>
+									{ __( 'Cancel', 'jetpack-forms' ) }
+								</Button>
+								<Button
+									aria-disabled={ isRenaming }
+									isBusy={ isRenaming }
+									variant="primary"
+									type="submit"
+								>
+									{ __( 'Save', 'jetpack-forms' ) }
+								</Button>
+							</div>
+						</form>
+					</Modal>
+				) }
 				<DataViews
 					paginationInfo={ paginationInfo }
 					fields={ fields }

--- a/projects/packages/forms/src/dashboard/forms/index.tsx
+++ b/projects/packages/forms/src/dashboard/forms/index.tsx
@@ -27,7 +27,7 @@ import { EmptyWrapper } from '../components/empty-responses/index.tsx';
 import Page from '../components/page/index.tsx';
 import { NON_TRASH_FORM_STATUSES } from '../constants.ts';
 import useDeleteForm from '../hooks/use-delete-form.ts';
-import useFormsData from '../hooks/use-forms-data.ts';
+import useFormsData, { getFormsListQuery } from '../hooks/use-forms-data.ts';
 import { defaultLayouts, useView } from './views.ts';
 import './style.scss';
 import type { FormListItem } from '../hooks/use-forms-data.ts';
@@ -152,10 +152,15 @@ export default function FormsDashboardForms(): JSX.Element | null {
 		const newTitle = renameTitle.trim() || __( 'Untitled Form', 'jetpack-forms' );
 
 		try {
-			await editEntityRecord( 'postType', 'jetpack_form', renameFormItem.id, {
-				title: newTitle,
+			await apiFetch( {
+				path: `/wp/v2/jetpack-forms/${ renameFormItem.id }`,
+				method: 'POST',
+				data: { title: newTitle },
 			} );
-			await saveEditedEntityRecord( 'postType', 'jetpack_form', renameFormItem.id );
+
+			// Invalidate the forms list cache to refresh the data
+			const query = getFormsListQuery( view.page, view.perPage, view.search, statusQuery );
+			invalidateResolution( 'getEntityRecords', [ 'postType', 'jetpack_form', query ] );
 
 			createSuccessNotice( __( 'Form renamed.', 'jetpack-forms' ), { type: 'snackbar' } );
 		} catch ( error ) {
@@ -172,8 +177,11 @@ export default function FormsDashboardForms(): JSX.Element | null {
 		renameFormItem,
 		renameTitle,
 		isRenaming,
-		editEntityRecord,
-		saveEditedEntityRecord,
+		view.page,
+		view.perPage,
+		view.search,
+		statusQuery,
+		invalidateResolution,
 		createSuccessNotice,
 		createErrorNotice,
 		closeRenameModal,

--- a/projects/packages/forms/src/dashboard/forms/index.tsx
+++ b/projects/packages/forms/src/dashboard/forms/index.tsx
@@ -3,13 +3,7 @@
  */
 import { JetpackLogo } from '@automattic/jetpack-components';
 import apiFetch from '@wordpress/api-fetch';
-import {
-	__experimentalConfirmDialog as ConfirmDialog, // eslint-disable-line @wordpress/no-unsafe-wp-apis
-	Button,
-	Modal,
-	TextControl,
-} from '@wordpress/components';
-import { store as coreStore } from '@wordpress/core-data';
+import { __experimentalConfirmDialog as ConfirmDialog } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
 import { useDispatch } from '@wordpress/data';
 import { DataViews } from '@wordpress/dataviews/wp';
 import { dateI18n, getSettings as getDateSettings } from '@wordpress/date';
@@ -27,7 +21,7 @@ import { EmptyWrapper } from '../components/empty-responses/index.tsx';
 import Page from '../components/page/index.tsx';
 import { NON_TRASH_FORM_STATUSES } from '../constants.ts';
 import useDeleteForm from '../hooks/use-delete-form.ts';
-import useFormsData, { getFormsListQuery } from '../hooks/use-forms-data.ts';
+import useFormsData from '../hooks/use-forms-data.ts';
 import { defaultLayouts, useView } from './views.ts';
 import './style.scss';
 import type { FormListItem } from '../hooks/use-forms-data.ts';
@@ -92,12 +86,6 @@ export default function FormsDashboardForms(): JSX.Element | null {
 	const [ selection, setSelection ] = useState< string[] >( [] );
 	const [ pendingPermanentDeleteCount, setPendingPermanentDeleteCount ] = useState( 0 );
 
-	// Rename modal state
-	const [ isRenameModalOpen, setIsRenameModalOpen ] = useState( false );
-	const [ renameFormItem, setRenameFormItem ] = useState< FormListItem | null >( null );
-	const [ renameTitle, setRenameTitle ] = useState( '' );
-	const [ isRenaming, setIsRenaming ] = useState( false );
-
 	useEffect( () => {
 		if ( isCentralFormManagementDisabled ) {
 			navigate( '/responses', { replace: true } );
@@ -130,73 +118,6 @@ export default function FormsDashboardForms(): JSX.Element | null {
 			setSelection( [] );
 		}
 	}, [ confirmPermanentDelete ] );
-
-	const openRenameModal = useCallback( ( item: FormListItem ) => {
-		setRenameFormItem( item );
-		setRenameTitle( item.title || '' );
-		setIsRenameModalOpen( true );
-	}, [] );
-
-	const closeRenameModal = useCallback( () => {
-		setIsRenameModalOpen( false );
-		setRenameFormItem( null );
-		setRenameTitle( '' );
-	}, [] );
-
-	const handleRename = useCallback( async () => {
-		if ( ! renameFormItem || isRenaming ) {
-			return;
-		}
-
-		setIsRenaming( true );
-		const newTitle = renameTitle.trim() || __( 'Untitled Form', 'jetpack-forms' );
-
-		try {
-			await apiFetch( {
-				path: `/wp/v2/jetpack-forms/${ renameFormItem.id }`,
-				method: 'POST',
-				data: { title: newTitle },
-			} );
-
-			// Invalidate the forms list cache to refresh the data
-			const query = getFormsListQuery( view.page, view.perPage, view.search, statusQuery );
-			invalidateResolution( 'getEntityRecords', [ 'postType', 'jetpack_form', query ] );
-
-			createSuccessNotice( __( 'Form renamed.', 'jetpack-forms' ), { type: 'snackbar' } );
-		} catch ( error ) {
-			createErrorNotice( __( 'Failed to rename form. Please try again.', 'jetpack-forms' ), {
-				type: 'snackbar',
-			} );
-			// eslint-disable-next-line no-console
-			console.error( 'Failed to rename form:', error );
-		} finally {
-			setIsRenaming( false );
-			closeRenameModal();
-		}
-	}, [
-		renameFormItem,
-		renameTitle,
-		isRenaming,
-		view.page,
-		view.perPage,
-		view.search,
-		statusQuery,
-		invalidateResolution,
-		createSuccessNotice,
-		createErrorNotice,
-		closeRenameModal,
-	] );
-
-	const onRenameFormSubmit = useCallback(
-		( event: React.FormEvent ) => {
-			event.preventDefault();
-			if ( isRenaming ) {
-				return;
-			}
-			handleRename();
-		},
-		[ handleRename, isRenaming ]
-	);
 
 	const statusLabel = useCallback( ( status: string ) => {
 		switch ( status ) {
@@ -433,7 +354,6 @@ export default function FormsDashboardForms(): JSX.Element | null {
 		isViewingTrash,
 		navigate,
 		onOpenPermanentDeleteConfirm,
-		openRenameModal,
 		restoreForms,
 		trashForms,
 	] );
@@ -475,42 +395,6 @@ export default function FormsDashboardForms(): JSX.Element | null {
 				actions={ headerActions }
 				hasPadding={ false }
 			>
-				{ isRenameModalOpen && (
-					<Modal
-						title={ __( 'Rename Form', 'jetpack-forms' ) }
-						onRequestClose={ closeRenameModal }
-						size="medium"
-					>
-						<form onSubmit={ onRenameFormSubmit }>
-							<TextControl
-								label={ __( 'Name', 'jetpack-forms' ) }
-								value={ renameTitle }
-								onChange={ setRenameTitle }
-								__next40pxDefaultSize
-							/>
-							<div
-								style={ {
-									display: 'flex',
-									justifyContent: 'flex-end',
-									gap: '8px',
-									marginTop: '16px',
-								} }
-							>
-								<Button variant="tertiary" onClick={ closeRenameModal }>
-									{ __( 'Cancel', 'jetpack-forms' ) }
-								</Button>
-								<Button
-									aria-disabled={ isRenaming }
-									isBusy={ isRenaming }
-									variant="primary"
-									type="submit"
-								>
-									{ __( 'Save', 'jetpack-forms' ) }
-								</Button>
-							</div>
-						</form>
-					</Modal>
-				) }
 				<DataViews
 					paginationInfo={ paginationInfo }
 					fields={ fields }

--- a/projects/packages/forms/src/form-editor/plugins/form-title-modal.tsx
+++ b/projects/packages/forms/src/form-editor/plugins/form-title-modal.tsx
@@ -5,14 +5,14 @@
  * Only displays for new/untitled forms that don't have any content yet.
  */
 
-import { Button, Modal, TextControl } from '@wordpress/components';
 import { store as coreStore } from '@wordpress/core-data';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
-import { useState, useCallback, useEffect } from '@wordpress/element';
+import { useState, useCallback, useEffect, useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { FORM_POST_TYPE } from '../../blocks/shared/util/constants.js';
+import { FormNameModal } from '../../dashboard/components/form-name-modal';
 
 /**
  * Form Title Modal component.
@@ -25,8 +25,7 @@ import { FORM_POST_TYPE } from '../../blocks/shared/util/constants.js';
 export const FormTitleModal = () => {
 	const [ isOpen, setIsOpen ] = useState( false );
 	const [ hasShown, setHasShown ] = useState( false );
-	const [ title, setTitle ] = useState( '' );
-	const [ isSaving, setIsSaving ] = useState( false );
+	const retryTitleRef = useRef< string >( '' );
 
 	const { editEntityRecord, saveEditedEntityRecord } = useDispatch( coreStore );
 	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
@@ -73,13 +72,15 @@ export const FormTitleModal = () => {
 
 	const handleClose = useCallback( () => {
 		setIsOpen( false );
+		retryTitleRef.current = '';
 	}, [] );
 
-	const handleConfirm = useCallback( async () => {
-		setIsSaving( true );
-		const newTitle = title.trim() || __( 'Untitled Form', 'jetpack-forms' );
+	const handleSave = useCallback(
+		async ( newTitle: string ) => {
+			if ( ! currentPostId ) {
+				return;
+			}
 
-		if ( currentPostId ) {
 			try {
 				await editEntityRecord( 'postType', FORM_POST_TYPE, currentPostId, {
 					title: newTitle,
@@ -88,46 +89,33 @@ export const FormTitleModal = () => {
 					throwOnError: true,
 				} );
 
-				setIsSaving( false );
-				setIsOpen( false );
 				createSuccessNotice( __( 'Form created.', 'jetpack-forms' ), {
 					type: 'snackbar',
 				} );
+				retryTitleRef.current = '';
 			} catch {
-				setIsSaving( false );
-				setIsOpen( false );
 				createErrorNotice( __( 'Failed to create form.', 'jetpack-forms' ), {
 					type: 'snackbar',
 					actions: [
 						{
 							label: __( 'Retry', 'jetpack-forms' ),
 							onClick: () => {
-								setTitle( newTitle );
+								retryTitleRef.current = newTitle;
 								setIsOpen( true );
 							},
 						},
 					],
 				} );
+				throw new Error( 'Failed to save' );
 			}
-		}
-	}, [
-		title,
-		currentPostId,
-		editEntityRecord,
-		saveEditedEntityRecord,
-		createSuccessNotice,
-		createErrorNotice,
-	] );
-
-	const onSubmitForm = useCallback(
-		( event: React.FormEvent ) => {
-			event.preventDefault();
-			if ( isSaving ) {
-				return;
-			}
-			handleConfirm();
 		},
-		[ handleConfirm, isSaving ]
+		[
+			currentPostId,
+			editEntityRecord,
+			saveEditedEntityRecord,
+			createSuccessNotice,
+			createErrorNotice,
+		]
 	);
 
 	// Show modal on first render if this is a new placeholder form in the form editor
@@ -138,35 +126,21 @@ export const FormTitleModal = () => {
 		}
 	}, [ isFormEditor, hasInnerBlocks, isNewForm, hasShown ] );
 
-	// Don't render anything if not in the form editor or modal is closed
-	if ( ! isFormEditor || ! isOpen ) {
+	// Don't render anything if not in the form editor
+	if ( ! isFormEditor ) {
 		return null;
 	}
 
 	return (
-		<Modal
+		<FormNameModal
+			isOpen={ isOpen }
+			onClose={ handleClose }
+			onSave={ handleSave }
 			title={ __( 'Create form', 'jetpack-forms' ) }
-			onRequestClose={ handleClose }
-			size="medium"
-		>
-			<form onSubmit={ onSubmitForm }>
-				<TextControl
-					label={ __( 'Name', 'jetpack-forms' ) }
-					value={ title }
-					onChange={ setTitle }
-					__next40pxDefaultSize
-					placeholder={ __( 'Enter form name', 'jetpack-forms' ) }
-					disabled={ isSaving }
-				/>
-				<div className="jetpack-forms-title-modal__buttons">
-					<Button variant="tertiary" onClick={ handleClose }>
-						{ __( 'Skip', 'jetpack-forms' ) }
-					</Button>
-					<Button aria-disabled={ isSaving } isBusy={ isSaving } variant="primary" type="submit">
-						{ __( 'Create', 'jetpack-forms' ) }
-					</Button>
-				</div>
-			</form>
-		</Modal>
+			initialValue={ retryTitleRef.current }
+			primaryButtonLabel={ __( 'Create', 'jetpack-forms' ) }
+			secondaryButtonLabel={ __( 'Skip', 'jetpack-forms' ) }
+			placeholder={ __( 'Enter form name', 'jetpack-forms' ) }
+		/>
 	);
 };

--- a/projects/packages/forms/src/form-editor/plugins/form-title-modal.tsx
+++ b/projects/packages/forms/src/form-editor/plugins/form-title-modal.tsx
@@ -106,7 +106,6 @@ export const FormTitleModal = () => {
 						},
 					],
 				} );
-				throw new Error( 'Failed to save' );
 			}
 		},
 		[

--- a/projects/packages/forms/src/form-editor/plugins/form-title-modal.tsx
+++ b/projects/packages/forms/src/form-editor/plugins/form-title-modal.tsx
@@ -72,7 +72,6 @@ export const FormTitleModal = () => {
 
 	const handleClose = useCallback( () => {
 		setIsOpen( false );
-		retryTitleRef.current = '';
 	}, [] );
 
 	const handleSave = useCallback(

--- a/projects/packages/forms/src/form-editor/plugins/form-title-modal.tsx
+++ b/projects/packages/forms/src/form-editor/plugins/form-title-modal.tsx
@@ -100,12 +100,13 @@ export const FormTitleModal = () => {
 						{
 							label: __( 'Retry', 'jetpack-forms' ),
 							onClick: () => {
-								retryTitleRef.current = newTitle;
 								setIsOpen( true );
 							},
 						},
 					],
 				} );
+				retryTitleRef.current = newTitle;
+				setIsOpen( false );
 			}
 		},
 		[

--- a/projects/packages/forms/src/form-editor/style.scss
+++ b/projects/packages/forms/src/form-editor/style.scss
@@ -11,10 +11,3 @@
 .post-type-jetpack_form .editor-post-last-edited-panel {
 	display: none;
 }
-
-.jetpack-forms-title-modal__buttons {
-	display: flex;
-	justify-content: flex-end;
-	gap: 8px;
-	margin-block-start: 16px;
-}


### PR DESCRIPTION
<img width="223" height="261" alt="Screenshot 2026-02-12 at 1 16 45 PM" src="https://github.com/user-attachments/assets/c5de0d69-08f3-4020-8b8a-d988c1d1e975" />

<img width="569" height="268" alt="Screenshot 2026-02-12 at 1 16 50 PM" src="https://github.com/user-attachments/assets/4fdab698-7ec7-41af-9ee5-1361434e3753" />


## Proposed changes:
- Add a "Rename" action to the forms list in the dashboard
- Show a modal dialog when clicking rename to enter a new form name
- Invalidate the forms list cache after rename to refresh the data
- Show success/error notices for rename operations



### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- N/A -->

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

* Enable the Forms wp-build dashboard (ensure `jetpack_forms_dashboard_routes_enabled` filter returns true)
* Navigate to Jetpack → Forms in the WordPress admin
* Click on the three-dot menu for any form in the list
* Click "Rename" from the dropdown menu
* Verify the rename modal appears with the current form name
* Enter a new name and click "Save"
* Verify the form name updates in the list
* Verify a success notice appears
* Try renaming with an empty name - should default to "Untitled Form"

🤖 Generated with [Claude Code](https://claude.com/claude-code)