### PR TITLE
Add Survicate survey integration for wp-admin, block editor, and site editor

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/2026-02-12-22-25-24-309661
+++ b/projects/packages/jetpack-mu-wpcom/changelog/2026-02-12-22-25-24-309661
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Survicate: add survey integration for wp-admin, block editor, and site editor.

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -325,6 +325,9 @@ class Jetpack_Mu_Wpcom {
 		if ( ! class_exists( 'A8C\FSE\Agents_Manager' ) ) {
 			require_once __DIR__ . '/features/agents-manager/class-agents-manager.php';
 		}
+		if ( ! class_exists( 'A8C\FSE\Survicate' ) ) {
+			require_once __DIR__ . '/features/survicate/class-survicate.php';
+		}
 		require_once __DIR__ . '/features/html-block-restricted-tags/html-block-restricted-tags.php';
 		require_once __DIR__ . '/features/marketing/marketing.php';
 		require_once __DIR__ . '/features/pages/pages.php';

--- a/projects/packages/jetpack-mu-wpcom/src/features/survicate/class-survicate.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/survicate/class-survicate.php
@@ -1,0 +1,150 @@
+<?php
+/**
+ * Survicate survey integration
+ *
+ * @package automattic/jetpack-mu-wpcom
+ */
+
+namespace A8C\FSE;
+
+/**
+ * Class Survicate
+ */
+class Survicate {
+	/**
+	 * Survicate workspace key.
+	 */
+	const WORKSPACE_KEY = 'e4794374cce15378101b63de24117572';
+
+	/**
+	 * Class instance.
+	 *
+	 * @var Survicate
+	 */
+	private static $instance = null;
+
+	/**
+	 * Survicate constructor.
+	 */
+	public function __construct() {
+		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_scripts' ), 100 );
+	}
+
+	/**
+	 * Creates instance.
+	 *
+	 * @return void
+	 */
+	public static function init() {
+		if ( self::$instance === null ) {
+			self::$instance = new self();
+		}
+	}
+
+	/**
+	 * Check whether Survicate should load on the current page.
+	 *
+	 * @return bool
+	 */
+	private function should_load() {
+		if ( ! is_user_logged_in() ) {
+			return false;
+		}
+
+		if ( ! is_admin() ) {
+			return false;
+		}
+
+		// Only load for English locale users.
+		if ( strpos( strtolower( get_user_locale() ), 'en' ) !== 0 ) {
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Detect the current editor context.
+	 *
+	 * @return string One of 'site-editor', 'block-editor', or 'wp-admin'.
+	 */
+	private function get_editor_context() {
+		global $pagenow;
+
+		if ( $pagenow === 'site-editor.php' ) {
+			return 'site-editor';
+		}
+
+		if ( function_exists( 'get_current_screen' ) ) {
+			$current_screen = get_current_screen();
+			if ( $current_screen && $current_screen->is_block_editor() && $current_screen->id !== 'widgets' ) {
+				return 'block-editor';
+			}
+		}
+
+		return 'wp-admin';
+	}
+
+	/**
+	 * Get visitor traits for Survicate.
+	 *
+	 * @return array
+	 */
+	private function get_visitor_traits() {
+		$user_data = get_userdata( get_current_user_id() );
+		$email     = $user_data ? $user_data->user_email : '';
+		$site_id   = get_wpcom_blog_id();
+		$site_type = ( defined( 'IS_ATOMIC' ) && IS_ATOMIC ) ? 'atomic' : 'simple';
+
+		return array(
+			'email'          => $email,
+			'site_id'        => $site_id ? (string) $site_id : '',
+			'site_type'      => $site_type,
+			'editor_context' => $this->get_editor_context(),
+		);
+	}
+
+	/**
+	 * Enqueue Survicate scripts.
+	 */
+	public function enqueue_scripts() {
+		if ( ! $this->should_load() ) {
+			return;
+		}
+
+		$traits_json   = wp_json_encode( $this->get_visitor_traits(), JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP );
+		$workspace_key = self::WORKSPACE_KEY;
+
+		// phpcs:ignore WordPress.WP.EnqueuedResourceParameters.NotInFooter
+		wp_register_script(
+			'wpcom-survicate',
+			false,
+			array(),
+			'1.0',
+			false
+		);
+
+		wp_add_inline_script(
+			'wpcom-survicate',
+			<<<JS
+( function () {
+	if ( window.innerWidth < 480 ) {
+		return;
+	}
+	var script = document.createElement( 'script' );
+	script.src = 'https://survey.survicate.com/workspaces/{$workspace_key}/web_surveys.js';
+	script.async = true;
+	document.head.appendChild( script );
+	var traits = {$traits_json};
+	window.addEventListener( 'SurvicateReady', function () {
+		window._sva.setVisitorTraits( traits );
+	} );
+} )();
+JS
+		);
+
+		wp_enqueue_script( 'wpcom-survicate' );
+	}
+}
+
+add_action( 'init', array( __NAMESPACE__ . '\Survicate', 'init' ) );

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/survicate/Survicate_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/survicate/Survicate_Test.php
@@ -1,0 +1,383 @@
+<?php
+/**
+ * Survicate Tests File
+ *
+ * @package automattic/jetpack-mu-wpcom
+ */
+
+namespace A8C\FSE;
+
+use Automattic\Jetpack\Constants;
+use Automattic\Jetpack\Jetpack_Mu_Wpcom;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
+
+require_once Jetpack_Mu_Wpcom::PKG_DIR . 'src/features/survicate/class-survicate.php';
+
+/**
+ * Class Survicate_Test
+ *
+ * @covers \A8C\FSE\Survicate
+ */
+#[CoversClass( Survicate::class )]
+class Survicate_Test extends \WorDBless\BaseTestCase {
+
+	/**
+	 * The Survicate instance.
+	 *
+	 * @var Survicate
+	 */
+	private $survicate;
+
+	/**
+	 * Original $pagenow global value to restore after tests.
+	 *
+	 * @var mixed
+	 */
+	private $original_pagenow;
+
+	/**
+	 * Original current_screen global value to restore after tests.
+	 *
+	 * @var mixed
+	 */
+	private $original_current_screen;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function set_up() {
+		parent::set_up();
+		$this->survicate = new Survicate();
+
+		global $pagenow;
+		$this->original_pagenow        = $pagenow;
+		$this->original_current_screen = $GLOBALS['current_screen'] ?? null;
+	}
+
+	/**
+	 * Tear down test fixtures.
+	 */
+	public function tear_down() {
+		remove_action( 'admin_enqueue_scripts', array( $this->survicate, 'enqueue_scripts' ), 100 );
+
+		global $pagenow;
+		$pagenow = $this->original_pagenow;
+
+		if ( $this->original_current_screen === null ) {
+			unset( $GLOBALS['current_screen'] );
+		} else {
+			$GLOBALS['current_screen'] = $this->original_current_screen;
+		}
+
+		wp_set_current_user( 0 );
+
+		global $wp_scripts;
+		$wp_scripts = null;
+
+		Constants::clear_constants();
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Helper to call a private method on the Survicate instance via reflection.
+	 *
+	 * @param string $method_name The method name to call.
+	 * @return mixed The method's return value.
+	 */
+	private function call_private_method( $method_name ) {
+		$method = ( new \ReflectionClass( Survicate::class ) )->getMethod( $method_name );
+		return $method->invoke( $this->survicate );
+	}
+
+	/**
+	 * Helper to simulate admin context for tests.
+	 */
+	private function set_admin_context() {
+		require_once ABSPATH . 'wp-admin/includes/screen.php';
+		set_current_screen( 'dashboard' );
+	}
+
+	/**
+	 * Helper to create a logged-in user.
+	 *
+	 * @param string $locale The locale for the user.
+	 * @return int The user ID.
+	 */
+	private function create_and_login_user( $locale = 'en_US' ) {
+		$user_id = wp_insert_user(
+			array(
+				'user_login' => 'test_user_' . wp_rand(),
+				'user_pass'  => 'password',
+				'user_email' => 'test@example.com',
+				'locale'     => $locale,
+			)
+		);
+		wp_set_current_user( $user_id );
+		return $user_id;
+	}
+
+	/**
+	 * Helper to set up a block editor screen via reflection.
+	 *
+	 * @param string $screen_id The screen ID (e.g. 'post', 'widgets').
+	 */
+	private function set_block_editor_screen( $screen_id ) {
+		require_once ABSPATH . 'wp-admin/includes/screen.php';
+		set_current_screen( $screen_id );
+		$screen   = get_current_screen();
+		$property = ( new \ReflectionClass( $screen ) )->getProperty( 'is_block_editor' );
+		$property->setValue( $screen, true );
+	}
+
+	/**
+	 * Helper to get the inline script output for the wpcom-survicate handle.
+	 *
+	 * @return string The concatenated inline script.
+	 */
+	private function get_inline_script() {
+		global $wp_scripts;
+		$inline_scripts = $wp_scripts->registered['wpcom-survicate']->extra['after'] ?? array();
+		return implode( "\n", array_filter( $inline_scripts ) );
+	}
+
+	/**
+	 * Helper to set up admin context with a logged-in English user and enqueue scripts.
+	 */
+	private function enqueue_survicate_scripts() {
+		global $pagenow;
+		$pagenow = 'index.php';
+		$this->set_admin_context();
+		$this->create_and_login_user( 'en_US' );
+		$this->survicate->enqueue_scripts();
+	}
+
+	// ---- should_load() tests ----
+
+	/**
+	 * Tests that should_load returns false when user is not logged in.
+	 */
+	public function test_should_load_returns_false_when_not_logged_in() {
+		$this->set_admin_context();
+		wp_set_current_user( 0 );
+
+		$this->assertFalse( $this->call_private_method( 'should_load' ) );
+	}
+
+	/**
+	 * Tests that should_load returns false when not in admin context.
+	 */
+	public function test_should_load_returns_false_when_not_admin() {
+		$this->create_and_login_user();
+
+		$this->assertFalse( is_admin() );
+		$this->assertFalse( $this->call_private_method( 'should_load' ) );
+	}
+
+	/**
+	 * Tests that should_load returns false for non-English locale users.
+	 *
+	 * @param string $locale The locale to test.
+	 * @dataProvider provide_non_english_locales
+	 */
+	#[DataProvider( 'provide_non_english_locales' )]
+	public function test_should_load_returns_false_for_non_english_locale( $locale ) {
+		$this->set_admin_context();
+		$this->create_and_login_user( $locale );
+
+		$this->assertFalse( $this->call_private_method( 'should_load' ) );
+	}
+
+	/**
+	 * Data provider for non-English locale tests.
+	 *
+	 * @return \Iterator
+	 */
+	public static function provide_non_english_locales(): \Iterator {
+		yield 'French' => array( 'fr_FR' );
+		yield 'Spanish' => array( 'es_ES' );
+		yield 'Japanese' => array( 'ja' );
+		yield 'Portuguese (Brazil)' => array( 'pt_BR' );
+	}
+
+	/**
+	 * Tests that should_load returns true for English locale variants.
+	 *
+	 * @param string $locale The locale to test.
+	 * @dataProvider provide_english_locales
+	 */
+	#[DataProvider( 'provide_english_locales' )]
+	public function test_should_load_returns_true_for_english_locales( $locale ) {
+		$this->set_admin_context();
+		$this->create_and_login_user( $locale );
+
+		$this->assertTrue( $this->call_private_method( 'should_load' ) );
+	}
+
+	/**
+	 * Data provider for English locale variant tests.
+	 *
+	 * @return \Iterator
+	 */
+	public static function provide_english_locales(): \Iterator {
+		yield 'en_US' => array( 'en_US' );
+		yield 'en_GB' => array( 'en_GB' );
+		yield 'en_AU' => array( 'en_AU' );
+		yield 'en_CA' => array( 'en_CA' );
+	}
+
+	// ---- get_editor_context() tests ----
+
+	/**
+	 * Tests that get_editor_context returns 'site-editor' on site-editor.php.
+	 */
+	public function test_get_editor_context_returns_site_editor() {
+		global $pagenow;
+		$pagenow = 'site-editor.php';
+
+		$this->assertSame( 'site-editor', $this->call_private_method( 'get_editor_context' ) );
+	}
+
+	/**
+	 * Tests that get_editor_context returns 'block-editor' in block editor screen.
+	 */
+	public function test_get_editor_context_returns_block_editor() {
+		global $pagenow;
+		$pagenow = 'post.php';
+		$this->set_block_editor_screen( 'post' );
+
+		$this->assertSame( 'block-editor', $this->call_private_method( 'get_editor_context' ) );
+	}
+
+	/**
+	 * Tests that get_editor_context returns 'wp-admin' for widgets screen even with block editor.
+	 */
+	public function test_get_editor_context_returns_wp_admin_for_widgets() {
+		global $pagenow;
+		$pagenow = 'widgets.php';
+		$this->set_block_editor_screen( 'widgets' );
+
+		$this->assertSame( 'wp-admin', $this->call_private_method( 'get_editor_context' ) );
+	}
+
+	/**
+	 * Tests that get_editor_context returns 'wp-admin' on regular admin pages.
+	 */
+	public function test_get_editor_context_returns_wp_admin_by_default() {
+		global $pagenow;
+		$pagenow = 'index.php';
+		$this->set_admin_context();
+
+		$this->assertSame( 'wp-admin', $this->call_private_method( 'get_editor_context' ) );
+	}
+
+	// ---- get_visitor_traits() tests ----
+
+	/**
+	 * Tests that get_visitor_traits returns correct structure and values.
+	 */
+	public function test_get_visitor_traits_returns_correct_structure() {
+		global $pagenow;
+		$pagenow = 'site-editor.php';
+		$this->set_admin_context();
+		$this->create_and_login_user();
+
+		$traits = $this->call_private_method( 'get_visitor_traits' );
+
+		$this->assertSame( 'test@example.com', $traits['email'] );
+		$this->assertArrayHasKey( 'site_id', $traits );
+		$this->assertArrayHasKey( 'site_type', $traits );
+		$this->assertSame( 'site-editor', $traits['editor_context'] );
+	}
+
+	/**
+	 * Tests that get_visitor_traits returns 'atomic' site_type when IS_ATOMIC is set.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	#[RunInSeparateProcess]
+	#[PreserveGlobalState( false )]
+	public function test_get_visitor_traits_returns_atomic_site_type() {
+		global $pagenow;
+		$pagenow = 'index.php';
+		$this->set_admin_context();
+		$this->create_and_login_user();
+
+		if ( ! defined( 'IS_ATOMIC' ) ) {
+			define( 'IS_ATOMIC', true );
+		}
+
+		$traits = $this->call_private_method( 'get_visitor_traits' );
+
+		$this->assertSame( 'atomic', $traits['site_type'] );
+	}
+
+	// ---- enqueue_scripts() tests ----
+
+	/**
+	 * Tests that enqueue_scripts does not enqueue when should_load returns false.
+	 */
+	public function test_enqueue_scripts_does_not_enqueue_when_not_logged_in() {
+		$this->set_admin_context();
+		wp_set_current_user( 0 );
+
+		$this->survicate->enqueue_scripts();
+
+		$this->assertFalse( wp_script_is( 'wpcom-survicate', 'enqueued' ) );
+	}
+
+	/**
+	 * Tests that enqueue_scripts does not enqueue for non-English locale.
+	 */
+	public function test_enqueue_scripts_does_not_enqueue_for_non_english_locale() {
+		$this->set_admin_context();
+		$this->create_and_login_user( 'fr_FR' );
+
+		$this->survicate->enqueue_scripts();
+
+		$this->assertFalse( wp_script_is( 'wpcom-survicate', 'enqueued' ) );
+	}
+
+	/**
+	 * Tests that enqueue_scripts registers the script and includes expected inline JS.
+	 */
+	public function test_enqueue_scripts_registers_script_with_expected_inline_js() {
+		$this->enqueue_survicate_scripts();
+
+		$this->assertTrue( wp_script_is( 'wpcom-survicate', 'enqueued' ) );
+
+		$inline_script = $this->get_inline_script();
+
+		$this->assertStringContainsString( Survicate::WORKSPACE_KEY, $inline_script );
+		$this->assertStringContainsString( 'window.innerWidth < 480', $inline_script );
+		$this->assertStringContainsString( 'SurvicateReady', $inline_script );
+		$this->assertStringContainsString( 'setVisitorTraits', $inline_script );
+		$this->assertStringContainsString( 'test@example.com', $inline_script );
+	}
+
+	// ---- Singleton tests ----
+
+	/**
+	 * Tests that the init method creates a singleton instance.
+	 */
+	public function test_init_creates_singleton_instance() {
+		$property = ( new \ReflectionClass( Survicate::class ) )->getProperty( 'instance' );
+
+		$dummy = $this->survicate;
+		$property->setValue( $dummy, null );
+
+		Survicate::init();
+		$instance1 = $property->getValue( $dummy );
+		$this->assertInstanceOf( Survicate::class, $instance1 );
+
+		Survicate::init();
+		$instance2 = $property->getValue( $dummy );
+		$this->assertSame( $instance1, $instance2 );
+
+		$property->setValue( $dummy, null );
+	}
+}


### PR DESCRIPTION
Fixes DOTCOM-15989

## Proposed changes:

* Add Survicate survey SDK integration for WordPress.com users in wp-admin contexts (admin pages, block editor, and site editor)
* Server-side guards: logged-in user, is_admin, English locale only
* Client-side guard: skips mobile viewports (< 480px)
* Sets visitor traits (email, site_id, site_type, editor_context) for survey targeting
* Uses the same Survicate workspace key as the existing Calypso integration

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

## Does this pull request change what data or activity we track or use?

This PR sends visitor traits (email, site_id, site_type, editor_context) to the Survicate survey SDK for survey targeting. This mirrors the existing Survicate integration in Calypso (`@automattic/survicate` package).

## Testing instructions

**Tip**: we can always reset our visitorId to see the survey in case we closed it:  `window._sva?.destroyVisitor?.();`
Log in as an English-locale WordPress.com user on a desktop browser:

- Apply it in your sandbox, redirect a simple site to it, open its /wp-admin, and add the `?test_survey=1` to the URL. It should appear:

<img width="1363" height="809" alt="image" src="https://github.com/user-attachments/assets/699f9319-5c9f-4098-9db6-f8e2742fa8e3" />

- Make sure it also works for the site editor:

<img width="1269" height="966" alt="image" src="https://github.com/user-attachments/assets/d0ed3441-cf95-4f57-a924-f96d8af1c836" />

- It should also work inside Gutenberg's Post/Page editor:

<img width="1431" height="778" alt="image" src="https://github.com/user-attachments/assets/9b70d57b-ab94-4c6f-941c-c0fbc3966eab" />

- It should work on Atomic sites as well (here's how to test: PCYsg-Osp-p2):

<img width="1330" height="830" alt="image" src="https://github.com/user-attachments/assets/87473736-3959-4fcc-ba45-56e015881e8c" />


### Negative tests

- Switch to a non-English locale user — Survicate should NOT load
- Resize browser below 480px width and reload — Survicate should NOT load
- Make sure we don't load it on the user's facing site (non WP-admin area):

<img width="1442" height="905" alt="image" src="https://github.com/user-attachments/assets/36aa76c2-f817-4f35-9555-0670ec20d689" />

### Survicate data test

- ~~In the console, verify `window._sva` exists and visitor traits are set (Paulo validated already)~~
- ~~IOpen a post in the block editor — verify `editor_context` trait is `block-editor` (Paulo validated already)~~
- ~~INavigate to Appearance > Editor — verify `editor_context` trait is `site-editor` (Paulo validated already)~~