### PR TITLE
Help Center - CIAB:  Allow multiple CSS to be enqueued

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/WOOPRD-2093-fix-help-in-editor
+++ b/projects/packages/jetpack-mu-wpcom/changelog/WOOPRD-2093-fix-help-in-editor
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+CIAB Editor: Ensure Help Center gutenber CSS can be loaded

--- a/projects/packages/jetpack-mu-wpcom/changelog/WOOPRD-2093-fix-help-in-editor
+++ b/projects/packages/jetpack-mu-wpcom/changelog/WOOPRD-2093-fix-help-in-editor
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-CIAB Editor: Ensure Help Center gutenber CSS can be loaded
+CIAB Editor: Ensure Help Center Gutenberg CSS can be loaded.

--- a/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-help-center.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-help-center.php
@@ -503,7 +503,7 @@ class Help_Center {
 		}
 
 		// widgets screen does have the block editor but also no Gutenberg top bar.
-		return $current_screen && $current_screen->is_block_editor() && $current_screen->id !== 'widgets';
+		return $current_screen->is_block_editor() && $current_screen->id !== 'widgets';
 	}
 
 	/**

--- a/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-help-center.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-help-center.php
@@ -253,7 +253,7 @@ class Help_Center {
 		);
 
 		wp_enqueue_style(
-			'help-center-style',
+			'help-center-' . $variant . '-style',
 			'https://widgets.wp.com/help-center/help-center-' . $variant . ( is_rtl() ? '.rtl.css' : '.css' ),
 			array(),
 			$version
@@ -497,6 +497,11 @@ class Help_Center {
 	 */
 	public function is_block_editor() {
 		global $current_screen;
+
+		if ( ! $current_screen ) {
+			return false;
+		}
+
 		// widgets screen does have the block editor but also no Gutenberg top bar.
 		return $current_screen && $current_screen->is_block_editor() && $current_screen->id !== 'widgets';
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Part of https://linear.app/a8c/issue/WOOPRD-2093/fix-help-in-editor

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* The CIAB editor loads both the ciab-admin CSS and the gutenberg CSS. For the Help Center to be styled correctly, we need the gutenberg CSS, but it was not loaded on the client side since the two handles for the two `wp_enqueue_style` were the same.
* With this, 2 CSS can be returned.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Have a CIAB website from MC tool
* Use site-gardener to develop the site, and in the local code that gets copied (repo_symlink) apply the same code as here
* Open the CIAB website trying to add a new page and open the Help Center

