### PR TITLE
Forms: Fix __experimentalLabel crash and show form title with status

### DIFF
--- a/projects/packages/forms/changelog/fix-experimental-label
+++ b/projects/packages/forms/changelog/fix-experimental-label
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Contact Form: Fix crash in block label function and display actual form title with status indicator.

--- a/projects/packages/forms/src/blocks/contact-form/index.js
+++ b/projects/packages/forms/src/blocks/contact-form/index.js
@@ -3,7 +3,7 @@ import { Path } from '@wordpress/components';
 import { store as coreStore } from '@wordpress/core-data';
 import { select } from '@wordpress/data';
 import { decodeEntities } from '@wordpress/html-entities';
-import { __, _x, sprintf } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import './editor.scss';
 import renderMaterialIcon from '../shared/components/render-material-icon.jsx';
 import { FORM_POST_TYPE } from '../shared/util/constants.js';
@@ -12,21 +12,10 @@ import blockMetadata from './block.json';
 import deprecated from './deprecated.js';
 import edit from './edit.tsx';
 import transforms from './transforms.js';
+import { DEFAULT_FORM_LABEL, extractTitleText, formatFormLabel } from './util/form-label.js';
 import variations from './variations.js';
 
 export const name = 'contact-form';
-
-/**
- * Status labels for non-published forms.
- * Hoisted to module level to avoid repeated allocations.
- */
-const STATUS_LABELS = {
-	draft: _x( 'Draft', 'form status', 'jetpack-forms' ),
-	pending: _x( 'Pending', 'form status', 'jetpack-forms' ),
-	future: _x( 'Scheduled', 'form status', 'jetpack-forms' ),
-	private: _x( 'Private', 'form status', 'jetpack-forms' ),
-	trash: _x( 'Trashed', 'form status', 'jetpack-forms' ),
-};
 
 /**
  * Get the label for a form block in List View.
@@ -38,39 +27,25 @@ const STATUS_LABELS = {
  * @param {number} props.ref - The form post ID (for synced forms)
  * @return {string} The label to display in List View
  */
-const getFormLabel = ( { ref } ) => {
-	const defaultLabel = __( 'Form', 'jetpack-forms' );
-
+export const getFormLabel = ( { ref } ) => {
 	if ( ! ref ) {
-		return defaultLabel;
+		return DEFAULT_FORM_LABEL;
 	}
 
 	const form = select( coreStore ).getEditedEntityRecord( 'postType', FORM_POST_TYPE, ref );
 
 	if ( ! form?.status ) {
-		return defaultLabel;
+		return DEFAULT_FORM_LABEL;
 	}
 
-	const rawTitle = form?.title;
+	const titleText = extractTitleText( form?.title );
+	const title = titleText ? decodeEntities( titleText ) : '';
 
-	// Handle both string and object formats for the title property
-	let titleText = '';
-	if ( typeof rawTitle === 'string' ) {
-		titleText = rawTitle;
-	} else if ( rawTitle && typeof rawTitle === 'object' && 'rendered' in rawTitle ) {
-		titleText = rawTitle.rendered;
-	}
-
-	const title = titleText ? decodeEntities( titleText ) : defaultLabel;
-	if ( form.status === 'publish' ) {
-		// translators: 1: Form title, e.g., "Contact Us"
-		return sprintf( __( 'Form: %1$s', 'jetpack-forms' ), title );
-	}
-
-	const statusLabel = STATUS_LABELS[ form.status ] || form.status;
-
-	/* translators: 1: Form title, 2: Form status (e.g., Draft, Scheduled) */
-	return sprintf( __( 'Form: %1$s (%2$s)', 'jetpack-forms' ), title, statusLabel );
+	return formatFormLabel( {
+		title,
+		status: form.status,
+		defaultLabel: DEFAULT_FORM_LABEL,
+	} );
 };
 
 const icon = renderMaterialIcon(

--- a/projects/packages/forms/src/blocks/contact-form/index.js
+++ b/projects/packages/forms/src/blocks/contact-form/index.js
@@ -1,8 +1,12 @@
 import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
 import { Path } from '@wordpress/components';
-import { __, _x } from '@wordpress/i18n';
+import { store as coreStore } from '@wordpress/core-data';
+import { select } from '@wordpress/data';
+import { decodeEntities } from '@wordpress/html-entities';
+import { __, _x, sprintf } from '@wordpress/i18n';
 import './editor.scss';
 import renderMaterialIcon from '../shared/components/render-material-icon.jsx';
+import { FORM_POST_TYPE } from '../shared/util/constants.js';
 import defaultAttributes from './attributes.ts';
 import blockMetadata from './block.json';
 import deprecated from './deprecated.js';
@@ -109,6 +113,28 @@ export const settings = {
 	transforms,
 	deprecated,
 	__experimentalLabel: ( { ref } ) => {
-		return ref ? __( 'Form', 'jetpack-forms' ) + ' (Synced)' : __( 'Form', 'jetpack-forms' );
+		if ( ! ref ) {
+			return;
+		}
+
+		const form = select( coreStore ).getEditedEntityRecord( 'postType', FORM_POST_TYPE, ref );
+		const title = form?.title ? decodeEntities( form.title ) : __( 'Form', 'jetpack-forms' );
+
+		if ( ! form?.status || form.status === 'publish' ) {
+			return title;
+		}
+
+		const statusLabels = {
+			draft: _x( 'Draft', 'form status', 'jetpack-forms' ),
+			pending: _x( 'Pending', 'form status', 'jetpack-forms' ),
+			future: _x( 'Scheduled', 'form status', 'jetpack-forms' ),
+			private: _x( 'Private', 'form status', 'jetpack-forms' ),
+			trash: _x( 'Trashed', 'form status', 'jetpack-forms' ),
+		};
+
+		const statusLabel = statusLabels[ form.status ] || form.status;
+
+		/* translators: 1: Form title, 2: Form status (e.g., Draft, Scheduled) */
+		return sprintf( __( '%1$s (%2$s)', 'jetpack-forms' ), title, statusLabel );
 	},
 };

--- a/projects/packages/forms/src/blocks/contact-form/index.js
+++ b/projects/packages/forms/src/blocks/contact-form/index.js
@@ -118,7 +118,14 @@ export const settings = {
 		}
 
 		const form = select( coreStore ).getEditedEntityRecord( 'postType', FORM_POST_TYPE, ref );
-		const title = form?.title ? decodeEntities( form.title ) : __( 'Form', 'jetpack-forms' );
+		const rawTitle = form?.title;
+		const titleText =
+			typeof rawTitle === 'string'
+				? rawTitle
+				: rawTitle && typeof rawTitle === 'object' && 'rendered' in rawTitle
+				? rawTitle.rendered
+				: '';
+		const title = titleText ? decodeEntities( titleText ) : __( 'Form', 'jetpack-forms' );
 
 		if ( ! form?.status || form.status === 'publish' ) {
 			return title;

--- a/projects/packages/forms/src/blocks/contact-form/index.js
+++ b/projects/packages/forms/src/blocks/contact-form/index.js
@@ -46,6 +46,11 @@ const getFormLabel = ( { ref } ) => {
 	}
 
 	const form = select( coreStore ).getEditedEntityRecord( 'postType', FORM_POST_TYPE, ref );
+
+	if ( ! form?.status ) {
+		return defaultLabel;
+	}
+
 	const rawTitle = form?.title;
 
 	// Handle both string and object formats for the title property
@@ -57,15 +62,15 @@ const getFormLabel = ( { ref } ) => {
 	}
 
 	const title = titleText ? decodeEntities( titleText ) : defaultLabel;
-
-	if ( ! form?.status || form.status === 'publish' ) {
-		return title;
+	if ( form.status === 'publish' ) {
+		// translators: 1: Form title, e.g., "Contact Us"
+		return sprintf( __( 'Form: %1$s', 'jetpack-forms' ), title );
 	}
 
 	const statusLabel = STATUS_LABELS[ form.status ] || form.status;
 
 	/* translators: 1: Form title, 2: Form status (e.g., Draft, Scheduled) */
-	return sprintf( __( '%1$s (%2$s)', 'jetpack-forms' ), title, statusLabel );
+	return sprintf( __( 'Form: %1$s (%2$s)', 'jetpack-forms' ), title, statusLabel );
 };
 
 const icon = renderMaterialIcon(

--- a/projects/packages/forms/src/blocks/contact-form/index.js
+++ b/projects/packages/forms/src/blocks/contact-form/index.js
@@ -16,6 +16,58 @@ import variations from './variations.js';
 
 export const name = 'contact-form';
 
+/**
+ * Status labels for non-published forms.
+ * Hoisted to module level to avoid repeated allocations.
+ */
+const STATUS_LABELS = {
+	draft: _x( 'Draft', 'form status', 'jetpack-forms' ),
+	pending: _x( 'Pending', 'form status', 'jetpack-forms' ),
+	future: _x( 'Scheduled', 'form status', 'jetpack-forms' ),
+	private: _x( 'Private', 'form status', 'jetpack-forms' ),
+	trash: _x( 'Trashed', 'form status', 'jetpack-forms' ),
+};
+
+/**
+ * Get the label for a form block in List View.
+ *
+ * For synced forms (with ref), displays the form title with status indicator.
+ * For inline forms (without ref), displays the default "Form" label.
+ *
+ * @param {object} props     - Block attributes
+ * @param {number} props.ref - The form post ID (for synced forms)
+ * @return {string} The label to display in List View
+ */
+const getFormLabel = ( { ref } ) => {
+	const defaultLabel = __( 'Form', 'jetpack-forms' );
+
+	if ( ! ref ) {
+		return defaultLabel;
+	}
+
+	const form = select( coreStore ).getEditedEntityRecord( 'postType', FORM_POST_TYPE, ref );
+	const rawTitle = form?.title;
+
+	// Handle both string and object formats for the title property
+	let titleText = '';
+	if ( typeof rawTitle === 'string' ) {
+		titleText = rawTitle;
+	} else if ( rawTitle && typeof rawTitle === 'object' && 'rendered' in rawTitle ) {
+		titleText = rawTitle.rendered;
+	}
+
+	const title = titleText ? decodeEntities( titleText ) : defaultLabel;
+
+	if ( ! form?.status || form.status === 'publish' ) {
+		return title;
+	}
+
+	const statusLabel = STATUS_LABELS[ form.status ] || form.status;
+
+	/* translators: 1: Form title, 2: Form status (e.g., Draft, Scheduled) */
+	return sprintf( __( '%1$s (%2$s)', 'jetpack-forms' ), title, statusLabel );
+};
+
 const icon = renderMaterialIcon(
 	<>
 		<Path fillRule="evenodd" clipRule="evenodd" d="M18 9H13V7.5H18V9Z" />
@@ -112,36 +164,7 @@ export const settings = {
 	category: 'contact-form',
 	transforms,
 	deprecated,
-	__experimentalLabel: ( { ref } ) => {
-		if ( ! ref ) {
-			return;
-		}
-
-		const form = select( coreStore ).getEditedEntityRecord( 'postType', FORM_POST_TYPE, ref );
-		const rawTitle = form?.title;
-		const titleText =
-			typeof rawTitle === 'string'
-				? rawTitle
-				: rawTitle && typeof rawTitle === 'object' && 'rendered' in rawTitle
-				? rawTitle.rendered
-				: '';
-		const title = titleText ? decodeEntities( titleText ) : __( 'Form', 'jetpack-forms' );
-
-		if ( ! form?.status || form.status === 'publish' ) {
-			return title;
-		}
-
-		const statusLabels = {
-			draft: _x( 'Draft', 'form status', 'jetpack-forms' ),
-			pending: _x( 'Pending', 'form status', 'jetpack-forms' ),
-			future: _x( 'Scheduled', 'form status', 'jetpack-forms' ),
-			private: _x( 'Private', 'form status', 'jetpack-forms' ),
-			trash: _x( 'Trashed', 'form status', 'jetpack-forms' ),
-		};
-
-		const statusLabel = statusLabels[ form.status ] || form.status;
-
-		/* translators: 1: Form title, 2: Form status (e.g., Draft, Scheduled) */
-		return sprintf( __( '%1$s (%2$s)', 'jetpack-forms' ), title, statusLabel );
-	},
+	// Custom label for List View - shows form title with status for synced forms
+	label: getFormLabel,
+	__experimentalLabel: getFormLabel, // Backwards compatibility with WP < 7.0
 };

--- a/projects/packages/forms/src/blocks/contact-form/util/form-label.js
+++ b/projects/packages/forms/src/blocks/contact-form/util/form-label.js
@@ -1,0 +1,67 @@
+/**
+ * Utility functions for generating form block labels in List View.
+ */
+
+import { __, _x, sprintf } from '@wordpress/i18n';
+
+/**
+ * Status labels for non-published forms.
+ * Maps post status to human-readable labels.
+ */
+export const STATUS_LABELS = {
+	draft: _x( 'Draft', 'form status', 'jetpack-forms' ),
+	pending: _x( 'Pending', 'form status', 'jetpack-forms' ),
+	future: _x( 'Scheduled', 'form status', 'jetpack-forms' ),
+	private: _x( 'Private', 'form status', 'jetpack-forms' ),
+	trash: _x( 'Trashed', 'form status', 'jetpack-forms' ),
+};
+
+/**
+ * Default label used when no form title is available.
+ */
+export const DEFAULT_FORM_LABEL = __( 'Form', 'jetpack-forms' );
+
+/**
+ * Extract title text from various WordPress title formats.
+ *
+ * WordPress entity records may return title as:
+ * - A string (when edited)
+ * - An object with `rendered` property (from REST API)
+ *
+ * @param {string|object|undefined} rawTitle - The raw title value
+ * @return {string} The extracted title text, or empty string if not found
+ */
+export function extractTitleText( rawTitle ) {
+	if ( typeof rawTitle === 'string' ) {
+		return rawTitle;
+	}
+
+	if ( rawTitle && typeof rawTitle === 'object' && 'rendered' in rawTitle ) {
+		return rawTitle.rendered;
+	}
+
+	return '';
+}
+
+/**
+ * Format the form label for display in List View.
+ *
+ * @param {object} options              - Formatting options
+ * @param {string} options.title        - The form title
+ * @param {string} options.status       - The form post status
+ * @param {string} options.defaultLabel - Default label if title is empty
+ * @return {string} The formatted label
+ */
+export function formatFormLabel( { title, status, defaultLabel = DEFAULT_FORM_LABEL } ) {
+	const displayTitle = title || defaultLabel;
+
+	if ( status === 'publish' ) {
+		/* translators: %s: Form title, e.g., "Contact Us" */
+		return sprintf( __( 'Form: %s', 'jetpack-forms' ), displayTitle );
+	}
+
+	const statusLabel = STATUS_LABELS[ status ] || status;
+
+	/* translators: 1: Form title, 2: Form status (e.g., Draft, Scheduled) */
+	return sprintf( __( 'Form: %1$s (%2$s)', 'jetpack-forms' ), displayTitle, statusLabel );
+}

--- a/projects/packages/forms/tests/js/contact-form/form-label.test.js
+++ b/projects/packages/forms/tests/js/contact-form/form-label.test.js
@@ -1,0 +1,156 @@
+/**
+ * Tests for form-label utility functions
+ */
+
+import { describe, expect, it, jest } from '@jest/globals';
+
+await jest.unstable_mockModule( '@wordpress/i18n', () => ( {
+	__: str => str,
+	_x: str => str,
+	sprintf: ( format, ...args ) => {
+		let result = format;
+		args.forEach( ( arg, index ) => {
+			result = result.replace( `%${ index + 1 }$s`, arg ).replace( '%s', arg );
+		} );
+		return result;
+	},
+} ) );
+
+const { extractTitleText, formatFormLabel, STATUS_LABELS, DEFAULT_FORM_LABEL } = await import(
+	'../../../src/blocks/contact-form/util/form-label'
+);
+
+describe( 'extractTitleText', () => {
+	it( 'returns the string when title is a string', () => {
+		expect( extractTitleText( 'My Form Title' ) ).toBe( 'My Form Title' );
+	} );
+
+	it( 'returns empty string for empty string input', () => {
+		expect( extractTitleText( '' ) ).toBe( '' );
+	} );
+
+	it( 'extracts rendered property from object', () => {
+		expect( extractTitleText( { rendered: 'Rendered Title' } ) ).toBe( 'Rendered Title' );
+	} );
+
+	it( 'returns empty string for object without rendered property', () => {
+		expect( extractTitleText( { other: 'value' } ) ).toBe( '' );
+	} );
+
+	it( 'returns empty string for undefined', () => {
+		expect( extractTitleText( undefined ) ).toBe( '' );
+	} );
+
+	it( 'returns empty string for null', () => {
+		expect( extractTitleText( null ) ).toBe( '' );
+	} );
+
+	it( 'returns empty string for number', () => {
+		expect( extractTitleText( 123 ) ).toBe( '' );
+	} );
+} );
+
+describe( 'formatFormLabel', () => {
+	it( 'formats published form with title', () => {
+		const result = formatFormLabel( {
+			title: 'Contact Us',
+			status: 'publish',
+		} );
+		expect( result ).toBe( 'Form: Contact Us' );
+	} );
+
+	it( 'uses default label when title is empty for published form', () => {
+		const result = formatFormLabel( {
+			title: '',
+			status: 'publish',
+			defaultLabel: 'Form',
+		} );
+		expect( result ).toBe( 'Form: Form' );
+	} );
+
+	it( 'formats draft form with title and status', () => {
+		const result = formatFormLabel( {
+			title: 'My Draft Form',
+			status: 'draft',
+		} );
+		expect( result ).toBe( 'Form: My Draft Form (Draft)' );
+	} );
+
+	it( 'formats pending form with title and status', () => {
+		const result = formatFormLabel( {
+			title: 'Pending Review',
+			status: 'pending',
+		} );
+		expect( result ).toBe( 'Form: Pending Review (Pending)' );
+	} );
+
+	it( 'formats scheduled form with title and status', () => {
+		const result = formatFormLabel( {
+			title: 'Future Form',
+			status: 'future',
+		} );
+		expect( result ).toBe( 'Form: Future Form (Scheduled)' );
+	} );
+
+	it( 'formats private form with title and status', () => {
+		const result = formatFormLabel( {
+			title: 'Secret Form',
+			status: 'private',
+		} );
+		expect( result ).toBe( 'Form: Secret Form (Private)' );
+	} );
+
+	it( 'formats trashed form with title and status', () => {
+		const result = formatFormLabel( {
+			title: 'Deleted Form',
+			status: 'trash',
+		} );
+		expect( result ).toBe( 'Form: Deleted Form (Trashed)' );
+	} );
+
+	it( 'uses raw status when status is unknown', () => {
+		const result = formatFormLabel( {
+			title: 'Custom Status Form',
+			status: 'custom-status',
+		} );
+		expect( result ).toBe( 'Form: Custom Status Form (custom-status)' );
+	} );
+
+	it( 'uses default label when title is empty for non-published form', () => {
+		const result = formatFormLabel( {
+			title: '',
+			status: 'draft',
+			defaultLabel: 'Form',
+		} );
+		expect( result ).toBe( 'Form: Form (Draft)' );
+	} );
+
+	it( 'uses DEFAULT_FORM_LABEL when defaultLabel not provided', () => {
+		const result = formatFormLabel( {
+			title: '',
+			status: 'publish',
+		} );
+		expect( result ).toBe( `Form: ${ DEFAULT_FORM_LABEL }` );
+	} );
+} );
+
+describe( 'STATUS_LABELS', () => {
+	it( 'has all expected status labels', () => {
+		expect( STATUS_LABELS ).toHaveProperty( 'draft' );
+		expect( STATUS_LABELS ).toHaveProperty( 'pending' );
+		expect( STATUS_LABELS ).toHaveProperty( 'future' );
+		expect( STATUS_LABELS ).toHaveProperty( 'private' );
+		expect( STATUS_LABELS ).toHaveProperty( 'trash' );
+	} );
+
+	it( 'does not have publish status (published forms show no status)', () => {
+		expect( STATUS_LABELS ).not.toHaveProperty( 'publish' );
+	} );
+} );
+
+describe( 'DEFAULT_FORM_LABEL', () => {
+	it( 'is defined', () => {
+		expect( DEFAULT_FORM_LABEL ).toBeDefined();
+		expect( typeof DEFAULT_FORM_LABEL ).toBe( 'string' );
+	} );
+} );


### PR DESCRIPTION
Before:
<img width="365" height="56" alt="Screenshot 2026-02-12 at 3 53 29 PM" src="https://github.com/user-attachments/assets/cdec2aa6-f3ee-4dcd-a947-6a09e244392e" />


After:
<img width="371" height="151" alt="Screenshot 2026-02-13 at 8 46 05 AM" src="https://github.com/user-attachments/assets/1f473db1-d9b4-44fe-ae5f-b2247fbbbfef" />


## Proposed changes:
- Fix a crash in the contact-form block's `__experimentalLabel` function where `form` (an object) was incorrectly called as a function
- Display the actual form title in the block list view instead of generic "Form (Synced)" text
- Show form status (Draft, Scheduled, Pending, Private, Trashed) for non-published forms
- Use proper i18n with `sprintf` and translator context for status labels

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
N/A

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Enable CFM 
```
add_filter( 'jetpack_block_editor_feature_flags', 'eb_register_feature' );
function eb_register_feature( $flags ) {
    $flags['central-form-management'] = ! isset( $_GET[  'not-cfm' ] );
    return $flags;
}
```

1. Create a new post or page in the block editor
2. Add a Form block (synced form)
3. Open the List View panel (Document Overview)
4. Verify the form displays its actual title instead of "Form (Synced)"
5. If the form is in draft status, verify it shows the title with "(Draft)" appended