### PR TITLE
Charts: fix broken layout in ConversionFunnelChart CustomRenderProps story

### DIFF
--- a/projects/js-packages/charts/changelog/charts-167-story-layout
+++ b/projects/js-packages/charts/changelog/charts-167-story-layout
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Fix Storybook story layout, no user-facing changes
+
+

--- a/projects/js-packages/charts/src/charts/conversion-funnel-chart/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/charts/conversion-funnel-chart/stories/index.stories.tsx
@@ -257,6 +257,7 @@ export const CustomRenderProps: Story = {
 			</div>
 		),
 	},
+	decorators: [ Story => <Story /> ],
 };
 
 export const WithoutTooltips: Story = {

--- a/projects/js-packages/charts/src/charts/conversion-funnel-chart/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/charts/conversion-funnel-chart/stories/index.stories.tsx
@@ -147,6 +147,7 @@ export const CustomRenderProps: Story = {
 					marginBottom: '32px',
 					color: 'white',
 					textAlign: 'center',
+					height: 'fit-content',
 				} }
 			>
 				<h3
@@ -256,7 +257,6 @@ export const CustomRenderProps: Story = {
 			</div>
 		),
 	},
-	decorators: [ Story => <Story /> ],
 };
 
 export const WithoutTooltips: Story = {


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/CHARTS-167

## Proposed changes:
* Fixed broken layout in the ConversionFunnelChart CustomRenderProps Storybook story by adding `height: fit-content` to the custom main metric section

The CustomRenderProps story had a broken layout where the custom main metric section (with gradient background) was expanding beyond its intended bounds. The issue was that the custom-rendered main metric needed an explicit height constraint in its inline styles.

### Other information:

- [x] Have you written new tests for your changes, if applicable? (No tests needed - Storybook documentation fix)
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Testing instructions:

1. Run Storybook locally: `pnpm --filter @automattic/jetpack-charts storybook`
2. Navigate to the "JS Packages/Charts Library/Charts/Conversion Funnel Chart" section
3. Select the "Custom Render Props" story
4. Verify that the custom gradient metric section is properly sized and doesn't expand beyond its container
5. Verify that the layout displays correctly with the custom styling

**Before:** The custom main metric section expanded vertically beyond its intended bounds
**After:** The custom main metric section is properly constrained with `height: fit-content`