### PR TITLE
CHARTS-171 - Charts: relocate visx tooltip portals for correct z-index stacking

### DIFF
--- a/projects/js-packages/charts/changelog/fix-charts-tooltip-portal-relocator
+++ b/projects/js-packages/charts/changelog/fix-charts-tooltip-portal-relocator
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Relocated visx tooltip portals from document.body into the chart container to fix z-index stacking issues with sticky headers and other positioned elements.
+Relocate visx tooltip portals from document.body into the chart container to fix z-index stacking issues with sticky headers and other positioned elements.

--- a/projects/js-packages/charts/changelog/fix-charts-tooltip-portal-relocator
+++ b/projects/js-packages/charts/changelog/fix-charts-tooltip-portal-relocator
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Relocated visx tooltip portals from document.body into the chart container to fix z-index stacking issues with sticky headers and other positioned elements.

--- a/projects/js-packages/charts/src/hooks/index.ts
+++ b/projects/js-packages/charts/src/hooks/index.ts
@@ -9,3 +9,4 @@ export { useTextTruncation } from './use-text-truncation';
 export { useZeroValueDisplay } from './use-zero-value-display';
 export { useInteractiveLegendData } from './use-interactive-legend-data';
 export { usePrefersReducedMotion } from './use-prefers-reduced-motion';
+export { useTooltipPortalRelocator } from './use-tooltip-portal-relocator';

--- a/projects/js-packages/charts/src/hooks/test/use-tooltip-portal-relocator.test.ts
+++ b/projects/js-packages/charts/src/hooks/test/use-tooltip-portal-relocator.test.ts
@@ -2,6 +2,15 @@
 import { renderHook } from '@testing-library/react';
 import { useTooltipPortalRelocator } from '../use-tooltip-portal-relocator';
 
+// In the production build, CSS module class names are hashed (e.g. "a8ccharts-abc123").
+// In jest, the SCSS module import is stubbed to a filename string, so
+// styles.relocatedPortal resolves to undefined and classList.add() is a no-op.
+// We mock the module to return a proper class map so we can assert on class names.
+jest.mock( '../use-tooltip-portal-relocator.module.scss', () => ( {
+	__esModule: true,
+	default: { relocatedPortal: 'relocatedPortal' },
+} ) );
+
 /**
  * Create a mock visx tooltip portal node for testing.
  * @return {HTMLDivElement} A div mimicking a visx tooltip portal.
@@ -12,6 +21,29 @@ function createVisxPortalNode(): HTMLDivElement {
 	child.className = 'visx-tooltip';
 	portal.appendChild( child );
 	return portal;
+}
+
+/**
+ * Sets up a container, ref, and renders the hook.
+ * Optionally appends a visx portal node to document.body before rendering.
+ * @param options - Setup options.
+ * @param options.withPortal - If true, creates and appends a visx portal before rendering.
+ * @return Setup result with container, ref, unmount, and optionally the portal node.
+ */
+function setupHook( { withPortal = false } = {} ) {
+	const container = document.createElement( 'div' );
+	document.body.appendChild( container );
+
+	let portal: HTMLDivElement | undefined;
+	if ( withPortal ) {
+		portal = createVisxPortalNode();
+		document.body.appendChild( portal );
+	}
+
+	const ref = { current: container };
+	const { unmount } = renderHook( () => useTooltipPortalRelocator( ref ) );
+
+	return { container, ref, unmount, portal };
 }
 
 describe( 'useTooltipPortalRelocator', () => {
@@ -48,58 +80,33 @@ describe( 'useTooltipPortalRelocator', () => {
 	} );
 
 	test( 'relocates existing visx portal nodes into the container', () => {
-		const container = document.createElement( 'div' );
-		document.body.appendChild( container );
-		const portal = createVisxPortalNode();
-		document.body.appendChild( portal );
-
-		const ref = { current: container };
-		const { unmount } = renderHook( () => useTooltipPortalRelocator( ref ) );
-
-		expect( portal.parentNode ).toBe( container );
+		const { container, unmount, portal } = setupHook( { withPortal: true } );
+		expect( portal!.parentNode ).toBe( container );
 		unmount();
 	} );
 
-	test( 'applies correct positioning styles to relocated portals', () => {
-		const container = document.createElement( 'div' );
-		document.body.appendChild( container );
-		const portal = createVisxPortalNode();
-		document.body.appendChild( portal );
-
-		const ref = { current: container };
-		const { unmount } = renderHook( () => useTooltipPortalRelocator( ref ) );
-
-		expect( portal ).toHaveStyle( { position: 'fixed' } );
-		expect( portal ).toHaveStyle( { top: '0px' } );
-		expect( portal ).toHaveStyle( { left: '0px' } );
-		expect( portal ).toHaveStyle( { width: '0px' } );
-		expect( portal ).toHaveStyle( { height: '0px' } );
-		expect( portal ).toHaveStyle( { overflow: 'visible' } );
-		expect( portal ).toHaveStyle( { zIndex: '1' } );
-		expect( portal ).toHaveStyle( { pointerEvents: 'none' } );
+	test( 'applies relocated-portal class to relocated portals', () => {
+		const { unmount, portal } = setupHook( { withPortal: true } );
+		expect( portal!.classList.contains( 'relocatedPortal' ) ).toBe( true );
 		unmount();
 	} );
 
-	test( 'does not relocate non-visx nodes', () => {
-		const container = document.createElement( 'div' );
-		document.body.appendChild( container );
+	test( 'does not relocate newly added non-visx nodes', async () => {
+		const { unmount } = setupHook();
+
 		const regularDiv = document.createElement( 'div' );
 		regularDiv.id = 'some-id';
 		document.body.appendChild( regularDiv );
 
-		const ref = { current: container };
-		const { unmount } = renderHook( () => useTooltipPortalRelocator( ref ) );
+		// MutationObserver is async — wait for microtask
+		await new Promise( resolve => setTimeout( resolve, 0 ) );
 
 		expect( regularDiv.parentNode ).toBe( document.body );
 		unmount();
 	} );
 
 	test( 'observes and relocates newly added portal nodes', async () => {
-		const container = document.createElement( 'div' );
-		document.body.appendChild( container );
-
-		const ref = { current: container };
-		const { unmount } = renderHook( () => useTooltipPortalRelocator( ref ) );
+		const { container, unmount } = setupHook();
 
 		const portal = createVisxPortalNode();
 		document.body.appendChild( portal );
@@ -112,27 +119,16 @@ describe( 'useTooltipPortalRelocator', () => {
 	} );
 
 	test( 'patched removeChild handles relocated nodes without throwing', () => {
-		const container = document.createElement( 'div' );
-		document.body.appendChild( container );
-		const portal = createVisxPortalNode();
-		document.body.appendChild( portal );
-
-		const ref = { current: container };
-		const { unmount } = renderHook( () => useTooltipPortalRelocator( ref ) );
+		const { unmount, portal } = setupHook( { withPortal: true } );
 
 		// Portal is now in container, but visx will call document.body.removeChild(portal)
-		expect( portal.parentNode ).toBe( container );
-		expect( () => document.body.removeChild( portal ) ).not.toThrow();
-		expect( portal.parentNode ).toBeNull();
+		expect( () => document.body.removeChild( portal! ) ).not.toThrow();
+		expect( portal!.parentNode ).toBeNull();
 		unmount();
 	} );
 
 	test( 'patched removeChild delegates to original for non-relocated nodes', () => {
-		const container = document.createElement( 'div' );
-		document.body.appendChild( container );
-
-		const ref = { current: container };
-		const { unmount } = renderHook( () => useTooltipPortalRelocator( ref ) );
+		const { unmount } = setupHook();
 
 		const regularDiv = document.createElement( 'div' );
 		document.body.appendChild( regularDiv );
@@ -142,12 +138,8 @@ describe( 'useTooltipPortalRelocator', () => {
 	} );
 
 	test( 'cleanup restores removeChild when it has not been wrapped by others', () => {
-		const container = document.createElement( 'div' );
-		document.body.appendChild( container );
-
 		const originalRemoveChild = document.body.removeChild;
-		const ref = { current: container };
-		const { unmount } = renderHook( () => useTooltipPortalRelocator( ref ) );
+		const { unmount } = setupHook();
 
 		// removeChild should be patched
 		expect( document.body.removeChild ).not.toBe( originalRemoveChild );
@@ -159,11 +151,7 @@ describe( 'useTooltipPortalRelocator', () => {
 	} );
 
 	test( 'cleanup leaves removeChild when another wrapper was installed after ours', () => {
-		const container = document.createElement( 'div' );
-		document.body.appendChild( container );
-
-		const ref = { current: container };
-		const { unmount } = renderHook( () => useTooltipPortalRelocator( ref ) );
+		const { unmount } = setupHook();
 
 		// Simulate another library wrapping removeChild after our patch
 		const ourPatch = document.body.removeChild;
@@ -179,20 +167,24 @@ describe( 'useTooltipPortalRelocator', () => {
 	} );
 
 	test( 'cleanup moves relocated nodes back to document.body', () => {
-		const container = document.createElement( 'div' );
-		document.body.appendChild( container );
-		const portal = createVisxPortalNode();
-		document.body.appendChild( portal );
+		const { container, unmount, portal } = setupHook( { withPortal: true } );
 
-		const ref = { current: container };
-		const { unmount } = renderHook( () => useTooltipPortalRelocator( ref ) );
-
-		expect( portal.parentNode ).toBe( container );
+		expect( portal!.parentNode ).toBe( container );
 
 		unmount();
 
 		// Node should be moved back to body on cleanup
-		expect( portal.parentNode ).toBe( document.body );
+		expect( portal!.parentNode ).toBe( document.body );
+	} );
+
+	test( 'cleanup removes relocated-portal class from nodes', () => {
+		const { unmount, portal } = setupHook( { withPortal: true } );
+
+		expect( portal!.classList.contains( 'relocatedPortal' ) ).toBe( true );
+
+		unmount();
+
+		expect( portal!.classList.contains( 'relocatedPortal' ) ).toBe( false );
 	} );
 
 	test( 'ref-counting allows multiple instances to share the patch', () => {

--- a/projects/js-packages/charts/src/hooks/test/use-tooltip-portal-relocator.test.ts
+++ b/projects/js-packages/charts/src/hooks/test/use-tooltip-portal-relocator.test.ts
@@ -26,8 +26,8 @@ function createVisxPortalNode(): HTMLDivElement {
 /**
  * Sets up a container, ref, and renders the hook.
  * Optionally appends a visx portal node to document.body before rendering.
- * @param  options              - Setup options.
- * @param  options.withPortal   - If true, creates and appends a visx portal before rendering.
+ * @param options            - Setup options.
+ * @param options.withPortal - If true, creates and appends a visx portal before rendering.
  * @return                      Setup result with container, ref, unmount, and optionally the portal node.
  */
 function setupHook( { withPortal = false } = {} ) {

--- a/projects/js-packages/charts/src/hooks/test/use-tooltip-portal-relocator.test.ts
+++ b/projects/js-packages/charts/src/hooks/test/use-tooltip-portal-relocator.test.ts
@@ -1,0 +1,224 @@
+/* eslint-disable testing-library/no-node-access */
+import { renderHook } from '@testing-library/react';
+import { useTooltipPortalRelocator } from '../use-tooltip-portal-relocator';
+
+/**
+ * Create a mock visx tooltip portal node for testing.
+ * @return {HTMLDivElement} A div mimicking a visx tooltip portal.
+ */
+function createVisxPortalNode(): HTMLDivElement {
+	const portal = document.createElement( 'div' );
+	const child = document.createElement( 'div' );
+	child.className = 'visx-tooltip';
+	portal.appendChild( child );
+	return portal;
+}
+
+describe( 'useTooltipPortalRelocator', () => {
+	let nativeRemoveChild: typeof document.body.removeChild;
+
+	beforeAll( () => {
+		nativeRemoveChild = document.body.removeChild;
+	} );
+
+	afterEach( () => {
+		// Restore native removeChild and clear all body children to prevent
+		// leaked portals from interfering with subsequent tests.
+		document.body.removeChild = nativeRemoveChild;
+		while ( document.body.firstChild ) {
+			nativeRemoveChild.call( document.body, document.body.firstChild );
+		}
+	} );
+
+	test( 'does nothing when containerRef is undefined', () => {
+		const { unmount } = renderHook( () => useTooltipPortalRelocator( undefined ) );
+		const portal = createVisxPortalNode();
+		document.body.appendChild( portal );
+		expect( portal.parentNode ).toBe( document.body );
+		unmount();
+	} );
+
+	test( 'does nothing when containerRef.current is null', () => {
+		const nullRef = { current: null };
+		const { unmount } = renderHook( () => useTooltipPortalRelocator( nullRef ) );
+		const portal = createVisxPortalNode();
+		document.body.appendChild( portal );
+		expect( portal.parentNode ).toBe( document.body );
+		unmount();
+	} );
+
+	test( 'relocates existing visx portal nodes into the container', () => {
+		const container = document.createElement( 'div' );
+		document.body.appendChild( container );
+		const portal = createVisxPortalNode();
+		document.body.appendChild( portal );
+
+		const ref = { current: container };
+		const { unmount } = renderHook( () => useTooltipPortalRelocator( ref ) );
+
+		expect( portal.parentNode ).toBe( container );
+		unmount();
+	} );
+
+	test( 'applies correct positioning styles to relocated portals', () => {
+		const container = document.createElement( 'div' );
+		document.body.appendChild( container );
+		const portal = createVisxPortalNode();
+		document.body.appendChild( portal );
+
+		const ref = { current: container };
+		const { unmount } = renderHook( () => useTooltipPortalRelocator( ref ) );
+
+		expect( portal ).toHaveStyle( { position: 'fixed' } );
+		expect( portal ).toHaveStyle( { top: '0px' } );
+		expect( portal ).toHaveStyle( { left: '0px' } );
+		expect( portal ).toHaveStyle( { width: '0px' } );
+		expect( portal ).toHaveStyle( { height: '0px' } );
+		expect( portal ).toHaveStyle( { overflow: 'visible' } );
+		expect( portal ).toHaveStyle( { zIndex: '1' } );
+		expect( portal ).toHaveStyle( { pointerEvents: 'none' } );
+		unmount();
+	} );
+
+	test( 'does not relocate non-visx nodes', () => {
+		const container = document.createElement( 'div' );
+		document.body.appendChild( container );
+		const regularDiv = document.createElement( 'div' );
+		regularDiv.id = 'some-id';
+		document.body.appendChild( regularDiv );
+
+		const ref = { current: container };
+		const { unmount } = renderHook( () => useTooltipPortalRelocator( ref ) );
+
+		expect( regularDiv.parentNode ).toBe( document.body );
+		unmount();
+	} );
+
+	test( 'observes and relocates newly added portal nodes', async () => {
+		const container = document.createElement( 'div' );
+		document.body.appendChild( container );
+
+		const ref = { current: container };
+		const { unmount } = renderHook( () => useTooltipPortalRelocator( ref ) );
+
+		const portal = createVisxPortalNode();
+		document.body.appendChild( portal );
+
+		// MutationObserver is async — wait for microtask
+		await new Promise( resolve => setTimeout( resolve, 0 ) );
+
+		expect( portal.parentNode ).toBe( container );
+		unmount();
+	} );
+
+	test( 'patched removeChild handles relocated nodes without throwing', () => {
+		const container = document.createElement( 'div' );
+		document.body.appendChild( container );
+		const portal = createVisxPortalNode();
+		document.body.appendChild( portal );
+
+		const ref = { current: container };
+		const { unmount } = renderHook( () => useTooltipPortalRelocator( ref ) );
+
+		// Portal is now in container, but visx will call document.body.removeChild(portal)
+		expect( portal.parentNode ).toBe( container );
+		expect( () => document.body.removeChild( portal ) ).not.toThrow();
+		expect( portal.parentNode ).toBeNull();
+		unmount();
+	} );
+
+	test( 'patched removeChild delegates to original for non-relocated nodes', () => {
+		const container = document.createElement( 'div' );
+		document.body.appendChild( container );
+
+		const ref = { current: container };
+		const { unmount } = renderHook( () => useTooltipPortalRelocator( ref ) );
+
+		const regularDiv = document.createElement( 'div' );
+		document.body.appendChild( regularDiv );
+		expect( () => document.body.removeChild( regularDiv ) ).not.toThrow();
+		expect( regularDiv.parentNode ).toBeNull();
+		unmount();
+	} );
+
+	test( 'cleanup restores removeChild when it has not been wrapped by others', () => {
+		const container = document.createElement( 'div' );
+		document.body.appendChild( container );
+
+		const originalRemoveChild = document.body.removeChild;
+		const ref = { current: container };
+		const { unmount } = renderHook( () => useTooltipPortalRelocator( ref ) );
+
+		// removeChild should be patched
+		expect( document.body.removeChild ).not.toBe( originalRemoveChild );
+
+		unmount();
+
+		// Should be restored
+		expect( document.body.removeChild ).toBe( originalRemoveChild );
+	} );
+
+	test( 'cleanup leaves removeChild when another wrapper was installed after ours', () => {
+		const container = document.createElement( 'div' );
+		document.body.appendChild( container );
+
+		const ref = { current: container };
+		const { unmount } = renderHook( () => useTooltipPortalRelocator( ref ) );
+
+		// Simulate another library wrapping removeChild after our patch
+		const ourPatch = document.body.removeChild;
+		const thirdPartyWrapper = function < T extends Node >( child: T ): T {
+			return ourPatch.call( document.body, child );
+		};
+		document.body.removeChild = thirdPartyWrapper;
+
+		unmount();
+
+		// Should NOT restore — third party wrapper is still in place
+		expect( document.body.removeChild ).toBe( thirdPartyWrapper );
+	} );
+
+	test( 'cleanup moves relocated nodes back to document.body', () => {
+		const container = document.createElement( 'div' );
+		document.body.appendChild( container );
+		const portal = createVisxPortalNode();
+		document.body.appendChild( portal );
+
+		const ref = { current: container };
+		const { unmount } = renderHook( () => useTooltipPortalRelocator( ref ) );
+
+		expect( portal.parentNode ).toBe( container );
+
+		unmount();
+
+		// Node should be moved back to body on cleanup
+		expect( portal.parentNode ).toBe( document.body );
+	} );
+
+	test( 'ref-counting allows multiple instances to share the patch', () => {
+		const container1 = document.createElement( 'div' );
+		const container2 = document.createElement( 'div' );
+		document.body.appendChild( container1 );
+		document.body.appendChild( container2 );
+
+		const ref1 = { current: container1 };
+		const ref2 = { current: container2 };
+
+		const originalRemoveChild = document.body.removeChild;
+
+		const { unmount: unmountFirst } = renderHook( () => useTooltipPortalRelocator( ref1 ) );
+		const patchedFn = document.body.removeChild;
+		const { unmount: unmountSecond } = renderHook( () => useTooltipPortalRelocator( ref2 ) );
+
+		// Both should share the same patched removeChild
+		expect( document.body.removeChild ).toBe( patchedFn );
+
+		// Unmounting the first should keep the patch (ref count > 0)
+		unmountFirst();
+		expect( document.body.removeChild ).toBe( patchedFn );
+
+		// Unmounting the second should restore the original
+		unmountSecond();
+		expect( document.body.removeChild ).toBe( originalRemoveChild );
+	} );
+} );

--- a/projects/js-packages/charts/src/hooks/test/use-tooltip-portal-relocator.test.ts
+++ b/projects/js-packages/charts/src/hooks/test/use-tooltip-portal-relocator.test.ts
@@ -26,9 +26,9 @@ function createVisxPortalNode(): HTMLDivElement {
 /**
  * Sets up a container, ref, and renders the hook.
  * Optionally appends a visx portal node to document.body before rendering.
- * @param options - Setup options.
- * @param options.withPortal - If true, creates and appends a visx portal before rendering.
- * @return Setup result with container, ref, unmount, and optionally the portal node.
+ * @param  options              - Setup options.
+ * @param  options.withPortal   - If true, creates and appends a visx portal before rendering.
+ * @return                      Setup result with container, ref, unmount, and optionally the portal node.
  */
 function setupHook( { withPortal = false } = {} ) {
 	const container = document.createElement( 'div' );
@@ -87,7 +87,7 @@ describe( 'useTooltipPortalRelocator', () => {
 
 	test( 'applies relocated-portal class to relocated portals', () => {
 		const { unmount, portal } = setupHook( { withPortal: true } );
-		expect( portal!.classList.contains( 'relocatedPortal' ) ).toBe( true );
+		expect( portal! ).toHaveClass( 'relocatedPortal' );
 		unmount();
 	} );
 
@@ -180,11 +180,11 @@ describe( 'useTooltipPortalRelocator', () => {
 	test( 'cleanup removes relocated-portal class from nodes', () => {
 		const { unmount, portal } = setupHook( { withPortal: true } );
 
-		expect( portal!.classList.contains( 'relocatedPortal' ) ).toBe( true );
+		expect( portal! ).toHaveClass( 'relocatedPortal' );
 
 		unmount();
 
-		expect( portal!.classList.contains( 'relocatedPortal' ) ).toBe( false );
+		expect( portal! ).not.toHaveClass( 'relocatedPortal' );
 	} );
 
 	test( 'ref-counting allows multiple instances to share the patch', () => {

--- a/projects/js-packages/charts/src/hooks/use-tooltip-portal-relocator.module.scss
+++ b/projects/js-packages/charts/src/hooks/use-tooltip-portal-relocator.module.scss
@@ -1,0 +1,10 @@
+.relocatedPortal {
+	position: fixed;
+	top: 0;
+	left: 0;
+	width: 0;
+	height: 0;
+	overflow: visible;
+	z-index: 1;
+	pointer-events: none;
+}

--- a/projects/js-packages/charts/src/hooks/use-tooltip-portal-relocator.ts
+++ b/projects/js-packages/charts/src/hooks/use-tooltip-portal-relocator.ts
@@ -1,0 +1,107 @@
+import { useEffect } from 'react';
+import type { RefObject } from 'react';
+
+/**
+ * Detects whether a DOM node is a visx chart tooltip portal.
+ *
+ * visx renders tooltips via `ReactDOM.createPortal` into plain `<div>` elements
+ * appended to `document.body`. These portals have no id or className and contain
+ * child elements with visx-specific classes (e.g. `.visx-tooltip-portal`).
+ * @param node - The DOM node to check.
+ * @return Whether the node is a visx tooltip portal div.
+ */
+function isVisxPortalNode( node: Node ): node is HTMLDivElement {
+	return (
+		node instanceof HTMLDivElement &&
+		node.parentElement === document.body &&
+		! node.id &&
+		! node.className &&
+		node.querySelector( '[class*="visx"]' ) !== null
+	);
+}
+
+/**
+ * Relocates visx chart tooltip portals from `document.body` into a target
+ * container element. This allows the tooltips to participate in the same CSS
+ * stacking context as other elements in the container (e.g. a sticky header),
+ * so z-index ordering works correctly between them.
+ *
+ * The relocated portal divs use `position: fixed` at the viewport origin to
+ * preserve the tooltip coordinate system (visx calculates positions relative
+ * to the viewport).
+ *
+ * Because the visx Portal class calls `document.body.removeChild(node)` during
+ * unmount, we patch `document.body.removeChild` to gracefully handle nodes that
+ * were moved out of body. Without this, React throws a "not a child of this
+ * node" error when tooltips unmount.
+ *
+ * @param containerRef - Ref to the element that portals should be relocated into.
+ *                     The container should use `position: relative; z-index: 0`
+ *                     to create a stacking context.
+ */
+export function useTooltipPortalRelocator(
+	containerRef: RefObject< HTMLElement | null > | undefined
+) {
+	useEffect( () => {
+		const container = containerRef?.current;
+		if ( ! container ) {
+			return;
+		}
+
+		// Track nodes we've relocated so we can intercept their removal.
+		const relocatedNodes = new WeakSet< Node >();
+
+		const relocateNode = ( node: Node ) => {
+			if ( ! isVisxPortalNode( node ) ) {
+				return;
+			}
+			// Position the portal at the viewport origin so visx's
+			// absolute-positioned tooltip coordinates remain correct.
+			node.style.position = 'fixed';
+			node.style.top = '0';
+			node.style.left = '0';
+			node.style.width = '0';
+			node.style.height = '0';
+			node.style.overflow = 'visible';
+			node.style.zIndex = '1';
+			node.style.pointerEvents = 'none';
+
+			// Insert at the start of the container (before header and content).
+			container.insertBefore( node, container.firstChild );
+			relocatedNodes.add( node );
+		};
+
+		// Patch document.body.removeChild so visx Portal unmount doesn't throw
+		// when it tries to remove a node we already moved out of body.
+		const origRemoveChild = document.body.removeChild;
+		document.body.removeChild = function < T extends Node >( child: T ): T {
+			if ( relocatedNodes.has( child ) && child.parentNode !== this ) {
+				relocatedNodes.delete( child );
+				child.parentNode?.removeChild( child );
+				return child;
+			}
+			return origRemoveChild.call( this, child );
+		};
+
+		// Relocate any portals that already exist.
+		for ( const child of Array.from( document.body.children ) ) {
+			relocateNode( child );
+		}
+
+		// Watch for new portals being appended to body.
+		const observer = new MutationObserver( mutations => {
+			for ( const mutation of mutations ) {
+				for ( const node of mutation.addedNodes ) {
+					relocateNode( node );
+				}
+			}
+		} );
+
+		observer.observe( document.body, { childList: true } );
+
+		return () => {
+			observer.disconnect();
+			document.body.removeChild = origRemoveChild;
+		};
+	}, [ containerRef ] );
+}

--- a/projects/js-packages/charts/src/hooks/use-tooltip-portal-relocator.ts
+++ b/projects/js-packages/charts/src/hooks/use-tooltip-portal-relocator.ts
@@ -6,7 +6,7 @@ import type { RefObject } from 'react';
  *
  * visx renders tooltips via `ReactDOM.createPortal` into plain `<div>` elements
  * appended to `document.body`. These portals have no id or className and contain
- * child elements with visx-specific classes (e.g. `.visx-tooltip-portal`).
+ * a child element with the class `visx-tooltip-portal`.
  * @param node - The DOM node to check.
  * @return Whether the node is a visx tooltip portal div.
  */
@@ -16,8 +16,53 @@ function isVisxPortalNode( node: Node ): node is HTMLDivElement {
 		node.parentElement === document.body &&
 		! node.id &&
 		! node.className &&
-		node.querySelector( '[class*="visx"]' ) !== null
+		node.querySelector( '.visx-tooltip-portal' ) !== null
 	);
+}
+
+// Shared state for the document.body.removeChild patch.
+// Reference-counted so multiple hook instances can coexist safely.
+let patchRefCount = 0;
+let origRemoveChild: typeof document.body.removeChild | null = null;
+let patchedRemoveChild: typeof document.body.removeChild | null = null;
+const relocatedNodes = new WeakSet< Node >();
+
+/**
+ * Installs (or increments the ref count of) the shared removeChild patch.
+ */
+function installRemoveChildPatch() {
+	if ( patchRefCount++ > 0 ) {
+		return;
+	}
+	origRemoveChild = document.body.removeChild;
+	patchedRemoveChild = function < T extends Node >( this: HTMLElement, child: T ): T {
+		if ( relocatedNodes.has( child ) && child.parentNode !== this ) {
+			relocatedNodes.delete( child );
+			child.parentNode?.removeChild( child );
+			return child;
+		}
+		return origRemoveChild!.call( this, child );
+	};
+	document.body.removeChild = patchedRemoveChild;
+}
+
+/**
+ * Decrements the ref count and removes the patch when no instances remain.
+ * If another library has since wrapped our patch, we leave it in place to
+ * avoid breaking their chain — our function becomes a transparent pass-through
+ * once all relocated nodes have been cleaned up.
+ */
+function uninstallRemoveChildPatch() {
+	if ( --patchRefCount > 0 ) {
+		return;
+	}
+	// Only revert if removeChild is still our function. If something else
+	// has wrapped it, reverting would break their patch.
+	if ( document.body.removeChild === patchedRemoveChild ) {
+		document.body.removeChild = origRemoveChild!;
+	}
+	origRemoveChild = null;
+	patchedRemoveChild = null;
 }
 
 /**
@@ -35,6 +80,10 @@ function isVisxPortalNode( node: Node ): node is HTMLDivElement {
  * were moved out of body. Without this, React throws a "not a child of this
  * node" error when tooltips unmount.
  *
+ * **Important:** The container and its ancestors must not have CSS `transform`,
+ * `perspective`, or `filter` properties set, as these create a new containing
+ * block for `position: fixed` children, breaking viewport-relative positioning.
+ *
  * @param containerRef - Ref to the element that portals should be relocated into.
  *                     The container should use `position: relative; z-index: 0`
  *                     to create a stacking context.
@@ -48,8 +97,8 @@ export function useTooltipPortalRelocator(
 			return;
 		}
 
-		// Track nodes we've relocated so we can intercept their removal.
-		const relocatedNodes = new WeakSet< Node >();
+		// Track nodes relocated by this instance so we can move them back on cleanup.
+		const instanceNodes = new Set< Node >();
 
 		const relocateNode = ( node: Node ) => {
 			if ( ! isVisxPortalNode( node ) ) {
@@ -58,6 +107,9 @@ export function useTooltipPortalRelocator(
 
 			// Position the portal at the viewport origin so visx's
 			// absolute-positioned tooltip coordinates remain correct.
+			// Zero-size with overflow: visible so it doesn't affect layout
+			// but tooltip content still renders. pointerEvents: none on the
+			// wrapper is intentional — tooltip inner elements manage their own.
 			Object.assign( node.style, {
 				position: 'fixed',
 				top: '0',
@@ -72,19 +124,12 @@ export function useTooltipPortalRelocator(
 			// Insert at the start of the container (before header and content).
 			container.insertBefore( node, container.firstChild );
 			relocatedNodes.add( node );
+			instanceNodes.add( node );
 		};
 
 		// Patch document.body.removeChild so visx Portal unmount doesn't throw
 		// when it tries to remove a node we already moved out of body.
-		const origRemoveChild = document.body.removeChild;
-		document.body.removeChild = function < T extends Node >( child: T ): T {
-			if ( relocatedNodes.has( child ) && child.parentNode !== this ) {
-				relocatedNodes.delete( child );
-				child.parentNode?.removeChild( child );
-				return child;
-			}
-			return origRemoveChild.call( this, child );
-		};
+		installRemoveChildPatch();
 
 		// Relocate any portals that already exist.
 		for ( const child of Array.from( document.body.children ) ) {
@@ -103,8 +148,21 @@ export function useTooltipPortalRelocator(
 		observer.observe( document.body, { childList: true } );
 
 		return () => {
+			// Disconnect first to avoid the observer re-relocating nodes
+			// as we move them back to body.
 			observer.disconnect();
-			document.body.removeChild = origRemoveChild;
+
+			// Move relocated nodes back to body so visx can clean them up
+			// normally with the original removeChild.
+			for ( const node of instanceNodes ) {
+				if ( node.parentNode === container ) {
+					document.body.appendChild( node );
+				}
+				relocatedNodes.delete( node );
+			}
+			instanceNodes.clear();
+
+			uninstallRemoveChildPatch();
 		};
 	}, [ containerRef ] );
 }

--- a/projects/js-packages/charts/src/hooks/use-tooltip-portal-relocator.ts
+++ b/projects/js-packages/charts/src/hooks/use-tooltip-portal-relocator.ts
@@ -6,7 +6,7 @@ import type { RefObject } from 'react';
  *
  * visx renders tooltips via `ReactDOM.createPortal` into plain `<div>` elements
  * appended to `document.body`. These portals have no id or className and contain
- * a child element with the class `visx-tooltip-portal`.
+ * a child element with the class `visx-tooltip`.
  * @param node - The DOM node to check.
  * @return Whether the node is a visx tooltip portal div.
  */
@@ -16,7 +16,7 @@ function isVisxPortalNode( node: Node ): node is HTMLDivElement {
 		node.parentElement === document.body &&
 		! node.id &&
 		! node.className &&
-		node.querySelector( '.visx-tooltip-portal' ) !== null
+		node.querySelector( '.visx-tooltip' ) !== null
 	);
 }
 

--- a/projects/js-packages/charts/src/hooks/use-tooltip-portal-relocator.ts
+++ b/projects/js-packages/charts/src/hooks/use-tooltip-portal-relocator.ts
@@ -55,16 +55,19 @@ export function useTooltipPortalRelocator(
 			if ( ! isVisxPortalNode( node ) ) {
 				return;
 			}
+
 			// Position the portal at the viewport origin so visx's
 			// absolute-positioned tooltip coordinates remain correct.
-			node.style.position = 'fixed';
-			node.style.top = '0';
-			node.style.left = '0';
-			node.style.width = '0';
-			node.style.height = '0';
-			node.style.overflow = 'visible';
-			node.style.zIndex = '1';
-			node.style.pointerEvents = 'none';
+			Object.assign( node.style, {
+				position: 'fixed',
+				top: '0',
+				left: '0',
+				width: '0',
+				height: '0',
+				overflow: 'visible',
+				zIndex: '1',
+				pointerEvents: 'none',
+			} );
 
 			// Insert at the start of the container (before header and content).
 			container.insertBefore( node, container.firstChild );

--- a/projects/js-packages/charts/src/hooks/use-tooltip-portal-relocator.ts
+++ b/projects/js-packages/charts/src/hooks/use-tooltip-portal-relocator.ts
@@ -121,10 +121,23 @@ export function useTooltipPortalRelocator(
 				pointerEvents: 'none',
 			} );
 
+			// Remember the focused element before moving the node — relocating
+			// a DOM subtree causes the browser to blur any focused descendants.
+			const { activeElement } = node.ownerDocument;
+			const focusedElement =
+				activeElement instanceof HTMLElement && node.contains( activeElement )
+					? activeElement
+					: null;
+
 			// Insert at the start of the container (before header and content).
 			container.insertBefore( node, container.firstChild );
 			relocatedNodes.add( node );
 			instanceNodes.add( node );
+
+			// Restore focus that was lost due to the DOM move.
+			if ( focusedElement ) {
+				focusedElement.focus();
+			}
 		};
 
 		// Patch document.body.removeChild so visx Portal unmount doesn't throw

--- a/projects/js-packages/charts/src/hooks/use-tooltip-portal-relocator.ts
+++ b/projects/js-packages/charts/src/hooks/use-tooltip-portal-relocator.ts
@@ -1,4 +1,5 @@
 import { useEffect } from 'react';
+import styles from './use-tooltip-portal-relocator.module.scss';
 import type { RefObject } from 'react';
 
 /**
@@ -85,8 +86,9 @@ function uninstallRemoveChildPatch() {
  * block for `position: fixed` children, breaking viewport-relative positioning.
  *
  * @param containerRef - Ref to the element that portals should be relocated into.
- *                     The container should use `position: relative; z-index: 0`
- *                     to create a stacking context.
+ *                     The element referenced here, or one of its ancestors,
+ *                     should establish the desired stacking context (for example
+ *                     by using position and z-index).
  */
 export function useTooltipPortalRelocator(
 	containerRef: RefObject< HTMLElement | null > | undefined
@@ -110,16 +112,7 @@ export function useTooltipPortalRelocator(
 			// Zero-size with overflow: visible so it doesn't affect layout
 			// but tooltip content still renders. pointerEvents: none on the
 			// wrapper is intentional — tooltip inner elements manage their own.
-			Object.assign( node.style, {
-				position: 'fixed',
-				top: '0',
-				left: '0',
-				width: '0',
-				height: '0',
-				overflow: 'visible',
-				zIndex: '1',
-				pointerEvents: 'none',
-			} );
+			node.classList.add( styles.relocatedPortal );
 
 			// Remember the focused element before moving the node — relocating
 			// a DOM subtree causes the browser to blur any focused descendants.
@@ -168,6 +161,9 @@ export function useTooltipPortalRelocator(
 			// Move relocated nodes back to body so visx can clean them up
 			// normally with the original removeChild.
 			for ( const node of instanceNodes ) {
+				if ( node instanceof HTMLElement ) {
+					node.classList.remove( styles.relocatedPortal );
+				}
 				if ( node.parentNode === container ) {
 					document.body.appendChild( node );
 				}

--- a/projects/js-packages/charts/src/providers/chart-context/global-charts-provider.tsx
+++ b/projects/js-packages/charts/src/providers/chart-context/global-charts-provider.tsx
@@ -30,8 +30,10 @@ export interface GlobalChartsProviderProps {
 	/**
 	 * Optional ref to an element that chart tooltip portals should be relocated into.
 	 * When provided, visx tooltip portals (normally appended to document.body) will be
-	 * moved into this container, placing them in the same CSS stacking context.
-	 * The container should have `position: relative` to create a stacking context.
+	 * moved into this container so they participate in the same effective CSS stacking context.
+	 * The element referenced here, or one of its ancestors, should establish the desired
+	 * stacking context (for example by using `position` and `z-index`) so that tooltips
+	 * appear above the relevant chart content.
 	 */
 	portalContainer?: React.RefObject< HTMLElement | null >;
 }

--- a/projects/js-packages/charts/src/providers/chart-context/global-charts-provider.tsx
+++ b/projects/js-packages/charts/src/providers/chart-context/global-charts-provider.tsx
@@ -8,6 +8,7 @@ import {
 	useLayoutEffect,
 	useRef,
 } from 'react';
+import { useTooltipPortalRelocator } from '../../hooks/use-tooltip-portal-relocator';
 import {
 	getItemShapeStyles,
 	getSeriesLineStyles,
@@ -26,9 +27,20 @@ export const GlobalChartsContext = createContext< GlobalChartsContextValue | nul
 export interface GlobalChartsProviderProps {
 	children: ReactNode;
 	theme?: Partial< ChartTheme >;
+	/**
+	 * Optional ref to an element that chart tooltip portals should be relocated into.
+	 * When provided, visx tooltip portals (normally appended to document.body) will be
+	 * moved into this container, placing them in the same CSS stacking context.
+	 * The container should have `position: relative` to create a stacking context.
+	 */
+	portalContainer?: React.RefObject< HTMLElement | null >;
 }
 
-export const GlobalChartsProvider: FC< GlobalChartsProviderProps > = ( { children, theme } ) => {
+export const GlobalChartsProvider: FC< GlobalChartsProviderProps > = ( {
+	children,
+	theme,
+	portalContainer,
+} ) => {
 	const [ charts, setCharts ] = useState< Map< string, ChartRegistration > >( () => new Map() );
 	// Track hidden series per chart: chartId -> Set<seriesLabel>
 	const [ hiddenSeries, setHiddenSeries ] = useState< Map< string, Set< string > > >(
@@ -37,6 +49,9 @@ export const GlobalChartsProvider: FC< GlobalChartsProviderProps > = ( { childre
 
 	// Ref to the wrapper element for resolving scoped CSS variables
 	const wrapperRef = useRef< HTMLDivElement >( null );
+
+	// Relocate tooltip portals into the wrapper (or a consumer-provided container) for z-index control.
+	useTooltipPortalRelocator( portalContainer ?? wrapperRef );
 
 	const providerTheme: CompleteChartTheme = useMemo( () => {
 		return theme ? mergeThemes( defaultTheme, theme ) : defaultTheme;


### PR DESCRIPTION
Fixes CHARTS-171

## Proposed changes:

Visx's `XyChart` renders tooltips via `ReactDOM.createPortal` into plain `<div>` elements appended directly to `document.body`. Because these portals live outside the component tree's DOM hierarchy, they exist in a completely separate CSS stacking context from the rest of the page. This makes it impossible to control z-index ordering between chart tooltips and other UI elements like sticky headers or modals — no matter what z-index you set on a sticky header, the tooltip portals on `document.body` don't participate in the same stacking context, so they can render above or below unpredictably.

This PR adds a `useTooltipPortalRelocator` hook that solves this by:

* **Detecting visx tooltip portals** — Identifies the anonymous `<div>` wrappers that visx appends to `document.body` by checking for a `.visx-tooltip-portal` child element.
* **Relocating them into a container** — Moves detected portals into a target container element (either the `GlobalChartsProvider` wrapper or a consumer-provided ref), so they share the same CSS stacking context as the chart and surrounding UI.
* **Preserving tooltip positioning** — Applies `position: fixed` at the viewport origin to relocated portals so visx's viewport-relative tooltip coordinates continue to work correctly.
* **Patching `removeChild` for safe unmount** — Since visx's Portal class calls `document.body.removeChild(node)` during cleanup, the hook patches `document.body.removeChild` to gracefully handle nodes that were moved out of `body`. The patch is reference-counted so multiple hook instances can coexist safely.
* **Clean teardown** — On unmount, the observer is disconnected, relocated nodes are moved back to `body`, and the `removeChild` patch is removed (if no other instances remain).

The hook is integrated into `GlobalChartsProvider` by default (using its wrapper div ref) and also accepts an optional `portalContainer` prop for consumers who need a specific stacking context target.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

* Render a chart component (e.g., `PieChart`, `LineChart`) inside a layout that has a sticky header or other z-indexed elements.
* Hover over chart data points to trigger tooltips.
* Verify that tooltips appear with correct z-index stacking relative to the sticky header — they should no longer render above/below unpredictably.
* Verify tooltip positioning is still accurate (no offset or jump when hovering).
* Unmount/remount the chart component and verify no console errors related to `removeChild`.