### PR TITLE
Bundle boot, theme and route in Jetpack

### DIFF
--- a/projects/packages/forms/tools/webpack.config.dashboard.js
+++ b/projects/packages/forms/tools/webpack.config.dashboard.js
@@ -137,6 +137,10 @@ export default {
 					// Bundle the package with our assets until WP core exposes wp-admin-ui.
 					'@wordpress/admin-ui': { external: false },
 					'@wordpress/admin-ui/build-style/style.css': { external: false },
+					// Bundle these packages that aren't in WordPress core yet
+					'@wordpress/boot': { external: false },
+					'@wordpress/theme': { external: false },
+					'@wordpress/route': { external: false },
 					// Bundle jetpack-connection since it's used by IntegrationsModal
 					'@automattic/jetpack-connection': { external: false },
 				},


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Local alternative to upstream change: 
- https://github.com/WordPress/gutenberg/pull/75504

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*  Bundle boot, theme and route in Jetpack Forms package.

TODO: move up to Jetpack config, this doesn't need to be forms specific.
 
### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

