### PR TITLE
FORNO-188:  Image Studio: Add jetpack.ai.imageGenerationHandler filter for Featured Image entrypoint

### DIFF
--- a/projects/plugins/jetpack/changelog/add-image-generation-handler-filter
+++ b/projects/plugins/jetpack/changelog/add-image-generation-handler-filter
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+AI Sidebar: Add `jetpack.ai.imageGenerationHandler` filter to allow external plugins (e.g. Image Studio) to replace the built-in AI image generation flow for the "Get Featured Image" entry point.

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/index.tsx
@@ -32,7 +32,7 @@ import {
 import { applyFilters } from '@wordpress/hooks';
 import { __ } from '@wordpress/i18n';
 import debugFactory from 'debug';
-import { ComponentType } from 'react';
+import { ComponentType, useCallback, useMemo } from 'react';
 /**
  * Internal dependencies
  */
@@ -93,13 +93,21 @@ const JetpackAndSettingsContent = ( {
 	const isPostEmpty = useSelect( select => select( editorStore ).isEditedPostEmpty(), [] );
 	const { editPost } = useDispatch( editorStore );
 
-	const imageGenerationHandler = applyFilters( 'jetpack.ai.imageGenerationHandler', null, {
-		entryPoint: 'featured-image',
-		onImageSelect: ( image: { id: number; url: string; mime?: string } ) => {
+	const onImageSelect = useCallback(
+		( image: { id: number; url: string; mime?: string } ) => {
 			editPost( { featured_media: image.id } );
 		},
-		extra: { placement, disabled: requireUpgrade },
-	} ) as ( () => void ) | null;
+		[ editPost ]
+	);
+
+	const imageGenerationHandler = useMemo( () => {
+		const result = applyFilters( 'jetpack.ai.imageGenerationHandler', null, {
+			entryPoint: 'featured-image',
+			onImageSelect,
+			extra: { placement, disabled: requireUpgrade },
+		} );
+		return typeof result === 'function' ? ( result as () => void ) : null;
+	}, [ onImageSelect, placement, requireUpgrade ] );
 
 	const currentTitleOptimizationSectionLabel = __( 'Optimize Publishing', 'jetpack' );
 	const SEOTitleOptimizationSectionLabel = __( 'Optimize Title', 'jetpack' );

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/index.tsx
@@ -100,6 +100,30 @@ const JetpackAndSettingsContent = ( {
 		[ editPost ]
 	);
 
+	/**
+	 * Filters the image generation handler for AI-powered image creation entry points.
+	 *
+	 * Allows external plugins (e.g. Image Studio) to provide a custom handler that
+	 * replaces the default image generation UI. When a handler is returned, it is
+	 * called to open the external image generation flow instead of the built-in one.
+	 *
+	 * @param {Function|null} handler                 - The handler function, or null if no handler is registered.
+	 * @param {object}        options                 - Options describing the entry point context.
+	 * @param {string}        options.entryPoint      - Identifies the UI location (e.g. 'featured-image').
+	 * @param {Function}      options.onImageSelect   - Callback invoked with the selected image ({ id, url, mime? }).
+	 * @param {object}        options.extra           - Additional context for the handler.
+	 * @param {string}        options.extra.placement - The placement identifier for the entry point.
+	 * @param {boolean}       options.extra.disabled  - Whether the handler should be disabled (e.g. upgrade required).
+	 * @return {Function|null} A function to invoke the image generation flow, or null to use the default behavior.
+	 *
+	 * @example
+	 * // Register a custom image generation handler from an external plugin.
+	 * import { addFilter } from '@wordpress/hooks';
+	 *
+	 * addFilter( 'jetpack.ai.imageGenerationHandler', 'my-plugin/image-studio', ( handler, options ) => {
+	 *     return () => openImageStudio( options.entryPoint, options.onImageSelect );
+	 * } );
+	 */
 	const imageGenerationHandler = useMemo( () => {
 		const result = applyFilters( 'jetpack.ai.imageGenerationHandler', null, {
 			entryPoint: 'featured-image',

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/index.tsx
@@ -14,14 +14,22 @@ import {
 	usePlanType,
 } from '@automattic/jetpack-shared-extension-utils';
 import { JetpackEditorPanelLogo } from '@automattic/jetpack-shared-extension-utils/components';
-import { PanelBody, PanelRow, BaseControl, ExternalLink, Notice } from '@wordpress/components';
+import {
+	PanelBody,
+	PanelRow,
+	BaseControl,
+	Button,
+	ExternalLink,
+	Notice,
+} from '@wordpress/components';
 import { store as coreStore } from '@wordpress/core-data';
-import { useSelect } from '@wordpress/data';
+import { useSelect, useDispatch } from '@wordpress/data';
 import {
 	PluginPrePublishPanel,
 	PluginDocumentSettingPanel,
 	store as editorStore,
 } from '@wordpress/editor';
+import { applyFilters } from '@wordpress/hooks';
 import { __ } from '@wordpress/i18n';
 import debugFactory from 'debug';
 import { ComponentType } from 'react';
@@ -83,6 +91,15 @@ const JetpackAndSettingsContent = ( {
 	const { productPageUrl } = useAiProductPage();
 	const isBreveAvailable = getBreveAvailability();
 	const isPostEmpty = useSelect( select => select( editorStore ).isEditedPostEmpty(), [] );
+	const { editPost } = useDispatch( editorStore );
+
+	const imageGenerationHandler = applyFilters( 'jetpack.ai.imageGenerationHandler', null, {
+		entryPoint: 'featured-image',
+		onImageSelect: ( image: { id: number; url: string; mime?: string } ) => {
+			editPost( { featured_media: image.id } );
+		},
+		extra: { placement, disabled: requireUpgrade },
+	} ) as ( () => void ) | null;
 
 	const currentTitleOptimizationSectionLabel = __( 'Optimize Publishing', 'jetpack' );
 	const SEOTitleOptimizationSectionLabel = __( 'Optimize Title', 'jetpack' );
@@ -128,13 +145,23 @@ const JetpackAndSettingsContent = ( {
 				</PanelRow>
 			) }
 
-			{ isAIFeaturedImageAvailable && (
+			{ ( imageGenerationHandler || isAIFeaturedImageAvailable ) && (
 				<PanelRow className="jetpack-ai-sidebar__feature-section">
 					<BaseControl __nextHasNoMarginBottom={ true }>
 						<BaseControl.VisualLabel>
 							{ __( 'Get Featured Image', 'jetpack' ) }
 						</BaseControl.VisualLabel>
-						<FeaturedImage busy={ false } disabled={ requireUpgrade } placement={ placement } />
+						{ imageGenerationHandler ? (
+							<Button
+								onClick={ imageGenerationHandler }
+								variant="secondary"
+								disabled={ requireUpgrade }
+							>
+								{ __( 'Generate image', 'jetpack' ) }
+							</Button>
+						) : (
+							<FeaturedImage busy={ false } disabled={ requireUpgrade } placement={ placement } />
+						) }
 					</BaseControl>
 				</PanelRow>
 			) }

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/test/index.test.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/test/index.test.tsx
@@ -1,32 +1,15 @@
-/* eslint-disable import/order */
-// Component import must come after jest.mock() calls to ensure mocks are applied
-import { render, screen } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { applyFilters } from '@wordpress/hooks';
+import AiAssistantPluginSidebar from '..';
 
-// Mock functions
-const mockApplyFilters = jest.fn();
 const mockEditPost = jest.fn();
 const mockRecordEvent = jest.fn();
 
-// Set up window.Jetpack_Editor_Initial_State before importing the component
-Object.defineProperty( window, 'Jetpack_Editor_Initial_State', {
-	value: {
-		available_blocks: {
-			'ai-assistant-usage-panel': { available: false },
-			'ai-featured-image-generator': { available: true },
-			'ai-title-optimization': { available: false },
-			'ai-title-optimization-keywords-support': { available: false },
-		},
-	},
-	writable: true,
-} );
-
-// Mock @wordpress/hooks
 jest.mock( '@wordpress/hooks', () => ( {
-	applyFilters: ( ...args: unknown[] ) => mockApplyFilters( ...args ),
+	applyFilters: jest.fn(),
 } ) );
 
-// Mock @wordpress/data
 jest.mock( '@wordpress/data', () => ( {
 	useSelect: ( selector: ( select: ( store: string ) => unknown ) => unknown ) => {
 		const stores: Record< string, unknown > = {
@@ -48,7 +31,6 @@ jest.mock( '@wordpress/data', () => ( {
 	},
 } ) );
 
-// Mock @automattic/jetpack-ai-client
 jest.mock( '@automattic/jetpack-ai-client', () => ( {
 	useAICheckout: () => ( { checkoutUrl: 'https://checkout.example.com' } ),
 	useAiFeature: () => ( {
@@ -61,7 +43,6 @@ jest.mock( '@automattic/jetpack-ai-client', () => ( {
 	FeaturedImage: () => <button>Generate using AI</button>,
 } ) );
 
-// Mock @automattic/jetpack-shared-extension-utils
 jest.mock( '@automattic/jetpack-shared-extension-utils', () => ( {
 	useAnalytics: () => ( { tracks: { recordEvent: mockRecordEvent } } ),
 	PLAN_TYPE_FREE: 'free',
@@ -73,7 +54,6 @@ jest.mock( '@automattic/jetpack-shared-extension-utils/components', () => ( {
 	JetpackEditorPanelLogo: () => <span>Logo</span>,
 } ) );
 
-// Mock @wordpress/editor
 jest.mock( '@wordpress/editor', () => ( {
 	PluginPrePublishPanel: ( { children }: { children: React.ReactNode } ) => (
 		<div data-testid="pre-publish-panel">{ children }</div>
@@ -84,7 +64,6 @@ jest.mock( '@wordpress/editor', () => ( {
 	store: 'core/editor',
 } ) );
 
-// Mock @wordpress/components
 jest.mock( '@wordpress/components', () => ( {
 	PanelBody: ( {
 		children,
@@ -139,12 +118,23 @@ jest.mock( '@wordpress/components', () => ( {
 	Notice: ( { children }: { children: React.ReactNode } ) => <div>{ children }</div>,
 } ) );
 
-// Mock @wordpress/core-data
-jest.mock( '@wordpress/core-data', () => ( {
-	store: 'core',
-} ) );
+jest.mock( '@wordpress/core-data', () => {
+	// Runs before imports due to jest.mock hoisting; the component reads this at module scope
+	Object.defineProperty( globalThis, 'Jetpack_Editor_Initial_State', {
+		value: {
+			available_blocks: {
+				'ai-assistant-usage-panel': { available: false },
+				'ai-featured-image-generator': { available: true },
+				'ai-title-optimization': { available: false },
+				'ai-title-optimization-keywords-support': { available: false },
+			},
+		},
+		writable: true,
+		configurable: true,
+	} );
+	return { store: 'core' };
+} );
 
-// Mock internal dependencies
 jest.mock( '../../../../../blocks/ai-assistant/hooks/use-ai-product-page', () => () => ( {
 	productPageUrl: 'https://product.example.com',
 } ) );
@@ -177,20 +167,17 @@ jest.mock( '../../usage-panel', () => ( { __esModule: true, default: () => null 
 jest.mock( '../upgrade', () => ( { __esModule: true, default: () => null } ) );
 jest.mock( '../style.scss', () => ( {} ) );
 
-// Import the component after all mocks are set up
-import AiAssistantPluginSidebar from '..';
-
 describe( 'AiAssistantPluginSidebar', () => {
 	beforeEach( () => {
 		jest.clearAllMocks();
-		mockApplyFilters.mockReturnValue( null );
+		jest.mocked( applyFilters ).mockReturnValue( null );
 	} );
 
 	describe( 'imageGenerationHandler filter', () => {
 		it( 'should call applyFilters with correct arguments for featured-image entry point', () => {
 			render( <AiAssistantPluginSidebar /> );
 
-			expect( mockApplyFilters ).toHaveBeenCalledWith(
+			expect( applyFilters ).toHaveBeenCalledWith(
 				'jetpack.ai.imageGenerationHandler',
 				null,
 				expect.objectContaining( {
@@ -206,11 +193,10 @@ describe( 'AiAssistantPluginSidebar', () => {
 
 		it( 'should render custom "Generate image" button when filter provides a handler', () => {
 			const mockHandler = jest.fn();
-			mockApplyFilters.mockReturnValue( mockHandler );
+			jest.mocked( applyFilters ).mockReturnValue( mockHandler );
 
 			render( <AiAssistantPluginSidebar /> );
 
-			// Should show the "Generate image" button from the filter handler
 			expect( screen.getAllByRole( 'button', { name: 'Generate image' } ).length ).toBeGreaterThan(
 				0
 			);
@@ -219,15 +205,31 @@ describe( 'AiAssistantPluginSidebar', () => {
 		it( 'should call custom handler when clicking "Generate image" button', async () => {
 			const user = userEvent.setup();
 			const mockHandler = jest.fn();
-			mockApplyFilters.mockReturnValue( mockHandler );
+			jest.mocked( applyFilters ).mockReturnValue( mockHandler );
 
 			render( <AiAssistantPluginSidebar /> );
 
-			// Click the first "Generate image" button (from document panel)
-			const generateButtons = screen.getAllByRole( 'button', { name: 'Generate image' } );
-			await user.click( generateButtons[ 0 ] );
+			const documentPanel = screen.getByTestId( 'document-panel' );
+			const generateButton = within( documentPanel ).getByRole( 'button', {
+				name: 'Generate image',
+			} );
+			await user.click( generateButton );
 
 			expect( mockHandler ).toHaveBeenCalled();
+		} );
+
+		it( 'should render FeaturedImage component when filter returns null and isAIFeaturedImageAvailable is true', () => {
+			jest.mocked( applyFilters ).mockReturnValue( null );
+
+			render( <AiAssistantPluginSidebar /> );
+
+			const documentPanel = screen.getByTestId( 'document-panel' );
+			expect(
+				within( documentPanel ).getByRole( 'button', { name: 'Generate using AI' } )
+			).toBeInTheDocument();
+			expect(
+				within( documentPanel ).queryByRole( 'button', { name: 'Generate image' } )
+			).not.toBeInTheDocument();
 		} );
 
 		it( 'should call editPost with featured_media when onImageSelect is called', () => {
@@ -235,7 +237,7 @@ describe( 'AiAssistantPluginSidebar', () => {
 				| ( ( image: { id: number; url: string; mime?: string } ) => void )
 				| null = null;
 
-			mockApplyFilters.mockImplementation(
+			( applyFilters as jest.Mock ).mockImplementation(
 				(
 					filterName: string,
 					defaultValue: unknown,
@@ -250,32 +252,14 @@ describe( 'AiAssistantPluginSidebar', () => {
 
 			render( <AiAssistantPluginSidebar /> );
 
-			// Simulate external handler calling onImageSelect
-			if ( capturedOnImageSelect ) {
-				capturedOnImageSelect( {
-					id: 123,
-					url: 'https://example.com/generated-image.png',
-					mime: 'image/png',
-				} );
-			}
+			expect( capturedOnImageSelect ).not.toBeNull();
+			capturedOnImageSelect!( {
+				id: 123,
+				url: 'https://example.com/generated-image.png',
+				mime: 'image/png',
+			} );
 
 			expect( mockEditPost ).toHaveBeenCalledWith( { featured_media: 123 } );
-		} );
-
-		it( 'should show Generate image button when filter provides handler', () => {
-			// When imageGenerationHandler is provided via filter, the component shows
-			// the custom "Generate image" button instead of the default FeaturedImage component.
-			// This test verifies the condition (imageGenerationHandler || isAIFeaturedImageAvailable)
-			// works correctly when imageGenerationHandler is truthy.
-			const mockHandler = jest.fn();
-			mockApplyFilters.mockReturnValue( mockHandler );
-
-			render( <AiAssistantPluginSidebar /> );
-
-			// With the handler provided, the "Generate image" button should be visible
-			expect( screen.getAllByRole( 'button', { name: 'Generate image' } ).length ).toBeGreaterThan(
-				0
-			);
 		} );
 	} );
 } );

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/test/index.test.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/test/index.test.tsx
@@ -1,0 +1,281 @@
+/* eslint-disable import/order */
+// Component import must come after jest.mock() calls to ensure mocks are applied
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+// Mock functions
+const mockApplyFilters = jest.fn();
+const mockEditPost = jest.fn();
+const mockRecordEvent = jest.fn();
+
+// Set up window.Jetpack_Editor_Initial_State before importing the component
+Object.defineProperty( window, 'Jetpack_Editor_Initial_State', {
+	value: {
+		available_blocks: {
+			'ai-assistant-usage-panel': { available: false },
+			'ai-featured-image-generator': { available: true },
+			'ai-title-optimization': { available: false },
+			'ai-title-optimization-keywords-support': { available: false },
+		},
+	},
+	writable: true,
+} );
+
+// Mock @wordpress/hooks
+jest.mock( '@wordpress/hooks', () => ( {
+	applyFilters: ( ...args: unknown[] ) => mockApplyFilters( ...args ),
+} ) );
+
+// Mock @wordpress/data
+jest.mock( '@wordpress/data', () => ( {
+	useSelect: ( selector: ( select: ( store: string ) => unknown ) => unknown ) => {
+		const stores: Record< string, unknown > = {
+			'core/editor': {
+				getCurrentPostType: () => 'post',
+				isEditedPostEmpty: () => false,
+			},
+			core: {
+				getPostType: () => ( { viewable: true } ),
+			},
+		};
+		return selector( ( store: string ) => stores[ store ] );
+	},
+	useDispatch: ( store: string ) => {
+		if ( store === 'core/editor' ) {
+			return { editPost: mockEditPost };
+		}
+		return {};
+	},
+} ) );
+
+// Mock @automattic/jetpack-ai-client
+jest.mock( '@automattic/jetpack-ai-client', () => ( {
+	useAICheckout: () => ( { checkoutUrl: 'https://checkout.example.com' } ),
+	useAiFeature: () => ( {
+		requireUpgrade: false,
+		upgradeType: 'default',
+		currentTier: { value: 1 },
+		isOverLimit: false,
+	} ),
+	FairUsageNotice: () => null,
+	FeaturedImage: () => <button>Generate using AI</button>,
+} ) );
+
+// Mock @automattic/jetpack-shared-extension-utils
+jest.mock( '@automattic/jetpack-shared-extension-utils', () => ( {
+	useAnalytics: () => ( { tracks: { recordEvent: mockRecordEvent } } ),
+	PLAN_TYPE_FREE: 'free',
+	PLAN_TYPE_UNLIMITED: 'unlimited',
+	usePlanType: () => 'free',
+} ) );
+
+jest.mock( '@automattic/jetpack-shared-extension-utils/components', () => ( {
+	JetpackEditorPanelLogo: () => <span>Logo</span>,
+} ) );
+
+// Mock @wordpress/editor
+jest.mock( '@wordpress/editor', () => ( {
+	PluginPrePublishPanel: ( { children }: { children: React.ReactNode } ) => (
+		<div data-testid="pre-publish-panel">{ children }</div>
+	),
+	PluginDocumentSettingPanel: ( { children }: { children: React.ReactNode } ) => (
+		<div data-testid="document-panel">{ children }</div>
+	),
+	store: 'core/editor',
+} ) );
+
+// Mock @wordpress/components
+jest.mock( '@wordpress/components', () => ( {
+	PanelBody: ( {
+		children,
+		title,
+	}: {
+		children: React.ReactNode;
+		title: string;
+		initialOpen?: boolean;
+		onToggle?: ( isOpen: boolean ) => void;
+		className?: string;
+	} ) => (
+		<div data-testid="panel-body" data-title={ title }>
+			{ children }
+		</div>
+	),
+	PanelRow: ( { children, className }: { children: React.ReactNode; className?: string } ) => (
+		<div data-testid="panel-row" className={ className }>
+			{ children }
+		</div>
+	),
+	BaseControl: Object.assign(
+		( {
+			children,
+			// eslint-disable-next-line @typescript-eslint/no-unused-vars
+			__nextHasNoMarginBottom,
+		}: {
+			children: React.ReactNode;
+			__nextHasNoMarginBottom?: boolean;
+		} ) => <div data-testid="base-control">{ children }</div>,
+		{
+			VisualLabel: ( { children }: { children: React.ReactNode } ) => <span>{ children }</span>,
+		}
+	),
+	Button: ( {
+		children,
+		onClick,
+		disabled,
+		variant,
+	}: {
+		children: React.ReactNode;
+		onClick?: () => void;
+		disabled?: boolean;
+		variant?: string;
+	} ) => (
+		<button onClick={ onClick } disabled={ disabled } data-variant={ variant }>
+			{ children }
+		</button>
+	),
+	ExternalLink: ( { children, href }: { children: React.ReactNode; href: string } ) => (
+		<a href={ href }>{ children }</a>
+	),
+	Notice: ( { children }: { children: React.ReactNode } ) => <div>{ children }</div>,
+} ) );
+
+// Mock @wordpress/core-data
+jest.mock( '@wordpress/core-data', () => ( {
+	store: 'core',
+} ) );
+
+// Mock internal dependencies
+jest.mock( '../../../../../blocks/ai-assistant/hooks/use-ai-product-page', () => () => ( {
+	productPageUrl: 'https://product.example.com',
+} ) );
+
+jest.mock( '../../../../../blocks/ai-assistant/lib/utils/get-feature-availability', () => ( {
+	getFeatureAvailability: () => false,
+} ) );
+
+jest.mock( '../../../../../shared/jetpack-plugin-sidebar', () => ( {
+	__esModule: true,
+	default: ( { children }: { children: React.ReactNode } ) => (
+		<div data-testid="jetpack-sidebar">{ children }</div>
+	),
+} ) );
+
+jest.mock( '../../breve', () => ( {
+	Breve: () => null,
+	registerBreveHighlights: jest.fn(),
+	Highlight: () => null,
+} ) );
+
+jest.mock( '../../breve/utils/get-availability', () => ( {
+	getBreveAvailability: () => false,
+	canWriteBriefBeEnabled: () => false,
+} ) );
+
+jest.mock( '../../feedback', () => ( { __esModule: true, default: () => null } ) );
+jest.mock( '../../title-optimization', () => ( { __esModule: true, default: () => null } ) );
+jest.mock( '../../usage-panel', () => ( { __esModule: true, default: () => null } ) );
+jest.mock( '../upgrade', () => ( { __esModule: true, default: () => null } ) );
+jest.mock( '../style.scss', () => ( {} ) );
+
+// Import the component after all mocks are set up
+import AiAssistantPluginSidebar from '..';
+
+describe( 'AiAssistantPluginSidebar', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		mockApplyFilters.mockReturnValue( null );
+	} );
+
+	describe( 'imageGenerationHandler filter', () => {
+		it( 'should call applyFilters with correct arguments for featured-image entry point', () => {
+			render( <AiAssistantPluginSidebar /> );
+
+			expect( mockApplyFilters ).toHaveBeenCalledWith(
+				'jetpack.ai.imageGenerationHandler',
+				null,
+				expect.objectContaining( {
+					entryPoint: 'featured-image',
+					onImageSelect: expect.any( Function ),
+					extra: expect.objectContaining( {
+						placement: expect.any( String ),
+						disabled: false,
+					} ),
+				} )
+			);
+		} );
+
+		it( 'should render custom "Generate image" button when filter provides a handler', () => {
+			const mockHandler = jest.fn();
+			mockApplyFilters.mockReturnValue( mockHandler );
+
+			render( <AiAssistantPluginSidebar /> );
+
+			// Should show the "Generate image" button from the filter handler
+			expect( screen.getAllByRole( 'button', { name: 'Generate image' } ).length ).toBeGreaterThan(
+				0
+			);
+		} );
+
+		it( 'should call custom handler when clicking "Generate image" button', async () => {
+			const user = userEvent.setup();
+			const mockHandler = jest.fn();
+			mockApplyFilters.mockReturnValue( mockHandler );
+
+			render( <AiAssistantPluginSidebar /> );
+
+			// Click the first "Generate image" button (from document panel)
+			const generateButtons = screen.getAllByRole( 'button', { name: 'Generate image' } );
+			await user.click( generateButtons[ 0 ] );
+
+			expect( mockHandler ).toHaveBeenCalled();
+		} );
+
+		it( 'should call editPost with featured_media when onImageSelect is called', () => {
+			let capturedOnImageSelect:
+				| ( ( image: { id: number; url: string; mime?: string } ) => void )
+				| null = null;
+
+			mockApplyFilters.mockImplementation(
+				(
+					filterName: string,
+					defaultValue: unknown,
+					args: { onImageSelect: ( image: { id: number; url: string; mime?: string } ) => void }
+				) => {
+					if ( filterName === 'jetpack.ai.imageGenerationHandler' ) {
+						capturedOnImageSelect = args.onImageSelect;
+					}
+					return null;
+				}
+			);
+
+			render( <AiAssistantPluginSidebar /> );
+
+			// Simulate external handler calling onImageSelect
+			if ( capturedOnImageSelect ) {
+				capturedOnImageSelect( {
+					id: 123,
+					url: 'https://example.com/generated-image.png',
+					mime: 'image/png',
+				} );
+			}
+
+			expect( mockEditPost ).toHaveBeenCalledWith( { featured_media: 123 } );
+		} );
+
+		it( 'should show Generate image button when filter provides handler', () => {
+			// When imageGenerationHandler is provided via filter, the component shows
+			// the custom "Generate image" button instead of the default FeaturedImage component.
+			// This test verifies the condition (imageGenerationHandler || isAIFeaturedImageAvailable)
+			// works correctly when imageGenerationHandler is truthy.
+			const mockHandler = jest.fn();
+			mockApplyFilters.mockReturnValue( mockHandler );
+
+			render( <AiAssistantPluginSidebar /> );
+
+			// With the handler provided, the "Generate image" button should be visible
+			expect( screen.getAllByRole( 'button', { name: 'Generate image' } ).length ).toBeGreaterThan(
+				0
+			);
+		} );
+	} );
+} );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
 - Introduces a jetpack.ai.imageGenerationHandler filter which allows external plugins (e.g., Image Studio) to replace the built-in AI image generation flow at two entry
  points:
    - Featured Image: "Generate image" button in the Jetpack AI sidebar's "Get Featured Image" section
  - The filter receives an onImageSelect callback that external handlers can invoke when an image is selected/generated, automatically updating the featured image .
  - Falls back to the default AI image modal when no filter handler is registered.


### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->


###  Local (Docker)

#### Setup

  1. Start Docker environment and build Jetpack:
  pnpm jetpack docker up -d && pnpm jetpack build plugins/jetpack --deps
  2. Add test snippet to tools/docker/mu-plugins/0-snippets.php: onebin 3a703 
  3. Replace image url and id in the code snippet 


###  WPCOM Sandbox

#### Setup

  1. Deploy this PR changes to your sandbox as per gh-actions command
  2. Add test snippet to your sandbox: onebin 3a703
  3. Replace image url and id in the code snippet 

### Test for both environments:

#### Test: Featured Image Entry Point 

  1. Go to Posts → Edit any post
  2. Open Jetpack sidebar (star icon in top-right toolbar)
  4. Expand "Improve with AI" panel
  5. Click "Generate image" button under "Get Featured Image"
  6. Expected:
    - Alert shows "Handler called: featured-image"
    - After clicking OK, the featured image updates to the test image


###  Fallback Test

  1. Remove the test snippet/sandbox
  2. Hard refresh and click "Generate image"
  3. Expected: Old AI image modal opens (default behavior when no filter is registered)

###  Cleanup

-  Remove or comment out tools/docker/mu-plugins/0-snippets.php and your sandbox when done testing.
