### PR TITLE
Forms: fix field width on mobile

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-layout-auto-width-mobile
+++ b/projects/packages/forms/changelog/fix-forms-layout-auto-width-mobile
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Forms: make sure 100% width fields apply properly on mobile

--- a/projects/packages/forms/src/contact-form/css/jetpack-forms-layout.scss
+++ b/projects/packages/forms/src/contact-form/css/jetpack-forms-layout.scss
@@ -119,6 +119,7 @@
 			box-sizing: border-box;
 			position: relative;
 			flex: 1 1 100%;
+			width: 100%;
 
 			&.grunion-field-width-25-wrap {
 				flex: 1 1 calc(25% - var(--wp--style--block-gap, 1.5rem) * 1);
@@ -142,6 +143,7 @@
 
 			&.grunion-field-width-auto-wrap {
 				flex: 1 1 auto;
+				width: auto;
 			}
 		}
 	}


### PR DESCRIPTION

## Proposed changes:
Field widths can misbehave on horizontal forms when on animated style

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
None

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Create a form, make it horizontal and apply animated style to it. Switching viewport mobile/desktop should behave as expected, making the fields take full width when "auto" forces them to jump to a new line.