### PR TITLE
Forms: make forms primary on wp-build dashboard

### DIFF
--- a/projects/packages/forms/changelog/update-forms-wpbuild-dashboard-tabs
+++ b/projects/packages/forms/changelog/update-forms-wpbuild-dashboard-tabs
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Dashboard: make forms primary on wp-build dashboard"

--- a/projects/packages/forms/changelog/update-forms-wpbuild-dashboard-tabs
+++ b/projects/packages/forms/changelog/update-forms-wpbuild-dashboard-tabs
@@ -1,4 +1,4 @@
 Significance: minor
 Type: changed
 
-Dashboard: make forms primary on wp-build dashboard"
+Dashboard: make forms primary on wp-build dashboard

--- a/projects/packages/forms/routes/root/route.ts
+++ b/projects/packages/forms/routes/root/route.ts
@@ -8,7 +8,7 @@ export const route = {
 	 * Redirect `/` to the default dashboard view.
 	 *
 	 * In wp-admin integrated mode, the boot router uses the `p` query arg and defaults to `/`
-	 * when missing. Adding this route lets us redirect to the default inbox view.
+	 * when missing. Adding this route lets us redirect to the default forms view.
 	 */
 	beforeLoad: () => {
 		throw redirect( { href: '/forms' } );

--- a/projects/packages/forms/routes/root/route.ts
+++ b/projects/packages/forms/routes/root/route.ts
@@ -5,12 +5,12 @@ import { redirect } from '@wordpress/route';
 
 export const route = {
 	/**
-	 * Redirect `/` to the default inbox view.
+	 * Redirect `/` to the default dashboard view.
 	 *
 	 * In wp-admin integrated mode, the boot router uses the `p` query arg and defaults to `/`
 	 * when missing. Adding this route lets us redirect to the default inbox view.
 	 */
 	beforeLoad: () => {
-		throw redirect( { href: '/responses/inbox' } );
+		throw redirect( { href: '/forms' } );
 	},
 };

--- a/projects/packages/forms/src/dashboard/wp-build/components/dataviews-header-row/index.tsx
+++ b/projects/packages/forms/src/dashboard/wp-build/components/dataviews-header-row/index.tsx
@@ -95,19 +95,19 @@ export default function DataViewsHeaderRow( {
 					) : (
 						<Tabs.Root value={ activeTab } onValueChange={ onTabChange }>
 							<Tabs.List density="compact">
-								<Tabs.Tab value="responses">
-									<span>
-										{ __( 'Responses', 'jetpack-forms' ) }
-										<Badge intent="default" className="jp-forms-count-badge">
-											{ formatNumberCompact( responsesInboxCount || 0 ) }
-										</Badge>
-									</span>
-								</Tabs.Tab>
 								<Tabs.Tab value="forms">
 									<span>
 										{ __( 'Forms', 'jetpack-forms' ) }
 										<Badge intent="default" className="jp-forms-count-badge">
 											{ formatNumberCompact( formsCount || 0 ) }
+										</Badge>
+									</span>
+								</Tabs.Tab>
+								<Tabs.Tab value="responses">
+									<span>
+										{ __( 'Responses', 'jetpack-forms' ) }
+										<Badge intent="default" className="jp-forms-count-badge">
+											{ formatNumberCompact( responsesInboxCount || 0 ) }
 										</Badge>
 									</span>
 								</Tabs.Tab>


### PR DESCRIPTION
## Proposed changes:

This PR make the "Forms" tab primary on the wp-build dashboard. It shows before Responses, and is the tab that load by default when you land on the dashboard. 

**Screenshot**

<img width="1333" height="533" alt="forms-tab-primary" src="https://github.com/user-attachments/assets/14306a58-6e0d-4350-81b4-3e1f2a30aef8" />


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
Slack: p1770999228247119/1770934854.630799-slack-C052XEUUBL4

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Enable these feature flags: 

```
add_filter( 'jetpack_forms_alpha', '__return_true', 20 );
add_filter( 'jetpack_block_editor_feature_flags', 'eb_register_feature' );
function eb_register_feature( $flags ) {
    $flags['central-form-management'] = true;
    return $flags;
}
```

Test:
* Go to Jetpack > Forms
* Confirm top menu tabs are Forms and Responses in that order
* Confirm you landed with the Forms tabs loaded by default