### PR TITLE
Forms: Email template design feedback fixes

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-email-template-design-feedback
+++ b/projects/packages/forms/changelog/fix-forms-email-template-design-feedback
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Email template: fix button layout regression, add responsive mobile stacking, improve font sizes, and align field icons with labels.

--- a/projects/packages/forms/src/contact-form/class-feedback-email-renderer.php
+++ b/projects/packages/forms/src/contact-form/class-feedback-email-renderer.php
@@ -42,6 +42,41 @@ class Feedback_Email_Renderer {
 	public const TEXT_COLOR = '#1e1e1e';
 
 	/**
+	 * Font size for field labels.
+	 *
+	 * @var string
+	 */
+	public const FONT_SIZE_FIELD_LABEL = '15px';
+
+	/**
+	 * Font size for field values, chips, and respondent name.
+	 *
+	 * @var string
+	 */
+	public const FONT_SIZE_FIELD_VALUE = '16px';
+
+	/**
+	 * Font size for metadata section and powered-by text.
+	 *
+	 * @var string
+	 */
+	public const FONT_SIZE_METADATA = '13px';
+
+	/**
+	 * Font size for action buttons and respondent email.
+	 *
+	 * @var string
+	 */
+	public const FONT_SIZE_BUTTON = '14px';
+
+	/**
+	 * Font size for small annotations like file sizes.
+	 *
+	 * @var string
+	 */
+	public const FONT_SIZE_SMALL = '12px';
+
+	/**
 	 * Build the complete email content for a form submission.
 	 *
 	 * Assembles the email title, compiled form fields, footer, actions,
@@ -156,7 +191,7 @@ class Feedback_Email_Renderer {
 				'jetpack_forms_response_email_footer',
 				array_filter(
 					array(
-						'<span style="font-size: 12px">',
+						'<span style="font-size: ' . self::FONT_SIZE_SMALL . '">',
 						$footer_time . '<br />',
 						$footer_ip ? $footer_ip . '<br />' : null,
 						$footer_browser ? $footer_browser . '<br />' : null,
@@ -177,10 +212,10 @@ class Feedback_Email_Renderer {
 				'<table role="presentation" border="0" cellpadding="0" cellspacing="0" class="button-table" align="center" style="border-collapse: collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; margin: 0 auto;">
 					<tr>
 						<td class="button-cell" width="50%%" style="text-align: right; padding-right: 8px; font-family: -apple-system, BlinkMacSystemFont, \'Segoe UI\', Roboto, Oxygen-Sans, Ubuntu, Cantarell, \'Helvetica Neue\', sans-serif;">
-							<a href="%1$s" class="action-button action-button-secondary" style="display: inline-block; background-color: transparent; color: %5$s; border: 1px solid #1e1e1e; border-radius: 4px; font-size: 14px; font-weight: 500; text-decoration: none; padding: 12px 24px; text-align: center; mso-padding-alt: 0;">%2$s</a>
+							<a href="%1$s" class="action-button action-button-secondary" style="display: inline-block; background-color: transparent; color: %5$s; border: 1px solid #1e1e1e; border-radius: 4px; font-size: ' . self::FONT_SIZE_BUTTON . '; font-weight: 500; text-decoration: none; padding: 12px 24px; text-align: center; mso-padding-alt: 0;">%2$s</a>
 						</td>
 						<td class="button-cell" width="50%%" style="text-align: left; padding-left: 8px; font-family: -apple-system, BlinkMacSystemFont, \'Segoe UI\', Roboto, Oxygen-Sans, Ubuntu, Cantarell, \'Helvetica Neue\', sans-serif;">
-							<a href="%3$s" class="action-button action-button-primary" style="display: inline-block; background-color: #3858e9; color: #ffffff; border-radius: 4px; font-size: 14px; font-weight: 500; text-decoration: none; padding: 12px 24px; text-align: center; mso-padding-alt: 0;">%4$s</a>
+							<a href="%3$s" class="action-button action-button-primary" style="display: inline-block; background-color: #3858e9; color: #ffffff; border-radius: 4px; font-size: ' . self::FONT_SIZE_BUTTON . '; font-weight: 500; text-decoration: none; padding: 12px 24px; text-align: center; mso-padding-alt: 0;">%4$s</a>
 						</td>
 					</tr>
 				</table>',
@@ -367,13 +402,13 @@ class Feedback_Email_Renderer {
 		$html .= '<td valign="top" style="padding: 20px 0;">';
 		if ( ! empty( $safe_label ) ) {
 			$html .= sprintf(
-				'<div style="font-size: 15px; color: %s; line-height: 1.4; margin-bottom: 8px;">%s</div>',
+				'<div style="font-size: ' . self::FONT_SIZE_FIELD_LABEL . '; color: %s; line-height: 1.4; margin-bottom: 8px;">%s</div>',
 				self::TEXT_SECONDARY_COLOR,
 				esc_html( $safe_label )
 			);
 		}
 		$html .= sprintf(
-			'<div style="font-size: 16px; color: %s; line-height: 1.5;">%s</div>',
+			'<div style="font-size: ' . self::FONT_SIZE_FIELD_VALUE . '; color: %s; line-height: 1.5;">%s</div>',
 			self::TEXT_COLOR,
 			$rendered_value
 		);
@@ -512,11 +547,11 @@ class Feedback_Email_Renderer {
 					<tr>
 						<td align="center" class="powered-by" style="padding: 24px 0 0 0; font-family: -apple-system, BlinkMacSystemFont, \'Segoe UI\', Roboto, Oxygen-Sans, Ubuntu, Cantarell, \'Helvetica Neue\', sans-serif;">
 							<img src="' . esc_url( $logo_url ) . '" alt="Jetpack" width="20" height="20" style="vertical-align: middle; margin-right: 6px; border: 0; outline: none; text-decoration: none;">
-							<span style="font-size: 13px; color: #50575e; line-height: 20px;">' .
+							<span style="font-size: ' . self::FONT_SIZE_METADATA . '; color: #50575e; line-height: 20px;">' .
 					sprintf(
 						// translators: %1$s is a link to the Jetpack Forms page.
 						__( 'Powered by %1$s', 'jetpack-forms' ),
-						'<a href="https://jetpack.com/forms/?utm_source=jetpack-forms&utm_medium=email&utm_campaign=form-submissions" style="font-size: 13px; color: #50575e; text-decoration: none;">Jetpack Forms</a>'
+						'<a href="https://jetpack.com/forms/?utm_source=jetpack-forms&utm_medium=email&utm_campaign=form-submissions" style="font-size: ' . self::FONT_SIZE_METADATA . '; color: #50575e; text-decoration: none;">Jetpack Forms</a>'
 					) . '</span>
 						</td>
 					</tr>
@@ -611,8 +646,8 @@ class Feedback_Email_Renderer {
 					<![endif]-->
 				</td>
 				<td class="respondent-details-cell" style="vertical-align: middle; font-family: -apple-system, BlinkMacSystemFont, \'Segoe UI\', Roboto, Oxygen-Sans, Ubuntu, Cantarell, \'Helvetica Neue\', sans-serif;">
-					' . ( ! empty( $name ) ? '<div class="respondent-name" style="font-size: 16px; font-weight: 600; color: ' . self::TEXT_COLOR . '; margin: 0 0 2px 0; line-height: 1.4;">' . $name . '</div>' : '' ) . '
-					' . ( ! empty( $email ) ? '<div class="respondent-email" style="font-size: 14px; margin: 0; line-height: 1.4;"><a href="mailto:' . $email . '" style="color: ' . self::TEXT_SECONDARY_COLOR . '; text-decoration: underline;">' . $email . '</a></div>' : '' ) . '
+					' . ( ! empty( $name ) ? '<div class="respondent-name" style="font-size: ' . self::FONT_SIZE_FIELD_VALUE . '; font-weight: 600; color: ' . self::TEXT_COLOR . '; margin: 0 0 2px 0; line-height: 1.4;">' . $name . '</div>' : '' ) . '
+					' . ( ! empty( $email ) ? '<div class="respondent-email" style="font-size: ' . self::FONT_SIZE_BUTTON . '; margin: 0; line-height: 1.4;"><a href="mailto:' . $email . '" style="color: ' . self::TEXT_SECONDARY_COLOR . '; text-decoration: underline;">' . $email . '</a></div>' : '' ) . '
 				</td>
 			</tr>
 		</table>';
@@ -686,8 +721,8 @@ class Feedback_Email_Renderer {
 	private static function generate_metadata_row( $label, $value ) {
 		return '
 			<tr>
-				<td class="metadata-label" style="color: #50575e; width: 100px; padding: 4px 12px 4px 0; font-size: 13px; vertical-align: top; font-family: -apple-system, BlinkMacSystemFont, \'Segoe UI\', Roboto, Oxygen-Sans, Ubuntu, Cantarell, \'Helvetica Neue\', sans-serif; line-height: 1.4;">' . esc_html( $label ) . ':</td>
-				<td class="metadata-value" style="color: #1e1e1e; padding: 4px 0; font-size: 13px; vertical-align: top; font-family: -apple-system, BlinkMacSystemFont, \'Segoe UI\', Roboto, Oxygen-Sans, Ubuntu, Cantarell, \'Helvetica Neue\', sans-serif; line-height: 1.4;">' . $value . '</td>
+				<td class="metadata-label" style="color: #50575e; width: 100px; padding: 4px 12px 4px 0; font-size: ' . self::FONT_SIZE_METADATA . '; vertical-align: top; font-family: -apple-system, BlinkMacSystemFont, \'Segoe UI\', Roboto, Oxygen-Sans, Ubuntu, Cantarell, \'Helvetica Neue\', sans-serif; line-height: 1.4;">' . esc_html( $label ) . ':</td>
+				<td class="metadata-value" style="color: #1e1e1e; padding: 4px 0; font-size: ' . self::FONT_SIZE_METADATA . '; vertical-align: top; font-family: -apple-system, BlinkMacSystemFont, \'Segoe UI\', Roboto, Oxygen-Sans, Ubuntu, Cantarell, \'Helvetica Neue\', sans-serif; line-height: 1.4;">' . $value . '</td>
 			</tr>';
 	}
 }

--- a/projects/packages/forms/src/contact-form/class-feedback-email-renderer.php
+++ b/projects/packages/forms/src/contact-form/class-feedback-email-renderer.php
@@ -367,13 +367,13 @@ class Feedback_Email_Renderer {
 		$html .= '<td valign="top" style="padding: 20px 0;">';
 		if ( ! empty( $safe_label ) ) {
 			$html .= sprintf(
-				'<div style="font-size: 13px; color: %s; line-height: 1.4; margin-bottom: 8px;">%s</div>',
+				'<div style="font-size: 15px; color: %s; line-height: 1.4; margin-bottom: 8px;">%s</div>',
 				self::TEXT_SECONDARY_COLOR,
 				esc_html( $safe_label )
 			);
 		}
 		$html .= sprintf(
-			'<div style="font-size: 13px; color: %s; line-height: 1.5;">%s</div>',
+			'<div style="font-size: 16px; color: %s; line-height: 1.5;">%s</div>',
 			self::TEXT_COLOR,
 			$rendered_value
 		);

--- a/projects/packages/forms/src/contact-form/class-feedback-email-renderer.php
+++ b/projects/packages/forms/src/contact-form/class-feedback-email-renderer.php
@@ -176,11 +176,11 @@ class Feedback_Email_Renderer {
 			$actions = sprintf(
 				'<table role="presentation" border="0" cellpadding="0" cellspacing="0" class="button-table" align="center" style="border-collapse: collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; margin: 0 auto;">
 					<tr>
-						<td class="button-cell" style="padding-right: 8px; font-family: -apple-system, BlinkMacSystemFont, \'Segoe UI\', Roboto, Oxygen-Sans, Ubuntu, Cantarell, \'Helvetica Neue\', sans-serif;">
-							<a href="%1$s" class="action-button action-button-secondary" style="background-color: transparent; color: %5$s; border: 1px solid #1e1e1e; border-radius: 4px; font-size: 14px; font-weight: 500; text-decoration: none; padding: 12px 24px; text-align: center; mso-padding-alt: 0;">%2$s</a>
+						<td class="button-cell" width="50%%" style="text-align: right; padding-right: 8px; font-family: -apple-system, BlinkMacSystemFont, \'Segoe UI\', Roboto, Oxygen-Sans, Ubuntu, Cantarell, \'Helvetica Neue\', sans-serif;">
+							<a href="%1$s" class="action-button action-button-secondary" style="display: inline-block; background-color: transparent; color: %5$s; border: 1px solid #1e1e1e; border-radius: 4px; font-size: 14px; font-weight: 500; text-decoration: none; padding: 12px 24px; text-align: center; mso-padding-alt: 0;">%2$s</a>
 						</td>
-						<td class="button-cell" style="font-family: -apple-system, BlinkMacSystemFont, \'Segoe UI\', Roboto, Oxygen-Sans, Ubuntu, Cantarell, \'Helvetica Neue\', sans-serif;">
-							<a href="%3$s" class="action-button action-button-primary" style="background-color: #3858e9; color: #ffffff; border-radius: 4px; font-size: 14px; font-weight: 500; text-decoration: none; padding: 12px 24px; text-align: center; mso-padding-alt: 0;">%4$s</a>
+						<td class="button-cell" width="50%%" style="text-align: left; padding-left: 8px; font-family: -apple-system, BlinkMacSystemFont, \'Segoe UI\', Roboto, Oxygen-Sans, Ubuntu, Cantarell, \'Helvetica Neue\', sans-serif;">
+							<a href="%3$s" class="action-button action-button-primary" style="display: inline-block; background-color: #3858e9; color: #ffffff; border-radius: 4px; font-size: 14px; font-weight: 500; text-decoration: none; padding: 12px 24px; text-align: center; mso-padding-alt: 0;">%4$s</a>
 						</td>
 					</tr>
 				</table>',
@@ -516,7 +516,7 @@ class Feedback_Email_Renderer {
 					sprintf(
 						// translators: %1$s is a link to the Jetpack Forms page.
 						__( 'Powered by %1$s', 'jetpack-forms' ),
-						'<a href="https://jetpack.com/forms/?utm_source=jetpack-forms&utm_medium=email&utm_campaign=form-submissions" style="color: #50575e; text-decoration: none;">Jetpack Forms</a>'
+						'<a href="https://jetpack.com/forms/?utm_source=jetpack-forms&utm_medium=email&utm_campaign=form-submissions" style="font-size: 13px; color: #50575e; text-decoration: none;">Jetpack Forms</a>'
 					) . '</span>
 						</td>
 					</tr>

--- a/projects/packages/forms/src/contact-form/class-feedback-email-renderer.php
+++ b/projects/packages/forms/src/contact-form/class-feedback-email-renderer.php
@@ -358,7 +358,7 @@ class Feedback_Email_Renderer {
 		// Build the field row as a table with icon + content.
 		$html  = '<table role="presentation" border="0" cellpadding="0" cellspacing="0" width="100%" style="border-bottom: 1px solid #F0F0F0; padding: 0; margin: 0;">';
 		$html .= '<tr>';
-		$html .= '<td width="24" valign="top" style="padding: 20px 16px 20px 0; width: 24px; vertical-align: top;">';
+		$html .= '<td width="24" valign="top" style="padding: 18px 16px 20px 0; width: 24px; vertical-align: top;">';
 		$html .= sprintf(
 			'<img src="%s" width="24" height="24" alt="" style="display: block; width: 24px; height: 24px;" />',
 			esc_url( $icon_url )

--- a/projects/packages/forms/src/contact-form/class-feedback-field.php
+++ b/projects/packages/forms/src/contact-form/class-feedback-field.php
@@ -483,7 +483,7 @@ class Feedback_Field {
 				continue;
 			}
 			$chips[] = sprintf(
-				'<div style="display: inline-block; height: 24px; padding: 0 8px; margin: 2px 4px 2px 0; background-color: #f0f0f0; border-radius: 2px; font-size: 13px; line-height: 24px; color: %s;">%s</div>',
+				'<div style="display: inline-block; height: 24px; padding: 0 8px; margin: 2px 4px 2px 0; background-color: #f0f0f0; border-radius: 2px; font-size: 16px; line-height: 24px; color: %s;">%s</div>',
 				Feedback_Email_Renderer::TEXT_COLOR,
 				$safe_item
 			);
@@ -506,7 +506,7 @@ class Feedback_Field {
 		$label  = $is_yes ? __( 'Yes', 'jetpack-forms' ) : __( 'No', 'jetpack-forms' );
 
 		return sprintf(
-			'<span style="display: inline-block; padding: 0 8px; border-radius: 2px; font-size: 13px; line-height: 1.4; background-color: #f0f0f0; color: %s;">%s</span>',
+			'<span style="display: inline-block; padding: 0 8px; border-radius: 2px; font-size: 16px; line-height: 1.4; background-color: #f0f0f0; color: %s;">%s</span>',
 			Feedback_Email_Renderer::TEXT_COLOR,
 			esc_html( $label )
 		);

--- a/projects/packages/forms/src/contact-form/class-feedback-field.php
+++ b/projects/packages/forms/src/contact-form/class-feedback-field.php
@@ -483,7 +483,7 @@ class Feedback_Field {
 				continue;
 			}
 			$chips[] = sprintf(
-				'<div style="display: inline-block; height: 24px; padding: 0 8px; margin: 2px 4px 2px 0; background-color: #f0f0f0; border-radius: 2px; font-size: 16px; line-height: 24px; color: %s;">%s</div>',
+				'<div style="display: inline-block; height: 24px; padding: 0 8px; margin: 2px 4px 2px 0; background-color: #f0f0f0; border-radius: 2px; font-size: ' . Feedback_Email_Renderer::FONT_SIZE_FIELD_VALUE . '; line-height: 24px; color: %s;">%s</div>',
 				Feedback_Email_Renderer::TEXT_COLOR,
 				$safe_item
 			);
@@ -506,7 +506,7 @@ class Feedback_Field {
 		$label  = $is_yes ? __( 'Yes', 'jetpack-forms' ) : __( 'No', 'jetpack-forms' );
 
 		return sprintf(
-			'<span style="display: inline-block; padding: 0 8px; border-radius: 2px; font-size: 16px; line-height: 1.4; background-color: #f0f0f0; color: %s;">%s</span>',
+			'<span style="display: inline-block; padding: 0 8px; border-radius: 2px; font-size: ' . Feedback_Email_Renderer::FONT_SIZE_FIELD_VALUE . '; line-height: 1.4; background-color: #f0f0f0; color: %s;">%s</span>',
 			Feedback_Email_Renderer::TEXT_COLOR,
 			esc_html( $label )
 		);
@@ -628,7 +628,7 @@ class Feedback_Field {
 
 			$html = esc_html( $file_name );
 			if ( ! empty( $file_size ) ) {
-				$html .= sprintf( ' <span style="color: ' . Feedback_Email_Renderer::TEXT_SECONDARY_COLOR . '; font-size: 12px;">(%s)</span>', esc_html( $file_size ) );
+				$html .= sprintf( ' <span style="color: ' . Feedback_Email_Renderer::TEXT_SECONDARY_COLOR . '; font-size: ' . Feedback_Email_Renderer::FONT_SIZE_SMALL . ';">(%s)</span>', esc_html( $file_size ) );
 			}
 
 			if ( ! empty( $file_url ) ) {

--- a/projects/packages/forms/src/contact-form/templates/email-response.php
+++ b/projects/packages/forms/src/contact-form/templates/email-response.php
@@ -593,9 +593,30 @@ $style = '<style media="all" type="text/css">
 			width: 90px !important;
 		}
 
+		.actions {
+			width: 100% !important;
+			padding: 0 !important;
+		}
+
+		.actions .button-table,
+		.actions .button-table tbody,
+		.actions .button-table tr,
+		.actions .button-cell {
+			display: block !important;
+			width: 100% !important;
+			max-width: 100% !important;
+		}
+
+		.button-cell {
+			text-align: center !important;
+			padding: 4px 0 !important;
+		}
+
 		.action-button {
 			display: block !important;
-			margin: 8px 0 !important;
+			width: 100% !important;
+			box-sizing: border-box !important;
+			text-align: center !important;
 		}
 	}
 

--- a/projects/packages/forms/src/contact-form/templates/email-response.php
+++ b/projects/packages/forms/src/contact-form/templates/email-response.php
@@ -22,9 +22,13 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit( 0 );
 }
 
-$link_color           = \Automattic\Jetpack\Forms\ContactForm\Feedback_Email_Renderer::LINK_COLOR;
-$text_color           = \Automattic\Jetpack\Forms\ContactForm\Feedback_Email_Renderer::TEXT_COLOR;
-$text_secondary_color = \Automattic\Jetpack\Forms\ContactForm\Feedback_Email_Renderer::TEXT_SECONDARY_COLOR;
+$link_color            = \Automattic\Jetpack\Forms\ContactForm\Feedback_Email_Renderer::LINK_COLOR;
+$text_color            = \Automattic\Jetpack\Forms\ContactForm\Feedback_Email_Renderer::TEXT_COLOR;
+$text_secondary_color  = \Automattic\Jetpack\Forms\ContactForm\Feedback_Email_Renderer::TEXT_SECONDARY_COLOR;
+$font_size_field_label = \Automattic\Jetpack\Forms\ContactForm\Feedback_Email_Renderer::FONT_SIZE_FIELD_LABEL;
+$font_size_field_value = \Automattic\Jetpack\Forms\ContactForm\Feedback_Email_Renderer::FONT_SIZE_FIELD_VALUE;
+$font_size_metadata    = \Automattic\Jetpack\Forms\ContactForm\Feedback_Email_Renderer::FONT_SIZE_METADATA;
+$font_size_button      = \Automattic\Jetpack\Forms\ContactForm\Feedback_Email_Renderer::FONT_SIZE_BUTTON;
 
 // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- used in class-contact-form.php
 $template = '
@@ -238,7 +242,7 @@ $style = '<style media="all" type="text/css">
 
 	.metadata-table td {
 		padding: 4px 0;
-		font-size: 13px;
+		font-size: ' . $font_size_metadata . ';
 		vertical-align: top;
 	}
 
@@ -300,14 +304,14 @@ $style = '<style media="all" type="text/css">
 	}
 
 	.field-label {
-		font-size: 15px;
+		font-size: ' . $font_size_field_label . ';
 		color: ' . $text_secondary_color . ';
 		margin: 0 0 4px 0;
 		text-transform: none;
 	}
 
 	.field-value {
-		font-size: 16px;
+		font-size: ' . $font_size_field_value . ';
 		color: ' . $text_color . ';
 		margin: 0;
 		word-wrap: break-word;
@@ -331,7 +335,7 @@ $style = '<style media="all" type="text/css">
 		background-color: #f0f0f0;
 		border-radius: 2px;
 		padding: 0 8px;
-		font-size: 16px;
+		font-size: ' . $font_size_field_value . ';
 		color: ' . $text_color . ';
 	}
 
@@ -399,7 +403,7 @@ $style = '<style media="all" type="text/css">
 		color: #155724;
 		border-radius: 2px;
 		padding: 0 8px;
-		font-size: 16px;
+		font-size: ' . $font_size_field_value . ';
 	}
 
 	.consent-chip.no {
@@ -421,7 +425,7 @@ $style = '<style media="all" type="text/css">
 		display: inline-block;
 		padding: 12px 24px;
 		border-radius: 4px;
-		font-size: 14px;
+		font-size: ' . $font_size_button . ';
 		font-weight: 500;
 		text-decoration: none;
 		margin: 0 6px;

--- a/projects/packages/forms/src/contact-form/templates/email-response.php
+++ b/projects/packages/forms/src/contact-form/templates/email-response.php
@@ -300,14 +300,14 @@ $style = '<style media="all" type="text/css">
 	}
 
 	.field-label {
-		font-size: 12px;
+		font-size: 15px;
 		color: ' . $text_secondary_color . ';
 		margin: 0 0 4px 0;
 		text-transform: none;
 	}
 
 	.field-value {
-		font-size: 13px;
+		font-size: 16px;
 		color: ' . $text_color . ';
 		margin: 0;
 		word-wrap: break-word;
@@ -331,7 +331,7 @@ $style = '<style media="all" type="text/css">
 		background-color: #f0f0f0;
 		border-radius: 2px;
 		padding: 0 8px;
-		font-size: 13px;
+		font-size: 16px;
 		color: ' . $text_color . ';
 	}
 
@@ -399,7 +399,7 @@ $style = '<style media="all" type="text/css">
 		color: #155724;
 		border-radius: 2px;
 		padding: 0 8px;
-		font-size: 13px;
+		font-size: 16px;
 	}
 
 	.consent-chip.no {


### PR DESCRIPTION
Follow-up to https://github.com/Automattic/jetpack/pull/47117

## Proposed changes:

* Fix button layout regression introduced during the renderer class refactor — restores `width="50%"`, `text-align`, and `display: inline-block` attributes on button cells that were lost
* Add responsive mobile stacking for action buttons using media queries that properly target `<table>`, `<tbody>`, `<tr>`, and `<td>` elements (the implicit `<tbody>` was preventing width overrides from propagating)
* Increase font sizes for improved readability: field labels 12px → 15px, field values 13px → 16px, choice chips 13px → 16px
* Ensure consistent font-size on the "Powered by Jetpack Forms" link across email clients by adding explicit `font-size: 13px` to the anchor tag
* Vertically align field icons with adjacent label text by adjusting icon cell padding

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

* Set up a local Jetpack dev environment with a form that includes multiple field types (text, multi-select, consent, dropdown)
* Submit the form and check the notification email
* **Button layout (desktop):** Verify "Mark as spam" and "View in dashboard" buttons appear side-by-side, centered, with minimal gap between them
* **Button layout (mobile):** View the email at a narrow viewport (< 640px) — buttons should stack vertically, full-width, and centered
* **Font sizes:** Field labels should be 15px, field values and choice chips 16px — check they look proportional and readable
* **Powered by:** "Powered by" and "Jetpack Forms" in the footer should appear the same font size
* **Icon alignment:** Field icons (left of labels) should be vertically centered with the label text, not offset