### PR TITLE
VideoPress: remove explicit wpcom API call for video deletion

### DIFF
--- a/projects/packages/videopress/.phan/baseline.php
+++ b/projects/packages/videopress/.phan/baseline.php
@@ -16,7 +16,6 @@ return [
     // PhanTypeMismatchReturn : 6 occurrences
     // PhanUndeclaredClassMethod : 6 occurrences
     // PhanCommentOverrideOnNonOverrideMethod : 4 occurrences
-    // PhanNonClassMethodCall : 4 occurrences
     // PhanTypeArraySuspiciousNullable : 4 occurrences
     // PhanTypeMismatchArgument : 4 occurrences
     // PhanTypeInvalidDimOffset : 2 occurrences
@@ -24,6 +23,7 @@ return [
     // PhanUndeclaredMethod : 2 occurrences
     // PhanUndeclaredMethodInCallable : 2 occurrences
     // PhanUndeclaredTypeThrowsType : 2 occurrences
+    // PhanNonClassMethodCall : 1 occurrence
     // PhanPluginSimplifyExpressionBool : 1 occurrence
     // PhanPluginUnreachableCode : 1 occurrence
     // PhanTypeMismatchReturnNullable : 1 occurrence
@@ -32,7 +32,7 @@ return [
     // Currently, file_suppressions and directory_suppressions are the only supported suppressions
     'file_suppressions' => [
         'src/class-access-control.php' => ['PhanPluginDuplicateConditionalNullCoalescing'],
-        'src/class-attachment-handler.php' => ['PhanNonClassMethodCall', 'PhanTypeArraySuspicious'],
+        'src/class-attachment-handler.php' => ['PhanTypeArraySuspicious'],
         'src/class-block-editor-content.php' => ['PhanPluginDuplicateConditionalNullCoalescing'],
         'src/class-block-editor-extensions.php' => ['PhanTypeMismatchReturnProbablyReal'],
         'src/class-data.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeArraySuspicious', 'PhanTypeMismatchReturn'],

--- a/projects/packages/videopress/changelog/fix-videopress-deletion-attribution
+++ b/projects/packages/videopress/changelog/fix-videopress-deletion-attribution
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Remove explicit wpcom API call for VideoPress video deletion, fixing Activity Log attribution. Cleanup is now handled via Jetpack Sync.

--- a/projects/packages/videopress/src/class-attachment-handler.php
+++ b/projects/packages/videopress/src/class-attachment-handler.php
@@ -7,9 +7,7 @@
 
 namespace Automattic\Jetpack\VideoPress;
 
-use Automattic\Jetpack\Connection\Client;
 use Automattic\Jetpack\Current_Plan;
-use WP_Error;
 use WP_Post;
 
 /**
@@ -35,7 +33,7 @@ class Attachment_Handler {
 			add_filter( 'upload_mimes', array( __CLASS__, 'add_video_upload_mimes' ), 999 );
 		}
 
-		add_filter( 'pre_delete_attachment', array( __CLASS__, 'delete_video_wpcom' ), 10, 2 );
+		add_action( 'delete_attachment', array( __CLASS__, 'delete_video_poster_attachment' ) );
 		add_filter( 'wp_mime_type_icon', array( __CLASS__, 'wp_mime_type_icon' ), 10, 3 );
 		add_filter( 'wp_video_extensions', array( __CLASS__, 'add_videopress_extenstion' ) );
 
@@ -65,7 +63,7 @@ class Attachment_Handler {
 	}
 
 	/**
-	 * Makes sure that all video mimes are added in, as multi site installs can remove them.
+	 * Makes sure that all video mimes are added in, as multisite installs can remove them.
 	 *
 	 * @param array $existing_mimes Mime types to extend/filter.
 	 * @return array
@@ -85,7 +83,7 @@ class Attachment_Handler {
 	}
 
 	/**
-	 * Filter designed to get rid of non video mime types.
+	 * Filter designed to get rid of non-video mime types.
 	 *
 	 * @param string $value Mime type to filter.
 	 * @return int
@@ -95,57 +93,37 @@ class Attachment_Handler {
 	}
 
 	/**
-	 * Attempts to delete a VideoPress video from wp.com.
-	 * Will block the deletion from continuing if certain errors return from the wp.com API.
+	 * Previously deleted a VideoPress video from wp.com via API call.
+	 *
+	 * @deprecated $$next-version$$ Video file cleanup is now handled via Jetpack Sync on wpcom.
 	 *
 	 * @param Boolean $delete if the deletion should occur or not (unused).
 	 * @param WP_Post $post the post object.
 	 *
-	 * @return null|WP_Error|Boolean null if deletion should continue.
+	 * @return null null to allow the deletion to continue.
 	 */
 	public static function delete_video_wpcom( $delete, $post ) {
-		if ( ! is_videopress_attachment( $post->ID ) ) {
-			return null;
-		}
+		_deprecated_function( __METHOD__, 'jetpack-videopress-$$next-version$$' );
 
-		$guid = get_post_meta( $post->ID, 'videopress_guid', true );
-		if ( empty( $guid ) ) {
-			self::delete_video_poster_attachment( $post->ID );
-			return null;
-		}
+		self::delete_video_poster_attachment( $post->ID );
 
-		// Phone home and have wp.com delete the VideoPress entry and files.
-		$wpcom_response = Client::wpcom_json_api_request_as_blog(
-			sprintf( '/videos/%s/delete', $guid ),
-			'1.1',
-			array( 'method' => 'POST' )
-		);
-
-		if ( is_wp_error( $wpcom_response ) ) {
-			return $wpcom_response;
-		}
-
-		// Upon success or a 404 (video already deleted on wp.com), return null to allow the deletion to continue.
-		if ( 200 === $wpcom_response['response']['code'] || 404 === $wpcom_response['response']['code'] ) {
-			self::delete_video_poster_attachment( $post->ID );
-			return null;
-		}
-
-		// Otherwise we stop the deletion from proceeding.
-		return false;
+		return null;
 	}
 
 	/**
-	 * Deletes a video poster attachment if it exists.
+	 * Deletes the video poster attachment for a VideoPress video if it exists.
 	 *
-	 * @param int $attachment_id the WP attachment id.
+	 * @param int $attachment_id The WP attachment ID.
 	 */
-	private static function delete_video_poster_attachment( $attachment_id ) {
+	public static function delete_video_poster_attachment( $attachment_id ) {
+		if ( ! is_videopress_attachment( $attachment_id ) ) {
+			return;
+		}
+
 		$thumbnail_id = get_post_meta( $attachment_id, '_thumbnail_id', true );
 		if ( ! empty( $thumbnail_id ) ) {
 			// Let's ensure this is a VP poster image before we delete it.
 			if ( '1' === get_post_meta( $thumbnail_id, 'videopress_poster_image', true ) ) {
-				// This call triggers the `delete_video_wpcom` filter again but it bails early at the is_videopress_attachment() check.
 				wp_delete_attachment( $thumbnail_id );
 			}
 		}
@@ -232,7 +210,7 @@ class Attachment_Handler {
 	 * Media List:
 	 * Do the same as `videopress_ajax_query_attachments_args()` but for the list view.
 	 *
-	 * @param array $query WP_Query instance.
+	 * @param \WP_Query $query WP_Query instance.
 	 */
 	public static function media_list_table_query( $query ) {
 

--- a/projects/plugins/jetpack/changelog/fix-videopress-deletion-attribution
+++ b/projects/plugins/jetpack/changelog/fix-videopress-deletion-attribution
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Updated deprecated VideoPress shim to avoid calling another deprecated method.
+
+

--- a/projects/plugins/jetpack/modules/videopress/class.jetpack-videopress.php
+++ b/projects/plugins/jetpack/modules/videopress/class.jetpack-videopress.php
@@ -148,19 +148,19 @@ class Jetpack_VideoPress {
 	}
 
 	/**
-	 * Attempts to delete a VideoPress video from wp.com.
-	 * Will block the deletion from continuing if certain errors return from the wp.com API.
+	 * Previously deleted a VideoPress video from wp.com via API call.
+	 *
+	 * @deprecated 11.3
 	 *
 	 * @param Boolean $delete if the deletion should occur or not (unused).
 	 * @param WP_Post $post the post object.
 	 *
-	 * @deprecated 11.3
-	 *
-	 * @return null|WP_Error|Boolean null if deletion should continue.
+	 * @return null null to allow the deletion to continue.
 	 */
 	public function delete_video_wpcom( $delete, $post ) {
-		_deprecated_function( __METHOD__, 'jetpack-11.3', 'Automattic\Jetpack\VideoPress\Attachment_Handler::delete_video_wpcom' );
-		return Attachment_Handler::delete_video_wpcom( $delete, $post );
+		_deprecated_function( __METHOD__, 'jetpack-11.3' );
+		Attachment_Handler::delete_video_poster_attachment( $post->ID );
+		return null;
 	}
 
 	/**

--- a/projects/plugins/jetpack/modules/videopress/editor-media-view.php
+++ b/projects/plugins/jetpack/modules/videopress/editor-media-view.php
@@ -116,7 +116,7 @@ function videopress_ajax_query_attachments_args( $args ) {
  * Media List:
  * Do the same as `videopress_ajax_query_attachments_args()` but for the list view.
  *
- * @param array $query WP_Query instance.
+ * @param \WP_Query $query WP_Query instance.
  * @deprecated 11.4
  */
 function videopress_media_list_table_query( $query ) {


### PR DESCRIPTION
Fixes https://linear.app/automattic/issue/VIDP-219

## Proposed changes:

* Remove the explicit wpcom API call (`/videos/{guid}/delete`) from `Attachment_Handler::delete_video_wpcom()` and deprecate the method.
* VideoPress file cleanup on wp.com is now handled via Jetpack Sync — when the attachment deletion is replicated, the wpcom replicastore fires `before_jetpack_deleted_post`, which triggers video file removal there.
* Hook `delete_video_poster_attachment()` directly into `delete_attachment` (instead of the old `pre_delete_attachment` filter) to clean up poster images.

### Context:

When a VideoPress video was deleted, the Jetpack site called the wp.com `/videos/{guid}/delete` endpoint using a blog token (`_as_blog`), which carries no user identity. On wp.com, the endpoint called `wp_delete_attachment()`, which fires `deleted_post` locally — and the WPCOM Sync Listener captures this event with an empty actor (user_id=0). This Activity Log entry preempted the Sync event from the Jetpack site that carries the correct user data, resulting in the deletion appearing with no attribution in the Activity Log.

Rather than switching to a user token, we remove the explicit API call entirely. The wpcom side now hooks into `before_jetpack_deleted_post` to handle video file cleanup when the Sync replicastore processes the deletion. Since the Sync event carries the correct user context from the originating Jetpack site, the Activity Log attribution is correct automatically.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?

No. The same deletion occurs — only the mechanism changes. Instead of the Jetpack site explicitly calling a wpcom API endpoint (with a blog token), the deletion is now handled via Jetpack Sync, which already carries the correct user context.

## Testing instructions:

* Upload a VideoPress video to a Jetpack-connected site.
* Wait for the video to finish processing.
* Delete the video from the Media Library.
* Check the Activity Log on wp.com (or Jetpack → Activity Log) for the deletion event.
* Verify that the deletion is attributed to the user who performed it (shows username and avatar), rather than appearing with a grey silhouette and no actor.
* Verify that VideoPress files are cleaned up on wpcom (video entry removed/marked deleted).