### PR TITLE
Forms: Add ref support to the contact-form shortcode

### DIFF
--- a/projects/packages/forms/changelog/fix-missing-shortcode-ref-attribute
+++ b/projects/packages/forms/changelog/fix-missing-shortcode-ref-attribute
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Contact Form: fix shortcode ref attribute to load form from jetpack_form post type.
+Contact Form: Fix shortcode ref attribute to load form from jetpack_form post type.

--- a/projects/packages/forms/changelog/fix-missing-shortcode-ref-attribute
+++ b/projects/packages/forms/changelog/fix-missing-shortcode-ref-attribute
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Contact Form: fix shortcode ref attribute to load form from jetpack_form post type.

--- a/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
+++ b/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
@@ -798,140 +798,17 @@ class Contact_Form_Block {
 
 		self::load_view_scripts();
 
-		// Handle ref attribute - load form from jetpack-form post
+		// Handle ref attribute - load form from jetpack_form post
 		if ( isset( $atts['ref'] ) ) {
 			$ref_id = absint( $atts['ref'] );
 			if ( $ref_id > 0 ) {
-				return self::render_synced_form( $ref_id );
+				return Contact_Form::render_synced_form( $ref_id );
 			} else {
 				return ''; // Invalid ref ID.
 			}
 		}
 
 		return Contact_Form::parse( $atts, do_blocks( $content ) );
-	}
-
-	/**
-	 * Render a synced form by reference ID.
-	 *
-	 * @param int $ref_id The jetpack_form post ID.
-	 * @return string Rendered form HTML.
-	 */
-	private static function render_synced_form( $ref_id ) {
-		// Circular reference prevention.
-		if ( Contact_Form::has_seen( $ref_id ) ) {
-			return '';
-		}
-		// Load the jetpack-form post.
-		$synced_form = get_post( $ref_id );
-
-		// Validate post.
-		if ( ! $synced_form || 'jetpack_form' !== $synced_form->post_type ) {
-			return '';
-		}
-
-		$status = $synced_form->post_status;
-
-		// Trashed forms are always hidden.
-		if ( 'trash' === $status ) {
-			return '';
-		}
-
-		// Published forms render normally for everyone.
-		if ( 'publish' === $status ) {
-			return self::render_synced_form_content( $ref_id, $synced_form );
-		}
-
-		// For non-published statuses (draft, pending, future, private), only show preview to users who can edit the form.
-		if ( ! current_user_can( 'edit_post', $ref_id ) ) {
-			return '';
-		}
-
-		// Render the form with a status notice for editors.
-		$notice       = self::render_frontend_status_notice( $synced_form );
-		$form_content = self::render_synced_form_content( $ref_id, $synced_form );
-
-		return $notice . $form_content;
-	}
-
-	/**
-	 * Render the actual form content for a synced form.
-	 *
-	 * @param int      $ref_id The jetpack_form post ID.
-	 * @param \WP_Post $synced_form The synced form post object.
-	 * @return string Rendered form HTML.
-	 */
-	private static function render_synced_form_content( $ref_id, $synced_form ) {
-		if ( $ref_id === Contact_Form::get_ref_id() ) {
-			return '';
-		}
-		// Mark as seen for circular reference prevention.
-		Contact_Form::set_ref_id( $ref_id );
-		$output = '';
-		try {
-			// Parse and render blocks from post_content.
-			$blocks = parse_blocks( $synced_form->post_content );
-			foreach ( $blocks as $block ) {
-				$output .= render_block( $block );
-			}
-		} finally {
-			// Clean up.
-			Contact_Form::clear_ref_id( $ref_id );
-		}
-		return $output;
-	}
-
-	/**
-	 * Render a frontend status notice for non-published forms.
-	 *
-	 * @param \WP_Post $synced_form The synced form post object.
-	 * @return string Notice HTML.
-	 */
-	private static function render_frontend_status_notice( $synced_form ) {
-		$status = $synced_form->post_status;
-
-		if ( 'publish' === $status || 'private' === $status ) {
-			return '';
-		}
-
-		$status_config = array(
-			'draft'   => array(
-				'type'    => 'warning',
-				'message' => __( 'This form is a draft and is only visible to you. Publish it to make it visible to site visitors.', 'jetpack-forms' ),
-			),
-			'pending' => array(
-				'type'    => 'warning',
-				'message' => __( 'This form is pending review and is only visible to you. It will be visible to site visitors once approved and published.', 'jetpack-forms' ),
-			),
-			'future'  => array(
-				'type'    => 'info',
-				'message' => sprintf(
-					/* translators: %s: scheduled publish date */
-					__( 'This form is scheduled for %s and is only visible to you until then.', 'jetpack-forms' ),
-					wp_date( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ), get_post_time( 'U', true, $synced_form ) )
-				),
-			),
-		);
-
-		if ( ! isset( $status_config[ $status ] ) ) {
-			return '';
-		}
-
-		$config     = $status_config[ $status ];
-		$type_class = 'info' === $config['type'] ? 'jetpack-form-status-notice--info' : 'jetpack-form-status-notice--warning';
-		$edit_url   = get_edit_post_link( $synced_form->ID, 'raw' );
-		$edit_link  = $edit_url ? sprintf(
-			' <a href="%s" class="jetpack-form-status-notice__edit-link">%s</a>',
-			esc_url( $edit_url ),
-			esc_html__( 'Edit form', 'jetpack-forms' )
-		) : '';
-
-		return sprintf(
-			'<div class="jetpack-form-status-notice %s"><p>%s%s</p></div>',
-			esc_attr( $type_class ),
-			esc_html( $config['message'] ),
-			$edit_link
-		);
 	}
 
 	/**

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -1185,6 +1185,8 @@ class Contact_Form extends Contact_Form_Shortcode {
 			$ref_id = absint( $attributes['ref'] );
 			if ( $ref_id > 0 ) {
 				return self::render_synced_form( $ref_id );
+			} else {
+				return '';
 			}
 		}
 

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -206,6 +206,133 @@ class Contact_Form extends Contact_Form_Shortcode {
 	}
 
 	/**
+	 * Render a synced form by reference ID.
+	 *
+	 * This handles loading a form from a jetpack_form post and rendering it.
+	 * Used by both the shortcode [contact-form ref="123"] and the block.
+	 *
+	 * @param int $ref_id The jetpack_form post ID.
+	 * @return string Rendered form HTML.
+	 */
+	public static function render_synced_form( $ref_id ) {
+		// Circular reference prevention.
+		if ( self::has_seen( $ref_id ) ) {
+			return '';
+		}
+
+		// Load the jetpack_form post.
+		$synced_form = get_post( $ref_id );
+
+		// Validate post.
+		if ( ! $synced_form || self::POST_TYPE !== $synced_form->post_type ) {
+			return '';
+		}
+
+		$status = $synced_form->post_status;
+
+		// Trashed forms are always hidden.
+		if ( 'trash' === $status ) {
+			return '';
+		}
+
+		// Published forms render normally for everyone.
+		if ( 'publish' === $status ) {
+			return self::render_synced_form_content( $ref_id, $synced_form );
+		}
+
+		// For non-published statuses (draft, pending, future, private), only show preview to users who can edit the form.
+		if ( ! current_user_can( 'edit_post', $ref_id ) ) {
+			return '';
+		}
+
+		// Render the form with a status notice for editors.
+		$notice       = self::render_frontend_status_notice( $synced_form );
+		$form_content = self::render_synced_form_content( $ref_id, $synced_form );
+
+		return $notice . $form_content;
+	}
+
+	/**
+	 * Render the actual form content for a synced form.
+	 *
+	 * @param int      $ref_id The jetpack_form post ID.
+	 * @param \WP_Post $synced_form The synced form post object.
+	 * @return string Rendered form HTML.
+	 */
+	private static function render_synced_form_content( $ref_id, $synced_form ) {
+		if ( $ref_id === self::get_ref_id() ) {
+			return '';
+		}
+		// Mark as seen for circular reference prevention.
+		self::set_ref_id( $ref_id );
+		$output = '';
+		try {
+			// Parse and render blocks from post_content.
+			$blocks = parse_blocks( $synced_form->post_content );
+			foreach ( $blocks as $block ) {
+				$output .= render_block( $block );
+			}
+		} finally {
+			// Clean up.
+			self::clear_ref_id( $ref_id );
+		}
+		return $output;
+	}
+
+	/**
+	 * Render a frontend status notice for non-published forms.
+	 *
+	 * @param \WP_Post $synced_form The synced form post object.
+	 * @return string Notice HTML.
+	 */
+	private static function render_frontend_status_notice( $synced_form ) {
+		$status = $synced_form->post_status;
+
+		if ( 'publish' === $status || 'private' === $status ) {
+			return '';
+		}
+
+		$status_config = array(
+			'draft'   => array(
+				'type'    => 'warning',
+				'message' => __( 'This form is a draft and is only visible to you. Publish it to make it visible to site visitors.', 'jetpack-forms' ),
+			),
+			'pending' => array(
+				'type'    => 'warning',
+				'message' => __( 'This form is pending review and is only visible to you. It will be visible to site visitors once approved and published.', 'jetpack-forms' ),
+			),
+			'future'  => array(
+				'type'    => 'info',
+				'message' => sprintf(
+					/* translators: %s: scheduled publish date */
+					__( 'This form is scheduled for %s and is only visible to you until then.', 'jetpack-forms' ),
+					wp_date( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ), get_post_time( 'U', true, $synced_form ) )
+				),
+			),
+		);
+
+		if ( ! isset( $status_config[ $status ] ) ) {
+			return '';
+		}
+
+		$config     = $status_config[ $status ];
+		$type_class = 'info' === $config['type'] ? 'jetpack-form-status-notice--info' : 'jetpack-form-status-notice--warning';
+		$edit_url   = get_edit_post_link( $synced_form->ID, 'raw' );
+		$edit_link  = $edit_url ? sprintf(
+			' <a href="%s" class="jetpack-form-status-notice__edit-link">%s</a>',
+			esc_url( $edit_url ),
+			esc_html__( 'Edit form', 'jetpack-forms' )
+		) : '';
+
+		return sprintf(
+			'<div class="jetpack-form-status-notice %s"><p>%s%s</p></div>',
+			esc_attr( $type_class ),
+			esc_html( $config['message'] ),
+			$edit_link
+		);
+	}
+
+	/**
 	 * Construction function.
 	 *
 	 * @param array  $attributes - the attributes.
@@ -1052,6 +1179,15 @@ class Contact_Form extends Contact_Form_Shortcode {
 		if ( Settings::is_syncing() ) {
 			return '';
 		}
+
+		// Handle ref attribute - load form from jetpack_form post
+		if ( is_array( $attributes ) && isset( $attributes['ref'] ) ) {
+			$ref_id = absint( $attributes['ref'] );
+			if ( $ref_id > 0 ) {
+				return self::render_synced_form( $ref_id );
+			}
+		}
+
 		if ( isset( $GLOBALS['grunion_block_template_part_id'] ) ) {
 			self::style_on();
 			if ( is_array( $attributes ) ) {

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Synced_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Synced_Test.php
@@ -535,6 +535,111 @@ class Contact_Form_Synced_Test extends BaseTestCase {
 	}
 
 	/**
+	 * Test that shortcode with ref attribute loads content from synced form post.
+	 */
+	public function test_shortcode_with_ref_attribute_loads_synced_form() {
+		// Disable content filtering to prevent WordPress from escaping JSON
+		kses_remove_filters();
+
+		// Use a unique label that wouldn't appear in a default form to avoid false positives
+		$unique_label = 'Unique Shortcode Test Field XYZ123';
+
+		// Create a jetpack_form post with form content containing the unique label
+		$form_id = wp_insert_post(
+			array(
+				'post_type'    => 'jetpack_form',
+				'post_status'  => 'publish',
+				'post_title'   => 'Test Synced Form',
+				'post_content' => sprintf(
+					'<!-- wp:jetpack/contact-form -->
+					<!-- wp:jetpack/field-text {"label":"%s","required":true} /-->
+					<!-- wp:jetpack/button {"element":"button","text":"Submit"} /-->
+					<!-- /wp:jetpack/contact-form -->',
+					$unique_label
+				),
+			)
+		);
+
+		kses_init_filters();
+
+		$this->assertGreaterThan( 0, $form_id, 'Synced form post should be created' );
+
+		// Process the shortcode with ref attribute
+		$shortcode = sprintf( '[contact-form ref="%d"]', $form_id );
+		$output    = do_shortcode( $shortcode );
+
+		// Verify the output contains the unique label from the synced form
+		// This ensures we're loading the actual referenced form, not a default form
+		$this->assertStringContainsString( $unique_label, $output, 'Shortcode output should contain the unique label from the referenced form' );
+	}
+
+	/**
+	 * Test that shortcode with invalid ref returns empty.
+	 */
+	public function test_shortcode_with_invalid_ref_returns_empty() {
+		// Process the shortcode with invalid ref
+		$shortcode = '[contact-form ref="99999"]'; // Non-existent form
+		$output    = do_shortcode( $shortcode );
+
+		// Should return empty or the original shortcode text (not render as a form)
+		$this->assertEmpty( $output, 'Shortcode with invalid ref should return empty' );
+	}
+
+	/**
+	 * Test that shortcode ref attribute prevents circular references.
+	 */
+	public function test_shortcode_ref_prevents_circular_reference() {
+		// Create a form that references itself
+		$form_id = wp_insert_post(
+			array(
+				'post_type'   => 'jetpack_form',
+				'post_status' => 'publish',
+				'post_title'  => 'Circular Form',
+			)
+		);
+
+		// Update the form to reference itself (circular reference)
+		kses_remove_filters();
+		$circular_content = sprintf( '<!-- wp:jetpack/contact-form {"ref":%d} /-->', $form_id );
+		wp_update_post(
+			array(
+				'ID'           => $form_id,
+				'post_content' => $circular_content,
+			)
+		);
+		kses_init_filters();
+
+		// Process the shortcode
+		$shortcode = sprintf( '[contact-form ref="%d"]', $form_id );
+		$output    = do_shortcode( $shortcode );
+
+		// Should return empty to prevent infinite loop
+		$this->assertEmpty( $output, 'Shortcode with circular ref should return empty' );
+	}
+
+	/**
+	 * Test that shortcode with ref attribute only renders published forms.
+	 */
+	public function test_shortcode_ref_only_renders_published_forms() {
+		// Create a trashed form
+		$trashed_form_id = wp_insert_post(
+			array(
+				'post_type'    => 'jetpack_form',
+				'post_status'  => 'trash',
+				'post_title'   => 'Trashed Form',
+				'post_content' => '<!-- wp:jetpack/contact-form --><!-- wp:jetpack/field-email /--><!-- /wp:jetpack/contact-form -->',
+			)
+		);
+
+		// Process the shortcode
+		$shortcode = sprintf( '[contact-form ref="%d"]', $trashed_form_id );
+		$output    = do_shortcode( $shortcode );
+
+		// Should not render trashed form
+		$this->assertEmpty( $output, 'Shortcode should not render trashed form' );
+	}
+
+	/**
 	 * Test that non-circular nested forms render successfully.
 	 */
 	public function test_non_circular_nested_forms_render() {


### PR DESCRIPTION
Add ref support for the 
## Proposed changes:

- Add support for the `ref` attribute in the `[contact-form]` shortcode to load form content from a `jetpack_form` post
- The shortcode `[contact-form ref='1234']` now properly loads the form from the referenced `jetpack_form` post, matching the behavior of the block version
- Includes circular reference prevention to avoid infinite loops
- Validates that referenced form exists, is the correct post type, and is published (or user can edit)

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

Enable `Central Form Management`

```
add_filter( 'jetpack_block_editor_feature_flags', 'eb_register_feature' );
function eb_register_feature( $flags ) {
    $flags['central-form-management'] = true;
    return $flags;
}
```

1. Create a new `jetpack_form` post via the Forms dashboard (WP Admin > Forms > Add New)
2. Add some form fields (e.g., Name, Email, Message) and publish the form
3. Note the form's post ID from the URL (e.g., `post=123`)
4. In a post or page, add the shortcode: `[contact-form ref="123"]` (using your form's ID)
5. View the post/page on the frontend and submit the form.
6. **Expected**: The form fields from the referenced `jetpack_form` should be displayed
7. **Before this fix**: The shortcode would render a default form, ignoring the `ref` attribute