### PR TITLE
Forms: fix layout display in widget areas

### DIFF
--- a/projects/packages/forms/changelog/fix-widget-area-forms-layout
+++ b/projects/packages/forms/changelog/fix-widget-area-forms-layout
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Contact Form: fix layout display in widget areas.

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -199,6 +199,10 @@
 	}
 }
 
+.widgets-php .wp-block-jetpack-contact-form:not(.is-layout-flex) {
+	display: block;
+}
+
 .jetpack-contact-form .components-placeholder {
 	padding: 24px;
 

--- a/projects/packages/forms/src/contact-form/css/grunion.scss
+++ b/projects/packages/forms/src/contact-form/css/grunion.scss
@@ -592,6 +592,10 @@
 	}
 }
 
+.widgets-php .wp-block-jetpack-contact-form:not(.is-layout-flex) {
+	display: block;
+}
+
 :where(.wp-block-jetpack-contact-form .wp-block-separator) {
 	max-width: var(--wp--preset--spacing--80, 100px);
 	margin-top: 0;

--- a/projects/packages/forms/src/contact-form/css/grunion.scss
+++ b/projects/packages/forms/src/contact-form/css/grunion.scss
@@ -592,10 +592,6 @@
 	}
 }
 
-.widgets-php .wp-block-jetpack-contact-form:not(.is-layout-flex) {
-	display: block;
-}
-
 :where(.wp-block-jetpack-contact-form .wp-block-separator) {
 	max-width: var(--wp--preset--spacing--80, 100px);
 	margin-top: 0;


### PR DESCRIPTION
## Proposed changes:
- Fix layout display issues for contact forms in widget areas
- Add `display: block` to forms in `.widgets-php` that don't use flex layout (`.is-layout-flex`)
- This prevents forms from rendering incorrectly when placed in legacy widget areas

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
N/A - CSS fix for existing functionality

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

1. Go to Appearance > Widgets (Legacy widgets screen)
2. Add a Jetpack Form block to a widget area
3. Verify the form displays correctly with proper block layout
4. Compare with trunk to confirm the form no longer has layout issues