### PR TITLE
Forms: remove grunion.css dependency from layout stylesheet

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-widget-area-remove-grunion
+++ b/projects/packages/forms/changelog/fix-forms-widget-area-remove-grunion
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Contact Form: remove grunion.css dependency from forms layout stylesheet.

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -199,10 +199,6 @@
 	}
 }
 
-.widgets-php .wp-block-jetpack-contact-form:not(.is-layout-flex) {
-	display: block;
-}
-
 .jetpack-contact-form .components-placeholder {
 	padding: 24px;
 

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -351,7 +351,7 @@ class Contact_Form_Plugin {
 		wp_register_style(
 			'jetpack-forms-layout',
 			Jetpack_Forms::plugin_url() . '../dist/contact-form/css/jetpack-forms-layout.css',
-			array( 'grunion.css' ),
+			array(),
 			\JETPACK__VERSION
 		);
 


### PR DESCRIPTION
## Proposed changes:
- Remove the `grunion.css` dependency from the `jetpack-forms-layout` stylesheet registration
- Remove the widget-specific CSS override (`.widgets-php .wp-block-jetpack-contact-form:not(.is-layout-flex) { display: block; }`) that is no longer needed

This is a follow-up to #47132. The grunion.css dependency was causing styling issues in widget areas where the layout styles weren't loading properly if grunion.css was enqueued.

This PR make it so that grunion only loads on the frontend and not in the widget area. This was introduced in https://github.com/Automattic/jetpack/pull/45272. So this PR will make it work more like before. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
See p1771010629674649-slack-C052XEUUBL4

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

1. Add a Jetpack Form block to a widget area (e.g., the sidebar widget area in a classic theme)
2. Verify the form displays correctly with proper layout (fields should appear in their expected positions)
3. Check that no console errors appear related to missing stylesheets
4. Confirm the form still works correctly in regular post/page content