### PR TITLE
Forms: add help for form blocks vs synced forms

### DIFF
--- a/projects/packages/forms/changelog/add-forms-wpbuild-dashboard-block-clarification
+++ b/projects/packages/forms/changelog/add-forms-wpbuild-dashboard-block-clarification
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Dashboard: add help for blocks vs forms.

--- a/projects/packages/forms/changelog/fix-forms-wp-build-single-view-source-column
+++ b/projects/packages/forms/changelog/fix-forms-wp-build-single-view-source-column
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Dashboard: re-add the source column to the single form view responses table.

--- a/projects/packages/forms/changelog/fix-forms-wp-build-single-view-source-column
+++ b/projects/packages/forms/changelog/fix-forms-wp-build-single-view-source-column
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Dashboard: re-add the source column to the single form view responses table.

--- a/projects/packages/forms/routes/forms/stage.tsx
+++ b/projects/packages/forms/routes/forms/stage.tsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { Page } from '@wordpress/admin-ui';
-import apiFetch from '@wordpress/api-fetch';
 import {
 	__experimentalConfirmDialog as ConfirmDialog, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 	Button,
@@ -26,8 +25,8 @@ import useDeleteForm from '../../src/dashboard/hooks/use-delete-form.ts';
 import useFormsData from '../../src/dashboard/hooks/use-forms-data.ts';
 import WpRouteDashboardSearchParamsProvider from '../../src/dashboard/router/wp-route-dashboard-search-params-provider.tsx';
 import DataViewsHeaderRow from '../../src/dashboard/wp-build/components/dataviews-header-row';
-import useFormItemActions from '../../src/dashboard/wp-build/hooks/use-form-item-actions';
 import FormsHelpModal from '../../src/dashboard/wp-build/components/forms-help-modal';
+import useFormItemActions from '../../src/dashboard/wp-build/hooks/use-form-item-actions';
 import usePageHeaderDetails from '../../src/dashboard/wp-build/hooks/use-page-header-details';
 import '../../src/dashboard/wp-build/style.scss';
 import useConfigValue from '../../src/hooks/use-config-value';
@@ -431,6 +430,7 @@ function StageInner() {
 		actions: headerActions,
 	} = usePageHeaderDetails( {
 		screen: 'forms',
+		formsCount: totalItems ?? 0,
 		isIntegrationsEnabled: !! isIntegrationsEnabled,
 		showDashboardIntegrations: !! showDashboardIntegrations,
 		onOpenIntegrations: openIntegrationsModal,

--- a/projects/packages/forms/routes/forms/stage.tsx
+++ b/projects/packages/forms/routes/forms/stage.tsx
@@ -2,7 +2,12 @@
  * External dependencies
  */
 import { Page } from '@wordpress/admin-ui';
-import { __experimentalConfirmDialog as ConfirmDialog } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
+import apiFetch from '@wordpress/api-fetch';
+import {
+	__experimentalConfirmDialog as ConfirmDialog, // eslint-disable-line @wordpress/no-unsafe-wp-apis
+	Button,
+	__experimentalHStack as HStack, // eslint-disable-line @wordpress/no-unsafe-wp-apis
+} from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { DataViews } from '@wordpress/dataviews';
 import { dateI18n, getSettings as getDateSettings } from '@wordpress/date';
@@ -22,6 +27,7 @@ import useFormsData from '../../src/dashboard/hooks/use-forms-data.ts';
 import WpRouteDashboardSearchParamsProvider from '../../src/dashboard/router/wp-route-dashboard-search-params-provider.tsx';
 import DataViewsHeaderRow from '../../src/dashboard/wp-build/components/dataviews-header-row';
 import useFormItemActions from '../../src/dashboard/wp-build/hooks/use-form-item-actions';
+import FormsHelpModal from '../../src/dashboard/wp-build/components/forms-help-modal';
 import usePageHeaderDetails from '../../src/dashboard/wp-build/hooks/use-page-header-details';
 import '../../src/dashboard/wp-build/style.scss';
 import useConfigValue from '../../src/hooks/use-config-value';
@@ -64,6 +70,7 @@ function StageInner() {
 
 	const dateSettings = getDateSettings();
 	const [ isIntegrationsModalOpen, setIsIntegrationsModalOpen ] = useState( false );
+	const [ isFormsHelpModalOpen, setIsFormsHelpModalOpen ] = useState( false );
 	const integrations = useSelect(
 		select => ( select( INTEGRATIONS_STORE ) as IntegrationsSelectors ).getIntegrations?.() ?? [],
 		[]
@@ -411,6 +418,12 @@ function StageInner() {
 	const closeIntegrationsModal = useCallback( () => {
 		setIsIntegrationsModalOpen( false );
 	}, [] );
+	const openFormsHelpModal = useCallback( () => {
+		setIsFormsHelpModalOpen( true );
+	}, [] );
+	const closeFormsHelpModal = useCallback( () => {
+		setIsFormsHelpModalOpen( false );
+	}, [] );
 
 	const {
 		breadcrumbs,
@@ -421,6 +434,7 @@ function StageInner() {
 		isIntegrationsEnabled: !! isIntegrationsEnabled,
 		showDashboardIntegrations: !! showDashboardIntegrations,
 		onOpenIntegrations: openIntegrationsModal,
+		onOpenFormsHelp: openFormsHelpModal,
 	} );
 	const getItemId = useCallback( ( item: FormListItem ) => String( item.id ), [] );
 	const onClickItem = useCallback(
@@ -452,11 +466,16 @@ function StageInner() {
 							'jetpack-forms'
 						) }
 						actions={
-							<CreateFormButton
-								label={ __( 'Create a new form', 'jetpack-forms' ) }
-								variant="primary"
-								showIcon={ false }
-							/>
+							<HStack justify="center" spacing="2">
+								<CreateFormButton
+									label={ __( 'Create a new form', 'jetpack-forms' ) }
+									variant="primary"
+									showIcon={ false }
+								/>
+								<Button size="compact" variant="secondary" onClick={ openFormsHelpModal }>
+									{ __( 'Missing forms?', 'jetpack-forms' ) }
+								</Button>
+							</HStack>
 						}
 					/>
 				}
@@ -506,6 +525,7 @@ function StageInner() {
 				refreshIntegrations={ refreshIntegrations }
 				context="dashboard"
 			/>
+			<FormsHelpModal isOpen={ isFormsHelpModalOpen } onClose={ closeFormsHelpModal } />
 		</Page>
 	);
 }

--- a/projects/packages/forms/routes/forms/stage.tsx
+++ b/projects/packages/forms/routes/forms/stage.tsx
@@ -107,6 +107,9 @@ function StageInner() {
 		return statusFilterValue === 'trash';
 	}, [ view.filters ] );
 
+	// Stable (non-trash) managed forms count, independent of the current DataViews search/filter state.
+	const { totalItems: totalNonTrashForms } = useFormsData( 1, 1, '', NON_TRASH_FORM_STATUSES );
+
 	const { records, isLoading, totalItems, totalPages } = useFormsData(
 		view.page ?? 1,
 		view.perPage ?? 20,
@@ -430,7 +433,7 @@ function StageInner() {
 		actions: headerActions,
 	} = usePageHeaderDetails( {
 		screen: 'forms',
-		formsCount: totalItems ?? 0,
+		formsCount: totalNonTrashForms ?? 0,
 		isIntegrationsEnabled: !! isIntegrationsEnabled,
 		showDashboardIntegrations: !! showDashboardIntegrations,
 		onOpenIntegrations: openIntegrationsModal,

--- a/projects/packages/forms/src/dashboard/wp-build/components/forms-help-modal/index.tsx
+++ b/projects/packages/forms/src/dashboard/wp-build/components/forms-help-modal/index.tsx
@@ -47,6 +47,7 @@ export default function FormsHelpModal( { isOpen, onClose }: Props ) {
 						<li>
 							{ __( 'Click “Edit Form” in the block toolbar to convert it.', 'jetpack-forms' ) }
 						</li>
+						<li>{ __( 'Save the page or post.', 'jetpack-forms' ) }</li>
 					</ol>
 				</div>
 				<div>

--- a/projects/packages/forms/src/dashboard/wp-build/components/forms-help-modal/index.tsx
+++ b/projects/packages/forms/src/dashboard/wp-build/components/forms-help-modal/index.tsx
@@ -37,7 +37,7 @@ export default function FormsHelpModal( { isOpen, onClose }: Props ) {
 				</Text>
 				<div>
 					<Text as="p" weight="500">
-						{ __( 'To convert a form block to a resuable form:', 'jetpack-forms' ) }
+						{ __( 'To convert a form block to a reusable form:', 'jetpack-forms' ) }
 					</Text>
 					<ol>
 						<li>

--- a/projects/packages/forms/src/dashboard/wp-build/components/forms-help-modal/index.tsx
+++ b/projects/packages/forms/src/dashboard/wp-build/components/forms-help-modal/index.tsx
@@ -1,0 +1,60 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	Button,
+	Modal,
+	__experimentalText as Text, // eslint-disable-line @wordpress/no-unsafe-wp-apis
+	__experimentalVStack as VStack, // eslint-disable-line @wordpress/no-unsafe-wp-apis
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+type Props = {
+	isOpen: boolean;
+	onClose: () => void;
+};
+
+/**
+ * Help modal explaining why some forms don't appear in the Forms list.
+ *
+ * This is intended for the wp-build "Forms" screen, where the list shows managed forms only.
+ *
+ * @param props         - Component props.
+ * @param props.isOpen  - Whether the modal is open.
+ * @param props.onClose - Close handler.
+ * @return The modal element, or null when closed.
+ */
+export default function FormsHelpModal( { isOpen, onClose }: Props ) {
+	if ( ! isOpen ) {
+		return null;
+	}
+
+	return (
+		<Modal title={ __( 'Not seeing all your forms?', 'jetpack-forms' ) } onRequestClose={ onClose }>
+			<VStack spacing="4">
+				<Text>
+					{ __( 'The Forms list shows reusable forms, not simple form blocks.', 'jetpack-forms' ) }
+				</Text>
+				<div>
+					<Text as="p" weight="500">
+						{ __( 'To convert a form block to a resuable form:', 'jetpack-forms' ) }
+					</Text>
+					<ol>
+						<li>
+							{ __( 'Open the page or post where your form block is embedded.', 'jetpack-forms' ) }
+						</li>
+						<li>{ __( 'Select the form block.', 'jetpack-forms' ) }</li>
+						<li>
+							{ __( 'Click “Edit Form” in the block toolbar to convert it.', 'jetpack-forms' ) }
+						</li>
+					</ol>
+				</div>
+				<div>
+					<Button variant="primary" onClick={ onClose }>
+						{ __( 'Got it', 'jetpack-forms' ) }
+					</Button>
+				</div>
+			</VStack>
+		</Modal>
+	);
+}

--- a/projects/packages/forms/src/dashboard/wp-build/hooks/use-page-header-details.tsx
+++ b/projects/packages/forms/src/dashboard/wp-build/hooks/use-page-header-details.tsx
@@ -177,25 +177,21 @@ export default function usePageHeaderDetails(
 
 	const subtitle = useMemo( () => {
 		if ( isFormsScreen ) {
-			const base = __( 'View and manage all your forms.', 'jetpack-forms' );
+			const shortMessage = __( 'View and manage all your forms.', 'jetpack-forms' );
+			const longMessage = __( 'View and manage all your forms in one place.', 'jetpack-forms' );
 
-			if ( ! onOpenFormsHelp ) {
-				return base;
-			}
+			const shouldShowFormsHelpLink =
+				!! onOpenFormsHelp && ( typeof formsCount !== 'number' || formsCount < 5 );
 
-			const shouldShowFormsHelpLink = typeof formsCount !== 'number' || formsCount < 5;
-
-			if ( ! shouldShowFormsHelpLink ) {
-				return base;
-			}
-
-			return (
+			return shouldShowFormsHelpLink ? (
 				<>
-					{ base }{ ' ' }
+					{ shortMessage }{ ' ' }
 					<Button variant="link" onClick={ onOpenFormsHelp }>
 						{ __( 'Missing forms?', 'jetpack-forms' ) }
 					</Button>
 				</>
+			) : (
+				longMessage
 			);
 		}
 

--- a/projects/packages/forms/src/dashboard/wp-build/hooks/use-page-header-details.tsx
+++ b/projects/packages/forms/src/dashboard/wp-build/hooks/use-page-header-details.tsx
@@ -3,12 +3,8 @@
  */
 import { useBreakpointMatch } from '@automattic/jetpack-components';
 import JetpackLogo from '@automattic/jetpack-components/jetpack-logo';
-/**
- * WordPress dependencies
- */
 import { Breadcrumbs } from '@wordpress/admin-ui';
-import { DropdownMenu } from '@wordpress/components';
-import { Button } from '@wordpress/components';
+import { DropdownMenu, Button } from '@wordpress/components';
 import { store as coreDataStore } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
 import { useMemo } from '@wordpress/element';
@@ -42,6 +38,7 @@ type UsePageHeaderDetailsProps = {
 	screen: 'forms' | 'responses';
 	statusView?: ResponsesStatusView;
 	sourceId?: string | number;
+	formsCount?: number;
 	isIntegrationsEnabled: boolean;
 	showDashboardIntegrations: boolean;
 	onOpenIntegrations: () => void;
@@ -69,6 +66,7 @@ export default function usePageHeaderDetails(
 	const {
 		screen,
 		sourceId,
+		formsCount,
 		isIntegrationsEnabled,
 		showDashboardIntegrations,
 		onOpenIntegrations,
@@ -185,6 +183,12 @@ export default function usePageHeaderDetails(
 				return base;
 			}
 
+			const shouldShowFormsHelpLink = typeof formsCount !== 'number' || formsCount < 5;
+
+			if ( ! shouldShowFormsHelpLink ) {
+				return base;
+			}
+
 			return (
 				<>
 					{ base }{ ' ' }
@@ -207,7 +211,7 @@ export default function usePageHeaderDetails(
 		}
 
 		return __( 'View and manage all your form submissions in one place.', 'jetpack-forms' );
-	}, [ formTitle, isFormsScreen, isSingleFormScreen, onOpenFormsHelp ] );
+	}, [ formTitle, isFormsScreen, isSingleFormScreen, onOpenFormsHelp, formsCount ] );
 
 	const actions = useMemo( () => {
 		// Mobile: show dropdown menu with actions

--- a/projects/packages/forms/src/dashboard/wp-build/hooks/use-page-header-details.tsx
+++ b/projects/packages/forms/src/dashboard/wp-build/hooks/use-page-header-details.tsx
@@ -8,6 +8,7 @@ import JetpackLogo from '@automattic/jetpack-components/jetpack-logo';
  */
 import { Breadcrumbs } from '@wordpress/admin-ui';
 import { DropdownMenu } from '@wordpress/components';
+import { Button } from '@wordpress/components';
 import { store as coreDataStore } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
 import { useMemo } from '@wordpress/element';
@@ -44,6 +45,7 @@ type UsePageHeaderDetailsProps = {
 	isIntegrationsEnabled: boolean;
 	showDashboardIntegrations: boolean;
 	onOpenIntegrations: () => void;
+	onOpenFormsHelp?: () => void;
 };
 
 type UsePageHeaderDetailsReturn = {
@@ -64,8 +66,14 @@ type UsePageHeaderDetailsReturn = {
 export default function usePageHeaderDetails(
 	props: UsePageHeaderDetailsProps
 ): UsePageHeaderDetailsReturn {
-	const { screen, sourceId, isIntegrationsEnabled, showDashboardIntegrations, onOpenIntegrations } =
-		props;
+	const {
+		screen,
+		sourceId,
+		isIntegrationsEnabled,
+		showDashboardIntegrations,
+		onOpenIntegrations,
+		onOpenFormsHelp,
+	} = props;
 	const statusView: ResponsesStatusView = props.statusView ?? 'inbox';
 	const sourceIdNumber = useMemo( () => {
 		const value = sourceId;
@@ -171,7 +179,20 @@ export default function usePageHeaderDetails(
 
 	const subtitle = useMemo( () => {
 		if ( isFormsScreen ) {
-			return __( 'View and manage all your forms in one place.', 'jetpack-forms' );
+			const base = __( 'View and manage all your forms.', 'jetpack-forms' );
+
+			if ( ! onOpenFormsHelp ) {
+				return base;
+			}
+
+			return (
+				<>
+					{ base }{ ' ' }
+					<Button variant="link" onClick={ onOpenFormsHelp }>
+						{ __( 'Missing forms?', 'jetpack-forms' ) }
+					</Button>
+				</>
+			);
 		}
 
 		if ( isSingleFormScreen ) {
@@ -186,7 +207,7 @@ export default function usePageHeaderDetails(
 		}
 
 		return __( 'View and manage all your form submissions in one place.', 'jetpack-forms' );
-	}, [ formTitle, isFormsScreen, isSingleFormScreen ] );
+	}, [ formTitle, isFormsScreen, isSingleFormScreen, onOpenFormsHelp ] );
 
 	const actions = useMemo( () => {
 		// Mobile: show dropdown menu with actions


### PR DESCRIPTION
## Proposed changes:

This is a trial PR. It offers a simple way to address confusion for users when we launch Centralized Form Management, and they do not see their forms in the central forms list because we only show form posts not form blocks. 

We add a "Missing Forms?" button when the forms list is empty, and a similar link in the page subititle. Both open a modal with an explanation. 

**Screenshots**
<img width="1337" height="707" alt="missing-forms" src="https://github.com/user-attachments/assets/7fb6f382-1191-46c0-8b5c-ad7be7cb4547" />
<img width="1334" height="657" alt="forms-modal-2" src="https://github.com/user-attachments/assets/b378d71d-63cf-4ca5-a278-4711544dbbca" />


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Enable these feature flags: 

```
add_filter( 'jetpack_forms_alpha', '__return_true', 20 );
add_filter( 'jetpack_block_editor_feature_flags', 'eb_register_feature' );
function eb_register_feature( $flags ) {
    $flags['central-form-management'] = true;
    return $flags;
}
```

Test:
* Go to Jetpack > Forms, and be sure you are on the Forms tab
* Confirm the Missing Forms? link in the subtitle appears and opens the modal
* Move all forms in your forms list to trash, and confirm the Missing Forms? button shows and opens the modal. 