### PR TITLE
Forms: fix layout classes on wrong element for synced forms

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-layout-support-for-synced-forms
+++ b/projects/packages/forms/changelog/fix-forms-layout-support-for-synced-forms
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Contact Form: fix layout classes applied to wrong element for synced forms.

--- a/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
+++ b/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
@@ -692,6 +692,15 @@ class Contact_Form_Block {
 		// Count and store form steps
 		self::$form_step_count = self::count_form_steps_in_block( $parsed_block );
 
+		// For ref (synced) forms, render here via pre_render_block to short-circuit
+		// render_block(). This prevents wp_render_layout_support_flag from adding
+		// layout classes to the outer ref block's container div. The synced form's
+		// inner jetpack/contact-form block renders through the normal pipeline and
+		// gets layout classes on the correct element (wp-block-jetpack-contact-form).
+		if ( isset( $parsed_block['attrs']['ref'] ) ) {
+			return self::gutenblock_render_form( $parsed_block['attrs'], '' );
+		}
+
 		return $pre_render; // Don't actually pre-render, let normal rendering continue
 	}
 


### PR DESCRIPTION
Fixes #

## Proposed changes:
* For synced (ref) forms, layout classes from `wp_render_layout_support_flag` were being applied to the outer `core/block` ref wrapper div instead of the inner `wp-block-jetpack-contact-form` element. This caused layout styles (e.g., constrained width, flex, grid) to not work correctly on synced forms.
* The fix short-circuits rendering for synced forms in `pre_render_block`, which prevents WordPress from wrapping the output in an extra container div with misplaced layout classes. The inner `jetpack/contact-form` block still renders through the normal pipeline and receives layout classes on the correct element.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:

* Create a synced form (Reusable block / Pattern) containing a Jetpack Contact Form.
* Add the synced form to a post/page.
* On the frontend, inspect the rendered form HTML.
* **Before fix:** Layout classes (e.g., `is-layout-constrained`) appear on the outer ref block wrapper div, not on the form element itself.
* **After fix:** Layout classes are correctly applied to the `.wp-block-jetpack-contact-form` element, and the form renders with proper layout styles.
