### PR TITLE
AI Experiments: add module with experiment toggle infrastructure

### DIFF
--- a/projects/plugins/jetpack/changelog/add-ai-experiments
+++ b/projects/plugins/jetpack/changelog/add-ai-experiments
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+AI Experiments: add module with experiment toggle infrastructure and AI bot detection header.

--- a/projects/plugins/jetpack/modules/ai-experiments.php
+++ b/projects/plugins/jetpack/modules/ai-experiments.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * Module Name: AI Experiments
+ * Module Description: Experimental features that make your site work better with AI agents and large language models.
+ * Sort Order: 40
+ * First Introduced: 15.6
+ * Requires Connection: No
+ * Auto Activate: No
+ * Module Tags: Developers
+ * Feature: Traffic
+ * Additional Search Queries: ai, agents, llm, markdown, content negotiation, bot detection
+ *
+ * @package automattic/jetpack
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
+require __DIR__ . '/ai-experiments/class-jetpack-ai-experiments.php';
+
+Jetpack_AI_Experiments::init();

--- a/projects/plugins/jetpack/modules/ai-experiments/class-jetpack-ai-experiments.php
+++ b/projects/plugins/jetpack/modules/ai-experiments/class-jetpack-ai-experiments.php
@@ -1,0 +1,125 @@
+<?php
+/**
+ * AI Experiments orchestrator.
+ *
+ * Manages experiment toggles and delegates to feature classes.
+ * Each experiment is gated by a filter: jetpack_ai_experiments_{$slug}.
+ *
+ * @package automattic/jetpack
+ */
+
+use Automattic\Jetpack\Device_Detection\User_Agent_Info;
+
+/**
+ * Orchestrator for the AI Experiments module.
+ */
+class Jetpack_AI_Experiments {
+
+	/**
+	 * Registered experiments: slug => default enabled state.
+	 *
+	 * @var array<string, bool>
+	 */
+	private static $experiments = array(
+		'ai_bot_header' => true,
+	);
+
+	/**
+	 * Initialize the module. Iterates experiments and wires enabled ones.
+	 */
+	public static function init() {
+		foreach ( self::$experiments as $slug => $default ) {
+			if ( ! self::is_enabled( $slug ) ) {
+				continue;
+			}
+
+			switch ( $slug ) {
+				case 'ai_bot_header':
+					add_action( 'send_headers', array( __CLASS__, 'add_ai_bot_header' ) );
+					break;
+			}
+		}
+	}
+
+	/**
+	 * Check whether an experiment is enabled.
+	 *
+	 * @param string $experiment Experiment slug.
+	 * @return bool
+	 */
+	public static function is_enabled( $experiment ) {
+		$default = isset( self::$experiments[ $experiment ] ) ? self::$experiments[ $experiment ] : false;
+
+		/**
+		 * Filter to enable or disable an AI experiment.
+		 *
+		 * The dynamic portion of the hook name, `$experiment`, refers to the experiment slug.
+		 *
+		 * @param bool $enabled Whether the experiment is enabled.
+		 */
+		return (bool) apply_filters( "jetpack_ai_experiments_{$experiment}", $default );
+	}
+
+	/**
+	 * Detect whether the current request is from an AI bot/agent.
+	 *
+	 * Delegates to User_Agent_Info::is_agent() from the device-detection package
+	 * when available, with a hardcoded fallback for environments without it.
+	 *
+	 * @return bool
+	 */
+	public static function is_ai_bot() {
+		if ( class_exists( User_Agent_Info::class ) && method_exists( User_Agent_Info::class, 'is_agent' ) ) {
+			return User_Agent_Info::is_agent();
+		}
+
+		return self::is_ai_bot_fallback();
+	}
+
+	/**
+	 * Fallback AI bot detection for environments without the device-detection package.
+	 *
+	 * @return bool
+	 */
+	private static function is_ai_bot_fallback() {
+		if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
+			return false;
+		}
+
+		$ua       = sanitize_text_field( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ) );
+		$patterns = array(
+			'claudebot',
+			'claude-web',
+			'anthropic-ai',
+			'chatgpt-user',
+			'gptbot',
+			'oai-searchbot',
+			'google-extended',
+			'gemini',
+			'perplexitybot',
+			'cohere-ai',
+			'bytespider',
+			'ccbot',
+		);
+
+		$ua_lower = strtolower( $ua );
+		foreach ( $patterns as $pattern ) {
+			if ( false !== strpos( $ua_lower, $pattern ) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Send X-AI-Bot response header indicating whether the request is from an AI agent.
+	 */
+	public static function add_ai_bot_header() {
+		if ( headers_sent() ) {
+			return;
+		}
+
+		header( 'X-AI-Bot: ' . ( self::is_ai_bot() ? 'true' : 'false' ) );
+	}
+}


### PR DESCRIPTION
## Proposed changes:

New Jetpack module: **AI Experiments** — a container for experimental features that help sites work better with AI agents and LLMs.

This is a minimal first PR that establishes the module pattern:

- **Experiment toggle infrastructure**: each experiment is gated by `jetpack_ai_experiments_{$slug}` filter, making it easy to enable/disable individual experiments
- **AI bot detection**: `is_ai_bot()` delegates to `User_Agent_Info::is_agent()` from device-detection package (PR #46803), with hardcoded fallback
- **First experiment: `ai_bot_header`** — sends `X-AI-Bot: true|false` response header on every page load

Follow-up PRs will add one experiment each: content negotiation, markdown feeds, public abilities, source:markdown RSS.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

## Does this pull request change what data or activity we track or use?

No. The `X-AI-Bot` header only reflects user-agent detection already performed by the device-detection package. No new data is collected or stored.

## Testing instructions:

1. Activate the AI Experiments module: **Jetpack → Settings** → find "AI Experiments" in the modules list → toggle on
2. Verify bot header works:
   ```bash
   curl -A "claudebot" -I http://localhost/
   # → should include: X-AI-Bot: true

   curl -A "Mozilla/5.0" -I http://localhost/
   # → should include: X-AI-Bot: false
   ```
3. Verify experiment toggle:
   ```php
   // Add to mu-plugins:
   add_filter( 'jetpack_ai_experiments_ai_bot_header', '__return_false' );
   ```
   Then repeat the curl — `X-AI-Bot` header should no longer appear.
4. Deactivate the module — header should stop appearing.