### PR TITLE
Forms: Place wp-build dashboard header actions in dropdown menu on mobile and fix content placement

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-wp-build-mobile
+++ b/projects/packages/forms/changelog/fix-forms-wp-build-mobile
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix wp-build dashboard headers and content positioning on mobile.

--- a/projects/packages/forms/routes/forms/stage.tsx
+++ b/projects/packages/forms/routes/forms/stage.tsx
@@ -21,6 +21,7 @@ import { EmptyWrapper } from '../../src/dashboard/components/empty-responses/ind
 import { NON_TRASH_FORM_STATUSES } from '../../src/dashboard/constants';
 import useDeleteForm from '../../src/dashboard/hooks/use-delete-form.ts';
 import useFormsData from '../../src/dashboard/hooks/use-forms-data.ts';
+import WpRouteDashboardSearchParamsProvider from '../../src/dashboard/router/wp-route-dashboard-search-params-provider.tsx';
 import DataViewsHeaderRow from '../../src/dashboard/wp-build/components/dataviews-header-row';
 import usePageHeaderDetails from '../../src/dashboard/wp-build/hooks/use-page-header-details';
 import '../../src/dashboard/wp-build/style.scss';
@@ -535,6 +536,12 @@ function StageInner() {
 	);
 }
 
-const Stage = () => <StageInner />;
+const Stage = () => {
+	return (
+		<WpRouteDashboardSearchParamsProvider from="/forms">
+			<StageInner />
+		</WpRouteDashboardSearchParamsProvider>
+	);
+};
 
 export { Stage as stage };

--- a/projects/packages/forms/routes/forms/style.scss
+++ b/projects/packages/forms/routes/forms/style.scss
@@ -1,2 +1,1 @@
-@use "sass:meta";
-@include meta.load-css("@wordpress/dataviews/build-style/style.css");
+@use "../shared";

--- a/projects/packages/forms/routes/responses/style.scss
+++ b/projects/packages/forms/routes/responses/style.scss
@@ -1,38 +1,5 @@
-@use "sass:meta";
 @use "@wordpress/base-styles/variables";
-@include meta.load-css("@wordpress/dataviews/build-style/style.css");
-
-// Fix for sticky header on mobile in wp-admin
-// The header needs to account for the wp-admin bar
-// (46px on mobile, 32px on tablet+)
-.admin-ui-page__header {
-
-	@media (max-width: 782px) {
-		// On mobile, the admin bar is fixed, so sticky header needs to be below it
-		top: 46px;
-	}
-}
-
-.jp-forms-dataviews__view-actions {
-	border-bottom: 1px solid var(--wpds-color-stroke-surface-neutral, #e0e0e0);
-	padding-inline: 20px;
-	overflow-x: auto;
-	width: 100%;
-	box-sizing: border-box;
-	container-type: inline-size;
-	flex-shrink: 0;
-
-	// On small screens, switch to column stacking
-	@container (width < 500px) {
-		--wp-ui-stack-justify: flex-start;
-		flex-direction: column;
-		align-items: flex-start;
-	}
-
-	> div:not(:empty) {
-		min-height: 48px;
-	}
-}
+@use "../shared";
 
 // Filters "pills" row: collapse when empty (match Inbox behavior).
 .jp-forms-dataviews-filters__container,

--- a/projects/packages/forms/routes/shared.scss
+++ b/projects/packages/forms/routes/shared.scss
@@ -1,0 +1,26 @@
+@use "sass:meta";
+@include meta.load-css("@wordpress/dataviews/build-style/style.css");
+
+// Fix for sticky header on mobile in wp-admin
+// The entire page needs to account for the wp-admin bar
+// (46px on mobile, 32px on tablet+)
+.admin-ui-page {
+
+	@media (max-width: 782px) {
+		// On mobile, the admin bar is fixed, so the page needs to be below it
+		top: 46px;
+	}
+}
+
+.jp-forms-dataviews__view-actions {
+	// On small screens, switch to column-reverse stacking
+	@container (width < 500px) {
+		--wp-ui-stack-justify: flex-start;
+		flex-direction: column-reverse;
+		align-items: flex-start;
+	}
+
+	> div:not(:empty) {
+		min-height: 48px;
+	}
+}

--- a/projects/packages/forms/src/dashboard/components/empty-spam-button/confirmation-modal.tsx
+++ b/projects/packages/forms/src/dashboard/components/empty-spam-button/confirmation-modal.tsx
@@ -1,0 +1,61 @@
+/**
+ * External dependencies
+ */
+import { formatNumber } from '@automattic/number-formatters';
+import { __experimentalConfirmDialog as ConfirmDialog } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
+import { __, _n, sprintf } from '@wordpress/i18n';
+
+interface EmptySpamConfirmationModalProps {
+	isOpen: boolean;
+	onCancel: () => void;
+	onConfirm: () => void;
+	totalItemsSpam: number;
+	selectedResponsesCount: number;
+}
+
+/**
+ * Confirmation modal for emptying spam.
+ *
+ * @param {object}   props                        - Component props.
+ * @param {boolean}  props.isOpen                 - Whether the modal is open.
+ * @param {Function} props.onCancel               - Function to call when the user cancels.
+ * @param {Function} props.onConfirm              - Function to call when the user confirms.
+ * @param {number}   props.totalItemsSpam         - The total number of spam items.
+ * @param {number}   props.selectedResponsesCount - The number of selected responses.
+ * @return {JSX.Element} The confirmation modal.
+ */
+export default function EmptySpamConfirmationModal( {
+	isOpen,
+	onCancel,
+	onConfirm,
+	totalItemsSpam,
+	selectedResponsesCount,
+}: EmptySpamConfirmationModalProps ): JSX.Element {
+	return (
+		<ConfirmDialog
+			onCancel={ onCancel }
+			onConfirm={ onConfirm }
+			isOpen={ isOpen }
+			confirmButtonText={ __( 'Delete', 'jetpack-forms' ) }
+		>
+			<h3>{ __( 'Delete forever', 'jetpack-forms' ) }</h3>
+			<p>
+				{ selectedResponsesCount > 0
+					? sprintf(
+							// translators: %s: the number of responses in spam
+							_n(
+								'%s response in spam will be deleted forever. This action cannot be undone.',
+								'All %s responses in spam will be deleted forever. This action cannot be undone.',
+								totalItemsSpam || 0,
+								'jetpack-forms'
+							),
+							formatNumber( totalItemsSpam )
+					  )
+					: __(
+							'All responses in spam will be deleted forever. This action cannot be undone.',
+							'jetpack-forms'
+					  ) }
+			</p>
+		</ConfirmDialog>
+	);
+}

--- a/projects/packages/forms/src/dashboard/components/empty-spam-button/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/empty-spam-button/index.tsx
@@ -12,20 +12,17 @@ import EmptySpamConfirmationModal from './confirmation-modal';
 
 interface EmptySpamButtonProps {
 	totalItemsSpam?: number;
-	isLoadingCounts?: boolean;
 }
 
 /**
  * Renders a button to empty form responses.
  *
- * @param {object}  props                 - Component props.
- * @param {number}  props.totalItemsSpam  - The total number of spam items (optional, will use hook if not provided).
- * @param {boolean} props.isLoadingCounts - Whether counts are loading (optional, will use hook if not provided).
+ * @param {object} props                - Component props.
+ * @param {number} props.totalItemsSpam - The total number of spam items (optional, will use hook if not provided).
  * @return {JSX.Element} The empty spam button.
  */
 const EmptySpamButton = ( {
 	totalItemsSpam: totalItemsSpamProp,
-	isLoadingCounts: isLoadingCountsProp,
 }: EmptySpamButtonProps = {} ): JSX.Element => {
 	const {
 		isConfirmDialogOpen,
@@ -38,7 +35,6 @@ const EmptySpamButton = ( {
 		selectedResponsesCount,
 	} = useEmptySpam( {
 		totalItemsSpam: totalItemsSpamProp,
-		isLoadingCounts: isLoadingCountsProp,
 	} );
 
 	return (

--- a/projects/packages/forms/src/dashboard/components/empty-spam-button/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/empty-spam-button/index.tsx
@@ -1,25 +1,14 @@
 /**
  * External dependencies
  */
-import jetpackAnalytics from '@automattic/jetpack-analytics';
-import { formatNumber } from '@automattic/number-formatters';
-import apiFetch from '@wordpress/api-fetch';
-import { Button, __experimentalConfirmDialog as ConfirmDialog } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
-import { store as coreStore } from '@wordpress/core-data';
-import { useDispatch } from '@wordpress/data';
-import { useState, useCallback, useEffect } from '@wordpress/element';
-import { __, _n, sprintf } from '@wordpress/i18n';
+import { Button } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
 import { trash } from '@wordpress/icons';
-import { store as noticesStore } from '@wordpress/notices';
 /**
  * Internal dependencies
  */
-import useInboxData from '../../hooks/use-inbox-data.ts';
-import { store as dashboardStore } from '../../store/index.js';
-
-type CoreStore = typeof coreStore & {
-	invalidateResolution: ( selector: string, args: unknown[] ) => void;
-};
+import useEmptySpam from '../../hooks/use-empty-spam';
+import EmptySpamConfirmationModal from './confirmation-modal';
 
 interface EmptySpamButtonProps {
 	totalItemsSpam?: number;
@@ -38,86 +27,19 @@ const EmptySpamButton = ( {
 	totalItemsSpam: totalItemsSpamProp,
 	isLoadingCounts: isLoadingCountsProp,
 }: EmptySpamButtonProps = {} ): JSX.Element => {
-	const [ isConfirmDialogOpen, setConfirmDialogOpen ] = useState( false );
-	const [ isEmptying, setIsEmptying ] = useState( false );
-	const [ isEmpty, setIsEmpty ] = useState( true );
-	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
-	const { invalidateResolution } = useDispatch( coreStore ) as unknown as CoreStore;
-	const { invalidateCounts } = useDispatch( dashboardStore );
-
-	// Use props if provided, otherwise use hook
-	const hookData = useInboxData();
-	const totalItemsSpam = totalItemsSpamProp ?? hookData.totalItemsSpam;
-	const isLoadingCounts = isLoadingCountsProp ?? false;
-	const { selectedResponsesCount, currentQuery } = hookData;
-
-	useEffect( () => {
-		setIsEmpty( isLoadingCounts || ! totalItemsSpam );
-	}, [ totalItemsSpam, isLoadingCounts ] );
-
-	const openConfirmDialog = useCallback( () => setConfirmDialogOpen( true ), [] );
-	const closeConfirmDialog = useCallback( () => setConfirmDialogOpen( false ), [] );
-
-	const onConfirmEmptying = useCallback( async () => {
-		if ( isEmptying || isEmpty ) {
-			return;
-		}
-
-		closeConfirmDialog();
-		setIsEmptying( true );
-
-		jetpackAnalytics.tracks.recordEvent( 'jetpack_forms_empty_spam_click' );
-
-		apiFetch( {
-			method: 'DELETE',
-			path: `/wp/v2/feedback/trash?status=spam`,
-		} )
-			.then( ( response: { deleted?: number } ) => {
-				const deleted = response?.deleted ?? 0;
-				const successMessage =
-					deleted === 1
-						? __( 'Response deleted permanently.', 'jetpack-forms' )
-						: sprintf(
-								/* translators: %s: The number of responses. */
-								_n(
-									'%s response deleted permanently.',
-									'%s responses deleted permanently.',
-									deleted,
-									'jetpack-forms'
-								),
-								formatNumber( deleted )
-						  );
-				createSuccessNotice( successMessage, { type: 'snackbar', id: 'empty-spam' } );
-			} )
-			.catch( () => {
-				createErrorNotice( __( 'Could not empty spam.', 'jetpack-forms' ), {
-					type: 'snackbar',
-					id: 'empty-spam-error',
-				} );
-			} )
-			.finally( () => {
-				setIsEmptying( false );
-				// invalidate items list
-				invalidateResolution( 'getEntityRecords', [ 'postType', 'feedback', currentQuery ] );
-				// invalidate total items value
-				invalidateResolution( 'getEntityRecords', [
-					'postType',
-					'feedback',
-					{ ...currentQuery, per_page: 1, _fields: 'id' },
-				] );
-				// invalidate counts to refresh the counts across all status tabs
-				invalidateCounts();
-			} );
-	}, [
+	const {
+		isConfirmDialogOpen,
+		openConfirmDialog,
 		closeConfirmDialog,
-		createErrorNotice,
-		createSuccessNotice,
-		invalidateResolution,
-		invalidateCounts,
+		onConfirmEmptying,
 		isEmpty,
 		isEmptying,
-		currentQuery,
-	] );
+		totalItemsSpam,
+		selectedResponsesCount,
+	} = useEmptySpam( {
+		totalItemsSpam: totalItemsSpamProp,
+		isLoadingCounts: isLoadingCountsProp,
+	} );
 
 	return (
 		<>
@@ -134,31 +56,13 @@ const EmptySpamButton = ( {
 			>
 				{ __( 'Delete spam', 'jetpack-forms' ) }
 			</Button>
-			<ConfirmDialog
+			<EmptySpamConfirmationModal
+				isOpen={ isConfirmDialogOpen }
 				onCancel={ closeConfirmDialog }
 				onConfirm={ onConfirmEmptying }
-				isOpen={ isConfirmDialogOpen }
-				confirmButtonText={ __( 'Delete', 'jetpack-forms' ) }
-			>
-				<h3>{ __( 'Delete forever', 'jetpack-forms' ) }</h3>
-				<p>
-					{ selectedResponsesCount > 0
-						? sprintf(
-								// translators: %s: the number of responses in spam
-								_n(
-									'%s response in spam will be deleted forever. This action cannot be undone.',
-									'All %s responses in spam will be deleted forever. This action cannot be undone.',
-									totalItemsSpam || 0,
-									'jetpack-forms'
-								),
-								formatNumber( totalItemsSpam )
-						  )
-						: __(
-								'All responses in spam will be deleted forever. This action cannot be undone.',
-								'jetpack-forms'
-						  ) }
-				</p>
-			</ConfirmDialog>
+				totalItemsSpam={ totalItemsSpam }
+				selectedResponsesCount={ selectedResponsesCount }
+			/>
 		</>
 	);
 };

--- a/projects/packages/forms/src/dashboard/components/empty-trash-button/confirmation-modal.tsx
+++ b/projects/packages/forms/src/dashboard/components/empty-trash-button/confirmation-modal.tsx
@@ -1,0 +1,61 @@
+/**
+ * External dependencies
+ */
+import { formatNumber } from '@automattic/number-formatters';
+import { __experimentalConfirmDialog as ConfirmDialog } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
+import { __, _n, sprintf } from '@wordpress/i18n';
+
+interface EmptyTrashConfirmationModalProps {
+	isOpen: boolean;
+	onCancel: () => void;
+	onConfirm: () => void;
+	totalItemsTrash: number;
+	selectedResponsesCount: number;
+}
+
+/**
+ * Confirmation modal for emptying trash.
+ *
+ * @param {object}   props                        - Component props.
+ * @param {boolean}  props.isOpen                 - Whether the modal is open.
+ * @param {Function} props.onCancel               - Function to call when the user cancels.
+ * @param {Function} props.onConfirm              - Function to call when the user confirms.
+ * @param {number}   props.totalItemsTrash        - The total number of trash items.
+ * @param {number}   props.selectedResponsesCount - The number of selected responses.
+ * @return {JSX.Element} The confirmation modal.
+ */
+export default function EmptyTrashConfirmationModal( {
+	isOpen,
+	onCancel,
+	onConfirm,
+	totalItemsTrash,
+	selectedResponsesCount,
+}: EmptyTrashConfirmationModalProps ): JSX.Element {
+	return (
+		<ConfirmDialog
+			onCancel={ onCancel }
+			onConfirm={ onConfirm }
+			isOpen={ isOpen }
+			confirmButtonText={ __( 'Delete', 'jetpack-forms' ) }
+		>
+			<h3>{ __( 'Delete forever', 'jetpack-forms' ) }</h3>
+			<p>
+				{ selectedResponsesCount > 0
+					? sprintf(
+							// translators: %s: the number of responses in the trash.
+							_n(
+								'%s response in trash will be deleted forever. This action cannot be undone.',
+								'All %s responses in trash will be deleted forever. This action cannot be undone.',
+								totalItemsTrash || 0,
+								'jetpack-forms'
+							),
+							formatNumber( totalItemsTrash )
+					  )
+					: __(
+							'All responses in trash will be deleted forever. This action cannot be undone.',
+							'jetpack-forms'
+					  ) }
+			</p>
+		</ConfirmDialog>
+	);
+}

--- a/projects/packages/forms/src/dashboard/components/empty-trash-button/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/empty-trash-button/index.tsx
@@ -12,20 +12,17 @@ import EmptyTrashConfirmationModal from './confirmation-modal';
 
 interface EmptyTrashButtonProps {
 	totalItemsTrash?: number;
-	isLoadingCounts?: boolean;
 }
 
 /**
  * Renders a button to empty form responses.
  *
- * @param {object}  props                 - Component props.
- * @param {number}  props.totalItemsTrash - The total number of trash items (optional, will use hook if not provided).
- * @param {boolean} props.isLoadingCounts - Whether counts are loading (optional, will use hook if not provided).
+ * @param {object} props                 - Component props.
+ * @param {number} props.totalItemsTrash - The total number of trash items (optional, will use hook if not provided).
  * @return {JSX.Element} The empty trash button.
  */
 const EmptyTrashButton = ( {
 	totalItemsTrash: totalItemsTrashProp,
-	isLoadingCounts: isLoadingCountsProp,
 }: EmptyTrashButtonProps = {} ): JSX.Element => {
 	const {
 		isConfirmDialogOpen,
@@ -38,7 +35,6 @@ const EmptyTrashButton = ( {
 		selectedResponsesCount,
 	} = useEmptyTrash( {
 		totalItemsTrash: totalItemsTrashProp,
-		isLoadingCounts: isLoadingCountsProp,
 	} );
 
 	return (

--- a/projects/packages/forms/src/dashboard/components/empty-trash-button/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/empty-trash-button/index.tsx
@@ -1,25 +1,14 @@
 /**
  * External dependencies
  */
-import jetpackAnalytics from '@automattic/jetpack-analytics';
-import { formatNumber } from '@automattic/number-formatters';
-import apiFetch from '@wordpress/api-fetch';
-import { Button, __experimentalConfirmDialog as ConfirmDialog } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
-import { store as coreStore } from '@wordpress/core-data';
-import { useDispatch } from '@wordpress/data';
-import { useState, useCallback, useEffect } from '@wordpress/element';
-import { __, _n, sprintf } from '@wordpress/i18n';
+import { Button } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
 import { trash } from '@wordpress/icons';
-import { store as noticesStore } from '@wordpress/notices';
 /**
  * Internal dependencies
  */
-import useInboxData from '../../hooks/use-inbox-data.ts';
-import { store as dashboardStore } from '../../store/index.js';
-
-type CoreStore = typeof coreStore & {
-	invalidateResolution: ( selector: string, args: unknown[] ) => void;
-};
+import useEmptyTrash from '../../hooks/use-empty-trash';
+import EmptyTrashConfirmationModal from './confirmation-modal';
 
 interface EmptyTrashButtonProps {
 	totalItemsTrash?: number;
@@ -38,86 +27,19 @@ const EmptyTrashButton = ( {
 	totalItemsTrash: totalItemsTrashProp,
 	isLoadingCounts: isLoadingCountsProp,
 }: EmptyTrashButtonProps = {} ): JSX.Element => {
-	const [ isConfirmDialogOpen, setConfirmDialogOpen ] = useState( false );
-	const [ isEmptying, setIsEmptying ] = useState( false );
-	const [ isEmpty, setIsEmpty ] = useState( true );
-	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
-	const { invalidateResolution } = useDispatch( coreStore ) as unknown as CoreStore;
-	const { invalidateCounts } = useDispatch( dashboardStore );
-
-	// Use props if provided, otherwise use hook
-	const hookData = useInboxData();
-	const totalItemsTrash = totalItemsTrashProp ?? hookData.totalItemsTrash;
-	const isLoadingCounts = isLoadingCountsProp ?? false;
-	const { selectedResponsesCount, currentQuery } = hookData;
-
-	useEffect( () => {
-		setIsEmpty( isLoadingCounts || ! totalItemsTrash );
-	}, [ totalItemsTrash, isLoadingCounts ] );
-
-	const openConfirmDialog = useCallback( () => setConfirmDialogOpen( true ), [] );
-	const closeConfirmDialog = useCallback( () => setConfirmDialogOpen( false ), [] );
-
-	const onConfirmEmptying = useCallback( async () => {
-		if ( isEmptying || isEmpty ) {
-			return;
-		}
-
-		closeConfirmDialog();
-		setIsEmptying( true );
-
-		jetpackAnalytics.tracks.recordEvent( 'jetpack_forms_empty_trash_click' );
-
-		apiFetch( {
-			method: 'DELETE',
-			path: `/wp/v2/feedback/trash`,
-		} )
-			.then( ( response: { deleted?: number } ) => {
-				const deleted = response?.deleted ?? 0;
-				const successMessage =
-					deleted === 1
-						? __( 'Response deleted permanently.', 'jetpack-forms' )
-						: sprintf(
-								// translators: %s: the number of responses deleted permanently.
-								_n(
-									'%s response deleted permanently.',
-									'%s responses deleted permanently.',
-									deleted,
-									'jetpack-forms'
-								),
-								formatNumber( deleted )
-						  );
-				createSuccessNotice( successMessage, { type: 'snackbar', id: 'empty-trash' } );
-			} )
-			.catch( () => {
-				createErrorNotice( __( 'Could not empty trash.', 'jetpack-forms' ), {
-					type: 'snackbar',
-					id: 'empty-trash-error',
-				} );
-			} )
-			.finally( () => {
-				setIsEmptying( false );
-				// invalidate items list
-				invalidateResolution( 'getEntityRecords', [ 'postType', 'feedback', currentQuery ] );
-				// invalidate total items value
-				invalidateResolution( 'getEntityRecords', [
-					'postType',
-					'feedback',
-					{ ...currentQuery, per_page: 1, _fields: 'id' },
-				] );
-				// invalidate counts to refresh the counts across all status tabs
-				invalidateCounts();
-			} );
-	}, [
+	const {
+		isConfirmDialogOpen,
+		openConfirmDialog,
 		closeConfirmDialog,
-		createErrorNotice,
-		createSuccessNotice,
-		invalidateResolution,
-		invalidateCounts,
+		onConfirmEmptying,
 		isEmpty,
 		isEmptying,
-		currentQuery,
-	] );
+		totalItemsTrash,
+		selectedResponsesCount,
+	} = useEmptyTrash( {
+		totalItemsTrash: totalItemsTrashProp,
+		isLoadingCounts: isLoadingCountsProp,
+	} );
 
 	return (
 		<>
@@ -134,31 +56,13 @@ const EmptyTrashButton = ( {
 			>
 				{ __( 'Empty trash', 'jetpack-forms' ) }
 			</Button>
-			<ConfirmDialog
+			<EmptyTrashConfirmationModal
+				isOpen={ isConfirmDialogOpen }
 				onCancel={ closeConfirmDialog }
 				onConfirm={ onConfirmEmptying }
-				isOpen={ isConfirmDialogOpen }
-				confirmButtonText={ __( 'Delete', 'jetpack-forms' ) }
-			>
-				<h3>{ __( 'Delete forever', 'jetpack-forms' ) }</h3>
-				<p>
-					{ selectedResponsesCount > 0
-						? sprintf(
-								// translators: %s: the number of responses in the trash.
-								_n(
-									'%s response in trash will be deleted forever. This action cannot be undone.',
-									'All %s responses in trash will be deleted forever. This action cannot be undone.',
-									totalItemsTrash || 0,
-									'jetpack-forms'
-								),
-								formatNumber( totalItemsTrash )
-						  )
-						: __(
-								'All responses in trash will be deleted forever. This action cannot be undone.',
-								'jetpack-forms'
-						  ) }
-				</p>
-			</ConfirmDialog>
+				totalItemsTrash={ totalItemsTrash }
+				selectedResponsesCount={ selectedResponsesCount }
+			/>
 		</>
 	);
 };

--- a/projects/packages/forms/src/dashboard/hooks/use-empty-spam.ts
+++ b/projects/packages/forms/src/dashboard/hooks/use-empty-spam.ts
@@ -1,0 +1,140 @@
+/**
+ * External dependencies
+ */
+import jetpackAnalytics from '@automattic/jetpack-analytics';
+import { formatNumber } from '@automattic/number-formatters';
+import apiFetch from '@wordpress/api-fetch';
+import { store as coreStore } from '@wordpress/core-data';
+import { useDispatch } from '@wordpress/data';
+import { useState, useCallback, useEffect } from '@wordpress/element';
+import { __, _n, sprintf } from '@wordpress/i18n';
+import { store as noticesStore } from '@wordpress/notices';
+/**
+ * Internal dependencies
+ */
+import { store as dashboardStore } from '../store/index';
+import useInboxData from './use-inbox-data';
+
+type CoreStore = typeof coreStore & {
+	invalidateResolution: ( selector: string, args: unknown[] ) => void;
+};
+
+type UseEmptySpamReturn = {
+	isConfirmDialogOpen: boolean;
+	openConfirmDialog: () => void;
+	closeConfirmDialog: () => void;
+	onConfirmEmptying: () => Promise< void >;
+	isEmpty: boolean;
+	isEmptying: boolean;
+	totalItemsSpam: number;
+	selectedResponsesCount: number;
+};
+
+/**
+ * Hook to manage empty spam functionality.
+ *
+ * @param props                 - Optional props.
+ * @param props.totalItemsSpam  - The total number of spam items (optional, will use hook if not provided).
+ * @param props.isLoadingCounts - Whether counts are loading (optional, will use hook if not provided).
+ * @return Object with empty spam state and handlers.
+ */
+export default function useEmptySpam( {
+	totalItemsSpam: totalItemsSpamProp,
+	isLoadingCounts: isLoadingCountsProp,
+}: {
+	totalItemsSpam?: number;
+	isLoadingCounts?: boolean;
+} = {} ): UseEmptySpamReturn {
+	const [ isConfirmDialogOpen, setConfirmDialogOpen ] = useState( false );
+	const [ isEmptying, setIsEmptying ] = useState( false );
+	const [ isEmpty, setIsEmpty ] = useState( true );
+	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
+	const { invalidateResolution } = useDispatch( coreStore ) as unknown as CoreStore;
+	const { invalidateCounts } = useDispatch( dashboardStore );
+
+	// Use props if provided, otherwise use hook
+	const hookData = useInboxData();
+	const totalItemsSpam = totalItemsSpamProp ?? hookData.totalItemsSpam ?? 0;
+	const isLoadingCounts = isLoadingCountsProp ?? false;
+	const { selectedResponsesCount, currentQuery } = hookData;
+
+	useEffect( () => {
+		setIsEmpty( isLoadingCounts || ! totalItemsSpam );
+	}, [ totalItemsSpam, isLoadingCounts ] );
+
+	const openConfirmDialog = useCallback( () => setConfirmDialogOpen( true ), [] );
+	const closeConfirmDialog = useCallback( () => setConfirmDialogOpen( false ), [] );
+
+	const onConfirmEmptying = useCallback( async () => {
+		if ( isEmptying || isEmpty ) {
+			return;
+		}
+
+		closeConfirmDialog();
+		setIsEmptying( true );
+
+		jetpackAnalytics.tracks.recordEvent( 'jetpack_forms_empty_spam_click' );
+
+		apiFetch( {
+			method: 'DELETE',
+			path: `/wp/v2/feedback/trash?status=spam`,
+		} )
+			.then( ( response: { deleted?: number } ) => {
+				const deleted = response?.deleted ?? 0;
+				const successMessage =
+					deleted === 1
+						? __( 'Response deleted permanently.', 'jetpack-forms' )
+						: sprintf(
+								/* translators: %s: The number of responses. */
+								_n(
+									'%s response deleted permanently.',
+									'%s responses deleted permanently.',
+									deleted,
+									'jetpack-forms'
+								),
+								formatNumber( deleted )
+						  );
+
+				createSuccessNotice( successMessage, { type: 'snackbar', id: 'empty-spam' } );
+			} )
+			.catch( () => {
+				createErrorNotice( __( 'Could not empty spam.', 'jetpack-forms' ), {
+					type: 'snackbar',
+					id: 'empty-spam-error',
+				} );
+			} )
+			.finally( () => {
+				setIsEmptying( false );
+				// invalidate items list
+				invalidateResolution( 'getEntityRecords', [ 'postType', 'feedback', currentQuery ] );
+				// invalidate total items value
+				invalidateResolution( 'getEntityRecords', [
+					'postType',
+					'feedback',
+					{ ...currentQuery, per_page: 1, _fields: 'id' },
+				] );
+				// invalidate counts to refresh the counts across all status tabs
+				invalidateCounts();
+			} );
+	}, [
+		closeConfirmDialog,
+		createErrorNotice,
+		createSuccessNotice,
+		invalidateResolution,
+		invalidateCounts,
+		isEmpty,
+		isEmptying,
+		currentQuery,
+	] );
+
+	return {
+		isConfirmDialogOpen,
+		openConfirmDialog,
+		closeConfirmDialog,
+		onConfirmEmptying,
+		isEmpty,
+		isEmptying,
+		totalItemsSpam,
+		selectedResponsesCount,
+	};
+}

--- a/projects/packages/forms/src/dashboard/hooks/use-empty-spam.ts
+++ b/projects/packages/forms/src/dashboard/hooks/use-empty-spam.ts
@@ -33,17 +33,14 @@ type UseEmptySpamReturn = {
 /**
  * Hook to manage empty spam functionality.
  *
- * @param props                 - Optional props.
- * @param props.totalItemsSpam  - The total number of spam items (optional, will use hook if not provided).
- * @param props.isLoadingCounts - Whether counts are loading (optional, will use hook if not provided).
+ * @param props                - Optional props.
+ * @param props.totalItemsSpam - The total number of spam items (optional, will use hook if not provided).
  * @return Object with empty spam state and handlers.
  */
 export default function useEmptySpam( {
 	totalItemsSpam: totalItemsSpamProp,
-	isLoadingCounts: isLoadingCountsProp,
 }: {
 	totalItemsSpam?: number;
-	isLoadingCounts?: boolean;
 } = {} ): UseEmptySpamReturn {
 	const [ isConfirmDialogOpen, setConfirmDialogOpen ] = useState( false );
 	const [ isEmptying, setIsEmptying ] = useState( false );
@@ -55,12 +52,11 @@ export default function useEmptySpam( {
 	// Use props if provided, otherwise use hook
 	const hookData = useInboxData();
 	const totalItemsSpam = totalItemsSpamProp ?? hookData.totalItemsSpam ?? 0;
-	const isLoadingCounts = isLoadingCountsProp ?? false;
 	const { selectedResponsesCount, currentQuery } = hookData;
 
 	useEffect( () => {
-		setIsEmpty( isLoadingCounts || ! totalItemsSpam );
-	}, [ totalItemsSpam, isLoadingCounts ] );
+		setIsEmpty( ! totalItemsSpam );
+	}, [ totalItemsSpam ] );
 
 	const openConfirmDialog = useCallback( () => setConfirmDialogOpen( true ), [] );
 	const closeConfirmDialog = useCallback( () => setConfirmDialogOpen( false ), [] );

--- a/projects/packages/forms/src/dashboard/hooks/use-empty-trash.ts
+++ b/projects/packages/forms/src/dashboard/hooks/use-empty-trash.ts
@@ -1,0 +1,140 @@
+/**
+ * External dependencies
+ */
+import jetpackAnalytics from '@automattic/jetpack-analytics';
+import { formatNumber } from '@automattic/number-formatters';
+import apiFetch from '@wordpress/api-fetch';
+import { store as coreStore } from '@wordpress/core-data';
+import { useDispatch } from '@wordpress/data';
+import { useState, useCallback, useEffect } from '@wordpress/element';
+import { __, _n, sprintf } from '@wordpress/i18n';
+import { store as noticesStore } from '@wordpress/notices';
+/**
+ * Internal dependencies
+ */
+import { store as dashboardStore } from '../store/index';
+import useInboxData from './use-inbox-data';
+
+type CoreStore = typeof coreStore & {
+	invalidateResolution: ( selector: string, args: unknown[] ) => void;
+};
+
+type UseEmptyTrashReturn = {
+	isConfirmDialogOpen: boolean;
+	openConfirmDialog: () => void;
+	closeConfirmDialog: () => void;
+	onConfirmEmptying: () => Promise< void >;
+	isEmpty: boolean;
+	isEmptying: boolean;
+	totalItemsTrash: number;
+	selectedResponsesCount: number;
+};
+
+/**
+ * Hook to manage empty trash functionality.
+ *
+ * @param props                 - Optional props.
+ * @param props.totalItemsTrash - The total number of trash items (optional, will use hook if not provided).
+ * @param props.isLoadingCounts - Whether counts are loading (optional, will use hook if not provided).
+ * @return Object with empty trash state and handlers.
+ */
+export default function useEmptyTrash( {
+	totalItemsTrash: totalItemsTrashProp,
+	isLoadingCounts: isLoadingCountsProp,
+}: {
+	totalItemsTrash?: number;
+	isLoadingCounts?: boolean;
+} = {} ): UseEmptyTrashReturn {
+	const [ isConfirmDialogOpen, setConfirmDialogOpen ] = useState( false );
+	const [ isEmptying, setIsEmptying ] = useState( false );
+	const [ isEmpty, setIsEmpty ] = useState( true );
+	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
+	const { invalidateResolution } = useDispatch( coreStore ) as unknown as CoreStore;
+	const { invalidateCounts } = useDispatch( dashboardStore );
+
+	// Use props if provided, otherwise use hook
+	const hookData = useInboxData();
+	const totalItemsTrash = totalItemsTrashProp ?? hookData.totalItemsTrash ?? 0;
+	const isLoadingCounts = isLoadingCountsProp ?? false;
+	const { selectedResponsesCount, currentQuery } = hookData;
+
+	useEffect( () => {
+		setIsEmpty( isLoadingCounts || ! totalItemsTrash );
+	}, [ totalItemsTrash, isLoadingCounts ] );
+
+	const openConfirmDialog = useCallback( () => setConfirmDialogOpen( true ), [] );
+	const closeConfirmDialog = useCallback( () => setConfirmDialogOpen( false ), [] );
+
+	const onConfirmEmptying = useCallback( async () => {
+		if ( isEmptying || isEmpty ) {
+			return;
+		}
+
+		closeConfirmDialog();
+		setIsEmptying( true );
+
+		jetpackAnalytics.tracks.recordEvent( 'jetpack_forms_empty_trash_click' );
+
+		apiFetch( {
+			method: 'DELETE',
+			path: `/wp/v2/feedback/trash`,
+		} )
+			.then( ( response: { deleted?: number } ) => {
+				const deleted = response?.deleted ?? 0;
+				const successMessage =
+					deleted === 1
+						? __( 'Response deleted permanently.', 'jetpack-forms' )
+						: sprintf(
+								/* translators: %s: the number of responses deleted permanently. */
+								_n(
+									'%s response deleted permanently.',
+									'%s responses deleted permanently.',
+									deleted,
+									'jetpack-forms'
+								),
+								formatNumber( deleted )
+						  );
+
+				createSuccessNotice( successMessage, { type: 'snackbar', id: 'empty-trash' } );
+			} )
+			.catch( () => {
+				createErrorNotice( __( 'Could not empty trash.', 'jetpack-forms' ), {
+					type: 'snackbar',
+					id: 'empty-trash-error',
+				} );
+			} )
+			.finally( () => {
+				setIsEmptying( false );
+				// invalidate items list
+				invalidateResolution( 'getEntityRecords', [ 'postType', 'feedback', currentQuery ] );
+				// invalidate total items value
+				invalidateResolution( 'getEntityRecords', [
+					'postType',
+					'feedback',
+					{ ...currentQuery, per_page: 1, _fields: 'id' },
+				] );
+				// invalidate counts to refresh the counts across all status tabs
+				invalidateCounts();
+			} );
+	}, [
+		closeConfirmDialog,
+		createErrorNotice,
+		createSuccessNotice,
+		invalidateResolution,
+		invalidateCounts,
+		isEmpty,
+		isEmptying,
+		currentQuery,
+	] );
+
+	return {
+		isConfirmDialogOpen,
+		openConfirmDialog,
+		closeConfirmDialog,
+		onConfirmEmptying,
+		isEmpty,
+		isEmptying,
+		totalItemsTrash,
+		selectedResponsesCount,
+	};
+}

--- a/projects/packages/forms/src/dashboard/hooks/use-empty-trash.ts
+++ b/projects/packages/forms/src/dashboard/hooks/use-empty-trash.ts
@@ -35,15 +35,12 @@ type UseEmptyTrashReturn = {
  *
  * @param props                 - Optional props.
  * @param props.totalItemsTrash - The total number of trash items (optional, will use hook if not provided).
- * @param props.isLoadingCounts - Whether counts are loading (optional, will use hook if not provided).
  * @return Object with empty trash state and handlers.
  */
 export default function useEmptyTrash( {
 	totalItemsTrash: totalItemsTrashProp,
-	isLoadingCounts: isLoadingCountsProp,
 }: {
 	totalItemsTrash?: number;
-	isLoadingCounts?: boolean;
 } = {} ): UseEmptyTrashReturn {
 	const [ isConfirmDialogOpen, setConfirmDialogOpen ] = useState( false );
 	const [ isEmptying, setIsEmptying ] = useState( false );
@@ -55,12 +52,11 @@ export default function useEmptyTrash( {
 	// Use props if provided, otherwise use hook
 	const hookData = useInboxData();
 	const totalItemsTrash = totalItemsTrashProp ?? hookData.totalItemsTrash ?? 0;
-	const isLoadingCounts = isLoadingCountsProp ?? false;
 	const { selectedResponsesCount, currentQuery } = hookData;
 
 	useEffect( () => {
-		setIsEmpty( isLoadingCounts || ! totalItemsTrash );
-	}, [ totalItemsTrash, isLoadingCounts ] );
+		setIsEmpty( ! totalItemsTrash );
+	}, [ totalItemsTrash ] );
 
 	const openConfirmDialog = useCallback( () => setConfirmDialogOpen( true ), [] );
 	const closeConfirmDialog = useCallback( () => setConfirmDialogOpen( false ), [] );

--- a/projects/packages/forms/src/dashboard/wp-build/hooks/use-page-header-details.tsx
+++ b/projects/packages/forms/src/dashboard/wp-build/hooks/use-page-header-details.tsx
@@ -13,7 +13,7 @@ import { useSelect } from '@wordpress/data';
 import { useMemo } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
 import { __, sprintf } from '@wordpress/i18n';
-import { moreVertical, plus, download, plugins } from '@wordpress/icons';
+import { moreVertical, plus, download, plugins, trash } from '@wordpress/icons';
 import { Stack } from '@wordpress/ui';
 /**
  * Internal dependencies
@@ -21,10 +21,14 @@ import { Stack } from '@wordpress/ui';
 import CreateFormButton from '../../components/create-form-button';
 import EditFormButton from '../../components/edit-form-button';
 import EmptySpamButton from '../../components/empty-spam-button';
+import EmptySpamConfirmationModal from '../../components/empty-spam-button/confirmation-modal';
 import EmptyTrashButton from '../../components/empty-trash-button';
+import EmptyTrashConfirmationModal from '../../components/empty-trash-button/confirmation-modal';
 import ExportResponsesButton from '../../components/export-responses/button';
 import ExportResponsesModal from '../../components/export-responses/modal';
 import useCreateForm from '../../hooks/use-create-form';
+import useEmptySpam from '../../hooks/use-empty-spam';
+import useEmptyTrash from '../../hooks/use-empty-trash';
 import useExportResponses from '../../hooks/use-export-responses';
 import useInboxData from '../../hooks/use-inbox-data';
 import ManageIntegrationsButton from '../components/manage-integrations-button';
@@ -87,6 +91,10 @@ export default function usePageHeaderDetails(
 	} = useExportResponses();
 	const { totalItems, isLoadingData } = useInboxData();
 	const hasResponses = ! isLoadingData && totalItems > 0;
+
+	// Empty spam/trash hooks
+	const emptySpam = useEmptySpam();
+	const emptyTrash = useEmptyTrash();
 
 	const formRecord = useSelect(
 		select =>
@@ -165,7 +173,7 @@ export default function usePageHeaderDetails(
 					title: __( 'Create a form', 'jetpack-forms' ),
 				} );
 			} else if ( isSingleFormScreen ) {
-				// Single form screen: Edit form (not in trash/spam), Export
+				// Single form screen: Edit form (not in trash/spam), Export, Empty trash/spam
 				if ( statusView === 'inbox' && sourceIdNumber ) {
 					dropdownControls.push( {
 						onClick: () => {
@@ -182,8 +190,26 @@ export default function usePageHeaderDetails(
 					title: exportLabel,
 					isDisabled: ! hasResponses,
 				} );
+
+				if ( statusView === 'trash' ) {
+					dropdownControls.push( {
+						icon: trash,
+						onClick: emptyTrash.openConfirmDialog,
+						title: __( 'Empty trash', 'jetpack-forms' ),
+						isDisabled: emptyTrash.isEmpty || emptyTrash.isEmptying,
+					} );
+				}
+
+				if ( statusView === 'spam' ) {
+					dropdownControls.push( {
+						icon: trash,
+						onClick: emptySpam.openConfirmDialog,
+						title: __( 'Delete spam', 'jetpack-forms' ),
+						isDisabled: emptySpam.isEmpty || emptySpam.isEmptying,
+					} );
+				}
 			} else {
-				// Responses list screen: Manage integrations (inbox only), Create a form (inbox only), Export
+				// Responses list screen: Manage integrations (inbox only), Create a form (inbox only), Export, Empty trash/spam
 				if ( statusView === 'inbox' && isIntegrationsEnabled && showDashboardIntegrations ) {
 					dropdownControls.push( {
 						icon: plugins,
@@ -191,6 +217,7 @@ export default function usePageHeaderDetails(
 						title: __( 'Manage integrations', 'jetpack-forms' ),
 					} );
 				}
+
 				if ( statusView === 'inbox' ) {
 					dropdownControls.push( {
 						icon: plus,
@@ -198,12 +225,31 @@ export default function usePageHeaderDetails(
 						title: __( 'Create a form', 'jetpack-forms' ),
 					} );
 				}
+
 				dropdownControls.push( {
 					icon: download,
 					onClick: openExportModal,
 					title: exportLabel,
 					isDisabled: ! hasResponses,
 				} );
+
+				if ( statusView === 'trash' ) {
+					dropdownControls.push( {
+						icon: trash,
+						onClick: emptyTrash.openConfirmDialog,
+						title: __( 'Empty trash', 'jetpack-forms' ),
+						isDisabled: emptyTrash.isEmpty || emptyTrash.isEmptying,
+					} );
+				}
+
+				if ( statusView === 'spam' ) {
+					dropdownControls.push( {
+						icon: trash,
+						onClick: emptySpam.openConfirmDialog,
+						title: __( 'Delete spam', 'jetpack-forms' ),
+						isDisabled: emptySpam.isEmpty || emptySpam.isEmptying,
+					} );
+				}
 			}
 
 			if ( dropdownControls.length === 0 ) {
@@ -217,7 +263,7 @@ export default function usePageHeaderDetails(
 					icon={ moreVertical }
 					label={ __( 'More actions', 'jetpack-forms' ) }
 				/>,
-				// Include the export modal when on mobile
+				// Include modals when on mobile
 				...( showExportModal
 					? [
 							<ExportResponsesModal
@@ -225,6 +271,30 @@ export default function usePageHeaderDetails(
 								onRequestClose={ closeExportModal }
 								onExport={ onExport }
 								autoConnectGdrive={ autoConnectGdrive }
+							/>,
+					  ]
+					: [] ),
+				...( emptyTrash.isConfirmDialogOpen
+					? [
+							<EmptyTrashConfirmationModal
+								key="empty-trash-confirm"
+								isOpen={ emptyTrash.isConfirmDialogOpen }
+								onCancel={ emptyTrash.closeConfirmDialog }
+								onConfirm={ emptyTrash.onConfirmEmptying }
+								totalItemsTrash={ emptyTrash.totalItemsTrash }
+								selectedResponsesCount={ emptyTrash.selectedResponsesCount }
+							/>,
+					  ]
+					: [] ),
+				...( emptySpam.isConfirmDialogOpen
+					? [
+							<EmptySpamConfirmationModal
+								key="empty-spam-confirm"
+								isOpen={ emptySpam.isConfirmDialogOpen }
+								onCancel={ emptySpam.closeConfirmDialog }
+								onConfirm={ emptySpam.onConfirmEmptying }
+								totalItemsSpam={ emptySpam.totalItemsSpam }
+								selectedResponsesCount={ emptySpam.selectedResponsesCount }
 							/>,
 					  ]
 					: [] ),
@@ -296,6 +366,22 @@ export default function usePageHeaderDetails(
 		autoConnectGdrive,
 		hasResponses,
 		exportLabel,
+		emptyTrash.openConfirmDialog,
+		emptyTrash.isEmpty,
+		emptyTrash.isEmptying,
+		emptyTrash.isConfirmDialogOpen,
+		emptyTrash.closeConfirmDialog,
+		emptyTrash.onConfirmEmptying,
+		emptyTrash.totalItemsTrash,
+		emptyTrash.selectedResponsesCount,
+		emptySpam.openConfirmDialog,
+		emptySpam.isEmpty,
+		emptySpam.isEmptying,
+		emptySpam.isConfirmDialogOpen,
+		emptySpam.closeConfirmDialog,
+		emptySpam.onConfirmEmptying,
+		emptySpam.totalItemsSpam,
+		emptySpam.selectedResponsesCount,
 	] );
 
 	return { breadcrumbs, subtitle, actions };

--- a/projects/packages/forms/src/dashboard/wp-build/hooks/use-page-header-details.tsx
+++ b/projects/packages/forms/src/dashboard/wp-build/hooks/use-page-header-details.tsx
@@ -1,16 +1,19 @@
 /**
  * External dependencies
  */
+import { useBreakpointMatch } from '@automattic/jetpack-components';
 import JetpackLogo from '@automattic/jetpack-components/jetpack-logo';
 /**
  * WordPress dependencies
  */
 import { Breadcrumbs } from '@wordpress/admin-ui';
+import { DropdownMenu } from '@wordpress/components';
 import { store as coreDataStore } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
 import { useMemo } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
 import { __, sprintf } from '@wordpress/i18n';
+import { moreVertical, plus, download, plugins } from '@wordpress/icons';
 import { Stack } from '@wordpress/ui';
 /**
  * Internal dependencies
@@ -20,6 +23,10 @@ import EditFormButton from '../../components/edit-form-button';
 import EmptySpamButton from '../../components/empty-spam-button';
 import EmptyTrashButton from '../../components/empty-trash-button';
 import ExportResponsesButton from '../../components/export-responses/button';
+import ExportResponsesModal from '../../components/export-responses/modal';
+import useCreateForm from '../../hooks/use-create-form';
+import useExportResponses from '../../hooks/use-export-responses';
+import useInboxData from '../../hooks/use-inbox-data';
 import ManageIntegrationsButton from '../components/manage-integrations-button';
 import type { ReactNode } from 'react';
 
@@ -61,9 +68,25 @@ export default function usePageHeaderDetails(
 		return Number.isFinite( numberValue ) && numberValue > 0 ? numberValue : null;
 	}, [ sourceId ] );
 
+	// Detect mobile viewport
+	const [ isSm ] = useBreakpointMatch( 'sm' );
+
 	// Mutually-exclusive screen flags.
 	const isFormsScreen = screen === 'forms';
 	const isSingleFormScreen = screen === 'responses' && sourceIdNumber !== null;
+
+	// Hooks for mobile dropdown menu actions
+	const { openNewForm } = useCreateForm();
+	const {
+		showExportModal,
+		openModal: openExportModal,
+		closeModal: closeExportModal,
+		onExport,
+		autoConnectGdrive,
+		exportLabel,
+	} = useExportResponses();
+	const { totalItems, isLoadingData } = useInboxData();
+	const hasResponses = ! isLoadingData && totalItems > 0;
 
 	const formRecord = useSelect(
 		select =>
@@ -122,6 +145,93 @@ export default function usePageHeaderDetails(
 	}, [ formTitle, isFormsScreen, isSingleFormScreen ] );
 
 	const actions = useMemo( () => {
+		// Mobile: show dropdown menu with actions
+		if ( isSm ) {
+			const dropdownControls = [];
+
+			if ( isFormsScreen ) {
+				// Forms screen: Manage integrations, Create a form
+				if ( isIntegrationsEnabled && showDashboardIntegrations ) {
+					dropdownControls.push( {
+						icon: plugins,
+						onClick: onOpenIntegrations,
+						title: __( 'Manage integrations', 'jetpack-forms' ),
+					} );
+				}
+
+				dropdownControls.push( {
+					icon: plus,
+					onClick: () => openNewForm( {} ),
+					title: __( 'Create a form', 'jetpack-forms' ),
+				} );
+			} else if ( isSingleFormScreen ) {
+				// Single form screen: Edit form (not in trash/spam), Export
+				if ( statusView === 'inbox' && sourceIdNumber ) {
+					dropdownControls.push( {
+						onClick: () => {
+							const fallbackEditUrl = `post.php?post=${ sourceIdNumber }&action=edit&post_type=jetpack_form`;
+							const url = new URL( fallbackEditUrl, window.location.origin );
+							window.location.href = url.toString();
+						},
+						title: __( 'Edit form', 'jetpack-forms' ),
+					} );
+				}
+				dropdownControls.push( {
+					icon: download,
+					onClick: openExportModal,
+					title: exportLabel,
+					isDisabled: ! hasResponses,
+				} );
+			} else {
+				// Responses list screen: Manage integrations (inbox only), Create a form (inbox only), Export
+				if ( statusView === 'inbox' && isIntegrationsEnabled && showDashboardIntegrations ) {
+					dropdownControls.push( {
+						icon: plugins,
+						onClick: onOpenIntegrations,
+						title: __( 'Manage integrations', 'jetpack-forms' ),
+					} );
+				}
+				if ( statusView === 'inbox' ) {
+					dropdownControls.push( {
+						icon: plus,
+						onClick: () => openNewForm( { showPatterns: false } ),
+						title: __( 'Create a form', 'jetpack-forms' ),
+					} );
+				}
+				dropdownControls.push( {
+					icon: download,
+					onClick: openExportModal,
+					title: exportLabel,
+					isDisabled: ! hasResponses,
+				} );
+			}
+
+			if ( dropdownControls.length === 0 ) {
+				return null;
+			}
+
+			return [
+				<DropdownMenu
+					key="actions-menu"
+					controls={ dropdownControls }
+					icon={ moreVertical }
+					label={ __( 'More actions', 'jetpack-forms' ) }
+				/>,
+				// Include the export modal when on mobile
+				...( showExportModal
+					? [
+							<ExportResponsesModal
+								key="export-modal"
+								onRequestClose={ closeExportModal }
+								onExport={ onExport }
+								autoConnectGdrive={ autoConnectGdrive }
+							/>,
+					  ]
+					: [] ),
+			];
+		}
+
+		// Desktop: show individual buttons
 		if ( isFormsScreen ) {
 			return [
 				...( isIntegrationsEnabled && showDashboardIntegrations
@@ -170,6 +280,7 @@ export default function usePageHeaderDetails(
 			...( statusView === 'spam' ? [ <EmptySpamButton key="empty-spam" /> ] : [] ),
 		];
 	}, [
+		isSm,
 		isIntegrationsEnabled,
 		onOpenIntegrations,
 		showDashboardIntegrations,
@@ -177,6 +288,14 @@ export default function usePageHeaderDetails(
 		isFormsScreen,
 		isSingleFormScreen,
 		statusView,
+		openNewForm,
+		openExportModal,
+		showExportModal,
+		closeExportModal,
+		onExport,
+		autoConnectGdrive,
+		hasResponses,
+		exportLabel,
 	] );
 
 	return { breadcrumbs, subtitle, actions };

--- a/projects/packages/forms/tests/js/dashboard/components/empty-spam-button/index.test.jsx
+++ b/projects/packages/forms/tests/js/dashboard/components/empty-spam-button/index.test.jsx
@@ -179,7 +179,7 @@ describe( 'EmptySpamButton', () => {
 	};
 
 	it( 'renders correctly', () => {
-		renderWithProvider( <EmptySpamButton totalItemsSpam={ 1 } isLoadingCounts={ false } /> );
+		renderWithProvider( <EmptySpamButton totalItemsSpam={ 1 } /> );
 
 		const button = screen.getByText( 'Delete spam' );
 		expect( button ).toBeInTheDocument();
@@ -187,8 +187,8 @@ describe( 'EmptySpamButton', () => {
 		expect( button ).toBeEnabled();
 	} );
 
-	it( 'shows disabled state when trash is empty', () => {
-		renderWithProvider( <EmptySpamButton totalItemsSpam={ 0 } isLoadingCounts={ false } /> );
+	it( 'shows disabled state when spam is empty', () => {
+		renderWithProvider( <EmptySpamButton totalItemsSpam={ 0 } /> );
 
 		const button = screen.getByText( 'Delete spam' );
 		expect( button ).toBeDisabled();
@@ -196,7 +196,7 @@ describe( 'EmptySpamButton', () => {
 	} );
 
 	it( 'shows confirmation dialog when clicked', async () => {
-		renderWithProvider( <EmptySpamButton totalItemsSpam={ 1 } isLoadingCounts={ false } /> );
+		renderWithProvider( <EmptySpamButton totalItemsSpam={ 1 } /> );
 
 		const button = screen.getByText( 'Delete spam' );
 		await userEvent.click( button );
@@ -206,14 +206,14 @@ describe( 'EmptySpamButton', () => {
 		expect( screen.getByText( 'Delete forever' ) ).toBeInTheDocument();
 	} );
 
-	it( 'empties trash when confirmed', async () => {
+	it( 'empties spam when confirmed', async () => {
 		const { default: apiFetch } = await import( '@wordpress/api-fetch' );
 		const { useDispatch } = await import( '@wordpress/data' );
 		const mockDispatch = useDispatch( 'notices' );
 
-		renderWithProvider( <EmptySpamButton totalItemsSpam={ 1 } isLoadingCounts={ false } /> );
+		renderWithProvider( <EmptySpamButton totalItemsSpam={ 1 } /> );
 
-		// Click empty trash button
+		// Click empty spam button
 		const button = screen.getByText( 'Delete spam' );
 		await userEvent.click( button );
 

--- a/projects/packages/forms/tests/js/dashboard/components/empty-trash-button/index.test.jsx
+++ b/projects/packages/forms/tests/js/dashboard/components/empty-trash-button/index.test.jsx
@@ -179,7 +179,7 @@ describe( 'EmptyTrashButton', () => {
 	};
 
 	it( 'renders correctly', () => {
-		renderWithProvider( <EmptyTrashButton totalItemsTrash={ 1 } isLoadingCounts={ false } /> );
+		renderWithProvider( <EmptyTrashButton totalItemsTrash={ 1 } /> );
 
 		const button = screen.getByText( 'Empty trash' );
 		expect( button ).toBeInTheDocument();
@@ -188,7 +188,7 @@ describe( 'EmptyTrashButton', () => {
 	} );
 
 	it( 'shows disabled state when trash is empty', () => {
-		renderWithProvider( <EmptyTrashButton totalItemsTrash={ 0 } isLoadingCounts={ false } /> );
+		renderWithProvider( <EmptyTrashButton totalItemsTrash={ 0 } /> );
 
 		const button = screen.getByText( 'Empty trash' );
 		expect( button ).toBeDisabled();
@@ -196,7 +196,7 @@ describe( 'EmptyTrashButton', () => {
 	} );
 
 	it( 'shows confirmation dialog when clicked', async () => {
-		renderWithProvider( <EmptyTrashButton totalItemsTrash={ 1 } isLoadingCounts={ false } /> );
+		renderWithProvider( <EmptyTrashButton totalItemsTrash={ 1 } /> );
 
 		const button = screen.getByText( 'Empty trash' );
 		await userEvent.click( button );
@@ -211,7 +211,7 @@ describe( 'EmptyTrashButton', () => {
 		const { useDispatch } = await import( '@wordpress/data' );
 		const mockDispatch = useDispatch( 'notices' );
 
-		renderWithProvider( <EmptyTrashButton totalItemsTrash={ 1 } isLoadingCounts={ false } /> );
+		renderWithProvider( <EmptyTrashButton totalItemsTrash={ 1 } /> );
 
 		// Click empty trash button
 		const button = screen.getByText( 'Empty trash' );

--- a/projects/packages/forms/tests/js/dashboard/hooks/use-empty-spam.test.jsx
+++ b/projects/packages/forms/tests/js/dashboard/hooks/use-empty-spam.test.jsx
@@ -1,0 +1,181 @@
+/**
+ * External dependencies
+ */
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { act, renderHook, waitFor } from '@testing-library/react';
+
+// Mock dependencies
+await jest.unstable_mockModule( '@wordpress/api-fetch', () => ( {
+	default: jest.fn( () => Promise.resolve( { deleted: 5 } ) ),
+} ) );
+
+await jest.unstable_mockModule( '@wordpress/notices', () => ( {
+	store: 'notices',
+} ) );
+
+await jest.unstable_mockModule( '@wordpress/core-data', () => ( {
+	store: 'core',
+} ) );
+
+await jest.unstable_mockModule( '@automattic/jetpack-analytics', () => ( {
+	default: {
+		tracks: {
+			recordEvent: jest.fn(),
+		},
+	},
+} ) );
+
+await jest.unstable_mockModule( '../../../../src/dashboard/store', () => ( {
+	store: 'dashboard',
+} ) );
+
+// Mock useInboxData
+await jest.unstable_mockModule( '../../../../src/dashboard/hooks/use-inbox-data', () => ( {
+	default: jest.fn( () => ( {
+		totalItemsSpam: 5,
+		selectedResponsesCount: 2,
+		currentQuery: { status: 'spam' },
+	} ) ),
+} ) );
+
+// Mock WordPress data
+await jest.unstable_mockModule( '@wordpress/data', () => {
+	const mockDispatch = {
+		createSuccessNotice: jest.fn(),
+		createErrorNotice: jest.fn(),
+		invalidateResolution: jest.fn(),
+		invalidateCounts: jest.fn(),
+	};
+
+	return {
+		useDispatch: jest.fn( store => {
+			if ( store === 'notices' ) {
+				return {
+					createSuccessNotice: mockDispatch.createSuccessNotice,
+					createErrorNotice: mockDispatch.createErrorNotice,
+				};
+			}
+			if ( store === 'core' ) {
+				return { invalidateResolution: mockDispatch.invalidateResolution };
+			}
+			if ( store === 'dashboard' ) {
+				return { invalidateCounts: mockDispatch.invalidateCounts };
+			}
+			return {};
+		} ),
+	};
+} );
+
+// Import the hook after mocks are set up
+const useEmptySpamModule = await import( '../../../../src/dashboard/hooks/use-empty-spam' );
+const useEmptySpam = useEmptySpamModule.default;
+
+describe( 'useEmptySpam', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'returns initial state', () => {
+		const { result } = renderHook( () => useEmptySpam() );
+
+		expect( result.current.isConfirmDialogOpen ).toBe( false );
+		expect( result.current.isEmpty ).toBe( false );
+		expect( result.current.isEmptying ).toBe( false );
+		expect( result.current.totalItemsSpam ).toBe( 5 );
+		expect( result.current.selectedResponsesCount ).toBe( 2 );
+		expect( typeof result.current.openConfirmDialog ).toBe( 'function' );
+		expect( typeof result.current.closeConfirmDialog ).toBe( 'function' );
+		expect( typeof result.current.onConfirmEmptying ).toBe( 'function' );
+	} );
+
+	it( 'sets isEmpty to true when totalItemsSpam is 0', async () => {
+		const useInboxDataModule = await import( '../../../../src/dashboard/hooks/use-inbox-data' );
+		useInboxDataModule.default.mockReturnValueOnce( {
+			totalItemsSpam: 0,
+			selectedResponsesCount: 0,
+			currentQuery: {},
+		} );
+
+		const { result } = renderHook( () => useEmptySpam() );
+
+		expect( result.current.isEmpty ).toBe( true );
+	} );
+
+	it( 'opens and closes confirmation dialog', () => {
+		const { result } = renderHook( () => useEmptySpam() );
+
+		expect( result.current.isConfirmDialogOpen ).toBe( false );
+
+		act( () => {
+			result.current.openConfirmDialog();
+		} );
+
+		expect( result.current.isConfirmDialogOpen ).toBe( true );
+
+		act( () => {
+			result.current.closeConfirmDialog();
+		} );
+
+		expect( result.current.isConfirmDialogOpen ).toBe( false );
+	} );
+
+	it( 'calls API and shows success notice when emptying spam', async () => {
+		const apiFetchModule = await import( '@wordpress/api-fetch' );
+		const analyticsModule = await import( '@automattic/jetpack-analytics' );
+		const { useDispatch } = await import( '@wordpress/data' );
+
+		const { result } = renderHook( () => useEmptySpam() );
+
+		await act( async () => {
+			await result.current.onConfirmEmptying();
+		} );
+
+		// Verify analytics event was recorded
+		expect( analyticsModule.default.tracks.recordEvent ).toHaveBeenCalledWith(
+			'jetpack_forms_empty_spam_click'
+		);
+
+		// Verify API call
+		await waitFor( () => {
+			expect( apiFetchModule.default ).toHaveBeenCalledWith( {
+				method: 'DELETE',
+				path: '/wp/v2/feedback/trash?status=spam',
+			} );
+		} );
+
+		// Verify success notice
+		const mockDispatch = useDispatch( 'notices' );
+		await waitFor( () => {
+			expect( mockDispatch.createSuccessNotice ).toHaveBeenCalledWith(
+				expect.stringContaining( 'deleted permanently' ),
+				{ type: 'snackbar', id: 'empty-spam' }
+			);
+		} );
+	} );
+
+	it( 'does not call API when isEmpty is true', async () => {
+		const useInboxDataModule = await import( '../../../../src/dashboard/hooks/use-inbox-data' );
+		useInboxDataModule.default.mockReturnValueOnce( {
+			totalItemsSpam: 0,
+			selectedResponsesCount: 0,
+			currentQuery: {},
+		} );
+
+		const apiFetchModule = await import( '@wordpress/api-fetch' );
+		apiFetchModule.default.mockClear();
+
+		const { result } = renderHook( () => useEmptySpam() );
+
+		await act( async () => {
+			await result.current.onConfirmEmptying();
+		} );
+
+		expect( apiFetchModule.default ).not.toHaveBeenCalled();
+	} );
+
+	it( 'uses provided totalItemsSpam prop over hook data', () => {
+		const { result } = renderHook( () => useEmptySpam( { totalItemsSpam: 10 } ) );
+
+		expect( result.current.totalItemsSpam ).toBe( 10 );
+	} );
+} );

--- a/projects/packages/forms/tests/js/dashboard/hooks/use-empty-trash.test.jsx
+++ b/projects/packages/forms/tests/js/dashboard/hooks/use-empty-trash.test.jsx
@@ -1,0 +1,181 @@
+/**
+ * External dependencies
+ */
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { act, renderHook, waitFor } from '@testing-library/react';
+
+// Mock dependencies
+await jest.unstable_mockModule( '@wordpress/api-fetch', () => ( {
+	default: jest.fn( () => Promise.resolve( { deleted: 3 } ) ),
+} ) );
+
+await jest.unstable_mockModule( '@wordpress/notices', () => ( {
+	store: 'notices',
+} ) );
+
+await jest.unstable_mockModule( '@wordpress/core-data', () => ( {
+	store: 'core',
+} ) );
+
+await jest.unstable_mockModule( '@automattic/jetpack-analytics', () => ( {
+	default: {
+		tracks: {
+			recordEvent: jest.fn(),
+		},
+	},
+} ) );
+
+await jest.unstable_mockModule( '../../../../src/dashboard/store', () => ( {
+	store: 'dashboard',
+} ) );
+
+// Mock useInboxData
+await jest.unstable_mockModule( '../../../../src/dashboard/hooks/use-inbox-data', () => ( {
+	default: jest.fn( () => ( {
+		totalItemsTrash: 3,
+		selectedResponsesCount: 1,
+		currentQuery: { status: 'trash' },
+	} ) ),
+} ) );
+
+// Mock WordPress data
+await jest.unstable_mockModule( '@wordpress/data', () => {
+	const mockDispatch = {
+		createSuccessNotice: jest.fn(),
+		createErrorNotice: jest.fn(),
+		invalidateResolution: jest.fn(),
+		invalidateCounts: jest.fn(),
+	};
+
+	return {
+		useDispatch: jest.fn( store => {
+			if ( store === 'notices' ) {
+				return {
+					createSuccessNotice: mockDispatch.createSuccessNotice,
+					createErrorNotice: mockDispatch.createErrorNotice,
+				};
+			}
+			if ( store === 'core' ) {
+				return { invalidateResolution: mockDispatch.invalidateResolution };
+			}
+			if ( store === 'dashboard' ) {
+				return { invalidateCounts: mockDispatch.invalidateCounts };
+			}
+			return {};
+		} ),
+	};
+} );
+
+// Import the hook after mocks are set up
+const useEmptyTrashModule = await import( '../../../../src/dashboard/hooks/use-empty-trash' );
+const useEmptyTrash = useEmptyTrashModule.default;
+
+describe( 'useEmptyTrash', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'returns initial state', () => {
+		const { result } = renderHook( () => useEmptyTrash() );
+
+		expect( result.current.isConfirmDialogOpen ).toBe( false );
+		expect( result.current.isEmpty ).toBe( false );
+		expect( result.current.isEmptying ).toBe( false );
+		expect( result.current.totalItemsTrash ).toBe( 3 );
+		expect( result.current.selectedResponsesCount ).toBe( 1 );
+		expect( typeof result.current.openConfirmDialog ).toBe( 'function' );
+		expect( typeof result.current.closeConfirmDialog ).toBe( 'function' );
+		expect( typeof result.current.onConfirmEmptying ).toBe( 'function' );
+	} );
+
+	it( 'sets isEmpty to true when totalItemsTrash is 0', async () => {
+		const useInboxDataModule = await import( '../../../../src/dashboard/hooks/use-inbox-data' );
+		useInboxDataModule.default.mockReturnValueOnce( {
+			totalItemsTrash: 0,
+			selectedResponsesCount: 0,
+			currentQuery: {},
+		} );
+
+		const { result } = renderHook( () => useEmptyTrash() );
+
+		expect( result.current.isEmpty ).toBe( true );
+	} );
+
+	it( 'opens and closes confirmation dialog', () => {
+		const { result } = renderHook( () => useEmptyTrash() );
+
+		expect( result.current.isConfirmDialogOpen ).toBe( false );
+
+		act( () => {
+			result.current.openConfirmDialog();
+		} );
+
+		expect( result.current.isConfirmDialogOpen ).toBe( true );
+
+		act( () => {
+			result.current.closeConfirmDialog();
+		} );
+
+		expect( result.current.isConfirmDialogOpen ).toBe( false );
+	} );
+
+	it( 'calls API and shows success notice when emptying trash', async () => {
+		const apiFetchModule = await import( '@wordpress/api-fetch' );
+		const analyticsModule = await import( '@automattic/jetpack-analytics' );
+		const { useDispatch } = await import( '@wordpress/data' );
+
+		const { result } = renderHook( () => useEmptyTrash() );
+
+		await act( async () => {
+			await result.current.onConfirmEmptying();
+		} );
+
+		// Verify analytics event was recorded
+		expect( analyticsModule.default.tracks.recordEvent ).toHaveBeenCalledWith(
+			'jetpack_forms_empty_trash_click'
+		);
+
+		// Verify API call
+		await waitFor( () => {
+			expect( apiFetchModule.default ).toHaveBeenCalledWith( {
+				method: 'DELETE',
+				path: '/wp/v2/feedback/trash',
+			} );
+		} );
+
+		// Verify success notice
+		const mockDispatch = useDispatch( 'notices' );
+		await waitFor( () => {
+			expect( mockDispatch.createSuccessNotice ).toHaveBeenCalledWith(
+				expect.stringContaining( 'deleted permanently' ),
+				{ type: 'snackbar', id: 'empty-trash' }
+			);
+		} );
+	} );
+
+	it( 'does not call API when isEmpty is true', async () => {
+		const useInboxDataModule = await import( '../../../../src/dashboard/hooks/use-inbox-data' );
+		useInboxDataModule.default.mockReturnValueOnce( {
+			totalItemsTrash: 0,
+			selectedResponsesCount: 0,
+			currentQuery: {},
+		} );
+
+		const apiFetchModule = await import( '@wordpress/api-fetch' );
+		apiFetchModule.default.mockClear();
+
+		const { result } = renderHook( () => useEmptyTrash() );
+
+		await act( async () => {
+			await result.current.onConfirmEmptying();
+		} );
+
+		expect( apiFetchModule.default ).not.toHaveBeenCalled();
+	} );
+
+	it( 'uses provided totalItemsTrash prop over hook data', () => {
+		const { result } = renderHook( () => useEmptyTrash( { totalItemsTrash: 8 } ) );
+
+		expect( result.current.totalItemsTrash ).toBe( 8 );
+	} );
+} );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes FORMS-587

## Proposed changes
<!--- Explain what functional changes your PR includes -->
- Move header actions (Manage integrations, Create a form, Export) to a three-dots dropdown menu on mobile viewports
- Add Empty spam/trash actions to the dropdown menu when in their respective status views
- Refactor EmptySpam and EmptyTrash components to extract reusable hooks (`useEmptySpam`, `useEmptyTrash`) and confirmation modal components
- Fix context provider issue on Forms tab by wrapping with `WpRouteDashboardSearchParamsProvider`
- Maintain current desktop behavior with individual buttons
- Fixes some UI issues with the header on mobile
- Moves the entire content down so that the WP header is not rendered on top of it

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No.

## Testing instructions
* Activate the alpha flag
* Navigate to the wp-build Forms dashboard (`/wp-admin/admin.php?page=jetpack-forms-responses-wp-admin&p=%2Fforms`)
* Resize your browser to a mobile viewport
* Check that you can open and close a response
* Verify that the header shows a three-dots menu icon instead of individual action buttons
* Click the three-dots menu and verify it shows "Manage integrations" and "Create a form" actions
* Navigate to the Responses tab (`/wp-admin/admin.php?page=jetpack-forms-responses-wp-admin&p=%2Fresponses%2Finbox`)
* In mobile viewport, verify the dropdown shows "Manage integrations", "Create a form", and "Export" actions
* Switch to spam status and verify the dropdown shows "Delete spam" action
* Switch to trash status and verify the dropdown shows "Empty trash" action
* Test the "Delete spam" and "Empty trash" actions - they should show confirmation modals and work correctly
* Resize to desktop viewport and verify that actions appear as individual buttons (original behavior)
* Verify the Export button is disabled when there are no responses
* Verify no console errors appear on either Forms or Responses tabs

| Before | After |
| - | - |
| <img width="465" height="612" alt="Screenshot from 2026-02-13 20-54-26" src="https://github.com/user-attachments/assets/b7f11830-e132-4c33-8cf4-c53519c2525e" /> | <img width="465" height="612" alt="Screenshot from 2026-02-13 21-09-37" src="https://github.com/user-attachments/assets/fdde0504-a10a-4191-a14d-99568271835b" /> |
| <img width="465" height="612" alt="Screenshot from 2026-02-13 20-54-37" src="https://github.com/user-attachments/assets/18781aab-4cbf-4b24-b541-727ac9906db8" /> | <img width="465" height="612" alt="Screenshot from 2026-02-13 21-09-52" src="https://github.com/user-attachments/assets/18e8ce7e-c11c-4e2f-94d1-e78dce790880" /> |
