### PR TITLE
Site Settings: add wpcom_public_coming_soon to the v1.4 endpoint and sync whitelist

### DIFF
--- a/projects/packages/sync/changelog/add-wpcom-public-coming-soon
+++ b/projects/packages/sync/changelog/add-wpcom-public-coming-soon
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Added wpcom_public_coming_soon to the options sync whitelist.

--- a/projects/packages/sync/changelog/add-wpcom-public-coming-soon
+++ b/projects/packages/sync/changelog/add-wpcom-public-coming-soon
@@ -1,4 +1,4 @@
 Significance: patch
 Type: added
 
-Added wpcom_public_coming_soon to the options sync whitelist.
+Add wpcom_public_coming_soon to the options sync whitelist.

--- a/projects/packages/sync/src/class-defaults.php
+++ b/projects/packages/sync/src/class-defaults.php
@@ -29,6 +29,7 @@ class Defaults {
 		'blog_charset',
 		'blog_public',
 		'wpcom_data_sharing_opt_out',
+		'wpcom_public_coming_soon',
 		'blogdescription',
 		'blogname',
 		'carousel_background_color',

--- a/projects/plugins/jetpack/changelog/add-wpcom-public-coming-soon
+++ b/projects/plugins/jetpack/changelog/add-wpcom-public-coming-soon
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Site Settings: add wpcom_public_coming_soon to the v1.4 site settings endpoint.

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
@@ -402,6 +402,7 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 						'instant_search_enabled'           => (bool) get_option( 'instant_search_enabled' ),
 						'blog_public'                      => (int) get_option( 'blog_public' ),
 						'wpcom_data_sharing_opt_out'       => (bool) get_option( 'wpcom_data_sharing_opt_out' ),
+						'wpcom_public_coming_soon'         => (int) get_option( 'wpcom_public_coming_soon' ),
 						'jetpack_sync_non_public_post_stati' => (bool) Jetpack_Options::get_option( 'sync_non_public_post_stati' ),
 						'jetpack_relatedposts_allowed'     => (bool) $this->jetpack_relatedposts_supported(),
 						'jetpack_relatedposts_enabled'     => (bool) $jetpack_relatedposts_options['enabled'],

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-v1-4-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-v1-4-endpoint.php
@@ -48,6 +48,7 @@ new WPCOM_JSON_API_Site_Settings_V1_4_Endpoint(
 			'default_comment_status'                    => '(bool) Allow comments on new articles?',
 			'blog_public'                               => '(string) Site visibility; -1: private, 0: discourage search engines, 1: allow search engines',
 			'wpcom_data_sharing_opt_out'                => '(bool) Did the site opt out of public content sharing with third parties and research partners?',
+			'wpcom_public_coming_soon'                  => '(string) Defines if the site should in the public coming soon mode; 1 means yes, 0 means no',
 			'jetpack_sync_non_public_post_stati'        => '(bool) allow sync of post and pages with non-public posts stati',
 			'jetpack_relatedposts_enabled'              => '(bool) Enable related posts?',
 			'jetpack_relatedposts_show_context'         => '(bool) Show post\'s tags and category in related posts?',

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-v1-4-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-v1-4-endpoint.php
@@ -48,7 +48,7 @@ new WPCOM_JSON_API_Site_Settings_V1_4_Endpoint(
 			'default_comment_status'                    => '(bool) Allow comments on new articles?',
 			'blog_public'                               => '(string) Site visibility; -1: private, 0: discourage search engines, 1: allow search engines',
 			'wpcom_data_sharing_opt_out'                => '(bool) Did the site opt out of public content sharing with third parties and research partners?',
-			'wpcom_public_coming_soon'                  => '(string) Defines if the site should in the public coming soon mode; 1 means yes, 0 means no',
+			'wpcom_public_coming_soon'                  => '(string) Defines if the site should be in the public coming soon mode; 1 means yes, 0 means no',
 			'jetpack_sync_non_public_post_stati'        => '(bool) allow sync of post and pages with non-public posts stati',
 			'jetpack_relatedposts_enabled'              => '(bool) Enable related posts?',
 			'jetpack_relatedposts_show_context'         => '(bool) Show post\'s tags and category in related posts?',

--- a/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Options_Test.php
+++ b/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Options_Test.php
@@ -132,6 +132,7 @@ class Jetpack_Sync_Options_Test extends Jetpack_Sync_TestBase {
 			'sticky_posts'                                 => 'pineapple',
 			'blog_public'                                  => 0,
 			'wpcom_data_sharing_opt_out'                   => false,
+			'wpcom_public_coming_soon'                     => 1,
 			'default_pingback_flag'                        => 'pineapple',
 			'require_name_email'                           => 'pineapple',
 			'close_comments_for_old_posts'                 => 'pineapple',


### PR DESCRIPTION
Related to ARC-1296

## Proposed changes:

* Add `wpcom_public_coming_soon` to the `request_format` array in the v1.4 site settings endpoint, so it is accepted as a POST parameter and falls through to the default `update_option` handler.
* Add `wpcom_public_coming_soon` to the sync options whitelist so the value is synced properly.

I noticed that `wpcom_public_coming_soon` was not being persisted when updated via the CIAB site visibility settings page. After investigation, I found that the option was missing from the `request_format` mapping in the v1.4 update endpoint. This is related to ongoing work around site visibility controls for CIAB sites.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

* Apply this change to your garden site.
* Apply this to your sandbox.
* Navigate to `https://my.wordpress.com/ciab/sites/:SITE/settings/site-visibility?back_to=site-overview`
* Update the visibility settings and ensure you the state persists by refresing the page.