### PR TITLE
Admin Menu: centralize Hosting & Upgrades menu registration

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/dotcom-13317-untangling-ia-hostingupgrades
+++ b/projects/packages/jetpack-mu-wpcom/changelog/dotcom-13317-untangling-ia-hostingupgrades
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Admin Menu: simplify Hosting menu to a single link, and centralize Upgrades menu registration for all admin interfaces.

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/p2-admin-menu.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/p2-admin-menu.php
@@ -54,9 +54,6 @@ function wpcom_remove_menus_for_p2_sites() {
 		remove_menu_page( 'stats' );
 		remove_submenu_page( 'paid-upgrades.php', "https://wordpress.com/domains/manage/$domain" );
 		remove_submenu_page( 'paid-upgrades.php', "https://wordpress.com/email/$domain" );
-		remove_submenu_page( 'wpcom-hosting-menu', "https://wordpress.com/overview/$domain" );
-		remove_submenu_page( 'wpcom-hosting-menu', "https://wordpress.com/email/$domain" );
-		remove_submenu_page( 'wpcom-hosting-menu', "https://wordpress.com/domains/manage/$domain" );
 		remove_menu_page( 'edit.php' );
 		remove_menu_page( 'edit.php?post_type=page' );
 		remove_menu_page( 'upload.php' );
@@ -75,7 +72,7 @@ function wpcom_remove_menus_for_p2_sites() {
 		add_submenu_page( 'tools.php', __( 'Integrations', 'jetpack-mu-wpcom' ), __( 'Integrations', 'jetpack-mu-wpcom' ), 'manage_options', "https://wordpress.com/marketing/connections/$domain", null, 0 );
 	} else {
 		remove_menu_page( 'paid-upgrades.php' );
-		remove_menu_page( 'wpcom-hosting-menu' );
+		remove_menu_page( esc_url( "https://wordpress.com/overview/$domain" ) );
 
 		$is_api_request = defined( 'REST_REQUEST' ) && REST_REQUEST;
 		if ( $is_api_request ) {

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/p2-admin-menu.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/p2-admin-menu.php
@@ -42,6 +42,7 @@ function wpcom_remove_menus_for_p2_sites() {
 	remove_submenu_page( 'options-general.php', 'crowdsignal-settings' );
 	remove_submenu_page( 'options-general.php', 'ratingsettings' );
 	remove_submenu_page( 'options-general.php', 'activitypub' );
+	remove_menu_page( "https://wordpress.com/overview/$domain" );
 
 	require_once WP_CONTENT_DIR . '/lib/wpforteams/functions.php';
 
@@ -72,7 +73,6 @@ function wpcom_remove_menus_for_p2_sites() {
 		add_submenu_page( 'tools.php', __( 'Integrations', 'jetpack-mu-wpcom' ), __( 'Integrations', 'jetpack-mu-wpcom' ), 'manage_options', "https://wordpress.com/marketing/connections/$domain", null, 0 );
 	} else {
 		remove_menu_page( 'paid-upgrades.php' );
-		remove_menu_page( esc_url( "https://wordpress.com/overview/$domain" ) );
 
 		$is_api_request = defined( 'REST_REQUEST' ) && REST_REQUEST;
 		if ( $is_api_request ) {

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.css
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.css
@@ -1,0 +1,13 @@
+/**
+ * Inline icon in a menu title
+ */
+.inline-icon {
+	font-size: 16px;
+	opacity: 0.8;
+	position: absolute;
+	right: 8px;
+}
+
+body.is-nav-unification .inline-icon {
+	right: 16px;
+}

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
@@ -104,9 +104,14 @@ add_action( 'admin_menu', 'wpcom_add_my_home_menu' );
 function wpcom_add_hosting_menu() {
 	$domain = wp_parse_url( home_url(), PHP_URL_HOST );
 
+	$menu_title = sprintf(
+		'%1$s<span class="inline-icon dashicons dashicons-external"></span>',
+		esc_attr__( 'Hosting', 'jetpack-mu-wpcom' )
+	);
+
 	add_menu_page(
 		esc_attr__( 'Hosting', 'jetpack-mu-wpcom' ),
-		esc_attr__( 'Hosting', 'jetpack-mu-wpcom' ),
+		$menu_title,
 		'manage_options',
 		esc_url( "https://wordpress.com/overview/$domain" ),
 		null, // @phan-suppress-current-line PhanTypeMismatchArgumentProbablyReal
@@ -115,6 +120,19 @@ function wpcom_add_hosting_menu() {
 	);
 }
 add_action( 'admin_menu', 'wpcom_add_hosting_menu' );
+
+/**
+ * Enqueues admin menu styles.
+ */
+function wpcom_admin_menu_enqueue_styles() {
+	wp_enqueue_style(
+		'wpcom-admin-menu',
+		plugins_url( 'wpcom-admin-menu.css', __FILE__ ),
+		array(),
+		filemtime( __DIR__ . '/wpcom-admin-menu.css' )
+	);
+}
+add_action( 'admin_enqueue_scripts', 'wpcom_admin_menu_enqueue_styles' );
 
 /**
  * Adds an Upgrades menu.

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
@@ -106,11 +106,11 @@ function wpcom_add_hosting_menu() {
 
 	$menu_title = sprintf(
 		'%1$s<span class="inline-icon dashicons dashicons-external"></span>',
-		esc_attr__( 'Hosting', 'jetpack-mu-wpcom' )
+		__( 'Hosting', 'jetpack-mu-wpcom' )
 	);
 
 	add_menu_page(
-		esc_attr__( 'Hosting', 'jetpack-mu-wpcom' ),
+		__( 'Hosting', 'jetpack-mu-wpcom' ),
 		$menu_title,
 		'manage_options',
 		esc_url( "https://wordpress.com/overview/$domain" ),
@@ -156,15 +156,15 @@ function wpcom_add_upgrades_menu() {
 		// Calypso and the masterbar CSS override this to show the plan label.
 		$menu_title = sprintf(
 			'%1$s<span class="inline-text" style="display:none">%2$s</span>',
-			esc_attr__( 'Upgrades', 'jetpack-mu-wpcom' ),
+			__( 'Upgrades', 'jetpack-mu-wpcom' ),
 			esc_html( $plan )
 		);
 	} else {
-		$menu_title = esc_attr__( 'Upgrades', 'jetpack-mu-wpcom' );
+		$menu_title = __( 'Upgrades', 'jetpack-mu-wpcom' );
 	}
 
 	add_menu_page(
-		esc_attr__( 'Upgrades', 'jetpack-mu-wpcom' ),
+		__( 'Upgrades', 'jetpack-mu-wpcom' ),
 		$menu_title,
 		'manage_options',
 		$parent_slug,
@@ -175,8 +175,8 @@ function wpcom_add_upgrades_menu() {
 
 	add_submenu_page(
 		$parent_slug,
-		esc_attr__( 'Plans', 'jetpack-mu-wpcom' ),
-		esc_attr__( 'Plans', 'jetpack-mu-wpcom' ),
+		__( 'Plans', 'jetpack-mu-wpcom' ),
+		__( 'Plans', 'jetpack-mu-wpcom' ),
 		'manage_options',
 		esc_url( "https://wordpress.com/plans/$domain" ),
 		null, // @phan-suppress-current-line PhanTypeMismatchArgumentProbablyReal
@@ -185,8 +185,8 @@ function wpcom_add_upgrades_menu() {
 
 	add_submenu_page(
 		$parent_slug,
-		esc_attr__( 'Add-ons', 'jetpack-mu-wpcom' ),
-		esc_attr__( 'Add-ons', 'jetpack-mu-wpcom' ),
+		__( 'Add-ons', 'jetpack-mu-wpcom' ),
+		__( 'Add-ons', 'jetpack-mu-wpcom' ),
 		'manage_options',
 		esc_url( "https://wordpress.com/add-ons/$domain" ),
 		null, // @phan-suppress-current-line PhanTypeMismatchArgumentProbablyReal
@@ -195,8 +195,8 @@ function wpcom_add_upgrades_menu() {
 
 	add_submenu_page(
 		$parent_slug,
-		esc_attr__( 'Domains', 'jetpack-mu-wpcom' ),
-		esc_attr__( 'Domains', 'jetpack-mu-wpcom' ),
+		__( 'Domains', 'jetpack-mu-wpcom' ),
+		__( 'Domains', 'jetpack-mu-wpcom' ),
 		'manage_options',
 		esc_url( "https://wordpress.com/domains/manage/$domain" ),
 		null, // @phan-suppress-current-line PhanTypeMismatchArgumentProbablyReal
@@ -205,8 +205,8 @@ function wpcom_add_upgrades_menu() {
 
 	add_submenu_page(
 		$parent_slug,
-		esc_attr__( 'Emails', 'jetpack-mu-wpcom' ),
-		esc_attr__( 'Emails', 'jetpack-mu-wpcom' ),
+		__( 'Emails', 'jetpack-mu-wpcom' ),
+		__( 'Emails', 'jetpack-mu-wpcom' ),
 		'manage_options',
 		esc_url( "https://wordpress.com/email/$domain" ),
 		null, // @phan-suppress-current-line PhanTypeMismatchArgumentProbablyReal
@@ -215,8 +215,8 @@ function wpcom_add_upgrades_menu() {
 
 	add_submenu_page(
 		$parent_slug,
-		esc_attr__( 'Purchases', 'jetpack-mu-wpcom' ),
-		esc_attr__( 'Purchases', 'jetpack-mu-wpcom' ),
+		__( 'Purchases', 'jetpack-mu-wpcom' ),
+		__( 'Purchases', 'jetpack-mu-wpcom' ),
 		'manage_options',
 		esc_url( "https://wordpress.com/purchases/subscriptions/$domain" ),
 		null, // @phan-suppress-current-line PhanTypeMismatchArgumentProbablyReal

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
@@ -102,30 +102,57 @@ add_action( 'admin_menu', 'wpcom_add_my_home_menu' );
  * Adds a Hosting menu.
  */
 function wpcom_add_hosting_menu() {
-	if ( get_option( 'wpcom_admin_interface' ) !== 'wp-admin' ) {
-		return;
-	}
-
-	$parent_slug = 'wpcom-hosting-menu';
-	$domain      = wp_parse_url( home_url(), PHP_URL_HOST );
+	$domain = wp_parse_url( home_url(), PHP_URL_HOST );
 
 	add_menu_page(
 		esc_attr__( 'Hosting', 'jetpack-mu-wpcom' ),
 		esc_attr__( 'Hosting', 'jetpack-mu-wpcom' ),
 		'manage_options',
-		$parent_slug,
+		esc_url( "https://wordpress.com/overview/$domain" ),
 		null, // @phan-suppress-current-line PhanTypeMismatchArgumentProbablyReal
 		'dashicons-cloud',
-		3
+		2.98
 	);
+}
+add_action( 'admin_menu', 'wpcom_add_hosting_menu' );
 
-	add_submenu_page(
-		$parent_slug,
-		esc_attr__( 'Overview', 'jetpack-mu-wpcom' ),
-		esc_attr__( 'Overview', 'jetpack-mu-wpcom' ),
+/**
+ * Adds an Upgrades menu.
+ *
+ * This centralizes the Upgrades menu registration for all admin interfaces (Calypso and wp-admin).
+ * The masterbar classes defer to this function instead of registering their own Upgrades menu.
+ */
+function wpcom_add_upgrades_menu() {
+	// Don't show Upgrades on staging sites.
+	if ( get_option( 'wpcom_is_staging_site' ) ) {
+		return;
+	}
+
+	$domain      = wp_parse_url( home_url(), PHP_URL_HOST );
+	$parent_slug = 'paid-upgrades.php';
+
+	// Build the menu title, optionally with the plan label.
+	$plan = wpcom_get_current_plan_name();
+	if ( $plan ) {
+		// Add display:none as a default for cases when CSS is not loaded.
+		// Calypso and the masterbar CSS override this to show the plan label.
+		$menu_title = sprintf(
+			'%1$s<span class="inline-text" style="display:none">%2$s</span>',
+			esc_attr__( 'Upgrades', 'jetpack-mu-wpcom' ),
+			esc_html( $plan )
+		);
+	} else {
+		$menu_title = esc_attr__( 'Upgrades', 'jetpack-mu-wpcom' );
+	}
+
+	add_menu_page(
+		esc_attr__( 'Upgrades', 'jetpack-mu-wpcom' ),
+		$menu_title,
 		'manage_options',
-		esc_url( "https://wordpress.com/overview/$domain" ),
-		null // @phan-suppress-current-line PhanTypeMismatchArgumentProbablyReal
+		$parent_slug,
+		null, // @phan-suppress-current-line PhanTypeMismatchArgumentProbablyReal
+		'dashicons-cart',
+		2.99
 	);
 
 	add_submenu_page(
@@ -134,7 +161,8 @@ function wpcom_add_hosting_menu() {
 		esc_attr__( 'Plans', 'jetpack-mu-wpcom' ),
 		'manage_options',
 		esc_url( "https://wordpress.com/plans/$domain" ),
-		null // @phan-suppress-current-line PhanTypeMismatchArgumentProbablyReal
+		null, // @phan-suppress-current-line PhanTypeMismatchArgumentProbablyReal
+		1
 	);
 
 	add_submenu_page(
@@ -143,7 +171,8 @@ function wpcom_add_hosting_menu() {
 		esc_attr__( 'Add-ons', 'jetpack-mu-wpcom' ),
 		'manage_options',
 		esc_url( "https://wordpress.com/add-ons/$domain" ),
-		null // @phan-suppress-current-line PhanTypeMismatchArgumentProbablyReal
+		null, // @phan-suppress-current-line PhanTypeMismatchArgumentProbablyReal
+		2
 	);
 
 	add_submenu_page(
@@ -152,7 +181,8 @@ function wpcom_add_hosting_menu() {
 		esc_attr__( 'Domains', 'jetpack-mu-wpcom' ),
 		'manage_options',
 		esc_url( "https://wordpress.com/domains/manage/$domain" ),
-		null // @phan-suppress-current-line PhanTypeMismatchArgumentProbablyReal
+		null, // @phan-suppress-current-line PhanTypeMismatchArgumentProbablyReal
+		3
 	);
 
 	add_submenu_page(
@@ -161,7 +191,8 @@ function wpcom_add_hosting_menu() {
 		esc_attr__( 'Emails', 'jetpack-mu-wpcom' ),
 		'manage_options',
 		esc_url( "https://wordpress.com/email/$domain" ),
-		null // @phan-suppress-current-line PhanTypeMismatchArgumentProbablyReal
+		null, // @phan-suppress-current-line PhanTypeMismatchArgumentProbablyReal
+		4
 	);
 
 	add_submenu_page(
@@ -170,16 +201,45 @@ function wpcom_add_hosting_menu() {
 		esc_attr__( 'Purchases', 'jetpack-mu-wpcom' ),
 		'manage_options',
 		esc_url( "https://wordpress.com/purchases/subscriptions/$domain" ),
-		null // @phan-suppress-current-line PhanTypeMismatchArgumentProbablyReal
+		null, // @phan-suppress-current-line PhanTypeMismatchArgumentProbablyReal
+		5
 	);
 
 	// By default, WordPress adds a submenu item for the parent menu item, which we don't want.
-	remove_submenu_page(
-		$parent_slug,
-		$parent_slug
-	);
+	remove_submenu_page( $parent_slug, $parent_slug );
+
+	// Remove legacy Upgrades submenus registered elsewhere on WP.com.
+	remove_submenu_page( $parent_slug, 'premium-themes' );
+	remove_submenu_page( $parent_slug, 'domains' );
+	remove_submenu_page( $parent_slug, 'my-upgrades' );
+	remove_submenu_page( $parent_slug, 'billing-history' );
 }
-add_action( 'admin_menu', 'wpcom_add_hosting_menu' );
+add_action( 'admin_menu', 'wpcom_add_upgrades_menu', 140 ); // After hookpress hook at 130, needed to ensure the legacy submenus are removed.
+
+/**
+ * Gets the current plan's short name.
+ *
+ * @return string|null The plan name, or null if unavailable.
+ */
+function wpcom_get_current_plan_name() {
+	// Simple sites: use WPCOM_Store_API.
+	if ( class_exists( 'WPCOM_Store_API' ) ) {
+		$current_plan = \WPCOM_Store_API::get_current_plan( get_current_blog_id() );
+		if ( ! empty( $current_plan['product_name_short'] ) ) {
+			return $current_plan['product_name_short'];
+		}
+	}
+
+	// Atomic sites: use Jetpack Current_Plan.
+	if ( class_exists( 'Automattic\Jetpack\Current_Plan' ) ) {
+		$products = \Automattic\Jetpack\Current_Plan::get();
+		if ( array_key_exists( 'product_name_short', $products ) ) {
+			return $products['product_name_short'];
+		}
+	}
+
+	return null;
+}
 
 /**
  * Re-order the submenu items of the given menu slug according to a sorted array of submenu slugs.

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/wpcom-admin-menu/WPCOM_Admin_Menu_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/wpcom-admin-menu/WPCOM_Admin_Menu_Test.php
@@ -1,0 +1,121 @@
+<?php
+/**
+ * Test class for wpcom-admin-menu.
+ *
+ * @package automattic/jetpack-mu-wpcom
+ */
+
+use Automattic\Jetpack\Jetpack_Mu_Wpcom;
+
+require_once Jetpack_Mu_Wpcom::PKG_DIR . 'src/features/wpcom-admin-menu/wpcom-admin-menu.php';
+
+/**
+ * Class WPCOM_Admin_Menu_Test
+ */
+class WPCOM_Admin_Menu_Test extends \WorDBless\BaseTestCase {
+
+	/**
+	 * Admin user ID.
+	 *
+	 * @var int
+	 */
+	private static $admin_id;
+
+	/**
+	 * Domain for the test site.
+	 *
+	 * @var string
+	 */
+	private static $domain;
+
+	/**
+	 * Set up before class.
+	 */
+	public static function set_up_before_class() {
+		parent::set_up_before_class();
+
+		self::$admin_id = wp_insert_user(
+			array(
+				'user_login' => 'admin_user',
+				'user_pass'  => 'pass',
+				'user_email' => 'admin@example.com',
+				'role'       => 'administrator',
+			)
+		);
+
+		self::$domain = wp_parse_url( home_url(), PHP_URL_HOST );
+	}
+
+	/**
+	 * Set up each test.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		global $menu, $submenu;
+		$menu    = array();
+		$submenu = array();
+
+		wp_set_current_user( self::$admin_id );
+	}
+
+	/**
+	 * Tests wpcom_add_hosting_menu
+	 */
+	public function test_add_hosting_menu() {
+		global $menu;
+
+		wpcom_add_hosting_menu();
+
+		// Find the Hosting menu item.
+		$hosting_menu = null;
+		foreach ( $menu as $item ) {
+			if ( strpos( $item[2], 'https://wordpress.com/overview/' ) !== false ) {
+				$hosting_menu = $item;
+				break;
+			}
+		}
+
+		$this->assertNotNull( $hosting_menu, 'Hosting menu item should exist.' );
+		$this->assertSame( 'https://wordpress.com/overview/' . self::$domain, $hosting_menu[2] );
+		$this->assertStringContainsString( 'inline-icon', $hosting_menu[0] );
+		$this->assertStringContainsString( 'dashicons-external', $hosting_menu[0] );
+	}
+
+	/**
+	 * Tests wpcom_add_upgrades_menu
+	 */
+	public function test_add_upgrades_menu() {
+		global $submenu;
+
+		wpcom_add_upgrades_menu();
+
+		$this->assertSame( 'https://wordpress.com/plans/' . self::$domain, $submenu['paid-upgrades.php'][1][2] );
+		$this->assertSame( 'https://wordpress.com/add-ons/' . self::$domain, $submenu['paid-upgrades.php'][2][2] );
+		$this->assertSame( 'https://wordpress.com/domains/manage/' . self::$domain, $submenu['paid-upgrades.php'][3][2] );
+		$this->assertSame( 'https://wordpress.com/email/' . self::$domain, $submenu['paid-upgrades.php'][4][2] );
+		$this->assertSame( 'https://wordpress.com/purchases/subscriptions/' . self::$domain, $submenu['paid-upgrades.php'][5][2] );
+	}
+
+	/**
+	 * Tests wpcom_add_upgrades_menu is not added on staging sites.
+	 */
+	public function test_add_upgrades_menu_not_on_staging() {
+		global $menu;
+
+		update_option( 'wpcom_is_staging_site', true );
+		wpcom_add_upgrades_menu();
+
+		$upgrades_menu = null;
+		foreach ( $menu as $item ) {
+			if ( $item[2] === 'paid-upgrades.php' ) {
+				$upgrades_menu = $item;
+				break;
+			}
+		}
+
+		$this->assertNull( $upgrades_menu, 'Upgrades menu should not exist on staging sites.' );
+
+		delete_option( 'wpcom_is_staging_site' );
+	}
+}

--- a/projects/packages/masterbar/changelog/dotcom-13317-untangling-ia-hostingupgrades
+++ b/projects/packages/masterbar/changelog/dotcom-13317-untangling-ia-hostingupgrades
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Admin Menu: move Upgrades menu registration to jetpack-mu-wpcom for all admin interfaces.

--- a/projects/packages/masterbar/src/admin-menu/admin-menu.css
+++ b/projects/packages/masterbar/src/admin-menu/admin-menu.css
@@ -177,6 +177,20 @@
 }
 
 /**
+ * Inline icon in a menu title
+ */
+.inline-icon {
+	font-size: 16px;
+	opacity: 0.8;
+	position: absolute;
+	right: 16px;
+}
+
+body.is-nav-unification .inline-icon {
+	right: 8px;
+}
+
+/**
  * Stats
  */
 [class*="toplevel_page_https://wordpress.com/stats/day"] .sidebar-unified__sparkline {

--- a/projects/packages/masterbar/src/admin-menu/admin-menu.css
+++ b/projects/packages/masterbar/src/admin-menu/admin-menu.css
@@ -177,20 +177,6 @@
 }
 
 /**
- * Inline icon in a menu title
- */
-.inline-icon {
-	font-size: 16px;
-	opacity: 0.8;
-	position: absolute;
-	right: 16px;
-}
-
-body.is-nav-unification .inline-icon {
-	right: 8px;
-}
-
-/**
  * Stats
  */
 [class*="toplevel_page_https://wordpress.com/stats/day"] .sidebar-unified__sparkline {

--- a/projects/packages/masterbar/src/admin-menu/class-admin-menu.php
+++ b/projects/packages/masterbar/src/admin-menu/class-admin-menu.php
@@ -20,7 +20,6 @@ class Admin_Menu extends Base_Admin_Menu {
 	 * Create the desired menu output.
 	 */
 	public function reregister_menu_items() {
-		$this->add_upgrades_menu();
 		$this->add_appearance_menu();
 		$this->add_plugins_menu();
 		$this->add_users_menu();
@@ -85,49 +84,6 @@ class Admin_Menu extends Base_Admin_Menu {
 		}
 
 		return true;
-	}
-
-	/**
-	 * Adds Upgrades menu.
-	 *
-	 * @param string $plan The current WPCOM plan of the blog.
-	 */
-	public function add_upgrades_menu( $plan = null ) {
-		global $menu;
-
-		$menu_exists = false;
-		foreach ( $menu as $item ) {
-			if ( 'paid-upgrades.php' === $item[2] ) {
-				$menu_exists = true;
-				break;
-			}
-		}
-
-		if ( ! $menu_exists ) {
-			if ( $plan ) {
-				// Add display:none as a default for cases when CSS is not loaded.
-				$site_upgrades = '%1$s<span class="inline-text" style="display:none">%2$s</span>';
-				$site_upgrades = sprintf(
-					$site_upgrades,
-					__( 'Upgrades', 'jetpack-masterbar' ),
-					// phpcs:ignore WordPress.WP.I18n.NonSingularStringLiteralText
-					__( $plan, 'jetpack-masterbar' )
-				);
-			} else {
-				$site_upgrades = __( 'Upgrades', 'jetpack-masterbar' );
-			}
-			// @phan-suppress-next-line PhanTypeMismatchArgumentProbablyReal -- Core should ideally document null for no-callback arg. https://core.trac.wordpress.org/ticket/52539.
-			add_menu_page( __( 'Upgrades', 'jetpack-masterbar' ), $site_upgrades, 'manage_options', 'paid-upgrades.php', null, 'dashicons-cart', 2.99 );
-		}
-		// @phan-suppress-next-line PhanTypeMismatchArgumentProbablyReal -- Core should ideally document null for no-callback arg. https://core.trac.wordpress.org/ticket/52539.
-		add_submenu_page( 'paid-upgrades.php', __( 'Plans', 'jetpack-masterbar' ), __( 'Plans', 'jetpack-masterbar' ), 'manage_options', 'https://wordpress.com/plans/' . $this->domain, null, 1 );
-		// @phan-suppress-next-line PhanTypeMismatchArgumentProbablyReal -- Core should ideally document null for no-callback arg. https://core.trac.wordpress.org/ticket/52539.
-		add_submenu_page( 'paid-upgrades.php', __( 'Purchases', 'jetpack-masterbar' ), __( 'Purchases', 'jetpack-masterbar' ), 'manage_options', 'https://wordpress.com/purchases/subscriptions/' . $this->domain, null, 2 );
-
-		if ( ! $menu_exists ) {
-			// Remove the submenu auto-created by Core.
-			$this->hide_submenu_page( 'paid-upgrades.php', 'paid-upgrades.php' );
-		}
 	}
 
 	/**

--- a/projects/packages/masterbar/src/admin-menu/class-atomic-admin-menu.php
+++ b/projects/packages/masterbar/src/admin-menu/class-atomic-admin-menu.php
@@ -8,7 +8,6 @@
 namespace Automattic\Jetpack\Masterbar;
 
 use Automattic\Jetpack\Connection\Client;
-use Automattic\Jetpack\Current_Plan as Jetpack_Plan;
 use Automattic\Jetpack\JITMS\JITM;
 use Automattic\Jetpack\Modules;
 
@@ -240,43 +239,6 @@ class Atomic_Admin_Menu extends Admin_Menu {
 				'feature_class'                => $message->feature_class,
 				'id'                           => $message->id,
 			);
-		}
-	}
-
-	/**
-	 * Adds Upgrades menu.
-	 *
-	 * @param string $plan The current WPCOM plan of the blog.
-	 */
-	public function add_upgrades_menu( $plan = null ) {
-
-		if ( get_option( 'wpcom_is_staging_site' ) ) {
-			return;
-		}
-		$products = Jetpack_Plan::get();
-		if ( array_key_exists( 'product_name_short', $products ) ) {
-			$plan = $products['product_name_short'];
-		}
-		parent::add_upgrades_menu( $plan );
-
-		$last_upgrade_submenu_position = $this->get_submenu_item_count( 'paid-upgrades.php' );
-
-		// @phan-suppress-next-line PhanTypeMismatchArgumentProbablyReal -- Core should ideally document null for no-callback arg. https://core.trac.wordpress.org/ticket/52539.
-		add_submenu_page( 'paid-upgrades.php', __( 'Domains', 'jetpack-masterbar' ), __( 'Domains', 'jetpack-masterbar' ), 'manage_options', 'https://wordpress.com/domains/manage/' . $this->domain, null, $last_upgrade_submenu_position - 1 );
-
-		/**
-		 * Whether to show the WordPress.com Emails submenu under the main Upgrades menu.
-		 *
-		 * @use add_filter( 'jetpack_show_wpcom_upgrades_email_menu', '__return_true' );
-		 * @module masterbar
-		 *
-		 * @since jetpack-9.7.0
-		 *
-		 * @param bool $show_wpcom_upgrades_email_menu Load the WordPress.com Emails submenu item. Default to false.
-		 */
-		if ( apply_filters( 'jetpack_show_wpcom_upgrades_email_menu', false ) ) {
-			// @phan-suppress-next-line PhanTypeMismatchArgumentProbablyReal -- Core should ideally document null for no-callback arg. https://core.trac.wordpress.org/ticket/52539.
-			add_submenu_page( 'paid-upgrades.php', __( 'Emails', 'jetpack-masterbar' ), __( 'Emails', 'jetpack-masterbar' ), 'manage_options', 'https://wordpress.com/email/' . $this->domain, null, $last_upgrade_submenu_position );
 		}
 	}
 

--- a/projects/packages/masterbar/src/admin-menu/class-wpcom-admin-menu.php
+++ b/projects/packages/masterbar/src/admin-menu/class-wpcom-admin-menu.php
@@ -17,13 +17,6 @@ require_once __DIR__ . '/class-admin-menu.php';
  */
 class WPcom_Admin_Menu extends Admin_Menu {
 	/**
-	 * Holds the current plan, set by get_current_plan().
-	 *
-	 * @var array
-	 */
-	private $current_plan = array();
-
-	/**
 	 * WPcom_Admin_Menu constructor.
 	 */
 	protected function __construct() {
@@ -161,48 +154,6 @@ class WPcom_Admin_Menu extends Admin_Menu {
 				'feature_class'                => $message->feature_class,
 				'id'                           => $message->id,
 			);
-		}
-	}
-
-	/**
-	 * Gets the current plan and stores it in $this->current_plan so the database is only called once per request.
-	 *
-	 * @return array
-	 */
-	private function get_current_plan() {
-		if ( empty( $this->current_plan ) && class_exists( 'WPCOM_Store_API' ) ) {
-			$this->current_plan = \WPCOM_Store_API::get_current_plan( get_current_blog_id() );
-		}
-		return $this->current_plan;
-	}
-
-	/**
-	 * Adds Upgrades menu.
-	 *
-	 * @param string $plan The current WPCOM plan of the blog.
-	 */
-	public function add_upgrades_menu( $plan = null ) {
-		$current_plan = $this->get_current_plan();
-		if ( ! empty( $current_plan['product_name_short'] ) ) {
-			$plan = $current_plan['product_name_short'];
-		}
-
-		parent::add_upgrades_menu( $plan );
-
-		$last_upgrade_submenu_position = $this->get_submenu_item_count( 'paid-upgrades.php' );
-
-		// @phan-suppress-next-line PhanTypeMismatchArgumentProbablyReal -- Core should ideally document null for no-callback arg. https://core.trac.wordpress.org/ticket/52539.
-		add_submenu_page( 'paid-upgrades.php', __( 'Domains', 'jetpack-masterbar' ), __( 'Domains', 'jetpack-masterbar' ), 'manage_options', 'https://wordpress.com/domains/manage/' . $this->domain, null, $last_upgrade_submenu_position - 1 );
-
-		/** This filter is already documented in modules/masterbar/admin-menu/class-atomic-admin-menu.php */
-		if ( apply_filters( 'jetpack_show_wpcom_upgrades_email_menu', false ) ) {
-			// @phan-suppress-next-line PhanTypeMismatchArgumentProbablyReal -- Core should ideally document null for no-callback arg. https://core.trac.wordpress.org/ticket/52539.
-			add_submenu_page( 'paid-upgrades.php', __( 'Emails', 'jetpack-masterbar' ), __( 'Emails', 'jetpack-masterbar' ), 'manage_options', 'https://wordpress.com/email/' . $this->domain, null, $last_upgrade_submenu_position );
-		}
-
-		if ( defined( 'WPCOM_ENABLE_ADD_ONS_MENU_ITEM' ) && WPCOM_ENABLE_ADD_ONS_MENU_ITEM ) {
-			// @phan-suppress-next-line PhanTypeMismatchArgumentProbablyReal -- Core should ideally document null for no-callback arg. https://core.trac.wordpress.org/ticket/52539.
-			add_submenu_page( 'paid-upgrades.php', __( 'Add-Ons', 'jetpack-masterbar' ), __( 'Add-Ons', 'jetpack-masterbar' ), 'manage_options', 'https://wordpress.com/add-ons/' . $this->domain, null, 1 );
 		}
 	}
 
@@ -350,11 +301,6 @@ class WPcom_Admin_Menu extends Admin_Menu {
 		/* @see https://github.com/Automattic/wp-calypso/issues/49210 */
 		remove_submenu_page( 'index.php', 'my-blogs' );
 		$_registered_pages['admin_page_my-blogs'] = true; // phpcs:ignore
-
-		remove_submenu_page( 'paid-upgrades.php', 'premium-themes' );
-		remove_submenu_page( 'paid-upgrades.php', 'domains' );
-		remove_submenu_page( 'paid-upgrades.php', 'my-upgrades' );
-		remove_submenu_page( 'paid-upgrades.php', 'billing-history' );
 
 		remove_submenu_page( 'themes.php', 'customize.php?autofocus[panel]=amp_panel&return=' . rawurlencode( admin_url() ) );
 

--- a/projects/packages/masterbar/tests/php/Admin_Menu_Test.php
+++ b/projects/packages/masterbar/tests/php/Admin_Menu_Test.php
@@ -104,7 +104,7 @@ class Admin_Menu_Test extends TestCase {
 
 		static::$admin_menu->reregister_menu_items();
 
-		$this->assertCount( 17, $menu, 'Admin menu should not have unexpected top menu items.' );
+		$this->assertCount( 16, $menu, 'Admin menu should not have unexpected top menu items.' );
 
 		$this->assertEquals( static::$submenu_data[''], $submenu[''], 'Submenu items without parent should stay the same.' );
 	}
@@ -117,18 +117,6 @@ class Admin_Menu_Test extends TestCase {
 		$this->assertSame( 'default', static::$admin_menu->get_preferred_view( 'users.php' ) );
 		static::$admin_menu->set_preferred_view( 'options-general.php', 'unknown' );
 		$this->assertSame( 'default', static::$admin_menu->get_preferred_view( 'options-general.php' ) );
-	}
-
-	/**
-	 * Tests add_upgrades_menu
-	 */
-	public function test_add_upgrades_menu() {
-		global $submenu;
-
-		static::$admin_menu->add_upgrades_menu( 'Test Plan' );
-		$this->assertSame( 'Upgrades<span class="inline-text" style="display:none">Test Plan</span>', $submenu['paid-upgrades.php'][0][0] );
-		$this->assertSame( 'https://wordpress.com/plans/' . static::$domain, $submenu['paid-upgrades.php'][1][2] );
-		$this->assertSame( 'https://wordpress.com/purchases/subscriptions/' . static::$domain, $submenu['paid-upgrades.php'][2][2] );
 	}
 
 	/**

--- a/projects/packages/masterbar/tests/php/Atomic_Admin_Menu_Test.php
+++ b/projects/packages/masterbar/tests/php/Atomic_Admin_Menu_Test.php
@@ -134,26 +134,6 @@ class Atomic_Admin_Menu_Test extends TestCase {
 	}
 
 	/**
-	 * Tests add_upgrades_menu
-	 */
-	public function test_add_upgrades_menu() {
-		global $submenu;
-
-		static::$admin_menu->add_upgrades_menu();
-
-		$this->assertSame( 'https://wordpress.com/plans/' . static::$domain, $submenu['paid-upgrades.php'][1][2] );
-		$this->assertSame( 'https://wordpress.com/domains/manage/' . static::$domain, $submenu['paid-upgrades.php'][2][2] );
-
-		/** This filter is already documented in modules/masterbar/admin-menu/class-atomic-admin-menu.php */
-		if ( apply_filters( 'jetpack_show_wpcom_upgrades_email_menu', false ) ) {
-			$this->assertSame( 'https://wordpress.com/email/' . static::$domain, $submenu['paid-upgrades.php'][3][2] );
-			$this->assertSame( 'https://wordpress.com/purchases/subscriptions/' . static::$domain, $submenu['paid-upgrades.php'][4][2] );
-		} else {
-			$this->assertSame( 'https://wordpress.com/purchases/subscriptions/' . static::$domain, $submenu['paid-upgrades.php'][3][2] );
-		}
-	}
-
-	/**
 	 * Tests add_users_menu
 	 */
 	public function test_add_users_menu() {

--- a/projects/packages/masterbar/tests/php/WPcom_Admin_Menu_Test.php
+++ b/projects/packages/masterbar/tests/php/WPcom_Admin_Menu_Test.php
@@ -144,26 +144,6 @@ class WPcom_Admin_Menu_Test extends TestCase {
 	}
 
 	/**
-	 * Tests add_upgrades_menu
-	 */
-	public function test_add_upgrades_menu() {
-		global $submenu;
-
-		static::$admin_menu->add_upgrades_menu();
-
-		$this->assertSame( 'https://wordpress.com/plans/' . static::$domain, $submenu['paid-upgrades.php'][1][2] );
-		$this->assertSame( 'https://wordpress.com/domains/manage/' . static::$domain, $submenu['paid-upgrades.php'][2][2] );
-
-		/** This filter is already documented in modules/masterbar/admin-menu/class-atomic-admin-menu.php */
-		if ( apply_filters( 'jetpack_show_wpcom_upgrades_email_menu', false ) ) {
-			$this->assertSame( 'https://wordpress.com/email/' . static::$domain, $submenu['paid-upgrades.php'][3][2] );
-			$this->assertSame( 'https://wordpress.com/purchases/subscriptions/' . static::$domain, $submenu['paid-upgrades.php'][4][2] );
-		} else {
-			$this->assertSame( 'https://wordpress.com/purchases/subscriptions/' . static::$domain, $submenu['paid-upgrades.php'][3][2] );
-		}
-	}
-
-	/**
 	 * Tests add_users_menu
 	 */
 	public function test_add_users_menu() {

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-menu.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-menu.php
@@ -184,6 +184,10 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_REST_Controller {
 					'description' => 'Additional text to be added inline with the menu title.',
 					'type'        => 'string',
 				),
+				'inlineIcon' => array(
+					'description' => 'Dashicon slug to be displayed inline with the menu title.',
+					'type'        => 'string',
+				),
 				'badge'      => array(
 					'description' => 'Badge to be added inline with the menu title.',
 					'type'        => 'string',
@@ -481,6 +485,21 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_REST_Controller {
 			if ( $text ) {
 				// Keep the text in the item array.
 				$item['inlineText'] = $text;
+			}
+
+			// Finally remove the markup.
+			$title = trim( str_replace( $matches[0], '', $title ) );
+		}
+
+		if (
+			str_contains( $title, 'inline-icon' )
+			&& preg_match( '/<span class="inline-icon dashicons (dashicons-[^"]+)"[^>]*><\/span>/', $title, $matches )
+		) {
+
+			$icon = $matches[1];
+			if ( $icon ) {
+				// Keep the dashicon slug in the item array.
+				$item['inlineIcon'] = $icon;
 			}
 
 			// Finally remove the markup.

--- a/projects/plugins/jetpack/changelog/dotcom-13317-untangling-ia-hostingupgrades
+++ b/projects/plugins/jetpack/changelog/dotcom-13317-untangling-ia-hostingupgrades
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Admin Menu: add inlineIcon support to the admin-menu REST endpoint.

--- a/projects/plugins/wpcomsh/changelog/dotcom-13317-untangling-ia-hostingupgrades
+++ b/projects/plugins/wpcomsh/changelog/dotcom-13317-untangling-ia-hostingupgrades
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Remove unused `jetpack_show_wpcom_upgrades_email_menu` filter.

--- a/projects/plugins/wpcomsh/feature-plugins/masterbar.php
+++ b/projects/plugins/wpcomsh/feature-plugins/masterbar.php
@@ -131,9 +131,6 @@ function wpcomsh_activate_nav_unification() {
 }
 add_filter( 'jetpack_load_admin_menu_class', 'wpcomsh_activate_nav_unification' );
 
-// Enables the Upgrades -> Emails menu item in the sidebar for all users (temporary hotfix due to Jetpack monthly release cycle)
-add_filter( 'jetpack_show_wpcom_upgrades_email_menu', '__return_true' );
-
 /**
  * Checks if site sticker is toggled on/off.
  * For further information/context on Atomic_Persistent_Data and site_stickers please also see this diff: D66496-code


### PR DESCRIPTION
Fixes DOTCOM-13317

## Proposed changes
* Simplify the Hosting menu to a single external link (`/overview/{domain}`) shown in all admin interfaces, instead of a full menu with submenus only in wp-admin mode.
* Centralize the Upgrades menu registration in `jetpack-mu-wpcom` (`wpcom_add_upgrades_menu()`) so it works consistently across all 4 combinations of platform (Simple/Atomic) and interface (Calypso/wp-admin).
* Remove `add_upgrades_menu()` from the masterbar package entirely (base class and both child classes).
* Make Add-ons and Emails submenus unconditional (previously gated behind feature flags).
* Move legacy Upgrades submenu cleanup (`premium-themes`, `domains`, `my-upgrades`, `billing-history`) from masterbar to the centralized function.
* Clean up the unused `jetpack_show_wpcom_upgrades_email_menu` filter from wpcomsh.

| Admin UI | Screen | Before | After |
|--------|--------|--------|--------|
| Calypso | Calypso | <img width="200" alt="Screenshot 2026-02-17 at 14 49 50" src="https://github.com/user-attachments/assets/52668ca9-3f75-4a31-9a99-6e79bdd68ff9" /> | <img width="200" alt="Screenshot 2026-02-17 at 14 52 32" src="https://github.com/user-attachments/assets/51206419-e677-4ba1-80eb-770d4476c4a1" /> |
| Calypso | wp-admin | <img width="200" alt="Screenshot 2026-02-17 at 14 50 14" src="https://github.com/user-attachments/assets/e340a195-9043-42a2-aadb-3f3b233071ec" /> | <img width="200" alt="Screenshot 2026-02-17 at 14 52 27" src="https://github.com/user-attachments/assets/4e07e784-5254-4c9b-b2df-a971edd0f7a2" /> |
| wp-admin | Calypso | <img width="200" alt="Screenshot 2026-02-17 at 14 50 43" src="https://github.com/user-attachments/assets/cd9edfd7-4da9-42e3-9053-52f78416ca36" /> | <img width="200" alt="Screenshot 2026-02-17 at 14 51 47" src="https://github.com/user-attachments/assets/ecd80e40-3ec1-4de3-b4de-4a785f2a6cf6" /> |
| wp-admin | wp-admin | <img width="200" alt="Screenshot 2026-02-17 at 14 50 33" src="https://github.com/user-attachments/assets/39093659-7902-4864-a016-24e13aede5da" /> | <img width="200" alt="Screenshot 2026-02-17 at 14 51 17" src="https://github.com/user-attachments/assets/a0ca25cc-f667-4068-bc01-f4f202761cb2" /> | 

### Other information

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?

No

## Testing instructions

### Expected behavior

For convenience, I'll just write the behavior we want to see **once**. Just refer to this list in each test case (marked with the 👀 emoji), and compare to the screenshots above.

* 👀 Ensure that...
   * The Hosting and Upgrades menus are separated, and both show up.
   * Hosting is a standalone top-level item, without children.
   * Hosting has a right-side `external` dashicon.
   * Hosting opens the site's overview panel in one of these, depending on user preferences:
      * Hosting Dashboard (`calypso.localhost:3000/overview/SITE.wordpress.com`).
      * Multi-site Dashboard (`my.localhost:3000/sites/SITE.wordpress.com`).
   * Upgrades contains the following submenu items, all opening the corresponding Calypso page:
      * Plans
      * Add-ons
      * Domains
      * Emails
      * Purchases

### Simple and P2 preparation

* Sync these changes to the sandbox with these two commands:
   * `bin/jetpack-downloader test jetpack dotcom-13317-untangling-ia-hostingupgrades`
   * `bin/jetpack-downloader test jetpack-mu-wpcom-plugin dotcom-13317-untangling-ia-hostingupgrades`
* Spin up Calypso with https://github.com/Automattic/wp-calypso/pull/108751 if not merged yet.
* Sandbox a Simple site and the Public API.
* Also sandbox a P2 and a P2 Hub sites.
   * To find the address of a P2 Hub, enter a regular P2 and click on the P2 icon in the top-left corner.

### Atomic preparation

* Install and activate the [Jetpack Beta](https://github.com/Automattic/jetpack-beta/releases) plugin.
* Enter the Jetpack Beta settings.
* Activate the `dotcom-13317-untangling-ia-hostingupgrades` feature branch for Jetpack (main plugin) and WordPress.com Site Helper.
* Sandbox the Public API. (This is probably not necessary for Atomic, but just in case. 😅 )

### Simple and Atomic testing steps

* Open `SITE/wp-admin/options-general.php` and enable the Default (Calypso) interface.
* Open a Calypso screen, e.g. `calypso.localhost:3000/home/SITE`.
* 👀 Ensure the sidebar behaves as expected.
* Open a wp-admin screen, e.g. `SITE/wp-admin/index.php`.
* 👀 Ensure the sidebar behaves as expected.
* Open `SITE/wp-admin/options-general.php` and enable the Classic (wp-admin) interface.
* Open a Calypso screen, e.g. `calypso.localhost:3000/home/SITE`.
* 👀 Ensure the sidebar behaves as expected.
* Open a wp-admin screen, e.g. `SITE/wp-admin/index.php`.
* 👀 Ensure the sidebar behaves as expected.

### P2 testing steps (special case)

* Open `P2/wp-admin/options-general.php` and enable the Default (Calypso) interface.
* Open a Calypso screen, e.g. `calypso.localhost:3000/home/P2`.
* 👀 Ensure neither Hosting nor Upgrades are displayed in the sidebar.
* Open a wp-admin screen, e.g. `SITE/wp-admin/index.php`.
* 👀 Ensure neither Hosting nor Upgrades are displayed in the sidebar.
* Open `P2/wp-admin/options-general.php` and enable the Classic (wp-admin) interface.
* Open a Calypso screen, e.g. `calypso.localhost:3000/home/P2`.
* 👀 Ensure neither Hosting nor Upgrades are displayed in the sidebar.
* Open a wp-admin screen, e.g. `SITE/wp-admin/index.php`.
* 👀 Ensure neither Hosting nor Upgrades are displayed in the sidebar.

### P2 Hub testing steps (special case)

* Open `P2_HUB/wp-admin/options-general.php` and enable the Default (Calypso) interface.
* Open a Calypso screen, e.g. `calypso.localhost:3000/plans/P2_HUB`.
* 👀 Ensure the Hosting menu is not displayed, and the Upgrades menu only contains Plans, Add-ons, Purchases.
* Open a wp-admin screen, e.g. `P2_HUB/wp-admin/options-general.php`.
* 👀 Ensure the Hosting menu is not displayed, and the Upgrades menu only contains Plans, Add-ons, Purchases.
* Open `P2_HUB/wp-admin/options-general.php` and enable the Classic (wp-admin) interface.
* Open a Calypso screen, e.g. `calypso.localhost:3000/plans/P2_HUB`.
* 👀 Ensure the Hosting menu is not displayed, and the Upgrades menu only contains Plans, Add-ons, Purchases.
* Open a wp-admin screen, e.g. `P2_HUB/wp-admin/options-general.php`.
* 👀 Ensure the Hosting menu is not displayed, and the Upgrades menu only contains Plans, Add-ons, Purchases.