### PR TITLE
Forms: Fix 'Mark as spam' button in email notifications for wp-build dashboard

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-wp-build-mark-as-spam
+++ b/projects/packages/forms/changelog/fix-forms-wp-build-mark-as-spam
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix 'Mark as spam' button in email notifications to work with wp-build dashboard.

--- a/projects/packages/forms/routes/responses/response/index.tsx
+++ b/projects/packages/forms/routes/responses/response/index.tsx
@@ -93,7 +93,7 @@ function SingleResponseView( {
 		onCancelMarkAsSpam,
 		markAsSpamConfirmationMessage,
 		isSaving,
-	} = useMarkAsSpam( response as FormResponse, {
+	} = useMarkAsSpam( response as FormResponse | null, {
 		checkParameter: () => searchParams?.mark_as_spam === 1,
 		removeParameter: () => {
 			navigate( {

--- a/projects/packages/forms/routes/responses/response/index.tsx
+++ b/projects/packages/forms/routes/responses/response/index.tsx
@@ -2,7 +2,12 @@
  * WordPress dependencies
  */
 import apiFetch from '@wordpress/api-fetch';
-import { Modal, Spinner, Tip } from '@wordpress/components';
+import {
+	Modal,
+	Spinner,
+	Tip,
+	__experimentalConfirmDialog as ConfirmDialog, // eslint-disable-line @wordpress/no-unsafe-wp-apis
+} from '@wordpress/components';
 import { store as coreStore } from '@wordpress/core-data';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useCallback, useEffect, useState } from '@wordpress/element';
@@ -19,6 +24,7 @@ import PreviewFile from '../../../src/dashboard/components/inspector/preview-fil
 import ResponseFieldsIterator from '../../../src/dashboard/components/inspector/response-fields';
 import ResponseMeta from '../../../src/dashboard/components/inspector/response-meta';
 import useInboxData from '../../../src/dashboard/hooks/use-inbox-data.ts';
+import { useMarkAsSpam } from '../../../src/dashboard/hooks/use-mark-as-spam.ts';
 import useConfigValue from '../../../src/hooks/use-config-value.ts';
 import { ResponseActions } from './actions';
 import { ResponseNavigation } from './navigation';
@@ -56,6 +62,8 @@ function SingleResponseView( {
 	const isNotesEnabled = useConfigValue( 'isNotesEnabled' ) ?? false;
 
 	const { editEntityRecord } = useDispatch( coreStore ) as unknown as DispatchActions;
+	const navigate = useNavigate();
+	const searchParams = useSearch( { from: '/responses/$view' } );
 
 	const { response, isLoading } = useSelect(
 		select => {
@@ -77,6 +85,35 @@ function SingleResponseView( {
 		},
 		[ responseId ]
 	);
+
+	// Use the mark as spam hook with wp-build specific callbacks
+	const {
+		isConfirmDialogOpen,
+		onConfirmMarkAsSpam,
+		onCancelMarkAsSpam,
+		markAsSpamConfirmationMessage,
+		isSaving,
+	} = useMarkAsSpam( response as FormResponse, {
+		checkParameter: () => searchParams?.mark_as_spam === 1,
+		removeParameter: () => {
+			navigate( {
+				search: {
+					...searchParams,
+					mark_as_spam: undefined,
+				},
+			} );
+		},
+		switchToSpam: ( id: number | string ) => {
+			navigate( {
+				to: '/responses/spam',
+				search: {
+					...searchParams,
+					responseIds: [ String( id ) ],
+					mark_as_spam: undefined,
+				},
+			} );
+		},
+	} );
 
 	const currentIndex = allResponseIds.indexOf( responseId );
 	const hasNext = currentIndex < allResponseIds.length - 1;
@@ -249,6 +286,15 @@ function SingleResponseView( {
 					/>
 				</Modal>
 			) }
+
+			<ConfirmDialog
+				isOpen={ isConfirmDialogOpen }
+				onConfirm={ onConfirmMarkAsSpam }
+				onCancel={ onCancelMarkAsSpam }
+				isBusy={ isSaving }
+			>
+				{ markAsSpamConfirmationMessage }
+			</ConfirmDialog>
 		</>
 	);
 }

--- a/projects/packages/forms/routes/responses/route.tsx
+++ b/projects/packages/forms/routes/responses/route.tsx
@@ -63,7 +63,7 @@ export const route = {
 	 * Checks if the feedback post type exists.
 	 */
 	beforeLoad: async () => {
-		// Redirect legacy hash from email links (e.g. #/responses?status=inbox&r=2879).
+		// Redirect legacy hash from email links (e.g. #/responses?status=inbox&r=2879&mark_as_spam).
 		// The hash survives server redirects but is never sent to the server, so we must
 		// convert it client-side to the wp-build URL with responseIds in the path.
 		const hash = window.location.hash;
@@ -77,11 +77,18 @@ export const route = {
 				const status = params.get( 'status' ) || 'inbox';
 				const validStatuses = [ 'inbox', 'spam', 'trash' ];
 				const view = validStatuses.includes( status ) ? status : 'inbox';
+				const hasMarkAsSpam = params.has( 'mark_as_spam' );
+
+				// Build redirect URL with mark_as_spam parameter if present
+				let redirectUrl = `/responses/${ view }?responseIds=${ encodeURIComponent(
+					JSON.stringify( [ r ] )
+				) }`;
+				if ( hasMarkAsSpam ) {
+					redirectUrl += '&mark_as_spam=1';
+				}
 
 				throw redirect( {
-					href: `/responses/${ view }?responseIds=${ encodeURIComponent(
-						JSON.stringify( [ r ] )
-					) }`,
+					href: redirectUrl,
 				} );
 			}
 		}

--- a/projects/packages/forms/src/contact-form/class-feedback-email-renderer.php
+++ b/projects/packages/forms/src/contact-form/class-feedback-email-renderer.php
@@ -134,7 +134,7 @@ class Feedback_Email_Renderer {
 
 		if ( $feedback_status !== 'jp-temp-feedback' ) {
 			$dashboard_url           = Forms_Dashboard::get_forms_admin_url( $status, $post_id );
-			$mark_as_spam_url        = $dashboard_url . '&mark_as_spam';
+			$mark_as_spam_url        = self::add_mark_as_spam_to_url( $dashboard_url );
 			$footer_mark_as_spam_url = sprintf(
 				'<a href="%1$s">%2$s</a>',
 				esc_url( $mark_as_spam_url ),
@@ -235,6 +235,40 @@ class Feedback_Email_Renderer {
 			'title'   => $title,
 			'message' => $message,
 		);
+	}
+
+	/**
+	 * Adds the mark_as_spam parameter to a dashboard URL.
+	 *
+	 * This method handles both legacy and wp-build dashboard URLs:
+	 * - Legacy: appends &mark_as_spam to the hash fragment
+	 * - WP-Build: adds mark_as_spam to the path inside the p parameter
+	 *
+	 * @param string $url The dashboard URL.
+	 * @return string The URL with mark_as_spam parameter added.
+	 */
+	private static function add_mark_as_spam_to_url( $url ) {
+		// Check if this is a wp-build URL (contains &p= parameter).
+		if ( strpos( $url, '&p=' ) !== false ) {
+			// WP-Build URL format: admin.php?page=jetpack-forms-responses-wp-admin&p=/responses/inbox?responseIds=["123"]
+			// We need to add &mark_as_spam=1 inside the p parameter path.
+			$parts = explode( '&p=', $url, 2 );
+
+			if ( count( $parts ) === 2 ) {
+				$base_url = $parts[0];
+				$path     = rawurldecode( $parts[1] );
+
+				// Add mark_as_spam parameter to the path.
+				$separator = strpos( $path, '?' ) !== false ? '&' : '?';
+				$path     .= $separator . 'mark_as_spam=1';
+
+				return $base_url . '&p=' . rawurlencode( $path );
+			}
+		}
+
+		// Legacy URL format: admin.php?page=jetpack-forms-admin#/responses?status=inbox&r=123
+		// Append &mark_as_spam to the hash fragment.
+		return $url . '&mark_as_spam';
 	}
 
 	/**

--- a/projects/packages/forms/src/dashboard/class-dashboard.php
+++ b/projects/packages/forms/src/dashboard/class-dashboard.php
@@ -120,21 +120,39 @@ class Dashboard {
 		// WP-Build URL requested but legacy is now active → redirect to legacy.
 		if ( $page === self::FORMS_WPBUILD_ADMIN_SLUG && ! $is_wp_build_enabled ) {
 			// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-			$p       = isset( $_GET['p'] ) ? rawurldecode( sanitize_text_field( wp_unslash( $_GET['p'] ) ) ) : '';
-			$tab     = 'inbox';
-			$post_id = null;
+			$p                = isset( $_GET['p'] ) ? rawurldecode( sanitize_text_field( wp_unslash( $_GET['p'] ) ) ) : '';
+			$tab              = 'inbox';
+			$post_id          = null;
+			$has_mark_as_spam = false;
+
+			// Check if mark_as_spam is a separate query parameter (old email format).
+			// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			if ( isset( $_GET['mark_as_spam'] ) ) {
+				$has_mark_as_spam = true;
+			}
 
 			if ( $p !== '' ) {
-				// Parse path like /responses/inbox?responseIds=["2879"] or /forms.
-				if ( preg_match( '#^/responses/(inbox|spam|trash)(?:\?responseIds=\["(\d+)"\])?$#', $p, $m ) ) {
+				// Parse path like /responses/inbox?responseIds=["2879"] or /responses/inbox?responseIds=["2879"]&mark_as_spam or /forms.
+				if ( preg_match( '#^/responses/(inbox|spam|trash)(?:\?responseIds=\["(\d+)"\])?(.*)$#', $p, $m ) ) {
 					$tab     = $m[1];
 					$post_id = ! empty( $m[2] ) ? absint( $m[2] ) : null;
+
+					// Check if mark_as_spam parameter is present inside the path.
+					if ( ! empty( $m[3] ) && strpos( $m[3], 'mark_as_spam' ) !== false ) {
+						$has_mark_as_spam = true;
+					}
 				} elseif ( preg_match( '#^/forms#', $p ) ) {
 					$tab = 'forms';
 				}
 			}
 
 			$redirect = self::get_forms_admin_url( $tab, $post_id );
+
+			// Add mark_as_spam parameter if it was present in the original URL (either format).
+			if ( $has_mark_as_spam ) {
+				$redirect .= '&mark_as_spam';
+			}
+
 			wp_safe_redirect( $redirect );
 			exit;
 		}

--- a/projects/packages/forms/src/dashboard/components/inspector/body.tsx
+++ b/projects/packages/forms/src/dashboard/components/inspector/body.tsx
@@ -11,6 +11,7 @@ import { useDispatch } from '@wordpress/data';
 import { useCallback, useEffect, useRef, useState } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
 import { __, _n, sprintf } from '@wordpress/i18n';
+import { useSearchParams } from 'react-router';
 /**
  * Internal dependencies
  */
@@ -52,6 +53,7 @@ const ResponseViewBody = ( {
 	const [ previewFile, setPreviewFile ] = useState< { url: string; name: string } | null >( null );
 	const [ isImageLoading, setIsImageLoading ] = useState( true );
 	const [ hasMarkedSelfAsRead, setHasMarkedSelfAsRead ] = useState( 0 );
+	const [ searchParams, setSearchParams ] = useSearchParams();
 
 	const { editEntityRecord } = useDispatch( 'core' );
 
@@ -59,9 +61,26 @@ const ResponseViewBody = ( {
 	const isNotesEnabled = useConfigValue( 'isNotesEnabled' ) ?? false;
 
 	// When opening a "Mark as spam" link from the email, the ResponseViewBody component is rendered, so we use a hook here to handle it.
-	const { isConfirmDialogOpen, onConfirmMarkAsSpam, onCancelMarkAsSpam } = useMarkAsSpam(
-		response as FormResponse
-	);
+	const {
+		isConfirmDialogOpen,
+		onConfirmMarkAsSpam,
+		onCancelMarkAsSpam,
+		markAsSpamConfirmationMessage,
+		isSaving,
+	} = useMarkAsSpam( response as FormResponse, {
+		checkParameter: () => searchParams.get( 'mark_as_spam' ) != null,
+		removeParameter: () => {
+			const newSearchParams = new URLSearchParams( searchParams );
+			newSearchParams.delete( 'mark_as_spam' );
+			setSearchParams( newSearchParams );
+		},
+		switchToSpam: () => {
+			const newSearchParams = new URLSearchParams( searchParams );
+			newSearchParams.set( 'status', 'spam' );
+			newSearchParams.delete( 'mark_as_spam' );
+			setSearchParams( newSearchParams );
+		},
+	} );
 
 	const { invalidateCounts, markRecordsAsInvalid } = useDispatch( dashboardStore );
 
@@ -199,8 +218,9 @@ const ResponseViewBody = ( {
 					isOpen={ isConfirmDialogOpen }
 					onConfirm={ onConfirmMarkAsSpam }
 					onCancel={ onCancelMarkAsSpam }
+					isBusy={ isSaving }
 				>
-					{ __( 'Are you sure you want to mark this response as spam?', 'jetpack-forms' ) }
+					{ markAsSpamConfirmationMessage }
 				</ConfirmDialog>
 			</div>
 			{ /* Comments section */ }

--- a/projects/packages/forms/src/dashboard/components/inspector/body.tsx
+++ b/projects/packages/forms/src/dashboard/components/inspector/body.tsx
@@ -67,7 +67,7 @@ const ResponseViewBody = ( {
 		onCancelMarkAsSpam,
 		markAsSpamConfirmationMessage,
 		isSaving,
-	} = useMarkAsSpam( response as FormResponse, {
+	} = useMarkAsSpam( response as FormResponse | null, {
 		checkParameter: () => searchParams.get( 'mark_as_spam' ) != null,
 		removeParameter: () => {
 			const newSearchParams = new URLSearchParams( searchParams );

--- a/projects/packages/forms/src/dashboard/hooks/use-mark-as-spam.ts
+++ b/projects/packages/forms/src/dashboard/hooks/use-mark-as-spam.ts
@@ -3,45 +3,87 @@
  */
 import { store as coreStore } from '@wordpress/core-data';
 import { useDispatch } from '@wordpress/data';
-import { useCallback, useEffect, useState } from '@wordpress/element';
+import { useCallback, useEffect, useMemo, useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
 import { store as dashboardStore } from '../store/index.js';
 /**
  * Types
  */
 import type { FormResponse } from '../../types/index.ts';
 
-export const useMarkAsSpam = ( response: FormResponse ) => {
+/**
+ * Options for the useMarkAsSpam hook.
+ */
+export type UseMarkAsSpamOptions = {
+	/**
+	 * Function to check if the mark_as_spam parameter is present in the URL.
+	 */
+	checkParameter: () => boolean;
+
+	/**
+	 * Function to remove the mark_as_spam parameter from the URL when cancelling the confirmation dialog.
+	 */
+	removeParameter: () => void;
+
+	/**
+	 * Function to navigate to the spam view after marking as spam, while also removing the mark_as_spam parameter from the URL.
+	 */
+	switchToSpam: ( responseId: number | string ) => void;
+};
+
+export const useMarkAsSpam = ( response: FormResponse, options: UseMarkAsSpamOptions ) => {
 	const [ isConfirmDialogOpen, setIsConfirmDialogOpen ] = useState( false );
+	const [ isSaving, setIsSaving ] = useState( false );
 	const { saveEntityRecord } = useDispatch( coreStore );
 	const { invalidateCounts } = useDispatch( dashboardStore );
+	const markAsSpamConfirmationMessage = useMemo(
+		() => __( 'Are you sure you want to mark this response as spam?', 'jetpack-forms' ),
+		[]
+	);
+
+	const { checkParameter, removeParameter, switchToSpam } = options;
 
 	const onConfirmMarkAsSpam = useCallback( async () => {
-		setIsConfirmDialogOpen( false );
+		try {
+			setIsSaving( true );
 
-		await saveEntityRecord( 'postType', 'feedback', {
-			id: response.id,
-			status: 'spam',
-		} );
+			await saveEntityRecord( 'postType', 'feedback', {
+				id: response.id,
+				status: 'spam',
+			} );
 
-		await invalidateCounts();
+			await invalidateCounts();
 
-		window.location.hash = window.location.hash.replace( 'status=inbox', 'status=spam' );
-	}, [ response, saveEntityRecord, invalidateCounts ] );
+			setIsSaving( false );
+
+			setIsConfirmDialogOpen( false );
+
+			switchToSpam( response.id );
+		} catch {
+			setIsSaving( false );
+		}
+	}, [ saveEntityRecord, response.id, invalidateCounts, switchToSpam ] );
+
+	const hasSpamParameter = useMemo( () => checkParameter(), [ checkParameter ] );
 
 	const onCancelMarkAsSpam = useCallback( () => {
 		setIsConfirmDialogOpen( false );
-	}, [ setIsConfirmDialogOpen ] );
+
+		removeParameter();
+	}, [ removeParameter ] );
 
 	// Email links have a query param that triggers the confirmation dialog.
 	useEffect( () => {
-		if ( window.location.hash.includes( '&mark_as_spam' ) ) {
-			window.location.hash = window.location.hash.replace( '&mark_as_spam', '' );
-
-			if ( ! [ 'spam', 'trash' ].includes( response.status ) ) {
-				setIsConfirmDialogOpen( true );
-			}
+		if ( hasSpamParameter && ! [ 'spam', 'trash' ].includes( response.status ) ) {
+			setIsConfirmDialogOpen( true );
 		}
-	}, [ response ] );
+	}, [ response.status, hasSpamParameter ] );
 
-	return { isConfirmDialogOpen, onConfirmMarkAsSpam, onCancelMarkAsSpam };
+	return {
+		isConfirmDialogOpen,
+		onConfirmMarkAsSpam,
+		onCancelMarkAsSpam,
+		markAsSpamConfirmationMessage,
+		isSaving,
+	};
 };

--- a/projects/packages/forms/src/dashboard/hooks/use-mark-as-spam.ts
+++ b/projects/packages/forms/src/dashboard/hooks/use-mark-as-spam.ts
@@ -31,7 +31,7 @@ export type UseMarkAsSpamOptions = {
 	switchToSpam: ( responseId: number | string ) => void;
 };
 
-export const useMarkAsSpam = ( response: FormResponse, options: UseMarkAsSpamOptions ) => {
+export const useMarkAsSpam = ( response: FormResponse | null, options: UseMarkAsSpamOptions ) => {
 	const [ isConfirmDialogOpen, setIsConfirmDialogOpen ] = useState( false );
 	const [ isSaving, setIsSaving ] = useState( false );
 	const { saveEntityRecord } = useDispatch( coreStore );
@@ -44,6 +44,10 @@ export const useMarkAsSpam = ( response: FormResponse, options: UseMarkAsSpamOpt
 	const { checkParameter, removeParameter, switchToSpam } = options;
 
 	const onConfirmMarkAsSpam = useCallback( async () => {
+		if ( ! response ) {
+			return;
+		}
+
 		try {
 			setIsSaving( true );
 
@@ -62,7 +66,7 @@ export const useMarkAsSpam = ( response: FormResponse, options: UseMarkAsSpamOpt
 		} catch {
 			setIsSaving( false );
 		}
-	}, [ saveEntityRecord, response.id, invalidateCounts, switchToSpam ] );
+	}, [ response, saveEntityRecord, invalidateCounts, switchToSpam ] );
 
 	const hasSpamParameter = useMemo( () => checkParameter(), [ checkParameter ] );
 
@@ -74,10 +78,10 @@ export const useMarkAsSpam = ( response: FormResponse, options: UseMarkAsSpamOpt
 
 	// Email links have a query param that triggers the confirmation dialog.
 	useEffect( () => {
-		if ( hasSpamParameter && ! [ 'spam', 'trash' ].includes( response.status ) ) {
+		if ( hasSpamParameter && response && ! [ 'spam', 'trash' ].includes( response.status ) ) {
 			setIsConfirmDialogOpen( true );
 		}
-	}, [ response.status, hasSpamParameter ] );
+	}, [ response?.status, hasSpamParameter, response ] );
 
 	return {
 		isConfirmDialogOpen,


### PR DESCRIPTION
Fixes FORMS-588

## Proposed changes:
* Refactored `useMarkAsSpam` hook to work with both legacy and wp-build dashboards by accepting callbacks for URL manipulation and spam action
* Added confirmation dialog for 'Mark as spam' action in wp-build dashboard (routes)
* Updated email renderer to properly encode `mark_as_spam` parameter for both dashboard variants
* Implemented cross-variant URL redirect support to preserve `mark_as_spam` parameter when switching between legacy and wp-build dashboards
* Exported confirmation message constant to avoid duplication across dashboards

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
N/A - Bug fix

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

### Prerequisites
1. Have a site with Jetpack Forms package installed
2. Have at least one form with responses
3. Have email notifications enabled for form responses

### Test Case 1: Mark as spam from email (wp-build dashboard)
1. Enable the wp-build dashboard: `add_filter( 'jetpack_forms_alpha', '__return_true' );`
2. Submit a form response to trigger an email notification
3. In the email, click the "Mark as spam" button
4. **Expected:** You should see a confirmation dialog asking "Are you sure you want to mark this response as spam?"
5. Click "Confirm"
6. **Expected:** Response is marked as spam and you're redirected to the spam view

### Test Case 2: Mark as spam from email (legacy dashboard)
1. Disable the wp-build dashboard: `add_filter( 'jetpack_forms_alpha', '__return_false' );`
2. Submit a form response to trigger an email notification
3. In the email, click the "Mark as spam" button
4. **Expected:** Same confirmation dialog appears
5. **Expected:** Response is marked as spam (same behavior as before)

### Test Case 3: Cross-variant redirect (wp-build email → legacy dashboard)
1. Enable wp-build: `add_filter( 'jetpack_forms_alpha', '__return_true' );`
2. Submit a form response and receive the email
3. Copy the "Mark as spam" link URL from the email
4. Disable wp-build: `add_filter( 'jetpack_forms_alpha', '__return_false' );`
5. Open the copied URL in your browser
6. **Expected:** URL redirects to legacy dashboard format and confirmation dialog appears

### Test Case 4: Cross-variant redirect (legacy email → wp-build dashboard)
1. Disable wp-build: `add_filter( 'jetpack_forms_alpha', '__return_false' );`
2. Submit a form response and receive the email
3. Copy the "Mark as spam" link URL from the email
4. Enable wp-build: `add_filter( 'jetpack_forms_alpha', '__return_true' );`
5. Open the copied URL in your browser
6. **Expected:** URL redirects to wp-build dashboard format and confirmation dialog appears