### PR TITLE
Reader: Fix YouTube shorts rendering

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-youtube-shorts-rendering-in-reader
+++ b/projects/plugins/jetpack/changelog/fix-youtube-shorts-rendering-in-reader
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Fix YouTube shorts rendering in WordPress Reader

--- a/projects/plugins/jetpack/changelog/fix-youtube-shorts-rendering-in-reader
+++ b/projects/plugins/jetpack/changelog/fix-youtube-shorts-rendering-in-reader
@@ -1,4 +1,4 @@
 Significance: patch
-Type: other
+Type: bugfix
 
-Fix YouTube shorts rendering in WordPress Reader
+WordPress.com Reader: Fix YouTube Shorts embeds not rendering correctly.

--- a/projects/plugins/jetpack/changelog/fix-youtube-shorts-rendering-in-reader
+++ b/projects/plugins/jetpack/changelog/fix-youtube-shorts-rendering-in-reader
@@ -1,4 +1,4 @@
 Significance: patch
 Type: bugfix
 
-WordPress.com Reader: Fix YouTube Shorts embeds not rendering correctly.
+Shortcode embeds: improve handling of YouTube shorts in embeds.

--- a/projects/plugins/jetpack/functions.compat.php
+++ b/projects/plugins/jetpack/functions.compat.php
@@ -71,7 +71,7 @@ if ( ! function_exists( 'jetpack_youtube_sanitize_url' ) ) :
 
 		$url = trim( $url, ' "' );
 		$url = trim( $url );
-		$url = str_replace( array( 'youtu.be/', '/v/', '#!v=', '&amp;', '&#038;', 'playlist' ), array( 'youtu.be/?v=', '/?v=', '?v=', '&', '&', 'videoseries' ), $url );
+		$url = str_replace( array( 'youtu.be/', '/v/', '/shorts/', '#!v=', '&amp;', '&#038;', 'playlist' ), array( 'youtu.be/?v=', '/?v=', '/watch?v=', '?v=', '&', '&', 'videoseries' ), $url );
 
 		// Replace any extra question marks with ampersands - the result of a URL like "https://www.youtube.com/v/dQw4w9WgXcQ?fs=1&hl=en_US" being passed in.
 		$query_string_start = strpos( $url, '?' );

--- a/projects/plugins/jetpack/modules/shortcodes/youtube.php
+++ b/projects/plugins/jetpack/modules/shortcodes/youtube.php
@@ -158,7 +158,7 @@ if ( ! function_exists( 'jetpack_youtube_sanitize_url' ) ) :
 
 		$url = trim( $url, ' "' );
 		$url = trim( $url );
-		$url = str_replace( array( 'youtu.be/', '/v/', '#!v=', '&amp;', '&#038;', 'playlist' ), array( 'youtu.be/?v=', '/?v=', '?v=', '&', '&', 'videoseries' ), $url );
+		$url = str_replace( array( 'youtu.be/', '/v/', '/shorts/', '#!v=', '&amp;', '&#038;', 'playlist' ), array( 'youtu.be/?v=', '/?v=', '/watch?v=', '?v=', '&', '&', 'videoseries' ), $url );
 
 		// Replace any extra question marks with ampersands - the result of a URL like "https://www.youtube.com/v/dQw4w9WgXcQ?fs=1&hl=en_US" being passed in.
 		$query_string_start = strpos( $url, '?' );

--- a/projects/plugins/jetpack/tests/php/general/Functions_Compat_Test.php
+++ b/projects/plugins/jetpack/tests/php/general/Functions_Compat_Test.php
@@ -156,7 +156,7 @@ class Functions_Compat_Test extends WP_UnitTestCase {
 
 	/**
 	 * @author mehmoodak
-	 * @since 14.5
+	 * @since $$next-version$$
 	 */
 	public function test_jetpack_youtube_sanitize_url_with_shorts_url() {
 		$sanitized_url = jetpack_youtube_sanitize_url( 'https://www.youtube.com/shorts/VIDEO_ID' );
@@ -194,7 +194,7 @@ class Functions_Compat_Test extends WP_UnitTestCase {
 
 	/**
 	 * @author mehmoodak
-	 * @since 14.5
+	 * @since $$next-version$$
 	 */
 	public function test_jetpack_get_youtube_id_with_shorts_url() {
 		$youtube_id = jetpack_get_youtube_id( 'https://www.youtube.com/shorts/VIDEO_ID' );

--- a/projects/plugins/jetpack/tests/php/general/Functions_Compat_Test.php
+++ b/projects/plugins/jetpack/tests/php/general/Functions_Compat_Test.php
@@ -155,6 +155,16 @@ class Functions_Compat_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @author mehmoodak
+	 * @since 14.5
+	 */
+	public function test_jetpack_youtube_sanitize_url_with_shorts_url() {
+		$sanitized_url = jetpack_youtube_sanitize_url( 'https://www.youtube.com/shorts/VIDEO_ID' );
+
+		$this->assertEquals( 'https://www.youtube.com/watch?v=VIDEO_ID', $sanitized_url );
+	}
+
+	/**
 	 * @author enkrates
 	 * @since 3.2
 	 */
@@ -180,5 +190,15 @@ class Functions_Compat_Test extends WP_UnitTestCase {
 		$youtube_id = jetpack_get_youtube_id( $playlist_url );
 
 		$this->assertEquals( $expected_id, $youtube_id );
+	}
+
+	/**
+	 * @author mehmoodak
+	 * @since 14.5
+	 */
+	public function test_jetpack_get_youtube_id_with_shorts_url() {
+		$youtube_id = jetpack_get_youtube_id( 'https://www.youtube.com/shorts/VIDEO_ID' );
+
+		$this->assertEquals( 'VIDEO_ID', $youtube_id );
 	}
 } // end class

--- a/projects/plugins/jetpack/tests/php/modules/shortcodes/Jetpack_Shortcodes_Youtube_Test.php
+++ b/projects/plugins/jetpack/tests/php/modules/shortcodes/Jetpack_Shortcodes_Youtube_Test.php
@@ -102,6 +102,10 @@ class Jetpack_Shortcodes_Youtube_Test extends WP_UnitTestCase {
 				'https://youtu.be/o-IvKy3322k?t=1m1s',
 				'start=61',
 			),
+			'shorts_url'   => array(
+				'https://youtube.com/shorts/VIDEO_ID',
+				'VIDEO_ID',
+			),
 		);
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Closes: [READ-319](https://linear.app/a8c/issue/READ-319/reader-fix-youtube-shorts-not-appearing-in-reader)

## Proposed changes:

Update `jetpack_youtube_sanitize_url` method to map YouTube Shorts URL correctly.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

N/A

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to https://wordpress.com/reader/feeds/67908692
* Verify shorts are not appearing
* Checkout this PR on sandbox.
* Allow write permissions.
* Refresh feed: `php bin/feedbag-update-feed.php 67908692`
* Verify shorts is appearing fine now.
