### PR TITLE
Add rtc filter

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-rtc-filter
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-rtc-filter
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -422,6 +422,7 @@ class Jetpack_Mu_Wpcom {
 		if ( ( isset( $pagenow ) && in_array( $pagenow, $allowed_pages, true ) ) || ! is_admin() ) {
 			require_once __DIR__ . '/features/block-editor/custom-line-height.php';
 			require_once __DIR__ . '/features/block-inserter-modifications/block-inserter-modifications.php';
+			require_once __DIR__ . '/features/gutenberg-rtc/gutenberg-rtc.php';
 			require_once __DIR__ . '/features/hide-homepage-title/hide-homepage-title.php';
 			require_once __DIR__ . '/features/override-preview-button-url/override-preview-button-url.php';
 			require_once __DIR__ . '/features/paragraph-block-placeholder/paragraph-block-placeholder.php';

--- a/projects/packages/jetpack-mu-wpcom/src/features/gutenberg-rtc/gutenberg-rtc.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/gutenberg-rtc/gutenberg-rtc.js
@@ -1,0 +1,9 @@
+import { addFilter } from '@wordpress/hooks';
+
+// Register PingHub provider and disable Http polling by returning only this provider.
+( function register() {
+	if ( typeof window === 'undefined' ) {
+		return;
+	}
+	addFilter( 'sync.providers', 'wpcom/pinghub-provider', () => [] );
+} )();

--- a/projects/packages/jetpack-mu-wpcom/src/features/gutenberg-rtc/gutenberg-rtc.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/gutenberg-rtc/gutenberg-rtc.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Gutenberg RTC (Real-Time Collaboration) customizations
+ * This handles RTC-related configurations for the Gutenberg editor on JP sites.
+ *
+ * Currently disables HTTP polling to prevent issues, but can be extended
+ * in the future for other RTC-related customizations.
+ *
+ * @package automattic/jetpack-mu-wpcom
+ */
+
+use Automattic\Jetpack\Jetpack_Mu_Wpcom;
+
+/**
+ * Enqueue block editor assets for Gutenberg RTC customizations.
+ */
+function wpcom_enqueue_gutenberg_rtc_assets() {
+	$asset_file          = include Jetpack_Mu_Wpcom::BASE_DIR . 'build/gutenberg-rtc/gutenberg-rtc.asset.php';
+	$script_dependencies = $asset_file['dependencies'] ?? array();
+	$version             = $asset_file['version'] ?? filemtime( Jetpack_Mu_Wpcom::BASE_DIR . 'build/gutenberg-rtc/gutenberg-rtc.js' );
+
+	wp_enqueue_script(
+		'gutenberg-rtc-script',
+		plugins_url( 'build/gutenberg-rtc/gutenberg-rtc.js', Jetpack_Mu_Wpcom::BASE_FILE ),
+		$script_dependencies,
+		$version,
+		true
+	);
+}
+add_action( 'enqueue_block_editor_assets', 'wpcom_enqueue_gutenberg_rtc_assets' );

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/gutenberg-rtc/Gutenberg_RTC_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/gutenberg-rtc/Gutenberg_RTC_Test.php
@@ -7,9 +7,10 @@
 
 declare( strict_types = 1 );
 
-//phpcs:ignore WordPressVIPMinimum.Files.IncludingFile.NotAbsolutePath
-require_once \Automattic\Jetpack\Jetpack_Mu_Wpcom::PKG_DIR . 'src/features/gutenberg-rtc/gutenberg-rtc.php';
+use Automattic\Jetpack\Jetpack_Mu_Wpcom;
 
+//phpcs:ignore WordPressVIPMinimum.Files.IncludingFile.NotAbsolutePath
+require_once Jetpack_Mu_Wpcom::PKG_DIR . 'src/features/gutenberg-rtc/gutenberg-rtc.php';
 use PHPUnit\Framework\Attributes\CoversFunction;
 
 /**
@@ -26,22 +27,5 @@ class Gutenberg_RTC_Test extends \WorDBless\BaseTestCase {
 	 */
 	public function test_wpcom_enqueue_gutenberg_rtc_assets_hooked() {
 		$this->assertSame( 10, has_action( 'enqueue_block_editor_assets', 'wpcom_enqueue_gutenberg_rtc_assets' ) );
-	}
-
-	/**
-	 * Tests whether the gutenberg-rtc script is enqueued correctly with proper dependencies.
-	 *
-	 * @return void
-	 */
-	public function test_wpcom_enqueue_gutenberg_rtc_assets_enqueues_script() {
-		wpcom_enqueue_gutenberg_rtc_assets();
-
-		// Check script is enqueued.
-		$this->assertTrue( wp_script_is( 'gutenberg-rtc-script', 'enqueued' ) );
-
-		// Check it has wp-hooks dependency.
-		global $wp_scripts;
-		$script = $wp_scripts->registered['gutenberg-rtc-script'];
-		$this->assertContains( 'wp-hooks', $script->deps );
 	}
 }

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/gutenberg-rtc/Gutenberg_RTC_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/gutenberg-rtc/Gutenberg_RTC_Test.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Gutenberg RTC Tests
+ *
+ * @package automattic/jetpack-mu-wpcom
+ */
+
+declare( strict_types = 1 );
+
+//phpcs:ignore WordPressVIPMinimum.Files.IncludingFile.NotAbsolutePath
+require_once \Automattic\Jetpack\Jetpack_Mu_Wpcom::PKG_DIR . 'src/features/gutenberg-rtc/gutenberg-rtc.php';
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+
+/**
+ * Tests for Gutenberg RTC feature.
+ *
+ * @covers ::wpcom_enqueue_gutenberg_rtc_assets
+ */
+#[CoversFunction( 'wpcom_enqueue_gutenberg_rtc_assets' )]
+class Gutenberg_RTC_Test extends \WorDBless\BaseTestCase {
+	/**
+	 * Tests whether the gutenberg-rtc assets enqueue function is hooked correctly.
+	 *
+	 * @return void
+	 */
+	public function test_wpcom_enqueue_gutenberg_rtc_assets_hooked() {
+		$this->assertSame( 10, has_action( 'enqueue_block_editor_assets', 'wpcom_enqueue_gutenberg_rtc_assets' ) );
+	}
+
+	/**
+	 * Tests whether the gutenberg-rtc script is enqueued correctly with proper dependencies.
+	 *
+	 * @return void
+	 */
+	public function test_wpcom_enqueue_gutenberg_rtc_assets_enqueues_script() {
+		wpcom_enqueue_gutenberg_rtc_assets();
+
+		// Check script is enqueued.
+		$this->assertTrue( wp_script_is( 'gutenberg-rtc-script', 'enqueued' ) );
+
+		// Check it has wp-hooks dependency.
+		global $wp_scripts;
+		$script = $wp_scripts->registered['gutenberg-rtc-script'];
+		$this->assertContains( 'wp-hooks', $script->deps );
+	}
+}

--- a/projects/packages/jetpack-mu-wpcom/webpack.config.js
+++ b/projects/packages/jetpack-mu-wpcom/webpack.config.js
@@ -18,6 +18,7 @@ module.exports = async () => {
 					'./src/features/custom-css/custom-css/js/core-customizer-css-preview.js',
 				'customizer-control': './src/features/custom-css/custom-css/css/customizer-control.css',
 				'error-reporting': './src/features/error-reporting/index.js',
+				'gutenberg-rtc': './src/features/gutenberg-rtc/gutenberg-rtc.js',
 				'holiday-snow': './src/features/holiday-snow/holiday-snow.scss',
 				'html-block-restricted-tags':
 					'./src/features/html-block-restricted-tags/html-block-restricted-tags.tsx',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Adds a new gutenberg-rtc feature to disable Real-Time Collaboration (RTC) HTTP polling in the Gutenberg editor for Jetpack sites. This prevents potential issues that may arise from the new RTC pooling feature introduced in recent Gutenberg versions.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Sync this PR to your sandbox
* Sync this PR to a atomic site via beta tester
* Visit the editor
* Check if the js file is enqueued
* Open the console
* Verify the filter is registered:
   `wp.hooks.hasFilter('sync.providers', 'wpcom/pinghub-provider')`
   Should return: true
    `wp.hooks.applyFilters('sync.providers', ['default'])`
   Should return: []


