### PR TITLE
Forms: render image-select fields with thumbnails in email notifications

### DIFF
--- a/projects/packages/forms/changelog/add-forms-email-image-select3
+++ b/projects/packages/forms/changelog/add-forms-email-image-select3
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Render images from image select fields on email notifications.

--- a/projects/packages/forms/src/contact-form/class-feedback-field.php
+++ b/projects/packages/forms/src/contact-form/class-feedback-field.php
@@ -440,6 +440,9 @@ class Feedback_Field {
 		if ( $this->is_of_type( 'file' ) ) {
 			return $this->render_email_file();
 		}
+		if ( $this->is_of_type( 'image-select' ) ) {
+			return $this->render_email_image_select();
+		}
 		return $this->render_email_default();
 	}
 
@@ -784,6 +787,75 @@ class Feedback_Field {
 		);
 
 		return $category_map[ $category ] ?? 'txt';
+	}
+
+	/**
+	 * Render an image-select field for email.
+	 *
+	 * Renders each selected choice as a card with an image thumbnail,
+	 * letter code, and label arranged horizontally.
+	 *
+	 * @return string HTML for the image-select field.
+	 */
+	private function render_email_image_select() {
+		if ( ! is_array( $this->value ) || empty( $this->value['choices'] ) || ! is_array( $this->value['choices'] ) ) {
+			return $this->render_empty_value_html();
+		}
+
+		$cards = array();
+		foreach ( $this->value['choices'] as $choice ) {
+			$letter     = isset( $choice['selected'] ) ? esc_html( $choice['selected'] ) : '';
+			$label      = ! empty( $choice['label'] ) ? esc_html( $choice['label'] ) : '';
+			$image_src  = ! empty( $choice['image']['src'] ) ? esc_url( $choice['image']['src'] ) : '';
+			$show_label = ! empty( $choice['showLabels'] );
+
+			// Image thumbnail with 8px padding inside the card.
+			$image_html = '';
+			if ( $image_src !== '' ) {
+				$image_html = sprintf(
+					'<div style="padding: 8px 8px 0 8px;"><img src="%s" alt="%s" width="138" height="144" style="display: block; width: 138px; height: 144px; object-fit: cover;" /></div>',
+					$image_src,
+					$label !== '' ? $label : $letter
+				);
+			}
+
+			// Letter code box + label.
+			$caption_html = '';
+			if ( $letter !== '' ) {
+				$caption_html .= sprintf(
+					'<span style="display: inline-block; min-width: 1em; padding: 4px; line-height: 1; text-align: center; border: 1px solid #dcdcde; border-radius: 2px; font-size: 11px; font-weight: 600; color: #1e1e1e; vertical-align: baseline;">%s</span>',
+					$letter
+				);
+			}
+
+			if ( $show_label && $label !== '' ) {
+				$caption_html .= sprintf(
+					' <span style="font-size: 13px; color: #1e1e1e; vertical-align: baseline;">%s</span>',
+					$label
+				);
+			}
+
+			// Card with outline matching the admin preview Card component (radiusLarge = 8px).
+			$card = '<div style="display: inline-block; vertical-align: top; border: 1px solid #dcdcde; border-radius: 8px; margin: 0 8px 8px 0;">';
+			if ( $image_html !== '' ) {
+				$card .= $image_html;
+			}
+			if ( $caption_html !== '' ) {
+				$card .= sprintf(
+					'<div style="padding: 4px 8px 8px 8px;">%s</div>',
+					$caption_html
+				);
+			}
+			$card .= '</div>';
+
+			$cards[] = $card;
+		}
+
+		if ( empty( $cards ) ) {
+			return $this->render_empty_value_html();
+		}
+
+		return implode( '', $cards );
 	}
 
 	/**

--- a/projects/packages/forms/src/contact-form/class-feedback-field.php
+++ b/projects/packages/forms/src/contact-form/class-feedback-field.php
@@ -817,7 +817,11 @@ class Feedback_Field {
 					$label !== '' ? $label : $letter
 				);
 			} else {
-				$image_html = '<div style="padding: 8px 8px 0 8px;"><div style="width: 138px; height: 144px; background-color: #f0f0f0;"></div></div>';
+				$placeholder_icon = Jetpack_Forms::plugin_url() . 'contact-form/images/field-icons/field-image-select@2x.png';
+				$image_html       = sprintf(
+					'<div style="padding: 8px 8px 0 8px;"><div style="width: 138px; height: 144px; background-color: #f0f0f0; text-align: center; line-height: 144px;"><img src="%s" alt="" width="24" height="24" style="vertical-align: middle;" /></div></div>',
+					esc_url( $placeholder_icon )
+				);
 			}
 
 			// Letter code box + label.

--- a/projects/packages/forms/src/contact-form/class-feedback-field.php
+++ b/projects/packages/forms/src/contact-form/class-feedback-field.php
@@ -809,14 +809,15 @@ class Feedback_Field {
 			$image_src  = ! empty( $choice['image']['src'] ) ? esc_url( $choice['image']['src'] ) : '';
 			$show_label = ! empty( $choice['showLabels'] );
 
-			// Image thumbnail with 8px padding inside the card.
-			$image_html = '';
+			// Image thumbnail or gray placeholder at 138×144.
 			if ( $image_src !== '' ) {
 				$image_html = sprintf(
 					'<div style="padding: 8px 8px 0 8px;"><img src="%s" alt="%s" width="138" height="144" style="display: block; width: 138px; height: 144px; object-fit: cover;" /></div>',
 					$image_src,
 					$label !== '' ? $label : $letter
 				);
+			} else {
+				$image_html = '<div style="padding: 8px 8px 0 8px;"><div style="width: 138px; height: 144px; background-color: #f0f0f0;"></div></div>';
 			}
 
 			// Letter code box + label.
@@ -835,14 +836,12 @@ class Feedback_Field {
 				);
 			}
 
-			// Card with outline matching the admin preview Card component (radiusLarge = 8px).
-			$card = '<div style="display: inline-block; vertical-align: top; border: 1px solid #dcdcde; border-radius: 8px; margin: 0 8px 8px 0;">';
-			if ( $image_html !== '' ) {
-				$card .= $image_html;
-			}
+			// Card with fixed width matching the admin preview (138px image + 16px padding).
+			$card  = '<div style="display: inline-block; vertical-align: top; width: 154px; border: 1px solid #dcdcde; border-radius: 8px; margin: 0 8px 8px 0;">';
+			$card .= $image_html;
 			if ( $caption_html !== '' ) {
 				$card .= sprintf(
-					'<div style="padding: 4px 8px 8px 8px;">%s</div>',
+					'<div style="padding: 4px 8px 8px 8px; overflow: hidden; white-space: nowrap; text-overflow: ellipsis;">%s</div>',
 					$caption_html
 				);
 			}

--- a/projects/packages/forms/tests/php/contact-form/Feedback_Field_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Feedback_Field_Test.php
@@ -606,6 +606,234 @@ class Feedback_Field_Test extends BaseTestCase {
 	}
 
 	/**
+	 * Test email_html renders plain text for a basic text field.
+	 */
+	public function test_email_html_text_field() {
+		$field  = new Feedback_Field( 'k', 'Label', 'Hello world', 'text' );
+		$result = $field->get_render_value( 'email_html' );
+
+		$this->assertStringContainsString( 'Hello world', $result );
+	}
+
+	/**
+	 * Test email_html renders empty value dash for empty text field.
+	 */
+	public function test_email_html_empty_text_field() {
+		$field  = new Feedback_Field( 'k', 'Label', '', 'text' );
+		$result = $field->get_render_value( 'email_html' );
+
+		$this->assertStringContainsString( '&mdash;', $result );
+	}
+
+	/**
+	 * Test email_html renders chips for select field.
+	 */
+	public function test_email_html_select_field() {
+		$field  = new Feedback_Field( 'k', 'Label', 'Option A', 'select' );
+		$result = $field->get_render_value( 'email_html' );
+
+		$this->assertStringContainsString( 'Option A', $result );
+		$this->assertStringContainsString( 'background-color: #f0f0f0', $result );
+	}
+
+	/**
+	 * Test email_html renders multiple chips for checkbox-multiple field.
+	 */
+	public function test_email_html_checkbox_multiple_field() {
+		$field  = new Feedback_Field( 'k', 'Label', array( 'Red', 'Blue' ), 'checkbox-multiple' );
+		$result = $field->get_render_value( 'email_html' );
+
+		$this->assertStringContainsString( 'Red', $result );
+		$this->assertStringContainsString( 'Blue', $result );
+		$this->assertStringContainsString( 'background-color: #f0f0f0', $result );
+	}
+
+	/**
+	 * Test email_html renders Yes for consent field with truthy value.
+	 */
+	public function test_email_html_consent_yes() {
+		$field  = new Feedback_Field( 'k', 'Consent', '1', 'consent' );
+		$result = $field->get_render_value( 'email_html' );
+
+		$this->assertStringContainsString( 'Yes', $result );
+	}
+
+	/**
+	 * Test email_html renders No for consent field with empty value.
+	 */
+	public function test_email_html_consent_no() {
+		$field  = new Feedback_Field( 'k', 'Consent', '', 'consent' );
+		$result = $field->get_render_value( 'email_html' );
+
+		$this->assertStringContainsString( 'No', $result );
+	}
+
+	/**
+	 * Test email_html renders tel: link for phone field.
+	 */
+	public function test_email_html_phone_field() {
+		$field  = new Feedback_Field( 'k', 'Phone', '+1 555 123 4567', 'phone' );
+		$result = $field->get_render_value( 'email_html' );
+
+		$this->assertStringContainsString( 'tel:', $result );
+		$this->assertStringContainsString( '+1 555 123 4567', $result );
+	}
+
+	/**
+	 * Test email_html renders clickable link for URL field.
+	 */
+	public function test_email_html_url_field() {
+		$field  = new Feedback_Field( 'k', 'Website', 'https://example.com', 'url' );
+		$result = $field->get_render_value( 'email_html' );
+
+		$this->assertStringContainsString( 'href="https://example.com"', $result );
+		$this->assertStringContainsString( 'https://example.com', $result );
+	}
+
+	/**
+	 * Test email_html renders stars for rating field.
+	 */
+	public function test_email_html_rating_field() {
+		$field  = new Feedback_Field( 'k', 'Rating', '3/5', 'rating' );
+		$result = $field->get_render_value( 'email_html' );
+
+		// 3 gold + 2 gray stars.
+		$this->assertSame( 3, substr_count( $result, '#e6a117' ) );
+		$this->assertSame( 2, substr_count( $result, '#cccccc' ) );
+	}
+
+	/**
+	 * Test email_html renders dash for empty chips.
+	 */
+	public function test_email_html_select_empty() {
+		$field  = new Feedback_Field( 'k', 'Label', '', 'select' );
+		$result = $field->get_render_value( 'email_html' );
+
+		$this->assertStringContainsString( '&mdash;', $result );
+	}
+
+	/**
+	 * Test email_html renders image-select field with thumbnails and letter codes.
+	 */
+	public function test_email_html_image_select_field() {
+		$value = array(
+			'type'    => 'image-select',
+			'choices' => array(
+				array(
+					'perceived'  => 'A',
+					'selected'   => 'A',
+					'label'      => 'Shoes',
+					'showLabels' => true,
+					'image'      => array(
+						'id'  => null,
+						'src' => 'https://example.com/shoes.jpg',
+					),
+				),
+				array(
+					'perceived'  => 'B',
+					'selected'   => 'C',
+					'label'      => 'Bags',
+					'showLabels' => true,
+					'image'      => array(
+						'id'  => null,
+						'src' => 'https://example.com/bags.jpg',
+					),
+				),
+			),
+		);
+
+		$field  = new Feedback_Field( 'k', 'Pick one', $value, 'image-select' );
+		$result = $field->get_render_value( 'email_html' );
+
+		// Should contain images.
+		$this->assertStringContainsString( 'https://example.com/shoes.jpg', $result );
+		$this->assertStringContainsString( 'https://example.com/bags.jpg', $result );
+		// Should contain letter codes.
+		$this->assertStringContainsString( '>A</span>', $result );
+		$this->assertStringContainsString( '>C</span>', $result );
+		// Should contain labels.
+		$this->assertStringContainsString( 'Shoes', $result );
+		$this->assertStringContainsString( 'Bags', $result );
+		// Should use img tags.
+		$this->assertSame( 2, substr_count( $result, '<img ' ) );
+		// Cards should have outline border.
+		$this->assertStringContainsString( 'border: 1px solid #dcdcde', $result );
+	}
+
+	/**
+	 * Test email_html renders image-select field without labels when showLabels is false.
+	 */
+	public function test_email_html_image_select_no_labels() {
+		$value = array(
+			'type'    => 'image-select',
+			'choices' => array(
+				array(
+					'perceived'  => 'A',
+					'selected'   => 'A',
+					'label'      => 'Shoes',
+					'showLabels' => false,
+					'image'      => array(
+						'id'  => null,
+						'src' => 'https://example.com/shoes.jpg',
+					),
+				),
+			),
+		);
+
+		$field  = new Feedback_Field( 'k', 'Pick one', $value, 'image-select' );
+		$result = $field->get_render_value( 'email_html' );
+
+		// Should contain letter code but not label text as a separate span.
+		$this->assertStringContainsString( '>A</span>', $result );
+		$this->assertStringNotContainsString( '>Shoes</span>', $result );
+	}
+
+	/**
+	 * Test email_html renders dash for empty image-select.
+	 */
+	public function test_email_html_image_select_empty() {
+		$value = array(
+			'type'    => 'image-select',
+			'choices' => array(),
+		);
+
+		$field  = new Feedback_Field( 'k', 'Pick one', $value, 'image-select' );
+		$result = $field->get_render_value( 'email_html' );
+
+		$this->assertStringContainsString( '&mdash;', $result );
+	}
+
+	/**
+	 * Test email_html renders image-select without image src gracefully.
+	 */
+	public function test_email_html_image_select_no_image() {
+		$value = array(
+			'type'    => 'image-select',
+			'choices' => array(
+				array(
+					'perceived'  => 'A',
+					'selected'   => 'B',
+					'label'      => 'Option',
+					'showLabels' => true,
+					'image'      => array(
+						'id'  => null,
+						'src' => '',
+					),
+				),
+			),
+		);
+
+		$field  = new Feedback_Field( 'k', 'Pick one', $value, 'image-select' );
+		$result = $field->get_render_value( 'email_html' );
+
+		// No img tag when src is empty.
+		$this->assertStringNotContainsString( '<img ', $result );
+		// But letter code and label should still render.
+		$this->assertStringContainsString( '>B</span>', $result );
+		$this->assertStringContainsString( 'Option', $result );
+	}
+
+	/**
 	 * Test get_admin_theme_color returns a hex color.
 	 */
 	public function test_get_admin_theme_color() {

--- a/projects/packages/forms/tests/php/contact-form/Feedback_Field_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Feedback_Field_Test.php
@@ -756,8 +756,11 @@ class Feedback_Field_Test extends BaseTestCase {
 		$this->assertStringContainsString( 'Bags', $result );
 		// Should use img tags.
 		$this->assertSame( 2, substr_count( $result, '<img ' ) );
-		// Cards should have outline border.
+		// Cards should have outline border and fixed width.
 		$this->assertStringContainsString( 'border: 1px solid #dcdcde', $result );
+		$this->assertStringContainsString( 'width: 154px', $result );
+		// Caption should have text truncation styles.
+		$this->assertStringContainsString( 'text-overflow: ellipsis', $result );
 	}
 
 	/**
@@ -826,9 +829,10 @@ class Feedback_Field_Test extends BaseTestCase {
 		$field  = new Feedback_Field( 'k', 'Pick one', $value, 'image-select' );
 		$result = $field->get_render_value( 'email_html' );
 
-		// No img tag when src is empty.
+		// No img tag when src is empty, but placeholder should render.
 		$this->assertStringNotContainsString( '<img ', $result );
-		// But letter code and label should still render.
+		$this->assertStringContainsString( 'background-color: #f0f0f0', $result );
+		// Letter code and label should still render.
 		$this->assertStringContainsString( '>B</span>', $result );
 		$this->assertStringContainsString( 'Option', $result );
 	}

--- a/projects/packages/forms/tests/php/contact-form/Feedback_Field_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Feedback_Field_Test.php
@@ -829,9 +829,9 @@ class Feedback_Field_Test extends BaseTestCase {
 		$field  = new Feedback_Field( 'k', 'Pick one', $value, 'image-select' );
 		$result = $field->get_render_value( 'email_html' );
 
-		// No img tag when src is empty, but placeholder should render.
-		$this->assertStringNotContainsString( '<img ', $result );
+		// Placeholder should render with gray background and icon.
 		$this->assertStringContainsString( 'background-color: #f0f0f0', $result );
+		$this->assertStringContainsString( 'field-image-select@2x.png', $result );
 		// Letter code and label should still render.
 		$this->assertStringContainsString( '>B</span>', $result );
 		$this->assertStringContainsString( 'Option', $result );

--- a/projects/plugins/jetpack/changelog/add-forms-email-image-select3
+++ b/projects/plugins/jetpack/changelog/add-forms-email-image-select3
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Forms: render images from image select fields on email notifications.


### PR DESCRIPTION
## Proposed changes:

* Add `render_email_image_select()` method to `Feedback_Field` for the `email_html` rendering context
* Each selected choice renders as a card with image thumbnail (138×144), letter code badge, and optional label
* Cards use an outline border and rounded corners matching the admin preview Card component (`border-radius: 8px`)
* Gracefully handles missing images (renders letter code + label only) and empty selections (renders em dash)
* Wires the new renderer into `get_render_email_html_value()` via the existing `is_of_type('image-select')` check

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?

no

## Testing instructions:

* Create a form with an image-select field (upload a few images, enable labels)
* Submit the form as a visitor
* Check the email notification in Mailpit (or your configured mail client)
* Verify image-select choices display as cards with thumbnails, letter codes, and labels
* Test with `showLabels` disabled — labels should not appear, only letter codes
* Test with an empty image-select submission — should show an em dash (—)
* Run `jetpack test php packages/forms` — 4 new tests should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)