### PR TITLE
Jetpack Sync: Send the triggering action name with jetpack_sync_data_loss

### DIFF
--- a/projects/packages/sync/changelog/add-sync-class-listener-data-loss-logging
+++ b/projects/packages/sync/changelog/add-sync-class-listener-data-loss-logging
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Sync: Add triggering action name to data sent with jetpack_sync_data_loss action.

--- a/projects/packages/sync/src/class-listener.php
+++ b/projects/packages/sync/src/class-listener.php
@@ -323,7 +323,7 @@ class Listener {
 		 */
 		if ( ! $this->can_add_to_queue( $queue ) ) {
 			if ( 'sync' === $queue->id ) {
-				$this->sync_data_loss( $queue );
+				$this->sync_data_loss( $queue, $current_filter );
 			}
 			return;
 		}
@@ -383,10 +383,13 @@ class Listener {
 	/**
 	 * Sync Data Loss Handler
 	 *
-	 * @param Queue $queue Sync queue.
+	 * Sends a single 'jetpack_sync_data_loss' action to WP.com with timestamp, queue_size, queue_lag and current_filter.
+	 *
+	 * @param Queue  $queue Sync queue.
+	 * @param string $current_filter Name of action that triggered sync.
 	 * @return boolean was send successful
 	 */
-	public function sync_data_loss( $queue ) {
+	public function sync_data_loss( $queue, $current_filter ) {
 		if ( ! Settings::is_sync_enabled() ) {
 			return;
 		}
@@ -400,6 +403,7 @@ class Listener {
 			'timestamp'  => microtime( true ),
 			'queue_size' => $queue->size(),
 			'queue_lag'  => $queue->lag(),
+			'extra'      => $current_filter,
 		);
 
 		$sender = Sender::get_instance();

--- a/projects/packages/sync/src/class-listener.php
+++ b/projects/packages/sync/src/class-listener.php
@@ -389,7 +389,7 @@ class Listener {
 	 * @param string $current_filter Name of action that triggered sync.
 	 * @return boolean was send successful
 	 */
-	public function sync_data_loss( $queue, $current_filter ) {
+	public function sync_data_loss( $queue, $current_filter = '' ) {
 		if ( ! Settings::is_sync_enabled() ) {
 			return;
 		}

--- a/projects/packages/sync/src/class-listener.php
+++ b/projects/packages/sync/src/class-listener.php
@@ -403,7 +403,9 @@ class Listener {
 			'timestamp'  => microtime( true ),
 			'queue_size' => $queue->size(),
 			'queue_lag'  => $queue->lag(),
-			'extra'      => $current_filter,
+			'extra'      => array(
+				'current_filter' => $current_filter,
+			),
 		);
 
 		$sender = Sender::get_instance();

--- a/projects/plugins/jetpack/changelog/add-sync-class-listener-data-loss-logging
+++ b/projects/plugins/jetpack/changelog/add-sync-class-listener-data-loss-logging
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Updating tests for Jetpack Sync.
+
+

--- a/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Listener_Test.php
+++ b/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Listener_Test.php
@@ -252,7 +252,8 @@ class Jetpack_Sync_Listener_Test extends Jetpack_Sync_TestBase {
 		$this->assertTrue( isset( $event->args['queue_size'] ) );
 		$this->assertTrue( isset( $event->args['queue_lag'] ) );
 		$this->assertTrue( isset( $event->args['extra'] ) );
-		$this->assertEquals( 'test_action', $event->args['extra'] );
+		$this->assertIsArray( $event->args['extra'] );
+		$this->assertEquals( array( 'current_filter' => 'test_action' ), $event->args['extra'] );
 		$this->assertEquals( Health::STATUS_OUT_OF_SYNC, Health::get_status() );
 	}
 

--- a/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Listener_Test.php
+++ b/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Listener_Test.php
@@ -245,19 +245,21 @@ class Jetpack_Sync_Listener_Test extends Jetpack_Sync_TestBase {
 		Health::update_status( Health::STATUS_IN_SYNC );
 		$this->assertEquals( Health::STATUS_IN_SYNC, Health::get_status() );
 
-		$this->listener->sync_data_loss( $this->listener->get_sync_queue() );
+		$this->listener->sync_data_loss( $this->listener->get_sync_queue(), 'test_action' );
 		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_sync_data_loss' );
 
 		$this->assertTrue( isset( $event->args['timestamp'] ) );
 		$this->assertTrue( isset( $event->args['queue_size'] ) );
 		$this->assertTrue( isset( $event->args['queue_lag'] ) );
+		$this->assertTrue( isset( $event->args['extra'] ) );
+		$this->assertEquals( 'test_action', $event->args['extra'] );
 		$this->assertEquals( Health::STATUS_OUT_OF_SYNC, Health::get_status() );
 	}
 
 	public function test_data_loss_action_ignored_if_already_out_of_sync() {
 		Health::update_status( Health::STATUS_OUT_OF_SYNC );
 
-		$this->listener->sync_data_loss( $this->listener->get_sync_queue() );
+		$this->listener->sync_data_loss( $this->listener->get_sync_queue(), 'test_action' );
 		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_sync_data_loss' );
 
 		$this->assertFalse( $event );


### PR DESCRIPTION
Fixes SYNC-244

## Proposed changes:

* This PR adds additional information - the triggering action name - to be sent along with the `jetpack_sync_data_loss` action to WPcom. This is to allow us to log more information from the WPcom end, enabling us to better debug data loss events.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

n/a

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

This needs to be tested alongside the WPcom counterpart: 204130-ghe-Automattic/wpcom.

You'll need a Jetpack API sandboxed site.

* To test, apply the WPcom PR in your WPcom sandbox, and this PR locally or using the Jetpack Beta tester plugin for your test site.
* Comment out [all of the checks](https://github.com/Automattic/jetpack/blob/5bc75844a9f971375e0f84833a447c7bbefdad7e/projects/packages/sync/src/class-listener.php#L389) in `sync_data loss()` before `$data = array`.
* In `enqueue_action`, add `$this->sync_data_loss( $queue, $current_filter );` early on in the function.
* Take any action on your test site that would ordinarily be synced, then comment the above line out as soon as possible to prevent too many other actions being sent as well.
* View the logs for your site: 31cc401410096ca92144710b5e9fbe44-logstash (replacing the blog ID)
* You should see the sending action under 'extra'.