### PR TITLE
wpcom_site_management_panel_link: Update settings link to new path

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/wpcom-update-settings-link
+++ b/projects/packages/jetpack-mu-wpcom/changelog/wpcom-update-settings-link
@@ -1,5 +1,5 @@
 Significance: patch
 Type: fixed
-Comment: wpcom_site_management_panel_link: Update settings link to new path
+Comment: Fix broken link to site settings on WordPress.com.
 
 

--- a/projects/packages/jetpack-mu-wpcom/changelog/wpcom-update-settings-link
+++ b/projects/packages/jetpack-mu-wpcom/changelog/wpcom-update-settings-link
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: wpcom_site_management_panel_link: Update settings link to new path
+
+

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-options-general/options-general.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-options-general/options-general.php
@@ -39,7 +39,7 @@ add_action( 'load-options-general.php', 'wpcom_fiverr' );
  */
 function wpcom_site_management_panel_link() {
 	?>
-	<a href="https://wordpress.com/sites/settings/site/<?php echo esc_attr( wpcom_get_site_slug() ); ?>">
+	<a href="https://wordpress.com/sites/<?php echo esc_attr( wpcom_get_site_slug() ); ?>/settings">
 		<?php esc_html_e( 'Manage gift subscriptions, ownership, and other site tools on WordPress.com ↗', 'jetpack-mu-wpcom' ); ?>
 	</a>
 	<?php


### PR DESCRIPTION
## Proposed changes:
* On wpcom options-general.php, update the link to calypso with the correct path.

**This link:**
<img width="842" height="81" alt="Screenshot 2026-02-16 at 6 09 15 PM" src="https://github.com/user-attachments/assets/a3d2aae3-d43c-46ec-b58b-b7fdb3b157de" />

**Is going to a bad path which triggers an empty panel:**
<img width="1087" height="501" alt="Screenshot 2026-02-16 at 6 05 51 PM" src="https://github.com/user-attachments/assets/6d318304-f98f-47e4-81d4-47323178d435" />

I tried to fix it here, https://github.com/Automattic/wp-calypso/pull/108733 , but while this worked when reproducing on localhost, it doesn't seem to actually fix the problem in production.


See also https://github.com/Automattic/wp-calypso/pull/104921 and p1753168342337159-slack-CRWCHQGUB

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

## Does this pull request change what data or activity we track or use?

## Testing instructions:

* Go to '..'
*

