### PR TITLE
renovate: Allow constraint updates for some packages

### DIFF
--- a/.github/renovate-config.js
+++ b/.github/renovate-config.js
@@ -156,5 +156,18 @@ module.exports = {
 			}
 			return Object.values( ret );
 		} )(),
+		// Override PHP version constraint for certain packages that are plugins to other tools. We want renovate to recommend updates even if a constraint bump is needed.
+		{
+			matchFileNames: [
+				'projects/packages/codesniffer/composer.json',
+				'projects/packages/phan-plugins/composer.json',
+				'projects/packages/phpcs-filter/composer.json',
+			],
+			matchDatasources: [ 'packagist' ],
+			matchDepTypes: [ 'require' ],
+			constraints: {
+				php: `~${ versions.PHP_VERSION }.0`,
+			},
+		},
 	],
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
For some of our packages that are plugins for other tools, we'd rather let the deps drive the constraints rather than having the constraints drive the deps.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* I think you'd have to merge this in a fork, then run it there.
  * [x] https://github.com/anomiex/jetpack/actions/runs/22107989994/job/63896112177