### PR TITLE
Post media: add initial package skeleton

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3374,6 +3374,8 @@ importers:
         specifier: 6.0.1
         version: 6.0.1(webpack@5.104.1)
 
+  projects/packages/post-media: {}
+
   projects/packages/protect-models: {}
 
   projects/packages/protect-status: {}

--- a/projects/packages/post-media/.gitattributes
+++ b/projects/packages/post-media/.gitattributes
@@ -1,0 +1,16 @@
+# Files not needed to be distributed in the package.
+.gitattributes    export-ignore
+.github/          export-ignore
+package.json      export-ignore
+
+# Files to include in the mirror repo, but excluded via gitignore
+# Remember to end all directories with `/**` to properly tag every file.
+# /src/js/example.min.js  production-include
+
+# Files to exclude from the mirror repo, but included in the monorepo.
+# Remember to end all directories with `/**` to properly tag every file.
+.gitignore        production-exclude
+changelog/**      production-exclude
+.phpcs.dir.xml    production-exclude
+tests/**          production-exclude
+.phpcsignore      production-exclude

--- a/projects/packages/post-media/.gitignore
+++ b/projects/packages/post-media/.gitignore
@@ -1,0 +1,2 @@
+vendor/
+node_modules/

--- a/projects/packages/post-media/.gitignore
+++ b/projects/packages/post-media/.gitignore
@@ -1,2 +1,3 @@
 vendor/
 node_modules/
+wordpress/

--- a/projects/packages/post-media/.phan/baseline.php
+++ b/projects/packages/post-media/.phan/baseline.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * This is an automatically generated baseline for Phan issues.
+ *
+ * Use `jetpack phan --update-baseline` to update this file.
+ */
+return [
+    // Currently, file_suppressions and directory_suppressions are the only supported suppressions
+    'file_suppressions' => [],
+    // 'directory_suppressions' => ['src/directory_name' => ['PhanIssueName1', 'PhanIssueName2']] can be manually added if needed.
+    // (directory_suppressions will currently be ignored by subsequent calls to --save-baseline, but may be preserved in future Phan releases)
+];

--- a/projects/packages/post-media/.phan/baseline.php
+++ b/projects/packages/post-media/.phan/baseline.php
@@ -1,12 +1,17 @@
 <?php
 /**
  * This is an automatically generated baseline for Phan issues.
+ * When Phan is invoked with --load-baseline=path/to/baseline.php,
+ * The pre-existing issues listed in this file won't be emitted.
  *
- * Use `jetpack phan --update-baseline` to update this file.
+ * This file can be updated by invoking Phan with --save-baseline=path/to/baseline.php
+ * (can be combined with --load-baseline)
  */
 return [
+    // This baseline has no suppressions
     // Currently, file_suppressions and directory_suppressions are the only supported suppressions
-    'file_suppressions' => [],
+    'file_suppressions' => [
+    ],
     // 'directory_suppressions' => ['src/directory_name' => ['PhanIssueName1', 'PhanIssueName2']] can be manually added if needed.
     // (directory_suppressions will currently be ignored by subsequent calls to --save-baseline, but may be preserved in future Phan releases)
 ];

--- a/projects/packages/post-media/.phan/config.php
+++ b/projects/packages/post-media/.phan/config.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * This configuration will be read and overlaid on top of the
+ * default configuration. Command-line arguments will be applied
+ * after this file is read.
+ *
+ * @package automattic/jetpack-post-media
+ */
+
+// Require base config.
+require __DIR__ . '/../../../../.phan/config.base.php';
+
+return make_phan_config( dirname( __DIR__ ) );

--- a/projects/packages/post-media/.phpcs.dir.xml
+++ b/projects/packages/post-media/.phpcs.dir.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<ruleset>
+
+	<rule ref="WordPress.WP.I18n">
+		<properties>
+			<property name="text_domain" type="array">
+				<element value="jetpack-post-media" />
+			</property>
+		</properties>
+	</rule>
+	<rule ref="Jetpack.Functions.I18n">
+		<properties>
+			<property name="text_domain" value="jetpack-post-media" />
+		</properties>
+	</rule>
+
+	<rule ref="WordPress.Utils.I18nTextDomainFixer">
+		<properties>
+			<property name="old_text_domain" type="array" />
+			<property name="new_text_domain" value="jetpack-post-media" />
+		</properties>
+	</rule>
+
+</ruleset>

--- a/projects/packages/post-media/CHANGELOG.md
+++ b/projects/packages/post-media/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+

--- a/projects/packages/post-media/README.md
+++ b/projects/packages/post-media/README.md
@@ -1,0 +1,24 @@
+# post-media
+
+Tools to extract useful information and meta data from WordPress posts.
+
+## How to install post-media
+
+### Installation From Git Repo
+
+## Contribute
+
+## Get Help
+
+## Using this package in your WordPress plugin
+
+If you plan on using this package in your WordPress plugin, we would recommend that you use [Jetpack Autoloader](https://packagist.org/packages/automattic/jetpack-autoloader) as your autoloader. This will allow for maximum interoperability with other plugins that use this package as well.
+
+## Security
+
+Need to report a security vulnerability? Go to [https://automattic.com/security/](https://automattic.com/security/) or directly to our security bug bounty site [https://hackerone.com/automattic](https://hackerone.com/automattic).
+
+## License
+
+post-media is licensed under [GNU General Public License v2 (or later)](./LICENSE.txt)
+

--- a/projects/packages/post-media/changelog/initial-version
+++ b/projects/packages/post-media/changelog/initial-version
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Initial version.

--- a/projects/packages/post-media/composer.json
+++ b/projects/packages/post-media/composer.json
@@ -1,0 +1,61 @@
+{
+	"name": "automattic/jetpack-post-media",
+	"description": "Tools to extract useful information and meta data from WordPress posts.",
+	"type": "jetpack-library",
+	"license": "GPL-2.0-or-later",
+	"require": {
+		"php": ">=7.2"
+	},
+	"require-dev": {
+		"yoast/phpunit-polyfills": "^4.0.0",
+		"automattic/jetpack-changelogger": "@dev",
+		"automattic/phpunit-select-config": "@dev",
+		"automattic/jetpack-test-environment": "@dev"
+	},
+	"autoload": {
+		"classmap": [
+			"src/"
+		]
+	},
+	"scripts": {
+		"build-development": "echo 'Add your build step to composer.json, please!'",
+		"build-production": "echo 'Add your build step to composer.json, please!'",
+		"phpunit": [
+			"phpunit-select-config phpunit.#.xml.dist --colors=always"
+		],
+		"test-coverage": [
+			"php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\""
+		],
+		"test-php": [
+			"@composer phpunit"
+		]
+	},
+	"repositories": [
+		{
+			"type": "path",
+			"url": "../../packages/*",
+			"options": {
+				"monorepo": true
+			}
+		}
+	],
+	"minimum-stability": "dev",
+	"prefer-stable": true,
+	"extra": {
+		"autotagger": true,
+		"branch-alias": {
+			"dev-trunk": "0.1.x-dev"
+		},
+		"changelogger": {
+			"link-template": "https://github.com/Automattic/jetpack-post-media/compare/v${old}...v${new}"
+		},
+		"mirror-repo": "Automattic/jetpack-post-media",
+		"textdomain": "jetpack-post-media",
+		"version-constants": {
+			"::PACKAGE_VERSION": "src/class-post-media.php"
+		}
+	},
+	"suggest": {
+		"automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
+	}
+}

--- a/projects/packages/post-media/package.json
+++ b/projects/packages/post-media/package.json
@@ -1,0 +1,24 @@
+{
+	"name": "@automattic/jetpack-post-media",
+	"version": "0.1.0-alpha",
+	"private": true,
+	"description": "Tools to extract useful information and meta data from WordPress posts.",
+	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/post-media/#readme",
+	"bugs": {
+		"url": "https://github.com/Automattic/jetpack/labels/[Package] Post Media"
+	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/Automattic/jetpack.git",
+		"directory": "projects/packages/post-media"
+	},
+	"license": "GPL-2.0-or-later",
+	"author": "Automattic",
+	"scripts": {
+		"build": "echo 'Not implemented.'",
+		"build-js": "echo 'Not implemented.'",
+		"build-production": "echo 'Not implemented.'",
+		"build-production-js": "echo 'Not implemented.'",
+		"clean": "true"
+	}
+}

--- a/projects/packages/post-media/phpunit.11.xml.dist
+++ b/projects/packages/post-media/phpunit.11.xml.dist
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+	bootstrap="tests/php/bootstrap.php"
+	cacheDirectory=".phpunit.cache"
+	colors="true"
+	executionOrder="depends"
+	beStrictAboutOutputDuringTests="true"
+	displayDetailsOnPhpunitDeprecations="true"
+	displayDetailsOnTestsThatTriggerDeprecations="true"
+	displayDetailsOnTestsThatTriggerErrors="true"
+	displayDetailsOnTestsThatTriggerNotices="true"
+	displayDetailsOnTestsThatTriggerWarnings="true"
+	failOnDeprecation="true"
+	failOnEmptyTestSuite="true"
+	failOnPhpunitDeprecation="true"
+	failOnNotice="true"
+	failOnRisky="true"
+	failOnWarning="true"
+>
+	<testsuites>
+		<testsuite name="main">
+			<directory suffix="Test.php">tests/php</directory>
+		</testsuite>
+	</testsuites>
+
+	<source>
+		<include>
+			<!-- Better to only include "src" than to add "." and then exclude "tests", "vendor", and so on, as PHPUnit still scans the excluded directories. -->
+			<!-- Add additional lines for any files or directories outside of src/ that need coverage. -->
+			<directory suffix=".php">src</directory>
+		</include>
+	</source>
+	<coverage ignoreDeprecatedCodeUnits="true">
+	</coverage>
+</phpunit>

--- a/projects/packages/post-media/phpunit.11.xml.dist
+++ b/projects/packages/post-media/phpunit.11.xml.dist
@@ -12,7 +12,7 @@
 	displayDetailsOnTestsThatTriggerNotices="true"
 	displayDetailsOnTestsThatTriggerWarnings="true"
 	failOnDeprecation="true"
-	failOnEmptyTestSuite="true"
+	failOnEmptyTestSuite="false"
 	failOnPhpunitDeprecation="true"
 	failOnNotice="true"
 	failOnRisky="true"

--- a/projects/packages/post-media/phpunit.12.xml.dist
+++ b/projects/packages/post-media/phpunit.12.xml.dist
@@ -1,0 +1,1 @@
+phpunit.11.xml.dist

--- a/projects/packages/post-media/phpunit.8.xml.dist
+++ b/projects/packages/post-media/phpunit.8.xml.dist
@@ -1,0 +1,1 @@
+phpunit.9.xml.dist

--- a/projects/packages/post-media/phpunit.9.xml.dist
+++ b/projects/packages/post-media/phpunit.9.xml.dist
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.6/phpunit.xsd"
+	bootstrap="tests/php/bootstrap.php"
+	cacheResultFile=".phpunit.cache/test-results"
+	colors="true"
+	executionOrder="depends"
+	beStrictAboutOutputDuringTests="true"
+	failOnRisky="true"
+	failOnWarning="true"
+>
+	<testsuites>
+		<testsuite name="main">
+			<directory suffix="Test.php">tests/php</directory>
+		</testsuite>
+	</testsuites>
+</phpunit>

--- a/projects/packages/post-media/src/class-post-media.php
+++ b/projects/packages/post-media/src/class-post-media.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * Package description here
+ *
+ * @package automattic/jetpack-post-media
+ */
+
+namespace Automattic\Jetpack;
+
+/**
+ * Class description.
+ */
+class Post_Media {
+
+	const PACKAGE_VERSION = '0.1.0-alpha';
+}

--- a/projects/packages/post-media/tests/.phpcs.dir.xml
+++ b/projects/packages/post-media/tests/.phpcs.dir.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<ruleset>
+	<rule ref="Jetpack-Tests" />
+</ruleset>

--- a/projects/packages/post-media/tests/php/bootstrap.php
+++ b/projects/packages/post-media/tests/php/bootstrap.php
@@ -1,0 +1,11 @@
+<?php
+/**
+ * Bootstrap.
+ *
+ * @package automattic/
+ */
+
+/**
+ * Include the composer autoloader.
+ */
+require_once __DIR__ . '/../../vendor/autoload.php';

--- a/projects/packages/post-media/tests/php/bootstrap.php
+++ b/projects/packages/post-media/tests/php/bootstrap.php
@@ -2,7 +2,7 @@
 /**
  * Bootstrap.
  *
- * @package automattic/
+ * @package automattic/jetpack-post-media
  */
 
 /**


### PR DESCRIPTION
Fixes CM-77

## Proposed changes:

This package will house a few utilties currently spread across the codebase:

- Jetpack_Twitter_Cards
- Jetpack_Media_Summary
- Jetpack_Media_Meta_Extractor
- General youtube functions
- functions.opengraph.php
- Jetpack_PostImages
- And more

For now it's empty. I've created the mirror repo and added the necessary secrets.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

Not much to test for now ; just make sure CI is happy.
