### PR TITLE
Test: Change without changelog

### DIFF
--- a/projects/packages/a8c-mc-stats/changelog/pr-47166
+++ b/projects/packages/a8c-mc-stats/changelog/pr-47166
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Trivial doc comment edit, no user-facing change.
+
+

--- a/projects/packages/a8c-mc-stats/src/class-a8c-mc-stats.php
+++ b/projects/packages/a8c-mc-stats/src/class-a8c-mc-stats.php
@@ -8,7 +8,7 @@
 namespace Automattic\Jetpack;
 
 /**
- * Class MC Stats, used to record stats using https://pixel.wp.com/g.gif
+ * MC Stats class, used to record stats using https://pixel.wp.com/g.gif.
  */
 class A8c_Mc_Stats {
 


### PR DESCRIPTION
See #46533

## Proposed changes:

* Trivial doc comment edit in `packages/a8c-mc-stats` without a changelog entry, to test the Claude changelog generator workflow added in #46533.

### Other information:

- [x] Have you written new tests for your changes, if applicable? N/A - test PR
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them? N/A
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

N/A

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

1. Verify the `Changelogger use` check fails (no changelog entry exists)
2. Check the "Generate changelog entries for this PR (using AI)" checkbox in the PR description
3. Verify the `Changelog Auto-Add` workflow triggers and Claude generates the correct changelog file
4. Verify the `Changelogger use` check passes after Claude's commit

## Changelog

- [x] Generate changelog entries for this PR (using AI).