### PR TITLE
Fix changelog auto-add workflow permissions and PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -37,4 +37,3 @@ Fixes #
 <!-- Check one of the boxes below. -->
 
 - [ ] Generate changelog entries for this PR (using AI).
-- [ ] No changelog entries needed.

--- a/.github/workflows/changelog-auto-add.yml
+++ b/.github/workflows/changelog-auto-add.yml
@@ -19,6 +19,7 @@ concurrency:
 permissions:
   contents: write
   pull-requests: read
+  id-token: write
 
 jobs:
   generate:

--- a/.github/workflows/changelog-auto-add.yml
+++ b/.github/workflows/changelog-auto-add.yml
@@ -2,9 +2,9 @@
 # "Generate changelog entries" checkbox is checked in the PR template.
 #
 # It triggers on pull_request_target so it has write permissions to push
-# commits to the PR branch. It only runs the changelogger check script
-# and Claude against the PR head — no untrusted code is executed in a
-# privileged context.
+# commits to the PR branch. It's restricted to same-repo branches (no
+# forks) because the checkout runs local actions and scripts from the
+# PR head, which would be untrusted code in a fork context.
 
 name: Changelog Auto-Add
 
@@ -24,8 +24,12 @@ permissions:
 jobs:
   generate:
     name: Generate changelog entries
-    # Skip bot PRs (e.g. Renovate, dependabot).
-    if: github.event.pull_request.user.login != 'renovate[bot]' && github.event.pull_request.user.login != 'dependabot[bot]' && github.event.pull_request.user.login != 'matticbot'
+    # Only run for same-repo branches (not forks) and skip bot PRs.
+    if: >-
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.event.pull_request.user.login != 'renovate[bot]' &&
+      github.event.pull_request.user.login != 'dependabot[bot]' &&
+      github.event.pull_request.user.login != 'matticbot'
     runs-on: ubuntu-latest
     timeout-minutes: 10
 


### PR DESCRIPTION
Follow-up fixes for #46533.

## Proposed changes:

* Remove the "No changelog entries needed" checkbox from the PR template — it served no automated purpose and is redundant now that the changelog generation checkbox exists.
* Add `id-token: write` permission to the `changelog-auto-add` workflow. The `claude-code-action` needs this for OIDC authentication (same as the existing `claude.yml` workflow already has).

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

N/A — CI/workflow config only.

## Jetpack product discussion

N/A

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

* Verify the PR template no longer shows "No changelog entries needed" checkbox
* Verify the `changelog-auto-add.yml` workflow has `id-token: write` in its permissions block

## Changelog

- [x] Generate changelog entries for this PR (using AI).
