### PR TITLE
Form Editor: add padding below title to prevent block toolbar overlap

### DIFF
--- a/projects/packages/forms/changelog/fix-form-editor-min-title-padding
+++ b/projects/packages/forms/changelog/fix-form-editor-min-title-padding
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Form Editor: add padding below title to prevent block toolbar overlap.

--- a/projects/packages/forms/src/form-editor/style.scss
+++ b/projects/packages/forms/src/form-editor/style.scss
@@ -2,6 +2,12 @@
 	display: none;
 }
 
+// Ensure the form title has enough padding to not be hidden by
+// the block toolbar.
+.post-type-jetpack_form .editor-post-title {
+	padding-block-end: 48px;
+}
+
 .post-type-jetpack_form .editor-post-last-edited-panel {
 	display: none;
 }


### PR DESCRIPTION
## Proposed changes:
* Add 48px bottom padding to the form title in the Form Editor to prevent it from being overlapped by the block toolbar when the form block is selected

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
N/A - Minor CSS fix

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
* Go to a WordPress site with Jetpack Forms installed
* Navigate to Forms > Add New to create a new form
* Observe that the form title at the top of the editor now has adequate spacing below it
* Select the form block and verify the block toolbar no longer overlaps with the title