### PR TITLE
Forms: add duplicate form action

### DIFF
--- a/projects/packages/forms/changelog/add-forms-duplicate-action
+++ b/projects/packages/forms/changelog/add-forms-duplicate-action
@@ -1,0 +1,5 @@
+Significance: minor
+Type: added
+
+Dashboard: add "Duplicate" action to the wp-build forms list.
+

--- a/projects/packages/forms/routes/forms/stage.tsx
+++ b/projects/packages/forms/routes/forms/stage.tsx
@@ -104,14 +104,14 @@ function StageInner() {
 		return statusFilterValue === 'trash';
 	}, [ view.filters ] );
 
-	const { records, isLoading, totalItems, totalPages, query } = useFormsData(
+	const { records, isLoading, totalItems, totalPages } = useFormsData(
 		view.page ?? 1,
 		view.perPage ?? 20,
 		view.search ?? '',
 		statusQuery
 	);
 
-	const { duplicateForm } = useDuplicateForm( { currentQuery: query } );
+	const { duplicateForm } = useDuplicateForm();
 
 	const {
 		isDeleting,

--- a/projects/packages/forms/routes/forms/stage.tsx
+++ b/projects/packages/forms/routes/forms/stage.tsx
@@ -23,6 +23,7 @@ import useDeleteForm from '../../src/dashboard/hooks/use-delete-form.ts';
 import useFormsData from '../../src/dashboard/hooks/use-forms-data.ts';
 import WpRouteDashboardSearchParamsProvider from '../../src/dashboard/router/wp-route-dashboard-search-params-provider.tsx';
 import DataViewsHeaderRow from '../../src/dashboard/wp-build/components/dataviews-header-row';
+import useDuplicateForm from '../../src/dashboard/wp-build/hooks/use-duplicate-form';
 import usePageHeaderDetails from '../../src/dashboard/wp-build/hooks/use-page-header-details';
 import '../../src/dashboard/wp-build/style.scss';
 import useConfigValue from '../../src/hooks/use-config-value';
@@ -103,12 +104,14 @@ function StageInner() {
 		return statusFilterValue === 'trash';
 	}, [ view.filters ] );
 
-	const { records, isLoading, totalItems, totalPages } = useFormsData(
+	const { records, isLoading, totalItems, totalPages, query } = useFormsData(
 		view.page ?? 1,
 		view.perPage ?? 20,
 		view.search ?? '',
 		statusQuery
 	);
+
+	const { duplicateForm } = useDuplicateForm( { currentQuery: query } );
 
 	const {
 		isDeleting,
@@ -296,6 +299,21 @@ function StageInner() {
 		} );
 
 		actionsList.push( {
+			id: 'duplicate-form',
+			isPrimary: false,
+			label: __( 'Duplicate', 'jetpack-forms' ),
+			supportsBulk: false,
+			async callback( items: FormListItem[] ) {
+				const [ item ] = items;
+				if ( ! item ) {
+					return;
+				}
+
+				await duplicateForm( item );
+			},
+		} );
+
+		actionsList.push( {
 			id: 'preview-form',
 			isPrimary: false,
 			label: __( 'Preview', 'jetpack-forms' ),
@@ -398,6 +416,7 @@ function StageInner() {
 	}, [
 		createErrorNotice,
 		createSuccessNotice,
+		duplicateForm,
 		isDeleting,
 		isViewingTrash,
 		onOpenPermanentDeleteConfirm,

--- a/projects/packages/forms/src/dashboard/hooks/use-forms-data.ts
+++ b/projects/packages/forms/src/dashboard/hooks/use-forms-data.ts
@@ -53,7 +53,6 @@ type UseFormsDataReturn = {
 	isLoading: boolean;
 	totalItems: number;
 	totalPages: number;
-	query: Record< string, unknown >;
 };
 
 /**
@@ -100,6 +99,5 @@ export default function useFormsData(
 		isLoading: ! hasResolved,
 		totalItems: totalItems ?? 0,
 		totalPages: totalPages ?? 0,
-		query,
 	};
 }

--- a/projects/packages/forms/src/dashboard/hooks/use-forms-data.ts
+++ b/projects/packages/forms/src/dashboard/hooks/use-forms-data.ts
@@ -53,6 +53,7 @@ type UseFormsDataReturn = {
 	isLoading: boolean;
 	totalItems: number;
 	totalPages: number;
+	query: Record< string, unknown >;
 };
 
 /**
@@ -99,5 +100,6 @@ export default function useFormsData(
 		isLoading: ! hasResolved,
 		totalItems: totalItems ?? 0,
 		totalPages: totalPages ?? 0,
+		query,
 	};
 }

--- a/projects/packages/forms/src/dashboard/wp-build/hooks/use-duplicate-form.ts
+++ b/projects/packages/forms/src/dashboard/wp-build/hooks/use-duplicate-form.ts
@@ -70,8 +70,7 @@ export default function useDuplicateForm(): UseDuplicateFormReturn {
 					);
 					return;
 				}
-				const originalRecord = original as JetpackFormEntityRecord | null | undefined;
-				const raw = originalRecord?.content?.raw;
+				const raw = ( original as JetpackFormEntityRecord ).content?.raw;
 				const originalContentRaw = typeof raw === 'string' ? raw : '';
 
 				const originalTitle = item.title || __( 'Untitled Form', 'jetpack-forms' );

--- a/projects/packages/forms/src/dashboard/wp-build/hooks/use-duplicate-form.ts
+++ b/projects/packages/forms/src/dashboard/wp-build/hooks/use-duplicate-form.ts
@@ -1,0 +1,147 @@
+/**
+ * External dependencies
+ */
+import { resolveSelect, useDispatch } from '@wordpress/data';
+import { useCallback, useState } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
+import { store as noticesStore } from '@wordpress/notices';
+/**
+ * Internal dependencies
+ */
+import { FORM_SOURCE_META_KEY } from '../../../blocks/shared/util/constants.js';
+/**
+ * Types
+ */
+import type { FormListItem } from '../../hooks/use-forms-data.ts';
+
+type CoreDispatch = {
+	saveEntityRecord: (
+		kind: string,
+		name: string,
+		record: Record< string, unknown >,
+		options?: { throwOnError?: boolean }
+	) => Promise< unknown >;
+	invalidateResolution: ( selector: string, args: unknown[] ) => void;
+};
+
+type DuplicateFormQuery = Record< string, unknown >;
+
+type JetpackFormEntityRecord = {
+	content?: { raw?: unknown };
+};
+
+type UseDuplicateFormArgs = {
+	currentQuery: DuplicateFormQuery;
+};
+
+type UseDuplicateFormReturn = {
+	duplicateForm: ( item: FormListItem ) => Promise< void >;
+	isDuplicating: boolean;
+};
+
+/**
+ * Duplicate a `jetpack_form` post and refresh the current list query.
+ *
+ * @param params              - Hook params.
+ * @param params.currentQuery - The exact core-data query object used for the current Forms list view.
+ * @return Duplicate handler and in-flight state.
+ */
+export default function useDuplicateForm( {
+	currentQuery,
+}: UseDuplicateFormArgs ): UseDuplicateFormReturn {
+	const [ isDuplicating, setIsDuplicating ] = useState( false );
+	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
+	const { saveEntityRecord, invalidateResolution } = useDispatch(
+		'core'
+	) as unknown as CoreDispatch;
+
+	const invalidateListQueries = useCallback(
+		( query: DuplicateFormQuery ) => {
+			// Invalidate list results.
+			invalidateResolution( 'getEntityRecords', [ 'postType', 'jetpack_form', query ] );
+			// Invalidate totals (core-data uses a separate selector under the hood).
+			invalidateResolution( 'getEntityRecords', [
+				'postType',
+				'jetpack_form',
+				{ ...query, per_page: 1, _fields: 'id' },
+			] );
+		},
+		[ invalidateResolution ]
+	);
+
+	const duplicateForm = useCallback(
+		async ( item: FormListItem ) => {
+			if ( isDuplicating ) {
+				return;
+			}
+			if ( ! item?.id ) {
+				return;
+			}
+
+			setIsDuplicating( true );
+			try {
+				const original: unknown = await resolveSelect( 'core' ).getEntityRecord(
+					'postType',
+					'jetpack_form',
+					item.id,
+					{ context: 'edit' }
+				);
+				const originalRecord = original as JetpackFormEntityRecord | null | undefined;
+				const raw = originalRecord?.content?.raw;
+				const originalContentRaw = typeof raw === 'string' ? raw : '';
+
+				const originalTitle = item.title || __( 'Untitled Form', 'jetpack-forms' );
+				const newTitle = sprintf(
+					/* translators: %s: original form title */
+					__( '%s Copy', 'jetpack-forms' ),
+					originalTitle
+				);
+
+				const created = ( await saveEntityRecord(
+					'postType',
+					'jetpack_form',
+					{
+						title: newTitle,
+						// Duplicate the raw block content so the form is an exact copy.
+						content: originalContentRaw,
+						status: 'publish',
+						meta: {
+							[ FORM_SOURCE_META_KEY ]: item.id,
+						},
+					},
+					{ throwOnError: true }
+				) ) as { id?: number } | undefined;
+
+				const createdId = created?.id;
+				if ( ! createdId ) {
+					createErrorNotice( __( 'Could not duplicate form. Please try again.', 'jetpack-forms' ), {
+						type: 'snackbar',
+					} );
+					return;
+				}
+
+				invalidateListQueries( currentQuery );
+
+				createSuccessNotice( __( 'Form duplicated.', 'jetpack-forms' ), {
+					type: 'snackbar',
+				} );
+			} catch {
+				createErrorNotice( __( 'Could not duplicate form. Please try again.', 'jetpack-forms' ), {
+					type: 'snackbar',
+				} );
+			} finally {
+				setIsDuplicating( false );
+			}
+		},
+		[
+			createErrorNotice,
+			createSuccessNotice,
+			currentQuery,
+			invalidateListQueries,
+			isDuplicating,
+			saveEntityRecord,
+		]
+	);
+
+	return { duplicateForm, isDuplicating };
+}

--- a/projects/packages/forms/src/dashboard/wp-build/hooks/use-duplicate-form.ts
+++ b/projects/packages/forms/src/dashboard/wp-build/hooks/use-duplicate-form.ts
@@ -86,6 +86,15 @@ export default function useDuplicateForm( {
 					item.id,
 					{ context: 'edit' }
 				);
+				if ( ! original ) {
+					createErrorNotice(
+						__( 'Could not load the form to duplicate. Please try again.', 'jetpack-forms' ),
+						{
+							type: 'snackbar',
+						}
+					);
+					return;
+				}
 				const originalRecord = original as JetpackFormEntityRecord | null | undefined;
 				const raw = originalRecord?.content?.raw;
 				const originalContentRaw = typeof raw === 'string' ? raw : '';

--- a/projects/packages/forms/src/dashboard/wp-build/hooks/use-duplicate-form.ts
+++ b/projects/packages/forms/src/dashboard/wp-build/hooks/use-duplicate-form.ts
@@ -9,6 +9,7 @@ import { store as noticesStore } from '@wordpress/notices';
  * Internal dependencies
  */
 import { FORM_SOURCE_META_KEY } from '../../../blocks/shared/util/constants.js';
+import useConfigValue from '../../../hooks/use-config-value';
 /**
  * Types
  */
@@ -21,17 +22,10 @@ type CoreDispatch = {
 		record: Record< string, unknown >,
 		options?: { throwOnError?: boolean }
 	) => Promise< unknown >;
-	invalidateResolution: ( selector: string, args: unknown[] ) => void;
 };
-
-type DuplicateFormQuery = Record< string, unknown >;
 
 type JetpackFormEntityRecord = {
 	content?: { raw?: unknown };
-};
-
-type UseDuplicateFormArgs = {
-	currentQuery: DuplicateFormQuery;
 };
 
 type UseDuplicateFormReturn = {
@@ -40,34 +34,15 @@ type UseDuplicateFormReturn = {
 };
 
 /**
- * Duplicate a `jetpack_form` post and refresh the current list query.
+ * Duplicate a `jetpack_form` post.
  *
- * @param params              - Hook params.
- * @param params.currentQuery - The exact core-data query object used for the current Forms list view.
  * @return Duplicate handler and in-flight state.
  */
-export default function useDuplicateForm( {
-	currentQuery,
-}: UseDuplicateFormArgs ): UseDuplicateFormReturn {
+export default function useDuplicateForm(): UseDuplicateFormReturn {
 	const [ isDuplicating, setIsDuplicating ] = useState( false );
 	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
-	const { saveEntityRecord, invalidateResolution } = useDispatch(
-		'core'
-	) as unknown as CoreDispatch;
-
-	const invalidateListQueries = useCallback(
-		( query: DuplicateFormQuery ) => {
-			// Invalidate list results.
-			invalidateResolution( 'getEntityRecords', [ 'postType', 'jetpack_form', query ] );
-			// Invalidate totals (core-data uses a separate selector under the hood).
-			invalidateResolution( 'getEntityRecords', [
-				'postType',
-				'jetpack_form',
-				{ ...query, per_page: 1, _fields: 'id' },
-			] );
-		},
-		[ invalidateResolution ]
-	);
+	const { saveEntityRecord } = useDispatch( 'core' ) as unknown as CoreDispatch;
+	const adminUrl = useConfigValue( 'adminUrl' ) || '';
 
 	const duplicateForm = useCallback(
 		async ( item: FormListItem ) => {
@@ -129,10 +104,18 @@ export default function useDuplicateForm( {
 					return;
 				}
 
-				invalidateListQueries( currentQuery );
-
 				createSuccessNotice( __( 'Form duplicated.', 'jetpack-forms' ), {
 					type: 'snackbar',
+					actions: [
+						{
+							label: __( 'Edit', 'jetpack-forms' ),
+							onClick: () => {
+								if ( adminUrl ) {
+									window.location.href = `${ adminUrl }post.php?post=${ createdId }&action=edit&post_type=jetpack_form`;
+								}
+							},
+						},
+					],
 				} );
 			} catch {
 				createErrorNotice( __( 'Could not duplicate form. Please try again.', 'jetpack-forms' ), {
@@ -142,14 +125,7 @@ export default function useDuplicateForm( {
 				setIsDuplicating( false );
 			}
 		},
-		[
-			createErrorNotice,
-			createSuccessNotice,
-			currentQuery,
-			invalidateListQueries,
-			isDuplicating,
-			saveEntityRecord,
-		]
+		[ createErrorNotice, createSuccessNotice, adminUrl, isDuplicating, saveEntityRecord ]
 	);
 
 	return { duplicateForm, isDuplicating };


### PR DESCRIPTION
## Proposed changes:

Adds a 'Duplicate' form action to the new forms dashboard so users can quickly and easily clone forms. As part of this, I add a new useDuplicateForm hook. 

**Screenshot**

<img width="1326" height="625" alt="duplicate-action" src="https://github.com/user-attachments/assets/6712f675-fa79-4086-98d0-be245b180edb" />

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Enable these feature flags: 

```
add_filter( 'jetpack_forms_alpha', '__return_true', 20 );
add_filter( 'jetpack_block_editor_feature_flags', 'eb_register_feature' );
function eb_register_feature( $flags ) {
    $flags['central-form-management'] = true;
    return $flags;
}
```

Test:
* Go to Jetpack > Forms and confirm you are on the form tab
* For any form in your list, click the three-dot action menu on its row, and click 'Duplicate'
* Confirm a duplicate form is created. 
* Confirm forms list is immediately updated and shows the new form. 

## Changelog
<!-- Check one of the boxes below. -->

- [x] Generate changelog entries for this PR (using AI).
