### PR TITLE
Fix changelog-auto-add workflow: use v1 action inputs and explicit token

### DIFF
--- a/.github/workflows/changelog-auto-add.yml
+++ b/.github/workflows/changelog-auto-add.yml
@@ -19,7 +19,6 @@ concurrency:
 permissions:
   contents: write
   pull-requests: read
-  id-token: write
 
 jobs:
   generate:
@@ -85,7 +84,8 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          direct_prompt: |
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          prompt: |
             You are generating changelog entries for a Jetpack monorepo PR.
 
             The following projects need changelog entries:
@@ -112,15 +112,16 @@ jobs:
             7. After generating all entries, commit them with the message "Add changelog entries." and push to the current branch.
             8. Do NOT modify any files other than changelog entries.
 
-          allowed_tools: |
-            Bash(git diff:*)
-            Bash(git log:*)
-            Bash(git add:*)
-            Bash(git commit:*)
-            Bash(git push:*)
-            Bash(pnpm jetpack changelog:*)
-            Bash(cat projects/*/changelog/*)
-            Bash(ls projects/*/changelog/*)
+          claude_args: >-
+            --allowedTools
+            "Bash(git diff:*)"
+            "Bash(git log:*)"
+            "Bash(git add:*)"
+            "Bash(git commit:*)"
+            "Bash(git push:*)"
+            "Bash(pnpm jetpack changelog:*)"
+            "Bash(cat projects/*/changelog/*)"
+            "Bash(ls projects/*/changelog/*)"
             Read
             Glob
             Grep


### PR DESCRIPTION
Follow-up fix for #47167 and #46533. The `changelog-auto-add` workflow fails when triggered due to deprecated inputs and OIDC token exchange failure.

## Proposed changes:

* Rename `direct_prompt` to `prompt` — the v0.x input is deprecated in `claude-code-action@v1` and silently ignored, so Claude receives no prompt.
* Replace `allowed_tools` with `claude_args` using `--allowedTools` flag — `allowed_tools` is also a deprecated v0.x input.
* Add explicit `github_token: ${{ secrets.GITHUB_TOKEN }}` so the action uses the workflow's built-in token instead of attempting an OIDC App token exchange (which fails with "Invalid OIDC token").
* Remove `id-token: write` permission since OIDC exchange is no longer used.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

N/A — CI/workflow config only.

## Jetpack product discussion

N/A

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

* Open a test PR with the `[x] Generate changelog entries` checkbox checked
* Confirm the workflow no longer shows "Unexpected input" warnings for `direct_prompt` and `allowed_tools`
* Confirm the workflow no longer fails with "Invalid OIDC token"

## Changelog

- [x] Generate changelog entries for this PR (using AI).