### PR TITLE
Harden changelog workflow and restore pre-push changelog check

### DIFF
--- a/.github/workflows/changelog-auto-add.yml
+++ b/.github/workflows/changelog-auto-add.yml
@@ -127,8 +127,8 @@ jobs:
                (Run this from the main working directory, which has full history.)
 
             2. For each project listed above, create a changelog file using the Write tool.
-               The file path must be: `pr-checkout/projects/<type>/<name>/changelog/${{ github.event.pull_request.head.ref }}`
-               (e.g., `pr-checkout/projects/packages/connection/changelog/${{ github.event.pull_request.head.ref }}`)
+               The file path must be: `pr-checkout/projects/<type>/<name>/changelog/pr-${{ github.event.pull_request.number }}`
+               (e.g., `pr-checkout/projects/packages/connection/changelog/pr-${{ github.event.pull_request.number }}`)
 
                The file format is:
                ```
@@ -158,7 +158,7 @@ jobs:
             7. After writing all changelog files, commit and push from the PR checkout:
                ```
                cd pr-checkout
-               git add 'projects/*/changelog/${{ github.event.pull_request.head.ref }}'
+               git add 'projects/*/*/changelog/pr-${{ github.event.pull_request.number }}'
                git commit -m "Add changelog entries."
                git push
                ```

--- a/.github/workflows/changelog-auto-add.yml
+++ b/.github/workflows/changelog-auto-add.yml
@@ -53,7 +53,6 @@ jobs:
         if: steps.checkbox.outputs.checked == 'true'
         uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.repository.default_branch }}
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/changelog-auto-add.yml
+++ b/.github/workflows/changelog-auto-add.yml
@@ -53,20 +53,26 @@ jobs:
         if: steps.checkbox.outputs.checked == 'true'
         uses: actions/checkout@v6
         with:
-          fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Fetch PR head SHA
+      - name: Deepen to merge base
         if: steps.checkbox.outputs.checked == 'true'
-        env:
-          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-        run: git fetch origin "$PR_HEAD_SHA"
+        uses: ./.github/actions/deepen-to-merge-base
+        with:
+          checkout: false
 
       - name: Setup tools
         if: steps.checkbox.outputs.checked == 'true'
         uses: ./.github/actions/tool-setup
-        with:
-          node: false
+
+      - name: Install monorepo dependencies
+        if: steps.checkbox.outputs.checked == 'true'
+        run: pnpm install
+
+      - name: Prepare changelogger
+        if: steps.checkbox.outputs.checked == 'true'
+        run: composer update
+        working-directory: projects/packages/changelogger
 
       - name: Check which projects need changelog entries
         if: steps.checkbox.outputs.checked == 'true'
@@ -75,18 +81,34 @@ jobs:
           BASE: ${{ github.event.pull_request.base.sha }}
           HEAD: ${{ github.event.pull_request.head.sha }}
         run: |
+          source .github/files/gh-funcs.sh
           PROJECTS=$(php tools/check-changelogger-use.php --list "$BASE" "$HEAD" 2>/dev/null || true)
           if [ -z "$PROJECTS" ]; then
             echo "needed=false" >> "$GITHUB_OUTPUT"
             echo "No projects need changelog entries."
           else
             echo "needed=true" >> "$GITHUB_OUTPUT"
-            echo "projects<<EOF" >> "$GITHUB_OUTPUT"
-            echo "$PROJECTS" >> "$GITHUB_OUTPUT"
-            echo "EOF" >> "$GITHUB_OUTPUT"
+            gh_set_output projects "$PROJECTS"
             echo "Projects needing changelog entries:"
             echo "$PROJECTS"
           fi
+
+      - name: Compute dependent plugins
+        if: steps.checkbox.outputs.checked == 'true' && steps.check.outputs.needed == 'true'
+        id: deps
+        env:
+          PROJECTS: ${{ steps.check.outputs.projects }}
+        run: |
+          source .github/files/gh-funcs.sh
+          DEPS=""
+          while IFS= read -r proj; do
+            [ -z "$proj" ] && continue
+            PLUGIN_DEPS=$(pnpm jetpack dependencies list "$proj" --add-dependents --no-dev --extra build 2>/dev/null | grep '^plugins/' || true)
+            if [ -n "$PLUGIN_DEPS" ]; then
+              DEPS="${DEPS}${proj}:${PLUGIN_DEPS}"$'\n'
+            fi
+          done <<< "$PROJECTS"
+          gh_set_output plugin_deps "$DEPS"
 
       - name: Checkout PR branch
         if: steps.checkbox.outputs.checked == 'true' && steps.check.outputs.needed == 'true'
@@ -110,31 +132,43 @@ jobs:
             The following projects need changelog entries:
             ${{ steps.check.outputs.projects }}
 
+            Pre-computed plugin dependents for each project (may be empty):
+            ${{ steps.deps.outputs.plugin_deps }}
+
             PR title: ${{ github.event.pull_request.title }}
+            PR number: ${{ github.event.pull_request.number }}
             PR branch: ${{ github.event.pull_request.head.ref }}
             PR description:
+            <pr-description>
             ${{ github.event.pull_request.body }}
+            </pr-description>
 
             The PR branch is checked out at `./pr-checkout`. Use that directory for
             writing changelog files and for committing/pushing. The main working
             directory contains the base branch (trunk) — use it only to read
             `composer.json` files for project metadata.
 
+            A changelogger binary is available at:
+            `$GITHUB_WORKSPACE/projects/packages/changelogger/vendor/bin/changelogger`
+
             Instructions:
             1. Read the diff for this PR to understand the changes:
                `git diff ${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }}`
                (Run this from the main working directory, which has full history.)
 
-            2. For each project listed above, create a changelog file using the Write tool.
-               The file path must be: `pr-checkout/projects/<type>/<name>/changelog/pr-${{ github.event.pull_request.number }}`
-               (e.g., `pr-checkout/projects/packages/connection/changelog/pr-${{ github.event.pull_request.number }}`)
-
-               The file format is:
+            2. For each project listed above, create a changelog entry by running the
+               changelogger CLI from the project's directory in the PR checkout:
                ```
-               Significance: <patch|minor|major>
-               Type: <type>
+               cd $GITHUB_WORKSPACE/pr-checkout/projects/<type>/<name>
+               $GITHUB_WORKSPACE/projects/packages/changelogger/vendor/bin/changelogger add \
+                 --no-interaction -s <significance> -t <type> -e "<entry>" -f "pr-${{ github.event.pull_request.number }}"
+               ```
 
-               <entry text>
+               For trivial/internal changes with no user-facing impact, use an empty
+               entry with a comment explaining why:
+               ```
+               $GITHUB_WORKSPACE/projects/packages/changelogger/vendor/bin/changelogger add \
+                 --no-interaction -s patch -t changed -e "" -c "reason" -f "pr-${{ github.event.pull_request.number }}"
                ```
 
             3. Follow these rules for changelog entries:
@@ -150,13 +184,15 @@ jobs:
                BUT `plugins/jetpack` uses custom types: `major`, `enhancement`, `compat`, `bugfix`, `other`.
                Check each project's `composer.json` at `.extra.changelogger.types` to confirm available types.
 
-            6. Check for indirect dependencies: read each project's `composer.json` to see if other projects
-               (especially plugins) depend on it. If a plugin bundles a package you're adding a changelog entry for,
-               also add a changelog entry for that plugin describing the downstream impact.
+            6. The pre-computed plugin dependents above show which plugins depend on each
+               project. If a plugin is listed as a dependent of a project you are adding
+               a changelog entry for, also add a changelog entry for that plugin
+               describing the downstream impact. Only add a plugin changelog entry if the
+               change is relevant to end users or site administrators.
 
-            7. After writing all changelog files, commit and push from the PR checkout:
+            7. After creating all changelog entries, commit and push from the PR checkout:
                ```
-               cd pr-checkout
+               cd $GITHUB_WORKSPACE/pr-checkout
                git add 'projects/*/*/changelog/pr-${{ github.event.pull_request.number }}'
                git commit -m "Add changelog entries."
                git push
@@ -164,6 +200,8 @@ jobs:
 
             8. Do NOT modify any files other than changelog entries.
 
+          # WARNING: Do not add tools that could execute code from the PR checkout.
+          # The PR checkout contains untrusted code. Only the base branch is trusted.
           claude_args: >-
             --allowedTools
             "Bash(git diff *)"
@@ -172,6 +210,7 @@ jobs:
             "Bash(git commit *)"
             "Bash(git push *)"
             "Bash(cd *)"
+            "Bash(*/changelogger *)"
             Read
             Write
             Glob

--- a/.github/workflows/changelog-auto-add.yml
+++ b/.github/workflows/changelog-auto-add.yml
@@ -2,9 +2,9 @@
 # "Generate changelog entries" checkbox is checked in the PR template.
 #
 # It triggers on pull_request_target so it has write permissions to push
-# commits to the PR branch. It's restricted to same-repo branches (no
-# forks) because the checkout runs local actions and scripts from the
-# PR head, which would be untrusted code in a fork context.
+# commits to the PR branch. For security, it checks out the default branch
+# (trunk) for all tool setup and scripts, and only fetches the PR head ref
+# for diffing — no code from the PR is ever executed.
 
 name: Changelog Auto-Add
 
@@ -44,14 +44,17 @@ jobs:
             echo "checked=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Checkout PR head branch
+      - name: Checkout default branch
         if: steps.checkbox.outputs.checked == 'true'
         uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.pull_request.head.ref }}
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.repository.default_branch }}
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Fetch PR head
+        if: steps.checkbox.outputs.checked == 'true'
+        run: git fetch origin ${{ github.event.pull_request.head.ref }}
 
       - name: Setup tools
         if: steps.checkbox.outputs.checked == 'true'
@@ -92,36 +95,63 @@ jobs:
             ${{ steps.check.outputs.projects }}
 
             PR title: ${{ github.event.pull_request.title }}
+            PR branch: ${{ github.event.pull_request.head.ref }}
             PR description:
             ${{ github.event.pull_request.body }}
 
             Instructions:
-            1. Read the diff for this PR to understand the changes: run `git diff ${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }}`
-            2. For each project listed above, generate an appropriate changelog entry using the `jetpack changelog add` command (via `pnpm jetpack changelog add`).
+            1. Read the diff for this PR to understand the changes:
+               `git diff ${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }}`
+
+            2. For each project listed above, create a changelog file using the Write tool.
+               The file path must be: `projects/<type>/<name>/changelog/${{ github.event.pull_request.head.ref }}`
+               (e.g., `projects/packages/connection/changelog/${{ github.event.pull_request.head.ref }}`)
+
+               The file format is:
+               ```
+               Significance: <patch|minor|major>
+               Type: <type>
+
+               <entry text>
+               ```
+
             3. Follow these rules for changelog entries:
                - Start with a capital letter and end with a period.
                - Use imperative mood (e.g., "Add feature." not "Added feature").
                - Use a "Component: description" prefix when the change is specific to a component within the project.
                - Do NOT use the package/project name itself as prefix for entries in that package.
                - Describe the change from a user's perspective.
-            4. For significance, use: `patch` for bug fixes and minor changes, `minor` for new features and enhancements, `major` for breaking changes.
+
+            4. For significance: `patch` for bug fixes and minor changes, `minor` for new features and enhancements, `major` for breaking changes.
+
             5. For type, most projects use: `security`, `added`, `changed`, `deprecated`, `removed`, `fixed`.
                BUT `plugins/jetpack` uses custom types: `major`, `enhancement`, `compat`, `bugfix`, `other`.
-            6. Use this exact command format for each project:
-               `pnpm jetpack changelog add <project-slug> -s <significance> -t <type> -e "<entry text>"`
-            7. After generating all entries, commit them with the message "Add changelog entries." and push to the current branch.
+               Check each project's `composer.json` at `.extra.changelogger.types` to confirm available types.
+
+            6. Check for indirect dependencies: read each project's `composer.json` to see if other projects
+               (especially plugins) depend on it. If a plugin bundles a package you're adding a changelog entry for,
+               also add a changelog entry for that plugin describing the downstream impact.
+
+            7. After writing all changelog files, switch to the PR branch and commit:
+               ```
+               git checkout ${{ github.event.pull_request.head.ref }}
+               git add 'projects/*/changelog/${{ github.event.pull_request.head.ref }}'
+               git commit -m "Add changelog entries."
+               git push origin ${{ github.event.pull_request.head.ref }}
+               ```
+
             8. Do NOT modify any files other than changelog entries.
 
           claude_args: >-
             --allowedTools
-            "Bash(git diff:*)"
-            "Bash(git log:*)"
-            "Bash(git add:*)"
-            "Bash(git commit:*)"
-            "Bash(git push:*)"
-            "Bash(pnpm jetpack changelog:*)"
-            "Bash(cat projects/*/changelog/*)"
-            "Bash(ls projects/*/changelog/*)"
+            "Bash(git diff *)"
+            "Bash(git log *)"
+            "Bash(git add *)"
+            "Bash(git commit *)"
+            "Bash(git push *)"
+            "Bash(git checkout *)"
+            "Bash(git fetch *)"
             Read
+            Write
             Glob
             Grep

--- a/.github/workflows/changelog-auto-add.yml
+++ b/.github/workflows/changelog-auto-add.yml
@@ -145,10 +145,9 @@ jobs:
 
             The PR branch is checked out at `./pr-checkout`. Use that directory for
             writing changelog files and for committing/pushing. The main working
-            directory contains the base branch (trunk) — use it only to read
-            `composer.json` files for project metadata.
+            directory contains the base branch (trunk).
 
-            A changelogger binary is available at:
+            The changelogger binary is available at:
             `$GITHUB_WORKSPACE/projects/packages/changelogger/vendor/bin/changelogger`
 
             Instructions:
@@ -210,7 +209,7 @@ jobs:
             "Bash(git commit *)"
             "Bash(git push *)"
             "Bash(cd *)"
-            "Bash(*/changelogger *)"
+            "Bash(*/projects/packages/changelogger/vendor/bin/changelogger *)"
             Read
             Write
             Glob

--- a/.github/workflows/changelog-auto-add.yml
+++ b/.github/workflows/changelog-auto-add.yml
@@ -58,7 +58,9 @@ jobs:
 
       - name: Fetch PR head SHA
         if: steps.checkbox.outputs.checked == 'true'
-        run: git fetch origin ${{ github.event.pull_request.head.sha }}
+        env:
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: git fetch origin "$PR_HEAD_SHA"
 
       - name: Setup tools
         if: steps.checkbox.outputs.checked == 'true'

--- a/.github/workflows/changelog-auto-add.yml
+++ b/.github/workflows/changelog-auto-add.yml
@@ -2,9 +2,13 @@
 # "Generate changelog entries" checkbox is checked in the PR template.
 #
 # It triggers on pull_request_target so it has write permissions to push
-# commits to the PR branch. For security, it checks out the default branch
-# (trunk) for all tool setup and scripts, and only fetches the PR head ref
-# for diffing — no code from the PR is ever executed.
+# commits to the PR branch.
+#
+# Security: the default checkout is the base branch (trunk). Tool setup,
+# the PHP detection script, and composer.json reads all come from trusted
+# code. The PR branch is checked out at a separate path (./pr-checkout)
+# only after all detection is done, and only so Claude can write changelog
+# files there and push. No code from the PR is ever executed.
 
 name: Changelog Auto-Add
 
@@ -52,9 +56,9 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Fetch PR head
+      - name: Fetch PR head SHA
         if: steps.checkbox.outputs.checked == 'true'
-        run: git fetch origin ${{ github.event.pull_request.head.ref }}
+        run: git fetch origin ${{ github.event.pull_request.head.sha }}
 
       - name: Setup tools
         if: steps.checkbox.outputs.checked == 'true'
@@ -82,6 +86,16 @@ jobs:
             echo "$PROJECTS"
           fi
 
+      - name: Checkout PR branch
+        if: steps.checkbox.outputs.checked == 'true' && steps.check.outputs.needed == 'true'
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          # DO NOT run any code in this checkout. Not even an `npm install`.
+          path: ./pr-checkout
+          token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Generate changelog entries with Claude
         if: steps.checkbox.outputs.checked == 'true' && steps.check.outputs.needed == 'true'
         uses: anthropics/claude-code-action@v1
@@ -99,13 +113,19 @@ jobs:
             PR description:
             ${{ github.event.pull_request.body }}
 
+            The PR branch is checked out at `./pr-checkout`. Use that directory for
+            writing changelog files and for committing/pushing. The main working
+            directory contains the base branch (trunk) — use it only to read
+            `composer.json` files for project metadata.
+
             Instructions:
             1. Read the diff for this PR to understand the changes:
                `git diff ${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }}`
+               (Run this from the main working directory, which has full history.)
 
             2. For each project listed above, create a changelog file using the Write tool.
-               The file path must be: `projects/<type>/<name>/changelog/${{ github.event.pull_request.head.ref }}`
-               (e.g., `projects/packages/connection/changelog/${{ github.event.pull_request.head.ref }}`)
+               The file path must be: `pr-checkout/projects/<type>/<name>/changelog/${{ github.event.pull_request.head.ref }}`
+               (e.g., `pr-checkout/projects/packages/connection/changelog/${{ github.event.pull_request.head.ref }}`)
 
                The file format is:
                ```
@@ -132,12 +152,12 @@ jobs:
                (especially plugins) depend on it. If a plugin bundles a package you're adding a changelog entry for,
                also add a changelog entry for that plugin describing the downstream impact.
 
-            7. After writing all changelog files, switch to the PR branch and commit:
+            7. After writing all changelog files, commit and push from the PR checkout:
                ```
-               git checkout ${{ github.event.pull_request.head.ref }}
+               cd pr-checkout
                git add 'projects/*/changelog/${{ github.event.pull_request.head.ref }}'
                git commit -m "Add changelog entries."
-               git push origin ${{ github.event.pull_request.head.ref }}
+               git push
                ```
 
             8. Do NOT modify any files other than changelog entries.
@@ -149,8 +169,7 @@ jobs:
             "Bash(git add *)"
             "Bash(git commit *)"
             "Bash(git push *)"
-            "Bash(git checkout *)"
-            "Bash(git fetch *)"
+            "Bash(cd *)"
             Read
             Write
             Glob

--- a/.github/workflows/changelog-auto-add.yml
+++ b/.github/workflows/changelog-auto-add.yml
@@ -1,8 +1,9 @@
 # This workflow auto-generates changelog entries using Claude when the
 # "Generate changelog entries" checkbox is checked in the PR template.
 #
-# It triggers on pull_request_target so it has write permissions to push
-# commits to the PR branch.
+# It triggers on pull_request_target so it can access repository secrets
+# (ANTHROPIC_API_KEY). Regular pull_request events for same-repo branches
+# don't expose secrets.
 #
 # Security: the default checkout is the base branch (trunk). Tool setup,
 # the PHP detection script, and composer.json reads all come from trusted

--- a/tools/js-tools/git-hooks/pre-push-hook.mjs
+++ b/tools/js-tools/git-hooks/pre-push-hook.mjs
@@ -265,6 +265,7 @@ async function checkChangelogFiles() {
 	}
 
 	// q, empty, EOF, or anything else → abort.
+	console.error( chalk.red( 'Abort selected' ) );
 	process.exitCode = 1;
 }
 

--- a/tools/js-tools/git-hooks/pre-push-hook.mjs
+++ b/tools/js-tools/git-hooks/pre-push-hook.mjs
@@ -1,7 +1,10 @@
 #!/usr/bin/env node
 
-import { spawn } from 'child_process';
+import { spawn, spawnSync } from 'child_process';
+import { createInterface } from 'node:readline';
+import { fileURLToPath } from 'url';
 import chalk from 'chalk';
+import isJetpackDraftMode from './jetpack-draft.mjs';
 
 /**
  * Exec a command and collect the lines.
@@ -99,5 +102,171 @@ async function checkFilenameCollisions() {
 	}
 }
 
+/**
+ * Prompt the user for input on stdin.
+ *
+ * @param {string} question - The prompt text.
+ * @return {Promise<string>} The user's response.
+ */
+function promptUser( question ) {
+	const rl = createInterface( {
+		input: process.stdin,
+		output: process.stderr,
+	} );
+	return new Promise( resolve => {
+		rl.question( question, answer => {
+			rl.close();
+			resolve( answer.trim().toLowerCase() );
+		} );
+	} );
+}
+
+/**
+ * Print "push again" message and set exit code 75 so git retries.
+ */
+function pushAgain() {
+	console.log(
+		chalk.green(
+			'\nChangelog file(s) committed! Ignore the error below and `git push` again to include them.'
+		)
+	);
+	process.exitCode = 75;
+}
+
+/**
+ * Checks if changelog files are needed and offers options to the developer.
+ */
+async function checkChangelogFiles() {
+	if ( process.exitCode !== 0 ) {
+		return;
+	}
+
+	console.log( chalk.green( 'Checking if changelog files are needed. Just a sec...' ) );
+
+	// Skip for release branches (e.g. boost/branch-1.3.0).
+	let currentBranch = spawnSync( 'git', [ 'branch', '--show-current' ] );
+	currentBranch = currentBranch.stdout.toString().trim();
+	if ( /.*\/branch-/.test( currentBranch ) ) {
+		console.log( chalk.green( 'Release branch detected. Skipping changelog test.' ) );
+		return;
+	}
+	if ( currentBranch === 'prerelease' ) {
+		console.log( chalk.green( 'Prerelease branch detected. Skipping changelog test.' ) );
+		return;
+	}
+
+	// Check if any changelog files are needed.
+	const needChangelog = spawnSync(
+		'tools/check-changelogger-use.php',
+		[ '--maybe-merge', 'origin/trunk', 'HEAD' ],
+		{
+			stdio: 'inherit',
+			cwd: fileURLToPath( new URL( '../../../', import.meta.url ) ),
+		}
+	);
+
+	if ( needChangelog.status === 0 ) {
+		console.log( chalk.green( 'Changelog check passed.' ) );
+		return;
+	}
+
+	if ( needChangelog.status === 8 ) {
+		pushAgain();
+		return;
+	}
+
+	if ( isJetpackDraftMode() ) {
+		console.log(
+			chalk.yellow(
+				"Allowing push because you're in draft mode. To exit draft mode, use `jetpack draft disable`."
+			)
+		);
+		return;
+	}
+
+	// Non-TTY: warn but don't block (scripts, CI, editor integrations).
+	if ( ! process.stdin.isTTY ) {
+		console.log(
+			chalk.yellow(
+				'Changelog entries may be needed. Check the "Generate changelog entries" box in the PR to auto-generate them.'
+			)
+		);
+		return;
+	}
+
+	// Actionable exit codes: 2 (missing), 4 (uncommitted), 6 (both), 10 (committed + still missing).
+	const actionable = [ 2, 4, 6, 10 ];
+	if ( ! actionable.includes( needChangelog.status ) ) {
+		console.log(
+			chalk.yellow(
+				`Unexpected changelog check exit code (${ needChangelog.status }). Allowing push.`
+			)
+		);
+		return;
+	}
+
+	// Interactive prompt.
+	const answer = await promptUser(
+		'\n' +
+			chalk.yellow( 'Changelog entries may be needed for this push.\n' ) +
+			'\n' +
+			'  a - Add changelog entries now (interactive)\n' +
+			'  p - Push anyway (let CI auto-generate via PR checkbox)\n' +
+			'  q - Abort push\n' +
+			'\nWhat would you like to do? [a/p/q] '
+	);
+
+	if ( answer === 'p' ) {
+		console.log(
+			chalk.green(
+				'Pushing without changelog entries. Check the "Generate changelog entries" box in the PR to auto-generate them.'
+			)
+		);
+		return;
+	}
+
+	if ( answer === 'a' ) {
+		const autoChangelog = spawnSync( 'pnpm', [ 'jetpack', 'changelog', 'add' ], {
+			stdio: 'inherit',
+		} );
+
+		if ( autoChangelog.status === 0 ) {
+			const changelogFiles = await spawnAndReadStdout( 'git', [
+				'-c',
+				'core.quotepath=off',
+				'diff',
+				'--name-only',
+				'--diff-filter=A',
+				'--cached',
+			] );
+
+			const filesToCommit = changelogFiles.filter( file =>
+				/^projects\/[^/]+\/[^/]+\/changelog\//.test( file )
+			);
+
+			if ( filesToCommit.length > 0 ) {
+				const commitFiles = spawnSync( 'git', [
+					'commit',
+					...filesToCommit,
+					'-m',
+					'Add changelog entries.',
+				] );
+				if ( commitFiles.status === 0 ) {
+					pushAgain();
+					return;
+				}
+			}
+		}
+
+		// If we get here, something went wrong with the interactive flow.
+		process.exitCode = 1;
+		return;
+	}
+
+	// q, empty, EOF, or anything else → abort.
+	process.exitCode = 1;
+}
+
 process.exitCode = 0;
 await checkFilenameCollisions();
+await checkChangelogFiles();

--- a/tools/js-tools/git-hooks/pre-push-hook.mjs
+++ b/tools/js-tools/git-hooks/pre-push-hook.mjs
@@ -197,11 +197,12 @@ async function checkChangelogFiles() {
 	// Actionable exit codes: 2 (missing), 4 (uncommitted), 6 (both), 10 (committed + still missing).
 	const actionable = [ 2, 4, 6, 10 ];
 	if ( ! actionable.includes( needChangelog.status ) ) {
-		console.log(
-			chalk.yellow(
-				`Unexpected changelog check exit code (${ needChangelog.status }). Allowing push.`
+		console.error(
+			chalk.red(
+				`Changelog check failed with unexpected exit code (${ needChangelog.status }). Aborting push.`
 			)
 		);
+		process.exitCode = 1;
 		return;
 	}
 


### PR DESCRIPTION
See #46533

## Proposed changes:

The changelog-auto-add workflow (#46533) had two problems: it executed code from the PR branch (tool-setup action, PHP scripts, pnpm install), and the Claude tool permissions were broken (`:*` syntax, missing `Write` tool).

This PR fixes both and restores the pre-push changelog check that was removed in #46533:

**Workflow hardening (`changelog-auto-add.yml`):**
- Check out trunk (default branch) for tool-setup and detection scripts instead of the PR branch — no code from the PR is ever executed
- Use `deepen-to-merge-base` action instead of `fetch-depth: 0` for efficient history fetching
- Enable node/pnpm and prepare the changelogger binary from the base checkout (trusted code)
- Claude creates changelog entries via the `changelogger add --no-interaction` CLI instead of manually writing files, matching the pattern in `tools/cli/commands/changelog.js`
- Pre-compute plugin dependents using `pnpm jetpack dependencies list` so Claude doesn't guess at indirect dependencies
- Fix `allowedTools` patterns (`:*` → space syntax) and add `Write` (fallback) and `*/changelogger` tool permissions
- Use `gh_set_output` for multi-line step outputs instead of raw `<<EOF` heredoc
- Delimit PR description in prompt with `<pr-description>` tags
- Add security warning comment on `claude_args` (don't add tools that execute PR code)
- Include trivial change format (`-e "" -c "reason"`) and plugin relevance gate in prompt

**Restored pre-push hook (`pre-push-hook.mjs`):**
- Restore `checkChangelogFiles()` with a new interactive UX offering three choices:
  - `a` — Add changelog entries now (runs `pnpm jetpack changelog add` interactively)
  - `p` — Push anyway (let CI auto-generate via the PR checkbox)
  - `q` — Abort push
- Non-TTY environments (scripts, CI, editors) get a warning but are never blocked
- Skip check for release branches, prerelease branch, and draft mode
- No ASCII art banner — simple chalk message instead

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

N/A — tooling change only.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

**Pre-push hook:**
1. Check out this branch and push to a branch that touches a project without changelog entries — verify the interactive prompt appears with a/p/q options
2. Test `p` — push should proceed with a reminder message
3. Test `q` — push should abort
4. Test `a` — interactive changelog add should run, commit, and print "push again" message
5. Non-TTY: `echo "" | node tools/js-tools/git-hooks/pre-push-hook.mjs` — should warn but not block
6. Draft mode: `touch .jetpack-draft` then push — should allow with warning

**CI workflow:**
1. Open a test PR with the "Generate changelog entries" checkbox checked
2. Verify tool-setup runs from trunk (check the checkout step in the Actions log)
3. Verify Claude uses the changelogger CLI to create entries and commits them to the PR branch

## Changelog

- [ ] Generate changelog entries for this PR (using AI).
