### PR TITLE
Skip PHP lint, Phan, and typecheck on non-relevant PRs

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -63,6 +63,9 @@ jobs:
       # Whether any miscellaneous files related to CSS linting have changed.
       misc_css: ${{ steps.filter.outputs.misc == 'true' || steps.filter.outputs.misc_css == 'true' }}
 
+      # Whether any miscellaneous files related to Phan static analysis have changed.
+      misc_phan: ${{ steps.filter.outputs.misc == 'true' || steps.filter.outputs.misc_phan == 'true' }}
+
       # JSON string holding an array of files in phpcs-excludelist.json that have changed.
       php_excluded_files: ${{ steps.filterPHP.outputs.php_excluded_files }}
 
@@ -178,6 +181,12 @@ jobs:
               - stylelint.config.mjs
               - '**/stylelint.config.{js,mjs,cjs}'
               - tools/js-tools/stylelint.config.base.mjs
+            misc_phan:
+              # If Phan config or the CLI that runs it changed, re-run static analysis.
+              - '.phan/**'
+              - '**/.phan/**'
+              - 'tools/cli/**'
+              - 'projects/packages/phan-plugins/**'
             misc_excludelist:
               - 'tools/cleanup-excludelists.sh'
               - 'tools/js-tools/check-excludelist-diff.js'
@@ -657,7 +666,7 @@ jobs:
     name: Static analysis
     runs-on: ubuntu-latest
     needs: changed_files
-    if: github.event_name == 'push' || needs.changed_files.outputs.php == 'true' || needs.changed_files.outputs.misc_php == 'true'
+    if: github.event_name == 'push' || needs.changed_files.outputs.php == 'true' || needs.changed_files.outputs.misc_phan == 'true'
     timeout-minutes: 25 # 2025-11-20: Up to about 10 minutes now that we're running against the old WP and Woo stubs too.
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -632,18 +632,15 @@ jobs:
     name: Type checking
     runs-on: ubuntu-latest
     needs: changed_files
+    if: github.event_name == 'push' || needs.changed_files.outputs.js == 'true' || needs.changed_files.outputs.misc_js == 'true'
     timeout-minutes: 10 # 2025-11-20: Takes around 3 minutes.
     steps:
       - uses: actions/checkout@v6
-        if: github.event_name == 'push' || needs.changed_files.outputs.js == 'true' || needs.changed_files.outputs.misc_js == 'true'
       - name: Setup tools
-        if: github.event_name == 'push' || needs.changed_files.outputs.js == 'true' || needs.changed_files.outputs.misc_js == 'true'
         uses: ./.github/actions/tool-setup
       - name: Pnpm install
-        if: github.event_name == 'push' || needs.changed_files.outputs.js == 'true' || needs.changed_files.outputs.misc_js == 'true'
         run: pnpm install
       - name: Run type checking
-        if: github.event_name == 'push' || needs.changed_files.outputs.js == 'true' || needs.changed_files.outputs.misc_js == 'true'
         # Can't just `pnpm typecheck` here, GitHub won't match the output files correctly
         # and unfortunately https://github.com/microsoft/TypeScript/issues/36221 is still open.
         run: |
@@ -660,18 +657,15 @@ jobs:
     name: Static analysis
     runs-on: ubuntu-latest
     needs: changed_files
+    if: github.event_name == 'push' || needs.changed_files.outputs.php == 'true' || needs.changed_files.outputs.misc_php == 'true'
     timeout-minutes: 25 # 2025-11-20: Up to about 10 minutes now that we're running against the old WP and Woo stubs too.
     steps:
       - uses: actions/checkout@v6
-        if: github.event_name == 'push' || needs.changed_files.outputs.php == 'true' || needs.changed_files.outputs.misc_php == 'true'
       - name: Setup tools
-        if: github.event_name == 'push' || needs.changed_files.outputs.php == 'true' || needs.changed_files.outputs.misc_php == 'true'
         uses: ./.github/actions/tool-setup
       - name: Pnpm install
-        if: github.event_name == 'push' || needs.changed_files.outputs.php == 'true' || needs.changed_files.outputs.misc_php == 'true'
         run: pnpm install
       - name: Add back removed packages in case of a release branch.
-        if: github.event_name == 'push' || needs.changed_files.outputs.php == 'true' || needs.changed_files.outputs.misc_php == 'true'
         run: |
           echo "Checking for non-mirrored require-dev packages, in case this is testing a release branch"
           for FILE in projects/*/*/composer.json; do
@@ -687,10 +681,8 @@ jobs:
             fi
           done
       - name: Run phan
-        if: github.event_name == 'push' || needs.changed_files.outputs.php == 'true' || needs.changed_files.outputs.misc_php == 'true'
         run: pnpm jetpack phan --all -v --update-baseline --format github
       - name: Run phan for previous WP version and old Woo
-        if: github.event_name == 'push' || needs.changed_files.outputs.php == 'true' || needs.changed_files.outputs.misc_php == 'true'
         env:
           # Don't bother complaining about unused suppressions that may be used with the newer stubs. See .phan/config.base.php for how this gets applied.
           NO_PHAN_UNUSED_SUPPRESSION: 1
@@ -699,7 +691,6 @@ jobs:
           # Don't re-update baselines here, only check.
           pnpm jetpack phan --all -v --format github
       - name: Check baselines
-        if: github.event_name == 'push' || needs.changed_files.outputs.php == 'true' || needs.changed_files.outputs.misc_php == 'true'
         run: |
           # Anything changed? (with a side of printing the diff)
           if git diff --exit-code --ignore-matching-lines='^    // ' -- .phan/baseline.php '*/.phan/baseline.php'; then

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -182,6 +182,9 @@ jobs:
               - '**/stylelint.config.{js,mjs,cjs}'
               - tools/js-tools/stylelint.config.base.mjs
             misc_phan:
+              # If root composer changed, there may be new stub packages.
+              - 'composer.json'
+              - 'composer.lock'
               # If Phan config or the CLI that runs it changed, re-run static analysis.
               - '.phan/**'
               - '**/.phan/**'

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -223,7 +223,9 @@ jobs:
 
   ### Runs `php -l` over all PHP files, in all relevant PHP versions
   # Local equivalent: `composer php:lint`
-  # We don't use an `if` here because GH Actions had issues expanding the name when we did. See also:
+  # We can't use a job-level `if` because GH Actions doesn't expand matrix names for skipped jobs,
+  # which breaks required status checks. Instead, we gate at the step level so the matrix entries
+  # always report a status. See also:
   #    - https://github.com/Automattic/jetpack/pull/17940
   #    - https://github.com/Automattic/jetpack/pull/18979
   php_lint:
@@ -241,14 +243,17 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        if: github.event_name == 'push' || needs.changed_files.outputs.php == 'true' || needs.changed_files.outputs.misc_php == 'true'
 
       - name: Setup tools
+        if: github.event_name == 'push' || needs.changed_files.outputs.php == 'true' || needs.changed_files.outputs.misc_php == 'true'
         uses: ./.github/actions/tool-setup
         with:
           php: ${{ matrix.php-versions }}
           node: false
 
       - name: Install dependencies
+        if: github.event_name == 'push' || needs.changed_files.outputs.php == 'true' || needs.changed_files.outputs.misc_php == 'true'
         run: |
           # Install stuff ignoring platform reqs.
           composer install --ignore-platform-reqs
@@ -257,6 +262,7 @@ jobs:
           composer remove --dev sirbrillig/phpcs-changed automattic/jetpack-codesniffer automattic/jetpack-phan-plugins phan/phan
 
       - name: Run linter
+        if: github.event_name == 'push' || needs.changed_files.outputs.php == 'true' || needs.changed_files.outputs.misc_php == 'true'
         run: |
           echo "::add-matcher::.github/matchers/php-lint-problem-matcher.json"
           composer php:lint -- --checkstyle
@@ -625,14 +631,19 @@ jobs:
   typecheck:
     name: Type checking
     runs-on: ubuntu-latest
+    needs: changed_files
     timeout-minutes: 10 # 2025-11-20: Takes around 3 minutes.
     steps:
       - uses: actions/checkout@v6
+        if: github.event_name == 'push' || needs.changed_files.outputs.js == 'true' || needs.changed_files.outputs.misc_js == 'true'
       - name: Setup tools
+        if: github.event_name == 'push' || needs.changed_files.outputs.js == 'true' || needs.changed_files.outputs.misc_js == 'true'
         uses: ./.github/actions/tool-setup
       - name: Pnpm install
+        if: github.event_name == 'push' || needs.changed_files.outputs.js == 'true' || needs.changed_files.outputs.misc_js == 'true'
         run: pnpm install
       - name: Run type checking
+        if: github.event_name == 'push' || needs.changed_files.outputs.js == 'true' || needs.changed_files.outputs.misc_js == 'true'
         # Can't just `pnpm typecheck` here, GitHub won't match the output files correctly
         # and unfortunately https://github.com/microsoft/TypeScript/issues/36221 is still open.
         run: |
@@ -648,14 +659,19 @@ jobs:
   phan:
     name: Static analysis
     runs-on: ubuntu-latest
+    needs: changed_files
     timeout-minutes: 25 # 2025-11-20: Up to about 10 minutes now that we're running against the old WP and Woo stubs too.
     steps:
       - uses: actions/checkout@v6
+        if: github.event_name == 'push' || needs.changed_files.outputs.php == 'true' || needs.changed_files.outputs.misc_php == 'true'
       - name: Setup tools
+        if: github.event_name == 'push' || needs.changed_files.outputs.php == 'true' || needs.changed_files.outputs.misc_php == 'true'
         uses: ./.github/actions/tool-setup
       - name: Pnpm install
+        if: github.event_name == 'push' || needs.changed_files.outputs.php == 'true' || needs.changed_files.outputs.misc_php == 'true'
         run: pnpm install
       - name: Add back removed packages in case of a release branch.
+        if: github.event_name == 'push' || needs.changed_files.outputs.php == 'true' || needs.changed_files.outputs.misc_php == 'true'
         run: |
           echo "Checking for non-mirrored require-dev packages, in case this is testing a release branch"
           for FILE in projects/*/*/composer.json; do
@@ -671,8 +687,10 @@ jobs:
             fi
           done
       - name: Run phan
+        if: github.event_name == 'push' || needs.changed_files.outputs.php == 'true' || needs.changed_files.outputs.misc_php == 'true'
         run: pnpm jetpack phan --all -v --update-baseline --format github
       - name: Run phan for previous WP version and old Woo
+        if: github.event_name == 'push' || needs.changed_files.outputs.php == 'true' || needs.changed_files.outputs.misc_php == 'true'
         env:
           # Don't bother complaining about unused suppressions that may be used with the newer stubs. See .phan/config.base.php for how this gets applied.
           NO_PHAN_UNUSED_SUPPRESSION: 1
@@ -681,6 +699,7 @@ jobs:
           # Don't re-update baselines here, only check.
           pnpm jetpack phan --all -v --format github
       - name: Check baselines
+        if: github.event_name == 'push' || needs.changed_files.outputs.php == 'true' || needs.changed_files.outputs.misc_php == 'true'
         run: |
           # Anything changed? (with a side of printing the diff)
           if git diff --exit-code --ignore-matching-lines='^    // ' -- .phan/baseline.php '*/.phan/baseline.php'; then

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -255,17 +255,17 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
-        if: github.event_name == 'push' || needs.changed_files.outputs.php == 'true' || needs.changed_files.outputs.misc_php == 'true'
+        if: &php_lint_cond github.event_name == 'push' || needs.changed_files.outputs.php == 'true' || needs.changed_files.outputs.misc_php == 'true'
 
       - name: Setup tools
-        if: github.event_name == 'push' || needs.changed_files.outputs.php == 'true' || needs.changed_files.outputs.misc_php == 'true'
+        if: *php_lint_cond
         uses: ./.github/actions/tool-setup
         with:
           php: ${{ matrix.php-versions }}
           node: false
 
       - name: Install dependencies
-        if: github.event_name == 'push' || needs.changed_files.outputs.php == 'true' || needs.changed_files.outputs.misc_php == 'true'
+        if: *php_lint_cond
         run: |
           # Install stuff ignoring platform reqs.
           composer install --ignore-platform-reqs
@@ -274,7 +274,7 @@ jobs:
           composer remove --dev sirbrillig/phpcs-changed automattic/jetpack-codesniffer automattic/jetpack-phan-plugins phan/phan
 
       - name: Run linter
-        if: github.event_name == 'push' || needs.changed_files.outputs.php == 'true' || needs.changed_files.outputs.misc_php == 'true'
+        if: *php_lint_cond
         run: |
           echo "::add-matcher::.github/matchers/php-lint-problem-matcher.json"
           composer php:lint -- --checkstyle


### PR DESCRIPTION
Fixes MONOREP-363

## Proposed changes:

* Gate steps in the `php_lint`, `phan`, and `typecheck` jobs behind step-level `if` conditions that check whether PHP or JS/TS files actually changed.
* The jobs themselves still run unconditionally (so matrix entries and required status checks report a status), but skip the expensive steps (checkout, setup, install, lint) when no relevant files were modified.
* Add `needs: changed_files` to `phan` and `typecheck` jobs so they can access the path-filter outputs.
* Update the `php_lint` comment block to explain the step-level gating approach.

This extends the existing pattern used by PHPCS, ESLint, Stylelint, and other jobs in the same workflow. Step-level gating avoids the [GitHub Actions bug](https://github.com/actions/runner/issues/952) where skipped matrix jobs don't expand their names, breaking required checks.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

N/A for all three -- this is a CI-only change to workflow gating logic.

## Jetpack product discussion

N/A

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

1. Observe the CI checks on this PR. Since it only modifies `.github/workflows/linting.yml` (no PHP or JS/TS files), the `PHP lint (X.Y)`, `Static analysis`, and `Type checking` jobs should all pass quickly (~seconds) with skipped steps.
2. Confirm all required status checks still report as passing.
3. For a separate PR that touches `.php` files, confirm PHP lint and Phan still run their full steps.
4. For a separate PR that touches `.ts` files, confirm Type checking still runs its full steps.

**Test PR:** #47178 is a child PR (against this branch) that only adds a workflow comment -- no PHP/JS files. Check its CI to verify the gated steps skip quickly.

## Changelog

- [x] Generate changelog entries for this PR (using AI).
