### PR TITLE
Forms: Fix inspector sidebar FOUC on initial page load

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-wp-build-sidebar-fouc
+++ b/projects/packages/forms/changelog/fix-forms-wp-build-sidebar-fouc
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Dashboard: Fix flash of unstyled response data in the inspector sidebar on initial page load.

--- a/projects/packages/forms/routes/responses/route.tsx
+++ b/projects/packages/forms/routes/responses/route.tsx
@@ -18,7 +18,7 @@ export const route = {
 	 *
 	 * @return                         - Whether to show the inspector panel.
 	 */
-	inspector: async ( { search }: { search: { responseIds?: string[] } } ) => {
+	inspector: ( { search }: { search: { responseIds?: string[] } } ) => {
 		return !! ( search?.responseIds && search.responseIds.length === 1 );
 	},
 
@@ -52,6 +52,7 @@ export const route = {
 			status,
 			orderby: 'date',
 			order: 'desc',
+			fields_format: 'collection',
 		} );
 
 		// Preload global header tab counts.


### PR DESCRIPTION
Fixes FORMS-591

## Proposed changes:

* Add `fields_format: 'collection'` to the route loader's `getEntityRecords` preload query, so the inspector renders the collection-format field layout (with icons, separators, and correct label colors) on the very first paint instead of briefly showing the legacy key-value layout.
* Remove unnecessary `async` from the `inspector` predicate since it only performs a synchronous check.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

* Go to the wp-build dashboard
* Navigate to a response by clicking on one — the inspector sidebar should open with properly styled fields (icons, separators between fields, gray label text) immediately, with no flash of unstyled content.
* Reload the page
* Check that the sidebar content is rendered correctly from the start
* Alternatively, load the page from an email notification link — the inspector should render correctly on first paint.

| Before | After |
| - | - |
| <img width="488" height="813" alt="Screenshot from 2026-02-17 18-10-24" src="https://github.com/user-attachments/assets/0e477bd5-124f-4223-87bc-36d8a4b8c741" /> | <img width="414" height="668" alt="Screenshot from 2026-02-17 19-38-41" src="https://github.com/user-attachments/assets/3400622e-eb9b-42bd-93e8-0490575ccd04" /> |



## Changelog

- [ ] Generate changelog entries for this PR (using AI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)