### PR TITLE
FORNO-188: Image Studio: Add jetpack.ai.imageGenerationHandler filter for social-media entry point

### DIFF
--- a/projects/js-packages/components/changelog/fix-navigator-modal-dismisser-guard
+++ b/projects/js-packages/components/changelog/fix-navigator-modal-dismisser-guard
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+NavigatorModal: Guard against WordPress Modal dismisser mechanism to prevent the modal from being closed when an external modal (e.g. Image Studio) opens.

--- a/projects/js-packages/components/components/navigator-modal/index.tsx
+++ b/projects/js-packages/components/components/navigator-modal/index.tsx
@@ -1,6 +1,6 @@
 import { Modal, Navigator } from '@wordpress/components';
 import clsx from 'clsx';
-import { useContext } from 'react';
+import { useCallback, useContext } from 'react';
 import { NavigatorModalContext } from './context.ts';
 import { Screen } from './screen.tsx';
 import './styles.scss';
@@ -23,16 +23,31 @@ function InternalNavigatorModal( {
 	className,
 	...props
 }: Omit< ModalProps, 'onRequestClose' > ) {
-	const context = useContext( NavigatorModalContext );
+	const { onClose, initialPath } = useContext( NavigatorModalContext );
+
+	// WordPress Modal's dismisser mechanism (ModalContext) calls onRequestClose()
+	// without arguments when another non-nested Modal mounts. We guard against
+	// this so that external modals (e.g. Image Studio) don't destroy this one.
+	// User-initiated closes (Escape, close button) always pass an event.
+	// The NavigatorModal's own Header/Footer close buttons call context.onClose
+	// directly and are unaffected by this guard.
+	const onRequestClose = useCallback(
+		( event?: React.SyntheticEvent ) => {
+			if ( event ) {
+				onClose?.();
+			}
+		},
+		[ onClose ]
+	);
 
 	return (
 		<Modal
 			__experimentalHideHeader
-			onRequestClose={ context.onClose }
+			onRequestClose={ onRequestClose }
 			className={ clsx( 'jp-navigator-modal', className ) }
 			{ ...props }
 		>
-			<Navigator initialPath={ context.initialPath } className="jp-navigator-modal__navigator">
+			<Navigator initialPath={ initialPath } className="jp-navigator-modal__navigator">
 				{ children }
 			</Navigator>
 		</Modal>

--- a/projects/js-packages/components/components/navigator-modal/test/component.tsx
+++ b/projects/js-packages/components/components/navigator-modal/test/component.tsx
@@ -1,0 +1,99 @@
+/* eslint-disable react/jsx-no-bind */
+
+import { jest } from '@jest/globals';
+import { render, screen } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
+
+// ESM-compatible mock - must be before dynamic import
+jest.unstable_mockModule( '@wordpress/components', () => ( {
+	Modal: ( {
+		children,
+		onRequestClose,
+	}: {
+		children: React.ReactNode;
+		onRequestClose?: ( event?: React.SyntheticEvent ) => void;
+	} ) => (
+		<div data-testid="mock-modal">
+			<button data-testid="close-with-event" onClick={ e => onRequestClose?.( e ) }>
+				Close with event
+			</button>
+			<button data-testid="close-without-event" onClick={ () => onRequestClose?.() }>
+				Close without event
+			</button>
+			{ children }
+		</div>
+	),
+	Navigator: ( { children }: { children: React.ReactNode } ) => (
+		<div data-testid="mock-navigator">{ children }</div>
+	),
+	Button: ( { children, onClick }: { children: React.ReactNode; onClick?: () => void } ) => (
+		<button onClick={ onClick }>{ children }</button>
+	),
+	Flex: ( { children }: { children: React.ReactNode } ) => <div>{ children }</div>,
+	FlexBlock: ( { children }: { children: React.ReactNode } ) => <div>{ children }</div>,
+	FlexItem: ( { children }: { children: React.ReactNode } ) => <div>{ children }</div>,
+	useNavigator: () => ( { goBack: jest.fn(), goTo: jest.fn(), location: { path: '/' } } ),
+} ) );
+
+// Dynamic import after mock setup
+const { NavigatorModal } = await import( '../index.tsx' );
+
+describe( 'NavigatorModal', () => {
+	it( 'renders children within the modal', () => {
+		render(
+			<NavigatorModal>
+				<div data-testid="test-content">Test Content</div>
+			</NavigatorModal>
+		);
+
+		expect( screen.getByTestId( 'mock-modal' ) ).toBeInTheDocument();
+		expect( screen.getByTestId( 'test-content' ) ).toBeInTheDocument();
+	} );
+
+	describe( 'onRequestClose guard', () => {
+		it( 'calls onClose when user-initiated close passes an event', async () => {
+			const user = userEvent.setup();
+			const mockOnClose = jest.fn();
+
+			render(
+				<NavigatorModal onClose={ mockOnClose }>
+					<div>Content</div>
+				</NavigatorModal>
+			);
+
+			await user.click( screen.getByTestId( 'close-with-event' ) );
+
+			expect( mockOnClose ).toHaveBeenCalledTimes( 1 );
+		} );
+
+		it( 'does not call onClose when WordPress Modal dismisser calls onRequestClose without an event', async () => {
+			const user = userEvent.setup();
+			const mockOnClose = jest.fn();
+
+			render(
+				<NavigatorModal onClose={ mockOnClose }>
+					<div>Content</div>
+				</NavigatorModal>
+			);
+
+			await user.click( screen.getByTestId( 'close-without-event' ) );
+
+			expect( mockOnClose ).not.toHaveBeenCalled();
+		} );
+
+		it( 'does not crash when onClose is not provided', async () => {
+			const user = userEvent.setup();
+
+			render(
+				<NavigatorModal>
+					<div>Content</div>
+				</NavigatorModal>
+			);
+
+			// Should not throw when clicking close without onClose handler
+			await user.click( screen.getByTestId( 'close-with-event' ) );
+
+			expect( screen.getByTestId( 'mock-modal' ) ).toBeInTheDocument();
+		} );
+	} );
+} );

--- a/projects/packages/publicize/_inc/components/media-section-v2/index.tsx
+++ b/projects/packages/publicize/_inc/components/media-section-v2/index.tsx
@@ -9,6 +9,7 @@ import { useAnalytics } from '@automattic/jetpack-shared-extension-utils';
 import { MediaUpload } from '@wordpress/block-editor';
 import { BaseControl, Button, ExternalLink } from '@wordpress/components';
 import { useCallback, useMemo, useReducer, useRef } from '@wordpress/element';
+import { applyFilters } from '@wordpress/hooks';
 import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
 import useFeaturedImage from '../../hooks/use-featured-image';
@@ -253,6 +254,41 @@ export default function MediaSectionV2( {
 		[ updateMediaOptions, imageGeneratorSettings, recordEvent, analyticsData ]
 	);
 
+	// Callback for external handlers to update the selected image
+	const onImageSelectCallback = useCallback(
+		( image: { id: number; url: string; mime?: string } ) => {
+			// Update media without toggling modal (custom handler manages its own UI)
+			updateMediaOptions( {
+				media_source: 'media-library',
+				attached_media: [ { id: image.id, url: image.url, type: image.mime || 'image/png' } ],
+				image_generator_settings: { ...imageGeneratorSettings, enabled: false },
+			} );
+			recordEvent( 'jetpack_social_media_source_changed', {
+				...analyticsData,
+				source: 'ai-image',
+			} );
+		},
+		[ updateMediaOptions, imageGeneratorSettings, recordEvent, analyticsData ]
+	);
+
+	// Filter to allow external plugins (e.g., Image Studio) to replace the image generation flow
+	const imageGenerationHandler = useMemo( () => {
+		const handler = applyFilters( 'jetpack.ai.imageGenerationHandler', null, {
+			entryPoint: 'social-media',
+			onImageSelect: onImageSelectCallback,
+		} );
+		// Runtime type check: only accept functions
+		return typeof handler === 'function' ? ( handler as () => void ) : null;
+	}, [ onImageSelectCallback ] );
+
+	const handleAiImageClick = useCallback( () => {
+		if ( imageGenerationHandler ) {
+			imageGenerationHandler();
+		} else {
+			toggleShowAiImageModal();
+		}
+	}, [ imageGenerationHandler, toggleShowAiImageModal ] );
+
 	const renderMediaUpload = useCallback( ( { open }: { open: () => void } ) => {
 		openMediaLibraryRef.current = open;
 		return null;
@@ -366,7 +402,7 @@ export default function MediaSectionV2( {
 								currentSource={ currentSource }
 								onSelect={ handleSourceSelect }
 								onMediaLibraryClick={ handleMediaLibraryClick }
-								onAiImageClick={ toggleShowAiImageModal }
+								onAiImageClick={ handleAiImageClick }
 								disabled={ disabled }
 								featuredImageId={ featuredImageId }
 							>
@@ -406,7 +442,7 @@ export default function MediaSectionV2( {
 							currentSource={ currentSource }
 							onSelect={ handleSourceSelect }
 							onMediaLibraryClick={ handleMediaLibraryClick }
-							onAiImageClick={ toggleShowAiImageModal }
+							onAiImageClick={ handleAiImageClick }
 							disabled={ disabled }
 							featuredImageId={ featuredImageId }
 						/>

--- a/projects/packages/publicize/_inc/components/media-section-v2/test/index.test.tsx
+++ b/projects/packages/publicize/_inc/components/media-section-v2/test/index.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import MediaSectionV2 from '..';
 import useFeaturedImage from '../../../hooks/use-featured-image';
@@ -11,6 +11,7 @@ import useSigPreview from '../../../hooks/use-sig-preview';
 const mockUpdateJetpackSocialOptions = jest.fn();
 const mockRecordEvent = jest.fn();
 const mockOpenUnifiedModal = jest.fn();
+const mockApplyFilters = jest.fn();
 
 // Mock the social store to prevent importing @wordpress/editor
 jest.mock( '../../../social-store', () => ( {
@@ -87,8 +88,12 @@ jest.mock( '../../../utils', () => ( {
 } ) );
 
 jest.mock( '@automattic/jetpack-ai-client', () => ( {
-	GeneralPurposeImage: () => null,
+	GeneralPurposeImage: () => <div data-testid="ai-image-modal">AI Image Modal</div>,
 	AiSVG: 'svg',
+} ) );
+
+jest.mock( '@wordpress/hooks', () => ( {
+	applyFilters: ( ...args: unknown[] ) => mockApplyFilters( ...args ),
 } ) );
 
 jest.mock( '@wordpress/block-editor', () => ( {
@@ -393,6 +398,135 @@ describe( 'MediaSectionV2', () => {
 
 			expect( screen.getByRole( 'button', { name: 'Replace' } ) ).toBeDisabled();
 			expect( screen.getByRole( 'button', { name: 'Remove' } ) ).toBeDisabled();
+		} );
+	} );
+
+	describe( 'imageGenerationHandler filter', () => {
+		it( 'should call applyFilters with correct arguments', () => {
+			mockApplyFilters.mockReturnValue( null );
+
+			render( <MediaSectionV2 /> );
+
+			expect( mockApplyFilters ).toHaveBeenCalledWith(
+				'jetpack.ai.imageGenerationHandler',
+				null,
+				expect.objectContaining( {
+					entryPoint: 'social-media',
+					onImageSelect: expect.any( Function ),
+				} )
+			);
+		} );
+
+		it( 'should open default AI modal when no filter handler is registered', async () => {
+			const user = userEvent.setup();
+			mockApplyFilters.mockReturnValue( null );
+
+			render( <MediaSectionV2 /> );
+
+			// Modal should not be visible initially
+			expect( screen.queryByTestId( 'ai-image-modal' ) ).not.toBeInTheDocument();
+
+			// Open dropdown
+			await user.click( screen.getByRole( 'button', { name: 'Replace' } ) );
+
+			// Click Generate image option
+			await user.click( screen.getByRole( 'menuitem', { name: 'Generate image' } ) );
+
+			// The GeneralPurposeImage modal should now be rendered
+			expect( screen.getByTestId( 'ai-image-modal' ) ).toBeInTheDocument();
+		} );
+
+		it( 'should call custom handler when filter provides one', async () => {
+			const user = userEvent.setup();
+			const mockCustomHandler = jest.fn();
+			mockApplyFilters.mockReturnValue( mockCustomHandler );
+
+			render( <MediaSectionV2 /> );
+
+			// Open dropdown
+			await user.click( screen.getByRole( 'button', { name: 'Replace' } ) );
+
+			// Click Generate image option
+			await user.click( screen.getByRole( 'menuitem', { name: 'Generate image' } ) );
+
+			expect( mockCustomHandler ).toHaveBeenCalled();
+		} );
+
+		it( 'should update media options when filter handler calls onImageSelect', async () => {
+			let capturedOnImageSelect:
+				| ( ( image: { id: number; url: string; mime?: string } ) => void )
+				| null = null;
+
+			mockApplyFilters.mockImplementation(
+				(
+					filterName: string,
+					defaultValue: unknown,
+					args: { onImageSelect: ( image: { id: number; url: string; mime?: string } ) => void }
+				) => {
+					if ( filterName === 'jetpack.ai.imageGenerationHandler' ) {
+						capturedOnImageSelect = args.onImageSelect;
+					}
+					return null;
+				}
+			);
+
+			render( <MediaSectionV2 /> );
+
+			// Simulate external handler calling onImageSelect
+			await act( async () => {
+				if ( capturedOnImageSelect ) {
+					capturedOnImageSelect( {
+						id: 999,
+						url: 'https://example.com/ai-generated.png',
+						mime: 'image/png',
+					} );
+				}
+			} );
+
+			expect( mockUpdateJetpackSocialOptions ).toHaveBeenCalledWith( {
+				media_source: 'media-library',
+				attached_media: [
+					{ id: 999, url: 'https://example.com/ai-generated.png', type: 'image/png' },
+				],
+				image_generator_settings: { enabled: false },
+			} );
+		} );
+
+		it( 'should default to image/png mime type when not provided', async () => {
+			let capturedOnImageSelect:
+				| ( ( image: { id: number; url: string; mime?: string } ) => void )
+				| null = null;
+
+			mockApplyFilters.mockImplementation(
+				(
+					filterName: string,
+					defaultValue: unknown,
+					args: { onImageSelect: ( image: { id: number; url: string; mime?: string } ) => void }
+				) => {
+					if ( filterName === 'jetpack.ai.imageGenerationHandler' ) {
+						capturedOnImageSelect = args.onImageSelect;
+					}
+					return null;
+				}
+			);
+
+			render( <MediaSectionV2 /> );
+
+			// Simulate external handler calling onImageSelect without mime
+			await act( async () => {
+				if ( capturedOnImageSelect ) {
+					capturedOnImageSelect( {
+						id: 888,
+						url: 'https://example.com/no-mime.png',
+					} );
+				}
+			} );
+
+			expect( mockUpdateJetpackSocialOptions ).toHaveBeenCalledWith( {
+				media_source: 'media-library',
+				attached_media: [ { id: 888, url: 'https://example.com/no-mime.png', type: 'image/png' } ],
+				image_generator_settings: { enabled: false },
+			} );
 		} );
 	} );
 } );

--- a/projects/packages/publicize/_inc/components/media-section-v2/test/index.test.tsx
+++ b/projects/packages/publicize/_inc/components/media-section-v2/test/index.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, act } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import MediaSectionV2 from '..';
 import useFeaturedImage from '../../../hooks/use-featured-image';
@@ -452,7 +452,7 @@ describe( 'MediaSectionV2', () => {
 			expect( mockCustomHandler ).toHaveBeenCalled();
 		} );
 
-		it( 'should update media options when filter handler calls onImageSelect', async () => {
+		it( 'should update media options when filter handler calls onImageSelect', () => {
 			let capturedOnImageSelect:
 				| ( ( image: { id: number; url: string; mime?: string } ) => void )
 				| null = null;
@@ -473,15 +473,13 @@ describe( 'MediaSectionV2', () => {
 			render( <MediaSectionV2 /> );
 
 			// Simulate external handler calling onImageSelect
-			await act( async () => {
-				if ( capturedOnImageSelect ) {
-					capturedOnImageSelect( {
-						id: 999,
-						url: 'https://example.com/ai-generated.png',
-						mime: 'image/png',
-					} );
-				}
-			} );
+			if ( capturedOnImageSelect ) {
+				capturedOnImageSelect( {
+					id: 999,
+					url: 'https://example.com/ai-generated.png',
+					mime: 'image/png',
+				} );
+			}
 
 			expect( mockUpdateJetpackSocialOptions ).toHaveBeenCalledWith( {
 				media_source: 'media-library',
@@ -492,7 +490,7 @@ describe( 'MediaSectionV2', () => {
 			} );
 		} );
 
-		it( 'should default to image/png mime type when not provided', async () => {
+		it( 'should default to image/png mime type when not provided', () => {
 			let capturedOnImageSelect:
 				| ( ( image: { id: number; url: string; mime?: string } ) => void )
 				| null = null;
@@ -513,14 +511,12 @@ describe( 'MediaSectionV2', () => {
 			render( <MediaSectionV2 /> );
 
 			// Simulate external handler calling onImageSelect without mime
-			await act( async () => {
-				if ( capturedOnImageSelect ) {
-					capturedOnImageSelect( {
-						id: 888,
-						url: 'https://example.com/no-mime.png',
-					} );
-				}
-			} );
+			if ( capturedOnImageSelect ) {
+				capturedOnImageSelect( {
+					id: 888,
+					url: 'https://example.com/no-mime.png',
+				} );
+			}
 
 			expect( mockUpdateJetpackSocialOptions ).toHaveBeenCalledWith( {
 				media_source: 'media-library',

--- a/projects/packages/publicize/changelog/add-image-generation-handler-filter
+++ b/projects/packages/publicize/changelog/add-image-generation-handler-filter
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Social: Add `jetpack.ai.imageGenerationHandler` filter to allow external plugins (e.g. Image Studio) to replace the built-in AI image generation flow for the "Generate image" entry point.


### PR DESCRIPTION
This PR introduces a filter in the Social Media section that allows external plugins (e.g., Image Studio) to replace the built-in AI image generation flow for the "Generate image" option in the attachment dropdown in the JP Social.

The filter receives an onImageSelect callback that external handlers can invoke when an image is selected/generated, automatically updating the attached media. Falls back to the default AI image modal when no filter handler is registered.

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->


## Proposed changes:
<!--- Explain what functional changes your PR includes -->


  - Add `jetpack.ai.imageGenerationHandler` filter to the social media section
  - Guard NavigatorModal's `onRequestClose` to prevent it from closing when an external modal opens (required for the filter to work correctly)
### Other information:

- [X ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

 **Note:** This PR provides the integration hook. Full testing with Image Studio requires the corresponding Big Sky PR 5673

###  Local (Docker)

#### Setup

  1. Start Docker environment and build Jetpack:
  pnpm jetpack docker up -d && pnpm jetpack build plugins/jetpack --deps
  2. Add test snippet to tools/docker/mu-plugins/0-snippets.php: onebin 3a703 
  3. Replace image url and id in the code snippet 


###  WPCOM Sandbox

#### Setup

  1. Deploy this PR changes to your sandbox as per gh-actions command
  2. Add test snippet to your sandbox: onebin 3a703
  3. Replace image url and id in the code snippet 

### Test: Social Media Entry Point

1. Go to Posts → Edit any post
2. Open Jetpack sidebar (star icon in top-right toolbar)
3. Scroll to "Share to social media" section
4. Click "Preview and share" button
5. In the modal, click "Select" dropdown under "MEDIA"
6. Click "Generate image" (under "FOR ATTACHMENT")
7. Expected:
- Alert shows "Handler called: social-media"
- After clicking OK, the test image appears in the Media preview (no modal opens)

## Changelog
<!-- Check one of the boxes below. -->

- [ ] Generate changelog entries for this PR (using AI).
