### PR TITLE
Add my.woo.ai to known Calypso origins

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/DOTMSD-1094-calypso-origins
+++ b/projects/packages/jetpack-mu-wpcom/changelog/DOTMSD-1094-calypso-origins
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Calypso Origins: add my.woo.ai and my.woo.localhost to known origins.
+Calypso Origins: Add my.woo.ai and my.woo.localhost to known origins.

--- a/projects/packages/jetpack-mu-wpcom/changelog/DOTMSD-1094-calypso-origins
+++ b/projects/packages/jetpack-mu-wpcom/changelog/DOTMSD-1094-calypso-origins
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Calypso Origins: add my.woo.ai and my.woo.localhost to known origins.

--- a/projects/packages/jetpack-mu-wpcom/src/utils.php
+++ b/projects/packages/jetpack-mu-wpcom/src/utils.php
@@ -89,6 +89,8 @@ function wpcom_get_calypso_origin() {
 		'https://wordpress.com',
 		'http://my.localhost:3000',
 		'https://my.wordpress.com',
+		'http://my.woo.localhost:3000',
+		'https://my.woo.ai',
 	);
 	return in_array( $origin, $allowed, true ) ? $origin : 'https://wordpress.com';
 }


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/DOTMSD-1094

## Proposed changes:
* Add `https://my.woo.ai` and `http://my.woo.localhost:3000` to the known Calypso origins allowlist in `wpcom_get_calypso_origin()`.

This is used in the block editor when linking back to the dashboard.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
* Pass `?calypso_origin=https://my.woo.ai` to a Jetpack-connected site
* Verify the origin is accepted (not replaced with `https://wordpress.com`)

## Changelog

- [x] Generate changelog entries for this PR (using AI).