### PR TITLE
Post Images: add image exclusion via CSS class and filter

### DIFF
--- a/projects/plugins/jetpack/changelog/related-posts-image-filter
+++ b/projects/plugins/jetpack/changelog/related-posts-image-filter
@@ -1,4 +1,4 @@
 Significance: minor
 Type: enhancement
 
-Post Images: add `jetpack-ignore-thumbnail` CSS class and `jetpack_postimages_exclude_image` filter to exclude specific images from post image discovery.
+Post Images: Add `jetpack-ignore-thumbnail` CSS class and `jetpack_postimages_exclude_image` filter to exclude specific images from post image discovery.

--- a/projects/plugins/jetpack/changelog/related-posts-image-filter
+++ b/projects/plugins/jetpack/changelog/related-posts-image-filter
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Post Images: add `jetpack-ignore-thumbnail` CSS class and `jetpack_postimages_exclude_image` filter to exclude specific images from post image discovery.

--- a/projects/plugins/jetpack/class.jetpack-post-images.php
+++ b/projects/plugins/jetpack/class.jetpack-post-images.php
@@ -505,6 +505,13 @@ class Jetpack_PostImages {
 	private static function get_images_from_block_attributes( $block_type, $attributes, $html_info, $width, $height ) {
 		$images = array();
 
+		// Skip blocks marked with the jetpack-ignore-thumbnail CSS class
+		// (set via the block editor's "Advanced > Additional CSS class" panel).
+		$class_name = $attributes['className'] ?? '';
+		if ( false !== stripos( $class_name, 'jetpack-ignore-thumbnail' ) ) {
+			return $images;
+		}
+
 		switch ( $block_type ) {
 			case 'core/image':
 			case 'core/media-text':
@@ -512,6 +519,10 @@ class Jetpack_PostImages {
 				if ( ! empty( $attributes[ $id_key ] ) ) {
 					$image = self::get_attachment_data( $attributes[ $id_key ], $html_info['post_url'], $width, $height );
 					if ( false !== $image ) {
+						/** This filter is documented in class.jetpack-post-images.php */
+						if ( apply_filters( 'jetpack_postimages_exclude_image', false, $image ) ) {
+							break;
+						}
 						$images[] = $image;
 					}
 				}
@@ -609,6 +620,11 @@ class Jetpack_PostImages {
 				continue;
 			}
 
+			// Allow users to exclude images by adding a CSS class to the img tag.
+			if ( false !== stripos( $image_tag->getAttribute( 'class' ) ?? '', 'jetpack-ignore-thumbnail' ) ) {
+				continue;
+			}
+
 			// First try to get the width and height from the img attributes, but if they are not set, check to see if they are specified in the url. WordPress automatically names files like foo-1024x768.jpg during the upload process
 			$width  = (int) $image_tag->getAttribute( 'width' );
 			$height = (int) $image_tag->getAttribute( 'height' );
@@ -675,6 +691,33 @@ class Jetpack_PostImages {
 			if ( ! empty( $meta['alt_text'] ) ) {
 				$image['alt_text'] = $meta['alt_text'];
 			}
+
+			/**
+			 * Filters whether to exclude a specific image from post image discovery.
+			 *
+			 * This filter runs inside Jetpack_PostImages, which powers image selection
+			 * for Related Posts, Open Graph tags, and other features. Returning a truthy
+			 * value causes the image to be skipped.
+			 *
+			 * @since $$next-version$$
+			 *
+			 * @param bool  $exclude Whether to exclude the image. Default false.
+			 * @param array $image   {
+			 *     Image data.
+			 *
+			 *     @type string $type       The type of the image (always 'image').
+			 *     @type string $from       The source method ('html', 'attachment', 'thumbnail', etc.).
+			 *     @type string $src        The image URL.
+			 *     @type int    $src_width  The image width in pixels.
+			 *     @type int    $src_height The image height in pixels.
+			 *     @type string $href       The permalink of the post containing the image.
+			 *     @type string $alt_text   The image alt text, if available.
+			 * }
+			 */
+			if ( apply_filters( 'jetpack_postimages_exclude_image', false, $image ) ) {
+				continue;
+			}
+
 			$images[] = $image;
 		}
 		return $images;

--- a/projects/plugins/jetpack/class.jetpack-post-images.php
+++ b/projects/plugins/jetpack/class.jetpack-post-images.php
@@ -508,7 +508,7 @@ class Jetpack_PostImages {
 		// Skip blocks marked with the jetpack-ignore-thumbnail CSS class
 		// (set via the block editor's "Advanced > Additional CSS class" panel).
 		$class_name = $attributes['className'] ?? '';
-		if ( false !== stripos( $class_name, 'jetpack-ignore-thumbnail' ) ) {
+		if ( str_contains( $class_name, 'jetpack-ignore-thumbnail' ) ) {
 			return $images;
 		}
 
@@ -621,7 +621,7 @@ class Jetpack_PostImages {
 			}
 
 			// Allow users to exclude images by adding a CSS class to the img tag.
-			if ( false !== stripos( $image_tag->getAttribute( 'class' ) ?? '', 'jetpack-ignore-thumbnail' ) ) {
+			if ( str_contains( $image_tag->getAttribute( 'class' ) ?? '', 'jetpack-ignore-thumbnail' ) ) {
 				continue;
 			}
 

--- a/projects/plugins/jetpack/class.jetpack-post-images.php
+++ b/projects/plugins/jetpack/class.jetpack-post-images.php
@@ -535,6 +535,10 @@ class Jetpack_PostImages {
 					foreach ( $attributes['ids'] as $img_id ) {
 						$image = self::get_attachment_data( $img_id, $html_info['post_url'], $width, $height );
 						if ( false !== $image ) {
+							/** This filter is documented in class.jetpack-post-images.php */
+							if ( apply_filters( 'jetpack_postimages_exclude_image', false, $image ) ) {
+								continue;
+							}
 							$images[] = $image;
 						}
 					}
@@ -547,6 +551,10 @@ class Jetpack_PostImages {
 						if ( ! empty( $media_file['id'] ) ) {
 							$image = self::get_attachment_data( $media_file['id'], $html_info['post_url'], $width, $height );
 							if ( false !== $image ) {
+								/** This filter is documented in class.jetpack-post-images.php */
+								if ( apply_filters( 'jetpack_postimages_exclude_image', false, $image ) ) {
+									continue;
+								}
 								$images[] = $image;
 							}
 						}

--- a/projects/plugins/jetpack/tests/php/media/Jetpack_PostImages_Test.php
+++ b/projects/plugins/jetpack/tests/php/media/Jetpack_PostImages_Test.php
@@ -1316,7 +1316,7 @@ class Jetpack_PostImages_Test extends WP_UnitTestCase {
 			'height' => 250,
 		);
 
-		$post_id        = self::factory()->post->create();
+		$post_id         = self::factory()->post->create();
 		$attachment_id_1 = self::factory()->attachment->create_object(
 			'exclude-me.jpg',
 			$post_id,

--- a/projects/plugins/jetpack/tests/php/media/Jetpack_PostImages_Test.php
+++ b/projects/plugins/jetpack/tests/php/media/Jetpack_PostImages_Test.php
@@ -1226,21 +1226,18 @@ class Jetpack_PostImages_Test extends WP_UnitTestCase {
 		$html = '<img src="https://example.com/qr-code-300x300.jpg" width="300" height="300" alt="QR Code" />'
 			. '<img src="https://example.com/photo-400x300.jpg" width="400" height="300" alt="Photo" />';
 
-		add_filter(
-			'jetpack_postimages_exclude_image',
-			function ( $exclude, $image ) {
-				if ( false !== strpos( $image['src'], 'qr-code' ) ) {
-					return true;
-				}
-				return $exclude;
-			},
-			10,
-			2
-		);
+		$callback = function ( $exclude, $image ) {
+			if ( false !== strpos( $image['src'], 'qr-code' ) ) {
+				return true;
+			}
+			return $exclude;
+		};
+
+		add_filter( 'jetpack_postimages_exclude_image', $callback, 10, 2 );
 
 		$result = Jetpack_PostImages::from_html( $html );
 
-		remove_all_filters( 'jetpack_postimages_exclude_image' );
+		remove_filter( 'jetpack_postimages_exclude_image', $callback, 10 );
 
 		$this->assertCount( 1, $result );
 		$this->assertStringContainsString( 'photo', $result[0]['src'] );
@@ -1303,5 +1300,75 @@ class Jetpack_PostImages_Test extends WP_UnitTestCase {
 
 		$this->assertCount( 1, $images );
 		$this->assertEquals( $keep_url, $images[0]['src'] );
+	}
+
+	/**
+	 * Test that the jetpack_postimages_exclude_image filter can exclude images from from_blocks().
+	 */
+	public function test_from_blocks_exclude_image_filter() {
+		if ( ! function_exists( 'parse_blocks' ) ) {
+			$this->markTestSkipped( 'parse_blocks not available. Block editor not available' );
+			return; // @phan-suppress-current-line PhanPluginUnreachableCode
+		}
+
+		$img_dimensions = array(
+			'width'  => 300,
+			'height' => 250,
+		);
+
+		$post_id        = self::factory()->post->create();
+		$attachment_id_1 = self::factory()->attachment->create_object(
+			'exclude-me.jpg',
+			$post_id,
+			array(
+				'post_mime_type' => 'image/jpeg',
+				'post_type'      => 'attachment',
+			)
+		);
+		wp_update_attachment_metadata( $attachment_id_1, $img_dimensions );
+
+		$attachment_id_2 = self::factory()->attachment->create_object(
+			'keep-me.jpg',
+			$post_id,
+			array(
+				'post_mime_type' => 'image/jpeg',
+				'post_type'      => 'attachment',
+			)
+		);
+		wp_update_attachment_metadata( $attachment_id_2, $img_dimensions );
+
+		$url_1 = wp_get_attachment_url( $attachment_id_1 );
+		$url_2 = wp_get_attachment_url( $attachment_id_2 );
+
+		$post_html = sprintf(
+			'<!-- wp:image {"id":%1$d} --><div class="wp-block-image"><figure class="wp-block-image"><img src="%2$s" alt="" class="wp-image-%1$d"/></figure></div><!-- /wp:image -->'
+			. '<!-- wp:image {"id":%3$d} --><div class="wp-block-image"><figure class="wp-block-image"><img src="%4$s" alt="" class="wp-image-%3$d"/></figure></div><!-- /wp:image -->',
+			$attachment_id_1,
+			$url_1,
+			$attachment_id_2,
+			$url_2
+		);
+
+		$second_post_id = self::factory()->post->create(
+			array(
+				'post_content' => $post_html,
+			)
+		);
+
+		$callback = function ( $exclude, $image ) use ( $url_1 ) {
+			if ( $image['src'] === $url_1 ) {
+				return true;
+			}
+			return $exclude;
+		};
+
+		add_filter( 'jetpack_postimages_exclude_image', $callback, 10, 2 );
+
+		$images = Jetpack_PostImages::from_blocks( $second_post_id );
+
+		remove_filter( 'jetpack_postimages_exclude_image', $callback, 10 );
+
+		$this->assertCount( 1, $images );
+		$this->assertEquals( $url_2, $images[0]['src'] );
 	}
 } // end class

--- a/projects/plugins/jetpack/tests/php/media/Jetpack_PostImages_Test.php
+++ b/projects/plugins/jetpack/tests/php/media/Jetpack_PostImages_Test.php
@@ -1205,4 +1205,103 @@ class Jetpack_PostImages_Test extends WP_UnitTestCase {
 			$this->assertEquals( 250, $image['src_height'] );
 		}
 	}
+
+	/**
+	 * Test that images with the jetpack-ignore-thumbnail CSS class are excluded from from_html().
+	 */
+	public function test_from_html_ignores_jetpack_ignore_thumbnail_class() {
+		$html = '<img src="qr-code-300x300.jpg" width="300" height="300" class="jetpack-ignore-thumbnail" alt="QR Code" />'
+			. '<img src="real-image-400x300.jpg" width="400" height="300" alt="Real Image" />';
+
+		$result = Jetpack_PostImages::from_html( $html );
+
+		$this->assertCount( 1, $result );
+		$this->assertStringContainsString( 'real-image', $result[0]['src'] );
+	}
+
+	/**
+	 * Test that the jetpack_postimages_exclude_image filter can exclude images from from_html().
+	 */
+	public function test_from_html_exclude_image_filter() {
+		$html = '<img src="https://example.com/qr-code-300x300.jpg" width="300" height="300" alt="QR Code" />'
+			. '<img src="https://example.com/photo-400x300.jpg" width="400" height="300" alt="Photo" />';
+
+		add_filter(
+			'jetpack_postimages_exclude_image',
+			function ( $exclude, $image ) {
+				if ( false !== strpos( $image['src'], 'qr-code' ) ) {
+					return true;
+				}
+				return $exclude;
+			},
+			10,
+			2
+		);
+
+		$result = Jetpack_PostImages::from_html( $html );
+
+		remove_all_filters( 'jetpack_postimages_exclude_image' );
+
+		$this->assertCount( 1, $result );
+		$this->assertStringContainsString( 'photo', $result[0]['src'] );
+	}
+
+	/**
+	 * Test that image blocks with the jetpack-ignore-thumbnail CSS class are excluded from from_blocks().
+	 */
+	public function test_from_blocks_ignores_jetpack_ignore_thumbnail_class() {
+		if ( ! function_exists( 'parse_blocks' ) ) {
+			$this->markTestSkipped( 'parse_blocks not available. Block editor not available' );
+			return; // @phan-suppress-current-line PhanPluginUnreachableCode
+		}
+
+		$img_dimensions = array(
+			'width'  => 300,
+			'height' => 250,
+		);
+
+		$post_id         = self::factory()->post->create();
+		$skip_attachment  = self::factory()->attachment->create_object(
+			'skip-image.jpg',
+			$post_id,
+			array(
+				'post_mime_type' => 'image/jpeg',
+				'post_type'      => 'attachment',
+			)
+		);
+		wp_update_attachment_metadata( $skip_attachment, $img_dimensions );
+
+		$keep_attachment = self::factory()->attachment->create_object(
+			'keep-image.jpg',
+			$post_id,
+			array(
+				'post_mime_type' => 'image/jpeg',
+				'post_type'      => 'attachment',
+			)
+		);
+		wp_update_attachment_metadata( $keep_attachment, $img_dimensions );
+
+		$skip_url = wp_get_attachment_url( $skip_attachment );
+		$keep_url = wp_get_attachment_url( $keep_attachment );
+
+		$post_html = sprintf(
+			'<!-- wp:image {"id":%1$d,"className":"jetpack-ignore-thumbnail"} --><div class="wp-block-image"><figure class="wp-block-image jetpack-ignore-thumbnail"><img src="%2$s" alt="" class="wp-image-%1$d"/></figure></div><!-- /wp:image -->'
+			. '<!-- wp:image {"id":%3$d} --><div class="wp-block-image"><figure class="wp-block-image"><img src="%4$s" alt="" class="wp-image-%3$d"/></figure></div><!-- /wp:image -->',
+			$skip_attachment,
+			$skip_url,
+			$keep_attachment,
+			$keep_url
+		);
+
+		$second_post_id = self::factory()->post->create(
+			array(
+				'post_content' => $post_html,
+			)
+		);
+
+		$images = Jetpack_PostImages::from_blocks( $second_post_id );
+
+		$this->assertCount( 1, $images );
+		$this->assertEquals( $keep_url, $images[0]['src'] );
+	}
 } // end class

--- a/projects/plugins/jetpack/tests/php/media/Jetpack_PostImages_Test.php
+++ b/projects/plugins/jetpack/tests/php/media/Jetpack_PostImages_Test.php
@@ -1261,7 +1261,7 @@ class Jetpack_PostImages_Test extends WP_UnitTestCase {
 		);
 
 		$post_id         = self::factory()->post->create();
-		$skip_attachment  = self::factory()->attachment->create_object(
+		$skip_attachment = self::factory()->attachment->create_object(
 			'skip-image.jpg',
 			$post_id,
 			array(


### PR DESCRIPTION
Fixes #47054

## Proposed changes:
* Add `jetpack-ignore-thumbnail` CSS class support to `Jetpack_PostImages` — any `<img>` tag with this class (or any block with this class in "Advanced > Additional CSS class") is skipped during image discovery
* Add `jetpack_postimages_exclude_image` filter for programmatic exclusion — developers can hook in to exclude images by URL pattern, dimensions, or other metadata
* Both mechanisms apply at the `Jetpack_PostImages` level (`from_html` and `from_blocks`), so all consumers benefit: Related Posts, Open Graph tags, and anything else that relies on this class for image selection

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:

* Create a post with two images and no featured image set
* Add the CSS class `jetpack-ignore-thumbnail` to the first image:
  * **Block editor**: Select the image block → open the "Advanced" panel in the sidebar → add `jetpack-ignore-thumbnail` to "Additional CSS class(es)"
  * **Classic editor**: Add `class="jetpack-ignore-thumbnail"` to the `<img>` tag in the HTML view
* Verify that Related Posts (and/or Open Graph meta tags) use the second image instead of the first
* Alternatively, test the filter by adding this to a plugin or `functions.php`:
```php
add_filter( 'jetpack_postimages_exclude_image', function( $exclude, $image ) {
    if ( str_contains( $image['src'], 'qr-code' ) ) {
        return true;
    }
    return $exclude;
}, 10, 2 );
```

## Changelog

- [x] Generate changelog entries for this PR (using AI).
