### PR TITLE
Verbum Block Editor: Fix focus on edit comment screen

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/do-not-focus-verbum-editor-on-edit-comments-screen
+++ b/projects/packages/jetpack-mu-wpcom/changelog/do-not-focus-verbum-editor-on-edit-comments-screen
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Verbum Editor: Fix editor focus on edit comments screen
+Verbum Editor: Fix editor focus on edit comment screen.

--- a/projects/packages/jetpack-mu-wpcom/changelog/do-not-focus-verbum-editor-on-edit-comments-screen
+++ b/projects/packages/jetpack-mu-wpcom/changelog/do-not-focus-verbum-editor-on-edit-comments-screen
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Verbum Editor: Fix editor focus on edit comments screen

--- a/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/assets/comments-moderation.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/assets/comments-moderation.js
@@ -28,6 +28,7 @@ document.addEventListener( 'DOMContentLoaded', function () {
 		},
 		VerbumComments.isRTL,
 		embedContentCallback,
-		false // No dark-mode: wp-admin is always the same colour as winter in Britain.
+		false, // No dark-mode: wp-admin is always the same colour as winter in Britain.
+		false // Avoid focusing the editor when it mounts, as this shifts focus to the editor immediately on page load, a practice that is not ideal for accessibility.
 	);
 } );

--- a/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/components/comment-input-field.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/components/comment-input-field.tsx
@@ -76,7 +76,7 @@ export const CommentInputField = forwardRef(
 					VerbumComments.colorScheme === 'dark',
 					true
 				);
-				// Wait fro the block editor to render.
+				// Wait for the block editor to render.
 				setTimeout( () => setEditorState( 'LOADED' ), 100 );
 			} catch {
 				// Switch to the textarea if the editor fails to load.

--- a/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/components/comment-input-field.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/components/comment-input-field.tsx
@@ -73,7 +73,8 @@ export const CommentInputField = forwardRef(
 					},
 					VerbumComments.isRTL,
 					embedContentCallback,
-					VerbumComments.colorScheme === 'dark'
+					VerbumComments.colorScheme === 'dark',
+					true
 				);
 				// Wait fro the block editor to render.
 				setTimeout( () => setEditorState( 'LOADED' ), 100 );

--- a/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/components/types.d.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/components/types.d.ts
@@ -12,7 +12,8 @@ declare global {
 			content: ( embedUrl: string ) => void,
 			isRtl: boolean,
 			onEmbedContent: ( embedUrl: string ) => void,
-			isDarkMode: boolean
+			isDarkMode: boolean,
+			focusOnMount: boolean
 		) => void;
 	};
 	const vbeCacheBuster: string;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related: [READ-289](https://linear.app/a8c/issue/READ-289)

## Proposed changes:

- On page load do not focus Verbum Editor on edit comments screen.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Go to all comments screen ([example](https://loopsimple.wordpress.com/wp-admin/edit-comments.php)). Click on Edit.
1. Note that the focus is moved to the editor after page load.
1. Checkout this PR.
1. Sandbox `widgets.wp.com` and simple site.
1. Go to all comments screen ([example](https://loopsimple.wordpress.com/wp-admin/edit-comments.php)). Click on Edit.
1. Verify toolbar is visible and editor is not focused.
1. Go to any post on simple site and try adding comment. ([example post](https://loopsimple.wordpress.com/2025/05/08/free-post/))
1. Verify toolbar is visible and editor is focused as here we want to move focus to the editor.
