### PR TITLE
CHARTS-170 - fix: strip data-testid attributes from production builds in charts

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -422,6 +422,12 @@ importers:
       '@babel/core':
         specifier: 7.29.0
         version: 7.29.0
+      '@babel/preset-react':
+        specifier: 7.28.5
+        version: 7.28.5(@babel/core@7.29.0)
+      '@babel/preset-typescript':
+        specifier: 7.28.5
+        version: 7.28.5(@babel/core@7.29.0)
       '@storybook/addon-docs':
         specifier: 10.2.3
         version: 10.2.3(@types/react@18.3.26)(esbuild@0.25.9)(storybook@10.2.3(@testing-library/dom@10.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
@@ -461,9 +467,15 @@ importers:
       babel-jest:
         specifier: 30.2.0
         version: 30.2.0(@babel/core@7.29.0)
+      babel-plugin-react-remove-properties:
+        specifier: ^0.3.1
+        version: 0.3.1
       esbuild:
         specifier: 0.25.9
         version: 0.25.9
+      esbuild-plugin-babel:
+        specifier: ^0.2.3
+        version: 0.2.3(@babel/core@7.29.0)
       esbuild-sass-plugin:
         specifier: ^3.1.0
         version: 3.3.1(esbuild@0.25.9)(sass-embedded@1.97.2)
@@ -11211,6 +11223,9 @@ packages:
     resolution: {integrity: sha512-hYm+XLYRMvupxiQzrvXUj7YyvFFVfv5gI0R71AJzudg1g2AI2vyCPPIFEBjk162/wFzti3inBHo7isWFuEVS/A==}
     peerDependencies:
       '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
+
+  babel-plugin-react-remove-properties@0.3.1:
+    resolution: {integrity: sha512-JQ0oEgC4P6TZxSqEaoPZdbgE2L38Kz7RgTgGcOUUR24Z19OiGhnhdXkXkwwsYyx6LOr/bMY5ljDADhxDr/JQug==}
 
   babel-plugin-tester@12.0.0:
     resolution: {integrity: sha512-V3ZFYmXPV9fm3ArpLHbvh0R5IfwnyFwlvdZ2FFQ49af4seC10U0JDWssjhXInuDDli6hyQsoOybGFSTCovrGyA==}
@@ -26816,6 +26831,8 @@ snapshots:
       '@babel/helper-define-polyfill-provider': 0.6.6(@babel/core@7.29.0)
     transitivePeerDependencies:
       - supports-color
+
+  babel-plugin-react-remove-properties@0.3.1: {}
 
   babel-plugin-tester@12.0.0(@babel/core@7.29.0):
     dependencies:

--- a/projects/js-packages/charts/changelog/strip-data-testid-production-builds
+++ b/projects/js-packages/charts/changelog/strip-data-testid-production-builds
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Build: strip data-testid attributes from production builds to reduce bundle size and keep the DOM cleaner.

--- a/projects/js-packages/charts/package.json
+++ b/projects/js-packages/charts/package.json
@@ -232,6 +232,8 @@
 	"devDependencies": {
 		"@automattic/jetpack-webpack-config": "workspace:*",
 		"@babel/core": "7.29.0",
+		"@babel/preset-react": "7.28.5",
+		"@babel/preset-typescript": "7.28.5",
 		"@storybook/addon-docs": "10.2.3",
 		"@storybook/react": "10.2.3",
 		"@testing-library/dom": "^10.0.0",
@@ -245,7 +247,9 @@
 		"@wordpress/components": "32.1.0",
 		"@wordpress/element": "6.39.0",
 		"babel-jest": "30.2.0",
+		"babel-plugin-react-remove-properties": "^0.3.1",
 		"esbuild": "0.25.9",
+		"esbuild-plugin-babel": "^0.2.3",
 		"esbuild-sass-plugin": "^3.1.0",
 		"jest": "30.2.0",
 		"jest-extended": "7.0.0",

--- a/projects/js-packages/charts/src/charts/pie-chart/pie-chart.tsx
+++ b/projects/js-packages/charts/src/charts/pie-chart/pie-chart.tsx
@@ -384,10 +384,9 @@ const PieChartInternal = ( {
 											} );
 										};
 
-										const pathProps: SVGProps< SVGPathElement > & { 'data-testid'?: string } = {
+										const pathProps: SVGProps< SVGPathElement > = {
 											d: pie.path( arc ) || '',
 											fill: accessors.fill( arc.data ),
-											'data-testid': 'pie-segment',
 										};
 
 										const groupProps: SVGProps< SVGGElement > = {};
@@ -405,7 +404,7 @@ const PieChartInternal = ( {
 
 										return (
 											<g key={ `arc-${ index }` } { ...groupProps }>
-												<path { ...pathProps } />
+												<path { ...pathProps } data-testid="pie-segment" />
 												{ showLabels && hasSpaceForLabel && (
 													<g>
 														{ providerTheme.labelBackgroundColor && (

--- a/projects/js-packages/charts/tsup.config.ts
+++ b/projects/js-packages/charts/tsup.config.ts
@@ -1,3 +1,4 @@
+import babel from 'esbuild-plugin-babel';
 import { sassPlugin, postcssModules } from 'esbuild-sass-plugin';
 import { defineConfig } from 'tsup';
 import pkg from './package.json';
@@ -23,6 +24,16 @@ export default defineConfig( {
 		'.png': 'file',
 	},
 	esbuildPlugins: [
+		babel( {
+			filter: /\.tsx$/,
+			config: {
+				presets: [
+					'@babel/preset-typescript',
+					[ '@babel/preset-react', { runtime: 'automatic' } ],
+				],
+				plugins: [ [ 'react-remove-properties', { properties: [ 'data-testid' ] } ] ],
+			},
+		} ),
 		sassPlugin( {
 			filter: /\.module\.(css|scss)$/,
 			embedded: true,


### PR DESCRIPTION
Fixes CHARTS-170

## Proposed changes:

* Add `esbuild-plugin-babel` with `babel-plugin-react-remove-properties` to the tsup build pipeline so `data-testid` attributes are automatically stripped from production bundles
* Move the pie-chart `data-testid` from the props object to inline JSX so the babel plugin can detect and remove it
* Add `@babel/preset-react` and `@babel/preset-typescript` as dev dependencies to support the babel transform within the esbuild pipeline

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Testing instructions:

* Build the charts package: `cd projects/js-packages/charts && pnpm build:prod`
* Inspect the output bundle and confirm no `data-testid` attributes are present in the production build
* Run `pnpm test` in the charts package to confirm tests still pass (tests run against source, not built output, so `data-testid` is still available in test environment)
* Run `pnpm storybook` and verify pie chart stories render correctly

## Changelog

- [x] Generate changelog entries for this PR (using AI).

## Does this pull request change what data or activity we track or use?

No