### PR TITLE
Change Scan Feature Access

### DIFF
--- a/projects/plugins/wpcomsh/changelog/jetpack-scan-gating
+++ b/projects/plugins/wpcomsh/changelog/jetpack-scan-gating
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add SCAN_SELF_SERVE feature and expand SCAN access to all WoW plans.

--- a/projects/plugins/wpcomsh/wpcom-features/class-wpcom-features.php
+++ b/projects/plugins/wpcomsh/wpcom-features/class-wpcom-features.php
@@ -468,6 +468,7 @@ class WPCOM_Features {
 	public const REPUBLICIZE                       = 'republicize';
 	public const SCAN                              = 'scan';
 	public const SCAN_MANAGED                      = 'scan-managed';
+	public const SCAN_SELF_SERVE                   = 'scan-self-serve';
 	public const SCHEDULED_UPDATES                 = 'scheduled-updates';
 	public const SECURITY_SETTINGS                 = 'security-settings';
 	public const SEO_PREVIEW_TOOLS                 = 'seo-preview-tools';
@@ -1199,6 +1200,7 @@ class WPCOM_Features {
 			self::JETPACK_PREMIUM_AND_HIGHER,
 			self::JETPACK_SCAN_PLANS,
 			self::JETPACK_GOLDEN_TOKEN,
+			self::WPCOM_PERSONAL_AND_PREMIUM_PLANS,
 			self::WPCOM_BUSINESS_AND_HIGHER_PLANS,
 			self::WPCOM_PRO_PLANS,
 			self::WPCOM_FLEX_CACHE_SITE_FREE_PLANS,
@@ -1209,6 +1211,19 @@ class WPCOM_Features {
 		 * See D57207-code.
 		 */
 		self::SCAN_MANAGED                      => array(
+			self::WPCOM_PERSONAL_AND_PREMIUM_PLANS,
+			self::WPCOM_BUSINESS_AND_HIGHER_PLANS,
+			self::WPCOM_PRO_PLANS,
+			self::WPCOM_FLEX_CACHE_SITE_FREE_PLANS,
+		),
+
+		// This governs UI access to Jetpack Scan.
+		// All WoW sites should perform scans, however we don't want to expose the UI to sites on lower wpcom plans.
+		// It's not completely clear how this differs from SCAN_MANAGED.
+		self::SCAN_SELF_SERVE                   => array(
+			self::JETPACK_PREMIUM_AND_HIGHER,
+			self::JETPACK_SCAN_PLANS,
+			self::JETPACK_GOLDEN_TOKEN,
 			self::WPCOM_BUSINESS_AND_HIGHER_PLANS,
 			self::WPCOM_PRO_PLANS,
 			self::WPCOM_FLEX_CACHE_SITE_FREE_PLANS,


### PR DESCRIPTION
Part of CHE-410

## Proposed changes:

* Add `SCAN_SELF_SERVE` feature constant to control UI access to Jetpack Scan separately from the scan functionality itself
* Expand `SCAN` feature access to include `WPCOM_PERSONAL_AND_PREMIUM_PLANS` so all WoW sites get scans
* Expand `SCAN_MANAGED` to include personal and premium plans
* `SCAN_SELF_SERVE` retains the original restrictions (Business and higher) to control which plans see the Scan UI

This is a copy of wpcom# 204203

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

This is mainly just to keep the feature in sync. You can enable this branch in jetpack beta and test alongside https://github.com/Automattic/wp-calypso/pull/108756 though