### PR TITLE
Social: Add analytics tracking for per network customizations UI

### DIFF
--- a/projects/packages/publicize/_inc/components/form/upgrade-notice-customization.tsx
+++ b/projects/packages/publicize/_inc/components/form/upgrade-notice-customization.tsx
@@ -1,8 +1,9 @@
 import { getRedirectUrl } from '@automattic/jetpack-components';
 import { isSimpleSite } from '@automattic/jetpack-script-data';
-import { getSiteFragment } from '@automattic/jetpack-shared-extension-utils';
+import { useAnalytics, getSiteFragment } from '@automattic/jetpack-shared-extension-utils';
 import { Button, Flex, FlexItem, Notice } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { useCallback } from 'react';
 
 /**
  * A notice for upgrading to a plan that supports per-network customization.
@@ -10,6 +11,12 @@ import { __ } from '@wordpress/i18n';
  * @return The UpgradeNoticeCustomization component.
  */
 export function UpgradeNoticeCustomization() {
+	const { recordEvent } = useAnalytics();
+
+	const onClickUpgrade = useCallback( () => {
+		recordEvent( 'jetpack_social_per_network_customization_upgrade_click' );
+	}, [ recordEvent ] );
+
 	if ( isSimpleSite() ) {
 		return null;
 	}
@@ -41,6 +48,7 @@ export function UpgradeNoticeCustomization() {
 						className="is-compact"
 						target="_blank"
 						rel="noopener noreferrer"
+						onClick={ onClickUpgrade }
 					>
 						{ __( 'Upgrade now', 'jetpack-publicize-pkg' ) }
 					</Button>

--- a/projects/packages/publicize/_inc/hooks/use-per-network-customization/index.ts
+++ b/projects/packages/publicize/_inc/hooks/use-per-network-customization/index.ts
@@ -70,7 +70,7 @@ export function usePerNetworkCustomization() {
 		const isNowEnabled = ! isEnabled;
 
 		recordEvent( 'jetpack_social_per_network_customization_toggled', {
-			isNowEnabled,
+			enabled: isNowEnabled,
 		} );
 
 		// Update post metadata.

--- a/projects/packages/publicize/_inc/hooks/use-per-network-customization/index.ts
+++ b/projects/packages/publicize/_inc/hooks/use-per-network-customization/index.ts
@@ -1,3 +1,4 @@
+import { useAnalytics } from '@automattic/jetpack-shared-extension-utils';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
 import { useCallback, useMemo } from '@wordpress/element';
@@ -16,6 +17,7 @@ import { computeAttachedMediaForSource, getEffectiveMediaSource } from './utils'
  */
 export function usePerNetworkCustomization() {
 	const postMeta = usePostMeta();
+	const { recordEvent } = useAnalytics();
 
 	const { editPost } = useDispatch( editorStore );
 	const { customizeConnectionById } = useDispatch( socialStore );
@@ -67,6 +69,10 @@ export function usePerNetworkCustomization() {
 	const toggle = useCallback( () => {
 		const isNowEnabled = ! isEnabled;
 
+		recordEvent( 'jetpack_social_per_network_customization_toggled', {
+			isNowEnabled,
+		} );
+
 		// Update post metadata.
 		editPost( {
 			meta: {
@@ -77,7 +83,7 @@ export function usePerNetworkCustomization() {
 		if ( isNowEnabled ) {
 			syncConnections();
 		}
-	}, [ isEnabled, editPost, syncConnections ] );
+	}, [ isEnabled, recordEvent, editPost, syncConnections ] );
 
 	return useMemo(
 		() => ( {

--- a/projects/packages/publicize/_inc/hooks/use-per-network-customization/test/index.test.ts
+++ b/projects/packages/publicize/_inc/hooks/use-per-network-customization/test/index.test.ts
@@ -31,6 +31,11 @@ jest.mock( '../../use-post-meta', () => ( {
 	} ) ),
 } ) );
 
+// Mock useAnalytics to avoid deep dependency chain
+jest.mock( '@automattic/jetpack-shared-extension-utils', () => ( {
+	useAnalytics: jest.fn( () => ( { recordEvent: jest.fn() } ) ),
+} ) );
+
 // Mock hasSocialPaidFeatures to return true by default
 jest.mock( '../../../utils', () => {
 	const actual = jest.requireActual( '../../../utils' );

--- a/projects/packages/publicize/changelog/add-social-tracking-for-per-network-customizations
+++ b/projects/packages/publicize/changelog/add-social-tracking-for-per-network-customizations
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add analytics tracking for per network customizations UI.


### PR DESCRIPTION
Closes SOCIAL-368

## Proposed changes:

Adds analytics tracking for per-network customization actions to help understand feature adoption.

- Track when the per-network customization toggle is switched on/off (`jetpack_social_per_network_customization_toggled` with `enabled` property)
- Track when the upgrade button is clicked in the per-network customization upsell notice (`jetpack_social_per_network_customization_upgrade_click`)

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

SOCIAL-368

## Does this pull request change what data or activity we track or use?

Yes. Two new Tracks events:

- `jetpack_social_per_network_customization_toggled` — fired when the user toggles per-network customization on or off. Includes `enabled` (boolean) property.
- `jetpack_social_per_network_customization_upgrade_click` — fired when the user clicks the "Upgrade now" button in the per-network customization upsell notice.

## Testing instructions:

- Create or edit a post with Jetpack Social connections configured
- Open the browser console and enter this

```js
localStorage.setItem('debug', 'dops:analytics');
```

### Toggle tracking
- Open the Social preview modal
- Toggle "Customize each" on
- **Verify**: `jetpack_social_per_network_customization_toggled` event is fired with `enabled: true`
- Toggle it off
- **Verify**: The same event is fired with `enabled: false`

### Upgrade button tracking (free plan)
- On a site without a Social paid plan, open the preview modal
- Click the "Upgrade now" button in the per-network customization upsell
- **Verify**: `jetpack_social_per_network_customization_upgrade_click` event is fired

## Changelog

- [x] Generate changelog entries for this PR (using AI).
