### PR TITLE
CHARTS-172: Prevent tooltip flash at origin before visx positions it

### DIFF
--- a/projects/js-packages/charts/changelog/fix-charts-172-tooltip-flash
+++ b/projects/js-packages/charts/changelog/fix-charts-172-tooltip-flash
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Tooltip: prevent flash at origin before visx calculates correct position.

--- a/projects/js-packages/charts/src/hooks/use-tooltip-portal-relocator.ts
+++ b/projects/js-packages/charts/src/hooks/use-tooltip-portal-relocator.ts
@@ -107,6 +107,10 @@ export function useTooltipPortalRelocator(
 				return;
 			}
 
+			// Hide the portal immediately to prevent the tooltip from
+			// flashing at (0,0) before visx calculates the correct position.
+			node.style.opacity = '0';
+
 			// Position the portal at the viewport origin so visx's
 			// absolute-positioned tooltip coordinates remain correct.
 			// Zero-size with overflow: visible so it doesn't affect layout
@@ -131,6 +135,13 @@ export function useTooltipPortalRelocator(
 			if ( focusedElement ) {
 				focusedElement.focus();
 			}
+
+			// Reveal after the next paint so visx has positioned the tooltip.
+			requestAnimationFrame( () => {
+				requestAnimationFrame( () => {
+					node.style.opacity = '';
+				} );
+			} );
 		};
 
 		// Patch document.body.removeChild so visx Portal unmount doesn't throw

--- a/projects/js-packages/charts/src/hooks/use-tooltip-portal-relocator.ts
+++ b/projects/js-packages/charts/src/hooks/use-tooltip-portal-relocator.ts
@@ -136,7 +136,7 @@ export function useTooltipPortalRelocator(
 				focusedElement.focus();
 			}
 
-			// Reveal after the next paint so visx has positioned the tooltip.
+			// Reveal after two animation frames so visx has positioned the tooltip.
 			requestAnimationFrame( () => {
 				requestAnimationFrame( () => {
 					node.style.opacity = '';


### PR DESCRIPTION
Fixes CHARTS-172

## Proposed changes:

* Hide the tooltip portal node immediately on relocation (`opacity: 0`) and reveal it after two animation frames via `requestAnimationFrame`, giving visx time to calculate the correct tooltip position and avoiding a visible flash at (0, 0).

### Before


https://github.com/user-attachments/assets/381bab78-a33b-4a69-82e0-6104a863df90

### After


https://github.com/user-attachments/assets/d7caf033-4b77-4d5f-9dc1-bb3f82275a7e



### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Testing instructions:

* Hover over any chart with tooltips (e.g., line chart, bar chart) and observe that the tooltip no longer briefly flashes at the top-left corner before appearing at the correct position.
* Rapidly move the mouse across data points to confirm no flicker or stale positioning.

## Changelog

- [ ] Generate changelog entries for this PR (using AI).

## Does this pull request change what data or activity we track or use?

No