### PR TITLE
Add/allow sync for woocommerce site settings

### DIFF
--- a/projects/packages/sync/changelog/add-allow-sync-for-woocommerce-site-settings
+++ b/projects/packages/sync/changelog/add-allow-sync-for-woocommerce-site-settings
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add WooCommerce currency symbol, store address details, and related site options to sync whitelist for improved WooCommerce site settings sync.

--- a/projects/packages/sync/changelog/add-allow-sync-for-woocommerce-site-settings
+++ b/projects/packages/sync/changelog/add-allow-sync-for-woocommerce-site-settings
@@ -1,4 +1,4 @@
 Significance: minor
 Type: added
 
-Add WooCommerce currency symbol, store address details, and related site options to sync whitelist for improved WooCommerce site settings sync.
+Add WooCommerce store address details (address, address_2, city, postcode) and admin install timestamp to sync whitelist for improved WooCommerce site settings sync.

--- a/projects/packages/sync/src/modules/class-woocommerce.php
+++ b/projects/packages/sync/src/modules/class-woocommerce.php
@@ -395,21 +395,6 @@ class WooCommerce extends Module {
 	}
 
 	/**
-	 * Add WooCommerce callables to the callable whitelist.
-	 *
-	 * @param array $list Existing callable whitelist.
-	 * @return array Updated callable whitelist.
-	 */
-	public function add_woocommerce_callable_whitelist( $list ) {
-		return array_merge(
-			$list,
-			array(
-				'woocommerce_currency_symbol' => 'get_woocommerce_currency_symbol',
-			)
-		);
-	}
-
-	/**
 	 * Add WooCommerce constants to the constants whitelist.
 	 *
 	 * @param array $list Existing constants whitelist.

--- a/projects/packages/sync/src/modules/class-woocommerce.php
+++ b/projects/packages/sync/src/modules/class-woocommerce.php
@@ -124,7 +124,6 @@ class WooCommerce extends Module {
 
 		// Options, constants and post meta whitelists.
 		add_filter( 'jetpack_sync_options_whitelist', array( $this, 'add_woocommerce_options_whitelist' ), 10 );
-		add_filter( 'jetpack_sync_callable_whitelist', array( $this, 'add_woocommerce_callable_whitelist' ), 10 );
 		add_filter( 'jetpack_sync_constants_whitelist', array( $this, 'add_woocommerce_constants_whitelist' ), 10 );
 		add_filter( 'jetpack_sync_post_meta_whitelist', array( $this, 'add_woocommerce_post_meta_whitelist' ), 10 );
 		add_filter( 'jetpack_sync_comment_meta_whitelist', array( $this, 'add_woocommerce_comment_meta_whitelist' ), 10 );
@@ -498,7 +497,6 @@ class WooCommerce extends Module {
 		'woocommerce_dimension_unit',
 		'woocommerce_default_country',
 		'woocommerce_default_customer_address',
-		'woocommerce_currency',
 		'woocommerce_currency_pos',
 		'woocommerce_api_enabled',
 		'woocommerce_allow_tracking',

--- a/projects/packages/sync/src/modules/class-woocommerce.php
+++ b/projects/packages/sync/src/modules/class-woocommerce.php
@@ -124,6 +124,7 @@ class WooCommerce extends Module {
 
 		// Options, constants and post meta whitelists.
 		add_filter( 'jetpack_sync_options_whitelist', array( $this, 'add_woocommerce_options_whitelist' ), 10 );
+		add_filter( 'jetpack_sync_callable_whitelist', array( $this, 'add_woocommerce_callable_whitelist' ), 10 );
 		add_filter( 'jetpack_sync_constants_whitelist', array( $this, 'add_woocommerce_constants_whitelist' ), 10 );
 		add_filter( 'jetpack_sync_post_meta_whitelist', array( $this, 'add_woocommerce_post_meta_whitelist' ), 10 );
 		add_filter( 'jetpack_sync_comment_meta_whitelist', array( $this, 'add_woocommerce_comment_meta_whitelist' ), 10 );
@@ -394,6 +395,21 @@ class WooCommerce extends Module {
 	}
 
 	/**
+	 * Add WooCommerce callables to the callable whitelist.
+	 *
+	 * @param array $list Existing callable whitelist.
+	 * @return array Updated callable whitelist.
+	 */
+	public function add_woocommerce_callable_whitelist( $list ) {
+		return array_merge(
+			$list,
+			array(
+				'woocommerce_currency_symbol' => 'get_woocommerce_currency_symbol',
+			)
+		);
+	}
+
+	/**
 	 * Add WooCommerce constants to the constants whitelist.
 	 *
 	 * @param array $list Existing constants whitelist.
@@ -497,11 +513,17 @@ class WooCommerce extends Module {
 		'woocommerce_dimension_unit',
 		'woocommerce_default_country',
 		'woocommerce_default_customer_address',
+		'woocommerce_currency',
 		'woocommerce_currency_pos',
 		'woocommerce_api_enabled',
 		'woocommerce_allow_tracking',
 		'woocommerce_task_list_hidden',
 		'woocommerce_cod_settings',
+		'woocommerce_store_address',
+		'woocommerce_store_address_2',
+		'woocommerce_store_city',
+		'woocommerce_store_postcode',
+		'woocommerce_admin_install_timestamp',
 	);
 
 	/**

--- a/projects/plugins/jetpack/changelog/remove-sending-is-singular-post
+++ b/projects/plugins/jetpack/changelog/remove-sending-is-singular-post
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Previously we added sending is_singular_post to adflow/conf to highlight it's the page for inline ads. Since it was solved via JavaScript, we don't have to send that query param any more.

--- a/projects/plugins/jetpack/changelog/remove-sending-is-singular-post
+++ b/projects/plugins/jetpack/changelog/remove-sending-is-singular-post
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Previously we added sending is_singular_post to adflow/conf to highlight it's the page for inline ads. Since it was solved via JavaScript, we don't have to send that query param any more.


### PR DESCRIPTION
Related to WOOAI-268

Related WPCOM's PR: 204337-ghe-Automattic/wpcom

## Proposed changes:

* Allow WooCommerce related options and a callable to be synced

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Testing instructions:
Please use testing instructions from related WPCOM PR.

## Changelog
-  Add WooCommerce currency symbol, store address details, and related site options to sync whitelist for improved WooCommerce site settings sync
