### PR TITLE
Social: Disable AI image option in the media UI when Jetpack plugin is not active.

### DIFF
--- a/projects/packages/publicize/_inc/components/media-section-v2/test/index.test.tsx
+++ b/projects/packages/publicize/_inc/components/media-section-v2/test/index.test.tsx
@@ -78,6 +78,14 @@ jest.mock( '@automattic/jetpack-shared-extension-utils', () => ( {
 	} ),
 } ) );
 
+jest.mock( '../../../utils', () => ( {
+	getSocialScriptData: jest.fn( () => ( {
+		plugin_info: {
+			jetpack: { version: '15.5' },
+		},
+	} ) ),
+} ) );
+
 jest.mock( '@automattic/jetpack-ai-client', () => ( {
 	GeneralPurposeImage: () => null,
 	AiSVG: 'svg',

--- a/projects/packages/publicize/_inc/components/media-section-v2/test/media-source-menu.test.tsx
+++ b/projects/packages/publicize/_inc/components/media-section-v2/test/media-source-menu.test.tsx
@@ -3,6 +3,14 @@ import userEvent from '@testing-library/user-event';
 import MediaSourceMenu from '../media-source-menu';
 import { getMediaSourceDescription } from '../utils/media-source-options';
 
+jest.mock( '../../../utils', () => ( {
+	getSocialScriptData: jest.fn( () => ( {
+		plugin_info: {
+			jetpack: { version: '15.5' },
+		},
+	} ) ),
+} ) );
+
 describe( 'getMediaSourceDescription', () => {
 	it( 'should return default message when sourceType is null', () => {
 		expect( getMediaSourceDescription( null ) ).toBe( "Your post won't show an image." );

--- a/projects/packages/publicize/_inc/components/media-section-v2/utils/media-source-options.ts
+++ b/projects/packages/publicize/_inc/components/media-section-v2/utils/media-source-options.ts
@@ -5,6 +5,7 @@
 import { AiSVG } from '@automattic/jetpack-ai-client';
 import { __ } from '@wordpress/i18n';
 import { image, starEmpty, media as mediaIcon } from '@wordpress/icons';
+import { getSocialScriptData } from '../../../utils';
 import { MediaSourceOption, MediaSourceType } from '../types';
 
 /**
@@ -14,6 +15,8 @@ import { MediaSourceOption, MediaSourceType } from '../types';
  * @return {MediaSourceOption[]} Array of media source options
  */
 export function getMediaSourceOptions(): MediaSourceOption[] {
+	const { plugin_info } = getSocialScriptData();
+
 	return [
 		{
 			id: 'sig',
@@ -37,17 +40,19 @@ export function getMediaSourceOptions(): MediaSourceOption[] {
 				'jetpack-publicize-pkg'
 			),
 		},
-		{
-			id: 'ai-image',
-			label: __( 'Generate image', 'jetpack-publicize-pkg' ),
-			description: __( 'You are using an AI-generated image.', 'jetpack-publicize-pkg' ),
-			icon: AiSVG,
-			group: 'attachment',
-			attachmentDescription: __(
-				'Shares your AI-generated image as an attachment for higher engagement.',
-				'jetpack-publicize-pkg'
-			),
-		},
+		plugin_info.jetpack.version
+			? {
+					id: 'ai-image',
+					label: __( 'Generate image', 'jetpack-publicize-pkg' ),
+					description: __( 'You are using an AI-generated image.', 'jetpack-publicize-pkg' ),
+					icon: AiSVG,
+					group: 'attachment',
+					attachmentDescription: __(
+						'Shares your AI-generated image as an attachment for higher engagement.',
+						'jetpack-publicize-pkg'
+					),
+			  }
+			: null,
 		{
 			id: 'media-library',
 			label: __( 'From Media Library', 'jetpack-publicize-pkg' ),
@@ -55,7 +60,7 @@ export function getMediaSourceOptions(): MediaSourceOption[] {
 			icon: mediaIcon,
 			group: 'attachment',
 		},
-	];
+	].filter( Boolean ) as MediaSourceOption[];
 }
 
 interface MediaSourceContext {

--- a/projects/packages/publicize/changelog/update-social-disable-ai-image-option-for-standalone-plugin
+++ b/projects/packages/publicize/changelog/update-social-disable-ai-image-option-for-standalone-plugin
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Disable AI image option in the media UI for standalone plugin.

--- a/projects/plugins/social/changelog/update-social-disable-ai-image-option-for-standalone-plugin
+++ b/projects/plugins/social/changelog/update-social-disable-ai-image-option-for-standalone-plugin
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Disable AI image option in the media UI when Jetpack plugin is not active.


### PR DESCRIPTION
See p1771422555884399/1771356705.540059-slack-C08PN0LHCCT

## Proposed changes:

The "Generate image" (AI image) option in the Social media source menu depends on the Jetpack AI module, which is only available when the Jetpack plugin is active. This PR hides the option when running as the standalone Social plugin, since clicking it would not work without the AI module.

- Conditionally include the `ai-image` media source option only when `plugin_info.jetpack.version` is set (i.e., the Jetpack plugin is active)
- Filter out `null` entries from the media source options array

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

N/A

## Does this pull request change what data or activity we track or use?

No changes to data tracking.

## Testing instructions:

### Standalone Social plugin (without Jetpack)
- Activate the Social plugin on a site without the Jetpack plugin
- Create or edit a post and open the Social preview modal
- Click on the media source dropdown
- **Verify**: The "Generate image" option is **not** shown

### With Jetpack plugin active
- Activate the Jetpack plugin (with or without the standalone Social plugin)
- Create or edit a post and open the Social preview modal
- Click on the media source dropdown
- **Verify**: The "Generate image" option **is** shown

## Changelog

- [ ] Generate changelog entries for this PR (using AI).

- With Jetpack
    <img width="350" height="438" alt="Screenshot 2026-02-18 at 7 41 12 PM" src="https://github.com/user-attachments/assets/809e1b98-e4e9-4074-b1fe-c1f7ab731f8e" />
- Without Jetpack
    <img width="353" height="440" alt="Screenshot 2026-02-18 at 7 41 50 PM" src="https://github.com/user-attachments/assets/2f825a50-b6b3-4f20-a986-9a345d977cae" />