### PR TITLE
Fix `jetpack draft disable` running wrong git hooks

### DIFF
--- a/tools/cli/commands/draft.js
+++ b/tools/cli/commands/draft.js
@@ -19,6 +19,22 @@ function getDraftFile() {
 }
 
 /**
+ * Returns the git hooks directory, respecting core.hooksPath if set.
+ *
+ * @return {string} - the hooks directory path
+ */
+function getHooksDir() {
+	const result = child_process.spawnSync( 'git', [ 'config', 'core.hooksPath' ], {
+		encoding: 'utf8',
+	} );
+	const hooksPath = result.stdout?.trim();
+	if ( hooksPath ) {
+		return path.resolve( process.cwd(), hooksPath );
+	}
+	return path.join( process.cwd(), '.git', 'hooks' );
+}
+
+/**
  * Enable draft mode.
  *
  * @param {object} argv - The argv for the command line.
@@ -78,7 +94,7 @@ export async function draftDisable( argv ) {
 
 		if ( preCommitAnswers.runPreCommit ) {
 			const data = child_process.spawnSync(
-				path.join( process.cwd(), '.git/hooks/pre-commit' ),
+				path.join( getHooksDir(), 'pre-commit' ),
 				[],
 				{ stdio: 'inherit' }
 			);
@@ -103,7 +119,7 @@ export async function draftDisable( argv ) {
 
 		// if ( prePushAnswers.runPrePush ) {
 		// 	const data = child_process.spawnSync(
-		// 		path.join( process.cwd(), '.git/hooks/pre-push' ),
+		// 		path.join( getHooksDir(), 'pre-push' ),
 		// 		[],
 		// 		{ stdio: "inherit" }
 		// 	);

--- a/tools/cli/commands/draft.js
+++ b/tools/cli/commands/draft.js
@@ -23,13 +23,20 @@ function getDraftFile() {
  *
  * @return {string} - the hooks directory path
  */
-function getHooksDir() {
+export function getHooksDir() {
 	const result = child_process.spawnSync( 'git', [ 'config', 'core.hooksPath' ], {
 		encoding: 'utf8',
 	} );
 	const hooksPath = result.stdout?.trim();
 	if ( hooksPath ) {
 		return path.resolve( process.cwd(), hooksPath );
+	}
+	const revParse = child_process.spawnSync( 'git', [ 'rev-parse', '--git-path', 'hooks' ], {
+		encoding: 'utf8',
+	} );
+	const gitHooksPath = revParse.stdout?.trim();
+	if ( gitHooksPath ) {
+		return path.resolve( process.cwd(), gitHooksPath );
 	}
 	return path.join( process.cwd(), '.git', 'hooks' );
 }
@@ -93,11 +100,9 @@ export async function draftDisable( argv ) {
 		] );
 
 		if ( preCommitAnswers.runPreCommit ) {
-			const data = child_process.spawnSync(
-				path.join( getHooksDir(), 'pre-commit' ),
-				[],
-				{ stdio: 'inherit' }
-			);
+			const data = child_process.spawnSync( path.join( getHooksDir(), 'pre-commit' ), [], {
+				stdio: 'inherit',
+			} );
 
 			// Node.js exit code status 0 === success
 			if ( data.status !== 0 ) {

--- a/tools/cli/tests/unit/commands/draft.test.js
+++ b/tools/cli/tests/unit/commands/draft.test.js
@@ -1,0 +1,93 @@
+import path from 'path';
+import { jest } from '@jest/globals';
+
+const mockSpawnSync = jest.fn();
+jest.unstable_mockModule( 'child_process', () => ( {
+	default: { spawnSync: mockSpawnSync },
+	spawnSync: mockSpawnSync,
+} ) );
+
+const { getHooksDir } = await import( '../../../commands/draft.js' );
+
+describe( 'getHooksDir', () => {
+	afterEach( () => {
+		mockSpawnSync.mockReset();
+	} );
+
+	test( 'returns core.hooksPath when set', () => {
+		mockSpawnSync.mockReturnValueOnce( {
+			stdout: '.husky',
+			status: 0,
+		} );
+
+		const result = getHooksDir();
+		expect( result ).toBe( path.resolve( process.cwd(), '.husky' ) );
+		expect( mockSpawnSync ).toHaveBeenCalledTimes( 1 );
+		expect( mockSpawnSync ).toHaveBeenCalledWith( 'git', [ 'config', 'core.hooksPath' ], {
+			encoding: 'utf8',
+		} );
+	} );
+
+	test( 'falls back to git rev-parse --git-path hooks when core.hooksPath is unset', () => {
+		mockSpawnSync
+			.mockReturnValueOnce( {
+				stdout: '',
+				status: 1,
+			} )
+			.mockReturnValueOnce( {
+				stdout: '.git/hooks',
+				status: 0,
+			} );
+
+		const result = getHooksDir();
+		expect( result ).toBe( path.resolve( process.cwd(), '.git/hooks' ) );
+		expect( mockSpawnSync ).toHaveBeenCalledTimes( 2 );
+		expect( mockSpawnSync ).toHaveBeenNthCalledWith(
+			2,
+			'git',
+			[ 'rev-parse', '--git-path', 'hooks' ],
+			{ encoding: 'utf8' }
+		);
+	} );
+
+	test( 'falls back to .git/hooks when both git commands fail', () => {
+		mockSpawnSync
+			.mockReturnValueOnce( {
+				stdout: '',
+				status: 1,
+			} )
+			.mockReturnValueOnce( {
+				stdout: '',
+				status: 1,
+			} );
+
+		const result = getHooksDir();
+		expect( result ).toBe( path.join( process.cwd(), '.git', 'hooks' ) );
+		expect( mockSpawnSync ).toHaveBeenCalledTimes( 2 );
+	} );
+
+	test( 'resolves absolute core.hooksPath as-is', () => {
+		mockSpawnSync.mockReturnValueOnce( {
+			stdout: '/opt/git-hooks',
+			status: 0,
+		} );
+
+		const result = getHooksDir();
+		expect( result ).toBe( '/opt/git-hooks' );
+	} );
+
+	test( 'handles worktree hooks path from rev-parse', () => {
+		mockSpawnSync
+			.mockReturnValueOnce( {
+				stdout: '',
+				status: 1,
+			} )
+			.mockReturnValueOnce( {
+				stdout: '../.git/worktrees/my-branch/hooks',
+				status: 0,
+			} );
+
+		const result = getHooksDir();
+		expect( result ).toBe( path.resolve( process.cwd(), '../.git/worktrees/my-branch/hooks' ) );
+	} );
+} );


### PR DESCRIPTION
## Proposed changes:
* `jetpack draft disable` hardcoded `.git/hooks/pre-commit` when running pre-commit
  checks, ignoring git's `core.hooksPath` setting. Users with native husky hooks
  (set up via `pnpm install`, which sets `core.hooksPath=.husky/_`) who had stale
  Docker-delegating hooks in `.git/hooks/` from a previous `jp init-hooks` would
  see hooks run through Docker instead of natively.
* Add a `getHooksDir()` helper that checks `core.hooksPath` first and falls back
  to `.git/hooks/` when unset. Also fix the same path in the commented-out
  pre-push block.

### Other information:
- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
1. Run `pnpm install` at the monorepo root (this sets `core.hooksPath=.husky/_` via husky)
2. Run `jp init-hooks` to create Docker-delegating hooks in `.git/hooks/`
3. Run `pnpm install` again to restore `core.hooksPath=.husky/_`
4. Run `jetpack draft enable`, then `jetpack draft disable` and answer Y to run pre-commit checks
5. Verify hooks run natively (you should NOT see "Using jp hooks (delegating to Docker)")

## Changelog
- [ ] Generate changelog entries for this PR (using AI).
