### PR TITLE
Status: Remove incorrect content-type from Vary header

### DIFF
--- a/projects/packages/status/changelog/fix-vary-header-content-type
+++ b/projects/packages/status/changelog/fix-vary-header-content-type
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Remove incorrect `content-type` from Vary header. Per RFC 7231 Section 7.1.4, Vary should only reference request headers, and Content-Type is a response header.

--- a/projects/packages/status/src/class-request.php
+++ b/projects/packages/status/src/class-request.php
@@ -71,7 +71,11 @@ class Request {
 
 	/**
 	 * Go through headers and get a list of Vary headers to add,
-	 * including Vary on Accept and Content-Type if necessary.
+	 * including Vary on Accept if necessary.
+	 *
+	 * Note: Content-Type was previously included but was removed because it's
+	 * a response header, not a request header. Per RFC 7231 Section 7.1.4,
+	 * the Vary header should only reference request headers.
 	 *
 	 * @since jetpack-12.2
 	 *
@@ -80,7 +84,7 @@ class Request {
 	 * @return array $vary_header_parts Vary Headers to be sent.
 	 */
 	public static function get_vary_headers( $headers = array() ) {
-		$vary_header_parts = array( 'accept', 'content-type' );
+		$vary_header_parts = array( 'accept' );
 
 		foreach ( $headers as $header ) {
 			// Check for a Vary header.

--- a/projects/packages/status/tests/php/Request_Test.php
+++ b/projects/packages/status/tests/php/Request_Test.php
@@ -64,7 +64,7 @@ class Request_Test extends TestCase {
 		// Set up header expectations
 		if ( $should_set_headers ) {
 			Functions\when( 'headers_list' )->justReturn( array() );
-			Functions\expect( 'header' )->once()->with( 'Vary: accept, content-type' );
+			Functions\expect( 'header' )->once()->with( 'Vary: accept' );
 		} else {
 			Functions\expect( 'header' )->never();
 		}
@@ -204,7 +204,7 @@ class Request_Test extends TestCase {
 		return array(
 			'no existing headers'                       => array(
 				'existing_headers' => array(),
-				'expected_header'  => 'Vary: accept, content-type',
+				'expected_header'  => 'Vary: accept',
 			),
 			'existing Accept-Encoding header'           => array(
 				'existing_headers' => array(
@@ -212,7 +212,7 @@ class Request_Test extends TestCase {
 					'Content-Type: text/html; charset=UTF-8',
 					'Vary: Accept-Encoding',
 				),
-				'expected_header'  => 'Vary: accept, content-type, accept-encoding',
+				'expected_header'  => 'Vary: accept, accept-encoding',
 			),
 			'multiple Vary headers'                     => array(
 				'existing_headers' => array(
@@ -221,7 +221,7 @@ class Request_Test extends TestCase {
 					'Vary: Accept',
 					'Vary: Accept-Encoding',
 				),
-				'expected_header'  => 'Vary: accept, content-type, accept-encoding',
+				'expected_header'  => 'Vary: accept, accept-encoding',
 			),
 			'wildcard Vary header'                      => array(
 				'existing_headers' => array(
@@ -237,7 +237,7 @@ class Request_Test extends TestCase {
 					'Content-Type: text/html; charset=UTF-8',
 					'Vary: Accept',
 				),
-				'expected_header'  => 'Vary: accept, content-type',
+				'expected_header'  => 'Vary: accept',
 			),
 			'mixed case Vary header'                    => array(
 				'existing_headers' => array(
@@ -245,7 +245,7 @@ class Request_Test extends TestCase {
 					'Content-Type: text/html; charset=UTF-8',
 					'Vary: Accept-Language, Accept-Encoding',
 				),
-				'expected_header'  => 'Vary: accept, content-type, accept-language, accept-encoding',
+				'expected_header'  => 'Vary: accept, accept-language, accept-encoding',
 			),
 		);
 	}
@@ -271,7 +271,7 @@ class Request_Test extends TestCase {
 			Functions\when( 'wp_is_xml_request' )->justReturn( false );
 			Functions\when( 'headers_sent' )->justReturn( false );
 			Functions\when( 'headers_list' )->justReturn( array() );
-			Functions\expect( 'header' )->once()->with( 'Vary: accept, content-type' );
+			Functions\expect( 'header' )->once()->with( 'Vary: accept' );
 		} else {
 			// Non-frontend request setup (admin)
 			Functions\when( 'is_admin' )->justReturn( true );
@@ -344,19 +344,19 @@ class Request_Test extends TestCase {
 		return array(
 			'no headers'                             => array(
 				array(),
-				array( 'accept', 'content-type' ),
+				array( 'accept' ),
 			),
 			'Single Vary Encoding header'            => array(
 				array(
 					'Vary: Accept-Encoding',
 				),
-				array( 'accept', 'content-type', 'accept-encoding' ),
+				array( 'accept', 'accept-encoding' ),
 			),
 			'Double Vary: Accept-Encoding & Accept'  => array(
 				array(
 					'Vary: Accept, Accept-Encoding',
 				),
-				array( 'accept', 'content-type', 'accept-encoding' ),
+				array( 'accept', 'accept-encoding' ),
 			),
 			'vary header'                            => array(
 				array(
@@ -364,7 +364,7 @@ class Request_Test extends TestCase {
 					'Content-Type: text/html; charset=UTF-8',
 					'Vary: Accept',
 				),
-				array( 'accept', 'content-type' ),
+				array( 'accept' ),
 			),
 			'Wildcard Vary header'                   => array(
 				array(
@@ -381,7 +381,7 @@ class Request_Test extends TestCase {
 					'Vary: Accept',
 					'Vary: Accept-Encoding',
 				),
-				array( 'accept', 'content-type', 'accept-encoding' ),
+				array( 'accept', 'accept-encoding' ),
 			),
 			'Multiple Vary headers, with a wildcard' => array(
 				array(


### PR DESCRIPTION
## Summary

Removes `content-type` from the Vary header in `Request::get_vary_headers()`.

## Problem

The current implementation adds `Vary: accept, content-type` to responses. However, `Content-Type` is a **response header**, not a request header. Per [RFC 7231 Section 7.1.4](https://datatracker.ietf.org/doc/html/rfc7231#section-7.1.4):

> The "Vary" header field in a response describes what parts of a **request message**, other than the method, Host header field, and request target, might influence the origin server's process for selecting and representing this response.

Including a response header in Vary is semantically incorrect and provides no caching benefit.

## Background

This was originally added in [PR #30413](https://github.com/Automattic/jetpack/pull/30413) to prevent cache pollution between HTML and JSON (ActivityPub) responses. The `accept` header is correct for this purpose, but `content-type` was mistakenly included alongside it.

## Changes

- Removed `content-type` from `$vary_header_parts` array in `get_vary_headers()`
- Updated docblock to explain why it was removed
- Updated all corresponding test assertions

## Testing

- All existing tests updated and passing
- `composer test-php` passes with 105 tests, 124 assertions