### PR TITLE
Detect jp vs jetpack CLI in post-checkout/merge hook

### DIFF
--- a/tools/js-tools/git-hooks/post-merge-checkout-hook.sh
+++ b/tools/js-tools/git-hooks/post-merge-checkout-hook.sh
@@ -26,7 +26,15 @@ if [[ ${#changedSlugs[@]} -gt 0 || -n "$rootChanged" ]]; then
 		installArgs+=("-r")
 	fi
 	installArgs+=("${changedSlugs[@]}")
-	echo -e "${SEP}Lock files have changed. To update, run:\n  jetpack install ${installArgs[*]}"
+
+	# Detect whether to suggest `jetpack` or `jp` based on hook configuration.
+	if git config core.hooksPath > /dev/null 2>&1; then
+		CLI_CMD="jetpack"
+	else
+		CLI_CMD="jp"
+	fi
+
+	echo -e "${SEP}Lock files have changed. To update, run:\n  $CLI_CMD install ${installArgs[*]}"
 	SEP=
 fi
 

--- a/tools/js-tools/git-hooks/post-merge-checkout-hook.sh
+++ b/tools/js-tools/git-hooks/post-merge-checkout-hook.sh
@@ -27,11 +27,13 @@ if [[ ${#changedSlugs[@]} -gt 0 || -n "$rootChanged" ]]; then
 	fi
 	installArgs+=("${changedSlugs[@]}")
 
-	# Detect whether to suggest `jetpack` or `jp` based on hook configuration.
-	if git config core.hooksPath > /dev/null 2>&1; then
-		CLI_CMD="jetpack"
-	else
+	# Detect whether to suggest `jp` or `jetpack` by checking how the hook was installed.
+	# jp-installed hooks (in .git/hooks/) contain "jp git-hook"; Husky hooks don't.
+	HOOKDIR="$(git rev-parse --git-path hooks)"
+	if grep -q 'jp git-hook' "$HOOKDIR/post-merge" "$HOOKDIR/post-checkout" 2>/dev/null; then
 		CLI_CMD="jp"
+	else
+		CLI_CMD="jetpack"
 	fi
 
 	echo -e "${SEP}Lock files have changed. To update, run:\n  $CLI_CMD install ${installArgs[*]}"


### PR DESCRIPTION
## Proposed changes:
* The post-checkout and post-merge hooks always suggest `jetpack install` when lock files change, but Docker workflow users need `jp install`. Detect the right command by checking `git config core.hooksPath`: if set (Husky), use `jetpack`; if unset (`jp git-hook` installed hooks), use `jp`.

### Other information:
- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
* Pick a commit that changed lock files (e.g. `9b98a6bd53`):
  ```
  # With core.hooksPath unset (Docker) → should say "jp install":
  bash tools/js-tools/git-hooks/post-merge-checkout-hook.sh 9b98a6bd53~1

  # With core.hooksPath set (local dev) → should say "jetpack install":
  git config core.hooksPath .husky
  bash tools/js-tools/git-hooks/post-merge-checkout-hook.sh 9b98a6bd53~1
  git config --unset core.hooksPath
  ```

## Changelog
- [ ] Generate changelog entries for this PR (using AI).