### PR TITLE
Post Media: Add Shortcodes class for shortcode ID extraction

### DIFF
--- a/projects/packages/post-media/changelog/jeherve-shortcode-extractors
+++ b/projects/packages/post-media/changelog/jeherve-shortcode-extractors
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add Shortcodes class with methods to extract media identifiers from shortcode attributes (YouTube, Vimeo, TED, VideoPress, Hulu, Archive.org).

--- a/projects/packages/post-media/src/class-shortcodes.php
+++ b/projects/packages/post-media/src/class-shortcodes.php
@@ -1,0 +1,254 @@
+<?php
+/**
+ * Shortcode ID extraction methods.
+ *
+ * Provides static methods to extract identifiers from shortcode attributes
+ * for various media types (YouTube, Vimeo, TED, VideoPress, etc.).
+ *
+ * @package automattic/jetpack-post-media
+ */
+
+namespace Automattic\Jetpack;
+
+/**
+ * Extracts media identifiers from shortcode attributes.
+ *
+ * @since $$next-version$$
+ */
+class Shortcodes {
+
+	/**
+	 * Get an ID from a shortcode attribute by key.
+	 *
+	 * Used for shortcodes that store their identifier in a single attribute,
+	 * e.g. ted and hulu use a named 'id' attribute, while wpvideo and
+	 * videopress use the first positional attribute.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param array      $atts Shortcode attributes.
+	 * @param string|int $key  The attribute key to look up. Defaults to 0 (first positional attribute).
+	 * @return string|int The attribute value, or 0 if not found.
+	 */
+	public static function get_attribute_id( $atts, $key = 0 ) {
+		return ! empty( $atts[ $key ] ) ? $atts[ $key ] : 0;
+	}
+
+	/**
+	 * Normalizes a YouTube URL to include a v= parameter and a query string free of encoded ampersands.
+	 *
+	 * Handles youtu.be short links, /v/ paths, /shorts/ paths, playlist URLs, and encoded ampersands.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param string|array $url YouTube URL, or an array with a 'url' key.
+	 * @return string|false The normalized URL, or false if input is invalid.
+	 */
+	public static function sanitize_youtube_url( $url ) {
+		if ( is_array( $url ) && isset( $url['url'] ) ) {
+			$url = $url['url'];
+		}
+		if ( ! is_string( $url ) ) {
+			return false;
+		}
+
+		$url = trim( $url, ' "' );
+		$url = trim( $url );
+		$url = str_replace(
+			array( 'youtu.be/', '/v/', '/shorts/', '#!v=', '&amp;', '&#038;', 'playlist' ),
+			array( 'youtu.be/?v=', '/?v=', '/watch?v=', '?v=', '&', '&', 'videoseries' ),
+			$url
+		);
+
+		// Replace any extra question marks with ampersands - the result of a URL like
+		// "https://www.youtube.com/v/dQw4w9WgXcQ?fs=1&hl=en_US" being passed in.
+		$query_string_start = strpos( $url, '?' );
+
+		if ( false !== $query_string_start ) {
+			$url = substr( $url, 0, $query_string_start + 1 ) . str_replace( '?', '&', substr( $url, $query_string_start + 1 ) );
+		}
+
+		return $url;
+	}
+
+	/**
+	 * Extract a YouTube video or playlist ID from shortcode attributes.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param string|array $atts Shortcode attributes. Can be just the URL string or the full $atts array.
+	 * @return string|false The YouTube video or playlist ID, or false on failure.
+	 */
+	public static function get_youtube_id( $atts ) {
+		// Do we have an $atts array? Get first att.
+		if ( is_array( $atts ) ) {
+			$atts = reset( $atts );
+		}
+
+		$url = self::sanitize_youtube_url( $atts );
+
+		if ( ! is_string( $url ) || '' === $url ) {
+			return false;
+		}
+
+		$parsed = parse_url( $url ); // phpcs:ignore WordPress.WP.AlternativeFunctions.parse_url_parse_url
+
+		if ( ! is_array( $parsed ) || ! isset( $parsed['query'] ) ) {
+			return false;
+		}
+
+		parse_str( $parsed['query'], $qargs );
+
+		if ( ! isset( $qargs['v'] ) && ! isset( $qargs['list'] ) ) {
+			return false;
+		}
+
+		$id = '';
+
+		if ( isset( $qargs['list'] ) ) {
+			$id = preg_replace( '|[^_a-z0-9-]|i', '', $qargs['list'] );
+		}
+
+		if ( empty( $id ) && isset( $qargs['v'] ) ) {
+			$id = preg_replace( '|[^_a-z0-9-]|i', '', $qargs['v'] );
+		}
+
+		return empty( $id ) ? false : $id;
+	}
+
+	/**
+	 * Extract a Vimeo video ID from shortcode attributes.
+	 *
+	 * Supports numeric IDs and various Vimeo URL formats including
+	 * groups, albums, channels, and player URLs.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param array $atts Shortcode attributes.
+	 * @return int The Vimeo video ID, or 0 if not found.
+	 */
+	public static function get_vimeo_id( $atts ) {
+		if ( isset( $atts[0] ) ) {
+			$atts[0] = trim( $atts[0], '=' );
+			if ( is_numeric( $atts[0] ) ) {
+				return (int) $atts[0];
+			}
+
+			/**
+			 * Extract Vimeo ID from the URL. For examples:
+			 * https://vimeo.com/12345
+			 * https://vimeo.com/289091934/cd1f466bcc
+			 * https://vimeo.com/album/2838732/video/6342264
+			 * https://vimeo.com/groups/758728/videos/897094040
+			 * https://vimeo.com/channels/staffpicks/videos/123456789
+			 * https://vimeo.com/album/1234567/video/7654321
+			 * https://player.vimeo.com/video/18427511
+			 */
+			$pattern = '/(?:https?:\/\/)?vimeo\.com\/(?:groups\/\d+\/videos\/|album\/\d+\/video\/|video\/|channels\/[^\/]+\/videos\/|[^\/]+\/)?([0-9]+)(?:[^\'\"0-9<]|$)/i';
+			$match   = array();
+			if ( preg_match( $pattern, $atts[0], $match ) ) {
+				return (int) $match[1];
+			}
+		}
+
+		return 0;
+	}
+
+	/**
+	 * Get the unique ID of a TED video from shortcode attributes.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param array $atts Shortcode attributes.
+	 * @return string|int The TED video ID, or 0 if not found.
+	 */
+	public static function get_ted_id( $atts ) {
+		return self::get_attribute_id( $atts, 'id' );
+	}
+
+	/**
+	 * Get a VideoPress ID from wpvideo shortcode attributes.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param array $atts Shortcode attributes.
+	 * @return string|int The VideoPress ID, or 0 if not found.
+	 */
+	public static function get_wpvideo_id( $atts ) {
+		return self::get_attribute_id( $atts );
+	}
+
+	/**
+	 * Get a VideoPress ID from videopress shortcode attributes.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param array $atts Shortcode attributes.
+	 * @return string|int The VideoPress ID, or 0 if not found.
+	 */
+	public static function get_videopress_id( $atts ) {
+		return self::get_attribute_id( $atts );
+	}
+
+	/**
+	 * Get a Hulu video ID from shortcode attributes.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param array $atts Shortcode attributes.
+	 * @return string|int The Hulu video ID, or 0 if not found.
+	 */
+	public static function get_hulu_id( $atts ) {
+		return self::get_attribute_id( $atts, 'id' );
+	}
+
+	/**
+	 * Get an Archive.org embed ID from shortcode attributes.
+	 *
+	 * Extracts the identifier from an Archive.org details or embed URL,
+	 * or uses the raw attribute value if it is not a URL.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param array $atts Shortcode attributes.
+	 * @return string|int The Archive.org identifier, the raw attribute value
+	 *                     (which may be empty), or 0 if the attribute is not set.
+	 */
+	public static function get_archiveorg_id( $atts ) {
+		if ( isset( $atts[0] ) ) {
+			$atts[0] = trim( $atts[0], '=' );
+			if ( preg_match( '~archive\.org/(details|embed)/([^/?#]+)~i', $atts[0], $match ) ) {
+				$id = $match[2];
+			} else {
+				$id = $atts[0];
+			}
+			return $id;
+		}
+		return 0;
+	}
+
+	/**
+	 * Get an Archive.org book embed ID from shortcode attributes.
+	 *
+	 * Extracts the identifier from an Archive.org stream URL,
+	 * or uses the raw attribute value if it is not a URL.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param array $atts Shortcode attributes.
+	 * @return string|int The Archive.org book identifier, the raw attribute value
+	 *                     (which may be empty), or 0 if the attribute is not set.
+	 */
+	public static function get_archiveorg_book_id( $atts ) {
+		if ( isset( $atts[0] ) ) {
+			$atts[0] = trim( $atts[0], '=' );
+			if ( preg_match( '~archive\.org/stream/([^/?#]+)~i', $atts[0], $match ) ) {
+				$id = $match[1];
+			} else {
+				$id = $atts[0];
+			}
+			return $id;
+		}
+		return 0;
+	}
+}

--- a/projects/packages/post-media/src/class-shortcodes.php
+++ b/projects/packages/post-media/src/class-shortcodes.php
@@ -144,7 +144,7 @@ class Shortcodes {
 			 * https://vimeo.com/album/1234567/video/7654321
 			 * https://player.vimeo.com/video/18427511
 			 */
-			$pattern = '/(?:https?:\/\/)?vimeo\.com\/(?:groups\/\d+\/videos\/|album\/\d+\/video\/|video\/|channels\/[^\/]+\/videos\/|[^\/]+\/)?([0-9]+)(?:[^\'\"0-9<]|$)/i';
+			$pattern = '/(?:https?:\/\/)?vimeo\.com\/(?:groups\/[^\/]+\/videos\/|album\/\d+\/video\/|video\/|channels\/[^\/]+\/videos\/|[^\/]+\/)?([0-9]+)(?:[^\'\"0-9<]|$)/i';
 			$match   = array();
 			if ( preg_match( $pattern, $atts[0], $match ) ) {
 				return (int) $match[1];

--- a/projects/packages/post-media/tests/php/Shortcodes_Test.php
+++ b/projects/packages/post-media/tests/php/Shortcodes_Test.php
@@ -1,0 +1,437 @@
+<?php
+/**
+ * Tests for the Shortcodes class.
+ *
+ * @package automattic/jetpack-post-media
+ */
+
+use Automattic\Jetpack\Shortcodes;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Test shortcode ID extraction methods.
+ *
+ * @covers \Automattic\Jetpack\Shortcodes
+ */
+#[CoversClass( Shortcodes::class )]
+class Shortcodes_Test extends TestCase {
+
+	// ----------------------------- YouTube -----------------------------------
+
+	/**
+	 * Test extracting a YouTube video ID from a standard watch URL.
+	 */
+	public function test_get_youtube_id_with_single_video_url() {
+		$url = 'https://www.youtube.com/watch?v=snAvGxz7D04';
+		$this->assertSame( 'snAvGxz7D04', Shortcodes::get_youtube_id( $url ) );
+	}
+
+	/**
+	 * Test extracting a YouTube playlist ID.
+	 */
+	public function test_get_youtube_id_with_playlist_url() {
+		$url = 'https://www.youtube.com/playlist?list=PL56C3506BBE979C1B';
+		$this->assertSame( 'PL56C3506BBE979C1B', Shortcodes::get_youtube_id( $url ) );
+	}
+
+	/**
+	 * Test extracting a YouTube video ID from a shorts URL.
+	 */
+	public function test_get_youtube_id_with_shorts_url() {
+		$this->assertSame( 'VIDEO_ID', Shortcodes::get_youtube_id( 'https://www.youtube.com/shorts/VIDEO_ID' ) );
+	}
+
+	/**
+	 * Test extracting a YouTube video ID from a youtu.be short URL.
+	 */
+	public function test_get_youtube_id_with_short_url() {
+		$url = 'https://youtu.be/dQw4w9WgXcQ';
+		$this->assertSame( 'dQw4w9WgXcQ', Shortcodes::get_youtube_id( $url ) );
+	}
+
+	/**
+	 * Test extracting a YouTube video ID from a /v/ URL format.
+	 */
+	public function test_get_youtube_id_with_v_path_url() {
+		$url = 'https://www.youtube.com/v/dQw4w9WgXcQ?fs=1&hl=en_US';
+		$this->assertSame( 'dQw4w9WgXcQ', Shortcodes::get_youtube_id( $url ) );
+	}
+
+	/**
+	 * Test extracting a YouTube video ID when attributes are an array.
+	 */
+	public function test_get_youtube_id_with_array_atts() {
+		$atts = array( 'https://www.youtube.com/watch?v=snAvGxz7D04' );
+		$this->assertSame( 'snAvGxz7D04', Shortcodes::get_youtube_id( $atts ) );
+	}
+
+	/**
+	 * Test that a URL without a video ID returns false.
+	 */
+	public function test_get_youtube_id_returns_false_for_url_without_id() {
+		$this->assertFalse( Shortcodes::get_youtube_id( 'https://www.youtube.com/' ) );
+	}
+
+	/**
+	 * Test extracting a YouTube video ID from a URL with encoded ampersands.
+	 */
+	public function test_get_youtube_id_with_encoded_ampersands() {
+		$url = 'https://www.youtube.com/watch?v=snAvGxz7D04&amp;feature=related';
+		$this->assertSame( 'snAvGxz7D04', Shortcodes::get_youtube_id( $url ) );
+	}
+
+	/**
+	 * Test that a URL with an empty v= parameter returns false.
+	 */
+	public function test_get_youtube_id_returns_false_for_empty_v() {
+		$this->assertFalse( Shortcodes::get_youtube_id( 'https://www.youtube.com/watch?v=' ) );
+	}
+
+	/**
+	 * Test that get_youtube_id handles non-string input gracefully.
+	 */
+	public function test_get_youtube_id_returns_false_for_non_string() {
+		// @phan-suppress-next-line PhanTypeMismatchArgument -- This is testing the error case.
+		$this->assertFalse( Shortcodes::get_youtube_id( 42 ) );
+	}
+
+	/**
+	 * Test that a playlist URL returns the list ID when there's no v parameter.
+	 */
+	public function test_get_youtube_id_playlist_over_empty_v() {
+		$url = 'https://www.youtube.com/playlist?list=PLrAXtmErZgOeiKm4sgNOknGvNjby9efdf';
+		$this->assertSame( 'PLrAXtmErZgOeiKm4sgNOknGvNjby9efdf', Shortcodes::get_youtube_id( $url ) );
+	}
+
+	// ----------------------- sanitize_youtube_url ----------------------------
+
+	/**
+	 * Test sanitize_youtube_url with a standard URL.
+	 */
+	public function test_sanitize_youtube_url_standard() {
+		$url = 'https://www.youtube.com/watch?v=dQw4w9WgXcQ';
+		$this->assertSame( $url, Shortcodes::sanitize_youtube_url( $url ) );
+	}
+
+	/**
+	 * Test sanitize_youtube_url with a youtu.be short URL.
+	 */
+	public function test_sanitize_youtube_url_short_url() {
+		$url    = 'https://youtu.be/dQw4w9WgXcQ';
+		$result = Shortcodes::sanitize_youtube_url( $url );
+		$this->assertStringContainsString( '?v=dQw4w9WgXcQ', $result );
+	}
+
+	/**
+	 * Test sanitize_youtube_url replaces encoded ampersands.
+	 */
+	public function test_sanitize_youtube_url_encoded_ampersands() {
+		$url = 'https://www.youtube.com/watch?v=abc&amp;feature=related';
+		$this->assertStringNotContainsString( '&amp;', Shortcodes::sanitize_youtube_url( $url ) );
+	}
+
+	/**
+	 * Test sanitize_youtube_url with non-string input returns false.
+	 */
+	public function test_sanitize_youtube_url_non_string_returns_false() {
+		// @phan-suppress-next-line PhanTypeMismatchArgument -- This is testing the error case.
+		$this->assertFalse( Shortcodes::sanitize_youtube_url( 42 ) );
+	}
+
+	/**
+	 * Test sanitize_youtube_url with an array containing a 'url' key.
+	 */
+	public function test_sanitize_youtube_url_with_array_url_key() {
+		$url    = array( 'url' => 'https://www.youtube.com/watch?v=abc' );
+		$result = Shortcodes::sanitize_youtube_url( $url );
+		$this->assertStringContainsString( 'v=abc', $result );
+	}
+
+	/**
+	 * Test sanitize_youtube_url with a shorts URL.
+	 */
+	public function test_sanitize_youtube_url_shorts() {
+		$result = Shortcodes::sanitize_youtube_url( 'https://www.youtube.com/shorts/VIDEO_ID' );
+		$this->assertStringContainsString( '/watch?v=VIDEO_ID', $result );
+	}
+
+	/**
+	 * Test sanitize_youtube_url with a /v/ path URL.
+	 */
+	public function test_sanitize_youtube_url_v_path() {
+		$result = Shortcodes::sanitize_youtube_url( 'https://www.youtube.com/v/dQw4w9WgXcQ?fs=1&hl=en_US' );
+		$this->assertStringContainsString( '?v=dQw4w9WgXcQ', $result );
+	}
+
+	// ----------------------------- Vimeo -------------------------------------
+
+	/**
+	 * Provides Vimeo URL test cases.
+	 *
+	 * @return array
+	 */
+	public static function provide_vimeo_urls() {
+		return array(
+			'simple id'                     => array(
+				array( '6342264' ),
+				6342264,
+			),
+			'id with leading equals'        => array(
+				array( '=6342264' ),
+				6342264,
+			),
+			'simple URL'                    => array(
+				array( 'https://vimeo.com/6342264 ' ),
+				6342264,
+			),
+			'unlisted video'                => array(
+				array( 'https://vimeo.com/289091934/cd1f466bcc' ),
+				289091934,
+			),
+			'video within a playlist'       => array(
+				array( 'https://vimeo.com/album/2838732/video/6342264' ),
+				6342264,
+			),
+			'player URL'                    => array(
+				array( 'http://player.vimeo.com/video/18427511' ),
+				18427511,
+			),
+			'groups URL'                    => array(
+				array( 'https://vimeo.com/groups/758728/videos/897094040' ),
+				897094040,
+			),
+			'channels URL'                  => array(
+				array( 'https://vimeo.com/channels/staffpicks/videos/123456789 ' ),
+				123456789,
+			),
+			'empty attributes returns 0'    => array(
+				array(),
+				0,
+			),
+			'non-numeric non-URL returns 0' => array(
+				array( 'notavimeourl' ),
+				0,
+			),
+		);
+	}
+
+	/**
+	 * Test Vimeo ID extraction with various URL formats.
+	 *
+	 * @dataProvider provide_vimeo_urls
+	 *
+	 * @param array $atts     Shortcode attributes.
+	 * @param int   $expected Expected Vimeo ID.
+	 */
+	#[DataProvider( 'provide_vimeo_urls' )]
+	public function test_get_vimeo_id( $atts, $expected ) {
+		$this->assertSame( $expected, Shortcodes::get_vimeo_id( $atts ) );
+	}
+
+	// ----------------------------- get_attribute_id ----------------------------
+
+	/**
+	 * Test get_attribute_id with default key (positional 0), as used by wpvideo/videopress.
+	 */
+	public function test_get_attribute_id_positional() {
+		$this->assertSame( 'AbCd1234', Shortcodes::get_attribute_id( array( 'AbCd1234' ) ) );
+	}
+
+	/**
+	 * Test get_attribute_id with named key, as used by ted/hulu.
+	 */
+	public function test_get_attribute_id_named() {
+		$this->assertSame( '210', Shortcodes::get_attribute_id( array( 'id' => '210' ), 'id' ) );
+	}
+
+	/**
+	 * Test get_attribute_id with a numeric value.
+	 */
+	public function test_get_attribute_id_numeric_value() {
+		$this->assertSame( 1539, Shortcodes::get_attribute_id( array( 'id' => 1539 ), 'id' ) );
+	}
+
+	/**
+	 * Test get_attribute_id returns 0 for empty attributes.
+	 */
+	public function test_get_attribute_id_returns_0_for_empty_atts() {
+		$this->assertSame( 0, Shortcodes::get_attribute_id( array() ) );
+	}
+
+	/**
+	 * Test get_attribute_id returns 0 when the requested key is missing.
+	 */
+	public function test_get_attribute_id_returns_0_for_missing_key() {
+		$this->assertSame( 0, Shortcodes::get_attribute_id( array( 'lang' => 'en' ), 'id' ) );
+	}
+
+	// ----------------------------- Wrapper methods ----------------------------
+
+	/**
+	 * Test get_ted_id returns the named 'id' attribute.
+	 */
+	public function test_get_ted_id_with_named_id() {
+		$this->assertSame( '210', Shortcodes::get_ted_id( array( 'id' => '210' ) ) );
+	}
+
+	/**
+	 * Test get_ted_id returns 0 for positional attributes (uses 'id' key).
+	 */
+	public function test_get_ted_id_ignores_positional() {
+		$this->assertSame( 0, Shortcodes::get_ted_id( array( '210' ) ) );
+	}
+
+	/**
+	 * Test get_hulu_id returns the named 'id' attribute.
+	 */
+	public function test_get_hulu_id_with_named_id() {
+		$this->assertSame( '123456', Shortcodes::get_hulu_id( array( 'id' => '123456' ) ) );
+	}
+
+	/**
+	 * Test get_hulu_id returns 0 for positional attributes (uses 'id' key).
+	 */
+	public function test_get_hulu_id_ignores_positional() {
+		$this->assertSame( 0, Shortcodes::get_hulu_id( array( '123456' ) ) );
+	}
+
+	/**
+	 * Test get_wpvideo_id returns the first positional attribute.
+	 */
+	public function test_get_wpvideo_id_with_positional() {
+		$this->assertSame( 'abc123', Shortcodes::get_wpvideo_id( array( 'abc123' ) ) );
+	}
+
+	/**
+	 * Test get_wpvideo_id returns 0 for named attributes (uses positional key).
+	 */
+	public function test_get_wpvideo_id_ignores_named() {
+		$this->assertSame( 0, Shortcodes::get_wpvideo_id( array( 'id' => 'abc123' ) ) );
+	}
+
+	/**
+	 * Test get_videopress_id returns the first positional attribute.
+	 */
+	public function test_get_videopress_id_with_positional() {
+		$this->assertSame( 'xyz789', Shortcodes::get_videopress_id( array( 'xyz789' ) ) );
+	}
+
+	/**
+	 * Test get_videopress_id returns 0 for named attributes (uses positional key).
+	 */
+	public function test_get_videopress_id_ignores_named() {
+		$this->assertSame( 0, Shortcodes::get_videopress_id( array( 'id' => 'xyz789' ) ) );
+	}
+
+	// ----------------------------- Archive.org -------------------------------
+
+	/**
+	 * Provides Archive.org shortcode test cases.
+	 *
+	 * @return array
+	 */
+	public static function provide_archiveorg_atts() {
+		return array(
+			'plain identifier'             => array(
+				array( 'Experime1940' ),
+				'Experime1940',
+			),
+			'details URL'                  => array(
+				array( 'http://archive.org/details/Experime1940' ),
+				'Experime1940',
+			),
+			'https details URL'            => array(
+				array( 'https://archive.org/details/Experime1940' ),
+				'Experime1940',
+			),
+			'embed URL'                    => array(
+				array( 'https://archive.org/embed/Experime1940' ),
+				'Experime1940',
+			),
+			'with leading equals'          => array(
+				array( '=Experime1940' ),
+				'Experime1940',
+			),
+			'URL with query string'        => array(
+				array( 'https://archive.org/details/Experime1940?foo=bar' ),
+				'Experime1940',
+			),
+			'URL with extra path segments' => array(
+				array( 'https://archive.org/details/Experime1940/page/n3' ),
+				'Experime1940',
+			),
+			'empty attributes'             => array(
+				array(),
+				0,
+			),
+		);
+	}
+
+	/**
+	 * Test Archive.org ID extraction from various formats.
+	 *
+	 * @dataProvider provide_archiveorg_atts
+	 *
+	 * @param array      $atts     Shortcode attributes.
+	 * @param string|int $expected Expected Archive.org identifier.
+	 */
+	#[DataProvider( 'provide_archiveorg_atts' )]
+	public function test_get_archiveorg_id( $atts, $expected ) {
+		$this->assertSame( $expected, Shortcodes::get_archiveorg_id( $atts ) );
+	}
+
+	// ----------------------------- Archive.org Book --------------------------
+
+	/**
+	 * Provides Archive.org book shortcode test cases.
+	 *
+	 * @return array
+	 */
+	public static function provide_archiveorg_book_atts() {
+		return array(
+			'plain identifier'             => array(
+				array( 'goodytwoshoes00newyiala' ),
+				'goodytwoshoes00newyiala',
+			),
+			'stream URL'                   => array(
+				array( 'https://www.archive.org/stream/goodytwoshoes00newyiala' ),
+				'goodytwoshoes00newyiala',
+			),
+			'http stream URL'              => array(
+				array( 'http://archive.org/stream/goodytwoshoes00newyiala' ),
+				'goodytwoshoes00newyiala',
+			),
+			'with leading equals'          => array(
+				array( '=goodytwoshoes00newyiala' ),
+				'goodytwoshoes00newyiala',
+			),
+			'URL with extra path segments' => array(
+				array( 'https://archive.org/stream/goodytwoshoes00newyiala/page/n3' ),
+				'goodytwoshoes00newyiala',
+			),
+			'URL with query string'        => array(
+				array( 'https://archive.org/stream/goodytwoshoes00newyiala?ui=embed' ),
+				'goodytwoshoes00newyiala',
+			),
+			'empty attributes'             => array(
+				array(),
+				0,
+			),
+		);
+	}
+
+	/**
+	 * Test Archive.org book ID extraction from various formats.
+	 *
+	 * @dataProvider provide_archiveorg_book_atts
+	 *
+	 * @param array      $atts     Shortcode attributes.
+	 * @param string|int $expected Expected Archive.org book identifier.
+	 */
+	#[DataProvider( 'provide_archiveorg_book_atts' )]
+	public function test_get_archiveorg_book_id( $atts, $expected ) {
+		$this->assertSame( $expected, Shortcodes::get_archiveorg_book_id( $atts ) );
+	}
+}


### PR DESCRIPTION
Fixes CM-544

> [!NOTE]
> This only adds the functions to the package, it doesn't replace their usage across the codebase. I'll do that in a follow-up PR.
> That means we only need to check that the CI checks pass in this PR.

## Proposed changes:
* Add a new `Shortcodes` class to the `post-media` package that consolidates shortcode ID extraction logic currently scattered across the Jetpack plugin codebase.
* The class provides static methods for extracting media identifiers from shortcode attributes for: YouTube, Vimeo, TED, VideoPress (wpvideo/videopress), Hulu, and Archive.org (including books).
* Includes a `sanitize_youtube_url()` helper that normalizes YouTube URLs (youtu.be, /v/, /shorts/, encoded ampersands, playlists).

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

n/a

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

* This PR adds new code that is not yet used anywhere — it only introduces the new class and tests. Testing if CI is happy should be enough.