### PR TITLE
Add `jp composer` and `jp pnpm` passthrough commands

### DIFF
--- a/projects/js-packages/jetpack-cli/changelog/jp-composer-command
+++ b/projects/js-packages/jetpack-cli/changelog/jp-composer-command
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add composer command for running Composer in the monorepo root or a specific project.

--- a/projects/js-packages/jetpack-cli/changelog/jp-pnpm-command
+++ b/projects/js-packages/jetpack-cli/changelog/jp-pnpm-command
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add pnpm command for running pnpm in the monorepo root or a specific project.

--- a/tools/cli/cliRouter.js
+++ b/tools/cli/cliRouter.js
@@ -4,6 +4,7 @@ import * as buildCommand from './commands/build.js';
 import { changelogDefine } from './commands/changelog.js';
 import { cleanDefine } from './commands/clean.js';
 import { cliDefine } from './commands/cli.js';
+import * as composerCommand from './commands/composer.js';
 import * as dependenciesCommand from './commands/dependencies.js';
 import { dockerDefine } from './commands/docker.js';
 import { docsDefine } from './commands/docs.js';
@@ -37,6 +38,7 @@ export async function cli() {
 	argv = changelogDefine( argv );
 	argv = cleanDefine( argv );
 	argv = cliDefine( argv );
+	argv.command( composerCommand );
 	argv.completion( 'completion', 'Generate bash/zsh completions' ); // Placed here to keep things alphabetical.
 	argv.command( dependenciesCommand );
 	argv = dockerDefine( argv );

--- a/tools/cli/cliRouter.js
+++ b/tools/cli/cliRouter.js
@@ -13,6 +13,7 @@ import { generateDefine } from './commands/generate.js';
 import * as installCommand from './commands/install.js';
 import * as noopCommand from './commands/noop.js';
 import * as phanCommand from './commands/phan.js';
+import * as pnpmCommand from './commands/pnpm.js';
 import { releaseDefine } from './commands/release.js';
 import { rsyncDefine } from './commands/rsync.js';
 import * as testCommand from './commands/test.js';
@@ -48,6 +49,7 @@ export async function cli() {
 	argv.command( installCommand );
 	argv.command( noopCommand );
 	argv.command( phanCommand );
+	argv.command( pnpmCommand );
 	argv = releaseDefine( argv );
 	argv = rsyncDefine( argv );
 	argv.command( testCommand );

--- a/tools/cli/commands/composer.js
+++ b/tools/cli/commands/composer.js
@@ -1,8 +1,4 @@
-import fs from 'fs/promises';
-import chalk from 'chalk';
-import { execa } from 'execa';
-import { projectDir } from '../helpers/install.js';
-import { projectTypes } from '../helpers/projectHelpers.js';
+import { runPackageManager } from '../helpers/runPackageManager.js';
 
 export const command = 'composer';
 export const describe = 'Run Composer commands in the monorepo root or a specific project.';
@@ -32,39 +28,5 @@ export function builder( yargs ) {
  * Entry point for the CLI.
  */
 export async function handler() {
-	// Extract raw args from process.argv after 'composer'.
-	const allArgs = process.argv.slice( 2 );
-	const composerIdx = allArgs.indexOf( 'composer' );
-	const rawArgs = allArgs.slice( composerIdx + 1 );
-
-	// Determine if the first arg is a project.
-	let cwd;
-	let composerArgs;
-
-	if ( rawArgs.length > 0 && projectTypes.some( t => rawArgs[ 0 ].startsWith( t + '/' ) ) ) {
-		const project = rawArgs[ 0 ];
-		composerArgs = rawArgs.slice( 1 );
-		cwd = projectDir( project );
-	} else {
-		composerArgs = rawArgs;
-		cwd = projectDir( 'monorepo' );
-	}
-
-	// Validate the target directory has a composer.json.
-	if ( ( await fs.access( cwd + '/composer.json' ).catch( () => false ) ) === false ) {
-		console.error( chalk.red( `No composer.json found in ${ cwd }` ) );
-		process.exit( 1 );
-	}
-
-	try {
-		const result = await execa( 'composer', composerArgs, {
-			cwd,
-			stdio: 'inherit',
-			reject: false,
-		} );
-		process.exit( result.exitCode );
-	} catch ( e ) {
-		console.error( chalk.red( `Failed to run composer: ${ e.message }` ) );
-		process.exit( 1 );
-	}
+	await runPackageManager( { command: 'composer', requiredFile: 'composer.json' } );
 }

--- a/tools/cli/commands/composer.js
+++ b/tools/cli/commands/composer.js
@@ -1,0 +1,70 @@
+import fs from 'fs/promises';
+import chalk from 'chalk';
+import { execa } from 'execa';
+import { projectDir } from '../helpers/install.js';
+import { projectTypes } from '../helpers/projectHelpers.js';
+
+export const command = 'composer';
+export const describe = 'Run Composer commands in the monorepo root or a specific project.';
+
+/**
+ * Options definition for the composer subcommand.
+ *
+ * @param {object} yargs - The Yargs dependency.
+ * @return {object} Yargs with the composer commands defined.
+ */
+export function builder( yargs ) {
+	return yargs
+		.parserConfiguration( { 'unknown-options-as-args': true } )
+		.strict( false )
+		.usage(
+			'$0 composer [args..]\n$0 composer <project> [args..]\n\n' +
+				'Runs Composer at the monorepo root, or in a specific project directory.\n\n' +
+				'Examples:\n' +
+				'  $0 composer install --no-dev\n' +
+				'  $0 composer phpcs:lint\n' +
+				'  $0 composer plugins/jetpack phpunit\n' +
+				'  $0 composer packages/connection install'
+		);
+}
+
+/**
+ * Entry point for the CLI.
+ */
+export async function handler() {
+	// Extract raw args from process.argv after 'composer'.
+	const allArgs = process.argv.slice( 2 );
+	const composerIdx = allArgs.indexOf( 'composer' );
+	const rawArgs = allArgs.slice( composerIdx + 1 );
+
+	// Determine if the first arg is a project.
+	let cwd;
+	let composerArgs;
+
+	if ( rawArgs.length > 0 && projectTypes.some( t => rawArgs[ 0 ].startsWith( t + '/' ) ) ) {
+		const project = rawArgs[ 0 ];
+		composerArgs = rawArgs.slice( 1 );
+		cwd = projectDir( project );
+	} else {
+		composerArgs = rawArgs;
+		cwd = projectDir( 'monorepo' );
+	}
+
+	// Validate the target directory has a composer.json.
+	if ( ( await fs.access( cwd + '/composer.json' ).catch( () => false ) ) === false ) {
+		console.error( chalk.red( `No composer.json found in ${ cwd }` ) );
+		process.exit( 1 );
+	}
+
+	try {
+		const result = await execa( 'composer', composerArgs, {
+			cwd,
+			stdio: 'inherit',
+			reject: false,
+		} );
+		process.exit( result.exitCode );
+	} catch ( e ) {
+		console.error( chalk.red( `Failed to run composer: ${ e.message }` ) );
+		process.exit( 1 );
+	}
+}

--- a/tools/cli/commands/composer.js
+++ b/tools/cli/commands/composer.js
@@ -13,6 +13,8 @@ export function builder( yargs ) {
 	return yargs
 		.parserConfiguration( { 'unknown-options-as-args': true } )
 		.strict( false )
+		.help( false )
+		.version( false )
 		.usage(
 			'$0 composer [args..]\n$0 composer <project> [args..]\n\n' +
 				'Runs Composer at the monorepo root, or in a specific project directory.\n\n' +

--- a/tools/cli/commands/pnpm.js
+++ b/tools/cli/commands/pnpm.js
@@ -13,6 +13,8 @@ export function builder( yargs ) {
 	return yargs
 		.parserConfiguration( { 'unknown-options-as-args': true } )
 		.strict( false )
+		.help( false )
+		.version( false )
 		.usage(
 			'$0 pnpm [args..]\n$0 pnpm <project> [args..]\n\n' +
 				'Runs pnpm at the monorepo root, or in a specific project directory.\n\n' +

--- a/tools/cli/commands/pnpm.js
+++ b/tools/cli/commands/pnpm.js
@@ -1,0 +1,32 @@
+import { runPackageManager } from '../helpers/runPackageManager.js';
+
+export const command = 'pnpm';
+export const describe = 'Run pnpm commands in the monorepo root or a specific project.';
+
+/**
+ * Options definition for the pnpm subcommand.
+ *
+ * @param {object} yargs - The Yargs dependency.
+ * @return {object} Yargs with the pnpm commands defined.
+ */
+export function builder( yargs ) {
+	return yargs
+		.parserConfiguration( { 'unknown-options-as-args': true } )
+		.strict( false )
+		.usage(
+			'$0 pnpm [args..]\n$0 pnpm <project> [args..]\n\n' +
+				'Runs pnpm at the monorepo root, or in a specific project directory.\n\n' +
+				'Examples:\n' +
+				'  $0 pnpm install\n' +
+				'  $0 pnpm run build\n' +
+				'  $0 pnpm plugins/jetpack run build\n' +
+				'  $0 pnpm js-packages/components install'
+		);
+}
+
+/**
+ * Entry point for the CLI.
+ */
+export async function handler() {
+	await runPackageManager( { command: 'pnpm', requiredFile: 'package.json' } );
+}

--- a/tools/cli/helpers/runPackageManager.js
+++ b/tools/cli/helpers/runPackageManager.js
@@ -1,0 +1,50 @@
+import fs from 'fs/promises';
+import chalk from 'chalk';
+import { execa } from 'execa';
+import { projectDir } from './install.js';
+import { projectTypes } from './projectHelpers.js';
+
+/**
+ * Run a package-manager command in the monorepo root or a specific project directory.
+ *
+ * @param {object}  options              - Configuration for the package manager.
+ * @param {string}  options.command      - The CLI command name (e.g. 'composer', 'pnpm').
+ * @param {string}  options.requiredFile - File that must exist in the target directory (e.g. 'composer.json').
+ */
+export async function runPackageManager( { command, requiredFile } ) {
+	// Extract raw args from process.argv after the command name.
+	const allArgs = process.argv.slice( 2 );
+	const cmdIdx = allArgs.indexOf( command );
+	const rawArgs = allArgs.slice( cmdIdx + 1 );
+
+	// Determine if the first arg is a project.
+	let cwd;
+	let cmdArgs;
+
+	if ( rawArgs.length > 0 && projectTypes.some( t => rawArgs[ 0 ].startsWith( t + '/' ) ) ) {
+		const project = rawArgs[ 0 ];
+		cmdArgs = rawArgs.slice( 1 );
+		cwd = projectDir( project );
+	} else {
+		cmdArgs = rawArgs;
+		cwd = projectDir( 'monorepo' );
+	}
+
+	// Validate the target directory has the required file.
+	if ( ( await fs.access( cwd + '/' + requiredFile ).catch( () => false ) ) === false ) {
+		console.error( chalk.red( `No ${ requiredFile } found in ${ cwd }` ) );
+		process.exit( 1 );
+	}
+
+	try {
+		const result = await execa( command, cmdArgs, {
+			cwd,
+			stdio: 'inherit',
+			reject: false,
+		} );
+		process.exit( result.exitCode );
+	} catch ( e ) {
+		console.error( chalk.red( `Failed to run ${ command }: ${ e.message }` ) );
+		process.exit( 1 );
+	}
+}

--- a/tools/cli/helpers/runPackageManager.js
+++ b/tools/cli/helpers/runPackageManager.js
@@ -23,7 +23,11 @@ export async function runPackageManager( { command, requiredFile } ) {
 
 	let project;
 
-	if ( rawArgs.length > 0 && projectTypes.some( t => rawArgs[ 0 ].startsWith( t + '/' ) ) ) {
+	if (
+		rawArgs.length > 0 &&
+		( rawArgs[ 0 ] === 'monorepo' ||
+			projectTypes.some( t => rawArgs[ 0 ].startsWith( t + '/' ) ) )
+	) {
 		project = rawArgs[ 0 ];
 		cmdArgs = rawArgs.slice( 1 );
 		cwd = projectDir( project );

--- a/tools/cli/helpers/runPackageManager.js
+++ b/tools/cli/helpers/runPackageManager.js
@@ -25,8 +25,7 @@ export async function runPackageManager( { command, requiredFile } ) {
 
 	if (
 		rawArgs.length > 0 &&
-		( rawArgs[ 0 ] === 'monorepo' ||
-			projectTypes.some( t => rawArgs[ 0 ].startsWith( t + '/' ) ) )
+		( rawArgs[ 0 ] === 'monorepo' || projectTypes.some( t => rawArgs[ 0 ].startsWith( t + '/' ) ) )
 	) {
 		project = rawArgs[ 0 ];
 		cmdArgs = rawArgs.slice( 1 );

--- a/tools/cli/helpers/runPackageManager.js
+++ b/tools/cli/helpers/runPackageManager.js
@@ -1,4 +1,5 @@
 import fs from 'fs/promises';
+import path from 'path';
 import chalk from 'chalk';
 import { execa } from 'execa';
 import { projectDir } from './install.js';
@@ -18,26 +19,15 @@ export async function runPackageManager( { command, requiredFile } ) {
 	const rawArgs = allArgs.slice( cmdIdx + 1 );
 
 	// Determine if the first arg is a project.
-	let cwd;
-	let cmdArgs;
-
-	let project;
-
-	if (
+	const isProjectArg =
 		rawArgs.length > 0 &&
-		( rawArgs[ 0 ] === 'monorepo' || projectTypes.some( t => rawArgs[ 0 ].startsWith( t + '/' ) ) )
-	) {
-		project = rawArgs[ 0 ];
-		cmdArgs = rawArgs.slice( 1 );
-		cwd = projectDir( project );
-	} else {
-		project = 'monorepo';
-		cmdArgs = rawArgs;
-		cwd = projectDir( project );
-	}
+		( rawArgs[ 0 ] === 'monorepo' || projectTypes.some( t => rawArgs[ 0 ].startsWith( t + '/' ) ) );
+	const project = isProjectArg ? rawArgs[ 0 ] : 'monorepo';
+	const cmdArgs = isProjectArg ? rawArgs.slice( 1 ) : rawArgs;
+	const cwd = projectDir( project );
 
 	// Validate the target directory has the required file.
-	if ( ( await fs.access( cwd + '/' + requiredFile ).catch( () => false ) ) === false ) {
+	if ( ( await fs.access( path.join( cwd, requiredFile ) ).catch( () => false ) ) === false ) {
 		console.error( chalk.red( `No ${ requiredFile } found in project ${ project }` ) );
 		process.exit( 1 );
 	}

--- a/tools/cli/helpers/runPackageManager.js
+++ b/tools/cli/helpers/runPackageManager.js
@@ -13,7 +13,9 @@ import { projectTypes } from './projectHelpers.js';
  * @param {string} options.requiredFile - File that must exist in the target directory (e.g. 'composer.json').
  */
 export async function runPackageManager( { command, requiredFile } ) {
-	// Extract raw args from process.argv after the command name.
+	// Extract raw args from process.argv rather than yargs-parsed argv, because
+	// yargs consumes flags it recognizes (e.g. --verbose) and can mangle others
+	// (e.g. --no-dev). Reading process.argv ensures all flags pass through untouched.
 	const allArgs = process.argv.slice( 2 );
 	const cmdIdx = allArgs.indexOf( command );
 	const rawArgs = allArgs.slice( cmdIdx + 1 );

--- a/tools/cli/helpers/runPackageManager.js
+++ b/tools/cli/helpers/runPackageManager.js
@@ -7,9 +7,9 @@ import { projectTypes } from './projectHelpers.js';
 /**
  * Run a package-manager command in the monorepo root or a specific project directory.
  *
- * @param {object}  options              - Configuration for the package manager.
- * @param {string}  options.command      - The CLI command name (e.g. 'composer', 'pnpm').
- * @param {string}  options.requiredFile - File that must exist in the target directory (e.g. 'composer.json').
+ * @param {object} options              - Configuration for the package manager.
+ * @param {string} options.command      - The CLI command name (e.g. 'composer', 'pnpm').
+ * @param {string} options.requiredFile - File that must exist in the target directory (e.g. 'composer.json').
  */
 export async function runPackageManager( { command, requiredFile } ) {
 	// Extract raw args from process.argv after the command name.

--- a/tools/cli/helpers/runPackageManager.js
+++ b/tools/cli/helpers/runPackageManager.js
@@ -21,18 +21,21 @@ export async function runPackageManager( { command, requiredFile } ) {
 	let cwd;
 	let cmdArgs;
 
+	let project;
+
 	if ( rawArgs.length > 0 && projectTypes.some( t => rawArgs[ 0 ].startsWith( t + '/' ) ) ) {
-		const project = rawArgs[ 0 ];
+		project = rawArgs[ 0 ];
 		cmdArgs = rawArgs.slice( 1 );
 		cwd = projectDir( project );
 	} else {
+		project = 'monorepo';
 		cmdArgs = rawArgs;
-		cwd = projectDir( 'monorepo' );
+		cwd = projectDir( project );
 	}
 
 	// Validate the target directory has the required file.
 	if ( ( await fs.access( cwd + '/' + requiredFile ).catch( () => false ) ) === false ) {
-		console.error( chalk.red( `No ${ requiredFile } found in ${ cwd }` ) );
+		console.error( chalk.red( `No ${ requiredFile } found in project ${ project }` ) );
 		process.exit( 1 );
 	}
 

--- a/tools/cli/tests/integration/commands/commands.test.js
+++ b/tools/cli/tests/integration/commands/commands.test.js
@@ -16,11 +16,29 @@ describe( 'verify commands are available', () => {
 	test( 'changelog command exists', () => {
 		expect( help ).toEqual( expect.stringContaining( 'jetpack changelog [cmd]' ) );
 	} );
+	test( 'clean command exists', () => {
+		expect( help ).toEqual( expect.stringContaining( 'jetpack clean [project] [include]' ) );
+	} );
 	test( 'cli command exists', () => {
 		expect( help ).toEqual( expect.stringContaining( 'jetpack cli <cmd>' ) );
 	} );
+	test( 'composer command exists', () => {
+		expect( help ).toEqual( expect.stringContaining( 'jetpack composer' ) );
+	} );
+	test( 'completion command exists', () => {
+		expect( help ).toEqual( expect.stringContaining( 'jetpack completion' ) );
+	} );
+	test( 'dependencies command exists', () => {
+		expect( help ).toEqual( expect.stringContaining( 'jetpack dependencies <subcommand>' ) );
+	} );
 	test( 'docker command exists', () => {
 		expect( help ).toEqual( expect.stringContaining( 'jetpack docker <cmd>' ) );
+	} );
+	test( 'docs command exists', () => {
+		expect( help ).toEqual( expect.stringContaining( 'jetpack docs [path] [dest]' ) );
+	} );
+	test( 'draft command exists', () => {
+		expect( help ).toEqual( expect.stringContaining( 'jetpack draft <cmd>' ) );
 	} );
 	test( 'generate command exists', () => {
 		expect( help ).toEqual( expect.stringContaining( 'jetpack generate [type]' ) );
@@ -28,13 +46,22 @@ describe( 'verify commands are available', () => {
 	test( 'install command exists', () => {
 		expect( help ).toEqual( expect.stringContaining( 'jetpack install [project...]' ) );
 	} );
+	test( 'phan command exists', () => {
+		expect( help ).toEqual( expect.stringContaining( 'jetpack phan [project...]' ) );
+	} );
+	test( 'pnpm command exists', () => {
+		expect( help ).toEqual( expect.stringContaining( 'jetpack pnpm' ) );
+	} );
+	test( 'release command exists', () => {
+		expect( help ).toEqual( expect.stringContaining( 'jetpack release [project] [script]' ) );
+	} );
+	test( 'rsync command exists', () => {
+		expect( help ).toEqual( expect.stringContaining( 'jetpack rsync [plugin] [dest]' ) );
+	} );
+	test( 'command exists', () => {
+		expect( help ).toEqual( expect.stringContaining( 'jetpack test [test] [project...]' ) );
+	} );
 	test( 'watch command exists', () => {
 		expect( help ).toEqual( expect.stringContaining( 'jetpack watch [project]' ) );
-	} );
-	test( 'completion command exists', () => {
-		expect( help ).toEqual( expect.stringContaining( 'jetpack completion' ) );
-	} );
-	test( 'draft command exists', () => {
-		expect( help ).toEqual( expect.stringContaining( 'jetpack draft <cmd>' ) );
 	} );
 } );


### PR DESCRIPTION
## Proposed changes:
* The `jp` CLI doesn't provide a way to run Composer or pnpm commands directly in project directories. Developers must manually `cd` to the right path before running these tools.
* Add `jp composer` and `jp pnpm` commands that auto-detect whether the first argument is a project path (e.g. `plugins/jetpack`) or a package manager command, resolving the working directory accordingly. All flags pass through untouched.
* Shared logic is extracted into a `runPackageManager` helper used by both commands.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

N/A — CLI tooling only, no WordPress.com impact.

## Jetpack product discussion

N/A — developer tooling change.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

* Run `jp composer --version` — should show Composer version
* Run `jp composer plugins/jetpack install --dry-run` — should run in `projects/plugins/jetpack/`
* Run `jp composer plugins/nonexistent install` — should error: "No composer.json found"
* Run `jp pnpm --version` — should show pnpm version
* Run `jp pnpm plugins/jetpack run build` — should run in `projects/plugins/jetpack/`
* Run `jp pnpm plugins/nonexistent install` — should error: "No package.json found"
* Run `jp composer` / `jp pnpm` with no args — should show respective help

## Changelog

- [x] Generate changelog entries for this PR (using AI).
