### PR TITLE
Forms: add single form action dropdown menu

### DIFF
--- a/projects/packages/forms/changelog/add-forms-single-view-actions-dropdown
+++ b/projects/packages/forms/changelog/add-forms-single-view-actions-dropdown
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Dashboard: add actions dropdown (Duplicate, Preview, Copy embed, Copy shortcode) to the single form view header.

--- a/projects/packages/forms/routes/forms/stage.tsx
+++ b/projects/packages/forms/routes/forms/stage.tsx
@@ -2,14 +2,12 @@
  * External dependencies
  */
 import { Page } from '@wordpress/admin-ui';
-import apiFetch from '@wordpress/api-fetch';
 import { __experimentalConfirmDialog as ConfirmDialog } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
 import { useDispatch, useSelect } from '@wordpress/data';
 import { DataViews } from '@wordpress/dataviews';
 import { dateI18n, getSettings as getDateSettings } from '@wordpress/date';
 import { useEffect, useMemo, useState, useCallback } from '@wordpress/element';
 import { __, _n, sprintf } from '@wordpress/i18n';
-import { store as noticesStore } from '@wordpress/notices';
 import { useSearch, useNavigate } from '@wordpress/route';
 import * as React from 'react';
 /**
@@ -23,7 +21,7 @@ import useDeleteForm from '../../src/dashboard/hooks/use-delete-form.ts';
 import useFormsData from '../../src/dashboard/hooks/use-forms-data.ts';
 import WpRouteDashboardSearchParamsProvider from '../../src/dashboard/router/wp-route-dashboard-search-params-provider.tsx';
 import DataViewsHeaderRow from '../../src/dashboard/wp-build/components/dataviews-header-row';
-import useDuplicateForm from '../../src/dashboard/wp-build/hooks/use-duplicate-form';
+import useFormItemActions from '../../src/dashboard/wp-build/hooks/use-form-item-actions';
 import usePageHeaderDetails from '../../src/dashboard/wp-build/hooks/use-page-header-details';
 import '../../src/dashboard/wp-build/style.scss';
 import useConfigValue from '../../src/hooks/use-config-value';
@@ -71,7 +69,6 @@ function StageInner() {
 		[]
 	);
 	const { refreshIntegrations } = useDispatch( INTEGRATIONS_STORE );
-	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
 	const isIntegrationsEnabled = useConfigValue( 'isIntegrationsEnabled' );
 	const showDashboardIntegrations = useConfigValue( 'showDashboardIntegrations' );
 
@@ -111,7 +108,7 @@ function StageInner() {
 		statusQuery
 	);
 
-	const { duplicateForm } = useDuplicateForm();
+	const { duplicateForm, previewForm, copyEmbed, copyShortcode } = useFormItemActions();
 
 	const {
 		isDeleting,
@@ -305,11 +302,9 @@ function StageInner() {
 			supportsBulk: false,
 			async callback( items: FormListItem[] ) {
 				const [ item ] = items;
-				if ( ! item ) {
-					return;
+				if ( item ) {
+					await duplicateForm( item );
 				}
-
-				await duplicateForm( item );
 			},
 		} );
 
@@ -320,21 +315,12 @@ function StageInner() {
 			supportsBulk: false,
 			async callback( items: FormListItem[] ) {
 				const [ item ] = items;
-				if ( ! item ) {
-					return;
-				}
-
-				try {
-					const response = await apiFetch< { preview_url: string } >( {
-						path: `/wp/v2/jetpack-forms/${ item.id }/preview-url`,
-					} );
-					window.open( response.preview_url, '_blank' );
-				} catch ( error ) {
-					// eslint-disable-next-line no-console
-					console.error( 'Failed to get preview URL:', error );
+				if ( item ) {
+					await previewForm( item );
 				}
 			},
 		} );
+
 		if ( navigator?.clipboard ) {
 			actionsList.push( {
 				id: 'copy-embed',
@@ -343,21 +329,8 @@ function StageInner() {
 				supportsBulk: false,
 				async callback( items: FormListItem[] ) {
 					const [ item ] = items;
-					if ( ! item ) {
-						return;
-					}
-
-					const embedCode = `<!-- wp:jetpack/contact-form {"ref":${ item.id }} /-->`;
-					try {
-						await navigator.clipboard.writeText( embedCode );
-						createSuccessNotice( __( 'Embed code copied to clipboard.', 'jetpack-forms' ), {
-							type: 'snackbar',
-						} );
-					} catch {
-						createErrorNotice(
-							__( 'Failed to copy embed code. Please try again.', 'jetpack-forms' ),
-							{ type: 'snackbar' }
-						);
+					if ( item ) {
+						await copyEmbed( item );
 					}
 				},
 			} );
@@ -369,27 +342,8 @@ function StageInner() {
 				supportsBulk: false,
 				async callback( items: FormListItem[] ) {
 					const [ item ] = items;
-					if ( ! item ) {
-						return;
-					}
-
-					if ( ! navigator.clipboard ) {
-						return;
-					}
-
-					const shortcode = `[contact-form ref="${ item.id }"]`;
-					try {
-						await navigator.clipboard.writeText( shortcode );
-						createSuccessNotice( __( 'Shortcode copied to clipboard.', 'jetpack-forms' ), {
-							type: 'snackbar',
-						} );
-					} catch {
-						createErrorNotice(
-							__( 'Failed to copy shortcode. Please try again.', 'jetpack-forms' ),
-							{
-								type: 'snackbar',
-							}
-						);
+					if ( item ) {
+						await copyShortcode( item );
 					}
 				},
 			} );
@@ -414,13 +368,14 @@ function StageInner() {
 
 		return actionsList;
 	}, [
-		createErrorNotice,
-		createSuccessNotice,
+		copyEmbed,
+		copyShortcode,
 		duplicateForm,
 		isDeleting,
 		isViewingTrash,
 		onOpenPermanentDeleteConfirm,
 		openSingleFormView,
+		previewForm,
 		restoreForms,
 		trashForms,
 	] );

--- a/projects/packages/forms/src/dashboard/wp-build/hooks/use-duplicate-form.ts
+++ b/projects/packages/forms/src/dashboard/wp-build/hooks/use-duplicate-form.ts
@@ -15,6 +15,8 @@ import useConfigValue from '../../../hooks/use-config-value';
  */
 import type { FormListItem } from '../../hooks/use-forms-data.ts';
 
+type DuplicateFormItem = Pick< FormListItem, 'id' > & Partial< Pick< FormListItem, 'title' > >;
+
 type CoreDispatch = {
 	saveEntityRecord: (
 		kind: string,
@@ -29,7 +31,7 @@ type JetpackFormEntityRecord = {
 };
 
 type UseDuplicateFormReturn = {
-	duplicateForm: ( item: FormListItem ) => Promise< void >;
+	duplicateForm: ( item: DuplicateFormItem ) => Promise< void >;
 	isDuplicating: boolean;
 };
 
@@ -45,7 +47,7 @@ export default function useDuplicateForm(): UseDuplicateFormReturn {
 	const adminUrl = useConfigValue( 'adminUrl' ) || '';
 
 	const duplicateForm = useCallback(
-		async ( item: FormListItem ) => {
+		async ( item: DuplicateFormItem ) => {
 			if ( isDuplicating ) {
 				return;
 			}

--- a/projects/packages/forms/src/dashboard/wp-build/hooks/use-form-item-actions.ts
+++ b/projects/packages/forms/src/dashboard/wp-build/hooks/use-form-item-actions.ts
@@ -1,0 +1,88 @@
+/**
+ * WordPress dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+import { useDispatch } from '@wordpress/data';
+import { useCallback } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { store as noticesStore } from '@wordpress/notices';
+/**
+ * Internal dependencies
+ */
+import useDuplicateForm from './use-duplicate-form';
+/**
+ * Types
+ */
+import type { FormListItem } from '../../hooks/use-forms-data.ts';
+
+type FormItem = Pick< FormListItem, 'id' > & Partial< Pick< FormListItem, 'title' > >;
+
+type UseFormItemActionsReturn = {
+	duplicateForm: ( item: FormItem ) => Promise< void >;
+	previewForm: ( item: FormItem ) => Promise< void >;
+	copyEmbed: ( item: FormItem ) => Promise< void >;
+	copyShortcode: ( item: FormItem ) => Promise< void >;
+	isDuplicating: boolean;
+};
+
+/**
+ * Shared form-level action callbacks (Duplicate, Preview, Copy embed, Copy shortcode).
+ *
+ * Each callback accepts a minimal `{ id, title? }` object so it works with both
+ * full `FormListItem` records (DataViews table) and a simple form ID + title
+ * (single form view header).
+ *
+ * @return Action callbacks and in-flight state.
+ */
+export default function useFormItemActions(): UseFormItemActionsReturn {
+	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
+	const { duplicateForm, isDuplicating } = useDuplicateForm();
+
+	const previewForm = useCallback( async ( item: FormItem ) => {
+		try {
+			const response = await apiFetch< { preview_url: string } >( {
+				path: `/wp/v2/jetpack-forms/${ item.id }/preview-url`,
+			} );
+			window.open( response.preview_url, '_blank' );
+		} catch ( error ) {
+			// eslint-disable-next-line no-console
+			console.error( 'Failed to get preview URL:', error );
+		}
+	}, [] );
+
+	const copyEmbed = useCallback(
+		async ( item: FormItem ) => {
+			const embedCode = `<!-- wp:jetpack/contact-form {"ref":${ item.id }} /-->`;
+			try {
+				await navigator.clipboard.writeText( embedCode );
+				createSuccessNotice( __( 'Embed code copied to clipboard.', 'jetpack-forms' ), {
+					type: 'snackbar',
+				} );
+			} catch {
+				createErrorNotice( __( 'Failed to copy embed code. Please try again.', 'jetpack-forms' ), {
+					type: 'snackbar',
+				} );
+			}
+		},
+		[ createErrorNotice, createSuccessNotice ]
+	);
+
+	const copyShortcode = useCallback(
+		async ( item: FormItem ) => {
+			const shortcode = `[contact-form ref="${ item.id }"]`;
+			try {
+				await navigator.clipboard.writeText( shortcode );
+				createSuccessNotice( __( 'Shortcode copied to clipboard.', 'jetpack-forms' ), {
+					type: 'snackbar',
+				} );
+			} catch {
+				createErrorNotice( __( 'Failed to copy shortcode. Please try again.', 'jetpack-forms' ), {
+					type: 'snackbar',
+				} );
+			}
+		},
+		[ createErrorNotice, createSuccessNotice ]
+	);
+
+	return { duplicateForm, previewForm, copyEmbed, copyShortcode, isDuplicating };
+}

--- a/projects/packages/forms/src/dashboard/wp-build/hooks/use-page-header-details.tsx
+++ b/projects/packages/forms/src/dashboard/wp-build/hooks/use-page-header-details.tsx
@@ -32,6 +32,7 @@ import useEmptyTrash from '../../hooks/use-empty-trash';
 import useExportResponses from '../../hooks/use-export-responses';
 import useInboxData from '../../hooks/use-inbox-data';
 import ManageIntegrationsButton from '../components/manage-integrations-button';
+import useFormItemActions from './use-form-item-actions';
 import type { ReactNode } from 'react';
 
 type ResponsesStatusView = 'inbox' | 'spam' | 'trash';
@@ -112,6 +113,41 @@ export default function usePageHeaderDetails(
 		const rendered = formRecord?.title?.rendered || '';
 		return decodeEntities( rendered );
 	}, [ formRecord?.title?.rendered ] );
+
+	const { duplicateForm, previewForm, copyEmbed, copyShortcode } = useFormItemActions();
+
+	const formItemControls = useMemo( () => {
+		if ( ! sourceIdNumber ) {
+			return [];
+		}
+
+		const formItem = { id: sourceIdNumber, title: formTitle };
+		const controls: Array< { title: string; onClick: () => void } > = [
+			{
+				title: __( 'Duplicate', 'jetpack-forms' ),
+				onClick: () => duplicateForm( formItem ),
+			},
+			{
+				title: __( 'Preview', 'jetpack-forms' ),
+				onClick: () => previewForm( formItem ),
+			},
+		];
+
+		if ( navigator?.clipboard ) {
+			controls.push(
+				{
+					title: __( 'Copy embed', 'jetpack-forms' ),
+					onClick: () => copyEmbed( formItem ),
+				},
+				{
+					title: __( 'Copy shortcode', 'jetpack-forms' ),
+					onClick: () => copyShortcode( formItem ),
+				}
+			);
+		}
+
+		return controls;
+	}, [ sourceIdNumber, formTitle, duplicateForm, previewForm, copyEmbed, copyShortcode ] );
 
 	const breadcrumbsItems = useMemo( () => {
 		if ( isSingleFormScreen ) {
@@ -208,6 +244,8 @@ export default function usePageHeaderDetails(
 						isDisabled: emptySpam.isEmpty || emptySpam.isEmptying,
 					} );
 				}
+
+				dropdownControls.push( ...formItemControls );
 			} else {
 				// Responses list screen: Manage integrations (inbox only), Create a form (inbox only), Export, Empty trash/spam
 				if ( statusView === 'inbox' && isIntegrationsEnabled && showDashboardIntegrations ) {
@@ -323,6 +361,16 @@ export default function usePageHeaderDetails(
 				/>,
 				...( statusView === 'trash' ? [ <EmptyTrashButton key="empty-trash" /> ] : [] ),
 				...( statusView === 'spam' ? [ <EmptySpamButton key="empty-spam" /> ] : [] ),
+				...( formItemControls.length > 0
+					? [
+							<DropdownMenu
+								key="form-actions-menu"
+								controls={ formItemControls }
+								icon={ moreVertical }
+								label={ __( 'More actions', 'jetpack-forms' ) }
+							/>,
+					  ]
+					: [] ),
 			];
 		}
 
@@ -357,6 +405,7 @@ export default function usePageHeaderDetails(
 		sourceIdNumber,
 		isFormsScreen,
 		isSingleFormScreen,
+		formItemControls,
 		statusView,
 		openNewForm,
 		openExportModal,


### PR DESCRIPTION
## Proposed changes:

This adds a dropdown action menu to the top of the single form screen. Right now, when on the forms list table, we offer actions for each form item row. You can duplicate a form, preview a form, copy embed code, or copy shortode. However, those actions are not available on the single form view. This PR: 
* Adds those four actions inside a three-dot dropdown in the upper right corner of the header. 
* Adds a new hook that defines and returns all actions (we now use them in two places - forms list and single form screen).
* Adds the same actions to the mobile menu on the single form screen 

**Screenshot**
<img width="1326" height="396" alt="single-form-action-menu" src="https://github.com/user-attachments/assets/824e585a-9d78-4b92-9584-d200cdb09bc4" />

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Enable these feature flags: 

```
add_filter( 'jetpack_forms_alpha', '__return_true', 20 );
add_filter( 'jetpack_block_editor_feature_flags', 'eb_register_feature' );
function eb_register_feature( $flags ) {
    $flags['central-form-management'] = true;
    return $flags;
}
```

Test:
* Go to Jetpack > Forms
* Click to open a specific form
* On the single form page, confirm there is a three-dot menu icon in the upper right that opens a dropdown menu
* Confirm each of the following items exist and work as expected: 
   - Duplicate
   - Preview
   - Copy embed
   - Copy shortcode 

## Changelog
<!-- Check one of the boxes below. -->

Changelog file already added.

- [ ] Generate changelog entries for this PR (using AI).
