### PR TITLE
VideoPress: Pass user ID when deleting videos on wpcom

### DIFF
--- a/projects/packages/videopress/changelog/fix-videopress-deletion-user-attribution
+++ b/projects/packages/videopress/changelog/fix-videopress-deletion-user-attribution
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Pass current user ID when deleting VideoPress videos on wpcom to fix activity log attribution.

--- a/projects/packages/videopress/src/class-attachment-handler.php
+++ b/projects/packages/videopress/src/class-attachment-handler.php
@@ -118,7 +118,8 @@ class Attachment_Handler {
 		$wpcom_response = Client::wpcom_json_api_request_as_blog(
 			sprintf( '/videos/%s/delete', $guid ),
 			'1.1',
-			array( 'method' => 'POST' )
+			array( 'method' => 'POST' ),
+			array( 'user_id' => get_current_user_id() )
 		);
 
 		if ( is_wp_error( $wpcom_response ) ) {


### PR DESCRIPTION
Fixes https://linear.app/automattic/issue/VIDP-219

## Proposed changes:
* Pass `array( 'user_id' => get_current_user_id() )` as the request body when calling `wpcom_json_api_request_as_blog()` in `Attachment_Handler::delete_video_wpcom()`.
* This allows the wpcom side to set the current user for the deletion request, so Activity Log and Audit Trail correctly attribute the action to the user who initiated it (instead of showing a blank actor / `Who=0`).

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

## Does this pull request change what data or activity we track or use?

No. This sends the existing current user ID alongside the existing video deletion request. No new data is collected or tracked.

## Testing instructions:

* On a WordPress.com site with the Jetpack VideoPress module active, upload a video to the Media Library and wait for processing.
* Delete the video from the Media Library.
* Check Jetpack → Activity Log — the deletion should show the correct user as the actor (not blank/unknown).
* Check BRC → Audit Trail — `Who` should show the correct user ID (not `0` / Server).

## Changelog

- [x] Generate changelog entries for this PR (using AI).