### PR TITLE
Forms: remove icons from mobile dropdown menu

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-wp-build-mobile-menu-icons
+++ b/projects/packages/forms/changelog/fix-forms-wp-build-mobile-menu-icons
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Dashboard: remove icons from mobile dropdown menu items for a cleaner appearance.

--- a/projects/packages/forms/src/dashboard/wp-build/hooks/use-page-header-details.tsx
+++ b/projects/packages/forms/src/dashboard/wp-build/hooks/use-page-header-details.tsx
@@ -13,7 +13,7 @@ import { useSelect } from '@wordpress/data';
 import { useMemo } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
 import { __, sprintf } from '@wordpress/i18n';
-import { moreVertical, plus, download, plugins, trash } from '@wordpress/icons';
+import { moreVertical } from '@wordpress/icons';
 import { Stack } from '@wordpress/ui';
 /**
  * Internal dependencies
@@ -161,14 +161,12 @@ export default function usePageHeaderDetails(
 				// Forms screen: Manage integrations, Create a form
 				if ( isIntegrationsEnabled && showDashboardIntegrations ) {
 					dropdownControls.push( {
-						icon: plugins,
 						onClick: onOpenIntegrations,
 						title: __( 'Manage integrations', 'jetpack-forms' ),
 					} );
 				}
 
 				dropdownControls.push( {
-					icon: plus,
 					onClick: () => openNewForm( {} ),
 					title: __( 'Create a form', 'jetpack-forms' ),
 				} );
@@ -185,7 +183,6 @@ export default function usePageHeaderDetails(
 					} );
 				}
 				dropdownControls.push( {
-					icon: download,
 					onClick: openExportModal,
 					title: exportLabel,
 					isDisabled: ! hasResponses,
@@ -193,7 +190,6 @@ export default function usePageHeaderDetails(
 
 				if ( statusView === 'trash' ) {
 					dropdownControls.push( {
-						icon: trash,
 						onClick: emptyTrash.openConfirmDialog,
 						title: __( 'Empty trash', 'jetpack-forms' ),
 						isDisabled: emptyTrash.isEmpty || emptyTrash.isEmptying,
@@ -202,7 +198,6 @@ export default function usePageHeaderDetails(
 
 				if ( statusView === 'spam' ) {
 					dropdownControls.push( {
-						icon: trash,
 						onClick: emptySpam.openConfirmDialog,
 						title: __( 'Delete spam', 'jetpack-forms' ),
 						isDisabled: emptySpam.isEmpty || emptySpam.isEmptying,
@@ -212,7 +207,6 @@ export default function usePageHeaderDetails(
 				// Responses list screen: Manage integrations (inbox only), Create a form (inbox only), Export, Empty trash/spam
 				if ( statusView === 'inbox' && isIntegrationsEnabled && showDashboardIntegrations ) {
 					dropdownControls.push( {
-						icon: plugins,
 						onClick: onOpenIntegrations,
 						title: __( 'Manage integrations', 'jetpack-forms' ),
 					} );
@@ -220,14 +214,12 @@ export default function usePageHeaderDetails(
 
 				if ( statusView === 'inbox' ) {
 					dropdownControls.push( {
-						icon: plus,
 						onClick: () => openNewForm( { showPatterns: false } ),
 						title: __( 'Create a form', 'jetpack-forms' ),
 					} );
 				}
 
 				dropdownControls.push( {
-					icon: download,
 					onClick: openExportModal,
 					title: exportLabel,
 					isDisabled: ! hasResponses,
@@ -235,7 +227,6 @@ export default function usePageHeaderDetails(
 
 				if ( statusView === 'trash' ) {
 					dropdownControls.push( {
-						icon: trash,
 						onClick: emptyTrash.openConfirmDialog,
 						title: __( 'Empty trash', 'jetpack-forms' ),
 						isDisabled: emptyTrash.isEmpty || emptyTrash.isEmptying,
@@ -244,7 +235,6 @@ export default function usePageHeaderDetails(
 
 				if ( statusView === 'spam' ) {
 					dropdownControls.push( {
-						icon: trash,
 						onClick: emptySpam.openConfirmDialog,
 						title: __( 'Delete spam', 'jetpack-forms' ),
 						isDisabled: emptySpam.isEmpty || emptySpam.isEmptying,


### PR DESCRIPTION
## Proposed changes:

We removed icons from header action buttons on the new wp-build dashboard based on designs. But we were still showing the icons in the mobile dropdown menu. This removes them for the Responses, Forms, and Single Forms screens. 

**Before**
<img width="514" height="499" alt="forms-mobile-with-icons" src="https://github.com/user-attachments/assets/335d4dd5-a6d5-4f2f-97eb-12c987454b3e" />

**After**
<img width="516" height="552" alt="form-mobile-no-icons" src="https://github.com/user-attachments/assets/5f496add-552b-4cfc-9abd-242018acc0d0" />

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Enable these feature flags: 

```
add_filter( 'jetpack_forms_alpha', '__return_true', 20 );
add_filter( 'jetpack_block_editor_feature_flags', 'eb_register_feature' );
function eb_register_feature( $flags ) {
    $flags['central-form-management'] = true;
    return $flags;
}
```

Test:
* Go to Jetpack > Forms
* Resize your browser to trigger the mobile menue
* For each of the Forms, Responses, and Single Forms screen, confirm that there are no icons on items in the drop down menu. 

## Changelog
<!-- Check one of the boxes below. -->

Already added changelog entry.

- [ ] Generate changelog entries for this PR (using AI).
