### PR TITLE
Docker: fix pre-commit autofix in worktrees with rw overlay mounts

### DIFF
--- a/tools/docker/bin/monorepo
+++ b/tools/docker/bin/monorepo
@@ -117,6 +117,8 @@ fi
       # Mount main .git/ so git operations work inside the container
       WORKTREE_DOCKER_ARGS+=(
           -v "$MAIN_GIT_DIR:/repo-git:ro"
+          -v "$MAIN_GIT_DIR/objects:/repo-git/objects"
+          -v "$MAIN_GIT_DIR/worktrees/$WORKTREE_NAME:/repo-git/worktrees/$WORKTREE_NAME"
           -e "GIT_DIR=/repo-git/worktrees/$WORKTREE_NAME"
           -e "GIT_WORK_TREE=/workspace"
       )


### PR DESCRIPTION
Fixes #

## Proposed changes:

In git worktrees, the Docker-based pre-commit hook mounts the main `.git` directory as read-only (`:ro`). This prevents eslint/prettier/phpcbf auto-fix from re-staging corrected files — `git add` inside Docker fails because it can't write blob objects or update the index. The original (unfixed) version gets committed instead.

This adds two targeted read-write overlay mounts that Docker resolves by path specificity:

- `objects/` — so `git add` can write new blob objects (immutable, content-addressed, safe)
- `worktrees/$WORKTREE_NAME/` — so `git add` can update this worktree's index

Shared git state (refs, config, other worktrees) remains read-only.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

N/A — tooling fix only.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

1. Check out this branch in a git worktree
2. Ensure `jp init-hooks` has been run (so Docker-delegating hooks are active)
3. Edit a JS file to introduce a fixable lint error (e.g., change single quotes to double quotes on a used variable)
4. Stage the file and `git commit`
5. Verify the pre-commit hook auto-fixes the error and the committed version contains the fix

Without this change, step 5 would commit the unfixed version (and leave the fix as an unstaged change).

## Changelog

- [ ] Generate changelog entries for this PR (using AI).