### PR TITLE
Forms: Change default layout to horizontal with wrap

### DIFF
--- a/projects/packages/forms/changelog/fix-default-layout-forms
+++ b/projects/packages/forms/changelog/fix-default-layout-forms
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Change default form layout from vertical to horizontal with wrap, allowing form fields to display side-by-side.

--- a/projects/packages/forms/src/blocks/contact-form/block.json
+++ b/projects/packages/forms/src/blocks/contact-form/block.json
@@ -23,8 +23,8 @@
 		"layout": {
 			"default": {
 				"type": "flex",
-				"flexWrap": "nowrap",
-				"orientation": "vertical",
+				"flexWrap": "wrap",
+				"orientation": "horizontal",
 				"justifyContent": "left",
 				"verticalAlignment": "bottom"
 			},

--- a/projects/packages/forms/src/blocks/contact-form/block.json
+++ b/projects/packages/forms/src/blocks/contact-form/block.json
@@ -26,7 +26,7 @@
 				"flexWrap": "wrap",
 				"orientation": "horizontal",
 				"justifyContent": "left",
-				"verticalAlignment": "bottom"
+				"verticalAlignment": "top"
 			},
 			"allowSwitching": false,
 			"allowEditing": true,

--- a/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
+++ b/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
@@ -48,8 +48,8 @@ class Contact_Form_Block {
 					'layout' => array(
 						'default'                => array(
 							'type'              => 'flex',
-							'flexWrap'          => 'nowrap',
-							'orientation'       => 'vertical',
+							'flexWrap'          => 'wrap',
+							'orientation'       => 'horizontal',
 							'justifyContent'    => 'left',
 							'verticalAlignment' => 'bottom',
 						),

--- a/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
+++ b/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
@@ -51,7 +51,7 @@ class Contact_Form_Block {
 							'flexWrap'          => 'wrap',
 							'orientation'       => 'horizontal',
 							'justifyContent'    => 'left',
-							'verticalAlignment' => 'bottom',
+							'verticalAlignment' => 'top',
 						),
 						'allowSwitching'         => false,
 						'allowEditing'           => true,

--- a/projects/packages/forms/src/blocks/contact-form/edit.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/edit.tsx
@@ -494,7 +494,7 @@ function JetpackContactFormEdit( {
 
 	// Effect to sync field widths when layout orientation changes
 	useEffect( () => {
-		const orientation = layout?.orientation ?? 'vertical';
+		const orientation = layout?.orientation ?? 'horizontal';
 
 		// Skip initial render, only react to actual orientation changes
 		if ( prevOrientationRef.current !== null && prevOrientationRef.current !== orientation ) {

--- a/projects/packages/forms/src/blocks/contact-form/edit.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/edit.tsx
@@ -336,7 +336,8 @@ function JetpackContactFormEdit( {
 		'jetpack-contact-form',
 		isFirstStep && 'is-first-step',
 		isLastStep && 'is-last-step',
-		variationName === 'multistep' && isSingleStep && 'is-previewing-step'
+		variationName === 'multistep' && isSingleStep && 'is-previewing-step',
+		attributes?.layout ? 'has-jetpack-form-layout' : 'has-no-jetpack-form-layout'
 	);
 	const innerBlocksProps = useInnerBlocksProps(
 		{

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -1,5 +1,32 @@
 @use "@automattic/jetpack-base-styles/gutenberg-base-styles" as gb;
 
+:where(.is-classic-layout) .jetpack-contact-form,
+.jetpack-contact-form.has-no-jetpack-form-layout {
+	display: flex;
+	flex-wrap: wrap;
+	justify-content: flex-start;
+	gap: var(--wp--style--block-gap, 1.5rem);
+
+	.wp-block {
+		flex: 0 0 100%;
+		margin-top: 0;
+		margin-bottom: 0;
+		max-width: 100%;
+	}
+
+	> div {
+		flex: 1 1 100%;
+	}
+
+	&.is-nowrap {
+		flex-wrap: nowrap;
+	}
+
+	.wp-block-jetpack-button {
+		align-self: flex-end;
+	}
+}
+
 .wp-block-jetpack-contact-form {
 	box-sizing: border-box;
 
@@ -47,25 +74,6 @@
 
 		// not horizontal or vertical means a form created
 		// before layout support was added
-		&:not(.is-horizontal, .is-vertical) {
-
-			display: flex;
-			flex-wrap: wrap;
-			justify-content: flex-start;
-			gap: var(--wp--style--block-gap, 1.5rem);
-
-			> div {
-				flex: 1 1 100%;
-			}
-
-			&.is-nowrap {
-				flex-wrap: nowrap;
-			}
-
-			.wp-block-jetpack-button {
-				align-self: flex-end;
-			}
-		}
 
 		.wp-block {
 			margin-top: 0;

--- a/projects/packages/forms/src/blocks/contact-form/variations.js
+++ b/projects/packages/forms/src/blocks/contact-form/variations.js
@@ -5,6 +5,14 @@ import { __, _x } from '@wordpress/i18n';
 import { people } from '@wordpress/icons';
 import renderMaterialIcon from '../shared/components/render-material-icon.jsx';
 
+const verticalLayout = {
+	type: 'flex',
+	flexWrap: 'nowrap',
+	orientation: 'vertical',
+	justifyContent: 'left',
+	verticalAlignment: 'bottom',
+};
+
 const variations = [
 	{
 		name: 'regular-form',
@@ -22,6 +30,7 @@ const variations = [
 		},
 		attributes: {
 			variationName: 'default-empty',
+			layout: verticalLayout,
 		},
 		scope: [ 'transform' ],
 		isActive: ( { variationName } ) => variationName !== 'multistep',
@@ -76,6 +85,7 @@ const variations = [
 		],
 		attributes: {
 			variationName: 'default',
+			layout: verticalLayout,
 		},
 	},
 	{
@@ -155,6 +165,7 @@ const variations = [
 		],
 		attributes: {
 			subject: __( 'A new RSVP from your website', 'jetpack-forms' ),
+			layout: verticalLayout,
 		},
 		example: {
 			innerBlocks: [
@@ -308,6 +319,7 @@ const variations = [
 		],
 		attributes: {
 			subject: __( 'A new registration from your website', 'jetpack-forms' ),
+			layout: verticalLayout,
 		},
 		example: {
 			innerBlocks: [
@@ -497,6 +509,7 @@ const variations = [
 		],
 		attributes: {
 			subject: __( 'A new appointment booked from your website', 'jetpack-forms' ),
+			layout: verticalLayout,
 		},
 		example: {
 			innerBlocks: [
@@ -643,6 +656,7 @@ const variations = [
 		],
 		attributes: {
 			subject: __( 'New feedback received from your website', 'jetpack-forms' ),
+			layout: verticalLayout,
 		},
 		example: {
 			innerBlocks: [
@@ -923,6 +937,7 @@ const variations = [
 		],
 		attributes: {
 			variationName: 'multistep',
+			layout: verticalLayout,
 		},
 		scope: [ 'block', 'inserter', 'transform' ],
 		isActive: [ 'variationName' ],
@@ -964,7 +979,9 @@ const variations = [
 				},
 			],
 		],
-		attributes: {},
+		attributes: {
+			layout: verticalLayout,
+		},
 		example: {
 			innerBlocks: [
 				{

--- a/projects/packages/forms/src/blocks/contact-form/variations.js
+++ b/projects/packages/forms/src/blocks/contact-form/variations.js
@@ -4,14 +4,7 @@ import { Path } from '@wordpress/components';
 import { __, _x } from '@wordpress/i18n';
 import { people } from '@wordpress/icons';
 import renderMaterialIcon from '../shared/components/render-material-icon.jsx';
-
-const verticalLayout = {
-	type: 'flex',
-	flexWrap: 'nowrap',
-	orientation: 'vertical',
-	justifyContent: 'left',
-	verticalAlignment: 'bottom',
-};
+import { VERTICAL_LAYOUT } from '../shared/util/constants.js';
 
 const variations = [
 	{
@@ -30,7 +23,7 @@ const variations = [
 		},
 		attributes: {
 			variationName: 'default-empty',
-			layout: verticalLayout,
+			layout: VERTICAL_LAYOUT,
 		},
 		scope: [ 'transform' ],
 		isActive: ( { variationName } ) => variationName !== 'multistep',
@@ -85,7 +78,7 @@ const variations = [
 		],
 		attributes: {
 			variationName: 'default',
-			layout: verticalLayout,
+			layout: VERTICAL_LAYOUT,
 		},
 	},
 	{
@@ -165,7 +158,7 @@ const variations = [
 		],
 		attributes: {
 			subject: __( 'A new RSVP from your website', 'jetpack-forms' ),
-			layout: verticalLayout,
+			layout: VERTICAL_LAYOUT,
 		},
 		example: {
 			innerBlocks: [
@@ -319,7 +312,7 @@ const variations = [
 		],
 		attributes: {
 			subject: __( 'A new registration from your website', 'jetpack-forms' ),
-			layout: verticalLayout,
+			layout: VERTICAL_LAYOUT,
 		},
 		example: {
 			innerBlocks: [
@@ -509,7 +502,7 @@ const variations = [
 		],
 		attributes: {
 			subject: __( 'A new appointment booked from your website', 'jetpack-forms' ),
-			layout: verticalLayout,
+			layout: VERTICAL_LAYOUT,
 		},
 		example: {
 			innerBlocks: [
@@ -656,7 +649,7 @@ const variations = [
 		],
 		attributes: {
 			subject: __( 'New feedback received from your website', 'jetpack-forms' ),
-			layout: verticalLayout,
+			layout: VERTICAL_LAYOUT,
 		},
 		example: {
 			innerBlocks: [
@@ -937,7 +930,7 @@ const variations = [
 		],
 		attributes: {
 			variationName: 'multistep',
-			layout: verticalLayout,
+			layout: VERTICAL_LAYOUT,
 		},
 		scope: [ 'block', 'inserter', 'transform' ],
 		isActive: [ 'variationName' ],
@@ -980,7 +973,7 @@ const variations = [
 			],
 		],
 		attributes: {
-			layout: verticalLayout,
+			layout: VERTICAL_LAYOUT,
 		},
 		example: {
 			innerBlocks: [

--- a/projects/packages/forms/src/blocks/shared/hooks/use-form-wrapper.js
+++ b/projects/packages/forms/src/blocks/shared/hooks/use-form-wrapper.js
@@ -9,6 +9,14 @@ import useConfigValue from '../../../hooks/use-config-value.ts';
 import { createSyncedForm } from '../../contact-form/util/create-synced-form.ts';
 import { FORM_BLOCK_NAME, FORM_POST_TYPE } from '../util/constants.js';
 
+const verticalLayout = {
+	type: 'flex',
+	flexWrap: 'nowrap',
+	orientation: 'vertical',
+	justifyContent: 'left',
+	verticalAlignment: 'bottom',
+};
+
 /**
  * Creates the form block structure with a field and submit button.
  *
@@ -24,7 +32,10 @@ export function createFormBlockStructure( fieldBlockName, fieldAttributes, field
 		type: 'submit',
 		tagName: 'button',
 	} );
-	const formBlock = createBlock( FORM_BLOCK_NAME, {}, [ fieldBlock, submitButton ] );
+	const formBlock = createBlock( FORM_BLOCK_NAME, { layout: verticalLayout }, [
+		fieldBlock,
+		submitButton,
+	] );
 
 	return { formBlock, fieldBlock, submitButton };
 }

--- a/projects/packages/forms/src/blocks/shared/hooks/use-form-wrapper.js
+++ b/projects/packages/forms/src/blocks/shared/hooks/use-form-wrapper.js
@@ -7,15 +7,7 @@ import { useEffect, useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import useConfigValue from '../../../hooks/use-config-value.ts';
 import { createSyncedForm } from '../../contact-form/util/create-synced-form.ts';
-import { FORM_BLOCK_NAME, FORM_POST_TYPE } from '../util/constants.js';
-
-const verticalLayout = {
-	type: 'flex',
-	flexWrap: 'nowrap',
-	orientation: 'vertical',
-	justifyContent: 'left',
-	verticalAlignment: 'bottom',
-};
+import { FORM_BLOCK_NAME, FORM_POST_TYPE, VERTICAL_LAYOUT } from '../util/constants.js';
 
 /**
  * Creates the form block structure with a field and submit button.
@@ -32,7 +24,7 @@ export function createFormBlockStructure( fieldBlockName, fieldAttributes, field
 		type: 'submit',
 		tagName: 'button',
 	} );
-	const formBlock = createBlock( FORM_BLOCK_NAME, { layout: verticalLayout }, [
+	const formBlock = createBlock( FORM_BLOCK_NAME, { layout: VERTICAL_LAYOUT }, [
 		fieldBlock,
 		submitButton,
 	] );

--- a/projects/packages/forms/src/blocks/shared/util/constants.js
+++ b/projects/packages/forms/src/blocks/shared/util/constants.js
@@ -69,7 +69,7 @@ export const VERTICAL_LAYOUT = {
 	flexWrap: 'nowrap',
 	orientation: 'vertical',
 	justifyContent: 'left',
-	verticalAlignment: 'bottom',
+	verticalAlignment: 'top',
 };
 
 export const FORM_STYLE = {

--- a/projects/packages/forms/src/blocks/shared/util/constants.js
+++ b/projects/packages/forms/src/blocks/shared/util/constants.js
@@ -58,6 +58,20 @@ export const DATE_FORMAT_OPTIONS = DATE_FORMATS.map(
 
 export const FORM_BLOCK_NAME = 'jetpack/contact-form';
 
+/**
+ * Vertical layout preset for form variations and programmatic form creation.
+ * Matches the pre-layout-support behavior where fields stack vertically.
+ * Used by variations and createFormBlockStructure() to explicitly set vertical layout,
+ * since the block default was changed to horizontal/wrap for legacy form compatibility.
+ */
+export const VERTICAL_LAYOUT = {
+	type: 'flex',
+	flexWrap: 'nowrap',
+	orientation: 'vertical',
+	justifyContent: 'left',
+	verticalAlignment: 'bottom',
+};
+
 export const FORM_STYLE = {
 	ANIMATED: 'animated',
 	BELOW: 'below',

--- a/projects/packages/forms/src/blocks/shared/util/constants.js
+++ b/projects/packages/forms/src/blocks/shared/util/constants.js
@@ -59,10 +59,10 @@ export const DATE_FORMAT_OPTIONS = DATE_FORMATS.map(
 export const FORM_BLOCK_NAME = 'jetpack/contact-form';
 
 /**
- * Vertical layout preset for form variations and programmatic form creation.
- * Matches the pre-layout-support behavior where fields stack vertically.
- * Used by variations and createFormBlockStructure() to explicitly set vertical layout,
- * since the block default was changed to horizontal/wrap for legacy form compatibility.
+ * Vertical layout preset for new form variations and programmatic form creation
+ * that should explicitly stack fields vertically.
+ * Used by variations and createFormBlockStructure() to opt into vertical layout,
+ * while older forms keep the legacy horizontal/wrap layout as their default.
  */
 export const VERTICAL_LAYOUT = {
 	type: 'flex',

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -1415,6 +1415,13 @@ class Contact_Form extends Contact_Form_Shortcode {
 			if ( $submission_success ) {
 				$form_classes .= ' submission-success';
 			}
+
+			if ( isset( $attributes['layout'] ) ) {
+				$form_classes .= ' has-jetpack-form-layout';
+			} else {
+				$form_classes .= ' has-no-jetpack-form-layout';
+			}
+
 			$post_title           = $post->post_title ?? '';
 			$form_accessible_name = ! empty( $attributes['formTitle'] ) ? $attributes['formTitle'] : $post_title;
 			$form_aria_label      = isset( $form_accessible_name ) && ! empty( $form_accessible_name ) ? 'aria-label="' . esc_attr( $form_accessible_name ) . '"' : '';

--- a/projects/packages/forms/src/contact-form/css/grunion.scss
+++ b/projects/packages/forms/src/contact-form/css/grunion.scss
@@ -574,6 +574,8 @@
 	box-sizing: border-box;
 }
 
+:where(.wp-block-jetpack-contact-form.is-classic-layout), // This allows forms even with layout attribute to keep the previous layout.
+:where(.has-no-jetpack-form-layout) .wp-block-jetpack-contact-form,
 .wp-block-jetpack-contact-form:not(.is-layout-flex) {
 	display: flex;
 	flex-wrap: wrap;

--- a/projects/packages/forms/src/contact-form/css/grunion.scss
+++ b/projects/packages/forms/src/contact-form/css/grunion.scss
@@ -674,34 +674,34 @@
 	}
 }
 
-.wp-block-jetpack-contact-form.wp-block-jetpack-contact-form .wp-block-button__width-25,
-.wp-block-jetpack-contact-form.wp-block-jetpack-contact-form .grunion-field-width-25-wrap {
+.wp-block-jetpack-contact-form .wp-block-button__width-25,
+.wp-block-jetpack-contact-form .grunion-field-width-25-wrap {
 	flex: 1 1 calc(25% - calc(var(--wp--style--block-gap, 1.5rem) * 1));
 	max-width: 25%;
 	width: calc(25% - calc(var(--wp--style--block-gap, 1.5rem) * 1));
 }
 
-.wp-block-jetpack-contact-form.wp-block-jetpack-contact-form .grunion-field-width-33-wrap {
+.wp-block-jetpack-contact-form .grunion-field-width-33-wrap {
 	flex: 1 1 calc(33.33% - calc(var(--wp--style--block-gap, 1.5rem) * 1));
 	max-width: 33.33%;
 	width: calc(33.33% - calc(var(--wp--style--block-gap, 1.5rem) * 1));
 }
 
-.wp-block-jetpack-contact-form.wp-block-jetpack-contact-form .wp-block-button__width-50,
-.wp-block-jetpack-contact-form.wp-block-jetpack-contact-form .grunion-field-width-50-wrap {
+.wp-block-jetpack-contact-form .wp-block-button__width-50,
+.wp-block-jetpack-contact-form .grunion-field-width-50-wrap {
 	flex: 1 1 calc(50% - calc(var(--wp--style--block-gap, 1.5rem) * 1));
 	max-width: 50%;
 	width: calc(50% - calc(var(--wp--style--block-gap, 1.5rem) * 1));
 }
 
-.wp-block-jetpack-contact-form.wp-block-jetpack-contact-form .wp-block-button__width-75,
-.wp-block-jetpack-contact-form.wp-block-jetpack-contact-form .grunion-field-width-75-wrap {
+.wp-block-jetpack-contact-form .wp-block-button__width-75,
+.wp-block-jetpack-contact-form .grunion-field-width-75-wrap {
 	flex: 1 1 calc(75% - calc(var(--wp--style--block-gap, 1.5rem) * 1));
 	max-width: 75%;
 	width: calc(75% - calc(var(--wp--style--block-gap, 1.5rem) * 1));
 }
 
-.wp-block-jetpack-contact-form.wp-block-jetpack-contact-form .grunion-field-width-auto-wrap {
+.wp-block-jetpack-contact-form .grunion-field-width-auto-wrap {
 	flex: 1 1 0;
 }
 

--- a/projects/packages/forms/src/contact-form/css/grunion.scss
+++ b/projects/packages/forms/src/contact-form/css/grunion.scss
@@ -674,34 +674,34 @@
 	}
 }
 
-.wp-block-jetpack-contact-form .wp-block-button__width-25,
-.wp-block-jetpack-contact-form .grunion-field-width-25-wrap {
+.wp-block-jetpack-contact-form.wp-block-jetpack-contact-form .wp-block-button__width-25,
+.wp-block-jetpack-contact-form.wp-block-jetpack-contact-form .grunion-field-width-25-wrap {
 	flex: 1 1 calc(25% - calc(var(--wp--style--block-gap, 1.5rem) * 1));
 	max-width: 25%;
 	width: calc(25% - calc(var(--wp--style--block-gap, 1.5rem) * 1));
 }
 
-.wp-block-jetpack-contact-form .grunion-field-width-33-wrap {
+.wp-block-jetpack-contact-form.wp-block-jetpack-contact-form .grunion-field-width-33-wrap {
 	flex: 1 1 calc(33.33% - calc(var(--wp--style--block-gap, 1.5rem) * 1));
 	max-width: 33.33%;
 	width: calc(33.33% - calc(var(--wp--style--block-gap, 1.5rem) * 1));
 }
 
-.wp-block-jetpack-contact-form .wp-block-button__width-50,
-.wp-block-jetpack-contact-form .grunion-field-width-50-wrap {
+.wp-block-jetpack-contact-form.wp-block-jetpack-contact-form .wp-block-button__width-50,
+.wp-block-jetpack-contact-form.wp-block-jetpack-contact-form .grunion-field-width-50-wrap {
 	flex: 1 1 calc(50% - calc(var(--wp--style--block-gap, 1.5rem) * 1));
 	max-width: 50%;
 	width: calc(50% - calc(var(--wp--style--block-gap, 1.5rem) * 1));
 }
 
-.wp-block-jetpack-contact-form .wp-block-button__width-75,
-.wp-block-jetpack-contact-form .grunion-field-width-75-wrap {
+.wp-block-jetpack-contact-form.wp-block-jetpack-contact-form .wp-block-button__width-75,
+.wp-block-jetpack-contact-form.wp-block-jetpack-contact-form .grunion-field-width-75-wrap {
 	flex: 1 1 calc(75% - calc(var(--wp--style--block-gap, 1.5rem) * 1));
 	max-width: 75%;
 	width: calc(75% - calc(var(--wp--style--block-gap, 1.5rem) * 1));
 }
 
-.wp-block-jetpack-contact-form .grunion-field-width-auto-wrap {
+.wp-block-jetpack-contact-form.wp-block-jetpack-contact-form .grunion-field-width-auto-wrap {
 	flex: 1 1 0;
 }
 


### PR DESCRIPTION
This PR fixes the regression cased in https://github.com/Automattic/jetpack/pull/45272. 

Which broke previous forms by making them always vertical. This PR does the following. 

1. it detects when a form has the layout attributes. ( new since https://github.com/Automattic/jetpack/pull/45272) and make sure that the previous form styles are applied. 
2. Make the default layout for forms without layout to be the same as the previous one. This is a horizontal one. 
3. When a new form is inserted that we do add the vertical layout. 
4. Add a new `is-classic-layout` class that can be applied to the form to always have the previous styles applies. This is done because there are blocks that you can insert into the form that you can't change the width of. Such as paragraph. 

## Proposed changes:
* Change the default form layout from vertical (`nowrap`) to horizontal (`wrap`), allowing form fields to display side-by-side with proper wrapping behavior
* Increase CSS specificity for field width selectors by doubling the parent class selector (`.wp-block-jetpack-contact-form.wp-block-jetpack-contact-form`) to ensure width styles apply correctly when the horizontal layout is active

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion


## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

* Create a new post or page and add a Jetpack Form block
* Verify that newly added form fields display horizontally (side-by-side) by default rather than stacked vertically
* Test that field width settings (25%, 33%, 50%, 75%, auto) apply correctly with the new layout
* Verify fields wrap to the next line appropriately when the container width is insufficient

## Changelog

- [x] Generate changelog entries for this PR (using AI).

🤖 Generated with [Claude Code](https://claude.ai/code)