### PR TITLE
Stats: Add transient cleanup cron job to prevent database bloat

### DIFF
--- a/projects/packages/stats/changelog/add-stats-transient-cleanup
+++ b/projects/packages/stats/changelog/add-stats-transient-cleanup
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add Transient_Cleanup class to periodically clean up expired stats cache transients on sites without persistent object cache.

--- a/projects/packages/stats/src/class-main.php
+++ b/projects/packages/stats/src/class-main.php
@@ -76,6 +76,7 @@ class Main {
 
 		XMLRPC_Provider::init();
 		REST_Provider::init();
+		Transient_Cleanup::init();
 
 		// Set up package version hook.
 		add_filter( 'jetpack_package_versions', __NAMESPACE__ . '\Package_Version::send_package_version_to_tracker' );

--- a/projects/packages/stats/src/class-main.php
+++ b/projects/packages/stats/src/class-main.php
@@ -78,6 +78,9 @@ class Main {
 		REST_Provider::init();
 		Transient_Cleanup::init();
 
+		// Clean up transient cron on module deactivation.
+		add_action( 'jetpack_deactivate_module_stats', array( Transient_Cleanup::class, 'unschedule_cleanup' ) );
+
 		// Set up package version hook.
 		add_filter( 'jetpack_package_versions', __NAMESPACE__ . '\Package_Version::send_package_version_to_tracker' );
 	}

--- a/projects/packages/stats/src/class-transient-cleanup.php
+++ b/projects/packages/stats/src/class-transient-cleanup.php
@@ -174,7 +174,7 @@ class Transient_Cleanup {
 	 * Purge expired transients for a specific prefix.
 	 *
 	 * @param string $prefix The transient prefix to clean up.
-	 * @return int Number of deleted transients.
+	 * @return int Number of deleted transient options, two entries for each transient.
 	 */
 	private static function purge_expired_transients( $prefix ) {
 		global $wpdb;
@@ -227,7 +227,6 @@ class Transient_Cleanup {
 			}
 		}
 
-		// Each transient has 2 rows (value + timeout), so divide by 2 for transient count.
-		return (int) ( $total_deleted / 2 );
+		return $total_deleted;
 	}
 }

--- a/projects/packages/stats/src/class-transient-cleanup.php
+++ b/projects/packages/stats/src/class-transient-cleanup.php
@@ -206,24 +206,28 @@ class Transient_Cleanup {
 			$options_names[] = '_transient_timeout_' . $prefix . $transient;
 		}
 
-		// Delete all in a single query.
-		$placeholders = implode( ', ', array_fill( 0, count( $options_names ), '%s' ) );
+		// Delete in chunks to avoid excessively long SQL queries.
+		// Each option name can be ~80 chars, so 50 items ≈ 4KB per query.
+		$chunks        = array_chunk( $options_names, 50 );
+		$total_deleted = 0;
 
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
-		$result = $wpdb->query(
-			$wpdb->prepare(
-				"DELETE FROM {$wpdb->options} WHERE option_name IN ($placeholders)", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare -- $placeholders is a list of %s.
-				$options_names
-			)
-		);
+		foreach ( $chunks as $chunk ) {
+			$placeholders = implode( ', ', array_fill( 0, count( $chunk ), '%s' ) );
 
-		if ( false === $result ) {
-			return 0;
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+			$result = $wpdb->query(
+				$wpdb->prepare(
+					"DELETE FROM {$wpdb->options} WHERE option_name IN ($placeholders)", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare -- $placeholders is a list of %s.
+					$chunk
+				)
+			);
+
+			if ( false !== $result ) {
+				$total_deleted += $result;
+			}
 		}
 
 		// Each transient has 2 rows (value + timeout), so divide by 2 for transient count.
-		// Using actual rows deleted rather than count($transients) in case some were
-		// already deleted by another process or were missing.
-		return (int) ( $result / 2 );
+		return (int) ( $total_deleted / 2 );
 	}
 }

--- a/projects/packages/stats/src/class-transient-cleanup.php
+++ b/projects/packages/stats/src/class-transient-cleanup.php
@@ -36,7 +36,7 @@ class Transient_Cleanup {
 	 * Used as the SQL LIMIT per prefix and as the threshold for stopping iteration.
 	 * Actual deletions per run may slightly exceed this when processing multiple prefixes.
 	 */
-	const BATCH_SIZE = 2000;
+	const BATCH_SIZE = 5000;
 
 	/**
 	 * Cron interval in seconds (8 hours).

--- a/projects/packages/stats/src/class-transient-cleanup.php
+++ b/projects/packages/stats/src/class-transient-cleanup.php
@@ -1,0 +1,232 @@
+<?php
+/**
+ * Stats Transient Cleanup
+ *
+ * Handles cleanup of expired stats cache transients to prevent database bloat
+ * on sites without a persistent object cache.
+ *
+ * Adapted from Brute Force Protection transient cleanup.
+ *
+ * @package automattic/jetpack-stats
+ */
+
+namespace Automattic\Jetpack\Stats;
+
+/**
+ * Transient_Cleanup class.
+ *
+ * Provides a scheduled cron job to clean up expired stats transients.
+ * WordPress transient garbage collection is "lazy" - expired transients are only
+ * deleted when accessed via get_transient(). Stats transients use dynamic cache keys
+ * based on query parameters, so expired entries are rarely accessed again and
+ * accumulate indefinitely in wp_options on sites without an external object cache.
+ *
+ * @since $$next-version$$
+ */
+class Transient_Cleanup {
+
+	/**
+	 * Cron hook name.
+	 */
+	const CRON_HOOK = 'jetpack_stats_transient_cleanup';
+
+	/**
+	 * Lock transient name to prevent concurrent runs.
+	 */
+	const LOCK_TRANSIENT = 'jetpack_stats_cleanup_lock';
+
+	/**
+	 * Lock timeout in seconds (5 minutes).
+	 */
+	const LOCK_TIMEOUT = 300;
+
+	/**
+	 * Maximum number of transients to delete per run.
+	 */
+	const BATCH_SIZE = 100;
+
+	/**
+	 * Cron interval in seconds (8 hours).
+	 */
+	const CRON_INTERVAL = 28800;
+
+	/**
+	 * Initialize the transient cleanup.
+	 *
+	 * @return void
+	 */
+	public static function init() {
+		// Register the cron hook.
+		add_action( self::CRON_HOOK, array( static::class, 'run_cleanup' ) );
+
+		// Register custom cron schedule.
+		// phpcs:ignore WordPress.WP.CronInterval.ChangeDetected -- 8 hours is intentional for batched transient cleanup.
+		add_filter( 'cron_schedules', array( static::class, 'add_cron_schedule' ) );
+
+		// Schedule the cron job if not already scheduled.
+		add_action( 'admin_init', array( static::class, 'schedule_cleanup' ) );
+	}
+
+	/**
+	 * Add custom cron schedule for 8-hour intervals.
+	 *
+	 * @param array $schedules Existing cron schedules.
+	 * @return array Modified cron schedules.
+	 */
+	public static function add_cron_schedule( $schedules ) {
+		if ( ! isset( $schedules['jetpack_stats_eight_hours'] ) ) {
+			$schedules['jetpack_stats_eight_hours'] = array(
+				'interval' => self::CRON_INTERVAL,
+				'display'  => __( 'Every Eight Hours', 'jetpack-stats' ),
+			);
+		}
+		return $schedules;
+	}
+
+	/**
+	 * Schedule the cleanup cron job.
+	 *
+	 * @return void
+	 */
+	public static function schedule_cleanup() {
+		if ( ! wp_next_scheduled( self::CRON_HOOK ) ) {
+			wp_schedule_event( time() + self::CRON_INTERVAL, 'jetpack_stats_eight_hours', self::CRON_HOOK );
+		}
+	}
+
+	/**
+	 * Unschedule the cleanup cron job.
+	 * Should be called on plugin deactivation.
+	 *
+	 * @return void
+	 */
+	public static function unschedule_cleanup() {
+		$timestamp = wp_next_scheduled( self::CRON_HOOK );
+		if ( $timestamp ) {
+			wp_unschedule_event( $timestamp, self::CRON_HOOK );
+		}
+	}
+
+	/**
+	 * Get the list of transient prefixes to clean up.
+	 *
+	 * @return array List of transient prefixes.
+	 */
+	public static function get_transient_prefixes() {
+		$prefixes = array(
+			WPCOM_Stats::STATS_CACHE_TRANSIENT_PREFIX, // jetpack_restapi_stats_cache_
+		);
+
+		/**
+		 * Filter the list of transient prefixes to clean up.
+		 *
+		 * @since $$next-version$$
+		 *
+		 * @param array $prefixes List of transient prefixes.
+		 */
+		return apply_filters( 'jetpack_stats_transient_cleanup_prefixes', $prefixes );
+	}
+
+	/**
+	 * Run the transient cleanup.
+	 *
+	 * @return int|false Number of deleted transients, or false if skipped.
+	 */
+	public static function run_cleanup() {
+		/**
+		 * Filter to disable transient cleanup.
+		 *
+		 * @since $$next-version$$
+		 *
+		 * @param bool $disabled Whether to disable transient cleanup. Default false.
+		 */
+		if ( apply_filters( 'jetpack_stats_transient_cleanup_disabled', false ) ) {
+			return false;
+		}
+
+		// Skip if using external object cache - transients auto-expire there.
+		if ( wp_using_ext_object_cache() ) {
+			return false;
+		}
+
+		// Acquire lock to prevent concurrent runs.
+		if ( get_transient( self::LOCK_TRANSIENT ) ) {
+			return false;
+		}
+
+		// Set lock.
+		set_transient( self::LOCK_TRANSIENT, 1, self::LOCK_TIMEOUT );
+
+		$total_deleted = 0;
+		$prefixes      = self::get_transient_prefixes();
+
+		foreach ( $prefixes as $prefix ) {
+			$deleted        = self::purge_expired_transients( $prefix );
+			$total_deleted += $deleted;
+
+			// Stop if we've hit the batch limit.
+			if ( $total_deleted >= self::BATCH_SIZE ) {
+				break;
+			}
+		}
+
+		// Release lock.
+		delete_transient( self::LOCK_TRANSIENT );
+
+		return $total_deleted;
+	}
+
+	/**
+	 * Purge expired transients for a specific prefix.
+	 *
+	 * @param string $prefix The transient prefix to clean up.
+	 * @return int Number of deleted transients.
+	 */
+	private static function purge_expired_transients( $prefix ) {
+		global $wpdb;
+
+		$now            = time();
+		$timeout_prefix = '_transient_timeout_' . $prefix;
+		$like_pattern   = $wpdb->esc_like( $timeout_prefix ) . '%';
+
+		// Find expired transients by querying timeout entries.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$transients = $wpdb->get_col(
+			$wpdb->prepare(
+				"SELECT SUBSTRING(option_name, %d) AS transient_name FROM {$wpdb->options} WHERE option_name LIKE %s AND option_value < %d LIMIT %d",
+				strlen( $timeout_prefix ) + 1,
+				$like_pattern,
+				$now,
+				self::BATCH_SIZE
+			)
+		);
+
+		if ( empty( $transients ) ) {
+			return 0;
+		}
+
+		// Build list of option names to delete (both transient and timeout entries).
+		$options_names = array();
+		foreach ( $transients as $transient ) {
+			$options_names[] = '_transient_' . $prefix . $transient;
+			$options_names[] = '_transient_timeout_' . $prefix . $transient;
+		}
+
+		// Delete all in a single query.
+		$placeholders = implode( ', ', array_fill( 0, count( $options_names ), '%s' ) );
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$result = $wpdb->query(
+			$wpdb->prepare(
+				"DELETE FROM {$wpdb->options} WHERE option_name IN ($placeholders)", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare -- $placeholders is a list of %s.
+				$options_names
+			)
+		);
+
+		if ( false === $result ) {
+			return 0;
+		}
+
+		return count( $transients );
+	}
+}

--- a/projects/packages/stats/src/class-transient-cleanup.php
+++ b/projects/packages/stats/src/class-transient-cleanup.php
@@ -36,7 +36,7 @@ class Transient_Cleanup {
 	 * Used as the SQL LIMIT per prefix and as the threshold for stopping iteration.
 	 * Actual deletions per run may slightly exceed this when processing multiple prefixes.
 	 */
-	const BATCH_SIZE = 1000;
+	const BATCH_SIZE = 2000;
 
 	/**
 	 * Cron interval in seconds (8 hours).

--- a/projects/packages/stats/src/class-transient-cleanup.php
+++ b/projects/packages/stats/src/class-transient-cleanup.php
@@ -36,7 +36,7 @@ class Transient_Cleanup {
 	 * Used as the SQL LIMIT per prefix and as the threshold for stopping iteration.
 	 * Actual deletions per run may slightly exceed this when processing multiple prefixes.
 	 */
-	const BATCH_SIZE = 100;
+	const BATCH_SIZE = 1000;
 
 	/**
 	 * Cron interval in seconds (8 hours).

--- a/projects/packages/stats/src/class-transient-cleanup.php
+++ b/projects/packages/stats/src/class-transient-cleanup.php
@@ -101,10 +101,7 @@ class Transient_Cleanup {
 	 * @return void
 	 */
 	public static function unschedule_cleanup() {
-		$timestamp = wp_next_scheduled( self::CRON_HOOK );
-		if ( $timestamp ) {
-			wp_unschedule_event( $timestamp, self::CRON_HOOK );
-		}
+		wp_clear_scheduled_hook( self::CRON_HOOK );
 	}
 
 	/**

--- a/projects/packages/stats/src/class-transient-cleanup.php
+++ b/projects/packages/stats/src/class-transient-cleanup.php
@@ -221,6 +221,9 @@ class Transient_Cleanup {
 			return 0;
 		}
 
-		return count( $transients );
+		// Each transient has 2 rows (value + timeout), so divide by 2 for transient count.
+		// Using actual rows deleted rather than count($transients) in case some were
+		// already deleted by another process or were missing.
+		return (int) ( $result / 2 );
 	}
 }

--- a/projects/packages/stats/src/class-transient-cleanup.php
+++ b/projects/packages/stats/src/class-transient-cleanup.php
@@ -134,7 +134,7 @@ class Transient_Cleanup {
 	/**
 	 * Run the transient cleanup.
 	 *
-	 * @return int|false Number of deleted transients, or false if skipped.
+	 * @return int|false Number of deleted transient options (two entries per transient), or false if skipped.
 	 */
 	public static function run_cleanup() {
 		/**
@@ -200,15 +200,15 @@ class Transient_Cleanup {
 		}
 
 		// Build list of option names to delete (both transient and timeout entries).
-		$options_names = array();
+		$option_names = array();
 		foreach ( $transients as $transient ) {
-			$options_names[] = '_transient_' . $prefix . $transient;
-			$options_names[] = '_transient_timeout_' . $prefix . $transient;
+			$option_names[] = '_transient_' . $prefix . $transient;
+			$option_names[] = '_transient_timeout_' . $prefix . $transient;
 		}
 
 		// Delete in chunks to avoid excessively long SQL queries.
 		// Each option name can be ~80 chars, so 50 items ≈ 4KB per query.
-		$chunks        = array_chunk( $options_names, 50 );
+		$chunks        = array_chunk( $option_names, 50 );
 		$total_deleted = 0;
 
 		foreach ( $chunks as $chunk ) {

--- a/projects/packages/stats/src/class-transient-cleanup.php
+++ b/projects/packages/stats/src/class-transient-cleanup.php
@@ -31,7 +31,10 @@ class Transient_Cleanup {
 	const CRON_HOOK = 'jetpack_stats_transient_cleanup';
 
 	/**
-	 * Maximum number of transients to delete per run.
+	 * Batch size for transient cleanup.
+	 *
+	 * Used as the SQL LIMIT per prefix and as the threshold for stopping iteration.
+	 * Actual deletions per run may slightly exceed this when processing multiple prefixes.
 	 */
 	const BATCH_SIZE = 100;
 
@@ -157,7 +160,8 @@ class Transient_Cleanup {
 			$deleted        = self::purge_expired_transients( $prefix );
 			$total_deleted += $deleted;
 
-			// Stop if we've hit the batch limit.
+			// Stop processing additional prefixes once we've reached the batch threshold.
+			// Note: total may exceed BATCH_SIZE since each prefix can delete up to BATCH_SIZE.
 			if ( $total_deleted >= self::BATCH_SIZE ) {
 				break;
 			}

--- a/projects/packages/stats/src/class-transient-cleanup.php
+++ b/projects/packages/stats/src/class-transient-cleanup.php
@@ -31,16 +31,6 @@ class Transient_Cleanup {
 	const CRON_HOOK = 'jetpack_stats_transient_cleanup';
 
 	/**
-	 * Lock transient name to prevent concurrent runs.
-	 */
-	const LOCK_TRANSIENT = 'jetpack_stats_cleanup_lock';
-
-	/**
-	 * Lock timeout in seconds (5 minutes).
-	 */
-	const LOCK_TIMEOUT = 300;
-
-	/**
 	 * Maximum number of transients to delete per run.
 	 */
 	const BATCH_SIZE = 100;
@@ -121,7 +111,21 @@ class Transient_Cleanup {
 		 *
 		 * @param array $prefixes List of transient prefixes.
 		 */
-		return apply_filters( 'jetpack_stats_transient_cleanup_prefixes', $prefixes );
+		$filtered = apply_filters( 'jetpack_stats_transient_cleanup_prefixes', $prefixes );
+
+		// Normalize filtered value: ensure array, filter to non-empty strings, dedupe.
+		if ( ! is_array( $filtered ) ) {
+			$filtered = $prefixes;
+		}
+
+		$filtered = array_filter(
+			$filtered,
+			function ( $prefix ) {
+				return is_string( $prefix ) && '' !== $prefix;
+			}
+		);
+
+		return array_unique( $filtered );
 	}
 
 	/**
@@ -146,14 +150,6 @@ class Transient_Cleanup {
 			return false;
 		}
 
-		// Acquire lock to prevent concurrent runs.
-		if ( get_transient( self::LOCK_TRANSIENT ) ) {
-			return false;
-		}
-
-		// Set lock.
-		set_transient( self::LOCK_TRANSIENT, 1, self::LOCK_TIMEOUT );
-
 		$total_deleted = 0;
 		$prefixes      = self::get_transient_prefixes();
 
@@ -166,9 +162,6 @@ class Transient_Cleanup {
 				break;
 			}
 		}
-
-		// Release lock.
-		delete_transient( self::LOCK_TRANSIENT );
 
 		return $total_deleted;
 	}

--- a/projects/packages/stats/src/class-transient-cleanup.php
+++ b/projects/packages/stats/src/class-transient-cleanup.php
@@ -86,7 +86,7 @@ class Transient_Cleanup {
 
 	/**
 	 * Unschedule the cleanup cron job.
-	 * Should be called on plugin deactivation.
+	 * Hooked to 'jetpack_deactivate_module_stats' in Main::__construct().
 	 *
 	 * @return void
 	 */

--- a/projects/packages/stats/tests/php/Transient_Cleanup_Test.php
+++ b/projects/packages/stats/tests/php/Transient_Cleanup_Test.php
@@ -18,9 +18,6 @@ class Transient_Cleanup_Test extends StatsBaseTestCase {
 	public function tear_down() {
 		parent::tear_down();
 
-		// Clean up lock transient.
-		delete_transient( Transient_Cleanup::LOCK_TRANSIENT );
-
 		// Unschedule cron.
 		Transient_Cleanup::unschedule_cleanup();
 
@@ -128,32 +125,6 @@ class Transient_Cleanup_Test extends StatsBaseTestCase {
 	}
 
 	/**
-	 * Test that concurrent runs are prevented by lock transient.
-	 */
-	public function test_concurrent_runs_prevented_by_lock() {
-		// Set a lock transient.
-		set_transient( Transient_Cleanup::LOCK_TRANSIENT, 1, Transient_Cleanup::LOCK_TIMEOUT );
-
-		$result = Transient_Cleanup::run_cleanup();
-
-		$this->assertFalse( $result );
-	}
-
-	/**
-	 * Test that run_cleanup sets and releases lock.
-	 */
-	public function test_run_cleanup_sets_and_releases_lock() {
-		// Run cleanup (no transients to delete, but lock should be set then released).
-		$result = Transient_Cleanup::run_cleanup();
-
-		// Lock should be released after cleanup.
-		$this->assertFalse( get_transient( Transient_Cleanup::LOCK_TRANSIENT ) );
-
-		// Result should be 0 (no transients deleted) not false (skipped).
-		$this->assertSame( 0, $result );
-	}
-
-	/**
 	 * Test that run_cleanup returns 0 when no expired transients exist.
 	 */
 	public function test_run_cleanup_returns_zero_when_no_expired() {
@@ -194,8 +165,6 @@ class Transient_Cleanup_Test extends StatsBaseTestCase {
 	 */
 	public function test_constants() {
 		$this->assertSame( 'jetpack_stats_transient_cleanup', Transient_Cleanup::CRON_HOOK );
-		$this->assertSame( 'jetpack_stats_cleanup_lock', Transient_Cleanup::LOCK_TRANSIENT );
-		$this->assertSame( 300, Transient_Cleanup::LOCK_TIMEOUT );
 		$this->assertSame( 100, Transient_Cleanup::BATCH_SIZE );
 		$this->assertSame( 28800, Transient_Cleanup::CRON_INTERVAL );
 	}

--- a/projects/packages/stats/tests/php/Transient_Cleanup_Test.php
+++ b/projects/packages/stats/tests/php/Transient_Cleanup_Test.php
@@ -21,6 +21,11 @@ class Transient_Cleanup_Test extends StatsBaseTestCase {
 		// Unschedule cron.
 		Transient_Cleanup::unschedule_cleanup();
 
+		// Remove hooks registered by init() to prevent test pollution.
+		remove_action( Transient_Cleanup::CRON_HOOK, array( Transient_Cleanup::class, 'run_cleanup' ) );
+		remove_filter( 'cron_schedules', array( Transient_Cleanup::class, 'add_cron_schedule' ) );
+		remove_action( 'admin_init', array( Transient_Cleanup::class, 'schedule_cleanup' ) );
+
 		// Remove any test filters.
 		remove_all_filters( 'jetpack_stats_transient_cleanup_prefixes' );
 		remove_all_filters( 'jetpack_stats_transient_cleanup_disabled' );

--- a/projects/packages/stats/tests/php/Transient_Cleanup_Test.php
+++ b/projects/packages/stats/tests/php/Transient_Cleanup_Test.php
@@ -170,7 +170,7 @@ class Transient_Cleanup_Test extends StatsBaseTestCase {
 	 */
 	public function test_constants() {
 		$this->assertSame( 'jetpack_stats_transient_cleanup', Transient_Cleanup::CRON_HOOK );
-		$this->assertSame( 100, Transient_Cleanup::BATCH_SIZE );
+		$this->assertSame( 1000, Transient_Cleanup::BATCH_SIZE );
 		$this->assertSame( 28800, Transient_Cleanup::CRON_INTERVAL );
 	}
 

--- a/projects/packages/stats/tests/php/Transient_Cleanup_Test.php
+++ b/projects/packages/stats/tests/php/Transient_Cleanup_Test.php
@@ -173,4 +173,85 @@ class Transient_Cleanup_Test extends StatsBaseTestCase {
 		$this->assertSame( 100, Transient_Cleanup::BATCH_SIZE );
 		$this->assertSame( 28800, Transient_Cleanup::CRON_INTERVAL );
 	}
+
+	/**
+	 * Test that cleanup is skipped when using external object cache.
+	 */
+	public function test_cleanup_skipped_with_external_object_cache() {
+		global $_wp_using_ext_object_cache;
+
+		// Enable external object cache.
+		$original                   = $_wp_using_ext_object_cache;
+		$_wp_using_ext_object_cache = true;
+
+		$result = Transient_Cleanup::run_cleanup();
+
+		// Restore original value.
+		$_wp_using_ext_object_cache = $original;
+
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * Note: Tests for actual transient deletion (purge_expired_transients) are not included
+	 * because they require direct SQL queries which WorDBless doesn't support.
+	 * These behaviors should be tested via integration tests on a real WordPress installation:
+	 * - test_cleanup_deletes_expired_transients
+	 * - test_cleanup_does_not_delete_non_expired_transients
+	 * - test_cleanup_with_custom_prefix
+	 *
+	 * Manual testing instructions are provided in the PR description.
+	 */
+
+	/**
+	 * Test that filter returning invalid value falls back to defaults.
+	 */
+	public function test_get_transient_prefixes_filter_invalid_value() {
+		// Return a non-array.
+		add_filter( 'jetpack_stats_transient_cleanup_prefixes', '__return_false' );
+
+		$prefixes = Transient_Cleanup::get_transient_prefixes();
+
+		// Should fall back to default prefixes.
+		$this->assertContains( WPCOM_Stats::STATS_CACHE_TRANSIENT_PREFIX, $prefixes );
+	}
+
+	/**
+	 * Test that filter returning empty strings are filtered out.
+	 */
+	public function test_get_transient_prefixes_filters_empty_strings() {
+		add_filter(
+			'jetpack_stats_transient_cleanup_prefixes',
+			function ( $prefixes ) {
+				$prefixes[] = '';
+				$prefixes[] = 'valid_prefix_';
+				return $prefixes;
+			}
+		);
+
+		$prefixes = Transient_Cleanup::get_transient_prefixes();
+
+		$this->assertNotContains( '', $prefixes );
+		$this->assertContains( 'valid_prefix_', $prefixes );
+	}
+
+	/**
+	 * Test that duplicate prefixes are removed.
+	 */
+	public function test_get_transient_prefixes_removes_duplicates() {
+		add_filter(
+			'jetpack_stats_transient_cleanup_prefixes',
+			function ( $prefixes ) {
+				$prefixes[] = WPCOM_Stats::STATS_CACHE_TRANSIENT_PREFIX;
+				$prefixes[] = WPCOM_Stats::STATS_CACHE_TRANSIENT_PREFIX;
+				return $prefixes;
+			}
+		);
+
+		$prefixes = Transient_Cleanup::get_transient_prefixes();
+
+		// Count occurrences of the default prefix.
+		$count = array_count_values( $prefixes )[ WPCOM_Stats::STATS_CACHE_TRANSIENT_PREFIX ];
+		$this->assertSame( 1, $count );
+	}
 }

--- a/projects/packages/stats/tests/php/Transient_Cleanup_Test.php
+++ b/projects/packages/stats/tests/php/Transient_Cleanup_Test.php
@@ -7,9 +7,14 @@
 
 namespace Automattic\Jetpack\Stats;
 
+use PHPUnit\Framework\Attributes\CoversClass;
+
 /**
  * Class Transient_Cleanup_Test
+ *
+ * @covers \Automattic\Jetpack\Stats\Transient_Cleanup
  */
+#[CoversClass( Transient_Cleanup::class )]
 class Transient_Cleanup_Test extends StatsBaseTestCase {
 
 	/**

--- a/projects/packages/stats/tests/php/Transient_Cleanup_Test.php
+++ b/projects/packages/stats/tests/php/Transient_Cleanup_Test.php
@@ -1,0 +1,202 @@
+<?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
+/**
+ * Tests for Transient_Cleanup class.
+ *
+ * @package jetpack-stats
+ */
+
+namespace Automattic\Jetpack\Stats;
+
+/**
+ * Class Transient_Cleanup_Test
+ */
+class Transient_Cleanup_Test extends StatsBaseTestCase {
+
+	/**
+	 * Clean up after each test.
+	 */
+	public function tear_down() {
+		parent::tear_down();
+
+		// Clean up lock transient.
+		delete_transient( Transient_Cleanup::LOCK_TRANSIENT );
+
+		// Unschedule cron.
+		Transient_Cleanup::unschedule_cleanup();
+
+		// Remove any test filters.
+		remove_all_filters( 'jetpack_stats_transient_cleanup_prefixes' );
+		remove_all_filters( 'jetpack_stats_transient_cleanup_disabled' );
+	}
+
+	/**
+	 * Test that init registers the cron hook.
+	 */
+	public function test_init_registers_cron_hook() {
+		Transient_Cleanup::init();
+
+		$this->assertNotFalse(
+			has_action( Transient_Cleanup::CRON_HOOK, array( Transient_Cleanup::class, 'run_cleanup' ) )
+		);
+	}
+
+	/**
+	 * Test that init registers the cron schedule filter.
+	 */
+	public function test_init_registers_cron_schedule_filter() {
+		Transient_Cleanup::init();
+
+		$this->assertNotFalse(
+			has_filter( 'cron_schedules', array( Transient_Cleanup::class, 'add_cron_schedule' ) )
+		);
+	}
+
+	/**
+	 * Test that add_cron_schedule adds the six hour schedule.
+	 */
+	public function test_add_cron_schedule() {
+		$schedules = Transient_Cleanup::add_cron_schedule( array() );
+
+		$this->assertArrayHasKey( 'jetpack_stats_eight_hours', $schedules );
+		$this->assertSame( Transient_Cleanup::CRON_INTERVAL, $schedules['jetpack_stats_eight_hours']['interval'] );
+		$this->assertSame( 28800, $schedules['jetpack_stats_eight_hours']['interval'] ); // 8 hours in seconds.
+	}
+
+	/**
+	 * Test that add_cron_schedule does not override existing schedule.
+	 */
+	public function test_add_cron_schedule_does_not_override() {
+		$existing = array(
+			'jetpack_stats_eight_hours' => array(
+				'interval' => 12345,
+				'display'  => 'Existing',
+			),
+		);
+
+		$schedules = Transient_Cleanup::add_cron_schedule( $existing );
+
+		$this->assertSame( 12345, $schedules['jetpack_stats_eight_hours']['interval'] );
+	}
+
+	/**
+	 * Test that schedule_cleanup schedules the cron event.
+	 */
+	public function test_schedule_cleanup() {
+		Transient_Cleanup::init();
+		Transient_Cleanup::schedule_cleanup();
+
+		$this->assertNotFalse( wp_next_scheduled( Transient_Cleanup::CRON_HOOK ) );
+	}
+
+	/**
+	 * Test that schedule_cleanup does not reschedule if already scheduled.
+	 */
+	public function test_schedule_cleanup_does_not_reschedule() {
+		Transient_Cleanup::init();
+		Transient_Cleanup::schedule_cleanup();
+
+		$first_timestamp = wp_next_scheduled( Transient_Cleanup::CRON_HOOK );
+
+		// Try to schedule again.
+		Transient_Cleanup::schedule_cleanup();
+
+		$second_timestamp = wp_next_scheduled( Transient_Cleanup::CRON_HOOK );
+
+		$this->assertSame( $first_timestamp, $second_timestamp );
+	}
+
+	/**
+	 * Test that unschedule_cleanup removes the cron event.
+	 */
+	public function test_unschedule_cleanup() {
+		Transient_Cleanup::init();
+		Transient_Cleanup::schedule_cleanup();
+		Transient_Cleanup::unschedule_cleanup();
+
+		$this->assertFalse( wp_next_scheduled( Transient_Cleanup::CRON_HOOK ) );
+	}
+
+	/**
+	 * Test that cleanup can be disabled via filter.
+	 */
+	public function test_cleanup_disabled_via_filter() {
+		add_filter( 'jetpack_stats_transient_cleanup_disabled', '__return_true' );
+
+		$result = Transient_Cleanup::run_cleanup();
+
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * Test that concurrent runs are prevented by lock transient.
+	 */
+	public function test_concurrent_runs_prevented_by_lock() {
+		// Set a lock transient.
+		set_transient( Transient_Cleanup::LOCK_TRANSIENT, 1, Transient_Cleanup::LOCK_TIMEOUT );
+
+		$result = Transient_Cleanup::run_cleanup();
+
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * Test that run_cleanup sets and releases lock.
+	 */
+	public function test_run_cleanup_sets_and_releases_lock() {
+		// Run cleanup (no transients to delete, but lock should be set then released).
+		$result = Transient_Cleanup::run_cleanup();
+
+		// Lock should be released after cleanup.
+		$this->assertFalse( get_transient( Transient_Cleanup::LOCK_TRANSIENT ) );
+
+		// Result should be 0 (no transients deleted) not false (skipped).
+		$this->assertSame( 0, $result );
+	}
+
+	/**
+	 * Test that run_cleanup returns 0 when no expired transients exist.
+	 */
+	public function test_run_cleanup_returns_zero_when_no_expired() {
+		$result = Transient_Cleanup::run_cleanup();
+
+		$this->assertSame( 0, $result );
+	}
+
+	/**
+	 * Test that get_transient_prefixes returns default prefix.
+	 */
+	public function test_get_transient_prefixes_returns_default() {
+		$prefixes = Transient_Cleanup::get_transient_prefixes();
+
+		$this->assertContains( WPCOM_Stats::STATS_CACHE_TRANSIENT_PREFIX, $prefixes );
+	}
+
+	/**
+	 * Test that get_transient_prefixes filter works.
+	 */
+	public function test_get_transient_prefixes_filter() {
+		add_filter(
+			'jetpack_stats_transient_cleanup_prefixes',
+			function ( $prefixes ) {
+				$prefixes[] = 'custom_prefix_';
+				return $prefixes;
+			}
+		);
+
+		$prefixes = Transient_Cleanup::get_transient_prefixes();
+
+		$this->assertContains( WPCOM_Stats::STATS_CACHE_TRANSIENT_PREFIX, $prefixes );
+		$this->assertContains( 'custom_prefix_', $prefixes );
+	}
+
+	/**
+	 * Test constants have expected values.
+	 */
+	public function test_constants() {
+		$this->assertSame( 'jetpack_stats_transient_cleanup', Transient_Cleanup::CRON_HOOK );
+		$this->assertSame( 'jetpack_stats_cleanup_lock', Transient_Cleanup::LOCK_TRANSIENT );
+		$this->assertSame( 300, Transient_Cleanup::LOCK_TIMEOUT );
+		$this->assertSame( 100, Transient_Cleanup::BATCH_SIZE );
+		$this->assertSame( 28800, Transient_Cleanup::CRON_INTERVAL );
+	}
+}

--- a/projects/packages/stats/tests/php/Transient_Cleanup_Test.php
+++ b/projects/packages/stats/tests/php/Transient_Cleanup_Test.php
@@ -49,7 +49,7 @@ class Transient_Cleanup_Test extends StatsBaseTestCase {
 	}
 
 	/**
-	 * Test that add_cron_schedule adds the six hour schedule.
+	 * Test that add_cron_schedule adds the eight hour schedule.
 	 */
 	public function test_add_cron_schedule() {
 		$schedules = Transient_Cleanup::add_cron_schedule( array() );

--- a/projects/packages/stats/tests/php/Transient_Cleanup_Test.php
+++ b/projects/packages/stats/tests/php/Transient_Cleanup_Test.php
@@ -243,7 +243,7 @@ class Transient_Cleanup_Test extends StatsBaseTestCase {
 			'jetpack_stats_transient_cleanup_prefixes',
 			function ( $prefixes ) {
 				$prefixes[] = WPCOM_Stats::STATS_CACHE_TRANSIENT_PREFIX;
-				$prefixes[] = WPCOM_Stats::STATS_CACHE_TRANSIENT_PREFIX;
+				$prefixes[] = WPCOM_Stats::STATS_CACHE_TRANSIENT_PREFIX; // @phan-suppress-current-line PhanPluginDuplicateAdjacentStatement -- Intentional duplicate to test deduplication.
 				return $prefixes;
 			}
 		);

--- a/projects/packages/stats/tests/php/Transient_Cleanup_Test.php
+++ b/projects/packages/stats/tests/php/Transient_Cleanup_Test.php
@@ -175,7 +175,7 @@ class Transient_Cleanup_Test extends StatsBaseTestCase {
 	 */
 	public function test_constants() {
 		$this->assertSame( 'jetpack_stats_transient_cleanup', Transient_Cleanup::CRON_HOOK );
-		$this->assertSame( 2000, Transient_Cleanup::BATCH_SIZE );
+		$this->assertSame( 5000, Transient_Cleanup::BATCH_SIZE );
 		$this->assertSame( 28800, Transient_Cleanup::CRON_INTERVAL );
 	}
 

--- a/projects/packages/stats/tests/php/Transient_Cleanup_Test.php
+++ b/projects/packages/stats/tests/php/Transient_Cleanup_Test.php
@@ -175,7 +175,7 @@ class Transient_Cleanup_Test extends StatsBaseTestCase {
 	 */
 	public function test_constants() {
 		$this->assertSame( 'jetpack_stats_transient_cleanup', Transient_Cleanup::CRON_HOOK );
-		$this->assertSame( 1000, Transient_Cleanup::BATCH_SIZE );
+		$this->assertSame( 2000, Transient_Cleanup::BATCH_SIZE );
 		$this->assertSame( 28800, Transient_Cleanup::CRON_INTERVAL );
 	}
 


### PR DESCRIPTION
Fixes STATS-216

## Proposed changes:

* Add `Transient_Cleanup` class to periodically clean up expired stats cache transients
* Prevents database bloat on sites without persistent object cache where WordPress lazy garbage collection never triggers for dynamic cache keys
* Runs every 8 hours via WP-Cron, deleting up to 5000 expired transient options per run - could exceed the number in some circumstances
* Skips cleanup on sites with persistent object cache (not needed there)
* Hooks `unschedule_cleanup()` to `jetpack_deactivate_module_stats` for proper cleanup on module deactivation
* Provides extensibility filters:
  - `jetpack_stats_transient_cleanup_prefixes` - Add custom transient prefixes to clean up
  - `jetpack_stats_transient_cleanup_disabled` - Disable cleanup entirely

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

https://linear.app/a8c/issue/JETPACK-1268

## Does this pull request change what data or activity we track or use?

No. This PR only adds cleanup of expired transient data that was already scheduled for deletion. It does not collect, track, or transmit any new data.

## Testing instructions:

### Unit tests
* Run `cd projects/packages/stats && composer test-php`
* Verify all tests pass

### Manual testing on a site WITHOUT persistent object cache
* Set up a local WordPress site without Redis/Memcached
* Activate Jetpack with Stats module enabled
* Visit the Stats dashboard to generate some transients
* Run `wp db query "SELECT option_name FROM wp_options WHERE option_name LIKE '_transient_jetpack_restapi_stats_cache_%'"` to verify transients exist
* Expire them manually: `wp db query "UPDATE wp_options SET option_value = 1 WHERE option_name LIKE '_transient_timeout_jetpack_restapi_stats_cache_%'"`
* Trigger the cron: `wp cron event run jetpack_stats_transient_cleanup`
* Verify expired transients are deleted by running the SELECT query again

```
$ jetpack docker wp  cron event list | grep jetpack_stats_transient_cleanup                                                            
jetpack_stats_transient_cleanup 2026-02-19 10:19:11     7 hours 27 minutes      8 hours

```

```
$ jetpack docker wp cron event run jetpack_stats_transient_cleanup                                                                  127 ↵
Executed the cron event 'jetpack_stats_transient_cleanup' in 0.004s.
Success: Executed a total of 1 cron event.

```

### Test cleanup is skipped on a site WITH persistent object cache
* Set up a site with Redis or Memcached
* Run `wp cron event run jetpack_stats_transient_cleanup`
* Verify the cleanup is skipped (returns false, no database queries made)

### Test the disable filter
* Add to a plugin or theme: `add_filter( 'jetpack_stats_transient_cleanup_disabled', '__return_true' );`
* Trigger the cron and verify cleanup is skipped

### Test module deactivation cleanup
* With Stats module active, verify cron is scheduled: `wp cron event list | grep jetpack_stats_transient_cleanup`
* Deactivate Stats module
* Verify cron is unscheduled: `wp cron event list | grep jetpack_stats_transient_cleanup` (should return nothing)

