### PR TITLE
Stats Admin: Register transient prefix for cleanup

### DIFF
--- a/projects/packages/stats-admin/changelog/add-stats-admin-transient-cleanup
+++ b/projects/packages/stats-admin/changelog/add-stats-admin-transient-cleanup
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Register STATS_REST_RESP_ transient prefix for cleanup by the stats package transient cleanup cron.

--- a/projects/packages/stats-admin/src/class-main.php
+++ b/projects/packages/stats-admin/src/class-main.php
@@ -65,6 +65,20 @@ class Main {
 			10,
 			2
 		);
+
+		// Register stats-admin transient prefix for cleanup by the stats package.
+		add_filter( 'jetpack_stats_transient_cleanup_prefixes', array( $this, 'register_transient_cleanup_prefix' ) );
+	}
+
+	/**
+	 * Register the stats-admin transient prefix for cleanup.
+	 *
+	 * @param array $prefixes List of transient prefixes to clean up.
+	 * @return array Modified list of prefixes.
+	 */
+	public function register_transient_cleanup_prefix( $prefixes ) {
+		$prefixes[] = WPCOM_Client::CACHE_TRANSIENT_PREFIX;
+		return $prefixes;
 	}
 
 	/**

--- a/projects/packages/stats-admin/src/class-wpcom-client.php
+++ b/projects/packages/stats-admin/src/class-wpcom-client.php
@@ -17,6 +17,13 @@ use WP_Error;
  */
 class WPCOM_Client {
 	/**
+	 * Transient prefix for caching REST API responses.
+	 *
+	 * @var string
+	 */
+	const CACHE_TRANSIENT_PREFIX = 'STATS_REST_RESP_';
+
+	/**
 	 * Query the WordPress.com REST API using the blog token cached.
 	 *
 	 * @param String $path The API endpoint relative path.
@@ -33,7 +40,7 @@ class WPCOM_Client {
 		$use_cache = $use_cache && ! ( isset( $args['method'] ) && strtoupper( $args['method'] ) !== 'GET' ) && ! static::should_bypass_cache();
 
 		// Arrays are serialized without considering the order of objects, but it's okay atm.
-		$cache_key = $cache_key !== null ? $cache_key : 'STATS_REST_RESP_' . md5( implode( '|', array( $path, $version, wp_json_encode( $args, JSON_UNESCAPED_SLASHES ), wp_json_encode( $body, JSON_UNESCAPED_SLASHES ), $base_api_path ) ) );
+		$cache_key = $cache_key !== null ? $cache_key : self::CACHE_TRANSIENT_PREFIX . md5( implode( '|', array( $path, $version, wp_json_encode( $args, JSON_UNESCAPED_SLASHES ), wp_json_encode( $body, JSON_UNESCAPED_SLASHES ), $base_api_path ) ) );
 
 		if ( $use_cache ) {
 			$response_body_content = get_transient( $cache_key );


### PR DESCRIPTION
**Depends on #47212**

Fixes STATS-216

## Proposed changes:

* Add `CACHE_TRANSIENT_PREFIX` constant to `WPCOM_Client` class for the `STATS_REST_RESP_` transient prefix
* Register the prefix with the stats package transient cleanup cron via `jetpack_stats_transient_cleanup_prefixes` filter
* Ensures expired stats-admin transients are cleaned up on sites without persistent object cache

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

https://linear.app/a8c/issue/JETPACK-1268

## Does this pull request change what data or activity we track or use?

No. This PR only registers an existing transient prefix for cleanup. It does not collect, track, or transmit any new data.

## Testing instructions:

### Unit tests
* Run `cd projects/packages/stats-admin && composer test-php`
* Verify all tests pass

### Manual testing
* Ensure #47212 is merged first (or test with both branches checked out)
* On a site without persistent object cache:
  * Use the Jetpack Stats dashboard to generate `STATS_REST_RESP_*` transients
  * Verify transients exist: `wp db query "SELECT option_name FROM wp_options WHERE option_name LIKE '_transient_STATS_REST_RESP_%'"`
  * Expire them: `wp db query "UPDATE wp_options SET option_value = 1 WHERE option_name LIKE '_transient_timeout_STATS_REST_RESP_%'"`
  * Run `wp cron event run jetpack_stats_transient_cleanup`
  * Verify the expired `STATS_REST_RESP_*` transients are deleted

### Verify the prefix is registered
* Run: `wp eval "var_dump( in_array( 'STATS_REST_RESP_', apply_filters( 'jetpack_stats_transient_cleanup_prefixes', array() ), true ) );"`
* Should output `bool(true)`