### PR TITLE
Social: Add visual dot to active connection in preview modal

### DIFF
--- a/projects/packages/publicize/_inc/components/customize-and-preview/tab-panels/styles.module.scss
+++ b/projects/packages/publicize/_inc/components/customize-and-preview/tab-panels/styles.module.scss
@@ -54,6 +54,24 @@
 	}
 }
 
+.enabled-connection {
+
+	// Add a dot indicator for enabled connections
+	&::after {
+		content: "";
+		display: block;
+		width: 8px;
+		height: 8px;
+		border-radius: 50%;
+		border: 2px solid gb.$white;
+		position: absolute;
+		inset-block-start: 2px;
+		inset-inline-start: 2px;
+		z-index: 1;
+		background-color: var(--wp-admin-theme-color, #3858e9);
+	}
+}
+
 .tab-content {
 	display: grid;
 	grid-template-columns: 1fr;

--- a/projects/packages/publicize/_inc/components/customize-and-preview/tab-panels/styles.module.scss
+++ b/projects/packages/publicize/_inc/components/customize-and-preview/tab-panels/styles.module.scss
@@ -60,14 +60,13 @@
 	&::after {
 		content: "";
 		display: block;
-		width: 8px;
-		height: 8px;
+		width: 12px;
+		height: 12px;
 		border-radius: 50%;
 		border: 2px solid gb.$white;
 		position: absolute;
-		inset-block-start: 2px;
-		inset-inline-start: 2px;
-		z-index: 1;
+		inset-block-start: 0;
+		inset-inline-start: 0;
 		background-color: var(--wp-admin-theme-color, #3858e9);
 	}
 }

--- a/projects/packages/publicize/_inc/components/customize-and-preview/tab-panels/use-connection-tabs.tsx
+++ b/projects/packages/publicize/_inc/components/customize-and-preview/tab-panels/use-connection-tabs.tsx
@@ -1,6 +1,8 @@
+import clsx from 'clsx';
 import { useMemo } from 'react';
 import useSocialMediaConnections from '../../../hooks/use-social-media-connections';
 import ConnectionIcon from '../../connection-icon';
+import styles from './styles.module.scss';
 import { ConnectionTab } from './types';
 
 /**
@@ -23,6 +25,7 @@ export function useConnectionTabs() {
 						// Avoid screen reader reading the label twice when the item is focused
 						label=""
 						profilePicture={ connection.profile_picture }
+						className={ clsx( { [ styles[ 'enabled-connection' ] ]: connection.enabled } ) }
 					/>
 				),
 			};

--- a/projects/packages/publicize/changelog/update-social-active-connection-dot
+++ b/projects/packages/publicize/changelog/update-social-active-connection-dot
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add visual dot to active connection in preview modal.

--- a/projects/plugins/jetpack/changelog/update-social-active-connection-dot
+++ b/projects/plugins/jetpack/changelog/update-social-active-connection-dot
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Social: Add visual dot to active connection in preview modal.

--- a/projects/plugins/social/changelog/update-social-active-connection-dot
+++ b/projects/plugins/social/changelog/update-social-active-connection-dot
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add visual dot to active connection in preview modal.


### PR DESCRIPTION
Fixes SOCIAL-370

## Proposed changes:
* Add a visual dot indicator on the connection icon in the preview modal tabs to show which connections are enabled/active
* The dot uses the WP admin theme color and is positioned at the top-left of the connection avatar with a white border
* Only enabled connections show the dot, making it easy to identify active connections at a glance without clicking each tab

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
SOCIAL-370

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:

* Go to the post editor and connect multiple social accounts (ensure at least one is enabled and one is disabled)
* Open the Social preview modal
* Verify that enabled connections show a small colored dot (using the WP admin theme color) at the top-left of the avatar icon
* Verify that disabled connections do not show a dot
* Toggle a connection off and confirm the dot disappears; toggle it back on and confirm the dot reappears

## Changelog

- [x] Generate changelog entries for this PR (using AI).

<img width="766" height="764" alt="Screenshot 2026-02-19 at 12 18 35 PM" src="https://github.com/user-attachments/assets/6bc360bb-a4fe-47fe-84f4-65126a284761" />
