### PR TITLE
Backport charts v0.56.4 changelog to trunk

### DIFF
--- a/projects/js-packages/charts/CHANGELOG.md
+++ b/projects/js-packages/charts/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.56.4] - 2026-02-19
+### Changed
+- Build: strip data-testid attributes from production builds to reduce bundle size and keep the DOM cleaner. [#47185]
+
+### Fixed
+- ConversionFunnelChart: Default to filling the parent container height and add a height prop for explicit sizing. [#47119]
+- Relocate visx tooltip portals from document.body into the chart container to fix z-index stacking issues with sticky headers and other positioned elements. [#47118]
+
 ## [0.56.3] - 2026-02-18
 ### Changed
 - Set `.repository.url` in `package.json` to the mirror repo rather than the monorepo. [#47149]
@@ -686,6 +694,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed lints following ESLint rule changes for TS [#40584]
 - Fixing a bug in Chart storybook data. [#40640]
 
+[0.56.4]: https://github.com/Automattic/charts/compare/v0.56.3...v0.56.4
 [0.56.3]: https://github.com/Automattic/charts/compare/v0.56.2...v0.56.3
 [0.56.2]: https://github.com/Automattic/charts/compare/v0.56.1...v0.56.2
 [0.56.1]: https://github.com/Automattic/charts/compare/v0.56.0...v0.56.1

--- a/projects/js-packages/charts/changelog/fix-charts-tooltip-portal-relocator
+++ b/projects/js-packages/charts/changelog/fix-charts-tooltip-portal-relocator
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Relocate visx tooltip portals from document.body into the chart container to fix z-index stacking issues with sticky headers and other positioned elements.

--- a/projects/js-packages/charts/changelog/fix-wooa7s-1029-conversion-funnel-chart-height
+++ b/projects/js-packages/charts/changelog/fix-wooa7s-1029-conversion-funnel-chart-height
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-ConversionFunnelChart: Default to filling the parent container height and add a height prop for explicit sizing.

--- a/projects/js-packages/charts/changelog/strip-data-testid-production-builds
+++ b/projects/js-packages/charts/changelog/strip-data-testid-production-builds
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Build: strip data-testid attributes from production builds to reduce bundle size and keep the DOM cleaner.

--- a/projects/js-packages/charts/package.json
+++ b/projects/js-packages/charts/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/charts",
-	"version": "0.56.3",
+	"version": "0.56.4",
 	"description": "Display charts within Automattic products.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/charts/#readme",
 	"bugs": {


### PR DESCRIPTION
## Summary
Backports changelog and version bump for `@automattic/charts` v0.56.4 release to trunk.

## Testing instructions
This is a changelog-only backport from the prerelease branch. No functional code changes.
- Verify the changelog entries in `projects/js-packages/charts/CHANGELOG.md` are correct.
- Verify the version in `projects/js-packages/charts/package.json` is `0.56.4`.

## Does this pull request change what data or activity we track or use?
No, this PR only updates the changelog and version number.