### PR TITLE
CHARTS-171: Simplify relocated portal positioning with CSS inset shorthand

### DIFF
--- a/projects/js-packages/charts/changelog/fix-CHARTS-171-simplify-tooltip-portal-css
+++ b/projects/js-packages/charts/changelog/fix-CHARTS-171-simplify-tooltip-portal-css
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Simplify relocated portal positioning with CSS inset shorthand

--- a/projects/js-packages/charts/src/hooks/use-tooltip-portal-relocator.module.scss
+++ b/projects/js-packages/charts/src/hooks/use-tooltip-portal-relocator.module.scss
@@ -1,9 +1,6 @@
 .relocatedPortal {
 	position: fixed;
-	top: 0;
-	left: 0;
-	width: 0;
-	height: 0;
+	inset: 0;
 	overflow: visible;
 	z-index: 1;
 	pointer-events: none;


### PR DESCRIPTION
Fixes CHARTS-171

## Proposed changes:

* Replaces explicit `top: 0; left: 0; width: 0; height: 0;` with the `inset: 0` CSS shorthand on the relocated tooltip portal container.
* This is a follow-up cleanup to #47118 — same visual behavior, just cleaner CSS.

### Screenshots

Tooltip width in a consumer was reduced because of `width: 0` CSS, this change fixes it

| Before | After |
| --- | --- |
| <img width="399" height="382" alt="image" src="https://github.com/user-attachments/assets/cd038c8b-917b-445b-96ae-b1ef64c8169a" /> | <img width="764" height="750" alt="Arc -2026-02-19 at 15 35 01@2x" src="https://github.com/user-attachments/assets/53b1203d-0006-4b25-858f-da5c80738f74" /> |


### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Testing instructions:

* Open any chart component that uses visx tooltips (e.g., `PieChart`, `PieSemiCircleChart`, or any line/bar chart with tooltips enabled).
* Hover over data points to trigger tooltips.
* Verify tooltips still render at the correct position and z-index stacking is correct.

## Does this pull request change what data or activity we track or use?

No

## Changelog

- [ ] Generate changelog entries for this PR (using AI).