### PR TITLE
Update/mcp actor

### DIFF
--- a/projects/packages/sync/changelog/update-mcp-actor
+++ b/projects/packages/sync/changelog/update-mcp-actor
@@ -1,4 +1,4 @@
 Significance: minor
 Type: added
 
-Adds MCP information to actor
+Sync: Add MCP information to the actor.

--- a/projects/packages/sync/changelog/update-mcp-actor
+++ b/projects/packages/sync/changelog/update-mcp-actor
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Adds MCP information to actor

--- a/projects/packages/sync/src/class-listener.php
+++ b/projects/packages/sync/src/class-listener.php
@@ -458,7 +458,7 @@ class Listener {
 			$raw_mcp_header = trim( wp_unslash( $_SERVER['HTTP_X_WPCOM_MCP'] ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Sanitization happens below.
 		}
 
-		if ( ! empty( $raw_mcp_header ) && preg_match( '/^[A-Za-z0-9+\\/=]+$/', $raw_mcp_header ) ) {
+		if ( ! empty( $raw_mcp_header ) && preg_match( '/^[A-Za-z0-9+\/=]+$/', $raw_mcp_header ) ) {
 			// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode -- Decoding MCP header payload.
 			$decoded = base64_decode( $raw_mcp_header, true );
 			if ( false !== $decoded ) {

--- a/projects/packages/sync/src/class-listener.php
+++ b/projects/packages/sync/src/class-listener.php
@@ -453,6 +453,30 @@ class Listener {
 			$actor['user_agent'] = isset( $_SERVER['HTTP_USER_AGENT'] ) ? filter_var( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ) ) : 'unknown';
 		}
 
+		$raw_mcp_header = '';
+		if ( isset( $_SERVER['HTTP_X_WPCOM_MCP'] ) && is_string( $_SERVER['HTTP_X_WPCOM_MCP'] ) ) {
+			$raw_mcp_header = trim( wp_unslash( $_SERVER['HTTP_X_WPCOM_MCP'] ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Sanitization happens below.
+		}
+
+		if ( ! empty( $raw_mcp_header ) && preg_match( '/^[A-Za-z0-9+\\/=]+$/', $raw_mcp_header ) ) {
+			// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode -- Decoding MCP header payload.
+			$decoded = base64_decode( $raw_mcp_header, true );
+			if ( false !== $decoded ) {
+				$mcp_data = json_decode( $decoded, true );
+				if ( is_array( $mcp_data ) ) {
+					if ( isset( $mcp_data['mcp_client_name'] ) && is_string( $mcp_data['mcp_client_name'] ) ) {
+						$actor['mcp_client_name'] = sanitize_text_field( $mcp_data['mcp_client_name'] );
+					}
+					if ( isset( $mcp_data['mcp_client_version'] ) && is_string( $mcp_data['mcp_client_version'] ) ) {
+						$actor['mcp_client_version'] = sanitize_text_field( $mcp_data['mcp_client_version'] );
+					}
+					if ( ! empty( $actor['mcp_client_name'] ) || ! empty( $actor['mcp_client_version'] ) ) {
+						$actor['is_mcp_agent'] = true;
+					}
+				}
+			}
+		}
+
 		return $actor;
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to https://linear.app/a8c/issue/AI-890/add-user-facing-activity-log-for-mcp-tool-executions

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Enriches sync actor from `X-WPCOM-MCP` header by decoding base64 JSON, sanitizing client name/version, and marking is_mcp_agent when either is present.
* 
### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Test on simple with 204134-ghe-Automattic/wpcom

## Changelog
<!-- Check one of the boxes below. -->

- [ ] Generate changelog entries for this PR (using AI).