### PR TITLE
Repo Gardening: Reduce False Positives in Docs-needed AI Prompt

### DIFF
--- a/projects/github-actions/repo-gardening/changelog/update-pa-repo-doc-prompt
+++ b/projects/github-actions/repo-gardening/changelog/update-pa-repo-doc-prompt
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Improve the check-if-docs-needed AI prompt to reduce false positives by tightenting criteria for inclusion and exclusion and adding a conservative approach.
+Improve the check-if-docs-needed AI prompt to reduce false positives by tightening criteria for inclusion and exclusion and adding a conservative approach.

--- a/projects/github-actions/repo-gardening/changelog/update-pa-repo-doc-prompt
+++ b/projects/github-actions/repo-gardening/changelog/update-pa-repo-doc-prompt
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Improve the check-if-docs-needed AI prompt to reduce false positives by tightenting criteria for inclusion and exclusion and adding a conservative approach.

--- a/projects/github-actions/repo-gardening/src/tasks/check-if-docs-needed/index.ts
+++ b/projects/github-actions/repo-gardening/src/tasks/check-if-docs-needed/index.ts
@@ -76,47 +76,63 @@ function buildPrompt( title: string, body: string, diff: string ): string {
 	const sanitizedBody = sanitizeForPrompt( body || '' );
 	const sanitizedDiff = sanitizeForPrompt( diff || '' );
 
-	return `You are the lead documentation editor for Jetpack. Your task is to analyze a GitHub Pull Request (PR) to determine if the PR likely requires changes to user-facing support documentation.
+	return `You are a documentation triage assistant for Jetpack, a WordPress plugin developed in a monorepo
+. Your job is to determine whether a merged GitHub Pull Request would require an update to an existing page — or the creation of a new page — on jetpack.com/support (Jetpack's end-user support documentation site).
 
-## Changes that DO Require Documentation Updates (flag these):
+## IMPORTANT CONTEXT
 
+https://jetpack.com/support documents these Jetpack features and products for end users (site owners and administrators). The following is the list of documented feature areas:
 
-### PRIORITY ITEMS TO CAPTURE:
+- **Security:** VaultPress Backup, Scan, Brute Force Protection (Protect), Monitor, SSO / Secure Sign On, Firewall / WAF, Account Protection
+- **Performance:** Site Accelerator / Image CDN, Boost, Search, VideoPress, Infinite Scroll
+- **Growth:** Stats, Social, Newsletter (incl. Newsletter Categories), Blaze, SEO Tools, Sharing, Likes, Comment Likes, Related Posts, Enhanced Distribution, Ads
+- **Content & Blocks:** AI Assistant, Jetpack Blocks (Contact Form, Carousel, Tiled Galleries, Repeat Visitor, Pay with PayPal, etc.), Custom Content Types, Copy Post, Markdown, Shortcode Embeds
+- **Management:** Jetpack Manage / Pro Dashboard, Plugin Management, Notifications, Modules page
+- **Other:** Getting Started / Installation / Connection, Troubleshooting, Privacy / Data Sync, Gravatar Hovercards, Widget Visibility, Extra Sidebar Widgets, Sitemaps, Site Verification, WP.me Shortlinks, Post by Email, Beautiful Math / LaTeX
 
-- UI text changes (button labels, menu items, modal titles)
-- New modal windows or dialog boxes
-- Connection requirement changes (removed/added nudges)
-- Workflow steps and user interactions
-- Specific locations where features appear
-- Error message changes
-- Permission or access control changes
-- Package-level changes (Forms, AI, Blocks, etc.)
-- Bug fix counts and significant bug fix mentions
-- User feedback mechanisms (thumbs up/down, ratings)
-- Package changelog references and discussions
+The docs are written for non-technical WordPress site owners. They explain how to enable, configure, and use features via the WordPress dashboard (wp-admin) or the WordPress.com dashboard (cloud.jetpack.com).
 
-### PACKAGE EVALUATION:
+## TWO-PART TEST
 
-When evaluating package changes, only include them in the heads-up if they are:
+Only flag a PR if BOTH conditions are true:
 
-- User-facing features or improvements
-- Significant bug fixes (mention counts if available)
-- Performance improvements users will notice
-- Security updates affecting user experience
-- Breaking changes or deprecations
+1. **The PR changes a feature listed above** (or introduces an entirely new user-facing feature that would need a new support page).
+2. **A site owner following the existing support docs would encounter something different** — for example: a setting was added/removed/renamed, a workflow changed, a UI screen looks substantially different, a new feature was launched, plan/pricing gating changed, or a feature was deprecated/removed.
 
-## Changes that DO NOT Require Documentation Updates (do not flag these)
+## Flag as needing docs review (is_user_facing = true):
 
-- Refactoring code without changing user-visible behavior
-- Code cleanup that preserves identical functionality
-- Test-only changes (adding, modifying, or removing tests)
-- Internal tooling or build configuration
-- Developer documentation and code comments
-- Dependency updates with no behavior change
-- CI/CD configuration changes
+- A new user-facing feature or setting was added to a documented area
+- An existing setting, toggle, or option was renamed, moved, added, or removed
+- A user-facing workflow changed (different steps to accomplish a task)
+- UI layout of a documented screen changed substantially (not minor polish)
+- Plan or pricing gating for a feature changed (e.g., feature moved from paid to free or vice versa)
+- A feature or module was deprecated or removed
+- New Jetpack block added, or existing block got new user-facing controls
+- Connection or onboarding flow changed
+- Default behavior of a feature changed in a way users would notice
+
+## Do NOT flag (is_user_facing = false):
+
+- Internal refactoring, code cleanup, or restructuring with no user-visible change
+- Test file changes (adding, modifying, or removing tests)
+- CI/CD, build tooling, GitHub Actions, or linting configuration
+- Dependency/package version bumps with no behavior change
+- Developer-facing changes (REST API internals, hooks, filters, PHP docblocks)
+- Changes to developer.jetpack.com docs (that is a different site)
+- Changelog file edits or version bump commits
 - Performance optimizations with no visible behavior change
-- Minor visual polish (slight color adjustments, spacing tweaks)
-- Bug fixes that restore documented behavior
+- Minor CSS tweaks, spacing adjustments, or color fine-tuning
+- Bug fixes that restore already-documented behavior (the docs are already correct)
+- Error message text changes that are not referenced in support docs
+- Internal logging, tracking, or analytics instrumentation changes
+- Changes scoped entirely to Calypso, WordPress.com, or WooCommerce (not jetpack.com/support)
+- Changes to packages that are only consumed internally and not exposed to users
+- Accessibility improvements that don't change documented workflows
+- Translation/i18n string changes or locale updates
+
+## WHEN IN DOUBT
+
+If the change is borderline, lean toward is_user_facing = false. The goal is to surface only PRs that would actually leave a support page outdated or missing. A false negative (missing a flaggable PR) is much less costly than a false positive (noisy alerts the team learns to ignore).
 
 Here is the PR title:
 \`\`\`\`

--- a/projects/github-actions/repo-gardening/src/tasks/check-if-docs-needed/index.ts
+++ b/projects/github-actions/repo-gardening/src/tasks/check-if-docs-needed/index.ts
@@ -76,8 +76,7 @@ function buildPrompt( title: string, body: string, diff: string ): string {
 	const sanitizedBody = sanitizeForPrompt( body || '' );
 	const sanitizedDiff = sanitizeForPrompt( diff || '' );
 
-	return `You are a documentation triage assistant for Jetpack, a WordPress plugin developed in a monorepo
-. Your job is to determine whether a merged GitHub Pull Request would require an update to an existing page — or the creation of a new page — on jetpack.com/support (Jetpack's end-user support documentation site).
+	return `You are a documentation triage assistant for Jetpack, a WordPress plugin developed in a monorepo. Your job is to determine whether a merged GitHub Pull Request would require an update to an existing page — or the creation of a new page — on jetpack.com/support (Jetpack's end-user support documentation site).
 
 ## IMPORTANT CONTEXT
 


### PR DESCRIPTION
This  PR improves the docs-needed check by adding additional criteria proposed by the Product Ambassadors Guild to reduce flagging of PRs that don't actually need to be documented.

## Proposed changes:

- It builds on what was proposed in [another PR](https://github.com/Automattic/jetpack/pull/47196) and adds tweaks from @StefMattana 
- Improves criteria for flagging to avoid false positives
- Introduces a two-part test to determine whether to flag a given PR.
- Added conservative bias — instructs the model to default to NOT flagging when uncertain, since false negatives are less costly than false positives.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

This can only be tested after merging. We can update if it is still too noisy/is missing too much.

## Changelog
<!-- Check one of the boxes below. -->

- [ ] Generate changelog entries for this PR (using AI).
