### PR TITLE
Slideshow block: fix further issues with aspect ratio

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-slideshow-add-further-fallbacks
+++ b/projects/plugins/jetpack/changelog/fix-slideshow-add-further-fallbacks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Slideshow block: fix further issues with aspect ratio.

--- a/projects/plugins/jetpack/extensions/blocks/slideshow/swiper-callbacks.js
+++ b/projects/plugins/jetpack/extensions/blocks/slideshow/swiper-callbacks.js
@@ -77,7 +77,7 @@ function swiperResize( swiper ) {
 		// This might cause a layout shift, but it improves the chances that we display the
 		// slideshow at the correct aspect ratio, based on the image's natural dimensions.
 		if ( ! img.complete ) {
-			img.addEventListener( 'load', () => swiperResize( swiper ) );
+			img.addEventListener( 'load', () => swiperResize( swiper ), { once: true } );
 		}
 	}
 

--- a/projects/plugins/jetpack/extensions/blocks/slideshow/swiper-callbacks.js
+++ b/projects/plugins/jetpack/extensions/blocks/slideshow/swiper-callbacks.js
@@ -49,25 +49,36 @@ function swiperResize( swiper ) {
 	}
 
 	let aspectRatio;
-	const hasNatural = img.naturalWidth > 0 && img.naturalHeight > 0;
 
 	// If the image element has `naturalWidth` and `naturalHeight` defined, we prefer using
 	// those numbers, because they're guaranteed to be up to date and correct, since they're
 	// taken from the actual image that the browser loaded.
 	//
 	// However, in some cases these numbers will be missing, due to e.g. lazy image loading.
-	// In those situations, we first fall back to the recorded aspect ratio in the HTML, and
-	// if that's missing as well, we fall back to a hardcoded 16:9.
-	if ( hasNatural ) {
+	// In those situations, we first fall back to the recorded aspect ratio in the <img>
+	// element, then the `width` and `height` attributes in the same element.
+	if ( img.naturalWidth > 0 && img.naturalHeight > 0 ) {
 		aspectRatio = img.naturalWidth / img.naturalHeight;
-	} else {
-		if ( img.dataset.aspectRatio ) {
-			const matches = img.dataset.aspectRatio.match( /(\d+) \/ (\d+)/ );
-			if ( matches && matches[ 1 ] && matches[ 2 ] ) {
-				aspectRatio = parseInt( matches[ 1 ], 10 ) / parseInt( matches[ 2 ], 10 );
-			}
+	} else if ( img.dataset.aspectRatio ) {
+		const matches = img.dataset.aspectRatio.match( /(\d+) \/ (\d+)/ );
+		if ( matches && matches[ 1 ] && matches[ 2 ] ) {
+			aspectRatio = parseInt( matches[ 1 ], 10 ) / parseInt( matches[ 2 ], 10 );
 		}
+	} else if ( img.getAttribute( 'width' ) && img.getAttribute( 'height' ) ) {
+		aspectRatio =
+			parseInt( img.getAttribute( 'width' ), 10 ) / parseInt( img.getAttribute( 'height' ), 10 );
+	}
+
+	// If we don't have a valid aspect ratio at this point, we set it to a sane default.
+	if ( ! aspectRatio ) {
 		aspectRatio = aspectRatio || SIXTEEN_BY_NINE;
+
+		// Then, if the image is still loading, we schedule a new resize for once it loads.
+		// This might cause a layout shift, but it improves the chances that we display the
+		// slideshow at the correct aspect ratio, based on the image's natural dimensions.
+		if ( ! img.complete ) {
+			img.addEventListener( 'load', () => swiperResize( swiper ) );
+		}
 	}
 
 	// After we have an aspect ratio, we run a final check to make sure it's within an

--- a/projects/plugins/jetpack/extensions/blocks/slideshow/swiper-callbacks.js
+++ b/projects/plugins/jetpack/extensions/blocks/slideshow/swiper-callbacks.js
@@ -71,7 +71,7 @@ function swiperResize( swiper ) {
 
 	// If we don't have a valid aspect ratio at this point, we set it to a sane default.
 	if ( ! aspectRatio ) {
-		aspectRatio = aspectRatio || SIXTEEN_BY_NINE;
+		aspectRatio = SIXTEEN_BY_NINE;
 
 		// Then, if the image is still loading, we schedule a new resize for once it loads.
 		// This might cause a layout shift, but it improves the chances that we display the


### PR DESCRIPTION
This PR fixes further scenarios in which the slideshow block renders at the incorrect aspect ratio, building on top of #46924 and #46450.

Fixes JETPACK-1217.

## Proposed changes:

* If neither the natural dimensions nor the aspect ratio are present in the DOM, use the first image's `width` and `height` attributes instead.
* If they're not present either, default to 16:9.
* If we defaulted to 16:9 because we didn't have any reliable aspect ratio, and if we're still waiting for the image to load, schedule a resize for when it does load.

When combined, these fallbacks should ensure that the slideshow loads with the correct aspect ratio (that of the first image) the vast majority of the time.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

JETPACK-1217

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

I prepared two test sites with several of the scenarios being addressed here. All the slideshows use portrait-sized first images, so they should all have a portrait aspect ratio.

Stable (shows bug): https://sure-ray.jurassic.ninja/2026/02/19/slideshow-test-post/
This branch (bug fixed): https://dutifully-outdoor-toucan.jurassic.ninja/2026/02/19/slideshow-test-post/

Please load both pages with a clean cache and check whether all slideshows exhibit a portrait aspect ratio. In my testing, in the stable branch the last two slideshows will have an incorrect aspect ratio, whereas in this branch they will all be correct.