### PR TITLE
CI: Use API_TOKEN_GITHUB for changelog auto-add action

### DIFF
--- a/.github/workflows/changelog-auto-add.yml
+++ b/.github/workflows/changelog-auto-add.yml
@@ -125,7 +125,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.API_TOKEN_GITHUB }}
           prompt: |
             You are generating changelog entries for a Jetpack monorepo PR.
 


### PR DESCRIPTION
## Proposed changes:
* Switch the `claude-code-action` step in the Changelog Auto-Add workflow from `secrets.GITHUB_TOKEN` to `secrets.API_TOKEN_GITHUB` so that commits pushed by the action can trigger downstream CI workflows.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
N/A

## Testing instructions:
* Open a PR with the "Generate changelog entries" checkbox checked.
* Verify that the changelog commit pushed by Claude triggers the expected CI checks (previously skipped due to `GITHUB_TOKEN` limitations).

## Changelog

- [ ] Generate changelog entries for this PR (using AI).