### PR TITLE
CI: Use API_TOKEN_GITHUB for PR branch checkout in changelog workflow

### DIFF
--- a/.github/workflows/changelog-auto-add.yml
+++ b/.github/workflows/changelog-auto-add.yml
@@ -118,7 +118,7 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           # DO NOT run any code in this checkout. Not even an `npm install`.
           path: ./pr-checkout
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.API_TOKEN_GITHUB }}
 
       - name: Generate changelog entries with Claude
         if: steps.checkbox.outputs.checked == 'true' && steps.check.outputs.needed == 'true'


### PR DESCRIPTION
Fixes #47230 (partial fix — that PR changed the claude-code-action token but missed the checkout token)

## Proposed changes:
* Use `API_TOKEN_GITHUB` for the PR branch `actions/checkout` step in the changelog auto-add workflow, so that `git push` from `./pr-checkout` uses a PAT that triggers downstream CI checks.

### Other information:

The previous fix (PR #47230, commit 3398d9e944) set `API_TOKEN_GITHUB` on the `claude-code-action` step, but `actions/checkout` persists its token into `.git/config` as a credential helper (`persist-credentials: true` is the default). Since the PR branch checkout still used `GITHUB_TOKEN`, git push operations from that directory used `GITHUB_TOKEN` credentials — which don't trigger downstream CI workflows.

Evidence: the `test-changelog-gen` PR only had 3 CodeQL checks after a changelog push, while a normal PR has 60+ checks.

- [x] Have you written new tests for your changes, if applicable? N/A — CI config change only.
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them? N/A
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)? N/A

## Testing instructions:

* Open a test PR with the "Generate changelog entries" checkbox checked
* Verify the changelog commit triggers the full CI suite (60+ checks, not just 3 CodeQL checks)

## Changelog

- [ ] Generate changelog entries for this PR (using AI).