### PR TITLE
Forms: show source in single form table

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-wp-build-single-view-source-column
+++ b/projects/packages/forms/changelog/fix-forms-wp-build-single-view-source-column
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Dashboard: re-add the source column to the single form view responses table.

--- a/projects/packages/forms/routes/responses/stage.tsx
+++ b/projects/packages/forms/routes/responses/stage.tsx
@@ -453,38 +453,34 @@ function StageInner() {
 				filterBy: { operators: [ 'is' ] as Operator[] },
 				enableSorting: false,
 			},
-			...( isSingleFormView
-				? []
-				: [
-						{
-							id: 'source',
-							label: __( 'Source', 'jetpack-forms' ),
-							render: ( { item } ) => {
-								const source =
-									item.entry_title ||
-									getUrlPath( item.entry_permalink ) ||
-									__( '(no title)', 'jetpack-forms' );
-								if ( item.entry_permalink ) {
-									return styleUnreadValue(
-										<ExternalLink href={ item.entry_permalink }>{ source }</ExternalLink>,
-										item.is_unread
-									);
-								}
-								return styleUnreadValue( source, item.is_unread );
-							},
-							elements: ( ( filterOptions as unknown as FeedbackFilters )?.source || [] ).map(
-								source => ( {
-									value: source.id.toString(),
-									label:
-										decodeEntities( source.title ) ||
-										getUrlPath( source.url ) ||
-										__( '(no title)', 'jetpack-forms' ),
-								} )
-							),
-							filterBy: { operators: [ 'is' ] as Operator[] },
-							enableSorting: false,
-						},
-				  ] ),
+			{
+				id: 'source',
+				label: __( 'Source', 'jetpack-forms' ),
+				render: ( { item } ) => {
+					const source =
+						item.entry_title ||
+						getUrlPath( item.entry_permalink ) ||
+						__( '(no title)', 'jetpack-forms' );
+					if ( item.entry_permalink ) {
+						return styleUnreadValue(
+							<ExternalLink href={ item.entry_permalink }>{ source }</ExternalLink>,
+							item.is_unread
+						);
+					}
+					return styleUnreadValue( source, item.is_unread );
+				},
+				elements: ( ( filterOptions as unknown as FeedbackFilters )?.source || [] ).map(
+					source => ( {
+						value: source.id.toString(),
+						label:
+							decodeEntities( source.title ) ||
+							getUrlPath( source.url ) ||
+							__( '(no title)', 'jetpack-forms' ),
+					} )
+				),
+				...( isSingleFormView ? {} : { filterBy: { operators: [ 'is' ] as Operator[] } } ),
+				enableSorting: false,
+			},
 			{
 				id: 'read_status',
 				label: __( 'Status', 'jetpack-forms' ),


### PR DESCRIPTION
## Proposed changes:

This PR un-hides the 'source' column in the single forms table. It was originally hidden because we though it would be redundant given the single form view is already tied to a single form post. But the source column shows the page where a form is embedded, which is different. 

**Screenshot - note source column**
<img width="1327" height="396" alt="source-column-after" src="https://github.com/user-attachments/assets/f75e0c02-9daf-4f95-9b8a-9ba2e68de594" />

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Enable these feature flags: 

```
add_filter( 'jetpack_forms_alpha', '__return_true', 20 );
add_filter( 'jetpack_block_editor_feature_flags', 'eb_register_feature' );
function eb_register_feature( $flags ) {
    $flags['central-form-management'] = true;
    return $flags;
}
```

Test:
* Go to Jetpack > Forms and click to view a single form that has some responses
* On the single form screen, confirm the DataViews table now shows the 'source' column

## Changelog
<!-- Check one of the boxes below. -->

I already added a changelog entry. 

- [ ] Generate changelog entries for this PR (using AI).
