### PR TITLE
Canonical URLs: Add module for archive pages

### DIFF
--- a/projects/plugins/jetpack/changelog/jetpack-1292-canonical-urls
+++ b/projects/plugins/jetpack/changelog/jetpack-1292-canonical-urls
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+SEO: Add Canonical URLs module for archive pages to prevent duplicate content in search engines.

--- a/projects/plugins/jetpack/modules/canonical-urls.php
+++ b/projects/plugins/jetpack/modules/canonical-urls.php
@@ -3,7 +3,7 @@
  * Module Name: Canonical URLs
  * Module Description: Add canonical URL tags to archive pages to prevent duplicate content in search engines.
  * Sort Order: 36
- * First Introduced: $$next-version$$
+ * First Introduced: 15.6
  * Requires Connection: No
  * Requires User Connection: No
  * Auto Activate: No

--- a/projects/plugins/jetpack/modules/canonical-urls.php
+++ b/projects/plugins/jetpack/modules/canonical-urls.php
@@ -86,17 +86,6 @@ function jetpack_canonical_urls_output_tag() {
 
 	$url = Jetpack_Canonical_Urls_Resolver::get_canonical_url();
 
-	/**
-	 * Filter the canonical URL before output.
-	 *
-	 * @module canonical-urls
-	 *
-	 * @since $$next-version$$
-	 *
-	 * @param string $url The canonical URL for the current page.
-	 */
-	$url = apply_filters( 'jetpack_canonical_url', $url );
-
 	if ( ! empty( $url ) ) {
 		echo '<link rel="canonical" href="' . esc_url( $url ) . '" />' . "\n";
 	}

--- a/projects/plugins/jetpack/modules/canonical-urls.php
+++ b/projects/plugins/jetpack/modules/canonical-urls.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * Module Name: Canonical URLs
+ * Module Description: Add canonical URL tags to archive pages to prevent duplicate content in search engines.
+ * Sort Order: 36
+ * First Introduced: $$next-version$$
+ * Requires Connection: No
+ * Requires User Connection: No
+ * Auto Activate: No
+ * Module Tags: Traffic
+ * Feature: Traffic
+ * Additional Search Queries: canonical, seo, duplicate content, woocommerce, archive
+ *
+ * @package automattic/jetpack
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
+// Disable canonical URL output when a conflicting SEO plugin is active.
+add_filter( 'jetpack_disable_canonical_urls', 'jetpack_canonical_urls_check_conflicts' );
+
+/**
+ * Can be used to prevent the Canonical URLs module from outputting canonical tags.
+ *
+ * @module canonical-urls
+ *
+ * @since $$next-version$$
+ *
+ * @param bool $disabled Whether canonical URL output is disabled. Defaults to false.
+ */
+if ( ! apply_filters( 'jetpack_disable_canonical_urls', false ) ) {
+	require_once __DIR__ . '/canonical-urls/class-jetpack-canonical-urls-resolver.php';
+	add_action( 'wp_head', 'jetpack_canonical_urls_output_tag' );
+}
+
+/**
+ * Check if a conflicting SEO plugin is active and disable canonical URL output.
+ *
+ * @since $$next-version$$
+ *
+ * @param bool $disabled Whether canonical URL output is already disabled.
+ * @return bool Whether canonical URL output should be disabled.
+ */
+function jetpack_canonical_urls_check_conflicts( $disabled ) {
+	if ( $disabled ) {
+		return $disabled;
+	}
+
+	$conflicting_plugins = array(
+		'wordpress-seo/wp-seo.php',
+		'wordpress-seo-premium/wp-seo-premium.php',
+		'all-in-one-seo-pack/all_in_one_seo_pack.php',
+		'all-in-one-seo-pack-pro/all_in_one_seo_pack.php',
+		'seo-by-rank-math/rank-math.php',
+		'autodescription/autodescription.php',
+		'slim-seo/slim-seo.php',
+		'wp-seopress/seopress.php',
+		'wp-seopress-pro/seopress-pro.php',
+		'seo-key/seo-key.php',
+		'seo-key-pro/seo-key.php',
+	);
+
+	foreach ( $conflicting_plugins as $plugin ) {
+		if ( Jetpack::is_plugin_active( $plugin ) ) {
+			return true;
+		}
+	}
+
+	return $disabled;
+}
+
+/**
+ * Output the canonical link tag for non-singular pages.
+ *
+ * WordPress core handles singular posts/pages via rel_canonical(),
+ * so this function only outputs canonical tags for archive pages.
+ *
+ * @since $$next-version$$
+ */
+function jetpack_canonical_urls_output_tag() {
+	if ( is_singular() ) {
+		return;
+	}
+
+	$url = Jetpack_Canonical_Urls_Resolver::get_canonical_url();
+
+	/**
+	 * Filter the canonical URL before output.
+	 *
+	 * @module canonical-urls
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param string $url The canonical URL for the current page.
+	 */
+	$url = apply_filters( 'jetpack_canonical_url', $url );
+
+	if ( ! empty( $url ) ) {
+		echo '<link rel="canonical" href="' . esc_url( $url ) . '" />' . "\n";
+	}
+}

--- a/projects/plugins/jetpack/modules/canonical-urls/class-jetpack-canonical-urls-resolver.php
+++ b/projects/plugins/jetpack/modules/canonical-urls/class-jetpack-canonical-urls-resolver.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * URL resolution logic for the Canonical URLs module.
+ *
+ * @package automattic/jetpack
+ */
+
+/**
+ * Resolves canonical URLs for different archive page types.
+ *
+ * URLs are built from scratch using WordPress API functions (get_permalink,
+ * get_term_link, etc.) rather than parsing the current request URL, so they
+ * are inherently clean — no sorting, filtering, or tracking parameters.
+ */
+class Jetpack_Canonical_Urls_Resolver {
+
+	/**
+	 * Get the canonical URL for the current page.
+	 *
+	 * Routes to the correct URL based on the current query conditionals.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @return string The canonical URL, or empty string if none should be output.
+	 */
+	public static function get_canonical_url() {
+		$url = '';
+
+		if ( is_front_page() && is_home() ) {
+			// Default homepage (latest posts).
+			$url = home_url( '/' );
+		} elseif ( is_front_page() ) {
+			// Static front page.
+			$url = home_url( '/' );
+		} elseif ( is_home() ) {
+			// Blog page (when a static front page is set).
+			$blog_page_id = (int) get_option( 'page_for_posts' );
+			if ( $blog_page_id ) {
+				$url = get_permalink( $blog_page_id );
+			}
+		} elseif ( function_exists( 'is_shop' ) && is_shop() ) {
+			// WooCommerce shop page.
+			$shop_page_id = (int) get_option( 'woocommerce_shop_page_id' );
+			if ( $shop_page_id ) {
+				$url = get_permalink( $shop_page_id );
+			}
+		} elseif ( is_category() || is_tag() || is_tax() ) {
+			$term = get_queried_object();
+			if ( $term instanceof WP_Term ) {
+				$url = get_term_link( $term );
+				if ( is_wp_error( $url ) ) {
+					$url = '';
+				}
+			}
+		} elseif ( is_post_type_archive() ) {
+			$url = get_post_type_archive_link( get_query_var( 'post_type' ) );
+		} elseif ( is_author() ) {
+			$author = get_queried_object();
+			if ( $author instanceof WP_User ) {
+				$url = get_author_posts_url( $author->ID );
+			}
+		} elseif ( is_year() ) {
+			$url = get_year_link( get_query_var( 'year' ) );
+		} elseif ( is_month() ) {
+			$url = get_month_link( get_query_var( 'year' ), get_query_var( 'monthnum' ) );
+		} elseif ( is_day() ) {
+			$url = get_day_link( get_query_var( 'year' ), get_query_var( 'monthnum' ), get_query_var( 'day' ) );
+		}
+		// is_search() and is_404() intentionally return empty string (no canonical).
+
+		if ( ! empty( $url ) ) {
+			$url = self::apply_pagination( $url );
+		}
+
+		return $url;
+	}
+
+	/**
+	 * Append pagination to the canonical URL for paged views.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param string $url The base canonical URL.
+	 * @return string The URL with pagination appended if applicable.
+	 */
+	private static function apply_pagination( $url ) {
+		$paged = get_query_var( 'paged', 0 );
+
+		if ( $paged < 2 ) {
+			return $url;
+		}
+
+		global $wp_rewrite;
+
+		if ( $wp_rewrite->using_permalinks() ) {
+			$url = trailingslashit( $url ) . $wp_rewrite->pagination_base . '/' . $paged . '/';
+		} else {
+			$url = add_query_arg( 'paged', $paged, $url );
+		}
+
+		return $url;
+	}
+}

--- a/projects/plugins/jetpack/modules/canonical-urls/class-jetpack-canonical-urls-resolver.php
+++ b/projects/plugins/jetpack/modules/canonical-urls/class-jetpack-canonical-urls-resolver.php
@@ -75,7 +75,16 @@ class Jetpack_Canonical_Urls_Resolver {
 			$url = self::apply_pagination( $url );
 		}
 
-		return $url;
+		/**
+		 * Filter the canonical URL before output.
+		 *
+		 * @module canonical-urls
+		 *
+		 * @since $$next-version$$
+		 *
+		 * @param string $url The canonical URL for the current page.
+		 */
+		return apply_filters( 'jetpack_canonical_url', $url );
 	}
 
 	/**

--- a/projects/plugins/jetpack/modules/canonical-urls/class-jetpack-canonical-urls-resolver.php
+++ b/projects/plugins/jetpack/modules/canonical-urls/class-jetpack-canonical-urls-resolver.php
@@ -54,6 +54,9 @@ class Jetpack_Canonical_Urls_Resolver {
 			}
 		} elseif ( is_post_type_archive() ) {
 			$url = get_post_type_archive_link( get_query_var( 'post_type' ) );
+			if ( false === $url ) {
+				$url = '';
+			}
 		} elseif ( is_author() ) {
 			$author = get_queried_object();
 			if ( $author instanceof WP_User ) {
@@ -92,8 +95,8 @@ class Jetpack_Canonical_Urls_Resolver {
 
 		global $wp_rewrite;
 
-		if ( $wp_rewrite->using_permalinks() ) {
-			$url = trailingslashit( $url ) . $wp_rewrite->pagination_base . '/' . $paged . '/';
+		if ( $wp_rewrite->using_permalinks() && false === strpos( $url, '?' ) ) {
+			$url = user_trailingslashit( trailingslashit( $url ) . $wp_rewrite->pagination_base . '/' . $paged );
 		} else {
 			$url = add_query_arg( 'paged', $paged, $url );
 		}

--- a/projects/plugins/jetpack/phpunit.11.xml.dist
+++ b/projects/plugins/jetpack/phpunit.11.xml.dist
@@ -126,6 +126,9 @@
 		<testsuite name="seo-tools">
 			<directory suffix="Test.php">tests/php/modules/seo-tools</directory>
 		</testsuite>
+		<testsuite name="canonical-urls">
+			<directory suffix="Test.php">tests/php/modules/canonical-urls</directory>
+		</testsuite>
 		<testsuite name="compatfunctions">
 			<file>tests/php/Jetpack_Compat_Functions_Test.php</file>
 		</testsuite>

--- a/projects/plugins/jetpack/phpunit.9.xml.dist
+++ b/projects/plugins/jetpack/phpunit.9.xml.dist
@@ -117,6 +117,9 @@
 		<testsuite name="seo-tools">
 			<directory suffix="Test.php">tests/php/modules/seo-tools</directory>
 		</testsuite>
+		<testsuite name="canonical-urls">
+			<directory suffix="Test.php">tests/php/modules/canonical-urls</directory>
+		</testsuite>
 		<testsuite name="compatfunctions">
 			<file>tests/php/Jetpack_Compat_Functions_Test.php</file>
 		</testsuite>

--- a/projects/plugins/jetpack/tests/php/modules/canonical-urls/Jetpack_Canonical_Urls_Test.php
+++ b/projects/plugins/jetpack/tests/php/modules/canonical-urls/Jetpack_Canonical_Urls_Test.php
@@ -1,0 +1,451 @@
+<?php
+/**
+ * Tests for the Canonical URLs module.
+ *
+ * @package automattic/jetpack
+ */
+
+require_once JETPACK__PLUGIN_DIR . 'modules/canonical-urls.php';
+
+/**
+ * Class Jetpack_Canonical_Urls_Test
+ */
+class Jetpack_Canonical_Urls_Test extends WP_UnitTestCase {
+	use \Automattic\Jetpack\PHPUnit\WP_UnitTestCase_Fix;
+
+	/**
+	 * Tear down after each test.
+	 */
+	public function tear_down() {
+		remove_all_actions( 'wp_head' );
+		parent::tear_down();
+	}
+
+	// -------------------------------------------------------------------------
+	// Singular / archive behavior tests
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Test that output_tag produces no output on singular posts (WP core handles those).
+	 */
+	public function test_output_tag_skips_singular() {
+		$post_id = self::factory()->post->create();
+		$this->go_to( get_permalink( $post_id ) );
+
+		ob_start();
+		jetpack_canonical_urls_output_tag();
+		$output = ob_get_clean();
+
+		$this->assertEmpty( $output );
+	}
+
+	/**
+	 * Test that output_tag produces output on the home page.
+	 */
+	public function test_output_tag_on_home() {
+		$this->go_to( home_url( '/' ) );
+
+		ob_start();
+		jetpack_canonical_urls_output_tag();
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'rel="canonical"', $output );
+	}
+
+	/**
+	 * Test that output_tag produces output on a category archive.
+	 */
+	public function test_output_tag_on_category() {
+		$category_id = self::factory()->category->create();
+		self::factory()->post->create( array( 'post_category' => array( $category_id ) ) );
+		$this->go_to( get_category_link( $category_id ) );
+
+		ob_start();
+		jetpack_canonical_urls_output_tag();
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'rel="canonical"', $output );
+	}
+
+	// -------------------------------------------------------------------------
+	// Output tag tests
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Test that output_tag produces nothing when URL is empty.
+	 */
+	public function test_output_tag_empty_url() {
+		add_filter( 'jetpack_canonical_url', '__return_empty_string' );
+
+		ob_start();
+		jetpack_canonical_urls_output_tag();
+		$output = ob_get_clean();
+
+		$this->assertEmpty( $output );
+
+		remove_filter( 'jetpack_canonical_url', '__return_empty_string' );
+	}
+
+	/**
+	 * Test that output_tag produces a link element with the canonical URL.
+	 */
+	public function test_output_tag_renders_link() {
+		$category_id = self::factory()->category->create();
+		self::factory()->post->create( array( 'post_category' => array( $category_id ) ) );
+		$this->go_to( get_category_link( $category_id ) );
+
+		ob_start();
+		jetpack_canonical_urls_output_tag();
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'rel="canonical"', $output );
+		$this->assertStringContainsString( get_category_link( $category_id ), $output );
+	}
+
+	/**
+	 * Test that the jetpack_canonical_url filter can modify the URL.
+	 */
+	public function test_jetpack_canonical_url_filter() {
+		$this->go_to( home_url( '/' ) );
+
+		add_filter( 'jetpack_canonical_url', array( $this, 'filter_canonical_url_override' ) );
+
+		ob_start();
+		jetpack_canonical_urls_output_tag();
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'https://example.com/custom/', $output );
+
+		remove_filter( 'jetpack_canonical_url', array( $this, 'filter_canonical_url_override' ) );
+	}
+
+	/**
+	 * Helper method for the jetpack_canonical_url filter test.
+	 *
+	 * @return string Custom URL.
+	 */
+	public function filter_canonical_url_override() {
+		return 'https://example.com/custom/';
+	}
+
+	// -------------------------------------------------------------------------
+	// Resolver: clean archive URLs
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Test resolver returns home_url for the default homepage.
+	 */
+	public function test_resolver_home_page() {
+		$this->go_to( home_url( '/' ) );
+
+		$url = Jetpack_Canonical_Urls_Resolver::get_canonical_url();
+
+		$this->assertSame( home_url( '/' ), $url );
+	}
+
+	/**
+	 * Test resolver returns blog page permalink when a static front page is set.
+	 */
+	public function test_resolver_blog_page() {
+		$front_page_id = self::factory()->post->create( array( 'post_type' => 'page' ) );
+		$blog_page_id  = self::factory()->post->create( array( 'post_type' => 'page' ) );
+
+		update_option( 'show_on_front', 'page' );
+		update_option( 'page_on_front', $front_page_id );
+		update_option( 'page_for_posts', $blog_page_id );
+
+		$this->go_to( get_permalink( $blog_page_id ) );
+
+		$url = Jetpack_Canonical_Urls_Resolver::get_canonical_url();
+
+		$this->assertSame( get_permalink( $blog_page_id ), $url );
+
+		// Clean up.
+		update_option( 'show_on_front', 'posts' );
+		delete_option( 'page_on_front' );
+		delete_option( 'page_for_posts' );
+	}
+
+	/**
+	 * Test resolver returns the category link for a category archive.
+	 */
+	public function test_resolver_category() {
+		$category_id = self::factory()->category->create();
+		self::factory()->post->create( array( 'post_category' => array( $category_id ) ) );
+		$this->go_to( get_category_link( $category_id ) );
+
+		$url = Jetpack_Canonical_Urls_Resolver::get_canonical_url();
+
+		$this->assertSame( get_category_link( $category_id ), $url );
+	}
+
+	/**
+	 * Test resolver returns the tag link for a tag archive.
+	 */
+	public function test_resolver_tag() {
+		$tag_id  = self::factory()->tag->create();
+		$post_id = self::factory()->post->create();
+		wp_set_post_tags( $post_id, array( $tag_id ) );
+		$this->go_to( get_tag_link( $tag_id ) );
+
+		$url = Jetpack_Canonical_Urls_Resolver::get_canonical_url();
+
+		$this->assertSame( get_tag_link( $tag_id ), $url );
+	}
+
+	/**
+	 * Test resolver returns the author posts URL for an author archive.
+	 */
+	public function test_resolver_author() {
+		$user_id = self::factory()->user->create();
+		self::factory()->post->create( array( 'post_author' => $user_id ) );
+		$this->go_to( get_author_posts_url( $user_id ) );
+
+		$url = Jetpack_Canonical_Urls_Resolver::get_canonical_url();
+
+		$this->assertSame( get_author_posts_url( $user_id ), $url );
+	}
+
+	/**
+	 * Test resolver returns the year link for a yearly archive.
+	 */
+	public function test_resolver_year() {
+		$post_id = self::factory()->post->create();
+		$year    = (int) get_the_date( 'Y', $post_id );
+		$this->go_to( get_year_link( $year ) );
+
+		$url = Jetpack_Canonical_Urls_Resolver::get_canonical_url();
+
+		$this->assertSame( get_year_link( $year ), $url );
+	}
+
+	/**
+	 * Test resolver returns the month link for a monthly archive.
+	 */
+	public function test_resolver_month() {
+		$post_id = self::factory()->post->create();
+		$year    = (int) get_the_date( 'Y', $post_id );
+		$month   = (int) get_the_date( 'n', $post_id );
+		$this->go_to( get_month_link( $year, $month ) );
+
+		$url = Jetpack_Canonical_Urls_Resolver::get_canonical_url();
+
+		$this->assertSame( get_month_link( $year, $month ), $url );
+	}
+
+	/**
+	 * Test resolver returns the day link for a daily archive.
+	 */
+	public function test_resolver_day() {
+		$post_id = self::factory()->post->create();
+		$year    = (int) get_the_date( 'Y', $post_id );
+		$month   = (int) get_the_date( 'n', $post_id );
+		$day     = (int) get_the_date( 'j', $post_id );
+		$this->go_to( get_day_link( $year, $month, $day ) );
+
+		$url = Jetpack_Canonical_Urls_Resolver::get_canonical_url();
+
+		$this->assertSame( get_day_link( $year, $month, $day ), $url );
+	}
+
+	/**
+	 * Test resolver returns empty string for search pages.
+	 */
+	public function test_resolver_search_returns_empty() {
+		$this->go_to( home_url( '?s=test' ) );
+
+		$url = Jetpack_Canonical_Urls_Resolver::get_canonical_url();
+
+		$this->assertSame( '', $url );
+	}
+
+	/**
+	 * Test resolver returns empty string for 404 pages.
+	 */
+	public function test_resolver_404_returns_empty() {
+		$this->go_to( home_url( '?p=999999' ) );
+
+		// Confirm we're actually on a 404.
+		$this->assertTrue( is_404(), 'Expected a 404 page' );
+
+		$url = Jetpack_Canonical_Urls_Resolver::get_canonical_url();
+
+		$this->assertSame( '', $url );
+	}
+
+	/**
+	 * Test resolver returns the post type archive link for a custom post type archive.
+	 */
+	public function test_resolver_post_type_archive() {
+		register_post_type(
+			'book',
+			array(
+				'public'      => true,
+				'has_archive' => true,
+			)
+		);
+		self::factory()->post->create( array( 'post_type' => 'book' ) );
+		$this->go_to( get_post_type_archive_link( 'book' ) );
+
+		$url = Jetpack_Canonical_Urls_Resolver::get_canonical_url();
+
+		$this->assertSame( get_post_type_archive_link( 'book' ), $url );
+
+		unregister_post_type( 'book' );
+	}
+
+	/**
+	 * Test resolver appends pagination for paged views without pretty permalinks.
+	 */
+	public function test_resolver_pagination_plain_permalinks() {
+		$category_id = self::factory()->category->create();
+		// Create enough posts to trigger pagination.
+		for ( $i = 0; $i < 15; $i++ ) {
+			self::factory()->post->create( array( 'post_category' => array( $category_id ) ) );
+		}
+
+		$this->go_to( add_query_arg( 'paged', 2, get_category_link( $category_id ) ) );
+
+		$url = Jetpack_Canonical_Urls_Resolver::get_canonical_url();
+
+		$this->assertStringContainsString( 'paged=2', $url );
+	}
+
+	// -------------------------------------------------------------------------
+	// Resolver: archive URLs with query arguments
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Test that visiting the home page with a sorting argument still returns clean home_url.
+	 */
+	public function test_resolver_home_with_orderby_arg() {
+		$this->go_to( home_url( '/?orderby=date' ) );
+
+		$url = Jetpack_Canonical_Urls_Resolver::get_canonical_url();
+
+		$this->assertSame( home_url( '/' ), $url );
+	}
+
+	/**
+	 * Test that visiting a category with UTM tracking params returns clean category link.
+	 */
+	public function test_resolver_category_with_utm_args() {
+		$category_id = self::factory()->category->create();
+		self::factory()->post->create( array( 'post_category' => array( $category_id ) ) );
+		$this->go_to(
+			add_query_arg(
+				array(
+					'utm_source' => 'google',
+					'utm_medium' => 'cpc',
+				),
+				get_category_link( $category_id )
+			)
+		);
+
+		$url = Jetpack_Canonical_Urls_Resolver::get_canonical_url();
+
+		$this->assertSame( get_category_link( $category_id ), $url );
+		$this->assertStringNotContainsString( 'utm_source', $url );
+		$this->assertStringNotContainsString( 'utm_medium', $url );
+	}
+
+	/**
+	 * Test that visiting a tag archive with fbclid returns clean tag link.
+	 */
+	public function test_resolver_tag_with_fbclid_arg() {
+		$tag_id  = self::factory()->tag->create();
+		$post_id = self::factory()->post->create();
+		wp_set_post_tags( $post_id, array( $tag_id ) );
+		$this->go_to( add_query_arg( 'fbclid', 'abc123', get_tag_link( $tag_id ) ) );
+
+		$url = Jetpack_Canonical_Urls_Resolver::get_canonical_url();
+
+		$this->assertSame( get_tag_link( $tag_id ), $url );
+		$this->assertStringNotContainsString( 'fbclid', $url );
+	}
+
+	/**
+	 * Test that visiting an author archive with multiple tracking args returns clean URL.
+	 */
+	public function test_resolver_author_with_tracking_args() {
+		$user_id = self::factory()->user->create();
+		self::factory()->post->create( array( 'post_author' => $user_id ) );
+		$this->go_to(
+			add_query_arg(
+				array(
+					'gclid'        => 'xyz789',
+					'utm_campaign' => 'test',
+					'ref'          => 'sidebar',
+				),
+				get_author_posts_url( $user_id )
+			)
+		);
+
+		$url = Jetpack_Canonical_Urls_Resolver::get_canonical_url();
+
+		$this->assertSame( get_author_posts_url( $user_id ), $url );
+	}
+
+	/**
+	 * Test that visiting a date archive with a preview arg returns clean date link.
+	 */
+	public function test_resolver_date_with_preview_arg() {
+		$post_id = self::factory()->post->create();
+		$year    = (int) get_the_date( 'Y', $post_id );
+		$this->go_to( add_query_arg( 'preview', 'true', get_year_link( $year ) ) );
+
+		$url = Jetpack_Canonical_Urls_Resolver::get_canonical_url();
+
+		$this->assertSame( get_year_link( $year ), $url );
+		$this->assertStringNotContainsString( 'preview', $url );
+	}
+
+	/**
+	 * Test that visiting a post type archive with arbitrary unknown args still returns clean URL.
+	 */
+	public function test_resolver_post_type_archive_with_unknown_args() {
+		register_post_type(
+			'book',
+			array(
+				'public'      => true,
+				'has_archive' => true,
+			)
+		);
+		self::factory()->post->create( array( 'post_type' => 'book' ) );
+		$this->go_to( add_query_arg( 'custom_filter', 'value', get_post_type_archive_link( 'book' ) ) );
+
+		$url = Jetpack_Canonical_Urls_Resolver::get_canonical_url();
+
+		$this->assertSame( get_post_type_archive_link( 'book' ), $url );
+		$this->assertStringNotContainsString( 'custom_filter', $url );
+
+		unregister_post_type( 'book' );
+	}
+
+	/**
+	 * Test that paged category with tracking args returns URL with pagination but no tracking.
+	 */
+	public function test_resolver_paged_category_with_tracking_args() {
+		$category_id = self::factory()->category->create();
+		for ( $i = 0; $i < 15; $i++ ) {
+			self::factory()->post->create( array( 'post_category' => array( $category_id ) ) );
+		}
+
+		$this->go_to(
+			add_query_arg(
+				array(
+					'paged'      => 2,
+					'utm_source' => 'newsletter',
+					'fbclid'     => 'abc',
+				),
+				get_category_link( $category_id )
+			)
+		);
+
+		$url = Jetpack_Canonical_Urls_Resolver::get_canonical_url();
+
+		$this->assertStringContainsString( 'paged=2', $url );
+		$this->assertStringNotContainsString( 'utm_source', $url );
+		$this->assertStringNotContainsString( 'fbclid', $url );
+	}
+}

--- a/projects/plugins/jetpack/tests/php/modules/canonical-urls/Jetpack_Canonical_Urls_Test.php
+++ b/projects/plugins/jetpack/tests/php/modules/canonical-urls/Jetpack_Canonical_Urls_Test.php
@@ -17,7 +17,7 @@ class Jetpack_Canonical_Urls_Test extends WP_UnitTestCase {
 	 * Tear down after each test.
 	 */
 	public function tear_down() {
-		remove_all_actions( 'wp_head' );
+		remove_action( 'wp_head', 'jetpack_canonical_urls_output_tag' );
 		parent::tear_down();
 	}
 
@@ -309,6 +309,39 @@ class Jetpack_Canonical_Urls_Test extends WP_UnitTestCase {
 		$url = Jetpack_Canonical_Urls_Resolver::get_canonical_url();
 
 		$this->assertStringContainsString( 'paged=2', $url );
+	}
+
+	/**
+	 * Test resolver uses query-based pagination for query-based archive URLs
+	 * even when pretty permalinks are enabled globally.
+	 */
+	public function test_resolver_pagination_query_based_archive_with_pretty_permalinks() {
+		$this->set_permalink_structure( '/%postname%/' );
+
+		register_post_type(
+			'no_rewrite_cpt',
+			array(
+				'public'      => true,
+				'has_archive' => true,
+				'rewrite'     => false,
+			)
+		);
+
+		for ( $i = 0; $i < 15; $i++ ) {
+			self::factory()->post->create( array( 'post_type' => 'no_rewrite_cpt' ) );
+		}
+
+		$archive_url = get_post_type_archive_link( 'no_rewrite_cpt' );
+		$this->go_to( add_query_arg( 'paged', 2, $archive_url ) );
+
+		$url = Jetpack_Canonical_Urls_Resolver::get_canonical_url();
+
+		// Should use query-based pagination since the archive URL contains a query string.
+		$this->assertStringContainsString( 'paged=2', $url );
+		$this->assertStringNotContainsString( '/page/', $url );
+
+		unregister_post_type( 'no_rewrite_cpt' );
+		$this->set_permalink_structure( '' );
 	}
 
 	// -------------------------------------------------------------------------


### PR DESCRIPTION
Related to JETPACK-1292

## Proposed changes:
* Add a new `canonical-urls` Jetpack module that outputs `<link rel="canonical">` tags on archive pages (categories, tags, authors, dates, post type archives, WooCommerce shop) to prevent duplicate content issues in search engines.
* WordPress core only handles canonical URLs for singular posts/pages — this fills the gap for all archive types.
* Auto-disables when conflicting SEO plugins are active (Yoast, Rank Math, AIOSEO, The SEO Framework, Slim SEO, SEOPress, SEO Key).
* Provides `jetpack_canonical_url` and `jetpack_disable_canonical_urls` filters for customization.
* URLs are built from scratch using WordPress API functions, so they're inherently clean of tracking/filter query parameters.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- TBD -->

## Does this pull request change what data or activity we track or use?
No. This module only outputs standard HTML `<link>` canonical tags in the page head. It does not track, collect, or transmit any data.

## Testing instructions:
* Activate the Jetpack plugin and enable the "Canonical URLs" module under Jetpack → Modules → Cacnonical URLs (**wp-admin/admin.php?page=jetpack_modules**).
* Ensure no other SEO plugin (Yoast, Rank Math, etc.) is active.
* Visit a category, tag, author, or date archive page.
* View page source and confirm a `<link rel="canonical" ...>` tag is present in the `<head>`.
* Add query parameters (e.g., `?utm_source=test&fbclid=abc`) to the archive URL — the canonical tag should point to the clean URL without those parameters.
* Visit a paginated archive (page 2+) — the canonical tag should include the pagination.
* Visit a singular post/page — no Jetpack canonical tag should be output (WordPress core handles those).

## Changelog

- [x] Generate changelog entries for this PR (using AI).