### PR TITLE
Form: show synced forms as read-only preview in widget editor

### DIFF
--- a/projects/packages/forms/changelog/fix-widget-editor-ref-form
+++ b/projects/packages/forms/changelog/fix-widget-editor-ref-form
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Contact Form: show synced forms as read-only preview in widget editor with Edit Form button.

--- a/projects/packages/forms/src/blocks/contact-form/edit.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/edit.tsx
@@ -1018,10 +1018,6 @@ function JetpackContactFormEdit( {
 	}
 	// In widget editor, synced forms (with ref) are not editable
 	else if ( isWidgetEditorWithRef ) {
-		// Use syncedFormBlocks from API, or fall back to currentInnerBlocks if already loaded into editor
-		const previewBlocks =
-			syncedFormBlocks && syncedFormBlocks.length > 0 ? syncedFormBlocks : currentInnerBlocks;
-
 		const handleEditForm = () => {
 			flushPendingSave();
 			navigateToForm( ref, 'widget' );
@@ -1052,13 +1048,10 @@ function JetpackContactFormEdit( {
 						'jetpack-forms'
 					) }
 				</Notice>
-				{ previewBlocks && previewBlocks.length > 0 ? (
-					<Disabled>
-						<div { ...innerBlocksProps } />
-					</Disabled>
-				) : (
-					<ContactFormSkeletonLoader />
-				) }
+
+				<Disabled>
+					<div { ...innerBlocksProps } />
+				</Disabled>
 			</div>
 		);
 	} else if ( ! isModuleActive ) {

--- a/projects/packages/forms/src/blocks/contact-form/edit.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/edit.tsx
@@ -13,7 +13,7 @@ import {
 	store as blockEditorStore,
 	BlockControls,
 	BlockContextProvider,
-	BlockPreview,
+	useBlockEditingMode,
 } from '@wordpress/block-editor';
 import { createBlock } from '@wordpress/blocks';
 import {
@@ -215,6 +215,11 @@ function JetpackContactFormEdit( {
 
 	// Check if we're in widget editor with a synced form (ref)
 	const isWidgetEditorWithRef = ref && getEditorContext() === 'widget';
+
+	// Hide auxiliary block controls (toolbar, movers, settings) for synced forms in widget editor.
+	// 'contentOnly' mode hides these controls while still allowing interaction with content (like our "Edit Form" button).
+	// This replaces the blocks.registerBlockType filter approach and provides runtime control.
+	useBlockEditingMode( isWidgetEditorWithRef ? 'contentOnly' : 'default' );
 
 	// Load synced form data from the jetpack_form post type
 	const {
@@ -1031,8 +1036,6 @@ function JetpackContactFormEdit( {
 						onBeforeNavigate={ flushPendingSave }
 					/>
 				</BlockControls>
-				<InspectorControls />
-				<InspectorControls group="color" />
 				<Notice
 					status="info"
 					isDismissible={ false }
@@ -1048,9 +1051,7 @@ function JetpackContactFormEdit( {
 				</Notice>
 				{ previewBlocks && previewBlocks.length > 0 ? (
 					<Disabled>
-						<div className={ formClassnames }>
-							<BlockPreview blocks={ previewBlocks } viewportWidth={ 0 } />
-						</div>
+						<div { ...innerBlocksProps } />
 					</Disabled>
 				) : (
 					<ContactFormSkeletonLoader />

--- a/projects/packages/forms/src/blocks/contact-form/edit.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/edit.tsx
@@ -13,9 +13,11 @@ import {
 	store as blockEditorStore,
 	BlockControls,
 	BlockContextProvider,
+	BlockPreview,
 } from '@wordpress/block-editor';
 import { createBlock } from '@wordpress/blocks';
 import {
+	Disabled,
 	ExternalLink,
 	Notice,
 	PanelBody,
@@ -49,7 +51,7 @@ import useFormSteps from '../shared/hooks/use-form-steps.js';
 import { SyncedAttributeProvider } from '../shared/hooks/use-synced-attributes.js';
 import { CORE_BLOCKS, FORM_POST_TYPE } from '../shared/util/constants.js';
 import { childBlocks } from './child-blocks.js';
-import { ConvertFormToolbar } from './components/convert-form-toolbar.tsx';
+import { ConvertFormToolbar, navigateToForm } from './components/convert-form-toolbar.tsx';
 import FormStatusNotice from './components/form-status-notice.tsx';
 import { ContactFormPlaceholder } from './components/jetpack-contact-form-placeholder.js';
 import ContactFormSkeletonLoader from './components/jetpack-contact-form-skeleton-loader.js';
@@ -59,6 +61,7 @@ import { useSyncedFormAutoSave } from './hooks/use-synced-form-auto-save.ts';
 import { useSyncedFormLoader } from './hooks/use-synced-form-loader.ts';
 import { useSyncedForm } from './hooks/use-synced-form.ts';
 import useFormBlockDefaults from './shared/hooks/use-form-block-defaults.js';
+import { getEditorContext } from './util/get-editor-context.ts';
 import VariationPicker from './variation-picker.js';
 import './util/form-styles.js';
 
@@ -209,6 +212,9 @@ function JetpackContactFormEdit( {
 	const showBlockIntegrations = useConfigValue( 'showBlockIntegrations' );
 	const isCentralFormManagementEnabled = hasFeatureFlag( 'central-form-management' );
 	const instanceId = useInstanceId( JetpackContactFormEdit );
+
+	// Check if we're in widget editor with a synced form (ref)
+	const isWidgetEditorWithRef = ref && getEditorContext() === 'widget';
 
 	// Load synced form data from the jetpack_form post type
 	const {
@@ -1003,6 +1009,53 @@ function JetpackContactFormEdit( {
 			<Notice status="warning" isDismissible={ false }>
 				{ __( 'The referenced form could not be found.', 'jetpack-forms' ) }
 			</Notice>
+		);
+	}
+	// In widget editor, synced forms (with ref) are not editable
+	else if ( isWidgetEditorWithRef ) {
+		// Use syncedFormBlocks from API, or fall back to currentInnerBlocks if already loaded into editor
+		const previewBlocks =
+			syncedFormBlocks && syncedFormBlocks.length > 0 ? syncedFormBlocks : currentInnerBlocks;
+
+		const handleEditForm = () => {
+			navigateToForm( ref, 'widget' );
+		};
+
+		return (
+			<div { ...blockProps }>
+				{ /* Empty controls to hide the default panels from block supports */ }
+				<BlockControls>
+					<ConvertFormToolbar
+						clientId={ clientId }
+						attributes={ attributes }
+						onBeforeNavigate={ flushPendingSave }
+					/>
+				</BlockControls>
+				<InspectorControls />
+				<InspectorControls group="color" />
+				<Notice
+					status="info"
+					isDismissible={ false }
+					actions={ [
+						{
+							label: __( 'Edit Form', 'jetpack-forms' ),
+							onClick: handleEditForm,
+							variant: 'primary',
+						},
+					] }
+				>
+					{ __( 'This form cannot be edited in the widget editor.', 'jetpack-forms' ) }
+				</Notice>
+				{ previewBlocks && previewBlocks.length > 0 ? (
+					<Disabled>
+						<div className={ formClassnames }>
+							<BlockPreview blocks={ previewBlocks } viewportWidth={ 0 } />
+						</div>
+					</Disabled>
+				) : (
+					<ContactFormSkeletonLoader />
+				) }
+			</div>
 		);
 	} else if ( ! isModuleActive ) {
 		if ( isLoadingModules ) {

--- a/projects/packages/forms/src/blocks/contact-form/edit.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/edit.tsx
@@ -1039,9 +1039,13 @@ function JetpackContactFormEdit( {
 						'jetpack-forms'
 					) }
 				</Notice>
-				<Disabled>
-					<div { ...innerBlocksProps } />
-				</Disabled>
+				{ isResolvingSyncedForm ? (
+					<ContactFormSkeletonLoader />
+				) : (
+					<Disabled>
+						<div { ...innerBlocksProps } />
+					</Disabled>
+				) }
 			</div>
 		);
 	} else if ( ! isModuleActive ) {

--- a/projects/packages/forms/src/blocks/contact-form/edit.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/edit.tsx
@@ -216,9 +216,6 @@ function JetpackContactFormEdit( {
 	// Check if we're in widget editor with a synced form (ref)
 	const isWidgetEditorWithRef = !! ref && getEditorContext() === 'widget';
 
-	// Hide auxiliary block controls (toolbar, movers, settings) for synced forms in widget editor.
-	// 'contentOnly' mode hides these controls while still allowing interaction with content (like our "Edit Form" button).
-	// This replaces the blocks.registerBlockType filter approach and provides runtime control.
 	useBlockEditingMode( isWidgetEditorWithRef ? 'contentOnly' : 'default' );
 
 	// Load synced form data from the jetpack_form post type

--- a/projects/packages/forms/src/blocks/contact-form/edit.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/edit.tsx
@@ -1017,12 +1017,13 @@ function JetpackContactFormEdit( {
 	else if ( isWidgetEditorWithRef ) {
 		const handleEditForm = () => {
 			flushPendingSave();
-			navigateToForm( ref, 'widget' );
+			navigateToForm( ref as number, 'widget' );
 		};
 
 		return (
 			<div { ...blockProps }>
 				<Notice
+					className="jetpack-contact-form-widget-readonly-notice"
 					status="info"
 					isDismissible={ false }
 					actions={ [

--- a/projects/packages/forms/src/blocks/contact-form/edit.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/edit.tsx
@@ -214,7 +214,7 @@ function JetpackContactFormEdit( {
 	const instanceId = useInstanceId( JetpackContactFormEdit );
 
 	// Check if we're in widget editor with a synced form (ref)
-	const isWidgetEditorWithRef = ref && getEditorContext() === 'widget';
+	const isWidgetEditorWithRef = !! ref && getEditorContext() === 'widget';
 
 	// Hide auxiliary block controls (toolbar, movers, settings) for synced forms in widget editor.
 	// 'contentOnly' mode hides these controls while still allowing interaction with content (like our "Edit Form" button).
@@ -1023,6 +1023,7 @@ function JetpackContactFormEdit( {
 			syncedFormBlocks && syncedFormBlocks.length > 0 ? syncedFormBlocks : currentInnerBlocks;
 
 		const handleEditForm = () => {
+			flushPendingSave();
 			navigateToForm( ref, 'widget' );
 		};
 

--- a/projects/packages/forms/src/blocks/contact-form/edit.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/edit.tsx
@@ -1022,13 +1022,6 @@ function JetpackContactFormEdit( {
 
 		return (
 			<div { ...blockProps }>
-				<BlockControls>
-					<ConvertFormToolbar
-						clientId={ clientId }
-						attributes={ attributes }
-						onBeforeNavigate={ flushPendingSave }
-					/>
-				</BlockControls>
 				<Notice
 					status="info"
 					isDismissible={ false }
@@ -1045,7 +1038,6 @@ function JetpackContactFormEdit( {
 						'jetpack-forms'
 					) }
 				</Notice>
-
 				<Disabled>
 					<div { ...innerBlocksProps } />
 				</Disabled>

--- a/projects/packages/forms/src/blocks/contact-form/edit.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/edit.tsx
@@ -1029,7 +1029,6 @@ function JetpackContactFormEdit( {
 
 		return (
 			<div { ...blockProps }>
-				{ /* Empty controls to hide the default panels from block supports */ }
 				<BlockControls>
 					<ConvertFormToolbar
 						clientId={ clientId }

--- a/projects/packages/forms/src/blocks/contact-form/edit.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/edit.tsx
@@ -1047,7 +1047,10 @@ function JetpackContactFormEdit( {
 						},
 					] }
 				>
-					{ __( 'This form cannot be edited in the widget editor.', 'jetpack-forms' ) }
+					{ __(
+						'Forms are edited in the Form Editor. Changes will sync back to this widget.',
+						'jetpack-forms'
+					) }
 				</Notice>
 				{ previewBlocks && previewBlocks.length > 0 ? (
 					<Disabled>

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -210,7 +210,7 @@
 		}
 	}
 
-	/* Fixes notices styling when gutenberg is not there */
+	/* Fixes notices styling when Gutenberg is not there */
 	.components-notice {
 		margin-top: 8px;
 

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -209,6 +209,16 @@
 			margin: unset;
 		}
 	}
+
+	/* Fixes notices styling when gutenberg is not there */
+	.components-notice {
+		margin-top: 8px;
+
+		.components-notice__action.components-button {
+			margin-left: 0;
+			margin-top: 8px;
+		}
+	}
 }
 
 .jetpack-contact-form .components-placeholder {
@@ -1105,19 +1115,6 @@
 :where(.is-style-outlined .jetpack-contact-form .jetpack-field .notched-label__trailing) {
 	border: var(--jetpack--contact-form--border);
 	background-color: var(--jetpack--contact-form--input-background);
-}
-
-.wp-block-jetpack-contact-form
-.components-notice.jetpack-contact-form-widget-editor-readonly-notice
-.components-notice__actions
-.components-button {
-	margin-left: 0;
-	margin-top: 12px;
-}
-
-.wp-block-jetpack-contact-form
-.components-notice.jetpack-contact-form-widget-editor-readonly-notice {
-	margin-top: 8px;
 }
 
 :where(.wp-block-jetpack-contact-form.is-style-outlined) {

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -1108,15 +1108,15 @@
 }
 
 .wp-block-jetpack-contact-form
-	.components-notice.jetpack-contact-form-widget-editor-readonly-notice
-	.components-notice__actions
-	.components-button {
+.components-notice.jetpack-contact-form-widget-editor-readonly-notice
+.components-notice__actions
+.components-button {
 	margin-left: 0;
 	margin-top: 12px;
 }
 
 .wp-block-jetpack-contact-form
-	.components-notice.jetpack-contact-form-widget-editor-readonly-notice {
+.components-notice.jetpack-contact-form-widget-editor-readonly-notice {
 	margin-top: 8px;
 }
 

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -1107,6 +1107,15 @@
 	background-color: var(--jetpack--contact-form--input-background);
 }
 
+.wp-block-jetpack-contact-form .components-notice__actions .components-button {
+	margin-left: 0;
+	margin-top: 12px;
+}
+
+.wp-block-jetpack-contact-form .components-notice {
+	margin-top: 8px;
+}
+
 :where(.wp-block-jetpack-contact-form.is-style-outlined) {
 
 	.notched-label__leading {

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -1107,12 +1107,16 @@
 	background-color: var(--jetpack--contact-form--input-background);
 }
 
-.wp-block-jetpack-contact-form .components-notice__actions .components-button {
+.wp-block-jetpack-contact-form
+	.components-notice.jetpack-contact-form-widget-editor-readonly-notice
+	.components-notice__actions
+	.components-button {
 	margin-left: 0;
 	margin-top: 12px;
 }
 
-.wp-block-jetpack-contact-form .components-notice {
+.wp-block-jetpack-contact-form
+	.components-notice.jetpack-contact-form-widget-editor-readonly-notice {
 	margin-top: 8px;
 }
 

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -211,7 +211,7 @@
 	}
 
 	/* Fixes notices styling when Gutenberg is not there */
-	.components-notice {
+	.jetpack-contact-form-widget-readonly-notice {
 		margin-top: 8px;
 
 		.components-notice__action.components-button {

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -212,7 +212,7 @@
 
 	/* Fixes notices styling when Gutenberg is not there */
 	.jetpack-contact-form-widget-readonly-notice {
-		margin-top: 8px;
+		margin: 8px 0 4px;
 
 		.components-notice__action.components-button {
 			margin-left: 0;

--- a/projects/packages/forms/src/blocks/contact-form/index.js
+++ b/projects/packages/forms/src/blocks/contact-form/index.js
@@ -2,7 +2,6 @@ import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
 import { Path } from '@wordpress/components';
 import { store as coreStore } from '@wordpress/core-data';
 import { select } from '@wordpress/data';
-import { addFilter } from '@wordpress/hooks';
 import { decodeEntities } from '@wordpress/html-entities';
 import { __, _x } from '@wordpress/i18n';
 import './editor.scss';
@@ -14,7 +13,6 @@ import deprecated from './deprecated.js';
 import edit from './edit.tsx';
 import transforms from './transforms.js';
 import { DEFAULT_FORM_LABEL, extractTitleText, formatFormLabel } from './util/form-label.js';
-import { getEditorContext } from './util/get-editor-context.ts';
 import variations from './variations.js';
 
 export const name = 'contact-form';
@@ -75,32 +73,6 @@ const icon = renderMaterialIcon(
 // Extract only valid block registration properties from block.json
 // Exclude file-based properties like editorScript, style, etc.
 const { editorScript, style, name: blockName, $schema, ...validBlockMetadata } = blockMetadata;
-
-/**
- * Filter to disable layout support in the widget editor.
- *
- * In the widget editor, synced forms (with ref) are read-only and shown as previews.
- * Disabling layout support prevents showing controls that users cannot interact with.
- */
-addFilter(
-	'blocks.registerBlockType',
-	'jetpack-forms/disable-layout-in-widget-editor',
-	( settings, blockType ) => {
-		if ( blockType !== 'jetpack/contact-form' ) {
-			return settings;
-		}
-
-		// Disable layout support in widget editor
-		if ( getEditorContext() === 'widget' ) {
-			return {
-				...settings,
-				supports: {},
-			};
-		}
-
-		return settings;
-	}
-);
 
 export const settings = {
 	// Import valid metadata from block.json to ensure consistency

--- a/projects/packages/forms/src/blocks/contact-form/index.js
+++ b/projects/packages/forms/src/blocks/contact-form/index.js
@@ -2,6 +2,7 @@ import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
 import { Path } from '@wordpress/components';
 import { store as coreStore } from '@wordpress/core-data';
 import { select } from '@wordpress/data';
+import { addFilter } from '@wordpress/hooks';
 import { decodeEntities } from '@wordpress/html-entities';
 import { __, _x } from '@wordpress/i18n';
 import './editor.scss';
@@ -13,6 +14,7 @@ import deprecated from './deprecated.js';
 import edit from './edit.tsx';
 import transforms from './transforms.js';
 import { DEFAULT_FORM_LABEL, extractTitleText, formatFormLabel } from './util/form-label.js';
+import { getEditorContext } from './util/get-editor-context.ts';
 import variations from './variations.js';
 
 export const name = 'contact-form';
@@ -73,6 +75,32 @@ const icon = renderMaterialIcon(
 // Extract only valid block registration properties from block.json
 // Exclude file-based properties like editorScript, style, etc.
 const { editorScript, style, name: blockName, $schema, ...validBlockMetadata } = blockMetadata;
+
+/**
+ * Filter to disable layout support in the widget editor.
+ *
+ * In the widget editor, synced forms (with ref) are read-only and shown as previews.
+ * Disabling layout support prevents showing controls that users cannot interact with.
+ */
+addFilter(
+	'blocks.registerBlockType',
+	'jetpack-forms/disable-layout-in-widget-editor',
+	( settings, blockType ) => {
+		if ( blockType !== 'jetpack/contact-form' ) {
+			return settings;
+		}
+
+		// Disable layout support in widget editor
+		if ( getEditorContext() === 'widget' ) {
+			return {
+				...settings,
+				supports: {},
+			};
+		}
+
+		return settings;
+	}
+);
 
 export const settings = {
 	// Import valid metadata from block.json to ensure consistency


### PR DESCRIPTION

<img width="827" height="560" alt="Screenshot 2026-03-03 at 5 51 01 AM" src="https://github.com/user-attachments/assets/2315000a-763a-4b96-8ffd-5380951e5506" />



## Proposed changes:
* In the widget editor, synced forms (forms with a `ref` attribute) are now displayed as read-only previews instead of being fully editable
* Added an "Edit Form" button that navigates to the form editor where users can make changes
* Disabled layout support controls in the widget editor for the contact form block, since synced forms cannot be edited there

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

* Add a synced form (form with ref) to a widget area using the widget editor at `/wp-admin/widgets.php`
* Verify the form shows as a read-only preview with a notice: "This form cannot be edited in the widget editor."
* Verify an "Edit Form" button is present and clicking it navigates to the form editor
* Verify the form preview displays correctly with the form fields visible but disabled
* Verify no layout controls are shown in the block toolbar or inspector for the form block

## Changelog

- [x] Generate changelog entries for this PR (using AI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)