### PR TITLE
Jetpack Forms: Guard image-select render_block() against invalid image payloads

### DIFF
--- a/projects/packages/forms/changelog/pr-47236
+++ b/projects/packages/forms/changelog/pr-47236
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Image Select: Prevent fatal error when rendering image-select fields with invalid image payloads.

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -2077,6 +2077,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 			$option_label  = Contact_Form_Plugin::strip_tags( $option['label'] );
 			$option_letter = Contact_Form_Plugin::strip_tags( $option['letter'] );
 			$image_block   = $option['image'] ?? null;
+			$image_id      = ( is_array( $image_block ) && isset( $image_block['attrs'] ) && is_array( $image_block['attrs'] ) ) ? ( $image_block['attrs']['id'] ?? null ) : null;
 
 			$rendered_image_block = is_array( $image_block ) ? render_block( $image_block ) : '';
 			// Remove any links from the rendered block
@@ -2104,7 +2105,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 					'label'      => $option_label,
 					'showLabels' => $show_labels,
 					'image'      => array(
-						'id'  => $image_block['attrs']['id'] ?? null,
+						'id'  => $image_id,
 						'src' => $image_src ?? null,
 					),
 				),

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -2076,9 +2076,9 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 		foreach ( $working_options as $option_index => $option ) {
 			$option_label  = Contact_Form_Plugin::strip_tags( $option['label'] );
 			$option_letter = Contact_Form_Plugin::strip_tags( $option['letter'] );
-			$image_block   = $option['image'];
+			$image_block   = $option['image'] ?? null;
 
-			$rendered_image_block = render_block( $image_block );
+			$rendered_image_block = is_array( $image_block ) ? render_block( $image_block ) : '';
 			// Remove any links from the rendered block
 			$rendered_image_block = preg_replace( '/<a[^>]*>(.*?)<\/a>/s', '$1', $rendered_image_block );
 

--- a/projects/plugins/jetpack/changelog/pr-47236
+++ b/projects/plugins/jetpack/changelog/pr-47236
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Forms: Prevent fatal error when rendering image-select fields with invalid image payloads.


### PR DESCRIPTION
## Proposed changes:

This hotfix prevents a fatal error when rendering Jetpack Forms `image-select` fields if an option contains an invalid `image` payload (for example, an empty string).

Previously, `render_image_select_field()` always called:

- `render_block( $image_block )`

When `$image_block` was not a parsed block array, WordPress/Gutenberg block rendering filters received an unexpected value and could fatally error.

This patch adds a minimal type guard so `render_block()` is called only for array payloads.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

## Does this pull request change what data or activity we track or use?

## Testing instructions:

* wordpress.com: Sandbox and visit the site listed in p1771536457540429-slack-C4N88L95W
*

## Changelog

- [x] Generate changelog entries for this PR (using AI).