### PR TITLE
Forms: Add embed code panel to form editor

### DIFF
--- a/projects/packages/forms/changelog/add-copy-code-form-editor
+++ b/projects/packages/forms/changelog/add-copy-code-form-editor
@@ -1,4 +1,4 @@
 Significance: minor
 Type: added
 
-Add embed code panel to form editor for copying embed code
+Add embed code panel to form editor for copying embed code.

--- a/projects/packages/forms/changelog/add-copy-code-form-editor
+++ b/projects/packages/forms/changelog/add-copy-code-form-editor
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add embed code panel to form editor for copying embed code

--- a/projects/packages/forms/src/form-editor/index.tsx
+++ b/projects/packages/forms/src/form-editor/index.tsx
@@ -12,12 +12,12 @@ import { subscribe, select, dispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { getPlugin, registerPlugin, unregisterPlugin } from '@wordpress/plugins';
 import { FORM_POST_TYPE } from '../blocks/shared/util/constants.js';
+import { EmbedCodePanel, EMBED_CODE_PANEL_PLUGIN } from './plugins/embed-code-panel';
 import {
 	FormPrePublishPanel,
 	JETPACK_FORM_PRE_PUBLISH_PANEL,
 } from './plugins/form-pre-publish-panel';
 import { FormTitleModal } from './plugins/form-title-modal';
-import { EmbedCodePanel, EMBED_CODE_PANEL_PLUGIN } from './plugins/embed-code-panel';
 import { HeaderActions, HEADER_ACTIONS_PLUGIN } from './plugins/header-actions';
 import {
 	activateBlockCategoryOverrides,

--- a/projects/packages/forms/src/form-editor/index.tsx
+++ b/projects/packages/forms/src/form-editor/index.tsx
@@ -17,6 +17,7 @@ import {
 	JETPACK_FORM_PRE_PUBLISH_PANEL,
 } from './plugins/form-pre-publish-panel';
 import { FormTitleModal } from './plugins/form-title-modal';
+import { EmbedCodePanel, EMBED_CODE_PANEL_PLUGIN } from './plugins/embed-code-panel';
 import { HeaderActions, HEADER_ACTIONS_PLUGIN } from './plugins/header-actions';
 import {
 	activateBlockCategoryOverrides,
@@ -368,6 +369,9 @@ const setupFormEditorSubscription = () => {
 					registerPlugin( HEADER_ACTIONS_PLUGIN, {
 						render: HeaderActions,
 					} );
+					registerPlugin( EMBED_CODE_PANEL_PLUGIN, {
+						render: EmbedCodePanel,
+					} );
 				} else {
 					// We just left the form editor.
 					document.body.classList.remove( 'post-type-jetpack_form' );
@@ -380,6 +384,10 @@ const setupFormEditorSubscription = () => {
 
 					if ( getPlugin( JETPACK_FORM_PRE_PUBLISH_PANEL ) ) {
 						unregisterPlugin( JETPACK_FORM_PRE_PUBLISH_PANEL );
+					}
+
+					if ( getPlugin( EMBED_CODE_PANEL_PLUGIN ) ) {
+						unregisterPlugin( EMBED_CODE_PANEL_PLUGIN );
 					}
 
 					if ( state.categoriesSetUp ) {

--- a/projects/packages/forms/src/form-editor/plugins/copy-code-row.scss
+++ b/projects/packages/forms/src/form-editor/plugins/copy-code-row.scss
@@ -1,0 +1,35 @@
+.jetpack-form-embed-code__popover .components-popover__content {
+	padding: 4px 8px;
+}
+
+.jetpack-form-embed-code {
+	width: 100%;
+
+	.jetpack-form-embed-code__rows {
+		display: flex;
+		flex-direction: column;
+		gap: 8px;
+		width: 100%;
+	}
+
+	.jetpack-form-embed-code__container {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		width: 100%;
+		border: 1px solid #ddd;
+		border-radius: 4px;
+		padding: 8px 8px 8px 12px;
+		gap: 8px;
+	}
+
+	.jetpack-form-embed-code__text {
+		font-family: monospace;
+		font-size: 12px;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+		flex: 1;
+		min-width: 0;
+	}
+}

--- a/projects/packages/forms/src/form-editor/plugins/copy-code-row.scss
+++ b/projects/packages/forms/src/form-editor/plugins/copy-code-row.scss
@@ -8,7 +8,7 @@
 	.jetpack-form-embed-code__rows {
 		display: flex;
 		flex-direction: column;
-		gap: 8px;
+		gap: 16px;
 		width: 100%;
 	}
 

--- a/projects/packages/forms/src/form-editor/plugins/copy-code-row.scss
+++ b/projects/packages/forms/src/form-editor/plugins/copy-code-row.scss
@@ -44,5 +44,7 @@
 		white-space: nowrap;
 		flex: 1;
 		min-width: 0;
+		cursor: text;
+		user-select: all;
 	}
 }

--- a/projects/packages/forms/src/form-editor/plugins/copy-code-row.scss
+++ b/projects/packages/forms/src/form-editor/plugins/copy-code-row.scss
@@ -12,6 +12,19 @@
 		width: 100%;
 	}
 
+	.jetpack-form-embed-code__row {
+		display: flex;
+		flex-direction: column;
+		gap: 4px;
+	}
+
+	.jetpack-form-embed-code__label {
+		font-size: 11px;
+		font-weight: 500;
+		text-transform: uppercase;
+		color: #757575;
+	}
+
 	.jetpack-form-embed-code__container {
 		display: flex;
 		align-items: center;

--- a/projects/packages/forms/src/form-editor/plugins/copy-code-row.tsx
+++ b/projects/packages/forms/src/form-editor/plugins/copy-code-row.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import './copy-code-row.scss';
-import { Button, Popover, Tooltip } from '@wordpress/components';
+import { Button, Popover } from '@wordpress/components';
 import { useCopyToClipboard } from '@wordpress/compose';
 import { useState, useEffect, useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -10,7 +10,7 @@ import { copySmall, check } from '@wordpress/icons';
 
 type CopyCodeRowProps = {
 	text: string;
-	tooltipLabel: string;
+	label: string;
 };
 
 /**
@@ -19,7 +19,7 @@ type CopyCodeRowProps = {
  * @param {CopyCodeRowProps} props - The component props.
  * @return {JSX.Element} The copy code row component.
  */
-export const CopyCodeRow = ( { text, tooltipLabel }: CopyCodeRowProps ) => {
+export const CopyCodeRow = ( { text, label }: CopyCodeRowProps ) => {
 	const [ showCopyConfirmation, setShowCopyConfirmation ] = useState( false );
 	const timeoutIdRef = useRef< number | null >( null );
 
@@ -42,29 +42,30 @@ export const CopyCodeRow = ( { text, tooltipLabel }: CopyCodeRowProps ) => {
 	}, [] );
 
 	return (
-		<div className="jetpack-form-embed-code__container">
-			<span className="jetpack-form-embed-code__text">{ text }</span>
-			{ showCopyConfirmation ? (
-				<Button
-					ref={ ref }
-					icon={ check }
-					size="compact"
-					label={ __( 'Copied!', 'jetpack-forms' ) }
-				>
-					<Popover
-						placement="top"
-						noArrow={ false }
-						focusOnMount={ false }
-						className="jetpack-form-embed-code__popover"
+		<div className="jetpack-form-embed-code__row">
+			<span className="jetpack-form-embed-code__label">{ label }</span>
+			<div className="jetpack-form-embed-code__container">
+				<span className="jetpack-form-embed-code__text">{ text }</span>
+				{ showCopyConfirmation ? (
+					<Button
+						ref={ ref }
+						icon={ check }
+						size="compact"
+						label={ __( 'Copied!', 'jetpack-forms' ) }
 					>
-						{ __( 'Copied!', 'jetpack-forms' ) }
-					</Popover>
-				</Button>
-			) : (
-				<Tooltip text={ tooltipLabel }>
-					<Button ref={ ref } icon={ copySmall } size="compact" label={ tooltipLabel } />
-				</Tooltip>
-			) }
+						<Popover
+							placement="top"
+							noArrow={ false }
+							focusOnMount={ false }
+							className="jetpack-form-embed-code__popover"
+						>
+							{ __( 'Copied!', 'jetpack-forms' ) }
+						</Popover>
+					</Button>
+				) : (
+					<Button ref={ ref } icon={ copySmall } size="compact" label={ label } />
+				) }
+			</div>
 		</div>
 	);
 };

--- a/projects/packages/forms/src/form-editor/plugins/copy-code-row.tsx
+++ b/projects/packages/forms/src/form-editor/plugins/copy-code-row.tsx
@@ -5,7 +5,7 @@ import './copy-code-row.scss';
 import { Button, Popover } from '@wordpress/components';
 import { useCopyToClipboard } from '@wordpress/compose';
 import { useState, useEffect, useRef, useCallback } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { __, isRTL } from '@wordpress/i18n';
 import { copySmall, check } from '@wordpress/icons';
 
 type CopyCodeRowProps = {
@@ -86,7 +86,7 @@ export const CopyCodeRow = ( { text, label }: CopyCodeRowProps ) => {
 						label={ __( 'Copied!', 'jetpack-forms' ) }
 					>
 						<Popover
-							placement="top"
+							placement={ isRTL() ? 'top-start' : 'top-end' }
 							noArrow={ false }
 							focusOnMount={ false }
 							className="jetpack-form-embed-code__popover"

--- a/projects/packages/forms/src/form-editor/plugins/copy-code-row.tsx
+++ b/projects/packages/forms/src/form-editor/plugins/copy-code-row.tsx
@@ -5,7 +5,7 @@ import './copy-code-row.scss';
 import { Button, Popover } from '@wordpress/components';
 import { useCopyToClipboard } from '@wordpress/compose';
 import { useState, useEffect, useRef, useCallback } from '@wordpress/element';
-import { __, isRTL } from '@wordpress/i18n';
+import { __, isRTL, sprintf } from '@wordpress/i18n';
 import { copySmall, check } from '@wordpress/icons';
 
 type CopyCodeRowProps = {
@@ -30,7 +30,7 @@ export const CopyCodeRow = ( { text, label }: CopyCodeRowProps ) => {
 		}
 		const selection = textRef.current.ownerDocument.defaultView?.getSelection();
 		if ( selection ) {
-			const range = document.createRange();
+			const range = textRef.current.ownerDocument.createRange();
 			range.selectNodeContents( textRef.current );
 			selection.removeAllRanges();
 			selection.addRange( range );
@@ -40,6 +40,8 @@ export const CopyCodeRow = ( { text, label }: CopyCodeRowProps ) => {
 	const handleKeyDown = useCallback(
 		( event: React.KeyboardEvent ) => {
 			if ( event.key === 'Enter' || event.key === ' ' ) {
+				event.preventDefault();
+				event.stopPropagation();
 				handleTextClick();
 			}
 		},
@@ -73,6 +75,7 @@ export const CopyCodeRow = ( { text, label }: CopyCodeRowProps ) => {
 					className="jetpack-form-embed-code__text"
 					onClick={ handleTextClick }
 					role="textbox"
+					aria-readonly="true"
 					tabIndex={ 0 }
 					onKeyDown={ handleKeyDown }
 				>
@@ -95,7 +98,13 @@ export const CopyCodeRow = ( { text, label }: CopyCodeRowProps ) => {
 						</Popover>
 					</Button>
 				) : (
-					<Button ref={ ref } icon={ copySmall } size="compact" label={ label } />
+					<Button
+						ref={ ref }
+						icon={ copySmall }
+						size="compact"
+						/* translators: %s: label for the code row (e.g. "Embed code", "Shortcode") */
+						label={ sprintf( __( 'Copy %s', 'jetpack-forms' ), label.toLowerCase() ) }
+					/>
 				) }
 			</div>
 		</div>

--- a/projects/packages/forms/src/form-editor/plugins/copy-code-row.tsx
+++ b/projects/packages/forms/src/form-editor/plugins/copy-code-row.tsx
@@ -65,6 +65,8 @@ export const CopyCodeRow = ( { text, label }: CopyCodeRowProps ) => {
 			}
 		};
 	}, [] );
+	/* translators: %s: label for the code row (e.g. "Embed code", "Shortcode") */
+	const buttonLabel = __( 'Copy %s', 'jetpack-forms' );
 
 	return (
 		<div className="jetpack-form-embed-code__row">
@@ -102,8 +104,7 @@ export const CopyCodeRow = ( { text, label }: CopyCodeRowProps ) => {
 						ref={ ref }
 						icon={ copySmall }
 						size="compact"
-						/* translators: %s: label for the code row (e.g. "Embed code", "Shortcode") */
-						label={ sprintf( __( 'Copy %s', 'jetpack-forms' ), label.toLowerCase() ) }
+						label={ sprintf( buttonLabel, label.toLowerCase() ) }
 					/>
 				) }
 			</div>

--- a/projects/packages/forms/src/form-editor/plugins/copy-code-row.tsx
+++ b/projects/packages/forms/src/form-editor/plugins/copy-code-row.tsx
@@ -4,7 +4,7 @@
 import './copy-code-row.scss';
 import { Button, Popover } from '@wordpress/components';
 import { useCopyToClipboard } from '@wordpress/compose';
-import { useState, useEffect, useRef } from '@wordpress/element';
+import { useState, useEffect, useRef, useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { copySmall, check } from '@wordpress/icons';
 
@@ -22,6 +22,29 @@ type CopyCodeRowProps = {
 export const CopyCodeRow = ( { text, label }: CopyCodeRowProps ) => {
 	const [ showCopyConfirmation, setShowCopyConfirmation ] = useState( false );
 	const timeoutIdRef = useRef< number | null >( null );
+	const textRef = useRef< HTMLSpanElement >( null );
+
+	const handleTextClick = useCallback( () => {
+		if ( ! textRef.current ) {
+			return;
+		}
+		const selection = textRef.current.ownerDocument.defaultView?.getSelection();
+		if ( selection ) {
+			const range = document.createRange();
+			range.selectNodeContents( textRef.current );
+			selection.removeAllRanges();
+			selection.addRange( range );
+		}
+	}, [] );
+
+	const handleKeyDown = useCallback(
+		( event: React.KeyboardEvent ) => {
+			if ( event.key === 'Enter' || event.key === ' ' ) {
+				handleTextClick();
+			}
+		},
+		[ handleTextClick ]
+	);
 
 	const ref = useCopyToClipboard( text, () => {
 		setShowCopyConfirmation( true );
@@ -45,7 +68,16 @@ export const CopyCodeRow = ( { text, label }: CopyCodeRowProps ) => {
 		<div className="jetpack-form-embed-code__row">
 			<span className="jetpack-form-embed-code__label">{ label }</span>
 			<div className="jetpack-form-embed-code__container">
-				<span className="jetpack-form-embed-code__text">{ text }</span>
+				<span
+					ref={ textRef }
+					className="jetpack-form-embed-code__text"
+					onClick={ handleTextClick }
+					role="textbox"
+					tabIndex={ 0 }
+					onKeyDown={ handleKeyDown }
+				>
+					{ text }
+				</span>
 				{ showCopyConfirmation ? (
 					<Button
 						ref={ ref }

--- a/projects/packages/forms/src/form-editor/plugins/copy-code-row.tsx
+++ b/projects/packages/forms/src/form-editor/plugins/copy-code-row.tsx
@@ -1,0 +1,70 @@
+/**
+ * External dependencies
+ */
+import './copy-code-row.scss';
+import { Button, Popover, Tooltip } from '@wordpress/components';
+import { useCopyToClipboard } from '@wordpress/compose';
+import { useState, useEffect, useRef } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { copySmall, check } from '@wordpress/icons';
+
+type CopyCodeRowProps = {
+	text: string;
+	tooltipLabel: string;
+};
+
+/**
+ * A row displaying a code snippet with a copy button.
+ *
+ * @param {CopyCodeRowProps} props - The component props.
+ * @return {JSX.Element} The copy code row component.
+ */
+export const CopyCodeRow = ( { text, tooltipLabel }: CopyCodeRowProps ) => {
+	const [ showCopyConfirmation, setShowCopyConfirmation ] = useState( false );
+	const timeoutIdRef = useRef< number | null >( null );
+
+	const ref = useCopyToClipboard( text, () => {
+		setShowCopyConfirmation( true );
+		if ( timeoutIdRef.current ) {
+			clearTimeout( timeoutIdRef.current );
+		}
+		timeoutIdRef.current = setTimeout( () => {
+			setShowCopyConfirmation( false );
+		}, 2000 );
+	} );
+
+	useEffect( () => {
+		return () => {
+			if ( timeoutIdRef.current ) {
+				clearTimeout( timeoutIdRef.current );
+			}
+		};
+	}, [] );
+
+	return (
+		<div className="jetpack-form-embed-code__container">
+			<span className="jetpack-form-embed-code__text">{ text }</span>
+			{ showCopyConfirmation ? (
+				<Button
+					ref={ ref }
+					icon={ check }
+					size="compact"
+					label={ __( 'Copied!', 'jetpack-forms' ) }
+				>
+					<Popover
+						placement="top"
+						noArrow={ false }
+						focusOnMount={ false }
+						className="jetpack-form-embed-code__popover"
+					>
+						{ __( 'Copied!', 'jetpack-forms' ) }
+					</Popover>
+				</Button>
+			) : (
+				<Tooltip text={ tooltipLabel }>
+					<Button ref={ ref } icon={ copySmall } size="compact" label={ tooltipLabel } />
+				</Tooltip>
+			) }
+		</div>
+	);
+};

--- a/projects/packages/forms/src/form-editor/plugins/embed-code-panel.tsx
+++ b/projects/packages/forms/src/form-editor/plugins/embed-code-panel.tsx
@@ -15,7 +15,8 @@ export const EMBED_CODE_PANEL_PLUGIN = 'jetpack-form-embed-code-panel';
  * Embed Code Panel component.
  *
  * Adds post status info rows with the embed code and shortcode, each with a copy button.
- * Only renders when editing a jetpack_form post type.
+ * Rendered only in the jetpack_form post editor; post-type scoping is handled by
+ * registration logic in form-editor/index.tsx.
  *
  * @return {JSX.Element|null} The embed code panel or null.
  */

--- a/projects/packages/forms/src/form-editor/plugins/embed-code-panel.tsx
+++ b/projects/packages/forms/src/form-editor/plugins/embed-code-panel.tsx
@@ -47,8 +47,8 @@ export const EmbedCodePanel = () => {
 	return (
 		<PluginPostStatusInfo className="jetpack-form-embed-code">
 			<div className="jetpack-form-embed-code__rows">
-				<CopyCodeRow text={ embedCode } tooltipLabel={ __( 'Copy embed code', 'jetpack-forms' ) } />
-				<CopyCodeRow text={ shortcode } tooltipLabel={ __( 'Copy shortcode', 'jetpack-forms' ) } />
+				<CopyCodeRow text={ embedCode } label={ __( 'Embed code', 'jetpack-forms' ) } />
+				<CopyCodeRow text={ shortcode } label={ __( 'Shortcode', 'jetpack-forms' ) } />
 			</div>
 		</PluginPostStatusInfo>
 	);

--- a/projects/packages/forms/src/form-editor/plugins/embed-code-panel.tsx
+++ b/projects/packages/forms/src/form-editor/plugins/embed-code-panel.tsx
@@ -1,0 +1,100 @@
+/**
+ * External dependencies
+ */
+import { Button } from '@wordpress/components';
+import { useCopyToClipboard } from '@wordpress/compose';
+import { useSelect } from '@wordpress/data';
+import { PluginDocumentSettingPanel } from '@wordpress/editor';
+import { useState, useEffect, useRef, useCallback } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+
+type CopyButtonProps = {
+	text: string;
+	label: string;
+};
+
+export const EMBED_CODE_PANEL_PLUGIN = 'jetpack-forms-embedcode-panel';
+
+/**
+ * Copy button component that shows a checkmark when copied.
+ *
+ * @param {CopyButtonProps} props - The component props.
+ * @return {JSX.Element} The copy button component.
+ */
+const CopyButton = ( { text, label }: CopyButtonProps ) => {
+	const [ showCopyConfirmation, setShowCopyConfirmation ] = useState( false );
+	const timeoutIdRef = useRef< number | null >( null );
+	const ref = useCopyToClipboard( text, () => {
+		setShowCopyConfirmation( true );
+		if ( timeoutIdRef.current ) {
+			clearTimeout( timeoutIdRef.current );
+		}
+		timeoutIdRef.current = setTimeout( () => {
+			setShowCopyConfirmation( false );
+		}, 2000 );
+	} );
+
+	useEffect( () => {
+		return () => {
+			if ( timeoutIdRef.current ) {
+				clearTimeout( timeoutIdRef.current );
+			}
+		};
+	}, [] );
+
+	const copiedLabel = __( 'Copied!', 'jetpack-forms' );
+
+	return (
+		<div style={ { marginBottom: '8px' } }>
+			<Button __next40pxDefaultSize size="compact" variant="secondary" ref={ ref }>
+				{ showCopyConfirmation ? copiedLabel : label }
+			</Button>
+		</div>
+	);
+};
+
+/**
+ * Embed Code Panel component.
+ *
+ * Adds a document settings panel with buttons to copy the embed code.
+ * Only renders when editing a jetpack_form post type.
+ *
+ * @return {JSX.Element|null} The embed code panel or null.
+ */
+export const EmbedCodePanel = () => {
+	const { postId, postStatus } = useSelect( select => {
+		const editor = select( 'core/editor' ) as {
+			getCurrentPostId: () => number;
+			getEditedPostAttribute: ( attr: string ) => string;
+		};
+		return {
+			postId: editor.getCurrentPostId(),
+			postStatus: editor.getEditedPostAttribute( 'status' ),
+		};
+	} );
+
+	const getEmbedCode = useCallback( () => {
+		return `<!-- wp:jetpack/contact-form {"ref":${ postId }} /-->`;
+	}, [ postId ] );
+
+	// Don't show for drafts or auto-drafts since they don't have a stable ID yet.
+	if ( postStatus === 'auto-draft' ) {
+		return null;
+	}
+
+	// PluginDocumentSettingPanel may not be available in older WordPress versions.
+	if ( ! PluginDocumentSettingPanel ) {
+		return null;
+	}
+
+	return (
+		<PluginDocumentSettingPanel
+			name="jetpack-form-embed-code"
+			title={ __( 'Embed code', 'jetpack-forms' ) }
+		>
+			<p>{ __( 'Copy the code below to embed this form.', 'jetpack-forms' ) }</p>
+
+			<CopyButton text={ getEmbedCode() } label={ __( 'Copy embed code', 'jetpack-forms' ) } />
+		</PluginDocumentSettingPanel>
+	);
+};

--- a/projects/packages/forms/src/form-editor/plugins/embed-code-panel.tsx
+++ b/projects/packages/forms/src/form-editor/plugins/embed-code-panel.tsx
@@ -9,7 +9,7 @@ import { __ } from '@wordpress/i18n';
  */
 import { CopyCodeRow } from './copy-code-row';
 
-export const EMBED_CODE_PANEL_PLUGIN = 'jetpack-forms-embedcode-panel';
+export const EMBED_CODE_PANEL_PLUGIN = 'jetpack-form-embed-code-panel';
 
 /**
  * Embed Code Panel component.
@@ -31,7 +31,7 @@ export const EmbedCodePanel = () => {
 		};
 	} );
 
-	// Don't show for drafts or auto-drafts since they don't have a stable ID yet.
+	// Don't show for auto-drafts since they don't have a stable ID yet.
 	if ( postStatus === 'auto-draft' ) {
 		return null;
 	}

--- a/projects/packages/forms/src/form-editor/plugins/embed-code-panel.tsx
+++ b/projects/packages/forms/src/form-editor/plugins/embed-code-panel.tsx
@@ -1,62 +1,20 @@
 /**
  * External dependencies
  */
-import { Button } from '@wordpress/components';
-import { useCopyToClipboard } from '@wordpress/compose';
 import { useSelect } from '@wordpress/data';
-import { PluginDocumentSettingPanel } from '@wordpress/editor';
-import { useState, useEffect, useRef, useCallback } from '@wordpress/element';
+import { PluginPostStatusInfo } from '@wordpress/editor';
 import { __ } from '@wordpress/i18n';
-
-type CopyButtonProps = {
-	text: string;
-	label: string;
-};
+/**
+ * Internal dependencies
+ */
+import { CopyCodeRow } from './copy-code-row';
 
 export const EMBED_CODE_PANEL_PLUGIN = 'jetpack-forms-embedcode-panel';
 
 /**
- * Copy button component that shows a checkmark when copied.
- *
- * @param {CopyButtonProps} props - The component props.
- * @return {JSX.Element} The copy button component.
- */
-const CopyButton = ( { text, label }: CopyButtonProps ) => {
-	const [ showCopyConfirmation, setShowCopyConfirmation ] = useState( false );
-	const timeoutIdRef = useRef< number | null >( null );
-	const ref = useCopyToClipboard( text, () => {
-		setShowCopyConfirmation( true );
-		if ( timeoutIdRef.current ) {
-			clearTimeout( timeoutIdRef.current );
-		}
-		timeoutIdRef.current = setTimeout( () => {
-			setShowCopyConfirmation( false );
-		}, 2000 );
-	} );
-
-	useEffect( () => {
-		return () => {
-			if ( timeoutIdRef.current ) {
-				clearTimeout( timeoutIdRef.current );
-			}
-		};
-	}, [] );
-
-	const copiedLabel = __( 'Copied!', 'jetpack-forms' );
-
-	return (
-		<div style={ { marginBottom: '8px' } }>
-			<Button __next40pxDefaultSize size="compact" variant="secondary" ref={ ref }>
-				{ showCopyConfirmation ? copiedLabel : label }
-			</Button>
-		</div>
-	);
-};
-
-/**
  * Embed Code Panel component.
  *
- * Adds a document settings panel with buttons to copy the embed code.
+ * Adds post status info rows with the embed code and shortcode, each with a copy button.
  * Only renders when editing a jetpack_form post type.
  *
  * @return {JSX.Element|null} The embed code panel or null.
@@ -73,28 +31,25 @@ export const EmbedCodePanel = () => {
 		};
 	} );
 
-	const getEmbedCode = useCallback( () => {
-		return `<!-- wp:jetpack/contact-form {"ref":${ postId }} /-->`;
-	}, [ postId ] );
-
 	// Don't show for drafts or auto-drafts since they don't have a stable ID yet.
 	if ( postStatus === 'auto-draft' ) {
 		return null;
 	}
 
-	// PluginDocumentSettingPanel may not be available in older WordPress versions.
-	if ( ! PluginDocumentSettingPanel ) {
+	// PluginPostStatusInfo may not be available in older WordPress versions.
+	if ( ! PluginPostStatusInfo ) {
 		return null;
 	}
 
-	return (
-		<PluginDocumentSettingPanel
-			name="jetpack-form-embed-code"
-			title={ __( 'Embed code', 'jetpack-forms' ) }
-		>
-			<p>{ __( 'Copy the code below to embed this form.', 'jetpack-forms' ) }</p>
+	const embedCode = `<!-- wp:jetpack/contact-form {"ref":${ postId }} /-->`;
+	const shortcode = `[contact-form ref="${ postId }"]`;
 
-			<CopyButton text={ getEmbedCode() } label={ __( 'Copy embed code', 'jetpack-forms' ) } />
-		</PluginDocumentSettingPanel>
+	return (
+		<PluginPostStatusInfo className="jetpack-form-embed-code">
+			<div className="jetpack-form-embed-code__rows">
+				<CopyCodeRow text={ embedCode } tooltipLabel={ __( 'Copy embed code', 'jetpack-forms' ) } />
+				<CopyCodeRow text={ shortcode } tooltipLabel={ __( 'Copy shortcode', 'jetpack-forms' ) } />
+			</div>
+		</PluginPostStatusInfo>
 	);
 };

--- a/projects/packages/forms/tests/js/form-editor/plugins/embed-code-panel.test.jsx
+++ b/projects/packages/forms/tests/js/form-editor/plugins/embed-code-panel.test.jsx
@@ -41,9 +41,9 @@ await jest.unstable_mockModule( '@wordpress/editor', () => ( {
 // Mock CopyCodeRow to capture text props
 const copyCodeRowTexts = [];
 await jest.unstable_mockModule( '../../../../src/form-editor/plugins/copy-code-row', () => ( {
-	CopyCodeRow: ( { text, tooltipLabel } ) => {
+	CopyCodeRow: ( { text, label } ) => {
 		copyCodeRowTexts.push( text );
-		return <div data-testid="copy-code-row">{ tooltipLabel }</div>;
+		return <div data-testid="copy-code-row">{ label }</div>;
 	},
 } ) );
 
@@ -66,8 +66,8 @@ describe( 'EmbedCodePanel', () => {
 	it( 'renders embed code and shortcode rows for published posts', () => {
 		render( <EmbedCodePanel /> );
 
-		expect( screen.getByText( 'Copy embed code' ) ).toBeInTheDocument();
-		expect( screen.getByText( 'Copy shortcode' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Embed code' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Shortcode' ) ).toBeInTheDocument();
 	} );
 
 	it( 'returns null for auto-draft posts', () => {
@@ -83,7 +83,7 @@ describe( 'EmbedCodePanel', () => {
 
 		render( <EmbedCodePanel /> );
 
-		expect( screen.getByText( 'Copy embed code' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Embed code' ) ).toBeInTheDocument();
 	} );
 
 	it( 'uses the correct post ID in embed code and shortcode', () => {

--- a/projects/packages/forms/tests/js/form-editor/plugins/embed-code-panel.test.jsx
+++ b/projects/packages/forms/tests/js/form-editor/plugins/embed-code-panel.test.jsx
@@ -18,8 +18,8 @@ let mockPostId = 42;
 let mockPostStatus = 'publish';
 
 await jest.unstable_mockModule( '@wordpress/data', () => ( {
-	useSelect: jest.fn( ( callback ) => {
-		const mockSelect = ( storeName ) => {
+	useSelect: jest.fn( callback => {
+		const mockSelect = storeName => {
 			expect( storeName ).toBe( 'core/editor' );
 			return {
 				getCurrentPostId: () => mockPostId,

--- a/projects/packages/forms/tests/js/form-editor/plugins/embed-code-panel.test.jsx
+++ b/projects/packages/forms/tests/js/form-editor/plugins/embed-code-panel.test.jsx
@@ -40,15 +40,12 @@ await jest.unstable_mockModule( '@wordpress/editor', () => ( {
 
 // Mock CopyCodeRow to capture text props
 const copyCodeRowTexts = [];
-await jest.unstable_mockModule(
-	'../../../../src/form-editor/plugins/copy-code-row',
-	() => ( {
-		CopyCodeRow: ( { text, tooltipLabel } ) => {
-			copyCodeRowTexts.push( text );
-			return <div data-testid="copy-code-row">{ tooltipLabel }</div>;
-		},
-	} )
-);
+await jest.unstable_mockModule( '../../../../src/form-editor/plugins/copy-code-row', () => ( {
+	CopyCodeRow: ( { text, tooltipLabel } ) => {
+		copyCodeRowTexts.push( text );
+		return <div data-testid="copy-code-row">{ tooltipLabel }</div>;
+	},
+} ) );
 
 // Import component after mocks
 const { EmbedCodePanel, EMBED_CODE_PANEL_PLUGIN } = await import(

--- a/projects/packages/forms/tests/js/form-editor/plugins/embed-code-panel.test.jsx
+++ b/projects/packages/forms/tests/js/form-editor/plugins/embed-code-panel.test.jsx
@@ -18,11 +18,14 @@ let mockPostId = 42;
 let mockPostStatus = 'publish';
 
 await jest.unstable_mockModule( '@wordpress/data', () => ( {
-	useSelect: jest.fn( callback => {
-		const mockSelect = () => ( {
-			getCurrentPostId: () => mockPostId,
-			getEditedPostAttribute: () => mockPostStatus,
-		} );
+	useSelect: jest.fn( ( callback ) => {
+		const mockSelect = ( storeName ) => {
+			expect( storeName ).toBe( 'core/editor' );
+			return {
+				getCurrentPostId: () => mockPostId,
+				getEditedPostAttribute: () => mockPostStatus,
+			};
+		};
 		return callback( mockSelect );
 	} ),
 } ) );

--- a/projects/packages/forms/tests/js/form-editor/plugins/embed-code-panel.test.jsx
+++ b/projects/packages/forms/tests/js/form-editor/plugins/embed-code-panel.test.jsx
@@ -1,0 +1,100 @@
+/**
+ * Tests for form-editor/plugins/embed-code-panel.tsx
+ *
+ * This file tests the EmbedCodePanel component which provides
+ * copy buttons for form embed code and shortcode in the editor sidebar.
+ */
+
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { render, screen } from '@testing-library/react';
+
+// Mock WordPress i18n
+await jest.unstable_mockModule( '@wordpress/i18n', () => ( {
+	__: text => text,
+} ) );
+
+// Mock WordPress data
+let mockPostId = 42;
+let mockPostStatus = 'publish';
+
+await jest.unstable_mockModule( '@wordpress/data', () => ( {
+	useSelect: jest.fn( callback => {
+		const mockSelect = () => ( {
+			getCurrentPostId: () => mockPostId,
+			getEditedPostAttribute: () => mockPostStatus,
+		} );
+		return callback( mockSelect );
+	} ),
+} ) );
+
+// Mock WordPress editor
+const MockPluginPostStatusInfo = ( { children, className } ) => (
+	<div data-testid="post-status-info" className={ className }>
+		{ children }
+	</div>
+);
+
+await jest.unstable_mockModule( '@wordpress/editor', () => ( {
+	PluginPostStatusInfo: MockPluginPostStatusInfo,
+} ) );
+
+// Mock CopyCodeRow to capture text props
+const copyCodeRowTexts = [];
+await jest.unstable_mockModule(
+	'../../../../src/form-editor/plugins/copy-code-row',
+	() => ( {
+		CopyCodeRow: ( { text, tooltipLabel } ) => {
+			copyCodeRowTexts.push( text );
+			return <div data-testid="copy-code-row">{ tooltipLabel }</div>;
+		},
+	} )
+);
+
+// Import component after mocks
+const { EmbedCodePanel, EMBED_CODE_PANEL_PLUGIN } = await import(
+	'../../../../src/form-editor/plugins/embed-code-panel.tsx'
+);
+
+describe( 'EmbedCodePanel', () => {
+	beforeEach( () => {
+		mockPostId = 42;
+		mockPostStatus = 'publish';
+		copyCodeRowTexts.length = 0;
+	} );
+
+	it( 'follows the jetpack-form-* plugin naming convention', () => {
+		expect( EMBED_CODE_PANEL_PLUGIN ).toBe( 'jetpack-form-embed-code-panel' );
+	} );
+
+	it( 'renders embed code and shortcode rows for published posts', () => {
+		render( <EmbedCodePanel /> );
+
+		expect( screen.getByText( 'Copy embed code' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Copy shortcode' ) ).toBeInTheDocument();
+	} );
+
+	it( 'returns null for auto-draft posts', () => {
+		mockPostStatus = 'auto-draft';
+
+		const { container } = render( <EmbedCodePanel /> );
+
+		expect( container ).toBeEmptyDOMElement();
+	} );
+
+	it( 'renders for draft posts', () => {
+		mockPostStatus = 'draft';
+
+		render( <EmbedCodePanel /> );
+
+		expect( screen.getByText( 'Copy embed code' ) ).toBeInTheDocument();
+	} );
+
+	it( 'uses the correct post ID in embed code and shortcode', () => {
+		mockPostId = 123;
+
+		render( <EmbedCodePanel /> );
+
+		expect( copyCodeRowTexts ).toContain( '<!-- wp:jetpack/contact-form {"ref":123} /-->' );
+		expect( copyCodeRowTexts ).toContain( '[contact-form ref="123"]' );
+	} );
+} );


### PR DESCRIPTION
Adds a "copy embed code" to the PluginPostStatusInfo  

<img width="294" height="573" alt="Screenshot 2026-03-03 at 6 44 42 AM" src="https://github.com/user-attachments/assets/a3ddb974-344b-4ea8-b1b9-c0d6e714b90b" />

See 

https://github.com/user-attachments/assets/93c901ab-4a2e-4cc9-9fd8-c9e91e74ebb6



## Proposed changes:
* Add a new "Emboed code" to PluginPostStatusInfo slot 
* Allow users to copy the embed code and shortcode for embedding forms in posts and pages.
* Panel only displays for saved forms (not auto-drafts). 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?




## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

1. Go to Jetpack Forms dashboard (wp-admin/admin.php?page=jetpack-forms)
2. Create a new form or edit an existing one
3. In the Form tab see the new buttons. 
4. Click "Copy embed code" button
5. Verify that you see the popup. 
6. Paste somewhere to verify the correct embed code was copied (should be `<!-- wp:jetpack/contact-form {"ref":<form-id>} /-->`)
8. For a new unsaved form (auto-draft status), verify the panel does not appear until the form is saved

## Changelog

- [x] Changelog entry added via changelogger