### PR TITLE
Forms: Redesign placeholder component with template preview grid

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2350,6 +2350,9 @@ importers:
       '@automattic/babel-plugin-replace-textdomain':
         specifier: workspace:*
         version: link:../../js-packages/babel-plugin-replace-textdomain
+      '@automattic/jetpack-ai-client':
+        specifier: workspace:*
+        version: link:../../js-packages/ai-client
       '@automattic/jetpack-analytics':
         specifier: workspace:*
         version: link:../../js-packages/analytics

--- a/projects/packages/forms/changelog/try-forms-placeholder-preview
+++ b/projects/packages/forms/changelog/try-forms-placeholder-preview
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Redesign form block placeholder with template preview grid and AI prompt input field

--- a/projects/packages/forms/package.json
+++ b/projects/packages/forms/package.json
@@ -42,6 +42,7 @@
 	],
 	"dependencies": {
 		"@automattic/babel-plugin-replace-textdomain": "workspace:*",
+		"@automattic/jetpack-ai-client": "workspace:*",
 		"@automattic/jetpack-analytics": "workspace:*",
 		"@automattic/jetpack-components": "workspace:*",
 		"@automattic/jetpack-connection": "workspace:*",

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -239,7 +239,8 @@
 
 .jetpack-contact-form.is-placeholder {
 	background-color: #fff;
-	border: 1px solid #1e1e1e;
+	border: 1px solid #ddd;
+	border-radius: 4px;
 	padding: 24px;
 
 	.components-placeholder {
@@ -262,6 +263,204 @@
 			text-align: left;
 		}
 	}
+
+	// Header section
+	.form-placeholder__header {
+		display: flex;
+		align-items: center;
+		gap: 10px;
+		margin-bottom: 0;
+	}
+
+	.form-placeholder__header-icon {
+		flex-shrink: 0;
+		width: 24px;
+		height: 24px;
+		fill: currentColor;
+	}
+
+	.form-placeholder__header-title {
+		font-size: 16px;
+		font-weight: 600;
+		color: #1e1e1e;
+	}
+
+	// AI Prompt input section
+	.form-placeholder__prompt {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+		margin: 0;
+		background-color: #fff;
+		border: 1px solid #ddd;
+		border-radius: 28px;
+		padding: 4px 4px 4px 16px;
+
+		.components-base-control {
+			flex: 1;
+			margin-bottom: 0;
+		}
+
+		.components-base-control__field {
+			margin-bottom: 0;
+		}
+
+		.components-text-control__input,
+		input[type="text"],
+		input:not([type="submit"]):not([type="checkbox"]):not([type="radio"]):not([type="range"]) {
+			background: transparent;
+			border: none !important;
+			box-shadow: none !important;
+			flex: 1;
+			font-size: 16px;
+			padding: 10px 0;
+			margin: 0;
+			min-height: auto;
+			height: auto;
+			line-height: 1.4;
+			outline: none !important;
+
+			&:focus {
+				box-shadow: none !important;
+				outline: none !important;
+				border: none !important;
+			}
+
+			&::placeholder {
+				color: #757575;
+			}
+		}
+	}
+
+	.form-placeholder__prompt-submit {
+		background-color: #f0f0f0;
+		border-radius: 50%;
+		width: 40px;
+		height: 40px;
+		min-width: 40px;
+		padding: 0;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		flex-shrink: 0;
+		border: none;
+
+		&:hover:not(:disabled) {
+			background-color: #e0e0e0;
+		}
+
+		&:disabled {
+			opacity: 0.4;
+		}
+
+		svg {
+			width: 24px;
+			height: 24px;
+			fill: #1e1e1e;
+		}
+	}
+
+	// Template grid section
+	.form-placeholder__grid {
+		display: grid;
+		grid-template-columns: repeat(3, minmax(0, 1fr));
+		gap: 20px;
+		margin-bottom: 24px;
+
+		@media (max-width: 782px) {
+			grid-template-columns: repeat(2, minmax(0, 1fr));
+		}
+
+		@media (max-width: 480px) {
+			grid-template-columns: minmax(0, 1fr);
+		}
+	}
+
+	.form-placeholder__template-card {
+		cursor: pointer;
+		border-radius: 4px;
+		transition: box-shadow 0.15s ease;
+		min-width: 0; // Prevent grid blowout
+
+		&:hover,
+		&:focus {
+			outline: none;
+
+			.form-placeholder__template-preview {
+				border-color: #007cba;
+				box-shadow: 0 0 0 1px #007cba;
+			}
+		}
+	}
+
+	.form-placeholder__template-preview {
+		background: #f6f7f7;
+		border: 1px solid #e0e0e0;
+		border-radius: 8px;
+		overflow: hidden;
+		height: 180px;
+		margin-bottom: 12px;
+		transition: border-color 0.15s ease, box-shadow 0.15s ease;
+
+		// Ensure the preview container fills and clips
+		.block-editor-block-preview__container {
+			overflow: hidden;
+			width: 100%;
+			height: 100%;
+		}
+
+		// Scale down the preview content
+		.block-editor-block-preview__content {
+			transform-origin: top left;
+		}
+
+		// Hide any iframe scrollbars
+		iframe {
+			pointer-events: none;
+		}
+	}
+
+	.form-placeholder__template-label {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+		font-size: 14px;
+		font-weight: 500;
+		color: #1e1e1e;
+	}
+
+	.form-placeholder__template-icon {
+		flex-shrink: 0;
+		width: 20px;
+		height: 20px;
+		fill: currentColor;
+	}
+
+	.form-placeholder__template-title {
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+	}
+
+	// Actions section
+	.form-placeholder__actions {
+		display: flex;
+		justify-content: center;
+		margin-bottom: 16px;
+	}
+
+	.form-placeholder__view-all {
+		width: 100%;
+		justify-content: center;
+		border-color: #007cba;
+		color: #007cba;
+
+		&:hover {
+			border-color: #006ba1;
+			color: #006ba1;
+		}
+	}
+
 }
 
 .is-form-empty .block-editor-inserter {

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -287,31 +287,55 @@
 
 	// AI Prompt input section
 	.form-placeholder__prompt {
-		display: flex;
-		align-items: center;
-		gap: 8px;
 		margin: 0;
-		background-color: #fff;
-		border: 1px solid #ddd;
-		border-radius: 28px;
-		padding: 4px 4px 4px 16px;
 
-		.components-base-control {
+		// Remove all shadows from AIControl
+		*,
+		*::before,
+		*::after {
+			box-shadow: none !important;
+		}
+
+		// Override AIControl container styles
+		.jetpack-components-ai-control__container-wrapper {
+			margin: 0;
+			box-shadow: none !important;
+		}
+
+		.jetpack-components-ai-control__container {
+			margin: 0;
+			box-shadow: none;
+			border: none;
+		}
+
+		.jetpack-components-ai-control__wrapper {
+			background-color: #fff;
+			border: 1px solid #ddd;
+			border-radius: 28px;
+			padding: 4px 6px 4px 20px;
+			box-shadow: none !important;
+			min-height: auto;
+			gap: 8px;
+
+			&:focus-within {
+				border-color: #ddd;
+				box-shadow: none !important;
+			}
+		}
+
+		// Hide the AI status indicator
+		.jetpack-components-ai-status-indicator {
+			display: none;
+		}
+
+		.jetpack-components-ai-control__input-wrapper {
 			flex: 1;
-			margin-bottom: 0;
 		}
 
-		.components-base-control__field {
-			margin-bottom: 0;
-		}
-
-		.components-text-control__input,
-		input[type="text"],
-		input:not([type="submit"]):not([type="checkbox"]):not([type="radio"]):not([type="range"]) {
+		.jetpack-components-ai-control__input {
 			background: transparent;
 			border: none !important;
 			box-shadow: none !important;
-			flex: 1;
 			font-size: 16px;
 			padding: 10px 0;
 			margin: 0;
@@ -467,12 +491,11 @@
 	width: 100%;
 }
 
-.form-placeholder__patterns-modal {
-	max-width: 1200px;
+.form-placeholder__forms-modal {
+	max-width: 900px;
 
 	@include gb.break-small() {
 		width: calc(100% - #{ gb.$grid-unit-20 * 2 });
-		height: calc(100% - #{ gb.$header-height * 2 });
 	}
 
 	@include gb.break-medium() {
@@ -480,33 +503,33 @@
 	}
 
 	@include gb.break-large() {
-		height: 80%;
 		width: 80%;
-		max-height: none;
+		max-width: 900px;
 	}
 
 	.components-modal__content {
-		padding: 0;
-		margin-bottom: 60px;
-
-		.view-mode-carousel {
-
-			.carousel-container {
-				margin-bottom: 20px;
-			}
-
-			.pattern-slide {
-				border: 1px solid #ddd;
-			}
-
-			.block-editor-block-pattern-setup__container {
-				padding: 0 32px;
-			}
-		}
+		padding: 20px;
 	}
 
-	.block-editor-block-pattern-setup__grid .block-editor-block-pattern-setup__container {
-		padding-bottom: 72px;
+	.form-placeholder__forms-loading {
+		display: flex;
+		justify-content: center;
+		align-items: center;
+		min-height: 200px;
+	}
+
+	.form-placeholder__forms-grid {
+		display: grid;
+		grid-template-columns: repeat(2, minmax(0, 1fr));
+		gap: 20px;
+
+		@include gb.break-medium() {
+			grid-template-columns: repeat(3, minmax(0, 1fr));
+		}
+
+		.form-placeholder__template-card {
+			margin: 0;
+		}
 	}
 }
 

--- a/projects/packages/forms/src/blocks/contact-form/variation-picker.js
+++ b/projects/packages/forms/src/blocks/contact-form/variation-picker.js
@@ -1,14 +1,15 @@
-import { hasFeatureFlag } from '@automattic/jetpack-shared-extension-utils';
+import { AIControl, useAiSuggestions } from '@automattic/jetpack-ai-client';
 import {
-	__experimentalBlockPatternSetup as BlockPatternSetup, // eslint-disable-line @wordpress/no-unsafe-wp-apis
-	BlockPreview,
-	store as blockEditorStore,
-} from '@wordpress/block-editor';
-import { createBlock, store as blocksStore } from '@wordpress/blocks';
-import { Button, Modal, TextControl, Icon } from '@wordpress/components';
+	hasFeatureFlag,
+	getJetpackExtensionAvailability,
+} from '@automattic/jetpack-shared-extension-utils';
+import { BlockPreview, store as blockEditorStore } from '@wordpress/block-editor';
+import { createBlock, parse, store as blocksStore } from '@wordpress/blocks';
+import { Button, Modal, Icon, Spinner } from '@wordpress/components';
+import { store as coreStore } from '@wordpress/core-data';
 import { useDispatch, useRegistry, useSelect } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
-import { useEffect, useState, useMemo } from '@wordpress/element';
+import { useEffect, useState, useMemo, memo, useCallback, useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { arrowUp, symbolFilled } from '@wordpress/icons';
 import { store as noticesStore } from '@wordpress/notices';
@@ -41,15 +42,61 @@ const createBlocksFromExample = innerBlocks => {
 	);
 };
 
+// Stable reference for additionalStyles to prevent BlockPreview re-renders
+const PREVIEW_ADDITIONAL_STYLES = [ { css: '.is-root-container { padding: 32px; }' } ];
+
+/**
+ * Fix incomplete HTML by using the browser's parser.
+ *
+ * @param {string} html - The HTML to fix
+ * @return {string} Fixed HTML
+ */
+const fixIncompleteHTML = html => {
+	const div = document.createElement( 'div' );
+	div.innerHTML = html;
+	return div.innerHTML;
+};
+
+/**
+ * Process AI suggestion content to extract valid form blocks.
+ * Based on JetpackFormHandler.setContent from the AI assistant extension.
+ *
+ * @param {string} content - The AI-generated content
+ * @return {Array} Array of valid blocks
+ */
+const processAiFormContent = content => {
+	// Remove the Jetpack Form block wrapper from the content
+	const processedContent = content.replace(
+		/<!-- (\/)*wp:jetpack\/(contact-)*form ({[^}]*} )*(\/)*-->/g,
+		''
+	);
+
+	// Fix incomplete HTML tags
+	const fixedContent = fixIncompleteHTML( processedContent );
+
+	// Parse the content into blocks
+	const parsedBlocks = parse( fixedContent );
+
+	// Filter out invalid or problematic blocks
+	const validBlocks = parsedBlocks.filter( block => {
+		return (
+			block.isValid && ! [ 'core/freeform', 'core/missing', 'core/html' ].includes( block.name )
+		);
+	} );
+
+	return validBlocks;
+};
+
 /**
  * Component to render a preview of a form template variation.
+ * Memoized to prevent re-renders when parent state changes (e.g., typing in AI input).
  *
  * @param {object}   props           - Component props
  * @param {object}   props.variation - The form variation to preview
  * @param {Function} props.onClick   - Click handler when preview is selected
  * @return {JSX.Element} The form template preview component
  */
-function FormTemplatePreview( { variation, onClick } ) {
+const FormTemplatePreview = memo( function FormTemplatePreview( { variation, onClick } ) {
 	const previewBlocks = useMemo( () => {
 		// Prefer example data if available (object format), otherwise use innerBlocks (template format)
 		if ( variation.example?.innerBlocks ) {
@@ -66,26 +113,34 @@ function FormTemplatePreview( { variation, onClick } ) {
 		return createBlock( 'jetpack/contact-form', variation.attributes || {}, previewBlocks );
 	}, [ variation.attributes, previewBlocks ] );
 
+	// Memoize the blocks array to prevent BlockPreview re-renders
+	const blocks = useMemo( () => [ formBlock ], [ formBlock ] );
+
+	const handleKeyDown = useCallback(
+		event => {
+			if ( event.key === 'Enter' || event.key === ' ' ) {
+				event.preventDefault();
+				onClick();
+			}
+		},
+		[ onClick ]
+	);
+
 	return (
 		<div
 			className="form-placeholder__template-card"
 			onClick={ onClick }
-			onKeyDown={ event => {
-				if ( event.key === 'Enter' || event.key === ' ' ) {
-					event.preventDefault();
-					onClick();
-				}
-			} }
+			onKeyDown={ handleKeyDown }
 			role="button"
 			tabIndex={ 0 }
 			aria-label={ variation.title }
 		>
 			<div className="form-placeholder__template-preview">
 				<BlockPreview
-					blocks={ [ formBlock ] }
+					blocks={ blocks }
 					viewportWidth={ 600 }
 					minHeight={ 160 }
-					additionalStyles={ [ { css: '.is-root-container { padding: 32px; }' } ] }
+					additionalStyles={ PREVIEW_ADDITIONAL_STYLES }
 				/>
 			</div>
 			<div className="form-placeholder__template-label">
@@ -94,19 +149,97 @@ function FormTemplatePreview( { variation, onClick } ) {
 			</div>
 		</div>
 	);
-}
+} );
+
+/**
+ * Component to render a preview of an existing form from the jetpack_form post type.
+ * Memoized to prevent re-renders.
+ *
+ * @param {object}   props         - Component props
+ * @param {object}   props.form    - The form post object
+ * @param {Function} props.onClick - Click handler when form is selected
+ * @return {JSX.Element} The existing form preview component
+ */
+const ExistingFormPreview = memo( function ExistingFormPreview( { form, onClick } ) {
+	// Parse the form content to get blocks for preview
+	const blocks = useMemo( () => {
+		if ( ! form?.content?.raw ) {
+			return [];
+		}
+		const parsedBlocks = parse( form.content.raw );
+		return parsedBlocks.length > 0 ? parsedBlocks : [];
+	}, [ form?.content?.raw ] );
+
+	const handleKeyDown = useCallback(
+		event => {
+			if ( event.key === 'Enter' || event.key === ' ' ) {
+				event.preventDefault();
+				onClick();
+			}
+		},
+		[ onClick ]
+	);
+
+	const title = form?.title?.rendered || form?.title?.raw || __( 'Untitled Form', 'jetpack-forms' );
+
+	return (
+		<div
+			className="form-placeholder__template-card"
+			onClick={ onClick }
+			onKeyDown={ handleKeyDown }
+			role="button"
+			tabIndex={ 0 }
+			aria-label={ title }
+		>
+			<div className="form-placeholder__template-preview">
+				<BlockPreview
+					blocks={ blocks }
+					viewportWidth={ 600 }
+					minHeight={ 160 }
+					additionalStyles={ PREVIEW_ADDITIONAL_STYLES }
+				/>
+			</div>
+			<div className="form-placeholder__template-label">
+				<Icon icon={ symbolFilled } className="form-placeholder__template-icon" />
+				<span className="form-placeholder__template-title">{ title }</span>
+			</div>
+		</div>
+	);
+} );
 
 export default function VariationPicker( { blockName, setAttributes, clientId, classNames } ) {
 	const registry = useRegistry();
-	const [ isPatternsModalOpen, setIsPatternsModalOpen ] = useState( false );
+	const [ isFormsModalOpen, setIsFormsModalOpen ] = useState( false );
 	const [ promptValue, setPromptValue ] = useState( '' );
 	const { replaceInnerBlocks, selectBlock } = useDispatch( blockEditorStore );
-	const { createSuccessNotice } = useDispatch( noticesStore );
+	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
 	const isCentralFormManagementEnabled = hasFeatureFlag( 'central-form-management' );
-	const { blockType, defaultVariation, variations, currentPostType, currentPostId } = useSelect(
+	const isAiAssistantAvailable = getJetpackExtensionAvailability( 'ai-assistant' ).available;
+
+	// Track valid blocks during streaming for progressive updates
+	const currentValidBlocksRef = useRef( [] );
+
+	const {
+		blockType,
+		defaultVariation,
+		variations,
+		currentPostType,
+		currentPostId,
+		existingForms,
+		isLoadingForms,
+	} = useSelect(
 		select => {
 			const { getBlockType, getBlockVariations, getDefaultBlockVariation } = select( blocksStore );
 			const { getCurrentPostType, getCurrentPostId } = select( editorStore );
+			const { getEntityRecords, isResolving } = select( coreStore );
+
+			// Fetch existing forms from jetpack_form post type
+			const forms = getEntityRecords( 'postType', FORM_POST_TYPE, {
+				per_page: 100,
+				status: 'publish',
+				orderby: 'modified',
+				order: 'desc',
+			} );
 
 			return {
 				blockType: getBlockType( blockName ),
@@ -114,6 +247,12 @@ export default function VariationPicker( { blockName, setAttributes, clientId, c
 				variations: getBlockVariations( blockName, 'block' ),
 				currentPostType: getCurrentPostType(),
 				currentPostId: getCurrentPostId(),
+				existingForms: forms || [],
+				isLoadingForms: isResolving( 'getEntityRecords', [
+					'postType',
+					FORM_POST_TYPE,
+					{ per_page: 100, status: 'publish', orderby: 'modified', order: 'desc' },
+				] ),
 			};
 		},
 		[ blockName ]
@@ -132,71 +271,119 @@ export default function VariationPicker( { blockName, setAttributes, clientId, c
 		return displayVariations.slice( 0, 6 );
 	}, [ displayVariations ] );
 
+	// Handle AI suggestion streaming - update form blocks progressively
+	const handleAiSuggestion = useCallback(
+		suggestion => {
+			const validBlocks = processAiFormContent( suggestion );
+
+			// Only update if we have new valid blocks
+			if ( validBlocks.length > 0 && validBlocks.length >= currentValidBlocksRef.current.length ) {
+				currentValidBlocksRef.current = validBlocks;
+				replaceInnerBlocks( clientId, validBlocks );
+			}
+		},
+		[ clientId, replaceInnerBlocks ]
+	);
+
+	// Handle AI completion - finalize the form
+	const handleAiDone = useCallback(
+		suggestion => {
+			const validBlocks = processAiFormContent( suggestion );
+
+			// Ensure we have at least a submit button
+			const hasButton = validBlocks.some( block => block.name === 'jetpack/button' );
+			const hasNavigation = validBlocks.some(
+				block => block.name === 'jetpack/form-step-navigation'
+			);
+
+			let finalBlocks = validBlocks;
+
+			if ( ! hasButton && ! hasNavigation && validBlocks.length > 0 ) {
+				// Add a submit button if missing
+				finalBlocks = [
+					...validBlocks,
+					createBlock( 'jetpack/button', {
+						label: __( 'Submit', 'jetpack-forms' ),
+						element: 'button',
+						text: __( 'Submit', 'jetpack-forms' ),
+						borderRadius: 8,
+						lock: { remove: true },
+					} ),
+				];
+			}
+
+			if ( finalBlocks.length > 0 ) {
+				registry.batch( () => {
+					replaceInnerBlocks( clientId, finalBlocks );
+					selectBlock( clientId );
+				} );
+
+				createSuccessNotice( __( 'Form created with AI.', 'jetpack-forms' ), {
+					type: 'snackbar',
+					isDismissible: true,
+				} );
+			}
+
+			// Reset tracking ref
+			currentValidBlocksRef.current = [];
+			setPromptValue( '' );
+		},
+		[ clientId, createSuccessNotice, registry, replaceInnerBlocks, selectBlock ]
+	);
+
+	// Handle AI errors
+	const handleAiError = useCallback(
+		error => {
+			// eslint-disable-next-line no-console
+			console.error( 'AI form generation error:', error );
+			createErrorNotice(
+				error?.message || __( 'Failed to generate form. Please try again.', 'jetpack-forms' ),
+				{
+					type: 'snackbar',
+					isDismissible: true,
+				}
+			);
+			currentValidBlocksRef.current = [];
+		},
+		[ createErrorNotice ]
+	);
+
+	// Setup the AI suggestions hook
+	const {
+		request: requestAiSuggestion,
+		requestingState,
+		stopSuggestion,
+	} = useAiSuggestions( {
+		onSuggestion: handleAiSuggestion,
+		onDone: handleAiDone,
+		onError: handleAiError,
+		askQuestionOptions: {
+			postId: currentPostId,
+			feature: 'jetpack-form-ai-extension',
+		},
+	} );
+
+	const isAiGenerating = requestingState === 'requesting' || requestingState === 'suggesting';
+
 	useEffect( () => {
-		if (
-			! isPatternsModalOpen &&
-			window.location.search.indexOf( 'showJetpackFormsPatterns' ) !== -1
-		) {
-			setIsPatternsModalOpen( true );
+		if ( ! isFormsModalOpen && window.location.search.indexOf( 'showJetpackFormsModal' ) !== -1 ) {
+			setIsFormsModalOpen( true );
 		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [] );
 
-	const handleVariationSelect = async ( nextVariation = defaultVariation ) => {
-		// If we're editing a jetpack-form post directly, or central form management
-		// is disabled, use the "old" behavior: apply the variation directly to this
-		// block by setting attributes and inner blocks, without creating a synced
-		// form post (i.e., without creating or updating a ref). This avoids relying
-		// on central form management when it is not available or not appropriate.
-		if (
-			isEditingJetpackFormPost ||
-			! isCentralFormManagementEnabled ||
-			nextVariation.name === 'regular-form'
-		) {
-			applyVariationToFormBlock( {
-				batch: registry.batch,
-				setAttributes,
-				replaceInnerBlocks,
-				selectBlock,
-				clientId,
-				variation: nextVariation,
-				createBlocksFromTemplate: createBlocksFromInnerBlocksTemplate,
-			} );
-		} else {
-			// We're editing a regular post/page - create a synced form with ref
-			try {
-				// Create inner blocks from template
-				const innerBlocks = createBlocksFromInnerBlocksTemplate( nextVariation.innerBlocks );
-
-				// Create the full jetpack/contact-form block with attributes and inner blocks
-				const formBlockToCreate = createBlock(
-					'jetpack/contact-form',
-					nextVariation.attributes || {},
-					innerBlocks
-				);
-
-				// Create synced form post and get its ID
-				const formId = await createSyncedForm(
-					formBlockToCreate,
-					nextVariation.title || 'Form',
-					currentPostId
-				);
-
-				// Set ONLY ref attribute
-				registry.batch( () => {
-					setAttributes( { ref: formId } );
-					selectBlock( clientId );
-				} );
-
-				// Show success notice
-				createSuccessNotice( __( 'New form created.', 'jetpack-forms' ), {
-					type: 'snackbar',
-					isDismissible: true,
-				} );
-			} catch ( error ) {
-				// eslint-disable-next-line no-console
-				console.error( 'Failed to create synced form:', error );
-				// Fallback to applying variation locally
+	const handleVariationSelect = useCallback(
+		async ( nextVariation = defaultVariation ) => {
+			// If we're editing a jetpack-form post directly, or central form management
+			// is disabled, use the "old" behavior: apply the variation directly to this
+			// block by setting attributes and inner blocks, without creating a synced
+			// form post (i.e., without creating or updating a ref). This avoids relying
+			// on central form management when it is not available or not appropriate.
+			if (
+				isEditingJetpackFormPost ||
+				! isCentralFormManagementEnabled ||
+				nextVariation.name === 'regular-form'
+			) {
 				applyVariationToFormBlock( {
 					batch: registry.batch,
 					setAttributes,
@@ -206,16 +393,119 @@ export default function VariationPicker( { blockName, setAttributes, clientId, c
 					variation: nextVariation,
 					createBlocksFromTemplate: createBlocksFromInnerBlocksTemplate,
 				} );
-			}
-		}
-	};
+			} else {
+				// We're editing a regular post/page - create a synced form with ref
+				try {
+					// Create inner blocks from template
+					const innerBlocks = createBlocksFromInnerBlocksTemplate( nextVariation.innerBlocks );
 
-	const handlePromptSubmit = () => {
-		// TODO: Implement AI form generation with promptValue
-		// For now, this is a placeholder for future AI integration
-		// eslint-disable-next-line no-console
-		console.log( 'Form prompt submitted:', promptValue );
-	};
+					// Create the full jetpack/contact-form block with attributes and inner blocks
+					const formBlockToCreate = createBlock(
+						'jetpack/contact-form',
+						nextVariation.attributes || {},
+						innerBlocks
+					);
+
+					// Create synced form post and get its ID
+					const formId = await createSyncedForm(
+						formBlockToCreate,
+						nextVariation.title || 'Form',
+						currentPostId
+					);
+
+					// Set ONLY ref attribute
+					registry.batch( () => {
+						setAttributes( { ref: formId } );
+						selectBlock( clientId );
+					} );
+
+					// Show success notice
+					createSuccessNotice( __( 'New form created.', 'jetpack-forms' ), {
+						type: 'snackbar',
+						isDismissible: true,
+					} );
+				} catch ( error ) {
+					// eslint-disable-next-line no-console
+					console.error( 'Failed to create synced form:', error );
+					// Fallback to applying variation locally
+					applyVariationToFormBlock( {
+						batch: registry.batch,
+						setAttributes,
+						replaceInnerBlocks,
+						selectBlock,
+						clientId,
+						variation: nextVariation,
+						createBlocksFromTemplate: createBlocksFromInnerBlocksTemplate,
+					} );
+				}
+			}
+		},
+		[
+			clientId,
+			createSuccessNotice,
+			currentPostId,
+			defaultVariation,
+			isCentralFormManagementEnabled,
+			isEditingJetpackFormPost,
+			registry,
+			replaceInnerBlocks,
+			selectBlock,
+			setAttributes,
+		]
+	);
+
+	const handlePromptSubmit = useCallback( () => {
+		if ( ! promptValue.trim() || isAiGenerating ) {
+			return;
+		}
+
+		// Build the prompt message for form generation
+		const messages = [
+			{
+				role: 'jetpack-ai',
+				context: {
+					type: 'form-ai-extension',
+					content: '', // Empty form content since we're creating a new form
+					request: promptValue.trim(),
+				},
+			},
+		];
+
+		// Reset tracking ref before starting
+		currentValidBlocksRef.current = [];
+
+		// Send the AI request
+		requestAiSuggestion( messages );
+	}, [ promptValue, isAiGenerating, requestAiSuggestion ] );
+
+	// Handle stopping the AI generation
+	const handleStopGeneration = useCallback( () => {
+		stopSuggestion();
+		currentValidBlocksRef.current = [];
+	}, [ stopSuggestion ] );
+
+	// Handle selecting an existing form
+	const handleExistingFormSelect = useCallback(
+		form => {
+			if ( ! form?.id ) {
+				return;
+			}
+
+			// Set the ref attribute to use the existing form
+			registry.batch( () => {
+				setAttributes( { ref: form.id } );
+				selectBlock( clientId );
+			} );
+
+			setIsFormsModalOpen( false );
+
+			createSuccessNotice( __( 'Existing form selected.', 'jetpack-forms' ), {
+				type: 'snackbar',
+				isDismissible: true,
+			} );
+		},
+		[ clientId, createSuccessNotice, registry, selectBlock, setAttributes ]
+	);
 
 	return (
 		<div className={ clsx( classNames, 'is-placeholder' ) }>
@@ -229,27 +519,37 @@ export default function VariationPicker( { blockName, setAttributes, clientId, c
 				</span>
 			</div>
 
-			{ /* AI Prompt Input */ }
-			<div className="form-placeholder__prompt">
-				<TextControl
-					__nextHasNoMarginBottom
-					placeholder={ __( 'Type your form questions or goal…', 'jetpack-forms' ) }
-					value={ promptValue }
-					onChange={ setPromptValue }
-					onKeyDown={ event => {
-						if ( event.key === 'Enter' && promptValue.trim() ) {
-							handlePromptSubmit();
+			{ /* AI Prompt Input - only shown when AI Assistant is available */ }
+			{ isAiAssistantAvailable && (
+				<div className="form-placeholder__prompt">
+					<AIControl
+						placeholder={ __( 'Type your form questions or goal…', 'jetpack-forms' ) }
+						value={ promptValue }
+						onChange={ setPromptValue }
+						disabled={ isAiGenerating }
+						state="init"
+						actions={
+							isAiGenerating ? (
+								<Button
+									className="form-placeholder__prompt-submit"
+									onClick={ handleStopGeneration }
+									label={ __( 'Stop generating', 'jetpack-forms' ) }
+								>
+									<Spinner />
+								</Button>
+							) : (
+								<Button
+									className="form-placeholder__prompt-submit"
+									icon={ arrowUp }
+									onClick={ handlePromptSubmit }
+									disabled={ ! promptValue.trim() }
+									label={ __( 'Generate form', 'jetpack-forms' ) }
+								/>
+							)
 						}
-					} }
-				/>
-				<Button
-					className="form-placeholder__prompt-submit"
-					icon={ arrowUp }
-					onClick={ handlePromptSubmit }
-					disabled={ ! promptValue.trim() }
-					label={ __( 'Generate form', 'jetpack-forms' ) }
-				/>
-			</div>
+					/>
+				</div>
+			) }
 
 			{ /* Template Grid */ }
 			<div className="form-placeholder__grid">
@@ -262,33 +562,47 @@ export default function VariationPicker( { blockName, setAttributes, clientId, c
 				) ) }
 			</div>
 
-			{ /* View All Forms Button */ }
-			<div className="form-placeholder__actions">
-				<Button
-					__next40pxDefaultSize
-					variant="secondary"
-					className="form-placeholder__view-all"
-					onClick={ () => setIsPatternsModalOpen( true ) }
-				>
-					{ __( 'View all forms', 'jetpack-forms' ) }
-				</Button>
-			</div>
+			{ /* View All Forms Button - only show if there are existing forms */ }
+			{ existingForms.length > 0 && (
+				<div className="form-placeholder__actions">
+					<Button
+						__next40pxDefaultSize
+						variant="secondary"
+						className="form-placeholder__view-all"
+						onClick={ () => setIsFormsModalOpen( true ) }
+					>
+						{ __( 'Choose existing form', 'jetpack-forms' ) }
+					</Button>
+				</div>
+			) }
 
-			{ /* Patterns Modal */ }
-			{ isPatternsModalOpen && (
+			{ /* Existing Forms Modal */ }
+			{ isFormsModalOpen && (
 				<Modal
-					className="form-placeholder__patterns-modal"
-					title={ __( 'Choose a pattern', 'jetpack-forms' ) }
+					className="form-placeholder__forms-modal"
+					title={ __( 'Choose a form', 'jetpack-forms' ) }
 					closeLabel={ __( 'Cancel', 'jetpack-forms' ) }
-					onRequestClose={ () => setIsPatternsModalOpen( false ) }
+					onRequestClose={ () => setIsFormsModalOpen( false ) }
 				>
-					<BlockPatternSetup
-						initialViewMode="grid"
-						filterPatternsFn={ pattern => {
-							return pattern.content.indexOf( 'jetpack/contact-form' ) !== -1;
-						} }
-						clientId={ clientId }
-					/>
+					{ isLoadingForms && (
+						<div className="form-placeholder__forms-loading">
+							<Spinner />
+						</div>
+					) }
+					{ ! isLoadingForms && existingForms.length === 0 && (
+						<p>{ __( 'No forms found.', 'jetpack-forms' ) }</p>
+					) }
+					{ ! isLoadingForms && existingForms.length > 0 && (
+						<div className="form-placeholder__forms-grid">
+							{ existingForms.map( form => (
+								<ExistingFormPreview
+									key={ form.id }
+									form={ form }
+									onClick={ () => handleExistingFormSelect( form ) }
+								/>
+							) ) }
+						</div>
+					) }
 				</Modal>
 			) }
 		</div>

--- a/projects/packages/forms/src/blocks/contact-form/variation-picker.js
+++ b/projects/packages/forms/src/blocks/contact-form/variation-picker.js
@@ -1,23 +1,22 @@
 import { hasFeatureFlag } from '@automattic/jetpack-shared-extension-utils';
 import {
-	__experimentalBlockVariationPicker as BlockVariationPicker, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 	__experimentalBlockPatternSetup as BlockPatternSetup, // eslint-disable-line @wordpress/no-unsafe-wp-apis
+	BlockPreview,
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import { createBlock, store as blocksStore } from '@wordpress/blocks';
-import { Button, Modal, SelectControl } from '@wordpress/components';
-import { store as coreStore } from '@wordpress/core-data';
+import { Button, Modal, TextControl, Icon } from '@wordpress/components';
 import { useDispatch, useRegistry, useSelect } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
-import { useEffect, useState } from '@wordpress/element';
+import { useEffect, useState, useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { arrowUp, symbolFilled } from '@wordpress/icons';
 import { store as noticesStore } from '@wordpress/notices';
 import clsx from 'clsx';
 import { FORM_POST_TYPE } from '../shared/util/constants.js';
 import './util/form-styles.js';
 import applyVariationToFormBlock from './util/apply-variation.js';
 import { createSyncedForm } from './util/create-synced-form.ts';
-import { handleFormSelection } from './util/handle-form-selection.js';
 
 const createBlocksFromInnerBlocksTemplate = innerBlocksTemplate => {
 	const blocks = innerBlocksTemplate.map( ( [ blockName, attr, innerBlocks = [] ] ) =>
@@ -27,43 +26,111 @@ const createBlocksFromInnerBlocksTemplate = innerBlocksTemplate => {
 	return blocks;
 };
 
-// Stable references to avoid useSelect re-fetching on every render
-const EMPTY_FORMS_ARRAY = [];
-const FORMS_QUERY = {
-	per_page: 100,
-	status: 'publish',
-	orderby: 'modified',
+/**
+ * Creates blocks from an example innerBlocks structure (object format).
+ *
+ * @param {Array} innerBlocks - Array of block definitions in example format
+ * @return {Array} Array of created blocks
+ */
+const createBlocksFromExample = innerBlocks => {
+	if ( ! innerBlocks ) {
+		return [];
+	}
+	return innerBlocks.map( block =>
+		createBlock( block.name, block.attributes || {}, createBlocksFromExample( block.innerBlocks ) )
+	);
 };
+
+/**
+ * Component to render a preview of a form template variation.
+ *
+ * @param {object}   props           - Component props
+ * @param {object}   props.variation - The form variation to preview
+ * @param {Function} props.onClick   - Click handler when preview is selected
+ * @return {JSX.Element} The form template preview component
+ */
+function FormTemplatePreview( { variation, onClick } ) {
+	const previewBlocks = useMemo( () => {
+		// Prefer example data if available (object format), otherwise use innerBlocks (template format)
+		if ( variation.example?.innerBlocks ) {
+			return createBlocksFromExample( variation.example.innerBlocks );
+		}
+		if ( variation.innerBlocks ) {
+			return createBlocksFromInnerBlocksTemplate( variation.innerBlocks );
+		}
+		return [];
+	}, [ variation ] );
+
+	// Create a wrapper form block to preview
+	const formBlock = useMemo( () => {
+		return createBlock( 'jetpack/contact-form', variation.attributes || {}, previewBlocks );
+	}, [ variation.attributes, previewBlocks ] );
+
+	return (
+		<div
+			className="form-placeholder__template-card"
+			onClick={ onClick }
+			onKeyDown={ event => {
+				if ( event.key === 'Enter' || event.key === ' ' ) {
+					event.preventDefault();
+					onClick();
+				}
+			} }
+			role="button"
+			tabIndex={ 0 }
+			aria-label={ variation.title }
+		>
+			<div className="form-placeholder__template-preview">
+				<BlockPreview
+					blocks={ [ formBlock ] }
+					viewportWidth={ 600 }
+					minHeight={ 160 }
+					additionalStyles={ [ { css: '.is-root-container { padding: 32px; }' } ] }
+				/>
+			</div>
+			<div className="form-placeholder__template-label">
+				<Icon icon={ symbolFilled } className="form-placeholder__template-icon" />
+				<span className="form-placeholder__template-title">{ variation.title }</span>
+			</div>
+		</div>
+	);
+}
 
 export default function VariationPicker( { blockName, setAttributes, clientId, classNames } ) {
 	const registry = useRegistry();
 	const [ isPatternsModalOpen, setIsPatternsModalOpen ] = useState( false );
+	const [ promptValue, setPromptValue ] = useState( '' );
 	const { replaceInnerBlocks, selectBlock } = useDispatch( blockEditorStore );
 	const { createSuccessNotice } = useDispatch( noticesStore );
 	const isCentralFormManagementEnabled = hasFeatureFlag( 'central-form-management' );
-	const { blockType, defaultVariation, variations, currentPostType, currentPostId, jetpackForms } =
-		useSelect(
-			select => {
-				const { getBlockType, getBlockVariations, getDefaultBlockVariation } =
-					select( blocksStore );
-				const { getCurrentPostType, getCurrentPostId } = select( editorStore );
-				const { getEntityRecords } = select( coreStore );
+	const { blockType, defaultVariation, variations, currentPostType, currentPostId } = useSelect(
+		select => {
+			const { getBlockType, getBlockVariations, getDefaultBlockVariation } = select( blocksStore );
+			const { getCurrentPostType, getCurrentPostId } = select( editorStore );
 
-				return {
-					blockType: getBlockType( blockName ),
-					defaultVariation: getDefaultBlockVariation( blockName, 'block' ),
-					variations: getBlockVariations( blockName, 'block' ),
-					currentPostType: getCurrentPostType(),
-					currentPostId: getCurrentPostId(),
-					jetpackForms:
-						getEntityRecords( 'postType', FORM_POST_TYPE, FORMS_QUERY ) ?? EMPTY_FORMS_ARRAY,
-				};
-			},
-			[ blockName ]
-		);
+			return {
+				blockType: getBlockType( blockName ),
+				defaultVariation: getDefaultBlockVariation( blockName, 'block' ),
+				variations: getBlockVariations( blockName, 'block' ),
+				currentPostType: getCurrentPostType(),
+				currentPostId: getCurrentPostId(),
+			};
+		},
+		[ blockName ]
+	);
 
 	// Check if we're editing a jetpack-form post directly
 	const isEditingJetpackFormPost = currentPostType === FORM_POST_TYPE;
+
+	// Filter variations for display (exclude hidden ones and regular-form which is for transforms)
+	const displayVariations = useMemo( () => {
+		return variations.filter( v => ! v.hiddenFromPicker && v.name !== 'regular-form' );
+	}, [ variations ] );
+
+	// Limit to 6 templates for the grid display
+	const gridVariations = useMemo( () => {
+		return displayVariations.slice( 0, 6 );
+	}, [ displayVariations ] );
 
 	useEffect( () => {
 		if (
@@ -75,119 +142,139 @@ export default function VariationPicker( { blockName, setAttributes, clientId, c
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [] );
 
-	const onFormSelect = formId => {
-		handleFormSelection( {
-			formId,
-			batch: registry.batch,
-			setAttributes,
-			selectBlock,
-			clientId,
-		} );
+	const handleVariationSelect = async ( nextVariation = defaultVariation ) => {
+		// If we're editing a jetpack-form post directly, or central form management
+		// is disabled, use the "old" behavior: apply the variation directly to this
+		// block by setting attributes and inner blocks, without creating a synced
+		// form post (i.e., without creating or updating a ref). This avoids relying
+		// on central form management when it is not available or not appropriate.
+		if (
+			isEditingJetpackFormPost ||
+			! isCentralFormManagementEnabled ||
+			nextVariation.name === 'regular-form'
+		) {
+			applyVariationToFormBlock( {
+				batch: registry.batch,
+				setAttributes,
+				replaceInnerBlocks,
+				selectBlock,
+				clientId,
+				variation: nextVariation,
+				createBlocksFromTemplate: createBlocksFromInnerBlocksTemplate,
+			} );
+		} else {
+			// We're editing a regular post/page - create a synced form with ref
+			try {
+				// Create inner blocks from template
+				const innerBlocks = createBlocksFromInnerBlocksTemplate( nextVariation.innerBlocks );
+
+				// Create the full jetpack/contact-form block with attributes and inner blocks
+				const formBlockToCreate = createBlock(
+					'jetpack/contact-form',
+					nextVariation.attributes || {},
+					innerBlocks
+				);
+
+				// Create synced form post and get its ID
+				const formId = await createSyncedForm(
+					formBlockToCreate,
+					nextVariation.title || 'Form',
+					currentPostId
+				);
+
+				// Set ONLY ref attribute
+				registry.batch( () => {
+					setAttributes( { ref: formId } );
+					selectBlock( clientId );
+				} );
+
+				// Show success notice
+				createSuccessNotice( __( 'New form created.', 'jetpack-forms' ), {
+					type: 'snackbar',
+					isDismissible: true,
+				} );
+			} catch ( error ) {
+				// eslint-disable-next-line no-console
+				console.error( 'Failed to create synced form:', error );
+				// Fallback to applying variation locally
+				applyVariationToFormBlock( {
+					batch: registry.batch,
+					setAttributes,
+					replaceInnerBlocks,
+					selectBlock,
+					clientId,
+					variation: nextVariation,
+					createBlocksFromTemplate: createBlocksFromInnerBlocksTemplate,
+				} );
+			}
+		}
+	};
+
+	const handlePromptSubmit = () => {
+		// TODO: Implement AI form generation with promptValue
+		// For now, this is a placeholder for future AI integration
+		// eslint-disable-next-line no-console
+		console.log( 'Form prompt submitted:', promptValue );
 	};
 
 	return (
 		<div className={ clsx( classNames, 'is-placeholder' ) }>
-			<BlockVariationPicker
-				icon={ blockType?.icon?.src }
-				label={ blockType?.title }
-				instructions={ __(
-					'Start by selecting one of these templates, browse patterns, or select an existing form below.',
-					'jetpack-forms'
+			{ /* Header */ }
+			<div className="form-placeholder__header">
+				{ blockType?.icon && (
+					<Icon icon={ blockType.icon.src } className="form-placeholder__header-icon" />
 				) }
-				variations={ variations.filter( v => ! v.hiddenFromPicker ) }
-				onSelect={ async ( nextVariation = defaultVariation ) => {
-					// If we're editing a jetpack-form post directly, or central form management
-					// is disabled, use the "old" behavior: apply the variation directly to this
-					// block by setting attributes and inner blocks, without creating a synced
-					// form post (i.e., without creating or updating a ref). This avoids relying
-					// on central form management when it is not available or not appropriate.
-					if (
-						isEditingJetpackFormPost ||
-						! isCentralFormManagementEnabled ||
-						nextVariation.name === 'regular-form'
-					) {
-						applyVariationToFormBlock( {
-							batch: registry.batch,
-							setAttributes,
-							replaceInnerBlocks,
-							selectBlock,
-							clientId,
-							variation: nextVariation,
-							createBlocksFromTemplate: createBlocksFromInnerBlocksTemplate,
-						} );
-					} else {
-						// We're editing a regular post/page - create a synced form with ref
-						try {
-							// Create inner blocks from template
-							const innerBlocks = createBlocksFromInnerBlocksTemplate( nextVariation.innerBlocks );
+				<span className="form-placeholder__header-title">
+					{ __( 'What form would you like to create?', 'jetpack-forms' ) }
+				</span>
+			</div>
 
-							// Create the full jetpack/contact-form block with attributes and inner blocks
-							const formBlock = createBlock(
-								'jetpack/contact-form',
-								nextVariation.attributes || {},
-								innerBlocks
-							);
-
-							// Create synced form post and get its ID
-							const formId = await createSyncedForm(
-								formBlock,
-								nextVariation.title || 'Form',
-								currentPostId
-							);
-
-							// Set ONLY ref attribute
-							registry.batch( () => {
-								setAttributes( { ref: formId } );
-								selectBlock( clientId );
-							} );
-
-							// Show success notice
-							createSuccessNotice( __( 'New form created.', 'jetpack-forms' ), {
-								type: 'snackbar',
-								isDismissible: true,
-							} );
-						} catch ( error ) {
-							// eslint-disable-next-line no-console
-							console.error( 'Failed to create synced form:', error );
-							// Fallback to applying variation locally
-							applyVariationToFormBlock( {
-								batch: registry.batch,
-								setAttributes,
-								replaceInnerBlocks,
-								selectBlock,
-								clientId,
-								variation: nextVariation,
-								createBlocksFromTemplate: createBlocksFromInnerBlocksTemplate,
-							} );
+			{ /* AI Prompt Input */ }
+			<div className="form-placeholder__prompt">
+				<TextControl
+					__nextHasNoMarginBottom
+					placeholder={ __( 'Type your form questions or goal…', 'jetpack-forms' ) }
+					value={ promptValue }
+					onChange={ setPromptValue }
+					onKeyDown={ event => {
+						if ( event.key === 'Enter' && promptValue.trim() ) {
+							handlePromptSubmit();
 						}
-					}
-				} }
-			/>
-			<div className="form-placeholder__shell">
+					} }
+				/>
+				<Button
+					className="form-placeholder__prompt-submit"
+					icon={ arrowUp }
+					onClick={ handlePromptSubmit }
+					disabled={ ! promptValue.trim() }
+					label={ __( 'Generate form', 'jetpack-forms' ) }
+				/>
+			</div>
+
+			{ /* Template Grid */ }
+			<div className="form-placeholder__grid">
+				{ gridVariations.map( variation => (
+					<FormTemplatePreview
+						key={ variation.name }
+						variation={ variation }
+						onClick={ () => handleVariationSelect( variation ) }
+					/>
+				) ) }
+			</div>
+
+			{ /* View All Forms Button */ }
+			<div className="form-placeholder__actions">
 				<Button
 					__next40pxDefaultSize
 					variant="secondary"
+					className="form-placeholder__view-all"
 					onClick={ () => setIsPatternsModalOpen( true ) }
 				>
-					{ __( 'Browse form patterns', 'jetpack-forms' ) }
+					{ __( 'View all forms', 'jetpack-forms' ) }
 				</Button>
 			</div>
-			{ ! isEditingJetpackFormPost && isCentralFormManagementEnabled && jetpackForms.length > 0 && (
-				<div className="form-placeholder__shell">
-					<SelectControl
-						__next40pxDefaultSize
-						label={ __( 'Or select an existing form', 'jetpack-forms' ) }
-						options={ [
-							{ label: __( 'Select a form…', 'jetpack-forms' ), value: '' },
-							...jetpackForms.map( form => ( {
-								label: form.title?.rendered || __( '(Untitled)', 'jetpack-forms' ),
-								value: form.id.toString(),
-							} ) ),
-						] }
-						onChange={ onFormSelect }
-					/>
-				</div>
-			) }
+
+			{ /* Patterns Modal */ }
 			{ isPatternsModalOpen && (
 				<Modal
 					className="form-placeholder__patterns-modal"


### PR DESCRIPTION
<img width="683" height="767" alt="Screenshot 2026-02-19 at 5 06 38 PM" src="https://github.com/user-attachments/assets/c436b71f-e679-4acf-b77a-5acc08700903" />


## Summary

Redesigns the form block placeholder component shown when users first insert a form block. The new design features:

- A 3x2 grid of form template previews using `BlockPreview` for visual selection
- AI prompt input field (placeholder for future AI form generation feature)
- Header with form block icon and clear title
- "View all forms" button to browse patterns
- Cleaner, more modern visual design

## Proposed changes

- Replace `BlockVariationPicker` with custom template preview grid using `BlockPreview`
- Add `FormTemplatePreview` component that renders live previews of form templates
- Add AI prompt input field with submit button (currently logs to console as placeholder)
- Update styles for improved visual design with fixed-width previews
- Remove "Or select an existing form" dropdown (simplifying the UI)
- Add consistent `symbolFilled` icon for all template labels

## Does this pull request change what data or activity we track or use?
No

## Testing instructions

1. Create a new post or page
2. Add a Form block (Jetpack Form)
3. Verify the new placeholder UI appears with:
   - Header showing form icon and "What form would you like to create?"
   - AI prompt input field with placeholder text
   - 3x2 grid of form template previews (Contact Form, RSVP Form, Registration Form, Appointment Form, Feedback Form, Multistep Form)
   - "View all forms" button at the bottom
4. Click on a template preview to verify it creates the form correctly
5. Click "View all forms" to verify the patterns modal opens
6. Test the AI prompt input field (should log to console when submitted)

## Screenshots

<!-- Add screenshots of the new placeholder UI -->

---

🤖 Generated with [Claude Code](https://claude.ai/code)