### PR TITLE
Sync: Minor fix for get_actor

### DIFF
--- a/projects/packages/sync/changelog/pr-47244
+++ b/projects/packages/sync/changelog/pr-47244
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Listener: Replace redundant filter_var with sanitize_text_field for user agent sanitization.

--- a/projects/packages/sync/src/class-listener.php
+++ b/projects/packages/sync/src/class-listener.php
@@ -450,7 +450,7 @@ class Listener {
 			$ip = IP_Utils::get_ip();
 
 			$actor['ip']         = $ip ? $ip : '';
-			$actor['user_agent'] = isset( $_SERVER['HTTP_USER_AGENT'] ) ? filter_var( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ) ) : 'unknown';
+			$actor['user_agent'] = isset( $_SERVER['HTTP_USER_AGENT'] ) ? sanitize_text_field( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ) ) : 'unknown';
 		}
 
 		$raw_mcp_header = '';

--- a/projects/plugins/jetpack/changelog/pr-47244
+++ b/projects/plugins/jetpack/changelog/pr-47244
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Internal: Add unit tests for MCP actor fields in sync listener.

--- a/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Listener_Test.php
+++ b/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Listener_Test.php
@@ -267,6 +267,79 @@ class Jetpack_Sync_Listener_Test extends Jetpack_Sync_TestBase {
 		$this->assertEquals( Health::STATUS_OUT_OF_SYNC, Health::get_status() );
 	}
 
+	public function test_does_listener_add_mcp_actor_fields_when_header_present() {
+		$user_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $user_id );
+		$queue = $this->listener->get_sync_queue();
+		$queue->reset();
+
+		$mcp_data                    = array(
+			'mcp_client_name'    => 'test-client',
+			'mcp_client_version' => '1.0.0',
+		);
+		$_SERVER['HTTP_X_WPCOM_MCP'] = base64_encode( wp_json_encode( $mcp_data, JSON_UNESCAPED_SLASHES ) );
+		self::factory()->post->create();
+
+		$all = $queue->get_all();
+		$this->assertNotEmpty( $all );
+
+		foreach ( $all as $queue_item ) {
+			list( , , , , , $actor ) = $queue_item->value;
+			$this->assertArrayHasKey( 'mcp_client_name', $actor );
+			$this->assertArrayHasKey( 'mcp_client_version', $actor );
+			$this->assertArrayHasKey( 'is_mcp_agent', $actor );
+			$this->assertEquals( 'test-client', $actor['mcp_client_name'] );
+			$this->assertEquals( '1.0.0', $actor['mcp_client_version'] );
+			$this->assertTrue( $actor['is_mcp_agent'] );
+		}
+	}
+
+	public function test_does_listener_not_add_mcp_actor_fields_when_header_invalid() {
+		$user_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $user_id );
+		$queue = $this->listener->get_sync_queue();
+		$queue->reset();
+
+		$_SERVER['HTTP_X_WPCOM_MCP'] = '!!!invalid-base64!!!';
+
+		self::factory()->post->create();
+
+		$all = $queue->get_all();
+		$this->assertNotEmpty( $all );
+
+		foreach ( $all as $queue_item ) {
+			list( , , , , , $actor ) = $queue_item->value;
+			$this->assertArrayNotHasKey( 'mcp_client_name', $actor );
+			$this->assertArrayNotHasKey( 'mcp_client_version', $actor );
+			$this->assertArrayNotHasKey( 'is_mcp_agent', $actor );
+		}
+	}
+
+	public function test_does_listener_add_mcp_actor_fields_with_partial_data() {
+		$user_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $user_id );
+		$queue = $this->listener->get_sync_queue();
+		$queue->reset();
+
+		$mcp_data                    = array(
+			'mcp_client_name' => 'partial-client',
+		);
+		$_SERVER['HTTP_X_WPCOM_MCP'] = base64_encode( wp_json_encode( $mcp_data, JSON_UNESCAPED_SLASHES ) );
+		self::factory()->post->create();
+
+		$all = $queue->get_all();
+		$this->assertNotEmpty( $all );
+
+		foreach ( $all as $queue_item ) {
+			list( , , , , , $actor ) = $queue_item->value;
+			$this->assertArrayHasKey( 'mcp_client_name', $actor );
+			$this->assertArrayNotHasKey( 'mcp_client_version', $actor );
+			$this->assertArrayHasKey( 'is_mcp_agent', $actor );
+			$this->assertEquals( 'partial-client', $actor['mcp_client_name'] );
+			$this->assertTrue( $actor['is_mcp_agent'] );
+		}
+	}
+
 	public function get_page_url() {
 		return 'http' . ( isset( $_SERVER['HTTPS'] ) ? 's' : '' ) . '://' . "{$_SERVER['HTTP_HOST']}{$_SERVER['REQUEST_URI']}";
 	}

--- a/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_TestBase.php
+++ b/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_TestBase.php
@@ -147,6 +147,7 @@ abstract class Jetpack_Sync_TestBase extends WP_UnitTestCase {
 	public function tear_down() {
 		parent::tear_down();
 		unset( $_SERVER['HTTP_USER_AGENT'] );
+		unset( $_SERVER['HTTP_X_WPCOM_MCP'] );
 		unset( $GLOBALS['publicize'] );
 		unset( $GLOBALS['publicize_ui'] );
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Follows up https://github.com/Automattic/jetpack/pull/47223 by adding related unit tests
* `Automattic\Jetpack\Sync\Listener::get_actor`: Replaces redundant `filter_var` with no filter set with `sanitize_text_field`

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Code Review

## Changelog
<!-- Check one of the boxes below. -->

- [x] Generate changelog entries for this PR (using AI).
