### PR TITLE
My Jetpack: Move wpcom-reader module to Growth category

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/products/mappings.ts
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/products/mappings.ts
@@ -46,6 +46,7 @@ export const CATEGORY_CARDS_AND_MODULES: {
 			'subscriptions',
 			'woocommerce-analytics',
 			'wordads',
+			'wpcom-reader',
 		],
 	},
 	performance: {
@@ -76,7 +77,6 @@ export const CATEGORY_CARDS_AND_MODULES: {
 			'markdown',
 			'post-by-email',
 			'post-list',
-			'wpcom-reader',
 			'shortcodes',
 			'shortlinks',
 			'tiled-gallery',

--- a/projects/packages/my-jetpack/changelog/move-wpcom-reader-to-growth
+++ b/projects/packages/my-jetpack/changelog/move-wpcom-reader-to-growth
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Move wpcom-reader module from Other to Growth category in My Jetpack tab panel


### PR DESCRIPTION
Fixes READ-332

## Proposed changes:
* Move the `wpcom-reader` module from the "Other" category to the "Growth" category in the My Jetpack tab panel product mappings.
* The Reader module is a better fit under Growth, as it relates to audience engagement and content discovery.

### Other information:

- [x] Have you written new tests for your changes, if applicable? N/A — no logic change, only a category reassignment.
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

* Go to WP Admin > Jetpack > My Jetpack.
* Open the "Growth" tab and verify that the "Reader" module now appears there.
* Open the "Other" tab and verify that the "Reader" module is no longer listed.
* Confirm no modules are missing or duplicated across categories.

## Changelog

- [x] Generate changelog entries for this PR (using AI).