### PR TITLE
Reader Link: open link in new tab on self-hosted sites

### DIFF
--- a/projects/packages/newsletter/changelog/update-reader-link-self-hosted
+++ b/projects/packages/newsletter/changelog/update-reader-link-self-hosted
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Reader Link: Open the Reader in a different tab on self-hosted sites.

--- a/projects/packages/newsletter/src/class-reader-link.php
+++ b/projects/packages/newsletter/src/class-reader-link.php
@@ -9,6 +9,7 @@ namespace Automattic\Jetpack\Newsletter;
 
 use Automattic\Jetpack\Connection\Urls;
 use Automattic\Jetpack\Modules;
+use Automattic\Jetpack\Status\Host;
 use WP_Admin_Bar;
 
 /**
@@ -81,18 +82,27 @@ class Reader_Link {
 	 * @param WP_Admin_Bar $wp_admin_bar The WP_Admin_Bar core object.
 	 */
 	public function add_reader_menu( $wp_admin_bar ) {
-		$wp_admin_bar->add_menu(
-			array(
-				'id'     => 'reader',
-				'title'  => '<span class="ab-icon" title="' . __( 'Read the blogs and topics you follow', 'jetpack-newsletter' ) . '" aria-hidden="true"></span>' .
-							'<span class="ab-label">' . __( 'Reader', 'jetpack-newsletter' ) . '</span>',
-				'href'   => Urls::maybe_add_origin_site_id( 'https://wordpress.com/reader' ),
-				'meta'   => array(
-					'class' => 'wp-admin-bar-reader',
-				),
-				'parent' => 'top-secondary',
-			)
+		$reader_menu_settings = array(
+			'id'     => 'reader',
+			'title'  => '<span class="ab-icon" title="' . __( 'Read the blogs and topics you follow', 'jetpack-newsletter' ) . '" aria-hidden="true"></span>' .
+						'<span class="ab-label">' . __( 'Reader', 'jetpack-newsletter' ) . '</span>',
+			'href'   => Urls::maybe_add_origin_site_id( 'https://wordpress.com/reader' ),
+			'meta'   => array(
+				'class' => 'wp-admin-bar-reader',
+			),
+			'parent' => 'top-secondary',
 		);
+
+		/*
+		 * On self-hosted sites, open the Reader link in a new tab
+		 * since they're not necessarily logged in to WordPress.com
+		 * and may not want to navigate away from their site.
+		 */
+		if ( ! ( new Host() )->is_wpcom_platform() ) {
+			$reader_menu_settings['meta']['target'] = '_blank';
+		}
+
+		$wp_admin_bar->add_menu( $reader_menu_settings );
 	}
 
 	/**


### PR DESCRIPTION
Fixes READ-331

## Proposed changes:

On self-hosted sites folks are not always logged in to their WordPress.com account. If they click to open the Reader, they may find themselves in front of a log in screen, and will not easily find their way back to their site afterwards.

On WordPress.com sites, however, folks are logged in and used to the WordPress.com interface. We can assume they'll find their way around.

To avoid confusion, let's open the Reader in a new tab on self-hosted sites.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* Go to Jetpack > Settings > Reader
* Activate the feature
* Click on the Reader link in the admin bar
    * On self-hosted sites it should open in a new tab
    * On WordPress.com sites it should open in the same tab.
