### PR TITLE
Agents Manager: Add filter to skip enqueue in block editor contexts

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-agents-manager-block-editor-filter
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-agents-manager-block-editor-filter
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Agents Manager: Add `agents_manager_enqueue_in_block_editor` filter to allow preventing enqueue in block editor contexts.

--- a/projects/packages/jetpack-mu-wpcom/src/features/agents-manager/class-agents-manager.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/agents-manager/class-agents-manager.php
@@ -311,6 +311,12 @@ class Agents_Manager {
 	 * @return bool
 	 */
 	private function is_enabled() {
+		// Allow environments (e.g. CIAB) to prevent loading in block editor contexts
+		// where agents-manager is already running from the parent page.
+		if ( $this->is_block_editor() && ! apply_filters( 'agents_manager_enqueue_in_block_editor', true ) ) {
+			return false;
+		}
+
 		// Full unified experience: Agents Manager with support guides, Help Center takeover, etc.
 		if ( apply_filters( 'agents_manager_use_unified_experience', false ) ) {
 			return true;

--- a/projects/packages/jetpack-mu-wpcom/src/features/agents-manager/class-agents-manager.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/agents-manager/class-agents-manager.php
@@ -313,6 +313,17 @@ class Agents_Manager {
 	private function is_enabled() {
 		// Allow environments (e.g. CIAB) to prevent loading in block editor contexts
 		// where agents-manager is already running from the parent page.
+		/**
+		 * Filter whether to enqueue Agents Manager assets inside the block editor iframe.
+		 *
+		 * This allows environments that already run Agents Manager from the parent page
+		 * to disable enqueueing a second instance within the block editor context.
+		 *
+		 * @param bool $enqueue_in_block_editor Whether to enqueue Agents Manager assets
+		 *                                      in the block editor iframe. Default true.
+		 *
+		 * @return bool Whether to enqueue Agents Manager assets in the block editor iframe.
+		 */
 		if ( $this->is_block_editor() && ! apply_filters( 'agents_manager_enqueue_in_block_editor', true ) ) {
 			return false;
 		}

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/agents-manager/Agents_Manager_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/agents-manager/Agents_Manager_Test.php
@@ -1370,7 +1370,7 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 		set_current_screen( 'post' );
 		$screen = get_current_screen();
 
-		// Use reflection to set the block_editor property.
+		// Use reflection to set the is_block_editor property.
 		$reflection = new \ReflectionClass( $screen );
 		$property   = $reflection->getProperty( 'is_block_editor' );
 		if ( PHP_VERSION_ID < 80100 ) {
@@ -1380,7 +1380,8 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 
 		$_SERVER['REQUEST_URI'] = '/wp-admin/post.php';
 
-		// Enable unified experience so the test reaches the filter check.
+		// Enable unified experience so should_enqueue_script() would otherwise return true,
+		// ensuring this test actually exercises the agents_manager_enqueue_in_block_editor filter.
 		add_filter( 'agents_manager_use_unified_experience', '__return_true', 20 );
 		// Disable enqueue in block editor via the new filter.
 		add_filter( 'agents_manager_enqueue_in_block_editor', '__return_false' );

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/agents-manager/Agents_Manager_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/agents-manager/Agents_Manager_Test.php
@@ -1357,6 +1357,43 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
+	 * Tests that should_enqueue_script returns false in block editor when
+	 * agents_manager_enqueue_in_block_editor filter returns false.
+	 *
+	 * This allows environments like CIAB to prevent duplicate loading when
+	 * agents-manager is already running from the parent page.
+	 */
+	public function test_should_enqueue_script_returns_false_in_block_editor_when_filter_disables_it() {
+		require_once ABSPATH . 'wp-admin/includes/screen.php';
+
+		// Set up block editor context.
+		set_current_screen( 'post' );
+		$screen = get_current_screen();
+
+		// Use reflection to set the block_editor property.
+		$reflection = new \ReflectionClass( $screen );
+		$property   = $reflection->getProperty( 'is_block_editor' );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$property->setAccessible( true );
+		}
+		$property->setValue( $screen, true );
+
+		$_SERVER['REQUEST_URI'] = '/wp-admin/post.php';
+
+		// Enable unified experience so the test reaches the filter check.
+		add_filter( 'agents_manager_use_unified_experience', '__return_true', 20 );
+		// Disable enqueue in block editor via the new filter.
+		add_filter( 'agents_manager_enqueue_in_block_editor', '__return_false' );
+
+		$result = $this->call_should_enqueue_script();
+
+		remove_filter( 'agents_manager_use_unified_experience', '__return_true', 20 );
+		remove_filter( 'agents_manager_enqueue_in_block_editor', '__return_false' );
+
+		$this->assertFalse( $result );
+	}
+
+	/**
 	 * Helper to call the private get_current_user_data method via reflection.
 	 *
 	 * @return array|null The result of get_current_user_data.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to WOOAI-332

Add `agents_manager_enqueue_in_block_editor` filter so environments like CIAB can prevent agents-manager from loading in block editor asset requests where it is already running from the parent page.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add a new `agents_manager_enqueue_in_block_editor` filter that allows disabling the gutenberg assets in the editor on demand.

## Why is this needed?

CIAB doesn't load the block editor the traditional WordPress way (full page render with <script> tags). Instead, the SPA dynamically fetches block editor dependencies via a REST API call:

1. GET /wp/v2/editor/assets: PHP fires WordPress hooks (admin_enqueue_scripts, enqueue_block_editor_assets) in a synthetic context, captures everything that was wp_enqueue_script'd into JSON
2. Frontend loadAssets() takes that JSON and creates real <script> tags in the DOM

Agents-manager hooks into admin_enqueue_scripts so when the editor assets endpoint fires `admin_enqueue_scripts` it enqueues the `gutenberg` variant.

Later in the frontend this is processed, leading to a **double** chat UI interface: one per the original `wp-admin` variant and one for the new `gutenberg` variant due to this dynamic assets loading for the SPA.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

None.

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Test instructions in 3155-ghe-Automattic/ciab-admin

## Changelog
<!-- Check one of the boxes below. -->

- [ ] Generate changelog entries for this PR (using AI).