### PR TITLE
Replace Jetpack_PostImages with Post_Media Images class

### DIFF
--- a/projects/packages/classic-theme-helper/.phan/baseline.php
+++ b/projects/packages/classic-theme-helper/.phan/baseline.php
@@ -9,14 +9,15 @@
  */
 return [
     // # Issue statistics:
-    // PhanTypePossiblyInvalidDimOffset : 8 occurrences
-    // PhanUndeclaredClassMethod : 8 occurrences
+    // UnusedPluginSuppression : 9 occurrences
     // PhanTypeSuspiciousNonTraversableForeach : 6 occurrences
     // PhanTypeMismatchArgumentProbablyReal : 5 occurrences
-    // PhanUndeclaredClassReference : 4 occurrences
+    // PhanUndeclaredClassMethod : 5 occurrences
     // PhanTypeInvalidDimOffset : 2 occurrences
     // PhanTypeMismatchArgument : 2 occurrences
+    // PhanUndeclaredClassReference : 2 occurrences
     // PhanTypeMismatchProperty : 1 occurrence
+    // PhanTypePossiblyInvalidDimOffset : 1 occurrence
     // PhanUndeclaredTypeProperty : 1 occurrence
 
     // Currently, file_suppressions and directory_suppressions are the only supported suppressions
@@ -24,11 +25,10 @@ return [
         '_inc/lib/tonesque.php' => ['PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentProbablyReal'],
         'src/class-featured-content.php' => ['PhanTypeInvalidDimOffset', 'PhanTypeMismatchArgument', 'PhanTypeMismatchProperty', 'PhanTypePossiblyInvalidDimOffset'],
         'src/class-social-links.php' => ['PhanUndeclaredClassMethod', 'PhanUndeclaredClassReference', 'PhanUndeclaredTypeProperty'],
-        'src/content-options/featured-images-fallback.php' => ['PhanTypePossiblyInvalidDimOffset'],
-        'src/custom-content-types.php' => ['PhanUndeclaredClassMethod'],
-        'src/custom-post-types/class-jetpack-portfolio.php' => ['PhanTypeMismatchArgumentProbablyReal', 'PhanTypeSuspiciousNonTraversableForeach'],
-        'src/custom-post-types/class-jetpack-testimonial.php' => ['PhanTypeMismatchArgumentProbablyReal'],
-        'src/custom-post-types/class-nova-restaurant.php' => ['PhanTypeSuspiciousNonTraversableForeach'],
+        'src/content-options/post-details.php' => ['UnusedPluginSuppression'],
+        'src/custom-post-types/class-jetpack-portfolio.php' => ['PhanTypeMismatchArgumentProbablyReal', 'PhanTypeSuspiciousNonTraversableForeach', 'UnusedPluginSuppression'],
+        'src/custom-post-types/class-jetpack-testimonial.php' => ['PhanTypeMismatchArgumentProbablyReal', 'UnusedPluginSuppression'],
+        'src/custom-post-types/class-nova-restaurant.php' => ['PhanTypeSuspiciousNonTraversableForeach', 'UnusedPluginSuppression'],
     ],
     // 'directory_suppressions' => ['src/directory_name' => ['PhanIssueName1', 'PhanIssueName2']] can be manually added if needed.
     // (directory_suppressions will currently be ignored by subsequent calls to --save-baseline, but may be preserved in future Phan releases)

--- a/projects/packages/classic-theme-helper/changelog/replace-jetpack-postimages
+++ b/projects/packages/classic-theme-helper/changelog/replace-jetpack-postimages
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Use the new Post_Media Images class instead of Jetpack_PostImages for featured image fallbacks.

--- a/projects/packages/classic-theme-helper/composer.json
+++ b/projects/packages/classic-theme-helper/composer.json
@@ -6,7 +6,8 @@
 	"require": {
 		"php": ">=7.2",
 		"automattic/jetpack-assets": "@dev",
-		"automattic/jetpack-blocks": "@dev"
+		"automattic/jetpack-blocks": "@dev",
+		"automattic/jetpack-post-media": "@dev"
 	},
 	"require-dev": {
 		"yoast/phpunit-polyfills": "^4.0.0",

--- a/projects/packages/classic-theme-helper/src/content-options/featured-images-fallback.php
+++ b/projects/packages/classic-theme-helper/src/content-options/featured-images-fallback.php
@@ -5,6 +5,8 @@
  * @package automattic/jetpack-classic-theme-helper
  */
 
+use Automattic\Jetpack\Post_Media\Images;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit( 0 );
 }
@@ -41,97 +43,94 @@ if ( ! function_exists( 'jetpack_featured_images_fallback_get_image' ) ) {
 			}
 		}
 
-		if ( class_exists( 'Jetpack_PostImages' ) ) {
-			global $_wp_additional_image_sizes;
+		global $_wp_additional_image_sizes;
 
-			$args = array(
-				'from_thumbnail'  => false,
-				'from_slideshow'  => true,
-				'from_gallery'    => true,
-				'from_attachment' => false,
+		$args = array(
+			'from_thumbnail'  => false,
+			'from_slideshow'  => true,
+			'from_gallery'    => true,
+			'from_attachment' => false,
+		);
+
+		$image = Images::get_image( $post_id, $args );
+
+		if ( ! empty( $image ) ) {
+			$image['width']  = '';
+			$image['height'] = '';
+			$image['crop']   = '';
+
+			if ( array_key_exists( $size, $_wp_additional_image_sizes ) ) {
+				$image['width']  = $_wp_additional_image_sizes[ $size ]['width'];
+				$image['height'] = $_wp_additional_image_sizes[ $size ]['height'];
+				$image['crop']   = $_wp_additional_image_sizes[ $size ]['crop'];
+			}
+
+			// Force `crop` to be a simple boolean, to avoid dealing with WP crop positions.
+			$image['crop'] = boolval( $image['crop'] );
+
+			$image_sizes = '';
+
+			$width  = isset( $image['width'] ) ? intval( $image['width'] ) : null;
+			$height = isset( $image['height'] ) ? intval( $image['height'] ) : null;
+
+			if ( ! empty( $image['src_width'] ) && ! empty( $image['src_height'] ) && ! empty( $image['width'] ) && ! empty( $image['height'] ) ) {
+				$src_width  = intval( $image['src_width'] );
+				$src_height = intval( $image['src_height'] );
+
+				// If we're aware of the source dimensions, calculate the final image height and width.
+				// This allows us to provide them as attributes in the `<img>` tag, to avoid layout shifts.
+				// It also allows us to calculate a `srcset`.
+				if ( $image['crop'] ) {
+					// If we're cropping, the final dimensions are calculated independently of each other.
+					$width  = min( $width, $src_width );
+					$height = min( $height, $src_height );
+				} else {
+					// If we're not cropping, we need to preserve aspect ratio.
+					$dims   = wp_constrain_dimensions( $src_width, $src_height, $width, $height );
+					$width  = $dims[0];
+					$height = $dims[1];
+				}
+
+				$image_src    = Images::fit_image_url( $image['src'], $width, $height );
+				$image_srcset = Images::generate_cropped_srcset( $image, $width, $height, true );
+				$image_sizes  = 'min(' . $width . 'px, 100vw)';
+			} else {
+				// If we're not aware of the source dimensions, leave the size calculations to the CDN, and
+				// fall back to a simpler `<img>` tag without `width`/`height` or `srcset`.
+				$image_src = Images::fit_image_url( $image['src'], $image['width'], $image['height'] );
+
+				// Use the theme's crop setting rather than forcing to true.
+				$image_src = add_query_arg( 'crop', $image['crop'], $image_src );
+
+				$image_srcset = null;
+				$image_sizes  = null;
+			}
+
+			$default_attr = array(
+				'srcset'   => $image_srcset,
+				'sizes'    => $image_sizes,
+				'loading'  => is_singular() ? 'eager' : 'lazy',
+				'decoding' => 'async',
+				'title'    => wp_strip_all_tags( get_the_title() ),
+				'alt'      => '',
+				'class'    => "attachment-$size wp-post-image",
 			);
 
-			// @phan-suppress-next-line PhanUndeclaredClassMethod -- We we've checked the class exists earlier.
-			$image = Jetpack_PostImages::get_image( $post_id, $args );
+			$image_attr = wp_parse_args( $attr, $default_attr );
+			$hwstring   = image_hwstring( $width, $height );
 
-			if ( ! empty( $image ) ) {
-				$image['width']  = '';
-				$image['height'] = '';
-				$image['crop']   = '';
+			$html  = rtrim( "<img $hwstring" );
+			$html .= ' src="' . esc_url( $image_src ) . '"';
 
-				if ( array_key_exists( $size, $_wp_additional_image_sizes ) ) {
-					$image['width']  = $_wp_additional_image_sizes[ $size ]['width'];
-					$image['height'] = $_wp_additional_image_sizes[ $size ]['height'];
-					$image['crop']   = $_wp_additional_image_sizes[ $size ]['crop'];
+			foreach ( $image_attr as $name => $value ) {
+				if ( $value ) {
+					$html .= " $name=" . '"' . esc_attr( $value ) . '"';
 				}
-
-				// Force `crop` to be a simple boolean, to avoid dealing with WP crop positions.
-				$image['crop'] = boolval( $image['crop'] );
-
-				$image_sizes = '';
-
-				$width  = isset( $image['width'] ) ? intval( $image['width'] ) : null;
-				$height = isset( $image['height'] ) ? intval( $image['height'] ) : null;
-
-				if ( ! empty( $image['src_width'] ) && ! empty( $image['src_height'] ) && ! empty( $image['width'] ) && ! empty( $image['height'] ) ) {
-					$src_width  = intval( $image['src_width'] );
-					$src_height = intval( $image['src_height'] );
-
-					// If we're aware of the source dimensions, calculate the final image height and width.
-					// This allows us to provide them as attributes in the `<img>` tag, to avoid layout shifts.
-					// It also allows us to calculate a `srcset`.
-					if ( $image['crop'] ) {
-						// If we're cropping, the final dimensions are calculated independently of each other.
-						$width  = min( $width, $src_width );
-						$height = min( $height, $src_height );
-					} else {
-						// If we're not cropping, we need to preserve aspect ratio.
-						$dims   = wp_constrain_dimensions( $src_width, $src_height, $width, $height );
-						$width  = $dims[0];
-						$height = $dims[1];
-					}
-
-					$image_src    = Jetpack_PostImages::fit_image_url( $image['src'], $width, $height ); // @phan-suppress-current-line PhanUndeclaredClassMethod -- We've checked the class exists earlier.
-					$image_srcset = Jetpack_PostImages::generate_cropped_srcset( $image, $width, $height, true ); // @phan-suppress-current-line PhanUndeclaredClassMethod -- We've checked the class exists earlier.
-					$image_sizes  = 'min(' . $width . 'px, 100vw)';
-				} else {
-					// If we're not aware of the source dimensions, leave the size calculations to the CDN, and
-					// fall back to a simpler `<img>` tag without `width`/`height` or `srcset`.
-					$image_src = Jetpack_PostImages::fit_image_url( $image['src'], $image['width'], $image['height'] ); // @phan-suppress-current-line PhanUndeclaredClassMethod -- We've checked the class exists earlier.
-
-					// Use the theme's crop setting rather than forcing to true.
-					$image_src = add_query_arg( 'crop', $image['crop'], $image_src );
-
-					$image_srcset = null;
-					$image_sizes  = null;
-				}
-
-				$default_attr = array(
-					'srcset'   => $image_srcset,
-					'sizes'    => $image_sizes,
-					'loading'  => is_singular() ? 'eager' : 'lazy',
-					'decoding' => 'async',
-					'title'    => wp_strip_all_tags( get_the_title() ),
-					'alt'      => '',
-					'class'    => "attachment-$size wp-post-image",
-				);
-
-				$image_attr = wp_parse_args( $attr, $default_attr );
-				$hwstring   = image_hwstring( $width, $height );
-
-				$html  = rtrim( "<img $hwstring" );
-				$html .= ' src="' . esc_url( $image_src ) . '"';
-
-				foreach ( $image_attr as $name => $value ) {
-					if ( $value ) {
-						$html .= " $name=" . '"' . esc_attr( $value ) . '"';
-					}
-				}
-
-				$html .= ' />';
-
-				return trim( $html );
 			}
+
+			$html .= ' />';
+
+			return trim( $html );
 		}
 
 		return trim( $html );
@@ -168,36 +167,34 @@ if ( ! function_exists( 'jetpack_featured_images_fallback_get_image_src' ) ) {
 			}
 		}
 
-		if ( class_exists( 'Jetpack_PostImages' ) ) {
-			global $_wp_additional_image_sizes;
+		global $_wp_additional_image_sizes;
 
-			$args = array(
-				'from_thumbnail'  => false,
-				'from_slideshow'  => true,
-				'from_gallery'    => true,
-				'from_attachment' => false,
-			);
+		$args = array(
+			'from_thumbnail'  => false,
+			'from_slideshow'  => true,
+			'from_gallery'    => true,
+			'from_attachment' => false,
+		);
 
-			$image = Jetpack_PostImages::get_image( $post_id, $args ); // @phan-suppress-current-line PhanUndeclaredClassMethod -- We've checked the class exists earlier.
+		$image = Images::get_image( $post_id, $args );
 
-			if ( ! empty( $image ) ) {
-				$image['width']  = '';
-				$image['height'] = '';
-				$image['crop']   = '';
+		if ( ! empty( $image ) ) {
+			$image['width']  = '';
+			$image['height'] = '';
+			$image['crop']   = '';
 
-				if ( array_key_exists( $size, $_wp_additional_image_sizes ) ) {
-					$image['width']  = $_wp_additional_image_sizes[ $size ]['width'];
-					$image['height'] = $_wp_additional_image_sizes[ $size ]['height'];
-					$image['crop']   = $_wp_additional_image_sizes[ $size ]['crop'];
-				}
-
-				$image_src = Jetpack_PostImages::fit_image_url( $image['src'], $image['width'], $image['height'] ); // @phan-suppress-current-line PhanUndeclaredClassMethod -- We've checked the class exists earlier.
-
-				// Use the theme's crop setting rather than forcing to true.
-				$image_src = add_query_arg( 'crop', $image['crop'], $image_src );
-
-				return esc_url( $image_src );
+			if ( array_key_exists( $size, $_wp_additional_image_sizes ) ) {
+				$image['width']  = $_wp_additional_image_sizes[ $size ]['width'];
+				$image['height'] = $_wp_additional_image_sizes[ $size ]['height'];
+				$image['crop']   = $_wp_additional_image_sizes[ $size ]['crop'];
 			}
+
+			$image_src = Images::fit_image_url( $image['src'], $image['width'], $image['height'] );
+
+			// Use the theme's crop setting rather than forcing to true.
+			$image_src = add_query_arg( 'crop', $image['crop'], $image_src );
+
+			return esc_url( $image_src );
 		}
 
 		return esc_url( $image_src );

--- a/projects/packages/post-media/changelog/replace-jetpack-postimages
+++ b/projects/packages/post-media/changelog/replace-jetpack-postimages
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Use the new Images class instead of Jetpack_PostImages in Twitter Cards.

--- a/projects/packages/post-media/src/class-twitter-cards.php
+++ b/projects/packages/post-media/src/class-twitter-cards.php
@@ -99,9 +99,8 @@ class Twitter_Cards {
 		$card_type = 'summary';
 
 		// Try to give priority to featured images.
-		// @todo Jetpack_PostImages is defined in the Jetpack plugin. It should be moved to this package.
-		if ( class_exists( 'Jetpack_PostImages' ) && ! empty( $post_id ) ) {
-			$post_image = \Jetpack_PostImages::get_image( // @phan-suppress-current-line PhanUndeclaredClassMethod -- Guarded by class_exists().
+		if ( ! empty( $post_id ) ) {
+			$post_image = Images::get_image(
 				$post_id,
 				array(
 					'width'  => 144,

--- a/projects/plugins/classic-theme-helper-plugin/changelog/replace-jetpack-postimages
+++ b/projects/plugins/classic-theme-helper-plugin/changelog/replace-jetpack-postimages
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock.
+
+

--- a/projects/plugins/classic-theme-helper-plugin/composer.lock
+++ b/projects/plugins/classic-theme-helper-plugin/composer.lock
@@ -7,6 +7,70 @@
     "content-hash": "20f23ff09f1376cb789e40a16632ec1d",
     "packages": [
         {
+            "name": "automattic/block-delimiter",
+            "version": "dev-trunk",
+            "dist": {
+                "type": "path",
+                "url": "../../packages/block-delimiter",
+                "reference": "38b17cad3ac0259b1358356beb4744d6ca606488"
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "require-dev": {
+                "automattic/jetpack-changelogger": "@dev",
+                "automattic/jetpack-test-environment": "@dev",
+                "automattic/phpunit-select-config": "@dev",
+                "yoast/phpunit-polyfills": "^4.0.0"
+            },
+            "suggest": {
+                "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
+            },
+            "type": "jetpack-library",
+            "extra": {
+                "autotagger": true,
+                "branch-alias": {
+                    "dev-trunk": "0.3.x-dev"
+                },
+                "changelogger": {
+                    "link-template": "https://github.com/Automattic/block-delimiter/compare/v${old}...v${new}"
+                },
+                "mirror-repo": "Automattic/block-delimiter",
+                "textdomain": "jetpack-block-delimiter"
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "autoload-dev": {
+                "classmap": [
+                    "tests/php/lib/"
+                ],
+                "psr-4": {
+                    "Automattic\\Block_Delimiter\\Tests\\": "tests/php/"
+                }
+            },
+            "scripts": {
+                "phpunit": [
+                    "phpunit-select-config phpunit.#.xml.dist --colors=always"
+                ],
+                "test-coverage": [
+                    "php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\""
+                ],
+                "test-php": [
+                    "@composer phpunit"
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Efficiently work with block structure",
+            "transport-options": {
+                "relative": true
+            }
+        },
+        {
             "name": "automattic/jetpack-a8c-mc-stats",
             "version": "dev-trunk",
             "dist": {
@@ -56,6 +120,66 @@
                 "GPL-2.0-or-later"
             ],
             "description": "Used to record internal usage stats for Automattic. Not visible to site owners.",
+            "transport-options": {
+                "relative": true
+            }
+        },
+        {
+            "name": "automattic/jetpack-admin-ui",
+            "version": "dev-trunk",
+            "dist": {
+                "type": "path",
+                "url": "../../packages/admin-ui",
+                "reference": "fee1504bb96380c418e439af5696ba75fbfc0d96"
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "require-dev": {
+                "automattic/jetpack-changelogger": "@dev",
+                "automattic/jetpack-logo": "@dev",
+                "automattic/jetpack-test-environment": "@dev",
+                "automattic/phpunit-select-config": "@dev",
+                "yoast/phpunit-polyfills": "^4.0.0"
+            },
+            "suggest": {
+                "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
+            },
+            "type": "jetpack-library",
+            "extra": {
+                "autotagger": true,
+                "mirror-repo": "Automattic/jetpack-admin-ui",
+                "textdomain": "jetpack-admin-ui",
+                "changelogger": {
+                    "link-template": "https://github.com/Automattic/jetpack-admin-ui/compare/${old}...${new}"
+                },
+                "branch-alias": {
+                    "dev-trunk": "0.5.x-dev"
+                },
+                "version-constants": {
+                    "::PACKAGE_VERSION": "src/class-admin-menu.php"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "scripts": {
+                "phpunit": [
+                    "phpunit-select-config phpunit.#.xml.dist --colors=always"
+                ],
+                "test-coverage": [
+                    "php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\""
+                ],
+                "test-php": [
+                    "@composer phpunit"
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Generic Jetpack wp-admin UI elements",
             "transport-options": {
                 "relative": true
             }
@@ -263,11 +387,12 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/classic-theme-helper",
-                "reference": "f845c60c1f7aa13f5b66b488712dcdd816ad19db"
+                "reference": "2a0ad5d46ab475954e8ec3d2d633234c06316b91"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
                 "automattic/jetpack-blocks": "@dev",
+                "automattic/jetpack-post-media": "@dev",
                 "php": ">=7.2"
             },
             "require-dev": {
@@ -457,6 +582,93 @@
             }
         },
         {
+            "name": "automattic/jetpack-connection",
+            "version": "dev-trunk",
+            "dist": {
+                "type": "path",
+                "url": "../../packages/connection",
+                "reference": "5e94dbbd45981068770c413e22b57461618400de"
+            },
+            "require": {
+                "automattic/jetpack-a8c-mc-stats": "@dev",
+                "automattic/jetpack-admin-ui": "@dev",
+                "automattic/jetpack-assets": "@dev",
+                "automattic/jetpack-constants": "@dev",
+                "automattic/jetpack-redirect": "@dev",
+                "automattic/jetpack-roles": "@dev",
+                "automattic/jetpack-status": "@dev",
+                "php": ">=7.2"
+            },
+            "require-dev": {
+                "automattic/jetpack-changelogger": "@dev",
+                "automattic/jetpack-licensing": "@dev",
+                "automattic/jetpack-sync": "@dev",
+                "automattic/jetpack-test-environment": "@dev",
+                "automattic/phpunit-select-config": "@dev",
+                "brain/monkey": "^2.6.2",
+                "yoast/phpunit-polyfills": "^4.0.0"
+            },
+            "suggest": {
+                "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
+            },
+            "type": "jetpack-library",
+            "extra": {
+                "autotagger": true,
+                "mirror-repo": "Automattic/jetpack-connection",
+                "textdomain": "jetpack-connection",
+                "version-constants": {
+                    "::PACKAGE_VERSION": "src/class-package-version.php"
+                },
+                "changelogger": {
+                    "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
+                },
+                "branch-alias": {
+                    "dev-trunk": "7.1.x-dev"
+                },
+                "dependencies": {
+                    "test-only": [
+                        "packages/licensing",
+                        "packages/sync"
+                    ]
+                }
+            },
+            "autoload": {
+                "files": [
+                    "actions.php"
+                ],
+                "classmap": [
+                    "legacy",
+                    "src/",
+                    "src/webhooks",
+                    "src/identity-crisis"
+                ]
+            },
+            "scripts": {
+                "build-production": [
+                    "pnpm run build-production"
+                ],
+                "build-development": [
+                    "pnpm run build"
+                ],
+                "phpunit": [
+                    "phpunit-select-config phpunit.#.xml.dist --colors=always"
+                ],
+                "test-coverage": [
+                    "php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\""
+                ],
+                "test-php": [
+                    "@composer phpunit"
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Everything needed to connect to the Jetpack infrastructure",
+            "transport-options": {
+                "relative": true
+            }
+        },
+        {
             "name": "automattic/jetpack-constants",
             "version": "dev-trunk",
             "dist": {
@@ -507,6 +719,67 @@
                 "GPL-2.0-or-later"
             ],
             "description": "A wrapper for defining constants in a more testable way.",
+            "transport-options": {
+                "relative": true
+            }
+        },
+        {
+            "name": "automattic/jetpack-image-cdn",
+            "version": "dev-trunk",
+            "dist": {
+                "type": "path",
+                "url": "../../packages/image-cdn",
+                "reference": "79b4ce2978edf4a5f586ceab9c2058a6cfcbef94"
+            },
+            "require": {
+                "automattic/jetpack-assets": "@dev",
+                "automattic/jetpack-status": "@dev",
+                "php": ">=7.2"
+            },
+            "require-dev": {
+                "automattic/jetpack-changelogger": "@dev",
+                "automattic/jetpack-test-environment": "@dev",
+                "automattic/phpunit-select-config": "@dev",
+                "yoast/phpunit-polyfills": "^4.0.0"
+            },
+            "suggest": {
+                "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
+            },
+            "type": "jetpack-library",
+            "extra": {
+                "mirror-repo": "Automattic/jetpack-image-cdn",
+                "changelogger": {
+                    "link-template": "https://github.com/Automattic/jetpack-image-cdn/compare/v${old}...v${new}"
+                },
+                "autotagger": true,
+                "branch-alias": {
+                    "dev-trunk": "0.7.x-dev"
+                },
+                "textdomain": "jetpack-image-cdn",
+                "version-constants": {
+                    "::PACKAGE_VERSION": "src/class-image-cdn.php"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "scripts": {
+                "phpunit": [
+                    "phpunit-select-config phpunit.#.xml.dist --colors=always"
+                ],
+                "test-coverage": [
+                    "php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\""
+                ],
+                "test-php": [
+                    "@composer phpunit"
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Serve images through Jetpack's powerful CDN",
             "transport-options": {
                 "relative": true
             }
@@ -564,6 +837,185 @@
                 "GPL-2.0-or-later"
             ],
             "description": "Handle installation of plugins from WP.org",
+            "transport-options": {
+                "relative": true
+            }
+        },
+        {
+            "name": "automattic/jetpack-post-media",
+            "version": "dev-trunk",
+            "dist": {
+                "type": "path",
+                "url": "../../packages/post-media",
+                "reference": "28b5f5b5b8ca9858e6c5ce23a4e852c756713960"
+            },
+            "require": {
+                "automattic/block-delimiter": "@dev",
+                "automattic/jetpack-connection": "@dev",
+                "automattic/jetpack-image-cdn": "@dev",
+                "php": ">=7.2"
+            },
+            "require-dev": {
+                "automattic/jetpack-changelogger": "@dev",
+                "automattic/jetpack-test-environment": "@dev",
+                "automattic/phpunit-select-config": "@dev",
+                "yoast/phpunit-polyfills": "^4.0.0"
+            },
+            "suggest": {
+                "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
+            },
+            "type": "jetpack-library",
+            "extra": {
+                "autotagger": true,
+                "branch-alias": {
+                    "dev-trunk": "0.1.x-dev"
+                },
+                "changelogger": {
+                    "link-template": "https://github.com/Automattic/jetpack-post-media/compare/v${old}...v${new}"
+                },
+                "mirror-repo": "Automattic/jetpack-post-media",
+                "textdomain": "jetpack-post-media",
+                "version-constants": {
+                    "::PACKAGE_VERSION": "src/class-post-media.php"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "scripts": {
+                "build-development": [
+                    "echo 'Add your build step to composer.json, please!'"
+                ],
+                "build-production": [
+                    "echo 'Add your build step to composer.json, please!'"
+                ],
+                "phpunit": [
+                    "phpunit-select-config phpunit.#.xml.dist --colors=always"
+                ],
+                "test-coverage": [
+                    "php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\""
+                ],
+                "test-php": [
+                    "@composer phpunit"
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Tools to extract useful information and meta data from WordPress posts.",
+            "transport-options": {
+                "relative": true
+            }
+        },
+        {
+            "name": "automattic/jetpack-redirect",
+            "version": "dev-trunk",
+            "dist": {
+                "type": "path",
+                "url": "../../packages/redirect",
+                "reference": "44d6ec93e4d3b3db6287bf82f316a294d7ef868d"
+            },
+            "require": {
+                "automattic/jetpack-status": "@dev",
+                "php": ">=7.2"
+            },
+            "require-dev": {
+                "automattic/jetpack-changelogger": "@dev",
+                "automattic/phpunit-select-config": "@dev",
+                "brain/monkey": "^2.6.2",
+                "yoast/phpunit-polyfills": "^4.0.0"
+            },
+            "suggest": {
+                "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
+            },
+            "type": "jetpack-library",
+            "extra": {
+                "autotagger": true,
+                "mirror-repo": "Automattic/jetpack-redirect",
+                "changelogger": {
+                    "link-template": "https://github.com/Automattic/jetpack-redirect/compare/v${old}...v${new}"
+                },
+                "branch-alias": {
+                    "dev-trunk": "3.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "scripts": {
+                "phpunit": [
+                    "phpunit-select-config phpunit.#.xml.dist --colors=always"
+                ],
+                "test-coverage": [
+                    "php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\""
+                ],
+                "test-php": [
+                    "@composer phpunit"
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Utilities to build URLs to the jetpack.com/redirect/ service",
+            "transport-options": {
+                "relative": true
+            }
+        },
+        {
+            "name": "automattic/jetpack-roles",
+            "version": "dev-trunk",
+            "dist": {
+                "type": "path",
+                "url": "../../packages/roles",
+                "reference": "f7098eb11833c5fddfff032427d8576039aa3521"
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "require-dev": {
+                "automattic/jetpack-changelogger": "@dev",
+                "automattic/phpunit-select-config": "@dev",
+                "brain/monkey": "^2.6.2",
+                "yoast/phpunit-polyfills": "^4.0.0"
+            },
+            "suggest": {
+                "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
+            },
+            "type": "jetpack-library",
+            "extra": {
+                "autotagger": true,
+                "mirror-repo": "Automattic/jetpack-roles",
+                "changelogger": {
+                    "link-template": "https://github.com/Automattic/jetpack-roles/compare/v${old}...v${new}"
+                },
+                "branch-alias": {
+                    "dev-trunk": "3.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "scripts": {
+                "phpunit": [
+                    "phpunit-select-config phpunit.#.xml.dist --colors=always"
+                ],
+                "test-coverage": [
+                    "php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\""
+                ],
+                "test-php": [
+                    "@composer phpunit"
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Utilities, related with user roles and capabilities.",
             "transport-options": {
                 "relative": true
             }

--- a/projects/plugins/jetpack/3rd-party/class.jetpack-amp-support.php
+++ b/projects/plugins/jetpack/3rd-party/class.jetpack-amp-support.php
@@ -1,6 +1,7 @@
 <?php //phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
 
 use Automattic\Jetpack\Assets;
+use Automattic\Jetpack\Post_Media\Images;
 use Automattic\Jetpack\Stats\Tracking_Pixel as Stats_Tracking_Pixel;
 use Automattic\Jetpack\Sync\Functions;
 
@@ -228,7 +229,7 @@ class Jetpack_AMP_Support {
 	 * @return array Metadata.
 	 */
 	private static function add_image_to_metadata( $metadata, $post ) {
-		$image = Jetpack_PostImages::get_image(
+		$image = Images::get_image(
 			$post->ID,
 			array(
 				'fallback_to_avatars' => true,

--- a/projects/plugins/jetpack/_inc/lib/class.media-extractor.php
+++ b/projects/plugins/jetpack/_inc/lib/class.media-extractor.php
@@ -6,6 +6,8 @@
  * @package automattic/jetpack
  */
 
+use Automattic\Jetpack\Post_Media\Images;
+
 /**
  * Class with methods to extract metadata from a post/page about videos, images, links, mentions embedded
  * in or attached to the post/page.
@@ -383,7 +385,7 @@ class Jetpack_Media_Meta_Extractor {
 	/**
 	 * Get image fields for matching images.
 	 *
-	 * @uses Jetpack_PostImages
+	 * @uses Images
 	 *
 	 * @param WP_Post $post A post object.
 	 * @param array   $args Optional args, see defaults list for details.
@@ -408,7 +410,7 @@ class Jetpack_Media_Meta_Extractor {
 		$image_booleans            = array();
 		$image_booleans['gallery'] = 0;
 
-		$from_featured_image = Jetpack_PostImages::from_thumbnail( $post->ID, $args['width'], $args['height'] );
+		$from_featured_image = Images::from_thumbnail( $post->ID, $args['width'], $args['height'] );
 		if ( ! empty( $from_featured_image ) ) {
 			if ( $extract_alt_text ) {
 				$image_list = array_merge( $image_list, self::reduce_extracted_images( $from_featured_image ) );
@@ -418,7 +420,7 @@ class Jetpack_Media_Meta_Extractor {
 			}
 		}
 
-		$from_slideshow = Jetpack_PostImages::from_slideshow( $post->ID, $args['width'], $args['height'] );
+		$from_slideshow = Images::from_slideshow( $post->ID, $args['width'], $args['height'] );
 		if ( ! empty( $from_slideshow ) ) {
 			if ( $extract_alt_text ) {
 				$image_list = array_merge( $image_list, self::reduce_extracted_images( $from_slideshow ) );
@@ -428,7 +430,7 @@ class Jetpack_Media_Meta_Extractor {
 			}
 		}
 
-		$from_gallery = Jetpack_PostImages::from_gallery( $post->ID );
+		$from_gallery = Images::from_gallery( $post->ID );
 		if ( ! empty( $from_gallery ) ) {
 			if ( $extract_alt_text ) {
 				$image_list = array_merge( $image_list, self::reduce_extracted_images( $from_gallery ) );
@@ -528,7 +530,7 @@ class Jetpack_Media_Meta_Extractor {
 	 */
 	public static function get_images_from_html( $html, $images_already_extracted, $extract_alt_text = false ) {
 		$image_list = $images_already_extracted;
-		$from_html  = Jetpack_PostImages::from_html( $html );
+		$from_html  = Images::from_html( $html );
 		// early return if no image in html.
 		if ( empty( $from_html ) ) {
 			return $image_list;

--- a/projects/plugins/jetpack/changelog/replace-jetpack-postimages
+++ b/projects/plugins/jetpack/changelog/replace-jetpack-postimages
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Replace Jetpack_PostImages usage with the new Post_Media Images class.

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -793,11 +793,12 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/classic-theme-helper",
-                "reference": "f845c60c1f7aa13f5b66b488712dcdd816ad19db"
+                "reference": "2a0ad5d46ab475954e8ec3d2d633234c06316b91"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
                 "automattic/jetpack-blocks": "@dev",
+                "automattic/jetpack-post-media": "@dev",
                 "php": ">=7.2"
             },
             "require-dev": {

--- a/projects/plugins/jetpack/enhanced-open-graph.php
+++ b/projects/plugins/jetpack/enhanced-open-graph.php
@@ -5,6 +5,8 @@
  * @package automattic/jetpack
  */
 
+use Automattic\Jetpack\Post_Media\Images;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit( 0 );
 }
@@ -191,5 +193,5 @@ add_filter( 'jetpack_open_graph_tags', 'enhanced_og_video' );
  * @return bool True if the post has a suitable featured image, false otherwise.
  */
 function enhanced_og_has_featured_image( $post_id ) {
-	return ! empty( Jetpack_PostImages::from_thumbnail( $post_id ) );
+	return ! empty( Images::from_thumbnail( $post_id ) );
 }

--- a/projects/plugins/jetpack/extensions/blocks/sharing-button/class-sharing-source-block.php
+++ b/projects/plugins/jetpack/extensions/blocks/sharing-button/class-sharing-source-block.php
@@ -12,7 +12,7 @@
 namespace Automattic\Jetpack\Extensions\Sharing_Button_Block;
 
 use Automattic\Jetpack\Device_Detection\User_Agent_Info;
-use Jetpack_PostImages;
+use Automattic\Jetpack\Post_Media\Images;
 use WP_Post;
 
 /**
@@ -687,11 +687,9 @@ class Share_Pinterest_Block extends Sharing_Source_Block {
 	 * @return string
 	 */
 	public function get_image( $post ) {
-		if ( class_exists( 'Jetpack_PostImages' ) ) {
-			$image = Jetpack_PostImages::get_image( $post->ID, array( 'fallback_to_avatars' => true ) );
-			if ( ! empty( $image ) ) {
-				return $image['src'];
-			}
+		$image = Images::get_image( $post->ID, array( 'fallback_to_avatars' => true ) );
+		if ( ! empty( $image ) ) {
+			return $image['src'];
 		}
 
 		/**

--- a/projects/plugins/jetpack/extensions/blocks/story/story.php
+++ b/projects/plugins/jetpack/extensions/blocks/story/story.php
@@ -11,9 +11,9 @@ namespace Automattic\Jetpack\Extensions\Story;
 
 use Automattic\Jetpack\Blocks;
 use Automattic\Jetpack\Connection\Connection_Assets;
+use Automattic\Jetpack\Post_Media\Images;
 use Jetpack;
 use Jetpack_Gutenberg;
-use Jetpack_PostImages;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit( 0 );
@@ -278,7 +278,7 @@ function get_image_crop_class( $width, $height ) {
  * @return string
  */
 function get_blavatar_or_site_icon_url( $size, $fallback ) {
-	$image_array = Jetpack_PostImages::from_blavatar( get_the_ID(), $size );
+	$image_array = Images::from_blavatar( get_the_ID(), $size );
 	if ( ! empty( $image_array ) ) {
 		return $image_array[0]['src'];
 	} else {

--- a/projects/plugins/jetpack/functions.opengraph.php
+++ b/projects/plugins/jetpack/functions.opengraph.php
@@ -14,6 +14,7 @@
 use Automattic\Block_Scanner;
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Current_Plan;
+use Automattic\Jetpack\Post_Media\Images;
 use Automattic\Jetpack\Status\Host;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -332,12 +333,12 @@ function jetpack_og_get_image( $width = 200, $height = 200, $deprecated = null )
 		// Grab obvious image if post is an attachment page for an image.
 		if ( is_attachment( get_the_ID() ) && str_starts_with( get_post_mime_type(), 'image' ) ) {
 			$image['src']      = wp_get_attachment_url( get_the_ID() );
-			$image['alt_text'] = Jetpack_PostImages::get_alt_text( get_the_ID() );
+			$image['alt_text'] = Images::get_alt_text( get_the_ID() );
 		}
 
 		// Attempt to find something good for this post using our generalized PostImages code.
-		if ( empty( $image ) && class_exists( 'Jetpack_PostImages' ) ) {
-			$post_image = Jetpack_PostImages::get_image(
+		if ( empty( $image ) ) {
+			$post_image = Images::get_image(
 				get_the_ID(),
 				array(
 					'width'  => $width,
@@ -528,7 +529,7 @@ function jetpack_og_get_site_image( $width, $height ) {
 				'src'      => $sl_details[0],
 				'width'    => $sl_details[1],
 				'height'   => $sl_details[2],
-				'alt_text' => Jetpack_PostImages::get_alt_text( $custom_logo_id ),
+				'alt_text' => Images::get_alt_text( $custom_logo_id ),
 			);
 		}
 	}

--- a/projects/plugins/jetpack/modules/related-posts/jetpack-related-posts.php
+++ b/projects/plugins/jetpack/modules/related-posts/jetpack-related-posts.php
@@ -7,6 +7,7 @@
 
 use Automattic\Jetpack\Assets;
 use Automattic\Jetpack\Blocks;
+use Automattic\Jetpack\Post_Media\Images;
 use Automattic\Jetpack\Status\Request;
 use Automattic\Jetpack\Sync\Settings;
 
@@ -1442,10 +1443,10 @@ EOT;
 
 	/**
 	 * Generates the thumbnail image to be used for the post. Uses the
-	 * image as returned by Jetpack_PostImages::get_image()
+	 * image as returned by Images::get_image()
 	 *
 	 * @param int $post_id - the post ID.
-	 * @uses self::get_options, apply_filters, Jetpack_PostImages::get_image, Jetpack_PostImages::fit_image_url
+	 * @uses self::get_options, apply_filters, Images::get_image, Images::fit_image_url
 	 * @return string
 	 */
 	protected function generate_related_post_image_params( $post_id ) {
@@ -1480,58 +1481,56 @@ EOT;
 		}
 
 		// Try to get post image.
-		if ( class_exists( 'Jetpack_PostImages' ) ) {
-			$img_url    = '';
-			$post_image = Jetpack_PostImages::get_image(
-				$post_id,
-				$thumbnail_size
-			);
+		$img_url    = '';
+		$post_image = Images::get_image(
+			$post_id,
+			$thumbnail_size
+		);
 
-			if ( is_array( $post_image ) ) {
-				$img_url = $post_image['src'];
-			} elseif ( class_exists( 'Jetpack_Media_Summary' ) ) {
-				$media = Jetpack_Media_Summary::get( $post_id );
+		if ( is_array( $post_image ) ) {
+			$img_url = $post_image['src'];
+		} elseif ( class_exists( 'Jetpack_Media_Summary' ) ) {
+			$media = Jetpack_Media_Summary::get( $post_id );
 
-				if ( is_array( $media ) && ! empty( $media['image'] ) ) {
-					$img_url = $media['image'];
-				}
+			if ( is_array( $media ) && ! empty( $media['image'] ) ) {
+				$img_url = $media['image'];
+			}
+		}
+
+		if ( ! empty( $img_url ) ) {
+			if ( ! empty( $post_image['alt_text'] ) ) {
+				$image_params['alt_text'] = $post_image['alt_text'];
+			} else {
+				$image_params['alt_text'] = '';
 			}
 
-			if ( ! empty( $img_url ) ) {
-				if ( ! empty( $post_image['alt_text'] ) ) {
-					$image_params['alt_text'] = $post_image['alt_text'];
-				} else {
-					$image_params['alt_text'] = '';
-				}
+			$thumbnail_width  = 0;
+			$thumbnail_height = 0;
 
-				$thumbnail_width  = 0;
-				$thumbnail_height = 0;
+			if ( ! empty( $thumbnail_size['width'] ) ) {
+				$thumbnail_width       = $thumbnail_size['width'];
+				$image_params['width'] = $thumbnail_width;
+			}
 
-				if ( ! empty( $thumbnail_size['width'] ) ) {
-					$thumbnail_width       = $thumbnail_size['width'];
-					$image_params['width'] = $thumbnail_width;
-				}
+			if ( ! empty( $thumbnail_size['height'] ) ) {
+				$thumbnail_height       = $thumbnail_size['height'];
+				$image_params['height'] = $thumbnail_height;
+			}
 
-				if ( ! empty( $thumbnail_size['height'] ) ) {
-					$thumbnail_height       = $thumbnail_size['height'];
-					$image_params['height'] = $thumbnail_height;
-				}
+			$image_params['src'] = Images::fit_image_url(
+				$img_url,
+				$thumbnail_width,
+				$thumbnail_height
+			);
 
-				$image_params['src'] = Jetpack_PostImages::fit_image_url(
-					$img_url,
-					$thumbnail_width,
-					$thumbnail_height
-				);
-
-				// Add a srcset to handle zoomed views and high-density screens.
-				$srcset = Jetpack_PostImages::generate_cropped_srcset(
-					$post_image,
-					$thumbnail_width,
-					$thumbnail_height
-				);
-				if ( ! empty( $srcset ) ) {
-					$image_params['srcset'] = $srcset;
-				}
+			// Add a srcset to handle zoomed views and high-density screens.
+			$srcset = Images::generate_cropped_srcset(
+				$post_image,
+				$thumbnail_width,
+				$thumbnail_height
+			);
+			if ( ! empty( $srcset ) ) {
+				$image_params['srcset'] = $srcset;
 			}
 		}
 

--- a/projects/plugins/jetpack/modules/sharedaddy/sharing-sources.php
+++ b/projects/plugins/jetpack/modules/sharedaddy/sharing-sources.php
@@ -6,6 +6,7 @@
  */
 
 use Automattic\Jetpack\Device_Detection\User_Agent_Info;
+use Automattic\Jetpack\Post_Media\Images;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit( 0 );
@@ -2709,11 +2710,9 @@ class Share_Pinterest extends Sharing_Source {
 	 * @return string
 	 */
 	public function get_image( $post ) {
-		if ( class_exists( 'Jetpack_PostImages' ) ) {
-			$image = Jetpack_PostImages::get_image( $post->ID, array( 'fallback_to_avatars' => true ) );
-			if ( ! empty( $image ) ) {
-				return $image['src'];
-			}
+		$image = Images::get_image( $post->ID, array( 'fallback_to_avatars' => true ) );
+		if ( ! empty( $image ) ) {
+			return $image['src'];
 		}
 
 		/**

--- a/projects/plugins/jetpack/modules/theme-tools/content-options/featured-images-fallback.php
+++ b/projects/plugins/jetpack/modules/theme-tools/content-options/featured-images-fallback.php
@@ -5,6 +5,8 @@
  * @package automattic/jetpack
  */
 
+use Automattic\Jetpack\Post_Media\Images;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit( 0 );
 }
@@ -43,96 +45,94 @@ if ( ! function_exists( 'jetpack_featured_images_fallback_get_image' ) ) {
 			}
 		}
 
-		if ( class_exists( 'Jetpack_PostImages' ) ) {
-			global $_wp_additional_image_sizes;
+		global $_wp_additional_image_sizes;
 
-			$args = array(
-				'from_thumbnail'  => false,
-				'from_slideshow'  => true,
-				'from_gallery'    => true,
-				'from_attachment' => false,
+		$args = array(
+			'from_thumbnail'  => false,
+			'from_slideshow'  => true,
+			'from_gallery'    => true,
+			'from_attachment' => false,
+		);
+
+		$image = Images::get_image( $post_id, $args );
+
+		if ( ! empty( $image ) ) {
+			$image['width']  = '';
+			$image['height'] = '';
+			$image['crop']   = '';
+
+			if ( array_key_exists( $size, $_wp_additional_image_sizes ) ) {
+				$image['width']  = $_wp_additional_image_sizes[ $size ]['width'];
+				$image['height'] = $_wp_additional_image_sizes[ $size ]['height'];
+				$image['crop']   = $_wp_additional_image_sizes[ $size ]['crop'];
+			}
+
+			// Force `crop` to be a simple boolean, to avoid dealing with WP crop positions.
+			$image['crop'] = boolval( $image['crop'] );
+
+			$image_sizes = '';
+
+			$width  = isset( $image['width'] ) ? intval( $image['width'] ) : null;
+			$height = isset( $image['height'] ) ? intval( $image['height'] ) : null;
+
+			if ( ! empty( $image['src_width'] ) && ! empty( $image['src_height'] ) && ! empty( $image['width'] ) && ! empty( $image['height'] ) ) {
+				$src_width  = intval( $image['src_width'] );
+				$src_height = intval( $image['src_height'] );
+
+				// If we're aware of the source dimensions, calculate the final image height and width.
+				// This allows us to provide them as attributes in the `<img>` tag, to avoid layout shifts.
+				// It also allows us to calculate a `srcset`.
+				if ( $image['crop'] ) {
+					// If we're cropping, the final dimensions are calculated independently of each other.
+					$width  = min( $width, $src_width );
+					$height = min( $height, $src_height );
+				} else {
+					// If we're not cropping, we need to preserve aspect ratio.
+					$dims   = wp_constrain_dimensions( $src_width, $src_height, $width, $height );
+					$width  = $dims[0];
+					$height = $dims[1];
+				}
+
+				$image_src    = Images::fit_image_url( $image['src'], $width, $height );
+				$image_srcset = Images::generate_cropped_srcset( $image, $width, $height, true );
+				$image_sizes  = 'min(' . $width . 'px, 100vw)';
+			} else {
+				// If we're not aware of the source dimensions, leave the size calculations to the CDN, and
+				// fall back to a simpler `<img>` tag without `width`/`height` or `srcset`.
+				$image_src = Images::fit_image_url( $image['src'], $image['width'], $image['height'] );
+
+				// Use the theme's crop setting rather than forcing to true.
+				$image_src = add_query_arg( 'crop', $image['crop'], $image_src );
+
+				$image_srcset = null;
+				$image_sizes  = null;
+			}
+
+			$default_attr = array(
+				'srcset'   => $image_srcset,
+				'sizes'    => $image_sizes,
+				'loading'  => is_singular() ? 'eager' : 'lazy',
+				'decoding' => 'async',
+				'title'    => wp_strip_all_tags( get_the_title() ),
+				'alt'      => '',
+				'class'    => "attachment-$size wp-post-image",
 			);
 
-			$image = Jetpack_PostImages::get_image( $post_id, $args );
+			$image_attr = wp_parse_args( $attr, $default_attr );
+			$hwstring   = image_hwstring( $width, $height );
 
-			if ( ! empty( $image ) ) {
-				$image['width']  = '';
-				$image['height'] = '';
-				$image['crop']   = '';
+			$html  = rtrim( "<img $hwstring" );
+			$html .= ' src="' . esc_url( $image_src ) . '"';
 
-				if ( array_key_exists( $size, $_wp_additional_image_sizes ) ) {
-					$image['width']  = $_wp_additional_image_sizes[ $size ]['width'];
-					$image['height'] = $_wp_additional_image_sizes[ $size ]['height'];
-					$image['crop']   = $_wp_additional_image_sizes[ $size ]['crop'];
+			foreach ( $image_attr as $name => $value ) {
+				if ( $value ) {
+					$html .= " $name=" . '"' . esc_attr( $value ) . '"';
 				}
-
-				// Force `crop` to be a simple boolean, to avoid dealing with WP crop positions.
-				$image['crop'] = boolval( $image['crop'] );
-
-				$image_sizes = '';
-
-				$width  = isset( $image['width'] ) ? intval( $image['width'] ) : null;
-				$height = isset( $image['height'] ) ? intval( $image['height'] ) : null;
-
-				if ( ! empty( $image['src_width'] ) && ! empty( $image['src_height'] ) && ! empty( $image['width'] ) && ! empty( $image['height'] ) ) {
-					$src_width  = intval( $image['src_width'] );
-					$src_height = intval( $image['src_height'] );
-
-					// If we're aware of the source dimensions, calculate the final image height and width.
-					// This allows us to provide them as attributes in the `<img>` tag, to avoid layout shifts.
-					// It also allows us to calculate a `srcset`.
-					if ( $image['crop'] ) {
-						// If we're cropping, the final dimensions are calculated independently of each other.
-						$width  = min( $width, $src_width );
-						$height = min( $height, $src_height );
-					} else {
-						// If we're not cropping, we need to preserve aspect ratio.
-						$dims   = wp_constrain_dimensions( $src_width, $src_height, $width, $height );
-						$width  = $dims[0];
-						$height = $dims[1];
-					}
-
-					$image_src    = Jetpack_PostImages::fit_image_url( $image['src'], $width, $height );
-					$image_srcset = Jetpack_PostImages::generate_cropped_srcset( $image, $width, $height, true );
-					$image_sizes  = 'min(' . $width . 'px, 100vw)';
-				} else {
-					// If we're not aware of the source dimensions, leave the size calculations to the CDN, and
-					// fall back to a simpler `<img>` tag without `width`/`height` or `srcset`.
-					$image_src = Jetpack_PostImages::fit_image_url( $image['src'], $image['width'], $image['height'] );
-
-					// Use the theme's crop setting rather than forcing to true.
-					$image_src = add_query_arg( 'crop', $image['crop'], $image_src );
-
-					$image_srcset = null;
-					$image_sizes  = null;
-				}
-
-				$default_attr = array(
-					'srcset'   => $image_srcset,
-					'sizes'    => $image_sizes,
-					'loading'  => is_singular() ? 'eager' : 'lazy',
-					'decoding' => 'async',
-					'title'    => wp_strip_all_tags( get_the_title() ),
-					'alt'      => '',
-					'class'    => "attachment-$size wp-post-image",
-				);
-
-				$image_attr = wp_parse_args( $attr, $default_attr );
-				$hwstring   = image_hwstring( $width, $height );
-
-				$html  = rtrim( "<img $hwstring" );
-				$html .= ' src="' . esc_url( $image_src ) . '"';
-
-				foreach ( $image_attr as $name => $value ) {
-					if ( $value ) {
-						$html .= " $name=" . '"' . esc_attr( $value ) . '"';
-					}
-				}
-
-				$html .= ' />';
-
-				return trim( $html );
 			}
+
+			$html .= ' />';
+
+			return trim( $html );
 		}
 
 		return trim( $html );
@@ -171,36 +171,34 @@ if ( ! function_exists( 'jetpack_featured_images_fallback_get_image_src' ) ) {
 			}
 		}
 
-		if ( class_exists( 'Jetpack_PostImages' ) ) {
-			global $_wp_additional_image_sizes;
+		global $_wp_additional_image_sizes;
 
-			$args = array(
-				'from_thumbnail'  => false,
-				'from_slideshow'  => true,
-				'from_gallery'    => true,
-				'from_attachment' => false,
-			);
+		$args = array(
+			'from_thumbnail'  => false,
+			'from_slideshow'  => true,
+			'from_gallery'    => true,
+			'from_attachment' => false,
+		);
 
-			$image = Jetpack_PostImages::get_image( $post_id, $args );
+		$image = Images::get_image( $post_id, $args );
 
-			if ( ! empty( $image ) ) {
-				$image['width']  = '';
-				$image['height'] = '';
-				$image['crop']   = '';
+		if ( ! empty( $image ) ) {
+			$image['width']  = '';
+			$image['height'] = '';
+			$image['crop']   = '';
 
-				if ( array_key_exists( $size, $_wp_additional_image_sizes ) ) {
-					$image['width']  = $_wp_additional_image_sizes[ $size ]['width'];
-					$image['height'] = $_wp_additional_image_sizes[ $size ]['height'];
-					$image['crop']   = $_wp_additional_image_sizes[ $size ]['crop'];
-				}
-
-				$image_src = Jetpack_PostImages::fit_image_url( $image['src'], $image['width'], $image['height'] );
-
-				// Use the theme's crop setting rather than forcing to true.
-				$image_src = add_query_arg( 'crop', $image['crop'], $image_src );
-
-				return esc_url( $image_src );
+			if ( array_key_exists( $size, $_wp_additional_image_sizes ) ) {
+				$image['width']  = $_wp_additional_image_sizes[ $size ]['width'];
+				$image['height'] = $_wp_additional_image_sizes[ $size ]['height'];
+				$image['crop']   = $_wp_additional_image_sizes[ $size ]['crop'];
 			}
+
+			$image_src = Images::fit_image_url( $image['src'], $image['width'], $image['height'] );
+
+			// Use the theme's crop setting rather than forcing to true.
+			$image_src = add_query_arg( 'crop', $image['crop'], $image_src );
+
+			return esc_url( $image_src );
 		}
 
 		return esc_url( $image_src );

--- a/projects/plugins/jetpack/modules/widgets/top-posts.php
+++ b/projects/plugins/jetpack/modules/widgets/top-posts.php
@@ -12,6 +12,7 @@
 
 // phpcs:disable Universal.Files.SeparateFunctionsFromOO.Mixed -- TODO: Move classes to appropriately-named class files.
 
+use Automattic\Jetpack\Post_Media\Images;
 use Automattic\Jetpack\Redirect;
 use Automattic\Jetpack\Stats\WPCOM_Stats;
 use Automattic\Jetpack\Status;
@@ -434,7 +435,7 @@ class Jetpack_Top_Posts_Widget extends WP_Widget {
 				}
 
 				foreach ( $posts as &$post ) {
-					$image = Jetpack_PostImages::get_image(
+					$image = Images::get_image(
 						$post['post_id'],
 						array(
 							'fallback_to_avatars' => (bool) $get_image_options['fallback_to_avatars'],
@@ -445,13 +446,13 @@ class Jetpack_Top_Posts_Widget extends WP_Widget {
 					);
 
 					if ( $image ) {
-						$post['image'] = Jetpack_PostImages::fit_image_url(
+						$post['image'] = Images::fit_image_url(
 							$image['src'],
 							$width,
 							$height
 						);
 
-						$post['image_srcset'] = Jetpack_PostImages::generate_cropped_srcset(
+						$post['image_srcset'] = Images::generate_cropped_srcset(
 							$image,
 							$width,
 							$height

--- a/projects/plugins/mu-wpcom-plugin/changelog/replace-jetpack-postimages
+++ b/projects/plugins/mu-wpcom-plugin/changelog/replace-jetpack-postimages
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock.
+
+

--- a/projects/plugins/mu-wpcom-plugin/composer.lock
+++ b/projects/plugins/mu-wpcom-plugin/composer.lock
@@ -394,11 +394,12 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/classic-theme-helper",
-                "reference": "f845c60c1f7aa13f5b66b488712dcdd816ad19db"
+                "reference": "2a0ad5d46ab475954e8ec3d2d633234c06316b91"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
                 "automattic/jetpack-blocks": "@dev",
+                "automattic/jetpack-post-media": "@dev",
                 "php": ">=7.2"
             },
             "require-dev": {
@@ -886,6 +887,67 @@
                 "GPL-2.0-or-later"
             ],
             "description": "Set up Google Analytics without touching a line of code.",
+            "transport-options": {
+                "relative": true
+            }
+        },
+        {
+            "name": "automattic/jetpack-image-cdn",
+            "version": "dev-trunk",
+            "dist": {
+                "type": "path",
+                "url": "../../packages/image-cdn",
+                "reference": "79b4ce2978edf4a5f586ceab9c2058a6cfcbef94"
+            },
+            "require": {
+                "automattic/jetpack-assets": "@dev",
+                "automattic/jetpack-status": "@dev",
+                "php": ">=7.2"
+            },
+            "require-dev": {
+                "automattic/jetpack-changelogger": "@dev",
+                "automattic/jetpack-test-environment": "@dev",
+                "automattic/phpunit-select-config": "@dev",
+                "yoast/phpunit-polyfills": "^4.0.0"
+            },
+            "suggest": {
+                "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
+            },
+            "type": "jetpack-library",
+            "extra": {
+                "mirror-repo": "Automattic/jetpack-image-cdn",
+                "changelogger": {
+                    "link-template": "https://github.com/Automattic/jetpack-image-cdn/compare/v${old}...v${new}"
+                },
+                "autotagger": true,
+                "branch-alias": {
+                    "dev-trunk": "0.7.x-dev"
+                },
+                "textdomain": "jetpack-image-cdn",
+                "version-constants": {
+                    "::PACKAGE_VERSION": "src/class-image-cdn.php"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "scripts": {
+                "phpunit": [
+                    "phpunit-select-config phpunit.#.xml.dist --colors=always"
+                ],
+                "test-coverage": [
+                    "php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\""
+                ],
+                "test-php": [
+                    "@composer phpunit"
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Serve images through Jetpack's powerful CDN",
             "transport-options": {
                 "relative": true
             }
@@ -1442,6 +1504,74 @@
                 "GPL-2.0-or-later"
             ],
             "description": "Fetch information about Jetpack Plans from wpcom",
+            "transport-options": {
+                "relative": true
+            }
+        },
+        {
+            "name": "automattic/jetpack-post-media",
+            "version": "dev-trunk",
+            "dist": {
+                "type": "path",
+                "url": "../../packages/post-media",
+                "reference": "28b5f5b5b8ca9858e6c5ce23a4e852c756713960"
+            },
+            "require": {
+                "automattic/block-delimiter": "@dev",
+                "automattic/jetpack-connection": "@dev",
+                "automattic/jetpack-image-cdn": "@dev",
+                "php": ">=7.2"
+            },
+            "require-dev": {
+                "automattic/jetpack-changelogger": "@dev",
+                "automattic/jetpack-test-environment": "@dev",
+                "automattic/phpunit-select-config": "@dev",
+                "yoast/phpunit-polyfills": "^4.0.0"
+            },
+            "suggest": {
+                "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
+            },
+            "type": "jetpack-library",
+            "extra": {
+                "autotagger": true,
+                "branch-alias": {
+                    "dev-trunk": "0.1.x-dev"
+                },
+                "changelogger": {
+                    "link-template": "https://github.com/Automattic/jetpack-post-media/compare/v${old}...v${new}"
+                },
+                "mirror-repo": "Automattic/jetpack-post-media",
+                "textdomain": "jetpack-post-media",
+                "version-constants": {
+                    "::PACKAGE_VERSION": "src/class-post-media.php"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "scripts": {
+                "build-development": [
+                    "echo 'Add your build step to composer.json, please!'"
+                ],
+                "build-production": [
+                    "echo 'Add your build step to composer.json, please!'"
+                ],
+                "phpunit": [
+                    "phpunit-select-config phpunit.#.xml.dist --colors=always"
+                ],
+                "test-coverage": [
+                    "php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\""
+                ],
+                "test-php": [
+                    "@composer phpunit"
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Tools to extract useful information and meta data from WordPress posts.",
             "transport-options": {
                 "relative": true
             }

--- a/projects/plugins/wpcomsh/changelog/replace-jetpack-postimages
+++ b/projects/plugins/wpcomsh/changelog/replace-jetpack-postimages
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock.
+
+

--- a/projects/plugins/wpcomsh/composer.lock
+++ b/projects/plugins/wpcomsh/composer.lock
@@ -531,11 +531,12 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/classic-theme-helper",
-                "reference": "f845c60c1f7aa13f5b66b488712dcdd816ad19db"
+                "reference": "2a0ad5d46ab475954e8ec3d2d633234c06316b91"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
                 "automattic/jetpack-blocks": "@dev",
+                "automattic/jetpack-post-media": "@dev",
                 "php": ">=7.2"
             },
             "require-dev": {
@@ -1095,6 +1096,67 @@
                 "GPL-2.0-or-later"
             ],
             "description": "Set up Google Analytics without touching a line of code.",
+            "transport-options": {
+                "relative": true
+            }
+        },
+        {
+            "name": "automattic/jetpack-image-cdn",
+            "version": "dev-trunk",
+            "dist": {
+                "type": "path",
+                "url": "../../packages/image-cdn",
+                "reference": "79b4ce2978edf4a5f586ceab9c2058a6cfcbef94"
+            },
+            "require": {
+                "automattic/jetpack-assets": "@dev",
+                "automattic/jetpack-status": "@dev",
+                "php": ">=7.2"
+            },
+            "require-dev": {
+                "automattic/jetpack-changelogger": "@dev",
+                "automattic/jetpack-test-environment": "@dev",
+                "automattic/phpunit-select-config": "@dev",
+                "yoast/phpunit-polyfills": "^4.0.0"
+            },
+            "suggest": {
+                "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
+            },
+            "type": "jetpack-library",
+            "extra": {
+                "mirror-repo": "Automattic/jetpack-image-cdn",
+                "changelogger": {
+                    "link-template": "https://github.com/Automattic/jetpack-image-cdn/compare/v${old}...v${new}"
+                },
+                "autotagger": true,
+                "branch-alias": {
+                    "dev-trunk": "0.7.x-dev"
+                },
+                "textdomain": "jetpack-image-cdn",
+                "version-constants": {
+                    "::PACKAGE_VERSION": "src/class-image-cdn.php"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "scripts": {
+                "phpunit": [
+                    "phpunit-select-config phpunit.#.xml.dist --colors=always"
+                ],
+                "test-coverage": [
+                    "php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\""
+                ],
+                "test-php": [
+                    "@composer phpunit"
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Serve images through Jetpack's powerful CDN",
             "transport-options": {
                 "relative": true
             }
@@ -1717,6 +1779,74 @@
                 "GPL-2.0-or-later"
             ],
             "description": "Enhance the classic view of the Admin section of your WordPress site",
+            "transport-options": {
+                "relative": true
+            }
+        },
+        {
+            "name": "automattic/jetpack-post-media",
+            "version": "dev-trunk",
+            "dist": {
+                "type": "path",
+                "url": "../../packages/post-media",
+                "reference": "28b5f5b5b8ca9858e6c5ce23a4e852c756713960"
+            },
+            "require": {
+                "automattic/block-delimiter": "@dev",
+                "automattic/jetpack-connection": "@dev",
+                "automattic/jetpack-image-cdn": "@dev",
+                "php": ">=7.2"
+            },
+            "require-dev": {
+                "automattic/jetpack-changelogger": "@dev",
+                "automattic/jetpack-test-environment": "@dev",
+                "automattic/phpunit-select-config": "@dev",
+                "yoast/phpunit-polyfills": "^4.0.0"
+            },
+            "suggest": {
+                "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
+            },
+            "type": "jetpack-library",
+            "extra": {
+                "autotagger": true,
+                "branch-alias": {
+                    "dev-trunk": "0.1.x-dev"
+                },
+                "changelogger": {
+                    "link-template": "https://github.com/Automattic/jetpack-post-media/compare/v${old}...v${new}"
+                },
+                "mirror-repo": "Automattic/jetpack-post-media",
+                "textdomain": "jetpack-post-media",
+                "version-constants": {
+                    "::PACKAGE_VERSION": "src/class-post-media.php"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "scripts": {
+                "build-development": [
+                    "echo 'Add your build step to composer.json, please!'"
+                ],
+                "build-production": [
+                    "echo 'Add your build step to composer.json, please!'"
+                ],
+                "phpunit": [
+                    "phpunit-select-config phpunit.#.xml.dist --colors=always"
+                ],
+                "test-coverage": [
+                    "php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\""
+                ],
+                "test-php": [
+                    "@composer phpunit"
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Tools to extract useful information and meta data from WordPress posts.",
             "transport-options": {
                 "relative": true
             }


### PR DESCRIPTION
Fixes CM-547

## Summary

Migrate all references to `Jetpack_PostImages` across the codebase to use the new `Automattic\Jetpack\Post_Media\Images` class introduced in #47208.

- Replace all `Jetpack_PostImages::` static method calls with `Images::` and add proper `use` imports
- Remove `class_exists('Jetpack_PostImages')` guards (the new class is autoloaded via Composer)
- Remove related phan suppression comments
- Add `automattic/jetpack-post-media` dependency to `classic-theme-helper`

The old `Jetpack_PostImages` class is not deprecated yet — that will follow in a separate PR.

## Does this pull request change what data or activity we track or use?

No

## Testing instructions

> [!NOTE]
> To test on a Jetpack site, you can also visit [this test site](https://honestly-miniature-phoenix.jurassic.ninja/wp-admin/options-general.php) where the branch is set up, and the site has some content.

1. Activate the Related Posts, sharing, stats, extra sidebar widgets, and Publicize features
2. Install a classic theme, and install and activate the Classic Widgets plugin
3. Add the Top Posts widget to your sidebar (in Appearance > Widgets) ; switch the settings to display an image list.
4. Create posts with featured images and posts without featured images but with images in the content.
5. Visit those posts in an incognito window.
6. Verify Open Graph meta tags include correct image URLs.
7. Verify sharing buttons (Pinterest) can find post images.
8. Verify Related Posts display images correctly (you need at least 10 posts for that).
9. Verify the Top Posts widget displays images (you need to wait a bit for the stats to pick visits after you visited a few posts)
10. Verify Twitter Cards include correct image meta tags.