### PR TITLE
Forms: Fix image-select field preview styling on wp-build dashboard

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-image-select-preview
+++ b/projects/packages/forms/changelog/fix-forms-image-select-preview
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix image-select field preview styling on the wp-build dashboard

--- a/projects/packages/forms/src/dashboard/components/inspector/response-fields/field-image-select/style.scss
+++ b/projects/packages/forms/src/dashboard/components/inspector/response-fields/field-image-select/style.scss
@@ -28,6 +28,7 @@
 
 		.jp-forms__image-select-preview-image {
 			object-fit: cover;
+			min-height: 144px;
 		}
 	}
 


### PR DESCRIPTION
## Proposed changes:
* Add `min-height: 144px` to the image-select preview image in the inspector sidebar, fixing the layout on the wp-build (alpha) dashboard where the images were collapsing to zero height.

Before:
<img width="406" height="295" alt="image" src="https://github.com/user-attachments/assets/2c2b64d8-495b-425f-83f2-bea6db6150d4" />

After:
<img width="407" height="288" alt="image" src="https://github.com/user-attachments/assets/b7691f73-72c3-4516-8139-56a535b53509" />


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
N/A — minor CSS fix for existing field preview.

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:

* Open the wp-build (alpha) Jetpack Forms dashboard
* Navigate to a form response that contains an image-select field
* Open the inspector sidebar for that response
* Verify the image-select preview images display correctly with proper height instead of collapsing
