### PR TITLE
Forms: Fix file-type icon paths and show image thumbnails in inspector

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-file-field-icons
+++ b/projects/packages/forms/changelog/fix-forms-file-field-icons
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix file-type icon paths and show image thumbnails for file fields in the inspector

--- a/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
@@ -1557,6 +1557,7 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 			'blogId'                         => get_current_blog_id(),
 			'gdriveConnectSupportURL'        => esc_url( Redirect::get_url( 'jetpack-support-contact-form-export' ) ),
 			'pluginAssetsURL'                => Jetpack_Forms::assets_url(),
+			'fileIconsUrl'                   => Jetpack_Forms::plugin_url() . 'contact-form/images/file-icons/',
 			'siteURL'                        => ( new Status() )->get_site_suffix(),
 			'hasFeedback'                    => ( new Forms_Dashboard() )->has_feedback(),
 			'isNotesEnabled'                 => Forms_Dashboard::is_notes_enabled(),

--- a/projects/packages/forms/src/dashboard/components/inspector/response-fields/field-file/file.tsx
+++ b/projects/packages/forms/src/dashboard/components/inspector/response-fields/field-file/file.tsx
@@ -6,53 +6,63 @@ import { decodeEntities } from '@wordpress/html-entities';
 import { __, sprintf } from '@wordpress/i18n';
 import { download } from '@wordpress/icons';
 import clsx from 'clsx';
+/**
+ * Internal dependencies
+ */
+import useConfigValue from '../../../../../hooks/use-config-value.ts';
+
+const extensionMap: Record< string, string > = {
+	pdf: 'pdf',
+	png: 'png',
+	jpg: 'png',
+	jpeg: 'png',
+	gif: 'png',
+	mp4: 'mp4',
+	mp3: 'mp3',
+	webm: 'mp4',
+	doc: 'doc',
+	docx: 'doc',
+	txt: 'txt',
+	ppt: 'ppt',
+	pptx: 'ppt',
+	xls: 'xls',
+	xlsx: 'xls',
+	csv: 'xls',
+	zip: 'zip',
+	sql: 'sql',
+	cal: 'cal',
+	html: 'html',
+};
+
+const mimeMap: Record< string, string > = {
+	image: 'png',
+	video: 'mp4',
+	audio: 'mp3',
+	document: 'pdf',
+	application: 'txt',
+};
 
 const FieldFile = ( { file, onClick } ) => {
 	const fileExtension = file.name.split( '.' ).pop().toLowerCase();
 	const fileType = file.type.split( '/' )[ 0 ];
+	const fileIconsUrl = useConfigValue( 'fileIconsUrl' );
 
-	const iconMap = {
-		image: 'png',
-		video: 'mp4',
-		audio: 'mp3',
-		document: 'pdf',
-		application: 'txt',
-	};
-
-	const extensionMap = {
-		pdf: 'pdf',
-		png: 'png',
-		jpg: 'png',
-		jpeg: 'png',
-		gif: 'png',
-		mp4: 'mp4',
-		mp3: 'mp3',
-		webm: 'webm',
-		doc: 'doc',
-		docx: 'doc',
-		txt: 'txt',
-		ppt: 'ppt',
-		pptx: 'ppt',
-		xls: 'xls',
-		xlsx: 'xls',
-		csv: 'xls',
-		zip: 'zip',
-		sql: 'sql',
-		cal: 'cal',
-	};
-	const iconType = extensionMap[ fileExtension ] || iconMap[ fileType ] || 'txt';
+	const iconType = extensionMap[ fileExtension ] || mimeMap[ fileType ] || 'txt';
 	const iconClass = clsx( 'jp-forms__inbox-response-file__icon', {
 		[ 'icon-' + iconType ]: ! file.is_previewable,
 		'has-thumbnail': file.is_previewable,
 	} );
 
-	const thumbnailStyle = file.is_previewable
-		? { backgroundImage: `url(${ file.url })`, backgroundSize: 'cover' }
-		: undefined;
+	let iconStyle;
+	if ( file.is_previewable ) {
+		iconStyle = { backgroundImage: `url(${ file.url })`, backgroundSize: 'cover' };
+	} else if ( fileIconsUrl ) {
+		iconStyle = { backgroundImage: `url(${ fileIconsUrl }${ iconType }.svg)` };
+	}
 	return (
 		<div className="jp-forms__inbox-response-file">
 			<div className="jp-forms__inbox-response-file__info">
-				<div className={ iconClass } style={ thumbnailStyle }></div>
+				<div className={ iconClass } style={ iconStyle }></div>
 				<div className="jp-forms__inbox-response-file__name">
 					{ file.is_previewable && (
 						<Button target="_blank" variant="link" onClick={ onClick }>

--- a/projects/packages/forms/src/dashboard/components/inspector/response-fields/field-file/file.tsx
+++ b/projects/packages/forms/src/dashboard/components/inspector/response-fields/field-file/file.tsx
@@ -41,11 +41,18 @@ const FieldFile = ( { file, onClick } ) => {
 		cal: 'cal',
 	};
 	const iconType = extensionMap[ fileExtension ] || iconMap[ fileType ] || 'txt';
-	const iconClass = clsx( 'jp-forms__inbox-response-file__icon', 'icon-' + iconType );
+	const iconClass = clsx( 'jp-forms__inbox-response-file__icon', {
+		[ 'icon-' + iconType ]: ! file.is_previewable,
+		'has-thumbnail': file.is_previewable,
+	} );
+
+	const thumbnailStyle = file.is_previewable
+		? { backgroundImage: `url(${ file.url })`, backgroundSize: 'cover' }
+		: undefined;
 	return (
 		<div className="jp-forms__inbox-response-file">
 			<div className="jp-forms__inbox-response-file__info">
-				<div className={ iconClass }></div>
+				<div className={ iconClass } style={ thumbnailStyle }></div>
 				<div className="jp-forms__inbox-response-file__name">
 					{ file.is_previewable && (
 						<Button target="_blank" variant="link" onClick={ onClick }>

--- a/projects/packages/forms/src/dashboard/components/inspector/response-fields/field-file/file.tsx
+++ b/projects/packages/forms/src/dashboard/components/inspector/response-fields/field-file/file.tsx
@@ -44,7 +44,7 @@ const mimeMap: Record< string, string > = {
 
 const FieldFile = ( { file, onClick } ) => {
 	const fileExtension = file.name.split( '.' ).pop().toLowerCase();
-	const fileType = file.type.split( '/' )[ 0 ];
+	const fileType = file.type?.split( '/' )?.[ 0 ];
 	const fileIconsUrl = useConfigValue( 'fileIconsUrl' );
 
 	const iconType = extensionMap[ fileExtension ] || mimeMap[ fileType ] || 'txt';

--- a/projects/packages/forms/src/dashboard/components/inspector/response-fields/field-file/style.scss
+++ b/projects/packages/forms/src/dashboard/components/inspector/response-fields/field-file/style.scss
@@ -75,6 +75,9 @@
 		background-image: url(../../../../../contact-form/images/file-icons/zip.svg);
 	}
 
+	&.has-thumbnail {
+		background-image: none;
+	}
 }
 
 .jp-forms__inbox-response-file__info {

--- a/projects/packages/forms/src/types/index.ts
+++ b/projects/packages/forms/src/types/index.ts
@@ -332,6 +332,8 @@ export interface FormsConfigData {
 	gdriveConnectSupportURL?: string;
 	/** Base URL to static/assets for the Forms package. */
 	pluginAssetsURL?: string;
+	/** Base URL to file-type icon SVGs (e.g. txt.svg, pdf.svg). */
+	fileIconsUrl?: string;
 	/** The site suffix/fragment for building admin links. */
 	siteURL?: string;
 	/** The dashboard URL with migration acknowledgement parameter. */


### PR DESCRIPTION
## Proposed changes:
* Show the actual uploaded image as a thumbnail in the inspector sidebar for previewable file fields (jpg, png, gif, webp) instead of a generic file-type icon.
* Fix broken file-type SVG icon paths on the wp-build (alpha) dashboard by resolving icon URLs at runtime via `fileIconsUrl` from the REST config, instead of relying on CSS `url()` references that are not rewritten at build time.
* Add `fileIconsUrl` to the REST endpoint config and the `FormsConfigData` type.

Before:
<img width="413" height="143" alt="image" src="https://github.com/user-attachments/assets/c72a481e-b706-4769-b238-68970a901a63" />
<img width="400" height="150" alt="image" src="https://github.com/user-attachments/assets/4c7e9439-6c84-435a-8e61-870c3d11ac63" />

After:
<img width="413" height="140" alt="image" src="https://github.com/user-attachments/assets/51d64d36-1119-422e-84a9-e878ff525343" />
<img width="406" height="158" alt="image" src="https://github.com/user-attachments/assets/cd0abaf8-b206-4090-8aca-790dc5703d6f" />


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
N/A — bug fix for existing file field preview in the inspector.

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:

* Open the Jetpack Forms dashboard (both Calypso/alpha and wp-admin)
* Navigate to a form response that has file upload attachments
* Open the inspector sidebar for that response
* Verify file-type icons (pdf, doc, mp3, etc.) display correctly — they should show the appropriate SVG icon
* For image files (jpg, png, gif, webp), verify the actual uploaded image is shown as a rounded thumbnail instead of a generic icon
* Click on a previewable image file and verify the preview still works
