### PR TITLE
AGENTS.md: Add testing prerequisites and jp CLI notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,6 +114,7 @@ jp test coverage <project>  # Generate coverage report
   1. `jp docker up -d` — Start Docker WordPress containers
   2. `jp docker install` — Install WordPress in Docker
   Then run: `jp test php plugins/jetpack`
+- If you've modified package versions or dependencies between monorepo packages, run `tools/fixup-project-versions.sh` to update lock files before testing.
 - If a project's `composer.json` doesn't define `test-js`, the JS test step is skipped automatically — this is normal, not an error.
 
 ### What to Test
@@ -124,6 +125,7 @@ After modifying a project, run its tests and static analysis:
 jp test php <project>           # PHP tests
 jp test js <project>            # JS tests (skipped if not defined)
 jp phan <project>               # Static analysis
+jp test coverage <project>      # Generate coverage report (optional)
 ```
 
 ### PHP Testing

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ Projects define build steps in `composer.json`:
 
 ## Jetpack CLI (`jp`)
 
-The `jp` command runs `pnpm jetpack` inside the monorepo Docker container. Install globally: `npm install -g @automattic/jetpack-cli`
+The `jp` command runs `pnpm jetpack` inside the monorepo Docker container. Install globally: `npm install -g @automattic/jetpack-cli` (this is a global install, safe to run even inside a Jetpack checkout). `jp` commands work from git worktrees — the CLI resolves to the monorepo root automatically.
 
 ### Common Commands
 
@@ -105,6 +105,25 @@ The `$$next-version$$` placeholder is automatically replaced with the correct ve
 jp test php <project> -v    # PHPUnit tests (verbose)
 jp test js <project>        # Jest tests
 jp test coverage <project>  # Generate coverage report
+```
+
+### Testing Prerequisites
+
+- **Packages** (`jp test php packages/...`, `jp test js packages/...`): Work immediately with no extra setup. The monorepo Docker container handles everything.
+- **Plugins**: Some plugins use mocked WordPress environments (WorDBless/Brain Monkey) and their tests work immediately. Others (notably `plugins/jetpack`) require a full WordPress test environment:
+  1. `jp docker up -d` — Start Docker WordPress containers
+  2. `jp docker install` — Install WordPress in Docker
+  Then run: `jp test php plugins/jetpack`
+- If a project's `composer.json` doesn't define `test-js`, the JS test step is skipped automatically — this is normal, not an error.
+
+### What to Test
+
+After modifying a project, run its tests and static analysis:
+
+```bash
+jp test php <project>           # PHP tests
+jp test js <project>            # JS tests (skipped if not defined)
+jp phan <project>               # Static analysis
 ```
 
 ### PHP Testing


### PR DESCRIPTION
Fixes #

## Proposed changes:

Prompted by:

> I need you to let me know if you can do this: "An agent can build the project and run tests on its own. It can verify its code compiles and doesn't break existing functionality without human hand-holding."
> Investigate how easy it is for you to do this without any instruction from me. If you run into problems, stop. The end goal is for your instructions (e.g. AGENTS.md, etc) to be clear enough for agents to build and run tests without any confusion.

An agent tried building and testing across the monorepo using only the existing AGENTS.md instructions. Packages worked fine—builds, PHP tests, JS tests, and Phan all ran without issues. Plugin integration tests (notably `plugins/jetpack`) failed with an unhelpful error about `WORDPRESS_DEVELOP_DIR` because the Docker WordPress prerequisite wasn't documented as a testing dependency.

This PR closes three documentation gaps:

* **Testing prerequisites**: Explains that package tests work immediately while some plugin tests need `jp docker up -d` + `jp docker install` first. Also notes that a missing `test-js` script is normal (not an error).
* **What to test**: Adds a quick-reference section for which verification commands to run after modifying a project.
* **jp CLI notes**: Clarifies that `npm install -g` is a safe global install (relevant because project-level CLAUDE.md rules restrict running `npm` in-checkout) and that `jp` works from git worktrees.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

N/A—documentation-only change.

## Jetpack product discussion

N/A

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

* Read through the updated `AGENTS.md` and verify the new sections make sense.
* Confirm the testing prerequisites match your understanding of the build/test setup.

## Changelog

- [x] Generate changelog entries for this PR (using AI).
