### PR TITLE
Forms: add pre-publish panel with settings summary

### DIFF
--- a/projects/packages/forms/changelog/add-forms-pre-publish-panel
+++ b/projects/packages/forms/changelog/add-forms-pre-publish-panel
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Forms: add pre-publish panel with settings summary and quick navigation to the form editor.

--- a/projects/packages/forms/src/blocks/contact-form/edit.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/edit.tsx
@@ -28,12 +28,13 @@ import { useInstanceId } from '@wordpress/compose';
 import { store as coreStore } from '@wordpress/core-data';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
-import { useRef, useEffect, useCallback, lazy, Suspense } from '@wordpress/element';
+import { useRef, useEffect, useCallback, lazy, Suspense, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
 /*
  * Internal dependencies
  */
+import { PANEL_STATE_STORE } from '../../form-editor/store/panel-state.ts';
 import useConfigValue from '../../hooks/use-config-value.ts';
 import { store as singleStepStore } from '../../store/form-step-preview.js';
 import {
@@ -306,6 +307,34 @@ function JetpackContactFormEdit( {
 			submitButton.attributes.lock = lock;
 		}
 	}, [ submitButton ] );
+
+	// Panel state management for pre-publish panel navigation
+	const activePanel = useSelect(
+		select => {
+			// Only subscribe to panel state in the form editor
+			if ( ! isJetpackFormEditor ) {
+				return null;
+			}
+			const panelStore = select( PANEL_STATE_STORE ) as {
+				getActivePanel: () => string | null;
+			};
+			return panelStore?.getActivePanel?.() ?? null;
+		},
+		[ isJetpackFormEditor ]
+	);
+	const { closePanel } = useDispatch( PANEL_STATE_STORE );
+
+	// Track open state for each panel - panels open when activePanel matches, then stay open
+	const [ openPanels, setOpenPanels ] = useState< Record< string, boolean > >( {} );
+
+	// When activePanel changes, open that panel and clear the store
+	useEffect( () => {
+		if ( activePanel ) {
+			setOpenPanels( prev => ( { ...prev, [ activePanel ]: true } ) );
+			// Clear the active panel from the store so it doesn't reopen on re-render
+			closePanel();
+		}
+	}, [ activePanel, closePanel ] );
 
 	const { isSingleStep, isFirstStep, isLastStep, currentStepClientId } = useSelect(
 		select => {
@@ -1026,6 +1055,13 @@ function JetpackContactFormEdit( {
 					<PanelBody
 						title={ __( 'Action after submit', 'jetpack-forms' ) }
 						initialOpen={ false }
+						opened={ openPanels[ 'action-after-submit' ] }
+						onToggle={ () =>
+							setOpenPanels( prev => ( {
+								...prev,
+								'action-after-submit': ! prev[ 'action-after-submit' ],
+							} ) )
+						}
 						className="jetpack-contact-form__panel"
 					>
 						<RadioControl
@@ -1099,6 +1135,13 @@ function JetpackContactFormEdit( {
 					<PanelBody
 						title={ __( 'Form notifications', 'jetpack-forms' ) }
 						initialOpen={ false }
+						opened={ openPanels[ 'form-notifications' ] }
+						onToggle={ () =>
+							setOpenPanels( prev => ( {
+								...prev,
+								'form-notifications': ! prev[ 'form-notifications' ],
+							} ) )
+						}
 						className="jetpack-contact-form__panel"
 					>
 						<NotificationsSettings
@@ -1133,6 +1176,13 @@ function JetpackContactFormEdit( {
 						title={ __( 'Responses storage', 'jetpack-forms' ) }
 						className="jetpack-contact-form__panel jetpack-contact-form__responses-storage-panel"
 						initialOpen={ false }
+						opened={ openPanels[ 'responses-storage' ] }
+						onToggle={ () =>
+							setOpenPanels( prev => ( {
+								...prev,
+								'responses-storage': ! prev[ 'responses-storage' ],
+							} ) )
+						}
 					>
 						<JetpackManageResponsesSettings
 							attributes={ attributes }

--- a/projects/packages/forms/src/form-editor/index.tsx
+++ b/projects/packages/forms/src/form-editor/index.tsx
@@ -482,3 +482,4 @@ setupFormEditorSubscription();
 
 // Import plugins
 import './plugins/preview-button';
+import './plugins/form-pre-publish-panel';

--- a/projects/packages/forms/src/form-editor/index.tsx
+++ b/projects/packages/forms/src/form-editor/index.tsx
@@ -12,6 +12,10 @@ import { subscribe, select, dispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { getPlugin, registerPlugin, unregisterPlugin } from '@wordpress/plugins';
 import { FORM_POST_TYPE } from '../blocks/shared/util/constants.js';
+import {
+	FormPrePublishPanel,
+	JETPACK_FORM_PRE_PUBLISH_PANEL,
+} from './plugins/form-pre-publish-panel';
 import { FormTitleModal } from './plugins/form-title-modal';
 import {
 	activateBlockCategoryOverrides,
@@ -352,11 +356,17 @@ const setupFormEditorSubscription = () => {
 					registerPlugin( NEW_FORMS_MODAL_PLUGIN, {
 						render: FormTitleModal,
 					} );
+
+					registerPlugin( JETPACK_FORM_PRE_PUBLISH_PANEL, { render: FormPrePublishPanel } );
 				} else {
 					// We just left the form editor.
 					document.body.classList.remove( 'post-type-jetpack_form' );
 					if ( getPlugin( NEW_FORMS_MODAL_PLUGIN ) ) {
 						unregisterPlugin( NEW_FORMS_MODAL_PLUGIN );
+					}
+
+					if ( getPlugin( JETPACK_FORM_PRE_PUBLISH_PANEL ) ) {
+						unregisterPlugin( JETPACK_FORM_PRE_PUBLISH_PANEL );
 					}
 
 					if ( state.categoriesSetUp ) {
@@ -482,4 +492,3 @@ setupFormEditorSubscription();
 
 // Import plugins
 import './plugins/preview-button';
-import './plugins/form-pre-publish-panel';

--- a/projects/packages/forms/src/form-editor/plugins/form-pre-publish-panel.scss
+++ b/projects/packages/forms/src/form-editor/plugins/form-pre-publish-panel.scss
@@ -1,7 +1,7 @@
 // Hide the default WordPress "Visibility" and "Publish: Immediately" rows
 // in the pre-publish sidebar — not relevant for forms.
 // This CSS only loads in the form editor context.
-.editor-post-publish-panel__prepublish > .components-panel__body:not( .jetpack-form-pre-publish-panel ) {
+.editor-post-publish-panel__prepublish > .components-panel__body:not(.jetpack-form-pre-publish-panel) {
 	display: none !important;
 }
 
@@ -12,7 +12,7 @@
 	flex-direction: column;
 
 	// Site info section (typically the second child)
-	> div:not( .components-panel__body ) {
+	> div:not(.components-panel__body) {
 		order: -1;
 	}
 

--- a/projects/packages/forms/src/form-editor/plugins/form-pre-publish-panel.scss
+++ b/projects/packages/forms/src/form-editor/plugins/form-pre-publish-panel.scss
@@ -1,111 +1,107 @@
-// Hide the default WordPress "Visibility" and "Publish: Immediately" rows
-// in the pre-publish sidebar — not relevant for forms.
-// This CSS only loads in the form editor context.
-.editor-post-publish-panel__prepublish > .components-panel__body:not(.jetpack-form-pre-publish-panel) {
-	display: none !important;
-}
-
-// Reorder the prepublish sidebar so the site info appears
-// above the "Are you ready to publish?" text.
-.editor-post-publish-panel__prepublish {
-	display: flex;
-	flex-direction: column;
-
-	// Site info section (typically the second child)
-	> div:not(.components-panel__body) {
-		order: -1;
-	}
-
-	// Hide the "Are you ready to publish?" text — not needed for forms.
-	> p,
-	> .editor-post-publish-panel__prepublish-checks {
-		display: none !important;
-	}
-}
-
-.jetpack-form-pre-publish-panel {
-	// Hide the default PanelBody collapsible header (toggle arrow + title)
-	.components-panel__body-toggle {
+// Styles scoped to the jetpack_form post type editor only.
+.post-type-jetpack_form {
+	// Hide the default WordPress "Visibility" and "Publish: Immediately" rows
+	// in the pre-publish sidebar — not relevant for forms.
+	.editor-post-publish-panel__prepublish > .components-panel__body:not(.jetpack-form-pre-publish-panel) {
 		display: none !important;
 	}
 
-	// Remove top border that PanelBody adds
-	&.components-panel__body {
-		border-top: none;
-	}
-
-	// Form identity card
-	.jetpack-form-pre-publish__form-card {
-		display: flex;
-		align-items: center;
-		gap: 12px;
-		padding: 4px 0 12px;
-	}
-
-	.jetpack-form-pre-publish__form-icon {
-		display: flex;
-		align-items: center;
-		justify-content: center;
-		width: 24px;
-		height: 24px;
-		color: #1e1e1e;
-
-		svg {
-			width: 24px;
-			height: 24px;
-		}
-	}
-
-	.jetpack-form-pre-publish__form-title {
-		font-size: 14px;
-		font-weight: 600;
-		color: #1e1e1e;
-		line-height: 24px;
-	}
-
-	// Preview button
-	.jetpack-form-pre-publish__preview-button {
-		width: 100%;
-		justify-content: center;
-		margin-bottom: 16px;
-	}
-
-	// Settings summary rows — uses WordPress's own .editor-post-panel__row
-	// classes for pixel-perfect matching with the Form tab sidebar.
-	// Override the default 38% label width so "Save responses" fits on one line
-	// and all values align at the same position.
-	.jetpack-form-pre-publish__settings {
+	// Reorder the prepublish sidebar so the site info appears
+	// above the "Are you ready to publish?" text.
+	.editor-post-publish-panel__prepublish {
 		display: flex;
 		flex-direction: column;
 
-		.editor-post-panel__row-label {
-			width: 50%;
-			white-space: nowrap;
+		// Site info section (typically the second child)
+		> div:not(.components-panel__body) {
+			order: -1;
 		}
 
-		.editor-post-panel__row-control {
-			display: flex;
-			justify-content: flex-end;
-			width: 50%;
-			overflow: hidden;
-
-			.components-button {
-				overflow: hidden;
-				text-overflow: ellipsis;
-				white-space: nowrap;
-				max-width: 100%;
-			}
+		// hides "Double-check your settings before publishing."
+		> p,
+		> .editor-post-publish-panel__prepublish-checks {
+			display: none !important;
 		}
 	}
 
-	// Integration icons row
-	.jetpack-form-pre-publish__integration-icons {
-		display: flex;
-		align-items: center;
-		gap: 4px;
+	.jetpack-form-pre-publish-panel {
+		// Hide the default PanelBody collapsible header (toggle arrow + title)
+		.components-panel__body-toggle {
+			display: none !important;
+		}
 
-		svg {
-			flex-shrink: 0;
+		// Remove top border that PanelBody adds
+		&.components-panel__body {
+			border-top: none;
+		}
+
+		// Form identity card
+		.jetpack-form-pre-publish__form-card {
+			display: flex;
+			align-items: center;
+			gap: 12px;
+			padding: 4px 0 12px;
+		}
+
+		.jetpack-form-pre-publish__form-icon {
+			display: flex;
+			align-items: center;
+			justify-content: center;
+			width: 24px;
+			height: 24px;
+			color: #1e1e1e;
+
+			svg {
+				width: 24px;
+				height: 24px;
+			}
+		}
+
+		.jetpack-form-pre-publish__form-title {
+			font-size: 14px;
+			font-weight: 600;
+			color: #1e1e1e;
+			line-height: 24px;
+		}
+
+		// Preview button
+		.jetpack-form-pre-publish__preview-button {
+			width: 100%;
+			justify-content: center;
+			margin-bottom: 16px;
+		}
+
+		// Settings summary rows — uses WordPress's own .editor-post-panel__row
+		// classes for pixel-perfect matching with the Form tab sidebar.
+		// Override the default 38% label width so "Save responses" fits on one line
+		// and all values align at the same position.
+		.jetpack-form-pre-publish__settings {
+			display: flex;
+			flex-direction: column;
+			padding-bottom: 10px;
+
+			&:last-child {
+				padding-bottom: 0;
+			}
+
+			.editor-post-panel__row-label {
+				width: 50%;
+				white-space: nowrap;
+			}
+
+			.editor-post-panel__row-control {
+				display: flex;
+				justify-content: flex-end;
+				width: 50%;
+			}
+		}
+
+		// Integration icons row
+		.jetpack-form-pre-publish__integration-icons {
+			display: flex;
+			align-items: center;
+			gap: 4px;
+			margin-bottom: -2px;
 		}
 	}
 }

--- a/projects/packages/forms/src/form-editor/plugins/form-pre-publish-panel.scss
+++ b/projects/packages/forms/src/form-editor/plugins/form-pre-publish-panel.scss
@@ -1,0 +1,111 @@
+// Hide the default WordPress "Visibility" and "Publish: Immediately" rows
+// in the pre-publish sidebar — not relevant for forms.
+// This CSS only loads in the form editor context.
+.editor-post-publish-panel__prepublish > .components-panel__body:not( .jetpack-form-pre-publish-panel ) {
+	display: none !important;
+}
+
+// Reorder the prepublish sidebar so the site info appears
+// above the "Are you ready to publish?" text.
+.editor-post-publish-panel__prepublish {
+	display: flex;
+	flex-direction: column;
+
+	// Site info section (typically the second child)
+	> div:not( .components-panel__body ) {
+		order: -1;
+	}
+
+	// Hide the "Are you ready to publish?" text — not needed for forms.
+	> p,
+	> .editor-post-publish-panel__prepublish-checks {
+		display: none !important;
+	}
+}
+
+.jetpack-form-pre-publish-panel {
+	// Hide the default PanelBody collapsible header (toggle arrow + title)
+	.components-panel__body-toggle {
+		display: none !important;
+	}
+
+	// Remove top border that PanelBody adds
+	&.components-panel__body {
+		border-top: none;
+	}
+
+	// Form identity card
+	.jetpack-form-pre-publish__form-card {
+		display: flex;
+		align-items: center;
+		gap: 12px;
+		padding: 4px 0 12px;
+	}
+
+	.jetpack-form-pre-publish__form-icon {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		width: 24px;
+		height: 24px;
+		color: #1e1e1e;
+
+		svg {
+			width: 24px;
+			height: 24px;
+		}
+	}
+
+	.jetpack-form-pre-publish__form-title {
+		font-size: 14px;
+		font-weight: 600;
+		color: #1e1e1e;
+		line-height: 24px;
+	}
+
+	// Preview button
+	.jetpack-form-pre-publish__preview-button {
+		width: 100%;
+		justify-content: center;
+		margin-bottom: 16px;
+	}
+
+	// Settings summary rows — uses WordPress's own .editor-post-panel__row
+	// classes for pixel-perfect matching with the Form tab sidebar.
+	// Override the default 38% label width so "Save responses" fits on one line
+	// and all values align at the same position.
+	.jetpack-form-pre-publish__settings {
+		display: flex;
+		flex-direction: column;
+
+		.editor-post-panel__row-label {
+			width: 50%;
+			white-space: nowrap;
+		}
+
+		.editor-post-panel__row-control {
+			display: flex;
+			justify-content: flex-end;
+			width: 50%;
+			overflow: hidden;
+
+			.components-button {
+				overflow: hidden;
+				text-overflow: ellipsis;
+				white-space: nowrap;
+				max-width: 100%;
+			}
+		}
+	}
+
+	// Integration icons row
+	.jetpack-form-pre-publish__integration-icons {
+		display: flex;
+		align-items: center;
+		gap: 4px;
+
+		svg {
+			flex-shrink: 0;
+		}
+	}
+}

--- a/projects/packages/forms/src/form-editor/plugins/form-pre-publish-panel.tsx
+++ b/projects/packages/forms/src/form-editor/plugins/form-pre-publish-panel.tsx
@@ -21,6 +21,7 @@ import IntegrationsModal from '../../blocks/contact-form/components/jetpack-inte
 import { settings as formBlockSettings } from '../../blocks/contact-form/index.js';
 import { FORM_POST_TYPE, FORM_BLOCK_NAME } from '../../blocks/shared/util/constants.js';
 import { INTEGRATIONS_STORE } from '../../store/integrations/index.ts';
+import { PANEL_STATE_STORE } from '../store/panel-state.ts';
 import IntegrationIcons from './integration-icons.tsx';
 import type { Integration } from '../../types/index.ts';
 import type { Block } from '@wordpress/blocks';
@@ -120,6 +121,8 @@ export const FormPrePublishPanel = () => {
 	const { createErrorNotice } = useDispatch( noticesStore );
 	const { closePublishSidebar } = useDispatch( editorStore );
 	const { selectBlock, updateBlockAttributes } = useDispatch( blockEditorStore );
+	const { enableComplementaryArea } = useDispatch( 'core/interface' );
+	const { openPanel } = useDispatch( PANEL_STATE_STORE );
 
 	// Integrations store data for the modal
 	const integrationsData = useSelect( select => {
@@ -168,170 +171,35 @@ export const FormPrePublishPanel = () => {
 	}, [ postId, isPreviewLoading, isDirty, isAutosaveable, autosave, createErrorNotice ] );
 
 	/**
-	 * Navigate to a specific settings panel in the block inspector.
+	 * Open the block inspector sidebar and expand a specific panel.
+	 * Uses the panel-state store to communicate with the block's edit component.
 	 *
-	 * Flow:
-	 * 1. Close the publish sidebar
-	 * 2. Open the block inspector sidebar via wp.data store
-	 * 3. Select the form block
-	 * 4. Wait for the sidebar to render, then click the Block tab + Settings sub-tab
-	 * 5. Wait for the inspector panels to render, then open the target panel
-	 *
-	 * @param {string} panelTitle - The title of the panel to open.
+	 * @param {string} panelName - The panel to open.
 	 */
 	const openInspectorPanel = useCallback(
-		( panelTitle: string ) => {
-			// Step 1: Close the pre-publish sidebar
+		( panelName: 'action-after-submit' | 'form-notifications' | 'responses-storage' ) => {
 			closePublishSidebar();
-
-			// Step 2: Select the form block
 			selectBlock( clientId );
-
-			// Step 3: Use the openGeneralSidebar API to request the block inspector sidebar,
-			// then use a retry loop for the DOM tab click and panel expansion.
-			const wpData = (
-				window as unknown as {
-					wp: {
-						data: {
-							dispatch: ( storeKey: string ) => Record< string, ( ...args: unknown[] ) => unknown >;
-						};
-					};
-				}
-			 ).wp?.data;
-
-			if ( wpData ) {
-				try {
-					wpData.dispatch( 'core/edit-post' ).openGeneralSidebar( 'edit-post/block' );
-				} catch {
-					try {
-						wpData
-							.dispatch( 'core/interface' )
-							.enableComplementaryArea( 'core', 'edit-post/block' );
-					} catch {
-						// Silently fail — the retry loop will handle sidebar activation via DOM.
-					}
-				}
-			}
-
-			const tryOpen = ( attempt: number ) => {
-				if ( attempt > 20 ) {
-					return;
-				}
-				setTimeout( () => {
-					// 3a: Find and click the top-level "Block" tab.
-					const sidebar =
-						document.querySelector( '.interface-complementary-area' ) ||
-						document.querySelector( '.edit-post-sidebar' );
-					if ( ! sidebar ) {
-						tryOpen( attempt + 1 );
-						return;
-					}
-
-					const topTabs = sidebar.querySelectorAll(
-						':scope > [role="tablist"] > [role="tab"], :scope [role="tablist"] [role="tab"]'
-					);
-					let blockTabActive = false;
-					for ( const tab of topTabs ) {
-						if ( tab.textContent?.trim() === 'Block' ) {
-							if ( ( tab as HTMLElement ).getAttribute( 'aria-selected' ) !== 'true' ) {
-								( tab as HTMLElement ).click();
-								tryOpen( attempt + 1 );
-								return;
-							}
-							blockTabActive = true;
-							break;
-						}
-					}
-
-					if ( ! blockTabActive ) {
-						tryOpen( attempt + 1 );
-						return;
-					}
-
-					// 3b: Inside the block inspector, click the "Settings" sub-tab
-					// (the gear icon — the second of the three icon tabs).
-					const inspector = sidebar.querySelector( '.block-editor-block-inspector' );
-					if ( ! inspector ) {
-						tryOpen( attempt + 1 );
-						return;
-					}
-
-					const subTabs = inspector.querySelectorAll( '[role="tab"]' );
-					let settingsTabActive = false;
-					for ( const tab of subTabs ) {
-						const tabLabel = (
-							tab.getAttribute( 'aria-label' ) ||
-							tab.textContent ||
-							''
-						).toLowerCase();
-						if ( tabLabel.includes( 'settings' ) || tabLabel.includes( 'setting' ) ) {
-							if ( ( tab as HTMLElement ).getAttribute( 'aria-selected' ) !== 'true' ) {
-								( tab as HTMLElement ).click();
-								tryOpen( attempt + 1 );
-								return;
-							}
-							settingsTabActive = true;
-							break;
-						}
-					}
-
-					// Fallback: try the second tab in the inspector sub-tab list.
-					if ( ! settingsTabActive && subTabs.length >= 2 ) {
-						const secondTab = subTabs[ 1 ] as HTMLElement;
-						if ( secondTab.getAttribute( 'aria-selected' ) !== 'true' ) {
-							secondTab.click();
-							tryOpen( attempt + 1 );
-							return;
-						}
-						settingsTabActive = true;
-					}
-
-					if ( ! settingsTabActive ) {
-						tryOpen( attempt + 1 );
-						return;
-					}
-
-					// 3c: Settings sub-tab is active — find and open the target panel
-					const panels = document.querySelectorAll( '.components-panel__body-toggle' );
-					let found = false;
-					for ( const toggle of panels ) {
-						if ( toggle.textContent?.includes( panelTitle ) ) {
-							if ( toggle.getAttribute( 'aria-expanded' ) === 'false' ) {
-								( toggle as HTMLElement ).click();
-							}
-							( toggle as HTMLElement ).scrollIntoView( {
-								behavior: 'smooth',
-								block: 'start',
-							} );
-							found = true;
-							break;
-						}
-					}
-
-					if ( ! found ) {
-						tryOpen( attempt + 1 );
-					}
-				}, 150 );
-			};
-			tryOpen( 0 );
+			enableComplementaryArea( 'core/edit-post', 'edit-post/block' );
+			openPanel( panelName );
 		},
-		[ closePublishSidebar, selectBlock, clientId ]
+		[ closePublishSidebar, selectBlock, clientId, enableComplementaryArea, openPanel ]
 	);
 
 	// Click handlers for settings rows
 	const handleConfirmationClick = useCallback(
-		() => openInspectorPanel( __( 'Action after submit', 'jetpack-forms' ) ),
+		() => openInspectorPanel( 'action-after-submit' ),
 		[ openInspectorPanel ]
 	);
-	const handleEmailClick = useCallback(
-		() => openInspectorPanel( __( 'Form notifications', 'jetpack-forms' ) ),
+	const handleNotificationsClick = useCallback(
+		() => openInspectorPanel( 'form-notifications' ),
+		[ openInspectorPanel ]
+	);
+	const handleResponsesClick = useCallback(
+		() => openInspectorPanel( 'responses-storage' ),
 		[ openInspectorPanel ]
 	);
 	const handleIntegrationsClick = useCallback( () => setIsIntegrationsModalOpen( true ), [] );
-	const handleResponsesClick = useCallback(
-		() => openInspectorPanel( __( 'Responses storage', 'jetpack-forms' ) ),
-		[ openInspectorPanel ]
-	);
 	const handleIntegrationsModalClose = useCallback( () => setIsIntegrationsModalOpen( false ), [] );
 
 	// Only render for jetpack_form post type
@@ -432,12 +300,12 @@ export const FormPrePublishPanel = () => {
 				<SettingRow
 					label={ __( 'Email notifications', 'jetpack-forms' ) }
 					value={ emailsLabel }
-					onClick={ handleEmailClick }
+					onClick={ handleNotificationsClick }
 				/>
 				<SettingRow
 					label={ __( 'Push notifications', 'jetpack-forms' ) }
 					value={ notificationsLabel }
-					onClick={ handleEmailClick }
+					onClick={ handleNotificationsClick }
 				/>
 				<SettingRow
 					label={ __( 'Integrations', 'jetpack-forms' ) }

--- a/projects/packages/forms/src/form-editor/plugins/form-pre-publish-panel.tsx
+++ b/projects/packages/forms/src/form-editor/plugins/form-pre-publish-panel.tsx
@@ -34,10 +34,10 @@ import './form-pre-publish-panel.scss';
  * Uses the same structure as WordPress's PostPanelRow component
  * (HStack with editor-post-panel__row classes) for pixel-perfect matching.
  *
- * @param {object}              props         - Component props.
- * @param {string}              props.label   - The row label.
- * @param {string|JSX.Element}  props.value   - The row value.
- * @param {Function}            props.onClick - Click handler for the value button.
+ * @param {object} props         - Component props.
+ * @param {string} props.label   - The row label.
+ * @param {string|JSX.Element} props.value - The row value.
+ * @param {Function} props.onClick - Click handler for the value button.
  * @return {JSX.Element} The setting row element.
  */
 const SettingRow = ( {
@@ -160,7 +160,7 @@ const FormPrePublishPanel = () => {
 				path: `/wp/v2/jetpack-forms/${ postId }/preview-url`,
 			} );
 			window.open( response.preview_url, '_blank' );
-		} catch ( error ) { // eslint-disable-line no-unused-vars
+		} catch {
 			createErrorNotice(
 				__( 'Failed to generate preview URL. Please try again.', 'jetpack-forms' ),
 				{ type: 'snackbar' }
@@ -196,23 +196,21 @@ const FormPrePublishPanel = () => {
 				window as unknown as {
 					wp: {
 						data: {
-							dispatch: (
-								storeKey: string
-							) => Record< string, ( ...args: unknown[] ) => unknown >;
+							dispatch: ( storeKey: string ) => Record< string, ( ...args: unknown[] ) => unknown >;
 						};
 					};
 				}
-			).wp?.data;
+			 ).wp?.data;
 
 			if ( wpData ) {
 				try {
 					wpData.dispatch( 'core/edit-post' ).openGeneralSidebar( 'edit-post/block' );
-				} catch ( e ) { // eslint-disable-line no-unused-vars
+				} catch {
 					try {
 						wpData
 							.dispatch( 'core/interface' )
 							.enableComplementaryArea( 'core', 'edit-post/block' );
-					} catch ( e2 ) { // eslint-disable-line no-unused-vars
+					} catch {
 						// Silently fail — the retry loop will handle sidebar activation via DOM.
 					}
 				}
@@ -332,18 +330,12 @@ const FormPrePublishPanel = () => {
 		() => openInspectorPanel( __( 'Form notifications', 'jetpack-forms' ) ),
 		[ openInspectorPanel ]
 	);
-	const handleIntegrationsClick = useCallback(
-		() => setIsIntegrationsModalOpen( true ),
-		[]
-	);
+	const handleIntegrationsClick = useCallback( () => setIsIntegrationsModalOpen( true ), [] );
 	const handleResponsesClick = useCallback(
 		() => openInspectorPanel( __( 'Responses storage', 'jetpack-forms' ) ),
 		[ openInspectorPanel ]
 	);
-	const handleIntegrationsModalClose = useCallback(
-		() => setIsIntegrationsModalOpen( false ),
-		[]
-	);
+	const handleIntegrationsModalClose = useCallback( () => setIsIntegrationsModalOpen( false ), [] );
 
 	// Only render for jetpack_form post type
 	if ( postType !== FORM_POST_TYPE ) {
@@ -493,7 +485,11 @@ const FormPrePublishPanel = () => {
 				/>
 				<SettingRow
 					label={ __( 'Save responses', 'jetpack-forms' ) }
-					value={ saveResponses ? __( 'Yes', 'jetpack-forms' ) : _x( 'No', 'save responses', 'jetpack-forms' ) }
+					value={
+						saveResponses
+							? __( 'Yes', 'jetpack-forms' )
+							: _x( 'No', 'save responses', 'jetpack-forms' )
+					}
 					onClick={ handleResponsesClick }
 				/>
 			</div>

--- a/projects/packages/forms/src/form-editor/plugins/form-pre-publish-panel.tsx
+++ b/projects/packages/forms/src/form-editor/plugins/form-pre-publish-panel.tsx
@@ -1,0 +1,489 @@
+/**
+ * External dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+import { store as blockEditorStore } from '@wordpress/block-editor';
+import {
+	Button,
+	__experimentalHStack as HStack, // eslint-disable-line @wordpress/no-unsafe-wp-apis
+} from '@wordpress/components';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { PluginPrePublishPanel, store as editorStore } from '@wordpress/editor';
+import { useCallback, useMemo, useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { page as pageIcon } from '@wordpress/icons';
+import { store as noticesStore } from '@wordpress/notices';
+import { registerPlugin } from '@wordpress/plugins';
+
+/**
+ * Internal dependencies
+ */
+import ConsentToggle from '../../blocks/contact-form/components/jetpack-integrations-modal/components/consent-toggle.tsx';
+import IntegrationsModal from '../../blocks/contact-form/components/jetpack-integrations-modal/index.tsx';
+import { FORM_POST_TYPE, FORM_BLOCK_NAME } from '../../blocks/shared/util/constants.js';
+import AkismetIcon from '../../icons/akismet';
+import GoogleSheetsIcon from '../../icons/google-sheets';
+import HostingerReachIcon from '../../icons/hostinger-reach';
+import MailPoetIcon from '../../icons/mailpoet';
+import SalesforceIcon from '../../icons/salesforce';
+import { INTEGRATIONS_STORE } from '../../store/integrations/index.ts';
+import './form-pre-publish-panel.scss';
+
+/**
+ * A single settings summary row displayed in the pre-publish panel.
+ * Uses the same structure as WordPress's PostPanelRow component
+ * (HStack with editor-post-panel__row classes) for pixel-perfect matching.
+ * @param root0
+ * @param root0.label
+ * @param root0.value
+ * @param root0.onClick
+ */
+const SettingRow = ( {
+	label,
+	value,
+	onClick,
+}: {
+	label: string;
+	value: string | JSX.Element;
+	onClick?: () => void;
+} ) => {
+	return (
+		<HStack className="editor-post-panel__row">
+			<div className="editor-post-panel__row-label">{ label }</div>
+			<div className="editor-post-panel__row-control">
+				<Button variant="tertiary" onClick={ onClick } disabled={ ! onClick }>
+					{ value }
+				</Button>
+			</div>
+		</HStack>
+	);
+};
+
+/**
+ * Get the contact-form block attributes from the editor.
+ * Since the form editor always has exactly one contact-form block,
+ * we find it and return its attributes.
+ */
+const useFormAttributes = () => {
+	return useSelect( select => {
+		const { getBlocks } = select( blockEditorStore ) as {
+			getBlocks: () => Array< {
+				name: string;
+				clientId: string;
+				attributes: Record< string, unknown >;
+			} >;
+		};
+
+		const blocks = getBlocks();
+		const formBlock = blocks.find( block => block.name === FORM_BLOCK_NAME );
+
+		return {
+			formBlock,
+			attributes: ( formBlock?.attributes || {} ) as Record< string, unknown >,
+			clientId: formBlock?.clientId || '',
+		};
+	}, [] );
+};
+
+/**
+ * Hook to update contact-form block attributes from outside the block.
+ */
+
+/**
+ * Form Pre-Publish Panel component.
+ *
+ * Displays a summary of form settings in the WordPress pre-publish sidebar,
+ * allowing users to review and adjust settings before publishing.
+ */
+const FormPrePublishPanel = () => {
+	const [ isPreviewLoading, setIsPreviewLoading ] = useState( false );
+	const [ isIntegrationsModalOpen, setIsIntegrationsModalOpen ] = useState( false );
+
+	const { postType, postTitle, postId, isDirty, isAutosaveable } = useSelect( select => {
+		const editor = select( editorStore ) as {
+			getCurrentPostType: () => string;
+			getEditedPostAttribute: ( attr: string ) => unknown;
+			getCurrentPostId: () => number;
+			isEditedPostDirty: () => boolean;
+			isEditedPostAutosaveable: () => boolean;
+		};
+
+		return {
+			postType: editor.getCurrentPostType(),
+			postTitle: editor.getEditedPostAttribute( 'title' ) as string,
+			postId: editor.getCurrentPostId(),
+			isDirty: editor.isEditedPostDirty(),
+			isAutosaveable: editor.isEditedPostAutosaveable(),
+		};
+	} );
+
+	const { attributes, clientId } = useFormAttributes();
+	const { autosave } = useDispatch( 'core/editor' );
+	const { createErrorNotice } = useDispatch( noticesStore );
+	const { closePublishSidebar } = useDispatch( editorStore );
+	const { selectBlock } = useDispatch( blockEditorStore );
+	const { updateBlockAttributes } = useDispatch( blockEditorStore );
+
+	// Integrations store data for the modal
+	const integrationsData = useSelect( select => {
+		const store = select( INTEGRATIONS_STORE ) as {
+			getIntegrations: () => Array< Record< string, unknown > >;
+		};
+		return store.getIntegrations() || [];
+	}, [] );
+	const { refreshIntegrations } = useDispatch( INTEGRATIONS_STORE );
+	const modalComponents = useMemo( () => ( { ConsentToggle } ), [] );
+
+	// setAttributes wrapper for the integrations modal
+	const setFormAttributes = useCallback(
+		( newAttributes: Record< string, unknown > ) => {
+			if ( clientId ) {
+				updateBlockAttributes( clientId, newAttributes );
+			}
+		},
+		[ clientId, updateBlockAttributes ]
+	);
+
+	// Only render for jetpack_form post type
+	if ( postType !== FORM_POST_TYPE ) {
+		return null;
+	}
+
+	// Extract form settings from block attributes
+	const confirmationType = ( attributes.confirmationType as string ) || 'text';
+	const emailNotifications = attributes.emailNotifications !== false;
+	const emailTo = ( attributes.to as string ) || '';
+	const notificationRecipients = ( attributes.notificationRecipients as string[] ) || [];
+	const hasNotifications = notificationRecipients.length > 0;
+	const saveResponses = attributes.saveResponses !== false;
+
+	// Determine active integrations and collect their icons
+	const integrationIcons: JSX.Element[] = [];
+
+	// Akismet is always active by default
+	integrationIcons.push( <AkismetIcon key="akismet" width={ 20 } height={ 20 } /> );
+
+	if ( attributes.jetpackCRM ) {
+		// Use the Jetpack green icon for CRM
+		integrationIcons.push(
+			<svg
+				key="jetpack-crm"
+				width="20"
+				height="20"
+				viewBox="0 0 32 32"
+				fill="none"
+				xmlns="http://www.w3.org/2000/svg"
+			>
+				<path
+					d="M16 0C7.2 0 0 7.2 0 16s7.2 16 16 16 16-7.2 16-16S24.8 0 16 0zm-2.4 24.8L7.2 14.4l2.4-1.6 4 5.6 8.8-12 2.4 1.6-11.2 16.8z"
+					fill="#069e08"
+				/>
+			</svg>
+		);
+	}
+
+	const salesforceData = attributes.salesforceData as { organizationId?: string } | undefined;
+	if ( salesforceData?.organizationId ) {
+		integrationIcons.push( <SalesforceIcon key="salesforce" width={ 20 } height={ 20 } /> );
+	}
+
+	const mailpoet = attributes.mailpoet as { listId?: string | null } | undefined;
+	if ( mailpoet?.listId ) {
+		integrationIcons.push( <MailPoetIcon key="mailpoet" width={ 20 } height={ 20 } /> );
+	}
+
+	const hostingerReach = attributes.hostingerReach as { groupName?: string } | undefined;
+	if ( hostingerReach?.groupName ) {
+		integrationIcons.push( <HostingerReachIcon key="hostinger" width={ 20 } height={ 20 } /> );
+	}
+
+	// Google Sheets integration
+	if ( attributes.googleSheets ) {
+		integrationIcons.push( <GoogleSheetsIcon key="google-sheets" width={ 20 } height={ 20 } /> );
+	}
+
+	const integrationsValue = (
+		<span className="jetpack-form-pre-publish__integration-icons">{ integrationIcons }</span>
+	);
+
+	// Format confirmation type for display
+	const confirmationLabel =
+		confirmationType === 'redirect'
+			? __( 'Redirect', 'jetpack-forms' )
+			: __( 'Text', 'jetpack-forms' );
+
+	// Format email recipients — show the address or count
+	let emailsLabel: string;
+	if ( ! emailNotifications ) {
+		emailsLabel = __( 'Disabled', 'jetpack-forms' );
+	} else if ( emailTo ) {
+		const recipients = emailTo
+			.split( ',' )
+			.map( e => e.trim() )
+			.filter( Boolean );
+		if ( recipients.length === 1 ) {
+			emailsLabel = __( '1 recipient', 'jetpack-forms' );
+		} else {
+			emailsLabel = recipients.length + ' ' + __( 'recipients', 'jetpack-forms' );
+		}
+	} else {
+		emailsLabel = __( 'Enabled', 'jetpack-forms' );
+	}
+
+	// Format push notification recipients — show count
+	let notificationsLabel: string;
+	if ( ! hasNotifications ) {
+		notificationsLabel = __( 'Disabled', 'jetpack-forms' );
+	} else if ( notificationRecipients.length === 1 ) {
+		notificationsLabel = __( '1 recipient', 'jetpack-forms' );
+	} else {
+		notificationsLabel = notificationRecipients.length + ' ' + __( 'recipients', 'jetpack-forms' );
+	}
+
+	// Preview handler (reuses the same logic as preview-button.tsx)
+	const handlePreview = useCallback( async () => {
+		if ( isPreviewLoading ) {
+			return;
+		}
+
+		setIsPreviewLoading( true );
+		try {
+			if ( isDirty && isAutosaveable ) {
+				await autosave();
+			}
+
+			const response = await apiFetch< { preview_url: string } >( {
+				path: `/wp/v2/jetpack-forms/${ postId }/preview-url`,
+			} );
+			window.open( response.preview_url, '_blank' );
+		} catch {
+			createErrorNotice(
+				__( 'Failed to generate preview URL. Please try again.', 'jetpack-forms' ),
+				{ type: 'snackbar' }
+			);
+		} finally {
+			setIsPreviewLoading( false );
+		}
+	}, [ postId, isPreviewLoading, isDirty, isAutosaveable, autosave, createErrorNotice ] );
+
+	/**
+	 * Navigate to a specific settings panel in the block inspector.
+	 *
+	 * Flow:
+	 * 1. Close the publish sidebar
+	 * 2. Open the block inspector sidebar via wp.data store
+	 * 3. Select the form block
+	 * 4. Wait for the sidebar to render, then click the Block tab
+	 * 5. Wait for the inspector panels to render, then open the target panel
+	 */
+	const openInspectorPanel = useCallback(
+		( panelTitle: string ) => {
+			// Step 1: Close the pre-publish sidebar
+			closePublishSidebar();
+
+			// Step 2: Select the form block
+			selectBlock( clientId );
+
+			// Step 3: Use the older openGeneralSidebar API to explicitly request
+			// the block inspector sidebar, then use a retry loop for the DOM tab
+			// click and panel expansion.
+			const wpData = (
+				window as unknown as {
+					wp: {
+						data: {
+							dispatch: ( store: string ) => Record< string, ( ...args: unknown[] ) => unknown >;
+						};
+					};
+				}
+			 ).wp?.data;
+
+			// Use openGeneralSidebar from edit-post store — this is the most
+			// reliable way to switch to the block inspector tab.
+			if ( wpData ) {
+				try {
+					wpData.dispatch( 'core/edit-post' ).openGeneralSidebar( 'edit-post/block' );
+				} catch {
+					// Fallback: try the interface store
+					try {
+						wpData
+							.dispatch( 'core/interface' )
+							.enableComplementaryArea( 'core', 'edit-post/block' );
+					} catch {
+						// silent
+					}
+				}
+			}
+
+			const tryOpen = ( attempt: number ) => {
+				if ( attempt > 20 ) {
+					return;
+				}
+				setTimeout( () => {
+					// 3a: Find and click the top-level "Block" tab.
+					// The form editor sidebar has "Form" and "Block" top-level tabs.
+					const sidebar =
+						document.querySelector( '.interface-complementary-area' ) ||
+						document.querySelector( '.edit-post-sidebar' );
+					if ( ! sidebar ) {
+						tryOpen( attempt + 1 );
+						return;
+					}
+
+					const topTabs = sidebar.querySelectorAll(
+						':scope > [role="tablist"] > [role="tab"], :scope [role="tablist"] [role="tab"]'
+					);
+					let blockTabActive = false;
+					for ( const tab of topTabs ) {
+						if ( tab.textContent?.trim() === 'Block' ) {
+							if ( ( tab as HTMLElement ).getAttribute( 'aria-selected' ) !== 'true' ) {
+								( tab as HTMLElement ).click();
+								tryOpen( attempt + 1 );
+								return;
+							}
+							blockTabActive = true;
+							break;
+						}
+					}
+
+					if ( ! blockTabActive ) {
+						tryOpen( attempt + 1 );
+						return;
+					}
+
+					// 3b: Inside the block inspector, click the "Settings" sub-tab
+					// (the gear icon — the second of the three icon tabs:
+					// list view, settings, appearance/styles).
+					const inspector = sidebar.querySelector( '.block-editor-block-inspector' );
+					if ( ! inspector ) {
+						tryOpen( attempt + 1 );
+						return;
+					}
+
+					const subTabs = inspector.querySelectorAll( '[role="tab"]' );
+					let settingsTabActive = false;
+					for ( const tab of subTabs ) {
+						const label = (
+							tab.getAttribute( 'aria-label' ) ||
+							tab.textContent ||
+							''
+						).toLowerCase();
+						if ( label.includes( 'settings' ) || label.includes( 'setting' ) ) {
+							if ( ( tab as HTMLElement ).getAttribute( 'aria-selected' ) !== 'true' ) {
+								( tab as HTMLElement ).click();
+								tryOpen( attempt + 1 );
+								return;
+							}
+							settingsTabActive = true;
+							break;
+						}
+					}
+
+					// Fallback: if we can't find a tab by label, try the second tab
+					// in the inspector sub-tab list (settings is typically the second).
+					if ( ! settingsTabActive && subTabs.length >= 2 ) {
+						const secondTab = subTabs[ 1 ] as HTMLElement;
+						if ( secondTab.getAttribute( 'aria-selected' ) !== 'true' ) {
+							secondTab.click();
+							tryOpen( attempt + 1 );
+							return;
+						}
+						settingsTabActive = true;
+					}
+
+					if ( ! settingsTabActive ) {
+						tryOpen( attempt + 1 );
+						return;
+					}
+
+					// 3c: Settings sub-tab is active — find and open the target panel
+					const panels = document.querySelectorAll( '.components-panel__body-toggle' );
+					let found = false;
+					for ( const toggle of panels ) {
+						if ( toggle.textContent?.includes( panelTitle ) ) {
+							if ( toggle.getAttribute( 'aria-expanded' ) === 'false' ) {
+								( toggle as HTMLElement ).click();
+							}
+							( toggle as HTMLElement ).scrollIntoView( { behavior: 'smooth', block: 'start' } );
+							found = true;
+							break;
+						}
+					}
+
+					if ( ! found ) {
+						tryOpen( attempt + 1 );
+					}
+				}, 150 );
+			};
+			tryOpen( 0 );
+		},
+		[ closePublishSidebar, selectBlock, clientId ]
+	);
+
+	return (
+		<PluginPrePublishPanel className="jetpack-form-pre-publish-panel" initialOpen>
+			{ /* Form identity card */ }
+			<div className="jetpack-form-pre-publish__form-card">
+				<span className="jetpack-form-pre-publish__form-icon">{ pageIcon }</span>
+				<span className="jetpack-form-pre-publish__form-title">
+					{ postTitle || __( 'Untitled Form', 'jetpack-forms' ) }
+				</span>
+			</div>
+
+			{ /* Preview button */ }
+			<Button
+				variant="secondary"
+				className="jetpack-form-pre-publish__preview-button"
+				onClick={ handlePreview }
+				isBusy={ isPreviewLoading }
+			>
+				{ isPreviewLoading
+					? __( 'Saving & opening', 'jetpack-forms' )
+					: __( 'Preview the form', 'jetpack-forms' ) }
+			</Button>
+
+			{ /* Settings summary rows */ }
+			<div className="jetpack-form-pre-publish__settings">
+				<SettingRow
+					label={ __( 'Confirmation', 'jetpack-forms' ) }
+					value={ confirmationLabel }
+					onClick={ () => openInspectorPanel( __( 'Action after submit', 'jetpack-forms' ) ) }
+				/>
+				<SettingRow
+					label={ __( 'Email notifications', 'jetpack-forms' ) }
+					value={ emailsLabel }
+					onClick={ () => openInspectorPanel( __( 'Form notifications', 'jetpack-forms' ) ) }
+				/>
+				<SettingRow
+					label={ __( 'Push notifications', 'jetpack-forms' ) }
+					value={ notificationsLabel }
+					onClick={ () => openInspectorPanel( __( 'Form notifications', 'jetpack-forms' ) ) }
+				/>
+				<SettingRow
+					label={ __( 'Integrations', 'jetpack-forms' ) }
+					value={ integrationsValue }
+					onClick={ () => setIsIntegrationsModalOpen( true ) }
+				/>
+				<SettingRow
+					label={ __( 'Save responses', 'jetpack-forms' ) }
+					value={ saveResponses ? __( 'Yes', 'jetpack-forms' ) : __( 'No', 'jetpack-forms' ) }
+					onClick={ () => openInspectorPanel( __( 'Responses storage', 'jetpack-forms' ) ) }
+				/>
+			</div>
+
+			<IntegrationsModal
+				isOpen={ isIntegrationsModalOpen }
+				onClose={ () => setIsIntegrationsModalOpen( false ) }
+				attributes={ attributes }
+				setAttributes={ setFormAttributes }
+				integrationsData={ integrationsData as Array< Record< string, unknown > > }
+				refreshIntegrations={ refreshIntegrations }
+				components={ modalComponents }
+			/>
+		</PluginPrePublishPanel>
+	);
+};
+
+// Register the pre-publish panel plugin
+registerPlugin( 'jetpack-form-pre-publish', {
+	render: FormPrePublishPanel,
+} );

--- a/projects/packages/forms/src/form-editor/plugins/form-pre-publish-panel.tsx
+++ b/projects/packages/forms/src/form-editor/plugins/form-pre-publish-panel.tsx
@@ -34,10 +34,10 @@ import './form-pre-publish-panel.scss';
  * Uses the same structure as WordPress's PostPanelRow component
  * (HStack with editor-post-panel__row classes) for pixel-perfect matching.
  *
- * @param {object} props         - Component props.
- * @param {string} props.label   - The row label.
- * @param {string|JSX.Element} props.value - The row value.
- * @param {Function} props.onClick - Click handler for the value button.
+ * @param {object}             props         - Component props.
+ * @param {string}             props.label   - The row label.
+ * @param {string|JSX.Element} props.value   - The row value.
+ * @param {Function}           props.onClick - Click handler for the value button.
  * @return {JSX.Element} The setting row element.
  */
 const SettingRow = ( {

--- a/projects/packages/forms/src/form-editor/plugins/form-pre-publish-panel.tsx
+++ b/projects/packages/forms/src/form-editor/plugins/form-pre-publish-panel.tsx
@@ -5,29 +5,28 @@ import apiFetch from '@wordpress/api-fetch';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 import {
 	Button,
+	Notice,
 	__experimentalHStack as HStack, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { PluginPrePublishPanel, store as editorStore } from '@wordpress/editor';
 import { useCallback, useMemo, useState } from '@wordpress/element';
 import { __, _n, _nx, _x, sprintf } from '@wordpress/i18n';
-import { page as pageIcon } from '@wordpress/icons';
 import { store as noticesStore } from '@wordpress/notices';
-import { registerPlugin } from '@wordpress/plugins';
 /**
  * Internal dependencies
  */
 import ConsentToggle from '../../blocks/contact-form/components/jetpack-integrations-modal/components/consent-toggle.tsx';
 import IntegrationsModal from '../../blocks/contact-form/components/jetpack-integrations-modal/index.tsx';
+import { settings as formBlockSettings } from '../../blocks/contact-form/index.js';
 import { FORM_POST_TYPE, FORM_BLOCK_NAME } from '../../blocks/shared/util/constants.js';
-import AkismetIcon from '../../icons/akismet';
-import GoogleSheetsIcon from '../../icons/google-sheets';
-import HostingerReachIcon from '../../icons/hostinger-reach';
-import MailPoetIcon from '../../icons/mailpoet';
-import SalesforceIcon from '../../icons/salesforce';
 import { INTEGRATIONS_STORE } from '../../store/integrations/index.ts';
+import IntegrationIcons from './integration-icons.tsx';
 import type { Integration } from '../../types/index.ts';
+import type { Block } from '@wordpress/blocks';
 import './form-pre-publish-panel.scss';
+
+export const JETPACK_FORM_PRE_PUBLISH_PANEL = 'jetpack-form-pre-publish';
 
 /**
  * A single settings summary row displayed in the pre-publish panel.
@@ -53,7 +52,7 @@ const SettingRow = ( {
 		<HStack className="editor-post-panel__row">
 			<div className="editor-post-panel__row-label">{ label }</div>
 			<div className="editor-post-panel__row-control">
-				<Button variant="tertiary" onClick={ onClick } disabled={ ! onClick }>
+				<Button variant="tertiary" size="compact" onClick={ onClick }>
 					{ value }
 				</Button>
 			</div>
@@ -66,24 +65,22 @@ const SettingRow = ( {
  * Since the form editor always has exactly one contact-form block,
  * we find it and return its attributes.
  *
- * @return {object} The form block attributes and clientId.
+ * @return {object} The form block attributes, clientId, and whether it has fields.
  */
 const useFormAttributes = () => {
 	return useSelect( select => {
 		const { getBlocks } = select( blockEditorStore ) as {
-			getBlocks: () => Array< {
-				name: string;
-				clientId: string;
-				attributes: Record< string, unknown >;
-			} >;
+			getBlocks: () => Block[];
 		};
 
 		const blocks = getBlocks();
 		const formBlock = blocks.find( block => block.name === FORM_BLOCK_NAME );
+		const hasFields = formBlock?.innerBlocks?.length;
 
 		return {
 			attributes: ( formBlock?.attributes || {} ) as Record< string, unknown >,
 			clientId: formBlock?.clientId || '',
+			hasFields,
 		};
 	}, [] );
 };
@@ -96,7 +93,7 @@ const useFormAttributes = () => {
  *
  * @return {JSX.Element|null} The pre-publish panel or null.
  */
-const FormPrePublishPanel = () => {
+export const FormPrePublishPanel = () => {
 	const [ isPreviewLoading, setIsPreviewLoading ] = useState( false );
 	const [ isIntegrationsModalOpen, setIsIntegrationsModalOpen ] = useState( false );
 
@@ -118,7 +115,7 @@ const FormPrePublishPanel = () => {
 		};
 	} );
 
-	const { attributes, clientId } = useFormAttributes();
+	const { attributes, clientId, hasFields } = useFormAttributes();
 	const { autosave } = useDispatch( 'core/editor' );
 	const { createErrorNotice } = useDispatch( noticesStore );
 	const { closePublishSidebar } = useDispatch( editorStore );
@@ -350,53 +347,6 @@ const FormPrePublishPanel = () => {
 	const hasNotifications = notificationRecipients.length > 0;
 	const saveResponses = attributes.saveResponses !== false;
 
-	// Determine active integrations and collect their icons
-	const integrationIcons: JSX.Element[] = [];
-
-	// Akismet is always active by default
-	integrationIcons.push( <AkismetIcon key="akismet" width={ 20 } height={ 20 } /> );
-
-	if ( attributes.jetpackCRM ) {
-		integrationIcons.push(
-			<svg
-				key="jetpack-crm"
-				width="20"
-				height="20"
-				viewBox="0 0 32 32"
-				fill="none"
-				xmlns="http://www.w3.org/2000/svg"
-			>
-				<path
-					d="M16 0C7.2 0 0 7.2 0 16s7.2 16 16 16 16-7.2 16-16S24.8 0 16 0zm-2.4 24.8L7.2 14.4l2.4-1.6 4 5.6 8.8-12 2.4 1.6-11.2 16.8z"
-					fill="#069e08"
-				/>
-			</svg>
-		);
-	}
-
-	const salesforceData = attributes.salesforceData as { organizationId?: string } | undefined;
-	if ( salesforceData?.organizationId ) {
-		integrationIcons.push( <SalesforceIcon key="salesforce" width={ 20 } height={ 20 } /> );
-	}
-
-	const mailpoet = attributes.mailpoet as { listId?: string | null } | undefined;
-	if ( mailpoet?.listId ) {
-		integrationIcons.push( <MailPoetIcon key="mailpoet" width={ 20 } height={ 20 } /> );
-	}
-
-	const hostingerReach = attributes.hostingerReach as { groupName?: string } | undefined;
-	if ( hostingerReach?.groupName ) {
-		integrationIcons.push( <HostingerReachIcon key="hostinger" width={ 20 } height={ 20 } /> );
-	}
-
-	if ( attributes.googleSheets ) {
-		integrationIcons.push( <GoogleSheetsIcon key="google-sheets" width={ 20 } height={ 20 } /> );
-	}
-
-	const integrationsValue = (
-		<span className="jetpack-form-pre-publish__integration-icons">{ integrationIcons }</span>
-	);
-
 	// Format confirmation type for display
 	const confirmationLabel =
 		confirmationType === 'redirect'
@@ -439,17 +389,30 @@ const FormPrePublishPanel = () => {
 		);
 	}
 
+	// Show warning if form has no fields
+	if ( ! hasFields ) {
+		return (
+			<PluginPrePublishPanel className="jetpack-form-pre-publish-panel" initialOpen>
+				<Notice status="error" isDismissible={ false }>
+					{ __(
+						'This form has no fields. Add at least one field before publishing.',
+						'jetpack-forms'
+					) }
+				</Notice>
+			</PluginPrePublishPanel>
+		);
+	}
+
 	return (
 		<PluginPrePublishPanel className="jetpack-form-pre-publish-panel" initialOpen>
-			{ /* Form identity card */ }
 			<div className="jetpack-form-pre-publish__form-card">
-				<span className="jetpack-form-pre-publish__form-icon">{ pageIcon }</span>
+				<span className="jetpack-form-pre-publish__form-icon">
+					{ formBlockSettings.icon.src() }
+				</span>
 				<span className="jetpack-form-pre-publish__form-title">
 					{ postTitle || __( 'Untitled Form', 'jetpack-forms' ) }
 				</span>
 			</div>
-
-			{ /* Preview button */ }
 			<Button
 				variant="secondary"
 				className="jetpack-form-pre-publish__preview-button"
@@ -460,8 +423,6 @@ const FormPrePublishPanel = () => {
 					? __( 'Saving & opening', 'jetpack-forms' )
 					: _x( 'Preview the form', 'button label', 'jetpack-forms' ) }
 			</Button>
-
-			{ /* Settings summary rows */ }
 			<div className="jetpack-form-pre-publish__settings">
 				<SettingRow
 					label={ __( 'Confirmation', 'jetpack-forms' ) }
@@ -480,7 +441,7 @@ const FormPrePublishPanel = () => {
 				/>
 				<SettingRow
 					label={ __( 'Integrations', 'jetpack-forms' ) }
-					value={ integrationsValue }
+					value={ <IntegrationIcons attributes={ attributes } integrations={ integrationsData } /> }
 					onClick={ handleIntegrationsClick }
 				/>
 				<SettingRow
@@ -493,7 +454,6 @@ const FormPrePublishPanel = () => {
 					onClick={ handleResponsesClick }
 				/>
 			</div>
-
 			<IntegrationsModal
 				isOpen={ isIntegrationsModalOpen }
 				onClose={ handleIntegrationsModalClose }
@@ -506,8 +466,3 @@ const FormPrePublishPanel = () => {
 		</PluginPrePublishPanel>
 	);
 };
-
-// Register the pre-publish panel plugin
-registerPlugin( 'jetpack-form-pre-publish', {
-	render: FormPrePublishPanel,
-} );

--- a/projects/packages/forms/src/form-editor/plugins/form-pre-publish-panel.tsx
+++ b/projects/packages/forms/src/form-editor/plugins/form-pre-publish-panel.tsx
@@ -10,11 +10,10 @@ import {
 import { useSelect, useDispatch } from '@wordpress/data';
 import { PluginPrePublishPanel, store as editorStore } from '@wordpress/editor';
 import { useCallback, useMemo, useState } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { __, _n, _nx, _x, sprintf } from '@wordpress/i18n';
 import { page as pageIcon } from '@wordpress/icons';
 import { store as noticesStore } from '@wordpress/notices';
 import { registerPlugin } from '@wordpress/plugins';
-
 /**
  * Internal dependencies
  */
@@ -27,16 +26,19 @@ import HostingerReachIcon from '../../icons/hostinger-reach';
 import MailPoetIcon from '../../icons/mailpoet';
 import SalesforceIcon from '../../icons/salesforce';
 import { INTEGRATIONS_STORE } from '../../store/integrations/index.ts';
+import type { Integration } from '../../types/index.ts';
 import './form-pre-publish-panel.scss';
 
 /**
  * A single settings summary row displayed in the pre-publish panel.
  * Uses the same structure as WordPress's PostPanelRow component
  * (HStack with editor-post-panel__row classes) for pixel-perfect matching.
- * @param root0
- * @param root0.label
- * @param root0.value
- * @param root0.onClick
+ *
+ * @param {object}              props         - Component props.
+ * @param {string}              props.label   - The row label.
+ * @param {string|JSX.Element}  props.value   - The row value.
+ * @param {Function}            props.onClick - Click handler for the value button.
+ * @return {JSX.Element} The setting row element.
  */
 const SettingRow = ( {
 	label,
@@ -63,6 +65,8 @@ const SettingRow = ( {
  * Get the contact-form block attributes from the editor.
  * Since the form editor always has exactly one contact-form block,
  * we find it and return its attributes.
+ *
+ * @return {object} The form block attributes and clientId.
  */
 const useFormAttributes = () => {
 	return useSelect( select => {
@@ -78,7 +82,6 @@ const useFormAttributes = () => {
 		const formBlock = blocks.find( block => block.name === FORM_BLOCK_NAME );
 
 		return {
-			formBlock,
 			attributes: ( formBlock?.attributes || {} ) as Record< string, unknown >,
 			clientId: formBlock?.clientId || '',
 		};
@@ -86,14 +89,12 @@ const useFormAttributes = () => {
 };
 
 /**
- * Hook to update contact-form block attributes from outside the block.
- */
-
-/**
  * Form Pre-Publish Panel component.
  *
  * Displays a summary of form settings in the WordPress pre-publish sidebar,
  * allowing users to review and adjust settings before publishing.
+ *
+ * @return {JSX.Element|null} The pre-publish panel or null.
  */
 const FormPrePublishPanel = () => {
 	const [ isPreviewLoading, setIsPreviewLoading ] = useState( false );
@@ -121,15 +122,14 @@ const FormPrePublishPanel = () => {
 	const { autosave } = useDispatch( 'core/editor' );
 	const { createErrorNotice } = useDispatch( noticesStore );
 	const { closePublishSidebar } = useDispatch( editorStore );
-	const { selectBlock } = useDispatch( blockEditorStore );
-	const { updateBlockAttributes } = useDispatch( blockEditorStore );
+	const { selectBlock, updateBlockAttributes } = useDispatch( blockEditorStore );
 
 	// Integrations store data for the modal
 	const integrationsData = useSelect( select => {
-		const store = select( INTEGRATIONS_STORE ) as {
-			getIntegrations: () => Array< Record< string, unknown > >;
+		const integrationsStore = select( INTEGRATIONS_STORE ) as {
+			getIntegrations: () => Integration[] | null;
 		};
-		return store.getIntegrations() || [];
+		return integrationsStore.getIntegrations() || [];
 	}, [] );
 	const { refreshIntegrations } = useDispatch( INTEGRATIONS_STORE );
 	const modalComponents = useMemo( () => ( { ConsentToggle } ), [] );
@@ -142,6 +142,207 @@ const FormPrePublishPanel = () => {
 			}
 		},
 		[ clientId, updateBlockAttributes ]
+	);
+
+	// Preview handler (reuses the same logic as preview-button.tsx)
+	const handlePreview = useCallback( async () => {
+		if ( isPreviewLoading ) {
+			return;
+		}
+
+		setIsPreviewLoading( true );
+		try {
+			if ( isDirty && isAutosaveable ) {
+				await autosave();
+			}
+
+			const response = await apiFetch< { preview_url: string } >( {
+				path: `/wp/v2/jetpack-forms/${ postId }/preview-url`,
+			} );
+			window.open( response.preview_url, '_blank' );
+		} catch ( error ) { // eslint-disable-line no-unused-vars
+			createErrorNotice(
+				__( 'Failed to generate preview URL. Please try again.', 'jetpack-forms' ),
+				{ type: 'snackbar' }
+			);
+		} finally {
+			setIsPreviewLoading( false );
+		}
+	}, [ postId, isPreviewLoading, isDirty, isAutosaveable, autosave, createErrorNotice ] );
+
+	/**
+	 * Navigate to a specific settings panel in the block inspector.
+	 *
+	 * Flow:
+	 * 1. Close the publish sidebar
+	 * 2. Open the block inspector sidebar via wp.data store
+	 * 3. Select the form block
+	 * 4. Wait for the sidebar to render, then click the Block tab + Settings sub-tab
+	 * 5. Wait for the inspector panels to render, then open the target panel
+	 *
+	 * @param {string} panelTitle - The title of the panel to open.
+	 */
+	const openInspectorPanel = useCallback(
+		( panelTitle: string ) => {
+			// Step 1: Close the pre-publish sidebar
+			closePublishSidebar();
+
+			// Step 2: Select the form block
+			selectBlock( clientId );
+
+			// Step 3: Use the openGeneralSidebar API to request the block inspector sidebar,
+			// then use a retry loop for the DOM tab click and panel expansion.
+			const wpData = (
+				window as unknown as {
+					wp: {
+						data: {
+							dispatch: (
+								storeKey: string
+							) => Record< string, ( ...args: unknown[] ) => unknown >;
+						};
+					};
+				}
+			).wp?.data;
+
+			if ( wpData ) {
+				try {
+					wpData.dispatch( 'core/edit-post' ).openGeneralSidebar( 'edit-post/block' );
+				} catch ( e ) { // eslint-disable-line no-unused-vars
+					try {
+						wpData
+							.dispatch( 'core/interface' )
+							.enableComplementaryArea( 'core', 'edit-post/block' );
+					} catch ( e2 ) { // eslint-disable-line no-unused-vars
+						// Silently fail — the retry loop will handle sidebar activation via DOM.
+					}
+				}
+			}
+
+			const tryOpen = ( attempt: number ) => {
+				if ( attempt > 20 ) {
+					return;
+				}
+				setTimeout( () => {
+					// 3a: Find and click the top-level "Block" tab.
+					const sidebar =
+						document.querySelector( '.interface-complementary-area' ) ||
+						document.querySelector( '.edit-post-sidebar' );
+					if ( ! sidebar ) {
+						tryOpen( attempt + 1 );
+						return;
+					}
+
+					const topTabs = sidebar.querySelectorAll(
+						':scope > [role="tablist"] > [role="tab"], :scope [role="tablist"] [role="tab"]'
+					);
+					let blockTabActive = false;
+					for ( const tab of topTabs ) {
+						if ( tab.textContent?.trim() === 'Block' ) {
+							if ( ( tab as HTMLElement ).getAttribute( 'aria-selected' ) !== 'true' ) {
+								( tab as HTMLElement ).click();
+								tryOpen( attempt + 1 );
+								return;
+							}
+							blockTabActive = true;
+							break;
+						}
+					}
+
+					if ( ! blockTabActive ) {
+						tryOpen( attempt + 1 );
+						return;
+					}
+
+					// 3b: Inside the block inspector, click the "Settings" sub-tab
+					// (the gear icon — the second of the three icon tabs).
+					const inspector = sidebar.querySelector( '.block-editor-block-inspector' );
+					if ( ! inspector ) {
+						tryOpen( attempt + 1 );
+						return;
+					}
+
+					const subTabs = inspector.querySelectorAll( '[role="tab"]' );
+					let settingsTabActive = false;
+					for ( const tab of subTabs ) {
+						const tabLabel = (
+							tab.getAttribute( 'aria-label' ) ||
+							tab.textContent ||
+							''
+						).toLowerCase();
+						if ( tabLabel.includes( 'settings' ) || tabLabel.includes( 'setting' ) ) {
+							if ( ( tab as HTMLElement ).getAttribute( 'aria-selected' ) !== 'true' ) {
+								( tab as HTMLElement ).click();
+								tryOpen( attempt + 1 );
+								return;
+							}
+							settingsTabActive = true;
+							break;
+						}
+					}
+
+					// Fallback: try the second tab in the inspector sub-tab list.
+					if ( ! settingsTabActive && subTabs.length >= 2 ) {
+						const secondTab = subTabs[ 1 ] as HTMLElement;
+						if ( secondTab.getAttribute( 'aria-selected' ) !== 'true' ) {
+							secondTab.click();
+							tryOpen( attempt + 1 );
+							return;
+						}
+						settingsTabActive = true;
+					}
+
+					if ( ! settingsTabActive ) {
+						tryOpen( attempt + 1 );
+						return;
+					}
+
+					// 3c: Settings sub-tab is active — find and open the target panel
+					const panels = document.querySelectorAll( '.components-panel__body-toggle' );
+					let found = false;
+					for ( const toggle of panels ) {
+						if ( toggle.textContent?.includes( panelTitle ) ) {
+							if ( toggle.getAttribute( 'aria-expanded' ) === 'false' ) {
+								( toggle as HTMLElement ).click();
+							}
+							( toggle as HTMLElement ).scrollIntoView( {
+								behavior: 'smooth',
+								block: 'start',
+							} );
+							found = true;
+							break;
+						}
+					}
+
+					if ( ! found ) {
+						tryOpen( attempt + 1 );
+					}
+				}, 150 );
+			};
+			tryOpen( 0 );
+		},
+		[ closePublishSidebar, selectBlock, clientId ]
+	);
+
+	// Click handlers for settings rows
+	const handleConfirmationClick = useCallback(
+		() => openInspectorPanel( __( 'Action after submit', 'jetpack-forms' ) ),
+		[ openInspectorPanel ]
+	);
+	const handleEmailClick = useCallback(
+		() => openInspectorPanel( __( 'Form notifications', 'jetpack-forms' ) ),
+		[ openInspectorPanel ]
+	);
+	const handleIntegrationsClick = useCallback(
+		() => setIsIntegrationsModalOpen( true ),
+		[]
+	);
+	const handleResponsesClick = useCallback(
+		() => openInspectorPanel( __( 'Responses storage', 'jetpack-forms' ) ),
+		[ openInspectorPanel ]
+	);
+	const handleIntegrationsModalClose = useCallback(
+		() => setIsIntegrationsModalOpen( false ),
+		[]
 	);
 
 	// Only render for jetpack_form post type
@@ -164,7 +365,6 @@ const FormPrePublishPanel = () => {
 	integrationIcons.push( <AkismetIcon key="akismet" width={ 20 } height={ 20 } /> );
 
 	if ( attributes.jetpackCRM ) {
-		// Use the Jetpack green icon for CRM
 		integrationIcons.push(
 			<svg
 				key="jetpack-crm"
@@ -197,7 +397,6 @@ const FormPrePublishPanel = () => {
 		integrationIcons.push( <HostingerReachIcon key="hostinger" width={ 20 } height={ 20 } /> );
 	}
 
-	// Google Sheets integration
 	if ( attributes.googleSheets ) {
 		integrationIcons.push( <GoogleSheetsIcon key="google-sheets" width={ 20 } height={ 20 } /> );
 	}
@@ -210,9 +409,9 @@ const FormPrePublishPanel = () => {
 	const confirmationLabel =
 		confirmationType === 'redirect'
 			? __( 'Redirect', 'jetpack-forms' )
-			: __( 'Text', 'jetpack-forms' );
+			: _x( 'Text', 'confirmation type', 'jetpack-forms' );
 
-	// Format email recipients — show the address or count
+	// Format email recipients — show count
 	let emailsLabel: string;
 	if ( ! emailNotifications ) {
 		emailsLabel = __( 'Disabled', 'jetpack-forms' );
@@ -221,11 +420,11 @@ const FormPrePublishPanel = () => {
 			.split( ',' )
 			.map( e => e.trim() )
 			.filter( Boolean );
-		if ( recipients.length === 1 ) {
-			emailsLabel = __( '1 recipient', 'jetpack-forms' );
-		} else {
-			emailsLabel = recipients.length + ' ' + __( 'recipients', 'jetpack-forms' );
-		}
+		emailsLabel = sprintf(
+			/* translators: %d: number of email recipients */
+			_n( '%d recipient', '%d recipients', recipients.length, 'jetpack-forms' ),
+			recipients.length
+		);
 	} else {
 		emailsLabel = __( 'Enabled', 'jetpack-forms' );
 	}
@@ -234,190 +433,19 @@ const FormPrePublishPanel = () => {
 	let notificationsLabel: string;
 	if ( ! hasNotifications ) {
 		notificationsLabel = __( 'Disabled', 'jetpack-forms' );
-	} else if ( notificationRecipients.length === 1 ) {
-		notificationsLabel = __( '1 recipient', 'jetpack-forms' );
 	} else {
-		notificationsLabel = notificationRecipients.length + ' ' + __( 'recipients', 'jetpack-forms' );
+		notificationsLabel = sprintf(
+			/* translators: %d: number of push notification recipients */
+			_nx(
+				'%d recipient',
+				'%d recipients',
+				notificationRecipients.length,
+				'push notifications',
+				'jetpack-forms'
+			),
+			notificationRecipients.length
+		);
 	}
-
-	// Preview handler (reuses the same logic as preview-button.tsx)
-	const handlePreview = useCallback( async () => {
-		if ( isPreviewLoading ) {
-			return;
-		}
-
-		setIsPreviewLoading( true );
-		try {
-			if ( isDirty && isAutosaveable ) {
-				await autosave();
-			}
-
-			const response = await apiFetch< { preview_url: string } >( {
-				path: `/wp/v2/jetpack-forms/${ postId }/preview-url`,
-			} );
-			window.open( response.preview_url, '_blank' );
-		} catch {
-			createErrorNotice(
-				__( 'Failed to generate preview URL. Please try again.', 'jetpack-forms' ),
-				{ type: 'snackbar' }
-			);
-		} finally {
-			setIsPreviewLoading( false );
-		}
-	}, [ postId, isPreviewLoading, isDirty, isAutosaveable, autosave, createErrorNotice ] );
-
-	/**
-	 * Navigate to a specific settings panel in the block inspector.
-	 *
-	 * Flow:
-	 * 1. Close the publish sidebar
-	 * 2. Open the block inspector sidebar via wp.data store
-	 * 3. Select the form block
-	 * 4. Wait for the sidebar to render, then click the Block tab
-	 * 5. Wait for the inspector panels to render, then open the target panel
-	 */
-	const openInspectorPanel = useCallback(
-		( panelTitle: string ) => {
-			// Step 1: Close the pre-publish sidebar
-			closePublishSidebar();
-
-			// Step 2: Select the form block
-			selectBlock( clientId );
-
-			// Step 3: Use the older openGeneralSidebar API to explicitly request
-			// the block inspector sidebar, then use a retry loop for the DOM tab
-			// click and panel expansion.
-			const wpData = (
-				window as unknown as {
-					wp: {
-						data: {
-							dispatch: ( store: string ) => Record< string, ( ...args: unknown[] ) => unknown >;
-						};
-					};
-				}
-			 ).wp?.data;
-
-			// Use openGeneralSidebar from edit-post store — this is the most
-			// reliable way to switch to the block inspector tab.
-			if ( wpData ) {
-				try {
-					wpData.dispatch( 'core/edit-post' ).openGeneralSidebar( 'edit-post/block' );
-				} catch {
-					// Fallback: try the interface store
-					try {
-						wpData
-							.dispatch( 'core/interface' )
-							.enableComplementaryArea( 'core', 'edit-post/block' );
-					} catch {
-						// silent
-					}
-				}
-			}
-
-			const tryOpen = ( attempt: number ) => {
-				if ( attempt > 20 ) {
-					return;
-				}
-				setTimeout( () => {
-					// 3a: Find and click the top-level "Block" tab.
-					// The form editor sidebar has "Form" and "Block" top-level tabs.
-					const sidebar =
-						document.querySelector( '.interface-complementary-area' ) ||
-						document.querySelector( '.edit-post-sidebar' );
-					if ( ! sidebar ) {
-						tryOpen( attempt + 1 );
-						return;
-					}
-
-					const topTabs = sidebar.querySelectorAll(
-						':scope > [role="tablist"] > [role="tab"], :scope [role="tablist"] [role="tab"]'
-					);
-					let blockTabActive = false;
-					for ( const tab of topTabs ) {
-						if ( tab.textContent?.trim() === 'Block' ) {
-							if ( ( tab as HTMLElement ).getAttribute( 'aria-selected' ) !== 'true' ) {
-								( tab as HTMLElement ).click();
-								tryOpen( attempt + 1 );
-								return;
-							}
-							blockTabActive = true;
-							break;
-						}
-					}
-
-					if ( ! blockTabActive ) {
-						tryOpen( attempt + 1 );
-						return;
-					}
-
-					// 3b: Inside the block inspector, click the "Settings" sub-tab
-					// (the gear icon — the second of the three icon tabs:
-					// list view, settings, appearance/styles).
-					const inspector = sidebar.querySelector( '.block-editor-block-inspector' );
-					if ( ! inspector ) {
-						tryOpen( attempt + 1 );
-						return;
-					}
-
-					const subTabs = inspector.querySelectorAll( '[role="tab"]' );
-					let settingsTabActive = false;
-					for ( const tab of subTabs ) {
-						const label = (
-							tab.getAttribute( 'aria-label' ) ||
-							tab.textContent ||
-							''
-						).toLowerCase();
-						if ( label.includes( 'settings' ) || label.includes( 'setting' ) ) {
-							if ( ( tab as HTMLElement ).getAttribute( 'aria-selected' ) !== 'true' ) {
-								( tab as HTMLElement ).click();
-								tryOpen( attempt + 1 );
-								return;
-							}
-							settingsTabActive = true;
-							break;
-						}
-					}
-
-					// Fallback: if we can't find a tab by label, try the second tab
-					// in the inspector sub-tab list (settings is typically the second).
-					if ( ! settingsTabActive && subTabs.length >= 2 ) {
-						const secondTab = subTabs[ 1 ] as HTMLElement;
-						if ( secondTab.getAttribute( 'aria-selected' ) !== 'true' ) {
-							secondTab.click();
-							tryOpen( attempt + 1 );
-							return;
-						}
-						settingsTabActive = true;
-					}
-
-					if ( ! settingsTabActive ) {
-						tryOpen( attempt + 1 );
-						return;
-					}
-
-					// 3c: Settings sub-tab is active — find and open the target panel
-					const panels = document.querySelectorAll( '.components-panel__body-toggle' );
-					let found = false;
-					for ( const toggle of panels ) {
-						if ( toggle.textContent?.includes( panelTitle ) ) {
-							if ( toggle.getAttribute( 'aria-expanded' ) === 'false' ) {
-								( toggle as HTMLElement ).click();
-							}
-							( toggle as HTMLElement ).scrollIntoView( { behavior: 'smooth', block: 'start' } );
-							found = true;
-							break;
-						}
-					}
-
-					if ( ! found ) {
-						tryOpen( attempt + 1 );
-					}
-				}, 150 );
-			};
-			tryOpen( 0 );
-		},
-		[ closePublishSidebar, selectBlock, clientId ]
-	);
 
 	return (
 		<PluginPrePublishPanel className="jetpack-form-pre-publish-panel" initialOpen>
@@ -438,7 +466,7 @@ const FormPrePublishPanel = () => {
 			>
 				{ isPreviewLoading
 					? __( 'Saving & opening', 'jetpack-forms' )
-					: __( 'Preview the form', 'jetpack-forms' ) }
+					: _x( 'Preview the form', 'button label', 'jetpack-forms' ) }
 			</Button>
 
 			{ /* Settings summary rows */ }
@@ -446,36 +474,36 @@ const FormPrePublishPanel = () => {
 				<SettingRow
 					label={ __( 'Confirmation', 'jetpack-forms' ) }
 					value={ confirmationLabel }
-					onClick={ () => openInspectorPanel( __( 'Action after submit', 'jetpack-forms' ) ) }
+					onClick={ handleConfirmationClick }
 				/>
 				<SettingRow
 					label={ __( 'Email notifications', 'jetpack-forms' ) }
 					value={ emailsLabel }
-					onClick={ () => openInspectorPanel( __( 'Form notifications', 'jetpack-forms' ) ) }
+					onClick={ handleEmailClick }
 				/>
 				<SettingRow
 					label={ __( 'Push notifications', 'jetpack-forms' ) }
 					value={ notificationsLabel }
-					onClick={ () => openInspectorPanel( __( 'Form notifications', 'jetpack-forms' ) ) }
+					onClick={ handleEmailClick }
 				/>
 				<SettingRow
 					label={ __( 'Integrations', 'jetpack-forms' ) }
 					value={ integrationsValue }
-					onClick={ () => setIsIntegrationsModalOpen( true ) }
+					onClick={ handleIntegrationsClick }
 				/>
 				<SettingRow
 					label={ __( 'Save responses', 'jetpack-forms' ) }
-					value={ saveResponses ? __( 'Yes', 'jetpack-forms' ) : __( 'No', 'jetpack-forms' ) }
-					onClick={ () => openInspectorPanel( __( 'Responses storage', 'jetpack-forms' ) ) }
+					value={ saveResponses ? __( 'Yes', 'jetpack-forms' ) : _x( 'No', 'save responses', 'jetpack-forms' ) }
+					onClick={ handleResponsesClick }
 				/>
 			</div>
 
 			<IntegrationsModal
 				isOpen={ isIntegrationsModalOpen }
-				onClose={ () => setIsIntegrationsModalOpen( false ) }
+				onClose={ handleIntegrationsModalClose }
 				attributes={ attributes }
 				setAttributes={ setFormAttributes }
-				integrationsData={ integrationsData as Array< Record< string, unknown > > }
+				integrationsData={ integrationsData }
 				refreshIntegrations={ refreshIntegrations }
 				components={ modalComponents }
 			/>

--- a/projects/packages/forms/src/form-editor/plugins/integration-icons.tsx
+++ b/projects/packages/forms/src/form-editor/plugins/integration-icons.tsx
@@ -1,0 +1,105 @@
+/**
+ * External dependencies
+ */
+import { Icon, Tooltip } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { plugins } from '@wordpress/icons';
+/**
+ * Internal dependencies
+ */
+import { isValidSalesforceOrgId } from '../../blocks/contact-form/components/jetpack-integrations-modal/helpers/salesforce.tsx';
+import type { Integration } from '../../types/index.ts';
+
+type FormAttributes = {
+	jetpackCRM?: boolean;
+	salesforceData?: { sendToSalesforce?: boolean; organizationId?: string };
+	mailpoet?: { enabledForForm?: boolean; listId?: string | null };
+	hostingerReach?: { enabledForForm?: boolean; groupName?: string };
+	googleSheets?: boolean;
+};
+
+/**
+ * Filters integrations to only those that are active for this form.
+ *
+ * @param {Integration[]}  integrations - All available integrations from the store.
+ * @param {FormAttributes} attributes   - The form block attributes.
+ * @return {Integration[]} Active integrations.
+ */
+const getActiveIntegrations = (
+	integrations: Integration[],
+	attributes: FormAttributes
+): Integration[] => {
+	return integrations.filter( integration => {
+		switch ( integration.id ) {
+			case 'akismet':
+				return integration.isConnected;
+			case 'zero-bs-crm':
+				return integration.isActive && integration.details?.hasExtension && attributes.jetpackCRM;
+			case 'mailpoet':
+				return (
+					integration.isActive && integration.isConnected && attributes.mailpoet?.enabledForForm
+				);
+			case 'hostinger-reach':
+				return (
+					integration.isActive &&
+					integration.isConnected &&
+					attributes.hostingerReach?.enabledForForm
+				);
+			case 'salesforce':
+				return (
+					attributes.salesforceData?.sendToSalesforce &&
+					attributes.salesforceData?.organizationId &&
+					isValidSalesforceOrgId( attributes.salesforceData.organizationId )
+				);
+			case 'google-drive':
+				return attributes.googleSheets;
+			default:
+				return false;
+		}
+	} );
+};
+
+/**
+ * Displays icons for all active integrations on a form.
+ *
+ * @param {object}         props              - Component props.
+ * @param {FormAttributes} props.attributes   - The form block attributes.
+ * @param {Integration[]}  props.integrations - All available integrations from the store.
+ * @return {JSX.Element} The integration icons element.
+ */
+const IntegrationIcons = ( {
+	attributes,
+	integrations,
+}: {
+	attributes: FormAttributes;
+	integrations: Integration[];
+} ) => {
+	const activeIntegrations = getActiveIntegrations( integrations, attributes );
+
+	if ( ! activeIntegrations.length ) {
+		return <>{ __( 'None', 'jetpack-forms' ) }</>;
+	}
+
+	return (
+		<span className="jetpack-form-pre-publish__integration-icons">
+			{ activeIntegrations.map( integration => (
+				<Tooltip key={ integration.id } text={ integration.title || '' }>
+					<span>
+						{ integration.iconUrl ? (
+							<img
+								src={ integration.iconUrl }
+								alt={ integration.title || integration.id }
+								width={ 20 }
+								height={ 20 }
+							/>
+						) : (
+							<Icon icon={ plugins } size={ 20 } />
+						) }
+					</span>
+				</Tooltip>
+			) ) }
+		</span>
+	);
+};
+
+export default IntegrationIcons;

--- a/projects/packages/forms/src/form-editor/store/panel-state.ts
+++ b/projects/packages/forms/src/form-editor/store/panel-state.ts
@@ -58,4 +58,4 @@ const store = createReduxStore( PANEL_STATE_STORE, {
 
 register( store );
 
-export { store };
+export { store, actions, selectors, reducer, DEFAULT_STATE };

--- a/projects/packages/forms/src/form-editor/store/panel-state.ts
+++ b/projects/packages/forms/src/form-editor/store/panel-state.ts
@@ -1,0 +1,61 @@
+/**
+ * Small data store to manage which inspector panel should be opened.
+ * This allows the pre-publish panel to communicate with the block's edit component.
+ */
+import { createReduxStore, register } from '@wordpress/data';
+
+export const PANEL_STATE_STORE = 'jetpack-forms/panel-state';
+
+export type PanelName = 'action-after-submit' | 'form-notifications' | 'responses-storage' | null;
+
+type State = {
+	activePanel: PanelName;
+};
+
+const DEFAULT_STATE: State = {
+	activePanel: null,
+};
+
+const actions = {
+	openPanel( panelName: PanelName ) {
+		return {
+			type: 'OPEN_PANEL' as const,
+			panelName,
+		};
+	},
+	closePanel() {
+		return {
+			type: 'CLOSE_PANEL' as const,
+		};
+	},
+};
+
+const selectors = {
+	getActivePanel( state: State ): PanelName {
+		return state.activePanel;
+	},
+};
+
+const reducer = (
+	state: State = DEFAULT_STATE,
+	action: ReturnType< typeof actions.openPanel > | ReturnType< typeof actions.closePanel >
+): State => {
+	switch ( action.type ) {
+		case 'OPEN_PANEL':
+			return { ...state, activePanel: action.panelName };
+		case 'CLOSE_PANEL':
+			return { ...state, activePanel: null };
+		default:
+			return state;
+	}
+};
+
+const store = createReduxStore( PANEL_STATE_STORE, {
+	reducer,
+	actions,
+	selectors,
+} );
+
+register( store );
+
+export { store };

--- a/projects/packages/forms/tests/js/store/panel-state.test.js
+++ b/projects/packages/forms/tests/js/store/panel-state.test.js
@@ -1,0 +1,140 @@
+import { describe, expect, it } from '@jest/globals';
+import { createRegistry } from '@wordpress/data';
+
+const { store, PANEL_STATE_STORE, actions, selectors, reducer, DEFAULT_STATE } = await import(
+	'../../../src/form-editor/store/panel-state'
+);
+
+const createRegistryWithStores = () => {
+	const registry = createRegistry();
+	registry.register( store );
+	return registry;
+};
+
+describe( 'Panel State Store', () => {
+	describe( 'DEFAULT_STATE', () => {
+		it( 'should have activePanel set to null', () => {
+			expect( DEFAULT_STATE.activePanel ).toBeNull();
+		} );
+	} );
+
+	describe( 'actions', () => {
+		it( 'openPanel should return OPEN_PANEL action with panel name', () => {
+			const action = actions.openPanel( 'action-after-submit' );
+
+			expect( action ).toEqual( {
+				type: 'OPEN_PANEL',
+				panelName: 'action-after-submit',
+			} );
+		} );
+
+		it( 'openPanel should accept all valid panel names', () => {
+			expect( actions.openPanel( 'form-notifications' ).panelName ).toBe( 'form-notifications' );
+			expect( actions.openPanel( 'responses-storage' ).panelName ).toBe( 'responses-storage' );
+			expect( actions.openPanel( null ).panelName ).toBeNull();
+		} );
+
+		it( 'closePanel should return CLOSE_PANEL action', () => {
+			const action = actions.closePanel();
+
+			expect( action ).toEqual( {
+				type: 'CLOSE_PANEL',
+			} );
+		} );
+	} );
+
+	describe( 'selectors', () => {
+		it( 'getActivePanel should return the active panel from state', () => {
+			const state = { activePanel: 'form-notifications' };
+
+			expect( selectors.getActivePanel( state ) ).toBe( 'form-notifications' );
+		} );
+
+		it( 'getActivePanel should return null when no panel is active', () => {
+			const state = { activePanel: null };
+
+			expect( selectors.getActivePanel( state ) ).toBeNull();
+		} );
+	} );
+
+	describe( 'reducer', () => {
+		it( 'should return default state when called with undefined state', () => {
+			const action = { type: 'UNKNOWN_ACTION' };
+			const state = reducer( undefined, action );
+
+			expect( state ).toEqual( DEFAULT_STATE );
+		} );
+
+		it( 'should handle OPEN_PANEL action', () => {
+			const action = actions.openPanel( 'action-after-submit' );
+			const state = reducer( DEFAULT_STATE, action );
+
+			expect( state.activePanel ).toBe( 'action-after-submit' );
+		} );
+
+		it( 'should handle OPEN_PANEL action when another panel is already open', () => {
+			const initialState = { activePanel: 'form-notifications' };
+			const action = actions.openPanel( 'responses-storage' );
+			const state = reducer( initialState, action );
+
+			expect( state.activePanel ).toBe( 'responses-storage' );
+		} );
+
+		it( 'should handle CLOSE_PANEL action', () => {
+			const initialState = { activePanel: 'action-after-submit' };
+			const action = actions.closePanel();
+			const state = reducer( initialState, action );
+
+			expect( state.activePanel ).toBeNull();
+		} );
+
+		it( 'should handle CLOSE_PANEL action when no panel is open', () => {
+			const action = actions.closePanel();
+			const state = reducer( DEFAULT_STATE, action );
+
+			expect( state.activePanel ).toBeNull();
+		} );
+
+		it( 'should return unchanged state for unknown action', () => {
+			const initialState = { activePanel: 'form-notifications' };
+			const action = { type: 'UNKNOWN_ACTION' };
+			const state = reducer( initialState, action );
+
+			expect( state ).toBe( initialState );
+		} );
+
+		it( 'should not mutate the original state', () => {
+			const initialState = { activePanel: null };
+			const action = actions.openPanel( 'action-after-submit' );
+			const newState = reducer( initialState, action );
+
+			expect( newState ).not.toBe( initialState );
+			expect( initialState.activePanel ).toBeNull();
+		} );
+	} );
+
+	describe( 'store integration', () => {
+		it( 'should have the correct store name', () => {
+			expect( PANEL_STATE_STORE ).toBe( 'jetpack-forms/panel-state' );
+		} );
+
+		it( 'should work with registry dispatch and select', () => {
+			const registry = createRegistryWithStores();
+
+			// Initial state
+			expect( registry.select( PANEL_STATE_STORE ).getActivePanel() ).toBeNull();
+
+			// Open panel
+			registry.dispatch( PANEL_STATE_STORE ).openPanel( 'action-after-submit' );
+			expect( registry.select( PANEL_STATE_STORE ).getActivePanel() ).toBe( 'action-after-submit' );
+
+			// Open different panel
+			registry.dispatch( PANEL_STATE_STORE ).openPanel( 'form-notifications' );
+			expect( registry.select( PANEL_STATE_STORE ).getActivePanel() ).toBe( 'form-notifications' );
+
+			// Close panel
+			registry.dispatch( PANEL_STATE_STORE ).closePanel();
+			expect( registry.select( PANEL_STATE_STORE ).getActivePanel() ).toBeNull();
+		} );
+	} );
+} );


### PR DESCRIPTION


https://github.com/user-attachments/assets/760ab60b-f87a-4d0d-b39c-4734d23398d2

## Proposed changes:
* Add a pre-publish panel to the Jetpack Forms editor that surfaces a summary of form settings before publishing.
* The panel displays the form name, a preview button, and five setting rows: Confirmation, Email notifications, Push notifications, Integrations, and Save responses.
* Each setting row shows a dynamic value (e.g., redirect or text, recipient count, active integration icons) and acts as a shortcut — clicking navigates to the corresponding settings panel in the block inspector.
* Clicking the Integrations row opens the existing "Manage integrations" modal directly.
* Hides the default WordPress pre-publish panels (Visibility, Publish schedule) that aren't relevant for the `jetpack_form` post type.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- Link to p2 discussion -->

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
* Ensure the `central-form-management` feature flag is enabled.
* Go to **Forms → Add New** (or edit an existing `jetpack_form`).
* Click the **Publish** button to open the pre-publish sidebar.
* Verify the panel shows:
  - Site info at the top
  - Form icon + title
  - "Preview the form" button
  - Five settings rows: Confirmation, Email notifications, Push notifications, Integrations, Save responses
* Verify each row shows a dynamic value (e.g., "Text", "1 recipient", Akismet icon).
* Click each tertiary button — it should close the publish sidebar, open the Block tab → Settings sub-tab in the inspector, and expand the matching panel.
* Click the Integrations row — it should open the "Manage integrations" modal.
* Verify the default WordPress "Visibility" and "Publish: Immediately" panels are hidden.
