### PR TITLE
Forms: enforce consistent terminology for responses

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-dashboard-terminology-consistency
+++ b/projects/packages/forms/changelog/fix-forms-dashboard-terminology-consistency
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Dashboard: use consistent "responses" terminology instead of "entries" and "submissions".

--- a/projects/packages/forms/routes/forms/stage.tsx
+++ b/projects/packages/forms/routes/forms/stage.tsx
@@ -257,7 +257,7 @@ function StageInner() {
 			},
 			{
 				id: 'entries',
-				label: __( 'Entries', 'jetpack-forms' ),
+				label: __( 'Responses', 'jetpack-forms' ),
 				getValue: ( { item }: { item: FormListItem } ) => item.entriesCount ?? 0,
 				render: ( { item }: { item: FormListItem } ) => item.entriesCount ?? 0,
 				enableSorting: false,

--- a/projects/packages/forms/src/dashboard/wp-build/hooks/use-page-header-details.tsx
+++ b/projects/packages/forms/src/dashboard/wp-build/hooks/use-page-header-details.tsx
@@ -206,7 +206,7 @@ export default function usePageHeaderDetails(
 			return __( 'View responses for this form.', 'jetpack-forms' );
 		}
 
-		return __( 'View and manage all your form submissions in one place.', 'jetpack-forms' );
+		return __( 'View and manage all your form responses in one place.', 'jetpack-forms' );
 	}, [ formTitle, isFormsScreen, isSingleFormScreen, onOpenFormsHelp, formsCount ] );
 
 	const actions = useMemo( () => {


### PR DESCRIPTION
## Proposed changes:

We were still using 'entries' and 'submission' in a couple places on the forms dashboard. This updates those to 'responses' for consistency. Specific changes:
* 'submissions' in responses page subtitle
* 'entries' in forms list column title

**Screenshots**
<img width="1331" height="311" alt="form-responses" src="https://github.com/user-attachments/assets/fad840c7-f280-49fe-9e8a-f98ba3e13728" />

<img width="1331" height="371" alt="form-list-responses" src="https://github.com/user-attachments/assets/0d1878cc-ee80-4e0e-ab00-1370fe1823d8" />


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Enable these feature flags: 

```
add_filter( 'jetpack_forms_alpha', '__return_true', 20 );
add_filter( 'jetpack_block_editor_feature_flags', 'eb_register_feature' );
function eb_register_feature( $flags ) {
    $flags['central-form-management'] = true;
    return $flags;
}
```

Test:
* Go to Jetpack > Forms
* Forms screen: ensure 'Entries' table column is now 'responses'
* Responses screen: ensure subtitle now says "View and manage all your form responses in one place."

## Changelog
<!-- Check one of the boxes below. -->

Already added changelog file. 

- [ ] Generate changelog entries for this PR (using AI).
