### PR TITLE
Newsletter: Use script-data utilities for site info and admin URLs

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3142,6 +3142,9 @@ importers:
       '@automattic/jetpack-components':
         specifier: workspace:*
         version: link:../../js-packages/components
+      '@automattic/jetpack-script-data':
+        specifier: workspace:*
+        version: link:../../js-packages/script-data
       '@automattic/jetpack-shared-extension-utils':
         specifier: workspace:*
         version: link:../../js-packages/shared-extension-utils

--- a/projects/js-packages/script-data/changelog/dotcom-16058-make-better-use-of-script_data-to-reduce-duplication
+++ b/projects/js-packages/script-data/changelog/dotcom-16058-make-better-use-of-script_data-to-reduce-duplication
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add getSiteType() utility for categorizing sites as 'simple', 'atomic', or 'jetpack'

--- a/projects/js-packages/script-data/changelog/dotcom-16058-make-better-use-of-script_data-to-reduce-duplication
+++ b/projects/js-packages/script-data/changelog/dotcom-16058-make-better-use-of-script_data-to-reduce-duplication
@@ -1,4 +1,4 @@
 Significance: minor
 Type: added
 
-Add getSiteType() utility for categorizing sites as 'simple', 'atomic', or 'jetpack'
+Add getSiteType() utility for categorizing sites as 'simple', 'woa', or 'jetpack'.

--- a/projects/js-packages/script-data/src/types.ts
+++ b/projects/js-packages/script-data/src/types.ts
@@ -60,3 +60,11 @@ declare global {
 		JetpackScriptData: JetpackScriptData;
 	}
 }
+
+/**
+ * Site type categories for analytics and conditional logic.
+ * - 'simple': WordPress.com Simple sites
+ * - 'woa': WordPress.com sites on Atomic infrastructure
+ * - 'jetpack': Self-hosted Jetpack sites
+ */
+export type SiteType = 'simple' | 'woa' | 'jetpack';

--- a/projects/js-packages/script-data/src/utils.ts
+++ b/projects/js-packages/script-data/src/utils.ts
@@ -112,6 +112,32 @@ export function isJetpackSelfHostedSite() {
 }
 
 /**
+ * Site type categories for analytics and conditional logic.
+ * - 'simple': WordPress.com Simple sites
+ * - 'atomic': WordPress.com Atomic sites (including WoA)
+ * - 'jetpack': Self-hosted Jetpack sites
+ */
+export type SiteType = 'simple' | 'atomic' | 'jetpack';
+
+/**
+ * Get the site type category.
+ * Useful for analytics tracking and conditional UI logic.
+ *
+ * @return {SiteType} The site type: 'simple', 'atomic', or 'jetpack'.
+ */
+export function getSiteType(): SiteType {
+	if ( isSimpleSite() ) {
+		return 'simple';
+	}
+
+	if ( isWpcomPlatformSite() ) {
+		return 'atomic';
+	}
+
+	return 'jetpack';
+}
+
+/**
  * Check if the current user has a particular capability.
  *
  * @param capability - The capability to check.

--- a/projects/js-packages/script-data/src/utils.ts
+++ b/projects/js-packages/script-data/src/utils.ts
@@ -114,16 +114,16 @@ export function isJetpackSelfHostedSite() {
 /**
  * Site type categories for analytics and conditional logic.
  * - 'simple': WordPress.com Simple sites
- * - 'atomic': WordPress.com Atomic sites (including WoA)
+ * - 'woa': WordPress.com sites on Atomic infrastructure
  * - 'jetpack': Self-hosted Jetpack sites
  */
-export type SiteType = 'simple' | 'atomic' | 'jetpack';
+export type SiteType = 'simple' | 'woa' | 'jetpack';
 
 /**
  * Get the site type category.
  * Useful for analytics tracking and conditional UI logic.
  *
- * @return {SiteType} The site type: 'simple', 'atomic', or 'jetpack'.
+ * @return {SiteType} The site type: 'simple', 'woa', or 'jetpack'.
  */
 export function getSiteType(): SiteType {
 	if ( isSimpleSite() ) {
@@ -131,7 +131,7 @@ export function getSiteType(): SiteType {
 	}
 
 	if ( isWpcomPlatformSite() ) {
-		return 'atomic';
+		return 'woa';
 	}
 
 	return 'jetpack';

--- a/projects/js-packages/script-data/src/utils.ts
+++ b/projects/js-packages/script-data/src/utils.ts
@@ -1,4 +1,4 @@
-import { CurrentUserData } from './types.ts';
+import { CurrentUserData, SiteType } from './types.ts';
 
 /**
  * Get the script data from the window object.
@@ -110,14 +110,6 @@ export function isWpcomPlatformSite() {
 export function isJetpackSelfHostedSite() {
 	return getScriptData()?.site?.host === 'unknown';
 }
-
-/**
- * Site type categories for analytics and conditional logic.
- * - 'simple': WordPress.com Simple sites
- * - 'woa': WordPress.com sites on Atomic infrastructure
- * - 'jetpack': Self-hosted Jetpack sites
- */
-export type SiteType = 'simple' | 'woa' | 'jetpack';
 
 /**
  * Get the site type category.

--- a/projects/packages/newsletter/changelog/dotcom-16058-make-better-use-of-script_data-to-reduce-duplication
+++ b/projects/packages/newsletter/changelog/dotcom-16058-make-better-use-of-script_data-to-reduce-duplication
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Refactor settings to use @automattic/jetpack-script-data utilities for site info and admin URLs

--- a/projects/packages/newsletter/package.json
+++ b/projects/packages/newsletter/package.json
@@ -35,6 +35,7 @@
 		"@automattic/jetpack-analytics": "workspace:*",
 		"@automattic/jetpack-api": "workspace:*",
 		"@automattic/jetpack-components": "workspace:*",
+		"@automattic/jetpack-script-data": "workspace:*",
 		"@automattic/jetpack-shared-extension-utils": "workspace:*",
 		"@wordpress/api-fetch": "7.40.0",
 		"@wordpress/components": "32.2.0",

--- a/projects/packages/newsletter/src/class-settings.php
+++ b/projects/packages/newsletter/src/class-settings.php
@@ -9,7 +9,6 @@ namespace Automattic\Jetpack\Newsletter;
 
 use Automattic\Jetpack\Admin_UI\Admin_Menu;
 use Automattic\Jetpack\Assets;
-use Automattic\Jetpack\Assets\Script_Data;
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Modules;
 use Automattic\Jetpack\Paths;
@@ -36,7 +35,6 @@ class Settings {
 	public static function init() {
 		if ( ! self::$initialized ) {
 			self::$initialized = true;
-			Script_Data::configure();
 			( new self() )->init_hooks();
 		}
 	}

--- a/projects/packages/newsletter/src/class-settings.php
+++ b/projects/packages/newsletter/src/class-settings.php
@@ -82,7 +82,9 @@ class Settings {
 		}
 
 		// Add admin menu item.
-		add_action( 'admin_menu', array( $this, 'add_wp_admin_menu' ), 1000 );
+		// Use priority 999 to ensure menu items are queued BEFORE Admin_Menu::admin_menu_hook_callback
+		// runs at priority 1000 to process all queued items.
+		add_action( 'admin_menu', array( $this, 'add_wp_admin_menu' ), 999 );
 
 		// Hijack the config URLs to point to our settings page.
 		// Customize the configuration URL to lead to the Subscriptions settings.

--- a/projects/packages/newsletter/src/class-settings.php
+++ b/projects/packages/newsletter/src/class-settings.php
@@ -9,6 +9,7 @@ namespace Automattic\Jetpack\Newsletter;
 
 use Automattic\Jetpack\Admin_UI\Admin_Menu;
 use Automattic\Jetpack\Assets;
+use Automattic\Jetpack\Assets\Script_Data;
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Modules;
 use Automattic\Jetpack\Paths;
@@ -35,6 +36,7 @@ class Settings {
 	public static function init() {
 		if ( ! self::$initialized ) {
 			self::$initialized = true;
+			Script_Data::configure();
 			( new self() )->init_hooks();
 		}
 	}
@@ -178,7 +180,50 @@ class Settings {
 	 * Admin init actions.
 	 */
 	public function admin_init() {
+		add_filter( 'jetpack_admin_js_script_data', array( $this, 'add_script_data' ) );
 		add_action( 'admin_enqueue_scripts', array( $this, 'load_admin_scripts' ) );
+	}
+
+	/**
+	 * Add newsletter-specific data to the global JetpackScriptData object.
+	 *
+	 * @param array $data The existing script data.
+	 * @return array The modified script data.
+	 */
+	public function add_script_data( $data ) {
+		$current_user = wp_get_current_user();
+		$theme        = wp_get_theme();
+
+		$site_url     = get_site_url();
+		$site_raw_url = preg_replace( '(^https?://)', '', $site_url );
+
+		$host                   = new Host();
+		$blog_id                = (int) $host->get_wpcom_site_id();
+		$is_wpcom_simple        = $host->is_wpcom_simple();
+		$setup_payment_plan_url = ( $is_wpcom_simple ? 'https://wordpress.com/earn/payments/' : 'https://cloud.jetpack.com/monetize/payments/' ) . rawurlencode( $site_raw_url );
+
+		$wp_admin_subscriber_management_enabled = apply_filters( 'jetpack_wp_admin_subscriber_management_enabled', false );
+
+		// Populate blog_id which is needed for API calls on Simple sites.
+		$data['site']['wpcom']['blog_id'] = $blog_id;
+
+		// Add newsletter-specific data.
+		// Note: Common data like admin_url, rest_nonce, rest_root, title, is_wpcom_platform,
+		// and user.current_user.display_name are already provided by Script_Data.
+		$data['newsletter'] = array(
+			'isBlockTheme'                    => wp_is_block_theme(),
+			'themeStylesheet'                 => $theme->get_stylesheet(),
+			'email'                           => $current_user->user_email,
+			'gravatar'                        => get_avatar_url( $current_user->ID ),
+			'dateExample'                     => gmdate( get_option( 'date_format' ), time() ),
+			'subscriberManagementUrl'         => $this->get_subscriber_management_url( $wp_admin_subscriber_management_enabled, $is_wpcom_simple, $site_raw_url, $blog_id ),
+			'isSubscriptionSiteEditSupported' => wp_is_block_theme(),
+			'setupPaymentPlansUrl'            => $setup_payment_plan_url,
+			'isSitePublic'                    => (int) get_option( 'blog_public' ) === 1,
+			'tracksUserData'                  => Jetpack_Tracks_Client::get_connected_user_tracks_identity(),
+		);
+
+		return $data;
 	}
 
 	/**
@@ -190,16 +235,11 @@ class Settings {
 			'../build/newsletter.js',
 			__FILE__,
 			array(
-				'in_footer'  => true,
-				'textdomain' => 'jetpack-newsletter',
-				'enqueue'    => true,
+				'in_footer'    => true,
+				'textdomain'   => 'jetpack-newsletter',
+				'enqueue'      => true,
+				'dependencies' => array( 'jetpack-script-data' ),
 			)
-		);
-
-		wp_add_inline_script(
-			'jetpack-newsletter',
-			'window.jetpackNewsletterSettings = ' . wp_json_encode( $this->get_settings_data(), JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP ) . ';',
-			'before'
 		);
 
 		// Enqueue the Tracks script for analytics.
@@ -235,48 +275,6 @@ class Settings {
 		return Redirect::get_url(
 			'jetpack-settings-jetpack-manage-subscribers',
 			array( 'site' => $site_id )
-		);
-	}
-
-	/**
-	 * Get the data to be passed to the newsletter settings page.
-	 *
-	 * @return array
-	 */
-	private function get_settings_data() {
-		$current_user = wp_get_current_user();
-		$theme        = wp_get_theme();
-
-		$site_url     = get_site_url();
-		$site_raw_url = preg_replace( '(^https?://)', '', $site_url );
-
-		$host                   = new Host();
-		$blog_id                = (int) $host->get_wpcom_site_id();
-		$is_wpcom               = $host->is_wpcom_platform();
-		$is_wpcom_simple        = $host->is_wpcom_simple();
-		$setup_payment_plan_url = ( $is_wpcom_simple ? 'https://wordpress.com/earn/payments/' : 'https://cloud.jetpack.com/monetize/payments/' ) . rawurlencode( $site_raw_url );
-
-		$wp_admin_subscriber_management_enabled = apply_filters( 'jetpack_wp_admin_subscriber_management_enabled', false );
-
-		return array(
-			'isBlockTheme'                    => wp_is_block_theme(),
-			'siteAdminUrl'                    => admin_url(),
-			'themeStylesheet'                 => $theme->get_stylesheet(),
-			'blogID'                          => $blog_id,
-			'email'                           => $current_user->user_email,
-			'gravatar'                        => get_avatar_url( $current_user->ID ),
-			'displayName'                     => $current_user->display_name,
-			'dateExample'                     => gmdate( get_option( 'date_format' ), time() ),
-			'subscriberManagementUrl'         => $this->get_subscriber_management_url( $wp_admin_subscriber_management_enabled, $is_wpcom_simple, $site_raw_url, $blog_id ),
-			'isSubscriptionSiteEditSupported' => wp_is_block_theme(),
-			'setupPaymentPlansUrl'            => $setup_payment_plan_url,
-			'isSitePublic'                    => (int) get_option( 'blog_public' ) === 1,
-			'isWpcomPlatform'                 => $is_wpcom,
-			'isWpcomSimple'                   => $is_wpcom_simple,
-			'restApiRoot'                     => esc_url_raw( rest_url() ),
-			'restApiNonce'                    => wp_create_nonce( 'wp_rest' ),
-			'siteName'                        => get_bloginfo( 'name' ),
-			'tracksUserData'                  => Jetpack_Tracks_Client::get_connected_user_tracks_identity(),
 		);
 	}
 

--- a/projects/packages/newsletter/src/settings/api.ts
+++ b/projects/packages/newsletter/src/settings/api.ts
@@ -7,45 +7,51 @@
  */
 
 import restApi from '@automattic/jetpack-api';
+import { getSiteData, isSimpleSite } from '@automattic/jetpack-script-data';
 import apiFetch from '@wordpress/api-fetch';
-import type { JetpackNewsletterSettings } from './types';
 
 let apiInitialized = false;
 
 /**
- * Initialize the REST API with settings from PHP.
+ * Initialize the REST API with data from JetpackScriptData.
  * Only needed for non-Simple sites. Call this before making API requests.
- *
- * @param {JetpackNewsletterSettings} jetpackSettings - Settings from PHP
  */
-export function initializeApi( jetpackSettings: JetpackNewsletterSettings | undefined ): void {
-	if ( apiInitialized || jetpackSettings?.isWpcomSimple ) {
+export function initializeApi(): void {
+	if ( apiInitialized || isSimpleSite() ) {
 		return;
 	}
 
-	if ( jetpackSettings?.restApiRoot && jetpackSettings?.restApiNonce ) {
-		restApi.setApiRoot( jetpackSettings.restApiRoot );
-		restApi.setApiNonce( jetpackSettings.restApiNonce );
+	const siteData = getSiteData();
+	if ( siteData?.rest_root && siteData?.rest_nonce ) {
+		restApi.setApiRoot( siteData.rest_root );
+		restApi.setApiNonce( siteData.rest_nonce );
 		apiInitialized = true;
 	}
+}
+
+/**
+ * Get the blog ID from JetpackScriptData.
+ *
+ * @return {number} The blog ID
+ */
+function getBlogId(): number {
+	return getSiteData()?.wpcom?.blog_id ?? 0;
 }
 
 /**
  * Fetch settings from the Jetpack REST API.
  * On Simple sites, uses the WordPress.com REST API.
  *
- * @param {JetpackNewsletterSettings} jetpackSettings - Settings from PHP
  * @return {Promise<Record<string, unknown>>} The settings object
  */
-export async function fetchSettings(
-	jetpackSettings: JetpackNewsletterSettings | undefined
-): Promise< Record< string, unknown > > {
-	if ( jetpackSettings?.isWpcomSimple && jetpackSettings?.blogID ) {
-		return fetchSettingsViaWpcomApi( jetpackSettings.blogID );
+export async function fetchSettings(): Promise< Record< string, unknown > > {
+	const blogId = getBlogId();
+	if ( isSimpleSite() && blogId ) {
+		return fetchSettingsViaWpcomApi( blogId );
 	}
 
 	// For non-Simple sites, use the standard API
-	initializeApi( jetpackSettings );
+	initializeApi();
 	return restApi.fetchSettings();
 }
 
@@ -53,20 +59,19 @@ export async function fetchSettings(
  * Update settings via the Jetpack REST API.
  * On Simple sites, uses the WordPress.com REST API.
  *
- * @param {Record<string, unknown>}   updates         - The settings to update
- * @param {JetpackNewsletterSettings} jetpackSettings - Settings from PHP
+ * @param {Record<string, unknown>} updates - The settings to update
  * @return {Promise<Record<string, unknown>>} The response
  */
 export async function updateSettings(
-	updates: Record< string, unknown >,
-	jetpackSettings: JetpackNewsletterSettings | undefined
+	updates: Record< string, unknown >
 ): Promise< Record< string, unknown > > {
-	if ( jetpackSettings?.isWpcomSimple && jetpackSettings?.blogID ) {
-		return updateSettingsViaWpcomApi( updates, jetpackSettings.blogID );
+	const blogId = getBlogId();
+	if ( isSimpleSite() && blogId ) {
+		return updateSettingsViaWpcomApi( updates, blogId );
 	}
 
 	// For non-Simple sites, use the standard API
-	initializeApi( jetpackSettings );
+	initializeApi();
 	return restApi.updateSettings( updates );
 }
 
@@ -123,14 +128,12 @@ export interface Category {
  * Fetch all categories, handling pagination.
  * On Simple sites, uses the WordPress.com REST API.
  *
- * @param {JetpackNewsletterSettings} jetpackSettings - Settings from PHP
  * @return {Promise<Category[]>} Array of categories
  */
-export async function fetchCategories(
-	jetpackSettings: JetpackNewsletterSettings | undefined
-): Promise< Category[] > {
-	if ( jetpackSettings?.isWpcomSimple && jetpackSettings?.blogID ) {
-		return fetchCategoriesViaWpcomApi( jetpackSettings.blogID );
+export async function fetchCategories(): Promise< Category[] > {
+	const blogId = getBlogId();
+	if ( isSimpleSite() && blogId ) {
+		return fetchCategoriesViaWpcomApi( blogId );
 	}
 
 	return fetchCategoriesViaWpApi();

--- a/projects/packages/newsletter/src/settings/components/toggle-with-link.tsx
+++ b/projects/packages/newsletter/src/settings/components/toggle-with-link.tsx
@@ -2,16 +2,12 @@
  * External dependencies
  */
 import analytics from '@automattic/jetpack-analytics';
-import { getAdminUrl } from '@automattic/jetpack-script-data';
+import { getAdminUrl, type SiteType } from '@automattic/jetpack-script-data';
 import { ExternalLink, ToggleControl } from '@wordpress/components';
 import { type Field } from '@wordpress/dataviews/wp';
 import { useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
-/**
- * Internal dependencies
- */
-import { type SiteType } from '../utils';
 import './toggle-with-link.scss';
 
 interface ToggleWithLinkProps {

--- a/projects/packages/newsletter/src/settings/components/toggle-with-link.tsx
+++ b/projects/packages/newsletter/src/settings/components/toggle-with-link.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import analytics from '@automattic/jetpack-analytics';
+import { getAdminUrl } from '@automattic/jetpack-script-data';
 import { ExternalLink, ToggleControl } from '@wordpress/components';
 import { type Field } from '@wordpress/dataviews/wp';
 import { useCallback } from '@wordpress/element';
@@ -77,7 +78,6 @@ interface ToggleWithEditorLinkProps {
 	data: Record< string, unknown >;
 	field: Field< Record< string, unknown > >;
 	onChange: ( updates: Record< string, unknown > ) => void;
-	siteAdminUrl: string;
 	themeStylesheet: string;
 	postType: 'wp_template' | 'wp_template_part';
 	templateId: string;
@@ -91,7 +91,6 @@ interface ToggleWithEditorLinkProps {
  * @param {object}   props.data            - The data object
  * @param {object}   props.field           - The field definition
  * @param {Function} props.onChange        - Change handler
- * @param {string}   props.siteAdminUrl    - Site admin URL
  * @param {string}   props.themeStylesheet - Theme stylesheet name
  * @param {string}   props.postType        - Post type (wp_template or wp_template_part)
  * @param {string}   props.templateId      - Template ID
@@ -102,13 +101,12 @@ export function ToggleWithEditorLink( {
 	data,
 	field,
 	onChange,
-	siteAdminUrl,
 	themeStylesheet,
 	postType,
 	templateId,
 	siteType,
 }: ToggleWithEditorLinkProps ): JSX.Element {
-	const url = addQueryArgs( `${ siteAdminUrl }site-editor.php`, {
+	const url = addQueryArgs( getAdminUrl( 'site-editor.php' ), {
 		postType,
 		postId: `${ themeStylesheet }//${ templateId }`,
 		canvas: 'edit',

--- a/projects/packages/newsletter/src/settings/declarations.d.ts
+++ b/projects/packages/newsletter/src/settings/declarations.d.ts
@@ -1,0 +1,8 @@
+import { NewsletterScriptData } from './types';
+
+// Use module augmentation to add the newsletter property to JetpackScriptData
+declare module '@automattic/jetpack-script-data' {
+	interface JetpackScriptData {
+		newsletter: NewsletterScriptData;
+	}
+}

--- a/projects/packages/newsletter/src/settings/index.tsx
+++ b/projects/packages/newsletter/src/settings/index.tsx
@@ -405,7 +405,7 @@ function NewsletterSettingsApp(): JSX.Element | null {
 			<Container horizontalSpacing={ 3 }>
 				<Col>
 					<div className="newsletter-settings">
-						{ ! jetpackSettings?.isWpcomSimple && (
+						{ ! isSimpleSite() && (
 							<NewsletterSection
 								data={ data }
 								jetpackSettings={ jetpackSettings }
@@ -476,7 +476,6 @@ function NewsletterSettingsApp(): JSX.Element | null {
 							isSaving={ isSavingWelcomeEmail }
 							hasChanges={ hasWelcomeEmailChanges }
 							isNewsletterEnabled={ data.subscriptions }
-							jetpackSettings={ jetpackSettings }
 						/>
 
 						<GlobalNotices />

--- a/projects/packages/newsletter/src/settings/index.tsx
+++ b/projects/packages/newsletter/src/settings/index.tsx
@@ -9,8 +9,14 @@ import {
 	GlobalNotices,
 	useGlobalNotices,
 } from '@automattic/jetpack-components';
+import {
+	getScriptData,
+	getSiteData,
+	isSimpleSite,
+	isWpcomPlatformSite,
+} from '@automattic/jetpack-script-data';
 import { Notice } from '@wordpress/components';
-import { createRoot, useCallback, useEffect, useState } from '@wordpress/element';
+import { createRoot, useCallback, useEffect, useState, useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
@@ -29,7 +35,11 @@ import {
 	WelcomeEmailSection,
 } from './sections';
 import { getSiteType } from './utils';
-import type { NewsletterSettings, JetpackNewsletterSettings } from './types';
+import type {
+	NewsletterSettings,
+	NewsletterJetpackScriptData,
+	CombinedNewsletterSettings,
+} from './types';
 import './style.scss';
 
 const MODULE_NAME = __( 'Jetpack Newsletter', 'jetpack-newsletter' );
@@ -87,25 +97,47 @@ function NewsletterSettingsApp(): JSX.Element | null {
 	);
 	const [ isSavingWelcomeEmail, setIsSavingWelcomeEmail ] = useState( false );
 
-	// Get settings from PHP
-	const jetpackSettings = (
-		window as Window & { jetpackNewsletterSettings?: JetpackNewsletterSettings }
-	 ).jetpackNewsletterSettings;
+	// Get all data from JetpackScriptData (common site data + newsletter-specific data)
+	const scriptData = useMemo(
+		() => getScriptData() as NewsletterJetpackScriptData | undefined,
+		[]
+	);
+	const siteData = useMemo( () => getSiteData(), [] );
+	const newsletterData = scriptData?.newsletter;
+
+	// Combine site data, user data, and newsletter data for section components
+	const jetpackSettings = useMemo( (): CombinedNewsletterSettings | undefined => {
+		if ( ! newsletterData || ! siteData || ! scriptData?.user ) {
+			return undefined;
+		}
+		return {
+			...newsletterData,
+			// Site data fields needed by components (using script-data utilities)
+			siteName: siteData.title ?? '',
+			blogID: siteData.wpcom?.blog_id ?? 0,
+			isWpcomPlatform: isWpcomPlatformSite() ?? false,
+			// User data fields needed by components
+			displayName: scriptData.user.current_user?.display_name ?? '',
+		};
+	}, [ newsletterData, siteData, scriptData?.user ] );
 
 	// Global notices for success/error messages
 	const { createSuccessNotice, createErrorNotice } = useGlobalNotices();
 
+	// Get site type for analytics (uses JetpackScriptData)
+	const siteType = useMemo( () => getSiteType(), [] );
+
 	// Initialize analytics with user data
 	useEffect( () => {
-		const tracksUserData = jetpackSettings?.tracksUserData;
+		const tracksUserData = newsletterData?.tracksUserData;
 		if ( tracksUserData && typeof tracksUserData === 'object' ) {
 			analytics.initialize( tracksUserData.userid, tracksUserData.username );
 		}
-	}, [ jetpackSettings ] );
+	}, [ newsletterData ] );
 
 	// Load settings on mount
 	useEffect( () => {
-		fetchSettings( jetpackSettings )
+		fetchSettings()
 			.then( ( settings: Record< string, unknown > ) => {
 				setData( normalizeSettings( settings ) );
 				setIsLoading( false );
@@ -116,10 +148,7 @@ function NewsletterSettingsApp(): JSX.Element | null {
 				setError( err.message || __( 'Failed to load settings', 'jetpack-newsletter' ) );
 				setIsLoading( false );
 			} );
-	}, [ jetpackSettings ] );
-
-	// Get site type for analytics
-	const siteType = getSiteType( jetpackSettings );
+	}, [] );
 
 	// Handle auto-save for newsletter toggle and email settings
 	const handleAutoSave = useCallback(
@@ -158,7 +187,7 @@ function NewsletterSettingsApp(): JSX.Element | null {
 			setData( prev => ( { ...prev, ...updates } ) );
 
 			// Save to backend
-			updateSettings( updates, jetpackSettings )
+			updateSettings( updates )
 				.then( () => {
 					createSuccessNotice( __( 'Settings saved', 'jetpack-newsletter' ) );
 				} )
@@ -172,7 +201,7 @@ function NewsletterSettingsApp(): JSX.Element | null {
 					setData( data );
 				} );
 		},
-		[ createErrorNotice, createSuccessNotice, data, jetpackSettings, siteType ]
+		[ createErrorNotice, createSuccessNotice, data, siteType ]
 	);
 
 	// Handle sender name changes (staged, not auto-saved)
@@ -191,7 +220,7 @@ function NewsletterSettingsApp(): JSX.Element | null {
 
 		setIsSavingSenderName( true );
 
-		updateSettings( senderNameChanges, jetpackSettings )
+		updateSettings( senderNameChanges )
 			.then( () => {
 				setSenderNameChanges( {} );
 				createSuccessNotice( __( 'Sender name saved', 'jetpack-newsletter' ) );
@@ -207,7 +236,7 @@ function NewsletterSettingsApp(): JSX.Element | null {
 			.finally( () => {
 				setIsSavingSenderName( false );
 			} );
-	}, [ createErrorNotice, createSuccessNotice, senderNameChanges, data, jetpackSettings ] );
+	}, [ createErrorNotice, createSuccessNotice, senderNameChanges, data ] );
 
 	// Handle subscription settings changes (staged, not auto-saved)
 	const handleSubscriptionChange = useCallback( ( updates: Partial< NewsletterSettings > ) => {
@@ -225,7 +254,7 @@ function NewsletterSettingsApp(): JSX.Element | null {
 
 		setIsSavingSubscriptions( true );
 
-		updateSettings( subscriptionChanges, jetpackSettings )
+		updateSettings( subscriptionChanges )
 			.then( () => {
 				setSubscriptionChanges( {} );
 				createSuccessNotice( __( 'Settings saved', 'jetpack-newsletter' ) );
@@ -241,7 +270,7 @@ function NewsletterSettingsApp(): JSX.Element | null {
 			.finally( () => {
 				setIsSavingSubscriptions( false );
 			} );
-	}, [ createErrorNotice, createSuccessNotice, subscriptionChanges, data, jetpackSettings ] );
+	}, [ createErrorNotice, createSuccessNotice, subscriptionChanges, data ] );
 
 	// Handle newsletter categories changes (staged, not auto-saved)
 	const handleNewsletterCategoriesChange = useCallback(
@@ -280,7 +309,7 @@ function NewsletterSettingsApp(): JSX.Element | null {
 			}
 		}
 
-		updateSettings( apiUpdates, jetpackSettings )
+		updateSettings( apiUpdates )
 			.then( () => {
 				setNewsletterCategoriesChanges( {} );
 				createSuccessNotice( __( 'Newsletter categories saved', 'jetpack-newsletter' ) );
@@ -296,13 +325,7 @@ function NewsletterSettingsApp(): JSX.Element | null {
 			.finally( () => {
 				setIsSavingNewsletterCategories( false );
 			} );
-	}, [
-		createErrorNotice,
-		createSuccessNotice,
-		newsletterCategoriesChanges,
-		data,
-		jetpackSettings,
-	] );
+	}, [ createErrorNotice, createSuccessNotice, newsletterCategoriesChanges, data ] );
 
 	// Handle welcome email changes (staged, not auto-saved)
 	const handleWelcomeEmailChange = useCallback( ( updates: Partial< NewsletterSettings > ) => {
@@ -320,7 +343,7 @@ function NewsletterSettingsApp(): JSX.Element | null {
 
 		setIsSavingWelcomeEmail( true );
 
-		updateSettings( welcomeEmailChanges, jetpackSettings )
+		updateSettings( welcomeEmailChanges )
 			.then( () => {
 				setWelcomeEmailChanges( {} );
 				createSuccessNotice( __( 'Welcome email message saved', 'jetpack-newsletter' ) );
@@ -336,7 +359,7 @@ function NewsletterSettingsApp(): JSX.Element | null {
 			.finally( () => {
 				setIsSavingWelcomeEmail( false );
 			} );
-	}, [ createErrorNotice, createSuccessNotice, welcomeEmailChanges, data, jetpackSettings ] );
+	}, [ createErrorNotice, createSuccessNotice, welcomeEmailChanges, data ] );
 
 	if ( isLoading ) {
 		return (

--- a/projects/packages/newsletter/src/settings/index.tsx
+++ b/projects/packages/newsletter/src/settings/index.tsx
@@ -14,7 +14,6 @@ import {
 	getSiteData,
 	getSiteType,
 	isSimpleSite,
-	isWpcomPlatformSite,
 } from '@automattic/jetpack-script-data';
 import { Notice } from '@wordpress/components';
 import { createRoot, useCallback, useEffect, useState, useMemo } from '@wordpress/element';
@@ -112,11 +111,8 @@ function NewsletterSettingsApp(): JSX.Element | null {
 		}
 		return {
 			...newsletterData,
-			// Site data fields needed by components (using script-data utilities)
+			// Site data fields needed by components
 			siteName: siteData.title ?? '',
-			blogID: siteData.wpcom?.blog_id ?? 0,
-			isWpcomPlatform: isWpcomPlatformSite() ?? false,
-			// User data fields needed by components
 			displayName: scriptData.user.current_user?.display_name ?? '',
 		};
 	}, [ newsletterData, siteData, scriptData?.user ] );
@@ -435,7 +431,6 @@ function NewsletterSettingsApp(): JSX.Element | null {
 							onSave={ saveNewsletterCategories }
 							isSaving={ isSavingNewsletterCategories }
 							hasChanges={ hasNewsletterCategoriesChanges }
-							jetpackSettings={ jetpackSettings }
 							isNewsletterEnabled={ data.subscriptions }
 						/>
 

--- a/projects/packages/newsletter/src/settings/index.tsx
+++ b/projects/packages/newsletter/src/settings/index.tsx
@@ -12,6 +12,7 @@ import {
 import {
 	getScriptData,
 	getSiteData,
+	getSiteType,
 	isSimpleSite,
 	isWpcomPlatformSite,
 } from '@automattic/jetpack-script-data';
@@ -34,7 +35,6 @@ import {
 	SubscriptionsSection,
 	WelcomeEmailSection,
 } from './sections';
-import { getSiteType } from './utils';
 import type {
 	NewsletterSettings,
 	NewsletterJetpackScriptData,

--- a/projects/packages/newsletter/src/settings/index.tsx
+++ b/projects/packages/newsletter/src/settings/index.tsx
@@ -9,12 +9,7 @@ import {
 	GlobalNotices,
 	useGlobalNotices,
 } from '@automattic/jetpack-components';
-import {
-	getScriptData,
-	getSiteData,
-	getSiteType,
-	isSimpleSite,
-} from '@automattic/jetpack-script-data';
+import { getSiteType, isSimpleSite } from '@automattic/jetpack-script-data';
 import { Notice } from '@wordpress/components';
 import { createRoot, useCallback, useEffect, useState, useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -23,6 +18,7 @@ import { __ } from '@wordpress/i18n';
  */
 import { fetchSettings, updateSettings } from './api';
 import { Header } from './components/header';
+import { getNewsletterScriptData } from './script-data';
 import {
 	EmailContentSection,
 	EmailBylineSection,
@@ -34,11 +30,7 @@ import {
 	SubscriptionsSection,
 	WelcomeEmailSection,
 } from './sections';
-import type {
-	NewsletterSettings,
-	NewsletterJetpackScriptData,
-	CombinedNewsletterSettings,
-} from './types';
+import type { NewsletterSettings } from './types';
 import './style.scss';
 
 const MODULE_NAME = __( 'Jetpack Newsletter', 'jetpack-newsletter' );
@@ -96,40 +88,22 @@ function NewsletterSettingsApp(): JSX.Element | null {
 	);
 	const [ isSavingWelcomeEmail, setIsSavingWelcomeEmail ] = useState( false );
 
-	// Get all data from JetpackScriptData (common site data + newsletter-specific data)
-	const scriptData = useMemo(
-		() => getScriptData() as NewsletterJetpackScriptData | undefined,
-		[]
-	);
-	const siteData = useMemo( () => getSiteData(), [] );
-	const newsletterData = scriptData?.newsletter;
-
-	// Combine site data, user data, and newsletter data for section components
-	const jetpackSettings = useMemo( (): CombinedNewsletterSettings | undefined => {
-		if ( ! newsletterData || ! siteData || ! scriptData?.user ) {
-			return undefined;
-		}
-		return {
-			...newsletterData,
-			// Site data fields needed by components
-			siteName: siteData.title ?? '',
-			displayName: scriptData.user.current_user?.display_name ?? '',
-		};
-	}, [ newsletterData, siteData, scriptData?.user ] );
+	// Get newsletter script data
+	const newsletterScriptData = useMemo( () => getNewsletterScriptData(), [] );
 
 	// Global notices for success/error messages
 	const { createSuccessNotice, createErrorNotice } = useGlobalNotices();
 
-	// Get site type for analytics (uses JetpackScriptData)
+	// Get site type for analytics
 	const siteType = useMemo( () => getSiteType(), [] );
 
 	// Initialize analytics with user data
 	useEffect( () => {
-		const tracksUserData = newsletterData?.tracksUserData;
+		const tracksUserData = newsletterScriptData?.tracksUserData;
 		if ( tracksUserData && typeof tracksUserData === 'object' ) {
 			analytics.initialize( tracksUserData.userid, tracksUserData.username );
 		}
-	}, [ newsletterData ] );
+	}, [ newsletterScriptData ] );
 
 	// Load settings on mount
 	useEffect( () => {
@@ -401,17 +375,10 @@ function NewsletterSettingsApp(): JSX.Element | null {
 			<Container horizontalSpacing={ 3 }>
 				<Col>
 					<div className="newsletter-settings">
-						{ ! isSimpleSite() && (
-							<NewsletterSection
-								data={ data }
-								jetpackSettings={ jetpackSettings }
-								onChange={ handleAutoSave }
-							/>
-						) }
+						{ ! isSimpleSite() && <NewsletterSection data={ data } onChange={ handleAutoSave } /> }
 
 						<SubscriptionsSection
 							data={ data }
-							jetpackSettings={ jetpackSettings }
 							onChange={ handleSubscriptionChange }
 							onSave={ saveSubscriptionSettings }
 							isSaving={ isSavingSubscriptions }
@@ -420,7 +387,6 @@ function NewsletterSettingsApp(): JSX.Element | null {
 						/>
 
 						<PaidNewsletterSection
-							jetpackSettings={ jetpackSettings }
 							isNewsletterEnabled={ data.subscriptions }
 							hasActivePlan={ data.newsletter_has_active_plan }
 						/>
@@ -437,14 +403,12 @@ function NewsletterSettingsApp(): JSX.Element | null {
 						<EmailContentSection
 							data={ data }
 							onChange={ handleAutoSave }
-							isSitePublic={ jetpackSettings?.isSitePublic ?? true }
 							isNewsletterEnabled={ data.subscriptions }
 						/>
 
 						<EmailBylineSection
 							data={ data }
 							onChange={ handleAutoSave }
-							jetpackSettings={ jetpackSettings }
 							isNewsletterEnabled={ data.subscriptions }
 						/>
 
@@ -454,7 +418,6 @@ function NewsletterSettingsApp(): JSX.Element | null {
 							onSave={ saveSenderName }
 							isSaving={ isSavingSenderName }
 							hasChanges={ hasSenderNameChanges }
-							jetpackSettings={ jetpackSettings }
 							isNewsletterEnabled={ data.subscriptions }
 						/>
 

--- a/projects/packages/newsletter/src/settings/script-data.ts
+++ b/projects/packages/newsletter/src/settings/script-data.ts
@@ -1,0 +1,11 @@
+import { getScriptData } from '@automattic/jetpack-script-data';
+import type { NewsletterScriptData } from './types';
+
+/**
+ * Get the newsletter script data from the window object.
+ *
+ * @return The newsletter script data.
+ */
+export function getNewsletterScriptData(): NewsletterScriptData | undefined {
+	return getScriptData()?.newsletter;
+}

--- a/projects/packages/newsletter/src/settings/sections/email-byline-section.tsx
+++ b/projects/packages/newsletter/src/settings/sections/email-byline-section.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { getAdminUrl } from '@automattic/jetpack-script-data';
+import { getAdminUrl, getScriptData } from '@automattic/jetpack-script-data';
 import { DataForm, type Field } from '@wordpress/dataviews/wp';
 import { __ } from '@wordpress/i18n';
 /**
@@ -9,12 +9,12 @@ import { __ } from '@wordpress/i18n';
  */
 import { BylinePreview } from '../components/byline-preview';
 import { ToggleWithLink } from '../components/toggle-with-link';
-import type { NewsletterSettings, CombinedNewsletterSettings } from '../types';
+import { getNewsletterScriptData } from '../script-data';
+import type { NewsletterSettings } from '../types';
 
 interface EmailBylineSectionProps {
 	data: NewsletterSettings;
 	onChange: ( updates: Partial< NewsletterSettings > ) => void;
-	jetpackSettings: CombinedNewsletterSettings | undefined;
 	isNewsletterEnabled: boolean;
 }
 
@@ -29,15 +29,15 @@ interface EmailBylineSectionProps {
 export function EmailBylineSection( {
 	data,
 	onChange,
-	jetpackSettings,
 	isNewsletterEnabled,
 }: EmailBylineSectionProps ): JSX.Element {
+	const newsletterScriptData = getNewsletterScriptData();
 	const fields: Field< NewsletterSettings >[] = [
 		{
 			id: 'jetpack_gravatar_in_email',
 			label: __( 'Show author avatar on your emails', 'jetpack-newsletter' ),
 			type: 'boolean' as const,
-			Edit: jetpackSettings?.email
+			Edit: newsletterScriptData?.email
 				? ( { data: fieldData, field, onChange: fieldOnChange } ) => (
 						<ToggleWithLink
 							data={ fieldData as Record< string, unknown > }
@@ -106,14 +106,14 @@ export function EmailBylineSection( {
 				/>
 
 				{ /* Byline Preview - positioned right after the toggles */ }
-				{ jetpackSettings && (
+				{ newsletterScriptData && (
 					<BylinePreview
 						isGravatarEnabled={ data.jetpack_gravatar_in_email }
 						isAuthorEnabled={ data.jetpack_author_in_email }
 						isPostDateEnabled={ data.jetpack_post_date_in_email }
-						gravatar={ jetpackSettings.gravatar }
-						displayName={ jetpackSettings.displayName }
-						dateExample={ jetpackSettings.dateExample }
+						gravatar={ newsletterScriptData.gravatar }
+						displayName={ getScriptData()?.user.current_user?.display_name ?? '' }
+						dateExample={ newsletterScriptData.dateExample }
 					/>
 				) }
 			</fieldset>

--- a/projects/packages/newsletter/src/settings/sections/email-byline-section.tsx
+++ b/projects/packages/newsletter/src/settings/sections/email-byline-section.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { getAdminUrl } from '@automattic/jetpack-script-data';
 import { DataForm, type Field } from '@wordpress/dataviews/wp';
 import { __ } from '@wordpress/i18n';
 /**
@@ -8,12 +9,12 @@ import { __ } from '@wordpress/i18n';
  */
 import { BylinePreview } from '../components/byline-preview';
 import { ToggleWithLink } from '../components/toggle-with-link';
-import type { NewsletterSettings, JetpackNewsletterSettings } from '../types';
+import type { NewsletterSettings, CombinedNewsletterSettings } from '../types';
 
 interface EmailBylineSectionProps {
 	data: NewsletterSettings;
 	onChange: ( updates: Partial< NewsletterSettings > ) => void;
-	jetpackSettings: JetpackNewsletterSettings | undefined;
+	jetpackSettings: CombinedNewsletterSettings | undefined;
 	isNewsletterEnabled: boolean;
 }
 
@@ -62,18 +63,16 @@ export function EmailBylineSection( {
 			id: 'jetpack_post_date_in_email',
 			label: __( 'Add the post date', 'jetpack-newsletter' ),
 			type: 'boolean' as const,
-			Edit: jetpackSettings?.siteAdminUrl
-				? ( { data: fieldData, field, onChange: fieldOnChange } ) => (
-						<ToggleWithLink
-							data={ fieldData as Record< string, unknown > }
-							field={ field as Field< Record< string, unknown > > }
-							onChange={ fieldOnChange }
-							url={ `${ jetpackSettings.siteAdminUrl }options-general.php` }
-							linkText={ __( 'Customize date format', 'jetpack-newsletter' ) }
-							isExternal={ false }
-						/>
-				  )
-				: ( 'toggle' as const ),
+			Edit: ( { data: fieldData, field, onChange: fieldOnChange } ) => (
+				<ToggleWithLink
+					data={ fieldData as Record< string, unknown > }
+					field={ field as Field< Record< string, unknown > > }
+					onChange={ fieldOnChange }
+					url={ getAdminUrl( 'options-general.php' ) }
+					linkText={ __( 'Customize date format', 'jetpack-newsletter' ) }
+					isExternal={ false }
+				/>
+			),
 		},
 	];
 

--- a/projects/packages/newsletter/src/settings/sections/email-content-section.tsx
+++ b/projects/packages/newsletter/src/settings/sections/email-content-section.tsx
@@ -7,12 +7,12 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
+import { getNewsletterScriptData } from '../script-data';
 import type { NewsletterSettings } from '../types';
 
 interface EmailContentSectionProps {
 	data: NewsletterSettings;
 	onChange: ( updates: Partial< NewsletterSettings > ) => void;
-	isSitePublic: boolean;
 	isNewsletterEnabled: boolean;
 }
 
@@ -27,9 +27,9 @@ interface EmailContentSectionProps {
 export function EmailContentSection( {
 	data,
 	onChange,
-	isSitePublic,
 	isNewsletterEnabled,
 }: EmailContentSectionProps ): JSX.Element {
+	const isSitePublic = getNewsletterScriptData()?.isSitePublic ?? true;
 	const fields: Field< NewsletterSettings >[] = [
 		{
 			id: 'wpcom_featured_image_in_email',

--- a/projects/packages/newsletter/src/settings/sections/email-sender-settings-section.tsx
+++ b/projects/packages/newsletter/src/settings/sections/email-sender-settings-section.tsx
@@ -39,7 +39,7 @@ export function EmailSenderSettingsSection( {
 	jetpackSettings,
 	isNewsletterEnabled,
 }: EmailSenderSettingsSectionProps ): JSX.Element {
-	const siteType = getSiteType( jetpackSettings );
+	const siteType = getSiteType();
 
 	// Translation strings for save button
 	const savingText = __( 'Saving…', 'jetpack-newsletter' );

--- a/projects/packages/newsletter/src/settings/sections/email-sender-settings-section.tsx
+++ b/projects/packages/newsletter/src/settings/sections/email-sender-settings-section.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import analytics from '@automattic/jetpack-analytics';
-import { getSiteType } from '@automattic/jetpack-script-data';
+import { getSiteData, getSiteType } from '@automattic/jetpack-script-data';
 import { Button } from '@wordpress/components';
 import { DataForm, type Field } from '@wordpress/dataviews/wp';
 import { createInterpolateElement, useCallback } from '@wordpress/element';
@@ -10,7 +10,7 @@ import { __, sprintf } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import type { NewsletterSettings, CombinedNewsletterSettings } from '../types';
+import type { NewsletterSettings } from '../types';
 
 interface EmailSenderSettingsSectionProps {
 	data: NewsletterSettings;
@@ -18,7 +18,6 @@ interface EmailSenderSettingsSectionProps {
 	onSave: () => void;
 	isSaving: boolean;
 	hasChanges: boolean;
-	jetpackSettings: CombinedNewsletterSettings | undefined;
 	isNewsletterEnabled: boolean;
 }
 
@@ -36,7 +35,6 @@ export function EmailSenderSettingsSection( {
 	onSave,
 	isSaving,
 	hasChanges,
-	jetpackSettings,
 	isNewsletterEnabled,
 }: EmailSenderSettingsSectionProps ): JSX.Element {
 	const siteType = getSiteType();
@@ -54,12 +52,14 @@ export function EmailSenderSettingsSection( {
 		onSave();
 	}, [ onSave, siteType ] );
 
+	const siteName = getSiteData()?.title;
+
 	const fields: Field< NewsletterSettings >[] = [
 		{
 			id: 'jetpack_subscriptions_from_name',
 			label: __( 'Sender name', 'jetpack-newsletter' ),
 			type: 'text' as const,
-			placeholder: jetpackSettings?.siteName,
+			placeholder: siteName,
 			description: __(
 				"This is the name that appears in subscribers' inboxes. It's usually the name of your newsletter or the author.",
 				'jetpack-newsletter'
@@ -99,7 +99,7 @@ export function EmailSenderSettingsSection( {
 									'Preview: <strong>%1$s</strong> <author-name@example.com>',
 									'jetpack-newsletter'
 								),
-								senderName || jetpackSettings?.siteName || __( 'Your Name', 'jetpack-newsletter' )
+								senderName || siteName || __( 'Your Name', 'jetpack-newsletter' )
 							),
 							{
 								strong: <strong />,

--- a/projects/packages/newsletter/src/settings/sections/email-sender-settings-section.tsx
+++ b/projects/packages/newsletter/src/settings/sections/email-sender-settings-section.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import analytics from '@automattic/jetpack-analytics';
+import { getSiteType } from '@automattic/jetpack-script-data';
 import { Button } from '@wordpress/components';
 import { DataForm, type Field } from '@wordpress/dataviews/wp';
 import { createInterpolateElement, useCallback } from '@wordpress/element';
@@ -9,7 +10,6 @@ import { __, sprintf } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { getSiteType } from '../utils';
 import type { NewsletterSettings, CombinedNewsletterSettings } from '../types';
 
 interface EmailSenderSettingsSectionProps {

--- a/projects/packages/newsletter/src/settings/sections/email-sender-settings-section.tsx
+++ b/projects/packages/newsletter/src/settings/sections/email-sender-settings-section.tsx
@@ -10,7 +10,7 @@ import { __, sprintf } from '@wordpress/i18n';
  * Internal dependencies
  */
 import { getSiteType } from '../utils';
-import type { NewsletterSettings, JetpackNewsletterSettings } from '../types';
+import type { NewsletterSettings, CombinedNewsletterSettings } from '../types';
 
 interface EmailSenderSettingsSectionProps {
 	data: NewsletterSettings;
@@ -18,7 +18,7 @@ interface EmailSenderSettingsSectionProps {
 	onSave: () => void;
 	isSaving: boolean;
 	hasChanges: boolean;
-	jetpackSettings: JetpackNewsletterSettings | undefined;
+	jetpackSettings: CombinedNewsletterSettings | undefined;
 	isNewsletterEnabled: boolean;
 }
 

--- a/projects/packages/newsletter/src/settings/sections/newsletter-categories-section.tsx
+++ b/projects/packages/newsletter/src/settings/sections/newsletter-categories-section.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import analytics from '@automattic/jetpack-analytics';
+import { getAdminUrl } from '@automattic/jetpack-script-data';
 import { WpcomSupportLink } from '@automattic/jetpack-shared-extension-utils/components';
 import { Button, ExternalLink, Notice } from '@wordpress/components';
 import { DataForm, type Field, useFormValidity } from '@wordpress/dataviews/wp';
@@ -12,7 +13,7 @@ import { __ } from '@wordpress/i18n';
  */
 import { fetchCategories } from '../api';
 import { getSiteType } from '../utils';
-import type { NewsletterSettings, JetpackNewsletterSettings, WordPressCategory } from '../types';
+import type { NewsletterSettings, CombinedNewsletterSettings, WordPressCategory } from '../types';
 
 interface NewsletterCategoriesSectionProps {
 	data: NewsletterSettings;
@@ -20,7 +21,7 @@ interface NewsletterCategoriesSectionProps {
 	onSave: () => void;
 	isSaving: boolean;
 	hasChanges: boolean;
-	jetpackSettings: JetpackNewsletterSettings | undefined;
+	jetpackSettings: CombinedNewsletterSettings | undefined;
 	isNewsletterEnabled: boolean;
 }
 
@@ -183,10 +184,12 @@ export function NewsletterCategoriesSection( {
 					validity={ validity }
 				/>
 
-				{ data.wpcom_newsletter_categories_enabled && jetpackSettings?.siteAdminUrl && (
+				{ data.wpcom_newsletter_categories_enabled && (
 					<div className="newsletter-settings__link">
 						<ExternalLink
-							href={ `${ jetpackSettings.siteAdminUrl }edit-tags.php?taxonomy=category&referer=newsletter-categories` }
+							href={ getAdminUrl(
+								'edit-tags.php?taxonomy=category&referer=newsletter-categories'
+							) }
 						>
 							{ __( 'Add New Category', 'jetpack-newsletter' ) }
 						</ExternalLink>

--- a/projects/packages/newsletter/src/settings/sections/newsletter-categories-section.tsx
+++ b/projects/packages/newsletter/src/settings/sections/newsletter-categories-section.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import analytics from '@automattic/jetpack-analytics';
-import { getAdminUrl } from '@automattic/jetpack-script-data';
+import { getAdminUrl, getSiteType } from '@automattic/jetpack-script-data';
 import { WpcomSupportLink } from '@automattic/jetpack-shared-extension-utils/components';
 import { Button, ExternalLink, Notice } from '@wordpress/components';
 import { DataForm, type Field, useFormValidity } from '@wordpress/dataviews/wp';
@@ -12,7 +12,6 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import { fetchCategories } from '../api';
-import { getSiteType } from '../utils';
 import type { NewsletterSettings, CombinedNewsletterSettings, WordPressCategory } from '../types';
 
 interface NewsletterCategoriesSectionProps {

--- a/projects/packages/newsletter/src/settings/sections/newsletter-categories-section.tsx
+++ b/projects/packages/newsletter/src/settings/sections/newsletter-categories-section.tsx
@@ -40,7 +40,7 @@ export function NewsletterCategoriesSection( {
 	jetpackSettings,
 	isNewsletterEnabled,
 }: NewsletterCategoriesSectionProps ): JSX.Element {
-	const siteType = getSiteType( jetpackSettings );
+	const siteType = getSiteType();
 	const [ categories, setCategories ] = useState< WordPressCategory[] >( [] );
 	const [ isFetchingCategories, setIsFetchingCategories ] = useState( true );
 	const [ categoriesError, setCategoriesError ] = useState< string | null >( null );
@@ -56,7 +56,7 @@ export function NewsletterCategoriesSection( {
 
 	// Fetch WordPress categories on mount
 	useEffect( () => {
-		fetchCategories( jetpackSettings )
+		fetchCategories()
 			.then( fetchedCategories => {
 				// Convert category IDs to strings
 				setCategories(
@@ -73,7 +73,7 @@ export function NewsletterCategoriesSection( {
 				);
 				setIsFetchingCategories( false );
 			} );
-	}, [ jetpackSettings ] );
+	}, [] );
 
 	// Define fields
 	const fields: Field< NewsletterSettings >[] = [

--- a/projects/packages/newsletter/src/settings/sections/newsletter-categories-section.tsx
+++ b/projects/packages/newsletter/src/settings/sections/newsletter-categories-section.tsx
@@ -2,7 +2,12 @@
  * External dependencies
  */
 import analytics from '@automattic/jetpack-analytics';
-import { getAdminUrl, getSiteType } from '@automattic/jetpack-script-data';
+import {
+	getAdminUrl,
+	getSiteData,
+	getSiteType,
+	isWpcomPlatformSite,
+} from '@automattic/jetpack-script-data';
 import { WpcomSupportLink } from '@automattic/jetpack-shared-extension-utils/components';
 import { Button, ExternalLink, Notice } from '@wordpress/components';
 import { DataForm, type Field, useFormValidity } from '@wordpress/dataviews/wp';
@@ -12,7 +17,7 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import { fetchCategories } from '../api';
-import type { NewsletterSettings, CombinedNewsletterSettings, WordPressCategory } from '../types';
+import type { NewsletterSettings, WordPressCategory } from '../types';
 
 interface NewsletterCategoriesSectionProps {
 	data: NewsletterSettings;
@@ -20,7 +25,6 @@ interface NewsletterCategoriesSectionProps {
 	onSave: () => void;
 	isSaving: boolean;
 	hasChanges: boolean;
-	jetpackSettings: CombinedNewsletterSettings | undefined;
 	isNewsletterEnabled: boolean;
 }
 
@@ -36,7 +40,6 @@ export function NewsletterCategoriesSection( {
 	onSave,
 	isSaving,
 	hasChanges,
-	jetpackSettings,
 	isNewsletterEnabled,
 }: NewsletterCategoriesSectionProps ): JSX.Element {
 	const siteType = getSiteType();
@@ -138,13 +141,14 @@ export function NewsletterCategoriesSection( {
 	const saveText = __( 'Save', 'jetpack-newsletter' );
 
 	// Build subscribe block documentation URL and component
-	const subscribeBlockUrl = jetpackSettings?.isWpcomPlatform
+	const isWpcom = isWpcomPlatformSite();
+	const subscribeBlockUrl = isWpcom
 		? 'https://wordpress.com/support/wordpress-editor/blocks/subscribe-block/'
 		: `https://jetpack.com/redirect/?source=jetpack-support-subscribe-block&site=${
-				jetpackSettings?.blogID || ''
+				getSiteData()?.wpcom?.blog_id || ''
 		  }`;
 
-	const SubscribeBlockLink = jetpackSettings?.isWpcomPlatform ? (
+	const SubscribeBlockLink = isWpcom ? (
 		<WpcomSupportLink supportLink={ subscribeBlockUrl } supportPostId={ 170164 } />
 	) : (
 		<ExternalLink href={ subscribeBlockUrl } children={ null } />

--- a/projects/packages/newsletter/src/settings/sections/newsletter-section.tsx
+++ b/projects/packages/newsletter/src/settings/sections/newsletter-section.tsx
@@ -10,11 +10,11 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import { getSiteType } from '../utils';
-import type { NewsletterSettings, JetpackNewsletterSettings } from '../types';
+import type { NewsletterSettings, CombinedNewsletterSettings } from '../types';
 
 interface NewsletterSectionProps {
 	data: NewsletterSettings;
-	jetpackSettings: JetpackNewsletterSettings | undefined;
+	jetpackSettings: CombinedNewsletterSettings | undefined;
 	onChange: ( updates: Partial< NewsletterSettings > ) => void;
 }
 

--- a/projects/packages/newsletter/src/settings/sections/newsletter-section.tsx
+++ b/projects/packages/newsletter/src/settings/sections/newsletter-section.tsx
@@ -10,11 +10,11 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import type { NewsletterSettings, CombinedNewsletterSettings } from '../types';
+import { getNewsletterScriptData } from '../script-data';
+import type { NewsletterSettings } from '../types';
 
 interface NewsletterSectionProps {
 	data: NewsletterSettings;
-	jetpackSettings: CombinedNewsletterSettings | undefined;
 	onChange: ( updates: Partial< NewsletterSettings > ) => void;
 }
 
@@ -24,11 +24,8 @@ interface NewsletterSectionProps {
  * @param {NewsletterSectionProps} props - Component props
  * @return {JSX.Element} The newsletter section
  */
-export function NewsletterSection( {
-	data,
-	jetpackSettings,
-	onChange,
-}: NewsletterSectionProps ): JSX.Element {
+export function NewsletterSection( { data, onChange }: NewsletterSectionProps ): JSX.Element {
+	const newsletterScriptData = getNewsletterScriptData();
 	const siteType = getSiteType();
 	const previousSubscriptionsValue = useRef( data.subscriptions );
 
@@ -87,10 +84,10 @@ export function NewsletterSection( {
 					} }
 					onChange={ handleChange }
 				/>
-				{ data.subscriptions && jetpackSettings && (
+				{ data.subscriptions && newsletterScriptData && (
 					<div>
 						<ExternalLink
-							href={ jetpackSettings.subscriberManagementUrl }
+							href={ newsletterScriptData.subscriberManagementUrl }
 							onClick={ handleManageSubscribersClick }
 						>
 							{ __( 'Manage all subscribers', 'jetpack-newsletter' ) }

--- a/projects/packages/newsletter/src/settings/sections/newsletter-section.tsx
+++ b/projects/packages/newsletter/src/settings/sections/newsletter-section.tsx
@@ -29,7 +29,7 @@ export function NewsletterSection( {
 	jetpackSettings,
 	onChange,
 }: NewsletterSectionProps ): JSX.Element {
-	const siteType = getSiteType( jetpackSettings );
+	const siteType = getSiteType();
 	const previousSubscriptionsValue = useRef( data.subscriptions );
 
 	// Wrap onChange to track module toggle

--- a/projects/packages/newsletter/src/settings/sections/newsletter-section.tsx
+++ b/projects/packages/newsletter/src/settings/sections/newsletter-section.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import analytics from '@automattic/jetpack-analytics';
+import { getSiteType } from '@automattic/jetpack-script-data';
 import { ExternalLink } from '@wordpress/components';
 import { DataForm, type Field } from '@wordpress/dataviews/wp';
 import { useCallback, useRef } from '@wordpress/element';
@@ -9,7 +10,6 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { getSiteType } from '../utils';
 import type { NewsletterSettings, CombinedNewsletterSettings } from '../types';
 
 interface NewsletterSectionProps {

--- a/projects/packages/newsletter/src/settings/sections/paid-newsletter-section.tsx
+++ b/projects/packages/newsletter/src/settings/sections/paid-newsletter-section.tsx
@@ -28,7 +28,7 @@ export function PaidNewsletterSection( {
 	isNewsletterEnabled,
 	hasActivePlan = false,
 }: PaidNewsletterSectionProps ): JSX.Element | null {
-	const siteType = getSiteType( jetpackSettings );
+	const siteType = getSiteType();
 
 	// Track paid plans button click
 	const handlePaidPlansClick = useCallback( () => {

--- a/projects/packages/newsletter/src/settings/sections/paid-newsletter-section.tsx
+++ b/projects/packages/newsletter/src/settings/sections/paid-newsletter-section.tsx
@@ -2,13 +2,13 @@
  * External dependencies
  */
 import analytics from '@automattic/jetpack-analytics';
+import { getSiteType } from '@automattic/jetpack-script-data';
 import { Button } from '@wordpress/components';
 import { useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { getSiteType } from '../utils';
 import type { CombinedNewsletterSettings } from '../types';
 
 interface PaidNewsletterSectionProps {

--- a/projects/packages/newsletter/src/settings/sections/paid-newsletter-section.tsx
+++ b/projects/packages/newsletter/src/settings/sections/paid-newsletter-section.tsx
@@ -9,10 +9,9 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import type { CombinedNewsletterSettings } from '../types';
+import { getNewsletterScriptData } from '../script-data';
 
 interface PaidNewsletterSectionProps {
-	jetpackSettings: CombinedNewsletterSettings | undefined;
 	isNewsletterEnabled: boolean;
 	hasActivePlan?: boolean;
 }
@@ -24,11 +23,11 @@ interface PaidNewsletterSectionProps {
  * @return {JSX.Element | null} The paid newsletter section or null if URL not available
  */
 export function PaidNewsletterSection( {
-	jetpackSettings,
 	isNewsletterEnabled,
 	hasActivePlan = false,
 }: PaidNewsletterSectionProps ): JSX.Element | null {
 	const siteType = getSiteType();
+	const newsletterScriptData = getNewsletterScriptData();
 
 	// Track paid plans button click
 	const handlePaidPlansClick = useCallback( () => {
@@ -38,7 +37,7 @@ export function PaidNewsletterSection( {
 		} );
 	}, [ hasActivePlan, siteType ] );
 
-	if ( ! jetpackSettings?.setupPaymentPlansUrl ) {
+	if ( ! newsletterScriptData?.setupPaymentPlansUrl ) {
 		return null;
 	}
 
@@ -61,7 +60,7 @@ export function PaidNewsletterSection( {
 			<fieldset className="newsletter-settings__section-content" disabled={ ! isNewsletterEnabled }>
 				<Button
 					variant="primary"
-					href={ jetpackSettings.setupPaymentPlansUrl }
+					href={ newsletterScriptData.setupPaymentPlansUrl }
 					target="_blank"
 					rel="noopener noreferrer"
 					disabled={ ! isNewsletterEnabled }

--- a/projects/packages/newsletter/src/settings/sections/paid-newsletter-section.tsx
+++ b/projects/packages/newsletter/src/settings/sections/paid-newsletter-section.tsx
@@ -9,10 +9,10 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import { getSiteType } from '../utils';
-import type { JetpackNewsletterSettings } from '../types';
+import type { CombinedNewsletterSettings } from '../types';
 
 interface PaidNewsletterSectionProps {
-	jetpackSettings: JetpackNewsletterSettings | undefined;
+	jetpackSettings: CombinedNewsletterSettings | undefined;
 	isNewsletterEnabled: boolean;
 	hasActivePlan?: boolean;
 }

--- a/projects/packages/newsletter/src/settings/sections/subscriptions-section.tsx
+++ b/projects/packages/newsletter/src/settings/sections/subscriptions-section.tsx
@@ -11,7 +11,7 @@ import { __ } from '@wordpress/i18n';
  */
 import { ToggleWithEditorLink } from '../components/toggle-with-link';
 import { getSiteType } from '../utils';
-import type { NewsletterSettings, JetpackNewsletterSettings } from '../types';
+import type { NewsletterSettings, CombinedNewsletterSettings } from '../types';
 
 interface FieldRenderProps {
 	data: NewsletterSettings;
@@ -21,7 +21,7 @@ interface FieldRenderProps {
 
 interface SubscriptionsSectionProps {
 	data: NewsletterSettings;
-	jetpackSettings: JetpackNewsletterSettings | undefined;
+	jetpackSettings: CombinedNewsletterSettings | undefined;
 	onChange: ( updates: Partial< NewsletterSettings > ) => void;
 	onSave: () => void;
 	isSaving: boolean;
@@ -61,15 +61,11 @@ export function SubscriptionsSection( {
 
 	// Helper to check if we can show editor links for block theme features
 	const canShowBlockThemeEditorLinks =
-		jetpackSettings?.isBlockTheme &&
-		jetpackSettings?.siteAdminUrl &&
-		jetpackSettings?.themeStylesheet;
+		jetpackSettings?.isBlockTheme && jetpackSettings?.themeStylesheet;
 
 	// Helper to check if we can show editor links for subscription site edit features
 	const canShowSubscriptionEditorLinks =
-		jetpackSettings?.isSubscriptionSiteEditSupported &&
-		jetpackSettings?.siteAdminUrl &&
-		jetpackSettings?.themeStylesheet;
+		jetpackSettings?.isSubscriptionSiteEditSupported && jetpackSettings?.themeStylesheet;
 
 	const fields: Field< NewsletterSettings >[] = [
 		{
@@ -82,7 +78,6 @@ export function SubscriptionsSection( {
 							data={ formData }
 							field={ field }
 							onChange={ fieldOnChange }
-							siteAdminUrl={ jetpackSettings.siteAdminUrl }
 							themeStylesheet={ jetpackSettings.themeStylesheet }
 							postType="wp_template"
 							templateId="single"
@@ -101,7 +96,6 @@ export function SubscriptionsSection( {
 							data={ formData }
 							field={ field }
 							onChange={ fieldOnChange }
-							siteAdminUrl={ jetpackSettings.siteAdminUrl }
 							themeStylesheet={ jetpackSettings.themeStylesheet }
 							postType="wp_template_part"
 							templateId="jetpack-subscribe-modal"
@@ -120,7 +114,6 @@ export function SubscriptionsSection( {
 							data={ formData }
 							field={ field }
 							onChange={ fieldOnChange }
-							siteAdminUrl={ jetpackSettings.siteAdminUrl }
 							themeStylesheet={ jetpackSettings.themeStylesheet }
 							postType="wp_template_part"
 							templateId="jetpack-subscribe-overlay"
@@ -139,7 +132,6 @@ export function SubscriptionsSection( {
 							data={ formData }
 							field={ field }
 							onChange={ fieldOnChange }
-							siteAdminUrl={ jetpackSettings.siteAdminUrl }
 							themeStylesheet={ jetpackSettings.themeStylesheet }
 							postType="wp_template_part"
 							templateId="jetpack-subscribe-floating-button"
@@ -158,7 +150,6 @@ export function SubscriptionsSection( {
 							data={ formData }
 							field={ field }
 							onChange={ fieldOnChange }
-							siteAdminUrl={ jetpackSettings.siteAdminUrl }
 							themeStylesheet={ jetpackSettings.themeStylesheet }
 							postType="wp_template"
 							templateId="index"
@@ -177,7 +168,6 @@ export function SubscriptionsSection( {
 							data={ formData }
 							field={ field }
 							onChange={ fieldOnChange }
-							siteAdminUrl={ jetpackSettings.siteAdminUrl }
 							themeStylesheet={ jetpackSettings.themeStylesheet }
 							postType="wp_template"
 							templateId="index"

--- a/projects/packages/newsletter/src/settings/sections/subscriptions-section.tsx
+++ b/projects/packages/newsletter/src/settings/sections/subscriptions-section.tsx
@@ -11,7 +11,8 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import { ToggleWithEditorLink } from '../components/toggle-with-link';
-import type { NewsletterSettings, CombinedNewsletterSettings } from '../types';
+import { getNewsletterScriptData } from '../script-data';
+import type { NewsletterSettings } from '../types';
 
 interface FieldRenderProps {
 	data: NewsletterSettings;
@@ -21,7 +22,6 @@ interface FieldRenderProps {
 
 interface SubscriptionsSectionProps {
 	data: NewsletterSettings;
-	jetpackSettings: CombinedNewsletterSettings | undefined;
 	onChange: ( updates: Partial< NewsletterSettings > ) => void;
 	onSave: () => void;
 	isSaving: boolean;
@@ -37,7 +37,6 @@ interface SubscriptionsSectionProps {
  */
 export function SubscriptionsSection( {
 	data,
-	jetpackSettings,
 	onChange,
 	onSave,
 	isSaving,
@@ -45,6 +44,7 @@ export function SubscriptionsSection( {
 	isNewsletterEnabled,
 }: SubscriptionsSectionProps ): JSX.Element {
 	const siteType = getSiteType();
+	const newsletterScriptData = getNewsletterScriptData();
 
 	// Translation strings for save button
 	const savingText = __( 'Saving…', 'jetpack-newsletter' );
@@ -61,11 +61,11 @@ export function SubscriptionsSection( {
 
 	// Helper to check if we can show editor links for block theme features
 	const canShowBlockThemeEditorLinks =
-		jetpackSettings?.isBlockTheme && jetpackSettings?.themeStylesheet;
+		newsletterScriptData?.isBlockTheme && newsletterScriptData?.themeStylesheet;
 
 	// Helper to check if we can show editor links for subscription site edit features
 	const canShowSubscriptionEditorLinks =
-		jetpackSettings?.isSubscriptionSiteEditSupported && jetpackSettings?.themeStylesheet;
+		newsletterScriptData?.isSubscriptionSiteEditSupported && newsletterScriptData?.themeStylesheet;
 
 	const fields: Field< NewsletterSettings >[] = [
 		{
@@ -78,7 +78,7 @@ export function SubscriptionsSection( {
 							data={ formData }
 							field={ field }
 							onChange={ fieldOnChange }
-							themeStylesheet={ jetpackSettings.themeStylesheet }
+							themeStylesheet={ newsletterScriptData.themeStylesheet }
 							postType="wp_template"
 							templateId="single"
 							siteType={ siteType }
@@ -96,7 +96,7 @@ export function SubscriptionsSection( {
 							data={ formData }
 							field={ field }
 							onChange={ fieldOnChange }
-							themeStylesheet={ jetpackSettings.themeStylesheet }
+							themeStylesheet={ newsletterScriptData.themeStylesheet }
 							postType="wp_template_part"
 							templateId="jetpack-subscribe-modal"
 							siteType={ siteType }
@@ -114,7 +114,7 @@ export function SubscriptionsSection( {
 							data={ formData }
 							field={ field }
 							onChange={ fieldOnChange }
-							themeStylesheet={ jetpackSettings.themeStylesheet }
+							themeStylesheet={ newsletterScriptData.themeStylesheet }
 							postType="wp_template_part"
 							templateId="jetpack-subscribe-overlay"
 							siteType={ siteType }
@@ -132,7 +132,7 @@ export function SubscriptionsSection( {
 							data={ formData }
 							field={ field }
 							onChange={ fieldOnChange }
-							themeStylesheet={ jetpackSettings.themeStylesheet }
+							themeStylesheet={ newsletterScriptData.themeStylesheet }
 							postType="wp_template_part"
 							templateId="jetpack-subscribe-floating-button"
 							siteType={ siteType }
@@ -150,7 +150,7 @@ export function SubscriptionsSection( {
 							data={ formData }
 							field={ field }
 							onChange={ fieldOnChange }
-							themeStylesheet={ jetpackSettings.themeStylesheet }
+							themeStylesheet={ newsletterScriptData.themeStylesheet }
 							postType="wp_template"
 							templateId="index"
 							siteType={ siteType }
@@ -168,7 +168,7 @@ export function SubscriptionsSection( {
 							data={ formData }
 							field={ field }
 							onChange={ fieldOnChange }
-							themeStylesheet={ jetpackSettings.themeStylesheet }
+							themeStylesheet={ newsletterScriptData.themeStylesheet }
 							postType="wp_template"
 							templateId="index"
 							siteType={ siteType }

--- a/projects/packages/newsletter/src/settings/sections/subscriptions-section.tsx
+++ b/projects/packages/newsletter/src/settings/sections/subscriptions-section.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import analytics from '@automattic/jetpack-analytics';
+import { getSiteType } from '@automattic/jetpack-script-data';
 import { Button } from '@wordpress/components';
 import { DataForm, type Field } from '@wordpress/dataviews/wp';
 import { useCallback } from '@wordpress/element';
@@ -10,7 +11,6 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import { ToggleWithEditorLink } from '../components/toggle-with-link';
-import { getSiteType } from '../utils';
 import type { NewsletterSettings, CombinedNewsletterSettings } from '../types';
 
 interface FieldRenderProps {

--- a/projects/packages/newsletter/src/settings/sections/subscriptions-section.tsx
+++ b/projects/packages/newsletter/src/settings/sections/subscriptions-section.tsx
@@ -44,7 +44,7 @@ export function SubscriptionsSection( {
 	hasChanges,
 	isNewsletterEnabled,
 }: SubscriptionsSectionProps ): JSX.Element {
-	const siteType = getSiteType( jetpackSettings );
+	const siteType = getSiteType();
 
 	// Translation strings for save button
 	const savingText = __( 'Saving…', 'jetpack-newsletter' );

--- a/projects/packages/newsletter/src/settings/sections/welcome-email-section.tsx
+++ b/projects/packages/newsletter/src/settings/sections/welcome-email-section.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import analytics from '@automattic/jetpack-analytics';
+import { getSiteType } from '@automattic/jetpack-script-data';
 import { Button } from '@wordpress/components';
 import { DataForm, type Field } from '@wordpress/dataviews/wp';
 import { useCallback, useMemo } from '@wordpress/element';
@@ -9,7 +10,6 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { getSiteType } from '../utils';
 import type { NewsletterSettings } from '../types';
 
 interface WelcomeEmailSectionProps {

--- a/projects/packages/newsletter/src/settings/sections/welcome-email-section.tsx
+++ b/projects/packages/newsletter/src/settings/sections/welcome-email-section.tsx
@@ -10,7 +10,7 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import { getSiteType } from '../utils';
-import type { NewsletterSettings, CombinedNewsletterSettings } from '../types';
+import type { NewsletterSettings } from '../types';
 
 interface WelcomeEmailSectionProps {
 	data: NewsletterSettings;
@@ -19,7 +19,6 @@ interface WelcomeEmailSectionProps {
 	isSaving: boolean;
 	hasChanges: boolean;
 	isNewsletterEnabled: boolean;
-	jetpackSettings?: CombinedNewsletterSettings;
 }
 
 // Flattened data structure for DataForm
@@ -42,9 +41,8 @@ export function WelcomeEmailSection( {
 	isSaving,
 	hasChanges,
 	isNewsletterEnabled,
-	jetpackSettings,
 }: WelcomeEmailSectionProps ): JSX.Element {
-	const siteType = getSiteType( jetpackSettings );
+	const siteType = getSiteType();
 
 	// Flatten data for DataForm
 	const formData: WelcomeEmailFormData = useMemo(

--- a/projects/packages/newsletter/src/settings/sections/welcome-email-section.tsx
+++ b/projects/packages/newsletter/src/settings/sections/welcome-email-section.tsx
@@ -10,7 +10,7 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import { getSiteType } from '../utils';
-import type { NewsletterSettings, JetpackNewsletterSettings } from '../types';
+import type { NewsletterSettings, CombinedNewsletterSettings } from '../types';
 
 interface WelcomeEmailSectionProps {
 	data: NewsletterSettings;
@@ -19,7 +19,7 @@ interface WelcomeEmailSectionProps {
 	isSaving: boolean;
 	hasChanges: boolean;
 	isNewsletterEnabled: boolean;
-	jetpackSettings?: JetpackNewsletterSettings;
+	jetpackSettings?: CombinedNewsletterSettings;
 }
 
 // Flattened data structure for DataForm

--- a/projects/packages/newsletter/src/settings/types.ts
+++ b/projects/packages/newsletter/src/settings/types.ts
@@ -2,8 +2,10 @@
  * Type definitions for newsletter settings
  */
 
+import type { JetpackScriptData } from '@automattic/jetpack-script-data';
+
 /**
- * Type definitions for newsletter settings data
+ * Type definitions for newsletter settings data from the API
  */
 export interface NewsletterSettings {
 	subscriptions: boolean;
@@ -34,32 +36,46 @@ export interface NewsletterSettings {
 }
 
 /**
- * Type definitions for Jetpack Newsletter settings passed from PHP
+ * Newsletter-specific data added to JetpackScriptData via the jetpack_admin_js_script_data filter.
+ * Note: Common data like admin_url, rest_nonce, title, is_wpcom_platform, and
+ * user.current_user.display_name are provided by Script_Data defaults.
  */
-export interface JetpackNewsletterSettings {
+export interface NewsletterScriptData {
 	isBlockTheme: boolean;
-	siteAdminUrl: string;
 	themeStylesheet: string;
-	blogID: number;
 	email: string;
 	gravatar: string;
-	displayName: string;
 	dateExample: string;
 	subscriberManagementUrl: string;
 	isSubscriptionSiteEditSupported: boolean;
 	setupPaymentPlansUrl: string;
 	isSitePublic: boolean;
-	isWpcomPlatform: boolean;
-	isWpcomSimple: boolean;
-	restApiRoot: string;
-	restApiNonce: string;
-	siteName: string;
 	tracksUserData?:
 		| {
 				userid: number;
 				username: string;
 		  }
 		| false;
+}
+
+/**
+ * Extended JetpackScriptData with newsletter-specific data.
+ */
+export interface NewsletterJetpackScriptData extends JetpackScriptData {
+	newsletter: NewsletterScriptData;
+}
+
+/**
+ * Combined settings interface used by section components.
+ * Combines newsletter-specific data with site/user data fields needed by components.
+ */
+export interface CombinedNewsletterSettings extends NewsletterScriptData {
+	// From JetpackScriptData.site
+	siteName: string;
+	blogID: number;
+	isWpcomPlatform: boolean;
+	// From JetpackScriptData.user.current_user
+	displayName: string;
 }
 
 /**

--- a/projects/packages/newsletter/src/settings/types.ts
+++ b/projects/packages/newsletter/src/settings/types.ts
@@ -2,8 +2,6 @@
  * Type definitions for newsletter settings
  */
 
-import type { JetpackScriptData } from '@automattic/jetpack-script-data';
-
 /**
  * Type definitions for newsletter settings data from the API
  */
@@ -37,7 +35,7 @@ export interface NewsletterSettings {
 
 /**
  * Newsletter-specific data added to JetpackScriptData via the jetpack_admin_js_script_data filter.
- * Note: Common data like admin_url, rest_nonce, title, is_wpcom_platform, and
+ * Common data like admin_url, rest_nonce, title, is_wpcom_platform, and
  * user.current_user.display_name are provided by Script_Data defaults.
  */
 export interface NewsletterScriptData {
@@ -56,24 +54,6 @@ export interface NewsletterScriptData {
 				username: string;
 		  }
 		| false;
-}
-
-/**
- * Extended JetpackScriptData with newsletter-specific data.
- */
-export interface NewsletterJetpackScriptData extends JetpackScriptData {
-	newsletter: NewsletterScriptData;
-}
-
-/**
- * Combined settings interface used by section components.
- * Combines newsletter-specific data with site/user data fields needed by components.
- */
-export interface CombinedNewsletterSettings extends NewsletterScriptData {
-	// From JetpackScriptData.site
-	siteName: string;
-	// From JetpackScriptData.user.current_user
-	displayName: string;
 }
 
 /**

--- a/projects/packages/newsletter/src/settings/types.ts
+++ b/projects/packages/newsletter/src/settings/types.ts
@@ -72,8 +72,6 @@ export interface NewsletterJetpackScriptData extends JetpackScriptData {
 export interface CombinedNewsletterSettings extends NewsletterScriptData {
 	// From JetpackScriptData.site
 	siteName: string;
-	blogID: number;
-	isWpcomPlatform: boolean;
 	// From JetpackScriptData.user.current_user
 	displayName: string;
 }

--- a/projects/packages/newsletter/src/settings/utils.ts
+++ b/projects/packages/newsletter/src/settings/utils.ts
@@ -1,32 +1,5 @@
 /**
- * Analytics utilities for Newsletter settings
+ * Re-export utilities from `@automattic/jetpack-script-data` for convenience.
  */
-
-import type { JetpackNewsletterSettings } from './types';
-
-/**
- * Site types for analytics tracking
- */
-export type SiteType = 'simple' | 'atomic' | 'jetpack';
-
-/**
- * Get the site type from settings
- *
- * @param {JetpackNewsletterSettings | undefined} settings - Settings from PHP
- * @return {SiteType} The site type
- */
-export function getSiteType( settings: JetpackNewsletterSettings | undefined ): SiteType {
-	if ( ! settings ) {
-		return 'jetpack';
-	}
-
-	if ( settings.isWpcomSimple ) {
-		return 'simple';
-	}
-
-	if ( settings.isWpcomPlatform ) {
-		return 'atomic';
-	}
-
-	return 'jetpack';
-}
+export { getSiteType } from '@automattic/jetpack-script-data';
+export type { SiteType } from '@automattic/jetpack-script-data';

--- a/projects/packages/newsletter/src/settings/utils.ts
+++ b/projects/packages/newsletter/src/settings/utils.ts
@@ -1,5 +1,0 @@
-/**
- * Re-export utilities from `@automattic/jetpack-script-data` for convenience.
- */
-export { getSiteType } from '@automattic/jetpack-script-data';
-export type { SiteType } from '@automattic/jetpack-script-data';


### PR DESCRIPTION
Fixes # DOTCOM-16058

## Proposed changes:
* Consolidate newsletter settings data into `JetpackScriptData.newsletter` instead of a separate `window.jetpackNewsletterSettings` object
* Add `getSiteType()` utility to `@automattic/jetpack-script-data` for categorizing sites as 'simple', 'atomic', or 'jetpack'
* Use `getAdminUrl()` directly in components instead of passing `siteAdminUrl` through props
* Use `isWpcomPlatformSite()` utility instead of accessing raw data properties
* Remove `siteAdminUrl` from `CombinedNewsletterSettings` interface
* API functions now self-initialize using `getSiteData()` instead of requiring settings parameter

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion


## Does this pull request change what data or activity we track or use?
No changes to tracking. 

## Testing instructions:
* Enable the newsletter settings UI filter: `add_filter( 'jetpack_wp_admin_newsletter_settings_enabled', '__return_true' );`
* Go to Jetpack → Newsletter in wp-admin
* Verify the settings page loads correctly
* Test on different site types if possible:
  * Jetpack site: verify settings load and save
  * Atomic site: verify settings load and save
  * Simple site: verify settings load and save
* In the Subscriptions section, verify "Preview and edit" links work correctly (should open site editor)
* In Email byline section, verify "Customize date format" link works (should open General Settings)
* In Newsletter categories section, enable categories and verify "Add New Category" link works

## Changelog

- [x] Generate changelog entries for this PR (using AI).