### PR TITLE
Forms: fix minor dashboard style issues

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-wp-build-search-margin
+++ b/projects/packages/forms/changelog/fix-forms-wp-build-search-margin
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Dashboard: remove bottom margin on search control that caused vertical misalignment in the header row.

--- a/projects/packages/forms/src/dashboard/wp-build/hooks/use-page-header-details.tsx
+++ b/projects/packages/forms/src/dashboard/wp-build/hooks/use-page-header-details.tsx
@@ -311,6 +311,7 @@ export default function usePageHeaderDetails(
 					controls={ dropdownControls }
 					icon={ moreVertical }
 					label={ __( 'More actions', 'jetpack-forms' ) }
+					toggleProps={ { size: 'compact' } }
 				/>,
 				// Include modals when on mobile
 				...( showExportModal
@@ -379,6 +380,7 @@ export default function usePageHeaderDetails(
 								controls={ formItemControls }
 								icon={ moreVertical }
 								label={ __( 'More actions', 'jetpack-forms' ) }
+								toggleProps={ { size: 'compact' } }
 							/>,
 					  ]
 					: [] ),

--- a/projects/packages/forms/src/dashboard/wp-build/style.scss
+++ b/projects/packages/forms/src/dashboard/wp-build/style.scss
@@ -3,12 +3,17 @@
  */
 
 /**
- * Temporary overrides to align styling of core breadcrumbs with Jetpack Forms
+ * Temporary overrides to align styling of core elements with Jetpack Forms
  * designs and Commerce in a Box designs.
  *
- * To remove these overrides, the breadcrumbs component would need to support:
+ * To remove these overrides
+ *
+ * The breadcrumbs component would need to support:
  * - removing bottom margin on breadcrumb list items
  * - applying a color attribute to breadcrumb links
+ *
+ * The search control component would need to support:
+ * - removing bottom margin on the search field
  */
 body.jetpack_page_jetpack-forms-responses-wp-admin,
 body.jetpack-forms-responses {
@@ -24,6 +29,10 @@ body.jetpack-forms-responses {
 			color: var(--wp-components-color-foreground, #1e1e1e);
 			font-weight: 600;
 		}
+	}
+
+	.dataviews-search .components-base-control__field {
+		margin-bottom: 0;
 	}
 }
 


### PR DESCRIPTION
## Proposed changes:

This PR fixes a couple minor style issues in the new forms dashboard. 
* The new 3-dot menu in the single form screen header had some extra height. This caused the whole header to shift downward a few pixels when navigating to that screen. This is fixed by applying a 'compact' prop. 
* The search bar in the DataViews header is not vertically centered. I searched for a core-way to adjust that, but there is not. I'm fixing it via custom CSS for now. It is added to some other CSS that is overriding core, and is very well documented as such. We'll need to separately have a convo about how to fix this within core if possible. 

**Screenshot**

<img width="1338" height="396" alt="dashboard-css-fixes" src="https://github.com/user-attachments/assets/598abb43-80f3-4ba5-9039-398937ae654b" />

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Enable these feature flags: 

```
add_filter( 'jetpack_forms_alpha', '__return_true', 20 );
add_filter( 'jetpack_block_editor_feature_flags', 'eb_register_feature' );
function eb_register_feature( $flags ) {
    $flags['central-form-management'] = true;
    return $flags;
}
```

Test:
* Go to Jetpack > Forms
* Responses tab: confirm that the search box is vertically centered
* Single forms screen: toggle between this and All Forms screen, and confirm title does not shift downward. 

## Changelog
<!-- Check one of the boxes below. -->

Already added changelog file. 

- [ ] Generate changelog entries for this PR (using AI).
