### PR TITLE
Forms: fix infinite loop in Name field block

### DIFF
--- a/projects/packages/forms/changelog/fix-name-field
+++ b/projects/packages/forms/changelog/fix-name-field
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix infinite loop in Name field block when initializing fieldVariant attribute

--- a/projects/packages/forms/src/blocks/field-name/edit.js
+++ b/projects/packages/forms/src/blocks/field-name/edit.js
@@ -19,7 +19,7 @@ export default function NameFieldEdit( props ) {
 
 	// Initialize fieldVariant for backward compatibility with existing Name field blocks.
 	useEffect( () => {
-		if ( fieldVariant !== undefined ) {
+		if ( fieldVariant ) {
 			return;
 		}
 

--- a/projects/packages/forms/src/blocks/field-name/edit.js
+++ b/projects/packages/forms/src/blocks/field-name/edit.js
@@ -6,7 +6,6 @@ import useNameFieldTransforms from './hooks/use-name-field-transforms.js';
 import {
 	isFirstNameVariationId,
 	isLastNameVariationId,
-	isNameVariationId,
 	FIRST_NAME_ID,
 	LAST_NAME_ID,
 	NAME_ID,
@@ -20,20 +19,19 @@ export default function NameFieldEdit( props ) {
 
 	// Initialize fieldVariant for backward compatibility with existing Name field blocks.
 	useEffect( () => {
-		if ( fieldVariant ) {
+		if ( fieldVariant !== undefined ) {
 			return;
 		}
+
+		let variant = NAME_ID;
 		if ( isFirstNameVariationId( id ) ) {
-			setAttributes( { fieldVariant: FIRST_NAME_ID } );
+			variant = FIRST_NAME_ID;
 		} else if ( isLastNameVariationId( id ) ) {
-			setAttributes( { fieldVariant: LAST_NAME_ID } );
-		} else if ( isNameVariationId( id ) ) {
-			setAttributes( { fieldVariant: NAME_ID } );
-		} else {
-			// Default to base 'name' variant for any other case (empty id or 'name' id)
-			setAttributes( { fieldVariant: '' } );
+			variant = LAST_NAME_ID;
 		}
-	}, [ clientId, fieldVariant, id, setAttributes ] );
+
+		setAttributes( { fieldVariant: variant } );
+	}, [ fieldVariant, id, setAttributes ] );
 
 	// Update HTML IDs and labels when transforming between variations.
 	useNameFieldTransforms( { clientId, fieldVariant } );


### PR DESCRIPTION
Fixes an js error that can be sometimes encounted when adding the name field. 

```
 Warning: Maximum update depth exceeded. This can happen when a component calls setState inside useEffect, but useEffect either
  doesn't have a dependency array, or one of the dependencies changes on every render. Component Stack:
  NameFieldEdit edit.js:16
  Edit block-editor.js:33820
  addGridVisualizerToBlockEdit block-editor.js:46981
  withBlockEditHooks block-editor.js:15508
  withPatternOverrideControls editor.js:12374
  withNavigationViewButton editor.js:12458
  withTemplatePartNavigationEditButton editor.js:12541
  ....
  ```

## Proposed changes:
* Fix infinite loop in NameFieldEdit component caused by useEffect setting a falsy `fieldVariant` value
* The bug occurred because `if (fieldVariant)` treated empty strings as falsy, but the default case set `fieldVariant: ''`, causing the effect to re-run infinitely
* Changed condition to `fieldVariant !== undefined` to properly handle empty string values
* Simplified the conditional logic and removed redundant `isNameVariationId` check
* Removed unused `clientId` from effect dependency array

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

* Create a new post with a Contact Form block
* Add a Name field to the form
* Verify no console errors appear (previously would show "Maximum update depth exceeded")
* Verify the Name field renders correctly and is functional
* Save the post and reload to verify the field persists correctly

## Changelog

- [x] Generate changelog entries for this PR (using AI).