### PR TITLE
Stats: Skip scheduling transient cleanup cron on sites with object cache

### DIFF
--- a/projects/packages/stats/changelog/update-stats-skip-cron-scheduling
+++ b/projects/packages/stats/changelog/update-stats-skip-cron-scheduling
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Transient cleanup: Skip scheduling cron job entirely on sites with persistent object cache

--- a/projects/packages/stats/src/class-transient-cleanup.php
+++ b/projects/packages/stats/src/class-transient-cleanup.php
@@ -79,9 +79,21 @@ class Transient_Cleanup {
 	/**
 	 * Schedule the cleanup cron job.
 	 *
+	 * Skips scheduling on sites with persistent object cache since transients
+	 * auto-expire there and cleanup is unnecessary.
+	 *
 	 * @return void
 	 */
 	public static function schedule_cleanup() {
+		// Skip scheduling on sites with persistent object cache - not needed there.
+		if ( wp_using_ext_object_cache() ) {
+			// Unschedule if it was previously scheduled (e.g., object cache was added later).
+			if ( wp_next_scheduled( self::CRON_HOOK ) ) {
+				wp_clear_scheduled_hook( self::CRON_HOOK );
+			}
+			return;
+		}
+
 		if ( ! wp_next_scheduled( self::CRON_HOOK ) ) {
 			wp_schedule_event( time() + self::CRON_INTERVAL, 'jetpack_stats_eight_hours', self::CRON_HOOK );
 		}

--- a/projects/packages/stats/tests/php/Transient_Cleanup_Test.php
+++ b/projects/packages/stats/tests/php/Transient_Cleanup_Test.php
@@ -198,6 +198,53 @@ class Transient_Cleanup_Test extends StatsBaseTestCase {
 	}
 
 	/**
+	 * Test that schedule_cleanup does not schedule when using external object cache.
+	 */
+	public function test_schedule_cleanup_skipped_with_external_object_cache() {
+		global $_wp_using_ext_object_cache;
+
+		Transient_Cleanup::init();
+
+		// Enable external object cache.
+		$original                   = $_wp_using_ext_object_cache;
+		$_wp_using_ext_object_cache = true;
+
+		Transient_Cleanup::schedule_cleanup();
+
+		// Restore original value.
+		$_wp_using_ext_object_cache = $original;
+
+		$this->assertFalse( wp_next_scheduled( Transient_Cleanup::CRON_HOOK ) );
+	}
+
+	/**
+	 * Test that schedule_cleanup unschedules existing cron when object cache is enabled later.
+	 */
+	public function test_schedule_cleanup_unschedules_when_object_cache_added() {
+		global $_wp_using_ext_object_cache;
+
+		Transient_Cleanup::init();
+
+		// First, schedule without object cache.
+		$original                   = $_wp_using_ext_object_cache;
+		$_wp_using_ext_object_cache = false;
+		Transient_Cleanup::schedule_cleanup();
+
+		// Verify it was scheduled.
+		$this->assertNotFalse( wp_next_scheduled( Transient_Cleanup::CRON_HOOK ) );
+
+		// Now enable object cache and call schedule_cleanup again.
+		$_wp_using_ext_object_cache = true;
+		Transient_Cleanup::schedule_cleanup();
+
+		// Restore original value.
+		$_wp_using_ext_object_cache = $original;
+
+		// The cron should be unscheduled.
+		$this->assertFalse( wp_next_scheduled( Transient_Cleanup::CRON_HOOK ) );
+	}
+
+	/**
 	 * Note: Tests for actual transient deletion (purge_expired_transients) are not included
 	 * because they require direct SQL queries which WorDBless doesn't support.
 	 * These behaviors should be tested via integration tests on a real WordPress installation:


### PR DESCRIPTION
Follow-up to #47212

## Proposed changes:

* Skip scheduling the transient cleanup cron job entirely on sites with persistent object cache (e.g., Simple sites on WPCOM infrastructure)
* If a site gains object cache after the cron was already scheduled, unschedule it on next `admin_init`
* Adds two unit tests for the new scheduling behavior

This avoids unnecessary cron entries in the database and eliminates wasted execution cycles on Simple sites where transients auto-expire anyway.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

https://linear.app/a8c/issue/JETPACK-1268

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

### Unit tests
* Run `cd projects/packages/stats && composer test-php -- --filter=Transient_Cleanup`
* Verify all tests pass, including the two new tests:
  - `test_schedule_cleanup_skipped_with_external_object_cache`
  - `test_schedule_cleanup_unschedules_when_object_cache_added`

### Manual testing on a site WITH persistent object cache
* Set up a site with Redis or Memcached
* Activate Jetpack with Stats module enabled
* Check cron list: `wp cron event list | grep jetpack_stats_transient_cleanup`
* The cron should NOT be scheduled

### Test object cache transition
* Start with a site WITHOUT object cache
* Verify the cron is scheduled: `wp cron event list | grep jetpack_stats_transient_cleanup`
* Enable object cache (e.g., install Redis)
* Visit any admin page (triggers `admin_init`)
* Verify the cron is now unscheduled: `wp cron event list | grep jetpack_stats_transient_cleanup` (should return nothing)

## Changelog

- [x] Generate changelog entries for this PR (using AI).