### PR TITLE
Forms: fix border appearing in latest gutenberg

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-border-gb-22-6
+++ b/projects/packages/forms/changelog/fix-forms-border-gb-22-6
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: Fix unwanted border appearing in Gutenberg 22.6.0.

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -1,5 +1,10 @@
 @use "@automattic/jetpack-base-styles/gutenberg-base-styles" as gb;
 
+
+:where(.jetpack-contact-form) {
+	border-width: 0;
+}
+
 :where(.is-classic-layout) .jetpack-contact-form,
 .jetpack-contact-form.has-no-jetpack-form-layout {
 	display: flex;

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -1,6 +1,5 @@
 @use "@automattic/jetpack-base-styles/gutenberg-base-styles" as gb;
 
-
 :where(.jetpack-contact-form) {
 	border-width: 0;
 }

--- a/projects/packages/forms/src/contact-form/css/grunion.scss
+++ b/projects/packages/forms/src/contact-form/css/grunion.scss
@@ -605,6 +605,10 @@
 	max-width: inherit;
 }
 
+:where(.jetpack-contact-form-container) {
+	border-width: 0;
+}
+
 /* Added circa Nov 2022: container class assigned to topmost block div */
 .jetpack-contact-form-container.alignfull .wp-block-jetpack-contact-form {
 	padding-inline: 0;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Loosely related to adding border support in https://github.com/Automattic/jetpack/pull/47274

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Latest Gutenberg trunk (or 22.6.0 RC1) has changes that brought up a border in Form block:

This ensures the border won't appear, but `:where()` still ensures we don't step in themer's shoes who might've done some custom CSS to introduce borders.

Before
<img width="846" height="608" alt="image" src="https://github.com/user-attachments/assets/9adf4e78-376f-4057-8767-08d51894a3f0" />



### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* With latest Gutenberg `trunk`, see how there's border in editor and frontend of the site
* With PR the borders are gone

## Changelog
<!-- Check one of the boxes below. -->

- [ ] Generate changelog entries for this PR (using AI).
