### PR TITLE
Add agents_manager_enabled_in_block_editor filter to is_enabled()

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-unified-big-sky-proxy-check
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-unified-big-sky-proxy-check
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Agents Manager: Replace unified-big-sky query string flag with is_dev_mode() check to enable unified experience automatically in dev environments.

--- a/projects/packages/jetpack-mu-wpcom/changelog/update-unified-big-sky-proxy-check
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-unified-big-sky-proxy-check
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Agents Manager: Replace unified-big-sky query string flag with a new agents_manager_use_unified_big_sky filter, hooked by Big Sky, to enable Agents Manager on Big Sky surfaces.
+Agents Manager: Replace unified-big-sky query string flag with a new agents_manager_enabled_in_block_editor filter, hooked by Big Sky, to enable Agents Manager in the block editor.

--- a/projects/packages/jetpack-mu-wpcom/changelog/update-unified-big-sky-proxy-check
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-unified-big-sky-proxy-check
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Agents Manager: Replace unified-big-sky query string flag with is_dev_mode() check to enable unified experience automatically in dev environments.
+Agents Manager: Replace unified-big-sky query string flag with a new agents_manager_use_unified_big_sky filter, hooked by Big Sky, to enable Agents Manager on Big Sky surfaces.

--- a/projects/packages/jetpack-mu-wpcom/src/features/agents-manager/class-agents-manager.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/agents-manager/class-agents-manager.php
@@ -308,21 +308,13 @@ class Agents_Manager {
 	/**
 	 * Returns true if the Agents Manager should be loaded in the current context.
 	 *
-	 * True when the unified experience filter is enabled, or when Big Sky is present
-	 * in the block editor and the current environment is a dev environment.
+	 * Enabled when the unified experience filter returns true. Big Sky hooks this
+	 * filter in dev environments; the Agents Manager hooks it for opted-in users.
 	 *
 	 * @return bool
 	 */
 	private function is_enabled() {
-		if ( apply_filters( 'agents_manager_use_unified_experience', false ) ) {
-			return true;
-		}
-
-		if ( $this->is_block_editor() && class_exists( 'Big_Sky' ) && $this->should_use_unified_big_sky() ) {
-			return true;
-		}
-
-		return false;
+		return (bool) apply_filters( 'agents_manager_use_unified_experience', false );
 	}
 
 	/**
@@ -750,17 +742,6 @@ class Agents_Manager {
 		}
 
 		return false;
-	}
-
-	/**
-	 * Determine if the unified Agents Manager experience should replace Big Sky.
-	 *
-	 * Currently enabled in all dev environments (local, proxied, sandbox).
-	 *
-	 * @return bool
-	 */
-	private function should_use_unified_big_sky() {
-		return self::is_dev_mode();
 	}
 
 	/**

--- a/projects/packages/jetpack-mu-wpcom/src/features/agents-manager/class-agents-manager.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/agents-manager/class-agents-manager.php
@@ -308,8 +308,8 @@ class Agents_Manager {
 	/**
 	 * Returns true if the Agents Manager should be loaded in the current context.
 	 *
-	 * True when the unified experience filter is enabled, or when the block editor
-	 * has the unified Big Sky flag active.
+	 * True when the unified experience filter is enabled, or when Big Sky is present
+	 * in the block editor and the current environment is a dev environment.
 	 *
 	 * @return bool
 	 */

--- a/projects/packages/jetpack-mu-wpcom/src/features/agents-manager/class-agents-manager.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/agents-manager/class-agents-manager.php
@@ -756,16 +756,7 @@ class Agents_Manager {
 	 * Determine if the user should use unified experience for Big Sky.
 	 */
 	private function has_unified_big_sky_flag() {
-		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- This is a feature flag check, not a form submission.
-		if ( isset( $_GET['flags'] ) ) {
-			// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- This is a feature flag check, not a form submission.
-			$flags = explode( ',', sanitize_text_field( wp_unslash( $_GET['flags'] ) ) );
-			if ( in_array( 'unified-big-sky', $flags, true ) ) {
-				return true;
-			}
-		}
-
-		return false;
+		return self::is_proxied();
 	}
 
 	/**

--- a/projects/packages/jetpack-mu-wpcom/src/features/agents-manager/class-agents-manager.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/agents-manager/class-agents-manager.php
@@ -318,7 +318,7 @@ class Agents_Manager {
 			return true;
 		}
 
-		if ( $this->is_block_editor() && class_exists( 'Big_Sky' ) && $this->has_unified_big_sky_flag() ) {
+		if ( $this->is_block_editor() && class_exists( 'Big_Sky' ) && $this->should_use_unified_big_sky() ) {
 			return true;
 		}
 
@@ -753,9 +753,13 @@ class Agents_Manager {
 	}
 
 	/**
-	 * Determine if the user should use unified experience for Big Sky.
+	 * Determine if the unified Agents Manager experience should replace Big Sky.
+	 *
+	 * Currently enabled in all dev environments (local, proxied, sandbox).
+	 *
+	 * @return bool
 	 */
-	private function has_unified_big_sky_flag() {
+	private function should_use_unified_big_sky() {
 		return self::is_dev_mode();
 	}
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/agents-manager/class-agents-manager.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/agents-manager/class-agents-manager.php
@@ -756,7 +756,7 @@ class Agents_Manager {
 	 * Determine if the user should use unified experience for Big Sky.
 	 */
 	private function has_unified_big_sky_flag() {
-		return self::is_proxied();
+		return self::is_dev_mode();
 	}
 
 	/**

--- a/projects/packages/jetpack-mu-wpcom/src/features/agents-manager/class-agents-manager.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/agents-manager/class-agents-manager.php
@@ -317,7 +317,7 @@ class Agents_Manager {
 		}
 
 		// Unified Big Sky only: Agents Manager replaces Big Sky's native UI on its surfaces
-		// (block editor, wp-admin, CIAB). Hooked by Big Sky in dev environments.
+		// (block editor, wp-admin, CIAB). Hooked by Big Sky.
 		if ( apply_filters( 'agents_manager_use_unified_big_sky', false ) ) {
 			return true;
 		}

--- a/projects/packages/jetpack-mu-wpcom/src/features/agents-manager/class-agents-manager.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/agents-manager/class-agents-manager.php
@@ -316,9 +316,8 @@ class Agents_Manager {
 			return true;
 		}
 
-		// Unified Big Sky only: Agents Manager replaces Big Sky's native UI on its surfaces
-		// (block editor, wp-admin, CIAB). Hooked by Big Sky.
-		if ( apply_filters( 'agents_manager_use_unified_big_sky', false ) ) {
+		// Block editor only: Agents Manager replaces Big Sky's native UI. Hooked by Big Sky.
+		if ( $this->is_block_editor() && apply_filters( 'agents_manager_enabled_in_block_editor', false ) ) {
 			return true;
 		}
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/agents-manager/class-agents-manager.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/agents-manager/class-agents-manager.php
@@ -308,13 +308,22 @@ class Agents_Manager {
 	/**
 	 * Returns true if the Agents Manager should be loaded in the current context.
 	 *
-	 * Enabled when the unified experience filter returns true. Big Sky hooks this
-	 * filter in dev environments; the Agents Manager hooks it for opted-in users.
+	 * True when either the general unified experience filter is enabled (for
+	 * opted-in users) or the unified Big Sky filter is enabled (hooked by
+	 * Big Sky in dev environments).
 	 *
 	 * @return bool
 	 */
 	private function is_enabled() {
-		return (bool) apply_filters( 'agents_manager_use_unified_experience', false );
+		if ( apply_filters( 'agents_manager_use_unified_experience', false ) ) {
+			return true;
+		}
+
+		if ( apply_filters( 'agents_manager_use_unified_big_sky', false ) ) {
+			return true;
+		}
+
+		return false;
 	}
 
 	/**

--- a/projects/packages/jetpack-mu-wpcom/src/features/agents-manager/class-agents-manager.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/agents-manager/class-agents-manager.php
@@ -308,17 +308,16 @@ class Agents_Manager {
 	/**
 	 * Returns true if the Agents Manager should be loaded in the current context.
 	 *
-	 * True when either the general unified experience filter is enabled (for
-	 * opted-in users) or the unified Big Sky filter is enabled (hooked by
-	 * Big Sky in dev environments).
-	 *
 	 * @return bool
 	 */
 	private function is_enabled() {
+		// Full unified experience: Agents Manager with support guides, Help Center takeover, etc.
 		if ( apply_filters( 'agents_manager_use_unified_experience', false ) ) {
 			return true;
 		}
 
+		// Unified Big Sky only: Agents Manager replaces Big Sky's native UI on its surfaces
+		// (block editor, wp-admin, CIAB). Hooked by Big Sky in dev environments.
 		if ( apply_filters( 'agents_manager_use_unified_big_sky', false ) ) {
 			return true;
 		}


### PR DESCRIPTION
## Summary

- Removes the `?flags=unified-big-sky` query string check (`has_unified_big_sky_flag()`) entirely — Jetpack no longer has any awareness of the query string flag
- Adds support for a new `agents_manager_enabled_in_block_editor` filter in `is_enabled()`, gated by `is_block_editor()`, which enables Agents Manager in the block editor. Hooked by Big Sky.
- This is separate from `agents_manager_use_unified_experience`, which enables the **full** unified experience including support guides and Help Center takeover
- Agents Manager loads when **either** filter is active (with the block editor filter additionally requiring a block editor context)

## Testing instructions

- See paired Big Sky plugin PR for testing instructions.

## Does this pull request change what data or activity we track or use?

No. This only changes the gating mechanism for an existing feature from an inline query string check to a WordPress filter.