### PR TITLE
Fix misleading WordPress.com importer banner copy

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-dotcon-161-misleading-import-banner
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-dotcon-161-misleading-import-banner
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Update misleading WordPress.com importer banner copy on WP-Admin Tools > Import page

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-imports/wpcom-importer-entry.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-imports/wpcom-importer-entry.js
@@ -25,7 +25,7 @@ function wpcomImporterEntry( width ) {
 		'<td class="desc">' +
 		'<span class="importer-desc">' +
 		wp.i18n.__(
-			'Effortless WordPress migrations, plus content imports from platforms like Medium and Squarespace - no plugins or technical setup required.',
+			'Move any WordPress site, including all content, themes, plugins, and users to WordPress.com.',
 			'jetpack-mu-wpcom'
 		) +
 		'</span>' +

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-imports/wpcom-imports.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-imports/wpcom-imports.php
@@ -136,7 +136,7 @@ function wpcom_imports_enqueue_script() {
 		'wpcom-importer-entry',
 		plugins_url( 'wpcom-importer-entry.js', __FILE__ ),
 		array( 'wp-i18n', 'wp-dom-ready' ),
-		'1.0.0',
+		'1.0.1',
 		true
 	);
 


### PR DESCRIPTION
Fixes DOTCON-161

## Proposed changes:
* Update the WordPress.com importer banner description on WP-Admin Tools > Import page
* Replace inaccurate copy ("no plugins or technical setup required") with clearer text: "Move any WordPress site, including all content, themes, plugins, and users to WordPress.com."
* Removes mention of Medium and Squarespace from the banner, since they already have dedicated importer entries in the list below

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:

* Go to a WoW site
* Navigate to Tools > Import (`/wp-admin/import.php`)
* Verify the WordPress.com banner at the top now reads: "Move any WordPress site, including all content, themes, plugins, and users to WordPress.com."
* Verify Medium, Squarespace, Wix, Substack, and other importers still appear as individual entries in the list below
* Also test on a Simple site