### PR TITLE
Forms: prevent decorative icons from being included in email copy/paste

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-email-icon-user-select
+++ b/projects/packages/forms/changelog/fix-forms-email-icon-user-select
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Prevent decorative icons from being included when copy/pasting form response emails.

--- a/projects/packages/forms/src/contact-form/class-feedback-email-renderer.php
+++ b/projects/packages/forms/src/contact-form/class-feedback-email-renderer.php
@@ -428,9 +428,9 @@ class Feedback_Email_Renderer {
 		// Build the field row as a table with icon + content.
 		$html  = '<table role="presentation" border="0" cellpadding="0" cellspacing="0" width="100%" style="border-bottom: 1px solid #F0F0F0; padding: 0; margin: 0;">';
 		$html .= '<tr>';
-		$html .= '<td width="24" valign="top" style="padding: 18px 16px 20px 0; width: 24px; vertical-align: top;">';
+		$html .= '<td width="24" valign="top" style="padding: 18px 16px 20px 0; width: 24px; vertical-align: top; -webkit-user-select: none; user-select: none;">';
 		$html .= sprintf(
-			'<img src="%s" width="24" height="24" alt="" style="display: block; width: 24px; height: 24px;" />',
+			'<img src="%s" width="24" height="24" alt="" style="display: block; width: 24px; height: 24px; -webkit-user-select: none; user-select: none;" />',
 			esc_url( $icon_url )
 		);
 		$html .= '</td>';
@@ -581,7 +581,7 @@ class Feedback_Email_Renderer {
 				<table role="presentation" border="0" cellpadding="0" cellspacing="0" width="100%" class="powered-by-table" style="border-collapse: collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; margin-top: 24px;">
 					<tr>
 						<td align="center" class="powered-by" style="padding: 24px 0 0 0; font-family: -apple-system, BlinkMacSystemFont, \'Segoe UI\', Roboto, Oxygen-Sans, Ubuntu, Cantarell, \'Helvetica Neue\', sans-serif;">
-							<img src="' . esc_url( $logo_url ) . '" alt="Jetpack" width="20" height="20" style="vertical-align: middle; margin-right: 6px; border: 0; outline: none; text-decoration: none;">
+							<img src="' . esc_url( $logo_url ) . '" alt="Jetpack" width="20" height="20" style="vertical-align: middle; margin-right: 6px; border: 0; outline: none; text-decoration: none; -webkit-user-select: none; user-select: none;">
 							<span style="font-size: ' . self::FONT_SIZE_METADATA . '; color: #50575e; line-height: 20px;">' .
 					sprintf(
 						// translators: %1$s is a link to the Jetpack Forms page.

--- a/projects/packages/forms/src/contact-form/class-feedback-field.php
+++ b/projects/packages/forms/src/contact-form/class-feedback-field.php
@@ -682,7 +682,7 @@ class Feedback_Field {
 		if ( ! empty( $file_url ) ) {
 			$download_icon_url = Jetpack_Forms::plugin_url() . 'contact-form/images/file-icons/download@2x.png';
 			$download_icon     = sprintf(
-				'<a href="%1$s" target="_blank" style="text-decoration: none;"><img src="%2$s" width="20" height="20" alt="%3$s" style="display: block; width: 20px; height: 20px;" /></a>',
+				'<a href="%1$s" target="_blank" style="text-decoration: none;"><img src="%2$s" width="20" height="20" alt="%3$s" style="display: block; width: 20px; height: 20px; -webkit-user-select: none; user-select: none;" /></a>',
 				esc_url( $file_url ),
 				esc_url( $download_icon_url ),
 				esc_attr__( 'Download', 'jetpack-forms' )
@@ -734,7 +734,7 @@ class Feedback_Field {
 
 		return sprintf(
 			'<img src="%1$s" width="24" height="24" alt=""
-				style="padding: 8px; border-radius: 50%%; width: 24px; height: 24px; background-color: #f0f0f0;" />',
+				style="padding: 8px; border-radius: 50%%; width: 24px; height: 24px; background-color: #f0f0f0; -webkit-user-select: none; user-select: none;" />',
 			esc_url( $icon_url )
 		);
 	}


### PR DESCRIPTION
Fixes FORMS-598

## Proposed changes:
* Add `user-select: none` and `-webkit-user-select: none` to decorative icon `<img>` tags in form response emails, preventing them from being included when users copy/paste email content.
* Applied to: field type icons, file thumbnail icons, download icons, and the Jetpack logo.
* Also applied to the `<td>` wrapping field type icons for broader email client coverage.
* User content images (e.g., image-select thumbnails) are left selectable.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
* Set up a site with the Jetpack Forms plugin active.
* Create a page with a Jetpack Form that includes several field types (text, email, textarea, select, etc.).
* Submit the form so a response email is sent.
* Open the response email and try to select/copy the form content.
* **Before**: Copying would include icon image artifacts and extra spacing from the decorative icons.
* **After**: Icons are excluded from the selection — only the field labels and values are copied.

## Changelog
Changelog entry added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)