### PR TITLE
Jetpack Sync: Listener - use request cache to avoid repeated get_transient calls

### DIFF
--- a/projects/packages/sync/changelog/pr-47282
+++ b/projects/packages/sync/changelog/pr-47282
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Listener: Add per-request in-memory cache to avoid repeated get_transient calls when checking queue state.

--- a/projects/packages/sync/src/class-listener.php
+++ b/projects/packages/sync/src/class-listener.php
@@ -52,7 +52,7 @@ class Listener {
 	 * Avoids repeated get_transient() calls for every
 	 * can_add_to_queue check within a single request.
 	 *
-	 * @var array<string, array<int, float>>
+	 * @var array<string, array{int, float}>
 	 */
 	private $request_queue_state_cache = array();
 
@@ -189,7 +189,7 @@ class Listener {
 		if ( isset( $this->request_queue_state_cache[ $queue->id ] ) ) {
 			list( $queue_size, $queue_age ) = $this->request_queue_state_cache[ $queue->id ];
 			return ( $queue_age < $this->sync_queue_lag_limit )
-				|| ( ( $queue_size + 1 ) < $this->sync_queue_size_limit );
+				|| ( ( $queue_size + ( $this->request_adds_count[ $queue->id ] ?? 0 ) + 1 ) < $this->sync_queue_size_limit );
 		}
 
 		$state_transient_name = self::QUEUE_STATE_CHECK_TRANSIENT . '_' . $queue->id;

--- a/projects/packages/sync/src/class-listener.php
+++ b/projects/packages/sync/src/class-listener.php
@@ -184,10 +184,9 @@ class Listener {
 			return false;
 		}
 
-		// Per-request in-memory cache: avoids a get_transient() call on every enqueue within
-		// the same request. On sites without an object cache, each get_transient() is a DB read,
-		// so a request that enqueues many actions would otherwise generate one DB read per action
-		// just for this check.
+		// Per-request in-memory cache: avoids a get_transient() call on every enqueue within the same request.
+		// On sites with an external object cache, each get_transient() is a network rount-trip, so a request that
+		// enqueues many actions would otherwise make one network call per action just for this check.
 		if ( isset( $this->request_queue_state_cache[ $queue->id ] ) ) {
 			list( $queue_size, $queue_age ) = $this->request_queue_state_cache[ $queue->id ];
 			return ( $queue_age < $this->sync_queue_lag_limit )

--- a/projects/packages/sync/src/class-listener.php
+++ b/projects/packages/sync/src/class-listener.php
@@ -15,8 +15,9 @@ use Automattic\Jetpack\Roles;
  * This class monitors actions and logs them to the queue to be sent.
  */
 class Listener {
-	const QUEUE_STATE_CHECK_TRANSIENT = 'jetpack_sync_last_checked_queue_state';
-	const QUEUE_STATE_CHECK_TIMEOUT   = 30; // 30 seconds.
+	const QUEUE_STATE_CHECK_TRANSIENT          = 'jetpack_sync_last_checked_queue_state';
+	const QUEUE_STATE_CHECK_TIMEOUT            = 30; // 30 seconds.
+	const REQUEST_STATE_CACHE_INVALIDATE_AFTER = 50; // Number of queue adds per request before invalidating the cache.
 
 	/**
 	 * Sync queue.
@@ -45,6 +46,23 @@ class Listener {
 	 * @var int Lag limit.
 	 */
 	private $sync_queue_lag_limit;
+
+	/**
+	 * Per-request in-memory cache of queue state.
+	 * Avoids repeated get_transient() calls for every
+	 * can_add_to_queue check within a single request.
+	 *
+	 * @var array<string, array<int, float>>
+	 */
+	private $request_queue_state_cache = array();
+
+	/**
+	 * Count of successful adds per queue within this request, used to decide when
+	 * to invalidate the in-memory cache so the size estimate stays accurate.
+	 *
+	 * @var array<string, int>
+	 */
+	private $request_adds_count = array();
 
 	/**
 	 * Singleton implementation.
@@ -148,6 +166,8 @@ class Listener {
 	public function force_recheck_queue_limit() {
 		delete_transient( self::QUEUE_STATE_CHECK_TRANSIENT . '_' . $this->sync_queue->id );
 		delete_transient( self::QUEUE_STATE_CHECK_TRANSIENT . '_' . $this->full_sync_queue->id );
+		$this->request_queue_state_cache = array();
+		$this->request_adds_count        = array();
 	}
 
 	/**
@@ -164,6 +184,16 @@ class Listener {
 			return false;
 		}
 
+		// Per-request in-memory cache: avoids a get_transient() call on every enqueue within
+		// the same request. On sites without an object cache, each get_transient() is a DB read,
+		// so a request that enqueues many actions would otherwise generate one DB read per action
+		// just for this check.
+		if ( isset( $this->request_queue_state_cache[ $queue->id ] ) ) {
+			list( $queue_size, $queue_age ) = $this->request_queue_state_cache[ $queue->id ];
+			return ( $queue_age < $this->sync_queue_lag_limit )
+				|| ( ( $queue_size + 1 ) < $this->sync_queue_size_limit );
+		}
+
 		$state_transient_name = self::QUEUE_STATE_CHECK_TRANSIENT . '_' . $queue->id;
 
 		$queue_state = get_transient( $state_transient_name );
@@ -172,6 +202,10 @@ class Listener {
 			$queue_state = array( $queue->size(), $queue->lag() );
 			set_transient( $state_transient_name, $queue_state, self::QUEUE_STATE_CHECK_TIMEOUT );
 		}
+
+		// Populate in-memory cache from the transient result so subsequent calls this request
+		// don't need to hit the object cache or DB at all.
+		$this->request_queue_state_cache[ $queue->id ] = $queue_state;
 
 		list( $queue_size, $queue_age ) = $queue_state;
 
@@ -369,6 +403,16 @@ class Listener {
 					Settings::is_importing(),
 				)
 			);
+		}
+
+		// Track how many items have been added to this queue during this request and periodically
+		// invalidate the in-memory queue-state cache so the size/lag estimate stays accurate.
+		// Without this, a burst that fills the queue mid-request would keep passing can_add_to_queue
+		// with a stale "queue is fine" result captured at the start of the request.
+		$this->request_adds_count[ $queue->id ] = ( $this->request_adds_count[ $queue->id ] ?? 0 ) + 1;
+		if ( $this->request_adds_count[ $queue->id ] >= self::REQUEST_STATE_CACHE_INVALIDATE_AFTER ) {
+			unset( $this->request_queue_state_cache[ $queue->id ] );
+			$this->request_adds_count[ $queue->id ] = 0;
 		}
 
 		// since we've added some items, let's try to load the sender so we can send them as quickly as possible.

--- a/projects/packages/sync/src/class-listener.php
+++ b/projects/packages/sync/src/class-listener.php
@@ -184,9 +184,8 @@ class Listener {
 			return false;
 		}
 
-		// Per-request in-memory cache: avoids a get_transient() call on every enqueue within the same request.
-		// On sites with an external object cache, each get_transient() is a network rount-trip, so a request that
-		// enqueues many actions would otherwise make one network call per action just for this check.
+		// Per-request in-memory cache: avoids a get_transient() call on every can_add_to_queue
+		// check within the same request when many actions are enqueued.
 		if ( isset( $this->request_queue_state_cache[ $queue->id ] ) ) {
 			list( $queue_size, $queue_age ) = $this->request_queue_state_cache[ $queue->id ];
 			return ( $queue_age < $this->sync_queue_lag_limit )

--- a/projects/plugins/jetpack/changelog/pr-47282
+++ b/projects/plugins/jetpack/changelog/pr-47282
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Sync: Add per-request in-memory cache in the Listener to reduce get_transient calls during action queue checks.

--- a/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Listener_Test.php
+++ b/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Listener_Test.php
@@ -340,6 +340,29 @@ class Jetpack_Sync_Listener_Test extends Jetpack_Sync_TestBase {
 		}
 	}
 
+	public function test_request_cache_reduces_get_transient_calls() {
+		$transient_calls = 0;
+		add_filter(
+			'pre_transient_jetpack_sync_last_checked_queue_state_sync',
+			function ( $pre ) use ( &$transient_calls ) {
+				$transient_calls++;
+				return $pre;
+			},
+			0
+		);
+
+		add_action( 'my_action', array( $this->listener, 'action_handler' ) );
+		$this->listener->force_recheck_queue_limit();
+
+		do_action( 'my_action' );
+		do_action( 'my_action' );
+		do_action( 'my_action' );
+
+		remove_action( 'my_action', array( $this->listener, 'action_handler' ) );
+
+		$this->assertSame( 1, $transient_calls );
+	}
+
 	public function get_page_url() {
 		return 'http' . ( isset( $_SERVER['HTTPS'] ) ? 's' : '' ) . '://' . "{$_SERVER['HTTP_HOST']}{$_SERVER['REQUEST_URI']}";
 	}

--- a/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Listener_Test.php
+++ b/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Listener_Test.php
@@ -355,12 +355,41 @@ class Jetpack_Sync_Listener_Test extends Jetpack_Sync_TestBase {
 		$this->listener->force_recheck_queue_limit();
 
 		do_action( 'my_action' );
+		// @phan-suppress-next-line PhanPluginDuplicateAdjacentStatement - intentional for testing.
 		do_action( 'my_action' );
+		// @phan-suppress-next-line PhanPluginDuplicateAdjacentStatement - intentional for testing.
 		do_action( 'my_action' );
 
 		remove_action( 'my_action', array( $this->listener, 'action_handler' ) );
 
 		$this->assertSame( 1, $transient_calls );
+	}
+
+	public function test_request_cache_invalidates_after_threshold() {
+		$transient_calls = 0;
+		add_filter(
+			'pre_transient_jetpack_sync_last_checked_queue_state_sync',
+			function ( $pre ) use ( &$transient_calls ) {
+				$transient_calls++;
+				return $pre;
+			},
+			0
+		);
+
+		add_action( 'my_action', array( $this->listener, 'action_handler' ) );
+		$this->listener->force_recheck_queue_limit();
+
+		// Fire one more than the invalidation threshold: the first item causes a transient
+		// read, items 2–50 hit the in-memory cache, and item 51 causes a second
+		// transient read after the cache is invalidated at the 50-item threshold.
+		$threshold = \Automattic\Jetpack\Sync\Listener::REQUEST_STATE_CACHE_INVALIDATE_AFTER;
+		for ( $i = 0; $i < $threshold + 1; $i++ ) {
+			do_action( 'my_action' );
+		}
+
+		remove_action( 'my_action', array( $this->listener, 'action_handler' ) );
+
+		$this->assertSame( 2, $transient_calls );
 	}
 
 	public function get_page_url() {


### PR DESCRIPTION
Fixes SYNC-254

## Proposed changes:

* Previously, `can_add_to_queue()` called `get_transient()` for every action considered for the sync queue. This PR adds a per-request in-memory cache, reducing that to one call per request, refreshed after every 50 successfully enqueued actions.


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

n/a

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

To replicate the issue:

* To test, on a test site connected to Jetpack, ensure you have around 100 test posts. For this test (you can use the WP Dummy Content Generator plugin)
* Add and install the Code Snippets plugin
* Add the following code snippet:3a7fc-pb
* Visit `/wp-admin/?jetpack_sync_burst_test=1`
* Note down the resulting details
* Confirm the details have been synced to your cache site: `gpr select * from wp_YOURBLOGID_postmeta where meta_key="_wpas_mess"`
* Then visit `/wp-admin/?jetpack_sync_burst_cleanup=1` and wait for the cleanup to run (and complete on the cache site as well, checking with the above command to make sure everything is cleaned up)

To test this PR:

* Apply the changes in the PR using the Jetpack Beta tester plugin
* Follow the same steps as above.
* Note the resulting details. You should see that `get_transient` calls have reduced from 100 to 2

## Changelog
<!-- Check one of the boxes below. -->

- [x] Generate changelog entries for this PR (using AI).