### PR TITLE
Forms: Add print-friendly styles to submission emails

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-email-style-support-printable
+++ b/projects/packages/forms/changelog/fix-forms-email-style-support-printable
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add print-friendly styles to form submission emails: hide decorative field icons, tighten spacing, and remove non-essential elements when printing. Minify email CSS to stay under Gmail's 8,192-character style block limit.

--- a/projects/packages/forms/src/contact-form/class-feedback-email-renderer.php
+++ b/projects/packages/forms/src/contact-form/class-feedback-email-renderer.php
@@ -674,14 +674,14 @@ class Feedback_Email_Renderer {
 
 		// Avatar content - either image or initials.
 		$avatar_content = ! empty( $avatar )
-			? '<img src="' . $avatar . '" alt="" width="48" height="48" style="border-radius: 24px;">'
+			? '<img src="' . $avatar . '" alt="" width="48" height="48" style="border-radius: 24px; vertical-align: middle;">'
 			: esc_html( $initials );
 
 		// Use table layout for maximum email client compatibility.
 		$html = '
 		<table role="presentation" border="0" cellpadding="0" cellspacing="0" class="respondent-table" width="100%" style="border-collapse: collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; margin-bottom: 16px;">
 			<tr>
-				<td class="respondent-avatar-cell" style="width: 64px; vertical-align: top; font-family: -apple-system, BlinkMacSystemFont, \'Segoe UI\', Roboto, Oxygen-Sans, Ubuntu, Cantarell, \'Helvetica Neue\', sans-serif;">
+				<td class="respondent-avatar-cell" style="width: 64px; vertical-align: middle; font-family: -apple-system, BlinkMacSystemFont, \'Segoe UI\', Roboto, Oxygen-Sans, Ubuntu, Cantarell, \'Helvetica Neue\', sans-serif;">
 					<!--[if mso]>
 					<table role="presentation" border="0" cellpadding="0" cellspacing="0" width="48" height="48" style="width: 48px; height: 48px;">
 					<tr>

--- a/projects/packages/forms/src/contact-form/class-feedback-email-renderer.php
+++ b/projects/packages/forms/src/contact-form/class-feedback-email-renderer.php
@@ -628,6 +628,14 @@ class Feedback_Email_Renderer {
 			$metadata_html
 		);
 
+		// Inject print styles into <body> for Outlook.com compatibility (it strips <head> styles
+		// but preserves <body> styles). The same styles are already in <head> for Gmail and others.
+		// This is done after sprintf to avoid % signs in CSS being interpreted as format specifiers.
+		if ( isset( $print_style ) ) {
+			// phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable -- defined in the template file loaded via require above.
+			$html_message = str_replace( '</body>', '<style type="text/css">' . $print_style . '</style></body>', $html_message );
+		}
+
 		return $html_message;
 	}
 

--- a/projects/packages/forms/src/contact-form/class-feedback-email-renderer.php
+++ b/projects/packages/forms/src/contact-form/class-feedback-email-renderer.php
@@ -428,7 +428,7 @@ class Feedback_Email_Renderer {
 		// Build the field row as a table with icon + content.
 		$html  = '<table role="presentation" border="0" cellpadding="0" cellspacing="0" width="100%" style="border-bottom: 1px solid #F0F0F0; padding: 0; margin: 0;">';
 		$html .= '<tr>';
-		$html .= '<td width="24" valign="top" style="padding: 18px 16px 20px 0; width: 24px; vertical-align: top; -webkit-user-select: none; user-select: none;">';
+		$html .= '<td class="field-icon-cell" width="24" valign="top" style="padding: 18px 16px 20px 0; width: 24px; vertical-align: top; -webkit-user-select: none; user-select: none;">';
 		$html .= sprintf(
 			'<img src="%s" width="24" height="24" alt="" style="display: block; width: 24px; height: 24px; -webkit-user-select: none; user-select: none;" />',
 			esc_url( $icon_url )
@@ -623,6 +623,14 @@ class Feedback_Email_Renderer {
 			$respondent_html,
 			$metadata_html
 		);
+
+		// Inject print styles into <body> for Outlook.com compatibility (it strips <head> styles
+		// but preserves <body> styles). The same styles are already in <head> for Gmail and others.
+		// This is done after sprintf to avoid % signs in CSS being interpreted as format specifiers.
+		if ( isset( $print_style ) ) {
+			// phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable -- defined in the template file loaded via require above.
+			$html_message = str_replace( '</body>', '<style type="text/css">' . $print_style . '</style></body>', $html_message );
+		}
 
 		return $html_message;
 	}

--- a/projects/packages/forms/src/contact-form/class-feedback-email-renderer.php
+++ b/projects/packages/forms/src/contact-form/class-feedback-email-renderer.php
@@ -562,6 +562,7 @@ class Feedback_Email_Renderer {
 		 *
 		 * @param string the filename of the HTML template used for response emails to the form owner.
 		 */
+		$print_style = null; // May be set by the template file loaded below.
 		require apply_filters( 'jetpack_forms_response_email_template', __DIR__ . '/templates/email-response.php' );
 
 		/**
@@ -631,8 +632,8 @@ class Feedback_Email_Renderer {
 		// Inject print styles into <body> for Outlook.com compatibility (it strips <head> styles
 		// but preserves <body> styles). The same styles are already in <head> for Gmail and others.
 		// This is done after sprintf to avoid % signs in CSS being interpreted as format specifiers.
-		if ( isset( $print_style ) ) {
-			// phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable -- defined in the template file loaded via require above.
+		// @phan-suppress-next-line PhanRedundantCondition -- $print_style is set by the template file loaded via require above.
+		if ( ! empty( $print_style ) ) {
 			$html_message = str_replace( '</body>', '<style type="text/css">' . $print_style . '</style></body>', $html_message );
 		}
 

--- a/projects/packages/forms/src/contact-form/class-feedback-email-renderer.php
+++ b/projects/packages/forms/src/contact-form/class-feedback-email-renderer.php
@@ -793,7 +793,7 @@ class Feedback_Email_Renderer {
 		$css = preg_replace( '/\s+/', ' ', $css );
 		// Remove spaces around CSS punctuation: { } ; : ,
 		$css = preg_replace( '/\s*([{};,])\s*/', '$1', $css );
-		// Remove space after colons (but not inside url() or content strings).
+		// Remove space after colons in all contexts.
 		$css = preg_replace( '/:\s+/', ':', $css );
 		// Remove trailing semicolons before closing braces.
 		$css = str_replace( ';}', '}', $css );

--- a/projects/packages/forms/src/contact-form/class-feedback-email-renderer.php
+++ b/projects/packages/forms/src/contact-form/class-feedback-email-renderer.php
@@ -628,14 +628,6 @@ class Feedback_Email_Renderer {
 			$metadata_html
 		);
 
-		// Inject print styles into <body> for Outlook.com compatibility (it strips <head> styles
-		// but preserves <body> styles). The same styles are already in <head> for Gmail and others.
-		// This is done after sprintf to avoid % signs in CSS being interpreted as format specifiers.
-		if ( isset( $print_style ) ) {
-			// phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable -- defined in the template file loaded via require above.
-			$html_message = str_replace( '</body>', '<style type="text/css">' . $print_style . '</style></body>', $html_message );
-		}
-
 		return $html_message;
 	}
 

--- a/projects/packages/forms/src/contact-form/class-feedback-email-renderer.php
+++ b/projects/packages/forms/src/contact-form/class-feedback-email-renderer.php
@@ -603,6 +603,10 @@ class Feedback_Email_Renderer {
 		// Generate metadata HTML.
 		$metadata_html = self::generate_metadata_html( $metadata );
 
+		// Minify CSS to stay under Gmail's 8,192-char limit for style blocks.
+		// The template file keeps readable formatting; we strip it here at render time.
+		$style = self::minify_css( $style );
+
 		$html_message = sprintf(
 			// The tabs are just here so that the raw code is correctly formatted for developers
 			// They're removed so that they don't affect the final message sent to users.
@@ -770,5 +774,29 @@ class Feedback_Email_Renderer {
 				<td class="metadata-label" style="color: #50575e; width: 100px; padding: 4px 12px 4px 0; font-size: ' . self::FONT_SIZE_METADATA . '; vertical-align: top; font-family: -apple-system, BlinkMacSystemFont, \'Segoe UI\', Roboto, Oxygen-Sans, Ubuntu, Cantarell, \'Helvetica Neue\', sans-serif; line-height: 1.4;">' . esc_html( $label ) . ':</td>
 				<td class="metadata-value" style="color: #1e1e1e; padding: 4px 0; font-size: ' . self::FONT_SIZE_METADATA . '; vertical-align: top; font-family: -apple-system, BlinkMacSystemFont, \'Segoe UI\', Roboto, Oxygen-Sans, Ubuntu, Cantarell, \'Helvetica Neue\', sans-serif; line-height: 1.4;">' . $value . '</td>
 			</tr>';
+	}
+
+	/**
+	 * Minify a CSS string by removing comments, collapsing whitespace,
+	 * and stripping unnecessary characters.
+	 *
+	 * Gmail imposes an 8,192-character limit across all <style> blocks.
+	 * This keeps the template file readable while fitting under the limit.
+	 *
+	 * @param string $css The CSS string (may include <style> tags).
+	 * @return string The minified CSS string.
+	 */
+	private static function minify_css( $css ) {
+		// Remove CSS comments.
+		$css = preg_replace( '/\/\*.*?\*\//s', '', $css );
+		// Collapse all whitespace (tabs, newlines, spaces) into single spaces.
+		$css = preg_replace( '/\s+/', ' ', $css );
+		// Remove spaces around CSS punctuation: { } ; : ,
+		$css = preg_replace( '/\s*([{};,])\s*/', '$1', $css );
+		// Remove space after colons (but not inside url() or content strings).
+		$css = preg_replace( '/:\s+/', ':', $css );
+		// Remove trailing semicolons before closing braces.
+		$css = str_replace( ';}', '}', $css );
+		return trim( $css );
 	}
 }

--- a/projects/packages/forms/src/contact-form/templates/email-response.php
+++ b/projects/packages/forms/src/contact-form/templates/email-response.php
@@ -30,6 +30,19 @@ $font_size_field_value = \Automattic\Jetpack\Forms\ContactForm\Feedback_Email_Re
 $font_size_metadata    = \Automattic\Jetpack\Forms\ContactForm\Feedback_Email_Renderer::FONT_SIZE_METADATA;
 $font_size_button      = \Automattic\Jetpack\Forms\ContactForm\Feedback_Email_Renderer::FONT_SIZE_BUTTON;
 
+// Print styles: defined once, included in both <head> and <body> for maximum
+// email client compatibility (Gmail preserves <head> styles, Outlook.com preserves <body> styles).
+$print_style = '@media print {
+	body, .body { background-color: #ffffff !important; }
+	.container { width: 100% !important; max-width: 100% !important; padding: 0 !important; }
+	.wrapper { padding: 16px 0 !important; }
+	.main { border-radius: 0 !important; }
+	.field-icon-cell { display: none !important; width: 0 !important; max-width: 0 !important; padding: 0 !important; overflow: hidden !important; }
+	.form-fields-inner { padding: 0 !important; }
+	.actions, .powered-by-table, .preheader { display: none !important; }
+	.collapse { display: none !important; }
+}';
+
 // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- used in class-contact-form.php
 $template = '
 <!DOCTYPE html>
@@ -623,6 +636,8 @@ $style = '<style media="all" type="text/css">
 			text-align: center !important;
 		}
 	}
+
+	' . $print_style . '
 
 	@media all {
 		.ExternalClass {

--- a/projects/packages/forms/src/contact-form/templates/email-response.php
+++ b/projects/packages/forms/src/contact-form/templates/email-response.php
@@ -32,6 +32,17 @@ $font_size_button     = \Automattic\Jetpack\Forms\ContactForm\Feedback_Email_Ren
 // and removes non-essential elements. Works for clients that preserve <style> tags
 // in print (Apple Mail ~52%, Outlook, Thunderbird). Gmail strips <style> when
 // printing so @media print has no effect there — a known limitation.
+// Defined as a variable so it can also be injected into <body> for Outlook.com.
+$print_style = '@media print {
+	body, .body { background-color: #ffffff !important; }
+	.container { width: 100% !important; max-width: 100% !important; padding: 0 !important; }
+	.wrapper { padding: 16px 0 !important; }
+	.main { border-radius: 0 !important; }
+	.field-icon-cell { display: none !important; width: 0 !important; max-width: 0 !important; padding: 0 !important; overflow: hidden !important; }
+	.form-fields-inner { padding: 0 !important; }
+	.actions, .powered-by-table, .preheader { display: none !important; }
+	.collapse { display: none !important; }
+}';
 
 // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- used in class-contact-form.php
 $template = '
@@ -74,7 +85,9 @@ $template = '
 								%4$s
 
 								<!-- Actions -->
-								%8$s
+								<div class="actions">
+									%8$s
+								</div>
 
 								<!-- Powered By -->
 								%9$s
@@ -362,16 +375,7 @@ $style = '<style media="all" type="text/css">
 		}
 	}
 
-	@media print {
-		body, .body { background-color: #ffffff !important; }
-		.container { width: 100% !important; max-width: 100% !important; padding: 0 !important; }
-		.wrapper { padding: 16px 0 !important; }
-		.main { border-radius: 0 !important; }
-		.field-icon-cell { display: none !important; width: 0 !important; max-width: 0 !important; padding: 0 !important; overflow: hidden !important; }
-		.form-fields-inner { padding: 0 !important; }
-		.actions, .powered-by-table, .preheader { display: none !important; }
-		.collapse { display: none !important; }
-	}
+	' . $print_style . '
 
 	@media all {
 		.ExternalClass {

--- a/projects/packages/forms/src/contact-form/templates/email-response.php
+++ b/projects/packages/forms/src/contact-form/templates/email-response.php
@@ -279,7 +279,7 @@ $style = '<style media="all" type="text/css">
 
 	.respondent-avatar-cell {
 		width: 64px;
-		vertical-align: top;
+		vertical-align: middle;
 	}
 
 	.respondent-avatar-wrapper {

--- a/projects/packages/forms/src/contact-form/templates/email-response.php
+++ b/projects/packages/forms/src/contact-form/templates/email-response.php
@@ -22,26 +22,16 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit( 0 );
 }
 
-$link_color            = \Automattic\Jetpack\Forms\ContactForm\Feedback_Email_Renderer::LINK_COLOR;
-$text_color            = \Automattic\Jetpack\Forms\ContactForm\Feedback_Email_Renderer::TEXT_COLOR;
-$text_secondary_color  = \Automattic\Jetpack\Forms\ContactForm\Feedback_Email_Renderer::TEXT_SECONDARY_COLOR;
-$font_size_field_label = \Automattic\Jetpack\Forms\ContactForm\Feedback_Email_Renderer::FONT_SIZE_FIELD_LABEL;
-$font_size_field_value = \Automattic\Jetpack\Forms\ContactForm\Feedback_Email_Renderer::FONT_SIZE_FIELD_VALUE;
-$font_size_metadata    = \Automattic\Jetpack\Forms\ContactForm\Feedback_Email_Renderer::FONT_SIZE_METADATA;
-$font_size_button      = \Automattic\Jetpack\Forms\ContactForm\Feedback_Email_Renderer::FONT_SIZE_BUTTON;
+$link_color           = \Automattic\Jetpack\Forms\ContactForm\Feedback_Email_Renderer::LINK_COLOR;
+$text_color           = \Automattic\Jetpack\Forms\ContactForm\Feedback_Email_Renderer::TEXT_COLOR;
+$text_secondary_color = \Automattic\Jetpack\Forms\ContactForm\Feedback_Email_Renderer::TEXT_SECONDARY_COLOR;
+$font_size_metadata   = \Automattic\Jetpack\Forms\ContactForm\Feedback_Email_Renderer::FONT_SIZE_METADATA;
+$font_size_button     = \Automattic\Jetpack\Forms\ContactForm\Feedback_Email_Renderer::FONT_SIZE_BUTTON;
 
-// Print styles: defined once, included in both <head> and <body> for maximum
-// email client compatibility (Gmail preserves <head> styles, Outlook.com preserves <body> styles).
-$print_style = '@media print {
-	body, .body { background-color: #ffffff !important; }
-	.container { width: 100% !important; max-width: 100% !important; padding: 0 !important; }
-	.wrapper { padding: 16px 0 !important; }
-	.main { border-radius: 0 !important; }
-	.field-icon-cell { display: none !important; width: 0 !important; max-width: 0 !important; padding: 0 !important; overflow: hidden !important; }
-	.form-fields-inner { padding: 0 !important; }
-	.actions, .powered-by-table, .preheader { display: none !important; }
-	.collapse { display: none !important; }
-}';
+// Print-friendly styles: @media print hides decorative icons, tightens spacing,
+// and removes non-essential elements. Works for clients that preserve <style> tags
+// in print (Apple Mail ~52%, Outlook, Thunderbird). Gmail strips <style> when
+// printing so @media print has no effect there — a known limitation.
 
 // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- used in class-contact-form.php
 $template = '
@@ -165,11 +155,6 @@ $style = '<style media="all" type="text/css">
 		padding: 40px 48px;
 	}
 
-	.content-block {
-		box-sizing: border-box;
-		padding: 0 32px 24px;
-	}
-
 	.preheader {
 		color: transparent;
 		display: none;
@@ -192,40 +177,6 @@ $style = '<style media="all" type="text/css">
 		padding: 0;
 	}
 
-	/* Respondent Info Section */
-	.respondent-info {
-		display: flex;
-		align-items: center;
-		margin-bottom: 24px;
-		padding-bottom: 20px;
-		border-bottom: 1px solid #E4E4E7;
-	}
-
-	.respondent-avatar {
-		width: 48px;
-		height: 48px;
-		border-radius: 50%;
-		background-color: #f0f0f0;
-		display: flex;
-		align-items: center;
-		justify-content: center;
-		font-size: 18px;
-		font-weight: 600;
-		color: #50575e;
-		margin-right: 16px;
-		flex-shrink: 0;
-	}
-
-	.respondent-avatar img {
-		width: 48px;
-		height: 48px;
-		border-radius: 50%;
-	}
-
-	.respondent-details {
-		flex: 1;
-	}
-
 	.respondent-name {
 		font-size: 16px;
 		font-weight: 500;
@@ -238,13 +189,6 @@ $style = '<style media="all" type="text/css">
 		color: ' . $text_secondary_color . ';
 		margin: 0;
 		line-height: 1.4;
-	}
-
-	/* Metadata Section */
-	.metadata-section {
-		border-bottom: 1px solid #E4E4E7;
-		padding: 16px 0;
-		margin-bottom: 24px;
 	}
 
 	.metadata-table {
@@ -281,157 +225,6 @@ $style = '<style media="all" type="text/css">
 		padding: 16px 16px 24px;
 	}
 
-	.form-field {
-		padding: 16px 0;
-		border-bottom: 1px solid #F0F0F0;
-	}
-
-	.form-field:last-child {
-		border-bottom: none;
-	}
-
-	.field-row {
-		display: flex;
-		align-items: flex-start;
-	}
-
-	.field-icon {
-		width: 24px;
-		height: 24px;
-		margin-right: 16px;
-		flex-shrink: 0;
-		margin-top: 2px;
-	}
-
-	.field-icon svg {
-		width: 24px;
-		height: 24px;
-		fill: #50575e;
-	}
-
-	.field-content {
-		flex: 1;
-		min-width: 0;
-	}
-
-	.field-label {
-		font-size: ' . $font_size_field_label . ';
-		color: ' . $text_secondary_color . ';
-		margin: 0 0 4px 0;
-		text-transform: none;
-	}
-
-	.field-value {
-		font-size: ' . $font_size_field_value . ';
-		color: ' . $text_color . ';
-		margin: 0;
-		word-wrap: break-word;
-	}
-
-	.field-value a {
-		color: ' . $link_color . ';
-		text-decoration: underline;
-	}
-
-	/* Tag/Chip Styles for Multi-select */
-	.field-tags {
-		display: flex;
-		flex-wrap: wrap;
-		gap: 6px;
-		margin-top: 4px;
-	}
-
-	.field-tag {
-		display: inline-block;
-		background-color: #f0f0f0;
-		border-radius: 2px;
-		padding: 0 8px;
-		font-size: ' . $font_size_field_value . ';
-		color: ' . $text_color . ';
-	}
-
-	/* Image Select Styles */
-	.image-choices {
-		display: flex;
-		flex-wrap: wrap;
-		gap: 12px;
-		margin-top: 8px;
-	}
-
-	.image-choice {
-		text-align: center;
-	}
-
-	.image-choice img {
-		width: 80px;
-		height: 80px;
-		object-fit: cover;
-		border-radius: 4px;
-		border: 1px solid #e0e0e0;
-	}
-
-	.image-choice-label {
-		font-size: 12px;
-		color: #50575e;
-		margin-top: 4px;
-	}
-
-	/* Rating Styles */
-	.rating-stars {
-		color: #f5c518;
-		font-size: 18px;
-		letter-spacing: 2px;
-	}
-
-	/* File Upload Styles */
-	.file-item {
-		display: flex;
-		align-items: center;
-		gap: 8px;
-		margin-top: 4px;
-	}
-
-	.file-icon {
-		width: 16px;
-		height: 16px;
-		fill: #50575e;
-	}
-
-	.file-name {
-		color: ' . $link_color . ';
-		text-decoration: underline;
-	}
-
-	.file-size {
-		color: #50575e;
-		font-size: 12px;
-	}
-
-	/* Consent Chip */
-	.consent-chip {
-		display: inline-block;
-		background-color: #d4edda;
-		color: #155724;
-		border-radius: 2px;
-		padding: 0 8px;
-		font-size: ' . $font_size_field_value . ';
-	}
-
-	.consent-chip.no {
-		background-color: #f8d7da;
-		color: #721c24;
-	}
-
-	/* Actions Section */
-	.actions {
-		margin-top: 24px;
-		text-align: center;
-	}
-
-	.actions-table {
-		width: 100%;
-	}
-
 	.action-button {
 		display: inline-block;
 		padding: 12px 24px;
@@ -453,39 +246,9 @@ $style = '<style media="all" type="text/css">
 		border: 1px solid ' . $link_color . ';
 	}
 
-	/* Footer */
-	.footer {
-		clear: both;
-		padding: 24px 0;
-		width: 100%;
-	}
-
-	.footer-content {
-		text-align: center;
-	}
-
-	.footer td,
-	.footer p,
-	.footer span,
-	.footer a {
-		color: #50575e;
-		font-size: 12px;
-	}
-
 	.powered-by {
 		text-align: center;
 		padding: 16px 0;
-	}
-
-	.powered-by a {
-		color: #50575e;
-		text-decoration: none;
-		font-size: 12px;
-	}
-
-	.powered-by img {
-		vertical-align: middle;
-		margin-right: 4px;
 	}
 
 	h1 {
@@ -599,7 +362,16 @@ $style = '<style media="all" type="text/css">
 		}
 	}
 
-	' . $print_style . '
+	@media print {
+		body, .body { background-color: #ffffff !important; }
+		.container { width: 100% !important; max-width: 100% !important; padding: 0 !important; }
+		.wrapper { padding: 16px 0 !important; }
+		.main { border-radius: 0 !important; }
+		.field-icon-cell { display: none !important; width: 0 !important; max-width: 0 !important; padding: 0 !important; overflow: hidden !important; }
+		.form-fields-inner { padding: 0 !important; }
+		.actions, .powered-by-table, .preheader { display: none !important; }
+		.collapse { display: none !important; }
+	}
 
 	@media all {
 		.ExternalClass {

--- a/projects/packages/forms/src/contact-form/templates/email-response.php
+++ b/projects/packages/forms/src/contact-form/templates/email-response.php
@@ -560,7 +560,8 @@ $style = '<style media="all" type="text/css">
 	.respondent-details-cell {
 		vertical-align: middle;
 	}
-
+</style>
+<style media="all" type="text/css">
 	/* Responsive */
 	@media only screen and (max-width: 640px) {
 		.main p,

--- a/projects/packages/forms/src/contact-form/templates/email-response.php
+++ b/projects/packages/forms/src/contact-form/templates/email-response.php
@@ -84,9 +84,7 @@ $template = '
 								%4$s
 
 								<!-- Actions -->
-								<div class="actions">
-									%8$s
-								</div>
+								%8$s
 
 								<!-- Powered By -->
 								%9$s
@@ -453,43 +451,6 @@ $style = '<style media="all" type="text/css">
 		background-color: transparent;
 		color: ' . $link_color . ' !important;
 		border: 1px solid ' . $link_color . ';
-	}
-
-	/* Legacy Actions Support */
-	.actions .button_block {
-		mso-table-lspace: 0pt;
-		mso-table-rspace: 0pt;
-		width: unset;
-		margin-top: 24px;
-	}
-
-	.actions .button_block .pad,
-	.actions .button_block .pad a {
-		border-radius: 4px;
-		background-image: url(\'https://s0.wordpress.com/i/emails/marketing/wpcom/2024/blueberry-px.png\');
-		background-size: cover;
-		background-color: #3858E9;
-	}
-
-	.actions .button_block .pad a {
-		font-size: 14px;
-		font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
-		font-weight: 500;
-		text-decoration: none;
-		padding: 12px 24px;
-		color: #ffffff;
-		border-radius: 4px;
-		display: inline-block;
-		mso-padding-alt: 0;
-	}
-
-	.actions .button_block .pad a span {
-		mso-text-raise: 15pt;
-	}
-
-	.actions .button_block .pad i {
-		letter-spacing: 25px;
-		mso-font-width: -100%;
 	}
 
 	/* Footer */


### PR DESCRIPTION
Part of FORMS-443
Part of FORMS-597
Part of FORMS-589

## Proposed changes:

* Add `@media print` CSS rules to form submission emails that hide decorative field icons, tighten spacing, and remove non-essential elements (action buttons, powered-by footer, preheader) when printing.
* Add `field-icon-cell` CSS class to icon table cells in the email renderer to enable targeted print styling.
* Split the email stylesheet into two `<style>` blocks and minify CSS to stay under Gmail's 8,192-character style block limit.

Outlook Desktop print output
<img width="729" height="609" alt="image" src="https://github.com/user-attachments/assets/9867c2f9-1205-43d6-a16d-ab3749f17432" />

Outlook web UI print output
<img width="497" height="575" alt="image" src="https://github.com/user-attachments/assets/2aa956e8-ba1a-4a0f-8e29-3786a5c4ce6c" />


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

1. Set up a Jetpack site with the Forms package from this branch
2. Create a form and submit a test entry
3. Open the form submission notification email in various clients:
   - **Apple Mail / Thunderbird**: Print the email — icons should be hidden, spacing tightened, action buttons and footer removed
   - **Gmail**: Verify the email renders correctly on screen (note: Gmail's print view strips `<style>` tags, so print-specific styles won't apply there — this is a known Gmail limitation)
4. Verify the email still renders correctly on screen across clients (no visual regressions)

## Changelog

- [x] Generate changelog entries for this PR (using AI).
