### PR TITLE
Forms: add Change Status action for forms

### DIFF
--- a/projects/packages/forms/changelog/add-wp-build-forms-change-status
+++ b/projects/packages/forms/changelog/add-wp-build-forms-change-status
@@ -1,4 +1,4 @@
 Significance: minor
 Type: added
 
-Forms dashboard: Add a "Change status" action for managed forms in the new wp-build Forms list.
+Forms dashboard: Add a "Change status" action for managed forms (Forms list and single-form header menu).

--- a/projects/packages/forms/changelog/add-wp-build-forms-change-status
+++ b/projects/packages/forms/changelog/add-wp-build-forms-change-status
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Forms dashboard: Add a "Change status" action for managed forms in the new wp-build Forms list.

--- a/projects/packages/forms/routes/forms/stage.tsx
+++ b/projects/packages/forms/routes/forms/stage.tsx
@@ -28,8 +28,10 @@ import { NON_TRASH_FORM_STATUSES } from '../../src/dashboard/constants';
 import useDeleteForm from '../../src/dashboard/hooks/use-delete-form.ts';
 import useFormsData from '../../src/dashboard/hooks/use-forms-data.ts';
 import WpRouteDashboardSearchParamsProvider from '../../src/dashboard/router/wp-route-dashboard-search-params-provider.tsx';
+import ChangeFormStatusModal from '../../src/dashboard/wp-build/components/change-form-status-modal';
 import DataViewsHeaderRow from '../../src/dashboard/wp-build/components/dataviews-header-row';
 import FormsHelpModal from '../../src/dashboard/wp-build/components/forms-help-modal';
+import useChangeFormStatus from '../../src/dashboard/wp-build/hooks/use-change-form-status';
 import useFormItemActions from '../../src/dashboard/wp-build/hooks/use-form-item-actions';
 import usePageHeaderDetails from '../../src/dashboard/wp-build/hooks/use-page-header-details';
 import '../../src/dashboard/wp-build/style.scss';
@@ -138,12 +140,22 @@ function StageInner() {
 		statusQuery,
 	} );
 
+	const { isChangingStatus, changeFormStatus } = useChangeFormStatus( {
+		view,
+		setView,
+		recordsLength: records?.length ?? 0,
+		statusQuery,
+	} );
+
 	const [ selection, setSelection ] = useState< string[] >( [] );
 	const [ pendingPermanentDeleteCount, setPendingPermanentDeleteCount ] = useState( 0 );
 
 	// Rename modal state
 	const [ renameFormItem, setRenameFormItem ] = useState< FormListItem | null >( null );
 	const renameRetryRef = useRef< { item: FormListItem; title: string } | null >( null );
+
+	// Change status modal state
+	const [ statusChangeItems, setStatusChangeItems ] = useState< FormListItem[] | null >( null );
 
 	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
 	const { saveEntityRecord } = useDispatch( coreStore );
@@ -183,6 +195,34 @@ function StageInner() {
 		setRenameFormItem( null );
 		renameRetryRef.current = null;
 	}, [] );
+
+	const openChangeStatusModal = useCallback(
+		( items: FormListItem[] ) => {
+			if ( ! items?.length || isDeleting || isChangingStatus ) {
+				return;
+			}
+			setStatusChangeItems( items );
+		},
+		[ isChangingStatus, isDeleting ]
+	);
+
+	const closeChangeStatusModal = useCallback( () => {
+		setStatusChangeItems( null );
+	}, [] );
+
+	const handleConfirmChangeStatus = useCallback(
+		async ( nextStatus: string ) => {
+			if ( ! statusChangeItems?.length ) {
+				return;
+			}
+			try {
+				await changeFormStatus( statusChangeItems, nextStatus );
+			} finally {
+				setSelection( [] );
+			}
+		},
+		[ changeFormStatus, statusChangeItems ]
+	);
 
 	const handleRename = useCallback(
 		async ( newTitle: string ) => {
@@ -226,6 +266,18 @@ function StageInner() {
 		},
 		[ renameFormItem, saveEntityRecord, createSuccessNotice, createErrorNotice ]
 	);
+
+	const statusChangeInitialStatus = useMemo( () => {
+		if ( ! statusChangeItems?.length ) {
+			return undefined;
+		}
+		const firstStatus = statusChangeItems[ 0 ]?.status;
+		if ( ! firstStatus ) {
+			return undefined;
+		}
+		const allSame = statusChangeItems.every( item => item.status === firstStatus );
+		return allSame ? firstStatus : undefined;
+	}, [ statusChangeItems ] );
 
 	const statusLabel = useCallback( ( status: string ) => {
 		switch ( status ) {
@@ -420,6 +472,17 @@ function StageInner() {
 				},
 			} );
 		}
+
+		actionsList.push( {
+			id: 'change-status',
+			isPrimary: false,
+			label: __( 'Change status', 'jetpack-forms' ),
+			supportsBulk: true,
+			callback( items: FormListItem[] ) {
+				openChangeStatusModal( items );
+			},
+		} );
+
 		actionsList.push( {
 			id: 'rename-form',
 			isPrimary: false,
@@ -459,6 +522,7 @@ function StageInner() {
 		isDeleting,
 		isViewingTrash,
 		onOpenPermanentDeleteConfirm,
+		openChangeStatusModal,
 		openRenameModal,
 		openSingleFormView,
 		previewForm,
@@ -602,6 +666,13 @@ function StageInner() {
 				onSave={ handleRename }
 				title={ __( 'Rename form', 'jetpack-forms' ) }
 				initialValue={ renameRetryRef.current?.title || renameFormItem?.title || '' }
+			/>
+			<ChangeFormStatusModal
+				isOpen={ !! statusChangeItems?.length }
+				itemsCount={ statusChangeItems?.length || 0 }
+				initialStatus={ statusChangeInitialStatus }
+				onClose={ closeChangeStatusModal }
+				onConfirm={ handleConfirmChangeStatus }
 			/>
 			<IntegrationsModal
 				isOpen={ isIntegrationsModalOpen }

--- a/projects/packages/forms/src/dashboard/hooks/use-forms-data.ts
+++ b/projects/packages/forms/src/dashboard/hooks/use-forms-data.ts
@@ -11,6 +11,20 @@ export type FormListItem = {
 	editUrl?: string;
 };
 
+let lastFormsListQuery: Record< string, unknown > | null = null;
+
+/**
+ * Get the most recent Forms list query used by this module.
+ *
+ * This is used by other dashboard actions (e.g. status changes from outside the list)
+ * to invalidate the exact `getEntityRecords` resolution key.
+ *
+ * @return The last query object, or null if none has been set yet.
+ */
+export function getLastFormsListQuery(): Record< string, unknown > | null {
+	return lastFormsListQuery;
+}
+
 /**
  * Build the query object for fetching Forms list records from core-data.
  *
@@ -74,6 +88,8 @@ export default function useFormsData(
 	const query = useMemo( () => {
 		return getFormsListQuery( page, perPage, search, status );
 	}, [ page, perPage, search, status ] );
+
+	lastFormsListQuery = query;
 
 	const {
 		records: rawRecords,

--- a/projects/packages/forms/src/dashboard/wp-build/components/change-form-status-modal/index.tsx
+++ b/projects/packages/forms/src/dashboard/wp-build/components/change-form-status-modal/index.tsx
@@ -4,6 +4,10 @@
 import { Button, Modal, SelectControl } from '@wordpress/components';
 import { useCallback, useEffect, useMemo, useState } from '@wordpress/element';
 import { __, _n, sprintf } from '@wordpress/i18n';
+/**
+ * Internal dependencies
+ */
+import './style.scss';
 
 type StatusOption = {
 	label: string;
@@ -107,7 +111,7 @@ export default function ChangeFormStatusModal( props: ChangeFormStatusModalProps
 				__next40pxDefaultSize
 				disabled={ isSaving }
 			/>
-			<div className="jp-forms-name-modal__buttons">
+			<div className="jp-forms-change-status-modal__buttons">
 				<Button variant="tertiary" onClick={ handleClose } disabled={ isSaving }>
 					{ __( 'Cancel', 'jetpack-forms' ) }
 				</Button>

--- a/projects/packages/forms/src/dashboard/wp-build/components/change-form-status-modal/index.tsx
+++ b/projects/packages/forms/src/dashboard/wp-build/components/change-form-status-modal/index.tsx
@@ -1,0 +1,126 @@
+/**
+ * WordPress dependencies
+ */
+import { Button, Modal, SelectControl } from '@wordpress/components';
+import { useCallback, useEffect, useMemo, useState } from '@wordpress/element';
+import { __, _n, sprintf } from '@wordpress/i18n';
+
+type StatusOption = {
+	label: string;
+	value: string;
+};
+
+export type ChangeFormStatusModalProps = {
+	isOpen: boolean;
+	itemsCount: number;
+	initialStatus?: string;
+	statusOptions?: StatusOption[];
+	onClose: () => void;
+	onConfirm: ( nextStatus: string ) => Promise< void >;
+};
+
+const DEFAULT_STATUS_OPTIONS: StatusOption[] = [
+	{ label: __( 'Published', 'jetpack-forms' ), value: 'publish' },
+	{ label: __( 'Draft', 'jetpack-forms' ), value: 'draft' },
+	{ label: __( 'Private', 'jetpack-forms' ), value: 'private' },
+	{ label: __( 'Pending review', 'jetpack-forms' ), value: 'pending' },
+];
+
+/**
+ * Modal for changing the status of one or more forms.
+ *
+ * @param props - Component props.
+ * @return The modal element, or null when closed.
+ */
+export default function ChangeFormStatusModal( props: ChangeFormStatusModalProps ) {
+	const { isOpen, itemsCount, initialStatus, statusOptions, onClose, onConfirm } = props;
+	const options = useMemo( () => statusOptions || DEFAULT_STATUS_OPTIONS, [ statusOptions ] );
+	const [ selectedStatus, setSelectedStatus ] = useState(
+		initialStatus || options[ 0 ]?.value || ''
+	);
+	const [ isSaving, setIsSaving ] = useState( false );
+
+	useEffect( () => {
+		if ( isOpen ) {
+			setSelectedStatus( initialStatus || options[ 0 ]?.value || '' );
+		}
+	}, [ initialStatus, isOpen, options ] );
+
+	const title = useMemo( () => {
+		return itemsCount === 1
+			? __( 'Change status', 'jetpack-forms' )
+			: sprintf(
+					/* translators: %d: number of forms. */
+					_n(
+						'Change status for %d form',
+						'Change status for %d forms',
+						itemsCount,
+						'jetpack-forms'
+					),
+					itemsCount
+			  );
+	}, [ itemsCount ] );
+
+	const isConfirmDisabled = useMemo( () => {
+		if ( ! selectedStatus ) {
+			return true;
+		}
+		if ( isSaving ) {
+			return true;
+		}
+		return itemsCount === 1 && initialStatus && selectedStatus === initialStatus;
+	}, [ initialStatus, isSaving, itemsCount, selectedStatus ] );
+
+	const handleClose = useCallback( () => {
+		if ( ! isSaving ) {
+			onClose();
+		}
+	}, [ isSaving, onClose ] );
+
+	const handleConfirm = useCallback( async () => {
+		if ( isConfirmDisabled ) {
+			return;
+		}
+
+		setIsSaving( true );
+		try {
+			await onConfirm( selectedStatus );
+			onClose();
+		} catch {
+			// Error handling is delegated to the caller; keep modal open for retry.
+		} finally {
+			setIsSaving( false );
+		}
+	}, [ isConfirmDisabled, onClose, onConfirm, selectedStatus ] );
+
+	if ( ! isOpen ) {
+		return null;
+	}
+
+	return (
+		<Modal title={ title } onRequestClose={ handleClose } size="medium">
+			<SelectControl
+				label={ __( 'New status', 'jetpack-forms' ) }
+				value={ selectedStatus }
+				options={ options }
+				onChange={ setSelectedStatus }
+				__next40pxDefaultSize
+				disabled={ isSaving }
+			/>
+			<div className="jp-forms-name-modal__buttons">
+				<Button variant="tertiary" onClick={ handleClose } disabled={ isSaving }>
+					{ __( 'Cancel', 'jetpack-forms' ) }
+				</Button>
+				<Button
+					aria-disabled={ isConfirmDisabled }
+					disabled={ isConfirmDisabled }
+					isBusy={ isSaving }
+					variant="primary"
+					onClick={ handleConfirm }
+				>
+					{ __( 'Apply', 'jetpack-forms' ) }
+				</Button>
+			</div>
+		</Modal>
+	);
+}

--- a/projects/packages/forms/src/dashboard/wp-build/components/change-form-status-modal/style.scss
+++ b/projects/packages/forms/src/dashboard/wp-build/components/change-form-status-modal/style.scss
@@ -1,0 +1,7 @@
+.jp-forms-change-status-modal__buttons {
+	display: flex;
+	justify-content: flex-end;
+	gap: 8px;
+	margin-top: 16px;
+}
+

--- a/projects/packages/forms/src/dashboard/wp-build/hooks/use-change-form-status.ts
+++ b/projects/packages/forms/src/dashboard/wp-build/hooks/use-change-form-status.ts
@@ -1,0 +1,184 @@
+/**
+ * WordPress dependencies
+ */
+import { useDispatch } from '@wordpress/data';
+import { useCallback, useMemo, useState } from '@wordpress/element';
+import { __, _n, sprintf } from '@wordpress/i18n';
+import { store as noticesStore } from '@wordpress/notices';
+/**
+ * Internal dependencies
+ */
+import { FORM_POST_TYPE } from '../../../blocks/shared/util/constants.js';
+import { getFormsListQuery } from '../../hooks/use-forms-data.ts';
+/**
+ * Types
+ */
+import type { FormListItem } from '../../hooks/use-forms-data.ts';
+import type { View } from '@wordpress/dataviews/wp';
+
+type CoreDispatch = {
+	saveEntityRecord: (
+		kind: string,
+		name: string,
+		record: Record< string, unknown >,
+		options?: { throwOnError?: boolean }
+	) => Promise< unknown >;
+	invalidateResolution: ( selector: string, args: unknown[] ) => void;
+};
+
+type UseChangeFormStatusArgs = {
+	view: View;
+	setView: ( newView: View ) => void;
+	recordsLength: number;
+	statusQuery: string;
+};
+
+type UseChangeFormStatusReturn = {
+	isChangingStatus: boolean;
+	changeFormStatus: ( items: FormListItem[], nextStatus: string ) => Promise< void >;
+};
+
+/**
+ * Bulk-change form post statuses from the wp-build Forms list.
+ *
+ * Handles saving via core-data, notices, pagination edge cases, and invalidating list queries.
+ *
+ * @param args - Hook arguments.
+ * @return Hook state and change handler.
+ */
+export default function useChangeFormStatus(
+	args: UseChangeFormStatusArgs
+): UseChangeFormStatusReturn {
+	const { view, setView, recordsLength, statusQuery } = args;
+	const [ isChangingStatus, setIsChangingStatus ] = useState( false );
+	const { saveEntityRecord, invalidateResolution } = useDispatch( 'core' ) as CoreDispatch;
+	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
+
+	const page = view.page ?? 1;
+	const perPage = view.perPage ?? 20;
+	const search = view.search ?? '';
+
+	const currentQuery = useMemo(
+		() => getFormsListQuery( page, perPage, search, statusQuery ),
+		[ page, perPage, search, statusQuery ]
+	);
+
+	const invalidateListQueries = useCallback(
+		( query: Record< string, unknown > ) => {
+			invalidateResolution( 'getEntityRecords', [ 'postType', FORM_POST_TYPE, query ] );
+			invalidateResolution( 'getEntityRecords', [
+				'postType',
+				FORM_POST_TYPE,
+				{ ...query, per_page: 1, _fields: 'id' },
+			] );
+		},
+		[ invalidateResolution ]
+	);
+
+	const changeFormStatus = useCallback(
+		async ( items: FormListItem[], nextStatus: string ) => {
+			if ( isChangingStatus || ! items?.length || ! nextStatus ) {
+				return;
+			}
+
+			setIsChangingStatus( true );
+
+			const currentQuerySnapshot = currentQuery as Record< string, unknown >;
+			const isSingleStatusView = typeof statusQuery === 'string' && ! statusQuery.includes( ',' );
+			let shouldNavigateToPreviousPage = false;
+
+			try {
+				const promises = await Promise.allSettled(
+					items.map( item =>
+						saveEntityRecord(
+							'postType',
+							FORM_POST_TYPE,
+							{ id: item.id, status: nextStatus },
+							{ throwOnError: true }
+						)
+					)
+				);
+
+				const updatedCount = promises.filter( p => p.status === 'fulfilled' ).length;
+				const failedCount = promises.length - updatedCount;
+
+				if ( updatedCount ) {
+					shouldNavigateToPreviousPage =
+						isSingleStatusView &&
+						page > 1 &&
+						nextStatus !== statusQuery &&
+						updatedCount >= recordsLength;
+
+					const successMessage =
+						updatedCount === 1
+							? __( 'Status updated.', 'jetpack-forms' )
+							: sprintf(
+									/* translators: %d: number of forms. */
+									_n(
+										'Status updated for %d form.',
+										'Status updated for %d forms.',
+										updatedCount,
+										'jetpack-forms'
+									),
+									updatedCount
+							  );
+
+					createSuccessNotice( successMessage, {
+						type: 'snackbar',
+						id: `change-form-status-${ Date.now() }`,
+					} );
+
+					if ( shouldNavigateToPreviousPage ) {
+						setView( { ...view, page: page - 1 } );
+					}
+				}
+
+				if ( failedCount ) {
+					createErrorNotice(
+						sprintf(
+							/* translators: %d: number of forms. */
+							_n(
+								'Could not update status for %d form.',
+								'Could not update status for %d forms.',
+								failedCount,
+								'jetpack-forms'
+							),
+							failedCount
+						),
+						{
+							type: 'snackbar',
+							id: `change-form-status-error-${ Date.now() }`,
+						}
+					);
+				}
+			} finally {
+				setIsChangingStatus( false );
+
+				// Invalidate the current list query so updated forms move in/out of filtered views and totals refresh.
+				invalidateListQueries( currentQuerySnapshot );
+				if ( shouldNavigateToPreviousPage ) {
+					invalidateListQueries(
+						getFormsListQuery( page - 1, perPage, search, statusQuery ) as Record< string, unknown >
+					);
+				}
+			}
+		},
+		[
+			currentQuery,
+			createErrorNotice,
+			createSuccessNotice,
+			invalidateListQueries,
+			isChangingStatus,
+			page,
+			perPage,
+			recordsLength,
+			saveEntityRecord,
+			search,
+			setView,
+			statusQuery,
+			view,
+		]
+	);
+
+	return { isChangingStatus, changeFormStatus };
+}

--- a/projects/packages/forms/src/dashboard/wp-build/hooks/use-change-form-status.ts
+++ b/projects/packages/forms/src/dashboard/wp-build/hooks/use-change-form-status.ts
@@ -1,30 +1,19 @@
 /**
  * WordPress dependencies
  */
-import { useDispatch } from '@wordpress/data';
-import { useCallback, useMemo, useState } from '@wordpress/element';
-import { __, _n, sprintf } from '@wordpress/i18n';
-import { store as noticesStore } from '@wordpress/notices';
+import { useCallback, useMemo } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import { FORM_POST_TYPE } from '../../../blocks/shared/util/constants.js';
 import { getFormsListQuery } from '../../hooks/use-forms-data.ts';
+import useUpdateFormStatus from './use-update-form-status';
 /**
  * Types
  */
 import type { FormListItem } from '../../hooks/use-forms-data.ts';
 import type { View } from '@wordpress/dataviews/wp';
 
-type CoreDispatch = {
-	saveEntityRecord: (
-		kind: string,
-		name: string,
-		record: Record< string, unknown >,
-		options?: { throwOnError?: boolean }
-	) => Promise< unknown >;
-	invalidateResolution: ( selector: string, args: unknown[] ) => void;
-};
+type StatusChangeItem = Pick< FormListItem, 'id' >;
 
 type UseChangeFormStatusArgs = {
 	view: View;
@@ -35,11 +24,11 @@ type UseChangeFormStatusArgs = {
 
 type UseChangeFormStatusReturn = {
 	isChangingStatus: boolean;
-	changeFormStatus: ( items: FormListItem[], nextStatus: string ) => Promise< void >;
+	changeFormStatus: ( items: StatusChangeItem[], nextStatus: string ) => Promise< void >;
 };
 
 /**
- * Bulk-change form post statuses from the wp-build Forms list.
+ * Change one or more managed form post statuses from the Forms list.
  *
  * Handles saving via core-data, notices, pagination edge cases, and invalidating list queries.
  *
@@ -50,9 +39,8 @@ export default function useChangeFormStatus(
 	args: UseChangeFormStatusArgs
 ): UseChangeFormStatusReturn {
 	const { view, setView, recordsLength, statusQuery } = args;
-	const [ isChangingStatus, setIsChangingStatus ] = useState( false );
-	const { saveEntityRecord, invalidateResolution } = useDispatch( 'core' ) as CoreDispatch;
-	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
+
+	const { isUpdating, updateStatus } = useUpdateFormStatus();
 
 	const page = view.page ?? 1;
 	const perPage = view.perPage ?? 20;
@@ -63,122 +51,53 @@ export default function useChangeFormStatus(
 		[ page, perPage, search, statusQuery ]
 	);
 
-	const invalidateListQueries = useCallback(
-		( query: Record< string, unknown > ) => {
-			invalidateResolution( 'getEntityRecords', [ 'postType', FORM_POST_TYPE, query ] );
-			invalidateResolution( 'getEntityRecords', [
-				'postType',
-				FORM_POST_TYPE,
-				{ ...query, per_page: 1, _fields: 'id' },
-			] );
-		},
-		[ invalidateResolution ]
-	);
-
 	const changeFormStatus = useCallback(
-		async ( items: FormListItem[], nextStatus: string ) => {
-			if ( isChangingStatus || ! items?.length || ! nextStatus ) {
+		async ( items: StatusChangeItem[], nextStatus: string ) => {
+			if ( isUpdating || ! items?.length || ! nextStatus ) {
 				return;
 			}
 
-			setIsChangingStatus( true );
-
-			const currentQuerySnapshot = currentQuery as Record< string, unknown >;
-			const isSingleStatusView = typeof statusQuery === 'string' && ! statusQuery.includes( ',' );
 			let shouldNavigateToPreviousPage = false;
 
 			try {
-				const promises = await Promise.allSettled(
-					items.map( item =>
-						saveEntityRecord(
-							'postType',
-							FORM_POST_TYPE,
-							{ id: item.id, status: nextStatus },
-							{ throwOnError: true }
-						)
-					)
-				);
-
-				const updatedCount = promises.filter( p => p.status === 'fulfilled' ).length;
-				const failedCount = promises.length - updatedCount;
-
-				if ( updatedCount ) {
-					shouldNavigateToPreviousPage =
-						isSingleStatusView &&
-						page > 1 &&
-						nextStatus !== statusQuery &&
-						updatedCount >= recordsLength;
-
-					const successMessage =
-						updatedCount === 1
-							? __( 'Status updated.', 'jetpack-forms' )
-							: sprintf(
-									/* translators: %d: number of forms. */
-									_n(
-										'Status updated for %d form.',
-										'Status updated for %d forms.',
-										updatedCount,
-										'jetpack-forms'
-									),
-									updatedCount
-							  );
-
-					createSuccessNotice( successMessage, {
-						type: 'snackbar',
-						id: `change-form-status-${ Date.now() }`,
-					} );
-
-					if ( shouldNavigateToPreviousPage ) {
-						setView( { ...view, page: page - 1 } );
-					}
-				}
-
-				if ( failedCount ) {
-					createErrorNotice(
-						sprintf(
-							/* translators: %d: number of forms. */
-							_n(
-								'Could not update status for %d form.',
-								'Could not update status for %d forms.',
-								failedCount,
-								'jetpack-forms'
-							),
-							failedCount
-						),
-						{
-							type: 'snackbar',
-							id: `change-form-status-error-${ Date.now() }`,
-						}
-					);
-				}
-			} finally {
-				setIsChangingStatus( false );
-
-				// Invalidate the current list query so updated forms move in/out of filtered views and totals refresh.
-				invalidateListQueries( currentQuerySnapshot );
-				if ( shouldNavigateToPreviousPage ) {
-					invalidateListQueries(
+				const invalidateQueries: Array< Record< string, unknown > > = [
+					currentQuery as Record< string, unknown >,
+				];
+				if ( page > 1 ) {
+					invalidateQueries.push(
 						getFormsListQuery( page - 1, perPage, search, statusQuery ) as Record< string, unknown >
 					);
 				}
+
+				const { updatedCount } = await updateStatus( items, nextStatus, { invalidateQueries } );
+
+				const isSingleStatusView = typeof statusQuery === 'string' && ! statusQuery.includes( ',' );
+				shouldNavigateToPreviousPage =
+					isSingleStatusView &&
+					page > 1 &&
+					nextStatus !== statusQuery &&
+					updatedCount >= recordsLength;
+
+				if ( shouldNavigateToPreviousPage ) {
+					setView( { ...view, page: page - 1 } );
+				}
+			} finally {
+				// Notices and invalidation are handled in `useUpdateFormStatus`.
 			}
 		},
 		[
 			currentQuery,
-			createErrorNotice,
-			createSuccessNotice,
-			invalidateListQueries,
-			isChangingStatus,
+			isUpdating,
 			page,
 			perPage,
 			recordsLength,
-			saveEntityRecord,
 			search,
 			setView,
 			statusQuery,
+			updateStatus,
 			view,
 		]
 	);
 
-	return { isChangingStatus, changeFormStatus };
+	return { isChangingStatus: isUpdating, changeFormStatus };
 }

--- a/projects/packages/forms/src/dashboard/wp-build/hooks/use-page-header-details.tsx
+++ b/projects/packages/forms/src/dashboard/wp-build/hooks/use-page-header-details.tsx
@@ -152,11 +152,6 @@ export default function usePageHeaderDetails(
 		const formItem = { id: sourceIdNumber, title: formTitle };
 		const controls: Array< { title: string; onClick: () => void; isDisabled?: boolean } > = [
 			{
-				title: __( 'Change status…', 'jetpack-forms' ),
-				onClick: openChangeStatusModal,
-				isDisabled: isChangingStatus,
-			},
-			{
 				title: __( 'Duplicate', 'jetpack-forms' ),
 				onClick: () => duplicateForm( formItem ),
 			},
@@ -178,6 +173,12 @@ export default function usePageHeaderDetails(
 				}
 			);
 		}
+
+		controls.push( {
+			title: __( 'Change status', 'jetpack-forms' ),
+			onClick: openChangeStatusModal,
+			isDisabled: isChangingStatus,
+		} );
 
 		return controls;
 	}, [

--- a/projects/packages/forms/src/dashboard/wp-build/hooks/use-page-header-details.tsx
+++ b/projects/packages/forms/src/dashboard/wp-build/hooks/use-page-header-details.tsx
@@ -7,7 +7,7 @@ import { Breadcrumbs } from '@wordpress/admin-ui';
 import { DropdownMenu, Button } from '@wordpress/components';
 import { store as coreDataStore } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
-import { useMemo } from '@wordpress/element';
+import { useCallback, useMemo, useState } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
 import { __, sprintf } from '@wordpress/i18n';
 import { moreVertical } from '@wordpress/icons';
@@ -28,8 +28,10 @@ import useEmptySpam from '../../hooks/use-empty-spam';
 import useEmptyTrash from '../../hooks/use-empty-trash';
 import useExportResponses from '../../hooks/use-export-responses';
 import useInboxData from '../../hooks/use-inbox-data';
+import ChangeFormStatusModal from '../components/change-form-status-modal';
 import ManageIntegrationsButton from '../components/manage-integrations-button';
 import useFormItemActions from './use-form-item-actions';
+import useUpdateFormStatus from './use-update-form-status';
 import type { ReactNode } from 'react';
 
 type ResponsesStatusView = 'inbox' | 'spam' | 'trash';
@@ -110,7 +112,7 @@ export default function usePageHeaderDetails(
 						'postType',
 						'jetpack_form',
 						sourceIdNumber
-				  ) as { title?: { rendered?: string } } | undefined )
+				  ) as { title?: { rendered?: string }; status?: string } | undefined )
 				: undefined,
 		[ sourceIdNumber ]
 	);
@@ -120,7 +122,27 @@ export default function usePageHeaderDetails(
 		return decodeEntities( rendered );
 	}, [ formRecord?.title?.rendered ] );
 
+	const formStatus = formRecord?.status;
+
 	const { duplicateForm, previewForm, copyEmbed, copyShortcode } = useFormItemActions();
+
+	const [ isChangeStatusModalOpen, setIsChangeStatusModalOpen ] = useState( false );
+	const openChangeStatusModal = useCallback( () => setIsChangeStatusModalOpen( true ), [] );
+	const closeChangeStatusModal = useCallback( () => setIsChangeStatusModalOpen( false ), [] );
+
+	const { isUpdating: isChangingStatus, updateStatus } = useUpdateFormStatus();
+
+	const handleConfirmChangeStatus = useCallback(
+		async ( nextStatus: string ) => {
+			if ( ! sourceIdNumber ) {
+				return;
+			}
+			await updateStatus( [ { id: sourceIdNumber } ], nextStatus, {
+				invalidateLastFormsListQuery: true,
+			} );
+		},
+		[ sourceIdNumber, updateStatus ]
+	);
 
 	const formItemControls = useMemo( () => {
 		if ( ! sourceIdNumber ) {
@@ -128,7 +150,12 @@ export default function usePageHeaderDetails(
 		}
 
 		const formItem = { id: sourceIdNumber, title: formTitle };
-		const controls: Array< { title: string; onClick: () => void } > = [
+		const controls: Array< { title: string; onClick: () => void; isDisabled?: boolean } > = [
+			{
+				title: __( 'Change status…', 'jetpack-forms' ),
+				onClick: openChangeStatusModal,
+				isDisabled: isChangingStatus,
+			},
 			{
 				title: __( 'Duplicate', 'jetpack-forms' ),
 				onClick: () => duplicateForm( formItem ),
@@ -153,7 +180,39 @@ export default function usePageHeaderDetails(
 		}
 
 		return controls;
-	}, [ sourceIdNumber, formTitle, duplicateForm, previewForm, copyEmbed, copyShortcode ] );
+	}, [
+		sourceIdNumber,
+		formTitle,
+		duplicateForm,
+		previewForm,
+		copyEmbed,
+		copyShortcode,
+		openChangeStatusModal,
+		isChangingStatus,
+	] );
+
+	const changeStatusModal = useMemo( () => {
+		if ( ! isSingleFormScreen || ! sourceIdNumber ) {
+			return null;
+		}
+		return (
+			<ChangeFormStatusModal
+				key="change-status-modal"
+				isOpen={ isChangeStatusModalOpen }
+				itemsCount={ 1 }
+				initialStatus={ typeof formStatus === 'string' ? formStatus : undefined }
+				onClose={ closeChangeStatusModal }
+				onConfirm={ handleConfirmChangeStatus }
+			/>
+		);
+	}, [
+		closeChangeStatusModal,
+		formStatus,
+		handleConfirmChangeStatus,
+		isChangeStatusModalOpen,
+		isSingleFormScreen,
+		sourceIdNumber,
+	] );
 
 	const breadcrumbsItems = useMemo( () => {
 		if ( isSingleFormScreen ) {
@@ -314,6 +373,7 @@ export default function usePageHeaderDetails(
 					toggleProps={ { size: 'compact' } }
 				/>,
 				// Include modals when on mobile
+				changeStatusModal,
 				...( showExportModal
 					? [
 							<ExportResponsesModal
@@ -384,6 +444,7 @@ export default function usePageHeaderDetails(
 							/>,
 					  ]
 					: [] ),
+				changeStatusModal,
 			];
 		}
 
@@ -419,6 +480,7 @@ export default function usePageHeaderDetails(
 		isFormsScreen,
 		isSingleFormScreen,
 		formItemControls,
+		changeStatusModal,
 		statusView,
 		openNewForm,
 		openExportModal,

--- a/projects/packages/forms/src/dashboard/wp-build/hooks/use-update-form-status.ts
+++ b/projects/packages/forms/src/dashboard/wp-build/hooks/use-update-form-status.ts
@@ -1,0 +1,171 @@
+/**
+ * WordPress dependencies
+ */
+import { useDispatch } from '@wordpress/data';
+import { useCallback, useState } from '@wordpress/element';
+import { __, _n, sprintf } from '@wordpress/i18n';
+import { store as noticesStore } from '@wordpress/notices';
+/**
+ * Internal dependencies
+ */
+import { FORM_POST_TYPE } from '../../../blocks/shared/util/constants.js';
+import { NON_TRASH_FORM_STATUSES } from '../../constants';
+import { getFormsListQuery, getLastFormsListQuery } from '../../hooks/use-forms-data.ts';
+/**
+ * Types
+ */
+import type { FormListItem } from '../../hooks/use-forms-data.ts';
+
+type CoreDispatch = {
+	saveEntityRecord: (
+		kind: string,
+		name: string,
+		record: Record< string, unknown >,
+		options?: { throwOnError?: boolean }
+	) => Promise< unknown >;
+	invalidateResolution: ( selector: string, args: unknown[] ) => void;
+};
+
+type StatusChangeItem = Pick< FormListItem, 'id' >;
+
+type UpdateFormStatusOptions = {
+	/**
+	 * List queries to invalidate (exact query objects used with `useEntityRecords`).
+	 */
+	invalidateQueries?: Array< Record< string, unknown > >;
+	/**
+	 * When true, also invalidates the most recent Forms list query tracked by `useFormsData`.
+	 * Useful when changing status outside the list (e.g. single-form header).
+	 */
+	invalidateLastFormsListQuery?: boolean;
+};
+
+type UseUpdateFormStatusReturn = {
+	isUpdating: boolean;
+	updateStatus: (
+		items: StatusChangeItem[],
+		nextStatus: string,
+		options?: UpdateFormStatusOptions
+	) => Promise< { updatedCount: number; failedCount: number } >;
+};
+
+/**
+ * Update the status of one or more managed forms.
+ *
+ * Handles saving via core-data, notices, and invalidating affected entity records/list queries.
+ *
+ * @return Hook state and update handler.
+ */
+export default function useUpdateFormStatus(): UseUpdateFormStatusReturn {
+	const [ isUpdating, setIsUpdating ] = useState( false );
+	const { saveEntityRecord, invalidateResolution } = useDispatch( 'core' ) as CoreDispatch;
+	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
+
+	const invalidateListQuery = useCallback(
+		( query: Record< string, unknown > ) => {
+			invalidateResolution( 'getEntityRecords', [ 'postType', FORM_POST_TYPE, query ] );
+			invalidateResolution( 'getEntityRecords', [
+				'postType',
+				FORM_POST_TYPE,
+				{ ...query, per_page: 1, _fields: 'id' },
+			] );
+		},
+		[ invalidateResolution ]
+	);
+
+	const updateStatus = useCallback(
+		async (
+			items: StatusChangeItem[],
+			nextStatus: string,
+			options: UpdateFormStatusOptions = {}
+		): Promise< { updatedCount: number; failedCount: number } > => {
+			if ( isUpdating || ! items?.length || ! nextStatus ) {
+				return { updatedCount: 0, failedCount: items?.length ?? 0 };
+			}
+
+			setIsUpdating( true );
+
+			try {
+				const promises = await Promise.allSettled(
+					items.map( item =>
+						saveEntityRecord(
+							'postType',
+							FORM_POST_TYPE,
+							{ id: item.id, status: nextStatus },
+							{ throwOnError: true }
+						)
+					)
+				);
+
+				const updatedCount = promises.filter( p => p.status === 'fulfilled' ).length;
+				const failedCount = promises.length - updatedCount;
+
+				if ( updatedCount ) {
+					const successMessage =
+						updatedCount === 1
+							? __( 'Status updated.', 'jetpack-forms' )
+							: sprintf(
+									/* translators: %d: number of forms. */
+									_n(
+										'Status updated for %d form.',
+										'Status updated for %d forms.',
+										updatedCount,
+										'jetpack-forms'
+									),
+									updatedCount
+							  );
+					createSuccessNotice( successMessage, { type: 'snackbar' } );
+				}
+
+				if ( failedCount ) {
+					createErrorNotice(
+						sprintf(
+							/* translators: %d: number of forms. */
+							_n(
+								'Could not update status for %d form.',
+								'Could not update status for %d forms.',
+								failedCount,
+								'jetpack-forms'
+							),
+							failedCount
+						),
+						{ type: 'snackbar' }
+					);
+				}
+
+				// Always invalidate updated items.
+				items.forEach( item => {
+					invalidateResolution( 'getEntityRecord', [ 'postType', FORM_POST_TYPE, item.id ] );
+				} );
+
+				// Invalidate provided list queries (exact objects).
+				( options.invalidateQueries || [] ).forEach( invalidateListQuery );
+
+				if ( options.invalidateLastFormsListQuery ) {
+					const lastQuery = getLastFormsListQuery();
+					if ( lastQuery ) {
+						invalidateListQuery( lastQuery );
+					} else {
+						invalidateListQuery(
+							getFormsListQuery( 1, 20, '', NON_TRASH_FORM_STATUSES ) as Record< string, unknown >
+						);
+					}
+				}
+
+				return { updatedCount, failedCount };
+			} finally {
+				setIsUpdating( false );
+			}
+		},
+		[
+			createErrorNotice,
+			createSuccessNotice,
+			invalidateListQuery,
+			invalidateResolution,
+			isUpdating,
+			saveEntityRecord,
+		]
+	);
+
+	return { isUpdating, updateStatus };
+}


### PR DESCRIPTION
## Proposed changes:

Adds a **“Change status”** action to the new wp-build Forms dashboard, allowing users to quickly update a managed form’s post status (Published/Draft/Private/Pending review) via a modal (single and bulk). Scheduled is intentionally not offered as a target status in this first pass.

### Implementation notes
- Adds `ChangeFormStatusModal`, `useUpdateFormStatus` (shared status updates) and `useChangeFormStatus` (Forms list integration) to handle bulk updates, notices, and list refresh/invalidation.

**Screenshots**
<img width="1327" height="698" alt="change-status-action" src="https://github.com/user-attachments/assets/d48216a7-8954-423d-8636-8b0db364b7fc" />

<img width="1330" height="708" alt="change-status-modal" src="https://github.com/user-attachments/assets/e95c61ac-9a0f-476d-9f4d-11af10ce7c61" />

<img width="1332" height="433" alt="single-form-change-status2" src="https://github.com/user-attachments/assets/a9bb187b-c548-4633-936c-aaf1de5bc4de" />

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Enable these feature flags:
