### PR TITLE
Forms: Fix duplicate title in plain text email

### DIFF
--- a/projects/packages/forms/changelog/pr-47291
+++ b/projects/packages/forms/changelog/pr-47291
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix duplicate title in plain text email by removing the preheader element before generating plain text alternative.

--- a/projects/packages/forms/src/contact-form/class-feedback-email-renderer.php
+++ b/projects/packages/forms/src/contact-form/class-feedback-email-renderer.php
@@ -497,8 +497,11 @@ class Feedback_Email_Renderer {
 	public static function add_plain_text_alternative( $phpmailer ) {
 		// phpcs:disable WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 
+		// Remove the preheader (hidden email preview text) so it doesn't duplicate the title in plain text.
+		$alt_body = preg_replace( '/<span class="preheader">.*?<\/span>/s', '', $phpmailer->Body );
+
 		// Add an extra break so that the extra space above the <p> is preserved after the <p> is stripped out.
-		$alt_body = str_replace( '<p>', '<p><br />', $phpmailer->Body );
+		$alt_body = str_replace( '<p>', '<p><br />', $alt_body );
 
 		// Convert <br> to \n breaks, to preserve the space between lines that we want to keep.
 		$alt_body = str_replace( array( '<br>', '<br />' ), "\n", $alt_body );

--- a/projects/plugins/jetpack/changelog/pr-47291
+++ b/projects/plugins/jetpack/changelog/pr-47291
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Forms: Fix duplicate title in plain text form submission notification emails.


### PR DESCRIPTION
## Proposed changes:

* Remove the preheader element (hidden email preview text) before generating the plain text alternative of form submission emails. The preheader duplicates the email title, causing it to appear twice in the plain text version.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

1. Submit a form on a Jetpack site with the Forms package
2. View the notification email raw source and check the plain text alternative (`Content-Type: text/plain`)
3. The title ("Hey, a new form response just came in!") should appear only once

## Changelog

- [x] Generate changelog entries for this PR (using AI).
