### PR TITLE
Full Sync: Store last_item in status

### DIFF
--- a/projects/packages/sync/changelog/pr-47292
+++ b/projects/packages/sync/changelog/pr-47292
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Full Sync: Store last_item in status to avoid re-running an expensive query on every invocation.

--- a/projects/packages/sync/src/modules/class-module.php
+++ b/projects/packages/sync/src/modules/class-module.php
@@ -437,7 +437,12 @@ abstract class Module {
 
 		$chunks_sent = 0;
 
-		$last_item = $this->get_last_item( $config );
+		// Store last_item in status to avoid re-running this expensive query on every invocation.
+		// The minimum ID does not change during a Full Sync.
+		if ( ! isset( $status['last_item'] ) ) {
+			$status['last_item'] = $this->get_last_item( $config );
+		}
+		$last_item = $status['last_item'];
 
 		while ( $chunks_sent < $limits['max_chunks'] && microtime( true ) < $send_until ) {
 			$objects = $this->get_next_chunk( $config, $status, $limits['chunk_size'] );

--- a/projects/plugins/jetpack/changelog/pr-47292
+++ b/projects/plugins/jetpack/changelog/pr-47292
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Sync: Store last_item in status to improve Full Sync performance.

--- a/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Full_Immediately_Test.php
+++ b/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Full_Immediately_Test.php
@@ -1403,4 +1403,40 @@ class Jetpack_Sync_Full_Immediately_Test extends Jetpack_Sync_TestBase {
 	public function count_before_module_sync_start() {
 		$this->before_module_sync_count += 1;
 	}
+
+	/**
+	 * Test that get_last_item result is stored in module progress status
+	 * and reused across subsequent full sync invocations.
+	 */
+	public function test_full_sync_stores_last_item_in_status() {
+		self::factory()->post->create_many( 5 );
+
+		// Use chunk_size=1, max_chunks=1 so the sync needs multiple rounds.
+		$limits          = \Automattic\Jetpack\Sync\Defaults::$default_full_sync_limits;
+		$limits['posts'] = array(
+			'chunk_size' => 1,
+			'max_chunks' => 1,
+		);
+		Settings::update_settings( array( 'full_sync_limits' => $limits ) );
+
+		$this->full_sync->start( array( 'posts' => true ) );
+		$this->sender->do_full_sync();
+
+		$status_after_first = $this->full_sync->get_status();
+		$this->assertArrayHasKey( 'last_item', $status_after_first['progress']['posts'], 'last_item should be stored in progress after first sync round.' );
+
+		$stored_last_item = $status_after_first['progress']['posts']['last_item'];
+		$this->assertNotNull( $stored_last_item, 'last_item should not be null.' );
+
+		// Run another round — last_item should be reused, not re-queried.
+		$this->full_sync->continue_sending();
+		$this->sender->do_full_sync();
+
+		$status_after_second = $this->full_sync->get_status();
+		$this->assertSame(
+			$stored_last_item,
+			$status_after_second['progress']['posts']['last_item'],
+			'last_item should remain the same across sync rounds (stored).'
+		);
+	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes SYNC-255

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* `Automattic\Jetpack\Sync\Modules\Module::send_full_sync_actions`: Store last_item in status to avoid re-running this expensive query on every invocation. The minimum ID does not change during a Full Sync.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Trigger a Full Sync via the JP Debugger and confirm same behaviour on trunk vs branch

## Changelog
<!-- Check one of the boxes below. -->

- [x] Generate changelog entries for this PR (using AI).
