### PR TITLE
Full Sync: Fix Full Sync chunk adjustment when stuck

### DIFF
--- a/projects/packages/sync/changelog/pr-47293
+++ b/projects/packages/sync/changelog/pr-47293
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Full Sync: Fix chunk size adjustment when sync is stuck to correctly preserve adjusted chunk size and stuck count across invocations.

--- a/projects/packages/sync/src/modules/class-module.php
+++ b/projects/packages/sync/src/modules/class-module.php
@@ -529,7 +529,7 @@ abstract class Module {
 		// Set or update the transient with the new last_sent, timestamp, and stuck_count.
 		// Reset the timestamp when not stuck or after an adjustment, so each new chunk size
 		// gets a 10-minute window to prove itself before halving further.
-		$previous_chunk_size = isset( $stuck_data['adjusted_chunk_size'] ) ? $stuck_data['adjusted_chunk_size'] : null;
+		$previous_chunk_size = $stuck_data['adjusted_chunk_size'] ?? null;
 		$reset_timestamp     = ! $is_stuck || $adjusted_chunk_size !== $previous_chunk_size;
 		set_transient(
 			$transient_key,

--- a/projects/packages/sync/src/modules/class-module.php
+++ b/projects/packages/sync/src/modules/class-module.php
@@ -488,12 +488,17 @@ abstract class Module {
 	 * @return int Adjusted chunk size.
 	 */
 	private function adjust_chunk_size_if_stuck( $last_sent, $default_chunk_size, $started ) {
-		$transient_key       = 'jetpack_sync_last_sent_' . $this->name() . '_' . $started;
-		$stuck_data          = get_transient( $transient_key );
-		$stuck_count         = 0;
-		$adjusted_chunk_size = $default_chunk_size;
-		$is_stuck            = isset( $stuck_data['last_sent'] ) && $stuck_data['last_sent'] === $last_sent;
+		$transient_key = 'jetpack_sync_last_sent_' . $this->name() . '_' . $started;
+		$stuck_data    = get_transient( $transient_key );
+		$is_stuck      = isset( $stuck_data['last_sent'] ) && $stuck_data['last_sent'] === $last_sent;
+
+		// Preserve the adjusted chunk size and stuck count from the transient when stuck.
+		$stuck_count         = $is_stuck && isset( $stuck_data['stuck_count'] ) ? $stuck_data['stuck_count'] : 0;
+		$adjusted_chunk_size = $is_stuck && isset( $stuck_data['adjusted_chunk_size'] ) ? $stuck_data['adjusted_chunk_size'] : $default_chunk_size;
+
 		if ( $is_stuck && $stuck_data['adjusted_chunk_size'] === 1 ) {
+			// Refresh transient TTL to prevent expiry-driven reset cycles.
+			set_transient( $transient_key, $stuck_data, HOUR_IN_SECONDS );
 			return 1; // If we are already at the minimum chunk size, do not adjust further.
 		}
 
@@ -502,27 +507,37 @@ abstract class Module {
 			$is_stuck &&
 			( time() - $stuck_data['timestamp'] ) >= 10 * MINUTE_IN_SECONDS
 		) {
-			$stuck_count         = ++$stuck_data['stuck_count'];
+			++$stuck_count;
 			$adjusted_chunk_size = max( 1, (int) ( $default_chunk_size / ( 2 ** $stuck_count ) ) ); // Halve the chunk size for each stuck iteration.
-			// If we are stuck, we will send an action to notify about the adjustment.
-			$this->send_action(
-				'jetpack_full_sync_stuck_adjustment',
-				array(
-					'module'              => $this->name(),
-					'last_sent'           => $last_sent,
-					'stuck_count'         => $stuck_count,
-					'adjusted_chunk_size' => $adjusted_chunk_size,
-				)
-			);
+
+			// Send one HTTP notification when chunk size reaches the minimum (1)
+			// so the stuck state is visible for monitoring. Intermediate cascade
+			// steps skip the HTTP request to avoid consuming the time budget.
+			if ( 1 === $adjusted_chunk_size ) {
+				$this->send_action(
+					'jetpack_full_sync_stuck_adjustment',
+					array(
+						array(
+							'module'              => $this->name(),
+							'last_sent'           => $last_sent,
+							'stuck_count'         => $stuck_count,
+							'adjusted_chunk_size' => $adjusted_chunk_size,
+						),
+					)
+				);
+			}
 		}
 
 		// Set or update the transient with the new last_sent, timestamp, and stuck_count.
-		// If we are not stuck, reset the timestamp and stuck_count.
+		// Reset the timestamp when not stuck or after an adjustment, so each new chunk size
+		// gets a 10-minute window to prove itself before halving further.
+		$previous_chunk_size = isset( $stuck_data['adjusted_chunk_size'] ) ? $stuck_data['adjusted_chunk_size'] : null;
+		$reset_timestamp     = ! $is_stuck || $adjusted_chunk_size !== $previous_chunk_size;
 		set_transient(
 			$transient_key,
 			array(
 				'last_sent'           => $last_sent,
-				'timestamp'           => $is_stuck ? $stuck_data['timestamp'] : time(),
+				'timestamp'           => $reset_timestamp ? time() : $stuck_data['timestamp'],
 				'stuck_count'         => $stuck_count,
 				'adjusted_chunk_size' => $adjusted_chunk_size,
 			),

--- a/projects/packages/sync/src/modules/class-module.php
+++ b/projects/packages/sync/src/modules/class-module.php
@@ -517,12 +517,10 @@ abstract class Module {
 				$this->send_action(
 					'jetpack_full_sync_stuck_adjustment',
 					array(
-						array(
-							'module'              => $this->name(),
-							'last_sent'           => $last_sent,
-							'stuck_count'         => $stuck_count,
-							'adjusted_chunk_size' => $adjusted_chunk_size,
-						),
+						'module'              => $this->name(),
+						'last_sent'           => $last_sent,
+						'stuck_count'         => $stuck_count,
+						'adjusted_chunk_size' => $adjusted_chunk_size,
 					)
 				);
 			}

--- a/projects/plugins/jetpack/changelog/pr-47293
+++ b/projects/plugins/jetpack/changelog/pr-47293
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Full Sync: Fix chunk size adjustment when sync is stuck to correctly preserve adjusted chunk size and stuck count across invocations.

--- a/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Full_Immediately_Test.php
+++ b/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Full_Immediately_Test.php
@@ -1632,6 +1632,13 @@ class Jetpack_Sync_Full_Immediately_Test extends Jetpack_Sync_TestBase {
 
 		$stuck_event = $this->server_event_storage->get_most_recent_event( 'jetpack_full_sync_stuck_adjustment' );
 		$this->assertNotFalse( $stuck_event, 'send_action should fire when chunk size reaches minimum (1).' );
+
+		// Verify the event data is a flat associative array, not nested in an extra wrapper.
+		$event_data = $stuck_event->args;
+		$this->assertArrayHasKey( 'module', $event_data, 'Event data should contain module key at the top level.' );
+		$this->assertArrayHasKey( 'adjusted_chunk_size', $event_data, 'Event data should contain adjusted_chunk_size key at the top level.' );
+		$this->assertSame( 'posts', $event_data['module'] );
+		$this->assertSame( 1, $event_data['adjusted_chunk_size'] );
 	}
 
 	/**

--- a/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Full_Immediately_Test.php
+++ b/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Full_Immediately_Test.php
@@ -1491,10 +1491,17 @@ class Jetpack_Sync_Full_Immediately_Test extends Jetpack_Sync_TestBase {
 	public function test_stuck_sync_halves_chunk_size_after_10_minutes() {
 		self::factory()->post->create_many( 3 );
 
+		$limits          = \Automattic\Jetpack\Sync\Defaults::$default_full_sync_limits;
+		$limits['posts'] = array(
+			'chunk_size' => 100,
+			'max_chunks' => 10,
+		);
+		Settings::update_settings( array( 'full_sync_limits' => $limits ) );
+
 		$this->full_sync->start( array( 'posts' => true ) );
 		$started = $this->full_sync->get_status()['started'];
 
-		// Simulate stuck for over 10 minutes with default chunk size.
+		// Simulate stuck for over 10 minutes with the configured chunk size.
 		$transient_key = $this->get_stuck_transient_key( 'posts', $started );
 		set_transient(
 			$transient_key,
@@ -1520,6 +1527,13 @@ class Jetpack_Sync_Full_Immediately_Test extends Jetpack_Sync_TestBase {
 	 */
 	public function test_stuck_sync_resets_timestamp_after_adjustment() {
 		self::factory()->post->create_many( 3 );
+
+		$limits          = \Automattic\Jetpack\Sync\Defaults::$default_full_sync_limits;
+		$limits['posts'] = array(
+			'chunk_size' => 100,
+			'max_chunks' => 10,
+		);
+		Settings::update_settings( array( 'full_sync_limits' => $limits ) );
 
 		$this->full_sync->start( array( 'posts' => true ) );
 		$started = $this->full_sync->get_status()['started'];
@@ -1586,6 +1600,13 @@ class Jetpack_Sync_Full_Immediately_Test extends Jetpack_Sync_TestBase {
 	 */
 	public function test_stuck_sync_sends_action_only_at_minimum_chunk_size() {
 		self::factory()->post->create_many( 3 );
+
+		$limits          = \Automattic\Jetpack\Sync\Defaults::$default_full_sync_limits;
+		$limits['posts'] = array(
+			'chunk_size' => 100,
+			'max_chunks' => 10,
+		);
+		Settings::update_settings( array( 'full_sync_limits' => $limits ) );
 
 		$this->full_sync->start( array( 'posts' => true ) );
 		$started = $this->full_sync->get_status()['started'];

--- a/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Full_Immediately_Test.php
+++ b/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Full_Immediately_Test.php
@@ -1439,4 +1439,266 @@ class Jetpack_Sync_Full_Immediately_Test extends Jetpack_Sync_TestBase {
 			'last_item should remain the same across sync rounds (stored).'
 		);
 	}
+
+	/**
+	 * Helper: build the transient key used by adjust_chunk_size_if_stuck.
+	 *
+	 * @param string $module_name The module name (e.g. 'posts').
+	 * @param int    $started     The full sync started timestamp.
+	 * @return string Transient key.
+	 */
+	private function get_stuck_transient_key( $module_name, $started ) {
+		return 'jetpack_sync_last_sent_' . $module_name . '_' . $started;
+	}
+
+	/**
+	 * Test that the adjusted chunk size is preserved across invocations when stuck.
+	 *
+	 * Previously, adjusted_chunk_size was reset to the default on every invocation,
+	 * so a reduced chunk size (e.g. 50) would be lost and revert to 100.
+	 */
+	public function test_stuck_sync_preserves_adjusted_chunk_size() {
+		self::factory()->post->create_many( 3 );
+
+		$this->full_sync->start( array( 'posts' => true ) );
+		$started = $this->full_sync->get_status()['started'];
+
+		// Simulate a stuck state: last_sent hasn't advanced, chunk was already halved to 50,
+		// but the 10-minute threshold has NOT passed yet (only 5 minutes).
+		$transient_key = $this->get_stuck_transient_key( 'posts', $started );
+		set_transient(
+			$transient_key,
+			array(
+				'last_sent'           => '~0',
+				'timestamp'           => time() - 5 * MINUTE_IN_SECONDS, // Only 5 min — not enough for another adjustment.
+				'stuck_count'         => 1,
+				'adjusted_chunk_size' => 50,
+			),
+			HOUR_IN_SECONDS
+		);
+
+		$this->sender->do_full_sync();
+
+		// The transient should still have chunk_size 50 (preserved, not reset to default).
+		$stuck_data = get_transient( $transient_key );
+		$this->assertSame( 50, $stuck_data['adjusted_chunk_size'], 'Adjusted chunk size should be preserved when stuck but before the 10-minute threshold.' );
+		$this->assertSame( 1, $stuck_data['stuck_count'], 'Stuck count should be preserved.' );
+	}
+
+	/**
+	 * Test that chunk size is halved after being stuck for 10+ minutes.
+	 */
+	public function test_stuck_sync_halves_chunk_size_after_10_minutes() {
+		self::factory()->post->create_many( 3 );
+
+		$this->full_sync->start( array( 'posts' => true ) );
+		$started = $this->full_sync->get_status()['started'];
+
+		// Simulate stuck for over 10 minutes with default chunk size.
+		$transient_key = $this->get_stuck_transient_key( 'posts', $started );
+		set_transient(
+			$transient_key,
+			array(
+				'last_sent'           => '~0',
+				'timestamp'           => time() - 11 * MINUTE_IN_SECONDS,
+				'stuck_count'         => 0,
+				'adjusted_chunk_size' => 100,
+			),
+			HOUR_IN_SECONDS
+		);
+
+		$this->sender->do_full_sync();
+
+		$stuck_data = get_transient( $transient_key );
+		$this->assertSame( 50, $stuck_data['adjusted_chunk_size'], 'Chunk size should be halved after 10 minutes stuck.' );
+		$this->assertSame( 1, $stuck_data['stuck_count'], 'Stuck count should be incremented.' );
+	}
+
+	/**
+	 * Test that timestamp is reset after a chunk size adjustment so
+	 * each new chunk size gets a 10-minute window before halving further.
+	 */
+	public function test_stuck_sync_resets_timestamp_after_adjustment() {
+		self::factory()->post->create_many( 3 );
+
+		$this->full_sync->start( array( 'posts' => true ) );
+		$started = $this->full_sync->get_status()['started'];
+
+		$old_timestamp = time() - 11 * MINUTE_IN_SECONDS;
+		$transient_key = $this->get_stuck_transient_key( 'posts', $started );
+		set_transient(
+			$transient_key,
+			array(
+				'last_sent'           => '~0',
+				'timestamp'           => $old_timestamp,
+				'stuck_count'         => 0,
+				'adjusted_chunk_size' => 100,
+			),
+			HOUR_IN_SECONDS
+		);
+
+		$this->sender->do_full_sync();
+
+		$stuck_data = get_transient( $transient_key );
+		$this->assertGreaterThan(
+			$old_timestamp,
+			$stuck_data['timestamp'],
+			'Timestamp should be reset after an adjustment so the new chunk size gets a fresh 10-minute window.'
+		);
+	}
+
+	/**
+	 * Test that timestamp is preserved when stuck but no adjustment is made
+	 * (still waiting for the 10-minute threshold).
+	 */
+	public function test_stuck_sync_preserves_timestamp_when_no_adjustment() {
+		self::factory()->post->create_many( 3 );
+
+		$this->full_sync->start( array( 'posts' => true ) );
+		$started = $this->full_sync->get_status()['started'];
+
+		$original_timestamp = time() - 5 * MINUTE_IN_SECONDS;
+		$transient_key      = $this->get_stuck_transient_key( 'posts', $started );
+		set_transient(
+			$transient_key,
+			array(
+				'last_sent'           => '~0',
+				'timestamp'           => $original_timestamp,
+				'stuck_count'         => 1,
+				'adjusted_chunk_size' => 50,
+			),
+			HOUR_IN_SECONDS
+		);
+
+		$this->sender->do_full_sync();
+
+		$stuck_data = get_transient( $transient_key );
+		$this->assertSame(
+			$original_timestamp,
+			$stuck_data['timestamp'],
+			'Timestamp should be preserved when stuck but no adjustment is made.'
+		);
+	}
+
+	/**
+	 * Test that send_action is only fired when chunk size reaches the minimum (1),
+	 * not on intermediate cascade steps.
+	 */
+	public function test_stuck_sync_sends_action_only_at_minimum_chunk_size() {
+		self::factory()->post->create_many( 3 );
+
+		$this->full_sync->start( array( 'posts' => true ) );
+		$started = $this->full_sync->get_status()['started'];
+
+		// Simulate stuck at chunk_size 50 for over 10 minutes — should halve to 25, no send_action.
+		$transient_key = $this->get_stuck_transient_key( 'posts', $started );
+		set_transient(
+			$transient_key,
+			array(
+				'last_sent'           => '~0',
+				'timestamp'           => time() - 11 * MINUTE_IN_SECONDS,
+				'stuck_count'         => 1,
+				'adjusted_chunk_size' => 50,
+			),
+			HOUR_IN_SECONDS
+		);
+
+		$this->server_event_storage->reset();
+		$this->sender->do_full_sync();
+
+		$stuck_event = $this->server_event_storage->get_most_recent_event( 'jetpack_full_sync_stuck_adjustment' );
+		$this->assertFalse( $stuck_event, 'send_action should NOT fire on intermediate cascade steps (50 -> 25).' );
+
+		// Now simulate stuck at chunk_size 2 for over 10 minutes — should reach 1 and fire send_action.
+		// Need to restart since the sync likely finished.
+		$this->full_sync->reset_data();
+		$this->full_sync->start( array( 'posts' => true ) );
+		$started = $this->full_sync->get_status()['started'];
+
+		$transient_key = $this->get_stuck_transient_key( 'posts', $started );
+		set_transient(
+			$transient_key,
+			array(
+				'last_sent'           => '~0',
+				'timestamp'           => time() - 11 * MINUTE_IN_SECONDS,
+				'stuck_count'         => 6, // default 100 / 2^7 = 0, clamped to 1.
+				'adjusted_chunk_size' => 2,
+			),
+			HOUR_IN_SECONDS
+		);
+
+		$this->server_event_storage->reset();
+		$this->sender->do_full_sync();
+
+		$stuck_event = $this->server_event_storage->get_most_recent_event( 'jetpack_full_sync_stuck_adjustment' );
+		$this->assertNotFalse( $stuck_event, 'send_action should fire when chunk size reaches minimum (1).' );
+	}
+
+	/**
+	 * Test that transient TTL is refreshed when already stuck at minimum chunk size,
+	 * preventing expiry-driven reset cycles.
+	 */
+	public function test_stuck_sync_refreshes_transient_ttl_at_minimum() {
+		self::factory()->post->create_many( 3 );
+
+		$this->full_sync->start( array( 'posts' => true ) );
+		$started = $this->full_sync->get_status()['started'];
+
+		$transient_key = $this->get_stuck_transient_key( 'posts', $started );
+		set_transient(
+			$transient_key,
+			array(
+				'last_sent'           => '~0',
+				'timestamp'           => time() - 30 * MINUTE_IN_SECONDS,
+				'stuck_count'         => 7,
+				'adjusted_chunk_size' => 1,
+			),
+			HOUR_IN_SECONDS
+		);
+
+		$this->sender->do_full_sync();
+
+		// The transient should still exist (TTL refreshed) and data should be unchanged.
+		$stuck_data = get_transient( $transient_key );
+		$this->assertNotFalse( $stuck_data, 'Transient should still exist after TTL refresh.' );
+		$this->assertSame( 1, $stuck_data['adjusted_chunk_size'], 'Chunk size should remain at minimum.' );
+		$this->assertSame( 7, $stuck_data['stuck_count'], 'Stuck count should not be incremented further at minimum.' );
+	}
+
+	/**
+	 * Test that stuck state resets when sync makes progress (last_sent advances).
+	 */
+	public function test_stuck_sync_resets_when_progress_is_made() {
+		self::factory()->post->create_many( 3 );
+
+		$limits          = \Automattic\Jetpack\Sync\Defaults::$default_full_sync_limits;
+		$limits['posts'] = array(
+			'chunk_size' => 100,
+			'max_chunks' => 10,
+		);
+		Settings::update_settings( array( 'full_sync_limits' => $limits ) );
+
+		$this->full_sync->start( array( 'posts' => true ) );
+		$started = $this->full_sync->get_status()['started'];
+
+		// Simulate stuck at a reduced chunk size, but with a last_sent that
+		// will NOT match the current status (sync has made progress).
+		$transient_key = $this->get_stuck_transient_key( 'posts', $started );
+		set_transient(
+			$transient_key,
+			array(
+				'last_sent'           => '999999', // Different from '~0' — not stuck.
+				'timestamp'           => time() - 20 * MINUTE_IN_SECONDS,
+				'stuck_count'         => 3,
+				'adjusted_chunk_size' => 12,
+			),
+			HOUR_IN_SECONDS
+		);
+
+		$this->sender->do_full_sync();
+
+		$stuck_data = get_transient( $transient_key );
+		$this->assertSame( 0, $stuck_data['stuck_count'], 'Stuck count should reset to 0 when progress is made.' );
+		$this->assertSame( 100, $stuck_data['adjusted_chunk_size'], 'Chunk size should return to default when progress is made.' );
+	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes SYNC-256

This pull request fixes a bug in the Full Sync chunk size adjustment mechanism when the Full Sync process gets stuck. The changes ensure that reduced chunk sizes are properly preserved across invocations, preventing them from being reset to default values prematurely.

## Proposed changes:

- Modified adjust_chunk_size_if_stuck method to preserve adjusted chunk sizes and stuck counts when the sync is still stuck but hasn't reached the 10-minute threshold for further adjustment
- Added transient TTL refresh when already at minimum chunk size to prevent expiry-driven reset cycles
- Changed notification behavior to only send HTTP action when chunk size reaches minimum (1) rather than on every adjustment step
- Added comprehensive test coverage for all stuck sync scenarios

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Checkout the test instructions in https://github.com/Automattic/jetpack/pull/44454 with the following caveats:
  1. A a single `jetpack_full_sync_stuck_adjustment` action will be sent when chunk size reaches minimum
  2. Note that each cascade step now waits the full threshold interval (not rapid-fire)
  3. The core testing approach (commenting out `set_send_full_sync_actions_status` or using `wp_die()` ) is unchanged

## Changelog
<!-- Check one of the boxes below. -->

- [x] Generate changelog entries for this PR (using AI).
