### PR TITLE
Newsletter: Add clarifying note to Reading settings page

### DIFF
--- a/projects/packages/newsletter/changelog/add-reading-settings-newsletter-notice
+++ b/projects/packages/newsletter/changelog/add-reading-settings-newsletter-notice
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add clarifying note to Reading settings page linking to Newsletter settings for email content control.

--- a/projects/packages/newsletter/src/class-settings.php
+++ b/projects/packages/newsletter/src/class-settings.php
@@ -68,6 +68,12 @@ class Settings {
 	 * Subscribe to necessary hooks.
 	 */
 	public function init_hooks() {
+		// Add the Reading settings notice regardless of the new UI feature flag,
+		// as long as subscriptions are active.
+		if ( $this->is_subscriptions_active() ) {
+			add_action( 'admin_init', array( $this, 'add_reading_page_notice' ) );
+		}
+
 		if ( ! $this->expose_to_users() ) {
 			return;
 		}
@@ -287,5 +293,44 @@ class Settings {
 		?>
 		<div id="newsletter-settings-root"></div>
 		<?php
+	}
+
+	/**
+	 * Register a notice on the Reading settings page to clarify that the RSS
+	 * excerpt setting does not control newsletter emails.
+	 *
+	 * @since $$next-version$$
+	 */
+	public function add_reading_page_notice() {
+		add_settings_field(
+			'jetpack_newsletter_reading_notice',
+			'',
+			array( $this, 'render_reading_page_notice' ),
+			'reading',
+			'default'
+		);
+	}
+
+	/**
+	 * Render the clarifying notice on the Reading settings page.
+	 *
+	 * @since $$next-version$$
+	 */
+	public function render_reading_page_notice() {
+		// Use the filtered URL so it points to the correct settings page
+		// regardless of whether the new newsletter UI is enabled.
+		$newsletter_url = apply_filters(
+			'jetpack_module_configuration_url_subscriptions',
+			admin_url( 'admin.php?page=jetpack#/newsletter' )
+		);
+
+		printf(
+			'<p class="description">%s</p>',
+			sprintf(
+				/* translators: %s is a link to the Newsletter settings page. */
+				esc_html__( 'This setting controls your RSS feed only. To control what\'s included in newsletter emails sent to subscribers, visit your %s.', 'jetpack-newsletter' ),
+				'<a href="' . esc_url( $newsletter_url ) . '">' . esc_html__( 'Newsletter settings', 'jetpack-newsletter' ) . '</a>'
+			)
+		);
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/96697

## Proposed changes:

- Add a clarifying note on the wp-admin Reading settings page (`options-reading.php`) that the "For each post in a feed, include: Full text / Excerpt" toggle controls RSS feeds only
- Link to the Newsletter settings page for controlling email content

Users and Happiness Engineers confuse the Reading settings excerpt toggle with the Newsletter settings excerpt toggle. Both say "Full text / Excerpt" but control different things (RSS vs email). This has generated support tickets for 7+ years, including cases where HEs directed users to the wrong settings page.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

NL-460

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

- Enable Jetpack with subscriptions module active
- Navigate to `wp-admin/options-reading.php`
- Verify a clarifying note appears near the "For each post in a feed, include" radio buttons saying "This setting controls your RSS feed only. To control what's included in newsletter emails sent to subscribers, visit your Newsletter settings."
- Verify the "Newsletter settings" link navigates to the correct newsletter settings page
- Deactivate the subscriptions module and verify the note does not appear
