### PR TITLE
Agents Manager: Make is_enabled() a public static method

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-agents-manager-is-enabled-static
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-agents-manager-is-enabled-static
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Agents Manager: Make is_enabled() a public static method so consumers can check enablement without duplicating filter logic

--- a/projects/packages/jetpack-mu-wpcom/src/features/agents-manager/class-agents-manager.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/agents-manager/class-agents-manager.php
@@ -273,7 +273,7 @@ class Agents_Manager {
 	private function get_variant() {
 		// CIAB/Next Admin: only load when disconnected (connected CIAB is handled by Help Center).
 		if ( $this->is_ciab_environment() ) {
-			if ( $this->is_enabled() && $this->is_jetpack_disconnected() ) {
+			if ( self::is_enabled() && $this->is_jetpack_disconnected() ) {
 				return 'ciab-disconnected';
 			}
 			return null;
@@ -281,7 +281,7 @@ class Agents_Manager {
 
 		// Frontend: load disconnected variant for eligible logged-in editors.
 		if ( ! is_admin() ) {
-			if ( $this->is_loading_on_frontend() && $this->is_enabled() ) {
+			if ( $this->is_loading_on_frontend() && self::is_enabled() ) {
 				return 'wp-admin-disconnected';
 			}
 			return null;
@@ -292,7 +292,7 @@ class Agents_Manager {
 			return null;
 		}
 
-		if ( ! $this->is_enabled() ) {
+		if ( ! self::is_enabled() ) {
 			return null;
 		}
 
@@ -310,14 +310,14 @@ class Agents_Manager {
 	 *
 	 * @return bool
 	 */
-	private function is_enabled() {
+	public static function is_enabled() {
 		// Full unified experience: Agents Manager with support guides, Help Center takeover, etc.
 		if ( apply_filters( 'agents_manager_use_unified_experience', false ) ) {
 			return true;
 		}
 
 		// Block editor only: Agents Manager replaces Big Sky's native UI. Hooked by Big Sky.
-		if ( $this->is_block_editor() && apply_filters( 'agents_manager_enabled_in_block_editor', false ) ) {
+		if ( self::is_block_editor() && apply_filters( 'agents_manager_enabled_in_block_editor', false ) ) {
 			return true;
 		}
 
@@ -708,7 +708,7 @@ class Agents_Manager {
 	 *
 	 * @return bool True if the current screen is the block editor.
 	 */
-	private function is_block_editor() {
+	private static function is_block_editor() {
 		if ( ! function_exists( 'get_current_screen' ) ) {
 			return false;
 		}

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/agents-manager/Agents_Manager_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/agents-manager/Agents_Manager_Test.php
@@ -1983,6 +1983,143 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
+	 * Tests that is_enabled returns false by default when no filters are active.
+	 */
+	public function test_is_enabled_returns_false_by_default() {
+		// Ensure no block editor context.
+		$this->assertFalse( is_admin() );
+
+		$result = Agents_Manager::is_enabled();
+
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * Tests that is_enabled returns true when the unified experience filter returns true.
+	 */
+	public function test_is_enabled_returns_true_when_unified_experience_enabled() {
+		add_filter( 'agents_manager_use_unified_experience', '__return_true', 20 );
+
+		$result = Agents_Manager::is_enabled();
+
+		remove_filter( 'agents_manager_use_unified_experience', '__return_true', 20 );
+
+		$this->assertTrue( $result );
+	}
+
+	/**
+	 * Tests that is_enabled returns true when in block editor and agents_manager_enabled_in_block_editor filter is true.
+	 */
+	public function test_is_enabled_returns_true_in_block_editor_when_block_editor_filter_enabled() {
+		require_once ABSPATH . 'wp-admin/includes/screen.php';
+
+		// Set up block editor context.
+		set_current_screen( 'post' );
+		$screen = get_current_screen();
+
+		$reflection = new \ReflectionClass( $screen );
+		$property   = $reflection->getProperty( 'is_block_editor' );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$property->setAccessible( true );
+		}
+		$property->setValue( $screen, true );
+
+		add_filter( 'agents_manager_enabled_in_block_editor', '__return_true' );
+
+		$result = Agents_Manager::is_enabled();
+
+		remove_filter( 'agents_manager_enabled_in_block_editor', '__return_true' );
+
+		$this->assertTrue( $result );
+	}
+
+	/**
+	 * Tests that is_enabled returns false when in block editor but block editor filter is not enabled.
+	 */
+	public function test_is_enabled_returns_false_in_block_editor_when_block_editor_filter_disabled() {
+		require_once ABSPATH . 'wp-admin/includes/screen.php';
+
+		// Set up block editor context.
+		set_current_screen( 'post' );
+		$screen = get_current_screen();
+
+		$reflection = new \ReflectionClass( $screen );
+		$property   = $reflection->getProperty( 'is_block_editor' );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$property->setAccessible( true );
+		}
+		$property->setValue( $screen, true );
+
+		// Do not add agents_manager_enabled_in_block_editor filter — default is false.
+		$result = Agents_Manager::is_enabled();
+
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * Tests that is_enabled returns false when not in block editor even if block editor filter is true.
+	 */
+	public function test_is_enabled_returns_false_when_not_in_block_editor_even_if_block_editor_filter_enabled() {
+		// Set to a non-block-editor admin screen.
+		$this->set_admin_context();
+
+		add_filter( 'agents_manager_enabled_in_block_editor', '__return_true' );
+
+		$result = Agents_Manager::is_enabled();
+
+		remove_filter( 'agents_manager_enabled_in_block_editor', '__return_true' );
+
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * Tests that is_enabled returns false for widgets screen even if block editor filter is true.
+	 *
+	 * The widgets screen has the block editor flag but is excluded from is_block_editor().
+	 */
+	public function test_is_enabled_returns_false_for_widgets_screen_with_block_editor_filter() {
+		require_once ABSPATH . 'wp-admin/includes/screen.php';
+
+		// Set up widgets screen with block editor flag.
+		set_current_screen( 'widgets' );
+		$screen = get_current_screen();
+
+		$reflection = new \ReflectionClass( $screen );
+		$property   = $reflection->getProperty( 'is_block_editor' );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$property->setAccessible( true );
+		}
+		$property->setValue( $screen, true );
+
+		add_filter( 'agents_manager_enabled_in_block_editor', '__return_true' );
+
+		$result = Agents_Manager::is_enabled();
+
+		remove_filter( 'agents_manager_enabled_in_block_editor', '__return_true' );
+
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * Tests that is_enabled prioritises the unified experience filter over the block editor filter.
+	 *
+	 * When the unified experience filter is true, is_enabled should return true
+	 * regardless of block editor state.
+	 */
+	public function test_is_enabled_unified_experience_takes_priority_over_block_editor() {
+		// Not in block editor context.
+		$this->assertFalse( is_admin() );
+
+		add_filter( 'agents_manager_use_unified_experience', '__return_true', 20 );
+
+		$result = Agents_Manager::is_enabled();
+
+		remove_filter( 'agents_manager_use_unified_experience', '__return_true', 20 );
+
+		$this->assertTrue( $result );
+	}
+
+	/**
 	 * Tests that should_enqueue_script returns false on WooCommerce Admin home page.
 	 *
 	 * This verifies the WooCommerce Admin exclusion to avoid UI conflicts,


### PR DESCRIPTION
## Summary
- Changes `Agents_Manager::is_enabled()` from `private` to `public static` so external consumers (e.g. Big Sky plugin) can call it directly instead of duplicating the filter-based enablement logic.
- Also makes `is_block_editor()` `private static` since it uses no instance state (called by `is_enabled()`).
- Updates internal `$this->is_enabled()` calls to `self::is_enabled()`.

## Testing instructions

1. On a site with Agents Manager active (proxied Simple or WoA), verify it loads correctly in:
   - wp-admin (standard admin pages)
   - Block editor (new post/page)
   - Frontend (logged in as editor)
2. Verify `\A8C\FSE\Agents_Manager::is_enabled()` is callable statically from external code (e.g. via `wp shell` or a test plugin).

## Does this pull request change what data or activity we track or use?

No, this is a pure visibility/signature change with no new data handling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)