### PR TITLE
Jetpack Sync: REST_Endpoints - Add clear-queue endpoint

### DIFF
--- a/projects/packages/sync/changelog/pr-47303
+++ b/projects/packages/sync/changelog/pr-47303
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+REST_Endpoints: Add clear-queue endpoint to allow clearing a Sync queue via REST API.

--- a/projects/packages/sync/src/class-rest-endpoints.php
+++ b/projects/packages/sync/src/class-rest-endpoints.php
@@ -840,7 +840,7 @@ class REST_Endpoints {
 	public static function clear_queue( $request ) {
 		$queue_name = $request->get_param( 'queue' );
 
-		if ( ! in_array( $queue_name, array( 'sync', 'full_sync' ), true ) ) {
+		if ( ! in_array( $queue_name, array( 'sync' ), true ) ) {
 			return new WP_Error( 'invalid_queue', 'Queue name should be sync or full_sync', array( 'status' => 400 ) );
 		}
 

--- a/projects/packages/sync/src/class-rest-endpoints.php
+++ b/projects/packages/sync/src/class-rest-endpoints.php
@@ -332,6 +332,24 @@ class REST_Endpoints {
 				'permission_callback' => __CLASS__ . '::verify_default_permissions',
 			)
 		);
+
+		// Clear Sync queue.
+		register_rest_route(
+			'jetpack/v4',
+			'/sync/clear-queue',
+			array(
+				'methods'             => WP_REST_Server::EDITABLE,
+				'callback'            => __CLASS__ . '::clear_queue',
+				'permission_callback' => __CLASS__ . '::verify_default_permissions',
+				'args'                => array(
+					'queue' => array(
+						'description' => __( 'Name of Sync queue to clear.', 'jetpack-sync' ),
+						'type'        => 'string',
+						'required'    => true,
+					),
+				),
+			)
+		);
 	}
 
 	/**
@@ -806,6 +824,39 @@ class REST_Endpoints {
 		return rest_ensure_response(
 			array(
 				'success' => true,
+			)
+		);
+	}
+
+	/**
+	 * Clear a Sync queue.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param \WP_REST_Request $request The request sent to the WP REST API.
+	 *
+	 * @return \WP_REST_Response|WP_Error
+	 */
+	public static function clear_queue( $request ) {
+		$queue_name = $request->get_param( 'queue' );
+
+		if ( ! in_array( $queue_name, array( 'sync', 'full_sync' ), true ) ) {
+			return new WP_Error( 'invalid_queue', 'Queue name should be sync or full_sync', array( 'status' => 400 ) );
+		}
+
+		$queue = new Queue( $queue_name );
+		$queue->reset();
+
+		// If the incremental sync queue was cleared, re-enable sending in case
+		// it was temporarily disabled during a pull.
+		if ( 'sync' === $queue_name ) {
+			delete_transient( Sender::TEMP_SYNC_DISABLE_TRANSIENT_NAME );
+		}
+
+		return rest_ensure_response(
+			array(
+				'success' => true,
+				'queue'   => $queue_name,
 			)
 		);
 	}

--- a/projects/packages/sync/src/class-rest-endpoints.php
+++ b/projects/packages/sync/src/class-rest-endpoints.php
@@ -838,7 +838,6 @@ class REST_Endpoints {
 		return rest_ensure_response(
 			array(
 				'success' => true,
-				'queue'   => 'sync',
 			)
 		);
 	}

--- a/projects/packages/sync/src/class-rest-endpoints.php
+++ b/projects/packages/sync/src/class-rest-endpoints.php
@@ -341,13 +341,6 @@ class REST_Endpoints {
 				'methods'             => WP_REST_Server::EDITABLE,
 				'callback'            => __CLASS__ . '::clear_queue',
 				'permission_callback' => __CLASS__ . '::verify_default_permissions',
-				'args'                => array(
-					'queue' => array(
-						'description' => __( 'Name of Sync queue to clear.', 'jetpack-sync' ),
-						'type'        => 'string',
-						'required'    => true,
-					),
-				),
 			)
 		);
 	}
@@ -829,34 +822,23 @@ class REST_Endpoints {
 	}
 
 	/**
-	 * Clear a Sync queue.
+	 * Clear the Sync queue.
 	 *
 	 * @since $$next-version$$
 	 *
-	 * @param \WP_REST_Request $request The request sent to the WP REST API.
-	 *
-	 * @return \WP_REST_Response|WP_Error
+	 * @return \WP_REST_Response
 	 */
-	public static function clear_queue( $request ) {
-		$queue_name = $request->get_param( 'queue' );
-
-		if ( ! in_array( $queue_name, array( 'sync' ), true ) ) {
-			return new WP_Error( 'invalid_queue', 'Queue name should be sync or full_sync', array( 'status' => 400 ) );
-		}
-
-		$queue = new Queue( $queue_name );
+	public static function clear_queue() {
+		$queue = new Queue( 'sync' );
 		$queue->reset();
 
-		// If the incremental sync queue was cleared, re-enable sending in case
-		// it was temporarily disabled during a pull.
-		if ( 'sync' === $queue_name ) {
-			delete_transient( Sender::TEMP_SYNC_DISABLE_TRANSIENT_NAME );
-		}
+		// Re-enable sending in case it was temporarily disabled during a pull.
+		delete_transient( Sender::TEMP_SYNC_DISABLE_TRANSIENT_NAME );
 
 		return rest_ensure_response(
 			array(
 				'success' => true,
-				'queue'   => $queue_name,
+				'queue'   => 'sync',
 			)
 		);
 	}

--- a/projects/packages/sync/tests/php/REST_Endpoints_Test.php
+++ b/projects/packages/sync/tests/php/REST_Endpoints_Test.php
@@ -263,6 +263,63 @@ class REST_Endpoints_Test extends TestCase {
 	}
 
 	/**
+	 * Testing the `POST /jetpack/v4/sync/clear-queue` endpoint clears the specified queue.
+	 */
+	public function test_sync_clear_queue() {
+		$user = wp_get_current_user();
+		$user->add_cap( 'manage_options' );
+
+		$request = new WP_REST_Request( 'POST', '/jetpack/v4/sync/clear-queue' );
+		$request->set_header( 'Content-Type', 'application/json' );
+		$request->set_body( '{ "queue": "sync" }' );
+
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		$user->remove_cap( 'manage_options' );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertTrue( $data['success'] );
+		$this->assertEquals( 'sync', $data['queue'] );
+	}
+
+	/**
+	 * Testing the `POST /jetpack/v4/sync/clear-queue` endpoint rejects queue names other than sync and full_sync.
+	 *
+	 * @param string $queue_name Queue name to test.
+	 * @dataProvider clear_queue_invalid_queue_provider
+	 */
+	#[DataProvider( 'clear_queue_invalid_queue_provider' )]
+	public function test_sync_clear_queue_invalid_queue( $queue_name ) {
+		$user = wp_get_current_user();
+		$user->add_cap( 'manage_options' );
+
+		$request = new WP_REST_Request( 'POST', '/jetpack/v4/sync/clear-queue' );
+		$request->set_header( 'Content-Type', 'application/json' );
+		$request->set_body( '{ "queue": "' . $queue_name . '" }' );
+
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		$user->remove_cap( 'manage_options' );
+
+		$this->assertEquals( 400, $response->get_status() );
+		$this->assertEquals( 'invalid_queue', $data['code'] );
+	}
+
+	/**
+	 * Queue names that should be rejected by the clear-queue endpoint.
+	 *
+	 * @return array
+	 */
+	public static function clear_queue_invalid_queue_provider() {
+		return array(
+			array( 'immediate' ),
+			array( 'invalid_queue' ),
+		);
+	}
+
+	/**
 	 * Array of Sync Endpoints and method.
 	 *
 	 * @return int[][]
@@ -283,6 +340,7 @@ class REST_Endpoints_Test extends TestCase {
 			array( 'sync/data-check', 'GET', null ),
 			array( 'sync/data-histogram', 'POST', null ),
 			array( 'sync/locks', 'DELETE', null ),
+			array( 'sync/clear-queue', 'POST', '{ "queue": "sync" }' ),
 		);
 	}
 

--- a/projects/packages/sync/tests/php/REST_Endpoints_Test.php
+++ b/projects/packages/sync/tests/php/REST_Endpoints_Test.php
@@ -284,7 +284,7 @@ class REST_Endpoints_Test extends TestCase {
 	}
 
 	/**
-	 * Testing the `POST /jetpack/v4/sync/clear-queue` endpoint rejects queue names other than sync and full_sync.
+	 * Testing the `POST /jetpack/v4/sync/clear-queue` endpoint rejects queue names other than sync.
 	 *
 	 * @param string $queue_name Queue name to test.
 	 * @dataProvider clear_queue_invalid_queue_provider
@@ -314,6 +314,7 @@ class REST_Endpoints_Test extends TestCase {
 	 */
 	public static function clear_queue_invalid_queue_provider() {
 		return array(
+			array( 'full_sync' ),
 			array( 'immediate' ),
 			array( 'invalid_queue' ),
 		);

--- a/projects/packages/sync/tests/php/REST_Endpoints_Test.php
+++ b/projects/packages/sync/tests/php/REST_Endpoints_Test.php
@@ -269,7 +269,10 @@ class REST_Endpoints_Test extends TestCase {
 		$user = wp_get_current_user();
 		$user->add_cap( 'manage_options' );
 
-		$request  = new WP_REST_Request( 'POST', '/jetpack/v4/sync/clear-queue' );
+		set_transient( Sender::TEMP_SYNC_DISABLE_TRANSIENT_NAME, time() );
+
+		$request = new WP_REST_Request( 'POST', '/jetpack/v4/sync/clear-queue' );
+		$request->set_header( 'Content-Type', 'application/json' );
 		$response = $this->server->dispatch( $request );
 		$data     = $response->get_data();
 
@@ -278,6 +281,7 @@ class REST_Endpoints_Test extends TestCase {
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertTrue( $data['success'] );
 		$this->assertEquals( 'sync', $data['queue'] );
+		$this->assertFalse( get_transient( Sender::TEMP_SYNC_DISABLE_TRANSIENT_NAME ) );
 	}
 
 	/**
@@ -301,7 +305,7 @@ class REST_Endpoints_Test extends TestCase {
 			array( 'sync/data-check', 'GET', null ),
 			array( 'sync/data-histogram', 'POST', null ),
 			array( 'sync/locks', 'DELETE', null ),
-			array( 'sync/clear-queue', 'POST', '{ "queue": "sync" }' ),
+			array( 'sync/clear-queue', 'POST', null ),
 		);
 	}
 

--- a/projects/packages/sync/tests/php/REST_Endpoints_Test.php
+++ b/projects/packages/sync/tests/php/REST_Endpoints_Test.php
@@ -280,7 +280,6 @@ class REST_Endpoints_Test extends TestCase {
 
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertTrue( $data['success'] );
-		$this->assertEquals( 'sync', $data['queue'] );
 		$this->assertFalse( get_transient( Sender::TEMP_SYNC_DISABLE_TRANSIENT_NAME ) );
 	}
 

--- a/projects/packages/sync/tests/php/REST_Endpoints_Test.php
+++ b/projects/packages/sync/tests/php/REST_Endpoints_Test.php
@@ -263,16 +263,13 @@ class REST_Endpoints_Test extends TestCase {
 	}
 
 	/**
-	 * Testing the `POST /jetpack/v4/sync/clear-queue` endpoint clears the specified queue.
+	 * Testing the `POST /jetpack/v4/sync/clear-queue` endpoint clears the sync queue.
 	 */
 	public function test_sync_clear_queue() {
 		$user = wp_get_current_user();
 		$user->add_cap( 'manage_options' );
 
-		$request = new WP_REST_Request( 'POST', '/jetpack/v4/sync/clear-queue' );
-		$request->set_header( 'Content-Type', 'application/json' );
-		$request->set_body( '{ "queue": "sync" }' );
-
+		$request  = new WP_REST_Request( 'POST', '/jetpack/v4/sync/clear-queue' );
 		$response = $this->server->dispatch( $request );
 		$data     = $response->get_data();
 
@@ -281,43 +278,6 @@ class REST_Endpoints_Test extends TestCase {
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertTrue( $data['success'] );
 		$this->assertEquals( 'sync', $data['queue'] );
-	}
-
-	/**
-	 * Testing the `POST /jetpack/v4/sync/clear-queue` endpoint rejects queue names other than sync.
-	 *
-	 * @param string $queue_name Queue name to test.
-	 * @dataProvider clear_queue_invalid_queue_provider
-	 */
-	#[DataProvider( 'clear_queue_invalid_queue_provider' )]
-	public function test_sync_clear_queue_invalid_queue( $queue_name ) {
-		$user = wp_get_current_user();
-		$user->add_cap( 'manage_options' );
-
-		$request = new WP_REST_Request( 'POST', '/jetpack/v4/sync/clear-queue' );
-		$request->set_header( 'Content-Type', 'application/json' );
-		$request->set_body( '{ "queue": "' . $queue_name . '" }' );
-
-		$response = $this->server->dispatch( $request );
-		$data     = $response->get_data();
-
-		$user->remove_cap( 'manage_options' );
-
-		$this->assertEquals( 400, $response->get_status() );
-		$this->assertEquals( 'invalid_queue', $data['code'] );
-	}
-
-	/**
-	 * Queue names that should be rejected by the clear-queue endpoint.
-	 *
-	 * @return array
-	 */
-	public static function clear_queue_invalid_queue_provider() {
-		return array(
-			array( 'full_sync' ),
-			array( 'immediate' ),
-			array( 'invalid_queue' ),
-		);
 	}
 
 	/**

--- a/projects/plugins/jetpack/changelog/pr-47303
+++ b/projects/plugins/jetpack/changelog/pr-47303
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Sync: Add clear-queue REST endpoint to allow clearing a Sync queue.


### PR DESCRIPTION
Fixes SYNC-257

## Proposed changes:

* This PR adds a new `clear-queue` Sync endpoint, that can be used to clear a queue. Also, if the `TEMP_SYNC_DISABLE_TRANSIENT_NAME` transient was set during incremental sync we want to delete it, in order to re-enable sending.
* This PR does not add the functionality needed on WPCOM to use the endpoint (testing instructions include a basic function to test with).
* Note that we're not including the `immediate` 'queue' as this is just used as a pathway into `Full_Sync_Immediately`

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

n/a

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

* To test, apply this PR on a Jetpack-connected, Jetpack API sandboxed self-hosted site.
* On WPCOM while sandboxed, add a new `reset_queue` function in `class.jetpack-sync-manager.php`:
```
	function reset_queue() {
		if ( $this->is_jetpack_sync_rest_supported() ) {
			$response = $this->call_core_api( 'POST', '/jetpack/v4/sync/clear-queue' );

			if ( is_wp_error( $response ) ) {
				return $response;
			}
			return (array) $response;
		}
	}
```
* To get some items in the queue, add the WP Dummy Content Generator and generate about 100 posts.
* Then run the following via `wpsh` to confirm a successful response from the API:
```
switch_to_blog(YOURBLOGID);
$jsm = new Jetpack_Sync_Manager( get_current_blog_id() );
$result = $jsm->reset_queue();
var_export($result);
```
* You should see an array showing that success is true.
* The queue should also appear to reset in the debugger (incremental queue section).

## Changelog
<!-- Check one of the boxes below. -->

- [x] Generate changelog entries for this PR (using AI).
