### PR TITLE
Social admin: Expand toggle sections width to fill container

### DIFF
--- a/projects/js-packages/components/changelog/adjust-container-maximum-width
+++ b/projects/js-packages/components/changelog/adjust-container-maximum-width
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Container: Adjust maximum width to 1040px

--- a/projects/js-packages/components/components/layout/container/style.module.scss
+++ b/projects/js-packages/components/components/layout/container/style.module.scss
@@ -8,11 +8,12 @@
 	@include breakpoints.media(#{$size}) using ($columns) {
 		padding: 0 #{$padding};
 		grid-template-columns: repeat(#{$columns}, minmax(0, 1fr));
+		max-width: calc(var(--max-container-width) + 2 * #{$padding});
 	}
 }
 
 .container {
-	--max-container-width: 1128px;
+	--max-container-width: 1040px;
 	// vertical spacing
 	--vertical-gutter: 24px;
 	// horizontal spacing
@@ -20,7 +21,6 @@
 
 	display: grid;
 	column-gap: var(--vertical-gutter);
-	max-width: var(--max-container-width);
 	margin: 0 auto;
 	width: 100%;
 

--- a/projects/packages/publicize/_inc/components/admin-page/info-section/styles.module.scss
+++ b/projects/packages/publicize/_inc/components/admin-page/info-section/styles.module.scss
@@ -2,7 +2,6 @@
 	grid-column: span 12;
 
 	.is-viewport-medium & {
-		grid-column: 2 / span 6;
 		display: grid;
 		grid-template-columns: auto 1fr auto 1fr;
 		column-gap: calc(var(--spacing-base) * 3);
@@ -18,10 +17,6 @@
 				margin-top: 0;
 			}
 		}
-	}
-
-	.is-viewport-large & {
-		grid-column: 3 / span 8;
 	}
 }
 

--- a/projects/packages/publicize/_inc/components/admin-page/toggles/social-image-generator-toggle/styles.module.scss
+++ b/projects/packages/publicize/_inc/components/admin-page/toggles/social-image-generator-toggle/styles.module.scss
@@ -1,5 +1,7 @@
 .text {
 	grid-column: span 2;
+	max-width: 80ch;
+	text-wrap: balance;
 
 	a {
 		color: inherit;

--- a/projects/packages/publicize/_inc/components/admin-page/toggles/social-image-generator-toggle/styles.module.scss
+++ b/projects/packages/publicize/_inc/components/admin-page/toggles/social-image-generator-toggle/styles.module.scss
@@ -2,6 +2,7 @@
 	grid-column: span 2;
 	max-width: 80ch;
 	text-wrap: balance;
+	text-wrap: pretty;
 
 	a {
 		color: inherit;

--- a/projects/packages/publicize/_inc/components/admin-page/toggles/social-module-toggle/styles.module.scss
+++ b/projects/packages/publicize/_inc/components/admin-page/toggles/social-module-toggle/styles.module.scss
@@ -1,5 +1,7 @@
 .text {
 	grid-column: span 2;
+	max-width: 80ch;
+	text-wrap: balance;
 
 	a {
 		color: inherit;

--- a/projects/packages/publicize/_inc/components/admin-page/toggles/social-module-toggle/styles.module.scss
+++ b/projects/packages/publicize/_inc/components/admin-page/toggles/social-module-toggle/styles.module.scss
@@ -2,6 +2,7 @@
 	grid-column: span 2;
 	max-width: 80ch;
 	text-wrap: balance;
+	text-wrap: pretty;
 
 	a {
 		color: inherit;

--- a/projects/packages/publicize/_inc/components/admin-page/toggles/social-notes-toggle/styles.module.scss
+++ b/projects/packages/publicize/_inc/components/admin-page/toggles/social-notes-toggle/styles.module.scss
@@ -1,5 +1,7 @@
 .text {
 	grid-column: span 2;
+	max-width: 80ch;
+	text-wrap: balance;
 
 	a {
 		color: inherit;

--- a/projects/packages/publicize/_inc/components/admin-page/toggles/social-notes-toggle/styles.module.scss
+++ b/projects/packages/publicize/_inc/components/admin-page/toggles/social-notes-toggle/styles.module.scss
@@ -2,6 +2,7 @@
 	grid-column: span 2;
 	max-width: 80ch;
 	text-wrap: balance;
+	text-wrap: pretty;
 
 	a {
 		color: inherit;

--- a/projects/packages/publicize/_inc/components/admin-page/toggles/styles.module.scss
+++ b/projects/packages/publicize/_inc/components/admin-page/toggles/styles.module.scss
@@ -16,15 +16,6 @@
 			margin-top: 0;
 		}
 	}
-
-	@media ( min-width: 600px ) {
-		grid-column: 2 / span 6;
-	}
-
-	@media ( min-width: 960px ) {
-		column-gap: calc(var(--spacing-base) * 6);
-		grid-column: 3 / span 8;
-	}
 }
 
 .column.notoggle {

--- a/projects/packages/publicize/_inc/components/admin-page/toggles/utm-toggle/styles.module.scss
+++ b/projects/packages/publicize/_inc/components/admin-page/toggles/utm-toggle/styles.module.scss
@@ -1,5 +1,7 @@
 .text {
 	grid-column: span 2;
+	max-width: 80ch;
+	text-wrap: balance;
 
 	a {
 		color: inherit;

--- a/projects/packages/publicize/_inc/components/admin-page/toggles/utm-toggle/styles.module.scss
+++ b/projects/packages/publicize/_inc/components/admin-page/toggles/utm-toggle/styles.module.scss
@@ -2,6 +2,7 @@
 	grid-column: span 2;
 	max-width: 80ch;
 	text-wrap: balance;
+	text-wrap: pretty;
 
 	a {
 		color: inherit;

--- a/projects/packages/publicize/changelog/expand-toggle-sections-to-fill-container
+++ b/projects/packages/publicize/changelog/expand-toggle-sections-to-fill-container
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Social admin: Expand toggle sections width to fill container


### PR DESCRIPTION
Part of DOTCOM-16126.

## Proposed changes:

Removes the bespoke widths from the sections within the social admin page so they stretch throughout the container:

<img width="2155" height="1478" alt="image" src="https://github.com/user-attachments/assets/842a76f3-be22-48b9-a213-8b8dc2b5fcf0" />


This is part of a series of PRs that will standardize the content width to match WPCOM.

## Jetpack product discussion

p1771956593002369-slack-C0AGM2YP9GW.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

Apply this PR to your sandbox, proxy a simple site to it, and verify that the width of the Jetpack Social section matches the heading title just like the screenshot. Verify that it still matches as you resize the screen.