### PR TITLE
Agents Manager: Return wp-admin variant for connected CIAB environments

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/agents-manager-ciab-wp-admin-variant
+++ b/projects/packages/jetpack-mu-wpcom/changelog/agents-manager-ciab-wp-admin-variant
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Agents Manager: Return wp-admin variant for connected CIAB environments instead of not loading.

--- a/projects/packages/jetpack-mu-wpcom/src/features/agents-manager/class-agents-manager.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/agents-manager/class-agents-manager.php
@@ -271,12 +271,12 @@ class Agents_Manager {
 	 * @return string|null The variant name, or null if scripts should not be loaded.
 	 */
 	private function get_variant() {
-		// CIAB/Next Admin: only load when disconnected (connected CIAB is handled by Help Center).
+		// CIAB/Next Admin: use ciab-disconnected when disconnected, wp-admin when connected.
 		if ( $this->is_ciab_environment() ) {
-			if ( $this->is_enabled() && $this->is_jetpack_disconnected() ) {
-				return 'ciab-disconnected';
+			if ( ! $this->is_enabled() ) {
+				return null;
 			}
-			return null;
+			return $this->is_jetpack_disconnected() ? 'ciab-disconnected' : 'wp-admin';
 		}
 
 		// Frontend: load disconnected variant for eligible logged-in editors.

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/agents-manager/Agents_Manager_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/agents-manager/Agents_Manager_Test.php
@@ -1952,11 +1952,11 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
-	 * Tests that should_enqueue_script returns false in CIAB environment when Jetpack is connected.
+	 * Tests that get_variant returns wp-admin in CIAB environment when Jetpack is connected.
 	 *
-	 * Connected CIAB is handled by Help Center; Agents Manager should not load.
+	 * Since there is no dedicated ciab variant, connected CIAB should use wp-admin.
 	 */
-	public function test_should_enqueue_script_returns_false_in_ciab_when_connected() {
+	public function test_get_variant_returns_wp_admin_in_ciab_when_connected() {
 		$this->set_admin_context();
 
 		// Save and simulate CIAB environment.
@@ -1968,7 +1968,7 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 		// is_jetpack_disconnected() returns false for non-Jetpack sites.
 		add_filter( 'agents_manager_use_unified_experience', '__return_true', 20 );
 
-		$result = $this->call_should_enqueue_script();
+		$result = $this->call_get_variant();
 
 		remove_filter( 'agents_manager_use_unified_experience', '__return_true', 20 );
 
@@ -1979,7 +1979,7 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 			$wp_actions['next_admin_init'] = $original_action_count;
 		}
 
-		$this->assertFalse( $result );
+		$this->assertSame( 'wp-admin', $result );
 	}
 
 	/**


### PR DESCRIPTION
## Proposed changes:
* In `get_variant()`, return `'wp-admin'` for CIAB environments when the site is connected (not disconnected), instead of returning `null` (which prevented scripts from loading).
* Since there is no dedicated `ciab` variant, connected CIAB environments should use the `wp-admin` variant.
* Update the existing test to verify the new behavior (`assertSame( 'wp-admin' )` instead of `assertFalse`).

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:

* In a CIAB/Next Admin environment with Jetpack connected (not disconnected), verify that the Agents Manager scripts load with the `wp-admin` variant (`sectionName` should be `"wp-admin"` in the inline `agentsManagerData`).
* In a CIAB/Next Admin environment with Jetpack disconnected, verify that the `ciab-disconnected` variant is still used.
* In a non-CIAB wp-admin environment, verify behavior is unchanged.

## Changelog
Changelog entry added to `projects/packages/jetpack-mu-wpcom/changelog/agents-manager-ciab-wp-admin-variant`.