### PR TITLE
Subscription Block: only add excerpt link to Newsletters

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-subscription-block-excerpt-text
+++ b/projects/plugins/jetpack/changelog/fix-subscription-block-excerpt-text
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Subscriptions: Only filter excerpts for newsletter emails, not on the front end.

--- a/projects/plugins/jetpack/changelog/fix-subscription-block-excerpt-text
+++ b/projects/plugins/jetpack/changelog/fix-subscription-block-excerpt-text
@@ -1,4 +1,4 @@
 Significance: patch
 Type: bugfix
 
-Subscriptions: Append paywall gate to excerpt on paid posts where the viewer cannot access the content.
+Subscriptions: Remove jetpack_filter_excerpt_for_newsletter method from the excerpt filter.

--- a/projects/plugins/jetpack/changelog/fix-subscription-block-excerpt-text
+++ b/projects/plugins/jetpack/changelog/fix-subscription-block-excerpt-text
@@ -1,4 +1,4 @@
 Significance: patch
 Type: bugfix
 
-Subscriptions: Only filter excerpts for newsletter emails, not on the front end.
+Subscriptions: Append paywall gate to excerpt on paid posts where the viewer cannot access the content.

--- a/projects/plugins/jetpack/changelog/fix-subscription-block-excerpt-text
+++ b/projects/plugins/jetpack/changelog/fix-subscription-block-excerpt-text
@@ -1,4 +1,4 @@
 Significance: patch
 Type: bugfix
 
-Subscriptions: Remove jetpack_filter_excerpt_for_newsletter method from the excerpt filter.
+Subscriptions: Stop appending the “View post … subscribe” message to post excerpts in subscription emails.

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -991,6 +991,11 @@ function render_email( $block_content, array $parsed_block, $rendering_context )
  * @return mixed
  */
 function jetpack_filter_excerpt_for_newsletter( $excerpt, $post = null ) {
+	// Only modify excerpts when rendering a newsletter email.
+	if ( ! defined( 'IS_HTML_EMAIL' ) && ! defined( 'IS_WC_EMAIL' ) ) {
+		return $excerpt;
+	}
+
 	// The blogmagazine theme is overriding WP core `get_the_excerpt` filter and only passing the excerpt
 	// TODO: Until this is fixed, return the excerpt without gating. See https://github.com/Automattic/jetpack/pull/28102#issuecomment-1369161116
 	if ( $post instanceof \WP_Post && has_block( 'jetpack/subscriptions', $post ) ) {

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -153,9 +153,6 @@ function register_block() {
 	// Hide existing comments
 	add_filter( 'get_comment', __NAMESPACE__ . '\maybe_gate_existing_comments' );
 
-	// Gate the excerpt for a post
-	add_filter( 'get_the_excerpt', __NAMESPACE__ . '\jetpack_filter_excerpt_for_newsletter', 10, 2 );
-
 	// Add a 'Newsletter' column to the Edit posts page
 	// We only display the "Newsletter" column if we have configured the paid newsletter plan
 	if ( defined( 'WP_ADMIN' ) && WP_ADMIN && Jetpack_Memberships::has_configured_plans_jetpack_recurring_payments( 'newsletter' ) ) {
@@ -980,36 +977,6 @@ function render_email( $block_content, array $parsed_block, $rendering_context )
 		$button_parsed_block,
 		$rendering_context
 	);
-}
-
-/**
- * Filter excerpts looking for subscription data.
- *
- * @param string   $excerpt The extrapolated excerpt string.
- * @param \WP_Post $post    The current post being processed (in `get_the_excerpt`).
- *
- * @return mixed
- */
-function jetpack_filter_excerpt_for_newsletter( $excerpt, $post = null ) {
-	// Only gate paid posts where the viewer cannot access the content.
-	if ( ! is_paid_post() ) {
-		return $excerpt;
-	}
-
-	require_once JETPACK__PLUGIN_DIR . 'modules/memberships/class-jetpack-memberships.php';
-
-	$post_id = null;
-	if ( $post instanceof \WP_Post ) {
-		$post_id = $post->ID;
-	}
-
-	if ( Jetpack_Memberships::user_can_view_post( $post_id ) ) {
-		return $excerpt;
-	}
-
-	$excerpt .= get_paywall_blocks();
-
-	return $excerpt;
 }
 
 /**

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -991,21 +991,23 @@ function render_email( $block_content, array $parsed_block, $rendering_context )
  * @return mixed
  */
 function jetpack_filter_excerpt_for_newsletter( $excerpt, $post = null ) {
-	// Only modify excerpts when rendering a newsletter email.
-	if ( ! defined( 'IS_HTML_EMAIL' ) && ! defined( 'IS_WC_EMAIL' ) ) {
+	// Only gate paid posts where the viewer cannot access the content.
+	if ( ! is_paid_post() ) {
 		return $excerpt;
 	}
 
-	// The blogmagazine theme is overriding WP core `get_the_excerpt` filter and only passing the excerpt
-	// TODO: Until this is fixed, return the excerpt without gating. See https://github.com/Automattic/jetpack/pull/28102#issuecomment-1369161116
-	if ( $post instanceof \WP_Post && has_block( 'jetpack/subscriptions', $post ) ) {
-		$excerpt .= '<br/><br/>';
-		$excerpt .= sprintf(
-			// translators: %s is the permalink url to the current post.
-			__( "<p><a href='%s'>View post</a> to subscribe to the site's newsletter.</p>", 'jetpack' ),
-			get_post_permalink()
-		);
+	require_once JETPACK__PLUGIN_DIR . 'modules/memberships/class-jetpack-memberships.php';
+
+	$post_id = null;
+	if ( $post instanceof \WP_Post ) {
+		$post_id = $post->ID;
 	}
+
+	if ( Jetpack_Memberships::user_can_view_post( $post_id ) ) {
+		return $excerpt;
+	}
+
+	$excerpt .= get_paywall_blocks();
 
 	return $excerpt;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Closes https://linear.app/a8c/issue/NL-470/only-append-subscribe-message-in-newsletter-email-render

## Proposed changes:

| After | Before |
|--------|--------|
| <img width="861" height="492" alt="Screen Shot 2026-02-25 at 12 15 11" src="https://github.com/user-attachments/assets/17e04e01-b575-4d2f-a73e-7ab6894baeed" /> | <img width="823" height="528" alt="Screen Shot 2026-02-25 at 12 17 02" src="https://github.com/user-attachments/assets/7b00140e-c446-487a-891d-243a2f5a58dc" /> | 

Remove the `jetpack_filter_excerpt_for_newsletter` method from the excerpt filter and delete the method.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Go to your Newsletter settings and set it to show `Excerpt`.
2. Create a post with and add a subscriptions block from the block inserter.
3. Set an excerpt or add some extra content to the post
4. Preview email for the post and ensure `View post to subscribe to site newsletter.` is gone