### PR TITLE
Charts: Make PieSemiCircleChart responsive by default

### DIFF
--- a/projects/js-packages/charts/changelog/charts-169-fix-chart-height-and-size-calculation-for-pie-semi-circle-chart
+++ b/projects/js-packages/charts/changelog/charts-169-fix-chart-height-and-size-calculation-for-pie-semi-circle-chart
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Charts: fix PieSemiCircleChart height and size calculations to be responsive by default, maintaining 2:1 width-to-height ratio.

--- a/projects/js-packages/charts/src/charts/bar-chart/bar-chart.tsx
+++ b/projects/js-packages/charts/src/charts/bar-chart/bar-chart.tsx
@@ -32,7 +32,6 @@ import { useBarChartOptions } from './private';
 import type { BaseChartProps, DataPointDate, SeriesData, Optional } from '../../types';
 import type { ResponsiveConfig } from '../private/with-responsive';
 import type { RenderTooltipParams } from '@visx/xychart/lib/components/Tooltip';
-import type { GapSize } from '@wordpress/theme';
 import type { FC, ReactNode, ComponentType } from 'react';
 
 export interface BarChartProps extends BaseChartProps< SeriesData[] > {
@@ -42,12 +41,6 @@ export interface BarChartProps extends BaseChartProps< SeriesData[] > {
 	showZeroValues?: boolean;
 	legendInteractive?: boolean;
 	children?: ReactNode;
-	/**
-	 * Gap between chart elements (SVG, legend, children).
-	 * Uses WordPress design system tokens.
-	 * @default 'md'
-	 */
-	gap?: GapSize;
 }
 
 // Base props type with optional responsive properties

--- a/projects/js-packages/charts/src/charts/bar-chart/stories/index.api.mdx
+++ b/projects/js-packages/charts/src/charts/bar-chart/stories/index.api.mdx
@@ -32,6 +32,7 @@ Main chart component with responsive behavior by default.
 | `options` | `ChartOptions` | `{}` | Advanced axis and scale configuration |
 | `className` | `string` | - | Additional CSS class name |
 | `children` | `ReactNode` | - | Child components (e.g., `<BarChart.Legend />`) |
+| `gap` | `GapSize` | `'md'` | Gap between chart elements (SVG, legend, children). Uses WordPress design system tokens |
 
 ## BarChart.Legend
 

--- a/projects/js-packages/charts/src/charts/line-chart/stories/index.api.mdx
+++ b/projects/js-packages/charts/src/charts/line-chart/stories/index.api.mdx
@@ -38,6 +38,7 @@ Main chart component with responsive behavior by default.
 | `onPointerMove` | `(event: EventHandlerParams) => void?` | - | Pointer move event handler |
 | `onPointerOut` | `(event: PointerEvent) => void?` | - | Pointer out event handler |
 | `children` | `ReactNode?` | - | Child components (e.g., annotations) |
+| `gap` | `GapSize` | `'md'` | Gap between chart elements (SVG, legend, children). Uses WordPress design system tokens |
 
 ## LineChart.AnnotationsOverlay
 

--- a/projects/js-packages/charts/src/charts/line-chart/types.ts
+++ b/projects/js-packages/charts/src/charts/line-chart/types.ts
@@ -7,7 +7,6 @@ import type {
 } from '../../types';
 import type { GlyphProps } from '@visx/xychart';
 import type { RenderTooltipParams } from '@visx/xychart/lib/components/Tooltip';
-import type { GapSize } from '@wordpress/theme';
 import type { ReactNode, SVGProps, FC } from 'react';
 
 export type LineChartAnnotationProps = {
@@ -44,12 +43,6 @@ export interface LineChartProps extends BaseChartProps< SeriesData[] > {
 	};
 	legendInteractive?: boolean;
 	children?: ReactNode;
-	/**
-	 * Gap between chart elements (SVG, legend, children).
-	 * Uses WordPress design system tokens.
-	 * @default 'md'
-	 */
-	gap?: GapSize;
 }
 
 export type TooltipDatum = {

--- a/projects/js-packages/charts/src/charts/pie-chart/pie-chart.tsx
+++ b/projects/js-packages/charts/src/charts/pie-chart/pie-chart.tsx
@@ -26,7 +26,6 @@ import styles from './pie-chart.module.scss';
 import type { LegendValueDisplay } from '../../components/legend';
 import type { BaseChartProps, DataPointPercentage, Optional } from '../../types';
 import type { ChartComponentWithComposition } from '../private/chart-composition';
-import type { GapSize } from '@wordpress/theme';
 import type { SVGProps, MouseEvent, ReactNode, FC } from 'react';
 
 /**
@@ -121,13 +120,6 @@ export interface PieChartProps extends BaseChartProps< DataPointPercentage[] > {
 	 * When provided, replaces the default BaseTooltip with custom content.
 	 */
 	renderTooltip?: ( params: PieChartRenderTooltipParams ) => ReactNode;
-
-	/**
-	 * Gap between chart elements (SVG, legend, children).
-	 * Uses WordPress design system tokens.
-	 * @default 'md'
-	 */
-	gap?: GapSize;
 }
 
 // Base props type with optional responsive properties

--- a/projects/js-packages/charts/src/charts/pie-semi-circle-chart/pie-semi-circle-chart.module.scss
+++ b/projects/js-packages/charts/src/charts/pie-semi-circle-chart/pie-semi-circle-chart.module.scss
@@ -1,9 +1,4 @@
 .pie-semi-circle-chart {
-	display: flex;
-	flex-direction: column;
-	text-align: center;
-	overflow: hidden;
-
 	// Fill parent when no explicit width/height provided
 	&--responsive {
 		height: 100%;
@@ -22,13 +17,11 @@
 	}
 
 	.label {
-		margin-bottom: 0; // Add space between label and pie chart
-		font-weight: 600; // Make label more prominent than note
-		font-size: 16px; // Set explicit font size
+		font-weight: 600;
+		font-size: 16px;
 	}
 
 	.note {
-		margin-top: 0; // Add space between pie chart and note
-		font-size: 14px; // Slightly smaller text for hierarchy
+		font-size: 14px;
 	}
 }

--- a/projects/js-packages/charts/src/charts/pie-semi-circle-chart/pie-semi-circle-chart.module.scss
+++ b/projects/js-packages/charts/src/charts/pie-semi-circle-chart/pie-semi-circle-chart.module.scss
@@ -2,10 +2,23 @@
 	display: flex;
 	flex-direction: column;
 	text-align: center;
-	gap: 20px;
+	overflow: hidden;
 
-	&--legend-top {
-		flex-direction: column-reverse;
+	// Fill parent when no explicit width/height provided
+	&--responsive {
+		height: 100%;
+		width: 100%;
+	}
+
+	// Flex wrapper that fills remaining Stack space and measures the SVG area
+	&__svg-wrapper {
+		flex: 1;
+		min-height: 0; // Required for flex shrinking
+		min-width: 0; // Required for flex shrinking
+		width: 100%;
+		display: flex;
+		align-items: center;
+		justify-content: center;
 	}
 
 	.label {

--- a/projects/js-packages/charts/src/charts/pie-semi-circle-chart/pie-semi-circle-chart.tsx
+++ b/projects/js-packages/charts/src/charts/pie-semi-circle-chart/pie-semi-circle-chart.tsx
@@ -53,6 +53,7 @@ const renderDefaultPieSemiCircleTooltip = ( {
 };
 
 const PAD_ANGLE = 0.03; // Padding between segments
+const DEFAULT_WIDTH = 400;
 
 export interface PieSemiCircleChartProps extends BaseChartProps< DataPointPercentage[] > {
 	/**
@@ -301,8 +302,12 @@ const PieSemiCircleChartInternal: FC< PieSemiCircleChartProps > = ( {
 
 	const prefersReducedMotion = usePrefersReducedMotion();
 
+	const effectiveWidth = propWidth || DEFAULT_WIDTH;
+
 	if ( ! isValid ) {
-		const errorWidth = Math.min( propWidth || 400, ( propHeight || ( propWidth || 400 ) / 2 ) * 2 );
+		const errorWidth = propHeight
+			? Math.min( propWidth || propHeight * 2, propHeight * 2 )
+			: effectiveWidth;
 		const errorHeight = errorWidth / 2;
 
 		return (
@@ -319,9 +324,9 @@ const PieSemiCircleChartInternal: FC< PieSemiCircleChartProps > = ( {
 	// Calculate chart dimensions maintaining the 2:1 width-to-height ratio.
 	// Use measured SVG wrapper dimensions to respect height constraints, falling back
 	// to explicit props during initial render before measurement is available.
-	const availableWidth = svgWrapperWidth > 0 ? svgWrapperWidth : propWidth || 400;
+	const availableWidth = svgWrapperWidth > 0 ? svgWrapperWidth : effectiveWidth;
 	const availableHeight =
-		svgWrapperHeight > 0 ? svgWrapperHeight : propHeight || ( propWidth || 400 ) / 2;
+		svgWrapperHeight > 0 ? svgWrapperHeight : propHeight || effectiveWidth / 2;
 	// Constrain width so that height (= width / 2) never exceeds the available height
 	const width = Math.min( availableWidth, availableHeight * 2 );
 	const height = width / 2;

--- a/projects/js-packages/charts/src/charts/pie-semi-circle-chart/pie-semi-circle-chart.tsx
+++ b/projects/js-packages/charts/src/charts/pie-semi-circle-chart/pie-semi-circle-chart.tsx
@@ -302,13 +302,12 @@ const PieSemiCircleChartInternal: FC< PieSemiCircleChartProps > = ( {
 	const prefersReducedMotion = usePrefersReducedMotion();
 
 	if ( ! isValid ) {
+		const errorWidth = Math.min( propWidth || 400, ( propHeight || ( propWidth || 400 ) / 2 ) * 2 );
+		const errorHeight = errorWidth / 2;
+
 		return (
 			<div className={ styles[ 'pie-semi-circle-chart' ] }>
-				<svg
-					width={ propWidth || 400 }
-					height={ ( propWidth || 400 ) / 2 }
-					data-testid="pie-chart-svg"
-				>
+				<svg width={ errorWidth } height={ errorHeight } data-testid="pie-chart-svg">
 					<text x="50%" y="50%" textAnchor="middle" className={ styles.error }>
 						{ message }
 					</text>

--- a/projects/js-packages/charts/src/charts/pie-semi-circle-chart/pie-semi-circle-chart.tsx
+++ b/projects/js-packages/charts/src/charts/pie-semi-circle-chart/pie-semi-circle-chart.tsx
@@ -3,6 +3,7 @@ import { Pie } from '@visx/shape';
 import { Text } from '@visx/text';
 import { useTooltip, useTooltipInPortal } from '@visx/tooltip';
 import { __ } from '@wordpress/i18n';
+import { Stack } from '@wordpress/ui';
 import clsx from 'clsx';
 import { useCallback, useContext, useMemo } from 'react';
 import { Legend, useChartLegendItems } from '../../components/legend';
@@ -55,7 +56,9 @@ const PAD_ANGLE = 0.03; // Padding between segments
 
 export interface PieSemiCircleChartProps extends BaseChartProps< DataPointPercentage[] > {
 	/**
-	 * Width of the chart in pixels; height would be half of this value calculated automatically.
+	 * Explicit width of the chart container in pixels.
+	 * When omitted, the chart fills its parent container's width.
+	 * The chart always maintains a 2:1 width-to-height ratio, constrained by available space.
 	 */
 	width?: number;
 
@@ -157,7 +160,8 @@ const validateData = ( data: DataPointPercentage[] ) => {
 const PieSemiCircleChartInternal: FC< PieSemiCircleChartProps > = ( {
 	data,
 	chartId: providedChartId,
-	width = 400,
+	width: propWidth,
+	height: propHeight,
 	thickness = 0.4,
 	clockwise = true,
 	withTooltips = false,
@@ -179,9 +183,11 @@ const PieSemiCircleChartInternal: FC< PieSemiCircleChartProps > = ( {
 	tooltipOffsetX = 0,
 	tooltipOffsetY = -15,
 	renderTooltip = renderDefaultPieSemiCircleTooltip,
+	gap = 'md',
 } ) => {
 	const chartId = useChartId( providedChartId );
-	const [ legendRef, , legendHeight ] = useElementSize< HTMLDivElement >();
+	// Measure the SVG wrapper to calculate constrained dimensions
+	const [ svgWrapperRef, svgWrapperWidth, svgWrapperHeight ] = useElementSize< HTMLDivElement >();
 	const { tooltipOpen, tooltipLeft, tooltipTop, tooltipData, hideTooltip, showTooltip } =
 		useTooltip< DataPointPercentage >();
 
@@ -298,7 +304,11 @@ const PieSemiCircleChartInternal: FC< PieSemiCircleChartProps > = ( {
 	if ( ! isValid ) {
 		return (
 			<div className={ styles[ 'pie-semi-circle-chart' ] }>
-				<svg width={ width } height={ width / 2 } data-testid="pie-chart-svg">
+				<svg
+					width={ propWidth || 400 }
+					height={ ( propWidth || 400 ) / 2 }
+					data-testid="pie-chart-svg"
+				>
 					<text x="50%" y="50%" textAnchor="middle" className={ styles.error }>
 						{ message }
 					</text>
@@ -307,12 +317,16 @@ const PieSemiCircleChartInternal: FC< PieSemiCircleChartProps > = ( {
 		);
 	}
 
-	// Calculate chart dimensions
-	// TODO: we might want to accept height as a prop in the future, because the height of container might not always be enough.
+	// Calculate chart dimensions maintaining the 2:1 width-to-height ratio.
+	// Use measured SVG wrapper dimensions to respect height constraints, falling back
+	// to explicit props during initial render before measurement is available.
+	const availableWidth = svgWrapperWidth > 0 ? svgWrapperWidth : propWidth || 400;
+	const availableHeight =
+		svgWrapperHeight > 0 ? svgWrapperHeight : propHeight || ( propWidth || 400 ) / 2;
+	// Constrain width so that height (= width / 2) never exceeds the available height
+	const width = Math.min( availableWidth, availableHeight * 2 );
 	const height = width / 2;
-	// The chart only takes the height minus the legend height.
-	const chartHeight = height - ( showLegend && legendPosition === 'top' ? legendHeight : 0 );
-	const radius = Math.min( width / 2, chartHeight );
+	const radius = height; // For a semi-circle, radius equals the SVG height
 	const innerRadius = radius * ( 1 - thickness );
 
 	// Map data with index for color assignment
@@ -329,119 +343,144 @@ const PieSemiCircleChartInternal: FC< PieSemiCircleChartProps > = ( {
 	const startAngle = clockwise ? -Math.PI / 2 : Math.PI / 2;
 	const endAngle = clockwise ? Math.PI / 2 : -Math.PI / 2;
 
+	const legendElement = showLegend && (
+		<Legend
+			orientation={ legendOrientation }
+			position={ legendPosition }
+			alignment={ legendAlignment }
+			maxWidth={ legendMaxWidth }
+			textOverflow={ legendTextOverflow }
+			legendItemClassName={ legendItemClassName }
+			shape={ legendShape }
+			chartId={ chartId }
+			interactive={ legendInteractive }
+		/>
+	);
+
 	return (
 		<SingleChartContext.Provider
 			value={ {
 				chartId,
 				chartWidth: width,
-				chartHeight: radius,
+				chartHeight: height,
 			} }
 		>
-			<div
+			<Stack
 				ref={ containerRef }
+				direction="column"
+				gap={ gap }
 				className={ clsx(
 					'pie-semi-circle-chart',
 					styles[ 'pie-semi-circle-chart' ],
 					{
-						[ styles[ 'pie-semi-circle-chart--legend-top' ] ]:
-							showLegend && legendPosition === 'top',
+						[ styles[ 'pie-semi-circle-chart--responsive' ] ]: ! propWidth && ! propHeight,
 					},
 					className
 				) }
+				style={ {
+					width: propWidth || undefined,
+					height: propHeight || undefined,
+				} }
 				data-testid="pie-chart-container"
 			>
-				<svg
-					width={ width }
-					height={ radius }
-					viewBox={ `0 0 ${ width } ${ chartHeight }` }
-					data-testid="pie-chart-svg"
-				>
-					<defs>
-						<RadialWipeAnimation
-							id={ `radial-wipe-${ chartId }` }
-							radius={ radius }
-							innerRadius={ innerRadius }
-							startAngle="-180deg"
-							wipePercentage={ 50 }
-						/>
-					</defs>
+				{ legendPosition === 'top' && legendElement }
 
-					{ /* Main chart group centered horizontally and positioned at bottom */ }
-					<Group
-						top={ chartHeight }
-						left={ width / 2 }
-						mask={ animation && ! prefersReducedMotion ? `url(#radial-wipe-${ chartId })` : null }
+				<div ref={ svgWrapperRef } className={ styles[ 'pie-semi-circle-chart__svg-wrapper' ] }>
+					<svg
+						width={ width }
+						height={ height }
+						viewBox={ `0 0 ${ width } ${ height }` }
+						data-testid="pie-chart-svg"
 					>
-						{ allSegmentsHidden ? (
-							<text
-								textAnchor="middle"
-								y={ -radius / 2 }
-								fill="#ccc"
-								fontSize="14"
-								fontFamily="-apple-system,BlinkMacSystemFont,Roboto,Helvetica Neue,sans-serif"
-							>
-								{ __(
-									'All segments are hidden. Click legend items to show data.',
-									'jetpack-charts'
-								) }
-							</text>
-						) : (
-							<>
-								{ /* Pie chart */ }
-								<Pie< DataPointPercentage & { index: number } >
-									data={ dataWithIndex }
-									pieValue={ accessors.value }
-									outerRadius={ radius }
-									innerRadius={ innerRadius }
-									cornerRadius={ 3 }
-									padAngle={ PAD_ANGLE }
-									startAngle={ startAngle }
-									endAngle={ endAngle }
-									pieSort={ accessors.sort }
+						<defs>
+							<RadialWipeAnimation
+								id={ `radial-wipe-${ chartId }` }
+								radius={ radius }
+								innerRadius={ innerRadius }
+								startAngle="-180deg"
+								wipePercentage={ 50 }
+							/>
+						</defs>
+
+						{ /* Main chart group centered horizontally and positioned at bottom */ }
+						<Group
+							top={ height }
+							left={ width / 2 }
+							mask={ animation && ! prefersReducedMotion ? `url(#radial-wipe-${ chartId })` : null }
+						>
+							{ allSegmentsHidden ? (
+								<text
+									textAnchor="middle"
+									y={ -radius / 2 }
+									fill="#ccc"
+									fontSize="14"
+									fontFamily="-apple-system,BlinkMacSystemFont,Roboto,Helvetica Neue,sans-serif"
 								>
-									{ pie => {
-										return pie.arcs.map( arc => (
-											<g
-												key={ arc.data.label }
-												onMouseMove={ withTooltips ? handleArcMouseMove( arc ) : undefined }
-												onMouseLeave={ withTooltips ? handleMouseLeave : undefined }
-											>
-												<path
-													d={ pie.path( arc ) || '' }
-													fill={ accessors.fill( arc.data ) }
-													data-testid="pie-segment"
-												/>
-											</g>
-										) );
-									} }
-								</Pie>
-
-								{ /* Label and note text */ }
-								<Group>
-									<Text
-										textAnchor="middle"
-										verticalAnchor="start"
-										y={ -40 } // Position above the chart with space for note
-										className={ styles.label }
+									{ __(
+										'All segments are hidden. Click legend items to show data.',
+										'jetpack-charts'
+									) }
+								</text>
+							) : (
+								<>
+									{ /* Pie chart */ }
+									<Pie< DataPointPercentage & { index: number } >
+										data={ dataWithIndex }
+										pieValue={ accessors.value }
+										outerRadius={ radius }
+										innerRadius={ innerRadius }
+										cornerRadius={ 3 }
+										padAngle={ PAD_ANGLE }
+										startAngle={ startAngle }
+										endAngle={ endAngle }
+										pieSort={ accessors.sort }
 									>
-										{ label }
-									</Text>
-									<Text
-										textAnchor="middle"
-										verticalAnchor="start"
-										y={ -20 } // Position between label and chart
-										className={ styles.note }
-									>
-										{ note }
-									</Text>
-								</Group>
+										{ pie => {
+											return pie.arcs.map( arc => (
+												<g
+													key={ arc.data.label }
+													onMouseMove={ withTooltips ? handleArcMouseMove( arc ) : undefined }
+													onMouseLeave={ withTooltips ? handleMouseLeave : undefined }
+												>
+													<path
+														d={ pie.path( arc ) || '' }
+														fill={ accessors.fill( arc.data ) }
+														data-testid="pie-segment"
+													/>
+												</g>
+											) );
+										} }
+									</Pie>
 
-								{ /* Render SVG children from composition API */ }
-								{ ! allSegmentsHidden && svgChildren }
-							</>
-						) }
-					</Group>
-				</svg>
+									{ /* Label and note text */ }
+									<Group>
+										<Text
+											textAnchor="middle"
+											verticalAnchor="start"
+											y={ -40 } // Position above the chart with space for note
+											className={ styles.label }
+										>
+											{ label }
+										</Text>
+										<Text
+											textAnchor="middle"
+											verticalAnchor="start"
+											y={ -20 } // Position between label and chart
+											className={ styles.note }
+										>
+											{ note }
+										</Text>
+									</Group>
+
+									{ /* Render SVG children from composition API */ }
+									{ ! allSegmentsHidden && svgChildren }
+								</>
+							) }
+						</Group>
+					</svg>
+				</div>
+
+				{ legendPosition !== 'top' && legendElement }
 
 				{ withTooltips && tooltipOpen && tooltipData && (
 					<TooltipInPortal top={ tooltipTop || 0 } left={ tooltipLeft || 0 }>
@@ -449,27 +488,12 @@ const PieSemiCircleChartInternal: FC< PieSemiCircleChartProps > = ( {
 					</TooltipInPortal>
 				) }
 
-				{ showLegend && (
-					<Legend
-						orientation={ legendOrientation }
-						position={ legendPosition }
-						alignment={ legendAlignment }
-						maxWidth={ legendMaxWidth }
-						textOverflow={ legendTextOverflow }
-						legendItemClassName={ legendItemClassName }
-						shape={ legendShape }
-						ref={ legendRef }
-						chartId={ chartId }
-						interactive={ legendInteractive }
-					/>
-				) }
-
 				{ /* Render HTML children from composition API */ }
 				{ htmlChildren }
 
 				{ /* Render any other children that aren't compound components */ }
 				{ otherChildren }
-			</div>
+			</Stack>
 		</SingleChartContext.Provider>
 	);
 };

--- a/projects/js-packages/charts/src/charts/pie-semi-circle-chart/stories/index.api.mdx
+++ b/projects/js-packages/charts/src/charts/pie-semi-circle-chart/stories/index.api.mdx
@@ -13,7 +13,7 @@ Main component for rendering semi-circular pie charts.
 | Prop | Type | Default | Description |
 | ---- | ---- | ------- | ----------- |
 | `data` | `DataPointPercentage[]` | - | **Required.** Array of data points to display |
-| `width` | `number` | `400` | Width of the chart in pixels (height is automatically half of width) |
+| `width` | `number` | responsive | Width of the chart in pixels. When omitted, fills parent width (height is automatically half of width) |
 | `thickness` | `number` | `0.4` | Thickness of the pie segments (0-1, where 1 is full thickness) |
 | `clockwise` | `boolean` | `true` | Direction of segment rendering |
 | `label` | `string` | - | Text displayed above the chart |
@@ -28,6 +28,7 @@ Main component for rendering semi-circular pie charts.
 | `legendPosition` | `'top' \| 'bottom'` | `'bottom'` | Legend position (where the legend appears) |
 | `legendShape` | `'circle' \| 'rect' \| 'line'` | `'circle'` | Shape of legend indicators |
 | `className` | `string` | - | Additional CSS class for the container |
+| `gap` | `GapSize` | `'md'` | Gap between chart elements (SVG, legend, children). Uses WordPress design system tokens |
 | `chartId` | `string` | - | Optional unique identifier (auto-generated if not provided) |
 
 ## PieSemiCircleChartRenderTooltipParams Type

--- a/projects/js-packages/charts/src/charts/pie-semi-circle-chart/stories/index.api.mdx
+++ b/projects/js-packages/charts/src/charts/pie-semi-circle-chart/stories/index.api.mdx
@@ -13,7 +13,7 @@ Main component for rendering semi-circular pie charts.
 | Prop | Type | Default | Description |
 | ---- | ---- | ------- | ----------- |
 | `data` | `DataPointPercentage[]` | - | **Required.** Array of data points to display |
-| `width` | `number` | responsive | Width of the chart in pixels. When omitted, fills parent width (height is automatically half of width) |
+| `width` | `number` | responsive | Width of the chart in pixels. When omitted, the chart will try to fill the parent width, but may reduce its width based on available height to maintain the 2:1 aspect ratio (height is automatically half of the final width) |
 | `thickness` | `number` | `0.4` | Thickness of the pie segments (0-1, where 1 is full thickness) |
 | `clockwise` | `boolean` | `true` | Direction of segment rendering |
 | `label` | `string` | - | Text displayed above the chart |

--- a/projects/js-packages/charts/src/charts/pie-semi-circle-chart/stories/index.api.mdx
+++ b/projects/js-packages/charts/src/charts/pie-semi-circle-chart/stories/index.api.mdx
@@ -13,7 +13,8 @@ Main component for rendering semi-circular pie charts.
 | Prop | Type | Default | Description |
 | ---- | ---- | ------- | ----------- |
 | `data` | `DataPointPercentage[]` | - | **Required.** Array of data points to display |
-| `width` | `number` | responsive | Width of the chart in pixels. When omitted, the chart will try to fill the parent width, but may reduce its width based on available height to maintain the 2:1 aspect ratio (height is automatically half of the final width) |
+| `width` | `number` | responsive | Width constraint in pixels. By default the chart fills its parent container. When provided, constrains the chart to this width while maintaining the 2:1 aspect ratio |
+| `height` | `number` | responsive | Height constraint in pixels. By default the chart fills its parent container. When provided, the chart will reduce its width if needed so that height (= width / 2) does not exceed this value |
 | `thickness` | `number` | `0.4` | Thickness of the pie segments (0-1, where 1 is full thickness) |
 | `clockwise` | `boolean` | `true` | Direction of segment rendering |
 | `label` | `string` | - | Text displayed above the chart |

--- a/projects/js-packages/charts/src/charts/pie-semi-circle-chart/stories/index.docs.mdx
+++ b/projects/js-packages/charts/src/charts/pie-semi-circle-chart/stories/index.docs.mdx
@@ -17,36 +17,33 @@ The PieSemiCircleChart component renders data as segments in a semi-circular arc
 	language="jsx"
 	code={ `import { PieSemiCircleChart } from '@automattic/charts';
 
-const data = [
-	{
-		label: 'MacOS',
-		value: 30000,
-		valueDisplay: '30K',
-		percentage: 30,
-	},
-	{
-		label: 'Linux',
-		value: 22000,
-		valueDisplay: '22K',
-		percentage: 22,
-	},
-	{
-		label: 'Windows',
-		value: 48000,
-		valueDisplay: '48K',
-		percentage: 48,
-	},
-];
+	const data = [
+		{
+			label: 'MacOS',
+			value: 30000,
+			valueDisplay: '30K',
+			percentage: 5,
+		},
+		{
+			label: 'Linux',
+			value: 22000,
+			valueDisplay: '22K',
+			percentage: 1,
+		},
+		{
+			label: 'Windows',
+			value: 80000,
+			valueDisplay: '80K',
+			percentage: 2,
+		},
+	];
 
-<PieSemiCircleChart
-	data={ data }
-	width={ 600 }
-	thickness={ 0.4 }
-	label="Operating Systems"
-	note="Windows +10%"
-	withTooltips={ true }
-	showLegend={ true }
-/>` }
+	<PieSemiCircleChart
+		data={ data }
+		thickness={ 0.4 }
+		label="OS"
+		note="Windows +10%"
+	/>` }
 />
 
 The chart automatically validates data to ensure positive values and meaningful percentages, displaying error states for invalid data configurations.
@@ -65,23 +62,12 @@ The simplest implementation requires only data with proper percentage values. Un
 
 <Source
 	language="jsx"
-	code={ `const basicData = [
-	{
-		label: 'Category A',
-		value: 60,
-		percentage: 60,
-	},
-	{
-		label: 'Category B',
-		value: 40,
-		percentage: 40,
-	},
-];
-
-<PieSemiCircleChart
-	data={ basicData }
-	width={ 400 }
-/>` }
+	code={ `<PieSemiCircleChart
+		data={ data }
+		thickness={ 0.4 }
+		label="OS"
+		note="Windows +10%"
+	/>` }
 />
 
 ### Required Props
@@ -103,12 +89,11 @@ Add `withTooltips` to enable hover interactions that display detailed informatio
 <Source
 	language="jsx"
 	code={ `<PieSemiCircleChart
-	data={ data }
-	width={ 600 }
-	withTooltips={ true }
-	label="OS Distribution"
-	note="Hover segments for details"
-/>` }
+		data={ data }
+		withTooltips={ true }
+		label="OS"
+		note="Windows +10%"
+	/>` }
 />
 
 ### Counter-Clockwise Direction
@@ -118,11 +103,11 @@ Use the `clockwise` prop to control the rendering direction of segments:
 <Source
 	language="jsx"
 	code={ `<PieSemiCircleChart
-	data={ data }
-	width={ 600 }
-	clockwise={ false }
-	label="Counter-clockwise Rendering"
-/>` }
+		data={ data }
+		width={ 600 }
+		clockwise={ false }
+		label="Counter-clockwise Rendering"
+	/>` }
 />
 
 ### Different Thickness Values
@@ -132,42 +117,44 @@ Adjust the visual weight of the chart using the `thickness` prop:
 <Source
 	language="jsx"
 	code={ `// Thin ring (thickness: 0.2)
-<PieSemiCircleChart
-	data={ data }
-	width={ 400 }
-	thickness={ 0.2 }
-	label="Thin Ring"
-/>
+	<PieSemiCircleChart
+		data={ data }
+		width={ 400 }
+		thickness={ 0.2 }
+		label="Thin Ring"
+	/>
 
-// Thick ring (thickness: 0.8)
-<PieSemiCircleChart
-	data={ data }
-	width={ 400 }
-	thickness={ 0.8 }
-	label="Thick Ring"
-/>` }
+	// Thick ring (thickness: 0.8)
+	<PieSemiCircleChart
+		data={ data }
+		width={ 400 }
+		thickness={ 0.8 }
+		label="Thick Ring"
+	/>` }
 />
 
 ## Responsive Behavior
 
-### Responsive Width
+By default, charts **fill their parent container's dimensions** while maintaining a 2:1 width-to-height aspect ratio. The parent must have an explicit height:
 
-The chart can be made responsive by omitting the `width` prop, allowing it to adapt to its container:
-
-<Canvas of={ PieSemiCircleChartStories.Responsiveness } />
+<Canvas of={ PieSemiCircleChartStories.Default } />
 
 <Source
 	language="jsx"
-	code={ `// Responsive chart adapts to container width
-<PieSemiCircleChart
-	data={ data }
-	thickness={ 0.4 }
-	label="Responsive Chart"
-	withTooltips={ true }
-/>` }
+	code={ `// Fill parent container (default) - parent needs explicit height
+	<div style={{ width: '100%', height: '400px' }}>
+		<PieSemiCircleChart data={ data } />
+	</div>
+
+	// Fixed dimensions - chart constrains to 2:1 ratio within these bounds
+	<PieSemiCircleChart data={ data } width={ 600 } height={ 300 } />` }
 />
 
-The responsive behavior maintains the 2:1 aspect ratio (width:height) and scales proportionally.
+The chart always maintains a 2:1 width-to-height ratio. When both `width` and `height` are provided, the chart constrains to whichever dimension is more restrictive. Use `width` and/or `height` to constrain the chart to specific pixel dimensions.
+
+<Canvas of={ PieSemiCircleChartStories.FixedDimensions } />
+
+For more details on responsive behavior, see the [Responsive Design section](./?path=/docs/js-packages-charts-library-introduction--docs#responsive-design) in the introduction.
 
 ## Styling and Customization
 
@@ -178,25 +165,25 @@ Segments automatically use theme colors, but you can override individual segment
 <Source
 	language="jsx"
 	code={ `const customColorData = [
-	{
-		label: 'Primary',
-		value: 60,
-		percentage: 60,
-		color: '#3366CC', // Custom blue
-	},
-	{
-		label: 'Secondary',
-		value: 40,
-		percentage: 40,
-		color: '#DC3912', // Custom red
-	},
-];
+		{
+			label: 'Primary',
+			value: 60,
+			percentage: 60,
+			color: '#3366CC', // Custom blue
+		},
+		{
+			label: 'Secondary',
+			value: 40,
+			percentage: 40,
+			color: '#DC3912', // Custom red
+		},
+	];
 
-<PieSemiCircleChart
-	data={ customColorData }
-	width={ 400 }
-	label="Custom Colors"
-/>` }
+	<PieSemiCircleChart
+		data={ customColorData }
+		width={ 400 }
+		label="Custom Colors"
+	/>` }
 />
 
 ### Label and Note Styling
@@ -209,11 +196,11 @@ The chart includes built-in styling for labels and notes with appropriate typogr
 <Source
 	language="jsx"
 	code={ `<PieSemiCircleChart
-	data={ data }
-	width={ 600 }
-	label="Primary Heading"
-	note="Secondary information or context"
-/>` }
+		data={ data }
+		width={ 600 }
+		label="Primary Heading"
+		note="Secondary information or context"
+	/>` }
 />
 
 ## Theming Integration
@@ -243,9 +230,9 @@ The Pie Semi Circle Chart component supports an optional entry animation that cr
 	language="jsx"
 	code={ `<PieSemiCircleChart
 		data={ data }
-		width={ 600 }
 		animation={ true }
-		label="Animated Chart"
+		label="OS"
+		note="Windows +10%"
 	/>` }
 />
 
@@ -267,20 +254,20 @@ Control legend placement using alignment properties:
 <Source
 	language="jsx"
 	code={ `// Legend at top-right
-<PieSemiCircleChart
-	data={ data }
-	showLegend={ true }
-	legendAlignment="end"
-	legendPosition="top"
-/>
+	<PieSemiCircleChart
+		data={ data }
+		showLegend={ true }
+		legendAlignment="end"
+		legendPosition="top"
+	/>
 
-// Vertical legend on the right
-<PieSemiCircleChart
-	data={ data }
-	showLegend={ true }
-	legendOrientation="vertical"
-	legendAlignment="end"
-/>` }
+	// Vertical legend on the right
+	<PieSemiCircleChart
+		data={ data }
+		showLegend={ true }
+		legendOrientation="vertical"
+		legendAlignment="end"
+	/>` }
 />
 
 ### Legend Shape Options
@@ -321,18 +308,18 @@ The chart gracefully handles single data points, rendering a complete semi-circl
 <Source
 	language="jsx"
 	code={ `const singlePointData = [
-	{
-		label: 'Complete',
-		value: 100,
-		percentage: 100,
-	},
-];
+		{
+			label: 'Complete',
+			value: 100,
+			percentage: 100,
+		},
+	];
 
-<PieSemiCircleChart
-	data={ singlePointData }
-	width={ 400 }
-	label="Single Category"
-/>` }
+	<PieSemiCircleChart
+		data={ singlePointData }
+		width={ 400 }
+		label="Single Category"
+	/>` }
 />
 
 ## Advanced Features
@@ -344,25 +331,25 @@ Use the `valueDisplay` property to show formatted values in tooltips and legends
 <Source
 	language="jsx"
 	code={ `const formattedData = [
-	{
-		label: 'Users',
-		value: 15000,
-		valueDisplay: '15K users', // Custom formatted display
-		percentage: 60,
-	},
-	{
-		label: 'Revenue',
-		value: 10000,
-		valueDisplay: '$10K', // Currency formatting
-		percentage: 40,
-	},
-];
+		{
+			label: 'Users',
+			value: 15000,
+			valueDisplay: '15K users', // Custom formatted display
+			percentage: 60,
+		},
+		{
+			label: 'Revenue',
+			value: 10000,
+			valueDisplay: '$10K', // Currency formatting
+			percentage: 40,
+		},
+	];
 
-<PieSemiCircleChart
-	data={ formattedData }
-	withTooltips={ true }
-	showLegend={ true }
-/>` }
+	<PieSemiCircleChart
+		data={ formattedData }
+		withTooltips={ true }
+		showLegend={ true }
+	/>` }
 />
 
 ### Chart Integration
@@ -382,16 +369,16 @@ Semi-circle charts use the same data format as full pie charts, making migration
 <Source
 	language="jsx"
 	code={ `// Full pie chart
-<PieChart
-	data={ data }
-	size={ 400 }
-/>
+	<PieChart
+		data={ data }
+		size={ 400 }
+	/>
 
-// Semi-circle chart (uses width instead of size)
-<PieSemiCircleChart
-	data={ data }
-	width={ 400 }
-/>` }
+	// Semi-circle chart (uses width instead of size)
+	<PieSemiCircleChart
+		data={ data }
+		width={ 400 }
+	/>` }
 />
 
 ### Key Differences from Full Pie Charts
@@ -408,19 +395,19 @@ Unlike full pie charts that require percentages to sum to exactly 100:
 <Source
 	language="jsx"
 	code={ `// Full pie chart - must sum to 100
-const fullPieData = [
-	{ label: 'A', value: 60, percentage: 60 },
-	{ label: 'B', value: 40, percentage: 40 }, // Total: 100%
-];
+	const fullPieData = [
+		{ label: 'A', value: 60, percentage: 60 },
+		{ label: 'B', value: 40, percentage: 40 }, // Total: 100%
+	];
 
-// Semi-circle chart - flexible totals
-const semiCircleData = [
-	{ label: 'Completed', value: 75, percentage: 75 },
-	{ label: 'Remaining', value: 25, percentage: 25 }, // Total: 100%
-];
+	// Semi-circle chart - flexible totals
+	const semiCircleData = [
+		{ label: 'Completed', value: 75, percentage: 75 },
+		{ label: 'Remaining', value: 25, percentage: 25 }, // Total: 100%
+	];
 
-// Or partial completion
-const partialData = [
-	{ label: 'Progress', value: 60, percentage: 60 }, // Shows 60% of semi-circle
-];` }
+	// Or partial completion
+	const partialData = [
+		{ label: 'Progress', value: 60, percentage: 60 }, // Shows 60% of semi-circle
+	];` }
 />

--- a/projects/js-packages/charts/src/charts/pie-semi-circle-chart/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/charts/pie-semi-circle-chart/stories/index.stories.tsx
@@ -51,13 +51,47 @@ type Story = StoryObj< StoryArgs >;
 export const Default: Story = {
 	args: {
 		...sharedThemeArgs,
-		containerWidth: '600px',
-		resize: 'none',
 		thickness: 0.4,
 		data,
 		label: 'OS',
 		note: 'Windows +10%',
 		clockwise: true,
+	},
+	parameters: {
+		docs: {
+			description: {
+				story:
+					'Responsive semi-circle pie chart. Resize the dashed container to see the chart adapt while maintaining a 2:1 width-to-height ratio.',
+			},
+		},
+	},
+};
+
+export const FixedDimensions: Story = {
+	render: args => (
+		<PieSemiCircleChartUnresponsive
+			width={ args.width ?? 400 }
+			data={ args.data }
+			label={ args.label }
+			note={ args.note }
+			thickness={ args.thickness }
+			clockwise={ args.clockwise }
+		/>
+	),
+	args: {
+		...Default.args,
+		resize: 'none',
+		containerWidth: '600px',
+		containerHeight: '350px',
+		width: 400,
+	},
+	parameters: {
+		docs: {
+			description: {
+				story:
+					'Semi-circle pie chart with fixed pixel dimensions. Use `PieSemiCircleChartUnresponsive` when you need precise control over the chart size.',
+			},
+		},
 	},
 };
 
@@ -102,7 +136,6 @@ export const WithCompositionLegend: Story = {
 			<div>
 				<h3>Traditional Props-based Legend</h3>
 				<PieSemiCircleChart
-					width={ 400 }
 					data={ args.data }
 					label="Performance Metrics"
 					note="Q4 2023 Results"
@@ -116,12 +149,7 @@ export const WithCompositionLegend: Story = {
 			</div>
 			<div>
 				<h3>Composition API with Legend Component</h3>
-				<PieSemiCircleChart
-					width={ 400 }
-					data={ args.data }
-					label="Performance Metrics"
-					note="Q4 2023 Results"
-				>
+				<PieSemiCircleChart data={ args.data } label="Performance Metrics" note="Q4 2023 Results">
 					<PieSemiCircleChart.Legend
 						position={ args.legendPosition || 'bottom' }
 						orientation={ args.legendOrientation || 'horizontal' }
@@ -136,6 +164,7 @@ export const WithCompositionLegend: Story = {
 	args: {
 		data,
 		containerWidth: '900px',
+		containerHeight: '400px',
 	},
 	argTypes: {
 		legendInteractive: {
@@ -192,8 +221,7 @@ export const InteractiveLegend: Story = {
 export const CustomLegendPositioning: Story = {
 	args: {
 		containerWidth: '600px',
-		containerHeight: '350px',
-		resize: 'none',
+		containerHeight: '400px',
 		thickness: 0.4,
 		data: [
 			{
@@ -234,15 +262,17 @@ export const CustomLegendPositioning: Story = {
 	},
 };
 
-const responsiveArgs = { ...Default.args, resize: 'both' as const };
-delete responsiveArgs.width;
 export const Responsiveness: Story = {
-	args: responsiveArgs,
+	args: {
+		...Default.args,
+		containerWidth: '800px',
+		containerHeight: '500px',
+	},
 	parameters: {
 		docs: {
 			description: {
 				story:
-					'Semi-circle pie chart with responsive behavior. Uses width prop for unified width/height handling.',
+					'Demonstrates responsive resizing. The chart automatically maintains a 2:1 width-to-height ratio as the container is resized. Drag the bottom-right corner of the dashed container to resize.',
 			},
 		},
 	},

--- a/projects/js-packages/charts/src/charts/pie-semi-circle-chart/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/charts/pie-semi-circle-chart/stories/index.stories.tsx
@@ -275,6 +275,9 @@ export const ErrorStates: Story = {
 			</div>
 		</div>
 	),
+	args: {
+		containerHeight: 600,
+	},
 	parameters: {
 		docs: {
 			description: {

--- a/projects/js-packages/charts/src/charts/pie-semi-circle-chart/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/charts/pie-semi-circle-chart/stories/index.stories.tsx
@@ -10,7 +10,7 @@ import {
 	partialOsUsageData as data,
 	themeArgTypes,
 } from '../../../stories';
-import { PieSemiCircleChart, PieSemiCircleChartUnresponsive } from '../index';
+import { PieSemiCircleChart } from '../index';
 import type { Meta, StoryObj } from '@storybook/react';
 
 type StoryArgs = ChartStoryArgs< React.ComponentProps< typeof PieSemiCircleChart > >;
@@ -27,6 +27,14 @@ const meta: Meta< StoryArgs > = {
 		...themeArgTypes,
 		...legendArgTypes,
 		width: {
+			control: {
+				type: 'range',
+				min: 100,
+				max: 1000,
+				step: 10,
+			},
+		},
+		height: {
 			control: {
 				type: 'range',
 				min: 100,
@@ -69,27 +77,27 @@ export const Default: Story = {
 
 export const FixedDimensions: Story = {
 	render: args => (
-		<PieSemiCircleChartUnresponsive
-			width={ args.width ?? 400 }
+		<PieSemiCircleChart
+			width={ args.width }
 			data={ args.data }
 			label={ args.label }
 			note={ args.note }
 			thickness={ args.thickness }
 			clockwise={ args.clockwise }
+			height={ args.height }
 		/>
 	),
 	args: {
 		...Default.args,
 		resize: 'none',
-		containerWidth: '600px',
-		containerHeight: '350px',
-		width: 400,
+		width: 600,
+		height: 300,
 	},
 	parameters: {
 		docs: {
 			description: {
 				story:
-					'Semi-circle pie chart with fixed pixel dimensions. Use `PieSemiCircleChartUnresponsive` when you need precise control over the chart size.',
+					'Semi-circle pie chart with fixed pixel dimensions. The chart will maintain a 2:1 width-to-height ratio within the provided dimensions.',
 			},
 		},
 	},
@@ -125,46 +133,18 @@ export const WithLegend: Story = {
 
 export const WithCompositionLegend: Story = {
 	render: args => (
-		<div
-			style={ {
-				display: 'grid',
-				gap: '2rem',
-				gridTemplateColumns: 'repeat(2, 1fr)',
-				alignItems: 'center',
-			} }
-		>
-			<div>
-				<h3>Traditional Props-based Legend</h3>
-				<PieSemiCircleChart
-					data={ args.data }
-					label="Performance Metrics"
-					note="Q4 2023 Results"
-					showLegend={ true }
-					legendPosition={ args.legendPosition || 'bottom' }
-					legendOrientation={ args.legendOrientation || 'horizontal' }
-					legendAlignment={ args.legendAlignment || 'center' }
-					legendMaxWidth={ args.legendMaxWidth }
-					legendTextOverflow={ args.legendTextOverflow || 'wrap' }
-				/>
-			</div>
-			<div>
-				<h3>Composition API with Legend Component</h3>
-				<PieSemiCircleChart data={ args.data } label="Performance Metrics" note="Q4 2023 Results">
-					<PieSemiCircleChart.Legend
-						position={ args.legendPosition || 'bottom' }
-						orientation={ args.legendOrientation || 'horizontal' }
-						alignment={ args.legendAlignment || 'center' }
-						maxWidth={ args.legendMaxWidth }
-						textOverflow={ args.legendTextOverflow || 'wrap' }
-					/>
-				</PieSemiCircleChart>
-			</div>
-		</div>
+		<PieSemiCircleChart data={ args.data } label="Performance Metrics" note="Q4 2023 Results">
+			<PieSemiCircleChart.Legend
+				position={ args.legendPosition || 'bottom' }
+				orientation={ args.legendOrientation || 'horizontal' }
+				alignment={ args.legendAlignment || 'center' }
+				maxWidth={ args.legendMaxWidth }
+				textOverflow={ args.legendTextOverflow || 'wrap' }
+			/>
+		</PieSemiCircleChart>
 	),
 	args: {
 		data,
-		containerWidth: '900px',
-		containerHeight: '400px',
 	},
 	argTypes: {
 		legendInteractive: {
@@ -184,29 +164,25 @@ export const WithCompositionLegend: Story = {
 export const InteractiveLegend: Story = {
 	render: args => (
 		<GlobalChartsProvider>
-			<div style={ { padding: '20px' } }>
-				<h3>Interactive Semi-Circle Chart</h3>
+			<PieSemiCircleChart
+				chartId="interactive-semi-circle-chart"
+				data={ args.data }
+				label="Performance Metrics"
+				note="Click legend to filter"
+				showLegend={ true }
+				legendInteractive={ true }
+				legendPosition={ args.legendPosition || 'bottom' }
+				legendOrientation={ args.legendOrientation || 'horizontal' }
+				legendAlignment={ args.legendAlignment || 'center' }
+			>
 				<p style={ { marginBottom: '20px', color: '#666' } }>
 					Click legend items to show/hide segments. Percentages adjust automatically.
 				</p>
-				<PieSemiCircleChartUnresponsive
-					chartId="interactive-semi-circle-chart"
-					width={ args.width || 400 }
-					data={ args.data }
-					label="Performance Metrics"
-					note="Click legend to filter"
-					showLegend={ true }
-					legendInteractive={ true }
-					legendPosition={ args.legendPosition || 'bottom' }
-					legendOrientation={ args.legendOrientation || 'horizontal' }
-					legendAlignment={ args.legendAlignment || 'center' }
-				/>
-			</div>
+			</PieSemiCircleChart>
 		</GlobalChartsProvider>
 	),
 	args: {
 		data,
-		width: 400,
 	},
 	parameters: {
 		docs: {
@@ -220,8 +196,6 @@ export const InteractiveLegend: Story = {
 
 export const CustomLegendPositioning: Story = {
 	args: {
-		containerWidth: '600px',
-		containerHeight: '400px',
 		thickness: 0.4,
 		data: [
 			{
@@ -262,22 +236,6 @@ export const CustomLegendPositioning: Story = {
 	},
 };
 
-export const Responsiveness: Story = {
-	args: {
-		...Default.args,
-		containerWidth: '800px',
-		containerHeight: '500px',
-	},
-	parameters: {
-		docs: {
-			description: {
-				story:
-					'Demonstrates responsive resizing. The chart automatically maintains a 2:1 width-to-height ratio as the container is resized. Drag the bottom-right corner of the dashed container to resize.',
-			},
-		},
-	},
-};
-
 export const ErrorStates: Story = {
 	render: () => (
 		<div style={ { display: 'grid', gap: '2rem', gridTemplateColumns: 'repeat(2, 1fr)' } }>
@@ -311,15 +269,12 @@ export const ErrorStates: Story = {
 			<div>
 				<h3>Single Data Point</h3>
 				<PieSemiCircleChart
-					width={ 300 }
+					height={ 300 }
 					data={ [ { label: 'Single Point', value: 100, percentage: 100 } ] }
 				/>
 			</div>
 		</div>
 	),
-	args: {
-		containerHeight: '600px',
-	},
 	parameters: {
 		docs: {
 			description: {
@@ -347,7 +302,7 @@ export const CompositionAPI: Story = {
 				<div>
 					<h3>With Custom SVG Elements</h3>
 					<PieSemiCircleChart
-						width={ 400 }
+						height={ 300 }
 						data={ args.data }
 						label="OS Usage"
 						note="Q4 2023"
@@ -386,7 +341,7 @@ export const CompositionAPI: Story = {
 				<div>
 					<h3>With Custom Legend and HTML Content</h3>
 					<PieSemiCircleChart
-						width={ 400 }
+						height={ 300 }
 						data={ args.data }
 						label="Performance"
 						note="Latest Results"
@@ -440,7 +395,7 @@ export const CompositionAPI: Story = {
 					For backward compatibility, Group components are still supported directly:
 				</p>
 				<PieSemiCircleChart
-					width={ 400 }
+					height={ 200 }
 					data={ args.data }
 					label="Legacy Mode"
 					note="Still works!"

--- a/projects/js-packages/charts/src/charts/pie-semi-circle-chart/stories/tooltip.stories.tsx
+++ b/projects/js-packages/charts/src/charts/pie-semi-circle-chart/stories/tooltip.stories.tsx
@@ -60,12 +60,9 @@ const Template: StoryFn< typeof PieSemiCircleChart > = args => <PieSemiCircleCha
 const tooltipStoryArgs = {
 	...sharedThemeArgs,
 	data,
-	width: 400,
 	withTooltips: true,
 	label: 'OS Usage',
 	note: 'Q4 2023',
-	containerWidth: '500px',
-	resize: 'none' as const,
 };
 
 export const Default: StoryObj< typeof PieSemiCircleChart > = Template.bind( {} );

--- a/projects/js-packages/charts/src/charts/pie-semi-circle-chart/test/pie-semi-circle-chart.test.tsx
+++ b/projects/js-packages/charts/src/charts/pie-semi-circle-chart/test/pie-semi-circle-chart.test.tsx
@@ -3,6 +3,15 @@ import userEvent from '@testing-library/user-event';
 import { GlobalChartsProvider } from '../../../providers';
 import PieSemiCircleChart from '../pie-semi-circle-chart';
 
+// Mock useParentSize so the responsive wrapper returns predictable dimensions in tests
+jest.mock( '@visx/responsive', () => ( {
+	useParentSize: jest.fn( () => ( {
+		parentRef: { current: null },
+		width: 400,
+		height: 200,
+	} ) ),
+} ) );
+
 // Mock data for testing
 const mockData = [
 	{
@@ -167,15 +176,15 @@ describe( 'PieSemiCircleChart', () => {
 		expect( thinPathD ).not.toBe( thickPathD );
 	} );
 
-	it( 'renders with correct dimensions', () => {
-		const width = 400;
-		render( <PieSemiCircleChart data={ mockData } width={ width } /> );
+	it( 'renders with correct dimensions from measured container', () => {
+		// Mock returns width:400, height:200 — chart should render at 400×200 (2:1 ratio)
+		render( <PieSemiCircleChart data={ mockData } /> );
 
 		const svg = screen.getByTestId( 'pie-chart-svg' );
 
-		expect( svg ).toHaveAttribute( 'width', width.toString() );
-		expect( svg ).toHaveAttribute( 'height', ( width / 2 ).toString() );
-		expect( svg ).toHaveAttribute( 'viewBox', `0 0 ${ width } ${ width / 2 }` );
+		expect( svg ).toHaveAttribute( 'width', '400' );
+		expect( svg ).toHaveAttribute( 'height', '200' );
+		expect( svg ).toHaveAttribute( 'viewBox', '0 0 400 200' );
 	} );
 
 	describe( 'Data Validation', () => {
@@ -213,6 +222,37 @@ describe( 'PieSemiCircleChart', () => {
 			expect(
 				screen.getByText( 'Invalid data: Negative values are not allowed' )
 			).toBeInTheDocument();
+		} );
+	} );
+
+	describe( 'Responsive wrapper', () => {
+		it( 'fills parent container (height:100%) by default', () => {
+			render( <PieSemiCircleChart data={ mockData } /> );
+			const wrapper = screen.getByTestId( 'responsive-wrapper' );
+			expect( wrapper ).toHaveStyle( { height: '100%' } );
+		} );
+
+		it( 'constrains chart to 2:1 ratio from measured dimensions', () => {
+			// Mock returns width:400, height:200, so chart renders at 400×200 (2:1 ratio)
+			render( <PieSemiCircleChart data={ mockData } /> );
+			const svg = screen.getByTestId( 'pie-chart-svg' );
+			expect( svg ).toHaveAttribute( 'width', '400' );
+			expect( svg ).toHaveAttribute( 'height', '200' );
+		} );
+
+		it( 'constrains chart width when container height is shorter than 2:1 ratio', () => {
+			// If parent height is 100px, chart should be at most 200×100 (not 400×200)
+			const { useParentSize } = jest.requireMock( '@visx/responsive' );
+			useParentSize.mockReturnValueOnce( {
+				parentRef: { current: null },
+				width: 400,
+				height: 100,
+			} );
+			render( <PieSemiCircleChart data={ mockData } /> );
+			const svg = screen.getByTestId( 'pie-chart-svg' );
+			// chartWidth = min(400, 100*2) = 200, chartHeight = 100
+			expect( svg ).toHaveAttribute( 'width', '200' );
+			expect( svg ).toHaveAttribute( 'height', '100' );
 		} );
 	} );
 

--- a/projects/js-packages/charts/src/types.ts
+++ b/projects/js-packages/charts/src/types.ts
@@ -7,6 +7,7 @@ import type { LegendShape } from '@visx/legend/lib/types';
 import type { ScaleInput, ScaleType } from '@visx/scale';
 import type { TextProps } from '@visx/text/lib/Text';
 import type { EventHandlerParams, GlyphProps, GridStyles, LineStyles } from '@visx/xychart';
+import type { GapSize } from '@wordpress/theme';
 import type { CSSProperties, PointerEvent, ReactNode } from 'react';
 import type { GoogleDataTableColumn, GoogleDataTableRow } from 'react-google-charts';
 
@@ -458,6 +459,13 @@ export type BaseChartProps< T = DataPoint | DataPointDate | LeaderboardEntry > =
 	 * Whether to show chart animation on initial render or not
 	 */
 	animation?: boolean;
+
+	/**
+	 * Gap between chart elements (SVG, legend, children).
+	 * Uses WordPress design system tokens.
+	 * @default 'md'
+	 */
+	gap?: GapSize;
 
 	/**
 	 * More options for the chart.


### PR DESCRIPTION
Fixes: https://linear.app/a8c/issue/CHARTS-169

## Summary

This PR is one in a series that make chart components responsive by default, so they fill their parent container without requiring explicit dimensions.

The PR applies the same pattern used for Line, Bar and Pie charts to the `PieSemiCircleChart`. It also standardises the `gap` prop across all chart types and aligns the Storybook docs with the responsive-by-default conventions established in the earlier PRs.

## Proposed changes:

- Make `PieSemiCircleChart` responsive by default — fills its parent container when no explicit `width`/`height` is provided
- Maintain strict 2:1 width-to-height ratio, constrained by available space using `useElementSize` on the SVG wrapper
- Apply the same constrained sizing to the error-state SVG so it respects explicit `width` and/or `height` props (e.g. `height={400}` correctly derives `width=800`)
- Replace manual legend-top flex hack with `@wordpress/ui` `Stack` for layout; add configurable `gap` prop
- Move `gap` prop to shared `BaseChartProps` and remove duplicate `GapSize` imports from `BarChart`, `LineChart`, and `PieChart`
- Rewrite Storybook docs to describe responsive-by-default behaviour consistently with line, bar, and pie chart docs — `width`/`height` are constraints, not enablers
- Fix `<Source>` code blocks in docs to match their `<Canvas>` stories (data, props, responsive defaults)
- Fix broken `Responsiveness` story reference in docs; add `FixedDimensions` Canvas
- Add missing `height` prop to the API reference
- Simplify Storybook stories: remove redundant `Responsiveness` story, drop hardcoded `width`/`containerWidth` props, add `height` control and fixed-dimensions story
- Update tests for responsive behaviour including height-constrained scenarios

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Testing instructions:

1. Start Storybook: `cd projects/js-packages/charts && pnpm storybook`
2. Open the `PieSemiCircleChart` stories
3. Verify the default story fills its container responsively and maintains the 2:1 ratio when resized
4. Verify the fixed-dimension story renders at the specified size and does not resize
5. Confirm legend renders correctly for both `top` and `bottom` positions
6. Check error states render correctly and don't overflow their containers
7. Run unit tests: `cd projects/js-packages/charts && pnpm test`

## Changelog

See `projects/js-packages/charts/changelog/charts-169-fix-chart-height-and-size-calculation-for-pie-semi-circle-chart`

## Does this pull request change what data or activity we track or use?

No. This PR only changes how `PieSemiCircleChart` calculates and renders its dimensions — no data collection, tracking, or analytics are added or modified.
