### PR TITLE
Agents Manager: Add dedicated CIAB variant support

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/agents-manager-ciab-variant-support
+++ b/projects/packages/jetpack-mu-wpcom/changelog/agents-manager-ciab-variant-support
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Agents Manager: Add dedicated CIAB variant. CIAB environments always load Agents Manager regardless of the unified experience setting, using the new 'ciab' variant for connected sites and 'ciab-disconnected' for disconnected sites.

--- a/projects/packages/jetpack-mu-wpcom/src/features/agents-manager/class-agents-manager.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/agents-manager/class-agents-manager.php
@@ -312,7 +312,7 @@ class Agents_Manager {
 	public static function is_enabled() {
 		// CIAB: Agents Manager is the default AI experience — enabled unless explicitly
 		// disabled via filter (e.g. for debugging or gradual rollout).
-		if ( (bool) did_action( 'next_admin_init' ) ) {
+		if ( self::is_ciab_environment() ) {
 			/**
 			 * Filter whether Agents Manager is enabled in CIAB (Next Admin) environments.
 			 *
@@ -735,7 +735,7 @@ class Agents_Manager {
 	 *
 	 * @return bool True if CIAB/Next Admin environment.
 	 */
-	private function is_ciab_environment() {
+	private static function is_ciab_environment() {
 		return (bool) did_action( 'next_admin_init' );
 	}
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/agents-manager/class-agents-manager.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/agents-manager/class-agents-manager.php
@@ -176,9 +176,11 @@ class Agents_Manager {
 			wp_dequeue_style( 'help-center-style' );
 		}
 
-		// For non-Gutenberg environments, add to admin bar
-		// Gutenberg doesn't have an admin bar, so JS will handle UI insertion
-		if ( ! $is_gutenberg ) {
+		// For non-Gutenberg, non-CIAB environments, add to admin bar.
+		// Gutenberg doesn't have an admin bar, so JS will handle UI insertion.
+		// CIAB hides the classic admin bar and uses its own Site Hub — the JS variant handles UI there.
+		$is_ciab = $this->is_ciab_environment();
+		if ( ! $is_gutenberg && ! $is_ciab ) {
 			add_action(
 				'admin_bar_menu',
 				function ( $wp_admin_bar ) use ( $use_disconnected ) {
@@ -271,12 +273,14 @@ class Agents_Manager {
 	 * @return string|null The variant name, or null if scripts should not be loaded.
 	 */
 	private function get_variant() {
-		// CIAB/Next Admin: only load when disconnected (connected CIAB is handled by Help Center).
-		if ( $this->is_ciab_environment() ) {
-			if ( self::is_enabled() && $this->is_jetpack_disconnected() ) {
-				return 'ciab-disconnected';
-			}
+		// Universal: skip block editor if explicitly disabled (e.g. CIAB parent page already runs AM).
+		if ( $this->is_block_editor() && ! apply_filters( 'agents_manager_enqueue_in_block_editor', true ) ) {
 			return null;
+		}
+
+		// CIAB/Next Admin: always load. No is_enabled() gating — CIAB manages its own AI experience.
+		if ( $this->is_ciab_environment() ) {
+			return $this->is_jetpack_disconnected() ? 'ciab-disconnected' : 'ciab';
 		}
 
 		// Frontend: load disconnected variant for eligible logged-in editors.
@@ -321,6 +325,7 @@ class Agents_Manager {
 			return true;
 		}
 
+		// Note: CIAB environments bypass is_enabled() entirely — see get_variant().
 		return false;
 	}
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/agents-manager/class-agents-manager.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/agents-manager/class-agents-manager.php
@@ -273,11 +273,6 @@ class Agents_Manager {
 	 * @return string|null The variant name, or null if scripts should not be loaded.
 	 */
 	private function get_variant() {
-		// Universal: skip block editor if explicitly disabled (e.g. CIAB parent page already runs AM).
-		if ( self::is_block_editor() && ! apply_filters( 'agents_manager_enqueue_in_block_editor', true ) ) {
-			return null;
-		}
-
 		// CIAB: Load either the connected or disconnected variants if enabled.
 		if ( $this->is_ciab_environment() && self::is_enabled() ) {
 			return $this->is_jetpack_disconnected() ? 'ciab-disconnected' : 'ciab';

--- a/projects/packages/jetpack-mu-wpcom/src/features/agents-manager/class-agents-manager.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/agents-manager/class-agents-manager.php
@@ -274,12 +274,12 @@ class Agents_Manager {
 	 */
 	private function get_variant() {
 		// Universal: skip block editor if explicitly disabled (e.g. CIAB parent page already runs AM).
-		if ( $this->is_block_editor() && ! apply_filters( 'agents_manager_enqueue_in_block_editor', true ) ) {
+		if ( self::is_block_editor() && ! apply_filters( 'agents_manager_enqueue_in_block_editor', true ) ) {
 			return null;
 		}
 
-		// CIAB/Next Admin: always load. No is_enabled() gating — CIAB manages its own AI experience.
-		if ( $this->is_ciab_environment() ) {
+		// CIAB: Load either the connected or disconnected variants if enabled.
+		if ( $this->is_ciab_environment() && self::is_enabled() ) {
 			return $this->is_jetpack_disconnected() ? 'ciab-disconnected' : 'ciab';
 		}
 
@@ -315,6 +315,17 @@ class Agents_Manager {
 	 * @return bool
 	 */
 	public static function is_enabled() {
+		// CIAB: Agents Manager is the default AI experience — enabled unless explicitly
+		// disabled via filter (e.g. for debugging or gradual rollout).
+		if ( (bool) did_action( 'next_admin_init' ) ) {
+			/**
+			 * Filter whether Agents Manager is enabled in CIAB (Next Admin) environments.
+			 *
+			 * @param bool $enabled Whether Agents Manager should load. Default true.
+			 */
+			return apply_filters( 'agents_manager_enabled_in_ciab', true );
+		}
+
 		// Full unified experience: Agents Manager with support guides, Help Center takeover, etc.
 		if ( apply_filters( 'agents_manager_use_unified_experience', false ) ) {
 			return true;
@@ -325,7 +336,6 @@ class Agents_Manager {
 			return true;
 		}
 
-		// Note: CIAB environments bypass is_enabled() entirely — see get_variant().
 		return false;
 	}
 

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/agents-manager/Agents_Manager_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/agents-manager/Agents_Manager_Test.php
@@ -61,6 +61,13 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 	private $original_current_screen;
 
 	/**
+	 * Original next_admin_init action count to restore after tests.
+	 *
+	 * @var int
+	 */
+	private $original_next_admin_init_count;
+
+	/**
 	 * Set up test fixtures.
 	 */
 	public function set_up() {
@@ -77,6 +84,10 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 
 		// Save original current_screen global.
 		$this->original_current_screen = $GLOBALS['current_screen'] ?? null;
+
+		// Save original next_admin_init action count (CIAB detection).
+		global $wp_actions;
+		$this->original_next_admin_init_count = $wp_actions['next_admin_init'] ?? 0;
 	}
 
 	/**
@@ -121,6 +132,14 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 
 		// Log out any logged-in user.
 		wp_set_current_user( 0 );
+
+		// Restore next_admin_init action count (CIAB detection).
+		global $wp_actions;
+		if ( $this->original_next_admin_init_count === 0 ) {
+			unset( $wp_actions['next_admin_init'] );
+		} else {
+			$wp_actions['next_admin_init'] = $this->original_next_admin_init_count;
+		}
 
 		// Clear the status cache and constants.
 		Cache::clear();
@@ -1740,7 +1759,7 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 
 	/**
 	 * Tests that enqueue_scripts includes sectionName as ciab-disconnected in CIAB environment
-	 * when Jetpack is disconnected. CIAB always loads AM regardless of unified experience setting.
+	 * when Jetpack is disconnected.
 	 */
 	public function test_enqueue_scripts_includes_section_name_ciab_disconnected() {
 		// Set admin context - scripts only enqueue in admin.
@@ -1750,8 +1769,9 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 		global $wp_actions;
 		$original_action_count = $wp_actions['next_admin_init'] ?? 0;
 
-		// Simulate CIAB environment by firing the next_admin_init action.
-		do_action( 'next_admin_init' );
+		// Simulate CIAB environment by incrementing the action counter directly
+		// (avoids side effects from firing the action, which would trigger enqueue_scripts).
+		$wp_actions['next_admin_init'] = ( $wp_actions['next_admin_init'] ?? 0 ) + 1;
 
 		// Reset the script registry.
 		global $wp_scripts;
@@ -1760,7 +1780,6 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 		wp_register_script( 'agents-manager', 'https://example.com/agents-manager.js', array(), '1.0', true );
 
 		// Simulate a Jetpack site with a disconnected user.
-		// Note: no agents_manager_use_unified_experience needed — CIAB bypasses is_enabled().
 		add_filter( 'is_jetpack_site', '__return_true', 20 );
 		// Do not connect the user - is_user_connected() will return false by default.
 
@@ -1784,7 +1803,7 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 
 	/**
 	 * Tests that enqueue_scripts includes sectionName as ciab in CIAB environment
-	 * when Jetpack is connected. CIAB always loads AM regardless of unified experience setting.
+	 * when is_jetpack_disconnected() returns false (non-Jetpack site or connected user).
 	 */
 	public function test_enqueue_scripts_includes_section_name_ciab_connected() {
 		// Set admin context - scripts only enqueue in admin.
@@ -1794,8 +1813,9 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 		global $wp_actions;
 		$original_action_count = $wp_actions['next_admin_init'] ?? 0;
 
-		// Simulate CIAB environment by firing the next_admin_init action.
-		do_action( 'next_admin_init' );
+		// Simulate CIAB environment by incrementing the action counter directly
+		// (avoids side effects from firing the action, which would trigger enqueue_scripts).
+		$wp_actions['next_admin_init'] = ( $wp_actions['next_admin_init'] ?? 0 ) + 1;
 
 		// Reset the script registry.
 		global $wp_scripts;
@@ -1991,19 +2011,17 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
-	 * Tests that get_variant returns ciab in CIAB environment when Jetpack is connected.
-	 *
-	 * CIAB always loads Agents Manager regardless of useUnifiedExperience flag.
+	 * Tests that get_variant returns ciab in CIAB environment
+	 * when is_jetpack_disconnected() returns false (non-Jetpack site or connected user).
 	 */
 	public function test_get_variant_returns_ciab_in_ciab_when_connected() {
 		$this->set_admin_context();
 
 		// Save and simulate CIAB environment.
 		global $wp_actions;
-		$original_action_count = $wp_actions['next_admin_init'] ?? 0;
-		do_action( 'next_admin_init' );
+		$original_action_count         = $wp_actions['next_admin_init'] ?? 0;
+		$wp_actions['next_admin_init'] = ( $wp_actions['next_admin_init'] ?? 0 ) + 1;
 
-		// Do NOT enable unified experience — CIAB bypasses is_enabled() entirely.
 		// is_jetpack_disconnected() returns false for non-Jetpack sites.
 		$result = $this->call_get_variant();
 
@@ -2152,6 +2170,34 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 		remove_filter( 'agents_manager_use_unified_experience', '__return_true', 20 );
 
 		$this->assertTrue( $result );
+	}
+
+	/**
+	 * Tests that get_variant returns null in CIAB when agents_manager_enabled_in_ciab filter returns false.
+	 */
+	public function test_get_variant_returns_null_in_ciab_when_disabled_by_filter() {
+		$this->set_admin_context();
+
+		// Save and simulate CIAB environment.
+		global $wp_actions;
+		$original_action_count         = $wp_actions['next_admin_init'] ?? 0;
+		$wp_actions['next_admin_init'] = ( $wp_actions['next_admin_init'] ?? 0 ) + 1;
+
+		// Disable AM in CIAB via filter.
+		add_filter( 'agents_manager_enabled_in_ciab', '__return_false', 20 );
+
+		$result = $this->call_get_variant();
+
+		remove_filter( 'agents_manager_enabled_in_ciab', '__return_false', 20 );
+
+		// Restore did_action counter.
+		if ( $original_action_count === 0 ) {
+			unset( $wp_actions['next_admin_init'] );
+		} else {
+			$wp_actions['next_admin_init'] = $original_action_count;
+		}
+
+		$this->assertNull( $result );
 	}
 
 	/**

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/agents-manager/Agents_Manager_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/agents-manager/Agents_Manager_Test.php
@@ -1740,7 +1740,7 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 
 	/**
 	 * Tests that enqueue_scripts includes sectionName as ciab-disconnected in CIAB environment
-	 * when unified experience is enabled but Jetpack is disconnected.
+	 * when Jetpack is disconnected. CIAB always loads AM regardless of unified experience setting.
 	 */
 	public function test_enqueue_scripts_includes_section_name_ciab_disconnected() {
 		// Set admin context - scripts only enqueue in admin.
@@ -1759,8 +1759,8 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 
 		wp_register_script( 'agents-manager', 'https://example.com/agents-manager.js', array(), '1.0', true );
 
-		// Enable unified experience and simulate a Jetpack site with a disconnected user.
-		add_filter( 'agents_manager_use_unified_experience', '__return_true', 20 );
+		// Simulate a Jetpack site with a disconnected user.
+		// Note: no agents_manager_use_unified_experience needed — CIAB bypasses is_enabled().
 		add_filter( 'is_jetpack_site', '__return_true', 20 );
 		// Do not connect the user - is_user_connected() will return false by default.
 
@@ -1772,8 +1772,47 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 
 		$this->assertStringContainsString( '"sectionName":"ciab-disconnected"', $inline_script );
 
-		remove_filter( 'agents_manager_use_unified_experience', '__return_true', 20 );
 		remove_filter( 'is_jetpack_site', '__return_true', 20 );
+
+		// Restore the original did_action counter to prevent test order dependencies.
+		if ( $original_action_count === 0 ) {
+			unset( $wp_actions['next_admin_init'] );
+		} else {
+			$wp_actions['next_admin_init'] = $original_action_count;
+		}
+	}
+
+	/**
+	 * Tests that enqueue_scripts includes sectionName as ciab in CIAB environment
+	 * when Jetpack is connected. CIAB always loads AM regardless of unified experience setting.
+	 */
+	public function test_enqueue_scripts_includes_section_name_ciab_connected() {
+		// Set admin context - scripts only enqueue in admin.
+		$this->set_admin_context();
+
+		// Save the current did_action counter for next_admin_init to restore later.
+		global $wp_actions;
+		$original_action_count = $wp_actions['next_admin_init'] ?? 0;
+
+		// Simulate CIAB environment by firing the next_admin_init action.
+		do_action( 'next_admin_init' );
+
+		// Reset the script registry.
+		global $wp_scripts;
+		$wp_scripts = null;
+
+		wp_register_script( 'agents-manager', 'https://example.com/agents-manager.js', array(), '1.0', true );
+
+		// Do NOT simulate a Jetpack disconnected site.
+		// is_jetpack_disconnected() returns false for non-Jetpack sites.
+
+		$this->agents_manager->enqueue_scripts();
+
+		$this->assertNotNull( $wp_scripts, 'wp_scripts should be initialized after enqueue_scripts' );
+		$inline_scripts = $wp_scripts->registered['agents-manager']->extra['before'] ?? array();
+		$inline_script  = implode( "\n", array_filter( $inline_scripts ) );
+
+		$this->assertStringContainsString( '"sectionName":"ciab"', $inline_script );
 
 		// Restore the original did_action counter to prevent test order dependencies.
 		if ( $original_action_count === 0 ) {
@@ -1952,11 +1991,11 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
-	 * Tests that should_enqueue_script returns false in CIAB environment when Jetpack is connected.
+	 * Tests that get_variant returns ciab in CIAB environment when Jetpack is connected.
 	 *
-	 * Connected CIAB is handled by Help Center; Agents Manager should not load.
+	 * CIAB always loads Agents Manager regardless of useUnifiedExperience flag.
 	 */
-	public function test_should_enqueue_script_returns_false_in_ciab_when_connected() {
+	public function test_get_variant_returns_ciab_in_ciab_when_connected() {
 		$this->set_admin_context();
 
 		// Save and simulate CIAB environment.
@@ -1964,13 +2003,9 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 		$original_action_count = $wp_actions['next_admin_init'] ?? 0;
 		do_action( 'next_admin_init' );
 
-		// Enable unified experience but do NOT simulate a Jetpack disconnected site.
+		// Do NOT enable unified experience — CIAB bypasses is_enabled() entirely.
 		// is_jetpack_disconnected() returns false for non-Jetpack sites.
-		add_filter( 'agents_manager_use_unified_experience', '__return_true', 20 );
-
-		$result = $this->call_should_enqueue_script();
-
-		remove_filter( 'agents_manager_use_unified_experience', '__return_true', 20 );
+		$result = $this->call_get_variant();
 
 		// Restore did_action counter.
 		if ( $original_action_count === 0 ) {
@@ -1979,7 +2014,7 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 			$wp_actions['next_admin_init'] = $original_action_count;
 		}
 
-		$this->assertFalse( $result );
+		$this->assertSame( 'ciab', $result );
 	}
 
 	/**


### PR DESCRIPTION
## Proposed changes

Add a dedicated `ciab` variant for Agents Manager in CIAB (Commerce in a Box / Next Admin) environments. This replaces the previous approach of falling back to the `wp-admin` variant.

This is part of a 3-PR change set for [WOOAI-253](https://linear.app/a8c/issue/WOOAI-253/migrate-ciab-ai-chat-to-unified-chat):

| PR | Repository | Purpose |
|----|-----------|---------|
| **This PR** | `Automattic/jetpack` | Add dedicated `ciab` variant to Agents Manager PHP |
| [wp-calypso #108896](https://github.com/Automattic/wp-calypso/pull/108896) | `Automattic/wp-calypso` | Add `agents-manager-ciab.js` webpack entry point |
| ciab-admin #3299 | `Automattic/ciab-admin` | Disable Big Sky dock when AM is active |

### Key changes:

- **CIAB variant**: `get_variant()` returns `'ciab'` for connected CIAB sites and `'ciab-disconnected'` for disconnected sites. CIAB manages its own AI experience.
- **Enabled by default with escape hatch**: CIAB goes through `is_enabled()` like every other context, but with a dedicated `agents_manager_enabled_in_ciab` filter that defaults to `true`. This provides a clean way to disable AM in CIAB for debugging or gradual rollout.
- **Skip admin bar for CIAB**: CIAB hides the classic WordPress admin bar and uses its own Site Hub. Admin bar manipulation (node removal, menu panel) is skipped for CIAB — the JS variant handles UI independently.
- **Help Center coexists**: AM does not dequeue Help Center scripts in CIAB (dequeue only happens in Gutenberg). Help Center continues to manage its own Site Hub button.

## Other information

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

## Testing instructions

### CIAB connected
1. Set up a CIAB environment with Jetpack connected
2. Verify `agentsManagerData.sectionName` is `"ciab"` in the inline script
3. Verify Agents Manager chat UI loads
4. Verify Help Center button still appears in the Site Hub

### CIAB disconnected
1. Simulate Jetpack disconnected in CIAB (edit `is_jetpack_disconnected` to return true)
2. Verify `sectionName` is `"ciab-disconnected"`

### Non-CIAB wp-admin
1. Verify behavior is unchanged — AM only loads when `useUnifiedExperience` is true

### Disabling via filter
1. Add `add_filter( 'agents_manager_enabled_in_ciab', '__return_false' )` in a plugin
2. Verify AM does not load in CIAB

## Does this pull request change what data or activity we track or use?

No.