### PR TITLE
Forms: Fix "Other" toggle not updating option label in editor

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-other-option-label-reset
+++ b/projects/packages/forms/changelog/fix-forms-other-option-label-reset
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix "Other" option toggle not updating the option label in the editor

--- a/projects/packages/forms/src/blocks/option/edit.js
+++ b/projects/packages/forms/src/blocks/option/edit.js
@@ -151,7 +151,12 @@ const OptionEdit = ( {
 						<ToggleControl
 							label={ __( '"Other" option', 'jetpack-forms' ) }
 							checked={ !! isOther }
-							onChange={ value => setAttributes( { isOther: value } ) }
+							onChange={ value =>
+								setAttributes( {
+									isOther: value,
+									label: value ? '' : label,
+								} )
+							}
 							help={ __(
 								'Show as "Other" option with a text input field below it.',
 								'jetpack-forms'

--- a/projects/packages/forms/src/blocks/option/edit.js
+++ b/projects/packages/forms/src/blocks/option/edit.js
@@ -174,7 +174,7 @@ const OptionEdit = ( {
 					tagName="div"
 					className="wp-block"
 					value={ labelValue }
-					placeholder={ __( 'Add option…', 'jetpack-forms' ) }
+					placeholder={ placeholderValue }
 					__unstableDisableFormats
 					onChange={ newLabel => setAttributes( { label: newLabel } ) }
 					onMerge={ mergeBlocks }


### PR DESCRIPTION
Follow-up of #46461 (fixes some regressions)

## Proposed changes:
* Fix the per-option sidebar "Other" toggle to clear the existing label when toggled on, so the "Other" placeholder text takes effect (matching the behavior of the parent-level "Include Other option" toggle which creates blocks with `label: 'Other'`).
* Use the dynamic `placeholderValue` (which switches between "Other" and "Add option…" based on `isOther`) for the non-standalone RichText placeholder, instead of a hardcoded "Add option…" string.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:

* Open a post with a Jetpack Form containing a **Single Choice (radio)** field with at least one option
* Select a radio option that has a label (e.g., type "Option B")
* In the block sidebar, toggle **"Other" option** ON
* Verify the label changes to show **"Other"** (placeholder text) and a "Please specify…" text input appears below
* Toggle **"Other" option** OFF and verify the label reverts to the "Add option…" placeholder
* Also test the parent-level **"Include Other option"** toggle (on the Single Choice field itself) to confirm it still works as before

## Changelog

- [x] Generate changelog entries for this PR (using AI).