### PR TITLE
Jetpack: SEO panel discoverability

### DIFF
--- a/projects/plugins/jetpack/changelog/jetpack-1369-seo-panel-discoverability
+++ b/projects/plugins/jetpack/changelog/jetpack-1369-seo-panel-discoverability
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+SEO: Restore the Optimize SEO panel to the Jetpack sidebar for improved discoverability.

--- a/projects/plugins/jetpack/changelog/jetpack-1369-seo-panel-discoverability
+++ b/projects/plugins/jetpack/changelog/jetpack-1369-seo-panel-discoverability
@@ -1,4 +1,4 @@
 Significance: patch
 Type: bugfix
 
-SEO: Restore the Optimize SEO panel to the Jetpack sidebar for improved discoverability.
+SEO: Restore the Optimize SEO panel to the Jetpack sidebar alongside document settings.

--- a/projects/plugins/jetpack/extensions/plugins/seo/index.js
+++ b/projects/plugins/jetpack/extensions/plugins/seo/index.js
@@ -9,7 +9,7 @@ import {
 	getRequiredPlan,
 } from '@automattic/jetpack-shared-extension-utils';
 import { JetpackEditorPanelLogo } from '@automattic/jetpack-shared-extension-utils/components';
-import { PanelRow } from '@wordpress/components';
+import { PanelBody, PanelRow } from '@wordpress/components';
 import { store as coreStore } from '@wordpress/core-data';
 import { useSelect, select as globalSelect, useDispatch } from '@wordpress/data';
 import {
@@ -23,6 +23,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
+import JetpackPluginSidebar from '../../shared/jetpack-plugin-sidebar';
 import { SeoEnhancer } from '../ai-assistant-plugin/components/seo-enhancer';
 import { SeoSummary } from '../ai-assistant-plugin/components/seo-enhancer/seo-summary';
 import { useSeoModuleSettings } from '../ai-assistant-plugin/components/seo-enhancer/use-seo-module-settings';
@@ -100,35 +101,59 @@ const Seo = () => {
 
 	if ( canShowUpsell && requiredPlan !== false ) {
 		return (
-			<PluginDocumentSettingPanel
-				className="jetpack-seo-panel"
-				title={ __( 'Optimize SEO', 'jetpack' ) }
-				name="jetpack-seo"
-				icon={ <JetpackEditorPanelLogo /> }
-			>
-				<UpsellNotice requiredPlan={ requiredPlan } />
-			</PluginDocumentSettingPanel>
+			<>
+				<JetpackPluginSidebar>
+					<PanelBody
+						title={ __( 'Optimize SEO', 'jetpack' ) }
+						initialOpen={ false }
+						className="jetpack-seo-panel"
+					>
+						<UpsellNotice requiredPlan={ requiredPlan } />
+					</PanelBody>
+				</JetpackPluginSidebar>
+				<PluginDocumentSettingPanel
+					className="jetpack-seo-panel"
+					title={ __( 'Optimize SEO', 'jetpack' ) }
+					name="jetpack-seo"
+					icon={ <JetpackEditorPanelLogo /> }
+				>
+					<UpsellNotice requiredPlan={ requiredPlan } />
+				</PluginDocumentSettingPanel>
+			</>
 		);
 	}
 
 	if ( ! isModuleActive ) {
+		const moduleInactiveContent = isLoadingModules ? (
+			<SeoSkeletonLoader />
+		) : (
+			<SeoPlaceholder
+				changeStatus={ changeStatus }
+				isModuleActive={ isModuleActive }
+				isLoading={ isChangingStatus }
+			/>
+		);
+
 		return (
-			<PluginDocumentSettingPanel
-				className="jetpack-seo-panel"
-				title={ __( 'Optimize SEO', 'jetpack' ) }
-				name="jetpack-seo"
-				icon={ <JetpackEditorPanelLogo /> }
-			>
-				{ isLoadingModules ? (
-					<SeoSkeletonLoader />
-				) : (
-					<SeoPlaceholder
-						changeStatus={ changeStatus }
-						isModuleActive={ isModuleActive }
-						isLoading={ isChangingStatus }
-					/>
-				) }
-			</PluginDocumentSettingPanel>
+			<>
+				<JetpackPluginSidebar>
+					<PanelBody
+						title={ __( 'Optimize SEO', 'jetpack' ) }
+						initialOpen={ false }
+						className="jetpack-seo-panel"
+					>
+						{ moduleInactiveContent }
+					</PanelBody>
+				</JetpackPluginSidebar>
+				<PluginDocumentSettingPanel
+					className="jetpack-seo-panel"
+					title={ __( 'Optimize SEO', 'jetpack' ) }
+					name="jetpack-seo"
+					icon={ <JetpackEditorPanelLogo /> }
+				>
+					{ moduleInactiveContent }
+				</PluginDocumentSettingPanel>
+			</>
 		);
 	}
 
@@ -141,6 +166,30 @@ const Seo = () => {
 	// TODO: remove all code related to the SeoAssistantWizard if it's a no-go
 	return (
 		<>
+			<JetpackPluginSidebar>
+				<PanelBody
+					title={ __( 'Optimize SEO', 'jetpack' ) }
+					initialOpen={ false }
+					className="jetpack-seo-panel"
+				>
+					{ isSeoEnhancerEnabled && hasRequiredPlanForEnhancer && (
+						<SeoEnhancer placement="jetpack-sidebar" disableAutoEnhance={ ! canHaveAutoEnhance } />
+					) }
+					<PanelRow>
+						<SeoTitlePanel />
+					</PanelRow>
+					<PanelRow>
+						<SeoDescriptionPanel />
+					</PanelRow>
+					<PanelRow>
+						<LinkPreviewModalWithTrigger />
+					</PanelRow>
+					<PanelRow>
+						<SeoNoindexPanel />
+					</PanelRow>
+				</PanelBody>
+			</JetpackPluginSidebar>
+
 			<PluginDocumentSettingPanel
 				className="jetpack-seo-panel"
 				title={ __( 'Optimize SEO', 'jetpack' ) }

--- a/projects/plugins/jetpack/extensions/plugins/seo/index.js
+++ b/projects/plugins/jetpack/extensions/plugins/seo/index.js
@@ -20,6 +20,7 @@ import {
 } from '@wordpress/editor';
 import { useEffect, useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import clsx from 'clsx';
 /**
  * Internal dependencies
  */
@@ -167,24 +168,28 @@ const Seo = () => {
 	return (
 		<>
 			<JetpackPluginSidebar>
-				<PanelBody
-					title={ __( 'Optimize SEO', 'jetpack' ) }
-					initialOpen={ false }
-					className="jetpack-seo-panel"
-				>
+				<PanelBody title={ __( 'Optimize SEO', 'jetpack' ) } className="jetpack-seo-panel">
 					{ isSeoEnhancerEnabled && hasRequiredPlanForEnhancer && (
 						<SeoEnhancer placement="jetpack-sidebar" disableAutoEnhance={ ! canHaveAutoEnhance } />
 					) }
-					<PanelRow>
+					<PanelRow
+						className={ clsx( { 'jetpack-seo-sidebar__feature-section': isSeoEnhancerEnabled } ) }
+					>
 						<SeoTitlePanel />
 					</PanelRow>
-					<PanelRow>
+					<PanelRow
+						className={ clsx( { 'jetpack-seo-sidebar__feature-section': isSeoEnhancerEnabled } ) }
+					>
 						<SeoDescriptionPanel />
 					</PanelRow>
-					<PanelRow>
+					<PanelRow
+						className={ clsx( { 'jetpack-seo-sidebar__feature-section': isSeoEnhancerEnabled } ) }
+					>
 						<LinkPreviewModalWithTrigger />
 					</PanelRow>
-					<PanelRow>
+					<PanelRow
+						className={ clsx( { 'jetpack-seo-sidebar__feature-section': isSeoEnhancerEnabled } ) }
+					>
 						<SeoNoindexPanel />
 					</PanelRow>
 				</PanelBody>


### PR DESCRIPTION
Fixes #JETPACK-1369

## Proposed changes:
*   The SEO panel is now displayed in both the Jetpack sidebar and the Document/Page settings area within the post editor.
*   This change addresses discoverability concerns by restoring the SEO panel's presence in the Jetpack sidebar, mirroring the behavior of AI features.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1771573807915309-slack-C08PN0LHCCT

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:
*   Ensure Jetpack is active and the SEO module is enabled.
*   Go to a post or page editor (e.g., `wp-admin/post-new.php`).
*   Open the Jetpack sidebar.
*   Verify that the "Optimize SEO" panel is visible within the Jetpack sidebar.
*   Switch to the Document/Page settings tab (the gear icon).
*   Verify that the "Optimize SEO" panel is also visible within the Document/Page settings.
*   Confirm that interacting with the SEO fields in one location updates the other.

## Changelog
- [x] Generate changelog entries for this PR (using AI).