### PR TITLE
Forms: fix name field title

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-name-field-title
+++ b/projects/packages/forms/changelog/fix-forms-name-field-title
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: change the default title on Name field variation

--- a/projects/packages/forms/src/blocks/field-name/variations.js
+++ b/projects/packages/forms/src/blocks/field-name/variations.js
@@ -26,7 +26,7 @@ export const isNameVariationId = id => typeof id === 'string' && /^name(?:-\d+)?
 const variations = [
 	{
 		name: NAME_ID,
-		title: DEFAULT_NAME_LABEL,
+		title: __( 'Name field', 'jetpack-forms' ), // must match that of main block title for e2e purposes
 		description: __( 'Collect the site visitor’s name.', 'jetpack-forms' ),
 		icon,
 		scope: [ 'transform' ],


### PR DESCRIPTION
## Proposed changes:
Change title on default variation to match the main block's. The title is a established pattern on form blocks and used on e2e tests for locators to find the field.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1771985310315169-slack-C034JEXD1RD

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Run e2e tests and see that they don't fail as in the slack thread

## Changelog
<!-- Check one of the boxes below. -->

- [ ] Generate changelog entries for this PR (using AI).