### PR TITLE
Newsletter: Address PR review feedback for script-data usage

### DIFF
--- a/projects/js-packages/script-data/changelog/dotcom-16058-make-better-use-of-script_data-to-reduce-duplicationtest-follow-up
+++ b/projects/js-packages/script-data/changelog/dotcom-16058-make-better-use-of-script_data-to-reduce-duplicationtest-follow-up
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Use isWoASite() instead of isWpcomPlatformSite() in getSiteType() for more explicit WoA detection

--- a/projects/js-packages/script-data/src/utils.ts
+++ b/projects/js-packages/script-data/src/utils.ts
@@ -122,7 +122,7 @@ export function getSiteType(): SiteType {
 		return 'simple';
 	}
 
-	if ( isWpcomPlatformSite() ) {
+	if ( isWoASite() ) {
 		return 'woa';
 	}
 

--- a/projects/packages/newsletter/changelog/dotcom-16058-make-better-use-of-script_data-to-reduce-duplicationtest-follow-up
+++ b/projects/packages/newsletter/changelog/dotcom-16058-make-better-use-of-script_data-to-reduce-duplicationtest-follow-up
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Use Status class methods for isSitePublic check (filterable and handles coming soon state)

--- a/projects/packages/newsletter/src/class-settings.php
+++ b/projects/packages/newsletter/src/class-settings.php
@@ -13,6 +13,7 @@ use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Modules;
 use Automattic\Jetpack\Paths;
 use Automattic\Jetpack\Redirect;
+use Automattic\Jetpack\Status;
 use Automattic\Jetpack\Status\Host;
 use Jetpack_Tracks_Client;
 
@@ -198,8 +199,10 @@ class Settings {
 		$site_raw_url = preg_replace( '(^https?://)', '', $site_url );
 
 		$host                   = new Host();
+		$status                 = new Status();
 		$blog_id                = (int) $host->get_wpcom_site_id();
 		$is_wpcom_simple        = $host->is_wpcom_simple();
+		$is_block_theme         = wp_is_block_theme();
 		$setup_payment_plan_url = ( $is_wpcom_simple ? 'https://wordpress.com/earn/payments/' : 'https://cloud.jetpack.com/monetize/payments/' ) . rawurlencode( $site_raw_url );
 
 		$wp_admin_subscriber_management_enabled = apply_filters( 'jetpack_wp_admin_subscriber_management_enabled', false );
@@ -211,15 +214,15 @@ class Settings {
 		// Note: Common data like admin_url, rest_nonce, rest_root, title, is_wpcom_platform,
 		// and user.current_user.display_name are already provided by Script_Data.
 		$data['newsletter'] = array(
-			'isBlockTheme'                    => wp_is_block_theme(),
+			'isBlockTheme'                    => $is_block_theme,
 			'themeStylesheet'                 => $theme->get_stylesheet(),
 			'email'                           => $current_user->user_email,
 			'gravatar'                        => get_avatar_url( $current_user->ID ),
 			'dateExample'                     => gmdate( get_option( 'date_format' ), time() ),
 			'subscriberManagementUrl'         => $this->get_subscriber_management_url( $wp_admin_subscriber_management_enabled, $is_wpcom_simple, $site_raw_url, $blog_id ),
-			'isSubscriptionSiteEditSupported' => wp_is_block_theme(),
+			'isSubscriptionSiteEditSupported' => $is_block_theme,
 			'setupPaymentPlansUrl'            => $setup_payment_plan_url,
-			'isSitePublic'                    => (int) get_option( 'blog_public' ) === 1,
+			'isSitePublic'                    => ! $status->is_private_site() && ! $status->is_coming_soon(),
 			'tracksUserData'                  => Jetpack_Tracks_Client::get_connected_user_tracks_identity(),
 		);
 

--- a/projects/packages/newsletter/src/settings/sections/email-content-section.tsx
+++ b/projects/packages/newsletter/src/settings/sections/email-content-section.tsx
@@ -68,7 +68,7 @@ export function EmailContentSection( {
 				{ ! isSitePublic && (
 					<Notice status="warning" isDismissible={ false }>
 						{ __(
-							'Featured images will not be used in your emails while the site is private, because access to the images is restricted to your site only.',
+							'Featured images will not be used in your emails until the site is public, because access to the images is restricted to your site only.',
 							'jetpack-newsletter'
 						) }
 					</Notice>


### PR DESCRIPTION
Fixes #47259 (follow-up)

## Proposed changes:
* Store `wp_is_block_theme()` result in variable to avoid duplicate function call
* Use `Status::is_private_site()` and `is_coming_soon()` for `isSitePublic` check instead of raw `blog_public` option - this is filterable, centralized, and more accurate
* Use `isWoASite()` instead of `isWpcomPlatformSite()` in `getSiteType()` for more explicit WoA detection
* Update featured image warning copy from "while the site is private" to "until the site is public" to better reflect the coming soon state

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
N/A - Addressing review feedback from #47259

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

* Go to a Jetpack-connected site with the newsletter settings feature flag enabled
* Navigate to Jetpack > Newsletter settings
* Verify the page loads correctly
* For `isSitePublic` testing:
  * On a private site or coming soon site, verify the featured image warning is shown in the Email Content section
  * On a public site, verify no warning is shown

## Changelog

- [x] Generate changelog entries for this PR (using AI).