### PR TITLE
Social: Fix Threads social preview for posts with gallery

### DIFF
--- a/projects/packages/publicize/_inc/components/social-post-modal/post-preview.tsx
+++ b/projects/packages/publicize/_inc/components/social-post-modal/post-preview.tsx
@@ -231,16 +231,6 @@ export function PostPreview( { connection }: PostPreviewProps ) {
 				caption = getCombinedText( title, excerpt );
 			}
 
-			const captionLength =
-				// 500 characters
-				500 -
-				// Number of characters in the article URL
-				url.length -
-				// 2 characters for line break
-				2;
-
-			caption = decodeEntities( caption ).slice( 0, captionLength );
-
 			caption += `\n\n${ url }`;
 
 			return (

--- a/projects/packages/publicize/changelog/fix-social-threads-preview
+++ b/projects/packages/publicize/changelog/fix-social-threads-preview
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix Threads social preview for posts with gallery.

--- a/projects/plugins/jetpack/changelog/fix-social-threads-preview
+++ b/projects/plugins/jetpack/changelog/fix-social-threads-preview
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Social: Fix Threads social preview for posts with gallery.

--- a/projects/plugins/social/changelog/fix-social-threads-preview
+++ b/projects/plugins/social/changelog/fix-social-threads-preview
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix Threads social preview for posts with gallery.


### PR DESCRIPTION
Fixes SOCIAL-374

## Proposed changes:

- The Threads preview had extra caption processing (manual truncation via `decodeEntities` + `.slice()`) that no other network had. This caused broken markup and a leading space in the preview for gallery posts.
- Removed that extra processing so Threads now builds the caption the same way as every other network and lets `preparePreviewText` handle it.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

- Create a post with a gallery (multiple images) and open the Social post modal.
- Select the Threads connection and check the preview:
  - Title is readable, no leading space before the excerpt, no broken markup, no raw URL in the text.
- Also check a non-gallery post — the link card should still show with the URL.

## Changelog

- [ ] Generate changelog entries for this PR (using AI).

| Before | After |
|--------|--------|
| <img width="825" height="739" alt="Screenshot 2026-02-25 at 9 47 14 PM" src="https://github.com/user-attachments/assets/7e1e1bee-48f5-49be-9d6e-cc44b175cb33" /> | <img width="826" height="736" alt="Screenshot 2026-02-25 at 9 46 33 PM" src="https://github.com/user-attachments/assets/b2a5ba12-ea89-44be-9789-614f0f313ee5" /> | 