### PR TITLE
Forms: add publish and unpublish actions

### DIFF
--- a/projects/packages/forms/changelog/add-forms-publish-unpublish-actions
+++ b/projects/packages/forms/changelog/add-forms-publish-unpublish-actions
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Forms: add publish/unpublish actions.

--- a/projects/packages/forms/routes/forms/stage.tsx
+++ b/projects/packages/forms/routes/forms/stage.tsx
@@ -401,6 +401,14 @@ function StageInner() {
 				},
 			} );
 		}
+		const currentListQuery = getFormsListQuery(
+			view.page ?? 1,
+			view.perPage ?? 20,
+			view.search ?? '',
+			statusQuery
+		) as Record< string, unknown >;
+		const statusUpdateOptions = { invalidateQueries: [ currentListQuery ] };
+
 		actionsList.push( {
 			id: 'publish-form',
 			isPrimary: false,
@@ -415,14 +423,8 @@ function StageInner() {
 				if ( ! eligibleItems.length ) {
 					return;
 				}
-				const query = getFormsListQuery(
-					view.page ?? 1,
-					view.perPage ?? 20,
-					view.search ?? '',
-					statusQuery
-				) as Record< string, unknown >;
 				try {
-					await publishForms( eligibleItems, { invalidateQueries: [ query ] } );
+					await publishForms( eligibleItems, statusUpdateOptions );
 				} finally {
 					setSelection( [] );
 				}
@@ -443,14 +445,8 @@ function StageInner() {
 				if ( ! eligibleItems.length ) {
 					return;
 				}
-				const query = getFormsListQuery(
-					view.page ?? 1,
-					view.perPage ?? 20,
-					view.search ?? '',
-					statusQuery
-				) as Record< string, unknown >;
 				try {
-					await setFormsToDraft( eligibleItems, { invalidateQueries: [ query ] } );
+					await setFormsToDraft( eligibleItems, statusUpdateOptions );
 				} finally {
 					setSelection( [] );
 				}

--- a/projects/packages/forms/routes/forms/stage.tsx
+++ b/projects/packages/forms/routes/forms/stage.tsx
@@ -362,19 +362,6 @@ function StageInner() {
 		} );
 
 		actionsList.push( {
-			id: 'duplicate-form',
-			isPrimary: false,
-			label: __( 'Duplicate', 'jetpack-forms' ),
-			supportsBulk: false,
-			async callback( items: FormListItem[] ) {
-				const [ item ] = items;
-				if ( item ) {
-					await duplicateForm( item );
-				}
-			},
-		} );
-
-		actionsList.push( {
 			id: 'preview-form',
 			isPrimary: false,
 			label: __( 'Preview', 'jetpack-forms' ),
@@ -481,6 +468,19 @@ function StageInner() {
 					return;
 				}
 				openRenameModal( item );
+			},
+		} );
+
+		actionsList.push( {
+			id: 'duplicate-form',
+			isPrimary: false,
+			label: __( 'Duplicate', 'jetpack-forms' ),
+			supportsBulk: false,
+			async callback( items: FormListItem[] ) {
+				const [ item ] = items;
+				if ( item ) {
+					await duplicateForm( item );
+				}
 			},
 		} );
 

--- a/projects/packages/forms/routes/forms/stage.tsx
+++ b/projects/packages/forms/routes/forms/stage.tsx
@@ -345,62 +345,6 @@ function StageInner() {
 		}
 
 		actionsList.push( {
-			id: 'publish-form',
-			isPrimary: false,
-			label: __( 'Publish', 'jetpack-forms' ),
-			isEligible: ( item: FormListItem ) => item.status !== 'publish',
-			supportsBulk: true,
-			async callback( items: FormListItem[] ) {
-				if ( isDeleting || isUpdatingStatus ) {
-					return;
-				}
-				const eligibleItems = ( items || [] ).filter( item => item.status !== 'publish' );
-				if ( ! eligibleItems.length ) {
-					return;
-				}
-				const query = getFormsListQuery(
-					view.page ?? 1,
-					view.perPage ?? 20,
-					view.search ?? '',
-					statusQuery
-				) as Record< string, unknown >;
-				try {
-					await publishForms( eligibleItems, { invalidateQueries: [ query ] } );
-				} finally {
-					setSelection( [] );
-				}
-			},
-		} );
-
-		actionsList.push( {
-			id: 'unpublish-form',
-			isPrimary: false,
-			label: __( 'Unpublish', 'jetpack-forms' ),
-			isEligible: ( item: FormListItem ) => item.status === 'publish',
-			supportsBulk: true,
-			async callback( items: FormListItem[] ) {
-				if ( isDeleting || isUpdatingStatus ) {
-					return;
-				}
-				const eligibleItems = ( items || [] ).filter( item => item.status === 'publish' );
-				if ( ! eligibleItems.length ) {
-					return;
-				}
-				const query = getFormsListQuery(
-					view.page ?? 1,
-					view.perPage ?? 20,
-					view.search ?? '',
-					statusQuery
-				) as Record< string, unknown >;
-				try {
-					await setFormsToDraft( eligibleItems, { invalidateQueries: [ query ] } );
-				} finally {
-					setSelection( [] );
-				}
-			},
-		} );
-
-		actionsList.push( {
 			id: 'edit-form',
 			isPrimary: true,
 			label: __( 'Edit', 'jetpack-forms' ),
@@ -470,6 +414,62 @@ function StageInner() {
 				},
 			} );
 		}
+		actionsList.push( {
+			id: 'publish-form',
+			isPrimary: false,
+			label: __( 'Publish', 'jetpack-forms' ),
+			isEligible: ( item: FormListItem ) => item.status !== 'publish',
+			supportsBulk: true,
+			async callback( items: FormListItem[] ) {
+				if ( isDeleting || isUpdatingStatus ) {
+					return;
+				}
+				const eligibleItems = ( items || [] ).filter( item => item.status !== 'publish' );
+				if ( ! eligibleItems.length ) {
+					return;
+				}
+				const query = getFormsListQuery(
+					view.page ?? 1,
+					view.perPage ?? 20,
+					view.search ?? '',
+					statusQuery
+				) as Record< string, unknown >;
+				try {
+					await publishForms( eligibleItems, { invalidateQueries: [ query ] } );
+				} finally {
+					setSelection( [] );
+				}
+			},
+		} );
+
+		actionsList.push( {
+			id: 'unpublish-form',
+			isPrimary: false,
+			label: __( 'Unpublish', 'jetpack-forms' ),
+			isEligible: ( item: FormListItem ) => item.status === 'publish',
+			supportsBulk: true,
+			async callback( items: FormListItem[] ) {
+				if ( isDeleting || isUpdatingStatus ) {
+					return;
+				}
+				const eligibleItems = ( items || [] ).filter( item => item.status === 'publish' );
+				if ( ! eligibleItems.length ) {
+					return;
+				}
+				const query = getFormsListQuery(
+					view.page ?? 1,
+					view.perPage ?? 20,
+					view.search ?? '',
+					statusQuery
+				) as Record< string, unknown >;
+				try {
+					await setFormsToDraft( eligibleItems, { invalidateQueries: [ query ] } );
+				} finally {
+					setSelection( [] );
+				}
+			},
+		} );
+
 		actionsList.push( {
 			id: 'rename-form',
 			isPrimary: false,

--- a/projects/packages/forms/routes/forms/stage.tsx
+++ b/projects/packages/forms/routes/forms/stage.tsx
@@ -27,7 +27,7 @@ import { EmptyWrapper } from '../../src/dashboard/components/empty-responses/ind
 import { FormNameModal } from '../../src/dashboard/components/form-name-modal';
 import { NON_TRASH_FORM_STATUSES, getFormStatusLabel } from '../../src/dashboard/constants';
 import useDeleteForm from '../../src/dashboard/hooks/use-delete-form.ts';
-import useFormsData from '../../src/dashboard/hooks/use-forms-data.ts';
+import useFormsData, { getFormsListQuery } from '../../src/dashboard/hooks/use-forms-data.ts';
 import WpRouteDashboardSearchParamsProvider from '../../src/dashboard/router/wp-route-dashboard-search-params-provider.tsx';
 import DataViewsHeaderRow from '../../src/dashboard/wp-build/components/dataviews-header-row';
 import FormsHelpModal from '../../src/dashboard/wp-build/components/forms-help-modal';
@@ -122,7 +122,15 @@ function StageInner() {
 		statusQuery
 	);
 
-	const { duplicateForm, previewForm, copyEmbed, copyShortcode } = useFormItemActions();
+	const {
+		duplicateForm,
+		previewForm,
+		copyEmbed,
+		copyShortcode,
+		publishForms,
+		setFormsToDraft,
+		isUpdatingStatus,
+	} = useFormItemActions();
 
 	const {
 		isDeleting,
@@ -337,6 +345,62 @@ function StageInner() {
 		}
 
 		actionsList.push( {
+			id: 'publish-form',
+			isPrimary: false,
+			label: __( 'Publish', 'jetpack-forms' ),
+			isEligible: ( item: FormListItem ) => item.status !== 'publish',
+			supportsBulk: true,
+			async callback( items: FormListItem[] ) {
+				if ( isDeleting || isUpdatingStatus ) {
+					return;
+				}
+				const eligibleItems = ( items || [] ).filter( item => item.status !== 'publish' );
+				if ( ! eligibleItems.length ) {
+					return;
+				}
+				const query = getFormsListQuery(
+					view.page ?? 1,
+					view.perPage ?? 20,
+					view.search ?? '',
+					statusQuery
+				) as Record< string, unknown >;
+				try {
+					await publishForms( eligibleItems, { invalidateQueries: [ query ] } );
+				} finally {
+					setSelection( [] );
+				}
+			},
+		} );
+
+		actionsList.push( {
+			id: 'unpublish-form',
+			isPrimary: false,
+			label: __( 'Unpublish', 'jetpack-forms' ),
+			isEligible: ( item: FormListItem ) => item.status === 'publish',
+			supportsBulk: true,
+			async callback( items: FormListItem[] ) {
+				if ( isDeleting || isUpdatingStatus ) {
+					return;
+				}
+				const eligibleItems = ( items || [] ).filter( item => item.status === 'publish' );
+				if ( ! eligibleItems.length ) {
+					return;
+				}
+				const query = getFormsListQuery(
+					view.page ?? 1,
+					view.perPage ?? 20,
+					view.search ?? '',
+					statusQuery
+				) as Record< string, unknown >;
+				try {
+					await setFormsToDraft( eligibleItems, { invalidateQueries: [ query ] } );
+				} finally {
+					setSelection( [] );
+				}
+			},
+		} );
+
+		actionsList.push( {
 			id: 'edit-form',
 			isPrimary: true,
 			label: __( 'Edit', 'jetpack-forms' ),
@@ -443,13 +507,20 @@ function StageInner() {
 		copyShortcode,
 		duplicateForm,
 		isDeleting,
+		isUpdatingStatus,
 		isViewingTrash,
 		onOpenPermanentDeleteConfirm,
 		openRenameModal,
 		openSingleFormView,
+		publishForms,
 		previewForm,
 		restoreForms,
+		setFormsToDraft,
+		statusQuery,
 		trashForms,
+		view.page,
+		view.perPage,
+		view.search,
 	] );
 
 	const paginationInfo = useMemo(

--- a/projects/packages/forms/src/dashboard/hooks/use-forms-data.ts
+++ b/projects/packages/forms/src/dashboard/hooks/use-forms-data.ts
@@ -82,17 +82,28 @@ export default function useFormsData(
 		totalPages,
 	} = useEntityRecords( 'postType', 'jetpack_form', query );
 
-	const records = ( rawRecords || [] ).map( item => {
-		const typedItem = item as JetpackFormRestItem;
-		return {
-			id: typedItem.id,
-			title: decodeEntities( typedItem.title?.rendered || '' ),
-			status: typedItem.status,
-			modified: typedItem.modified,
-			entriesCount: typedItem.entries_count ?? 0,
-			editUrl: typedItem.edit_url,
-		};
-	} );
+	const records = useMemo( () => {
+		const seen = new Set< number >();
+		const items: FormListItem[] = [];
+		for ( const item of rawRecords || [] ) {
+			const typedItem = item as JetpackFormRestItem;
+			// Deduplicate records because core-data can momentarily return the same entity
+			// twice during optimistic updates (e.g. when bulk-publishing forms).
+			if ( seen.has( typedItem.id ) ) {
+				continue;
+			}
+			seen.add( typedItem.id );
+			items.push( {
+				id: typedItem.id,
+				title: decodeEntities( typedItem.title?.rendered || '' ),
+				status: typedItem.status,
+				modified: typedItem.modified,
+				entriesCount: typedItem.entries_count ?? 0,
+				editUrl: typedItem.edit_url,
+			} );
+		}
+		return items;
+	}, [ rawRecords ] );
 
 	return {
 		records,

--- a/projects/packages/forms/src/dashboard/wp-build/hooks/use-form-item-actions.ts
+++ b/projects/packages/forms/src/dashboard/wp-build/hooks/use-form-item-actions.ts
@@ -3,7 +3,7 @@
  */
 import apiFetch from '@wordpress/api-fetch';
 import { useDispatch } from '@wordpress/data';
-import { useCallback, useState } from '@wordpress/element';
+import { useCallback, useRef, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 /**
@@ -48,6 +48,7 @@ export default function useFormItemActions(): UseFormItemActionsReturn {
 	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
 	const { duplicateForm, isDuplicating } = useDuplicateForm();
 	const [ isUpdatingStatus, setIsUpdatingStatus ] = useState( false );
+	const isUpdatingStatusRef = useRef( false );
 	const { saveEntityRecord, invalidateResolution } = useDispatch( 'core' ) as {
 		saveEntityRecord: (
 			kind: string,
@@ -122,10 +123,11 @@ export default function useFormItemActions(): UseFormItemActionsReturn {
 			nextStatus: 'publish' | 'draft',
 			options: UpdateStatusOptions = {}
 		) => {
-			if ( isUpdatingStatus || ! items?.length ) {
+			if ( isUpdatingStatusRef.current || ! items?.length ) {
 				return;
 			}
 
+			isUpdatingStatusRef.current = true;
 			setIsUpdatingStatus( true );
 			try {
 				const promises = await Promise.allSettled(
@@ -181,6 +183,7 @@ export default function useFormItemActions(): UseFormItemActionsReturn {
 					  ];
 				invalidateQueries.forEach( invalidateListQuery );
 			} finally {
+				isUpdatingStatusRef.current = false;
 				setIsUpdatingStatus( false );
 			}
 		},
@@ -189,7 +192,6 @@ export default function useFormItemActions(): UseFormItemActionsReturn {
 			createSuccessNotice,
 			invalidateListQuery,
 			invalidateResolution,
-			isUpdatingStatus,
 			saveEntityRecord,
 		]
 	);

--- a/projects/packages/forms/src/dashboard/wp-build/hooks/use-form-item-actions.ts
+++ b/projects/packages/forms/src/dashboard/wp-build/hooks/use-form-item-actions.ts
@@ -190,13 +190,9 @@ export default function useFormItemActions(): UseFormItemActionsReturn {
 												)
 											)
 										);
-										items.forEach( item => {
-											invalidateResolution( 'getEntityRecord', [
-												'postType',
-												FORM_POST_TYPE,
-												item.id,
-											] );
-										} );
+										// Invalidate list queries to refetch with updated statuses.
+										// Individual entity invalidation is unnecessary since saveEntityRecord
+										// already updates the record in the store.
 										const undoQueries = options.invalidateQueries?.length
 											? options.invalidateQueries
 											: [
@@ -243,10 +239,6 @@ export default function useFormItemActions(): UseFormItemActionsReturn {
 					} );
 				}
 
-				items.forEach( item => {
-					invalidateResolution( 'getEntityRecord', [ 'postType', FORM_POST_TYPE, item.id ] );
-				} );
-
 				const invalidateQueries = options.invalidateQueries?.length
 					? options.invalidateQueries
 					: [
@@ -258,13 +250,7 @@ export default function useFormItemActions(): UseFormItemActionsReturn {
 				setIsUpdatingStatus( false );
 			}
 		},
-		[
-			createErrorNotice,
-			createSuccessNotice,
-			invalidateListQuery,
-			invalidateResolution,
-			saveEntityRecord,
-		]
+		[ createErrorNotice, createSuccessNotice, invalidateListQuery, saveEntityRecord ]
 	);
 
 	const publishForms = useCallback(

--- a/projects/packages/forms/src/dashboard/wp-build/hooks/use-form-item-actions.ts
+++ b/projects/packages/forms/src/dashboard/wp-build/hooks/use-form-item-actions.ts
@@ -143,10 +143,29 @@ export default function useFormItemActions(): UseFormItemActionsReturn {
 				const failedCount = promises.length - updatedCount;
 
 				if ( updatedCount ) {
-					createSuccessNotice( __( 'Status updated.', 'jetpack-forms' ), { type: 'snackbar' } );
+					const message =
+						nextStatus === 'publish'
+							? __( 'Form published.', 'jetpack-forms' )
+							: __( 'Form set to draft.', 'jetpack-forms' );
+					const previousStatus = nextStatus === 'publish' ? 'draft' : 'publish';
+					createSuccessNotice( message, {
+						type: 'snackbar',
+						actions: [
+							{
+								label: __( 'Undo', 'jetpack-forms' ),
+								onClick: () => {
+									updateStatus( items, previousStatus, options );
+								},
+							},
+						],
+					} );
 				}
 				if ( failedCount ) {
-					createErrorNotice( __( 'Could not update status.', 'jetpack-forms' ), {
+					const errorMessage =
+						nextStatus === 'publish'
+							? __( 'Could not publish form.', 'jetpack-forms' )
+							: __( 'Could not set form to draft.', 'jetpack-forms' );
+					createErrorNotice( errorMessage, {
 						type: 'snackbar',
 					} );
 				}

--- a/projects/packages/forms/src/dashboard/wp-build/hooks/use-form-item-actions.ts
+++ b/projects/packages/forms/src/dashboard/wp-build/hooks/use-form-item-actions.ts
@@ -3,12 +3,15 @@
  */
 import apiFetch from '@wordpress/api-fetch';
 import { useDispatch } from '@wordpress/data';
-import { useCallback } from '@wordpress/element';
+import { useCallback, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 /**
  * Internal dependencies
  */
+import { FORM_POST_TYPE } from '../../../blocks/shared/util/constants.js';
+import { NON_TRASH_FORM_STATUSES } from '../../constants';
+import { getFormsListQuery } from '../../hooks/use-forms-data.ts';
 import useDuplicateForm from './use-duplicate-form';
 /**
  * Types
@@ -17,16 +20,23 @@ import type { FormListItem } from '../../hooks/use-forms-data.ts';
 
 type FormItem = Pick< FormListItem, 'id' > & Partial< Pick< FormListItem, 'title' > >;
 
+type UpdateStatusOptions = {
+	invalidateQueries?: Array< Record< string, unknown > >;
+};
+
 type UseFormItemActionsReturn = {
 	duplicateForm: ( item: FormItem ) => Promise< void >;
 	previewForm: ( item: FormItem ) => Promise< void >;
 	copyEmbed: ( item: FormItem ) => Promise< void >;
 	copyShortcode: ( item: FormItem ) => Promise< void >;
 	isDuplicating: boolean;
+	isUpdatingStatus: boolean;
+	publishForms: ( items: FormItem[], options?: UpdateStatusOptions ) => Promise< void >;
+	setFormsToDraft: ( items: FormItem[], options?: UpdateStatusOptions ) => Promise< void >;
 };
 
 /**
- * Shared form-level action callbacks (Duplicate, Preview, Copy embed, Copy shortcode).
+ * Shared form-level action callbacks (Duplicate, Preview, Copy embed, Copy shortcode, Publish, Unpublish).
  *
  * Each callback accepts a minimal `{ id, title? }` object so it works with both
  * full `FormListItem` records (DataViews table) and a simple form ID + title
@@ -37,6 +47,16 @@ type UseFormItemActionsReturn = {
 export default function useFormItemActions(): UseFormItemActionsReturn {
 	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
 	const { duplicateForm, isDuplicating } = useDuplicateForm();
+	const [ isUpdatingStatus, setIsUpdatingStatus ] = useState( false );
+	const { saveEntityRecord, invalidateResolution } = useDispatch( 'core' ) as {
+		saveEntityRecord: (
+			kind: string,
+			name: string,
+			record: Record< string, unknown >,
+			options?: { throwOnError?: boolean }
+		) => Promise< unknown >;
+		invalidateResolution: ( selector: string, args: unknown[] ) => void;
+	};
 
 	const previewForm = useCallback( async ( item: FormItem ) => {
 		try {
@@ -84,5 +104,99 @@ export default function useFormItemActions(): UseFormItemActionsReturn {
 		[ createErrorNotice, createSuccessNotice ]
 	);
 
-	return { duplicateForm, previewForm, copyEmbed, copyShortcode, isDuplicating };
+	const invalidateListQuery = useCallback(
+		( query: Record< string, unknown > ) => {
+			invalidateResolution( 'getEntityRecords', [ 'postType', FORM_POST_TYPE, query ] );
+			invalidateResolution( 'getEntityRecords', [
+				'postType',
+				FORM_POST_TYPE,
+				{ ...query, per_page: 1, _fields: 'id' },
+			] );
+		},
+		[ invalidateResolution ]
+	);
+
+	const updateStatus = useCallback(
+		async (
+			items: FormItem[],
+			nextStatus: 'publish' | 'draft',
+			options: UpdateStatusOptions = {}
+		) => {
+			if ( isUpdatingStatus || ! items?.length ) {
+				return;
+			}
+
+			setIsUpdatingStatus( true );
+			try {
+				const promises = await Promise.allSettled(
+					items.map( item =>
+						saveEntityRecord(
+							'postType',
+							FORM_POST_TYPE,
+							{ id: item.id, status: nextStatus },
+							{ throwOnError: true }
+						)
+					)
+				);
+
+				const updatedCount = promises.filter( p => p.status === 'fulfilled' ).length;
+				const failedCount = promises.length - updatedCount;
+
+				if ( updatedCount ) {
+					createSuccessNotice( __( 'Status updated.', 'jetpack-forms' ), { type: 'snackbar' } );
+				}
+				if ( failedCount ) {
+					createErrorNotice( __( 'Could not update status.', 'jetpack-forms' ), {
+						type: 'snackbar',
+					} );
+				}
+
+				items.forEach( item => {
+					invalidateResolution( 'getEntityRecord', [ 'postType', FORM_POST_TYPE, item.id ] );
+				} );
+
+				const invalidateQueries = options.invalidateQueries?.length
+					? options.invalidateQueries
+					: [
+							getFormsListQuery( 1, 20, '', NON_TRASH_FORM_STATUSES ) as Record< string, unknown >,
+					  ];
+				invalidateQueries.forEach( invalidateListQuery );
+			} finally {
+				setIsUpdatingStatus( false );
+			}
+		},
+		[
+			createErrorNotice,
+			createSuccessNotice,
+			invalidateListQuery,
+			invalidateResolution,
+			isUpdatingStatus,
+			saveEntityRecord,
+		]
+	);
+
+	const publishForms = useCallback(
+		async ( items: FormItem[], options?: UpdateStatusOptions ) => {
+			await updateStatus( items, 'publish', options );
+		},
+		[ updateStatus ]
+	);
+
+	const setFormsToDraft = useCallback(
+		async ( items: FormItem[], options?: UpdateStatusOptions ) => {
+			await updateStatus( items, 'draft', options );
+		},
+		[ updateStatus ]
+	);
+
+	return {
+		duplicateForm,
+		previewForm,
+		copyEmbed,
+		copyShortcode,
+		isDuplicating,
+		isUpdatingStatus,
+		publishForms,
+		setFormsToDraft,
+	};
 }

--- a/projects/packages/forms/src/dashboard/wp-build/hooks/use-form-item-actions.ts
+++ b/projects/packages/forms/src/dashboard/wp-build/hooks/use-form-item-actions.ts
@@ -18,7 +18,7 @@ import useDuplicateForm from './use-duplicate-form';
  */
 import type { FormListItem } from '../../hooks/use-forms-data.ts';
 
-type FormItem = Pick< FormListItem, 'id' > & Partial< Pick< FormListItem, 'title' > >;
+type FormItem = Pick< FormListItem, 'id' > & Partial< Pick< FormListItem, 'title' | 'status' > >;
 
 type UpdateStatusOptions = {
 	invalidateQueries?: Array< Record< string, unknown > >;
@@ -130,6 +130,8 @@ export default function useFormItemActions(): UseFormItemActionsReturn {
 			isUpdatingStatusRef.current = true;
 			setIsUpdatingStatus( true );
 			try {
+				// Capture each item's current status before updating so undo can restore it.
+				const previousStatuses = new Map( items.map( item => [ item.id, item.status ] ) );
 				const promises = await Promise.allSettled(
 					items.map( item =>
 						saveEntityRecord(
@@ -162,14 +164,52 @@ export default function useFormItemActions(): UseFormItemActionsReturn {
 									),
 									updatedCount
 							  );
-					const previousStatus = nextStatus === 'publish' ? 'draft' : 'publish';
+					const fallbackStatus = nextStatus === 'publish' ? 'draft' : 'publish';
 					createSuccessNotice( message, {
 						type: 'snackbar',
 						actions: [
 							{
 								label: __( 'Undo', 'jetpack-forms' ),
-								onClick: () => {
-									updateStatus( items, previousStatus, options );
+								onClick: async () => {
+									if ( isUpdatingStatusRef.current ) {
+										return;
+									}
+									isUpdatingStatusRef.current = true;
+									setIsUpdatingStatus( true );
+									try {
+										await Promise.allSettled(
+											items.map( item =>
+												saveEntityRecord(
+													'postType',
+													FORM_POST_TYPE,
+													{
+														id: item.id,
+														status: previousStatuses.get( item.id ) || fallbackStatus,
+													},
+													{ throwOnError: true }
+												)
+											)
+										);
+										items.forEach( item => {
+											invalidateResolution( 'getEntityRecord', [
+												'postType',
+												FORM_POST_TYPE,
+												item.id,
+											] );
+										} );
+										const undoQueries = options.invalidateQueries?.length
+											? options.invalidateQueries
+											: [
+													getFormsListQuery( 1, 20, '', NON_TRASH_FORM_STATUSES ) as Record<
+														string,
+														unknown
+													>,
+											  ];
+										undoQueries.forEach( invalidateListQuery );
+									} finally {
+										isUpdatingStatusRef.current = false;
+										setIsUpdatingStatus( false );
+									}
 								},
 							},
 						],

--- a/projects/packages/forms/src/dashboard/wp-build/hooks/use-form-item-actions.ts
+++ b/projects/packages/forms/src/dashboard/wp-build/hooks/use-form-item-actions.ts
@@ -4,7 +4,7 @@
 import apiFetch from '@wordpress/api-fetch';
 import { useDispatch } from '@wordpress/data';
 import { useCallback, useRef, useState } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { __, _n, sprintf } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 /**
  * Internal dependencies
@@ -147,8 +147,21 @@ export default function useFormItemActions(): UseFormItemActionsReturn {
 				if ( updatedCount ) {
 					const message =
 						nextStatus === 'publish'
-							? __( 'Form published.', 'jetpack-forms' )
-							: __( 'Form set to draft.', 'jetpack-forms' );
+							? sprintf(
+									/* translators: %d: number of forms */
+									_n( '%d form published.', '%d forms published.', updatedCount, 'jetpack-forms' ),
+									updatedCount
+							  )
+							: sprintf(
+									/* translators: %d: number of forms */
+									_n(
+										'%d form set to draft.',
+										'%d forms set to draft.',
+										updatedCount,
+										'jetpack-forms'
+									),
+									updatedCount
+							  );
 					const previousStatus = nextStatus === 'publish' ? 'draft' : 'publish';
 					createSuccessNotice( message, {
 						type: 'snackbar',
@@ -165,8 +178,26 @@ export default function useFormItemActions(): UseFormItemActionsReturn {
 				if ( failedCount ) {
 					const errorMessage =
 						nextStatus === 'publish'
-							? __( 'Could not publish form.', 'jetpack-forms' )
-							: __( 'Could not set form to draft.', 'jetpack-forms' );
+							? sprintf(
+									/* translators: %d: number of forms */
+									_n(
+										'Could not publish %d form.',
+										'Could not publish %d forms.',
+										failedCount,
+										'jetpack-forms'
+									),
+									failedCount
+							  )
+							: sprintf(
+									/* translators: %d: number of forms */
+									_n(
+										'Could not set %d form to draft.',
+										'Could not set %d forms to draft.',
+										failedCount,
+										'jetpack-forms'
+									),
+									failedCount
+							  );
 					createErrorNotice( errorMessage, {
 						type: 'snackbar',
 					} );

--- a/projects/packages/forms/src/dashboard/wp-build/hooks/use-page-header-details.tsx
+++ b/projects/packages/forms/src/dashboard/wp-build/hooks/use-page-header-details.tsx
@@ -133,7 +133,15 @@ export default function usePageHeaderDetails(
 		return <Badge intent="draft">{ statusLabel }</Badge>;
 	}, [ isSingleFormScreen, formStatus, statusLabel ] );
 
-	const { duplicateForm, previewForm, copyEmbed, copyShortcode } = useFormItemActions();
+	const {
+		duplicateForm,
+		previewForm,
+		copyEmbed,
+		copyShortcode,
+		publishForms,
+		setFormsToDraft,
+		isUpdatingStatus,
+	} = useFormItemActions();
 
 	const formItemControls = useMemo( () => {
 		if ( ! sourceIdNumber ) {
@@ -141,7 +149,7 @@ export default function usePageHeaderDetails(
 		}
 
 		const formItem = { id: sourceIdNumber, title: formTitle };
-		const controls: Array< { title: string; onClick: () => void } > = [
+		const controls: Array< { title: string; onClick: () => void; isDisabled?: boolean } > = [
 			{
 				title: __( 'Duplicate', 'jetpack-forms' ),
 				onClick: () => duplicateForm( formItem ),
@@ -165,8 +173,33 @@ export default function usePageHeaderDetails(
 			);
 		}
 
+		if ( formRecord?.status === 'publish' ) {
+			controls.push( {
+				title: __( 'Unpublish', 'jetpack-forms' ),
+				onClick: () => setFormsToDraft( [ formItem ] ),
+				isDisabled: isUpdatingStatus,
+			} );
+		} else {
+			controls.push( {
+				title: __( 'Publish', 'jetpack-forms' ),
+				onClick: () => publishForms( [ formItem ] ),
+				isDisabled: isUpdatingStatus,
+			} );
+		}
+
 		return controls;
-	}, [ sourceIdNumber, formTitle, duplicateForm, previewForm, copyEmbed, copyShortcode ] );
+	}, [
+		copyEmbed,
+		copyShortcode,
+		duplicateForm,
+		formRecord?.status,
+		formTitle,
+		isUpdatingStatus,
+		publishForms,
+		previewForm,
+		setFormsToDraft,
+		sourceIdNumber,
+	] );
 
 	const breadcrumbsItems = useMemo( () => {
 		if ( isSingleFormScreen ) {

--- a/projects/packages/forms/src/dashboard/wp-build/hooks/use-page-header-details.tsx
+++ b/projects/packages/forms/src/dashboard/wp-build/hooks/use-page-header-details.tsx
@@ -149,7 +149,7 @@ export default function usePageHeaderDetails(
 		}
 
 		const formItem = { id: sourceIdNumber, title: formTitle };
-		const controls: Array< { title: string; onClick: () => void; isDisabled?: boolean } > = [
+		const controls: Array< { title: string; onClick: () => void } > = [
 			{
 				title: __( 'Duplicate', 'jetpack-forms' ),
 				onClick: () => duplicateForm( formItem ),
@@ -176,14 +176,20 @@ export default function usePageHeaderDetails(
 		if ( formRecord?.status === 'publish' ) {
 			controls.push( {
 				title: __( 'Unpublish', 'jetpack-forms' ),
-				onClick: () => setFormsToDraft( [ formItem ] ),
-				isDisabled: isUpdatingStatus,
+				onClick: () => {
+					if ( ! isUpdatingStatus ) {
+						setFormsToDraft( [ formItem ] );
+					}
+				},
 			} );
 		} else {
 			controls.push( {
 				title: __( 'Publish', 'jetpack-forms' ),
-				onClick: () => publishForms( [ formItem ] ),
-				isDisabled: isUpdatingStatus,
+				onClick: () => {
+					if ( ! isUpdatingStatus ) {
+						publishForms( [ formItem ] );
+					}
+				},
 			} );
 		}
 


### PR DESCRIPTION
## Proposed changes:

Adds 'Publish' and 'Unpublish' actions for new Jetpack Forms posts. You'll see the Publish action is the form is in any non-published state. You'll see the Unpublish action if the form is in published state. 

**Screenshots**

<img width="1334" height="704" alt="forms-unpublish" src="https://github.com/user-attachments/assets/d4e73cfe-45a3-47fb-8622-56f617845502" />

<img width="1346" height="251" alt="single-form-unpublish" src="https://github.com/user-attachments/assets/4101a499-171a-40a0-80fa-dd128ba28314" />

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Enable these feature flags: 

```
add_filter( 'jetpack_forms_alpha', '__return_true', 20 );
add_filter( 'jetpack_block_editor_feature_flags', 'eb_register_feature' );
function eb_register_feature( $flags ) {
    $flags['central-form-management'] = true;
    return $flags;
}
```

Test:
* Go to Jetpack > Forms
* Forms screen: click the three-dot menu on a form row and confirm you see either Publish or Unpublish as an action depending on the current status of the form. Click the action and confirm it works as expected - either sets status to Published or Draft. 
* Single forms screen: click the three-dot menu in the page header and confirm you see either Publish or Unpublish as an action depending on the current status of the form. Click the action and confirm it works as expected - either sets status to Published or Draft. 

## Changelog
<!-- Check one of the boxes below. -->

Already added changelog file. 

- [ ] Generate changelog entries for this PR (using AI).