### PR TITLE
Search admin: Limit maximum container width to 1040px

### DIFF
--- a/projects/packages/search/changelog/search-max-width-1040px
+++ b/projects/packages/search/changelog/search-max-width-1040px
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Search admin: Change max-width of contents to 1040px

--- a/projects/packages/search/src/dashboard/components/module-control/index.jsx
+++ b/projects/packages/search/src/dashboard/components/module-control/index.jsx
@@ -180,14 +180,13 @@ const InstantSearchToggle = ( {
 	return (
 		<div className="jp-form-search-settings-group__toggle is-instant-search jp-search-dashboard-wrap">
 			<div className="jp-search-dashboard-row">
-				<div className="lg-col-span-2 md-col-span-1 sm-col-span-0"></div>
 				<CompactFormToggle
 					checked={ isInstantSearchToggleChecked }
 					disabled={ isInstantSearchToggleDisabled }
 					onChange={ toggleInstantSearch }
 					toggling={ isTogglingInstantSearch }
 					className="is-search-admin"
-					switchClassNames="lg-col-span-1 md-col-span-1 sm-col-span-1"
+					switchClassNames="jp-search-dashboard-toggle lg-col-span-1 md-col-span-1 sm-col-span-1"
 					labelClassNames=" lg-col-span-7 md-col-span-5 sm-col-span-3"
 					aria-label={ __(
 						'Enable instant search experience (recommended)',
@@ -204,7 +203,6 @@ const InstantSearchToggle = ( {
 				</CompactFormToggle>
 			</div>
 			<div className="jp-search-dashboard-row">
-				<div className="lg-col-span-3 md-col-span-2 sm-col-span-1"></div>
 				<div className="jp-form-search-settings-group__toggle-description lg-col-span-7 md-col-span-5 sm-col-span-3">
 					{ supportsInstantSearch && (
 						<Fragment>
@@ -217,7 +215,6 @@ const InstantSearchToggle = ( {
 						<InstantSearchUpsellNudge href={ upgradeUrl } upgrade={ supportsOnlyClassicSearch } />
 					) }
 				</div>
-				<div className="lg-col-span-2 md-col-span-1 sm-col-span-0"></div>
 			</div>
 			{ supportsInstantSearch && (
 				<InstantSearchButtons
@@ -237,7 +234,6 @@ const InstantSearchButtons = ( {
 } ) => {
 	return (
 		<div className="jp-form-search-settings-group-buttons jp-search-dashboard-row">
-			<div className="lg-col-span-3 md-col-span-2 sm-col-span-1"></div>
 			<Button
 				className="jp-form-search-settings-group-buttons__button is-customize-search lg-col-span-4 md-col-span-5 sm-col-span-3"
 				href={
@@ -263,7 +259,6 @@ const InstantSearchButtons = ( {
 			>
 				<span>{ __( 'Edit sidebar widgets', 'jetpack-search-pkg' ) }</span>
 			</Button>
-			<div className="lg-col-span-2 md-col-span-1 sm-col-span-0"></div>
 		</div>
 	);
 };
@@ -285,30 +280,26 @@ const SearchToggle = ( {
 		<div className="jp-form-search-settings-group__toggle is-search jp-search-dashboard-wrap">
 			{ ! isWpcom && (
 				<div className="jp-search-dashboard-row">
-					<div className="lg-col-span-2 md-col-span-1 sm-col-span-0"></div>
 					<CompactFormToggle
 						checked={ isSearchToggleChecked }
 						disabled={ isSearchToggleDisabled }
 						onChange={ toggleSearchModule }
 						toggling={ isTogglingModule }
 						className="is-search-admin"
-						switchClassNames="lg-col-span-1 md-col-span-1 sm-col-span-1"
+						switchClassNames="jp-search-dashboard-toggle lg-col-span-1 md-col-span-1 sm-col-span-1"
 						labelClassNames=" lg-col-span-7 md-col-span-5 sm-col-span-3"
 						aria-label={ __( 'Enable Jetpack Search', 'jetpack-search-pkg' ) }
 					>
 						{ __( 'Enable Jetpack Search', 'jetpack-search-pkg' ) }
 					</CompactFormToggle>
-					<div className="lg-col-span-2 md-col-span-1 sm-col-span-0"></div>
 				</div>
 			) }
 			<div className="jp-search-dashboard-row">
-				<div className="lg-col-span-3 md-col-span-2 sm-col-span-1"></div>
 				<div className="jp-form-search-settings-group__toggle-description lg-col-span-7 md-col-span-5 sm-col-span-3">
 					<p className="jp-form-search-settings-group__toggle-explanation">
 						{ SEARCH_DESCRIPTION }
 					</p>
 				</div>
-				<div className="lg-col-span-2 md-col-span-1 sm-col-span-0"></div>
 			</div>
 		</div>
 	);

--- a/projects/packages/search/src/dashboard/components/pages/dashboard-page.jsx
+++ b/projects/packages/search/src/dashboard/components/pages/dashboard-page.jsx
@@ -226,14 +226,12 @@ const MockedSearchInterface = ( { supportsInstantSearch, supportsOnlyClassicSear
 				<div className=" lg-col-span-6 md-col-span-1 sm-col-span-0"></div>
 			</div>
 			<div className="jp-search-dashboard-row" aria-hidden="true">
-				<div className="lg-col-span-1 md-col-span-1 sm-col-span-0"></div>
-				<div className="jp-search-dashboard-top__mocked-search-interface lg-col-span-10 md-col-span-6 sm-col-span-4">
+				<div className="jp-search-dashboard-top__mocked-search-interface lg-col-span-12 md-col-span-6 sm-col-span-4">
 					<MockedSearch
 						supportsInstantSearch={ supportsInstantSearch }
 						supportsOnlyClassicSearch={ supportsOnlyClassicSearch }
 					/>
 				</div>
-				<div className="lg-col-span-1 md-col-span-1 sm-col-span-0"></div>
 			</div>
 		</div>
 	);

--- a/projects/packages/search/src/dashboard/components/pages/sections/plan-usage-section.jsx
+++ b/projects/packages/search/src/dashboard/components/pages/sections/plan-usage-section.jsx
@@ -243,14 +243,12 @@ const PlanUsageSection = ( { isFreePlan, planInfo, sendPaidPlanToCart, isPlanJus
 	return (
 		<div className="jp-search-dashboard-wrap jp-search-dashboard-meter-wrap">
 			<div className="jp-search-dashboard-row">
-				<div className="lg-col-span-2 md-col-span-1 sm-col-span-0"></div>
-				<div className="jp-search-dashboard-meter-wrap__content lg-col-span-8 md-col-span-6 sm-col-span-4">
+				<div className="jp-search-dashboard-meter-wrap__content lg-col-span-12 md-col-span-6 sm-col-span-4">
 					<PlanSummary isFreePlan={ isFreePlan } planInfo={ planInfo } />
 					<UsageMeters usageInfo={ usageInfo } isPlanJustUpgraded={ isPlanJustUpgraded } />
 					<UpgradeTrigger upgradeMessage={ upgradeMessage } ctaCallback={ sendPaidPlanToCart } />
 					<AboutPlanLimits />
 				</div>
-				<div className="lg-col-span-2 md-col-span-1 sm-col-span-0"></div>
 			</div>
 		</div>
 	);

--- a/projects/packages/search/src/dashboard/components/record-meter/index.jsx
+++ b/projects/packages/search/src/dashboard/components/record-meter/index.jsx
@@ -29,8 +29,7 @@ export default function RecordMeter( {
 	return (
 		<div className="jp-search-record-meter jp-search-dashboard-wrap" data-testid="record-meter">
 			<div className="jp-search-dashboard-row">
-				<div className="lg-col-span-2 md-col-span-1 sm-col-span-0"></div>
-				<div className="jp-search-record-meter__content lg-col-span-8 md-col-span-6 sm-col-span-4">
+				<div className="jp-search-record-meter__content lg-col-span-12 md-col-span-6 sm-col-span-4">
 					<h2>
 						{
 							/* translators: 'Your search index' is a breakdown of the site's indexed post type content,
@@ -56,7 +55,6 @@ export default function RecordMeter( {
 						></NoticeBox>
 					</div>
 				</div>
-				<div className="lg-col-span-2 md-col-span-1 sm-col-span-0"></div>
 			</div>
 		</div>
 	);

--- a/projects/packages/search/src/dashboard/scss/rna-styles.scss
+++ b/projects/packages/search/src/dashboard/scss/rna-styles.scss
@@ -46,7 +46,7 @@
 
 	@include variables.for-tablet-up {
 		grid-template-columns: repeat(12, 1fr);
-		max-width: 1128px;
+		max-width: 1040px;
 		width: calc(100% - 48px);
 		margin: 0 24px;
 	}
@@ -99,4 +99,8 @@
 			display: block;
 		}
 	}
+}
+
+.jp-search-dashboard-toggle {
+	justify-content: start !important;
 }


### PR DESCRIPTION
Part of DOTCOM-16126.

## Proposed changes:

Limits the search admin contents to to 1040px wide and expands the elements so it fills that container:

<img width="2880" height="3536" alt="zaguiini065 wordpress com_wp-admin_admin php_page=jetpack-search" src="https://github.com/user-attachments/assets/6a0f0b5f-c44d-4458-9aa4-532bf8f45ba6" />



This is part of a series of PRs that will standardize the content width to match WPCOM.



## Jetpack product discussion

p1771956593002369-slack-C0AGM2YP9GW.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

Apply this PR to your sandbox, proxy a simple site to it, and verify that the width of the Jetpack Search section matches the heading title just like the screenshot. Verify that it still matches as you resize the screen.