### PR TITLE
Forms: Fix synced form loading state during initial IDLE status

### DIFF
--- a/projects/packages/forms/changelog/fix-cfm-form-loading
+++ b/projects/packages/forms/changelog/fix-cfm-form-loading
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed synced form loading state to correctly report loading during initial IDLE status

--- a/projects/packages/forms/src/blocks/contact-form/edit.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/edit.tsx
@@ -290,7 +290,7 @@ function JetpackContactFormEdit( {
 
 			return {
 				postTitle: title,
-				hasAnyInnerBlocks: innerBlocksData.length > 0,
+				hasAnyInnerBlocks: innerBlocksData.length > 0 || syncedFormBlocks?.length > 0,
 				postAuthorEmail: authorEmail,
 				selectedBlockClientId: selectedStepBlockId,
 				onlySubmitBlock: isSingleButtonBlock,
@@ -298,7 +298,7 @@ function JetpackContactFormEdit( {
 				hasChildSelected: hasSelectedInnerBlock( clientId, true ),
 			};
 		},
-		[ clientId ]
+		[ clientId, syncedFormBlocks ]
 	);
 
 	useEffect( () => {

--- a/projects/packages/forms/src/blocks/contact-form/hooks/use-synced-form.ts
+++ b/projects/packages/forms/src/blocks/contact-form/hooks/use-synced-form.ts
@@ -24,6 +24,8 @@ interface UseSyncedFormResult {
 	syncedForm: JetpackForm | null;
 }
 
+const EMPTY_FORM = { syncedAttributes: null, syncedInnerBlocks: null };
+
 /**
  * Custom hook to load a synced form from jetpack_form post type
  * When a form block has a `ref` attribute, this hook loads the full block content
@@ -33,11 +35,13 @@ interface UseSyncedFormResult {
  * @return {UseSyncedFormResult} Object containing loading state and parsed block data
  */
 export function useSyncedForm( ref: number | undefined ): UseSyncedFormResult {
-	const { record, isResolving, hasEdits } = useEntityRecord< JetpackForm >(
+	const { record, isResolving, status, hasEdits } = useEntityRecord< JetpackForm >(
 		'postType',
 		FORM_POST_TYPE,
 		ref,
-		{ enabled: !! ref }
+		{
+			enabled: !! ref,
+		}
 	);
 
 	// Get the actual pending edits object to see exactly what's being changed
@@ -99,20 +103,20 @@ export function useSyncedForm( ref: number | undefined ): UseSyncedFormResult {
 
 		// Fall back to saved record content
 		if ( ! record?.content?.raw ) {
-			return { syncedAttributes: null, syncedInnerBlocks: null };
+			return EMPTY_FORM;
 		}
 
 		const parsedBlocks = parse( record.content.raw );
 
 		if ( ! parsedBlocks || parsedBlocks.length === 0 ) {
-			return { syncedAttributes: null, syncedInnerBlocks: null };
+			return EMPTY_FORM;
 		}
 
 		// Get the first block (should be the contact-form block)
 		const formBlock = parsedBlocks[ 0 ];
 
 		if ( formBlock.name !== 'jetpack/contact-form' ) {
-			return { syncedAttributes: null, syncedInnerBlocks: null };
+			return EMPTY_FORM;
 		}
 
 		// Get attributes and add 'ref' (lock is stripped via destructuring)
@@ -136,6 +140,16 @@ export function useSyncedForm( ref: number | undefined ): UseSyncedFormResult {
 			syncedAttributes: null,
 			syncedInnerBlocks: null,
 			syncedForm: null,
+		};
+	}
+
+	// IDLE Status is when we haven't started the loading process just yet.
+	if ( status === 'IDLE' ) {
+		return {
+			isLoading: true,
+			syncedAttributes,
+			syncedInnerBlocks,
+			syncedForm: record,
 		};
 	}
 


### PR DESCRIPTION
This PR tries to improve the loading states that the user sees when the form with ref loads. 



Before:


https://github.com/user-attachments/assets/bed7ab69-9697-4982-8d79-8b230dd04c93


After:

https://github.com/user-attachments/assets/5b2dfada-f9ff-4418-80d6-b315d7592e9b


The main difference is that we don't show the yellow waring notice for users with valid forms. 
Instead we show the skeleton placeholder. 

For users that had a bad ref ID. We show the loading placeholder as well. Before we would have shown the ref ID always. 

## Proposed changes:
- Fixed the `useSyncedForm` hook to correctly report `isLoading: true` when the `useEntityRecord` status is `IDLE`
- Previously, the hook only checked `isResolving` to determine loading state, but `IDLE` status occurs before loading even starts
- This prevents a brief flash where the synced form appears loaded before the actual loading begins

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

1. Go to the block editor on a page/post
2. Insert a Jetpack Form block that references a synced form (one with a `ref` attribute)
3. Observe that the form loading state is correctly shown during the initial load
4. Previously, there could be a brief flash of the form appearing "loaded" before actual loading began

## Changelog

- [x] Generate changelog entries for this PR (using AI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)