### PR TITLE
Forms Dashboard: Add form status badge to single form view

### DIFF
--- a/projects/packages/forms/changelog/add-forms-dashboard-status
+++ b/projects/packages/forms/changelog/add-forms-dashboard-status
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Forms Dashboard: Display form status badge in the single form view header

--- a/projects/packages/forms/routes/forms/package.json
+++ b/projects/packages/forms/routes/forms/package.json
@@ -4,6 +4,7 @@
 	"private": true,
 	"dependencies": {
 		"@automattic/jetpack-components": "workspace:*",
+		"@automattic/ui": "1.0.2",
 		"@base-ui-components/react": "^1.0.0-beta.4",
 		"@types/react": "18.3.28",
 		"@wordpress/admin-ui": "1.8.0",

--- a/projects/packages/forms/routes/forms/stage.tsx
+++ b/projects/packages/forms/routes/forms/stage.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { Badge } from '@automattic/ui';
 import { Page } from '@wordpress/admin-ui';
 import {
 	__experimentalConfirmDialog as ConfirmDialog, // eslint-disable-line @wordpress/no-unsafe-wp-apis
@@ -266,7 +267,11 @@ function StageInner() {
 				id: 'status',
 				label: __( 'Status', 'jetpack-forms' ),
 				getValue: ( { item }: { item: FormListItem } ) => item.status,
-				render: ( { item }: { item: FormListItem } ) => statusLabel( item.status ),
+				render: ( { item }: { item: FormListItem } ) => (
+					<Badge intent="default" className="jp-forms-badge">
+						{ statusLabel( item.status ) }
+					</Badge>
+				),
 				elements: [
 					{ label: __( 'All', 'jetpack-forms' ), value: 'all' },
 					{ label: __( 'Published', 'jetpack-forms' ), value: 'publish' },

--- a/projects/packages/forms/routes/responses/stage.tsx
+++ b/projects/packages/forms/routes/responses/stage.tsx
@@ -545,6 +545,7 @@ function StageInner() {
 
 	const {
 		breadcrumbs,
+		badges,
 		subtitle,
 		actions: headerActions,
 	} = usePageHeaderDetails( {
@@ -570,6 +571,7 @@ function StageInner() {
 		<Page
 			showSidebarToggle={ false }
 			breadcrumbs={ breadcrumbs }
+			badges={ badges }
 			subTitle={ subtitle }
 			actions={ headerActions }
 			hasPadding={ false }

--- a/projects/packages/forms/src/dashboard/wp-build/components/dataviews-header-row/index.tsx
+++ b/projects/packages/forms/src/dashboard/wp-build/components/dataviews-header-row/index.tsx
@@ -98,7 +98,7 @@ export default function DataViewsHeaderRow( {
 								<Tabs.Tab value="forms">
 									<span>
 										{ __( 'Forms', 'jetpack-forms' ) }
-										<Badge intent="default" className="jp-forms-count-badge">
+										<Badge intent="default" className="jp-forms-badge">
 											{ formatNumberCompact( formsCount || 0 ) }
 										</Badge>
 									</span>
@@ -106,7 +106,7 @@ export default function DataViewsHeaderRow( {
 								<Tabs.Tab value="responses">
 									<span>
 										{ __( 'Responses', 'jetpack-forms' ) }
-										<Badge intent="default" className="jp-forms-count-badge">
+										<Badge intent="default" className="jp-forms-badge">
 											{ formatNumberCompact( responsesInboxCount || 0 ) }
 										</Badge>
 									</span>

--- a/projects/packages/forms/src/dashboard/wp-build/components/dataviews-header-row/style.scss
+++ b/projects/packages/forms/src/dashboard/wp-build/components/dataviews-header-row/style.scss
@@ -32,7 +32,7 @@
 }
 
 // Temporary hard-coded styles for tab count badges in wp-build dashboard.
-.jp-forms-count-badge {
+.jp-forms-badge {
 	background-color: #f0f0f0;
 	color: #2f2f2f;
 	margin-inline-start: 4px;

--- a/projects/packages/forms/src/dashboard/wp-build/components/inbox-status-toggle/index.tsx
+++ b/projects/packages/forms/src/dashboard/wp-build/components/inbox-status-toggle/index.tsx
@@ -41,7 +41,7 @@ const getLabel = ( status: Status, count: number ): JSX.Element => {
 	return (
 		<span>
 			{ label }
-			<Badge intent="default" className="jp-forms-count-badge">
+			<Badge intent="default" className="jp-forms-badge">
 				{ formatNumberCompact( count || 0 ) }
 			</Badge>
 		</span>

--- a/projects/packages/forms/src/dashboard/wp-build/hooks/use-page-header-details.tsx
+++ b/projects/packages/forms/src/dashboard/wp-build/hooks/use-page-header-details.tsx
@@ -142,10 +142,14 @@ export default function usePageHeaderDetails(
 	}, [ formStatus ] );
 
 	const badges = useMemo( () => {
-		if ( ! isSingleFormScreen || ! formStatus ) {
+		if ( ! isSingleFormScreen || ! formStatus || formStatus === 'publish' ) {
 			return undefined;
 		}
-		return <Badge intent="default">{ statusLabel }</Badge>;
+		return (
+			<Badge className="jp-forms-badge" intent="default">
+				{ statusLabel }
+			</Badge>
+		);
 	}, [ isSingleFormScreen, formStatus, statusLabel ] );
 
 	const { duplicateForm, previewForm, copyEmbed, copyShortcode } = useFormItemActions();

--- a/projects/packages/forms/src/dashboard/wp-build/hooks/use-page-header-details.tsx
+++ b/projects/packages/forms/src/dashboard/wp-build/hooks/use-page-header-details.tsx
@@ -3,6 +3,7 @@
  */
 import { useBreakpointMatch } from '@automattic/jetpack-components';
 import JetpackLogo from '@automattic/jetpack-components/jetpack-logo';
+import { Badge } from '@automattic/ui';
 import { Breadcrumbs } from '@wordpress/admin-ui';
 import { DropdownMenu, Button } from '@wordpress/components';
 import { store as coreDataStore } from '@wordpress/core-data';
@@ -47,6 +48,7 @@ type UsePageHeaderDetailsProps = {
 
 type UsePageHeaderDetailsReturn = {
 	breadcrumbs: ReactNode;
+	badges?: ReactNode;
 	subtitle: ReactNode;
 	actions?: ReactNode;
 };
@@ -110,7 +112,7 @@ export default function usePageHeaderDetails(
 						'postType',
 						'jetpack_form',
 						sourceIdNumber
-				  ) as { title?: { rendered?: string } } | undefined )
+				  ) as { title?: { rendered?: string }; status?: string } | undefined )
 				: undefined,
 		[ sourceIdNumber ]
 	);
@@ -119,6 +121,32 @@ export default function usePageHeaderDetails(
 		const rendered = formRecord?.title?.rendered || '';
 		return decodeEntities( rendered );
 	}, [ formRecord?.title?.rendered ] );
+
+	const formStatus = formRecord?.status;
+
+	const statusLabel = useMemo( () => {
+		switch ( formStatus ) {
+			case 'publish':
+				return __( 'Published', 'jetpack-forms' );
+			case 'draft':
+				return __( 'Draft', 'jetpack-forms' );
+			case 'pending':
+				return __( 'Pending review', 'jetpack-forms' );
+			case 'future':
+				return __( 'Scheduled', 'jetpack-forms' );
+			case 'private':
+				return __( 'Private', 'jetpack-forms' );
+			default:
+				return formStatus;
+		}
+	}, [ formStatus ] );
+
+	const badges = useMemo( () => {
+		if ( ! isSingleFormScreen || ! formStatus ) {
+			return undefined;
+		}
+		return <Badge intent="default">{ statusLabel }</Badge>;
+	}, [ isSingleFormScreen, formStatus, statusLabel ] );
 
 	const { duplicateForm, previewForm, copyEmbed, copyShortcode } = useFormItemActions();
 
@@ -446,5 +474,5 @@ export default function usePageHeaderDetails(
 		emptySpam.selectedResponsesCount,
 	] );
 
-	return { breadcrumbs, subtitle, actions };
+	return { breadcrumbs, badges, subtitle, actions };
 }


### PR DESCRIPTION
Updates to use Badges. 

<img width="370" height="99" alt="Screenshot 2026-02-25 at 12 45 17 PM" src="https://github.com/user-attachments/assets/4055c09b-7fbc-4790-a079-c06833cb71e2" />

<img width="1388" height="457" alt="Screenshot 2026-02-25 at 12 54 22 PM" src="https://github.com/user-attachments/assets/ef5f9805-7df7-4ddc-9210-7047f2f54ecd" />


## Proposed changes

- Add form status badge (Published, Draft, Pending review, Scheduled, Private) to the single form view header in the wp-build dashboard
- Display the badge next to the form name in the page header when viewing responses for a specific form
- Uses the existing `Badge` component from `@automattic/ui` with `intent="default"`

## Other information

This change enhances the single form view by showing users the publication status of the form they're viewing responses for, consistent with how status is displayed in the forms list view.

## Does this pull request change what data or activity we track or use?

No


## Testing instructions

1. Navigate to the Jetpack Forms dashboard (wp-build version)
2. Click on any form to view its responses (single form view)
3. Verify that the form's status badge appears in the page header next to the form name
4. Test with forms in different statuses:
   - Published forms should show "Published" badge
   - Draft forms should show "Draft" badge
   - Other statuses (Pending review, Scheduled, Private) should display accordingly

🤖 Generated with [Claude Code](https://claude.ai/code)