### PR TITLE
Forms: Create synced form when inserting form variations via block inserter

### DIFF
--- a/projects/packages/forms/changelog/fix-cfm-insert-form-variation
+++ b/projects/packages/forms/changelog/fix-cfm-insert-form-variation
@@ -1,4 +1,4 @@
 Significance: minor
-Type: added
+Type: fixed
 
 Create synced form when inserting form variations via the block inserter.

--- a/projects/packages/forms/changelog/fix-cfm-insert-form-variation
+++ b/projects/packages/forms/changelog/fix-cfm-insert-form-variation
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Create synced form when inserting form variations via the block inserter.

--- a/projects/packages/forms/src/blocks/contact-form/edit.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/edit.tsx
@@ -56,6 +56,7 @@ import ContactFormSkeletonLoader from './components/jetpack-contact-form-skeleto
 import NotificationsSettings from './components/notifications-settings.js';
 import WebhooksSettings from './components/webhooks-settings.js';
 import WidgetEditorReadonlyView from './components/widget-editor-readonly-view.tsx';
+import { useCreateSyncedFormOnInsertion } from './hooks/use-create-synced-form-on-insertion.ts';
 import { useSyncedFormAutoSave } from './hooks/use-synced-form-auto-save.ts';
 import { useSyncedFormLoader } from './hooks/use-synced-form-loader.ts';
 import { useSyncedForm } from './hooks/use-synced-form.ts';
@@ -423,6 +424,14 @@ function JetpackContactFormEdit( {
 		currentInnerBlocks,
 		isSyncingRef,
 		editEntityRecord,
+	} );
+
+	// Create synced form when a variation is inserted via the block inserter
+	useCreateSyncedFormOnInsertion( {
+		ref,
+		innerBlocks: currentInnerBlocks,
+		attributes,
+		setAttributes,
 	} );
 
 	// Note: We don't clear attributes in memory when ref is set, as they're needed

--- a/projects/packages/forms/src/blocks/contact-form/edit.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/edit.tsx
@@ -428,6 +428,7 @@ function JetpackContactFormEdit( {
 
 	// Create synced form when a variation is inserted via the block inserter
 	useCreateSyncedFormOnInsertion( {
+		clientId,
 		ref,
 		innerBlocks: currentInnerBlocks,
 		attributes,

--- a/projects/packages/forms/src/blocks/contact-form/hooks/use-create-synced-form-on-insertion.ts
+++ b/projects/packages/forms/src/blocks/contact-form/hooks/use-create-synced-form-on-insertion.ts
@@ -133,6 +133,13 @@ export function useCreateSyncedFormOnInsertion( {
 		return () => {
 			cancelled = true;
 		};
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [] );
+	}, [
+		shouldCreate,
+		attributes,
+		innerBlocks,
+		currentPostId,
+		setAttributes,
+		createSuccessNotice,
+		createErrorNotice,
+	] );
 }

--- a/projects/packages/forms/src/blocks/contact-form/hooks/use-create-synced-form-on-insertion.ts
+++ b/projects/packages/forms/src/blocks/contact-form/hooks/use-create-synced-form-on-insertion.ts
@@ -132,14 +132,8 @@ export function useCreateSyncedFormOnInsertion( {
 
 		return () => {
 			cancelled = true;
+			hasAttemptedCreation.current = false;
 		};
-	}, [
-		shouldCreate,
-		attributes,
-		innerBlocks,
-		currentPostId,
-		setAttributes,
-		createSuccessNotice,
-		createErrorNotice,
-	] );
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [] );
 }

--- a/projects/packages/forms/src/blocks/contact-form/hooks/use-create-synced-form-on-insertion.ts
+++ b/projects/packages/forms/src/blocks/contact-form/hooks/use-create-synced-form-on-insertion.ts
@@ -25,12 +25,14 @@ interface UseCreateSyncedFormOnInsertionProps {
 }
 
 /**
- * Get the variation name from attributes or inner blocks structure.
- * Returns undefined if the form doesn't match a known variation template.
+ * Get the variation title from attributes or inner blocks structure.
+ * If the form matches a known variation template, returns that variation's title.
+ * If the form has inner blocks but doesn't match a known template, returns a generic "Form" title.
+ * If the form has no inner blocks, returns undefined.
  *
  * @param {Record<string, unknown>} attributes  - Block attributes.
  * @param {Block[]}                 innerBlocks - Inner blocks of the form.
- * @return {string | undefined} The variation title, or undefined if not found.
+ * @return {string | undefined} The variation title, a generic "Form" title, or undefined when there are no inner blocks.
  */
 function getVariationTitleFromAttributes(
 	attributes: Record< string, unknown >,

--- a/projects/packages/forms/src/blocks/contact-form/hooks/use-create-synced-form-on-insertion.ts
+++ b/projects/packages/forms/src/blocks/contact-form/hooks/use-create-synced-form-on-insertion.ts
@@ -74,6 +74,8 @@ export function useCreateSyncedFormOnInsertion( {
 
 		hasAttemptedCreation.current = true;
 
+		let cancelled = false;
+
 		( async () => {
 			try {
 				const name = attributes.variationName as string | undefined;
@@ -89,9 +91,21 @@ export function useCreateSyncedFormOnInsertion( {
 
 				const formId = await createSyncedForm( formBlock, formTitle, Number( currentPostId ) );
 
-				// Preload the entity record into the cache before setting ref
+				if ( cancelled ) {
+					return;
+				}
+
+				// Best-effort preload of the entity record into the cache before setting ref
 				// to prevent the form from showing a loading skeleton.
-				await resolveSelect( coreStore ).getEntityRecord( 'postType', FORM_POST_TYPE, formId );
+				try {
+					await resolveSelect( coreStore ).getEntityRecord( 'postType', FORM_POST_TYPE, formId );
+				} catch {
+					// Preload failed; the form will show a brief loading state.
+				}
+
+				if ( cancelled ) {
+					return;
+				}
 
 				setAttributes( { ref: formId } );
 
@@ -100,6 +114,10 @@ export function useCreateSyncedFormOnInsertion( {
 					isDismissible: true,
 				} );
 			} catch ( error ) {
+				if ( cancelled ) {
+					return;
+				}
+
 				// eslint-disable-next-line no-console
 				console.error( 'Failed to create synced form on insertion:', error );
 				createErrorNotice(
@@ -111,6 +129,10 @@ export function useCreateSyncedFormOnInsertion( {
 				);
 			}
 		} )();
+
+		return () => {
+			cancelled = true;
+		};
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [] );
 }

--- a/projects/packages/forms/src/blocks/contact-form/hooks/use-create-synced-form-on-insertion.ts
+++ b/projects/packages/forms/src/blocks/contact-form/hooks/use-create-synced-form-on-insertion.ts
@@ -7,6 +7,7 @@
  */
 
 import { hasFeatureFlag } from '@automattic/jetpack-shared-extension-utils';
+import { store as blockEditorStore } from '@wordpress/block-editor';
 import { createBlock, type Block } from '@wordpress/blocks';
 import { useSelect, useDispatch, useRegistry } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
@@ -18,6 +19,7 @@ import { createSyncedForm } from '../util/create-synced-form.ts';
 import variations from '../variations.js';
 
 interface UseCreateSyncedFormOnInsertionProps {
+	clientId: string;
 	ref: number | undefined;
 	innerBlocks: Block[];
 	attributes: Record< string, unknown >;
@@ -25,91 +27,22 @@ interface UseCreateSyncedFormOnInsertionProps {
 }
 
 /**
- * Get the variation title from attributes or inner blocks structure.
- * If the form matches a known variation template, returns that variation's title.
- * If the form has inner blocks but doesn't match a known template, returns a generic "Form" title.
- * If the form has no inner blocks, returns undefined.
+ * Get the variation title from the variationName attribute.
  *
- * @param {Record<string, unknown>} attributes  - Block attributes.
- * @param {Block[]}                 innerBlocks - Inner blocks of the form.
- * @return {string | undefined} The variation title, a generic "Form" title, or undefined when there are no inner blocks.
+ * @param {Record<string, unknown>} attributes - Block attributes.
+ * @return {string | undefined} The variation title, or undefined if no variationName.
  */
-function getVariationTitleFromAttributes(
-	attributes: Record< string, unknown >,
-	innerBlocks: Block[]
-): string | undefined {
-	// First check if there's a variationName attribute that matches a known variation
+function getVariationTitle( attributes: Record< string, unknown > ): string | undefined {
 	const variationName = attributes.variationName as string | undefined;
-	if ( variationName ) {
-		const matchingVariation = variations.find( v => {
-			// Check if the variation's attributes include this variationName
-			return (
-				v.attributes?.variationName === variationName ||
-				( v.name === 'contact-form' && variationName === 'default' )
-			);
-		} );
-		if ( matchingVariation ) {
-			return matchingVariation.title;
-		}
-	}
-
-	// If no variationName, try to match by inner blocks structure
-	// This is a simple heuristic based on the number and types of inner blocks
-	if ( innerBlocks.length === 0 ) {
+	if ( ! variationName ) {
 		return undefined;
 	}
 
-	// Look for specific patterns that identify variations
-	const blockNames = innerBlocks.map( b => b.name );
+	const matchingVariation = variations.find(
+		v => v.attributes?.variationName === variationName || v.name === variationName
+	);
 
-	// Rating field is unique to feedback form
-	if ( blockNames.includes( 'jetpack/field-rating' ) ) {
-		const feedbackVariation = variations.find( v => v.name === 'feedback-form' );
-		return feedbackVariation?.title;
-	}
-
-	// Date field is unique to appointment form
-	if ( blockNames.includes( 'jetpack/field-date' ) ) {
-		const appointmentVariation = variations.find( v => v.name === 'appointment-form' );
-		return appointmentVariation?.title;
-	}
-
-	// Radio field with name/email suggests RSVP (no date/phone)
-	if (
-		blockNames.includes( 'jetpack/field-radio' ) &&
-		! blockNames.includes( 'jetpack/field-telephone' )
-	) {
-		const rsvpVariation = variations.find( v => v.name === 'rsvp-form' );
-		return rsvpVariation?.title;
-	}
-
-	// Phone + select suggests registration form
-	if (
-		blockNames.includes( 'jetpack/field-telephone' ) &&
-		blockNames.includes( 'jetpack/field-select' )
-	) {
-		const registrationVariation = variations.find( v => v.name === 'registration-form' );
-		return registrationVariation?.title;
-	}
-
-	// Consent field suggests lead capture
-	if ( blockNames.includes( 'jetpack/field-consent' ) ) {
-		const leadCaptureVariation = variations.find( v => v.name === 'lead-capture-form' );
-		return leadCaptureVariation?.title;
-	}
-
-	// Default to contact form for name/email/textarea pattern
-	if (
-		blockNames.includes( 'jetpack/field-name' ) &&
-		blockNames.includes( 'jetpack/field-email' ) &&
-		blockNames.includes( 'jetpack/field-textarea' )
-	) {
-		const contactVariation = variations.find( v => v.name === 'contact-form' );
-		return contactVariation?.title;
-	}
-
-	// Fallback to generic form title
-	return __( 'Form', 'jetpack-forms' );
+	return matchingVariation?.title;
 }
 
 /**
@@ -118,6 +51,7 @@ function getVariationTitleFromAttributes(
  * @param {UseCreateSyncedFormOnInsertionProps} props - Hook properties.
  */
 export function useCreateSyncedFormOnInsertion( {
+	clientId,
 	ref,
 	innerBlocks,
 	attributes,
@@ -129,19 +63,28 @@ export function useCreateSyncedFormOnInsertion( {
 
 	const isCentralFormManagementEnabled = hasFeatureFlag( 'central-form-management' );
 
-	const { currentPostType, currentPostId } = useSelect( select => {
-		const { getCurrentPostType, getCurrentPostId } = select( editorStore );
-		return {
-			currentPostType: getCurrentPostType(),
-			currentPostId: getCurrentPostId(),
-		};
-	}, [] );
+	const { currentPostType, currentPostId, wasBlockJustInserted } = useSelect(
+		select => {
+			const { getCurrentPostType, getCurrentPostId } = select( editorStore );
+			return {
+				currentPostType: getCurrentPostType(),
+				currentPostId: getCurrentPostId(),
+				wasBlockJustInserted: select( blockEditorStore ).wasBlockJustInserted( clientId ),
+			};
+		},
+		[ clientId ]
+	);
 
 	const isEditingJetpackFormPost = currentPostType === FORM_POST_TYPE;
 
 	useEffect( () => {
 		// Only run this effect once
 		if ( hasAttemptedCreation.current ) {
+			return;
+		}
+
+		// Skip if block was not just inserted
+		if ( ! wasBlockJustInserted ) {
 			return;
 		}
 
@@ -175,7 +118,7 @@ export function useCreateSyncedFormOnInsertion( {
 		const createForm = async () => {
 			try {
 				// Get the variation title for naming the form
-				const formTitle = getVariationTitleFromAttributes( attributes, innerBlocks );
+				const formTitle = getVariationTitle( attributes );
 
 				// Create a block with the current attributes and inner blocks
 				const formBlock = createBlock(
@@ -219,6 +162,7 @@ export function useCreateSyncedFormOnInsertion( {
 		ref,
 		innerBlocks,
 		attributes,
+		wasBlockJustInserted,
 		isEditingJetpackFormPost,
 		isCentralFormManagementEnabled,
 		currentPostId,

--- a/projects/packages/forms/src/blocks/contact-form/hooks/use-create-synced-form-on-insertion.ts
+++ b/projects/packages/forms/src/blocks/contact-form/hooks/use-create-synced-form-on-insertion.ts
@@ -57,13 +57,14 @@ export function useCreateSyncedFormOnInsertion( {
 				currentPostId: getCurrentPostId(),
 				shouldCreate:
 					isCentralFormManagementEnabled &&
+					!! attributes.variationName &&
 					select( blockEditorStore ).wasBlockJustInserted( clientId ) &&
 					! ref &&
 					innerBlocks?.length > 0 &&
 					getCurrentPostType() !== FORM_POST_TYPE,
 			};
 		},
-		[ clientId, ref, innerBlocks, isCentralFormManagementEnabled ]
+		[ clientId, ref, innerBlocks, attributes.variationName, isCentralFormManagementEnabled ]
 	);
 
 	useEffect( () => {
@@ -77,7 +78,8 @@ export function useCreateSyncedFormOnInsertion( {
 			try {
 				const name = attributes.variationName as string | undefined;
 				const formTitle =
-					variations.find( v => v.name === name )?.title || __( 'Form', 'jetpack-forms' );
+					variations.find( v => v.attributes?.variationName === name )?.title ||
+					__( 'Form', 'jetpack-forms' );
 
 				const formBlock = createBlock(
 					'jetpack/contact-form',

--- a/projects/packages/forms/src/blocks/contact-form/hooks/use-create-synced-form-on-insertion.ts
+++ b/projects/packages/forms/src/blocks/contact-form/hooks/use-create-synced-form-on-insertion.ts
@@ -9,7 +9,8 @@
 import { hasFeatureFlag } from '@automattic/jetpack-shared-extension-utils';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 import { createBlock, type Block } from '@wordpress/blocks';
-import { useSelect, useDispatch, useRegistry } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
+import { useSelect, useDispatch, resolveSelect } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
 import { useEffect, useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -29,8 +30,11 @@ interface UseCreateSyncedFormOnInsertionProps {
 /**
  * Get the variation title from the variationName attribute.
  *
+ * Returns the matching variation's title if variationName is set and matches a known variation.
+ * Returns undefined if variationName is not set or doesn't match any known variation.
+ *
  * @param {Record<string, unknown>} attributes - Block attributes.
- * @return {string | undefined} The variation title, or undefined if no variationName.
+ * @return {string | undefined} The variation title, or undefined.
  */
 function getVariationTitle( attributes: Record< string, unknown > ): string | undefined {
 	const variationName = attributes.variationName as string | undefined;
@@ -58,7 +62,6 @@ export function useCreateSyncedFormOnInsertion( {
 	setAttributes,
 }: UseCreateSyncedFormOnInsertionProps ): void {
 	const hasAttemptedCreation = useRef( false );
-	const registry = useRegistry();
 	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
 
 	const isCentralFormManagementEnabled = hasFeatureFlag( 'central-form-management' );
@@ -134,10 +137,11 @@ export function useCreateSyncedFormOnInsertion( {
 					currentPostId
 				);
 
-				// Set the ref attribute to link to the synced form
-				registry.batch( () => {
-					setAttributes( { ref: formId } );
-				} );
+				// Preload the entity record into the cache before setting ref
+				// to prevent the form from showing a loading skeleton.
+				await resolveSelect( coreStore ).getEntityRecord( 'postType', FORM_POST_TYPE, formId );
+
+				setAttributes( { ref: formId } );
 
 				createSuccessNotice( __( 'New form created.', 'jetpack-forms' ), {
 					type: 'snackbar',
@@ -158,17 +162,6 @@ export function useCreateSyncedFormOnInsertion( {
 		};
 
 		createForm();
-	}, [
-		ref,
-		innerBlocks,
-		attributes,
-		wasBlockJustInserted,
-		isEditingJetpackFormPost,
-		isCentralFormManagementEnabled,
-		currentPostId,
-		setAttributes,
-		registry,
-		createSuccessNotice,
-		createErrorNotice,
-	] );
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [] );
 }

--- a/projects/packages/forms/src/blocks/contact-form/hooks/use-create-synced-form-on-insertion.ts
+++ b/projects/packages/forms/src/blocks/contact-form/hooks/use-create-synced-form-on-insertion.ts
@@ -1,0 +1,228 @@
+/**
+ * Hook to create a synced form when a form variation is inserted via the block inserter.
+ *
+ * When users insert a form variation directly from the block inserter (e.g., "Contact Form"),
+ * WordPress creates the block with innerBlocks immediately, bypassing the VariationPicker.
+ * This hook detects that scenario and creates a synced form, setting the ref attribute.
+ */
+
+import { hasFeatureFlag } from '@automattic/jetpack-shared-extension-utils';
+import { createBlock, type Block } from '@wordpress/blocks';
+import { useSelect, useDispatch, useRegistry } from '@wordpress/data';
+import { store as editorStore } from '@wordpress/editor';
+import { useEffect, useRef } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { store as noticesStore } from '@wordpress/notices';
+import { FORM_POST_TYPE } from '../../shared/util/constants.js';
+import { createSyncedForm } from '../util/create-synced-form.ts';
+import variations from '../variations.js';
+
+interface UseCreateSyncedFormOnInsertionProps {
+	ref: number | undefined;
+	innerBlocks: Block[];
+	attributes: Record< string, unknown >;
+	setAttributes: ( attributes: Record< string, unknown > ) => void;
+}
+
+/**
+ * Get the variation name from attributes or inner blocks structure.
+ * Returns undefined if the form doesn't match a known variation template.
+ *
+ * @param {Record<string, unknown>} attributes  - Block attributes.
+ * @param {Block[]}                 innerBlocks - Inner blocks of the form.
+ * @return {string | undefined} The variation title, or undefined if not found.
+ */
+function getVariationTitleFromAttributes(
+	attributes: Record< string, unknown >,
+	innerBlocks: Block[]
+): string | undefined {
+	// First check if there's a variationName attribute that matches a known variation
+	const variationName = attributes.variationName as string | undefined;
+	if ( variationName ) {
+		const matchingVariation = variations.find( v => {
+			// Check if the variation's attributes include this variationName
+			return (
+				v.attributes?.variationName === variationName ||
+				( v.name === 'contact-form' && variationName === 'default' )
+			);
+		} );
+		if ( matchingVariation ) {
+			return matchingVariation.title;
+		}
+	}
+
+	// If no variationName, try to match by inner blocks structure
+	// This is a simple heuristic based on the number and types of inner blocks
+	if ( innerBlocks.length === 0 ) {
+		return undefined;
+	}
+
+	// Look for specific patterns that identify variations
+	const blockNames = innerBlocks.map( b => b.name );
+
+	// Rating field is unique to feedback form
+	if ( blockNames.includes( 'jetpack/field-rating' ) ) {
+		const feedbackVariation = variations.find( v => v.name === 'feedback-form' );
+		return feedbackVariation?.title;
+	}
+
+	// Date field is unique to appointment form
+	if ( blockNames.includes( 'jetpack/field-date' ) ) {
+		const appointmentVariation = variations.find( v => v.name === 'appointment-form' );
+		return appointmentVariation?.title;
+	}
+
+	// Radio field with name/email suggests RSVP (no date/phone)
+	if (
+		blockNames.includes( 'jetpack/field-radio' ) &&
+		! blockNames.includes( 'jetpack/field-telephone' )
+	) {
+		const rsvpVariation = variations.find( v => v.name === 'rsvp-form' );
+		return rsvpVariation?.title;
+	}
+
+	// Phone + select suggests registration form
+	if (
+		blockNames.includes( 'jetpack/field-telephone' ) &&
+		blockNames.includes( 'jetpack/field-select' )
+	) {
+		const registrationVariation = variations.find( v => v.name === 'registration-form' );
+		return registrationVariation?.title;
+	}
+
+	// Consent field suggests lead capture
+	if ( blockNames.includes( 'jetpack/field-consent' ) ) {
+		const leadCaptureVariation = variations.find( v => v.name === 'lead-capture-form' );
+		return leadCaptureVariation?.title;
+	}
+
+	// Default to contact form for name/email/textarea pattern
+	if (
+		blockNames.includes( 'jetpack/field-name' ) &&
+		blockNames.includes( 'jetpack/field-email' ) &&
+		blockNames.includes( 'jetpack/field-textarea' )
+	) {
+		const contactVariation = variations.find( v => v.name === 'contact-form' );
+		return contactVariation?.title;
+	}
+
+	// Fallback to generic form title
+	return __( 'Form', 'jetpack-forms' );
+}
+
+/**
+ * Hook to create a synced form when a form variation is inserted via the block inserter.
+ *
+ * @param {UseCreateSyncedFormOnInsertionProps} props - Hook properties.
+ */
+export function useCreateSyncedFormOnInsertion( {
+	ref,
+	innerBlocks,
+	attributes,
+	setAttributes,
+}: UseCreateSyncedFormOnInsertionProps ): void {
+	const hasAttemptedCreation = useRef( false );
+	const registry = useRegistry();
+	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
+
+	const isCentralFormManagementEnabled = hasFeatureFlag( 'central-form-management' );
+
+	const { currentPostType, currentPostId } = useSelect( select => {
+		const { getCurrentPostType, getCurrentPostId } = select( editorStore );
+		return {
+			currentPostType: getCurrentPostType(),
+			currentPostId: getCurrentPostId(),
+		};
+	}, [] );
+
+	const isEditingJetpackFormPost = currentPostType === FORM_POST_TYPE;
+
+	useEffect( () => {
+		// Only run this effect once
+		if ( hasAttemptedCreation.current ) {
+			return;
+		}
+
+		// Skip if we already have a ref (already synced)
+		if ( ref ) {
+			hasAttemptedCreation.current = true;
+			return;
+		}
+
+		// Skip if no inner blocks (empty form, will show VariationPicker)
+		if ( ! innerBlocks || innerBlocks.length === 0 ) {
+			return;
+		}
+
+		// Skip if editing a jetpack_form post directly
+		if ( isEditingJetpackFormPost ) {
+			hasAttemptedCreation.current = true;
+			return;
+		}
+
+		// Skip if central form management is disabled
+		if ( ! isCentralFormManagementEnabled ) {
+			hasAttemptedCreation.current = true;
+			return;
+		}
+
+		// Mark that we've attempted creation
+		hasAttemptedCreation.current = true;
+
+		// Create the synced form
+		const createForm = async () => {
+			try {
+				// Get the variation title for naming the form
+				const formTitle = getVariationTitleFromAttributes( attributes, innerBlocks );
+
+				// Create a block with the current attributes and inner blocks
+				const formBlock = createBlock(
+					'jetpack/contact-form',
+					attributes as Record< string, unknown >,
+					innerBlocks
+				);
+
+				// Create the synced form post
+				const formId = await createSyncedForm(
+					formBlock,
+					formTitle || __( 'Form', 'jetpack-forms' ),
+					currentPostId
+				);
+
+				// Set the ref attribute to link to the synced form
+				registry.batch( () => {
+					setAttributes( { ref: formId } );
+				} );
+
+				createSuccessNotice( __( 'New form created.', 'jetpack-forms' ), {
+					type: 'snackbar',
+					isDismissible: true,
+				} );
+			} catch ( error ) {
+				// eslint-disable-next-line no-console
+				console.error( 'Failed to create synced form on insertion:', error );
+				createErrorNotice(
+					__( 'Failed to create form. Using inline form instead.', 'jetpack-forms' ),
+					{
+						type: 'snackbar',
+						isDismissible: true,
+					}
+				);
+				// Form will remain as inline form (no ref)
+			}
+		};
+
+		createForm();
+	}, [
+		ref,
+		innerBlocks,
+		attributes,
+		isEditingJetpackFormPost,
+		isCentralFormManagementEnabled,
+		currentPostId,
+		setAttributes,
+		registry,
+		createSuccessNotice,
+		createErrorNotice,
+	] );
+}

--- a/projects/packages/forms/src/blocks/contact-form/hooks/use-create-synced-form-on-insertion.ts
+++ b/projects/packages/forms/src/blocks/contact-form/hooks/use-create-synced-form-on-insertion.ts
@@ -85,7 +85,7 @@ export function useCreateSyncedFormOnInsertion( {
 					innerBlocks
 				);
 
-				const formId = await createSyncedForm( formBlock, formTitle, currentPostId );
+				const formId = await createSyncedForm( formBlock, formTitle, Number( currentPostId ) );
 
 				// Preload the entity record into the cache before setting ref
 				// to prevent the form from showing a loading skeleton.

--- a/projects/packages/forms/src/blocks/contact-form/hooks/use-create-synced-form-on-insertion.ts
+++ b/projects/packages/forms/src/blocks/contact-form/hooks/use-create-synced-form-on-insertion.ts
@@ -28,28 +28,6 @@ interface UseCreateSyncedFormOnInsertionProps {
 }
 
 /**
- * Get the variation title from the variationName attribute.
- *
- * Returns the matching variation's title if variationName is set and matches a known variation.
- * Returns undefined if variationName is not set or doesn't match any known variation.
- *
- * @param {Record<string, unknown>} attributes - Block attributes.
- * @return {string | undefined} The variation title, or undefined.
- */
-function getVariationTitle( attributes: Record< string, unknown > ): string | undefined {
-	const variationName = attributes.variationName as string | undefined;
-	if ( ! variationName ) {
-		return undefined;
-	}
-
-	const matchingVariation = variations.find(
-		v => v.attributes?.variationName === variationName || v.name === variationName
-	);
-
-	return matchingVariation?.title;
-}
-
-/**
  * Hook to create a synced form when a form variation is inserted via the block inserter.
  *
  * @param {UseCreateSyncedFormOnInsertionProps} props - Hook properties.
@@ -66,76 +44,48 @@ export function useCreateSyncedFormOnInsertion( {
 
 	const isCentralFormManagementEnabled = hasFeatureFlag( 'central-form-management' );
 
-	const { currentPostType, currentPostId, wasBlockJustInserted } = useSelect(
+	// Short-circuit store queries after creation has been attempted.
+	const { currentPostId, shouldCreate } = useSelect(
 		select => {
+			if ( hasAttemptedCreation.current ) {
+				return { currentPostId: 0, shouldCreate: false };
+			}
+
 			const { getCurrentPostType, getCurrentPostId } = select( editorStore );
+
 			return {
-				currentPostType: getCurrentPostType(),
 				currentPostId: getCurrentPostId(),
-				wasBlockJustInserted: select( blockEditorStore ).wasBlockJustInserted( clientId ),
+				shouldCreate:
+					isCentralFormManagementEnabled &&
+					select( blockEditorStore ).wasBlockJustInserted( clientId ) &&
+					! ref &&
+					innerBlocks?.length > 0 &&
+					getCurrentPostType() !== FORM_POST_TYPE,
 			};
 		},
-		[ clientId ]
+		[ clientId, ref, innerBlocks, isCentralFormManagementEnabled ]
 	);
 
-	const isEditingJetpackFormPost = currentPostType === FORM_POST_TYPE;
-
 	useEffect( () => {
-		// Only run this effect once
-		if ( hasAttemptedCreation.current ) {
+		if ( hasAttemptedCreation.current || ! shouldCreate ) {
 			return;
 		}
 
-		// Skip if block was not just inserted
-		if ( ! wasBlockJustInserted ) {
-			return;
-		}
-
-		// Skip if we already have a ref (already synced)
-		if ( ref ) {
-			hasAttemptedCreation.current = true;
-			return;
-		}
-
-		// Skip if no inner blocks (empty form, will show VariationPicker)
-		if ( ! innerBlocks || innerBlocks.length === 0 ) {
-			return;
-		}
-
-		// Skip if editing a jetpack_form post directly
-		if ( isEditingJetpackFormPost ) {
-			hasAttemptedCreation.current = true;
-			return;
-		}
-
-		// Skip if central form management is disabled
-		if ( ! isCentralFormManagementEnabled ) {
-			hasAttemptedCreation.current = true;
-			return;
-		}
-
-		// Mark that we've attempted creation
 		hasAttemptedCreation.current = true;
 
-		// Create the synced form
-		const createForm = async () => {
+		( async () => {
 			try {
-				// Get the variation title for naming the form
-				const formTitle = getVariationTitle( attributes );
+				const name = attributes.variationName as string | undefined;
+				const formTitle =
+					variations.find( v => v.name === name )?.title || __( 'Form', 'jetpack-forms' );
 
-				// Create a block with the current attributes and inner blocks
 				const formBlock = createBlock(
 					'jetpack/contact-form',
 					attributes as Record< string, unknown >,
 					innerBlocks
 				);
 
-				// Create the synced form post
-				const formId = await createSyncedForm(
-					formBlock,
-					formTitle || __( 'Form', 'jetpack-forms' ),
-					currentPostId
-				);
+				const formId = await createSyncedForm( formBlock, formTitle, currentPostId );
 
 				// Preload the entity record into the cache before setting ref
 				// to prevent the form from showing a loading skeleton.
@@ -157,11 +107,8 @@ export function useCreateSyncedFormOnInsertion( {
 						isDismissible: true,
 					}
 				);
-				// Form will remain as inline form (no ref)
 			}
-		};
-
-		createForm();
+		} )();
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [] );
 }

--- a/projects/packages/forms/src/blocks/contact-form/variations.js
+++ b/projects/packages/forms/src/blocks/contact-form/variations.js
@@ -157,6 +157,7 @@ const variations = [
 			],
 		],
 		attributes: {
+			variationName: 'rsvp-form',
 			subject: __( 'A new RSVP from your website', 'jetpack-forms' ),
 			layout: VERTICAL_LAYOUT,
 		},
@@ -311,6 +312,7 @@ const variations = [
 			],
 		],
 		attributes: {
+			variationName: 'registration-form',
 			subject: __( 'A new registration from your website', 'jetpack-forms' ),
 			layout: VERTICAL_LAYOUT,
 		},
@@ -501,6 +503,7 @@ const variations = [
 			],
 		],
 		attributes: {
+			variationName: 'appointment-form',
 			subject: __( 'A new appointment booked from your website', 'jetpack-forms' ),
 			layout: VERTICAL_LAYOUT,
 		},
@@ -648,6 +651,7 @@ const variations = [
 			],
 		],
 		attributes: {
+			variationName: 'feedback-form',
 			subject: __( 'New feedback received from your website', 'jetpack-forms' ),
 			layout: VERTICAL_LAYOUT,
 		},
@@ -970,6 +974,7 @@ const variations = [
 			],
 		],
 		attributes: {
+			variationName: 'lead-capture-form',
 			layout: VERTICAL_LAYOUT,
 		},
 		example: {

--- a/projects/packages/forms/tests/js/contact-form/use-create-synced-form-on-insertion.test.js
+++ b/projects/packages/forms/tests/js/contact-form/use-create-synced-form-on-insertion.test.js
@@ -1,0 +1,378 @@
+/**
+ * Tests for useCreateSyncedFormOnInsertion hook
+ */
+
+import { afterAll, beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { renderHook, waitFor } from '@testing-library/react';
+
+// Mock dependencies
+const mockCreateSyncedForm = jest.fn();
+const mockCreateSuccessNotice = jest.fn();
+const mockCreateErrorNotice = jest.fn();
+const mockSetAttributes = jest.fn();
+const mockBatch = jest.fn( callback => callback() );
+let mockHasFeatureFlag = true;
+let mockCurrentPostType = 'post';
+let mockCurrentPostId = 123;
+
+await jest.unstable_mockModule( '@automattic/jetpack-shared-extension-utils', () => ( {
+	hasFeatureFlag: flag => {
+		if ( flag === 'central-form-management' ) {
+			return mockHasFeatureFlag;
+		}
+		return false;
+	},
+} ) );
+
+await jest.unstable_mockModule( '@wordpress/blocks', () => ( {
+	createBlock: ( name, attributes, innerBlocks ) => ( {
+		name,
+		attributes,
+		innerBlocks,
+	} ),
+} ) );
+
+await jest.unstable_mockModule( '@wordpress/editor', () => ( {
+	store: 'core/editor',
+} ) );
+
+await jest.unstable_mockModule( '@wordpress/notices', () => ( {
+	store: 'core/notices',
+} ) );
+
+await jest.unstable_mockModule( '@wordpress/data', () => ( {
+	useSelect: selector => {
+		// The selector function expects to receive a `select` function
+		// that takes a store name and returns selectors for that store
+		const select = () => ( {
+			getCurrentPostType: () => mockCurrentPostType,
+			getCurrentPostId: () => mockCurrentPostId,
+		} );
+		return selector( select );
+	},
+	useDispatch: store => {
+		if ( store === 'core/notices' ) {
+			return {
+				createSuccessNotice: mockCreateSuccessNotice,
+				createErrorNotice: mockCreateErrorNotice,
+			};
+		}
+		return {};
+	},
+	useRegistry: () => ( {
+		batch: mockBatch,
+	} ),
+} ) );
+
+await jest.unstable_mockModule( '@wordpress/i18n', () => ( {
+	__: str => str,
+} ) );
+
+await jest.unstable_mockModule(
+	'../../../src/blocks/contact-form/util/create-synced-form.ts',
+	() => ( {
+		createSyncedForm: mockCreateSyncedForm,
+	} )
+);
+
+await jest.unstable_mockModule( '../../../src/blocks/shared/util/constants.js', () => ( {
+	FORM_POST_TYPE: 'jetpack_form',
+} ) );
+
+await jest.unstable_mockModule( '../../../src/blocks/contact-form/variations.js', () => ( {
+	default: [
+		{
+			name: 'contact-form',
+			title: 'Contact Form',
+			attributes: { variationName: 'default' },
+		},
+		{
+			name: 'feedback-form',
+			title: 'Feedback Form',
+			attributes: {},
+		},
+		{
+			name: 'appointment-form',
+			title: 'Appointment Form',
+			attributes: {},
+		},
+		{
+			name: 'rsvp-form',
+			title: 'RSVP Form',
+			attributes: {},
+		},
+		{
+			name: 'registration-form',
+			title: 'Registration Form',
+			attributes: {},
+		},
+		{
+			name: 'lead-capture-form',
+			title: 'Lead capture',
+			attributes: {},
+		},
+	],
+} ) );
+
+const { useCreateSyncedFormOnInsertion } = await import(
+	'../../../src/blocks/contact-form/hooks/use-create-synced-form-on-insertion.ts'
+);
+
+describe( 'useCreateSyncedFormOnInsertion', () => {
+	const defaultProps = {
+		ref: undefined,
+		innerBlocks: [
+			{ name: 'jetpack/field-name', innerBlocks: [] },
+			{ name: 'jetpack/field-email', innerBlocks: [] },
+			{ name: 'jetpack/field-textarea', innerBlocks: [] },
+			{ name: 'core/button', innerBlocks: [] },
+		],
+		attributes: { variationName: 'default' },
+		setAttributes: mockSetAttributes,
+	};
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+		mockHasFeatureFlag = true;
+		mockCurrentPostType = 'post';
+		mockCurrentPostId = 123;
+		mockCreateSyncedForm.mockResolvedValue( 42 );
+	} );
+
+	afterAll( () => {
+		jest.restoreAllMocks();
+	} );
+
+	it( 'creates a synced form when a variation is inserted with inner blocks', async () => {
+		renderHook( () => useCreateSyncedFormOnInsertion( defaultProps ) );
+
+		await waitFor( () => {
+			expect( mockCreateSyncedForm ).toHaveBeenCalled();
+		} );
+
+		expect( mockCreateSyncedForm ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				name: 'jetpack/contact-form',
+				attributes: defaultProps.attributes,
+				innerBlocks: defaultProps.innerBlocks,
+			} ),
+			'Contact Form',
+			123
+		);
+	} );
+
+	it( 'sets the ref attribute after creating synced form', async () => {
+		renderHook( () => useCreateSyncedFormOnInsertion( defaultProps ) );
+
+		await waitFor( () => {
+			expect( mockSetAttributes ).toHaveBeenCalledWith( { ref: 42 } );
+		} );
+	} );
+
+	it( 'shows success notice after creating synced form', async () => {
+		renderHook( () => useCreateSyncedFormOnInsertion( defaultProps ) );
+
+		await waitFor( () => {
+			expect( mockCreateSuccessNotice ).toHaveBeenCalledWith(
+				'New form created.',
+				expect.objectContaining( { type: 'snackbar' } )
+			);
+		} );
+	} );
+
+	it( 'does not create synced form if ref already exists', async () => {
+		const propsWithRef = { ...defaultProps, ref: 99 };
+
+		renderHook( () => useCreateSyncedFormOnInsertion( propsWithRef ) );
+
+		// Wait a bit to ensure no async calls
+		await new Promise( resolve => setTimeout( resolve, 100 ) );
+
+		expect( mockCreateSyncedForm ).not.toHaveBeenCalled();
+	} );
+
+	it( 'does not create synced form if no inner blocks', async () => {
+		const propsWithoutInnerBlocks = { ...defaultProps, innerBlocks: [] };
+
+		renderHook( () => useCreateSyncedFormOnInsertion( propsWithoutInnerBlocks ) );
+
+		// Wait a bit to ensure no async calls
+		await new Promise( resolve => setTimeout( resolve, 100 ) );
+
+		expect( mockCreateSyncedForm ).not.toHaveBeenCalled();
+	} );
+
+	it( 'does not create synced form when editing a jetpack_form post', async () => {
+		mockCurrentPostType = 'jetpack_form';
+
+		renderHook( () => useCreateSyncedFormOnInsertion( defaultProps ) );
+
+		// Wait a bit to ensure no async calls
+		await new Promise( resolve => setTimeout( resolve, 100 ) );
+
+		expect( mockCreateSyncedForm ).not.toHaveBeenCalled();
+	} );
+
+	it( 'does not create synced form when central form management is disabled', async () => {
+		mockHasFeatureFlag = false;
+
+		renderHook( () => useCreateSyncedFormOnInsertion( defaultProps ) );
+
+		// Wait a bit to ensure no async calls
+		await new Promise( resolve => setTimeout( resolve, 100 ) );
+
+		expect( mockCreateSyncedForm ).not.toHaveBeenCalled();
+	} );
+
+	it( 'only attempts to create synced form once', async () => {
+		const { rerender } = renderHook( props => useCreateSyncedFormOnInsertion( props ), {
+			initialProps: defaultProps,
+		} );
+
+		await waitFor( () => {
+			expect( mockCreateSyncedForm ).toHaveBeenCalledTimes( 1 );
+		} );
+
+		// Rerender with same props
+		rerender( defaultProps );
+
+		// Wait a bit and verify it wasn't called again
+		await new Promise( resolve => setTimeout( resolve, 100 ) );
+
+		expect( mockCreateSyncedForm ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'shows error notice when synced form creation fails', async () => {
+		mockCreateSyncedForm.mockRejectedValue( new Error( 'Failed to create' ) );
+
+		// Suppress the console.error from the rejected promise
+		const consoleSpy = jest.spyOn( console, 'error' ).mockImplementation( () => {} );
+
+		renderHook( () => useCreateSyncedFormOnInsertion( defaultProps ) );
+
+		await waitFor( () => {
+			expect( mockCreateErrorNotice ).toHaveBeenCalledWith(
+				'Failed to create form. Using inline form instead.',
+				expect.objectContaining( { type: 'snackbar' } )
+			);
+		} );
+
+		consoleSpy.mockRestore();
+	} );
+
+	it( 'identifies feedback form by rating field', async () => {
+		const feedbackProps = {
+			...defaultProps,
+			innerBlocks: [
+				{ name: 'jetpack/field-name', innerBlocks: [] },
+				{ name: 'jetpack/field-email', innerBlocks: [] },
+				{ name: 'jetpack/field-rating', innerBlocks: [] },
+				{ name: 'core/button', innerBlocks: [] },
+			],
+			attributes: {},
+		};
+
+		renderHook( () => useCreateSyncedFormOnInsertion( feedbackProps ) );
+
+		await waitFor( () => {
+			expect( mockCreateSyncedForm ).toHaveBeenCalledWith(
+				expect.anything(),
+				'Feedback Form',
+				expect.anything()
+			);
+		} );
+	} );
+
+	it( 'identifies appointment form by date field', async () => {
+		const appointmentProps = {
+			...defaultProps,
+			innerBlocks: [
+				{ name: 'jetpack/field-name', innerBlocks: [] },
+				{ name: 'jetpack/field-email', innerBlocks: [] },
+				{ name: 'jetpack/field-date', innerBlocks: [] },
+				{ name: 'core/button', innerBlocks: [] },
+			],
+			attributes: {},
+		};
+
+		renderHook( () => useCreateSyncedFormOnInsertion( appointmentProps ) );
+
+		await waitFor( () => {
+			expect( mockCreateSyncedForm ).toHaveBeenCalledWith(
+				expect.anything(),
+				'Appointment Form',
+				expect.anything()
+			);
+		} );
+	} );
+
+	it( 'identifies RSVP form by radio field without phone', async () => {
+		const rsvpProps = {
+			...defaultProps,
+			innerBlocks: [
+				{ name: 'jetpack/field-name', innerBlocks: [] },
+				{ name: 'jetpack/field-email', innerBlocks: [] },
+				{ name: 'jetpack/field-radio', innerBlocks: [] },
+				{ name: 'core/button', innerBlocks: [] },
+			],
+			attributes: {},
+		};
+
+		renderHook( () => useCreateSyncedFormOnInsertion( rsvpProps ) );
+
+		await waitFor( () => {
+			expect( mockCreateSyncedForm ).toHaveBeenCalledWith(
+				expect.anything(),
+				'RSVP Form',
+				expect.anything()
+			);
+		} );
+	} );
+
+	it( 'identifies registration form by phone and select fields', async () => {
+		const registrationProps = {
+			...defaultProps,
+			innerBlocks: [
+				{ name: 'jetpack/field-name', innerBlocks: [] },
+				{ name: 'jetpack/field-email', innerBlocks: [] },
+				{ name: 'jetpack/field-telephone', innerBlocks: [] },
+				{ name: 'jetpack/field-select', innerBlocks: [] },
+				{ name: 'core/button', innerBlocks: [] },
+			],
+			attributes: {},
+		};
+
+		renderHook( () => useCreateSyncedFormOnInsertion( registrationProps ) );
+
+		await waitFor( () => {
+			expect( mockCreateSyncedForm ).toHaveBeenCalledWith(
+				expect.anything(),
+				'Registration Form',
+				expect.anything()
+			);
+		} );
+	} );
+
+	it( 'identifies lead capture form by consent field', async () => {
+		const leadCaptureProps = {
+			...defaultProps,
+			innerBlocks: [
+				{ name: 'jetpack/field-name', innerBlocks: [] },
+				{ name: 'jetpack/field-email', innerBlocks: [] },
+				{ name: 'jetpack/field-consent', innerBlocks: [] },
+				{ name: 'core/button', innerBlocks: [] },
+			],
+			attributes: {},
+		};
+
+		renderHook( () => useCreateSyncedFormOnInsertion( leadCaptureProps ) );
+
+		await waitFor( () => {
+			expect( mockCreateSyncedForm ).toHaveBeenCalledWith(
+				expect.anything(),
+				'Lead capture',
+				expect.anything()
+			);
+		} );
+	} );
+} );

--- a/projects/packages/forms/tests/js/contact-form/use-create-synced-form-on-insertion.test.js
+++ b/projects/packages/forms/tests/js/contact-form/use-create-synced-form-on-insertion.test.js
@@ -14,6 +14,7 @@ const mockBatch = jest.fn( callback => callback() );
 let mockHasFeatureFlag = true;
 let mockCurrentPostType = 'post';
 let mockCurrentPostId = 123;
+let mockWasBlockJustInserted = true;
 
 await jest.unstable_mockModule( '@automattic/jetpack-shared-extension-utils', () => ( {
 	hasFeatureFlag: flag => {
@@ -22,6 +23,10 @@ await jest.unstable_mockModule( '@automattic/jetpack-shared-extension-utils', ()
 		}
 		return false;
 	},
+} ) );
+
+await jest.unstable_mockModule( '@wordpress/block-editor', () => ( {
+	store: 'core/block-editor',
 } ) );
 
 await jest.unstable_mockModule( '@wordpress/blocks', () => ( {
@@ -44,10 +49,20 @@ await jest.unstable_mockModule( '@wordpress/data', () => ( {
 	useSelect: selector => {
 		// The selector function expects to receive a `select` function
 		// that takes a store name and returns selectors for that store
-		const select = () => ( {
-			getCurrentPostType: () => mockCurrentPostType,
-			getCurrentPostId: () => mockCurrentPostId,
-		} );
+		const select = store => {
+			if ( store === 'core/editor' ) {
+				return {
+					getCurrentPostType: () => mockCurrentPostType,
+					getCurrentPostId: () => mockCurrentPostId,
+				};
+			}
+			if ( store === 'core/block-editor' ) {
+				return {
+					wasBlockJustInserted: () => mockWasBlockJustInserted,
+				};
+			}
+			return {};
+		};
 		return selector( select );
 	},
 	useDispatch: store => {
@@ -120,6 +135,7 @@ const { useCreateSyncedFormOnInsertion } = await import(
 
 describe( 'useCreateSyncedFormOnInsertion', () => {
 	const defaultProps = {
+		clientId: 'test-client-id',
 		ref: undefined,
 		innerBlocks: [
 			{ name: 'jetpack/field-name', innerBlocks: [] },
@@ -136,6 +152,7 @@ describe( 'useCreateSyncedFormOnInsertion', () => {
 		mockHasFeatureFlag = true;
 		mockCurrentPostType = 'post';
 		mockCurrentPostId = 123;
+		mockWasBlockJustInserted = true;
 		mockCreateSyncedForm.mockResolvedValue( 42 );
 	} );
 
@@ -260,117 +277,46 @@ describe( 'useCreateSyncedFormOnInsertion', () => {
 		consoleSpy.mockRestore();
 	} );
 
-	it( 'identifies feedback form by rating field', async () => {
-		const feedbackProps = {
+	it( 'does not create synced form when block was not just inserted', async () => {
+		mockWasBlockJustInserted = false;
+
+		renderHook( () => useCreateSyncedFormOnInsertion( defaultProps ) );
+
+		// Wait a bit to ensure no async calls
+		await new Promise( resolve => setTimeout( resolve, 100 ) );
+
+		expect( mockCreateSyncedForm ).not.toHaveBeenCalled();
+	} );
+
+	it( 'uses variationName attribute to get form title', async () => {
+		const propsWithVariationName = {
 			...defaultProps,
-			innerBlocks: [
-				{ name: 'jetpack/field-name', innerBlocks: [] },
-				{ name: 'jetpack/field-email', innerBlocks: [] },
-				{ name: 'jetpack/field-rating', innerBlocks: [] },
-				{ name: 'core/button', innerBlocks: [] },
-			],
-			attributes: {},
+			attributes: { variationName: 'default' },
 		};
 
-		renderHook( () => useCreateSyncedFormOnInsertion( feedbackProps ) );
+		renderHook( () => useCreateSyncedFormOnInsertion( propsWithVariationName ) );
 
 		await waitFor( () => {
 			expect( mockCreateSyncedForm ).toHaveBeenCalledWith(
 				expect.anything(),
-				'Feedback Form',
+				'Contact Form',
 				expect.anything()
 			);
 		} );
 	} );
 
-	it( 'identifies appointment form by date field', async () => {
-		const appointmentProps = {
+	it( 'falls back to generic Form title when no variationName', async () => {
+		const propsWithoutVariationName = {
 			...defaultProps,
-			innerBlocks: [
-				{ name: 'jetpack/field-name', innerBlocks: [] },
-				{ name: 'jetpack/field-email', innerBlocks: [] },
-				{ name: 'jetpack/field-date', innerBlocks: [] },
-				{ name: 'core/button', innerBlocks: [] },
-			],
 			attributes: {},
 		};
 
-		renderHook( () => useCreateSyncedFormOnInsertion( appointmentProps ) );
+		renderHook( () => useCreateSyncedFormOnInsertion( propsWithoutVariationName ) );
 
 		await waitFor( () => {
 			expect( mockCreateSyncedForm ).toHaveBeenCalledWith(
 				expect.anything(),
-				'Appointment Form',
-				expect.anything()
-			);
-		} );
-	} );
-
-	it( 'identifies RSVP form by radio field without phone', async () => {
-		const rsvpProps = {
-			...defaultProps,
-			innerBlocks: [
-				{ name: 'jetpack/field-name', innerBlocks: [] },
-				{ name: 'jetpack/field-email', innerBlocks: [] },
-				{ name: 'jetpack/field-radio', innerBlocks: [] },
-				{ name: 'core/button', innerBlocks: [] },
-			],
-			attributes: {},
-		};
-
-		renderHook( () => useCreateSyncedFormOnInsertion( rsvpProps ) );
-
-		await waitFor( () => {
-			expect( mockCreateSyncedForm ).toHaveBeenCalledWith(
-				expect.anything(),
-				'RSVP Form',
-				expect.anything()
-			);
-		} );
-	} );
-
-	it( 'identifies registration form by phone and select fields', async () => {
-		const registrationProps = {
-			...defaultProps,
-			innerBlocks: [
-				{ name: 'jetpack/field-name', innerBlocks: [] },
-				{ name: 'jetpack/field-email', innerBlocks: [] },
-				{ name: 'jetpack/field-telephone', innerBlocks: [] },
-				{ name: 'jetpack/field-select', innerBlocks: [] },
-				{ name: 'core/button', innerBlocks: [] },
-			],
-			attributes: {},
-		};
-
-		renderHook( () => useCreateSyncedFormOnInsertion( registrationProps ) );
-
-		await waitFor( () => {
-			expect( mockCreateSyncedForm ).toHaveBeenCalledWith(
-				expect.anything(),
-				'Registration Form',
-				expect.anything()
-			);
-		} );
-	} );
-
-	it( 'identifies lead capture form by consent field', async () => {
-		const leadCaptureProps = {
-			...defaultProps,
-			innerBlocks: [
-				{ name: 'jetpack/field-name', innerBlocks: [] },
-				{ name: 'jetpack/field-email', innerBlocks: [] },
-				{ name: 'jetpack/field-consent', innerBlocks: [] },
-				{ name: 'core/button', innerBlocks: [] },
-			],
-			attributes: {},
-		};
-
-		renderHook( () => useCreateSyncedFormOnInsertion( leadCaptureProps ) );
-
-		await waitFor( () => {
-			expect( mockCreateSyncedForm ).toHaveBeenCalledWith(
-				expect.anything(),
-				'Lead capture',
+				'Form',
 				expect.anything()
 			);
 		} );

--- a/projects/packages/forms/tests/js/contact-form/use-create-synced-form-on-insertion.test.js
+++ b/projects/packages/forms/tests/js/contact-form/use-create-synced-form-on-insertion.test.js
@@ -101,10 +101,12 @@ await jest.unstable_mockModule( '../../../src/blocks/contact-form/variations.js'
 		{
 			name: 'contact-form',
 			title: 'Contact Form',
+			attributes: { variationName: 'default' },
 		},
 		{
 			name: 'rsvp-form',
 			title: 'RSVP Form',
+			attributes: { variationName: 'rsvp-form' },
 		},
 	],
 } ) );
@@ -123,7 +125,7 @@ describe( 'useCreateSyncedFormOnInsertion', () => {
 			{ name: 'jetpack/field-textarea', innerBlocks: [] },
 			{ name: 'core/button', innerBlocks: [] },
 		],
-		attributes: { variationName: 'contact-form' },
+		attributes: { variationName: 'default' },
 		setAttributes: mockSetAttributes,
 	};
 
@@ -251,6 +253,19 @@ describe( 'useCreateSyncedFormOnInsertion', () => {
 		consoleSpy.mockRestore();
 	} );
 
+	it( 'still sets ref when entity preload fails', async () => {
+		mockGetEntityRecord.mockRejectedValue( new Error( 'Network error' ) );
+
+		renderHook( () => useCreateSyncedFormOnInsertion( defaultProps ) );
+
+		await waitFor( () => {
+			expect( mockSetAttributes ).toHaveBeenCalledWith( { ref: 42 } );
+		} );
+
+		expect( mockCreateSuccessNotice ).toHaveBeenCalled();
+		expect( mockCreateErrorNotice ).not.toHaveBeenCalled();
+	} );
+
 	it( 'does not create synced form when block was not just inserted', async () => {
 		mockWasBlockJustInserted = false;
 
@@ -278,11 +293,24 @@ describe( 'useCreateSyncedFormOnInsertion', () => {
 		} );
 	} );
 
-	it( 'falls back to generic Form title when no variationName', async () => {
+	it( 'does not create synced form when no variationName', async () => {
 		renderHook( () =>
 			useCreateSyncedFormOnInsertion( {
 				...defaultProps,
 				attributes: {},
+			} )
+		);
+
+		await act( () => Promise.resolve() );
+
+		expect( mockCreateSyncedForm ).not.toHaveBeenCalled();
+	} );
+
+	it( 'falls back to generic Form title when variationName does not match a variation', async () => {
+		renderHook( () =>
+			useCreateSyncedFormOnInsertion( {
+				...defaultProps,
+				attributes: { variationName: 'unknown-variation' },
 			} )
 		);
 

--- a/projects/packages/forms/tests/js/contact-form/use-create-synced-form-on-insertion.test.js
+++ b/projects/packages/forms/tests/js/contact-form/use-create-synced-form-on-insertion.test.js
@@ -51,8 +51,6 @@ await jest.unstable_mockModule( '@wordpress/core-data', () => ( {
 
 await jest.unstable_mockModule( '@wordpress/data', () => ( {
 	useSelect: selector => {
-		// The selector function expects to receive a `select` function
-		// that takes a store name and returns selectors for that store
 		const select = store => {
 			if ( store === 'core/editor' ) {
 				return {
@@ -103,32 +101,10 @@ await jest.unstable_mockModule( '../../../src/blocks/contact-form/variations.js'
 		{
 			name: 'contact-form',
 			title: 'Contact Form',
-			attributes: { variationName: 'default' },
-		},
-		{
-			name: 'feedback-form',
-			title: 'Feedback Form',
-			attributes: {},
-		},
-		{
-			name: 'appointment-form',
-			title: 'Appointment Form',
-			attributes: {},
 		},
 		{
 			name: 'rsvp-form',
 			title: 'RSVP Form',
-			attributes: {},
-		},
-		{
-			name: 'registration-form',
-			title: 'Registration Form',
-			attributes: {},
-		},
-		{
-			name: 'lead-capture-form',
-			title: 'Lead capture',
-			attributes: {},
 		},
 	],
 } ) );
@@ -147,7 +123,7 @@ describe( 'useCreateSyncedFormOnInsertion', () => {
 			{ name: 'jetpack/field-textarea', innerBlocks: [] },
 			{ name: 'core/button', innerBlocks: [] },
 		],
-		attributes: { variationName: 'default' },
+		attributes: { variationName: 'contact-form' },
 		setAttributes: mockSetAttributes,
 	};
 
@@ -207,7 +183,6 @@ describe( 'useCreateSyncedFormOnInsertion', () => {
 
 		renderHook( () => useCreateSyncedFormOnInsertion( propsWithRef ) );
 
-		// Flush microtasks to ensure no async calls fire
 		await act( () => Promise.resolve() );
 
 		expect( mockCreateSyncedForm ).not.toHaveBeenCalled();
@@ -218,7 +193,6 @@ describe( 'useCreateSyncedFormOnInsertion', () => {
 
 		renderHook( () => useCreateSyncedFormOnInsertion( propsWithoutInnerBlocks ) );
 
-		// Flush microtasks to ensure no async calls fire
 		await act( () => Promise.resolve() );
 
 		expect( mockCreateSyncedForm ).not.toHaveBeenCalled();
@@ -229,7 +203,6 @@ describe( 'useCreateSyncedFormOnInsertion', () => {
 
 		renderHook( () => useCreateSyncedFormOnInsertion( defaultProps ) );
 
-		// Flush microtasks to ensure no async calls fire
 		await act( () => Promise.resolve() );
 
 		expect( mockCreateSyncedForm ).not.toHaveBeenCalled();
@@ -240,7 +213,6 @@ describe( 'useCreateSyncedFormOnInsertion', () => {
 
 		renderHook( () => useCreateSyncedFormOnInsertion( defaultProps ) );
 
-		// Flush microtasks to ensure no async calls fire
 		await act( () => Promise.resolve() );
 
 		expect( mockCreateSyncedForm ).not.toHaveBeenCalled();
@@ -255,10 +227,8 @@ describe( 'useCreateSyncedFormOnInsertion', () => {
 			expect( mockCreateSyncedForm ).toHaveBeenCalledTimes( 1 );
 		} );
 
-		// Rerender with same props
 		rerender( defaultProps );
 
-		// Flush microtasks to ensure it wasn't called again
 		await act( () => Promise.resolve() );
 
 		expect( mockCreateSyncedForm ).toHaveBeenCalledTimes( 1 );
@@ -267,7 +237,6 @@ describe( 'useCreateSyncedFormOnInsertion', () => {
 	it( 'shows error notice when synced form creation fails', async () => {
 		mockCreateSyncedForm.mockRejectedValue( new Error( 'Failed to create' ) );
 
-		// Suppress the console.error from the rejected promise
 		const consoleSpy = jest.spyOn( console, 'error' ).mockImplementation( () => {} );
 
 		renderHook( () => useCreateSyncedFormOnInsertion( defaultProps ) );
@@ -287,36 +256,35 @@ describe( 'useCreateSyncedFormOnInsertion', () => {
 
 		renderHook( () => useCreateSyncedFormOnInsertion( defaultProps ) );
 
-		// Flush microtasks to ensure no async calls fire
 		await act( () => Promise.resolve() );
 
 		expect( mockCreateSyncedForm ).not.toHaveBeenCalled();
 	} );
 
-	it( 'uses variationName attribute to get form title', async () => {
-		const propsWithVariationName = {
-			...defaultProps,
-			attributes: { variationName: 'default' },
-		};
-
-		renderHook( () => useCreateSyncedFormOnInsertion( propsWithVariationName ) );
+	it( 'uses variation name to get form title', async () => {
+		renderHook( () =>
+			useCreateSyncedFormOnInsertion( {
+				...defaultProps,
+				attributes: { variationName: 'rsvp-form' },
+			} )
+		);
 
 		await waitFor( () => {
 			expect( mockCreateSyncedForm ).toHaveBeenCalledWith(
 				expect.anything(),
-				'Contact Form',
+				'RSVP Form',
 				expect.anything()
 			);
 		} );
 	} );
 
 	it( 'falls back to generic Form title when no variationName', async () => {
-		const propsWithoutVariationName = {
-			...defaultProps,
-			attributes: {},
-		};
-
-		renderHook( () => useCreateSyncedFormOnInsertion( propsWithoutVariationName ) );
+		renderHook( () =>
+			useCreateSyncedFormOnInsertion( {
+				...defaultProps,
+				attributes: {},
+			} )
+		);
 
 		await waitFor( () => {
 			expect( mockCreateSyncedForm ).toHaveBeenCalledWith(

--- a/projects/packages/forms/tests/js/contact-form/use-create-synced-form-on-insertion.test.js
+++ b/projects/packages/forms/tests/js/contact-form/use-create-synced-form-on-insertion.test.js
@@ -3,14 +3,14 @@
  */
 
 import { afterAll, beforeEach, describe, expect, it, jest } from '@jest/globals';
-import { renderHook, waitFor } from '@testing-library/react';
+import { renderHook, act, waitFor } from '@testing-library/react';
 
 // Mock dependencies
 const mockCreateSyncedForm = jest.fn();
 const mockCreateSuccessNotice = jest.fn();
 const mockCreateErrorNotice = jest.fn();
 const mockSetAttributes = jest.fn();
-const mockBatch = jest.fn( callback => callback() );
+const mockGetEntityRecord = jest.fn().mockResolvedValue( {} );
 let mockHasFeatureFlag = true;
 let mockCurrentPostType = 'post';
 let mockCurrentPostId = 123;
@@ -45,6 +45,10 @@ await jest.unstable_mockModule( '@wordpress/notices', () => ( {
 	store: 'core/notices',
 } ) );
 
+await jest.unstable_mockModule( '@wordpress/core-data', () => ( {
+	store: 'core',
+} ) );
+
 await jest.unstable_mockModule( '@wordpress/data', () => ( {
 	useSelect: selector => {
 		// The selector function expects to receive a `select` function
@@ -74,8 +78,8 @@ await jest.unstable_mockModule( '@wordpress/data', () => ( {
 		}
 		return {};
 	},
-	useRegistry: () => ( {
-		batch: mockBatch,
+	resolveSelect: () => ( {
+		getEntityRecord: mockGetEntityRecord,
 	} ),
 } ) );
 
@@ -154,6 +158,7 @@ describe( 'useCreateSyncedFormOnInsertion', () => {
 		mockCurrentPostId = 123;
 		mockWasBlockJustInserted = true;
 		mockCreateSyncedForm.mockResolvedValue( 42 );
+		mockGetEntityRecord.mockResolvedValue( {} );
 	} );
 
 	afterAll( () => {
@@ -202,8 +207,8 @@ describe( 'useCreateSyncedFormOnInsertion', () => {
 
 		renderHook( () => useCreateSyncedFormOnInsertion( propsWithRef ) );
 
-		// Wait a bit to ensure no async calls
-		await new Promise( resolve => setTimeout( resolve, 100 ) );
+		// Flush microtasks to ensure no async calls fire
+		await act( () => Promise.resolve() );
 
 		expect( mockCreateSyncedForm ).not.toHaveBeenCalled();
 	} );
@@ -213,8 +218,8 @@ describe( 'useCreateSyncedFormOnInsertion', () => {
 
 		renderHook( () => useCreateSyncedFormOnInsertion( propsWithoutInnerBlocks ) );
 
-		// Wait a bit to ensure no async calls
-		await new Promise( resolve => setTimeout( resolve, 100 ) );
+		// Flush microtasks to ensure no async calls fire
+		await act( () => Promise.resolve() );
 
 		expect( mockCreateSyncedForm ).not.toHaveBeenCalled();
 	} );
@@ -224,8 +229,8 @@ describe( 'useCreateSyncedFormOnInsertion', () => {
 
 		renderHook( () => useCreateSyncedFormOnInsertion( defaultProps ) );
 
-		// Wait a bit to ensure no async calls
-		await new Promise( resolve => setTimeout( resolve, 100 ) );
+		// Flush microtasks to ensure no async calls fire
+		await act( () => Promise.resolve() );
 
 		expect( mockCreateSyncedForm ).not.toHaveBeenCalled();
 	} );
@@ -235,8 +240,8 @@ describe( 'useCreateSyncedFormOnInsertion', () => {
 
 		renderHook( () => useCreateSyncedFormOnInsertion( defaultProps ) );
 
-		// Wait a bit to ensure no async calls
-		await new Promise( resolve => setTimeout( resolve, 100 ) );
+		// Flush microtasks to ensure no async calls fire
+		await act( () => Promise.resolve() );
 
 		expect( mockCreateSyncedForm ).not.toHaveBeenCalled();
 	} );
@@ -253,8 +258,8 @@ describe( 'useCreateSyncedFormOnInsertion', () => {
 		// Rerender with same props
 		rerender( defaultProps );
 
-		// Wait a bit and verify it wasn't called again
-		await new Promise( resolve => setTimeout( resolve, 100 ) );
+		// Flush microtasks to ensure it wasn't called again
+		await act( () => Promise.resolve() );
 
 		expect( mockCreateSyncedForm ).toHaveBeenCalledTimes( 1 );
 	} );
@@ -282,8 +287,8 @@ describe( 'useCreateSyncedFormOnInsertion', () => {
 
 		renderHook( () => useCreateSyncedFormOnInsertion( defaultProps ) );
 
-		// Wait a bit to ensure no async calls
-		await new Promise( resolve => setTimeout( resolve, 100 ) );
+		// Flush microtasks to ensure no async calls fire
+		await act( () => Promise.resolve() );
 
 		expect( mockCreateSyncedForm ).not.toHaveBeenCalled();
 	} );


### PR DESCRIPTION
## Proposed changes:
* When users insert a form variation directly from the block inserter (e.g., "Contact Form"), WordPress creates the block with innerBlocks immediately, bypassing the VariationPicker. This meant synced forms were not being created.
* This PR adds a new hook `useCreateSyncedFormOnInsertion` that detects when a form block is inserted with inner blocks but without a `ref` attribute, and automatically creates a synced form when central form management is enabled.
* The hook also intelligently identifies the form variation type based on the inner blocks to name the synced form appropriately.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
N/A

## Does this pull request change what data or activity we track or use?
No changes to data tracking.

## Testing instructions:

1. Ensure the `central-form-management` feature flag is enabled
2. Go to any post or page (not a jetpack_form post type)
3. Open the block inserter and search for "Contact Form" (or any other form variation like "RSVP Form", "Feedback Form", etc.)
4. Insert the form variation directly from the inserter
5. **Expected:** A synced form should be created automatically (you should see a "New form created" snackbar notice)
6. **Expected:** The form block should have a `ref` attribute linking to the newly created `jetpack_form` post
7. Save the post and verify the form is synced (editing the form should update the underlying synced form)

### Additional test cases:
- When editing a `jetpack_form` post directly, inserting a variation should NOT create a synced form (it should work as inline form)
- When `central-form-management` feature flag is disabled, inserting a variation should NOT create a synced form
- If synced form creation fails, an error notice should appear and the form should remain as an inline form

## Changelog
- [x] Generate changelog entries for this PR (using AI).