### PR TITLE
Forms: Use block type title for synced form naming

### DIFF
--- a/projects/packages/forms/changelog/fix-form-name-input-field
+++ b/projects/packages/forms/changelog/fix-form-name-input-field
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Use block type title instead of post title for synced form naming

--- a/projects/packages/forms/src/blocks/shared/hooks/use-form-wrapper.js
+++ b/projects/packages/forms/src/blocks/shared/hooks/use-form-wrapper.js
@@ -89,6 +89,19 @@ export function shouldWrapFieldInForm( currentPostType, parentForms ) {
 }
 
 /**
+ * Derives a form title from a block type name.
+ * Returns the block type's registered title (e.g. "Name field"),
+ * or a fallback "Untitled" string when the block type is not registered.
+ *
+ * @param {string} blockName - The registered block name (e.g. "jetpack-forms/name").
+ * @return {string} The derived form title.
+ */
+export function getFormTitleFromBlockType( blockName ) {
+	const blockType = getBlockType( blockName );
+	return blockType?.title || __( 'Untitled', 'jetpack-forms' );
+}
+
+/**
  *
  * Custom hook to wrap a field block in a form block when conditions are met.
  *
@@ -136,8 +149,7 @@ export default function useFormWrapper( { attributes, clientId, name } ) {
 		hasAttemptedWrap.current = true;
 
 		// Use block type title (e.g., "Name field") for the form title
-		const blockType = getBlockType( name );
-		const formTitle = blockType?.title || __( 'Untitled', 'jetpack-forms' );
+		const formTitle = getFormTitleFromBlockType( name );
 
 		const innerBlocks = getBlocks( clientId );
 

--- a/projects/packages/forms/src/blocks/shared/hooks/use-form-wrapper.js
+++ b/projects/packages/forms/src/blocks/shared/hooks/use-form-wrapper.js
@@ -1,5 +1,5 @@
 import { store as blockEditorStore } from '@wordpress/block-editor';
-import { createBlock } from '@wordpress/blocks';
+import { createBlock, getBlockType } from '@wordpress/blocks';
 import { store as coreStore } from '@wordpress/core-data';
 import { resolveSelect, useDispatch, useSelect } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
@@ -38,7 +38,7 @@ export function createFormBlockStructure( fieldBlockName, fieldAttributes, field
  * @param {object}   formBlock                     - The form block to convert.
  * @param {object}   fieldBlock                    - The field block inside the form.
  * @param {object}   submitButton                  - The submit button block.
- * @param {string}   postTitle                     - The title of the current post.
+ * @param {string}   formTitle                     - The title for the new form post.
  * @param {number}   currentPostId                 - The ID of the current post.
  * @param {Function} updateBlockAttributes         - Function to update block attributes.
  * @param {Function} markNextChangeAsNotPersistent - Function to mark changes as not persistent.
@@ -47,7 +47,7 @@ export async function convertFormToSynced(
 	formBlock,
 	fieldBlock,
 	submitButton,
-	postTitle,
+	formTitle,
 	currentPostId,
 	updateBlockAttributes,
 	markNextChangeAsNotPersistent
@@ -57,7 +57,7 @@ export async function convertFormToSynced(
 			attributes: {},
 			innerBlocks: [ fieldBlock, submitButton ],
 		},
-		postTitle,
+		formTitle,
 		currentPostId
 	);
 
@@ -105,22 +105,20 @@ export default function useFormWrapper( { attributes, clientId, name } ) {
 	// Feature flag for central form management
 	const isCentralFormManagementEnabled = useConfigValue( 'isCentralFormManagementEnabled' );
 
-	const { parentForms, postTitle, currentPostId, currentPostType, wasBlockJustInserted } =
-		useSelect(
-			select => {
-				return {
-					parentForms: select( blockEditorStore ).getBlockParentsByBlockName(
-						clientId,
-						FORM_BLOCK_NAME
-					),
-					postTitle: select( editorStore ).getEditedPostAttribute( 'title' ) || 'Untitled',
-					currentPostId: select( editorStore ).getEditedPostAttribute( 'id' ),
-					currentPostType: select( editorStore ).getCurrentPostType(),
-					wasBlockJustInserted: select( blockEditorStore ).wasBlockJustInserted( clientId ),
-				};
-			},
-			[ clientId ]
-		);
+	const { parentForms, currentPostId, currentPostType, wasBlockJustInserted } = useSelect(
+		select => {
+			return {
+				parentForms: select( blockEditorStore ).getBlockParentsByBlockName(
+					clientId,
+					FORM_BLOCK_NAME
+				),
+				currentPostId: select( editorStore ).getEditedPostAttribute( 'id' ),
+				currentPostType: select( editorStore ).getCurrentPostType(),
+				wasBlockJustInserted: select( blockEditorStore ).wasBlockJustInserted( clientId ),
+			};
+		},
+		[ clientId ]
+	);
 
 	// Guard against StrictMode double-invocation and re-renders
 	const hasAttemptedWrap = useRef( false );
@@ -137,10 +135,16 @@ export default function useFormWrapper( { attributes, clientId, name } ) {
 
 		hasAttemptedWrap.current = true;
 
+		// Use block type title (e.g., "Name field") for the form title
+		const blockType = getBlockType( name );
+		const formTitle = blockType?.title || __( 'Untitled', 'jetpack-forms' );
+
+		const innerBlocks = getBlocks( clientId );
+
 		const { formBlock, fieldBlock, submitButton } = createFormBlockStructure(
 			name,
 			attributes,
-			getBlocks( clientId )
+			innerBlocks
 		);
 
 		// Replace field with form (immediate visual feedback)
@@ -154,7 +158,7 @@ export default function useFormWrapper( { attributes, clientId, name } ) {
 				formBlock,
 				fieldBlock,
 				submitButton,
-				postTitle,
+				formTitle,
 				currentPostId,
 				updateBlockAttributes,
 				__unstableMarkNextChangeAsNotPersistent

--- a/projects/packages/forms/tests/js/blocks/shared/hooks/get-form-title-from-block-type.test.js
+++ b/projects/packages/forms/tests/js/blocks/shared/hooks/get-form-title-from-block-type.test.js
@@ -1,0 +1,90 @@
+import { describe, expect, jest, test, beforeEach } from '@jest/globals';
+
+const mockGetBlockType = jest.fn();
+
+await jest.unstable_mockModule( '@wordpress/blocks', () => ( {
+	createBlock: jest.fn( ( blockName, attributes, innerBlocks ) => ( {
+		name: blockName,
+		attributes: attributes || {},
+		innerBlocks: innerBlocks || [],
+		clientId: `mock-${ blockName }`,
+	} ) ),
+	getBlockType: mockGetBlockType,
+} ) );
+
+await jest.unstable_mockModule( '@wordpress/i18n', () => ( {
+	__: jest.fn( str => str ),
+} ) );
+
+await jest.unstable_mockModule( '@wordpress/core-data', () => ( {
+	store: 'core',
+} ) );
+
+await jest.unstable_mockModule( '@wordpress/block-editor', () => ( {
+	store: 'core/block-editor',
+} ) );
+
+await jest.unstable_mockModule( '@wordpress/data', () => ( {
+	resolveSelect: jest.fn(),
+	useDispatch: jest.fn( () => ( {} ) ),
+	useSelect: jest.fn( () => ( {} ) ),
+} ) );
+
+await jest.unstable_mockModule( '@wordpress/editor', () => ( {
+	store: 'core/editor',
+} ) );
+
+await jest.unstable_mockModule( '@wordpress/element', () => ( {
+	useEffect: jest.fn(),
+	useRef: jest.fn( () => ( { current: false } ) ),
+} ) );
+
+await jest.unstable_mockModule( '../../../../../src/hooks/use-config-value.ts', () => ( {
+	default: jest.fn(),
+} ) );
+
+await jest.unstable_mockModule(
+	'../../../../../src/blocks/contact-form/util/create-synced-form.ts',
+	() => ( {
+		createSyncedForm: jest.fn(),
+	} )
+);
+
+const { getFormTitleFromBlockType } = await import(
+	'../../../../../src/blocks/shared/hooks/use-form-wrapper.js'
+);
+
+describe( 'getFormTitleFromBlockType', () => {
+	beforeEach( () => {
+		mockGetBlockType.mockReset();
+	} );
+
+	test( 'returns the block type title when the block type is registered', () => {
+		mockGetBlockType.mockReturnValue( { title: 'Name field' } );
+		expect( getFormTitleFromBlockType( 'jetpack-forms/name' ) ).toBe( 'Name field' );
+		expect( mockGetBlockType ).toHaveBeenCalledWith( 'jetpack-forms/name' );
+	} );
+
+	test( 'returns "Untitled" when the block type is not registered', () => {
+		mockGetBlockType.mockReturnValue( undefined );
+		expect( getFormTitleFromBlockType( 'jetpack-forms/unknown' ) ).toBe( 'Untitled' );
+	} );
+
+	test( 'returns "Untitled" when getBlockType returns null', () => {
+		mockGetBlockType.mockReturnValue( null );
+		expect( getFormTitleFromBlockType( 'jetpack-forms/name' ) ).toBe( 'Untitled' );
+	} );
+
+	test( 'returns "Untitled" when block type has no title property', () => {
+		mockGetBlockType.mockReturnValue( { name: 'jetpack-forms/name' } );
+		expect( getFormTitleFromBlockType( 'jetpack-forms/name' ) ).toBe( 'Untitled' );
+	} );
+
+	test( 'returns the correct title for different block types', () => {
+		mockGetBlockType.mockReturnValue( { title: 'Email field' } );
+		expect( getFormTitleFromBlockType( 'jetpack-forms/email' ) ).toBe( 'Email field' );
+
+		mockGetBlockType.mockReturnValue( { title: 'Phone Number' } );
+		expect( getFormTitleFromBlockType( 'jetpack-forms/phone' ) ).toBe( 'Phone Number' );
+	} );
+} );


### PR DESCRIPTION


https://github.com/user-attachments/assets/45bacc3f-4fdd-436c-aa8d-20f91b62233f


## Proposed changes:
* When a field block is wrapped in a form and converted to a synced form, the form title now uses the block type title (e.g., "Name field") instead of the current post title
* This provides more descriptive and meaningful form names that reflect what type of field the form contains

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?

No


## Testing instructions:

1. Enable the Central Form Management feature flag 
```
add_filter( 'jetpack_block_editor_feature_flags', 'eb_register_feature' );
function eb_register_feature( $flags ) {
    $flags['central-form-management'] = ! isset( $_GET[  'not-cfm' ] );
    return $flags;
}
```
3. Create a new post or page
4. Insert a Name field block (or any other form field block) directly into the content (not inside an existing form)
5. Observe that the field is automatically wrapped in a form and converted to a synced form
6. Check the form title - it should now be "Name field" (or the appropriate block type title) instead of the post title
7. Verify this works for other field types as well (e.g., "Email field", "Checkbox field")

## Changelog

- [x] Changelog entry already added via changelogger

🤖 Generated with [Claude Code](https://claude.com/claude-code)