### PR TITLE
My Jetpack: Migrate admin page header to unified admin-ui Page layout

### DIFF
--- a/projects/js-packages/components/changelog/pr-47345
+++ b/projects/js-packages/components/changelog/pr-47345
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+AdminPage: Remove admin-ui header border via scoped CSS to support unified admin-ui Page layout.

--- a/projects/js-packages/components/components/admin-page/style.module.scss
+++ b/projects/js-packages/components/components/admin-page/style.module.scss
@@ -9,6 +9,13 @@
 		background-color: var(--jp-white);
 	}
 
+	// Remove the admin-ui header border. Scoped to .admin-page so this only
+	// applies within our component. Ideally admin-ui would expose a prop or
+	// CSS custom property for this — revisit if the upstream API changes.
+	:global(.admin-ui-page__header) {
+		border-bottom: none;
+	}
+
 	.admin-page-header {
 		display: flex;
 		align-items: center;

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/index.jsx
@@ -180,6 +180,7 @@ export default function MyJetpackScreen() {
 			sandboxedDomain={ sandboxedDomain }
 			apiRoot={ apiRoot }
 			apiNonce={ apiNonce }
+			title={ __( 'Jetpack', 'jetpack-my-jetpack' ) }
 			optionalMenuItems={ isDevVersion && userIsAdmin ? [ resetOptionsMenuItem ] : [] }
 			useInternalLinks={ shouldUseInternalLinks() }
 			className={ styles[ 'my-jetpack-screen' ] }

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/styles.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/styles.module.scss
@@ -15,7 +15,7 @@
 	:global(.components-tab-panel__tabs) {
 		position: relative;
 		z-index: 1;
-		padding-inline-start: 2rem;
+		padding-inline-start: 24px;
 		margin-block-end: -1px;
 
 		@media (max-width: gb.$break-medium ) {
@@ -65,8 +65,7 @@
 	margin: 0;
 
 	:global(.components-tab-panel__tabs) {
-
-		@include full-width-container;
+		padding-inline-start: 24px;
 	}
 
 	:global(.components-tab-panel__tab-content) {

--- a/projects/packages/my-jetpack/changelog/update-my-jetpack-unified-header-v2
+++ b/projects/packages/my-jetpack/changelog/update-my-jetpack-unified-header-v2
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Migrate admin page header to use unified AdminHeader component.


### PR DESCRIPTION
Part of the JETPACK-1352 project.

## Proposed changes:
* Add `title` prop to the `AdminPage` component in My Jetpack screen, which triggers the new admin-ui `Page` layout path with the standardized Jetpack bolt icon + "Jetpack" text header.
* Remove the admin-ui header border within AdminPage's scoped CSS.
* Left-align the tab panel with the header (24px padding instead of centered container).

### Before / After

| Before | After |
|--------|-------|
|<img width="1726" height="956" alt="Screenshot 2026-02-27 at 17 44 59" src="https://github.com/user-attachments/assets/1a09c558-73b8-44c3-91ca-68a71d850f59" /> | <img width="1718" height="958" alt="Screenshot 2026-02-27 at 18 07 39" src="https://github.com/user-attachments/assets/67ee0da3-a115-4c47-8012-c4702628319e" />|


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:

1. Build My Jetpack: `jetpack build packages/my-jetpack --deps`
2. Navigate to My Jetpack (`wp-admin/admin.php?page=my-jetpack`)
3. Verify the header shows the Jetpack bolt icon and "Jetpack" title
4. Verify there is no horizontal line below the header
5. Verify the Overview/Products/Help tabs are left-aligned with the header text
6. Verify the page content and footer render correctly below the header

## Changelog

- [x] Generate changelog entries for this PR (using AI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)