### PR TITLE
ActivityPub: sync extra data on plugin activation

### DIFF
--- a/projects/packages/sync/changelog/add-activitypub-sync-trigger-activation
+++ b/projects/packages/sync/changelog/add-activitypub-sync-trigger-activation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Documentation: Update variable type in docblock to match reality.

--- a/projects/packages/sync/src/class-server.php
+++ b/projects/packages/sync/src/class-server.php
@@ -139,7 +139,7 @@ class Server {
 			 * @since 1.6.3
 			 * @since-jetpack 4.2.0
 			 *
-			 * @param token The token object of the misbehaving site
+			 * @param object|null $token The token object of the misbehaving site
 			 */
 			do_action( 'jetpack_sync_multi_request_fail', $token );
 
@@ -155,7 +155,8 @@ class Server {
 		 * @since 1.6.3
 		 * @since-jetpack 4.2.0
 		 *
-		 * @param array Array of actions received from the remote site
+		 * @param array       $events Array of actions received from the remote site
+		 * @param object|null $token  The auth token used to invoke the API
 		 */
 		do_action( 'jetpack_sync_remote_actions', $events, $token );
 
@@ -168,14 +169,14 @@ class Server {
 			 * @since 1.6.3
 			 * @since-jetpack 4.2.0
 			 *
-			 * @param string $action_name The name of the action executed on the remote site
-			 * @param array $args The arguments passed to the action
-			 * @param int $user_id The external_user_id who did the action
-			 * @param bool $silent Whether the item was created via import
-			 * @param double $timestamp Timestamp (in seconds) when the action occurred
-			 * @param double $sent_timestamp Timestamp (in seconds) when the action was transmitted
-			 * @param string $queue_id ID of the queue from which the event was sent (sync or full_sync)
-			 * @param array $token The auth token used to invoke the API
+			 * @param string      $action_name    The name of the action executed on the remote site
+			 * @param array       $args           The arguments passed to the action
+			 * @param int         $user_id        The external_user_id who did the action
+			 * @param bool        $silent         Whether the item was created via import
+			 * @param double      $timestamp      Timestamp (in seconds) when the action occurred
+			 * @param double      $sent_timestamp Timestamp (in seconds) when the action was transmitted
+			 * @param string      $queue_id       ID of the queue from which the event was sent (sync or full_sync)
+			 * @param object|null $token          The auth token used to invoke the API
 			 */
 			do_action( 'jetpack_sync_remote_action', $action_name, $args, $user_id, $silent, $timestamp, $sent_timestamp, $queue_id, $token );
 

--- a/projects/plugins/wpcomsh/.phan/baseline.php
+++ b/projects/plugins/wpcomsh/.phan/baseline.php
@@ -17,7 +17,7 @@ return [
     // PhanTypeVoidAssignment : 5 occurrences
     // PhanUndeclaredConstant : 5 occurrences
     // PhanTypeArraySuspiciousNullable : 3 occurrences
-    // PhanUndeclaredClassMethod : 3 occurrences
+    // PhanUndeclaredClassMethod : 6 occurrences
     // PhanContextNotObject : 1 occurrence
     // PhanDeprecatedFunction : 1 occurrence
     // PhanDeprecatedProperty : 1 occurrence
@@ -41,6 +41,7 @@ return [
         'functions.php' => ['PhanUndeclaredClassStaticProperty'],
         'imports/playground/class-sql-importer.php' => ['PhanUndeclaredConstant'],
         'safeguard/utils.php' => ['PhanTypeMismatchArgument'],
+        'tests/ActivityPubTest.php' => ['PhanUndeclaredClassMethod'],
         'tests/AnyoneCanRegisterNoticeTest.php' => ['PhanTypeMismatchArgument', 'PhanTypeVoidArgument', 'PhanTypeVoidAssignment'],
         'tests/FrontendNoticesTest.php' => ['PhanUndeclaredStaticMethod'],
         'tests/PlanNoticesTest.php' => ['PhanDeprecatedProperty', 'PhanPluginUseReturnValueInternalKnown', 'PhanUndeclaredStaticMethod'],

--- a/projects/plugins/wpcomsh/changelog/add-activitypub-sync-trigger-activation
+++ b/projects/plugins/wpcomsh/changelog/add-activitypub-sync-trigger-activation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+ActivityPub: add new feature plugin, handling a custom sync event triggered when the plugin is activated.

--- a/projects/plugins/wpcomsh/feature-plugins/activitypub.php
+++ b/projects/plugins/wpcomsh/feature-plugins/activitypub.php
@@ -5,6 +5,8 @@
  * @package wpcomsh
  */
 
+use Automattic\Jetpack\Connection\Manager;
+
 /**
  * Pass extra data to WordPress.com when the ActivityPub plugin is activated.
  *
@@ -13,7 +15,7 @@
  * already expanded the original positional args into the three-element array below.
  *
  * When the activated plugin is ActivityPub, this function appends a fourth element
- * containing the blog-level actor URI so it can be synced to WordPress.com.
+ * containing the Jetpack connection owner's ActivityPub actor URI so it can be synced to WordPress.com.
  *
  * @param array|false $args {
  *     Positional activated_plugin hook arguments. False if a previous filter aborted.
@@ -22,7 +24,7 @@
  *     @type bool   $1 Whether the plugin was network-activated. Default false.
  *     @type array  $2 Plugin header data added by `expand_plugin_data()` (keys: 'name', 'version').
  *     @type array  $3 Optional. Added by this function when the plugin is ActivityPub.
- *                     Contains 'actor' — the blog-level ActivityPub actor URI.
+ *                     Contains 'actor' — the Jetpack connection owner's ActivityPub actor URI.
  * }
  *
  * @return array|false The (possibly augmented) args, or false if a previous filter aborted.
@@ -41,10 +43,15 @@ function wpcomsh_activitypub_sync_plugin_activation( $args ) {
 		return $args;
 	}
 
+	$connection_owner_id = ( new Manager() )->get_connection_owner_id();
+	if ( ! $connection_owner_id ) {
+		return $args;
+	}
+
 	// @phan-suppress-next-line PhanUndeclaredClassMethod We're checking the class exists above, and that class exists in the ActivityPub plugin.
-	$blog_actor = Activitypub\Collection\Actors::get_by_id( 0 );
-	if ( ! is_wp_error( $blog_actor ) ) {
-		$args[] = array( 'actor' => $blog_actor->get_id() );
+	$actor = Activitypub\Collection\Actors::get_by_id( $connection_owner_id );
+	if ( ! is_wp_error( $actor ) ) {
+		$args[] = array( 'actor' => $actor->get_id() );
 	}
 
 	return $args;

--- a/projects/plugins/wpcomsh/feature-plugins/activitypub.php
+++ b/projects/plugins/wpcomsh/feature-plugins/activitypub.php
@@ -8,13 +8,24 @@
 /**
  * Pass extra data to WordPress.com when the ActivityPub plugin is activated.
  *
+ * Hooked at priority 20 on the `jetpack_sync_before_enqueue_activated_plugin` filter,
+ * which means the Sync Plugins module's `expand_plugin_data()` (priority 10) has
+ * already expanded the original positional args into the three-element array below.
+ *
+ * When the activated plugin is ActivityPub, this function appends a fourth element
+ * containing the blog-level actor URI so it can be synced to WordPress.com.
+ *
  * @param array|false $args {
- *  activated_plugin hook arguments. Can be false if a previous filter aborted.
- *   @type string $plugin       Path to the plugin file relative to the plugins directory.
- *   @type bool   $network_wide Whether to enable the plugin for all sites in the network or just the current site. Multisite only. Default false.
+ *     Positional activated_plugin hook arguments. False if a previous filter aborted.
+ *
+ *     @type string $0 Plugin path relative to the plugins directory (e.g. 'activitypub/activitypub.php').
+ *     @type bool   $1 Whether the plugin was network-activated. Default false.
+ *     @type array  $2 Plugin header data added by `expand_plugin_data()` (keys: 'name', 'version').
+ *     @type array  $3 Optional. Added by this function when the plugin is ActivityPub.
+ *                     Contains 'actor' — the blog-level ActivityPub actor URI.
  * }
  *
- * @return array|false $args The hook arguments, or false if a previous filter aborted.
+ * @return array|false The (possibly augmented) args, or false if a previous filter aborted.
  */
 function wpcomsh_activitypub_sync_plugin_activation( $args ) {
 	if ( ! is_array( $args ) || ! isset( $args[0] ) ) {

--- a/projects/plugins/wpcomsh/feature-plugins/activitypub.php
+++ b/projects/plugins/wpcomsh/feature-plugins/activitypub.php
@@ -8,15 +8,19 @@
 /**
  * Pass extra data to WordPress.com when the ActivityPub plugin is activated.
  *
- * @param array $args {
- *  activated_plugin hook arguments.
+ * @param array|false $args {
+ *  activated_plugin hook arguments. Can be false if a previous filter aborted.
  *   @type string $plugin       Path to the plugin file relative to the plugins directory.
  *   @type bool   $network_wide Whether to enable the plugin for all sites in the network or just the current site. Multisite only. Default false.
  * }
  *
- * @return array $args The hook arguments.
+ * @return array|false $args The hook arguments, or false if a previous filter aborted.
  */
 function wpcomsh_activitypub_sync_plugin_activation( $args ) {
+	if ( ! is_array( $args ) || ! isset( $args[0] ) ) {
+		return $args;
+	}
+
 	$plugin_name = 'activitypub/activitypub.php';
 	if ( $plugin_name !== $args[0] ) {
 		return $args;

--- a/projects/plugins/wpcomsh/feature-plugins/activitypub.php
+++ b/projects/plugins/wpcomsh/feature-plugins/activitypub.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * ActivityPub plugin compatibility file.
+ *
+ * @package wpcomsh
+ */
+
+/**
+ * Pass extra data to WordPress.com when the ActivityPub plugin is activated.
+ *
+ * @param array $args {
+ *  activated_plugin hook arguments.
+ *   @type string $plugin       Path to the plugin file relative to the plugins directory.
+ *   @type bool   $network_wide Whether to enable the plugin for all sites in the network or just the current site. Multisite only. Default false.
+ * }
+ *
+ * @return array $args The hook arguments.
+ */
+function wpcomsh_activitypub_sync_plugin_activation( $args ) {
+	$plugin_name = 'activitypub/activitypub.php';
+	if ( $plugin_name !== $args[0] ) {
+		return $args;
+	}
+
+	if ( ! class_exists( 'Activitypub\Collection\Actors' ) ) {
+		return $args;
+	}
+
+	$blog_actor = Activitypub\Collection\Actors::get_by_id( 0 );
+	if ( ! is_wp_error( $blog_actor ) ) {
+		$args[] = array( 'actor' => $blog_actor->get_id() );
+	}
+
+	return $args;
+}
+add_filter( 'jetpack_sync_before_enqueue_activated_plugin', 'wpcomsh_activitypub_sync_plugin_activation', 20, 1 );

--- a/projects/plugins/wpcomsh/feature-plugins/activitypub.php
+++ b/projects/plugins/wpcomsh/feature-plugins/activitypub.php
@@ -26,6 +26,7 @@ function wpcomsh_activitypub_sync_plugin_activation( $args ) {
 		return $args;
 	}
 
+	// @phan-suppress-next-line PhanUndeclaredClassMethod We're checking the class exists above, and that class exists in the ActivityPub plugin.
 	$blog_actor = Activitypub\Collection\Actors::get_by_id( 0 );
 	if ( ! is_wp_error( $blog_actor ) ) {
 		$args[] = array( 'actor' => $blog_actor->get_id() );

--- a/projects/plugins/wpcomsh/tests/ActivityPubTest.php
+++ b/projects/plugins/wpcomsh/tests/ActivityPubTest.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * ActivityPub Test file.
+ *
+ * @package wpcomsh
+ */
+
+/**
+ * Class ActivityPubTest.
+ */
+class ActivityPubTest extends WP_UnitTestCase {
+	use \Automattic\Jetpack\PHPUnit\WP_UnitTestCase_Fix;
+
+	/**
+	 * Tests that the filter hook is registered.
+	 */
+	public function test_filter_is_registered() {
+		$this->assertSame(
+			20,
+			has_filter( 'jetpack_sync_before_enqueue_activated_plugin', 'wpcomsh_activitypub_sync_plugin_activation' )
+		);
+	}
+
+	/**
+	 * Tests that args are returned unchanged when the plugin is not ActivityPub.
+	 */
+	public function test_returns_args_unchanged_for_other_plugins() {
+		$args   = array( 'some-other-plugin/some-other-plugin.php', false );
+		$result = wpcomsh_activitypub_sync_plugin_activation( $args );
+
+		$this->assertSame( $args, $result );
+	}
+
+	/**
+	 * Tests that actor data is appended when the ActivityPub plugin is activated
+	 * and the actor is found successfully.
+	 */
+	public function test_appends_actor_data_when_actor_is_found() {
+		$actor_id = 'https://example.com/author/test';
+
+		\Activitypub\Collection\Actors::set_mock_return(
+			new \Activitypub\Collection\Actor( $actor_id )
+		);
+
+		$args   = array( 'activitypub/activitypub.php', false );
+		$result = wpcomsh_activitypub_sync_plugin_activation( $args );
+
+		$this->assertCount( 3, $result );
+		$this->assertSame( 'activitypub/activitypub.php', $result[0] );
+		$this->assertFalse( $result[1] );
+		$this->assertSame( array( 'actor' => $actor_id ), $result[2] );
+	}
+
+	/**
+	 * Tests that actor data is not appended when get_by_id returns a WP_Error.
+	 */
+	public function test_does_not_append_actor_data_when_wp_error() {
+		\Activitypub\Collection\Actors::set_mock_return(
+			new \WP_Error( 'actor_not_found', 'Actor not found' )
+		);
+
+		$args   = array( 'activitypub/activitypub.php', false );
+		$result = wpcomsh_activitypub_sync_plugin_activation( $args );
+
+		$this->assertCount( 2, $result );
+		$this->assertSame( $args, $result );
+	}
+}

--- a/projects/plugins/wpcomsh/tests/ActivityPubTest.php
+++ b/projects/plugins/wpcomsh/tests/ActivityPubTest.php
@@ -12,6 +12,30 @@ class ActivityPubTest extends WP_UnitTestCase {
 	use \Automattic\Jetpack\PHPUnit\WP_UnitTestCase_Fix;
 
 	/**
+	 * Set up the mock connection owner ID before each test.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		// Set the memoized connection_owner_id to a valid user ID
+		// so tests reach the Actors::get_by_id() code path.
+		$prop = new \ReflectionProperty( \Automattic\Jetpack\Connection\Manager::class, 'connection_owner_id' );
+		$prop->setAccessible( true );
+		$prop->setValue( null, 1 );
+	}
+
+	/**
+	 * Reset the mock connection owner ID after each test.
+	 */
+	public function tear_down() {
+		$prop = new \ReflectionProperty( \Automattic\Jetpack\Connection\Manager::class, 'connection_owner_id' );
+		$prop->setAccessible( true );
+		$prop->setValue( null, null );
+
+		parent::tear_down();
+	}
+
+	/**
 	 * Tests that the filter hook is registered.
 	 */
 	public function test_filter_is_registered() {
@@ -37,6 +61,21 @@ class ActivityPubTest extends WP_UnitTestCase {
 		$args   = array( 'some-other-plugin/some-other-plugin.php', false );
 		$result = wpcomsh_activitypub_sync_plugin_activation( $args );
 
+		$this->assertSame( $args, $result );
+	}
+
+	/**
+	 * Tests that args are returned unchanged when there is no Jetpack connection owner.
+	 */
+	public function test_returns_args_unchanged_when_no_connection_owner() {
+		$prop = new \ReflectionProperty( \Automattic\Jetpack\Connection\Manager::class, 'connection_owner_id' );
+		$prop->setAccessible( true );
+		$prop->setValue( null, 0 );
+
+		$args   = array( 'activitypub/activitypub.php', false );
+		$result = wpcomsh_activitypub_sync_plugin_activation( $args );
+
+		$this->assertCount( 2, $result );
 		$this->assertSame( $args, $result );
 	}
 

--- a/projects/plugins/wpcomsh/tests/ActivityPubTest.php
+++ b/projects/plugins/wpcomsh/tests/ActivityPubTest.php
@@ -22,6 +22,15 @@ class ActivityPubTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests that false is returned unchanged when a previous filter aborted.
+	 */
+	public function test_returns_false_when_previous_filter_aborted() {
+		$result = wpcomsh_activitypub_sync_plugin_activation( false );
+
+		$this->assertFalse( $result );
+	}
+
+	/**
 	 * Tests that args are returned unchanged when the plugin is not ActivityPub.
 	 */
 	public function test_returns_args_unchanged_for_other_plugins() {

--- a/projects/plugins/wpcomsh/tests/ActivityPubTest.php
+++ b/projects/plugins/wpcomsh/tests/ActivityPubTest.php
@@ -20,7 +20,10 @@ class ActivityPubTest extends WP_UnitTestCase {
 		// Set the memoized connection_owner_id to a valid user ID
 		// so tests reach the Actors::get_by_id() code path.
 		$prop = new \ReflectionProperty( \Automattic\Jetpack\Connection\Manager::class, 'connection_owner_id' );
-		$prop->setAccessible( true );
+		// @todo Remove this call once we no longer need to support PHP <8.1.
+		if ( PHP_VERSION_ID < 80100 ) {
+			$prop->setAccessible( true );
+		}
 		$prop->setValue( null, 1 );
 	}
 
@@ -29,7 +32,10 @@ class ActivityPubTest extends WP_UnitTestCase {
 	 */
 	public function tear_down() {
 		$prop = new \ReflectionProperty( \Automattic\Jetpack\Connection\Manager::class, 'connection_owner_id' );
-		$prop->setAccessible( true );
+		// @todo Remove this call once we no longer need to support PHP <8.1.
+		if ( PHP_VERSION_ID < 80100 ) {
+			$prop->setAccessible( true );
+		}
 		$prop->setValue( null, null );
 
 		parent::tear_down();
@@ -69,7 +75,10 @@ class ActivityPubTest extends WP_UnitTestCase {
 	 */
 	public function test_returns_args_unchanged_when_no_connection_owner() {
 		$prop = new \ReflectionProperty( \Automattic\Jetpack\Connection\Manager::class, 'connection_owner_id' );
-		$prop->setAccessible( true );
+		// @todo Remove this call once we no longer need to support PHP <8.1.
+		if ( PHP_VERSION_ID < 80100 ) {
+			$prop->setAccessible( true );
+		}
 		$prop->setValue( null, 0 );
 
 		$args   = array( 'activitypub/activitypub.php', false );

--- a/projects/plugins/wpcomsh/tests/lib/mocks/mock-activitypub-actors.php
+++ b/projects/plugins/wpcomsh/tests/lib/mocks/mock-activitypub-actors.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * Mock for Activitypub\Collection\Actors.
+ *
+ * @package wpcomsh
+ */
+
+// phpcs:ignoreFile -- Mock file with multiple namespaced classes.
+
+namespace Activitypub\Collection;
+
+if ( ! class_exists( 'Activitypub\Collection\Actors' ) ) {
+	/**
+	 * Mock Actor returned by the Actors collection.
+	 */
+	class Actor {
+		/**
+		 * Actor ID.
+		 *
+		 * @var string
+		 */
+		private $id;
+
+		/**
+		 * Constructor.
+		 *
+		 * @param string $id Actor ID.
+		 */
+		public function __construct( $id ) {
+			$this->id = $id;
+		}
+
+		/**
+		 * Get the actor ID.
+		 *
+		 * @return string
+		 */
+		public function get_id() {
+			return $this->id;
+		}
+	}
+
+	/**
+	 * Mock for the Activitypub Actors collection class.
+	 */
+	class Actors {
+		/**
+		 * The value to return from get_by_id.
+		 *
+		 * @var mixed
+		 */
+		private static $mock_return;
+
+		/**
+		 * Set the mock return value for get_by_id.
+		 *
+		 * @param mixed $value The value to return.
+		 */
+		public static function set_mock_return( $value ) {
+			self::$mock_return = $value;
+		}
+
+		/**
+		 * Mock get_by_id.
+		 *
+		 * @param int $id Actor ID.
+		 * @return mixed
+		 */
+		public static function get_by_id( $id ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+			return self::$mock_return;
+		}
+	}
+}

--- a/projects/plugins/wpcomsh/wpcomsh.php
+++ b/projects/plugins/wpcomsh/wpcomsh.php
@@ -125,6 +125,7 @@ require_once __DIR__ . '/vendor/automattic/text-media-widget-styles/text-media-w
 require_once __DIR__ . '/endpoints/rest-api.php';
 
 // Load feature plugins.
+require_once __DIR__ . '/feature-plugins/activitypub.php';
 require_once __DIR__ . '/feature-plugins/additional-css.php';
 require_once __DIR__ . '/feature-plugins/autosave-revision.php';
 require_once __DIR__ . '/feature-plugins/blaze.php';


### PR DESCRIPTION
Related: CM-562

## Proposed changes:

When the ActivityPub plugin is first activated on a site, let's pass information about the main admin's ActivityPub actor handle back to WordPress.com. We'll use that information to automatically follow that Fediverse handle, so folks have their first follower as they get started.

> [!NOTE]
> This will require changes on WordPress.com to catch that information.
> See 205423-ghe-Automattic/wpcom
> As part of this PR, I also fixed docblocks in the sync package, that were indicating a wrong type for the $token variable, which we'll use for the WordPress.com counterpart of this PR.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* Yes, it means that for WoA sites where folks activate the ActivityPub plugin, we grab the blog actor info and sync it back to WordPress.com.

## Testing instructions:

1. Start with a WoA dev blog
2. Using the Jetpack beta plugin, go to Jetpack > Beta tester > WordPress.com site helper, and switch to this branch
3. Point your dev blog to your WordPress.com sandbox with `define( 'JETPACK__SANDBOX_DOMAIN', 'xxx.wordpress.com' );`
4. Add debug statements to see what data is passed to WordPress.com.
