### PR TITLE
Repo Gardening: Prevent fork PRs from creating new repo labels

### DIFF
--- a/projects/github-actions/repo-gardening/changelog/update-repo-gardening-fork-labels
+++ b/projects/github-actions/repo-gardening/changelog/update-repo-gardening-fork-labels
@@ -1,0 +1,4 @@
+Significance: patch
+Type: security
+
+Prevent fork PRs from creating new labels in the repository; only add labels that already exist.

--- a/projects/github-actions/repo-gardening/src/tasks/add-labels/index.ts
+++ b/projects/github-actions/repo-gardening/src/tasks/add-labels/index.ts
@@ -3,6 +3,7 @@ import { getInput } from '@actions/core';
 import cleanName from '../../utils/clean-name.ts';
 import debug from '../../utils/debug.ts';
 import getFiles from '../../utils/get-files.ts';
+import getAvailableLabels from '../../utils/labels/get-available-labels.ts';
 import getLabels from '../../utils/labels/get-labels.ts';
 import type { OctokitClient, PullRequestEvent } from '../../types.ts';
 
@@ -290,7 +291,7 @@ async function getFileDerivedLabels(
 async function addLabels( payload: PullRequestEvent, octokit: OctokitClient ): Promise< void > {
 	const { number, repository, pull_request } = payload;
 	const { owner, name } = repository;
-	const { draft, title } = pull_request;
+	const { draft, title, head, base } = pull_request;
 
 	// GitHub allows 100 labels on a PR.
 	// Limit to less than that to allow a buffer for future manual labels.
@@ -360,6 +361,16 @@ async function addLabels( payload: PullRequestEvent, octokit: OctokitClient ): P
 	if ( labelsToAdd.length > maxLabelsToAdd ) {
 		debug( `add-labels: Limiting to the first ${ maxLabels }.` );
 		labelsToAdd.splice( maxLabelsToAdd );
+	}
+
+	// For fork PRs, only add labels that already exist in the repo
+	// to avoid creating new labels from untrusted sources.
+	const isFork = head.repo?.full_name !== base.repo?.full_name;
+	if ( isFork ) {
+		debug( 'add-labels: PR is from a fork. Filtering to only existing repo labels.' );
+		const availableLabels = await getAvailableLabels( octokit, owner.login, name );
+		const availableLabelNames = new Set( availableLabels.map( label => label.name ) );
+		labelsToAdd = labelsToAdd.filter( label => availableLabelNames.has( label ) );
 	}
 
 	// Check again, as all the above may have cleared out the labels we were going to add.

--- a/projects/github-actions/repo-gardening/src/tasks/add-labels/index.ts
+++ b/projects/github-actions/repo-gardening/src/tasks/add-labels/index.ts
@@ -326,6 +326,16 @@ async function addLabels( payload: PullRequestEvent, octokit: OctokitClient ): P
 		return;
 	}
 
+	// For fork PRs, only add labels that already exist in the repo
+	// to avoid creating new labels from untrusted sources.
+	const isFork = head.repo?.full_name !== base.repo?.full_name;
+	if ( isFork ) {
+		debug( 'add-labels: PR is from a fork. Filtering to only existing repo labels.' );
+		const availableLabels = await getAvailableLabels( octokit, owner.login, name );
+		const availableLabelNames = new Set( availableLabels.map( label => label.name ) );
+		labelsToAdd = labelsToAdd.filter( label => availableLabelNames.has( label ) );
+	}
+
 	// Determine how many labels can safely be added.
 	let maxLabelsToAdd = Math.max( 0, maxLabels - currentLabels.length );
 
@@ -361,16 +371,6 @@ async function addLabels( payload: PullRequestEvent, octokit: OctokitClient ): P
 	if ( labelsToAdd.length > maxLabelsToAdd ) {
 		debug( `add-labels: Limiting to the first ${ maxLabels }.` );
 		labelsToAdd.splice( maxLabelsToAdd );
-	}
-
-	// For fork PRs, only add labels that already exist in the repo
-	// to avoid creating new labels from untrusted sources.
-	const isFork = head.repo?.full_name !== base.repo?.full_name;
-	if ( isFork ) {
-		debug( 'add-labels: PR is from a fork. Filtering to only existing repo labels.' );
-		const availableLabels = await getAvailableLabels( octokit, owner.login, name );
-		const availableLabelNames = new Set( availableLabels.map( label => label.name ) );
-		labelsToAdd = labelsToAdd.filter( label => availableLabelNames.has( label ) );
 	}
 
 	// Check again, as all the above may have cleared out the labels we were going to add.

--- a/projects/github-actions/repo-gardening/tests/add-labels.test.ts
+++ b/projects/github-actions/repo-gardening/tests/add-labels.test.ts
@@ -1,0 +1,119 @@
+import { jest } from '@jest/globals';
+import type { OctokitClient, PullRequestEvent } from '../src/types.ts';
+
+// Provide a minimal @actions/core mock so getInput() doesn't throw.
+jest.unstable_mockModule( '@actions/core', () => ( {
+	getInput: jest.fn().mockReturnValue( '' ),
+} ) );
+
+// Mock getFiles to return a controllable file list.
+const mockGetFiles = jest.fn< () => Promise< string[] | null > >();
+jest.unstable_mockModule( '../src/utils/get-files.ts', () => ( {
+	default: mockGetFiles,
+} ) );
+
+// Mock getLabels (labels already on the PR).
+const mockGetLabels = jest.fn< () => Promise< string[] > >();
+jest.unstable_mockModule( '../src/utils/labels/get-labels.ts', () => ( {
+	default: mockGetLabels,
+} ) );
+
+// Mock getAvailableLabels (all labels that exist in the repo).
+const mockGetAvailableLabels = jest.fn< () => Promise< Array< { name: string } > > >();
+jest.unstable_mockModule( '../src/utils/labels/get-available-labels.ts', () => ( {
+	default: mockGetAvailableLabels,
+} ) );
+
+// Import the module under test after all mocks are registered.
+const { default: addLabels } = await import( '../src/tasks/add-labels/index.ts' );
+
+/**
+ * Build a minimal PullRequestEvent payload.
+ *
+ * @param headRepoFullName - Full name of the head repo (simulates fork when different from base).
+ * @param baseRepoFullName - Full name of the base repo.
+ * @return Mock payload.
+ */
+function makePayload( headRepoFullName: string, baseRepoFullName: string ): PullRequestEvent {
+	return {
+		number: 123,
+		repository: {
+			owner: { login: 'owner' },
+			name: 'repo',
+		},
+		pull_request: {
+			draft: false,
+			title: 'Add a feature',
+			head: { repo: { full_name: headRepoFullName } },
+			base: { repo: { full_name: baseRepoFullName } },
+		},
+	} as unknown as PullRequestEvent;
+}
+
+describe( 'addLabels', () => {
+	const mockAddLabels = jest.fn< () => Promise< void > >();
+	const mockOctokit = {
+		rest: {
+			issues: {
+				addLabels: mockAddLabels,
+			},
+		},
+	} as unknown as OctokitClient;
+
+	beforeEach( () => {
+		mockGetFiles.mockReset();
+		mockGetLabels.mockReset();
+		mockGetAvailableLabels.mockReset();
+		mockAddLabels.mockReset();
+
+		// Defaults: PR has no existing labels, repo has no labels.
+		mockGetLabels.mockResolvedValue( [] );
+		mockGetAvailableLabels.mockResolvedValue( [] );
+	} );
+
+	test( 'non-fork PR: adds labels even if they do not exist in the repo yet', async () => {
+		const payload = makePayload( 'owner/repo', 'owner/repo' );
+
+		// A file under .github/workflows triggers the "Actions" label.
+		mockGetFiles.mockResolvedValue( [ '.github/workflows/ci.yml' ] );
+
+		await addLabels( payload, mockOctokit );
+
+		expect( mockGetAvailableLabels ).not.toHaveBeenCalled();
+		expect( mockAddLabels ).toHaveBeenCalledTimes( 1 );
+		expect( mockAddLabels.mock.calls[ 0 ][ 0 ] ).toMatchObject( {
+			labels: expect.arrayContaining( [ 'Actions' ] ),
+		} );
+	} );
+
+	test( 'fork PR: only adds labels that already exist in the repo', async () => {
+		const payload = makePayload( 'contributor/repo', 'owner/repo' );
+
+		// File triggers "Actions" label.
+		mockGetFiles.mockResolvedValue( [ '.github/workflows/ci.yml' ] );
+
+		// Only "Actions" exists in the repo; other derived labels do not.
+		mockGetAvailableLabels.mockResolvedValue( [ { name: 'Actions' } ] );
+
+		await addLabels( payload, mockOctokit );
+
+		expect( mockGetAvailableLabels ).toHaveBeenCalledTimes( 1 );
+		expect( mockAddLabels ).toHaveBeenCalledTimes( 1 );
+		expect( mockAddLabels.mock.calls[ 0 ][ 0 ] ).toMatchObject( {
+			labels: [ 'Actions' ],
+		} );
+	} );
+
+	test( 'fork PR: skips adding labels when none of the derived labels exist in the repo', async () => {
+		const payload = makePayload( 'contributor/repo', 'owner/repo' );
+
+		// File triggers "Actions" label, but it doesn't exist in the repo.
+		mockGetFiles.mockResolvedValue( [ '.github/workflows/ci.yml' ] );
+		mockGetAvailableLabels.mockResolvedValue( [] );
+
+		await addLabels( payload, mockOctokit );
+
+		expect( mockGetAvailableLabels ).toHaveBeenCalledTimes( 1 );
+		expect( mockAddLabels ).not.toHaveBeenCalled();
+	} );
+} );


### PR DESCRIPTION
Fixes QAO-326

## Proposed changes:

* When a PR comes from a fork, filter the labels-to-add list so that only labels already existing in the repository are applied.
* This prevents fork PRs from auto-creating arbitrary new labels via the GitHub `addLabels` API.
* Non-fork PRs are unaffected and can still trigger label creation as before.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

N/A

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

* Open a PR from a fork that touches files which would trigger a label that does not yet exist in the repo (e.g. a new project type).
* Verify the non-existent label is **not** created.
* Open a PR from a fork that touches files which would trigger a label that **does** exist in the repo.
* Verify that label **is** added to the PR.
* Open a PR from the same repo (not a fork) that would trigger a new label.
* Verify the label is created and added as before.

## Changelog

- [x] Generate changelog entries for this PR (using AI).