### PR TITLE
Husky hooks: Use pnpm exec for automatic dependency installation

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,1 @@
-node tools/js-tools/git-hooks/pre-commit-hook.mjs
+pnpm exec node tools/js-tools/git-hooks/pre-commit-hook.mjs

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,4 +1,4 @@
 if test -c /dev/tty && sh -c ': < /dev/tty' >/dev/null 2>/dev/null; then
 	exec < /dev/tty
 fi
-node tools/js-tools/git-hooks/pre-push-hook.mjs
+pnpm exec node tools/js-tools/git-hooks/pre-push-hook.mjs

--- a/projects/js-packages/jetpack-cli/changelog/husky-pnpm-exec
+++ b/projects/js-packages/jetpack-cli/changelog/husky-pnpm-exec
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Remove Docker auto-install wrapper for worktrees; husky hooks now use pnpm exec for automatic dependency installation via verifyDepsBeforeRun.

--- a/tools/docker/bin/monorepo
+++ b/tools/docker/bin/monorepo
@@ -150,16 +150,6 @@ fi
 
   mkdir -p "$DOCKER_DATA_DIR"
 
-  # In worktrees, node_modules is missing (gitignored). Wrap the command to
-  # auto-install dependencies on first run so hooks and build scripts work.
-  # (verifyDepsBeforeRun in pnpm-workspace.yaml covers pnpm commands, but
-  # non-pnpm commands like git hooks need this.)
-  if [[ "$IS_WORKTREE" = "1" ]]; then
-      INSTALL_PREFIX='if [ ! -d /workspace/node_modules ]; then echo "Installing dependencies (first run in worktree)..." && pnpm install --frozen-lockfile; fi && '
-      WRAPPED_CMD="${INSTALL_PREFIX}$*"
-      set -- sh -c "$WRAPPED_CMD"
-  fi
-
   docker run --rm $TTY_FLAG \
     -v "$MONOREPO_ROOT:/workspace" \
     -v "$DOCKER_DATA_DIR:/root" \


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/MONOREP-370/use-pnpm-exec-for-husky-git-hooks-to-enable-auto-install-in-worktrees

## Proposed changes:

* Switch `.husky/pre-commit` and `.husky/pre-push` from direct `node` to `pnpm exec node`, so `verifyDepsBeforeRun: install` (pnpm-workspace.yaml) auto-installs dependencies in fresh worktrees.
* Remove the Docker auto-install wrapper from `tools/docker/bin/monorepo` — no longer needed since `pnpm exec` in the hooks covers both the host (husky) and Docker (`jp git-hook`) paths, and `verifyDepsBeforeRun` already covers all `pnpm` commands.
* No changes to `post-checkout`/`post-merge` hooks (pure shell scripts, no npm deps).

Suggested by Brad in #47265.

### Performance benchmark (pre-commit with trivial staged change):

| Method | Median (5 runs) |
|--------|----------------|
| `node` (direct) | ~0.118s |
| `pnpm exec node` | ~0.612s |
| **Overhead** | **~0.5s** |

The overhead is negligible given pre-commit hooks typically run linters for several seconds.

### Other information:

- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

1. **Normal commit (host):** Stage a JS file change, run `git commit` — linting/prettier should run normally.
2. **Normal push (host):** Push a branch — changelog/collision checks should run.
3. **Fresh worktree:** Create a worktree with `git worktree add ../test-wt -b test-wt`, stage a trivial change, and commit. `pnpm exec` should trigger `verifyDepsBeforeRun`, auto-install deps, then run the pre-commit hook.
4. **Docker path:** If `jp init-hooks` is set up, test `jp git-hook pre-commit` in a fresh worktree — should auto-install inside Docker then run hooks.
5. **`jp` commands in worktree:** Run `jp pnpm build` in a fresh worktree — `verifyDepsBeforeRun` should handle install without the removed wrapper.

## Changelog

- [x] Generate changelog entries for this PR (using AI).