### PR TITLE
VideoPress: Auto-complete upload and self-heal failed oEmbed cache

### DIFF
--- a/projects/packages/videopress/.phan/baseline.php
+++ b/projects/packages/videopress/.phan/baseline.php
@@ -10,7 +10,7 @@
 return [
     // # Issue statistics:
     // PhanPluginDuplicateConditionalNullCoalescing : 20+ occurrences
-    // PhanTypeMismatchArgumentProbablyReal : 9 occurrences
+    // PhanTypeMismatchArgumentProbablyReal : 8 occurrences
     // PhanTypeMismatchReturnProbablyReal : 7 occurrences
     // PhanTypeArraySuspicious : 6 occurrences
     // PhanTypeMismatchReturn : 6 occurrences
@@ -51,7 +51,6 @@ return [
         'src/utility-functions.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanPluginUnreachableCode', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchReturn', 'PhanTypeMismatchReturnNullable', 'PhanTypeMismatchReturnProbablyReal'],
         'src/videopress-divi/class-videopress-divi-extension.php' => ['PhanCommentOverrideOnNonOverrideMethod', 'PhanUndeclaredClass', 'PhanUndeclaredClassMethod', 'PhanUndeclaredExtendedClass', 'PhanUndeclaredMethod', 'PhanUndeclaredMethodInCallable'],
         'src/videopress-divi/class-videopress-divi-module.php' => ['PhanUndeclaredExtendedClass'],
-        'tests/php/Uploader_Test.php' => ['PhanTypeMismatchArgumentProbablyReal'],
         'tests/php/VideoPress_Uploader_Test.php' => ['PhanTypeMismatchArgument'],
     ],
     // 'directory_suppressions' => ['src/directory_name' => ['PhanIssueName1', 'PhanIssueName2']] can be manually added if needed.

--- a/projects/packages/videopress/changelog/fix-videopress-auto-complete-upload
+++ b/projects/packages/videopress/changelog/fix-videopress-auto-complete-upload
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+VideoPress: auto-complete upload when user hasn't edited title or poster, and self-heal failed oEmbed cache.

--- a/projects/packages/videopress/src/class-initializer.php
+++ b/projects/packages/videopress/src/class-initializer.php
@@ -350,13 +350,9 @@ class Initializer {
 				: get_the_ID();
 
 			if ( $post_id ) {
-				$embed_attr      = wp_embed_defaults( $videopress_url );
-				$key_suffix      = md5( $videopress_url . serialize( $embed_attr ) ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize -- Matching WP_Embed cache key format.
-				$oembed_meta_key = '_oembed_' . $key_suffix;
-				$oembed_time_key = '_oembed_time_' . $key_suffix;
-
-				$oembed_value = get_post_meta( $post_id, $oembed_meta_key, true );
-				$oembed_time  = (int) get_post_meta( $post_id, $oembed_time_key, true );
+				$key_suffix   = md5( $videopress_url . serialize( wp_embed_defaults( $videopress_url ) ) ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize -- Matching WP_Embed cache key format.
+				$oembed_value = get_post_meta( $post_id, '_oembed_' . $key_suffix, true );
+				$oembed_time  = (int) get_post_meta( $post_id, '_oembed_time_' . $key_suffix, true );
 
 				/*
 				 * Only clear the '{{unknown}}' cache entry when it is recent, to avoid
@@ -366,8 +362,8 @@ class Initializer {
 					'{{unknown}}' === $oembed_value
 					&& ( ! $oembed_time || ( time() - $oembed_time ) < MINUTE_IN_SECONDS )
 				) {
-					delete_post_meta( $post_id, $oembed_meta_key );
-					delete_post_meta( $post_id, $oembed_time_key );
+					delete_post_meta( $post_id, '_oembed_' . $key_suffix );
+					delete_post_meta( $post_id, '_oembed_time_' . $key_suffix );
 				}
 			}
 		}

--- a/projects/packages/videopress/src/class-initializer.php
+++ b/projects/packages/videopress/src/class-initializer.php
@@ -327,11 +327,8 @@ class Initializer {
 			};
 
 			add_filter( 'embed_maybe_make_link', $fallback, 10, 2 );
-			try {
-				$oembed_html = apply_filters( 'video_embed_html', $wp_embed->shortcode( array(), $videopress_url ) );
-			} finally {
-				remove_filter( 'embed_maybe_make_link', $fallback );
-			}
+			$oembed_html = apply_filters( 'video_embed_html', $wp_embed->shortcode( array(), $videopress_url ) );
+			remove_filter( 'embed_maybe_make_link', $fallback );
 
 			$video_wrapper = sprintf(
 				'<div class="%s">%s %s</div>',

--- a/projects/packages/videopress/src/class-initializer.php
+++ b/projects/packages/videopress/src/class-initializer.php
@@ -315,14 +315,14 @@ class Initializer {
 			 * This prevents the published page from showing a bare link.
 			 */
 			$fallback = function ( $output, $url ) use ( $videopress_url ) {
-				if ( $url !== $videopress_url ) {
+				if ( $url !== html_entity_decode( $videopress_url ) ) {
 					return $output;
 				}
 
 				return sprintf(
 					'<iframe title="%1$s" aria-label="%1$s" src="%2$s" width="640" height="360" allowfullscreen data-resize-to-parent="true" allow="clipboard-write"></iframe>',
 					esc_attr__( 'VideoPress Video Player', 'jetpack-videopress-pkg' ),
-					esc_url( preg_replace( '#/v/#', '/embed/', $videopress_url, 1 ) )
+					esc_url( preg_replace( '#/v/#', '/embed/', $url, 1 ) )
 				);
 			};
 
@@ -340,17 +340,34 @@ class Initializer {
 			/*
 			 * Self-heal failed oEmbed cache for VideoPress URLs.
 			 *
-			 * When VideoPress backend isn't ready for a fresh upload, WordPress caches
-			 * '{{unknown}}' in post meta indefinitely. Clear it so the next render retries
-			 * and the fallback iframe above is only used temporarily.
+			 * When the VideoPress backend isn't ready for a freshly uploaded video,
+			 * WordPress caches '{{unknown}}' in post meta with a TTL that is too long
+			 * for this use case. Clear recent failures so the next page render retries
+			 * oEmbed discovery, keeping the fallback iframe above temporary.
 			 */
-			$post_id = get_the_ID();
-			if ( $post_id ) {
-				$key_suffix = md5( $videopress_url . serialize( array() ) ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize -- Matching WP_Embed cache key format.
+			$post_id = ( $block instanceof \WP_Block && ! empty( $block->context['postId'] ) )
+				? (int) $block->context['postId']
+				: get_the_ID();
 
-				if ( '{{unknown}}' === get_post_meta( $post_id, '_oembed_' . $key_suffix, true ) ) {
-					delete_post_meta( $post_id, '_oembed_' . $key_suffix );
-					delete_post_meta( $post_id, '_oembed_time_' . $key_suffix );
+			if ( $post_id ) {
+				$embed_attr      = wp_embed_defaults( $videopress_url );
+				$key_suffix      = md5( $videopress_url . serialize( $embed_attr ) ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize -- Matching WP_Embed cache key format.
+				$oembed_meta_key = '_oembed_' . $key_suffix;
+				$oembed_time_key = '_oembed_time_' . $key_suffix;
+
+				$oembed_value = get_post_meta( $post_id, $oembed_meta_key, true );
+				$oembed_time  = (int) get_post_meta( $post_id, $oembed_time_key, true );
+
+				/*
+				 * Only clear the '{{unknown}}' cache entry when it is recent, to avoid
+				 * disabling WordPress's oEmbed backoff for persistent provider failures.
+				 */
+				if (
+					'{{unknown}}' === $oembed_value
+					&& ( ! $oembed_time || ( time() - $oembed_time ) < MINUTE_IN_SECONDS )
+				) {
+					delete_post_meta( $post_id, $oembed_meta_key );
+					delete_post_meta( $post_id, $oembed_time_key );
 				}
 			}
 		}

--- a/projects/packages/videopress/src/class-initializer.php
+++ b/projects/packages/videopress/src/class-initializer.php
@@ -327,8 +327,11 @@ class Initializer {
 			};
 
 			add_filter( 'embed_maybe_make_link', $fallback, 10, 2 );
-			$oembed_html = apply_filters( 'video_embed_html', $wp_embed->shortcode( array(), $videopress_url ) );
-			remove_filter( 'embed_maybe_make_link', $fallback );
+			try {
+				$oembed_html = apply_filters( 'video_embed_html', $wp_embed->shortcode( array(), $videopress_url ) );
+			} finally {
+				remove_filter( 'embed_maybe_make_link', $fallback );
+			}
 
 			$video_wrapper = sprintf(
 				'<div class="%s">%s %s</div>',

--- a/projects/packages/videopress/src/class-initializer.php
+++ b/projects/packages/videopress/src/class-initializer.php
@@ -7,8 +7,6 @@
 
 namespace Automattic\Jetpack\VideoPress;
 
-use WP_Block;
-
 /**
  * Initialized the VideoPress package
  */
@@ -191,9 +189,9 @@ class Initializer {
 	 *
 	 * @global \WP_Embed $wp_embed WordPress embed handler.
 	 *
-	 * @param array          $block_attributes Block attributes.
-	 * @param string         $content          Current block markup.
-	 * @param WP_Block|array $block            Current block.
+	 * @param array     $block_attributes Block attributes.
+	 * @param string    $content          Current block markup.
+	 * @param \WP_Block $block            Current block.
 	 *
 	 * @return string Block markup.
 	 */
@@ -345,9 +343,7 @@ class Initializer {
 			 * for this use case. Clear recent failures so the next page render retries
 			 * oEmbed discovery, keeping the fallback iframe above temporary.
 			 */
-			$post_id = ( $block instanceof \WP_Block && ! empty( $block->context['postId'] ) )
-				? (int) $block->context['postId']
-				: get_the_ID();
+			$post_id = $block->context['postId'] ?? get_the_ID();
 
 			if ( $post_id ) {
 				$key_suffix   = md5( $videopress_url . serialize( wp_embed_defaults( $videopress_url ) ) ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize -- Matching WP_Embed cache key format.

--- a/projects/packages/videopress/src/class-initializer.php
+++ b/projects/packages/videopress/src/class-initializer.php
@@ -315,7 +315,7 @@ class Initializer {
 			 * This prevents the published page from showing a bare link.
 			 */
 			$fallback = function ( $output, $url ) use ( $videopress_url ) {
-				if ( $url !== html_entity_decode( $videopress_url ) ) {
+				if ( $url !== html_entity_decode( $videopress_url, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401 ) ) {
 					return $output;
 				}
 

--- a/projects/packages/videopress/src/class-initializer.php
+++ b/projects/packages/videopress/src/class-initializer.php
@@ -189,6 +189,8 @@ class Initializer {
 	/**
 	 * VideoPress video block render method
 	 *
+	 * @global \WP_Embed $wp_embed WordPress embed handler.
+	 *
 	 * @param array    $block_attributes - Block attributes.
 	 * @param string   $content          - Current block markup.
 	 * @param WP_Block $block            - Current block.
@@ -306,13 +308,51 @@ class Initializer {
 
 		if ( $videopress_url ) {
 			$videopress_url = wp_kses_post( $videopress_url );
-			$oembed_html    = apply_filters( 'video_embed_html', $wp_embed->shortcode( array(), $videopress_url ) );
-			$video_wrapper  = sprintf(
+
+			/*
+			 * Provide a fallback iframe for when the oEmbed endpoint fails, e.g.
+			 * when the VideoPress backend isn't ready for a freshly uploaded video.
+			 * This prevents the published page from showing a bare link.
+			 */
+			$fallback = function ( $output, $url ) use ( $videopress_url ) {
+				if ( $url !== $videopress_url ) {
+					return $output;
+				}
+
+				return sprintf(
+					'<iframe title="%1$s" aria-label="%1$s" src="%2$s" width="640" height="360" allowfullscreen data-resize-to-parent="true" allow="clipboard-write"></iframe>',
+					esc_attr__( 'VideoPress Video Player', 'jetpack-videopress-pkg' ),
+					esc_url( preg_replace( '#/v/#', '/embed/', $videopress_url, 1 ) )
+				);
+			};
+
+			add_filter( 'embed_maybe_make_link', $fallback, 10, 2 );
+			$oembed_html = apply_filters( 'video_embed_html', $wp_embed->shortcode( array(), $videopress_url ) );
+			remove_filter( 'embed_maybe_make_link', $fallback );
+
+			$video_wrapper = sprintf(
 				'<div class="%s">%s %s</div>',
 				$video_wrapper_classes,
 				$preview_on_hover,
 				$oembed_html
 			);
+
+			/*
+			 * Self-heal failed oEmbed cache for VideoPress URLs.
+			 *
+			 * When VideoPress backend isn't ready for a fresh upload, WordPress caches
+			 * '{{unknown}}' in post meta indefinitely. Clear it so the next render retries
+			 * and the fallback iframe above is only used temporarily.
+			 */
+			$post_id = get_the_ID();
+			if ( $post_id ) {
+				$key_suffix = md5( $videopress_url . serialize( array() ) ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize -- Matching WP_Embed cache key format.
+
+				if ( '{{unknown}}' === get_post_meta( $post_id, '_oembed_' . $key_suffix, true ) ) {
+					delete_post_meta( $post_id, '_oembed_' . $key_suffix );
+					delete_post_meta( $post_id, '_oembed_time_' . $key_suffix );
+				}
+			}
 		}
 
 		// Get premium content from block context

--- a/projects/packages/videopress/src/class-initializer.php
+++ b/projects/packages/videopress/src/class-initializer.php
@@ -191,11 +191,11 @@ class Initializer {
 	 *
 	 * @global \WP_Embed $wp_embed WordPress embed handler.
 	 *
-	 * @param array    $block_attributes - Block attributes.
-	 * @param string   $content          - Current block markup.
-	 * @param WP_Block $block            - Current block.
+	 * @param array          $block_attributes Block attributes.
+	 * @param string         $content          Current block markup.
+	 * @param WP_Block|array $block            Current block.
 	 *
-	 * @return string                    Block markup.
+	 * @return string Block markup.
 	 */
 	public static function render_videopress_video_block( $block_attributes, $content, $block ) {
 		global $wp_embed;

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/videopress-uploader/uploader-progress.js
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/videopress-uploader/uploader-progress.js
@@ -181,20 +181,12 @@ const UploaderProgress = ( {
 	/**
 	 * Auto-complete the upload when the user hasn't made edits.
 	 * If the user edited the title or poster, show the "Done" button instead.
-	 *
-	 * The 2500ms delay gives the VideoPress backend time to be ready to serve
-	 * oEmbed responses, preventing a race condition where saving the post
-	 * immediately after upload caches a failed oEmbed response. See #28727.
 	 */
 	useEffect( () => {
 		if ( uploadedVideoData && ! hasUserEdits && ! hasAutoCompleted.current ) {
 			hasAutoCompleted.current = true;
-			debug( 'Auto-completing upload in 2500ms (no user edits detected)...' );
-			const timer = setTimeout( () => {
-				debug( 'Auto-completing upload now...' );
-				handleDoneUpload();
-			}, 2500 );
-			return () => clearTimeout( timer );
+			debug( 'Auto-completing upload (no user edits detected)...' );
+			handleDoneUpload();
 		}
 	}, [ uploadedVideoData, hasUserEdits, handleDoneUpload ] );
 

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/videopress-uploader/uploader-progress.js
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/videopress-uploader/uploader-progress.js
@@ -4,7 +4,7 @@
 import apiFetch from '@wordpress/api-fetch';
 import { Button, TextControl } from '@wordpress/components';
 import { useDebounce } from '@wordpress/compose';
-import { useState, useEffect } from '@wordpress/element';
+import { useState, useEffect, useRef } from '@wordpress/element';
 import { escapeHTML } from '@wordpress/escape-html';
 import { __, sprintf } from '@wordpress/i18n';
 import debugFactory from 'debug';
@@ -135,6 +135,8 @@ const usePosterAndTitleUpdate = ( { setAttributes, videoData, onDone } ) => {
 		}
 	}, [ videoPosterImageData, videoFrameMs, guid ] );
 
+	const hasPosterEdits = videoPosterImageData !== null || videoFrameMs !== null;
+
 	return [
 		handleVideoFrameSelected,
 		handleSelectPoster,
@@ -142,6 +144,7 @@ const usePosterAndTitleUpdate = ( { setAttributes, videoData, onDone } ) => {
 		handleDoneUpload,
 		videoPosterImageData,
 		isFinishingUpdate,
+		hasPosterEdits,
 	];
 };
 
@@ -165,30 +168,35 @@ const UploaderProgress = ( {
 		handleDoneUpload,
 		videoPosterImageData,
 		isFinishingUpdate,
+		hasPosterEdits,
 	] = usePosterAndTitleUpdate( {
 		setAttributes,
 		videoData: { ...uploadedVideoData, title: attributes.title },
 		onDone,
 	} );
 
-	/**
-	 * Flag to control the processing state
-	 */
-	const [ isProcessing, setIsProcessing ] = useState( true );
+	const hasUserEdits = !! attributes.title || hasPosterEdits;
+	const hasAutoCompleted = useRef( false );
 
 	/**
-	 * When the upload and the metadata update is ready,
-	 * wait for some time and then release the "Done" button.
+	 * Auto-complete the upload when the user hasn't made edits.
+	 * If the user edited the title or poster, show the "Done" button instead.
+	 *
+	 * The 2500ms delay gives the VideoPress backend time to be ready to serve
+	 * oEmbed responses, preventing a race condition where saving the post
+	 * immediately after upload caches a failed oEmbed response. See #28727.
 	 */
 	useEffect( () => {
-		if ( uploadedVideoData && ! isFinishingUpdate && isProcessing ) {
-			debug( 'Waiting for some time before enabling the DONE button...' );
-			setTimeout( () => {
-				debug( 'Done, enabling the DONE button now...' );
-				setIsProcessing( false );
+		if ( uploadedVideoData && ! hasUserEdits && ! hasAutoCompleted.current ) {
+			hasAutoCompleted.current = true;
+			debug( 'Auto-completing upload in 2500ms (no user edits detected)...' );
+			const timer = setTimeout( () => {
+				debug( 'Auto-completing upload now...' );
+				handleDoneUpload();
 			}, 2500 );
+			return () => clearTimeout( timer );
 		}
-	}, [ uploadedVideoData, isFinishingUpdate ] );
+	}, [ uploadedVideoData, hasUserEdits, handleDoneUpload ] );
 
 	const roundedProgress = Math.round( progress );
 	const cssWidth = { width: `${ roundedProgress }%` };
@@ -258,19 +266,21 @@ const UploaderProgress = ( {
 					</>
 				) : (
 					<>
-						{ ! isProcessing ? (
-							<span>{ __( 'Upload Complete!', 'jetpack-videopress-pkg' ) } 🎉</span>
+						{ hasUserEdits ? (
+							<>
+								<span>{ __( 'Upload Complete!', 'jetpack-videopress-pkg' ) } 🎉</span>
+								<Button
+									variant="primary"
+									onClick={ handleDoneUpload }
+									disabled={ isFinishingUpdate }
+									isBusy={ isFinishingUpdate }
+								>
+									{ __( 'Done', 'jetpack-videopress-pkg' ) }
+								</Button>
+							</>
 						) : (
 							<span>{ __( 'Finishing up …', 'jetpack-videopress-pkg' ) } 🎬</span>
 						) }
-						<Button
-							variant="primary"
-							onClick={ handleDoneUpload }
-							disabled={ isProcessing }
-							isBusy={ isProcessing }
-						>
-							{ __( 'Done', 'jetpack-videopress-pkg' ) }
-						</Button>
 					</>
 				) }
 			</div>

--- a/projects/packages/videopress/tests/php/Initializer_Test.php
+++ b/projects/packages/videopress/tests/php/Initializer_Test.php
@@ -37,13 +37,26 @@ class Initializer_Test extends BaseTestCase {
 	/**
 	 * Render the VideoPress block with the given attributes.
 	 *
+	 * Uses pre_oembed_result to force oEmbed failure so the fallback path
+	 * is always exercised, regardless of external service availability.
+	 *
 	 * @param array $attributes Block attributes.
 	 * @return string Rendered block markup.
 	 */
 	private function render( $attributes = array() ) {
 		$attributes = array_merge( self::$default_attributes, $attributes );
 		$block      = array( 'context' => array() );
-		return VideoPress_Initializer::render_videopress_video_block( $attributes, '', $block );
+
+		$force_failure = function () {
+			return false;
+		};
+		add_filter( 'pre_oembed_result', $force_failure );
+
+		$html = VideoPress_Initializer::render_videopress_video_block( $attributes, '', $block );
+
+		remove_filter( 'pre_oembed_result', $force_failure );
+
+		return $html;
 	}
 
 	/**
@@ -102,9 +115,11 @@ class Initializer_Test extends BaseTestCase {
 
 	/** Tests that the fallback filter is cleaned up after rendering. */
 	public function test_fallback_filter_removed_after_render() {
+		$before = has_filter( 'embed_maybe_make_link' );
+
 		$this->render();
 
-		$this->assertFalse( has_filter( 'embed_maybe_make_link' ) );
+		$this->assertSame( $before, has_filter( 'embed_maybe_make_link' ) );
 	}
 
 	/** Tests that recent {{unknown}} cache entries are cleared. */

--- a/projects/packages/videopress/tests/php/Initializer_Test.php
+++ b/projects/packages/videopress/tests/php/Initializer_Test.php
@@ -1,0 +1,172 @@
+<?php
+/**
+ * Tests for the oEmbed fallback and self-healing in Initializer::render_videopress_video_block.
+ *
+ * @package automattic/jetpack-videopress
+ */
+
+namespace Automattic\Jetpack;
+
+use Automattic\Jetpack\VideoPress\Initializer as VideoPress_Initializer;
+use Automattic\Jetpack\VideoPress\Utils;
+use WorDBless\BaseTestCase;
+
+/**
+ * Test suite for oEmbed fallback and self-healing behavior.
+ */
+class Initializer_Test extends BaseTestCase {
+
+	/**
+	 * Default block attributes with a valid GUID.
+	 *
+	 * @var array
+	 */
+	private static $default_attributes = array(
+		'guid'     => 'testGUID1',
+		'controls' => true,
+	);
+
+	/**
+	 * Tear down after each test.
+	 */
+	public function tear_down() {
+		parent::tear_down();
+		unset( $GLOBALS['post'] );
+	}
+
+	/**
+	 * Render the VideoPress block with the given attributes.
+	 *
+	 * @param array $attributes Block attributes.
+	 * @return string Rendered block markup.
+	 */
+	private function render( $attributes = array() ) {
+		$attributes = array_merge( self::$default_attributes, $attributes );
+		$block      = array( 'context' => array() );
+		return VideoPress_Initializer::render_videopress_video_block( $attributes, '', $block );
+	}
+
+	/**
+	 * Create a post and set it as the global post.
+	 *
+	 * @return int Post ID.
+	 */
+	private function create_global_post() {
+		$post_id = wp_insert_post(
+			array(
+				'post_title'  => 'Test',
+				'post_status' => 'publish',
+			)
+		);
+		$this->assertIsInt( $post_id );
+		$this->assertGreaterThan( 0, $post_id );
+
+		$GLOBALS['post'] = get_post( $post_id );
+
+		return $post_id;
+	}
+
+	/**
+	 * Compute the oEmbed cache key suffix for the default test attributes.
+	 *
+	 * Mirrors WP_Embed::shortcode() which uses md5( $url . serialize( $parsed_attr ) )
+	 * where $parsed_attr includes defaults from wp_embed_defaults().
+	 *
+	 * @return string Cache key suffix (md5 hash).
+	 */
+	private function get_oembed_key_suffix() {
+		$url        = wp_kses_post( Utils::get_video_press_url( 'testGUID1', self::$default_attributes ) );
+		$embed_attr = wp_embed_defaults( $url );
+		return md5( $url . serialize( $embed_attr ) ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize
+	}
+
+	/** Tests that the fallback iframe is rendered when oEmbed fails. */
+	public function test_fallback_iframe_rendered_on_oembed_failure() {
+		$html = $this->render();
+
+		$this->assertStringContainsString( '<iframe', $html );
+		$this->assertStringContainsString( 'videopress.com/embed/testGUID1', $html );
+		$this->assertStringNotContainsString( '<a href=', $html );
+	}
+
+	/** Tests that the fallback iframe has the expected attributes. */
+	public function test_fallback_iframe_attributes() {
+		$html = $this->render();
+
+		$this->assertStringContainsString( 'allowfullscreen', $html );
+		$this->assertStringContainsString( 'data-resize-to-parent="true"', $html );
+		$this->assertStringContainsString( 'allow="clipboard-write"', $html );
+		$this->assertStringContainsString( 'width="640"', $html );
+		$this->assertStringContainsString( 'height="360"', $html );
+	}
+
+	/** Tests that the fallback filter is cleaned up after rendering. */
+	public function test_fallback_filter_removed_after_render() {
+		$this->render();
+
+		$this->assertFalse( has_filter( 'embed_maybe_make_link' ) );
+	}
+
+	/** Tests that recent {{unknown}} cache entries are cleared. */
+	public function test_self_heal_clears_recent_unknown_cache() {
+		$post_id    = $this->create_global_post();
+		$key_suffix = $this->get_oembed_key_suffix();
+
+		update_post_meta( $post_id, '_oembed_' . $key_suffix, '{{unknown}}' );
+		update_post_meta( $post_id, '_oembed_time_' . $key_suffix, time() );
+
+		$this->render();
+
+		$this->assertEmpty( get_post_meta( $post_id, '_oembed_' . $key_suffix, true ) );
+		$this->assertEmpty( get_post_meta( $post_id, '_oembed_time_' . $key_suffix, true ) );
+	}
+
+	/** Tests that {{unknown}} cache entries without a timestamp are cleared. */
+	public function test_self_heal_clears_unknown_cache_without_timestamp() {
+		$post_id    = $this->create_global_post();
+		$key_suffix = $this->get_oembed_key_suffix();
+
+		update_post_meta( $post_id, '_oembed_' . $key_suffix, '{{unknown}}' );
+
+		$this->render();
+
+		$this->assertEmpty( get_post_meta( $post_id, '_oembed_' . $key_suffix, true ) );
+	}
+
+	/** Tests that old {{unknown}} cache entries are NOT cleared (backoff preserved). */
+	public function test_self_heal_preserves_old_unknown_cache() {
+		$post_id    = $this->create_global_post();
+		$key_suffix = $this->get_oembed_key_suffix();
+
+		update_post_meta( $post_id, '_oembed_' . $key_suffix, '{{unknown}}' );
+		update_post_meta( $post_id, '_oembed_time_' . $key_suffix, time() - 2 * MINUTE_IN_SECONDS );
+
+		$this->render();
+
+		$this->assertSame( '{{unknown}}', get_post_meta( $post_id, '_oembed_' . $key_suffix, true ) );
+		$this->assertNotEmpty( get_post_meta( $post_id, '_oembed_time_' . $key_suffix, true ) );
+	}
+
+	/** Tests that valid oEmbed cache entries are not touched. */
+	public function test_self_heal_does_not_touch_valid_cache() {
+		$post_id     = $this->create_global_post();
+		$key_suffix  = $this->get_oembed_key_suffix();
+		$valid_embed = '<iframe src="https://videopress.com/embed/testGUID1"></iframe>';
+
+		update_post_meta( $post_id, '_oembed_' . $key_suffix, $valid_embed );
+		update_post_meta( $post_id, '_oembed_time_' . $key_suffix, time() );
+
+		$this->render();
+
+		$this->assertSame( $valid_embed, get_post_meta( $post_id, '_oembed_' . $key_suffix, true ) );
+	}
+
+	/** Tests that the block renders without errors when there is no global post. */
+	public function test_self_heal_no_post_id() {
+		unset( $GLOBALS['post'] );
+
+		$html = $this->render();
+
+		$this->assertStringContainsString( '<iframe', $html );
+	}
+}

--- a/projects/packages/videopress/tests/php/Initializer_Test.php
+++ b/projects/packages/videopress/tests/php/Initializer_Test.php
@@ -47,14 +47,11 @@ class Initializer_Test extends BaseTestCase {
 		$attributes = array_merge( self::$default_attributes, $attributes );
 		$block      = array( 'context' => array() );
 
-		$force_failure = function () {
-			return false;
-		};
-		add_filter( 'pre_oembed_result', $force_failure );
+		add_filter( 'pre_oembed_result', '__return_false' );
 
 		$html = VideoPress_Initializer::render_videopress_video_block( $attributes, '', $block );
 
-		remove_filter( 'pre_oembed_result', $force_failure );
+		remove_filter( 'pre_oembed_result', '__return_false' );
 
 		return $html;
 	}

--- a/projects/packages/videopress/tests/php/Initializer_Test.php
+++ b/projects/packages/videopress/tests/php/Initializer_Test.php
@@ -45,7 +45,7 @@ class Initializer_Test extends BaseTestCase {
 	 */
 	private function render( $attributes = array() ) {
 		$attributes = array_merge( self::$default_attributes, $attributes );
-		$block      = array( 'context' => array() );
+		$block      = new \WP_Block( array( 'blockName' => 'videopress/video' ) );
 
 		add_filter( 'pre_oembed_result', '__return_false' );
 

--- a/projects/packages/videopress/tests/php/Uploader_Test.php
+++ b/projects/packages/videopress/tests/php/Uploader_Test.php
@@ -80,7 +80,7 @@ class Uploader_Test extends BaseTestCase {
 		);
 
 		$content = 'some content';
-		$block   = array( 'context' => array() );
+		$block   = new \WP_Block( array( 'blockName' => 'videopress/video' ) );
 
 		$rendered_block = VideoPress_Initializer::render_videopress_video_block( $attributes, $content, $block );
 
@@ -102,7 +102,7 @@ class Uploader_Test extends BaseTestCase {
 			'useAverageColor'     => false,
 		);
 
-		$block   = array( 'context' => array() );
+		$block   = new \WP_Block( array( 'blockName' => 'videopress/video' ) );
 		$content = 'some content';
 
 		$rendered_block = VideoPress_Initializer::render_videopress_video_block( $attributes, $content, $block );

--- a/projects/packages/videopress/tests/php/Uploader_Test.php
+++ b/projects/packages/videopress/tests/php/Uploader_Test.php
@@ -49,7 +49,7 @@ class Uploader_Test extends BaseTestCase {
 		$mock->expects( 'enqueue_jwt_token_bridge' )->once();
 
 		$cache_value    = 'some-markup';
-		$cache_returned = VideoPress_Initializer::video_enqueue_bridge_when_oembed_present( $cache_value, $url, null, null );
+		$cache_returned = VideoPress_Initializer::video_enqueue_bridge_when_oembed_present( $cache_value, $url, array(), 0 );
 		$this->assertEquals( $cache_value, $cache_returned );
 	}
 
@@ -59,7 +59,7 @@ class Uploader_Test extends BaseTestCase {
 		$mock->expects( 'enqueue_jwt_token_bridge' )->never();
 
 		$cache_value    = 'some-markup';
-		$cache_returned = VideoPress_Initializer::video_enqueue_bridge_when_oembed_present( $cache_value, 'https://www.some-site.com', null, null );
+		$cache_returned = VideoPress_Initializer::video_enqueue_bridge_when_oembed_present( $cache_value, 'https://www.some-site.com', array(), 0 );
 		$this->assertEquals( $cache_value, $cache_returned );
 	}
 


### PR DESCRIPTION
Fixes VIDP-220

## Proposed changes:

* Auto-complete the VideoPress upload flow when the user hasn't edited the title or poster, removing the need to click "Done"
* Add a fallback iframe via `embed_maybe_make_link` so a bare link is never shown when oEmbed fails for a freshly uploaded video
* Self-heal `{{unknown}}` oEmbed cache entries so the fallback is only temporary — the next page view retries and succeeds
* Remove the 2.5s upload delay (added in #29493) since the PHP self-healing handles the race condition

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

1. Upload a VideoPress video in the block editor **without** editing the title or poster
2. Verify the upload auto-completes ("Finishing up…" then transitions to the player) without needing to click "Done"
3. Upload a VideoPress video and **edit the title** during upload
4. Verify the "Done" button appears after upload completes, and clicking it saves the title
5. Publish a post with a freshly uploaded video immediately after upload completes
6. Verify the video renders correctly on the published page (not a bare link)
7. If oEmbed fails (e.g., simulated by temporarily blocking the endpoint), verify the fallback iframe is shown and on the next page load the proper oEmbed player appears

## Changelog

- [x] Generate changelog entries for this PR (using AI).