### PR TITLE
VideoPress: Refresh media library processing status via Heartbeat

### DIFF
--- a/projects/packages/videopress/.phan/baseline.php
+++ b/projects/packages/videopress/.phan/baseline.php
@@ -12,13 +12,13 @@ return [
     // PhanPluginDuplicateConditionalNullCoalescing : 20+ occurrences
     // PhanTypeMismatchArgumentProbablyReal : 9 occurrences
     // PhanTypeMismatchReturnProbablyReal : 7 occurrences
-    // PhanTypeArraySuspicious : 6 occurrences
     // PhanTypeMismatchReturn : 6 occurrences
     // PhanUndeclaredClassMethod : 6 occurrences
     // PhanCommentOverrideOnNonOverrideMethod : 4 occurrences
     // PhanNonClassMethodCall : 4 occurrences
     // PhanTypeArraySuspiciousNullable : 4 occurrences
     // PhanTypeMismatchArgument : 4 occurrences
+    // PhanTypeArraySuspicious : 3 occurrences
     // PhanTypeInvalidDimOffset : 2 occurrences
     // PhanUndeclaredExtendedClass : 2 occurrences
     // PhanUndeclaredMethod : 2 occurrences
@@ -32,7 +32,7 @@ return [
     // Currently, file_suppressions and directory_suppressions are the only supported suppressions
     'file_suppressions' => [
         'src/class-access-control.php' => ['PhanPluginDuplicateConditionalNullCoalescing'],
-        'src/class-attachment-handler.php' => ['PhanNonClassMethodCall', 'PhanTypeArraySuspicious'],
+        'src/class-attachment-handler.php' => ['PhanNonClassMethodCall'],
         'src/class-block-editor-content.php' => ['PhanPluginDuplicateConditionalNullCoalescing'],
         'src/class-block-editor-extensions.php' => ['PhanTypeMismatchReturnProbablyReal'],
         'src/class-data.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeArraySuspicious', 'PhanTypeMismatchReturn'],

--- a/projects/packages/videopress/changelog/fix-media-library-processing-status-refresh
+++ b/projects/packages/videopress/changelog/fix-media-library-processing-status-refresh
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Automatically refresh VideoPress video thumbnails in the Media Library grid after transcoding completes, instead of requiring a page reload.

--- a/projects/packages/videopress/src/class-attachment-handler.php
+++ b/projects/packages/videopress/src/class-attachment-handler.php
@@ -319,6 +319,12 @@ class Attachment_Handler {
 		);
 
 		add_filter( 'heartbeat_settings', array( __CLASS__, 'heartbeat_settings' ) );
+
+		// Constrain poster images so they fit within the media library grid cell.
+		wp_add_inline_style(
+			'media-views',
+			'.attachment-preview.type-video .thumbnail .centered img.thumbnail { max-width: 100%; max-height: 100%; }'
+		);
 	}
 
 	/**

--- a/projects/packages/videopress/src/class-attachment-handler.php
+++ b/projects/packages/videopress/src/class-attachment-handler.php
@@ -317,6 +317,23 @@ class Attachment_Handler {
 			Package_Version::PACKAGE_VERSION,
 			true
 		);
+
+		add_filter( 'heartbeat_settings', array( __CLASS__, 'heartbeat_settings' ) );
+	}
+
+	/**
+	 * Lowers the Heartbeat minimum interval on the media library page
+	 * so the polling script can request a faster tick rate.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param array $settings Heartbeat settings.
+	 * @return array
+	 */
+	public static function heartbeat_settings( $settings ) {
+		$settings['minimalInterval'] = 10;
+
+		return $settings;
 	}
 
 	/**

--- a/projects/packages/videopress/src/class-attachment-handler.php
+++ b/projects/packages/videopress/src/class-attachment-handler.php
@@ -46,6 +46,7 @@ class Attachment_Handler {
 		add_filter( 'user_has_cap', array( __CLASS__, 'disable_delete_if_disconnected' ), 10, 3 );
 
 		add_action( 'admin_print_scripts-upload.php', array( __CLASS__, 'enqueue_media_library_poll' ) );
+		add_action( 'admin_print_styles-upload.php', array( __CLASS__, 'enqueue_media_library_styles' ) );
 		add_filter( 'heartbeat_received', array( __CLASS__, 'heartbeat_received' ), 10, 2 );
 	}
 
@@ -319,7 +320,16 @@ class Attachment_Handler {
 		);
 
 		add_filter( 'heartbeat_settings', array( __CLASS__, 'heartbeat_settings' ) );
+	}
 
+	/**
+	 * Adds inline styles for the media library grid on the upload page.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @return void
+	 */
+	public static function enqueue_media_library_styles() {
 		// Constrain poster images so they fit within the media library grid cell.
 		wp_add_inline_style(
 			'media-views',

--- a/projects/packages/videopress/src/class-attachment-handler.php
+++ b/projects/packages/videopress/src/class-attachment-handler.php
@@ -194,7 +194,8 @@ class Attachment_Handler {
 	/**
 	 * Make sure that any Video that has a VideoPress GUID passes that data back.
 	 *
-	 * @param WP_Post $post Attachment object.
+	 * @param array $post Attachment data array.
+	 * @return array
 	 */
 	public static function prepare_attachment_for_js( $post ) {
 		if ( 'video' === $post['type'] ) {

--- a/projects/packages/videopress/src/class-attachment-handler.php
+++ b/projects/packages/videopress/src/class-attachment-handler.php
@@ -44,6 +44,9 @@ class Attachment_Handler {
 		add_action( 'pre_get_posts', array( __CLASS__, 'media_list_table_query' ) );
 
 		add_filter( 'user_has_cap', array( __CLASS__, 'disable_delete_if_disconnected' ), 10, 3 );
+
+		add_action( 'admin_print_scripts-upload.php', array( __CLASS__, 'enqueue_media_library_poll' ) );
+		add_filter( 'heartbeat_received', array( __CLASS__, 'heartbeat_received' ), 10, 2 );
 	}
 
 	/**
@@ -199,6 +202,10 @@ class Attachment_Handler {
 			if ( $guid ) {
 				$post['videopress_guid'] = $guid;
 			}
+			$status = get_post_meta( $post['id'], 'videopress_status', true );
+			if ( $status ) {
+				$post['videopress_status'] = $status;
+			}
 		}
 		return $post;
 	}
@@ -291,5 +298,53 @@ class Attachment_Handler {
 		}
 
 		return $allcaps;
+	}
+
+	/**
+	 * Enqueues the script that hooks into WP Heartbeat to refresh
+	 * processing VideoPress video data in the media library grid.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @return void
+	 */
+	public static function enqueue_media_library_poll() {
+		wp_enqueue_script(
+			'videopress-media-library-poll',
+			plugins_url( 'js/media-library-poll.js', __FILE__ ),
+			array( 'jquery', 'heartbeat', 'media-grid' ),
+			Package_Version::PACKAGE_VERSION,
+			true
+		);
+	}
+
+	/**
+	 * Heartbeat API handler that checks the processing status of VideoPress videos.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param array $response The Heartbeat response.
+	 * @param array $data     The data sent with the Heartbeat request.
+	 * @return array
+	 */
+	public static function heartbeat_received( $response, $data ) {
+		if ( empty( $data['videopress_processing_ids'] ) || ! is_array( $data['videopress_processing_ids'] ) ) {
+			return $response;
+		}
+
+		$statuses = array();
+		foreach ( $data['videopress_processing_ids'] as $id ) {
+			$id     = (int) $id;
+			$status = get_post_meta( $id, 'videopress_status', true );
+			if ( $status ) {
+				$statuses[ $id ] = $status;
+			}
+		}
+
+		if ( ! empty( $statuses ) ) {
+			$response['videopress_processing_status'] = $statuses;
+		}
+
+		return $response;
 	}
 }

--- a/projects/packages/videopress/src/class-attachment-handler.php
+++ b/projects/packages/videopress/src/class-attachment-handler.php
@@ -347,7 +347,7 @@ class Attachment_Handler {
 	 * @return array
 	 */
 	public static function heartbeat_settings( $settings ) {
-		$settings['minimalInterval'] = 10;
+		$settings['minimalInterval'] = 5;
 
 		return $settings;
 	}

--- a/projects/packages/videopress/src/js/media-library-poll.js
+++ b/projects/packages/videopress/src/js/media-library-poll.js
@@ -1,0 +1,66 @@
+/* global jQuery, wp */
+( function ( $, wp ) {
+	/**
+	 * Returns attachment IDs for VideoPress videos that are still processing.
+	 *
+	 * @return {Array} Attachment IDs.
+	 */
+	function getProcessingVideoIds() {
+		if ( ! wp.media.frame || ! wp.media.frame.state() ) {
+			return [];
+		}
+
+		const library = wp.media.frame.state().get( 'library' );
+		if ( ! library ) {
+			return [];
+		}
+
+		const ids = [];
+		library.each( function ( attachment ) {
+			if (
+				attachment.get( 'type' ) === 'video' &&
+				attachment.get( 'subtype' ) === 'videopress' &&
+				attachment.get( 'videopress_status' ) &&
+				attachment.get( 'videopress_status' ) !== 'complete'
+			) {
+				ids.push( attachment.get( 'id' ) );
+			}
+		} );
+		return ids;
+	}
+
+	$( document ).on( 'heartbeat-send', function ( e, data ) {
+		const ids = getProcessingVideoIds();
+		if ( ids.length ) {
+			data.videopress_processing_ids = ids;
+		}
+	} );
+
+	$( document ).on( 'heartbeat-tick', function ( e, data ) {
+		if ( ! data.videopress_processing_status ) {
+			return;
+		}
+
+		if ( ! wp.media.frame || ! wp.media.frame.state() ) {
+			return;
+		}
+
+		const library = wp.media.frame.state().get( 'library' );
+		if ( ! library ) {
+			return;
+		}
+
+		$.each( data.videopress_processing_status, function ( id, status ) {
+			const attachment = library.get( id );
+			if ( attachment && status === 'complete' ) {
+				wp.ajax
+					.send( 'get-attachment', {
+						data: { id: id },
+					} )
+					.done( function ( attrs ) {
+						attachment.set( attrs );
+					} );
+			}
+		} );
+	} );
+} )( jQuery, wp );

--- a/projects/packages/videopress/src/js/media-library-poll.js
+++ b/projects/packages/videopress/src/js/media-library-poll.js
@@ -1,6 +1,21 @@
 /* global jQuery, wp */
 ( function ( $, wp ) {
 	/**
+	 * Checks whether a Backbone attachment model is a processing VideoPress video.
+	 *
+	 * @param {object} attachment - Backbone attachment model.
+	 * @return {boolean} True when the video is still processing.
+	 */
+	function isProcessingVideo( attachment ) {
+		return (
+			attachment.get( 'type' ) === 'video' &&
+			attachment.get( 'subtype' ) === 'videopress' &&
+			attachment.get( 'videopress_status' ) &&
+			attachment.get( 'videopress_status' ) !== 'complete'
+		);
+	}
+
+	/**
 	 * Returns attachment IDs for VideoPress videos that are still processing.
 	 *
 	 * @return {Array} Attachment IDs.
@@ -17,12 +32,7 @@
 
 		const ids = [];
 		library.each( function ( attachment ) {
-			if (
-				attachment.get( 'type' ) === 'video' &&
-				attachment.get( 'subtype' ) === 'videopress' &&
-				attachment.get( 'videopress_status' ) &&
-				attachment.get( 'videopress_status' ) !== 'complete'
-			) {
+			if ( isProcessingVideo( attachment ) ) {
 				ids.push( attachment.get( 'id' ) );
 			}
 		} );
@@ -38,6 +48,30 @@
 			wp.heartbeat.interval( 'standard' );
 		}
 	} );
+
+	// Speed up heartbeat as soon as a processing video is uploaded.
+	const bootCheck = setInterval( function () {
+		if ( ! wp.media.frame ) {
+			return;
+		}
+		clearInterval( bootCheck );
+
+		const library = wp.media.frame.state().get( 'library' );
+		if ( ! library ) {
+			return;
+		}
+
+		library.on( 'add', function ( attachment ) {
+			if ( isProcessingVideo( attachment ) ) {
+				wp.heartbeat.interval( 'fast' );
+			}
+		} );
+
+		// Also kick off fast polling if videos were already processing on page load.
+		if ( getProcessingVideoIds().length ) {
+			wp.heartbeat.interval( 'fast' );
+		}
+	}, 500 );
 
 	$( document ).on( 'heartbeat-tick', function ( e, data ) {
 		if ( ! data.videopress_processing_status ) {

--- a/projects/packages/videopress/src/js/media-library-poll.js
+++ b/projects/packages/videopress/src/js/media-library-poll.js
@@ -83,6 +83,9 @@
 		$.each( data.videopress_processing_status, function ( id, status ) {
 			const attachment = library.get( id );
 			if ( attachment && status === 'complete' ) {
+				// Prevent duplicate fetches on subsequent ticks.
+				attachment.set( 'videopress_status', 'complete' );
+
 				wp.ajax
 					.send( 'get-attachment', {
 						data: { id: id },

--- a/projects/packages/videopress/src/js/media-library-poll.js
+++ b/projects/packages/videopress/src/js/media-library-poll.js
@@ -33,6 +33,9 @@
 		const ids = getProcessingVideoIds();
 		if ( ids.length ) {
 			data.videopress_processing_ids = ids;
+			wp.heartbeat.interval( 'fast' );
+		} else {
+			wp.heartbeat.interval( 'standard' );
 		}
 	} );
 

--- a/projects/packages/videopress/src/js/media-library-poll.js
+++ b/projects/packages/videopress/src/js/media-library-poll.js
@@ -1,21 +1,6 @@
 /* global jQuery, wp */
 ( function ( $, wp ) {
 	/**
-	 * Checks whether a Backbone attachment model is a processing VideoPress video.
-	 *
-	 * @param {object} attachment - Backbone attachment model.
-	 * @return {boolean} True when the video is still processing.
-	 */
-	function isProcessingVideo( attachment ) {
-		return (
-			attachment.get( 'type' ) === 'video' &&
-			attachment.get( 'subtype' ) === 'videopress' &&
-			attachment.get( 'videopress_status' ) &&
-			attachment.get( 'videopress_status' ) !== 'complete'
-		);
-	}
-
-	/**
 	 * Returns attachment IDs for VideoPress videos that are still processing.
 	 *
 	 * @return {Array} Attachment IDs.
@@ -32,7 +17,12 @@
 
 		const ids = [];
 		library.each( function ( attachment ) {
-			if ( isProcessingVideo( attachment ) ) {
+			if (
+				attachment.get( 'type' ) === 'video' &&
+				attachment.get( 'subtype' ) === 'videopress' &&
+				attachment.get( 'videopress_status' ) &&
+				attachment.get( 'videopress_status' ) !== 'complete'
+			) {
 				ids.push( attachment.get( 'id' ) );
 			}
 		} );
@@ -49,25 +39,27 @@
 		}
 	} );
 
-	// Speed up heartbeat when a video upload completes so processing status
-	// is detected quickly. The heartbeat-send handler reverts to 'standard'
-	// once no processing videos remain.
+	// Speed up heartbeat when a video is uploaded so processing status
+	// is polled quickly. wp.Uploader.queue fires 'add' as soon as an
+	// upload starts, with the file's MIME type available.
+	if ( wp.Uploader ) {
+		wp.Uploader.queue.on( 'add', function ( attachment ) {
+			const file = attachment.get( 'file' );
+			if ( file && /^video\//.test( file.type ) ) {
+				wp.heartbeat.interval( 'fast' );
+				wp.heartbeat.connectNow();
+			}
+		} );
+	}
+
+	// Also kick off fast polling if videos were already processing on
+	// page load. The media frame isn't available immediately, so poll
+	// until it is.
 	const bootCheck = setInterval( function () {
 		if ( ! wp.media.frame || ! wp.media.frame.state() ) {
 			return;
 		}
 		clearInterval( bootCheck );
-
-		const library = wp.media.frame.state().get( 'library' );
-		if ( ! library ) {
-			return;
-		}
-
-		library.on( 'add', function ( attachment ) {
-			if ( attachment.get( 'type' ) === 'video' ) {
-				wp.heartbeat.interval( 'fast' );
-			}
-		} );
 
 		if ( getProcessingVideoIds().length ) {
 			wp.heartbeat.interval( 'fast' );

--- a/projects/packages/videopress/src/js/media-library-poll.js
+++ b/projects/packages/videopress/src/js/media-library-poll.js
@@ -49,9 +49,11 @@
 		}
 	} );
 
-	// Speed up heartbeat as soon as a processing video is uploaded.
+	// Speed up heartbeat when a video upload completes so processing status
+	// is detected quickly. The heartbeat-send handler reverts to 'standard'
+	// once no processing videos remain.
 	const bootCheck = setInterval( function () {
-		if ( ! wp.media.frame ) {
+		if ( ! wp.media.frame || ! wp.media.frame.state() ) {
 			return;
 		}
 		clearInterval( bootCheck );
@@ -62,12 +64,11 @@
 		}
 
 		library.on( 'add', function ( attachment ) {
-			if ( isProcessingVideo( attachment ) ) {
+			if ( attachment.get( 'type' ) === 'video' ) {
 				wp.heartbeat.interval( 'fast' );
 			}
 		} );
 
-		// Also kick off fast polling if videos were already processing on page load.
 		if ( getProcessingVideoIds().length ) {
 			wp.heartbeat.interval( 'fast' );
 		}

--- a/projects/packages/videopress/src/js/test/media-library-poll.js
+++ b/projects/packages/videopress/src/js/test/media-library-poll.js
@@ -55,6 +55,7 @@ beforeEach( () => {
 	global.wp = {
 		media: { frame: null },
 		ajax: { send: jest.fn() },
+		heartbeat: { interval: jest.fn() },
 	};
 } );
 
@@ -121,6 +122,38 @@ describe( 'heartbeat-send', () => {
 		handlers[ 'heartbeat-send' ]( {}, data );
 
 		expect( data.videopress_processing_ids ).toBeUndefined();
+	} );
+
+	it( 'speeds up heartbeat when videos are processing', () => {
+		setupLibrary( [
+			createAttachment( {
+				id: 10,
+				type: 'video',
+				subtype: 'videopress',
+				videopress_status: 'processing',
+			} ),
+		] );
+		loadScript();
+
+		handlers[ 'heartbeat-send' ]( {}, {} );
+
+		expect( global.wp.heartbeat.interval ).toHaveBeenCalledWith( 'fast' );
+	} );
+
+	it( 'restores standard heartbeat when no videos are processing', () => {
+		setupLibrary( [
+			createAttachment( {
+				id: 10,
+				type: 'video',
+				subtype: 'videopress',
+				videopress_status: 'complete',
+			} ),
+		] );
+		loadScript();
+
+		handlers[ 'heartbeat-send' ]( {}, {} );
+
+		expect( global.wp.heartbeat.interval ).toHaveBeenCalledWith( 'standard' );
 	} );
 
 	it( 'handles missing media frame gracefully', () => {

--- a/projects/packages/videopress/src/js/test/media-library-poll.js
+++ b/projects/packages/videopress/src/js/test/media-library-poll.js
@@ -1,6 +1,6 @@
 let handlers;
 let mockLibrary;
-let libraryListeners;
+let queueListeners;
 
 /**
  * Creates a mock Backbone attachment model.
@@ -21,15 +21,11 @@ function createAttachment( attrs ) {
  * @param {Array} attachments - Array of mock attachment models.
  */
 function setupLibrary( attachments ) {
-	libraryListeners = {};
 	mockLibrary = {
 		each: jest.fn( cb => attachments.forEach( cb ) ),
 		get: jest.fn( id => {
 			// Backbone's collection.get coerces types; $.each object keys are strings.
 			return attachments.find( a => String( a.get( 'id' ) ) === String( id ) ) || null;
-		} ),
-		on: jest.fn( ( event, cb ) => {
-			libraryListeners[ event ] = cb;
 		} ),
 	};
 
@@ -45,6 +41,7 @@ beforeEach( () => {
 	jest.useFakeTimers();
 
 	handlers = {};
+	queueListeners = {};
 
 	// Mock jQuery: capture event handlers registered via $(document).on().
 	const $ = jest.fn( () => ( {
@@ -57,11 +54,18 @@ beforeEach( () => {
 	};
 	global.jQuery = $;
 
-	// Mock wp global.
+	// Mock wp global with Uploader queue.
 	global.wp = {
 		media: { frame: null },
 		ajax: { send: jest.fn() },
-		heartbeat: { interval: jest.fn() },
+		heartbeat: { interval: jest.fn(), connectNow: jest.fn() },
+		Uploader: {
+			queue: {
+				on: jest.fn( ( event, cb ) => {
+					queueListeners[ event ] = cb;
+				} ),
+			},
+		},
 	};
 } );
 
@@ -77,24 +81,22 @@ function loadScript() {
 }
 
 describe( 'upload detection', () => {
-	it( 'speeds up heartbeat when a video upload is added to the library', () => {
-		setupLibrary( [] );
+	it( 'speeds up heartbeat and connects immediately on video upload', () => {
 		loadScript();
-		jest.advanceTimersByTime( 500 );
 
-		libraryListeners.add( createAttachment( { type: 'video' } ) );
+		queueListeners.add( createAttachment( { file: { type: 'video/mp4' } } ) );
 
 		expect( global.wp.heartbeat.interval ).toHaveBeenCalledWith( 'fast' );
+		expect( global.wp.heartbeat.connectNow ).toHaveBeenCalled();
 	} );
 
 	it( 'ignores non-video uploads', () => {
-		setupLibrary( [] );
 		loadScript();
-		jest.advanceTimersByTime( 500 );
 
-		libraryListeners.add( createAttachment( { type: 'image' } ) );
+		queueListeners.add( createAttachment( { file: { type: 'image/jpeg' } } ) );
 
 		expect( global.wp.heartbeat.interval ).not.toHaveBeenCalled();
+		expect( global.wp.heartbeat.connectNow ).not.toHaveBeenCalled();
 	} );
 
 	it( 'sets fast heartbeat when processing videos exist at load', () => {

--- a/projects/packages/videopress/src/js/test/media-library-poll.js
+++ b/projects/packages/videopress/src/js/test/media-library-poll.js
@@ -1,0 +1,212 @@
+let handlers;
+let mockLibrary;
+
+/**
+ * Creates a mock Backbone attachment model.
+ *
+ * @param {object} attrs - Attachment attributes.
+ * @return {object} Mock attachment model.
+ */
+function createAttachment( attrs ) {
+	return {
+		get: key => attrs[ key ],
+		set: jest.fn(),
+	};
+}
+
+/**
+ * Sets up the mock media library with the given attachments.
+ *
+ * @param {Array} attachments - Array of mock attachment models.
+ */
+function setupLibrary( attachments ) {
+	mockLibrary = {
+		each: jest.fn( cb => attachments.forEach( cb ) ),
+		get: jest.fn( id => {
+			// Backbone's collection.get coerces types; $.each object keys are strings.
+			return attachments.find( a => String( a.get( 'id' ) ) === String( id ) ) || null;
+		} ),
+	};
+
+	global.wp.media.frame = {
+		state: () => ( {
+			get: key => ( key === 'library' ? mockLibrary : null ),
+		} ),
+	};
+}
+
+beforeEach( () => {
+	jest.resetModules();
+
+	handlers = {};
+
+	// Mock jQuery: capture event handlers registered via $(document).on().
+	const $ = jest.fn( () => ( {
+		on: ( event, handler ) => {
+			handlers[ event ] = handler;
+		},
+	} ) );
+	$.each = ( obj, cb ) => {
+		Object.keys( obj ).forEach( key => cb( key, obj[ key ] ) );
+	};
+	global.jQuery = $;
+
+	// Mock wp global.
+	global.wp = {
+		media: { frame: null },
+		ajax: { send: jest.fn() },
+	};
+} );
+
+/**
+ * Loads the media-library-poll script, triggering the IIFE.
+ */
+function loadScript() {
+	require( '../media-library-poll' );
+}
+
+describe( 'heartbeat-send', () => {
+	it( 'adds processing video IDs to heartbeat data', () => {
+		setupLibrary( [
+			createAttachment( {
+				id: 10,
+				type: 'video',
+				subtype: 'videopress',
+				videopress_status: 'processing',
+			} ),
+			createAttachment( {
+				id: 20,
+				type: 'video',
+				subtype: 'videopress',
+				videopress_status: 'complete',
+			} ),
+		] );
+		loadScript();
+
+		const data = {};
+		handlers[ 'heartbeat-send' ]( {}, data );
+
+		expect( data.videopress_processing_ids ).toEqual( [ 10 ] );
+	} );
+
+	it( 'does not add IDs when no videos are processing', () => {
+		setupLibrary( [
+			createAttachment( {
+				id: 10,
+				type: 'video',
+				subtype: 'videopress',
+				videopress_status: 'complete',
+			} ),
+		] );
+		loadScript();
+
+		const data = {};
+		handlers[ 'heartbeat-send' ]( {}, data );
+
+		expect( data.videopress_processing_ids ).toBeUndefined();
+	} );
+
+	it( 'skips non-videopress videos', () => {
+		setupLibrary( [
+			createAttachment( {
+				id: 10,
+				type: 'video',
+				subtype: 'mp4',
+				videopress_status: undefined,
+			} ),
+		] );
+		loadScript();
+
+		const data = {};
+		handlers[ 'heartbeat-send' ]( {}, data );
+
+		expect( data.videopress_processing_ids ).toBeUndefined();
+	} );
+
+	it( 'handles missing media frame gracefully', () => {
+		loadScript();
+
+		const data = {};
+		handlers[ 'heartbeat-send' ]( {}, data );
+
+		expect( data.videopress_processing_ids ).toBeUndefined();
+	} );
+} );
+
+describe( 'heartbeat-tick', () => {
+	it( 'fetches attachment data when status becomes complete', () => {
+		const attachment = createAttachment( {
+			id: 10,
+			type: 'video',
+			subtype: 'videopress',
+			videopress_status: 'processing',
+		} );
+		setupLibrary( [ attachment ] );
+
+		const deferred = {
+			done: jest.fn( cb => {
+				cb( { id: 10, icon: 'new-icon.png' } );
+				return deferred;
+			} ),
+		};
+		global.wp.ajax.send.mockReturnValue( deferred );
+
+		loadScript();
+
+		handlers[ 'heartbeat-tick' ](
+			{},
+			{
+				videopress_processing_status: { 10: 'complete' },
+			}
+		);
+
+		expect( global.wp.ajax.send ).toHaveBeenCalledWith( 'get-attachment', {
+			data: { id: '10' },
+		} );
+		expect( attachment.set ).toHaveBeenCalledWith( { id: 10, icon: 'new-icon.png' } );
+	} );
+
+	it( 'does not fetch when status is still processing', () => {
+		const attachment = createAttachment( {
+			id: 10,
+			type: 'video',
+			subtype: 'videopress',
+			videopress_status: 'processing',
+		} );
+		setupLibrary( [ attachment ] );
+
+		loadScript();
+
+		handlers[ 'heartbeat-tick' ](
+			{},
+			{
+				videopress_processing_status: { 10: 'processing' },
+			}
+		);
+
+		expect( global.wp.ajax.send ).not.toHaveBeenCalled();
+	} );
+
+	it( 'ignores response without processing status data', () => {
+		loadScript();
+
+		// Should not throw.
+		handlers[ 'heartbeat-tick' ]( {}, {} );
+
+		expect( global.wp.ajax.send ).not.toHaveBeenCalled();
+	} );
+
+	it( 'handles missing media frame gracefully on tick', () => {
+		loadScript();
+
+		// Should not throw even with status data but no frame.
+		handlers[ 'heartbeat-tick' ](
+			{},
+			{
+				videopress_processing_status: { 10: 'complete' },
+			}
+		);
+
+		expect( global.wp.ajax.send ).not.toHaveBeenCalled();
+	} );
+} );

--- a/projects/packages/videopress/src/js/test/media-library-poll.js
+++ b/projects/packages/videopress/src/js/test/media-library-poll.js
@@ -76,7 +76,27 @@ function loadScript() {
 	require( '../media-library-poll' );
 }
 
-describe( 'boot check', () => {
+describe( 'upload detection', () => {
+	it( 'speeds up heartbeat when a video upload is added to the library', () => {
+		setupLibrary( [] );
+		loadScript();
+		jest.advanceTimersByTime( 500 );
+
+		libraryListeners.add( createAttachment( { type: 'video' } ) );
+
+		expect( global.wp.heartbeat.interval ).toHaveBeenCalledWith( 'fast' );
+	} );
+
+	it( 'ignores non-video uploads', () => {
+		setupLibrary( [] );
+		loadScript();
+		jest.advanceTimersByTime( 500 );
+
+		libraryListeners.add( createAttachment( { type: 'image' } ) );
+
+		expect( global.wp.heartbeat.interval ).not.toHaveBeenCalled();
+	} );
+
 	it( 'sets fast heartbeat when processing videos exist at load', () => {
 		setupLibrary( [
 			createAttachment( {
@@ -87,36 +107,16 @@ describe( 'boot check', () => {
 			} ),
 		] );
 		loadScript();
-
 		jest.advanceTimersByTime( 500 );
 
 		expect( global.wp.heartbeat.interval ).toHaveBeenCalledWith( 'fast' );
-	} );
-
-	it( 'does not set fast heartbeat when no videos are processing', () => {
-		setupLibrary( [
-			createAttachment( {
-				id: 10,
-				type: 'video',
-				subtype: 'videopress',
-				videopress_status: 'complete',
-			} ),
-		] );
-		loadScript();
-
-		jest.advanceTimersByTime( 500 );
-
-		expect( global.wp.heartbeat.interval ).not.toHaveBeenCalled();
 	} );
 
 	it( 'waits for media frame before checking', () => {
 		loadScript();
-
-		// Frame not yet available — heartbeat should not be called.
 		jest.advanceTimersByTime( 500 );
 		expect( global.wp.heartbeat.interval ).not.toHaveBeenCalled();
 
-		// Frame becomes available with a processing video.
 		setupLibrary( [
 			createAttachment( {
 				id: 10,
@@ -128,44 +128,6 @@ describe( 'boot check', () => {
 		jest.advanceTimersByTime( 500 );
 
 		expect( global.wp.heartbeat.interval ).toHaveBeenCalledWith( 'fast' );
-	} );
-
-	it( 'speeds up heartbeat when a processing upload is added to the library', () => {
-		setupLibrary( [] );
-		loadScript();
-
-		jest.advanceTimersByTime( 500 );
-		expect( global.wp.heartbeat.interval ).not.toHaveBeenCalled();
-
-		// Simulate a new upload landing in the library.
-		libraryListeners.add(
-			createAttachment( {
-				id: 30,
-				type: 'video',
-				subtype: 'videopress',
-				videopress_status: 'processing',
-			} )
-		);
-
-		expect( global.wp.heartbeat.interval ).toHaveBeenCalledWith( 'fast' );
-	} );
-
-	it( 'ignores non-processing uploads added to the library', () => {
-		setupLibrary( [] );
-		loadScript();
-
-		jest.advanceTimersByTime( 500 );
-
-		libraryListeners.add(
-			createAttachment( {
-				id: 30,
-				type: 'image',
-				subtype: 'jpeg',
-				videopress_status: undefined,
-			} )
-		);
-
-		expect( global.wp.heartbeat.interval ).not.toHaveBeenCalled();
 	} );
 } );
 

--- a/projects/packages/videopress/src/js/test/media-library-poll.js
+++ b/projects/packages/videopress/src/js/test/media-library-poll.js
@@ -260,6 +260,7 @@ describe( 'heartbeat-tick', () => {
 			}
 		);
 
+		expect( attachment.set ).toHaveBeenCalledWith( 'videopress_status', 'complete' );
 		expect( global.wp.ajax.send ).toHaveBeenCalledWith( 'get-attachment', {
 			data: { id: '10' },
 		} );

--- a/projects/packages/videopress/src/js/test/media-library-poll.js
+++ b/projects/packages/videopress/src/js/test/media-library-poll.js
@@ -1,5 +1,6 @@
 let handlers;
 let mockLibrary;
+let libraryListeners;
 
 /**
  * Creates a mock Backbone attachment model.
@@ -20,11 +21,15 @@ function createAttachment( attrs ) {
  * @param {Array} attachments - Array of mock attachment models.
  */
 function setupLibrary( attachments ) {
+	libraryListeners = {};
 	mockLibrary = {
 		each: jest.fn( cb => attachments.forEach( cb ) ),
 		get: jest.fn( id => {
 			// Backbone's collection.get coerces types; $.each object keys are strings.
 			return attachments.find( a => String( a.get( 'id' ) ) === String( id ) ) || null;
+		} ),
+		on: jest.fn( ( event, cb ) => {
+			libraryListeners[ event ] = cb;
 		} ),
 	};
 
@@ -37,6 +42,7 @@ function setupLibrary( attachments ) {
 
 beforeEach( () => {
 	jest.resetModules();
+	jest.useFakeTimers();
 
 	handlers = {};
 
@@ -59,12 +65,109 @@ beforeEach( () => {
 	};
 } );
 
+afterEach( () => {
+	jest.useRealTimers();
+} );
+
 /**
  * Loads the media-library-poll script, triggering the IIFE.
  */
 function loadScript() {
 	require( '../media-library-poll' );
 }
+
+describe( 'boot check', () => {
+	it( 'sets fast heartbeat when processing videos exist at load', () => {
+		setupLibrary( [
+			createAttachment( {
+				id: 10,
+				type: 'video',
+				subtype: 'videopress',
+				videopress_status: 'processing',
+			} ),
+		] );
+		loadScript();
+
+		jest.advanceTimersByTime( 500 );
+
+		expect( global.wp.heartbeat.interval ).toHaveBeenCalledWith( 'fast' );
+	} );
+
+	it( 'does not set fast heartbeat when no videos are processing', () => {
+		setupLibrary( [
+			createAttachment( {
+				id: 10,
+				type: 'video',
+				subtype: 'videopress',
+				videopress_status: 'complete',
+			} ),
+		] );
+		loadScript();
+
+		jest.advanceTimersByTime( 500 );
+
+		expect( global.wp.heartbeat.interval ).not.toHaveBeenCalled();
+	} );
+
+	it( 'waits for media frame before checking', () => {
+		loadScript();
+
+		// Frame not yet available — heartbeat should not be called.
+		jest.advanceTimersByTime( 500 );
+		expect( global.wp.heartbeat.interval ).not.toHaveBeenCalled();
+
+		// Frame becomes available with a processing video.
+		setupLibrary( [
+			createAttachment( {
+				id: 10,
+				type: 'video',
+				subtype: 'videopress',
+				videopress_status: 'processing',
+			} ),
+		] );
+		jest.advanceTimersByTime( 500 );
+
+		expect( global.wp.heartbeat.interval ).toHaveBeenCalledWith( 'fast' );
+	} );
+
+	it( 'speeds up heartbeat when a processing upload is added to the library', () => {
+		setupLibrary( [] );
+		loadScript();
+
+		jest.advanceTimersByTime( 500 );
+		expect( global.wp.heartbeat.interval ).not.toHaveBeenCalled();
+
+		// Simulate a new upload landing in the library.
+		libraryListeners.add(
+			createAttachment( {
+				id: 30,
+				type: 'video',
+				subtype: 'videopress',
+				videopress_status: 'processing',
+			} )
+		);
+
+		expect( global.wp.heartbeat.interval ).toHaveBeenCalledWith( 'fast' );
+	} );
+
+	it( 'ignores non-processing uploads added to the library', () => {
+		setupLibrary( [] );
+		loadScript();
+
+		jest.advanceTimersByTime( 500 );
+
+		libraryListeners.add(
+			createAttachment( {
+				id: 30,
+				type: 'image',
+				subtype: 'jpeg',
+				videopress_status: undefined,
+			} )
+		);
+
+		expect( global.wp.heartbeat.interval ).not.toHaveBeenCalled();
+	} );
+} );
 
 describe( 'heartbeat-send', () => {
 	it( 'adds processing video IDs to heartbeat data', () => {

--- a/projects/packages/videopress/tests/php/Attachment_Handler_Test.php
+++ b/projects/packages/videopress/tests/php/Attachment_Handler_Test.php
@@ -1,0 +1,172 @@
+<?php
+/**
+ * Tests for Automattic\Jetpack\VideoPress\Attachment_Handler
+ *
+ * @package automattic/jetpack-videopress
+ */
+
+namespace Automattic\Jetpack\VideoPress;
+
+use WorDBless\BaseTestCase;
+
+/**
+ * Class Attachment_Handler_Test
+ */
+class Attachment_Handler_Test extends BaseTestCase {
+
+	/**
+	 * Clean up after each test.
+	 */
+	public function tear_down() {
+		\WorDBless\Posts::init()->clear_all_posts();
+		parent::tear_down();
+	}
+
+	/**
+	 * Test that prepare_attachment_for_js includes videopress_status when set.
+	 */
+	public function test_prepare_attachment_for_js_includes_videopress_status() {
+		$post_id = wp_insert_post(
+			array(
+				'post_type'      => 'attachment',
+				'post_mime_type' => 'video/videopress',
+				'post_title'     => 'Test video',
+			)
+		);
+		add_post_meta( $post_id, 'videopress_guid', 'abc123' );
+		add_post_meta( $post_id, 'videopress_status', 'processing' );
+
+		$post   = array(
+			'id'   => $post_id,
+			'type' => 'video',
+		);
+		$result = Attachment_Handler::prepare_attachment_for_js( $post );
+
+		$this->assertSame( 'abc123', $result['videopress_guid'] );
+		$this->assertSame( 'processing', $result['videopress_status'] );
+	}
+
+	/**
+	 * Test that prepare_attachment_for_js omits videopress_status when empty.
+	 */
+	public function test_prepare_attachment_for_js_omits_empty_videopress_status() {
+		$post_id = wp_insert_post(
+			array(
+				'post_type'      => 'attachment',
+				'post_mime_type' => 'video/videopress',
+				'post_title'     => 'Test video',
+			)
+		);
+		add_post_meta( $post_id, 'videopress_guid', 'abc123' );
+
+		$post   = array(
+			'id'   => $post_id,
+			'type' => 'video',
+		);
+		$result = Attachment_Handler::prepare_attachment_for_js( $post );
+
+		$this->assertSame( 'abc123', $result['videopress_guid'] );
+		$this->assertArrayNotHasKey( 'videopress_status', $result );
+	}
+
+	/**
+	 * Test that prepare_attachment_for_js skips non-video attachments.
+	 */
+	public function test_prepare_attachment_for_js_skips_non_video() {
+		$post = array(
+			'id'   => 1,
+			'type' => 'image',
+		);
+
+		$result = Attachment_Handler::prepare_attachment_for_js( $post );
+
+		$this->assertArrayNotHasKey( 'videopress_guid', $result );
+		$this->assertArrayNotHasKey( 'videopress_status', $result );
+	}
+
+	/**
+	 * Test that heartbeat_received returns statuses for requested IDs.
+	 */
+	public function test_heartbeat_received_returns_statuses() {
+		$post_id = wp_insert_post(
+			array(
+				'post_type'      => 'attachment',
+				'post_mime_type' => 'video/videopress',
+				'post_title'     => 'Test video',
+			)
+		);
+		add_post_meta( $post_id, 'videopress_status', 'complete' );
+
+		$result = Attachment_Handler::heartbeat_received(
+			array(),
+			array( 'videopress_processing_ids' => array( $post_id ) )
+		);
+
+		$this->assertArrayHasKey( 'videopress_processing_status', $result );
+		$this->assertSame( 'complete', $result['videopress_processing_status'][ $post_id ] );
+	}
+
+	/**
+	 * Test that heartbeat_received returns unchanged response when no IDs provided.
+	 */
+	public function test_heartbeat_received_ignores_missing_ids() {
+		$result = Attachment_Handler::heartbeat_received( array( 'existing' => true ), array() );
+
+		$this->assertArrayNotHasKey( 'videopress_processing_status', $result );
+		$this->assertTrue( $result['existing'] );
+	}
+
+	/**
+	 * Test that heartbeat_received rejects non-array IDs.
+	 */
+	public function test_heartbeat_received_rejects_non_array_ids() {
+		$result = Attachment_Handler::heartbeat_received(
+			array(),
+			array( 'videopress_processing_ids' => 'not-an-array' )
+		);
+
+		$this->assertArrayNotHasKey( 'videopress_processing_status', $result );
+	}
+
+	/**
+	 * Test that heartbeat_received casts IDs to integers.
+	 */
+	public function test_heartbeat_received_casts_ids_to_int() {
+		$post_id = wp_insert_post(
+			array(
+				'post_type'      => 'attachment',
+				'post_mime_type' => 'video/videopress',
+				'post_title'     => 'Test video',
+			)
+		);
+		add_post_meta( $post_id, 'videopress_status', 'processing' );
+
+		$result = Attachment_Handler::heartbeat_received(
+			array(),
+			array( 'videopress_processing_ids' => array( (string) $post_id ) )
+		);
+
+		$this->assertArrayHasKey( $post_id, $result['videopress_processing_status'] );
+		$this->assertSame( 'processing', $result['videopress_processing_status'][ $post_id ] );
+	}
+
+	/**
+	 * Test that heartbeat_received omits IDs with no status meta.
+	 */
+	public function test_heartbeat_received_omits_ids_without_status() {
+		$post_id = wp_insert_post(
+			array(
+				'post_type'      => 'attachment',
+				'post_mime_type' => 'video/videopress',
+				'post_title'     => 'Test video',
+			)
+		);
+
+		$result = Attachment_Handler::heartbeat_received(
+			array(),
+			array( 'videopress_processing_ids' => array( $post_id ) )
+		);
+
+		$this->assertArrayNotHasKey( 'videopress_processing_status', $result );
+	}
+}

--- a/projects/packages/videopress/tests/php/Attachment_Handler_Test.php
+++ b/projects/packages/videopress/tests/php/Attachment_Handler_Test.php
@@ -85,6 +85,15 @@ class Attachment_Handler_Test extends BaseTestCase {
 	}
 
 	/**
+	 * Test that enqueue_media_library_poll registers the script.
+	 */
+	public function test_enqueue_media_library_poll_registers_script() {
+		Attachment_Handler::enqueue_media_library_poll();
+
+		$this->assertTrue( wp_script_is( 'videopress-media-library-poll', 'enqueued' ) );
+	}
+
+	/**
 	 * Test that heartbeat_received returns statuses for requested IDs.
 	 */
 	public function test_heartbeat_received_returns_statuses() {

--- a/projects/packages/videopress/tests/php/Attachment_Handler_Test.php
+++ b/projects/packages/videopress/tests/php/Attachment_Handler_Test.php
@@ -94,6 +94,15 @@ class Attachment_Handler_Test extends BaseTestCase {
 	}
 
 	/**
+	 * Test that heartbeat_settings lowers the minimal interval.
+	 */
+	public function test_heartbeat_settings_lowers_minimal_interval() {
+		$settings = Attachment_Handler::heartbeat_settings( array() );
+
+		$this->assertSame( 10, $settings['minimalInterval'] );
+	}
+
+	/**
 	 * Test that heartbeat_received returns statuses for requested IDs.
 	 */
 	public function test_heartbeat_received_returns_statuses() {

--- a/projects/packages/videopress/tests/php/Attachment_Handler_Test.php
+++ b/projects/packages/videopress/tests/php/Attachment_Handler_Test.php
@@ -99,7 +99,7 @@ class Attachment_Handler_Test extends BaseTestCase {
 	public function test_heartbeat_settings_lowers_minimal_interval() {
 		$settings = Attachment_Handler::heartbeat_settings( array() );
 
-		$this->assertSame( 10, $settings['minimalInterval'] );
+		$this->assertSame( 5, $settings['minimalInterval'] );
 	}
 
 	/**

--- a/projects/packages/videopress/tests/php/Attachment_Handler_Test.php
+++ b/projects/packages/videopress/tests/php/Attachment_Handler_Test.php
@@ -94,6 +94,22 @@ class Attachment_Handler_Test extends BaseTestCase {
 	}
 
 	/**
+	 * Test that enqueue_media_library_styles adds inline CSS to media-views.
+	 */
+	public function test_enqueue_media_library_styles_adds_inline_css() {
+		wp_register_style( 'media-views', false, array(), '1.0' );
+
+		Attachment_Handler::enqueue_media_library_styles();
+
+		$data = wp_styles()->get_data( 'media-views', 'after' );
+		$this->assertIsArray( $data );
+		$this->assertStringContainsString( 'max-width: 100%', $data[0] );
+		$this->assertStringContainsString( 'max-height: 100%', $data[0] );
+
+		wp_deregister_style( 'media-views' );
+	}
+
+	/**
 	 * Test that heartbeat_settings lowers the minimal interval.
 	 */
 	public function test_heartbeat_settings_lowers_minimal_interval() {

--- a/projects/packages/videopress/tests/php/Data_Test.php
+++ b/projects/packages/videopress/tests/php/Data_Test.php
@@ -24,6 +24,13 @@ class Data_Test extends BaseTestCase {
 	private $captured_query;
 
 	/**
+	 * VideoPress REST API data instance.
+	 *
+	 * @var WPCOM_REST_API_V2_Attachment_VideoPress_Data
+	 */
+	private static $videopress_rest_data;
+
+	/**
 	 * Set up once before all tests in this class.
 	 */
 	public static function set_up_before_class() {
@@ -34,8 +41,7 @@ class Data_Test extends BaseTestCase {
 
 		// Initialize VideoPress components once for all tests.
 		Attachment_Handler::init();
-		new WPCOM_REST_API_V2_Attachment_VideoPress_Data();
-		do_action( 'rest_api_init' );
+		self::$videopress_rest_data = new WPCOM_REST_API_V2_Attachment_VideoPress_Data();
 	}
 
 	/**
@@ -45,6 +51,11 @@ class Data_Test extends BaseTestCase {
 		parent::set_up();
 
 		$this->captured_query = null;
+
+		// WorDBless resets hooks between tests, so re-register the
+		// rest_attachment_query filter and REST fields each test.
+		self::$videopress_rest_data->register_fields();
+		self::$videopress_rest_data->add_jetpack_videopress_custom_query_filters();
 
 		// Use high priority to capture before other filters might short-circuit.
 		add_filter( 'posts_pre_query', array( $this, 'capture_query' ), 10, 2 );

--- a/projects/plugins/jetpack/changelog/add-vidp-175-videopress-media-library-does-not-refresh-the-processing
+++ b/projects/plugins/jetpack/changelog/add-vidp-175-videopress-media-library-does-not-refresh-the-processing
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Fix phpdoc type for deprecated videopress_prepare_attachment_for_js wrapper.

--- a/projects/plugins/jetpack/modules/videopress/editor-media-view.php
+++ b/projects/plugins/jetpack/modules/videopress/editor-media-view.php
@@ -127,7 +127,7 @@ function videopress_media_list_table_query( $query ) {
 /**
  * Make sure that any Video that has a VideoPress GUID passes that data back.
  *
- * @param WP_Post $post Attachment object.
+ * @param array $post Attachment data array.
  * @deprecated 11.4
  */
 function videopress_prepare_attachment_for_js( $post ) {


### PR DESCRIPTION
Fixes https://github.com/Automattic/videopress/issues/1220

## Proposed changes:

* Pass `videopress_status` post meta through `wp_prepare_attachment_for_js` so the Backbone model knows which videos are still processing.
* Add a WP Heartbeat integration that sends processing video IDs on each tick and receives their current status from the server.
* When a video's status becomes `complete`, refetch the full attachment data via `get-attachment` AJAX, updating the Backbone model and re-rendering the grid item automatically.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

* Go to `/wp-admin/upload.php` (Media Library grid view).
* Upload a video file that VideoPress will process.
* Observe the processing icon/thumbnail in the grid.
* Wait for transcoding to complete on the WordPress.com backend (the XMLRPC callback will update `videopress_status` to `complete`).
* Confirm the grid item updates automatically without a manual page refresh — the processing icon should be replaced by the normal video thumbnail.
* Confirm that once all videos are complete, the Heartbeat no longer includes `videopress_processing_ids` in its payload (check Network tab for `admin-ajax.php` heartbeat requests).

## Changelog

Changelog entry included in `projects/packages/videopress/changelog/fix-media-library-processing-status-refresh`.