### PR TITLE
VideoPress: Migrate admin page header to unified header pattern

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-unified-header
+++ b/projects/packages/videopress/changelog/update-videopress-unified-header
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Migrate admin page header to use unified header pattern.

--- a/projects/packages/videopress/src/client/admin/components/admin-page/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/admin-page/index.tsx
@@ -11,7 +11,6 @@ import {
 	Col,
 	useBreakpointMatch,
 	ContextualUpgradeTrigger,
-	JetpackVideoPressLogo,
 } from '@automattic/jetpack-components';
 import {
 	useProductCheckoutWorkflow,
@@ -194,7 +193,7 @@ const Admin = () => {
 	return (
 		<AdminPage
 			moduleName={ __( 'Jetpack VideoPress', 'jetpack-videopress-pkg' ) }
-			header={ <JetpackVideoPressLogo /> }
+			title={ __( 'VideoPress', 'jetpack-videopress-pkg' ) }
 			useInternalLinks={ shouldUseInternalLinks() }
 		>
 			<div


### PR DESCRIPTION
Part of the [Standardize the Jetpack Header](https://linear.app/a8c/project/standardize-the-jetpack-header-a1cb7d275fe3) project.

## Proposed changes:
* Replace `JetpackVideoPressLogo` header with the new `AdminPage` `title` prop, rendering the standard admin-ui Page header with the Jetpack bolt logo and "VideoPress" title.
* Remove unused `JetpackVideoPressLogo` import.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:

* Build the videopress package: `jetpack build packages/videopress --deps`
* Open the VideoPress admin page (Jetpack → VideoPress)
* Verify the header displays:
  * Jetpack bolt logo (small, 20px)
  * "VideoPress" title
* Verify the page content (video library, upload area, settings) still renders correctly
* Verify footer still renders correctly

## Changelog
VideoPress changelog entry included.