### PR TITLE
Backup: Migrate admin page header to unified header pattern

### DIFF
--- a/projects/packages/backup/changelog/update-backup-unified-header
+++ b/projects/packages/backup/changelog/update-backup-unified-header
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Migrate admin page header to use unified header pattern.

--- a/projects/packages/backup/src/js/components/Admin/header-actions.js
+++ b/projects/packages/backup/src/js/components/Admin/header-actions.js
@@ -1,4 +1,3 @@
-import { JetpackVaultPressBackupLogo } from '@automattic/jetpack-components';
 import { useSelect } from '@wordpress/data';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -10,22 +9,23 @@ import { useShowBackUpNow } from '../back-up-now/hooks';
 import { BackupNowButton } from '../back-up-now/index';
 import { useIsFullyConnected } from './hooks';
 
-const Header = () => {
+const HeaderActions = () => {
 	const showActivateLicenseLink = useShowActivateLicenseLink();
 	const showBackUpNowButton = useShowBackUpNow();
 
+	if ( ! showActivateLicenseLink && ! showBackUpNowButton ) {
+		return null;
+	}
+
 	return (
-		<div className="jetpack-admin-page__header">
-			<span className="jetpack-admin-page__logo">
-				<JetpackVaultPressBackupLogo />
-			</span>
+		<>
 			{ showActivateLicenseLink && <ActivateLicenseLink /> }
 			{ showBackUpNowButton && (
 				<BackupNowButton variant="primary" tracksEventName="jetpack_backup_plugin_backup_now">
 					{ __( 'Back up now', 'jetpack-backup-pkg' ) }
 				</BackupNowButton>
 			) }
-		</div>
+		</>
 	);
 };
 
@@ -78,4 +78,4 @@ const ActivateLicenseLink = () => {
 	);
 };
 
-export default Header;
+export default HeaderActions;

--- a/projects/packages/backup/src/js/components/Admin/index.js
+++ b/projects/packages/backup/src/js/components/Admin/index.js
@@ -22,7 +22,7 @@ import { BackupConnectionScreen } from '../backup-connection-screen';
 import { BackupSecondaryAdminConnectionScreen } from '../backup-connection-screen/secondary-admin';
 import BackupStorageSpace from '../backup-storage-space';
 import ReviewRequest from '../review-request';
-import Header from './header';
+import HeaderActions from './header-actions';
 import {
 	useIsFullyConnected,
 	useIsSecondaryAdminNotConnected,
@@ -79,7 +79,8 @@ const Admin = () => {
 			showHeader
 			showFooter
 			moduleName={ __( 'VaultPress Backup', 'jetpack-backup-pkg' ) }
-			header={ <Header /> }
+			title={ __( 'VaultPress Backup', 'jetpack-backup-pkg' ) }
+			actions={ <HeaderActions /> }
 			useInternalLinks={ shouldUseInternalLinks() }
 		>
 			<div id="jetpack-backup-admin-container" className="jp-content">


### PR DESCRIPTION
Part of the [Standardize the Jetpack Header](https://linear.app/a8c/project/standardize-the-jetpack-header-a1cb7d275fe3) project.

## Proposed changes:
* Replace the custom `Header` component (VaultPress Backup logo + action buttons) with the new `AdminPage` `title` and `actions` props.
* `title` renders the standard admin-ui Page header with the Jetpack bolt logo and "VaultPress Backup" title.
* `actions` renders the conditional "Activate License" link and "Back up now" button on the right side of the header.
* Rename `header.js` → `header-actions.js` (strips the logo wrapper, keeps the action hooks and components intact).

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:

* Build the backup package: `jetpack build packages/backup --deps`
* Open the VaultPress Backup admin page (Jetpack → VaultPress Backup)
* Verify the header displays:
  * Jetpack bolt logo (small, 20px)
  * "VaultPress Backup" title
* **With an active backup plan**:
  * Verify the "Back up now" button appears on the right side of the header
  * Verify the "Activate License" link does NOT appear
* **Without an active backup plan** (or not fully connected):
  * Verify the "Activate License" link appears on the right side of the header
  * Verify clicking it navigates to My Jetpack license activation
* Verify footer still renders correctly

## Changelog
Backup changelog entry included.