### PR TITLE
CHARTS-165: Fix leaderboard chart height calculation

### DIFF
--- a/projects/js-packages/charts/AGENTS.md
+++ b/projects/js-packages/charts/AGENTS.md
@@ -113,6 +113,7 @@ For docs-heavy tasks with many repeated steps, agents may use the optional skill
 - Defining new chart prop interfaces that diverge from established base chart contracts (for example, not aligning with `BaseChartProps` when appropriate).
 - Implementing responsive wrappers that conflict with component sizing semantics (fixed-height charts, resize behavior, or aspect-ratio assumptions).
 - Adding stories that do not visibly demonstrate the documented behavior/props, or stories that render clipped due to container sizing.
+- Breaking MDX `<Source code={\`...\` } />` rendering by using malformed/flattened indentation inside multiline template literals; keep consistent indentation and formatting in code blocks so docs render correctly.
 - Tooltip styles/positioning that only work on default backgrounds or fail at chart edges (for example, shadows fading to opaque white instead of transparent).
 - Using mock/placeholder series data in production code.
 - Introducing avoidable multi-pass data transformations in render paths when a single pass is sufficient.

--- a/projects/js-packages/charts/changelog/charts-165-fix-height-calculation-for-leaderboard-chart
+++ b/projects/js-packages/charts/changelog/charts-165-fix-height-calculation-for-leaderboard-chart
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Charts: Fix leaderboard chart height calculation to include legend layout and keep responsive sizing by default.

--- a/projects/js-packages/charts/src/charts/leaderboard-chart/leaderboard-chart.module.scss
+++ b/projects/js-packages/charts/src/charts/leaderboard-chart/leaderboard-chart.module.scss
@@ -6,10 +6,6 @@
 		width: 100%;
 	}
 
-	&--with-legend {
-		gap: 16px;
-	}
-
 	&--loading {
 		opacity: 0.5;
 	}

--- a/projects/js-packages/charts/src/charts/leaderboard-chart/leaderboard-chart.module.scss
+++ b/projects/js-packages/charts/src/charts/leaderboard-chart/leaderboard-chart.module.scss
@@ -1,10 +1,9 @@
 .leaderboardChart {
-	display: flex;
-	flex-direction: column;
 	transition: opacity 0.3s ease-in-out;
 
-	&--legend-top {
-		flex-direction: column-reverse;
+	&--responsive {
+		height: 100%;
+		width: 100%;
 	}
 
 	&--with-legend {
@@ -13,6 +12,11 @@
 
 	&--loading {
 		opacity: 0.5;
+	}
+
+	&__content {
+		flex: 1;
+		min-height: 0;
 	}
 }
 
@@ -61,8 +65,6 @@
 }
 
 .valueContainer {
-	display: flex;
-	gap: 4px;
 	justify-content: flex-end;
 }
 

--- a/projects/js-packages/charts/src/charts/leaderboard-chart/leaderboard-chart.module.scss
+++ b/projects/js-packages/charts/src/charts/leaderboard-chart/leaderboard-chart.module.scss
@@ -13,6 +13,7 @@
 	&__content {
 		flex: 1;
 		min-height: 0;
+		overflow: auto;
 	}
 }
 

--- a/projects/js-packages/charts/src/charts/leaderboard-chart/leaderboard-chart.tsx
+++ b/projects/js-packages/charts/src/charts/leaderboard-chart/leaderboard-chart.tsx
@@ -270,6 +270,7 @@ const LeaderboardChartInternal: FC< LeaderboardChartProps > = ( {
 						{ [ styles[ 'leaderboardChart--loading' ] ]: loading },
 						className
 					) }
+					gap={ gap }
 					style={ {
 						...style,
 						width: propWidth || undefined,

--- a/projects/js-packages/charts/src/charts/leaderboard-chart/leaderboard-chart.tsx
+++ b/projects/js-packages/charts/src/charts/leaderboard-chart/leaderboard-chart.tsx
@@ -132,6 +132,7 @@ const BarWithLabel = ( {
  * @param props.legendShapeHeight - Height of legend shapes in pixels
  * @param props.legendLabels      - Custom labels for legend items
  * @param props.legendInteractive - Whether legend items are interactive (clickable to toggle series visibility)
+ * @param props.gap               - Spacing between legend and chart content
  * @param props.children          - Child components for composition API
  * @param props.className         - Additional CSS class name
  * @param props.style             - Custom styling for the chart container
@@ -159,6 +160,7 @@ const LeaderboardChartInternal: FC< LeaderboardChartProps > = ( {
 	legendShapeHeight = 8,
 	legendLabels,
 	legendInteractive = false,
+	gap = 'md',
 	className,
 	style,
 	children,
@@ -315,10 +317,10 @@ const LeaderboardChartInternal: FC< LeaderboardChartProps > = ( {
 					{
 						[ styles[ 'leaderboardChart--responsive' ] ]: ! propWidth && ! propHeight,
 						[ styles[ 'leaderboardChart--loading' ] ]: loading,
-						[ styles[ 'leaderboardChart--with-legend' ] ]: showLegend,
 					},
 					className
 				) }
+				gap={ showLegend ? gap : undefined }
 				style={ {
 					...style,
 					width: propWidth || undefined,

--- a/projects/js-packages/charts/src/charts/leaderboard-chart/leaderboard-chart.tsx
+++ b/projects/js-packages/charts/src/charts/leaderboard-chart/leaderboard-chart.tsx
@@ -320,7 +320,7 @@ const LeaderboardChartInternal: FC< LeaderboardChartProps > = ( {
 					},
 					className
 				) }
-				gap={ showLegend ? gap : undefined }
+				gap={ gap }
 				style={ {
 					...style,
 					width: propWidth || undefined,
@@ -357,7 +357,7 @@ const LeaderboardChartInternal: FC< LeaderboardChartProps > = ( {
 
 										<Stack
 											direction="row"
-											gap={ 1 }
+											gap="xs"
 											className={ clsx( styles.valueContainer, {
 												[ styles.overlayLabel ]: withOverlayLabel,
 											} ) }

--- a/projects/js-packages/charts/src/charts/leaderboard-chart/leaderboard-chart.tsx
+++ b/projects/js-packages/charts/src/charts/leaderboard-chart/leaderboard-chart.tsx
@@ -1,11 +1,8 @@
 /* eslint-disable @wordpress/no-unsafe-wp-apis */
-import {
-	__experimentalVStack as VStack,
-	__experimentalGrid as Grid,
-	__experimentalText as Text,
-} from '@wordpress/components';
+import { __experimentalGrid as Grid, __experimentalText as Text } from '@wordpress/components';
 import { Fragment } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { Stack } from '@wordpress/ui';
 import clsx from 'clsx';
 import { useContext, useMemo, type FC } from 'react';
 import { Legend } from '../../components/legend';
@@ -116,6 +113,8 @@ const BarWithLabel = ( {
  * @param props                   - Component props
  * @param props.data              - Array of leaderboard entries to display
  * @param props.chartId           - Optional unique identifier for the chart
+ * @param props.width             - Optional width of the chart container in pixels
+ * @param props.height            - Optional height of the chart container in pixels
  * @param props.withComparison    - Whether to show comparison data
  * @param props.withOverlayLabel  - Whether to overlay the label on top of the bar
  * @param props.primaryColor      - Primary color for current period bars
@@ -141,6 +140,8 @@ const BarWithLabel = ( {
 const LeaderboardChartInternal: FC< LeaderboardChartProps > = ( {
 	data,
 	chartId: providedChartId,
+	width: propWidth,
+	height: propHeight,
 	withComparison = false,
 	withOverlayLabel = false,
 	primaryColor,
@@ -258,13 +259,20 @@ const LeaderboardChartInternal: FC< LeaderboardChartProps > = ( {
 					chartHeight: 0,
 				} }
 			>
-				<div
+				<Stack
+					direction="column"
+					data-testid="leaderboard-chart-container"
 					className={ clsx(
 						styles.leaderboardChart,
+						{ [ styles[ 'leaderboardChart--responsive' ] ]: ! propWidth && ! propHeight },
 						{ [ styles[ 'leaderboardChart--loading' ] ]: loading },
 						className
 					) }
-					style={ style }
+					style={ {
+						...style,
+						width: propWidth || undefined,
+						height: propHeight || undefined,
+					} }
 				>
 					<div className={ styles.emptyState }>
 						{ loading
@@ -273,10 +281,23 @@ const LeaderboardChartInternal: FC< LeaderboardChartProps > = ( {
 					</div>
 					{ /* Render children from composition API */ }
 					{ otherChildren }
-				</div>
+				</Stack>
 			</SingleChartContext.Provider>
 		);
 	}
+
+	const legendElement = showLegend && (
+		<Legend
+			orientation={ legendOrientation }
+			position={ legendPosition }
+			alignment={ legendAlignment }
+			shape={ legendShape }
+			shapeWidth={ legendShapeWidth }
+			shapeHeight={ legendShapeHeight }
+			chartId={ chartId }
+			interactive={ legendInteractive }
+		/>
+	);
 
 	return (
 		<SingleChartContext.Provider
@@ -286,76 +307,79 @@ const LeaderboardChartInternal: FC< LeaderboardChartProps > = ( {
 				chartHeight: 0,
 			} }
 		>
-			<div
+			<Stack
+				direction="column"
+				data-testid="leaderboard-chart-container"
 				className={ clsx(
 					styles.leaderboardChart,
 					{
+						[ styles[ 'leaderboardChart--responsive' ] ]: ! propWidth && ! propHeight,
 						[ styles[ 'leaderboardChart--loading' ] ]: loading,
 						[ styles[ 'leaderboardChart--with-legend' ] ]: showLegend,
-						[ styles[ 'leaderboardChart--legend-top' ] ]: showLegend && legendPosition === 'top',
 					},
 					className
 				) }
-				style={ style }
+				style={ {
+					...style,
+					width: propWidth || undefined,
+					height: propHeight || undefined,
+				} }
 			>
-				{ allSeriesHidden ? (
-					<div className={ styles.emptyState }>
-						{ __( 'All series are hidden. Click legend items to show data.', 'jetpack-charts' ) }
-					</div>
-				) : (
-					<Grid templateColumns="minmax(0, 1fr) auto" rowGap={ rowGap } columnGap={ columnGap }>
-						{ data.map( entry => {
-							const colorIndex = Math.sign( entry.delta ) + 1;
-							const deltaColor = deltaColors[ colorIndex ];
+				{ legendPosition === 'top' && legendElement }
 
-							return (
-								<Fragment key={ entry.id }>
-									<VStack spacing={ labelSpacing }>
-										<BarWithLabel
-											entry={ entry }
-											withComparison={ withComparison }
-											withOverlayLabel={ withOverlayLabel }
-											primaryColor={ resolvedPrimaryColor }
-											secondaryColor={ resolvedSecondaryColor }
-											isPrimaryVisible={ isPrimaryVisible }
-											isComparisonVisible={ isComparisonVisible }
-											animation={ animation && ! loading && ! prefersReducedMotion }
-										/>
-									</VStack>
+				<div className={ styles.leaderboardChart__content }>
+					{ allSeriesHidden ? (
+						<div className={ styles.emptyState }>
+							{ __( 'All series are hidden. Click legend items to show data.', 'jetpack-charts' ) }
+						</div>
+					) : (
+						<Grid templateColumns="minmax(0, 1fr) auto" rowGap={ rowGap } columnGap={ columnGap }>
+							{ data.map( entry => {
+								const colorIndex = Math.sign( entry.delta ) + 1;
+								const deltaColor = deltaColors[ colorIndex ];
 
-									<div
-										className={ clsx( styles.valueContainer, {
-											[ styles.overlayLabel ]: withOverlayLabel,
-										} ) }
-									>
-										{ isPrimaryVisible && <Text>{ valueFormatter( entry.currentValue ) }</Text> }
+								return (
+									<Fragment key={ entry.id }>
+										<Stack direction="column" gap={ labelSpacing }>
+											<BarWithLabel
+												entry={ entry }
+												withComparison={ withComparison }
+												withOverlayLabel={ withOverlayLabel }
+												primaryColor={ resolvedPrimaryColor }
+												secondaryColor={ resolvedSecondaryColor }
+												isPrimaryVisible={ isPrimaryVisible }
+												isComparisonVisible={ isComparisonVisible }
+												animation={ animation && ! loading && ! prefersReducedMotion }
+											/>
+										</Stack>
 
-										{ withComparison && isComparisonVisible && (
-											<Text style={ { color: deltaColor } }>{ deltaFormatter( entry.delta ) }</Text>
-										) }
-									</div>
-								</Fragment>
-							);
-						} ) }
-					</Grid>
-				) }
+										<Stack
+											direction="row"
+											gap={ 1 }
+											className={ clsx( styles.valueContainer, {
+												[ styles.overlayLabel ]: withOverlayLabel,
+											} ) }
+										>
+											{ isPrimaryVisible && <Text>{ valueFormatter( entry.currentValue ) }</Text> }
 
-				{ showLegend && (
-					<Legend
-						orientation={ legendOrientation }
-						position={ legendPosition }
-						alignment={ legendAlignment }
-						shape={ legendShape }
-						shapeWidth={ legendShapeWidth }
-						shapeHeight={ legendShapeHeight }
-						chartId={ chartId }
-						interactive={ legendInteractive }
-					/>
-				) }
+											{ withComparison && isComparisonVisible && (
+												<Text style={ { color: deltaColor } }>
+													{ deltaFormatter( entry.delta ) }
+												</Text>
+											) }
+										</Stack>
+									</Fragment>
+								);
+							} ) }
+						</Grid>
+					) }
+				</div>
+
+				{ legendPosition === 'bottom' && legendElement }
 
 				{ /* Render children from composition API */ }
 				{ otherChildren }
-			</div>
+			</Stack>
 		</SingleChartContext.Provider>
 	);
 };

--- a/projects/js-packages/charts/src/charts/leaderboard-chart/stories/index.api.mdx
+++ b/projects/js-packages/charts/src/charts/leaderboard-chart/stories/index.api.mdx
@@ -30,8 +30,12 @@ Main chart component for displaying ranked data with optional comparison values.
 | `legendShapeHeight` | `number` | `8` | Height of legend shapes in pixels |
 | `legendLabels` | `{ primary?: string; comparison?: string }` | `undefined` | Custom labels for legend items |
 | `legendInteractive` | `boolean` | `false` | Whether legend items are interactive (clickable to toggle series visibility). **Note:** Only works with props-based legends (`showLegend={true}`), not with composition API (`<LeaderboardChart.Legend />`) |
+| `width` | `number` | `undefined` | Optional fixed width of the chart container in pixels |
+| `height` | `number` | `undefined` | Optional fixed height of the chart container in pixels |
+| `gap` | `string \| number` | `'md'` | Spacing between legend and chart content |
 | `className` | `string` | `undefined` | Additional CSS class name for the chart container |
 | `style` | `React.CSSProperties & CustomProperties` | `undefined` | Custom styling for the chart container |
+| `children` | `ReactNode` | `undefined` | Child components for composition API (for example, `LeaderboardChart.Legend`) |
 
 ## LeaderboardEntry Type
 

--- a/projects/js-packages/charts/src/charts/leaderboard-chart/stories/index.api.mdx
+++ b/projects/js-packages/charts/src/charts/leaderboard-chart/stories/index.api.mdx
@@ -29,10 +29,10 @@ Main chart component for displaying ranked data with optional comparison values.
 | `legendShapeWidth` | `number` | `8` | Width of legend shapes in pixels |
 | `legendShapeHeight` | `number` | `8` | Height of legend shapes in pixels |
 | `legendLabels` | `{ primary?: string; comparison?: string }` | `undefined` | Custom labels for legend items |
-| `legendInteractive` | `boolean` | `false` | Whether legend items are interactive (clickable to toggle series visibility). **Note:** Only works with props-based legends (`showLegend={true}`), not with composition API (`<LeaderboardChart.Legend />`) |
+| `legendInteractive` | `boolean` | `false` | Whether legend items are interactive (clickable to toggle series visibility). **Note:** For props-based legends, use `showLegend={true}`. For composition API, render an interactive legend child (for example, `<LeaderboardChart.Legend interactive />`) so it can use chart context. |
 | `width` | `number` | `undefined` | Optional fixed width of the chart container in pixels |
 | `height` | `number` | `undefined` | Optional fixed height of the chart container in pixels |
-| `gap` | `string \| number` | `'md'` | Spacing between legend and chart content |
+| `gap` | `GapSize` | `'md'` | Spacing between legend and chart content, using the WordPress `GapSize` scale |
 | `className` | `string` | `undefined` | Additional CSS class name for the chart container |
 | `style` | `React.CSSProperties & CustomProperties` | `undefined` | Custom styling for the chart container |
 | `children` | `ReactNode` | `undefined` | Child components for composition API (for example, `LeaderboardChart.Legend`) |

--- a/projects/js-packages/charts/src/charts/leaderboard-chart/stories/index.docs.mdx
+++ b/projects/js-packages/charts/src/charts/leaderboard-chart/stories/index.docs.mdx
@@ -496,17 +496,17 @@ By default, leaderboard charts fill their parent container dimensions. The paren
 <Source
 	language="tsx"
 	code={ `// Responsive by default (fills parent container)
-<div style={{ width: '100%', height: '320px' }}>
-	<LeaderboardChart data={ data } showLegend={ true } />
-</div>
+		<div style={{ width: '100%', height: '320px' }}>
+			<LeaderboardChart data={ data } showLegend={ true } />
+		</div>
 
-// Fixed-size exception
-<LeaderboardChart
-	data={ data }
-	width={ 300 }
-	height={ 400 }
-	showLegend={ true }
-/>` }
+		// Fixed-size exception
+		<LeaderboardChart
+			data={ data }
+			width={ 300 }
+			height={ 400 }
+			showLegend={ true }
+		/>` }
 />
 
 When content is taller than the available area, the content region scrolls and the legend remains visible without overlap.

--- a/projects/js-packages/charts/src/charts/leaderboard-chart/stories/index.docs.mdx
+++ b/projects/js-packages/charts/src/charts/leaderboard-chart/stories/index.docs.mdx
@@ -5,13 +5,13 @@ import * as LeaderboardChartStories from './index.stories';
 
 # Leaderboard Chart
 
-A flexible and accessible leaderboard chart component for displaying ranked data with WordPress ProgressBar components and optional comparison values.
+A flexible and accessible leaderboard chart component for displaying ranked data with optional comparison values and legend support.
 
 <Canvas of={ LeaderboardChartStories.Default } />
 
 ## Overview
 
-The Leaderboard Chart component provides a clean, responsive visualization for displaying ranked data with optional comparison values. Built with WordPress components, it supports customizable colors, flexible formatting, and comprehensive accessibility features:
+The Leaderboard Chart component provides a clean, responsive visualization for displaying ranked data with optional comparison values. Built with WordPress components, it supports customizable colors, flexible formatting, and accessibility-friendly defaults.
 
 <Source
 	language="tsx"
@@ -83,6 +83,8 @@ The simplest leaderboard chart requires only a `data` prop with pre-processed le
 - **`loading`**: Whether the chart is in loading state - `false` by default
 - **`className`**: Additional CSS class name for the chart container
 - **`style`**: Custom styling including CSS custom properties for border radius
+- **`width` / `height`**: Optional fixed chart container dimensions
+- **`gap`**: Spacing between legend and chart content (Stack gap token/value)
 
 For detailed prop information, type definitions, and examples, see the [Leaderboard Chart API Reference](./?path=/docs/js-packages-charts-library-charts-leaderboard-chart-api-reference--docs).
 
@@ -101,12 +103,6 @@ Display both current and previous period data with delta indicators:
 		withComparison={true}
 	/>` }
 />
-
-### Without Comparison
-
-Focus on current period data only:
-
-<Canvas of={ LeaderboardChartStories.WithoutComparison } />
 
 ### Negative Growth Handling
 
@@ -237,6 +233,12 @@ Gracefully handle empty data arrays:
 	/>` }
 />
 
+### Empty Data with Children
+
+Children passed to the composition API still render in empty-data state:
+
+<Canvas of={ LeaderboardChartStories.EmptyDataWithChildren } />
+
 ### Small Datasets
 
 Handle minimal datasets effectively:
@@ -348,10 +350,23 @@ Customize legend labels with specific date ranges or descriptive text:
 	/>` }
 />
 
+### Composition API Legend
+
+Use the composition API for explicit legend placement:
+
+<Canvas of={ LeaderboardChartStories.WithCompositionLegend } />
+
+### Interactive Legends
+
+Enable interactive legend items to toggle visibility of current and comparison series:
+
+<Canvas of={ LeaderboardChartStories.InteractiveLegend } />
+
 **Legend Configuration Options:**
 - Control legend positioning, alignment, and visual appearance
 - Customize legend shapes and sizes
 - Add custom labels for different time periods or data series
+- Control legend/content spacing with the chart-level `gap` prop
 
 See the [API Reference](./?path=/docs/js-packages-charts-library-charts-leaderboard-chart-api-reference--docs) for detailed prop information.
 
@@ -474,6 +489,30 @@ Leaderboard Charts integrate seamlessly with the chart theming system. The defau
 	</GlobalChartsProvider>` }
 />
 
+## Responsive Behavior
+
+By default, leaderboard charts fill their parent container dimensions. The parent must provide an explicit height for constrained layouts:
+
+<Source
+	language="tsx"
+	code={ `// Responsive by default (fills parent container)
+<div style={{ width: '100%', height: '320px' }}>
+	<LeaderboardChart data={ data } showLegend={ true } />
+</div>
+
+// Fixed-size exception
+<LeaderboardChart
+	data={ data }
+	width={ 300 }
+	height={ 400 }
+	showLegend={ true }
+/>` }
+/>
+
+When content is taller than the available area, the content region scrolls and the legend remains visible without overlap.
+
+For more details on responsive behavior, see the [Responsive Design section](./?path=/docs/js-packages-charts-library-introduction--docs#responsive-design) in the introduction.
+
 ## Animation
 
 The Leaderboard Chart component supports an optional entry animation that creates a smooth reveal effect when the chart first renders:
@@ -497,7 +536,7 @@ The Leaderboard Chart component supports an optional entry animation that create
 
 **Note**: The animation plays once when the chart initially renders and does not repeat.
 
-## Examples
+## Advanced Usage
 
 ### E-commerce Sales Channels
 
@@ -526,8 +565,18 @@ The Leaderboard Chart component supports an optional entry animation that create
 
 ## Accessibility
 
-- Built with semantic WordPress components (`Grid`, `VStack`, `Text`)
-- Screen reader accessible through proper text content
-- Color information supplemented with text values (not color-dependent)
-- Responsive design that adapts to system font size preferences
-- No interactive elements - functions as a display-only component
+### Keyboard Navigation
+
+- Interactive legends are keyboard accessible when `legendInteractive` is enabled.
+- Legend items can be toggled via keyboard using standard button interaction.
+
+### Screen Reader Support
+
+- Uses semantic text content for labels and values.
+- Legend items expose visible labels and state when interactive.
+- Value and delta text supplement color-based feedback.
+
+### Focus Management
+
+- Interactive legend items use standard focus behavior and visible focus indicators from the shared legend component.
+- The chart content area scrolls in constrained layouts, keeping focused legend controls visible and non-overlapping.

--- a/projects/js-packages/charts/src/charts/leaderboard-chart/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/charts/leaderboard-chart/stories/index.stories.tsx
@@ -1,3 +1,4 @@
+import { Stack } from '@wordpress/ui';
 import { defaultTheme, useGlobalChartsContext } from '../../../providers';
 import {
 	chartDecorator,
@@ -226,6 +227,21 @@ export const EmptyData: Story = {
 		withComparison: true,
 		loading: false,
 	},
+};
+
+export const EmptyDataWithChildren: Story = {
+	args: {
+		data: [],
+		withComparison: true,
+		loading: false,
+	},
+	render: args => (
+		<LeaderboardChart { ...args }>
+			<Stack direction="row" gap="xs" align="center" justify="center">
+				Child element
+			</Stack>
+		</LeaderboardChart>
+	),
 };
 
 export const LargeValues: Story = {

--- a/projects/js-packages/charts/src/charts/leaderboard-chart/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/charts/leaderboard-chart/stories/index.stories.tsx
@@ -402,12 +402,7 @@ export const CustomLegendLabels: Story = {
 export const WithCompositionLegend: Story = {
 	render: args => (
 		<LeaderboardChart { ...args }>
-			<LeaderboardChart.Legend
-				shape="circle"
-				shapeWidth={ 8 }
-				shapeHeight={ 8 }
-				style={ { marginTop: '16px' } }
-			/>
+			<LeaderboardChart.Legend shape="circle" shapeWidth={ 8 } shapeHeight={ 8 } />
 		</LeaderboardChart>
 	),
 	args: {

--- a/projects/js-packages/charts/src/charts/leaderboard-chart/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/charts/leaderboard-chart/stories/index.stories.tsx
@@ -157,6 +157,21 @@ export const Default: Story = {
 	},
 };
 
+export const FixedDimensions: Story = {
+	args: {
+		...Default.args,
+		width: 300,
+		height: 400,
+	},
+};
+
+export const AspectRatio: Story = {
+	args: {
+		...Default.args,
+		aspectRatio: 0.4,
+	},
+};
+
 export const WithoutComparison: Story = {
 	args: {
 		data: sampleData,
@@ -386,32 +401,14 @@ export const CustomLegendLabels: Story = {
 
 export const WithCompositionLegend: Story = {
 	render: args => (
-		<div
-			style={ {
-				display: 'grid',
-				gap: '2rem',
-				gridTemplateColumns: 'repeat(2, 1fr)',
-				alignItems: 'start',
-			} }
-		>
-			<div>
-				<h3 style={ { marginTop: 0, marginBottom: '1rem' } }>Traditional Props-based Legend</h3>
-				<LeaderboardChart { ...args } showLegend={ true } />
-			</div>
-			<div>
-				<h3 style={ { marginTop: 0, marginBottom: '1rem' } }>
-					Composition API with Legend Component
-				</h3>
-				<LeaderboardChart { ...args }>
-					<LeaderboardChart.Legend
-						shape="circle"
-						shapeWidth={ 8 }
-						shapeHeight={ 8 }
-						style={ { marginTop: '16px' } }
-					/>
-				</LeaderboardChart>
-			</div>
-		</div>
+		<LeaderboardChart { ...args }>
+			<LeaderboardChart.Legend
+				shape="circle"
+				shapeWidth={ 8 }
+				shapeHeight={ 8 }
+				style={ { marginTop: '16px' } }
+			/>
+		</LeaderboardChart>
 	),
 	args: {
 		data: sampleData,

--- a/projects/js-packages/charts/src/charts/leaderboard-chart/test/leaderboard-chart.test.tsx
+++ b/projects/js-packages/charts/src/charts/leaderboard-chart/test/leaderboard-chart.test.tsx
@@ -53,7 +53,7 @@ const testDeltaFormatter = ( value: number ) => `${ value }delta`;
 describe( 'LeaderboardChart', () => {
 	afterEach( () => {
 		const { useParentSize } = jest.requireMock( '@visx/responsive' );
-		useParentSize.mockReturnValue( mockDefaultParentSize() );
+		useParentSize.mockImplementation( () => mockDefaultParentSize() );
 	} );
 
 	it( 'renders leaderboard entries', () => {

--- a/projects/js-packages/charts/src/charts/leaderboard-chart/test/leaderboard-chart.test.tsx
+++ b/projects/js-packages/charts/src/charts/leaderboard-chart/test/leaderboard-chart.test.tsx
@@ -2,6 +2,15 @@ import { render, screen } from '@testing-library/react';
 import LeaderboardChart from '../leaderboard-chart';
 import type { LeaderboardEntry } from '../../../types';
 
+// Mock useParentSize so the responsive wrapper returns predictable dimensions in tests
+jest.mock( '@visx/responsive', () => ( {
+	useParentSize: jest.fn( () => ( {
+		parentRef: { current: null },
+		width: 400,
+		height: 300,
+	} ) ),
+} ) );
+
 const mockData: LeaderboardEntry[] = [
 	{
 		id: 'direct',
@@ -337,6 +346,28 @@ describe( 'LeaderboardChart', () => {
 			expect( screen.getByText( '8.8K' ) ).toBeInTheDocument();
 			expect( screen.getByText( '+25%' ) ).toBeInTheDocument();
 			expect( screen.getByText( '-8%' ) ).toBeInTheDocument();
+		} );
+	} );
+
+	describe( 'Responsive wrapper', () => {
+		it( 'fills parent container (height:100%) by default', () => {
+			render( <LeaderboardChart data={ mockData } /> );
+			const wrapper = screen.getByTestId( 'responsive-wrapper' );
+			expect( wrapper ).toHaveStyle( { height: '100%' } );
+		} );
+
+		it( 'applies explicit width and height to chart container', () => {
+			const { useParentSize } = jest.requireMock( '@visx/responsive' );
+			useParentSize.mockReturnValueOnce( {
+				parentRef: { current: null },
+				width: 0,
+				height: 0,
+			} );
+
+			render( <LeaderboardChart data={ mockData } width={ 500 } height={ 240 } /> );
+			const chartContainer = screen.getByTestId( 'leaderboard-chart-container' );
+
+			expect( chartContainer ).toHaveStyle( { width: '500px', height: '240px' } );
 		} );
 	} );
 } );

--- a/projects/js-packages/charts/src/charts/leaderboard-chart/test/leaderboard-chart.test.tsx
+++ b/projects/js-packages/charts/src/charts/leaderboard-chart/test/leaderboard-chart.test.tsx
@@ -2,13 +2,15 @@ import { render, screen } from '@testing-library/react';
 import LeaderboardChart from '../leaderboard-chart';
 import type { LeaderboardEntry } from '../../../types';
 
+const getDefaultParentSize = () => ( {
+	parentRef: { current: null },
+	width: 400,
+	height: 300,
+} );
+
 // Mock useParentSize so the responsive wrapper returns predictable dimensions in tests
 jest.mock( '@visx/responsive', () => ( {
-	useParentSize: jest.fn( () => ( {
-		parentRef: { current: null },
-		width: 400,
-		height: 300,
-	} ) ),
+	useParentSize: jest.fn( () => getDefaultParentSize() ),
 } ) );
 
 const mockData: LeaderboardEntry[] = [
@@ -49,6 +51,11 @@ const testValueFormatter = ( value: number ) => `${ value }$`;
 const testDeltaFormatter = ( value: number ) => `${ value }delta`;
 
 describe( 'LeaderboardChart', () => {
+	afterEach( () => {
+		const { useParentSize } = jest.requireMock( '@visx/responsive' );
+		useParentSize.mockReturnValue( getDefaultParentSize() );
+	} );
+
 	it( 'renders leaderboard entries', () => {
 		render( <LeaderboardChart data={ mockData } /> );
 
@@ -358,7 +365,7 @@ describe( 'LeaderboardChart', () => {
 
 		it( 'applies explicit width and height to chart container', () => {
 			const { useParentSize } = jest.requireMock( '@visx/responsive' );
-			useParentSize.mockReturnValueOnce( {
+			useParentSize.mockReturnValue( {
 				parentRef: { current: null },
 				width: 0,
 				height: 0,

--- a/projects/js-packages/charts/src/charts/leaderboard-chart/test/leaderboard-chart.test.tsx
+++ b/projects/js-packages/charts/src/charts/leaderboard-chart/test/leaderboard-chart.test.tsx
@@ -2,7 +2,7 @@ import { render, screen } from '@testing-library/react';
 import LeaderboardChart from '../leaderboard-chart';
 import type { LeaderboardEntry } from '../../../types';
 
-const getDefaultParentSize = () => ( {
+const mockDefaultParentSize = () => ( {
 	parentRef: { current: null },
 	width: 400,
 	height: 300,
@@ -10,7 +10,7 @@ const getDefaultParentSize = () => ( {
 
 // Mock useParentSize so the responsive wrapper returns predictable dimensions in tests
 jest.mock( '@visx/responsive', () => ( {
-	useParentSize: jest.fn( () => getDefaultParentSize() ),
+	useParentSize: jest.fn( () => mockDefaultParentSize() ),
 } ) );
 
 const mockData: LeaderboardEntry[] = [
@@ -53,7 +53,7 @@ const testDeltaFormatter = ( value: number ) => `${ value }delta`;
 describe( 'LeaderboardChart', () => {
 	afterEach( () => {
 		const { useParentSize } = jest.requireMock( '@visx/responsive' );
-		useParentSize.mockReturnValue( getDefaultParentSize() );
+		useParentSize.mockReturnValue( mockDefaultParentSize() );
 	} );
 
 	it( 'renders leaderboard entries', () => {

--- a/projects/js-packages/charts/src/charts/leaderboard-chart/types.ts
+++ b/projects/js-packages/charts/src/charts/leaderboard-chart/types.ts
@@ -15,6 +15,7 @@ export interface LeaderboardChartProps
 		| 'width'
 		| 'height'
 		| 'size'
+		| 'gap'
 		| 'legendInteractive'
 		| 'animation'
 	> {


### PR DESCRIPTION
Fixes #CHARTS-165

## Proposed changes:
* Fix `LeaderboardChart` height/layout behavior so legends are correctly accounted for in constrained-height containers.
* Refactor leaderboard layout to use `Stack` consistently, including chart-level `gap` support aligned with other chart components.
* Keep stories responsive by default (inherited from `Default`) with a fixed-dimensions exception for explicit sizing.
* Restore value/delta spacing on the right side after the Stack migration to avoid visual regression.
* Harden responsive wrapper tests by making mock reset behavior deterministic and jest-hoist-safe.
* Prevent legend overlap when content exceeds available height by making the chart content region scrollable.
* Add a charts changelog entry for `CHARTS-165`.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

- Internal Charts project workstream: CHARTS-105 parent / CHARTS-165 sub-issue.

## Does this pull request change what data or activity we track or use?

- No.

## Testing instructions:

* Check out this branch and install dependencies as usual.
* In `projects/js-packages/charts`, run:
* `pnpm run test -- src/charts/leaderboard-chart/test/leaderboard-chart.test.tsx`
* `pnpm run typecheck`
* Run Storybook from `projects/js-packages/charts` with `pnpm run storybook`.
* Open `JS Packages/Charts Library/Charts/Leaderboard Chart` and verify:
* `Default` and inherited stories render responsively in the resizable container.
* `With Legend` keeps a visible gap above the legend and does not overlap when container height is short.
* When container height is shorter than content, chart rows scroll inside the content region instead of overlapping the legend.
* Right-side value and delta spacing remains visually separated (no collapsed spacing regression).
* `FixedDimensions` behaves as the explicit fixed-size exception.

## Changelog

- [ ] Generate changelog entries for this PR (using AI).