### PR TITLE
Migrate VideoPress main admin page header to unified AdminHeader

### DIFF
--- a/projects/packages/videopress/changelog/update-normalize-videopress-admin-header
+++ b/projects/packages/videopress/changelog/update-normalize-videopress-admin-header
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Migrate main admin page header to use unified AdminHeader component from jetpack-components.

--- a/projects/packages/videopress/src/client/admin/components/admin-page/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/admin-page/index.tsx
@@ -11,7 +11,6 @@ import {
 	Col,
 	useBreakpointMatch,
 	ContextualUpgradeTrigger,
-	JetpackVideoPressLogo,
 } from '@automattic/jetpack-components';
 import {
 	useProductCheckoutWorkflow,
@@ -194,7 +193,8 @@ const Admin = () => {
 	return (
 		<AdminPage
 			moduleName={ __( 'Jetpack VideoPress', 'jetpack-videopress-pkg' ) }
-			header={ <JetpackVideoPressLogo /> }
+			title={ __( 'VideoPress', 'jetpack-videopress-pkg' ) }
+			subTitle={ __( 'Professional quality, ad-free video hosting.', 'jetpack-videopress-pkg' ) }
 			useInternalLinks={ shouldUseInternalLinks() }
 		>
 			<div


### PR DESCRIPTION
Part of JETPACK-1352

Fixes #

## Proposed changes:

* Migrates the VideoPress main admin page header to use the unified `AdminHeader` component from `@automattic/jetpack-components`, introduced in #47313.
* Replaces `header={ <JetpackVideoPressLogo /> }` with `title="VideoPress"` and `subTitle="Professional quality, ad-free video hosting."` props on `AdminPage`.
* Removes the unused `JetpackVideoPressLogo` import from the admin page component.

| Before | After |
|--------|--------|
| <img width="1111" height="689" alt="image" src="https://github.com/user-attachments/assets/8d229512-be8a-4867-9385-ad0ece4a6c54" /> | <img width="1130" height="687" alt="image" src="https://github.com/user-attachments/assets/3f6fb582-b580-4d04-ba3b-7d547cb0e0b5" /> | 
| <img width="1107" height="712" alt="image" src="https://github.com/user-attachments/assets/394be7b3-a76e-4241-a83e-e558a46463b6" /> | <img width="1112" height="684" alt="image" src="https://github.com/user-attachments/assets/42680054-fc3e-4192-8be0-156013988786" /> |





### Follow-up: Edit Video Details page

The edit-video-details page (`#/video/:videoId/edit`) has a more complex custom header with:
- A logo that acts as a navigation button (back to dashboard)
- A breadcrumb trail ("Edit video details")
- Save changes + video actions buttons

This could be migrated using `AdminHeader`'s `breadcrumbs` prop and `actions` prop, but requires more design consideration. Filed as a follow-up task.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

See the parent PR #47313 for context on the unified header approach.

## Does this pull request change what data or activity we track or use?

No changes to tracking or data usage.

## Testing instructions:

* Activate the VideoPress plugin (or Jetpack with VideoPress module enabled).
* Navigate to `/wp-admin/admin.php?page=jetpack-videopress`.
* Verify the header shows the Jetpack bolt icon + "VideoPress" title + "Professional quality, ad-free video hosting." subtitle.
* Verify the rest of the page (video library, upload area, settings) renders correctly.

## Changelog

Changelog entry already added manually.
