### PR TITLE
Charts: Bundle fast-deep-equal as a non-external dependency

### DIFF
--- a/projects/js-packages/charts/changelog/pr-47372
+++ b/projects/js-packages/charts/changelog/pr-47372
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Bundle fast-deep-equal as a non-external dependency to fix compatibility with webpack strict ESM mode.

--- a/projects/js-packages/charts/tsup.config.ts
+++ b/projects/js-packages/charts/tsup.config.ts
@@ -16,7 +16,7 @@ export default defineConfig( {
 	dts: true,
 	format: [ 'esm', 'cjs' ],
 	outDir: 'dist',
-	noExternal: [ '@wordpress/ui' ],
+	noExternal: [ '@wordpress/ui', 'fast-deep-equal' ],
 	loader: {
 		'.jpg': 'file',
 		'.gif': 'file',


### PR DESCRIPTION
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
The built ESM output of this package includes an external import for `fast-deep-equal/es6`. 

This breaks in webpack's strict ESM mode because `fast-deep-equal/es6/index.js` is actually CommonJS. This blocks other consumers from externalising @automattic/charts.

Adding fast-deep-equal to noExternal inlines the library (~500 bytes) into the output instead. There should be no change in behaviour.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Build the charts package: `pnpm run build`
- Verify fast-deep-equal no longer appears as an external import in the ESM output: `grep "from.*fast-deep-equal" dist/*.js` should return no results
- Verify it's inlined instead: `grep "fast-deep-equal" dist/*.js` should show it bundled inside chunks

## Changelog
<!-- Check one of the boxes below. -->

- [x] Generate changelog entries for this PR (using AI).
