### PR TITLE
tsgo: Remove deprecated baseUrl and add ambient .scss/.css declarations

### DIFF
--- a/projects/plugins/inspect/changelog/update-tsgo-clean-up-tsconfig-and-update-dts
+++ b/projects/plugins/inspect/changelog/update-tsgo-clean-up-tsconfig-and-update-dts
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Remove baseUrl from tsconfig for tsgo migration.

--- a/projects/plugins/inspect/tsconfig.json
+++ b/projects/plugins/inspect/tsconfig.json
@@ -6,8 +6,6 @@
 		"target": "es2021",
 		"strict": true,
 		"types": [],
-		"baseUrl": ".",
-		"paths": {},
 		"verbatimModuleSyntax": true
 	}
 }

--- a/projects/plugins/jetpack/changelog/update-tsgo-clean-up-tsconfig-and-update-dts
+++ b/projects/plugins/jetpack/changelog/update-tsgo-clean-up-tsconfig-and-update-dts
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Remove baseUrl from tsconfig for tsgo migration.

--- a/projects/plugins/jetpack/tsconfig.json
+++ b/projects/plugins/jetpack/tsconfig.json
@@ -1,10 +1,9 @@
 {
 	"extends": "jetpack-js-tools/tsconfig.base.json",
 	"compilerOptions": {
-		"baseUrl": ".",
 		"paths": {
 			// fallback to resolving imports relative to _inc/client
-			"*": [ "*", "./_inc/client/*" ]
+			"*": [ "./*", "./_inc/client/*" ]
 		}
 	},
 	"include": [ "./_inc", "./extensions", "./global.d.ts" ],

--- a/tools/js-tools/types/global.d.ts
+++ b/tools/js-tools/types/global.d.ts
@@ -1,4 +1,6 @@
 declare module '*.mdx';
+declare module '*.css';
+declare module '*.scss';
 declare module '*.module.scss' {
 	const classes: { [ key: string ]: string };
 	export default classes;


### PR DESCRIPTION
Completes MONOREP-375, MONOREP-373

## Proposed changes:

Prepare tsconfigs for tsgo migration:

* Remove deprecated `baseUrl` option from `inspect` and `jetpack` plugin tsconfigs (tsgo drops support for `baseUrl`).
  * In `inspect`, also remove the empty `paths: {}` that was only there because of `baseUrl`.
  * In `jetpack`, change the wildcard path `"*"` to `"./*"` so it resolves relative to the project root without relying on `baseUrl`.
* Add ambient module declarations for `*.css` and `*.scss` imports in `global.d.ts`. tsgo requires explicit declarations for side-effect imports (the existing `*.module.scss` declaration only covers CSS modules).

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

N/A — tooling-only change.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

* `pnpm typecheck` should pass in:
  * `projects/plugins/inspect`
  * `projects/plugins/jetpack`
  * `projects/js-packages/components`

## Changelog

- [ ] Generate changelog entries for this PR (using AI).
