### PR TITLE
tsgo: Replace typescript with @typescript/native-preview and update scripts

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -10,6 +10,7 @@
 		"dbaeumer.vscode-eslint", // ESLint
 		"esbenp.prettier-vscode", // Prettier - Code formatter
 		"obliviousharmony.vscode-php-codesniffer", // PHP_CodeSniffer
-		"stylelint.vscode-stylelint" // Stylelint
+		"stylelint.vscode-stylelint", // Stylelint
+		"TypeScriptTeam.native-preview" // Native TypeScript preview
 	]
 }

--- a/.vscode/settings.dist.jsonc
+++ b/.vscode/settings.dist.jsonc
@@ -62,5 +62,7 @@
 		"editor.formatOnSave": false,
 		"editor.defaultFormatter": "stylelint.vscode-stylelint"
 	},
-	"stylelint.validate": [ "css", "scss" ]
+	"stylelint.validate": [ "css", "scss" ],
+	// Use Native TypeScript
+	"typescript.experimental.useTsgo": true
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -82,6 +82,9 @@ importers:
       '@types/node':
         specifier: ^22.19.11
         version: 22.19.11
+      '@typescript/native-preview':
+        specifier: 7.0.0-dev.20260225.1
+        version: 7.0.0-dev.20260225.1
       '@vercel/ncc':
         specifier: 0.36.1
         version: 0.36.1
@@ -246,7 +249,7 @@ importers:
         version: 10.2.11(@types/react@18.3.28)(storybook@10.2.11(@testing-library/dom@10.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@storybook/react':
         specifier: 10.2.11
-        version: 10.2.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.2.11(@testing-library/dom@10.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.3)
+        version: 10.2.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.2.11(@testing-library/dom@10.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@testing-library/dom':
         specifier: 10.4.1
         version: 10.4.1
@@ -256,15 +259,15 @@ importers:
       '@types/turndown':
         specifier: 5.0.6
         version: 5.0.6
+      '@typescript/native-preview':
+        specifier: 7.0.0-dev.20260225.1
+        version: 7.0.0-dev.20260225.1
       jest:
         specifier: 30.2.0
         version: 30.2.0
       storybook:
         specifier: 10.2.11
         version: 10.2.11(@testing-library/dom@10.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      typescript:
-        specifier: 5.9.3
-        version: 5.9.3
 
   projects/js-packages/analytics:
     devDependencies:
@@ -322,12 +325,12 @@ importers:
       '@automattic/jetpack-webpack-config':
         specifier: workspace:*
         version: link:../webpack-config
+      '@typescript/native-preview':
+        specifier: 7.0.0-dev.20260225.1
+        version: 7.0.0-dev.20260225.1
       jest:
         specifier: 30.2.0
         version: 30.2.0
-      typescript:
-        specifier: 5.9.3
-        version: 5.9.3
       webpack:
         specifier: 5.105.2
         version: 5.105.2(webpack-cli@6.0.1)
@@ -464,6 +467,9 @@ importers:
       '@types/react-dom':
         specifier: 18.3.7
         version: 18.3.7(@types/react@18.3.28)
+      '@typescript/native-preview':
+        specifier: 7.0.0-dev.20260225.1
+        version: 7.0.0-dev.20260225.1
       '@visx/glyph':
         specifier: 3.12.0
         version: 3.12.0(react@18.3.1)
@@ -608,7 +614,7 @@ importers:
         version: 10.2.11(@types/react@18.3.28)(storybook@10.2.11(@testing-library/dom@10.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(webpack@5.105.2)
       '@storybook/react':
         specifier: 10.2.11
-        version: 10.2.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.2.11(@testing-library/dom@10.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.3)
+        version: 10.2.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.2.11(@testing-library/dom@10.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@testing-library/dom':
         specifier: 10.4.1
         version: 10.4.1
@@ -630,6 +636,9 @@ importers:
       '@types/react-slider':
         specifier: 1.3.6
         version: 1.3.6
+      '@typescript/native-preview':
+        specifier: 7.0.0-dev.20260225.1
+        version: 7.0.0-dev.20260225.1
       jest:
         specifier: 30.2.0
         version: 30.2.0
@@ -648,9 +657,6 @@ importers:
       ts-dedent:
         specifier: 2.2.0
         version: 2.2.0
-      typescript:
-        specifier: 5.9.3
-        version: 5.9.3
       webpack:
         specifier: 5.105.2
         version: 5.105.2(webpack-cli@6.0.1)
@@ -736,6 +742,9 @@ importers:
       '@types/react':
         specifier: 18.3.28
         version: 18.3.28
+      '@typescript/native-preview':
+        specifier: 7.0.0-dev.20260225.1
+        version: 7.0.0-dev.20260225.1
       jest:
         specifier: 30.2.0
         version: 30.2.0
@@ -748,9 +757,6 @@ importers:
       storybook:
         specifier: 10.2.11
         version: 10.2.11(@testing-library/dom@10.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      typescript:
-        specifier: 5.9.3
-        version: 5.9.3
 
   projects/js-packages/critical-css-gen:
     dependencies:
@@ -782,6 +788,9 @@ importers:
       '@types/node':
         specifier: ^22.19.11
         version: 22.19.11
+      '@typescript/native-preview':
+        specifier: 7.0.0-dev.20260225.1
+        version: 7.0.0-dev.20260225.1
       express:
         specifier: 4.22.0
         version: 4.22.0
@@ -809,9 +818,6 @@ importers:
       tslib:
         specifier: 2.8.1
         version: 2.8.1
-      typescript:
-        specifier: 5.9.3
-        version: 5.9.3
       webpack:
         specifier: 5.105.2
         version: 5.105.2(webpack-cli@6.0.1)
@@ -1000,6 +1006,9 @@ importers:
       '@rollup/plugin-typescript':
         specifier: 12.1.0
         version: 12.1.0(rollup@3.30.0)(tslib@2.8.1)(typescript@5.9.3)
+      '@typescript/native-preview':
+        specifier: 7.0.0-dev.20260225.1
+        version: 7.0.0-dev.20260225.1
       concurrently:
         specifier: 9.2.1
         version: 9.2.1
@@ -1103,6 +1112,9 @@ importers:
       '@types/react':
         specifier: 18.3.28
         version: 18.3.28
+      '@typescript/native-preview':
+        specifier: 7.0.0-dev.20260225.1
+        version: 7.0.0-dev.20260225.1
       babel-jest:
         specifier: 30.2.0
         version: 30.2.0(@babel/core@7.29.0)
@@ -1115,9 +1127,6 @@ importers:
       react-dom:
         specifier: 18.3.1
         version: 18.3.1(react@18.3.1)
-      typescript:
-        specifier: 5.9.3
-        version: 5.9.3
 
   projects/js-packages/number-formatters:
     dependencies:
@@ -1146,6 +1155,9 @@ importers:
       '@types/jest':
         specifier: 30.0.0
         version: 30.0.0
+      '@typescript/native-preview':
+        specifier: 7.0.0-dev.20260225.1
+        version: 7.0.0-dev.20260225.1
       jest:
         specifier: 30.2.0
         version: 30.2.0
@@ -1192,6 +1204,9 @@ importers:
       '@testing-library/user-event':
         specifier: 14.6.1
         version: 14.6.1(@testing-library/dom@10.4.1)
+      '@typescript/native-preview':
+        specifier: 7.0.0-dev.20260225.1
+        version: 7.0.0-dev.20260225.1
       '@wordpress/base-styles':
         specifier: 6.16.0
         version: 6.16.0
@@ -1225,6 +1240,9 @@ importers:
       '@tanstack/react-query-devtools':
         specifier: 5.90.2
         version: 5.90.2(@tanstack/react-query@5.90.8(react@18.3.1))(react@18.3.1)
+      '@typescript/native-preview':
+        specifier: 7.0.0-dev.20260225.1
+        version: 7.0.0-dev.20260225.1
       jest:
         specifier: 30.2.0
         version: 30.2.0
@@ -1237,9 +1255,6 @@ importers:
       tslib:
         specifier: 2.8.1
         version: 2.8.1
-      typescript:
-        specifier: 5.9.3
-        version: 5.9.3
       webpack:
         specifier: 5.105.2
         version: 5.105.2(webpack-cli@6.0.1)
@@ -1310,7 +1325,7 @@ importers:
         version: 10.2.11(@types/react@18.3.28)(storybook@10.2.11(@testing-library/dom@10.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@storybook/react':
         specifier: 10.2.11
-        version: 10.2.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.2.11(@testing-library/dom@10.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.3)
+        version: 10.2.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.2.11(@testing-library/dom@10.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@testing-library/dom':
         specifier: 10.4.1
         version: 10.4.1
@@ -1323,6 +1338,9 @@ importers:
       '@types/react':
         specifier: 18.3.28
         version: 18.3.28
+      '@typescript/native-preview':
+        specifier: 7.0.0-dev.20260225.1
+        version: 7.0.0-dev.20260225.1
       jest:
         specifier: 30.2.0
         version: 30.2.0
@@ -1335,15 +1353,12 @@ importers:
       storybook:
         specifier: 10.2.11
         version: 10.2.11(@testing-library/dom@10.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      typescript:
-        specifier: 5.9.3
-        version: 5.9.3
 
   projects/js-packages/script-data:
     devDependencies:
-      typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+      '@typescript/native-preview':
+        specifier: 7.0.0-dev.20260225.1
+        version: 7.0.0-dev.20260225.1
 
   projects/js-packages/shared-extension-utils:
     dependencies:
@@ -1435,6 +1450,9 @@ importers:
       '@testing-library/user-event':
         specifier: 14.6.1
         version: 14.6.1(@testing-library/dom@10.4.1)
+      '@typescript/native-preview':
+        specifier: 7.0.0-dev.20260225.1
+        version: 7.0.0-dev.20260225.1
       babel-jest:
         specifier: 30.2.0
         version: 30.2.0(@babel/core@7.29.0)
@@ -1450,9 +1468,6 @@ importers:
       react-dom:
         specifier: 18.3.1
         version: 18.3.1(react@18.3.1)
-      typescript:
-        specifier: 5.9.3
-        version: 5.9.3
 
   projects/js-packages/social-logos:
     dependencies:
@@ -1466,6 +1481,9 @@ importers:
       '@types/react-dom':
         specifier: 18.3.7
         version: 18.3.7(@types/react@18.3.28)
+      '@typescript/native-preview':
+        specifier: 7.0.0-dev.20260225.1
+        version: 7.0.0-dev.20260225.1
       glob:
         specifier: 13.0.0
         version: 13.0.0
@@ -1487,9 +1505,6 @@ importers:
       svgstore:
         specifier: ^3.0.1
         version: 3.0.1
-      typescript:
-        specifier: 5.9.3
-        version: 5.9.3
       wawoff2:
         specifier: ^2.0.1
         version: 2.0.1
@@ -1536,6 +1551,9 @@ importers:
       '@types/react-dom':
         specifier: 18.3.7
         version: 18.3.7(@types/react@18.3.28)
+      '@typescript/native-preview':
+        specifier: 7.0.0-dev.20260225.1
+        version: 7.0.0-dev.20260225.1
       babel-jest:
         specifier: 30.2.0
         version: 30.2.0(@babel/core@7.29.0)
@@ -1615,6 +1633,9 @@ importers:
       '@types/react':
         specifier: 18.3.28
         version: 18.3.28
+      '@typescript/native-preview':
+        specifier: 7.0.0-dev.20260225.1
+        version: 7.0.0-dev.20260225.1
       '@wordpress/base-styles':
         specifier: 6.16.0
         version: 6.16.0
@@ -1717,15 +1738,15 @@ importers:
       '@types/jest':
         specifier: 30.0.0
         version: 30.0.0
+      '@typescript/native-preview':
+        specifier: 7.0.0-dev.20260225.1
+        version: 7.0.0-dev.20260225.1
       jest:
         specifier: 30.2.0
         version: 30.2.0
       tslib:
         specifier: 2.8.1
         version: 2.8.1
-      typescript:
-        specifier: 5.9.3
-        version: 5.9.3
       webpack:
         specifier: 5.105.2
         version: 5.105.2(webpack-cli@6.0.1)
@@ -1820,6 +1841,9 @@ importers:
       '@babel/runtime':
         specifier: 7.28.6
         version: 7.28.6
+      '@typescript/native-preview':
+        specifier: 7.0.0-dev.20260225.1
+        version: 7.0.0-dev.20260225.1
       typescript:
         specifier: 5.9.3
         version: 5.9.3
@@ -1952,6 +1976,9 @@ importers:
       '@types/react':
         specifier: 18.3.28
         version: 18.3.28
+      '@typescript/native-preview':
+        specifier: 7.0.0-dev.20260225.1
+        version: 7.0.0-dev.20260225.1
       '@wordpress/browserslist-config':
         specifier: 6.40.0
         version: 6.40.0
@@ -1970,9 +1997,6 @@ importers:
       storybook:
         specifier: 10.2.11
         version: 10.2.11(@testing-library/dom@10.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      typescript:
-        specifier: 5.9.3
-        version: 5.9.3
       webpack:
         specifier: 5.105.2
         version: 5.105.2(webpack-cli@6.0.1)
@@ -2186,15 +2210,15 @@ importers:
       '@types/node':
         specifier: ^22.19.11
         version: 22.19.11
+      '@typescript/native-preview':
+        specifier: 7.0.0-dev.20260225.1
+        version: 7.0.0-dev.20260225.1
       concurrently:
         specifier: 9.2.1
         version: 9.2.1
       jest:
         specifier: 30.2.0
         version: 30.2.0(@types/node@22.19.11)
-      typescript:
-        specifier: 5.9.3
-        version: 5.9.3
       webpack:
         specifier: 5.105.2
         version: 5.105.2(webpack-cli@6.0.1)
@@ -2338,6 +2362,9 @@ importers:
       '@babel/preset-react':
         specifier: 7.28.5
         version: 7.28.5(@babel/core@7.29.0)
+      '@typescript/native-preview':
+        specifier: 7.0.0-dev.20260225.1
+        version: 7.0.0-dev.20260225.1
       jetpack-js-tools:
         specifier: workspace:*
         version: link:../../../tools/js-tools
@@ -2347,9 +2374,6 @@ importers:
       sass-loader:
         specifier: 16.0.5
         version: 16.0.5(sass-embedded@1.97.2)(webpack@5.105.2)
-      typescript:
-        specifier: 5.9.3
-        version: 5.9.3
       webpack:
         specifier: 5.105.2
         version: 5.105.2(webpack-cli@6.0.1)
@@ -2539,7 +2563,7 @@ importers:
         version: 7.28.6
       '@svgr/webpack':
         specifier: 8.1.0
-        version: 8.1.0(typescript@5.9.3)
+        version: 8.1.0
       '@tanstack/react-router':
         specifier: ^1.139.12
         version: 1.158.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -2561,6 +2585,9 @@ importers:
       '@types/react-dom':
         specifier: 18.3.7
         version: 18.3.7(@types/react@18.3.28)
+      '@typescript/native-preview':
+        specifier: 7.0.0-dev.20260225.1
+        version: 7.0.0-dev.20260225.1
       '@wordpress/api-fetch':
         specifier: 7.40.0
         version: 7.40.0
@@ -2596,7 +2623,7 @@ importers:
         version: 8.5.6
       postcss-loader:
         specifier: 8.2.0
-        version: 8.2.0(postcss@8.5.6)(typescript@5.9.3)(webpack@5.105.2)
+        version: 8.2.0(postcss@8.5.6)(webpack@5.105.2)
       postcss-modules:
         specifier: ^6.0.0
         version: 6.0.1(postcss@8.5.6)
@@ -2609,9 +2636,6 @@ importers:
       sharp:
         specifier: 0.33.5
         version: 0.33.5
-      typescript:
-        specifier: 5.9.3
-        version: 5.9.3
     optionalDependencies:
       react:
         specifier: 18.3.1
@@ -2870,6 +2894,9 @@ importers:
       '@types/react-dom':
         specifier: 18.3.7
         version: 18.3.7(@types/react@18.3.28)
+      '@typescript/native-preview':
+        specifier: 7.0.0-dev.20260225.1
+        version: 7.0.0-dev.20260225.1
       babel-plugin-transform-rename-properties:
         specifier: 0.1.0
         version: 0.1.0(@babel/core@7.29.0)
@@ -2882,9 +2909,6 @@ importers:
       sass-loader:
         specifier: 16.0.5
         version: 16.0.5(sass-embedded@1.97.2)(webpack@5.105.2)
-      typescript:
-        specifier: 5.9.3
-        version: 5.9.3
       wait-for-expect:
         specifier: 3.0.2
         version: 3.0.2
@@ -3084,7 +3108,7 @@ importers:
         version: 10.2.11(@types/react@18.3.28)(storybook@10.2.11(@testing-library/dom@10.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(webpack@5.105.2)
       '@storybook/react':
         specifier: 10.2.11
-        version: 10.2.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.2.11(@testing-library/dom@10.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.3)
+        version: 10.2.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.2.11(@testing-library/dom@10.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@testing-library/dom':
         specifier: 10.4.1
         version: 10.4.1
@@ -3106,6 +3130,9 @@ importers:
       '@types/react':
         specifier: 18.3.28
         version: 18.3.28
+      '@typescript/native-preview':
+        specifier: 7.0.0-dev.20260225.1
+        version: 7.0.0-dev.20260225.1
       concurrently:
         specifier: 9.2.1
         version: 9.2.1
@@ -3130,9 +3157,6 @@ importers:
       storybook:
         specifier: 10.2.11
         version: 10.2.11(@testing-library/dom@10.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      typescript:
-        specifier: 5.9.3
-        version: 5.9.3
       webpack:
         specifier: 5.105.2
         version: 5.105.2(webpack-cli@6.0.1)
@@ -3203,6 +3227,9 @@ importers:
       '@types/react-dom':
         specifier: 18.3.7
         version: 18.3.7(@types/react@18.3.28)
+      '@typescript/native-preview':
+        specifier: 7.0.0-dev.20260225.1
+        version: 7.0.0-dev.20260225.1
       '@wordpress/browserslist-config':
         specifier: 6.40.0
         version: 6.40.0
@@ -3218,9 +3245,6 @@ importers:
       sass-loader:
         specifier: 16.0.5
         version: 16.0.5(sass-embedded@1.97.2)(webpack@5.105.2)
-      typescript:
-        specifier: 5.9.3
-        version: 5.9.3
       webpack:
         specifier: 5.105.2
         version: 5.105.2(webpack-cli@6.0.1)
@@ -3375,6 +3399,9 @@ importers:
       '@automattic/jetpack-webpack-config':
         specifier: workspace:*
         version: link:../../js-packages/webpack-config
+      '@typescript/native-preview':
+        specifier: 7.0.0-dev.20260225.1
+        version: 7.0.0-dev.20260225.1
       sass-embedded:
         specifier: 1.97.2
         version: 1.97.2
@@ -3384,9 +3411,6 @@ importers:
       tslib:
         specifier: 2.8.1
         version: 2.8.1
-      typescript:
-        specifier: 5.9.3
-        version: 5.9.3
       webpack:
         specifier: 5.105.2
         version: 5.105.2(webpack-cli@6.0.1)
@@ -3565,7 +3589,7 @@ importers:
         version: 4.0.0(postcss@8.5.6)
       '@storybook/react':
         specifier: 10.2.11
-        version: 10.2.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.2.11(@testing-library/dom@10.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.3)
+        version: 10.2.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.2.11(@testing-library/dom@10.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@testing-library/dom':
         specifier: 10.4.1
         version: 10.4.1
@@ -3581,6 +3605,9 @@ importers:
       '@types/react':
         specifier: 18.3.28
         version: 18.3.28
+      '@typescript/native-preview':
+        specifier: 7.0.0-dev.20260225.1
+        version: 7.0.0-dev.20260225.1
       '@wordpress/browserslist-config':
         specifier: 6.40.0
         version: 6.40.0
@@ -3604,7 +3631,7 @@ importers:
         version: 12.1.11(postcss@8.5.6)
       postcss-loader:
         specifier: 8.2.0
-        version: 8.2.0(postcss@8.5.6)(typescript@5.9.3)(webpack@5.105.2)
+        version: 8.2.0(postcss@8.5.6)(webpack@5.105.2)
       react:
         specifier: 18.3.1
         version: 18.3.1
@@ -3620,9 +3647,6 @@ importers:
       storybook:
         specifier: 10.2.11
         version: 10.2.11(@testing-library/dom@10.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      typescript:
-        specifier: 5.9.3
-        version: 5.9.3
       webpack:
         specifier: 5.105.2
         version: 5.105.2(webpack-cli@6.0.1)
@@ -3864,6 +3888,9 @@ importers:
       '@types/jest':
         specifier: 30.0.0
         version: 30.0.0
+      '@typescript/native-preview':
+        specifier: 7.0.0-dev.20260225.1
+        version: 7.0.0-dev.20260225.1
       concurrently:
         specifier: 9.2.1
         version: 9.2.1
@@ -3882,9 +3909,6 @@ importers:
       sass-loader:
         specifier: 16.0.5
         version: 16.0.5(sass-embedded@1.97.2)(webpack@5.105.2)
-      typescript:
-        specifier: 5.9.3
-        version: 5.9.3
       webpack:
         specifier: 5.105.2
         version: 5.105.2(webpack-cli@6.0.1)
@@ -4025,7 +4049,7 @@ importers:
         version: 10.2.11(@types/react@18.3.28)(storybook@10.2.11(@testing-library/dom@10.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(webpack@5.105.2)
       '@storybook/react':
         specifier: 10.2.11
-        version: 10.2.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.2.11(@testing-library/dom@10.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.3)
+        version: 10.2.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.2.11(@testing-library/dom@10.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@testing-library/dom':
         specifier: 10.4.1
         version: 10.4.1
@@ -4047,6 +4071,9 @@ importers:
       '@types/react-dom':
         specifier: 18.3.7
         version: 18.3.7(@types/react@18.3.28)
+      '@typescript/native-preview':
+        specifier: 7.0.0-dev.20260225.1
+        version: 7.0.0-dev.20260225.1
       '@wordpress/browserslist-config':
         specifier: 6.40.0
         version: 6.40.0
@@ -4070,7 +4097,7 @@ importers:
         version: 12.1.11(postcss@8.5.6)
       postcss-loader:
         specifier: 8.2.0
-        version: 8.2.0(postcss@8.5.6)(typescript@5.9.3)(webpack@5.105.2)
+        version: 8.2.0(postcss@8.5.6)(webpack@5.105.2)
       require-from-string:
         specifier: 2.0.2
         version: 2.0.2
@@ -4083,9 +4110,6 @@ importers:
       storybook:
         specifier: 10.2.11
         version: 10.2.11(@testing-library/dom@10.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      typescript:
-        specifier: 5.9.3
-        version: 5.9.3
       webpack:
         specifier: 5.105.2
         version: 5.105.2(webpack-cli@6.0.1)
@@ -4117,15 +4141,15 @@ importers:
       '@types/jquery':
         specifier: 3.5.33
         version: 3.5.33
+      '@typescript/native-preview':
+        specifier: 7.0.0-dev.20260225.1
+        version: 7.0.0-dev.20260225.1
       '@wordpress/browserslist-config':
         specifier: 6.40.0
         version: 6.40.0
       jest:
         specifier: 30.2.0
         version: 30.2.0
-      typescript:
-        specifier: 5.9.3
-        version: 5.9.3
       webpack:
         specifier: 5.105.2
         version: 5.105.2(webpack-cli@6.0.1)
@@ -4385,7 +4409,7 @@ importers:
         version: 7.28.5(@babel/core@7.29.0)
       '@storybook/react':
         specifier: 10.2.11
-        version: 10.2.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.2.11(@testing-library/dom@10.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.3)
+        version: 10.2.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.2.11(@testing-library/dom@10.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@testing-library/dom':
         specifier: 10.4.1
         version: 10.4.1
@@ -4395,6 +4419,9 @@ importers:
       '@types/jquery':
         specifier: 3.5.33
         version: 3.5.33
+      '@typescript/native-preview':
+        specifier: 7.0.0-dev.20260225.1
+        version: 7.0.0-dev.20260225.1
       '@wordpress/browserslist-config':
         specifier: 6.40.0
         version: 6.40.0
@@ -4437,9 +4464,6 @@ importers:
       tslib:
         specifier: 2.8.1
         version: 2.8.1
-      typescript:
-        specifier: 5.9.3
-        version: 5.9.3
       webpack:
         specifier: 5.105.2
         version: 5.105.2(webpack-cli@6.0.1)
@@ -4455,6 +4479,9 @@ importers:
       '@types/node':
         specifier: ^22.19.11
         version: 22.19.11
+      '@typescript/native-preview':
+        specifier: 7.0.0-dev.20260225.1
+        version: 7.0.0-dev.20260225.1
       _jetpack-e2e-commons:
         specifier: workspace:*
         version: link:../../../../../tools/e2e-commons
@@ -4467,9 +4494,6 @@ importers:
       playwright-ctrf-json-reporter:
         specifier: ^0.0.26
         version: 0.0.26
-      typescript:
-        specifier: 5.9.3
-        version: 5.9.3
 
   projects/plugins/classic-theme-helper-plugin:
     dependencies:
@@ -4555,6 +4579,9 @@ importers:
       '@types/node':
         specifier: ^22.19.11
         version: 22.19.11
+      '@typescript/native-preview':
+        specifier: 7.0.0-dev.20260225.1
+        version: 7.0.0-dev.20260225.1
       _jetpack-e2e-commons:
         specifier: workspace:*
         version: link:../../../../../tools/e2e-commons
@@ -4567,9 +4594,6 @@ importers:
       playwright-ctrf-json-reporter:
         specifier: ^0.0.26
         version: 0.0.26
-      typescript:
-        specifier: 5.9.3
-        version: 5.9.3
 
   projects/plugins/crm:
     dependencies:
@@ -4658,6 +4682,9 @@ importers:
       '@types/react-dom':
         specifier: 18.3.7
         version: 18.3.7(@types/react@18.3.28)
+      '@typescript/native-preview':
+        specifier: 7.0.0-dev.20260225.1
+        version: 7.0.0-dev.20260225.1
       chart.js:
         specifier: 4.5.0
         version: 4.5.0
@@ -4712,9 +4739,6 @@ importers:
       typeahead.js:
         specifier: 0.11.1
         version: 0.11.1
-      typescript:
-        specifier: 5.9.3
-        version: 5.9.3
       webpack:
         specifier: 5.105.2
         version: 5.105.2(webpack-cli@6.0.1)
@@ -4742,6 +4766,9 @@ importers:
       '@rollup/plugin-typescript':
         specifier: 12.1.0
         version: 12.1.0(rollup@3.30.0)(tslib@2.8.1)(typescript@5.9.3)
+      '@typescript/native-preview':
+        specifier: 7.0.0-dev.20260225.1
+        version: 7.0.0-dev.20260225.1
       '@wordpress/i18n':
         specifier: 6.13.0
         version: 6.13.0
@@ -5078,7 +5105,7 @@ importers:
         version: 4.0.0(postcss@8.5.6)
       '@svgr/webpack':
         specifier: 8.1.0
-        version: 8.1.0(typescript@5.9.3)
+        version: 8.1.0
       '@testing-library/dom':
         specifier: 10.4.1
         version: 10.4.1
@@ -5097,6 +5124,9 @@ importers:
       '@types/wordpress__block-editor':
         specifier: 15.0.3
         version: 15.0.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@typescript/native-preview':
+        specifier: 7.0.0-dev.20260225.1
+        version: 7.0.0-dev.20260225.1
       '@wordpress/api-fetch':
         specifier: 7.40.0
         version: 7.40.0
@@ -5159,16 +5189,13 @@ importers:
         version: 8.5.6
       postcss-loader:
         specifier: 8.2.0
-        version: 8.2.0(postcss@8.5.6)(typescript@5.9.3)(webpack@5.105.2)
+        version: 8.2.0(postcss@8.5.6)(webpack@5.105.2)
       regenerator-runtime:
         specifier: 0.13.9
         version: 0.13.9
       sass-loader:
         specifier: 16.0.5
         version: 16.0.5(sass-embedded@1.97.2)(webpack@5.105.2)
-      typescript:
-        specifier: 5.9.3
-        version: 5.9.3
     optionalDependencies:
       react:
         specifier: 18.3.1
@@ -5185,6 +5212,9 @@ importers:
       '@types/node':
         specifier: ^22.19.11
         version: 22.19.11
+      '@typescript/native-preview':
+        specifier: 7.0.0-dev.20260225.1
+        version: 7.0.0-dev.20260225.1
       _jetpack-e2e-commons:
         specifier: workspace:*
         version: link:../../../../../tools/e2e-commons
@@ -5197,9 +5227,6 @@ importers:
       playwright-ctrf-json-reporter:
         specifier: ^0.0.26
         version: 0.0.26
-      typescript:
-        specifier: 5.9.3
-        version: 5.9.3
 
   projects/plugins/mu-wpcom-plugin: {}
 
@@ -5360,6 +5387,9 @@ importers:
       '@types/react':
         specifier: 18.3.28
         version: 18.3.28
+      '@typescript/native-preview':
+        specifier: 7.0.0-dev.20260225.1
+        version: 7.0.0-dev.20260225.1
       '@wordpress/browserslist-config':
         specifier: 6.40.0
         version: 6.40.0
@@ -5372,9 +5402,6 @@ importers:
       sass-loader:
         specifier: 16.0.5
         version: 16.0.5(sass-embedded@1.97.2)(webpack@5.105.2)
-      typescript:
-        specifier: 5.9.3
-        version: 5.9.3
       webpack:
         specifier: 5.105.2
         version: 5.105.2(webpack-cli@6.0.1)
@@ -5390,6 +5417,9 @@ importers:
       '@types/node':
         specifier: ^22.19.11
         version: 22.19.11
+      '@typescript/native-preview':
+        specifier: 7.0.0-dev.20260225.1
+        version: 7.0.0-dev.20260225.1
       _jetpack-e2e-commons:
         specifier: workspace:*
         version: link:../../../../../tools/e2e-commons
@@ -5402,9 +5432,6 @@ importers:
       playwright-ctrf-json-reporter:
         specifier: ^0.0.26
         version: 0.0.26
-      typescript:
-        specifier: 5.9.3
-        version: 5.9.3
 
   projects/plugins/search: {}
 
@@ -5416,6 +5443,9 @@ importers:
       '@types/node':
         specifier: ^22.19.11
         version: 22.19.11
+      '@typescript/native-preview':
+        specifier: 7.0.0-dev.20260225.1
+        version: 7.0.0-dev.20260225.1
       _jetpack-e2e-commons:
         specifier: workspace:*
         version: link:../../../../../tools/e2e-commons
@@ -5428,9 +5458,6 @@ importers:
       playwright-ctrf-json-reporter:
         specifier: ^0.0.26
         version: 0.0.26
-      typescript:
-        specifier: 5.9.3
-        version: 5.9.3
 
   projects/plugins/social:
     devDependencies:
@@ -5446,6 +5473,9 @@ importers:
       '@types/node':
         specifier: ^22.19.11
         version: 22.19.11
+      '@typescript/native-preview':
+        specifier: 7.0.0-dev.20260225.1
+        version: 7.0.0-dev.20260225.1
       _jetpack-e2e-commons:
         specifier: workspace:*
         version: link:../../../../../tools/e2e-commons
@@ -5458,9 +5488,6 @@ importers:
       playwright-ctrf-json-reporter:
         specifier: ^0.0.26
         version: 0.0.26
-      typescript:
-        specifier: 5.9.3
-        version: 5.9.3
 
   projects/plugins/starter-plugin:
     dependencies:
@@ -5543,6 +5570,9 @@ importers:
       '@types/node':
         specifier: ^22.19.11
         version: 22.19.11
+      '@typescript/native-preview':
+        specifier: 7.0.0-dev.20260225.1
+        version: 7.0.0-dev.20260225.1
       _jetpack-e2e-commons:
         specifier: workspace:*
         version: link:../../../../../tools/e2e-commons
@@ -5555,9 +5585,6 @@ importers:
       playwright-ctrf-json-reporter:
         specifier: ^0.0.26
         version: 0.0.26
-      typescript:
-        specifier: 5.9.3
-        version: 5.9.3
 
   projects/plugins/super-cache: {}
 
@@ -5572,6 +5599,9 @@ importers:
       '@types/shell-escape':
         specifier: 0.2.3
         version: 0.2.3
+      '@typescript/native-preview':
+        specifier: 7.0.0-dev.20260225.1
+        version: 7.0.0-dev.20260225.1
       _jetpack-e2e-commons:
         specifier: workspace:*
         version: link:../../../../../tools/e2e-commons
@@ -5672,6 +5702,9 @@ importers:
       '@types/node':
         specifier: ^22.19.11
         version: 22.19.11
+      '@typescript/native-preview':
+        specifier: 7.0.0-dev.20260225.1
+        version: 7.0.0-dev.20260225.1
       _jetpack-e2e-commons:
         specifier: workspace:*
         version: link:../../../../../tools/e2e-commons
@@ -5684,9 +5717,6 @@ importers:
       playwright-ctrf-json-reporter:
         specifier: ^0.0.26
         version: 0.0.26
-      typescript:
-        specifier: 5.9.3
-        version: 5.9.3
 
   projects/plugins/wpcomsh:
     devDependencies:
@@ -5781,6 +5811,9 @@ importers:
         specifier: 18.0.0
         version: 18.0.0
     devDependencies:
+      '@typescript/native-preview':
+        specifier: 7.0.0-dev.20260225.1
+        version: 7.0.0-dev.20260225.1
       jest:
         specifier: 30.2.0
         version: 30.2.0
@@ -5808,6 +5841,9 @@ importers:
       '@types/node':
         specifier: ^22.19.11
         version: 22.19.11
+      '@typescript/native-preview':
+        specifier: 7.0.0-dev.20260225.1
+        version: 7.0.0-dev.20260225.1
       '@wordpress/e2e-test-utils-playwright':
         specifier: 1.40.0
         version: 1.40.0(@playwright/test@1.58.2)(@types/node@22.19.11)
@@ -5835,9 +5871,6 @@ importers:
       shell-escape:
         specifier: 0.2.0
         version: 0.2.0
-      typescript:
-        specifier: 5.9.3
-        version: 5.9.3
       winston:
         specifier: 3.17.0
         version: 3.17.0
@@ -5889,6 +5922,9 @@ importers:
       '@testing-library/jest-dom':
         specifier: 6.9.1
         version: 6.9.1
+      '@typescript/native-preview':
+        specifier: 7.0.0-dev.20260225.1
+        version: 7.0.0-dev.20260225.1
       '@wordpress/eslint-plugin':
         specifier: 24.2.0
         version: 24.2.0(@babel/core@7.29.0)(eslint-config-prettier@10.1.8(eslint@9.39.3))(eslint-plugin-import@2.32.0)(eslint-plugin-jest@29.15.0(eslint@9.39.3)(jest@30.2.0)(typescript@5.9.3))(eslint-plugin-jsdoc@62.7.0(eslint@9.39.3))(eslint-plugin-jsx-a11y@6.10.2(eslint@9.39.3))(eslint-plugin-playwright@2.7.0(eslint@9.39.3))(eslint-plugin-prettier@5.5.5(eslint-config-prettier@10.1.8(eslint@9.39.3))(eslint@9.39.3)(wp-prettier@3.0.3))(eslint-plugin-react-hooks@7.0.1(eslint@9.39.3))(eslint-plugin-react@7.37.5(eslint@9.39.3))(eslint@9.39.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))(typescript@5.9.3)(wp-prettier@3.0.3)
@@ -10073,6 +10109,45 @@ packages:
   '@typescript-eslint/visitor-keys@8.56.0':
     resolution: {integrity: sha512-q+SL+b+05Ud6LbEE35qe4A99P+htKTKVbyiNEe45eCbJFyh/HVK9QXwlrbz+Q4L8SOW4roxSVwXYj4DMBT7Ieg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260225.1':
+    resolution: {integrity: sha512-3qSsqv7FmM4z09wEpEXdhmgMfiJF/OMOZa41AdgMsXTTRpX2/38hDg2KGhi3fc24M2T3MnLPLTqw6HyTOBaV1Q==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260225.1':
+    resolution: {integrity: sha512-F8ZCCX2UESHcbxvnkd1Dn5PTnOOgpGddFHYgn4usyWRMzNZLPP+YjyGALZe9zdR/D8L0uraND0Haok+TPq8xYg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260225.1':
+    resolution: {integrity: sha512-Up8Z/QNcwce5C4rWnbLNW5w7lRARdyKZcNbB1NMnaswaGOBdeDmdP0wbVsOgJMoDp6vnun+EkvrSft8hWLLhIg==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@typescript/native-preview-linux-arm@7.0.0-dev.20260225.1':
+    resolution: {integrity: sha512-Iu5rnCmqwGIMUu//BXkl9VQaxAAsqVvFhU4mJoNexNkMxPqVcu9quqYAouY7tN/95WcKzUsPpyRfkThdbNFO/g==}
+    cpu: [arm]
+    os: [linux]
+
+  '@typescript/native-preview-linux-x64@7.0.0-dev.20260225.1':
+    resolution: {integrity: sha512-WWjIfHCWlcriempYYc/sPJ3HFt6znNZKp60nvDNih0+wmxNqEfT5Yzu5zAY0awIe7XLelFSY+bolkpzMYVWEIQ==}
+    cpu: [x64]
+    os: [linux]
+
+  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260225.1':
+    resolution: {integrity: sha512-lmfQO+HdmPMk0dtPoNo8dZereTUYNQuapsAI7nFHCP8F25I8eGKKXY2nD1R8W1hp/LmVtske1pqKFNN6IOCt5g==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@typescript/native-preview-win32-x64@7.0.0-dev.20260225.1':
+    resolution: {integrity: sha512-e4eJyzR9ne0XreqYgQNqfX7SNuaePxggnUtVrLERgBv25QKwdQl72GnSXDhdxZHzrb97YwumiXWMQQJj9h8NCg==}
+    cpu: [x64]
+    os: [win32]
+
+  '@typescript/native-preview@7.0.0-dev.20260225.1':
+    resolution: {integrity: sha512-mUf1aON+eZLupLorX4214n4W6uWIz/lvNv81ErzjJylD/GyJPEJkvDLmgIK3bbvLpMwTRWdVJLhpLCah5Qe8iA==}
+    hasBin: true
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
@@ -22342,6 +22417,17 @@ snapshots:
       - uglify-js
       - webpack-cli
 
+  '@storybook/react@10.2.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.2.11(@testing-library/dom@10.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))':
+    dependencies:
+      '@storybook/global': 5.0.0
+      '@storybook/react-dom-shim': 10.2.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.2.11(@testing-library/dom@10.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+      react: 18.3.1
+      react-docgen: 8.0.2
+      react-dom: 18.3.1(react@18.3.1)
+      storybook: 10.2.11(@testing-library/dom@10.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+    transitivePeerDependencies:
+      - supports-color
+
   '@storybook/react@10.2.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.2.11(@testing-library/dom@10.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.3)':
     dependencies:
       '@storybook/global': 5.0.0
@@ -22444,12 +22530,12 @@ snapshots:
       '@svgr/babel-plugin-transform-react-native-svg': 8.1.0(@babel/core@7.29.0)
       '@svgr/babel-plugin-transform-svg-component': 8.0.0(@babel/core@7.29.0)
 
-  '@svgr/core@8.1.0(typescript@5.9.3)':
+  '@svgr/core@8.1.0':
     dependencies:
       '@babel/core': 7.29.0
       '@svgr/babel-preset': 8.1.0(@babel/core@7.29.0)
       camelcase: 6.3.0
-      cosmiconfig: 8.3.6(typescript@5.9.3)
+      cosmiconfig: 8.3.6
       snake-case: 3.0.4
     transitivePeerDependencies:
       - supports-color
@@ -22460,35 +22546,35 @@ snapshots:
       '@babel/types': 7.29.0
       entities: 4.5.0
 
-  '@svgr/plugin-jsx@8.1.0(@svgr/core@8.1.0(typescript@5.9.3))':
+  '@svgr/plugin-jsx@8.1.0(@svgr/core@8.1.0)':
     dependencies:
       '@babel/core': 7.29.0
       '@svgr/babel-preset': 8.1.0(@babel/core@7.29.0)
-      '@svgr/core': 8.1.0(typescript@5.9.3)
+      '@svgr/core': 8.1.0
       '@svgr/hast-util-to-babel-ast': 8.0.0
       svg-parser: 2.0.4
     transitivePeerDependencies:
       - supports-color
 
-  '@svgr/plugin-svgo@8.1.0(@svgr/core@8.1.0(typescript@5.9.3))(typescript@5.9.3)':
+  '@svgr/plugin-svgo@8.1.0(@svgr/core@8.1.0)':
     dependencies:
-      '@svgr/core': 8.1.0(typescript@5.9.3)
-      cosmiconfig: 8.3.6(typescript@5.9.3)
+      '@svgr/core': 8.1.0
+      cosmiconfig: 8.3.6
       deepmerge: 4.3.1
       svgo: 3.3.2
     transitivePeerDependencies:
       - typescript
 
-  '@svgr/webpack@8.1.0(typescript@5.9.3)':
+  '@svgr/webpack@8.1.0':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-transform-react-constant-elements': 7.27.1(@babel/core@7.29.0)
       '@babel/preset-env': 7.29.0(@babel/core@7.29.0)
       '@babel/preset-react': 7.28.5(@babel/core@7.29.0)
       '@babel/preset-typescript': 7.28.5(@babel/core@7.29.0)
-      '@svgr/core': 8.1.0(typescript@5.9.3)
-      '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0(typescript@5.9.3))
-      '@svgr/plugin-svgo': 8.1.0(@svgr/core@8.1.0(typescript@5.9.3))(typescript@5.9.3)
+      '@svgr/core': 8.1.0
+      '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0)
+      '@svgr/plugin-svgo': 8.1.0(@svgr/core@8.1.0)
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -23144,6 +23230,37 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 8.56.0
       eslint-visitor-keys: 5.0.1
+
+  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260225.1':
+    optional: true
+
+  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260225.1':
+    optional: true
+
+  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260225.1':
+    optional: true
+
+  '@typescript/native-preview-linux-arm@7.0.0-dev.20260225.1':
+    optional: true
+
+  '@typescript/native-preview-linux-x64@7.0.0-dev.20260225.1':
+    optional: true
+
+  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260225.1':
+    optional: true
+
+  '@typescript/native-preview-win32-x64@7.0.0-dev.20260225.1':
+    optional: true
+
+  '@typescript/native-preview@7.0.0-dev.20260225.1':
+    optionalDependencies:
+      '@typescript/native-preview-darwin-arm64': 7.0.0-dev.20260225.1
+      '@typescript/native-preview-darwin-x64': 7.0.0-dev.20260225.1
+      '@typescript/native-preview-linux-arm': 7.0.0-dev.20260225.1
+      '@typescript/native-preview-linux-arm64': 7.0.0-dev.20260225.1
+      '@typescript/native-preview-linux-x64': 7.0.0-dev.20260225.1
+      '@typescript/native-preview-win32-arm64': 7.0.0-dev.20260225.1
+      '@typescript/native-preview-win32-x64': 7.0.0-dev.20260225.1
 
   '@ungap/structured-clone@1.3.0': {}
 
@@ -27089,6 +27206,13 @@ snapshots:
       parse-json: 5.2.0
       path-type: 4.0.0
       yaml: 1.10.2
+
+  cosmiconfig@8.3.6:
+    dependencies:
+      import-fresh: 3.3.1
+      js-yaml: 4.1.1
+      parse-json: 5.2.0
+      path-type: 4.0.0
 
   cosmiconfig@8.3.6(typescript@5.9.3):
     dependencies:

--- a/projects/github-actions/repo-gardening/changelog/update-switch-to-tsgo
+++ b/projects/github-actions/repo-gardening/changelog/update-switch-to-tsgo
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Switch to Native TypeScript compiler based on Go.

--- a/projects/github-actions/repo-gardening/package.json
+++ b/projects/github-actions/repo-gardening/package.json
@@ -16,7 +16,7 @@
 		"build": "ncc build src/index.ts -o dist --source-map --license licenses.txt -t",
 		"test": "NODE_OPTIONS=--experimental-vm-modules jest --config=tests/jest.config.cjs --verbose",
 		"test-coverage": "pnpm run test --coverage",
-		"typecheck": "tsc --noEmit"
+		"typecheck": "tsgo --noEmit"
 	},
 	"dependencies": {
 		"@actions/core": "3.0.0",
@@ -34,6 +34,7 @@
 		"@babel/preset-typescript": "7.28.5",
 		"@octokit/webhooks-types": "7.6.1",
 		"@types/node": "^22.19.11",
+		"@typescript/native-preview": "7.0.0-dev.20260225.1",
 		"@vercel/ncc": "0.36.1",
 		"babel-jest": "30.2.0",
 		"jest": "30.2.0",

--- a/projects/js-packages/ai-client/changelog/update-switch-to-tsgo
+++ b/projects/js-packages/ai-client/changelog/update-switch-to-tsgo
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Switch to Native TypeScript compiler based on Go.

--- a/projects/js-packages/ai-client/package.json
+++ b/projects/js-packages/ai-client/package.json
@@ -26,11 +26,11 @@
 	"scripts": {
 		"build": "pnpm run clean && pnpm run compile-ts",
 		"clean": "rm -rf build/",
-		"compile-ts": "tsc --pretty",
+		"compile-ts": "tsgo --pretty",
 		"test": "NODE_OPTIONS=--experimental-vm-modules jest",
 		"test-coverage": "pnpm run test --coverage",
-		"typecheck": "tsc --noEmit",
-		"watch": "tsc --watch --pretty"
+		"typecheck": "tsgo --noEmit",
+		"watch": "tsgo --watch --pretty"
 	},
 	"dependencies": {
 		"@automattic/jetpack-base-styles": "workspace:*",
@@ -70,8 +70,8 @@
 		"@testing-library/dom": "10.4.1",
 		"@types/markdown-it": "14.1.2",
 		"@types/turndown": "5.0.6",
+		"@typescript/native-preview": "7.0.0-dev.20260225.1",
 		"jest": "30.2.0",
-		"storybook": "10.2.11",
-		"typescript": "5.9.3"
+		"storybook": "10.2.11"
 	}
 }

--- a/projects/js-packages/boost-score-api/changelog/update-switch-to-tsgo
+++ b/projects/js-packages/boost-score-api/changelog/update-switch-to-tsgo
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Switch to Native TypeScript compiler based on Go.

--- a/projects/js-packages/boost-score-api/package.json
+++ b/projects/js-packages/boost-score-api/package.json
@@ -26,7 +26,7 @@
 		"clean": "rm -rf build/",
 		"test": "jest --config=tests/jest.config.cjs",
 		"test-coverage": "pnpm run test --coverage",
-		"typecheck": "tsc --noEmit",
+		"typecheck": "tsgo --noEmit",
 		"watch": "pnpm run build && pnpm webpack watch"
 	},
 	"dependencies": {
@@ -35,8 +35,8 @@
 	},
 	"devDependencies": {
 		"@automattic/jetpack-webpack-config": "workspace:*",
+		"@typescript/native-preview": "7.0.0-dev.20260225.1",
 		"jest": "30.2.0",
-		"typescript": "5.9.3",
 		"webpack": "5.105.2",
 		"webpack-cli": "6.0.1"
 	}

--- a/projects/js-packages/charts/changelog/update-switch-to-tsgo
+++ b/projects/js-packages/charts/changelog/update-switch-to-tsgo
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Switch to Native TypeScript compiler based on Go.

--- a/projects/js-packages/charts/package.json
+++ b/projects/js-packages/charts/package.json
@@ -196,7 +196,7 @@
 		"storybook": "cd ../storybook && pnpm run storybook:dev",
 		"test": "TZ=UTC jest --config=tests/jest.config.cjs",
 		"test-coverage": "pnpm run test --coverage",
-		"typecheck": "tsc --noEmit"
+		"typecheck": "tsgo --noEmit"
 	},
 	"dependencies": {
 		"@automattic/number-formatters": "workspace:*",
@@ -243,6 +243,7 @@
 		"@types/jest": "^30.0.0",
 		"@types/react": "18.3.28",
 		"@types/react-dom": "18.3.7",
+		"@typescript/native-preview": "7.0.0-dev.20260225.1",
 		"@visx/glyph": "3.12.0",
 		"@wordpress/components": "32.2.0",
 		"@wordpress/element": "6.40.0",

--- a/projects/js-packages/components/changelog/update-switch-to-tsgo
+++ b/projects/js-packages/components/changelog/update-switch-to-tsgo
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Switch to Native TypeScript compiler based on Go.

--- a/projects/js-packages/components/package.json
+++ b/projects/js-packages/components/package.json
@@ -37,11 +37,11 @@
 	"scripts": {
 		"build": "pnpm run clean && pnpm run compile-ts && pnpm run copy-scss",
 		"clean": "rm -rf build/",
-		"compile-ts": "tsc --pretty --project tsconfig.build.json",
+		"compile-ts": "tsgo --pretty --project tsconfig.build.json",
 		"copy-scss": "node ./tools/copy-scss-to-build.mjs",
 		"test": "NODE_OPTIONS=--experimental-vm-modules jest",
 		"test-coverage": "pnpm run test --coverage",
-		"typecheck": "tsc --noEmit"
+		"typecheck": "tsgo --noEmit"
 	},
 	"browserslist": [
 		"extends @wordpress/browserslist-config"
@@ -85,13 +85,13 @@
 		"@types/react": "18.3.28",
 		"@types/react-dom": "18.3.7",
 		"@types/react-slider": "1.3.6",
+		"@typescript/native-preview": "7.0.0-dev.20260225.1",
 		"jest": "30.2.0",
 		"react": "18.3.1",
 		"react-dom": "18.3.1",
 		"require-from-string": "2.0.2",
 		"storybook": "10.2.11",
 		"ts-dedent": "2.2.0",
-		"typescript": "5.9.3",
 		"webpack": "5.105.2",
 		"webpack-cli": "6.0.1"
 	},

--- a/projects/js-packages/connection/changelog/update-switch-to-tsgo
+++ b/projects/js-packages/connection/changelog/update-switch-to-tsgo
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Switch to Native TypeScript compiler based on Go.

--- a/projects/js-packages/connection/package.json
+++ b/projects/js-packages/connection/package.json
@@ -25,7 +25,7 @@
 	"scripts": {
 		"test": "NODE_OPTIONS=--experimental-vm-modules jest",
 		"test-coverage": "pnpm run test --coverage",
-		"typecheck": "tsc --noEmit"
+		"typecheck": "tsgo --noEmit"
 	},
 	"dependencies": {
 		"@automattic/jetpack-analytics": "workspace:*",
@@ -53,11 +53,11 @@
 		"@testing-library/react": "16.3.0",
 		"@testing-library/user-event": "14.6.1",
 		"@types/react": "18.3.28",
+		"@typescript/native-preview": "7.0.0-dev.20260225.1",
 		"jest": "30.2.0",
 		"react": "18.3.1",
 		"react-dom": "18.3.1",
-		"storybook": "10.2.11",
-		"typescript": "5.9.3"
+		"storybook": "10.2.11"
 	},
 	"peerDependencies": {
 		"react": "^18.0.0",

--- a/projects/js-packages/critical-css-gen/changelog/update-switch-to-tsgo
+++ b/projects/js-packages/critical-css-gen/changelog/update-switch-to-tsgo
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Switch to Native TypeScript compiler based on Go.

--- a/projects/js-packages/critical-css-gen/package.json
+++ b/projects/js-packages/critical-css-gen/package.json
@@ -27,14 +27,14 @@
 	},
 	"main": "./build/browser.js",
 	"scripts": {
-		"build": "pnpm run clean && tsc",
+		"build": "pnpm run clean && tsgo",
 		"build:test": "pnpm run clean:test && webpack --config tests/data/webpack.config.cjs",
 		"clean": "rm -rf build/",
 		"clean:test": "rm -rf tests/build/",
 		"test": "pnpm build && pnpm build:test && NODE_ENV=test NODE_PATH=./node_modules jest --forceExit --config=tests/config/jest.config.js",
 		"test-coverage": "pnpm run test --coverage",
-		"typecheck": "tsc --noEmit",
-		"watch": "tsc --watch"
+		"typecheck": "tsgo --noEmit",
+		"watch": "tsgo --watch"
 	},
 	"dependencies": {
 		"clean-css": "^5.3.1",
@@ -48,6 +48,7 @@
 		"@types/clean-css": "4.2.11",
 		"@types/css-tree": "2.3.11",
 		"@types/node": "^22.19.11",
+		"@typescript/native-preview": "7.0.0-dev.20260225.1",
 		"express": "4.22.0",
 		"jest": "30.2.0",
 		"path-browserify": "1.0.1",
@@ -57,7 +58,6 @@
 		"source-map": "0.7.4",
 		"source-map-js": "1.2.0",
 		"tslib": "2.8.1",
-		"typescript": "5.9.3",
 		"webpack": "5.105.2",
 		"webpack-cli": "6.0.1"
 	},

--- a/projects/js-packages/critical-css-gen/tsconfig.json
+++ b/projects/js-packages/critical-css-gen/tsconfig.json
@@ -3,6 +3,7 @@
 	"include": [ "src/browser.ts", "src/playwright.ts" ],
 	"exclude": [ "node_modules/**/*" ],
 	"compilerOptions": {
+		"rootDir": "./src",
 		"outDir": "./build",
 		"target": "es2019",
 		"sourceMap": true,

--- a/projects/js-packages/image-guide/changelog/update-switch-to-tsgo
+++ b/projects/js-packages/image-guide/changelog/update-switch-to-tsgo
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Switch to Native TypeScript compiler based on Go.

--- a/projects/js-packages/image-guide/package.json
+++ b/projects/js-packages/image-guide/package.json
@@ -24,18 +24,18 @@
 		"@automattic/jetpack-image-guide": false
 	},
 	"scripts": {
-		"build": "rollup -c && tsc --emitDeclarationOnly",
+		"build": "rollup -c && tsgo --emitDeclarationOnly",
 		"build-concurrently": "pnpm run clear-dist && concurrently 'pnpm:validate-ts' 'rollup -c'",
 		"build-development": "pnpm run build-concurrently",
 		"build-production": "NODE_ENV=production BABEL_ENV=production pnpm run build-concurrently",
 		"clear-dist": "rm -rf app/assets/dist/*",
 		"dev": "concurrently 'pnpm:dev-validate-ts' 'pnpm:dev-compile'",
 		"dev-compile": "pnpm run clear-dist && rollup -c -w",
-		"dev-validate-ts": "tsc --watch --pretty --strict false # Note: Disable Strict mode to avoid noisy development, while keeping strict errors visible in IDEs.",
+		"dev-validate-ts": "tsgo --watch --pretty --strict false # Note: Disable Strict mode to avoid noisy development, while keeping strict errors visible in IDEs.",
 		"test": "NODE_OPTIONS=--experimental-vm-modules jest --config=tests/jest.config.cjs",
 		"test-coverage": "pnpm run test --coverage",
-		"typecheck": "tsc --noEmit",
-		"validate-ts": "tsc --pretty --strict false",
+		"typecheck": "tsgo --noEmit",
+		"validate-ts": "tsgo --pretty --strict false",
 		"watch": "pnpm run dev"
 	},
 	"devDependencies": {
@@ -50,6 +50,7 @@
 		"@rollup/plugin-replace": "5.0.2",
 		"@rollup/plugin-terser": "0.4.3",
 		"@rollup/plugin-typescript": "12.1.0",
+		"@typescript/native-preview": "7.0.0-dev.20260225.1",
 		"concurrently": "9.2.1",
 		"jest": "30.2.0",
 		"postcss": "8.5.6",

--- a/projects/js-packages/licensing/changelog/update-switch-to-tsgo
+++ b/projects/js-packages/licensing/changelog/update-switch-to-tsgo
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Switch to Native TypeScript compiler based on Go.

--- a/projects/js-packages/licensing/package.json
+++ b/projects/js-packages/licensing/package.json
@@ -23,7 +23,7 @@
 	"scripts": {
 		"test": "jest",
 		"test-coverage": "pnpm run test --coverage",
-		"typecheck": "tsc --noEmit"
+		"typecheck": "tsgo --noEmit"
 	},
 	"dependencies": {
 		"@automattic/jetpack-analytics": "workspace:*",
@@ -48,10 +48,10 @@
 		"@testing-library/react": "16.3.0",
 		"@testing-library/user-event": "14.6.1",
 		"@types/react": "18.3.28",
+		"@typescript/native-preview": "7.0.0-dev.20260225.1",
 		"babel-jest": "30.2.0",
 		"jest": "30.2.0",
 		"react": "18.3.1",
-		"react-dom": "18.3.1",
-		"typescript": "5.9.3"
+		"react-dom": "18.3.1"
 	}
 }

--- a/projects/js-packages/number-formatters/changelog/update-switch-to-tsgo
+++ b/projects/js-packages/number-formatters/changelog/update-switch-to-tsgo
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Switch to Native TypeScript compiler based on Go.

--- a/projects/js-packages/number-formatters/package.json
+++ b/projects/js-packages/number-formatters/package.json
@@ -30,7 +30,7 @@
 		"clean": "rm -rf dist",
 		"test": "NODE_OPTIONS=--experimental-vm-modules jest",
 		"test-coverage": "pnpm run test --coverage",
-		"typecheck": "tsc --noEmit"
+		"typecheck": "tsgo --noEmit"
 	},
 	"dependencies": {
 		"@wordpress/date": "^5.19.0",
@@ -43,6 +43,7 @@
 		"@jest/globals": "30.2.0",
 		"@knighted/duel": "2.1.5",
 		"@types/jest": "30.0.0",
+		"@typescript/native-preview": "7.0.0-dev.20260225.1",
 		"jest": "30.2.0",
 		"typescript": "5.9.3"
 	}

--- a/projects/js-packages/partner-coupon/changelog/update-switch-to-tsgo
+++ b/projects/js-packages/partner-coupon/changelog/update-switch-to-tsgo
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Switch to Native TypeScript compiler based on Go.

--- a/projects/js-packages/partner-coupon/package.json
+++ b/projects/js-packages/partner-coupon/package.json
@@ -37,6 +37,7 @@
 		"@testing-library/dom": "10.4.1",
 		"@testing-library/react": "16.3.0",
 		"@testing-library/user-event": "14.6.1",
+		"@typescript/native-preview": "7.0.0-dev.20260225.1",
 		"@wordpress/base-styles": "6.16.0",
 		"@wordpress/data": "10.40.0",
 		"jest": "30.2.0",

--- a/projects/js-packages/react-data-sync-client/changelog/update-switch-to-tsgo
+++ b/projects/js-packages/react-data-sync-client/changelog/update-switch-to-tsgo
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Switch to Native TypeScript compiler based on Go.

--- a/projects/js-packages/react-data-sync-client/package.json
+++ b/projects/js-packages/react-data-sync-client/package.json
@@ -28,18 +28,18 @@
 		"clean": "rm -rf build/",
 		"test": "NODE_OPTIONS=--experimental-vm-modules jest --config=tests/jest.config.cjs",
 		"test-coverage": "pnpm run test --coverage",
-		"typecheck": "tsc --noEmit",
+		"typecheck": "tsgo --noEmit",
 		"watch": "pnpm run build && pnpm webpack watch"
 	},
 	"devDependencies": {
 		"@automattic/jetpack-webpack-config": "workspace:*",
 		"@tanstack/react-query": "5.90.8",
 		"@tanstack/react-query-devtools": "5.90.2",
+		"@typescript/native-preview": "7.0.0-dev.20260225.1",
 		"jest": "30.2.0",
 		"react": "18.3.1",
 		"react-dom": "^18.0.0",
 		"tslib": "2.8.1",
-		"typescript": "5.9.3",
 		"webpack": "5.105.2",
 		"webpack-cli": "6.0.1",
 		"zod": "3.25.76"

--- a/projects/js-packages/scan/changelog/update-switch-to-tsgo
+++ b/projects/js-packages/scan/changelog/update-switch-to-tsgo
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Switch to Native TypeScript compiler based on Go.

--- a/projects/js-packages/scan/package.json
+++ b/projects/js-packages/scan/package.json
@@ -26,10 +26,10 @@
 	"scripts": {
 		"build": "pnpm run clean && pnpm run compile-ts",
 		"clean": "rm -rf build/",
-		"compile-ts": "tsc --pretty",
+		"compile-ts": "tsgo --pretty",
 		"test": "NODE_OPTIONS=--experimental-vm-modules jest",
 		"test-coverage": "pnpm run test --coverage",
-		"typecheck": "tsc --noEmit"
+		"typecheck": "tsgo --noEmit"
 	},
 	"dependencies": {
 		"@automattic/jetpack-api": "workspace:*",
@@ -52,11 +52,11 @@
 		"@testing-library/react": "16.3.0",
 		"@types/jest": "30.0.0",
 		"@types/react": "18.3.28",
+		"@typescript/native-preview": "7.0.0-dev.20260225.1",
 		"jest": "30.2.0",
 		"react": "^18.2.0",
 		"react-dom": "^18.2.0",
-		"storybook": "10.2.11",
-		"typescript": "5.9.3"
+		"storybook": "10.2.11"
 	},
 	"peerDependencies": {
 		"react": "^18.2.0",

--- a/projects/js-packages/script-data/changelog/update-switch-to-tsgo
+++ b/projects/js-packages/script-data/changelog/update-switch-to-tsgo
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Switch to Native TypeScript compiler based on Go.

--- a/projects/js-packages/script-data/package.json
+++ b/projects/js-packages/script-data/package.json
@@ -17,9 +17,9 @@
 		".": "./src/index.ts"
 	},
 	"scripts": {
-		"typecheck": "tsc --noEmit"
+		"typecheck": "tsgo --noEmit"
 	},
 	"devDependencies": {
-		"typescript": "5.9.3"
+		"@typescript/native-preview": "7.0.0-dev.20260225.1"
 	}
 }

--- a/projects/js-packages/shared-extension-utils/changelog/update-switch-to-tsgo
+++ b/projects/js-packages/shared-extension-utils/changelog/update-switch-to-tsgo
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Switch to Native TypeScript compiler based on Go.

--- a/projects/js-packages/shared-extension-utils/package.json
+++ b/projects/js-packages/shared-extension-utils/package.json
@@ -26,7 +26,7 @@
 	"scripts": {
 		"test": "jest",
 		"test-coverage": "pnpm run test --coverage",
-		"typecheck": "tsc --noEmit"
+		"typecheck": "tsgo --noEmit"
 	},
 	"dependencies": {
 		"@automattic/color-studio": "4.1.0",
@@ -60,11 +60,11 @@
 		"@testing-library/dom": "10.4.1",
 		"@testing-library/react": "16.3.0",
 		"@testing-library/user-event": "14.6.1",
+		"@typescript/native-preview": "7.0.0-dev.20260225.1",
 		"babel-jest": "30.2.0",
 		"jest": "30.2.0",
 		"jetpack-js-tools": "workspace:*",
 		"react": "18.3.1",
-		"react-dom": "18.3.1",
-		"typescript": "5.9.3"
+		"react-dom": "18.3.1"
 	}
 }

--- a/projects/js-packages/social-logos/changelog/update-switch-to-tsgo
+++ b/projects/js-packages/social-logos/changelog/update-switch-to-tsgo
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Switch to Native TypeScript compiler based on Go.

--- a/projects/js-packages/social-logos/package.json
+++ b/projects/js-packages/social-logos/package.json
@@ -28,7 +28,7 @@
 	"types": "build/react/index.d.ts",
 	"scripts": {
 		"build": "./tools/build",
-		"typecheck": "tsc --noEmit"
+		"typecheck": "tsgo --noEmit"
 	},
 	"dependencies": {
 		"prop-types": "^15.8.1"
@@ -36,6 +36,7 @@
 	"devDependencies": {
 		"@types/react": "18.3.28",
 		"@types/react-dom": "18.3.7",
+		"@typescript/native-preview": "7.0.0-dev.20260225.1",
 		"glob": "13.0.0",
 		"react": "^18.3.1",
 		"react-dom": "^18.3.1",
@@ -43,7 +44,6 @@
 		"svgicons2svgfont": "^15.0.0",
 		"svgo": "^4.0.0",
 		"svgstore": "^3.0.1",
-		"typescript": "5.9.3",
 		"wawoff2": "^2.0.1",
 		"xml2js": "^0.6.2"
 	},

--- a/projects/js-packages/social-previews/changelog/update-switch-to-tsgo
+++ b/projects/js-packages/social-previews/changelog/update-switch-to-tsgo
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Switch to Native TypeScript compiler based on Go.

--- a/projects/js-packages/social-previews/package.json
+++ b/projects/js-packages/social-previews/package.json
@@ -37,7 +37,7 @@
 		"build:prod": "tsup",
 		"test": "jest --config=tests/jest.config.cjs",
 		"test-coverage": "pnpm run test --coverage",
-		"typecheck": "tsc --noEmit"
+		"typecheck": "tsgo --noEmit"
 	},
 	"dependencies": {
 		"@wordpress/components": "32.2.0",
@@ -54,6 +54,7 @@
 		"@types/jest": "30.0.0",
 		"@types/react": "18.3.28",
 		"@types/react-dom": "18.3.7",
+		"@typescript/native-preview": "7.0.0-dev.20260225.1",
 		"babel-jest": "30.2.0",
 		"esbuild": "0.25.9",
 		"esbuild-sass-plugin": "3.3.1",

--- a/projects/js-packages/storybook/changelog/update-switch-to-tsgo
+++ b/projects/js-packages/storybook/changelog/update-switch-to-tsgo
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Switch to Native TypeScript compiler based on Go.

--- a/projects/js-packages/storybook/package.json
+++ b/projects/js-packages/storybook/package.json
@@ -38,6 +38,7 @@
 		"@storybook/test-runner": "0.24.2",
 		"@testing-library/dom": "10.4.1",
 		"@types/react": "18.3.28",
+		"@typescript/native-preview": "7.0.0-dev.20260225.1",
 		"@wordpress/base-styles": "6.16.0",
 		"@wordpress/block-editor": "15.13.1",
 		"@wordpress/block-library": "9.40.1",

--- a/projects/js-packages/videopress-core/changelog/update-switch-to-tsgo
+++ b/projects/js-packages/videopress-core/changelog/update-switch-to-tsgo
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Switch to Native TypeScript compiler based on Go.

--- a/projects/js-packages/videopress-core/package.json
+++ b/projects/js-packages/videopress-core/package.json
@@ -22,7 +22,7 @@
 		"clean": "rm -rf build/",
 		"test": "NODE_OPTIONS=--experimental-vm-modules jest --config=tests/jest.config.cjs",
 		"test-coverage": "pnpm run test --coverage",
-		"typecheck": "tsc --noEmit",
+		"typecheck": "tsgo --noEmit",
 		"watch": "pnpm run build && pnpm webpack watch"
 	},
 	"devDependencies": {
@@ -30,9 +30,9 @@
 		"@babel/core": "7.29.0",
 		"@babel/preset-react": "7.28.5",
 		"@types/jest": "30.0.0",
+		"@typescript/native-preview": "7.0.0-dev.20260225.1",
 		"jest": "30.2.0",
 		"tslib": "2.8.1",
-		"typescript": "5.9.3",
 		"webpack": "5.105.2",
 		"webpack-cli": "6.0.1"
 	}

--- a/projects/js-packages/webpack-config/changelog/update-switch-to-tsgo
+++ b/projects/js-packages/webpack-config/changelog/update-switch-to-tsgo
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Switch to Native TypeScript compiler based on Go.

--- a/projects/js-packages/webpack-config/package.json
+++ b/projects/js-packages/webpack-config/package.json
@@ -51,6 +51,7 @@
 	"devDependencies": {
 		"@babel/core": "7.29.0",
 		"@babel/runtime": "7.28.6",
+		"@typescript/native-preview": "7.0.0-dev.20260225.1",
 		"typescript": "5.9.3",
 		"webpack": "5.105.2",
 		"webpack-cli": "6.0.1",

--- a/projects/packages/backup/changelog/update-switch-to-tsgo
+++ b/projects/packages/backup/changelog/update-switch-to-tsgo
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Switch to Native TypeScript compiler based on Go.

--- a/projects/packages/backup/package.json
+++ b/projects/packages/backup/package.json
@@ -20,7 +20,7 @@
 		"clean": "rm -rf build/",
 		"test": "jest --config=tests/jest.config.js",
 		"test-coverage": "pnpm run test --coverage",
-		"typecheck": "tsc --noEmit",
+		"typecheck": "tsgo --noEmit",
 		"validate": "pnpm exec validate-es build/",
 		"watch": "pnpm run build && webpack watch"
 	},
@@ -56,13 +56,13 @@
 		"@testing-library/react": "16.3.0",
 		"@testing-library/user-event": "14.6.1",
 		"@types/react": "18.3.28",
+		"@typescript/native-preview": "7.0.0-dev.20260225.1",
 		"@wordpress/browserslist-config": "6.40.0",
 		"concurrently": "9.2.1",
 		"jest": "30.2.0",
 		"sass-embedded": "1.97.2",
 		"sass-loader": "16.0.5",
 		"storybook": "10.2.11",
-		"typescript": "5.9.3",
 		"webpack": "5.105.2",
 		"webpack-cli": "6.0.1"
 	}

--- a/projects/packages/explat/changelog/update-switch-to-tsgo
+++ b/projects/packages/explat/changelog/update-switch-to-tsgo
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Switch to Native TypeScript compiler based on Go.

--- a/projects/packages/explat/package.json
+++ b/projects/packages/explat/package.json
@@ -27,7 +27,7 @@
 		"compile": "webpack",
 		"test": "jest --config=tests/jest.config.cjs --passWithNoTests",
 		"test-coverage": "pnpm run test --coverage",
-		"typecheck": "tsc --noEmit",
+		"typecheck": "tsgo --noEmit",
 		"watch": "pnpm run build --watch"
 	},
 	"dependencies": {
@@ -42,9 +42,9 @@
 		"@automattic/jetpack-webpack-config": "workspace:*",
 		"@babel/core": "7.29.0",
 		"@types/node": "^22.19.11",
+		"@typescript/native-preview": "7.0.0-dev.20260225.1",
 		"concurrently": "9.2.1",
 		"jest": "30.2.0",
-		"typescript": "5.9.3",
 		"webpack": "5.105.2",
 		"webpack-cli": "6.0.1"
 	}

--- a/projects/packages/external-media/changelog/update-switch-to-tsgo
+++ b/projects/packages/external-media/changelog/update-switch-to-tsgo
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Switch to Native TypeScript compiler based on Go.

--- a/projects/packages/external-media/package.json
+++ b/projects/packages/external-media/package.json
@@ -53,10 +53,10 @@
 		"@babel/core": "7.29.0",
 		"@babel/plugin-transform-react-jsx": "7.28.6",
 		"@babel/preset-react": "7.28.5",
+		"@typescript/native-preview": "7.0.0-dev.20260225.1",
 		"jetpack-js-tools": "workspace:*",
 		"sass-embedded": "1.97.2",
 		"sass-loader": "16.0.5",
-		"typescript": "5.9.3",
 		"webpack": "5.105.2",
 		"webpack-cli": "6.0.1"
 	}

--- a/projects/packages/forms/changelog/update-switch-to-tsgo
+++ b/projects/packages/forms/changelog/update-switch-to-tsgo
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Switch to Native TypeScript compiler based on Go.

--- a/projects/packages/forms/package.json
+++ b/projects/packages/forms/package.json
@@ -31,7 +31,7 @@
 		"rasterize-icons": "node tools/rasterize-icons.mjs",
 		"test": "NODE_OPTIONS=--experimental-vm-modules jest --config=tests/jest.config.js",
 		"test-coverage": "pnpm run test --coverage",
-		"typecheck": "tsc --noEmit",
+		"typecheck": "tsgo --noEmit",
 		"validate": "pnpm exec validate-es --no-error-on-unmatched-pattern dist/",
 		"watch": "concurrently 'pnpm:build:blocks --watch' 'pnpm:build:contact-form --watch' 'pnpm:build:dashboard --watch' 'pnpm:module:watch' 'pnpm:build:form-editor --watch' 'pnpm:watch:wp-build' 'pnpm:watch:icons'",
 		"watch:icons": "node tools/watch-icons.mjs",
@@ -110,6 +110,7 @@
 		"@types/lodash": "4.17.20",
 		"@types/react": "18.3.28",
 		"@types/react-dom": "18.3.7",
+		"@typescript/native-preview": "7.0.0-dev.20260225.1",
 		"@wordpress/api-fetch": "7.40.0",
 		"@wordpress/browserslist-config": "6.40.0",
 		"@wordpress/build": "0.8.0",
@@ -125,8 +126,7 @@
 		"postcss-modules": "^6.0.0",
 		"sass-embedded": "1.97.2",
 		"sass-loader": "16.0.5",
-		"sharp": "0.33.5",
-		"typescript": "5.9.3"
+		"sharp": "0.33.5"
 	},
 	"optionalDependencies": {
 		"react": "18.3.1",

--- a/projects/packages/jetpack-mu-wpcom/changelog/update-switch-to-tsgo
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-switch-to-tsgo
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Switch to Native TypeScript compiler based on Go.

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -22,7 +22,7 @@
 		"clean": "rm -rf src/build/ src/build-module/",
 		"e2e-tests": "playwright test --config src/features/verbum-comments/playwright.config.ts",
 		"sync:newspack-blocks": "./bin/sync-newspack-blocks.sh",
-		"typecheck": "tsc --build",
+		"typecheck": "tsgo --build",
 		"watch": "pnpm run build-production-js && pnpm webpack watch"
 	},
 	"dependencies": {
@@ -111,11 +111,11 @@
 		"@types/node": "^22.19.11",
 		"@types/react": "^18.3.28",
 		"@types/react-dom": "18.3.7",
+		"@typescript/native-preview": "7.0.0-dev.20260225.1",
 		"babel-plugin-transform-rename-properties": "0.1.0",
 		"package-directory": "^8.1.0",
 		"sass-embedded": "1.97.2",
 		"sass-loader": "16.0.5",
-		"typescript": "5.9.3",
 		"wait-for-expect": "3.0.2",
 		"webpack": "5.105.2",
 		"webpack-cli": "6.0.1"

--- a/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/tsconfig.json
+++ b/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/tsconfig.json
@@ -1,18 +1,15 @@
 {
+	"extends": "jetpack-js-tools/tsconfig.base.json",
 	"compilerOptions": {
 		"target": "ES2020",
-		"module": "ESNext",
-		"moduleResolution": "bundler",
-		"noEmit": true,
-		"allowJs": true,
 		"checkJs": true,
-		"jsx": "react-jsx",
 		"jsxImportSource": "preact"
 	},
 	"typeRoots": [ "./src/components", "./src/editor", "./node_modules/@types" ],
 	"include": [ "node_modules/vite/client.d.ts", "**/*" ],
 	"exclude": [
 		// Linting this file makes tsc complain about a bunch of irrelevant stuff, including stuff deep inside node_modules. I don't know why.
-		"./tests/eslint.config.mjs"
+		"./tests/eslint.config.mjs",
+		"./playwright.config.ts"
 	]
 }

--- a/projects/packages/my-jetpack/changelog/update-switch-to-tsgo
+++ b/projects/packages/my-jetpack/changelog/update-switch-to-tsgo
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Switch to Native TypeScript compiler based on Go.

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -27,7 +27,7 @@
 		"clean": "rm -rf build/",
 		"test": "jest --config=tests/jest.config.js",
 		"test-coverage": "pnpm run test --coverage",
-		"typecheck": "tsc --noEmit",
+		"typecheck": "tsgo --noEmit",
 		"watch": "pnpm run build && pnpm webpack watch",
 		"watch:hot": "pnpm run clean && webpack serve"
 	},
@@ -76,6 +76,7 @@
 		"@types/jest": "30.0.0",
 		"@types/node": "^22.19.11",
 		"@types/react": "18.3.28",
+		"@typescript/native-preview": "7.0.0-dev.20260225.1",
 		"concurrently": "9.2.1",
 		"jest": "30.2.0",
 		"react": "18.3.1",
@@ -84,7 +85,6 @@
 		"sass-embedded": "1.97.2",
 		"sass-loader": "16.0.5",
 		"storybook": "10.2.11",
-		"typescript": "5.9.3",
 		"webpack": "5.105.2",
 		"webpack-cli": "6.0.1",
 		"webpack-dev-server": "5.2.3"

--- a/projects/packages/newsletter/changelog/update-switch-to-tsgo
+++ b/projects/packages/newsletter/changelog/update-switch-to-tsgo
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Switch to Native TypeScript compiler based on Go.

--- a/projects/packages/newsletter/package.json
+++ b/projects/packages/newsletter/package.json
@@ -24,7 +24,7 @@
 		"clean": "rm -rf build/",
 		"test": "jest --config=tests/jest.config.js --passWithNoTests",
 		"test-coverage": "pnpm run test --coverage",
-		"typecheck": "tsc --noEmit",
+		"typecheck": "tsgo --noEmit",
 		"validate": "pnpm exec validate-es build/",
 		"watch": "pnpm run build && pnpm webpack watch"
 	},
@@ -53,12 +53,12 @@
 		"@babel/runtime": "7.28.6",
 		"@types/react": "18.3.28",
 		"@types/react-dom": "18.3.7",
+		"@typescript/native-preview": "7.0.0-dev.20260225.1",
 		"@wordpress/browserslist-config": "6.40.0",
 		"concurrently": "9.2.1",
 		"jest": "30.2.0",
 		"sass-embedded": "1.97.2",
 		"sass-loader": "16.0.5",
-		"typescript": "5.9.3",
 		"webpack": "5.105.2",
 		"webpack-cli": "6.0.1"
 	},

--- a/projects/packages/plugin-deactivation/changelog/update-switch-to-tsgo
+++ b/projects/packages/plugin-deactivation/changelog/update-switch-to-tsgo
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Switch to Native TypeScript compiler based on Go.

--- a/projects/packages/plugin-deactivation/package.json
+++ b/projects/packages/plugin-deactivation/package.json
@@ -18,15 +18,15 @@
 		"build": "pnpm run clean && pnpm run build-client",
 		"build-client": "pnpm webpack --config webpack.config.js",
 		"clean": "rm -rf build/",
-		"typecheck": "tsc --noEmit",
+		"typecheck": "tsgo --noEmit",
 		"watch": "pnpm run build && pnpm webpack watch"
 	},
 	"devDependencies": {
 		"@automattic/jetpack-webpack-config": "workspace:*",
+		"@typescript/native-preview": "7.0.0-dev.20260225.1",
 		"sass-embedded": "1.97.2",
 		"sass-loader": "16.0.5",
 		"tslib": "2.8.1",
-		"typescript": "5.9.3",
 		"webpack": "5.105.2",
 		"webpack-cli": "6.0.1"
 	}

--- a/projects/packages/publicize/changelog/update-switch-to-tsgo
+++ b/projects/packages/publicize/changelog/update-switch-to-tsgo
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Switch to Native TypeScript compiler based on Go.

--- a/projects/packages/publicize/package.json
+++ b/projects/packages/publicize/package.json
@@ -28,7 +28,7 @@
 		"clean": "rm -rf build/",
 		"test": "TZ=UTC jest",
 		"test-coverage": "pnpm run test --coverage",
-		"typecheck": "tsc --noEmit",
+		"typecheck": "tsgo --noEmit",
 		"validate": "pnpm exec validate-es build/",
 		"watch": "pnpm run build && webpack watch",
 		"watch:hot": "pnpm run clean && webpack serve"
@@ -93,6 +93,7 @@
 		"@testing-library/user-event": "14.6.1",
 		"@types/jest": "30.0.0",
 		"@types/react": "18.3.28",
+		"@typescript/native-preview": "7.0.0-dev.20260225.1",
 		"@wordpress/browserslist-config": "6.40.0",
 		"autoprefixer": "10.4.20",
 		"babel-jest": "30.2.0",
@@ -106,7 +107,6 @@
 		"sass-embedded": "1.97.2",
 		"sass-loader": "16.0.5",
 		"storybook": "10.2.11",
-		"typescript": "5.9.3",
 		"webpack": "5.105.2",
 		"webpack-cli": "6.0.1",
 		"webpack-dev-server": "5.2.3"

--- a/projects/packages/subscribers-dashboard/changelog/update-switch-to-tsgo
+++ b/projects/packages/subscribers-dashboard/changelog/update-switch-to-tsgo
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Switch to Native TypeScript compiler based on Go.

--- a/projects/packages/subscribers-dashboard/package.json
+++ b/projects/packages/subscribers-dashboard/package.json
@@ -30,7 +30,7 @@
 		"clean": "rm -rf build/",
 		"test": "jest --config=tests/jest.config.js",
 		"test-coverage": "pnpm run test --coverage",
-		"typecheck": "tsc --noEmit",
+		"typecheck": "tsgo --noEmit",
 		"validate": "pnpm exec validate-es build/",
 		"watch": "pnpm run build && pnpm webpack watch"
 	},
@@ -50,13 +50,13 @@
 		"@testing-library/jest-dom": "6.9.1",
 		"@testing-library/react": "16.3.0",
 		"@types/jest": "30.0.0",
+		"@typescript/native-preview": "7.0.0-dev.20260225.1",
 		"concurrently": "9.2.1",
 		"jest": "30.2.0",
 		"react": "18.3.1",
 		"react-dom": "18.3.1",
 		"sass-embedded": "1.97.2",
 		"sass-loader": "16.0.5",
-		"typescript": "5.9.3",
 		"webpack": "5.105.2",
 		"webpack-cli": "6.0.1"
 	}

--- a/projects/packages/videopress/changelog/update-switch-to-tsgo
+++ b/projects/packages/videopress/changelog/update-switch-to-tsgo
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Switch to Native TypeScript compiler based on Go.

--- a/projects/packages/videopress/package.json
+++ b/projects/packages/videopress/package.json
@@ -77,6 +77,7 @@
 		"@types/jest": "30.0.0",
 		"@types/react": "18.3.28",
 		"@types/react-dom": "18.3.7",
+		"@typescript/native-preview": "7.0.0-dev.20260225.1",
 		"@wordpress/browserslist-config": "6.40.0",
 		"autoprefixer": "10.4.20",
 		"concurrently": "9.2.1",
@@ -89,7 +90,6 @@
 		"sass-embedded": "1.97.2",
 		"sass-loader": "16.0.5",
 		"storybook": "10.2.11",
-		"typescript": "5.9.3",
 		"webpack": "5.105.2",
 		"webpack-cli": "6.0.1"
 	}

--- a/projects/packages/woocommerce-analytics/changelog/update-switch-to-tsgo
+++ b/projects/packages/woocommerce-analytics/changelog/update-switch-to-tsgo
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Switch to Native TypeScript compiler based on Go.

--- a/projects/packages/woocommerce-analytics/package.json
+++ b/projects/packages/woocommerce-analytics/package.json
@@ -20,7 +20,7 @@
 		"clean": "rm -rf build/",
 		"test": "jest",
 		"test-coverage": "pnpm run test --coverage",
-		"typecheck": "tsc --noEmit",
+		"typecheck": "tsgo --noEmit",
 		"validate": "pnpm exec validate-es build/",
 		"watch": "pnpm build --watch"
 	},
@@ -34,9 +34,9 @@
 		"@jest/globals": "30.2.0",
 		"@types/jest": "30.0.0",
 		"@types/jquery": "3.5.33",
+		"@typescript/native-preview": "7.0.0-dev.20260225.1",
 		"@wordpress/browserslist-config": "6.40.0",
 		"jest": "30.2.0",
-		"typescript": "5.9.3",
 		"webpack": "5.105.2",
 		"webpack-cli": "6.0.1"
 	}

--- a/projects/plugins/boost/changelog/update-switch-to-tsgo
+++ b/projects/plugins/boost/changelog/update-switch-to-tsgo
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Switch to Native TypeScript compiler based on Go.

--- a/projects/plugins/boost/package.json
+++ b/projects/plugins/boost/package.json
@@ -66,6 +66,7 @@
 		"@testing-library/dom": "10.4.1",
 		"@types/jest": "30.0.0",
 		"@types/jquery": "3.5.33",
+		"@typescript/native-preview": "7.0.0-dev.20260225.1",
 		"@wordpress/browserslist-config": "6.40.0",
 		"@wordpress/i18n": "6.13.0",
 		"concurrently": "9.2.1",
@@ -80,7 +81,6 @@
 		"sass-loader": "16.0.5",
 		"storybook": "10.2.11",
 		"tslib": "2.8.1",
-		"typescript": "5.9.3",
 		"webpack": "5.105.2",
 		"webpack-cli": "6.0.1"
 	}

--- a/projects/plugins/boost/tests/e2e/package.json
+++ b/projects/plugins/boost/tests/e2e/package.json
@@ -16,17 +16,17 @@
 		"tunnel:down": "tunnel down",
 		"tunnel:reset": "tunnel reset",
 		"tunnel:up": "tunnel up",
-		"typecheck": "tsc --noEmit"
+		"typecheck": "tsgo --noEmit"
 	},
 	"browserslist": [],
 	"devDependencies": {
 		"@playwright/test": "1.58.2",
 		"@types/node": "^22.19.11",
+		"@typescript/native-preview": "7.0.0-dev.20260225.1",
 		"_jetpack-e2e-commons": "workspace:*",
 		"allure-playwright": "2.15.1",
 		"config": "4.1.1",
-		"playwright-ctrf-json-reporter": "^0.0.26",
-		"typescript": "5.9.3"
+		"playwright-ctrf-json-reporter": "^0.0.26"
 	},
 	"ci": {
 		"pluginSlug": "jetpack-boost",

--- a/projects/plugins/classic-theme-helper-plugin/changelog/update-switch-to-tsgo
+++ b/projects/plugins/classic-theme-helper-plugin/changelog/update-switch-to-tsgo
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Switch to Native TypeScript compiler based on Go.

--- a/projects/plugins/classic-theme-helper-plugin/tests/e2e/package.json
+++ b/projects/plugins/classic-theme-helper-plugin/tests/e2e/package.json
@@ -14,17 +14,17 @@
 		"tunnel:down": "tunnel down",
 		"tunnel:reset": "tunnel reset",
 		"tunnel:up": "tunnel up",
-		"typecheck": "tsc --noEmit"
+		"typecheck": "tsgo --noEmit"
 	},
 	"browserslist": [],
 	"devDependencies": {
 		"@playwright/test": "1.58.2",
 		"@types/node": "^22.19.11",
+		"@typescript/native-preview": "7.0.0-dev.20260225.1",
 		"_jetpack-e2e-commons": "workspace:*",
 		"allure-playwright": "2.15.1",
 		"config": "4.1.1",
-		"playwright-ctrf-json-reporter": "^0.0.26",
-		"typescript": "5.9.3"
+		"playwright-ctrf-json-reporter": "^0.0.26"
 	},
 	"ci": {
 		"targets": [

--- a/projects/plugins/crm/changelog/update-switch-to-tsgo
+++ b/projects/plugins/crm/changelog/update-switch-to-tsgo
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Switch to Native TypeScript compiler based on Go.

--- a/projects/plugins/crm/package.json
+++ b/projects/plugins/crm/package.json
@@ -50,6 +50,7 @@
 		"@types/jest": "30.0.0",
 		"@types/react": "18.3.28",
 		"@types/react-dom": "18.3.7",
+		"@typescript/native-preview": "7.0.0-dev.20260225.1",
 		"chart.js": "4.5.0",
 		"copy-webpack-plugin": "13.0.1",
 		"css-loader": "6.11.0",
@@ -68,7 +69,6 @@
 		"semantic-ui-css": "2.5.0",
 		"sweetalert2": "7.33.1",
 		"typeahead.js": "0.11.1",
-		"typescript": "5.9.3",
 		"webpack": "5.105.2",
 		"webpack-cli": "6.0.1"
 	}

--- a/projects/plugins/inspect/changelog/update-switch-to-tsgo
+++ b/projects/plugins/inspect/changelog/update-switch-to-tsgo
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Switch to Native TypeScript compiler based on Go.

--- a/projects/plugins/inspect/package.json
+++ b/projects/plugins/inspect/package.json
@@ -21,7 +21,7 @@
 		"build-production": "pnpm build-production-js",
 		"build-production-js": "rollup -c rollup.config.js",
 		"clean": "rm -rf app-ui/build/",
-		"typecheck": "tsc --noEmit"
+		"typecheck": "tsgo --noEmit"
 	},
 	"devDependencies": {
 		"@babel/core": "7.29.0",
@@ -30,6 +30,7 @@
 		"@rollup/plugin-node-resolve": "15.3.0",
 		"@rollup/plugin-terser": "0.4.3",
 		"@rollup/plugin-typescript": "12.1.0",
+		"@typescript/native-preview": "7.0.0-dev.20260225.1",
 		"@wordpress/i18n": "6.13.0",
 		"postcss": "8.5.6",
 		"rollup": "3.30.0",

--- a/projects/plugins/jetpack/changelog/update-switch-to-tsgo
+++ b/projects/plugins/jetpack/changelog/update-switch-to-tsgo
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Switch to Native TypeScript compiler based on Go.

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -34,7 +34,7 @@
 		"test-client": "NODE_PATH=tests:_inc/client jest --config=tests/jest.config.client.js",
 		"test-extensions": "TZ=UTC jest --config=tests/jest.config.extensions.js",
 		"test-gui": "NODE_PATH=tests:_inc/client jest --config=tests/jest.config.gui.js",
-		"typecheck": "tsc --noEmit",
+		"typecheck": "tsgo --noEmit",
 		"watch": "concurrently --names client-js,client-css,extensions,widget-visibility 'webpack watch --config ./tools/webpack.config.js' 'webpack watch --config ./tools/webpack.config.css.js' 'webpack watch --config ./tools/webpack.config.extensions.js' 'webpack watch --config ./tools/webpack.config.widget-visibility.js'"
 	},
 	"browserslist": [
@@ -148,6 +148,7 @@
 		"@types/jest": "30.0.0",
 		"@types/react": "18.3.28",
 		"@types/wordpress__block-editor": "15.0.3",
+		"@typescript/native-preview": "7.0.0-dev.20260225.1",
 		"@wordpress/api-fetch": "7.40.0",
 		"@wordpress/blob": "4.40.0",
 		"@wordpress/block-serialization-default-parser": "5.40.0",
@@ -170,8 +171,7 @@
 		"postcss": "8.5.6",
 		"postcss-loader": "8.2.0",
 		"regenerator-runtime": "0.13.9",
-		"sass-loader": "16.0.5",
-		"typescript": "5.9.3"
+		"sass-loader": "16.0.5"
 	},
 	"optionalDependencies": {
 		"react": "18.3.1",

--- a/projects/plugins/jetpack/tests/e2e/package.json
+++ b/projects/plugins/jetpack/tests/e2e/package.json
@@ -22,17 +22,17 @@
 		"tunnel:down": "tunnel down",
 		"tunnel:reset": "tunnel reset",
 		"tunnel:up": "tunnel up",
-		"typecheck": "tsc --noEmit"
+		"typecheck": "tsgo --noEmit"
 	},
 	"browserslist": [],
 	"devDependencies": {
 		"@playwright/test": "1.58.2",
 		"@types/node": "^22.19.11",
+		"@typescript/native-preview": "7.0.0-dev.20260225.1",
 		"_jetpack-e2e-commons": "workspace:*",
 		"allure-playwright": "2.15.1",
 		"config": "4.1.1",
-		"playwright-ctrf-json-reporter": "^0.0.26",
-		"typescript": "5.9.3"
+		"playwright-ctrf-json-reporter": "^0.0.26"
 	},
 	"ci": {
 		"pluginSlug": "jetpack",

--- a/projects/plugins/protect/changelog/update-switch-to-tsgo
+++ b/projects/plugins/protect/changelog/update-switch-to-tsgo
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Switch to Native TypeScript compiler based on Go.

--- a/projects/plugins/protect/package.json
+++ b/projects/plugins/protect/package.json
@@ -18,7 +18,7 @@
 		"build-concurrently": "pnpm run clean && concurrently 'pnpm:build-client'",
 		"build-production-concurrently": "pnpm run clean && concurrently 'NODE_ENV=production BABEL_ENV=production pnpm run build-client' && pnpm run validate",
 		"clean": "rm -rf build/",
-		"typecheck": "tsc --noEmit",
+		"typecheck": "tsgo --noEmit",
 		"validate": "pnpm exec validate-es build/",
 		"watch": "pnpm run build && webpack watch"
 	},
@@ -55,11 +55,11 @@
 		"@babel/preset-env": "7.29.0",
 		"@babel/runtime": "7.28.6",
 		"@types/react": "18.3.28",
+		"@typescript/native-preview": "7.0.0-dev.20260225.1",
 		"@wordpress/browserslist-config": "6.40.0",
 		"concurrently": "9.2.1",
 		"sass-embedded": "1.97.2",
 		"sass-loader": "16.0.5",
-		"typescript": "5.9.3",
 		"webpack": "5.105.2",
 		"webpack-cli": "6.0.1"
 	}

--- a/projects/plugins/protect/tests/e2e/package.json
+++ b/projects/plugins/protect/tests/e2e/package.json
@@ -15,17 +15,17 @@
 		"tunnel:down": "tunnel down",
 		"tunnel:reset": "tunnel reset",
 		"tunnel:up": "tunnel up",
-		"typecheck": "tsc --noEmit"
+		"typecheck": "tsgo --noEmit"
 	},
 	"browserslist": [],
 	"devDependencies": {
 		"@playwright/test": "1.58.2",
 		"@types/node": "^22.19.11",
+		"@typescript/native-preview": "7.0.0-dev.20260225.1",
 		"_jetpack-e2e-commons": "workspace:*",
 		"allure-playwright": "2.15.1",
 		"config": "4.1.1",
-		"playwright-ctrf-json-reporter": "^0.0.26",
-		"typescript": "5.9.3"
+		"playwright-ctrf-json-reporter": "^0.0.26"
 	},
 	"ci": {
 		"targets": [

--- a/projects/plugins/search/changelog/update-switch-to-tsgo
+++ b/projects/plugins/search/changelog/update-switch-to-tsgo
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Switch to Native TypeScript compiler based on Go.

--- a/projects/plugins/search/tests/e2e/package.json
+++ b/projects/plugins/search/tests/e2e/package.json
@@ -16,17 +16,17 @@
 		"tunnel:down": "tunnel down",
 		"tunnel:reset": "tunnel reset",
 		"tunnel:up": "tunnel up",
-		"typecheck": "tsc --noEmit"
+		"typecheck": "tsgo --noEmit"
 	},
 	"browserslist": [],
 	"devDependencies": {
 		"@playwright/test": "1.58.2",
 		"@types/node": "^22.19.11",
+		"@typescript/native-preview": "7.0.0-dev.20260225.1",
 		"_jetpack-e2e-commons": "workspace:*",
 		"allure-playwright": "2.15.1",
 		"config": "4.1.1",
-		"playwright-ctrf-json-reporter": "^0.0.26",
-		"typescript": "5.9.3"
+		"playwright-ctrf-json-reporter": "^0.0.26"
 	},
 	"ci": {
 		"pluginSlug": "jetpack-search",

--- a/projects/plugins/social/changelog/update-switch-to-tsgo
+++ b/projects/plugins/social/changelog/update-switch-to-tsgo
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Switch to Native TypeScript compiler based on Go.

--- a/projects/plugins/social/tests/e2e/package.json
+++ b/projects/plugins/social/tests/e2e/package.json
@@ -17,17 +17,17 @@
 		"tunnel:down": "tunnel down",
 		"tunnel:reset": "tunnel reset",
 		"tunnel:up": "tunnel up",
-		"typecheck": "tsc --noEmit"
+		"typecheck": "tsgo --noEmit"
 	},
 	"browserslist": [],
 	"devDependencies": {
 		"@playwright/test": "1.58.2",
 		"@types/node": "^22.19.11",
+		"@typescript/native-preview": "7.0.0-dev.20260225.1",
 		"_jetpack-e2e-commons": "workspace:*",
 		"allure-playwright": "2.15.1",
 		"config": "4.1.1",
-		"playwright-ctrf-json-reporter": "^0.0.26",
-		"typescript": "5.9.3"
+		"playwright-ctrf-json-reporter": "^0.0.26"
 	},
 	"ci": {
 		"pluginSlug": "jetpack-social",

--- a/projects/plugins/starter-plugin/changelog/update-switch-to-tsgo
+++ b/projects/plugins/starter-plugin/changelog/update-switch-to-tsgo
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Switch to Native TypeScript compiler based on Go.

--- a/projects/plugins/starter-plugin/tests/e2e/package.json
+++ b/projects/plugins/starter-plugin/tests/e2e/package.json
@@ -15,17 +15,17 @@
 		"tunnel:down": "tunnel down",
 		"tunnel:reset": "tunnel reset",
 		"tunnel:up": "tunnel up",
-		"typecheck": "tsc --noEmit"
+		"typecheck": "tsgo --noEmit"
 	},
 	"browserslist": [],
 	"devDependencies": {
 		"@playwright/test": "1.58.2",
 		"@types/node": "^22.19.11",
+		"@typescript/native-preview": "7.0.0-dev.20260225.1",
 		"_jetpack-e2e-commons": "workspace:*",
 		"allure-playwright": "2.15.1",
 		"config": "4.1.1",
-		"playwright-ctrf-json-reporter": "^0.0.26",
-		"typescript": "5.9.3"
+		"playwright-ctrf-json-reporter": "^0.0.26"
 	},
 	"ci": {
 		"targets": [

--- a/projects/plugins/super-cache/changelog/update-switch-to-tsgo
+++ b/projects/plugins/super-cache/changelog/update-switch-to-tsgo
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Switch to Native TypeScript compiler based on Go.

--- a/projects/plugins/super-cache/tests/e2e/package.json
+++ b/projects/plugins/super-cache/tests/e2e/package.json
@@ -9,12 +9,13 @@
 		"env:up": "docker-compose up -d",
 		"pretest:run": "pnpm run clean",
 		"test:run": "jest --runInBand",
-		"typecheck": "tsc --noEmit"
+		"typecheck": "tsgo --noEmit"
 	},
 	"devDependencies": {
 		"@jest/globals": "^30.0.0",
 		"@types/node": "^22.19.11",
 		"@types/shell-escape": "0.2.3",
+		"@typescript/native-preview": "7.0.0-dev.20260225.1",
 		"_jetpack-e2e-commons": "workspace:*",
 		"axios": "1.13.5",
 		"cheerio": "1.2.0",

--- a/projects/plugins/videopress/changelog/update-switch-to-tsgo
+++ b/projects/plugins/videopress/changelog/update-switch-to-tsgo
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Switch to Native TypeScript compiler based on Go.

--- a/projects/plugins/videopress/tests/e2e/package.json
+++ b/projects/plugins/videopress/tests/e2e/package.json
@@ -15,17 +15,17 @@
 		"tunnel:down": "tunnel down",
 		"tunnel:reset": "tunnel reset",
 		"tunnel:up": "tunnel up",
-		"typecheck": "tsc --noEmit"
+		"typecheck": "tsgo --noEmit"
 	},
 	"browserslist": [],
 	"devDependencies": {
 		"@playwright/test": "1.58.2",
 		"@types/node": "^22.19.11",
+		"@typescript/native-preview": "7.0.0-dev.20260225.1",
 		"_jetpack-e2e-commons": "workspace:*",
 		"allure-playwright": "2.15.1",
 		"config": "4.1.1",
-		"playwright-ctrf-json-reporter": "^0.0.26",
-		"typescript": "5.9.3"
+		"playwright-ctrf-json-reporter": "^0.0.26"
 	},
 	"ci": {
 		"pluginSlug": "jetpack-videopress",

--- a/tools/cli/package.json
+++ b/tools/cli/package.json
@@ -48,6 +48,7 @@
 		"yargs": "18.0.0"
 	},
 	"devDependencies": {
+		"@typescript/native-preview": "7.0.0-dev.20260225.1",
 		"jest": "30.2.0",
 		"jest-extended": "7.0.0",
 		"typescript": "5.9.3"

--- a/tools/e2e-commons/package.json
+++ b/tools/e2e-commons/package.json
@@ -27,7 +27,7 @@
 		"tunnel:down": "./bin/tunnel.sh down",
 		"tunnel:reset": "./bin/tunnel.sh reset",
 		"tunnel:up": "./bin/tunnel.sh up",
-		"typecheck": "tsc --noEmit"
+		"typecheck": "tsgo --noEmit"
 	},
 	"browserslist": [],
 	"devDependencies": {
@@ -36,6 +36,7 @@
 		"@types/config": "3.3.5",
 		"@types/lodash-es": "4.17.12",
 		"@types/node": "^22.19.11",
+		"@typescript/native-preview": "7.0.0-dev.20260225.1",
 		"@wordpress/e2e-test-utils-playwright": "1.40.0",
 		"allure-playwright": "2.15.1",
 		"axios": "1.13.5",
@@ -45,7 +46,6 @@
 		"lodash-es": "4.17.23",
 		"playwright-ctrf-json-reporter": "^0.0.26",
 		"shell-escape": "0.2.0",
-		"typescript": "5.9.3",
 		"winston": "3.17.0",
 		"yargs": "18.0.0"
 	}

--- a/tools/js-tools/package.json
+++ b/tools/js-tools/package.json
@@ -23,6 +23,7 @@
 		"@octokit/rest": "22.0.1",
 		"@tanstack/eslint-plugin-query": "5.91.2",
 		"@testing-library/jest-dom": "6.9.1",
+		"@typescript/native-preview": "7.0.0-dev.20260225.1",
 		"@wordpress/eslint-plugin": "24.2.0",
 		"@wordpress/jest-console": "8.40.0",
 		"@wordpress/stylelint-config": "23.32.0",


### PR DESCRIPTION
Completes MONOREP-387

## Proposed changes:

- Replace `typescript` (5.9.3) with `@typescript/native-preview` (7.0.0-dev.20260225.1) across all packages in the monorepo, except for the packages which need `typescript` as a peer dependency.
- Replace all `tsc` commands with `tsgo` in package.json scripts (`typecheck`, `build`, `watch`, etc.).
- Enable native TypeScript in VS Code settings (`typescript.experimental.useTsgo: true`).


## Improvements

Running `pnpm typecheck` from root after `jetpack clean all --include=ignored`

<table>
    <tbody>
        <tr>
            <th></th>
            <th><code>tsc</code> (trunk)</th>
            <th><code>tsgo</code> (this branch)</th>
        </tr>
        <tr>
            <th>Cold build</th>
            <td><code>150s</code></td>
            <td><code>49s</code></td>
        </tr>
        <tr>
            <th>Warm build</th>
            <td><code>143s</code></td>
            <td><code>32s</code></td>
        </tr>
    </tbody>
</table>

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

N/A — Tooling change only, no product impact.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

- Run `pnpm install` at the repo root to update dependencies.
- Run `pnpm typecheck` in any package (e.g., `projects/js-packages/ai-client`) and verify it completes successfully using `tsgo`.
- Run `pnpm build` in a package that uses the `compile-ts` script (e.g., `projects/js-packages/components`) and verify build output is generated.
- Open the repo in VS Code and confirm TypeScript language features work with the native TS server enabled.

## Changelog

- [ ] Generate changelog entries for this PR (using AI).
