### PR TITLE
Forms: use Badge component from @wordpress/ui

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2377,9 +2377,6 @@ importers:
       '@automattic/request-external-access':
         specifier: 1.0.1
         version: 1.0.1
-      '@automattic/ui':
-        specifier: 1.0.2
-        version: 1.0.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@gravatar-com/hovercards':
         specifier: 0.15.0
         version: 0.15.0
@@ -23532,7 +23529,7 @@ snapshots:
       webpack: 5.105.2(webpack-cli@6.0.1)
       webpack-cli: 6.0.1(webpack-dev-server@5.2.3)(webpack@5.105.2)
     optionalDependencies:
-      webpack-dev-server: 5.2.3(webpack-cli@6.0.1)(webpack@5.105.2)
+      webpack-dev-server: 5.2.3(debug@4.4.3)(webpack-cli@6.0.1)(webpack@5.105.2)
 
   '@webpack-cli/serve@3.0.1(webpack-cli@6.0.1)(webpack@5.105.2)':
     dependencies:
@@ -34212,7 +34209,7 @@ snapshots:
       webpack: 5.105.2(webpack-cli@6.0.1)
       webpack-merge: 6.0.1
     optionalDependencies:
-      webpack-dev-server: 5.2.3(webpack-cli@6.0.1)(webpack@5.105.2)
+      webpack-dev-server: 5.2.3(debug@4.4.3)(webpack-cli@6.0.1)(webpack@5.105.2)
 
   webpack-cli@6.0.1(webpack@5.105.2):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23529,7 +23529,7 @@ snapshots:
       webpack: 5.105.2(webpack-cli@6.0.1)
       webpack-cli: 6.0.1(webpack-dev-server@5.2.3)(webpack@5.105.2)
     optionalDependencies:
-      webpack-dev-server: 5.2.3(debug@4.4.3)(webpack-cli@6.0.1)(webpack@5.105.2)
+      webpack-dev-server: 5.2.3(webpack-cli@6.0.1)(webpack@5.105.2)
 
   '@webpack-cli/serve@3.0.1(webpack-cli@6.0.1)(webpack@5.105.2)':
     dependencies:
@@ -34209,7 +34209,7 @@ snapshots:
       webpack: 5.105.2(webpack-cli@6.0.1)
       webpack-merge: 6.0.1
     optionalDependencies:
-      webpack-dev-server: 5.2.3(debug@4.4.3)(webpack-cli@6.0.1)(webpack@5.105.2)
+      webpack-dev-server: 5.2.3(webpack-cli@6.0.1)(webpack@5.105.2)
 
   webpack-cli@6.0.1(webpack@5.105.2):
     dependencies:

--- a/projects/packages/forms/changelog/pr-47377
+++ b/projects/packages/forms/changelog/pr-47377
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Forms: Replace Badge component from @automattic/ui with @wordpress/ui Badge, fixing extra margin on badges in the forms dashboard.

--- a/projects/packages/forms/package.json
+++ b/projects/packages/forms/package.json
@@ -49,7 +49,6 @@
 		"@automattic/jetpack-shared-extension-utils": "workspace:*",
 		"@automattic/number-formatters": "workspace:*",
 		"@automattic/request-external-access": "1.0.1",
-		"@automattic/ui": "1.0.2",
 		"@gravatar-com/hovercards": "0.15.0",
 		"@wordpress/admin-ui": "1.8.0",
 		"@wordpress/base-styles": "6.16.0",

--- a/projects/packages/forms/routes/forms/package.json
+++ b/projects/packages/forms/routes/forms/package.json
@@ -4,7 +4,6 @@
 	"private": true,
 	"dependencies": {
 		"@automattic/jetpack-components": "workspace:*",
-		"@automattic/ui": "1.0.2",
 		"@types/react": "18.3.28",
 		"@wordpress/admin-ui": "1.8.0",
 		"@wordpress/api-fetch": "7.40.0",

--- a/projects/packages/forms/routes/forms/stage.tsx
+++ b/projects/packages/forms/routes/forms/stage.tsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { Badge } from '@automattic/ui';
 import { Page } from '@wordpress/admin-ui';
 import {
 	__experimentalConfirmDialog as ConfirmDialog, // eslint-disable-line @wordpress/no-unsafe-wp-apis
@@ -16,6 +15,7 @@ import { useEffect, useMemo, useState, useCallback, useRef } from '@wordpress/el
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { useSearch, useNavigate } from '@wordpress/route';
+import { Badge } from '@wordpress/ui';
 import * as React from 'react';
 /**
  * Internal dependencies
@@ -268,9 +268,7 @@ function StageInner() {
 				label: __( 'Status', 'jetpack-forms' ),
 				getValue: ( { item }: { item: FormListItem } ) => item.status,
 				render: ( { item }: { item: FormListItem } ) => (
-					<Badge intent="default" className="jp-forms-badge">
-						{ statusLabel( item.status ) }
-					</Badge>
+					<Badge intent="draft">{ statusLabel( item.status ) }</Badge>
 				),
 				elements: [
 					{ label: __( 'All', 'jetpack-forms' ), value: 'all' },

--- a/projects/packages/forms/routes/responses/package.json
+++ b/projects/packages/forms/routes/responses/package.json
@@ -7,7 +7,6 @@
 		"@automattic/jetpack-analytics": "workspace:*",
 		"@automattic/jetpack-components": "workspace:*",
 		"@automattic/number-formatters": "workspace:*",
-		"@automattic/ui": "1.0.2",
 		"@tanstack/react-router": ">=1.120.5 <1.121.0",
 		"@types/react": "18.3.28",
 		"@wordpress/admin-ui": "1.8.0",

--- a/projects/packages/forms/routes/responses/stage.tsx
+++ b/projects/packages/forms/routes/responses/stage.tsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { formatNumber } from '@automattic/number-formatters';
-import { Badge } from '@automattic/ui';
 /**
  * WordPress dependencies
  */
@@ -18,7 +17,7 @@ import { useMemo, useState, useCallback, useEffect } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
 import { __, sprintf } from '@wordpress/i18n';
 import { useParams, useSearch, useNavigate } from '@wordpress/route';
-import { Stack } from '@wordpress/ui';
+import { Badge, Stack } from '@wordpress/ui';
 import * as React from 'react';
 /**
  * Internal dependencies
@@ -492,7 +491,7 @@ function StageInner() {
 				enableSorting: false,
 				render: ( { item } ) => {
 					return (
-						<Badge intent="default">
+						<Badge intent="draft">
 							{ item.is_unread ? __( 'Unread', 'jetpack-forms' ) : __( 'Read', 'jetpack-forms' ) }
 						</Badge>
 					);

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/helpers/salesforce.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/helpers/salesforce.tsx
@@ -1,7 +1,6 @@
-import { Badge } from '@automattic/ui';
-import '@automattic/ui/style.css';
 import { BaseControl, ExternalLink, TextControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { Badge } from '@wordpress/ui';
 import SalesforceIcon from '../../../../../icons/salesforce.tsx';
 import HelpMessage from '../../help-message/index.jsx';
 import CreateSalesforceLeadFormButton from '../components/create-salesforce-lead-form-button.tsx';
@@ -47,11 +46,11 @@ export function buildSalesforceCard( {
 			} ),
 			setupBadge:
 				context === 'dashboard' ? (
-					<Badge intent="success" className="integration-card__setup-badge">
+					<Badge intent="stable" className="integration-card__setup-badge">
 						{ __( 'Configured per form', 'jetpack-forms' ) }
 					</Badge>
 				) : (
-					<Badge intent="default" className="integration-card__setup-badge">
+					<Badge intent="draft" className="integration-card__setup-badge">
 						{ __( 'Enter organization ID', 'jetpack-forms' ) }
 					</Badge>
 				),

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/integration-card/integration-card-header.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/integration-card/integration-card-header.tsx
@@ -2,8 +2,6 @@
  * External dependencies
  */
 import jetpackAnalytics from '@automattic/jetpack-analytics';
-import { Badge } from '@automattic/ui';
-import '@automattic/ui/style.css';
 /**
  * Internal dependencies
  */
@@ -17,6 +15,7 @@ import {
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { chevronDown, chevronUp, plugins } from '@wordpress/icons';
+import { Badge } from '@wordpress/ui';
 import clsx from 'clsx';
 import useConfigValue from '../../../../../hooks/use-config-value.ts';
 import PluginActionButton from './plugin-action-button.tsx';
@@ -142,7 +141,10 @@ const IntegrationCardHeader = ( {
 						{ __isPartial && (
 							<Animate type="loading">
 								{ ( { className } ) => (
-									<Badge className={ clsx( 'integration-card__plugin-badge', className ) }>
+									<Badge
+										intent="draft"
+										className={ clsx( 'integration-card__plugin-badge', className ) }
+									>
 										{ ' ' /* intentionally left blank */ }
 									</Badge>
 								) }
@@ -150,20 +152,20 @@ const IntegrationCardHeader = ( {
 						) }
 						{ showPluginAction && (
 							<Badge
-								intent={ isInstalled && ! isActive ? 'warning' : 'default' }
+								intent={ isInstalled && ! isActive ? 'low' : 'draft' }
 								className="integration-card__plugin-badge"
 							>
 								{ pluginActionLabel }
 							</Badge>
 						) }
 						{ showConnectedBadge && (
-							<Badge intent="success" className="integration-card__connected-badge">
+							<Badge intent="stable" className="integration-card__connected-badge">
 								{ __( 'Enabled', 'jetpack-forms' ) }
 							</Badge>
 						) }
 						{ showPendingBadge &&
 							( setupBadge || (
-								<Badge intent="warning" className="integration-card__setup-badge">
+								<Badge intent="low" className="integration-card__setup-badge">
 									{ __( 'Needs connection', 'jetpack-forms' ) }
 								</Badge>
 							) ) }

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/style.scss
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/style.scss
@@ -1,3 +1,5 @@
+@import "@wordpress/theme/design-tokens.css";
+
 .jetpack-forms-integrations-modal .components-modal__header-heading {
 	font-weight: 400;
 }

--- a/projects/packages/forms/src/dashboard/components/inbox-status-toggle/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/inbox-status-toggle/index.tsx
@@ -4,9 +4,8 @@
 import jetpackAnalytics from '@automattic/jetpack-analytics';
 import { useBreakpointMatch } from '@automattic/jetpack-components';
 import { formatNumberCompact } from '@automattic/number-formatters';
-import { Badge } from '@automattic/ui';
 import { __, _x } from '@wordpress/i18n';
-import { Tabs } from '@wordpress/ui';
+import { Badge, Tabs } from '@wordpress/ui';
 import { useCallback } from 'react';
 /**
  * Internal dependencies
@@ -25,7 +24,7 @@ function getTabLabel( label: string, count: number ): JSX.Element {
 	return (
 		<span style={ { display: 'flex', gap: '4px', alignItems: 'center' } }>
 			{ label }
-			<Badge intent="default">{ formatNumberCompact( count || 0 ) }</Badge>
+			<Badge intent="draft">{ formatNumberCompact( count || 0 ) }</Badge>
 		</span>
 	);
 }

--- a/projects/packages/forms/src/dashboard/components/inspector/response-fields/field-preview/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/inspector/response-fields/field-preview/index.tsx
@@ -2,13 +2,13 @@
  * External dependencies
  */
 import { formatNumber } from '@automattic/number-formatters';
-import { Badge } from '@automattic/ui';
 import {
 	ExternalLink,
 	Icon,
 	__experimentalHStack as HStack, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 	__experimentalVStack as VStack, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 } from '@wordpress/components';
+import { Badge } from '@wordpress/ui';
 /**
  * Internal dependencies
  */
@@ -58,7 +58,9 @@ const FieldPreview = ( { field, onFilePreview }: FieldPreviewProps ) => {
 			return (
 				<VStack spacing="2" alignment="topLeft">
 					{ ( value as string[] ).map( ( item, index ) => (
-						<Badge key={ index }>{ item }</Badge>
+						<Badge intent="draft" key={ index }>
+							{ item }
+						</Badge>
 					) ) }
 				</VStack>
 			);
@@ -86,7 +88,7 @@ const FieldPreview = ( { field, onFilePreview }: FieldPreviewProps ) => {
 		}
 
 		if ( BADGED_VALUE_FIELDS.includes( fieldType ) ) {
-			return <Badge>{ stringValue }</Badge>;
+			return <Badge intent="draft">{ stringValue }</Badge>;
 		}
 
 		// Numbers

--- a/projects/packages/forms/src/dashboard/inbox/stage/index.js
+++ b/projects/packages/forms/src/dashboard/inbox/stage/index.js
@@ -4,7 +4,6 @@
 import jetpackAnalytics from '@automattic/jetpack-analytics';
 import { JetpackLogo } from '@automattic/jetpack-components';
 import { isSimpleSite } from '@automattic/jetpack-script-data';
-import { Badge } from '@automattic/ui';
 import { ExternalLink, Modal } from '@wordpress/components';
 import { useViewportMatch } from '@wordpress/compose';
 import { useSelect } from '@wordpress/data';
@@ -13,6 +12,7 @@ import { dateI18n, getSettings as getDateSettings } from '@wordpress/date';
 import { useCallback, useMemo, useState } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
 import { __ } from '@wordpress/i18n';
+import { Badge } from '@wordpress/ui';
 import clsx from 'clsx';
 import { useEffect } from 'react';
 /**
@@ -468,7 +468,7 @@ export default function InboxView( { parentId, pageTitle, pageSubtitle } = {} ) 
 				enableSorting: false,
 				render: ( { item } ) => {
 					return (
-						<Badge intent="default">
+						<Badge intent="draft">
 							{ item.is_unread ? __( 'Unread', 'jetpack-forms' ) : __( 'Read', 'jetpack-forms' ) }
 						</Badge>
 					);

--- a/projects/packages/forms/src/dashboard/inbox/style.scss
+++ b/projects/packages/forms/src/dashboard/inbox/style.scss
@@ -4,6 +4,7 @@
 @use "../mixins";
 @use "../../blocks/shared/styles/empty_image_option" as *;
 @import "@wordpress/dataviews/build-style/style.css";
+@import "@wordpress/theme/design-tokens.css";
 
 .jp-forms-filters-bar {
 	border-bottom: 1px solid var(--wpds-color-stroke-surface-neutral-weak);

--- a/projects/packages/forms/src/dashboard/wp-build/components/dataviews-header-row/index.tsx
+++ b/projects/packages/forms/src/dashboard/wp-build/components/dataviews-header-row/index.tsx
@@ -101,7 +101,7 @@ export default function DataViewsHeaderRow( {
 								<Tabs.Tab value="responses">
 									<span>
 										{ __( 'Responses', 'jetpack-forms' ) }
-										<Badge intent="default" className="jp-forms-tabs-count">
+										<Badge intent="draft" className="jp-forms-tabs-count">
 											{ formatNumberCompact( responsesInboxCount || 0 ) }
 										</Badge>
 									</span>

--- a/projects/packages/forms/src/dashboard/wp-build/components/dataviews-header-row/index.tsx
+++ b/projects/packages/forms/src/dashboard/wp-build/components/dataviews-header-row/index.tsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { formatNumberCompact } from '@automattic/number-formatters';
-import { Badge } from '@automattic/ui';
 /**
  * WordPress dependencies
  */
@@ -11,7 +10,7 @@ import { DataViews } from '@wordpress/dataviews';
 import { useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { useNavigate } from '@wordpress/route';
-import { Stack, Tabs } from '@wordpress/ui';
+import { Badge, Stack, Tabs } from '@wordpress/ui';
 import { NON_TRASH_FORM_STATUSES } from '../../../constants.ts';
 import useFormsData from '../../../hooks/use-forms-data.ts';
 import { store as dashboardStore } from '../../../store/index.js';
@@ -94,7 +93,7 @@ export default function DataViewsHeaderRow( {
 								<Tabs.Tab value="forms">
 									<span>
 										{ __( 'Forms', 'jetpack-forms' ) }
-										<Badge intent="default" className="jp-forms-badge">
+										<Badge intent="draft" className="jp-forms-tabs-count">
 											{ formatNumberCompact( formsCount || 0 ) }
 										</Badge>
 									</span>
@@ -102,7 +101,7 @@ export default function DataViewsHeaderRow( {
 								<Tabs.Tab value="responses">
 									<span>
 										{ __( 'Responses', 'jetpack-forms' ) }
-										<Badge intent="default" className="jp-forms-badge">
+										<Badge intent="default" className="jp-forms-tabs-count">
 											{ formatNumberCompact( responsesInboxCount || 0 ) }
 										</Badge>
 									</span>

--- a/projects/packages/forms/src/dashboard/wp-build/components/dataviews-header-row/style.scss
+++ b/projects/packages/forms/src/dashboard/wp-build/components/dataviews-header-row/style.scss
@@ -33,8 +33,9 @@
 
 // Temporary hard-coded styles for tab count badges in wp-build dashboard.
 .jp-forms-tabs-count {
-	background-color: #f0f0f0;
-	color: #2f2f2f;
+	background-color: var(--wpds-color-bg-surface-neutral-weak, #f0f0f0);
+	border-radius: 0;
+	color: var(--wpds-color-fg-content-neutral, #1e1e1e);
 	margin-inline-start: 4px;
 	vertical-align: middle;
 }

--- a/projects/packages/forms/src/dashboard/wp-build/components/dataviews-header-row/style.scss
+++ b/projects/packages/forms/src/dashboard/wp-build/components/dataviews-header-row/style.scss
@@ -32,7 +32,7 @@
 }
 
 // Temporary hard-coded styles for tab count badges in wp-build dashboard.
-.jp-forms-badge {
+.jp-forms-tabs-count {
 	background-color: #f0f0f0;
 	color: #2f2f2f;
 	margin-inline-start: 4px;

--- a/projects/packages/forms/src/dashboard/wp-build/components/dataviews-header-row/style.scss
+++ b/projects/packages/forms/src/dashboard/wp-build/components/dataviews-header-row/style.scss
@@ -31,11 +31,7 @@
 	padding-block: variables.$grid-unit * 1.5;
 }
 
-// Temporary hard-coded styles for tab count badges in wp-build dashboard.
 .jp-forms-tabs-count {
-	background-color: var(--wpds-color-bg-surface-neutral-weak, #f0f0f0);
-	border-radius: 0;
-	color: var(--wpds-color-fg-content-neutral, #1e1e1e);
 	margin-inline-start: 4px;
 	vertical-align: middle;
 }

--- a/projects/packages/forms/src/dashboard/wp-build/components/inbox-status-toggle/index.tsx
+++ b/projects/packages/forms/src/dashboard/wp-build/components/inbox-status-toggle/index.tsx
@@ -2,10 +2,9 @@
  * External dependencies
  */
 import { formatNumberCompact } from '@automattic/number-formatters';
-import { Badge } from '@automattic/ui';
 import { useCallback, useMemo } from '@wordpress/element';
 import { __, _x } from '@wordpress/i18n';
-import { Tabs } from '@wordpress/ui';
+import { Badge, Tabs } from '@wordpress/ui';
 
 type Status = 'inbox' | 'spam' | 'trash';
 
@@ -38,7 +37,7 @@ const getLabel = ( status: Status, count: number ): JSX.Element => {
 	return (
 		<span>
 			{ label }
-			<Badge intent="default" className="jp-forms-badge">
+			<Badge intent="draft" className="jp-forms-tabs-count">
 				{ formatNumberCompact( count || 0 ) }
 			</Badge>
 		</span>

--- a/projects/packages/forms/src/dashboard/wp-build/hooks/use-page-header-details.tsx
+++ b/projects/packages/forms/src/dashboard/wp-build/hooks/use-page-header-details.tsx
@@ -3,7 +3,6 @@
  */
 import { useBreakpointMatch } from '@automattic/jetpack-components';
 import JetpackLogo from '@automattic/jetpack-components/jetpack-logo';
-import { Badge } from '@automattic/ui';
 import { Breadcrumbs } from '@wordpress/admin-ui';
 import { DropdownMenu, Button } from '@wordpress/components';
 import { store as coreDataStore } from '@wordpress/core-data';
@@ -12,7 +11,7 @@ import { useMemo } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
 import { __, sprintf } from '@wordpress/i18n';
 import { moreVertical } from '@wordpress/icons';
-import { Stack } from '@wordpress/ui';
+import { Badge, Stack } from '@wordpress/ui';
 /**
  * Internal dependencies
  */
@@ -145,11 +144,7 @@ export default function usePageHeaderDetails(
 		if ( ! isSingleFormScreen || ! formStatus || formStatus === 'publish' ) {
 			return undefined;
 		}
-		return (
-			<Badge className="jp-forms-badge" intent="default">
-				{ statusLabel }
-			</Badge>
-		);
+		return <Badge intent="draft">{ statusLabel }</Badge>;
 	}, [ isSingleFormScreen, formStatus, statusLabel ] );
 
 	const { duplicateForm, previewForm, copyEmbed, copyShortcode } = useFormItemActions();

--- a/projects/plugins/jetpack/changelog/pr-47377
+++ b/projects/plugins/jetpack/changelog/pr-47377
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Forms: Fix extra margin on badges in the forms dashboard.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Replace all Badge component usage with latest design system `@wordpress/ui` badge ([docs](https://wordpress.github.io/gutenberg/?path=/docs/design-system-components-badge--docs))
* Fixes styles adding extra margin to badge in form dataviews list as a follow up [to previous change](https://github.com/Automattic/jetpack/pull/47328/changes#r2861517455):
    <img width="159" height="325" alt="Screenshot 2026-02-27 at 11 43 24" src="https://github.com/user-attachments/assets/127955a8-4eff-4da2-96f3-c99a590ae807" />


### Before

Old dashboard
<img width="1107" height="540" alt="Screenshot 2026-02-27 at 13 50 07" src="https://github.com/user-attachments/assets/bde90e7a-8ed1-4d49-88bc-874839e79d86" />

New forms dashboard
<img width="1131" height="324" alt="image" src="https://github.com/user-attachments/assets/e3d992dc-c454-49b2-9a80-a06434080c71" />

Integrations modal at dashboard
<img width="865" height="584" alt="image" src="https://github.com/user-attachments/assets/65d99162-1c65-4bc7-af46-0172ad9f588f" />

Integrations modal at editor (central for management & page/post editor)
<img width="962" height="705" alt="image" src="https://github.com/user-attachments/assets/abf7fd89-de99-474e-95e8-c67496b7829f" />


### After

Old dashboard
<img width="1528" height="700" alt="Screenshot 2026-02-27 at 13 35 33" src="https://github.com/user-attachments/assets/66995c53-25d6-4283-be6d-befb7fd482b9" />

New forms dashboard
<img width="835" height="314" alt="image" src="https://github.com/user-attachments/assets/a16ae881-ddbe-45f4-9984-5e706daf2fbd" />

Integrations modal at dashboard
<img width="874" height="589" alt="image" src="https://github.com/user-attachments/assets/9bb2613b-ad02-4ff1-a5b6-cec96428ff97" />

Integrations modal at editor (central for management & page/post editor)
<img width="976" height="730" alt="image" src="https://github.com/user-attachments/assets/1433431c-3d2a-4e5c-9fc4-f6916c2539fd" />


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Test integrations in the editor and outside the editor
* Test forms dashboard
* Test responses dashboard; make read/unread status visible first from the dataviews settings cog
* Test response sidebar with radio/checkbox fields in responses

Test with and without the Gutenberg plugin active.

## Changelog
<!-- Check one of the boxes below. -->

- [x] Generate changelog entries for this PR (using AI).
