### PR TITLE
tsgo: Fix type errors in tools/e2e-commons

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5781,6 +5781,9 @@ importers:
       '@slack/web-api':
         specifier: 7.12.0
         version: 7.12.0
+      '@types/config':
+        specifier: 3.3.5
+        version: 3.3.5
       '@types/lodash-es':
         specifier: 4.17.12
         version: 4.17.12
@@ -9716,6 +9719,9 @@ packages:
 
   '@types/clean-css@4.2.11':
     resolution: {integrity: sha512-Y8n81lQVTAfP2TOdtJJEsCoYl1AnOkqDqMvXb9/7pfgZZ7r8YrEyurrAvAoAjHOGXKRybay+5CsExqIH6liccw==}
+
+  '@types/config@3.3.5':
+    resolution: {integrity: sha512-itq2HtXQBrNUKwMNZnb9mBRE3T99VYCdl1gjST9rq+9kFaB1iMMGuDeZnP88qid73DnpAMKH9ZolqDpS1Lz7+w==}
 
   '@types/connect-history-api-fallback@1.5.4':
     resolution: {integrity: sha512-n6Cr2xS1h4uAulPRdlw6Jl6s1oG8KrVilPN2yUITEs+K48EzMJJ3W1xy8K5eWuFvjp3R74AOIGSmp2UfBJ8HFw==}
@@ -22727,6 +22733,8 @@ snapshots:
     dependencies:
       '@types/node': 22.19.11
       source-map: 0.6.1
+
+  '@types/config@3.3.5': {}
 
   '@types/connect-history-api-fallback@1.5.4':
     dependencies:

--- a/tools/e2e-commons/package.json
+++ b/tools/e2e-commons/package.json
@@ -33,6 +33,7 @@
 	"devDependencies": {
 		"@playwright/test": "1.58.2",
 		"@slack/web-api": "7.12.0",
+		"@types/config": "3.3.5",
 		"@types/lodash-es": "4.17.12",
 		"@types/node": "^22.19.11",
 		"@wordpress/e2e-test-utils-playwright": "1.40.0",

--- a/tools/e2e-commons/playwright.config.default.ts
+++ b/tools/e2e-commons/playwright.config.default.ts
@@ -47,19 +47,19 @@ process.env.STORAGE_STATE_PATH = `${ process.env.STORAGE_STATE_DIR_PATH }/storag
 // Fail early if the required test site config is not defined
 // Let config lib throw by using get function on an undefined property
 if ( process.env.TEST_SITE ) {
-	config.get( 'testSites' ).get( process.env.TEST_SITE );
+	config.get< { get( key: string ): unknown } >( 'testSites' ).get( process.env.TEST_SITE );
 }
 
 // Create the temp config dir used to store all kinds of temp config stuff
 // This is needed because writeFileSync doesn't create parent dirs and will fail
-fs.mkdirSync( config.get( 'dirs.temp' ), { recursive: true } );
+fs.mkdirSync( config.get< string >( 'dirs.temp' ), { recursive: true } );
 
 const resolvedBaseURL = resolveSiteUrl();
 
 // Ensure the environment variables for `@wordpress/e2e-test-utils-playwright` are set
 const testSite = process.env.TEST_SITE ? process.env.TEST_SITE : 'default';
 logger.debug( `Using '${ testSite }' test site config` );
-const site = config.get( `testSites.${ testSite }` );
+const site = config.get< { username: string; password: string } >( `testSites.${ testSite }` );
 
 process.env.WP_BASE_URL = resolvedBaseURL;
 process.env.WP_USERNAME = site.username;
@@ -96,10 +96,11 @@ const playwrightConfig = defineConfig( {
 	},
 	retries: process.env.CI ? 1 : 0,
 	workers: defaultWorkers,
-	outputDir: config.get( 'dirs.results' ),
+	outputDir: config.get< string >( 'dirs.results' ),
 	reporter,
 	forbidOnly: !! process.env.CI,
 	use: {
+		...devices[ 'Desktop Chrome' ],
 		baseURL: resolvedBaseURL,
 		headless: true,
 		viewport: { width: 1280, height: 1600 },
@@ -119,7 +120,6 @@ const playwrightConfig = defineConfig( {
 			// TODO - Enable strictSelectors once all tests are updated.
 			// strictSelectors: true,
 		},
-		...devices[ 'Desktop Chrome' ],
 		storageState: fs.existsSync( process.env.STORAGE_STATE_PATH )
 			? process.env.STORAGE_STATE_PATH
 			: undefined,

--- a/tools/e2e-commons/setup-specs/env-check.setup.ts
+++ b/tools/e2e-commons/setup-specs/env-check.setup.ts
@@ -35,6 +35,10 @@ setup(
 	'verify environment readiness',
 	{ tag: [ getCIProjectNameTestTag() ] },
 	async ( { baseURL, request } ) => {
+		if ( ! baseURL ) {
+			throw new Error( 'baseURL is not configured' );
+		}
+
 		// Skip connectivity checks for localhost URLs
 		if ( baseURL.includes( 'localhost' ) || baseURL.includes( '127.0.0.1' ) ) {
 			await setup.step( 'skip - localhost environment', async () => {

--- a/tools/e2e-commons/utils/cli.ts
+++ b/tools/e2e-commons/utils/cli.ts
@@ -116,7 +116,7 @@ export async function executeCommand( cmd: string | string[] ): Promise< string 
 		logger.debug( `Command output: ${ maskSecrets( output.replace( /\n$/, '' ) ) }` );
 		return output;
 	} catch ( error ) {
-		logger.warn( `Command error: ${ maskSecrets( error.toString() ) }` );
+		logger.warn( `Command error: ${ maskSecrets( String( error ) ) }` );
 		throw error;
 	}
 }

--- a/tools/e2e-commons/utils/environment.ts
+++ b/tools/e2e-commons/utils/environment.ts
@@ -29,7 +29,7 @@ const { TEST_SITE } = process.env;
 export function getConfigTestSite(): TestSite {
 	const testSite = TEST_SITE ? TEST_SITE : 'default';
 	logger.debug( `Using '${ testSite }' test site config` );
-	return config.get( `testSites.${ testSite }` );
+	return config.get< TestSite >( `testSites.${ testSite }` );
 }
 
 /**
@@ -69,7 +69,9 @@ export function resolveSiteUrl(): string {
 	let url: string | undefined;
 
 	if ( TEST_SITE ) {
-		const siteConfig = config.get( `testSites.${ TEST_SITE }` );
+		const siteConfig = config.get< { get?: ( key: string ) => string; url?: string } >(
+			`testSites.${ TEST_SITE }`
+		);
 		url = typeof siteConfig.get === 'function' ? siteConfig.get( 'url' ) : siteConfig.url;
 	} else if ( process.env.USE_CLOUDFLARE_TUNNEL ) {
 		logger.debug( 'USE_CLOUDFLARE_TUNNEL is set, checking cloudflared tunnel file' );
@@ -78,8 +80,8 @@ export function resolveSiteUrl(): string {
 		try {
 			url = fs.readFileSync( cloudflaredPath, 'utf8' ).replace( 'http:', 'https:' );
 			logger.debug( `Using cloudflared tunnel URL from file: ${ url }` );
-		} catch ( error ) {
-			if ( error.code === 'ENOENT' ) {
+		} catch ( error: unknown ) {
+			if ( error instanceof Error && ( error as NodeJS.ErrnoException ).code === 'ENOENT' ) {
 				logger.warn( 'USE_CLOUDFLARE_TUNNEL is set but cloudflared tunnel file not found' );
 			} else {
 				logger.error( error );
@@ -93,8 +95,8 @@ export function resolveSiteUrl(): string {
 		try {
 			url = fs.readFileSync( localtunnelPath, 'utf8' ).replace( 'http:', 'https:' );
 			logger.debug( `Using localtunnel URL from file: ${ url }` );
-		} catch ( error ) {
-			if ( error.code === 'ENOENT' ) {
+		} catch ( error: unknown ) {
+			if ( error instanceof Error && ( error as NodeJS.ErrnoException ).code === 'ENOENT' ) {
 				logger.warn( 'Localtunnel file not found' );
 			} else {
 				logger.error( error );

--- a/tools/e2e-commons/utils/partner-provision.ts
+++ b/tools/e2e-commons/utils/partner-provision.ts
@@ -22,7 +22,7 @@ export async function partnerProvisionConnection(
 	user: string
 ): Promise< boolean > {
 	logger.info( `Provisioning Jetpack start connection [userId: ${ userId }, plan: ${ plan }]` );
-	const [ clientID, clientSecret ] = config.get( 'jetpackStartSecrets' );
+	const [ clientID, clientSecret ] = config.get< Array< string > >( 'jetpackStartSecrets' );
 	const __dirname = url.fileURLToPath( new URL( '.', import.meta.url ) );
 
 	const scriptPath = path.resolve( __dirname, '../../partner-provision.sh' );
@@ -54,7 +54,7 @@ export async function partnerProvisionConnection(
  */
 export async function cancelPartnerPlan() {
 	logger.info( `Cancelling partner plan` );
-	const [ clientID, clientSecret ] = config.get( 'jetpackStartSecrets' );
+	const [ clientID, clientSecret ] = config.get< string[] >( 'jetpackStartSecrets' );
 	const __dirname = url.fileURLToPath( new URL( '.', import.meta.url ) );
 	const scriptPath = path.resolve( __dirname, '../../partner-cancel.sh' );
 	const cmd = `sh ${ scriptPath } --partner_id=${ clientID } --partner_secret=${ clientSecret } --allow-root`;


### PR DESCRIPTION
Fixes MONOREP-376

## Proposed changes:
* Fix tsgo type errors in `tools/e2e-commons` by addressing strict type checking that tsgo enforces over tsc.

  **TS7016 — Missing type declarations for `config` module:**
  Added `@types/config` to devDependencies and used `config.get<T>()` generics for type-safe access.

  **TS2783 — `viewport`/`userAgent` specified more than once:**
  Moved `...devices['Desktop Chrome']` spread before custom `viewport` and `userAgent` properties so the custom values take precedence instead of being silently overwritten.

  **TS18048/TS2345 — `baseURL` possibly `undefined`:**
  Added an early guard in `env-check.setup.ts` to throw if `baseURL` is not configured, narrowing the type for subsequent usage.

  **TS18046 — `error` is of type `unknown`:**
  Used `String(error)` in `cli.ts` and `instanceof Error` with `NodeJS.ErrnoException` cast in `environment.ts` to safely access error properties.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

N/A — Internal tooling change.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

* Run `pnpm typecheck` in `tools/e2e-commons` and verify it passes with no errors.
* Verify that e2e tests still run correctly (the `...devices['Desktop Chrome']` reorder preserves the intended custom viewport/userAgent).

## Changelog

- [ ] Generate changelog entries for this PR (using AI).
