### PR TITLE
Sync: Add 'protocol' comment meta to the sync whitelist

### DIFF
--- a/projects/packages/sync/changelog/add-sync-comment-protocol-meta
+++ b/projects/packages/sync/changelog/add-sync-comment-protocol-meta
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Added 'protocol' to the comment meta whitelist for syncing.

--- a/projects/packages/sync/src/class-defaults.php
+++ b/projects/packages/sync/src/class-defaults.php
@@ -824,6 +824,7 @@ class Defaults {
 		'hc_foreign_user_id',
 		'hc_post_as',
 		'hc_wpcom_id_sig',
+		'protocol',
 	);
 
 	/**


### PR DESCRIPTION
Fixes CM-565

## Proposed changes:

* Add `protocol` to the comment meta whitelist in the Sync package, so that the `protocol` comment meta key is synchronized to WordPress.com when it is available on a comment.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

The existing `test_sync_whitelisted_comment_meta` test in `Jetpack_Sync_Meta_Test` dynamically iterates all keys in `Defaults::$comment_meta_whitelist`, so it automatically covers the new `protocol` key without needing additional test code.

## Jetpack product discussion

## Does this pull request change what data or activity we track or use?

Yes — this change adds the `protocol` comment meta key to the list of comment metadata that gets synced to WordPress.com. This meta key records the protocol used when a comment was created (e.g., ActivityPub). No new tracking is introduced; this simply allows an existing meta value to be included in the sync payload.

## Testing instructions:

* On a test site with Jetpack connected, create a comment that has a `protocol` meta value set (e.g., via `add_comment_meta( $comment_id, 'protocol', 'activitypub' )`).
* Trigger a sync (or wait for the next sync cycle).
* Verify that the `protocol` comment meta appears in the synced data on WordPress.com.
* Alternatively, run the existing sync meta test suite to confirm the new key is covered:
  ```
  jetpack docker phpunit jetpack -- --filter="test_sync_whitelisted_comment_meta"
  ```

## Changelog

- [x] Generate changelog entries for this PR (using AI).