### PR TITLE
tsgo: Fix js-packages/connection type errors

### DIFF
--- a/projects/js-packages/connection/changelog/update-tsgo-fix-use-connection-type-errors
+++ b/projects/js-packages/connection/changelog/update-tsgo-fix-use-connection-type-errors
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Convert useConnection hook to TypeScript.

--- a/projects/js-packages/connection/components/connect-screen/basic/index.tsx
+++ b/projects/js-packages/connection/components/connect-screen/basic/index.tsx
@@ -78,7 +78,7 @@ const ConnectScreen: FC< Props > = ( {
 
 	const displayButtonError = Boolean( registrationError );
 	const buttonIsLoading = siteIsRegistering || userIsConnecting;
-	const errorCode = registrationError?.response?.code;
+	const errorCode = registrationError ? registrationError.response?.code : undefined;
 
 	return (
 		<ConnectScreenVisual

--- a/projects/js-packages/connection/components/use-connection/index.ts
+++ b/projects/js-packages/connection/components/use-connection/index.ts
@@ -2,23 +2,26 @@ import restApi from '@automattic/jetpack-api';
 import { getScriptData } from '@automattic/jetpack-script-data';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useEffect } from 'react';
-import { STORE_ID } from '../../state/store';
+import { STORE_ID } from '../../state/store.jsx';
+import type {
+	RegistrationError,
+	UserConnectionData,
+	UseConnectionProps,
+	UseConnectionReturn,
+} from './types.ts';
 
-const initialState = window?.JP_CONNECTION_INITIAL_STATE || getScriptData()?.connection || {};
+type StoreSelector = ( storeId: string ) => Record< string, ( ...args: unknown[] ) => unknown >;
+
+const initialState =
+	window?.JP_CONNECTION_INITIAL_STATE ||
+	getScriptData()?.connection ||
+	( {} as Record< string, string > );
 
 /**
  * Hook to handle the connection process.
  *
- * @param {object}  [props]                    - The props.
- * @param {string}  [props.registrationNonce]  - The registration nonce.
- * @param {string}  [props.apiRoot]            - The API root URL.
- * @param {string}  [props.apiNonce]           - The API nonce.
- * @param {string}  [props.redirectUri]        - The redirect URI.
- * @param {boolean} [props.autoTrigger]        - Whether to auto-trigger the connection process.
- * @param {string}  [props.from]               - Value that represents the redirect origin.
- * @param {boolean} [props.skipUserConnection] - Whether to skip user connection.
- * @param {boolean} [props.skipPricingPage]    - Whether to skip the pricing page.
- * @return {object} The connection state and handlers.
+ * @param {UseConnectionProps} props - The props.
+ * @return {UseConnectionReturn} The connection state and handlers.
  */
 export default function useConnection( {
 	registrationNonce = initialState.registrationNonce,
@@ -29,10 +32,14 @@ export default function useConnection( {
 	from,
 	skipUserConnection,
 	skipPricingPage,
-} = {} ) {
+}: UseConnectionProps = {} ): UseConnectionReturn {
 	const { registerSite, connectUser, refreshConnectedPlugins } = useDispatch( STORE_ID );
 
-	const registrationError = useSelect( select => select( STORE_ID ).getRegistrationError() );
+	const registrationError = useSelect(
+		( select: StoreSelector ) =>
+			select( STORE_ID ).getRegistrationError() as RegistrationError | false,
+		[]
+	);
 	const {
 		siteIsRegistering,
 		userIsConnecting,
@@ -43,26 +50,34 @@ export default function useConnection( {
 		isUserConnected,
 		hasConnectedOwner,
 		isOfflineMode,
-	} = useSelect( select => ( {
-		siteIsRegistering: select( STORE_ID ).getSiteIsRegistering(),
-		userIsConnecting: select( STORE_ID ).getUserIsConnecting(),
-		userConnectionData: select( STORE_ID ).getUserConnectionData(),
-		connectedPlugins: select( STORE_ID ).getConnectedPlugins(),
-		connectionErrors: select( STORE_ID ).getConnectionErrors(),
-		isOfflineMode: select( STORE_ID ).getIsOfflineMode(),
-		...select( STORE_ID ).getConnectionStatus(),
-	} ) );
+	} = useSelect( ( select: StoreSelector ) => {
+		const connectionStatus = select( STORE_ID ).getConnectionStatus() as Record< string, unknown >;
+		return {
+			siteIsRegistering: select( STORE_ID ).getSiteIsRegistering() as boolean,
+			userIsConnecting: select( STORE_ID ).getUserIsConnecting() as boolean,
+			userConnectionData: ( select( STORE_ID ).getUserConnectionData() ||
+				{} ) as UserConnectionData,
+			connectedPlugins: select( STORE_ID ).getConnectedPlugins() as
+				| Record< string, unknown >
+				| unknown[],
+			connectionErrors: select( STORE_ID ).getConnectionErrors() as Array< string | object >,
+			isOfflineMode: select( STORE_ID ).getIsOfflineMode() as boolean,
+			isRegistered: ( connectionStatus.isRegistered ?? false ) as boolean,
+			isUserConnected: ( connectionStatus.isUserConnected ?? false ) as boolean,
+			hasConnectedOwner: ( connectionStatus.hasConnectedOwner ?? false ) as boolean,
+		};
+	}, [] );
 
 	/**
 	 * User register process handler.
 	 *
-	 * @return {Promise} - Promise which resolves when the product status is activated.
+	 * @return Promise when running the user connection process. Otherwise, nothing.
 	 */
-	const handleConnectUser = () => {
+	const handleConnectUser = (): Promise< unknown > => {
 		if ( ! skipUserConnection ) {
 			return connectUser( { from, redirectUri, skipPricingPage } );
 		} else if ( redirectUri ) {
-			window.location = redirectUri;
+			window.location.href = redirectUri;
 			return Promise.resolve( redirectUri );
 		}
 
@@ -79,9 +94,9 @@ export default function useConnection( {
 	 * the site was successfully registered.
 	 *
 	 * @param {Event} [e] - Event that dispatched handleRegisterSite
-	 * @return {Promise}   Promise when running the registration process. Otherwise, nothing.
+	 * @return Promise when running the site connection process. Otherwise, nothing.
 	 */
-	const handleRegisterSite = e => {
+	const handleRegisterSite = ( e?: Event ): Promise< unknown > => {
 		e && e.preventDefault();
 
 		if ( isRegistered ) {

--- a/projects/js-packages/connection/components/use-connection/types.ts
+++ b/projects/js-packages/connection/components/use-connection/types.ts
@@ -1,0 +1,77 @@
+export interface UseConnectionProps {
+	/**
+	 * The registration nonce.
+	 */
+	registrationNonce?: string;
+	/**
+	 * The API root URL.
+	 */
+	apiRoot?: string;
+	/**
+	 * The API nonce.
+	 */
+	apiNonce?: string;
+	/**
+	 * The redirect URI.
+	 */
+	redirectUri?: string;
+	/**
+	 * Whether to auto-trigger the connection process.
+	 */
+	autoTrigger?: boolean;
+	/**
+	 * Value that represents the redirect origin.
+	 */
+	from?: string;
+	/**
+	 * Whether to skip user connection.
+	 */
+	skipUserConnection?: boolean;
+	/**
+	 * Whether to skip the pricing page.
+	 */
+	skipPricingPage?: boolean;
+}
+
+export interface WpcomUser {
+	display_name?: string;
+	email?: string;
+	login?: string;
+	avatar?: string;
+	ID?: number;
+	[ key: string ]: unknown;
+}
+
+export interface UserConnectionData {
+	currentUser?: {
+		wpcomUser?: WpcomUser;
+		username?: string;
+		isMaster?: boolean;
+		possibleAccountErrors?: Record< string, unknown >;
+		[ key: string ]: unknown;
+	};
+	connectionOwner?: string | null;
+	[ key: string ]: unknown;
+}
+
+export interface RegistrationError {
+	message?: string;
+	response?: { code?: string };
+	[ key: string ]: unknown;
+}
+
+export interface UseConnectionReturn {
+	handleRegisterSite: ( e?: Event ) => Promise< unknown >;
+	handleConnectUser: () => Promise< unknown >;
+	refreshConnectedPlugins: () => Promise< unknown >;
+	isRegistered: boolean;
+	isUserConnected: boolean;
+	siteIsRegistering: boolean;
+	userIsConnecting: boolean;
+	registrationError: RegistrationError | false;
+	userConnectionData: UserConnectionData;
+	hasConnectedOwner: boolean;
+	connectedPlugins: Record< string, unknown > | unknown[];
+	connectionErrors: Array< string | object >;
+	isOfflineMode: boolean;
+}

--- a/projects/js-packages/connection/package.json
+++ b/projects/js-packages/connection/package.json
@@ -20,7 +20,7 @@
 	"type": "module",
 	"exports": {
 		".": "./index.jsx",
-		"./use-connection": "./components/use-connection/index.jsx"
+		"./use-connection": "./components/use-connection/index.ts"
 	},
 	"scripts": {
 		"test": "NODE_OPTIONS=--experimental-vm-modules jest",

--- a/projects/packages/my-jetpack/_inc/components/connection-status-card/test/component.tsx
+++ b/projects/packages/my-jetpack/_inc/components/connection-status-card/test/component.tsx
@@ -93,7 +93,11 @@ const setConnectionStore = ( {
 	jest
 		.spyOn( storeSelect, 'getConnectionStatus' )
 		.mockReset()
-		.mockReturnValue( { isRegistered, isUserConnected, hasConnectedOwner, userConnectionData } );
+		.mockReturnValue( { isRegistered, isUserConnected, hasConnectedOwner } );
+	jest
+		.spyOn( storeSelect, 'getUserConnectionData' )
+		.mockReset()
+		.mockReturnValue( userConnectionData );
 };
 beforeAll( () => {
 	global.JetpackScriptData = {

--- a/projects/packages/my-jetpack/changelog/update-tsgo-fix-use-connection-type-errors
+++ b/projects/packages/my-jetpack/changelog/update-tsgo-fix-use-connection-type-errors
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix JS tests following the change in useConnection.


### PR DESCRIPTION
Fixes MONOREP-377

## Proposed changes:

- Fix tsgo type errors in `js-packages/connection` by converting the `useConnection` hook from JavaScript to TypeScript.

  **TS2339 — Properties don't exist on type `'{}'`:**
  Converted `components/use-connection/index.jsx` to `.ts` with `UseConnectionProps` and `UseConnectionReturn` interfaces, giving the hook explicit parameter and return types. Extracted types into a separate `types.ts` file. Added concrete `UserConnectionData`, `WpcomUser`, and `RegistrationError` interfaces so downstream consumers (e.g. `my-jetpack`) get proper property access through `ReturnType<typeof useConnection>`.

  **TS2339 — `response` does not exist on type `false`:**
  Changed `registrationError?.response?.code` to a truthiness-narrowed ternary in `connect-screen/basic/index.tsx`, since optional chaining doesn't narrow the `false` branch of the union type.

  **Untyped `useSelect` callbacks:**
  Added explicit `StoreSelector` type for the `select` parameter and cast store selector return values to their expected types, replacing the opaque `getConnectionStatus()` spread with individually typed properties.

  **`window.location = redirectUri`:**
  Changed to `window.location.href = redirectUri` for type-safe assignment.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

N/A — Internal tooling change.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

- Run `pnpm typecheck` and verify cascading errors are also resolved.
- Verify that the connection screen still works as expected (no runtime behavior changes).

## Changelog

- [ ] Generate changelog entries for this PR (using AI).

Note: This is not the type of TypeScript I like but it's more like a band-aid for the problem. The real fix would be to convert the whole connection data store to TS and use the store object in useSelect and useDispatch instead of the store ID.