### PR TITLE
Forms: use integer format for responses count in dataviews

### DIFF
--- a/projects/packages/forms/changelog/pr-47381
+++ b/projects/packages/forms/changelog/pr-47381
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Forms: Use integer format for response count in dataviews.

--- a/projects/packages/forms/routes/forms/package.json
+++ b/projects/packages/forms/routes/forms/package.json
@@ -4,6 +4,7 @@
 	"private": true,
 	"dependencies": {
 		"@automattic/jetpack-components": "workspace:*",
+		"@automattic/number-formatters": "workspace:*",
 		"@automattic/ui": "1.0.2",
 		"@types/react": "18.3.28",
 		"@wordpress/admin-ui": "1.8.0",

--- a/projects/packages/forms/routes/forms/package.json
+++ b/projects/packages/forms/routes/forms/package.json
@@ -4,7 +4,6 @@
 	"private": true,
 	"dependencies": {
 		"@automattic/jetpack-components": "workspace:*",
-		"@automattic/number-formatters": "workspace:*",
 		"@automattic/ui": "1.0.2",
 		"@types/react": "18.3.28",
 		"@wordpress/admin-ui": "1.8.0",

--- a/projects/packages/forms/routes/forms/stage.tsx
+++ b/projects/packages/forms/routes/forms/stage.tsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { formatNumber } from '@automattic/number-formatters';
 import { Badge } from '@automattic/ui';
 import { Page } from '@wordpress/admin-ui';
 import {
@@ -260,8 +259,8 @@ function StageInner() {
 			{
 				id: 'entries',
 				label: __( 'Responses', 'jetpack-forms' ),
+				type: 'integer',
 				getValue: ( { item }: { item: FormListItem } ) => item.entriesCount ?? 0,
-				render: ( { item }: { item: FormListItem } ) => formatNumber( item.entriesCount ?? 0 ),
 				enableSorting: false,
 			},
 			{

--- a/projects/packages/forms/routes/forms/stage.tsx
+++ b/projects/packages/forms/routes/forms/stage.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { formatNumber } from '@automattic/number-formatters';
 import { Badge } from '@automattic/ui';
 import { Page } from '@wordpress/admin-ui';
 import {
@@ -260,7 +261,7 @@ function StageInner() {
 				id: 'entries',
 				label: __( 'Responses', 'jetpack-forms' ),
 				getValue: ( { item }: { item: FormListItem } ) => item.entriesCount ?? 0,
-				render: ( { item }: { item: FormListItem } ) => item.entriesCount ?? 0,
+				render: ( { item }: { item: FormListItem } ) => formatNumber( item.entriesCount ?? 0 ),
 				enableSorting: false,
 			},
 			{

--- a/projects/plugins/jetpack/changelog/pr-47381
+++ b/projects/plugins/jetpack/changelog/pr-47381
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Forms: Use integer format for response count in dataviews.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->



## Proposed changes:
<!--- Explain what functional changes your PR includes -->

Before

<img width="147" height="185" alt="Screenshot 2026-02-27 at 13 56 46" src="https://github.com/user-attachments/assets/743ac3ad-2077-492f-9ceb-b0686b925b68" />


After

<img width="182" height="174" alt="Screenshot 2026-02-27 at 13 56 50" src="https://github.com/user-attachments/assets/9928e10e-de98-4115-a86d-e8d5b2f345f6" />


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Check counter for responses in forms dataviews
   *  You can mock big numbers either in JS [or backend](https://github.com/Automattic/jetpack/blob/b7db1ae5365973524bce4811565963d2fd2f4356/projects/packages/forms/src/contact-form/class-jetpack-form-endpoint.php#L135)
* Tabs use short format (1.2K), while dataviews uses long format (1,200)

## Changelog
<!-- Check one of the boxes below. -->

- [x] Generate changelog entries for this PR (using AI).
