### PR TITLE
Canonical URLs: fix flaky author archive tests

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-author-archive-flake
+++ b/projects/plugins/jetpack/changelog/fix-author-archive-flake
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Canonical URLs: Fix flaky author archive canonical URL resolution on WordPress trunk.

--- a/projects/plugins/jetpack/modules/canonical-urls/class-jetpack-canonical-urls-resolver.php
+++ b/projects/plugins/jetpack/modules/canonical-urls/class-jetpack-canonical-urls-resolver.php
@@ -58,9 +58,9 @@ class Jetpack_Canonical_Urls_Resolver {
 				$url = '';
 			}
 		} elseif ( is_author() ) {
-			$author = get_queried_object();
-			if ( $author instanceof WP_User ) {
-				$url = get_author_posts_url( $author->ID );
+			$author_id = (int) get_query_var( 'author' );
+			if ( $author_id ) {
+				$url = get_author_posts_url( $author_id );
 			}
 		} elseif ( is_year() ) {
 			$url = get_year_link( get_query_var( 'year' ) );

--- a/projects/plugins/jetpack/tests/php/modules/canonical-urls/Jetpack_Canonical_Urls_Test.php
+++ b/projects/plugins/jetpack/tests/php/modules/canonical-urls/Jetpack_Canonical_Urls_Test.php
@@ -197,7 +197,7 @@ class Jetpack_Canonical_Urls_Test extends WP_UnitTestCase {
 	 * Test resolver returns the author posts URL for an author archive.
 	 */
 	public function test_resolver_author() {
-		$user_id = self::factory()->user->create();
+		$user_id = self::factory()->user->create( array( 'role' => 'author' ) );
 		self::factory()->post->create( array( 'post_author' => $user_id ) );
 		$this->go_to( get_author_posts_url( $user_id ) );
 
@@ -401,7 +401,7 @@ class Jetpack_Canonical_Urls_Test extends WP_UnitTestCase {
 	 * Test that visiting an author archive with multiple tracking args returns clean URL.
 	 */
 	public function test_resolver_author_with_tracking_args() {
-		$user_id = self::factory()->user->create();
+		$user_id = self::factory()->user->create( array( 'role' => 'author' ) );
 		self::factory()->post->create( array( 'post_author' => $user_id ) );
 		$this->go_to(
 			add_query_arg(

--- a/projects/plugins/jetpack/tests/php/modules/canonical-urls/Jetpack_Canonical_Urls_Test.php
+++ b/projects/plugins/jetpack/tests/php/modules/canonical-urls/Jetpack_Canonical_Urls_Test.php
@@ -200,6 +200,7 @@ class Jetpack_Canonical_Urls_Test extends WP_UnitTestCase {
 		$user_id = self::factory()->user->create( array( 'role' => 'author' ) );
 		self::factory()->post->create( array( 'post_author' => $user_id ) );
 		$this->go_to( get_author_posts_url( $user_id ) );
+		$this->assertTrue( is_author(), 'Expected is_author() after go_to author archive URL' );
 
 		$url = Jetpack_Canonical_Urls_Resolver::get_canonical_url();
 
@@ -413,6 +414,7 @@ class Jetpack_Canonical_Urls_Test extends WP_UnitTestCase {
 				get_author_posts_url( $user_id )
 			)
 		);
+		$this->assertTrue( is_author(), 'Expected is_author() after go_to author archive URL' );
 
 		$url = Jetpack_Canonical_Urls_Resolver::get_canonical_url();
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes JETPACK-1377

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Update canonical URL author archive resolution to use `get_query_var( 'author' )` instead of `get_queried_object()`.
* Update author archive tests to create users with the `author` role and assert `is_author()` after `go_to()`.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1772194222650529-slack-C08PN0LHCCT

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
No definite testing steps other than canonical URLs tests shouldn't be flaky