### PR TITLE
My Jetpack: Hide VideoPress on WoA plans without the feature

### DIFF
--- a/projects/packages/my-jetpack/changelog/fix-videopress-available-on-woa-personal
+++ b/projects/packages/my-jetpack/changelog/fix-videopress-available-on-woa-personal
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+VideoPress product no longer shows as available on WoA plans that do not include the VideoPress feature.

--- a/projects/packages/my-jetpack/src/products/class-videopress.php
+++ b/projects/packages/my-jetpack/src/products/class-videopress.php
@@ -7,7 +7,9 @@
 
 namespace Automattic\Jetpack\My_Jetpack\Products;
 
+use Automattic\Jetpack\Current_Plan;
 use Automattic\Jetpack\My_Jetpack\Hybrid_Product;
+use Automattic\Jetpack\My_Jetpack\Products;
 use Automattic\Jetpack\My_Jetpack\Wpcom_Products;
 use Automattic\Jetpack\VideoPress\Stats as VideoPress_Stats;
 use WP_Error;
@@ -91,11 +93,56 @@ class Videopress extends Hybrid_Product {
 	 */
 	public static $feature_identifying_paid_plan = 'videopress';
 
-		/**
-		 * Setup VideoPress REST API endpoints
-		 *
-		 * @return void
-		 */
+	/**
+	 * Checks whether the product is active.
+	 *
+	 * On WoA, the VideoPress free tier is not available on all plans.
+	 * Current_Plan::supports() handles this: on WoA it delegates to
+	 * wpcom_site_has_feature(), on self-hosted it returns true (free tier).
+	 *
+	 * When the platform does not support the feature (e.g. WoA Personal),
+	 * requires an actual paid plan instead of falling through to the
+	 * free-offering path in the parent class.
+	 *
+	 * @return boolean
+	 */
+	public static function is_active(): bool {
+		if ( static::$has_free_offering && ! Current_Plan::supports( static::$feature_identifying_paid_plan ) ) {
+			return static::is_plugin_active() && static::is_module_active() && static::has_any_plan_for_product();
+		}
+
+		return parent::is_active();
+	}
+
+	/**
+	 * Gets the product status.
+	 *
+	 * On WoA without the 'videopress' feature (e.g. Personal plans), the
+	 * parent returns STATUS_NEEDS_ACTIVATION because $has_free_offering is
+	 * true. This override corrects that to STATUS_NEEDS_PLAN, since the
+	 * free tier is not actually available on these plans.
+	 *
+	 * @return string
+	 */
+	public static function get_status(): string {
+		$status = parent::get_status();
+
+		if ( ! static::$has_free_offering || Current_Plan::supports( static::$feature_identifying_paid_plan ) ) {
+			return $status;
+		}
+
+		if ( Products::STATUS_NEEDS_ACTIVATION === $status ) {
+			return Products::STATUS_NEEDS_PLAN;
+		}
+
+		return $status;
+	}
+
+	/**
+	 * Setup VideoPress REST API endpoints
+	 *
+	 * @return void
+	 */
 	public static function register_endpoints(): void {
 		parent::register_endpoints();
 		// Get Jetpack VideoPress data.

--- a/projects/packages/my-jetpack/tests/php/Videopress_Product_Woa_Test.php
+++ b/projects/packages/my-jetpack/tests/php/Videopress_Product_Woa_Test.php
@@ -1,0 +1,191 @@
+<?php
+/**
+ * Tests for VideoPress product behavior on WoA sites.
+ *
+ * @package automattic/my-jetpack
+ */
+
+namespace Automattic\Jetpack\My_Jetpack;
+
+use Automattic\Jetpack\My_Jetpack\Products\Videopress;
+use PHPUnit\Framework\TestCase;
+use WorDBless\Options as WorDBless_Options;
+use WorDBless\Users as WorDBless_Users;
+
+require_once __DIR__ . '/assets/wpcom-feature-mocks.php';
+
+/**
+ * Tests for VideoPress product status and activation on WoA.
+ */
+class Videopress_Product_Woa_Test extends TestCase {
+
+	/**
+	 * The current user id.
+	 *
+	 * @var int
+	 */
+	private static $user_id;
+
+	/**
+	 * Filter callback for making the videopress module active.
+	 *
+	 * @param array $modules Active modules.
+	 * @return array
+	 */
+	public static function add_videopress_module( $modules ) {
+		$modules[] = 'videopress';
+		return $modules;
+	}
+
+	/**
+	 * Setting up the test.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		$this->install_mock_plugins();
+		wp_cache_delete( 'plugins', 'plugins' );
+
+		self::$user_id = wp_insert_user(
+			array(
+				'user_login' => 'test_admin',
+				'user_pass'  => '123',
+				'role'       => 'administrator',
+			)
+		);
+		wp_set_current_user( self::$user_id );
+	}
+
+	/**
+	 * Installs mock plugins.
+	 */
+	public function install_mock_plugins() {
+		$plugin_dir = WP_PLUGIN_DIR . '/' . Videopress::$plugin_slug;
+		if ( ! file_exists( $plugin_dir ) ) {
+			mkdir( $plugin_dir, 0777, true );
+		}
+		if ( ! file_exists( WP_PLUGIN_DIR . '/jetpack' ) ) {
+			mkdir( WP_PLUGIN_DIR . '/jetpack', 0777, true );
+		}
+		copy( __DIR__ . '/assets/videopress-mock-plugin.txt', WP_PLUGIN_DIR . '/jetpack-videopress/jetpack-videopress.php' );
+		copy( __DIR__ . '/assets/jetpack-mock-plugin.txt', WP_PLUGIN_DIR . '/jetpack/jetpack.php' );
+	}
+
+	/**
+	 * Returning the environment into its initial state.
+	 */
+	public function tearDown(): void {
+		parent::tearDown();
+		unset( $GLOBALS['wpcom_test_feature_exists'] );
+		unset( $GLOBALS['wpcom_test_site_features'] );
+		remove_filter( 'jetpack_active_modules', array( __CLASS__, 'add_videopress_module' ) );
+		WorDBless_Options::init()->clear_options();
+		WorDBless_Users::init()->clear_all_users();
+	}
+
+	/**
+	 * Simulate a WoA site where the 'videopress' feature is known but the
+	 * current plan does not include it (e.g. Personal plan).
+	 */
+	private function simulate_woa_without_videopress() {
+		$GLOBALS['wpcom_test_feature_exists'] = array( 'videopress' );
+		$GLOBALS['wpcom_test_site_features']  = array();
+	}
+
+	/**
+	 * Simulate a WoA site where the current plan includes VideoPress
+	 * (e.g. Premium or higher).
+	 */
+	private function simulate_woa_with_videopress() {
+		$GLOBALS['wpcom_test_feature_exists'] = array( 'videopress' );
+		$GLOBALS['wpcom_test_site_features']  = array( 'videopress' );
+	}
+
+	/**
+	 * On WoA Personal (no videopress feature), is_active() should return false
+	 * even when the plugin and module are active.
+	 */
+	public function test_is_active_returns_false_on_woa_without_videopress_feature() {
+		$this->simulate_woa_without_videopress();
+		activate_plugins( 'jetpack/jetpack.php' );
+		add_filter( 'jetpack_active_modules', array( __CLASS__, 'add_videopress_module' ) );
+
+		$this->assertFalse( Videopress::is_active() );
+	}
+
+	/**
+	 * On WoA Premium (has videopress feature), is_active() should return true
+	 * when the plugin and module are active.
+	 */
+	public function test_is_active_returns_true_on_woa_with_videopress_feature() {
+		$this->simulate_woa_with_videopress();
+		activate_plugins( 'jetpack/jetpack.php' );
+		add_filter( 'jetpack_active_modules', array( __CLASS__, 'add_videopress_module' ) );
+
+		$this->assertTrue( Videopress::is_active() );
+	}
+
+	/**
+	 * On self-hosted (no wpcom functions active), is_active() should return true
+	 * when the plugin and module are active — the free tier applies.
+	 *
+	 * Note: The mock wpcom_feature_exists() in wpcom-feature-mocks.php means
+	 * Current_Plan::supports() follows the WoA path, but with no globals set
+	 * it returns false, which still exercises the self-hosted-like free-tier
+	 * fallback in the parent class.
+	 */
+	public function test_is_active_returns_true_on_self_hosted() {
+		// Don't set any wpcom globals — simulates self-hosted.
+		activate_plugins( 'jetpack/jetpack.php' );
+		add_filter( 'jetpack_active_modules', array( __CLASS__, 'add_videopress_module' ) );
+
+		$this->assertTrue( Videopress::is_active() );
+	}
+
+	/**
+	 * On WoA Personal with the module active, get_status() should return
+	 * 'needs_plan' instead of 'needs_activation'.
+	 */
+	public function test_get_status_returns_needs_plan_on_woa_without_videopress_feature() {
+		$this->simulate_woa_without_videopress();
+		activate_plugins( 'jetpack/jetpack.php' );
+		add_filter( 'jetpack_active_modules', array( __CLASS__, 'add_videopress_module' ) );
+
+		$this->assertSame( Products::STATUS_NEEDS_PLAN, Videopress::get_status() );
+	}
+
+	/**
+	 * On WoA Personal with the module not active, get_status() should still
+	 * not return 'needs_activation'.
+	 */
+	public function test_get_status_does_not_return_needs_activation_on_woa_without_videopress_feature() {
+		$this->simulate_woa_without_videopress();
+		activate_plugins( 'jetpack/jetpack.php' );
+
+		$this->assertNotSame( Products::STATUS_NEEDS_ACTIVATION, Videopress::get_status() );
+	}
+
+	/**
+	 * On WoA Premium (has videopress feature), get_status() should pass
+	 * through the parent status unchanged.
+	 */
+	public function test_get_status_passes_through_on_woa_with_videopress_feature() {
+		$this->simulate_woa_with_videopress();
+		activate_plugins( 'jetpack/jetpack.php' );
+		add_filter( 'jetpack_active_modules', array( __CLASS__, 'add_videopress_module' ) );
+
+		$status = Videopress::get_status();
+		$this->assertNotSame( Products::STATUS_NEEDS_PLAN, $status );
+	}
+
+	/**
+	 * On self-hosted, get_status() should not return 'needs_plan' —
+	 * the free tier is available.
+	 */
+	public function test_get_status_does_not_return_needs_plan_on_self_hosted() {
+		// Don't set any wpcom globals — simulates self-hosted.
+		activate_plugins( 'jetpack/jetpack.php' );
+		add_filter( 'jetpack_active_modules', array( __CLASS__, 'add_videopress_module' ) );
+
+		$this->assertNotSame( Products::STATUS_NEEDS_PLAN, Videopress::get_status() );
+	}
+}

--- a/projects/packages/my-jetpack/tests/php/assets/wpcom-feature-mocks.php
+++ b/projects/packages/my-jetpack/tests/php/assets/wpcom-feature-mocks.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Mock wpcom feature functions for testing WoA behavior.
+ *
+ * Defines wpcom_feature_exists() and wpcom_site_has_feature() in the global
+ * namespace, controlled by $GLOBALS['wpcom_test_feature_exists'] and
+ * $GLOBALS['wpcom_test_site_features'].
+ *
+ * @package automattic/my-jetpack
+ */
+
+if ( ! function_exists( 'wpcom_feature_exists' ) ) {
+	/**
+	 * Mock wpcom_feature_exists().
+	 *
+	 * @param string $feature Feature slug.
+	 * @return bool
+	 */
+	function wpcom_feature_exists( $feature ) {
+		return isset( $GLOBALS['wpcom_test_feature_exists'] )
+			&& in_array( $feature, $GLOBALS['wpcom_test_feature_exists'], true );
+	}
+}
+
+if ( ! function_exists( 'wpcom_site_has_feature' ) ) {
+	/**
+	 * Mock wpcom_site_has_feature().
+	 *
+	 * @param string $feature Feature slug.
+	 * @return bool
+	 */
+	function wpcom_site_has_feature( $feature ) {
+		return isset( $GLOBALS['wpcom_test_site_features'] )
+			&& in_array( $feature, $GLOBALS['wpcom_test_site_features'], true );
+	}
+}


### PR DESCRIPTION
Fixes VIDP-217

## Proposed changes:

On WoA sites with a Personal plan, VideoPress appeared available in My Jetpack but couldn't actually be activated — the "1 free video" offer is only for self-hosted Jetpack sites. This happened because the `$has_free_offering` flag in the product base class bypassed plan checks universally, regardless of WoA feature gates.

- Override `is_active()` in the VideoPress product class to require a paid plan when `Current_Plan::supports('videopress')` returns false (i.e. on WoA Personal)
- Override `get_status()` to correct `STATUS_NEEDS_ACTIVATION` → `STATUS_NEEDS_PLAN` on plans without the feature
- Self-hosted and WoA Premium+ behavior is unchanged

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

- On WoA Personal: VideoPress status should be `needs_plan`, not `needs_activation`
- On WoA Premium+: VideoPress should work as before (active when plugin/module active)
- On self-hosted Jetpack: Free tier should still work (is_active returns true)
- Run `cd projects/packages/my-jetpack && vendor/bin/phpunit -c phpunit.11.xml.dist` — all 97 tests pass

## Changelog

- [ ] Generate changelog entries for this PR (using AI).